### PR TITLE
docs(QCA): vendor Schumacher-Werner source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
-Papers/quant-ph_0405174/*.eps binary
+Papers/**/*.eps binary
 Papers/quant-ph_0405174/qca.tex binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 Papers/quant-ph_0405174/*.eps binary
+Papers/quant-ph_0405174/qca.tex binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+Papers/quant-ph_0405174/*.eps binary

--- a/Papers/NOTICE.md
+++ b/Papers/NOTICE.md
@@ -16,7 +16,7 @@ record for each paper is the arXiv posting or the journal publication.
 
 | arXiv ID | Title | Authors | arXiv license |
 |---|---|---|---|
-| [quant-ph/0405174](https://arxiv.org/abs/quant-ph/0405174) | Reversible quantum cellular automata | B. Schumacher, R. F. Werner | assumed 1991-2003 |
+| [quant-ph/0405174](https://arxiv.org/abs/quant-ph/0405174) | Reversible Quantum Cellular Automata | B. Schumacher, R. F. Werner | assumed 1991-2003 |
 | [quant-ph/0608197](https://arxiv.org/abs/quant-ph/0608197) | Matrix Product State Representations | D. Pérez-García, F. Verstraete, M. M. Wolf, J. I. Cirac | assumed 1991-2003 |
 | [0802.0447](https://arxiv.org/abs/0802.0447) | String Order and Symmetries in Quantum Spin Lattices | D. Pérez-García, M. M. Wolf, M. Sanz, F. Verstraete, J. I. Cirac | assumed 1991-2003 |
 | [0909.5347](https://arxiv.org/abs/0909.5347) | A quantum version of Wielandt's inequality | M. Sanz, D. Pérez-García, M. M. Wolf, J. I. Cirac | non-exclusive-distrib 1.0 |

--- a/Papers/NOTICE.md
+++ b/Papers/NOTICE.md
@@ -9,13 +9,14 @@ works remains with their authors and, where applicable, their publishers.
 `LICENSE` (Apache License 2.0) applies to the Lean code, the blueprint, and
 the other original content of this repository, not to this directory. The
 sources below carry arXiv's non-exclusive distribution license (or, for the
-two oldest submissions, arXiv's assumed license for 1991-2003 submissions),
+older submissions noted below, arXiv's assumed license for 1991-2003 submissions),
 which grants no redistribution rights beyond arXiv itself. Do not reuse them
 outside this repository without the authors' permission; the version of
 record for each paper is the arXiv posting or the journal publication.
 
 | arXiv ID | Title | Authors | arXiv license |
 |---|---|---|---|
+| [quant-ph/0405174](https://arxiv.org/abs/quant-ph/0405174) | Reversible quantum cellular automata | B. Schumacher, R. F. Werner | assumed 1991-2003 |
 | [quant-ph/0608197](https://arxiv.org/abs/quant-ph/0608197) | Matrix Product State Representations | D. Pérez-García, F. Verstraete, M. M. Wolf, J. I. Cirac | assumed 1991-2003 |
 | [0802.0447](https://arxiv.org/abs/0802.0447) | String Order and Symmetries in Quantum Spin Lattices | D. Pérez-García, M. M. Wolf, M. Sanz, F. Verstraete, J. I. Cirac | assumed 1991-2003 |
 | [0909.5347](https://arxiv.org/abs/0909.5347) | A quantum version of Wielandt's inequality | M. Sanz, D. Pérez-García, M. M. Wolf, J. I. Cirac | non-exclusive-distrib 1.0 |

--- a/Papers/quant-ph_0405174/circuit1.eps
+++ b/Papers/quant-ph_0405174/circuit1.eps
@@ -1,0 +1,3215 @@
+%!PS-Adobe-3.1 EPSF-3.0
+%%Title: bild3
+%%Creator: Adobe Illustrator(R) 9.0
+%%AI8_CreatorVersion: 9.0
+%AI9_PrintingDataBegin
+%%For: Gerhard Gerlich
+%%CreationDate: 09.04.2003
+%%CropBox: 0.000000 0.000000 155.750000 49.875000
+%%BoundingBox: 0 0 156 50 
+%%HiResBoundingBox: 0.000000 0.000000 155.750000 49.875000
+%%LanguageLevel: 2 
+%%DocumentData: Clean7Bit
+%%Pages: 1 
+%%DocumentNeededResources: 
+%%DocumentSuppliedResources: procset Adobe_AGM_Core 2.0 0
+%%DocumentFonts: 
+%%DocumentSuppliedFonts: 
+%%PageOrder: Ascend
+%%DocumentProcessColors:  Black
+%%DocumentCustomColors: 
+%%CMYKCustomColor: 
+%%RGBCustomColor: 
+
+%%EndComments
+%%BeginDefaults
+%%EndDefaults
+%%BeginProlog
+%%BeginResource: procset Adobe_AGM_Core 2.0 0
+%%Version: 2.0 0
+%%Copyright: Copyright (C) 1997-1999 Adobe Systems, Inc.  All Rights Reserved.
+systemdict /setpacking known
+{
+	currentpacking
+	true setpacking
+} if
+userdict /Adobe_AGM_Core 233 dict dup begin put
+/nd{
+	null def
+}bind def
+/Adobe_AGM_Core_Id /Adobe_AGM_Core_2.0_0 def
+/AGMCORE_str256 256 string def
+/AGMCORE_src256 256 string def
+/AGMCORE_dst64 64 string def
+/AGMCORE_srcLen nd
+/AGMCORE_save nd
+/AGMCORE_graphicsave nd
+/AGMCORE_imagestring0 nd
+/AGMCORE_imagestring1 nd
+/AGMCORE_imagestring2 nd
+/AGMCORE_imagestring3 nd
+/AGMCORE_imagestring4 nd
+/AGMCORE_imagestring5 nd
+/AGMCORE_c 0 def
+/AGMCORE_m 0 def
+/AGMCORE_y 0 def
+/AGMCORE_k 0 def
+/AGMCORE_mbuf () def
+/AGMCORE_ybuf () def
+/AGMCORE_kbuf () def
+/AGMCORE_gbuf () def
+/AGMCORE_bbuf () def
+/AGMCORE_cmykbuf 4 array def
+/AGMCORE_screen [currentscreen] cvx def
+/AGMCORE_tmp 0 def
+/AGMCORE_arg1 nd
+/AGMCORE_arg2 nd
+/AGMCORE_&setgray nd
+/AGMCORE_&image nd
+/AGMCORE_&colorimage nd
+/AGMCORE_&imagemask nd
+/AGMCORE_&setcolor nd
+/AGMCORE_&setcolorspace nd
+/AGMCORE_&&setcolorspace nd
+/AGMCORE_cyan_plate nd
+/AGMCORE_magenta_plate nd
+/AGMCORE_yellow_plate nd
+/AGMCORE_black_plate nd
+/AGMCORE_plate_ndx nd
+/AGMCORE_get_ink_data nd
+/AGMCORE_is_cmyk_sep nd
+/AGMCORE_in_rip_sep nd
+/AGMCORE_host_sep nd
+/AGMCORE_will_host_sep nd
+/AGMCORE_avoid_L2_sep_space nd
+/AGMCORE_composite_job nd
+/AGMCORE_producing_seps nd
+/AGMCORE_ccimage_exists nd
+/AGMCORE_ps_level -1 def
+/AGMCORE_ps_version -1 def
+/AGMCORE_environ_ok nd
+/AGMCORE_CSA_cache 0 dict def
+/AGMCORE_CSD_cache 0 dict def
+/AGMCORE_pattern_cache 0 dict def
+/AGMCORE_currentoverprint false def
+/AGMCORE_deltaX nd
+/AGMCORE_deltaY nd
+/AGMCORE_name nd
+/AGMCORE_sep_special nd
+/AGMCORE_ndx nd
+/AGMCORE_err_strings nd
+/AGMCORE_cur_err nd
+/AGMCORE_ovp nd
+/AGMCORE_CRD_cache where{
+	pop
+}{
+	/AGMCORE_CRD_cache 0 dict def
+}ifelse
+/bdf
+{
+	bind def
+} bind def
+/xdf
+{
+	exch def
+} def
+/ldf 
+{
+	load def
+} def
+/ddf
+{
+	put
+} def	
+/xddf
+{
+	3 -1 roll put
+} def	
+/xpt
+{
+	exch put
+} def
+	/bdict
+	{
+		mark
+	} def
+	
+	/edict
+	{
+		counttomark 2 idiv dup dict begin {def} repeat pop currentdict end
+	}def
+	
+/ps_level
+	/languagelevel where{
+		pop languagelevel
+	}{
+		1
+	}ifelse
+def
+/level2 
+	ps_level 2 ge
+def
+/level3 
+	ps_level 3 ge
+def
+/ps_version
+	{version cvr} stopped {
+		-1
+	}if
+def
+/ndf
+{
+	1 index where{
+		pop pop pop
+	}{
+		dup xcheck
+		{bind}if
+		def
+	}ifelse
+} def
+/skip_image
+{
+	has_color ne{
+		dup 256 idiv
+		{currentfile AGMCORE_str256 readstring pop pop}repeat
+		currentfile AGMCORE_str256 0 4 -1 roll 256 mod getinterval
+		readstring pop pop
+	}{
+		pop
+	}ifelse
+} def
+/addprocs
+{
+     2{/exec load}repeat
+     3 1 roll
+     [ 5 1 roll ] bind cvx
+} def
+/colorbuf
+{
+	0 1 2 index length 1 sub
+		{
+		dup 2 index exch get 
+		255 exch sub 
+		2 index 
+		3 1 roll 
+		put
+		} for
+} def
+/makereadonlyarray
+{
+	/packedarray where
+		{pop packedarray}
+		{array astore readonly}
+	ifelse
+} def
+/getspotfunction
+{
+	AGMCORE_screen exch pop exch pop
+	dup type /dicttype eq 
+	{
+		dup /HalftoneType get 1 eq
+			{
+			/SpotFunction get
+			}
+			{
+			dup /HalftoneType get 2 eq
+				{
+				/GraySpotFunction get
+				}
+				{
+				pop
+				{abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1 sub}
+				{dup mul exch dup mul add 1 exch sub}ifelse}bind
+				}
+			ifelse
+			}
+		ifelse
+	}
+	if
+} def
+/clp_npth
+{
+	clip newpath
+} def
+/eoclp_npth
+{
+	eoclip newpath
+} def
+/stkpath_clp_npth
+{
+	strokepath clip newpath
+} def
+/stk_n_clp_npth
+{
+	gsave stroke grestore clip newpath
+} def
+/npth_clp
+{
+	newpath clip
+} def
+/graphic_setup
+{
+	/AGMCORE_graphicsave save def
+	concat
+	0 setgray
+	0 setlinecap
+	0 setlinejoin
+	1 setlinewidth
+	[] 0 setdash
+	10 setmiterlimit
+	newpath
+	false setoverprint
+	false setstrokeadjust
+	userdict begin
+	/showpage {} def
+	mark
+} def
+/graphic_cleanup
+{
+	cleartomark
+	end
+	AGMCORE_graphicsave restore
+} def
+/compose_error_msg
+{
+	grestoreall initgraphics	
+	/Helvetica findfont 10 scalefont setfont
+	
+	/AGMCORE_deltaY 100 def
+	/AGMCORE_deltaX 310 def
+			
+	/AGMCORE_arg2 xdf
+	/AGMCORE_arg1 xdf
+	
+	clippath pathbbox newpath pop pop 36 add exch 36 add exch moveto
+	0 AGMCORE_deltaY rlineto AGMCORE_deltaX 0 rlineto
+	0 AGMCORE_deltaY neg rlineto AGMCORE_deltaX neg 0 rlineto closepath
+	0 AGMCORE_&setgray
+	gsave 1 AGMCORE_&setgray fill grestore 
+	1 setlinewidth gsave stroke grestore
+		
+	currentpoint AGMCORE_deltaY 15 sub add exch 8 add exch moveto
+	
+	/AGMCORE_deltaY 12 def
+	/AGMCORE_tmp 0 def
+	AGMCORE_err_strings exch get
+		{
+		dup 32 eq
+			{
+			pop
+			AGMCORE_str256 0 AGMCORE_tmp getinterval
+			dup (.) ne AGMCORE_arg1 0 lt and
+				{
+				pop
+				}
+				{
+				stringwidth pop currentpoint pop add AGMCORE_deltaX 28 add gt
+					{
+					currentpoint AGMCORE_deltaY sub exch pop
+					clippath pathbbox pop pop pop 44 add exch moveto
+					} if
+				AGMCORE_str256 0 AGMCORE_tmp getinterval show ( ) show
+				} ifelse
+			
+			0 1 AGMCORE_str256 length 1 sub
+				{
+				AGMCORE_str256 exch 0 put
+				}for
+			/AGMCORE_tmp 0 def
+			}
+			{
+			dup 94 eq 
+				{
+				pop
+				AGMCORE_arg1 0 ge
+					{
+					AGMCORE_arg1 AGMCORE_str256 cvs
+					dup /AGMCORE_tmp exch length def
+					AGMCORE_str256 exch 0 exch putinterval
+					AGMCORE_str256 0 AGMCORE_tmp getinterval
+					stringwidth pop currentpoint pop add AGMCORE_deltaX 28 add gt
+						{
+						currentpoint AGMCORE_deltaY sub exch pop
+						clippath pathbbox pop pop pop 44 add exch moveto
+						} if
+					AGMCORE_str256 0 AGMCORE_tmp getinterval show
+					}
+					{
+					/AGMCORE_arg1 0 def
+					} ifelse
+				0 1 AGMCORE_str256 length 1 sub
+					{
+					AGMCORE_str256 exch 0 put
+					}for
+				/AGMCORE_tmp 0 def
+				AGMCORE_arg1 0 ne
+					{
+					/AGMCORE_arg1 AGMCORE_arg2 def
+					} if
+				}
+				{
+				AGMCORE_str256 exch AGMCORE_tmp exch put
+				/AGMCORE_tmp AGMCORE_tmp 1 add def
+				}ifelse
+			} ifelse
+		} forall
+} bdf
+level2{
+	/AGMCORE_map_reserved_ink_name
+	{
+		dup type /stringtype eq{
+			dup /Red eq{
+				pop (_Red_)
+			}{
+				dup /Green eq{
+					pop (_Green_)
+				}{
+					dup /Blue eq{
+						pop (_Blue_)
+					}{
+						dup /Cyan eq{
+							pop (_Cyan_)
+						}{
+							dup /Magenta eq{
+								pop (_Magenta_)
+							}{
+								dup /Yellow eq{
+									pop (_Yellow_)
+								}{
+									dup /Black eq{
+										pop (_Black_)
+									}{
+										dup / eq{
+											pop (Process)
+										}if
+									}ifelse
+								}ifelse
+							}ifelse
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+		}if
+	}def
+}if
+/doc_setup{
+	Adobe_AGM_Core begin
+	
+	/AGMCORE_will_host_separate xdf
+	/AGMCORE_ps_version xdf
+	/AGMCORE_ps_level xdf
+	
+	errordict /AGM_handleerror known not
+		{
+		errordict /AGM_handleerror errordict /handleerror get put
+		errordict /handleerror
+			{
+			Adobe_AGM_Core begin
+			$error /newerror get AGMCORE_cur_err null ne and {
+				$error /newerror false put
+				AGMCORE_cur_err /AGMCORE_bad_environ eq
+					{
+					/AGMCORE_bad_environ AGMCORE_ps_level AGMCORE_ps_version
+					}
+					{
+					AGMCORE_cur_err 0 0
+					} ifelse
+				compose_error_msg
+				} if
+			$error /newerror true put
+			end
+			errordict /AGM_handleerror get exec
+			} bind put
+		}if
+	/AGMCORE_environ_ok 
+		ps_level AGMCORE_ps_level ge
+		ps_version AGMCORE_ps_version ge and 
+		AGMCORE_ps_level -1 eq or
+	def
+	
+	AGMCORE_environ_ok not
+		{/AGMCORE_cur_err /AGMCORE_bad_environ def} if
+	
+	/AGMCORE_&setgray systemdict/setgray get def
+	level2{
+		/AGMCORE_&setcolor systemdict/setcolor get def
+		/AGMCORE_&setcolorspace systemdict/setcolorspace get def
+		/AGMCORE_&&setcolorspace /setcolorspace ldf
+	}if
+	/AGMCORE_&image systemdict/image get def
+	/AGMCORE_&imagemask systemdict/imagemask get def
+	/colorimage where{
+		pop
+		/AGMCORE_&colorimage /colorimage ldf
+	}if
+	/AGMCORE_in_rip_sep
+		level2{
+			currentpagedevice/Separations 2 copy known{
+				get
+			}{
+				pop pop false
+			}ifelse
+		}{
+			false
+		}ifelse
+	def
+	level2 not{
+		/xput{
+			dup load dup length exch maxlength eq{
+				dup dup load dup
+				length dup 0 eq {pop 1} if 2 mul dict copy def
+			}if
+			load begin
+				def
+ 			end
+		}def
+	}{
+		/xput{
+			load 3 1 roll put
+		}def
+	}ifelse
+	/AGMCORE_gstate_known{
+		where{
+			/Adobe_AGM_Core_Id known
+		}{
+			false
+		}ifelse
+	}ndf
+	/AGMCORE_GSTATE AGMCORE_gstate_known not{
+		/AGMCORE_GSTATE 21 dict def
+		/AGMCORE_tmpmatrix matrix def
+		/AGMCORE_gstack 32 array def
+		/AGMCORE_gstackptr 0 def
+		/AGMCORE_gstacksaveptr 0 def
+		/AGMCORE_gstackframekeys 7 def
+		/AGMCORE_&gsave /gsave ldf
+		/AGMCORE_&grestore /grestore ldf
+		/AGMCORE_&grestoreall /grestoreall ldf
+		/AGMCORE_&save /save ldf
+		/AGMCORE_gdictcopy {
+			begin
+			{ def } forall
+			end
+		}def
+		/AGMCORE_gput {
+			AGMCORE_gstack AGMCORE_gstackptr get
+			3 1 roll
+			put
+		}def
+		/AGMCORE_gget {
+			AGMCORE_gstack AGMCORE_gstackptr get
+			exch
+			get
+		}def
+		/gsave {
+			AGMCORE_&gsave
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gstackptr 1 add
+			dup 32 ge {limitcheck} if
+			Adobe_AGM_Core exch
+			/AGMCORE_gstackptr exch put
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gdictcopy
+		}def
+		/grestore {
+			AGMCORE_&grestore
+			AGMCORE_gstackptr 1 sub
+			dup AGMCORE_gstacksaveptr lt {1 add} if
+			Adobe_AGM_Core exch
+			/AGMCORE_gstackptr exch put
+		}def
+		/grestoreall {
+			AGMCORE_&grestoreall
+			Adobe_AGM_Core
+			/AGMCORE_gstackptr AGMCORE_gstacksaveptr put 
+		}def
+		/save {
+			AGMCORE_&save
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gstackptr 1 add
+			dup 32 ge {limitcheck} if
+			Adobe_AGM_Core begin
+				/AGMCORE_gstackptr exch def
+				/AGMCORE_gstacksaveptr AGMCORE_gstackptr def
+			end
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gdictcopy
+		}def
+		0 1 AGMCORE_gstack length 1 sub {
+				AGMCORE_gstack exch AGMCORE_gstackframekeys dict put
+		} for
+	}if
+	/currentcmykcolor [0 0 0 0] AGMCORE_gput
+	/currentstrokeadjust false AGMCORE_gput
+	/currentcolorspace [/DeviceGray] AGMCORE_gput
+	/sep_tint 0 AGMCORE_gput
+	/sep_colorspace_dict null AGMCORE_gput
+	/indexed_colorspace_dict null AGMCORE_gput
+	/currentcolor_intent () AGMCORE_gput
+	end
+}def
+/page_setup
+{
+	Adobe_AGM_Core begin
+	/setcmykcolor
+	{
+		4 copy AGMCORE_cmykbuf astore /currentcmykcolor exch AGMCORE_gput
+		1 sub 4 1 roll
+		3 {
+			3 index add neg dup 0 lt {
+				pop 0
+			} if
+			3 1 roll
+		} repeat
+		setrgbcolor pop
+	}ndf
+	/AGMCORE_ccimage_exists /customcolorimage where {pop true}{false} ifelse def
+	/currentcmykcolor
+	{
+		/currentcmykcolor AGMCORE_gget aload pop
+	}ndf
+	/setoverprint
+	{
+		pop
+	}ndf
+	/currentoverprint
+	{
+		false
+	}ndf
+	/AGMCORE_deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt def
+	/AGMCORE_cyan_plate 1 0 0 0 test_cmyk_color_plate def
+	/AGMCORE_magenta_plate 0 1 0 0 test_cmyk_color_plate def
+	/AGMCORE_yellow_plate 0 0 1 0 test_cmyk_color_plate def
+	/AGMCORE_black_plate 0 0 0 1 test_cmyk_color_plate def
+	/AGMCORE_plate_ndx 
+		AGMCORE_cyan_plate{ 
+			0
+		}{
+			AGMCORE_magenta_plate{
+				1
+			}{
+				AGMCORE_yellow_plate{
+					2
+				}{
+					AGMCORE_black_plate{
+						3
+					}{
+						4
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+		def
+	/AGMCORE_composite_job
+		AGMCORE_cyan_plate AGMCORE_magenta_plate and AGMCORE_yellow_plate and AGMCORE_black_plate and def
+	
+	/AGMCORE_producing_seps AGMCORE_composite_job not AGMCORE_in_rip_sep or def
+	
+	/AGMCORE_host_sep AGMCORE_producing_seps AGMCORE_in_rip_sep not and def
+	
+	/AGM_preserve_spots 
+		/AGM_preserve_spots where{
+			pop AGM_preserve_spots
+		}{
+			systemdict/setdistillerparams known product (Adobe PostScript Parser) ne and AGMCORE_producing_seps or
+		}ifelse
+	def
+	
+	AGMCORE_host_sep AGMCORE_will_host_separate not and {
+		/AGMCORE_cur_err /AGMCORE_color_space_onhost_seps def
+		AGMCORE_color_space_onhost_seps
+	}if
+	/AGMCORE_avoid_L2_sep_space  
+		version cvr 2012 lt 
+		level2 and 
+		AGMCORE_producing_seps not and
+	def
+	/AGMCORE_is_cmyk_sep
+		AGMCORE_cyan_plate AGMCORE_magenta_plate or AGMCORE_yellow_plate or AGMCORE_black_plate or
+	def
+	/AGM_avoid_0_cmyk where{
+		pop AGM_avoid_0_cmyk
+	}{
+		AGM_preserve_spots
+	}ifelse
+	{
+		/setcmykcolor[
+			{4 copy add add add 0 eq currentoverprint and{pop 0.0005}if}/exec cvx
+			/setcmykcolor load dup type/operatortype ne{/exec cvx}if
+		]cvx def
+	}if
+	AGMCORE_host_sep{
+		/AGMCORE_get_ink_data
+			AGMCORE_cyan_plate{
+				{pop pop pop}
+			}{
+			  	AGMCORE_magenta_plate{
+			  		{4 3 roll pop pop pop}
+			  	}{
+			  		AGMCORE_yellow_plate{
+			  			{4 2 roll pop pop pop}
+			  		}{
+			  			{4 1 roll pop pop pop}
+			  		}ifelse
+			  	}ifelse
+			}ifelse
+		def
+	}if
+	AGMCORE_in_rip_sep{
+		/setcustomcolor
+		{
+			exch aload pop
+			dup 7 1 roll inRip_spot_has_ink not	{ 
+				4 {4 index mul 4 1 roll}
+				repeat
+				/DeviceCMYK setcolorspace
+				6 -2 roll pop pop
+			}{ 
+				Adobe_AGM_Core begin
+					/AGMCORE_k xdf /AGMCORE_y xdf /AGMCORE_m xdf /AGMCORE_c xdf
+				end
+				[/Separation 4 -1 roll /DeviceCMYK
+				{dup AGMCORE_c mul exch dup AGMCORE_m mul exch dup AGMCORE_y mul exch AGMCORE_k mul}
+				]
+				setcolorspace
+			}ifelse
+			setcolor
+		}ndf
+		/setseparationgray
+		{
+			[/Separation (All) /DeviceGray {}] setcolorspace_opt
+			1 exch sub setcolor
+		}ndf
+	}{
+		/setseparationgray
+		{
+			AGMCORE_&setgray
+		}ndf
+	}ifelse
+	/findcmykcustomcolor
+	{
+		5 makereadonlyarray
+	}ndf
+	/setcustomcolor
+	{
+		exch aload pop pop
+		4 {4 index mul 4 1 roll} repeat
+		setcmykcolor pop
+	}ndf
+	
+	/has_color
+		/colorimage where{
+			AGMCORE_producing_seps{
+				pop true
+			}{
+				systemdict eq
+			}ifelse
+		}{
+			false
+		}ifelse
+	def
+	
+	/map_index
+	{
+		1 index mul exch getinterval {255 div} forall
+	}def
+	
+	level2{
+		/mo /moveto ldf
+		/ln /lineto ldf
+		/cv /curveto ldf
+		/knockout_unitsq
+		{
+			1 setgray
+			0 0 1 1 rectfill
+		}def
+		/level2ScreenFreq{
+			begin
+			60
+			HalftoneType 1 eq{
+				pop Frequency
+			}if
+			HalftoneType 2 eq{
+				pop GrayFrequency
+			}if
+			HalftoneType 5 eq{
+				pop Default level2ScreenFreq
+			}if
+			 end
+		}def
+		/currentScreenFreq{
+			currenthalftone level2ScreenFreq
+		}def
+		/invert_image_samples
+		{
+			Adobe_AGM_Core/AGMCORE_tmp Decode length ddf
+			/Decode [ Decode 1 get Decode 0 get] def
+		}def
+		/knockout_image_samples
+		{
+			Operator/imagemask ne{
+				/Decode [1 1] def
+			}if
+		}def
+		/get_gstate
+		{
+			AGMCORE_GSTATE begin
+			/AGMCORE_GSTATE_ctm AGMCORE_tmpmatrix currentmatrix def
+			/AGMCORE_GSTATE_clr_spc currentcolorspace def
+			/AGMCORE_GSTATE_clr_indx 0 def
+			/AGMCORE_GSTATE_clr_comps 12 array def
+			mark currentcolor counttomark
+				{AGMCORE_GSTATE_clr_comps AGMCORE_GSTATE_clr_indx 3 -1 roll put
+				/AGMCORE_GSTATE_clr_indx AGMCORE_GSTATE_clr_indx 1 add def} repeat pop
+			/AGMCORE_GSTATE_fnt rootfont def
+			/AGMCORE_GSTATE_lw currentlinewidth def
+			/AGMCORE_GSTATE_lc currentlinecap def
+			/AGMCORE_GSTATE_lj currentlinejoin def
+			/AGMCORE_GSTATE_ml currentmiterlimit def
+			currentdash /AGMCORE_GSTATE_do xdf /AGMCORE_GSTATE_da xdf
+			/AGMCORE_GSTATE_sa currentstrokeadjust def
+			
+			/AGMCORE_GSTATE_clr_rnd currentcolorrendering def
+			/AGMCORE_GSTATE_op currentoverprint def
+			/AGMCORE_GSTATE_bg currentblackgeneration cvlit def
+			/AGMCORE_GSTATE_ucr currentundercolorremoval cvlit def
+			currentcolortransfer 
+				cvlit /AGMCORE_GSTATE_gy_xfer xdf 
+				cvlit /AGMCORE_GSTATE_b_xfer xdf
+				cvlit /AGMCORE_GSTATE_g_xfer xdf 
+				cvlit /AGMCORE_GSTATE_r_xfer xdf
+			/AGMCORE_GSTATE_ht currenthalftone def
+			/AGMCORE_GSTATE_flt currentflat def
+			end
+		}ndf
+		
+		/set_gstate
+		{
+			AGMCORE_GSTATE begin
+			AGMCORE_GSTATE_ctm setmatrix
+			AGMCORE_GSTATE_clr_spc setcolorspace
+			AGMCORE_GSTATE_clr_indx {AGMCORE_GSTATE_clr_comps AGMCORE_GSTATE_clr_indx 1 sub get
+			/AGMCORE_GSTATE_clr_indx AGMCORE_GSTATE_clr_indx 1 sub def} repeat setcolor
+			AGMCORE_GSTATE_fnt setfont
+			AGMCORE_GSTATE_lw setlinewidth
+			AGMCORE_GSTATE_lc setlinecap
+			AGMCORE_GSTATE_lj setlinejoin
+			AGMCORE_GSTATE_ml setmiterlimit
+			AGMCORE_GSTATE_da AGMCORE_GSTATE_do setdash
+			AGMCORE_GSTATE_sa setstrokeadjust
+			
+			AGMCORE_GSTATE_clr_rnd setcolorrendering
+			AGMCORE_GSTATE_op setoverprint
+			AGMCORE_GSTATE_bg cvx setblackgeneration
+			AGMCORE_GSTATE_ucr cvx setundercolorremoval
+			AGMCORE_GSTATE_r_xfer cvx AGMCORE_GSTATE_g_xfer cvx AGMCORE_GSTATE_b_xfer cvx
+				AGMCORE_GSTATE_gy_xfer cvx setcolortransfer
+			AGMCORE_GSTATE_ht /HalftoneType get dup 9 eq exch 100 eq or
+				{
+				currenthalftone /HalftoneType get AGMCORE_GSTATE_ht /HalftoneType get ne
+					{
+					  mark AGMCORE_GSTATE_ht {sethalftone} stopped cleartomark
+					} if
+				}{
+				AGMCORE_GSTATE_ht sethalftone
+				} ifelse
+			AGMCORE_GSTATE_flt setflat
+			end
+		}ndf
+		AGMCORE_producing_seps not{
+	
+			/setcolorspace where{
+				/Adobe_AGM_Core_Id known not
+			}{
+				true
+			}ifelse
+			{
+				/setcolorspace
+				{
+					dup type dup /arraytype eq exch /packedarraytype eq or{
+						dup 0 get dup /Separation eq{
+							pop
+							[ exch {} forall ]
+							dup dup 1 get AGMCORE_map_reserved_ink_name 1 exch put
+						}{
+							/DeviceN eq {
+								[ exch {} forall ]
+								dup dup 1 get [ exch {AGMCORE_map_reserved_ink_name} forall ] 1 exch put
+							}if
+						}ifelse
+					}if
+					AGMCORE_&&setcolorspace 
+				}def
+			}if
+		}if	
+	}{
+		
+		/adj
+		{
+			currentstrokeadjust{
+				transform
+				0.25 sub round 0.25 add exch
+				0.25 sub round 0.25 add exch
+				itransform
+			}if
+		}def
+		/mo{
+			adj moveto
+		}def
+		/ln{
+			adj lineto
+		}def
+		/cv{
+			6 2 roll adj
+			6 2 roll adj
+			6 2 roll adj curveto
+		}def
+		/knockout_unitsq
+		{
+			1 setgray
+			8 8 1 [8 0 0 8 0 0] {<ffffffffffffffff>} image
+		}def
+		/currentstrokeadjust{
+			/currentstrokeadjust AGMCORE_gget
+		}def
+		/setstrokeadjust{
+			/currentstrokeadjust exch AGMCORE_gput
+		}def
+		/currentScreenFreq{
+			currentscreen pop pop
+		}def
+		/invert_image_samples
+		{
+			{1 exch sub} currenttransfer addprocs settransfer
+		}def
+		/knockout_image_samples
+		{
+			{ pop 1 } currenttransfer addprocs settransfer
+		}def
+		/setcolorspace
+		{
+			/currentcolorspace exch AGMCORE_gput
+		} def
+		
+		/currentcolorspace
+		{
+			/currentcolorspace AGMCORE_gget
+		} def
+		
+		/n_color_components
+		{
+			dup type /arraytype eq{
+				0 get
+			}if
+			dup /DeviceGray eq{
+				pop 1
+			}{
+				/DeviceCMYK eq{
+					4
+				}{
+					3
+				}ifelse
+			}ifelse
+		} def
+		
+		/setcolor_devicecolor
+		{
+			dup type /arraytype eq{
+				0 get
+			}if
+			dup /DeviceGray eq{
+				pop setgray
+			}{
+				/DeviceCMYK eq{
+					setcmykcolor
+				}{
+					setrgbcolor
+				}ifelse
+			}ifelse
+		}def
+	
+		/setcolor
+		{
+			currentcolorspace 0 get
+			dup /DeviceGray ne{
+				dup /DeviceCMYK ne{
+					dup /DeviceRGB ne{
+						dup /Separation eq{
+							pop
+							currentcolorspace 3 get exec
+							currentcolorspace 2 get
+						}{
+							dup /Indexed eq{
+								pop
+								currentcolorspace 3 get dup type /stringtype eq{
+									currentcolorspace 1 get n_color_components
+									3 -1 roll map_index
+								}{
+									exec
+								}ifelse
+								currentcolorspace 1 get
+							}{
+								/AGMCORE_cur_err /AGMCORE_invalid_color_space def
+								AGMCORE_invalid_color_space
+							}ifelse
+						}ifelse
+					}if
+				}if
+			}if
+			setcolor_devicecolor
+		} def
+	}ifelse
+	
+	/op /setoverprint ldf
+	/lw /setlinewidth ldf
+	/lc /setlinecap ldf
+	/lj /setlinejoin ldf
+	/ml /setmiterlimit ldf
+	/dsh /setdash ldf
+	/sadj /setstrokeadjust ldf
+	/gry /setgray ldf
+	/rgb /setrgbcolor ldf
+	/cmyk /setcmykcolor ldf
+	/sep /setsepcolor ldf
+	/idx /setindexedcolor ldf
+	/colr /setcolor ldf
+	/csacrd /set_csa_crd ldf
+	/sepcs /setsepcolorspace ldf
+	/idxcs /setindexedcolorspace ldf
+	/cp /closepath ldf
+	/clp /clp_npth ldf
+	/eclp /eoclp_npth ldf
+	/spclp /stkpath_clp_npth ldf
+	/f /fill ldf
+	/ef /eofill ldf
+	/s /stroke ldf
+	/sclp /stk_n_clp_npth ldf
+	/nclp /npth_clp ldf
+	/img /imageormask ldf
+	/sepimg /sep_imageormask ldf
+	/idximg /indexed_imageormask ldf
+	/gset /graphic_setup ldf
+	/gcln /graphic_cleanup ldf
+	
+	currentdict{
+		dup xcheck 1 index type dup /arraytype eq exch /packedarraytype eq or and {
+			bind
+		}if
+		def
+	}forall
+}def
+/page_trailer
+{
+	end
+}def
+/unload{
+	systemdict/languagelevel known{
+		systemdict/languagelevel get 2 ge{
+			userdict/Adobe_AGM_Core 2 copy known{
+				undef
+			}{
+				pop pop
+			}ifelse
+		}if
+	}if
+}def
+/doc_trailer{
+}def
+systemdict /findcolorrendering known{
+	/findcolorrendering systemdict /findcolorrendering get def
+}if
+systemdict /setcolorrendering known{
+	/setcolorrendering systemdict /setcolorrendering get def
+}if
+/test_cmyk_color_plate
+{
+	gsave
+	setcmykcolor currentgray 1 ne
+	grestore
+}def
+/inRip_spot_has_ink
+{
+	Adobe_AGM_Core/AGMCORE_name xddf
+	false
+	currentpagedevice/SeparationColorNames get{
+		AGMCORE_name eq or
+	}forall
+}def
+/current_ink
+{
+	dup length 0 eq{
+		pop true
+	}{
+		Adobe_AGM_Core/ink_result false put
+		{
+			dup /ProcessCyan eq{
+				AGMCORE_cyan_plate ink_result or Adobe_AGM_Core/ink_result xddf
+			}{
+				dup /ProcessMagenta eq{
+					AGMCORE_magenta_plate ink_result or Adobe_AGM_Core/ink_result xddf
+				}{
+					dup /ProcessYellow eq{
+						AGMCORE_yellow_plate ink_result or Adobe_AGM_Core/ink_result xddf
+					}{
+						dup /ProcessBlack eq{
+							AGMCORE_black_plate ink_result or Adobe_AGM_Core/ink_result xddf
+						}{
+							dup /sep_colorspace_dict AGMCORE_gget dup null eq{
+								pop false ink_result or Adobe_AGM_Core/ink_result xddf
+							}{
+								/Name get eq{
+									1 setsepcolor
+									currentgray 1 ne ink_result or Adobe_AGM_Core/ink_result xddf
+								}{
+									false ink_result or Adobe_AGM_Core/ink_result xddf
+								}ifelse
+							}ifelse
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+			pop 
+		} forall
+		ink_result
+	}ifelse
+}def
+/map255_to_range
+{
+	1 index sub
+	3 -1 roll 255 div mul add
+}def
+/set_csa_crd
+{
+	/sep_colorspace_dict null AGMCORE_gput
+	begin
+		CSA map_csa setcolorspace_opt
+		set_crd
+	end
+}
+def
+/setsepcolor
+{ 
+	
+	/sep_colorspace_dict AGMCORE_gget begin
+		dup /sep_tint exch AGMCORE_gput
+		TintProc
+	end
+} def
+/sep_colorspace_proc
+{
+	Adobe_AGM_Core/AGMCORE_tmp xddf
+	/sep_colorspace_dict AGMCORE_gget begin
+	currentdict/Components known{
+		Components aload pop 
+		TintMethod/Lab eq{
+			2 {AGMCORE_tmp mul NComponents 1 roll} repeat
+			LMax sub AGMCORE_tmp mul LMax add  NComponents 1 roll
+		}{
+			TintMethod/Subtractive eq{
+				NComponents{
+					AGMCORE_tmp mul NComponents 1 roll
+				}repeat
+			}{
+				NComponents{
+					1 sub AGMCORE_tmp mul 1 add  NComponents 1 roll
+				} repeat
+			}ifelse
+		}ifelse
+	}{
+		ColorLookup AGMCORE_tmp ColorLookup length 1 sub mul round cvi get
+		aload pop
+	}ifelse
+	end
+} def
+/sep_colorspace_gray_proc
+{
+	Adobe_AGM_Core/AGMCORE_tmp xddf
+	/sep_colorspace_dict AGMCORE_gget begin
+	GrayLookup AGMCORE_tmp GrayLookup length 1 sub mul round cvi get
+	end
+} def
+/sep_proc_name
+{
+	dup 0 get 
+	dup /DeviceRGB eq exch /DeviceCMYK eq or level2 not and has_color not and{
+		pop [/DeviceGray]
+		/sep_colorspace_gray_proc
+	}{
+		/sep_colorspace_proc
+	}ifelse
+} def
+/setsepcolorspace
+{ 
+	dup /sep_colorspace_dict exch AGMCORE_gput
+	begin
+	/MappedCSA CSA map_csa def
+	Adobe_AGM_Core/AGMCORE_sep_special Name dup () eq exch (All) eq or ddf
+	
+	AGMCORE_avoid_L2_sep_space{
+		[/Indexed MappedCSA sep_proc_name 255 exch 
+			{ 255 div } /exec cvx 3 -1 roll [ 4 1 roll load /exec cvx ] cvx 
+		] setcolorspace_opt
+		/TintProc {
+			255 mul setcolor
+		}bdf
+	}{
+		MappedCSA 0 get /DeviceCMYK eq 
+		currentdict/Components known and 
+		AGMCORE_sep_special not and{
+			/TintProc [
+				Components aload pop Name findcmykcustomcolor 
+				/exch cvx /setcustomcolor cvx
+			] cvx bdf
+		}{
+ 			AGMCORE_host_sep Name (All) eq and{
+ 				/TintProc { 
+					1 exch sub setseparationgray 
+				}bdf
+ 			}{
+				AGMCORE_in_rip_sep MappedCSA 0 get /DeviceCMYK eq and 
+				AGMCORE_host_sep or
+				Name () eq and{
+					/TintProc [
+						MappedCSA sep_proc_name exch 0 get /DeviceCMYK eq{
+							cvx /setcmykcolor cvx
+						}{
+							cvx /setgray cvx
+						}ifelse
+					] cvx bdf
+				}{
+					AGMCORE_producing_seps MappedCSA 0 get dup /DeviceCMYK eq exch /DeviceGray eq or and AGMCORE_sep_special not and{
+	 					/TintProc [
+							/dup cvx
+							MappedCSA sep_proc_name cvx exch
+							0 get /DeviceGray eq{
+								1 /exch cvx /sub cvx 0 0 0 4 -1 /roll cvx
+							}if
+							/Name cvx /findcmykcustomcolor cvx /exch cvx
+							
+							AGMCORE_host_sep{
+								AGMCORE_is_cmyk_sep
+							}{
+								Name inRip_spot_has_ink not
+							}ifelse
+							{
+		 						/pop cvx 1
+							}if
+							/setcustomcolor cvx
+						] cvx bdf
+ 					}{ 
+						/TintProc /setcolor ldf
+						
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+	}ifelse
+	set_crd
+	1 setsepcolor
+	end
+} def
+/setindexedcolorspace
+{
+	dup /indexed_colorspace_dict exch AGMCORE_gput
+	begin
+		/MappedCSA CSA map_csa def
+		AGMCORE_host_sep level2 not and{
+			0 0 0 0 setcmykcolor
+		}{
+			[/Indexed MappedCSA 
+			level2 not has_color not and{
+				dup 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or{
+					pop [/DeviceGray]
+				}if
+				HiVal GrayLookup
+			}{
+				HiVal 
+				currentdict/RangeArray known{
+					{ 
+						/indexed_colorspace_dict AGMCORE_gget begin
+						Lookup exch 
+						dup HiVal gt{
+							pop HiVal
+						}if
+						NComponents mul NComponents getinterval {} forall
+						NComponents 1 sub -1 0{
+							RangeArray exch 2 mul 2 getinterval aload pop map255_to_range
+							NComponents 1 roll
+						}for
+						end
+					} bind
+				}{
+					Lookup
+				}ifelse
+			}ifelse
+			] setcolorspace_opt
+			
+			set_crd
+		}ifelse
+	end
+}def
+/setindexedcolor
+{
+	AGMCORE_host_sep{
+		/indexed_colorspace_dict AGMCORE_gget/Lookup get 4 3 -1 roll map_index setcmykcolor
+	}{
+		setcolor
+	}ifelse
+} def
+/imageormask_sys
+{
+	begin
+		save mark
+		level2{
+			currentdict
+			Operator /imagemask eq{
+				AGMCORE_&imagemask
+			}{
+				AGMCORE_&image
+			}ifelse
+		}{
+			Width Height
+			Operator /imagemask eq{
+				Decode 0 get 1 eq Decode 1 get 0 eq	and
+				ImageMatrix /DataSource load
+				AGMCORE_&imagemask
+			}{
+				BitsPerComponent ImageMatrix /DataSource load
+				AGMCORE_&image
+			}ifelse
+		}ifelse
+		cleartomark restore
+	end
+}def
+/overprint_plate
+{
+	currentoverprint{
+		0 get
+		dup /DeviceGray eq{
+			pop AGMCORE_black_plate not
+		}{
+			/DeviceCMYK eq{
+				AGMCORE_is_cmyk_sep not
+			}if
+		}ifelse
+	}{
+		false
+	}ifelse
+}def
+/rdline {
+	currentfile AGMCORE_str256 readline pop
+} def
+/rdcmntline {
+	currentfile AGMCORE_str256 readline pop
+	(%) anchorsearch {pop} if
+} def
+/filter_cmyk
+{	
+	dup type /filetype ne{
+		0 () /SubFileDecode filter
+	}if
+	[
+	exch
+	{
+		AGMCORE_src256 readstring pop
+		dup length /AGMCORE_srcLen exch def
+		/AGMCORE_ndx 0 def
+		
+		AGMCORE_plate_ndx 4 AGMCORE_srcLen 1 sub{
+			1 index exch get
+			AGMCORE_dst64 AGMCORE_ndx 3 -1 roll put
+			/AGMCORE_ndx AGMCORE_ndx 1 add def
+		}for
+		pop
+		AGMCORE_dst64 0 AGMCORE_ndx getinterval
+	}
+	bind
+	/exec cvx
+	] cvx
+} def
+/imageormask
+{
+	begin
+		SkipImageProc not{
+			save mark
+			level2 AGMCORE_host_sep not and{
+				currentdict
+				Operator /imagemask eq{
+					imagemask
+				}{
+					AGMCORE_in_rip_sep currentoverprint and currentcolorspace 0 get /DeviceGray eq and{
+						[/Separation /Black /DeviceGray {}] setcolorspace
+						/Decode [ Decode 1 get Decode 0 get ] def
+					}if
+					image
+				}ifelse
+			}{
+				Width Height
+				Operator /imagemask eq{
+					Decode 0 get 1 eq Decode 1 get 0 eq	and
+					ImageMatrix /DataSource load
+					AGMCORE_host_sep{
+						currentgray 1 ne{
+							currentdict imageormask_sys
+						}{
+	 						currentoverprint not{
+			 					1 AGMCORE_&setgray
+	 							knockout_image_samples
+			 					currentdict imageormask_sys
+			 				}{
+			 					nulldevice currentdict imageormask_sys
+			 				}ifelse
+				 		}ifelse
+					}{
+						imagemask
+					}ifelse
+				}{
+					BitsPerComponent ImageMatrix 
+					MultipleDataSources{
+						0 1 NComponents 1 sub{
+							DataSource exch get
+						}for
+					}{
+						/DataSource load
+					}ifelse
+					Operator /colorimage eq{
+						AGMCORE_host_sep{
+							MultipleDataSources level2 or NComponents 4 eq and{
+								MultipleDataSources{
+									4 {pop} repeat
+									/DataSource [
+										DataSource 0 get /exec cvx
+										DataSource 1 get /exec cvx
+										DataSource 2 get /exec cvx
+										DataSource 3 get /exec cvx
+										/AGMCORE_get_ink_data cvx
+									] cvx def
+								}{
+									/DataSource /DataSource load filter_cmyk 0 () /SubFileDecode filter def
+								}ifelse
+	
+								/Decode [ Decode 0 get Decode 1 get ] def
+								/MultipleDataSources false def
+								/NComponents 1 def
+								/Operator /image def
+								AGMCORE_is_cmyk_sep{
+									currentoverprint InksUsed current_ink not and{
+										nulldevice
+									}{
+										invert_image_samples
+									}ifelse
+								}{
+		 							currentoverprint not{
+		 								knockout_image_samples
+				 					}{
+				 						nulldevice
+				 					}ifelse
+					 			}ifelse
+						 		1 AGMCORE_&setgray
+								currentdict imageormask_sys
+							}{
+									
+								currentcolortransfer
+								{pop 1} exch addprocs 4 1 roll				
+								{pop 1} exch addprocs 4 1 roll
+								{pop 1} exch addprocs 4 1 roll
+								{pop 1} exch addprocs 4 1 roll
+								setcolortransfer
+									
+								MultipleDataSources NComponents AGMCORE_&colorimage						
+							}ifelse
+						}{
+							true NComponents colorimage
+						}ifelse
+					}{
+						Operator /image eq{
+							AGMCORE_host_sep{
+								HostSepColorImage{
+									invert_image_samples
+								}{
+									AGMCORE_black_plate not{
+		 								currentoverprint not{
+		 									knockout_image_samples
+				 						}{
+				 							nulldevice
+				 						}ifelse
+					 				}if
+								}ifelse
+						 		1 AGMCORE_&setgray
+								currentdict imageormask_sys
+							}{
+								image
+							}ifelse
+						}{
+							Operator/knockout eq{
+								pop pop pop pop pop
+								currentoverprint InksUsed current_ink not and{
+								}{
+									currentcolorspace overprint_plate not{
+										knockout_unitsq
+									}if
+								}ifelse
+							}if
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+			cleartomark restore
+		}if
+	end
+}def
+/tint_image_to_color
+{
+	begin
+		Width Height BitsPerComponent ImageMatrix 
+		/DataSource load
+	end
+	Adobe_AGM_Core begin
+		/AGMCORE_mbuf 0 string def
+		/AGMCORE_ybuf 0 string def
+		/AGMCORE_kbuf 0 string def
+		{
+			colorbuf dup length AGMCORE_mbuf length ne
+				{
+				dup length dup dup
+				/AGMCORE_mbuf exch string def
+				/AGMCORE_ybuf exch string def
+				/AGMCORE_kbuf exch string def
+				} if
+			dup AGMCORE_mbuf copy AGMCORE_ybuf copy AGMCORE_kbuf copy pop
+		}
+		addprocs
+		{AGMCORE_mbuf}{AGMCORE_ybuf}{AGMCORE_kbuf} true 4 colorimage	
+	end
+} def			
+/sep_imageormask_lev1
+{
+	begin
+		MappedCSA 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or has_color not and{
+			
+			{
+				255 mul round cvi GrayLookup exch get
+			} currenttransfer addprocs settransfer
+			currentdict imageormask
+		}{
+			/sep_colorspace_dict AGMCORE_gget/Components known{
+				MappedCSA 0 get /DeviceCMYK eq{
+					Components aload pop
+				}{
+					0 0 0 Components aload pop 1 exch sub
+				}ifelse
+				
+				Adobe_AGM_Core/AGMCORE_k xddf 
+				Adobe_AGM_Core/AGMCORE_y xddf 
+				Adobe_AGM_Core/AGMCORE_m xddf 
+				Adobe_AGM_Core/AGMCORE_c xddf 
+					
+				AGMCORE_y 0.0 eq AGMCORE_m 0.0 eq and AGMCORE_c 0.0 eq and{
+					{AGMCORE_k mul 1 exch sub} currenttransfer addprocs settransfer
+					currentdict imageormask
+				}{ 
+					
+					currentcolortransfer
+					{AGMCORE_k mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_y mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_m mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_c mul 1 exch sub} exch addprocs 4 1 roll
+					setcolortransfer
+					currentdict tint_image_to_color
+				}ifelse
+			}{
+				
+				MappedCSA 0 get /DeviceGray eq {
+					{255 mul round cvi ColorLookup exch get 0 get} currenttransfer addprocs settransfer
+					currentdict imageormask
+				}{
+					MappedCSA 0 get /DeviceCMYK eq {
+						currentcolortransfer
+						{255 mul round cvi ColorLookup exch get 3 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 2 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 1 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 0 get 1 exch sub} exch addprocs 4 1 roll
+						setcolortransfer 
+						currentdict tint_image_to_color
+					}{ 
+						currentcolortransfer
+						{pop 1} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 2 get} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 1 get} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 0 get} exch addprocs 4 1 roll
+						setcolortransfer 
+						currentdict tint_image_to_color
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+	end
+}def
+/sep_image_lev1_sep
+{
+	begin
+		/sep_colorspace_dict AGMCORE_gget/Components known{
+			Components aload pop
+			
+			Adobe_AGM_Core/AGMCORE_k xddf 
+			Adobe_AGM_Core/AGMCORE_y xddf 
+			Adobe_AGM_Core/AGMCORE_m xddf 
+			Adobe_AGM_Core/AGMCORE_c xddf 
+				
+			{AGMCORE_c mul 1 exch sub}
+			{AGMCORE_m mul 1 exch sub}
+			{AGMCORE_y mul 1 exch sub}
+			{AGMCORE_k mul 1 exch sub}
+		}{ 
+			{255 mul round cvi ColorLookup exch get 0 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 1 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 2 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 3 get 1 exch sub}
+		}ifelse
+		
+		AGMCORE_get_ink_data currenttransfer addprocs settransfer
+		
+		currentdict imageormask_sys
+			
+	end
+}def
+/sep_imageormask
+{
+ 	/sep_colorspace_dict AGMCORE_gget begin
+	/MappedCSA CSA map_csa def
+	begin
+	SkipImageProc not{
+		save mark 
+	
+		AGMCORE_avoid_L2_sep_space{
+			/Decode [ Decode 0 get 255 mul Decode 1 get 255 mul ] def
+		}if
+ 		AGMCORE_ccimage_exists 
+		MappedCSA 0 get /DeviceCMYK eq and
+		currentdict/Components known and 
+		Name () ne and 
+		Name (All) ne and 
+		Operator /image eq and
+		AGMCORE_producing_seps not and
+		level2 not and
+		{
+			Width Height BitsPerComponent ImageMatrix 
+			[
+			/DataSource load /exec cvx
+			{
+				0 1 2 index length 1 sub{
+					1 index exch
+					2 copy get 255 xor put
+				}for
+			} /exec cvx
+			] cvx bind
+			MappedCSA 0 get /DeviceCMYK eq{
+				Components aload pop
+			}{
+				0 0 0 Components aload pop 1 exch sub
+			}ifelse
+			Name findcmykcustomcolor
+			customcolorimage
+		}{
+			AGMCORE_producing_seps not{
+				level2{
+					AGMCORE_avoid_L2_sep_space not currentcolorspace 0 get /Separation ne and{
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+						/sep_tint AGMCORE_gget setcolor
+					}if
+					currentdict imageormask
+				}{ 
+					currentdict
+					Operator /imagemask eq{
+						imageormask
+					}{
+						sep_imageormask_lev1
+					}ifelse
+				}ifelse
+ 			}{
+				AGMCORE_host_sep{
+					Operator/knockout eq{
+						currentoverprint InksUsed current_ink not and{
+						}{
+							currentdict/ImageMatrix get concat
+							knockout_unitsq
+						}ifelse
+					}{
+						currentgray 1 ne{
+ 							AGMCORE_is_cmyk_sep Name (All) ne and{
+ 								level2{
+	 								[ /Separation Name [/DeviceGray]
+	 								{ 
+	 									sep_colorspace_proc AGMCORE_get_ink_data
+										1 exch sub
+	 								} bind
+									] AGMCORE_&setcolorspace
+									/sep_tint AGMCORE_gget AGMCORE_&setcolor
+ 									currentdict imageormask_sys
+	 							}{
+	 								currentdict
+									Operator /imagemask eq{
+										imageormask_sys
+									}{
+										sep_image_lev1_sep
+									}ifelse
+	 							}ifelse
+ 							}{
+ 								Operator/imagemask ne{
+									invert_image_samples
+ 								}if
+		 						currentdict imageormask_sys
+ 							}ifelse
+ 						}{
+ 							currentoverprint not Name (All) eq or{
+ 								knockout_image_samples
+		 					}{
+		 						nulldevice 
+		 					}ifelse
+							currentdict imageormask_sys
+ 						}ifelse
+		 			}ifelse
+ 				}{
+					currentcolorspace 0 get /Separation ne{
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+						/sep_tint AGMCORE_gget setcolor
+					}if
+					currentoverprint 
+					MappedCSA 0 get /DeviceCMYK eq and 
+					Name inRip_spot_has_ink not and 
+					Name (All) ne and {
+						imageormask_l2_overprint
+					}{
+						currentdict imageormask
+ 					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+		cleartomark restore
+	}if
+	end
+	end
+}def
+/modify_halftone_xfer
+{
+	currenthalftone dup length dict copy begin
+    currentdict 2 index known{
+    	1 index load dup length dict copy begin
+		currentdict/TransferFunction known{
+			/TransferFunction load
+		}{
+			currenttransfer
+		}ifelse
+	    addprocs /TransferFunction xdf 
+	    currentdict end def
+		currentdict end sethalftone
+	}{ 
+		currentdict/TransferFunction known{
+			/TransferFunction load 
+		}{
+			currenttransfer
+		}ifelse
+		addprocs /TransferFunction xdf
+		currentdict end sethalftone		
+		pop
+	}ifelse
+}def
+/read_image_file
+{
+	AGMCORE_imagefile 0 setfileposition
+	dup /DataSource {AGMCORE_imagefile AGMCORE_imbuf readstring pop} put
+	exch
+	load exec
+}def
+/write_image_file
+{
+	{ (AGMCORE_imagefile) (w+) file } stopped{
+		false
+	}{
+		Adobe_AGM_Core/AGMCORE_imagefile xddf 
+		Adobe_AGM_Core/AGMCORE_imbuf Width BitsPerComponent mul 7 add 8 idiv string ddf
+		1 1 Height { 
+			pop
+			DataSource dup type /filetype eq{
+				AGMCORE_imbuf readstring pop
+			}{
+				exec
+			} ifelse
+			AGMCORE_imagefile exch writestring
+		}for
+		true
+	}ifelse
+}def
+/imageormask_l2_overprint
+{
+	write_image_file{
+		currentcmykcolor
+		0 ne{
+			[/Separation /Black /DeviceGray {}] setcolorspace
+			gsave
+			/Black
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 1 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Yellow /DeviceGray {}] setcolorspace
+			gsave
+			/Yellow
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 2 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Magenta /DeviceGray {}] setcolorspace
+			gsave
+			/Magenta
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 3 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Cyan /DeviceGray {}] setcolorspace
+			gsave
+			/Cyan 
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		} if
+		AGMCORE_imagefile closefile (AGMCORE_imagefile) deletefile
+	}{
+		currentdict imageormask
+	}ifelse
+} def
+/indexed_imageormask
+{
+	begin
+		save mark 
+	
+ 		currentdict
+ 		AGMCORE_host_sep{
+ 			
+			Operator/knockout eq{
+				/indexed_colorspace_dict AGMCORE_gget /CSA get map_csa overprint_plate not{
+					knockout_unitsq
+				}if
+			}{
+	 			AGMCORE_is_cmyk_sep{
+					Operator /imagemask eq{
+						imageormask_sys
+					}{
+						level2{
+							indexed_image_lev2_sep
+						}{
+							indexed_image_lev1_sep
+						}ifelse
+					}ifelse
+				}{
+					currentoverprint not{
+						knockout_image_samples
+		 				imageormask_sys
+		 			}{
+		 				nulldevice currentdict imageormask_sys
+		 			}ifelse
+				}ifelse
+			}ifelse
+ 		}{
+			level2{
+				imageormask
+			}{ 
+				Operator /imagemask eq{
+					imageormask
+				}{
+					indexed_imageormask_lev1
+				}ifelse
+			}ifelse
+ 		}ifelse
+		cleartomark restore
+	end
+}def
+/indexed_imageormask_lev1
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		currentdict
+		MappedCSA 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or has_color not and{
+			
+			{HiVal mul round cvi GrayLookup exch get HiVal div} currenttransfer addprocs settransfer
+			imageormask
+		}{
+			
+			MappedCSA 0 get /DeviceGray eq {
+				{HiVal mul round cvi Lookup exch get HiVal div} currenttransfer addprocs settransfer
+				imageormask
+			}{
+				MappedCSA 0 get /DeviceCMYK eq {
+					currentcolortransfer
+					{4 mul HiVal mul round cvi 3 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi 2 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi 1 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi       Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					setcolortransfer 
+					tint_image_to_color
+				}{ 
+					currentcolortransfer
+					{pop 1} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 2 add Lookup exch get HiVal div} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 1 add Lookup exch get HiVal div} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 	   Lookup exch get HiVal div} exch addprocs 4 1 roll
+					setcolortransfer 
+					tint_image_to_color
+				}ifelse
+			}ifelse
+		}ifelse
+	end end
+}def
+/indexed_image_lev1_sep
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		{4 mul HiVal mul round cvi       Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 1 add Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 2 add Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 3 add Lookup exch get HiVal div 1 exch sub}
+		
+		AGMCORE_get_ink_data currenttransfer addprocs settransfer
+		
+		currentdict imageormask_sys
+			
+	end end
+}def
+/indexed_image_lev2_sep
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		
+		currentcolorspace 
+		dup 1 /DeviceGray put
+		dup 3 [
+			currentcolorspace 3 get 
+			{
+				exch 4 mul 4 getinterval {} forall
+				AGMCORE_get_ink_data 255 div 1 exch sub
+			} /exec cvx
+		] cvx put
+		setcolorspace
+		
+		currentdict 
+		Operator /imagemask eq{
+			AGMCORE_&imagemask
+		}{
+			AGMCORE_&image
+		}ifelse
+			
+	end end
+}def
+/add_csa
+{
+	Adobe_AGM_Core begin
+			/AGMCORE_CSA_cache xput
+	end
+}def
+/map_csa
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_CSA_cache get exch get
+	}if
+}def
+/add_csd
+{
+	Adobe_AGM_Core begin
+		/AGMCORE_CSD_cache xput
+	end
+}def
+/get_csd
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_CSD_cache get exch get
+	}if
+}def
+/add_pattern
+{
+	Adobe_AGM_Core begin
+		/AGMCORE_pattern_cache xput
+	end
+}def
+/get_pattern
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_pattern_cache get exch get
+	}if
+}def
+/set_pattern
+{
+	dup /PatternType get 1 eq{
+		dup /PaintType get 1 eq{
+			false op [/DeviceGray] setcolorspace 0 setgray
+		}if
+	}if
+	setpattern
+}def
+/setcolorspace_opt
+{
+	dup currentcolorspace eq{
+		pop
+	}{
+		setcolorspace
+	}ifelse
+}def
+/updatecolorrendering
+{
+	
+	currentcolorrendering/Intent known{
+		currentcolorrendering/Intent get
+	}{
+		null
+	}ifelse
+	
+	Intent ne{
+		false  
+		Intent
+		AGMCORE_CRD_cache {
+			exch pop 
+			begin
+				dup Intent eq{
+					currentdict setcolorrendering_opt
+					end 
+					exch pop true exch	
+					exit
+				}if
+			end
+		} forall
+		pop
+		not{
+			systemdict /findcolorrendering known{
+				Intent findcolorrendering pop
+				/ColorRendering findresource 
+				dup length dict copy
+				setcolorrendering_opt
+			}if
+		}if
+	}if
+} def
+/add_crd
+{
+	AGMCORE_CRD_cache 3 1 roll put
+}def
+/set_crd
+{
+	AGMCORE_host_sep not level2 and{
+		currentdict/CRD known{
+			AGMCORE_CRD_cache CRD get dup null ne{
+				setcolorrendering_opt
+			}{
+				pop
+			}ifelse
+		}{
+			currentdict/Intent known{
+				updatecolorrendering
+			}if
+		}ifelse
+	}if
+}def
+/setcolorrendering_opt
+{
+	dup currentcolorrendering eq{
+		pop
+	}{
+		begin
+			/Intent Intent def
+			currentdict
+		end
+		setcolorrendering
+	}ifelse
+}def
+/OPIimage
+{
+	dup type /dicttype ne{
+		10 dict begin
+			/DataSource xdf
+			/ImageMatrix xdf
+			/BitsPerComponent xdf
+			/Height xdf
+			/Width xdf
+			/MultipleDataSources false def
+			/NComponents 1 def
+			/ImageType 1 def
+			/Decode [0 1 def]
+			/SkipImageProc {false} def
+			currentdict
+		end
+	}if
+	dup begin
+		/HostSepColorImage false def
+		currentdict/Decode known not{
+			/Decode [
+				0 
+				currentcolorspace 0 get /Indexed eq{
+					2 BitsPerComponent exp 1 sub
+				}{
+					1
+				}ifelse
+			] 
+			def
+		}if
+		currentdict/Operator known not{
+			/Operator /image def
+		}if
+	end
+	/sep_colorspace_dict AGMCORE_gget null eq{
+		imageormask
+	}{
+		gsave
+		dup begin invert_image_samples end
+		sep_imageormask
+		grestore
+	}ifelse
+}def
+/cpaint_gcomp
+{
+	AGM_preserve_spots{
+		gsave
+		nulldevice
+	}if
+}def
+/cpaint_gsep
+{
+	AGM_preserve_spots{
+		grestore
+		currentoverprint Adobe_AGM_Core/AGMCORE_ovp xddf 
+	}{	
+		gsave
+		nulldevice
+	}ifelse
+}def
+/cpaint_gend
+{
+	AGM_preserve_spots{
+		Adobe_AGM_Core/AGMCORE_ovp get setoverprint
+	}{
+		grestore
+	}ifelse
+	newpath
+}def
+/AGMCORE_ctm_stack bdict
+	/push_ctm {
+		stack length size le{
+			stack dup length 2 mul array 
+			dup /stack exch def
+			copy pop
+		}if
+		stack size 3 -1 roll put
+		/size size 1 add def
+	}
+	/pop_ctm {
+		/size size 1 sub def
+		size 0 lt{ 
+			/size 0 def
+		}if
+		stack size get
+	}
+	/stack 1 array
+	/size 0 
+edict 
+def
+/save_ctm
+{
+	matrix currentmatrix AGMCORE_ctm_stack begin 
+		push_ctm 
+	end
+}def
+/restore_ctm
+{
+	AGMCORE_ctm_stack begin
+		pop_ctm 
+	end
+	setmatrix
+}def
+/path_rez
+{
+	dup 0 ne{
+		AGMCORE_deviceDPI exch div 
+		dup 1 lt{
+			pop 1
+		}if
+		setflat
+	}{
+		pop
+	}ifelse 	
+}def
+end
+systemdict /setpacking known
+{
+	setpacking
+} if
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_AGM_Core/AGMCORE_err_strings 3 dict dup begin
+/AGMCORE_bad_environ (Die Voraussetzungen sind für den Auftrag nicht erfüllt, da mindestens 
+PostScript Level ^\tund PostScript-Version ^ erforderlich sind. Stellen Sie sicher, daß die PPD korrekt ist bzw. daß das gewünschte
+ PostScript-Level vom Drucker unterstützt wird. ) def
+/AGMCORE_color_space_onhost_seps (Dieser Auftrag verfügt über Inhalt, der nicht mit
+ Host-Methoden separiert werden kann. ) def
+/AGMCORE_invalid_color_space (Dieser Auftrag besitzt einen ungültigen Farbraum. ) def
+end put
+2 2010 true Adobe_AGM_Core/doc_setup get exec
+%%EndSetup
+%%Page: name:1 1
+%%EndPageComments
+%%BeginPageSetup
+Adobe_AGM_Core/page_setup get exec
+%%EndPageSetup
+Adobe_AGM_Core/AGMCORE_save save ddf
+mark
+/0 
+[/DeviceGray] add_csa
+/CSA /0 
+/1 
+[/DeviceCMYK] add_csa
+/CSA /1 
+/2 
+[/DeviceRGB] add_csa
+/CSA /2 
+cleartomark
+800 path_rez
+1 -1 scale 0 -49.875 translate
+gsave
+[1 0 0 1 0 0 ] concat
+gsave
+0 0 mo
+0 49.875 ln
+155.75 49.875 ln
+155.75 0 ln
+clp
+gsave
+0 49.875 mo
+0 0 ln
+155.75 0 ln
+155.75 49.875 ln
+0 49.875 ln
+clp
+7.375 0.875 mo
+6.375 0.875 ln
+6.375 48.875 ln
+7.375 48.875 ln
+7.375 0.875 ln
+false op
+0 0 0 1 cmyk
+ef
+6.875 24.375 mo
+10.4863 24.375 13.375 27.2637 13.375 30.875 cv
+13.375 34.4863 10.4863 37.375 6.875 37.375 cv
+3.26367 37.375 0.375 34.4863 0.375 30.875 cv
+0.375 27.2637 3.26367 24.375 6.875 24.375 cv
+cp
+6.875 25.375 mo
+3.81934 25.375 1.375 27.8193 1.375 30.875 cv
+1.375 33.9307 3.81934 36.375 6.875 36.375 cv
+9.93066 36.375 12.375 33.9307 12.375 30.875 cv
+12.375 27.8193 9.93066 25.375 6.875 25.375 cv
+ef
+0.875 30.375 mo
+0.875 31.375 ln
+18.875 31.375 ln
+18.875 30.375 ln
+0.875 30.375 ln
+ef
+18.375 30.875 mo
+19.375 30.875 ln
+19.375 12.875 ln
+18.375 12.875 ln
+18.375 30.875 ln
+ef
+18.875 12.375 mo
+18.875 13.375 ln
+30.875 13.375 ln
+30.875 12.375 ln
+18.875 12.375 ln
+ef
+30.9375 9.125 mo
+33.0557 9.125 34.75 10.8193 34.75 12.9375 cv
+34.75 15.0557 33.0557 16.75 30.9375 16.75 cv
+28.8193 16.75 27.125 15.0557 27.125 12.9375 cv
+27.125 10.8193 28.8193 9.125 30.9375 9.125 cv
+ef
+31.375 0.875 mo
+30.375 0.875 ln
+30.375 48.875 ln
+31.375 48.875 ln
+31.375 0.875 ln
+ef
+30.875 24.375 mo
+34.4863 24.375 37.375 27.2637 37.375 30.875 cv
+37.375 34.4863 34.4863 37.375 30.875 37.375 cv
+27.2637 37.375 24.375 34.4863 24.375 30.875 cv
+24.375 27.2637 27.2637 24.375 30.875 24.375 cv
+cp
+30.875 25.375 mo
+27.8193 25.375 25.375 27.8193 25.375 30.875 cv
+25.375 33.9307 27.8193 36.375 30.875 36.375 cv
+33.9307 36.375 36.375 33.9307 36.375 30.875 cv
+36.375 27.8193 33.9307 25.375 30.875 25.375 cv
+ef
+24.875 30.375 mo
+24.875 31.375 ln
+42.875 31.375 ln
+42.875 30.375 ln
+24.875 30.375 ln
+ef
+42.375 30.875 mo
+43.375 30.875 ln
+43.375 12.875 ln
+42.375 12.875 ln
+42.375 30.875 ln
+ef
+42.875 12.375 mo
+42.875 13.375 ln
+54.875 13.375 ln
+54.875 12.375 ln
+42.875 12.375 ln
+ef
+54.9375 9.125 mo
+57.0557 9.125 58.75 10.8193 58.75 12.9375 cv
+58.75 15.0557 57.0557 16.75 54.9375 16.75 cv
+52.8193 16.75 51.125 15.0557 51.125 12.9375 cv
+51.125 10.8193 52.8193 9.125 54.9375 9.125 cv
+ef
+55.375 0.875 mo
+54.375 0.875 ln
+54.375 48.875 ln
+55.375 48.875 ln
+55.375 0.875 ln
+ef
+54.875 24.375 mo
+58.4863 24.375 61.375 27.2637 61.375 30.875 cv
+61.375 34.4863 58.4863 37.375 54.875 37.375 cv
+51.2637 37.375 48.375 34.4863 48.375 30.875 cv
+48.375 27.2637 51.2637 24.375 54.875 24.375 cv
+cp
+54.875 25.375 mo
+51.8193 25.375 49.375 27.8193 49.375 30.875 cv
+49.375 33.9307 51.8193 36.375 54.875 36.375 cv
+57.9307 36.375 60.375 33.9307 60.375 30.875 cv
+60.375 27.8193 57.9307 25.375 54.875 25.375 cv
+ef
+48.875 30.375 mo
+48.875 31.375 ln
+66.875 31.375 ln
+66.875 30.375 ln
+48.875 30.375 ln
+ef
+66.375 30.875 mo
+67.375 30.875 ln
+67.375 12.875 ln
+66.375 12.875 ln
+66.375 30.875 ln
+ef
+66.875 12.375 mo
+66.875 13.375 ln
+78.875 13.375 ln
+78.875 12.375 ln
+66.875 12.375 ln
+ef
+78.9375 9.125 mo
+81.0557 9.125 82.75 10.8193 82.75 12.9375 cv
+82.75 15.0557 81.0557 16.75 78.9375 16.75 cv
+76.8193 16.75 75.125 15.0557 75.125 12.9375 cv
+75.125 10.8193 76.8193 9.125 78.9375 9.125 cv
+ef
+79.375 0.875 mo
+78.375 0.875 ln
+78.375 48.875 ln
+79.375 48.875 ln
+79.375 0.875 ln
+ef
+78.875 24.375 mo
+82.4863 24.375 85.375 27.2637 85.375 30.875 cv
+85.375 34.4863 82.4863 37.375 78.875 37.375 cv
+75.2637 37.375 72.375 34.4863 72.375 30.875 cv
+72.375 27.2637 75.2637 24.375 78.875 24.375 cv
+cp
+78.875 25.375 mo
+75.8193 25.375 73.375 27.8193 73.375 30.875 cv
+73.375 33.9307 75.8193 36.375 78.875 36.375 cv
+81.9307 36.375 84.375 33.9307 84.375 30.875 cv
+84.375 27.8193 81.9307 25.375 78.875 25.375 cv
+ef
+72.875 30.375 mo
+72.875 31.375 ln
+90.875 31.375 ln
+90.875 30.375 ln
+72.875 30.375 ln
+ef
+90.375 30.875 mo
+91.375 30.875 ln
+91.375 12.875 ln
+90.375 12.875 ln
+90.375 30.875 ln
+ef
+90.875 12.375 mo
+90.875 13.375 ln
+102.875 13.375 ln
+102.875 12.375 ln
+90.875 12.375 ln
+ef
+102.938 9.125 mo
+105.056 9.125 106.75 10.8193 106.75 12.9375 cv
+106.75 15.0557 105.056 16.75 102.938 16.75 cv
+100.819 16.75 99.125 15.0557 99.125 12.9375 cv
+99.125 10.8193 100.819 9.125 102.938 9.125 cv
+ef
+151.375 0.875 mo
+150.375 0.875 ln
+150.375 48.875 ln
+151.375 48.875 ln
+151.375 0.875 ln
+ef
+103.375 0.875 mo
+102.375 0.875 ln
+102.375 48.875 ln
+103.375 48.875 ln
+103.375 0.875 ln
+ef
+102.875 24.375 mo
+106.486 24.375 109.375 27.2637 109.375 30.875 cv
+109.375 34.4863 106.486 37.375 102.875 37.375 cv
+99.2637 37.375 96.375 34.4863 96.375 30.875 cv
+96.375 27.2637 99.2637 24.375 102.875 24.375 cv
+cp
+102.875 25.375 mo
+99.8193 25.375 97.375 27.8193 97.375 30.875 cv
+97.375 33.9307 99.8193 36.375 102.875 36.375 cv
+105.931 36.375 108.375 33.9307 108.375 30.875 cv
+108.375 27.8193 105.931 25.375 102.875 25.375 cv
+ef
+96.875 30.375 mo
+96.875 31.375 ln
+114.875 31.375 ln
+114.875 30.375 ln
+96.875 30.375 ln
+ef
+114.375 30.875 mo
+115.375 30.875 ln
+115.375 12.875 ln
+114.375 12.875 ln
+114.375 30.875 ln
+ef
+114.875 12.375 mo
+114.875 13.375 ln
+126.875 13.375 ln
+126.875 12.375 ln
+114.875 12.375 ln
+ef
+126.938 9.125 mo
+129.056 9.125 130.75 10.8193 130.75 12.9375 cv
+130.75 15.0557 129.056 16.75 126.938 16.75 cv
+124.819 16.75 123.125 15.0557 123.125 12.9375 cv
+123.125 10.8193 124.819 9.125 126.938 9.125 cv
+ef
+127.375 0.875 mo
+126.375 0.875 ln
+126.375 48.875 ln
+127.375 48.875 ln
+127.375 0.875 ln
+ef
+126.875 24.375 mo
+130.486 24.375 133.375 27.2637 133.375 30.875 cv
+133.375 34.4863 130.486 37.375 126.875 37.375 cv
+123.264 37.375 120.375 34.4863 120.375 30.875 cv
+120.375 27.2637 123.264 24.375 126.875 24.375 cv
+cp
+126.875 25.375 mo
+123.819 25.375 121.375 27.8193 121.375 30.875 cv
+121.375 33.9307 123.819 36.375 126.875 36.375 cv
+129.931 36.375 132.375 33.9307 132.375 30.875 cv
+132.375 27.8193 129.931 25.375 126.875 25.375 cv
+ef
+120.875 30.375 mo
+120.875 31.375 ln
+138.875 31.375 ln
+138.875 30.375 ln
+120.875 30.375 ln
+ef
+138.375 30.875 mo
+139.375 30.875 ln
+139.375 12.875 ln
+138.375 12.875 ln
+138.375 30.875 ln
+ef
+138.875 12.375 mo
+138.875 13.375 ln
+150.875 13.375 ln
+150.875 12.375 ln
+138.875 12.375 ln
+ef
+150.938 9.125 mo
+153.056 9.125 154.75 10.8193 154.75 12.9375 cv
+154.75 15.0557 153.056 16.75 150.938 16.75 cv
+148.819 16.75 147.125 15.0557 147.125 12.9375 cv
+147.125 10.8193 148.819 9.125 150.938 9.125 cv
+ef
+grestore
+grestore
+grestore
+Adobe_AGM_Core/AGMCORE_save get restore
+%%PageTrailer
+Adobe_AGM_Core/page_trailer get exec
+%%Trailer
+Adobe_AGM_Core/doc_trailer get exec
+%%EOF
+gsave userdict /annotatepage 2 copy known {get exec}{pop pop} ifelse grestore showpage
+%AI9_PrintingDataEnd
+
+userdict /AI9_read_buffer 256 string put
+userdict begin
+/ai9_skip_data
+{
+	mark
+	{
+		currentfile AI9_read_buffer { readline } stopped
+		{
+		}
+		{
+			not
+			{
+				exit
+			} if
+			(%AI9_PrivateDataEnd) eq
+			{
+				exit
+			} if
+		} ifelse
+	} loop
+	cleartomark
+} def
+end
+userdict /ai9_skip_data get exec
+%AI9_PrivateDataBegin
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(R) 9.0
+%%AI8_CreatorVersion: 9.0
+%%For: (Gerhard Gerlich) (TU Braunschweig)
+%%Title: (bild3)
+%%CreationDate: 09.04.2003 16:22 Uhr
+%AI9_DataStream
+%Gb"-6CNCf4E@CSil9CdlMNGJg?G%@`LEjl-d]57u#g'Zd_nMgXpU!D2`U6e!oLNctqF*RK<7NuSRiGY`D3d$'8to-1+Hc+dr87f]
+%+23+%eMls3^A@@!rV5;e4nop+5,UaRC&,RUrh"+Xq=`QcRgYi5[(Aj4I`_,s]%A'[(GWJQT"=pjk.>hUhgbLA`t*+FIf&O&_u5@O
+%hu<CiFoV<_mtX.-lFT:YiVo=U?aWs_q!MX-q;]@7g(WAXrH,RIlGLBMrQY;q5JFgT^Ua864P1$c0^[QnX#KjdTDn!A5/.$]S(:O8
+%ZW[;GHb`__jPB.*hmQihCZ]i1rT*tW]5Ko^I/W<I7t03A]0Et-o]bb`pY9B\Q#FD8h1n38>l/<iq<PN)HOWp,H773/lg-R>hqYu[
+%rUB@5lVE:\JM9l0s7Nj<lp!\lmf`X3q`"9,IJ*:MD)1!tKqJ&jr#u(EJ,e'R:S1hjD(9CLqsgTar:f4q1al]qr0Ld'rq>*Um>W3;
+%s7ZEkqGD%`-A^OSX1*S'h<*^d&+<_@oZ.POp9*<Pp@WY(T4fp6hQ$PNksl!VfUr0E!8ld'l!W40oRFI9e`A!DTJ3o_=nl?B\butd
+%G6`U'pnhEriYp\5kjQV56>V-ogtlrFL[0^L8smMGGl-n>pTHfp-&f#&U7nbHmD$R-gp/L?[^,_eg`bg-.(7R]3h!h^j#:oVo]*hb
+%?bcF!rML1`rf6.2(Z2m!e\1nUkuZd?7pF!c2HL3FTYLEmrp@a5^]3FpRk=hDHL.OO^3Y.P+FNnVr\Z=ln7DB%C@Db;5CWS)'C;Fi
+%mpP^9HmjaLoX"#Ch7`g^[iYnqhuu@F_qXqcnDSlVBO?$$%].F?\S/KdX?#?"RuWdd+2YO"g`\ci%nj+:/]B@]f)>O,2d_(+rl6ug
+%Le7S)^Nf^4[i^+qp<BKW^Toh3D=5R*Q1OqJT=/1W,Hoh6^9Zi#If_b3]8tise^6@g6_XP<2n,LSs&]"\I9`8>[QWL]lJK8SlM0<Y
+%/5P"A5Ic$o?Ij;:rJ.T@Du)QpV7l</5L:e;rGR/YTs\cRfuC8oljo$ILTC0ehhCLrq!c1.^A[oqqg\Lirpumr]E+fj>^a$XbORU8
+%D7qO1q)7'KgMlIsh6"@J2n(_)2qL"/S#`%%RsJ"NnkH]P2rVd6\/Td)Y&CL^Y-5$if2pRjfCc^[kNd41YJ[c_G0@;,2TOS4c11XT
+%4C0$]O7cV8q3[34(lnUZNqR.hDQdr\Y-3je='(_ior;9YX)o)[_NhlV=8'dAhHo&D?=+a,Y:_JpbBd;Do4>LlQf6A"\k@Bal>=56
+%fC`7Ll=I**e6Gq32,mpg[FLMrE`9-aZ!<R;;G/ILU_6<K^::#l@e+BMak-?UYOZ8-\`B8ZN]CXB?+/F^gN8X^dkP.)b>_D33MdEg
+%83XRpPDQd=-=4`&]S`%KgH$YCQsu!tqWOYj<9,smK^3Rc=5bpa:dPX@`"7M20%aS0XhXDXrogQ`V6@W.m$!JoGjjJJXZ,\!h7.6E
+%FB@nY<EEFKNJ"e"]Q;@Z@rLao]s^FXAM7o.`FbTU[)%(SXL6'TFYmqa9Uj>HZmd`sX%XJ"BmhXa]/8"gD)2*&Bs8DeW5J7JfCG)q
+%boPr5\X&TIBYVIUr+jsc)?qbdn:TV'I;Cmip@rm_1Y:`VlUn=Vs2rs`b]S?rih,=Eqf@,\\htig9@kB&9U@h^q3+m1CS?59=$1Q#
+%P?4MT$iFZ3.VGnF?>Yi)An`M62U[[+M5ZD5>W%[ah+5Sg1Q@@'7SZ8p/#eYtd`BXD,<*Y4G&H%.RRW$:UIV$*V:=^-BlrXg?S.7N
+%>rUbc)b_JeXqA#f?8pl0)j.1\fNgA/GMS)4D'K.k&OYH3@Vit;2^2DbAYYX57QGD@f:,6$?1LW5X0If=grO;KjS#U9h<ROZD]A-!
+%7ZMmAbH[2mgrOSSjSGm=mH[6UD]9VLiYkN%NOCcs^X;l2kl'&[#lf%bj4e;e1N8=&KZ5!0@hPUmMp'*sNfA>>eD!XFR#,TP,rFbI
+%)NuV0fj$G<F)9Xpk485g1iDBWr6e\GCb.%p<`L*^\n\>4\mb:!d56%/)I!T/]qra28n3(3NU7`*qn"lF?CSqE?/pj:n]0/SA81u4
+%o(m*8bk&E>p[*rS%+R5T)B+6&NR8Ns@TU&iD@hp^ia+llagf3)@(/X2gIBdZs*>*AG]C=d?U8H,CUhQ/=QiGKcdC&0f:!&=+O8<G
+%efC>l&WaMh-U2X3A$p)tW52CclEG[(7>0@/m.G#I@=W-eIpVR>F6aChof;<dT(]NR7t'+?SsJQ<:OCgEnf7=::O?9:UH\'Z:Wmh/
+%-W=Z0gpgI'd&Zllldk@PReDD%,l]DeCH3\UIBKBRS.`4n=418IM-?N%Be?5NXj<9>Q;aO/_ibd,;Hl'W&>t"S:3fr*H:UH9m+4#L
+%k]QR6FZb((r6+a8f?FDaC0&MLQ-2:/SbQ@[2tt+qAR.i_+3Vr:<%N<Li:I_[H1s?I/"Y4q:L;4i[J]8R:K6DqCINpT'<cBS=rqGJ
+%i3d>*HVq]7pLXYW+a_kZb1Y7o8)23>AXsV,C3_8o["qf,93J/]]NSXa3\B@Anl"%Q&[.LeZ;-<tH6L9%U0=2d:B-Xb0d`YkV%hP\
+%Bu3b5mn[d"0a=*FCAG\a*bolk/bGT4*1GNKUe)Fb3noPg0bn$F?5W03d7]BSp2dAOp#BN"('.dpk#kl@Z(H*>YTN^D*\,I.ZuG%.
+%SSL[m=Gp+F9Neb?]/e?=ol>1Lm\lWL?\pRRh`pe72o#7=l];)9f8"j'qoumeO:UiYfCqL5:AtFQXQ$e%D*6eRp3:q,Hhe:\XQ:Tg
+%m&>)9Gt8Hm.\0Z_d_hYK-^KP[Yc#p+jWQeRWH;V&,8B.VC8.I(MP5\iIIRubc;6cIocC:ba;Y%'A:F:Lj6Nn`HMu[ODZPEE]@NSj
+%Ui#<c='T$FF6/s.CIgMNXnbWkoeG%;a30Mk"MVqSS/)2K.ka*K!rZXij":,/li41!;*mXe,@m\cSWVtq_X>n;bq]j#OlVHh8'$\r
+%-q&?6p(6ltqL]Jq@3Phb#RD$)+s9??Ndr5Q8TLb*)C/!ARXd?uGle%iKgZ9h'G.:M+LT?_Z%-FTUg!k6QUgo6OG:R^/%RiOU,e-d
+%XU9@*gUi3Tn#nb=hUlKaH`G4;*QakeQA61M1Y;'@Z4Hs4T,6lk<0)+gg8B40_'_=VB_Ar!HX32V(B*q$V!Im,[@I6FE'8cp0$bil
+%l^q_rHJ[!J@3$P$2gH(49okGaaI+/^()/Gg]HlGK6q\(B8ZWo2]*OWN:9K;mVhgLRO01-,f(2J=Ia*K+Q.#<+1jt^b00:G-+QuMF
+%PLB'/e/Tn416D)B0n1Gp?d\CTO,T^(ifBhlbD(g;PC!8^;f"<&Foc0K-LrB*lKg!mrQ-<qB@IpMK'Hi6'bZa%O,>3]P&M:<-uVt^
+%"LSjV92I4D:qZu8'2282MukREoZXg%<>1Tk:cC]!["poTW-3dP$*#@$T:gXr!X^D*.&!;gOs175-n(jhN\78mP"l?f.I!\%R?DFp
+%g*u9aUnLu1cWg<V:fBq_,up54>,8?b`elf-CTXDAP3+7*.qu2_^Tn'e3im#"<sot[aQ+YY/8MSlc\b3HF^!1-=hsBmm4p*!?.MsY
+%GE=dSRBr*SOZ4M0>*M41'Pac<cA&U3`]NFtMpeH0g:OQ`ShlM&m^p]c03LX&V^$NNeAC]H80E20A.B5E87Wl`#/hJkAY[m9LW1#i
+%Ca@[rIG;ht))f[F:Y`hA`3@d'hB8/$V]@]dh\giLoNcIEYY@SF7:OG6cjaF951=_n-!P*[?3kAJBmX:)NBm3+lg7/T]-*-G!2jbj
+%"'+_ICr'6Y,EA.2]"tkFI)?0c!V`e+\A'0OO%,\nX>:`;2O`2tf4t50bEMZ04D.C)h8Zc`@,uU-3I$JHK13<"?k;BD,aZ+h1=h+-
+%!U7JSj:8=tUhFhY><_-lZH`[?1fG[QMs*erUi=^.Gj+j;.lB8j!@k8W[J.-XR@QOSJ,f6@GOIc0rV6'OpKrR;Ba&4a7l<O(XaA$1
+%;;&DLVA7*_<\/*"B6i1`Y\hRXI//q;5erFlh[BcA^V0%1`m@3ZooB0oQS=N9W%\c:=,rss>Hd6sgr<YK`c7$?=Jd2J'h`c1+8,aS
+%H?<;SCLJ50Z2H*rY/s]:]%$&'YG5FUHF<QN8;8/Ei'gr86g?mBYJ=5h/((aII`ka`WdJ+;Ff!\eYA:ghpps`f$GYmfI?OGgj<s/F
+%6JaU?jRIupP8<Y)CrE+9fXlmfh40/=k9B7<+"Sf1%o27,4ClN:p9G+P(pN^.<eD-%H,(EmJ2rGZX2/'EpaU8);>73Zek=he'%:s'
+%>>I-sD6^J;`feSgWEY.e$h"VZ'qRuX@D<q4<V/c01L[U4YTU&L'MV-fM<"cd#I8i5R`73W@(/]+%8m8:+DM/B!tc"')25PWquA\X
+%n-%_X2jf8-O>d_p!<)s<!dFjEAX!?e`(T/+`%A,he\+DC6!ONeL.C>T1AAkgFB.BF`'o3;!%5<[&>9N\-AO,UQjU)5?nB)sJ@Q5<
+%!=!U5`=MTrL3=f2`Vh@b>B[Y]4)WTeJ&<$FZ3nu*UubMArfn2'_@D*t-DR@^9Sf.Me#<q9%8#h+?l-YR7\slHY?-@k5YOjO8TZ!n
+%#A`Kgk],5BN"=m3(L_0(67t_&IhYNHP,X\=[k'2#8dRi9nrfu:J1A`8VGb9)0!(Y;HXKR&c_Z^`<MrW!Ms/lmY6PO!%gLfPm'qHt
+%`pf\S`[<$J0OpuMM#O_nL"r)TSSO$f>uk"Zn_-IUmR>d26?8D+WDel$45,\ZH^neol]+&8Vd4I>TbJ?=TeSoR9Fm3K!AY93dt;1W
+%Qjg$DBaBud@$r&gF#DT#8&L;9YaHOlK1;74GedjRYo7=(+Z*7r0utmrX(5Ui[Vq<@_FC=qLtcU/d<IbtE^]&Cck35r/X)r\Ai*6m
+%k/h2_3_(,8=XgtRZ<Jf@*"LOl,)TICoBX9eS*i!Ib9^%XUm#94&K@VBc[fhgZR);-dN2YTKQ8L6\7`um(sa,(&dRa4fZ1[Ek&)Im
+%,N(<ob6c#',1t0&A8*0^'D&b:$,of`VK=PiM\SQ0&RnjT,GH+/`Q0YY75;4anfe,gBQY[IUDOog!\[T!Z,B/Pn\CO[eM8f/q0">^
+%G=2uX@]A680>E[B9>)f^Ks-5eZt[UK.E;>--N:e"8M1U/<%o2GSkA=l5bP=R3pP7N1]Gn_.`7N;]gjT%QdQnsk7M:sB3J)sa(HrA
+%lmKC\P\%mgE[GRi-/j8&$JJ@CN?MjtGBmssfih>$T!G:\ASk>5Z^Acqk1Qoc/LtL==kL6Yk*<cudS2:Ka<G5^T%PZ\(:LV%Ci0i;
+%$^t>MkX&mJ^sR%f9+>.3q;o[I[&D$Dr@Xo4$3na>k8]fN,?^,)Sk:/N;O%2BhW>\)6eh,*FnYG@dY7D$KpEaQkKsT'Hhg"OI/D!L
+%Tudd&?^i=8-[;W:,nY9>#i,_"!H#&id"U?`"[1=f>Q]u01q81"F(c-LmkJ0+'FKJ6i-`-AK"#7&8@CW-J=BbPIh8uY@_hP%dD8&E
+%OXUbWY8<l=2ndDT1o;pDoFbN"'>#e^4Eu(t`$IWqn$uIpEbp,LrO_rf++EtSn<9Jp=(Am[rVA0Ui.%G/i'!gHWIlj#Y@Q_nb=g>8
+%)>X:&'(njdI_WN`]opciZFiT=P0nW^HsXK!2!3XiiVFAK10rAb!S5<qht_TGoWogF<_t&;%,:LJZnVJd^OQ:[h:o+C?SeXCSdjmV
+%rNn6Ne%X=-H\$Rla6/FGX2FD$NY,tNT-"QXHi<^'nDtiP?`pI0X:@bDlBfA5?OGtE.@g./E8HquGqUOG4@aSk>HAUul^-m^:UqNH
+%m-Y%\0@fZcGl:b\]6j&X^JrPVMliTF)>0F>\/sD`""DLX;WXKqrMOi6?_JNi$&8J<%>Om\'Ce^i`"s+GT-4\/`?'%H?LbRkD#Sft
+%,45S'4Qko)Zl2-sqX`h!cO`nG*rXhH<A)$&DoE*0/\Y2pr)2YI^L*7!1lFN"eE,KXAA-0[fgA1]kGBUW?W(IW8!UiZS,W/aJ[l7C
+%3*<p/EWFIkp>q3QI+*LKIqB]#=WMsp*<.[r_sbtWo;0A)PR]o*cMf!99O.:m1E._)g-B^?hS(OnSYfV+p7gue\Y^<^f!4s0Q"<KO
+%V=`5@[GH`<->M+G<@c?lnkDseZ^C98nb<LGF3((C2OuQRrs$0U"uA:\-I6XU52(8&b0skm_:E\@J@Pmo5!<$*@pPpeVB>B%(/1F3
+%6jo*0mU)agI#E^eX!.E)<t1P^6';)5ZU-,[La8erLcHb?'\JK/,(ljCNW]2BVQ2uQ8m3p8Kjsugg6!jtI8JGn&T(.lX>f%2K@Z]@
+%a`8GQj0Y:@q#Ce+S.]"r10U7V>+[;-#>gGr(##CBS1?l#!]Q?"^j-"dD,_:f%]q&k8TN4iR-qD)mPZn3Z<Zac'i$4Nk9D9r+sWZl
+%%<3S?s!^eWB<G1/iA>Q,ZeMY(_m2#RN\M(iJJ]uKK+3$!+r8F7QTTH9@@r@/`'m4-`'bs%ZHEgm"/Xp\orBmE@STcB'@\a"IDIV#
+%'tqDQ_1_W:,JbKin<RSjd>4%9,?.%o``8oULp8bpfHVCMnQ<6L""Q+--jX"A3sk.>UeX=ROcb@^a;uY4SDkm&,]GMD;K=N*'IG7:
+%B=W/b1=29qD4.A]k9Rg`(Tubl<$lCD@+B%i2P&id<9JS[o!b'Y38&E@E4P6(dhPn";PrQ,>2T5-^/*8VQFbu>lZ8WeF(qb*SpB"i
+%ToRJ)e>-5Q4ko=+Wfl,cPT2)D)P6n<+mP!am#1i/MuE"WSc.o5"8[oXqMPIPMZ`g6"8[oXqKk"gs7mR[?e2A>-+J=/T769U<4)6)
+%?=1RIT6U<;7QZ)+TDfHer?Zjfc_SJY$E<#X*pK"RdP#mA?h-b6VgUc#qN=AF=[r%#*pK"X04,("]X4U!0a>m8H"pZe_e0UAk7E\%
+%FSL:2b:eQU?KUFcFeP.OH(hJ#QO?]?q=*Y;+iO8s_pDa?7/e&Y#@TRT+A=XAojjZa7%Si;cZfN;E:=A'U>p5TI*BkkS?e?U;b"oO
+%T[%eDc?OlbI!/7pI#GJ_JN:VF3>ft3B9?`+$=:5/pa'9KH8<U)@re$JZVWUt+&X9fPup4C6Or,_H=dJS>!gVCR85K0o1SiePD,&P
+%OeYU1;VkV&CMrfQ',-@sN?lPhnAiHif7K:;.1hN)VoPf5O&2Lp3H7hD;>Y)B.T4I4Q+L%m[`[*'SXL7mAYi>YFXcNs-"meYEZ-2Q
+%aq^sYbFi9d*D<c@4Oo!H:3E3]LJ.l3L#NrIKhNGq4tibbb+^HQ<I(lb]CN*XO'3,uO*q1U;K3LZNNJ@*X1<"7G>NE0AN)/m^0BcH
+%gqtTE<I71)mBsI#&iZ:k(:(9f.30%(Z*nJm[Z/tO1#"Vk$cfP.Ef=uR-f`:oKon$hlKoTN7dTWFf[.eB7;h7tcp_Hc[h7]1MCm9u
+%el^;"br0HQZY0oK?qsinNQ[>'E@=L8T2W8p6;`c<;3B1b#^h)SB@:JX'F@aPDYYi?)^_^UC9R8/M+aYb7%NqDVb89^W^0FKn4`+u
+%kSl[%ig->`YP$+r,P)H,-&Wg-;4-;f4b+_3e*t9N:Z0G?X7UZ)dr=Hu1*$'gq,$R0daNHdds/l25Mq<6_0WC#SF&/)ldX7&)UEKa
+%Z^g*HN)OnM-b3O$'X0^R(@VU]$Q&s][0Ab<*q3_7b>TE8C(sbkBbb<k78\Of)Y80c?=#PPmkQLK)tTE"Q^<^-CI6G/bq[//FdMDX
+%^XWVREN^JW";6h<l`fJ^e)uGZrOh`5n"2T<9cX<tVnXgQ_r(+]\)"CJeu-:-B>6=hYj;pW>7CkQhOtSJZeoA0OdFVWDo;*`GR\<#
+%c"a2T!sPX=r^DeQ9(o0gUBNg5P#SH96Z>:VA*38V7/bZ3$jRi,e5W^HB:hKA97qihKST%K]45i"m(ceWI^%q?e2O#oe@,W&ZYT@F
+%+$Qmn`'NCirA1(X'D.M0b@g+q>j>JO$e'`WH52S(IXY9]_.l)3]H8Y!A3u?^>*)pH-X"],=nU7F7cNeH!=cWEDO?7OO]Dj^C"6!!
+%-^lf_CXiag&T^Do0qW&?gM1lB'bMEGhhoL8S8_L$KWFJX=5-ZVNXLaj,*&0SkA#Fn<Bo[3E^&Z$km(KCNFCNrckVZoPa%,`<+@E.
+%QtP(sONjr(4F.$*<aJhDEd%`Uk?N1E\ORrA8QEr+?p9oVj]%G$S'4OUVj9gYc.urEVdug?3WFmJWR/:M9%I1j=ri8Qj]_q3-KZIa
+%lF<qFi1=N5<T0YRZ`%4o[o*]+;Or'kFJqi5`Dd]oPiJp07EKcu"F7h9XoK-$*P_*M6IV8q0&:#he'C"/QNn#2>,t&,#P#f&]O&o_
+%#@(P5L>+%SII/Mu=XJ(W,LpJXU<?Sq?3]<W^)DF5<MN?\AOSgZ1X\K:=QX>f5u1*pH@iWlEC'NoojhFXe(m4*d@QE6*]e0(7!?@u
+%q#Rh7#<NH:n(=R5!`j'[!=k<^%YoA7-(U5d#;kOO_JnR7fKB?&&T+-dNKlY8XFM`_lM2p%GBBf%[(WX2n^41q:Ph2^E+p@M^TRHV
+%mB>i*ND637rj.!Diqh$M4Qtd1([Tj`f*Cn&W.\G*ltTs1%+BT'koeP_+WY1nE#DWnXsA0JYq(];<U@k;<u6W;Z-e3]Q,]sbG/^_e
+%Nnp&Z^%q$@?W[qfi`W&9$CK-X's2:peu/_Y4oM2(l'tVVX_uH&h*5IM,4*;_7Y`chjab`ikCh7YI*qo!7HM&Lq-[(\Fel7#Vi&c4
+%MXHu^\oX+7*[A6)VhhKN&EVA.,mJ?Q2KV,:F>tUhd5+,(T>NrZpLqne'%?DNQbu1aFN`he%X'IhDY]g?_9Rb_/Y@)DfXXhi7:PLf
+%p,()#!h)>TE&ek3F$;)8ChUrR9,(SriK<;H5!"gFH0cuN%jhjjP6J^cMZ/OYeD6%HQ0d>UV#3%"Hhf45IV-ik1BdYt<rFh2qO*UU
+%:52;hhV*bH1X:D2Zi6-8qc$Y?g!J@4fni0KDp.]LWCGla=^E`6Ld^E;j`#KG\e00EQ3SUA+&Q];6=:rBE3'ZC2d[bqs'-e8T:1`;
+%ih<2%T%N_1\SMe5K:c0*kOHPFnlGLWD:[50juRC_X8,rgT?GJZ2qKrfBq*c)p;F7/K\@bIm3PnPF0a:Y]BHHQFK^['\W][p;lsGs
+%V=qFso+S+X$^\^+Rml@Gf$Q1@=I:NK-;715+UDZtI,j$9IPlDHl72^C*W.[H^+AWA\s^30a2-0ZS_W&;h-Jd)J<si)G?MP_]*#Z,
+%YIiDtqlA7K%3iPQb(QgPoEjn.8>X[<J/h&,T>pdOFS\j.JL6s4r@t?/2fEf[APju$+Bbg6@M]Z8&/bUheH@/;T>lML_<*!9*jt[B
+%NB@n>qLkWg:Qk7!O=r_#_L[CG$Ps:8+',85NSt"mgTn>Wa`TL#1:kKj(?BT^Vp&!u@J%d\*goaP?slafU$jo!-8+c>P94O1;<)2/
+%V>pUQgQ)*(+[m4L`m;&=+OWHnMofr;?q]jii1CtD>_iDCe;M\lNS`-P2Y:i#gu,t5%uhbMl/TUlM^H"0iTnduH^<'mmMXjHA9?_b
+%@:cd_VZ!p/]>ULK(>W-RY/24PjSbmdl&80?S<[X2m%1>IHr!#_&J5hEmPdJl(XpE3[-;'O<44XqY$?o9/)Sp*a(DknZHV^(gpTY]
+%<om*Gd^4fODO0rFH<%X2ot$TT<I2Lh-`nq0k/re!@etU[s3V*9Nirg/D^PiCC#Q.Z4QNsCr0F?kI$Yc(-^cSMgSJPq^tr1i]l<6E
+%?[YK9UKK&lJSg=14he)OaVkOkd<4p@nJ)d^X!g*EHGYN-duU\sn;-'0b?eHW^:%e"j]]FXCX@SIrH5.n@?SahjRo/5DmHBO#51,)
+%h6WC2oTejeRj"TNlA"?70$3l<6[[LNDAnQ+ik6N4+Xm'I+Zk:VBJ5=n2i>Co#l9[Hg-#M=C22>)k=oWQ;e#id-=Fe9,-4>HQ0)4T
+%95^#,<CmCZ7#6u-Zn*1DG);eWWP0tW\$Z:H(@1ED@hM@$>XTdVDAGsiOfXIX4moj)2i!Pn$HC/!:Bq?4;?s(li??Qd<i5/Ve0sd]
+%&k"$\F4d^Y5uD3JW8V<_D4M"Q/p#\7.V`'qL6lc00Si)d_g=K/@pLIo(:Wh,RAk@!RIF`aH:cR*=QYp91sLU([Ci;L%T$_^8^eY_
+%k"#t.'@9<LaiS>%</t;.Sg!2]ZcX.1b?h<CLW`RZ=98#e;LVCiZcA#-P0rWTn)Lf7)*?I.&m_BZ0ji[KXZ]2Ab,r:G./'t03o7H:
+%GHH^+1Z[S2GO<\;B"j<OoJ>O1]'H7UJ#^FmFUuj`aK+`"#X&<?#f)erqm'o-IG!UGXeW)<\IaOXq_A'W.G<-:YaCs*0j$cljsVc)
+%D,VF?6t/`-DBa*hk(M*8<G9(5BuYt10d^ZAW]*jaeejk+e^$7GIN;*8#0j`L%Af[!l,QWsfkd(&,lL%fbGU&6`SE4#[i`U9JR$g!
+%&]h?ej]Wq)HkjeH.[Xulc?6f1k?<1"f1nT_3i&e]FfiQm1pCau7<[K:Z+OBHGHJcp:5!jD-fVcadOSR:_Nnq>Frg(K+^aV?"p04d
+%MZ"IR^E`ksNWYK0(qCb/$pu>UYGeZqf3$e[:Ne<<bDlnjHu.F;<<AJG+_<m*?u&Eg>#PJC09`<PibhXS*Do&U<E=5DQ?AmOh;n3G
+%A.^Uj%l+\h$enjNWDp\+<%>[XdIi>,6^cEQH\=Q&fIs&e^2/n!qtqSCZS',V_.`V!8g$8n^Z`3olr0#!PKVYJ"e[I=m3<"mT*\!A
+%Pdl4U^\Vc'qq9)rA(mQ&)^kW6dd4a7e2Z@RHZ<hko>thH)in]\_MPVbjuCuX.8GnQI/D1'\rcsgn>eL_qpXkls7)jq$YoWUL*q<)
+%YL/hgq%AD[Q3[$WT,8WU4=6Ep.6@7pf\!(AlJTkG,+BXWK.i:BCO1jJ^-!aBBg29+B4J.(JDPSjes*a.6dMHE"8q:o+5[%Wj#?Ek
+%IImI(=0Dh0*riJBljrS%:Oi2ZlVF/0IXL&"rUN1eqtP+(YJ5F2pgn76[UK%OEc>k3d=5Was0OM0LZ>bO(!PX/rZ,qWhtHC9DSSIW
+%_VqDJJ,*I6n.ih?l'Le0hTn9o_[c.hSbCk-Yef/f*8J6J%Y%'>Sl3-=RKf:c^Xk1X)3_bTnaNIM9/,pkGB+MR>n_[;9S?g=!J1"i
+%r9XqUhX4j\":2n$6$e/aE0Eo[Ues^/+t)U`ItMA(*X#l3nk^DJ[/3l.W0;pZf^h(-*US0W%$Lq'To9_5(rj/YiR==TJ)m<[GT&+3
+%8&so>4P%6$qP:c/5=(kIj#D"LbrjdA*]dm'*X'i+RUN_[h7"'#]otN\<IAKVl96A'1KXM$4;,;jFd7aYMCUI'Wt9eWb<p]*dte_V
+%n4qP88#uf!O&mBf-g"FE?Y!lKDk'%ARMd)r4OaTp%9N(N)Ol#^*SL'VH$LL(4>^Op9t-N\4KNm4NOVc^4Ob=nM#/C/P<2oQ>a=Qk
+%4)UA/F:!)W7P\oT18"b.;3[/D+TVNe&,!rkL_V6*:)6r%X92di=,*aY@TnS5[u]E+J,V8\3!+B(%rN;gU'*>3o5ORbl6@`&M&>L"
+%N1BKo0*=hjHV%PoVd1A/j-()THFY2Rff1Ohb?Y<u]`7K!pTNJ(rUHB7rjHgml1PZA>ash5HPV&:q6TjnFRi1UDiu_l6KrU%Bs$fX
+%-T]$?q,"d=?iKpC<g`t7$9\2\Dd-;o<qt;A-<`?eaac>J$VXT8ZF:2M8Ad5T]>M17Kl)Gn`?+ddkIEDF"doG,L]<ToLPFbRbMQ(V
+%3DkFecYD+\gA#VqSVe<cB`1o/!a8h"fNqFK95)e'_fpme+9_UplckuB783%*'?D224P\^nS8IPKDQkG%L*/S]IWQLen1f8)?[n-4
+%&VcMEF5!1#$;u^tW,4Sa*.;cDVTU:^S1M#"B!IZ!@e$)\Xnnti8odO*!RN/7HfR\F][2]/GAPF*70!aV+6ql+5&*l9r&kK!L(fq$
+%n84pCY%1Z,R&rS4K6U4$&4Vd-F!LNkjGuYFhl0-\H"+!:I1WZ>H<#XH=!E<Q_[d5em9d;f5&mD3:[C0SC%!`931-Dt@T176o"jXG
+%m(5r.&:j52V]7L2)'Rj+l:IRfL&5Z#+<0E$!Bb(3*EO>sV388]_1@<VW_56^>+2)dI+N;S7FS(@oMZ34lCKqIUgG#(A+cDnZrc?D
+%^6=W?gN$_4ncsTGp-*9Tp[l0ldka*EN3e"8_&C1=75@b4Io.u)$3JqiN"(OSF^:IWR%Sca1Mfs8D50MO+<`N*"*h`>$/,C*EK6n8
+%+,["?E//PQCP+8b#`jodS]82`E,G>OXgh'^<>`'-/.eHt]S"L&)[TmU^;nZ?3/5r>Qg#%N@X*D^]'Nb7D`$&XiM)*HeYGRg3r1W.
+%1CZ_n*QL1g3i!"C^T3QP[`gE-%C=q$GP8ll64+YeEb^tE66a-PaoEajrB%\mTB9?JD<:2[<8oe-W(/Ocm<.(XCAtgRPFpE'5D#C=
+%X)*tG%#P)MU0%qbq]_:n/(<qM;s4EHDmU[5!>Ks^8;G9MOj*^R$+KUVmSR%lQ!8^"B3C<m(*B$#30:dUJ-_`K#3gPXdi-a<;k@7F
+%/QHf9q!JT._W:X!jnLk2bqkpm8fH_"gt'r#EF6F)'YfPL4:HO8#P\RRA3I+Udg<b/g><qeV6+BBF<9ok<K5!r>8mW;Nt$Ns8)\<[
+%=3q[H'mbp,H^*+o`(nY3<N#Ip^,dD"2+4LP0.HdC-[1P]_?;\-%8+8U:%cY<Oe,i<BRohXgY7:-=Hq+hEGk*P%k"]7I63SrV/;Z'
+%)6\bcnXpgI$"XK,SPGJ;+gtf%e,sMddQ+sa#o9B;b/OFNTpbi3d_tD1Ej%7"65nb(%UVpn1^<"!`En%*3_o.15Kii_n`^E&JU=*9
+%\B"?&6m7W$(W),Y%K/f`S"B7pKn"55,^D-RrH8m>\+3nh-gP8>0XqDol'@G=FI%r@F[F">2'!3Uen<oB`?Mg#oTJoCHKrF7Y`[ee
+%m>#[EH@8&9G2rEUOp+7.-d(D?Bc?71EHqiL`s;RiCL<W%V'EWU*jfFlG3G<#.t=05??LZc1s0UUBGQPc&8<qW7>@Y55q'm^9[q'>
+%a[@\;;eK.aRCn:t1^&)G*8mS@G[;!OR=74D[^nD-?_G=38FK8E2bn9=h7!(/ojN+ZX3/n4G4'F<WTJc0k(0AKM5.3kWZCo7O_9XB
+%4sM&p::t\n9&muao>!n.:`J+/W'D1E<9)48`;%gtWK>(c@Bg,IJ6.FNVU4BUK54^*BL[BqdXgq]&P8H=Ic`EX+ntmUO_Yg=\K;(D
+%UWp6*_gD0MM2]N)e>A;!qH/0,I/RPl6\"k#?_,O3h]DdURr@3^m]3g8ILcpS4Xa&KQpeeHRY]HOo72Z'g:bCR>9E&b$,^ZcIkgli
+%BFk6Rl`?gegP(@YBtrG_*N&fDs67"k`Q8d$&gB<fF/WdTo\YD$5RaJf?YTbB/VK+_BIk1hHh>QMa):5RN))PAI8,4a1_\ml#"".>
+%/:":c5BHZTrhI-Vl!*!/1]+e_h'5*H8Uj2N0RX<)05d5+Vj$T#UE/N,)Sp%5'>HHI>M]4_`.-a4-@'6-:!5@*l&j/[Gi$pIcKUP@
+%39s-_4fr&EB,Y!F=D5V@1Xi7]?Xq*b)0q^>5>5FXqs2)[Pq=K?0hil`6T=eOGN3B5pkJ8*%m6.#rSl^!^4,h$=)ZtT1=UeDT/6lP
+%oeV$.d).sA(](rK8r(;)rHd+"VUZLe[PZ@^74m/u;cBmp3lBa\rV(bekC%8nYD\U3B9hP5J)KOihtJ;^p=nN=s.MqYTdu-)=WH``
+%&BOG>EE9O(%:^Bh$PgG3;_X,"6+ZI6-KtAVqRY/5^,$3o6',H&BYPO9p$(MkDgmUHZ3#RSD<iAB6i9&7U$##$CjdEM?uPU?qs0f]
+%><2U?es&=QImJ:n#75ok-kF)/7/Z<V'CcU:5JI0crRYljj>Yj?Xg@Ad\O0OBr2oq,dlW16A2[Q<XY<W[CiR'K,CA*uF3jerqL68j
+%Js_:Ylm;i9^(IZ9M\ne2*r2,5CO0BP[G:%BhU%n]mu\&Sa1]STEaj!*138F?o''G-(G9_Q#`$Qkh*idDb?Y1%EFFJ:Bo6cghD_Q7
+%[RIq3UT0Z*!f-=fKY9]&#hn+i2uTQbE0Br0(,#*7+f;EDn(JSU(o0<FRd0?9[S:LtcG[tE'.?5J/9;K'BrqTlZ>JLP^2/5TP\n`U
+%X+Hdr)cLLgGt?kKSSo`t7hSOYJ3oIO6ecGo\]4#RC!X*hP<m<r[X=4#\!pSuK8e#)Ja.q`T[!!>[X2p3I?j\a'?:8^*jr!/Jg,4c
+%Xd`XW<_M[OmtV]/N5sH!?lGfqO'e_;rpZeRg=TBac2B>=!gD;SI2!X[p:d_kJ7Ju@:p"Tu[(.9_5[fU"/m\5jioY\X22)Vt[XWl:
+%ATKpUZbQ_&?/,4+8XoTca!cnU<9kcs(cV3,NYE%C=]o(fcZ3e5(&HMM`.H*`"7i+YSTs?D)Ik<:"Gg+J%<N'6^!0SLR9j.jFr6Zu
+%PX#5&%6O;/bn(`<;?0K9WKu$337A50`;m)--t.1TX%=-N0NrHq7W!%4G&olUNPZ75&t-JNp3o8%"Yp"2fI!C#)!h'=%k*D28H;*6
+%Q=t>(lns>CblI:7eF!3*6j1O,SekJL!oGaBM;TY=b&udR2%E>i3^cdBAoO?LKpDP"/s6ZSa\\?,JKdB6F+Fe.^2JEY>i]N#f'%8j
+%f%T:("2o8'gV0s-RW3n4d^V8a*Rmp[EI/c[U,DQYKc.*k^];`%]t+CE=:pEreM\IY@mI:2LQpTVhUP)cK_5VPTi=cDqJ+1H^7h34
+%U*Hn^j\omj2S-?Ka^I*bZe5lH,;=K'?0eso<Y!5hm_R;7U.d@pI$71F5o)E+(6Mgq+A*.cd"\,3/6h<k=!,3Sp34s2%tF<H:C"To
+%fH2^-E4LA*9QJe"+GaLbX'D[:E4O5C8O.;OMH:5qDI>7emm_!.Kne-l&6-8$!?V)^O+[?*!b"hh;Lo1^5:4fNpYLFqJPBWJ3^@T0
+%7>RmC2fRMUV,9)OkM14j!CQAc/5>kI?pc\`R7qKK"lMlL13Lt=SSp0!^pXVl#StG,E&`+GL:69Y7:9W@ToJ0T_[R("!?<$XDn&%t
+%"$pAn&WLJkIFrN?h"VtX+$X%\oB+L\+5Xd3q!Wt[2p`'u8Crhgr93W7R\J9^s7!q,X33G?^3eJ=T@_H^7u+is%KGnjIlR-EU8EfO
+%r]#mt^1!O%p^/]/+uidF=_7gJZ7IY\c%gdTf$J0.V/,+c=`c>f]5)IMN@Fq9\2XO*@,kGo['^ru^Ym@09c+6:M'n;GCU:Z5?b<8@
+%M_q=CXGdu'+%\^37h?M1dm.ll;e+]>>+XQ5/L+cCAsgUsc[h\F_o3F[RU7`@nA?=grokLJ)$fO%(]8cOU_9-1<raO]PAa-k3J(NP
+%&DO5j;N=tSZqlW@'/8-rS$7M0@QXZ1bm$X'i.bakCYQ#eHu2hGeO%&@lRN')ijZO]put7b,GJO^P@5CF-IQC@lQ:\_eo[;#<)%5Y
+%T_AH%3$@,p54Mj)JnH$\\4G/mpX%9N8bCaVSrluH!,u/+Pk!i=NhV/W-;,9\U4_f'#P$L&\;N)-^t-r?%>`nl*TFF-0[]V=0VEY[
+%cmBl)JstJL6pQqk%]I1Eik4@YZ^hDYas2&UG'fkm9dHKQgEr'c0[Qtu;7/Vu9+0`td4[a^\UiK_B5Up+RV[o*$-jW]Jc\oo(Rf"V
+%K1m?iI(2QpP$H!=PU7>)5"/TB4i@G#!6BgS4;eGdQ9%!G*M7NlOE\TU$GIG6TG>1l(U]C;8GHlooii]\NP(1rql%7M/4$$?NhB+6
+%ZeQ8V#/]1]gnT9^,U2dQ\)#40BKLf")SBV#&j:*Yp'Ud%Q[D!D%/<*VC3,Mnb&=23-P:J>?hciJL[1;S'Q-B``tJsY_n<1CUJCtV
+%G6SscRiifu@K?nSnh,#=',j0H.\T=G43MmR2M+K(!8ho51aH+#!W-/u@5UG(`5#c$]dl2JitE)g`eithmq[tD1Y*a^Abcj29l>9+
+%Y4,le]t!4n(`[MP7+gqpIXfZCGr`E!].:E4))-rV=c.b`"3LTbdQ?SK)8]#Xgj(tr9aD-W&s:jp!i&*TQj)_jeplnY[r6Y<"t)E'
+%OQP1/!<ob?GqkcO*LNp-(_Qo?2^Kt'H!X;'C&eYj,66(lHe;VLR\-JCH5+NU:f&=G@rTohOM;]E_eg;C2J[Pk5(<X.gD5@]Nc@`!
+%P[Qu#p*$:G1'.,<64`[$9-s+L1KB*&-Mr<_I^Bp?5;]oFlY2e?:'9/6U/fma30IdX/8%mdEcr^R\3R+J1_UOb?m.ZKH4_;W`]4ql
+%\ea^%U@H`!NaCf&?tuPT`>B0X[Y$V2F5'BaLmX:Ygr&-dA+;TFHoVNe.9T-%-KlQu"e!M'S@&cmKQ7^4%#KMW#r3pEQIc1E@4T%7
+%'Oia=;XjbF9sQm^61IQt^ht8hf]tcb5@^V_]g8/,0?>FG0qsL4\`3Oq?O`MWMeJ9J$.=A4N003<aop#,a^k1P89Bp_/A'&L#.X.e
+%q%FYr>Q0;SZsiQ;GASu3lFY"VY"=<Y#OE=]KK'S!)SeX57$8PE^9/lkK%q%qIN7c4iWp)BeWBPS'2a]5d@c*ImuG4YX!e*?C39`j
+%l@:56@rM_]C]OeS2'q5(J?6fX@j;6#Yb!EOPu:]oJkaAj0BX0cXD%#`bJ8]Gg(op[JL8=2XiYj<gu3B!mZ>7jhug=uW!2^!TGFqY
+%k_moO^\[V4&Et);OU6R<_g?>i1Z"Zh@%tj$d5G_`J)dG_IUn^Y0MgpGKVueX8:(WSID\$MD59l?,;J!YZN2Ak2MZ-^f#-oT&=)&_
+%h`D$TK6j<6mbC5<]T(Y[<IS*A-4k01&n'X;eHVnsD)e(l(5<Q[86Tt?`P_+k0pMi.)J53+Irp%@5"2pSc=cUjci-o3c2.G1m*OiM
+%P\WYLKV1WE-lT3DRGWar<0G'K&V<piI@'c5-%sNT3Bh;dr3iTSBXk["s4(YgH^$DVZcm]doM/Xh#lR+V:KakfU'%6s0Gnrj%>:<N
+%P9#ti+<5DIK_;7]C)AM]:g:A9bPJ'gcsq9@j+]:f&T=72kun<$2*DS8rM^qMHKqao*+-H$.kQ_43hETE/jFc@EX%GV7jD99CepQ_
+%RPooU#p_7BpSYH]iMjN0Jqda1Cas_"1ONVKBUUF=6c_V`$X[cs4]u;afn`,PGR9'V'&@P<Gfdbi$gheX&\Nf<PUh&-)/(erh:rhi
+%%Z`Zq9]?Htp`)q,U/>-&]4<fN^_BWs![h!(4T6[M7I%[r;&el1J[;ONEBk0D#ReLA$,m<WHNL,sOTt$$ENF2e%4QoFVEjS`Mg2)L
+%TYcFV0bO*%R77IEr!A,f>%`jXlLs>`)Of0=l$5g?i>IYM5u%,,"!X+O!@3[Zm>5?^,bE[ll@>1VW*H*s1rCGP3(!O8US_Tmrs_`-
+%"[gi[_$72kJ2u59_JNF%boC(E,?U.69M*q=9<#-8aFt00*]Y-(64ml9n)!E+j*f[CdiX+.!_0<]1ac.e7mu_t*"]N@6#)CY9l)BE
+%-5\HP13cWI+#10\d<S43WWH3keM^T.XZNP7Ss[JlfMT&-0me.5ea1?aXLJT</#@%n[UFG)`O@'C0W%ZZHnC'Ug(h=;=?#\\HnALG
+%n/YpVk!@\<28U-ES2fPEHRjc99]uhlT5<L*?,8.^D4U23A`oF^ptG]U>B>e-@,UO"Ks,@!1="$mY79+ubIGPn&.?-(1W!`:EH^m@
+%bs#<Kn.e&-D>r,]>+uS:!FLc!YG5l!B?,b22K4k4r/@cfBG:55#'>PoZ]LQ7Xps1Cl=Y2jWap3f/`;>cG)`V3i$<'cZ*g]OqiIo3
+%$=?YO?=RaiVY=iQ'l7_;=A)ej/#\QOY0jYg7NMll41^$;.$Lmdd1n44`q_L'U2^XagOQKXMDdI=/GPm=h]Q`Po4[]RYcuUu7kc'%
+%!QR,phghp?m(nK;+Y6`:aOWHr/<%QP6$,@o=;ETP:C%=Q8?O"W1%<FO@W!k8b]#i0<u?iJQk3nhXo3qoASWLX[mF6%p?#gsP_HO]
+%Q[M-PRKd*T;&3uhM9rT(C`A[:aH!URIk#5uXc[kNKX-TS1KUa7#&R$aP\mTV&;r?<D#5>0CNPeX5R]*3;&657_3$rY;&8L'R!:`f
+%Cbe^lN_JCmb!H?#/iB@S(_s\,'%p+tXl<%7#F''-bGiK!ARU&g&kj_.k+KNh>bN^!;eQ,HVJc!jF.Q5EHiVRK29Ig2PU2kt(9e8=
+%NHS1gbs#aB;&8;qnIW<!=nL,SNU&!^9Rib1/-*@nQJ>=Q^^1bBNj/S*.AmJ^Yu>5uMQsD$fojlV0bssD<)PFdJ9d'Y!3VoaO+O[q
+%$3>p5Vuc93D6s!Pb/05ARnsi2!Jhmb,Kcb<ZMLjmfh/54'?XM95*Ro!Nj<h\XUpAY>[1\fGeBGr#e%UnlUH=,.)o,DaGR%bSXY]U
+%^)j'1An2'aYf9DYMY9)tdY+\%1kS%Z\;KU7X.O>G#E[^l&1Ht[fgj0]k9uRB@b#ObI<7s<B8PKH&.l3GfBIVQ"sV2R'EYrFa?_kL
+%Wchj!GE^mP)D+FSC.XX6igKt=at"lb_@[q+R:2Cj+<n'^!j]->n.sUK\Enh9(b?kr_i2H6*&_3G=EDls57'%Mel`TlNRr&L@-Q6B
+%[UbOJKe8kW_%orq,[g;MA7Nebr^'KnMm$l*gV-L]#D3rBP#7%6UMC_M!aZR=,Z[/TDJ7C=,J+CiTfia3D"=@/8]/J3DAgP(#D"Me
+%45>GVGWFI1<5I6uAW;ca'8<.lTF++Pd-#>Lc>A>-B2H]Q"!A^S_[;F;i]mno`]ckJoYJ4!K#5_:3sq8[$M$ssk0,+!MU,f8Q!Vj7
+%JFlj+pBmV!il06+'sX;UhZXB3Tb^(!6TPu,QY#4b0qL^-5U9n:]$D9]#=YG.B&57qUIeuOF-HmH?9ZXRS%FR=-YXZ@A4C>kiqnPW
+%I`@<V9B+'5#JI^kNg@W3ghPBuZQ#6_>S;Z.8)pV#b5@iNe\tW\)M`q@J6<GZk5BQ)0QuG<$W]c#D:>j,6@Yr9rq%41a:q<p0N[YX
+%j0!uA*U!@2S\7Z"Rf4(=U(49&/_J0kn`.,;?lBi7?P#LUY1&;^VYUXNZpJ^+Boq8B.'01IJa[,\9ONu!UYVkcb`QneA[3"DCFH6$
+%-j#GZ,j0i[2o2h7H2AW!hHVCA^(&u)7,A-5/-en&P!&mlmP0YuiJkGRb*k12L4+0<kQ2<j>X6$&6k'?fmE;>f]4n8^(Yb8qck2$0
+%E@06Jkp'f\]?,o,%$PNa:Gs/QT"&*Db!9g@'lOGq@>,R=Bsre#:\J5<$(U:p-mDPO?Ee.$PT`&udO15C"4/n6d(9l."'G:a:r5V+
+%S,a(J]\i6t1r\5-DTn\e/%fAr+W"I"qNn$4(3K8DbQ;s4P9%2K,=I$T57>@&'?:kI<@gWEU@1b/>&oHcfR+m;'Yt__p3B15BsaDa
+%Jdn6oVnb9*n)7b)G_$eCp'J0%L-k`VBI6P8?it^F[b>`6aj?O)hVHZdEo:(+;Ims1b4X7B8B;QKd4OSn%@E$?J>!)[22+F$cRp@l
+%g-reNRlLLTCR^aG_@:oJKPZe?2#oY,8D;(@-3qTlLa5S=0M8"E0S.1+Ui"la't%A<;\#I6BTKe.J='5'D:oWT^lbYg&^Xb3r$/-S
+%Q'VqHbq&Ws!uT*:8@hX=Y9;[D=lkP%"J]`&jJ7Q9)I*X=WIn32g1pORN)WsJT#$FDqDMf&;`#W9!ln!F<71k=#TG6,7^+3Z-3@X1
+%1Go>u)eIG#M@m+L/2=[E#'!kq'#h\,-&56hU=/>g@/nB#gD(-BQBe;4NoM8q3JM4=SAg;l"Mke4Z*W\"*..hBX\+P-2e\l"/a-a=
+%g>5Qn.WG<j)@N,=Ns:WsOLlt<)GZE)jL)i1[T=0X7^=^I@tghbD6^/n8.VmXSqD3-6OPTc;l>?IhmarkfU@>hEQ\?<huaa)-ntb9
+%0nkF:%3#*Ed?TI\X^jMD'8iRt7,01()_\4(@00MSRY1;r`i.!u*PF!jGX:H[Z=HdHlYf&jTd_\T\Sn5XRC7X!A_\3+qK0-5XarHQ
+%qo4GS:_5OLK_dP,\\3c1&P;+8%#sotNHMN1rl@u&,R(3!RhAM6)]hg@4quGQ5t2eG-no*Q&.R2=Af0Z77Z_(ee/#`j5_qZGd$U]2
+%ET9Z/6.\(`Q,$@+15BXQd%AOKX&7YuWCXC1+JaQ:Yn6hJ&dIV/c4tLfU4PlEokT>jKcCOL^/3GqIq57.;_o%SVm'9]!BTQma,lQN
+%Z7s--NfY0B]BTl8/)ij41l9peAi*UPQGe\R;CWC=nU7M@1DDJX9E7]?"k]jiZ^_:L&/LlT#97MUN1tp,^(ejcBu4(:XFZb%[G!>`
+%>ml'0/.$n:g.@ddH_'kfo+T_M@7P:N9;PI_qjH!/Us7R3b,]O4pgXQf!iQ/hmVaD35GA1c"Rm3M4TjB>BIXP:P;ls?23Kf6H47=Q
+%N9;?Ci^Sef3,`1V\Lg`Z^dqb=ei)[/Si'@<%eMO#qF)bW._sOl%"?T3aBTUq#15]GULAH[^f6WPYYkSt$XmP@2c&IVAAuQF0>UK9
+%$RFJgOW3>cYpE@;.RBBA&t/9o"Y0DlKI]kb[`Wh^\,\CR,(kgj<oZJL^]7AjcNhqh%.kA=+\aPD"]nTt!LP\\!;tl6-_Q#6#oijB
+%_Ie44CsR)T!KNS:K$8liO9_Cp*5Z8,Ud%c35dDOg!&Ti>cq0*-,Tu1u6SKeLOSJ)c>CEb#09RQEor+i9/ql[.86*TK35L?t(a+R8
+%;Oehn=XWM?Wk!j=B`Q&&G]&tMGhp1lThT;PKkAq>8ceEf!n,H&m:=?;@%id<e8A]e[8"7S!GIO1U\A0:TPf%#AT!A0$*XpDJF1g2
+%I1o$A@p<#&M?g^FnK%k.?lT3:js=lNA27_kU:k>IVFn@>&S-'%A)P?u7HF`P%qmP9E\Ep3\LF7"Em)Un@PDdcBrC/j_o2qPGVT<S
+%Y*<h?pZ=H:5dH.bfQC"-KlI'b?R8HFP-tYIFpRt.;0eD'\Vd.`8:-s/i94Q+OMR[/)j_Oij"#4;TP2@-bp<7>SL&8pStTHDk+rn$
+%T^M#$9G_5.&KcaZ%:o0b(^.o6Tsd\$ad0D=XJ?Ze$CRo:fF?IKMQH!bRfp\U!(-$<iAetf.XrAdlcm8lUr$.eqT+?5(^unB+ejt/
+%8/Cb$-2/$KJsqE%%NW"CpN5=$.3+PBU*t8'_Le\I@Sb\41^aq/h=cOUFZg*7"a1GY'%lc/rYYJerSV+8/S(0O,G;%F%5j0Zisf/D
+%XkJ:FeIBMsYXD=B2UeJ[JTR1u3S5IYShSYm1^UPn>C>KpND]q&5\=YNj>W3,(X3PA!fJ>YqQStNj-6&BEhuH^,Bj98X(+o;&oc:J
+%JSaGfp"erebngkjqhl:Z0%QTB\31E?!*6%ki]3>9/6YBTYcs"PO?<fHAAOh*6*P>#A8XiBq#/-N_3i`d%OYI`2YtP$%"8aC1.c>p
+%P/eZ:@1=uajl!_cLe!@\VT9XEaNo[H]*S]<=q_(?341Bu5"qQ%?qEp[QVq'+e']aHNX[,Qs*fN6:LY@@qo,uUgVa%tBLC:249tjQ
+%KH?"_;"^!I;+M)ekT?>1KgQC>VbSqO#L\Itp\V[3rp<+:mjkW2_p;g+TW(&@76^l.fj;R1)GjA10T^)C<D<Mf0Vpa(a>5-s$HNoH
+%EXCMG)Bk;So<$I6bC*>4B7d$[&2I7'_t+(6?Nhu:ETkU8<DDjH)<Ce@a6nq:\*o[\/?.ifV/h-NU;nOK`.glO9H6`!A>1WllQBlI
+%QE^@]q)`di^?YCQ53:Q@Hc>imZ(n@XIK,\EHd?;s&h.;4P(37uNIenMM(jPrlhaD;s&n(]llBp-.R^usM9KFn;/27OT^)KDeXGZN
+%\'p]@S.kRRGGk,i1p%lETrN1C5K:>.\(pB2gthtd]%\MVF(;&,X$23&p*!gWRj87)=<UeD3m.s[KXoj0K"M&aXhC9;h%XPJ#K+CV
+%):[A+RGD1V$BrI0R-01?*,H<tiG%9Q-VX/[$BUMV$W<]Z3rtVZMBVA=*CFm:m&?li$Ept;?r9IQKrPfS<0B08Lj"T)fkZQcbH[<R
+%Xk@W[\@%$UOB<-)6$3sr3ca(6Ul'5(T-4@@+,<t%8FjI-i%RPqEUiSm*`(d2nLEf.1,I##Cb(-VW`@p*IcZAUj0RI[,MM6%<YJ"[
+%\K7ji7PP%0j!Y@Q)ZJ(dV+P'6M$VE.(IRD)_Ym3hU>S1b7>"3LD=bge.>67k8ZedlloZh8$5%iLo+L"lCLK+F!@.)3:5ni%BW)&$
+%&NMmZ1"hjUkd:83kh+`5^bk"OUGNh)p[2!&?Vor>",1inn+I@O=m9Qk,1H-T,VT]VB@^dh63Q99Al>),,kAQ!jn3_e"@#h>Y3QQ3
+%]hdgin(tJS@3AB\%1@o0.7OI6mD;nDc'EqG$s)s13*iD=4TuMNUEhNqYmQ%*J<aa!%"ta6OR3d:,\l]bUOhdi7S+R*09:`Q^_SgF
+%<6hq'H;I@1$e\.&)&*u5X%,nJ5U.*NSQ1Vh'h8Ub;k[StZIG9C")[1[&\Id96Cuib6[4TV@@Z^0c0;GB3=<bun[FN1qr!m*AI796
+%$g*!2`M1<lU=`/e<<%4mWRSkTlV7P2\"*B!]brde>Iu]'[fe'ZCNj?6:uDJbllt"%#+iW]IE^R&"+-5ZE^BDbDS+-5?%R("'Yq7X
+%:b][MAC^Wj=kBJ>\O<`H,5G2)l"EM_^e98eS\2gB\iC\/rGi6-`aAE\4*fR%)*0ot1-%bZXkm(BaNM3GaEGDRak_F';_=)6*@u<(
+%MO75ofF'38&30]-"887jCT+ZonlM=%aQc%?OSVbh$eMeOdcGJd?qf'#1b,i+?P=aA]g=5dj0iY%;?ma??.,`i>Du5g:8[[>)$g:s
+%Cr6:T$)2+!%YeI59oWV_/h(fl??D_;1kH0n0Ke'R\_"oO6sI0eRf[.23'(_dlSr_tH^4/0'+bsG3[i"Y!DGacSU?$aLs-0]FWR=\
+%[&5-N1AB_R==\B_S5h;(J:VX)24,%?!GDNJBInMRDrRL:)"Z,%+PGg6D*oKSD`+N59!(Mc;?qnig!mH,!Z\HNY0A^&&Po5*!ILat
+%TaMX+A>WHQa"RSO64B)SOJ):'<k![0/d%faj*D1e<QXI_]+%k7&d$GMe4LVh30&r^_XS3#.SE]gZoj!QA8,T/6?+as2S_@902PHu
+%!klcs1aWIX&28.I5Tk-)Hrg?70t.>\MraeLY8oS4@"dfI*LT'fO)c5-\=*CjiD?Sc_Q;/XUit\#/rkRF=6nkUi7#'?TEUUl639r.
+%0f-OoUWuoTC)T(8A]2Fd3+D4W(@6cSBX)78\.;sI<N''X1X8p9U353%@[VG7o2NtS[;3SdMpg2+(/f?L?BKgO3)$I;\=&2lGg47n
+%`5m4eX(Jq#6A<A:n]5i`<:fuW_E!14aEj]d'01focQ(N3gI6o]n>iuhA`_2K#2mQb)OP!C7RdL#eJ>-6,qNa1NpLN]G?3ldODSHa
+%E(I$RFj3/P@n^2dob%KdE+PCfp2#^.>kc(QmJELB@_i<hetDIm#2`-_X9$=0Ic+KXndpt#%p;;b\HgWcP*@Lp1k8^Y=(#$g2:+us
+%lj/UlNI%c>7$79;R3s[b7'KDo$NQbr5a`=`aN57^R2j<q!"GKJa!@6RCM7K3SoX8L&@G`%!#UlfPBa=?@TCk@UH35hrXgVY2=rk%
+%Wj)J:qRIs>]MQJeVBtWrNL0[T05fWFq67X1:@6sp>p>phWO=7^"lXhCkq^Hu-D['>Sh8"mn9(0NaS4\OF+(J$i&G!U=QZ[Yfr#38
+%0ULqdWgk@n9c&0hnre"('KAl)kOOS<[=[rrKK$.gg35'+.7h/&^9al6+O>lO5kKhq+ojq_:][\09j0dcNOc.E[U4[FM\)rj3"i\$
+%g^,.b7@C_2R>#,(<n+NE4!B>0),B8],eNW`$nLlYl?F^geQ,^iA/Z,c'0";.8^cq;#_He>Df+E9'<j8P5c`gD]F^id-95WY^rTq3
+%Y]/XFPm/SL%BiAJAp#.*;c$q*[5Apu5"Z;mjp50?"&^:Bg==^F8g2<?lnSURS25]-9E`&7@,7ZW.O")`UkNMIDC'#]7Ms*'b`WYe
+%4\T>BFJAsuJOP@t;b@cJ>/\YmdGf=$Qibb_57=`EcZW`@K[o$q#'L"cN(01X1lC"0,EYdOF/5jM*ah,`FJgdBnMIb\?N=Qrgc0lt
+%fZ-$?q5XKDC63m.!``[WW<.%.j>>+2!:fiXEW0SnY18XrW.%WVmh%\I9T0,TUr%Bt?#k$dPBB>H!7rE;*42iG#bM];8)SpQ1RL*&
+%p<&2b>6[S/?!_A$!-94?gm0]9L/"/B'OFm[E;3V:=Zj+ZWgo63)5t.L^mHW:Os>?WZt1Fd!2Qq/-6bC$R34i"<5N`"S`9t[.Q`9N
+%,3'Xs:K?,>-W-G+Kk#OP=>^J&73*5c#TS(_L;S1l:ikVc3N=U0f,X+\J\qpnAVSPV#MjR3M;t[dD>o-j/?--Z>=\?&7`LFO`4Tno
+%npL`O!l;BR7<4c(_qb"b2MgfB4:!V8Y)qrpk4HV3"<uWQdESC!ifs+]P-JVlb$uYUNp%_$MNA&sWEqE;K/cgn$%PH7r$[G!mQtM5
+%R?RE[6V6`nrS(E;)3j@587BX$Plk5T]-N8rC;b\_>(E#fEfB-u2\!^H`/30/8.NS"](^%l=clEUS9RI/:@)&:coi,sR-G=_Aa'U1
+%Zm`740$.fB)W?R^;Xm&:P),`9SCF)'C-p>mfTp8d&Z80?<W\L9<;R`b<WZ1a/Ke3TUGecs3#:/eSYn4^`);jGAi.D*mgWh1')sAC
+%k*VG+QD=\n+cIDSOp93XET08=L!'`^/[5`KZe-ftWBc37*B\sak,a'1okCuY!qGVGFpL-cO6dGjSY`9(=1h!C`s_2irD8EK<>VLC
+%:Ljhd`bBKu^ad65d6qGt'J@BJh[Ae8jL*cHOI:]BAKGTZ3I?J5_47P4rd(KkD^EL8^g+c/<'#L<f2([?_i\Gc2*<F6NR*Bql85dk
+%P1=s=m"TLOI,I?m&5rTYnTi1e;:1W/`B`DiYSA?p<%el75)D9%P76]$^^iGQ#,;i<@JW^,Kf=H1UrYg$:NfW-60`GU5W33+6+ml5
+%rZ%F4HoNm9&s++mi+\rboOn:O-pL6+5QKg&BSFTq;&ht0Eb5m421Q)rkocuUlhLr?kTEo46;/,CKgF^/N2PkH-g+Y6RB\8odlts1
+%b!&3RW2!'QjN93Eil`N1AiilV\CE)/33embNJTMgcON[Fo=/Zt!cPIX@*qS*^7e+1i>a)j#n'Xob"]bdE"ue0!+2Kp@Fj@\.>%V3
+%L`)&bEiYJA%Jtg_W]\TCa>lQA5FDk361&`+`Ah[lX?crhUa-X576MA3C<`q6)gK8scOuG8M*L(Vbu2\-18OR5M+>-b3HZ:t^`da`
+%W2L[[_ks7EfZkWq*Yi?i$mI&/\JuJTL?*>,5Gei56`G"\oE0lii&&`n9H55Y/S;sj3CIa)6M.=06Y%=dlGI'@!Pg0S?Y0j'=+kQ,
+%K)i.#@Pqa%6-hVO1'iE(kV4k!(b72k5`K.X6kNf:!T-ZZG8#bQQqT"k)06(P<Ked?OeJo[j]%3Z!l,X(4E:]-Eh8M9#f$FsW#@Vu
+%@LG6o"qEqD(#m.Ug(,4;34"DLBqRp^dWho%Sm<sWC;_;O"=*,E:<Fa\>a91]Mo_1KnVeG3\#rQ&R9;o^HrLu;=Tm6!A#6<6#ZKq,
+%gD,W#R!:K.#]#60NsrlD[I'"`!XchU3JpKIKZQj,3eMs_Hd#)O"p't2ff4$Ypcq#8UN6]NkY/@O6brG+]nqk=!)Ug_.Yg9^11TDW
+%!9VMFc632/,tg:SaEWZ1?S_s4U>*a3YeFNs1P9@>&?5U(`#u90@%-lncDt&dKg/[1I*6*G*rsNPh>)\GN3+=SBIMeS&HuI,+E3U$
+%JO'iNM;ZD_!`4tLlbjo$>'YL`(^*g'`/';560,mQ\]kO,@j.h.5JV0[P`abs_[[XDUNfN;N`<"6)dVj^)Z^I8.ORPd7PK%,\)6p#
+%T*]T`@Usk\:tGPj1`6[7XP^T"jY#+o;=MJeK&nW$O>md2</Ag&O[nm6H[PHb5a!1gS*r7CN9socp*:J:=cZ%g=?@X<jn.?Q]+qjL
+%F$,X#'W>7DJq-b:Q[tl>U_$U%,J0ME:-4OB+O@7,pD^?4JbOA"WZsM7Mh0Aps+I*53!\1%An'W`cPKTT7F=%dcWJ'\h$RCddfNO'
+%eYf.,@6I/Lfag=\;`!/RVm`!&NDm#$a<QcV<oEia=O%O"?IgVI%g-;ap"M]?BKOLkp:?Z\2u>DN"b!)9'A)4bE,l0S1''(`>,DJJ
+%(aJM/C@M>[*S*S^i@%'s,>]2+#CO8f.pe8idiC+PCtL<!7gs83k751CVWQ/&N%n@bTU<[8h6Cu%b;,Kg;t^A`]9EF)oYh(2[:Hma
+%)^V+ilu`I)`SZ:9=5]+k_oqll(^;m9Qf00D[f(9&?8kgSAq.hOV0cQ#p=,MVO$1I(,X\rQ-[c#V"p%p`76!\H+0<fGD0e;dHTLk*
+%8^3CORj?]9phg/Z08*M?M%7AX#@m,"YNo'SK83Ml.T.!'m$:]p1dS2.?!??fB^'9Y$:@qs_1rcde>NtL?',UbkQE9!(RQ$MH@u9_
+%SDt_C7n84g0T+akMMY"lk?L5Hg:?XgEfuO6^pUeY1dT2r*#U*f&?n,K6h\_Ee7UY1OkW233'QrdP8ZLb_2"kJGG+!m[s7+1<"G:Y
+%F4d<o/-Ek!)lZm#gm/F#7ibBcf;qqB[=>2-%#(NOD2ZmaL7./o>8%RG:e"i-)/#7Bk,Wg4!lGX$PkIF:peO]pLa/Qka$1;E)W&b)
+%)1Dg#`A`*J<3/^k&RMG7li;FNq^N&H/oL"-#"L9s8nT&mFuY!Q/1T>p#KUn=TQ9V8C+aL\("1k#EJ4IO7k&?.F!e+40FsC'('LQ_
+%s/8+4D@9S*,)["Q,$jK=)hiZMDl,*O4tP_p]@]rOef$M!6/QYj^72q%`8Y9/WHs^eZ!q_%dNWH5&lb*op(9VGfTYjJ8;;s@Lb]"E
+%KWbg2fWe!EN#KJ6eXtKi';u[ub_rrn^/op8d[)kt^T-dkSO,*ZLD<J1Bj"<].1!!$3GVeK=,u"3U7hRPo$:,@$qn@nET]GtW:IiJ
+%IlLjDdh&YEUWrIZ"%P4%&SV!IENH;0dK$'Q/Cb0$gKHbr@H\G!7I[A)+%c603O&fZ)n[F:;CiK1(QetO=,0pq"A='8B8:d\=o<7<
+%&FNF"e#T^a+MEXq@pIH<7\u\6E:"sNX'MKePIC!88Q,P``,c/1ZBNAB#T2hr;D)K7)FPPnVM@VUI3!mugBt?iRca,c%?j1IUVJTH
+%jhX$,>U"'K<1\hD:/9o+dtY^H#5L\7ki2`!*KVP3PCm8C`m+2PT3$.<40J+-:<Z&..U9Rj7\>O`1/OR_.Sk^u>b;eWT8\d\$EM'f
+%":bM6;bfrc_'Y/%W`mac$@#`D9<1O_WMq=%<Xq\LUu&4]BUk9a'oJnl&r`RA5k:p@$`dl'*e]+0=(Ep@Zjg7u(jkAJ+(6V@YpBL^
+%G/pn9k^`V[p+0;"OQl4A4n]jf9-?_EG9r?I9H^>/Q+><s!`<?kO.o<W"<0!A"m8]_q_UW"d;edCUl_d)C^\cd*KNcBom1Us0X6#3
+%7mVnAJMZjW.AS0`T26+L4%.0"kJI_!N`r)3!&bBDoYo)`ji&U_qY%8(YjmQt0qKD;b,n",>^pqN(+,c.CHMnEbPcc_03gjgApWUP
+%q2>tp):`Y,N3PW6<Y!u:-j,b[&^34LW5k/]"?uWX:I;ni#A%K72X`^.`aPCGK7Yd"EdFPkr,)_bj4IEZ#@3<N\_HTM+Y3V*<4.;Y
+%0I)]$,g$G2,IB4!(FDceli<'eVd*l7%",PAp$'ECkGn?$<:`=Iaj1nP^[<WJ)mDMU\*4Khr;EWJ^dFPaQl]>*k0\>R[r3X5qf[S(
+%D^X1hd3'RT]s8;f^r%[Pq\!8nK\QgW%$"g>ONc$_#'0RjY'*n_`8tZf#oMX2L2LT7E"5`+kapGlN>/6K>hgM[p*P(DC1okD^iko.
+%&GL"7AFfg-5&36I).MmXfuegIi(B_YAYA'!8]O4L6ZN9*XUNn$\ZOQqd(sNkfDtHcce6To?Rs[TN@)b42Op%@'gB6iJ[:nUeX#P1
+%!#2sLm0qh\+5?/k26Y^LWKI_IC(p.F896b[)$J*c$KBsl;\-Gq+-);ah+Z4Er.3%0URf6,f.bbA2t'80=rJ6J<*V^^K1;=7-hAgR
+%"pV4^%7=?td6=O&E?,mpd!3#Vn@4Pj^LHd8C]C*VZud/[1.jbQPbCo7Rsa:1BQ0,J*>ku]<a9$?2`0#a>;S/^8NfYV2iAJV1WC'0
+%%1S`4e9SqY<>PnuZi]9R9>-9R#:DO+PRJ"Aiah$>7YW4"8RO5/8BSWu+i/OkkJ?Y5<?i'W9tkcq>R)bt8Zue/ZW97+$aLrfcU-j(
+%L<?s8j@L.Ym#3+:@SP\2i7P%0o]aUa3PBnc1+q^HbVe=GgN]\B'"IWkWXr$m+SONAAeMGK9;,Ck="%@s'#k1rabUFZO\KYD0O7bF
+%!j2eC]sdFS%rEh0=\ZRrb^eobW`[*J$qW8`3Hc$.4?9fC3%:iQUI(WF6o9McXnN5N4-tPu?^k#',E.6$+#q]%`hdJWN!MmJ*35d3
+%^@+M"p,7U>0FcR63](;6!;0KS(o5jm-@S1BU(.lY7kK2GeuOHF.AMQHA84NMKG26]Sj5O_^gIp1]pL\bPL'=92@d!M%cAg*WmPEY
+%_m"sG$Ht"^Jl*`O0At3B64l*Q"X]Q:W2?q^EBZqX*t0&479jVSFkAAJcWQde@"J1ZQM%#0;C=#m'Z=P@V1Z%T*fL<Vk[`C#C@7XC
+%akL-%XFhN@d$;DjM+eLIJ/!I.^c/>k864Kl2JW41Qn<pG!3rE*F<Fs&'f^V95Bklf3f.O[ck#>*gk^/0ZXe>!pEpNN(rUG,)!:X%
+%0f-cC_>qZC#Fi&7><6bAg9H2Qk;lH&KsH0I[TnlQ7`BAR;#MdYeLl5&2RfEX01W2fBD\VHgIL)-I>#qTIAD;G`su5/rZY;1"S54@
+%24og3O`!AQqrX(Oq!mL1P'5(t4(&rVMp.6<$f1GP:0:ohXpHHDRUA$M['c-H'?i'Ga7410n?<WTRXH\]hRDK\_:$Gc'o0T^4$KjL
+%26#p]JpNF5d1R/4^+`cCo"HCuQ'_??QS]kr3E"qWbt+3Nju6lt"[?Ba3b&71H@D"dBJSK;EU8<*X3Leo)18Bp0l(6m:hPie35.l>
+%W#&<SoV7<'Nb=u_b>g]DUMi'f'ej(X!I9(bpf;B*G1WsnA"\^I]Z;RYR`XU6)G4"pYu6PQ#UDWXQCK_Jb,Bp\2djkF-/du[=5`:d
+%*sLH98'dp&)nl'K\q%Gg,nL[`B!\&9D="i`WH>dHLOiKf@[G>kUtP=<HmMIk$pd[<lZ!G1!_3GKI!(O6Y@BDC'<utE]PpUn5\qf8
+%>;O6>W2k3&r=F;U'YUmVO?d;4$(oIWkJ3;LdN)gsU*/"ubi7+:oaDPY)M;S#ljRkj4#OC]Rktoc?"#dE*i@E@NWD:L^7]ET,QgKU
+%)$>T*jJIq\7B/A-_+14`%q&19)SB<gCo"Fc,<@Os-5EJK]8'!M>;HF_=]rWs!)#LafQ7P9gON3Oi`R@U^oAq\Y<;0"WOb&fBULE3
+%lrcj<g)=(9D*$0^*!Fn*L+'P[UDi/T6I66IO]1sL:86\mJ";Z3Tr/q,Dud);esDS3-Y[Gmd$%iQic`*,N-fEb:Z'FT8^nZ=?Jbq4
+%MT.>G-btr>o==_ESk/@Tj6X>IO+2o^UGK-FoY$*$P%1m1??r5&I6Sha%Gah>OOU%0M*nsMh'i$i_<cfH+q>'1n[@"@=gbc-"B8-X
+%Ru##`*9bNJ'bXJ+)0@'':uI'QBh#s?*M"iGdQjn1j(Dg]_N:oAq.UZ$!0pG`Q@ln4_60=jFjc:=JpPNS@0>%bBEG&O!H;Z62/h`p
+%M%>SRiE9:[aGilS#680m.o'1U)8kUFSN1il=s[Bsk/C0IM2d$agD&\*_b\(naC)T"*h`E`*@si#<=ZR2KolZmJkMA&mSUn?hEM?7
+%'3GC8WcE-HYc:_jSu"/\g:3D%<j]<Z+QAZk%S[`EZR.46U1;WaR6enf6fuZ:O*:"8\n3NT1<?soF8\RR\9=^E\&C+=<f8\%>s_et
+%=X)I70M:fOL@'$\"<>uXpRI?ZD[,F(CLEa<8[DHl9/p]@[3poVD$Nmq.meHfBEG1<2*g2X7FGmOb95&oI9rZQ=1_AY[6;_i2/^tQ
+%4/E[ckKQ1BmBR:f;BbAS,RZ&G(4(d"D]sb7"5]N/m1+4_kfcc1i*"Ep1CNrn?2iN+f,=Bsb=1<jk%tfS+RG=u0"^%Ed%Ld"6Itjh
+%*M/>MU'97<=FoX?c]o46r<kjKZd)!%oXaZDK**>-+/0</,.C1#QH[tiO_XOGm<>WD4),sMk^ME8YfGDhM:8:P*.FIEj6UW':ug\;
+%#UA:2TgtdAOZ.-X#<l34l_2H4J0Xlh@47Eu<7$2(ocdP(R1a8mE8qQj+Mc+0$<_0#j@1X.*t/0idWD(kUe+AfEqH9B]SRfk7dml!
+%N[i^*'//\TJe3oV7H01jI-W>f^a-uU1^^X<a<%%%VGeF7@'H7WWE7[k=!L@a,fP(ihjcNs^&f+@CLZ-FNPbQ_-7Scmr<;.hL$)Rr
+%UQ3DJ(7ZSr<YI/+qs\^lbO5)EE8#4-[#ZOW5t[,S5&busj/BpaZ,MK(bW1AgCLl5>fFuoN]+]A^b_c;+],,ZLm2#:gU$*DU\+kEB
+%VLGo^2Cn>rbPdU*U-(e=L7"M[B*l>B+F&W"Ldn]rE!"h*bh+.[&3MBX0X'[PXR5l]`PItQ&G"upJ(fDFi474DrX/Lr;dCu>+JHMo
+%/=lu$6`9Iq\Wk&G<\aAe"m-Mr4&H`54q0)cFKYrrR7fB-!08ddD9.9H-c"a]+b.=!0pu>:prYdAVneC5JAj<n[C[-iRZTqT\3^?&
+%_rHfEI%H8Kosolag`!F*S'Y!ET1$a<18Ao1O$Vq<.Sh_`6>t\mOJ2<(?h$2K_(@G?%`--*@6M=75.O&=oKOgV-bTR-V/S3ci2Os0
+%+iI(qEANsW3rs5TRqe#6n,$i%`V;'fn;g<jG7'3UhN(.UM*;)$=K_Wf'm'?:*Q%!<p<duhPa.-m&9if"jrkjNb!YTI-cO'%)0:;1
+%8!]oDjb"V7'</(t3sN/CjBssb[44>*n&c&l$I0&:FK.mMMH`U<<e-^d#-]BKJEVI7IK,E[X6A0B56PB8mhhRSj+0eiY7HdGM*PFo
+%%ZF/g`:lRiegi?]8Y&3#.G#Zs$p[8t.(fOSIh(J1ABHT#%)EcFGfS`A!rJ(tFpC;$\[LEmYAi$1Ipk]PY*OiPQ*-71m$^Kl7=AU.
+%?ap:\-5>8&GJXYZ&aO[5*1[mEE5XG/f'op[3<<EN[S8"s%.lH_0*IdJa8Km%5mdsR45TOASpJFb.?:"`6l?%uM>@EegC+k9F%dT.
+%q!uKH#d6j(d3!^0d[#gPDb%SV*K)*H*3ECT.LN!`+kSj4DK&!fQ$?;mW2L7-S`aZZNZR!Lb-)1IoSmC6:@/Kqq?as*USni[RM.B\
+%lS_[I.ftGNJW5UC">7?/=b6eX(AUrCn[a-5%h-T:l:DUjT(&;$Z^,/+5O]\GH+6<o!%1Gbk4es/?ErbgW$me'po:H@7h@03g:cV5
+%'d-[OARDNebePDfoIgSA8GKQgWceemH;^4teGU@0b5\t5.+p7MilCVc#<3q*SUcn`D1\IKAd":/)h;IC7j,E`Y]A`cTD*_*/1d5X
+%29!eYS,o/4n-qM`)l5,paECfD]6QM[8>TeB+-R[0+U@M6N$S[iZY3Z2f!<,WNmLc(3*8`qi,!je=4U;1ZBM6deH!U32c4b(SsO:>
+%Qp#0]l.f8'-&`:MLje66`/K'=#k/hgD4g]YKFU?nR\>s:G[Jl$>INQV.S[>1had':8?2:J=pUGl/P%uA-;!2+eo7GqLbBHBLbBaQ
+%7c+A7USiW]EQHDj+!<O^oVg_BqnS*o5g@d@f]EC5Z_\6>L&I)']S+@IgciBMar1CUaDmC"ptfp7j7GD;4-heO9gTt@1,F'[q(g<T
+%%,o!GEg4UiFW-f-<n]H'_/fhqo=]Q8NsiU_Hn5>3pkr++#qH.5iY<YS76])/JSgX8H=BjHT%UC6QJVpjm$K*6?=b1XW[LPpcOBmt
+%F!N3hT#>RW*#AsA*&gY$L>\OH(tKHcIV8?M,C,GZ;(,,&6^O<(N$6?#'.dPC'F@\f>k,2$q9W"4"2TSX?(f]['^%o'U:;"9$mRfD
+%1k!sfA]<5f82"AMb$ajT'226DR^M2[=P,kB,O9L&\Yo`k(!B&I=\oGIi_^-d2GA6%aZpbn.[DEaD-qgU$PP@ePZFH[5o!di'@,WW
+%W^Leqgal=G(\QeOD4+'sT,gQs@&V3\Y_OO0AFXfZODe%+\V]d?8O'Lk!ih/;Et&O;);^77)UFC&MD<'6#p*>)]C[#@<ju9^\i%<L
+%+-LetZ?r:.b#)EIrJX1HLql9Xm#C52,N.:X%bR-g2&.O3!IA>:!:J>\d:oP!;[;uIPllgIZgtNG84o>S,\'-X`8Wik?$Y4NZ'Sj$
+%-jaDn=t3]s07[q=#GQ1Q;:&L[g@@1&,?1.B,H.<dC>l[Q"RLog@dK^L0*cE!Wi&A&'I8@68]#dG<+J]L=I+.R^kd!T6hu+LU`-.b
+%?#!2+C,&t75D*W&*HX&q+"r1<*%Z_RrdsqEI4<BdXdkG_.2!S(@VnQuQd<a3(`YjVeFK"lOeNs(a;$X1Q*aj>DZlI#\BK7bAT!9'
+%G@0J%FJhfhWY/.6U=;g")-6Cr2)2_L,gOYnLkIt3W1C69,?'"uoqQU(W@mDNG?W2F,PrtHb)mQqr0H%g=2a6a:XZFY#!-[u>7!iO
+%F**&E]W9PdWOC,9Q1c<k@"Pda<b46:N^?#S'e/@G@=0O:A3u]X9C!noX&2kW%aS;$k')cS+l)J(Q9%C67dI<\$4`/Z4K;)4+-<K,
+%8=7K48kb8/%P26M!dW:8O`k1q=iI`E(hP&3`)6jM]g(f2L6#`B*@jD"OX.Ic#C\tEHBF&E=[,M:)B;Z7jZksh#GpXh!-lYX/:VPn
+%d6!04/KW$NoI/0f6%r-p;R/#k<b]iOd\niMlLkcMUp`MU!]"r4;G,!.(0oF#p8SlE!e[pXC/J@G7>2!T&ekK?!08\KGuIBOUfq'G
+%>(a$f#L!:^iZOL[b:3Bn_jcjJ7R<>DP&nko2h"QR&[:<?.Au_;cq<5%j:`Y%g2`p7j&m>LJN#=,k8"qdK^36/Q=8`;``.jg!B#_>
+%kIF>BL^$k<'s'7m[s'Aoj"U`.G]I74du;@=ar+'RT$U$>)q$D_^IOSuK\7[Z[&(3^q*G.cV*XiN'4@U%mEqA,5StU\D'?,FJ`''3
+%=2R+K*6jE4\D]kJ6j"_V1=sCl@ecljORJp*;)B7JY__Bdfe20)K1_CXoQlg!OrRq]H,K*3V*AjL=;MY:$r,kXJnL@L6\4%9*#oZ7
+%ITj8u9YVp1<)r3Xm7/lc$V>GTRQR4l<lKZR;HqeQd7FU*SO\O(YKR3WZ=Wi!dNBYTQC;gBA&Sf\o&gBH+#&^SfdCa=OedsN.?]bN
+%5HiF0gS[G7B;ulf+":5Y_B@omUngL!1a'uAS:gMB]sY-iREg;WkOX4f)QMX%3$sotTMq=L9=/d`3^22jBhRS>FjQlZO"l>qp(Z(!
+%OQY^*O$r6@"I*#f9P-NkMLl<O=F(4L$>0msp1Ojp!<l#ReZrh(hT@<6_%^k&3uEE5ml,OV<t+iM5nYolYgFG@`,a8I,5;L/HtEJb
+%YIk:&D6!4G;W4gGX_[M7Q!kN.*E4>D:hHh#jW5u/nqr=#AMH=B,,#$3pm!-9nou9[JOU%Ek`3L!aA*As"]SXrPnt&l`N)+#=b@IL
+%:-B];N-&%=jL#\>`8[WKOA4Lq%7NCtj'orG+ECHT.S<1!*X8nc!q?c/l@ECn$,^i#8NjRQQpcsGWM-^6;';$l-QNI3j2-^2/QOZu
+%^ht-g`2\fK>>>5Sb_;?m7->_9CXg4`k\(>*eta['0I)*C:#VL+<DkmIN#@JjZ<%m4@Z,JA0ZNc#qWYqMd+617osG3E$g[BrY]#u(
+%*fJMa.,q/`%Z6WPI?]=GeN,/!+=>9hkPZP4\W8ku`b-jpBr!"q#XZa0csWn,NtjY>8BmoW0O>nG?D;U2onHpJ[)#]#F/Ml/A',02
+%NC\`BMFO5dE2E_dfH#U`pljrU+RYuneDf0>4K]ZU80/s:,WlOabPmZ5<A/00YiUVLB&$5*^'ZYc-&fU]83m\n;fJZM9-03.bbTk6
+%iWL;8pkml:d])I*i)noS%#%Z6m%m7=l(ZaM!pZkEP*l*nE/]&64IkLWnZ5V5a/bZ"p#)G&Q*uo#nd/(@o&?7gEkl!S#A4d"dNi>$
+%r/X?gM>O>/pOcD58kH&ukf:OedPU"mUl'"c;'1Q.<Cj8T"$VQc#g%ue0E-mZpI=)YFHC=D?3c7N3SDDS"@SP@1mm_&KdEtN$%7]j
+%#;TV9h7a=CY[WWZ"$%"F)<%AJM>g+B7AVs`rKI'ia&.g2d+4(]74WmMomM@3,P;P(e*8*iG.pmMah4'mWH]rjYfb/-\m-kB@<nhN
+%@_q@\S]\L.Ksio?/X/d?m=FM>",a<faMKLa)Kc*-X+UK7:":eXF:hNV@+kV7H'N<%6YDJXGh7(k%Y+^Oe/pl=I"\3++A[b<">WT[
+%o5<m9A?I+aqb>mP\S;@Yhp4^;Zifi2HL8LL-[JLGh<1,Vd"fEW_P_kZ;X-^+:H=KS4d`V5Gqr9\"c67lO&D`ei\aOY/=D&%3"s7S
+%,NL/OD05(emuHujj`mn\HcDeo-7C:6\ehqkCGBlt>BX'?MS:#_p5ttcZQB<3q;`[j=mMLk2Is\:fWS!1XpF1b(jgEWM`7tZcm0Hp
+%e<sGS4g82+1_mi'PbA;G=GT@,;7`<(Vp[0nheCt(m>MAD-M]>Z"?h@7.`tL=U>`p[b>nrZ,^(:eT]d41ELgLsb%C`?T+<.5'M:ZJ
+%W:R'=8k9nr.bL/0r8`,sMW-)370oP?A0DNt1)2P)<Ra]+jKA/,=l<Gb`sp\.AS14@>Gp(1U7@,S>%1NWKQS#Ich7/Z*2+h*$7Y8&
+%8!%8k@OH)bRVk,o;&1+NntWbrJA'T&d)f$J6riM0;!qZm"t#.o.Nh:fVE<P#9L[8tf+APUP<$=*.shN""0W`LYDe!R2DtjM:1,pd
+%^NWR6!=nX1<I(rd_%<=JW*K!6g2ca'\,\\0RVX6+eVb7Hi#pu.XoBN9O@0=CI05!piulcX^OgZ0(=2u0p>0pRO5!2E]`R$-q^6aD
+%hhks7%l8!MfLfb!-HsCic5\TpPsnQR-&tPhS"cE+^4br%p<U:oh0!rLkjFeCm)[4l3O-[M)@`?j!`8R>;r3q*TFf;BfH4=AAf@Li
+%.Hc&PaE4OAR"L@gL_[$,NWmRX)K:*-Ds8I)%7_ag]o.NQgMOP@&LP36=MqHdcR9a:*S]h%@27_A;2*)Kqir'?(1D>eRj[<7%J\qM
+%h5LE+?\Q_nYs'6qmT('>T%]Rd9qD<`RJnkVJ1-I[gM2R\*'8+Sk-H5OZ5b4c<CjT<HduY_f%]D2.2H<>8:AO9$:_-U2>DWV$<",,
+%?F=u$o8HUBNH!3#&nPiN<d\k>8L4+(>(LRnC&Wu-3<D0M"WH=k-qBjK=e@P)%S,=9O<NEu:mNZ.Hl-$/e8.N;aM8Rq04hK#V.)J`
+%ZTsC%@(L=l!FQ6`"q3`s!>H8L]i/J8MU:DA*RWDad18h#;7?6cC2.]K!+<",[Z4VCf%"6N/g;7!lTW.mFD>Lk7M-."6QQ-JPMZi)
+%Vh>kE;=@Wf8hc&0V@>]s9*N5mP*!;I&jVNV^]l]#W(i\d6;n@sCabf%:WhtS)R^C'.W%]ap@-8sE<&-YL%nQB;K#<ja$d"a\5BPu
+%r;s1CYSI\e:>RnNCeX^TQp2ol/rJ^I.tC9YcR=o;`Q)\k*cgg5(o"?elih(NCoFXEWOG4M#tUp80StWcSi9nNP!DBs28aU;cDNR7
+%dUL'J?ij5'Y9%!]cUOc9eLMCJ8oX&Y=0N.l+q_H'+VQPfZ"opgOi\*X_QFs>iHV0]OnH9L^.hn]'30FU,`%[G0I,Y-=K!Yn[mDq#
+%jC=1nVlLWKY.J[ip&W@X^g78sGc2b-FK!D4=mRdiWo&k5glUJ`*57*hEM0&9Sqa'':mVb0njq>1*U&MP*Q_iM3Q4!7Uf3Mr-u&il
+%Lo!f0R&Nih_>=g=E?M3.`;=$P(oWPDd%k0B`!C@V'b'_u%q;u-g!1epZB)t@aP4ok.qo!/i'YMWi,0/`Y#<q24@W\G3C"1LeCK:k
+%?-IIXANPDY9iWlIWd6ZC+Z)&!j/Xld$l&bR746!+Qg(>J?0h&e#"Ufm$n54mXCbj(;t4NfE1"TupFU%!RP6D8b2<ET:^gnZha(Sn
+%@X6,G:dqYo1eP&He?Uiei[1G%$rI'c8-I,9P;o&?l2\hE68*]1S?;UKc;]bgE"J'@`)Yu:`&T[Y1NtFS-kScglR>?1+1hNgXqX\\
+%2_G_d:bt+1j*HWYL:BE*!DAO`B)qBOpkULJlllErL<8SjLqR-#US3k!6n$LUW^?)K:nqXo?611e".5ke%%)!`-o<]INC9:`fS7qu
+%8>$OqLb?`8&-62D56IHF#HerTj8!rL_$QqZ.6:)dES)5WQ_)gHX;>XTShD7*ia(enVROo+c4Sl5Z'XNUG"St5!3HNgRkFo[<2K"*
+%`9f_ol%<7T.],9-gN65)?n"r1S/jGpQOOId_ZEDs.TkU!JFEf#!J&h.CpUIoUl)q]icbs=2b:/3AY+OaZZWuOg_WmW8ZqdhpI/^:
+%Z8>h1E-;\FT[(G?*!A`_McmI@%3Q#6K@OE!m#XT$p0@6ZqhX@M@Vl)F[@%M%:>pJefUWBST\c/4YFNjdUnH^''gnNg'cf6Q,"N$>
+%6rPl&iJ2NlSg2,+3X..hlf_Z8:+0CeY(d)NB&"W))WWaafaLDt..P<D6H1Kt;CD\8iCU8[8j+;SD"ePc%T$Igo2`ph)5prE;Kepo
+%E"!+*O_!5T+La(81eCF9ZXr2k`SJN6Lp#_aL*UZ\_`%`VfXq`,$EX>"Idhe^VJ(P]_!jY0B\e6QSNt8.lnDO4i'g[bh%'AD\>BW*
+%&F&Of5XopPO4Y#V'?"It-%k%8ab*K#KUss2FgRiBE]]'rn;eHT;&,:Q81ej%n:d@Z_@;#b&j*au_94#rROW2_Kh5CAp5*pm3JG89
+%l#[8pn%qt0k%n?:3_W.rKV<[i./TfBN4.1e=.]`cOdoJZ.,SHC,-e"Al/LY<U%hH\!Ut.j+-<rTN5smgTfAD>T3>-SS.iMu^.:Dc
+%I^t9n$u><u2;D"DVE5;-ffh"ocdrGf(J.-4;[GRQZR#()#Lj]?mSqttLkFQdSRAZiW&>G>mKAZKN[Y-9<5H7u_cF>f;7'dDA7W1h
+%$&"bD^>R+l_SCVGUXPt0)hSHr29XrVK7-+;f-mn[9hg8/3(5&g=dP6$'g>SEN`EU@U%k0$6K%QMkdQRGL"ehD4"Rb$!O`s5X5,G/
+%2_V0e4!=tVJFlCm8@'Zl`'4i9G[H"h$CIKE6XbNV"ZR*V-9W(`+:.dNg!aA<Wkf6;"2`/+SUU%4b7`#C+X]?0`#?l&keu.%6IDs%
+%mfbBY=.ioh-N-U"_]3@cR\md&)E,!8jn+mRK_Xu(FXD1;7SuLWr8%(6,T;P]@613i;31fuEuKV_#T?(a%r#l&aj7U(r=cs[8DqX%
+%Zu8Cn;jbfD;&Kk<kb7_fHGT%o51ejmX$n%m\0-tDOAJVdS?PE3A%E0o)$+K8Ak1h^;]GgQMOAII^qk7k@RB;tYg`\*)5q'Y>.ihH
+%g$c+g"IB+P7SSM5b.ptm)G@c:`8_C(AcRVqh/R28Ls@sid05X#6mtdb_ig3W122F1#"'E,Ca^66)oe-F7]KkTZ"\HBJkuH>C`'S6
+%8ZPG+"W1k)</9us,?LsjK6Lq;l%eS7?\ucq&o>WSV//d.*WN(O=:c4(ea-2PSHJBdHZXGBDS1&k(RC7+)2aO&#8&uQp)Xk#8Zrgn
+%aFn5mO(jnmSVudqa"H7TS]KWuHU$#4B#Ys)N;T:c=b>iuXD#!m@Gt*<L@MqN#i(!5R^dH;K8)%nhUd9RZ-bGU:-+%.Z4r(%^p.UC
+%dp)lFodE/:&P2H2!Oo'46,3hIk+i$NRuV5GTLortjCbrI'7d`e_E4DrKA%5OKVjMV4qS;&%!b0]&?G5>pMJCFrf:12@M]54`#og1
+%2Ah<#!Ykm0f[W))"F#*6\rmY9n)GO,0&7_pQd&m^$UMlBl'C@h[Q8R+hS%ToVO12sQ5.jalLo)D*>[QpEo&lr*AL(H*0XRnq4TA+
+%>.X$N%U9Hdc4%SYFKJ%6?pfPhImo0$J0[`hKJ&\qUpY1ZM%unS5]I9W`mKV`AI1Y]"VW.GNKmP*5n^\n2@\fDL/ZC#(C9-IP<SCE
+%RhOVIeZZW5O&Y(kf-EB#ocRkfS..cSKLiqLnEN`+(,D*Fj9rilN,J&%CSo0L<7$@C')Vjbga49"Cu9rGD]3:/j]Zu4Q[_!8dm.FX
+%+a7a3qTTSg%A"i(cL;B[LZ8@L/_OPf!f/6@MnBSlh4N%?Yd/mYJDh@7h:PWY2<s_rI[uH]ROW'>h)n*hFKq2q^Dpt4&-<YhYgZ\Y
+%R4D3aW++!$OH!\[YMW\?<*QS`R>Y4WrE+<Vp.egNfs#Q7%C3BHX11S87;<55#6:6H(U&K!"&-A`b<k%:qcG@>2Np,r'^BOI^G$3s
+%(bq&T`h'2Rr\-%Z"?An\V#_GO,]k,_/"#tG=?dMf$4d$_D!Gm&`UkMd"`0BM7DRh)G!-6n;)FeB1`lr/e]5%u[N%#OacmB"AjY"=
+%&!Nu\l?3W(5&D2MAa5Jh<\_hZ8ap;3Q?7i`99Kb_luXPb+d!5G_&#(oKp+$sU3=7:SuERV4YqB4^633$&R[n'ga+[R?UO1ROZ?*4
+%Ku%*M`%dS_?nG*(?Y&>#+*%ueJdP5o_L=23*(^]Dp3[";'NWsF?uX67YP0sUQgZbIlHSgWa_[_di76<CDf8SJ"a81J&?rnT?P0tC
+%F^CT.MtDD4E\jU_2)J`"#WAA,bkoiC"C+M)Rhr@8&j!kS+pqdh(e2QIWbJ+^QM-fkec72d:t$!nW0R$$5S&C/U;O#@iUDK"D)Db5
+%=r&(4pkJK)(b=`e#c=Fs%2deTg2SBr2t:(jn>'Ub$`Xcb".U[jW"3,].g8:[7I+2H;0[Q=32f:#>a!`gn2sGHa\4&R0(VO*JPNhT
+%!=8PIL8:\M&I8PdV#:9Y2%C@%Qk;dl-J97jbB=BF>Bd$"O$19-%W?JV4t`!:$AbfI3Y2T7S-gt'[LMh7OU*E]<HHki['+^i?T(ki
+%Z7&g!?V'%llT.]HPS>4'Z.jp5SCG%VT;Z5SWd0BL%otd?nI]Zocs^<B.!0M5_@BG<`D:_Jjc'mmC;<([c&p+eC4ME(4CpAF#Z#IC
+%@h!AR!-ci6+qRPkmoW&t:_lrLCI,e<@ro0d,nC]6(DprYh0<4RF?d\7@/*KKDZb##.)BSZXsM`>PUt^,/`$s(1c7mnBE6\$IB?u6
+%o#69#`oq/8@pRg?!P:Zci%<o)/+NfR4^[P(^'Lc,/1U3n[fN[SLAJ!rOs8<OoSA5)e;@s]%]A.nhO#]V8,:LP>a#ksWW=r%Z9#GQ
+%k:a8l[&Ef(\L]Mi7\sPPp,X1-.A\TPL%M6P\F`h2DptM,.3pucm2Va96$/lqc3g"%6Xd)gq3]H&f5YCR3fJ4>Fi1Y%<,S?o&-oX(
+%D@)!8'\R=8f;-J0T<<;tlO][Y5i=A$09GU>`/&IU"L*OfWeWX!LMSG+LUpRm76?T$(q%91>_Mo?KcZIXE6g6@M*>:hM"gWg.U!/X
+%38,GS5MXt\63S%"7N=dOK*@H&JF]R?ntI>5.M%e2V.`40S.3^/U2t+EMd\EOoMbidNTi"@c]Pc@#p;[dUM_@,e,ZoY=$8$@[%rYi
+%7I#)<Q8AnBICS9Z+brs?j7$K$,D)bLSgM?SK5PZ.q64\%M<&N-B+V?]qAjN+4bjUS_?>89'iqF==mhZ<p%].bHSmeeWiaYmUfAnO
+%:,'?[<3oD<ZLDu/:,Rnk`hn<+,pI?EC1Y^U*li"A3X-nsWT(PKdIs"VK\BcF,;CqP<--hq@s+ON(hmM\%"#$E.B6@(ecLc(`k?rH
+%,%R=^J(au4_B/];.[NG$+BZg>i2?o28rFmX/rAl-G>ph::h5Jc+akI.!*I+gaMfoUC>jI5gG4+-FeB)YLOmK.nP+comQ@QCP[M'+
+%B$UmQ!QbrsJOW#XJU0pDfs!G$c]f\C&/6][@'`iPcpVKABU4(1VVRe*?FlHe<**LF[((g#=?jq`hbf;W1V4YJZC#.[8:soGA,kLC
+%>7P..p-s&A:o=&K;]jY(.3i3:W:T+C#(esN38p?JJFZ!W57(qnIE0n[)JILAdE3[e!6/?9!MtD21J@:+Ob%9onU-#/g`,fknRh+i
+%"7@4&H2$n&@1/3bZNZK0!QI/Y=c0GW'b7L"71L7\1k(3XCb&cYSI(?ef?=?-;(U!t.<Y/CXGt=K'a6$Vi1(C26+)#d+?&:b".[bN
+%`De`I87F0"@h2ac"Tr8NcgX=mMm:tHiUl*N9s+:qSG!5/BnIk%!J2F]LrrtqO\BDclbHqpF:q9Qk*'0W$-V[Ik>i/#6jm%ldjY"6
+%Wqdo3lHM$>4@h/pC<7n%3;OgF[j"?SF;hK)kjun;7i6<3`?dk+6DA9*p:*J![KIENV1(&J-tDDLkP_60*=^LH1+4iM/*:@gj<L\4
+%+Fr7-b^X$o^^pVMCc<$2^VP;t9Yr%1%"W!S$o4?eT`65G&A^jAR[FbN(FB5d9A#fJJ4i97MB$Q.;#C")j[1@t9G(l?;hB=4Pa^s,
+%h#hiIXuFn"D%T2[5_*J\;-S>[!H8)P+42igA-kS<Jn^L&CX%Y9+\I`1Q%JhR7TV*raDo6NNZ2oql^AAYKk9g>U/i6rrSS[;G0'8A
+%13%?)/uEL;EXp"T6qg7n?O0[Ob''@3+@tAaRt_T"iX3h,7QnB/A:nrJ0f!TQ5&[W!@)di6(Dg?Hc8*`lj(;>W_LgZ(H0$"2lt2W]
+%ZdVpH8X_IT%l$o(\Sp701T8<niAfQlXk&X6p,&JoTTD^e$-.\]EKeQj:X&\&K*rVQ5;O[3)&'>3KqldU[a:b*:=E4AD4omEcY,>o
+%:O>qCM;?A&Wame]EqX[<W$`f$CZZ<S@Es<OX2<=J(d3I<<d25f_-Lo2j<r^(RcMnDI(EHn`pc&B)LRSG_lm4Q?q?/D1,O%!iZ2]Z
+%-2Y7ZA$gKHP@XbN/n24Lf`5t%dj66V/kRi]f.)e$;+7-TTJ-trhZ5kQa[D.&(M?jTL_=Xm!26(PTFmV[;Uu;eYVF<:f$6[i(c*"\
+%Z`.[L9Z!3^,IcOVZm('edL,Z_`%iWOLe(IKCB96eh.0AoJ'GBY@9Lee)"Nc`=Q!9%ZEsNrbDq*T$QA<JU`_V/fEY&:_c86j6<4T&
+%'^NN'kcBl-Fl,q7>711!BG:\9_mpOU$P84(_HR.f2J>eT(+Pp;"SN\YA(&.<P.WeuZ74o6q]B%[WWurN%hKY6`9Z+GXbjA\,&do%
+%e-#H9,ea:2CW0Nf8q=V]@9L]=rbtZ^[-SnO<$kd`XT_*F_qttP]7@V<4+L7cFOSKgU6R8$P?73ml5$\^/H1fd%dM"ClP-jl&YhQ'
+%3Du)6J23'^&@2uIp^r:pBc,VJhUn8Faq$\gbQ1>'J*KKNlkM'IfN#F(\1RL15K<<O)!W\ac2MQF%lnXR2iG\c<q/50"sG[V"nTaO
+%8&>JQ?sH4q_(q'I^CAEndhYr=K:Y=/fJD.u%o<8u<#^XS+Ar)B"a&))?49'SW2a]4"kXb\Kn-g`A>1A/:BnG_lu1V-J_jpY(KLiD
+%1LNu[Y7F,*"0XEr-^[:!luXP`>6VpofD14bH[dlBXSUU^WqM,2LYcNN'eiL;n,Q$_#[qQW$MODrqdFS?Q:ndrL)QBchKre1g6g=%
+%TRd`]7"LL-0fn=[5npl1p[Ppg;SQO1,r[1Rqhg6GKOiEW.a@e&2Tb(C#OW2=3IN=o?t+'5m4qt]74'b'mo?3YlThG:Pk&NCZ>\4c
+%+o^Pn[.JH,0hV-sP)=FPjWYst6:8[4U##BbU>i55=G^[ne8bakrf^g5p9cH6X%g'!MPj)'a_8?)H(DZMW\F"C0_.s#-p3V=*kC#F
+%ljc+64aM:_`r"pYLEkt'hq]9]G-CHI&l#Jq['\s;SAj(/X4'5As(h4Jc+2uGcHVfB?CYUE6PQ]lXo,4/c\[>j%f^e244dpK?s#=G
+%:&")iZ]QUGEK,+@qu4G.9)\RD(IVRW^(+L-nT?,sV6EPVPTQ&^i9Eo&YCD78s'MrOGdk'=QH^V<1QT6\V3e'/J$uMB!cld"ET56]
+%mW+@6=!dhZERb?T9LR6Z`3'Dl1,u7VA[>mCA"pmFZMQ.Ep=i4;=^FuZ3KU/jN:\"I>cT/T@MLUd</PR&3e#`:L;]NSI[b[0RF!2g
+%l#MWX5"Yb)0%cDrfQ9q\pIa"tVC:RKH;@,j[l#V*I/l30mZ-r]RD#GsO_F@`r![jsGJ>dGiRR#dC2GOiF+u)B%JcE&^?EBof.pp;
+%AF:gOM,n^:h]Zbn\3iaXR%2*?Oth/eYu[&6l<u@[]jVWnmbbQGlZj*L,8Q>aQJc#9Z,0_0.E8XcE`c,t+CSB5f<]f\LeYAQas`KN
+%AC4PFVe"#M.1^'<plpm<ot/7?$?b`RFG*4oX0%%bP.X(kr,l`iS](m9@^Q=BIF,d6F'65@7\*R5[rNO-$;os'%+?nGdA$Ee7EE5f
+%=lfMXB#uZgoo^W_U&Cr#Tnl'*&TKR3RO#YC(2+n0VM&Tg,ILQQ740('d^E%3PH'6fW>4Or+T&0&]c4$\1%^W4?,k?8WG9jlj5)+W
+%RS8o+;iper$,(c8Us1`q)k+.'-;?jk#1KAZeta1P[.U+a]4k0HT*^t9lY">:8QAEP`0rfOTBmi12CD5Q9c^ZFPBPEE:)-L;=0d93
+%-"p18CJm\P;?hNX%[qJmZa\;drP\0r1VCVCIiga)B:*K#:"bsk7%p"q24:YF8b9#TX(g!oRaf?$aI3S+OAW6sC/U6mb`lkjVOB>-
+%PNp^Cq_9pAQo&M99q$e`Xen\Ud%k.iqcT,OGVk68Nq^\RC"MS=lmWeu5JY1U2!HGtCI;gij!TPlG0qMCOUb)(-C$T*dNOW<P=F#s
+%IV@/?RafTN1oht"%RZF\BMq;]fBT##9A_@)oaOZZApY(`@F_/#/'ToM;b`.6LTED-$^7`N2J^`SR^AM1*<T,m-J],sC=9;2Z7b1;
+%g#RPX'lKOXlXZb:bU=g32D:iVk%2;mfTBrLcSd;]lj:mE'33YBdhB/ML#[D:>mI?NBki<'g#b2X%*P8I-&0aiBO7Q*;KSL\!4Gn]
+%P;9,8<8*albiS]#\X6d$AH\7AMlt".+>pI1.\)C4(`Sl1SdH[k+raHKEu+;8OXuBCS>$B+8.Z/)<4+>jLD9,kTd7A)<R<]8PJkk:
+%l*t<nGKnhM^kLIFj\&G-SE1b;Q;Qd)A[1A2-XgLK!R;_70O2gp_SR$@mASWGba_ia=kF)8/,>')=NC"G28n#h*mP)kK\*<7nQr\3
+%42r+<+VRG2)i7G!0Z&C`Qr1(ZbJK=oPb:<7G)usV@5V0k*YB,4p&V?q\6i;I!0SL/Gi(.KNM?QU11t7+;#cg5,>TR6WZ^PVmh]VU
+%DscjSZV_@peOB@1?5--O-@(=*!4?RIE>CI.^fh%Y3<0(2e57dJX:Yp+5Y)/'`_&4H4'NBZY-aiLUnQ!^;)mdBq>0c@@S*F-B10+/
+%qB6>j&k,J[OBa`4P8>]r/SJrFeY"&b!a7@Bfi4l4=U8+,TV)f&$g+2)R':AVa=]!Q=>gUIK9;ArQ'Zok:mnX$m#=`=fS:"\<,l-I
+%=@jef%pP@;nF0/\C=FTS7kkRu?FlFJENHm4ZR2nQ_41<CN't>lJOHD_jo\,JhO]!@+P%JpnK0+n.n#=O5Y@)AZ8B,a!BKfh$(7pc
+%Yu[MK1#sERk<;lWGrCg^+]t88OgZSM?D%IB10I[$S?)QC<Q\T/Pq?I[>;n,M-:]S*WEAZDc$06UckLmsV`;uRHOV^iA?l4!_,OR.
+%>RfH'#lmWE_?RTZf_"r-X![ph:5++SH=g-f<))AmZD`\),n/j37BK=@]c&nH"WpKeXhE^6WbJ0-:pJ*,-Vkink09',Bi`>Ufh'7k
+%FV].Y<+5pUVF(?ZmSrMnSf''@/*Bb4W?h.%ecoD+2$JDETL9uXY)%V\PY[i#BL&lOa=qGflIE2rBa[8ELVZ13-\V<fAbuTF?'TT4
+%(_*IhJfY0[0md^m#A8QJS]Z,Z?ed&6B49=AW;A$!7I-1CMiF20LV3$X;,5Onnn9c\'?bKDP*NAr\']`Ga83<=e4GT!Qp/eLMFi1D
+%.6Es=L4oe^5*UrSp$#ap.V2#>>%.RHPR=^RKc7D/mhYP6Q^i?0SDg^bU)"Lp_*A);Vs,3:`YKpFc3cpDN9$8l\2C8RX-tU].>GA;
+%%@No;U?jeI#%/FgGah$KWR?f!PNE/-p$9Ii`d40<qfYCA?-LlBXI3V86C,ZVb80/)FVV2^cSsDBcK#[1:n_QjX`oFWG]!%C\?R[r
+%Z%VAJQr*c/k!0k$".Ha"=Yn(clQ(P'&dasTa^bV2P2bojWZ=U&`@TKEngsBu#J)(D'Ghe'L`0jGieAR=!EO-qZtU4^^XZ@iPMe+p
+%`[/kalOo1;W:c;+?!T5t[Zt>(0nW,C%hl'7cr@5fDhYl[',A;g5JO8A8X]7^6cR#<q^4M4mPE!#I][&c$6c\?eUYACH:$;?MKJPg
+%"=4L83)0Q)\n"W!N=%#2FB4m-$88afk).fW(%AE?lspo%hq4UQB(d.KEi>-0(0m<pYV]edLO!!C*D3qU0ulLMV,$bR1>F\pQb6Wn
+%2D.#n;<GetW/$(@=JDUA_t.ViTa>V8E.!8:q4#Zj0bGBP.h2YAK8pC=Q._k6-q^aVljsI3E#WL#j8C.bTsAD;\CGqpEL9NB;"8i9
+%--JH`CHf=pJC:;XR>d1L4i=jH`gU+qUAQpdfK3,n"YikWh<(R<Shql40?+"F[)+E$1i\Y7SZ!"Ge#J]gH;j<XrMKNiP8*M]-aoTI
+%*p.<(C9*lD3G.$TRRCn\SZLhpi(uDUG<(:B!t.4p:1JUXN#GG60$4G?g`lU=Hg1e"e\ag'4<C4J`g@LZ4/PULEBFOW@-WLj"s@]G
+%cFouZ5tA78U"Z2+7p=+@-5S:lgqh+>AN,XrVT^#iA013nKcCHL0b0&m#WG,/GoC+^i/\U<c5.dP1i"eh&u(\B"uQQ$2#ouRDP55s
+%EJLj,.%rI<nn)>(Es9p*C8#?o6A:'nRMe[:pH9@!$[+[*n7G7dfF4+jPUKRlE6Y*oej?-:=Oi=C4j$A9E4m^QMPAOrYqV.";sq8!
+%.<?lo`1f,(h15t"REJ/fEQi/!W#(J^$7f2O!*%#tTX=Al$-?:/7:+,F7&1/DUu;q""pstb3K9`PHeZX*J/-6699lN&[1%N?>n7-l
+%S\"OY8kDNaFH+C9A:0K73[eJ<?V-MrW!7Ks0PHME!H,)!^14gEO[>*`BN$h3WP-QZIOcR?=.JUW'W86VlS0dg5icA0JQRS%,&<n/
+%]\5EI3%e@YLjH%$*Nc@>CaAT(A]b:*p)9j9HJB*@/o2(/;74NqYd^a#`+"ir&AJRGLSG%`P''tL]Ns/qnbb@$-Cfd\fU:=EI3?eG
+%fOW>0BSp\+UC$h0'NOb-f)W&"qn4#^VcS.G<LI$`UJ@N@ZsMG\lY3OI5*io?#E%2:M,48*Ga%c:,aI92$Z(Sn;7pF%*1$H`<&H=,
+%%M74ZqQ@8",[VMXKb3_%qeXmN#A4QJ?)F*uB(VgVokG+@T]4(:4l0I"]nGciRnirqQ*Om3DjG@8?%YW*@PRkoReOOg-ioK??m\K6
+%6`MYL154SF]T,>G_Ua"gDCPT0'6fPbA]s?US?H*Jq29Nnb/1&%#3h6u6fU4!$:5)/>7*gRL$a?HfZ3^YLZt1%EqoKod@<FN!h8,J
+%F@+9CI2tSkG?jLHQgecYmQ9N?pEPI+*n!HT#]kTg?ja8#\8rqbPqD2*bgl$M#Y0D.hB/U[D=RpgJW7UjZ;8sNSDf/P-t6;^*Tf(k
+%5k35O:bugpE![9&7QNJeNcLLY>_NNuO5#\;GR/!h@RF!MW6XFT>[8m30V2/GbS\1VNI]Ri7p>Y!!SW$kh;Y0l`!V<Tj5\+[Y);@,
+%#?a,@/U`M1SVl!YpI]I%Hec>k=K0r(TnLW1[mP=]33],q>4m-P0Pc<E]ecGpiN,nte:UT0Mp,<i&!lsi,e!Vm8/PM>;\=".j+J6T
+%al]c0J5f>t,<\_*-5@tJ8Y"?-b2Mu3)\qJKTpFtA2qD7LG<s&@05Ie#e'"HlX&I\BDH<6'Mi/E?qfAT*GEqRjm:SnP/,":6`LW%J
+%3SP<3,s,PKX2oG0)%iebf+9/D))Mb%PEq-2l/sR+-=W[X6rC?_(afFad!<J[Wf.lM1'ug&A0$us5cJAV<GF@k"Zp7]qkqLrb,sMQ
+%iGnd?[H8hs(A;@Cb^K4=m(f'@,A!`@S6+6n:ao,>juE_:aceD<*+HOkaL*9'SF!=h0t^E7YbUhG:$P.@+5)ZiR:6:Z;aO@OJ:H(I
+%KJm'RXNu""(>h48e.-0Z\mm^n45hYt^EK.45U#SrRjOoZW(o-9CkW20GJ4SMed<\bT:M4nL5XCp\2+kM0H-&KKRh+nM5&ES8@8JD
+%9I5JYPpPO[b3\Lh5_WD#s35S06FE7f,agfh)E7l[Eb_]L9:#)FXm_!#C0h#YPHbU):O#%)o\&J$G0?5.@l+3]Q8>(o_j#h'4)C9Q
+%Ded^=Us#`0X2De\^iADQ#/VU<d.L9'+NPhZ5Mbcb@U4Xp1Iu#n,sZ+-4b*-P-l#&Oe/&r*W<3`%;%fq@(^unP6mK-t5"LL,=60a&
+%6gYNbRuQ$O3Y2JcO_*hoTisLUdZt,P9bV.qM,P@])0@sjesb*6HlOFM/Xi\eI%$7kENDc(prAJm5o'LDHkuT6J#C/]V'(JR57!/^
+%@>V"<jjT/i$_"Eo=hG68@ePnbN.aMV6,I0@8;Bj,(LeRm>]R]Z_Nn;QhhWduS^p,o7Q32"D/4fX$<ZCUFpepdK,)FZH68WBF(&gh
+%W[#3o\oAX/k)FHqj*P2AOVMa)@qToC3g[.@?C"b;!$dGT[:#6<\_"t$fEk%UI.F2H&=dm0q#ad`MWq:2VLnMe;Y.LDLjCk$j4$b1
+%ZrX&D5m9i'VWK5.f@AVR*T))>)0PM8NZF^9`B7$:'MH;qF?F3691,e=Pf.em8]>;^i-Mr1(\7Y`O-u[*p=51F3SFls/^rti)q_CC
+%GI;P@g<ID_P\<`on/-A+!/LDI?j-:0e[/"27J6ih63L2nMJa*\Kt\U@E@32MZq[jDNRU\'jpriW^/t(H$+>k#-B&u,Cf<to&_E*M
+%`?ddT?rSF<'PJ)_c\4Qc];-YN7>A^'Yp>D&*ka,N.Bbbp>_ZA0oPhZ,VmR^K(.3W6"Kejo"Z9EjF<6gEK\EG&;%bA"X%\9GP3a#g
+%"DP$Ug@rJ/!+I-Li)'N,JhE)9T8/%S.#NX8[iEXYfe='J.PYqa'N63E5u*=rTH^87Dp[WL13[4QQ$dg'ek$6O#a8QZjAa*[+.785
+%Ud/Zg/Ht>cbF.U*rs-.Gp;SSB?VEIb&Jq]aC7cjd1>S-Fk^[kD8RT]o7-^3Q]Hl6NLS:/iH8)G[fokNn*K[:/G0Wo9U`M%V@KH9<
+%CkSO;nN8.]Y)d<g+R24m]>lj_18^0XkNH5f*-F(I`,s5T?$pVS/G9\/-Sp-4F9Qil0p`=?47c%#&Z90pS84<^a]b_LYr#nJ_DLh(
+%OJ\ML)H:Ek1ZQ$ZlspV2q,<2HA#P"PN%QYe\(REgTK$9'Wt9q1,S]PY$("XO\n9KuG=dIV7?[%tc@g587'3C1MA*i7?\s.PSK</*
+%BVnYV!:PV!(#L!%05ph<<`Dr>((<pSRBlWSITsV=`_t"5:<i&PlOd5okog3H9_MebOU&5Wp?dRB@l6D_?u$g?.,g-XP$1O0W&h5(
+%A@GfnY43BLJ>e&H_06SG:_mOK&\_20_)O\8Fo9esgp\%4<Z1kd`V0RVT#IWp1Un1E3Zpa_gssS;P#DD'Yr&HSX!e$;K\][hhM\kh
+%O.hs[0HuHa$X:#g3E1s:!5'*''6;c"]41RVGTSEh<[LkS\Z!Ql9(Y<5;H5??bZrnrPna4UcD#n34j)cEQ>oE2<@h8,0'!9GDR&Pe
+%&?AV98o8OkOYGmr;L9H_DV!KYG,:<_1d?lkD3VkJ/E^^Ma9@P8#^m9)WQ>iaLe<kV;:uu$S)2h=`GUtCed0q6SMEI9>8^glg%X[B
+%do9B4<P@sF;:KAN:396QHD-CdN"g*$8#EMf">V/GUk=$H.KJnMg$>=YJn9K&Fsu0(IqSJJcX]0\kK%pS9VXFlbu(5I<^QX,(Ct];
+%ChWk9bH=MRWHF'2i1Z*13(uW]$Tnu'<GX?=<1NG?0+s3cCZR<)%FZS;a]M?TPqYomJCXY)eRbKlF3CWl&?"snqfk?jo/rTY:[QNC
+%H:B*Pc0\fE)s^EpHKCnE7(^@5"P;>4rDV/(Z^k(?*[s9N,?#QGCdra'L0Rt]'S^)!<J4]771FLb'U0]%A.sOI,$'%eA"8:pRUuXK
+%[(".$!\4N;mAa3!SNg%mQ+`kMZU^j"^6o2X(/`*1nR2&EP(l"t.Pa/&2P\0]b>C>SoO295DIti&&WpRC1QL0XL*3-IV19d[KkNqr
+%M<CC!IjGg&/$:#4[$qIO7:ieE*ua9$"c[5!Yob]GO:Fm/A211.8L@?oSi&7&*AnOdAWd\So,@:hetMMB($k28_*+[2Fp8IWX[('9
+%"emV1`*:<AhShnh=&h,l46"["4Rs[9GSLi!Y-M,c=VP:3V-0?0oHpi$TceG7,2B2p7jXl*0rGA1q6d9u\kiFeK;rI67-#'[+P!.K
+%*;`_6VIR6#)0'T[nnp882%^k-,p\$/1`Bn8&g9)AG/=u)7j0VF=-VNI*:B>F7E7)#XtiOm%5)a*'jE@VC#Kmb/ZNcr@dY!oNs7$%
+%5"Mhj/K4:V=h.?&S_rmq&N3j.Fp(WthN7=S4kiQ-he/jffK04j^S2$o0QO7Pc&\Y=s&I;*f:0%8(>.raGVpT/ds<^F[>,/VAi7PZ
+%I)p+XMHZn?1QHBV/^LGtF='!UC26.:-:2(54Sp7ZG8?e&KU:W`FDoKK_sRq\TUH)f1>]oX<#ALpnJ\2CD\LmZqX&>Ej,H/*Ha/mn
+%6<pOYOYh%C>/b5Ekn`<EOhuc1)9'/K$C_)WI=\3:A4o0h_'PHV/q!:@2>H=mo[(7h;ScVHgA>=CBG*'C68dn((EK"m=cYZ8HprYE
+%<GC*dBF$`/FCVM]W!!`Z9B&FoZZZ%!npA[.>L(CI\:X[bWeHr<l02B%!=.Fj[-4bW'"Ppm&MDa06l'd3[LScD*VPro7![I.E#l7L
+%:'jKXHdC@MloX9+qkdLbYAm7U?Y`tr8/;gQo*$&jKWR5f/^1pSQd'FH-$`l,0=`/X=HL3>:VF[\A!O#0S=tuaH:L.<$lcdleZu?E
+%Qj]u5%9iDP9ru@-QB?p6SATO%1a3bOke>WbaDL&JgqW2p<W)5q`:esVQ@Ps%Vn%d\!7ZQtG)t70pN&V_Dab849.AcjI`f$l?(V@n
+%2lng_!T:WuFESE>1=0*$'cN?bo#$DsgbjY6F1R;k"g_#XYMP$%1?ljj9:_7[jA)5O_M+b1qPFkY<aCt4#hTBF'blY4@"^EI`Zd&)
+%pN2C<]AAC6[maCU5;&:'?moSb<b!`cQR-<4UmcHt/KeLMjNl,3J<YB5X"4I=--c$M%PsmZV$+`Rfh9dJk085(ZF[>!bLEBj/GQ%C
+%AABfe#jj/h81qo@Y<*IKBN<s/S-rLW9Blr>!NcTqq+4YM4g)@b?kC\%:(n*u@>)[7[oadhDikdr%l68Nq1rOP_@*Bm#4lrPcP$e3
+%cB._<i)M&(=Uepkflc.CY"j<bZVbSkgF8+l,T4)Yr5++(,#g8KUp2grK?>@iNI(PYhn%G]]P9(nf/0279J;[\.O3ulN`<fr!SOWb
+%9X&uSdfFj3\)*!`KJW1a]Gk'MXEa<rbUM?UigC!J986f;A"kRN3fFu1ermb0:s\0-Z:7$,YSFM;!n.Pi,b;-]-65sIl><@91p04s
+%52"_RUfB8aqhYO>\B6a>03(H<C0]b'ZIH,d@PPT/&ZZ5/>sH\sS:.h3>ib<JA]7'jLZt.Y?%&Z?bt+Z43+"TOc];Uh]2">rh+:,1
+%adOpSEW'Qf=t2$WcU3M>Z)9G.*Lu2J6"qQ.`r:+U*P`]B1";2AlemS6[YFKe<>[;'a,J)=JaPd]\,oBjK7P\_$56M$G`+_7=_U$0
+%1Hg>=]jP61-6OKIC=JUp:T\UHNDmW.#44AdeX1[J*.gGc=a3&C'ZK2Z_55O)NL.)heMO[aKO/M8Ga27o20GEhX$QhAc=9$GF+fC.
+%`[.8c\2pe,,XO[r4]k^gq7p(d/)G#/3Ub2bmRsZG2[l@KH+U%dG<JU?V+Bp,a6d'LlJ!F[Nt\^+W^[_-jlItn.&eV6X]IL'aJe.,
+%A.lLrYK"sWFEMOi[tl9k8ug`)-FTuOp>obG<N%'?]hZ[#PAtHdgQ?lY:+B_!5PWSa%2`Yl!ETku2Dk_!!O;5"R)SE'c-UBuL5iLo
+%$)tBOd'QR*DtQ/i)!Z-n0Q_\qbu[<MOtINEAt^ZpSY9"@b]B^#4G]<!.ZgQPaJ'm3^!NW=f&qYe7Rgo!4eE>bJD<(OTW+SU00D%h
+%5Ukt@5(bhi?.jgNW>E]"7);c"U5k1oO_Es[lp/9P9t$PeW\c72oKMefd5^?LIm7O,],1.?Xb)pV=H1JGCYD6M1SUp^oo?'NiTMHo
+%$?/,!>_>RREq3.'0Cf*1;6r5$'oS>oKZYL1"57eGrWpR:l;da2Fbk,LH99KU5%!lUrM;rt07%Ah2rhCA_lT;??qF,3Jlo&jD2?VT
+%,&E$JeO>[*n52O+defm4XOEZs7QN`hC=6r[TsfZ.grO<sU/AIUfSji:U%BT]0T/BE]LP;J-;[puA$)Dl$&u&m+p7tG=cSoHBc`#+
+%Pc&X1>C;nV[[oKNW+^b3E5Gm>?nNCQVdn)u[<_H@@DWBF1;r^jM7[3H0UkNu[3m`5.?\j!HXT:EOmSZ72VNt>im!;fr+tsJS6Y#I
+%/A\2_)SWIgD@n3=7+2iKX\j%uGL`kQL9F'J,2cp$/6ZL_08A;BKM5*]$sRLa1,LgseVPFZB$4I;JmW`1RAisN7JNO%93R8:k4(TB
+%>D4$VZhbSJ)@Mjie5,N+(c7P?`/4e%AD(5fb0A/IjqLYM$oYXGMi._OX7ip$?o5Y:IG.ZO4];1.<2l(['G6W2;aSMFO//cK+[&2n
+%oP(^9`1Weo>cpOqkqn7'RhN(2);uaiJTA!AA;tt=Pr-9deEi\L"jbnCj:*E:bs'MoE^K.\W'Ks^3(_#3VUB:8,;0l#kS9B"75\N2
+%86[s@@MZ4p/%T]uOj%Otq-9cdAYGbZmOSgJ1S,UrDV%:\c<q:4)>$>!4/bD9?)af#1hc*=V8u5o^o`\)*k?mL!BjT"@#S,c:!Y_E
+%8CinLe/-n8,2)(8Jn-i$qAI4S7WmVlUO-N#3e9SjJgD;/"]l0`WgOF3EJm_%21(NG7`.d.U?S[c[j`dDif`XQ+R,An2/]1k3N^!I
+%@ShWo)7!@QF!RhhD9+3=(;al.S`LIX8q/sQD/\B-1g;0>6Q4+Co?Ci`.kn:d0eF>!*;_RFV5I`_o1#qMH(8KS,J=b3=_k%*5m^"R
+%UIM@Q2guJhjR#Bt(tDH2S#Xg]QgqaKLYq,d"l9=[B['#Bjoq.WXmQI*eVIL8QaLM/<G>hY,(/m\_'-NbQZo2dF;+o4VRB>k!uae#
+%<:d5ok*PqXLY,R:W,WGgX%5UdhDhb.PFW%8qpQ:Y!pqt>Q"M8]$.ct5#HC_tZ^j-+RLFbq;$0r:i<V?&(/mV13uN+QB.E<bZ>>k`
+%<P:B2f-poQ\jd)<<%ee2&]23D_3@\]KPkTU_!P9b\Ct%B\p7dD=uCGmZ0-[0R_Lj_"Q+O8Hc^:N4O2]$<VV]C?mC(\qt[sIo"uY[
+%A-+O!.ldni>RCt36K8sQ@mT8rDbj3!KTPC0o?UPDN/H3hg'%m$R:_1MK.P)2(C(:<ga!lLm'WXPktjdUP-kk"7h#*lkj;nK%@T8I
+%A4Gf;!kK0c/t<i,/OK5o_j$cIAO)6,KKhgbR$u;!OqGja]t(TG6`o5gGj>Ho$p&O&#&f;F'q_2,>\51Ypdh2<#IEt*&*b>OReqoZ
+%$I9(A,p]0FrWtRL+Oh3]M%P&KX?OC5eKWP=;"3smCgL\t@dr0e=_ss%[@4n*EsBg`<N&]WU?IMKT&>P9,"sgK@71)#d's2`n2J[]
+%K]fU,_?=*j0`q',L&q'e$7;-ARtSAe.39JnYpXO]mM/^'R_4G#9$Dod'?HHBa!$?uN`0U)'ifAl%0P_(,jK&43[-m=1Lej#!0HZH
+%c3W5R@mH%@`egi[gXN5[=f$_&l4IF%Lm0^1&"_iI*]<"J@g5g-/f?Cn,69'T[Kp<l&AdTcRq:EU"emD>JPjmD8J@0-1h2=`Y+o<7
+%E2KqdH96dr5X<"R4JQAd\"dXS`?;XmND+i2,MoGsCo?.!'Y#2HNF82TkFDXaK*)uXZFt'ST@7n\UP1`Tlu><HpGg$FV[CL`<R=2-
+%+A=S.l;=)",#>cr:'e>e%9+5l&eO%>;)@)H[oFPeHe*feFRq"_b(h.h::@CjScPgF7?H/e;&IpP-r*KRJoV)b\R(n-gpidH7psZ9
+%*!4_A;\q--<KL5W9Z;nV-)M+hak/j-`Sdb2,gX9@ZMfa6EGUI",;El7Q26D8=NY,L/D4W7l95XQDV-(DRVQQG?;P:RB#a3jm!+Ta
+%otYNh@o4R:lN1G-AP-lQ;^U3>],*C.%!H'q5#ZH"U6IiY#;h/A2<S5b(rEI3d=j+B#R`XFC]@i:`p.Q68.m+d]bb<G6(J`nID<99
+%Fje"l]n\&(FZ'R8l?Y+Dic%O[Ytr6<M"k@ijZ))&f+hs7!s5YrjEAU:;+p\.*AuPQ!'R*_qFRGI<OT:N@/>(Q(hqSJZ]$;q3qC+"
+%@?9IP&V(%]q=%=*&LJ%^P^+7G[EU:MXNqDgK]o;o%*4f*2KpNcT,T=jc#H(pmBRTWLQhP`-tC`'8s/(k`Q!ZG<CNd)negHEoHrPL
+%mRdSA$?2Y@bp!BbC_CMk,7,[-]aL]DA;Fbee(lb'HcNWX-DPLOS*Q&IChg+C0Pd+n-HRJF'OlI0i0.3b()m-\$H,^U`A5[?MF"HS
+%dSRqT9T5oOq/0lLdNDPi,1oa_UMfeSDHK].A19242kLp!Iuu#38W$tSXFs4&aqSo>=;o`EQOFp)cYH#3oLO7PW1:og)XFG5V6`bq
+%L9[em_oMBQVG7:pn7jAU6YL!i%h.G-aQ*o;VcD:=nG&aZ,#eJH5"#*R%t`n-)+=l=1M0P7'b\2c#;lM4Cb]\U:;d"qm?3kGJ535P
+%ah]e+@aflZdf\V3ds@0MM?o?^B<]=9c,1J4Oj1'H&8"!M;2L$$+Zbo%+N1B9Mi$)fjha5Bn[Y`Sr3DkINVT:kB'o#4&nF"NXX>8\
+%Z;&fMics;H%'uCmX9MAb*4!1)fC)=&5`!*-=_m&fl.Elq&u,Va,WXIpRtf]#qc1,[K5!`2I]*a:abUW^?.!-F&"j/Q**K`cm'bSD
+%'l(V:Htr*B:7MS^H_t8F_+,h*8j41j2AWR':e=tVjq)d='fblm&GM(=Y)AH?ZL(m?"C[$nVJ^S]J0W`nDXOAUiA9k=>a:894XHqt
+%?#j1_PIe(&56:qs!aR0^^qj(eN/mE`]>2K)'U9!E0OSpf\)s]P&#q21`?(8VKOi'-%?NE^fhsZXO.NQ/JtdIsh.PNf-$h%M5^C(M
+%n&2&lBr*9`lODi.l1]>h-X&6_CmB"P<j;dfQro"SbZJ++[p'tWV0F#L3'f2oJOTl'o5"WmfA"@lr>ImrJVP&2#rU]FV\rY)FL1E:
+%N)iCj9e[L'NsDGA-H(lbdD@"]X5iabm7LY3ICb6*-4HqE7i"QnB!j`DM\$+="\_PGJoQTIKBKFkYmM=^<C%PthuLt?LWIT'Y\F3;
+%?\:(-USN%K@eV^^1djD2eR@3h7V>a&Bg4VbMM)8O!fi.kY$OJsD'O+F_WXOt2@DB*7kjp/6[l&B)Sld)LVXBU'`QQUW2-QLJB+SB
+%Ka)2329Xi"U^UI\_hS>P"PIBM*(E[iJHKJMFRT95#\-,;"r8^RGYjP-IZq(tLMWP]!YK`0*[5\6l@qW!#;r0kgB:J=[C#$P$./`]
+%P@_#i@$@h4MZn-u<<_0Za/=Z'(UQZ6.99RT?$\c9$L?%V3g;-e-T$UXcWLHkqFW`g5=.7]F?oIW]uiH^UWuT7/p7S?\@.\Z@4aB'
+%`I#GL@6G"`/7Pk(.]J#aZm]sU"g=Wo,\0_(N'3A,h5kB8$t_fMV'P,D-<>\a:/5B6KO/]H@7:hS.LYVr77@kV_O*D'#,LSs51]D\
+%7+O5<s3_WE_\+Pf!:Ht/GmC1I@kl_a?lTo]>S7j*la+^]C$387_A529A\6sNaQ=7K6"FuNTGp6,j=hIaRZ&I3N"PST-EeWj6+2:n
+%&r)@N8r?-6+Q$E1%e)*0UcsiS"oQYTV*cCLe+Krl>IE#SWEE8=OY&U3J_p$EkS3H%Icr`J<+'(H/#8SjG"ds/.c6"DI0(f^T/"0u
+%R7KZp#l5:F9;*9[EDV+79i9kUj``/c1sP)f[A,%:=(`h&i*[qObT6ct1U\!,$1&un^l,7YLFD`LH6+]>W)2D9T:e>LT#_JpbW@Zg
+%2>EO*WN_,sJt+HoH9',pfP^leKGFO)mNo:&%4eQ8#,5/)hC$qs&T^CX%\o`LHlkXG*S!KD-d0*X'"];uW,+gHREN">et'`4,<3SA
+%5Dt<?8or`aX_LhA[4g=SP94PX[8um/+U32VJO9jMZG,@=-&mTQTt5R^m&\t@OEKWo;Q1S[aBY94;V_MOq]o-:,R*u$p#Lcu@5E?X
+%2"#"PM!uG?!;*6Ogqg^om<$Pq.]Y?ZiF1C*qW'23M2QRkI^1RLQ`0@De47A\7KqII0q+[TI0\:l#>Bsq2rGWm1\Ptr<%6:cn&j2$
+%_AZ.I^ca%M6W=Wap(tAA+9D#%>%NqA'nd/ikYW$*P$++<SiSj3WFuE.XEaV;bS=e[kHE)G,)SV"Gd%oA_tWpi`=YjFFR+MFAPO6Y
+%-F>d=EII5l0:7.'S]kT7M;a-r>$-+OM6>b^]C!ZDBgZO2]j#g`A`X=MfDX@EKTo8MeQA%f@q#Ga'bJ=,Y:>`GO>fE:O$a5^Euit;
+%K*eId*4I22<`W'@X"G[:4\Zm1Ek7\Q9b69In7A_SV]!D/3da:?WAE'WZ(th#9B%RKE@CK-*>/u9'8V>`-O7+Em>Y.T``&_Ud#Q8^
+%4rmq!pcME)Ad$+'[XJB.Jl^HX(K2S,pH77?rO@r&Yl$As&OH387P8I->D&]%=F@QNM8CG/(_u8F?>0O1kS6KU5"EF4H;0@=*!-lh
+%k34;S-`N>P1$V1Vl^;E8=M#>Z1/L(c^*FK[RES<!3PJMWo(5KnP?&p"c?@=OH6ul'6(>>!>%V3H7'lf=P5X2aiOIDGR2B-kq-n<b
+%@S.Sb5,rgnS$+PC,cnLAE<qa6eI!$:V(S>UV9_RD12i9,j&1`\HQO!e66?BLl;XlA\d&V^ohdm-bdS-K-K6n2(fN6c>1O.@9FRo(
+%O'S[+5ikhW4N'eakG'<sOg9;2SOP,(6)bpif!kcE\WJT3Tb=dRT+"to&Fq>\a\-#QcgVNp^s12MZUh0$G'HTW$9Nl9Y7h[g(7Ne/
+%-aP-H94#186!BE;83"ks1`n,H@Pr6'A/drm':M]$Lu*6`G_gcl[M2>0]39d,ehKDn6QE*J,M!e$YA8,Ic)^C%G-=nUREsm/=q0N=
+%)CgDp@3gGHU=QnQ&]m-R<)R/ll&eh*PMSkl5oCbo#&++5#Y[a;(h;,`dtZ\Qjl^Ao6GV>J*?#\d1Jl77-e"7b@F0f3.^3Z'7D0&1
+%pW,TMS1"mDFJI6WlDsGVlhA/K(hk#+<:)1K>p[\gmRI7j,)iH][oTn[2:hP;BjiD1KcUgr?tYX\oOG!'?E@-/EeJqF3"p0j0K(ZI
+%iTT89^`E]#ghrVT+tV8B`W_;<Qq.%,d&/PE1u9=_=K5;`3d5*.+CPL`HA(&"%pE-tR>Y3e>nj=r)\$;Ld\W&X+ZUK(H&Jn<YFV+/
+%pq$J4M'a6Vc3QU#?)neFRsLr2h4!N$WgVJ:9^#]#nSsM>Ml)t<LqG(9`IZR:^Kt`FV./d83)c"/^@tp@8-$3#@+DEZ!_OVMoeo2F
+%WGTG'X*ZW*S)J[0is;GW&Sq@<:@&[J6:/@;QUf30`k,q]T4iF&4nHrL!2aR7,9JK;DA!/L1keaU#j/A:Agd?3;-q"#J,k6/hX+bh
+%lt0CZ_3&J3-q(>@PuTgA$pN<D\!Th)#BQ+GjaF!%e/_@4>TJYGf]dBFSN9p7:*Dq5rS'GQ;SFHI5mi'ig`8p4PSq]khe\6-..=';
+%,JrZd'qhff,ZIUWaH/gQ+BS9]MO"`al9Vcol;\!T34poFH>QcZ_;pInlaG7nk;Wrb@nLdTG!L,AS0-*E5*4`Gm.NQr<PfRU/$0uO
+%3fj!2H#]bbKtaI*oP*0LlNc0IdTaRNJX)sujdLj[fb`?aRsK]#?aE(Z3GRG'#_T,_%1Ki]YGMd\.`LD24CS?%CsbmH0TbHACq(Yb
+%J-6'^rSUj[n`%M)01i*U9V%;H!N+.A<0PpCRY_S^ateZV/Rk&J;t=`P7a`n%\hMZ"163]cl[F+>KWM)Y[lf:3&2,4q@Ok/qE1n!l
+%@mWGDO/X[UkI";r*)[u67DO7\4f[Nljt3='>.-XFBUlBRLf6FQ'MZ5hJ!7YY'mB@TfoD("5WuBPTHJ\&d3'\B)JM@__6"bknTk1:
+%cdrSp-<j/?_-lrD>B`nm0.s:.("78=6A085CX<UPA\eFG)Si\d#`P_1)jeONAD0Ge6t49DMrm?b0aQ@34BR_'KuC>#Cu0l]lfl:i
+%iTP)E';GBjXBh8ld80uQUdJ'`+N(4i-qL9K*d+n2&0(sT7bP2XBl18&rOm[/j+?S1AKs9QY#UuD[(U2QE7^4VSS[?Or$<MBJSW'_
+%S#RK&OrCnt6=Uuf@5#eAWc.P[-<=*>DFDEJ'-Pd5(*rNn"\);g^F]'#\;dgM@$,D;`s.]f)Q&hu"q!g3)jbS!%[L*8hNCEk=L"0%
+%k.;+t*R$qe7XX-&HDS)2UN&!q#M55OT8?s=eY&;cMQEVS=rA37=tM&C<"_&TF&=Ze<\>Fg*nNoFQ/j[&TVrl0NZPZpi$j;?4Po#k
+%W5^2OcOVRa#'Eg0F[`6h[cc0]1:#Dk:pn,9gofW4JQbnO`'g&\[HKlSJ<&Bll$V0D8)?,:C/%2"f.?]/l;b/E*F!U>ZA@ZhGYeIN
+%2)Z<bg=Ds>WZjo5a!tVB=uPih[98`mG&(H9IBI0%mrZYd'8<KQ?F`fX6\6^8;2;U<9Z;XW#ZIL%DCD&D+tNcVqG\tg^ZFnnhKW,"
+%9pp-rM*2-Q&\C=q9t%^I=8]1Y9JX.d$!lcTLi=2hTW0/<8<Xsl7!O@Phe4S=Wmu\c*+A]:O26EB6ALhC412+f$6igGB,e,D^`kBH
+%VD0N_3jICSS>@aU'@_]'EVhZEZ<F4;_5*iaJOrr>giB<\=*4*bgC7b'ZQq[ZL,+JgFS.!;GuPX/cE00.X):oGbD::<f#q&jn1%9+
+%)]0QHh+=LV;"<46N!rq>&9\)VDI99D$5H'U2%hr.RL5/E(m`j7lDiPAB92;W#7/FR$(Gq9:pn3iU:95=>=P)-#K?E$C:6_^)B:Oh
+%ki/2I3b'V>7r_j>n8$9p5_qR>@T:SYb)S'Y`fkQHK`tR%8.eiacF6#O1<F?B@T@=e`2alkT__LdSkeuo<$5psG-$g\n*jg2WBG)1
+%4BhHY$g]5&1fbh('ie0Fd=GoaNQc%KC-X`XEjD6SHBlL+XI^LtBA,C$!5V32D!r&VPd]F[mDI4RpZtMM/`)#fdhL/MK,.a2r8sNY
+%LKS6flr1>"-BZuOA@b3m\8L9LlFL;oRT>VpS9jC<kg32F^!Iot(Q]ZmB#MN-cKth0VFi]SEo7d8-)[S'cEA]e^Mp7q!1i@635?90
+%HAC7-cEBL2$kh`CfVU(6JrURuS-7_g<$0@'TO0`22aa]H5L,Gp$DU9#<'ruaEm5K0^FTA^<%U'o$m$oaab>JB"#mDrcQJXb<+bsg
+%RH<\<4q85BdT;*:7oG5mkRbTZ+2mK$a-0@6cnu2=EXYX/N)%k']h(re_Sm]-..dB3YYU!70c>WRkal?NBQ"+_"'?mnL?t$-`DGOK
+%XG#WL^@[gn,G[rejoH5N(+:&&8Y,7EEVSeA?l59SRW+@>m9_gAaKWSc;*)MCinPA9\j\B63Y06C91"U.J59ggM)M6MW!ObYLfb%E
+%YClY2X9+)jHO74_X;=B+5=cZtR6pfWUWALT2mShBKVV'?;?hW(jYp\l&V\<A]seWORCR9Eg";png`TaAGXrKjV8WoiGf@<8%Ic?o
+%PG`:Ej<l+:qM72-&R;X=q?"uYE7?_Ma[3_Y#\ZcKRA[@n%FA^@J](>r9+D'n0bn6RLHXKJ0e=GroKS:bG`'I63g%HWOifR9VDPUr
+%LGVkj^`XJWEA3PO6ageDAd%Pu!?AE#I8i+Tn=IRE7ZU$q'AsC5Tq4\>[\M=r2#J.a(h:!>TFrC:*"ELpl^6OKipN3M?*nAf@EskJ
+%!r4jSafQdt'kk9H@+Hfdpu4ho[9DH4eQ!_N,.)^IK+hbd6/nS]iRRNu5Y!P%Tmh$`,g@"C4<j!?XuT57G>d`8m>;:TDD9Z]I1Raf
+%_gQ64[<XrTHB`3$/J``p$=/JnDsY1NWr8P3oYZ%E+9(Y7=$QZM_dBf9rpo498%5[/4ob<Tmd>=H,JoM%cRs-:iqNHJk2uU<q".D?
+%J)CeY5'[$VJd!E5i8=OHr:5ol&-'>!rcC\dh]2XU^YIf4,5o".;55g(g+q?IT8G[:UBRedI's[N9F#CLnZ@t$`)@s@bF="YJA?QU
+%4bo1A"o?Pc_TrI=QRs-:Z_bV//EYpC&,ak)^U0U^kM"lj<-+``NH"PlRCUDibEJ8g.9Z&DQ0cIqUV>AMrAg.F?EHf<,FNqBbK'1c
+%P]2p/6:m4%'jZg+L$qj]U?/\F].uIdW2]rOEq^?k)-[8SoD.Xj?TiZ)J>`I7WCJZ+j_r)qR-6J!"!hTHRW-CUX*4*qW;>]Y71f#$
+%/k\@Sdpt(4lC-&kPNc5M<h\Nh#;46J8_Jjk$;RZ8Z5qM6.R&%;FK0X4k:M:[c8C*-\!66D)R!eMCkeiJOWLU8)&C'o8-Qr*KuL8i
+%&s*3NNlZRWaKi9KF,VTq(?AkN\Ad+UBAXftA!o-]WnEDbNog(Gl'9C92(%H8T`n.a6aH7C5-.9`J)SEsc((VOlUX2Zc)gAm3M><o
+%!%c*C:=ZGM$0(O&eA(^6BbkhcC.XdaoKV%GW(p5nZ5=jK1hDr0-o5).9_;_10Gfl$Zj)54M%<mLddCO![;a]mpZM5EeRD4r`VNcm
+%'ZQ3tB?gW#'P>7=J$+=M\<Ug9!TJ*:;:6PDl;WidVa(K,eC"=c4Z>-.K&IZa,f6$-9-0a/!gr2:6s6`Yr&E*OaTi*76:k^V4doup
+%;N5\RWOjJB3Inh]ZOGc<GGi[$&trUCOjl<"+\B9A!c3rM.Ha^5#1d]brkn1+kC8D)Os/eY2:-J<g!.43HH`%uYC'C39#9FXZ7bsr
+%PMAXhj&IdRP]!%q?)Sb[@5`XF'8k@0k,5k"[4A@q/eMV#SBIG[?P8.9l6MKFa'#g.%Xj<rhj34kY=rg]Nu,dc<._ffQCnYH"P^>p
+%0A#ijF<@e``2&]gOElXUSY_hZXC:XA,U:H7d^[EYF.O0i,t(#0gnm3/]X-RE?7OkOP]jrYIOSG)+s`q`ZY[s(qoEmZc6Hu]U6<-1
+%$Vgq!q^=.d71D+#CE/b6=:O5BT"Afn>QL!*/ShQZ-)i0=^=bLC.6TfH3T^&dGh_<bB@,NU!=gLr6hn2A8j/VC:77KO?4ds`Rn;9[
+%G7.^ZYj?D!%j(+1a_@'cPKOS1\L?4$,TDGR$e[UIE(SS8Z2Ma6W,3_\U[:ZNC/+ck-b$^;Oj/$r2mb4j>4o\8WTCVNE$=+5D+76&
+%b`U+od8rW"8<"\>JPkEb0ZY(*>drkPg%g_^_&'%$#B8a8#7J_0Z'>3?=q[/.iTQLu8"NJr_pOXDRpHmmiMhsfVb1?<ob(ad]:,re
+%dtd%M7CB>16YaEB1%NDjZ&(N=+kI16du%&`C)q#a4X)rS&rfG\8t,Gr+%0EOSY5i#Ge:?Ccapu[;gOV4E-4'")KjT5SEocfeY`,S
+%h2!,*\hHZ6!me&G^@&PAiEZ;G:<(OMQm3[YY?)@Z`DeUQqm>HQ8]Z?Y>elf@W_nen^S:nd1@Yhg'LV%ISdQ6?]1eAPSUTh2f']PK
+%S_LeV`!iWC`Hnq@o+6EBi+IQ;i5=<]?X-pm?,!g/^]!c_D\g`I9L@*1GlR9L-[3%d2pW!&IItpB(Dj9YJ+qsjS;P%1q"[hWDjUJg
+%OK[qsdR-f9]"Bk]k.)O@QUr+'>N,(4pH>_r2_f9QRsqPCj$?D@&2LBbMW`5kGdH[BCBi1;Q_=tE:!hTiAqCi_Zq/MD;Xp%Sk\X>T
+%,9D!_E8,iR%MgFA7^>#KLceIT&P<A7r#1Vk2LZs+&!k[pW_Z>^E\Oc/$$t1.+ku%5mT9;sHi,H0B"3;YEbTOKLgD.DkMCguOe?XM
+%I_+.'T"!cb=UlG5D<J$FlE]NS&SCc@`A)5>'1g\O;UO-7*ghIO4X=&HFg?BFOOHq;YS[@!',SH)7F/HuG"'@k`klO$fJNUK%LjGe
+%0L(M+J2(qTE>j'_+aoMuTaHaI.o&Tcn`R]DN@"m!Y>D?iXYEq8]j1`sl"=?u8XOlp"md[P!FhI[L:<@#UDnZ0bRQ*-gh,/)7J\aV
+%I+lb=IIrsjQD9$:8V)&d0XV5D2m1Hc4GQMP,P*%%#iS7bc@6c8MmO0!!!8V9"V\J,8a^_33Y'<Fn1Y3Z,OubRg>/b_RW#QG`76O/
+%dkXf8H7q6eQ<K4LKpKk<b3&LDE+oBK_Jiq1j]5g[+uOVUKO>S-)0i#cbn'qP7:?R1-5bDk!^`T&(pdq"MOCb>V.bt8CgS?Hq!;`-
+%d_o+[PnoAIB-DP#jQe'o.4hXX0^%GH0*]q$eQe<HIlT]*S$jV5-'.9/gm=\Pa9)nV6AIZ,^(=C38S6&O;?:Ta2TZ%'6<GUTQ00T:
+%KrfUoIe/F1KE+;NI@pY17WrKt?ekgleg*)#dO1rb.[sLb2h0]?e>3!J'hb0ij0HMM?+R"9ef51DU_=?k9%3/<>Vm)I'j<alN!T`3
+%Q-Br:DMEf]=:=[HJd\d0?,5h7#n=agSH:u(MQ^]4(uo9NCBLR@\gp:T$?^<eZ-=b;kU^A)5QqF$N0]]Z\#?;nKP"*0L5r(eK>H>g
+%98>l7.I+dNfoTR<hN.VS^XGsb$FqPb/fYZpeU]uo/BTa\[2XoY^V=]t,=E:RakbUkirFcFg:V/SFZ.qhc=mk6<a-"\[6UKd8PJ;N
+%MY]RR3#60*&BGb<&Qt3LE]DbPGGr>L)*5]]gDunQop"kl+qFhJ7NdR$H('@UoQM!jRlIMu>hrj+-Vf0"XNT67B8I`gA8Lh85a=J9
+%g)-/L\*)#((aKYuKS/8Ii*71S-q.[CAhD.j%h\N*:bmf_#qgj9M2diG"Og*c6t$?&@pq&d+!+,i2^;eT#QdFK*"0AmT)b`BU(0Y3
+%C!cMDJbG1UYl6gi:i4L<liCXHbZY#i?U6ic/C_n:1^)a!,/aRic\[sa+Iq^om8Xc551nsl^HT1:SYcUp5Td^jJH3E-dV&nd\)[]9
+%We"*+Wg>Z(eHHL.\[3sHQD:"peK6KMHqP<Vn[0b'l1\g0WLs:(go4U=;t0c(T]bGcH)pF3U>O2236bk>1T+hnZ=lJiWn#XI+"1A4
+%pP/+aE*@>G`c`KA(ii%K%S2ctkDedoTC38;@7E7V1u^n?+Zb9IIh\cq7KVTa1nYTfYYYlJNiWMk+s,-lS&F62-#j+;!MUu6QuR((
+%cHp%R^%<F`'u6iETc-<Z)Xo)5"q+,hLakoH"G0oh>cYkQL,KW/(ai?_Eb%19)s\/'+>MO"e6tk'L<*_TWC!X\J;UL91gto2aqMXf
+%fukenqHpV23c+V5HfQ"7_3kX0Ea]#kp9]5cjW[X=UM`n+CU:=&W1[buL7ifRW<B^YRFDVo3Gl?T!P:Y8Ksee6IhrX`.seMHHf)SV
+%lcEJh56;\Tp^!9!..b>];IngT_fuc=grh>#KRg=:Ya88j/maD]^]490YBBEJmcVA)kK@ITrSbT+oC1h"]k;MPkIVVH9#Sdthf2oH
+%DN#`0>GA[-@U3"LEl;,[!'6lYc86iba^DWF'OhA4C-&peKSh:.=g"&NNf:uPFc',G!Qdn=VH.`@3PWCN<mo*U<)G=!ipTi6j7&:q
+%V8$/<Un/9)SJZ$#nEM0$SkI1hTi+"L!4"(O'^)71@:+eSPA"B7a;1hnF9kKsbO(QRo>RC0M4qRA$<2cgHAcf]`CQSXA-.'*Y36'j
+%'Hk34E@G7el%[a-8DFY\D=nFmAa##qVIhXo-/iZ8YmIt1GL%`8C:>u.H!#/TGO#`e2;N)[=:;\(3=+UCnrPZ)e5Yd,f8Qe_&s;sj
+%[2KKQ/25%d],8S!qr5]YbNVT@LtRNCAKHi-39*t/r,bqQOrZ;=&Jd>A#XLu#"P3fdA18_D<RbG0C0hAVKZ[!C&T(TjC+l^O_[fFL
+%XIgBX['Z@rSls%9EIk597."+N$K7eh">rmfj73[CW<jl2$s^.mX'Ggo:Vsq+;*EJ)E!WmQZqC%Z)k>5J.*/5PJ<m3i*UpNOI*uG`
+%L6`'+EOAh-N>Mt!fT]o06p"=uCl&W-#l:5V!1K`J<4Zi:TJhl79IJr/l`aF.2OG&VT%3GR.d"t%>7;uF1!C6=p;H*KrMs&s#pS%q
+%:!4`uJ`fGD.Z6d)690UT4qDmjDl-6e>ul>/D46//$5Jfb<K*+N<T$/dMX-^LG(rYQef>L$%LuI*Yo8EiZQ["F9tR,'q,i+9i4bq`
+%X1[W_-X1o&:FH%S//EB*jC,(79*I"OFj2tclq_64Z;=,2=--sL]3/1"TEr`(K[p6ceq7fO`:qB8GYAj9;1U'hp#?T("nO#T0LT2N
+%!+snQR)$\ZXK*OtWuq]t*M1=!R]]1!e3"4q4>X-@YnQD*blXu)!rCtaR6W@EN/+]cC![H7eU)_.Zg\M]\p!FT!+@\4'atSB:uG]f
+%lsO_JR:'-;'.]J0%/-o`-*s6V9oP&H#W7C:/PY_CHJXZn:$K7`-Bg[,1NNsR\-/SXE(c?PM_IX(B:%l4UKp>>DQ#P_X:-l3p6b)6
+%Q^!V</u*U7lku<mHoT&eH5KEjGhND?>*Rh5-bF?fDMI<pidk6Y;"</S"s4'EJM::>SBV+l7n=Yfhbt-f*rP!7QO3_![([W(lrH40
+%K/S2!+WYADKX_+>=c\&Yp@d?^JYfi,m+p6sHI'QDFKor.<eL'UIZXruTSW<cA]NG^8p=RRJ&6Ric'2"qT>*L;FEP6A\pVT^^\WXX
+%Q1o`UDirrWq;lUb:QC0W;%JEmD]]7NcOn5T:Lg#^3C@hR,Tqhr3*YB&!X:1Q\QbXP!c=eM-D>hm4b8["'G4eBk,<D8C('+/"QKqC
+%At6/11]BMG^kD8qd+Z%3okU^Q56afo0@;;'"(-6>0joZ?G$oWm]@-@A9TCj<m^81@]S`QO+i?P9,f+.;F201p^t*=j?)sKKqKh(&
+%7Ej\&blDUg8p#uC9%0Ot8`]QiR$pK1ld8u!^@sZfJRM5g0HEO2&3\n3+FZIH`GXOP2$:U*1%JJa"Q``5+i]DQ%]cm`==6S?-F<tb
+%X<9,"T!hf_5!saRecHKdJ3,MgU?q+1W,sru10BY?@jn2!4BR9E[7K\<]M'Xe%#g^q>'OTB$aPN4/PRh^5Z+3a<^?3WPU1F9"7n&n
+%2'Lg0@l:($fTN@78Ob(_EGL(2@7.8HD,tb#FfKQ<Ii5<KY!LFZPhWQR&?N)Th)d4Ul]mhh-@5D4m82^M"\UB!#7A\V,PJ5s9,oe2
+%G%\7:;6(#*"W/kJMrfo'>+'h;dfEPY9IMJXCKG(;GGeVg@mC,CHS"tI8_$>:ZAh`1o3E#mLot_R-=3"FIRs82]eH6SF0""5</:P_
+%K09fX2'Ua(m$?p+hg=m$/Z)IZio!ZW`@tiqC>$d)-l$8c4"up?SXaHNp&+gVpVV3grJo>:"gNKQp*FApip^W=Q6C7JT[jAe_3)ZF
+%,?DH.RVa@@T_/lfri495g0s\!m#3,?.&qlOC/'L-<BJ*'QIJ-+a?=Sbi1%(^.oep/H-=(J`aT(Z:`+kXNb&#S)]thI[1XjJIesf.
+%9'X@1+L:+t)Y5&7GQmh/rg;a7mQ4Wc')qEn?JKq@I-8-';a5XX@QnhYIsCHY0;l__a&fI2J,f5aIig?3*k_7+dhbf?H5-D(q9A`A
+%j6bg7[ni'on%\[:#PmE?o;eq8B=I%WT3ko<aksjXEV7/A*'V(uI!Tpanbe"u'Rg#NnA0HVhE-&A`TQDcD^mD/",\.sZ<YrE#K#6I
+%*V**mX#f%M^3P&"dKd)4FnCk*r^^:QX$YM$3d!Q4I!P>QT?a&MY>,g&aa^f`J+_LFo')10'N_[qqL>-p4?\2bo_(L:X;@KLhc/q1
+%N_bZo:Tg!JHuS#tmP"G,MlZI(=#AIa<8f4.T:FfPi2Ws+Di]\2+"sfMSfd?f7="k*L:#7kWVDC,++Lkd4Ah!:RYq+@`Ug.jRqqou
+%j"_e8U8e`2/M2<j<M*OO^::b#prV@RVg!2RY%h>ApW*;N`H5CWC>\F?nWah.+7W=`Im%+tmbV=47k\3+5*99g\YO*`c7Z:QNuu#a
+%G\#N;[E@C3[b+B073RU=]DUY!+6Y;+=WnbF9-KOQ/o;c;5^rKY2k<@K%nDiST9^Q@;X+^ZUD/VZP'X(48%kmg?a\:N`Ns=T_106k
+%oju!<)s.*AA1@@.rT@TlrpPK'5.o(iNC>6)qkrJH0ImXio>pJe+,n$?oTu1RqiE*80E9+T^?]2IMIer&<PSNRm,n0Js#9N3:LlSP
+%cVK-T\rcabF$h&&n%LC6gYBE5!Ge6R@[s8&/P@4Ndl(hTA0U%=l<U0;YFh7jI*+SNZ$Ts@pGQ`;pFX,&IY]I[C#S`o=BXCS;lMg7
+%m@fn#5)s86.a!-R'`#8Gq,*7Pd*&n[mh$%<lHO@iF`6Wk]@9$BFSF3`lmgHLK.UR,_#aRH=ea)8bC='RRCVj'IZ&Ok_jeoJ-"So$
+%e-`\)IoB)"I<!_hrp;UpGOJ6>ij[ZqGtZbTbc<hTH$2HB/p"p[PI#lO%\$nKX*-1$K$VB"&3XM4*V3Lc\=^C[khjt^]C/k-F@a\'
+%o9!Rq)#O(gpuuEMr>_`-K+(82grgTk%o,inNS/AS\r;Jm-XZ3L^#Ob#VF.%O1OJQ.eBp+%Cq:_b>.?rDKop/E/%&jm:5S2Z?bRfB
+%ckelZDEgmfg-7IKQa&_JHbOY"hW<8!k7U8_YT"X-CAFb\rSdcFa8Z["d87R9c/US%Y?h^<ooLs-O8&Hgkd=jTiT4/:+*gbI4#D6W
+%f0>>1iQZI3QHQOl28>709E5#=q`J/lq9@)uMnF&?5bs(^a?+lift@%*W7/ri3reY#]).a/6'o>;qo:(.J%dtXHLSbSDdNA+L4;5]
+%c-kZ#c]7W(Nm$DSfB5):b@,<L[P#brnFHl,I!BXTq=tV65C!+cqW3X3m,)/VdA_,2qXO1KbF=+u&F'(to4a>ZT6f^b]CUs,^?S((
+%nYVAm?X6us-fee8NiG*%IW9^U]RBIeW#^6G]jEBn[@>)0'-72>\W$8\i2C.i0Co"`].4qnPr3]pJc>)I/D^&<c_"O,[H?W_rq=,r
+%%Y+@`WV?>amR/"\T<@&+WRXX4I\i[s+Pu3F!AJooj^"HLV;BMd:$)BAl10ShVh`#M4?0udPuH_07XVR:g;A:;r9F(#c]:$"IJWT-
+%5/!Y:TA88:q!@dq%L2q.lF46+G1U;fO%qKnJ=L<.EqPXN*Y#uif0'A.etQ3Ql]/@IkWb><om_;:>CO;)W.,%+Jt;=+qW9j2pr1M,
+%f9^^Uo]>I(3]dV]b,"/)`W3[-llEbZO5E#b++3S$s*_P):%..-n?Z=npsJ1>kI7ob3pl[#mdFAnpYkF6DpMcT^IRD1J,L!spZh;W
+%*qj.U;p!KMZCii`.$.N^GL+%YogJ$Eg!\H=&gmq`N@=RNI9Kj0rI"J\MehbE&+Ge&+4D$cn,/)m?-W35NrY1KTS)ckq'Nj`kC=Z@
+%Q>h!GqVe',Qi@q$I<bYKmeH):dJ;&9GJ$FnVrq+\Q3Z$F[?7$HfmVJID'+6jarOhqhRkmU4oEplm:TcG?U$X*iI1O$dpGbi3/WV;
+%qBab5_R`7R&:N24f.eBF_fE0^h=AV$3NOj0LG'UI&*Af/;Y>D78#ha;H+E.4X7Nq0]((^%="gc&s"(q!V=+>6I4kIFpO8b,e+`ZU
+%QP7p^s6!*`WrCYbe9?!oGh`2SrNuTshZ&(Nq<H)liq`+kE@^r&:=`cn_L-uZL3I[4qMUEe?gT-;d1b8n5'jqjK_I[@5/071p@S:U
+%ZXnLi83pZnm$]G[LH_S*`;I#Z:_XZnDj#U"oPCMjUQ>EFV>5#\A,Rb*j,`tn'DXk@C$($5X"U&Sq!!]dpE+>L@dm5YUMJ6Hk3gU\
+%_`>l%[Zh/ad#K5!/r+B/Mu<pj:Bli,EP/r/Ie0#R9&KRgqCZm5[qbQUpF>XMIWbJkn_;Z>=-kkq,C4f_EVT=Xo;@AiO12;FQCG[R
+%H`R[kIW9H'qKAk#np%@;iN4'k9pn!$f#3ub-;LmVhpO'd3PKg9L/3r'5C)q]lLisFJ$99H?@;9qYo3O_/bf_Hg-=AaJ,]<<-)";!
+%hZp:W/Lm^\/9A"%nf(G'heZrRI@YXB*h[G\1HXb)3qI6Z+5^sKg3oM`5If"olcK/FB!1U+Z0>Pb]0kS12fU9E6m^qp9UmH2I0V-<
+%3KO*tp;P4m-dU,2^A-1F9_-<Eo;hIqbLq\0K@:'h?'3U6PD[8ro,"l`QnZ?spq"pqaKLmAHLJu+%JRhH2c$S_hm-X7iQlF,j&$q/
+%WleY\4MP"oEF5;Enma&]jKl&Y5(%KmFfQU7>C5o*p>T;eV1*UnK!WY$o>@c8NYe>$qWg-P;#[b<C&AJ8g@N(IF2>>$62[%B(V>$N
+%5C"o%pYAL5>MMm>\I3l_l)Whb!PY1U]o1g*6DlpDE9O,o?eqi1I=66`rP$KJefb!@F8,60"&qb3T-]=T&)T+'i^]pt5CS'1F168Q
+%YN=p=P>C9ZZ*<]CNU0ij7)#Js8X'=P*rMeoCB#HEftID4<om]-GB]l!M,>VbW4lMk]1WCgY\?=X0E7$qj6u_:n,3?ka$9AuhJVZW
+%h=91gk/iPC?SAV.0AeVqnZQj5rF,!/H^@Y1`n&SM?9f-1qe^&Z+1=K%-T1^"e`8)mC&?BFgJ<=IOl+\8j.0Q$Hf6)k"FF+A6QtEt
+%ImsC/C`T5\^4YjGZlT,DmI>Gr`T=/4(M']*(lstI?60XW6?nUH>=!o.NCQs(N(6k09ed$YRDnOd_D,/Z#]h?GkA3"kDNaf/jh-g^
+%eJG_8ALF$Z-gHU;b!dr7_kTnN0jqqHFXM#7Ocj(i0`OEgmZ\"$qrnXj^*e(u?=^YpPAK"77CHteaZf`JDE-PCVZ5]3a8U1pXG+Rl
+%FeIA3_WP/:):2a2QM+;\E"!oO_[e`JgEr<b1&6QR66,s#Wo15,0>@3fXSd;*:&F#2p@?=hje;;-PPkDUa7IXNcLoMjaQl^aP_8p6
+%Z-u3u06`i#qjpT.hdlk\hcr9N#qg-s^V4r@[s#V?<NZLt+)epGb3+*krr1BJq.\FX1i%Q/2;`WDhbQb6^\#URS40"kY:b;]E?h37
+%rr)E@(['+fg?7?H00]8BBuW`81]?hbK?2XR>I\"^hlT;Ua/]_F>"j8<o\&bO8^4s_4nA"iHbLSJKIi`iQf7[re)dcF3ra.6kj@]^
+%mU"dW/n^(%X2EWP`Ug_1K.d,gFGG5c*!Yk[r9)i+lV")WRU(gAc[SXf`W&!3r6Ci?J"aP9IhN4YHfQZrB=eBa($kb@b>7AH*Mn,C
+%_"7KF;u0Ki[ab)96htRVl$imZ?Jg2blu,+&cgOPS5/(2I`VIcbgWNAWrCMS>Fb3IdWS5>mCQ0!4VXc.3=GSEC[3#O@9DFY<PP9-F
+%:^T@[o^<K'aH90(ImZ3c+5s*lcSr>RB?.&gg)Gkjo:6h8^2J\Ep9hX:rU"fBI=Co[k4.V9kgA/&UV7g?)Z^[-:N#U>Ijq>SS"TlX
+%/jXTDq1l83"V,R:0hC1TbL-o$,Q92J*?AK-KIHUCHcls!`piq;@fFYK<*s*[n51G#.!PE[C0[osLTs!7Yt?^As5nSHI^#%H<WJ?o
+%PR;-Bl!T88HO1^A`)c:*=>\mZ1(mC_CXT>W>[G1X1>P!qdGcqWH9Q#qk!!*n`nf,_cD^BYS#7?35,Bo,b4P6"eT%!'gk_#`4HLhB
+%rp\coI!kqYea`?Zq5VK)s.[p@[oX)`dZ6&Y^<dYe5Eh&1hggR/73=D`6Z\$T*DZR@csOtEJ#1W0Hg/8Z#5W,fs4+0*MUJ.=Ie.b?
+%D>um$`l#_^,6+B(bC>"bOHReJIou\]jg"rA5@a\(Pfcs2*jm.-/XHj?[Qq5(X_i*K^%W&Hs52)[n_^`SZQ=,Sh0#d*?u],O1gf_,
+%/1m1MG!-0;[r%Fs$Z<=e5bUE+'EcP9BtSmN.cS:%eOji)[-7)PDuMB?7qeBO`+Y[,b`50rNRROA-lJmC"4cYRU\Q_0_#=!#r8uZE
+%T4%YmEW8V40XYit?,QBR>$:i:e$o#IO)&=+NUmtKS;ug\^KeLGV1tRcN2AG=Ckd"qk/RD_mn0-@.]nJJPif5Sri1[[[@;.V`OWr\
+%-c;]n;JOSi^Nb2(7(toj:!'B&;jlY-kr:P<.[*nSEGEm#-J2GTl8W*5)9[E6+P)$H/V<Yfee9-T',q?oY+H5q!W@0++L!FJFf\@Z
+%qT#3MW9f(q*csu'A$)XNYm)iXb4D[g(XI"1^\ZKIe[-f@22q%[06r"!Gd;B@p>@m<A1fmRo&AfoGk:cDfuK_U;lIs1le%M0l="g\
+%4T(c`YWb3J54_b`o$>nDIGuEMl74k8kL/uVB'jUIkCi>C;oS/BWeds%hbja!nab/<Cs)G`WogAY!&b?a'u)uJ'ft-ZGhU:m%t=G=
+%SMbA^paV[RcRrS\Xc?2Cna-6GPF8Oac#P[^j8@5n(hXqcIPSh%YTEe9s1*ONropKTN^*:[8;!Vr2j'^gIK/l9s$I:/%<puo1><i:
+%Geh%"hH@BCr57o[f.VVroBD/d:">qe5EV]#hd=,Z^\d$e`REF<lqKK&hY?5['DUS;^Nocm.<+jS+'i29rCSa?n5QQ*]P+>407;$$
+%jRmc>-SLNf/DC'`He*[nleu&/6T:B6p5TZ%SmBan>\<-gB(M&5hqik#,gnRHM\d25YEulm0@'%3+8kJd+5lnT1./h$pTU:gZ/cn2
+%?5o4L%a4P0abs_!+"gl)]sq@4a6f"mP&F4gg$S<So9NsS$gCNGk)_pA^M"GnpsP=("2;//BRmk,R/B*@J%o2_Niuc\h]?\grk,o3
+%o'$/jrh'/:9FFhhjn[)21;193I_Fs"A[nR-*7o*Yo\7uA043TWIWnPfA^R)s=8gs;nS%WTc`:]-F'PU*S"H&er:d:]DCF,\s7?*b
+%lLOAhLU6%(a"&V7[oDt<Mqb/MVu6F,E\&$d(O)oEYBkHbipbt!AWbFM4C$_o,Bj%V`N.1oUK,!UI,&qt1\>=<jHJW[l^*eZ4?NT7
+%n^_TefZ&_lC&+j#DZ,YgHM1lHbYO8B6,C<c34kkJ/.,lCa%$HZ]CY!bQ==spIihD^j)T\GnA4Dqs6g'd8fup(p#SC4c?Flmo:sa"
+%+0J>&;LXkREe(iLYl)Y!q\(0#n7l=^eV!#qrq4+PK6;jUkP'`%Lu4?][3;_!=-1@,L8:?*9MbWcKE(V5`RNc&+*giC+1:+gOG+PH
+%;;WFKhV.a1X1EO`'*$&'&e:ZHf<c$9%t7lW=`-/E[Q9[VL1O?mINS$0">-l>XK@uk>jQc]p#+;1A:H>pDY-%Tniar8$c0s^lD$r`
+%eb8lR&L;g>Lo2#^%bEX&n"W<W/=`J/o]o]Mq_Z0=dh:.bg:H^u`NG!GoDeL0b67\G2k0g-oB<hZ&djEHmZV1FD!I]s'pbojh"YZ6
+%DO+OqA=5A'WV8s]1h4pb(p2VU"D^qZpIXAQ-U[J!>Uo=(NJ.ee>^Ht(O0/sqa@TEW9_p&/Yd?O^\=8.&g4_@$C'j9)UHa`^6*`V=
+%)Q"TKV=J<&7Xqi?kjN2@4[7Z3mErn0?IH2'ksijl^==t_R<=BL[?p6eN.-:KbN-1`1:aL<2LZ``!#"K#X2?cM^1YkLb8>*'9T&.>
+%nG@G@,\W%b1"tp$>%T!6/Hbgq19#0!bVEA&[>j(A(8\EfYW>I1T]\\c/>KQ!1-)OR_=,hYkB0G!%VtC-58UpQc<=gop.!4j13?+p
+%pIU+*g!mp?[J6ki.:K8g<&3\PI;1E<Bc1d(Uh(Yd3i/_N,]VS&Q'PQFmBfP=>:ie.7a%17<kh5!*ip.++82j/bLEcH1=`M6N;blp
+%j&T@'Sf_h*p?:L(03QKJ[+-ohDRGEoAt:,Am3OhGUE<ml1:;#-9QTO-h0(l+F)1_^FdNB\pInb&)5E1W.<SohWS@/4JsKLZf%*QF
+%/p9B7/Hbgq1=^<N9PNh#?.uGMD64n]%auQaq9Un?k\RV"m@.:&V`75o'!&q(]'7P[Y(s?L.;c+sb3n?=b'fGHA]j^gZ`M`D[p#[-
+%s*^E^DVHiVKV-'Ki(JUo</XC@k.,/W!%ln+/_XE:W.G\uq17r44FTkkSE16EgqjB.gnht#jN,HYPfZP:PWYsG$tXG`'kN8s9F8u.
+%-Lf-2j.'T!?;-c3i??@bb#ulc:j0T')%RVhr4lPPA`@;JaolW2PFJ4=DAUH'4=JZX1d+e!M)&MaPR/R5k,d'+3KIp?L,/Q,:s-kZ
+%,Ke*MS%Xe>p&L?$#E8b9jEW5t`&/a]K[*IB2"ua!'ZqO&-q!Z$9nf66d?QKW!_\aacL1)Hg_GIJHpA)OUf7iHUt)`7Od2:^BNH]8
+%-52B4\ZV>UUstV8N[YY:j<>W%TqEfF!hX?_A#b).PK$a3'LeEf7^Yi_R?E,!"q$_AN__T1KIa#NPBo*NELnTmYG%7;&3q*]KeeH^
+%pn;aXAL)\!L,/9rW$tZ6Qm]A*aGMCp<\us<AU5n<j;X9kHt1;k`KWKb<=EHeN"k#h*;cheOj9_*KaCdDgkoLBB7d\%-(*`A!gH#*
+%`$f^Wo-hH'qHJPCf@q\ohasK*9FsR4F[Roa$GiC=F>F%DQumuB7`Y7"."sg?!BQLgQ!eTSLgY,-;&l2>Tp/4^"1_;m;c@*nY`uRB
+%(_l(snGNbfY9`%i;g`%CQsepA?s0IRPt/6>+ddL$R./p)4J/.:#ZkI@(4.nAo4o[T^ES7q!*Ps/oH4LnKXiRa`N;]7o?Imu2_e*G
+%QUEMK\Mb0scW#06QtL&74?L_hWL;c!=lq\t17k%Jna%f"Dk1IHFV",q=k4E4LhC?\XV"E"XL!koc6LnCeelKYZa7j_.-&u`(=1:3
+%Gj?oUXVlEM/8GY*`3Ze?<ei*P>A"i@C5"alKUl\WB5/ot.HB)aL8%B+q0iN:.H=WF=aG7Wdl='qcd$PKeLH;/4Zgh`PUU*`EZ4aQ
+%`,SPWa4=CZOe$&$a]VXF]72)==egKhA*Y\h^s94o``XogbVL)K=iY<\Xg?etl*:#p#g5/FQTosN^>l,PqQ6"2)o2)Pqr5e24+H"'
+%mWS2NYruq&Uq_;'GW]l(o2GQ]HL%("8asATgck^38fUa?T3e\X>jljN&'+Vqp:?+.Qg]t+rr2=/#$>d+j)Y,X:V#ZIG4Y%f@2jQq
+%?g75I]c=c#O&O#X_^cb"c<lf\H.&`h2co+1mOs?`;J!'0I[ApT\ef"i\G5RhEq(5%Sh!k~>
+%AI9_PrivateDataEnd

--- a/Papers/quant-ph_0405174/circuit2.eps
+++ b/Papers/quant-ph_0405174/circuit2.eps
@@ -1,0 +1,3178 @@
+%!PS-Adobe-3.1 EPSF-3.0
+%%Title: bild4
+%%Creator: Adobe Illustrator(R) 9.0
+%%AI8_CreatorVersion: 9.0
+%AI9_PrintingDataBegin
+%%For: Gerhard Gerlich
+%%CreationDate: 09.04.2003
+%%CropBox: 0.000000 0.000000 155.750000 49.875000
+%%BoundingBox: 0 0 156 50 
+%%HiResBoundingBox: 0.000000 0.000000 155.750000 49.875000
+%%LanguageLevel: 2 
+%%DocumentData: Clean7Bit
+%%Pages: 1 
+%%DocumentNeededResources: 
+%%DocumentSuppliedResources: procset Adobe_AGM_Core 2.0 0
+%%DocumentFonts: 
+%%DocumentSuppliedFonts: 
+%%PageOrder: Ascend
+%%DocumentProcessColors:  Black
+%%DocumentCustomColors: 
+%%CMYKCustomColor: 
+%%RGBCustomColor: 
+
+%%EndComments
+%%BeginDefaults
+%%EndDefaults
+%%BeginProlog
+%%BeginResource: procset Adobe_AGM_Core 2.0 0
+%%Version: 2.0 0
+%%Copyright: Copyright (C) 1997-1999 Adobe Systems, Inc.  All Rights Reserved.
+systemdict /setpacking known
+{
+	currentpacking
+	true setpacking
+} if
+userdict /Adobe_AGM_Core 233 dict dup begin put
+/nd{
+	null def
+}bind def
+/Adobe_AGM_Core_Id /Adobe_AGM_Core_2.0_0 def
+/AGMCORE_str256 256 string def
+/AGMCORE_src256 256 string def
+/AGMCORE_dst64 64 string def
+/AGMCORE_srcLen nd
+/AGMCORE_save nd
+/AGMCORE_graphicsave nd
+/AGMCORE_imagestring0 nd
+/AGMCORE_imagestring1 nd
+/AGMCORE_imagestring2 nd
+/AGMCORE_imagestring3 nd
+/AGMCORE_imagestring4 nd
+/AGMCORE_imagestring5 nd
+/AGMCORE_c 0 def
+/AGMCORE_m 0 def
+/AGMCORE_y 0 def
+/AGMCORE_k 0 def
+/AGMCORE_mbuf () def
+/AGMCORE_ybuf () def
+/AGMCORE_kbuf () def
+/AGMCORE_gbuf () def
+/AGMCORE_bbuf () def
+/AGMCORE_cmykbuf 4 array def
+/AGMCORE_screen [currentscreen] cvx def
+/AGMCORE_tmp 0 def
+/AGMCORE_arg1 nd
+/AGMCORE_arg2 nd
+/AGMCORE_&setgray nd
+/AGMCORE_&image nd
+/AGMCORE_&colorimage nd
+/AGMCORE_&imagemask nd
+/AGMCORE_&setcolor nd
+/AGMCORE_&setcolorspace nd
+/AGMCORE_&&setcolorspace nd
+/AGMCORE_cyan_plate nd
+/AGMCORE_magenta_plate nd
+/AGMCORE_yellow_plate nd
+/AGMCORE_black_plate nd
+/AGMCORE_plate_ndx nd
+/AGMCORE_get_ink_data nd
+/AGMCORE_is_cmyk_sep nd
+/AGMCORE_in_rip_sep nd
+/AGMCORE_host_sep nd
+/AGMCORE_will_host_sep nd
+/AGMCORE_avoid_L2_sep_space nd
+/AGMCORE_composite_job nd
+/AGMCORE_producing_seps nd
+/AGMCORE_ccimage_exists nd
+/AGMCORE_ps_level -1 def
+/AGMCORE_ps_version -1 def
+/AGMCORE_environ_ok nd
+/AGMCORE_CSA_cache 0 dict def
+/AGMCORE_CSD_cache 0 dict def
+/AGMCORE_pattern_cache 0 dict def
+/AGMCORE_currentoverprint false def
+/AGMCORE_deltaX nd
+/AGMCORE_deltaY nd
+/AGMCORE_name nd
+/AGMCORE_sep_special nd
+/AGMCORE_ndx nd
+/AGMCORE_err_strings nd
+/AGMCORE_cur_err nd
+/AGMCORE_ovp nd
+/AGMCORE_CRD_cache where{
+	pop
+}{
+	/AGMCORE_CRD_cache 0 dict def
+}ifelse
+/bdf
+{
+	bind def
+} bind def
+/xdf
+{
+	exch def
+} def
+/ldf 
+{
+	load def
+} def
+/ddf
+{
+	put
+} def	
+/xddf
+{
+	3 -1 roll put
+} def	
+/xpt
+{
+	exch put
+} def
+	/bdict
+	{
+		mark
+	} def
+	
+	/edict
+	{
+		counttomark 2 idiv dup dict begin {def} repeat pop currentdict end
+	}def
+	
+/ps_level
+	/languagelevel where{
+		pop languagelevel
+	}{
+		1
+	}ifelse
+def
+/level2 
+	ps_level 2 ge
+def
+/level3 
+	ps_level 3 ge
+def
+/ps_version
+	{version cvr} stopped {
+		-1
+	}if
+def
+/ndf
+{
+	1 index where{
+		pop pop pop
+	}{
+		dup xcheck
+		{bind}if
+		def
+	}ifelse
+} def
+/skip_image
+{
+	has_color ne{
+		dup 256 idiv
+		{currentfile AGMCORE_str256 readstring pop pop}repeat
+		currentfile AGMCORE_str256 0 4 -1 roll 256 mod getinterval
+		readstring pop pop
+	}{
+		pop
+	}ifelse
+} def
+/addprocs
+{
+     2{/exec load}repeat
+     3 1 roll
+     [ 5 1 roll ] bind cvx
+} def
+/colorbuf
+{
+	0 1 2 index length 1 sub
+		{
+		dup 2 index exch get 
+		255 exch sub 
+		2 index 
+		3 1 roll 
+		put
+		} for
+} def
+/makereadonlyarray
+{
+	/packedarray where
+		{pop packedarray}
+		{array astore readonly}
+	ifelse
+} def
+/getspotfunction
+{
+	AGMCORE_screen exch pop exch pop
+	dup type /dicttype eq 
+	{
+		dup /HalftoneType get 1 eq
+			{
+			/SpotFunction get
+			}
+			{
+			dup /HalftoneType get 2 eq
+				{
+				/GraySpotFunction get
+				}
+				{
+				pop
+				{abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1 sub}
+				{dup mul exch dup mul add 1 exch sub}ifelse}bind
+				}
+			ifelse
+			}
+		ifelse
+	}
+	if
+} def
+/clp_npth
+{
+	clip newpath
+} def
+/eoclp_npth
+{
+	eoclip newpath
+} def
+/stkpath_clp_npth
+{
+	strokepath clip newpath
+} def
+/stk_n_clp_npth
+{
+	gsave stroke grestore clip newpath
+} def
+/npth_clp
+{
+	newpath clip
+} def
+/graphic_setup
+{
+	/AGMCORE_graphicsave save def
+	concat
+	0 setgray
+	0 setlinecap
+	0 setlinejoin
+	1 setlinewidth
+	[] 0 setdash
+	10 setmiterlimit
+	newpath
+	false setoverprint
+	false setstrokeadjust
+	userdict begin
+	/showpage {} def
+	mark
+} def
+/graphic_cleanup
+{
+	cleartomark
+	end
+	AGMCORE_graphicsave restore
+} def
+/compose_error_msg
+{
+	grestoreall initgraphics	
+	/Helvetica findfont 10 scalefont setfont
+	
+	/AGMCORE_deltaY 100 def
+	/AGMCORE_deltaX 310 def
+			
+	/AGMCORE_arg2 xdf
+	/AGMCORE_arg1 xdf
+	
+	clippath pathbbox newpath pop pop 36 add exch 36 add exch moveto
+	0 AGMCORE_deltaY rlineto AGMCORE_deltaX 0 rlineto
+	0 AGMCORE_deltaY neg rlineto AGMCORE_deltaX neg 0 rlineto closepath
+	0 AGMCORE_&setgray
+	gsave 1 AGMCORE_&setgray fill grestore 
+	1 setlinewidth gsave stroke grestore
+		
+	currentpoint AGMCORE_deltaY 15 sub add exch 8 add exch moveto
+	
+	/AGMCORE_deltaY 12 def
+	/AGMCORE_tmp 0 def
+	AGMCORE_err_strings exch get
+		{
+		dup 32 eq
+			{
+			pop
+			AGMCORE_str256 0 AGMCORE_tmp getinterval
+			dup (.) ne AGMCORE_arg1 0 lt and
+				{
+				pop
+				}
+				{
+				stringwidth pop currentpoint pop add AGMCORE_deltaX 28 add gt
+					{
+					currentpoint AGMCORE_deltaY sub exch pop
+					clippath pathbbox pop pop pop 44 add exch moveto
+					} if
+				AGMCORE_str256 0 AGMCORE_tmp getinterval show ( ) show
+				} ifelse
+			
+			0 1 AGMCORE_str256 length 1 sub
+				{
+				AGMCORE_str256 exch 0 put
+				}for
+			/AGMCORE_tmp 0 def
+			}
+			{
+			dup 94 eq 
+				{
+				pop
+				AGMCORE_arg1 0 ge
+					{
+					AGMCORE_arg1 AGMCORE_str256 cvs
+					dup /AGMCORE_tmp exch length def
+					AGMCORE_str256 exch 0 exch putinterval
+					AGMCORE_str256 0 AGMCORE_tmp getinterval
+					stringwidth pop currentpoint pop add AGMCORE_deltaX 28 add gt
+						{
+						currentpoint AGMCORE_deltaY sub exch pop
+						clippath pathbbox pop pop pop 44 add exch moveto
+						} if
+					AGMCORE_str256 0 AGMCORE_tmp getinterval show
+					}
+					{
+					/AGMCORE_arg1 0 def
+					} ifelse
+				0 1 AGMCORE_str256 length 1 sub
+					{
+					AGMCORE_str256 exch 0 put
+					}for
+				/AGMCORE_tmp 0 def
+				AGMCORE_arg1 0 ne
+					{
+					/AGMCORE_arg1 AGMCORE_arg2 def
+					} if
+				}
+				{
+				AGMCORE_str256 exch AGMCORE_tmp exch put
+				/AGMCORE_tmp AGMCORE_tmp 1 add def
+				}ifelse
+			} ifelse
+		} forall
+} bdf
+level2{
+	/AGMCORE_map_reserved_ink_name
+	{
+		dup type /stringtype eq{
+			dup /Red eq{
+				pop (_Red_)
+			}{
+				dup /Green eq{
+					pop (_Green_)
+				}{
+					dup /Blue eq{
+						pop (_Blue_)
+					}{
+						dup /Cyan eq{
+							pop (_Cyan_)
+						}{
+							dup /Magenta eq{
+								pop (_Magenta_)
+							}{
+								dup /Yellow eq{
+									pop (_Yellow_)
+								}{
+									dup /Black eq{
+										pop (_Black_)
+									}{
+										dup / eq{
+											pop (Process)
+										}if
+									}ifelse
+								}ifelse
+							}ifelse
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+		}if
+	}def
+}if
+/doc_setup{
+	Adobe_AGM_Core begin
+	
+	/AGMCORE_will_host_separate xdf
+	/AGMCORE_ps_version xdf
+	/AGMCORE_ps_level xdf
+	
+	errordict /AGM_handleerror known not
+		{
+		errordict /AGM_handleerror errordict /handleerror get put
+		errordict /handleerror
+			{
+			Adobe_AGM_Core begin
+			$error /newerror get AGMCORE_cur_err null ne and {
+				$error /newerror false put
+				AGMCORE_cur_err /AGMCORE_bad_environ eq
+					{
+					/AGMCORE_bad_environ AGMCORE_ps_level AGMCORE_ps_version
+					}
+					{
+					AGMCORE_cur_err 0 0
+					} ifelse
+				compose_error_msg
+				} if
+			$error /newerror true put
+			end
+			errordict /AGM_handleerror get exec
+			} bind put
+		}if
+	/AGMCORE_environ_ok 
+		ps_level AGMCORE_ps_level ge
+		ps_version AGMCORE_ps_version ge and 
+		AGMCORE_ps_level -1 eq or
+	def
+	
+	AGMCORE_environ_ok not
+		{/AGMCORE_cur_err /AGMCORE_bad_environ def} if
+	
+	/AGMCORE_&setgray systemdict/setgray get def
+	level2{
+		/AGMCORE_&setcolor systemdict/setcolor get def
+		/AGMCORE_&setcolorspace systemdict/setcolorspace get def
+		/AGMCORE_&&setcolorspace /setcolorspace ldf
+	}if
+	/AGMCORE_&image systemdict/image get def
+	/AGMCORE_&imagemask systemdict/imagemask get def
+	/colorimage where{
+		pop
+		/AGMCORE_&colorimage /colorimage ldf
+	}if
+	/AGMCORE_in_rip_sep
+		level2{
+			currentpagedevice/Separations 2 copy known{
+				get
+			}{
+				pop pop false
+			}ifelse
+		}{
+			false
+		}ifelse
+	def
+	level2 not{
+		/xput{
+			dup load dup length exch maxlength eq{
+				dup dup load dup
+				length dup 0 eq {pop 1} if 2 mul dict copy def
+			}if
+			load begin
+				def
+ 			end
+		}def
+	}{
+		/xput{
+			load 3 1 roll put
+		}def
+	}ifelse
+	/AGMCORE_gstate_known{
+		where{
+			/Adobe_AGM_Core_Id known
+		}{
+			false
+		}ifelse
+	}ndf
+	/AGMCORE_GSTATE AGMCORE_gstate_known not{
+		/AGMCORE_GSTATE 21 dict def
+		/AGMCORE_tmpmatrix matrix def
+		/AGMCORE_gstack 32 array def
+		/AGMCORE_gstackptr 0 def
+		/AGMCORE_gstacksaveptr 0 def
+		/AGMCORE_gstackframekeys 7 def
+		/AGMCORE_&gsave /gsave ldf
+		/AGMCORE_&grestore /grestore ldf
+		/AGMCORE_&grestoreall /grestoreall ldf
+		/AGMCORE_&save /save ldf
+		/AGMCORE_gdictcopy {
+			begin
+			{ def } forall
+			end
+		}def
+		/AGMCORE_gput {
+			AGMCORE_gstack AGMCORE_gstackptr get
+			3 1 roll
+			put
+		}def
+		/AGMCORE_gget {
+			AGMCORE_gstack AGMCORE_gstackptr get
+			exch
+			get
+		}def
+		/gsave {
+			AGMCORE_&gsave
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gstackptr 1 add
+			dup 32 ge {limitcheck} if
+			Adobe_AGM_Core exch
+			/AGMCORE_gstackptr exch put
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gdictcopy
+		}def
+		/grestore {
+			AGMCORE_&grestore
+			AGMCORE_gstackptr 1 sub
+			dup AGMCORE_gstacksaveptr lt {1 add} if
+			Adobe_AGM_Core exch
+			/AGMCORE_gstackptr exch put
+		}def
+		/grestoreall {
+			AGMCORE_&grestoreall
+			Adobe_AGM_Core
+			/AGMCORE_gstackptr AGMCORE_gstacksaveptr put 
+		}def
+		/save {
+			AGMCORE_&save
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gstackptr 1 add
+			dup 32 ge {limitcheck} if
+			Adobe_AGM_Core begin
+				/AGMCORE_gstackptr exch def
+				/AGMCORE_gstacksaveptr AGMCORE_gstackptr def
+			end
+			AGMCORE_gstack AGMCORE_gstackptr get
+			AGMCORE_gdictcopy
+		}def
+		0 1 AGMCORE_gstack length 1 sub {
+				AGMCORE_gstack exch AGMCORE_gstackframekeys dict put
+		} for
+	}if
+	/currentcmykcolor [0 0 0 0] AGMCORE_gput
+	/currentstrokeadjust false AGMCORE_gput
+	/currentcolorspace [/DeviceGray] AGMCORE_gput
+	/sep_tint 0 AGMCORE_gput
+	/sep_colorspace_dict null AGMCORE_gput
+	/indexed_colorspace_dict null AGMCORE_gput
+	/currentcolor_intent () AGMCORE_gput
+	end
+}def
+/page_setup
+{
+	Adobe_AGM_Core begin
+	/setcmykcolor
+	{
+		4 copy AGMCORE_cmykbuf astore /currentcmykcolor exch AGMCORE_gput
+		1 sub 4 1 roll
+		3 {
+			3 index add neg dup 0 lt {
+				pop 0
+			} if
+			3 1 roll
+		} repeat
+		setrgbcolor pop
+	}ndf
+	/AGMCORE_ccimage_exists /customcolorimage where {pop true}{false} ifelse def
+	/currentcmykcolor
+	{
+		/currentcmykcolor AGMCORE_gget aload pop
+	}ndf
+	/setoverprint
+	{
+		pop
+	}ndf
+	/currentoverprint
+	{
+		false
+	}ndf
+	/AGMCORE_deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt def
+	/AGMCORE_cyan_plate 1 0 0 0 test_cmyk_color_plate def
+	/AGMCORE_magenta_plate 0 1 0 0 test_cmyk_color_plate def
+	/AGMCORE_yellow_plate 0 0 1 0 test_cmyk_color_plate def
+	/AGMCORE_black_plate 0 0 0 1 test_cmyk_color_plate def
+	/AGMCORE_plate_ndx 
+		AGMCORE_cyan_plate{ 
+			0
+		}{
+			AGMCORE_magenta_plate{
+				1
+			}{
+				AGMCORE_yellow_plate{
+					2
+				}{
+					AGMCORE_black_plate{
+						3
+					}{
+						4
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+		def
+	/AGMCORE_composite_job
+		AGMCORE_cyan_plate AGMCORE_magenta_plate and AGMCORE_yellow_plate and AGMCORE_black_plate and def
+	
+	/AGMCORE_producing_seps AGMCORE_composite_job not AGMCORE_in_rip_sep or def
+	
+	/AGMCORE_host_sep AGMCORE_producing_seps AGMCORE_in_rip_sep not and def
+	
+	/AGM_preserve_spots 
+		/AGM_preserve_spots where{
+			pop AGM_preserve_spots
+		}{
+			systemdict/setdistillerparams known product (Adobe PostScript Parser) ne and AGMCORE_producing_seps or
+		}ifelse
+	def
+	
+	AGMCORE_host_sep AGMCORE_will_host_separate not and {
+		/AGMCORE_cur_err /AGMCORE_color_space_onhost_seps def
+		AGMCORE_color_space_onhost_seps
+	}if
+	/AGMCORE_avoid_L2_sep_space  
+		version cvr 2012 lt 
+		level2 and 
+		AGMCORE_producing_seps not and
+	def
+	/AGMCORE_is_cmyk_sep
+		AGMCORE_cyan_plate AGMCORE_magenta_plate or AGMCORE_yellow_plate or AGMCORE_black_plate or
+	def
+	/AGM_avoid_0_cmyk where{
+		pop AGM_avoid_0_cmyk
+	}{
+		AGM_preserve_spots
+	}ifelse
+	{
+		/setcmykcolor[
+			{4 copy add add add 0 eq currentoverprint and{pop 0.0005}if}/exec cvx
+			/setcmykcolor load dup type/operatortype ne{/exec cvx}if
+		]cvx def
+	}if
+	AGMCORE_host_sep{
+		/AGMCORE_get_ink_data
+			AGMCORE_cyan_plate{
+				{pop pop pop}
+			}{
+			  	AGMCORE_magenta_plate{
+			  		{4 3 roll pop pop pop}
+			  	}{
+			  		AGMCORE_yellow_plate{
+			  			{4 2 roll pop pop pop}
+			  		}{
+			  			{4 1 roll pop pop pop}
+			  		}ifelse
+			  	}ifelse
+			}ifelse
+		def
+	}if
+	AGMCORE_in_rip_sep{
+		/setcustomcolor
+		{
+			exch aload pop
+			dup 7 1 roll inRip_spot_has_ink not	{ 
+				4 {4 index mul 4 1 roll}
+				repeat
+				/DeviceCMYK setcolorspace
+				6 -2 roll pop pop
+			}{ 
+				Adobe_AGM_Core begin
+					/AGMCORE_k xdf /AGMCORE_y xdf /AGMCORE_m xdf /AGMCORE_c xdf
+				end
+				[/Separation 4 -1 roll /DeviceCMYK
+				{dup AGMCORE_c mul exch dup AGMCORE_m mul exch dup AGMCORE_y mul exch AGMCORE_k mul}
+				]
+				setcolorspace
+			}ifelse
+			setcolor
+		}ndf
+		/setseparationgray
+		{
+			[/Separation (All) /DeviceGray {}] setcolorspace_opt
+			1 exch sub setcolor
+		}ndf
+	}{
+		/setseparationgray
+		{
+			AGMCORE_&setgray
+		}ndf
+	}ifelse
+	/findcmykcustomcolor
+	{
+		5 makereadonlyarray
+	}ndf
+	/setcustomcolor
+	{
+		exch aload pop pop
+		4 {4 index mul 4 1 roll} repeat
+		setcmykcolor pop
+	}ndf
+	
+	/has_color
+		/colorimage where{
+			AGMCORE_producing_seps{
+				pop true
+			}{
+				systemdict eq
+			}ifelse
+		}{
+			false
+		}ifelse
+	def
+	
+	/map_index
+	{
+		1 index mul exch getinterval {255 div} forall
+	}def
+	
+	level2{
+		/mo /moveto ldf
+		/ln /lineto ldf
+		/cv /curveto ldf
+		/knockout_unitsq
+		{
+			1 setgray
+			0 0 1 1 rectfill
+		}def
+		/level2ScreenFreq{
+			begin
+			60
+			HalftoneType 1 eq{
+				pop Frequency
+			}if
+			HalftoneType 2 eq{
+				pop GrayFrequency
+			}if
+			HalftoneType 5 eq{
+				pop Default level2ScreenFreq
+			}if
+			 end
+		}def
+		/currentScreenFreq{
+			currenthalftone level2ScreenFreq
+		}def
+		/invert_image_samples
+		{
+			Adobe_AGM_Core/AGMCORE_tmp Decode length ddf
+			/Decode [ Decode 1 get Decode 0 get] def
+		}def
+		/knockout_image_samples
+		{
+			Operator/imagemask ne{
+				/Decode [1 1] def
+			}if
+		}def
+		/get_gstate
+		{
+			AGMCORE_GSTATE begin
+			/AGMCORE_GSTATE_ctm AGMCORE_tmpmatrix currentmatrix def
+			/AGMCORE_GSTATE_clr_spc currentcolorspace def
+			/AGMCORE_GSTATE_clr_indx 0 def
+			/AGMCORE_GSTATE_clr_comps 12 array def
+			mark currentcolor counttomark
+				{AGMCORE_GSTATE_clr_comps AGMCORE_GSTATE_clr_indx 3 -1 roll put
+				/AGMCORE_GSTATE_clr_indx AGMCORE_GSTATE_clr_indx 1 add def} repeat pop
+			/AGMCORE_GSTATE_fnt rootfont def
+			/AGMCORE_GSTATE_lw currentlinewidth def
+			/AGMCORE_GSTATE_lc currentlinecap def
+			/AGMCORE_GSTATE_lj currentlinejoin def
+			/AGMCORE_GSTATE_ml currentmiterlimit def
+			currentdash /AGMCORE_GSTATE_do xdf /AGMCORE_GSTATE_da xdf
+			/AGMCORE_GSTATE_sa currentstrokeadjust def
+			
+			/AGMCORE_GSTATE_clr_rnd currentcolorrendering def
+			/AGMCORE_GSTATE_op currentoverprint def
+			/AGMCORE_GSTATE_bg currentblackgeneration cvlit def
+			/AGMCORE_GSTATE_ucr currentundercolorremoval cvlit def
+			currentcolortransfer 
+				cvlit /AGMCORE_GSTATE_gy_xfer xdf 
+				cvlit /AGMCORE_GSTATE_b_xfer xdf
+				cvlit /AGMCORE_GSTATE_g_xfer xdf 
+				cvlit /AGMCORE_GSTATE_r_xfer xdf
+			/AGMCORE_GSTATE_ht currenthalftone def
+			/AGMCORE_GSTATE_flt currentflat def
+			end
+		}ndf
+		
+		/set_gstate
+		{
+			AGMCORE_GSTATE begin
+			AGMCORE_GSTATE_ctm setmatrix
+			AGMCORE_GSTATE_clr_spc setcolorspace
+			AGMCORE_GSTATE_clr_indx {AGMCORE_GSTATE_clr_comps AGMCORE_GSTATE_clr_indx 1 sub get
+			/AGMCORE_GSTATE_clr_indx AGMCORE_GSTATE_clr_indx 1 sub def} repeat setcolor
+			AGMCORE_GSTATE_fnt setfont
+			AGMCORE_GSTATE_lw setlinewidth
+			AGMCORE_GSTATE_lc setlinecap
+			AGMCORE_GSTATE_lj setlinejoin
+			AGMCORE_GSTATE_ml setmiterlimit
+			AGMCORE_GSTATE_da AGMCORE_GSTATE_do setdash
+			AGMCORE_GSTATE_sa setstrokeadjust
+			
+			AGMCORE_GSTATE_clr_rnd setcolorrendering
+			AGMCORE_GSTATE_op setoverprint
+			AGMCORE_GSTATE_bg cvx setblackgeneration
+			AGMCORE_GSTATE_ucr cvx setundercolorremoval
+			AGMCORE_GSTATE_r_xfer cvx AGMCORE_GSTATE_g_xfer cvx AGMCORE_GSTATE_b_xfer cvx
+				AGMCORE_GSTATE_gy_xfer cvx setcolortransfer
+			AGMCORE_GSTATE_ht /HalftoneType get dup 9 eq exch 100 eq or
+				{
+				currenthalftone /HalftoneType get AGMCORE_GSTATE_ht /HalftoneType get ne
+					{
+					  mark AGMCORE_GSTATE_ht {sethalftone} stopped cleartomark
+					} if
+				}{
+				AGMCORE_GSTATE_ht sethalftone
+				} ifelse
+			AGMCORE_GSTATE_flt setflat
+			end
+		}ndf
+		AGMCORE_producing_seps not{
+	
+			/setcolorspace where{
+				/Adobe_AGM_Core_Id known not
+			}{
+				true
+			}ifelse
+			{
+				/setcolorspace
+				{
+					dup type dup /arraytype eq exch /packedarraytype eq or{
+						dup 0 get dup /Separation eq{
+							pop
+							[ exch {} forall ]
+							dup dup 1 get AGMCORE_map_reserved_ink_name 1 exch put
+						}{
+							/DeviceN eq {
+								[ exch {} forall ]
+								dup dup 1 get [ exch {AGMCORE_map_reserved_ink_name} forall ] 1 exch put
+							}if
+						}ifelse
+					}if
+					AGMCORE_&&setcolorspace 
+				}def
+			}if
+		}if	
+	}{
+		
+		/adj
+		{
+			currentstrokeadjust{
+				transform
+				0.25 sub round 0.25 add exch
+				0.25 sub round 0.25 add exch
+				itransform
+			}if
+		}def
+		/mo{
+			adj moveto
+		}def
+		/ln{
+			adj lineto
+		}def
+		/cv{
+			6 2 roll adj
+			6 2 roll adj
+			6 2 roll adj curveto
+		}def
+		/knockout_unitsq
+		{
+			1 setgray
+			8 8 1 [8 0 0 8 0 0] {<ffffffffffffffff>} image
+		}def
+		/currentstrokeadjust{
+			/currentstrokeadjust AGMCORE_gget
+		}def
+		/setstrokeadjust{
+			/currentstrokeadjust exch AGMCORE_gput
+		}def
+		/currentScreenFreq{
+			currentscreen pop pop
+		}def
+		/invert_image_samples
+		{
+			{1 exch sub} currenttransfer addprocs settransfer
+		}def
+		/knockout_image_samples
+		{
+			{ pop 1 } currenttransfer addprocs settransfer
+		}def
+		/setcolorspace
+		{
+			/currentcolorspace exch AGMCORE_gput
+		} def
+		
+		/currentcolorspace
+		{
+			/currentcolorspace AGMCORE_gget
+		} def
+		
+		/n_color_components
+		{
+			dup type /arraytype eq{
+				0 get
+			}if
+			dup /DeviceGray eq{
+				pop 1
+			}{
+				/DeviceCMYK eq{
+					4
+				}{
+					3
+				}ifelse
+			}ifelse
+		} def
+		
+		/setcolor_devicecolor
+		{
+			dup type /arraytype eq{
+				0 get
+			}if
+			dup /DeviceGray eq{
+				pop setgray
+			}{
+				/DeviceCMYK eq{
+					setcmykcolor
+				}{
+					setrgbcolor
+				}ifelse
+			}ifelse
+		}def
+	
+		/setcolor
+		{
+			currentcolorspace 0 get
+			dup /DeviceGray ne{
+				dup /DeviceCMYK ne{
+					dup /DeviceRGB ne{
+						dup /Separation eq{
+							pop
+							currentcolorspace 3 get exec
+							currentcolorspace 2 get
+						}{
+							dup /Indexed eq{
+								pop
+								currentcolorspace 3 get dup type /stringtype eq{
+									currentcolorspace 1 get n_color_components
+									3 -1 roll map_index
+								}{
+									exec
+								}ifelse
+								currentcolorspace 1 get
+							}{
+								/AGMCORE_cur_err /AGMCORE_invalid_color_space def
+								AGMCORE_invalid_color_space
+							}ifelse
+						}ifelse
+					}if
+				}if
+			}if
+			setcolor_devicecolor
+		} def
+	}ifelse
+	
+	/op /setoverprint ldf
+	/lw /setlinewidth ldf
+	/lc /setlinecap ldf
+	/lj /setlinejoin ldf
+	/ml /setmiterlimit ldf
+	/dsh /setdash ldf
+	/sadj /setstrokeadjust ldf
+	/gry /setgray ldf
+	/rgb /setrgbcolor ldf
+	/cmyk /setcmykcolor ldf
+	/sep /setsepcolor ldf
+	/idx /setindexedcolor ldf
+	/colr /setcolor ldf
+	/csacrd /set_csa_crd ldf
+	/sepcs /setsepcolorspace ldf
+	/idxcs /setindexedcolorspace ldf
+	/cp /closepath ldf
+	/clp /clp_npth ldf
+	/eclp /eoclp_npth ldf
+	/spclp /stkpath_clp_npth ldf
+	/f /fill ldf
+	/ef /eofill ldf
+	/s /stroke ldf
+	/sclp /stk_n_clp_npth ldf
+	/nclp /npth_clp ldf
+	/img /imageormask ldf
+	/sepimg /sep_imageormask ldf
+	/idximg /indexed_imageormask ldf
+	/gset /graphic_setup ldf
+	/gcln /graphic_cleanup ldf
+	
+	currentdict{
+		dup xcheck 1 index type dup /arraytype eq exch /packedarraytype eq or and {
+			bind
+		}if
+		def
+	}forall
+}def
+/page_trailer
+{
+	end
+}def
+/unload{
+	systemdict/languagelevel known{
+		systemdict/languagelevel get 2 ge{
+			userdict/Adobe_AGM_Core 2 copy known{
+				undef
+			}{
+				pop pop
+			}ifelse
+		}if
+	}if
+}def
+/doc_trailer{
+}def
+systemdict /findcolorrendering known{
+	/findcolorrendering systemdict /findcolorrendering get def
+}if
+systemdict /setcolorrendering known{
+	/setcolorrendering systemdict /setcolorrendering get def
+}if
+/test_cmyk_color_plate
+{
+	gsave
+	setcmykcolor currentgray 1 ne
+	grestore
+}def
+/inRip_spot_has_ink
+{
+	Adobe_AGM_Core/AGMCORE_name xddf
+	false
+	currentpagedevice/SeparationColorNames get{
+		AGMCORE_name eq or
+	}forall
+}def
+/current_ink
+{
+	dup length 0 eq{
+		pop true
+	}{
+		Adobe_AGM_Core/ink_result false put
+		{
+			dup /ProcessCyan eq{
+				AGMCORE_cyan_plate ink_result or Adobe_AGM_Core/ink_result xddf
+			}{
+				dup /ProcessMagenta eq{
+					AGMCORE_magenta_plate ink_result or Adobe_AGM_Core/ink_result xddf
+				}{
+					dup /ProcessYellow eq{
+						AGMCORE_yellow_plate ink_result or Adobe_AGM_Core/ink_result xddf
+					}{
+						dup /ProcessBlack eq{
+							AGMCORE_black_plate ink_result or Adobe_AGM_Core/ink_result xddf
+						}{
+							dup /sep_colorspace_dict AGMCORE_gget dup null eq{
+								pop false ink_result or Adobe_AGM_Core/ink_result xddf
+							}{
+								/Name get eq{
+									1 setsepcolor
+									currentgray 1 ne ink_result or Adobe_AGM_Core/ink_result xddf
+								}{
+									false ink_result or Adobe_AGM_Core/ink_result xddf
+								}ifelse
+							}ifelse
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+			pop 
+		} forall
+		ink_result
+	}ifelse
+}def
+/map255_to_range
+{
+	1 index sub
+	3 -1 roll 255 div mul add
+}def
+/set_csa_crd
+{
+	/sep_colorspace_dict null AGMCORE_gput
+	begin
+		CSA map_csa setcolorspace_opt
+		set_crd
+	end
+}
+def
+/setsepcolor
+{ 
+	
+	/sep_colorspace_dict AGMCORE_gget begin
+		dup /sep_tint exch AGMCORE_gput
+		TintProc
+	end
+} def
+/sep_colorspace_proc
+{
+	Adobe_AGM_Core/AGMCORE_tmp xddf
+	/sep_colorspace_dict AGMCORE_gget begin
+	currentdict/Components known{
+		Components aload pop 
+		TintMethod/Lab eq{
+			2 {AGMCORE_tmp mul NComponents 1 roll} repeat
+			LMax sub AGMCORE_tmp mul LMax add  NComponents 1 roll
+		}{
+			TintMethod/Subtractive eq{
+				NComponents{
+					AGMCORE_tmp mul NComponents 1 roll
+				}repeat
+			}{
+				NComponents{
+					1 sub AGMCORE_tmp mul 1 add  NComponents 1 roll
+				} repeat
+			}ifelse
+		}ifelse
+	}{
+		ColorLookup AGMCORE_tmp ColorLookup length 1 sub mul round cvi get
+		aload pop
+	}ifelse
+	end
+} def
+/sep_colorspace_gray_proc
+{
+	Adobe_AGM_Core/AGMCORE_tmp xddf
+	/sep_colorspace_dict AGMCORE_gget begin
+	GrayLookup AGMCORE_tmp GrayLookup length 1 sub mul round cvi get
+	end
+} def
+/sep_proc_name
+{
+	dup 0 get 
+	dup /DeviceRGB eq exch /DeviceCMYK eq or level2 not and has_color not and{
+		pop [/DeviceGray]
+		/sep_colorspace_gray_proc
+	}{
+		/sep_colorspace_proc
+	}ifelse
+} def
+/setsepcolorspace
+{ 
+	dup /sep_colorspace_dict exch AGMCORE_gput
+	begin
+	/MappedCSA CSA map_csa def
+	Adobe_AGM_Core/AGMCORE_sep_special Name dup () eq exch (All) eq or ddf
+	
+	AGMCORE_avoid_L2_sep_space{
+		[/Indexed MappedCSA sep_proc_name 255 exch 
+			{ 255 div } /exec cvx 3 -1 roll [ 4 1 roll load /exec cvx ] cvx 
+		] setcolorspace_opt
+		/TintProc {
+			255 mul setcolor
+		}bdf
+	}{
+		MappedCSA 0 get /DeviceCMYK eq 
+		currentdict/Components known and 
+		AGMCORE_sep_special not and{
+			/TintProc [
+				Components aload pop Name findcmykcustomcolor 
+				/exch cvx /setcustomcolor cvx
+			] cvx bdf
+		}{
+ 			AGMCORE_host_sep Name (All) eq and{
+ 				/TintProc { 
+					1 exch sub setseparationgray 
+				}bdf
+ 			}{
+				AGMCORE_in_rip_sep MappedCSA 0 get /DeviceCMYK eq and 
+				AGMCORE_host_sep or
+				Name () eq and{
+					/TintProc [
+						MappedCSA sep_proc_name exch 0 get /DeviceCMYK eq{
+							cvx /setcmykcolor cvx
+						}{
+							cvx /setgray cvx
+						}ifelse
+					] cvx bdf
+				}{
+					AGMCORE_producing_seps MappedCSA 0 get dup /DeviceCMYK eq exch /DeviceGray eq or and AGMCORE_sep_special not and{
+	 					/TintProc [
+							/dup cvx
+							MappedCSA sep_proc_name cvx exch
+							0 get /DeviceGray eq{
+								1 /exch cvx /sub cvx 0 0 0 4 -1 /roll cvx
+							}if
+							/Name cvx /findcmykcustomcolor cvx /exch cvx
+							
+							AGMCORE_host_sep{
+								AGMCORE_is_cmyk_sep
+							}{
+								Name inRip_spot_has_ink not
+							}ifelse
+							{
+		 						/pop cvx 1
+							}if
+							/setcustomcolor cvx
+						] cvx bdf
+ 					}{ 
+						/TintProc /setcolor ldf
+						
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+	}ifelse
+	set_crd
+	1 setsepcolor
+	end
+} def
+/setindexedcolorspace
+{
+	dup /indexed_colorspace_dict exch AGMCORE_gput
+	begin
+		/MappedCSA CSA map_csa def
+		AGMCORE_host_sep level2 not and{
+			0 0 0 0 setcmykcolor
+		}{
+			[/Indexed MappedCSA 
+			level2 not has_color not and{
+				dup 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or{
+					pop [/DeviceGray]
+				}if
+				HiVal GrayLookup
+			}{
+				HiVal 
+				currentdict/RangeArray known{
+					{ 
+						/indexed_colorspace_dict AGMCORE_gget begin
+						Lookup exch 
+						dup HiVal gt{
+							pop HiVal
+						}if
+						NComponents mul NComponents getinterval {} forall
+						NComponents 1 sub -1 0{
+							RangeArray exch 2 mul 2 getinterval aload pop map255_to_range
+							NComponents 1 roll
+						}for
+						end
+					} bind
+				}{
+					Lookup
+				}ifelse
+			}ifelse
+			] setcolorspace_opt
+			
+			set_crd
+		}ifelse
+	end
+}def
+/setindexedcolor
+{
+	AGMCORE_host_sep{
+		/indexed_colorspace_dict AGMCORE_gget/Lookup get 4 3 -1 roll map_index setcmykcolor
+	}{
+		setcolor
+	}ifelse
+} def
+/imageormask_sys
+{
+	begin
+		save mark
+		level2{
+			currentdict
+			Operator /imagemask eq{
+				AGMCORE_&imagemask
+			}{
+				AGMCORE_&image
+			}ifelse
+		}{
+			Width Height
+			Operator /imagemask eq{
+				Decode 0 get 1 eq Decode 1 get 0 eq	and
+				ImageMatrix /DataSource load
+				AGMCORE_&imagemask
+			}{
+				BitsPerComponent ImageMatrix /DataSource load
+				AGMCORE_&image
+			}ifelse
+		}ifelse
+		cleartomark restore
+	end
+}def
+/overprint_plate
+{
+	currentoverprint{
+		0 get
+		dup /DeviceGray eq{
+			pop AGMCORE_black_plate not
+		}{
+			/DeviceCMYK eq{
+				AGMCORE_is_cmyk_sep not
+			}if
+		}ifelse
+	}{
+		false
+	}ifelse
+}def
+/rdline {
+	currentfile AGMCORE_str256 readline pop
+} def
+/rdcmntline {
+	currentfile AGMCORE_str256 readline pop
+	(%) anchorsearch {pop} if
+} def
+/filter_cmyk
+{	
+	dup type /filetype ne{
+		0 () /SubFileDecode filter
+	}if
+	[
+	exch
+	{
+		AGMCORE_src256 readstring pop
+		dup length /AGMCORE_srcLen exch def
+		/AGMCORE_ndx 0 def
+		
+		AGMCORE_plate_ndx 4 AGMCORE_srcLen 1 sub{
+			1 index exch get
+			AGMCORE_dst64 AGMCORE_ndx 3 -1 roll put
+			/AGMCORE_ndx AGMCORE_ndx 1 add def
+		}for
+		pop
+		AGMCORE_dst64 0 AGMCORE_ndx getinterval
+	}
+	bind
+	/exec cvx
+	] cvx
+} def
+/imageormask
+{
+	begin
+		SkipImageProc not{
+			save mark
+			level2 AGMCORE_host_sep not and{
+				currentdict
+				Operator /imagemask eq{
+					imagemask
+				}{
+					AGMCORE_in_rip_sep currentoverprint and currentcolorspace 0 get /DeviceGray eq and{
+						[/Separation /Black /DeviceGray {}] setcolorspace
+						/Decode [ Decode 1 get Decode 0 get ] def
+					}if
+					image
+				}ifelse
+			}{
+				Width Height
+				Operator /imagemask eq{
+					Decode 0 get 1 eq Decode 1 get 0 eq	and
+					ImageMatrix /DataSource load
+					AGMCORE_host_sep{
+						currentgray 1 ne{
+							currentdict imageormask_sys
+						}{
+	 						currentoverprint not{
+			 					1 AGMCORE_&setgray
+	 							knockout_image_samples
+			 					currentdict imageormask_sys
+			 				}{
+			 					nulldevice currentdict imageormask_sys
+			 				}ifelse
+				 		}ifelse
+					}{
+						imagemask
+					}ifelse
+				}{
+					BitsPerComponent ImageMatrix 
+					MultipleDataSources{
+						0 1 NComponents 1 sub{
+							DataSource exch get
+						}for
+					}{
+						/DataSource load
+					}ifelse
+					Operator /colorimage eq{
+						AGMCORE_host_sep{
+							MultipleDataSources level2 or NComponents 4 eq and{
+								MultipleDataSources{
+									4 {pop} repeat
+									/DataSource [
+										DataSource 0 get /exec cvx
+										DataSource 1 get /exec cvx
+										DataSource 2 get /exec cvx
+										DataSource 3 get /exec cvx
+										/AGMCORE_get_ink_data cvx
+									] cvx def
+								}{
+									/DataSource /DataSource load filter_cmyk 0 () /SubFileDecode filter def
+								}ifelse
+	
+								/Decode [ Decode 0 get Decode 1 get ] def
+								/MultipleDataSources false def
+								/NComponents 1 def
+								/Operator /image def
+								AGMCORE_is_cmyk_sep{
+									currentoverprint InksUsed current_ink not and{
+										nulldevice
+									}{
+										invert_image_samples
+									}ifelse
+								}{
+		 							currentoverprint not{
+		 								knockout_image_samples
+				 					}{
+				 						nulldevice
+				 					}ifelse
+					 			}ifelse
+						 		1 AGMCORE_&setgray
+								currentdict imageormask_sys
+							}{
+									
+								currentcolortransfer
+								{pop 1} exch addprocs 4 1 roll				
+								{pop 1} exch addprocs 4 1 roll
+								{pop 1} exch addprocs 4 1 roll
+								{pop 1} exch addprocs 4 1 roll
+								setcolortransfer
+									
+								MultipleDataSources NComponents AGMCORE_&colorimage						
+							}ifelse
+						}{
+							true NComponents colorimage
+						}ifelse
+					}{
+						Operator /image eq{
+							AGMCORE_host_sep{
+								HostSepColorImage{
+									invert_image_samples
+								}{
+									AGMCORE_black_plate not{
+		 								currentoverprint not{
+		 									knockout_image_samples
+				 						}{
+				 							nulldevice
+				 						}ifelse
+					 				}if
+								}ifelse
+						 		1 AGMCORE_&setgray
+								currentdict imageormask_sys
+							}{
+								image
+							}ifelse
+						}{
+							Operator/knockout eq{
+								pop pop pop pop pop
+								currentoverprint InksUsed current_ink not and{
+								}{
+									currentcolorspace overprint_plate not{
+										knockout_unitsq
+									}if
+								}ifelse
+							}if
+						}ifelse
+					}ifelse
+				}ifelse
+			}ifelse
+			cleartomark restore
+		}if
+	end
+}def
+/tint_image_to_color
+{
+	begin
+		Width Height BitsPerComponent ImageMatrix 
+		/DataSource load
+	end
+	Adobe_AGM_Core begin
+		/AGMCORE_mbuf 0 string def
+		/AGMCORE_ybuf 0 string def
+		/AGMCORE_kbuf 0 string def
+		{
+			colorbuf dup length AGMCORE_mbuf length ne
+				{
+				dup length dup dup
+				/AGMCORE_mbuf exch string def
+				/AGMCORE_ybuf exch string def
+				/AGMCORE_kbuf exch string def
+				} if
+			dup AGMCORE_mbuf copy AGMCORE_ybuf copy AGMCORE_kbuf copy pop
+		}
+		addprocs
+		{AGMCORE_mbuf}{AGMCORE_ybuf}{AGMCORE_kbuf} true 4 colorimage	
+	end
+} def			
+/sep_imageormask_lev1
+{
+	begin
+		MappedCSA 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or has_color not and{
+			
+			{
+				255 mul round cvi GrayLookup exch get
+			} currenttransfer addprocs settransfer
+			currentdict imageormask
+		}{
+			/sep_colorspace_dict AGMCORE_gget/Components known{
+				MappedCSA 0 get /DeviceCMYK eq{
+					Components aload pop
+				}{
+					0 0 0 Components aload pop 1 exch sub
+				}ifelse
+				
+				Adobe_AGM_Core/AGMCORE_k xddf 
+				Adobe_AGM_Core/AGMCORE_y xddf 
+				Adobe_AGM_Core/AGMCORE_m xddf 
+				Adobe_AGM_Core/AGMCORE_c xddf 
+					
+				AGMCORE_y 0.0 eq AGMCORE_m 0.0 eq and AGMCORE_c 0.0 eq and{
+					{AGMCORE_k mul 1 exch sub} currenttransfer addprocs settransfer
+					currentdict imageormask
+				}{ 
+					
+					currentcolortransfer
+					{AGMCORE_k mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_y mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_m mul 1 exch sub} exch addprocs 4 1 roll
+					{AGMCORE_c mul 1 exch sub} exch addprocs 4 1 roll
+					setcolortransfer
+					currentdict tint_image_to_color
+				}ifelse
+			}{
+				
+				MappedCSA 0 get /DeviceGray eq {
+					{255 mul round cvi ColorLookup exch get 0 get} currenttransfer addprocs settransfer
+					currentdict imageormask
+				}{
+					MappedCSA 0 get /DeviceCMYK eq {
+						currentcolortransfer
+						{255 mul round cvi ColorLookup exch get 3 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 2 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 1 get 1 exch sub} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 0 get 1 exch sub} exch addprocs 4 1 roll
+						setcolortransfer 
+						currentdict tint_image_to_color
+					}{ 
+						currentcolortransfer
+						{pop 1} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 2 get} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 1 get} exch addprocs 4 1 roll
+						{255 mul round cvi ColorLookup exch get 0 get} exch addprocs 4 1 roll
+						setcolortransfer 
+						currentdict tint_image_to_color
+					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+	end
+}def
+/sep_image_lev1_sep
+{
+	begin
+		/sep_colorspace_dict AGMCORE_gget/Components known{
+			Components aload pop
+			
+			Adobe_AGM_Core/AGMCORE_k xddf 
+			Adobe_AGM_Core/AGMCORE_y xddf 
+			Adobe_AGM_Core/AGMCORE_m xddf 
+			Adobe_AGM_Core/AGMCORE_c xddf 
+				
+			{AGMCORE_c mul 1 exch sub}
+			{AGMCORE_m mul 1 exch sub}
+			{AGMCORE_y mul 1 exch sub}
+			{AGMCORE_k mul 1 exch sub}
+		}{ 
+			{255 mul round cvi ColorLookup exch get 0 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 1 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 2 get 1 exch sub}
+			{255 mul round cvi ColorLookup exch get 3 get 1 exch sub}
+		}ifelse
+		
+		AGMCORE_get_ink_data currenttransfer addprocs settransfer
+		
+		currentdict imageormask_sys
+			
+	end
+}def
+/sep_imageormask
+{
+ 	/sep_colorspace_dict AGMCORE_gget begin
+	/MappedCSA CSA map_csa def
+	begin
+	SkipImageProc not{
+		save mark 
+	
+		AGMCORE_avoid_L2_sep_space{
+			/Decode [ Decode 0 get 255 mul Decode 1 get 255 mul ] def
+		}if
+ 		AGMCORE_ccimage_exists 
+		MappedCSA 0 get /DeviceCMYK eq and
+		currentdict/Components known and 
+		Name () ne and 
+		Name (All) ne and 
+		Operator /image eq and
+		AGMCORE_producing_seps not and
+		level2 not and
+		{
+			Width Height BitsPerComponent ImageMatrix 
+			[
+			/DataSource load /exec cvx
+			{
+				0 1 2 index length 1 sub{
+					1 index exch
+					2 copy get 255 xor put
+				}for
+			} /exec cvx
+			] cvx bind
+			MappedCSA 0 get /DeviceCMYK eq{
+				Components aload pop
+			}{
+				0 0 0 Components aload pop 1 exch sub
+			}ifelse
+			Name findcmykcustomcolor
+			customcolorimage
+		}{
+			AGMCORE_producing_seps not{
+				level2{
+					AGMCORE_avoid_L2_sep_space not currentcolorspace 0 get /Separation ne and{
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+						/sep_tint AGMCORE_gget setcolor
+					}if
+					currentdict imageormask
+				}{ 
+					currentdict
+					Operator /imagemask eq{
+						imageormask
+					}{
+						sep_imageormask_lev1
+					}ifelse
+				}ifelse
+ 			}{
+				AGMCORE_host_sep{
+					Operator/knockout eq{
+						currentoverprint InksUsed current_ink not and{
+						}{
+							currentdict/ImageMatrix get concat
+							knockout_unitsq
+						}ifelse
+					}{
+						currentgray 1 ne{
+ 							AGMCORE_is_cmyk_sep Name (All) ne and{
+ 								level2{
+	 								[ /Separation Name [/DeviceGray]
+	 								{ 
+	 									sep_colorspace_proc AGMCORE_get_ink_data
+										1 exch sub
+	 								} bind
+									] AGMCORE_&setcolorspace
+									/sep_tint AGMCORE_gget AGMCORE_&setcolor
+ 									currentdict imageormask_sys
+	 							}{
+	 								currentdict
+									Operator /imagemask eq{
+										imageormask_sys
+									}{
+										sep_image_lev1_sep
+									}ifelse
+	 							}ifelse
+ 							}{
+ 								Operator/imagemask ne{
+									invert_image_samples
+ 								}if
+		 						currentdict imageormask_sys
+ 							}ifelse
+ 						}{
+ 							currentoverprint not Name (All) eq or{
+ 								knockout_image_samples
+		 					}{
+		 						nulldevice 
+		 					}ifelse
+							currentdict imageormask_sys
+ 						}ifelse
+		 			}ifelse
+ 				}{
+					currentcolorspace 0 get /Separation ne{
+						[/Separation Name MappedCSA sep_proc_name load ] setcolorspace_opt
+						/sep_tint AGMCORE_gget setcolor
+					}if
+					currentoverprint 
+					MappedCSA 0 get /DeviceCMYK eq and 
+					Name inRip_spot_has_ink not and 
+					Name (All) ne and {
+						imageormask_l2_overprint
+					}{
+						currentdict imageormask
+ 					}ifelse
+				}ifelse
+			}ifelse
+		}ifelse
+		cleartomark restore
+	}if
+	end
+	end
+}def
+/modify_halftone_xfer
+{
+	currenthalftone dup length dict copy begin
+    currentdict 2 index known{
+    	1 index load dup length dict copy begin
+		currentdict/TransferFunction known{
+			/TransferFunction load
+		}{
+			currenttransfer
+		}ifelse
+	    addprocs /TransferFunction xdf 
+	    currentdict end def
+		currentdict end sethalftone
+	}{ 
+		currentdict/TransferFunction known{
+			/TransferFunction load 
+		}{
+			currenttransfer
+		}ifelse
+		addprocs /TransferFunction xdf
+		currentdict end sethalftone		
+		pop
+	}ifelse
+}def
+/read_image_file
+{
+	AGMCORE_imagefile 0 setfileposition
+	dup /DataSource {AGMCORE_imagefile AGMCORE_imbuf readstring pop} put
+	exch
+	load exec
+}def
+/write_image_file
+{
+	{ (AGMCORE_imagefile) (w+) file } stopped{
+		false
+	}{
+		Adobe_AGM_Core/AGMCORE_imagefile xddf 
+		Adobe_AGM_Core/AGMCORE_imbuf Width BitsPerComponent mul 7 add 8 idiv string ddf
+		1 1 Height { 
+			pop
+			DataSource dup type /filetype eq{
+				AGMCORE_imbuf readstring pop
+			}{
+				exec
+			} ifelse
+			AGMCORE_imagefile exch writestring
+		}for
+		true
+	}ifelse
+}def
+/imageormask_l2_overprint
+{
+	write_image_file{
+		currentcmykcolor
+		0 ne{
+			[/Separation /Black /DeviceGray {}] setcolorspace
+			gsave
+			/Black
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 1 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Yellow /DeviceGray {}] setcolorspace
+			gsave
+			/Yellow
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 2 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Magenta /DeviceGray {}] setcolorspace
+			gsave
+			/Magenta
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {4 3 roll pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		}if
+		0 ne{
+			[/Separation /Cyan /DeviceGray {}] setcolorspace
+			gsave
+			/Cyan 
+			[{1 exch sub /sep_tint AGMCORE_gget mul} /exec cvx MappedCSA sep_proc_name cvx exch pop {pop pop pop 1 exch sub} /exec cvx]
+			cvx modify_halftone_xfer
+			Operator currentdict read_image_file
+			grestore
+		} if
+		AGMCORE_imagefile closefile (AGMCORE_imagefile) deletefile
+	}{
+		currentdict imageormask
+	}ifelse
+} def
+/indexed_imageormask
+{
+	begin
+		save mark 
+	
+ 		currentdict
+ 		AGMCORE_host_sep{
+ 			
+			Operator/knockout eq{
+				/indexed_colorspace_dict AGMCORE_gget /CSA get map_csa overprint_plate not{
+					knockout_unitsq
+				}if
+			}{
+	 			AGMCORE_is_cmyk_sep{
+					Operator /imagemask eq{
+						imageormask_sys
+					}{
+						level2{
+							indexed_image_lev2_sep
+						}{
+							indexed_image_lev1_sep
+						}ifelse
+					}ifelse
+				}{
+					currentoverprint not{
+						knockout_image_samples
+		 				imageormask_sys
+		 			}{
+		 				nulldevice currentdict imageormask_sys
+		 			}ifelse
+				}ifelse
+			}ifelse
+ 		}{
+			level2{
+				imageormask
+			}{ 
+				Operator /imagemask eq{
+					imageormask
+				}{
+					indexed_imageormask_lev1
+				}ifelse
+			}ifelse
+ 		}ifelse
+		cleartomark restore
+	end
+}def
+/indexed_imageormask_lev1
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		currentdict
+		MappedCSA 0 get dup /DeviceRGB eq exch /DeviceCMYK eq or has_color not and{
+			
+			{HiVal mul round cvi GrayLookup exch get HiVal div} currenttransfer addprocs settransfer
+			imageormask
+		}{
+			
+			MappedCSA 0 get /DeviceGray eq {
+				{HiVal mul round cvi Lookup exch get HiVal div} currenttransfer addprocs settransfer
+				imageormask
+			}{
+				MappedCSA 0 get /DeviceCMYK eq {
+					currentcolortransfer
+					{4 mul HiVal mul round cvi 3 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi 2 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi 1 add Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					{4 mul HiVal mul round cvi       Lookup exch get HiVal div 1 exch sub} exch addprocs 4 1 roll
+					setcolortransfer 
+					tint_image_to_color
+				}{ 
+					currentcolortransfer
+					{pop 1} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 2 add Lookup exch get HiVal div} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 1 add Lookup exch get HiVal div} exch addprocs 4 1 roll
+					{3 mul HiVal mul round cvi 	   Lookup exch get HiVal div} exch addprocs 4 1 roll
+					setcolortransfer 
+					tint_image_to_color
+				}ifelse
+			}ifelse
+		}ifelse
+	end end
+}def
+/indexed_image_lev1_sep
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		{4 mul HiVal mul round cvi       Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 1 add Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 2 add Lookup exch get HiVal div 1 exch sub}
+		{4 mul HiVal mul round cvi 3 add Lookup exch get HiVal div 1 exch sub}
+		
+		AGMCORE_get_ink_data currenttransfer addprocs settransfer
+		
+		currentdict imageormask_sys
+			
+	end end
+}def
+/indexed_image_lev2_sep
+{
+	/indexed_colorspace_dict AGMCORE_gget begin
+	begin
+		
+		currentcolorspace 
+		dup 1 /DeviceGray put
+		dup 3 [
+			currentcolorspace 3 get 
+			{
+				exch 4 mul 4 getinterval {} forall
+				AGMCORE_get_ink_data 255 div 1 exch sub
+			} /exec cvx
+		] cvx put
+		setcolorspace
+		
+		currentdict 
+		Operator /imagemask eq{
+			AGMCORE_&imagemask
+		}{
+			AGMCORE_&image
+		}ifelse
+			
+	end end
+}def
+/add_csa
+{
+	Adobe_AGM_Core begin
+			/AGMCORE_CSA_cache xput
+	end
+}def
+/map_csa
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_CSA_cache get exch get
+	}if
+}def
+/add_csd
+{
+	Adobe_AGM_Core begin
+		/AGMCORE_CSD_cache xput
+	end
+}def
+/get_csd
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_CSD_cache get exch get
+	}if
+}def
+/add_pattern
+{
+	Adobe_AGM_Core begin
+		/AGMCORE_pattern_cache xput
+	end
+}def
+/get_pattern
+{
+	dup type /nametype eq{
+		Adobe_AGM_Core/AGMCORE_pattern_cache get exch get
+	}if
+}def
+/set_pattern
+{
+	dup /PatternType get 1 eq{
+		dup /PaintType get 1 eq{
+			false op [/DeviceGray] setcolorspace 0 setgray
+		}if
+	}if
+	setpattern
+}def
+/setcolorspace_opt
+{
+	dup currentcolorspace eq{
+		pop
+	}{
+		setcolorspace
+	}ifelse
+}def
+/updatecolorrendering
+{
+	
+	currentcolorrendering/Intent known{
+		currentcolorrendering/Intent get
+	}{
+		null
+	}ifelse
+	
+	Intent ne{
+		false  
+		Intent
+		AGMCORE_CRD_cache {
+			exch pop 
+			begin
+				dup Intent eq{
+					currentdict setcolorrendering_opt
+					end 
+					exch pop true exch	
+					exit
+				}if
+			end
+		} forall
+		pop
+		not{
+			systemdict /findcolorrendering known{
+				Intent findcolorrendering pop
+				/ColorRendering findresource 
+				dup length dict copy
+				setcolorrendering_opt
+			}if
+		}if
+	}if
+} def
+/add_crd
+{
+	AGMCORE_CRD_cache 3 1 roll put
+}def
+/set_crd
+{
+	AGMCORE_host_sep not level2 and{
+		currentdict/CRD known{
+			AGMCORE_CRD_cache CRD get dup null ne{
+				setcolorrendering_opt
+			}{
+				pop
+			}ifelse
+		}{
+			currentdict/Intent known{
+				updatecolorrendering
+			}if
+		}ifelse
+	}if
+}def
+/setcolorrendering_opt
+{
+	dup currentcolorrendering eq{
+		pop
+	}{
+		begin
+			/Intent Intent def
+			currentdict
+		end
+		setcolorrendering
+	}ifelse
+}def
+/OPIimage
+{
+	dup type /dicttype ne{
+		10 dict begin
+			/DataSource xdf
+			/ImageMatrix xdf
+			/BitsPerComponent xdf
+			/Height xdf
+			/Width xdf
+			/MultipleDataSources false def
+			/NComponents 1 def
+			/ImageType 1 def
+			/Decode [0 1 def]
+			/SkipImageProc {false} def
+			currentdict
+		end
+	}if
+	dup begin
+		/HostSepColorImage false def
+		currentdict/Decode known not{
+			/Decode [
+				0 
+				currentcolorspace 0 get /Indexed eq{
+					2 BitsPerComponent exp 1 sub
+				}{
+					1
+				}ifelse
+			] 
+			def
+		}if
+		currentdict/Operator known not{
+			/Operator /image def
+		}if
+	end
+	/sep_colorspace_dict AGMCORE_gget null eq{
+		imageormask
+	}{
+		gsave
+		dup begin invert_image_samples end
+		sep_imageormask
+		grestore
+	}ifelse
+}def
+/cpaint_gcomp
+{
+	AGM_preserve_spots{
+		gsave
+		nulldevice
+	}if
+}def
+/cpaint_gsep
+{
+	AGM_preserve_spots{
+		grestore
+		currentoverprint Adobe_AGM_Core/AGMCORE_ovp xddf 
+	}{	
+		gsave
+		nulldevice
+	}ifelse
+}def
+/cpaint_gend
+{
+	AGM_preserve_spots{
+		Adobe_AGM_Core/AGMCORE_ovp get setoverprint
+	}{
+		grestore
+	}ifelse
+	newpath
+}def
+/AGMCORE_ctm_stack bdict
+	/push_ctm {
+		stack length size le{
+			stack dup length 2 mul array 
+			dup /stack exch def
+			copy pop
+		}if
+		stack size 3 -1 roll put
+		/size size 1 add def
+	}
+	/pop_ctm {
+		/size size 1 sub def
+		size 0 lt{ 
+			/size 0 def
+		}if
+		stack size get
+	}
+	/stack 1 array
+	/size 0 
+edict 
+def
+/save_ctm
+{
+	matrix currentmatrix AGMCORE_ctm_stack begin 
+		push_ctm 
+	end
+}def
+/restore_ctm
+{
+	AGMCORE_ctm_stack begin
+		pop_ctm 
+	end
+	setmatrix
+}def
+/path_rez
+{
+	dup 0 ne{
+		AGMCORE_deviceDPI exch div 
+		dup 1 lt{
+			pop 1
+		}if
+		setflat
+	}{
+		pop
+	}ifelse 	
+}def
+end
+systemdict /setpacking known
+{
+	setpacking
+} if
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_AGM_Core/AGMCORE_err_strings 3 dict dup begin
+/AGMCORE_bad_environ (Die Voraussetzungen sind für den Auftrag nicht erfüllt, da mindestens 
+PostScript Level ^\tund PostScript-Version ^ erforderlich sind. Stellen Sie sicher, daß die PPD korrekt ist bzw. daß das gewünschte
+ PostScript-Level vom Drucker unterstützt wird. ) def
+/AGMCORE_color_space_onhost_seps (Dieser Auftrag verfügt über Inhalt, der nicht mit
+ Host-Methoden separiert werden kann. ) def
+/AGMCORE_invalid_color_space (Dieser Auftrag besitzt einen ungültigen Farbraum. ) def
+end put
+2 2010 true Adobe_AGM_Core/doc_setup get exec
+%%EndSetup
+%%Page: name:1 1
+%%EndPageComments
+%%BeginPageSetup
+Adobe_AGM_Core/page_setup get exec
+%%EndPageSetup
+Adobe_AGM_Core/AGMCORE_save save ddf
+mark
+/0 
+[/DeviceGray] add_csa
+/CSA /0 
+/1 
+[/DeviceCMYK] add_csa
+/CSA /1 
+/2 
+[/DeviceRGB] add_csa
+/CSA /2 
+cleartomark
+800 path_rez
+1 -1 scale 0 -49.875 translate
+gsave
+[1 0 0 1 0 0 ] concat
+gsave
+0 0 mo
+0 49.875 ln
+155.75 49.875 ln
+155.75 0 ln
+clp
+gsave
+0 49.875 mo
+0 0 ln
+155.75 0 ln
+155.75 49.875 ln
+0 49.875 ln
+clp
+7.375 0.875 mo
+6.375 0.875 ln
+6.375 48.875 ln
+7.375 48.875 ln
+7.375 0.875 ln
+false op
+0 0 0 1 cmyk
+ef
+6.875 6.375 mo
+10.4863 6.375 13.375 9.26367 13.375 12.875 cv
+13.375 16.4863 10.4863 19.375 6.875 19.375 cv
+3.26367 19.375 0.375 16.4863 0.375 12.875 cv
+0.375 9.26367 3.26367 6.375 6.875 6.375 cv
+cp
+6.875 7.375 mo
+3.81934 7.375 1.375 9.81934 1.375 12.875 cv
+1.375 15.9307 3.81934 18.375 6.875 18.375 cv
+9.93066 18.375 12.375 15.9307 12.375 12.875 cv
+12.375 9.81934 9.93066 7.375 6.875 7.375 cv
+ef
+0.875 12.375 mo
+0.875 13.375 ln
+18.875 13.375 ln
+18.875 12.375 ln
+0.875 12.375 ln
+ef
+18.875 12.375 mo
+18.875 13.375 ln
+30.875 13.375 ln
+30.875 12.375 ln
+18.875 12.375 ln
+ef
+30.9375 9.125 mo
+33.0557 9.125 34.75 10.8193 34.75 12.9375 cv
+34.75 15.0557 33.0557 16.75 30.9375 16.75 cv
+28.8193 16.75 27.125 15.0557 27.125 12.9375 cv
+27.125 10.8193 28.8193 9.125 30.9375 9.125 cv
+ef
+31.375 0.875 mo
+30.375 0.875 ln
+30.375 48.875 ln
+31.375 48.875 ln
+31.375 0.875 ln
+ef
+30.875 24.375 mo
+34.4863 24.375 37.375 27.2637 37.375 30.875 cv
+37.375 34.4863 34.4863 37.375 30.875 37.375 cv
+27.2637 37.375 24.375 34.4863 24.375 30.875 cv
+24.375 27.2637 27.2637 24.375 30.875 24.375 cv
+cp
+30.875 25.375 mo
+27.8193 25.375 25.375 27.8193 25.375 30.875 cv
+25.375 33.9307 27.8193 36.375 30.875 36.375 cv
+33.9307 36.375 36.375 33.9307 36.375 30.875 cv
+36.375 27.8193 33.9307 25.375 30.875 25.375 cv
+ef
+24.875 30.375 mo
+24.875 31.375 ln
+42.875 31.375 ln
+42.875 30.375 ln
+24.875 30.375 ln
+ef
+42.875 30.375 mo
+42.875 31.375 ln
+54.875 31.375 ln
+54.875 30.375 ln
+42.875 30.375 ln
+ef
+54.9375 27.125 mo
+57.0557 27.125 58.75 28.8193 58.75 30.9375 cv
+58.75 33.0557 57.0557 34.75 54.9375 34.75 cv
+52.8193 34.75 51.125 33.0557 51.125 30.9375 cv
+51.125 28.8193 52.8193 27.125 54.9375 27.125 cv
+ef
+55.375 0.875 mo
+54.375 0.875 ln
+54.375 48.875 ln
+55.375 48.875 ln
+55.375 0.875 ln
+ef
+54.875 6.375 mo
+58.4863 6.375 61.375 9.26367 61.375 12.875 cv
+61.375 16.4863 58.4863 19.375 54.875 19.375 cv
+51.2637 19.375 48.375 16.4863 48.375 12.875 cv
+48.375 9.26367 51.2637 6.375 54.875 6.375 cv
+cp
+54.875 7.375 mo
+51.8193 7.375 49.375 9.81934 49.375 12.875 cv
+49.375 15.9307 51.8193 18.375 54.875 18.375 cv
+57.9307 18.375 60.375 15.9307 60.375 12.875 cv
+60.375 9.81934 57.9307 7.375 54.875 7.375 cv
+ef
+48.875 12.375 mo
+48.875 13.375 ln
+66.875 13.375 ln
+66.875 12.375 ln
+48.875 12.375 ln
+ef
+66.875 12.375 mo
+66.875 13.375 ln
+78.875 13.375 ln
+78.875 12.375 ln
+66.875 12.375 ln
+ef
+78.9375 9.125 mo
+81.0557 9.125 82.75 10.8193 82.75 12.9375 cv
+82.75 15.0557 81.0557 16.75 78.9375 16.75 cv
+76.8193 16.75 75.125 15.0557 75.125 12.9375 cv
+75.125 10.8193 76.8193 9.125 78.9375 9.125 cv
+ef
+79.375 0.875 mo
+78.375 0.875 ln
+78.375 48.875 ln
+79.375 48.875 ln
+79.375 0.875 ln
+ef
+78.875 24.375 mo
+82.4863 24.375 85.375 27.2637 85.375 30.875 cv
+85.375 34.4863 82.4863 37.375 78.875 37.375 cv
+75.2637 37.375 72.375 34.4863 72.375 30.875 cv
+72.375 27.2637 75.2637 24.375 78.875 24.375 cv
+cp
+78.875 25.375 mo
+75.8193 25.375 73.375 27.8193 73.375 30.875 cv
+73.375 33.9307 75.8193 36.375 78.875 36.375 cv
+81.9307 36.375 84.375 33.9307 84.375 30.875 cv
+84.375 27.8193 81.9307 25.375 78.875 25.375 cv
+ef
+72.875 30.375 mo
+72.875 31.375 ln
+90.875 31.375 ln
+90.875 30.375 ln
+72.875 30.375 ln
+ef
+90.875 30.375 mo
+90.875 31.375 ln
+102.875 31.375 ln
+102.875 30.375 ln
+90.875 30.375 ln
+ef
+102.938 27.125 mo
+105.056 27.125 106.75 28.8193 106.75 30.9375 cv
+106.75 33.0557 105.056 34.75 102.938 34.75 cv
+100.819 34.75 99.125 33.0557 99.125 30.9375 cv
+99.125 28.8193 100.819 27.125 102.938 27.125 cv
+ef
+103.375 0.875 mo
+102.375 0.875 ln
+102.375 48.875 ln
+103.375 48.875 ln
+103.375 0.875 ln
+ef
+102.875 6.375 mo
+106.486 6.375 109.375 9.26367 109.375 12.875 cv
+109.375 16.4863 106.486 19.375 102.875 19.375 cv
+99.2637 19.375 96.375 16.4863 96.375 12.875 cv
+96.375 9.26367 99.2637 6.375 102.875 6.375 cv
+cp
+102.875 7.375 mo
+99.8193 7.375 97.375 9.81934 97.375 12.875 cv
+97.375 15.9307 99.8193 18.375 102.875 18.375 cv
+105.931 18.375 108.375 15.9307 108.375 12.875 cv
+108.375 9.81934 105.931 7.375 102.875 7.375 cv
+ef
+96.875 12.375 mo
+96.875 13.375 ln
+114.875 13.375 ln
+114.875 12.375 ln
+96.875 12.375 ln
+ef
+114.875 12.375 mo
+114.875 13.375 ln
+126.875 13.375 ln
+126.875 12.375 ln
+114.875 12.375 ln
+ef
+126.938 9.125 mo
+129.056 9.125 130.75 10.8193 130.75 12.9375 cv
+130.75 15.0557 129.056 16.75 126.938 16.75 cv
+124.819 16.75 123.125 15.0557 123.125 12.9375 cv
+123.125 10.8193 124.819 9.125 126.938 9.125 cv
+ef
+127.375 0.875 mo
+126.375 0.875 ln
+126.375 48.875 ln
+127.375 48.875 ln
+127.375 0.875 ln
+ef
+126.875 24.375 mo
+130.486 24.375 133.375 27.2637 133.375 30.875 cv
+133.375 34.4863 130.486 37.375 126.875 37.375 cv
+123.264 37.375 120.375 34.4863 120.375 30.875 cv
+120.375 27.2637 123.264 24.375 126.875 24.375 cv
+cp
+126.875 25.375 mo
+123.819 25.375 121.375 27.8193 121.375 30.875 cv
+121.375 33.9307 123.819 36.375 126.875 36.375 cv
+129.931 36.375 132.375 33.9307 132.375 30.875 cv
+132.375 27.8193 129.931 25.375 126.875 25.375 cv
+ef
+120.875 30.375 mo
+120.875 31.375 ln
+138.875 31.375 ln
+138.875 30.375 ln
+120.875 30.375 ln
+ef
+138.875 30.375 mo
+138.875 31.375 ln
+150.875 31.375 ln
+150.875 30.375 ln
+138.875 30.375 ln
+ef
+150.938 27.125 mo
+153.056 27.125 154.75 28.8193 154.75 30.9375 cv
+154.75 33.0557 153.056 34.75 150.938 34.75 cv
+148.819 34.75 147.125 33.0557 147.125 30.9375 cv
+147.125 28.8193 148.819 27.125 150.938 27.125 cv
+ef
+151.375 0.875 mo
+150.375 0.875 ln
+150.375 48.875 ln
+151.375 48.875 ln
+151.375 0.875 ln
+ef
+grestore
+grestore
+grestore
+Adobe_AGM_Core/AGMCORE_save get restore
+%%PageTrailer
+Adobe_AGM_Core/page_trailer get exec
+%%Trailer
+Adobe_AGM_Core/doc_trailer get exec
+%%EOF
+gsave userdict /annotatepage 2 copy known {get exec}{pop pop} ifelse grestore showpage
+%AI9_PrintingDataEnd
+
+userdict /AI9_read_buffer 256 string put
+userdict begin
+/ai9_skip_data
+{
+	mark
+	{
+		currentfile AI9_read_buffer { readline } stopped
+		{
+		}
+		{
+			not
+			{
+				exit
+			} if
+			(%AI9_PrivateDataEnd) eq
+			{
+				exit
+			} if
+		} ifelse
+	} loop
+	cleartomark
+} def
+end
+userdict /ai9_skip_data get exec
+%AI9_PrivateDataBegin
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(R) 9.0
+%%AI8_CreatorVersion: 9.0
+%%For: (Gerhard Gerlich) (TU Braunschweig)
+%%Title: (bild4)
+%%CreationDate: 09.04.2003 16:23 Uhr
+%AI9_DataStream
+%Gb"-6CNCf4E@CSil9CdlMNGJg?G%@`LEjl-d]57u#g'Zd_nMgXpU!D2`U6e!oLNctqF*RK<7NuSRiGY`D3d$'8to-1+Hc+dr87f]
+%+23+%eMls3^A@@!rV5;e4nop+5,UaRC&,RUrh"+Xq=`QcRgYi5[(Aj4I`_,s]%A'[(GWJQT"=pjk.>hUhgbLA`t*+FIf&O&_u5@O
+%hu<CiFoV<_mtX.-lFT:YiVo=U?aWs_q!MX-q;]@7g(WAXrH,RIlGLBMrQY;q5JFgT^Ua864P1$c0^[QnX#KjdTDn!A5/.$]S(:O8
+%ZW[;GHb`__jPB.*hmQihCZ]i1rT*tW]5Ko^I/W<I7t03A]0Et-o]bb`pY9B\Q#FD8h1n38>l/<iq<PN)HOWp,H773/lg-R>hqYu[
+%rUB@5lVE:\JM9l0s7Nj<lp!\lmf`X3q`"9,IJ*:MD)1!tKqJ&jr#u(EJ,e'R:S1hjD(9CLqsgTar:f4q1al]qr0Ld'rq>*Um>W3;
+%s7ZEkqGD%`-A^OSX1*S'h<*^d&+<_@oZ.POp9*<Pp@WY(T4fp6hQ$PNksl!VfUr0E!8ld'l!W40oRFI9e`A!DTJ3o_=nl?B\butd
+%G6`U'pnhEriYp\5kjQV56>V-ogtlrFL[0^L8smMGGl-n>pTHfp-&f#&U7nbHmD$R-gp/L?[^,_eg`bg-.(7R]3h!h^j#:oVo]*hb
+%?bcF!rML1`rf6.2(Z2m!e\1nUkuZd?7pF!c2HL3FTYLEmrp@a5^]3FpRk=hDHL.OO^3Y.P+FNnVr\Z=ln7DB%C@Db;5CWS)'C;Fi
+%mpP^9HmjaLoX"#Ch7`g^[iYnqhuu@F_qXqcnDSlVBO?$$%].F?\S/KdX?#?"RuWdd+2YO"g`\ci%nj+:/]B@]f)>O,2d_(+rl6ug
+%Le7S)^Nf^4[i^+qp<BKW^Toh3D=5R*Q1OqJT=/1W,Hoh6^9Zi#If_b3]8tise^6@g6_XP<2n,LSs&]"\I9`8>[QWL]lJK8SlM0<Y
+%/5P"A5Ic$o?Ij;:rJ.T@Du)QpV7l</5L:e;rGR/YTs\cRfuC8oljo$ILTC0ehhCLrq!c1.^A[oqqg\Lirpumr]E+fj>^a$XbORU8
+%D7qO1q)7'KgMlIsh6"@J2n(_)2qL"/S#`%%RsJ"NnkH]P2rVd6\/Td)Y&CL^Y-5$if2pRjfCc^[kNd41YJ[c_G0@;,2TOS4c11XT
+%4C0$]O7cV8q3[34(lnUZNqR.hDQdr\Y-3je='(_ior;9YX)o)[_NhlV=8'dAhHo&D?=+a,Y:_JpbBd;Do4>LlQf6A"\k@Bal>=56
+%fC`7Ll=I**e6Gq32,mpg[FLMrE`9-aZ!<R;;G/ILU_6<K^::#l@e+BMak-?UYOZ8-\`B8ZN]CXB?+/F^gN8X^dkP.)b>_D33MdEg
+%83XRpPDQd=-=4`&]S`%KgH$YCQsu!tqWOYj<9,smK^3Rc=5bpa:dPX@`"7M20%aS0XhXDXrogQ`V6@W.m$!JoGjjJJXZ,\!h7.6E
+%FB@nY<EEFKNJ"e"]Q;@Z@rLao]s^FXAM7o.`FbTU[)%(SXL6'TFYmqa9Uj>HZmd`sX%XJ"BmhXa]/8"gD)2*&Bs8DeW5J7JfCG)q
+%boPr5\X&TIBYVIUr+jsc)?qbdn:TV'I;Cmip@rm_1Y:`VlUn=Vs2rs`b]S?rih,=Eqf@,\\htig9@kB&9U@h^q3+m1CS?59=$1Q#
+%P?4MT$iFZ3.VGnF?>Yi)An`M62U[[+M5ZD5>W%[ah+5Sg1Q@@'7SZ8p/#eYtd`BXD,<*Y4G&H%.RRW$:UIV$*V:=^-BlrXg?S.7N
+%>rUbc)b_JeXqA#f?8pl0)j.1\fNgA/GMS)4D'K.k&OYH3@Vit;2^2DbAYYX57QGD@f:,6$?1LW5X0If=grO;KjS#U9h<ROZD]A-!
+%7ZMmAbH[2mgrOSSjSGm=mH[6UD]9VLiYkN%NOCcs^X;l2kl'&[#lf%bj4e;e1N8=&KZ5!0@hPUmMp'*sNfA>>eD!XFR#,TP,rFbI
+%)NuV0fj$G<F)9Xpk485g1iDBWr6e\GCb.%p<`L*^\n\>4\mb:!d56%/)I!T/]qra28n3(3NU7`*qn"lF?CSqE?/pj:n]0/SA81u4
+%o(m*8bk&E>p[*rS%+R5T)B+6&NR8Ns@TU&iD@hp^ia+llagf3)@(/X2gIBdZs*>*AG]C=d?U8H,CUhQ/=QiGKcdC&0f:!&=+O8<G
+%efC>l&WaMh-U2X3A$p)tW52CclEG[(7>0@/m.G#I@=W-eIpVR>F6aChof;<dT(]NR7t'+?SsJQ<:OCgEnf7=::O?9:UH\'Z:Wmh/
+%-W=Z0gpgI'd&Zllldk@PReDD%,l]DeCH3\UIBKBRS.`4n=418IM-?N%Be?5NXj<9>Q;aO/_ibd,;Hl'W&>t"S:3fr*H:UH9m+4#L
+%k]QR6FZb((r6+a8f?FDaC0&MLQ-2:/SbQ@[2tt+qAR.i_+3Vr:<%N<Li:I_[H1s?I/"Y4q:L;4i[J]8R:K6DqCINpT'<cBS=rqGJ
+%i3d>*HVq]7pLXYW+a_kZb1Y7o8)23>AXsV,C3_8o["qf,93J/]]NSXa3\B@Anl"%Q&[.LeZ;-<tH6L9%U0=2d:B-Xb0d`YkV%hP\
+%Bu3b5mn[d"0a=*FCAG\a*bolk/bGT4*1GNKUe)Fb3noPg0bn$F?5W03d7]BSp2dAOp#BN"('.dpk#kl@Z(H*>YTN^D*\,I.ZuG%.
+%SSL[m=Gp+F9Neb?]/e?=ol>1Lm\lWL?\pRRh`pe72o#7=l];)9f8"j'qoumeO:UiYfCqL5:AtFQXQ$e%D*6eRp3:q,Hhe:\XQ:Tg
+%m&>)9Gt8Hm.\0Z_d_hYK-^KP[Yc#p+jWQeRWH;V&,8B.VC8.I(MP5\iIIRubc;6cIocC:ba;Y%'A:F:Lj6Nn`HMu[ODZPEE]@NSj
+%Ui#<c='T$FF6/s.CIgMNXnbWkoeG%;a30Mk"MVqSS/)2K.ka*K!rZXij":,/li41!;*mXe,@m\cSWVtq_X>n;bq]j#OlVHh8'$\r
+%-q&?6p(6ltqL]Jq@3Phb#RD$)+s9??Ndr5Q8TLb*)C/!ARXd?uGle%iKgZ9h'G.:M+LT?_Z%-FTUg!k6QUgo6OG:R^/%RiOU,e-d
+%XU9@*gUi3Tn#nb=hUlKaH`G4;*QakeQA61M1Y;'@Z4Hs4T,6lk<0)+gg8B40_'_=VB_Ar!HX32V(B*q$V!Im,[@I6FE'8cp0$bil
+%l^q_rHJ[!J@3$P$2gH(49okGaaI+/^()/Gg]HlGK6q\(B8ZWo2]*OWN:9K;mVhgLRO01-,f(2J=Ia*K+Q.#<+1jt^b00:G-+QuMF
+%PLB'/e/Tn416D)B0n1Gp?d\CTO,T^(ifBhlbD(g;PC!8^;f"<&Foc0K-LrB*lKg!mrQ-<qB@IpMK'Hi6'bZa%O,>3]P&M:<-uVt^
+%"LSjV92I4D:qZu8'2282MukREoZXg%<>1Tk:cC]!["poTW-3dP$*#@$T:gXr!X^D*.&!;gOs175-n(jhN\78mP"l?f.I!\%R?DFp
+%g*u9aUnLu1cWg<V:fBq_,up54>,8?b`elf-CTXDAP3+7*.qu2_^Tn'e3im#"<sot[aQ+YY/8MSlc\b3HF^!1-=hsBmm4p*!?.MsY
+%GE=dSRBr*SOZ4M0>*M41'Pac<cA&U3`]NFtMpeH0g:OQ`ShlM&m^p]c03LX&V^$NNeAC]H80E20A.B5E87Wl`#/hJkAY[m9LW1#i
+%Ca@[rIG;ht))f[F:Y`hA`3@d'hB8/$V]@]dh\giLoNcIEYY@SF7:OG6cjaF951=_n-!P*[?3kAJBmX:)NBm3+lg7/T]-*-G!2jbj
+%"'+_ICr'6Y,EA.2]"tkFI)?0c!V`e+\A'0OO%,\nX>:`;2O`2tf4t50bEMZ04D.C)h8Zc`@,uU-3I$JHK13<"?k;BD,aZ+h1=h+-
+%!U7JSj:8=tUhFhY><_-lZH`[?1fG[QMs*erUi=^.Gj+j;.lB8j!@k8W[J.-XR@QOSJ,f6@GOIc0rV6'OpKrR;Ba&4a7l<O(XaA$1
+%;;&DLVA7*_<\/*"B6i1`Y\hRXI//q;5erFlh[BcA^V0%1`m@3ZooB0oQS=N9W%\c:=,rss>Hd6sgr<YK`c7$?=Jd2J'h`c1+8,aS
+%H?<;SCLJ50Z2H*rY/s]:]%$&'YG5FUHF<QN8;8/Ei'gr86g?mBYJ=5h/((aII`ka`WdJ+;Ff!\eYA:ghpps`f$GYmfI?OGgj<s/F
+%6JaU?jRIupP8<Y)CrE+9fXlmfh40/=k9B7<+"Sf1%o27,4ClN:p9G+P(pN^.<eD-%H,(EmJ2rGZX2/'EpaU8);>73Zek=he'%:s'
+%>>I-sD6^J;`feSgWEY.e$h"VZ'qRuX@D<q4<V/c01L[U4YTU&L'MV-fM<"cd#I8i5R`73W@(/]+%8m8:+DM/B!tc"')25PWquA\X
+%n-%_X2jf8-O>d_p!<)s<!dFjEAX!?e`(T/+`%A,he\+DC6!ONeL.C>T1AAkgFB.BF`'o3;!%5<[&>9N\-AO,UQjU)5?nB)sJ@Q5<
+%!=!U5`=MTrL3=f2`Vh@b>B[Y]4)WTeJ&<$FZ3nu*UubMArfn2'_@D*t-DR@^9Sf.Me#<q9%8#h+?l-YR7\slHY?-@k5YOjO8TZ!n
+%#A`Kgk],5BN"=m3(L_0(67t_&IhYNHP,X\=[k'2#8dRi9nrfu:J1A`8VGb9)0!(Y;HXKR&c_Z^`<MrW!Ms/lmY6PO!%gLfPm'qHt
+%`pf\S`[<$J0OpuMM#O_nL"r)TSSO$f>uk"Zn_-IUmR>d26?8D+WDel$45,\ZH^neol]+&8Vd4I>TbJ?=TeSoR9Fm3K!AY93dt;1W
+%Qjg$DBaBud@$r&gF#DT#8&L;9YaHOlK1;74GedjRYo7=(+Z*7r0utmrX(5Ui[Vq<@_FC=qLtcU/d<IbtE^]&Cck35r/X)r\Ai*6m
+%k/h2_3_(,8=XgtRZ<Jf@*"LOl,)TICoBX9eS*i!Ib9^%XUm#94&K@VBc[fhgZR);-dN2YTKQ8L6\7`um(sa,(&dRa4fZ1[Ek&)Im
+%,N(<ob6c#',1t0&A8*0^'D&b:$,of`VK=PiM\SQ0&RnjT,GH+/`Q0YY75;4anfe,gBQY[IUDOog!\[T!Z,B/Pn\CO[eM8f/q0">^
+%G=2uX@]A680>E[B9>)f^Ks-5eZt[UK.E;>--N:e"8M1U/<%o2GSkA=l5bP=R3pP7N1]Gn_.`7N;]gjT%QdQnsk7M:sB3J)sa(HrA
+%lmKC\P\%mgE[GRi-/j8&$JJ@CN?MjtGBmssfih>$T!G:\ASk>5Z^Acqk1Qoc/LtL==kL6Yk*<cudS2:Ka<G5^T%PZ\(:LV%Ci0i;
+%$^t>MkX&mJ^sR%f9+>.3q;o[I[&D$Dr@Xo4$3na>k8]fN,?^,)Sk:/N;O%2BhW>\)6eh,*FnYG@dY7D$KpEaQkKsT'Hhg"OI/D!L
+%Tudd&?^i=8-[;W:,nY9>#i,_"!H#&id"U?`"[1=f>Q]u01q81"F(c-LmkJ0+'FKJ6i-`-AK"#7&8@CW-J=BbPIh8uY@_hP%dD8&E
+%OXUbWY8<l=2ndDT1o;pDoFbN"'>#e^4Eu(t`$IWqn$uIpEbp,LrO_rf++EtSn<9Jp=(Am[rVA0Ui.%G/i'!gHWIlj#Y@Q_nb=g>8
+%)>X:&'(njdI_WN`]opciZFiT=P0nW^HsXK!2!3XiiVFAK10rAb!S5<qht_TGoWogF<_t&;%,:LJZnVJd^OQ:[h:o+C?SeXCSdjmV
+%rNn6Ne%X=-H\$Rla6/FGX2FD$NY,tNT-"QXHi<^'nDtiP?`pI0X:@bDlBfA5?OGtE.@g./E8HquGqUOG4@aSk>HAUul^-m^:UqNH
+%m-Y%\0@fZcGl:b\]6j&X^JrPVMliTF)>0F>\/sD`""DLX;WXKqrMOi6?_JNi$&8J<%>Om\'Ce^i`"s+GT-4\/`?'%H?LbRkD#Sft
+%,45S'4Qko)Zl2-sqX`h!cO`nG*rXhH<A)$&DoE*0/\Y2pr)2YI^L*7!1lFN"eE,KXAA-0[fgA1]kGBUW?W(IW8!UiZS,W/aJ[l7C
+%3*<p/EWFIkp>q3QI+*LKIqB]#=WMsp*<.[r_sbtWo;0A)PR]o*cMf!99O.:m1E._)g-B^?hS(OnSYfV+p7gue\Y^<^f!4s0Q"<KO
+%V=`5@[GH`<->M+G<@c?lnkDseZ^C98nb<LGF3((C2OuQRrs$0U"uA:\-I6XU52(8&b0skm_:E\@J@Pmo5!<$*@pPpeVB>B%(/1F3
+%6jo*0mU)agI#E^eX!.E)<t1P^6';)5ZU-,[La8erLcHb?'\JK/,(ljCNW]2BVQ2uQ8m3p8Kjsugg6!jtI8JGn&T(.lX>f%2K@Z]@
+%a`8GQj0Y:@q#Ce+S.]"r10U7V>+[;-#>gGr(##CBS1?l#!]Q?"^j-"dD,_:f%]q&k8TN4iR-qD)mPZn3Z<Zac'i$4Nk9D9r+sWZl
+%%<3S?s!^eWB<G1/iA>Q,ZeMY(_m2#RN\M(iJJ]uKK+3$!+r8F7QTTH9@@r@/`'m4-`'bs%ZHEgm"/Xp\orBmE@STcB'@\a"IDIV#
+%'tqDQ_1_W:,JbKin<RSjd>4%9,?.%o``8oULp8bpfHVCMnQ<6L""Q+--jX"A3sk.>UeX=ROcb@^a;uY4SDkm&,]GMD;K=N*'IG7:
+%B=W/b1=29qD4.A]k9Rg`(Tubl<$lCD@+B%i2P&id<9JS[o!b'Y38&E@E4P6(dhPn";PrQ,>2T5-^/*8VQFbu>lZ8WeF(qb*SpB"i
+%ToRJ)e>-5Q4ko=+Wfl,cPT2)D)P6n<+mP!am#1i/MuE"WSc.o5"8[oXqMPIPMZ`g6"8[oXqKk"gs7mR[?e2A>-+J=/T769U<4)6)
+%?=1RIT6U<;7QZ)+TDfHer?Zjfc_SJY$E<#X*pK"RdP#mA?h-b6VgUc#qN=AF=[r%#*pK"X04,("]X4U!0a>m8H"pZe_e0UAk7E\%
+%FSL:2b:eQU?KUFcFeP.OH(hJ#QO?]?q=*Y;+iO8s_pDa?7/e&Y#@TRT+A=XAojjZa7%Si;cZfN;E:=A'U>p5TI*BkkS?e?U;b"oO
+%T[%eDc?OlbI!/7pI#GJ_JN:VF3>ft3B9?`+$=:5/pa'9KH8<U)@re$JZVWUt+&X9fPup4C6Or,_H=dJS>!gVCR85K0o1SiePD,&P
+%OeYU1;VkV&CMrfQ',-@sN?lPhnAiHif7K:;.1hN)VoPf5O&2Lp3H7hD;>Y)B.T4I4Q+L%m[`[*'SXL7mAYi>YFXcNs-"meYEZ-2Q
+%aq^sYbFi9d*D<c@4Oo!H:3E3]LJ.l3L#NrIKhNGq4tibbb+^HQ<I(lb]CN*XO'3,uO*q1U;K3LZNNJ@*X1<"7G>NE0AN)/m^0BcH
+%gqtTE<I71)mBsI#&iZ:k(:(9f.30%(Z*nJm[Z/tO1#"Vk$cfP.Ef=uR-f`:oKon$hlKoTN7dTWFf[.eB7;h7tcp_Hc[h7]1MCm9u
+%el^;"br0HQZY0oK?qsinNQ[>'E@=L8T2W8p6;`c<;3B1b#^h)SB@:JX'F@aPDYYi?)^_^UC9R8/M+aYb7%NqDVb89^W^0FKn4`+u
+%kSl[%ig->`YP$+r,P)H,-&Wg-;4-;f4b+_3e*t9N:Z0G?X7UZ)dr=Hu1*$'gq,$R0daNHdds/l25Mq<6_0WC#SF&/)ldX7&)UEKa
+%Z^g*HN)OnM-b3O$'X0^R(@VU]$Q&s][0Ab<*q3_7b>TE8C(sbkBbb<k78\Of)Y80c?=#PPmkQLK)tTE"Q^<^-CI6G/bq[//FdMDX
+%^XWVREN^JW";6h<l`fJ^e)uGZrOh`5n"2T<9cX<tVnXgQ_r(+]\)"CJeu-:-B>6=hYj;pW>7CkQhOtSJZeoA0OdFVWDo;*`GR\<#
+%c"a2T!sPX=r^DeQ9(o0gUBNg5P#SH96Z>:VA*38V7/bZ3$jRi,e5W^HB:hKA97qihKST%K]45i"m(ceWI^%q?e2O#oe@,W&ZYT@F
+%+$Qmn`'NCirA1(X'D.M0b@g+q>j>JO$e'`WH52S(IXY9]_.l)3]H8Y!A3u?^>*)pH-X"],=nU7F7cNeH!=cWEDO?7OO]Dj^C"6!!
+%-^lf_CXiag&T^Do0qW&?gM1lB'bMEGhhoL8S8_L$KWFJX=5-ZVNXLaj,*&0SkA#Fn<Bo[3E^&Z$km(KCNFCNrckVZoPa%,`<+@E.
+%QtP(sONjr(4F.$*<aJhDEd%`Uk?N1E\ORrA8QEr+?p9oVj]%G$S'4OUVj9gYc.urEVdug?3WFmJWR/:M9%I1j=ri8Qj]_q3-KZIa
+%lF<qFi1=N5<T0YRZ`%4o[o*]+;Or'kFJqi5`Dd]oPiJp07EKcu"F7h9XoK-$*P_*M6IV8q0&:#he'C"/QNn#2>,t&,#P#f&]O&o_
+%#@(P5L>+%SII/Mu=XJ(W,LpJXU<?Sq?3]<W^)DF5<MN?\AOSgZ1X\K:=QX>f5u1*pH@iWlEC'NoojhFXe(m4*d@QE6*]e0(7!?@u
+%q#Rh7#<NH:n(=R5!`j'[!=k<^%YoA7-(U5d#;kOO_JnR7fKB?&&T+-dNKlY8XFM`_lM2p%GBBf%[(WX2n^41q:Ph2^E+p@M^TRHV
+%mB>i*ND637rj.!Diqh$M4Qtd1([Tj`f*Cn&W.\G*ltTs1%+BT'koeP_+WY1nE#DWnXsA0JYq(];<U@k;<u6W;Z-e3]Q,]sbG/^_e
+%Nnp&Z^%q$@?W[qfi`W&9$CK-X's2:peu/_Y4oM2(l'tVVX_uH&h*5IM,4*;_7Y`chjab`ikCh7YI*qo!7HM&Lq-[(\Fel7#Vi&c4
+%MXHu^\oX+7*[A6)VhhKN&EVA.,mJ?Q2KV,:F>tUhd5+,(T>NrZpLqne'%?DNQbu1aFN`he%X'IhDY]g?_9Rb_/Y@)DfXXhi7:PLf
+%p,()#!h)>TE&ek3F$;)8ChUrR9,(SriK<;H5!"gFH0cuN%jhjjP6J^cMZ/OYeD6%HQ0d>UV#3%"Hhf45IV-ik1BdYt<rFh2qO*UU
+%:52;hhV*bH1X:D2Zi6-8qc$Y?g!J@4fni0KDp.]LWCGla=^E`6Ld^E;j`#KG\e00EQ3SUA+&Q];6=:rBE3'ZC2d[bqs'-e8T:1`;
+%ih<2%T%N_1\SMe5K:c0*kOHPFnlGLWD:[50juRC_X8,rgT?GJZ2qKrfBq*c)p;F7/K\@bIm3PnPF0a:Y]BHHQFK^['\W][p;lsGs
+%V=qFso+S+X$^\^+Rml@Gf$Q1@=I:NK-;715+UDZtI,j$9IPlDHl72^C*W.[H^+AWA\s^30a2-0ZS_W&;h-Jd)J<si)G?MP_]*#Z,
+%YIiDtqlA7K%3iPQb(QgPoEjn.8>X[<J/h&,T>pdOFS\j.JL6s4r@t?/2fEf[APju$+Bbg6@M]Z8&/bUheH@/;T>lML_<*!9*jt[B
+%NB@n>qLkWg:Qk7!O=r_#_L[CG$Ps:8+',85NSt"mgTn>Wa`TL#1:kKj(?BT^Vp&!u@J%d\*goaP?slafU$jo!-8+c>P94O1;<)2/
+%V>pUQgQ)*(+[m4L`m;&=+OWHnMofr;?q]jii1CtD>_iDCe;M\lNS`-P2Y:i#gu,t5%uhbMl/TUlM^H"0iTnduH^<'mmMXjHA9?_b
+%@:cd_VZ!p/]>ULK(>W-RY/24PjSbmdl&80?S<[X2m%1>IHr!#_&J5hEmPdJl(XpE3[-;'O<44XqY$?o9/)Sp*a(DknZHV^(gpTY]
+%<om*Gd^4fODO0rFH<%X2ot$TT<I2Lh-`nq0k/re!@etU[s3V*9Nirg/D^PiCC#Q.Z4QNsCr0F?kI$Yc(-^cSMgSJPq^tr1i]l<6E
+%?[YK9UKK&lJSg=14he)OaVkOkd<4p@nJ)d^X!g*EHGYN-duU\sn;-'0b?eHW^:%e"j]]FXCX@SIrH5.n@?SahjRo/5DmHBO#51,)
+%h6WC2oTejeRj"TNlA"?70$3l<6[[LNDAnQ+ik6N4+Xm'I+Zk:VBJ5=n2i>Co#l9[Hg-#M=C22>)k=oWQ;e#id-=Fe9,-4>HQ0)4T
+%95^#,<CmCZ7#6u-Zn*1DG);eWWP0tW\$Z:H(@1ED@hM@$>XTdVDAGsiOfXIX4moj)2i!Pn$HC/!:Bq?4;?s(li??Qd<i5/Ve0sd]
+%&k"$\F4d^Y5uD3JW8V<_D4M"Q/p#\7.V`'qL6lc00Si)d_g=K/@pLIo(:Wh,RAk@!RIF`aH:cR*=QYp91sLU([Ci;L%T$_^8^eY_
+%k"#t.'@9<LaiS>%</t;.Sg!2]ZcX.1b?h<CLW`RZ=98#e;LVCiZcA#-P0rWTn)Lf7)*?I.&m_BZ0ji[KXZ]2Ab,r:G./'t03o7H:
+%GHH^+1Z[S2GO<\;B"j<OoJ>O1]'H7UJ#^FmFUuj`aK+`"#X&<?#f)erqm'o-IG!UGXeW)<\IaOXq_A'W.G<-:YaCs*0j$cljsVc)
+%D,VF?6t/`-DBa*hk(M*8<G9(5BuYt10d^ZAW]*jaeejk+e^$7GIN;*8#0j`L%Af[!l,QWsfkd(&,lL%fbGU&6`SE4#[i`U9JR$g!
+%&]h?ej]Wq)HkjeH.[Xulc?6f1k?<1"f1nT_3i&e]FfiQm1pCau7<[K:Z+OBHGHJcp:5!jD-fVcadOSR:_Nnq>Frg(K+^aV?"p04d
+%MZ"IR^E`ksNWYK0(qCb/$pu>UYGeZqf3$e[:Ne<<bDlnjHu.F;<<AJG+_<m*?u&Eg>#PJC09`<PibhXS*Do&U<E=5DQ?AmOh;n3G
+%A.^Uj%l+\h$enjNWDp\+<%>[XdIi>,6^cEQH\=Q&fIs&e^2/n!qtqSCZS',V_.`V!8g$8n^Z`3olr0#!PKVYJ"e[I=m3<"mT*\!A
+%Pdl4U^\Vc'qq9)rA(mQ&)^kW6dd4a7e2Z@RHZ<hko>thH)in]\_MPVbjuCuX.8GnQI/D1'\rcsgn>eL_qpXkls7)jq$YoWUL*q<)
+%YL/hgq%AD[Q3[$WT,8WU4=6Ep.6@7pf\!(AlJTkG,+BXWK.i:BCO1jJ^-!aBBg29+B4J.(JDPSjes*a.6dMHE"8q:o+5[%Wj#?Ek
+%IImI(=0Dh0*riJBljrS%:Oi2ZlVF/0IXL&"rUN1eqtP+(YJ5F2pgn76[UK%OEc>k3d=5Was0OM0LZ>bO(!PX/rZ,qWhtHC9DSSIW
+%_VqDJJ,*I6n.ih?l'Le0hTn9o_[c.hSbCk-Yef/f*8J6J%Y%'>Sl3-=RKf:c^Xk1X)3_bTnaNIM9/,pkGB+MR>n_[;9S?g=!J1"i
+%r9XqUhX4j\":2n$6$e/aE0Eo[Ues^/+t)U`ItMA(*X#l3nk^DJ[/3l.W0;pZf^h(-*US0W%$Lq'To9_5(rj/YiR==TJ)m<[GT&+3
+%8&so>4P%6$qP:c/5=(kIj#D"LbrjdA*]dm'*X'i+RUN_[h7"'#]otN\<IAKVl96A'1KXM$4;,;jFd7aYMCUI'Wt9eWb<p]*dte_V
+%n4qP88#uf!O&mBf-g"FE?Y!lKDk'%ARMd)r4OaTp%9N(N)Ol#^*SL'VH$LL(4>^Op9t-N\4KNm4NOVc^4Ob=nM#/C/P<2oQ>a=Qk
+%4)UA/F:!)W7P\oT18"b.;3[/D+TVNe&,!rkL_V6*:)6r%X92di=,*aY@TnS5[u]E+J,V8\3!+B(%rN;gU'*>3o5ORbl6@`&M&>L"
+%N1BKo0*=hjHV%PoVd1A/j-()THFY2Rff1Ohb?Y<u]`7K!pTNJ(rUHB7rjHgml1PZA>ash5HPV&:q6TjnFRi1UDiu_l6KrU%Bs$fX
+%-T]$?q,"d=?iKpC<g`t7$9\2\Dd-;o<qt;A-<`?eaac>J$VXT8ZF:2M8Ad5T]>M17Kl)Gn`?+ddkIEDF"doG,L]<ToLPFbRbMQ(V
+%3DkFecYD+\gA#VqSVe<cB`1o/!a8h"fNqFK95)e'_fpme+9_UplckuB783%*'?D224P\^nS8IPKDQkG%L*/S]IWQLen1f8)?[n-4
+%&VcMEF5!1#$;u^tW,4Sa*.;cDVTU:^S1M#"B!IZ!@e$)\Xnnti8odO*!RN/7HfR\F][2]/GAPF*70!aV+6ql+5&*l9r&kK!L(fq$
+%n84pCY%1Z,R&rS4K6U4$&4Vd-F!LNkjGuYFhl0-\H"+!:I1WZ>H<#XH=!E<Q_[d5em9d;f5&mD3:[C0SC%!`931-Dt@T176o"jXG
+%m(5r.&:j52V]7L2)'Rj+l:IRfL&5Z#+<0E$!Bb(3*EO>sV388]_1@<VW_56^>+2)dI+N;S7FS(@oMZ34lCKqIUgG#(A+cDnZrc?D
+%^6=W?gN$_4ncsTGp-*9Tp[l0ldka*EN3e"8_&C1=75@b4Io.u)$3JqiN"(OSF^:IWR%Sca1Mfs8D50MO+<`N*"*h`>$/,C*EK6n8
+%+,["?E//PQCP+8b#`jodS]82`E,G>OXgh'^<>`'-/.eHt]S"L&)[TmU^;nZ?3/5r>Qg#%N@X*D^]'Nb7D`$&XiM)*HeYGRg3r1W.
+%1CZ_n*QL1g3i!"C^T3QP[`gE-%C=q$GP8ll64+YeEb^tE66a-PaoEajrB%\mTB9?JD<:2[<8oe-W(/Ocm<.(XCAtgRPFpE'5D#C=
+%X)*tG%#P)MU0%qbq]_:n/(<qM;s4EHDmU[5!>Ks^8;G9MOj*^R$+KUVmSR%lQ!8^"B3C<m(*B$#30:dUJ-_`K#3gPXdi-a<;k@7F
+%/QHf9q!JT._W:X!jnLk2bqkpm8fH_"gt'r#EF6F)'YfPL4:HO8#P\RRA3I+Udg<b/g><qeV6+BBF<9ok<K5!r>8mW;Nt$Ns8)\<[
+%=3q[H'mbp,H^*+o`(nY3<N#Ip^,dD"2+4LP0.HdC-[1P]_?;\-%8+8U:%cY<Oe,i<BRohXgY7:-=Hq+hEGk*P%k"]7I63SrV/;Z'
+%)6\bcnXpgI$"XK,SPGJ;+gtf%e,sMddQ+sa#o9B;b/OFNTpbi3d_tD1Ej%7"65nb(%UVpn1^<"!`En%*3_o.15Kii_n`^E&JU=*9
+%\B"?&6m7W$(W),Y%K/f`S"B7pKn"55,^D-RrH8m>\+3nh-gP8>0XqDol'@G=FI%r@F[F">2'!3Uen<oB`?Mg#oTJoCHKrF7Y`[ee
+%m>#[EH@8&9G2rEUOp+7.-d(D?Bc?71EHqiL`s;RiCL<W%V'EWU*jfFlG3G<#.t=05??LZc1s0UUBGQPc&8<qW7>@Y55q'm^9[q'>
+%a[@\;;eK.aRCn:t1^&)G*8mS@G[;!OR=74D[^nD-?_G=38FK8E2bn9=h7!(/ojN+ZX3/n4G4'F<WTJc0k(0AKM5.3kWZCo7O_9XB
+%4sM&p::t\n9&muao>!n.:`J+/W'D1E<9)48`;%gtWK>(c@Bg,IJ6.FNVU4BUK54^*BL[BqdXgq]&P8H=Ic`EX+ntmUO_Yg=\K;(D
+%UWp6*_gD0MM2]N)e>A;!qH/0,I/RPl6\"k#?_,O3h]DdURr@3^m]3g8ILcpS4Xa&KQpeeHRY]HOo72Z'g:bCR>9E&b$,^ZcIkgli
+%BFk6Rl`?gegP(@YBtrG_*N&fDs67"k`Q8d$&gB<fF/WdTo\YD$5RaJf?YTbB/VK+_BIk1hHh>QMa):5RN))PAI8,4a1_\ml#"".>
+%/:":c5BHZTrhI-Vl!*!/1]+e_h'5*H8Uj2N0RX<)05d5+Vj$T#UE/N,)Sp%5'>HHI>M]4_`.-a4-@'6-:!5@*l&j/[Gi$pIcKUP@
+%39s-_4fr&EB,Y!F=D5V@1Xi7]?Xq*b)0q^>5>5FXqs2)[Pq=K?0hil`6T=eOGN3B5pkJ8*%m6.#rSl^!^4,h$=)ZtT1=UeDT/6lP
+%oeV$.d).sA(](rK8r(;)rHd+"VUZLe[PZ@^74m/u;cBmp3lBa\rV(bekC%8nYD\U3B9hP5J)KOihtJ;^p=nN=s.MqYTdu-)=WH``
+%&BOG>EE9O(%:^Bh$PgG3;_X,"6+ZI6-KtAVqRY/5^,$3o6',H&BYPO9p$(MkDgmUHZ3#RSD<iAB6i9&7U$##$CjdEM?uPU?qs0f]
+%><2U?es&=QImJ:n#75ok-kF)/7/Z<V'CcU:5JI0crRYljj>Yj?Xg@Ad\O0OBr2oq,dlW16A2[Q<XY<W[CiR'K,CA*uF3jerqL68j
+%Js_:Ylm;i9^(IZ9M\ne2*r2,5CO0BP[G:%BhU%n]mu\&Sa1]STEaj!*138F?o''G-(G9_Q#`$Qkh*idDb?Y1%EFFJ:Bo6cghD_Q7
+%[RIq3UT0Z*!f-=fKY9]&#hn+i2uTQbE0Br0(,#*7+f;EDn(JSU(o0<FRd0?9[S:LtcG[tE'.?5J/9;K'BrqTlZ>JLP^2/5TP\n`U
+%X+Hdr)cLLgGt?kKSSo`t7hSOYJ3oIO6ecGo\]4#RC!X*hP<m<r[X=4#\!pSuK8e#)Ja.q`T[!!>[X2p3I?j\a'?:8^*jr!/Jg,4c
+%Xd`XW<_M[OmtV]/N5sH!?lGfqO'e_;rpZeRg=TBac2B>=!gD;SI2!X[p:d_kJ7Ju@:p"Tu[(.9_5[fU"/m\5jioY\X22)Vt[XWl:
+%ATKpUZbQ_&?/,4+8XoTca!cnU<9kcs(cV3,NYE%C=]o(fcZ3e5(&HMM`.H*`"7i+YSTs?D)Ik<:"Gg+J%<N'6^!0SLR9j.jFr6Zu
+%PX#5&%6O;/bn(`<;?0K9WKu$337A50`;m)--t.1TX%=-N0NrHq7W!%4G&olUNPZ75&t-JNp3o8%"Yp"2fI!C#)!h'=%k*D28H;*6
+%Q=t>(lns>CblI:7eF!3*6j1O,SekJL!oGaBM;TY=b&udR2%E>i3^cdBAoO?LKpDP"/s6ZSa\\?,JKdB6F+Fe.^2JEY>i]N#f'%8j
+%f%T:("2o8'gV0s-RW3n4d^V8a*Rmp[EI/c[U,DQYKc.*k^];`%]t+CE=:pEreM\IY@mI:2LQpTVhUP)cK_5VPTi=cDqJ+1H^7h34
+%U*Hn^j\omj2S-?Ka^I*bZe5lH,;=K'?0eso<Y!5hm_R;7U.d@pI$71F5o)E+(6Mgq+A*.cd"\,3/6h<k=!,3Sp34s2%tF<H:C"To
+%fH2^-E4LA*9QJe"+GaLbX'D[:E4O5C8O.;OMH:5qDI>7emm_!.Kne-l&6-8$!?V)^O+[?*!b"hh;Lo1^5:4fNpYLFqJPBWJ3^@T0
+%7>RmC2fRMUV,9)OkM14j!CQAc/5>kI?pc\`R7qKK"lMlL13Lt=SSp0!^pXVl#StG,E&`+GL:69Y7:9W@ToJ0T_[R("!?<$XDn&%t
+%"$pAn&WLJkIFrN?h"VtX+$X%\oB+L\+5Xd3q!Wt[2p`'u8Crhgr93W7R\J9^s7!q,X33G?^3eJ=T@_H^7u+is%KGnjIlR-EU8EfO
+%r]#mt^1!O%p^/]/+uidF=_7gJZ7IY\c%gdTf$J0.V/,+c=`c>f]5)IMN@Fq9\2XO*@,kGo['^ru^Ym@09c+6:M'n;GCU:Z5?b<8@
+%M_q=CXGdu'+%\^37h?M1dm.ll;e+]>>+XQ5/L+cCAsgUsc[h\F_o3F[RU7`@nA?=grokLJ)$fO%(]8cOU_9-1<raO]PAa-k3J(NP
+%&DO5j;N=tSZqlW@'/8-rS$7M0@QXZ1bm$X'i.bakCYQ#eHu2hGeO%&@lRN')ijZO]put7b,GJO^P@5CF-IQC@lQ:\_eo[;#<)%5Y
+%T_AH%3$@,p54Mj)JnH$\\4G/mpX%9N8bCaVSrluH!,u/+Pk!i=NhV/W-;,9\U4_f'#P$L&\;N)-^t-r?%>`nl*TFF-0[]V=0VEY[
+%cmBl)JstJL6pQqk%]I1Eik4@YZ^hDYas2&UG'fkm9dHKQgEr'c0[Qtu;7/Vu9+0`td4[a^\UiK_B5Up+RV[o*$-jW]Jc\oo(Rf"V
+%K1m?iI(2QpP$H!=PU7>)5"/TB4i@G#!6BgS4;eGdQ9%!G*M7NlOE\TU$GIG6TG>1l(U]C;8GHlooii]\NP(1rql%7M/4$$?NhB+6
+%ZeQ8V#/]1]gnT9^,U2dQ\)#40BKLf")SBV#&j:*Yp'Ud%Q[D!D%/<*VC3,Mnb&=23-P:J>?hciJL[1;S'Q-B``tJsY_n<1CUJCtV
+%G6SscRiifu@K?nSnh,#=',j0H.\T=G43MmR2M+K(!8ho51aH+#!W-/u@5UG(`5#c$]dl2JitE)g`eithmq[tD1Y*a^Abcj29l>9+
+%Y4,le]t!4n(`[MP7+gqpIXfZCGr`E!].:E4))-rV=c.b`"3LTbdQ?SK)8]#Xgj(tr9aD-W&s:jp!i&*TQj)_jeplnY[r6Y<"t)E'
+%OQP1/!<ob?GqkcO*LNp-(_Qo?2^Kt'H!X;'C&eYj,66(lHe;VLR\-JCH5+NU:f&=G@rTohOM;]E_eg;C2J[Pk5(<X.gD5@]Nc@`!
+%P[Qu#p*$:G1'.,<64`[$9-s+L1KB*&-Mr<_I^Bp?5;]oFlY2e?:'9/6U/fma30IdX/8%mdEcr^R\3R+J1_UOb?m.ZKH4_;W`]4ql
+%\ea^%U@H`!NaCf&?tuPT`>B0X[Y$V2F5'BaLmX:Ygr&-dA+;TFHoVNe.9T-%-KlQu"e!M'S@&cmKQ7^4%#KMW#r3pEQIc1E@4T%7
+%'Oia=;XjbF9sQm^61IQt^ht8hf]tcb5@^V_]g8/,0?>FG0qsL4\`3Oq?O`MWMeJ9J$.=A4N003<aop#,a^k1P89Bp_/A'&L#.X.e
+%q%FYr>Q0;SZsiQ;GASu3lFY"VY"=<Y#OE=]KK'S!)SeX57$8PE^9/lkK%q%qIN7c4iWp)BeWBPS'2a]5d@c*ImuG4YX!e*?C39`j
+%l@:56@rM_]C]OeS2'q5(J?6fX@j;6#Yb!EOPu:]oJkaAj0BX0cXD%#`bJ8]Gg(op[JL8=2XiYj<gu3B!mZ>7jhug=uW!2^!TGFqY
+%k_moO^\[V4&Et);OU6R<_g?>i1Z"Zh@%tj$d5G_`J)dG_IUn^Y0MgpGKVueX8:(WSID\$MD59l?,;J!YZN2Ak2MZ-^f#-oT&=)&_
+%h`D$TK6j<6mbC5<]T(Y[<IS*A-4k01&n'X;eHVnsD)e(l(5<Q[86Tt?`P_+k0pMi.)J53+Irp%@5"2pSc=cUjci-o3c2.G1m*OiM
+%P\WYLKV1WE-lT3DRGWar<0G'K&V<piI@'c5-%sNT3Bh;dr3iTSBXk["s4(YgH^$DVZcm]doM/Xh#lR+V:KakfU'%6s0Gnrj%>:<N
+%P9#ti+<5DIK_;7]C)AM]:g:A9bPJ'gcsq9@j+]:f&T=72kun<$2*DS8rM^qMHKqao*+-H$.kQ_43hETE/jFc@EX%GV7jD99CepQ_
+%RPooU#p_7BpSYH]iMjN0Jqda1Cas_"1ONVKBUUF=6c_V`$X[cs4]u;afn`,PGR9'V'&@P<Gfdbi$gheX&\Nf<PUh&-)/(erh:rhi
+%%Z`Zq9]?Htp`)q,U/>-&]4<fN^_BWs![h!(4T6[M7I%[r;&el1J[;ONEBk0D#ReLA$,m<WHNL,sOTt$$ENF2e%4QoFVEjS`Mg2)L
+%TYcFV0bO*%R77IEr!A,f>%`jXlLs>`)Of0=l$5g?i>IYM5u%,,"!X+O!@3[Zm>5?^,bE[ll@>1VW*H*s1rCGP3(!O8US_Tmrs_`-
+%"[gi[_$72kJ2u59_JNF%boC(E,?U.69M*q=9<#-8aFt00*]Y-(64ml9n)!E+j*f[CdiX+.!_0<]1ac.e7mu_t*"]N@6#)CY9l)BE
+%-5\HP13cWI+#10\d<S43WWH3keM^T.XZNP7Ss[JlfMT&-0me.5ea1?aXLJT</#@%n[UFG)`O@'C0W%ZZHnC'Ug(h=;=?#\\HnALG
+%n/YpVk!@\<28U-ES2fPEHRjc99]uhlT5<L*?,8.^D4U23A`oF^ptG]U>B>e-@,UO"Ks,@!1="$mY79+ubIGPn&.?-(1W!`:EH^m@
+%bs#<Kn.e&-D>r,]>+uS:!FLc!YG5l!B?,b22K4k4r/@cfBG:55#'>PoZ]LQ7Xps1Cl=Y2jWap3f/`;>cG)`V3i$<'cZ*g]OqiIo3
+%$=?YO?=RaiVY=iQ'l7_;=A)ej/#\QOY0jYg7NMll41^$;.$Lmdd1n44`q_L'U2^XagOQKXMDdI=/GPm=h]Q`Po4[]RYcuUu7kc'%
+%!QR,phghp?m(nK;+Y6`:aOWHr/<%QP6$,@o=;ETP:C%=Q8?O"W1%<FO@W!k8b]#i0<u?iJQk3nhXo3qoASWLX[mF6%p?#gsP_HO]
+%Q[M-PRKd*T;&3uhM9rT(C`A[:aH!URIk#5uXc[kNKX-TS1KUa7#&R$aP\mTV&;r?<D#5>0CNPeX5R]*3;&657_3$rY;&8L'R!:`f
+%Cbe^lN_JCmb!H?#/iB@S(_s\,'%p+tXl<%7#F''-bGiK!ARU&g&kj_.k+KNh>bN^!;eQ,HVJc!jF.Q5EHiVRK29Ig2PU2kt(9e8=
+%NHS1gbs#aB;&8;qnIW<!=nL,SNU&!^9Rib1/-*@nQJ>=Q^^1bBNj/S*.AmJ^Yu>5uMQsD$fojlV0bssD<)PFdJ9d'Y!3VoaO+O[q
+%$3>p5Vuc93D6s!Pb/05ARnsi2!Jhmb,Kcb<ZMLjmfh/54'?XM95*Ro!Nj<h\XUpAY>[1\fGeBGr#e%UnlUH=,.)o,DaGR%bSXY]U
+%^)j'1An2'aYf9DYMY9)tdY+\%1kS%Z\;KU7X.O>G#E[^l&1Ht[fgj0]k9uRB@b#ObI<7s<B8PKH&.l3GfBIVQ"sV2R'EYrFa?_kL
+%Wchj!GE^mP)D+FSC.XX6igKt=at"lb_@[q+R:2Cj+<n'^!j]->n.sUK\Enh9(b?kr_i2H6*&_3G=EDls57'%Mel`TlNRr&L@-Q6B
+%[UbOJKe8kW_%orq,[g;MA7Nebr^'KnMm$l*gV-L]#D3rBP#7%6UMC_M!aZR=,Z[/TDJ7C=,J+CiTfia3D"=@/8]/J3DAgP(#D"Me
+%45>GVGWFI1<5I6uAW;ca'8<.lTF++Pd-#>Lc>A>-B2H]Q"!A^S_[;F;i]mno`]ckJoYJ4!K#5_:3sq8[$M$ssk0,+!MU,f8Q!Vj7
+%JFlj+pBmV!il06+'sX;UhZXB3Tb^(!6TPu,QY#4b0qL^-5U9n:]$D9]#=YG.B&57qUIeuOF-HmH?9ZXRS%FR=-YXZ@A4C>kiqnPW
+%I`@<V9B+'5#JI^kNg@W3ghPBuZQ#6_>S;Z.8)pV#b5@iNe\tW\)M`q@J6<GZk5BQ)0QuG<$W]c#D:>j,6@Yr9rq%41a:q<p0N[YX
+%j0!uA*U!@2S\7Z"Rf4(=U(49&/_J0kn`.,;?lBi7?P#LUY1&;^VYUXNZpJ^+Boq8B.'01IJa[,\9ONu!UYVkcb`QneA[3"DCFH6$
+%-j#GZ,j0i[2o2h7H2AW!hHVCA^(&u)7,A-5/-en&P!&mlmP0YuiJkGRb*k12L4+0<kQ2<j>X6$&6k'?fmE;>f]4n8^(Yb8qck2$0
+%E@06Jkp'f\]?,o,%$PNa:Gs/QT"&*Db!9g@'lOGq@>,R=Bsre#:\J5<$(U:p-mDPO?Ee.$PT`&udO15C"4/n6d(9l."'G:a:r5V+
+%S,a(J]\i6t1r\5-DTn\e/%fAr+W"I"qNn$4(3K8DbQ;s4P9%2K,=I$T57>@&'?:kI<@gWEU@1b/>&oHcfR+m;'Yt__p3B15BsaDa
+%Jdn6oVnb9*n)7b)G_$eCp'J0%L-k`VBI6P8?it^F[b>`6aj?O)hVHZdEo:(+;Ims1b4X7B8B;QKd4OSn%@E$?J>!)[22+F$cRp@l
+%g-reNRlLLTCR^aG_@:oJKPZe?2#oY,8D;(@-3qTlLa5S=0M8"E0S.1+Ui"la't%A<;\#I6BTKe.J='5'D:oWT^lbYg&^Xb3r$/-S
+%Q'VqHbq&Ws!uT*:8@hX=Y9;[D=lkP%"J]`&jJ7Q9)I*X=WIn32g1pORN)WsJT#$FDqDMf&;`#W9!ln!F<71k=#TG6,7^+3Z-3@X1
+%1Go>u)eIG#M@m+L/2=[E#'!kq'#h\,-&56hU=/>g@/nB#gD(-BQBe;4NoM8q3JM4=SAg;l"Mke4Z*W\"*..hBX\+P-2e\l"/a-a=
+%g>5Qn.WG<j)@N,=Ns:WsOLlt<)GZE)jL)i1[T=0X7^=^I@tghbD6^/n8.VmXSqD3-6OPTc;l>?IhmarkfU@>hEQ\?<huaa)-ntb9
+%0nkF:%3#*Ed?TI\X^jMD'8iRt7,01()_\4(@00MSRY1;r`i.!u*PF!jGX:H[Z=HdHlYf&jTd_\T\Sn5XRC7X!A_\3+qK0-5XarHQ
+%qo4GS:_5OLK_dP,\\3c1&P;+8%#sotNHMN1rl@u&,R(3!RhAM6)]hg@4quGQ5t2eG-no*Q&.R2=Af0Z77Z_(ee/#`j5_qZGd$U]2
+%ET9Z/6.\(`Q,$@+15BXQd%AOKX&7YuWCXC1+JaQ:Yn6hJ&dIV/c4tLfU4PlEokT>jKcCOL^/3GqIq57.;_o%SVm'9]!BTQma,lQN
+%Z7s--NfY0B]BTl8/)ij41l9peAi*UPQGe\R;CWC=nU7M@1DDJX9E7]?"k]jiZ^_:L&/LlT#97MUN1tp,^(ejcBu4(:XFZb%[G!>`
+%>ml'0/.$n:g.@ddH_'kfo+T_M@7P:N9;PI_qjH!/Us7R3b,]O4pgXQf!iQ/hmVaD35GA1c"Rm3M4TjB>BIXP:P;ls?23Kf6H47=Q
+%N9;?Ci^Sef3,`1V\Lg`Z^dqb=ei)[/Si'@<%eMO#qF)bW._sOl%"?T3aBTUq#15]GULAH[^f6WPYYkSt$XmP@2c&IVAAuQF0>UK9
+%$RFJgOW3>cYpE@;.RBBA&t/9o"Y0DlKI]kb[`Wh^\,\CR,(kgj<oZJL^]7AjcNhqh%.kA=+\aPD"]nTt!LP\\!;tl6-_Q#6#oijB
+%_Ie44CsR)T!KNS:K$8liO9_Cp*5Z8,Ud%c35dDOg!&Ti>cq0*-,Tu1u6SKeLOSJ)c>CEb#09RQEor+i9/ql[.86*TK35L?t(a+R8
+%;Oehn=XWM?Wk!j=B`Q&&G]&tMGhp1lThT;PKkAq>8ceEf!n,H&m:=?;@%id<e8A]e[8"7S!GIO1U\A0:TPf%#AT!A0$*XpDJF1g2
+%I1o$A@p<#&M?g^FnK%k.?lT3:js=lNA27_kU:k>IVFn@>&S-'%A)P?u7HF`P%qmP9E\Ep3\LF7"Em)Un@PDdcBrC/j_o2qPGVT<S
+%Y*<h?pZ=H:5dH.bfQC"-KlI'b?R8HFP-tYIFpRt.;0eD'\Vd.`8:-s/i94Q+OMR[/)j_Oij"#4;TP2@-bp<7>SL&8pStTHDk+rn$
+%T^M#$9G_5.&KcaZ%:o0b(^.o6Tsd\$ad0D=XJ?Ze$CRo:fF?IKMQH!bRfp\U!(-$<iAetf.XrAdlcm8lUr$.eqT+?5(^unB+ejt/
+%8/Cb$-2/$KJsqE%%NW"CpN5=$.3+PBU*t8'_Le\I@Sb\41^aq/h=cOUFZg*7"a1GY'%lc/rYYJerSV+8/S(0O,G;%F%5j0Zisf/D
+%XkJ:FeIBMsYXD=B2UeJ[JTR1u3S5IYShSYm1^UPn>C>KpND]q&5\=YNj>W3,(X3PA!fJ>YqQStNj-6&BEhuH^,Bj98X(+o;&oc:J
+%JSaGfp"erebngkjqhl:Z0%QTB\31E?!*6%ki]3>9/6YBTYcs"PO?<fHAAOh*6*P>#A8XiBq#/-N_3i`d%OYI`2YtP$%"8aC1.c>p
+%P/eZ:@1=uajl!_cLe!@\VT9XEaNo[H]*S]<=q_(?341Bu5"qQ%?qEp[QVq'+e']aHNX[,Qs*fN6:LY@@qo,uUgVa%tBLC:249tjQ
+%KH?"_;"^!I;+M)ekT?>1KgQC>VbSqO#L\Itp\V[3rp<+:mjkW2_p;g+TW(&@76^l.fj;R1)GjA10T^)C<D<Mf0Vpa(a>5-s$HNoH
+%EXCMG)Bk;So<$I6bC*>4B7d$[&2I7'_t+(6?Nhu:ETkU8<DDjH)<Ce@a6nq:\*o[\/?.ifV/h-NU;nOK`.glO9H6`!A>1WllQBlI
+%QE^@]q)`di^?YCQ53:Q@Hc>imZ(n@XIK,\EHd?;s&h.;4P(37uNIenMM(jPrlhaD;s&n(]llBp-.R^usM9KFn;/27OT^)KDeXGZN
+%\'p]@S.kRRGGk,i1p%lETrN1C5K:>.\(pB2gthtd]%\MVF(;&,X$23&p*!gWRj87)=<UeD3m.s[KXoj0K"M&aXhC9;h%XPJ#K+CV
+%):[A+RGD1V$BrI0R-01?*,H<tiG%9Q-VX/[$BUMV$W<]Z3rtVZMBVA=*CFm:m&?li$Ept;?r9IQKrPfS<0B08Lj"T)fkZQcbH[<R
+%Xk@W[\@%$UOB<-)6$3sr3ca(6Ul'5(T-4@@+,<t%8FjI-i%RPqEUiSm*`(d2nLEf.1,I##Cb(-VW`@p*IcZAUj0RI[,MM6%<YJ"[
+%\K7ji7PP%0j!Y@Q)ZJ(dV+P'6M$VE.(IRD)_Ym3hU>S1b7>"3LD=bge.>67k8ZedlloZh8$5%iLo+L"lCLK+F!@.)3:5ni%BW)&$
+%&NMmZ1"hjUkd:83kh+`5^bk"OUGNh)p[2!&?Vor>",1inn+I@O=m9Qk,1H-T,VT]VB@^dh63Q99Al>),,kAQ!jn3_e"@#h>Y3QQ3
+%]hdgin(tJS@3AB\%1@o0.7OI6mD;nDc'EqG$s)s13*iD=4TuMNUEhNqYmQ%*J<aa!%"ta6OR3d:,\l]bUOhdi7S+R*09:`Q^_SgF
+%<6hq'H;I@1$e\.&)&*u5X%,nJ5U.*NSQ1Vh'h8Ub;k[StZIG9C")[1[&\Id96Cuib6[4TV@@Z^0c0;GB3=<bun[FN1qr!m*AI796
+%$g*!2`M1<lU=`/e<<%4mWRSkTlV7P2\"*B!]brde>Iu]'[fe'ZCNj?6:uDJbllt"%#+iW]IE^R&"+-5ZE^BDbDS+-5?%R("'Yq7X
+%:b][MAC^Wj=kBJ>\O<`H,5G2)l"EM_^e98eS\2gB\iC\/rGi6-`aAE\4*fR%)*0ot1-%bZXkm(BaNM3GaEGDRak_F';_=)6*@u<(
+%MO75ofF'38&30]-"887jCT+ZonlM=%aQc%?OSVbh$eMeOdcGJd?qf'#1b,i+?P=aA]g=5dj0iY%;?ma??.,`i>Du5g:8[[>)$g:s
+%Cr6:T$)2+!%YeI59oWV_/h(fl??D_;1kH0n0Ke'R\_"oO6sI0eRf[.23'(_dlSr_tH^4/0'+bsG3[i"Y!DGacSU?$aLs-0]FWR=\
+%[&5-N1AB_R==\B_S5h;(J:VX)24,%?!GDNJBInMRDrRL:)"Z,%+PGg6D*oKSD`+N59!(Mc;?qnig!mH,!Z\HNY0A^&&Po5*!ILat
+%TaMX+A>WHQa"RSO64B)SOJ):'<k![0/d%faj*D1e<QXI_]+%k7&d$GMe4LVh30&r^_XS3#.SE]gZoj!QA8,T/6?+as2S_@902PHu
+%!klcs1aWIX&28.I5Tk-)Hrg?70t.>\MraeLY8oS4@"dfI*LT'fO)c5-\=*CjiD?Sc_Q;/XUit\#/rkRF=6nkUi7#'?TEUUl639r.
+%0f-OoUWuoTC)T(8A]2Fd3+D4W(@6cSBX)78\.;sI<N''X1X8p9U353%@[VG7o2NtS[;3SdMpg2+(/f?L?BKgO3)$I;\=&2lGg47n
+%`5m4eX(Jq#6A<A:n]5i`<:fuW_E!14aEj]d'01focQ(N3gI6o]n>iuhA`_2K#2mQb)OP!C7RdL#eJ>-6,qNa1NpLN]G?3ldODSHa
+%E(I$RFj3/P@n^2dob%KdE+PCfp2#^.>kc(QmJELB@_i<hetDIm#2`-_X9$=0Ic+KXndpt#%p;;b\HgWcP*@Lp1k8^Y=(#$g2:+us
+%lj/UlNI%c>7$79;R3s[b7'KDo$NQbr5a`=`aN57^R2j<q!"GKJa!@6RCM7K3SoX8L&@G`%!#UlfPBa=?@TCk@UH35hrXgVY2=rk%
+%Wj)J:qRIs>]MQJeVBtWrNL0[T05fWFq67X1:@6sp>p>phWO=7^"lXhCkq^Hu-D['>Sh8"mn9(0NaS4\OF+(J$i&G!U=QZ[Yfr#38
+%0ULqdWgk@n9c&0hnre"('KAl)kOOS<[=[rrKK$.gg35'+.7h/&^9al6+O>lO5kKhq+ojq_:][\09j0dcNOc.E[U4[FM\)rj3"i\$
+%g^,.b7@C_2R>#,(<n+NE4!B>0),B8],eNW`$nLlYl?F^geQ,^iA/Z,c'0";.8^cq;#_He>Df+E9'<j8P5c`gD]F^id-95WY^rTq3
+%Y]/XFPm/SL%BiAJAp#.*;c$q*[5Apu5"Z;mjp50?"&^:Bg==^F8g2<?lnSURS25]-9E`&7@,7ZW.O")`UkNMIDC'#]7Ms*'b`WYe
+%4\T>BFJAsuJOP@t;b@cJ>/\YmdGf=$Qibb_57=`EcZW`@K[o$q#'L"cN(01X1lC"0,EYdOF/5jM*ah,`FJgdBnMIb\?N=Qrgc0lt
+%fZ-$?q5XKDC63m.!``[WW<.%.j>>+2!:fiXEW0SnY18XrW.%WVmh%\I9T0,TUr%Bt?#k$dPBB>H!7rE;*42iG#bM];8)SpQ1RL*&
+%p<&2b>6[S/?!_A$!-94?gm0]9L/"/B'OFm[E;3V:=Zj+ZWgo63)5t.L^mHW:Os>?WZt1Fd!2Qq/-6bC$R34i"<5N`"S`9t[.Q`9N
+%,3'Xs:K?,>-W-G+Kk#OP=>^J&73*5c#TS(_L;S1l:ikVc3N=U0f,X+\J\qpnAVSPV#MjR3M;t[dD>o-j/?--Z>=\?&7`LFO`4Tno
+%npL`O!l;BR7<4c(_qb"b2MgfB4:!V8Y)qrpk4HV3"<uWQdESC!ifs+]P-JVlb$uYUNp%_$MNA&sWEqE;K/cgn$%PH7r$[G!mQtM5
+%R?RE[6V6`nrS(E;)3j@587BX$Plk5T]-N8rC;b\_>(E#fEfB-u2\!^H`/30/8.NS"](^%l=clEUS9RI/:@)&:coi,sR-G=_Aa'U1
+%Zm`740$.fB)W?R^;Xm&:P),`9SCF)'C-p>mfTp8d&Z80?<W\L9<;R`b<WZ1a/Ke3TUGecs3#:/eSYn4^`);jGAi.D*mgWh1')sAC
+%k*VG+QD=\n+cIDSOp93XET08=L!'`^/[5`KZe-ftWBc37*B\sak,a'1okCuY!qGVGFpL-cO6dGjSY`9(=1h!C`s_2irD8EK<>VLC
+%:Ljhd`bBKu^ad65d6qGt'J@BJh[Ae8jL*cHOI:]BAKGTZ3I?J5_47P4rd(KkD^EL8^g+c/<'#L<f2([?_i\Gc2*<F6NR*Bql85dk
+%P1=s=m"TLOI,I?m&5rTYnTi1e;:1W/`B`DiYSA?p<%el75)D9%P76]$^^iGQ#,;i<@JW^,Kf=H1UrYg$:NfW-60`GU5W33+6+ml5
+%rZ%F4HoNm9&s++mi+\rboOn:O-pL6+5QKg&BSFTq;&ht0Eb5m421Q)rkocuUlhLr?kTEo46;/,CKgF^/N2PkH-g+Y6RB\8odlts1
+%b!&3RW2!'QjN93Eil`N1AiilV\CE)/33embNJTMgcON[Fo=/Zt!cPIX@*qS*^7e+1i>a)j#n'Xob"]bdE"ue0!+2Kp@Fj@\.>%V3
+%L`)&bEiYJA%Jtg_W]\TCa>lQA5FDk361&`+`Ah[lX?crhUa-X576MA3C<`q6)gK8scOuG8M*L(Vbu2\-18OR5M+>-b3HZ:t^`da`
+%W2L[[_ks7EfZkWq*Yi?i$mI&/\JuJTL?*>,5Gei56`G"\oE0lii&&`n9H55Y/S;sj3CIa)6M.=06Y%=dlGI'@!Pg0S?Y0j'=+kQ,
+%K)i.#@Pqa%6-hVO1'iE(kV4k!(b72k5`K.X6kNf:!T-ZZG8#bQQqT"k)06(P<Ked?OeJo[j]%3Z!l,X(4E:]-Eh8M9#f$FsW#@Vu
+%@LG6o"qEqD(#m.Ug(,4;34"DLBqRp^dWho%Sm<sWC;_;O"=*,E:<Fa\>a91]Mo_1KnVeG3\#rQ&R9;o^HrLu;=Tm6!A#6<6#ZKq,
+%gD,W#R!:K.#]#60NsrlD[I'"`!XchU3JpKIKZQj,3eMs_Hd#)O"p't2ff4$Ypcq#8UN6]NkY/@O6brG+]nqk=!)Ug_.Yg9^11TDW
+%!9VMFc632/,tg:SaEWZ1?S_s4U>*a3YeFNs1P9@>&?5U(`#u90@%-lncDt&dKg/[1I*6*G*rsNPh>)\GN3+=SBIMeS&HuI,+E3U$
+%JO'iNM;ZD_!`4tLlbjo$>'YL`(^*g'`/';560,mQ\]kO,@j.h.5JV0[P`abs_[[XDUNfN;N`<"6)dVj^)Z^I8.ORPd7PK%,\)6p#
+%T*]T`@Usk\:tGPj1`6[7XP^T"jY#+o;=MJeK&nW$O>md2</Ag&O[nm6H[PHb5a!1gS*r7CN9socp*:J:=cZ%g=?@X<jn.?Q]+qjL
+%F$,X#'W>7DJq-b:Q[tl>U_$U%,J0ME:-4OB+O@7,pD^?4JbOA"WZsM7Mh0Aps+I*53!\1%An'W`cPKTT7F=%dcWJ'\h$RCddfNO'
+%eYf.,@6I/Lfag=\;`!/RVm`!&NDm#$a<QcV<oEia=O%O"?IgVI%g-;ap"M]?BKOLkp:?Z\2u>DN"b!)9'A)4bE,l0S1''(`>,DJJ
+%(aJM/C@M>[*S*S^i@%'s,>]2+#CO8f.pe8idiC+PCtL<!7gs83k751CVWQ/&N%n@bTU<[8h6Cu%b;,Kg;t^A`]9EF)oYh(2[:Hma
+%)^V+ilu`I)`SZ:9=5]+k_oqll(^;m9Qf00D[f(9&?8kgSAq.hOV0cQ#p=,MVO$1I(,X\rQ-[c#V"p%p`76!\H+0<fGD0e;dHTLk*
+%8^3CORj?]9phg/Z08*M?M%7AX#@m,"YNo'SK83Ml.T.!'m$:]p1dS2.?!??fB^'9Y$:@qs_1rcde>NtL?',UbkQE9!(RQ$MH@u9_
+%SDt_C7n84g0T+akMMY"lk?L5Hg:?XgEfuO6^pUeY1dT2r*#U*f&?n,K6h\_Ee7UY1OkW233'QrdP8ZLb_2"kJGG+!m[s7+1<"G:Y
+%F4d<o/-Ek!)lZm#gm/F#7ibBcf;qqB[=>2-%#(NOD2ZmaL7./o>8%RG:e"i-)/#7Bk,Wg4!lGX$PkIF:peO]pLa/Qka$1;E)W&b)
+%)1Dg#`A`*J<3/^k&RMG7li;FNq^N&H/oL"-#"L9s8nT&mFuY!Q/1T>p#KUn=TQ9V8C+aL\("1k#EJ4IO7k&?.F!e+40FsC'('LQ_
+%s/8+4D@9S*,)["Q,$jK=)hiZMDl,*O4tP_p]@]rOef$M!6/QYj^72q%`8Y9/WHs^eZ!q_%dNWH5&lb*op(9VGfTYjJ8;;s@Lb]"E
+%KWbg2fWe!EN#KJ6eXtKi';u[ub_rrn^/op8d[)kt^T-dkSO,*ZLD<J1Bj"<].1!!$3GVeK=,u"3U7hRPo$:,@$qn@nET]GtW:IiJ
+%IlLjDdh&YEUWrIZ"%P4%&SV!IENH;0dK$'Q/Cb0$gKHbr@H\G!7I[A)+%c603O&fZ)n[F:;CiK1(QetO=,0pq"A='8B8:d\=o<7<
+%&FNF"e#T^a+MEXq@pIH<7\u\6E:"sNX'MKePIC!88Q,P``,c/1ZBNAB#T2hr;D)K7)FPPnVM@VUI3!mugBt?iRca,c%?j1IUVJTH
+%jhX$,>U"'K<1\hD:/9o+dtY^H#5L\7ki2`!*KVP3PCm8C`m+2PT3$.<40J+-:<Z&..U9Rj7\>O`1/OR_.Sk^u>b;eWT8\d\$EM'f
+%":bM6;bfrc_'Y/%W`mac$@#`D9<1O_WMq=%<Xq\LUu&4]BUk9a'oJnl&r`RA5k:p@$`dl'*e]+0=(Ep@Zjg7u(jkAJ+(6V@YpBL^
+%G/pn9k^`V[p+0;"OQl4A4n]jf9-?_EG9r?I9H^>/Q+><s!`<?kO.o<W"<0!A"m8]_q_UW"d;edCUl_d)C^\cd*KNcBom1Us0X6#3
+%7mVnAJMZjW.AS0`T26+L4%.0"kJI_!N`r)3!&bBDoYo)`ji&U_qY%8(YjmQt0qKD;b,n",>^pqN(+,c.CHMnEbPcc_03gjgApWUP
+%q2>tp):`Y,N3PW6<Y!u:-j,b[&^34LW5k/]"?uWX:I;ni#A%K72X`^.`aPCGK7Yd"EdFPkr,)_bj4IEZ#@3<N\_HTM+Y3V*<4.;Y
+%0I)]$,g$G2,IB4!(FDceli<'eVd*l7%",PAp$'ECkGn?$<:`=Iaj1nP^[<WJ)mDMU\*4Khr;EWJ^dFPaQl]>*k0\>R[r3X5qf[S(
+%D^X1hd3'RT]s8;f^r%[Pq\!8nK\QgW%$"g>ONc$_#'0RjY'*n_`8tZf#oMX2L2LT7E"5`+kapGlN>/6K>hgM[p*P(DC1okD^iko.
+%&GL"7AFfg-5&36I).MmXfuegIi(B_YAYA'!8]O4L6ZN9*XUNn$\ZOQqd(sNkfDtHcce6To?Rs[TN@)b42Op%@'gB6iJ[:nUeX#P1
+%!#2sLm0qh\+5?/k26Y^LWKI_IC(p.F896b[)$J*c$KBsl;\-Gq+-);ah+Z4Er.3%0URf6,f.bbA2t'80=rJ6J<*V^^K1;=7-hAgR
+%"pV4^%7=?td6=O&E?,mpd!3#Vn@4Pj^LHd8C]C*VZud/[1.jbQPbCo7Rsa:1BQ0,J*>ku]<a9$?2`0#a>;S/^8NfYV2iAJV1WC'0
+%%1S`4e9SqY<>PnuZi]9R9>-9R#:DO+PRJ"Aiah$>7YW4"8RO5/8BSWu+i/OkkJ?Y5<?i'W9tkcq>R)bt8Zue/ZW97+$aLrfcU-j(
+%L<?s8j@L.Ym#3+:@SP\2i7P%0o]aUa3PBnc1+q^HbVe=GgN]\B'"IWkWXr$m+SONAAeMGK9;,Ck="%@s'#k1rabUFZO\KYD0O7bF
+%!j2eC]sdFS%rEh0=\ZRrb^eobW`[*J$qW8`3Hc$.4?9fC3%:iQUI(WF6o9McXnN5N4-tPu?^k#',E.6$+#q]%`hdJWN!MmJ*35d3
+%^@+M"p,7U>0FcR63](;6!;0KS(o5jm-@S1BU(.lY7kK2GeuOHF.AMQHA84NMKG26]Sj5O_^gIp1]pL\bPL'=92@d!M%cAg*WmPEY
+%_m"sG$Ht"^Jl*`O0At3B64l*Q"X]Q:W2?q^EBZqX*t0&479jVSFkAAJcWQde@"J1ZQM%#0;C=#m'Z=P@V1Z%T*fL<Vk[`C#C@7XC
+%akL-%XFhN@d$;DjM+eLIJ/!I.^c/>k864Kl2JW41Qn<pG!3rE*F<Fs&'f^V95Bklf3f.O[ck#>*gk^/0ZXe>!pEpNN(rUG,)!:X%
+%0f-cC_>qZC#Fi&7><6bAg9H2Qk;lH&KsH0I[TnlQ7`BAR;#MdYeLl5&2RfEX01W2fBD\VHgIL)-I>#qTIAD;G`su5/rZY;1"S54@
+%24og3O`!AQqrX(Oq!mL1P'5(t4(&rVMp.6<$f1GP:0:ohXpHHDRUA$M['c-H'?i'Ga7410n?<WTRXH\]hRDK\_:$Gc'o0T^4$KjL
+%26#p]JpNF5d1R/4^+`cCo"HCuQ'_??QS]kr3E"qWbt+3Nju6lt"[?Ba3b&71H@D"dBJSK;EU8<*X3Leo)18Bp0l(6m:hPie35.l>
+%W#&<SoV7<'Nb=u_b>g]DUMi'f'ej(X!I9(bpf;B*G1WsnA"\^I]Z;RYR`XU6)G4"pYu6PQ#UDWXQCK_Jb,Bp\2djkF-/du[=5`:d
+%*sLH98'dp&)nl'K\q%Gg,nL[`B!\&9D="i`WH>dHLOiKf@[G>kUtP=<HmMIk$pd[<lZ!G1!_3GKI!(O6Y@BDC'<utE]PpUn5\qf8
+%>;O6>W2k3&r=F;U'YUmVO?d;4$(oIWkJ3;LdN)gsU*/"ubi7+:oaDPY)M;S#ljRkj4#OC]Rktoc?"#dE*i@E@NWD:L^7]ET,QgKU
+%)$>T*jJIq\7B/A-_+14`%q&19)SB<gCo"Fc,<@Os-5EJK]8'!M>;HF_=]rWs!)#LafQ7P9gON3Oi`R@U^oAq\Y<;0"WOb&fBULE3
+%lrcj<g)=(9D*$0^*!Fn*L+'P[UDi/T6I66IO]1sL:86\mJ";Z3Tr/q,Dud);esDS3-Y[Gmd$%iQic`*,N-fEb:Z'FT8^nZ=?Jbq4
+%MT.>G-btr>o==_ESk/@Tj6X>IO+2o^UGK-FoY$*$P%1m1??r5&I6Sha%Gah>OOU%0M*nsMh'i$i_<cfH+q>'1n[@"@=gbc-"B8-X
+%Ru##`*9bNJ'bXJ+)0@'':uI'QBh#s?*M"iGdQjn1j(Dg]_N:oAq.UZ$!0pG`Q@ln4_60=jFjc:=JpPNS@0>%bBEG&O!H;Z62/h`p
+%M%>SRiE9:[aGilS#680m.o'1U)8kUFSN1il=s[Bsk/C0IM2d$agD&\*_b\(naC)T"*h`E`*@si#<=ZR2KolZmJkMA&mSUn?hEM?7
+%'3GC8WcE-HYc:_jSu"/\g:3D%<j]<Z+QAZk%S[`EZR.46U1;WaR6enf6fuZ:O*:"8\n3NT1<?soF8\RR\9=^E\&C+=<f8\%>s_et
+%=X)I70M:fOL@'$\"<>uXpRI?ZD[,F(CLEa<8[DHl9/p]@[3poVD$Nmq.meHfBEG1<2*g2X7FGmOb95&oI9rZQ=1_AY[6;_i2/^tQ
+%4/E[ckKQ1BmBR:f;BbAS,RZ&G(4(d"D]sb7"5]N/m1+4_kfcc1i*"Ep1CNrn?2iN+f,=Bsb=1<jk%tfS+RG=u0"^%Ed%Ld"6Itjh
+%*M/>MU'97<=FoX?c]o46r<kjKZd)!%oXaZDK**>-+/0</,.C1#QH[tiO_XOGm<>WD4),sMk^ME8YfGDhM:8:P*.FIEj6UW':ug\;
+%#UA:2TgtdAOZ.-X#<l34l_2H4J0Xlh@47Eu<7$2(ocdP(R1a8mE8qQj+Mc+0$<_0#j@1X.*t/0idWD(kUe+AfEqH9B]SRfk7dml!
+%N[i^*'//\TJe3oV7H01jI-W>f^a-uU1^^X<a<%%%VGeF7@'H7WWE7[k=!L@a,fP(ihjcNs^&f+@CLZ-FNPbQ_-7Scmr<;.hL$)Rr
+%UQ3DJ(7ZSr<YI/+qs\^lbO5)EE8#4-[#ZOW5t[,S5&busj/BpaZ,MK(bW1AgCLl5>fFuoN]+]A^b_c;+],,ZLm2#:gU$*DU\+kEB
+%VLGo^2Cn>rbPdU*U-(e=L7"M[B*l>B+F&W"Ldn]rE!"h*bh+.[&3MBX0X'[PXR5l]`PItQ&G"upJ(fDFi474DrX/Lr;dCu>+JHMo
+%/=lu$6`9Iq\Wk&G<\aAe"m-Mr4&H`54q0)cFKYrrR7fB-!08ddD9.9H-c"a]+b.=!0pu>:prYdAVneC5JAj<n[C[-iRZTqT\3^?&
+%_rHfEI%H8Kosolag`!F*S'Y!ET1$a<18Ao1O$Vq<.Sh_`6>t\mOJ2<(?h$2K_(@G?%`--*@6M=75.O&=oKOgV-bTR-V/S3ci2Os0
+%+iI(qEANsW3rs5TRqe#6n,$i%`V;'fn;g<jG7'3UhN(.UM*;)$=K_Wf'm'?:*Q%!<p<duhPa.-m&9if"jrkjNb!YTI-cO'%)0:;1
+%8!]oDjb"V7'</(t3sN/CjBssb[44>*n&c&l$I0&:FK.mMMH`U<<e-^d#-]BKJEVI7IK,E[X6A0B56PB8mhhRSj+0eiY7HdGM*PFo
+%%ZF/g`:lRiegi?]8Y&3#.G#Zs$p[8t.(fOSIh(J1ABHT#%)EcFGfS`A!rJ(tFpC;$\[LEmYAi$1Ipk]PY*OiPQ*-71m$^Kl7=AU.
+%?ap:\-5>8&GJXYZ&aO[5*1[mEE5XG/f'op[3<<EN[S8"s%.lH_0*IdJa8Km%5mdsR45TOASpJFb.?:"`6l?%uM>@EegC+k9F%dT.
+%q!uKH#d6j(d3!^0d[#gPDb%SV*K)*H*3ECT.LN!`+kSj4DK&!fQ$?;mW2L7-S`aZZNZR!Lb-)1IoSmC6:@/Kqq?as*USni[RM.B\
+%lS_[I.ftGNJW5UC">7?/=b6eX(AUrCn[a-5%h-T:l:DUjT(&;$Z^,/+5O]\GH+6<o!%1Gbk4es/?ErbgW$me'po:H@7h@03g:cV5
+%'d-[OARDNebePDfoIgSA8GKQgWceemH;^4teGU@0b5\t5.+p7MilCVc#<3q*SUcn`D1\IKAd":/)h;IC7j,E`Y]A`cTD*_*/1d5X
+%29!eYS,o/4n-qM`)l5,paECfD]6QM[8>TeB+-R[0+U@M6N$S[iZY3Z2f!<,WNmLc(3*8`qi,!je=4U;1ZBM6deH!U32c4b(SsO:>
+%Qp#0]l.f8'-&`:MLje66`/K'=#k/hgD4g]YKFU?nR\>s:G[Jl$>INQV.S[>1had':8?2:J=pUGl/P%uA-;!2+eo7GqLbBHBLbBaQ
+%7c+A7USiW]EQHDj+!<O^oVg_BqnS*o5g@d@f]EC5Z_\6>L&I)']S+@IgciBMar1CUaDmC"ptfp7j7GD;4-heO9gTt@1,F'[q(g<T
+%%,o!GEg4UiFW-f-<n]H'_/fhqo=]Q8NsiU_Hn5>3pkr++#qH.5iY<YS76])/JSgX8H=BjHT%UC6QJVpjm$K*6?=b1XW[LPpcOBmt
+%F!N3hT#>RW*#AsA*&gY$L>\OH(tKHcIV8?M,C,GZ;(,,&6^O<(N$6?#'.dPC'F@\f>k,2$q9W"4"2TSX?(f]['^%o'U:;"9$mRfD
+%1k!sfA]<5f82"AMb$ajT'226DR^M2[=P,kB,O9L&\Yo`k(!B&I=\oGIi_^-d2GA6%aZpbn.[DEaD-qgU$PP@ePZFH[5o!di'@,WW
+%W^Leqgal=G(\QeOD4+'sT,gQs@&V3\Y_OO0AFXfZODe%+\V]d?8O'Lk!ih/;Et&O;);^77)UFC&MD<'6#p*>)]C[#@<ju9^\i%<L
+%+-LetZ?r:.b#)EIrJX1HLql9Xm#C52,N.:X%bR-g2&.O3!IA>:!:J>\d:oP!;[;uIPllgIZgtNG84o>S,\'-X`8Wik?$Y4NZ'Sj$
+%-jaDn=t3]s07[q=#GQ1Q;:&L[g@@1&,?1.B,H.<dC>l[Q"RLog@dK^L0*cE!Wi&A&'I8@68]#dG<+J]L=I+.R^kd!T6hu+LU`-.b
+%?#!2+C,&t75D*W&*HX&q+"r1<*%Z_RrdsqEI4<BdXdkG_.2!S(@VnQuQd<a3(`YjVeFK"lOeNs(a;$X1Q*aj>DZlI#\BK7bAT!9'
+%G@0J%FJhfhWY/.6U=;g")-6Cr2)2_L,gOYnLkIt3W1C69,?'"uoqQU(W@mDNG?W2F,PrtHb)mQqr0H%g=2a6a:XZFY#!-[u>7!iO
+%F**&E]W9PdWOC,9Q1c<k@"Pda<b46:N^?#S'e/@G@=0O:A3u]X9C!noX&2kW%aS;$k')cS+l)J(Q9%C67dI<\$4`/Z4K;)4+-<K,
+%8=7K48kb8/%P26M!dW:8O`k1q=iI`E(hP&3`)6jM]g(f2L6#`B*@jD"OX.Ic#C\tEHBF&E=[,M:)B;Z7jZksh#GpXh!-lYX/:VPn
+%d6!04/KW$NoI/0f6%r-p;R/#k<b]iOd\niMlLkcMUp`MU!]"r4;G,!.(0oF#p8SlE!e[pXC/J@G7>2!T&ekK?!08\KGuIBOUfq'G
+%>(a$f#L!:^iZOL[b:3Bn_jcjJ7R<>DP&nko2h"QR&[:<?.Au_;cq<5%j:`Y%g2`p7j&m>LJN#=,k8"qdK^36/Q=8`;``.jg!B#_>
+%kIF>BL^$k<'s'7m[s'Aoj"U`.G]I74du;@=ar+'RT$U$>)q$D_^IOSuK\7[Z[&(3^q*G.cV*XiN'4@U%mEqA,5StU\D'?,FJ`''3
+%=2R+K*6jE4\D]kJ6j"_V1=sCl@ecljORJp*;)B7JY__Bdfe20)K1_CXoQlg!OrRq]H,K*3V*AjL=;MY:$r,kXJnL@L6\4%9*#oZ7
+%ITj8u9YVp1<)r3Xm7/lc$V>GTRQR4l<lKZR;HqeQd7FU*SO\O(YKR3WZ=Wi!dNBYTQC;gBA&Sf\o&gBH+#&^SfdCa=OedsN.?]bN
+%5HiF0gS[G7B;ulf+":5Y_B@omUngL!1a'uAS:gMB]sY-iREg;WkOX4f)QMX%3$sotTMq=L9=/d`3^22jBhRS>FjQlZO"l>qp(Z(!
+%OQY^*O$r6@"I*#f9P-NkMLl<O=F(4L$>0msp1Ojp!<l#ReZrh(hT@<6_%^k&3uEE5ml,OV<t+iM5nYolYgFG@`,a8I,5;L/HtEJb
+%YIk:&D6!4G;W4gGX_[M7Q!kN.*E4>D:hHh#jW5u/nqr=#AMH=B,,#$3pm!-9nou9[JOU%Ek`3L!aA*As"]SXrPnt&l`N)+#=b@IL
+%:-B];N-&%=jL#\>`8[WKOA4Lq%7NCtj'orG+ECHT.S<1!*X8nc!q?c/l@ECn$,^i#8NjRQQpcsGWM-^6;';$l-QNI3j2-^2/QOZu
+%^ht-g`2\fK>>>5Sb_;?m7->_9CXg4`k\(>*eta['0I)*C:#VL+<DkmIN#@JjZ<%m4@Z,JA0ZNc#qWYqMd+617osG3E$g[BrY]#u(
+%*fJMa.,q/`%Z6WPI?]=GeN,/!+=>9hkPZP4\W8ku`b-jpBr!"q#XZa0csWn,NtjY>8BmoW0O>nG?D;U2onHpJ[)#]#F/Ml/A',02
+%NC\`BMFO5dE2E_dfH#U`pljrU+RYuneDf0>4K]ZU80/s:,WlOabPmZ5<A/00YiUVLB&$5*^'ZYc-&fU]83m\n;fJZM9-03.bbTk6
+%iWL;8pkml:d])I*i)noS%#%Z6m%m7=l(ZaM!pZkEP*l*nE/]&64IkLWnZ5V5a/bZ"p#)G&Q*uo#nd/(@o&?7gEkl!S#A4d"dNi>$
+%r/X?gM>O>/pOcD58kH&ukf:OedPU"mUl'"c;'1Q.<Cj8T"$VQc#g%ue0E-mZpI=)YFHC=D?3c7N3SDDS"@SP@1mm_&KdEtN$%7]j
+%#;TV9h7a=CY[WWZ"$%"F)<%AJM>g+B7AVs`rKI'ia&.g2d+4(]74WmMomM@3,P;P(e*8*iG.pmMah4'mWH]rjYfb/-\m-kB@<nhN
+%@_q@\S]\L.Ksio?/X/d?m=FM>",a<faMKLa)Kc*-X+UK7:":eXF:hNV@+kV7H'N<%6YDJXGh7(k%Y+^Oe/pl=I"\3++A[b<">WT[
+%o5<m9A?I+aqb>mP\S;@Yhp4^;Zifi2HL8LL-[JLGh<1,Vd"fEW_P_kZ;X-^+:H=KS4d`V5Gqr9\"c67lO&D`ei\aOY/=D&%3"s7S
+%,NL/OD05(emuHujj`mn\HcDeo-7C:6\ehqkCGBlt>BX'?MS:#_p5ttcZQB<3q;`[j=mMLk2Is\:fWS!1XpF1b(jgEWM`7tZcm0Hp
+%e<sGS4g82+1_mi'PbA;G=GT@,;7`<(Vp[0nheCt(m>MAD-M]>Z"?h@7.`tL=U>`p[b>nrZ,^(:eT]d41ELgLsb%C`?T+<.5'M:ZJ
+%W:R'=8k9nr.bL/0r8`,sMW-)370oP?A0DNt1)2P)<Ra]+jKA/,=l<Gb`sp\.AS14@>Gp(1U7@,S>%1NWKQS#Ich7/Z*2+h*$7Y8&
+%8!%8k@OH)bRVk,o;&1+NntWbrJA'T&d)f$J6riM0;!qZm"t#.o.Nh:fVE<P#9L[8tf+APUP<$=*.shN""0W`LYDe!R2DtjM:1,pd
+%^NWR6!=nX1<I(rd_%<=JW*K!6g2ca'\,\\0RVX6+eVb7Hi#pu.XoBN9O@0=CI05!piulcX^OgZ0(=2u0p>0o%Y2`%hI0..#ro4sG
+%$'VB7k`5WcdI"Yc_ei]&4h-8dJD_3"('*oWTR<h23%o9$p1rNM_j=A=XUU/NWR2(+&s0%lF(JqEn>1?K,UgSdWUGn=4&_,:>Di6J
+%-o,(D%;$`X4CU`pKjfQ'TE[M#JQo\s@tVk@VKXa+GC+1."2^k2$oL/JGXgA:9l-`ZKiJ,8UC*(tO"3(#(85kPSL<N9%9RW:maU/G
+%?Nn[CZ$mbqmT.lm4LMH'Ri;<*1]C_a!Du%aG1@5V3,[[(b[s4sAJ$9`<QME6HIZP^2VRBf-l2US&GqJ&'oZ=5C[h34'r573]lNR0
+%l5?Li)W@9%,g+]&XB9Fp8L.FbX[')@1p:@XNW@@,JIXXSjiET0kEBN46,[&^$lRW8A]Y"rLT0r4eOK1`9Pab+;Dt(M.`N\j$`"=9
+%[Mq^K^eGukJ-cJ]J>0p'GDb`n+aOFN&OX7`q]Y2aaqd34>n'OV!9gi?f9*,fL0Dg-MnfPY\PMWs]!X?qUC`4P6QP40PMH]#VrTKH
+%UV=(m.)AYh:i3Ef//8SQ91&&m8cV$B".RqVTf-K-$;ENkEM7?G4=R>320:@5<SBPefYT<!a5Q6U.E%Q&'mapV4=3BX`/Be\lka=V
+%donRB4*eF`ZQ\_6@.osER4+6MX8jkU5,1O.'Ha6PHH=4sTSUnQA1rric))u6PBomORt,1`J4W_9o"Fi&,mcCB=u5&2jn[CR9j15>
+%%+p)0e>n9>^pB/s61p(gKG'f$cP9[eGY#bjmZ7`=Mm7&h25/,$c,?b#iaI)-mud:Rl+KeY;Mcke;@l5g*LIFZ5;^lSO]u*JdpusJ
+%N2N]e^TP%cCpnk*A72UYf6FMBb&jT'.9Z9r.&uUR&iXK;Lr5SK4Tm6llY/n)%X&_`+ciE^eVW]Re<*_=fMe:r6O#tNN1tIqMHJ#c
+%Nh,Ir)SFt&.1Ql'+45OR!>?2'3gt/nP:.S,["@98jFaD5@l@I8>P>=hc1<j"a\"TZ(ANtG.<q?#N2KX`$]i!)9HBcIT[_SH[4\>g
+%TX#Su(JS$d<N:F,)'CbY+CeF(faJV2bDIR_KZ<Z3X/:#BQf4_\bRH"%l`=]+5#_%96?(Sr;"lOsA51^Cj(**1CbUT!JaX_bB!FI0
+%Wi.+FK/ZE.8(;Q7MY^%:3>o[:+@lXYWfoE3[djFljTJraRQ4UD+e:&"cf#u^+-<Pkfa'Sq"]KUs9p>o-4R4FdZQHXVS6[S::gRBp
+%m!r\g`l@Zd7icSt>QU38)9)Zj=g3]6-/9\`KFF'iGp.N_A4Q5`8e[jge#*QG5Cnf_c?oA7C^p.b-2;usp4p4K-I\*5E=^[*)B$Y2
+%6l\T20d];u0E[quAC9AfN83qS*d(jWWC;\48JR#o3Vq1u.a34d7c=.Vng<4Y`%ugqL*9'/42kNhDjchrYlLn^,<%gmi)>oP!tha6
+%+J98=9W6V3E7h%363Bi:ZJk/cZ+XCep`(2Cnu767/IrZs+>Ej=>F'+ap)-m/n%I?oK^?r0fGcWm6-S#n?R+Ec.AA*>H\(pcZ\9q>
+%%l;;0_*"[f:_3kO,Jh:!g?s\?$GD)B@.-e1TgsG^]&l39GVE8^!/K9%6BkFC4AG1f"TuEoRr,@!9n/s6`FhdI4/",b?Aq<8-);/J
+%acqQ$dKt5[&8UU!Y\;;/],ZH"\DUW:'?lqdO,0ftf.^`6+K82s%53F"<GJ=+(USrFSXl&2iM+D>0-NZ4o"pg(7#&fK"lkiQ0hmI6
+%>+g]tj^%qsN@CWZC:p/r,A0X:2@&a8.W.RDim'Z6;c&,6qd?GN)W8^Jh![fL9eHEBI#p*eDd[Jr#jI9g-4:-m8F*D0JY*A&<.PC=
+%cJA`#A9V.oL>\UF-3Gk<ln)!KPS,59Pj,<F9s'$%J_]2`R#r7dI<#q!7>:nnE3m#mK0plG*SP/hAK`Bp'fUMoM--O5M0Z->Kn,QT
+%F:45u_GXb'CfV/]-7(po]QpG(gSC3q^=+T6^PC\k)6X[cI#!`=aI5GlMhPMo@RHCj^s;%h5i.5L5)5DWia;h(C.XuWSEQNN+gn!>
+%jWOgGf%QHHge\cd3tE@b4t[,uf*IZYM+>?Z$%FR?8`D**W&OI];fO$K%f3VWie&OFe[[Xo-O;;HCanSB$Jkq+[aNufU(rA)H\T.p
+%5c@iN$f9)U%,W^VE*AKT@iur&AiX+2YVh+*)C60(X_Fpb:;%7<X@l+M$6,uY_^`mr@/Nb^6=BM"f5I4J$F>3bG$&E&")KpG=*n:R
+%DcThMH9rrJ379%2,OM(q0)g]tL%c<AUjrbt37KPLTf>e8Ue+>c!X*d4=S?iMQte;cUuB24-(V45\7Ne,+sA<q0#S[Q!pIST-Ucpr
+%QL=up-E_m61emh5b_A-jj_L=Q_J6fa2(PQ=Ca6lBf;q'%X#5\GMWO;Ma!BV?S.!dhQ&RgB&2pEeR#RanV#?D3p6#9sCX>:+Get-(
+%EZ#m%dJ+DF1IY8t""AQc4a+Ns[Kt2:H.6S+a$_Q$,QggjL,D^cU1uF=LQIGp2+b,!EIfR!!&aG;EK\,RE)0q0ko+NjiEA"LP)3lB
+%L>um\^YTQ-!hV=7)OOEW:W93;1^Zi;rfCIkE06hQ:/)MO)2Ac/i:<G[9,$cuj<Tp_)WA<E]FIgt0,m>!`fgKsWaOejBip@H5QIGC
+%)"lTSYDLF+-tZU^L\WSJ=0-TJG@m6,LZr;UM8i2OgQ4F\Z7Zl2r1isp5u^6Q[7_*Q%`fUHUU/ElUXA&1YXj)9-pg6B7-&U)H\c?u
+%?7Bh:';/JDdk&g+(Y-]i9tn5#Oh5bf51kL"`ZSlPr1=j0K'54rhJ-31_PLWKj*U5,\-$"o@HjQl%UXUsY61EVU2,:MF9hnX.YM3>
+%A(*<5\H!?/;2?nN&EA\dh5V4n!NV,7-Og(2FB%?&<N;'OIQ!ZSEKF6N]Yh-m5[2,DTrG98'&i>P+\RVd@b"]N^2&$XrXk&lm(pJ(
+%$t<)-K;"YV5Z*W]Y3P6oIYVR6.iCYH4q>BjdOhbP\boI@&/;d=?9-kMX&Ff@h4$$1M?tTdZ=;TUc+\%@_nu50N;(WP5g5<Ma.uc5
+%IP;.VQL758'3Bh.R6g>5Y#Q0dDeK^.?QgU1+:/\sU5NU`Bl+,#YsS*r.*fY>*8T7ENY'8k0L>9Y=D>/[,]VGaY!IKc+Q_rZJPb2c
+%n`0%V3RPHAmE3UuU^A?Z-HT\t#>mkNC`^MdJ/$35YL^'o+Yu,S[NN6.kiJtPB'L7k$JJ<E!e2>^fjmL?m>!BT9`pBM4A2mNnIOZ)
+%)BKbb^`AoCIPZd6K-pu#1Of\\_f:3aQL%Ec_20QVMnBSlgRl,OTOeA&!4uaVG%4$Rf;Zfga)s<.BWA">GOlMWd)BJbr$'RX+p97T
+%@+&-]Qn(OP-tCKO4<)31?GF6]YdRpY1DeMXqf2+KrLL*/dUDAl)WYYD<cX*pMUWJt*rpBq?E=c3$rHJ;0*cW,mpiIBfhUPf;lI0n
+%rkb1e_ME2b2YL+Xo>3b('1@_t8V:YdOO/D(Y+X2Nj8;``.kpTgZ`U^9(YbR0.%m'j-NYV*Z0Pi.'1MMVMItlkU=u!#e!;6P0<$^Y
+%a%hFOnt@fr<Sae[e'b**;5Q7.CF)>BT#AB;A4^E_?qIYtT:N,Q0-ntS2qS1%Z>_Q&=4GMKa>5+E\n;4cg/g&#1NHUE'R*-ueCPgi
+%E+BGW<+<(DRi(;9E*,b3i"tXgeV9S^PFt<RZHs[%=,nOI=S@/r7k(gRBt1u*o7"Bf"*f3kTi5mlc^7BbRYJS'RdKKZb.b[23?c9,
+%0>^aX/Lf#(PAu`!%leH=e>VM(R*>f(]IV5&dbEimOqKB#A.KsS"Hu:(M2g=F3d+Lt_`MAm^R8o_6%ob_3Wm98A\AC(!r,?Ln7kl]
+%m%C@_9uDRK70bd&d(T`o`Oppj=ut2b_*+QM,?_+)f1LcD-&Z&*M/YV./BLM4pk:J%0JBSBK8V,bbAS;N>-uI!M=(W+6OHA]182/#
+%(>4Ieg-$HAd!%BDC8r#":k2'i:B4MW?t"a$@:Wi1aadNsF*PB@LK[gHJY1r+<[Ztg,-#nhZ*m.M,/FM^_O55pL\\)Dj=2BSF4sF^
+%YB]A?2Qsc(;6U2;OM$_-FVkj";Cj0T[L!+d;WB?VU5JK@jr727XELE",JS6i%Kjj>TpHudlju$Xr8c2&\5>Rf%6b=pF(DR<24Tb9
+%4CrI%&YA'<O#=$+_mt[DMstsXI`F2fL9c>m>7V'a*NRA;.!_J1\F?aMgPsh68+/6]%tsBsrb_.0LR2DU8CnL@@7lu,eJ@VNG1mk2
+%9J?IJ[_>ct?MU>42e@(gWhD'4l[W<8+n1fqD(G/[%mF>o'OQ[H+VkggXP7]tFQW7!RjCLtrTOn'$!/X3brM;/*Omh$*$&Ua40U%\
+%7TBP(nt^DE_p2WUqIiat?ZT@\[#GF1_YnTgBdol0g-U,70jXXUg\5Dk]G-MLZ4;nk>6*JmW3\P0SY<:=Uj,RGVs?;u'HQmii,cfI
+%BiJtFJH-0rF5.B.M^bsd,-Hcb5<`B=,jQ#57mPueCG1e;DT%?P*X&-h%&eqBK847m_19+1#DG7$72WGMdTcqN6\ukG<%uWQ!f;A5
+%b)#fd,:Zjtr]&UR%XrZ11P?)n9T9TN#_N;M4ok/N=n8:2Ypp8!6D\?c'9!BZm%SiBJr=%p\;XB-S/T:J@%8H_>n_u-@?5_s:fdbG
+%$=*8&JA!7?^+E6tS$Ab\B^3JMXpZ,3_AfB`[i5?!<K&c&:Gq&7pWJ>%]5/a2-ThKmQ+Z#5Nhpb5@3A7(O*\[C%3Wh5o<E`d,%.T$
+%UHl4C=p23)M)GW_Y<UPh<1>F$?*.%b,*-_X+C'ag*,o*7nrM+:=p^3T!ILj!DKrV'jp@a\=2[X'Ld0Du\(+=2Vum5B=k/;@<J(uc
+%W'os&78`+$^h"+`cd%#$!Xljdp5^\a6"M/ub6-\$Lf]fV74;FSep["g!5tPO'sC#/+'AR`iG.:[R5),=4m[$RXd2"F"l[Aga#pW(
+%K,JmieLDj^Dh6Uu_p*^F#qgc56e:5hP[q,ZDucIY8VeK3>("+sX#cm[bXfEMp0F,)GHuJX=XL,N6JH0n$d!ep.*I!./S<8o-9>[7
+%a2!c@XgH+I_dp1]A+8iE@Z7!So,U^Nct4^O?c&o9j%:YM/81.7br@uaTR`X;2:$_ZCC:S2B]a!iOV\"=YJu)jJb,9Uq4Z/c[?>c!
+%6=]H.o3_I@fEMPpHSFPej(i'2OdNHZOiRRG3`]AjZ(VsDZ%5>s%3ZY(6Rd0n0(7)=cZ*a_iOMf:c<MN8nNF7=aYjk;.7a.n,6WX6
+%oiN>;jBDkZ_.LYc2EaU*/Ul^c>'0u^A&6Kq6q<0?g/$\7n78EIq^bKd"IZWJ'[.&=!(2R">bI3QB;b'G0M=M7.Ts)L0S4shFu-ZD
+%^b!lb<Cn)4?<K.T,Z26(`g[2=7T1oW"Wp5R;K+.,#m*n4'Ft(*g#iWNNcMX_Lf[-3X2-uD8BdCX7R=#GMfm1(3UUUrFJ,B0)FYtV
+%.Wk>D=V4e)[2oI$gQD=Ca<$_#5RuPnaQk^NV91&Cd`jnY/=f(]d22;%_uV(OkQ!Cp6Lr!h!,DnMP8EBpT`H@X>:A"8I@,CQ-&X@l
+%88AQ/YFSRV4em?h&)-]Q>-f6D-iaOWCa*Ue?QsHZ5f?1"$m&Q'd$ja:MVqYo@R(2s,?q!0I^7YW$6jNGnVQ;O>PPcV"B/ctm#S([
+%Ju9]X,M@`40-CoUkNQHeFtMl2oM1(HAGCjD[@qF".Dl>2)h-6i_G43!H-3'uc^AV;*+"k'gW&FB[>CCC_!f5E=0/apBThm@WsW:O
+%m7gXW`]Ul$cdLM2Wm;qbRa$U9W($+nDo)p]Z"e`XD)eZKOoG&2T[nXT8;[_oPNVJ!b9Kg,](LW.NL6=U'>09`=W,(RB`M@Nd7C1o
+%.TA?'+l]i;*8[U,."]C?EV(`K)^uYO4$_;Z!JiThM@_LT5F#7.BcN'QJK_)'?F&Ll2F?tuh.06#krh5dXYW?>*=iU.7f_N"1gEj&
+%`?H0<\S1LCYe?3J?&14=4NkjPE&0,@[5utA?k:^2,==+V0g4,\NZCtcJ5Msn&]ESCHR+c3*"j'#=L!YpDs.1pT^71@RR:!(*Or=6
+%b8/[S5dQh6."\e1C(<ph9ZiK%Ds1Ae5YL?q>$tg-Ou#M%.G4:n5gjPuW3X,!>05,BAdJlkaAFLm.qH1ns.Epn5cb+uoq>9F(LHG1
+%V4lisQ7O10LKTN.hbA&j8BAC2Vp6lJr$?HBK:cRWMkpT=`<>-O!^)rf9_&rKSj`^-N:4#cTFsiQ$p3.0o"P(Cf!4K@R)TemNZmq=
+%2ZM@H=XXllKa?u&pRNSD!Bk5;9FV>Z^(?u@aTDH\:Y2u?!#JT[>3`3n6nZsG%k!-_Z#p_q.7Cc3j[.A;(&Z1Sof.(%=`5(*a[?C-
+%@_t/0Y%5K7O$o!BV%UQPitTFJ5X0_9@;e121Pdus-AqAH%5r9X')%rddE2+iRO?l?>S,O']_7EV]f1Uj93JT>%GjHI%.h`<0s6eS
+%%\l;q$t@&ciU@Ga!AYM<OaXIXj3t-()e$=Pl7gSK;ZQ4of#GTV!.:dUO,kD\rEKMNcb<^Z5J="q>uCj?2rk\TnFD]uQHVH/k[(U/
+%Bi>7+PKd?7-!\\7HP1:G3#WY5)?Xu20uVC5=+[n]0VA2&Mo`6t8&NHKT67$2:T/a34]YV"-Y`W&+=R\D=;umE5(DHRP`Ek+8QYGU
+%`hS.S*ndMNVt;TTJ:oIN>fd*c*V&e&MVQbZptd9q?SA7=S!/DO`C+)8Z=dm:k58PTjDshspQ4:&^6B<cZ+'4GR4dA@P8M(/W^>*U
+%Gc;OFnnG@Ahkojpr5h%bl03k1PjE02(%&HQKh21L%2!sJmB3W+-!tN1$9WC+RPTKbT-R(<YN:RFD2*J%4B:rIB&ap"lh%S_Koo)`
+%4l9e2_@gSDOh8k(n$&S>Ve;oC]RPu`3-+HWh<f4JpF?1c_:1M695FOCR;?0B3^&)l=.?[7c8E@ZDUtWQij?VU7H++"b.l[&S2aX0
+%n;m=O\L(5T_fB1%L4:;5Prs>RCTLIjpJ9@A)UDc<+S%S`FnhtnY:Jic"\hn(r1IS@Y+GFfqH#BEs7Q5>G=s#q=Y2s#o4WP#]eo]b
+%ZZV6AOJ?ED'.jm/b<;(p(&1SG<?mGY!C;VkG"p&A_+D$bWuW^IM%UWGk-$2dD_'dZGtG^1!1mLQdV"AUXd3d[<C@R!.CtAppn;aJ
+%'^IO-D=4*.ng8'AQV0%*8b0?6nP*/MN<b/Z04k)rMPC*DG"MhMX\h[`J\0>#G-(GbXHfeXU<W/u2e;1/rOu6aVTJP^g7!ca$rX#B
+%nh\[@;8G<F11dIrlmFuR<cjef6#/BhK1>?tSA]]I0m6m.?5"Wb0UN1'YR1j.mp)[_]SQb'Ms!/pE3AP0_(EeDj4JZ<XLE220W`=\
+%h*!g;WnVl7'M9d\kcDp*1e,uZO0a7^MFdI;h<-/BH?M50_Pki3<q9a`]Kr@kFfH4JaU%uW[01XKTS[+;ZE06ZSQ7DIEh7.U;.a6k
+%@@4H9;?,4$aM2pZjS\o;a=`_MOX9.`j/EN^LkA//EO&l=,ep)qBHh>KKP.\;oi=gV-U7I'IALa,<@;'M/'JYlqGmK?2d$rkkU![K
+%bbsu/jeU#\]hP"R)(0RH+S.`1C45*;brD[AS?s4_9nSW6j.p8KU`#]0ota53EDj!`"A\6)=gE$FjcW*</s#'@3sqP'M3E*mLMc1L
+%h>!jG7[*;;X?TDcSCGfR'NBsS!T'p\-f*7Q'b]7sr'#VJ2sg84ET;(o\[K5:XZM.LRW26#q.cEVc^_?\-Z-jpD12_lg#NV]"oBet
+%2&aG-.48uT8J=(_?7g1>K9M%HPBPu^BlML8S?rc$3ju;c3N8-2LY1GQ?<T)O)Eket7AJoKpp_.g4[j1(0MVHB,Z2l?HK7!6_+DP_
+%1+,gXaDl1IBUmQ_:7@-*\s\aojeO_@E7,(gb21FO3cNNq[msJ9K+k*7*CO+63N:Cu1J[5"P9T*3ZVBr+Uo0s3S2;-3Xi<rQ"I-_o
+%GE\knoP7(MANVi>aL>O8`Q>\d<a%hL@MJ,!12C_jp03E2>cW1Z=fLLX?jrO']O$Pgd*8OONd&rnO@kk:8r/aMDH"[(r4,g:prnQV
+%Aa1O0kD9kf[S$Ep2YE;,4&_6O4?k\>'=>.5!@@W;.kiS@NNB2oVd`KB7`LOfJdAd*L(r%*7JpaCM]s@CkX#Fc`53Hn[>W]]7JiN%
+%M(a#e1lfI!Ece0>DV=nm[l+n=@JXbB#o];>]VC-8auH:mepQIFClBaW\RQPTMfD=U\AG'_oid<B;sbhD>=!`b?P*t;pg0\L\6?hg
+%3Uo>m1[AnlfDX<PYn*mcM587P`*TfI_?%fH]jR%iKcRQM5_G<f!"U8^2-C)(&J[_-!R7UU?WRX9U*3]bh_3WAUH2FecH^$qr[Y9E
+%Sk*<i6.,ek:X6c4g=LabZR!>e$hp3n.%Dtbnd<Fre>gX1RFmT&CIP&Z!"WIgNaf;+NG(if6:<eBXG?tgZSh:.PofRN1mD,ll41Dk
+%^90Xc/BRVEN//6B5KJC$;8a.Oa`We-H(hgQ"c[Ap)UumD!1&RW[ah?f(;LYL+R"Hh"`mOO9\B#QA="%G=B5kiF!E(2.j+XPH"G8h
+%TJnc_@NRutTo.N\aU0LhH.]D._o"CcW^3+.*l[VNp+j!#M.<qFcC2O:Fl(o7?mP$&#UGT$)%R^DH@+eR!*N\$KR]MVX=dtH!E)DB
+%P,69s"m"0?6tE[Ea'+%g`/oC8NVc[@jP<?pFi!'BNH@#qnH(iba^e\.@'4N[b*9LJ.U0i?[p`Gm9TE03;R)nJc$[=]TrIc$8TC9(
+%pDRT9PKDfL&#@A5jD!8$T)a9'RFhMK(7U1gFF"RIcDe$d;.W4N9@Y;:9T+41=2[?><Rg::fW1.><rBiAYI.HQTpcb.$5AC\H1L$L
+%_73W'/BoZT.Q\6qWm8P#O\-#^g2m\[WB8WkZ=h17rQ9C"!@gYcOL%5K8PMJm)^(9!TrU[KCl5.9'f:0@d`erM^=B8q]@.gSKS@6*
+%h^8s+Bk@2&._7+s;DB"dgBB_Mb[\*6Ae*)dF?5]S?<>o)>A%Eq/?&FtLI:AA>`4l:"[ZO>i_`J#0_/m4!Ya%)H]j]$b1^Moj(&$m
+%][Vds!15r\)"gIJ-n.4qaG,NTJNf<UeFffC1SqBISn_^:&sS8d'b`H@Da,fBh_$q\lo;ml,=!hS<e,`*-r/ea8rP>s7*#^f>R]\Y
+%hRGEln#Mm/*[uiS"q?uoI%kF8[glde_e;bMI]:bU8sABChMpj<,\%SPq7U(]72N9>*G6^%Y`Rs$jg#&8:gF6A2=aJL4.2T?#q?cD
+%U\0Z:#-WFr#rhRS6'a3Q-Bje2OZCdCa`'sZeZ9Wup[sQ^4c+j9P[lPeh3-dcjJa.iTZ'T'=a?lib6-R^8rAOe;+-C!A9(&!SiBbh
+%>2"'*DSO^s>a+)"3/gM!A*,'UF&;0Ie%<2':=rU-!Q<2f\pLAh21h\,I="WR4e/GNk5)Wj.ZuRYF,,^0S,Q4_b^.S`<qs(c,q+Gf
+%Y#f]:("Eu?5#b<j%n9CD5_J)ROMXWp[*ts]Eg=qMZW,q<<kqfLgToi:CQ4l)_AF4BeCojf6Wst2P/2`CP6jmGO8i#eCT^%hf1b?%
+%-`PV[]h"$ML?Xl`Q"9K\;\3M9Cl'Vm9[aV#"WY6Xh$\(=o*WMN9\nS7Ia!ZD@5?js-YL6"JZ:O?lABm:er1Ol!<I(*X^SRYJdRcC
+%1Vg-HBng%[%7&&$*L&,Lm&p4&<e?Yrh8uI?"R$`K>r1!cRafN!6]A_=e6!7qQ.9Yf3oESnEq*QHTM6fh1.r8rRHTL]!'RHa)5ELL
+%8+W5LK2#7ZO%O4O_g.WQrM[DM(?_(PhJ*\&EH\XF1NS>'.,RGt"U>h;BT^=,Bc/du5YRCS4Ldh=RIAW5e>pGT-\"6H=c>?kLj)N+
+%s5S>:<5?ikK+*O:;*+H3HGqt7M$_]B%Q`$I2B]PL;</3^`\"f2KJl9](c1c.f.Z2]TRh)R`.kdi>3s]Dm0#(C!'">MjO)2fYY,7*
+%!Z]],@+5/b&_mAU60&MfBi.32'(TXDp2^DqC9!tA"%%]t!Lt$!*;:Zp6OWTM9!Do!U=]m<b`jMVQ#P!B(tM*->ZfO7BKaL1)t:Kh
+%\;I#tVD0famo/YdVA-S)?XhDD[3!,;NQgL[:2u5-!`q%2RHdhU6uc$Hh13An<s9jZiY6Ye_MD%=_2tNe<#A$QQfg2\)XhN!UD$ZZ
+%-S/8tlI@ZZFa#&I#^0t:UF.@Eaqu%LRE5:K8TdkJ!.L(\cqk1U!+F:sUB8)7D19NQ2$8ORF3pe#PZ*($4oJDLL9<Kr!&./:j&Rl_
+%_1BZp]*#>M_*ljBI<i5C<cL7-RK<(ZXZBZdn_&`ZEQaRYp?XY3C%]"]^g-(G*2723Z!hQP/WiIHLEM$lJe(?\*$jp[)L/le]Ai]2
+%0dauY:@q4qmQNbX]'*ZY!-!g5>GDN$]+e9<Y1EZX:&Eecm\qWGXXZ[GFOV`NS2MjdJ!K^giaZ])3Ddr^8r+)k`0[9<,H:TQ?f3te
+%lGZE=_kF&J:0I0TjT&^0Y4&C&7.Rb5?P(VV^1Y&i5<+"o)D]"%25:t!XB1[s3\$`ffAk[3dnA?M[d.IR<[o%(dB\E-m5d'2(Q7h@
+%e\&Bi6j\qh"Z&FgR]!`+-<'-qaQk8$0!(Vql^%)p12mI1?+-hp_>1+]P.d59W[rBeU6$FQ1,Q.tVuWV9[&$U+?b#OuSUG=T5?,ZS
+%a^OigUH'uW!h/&IF@+9CI3%g5ms*K/0B(N=ginXrmRIb4(".c6*p2O,Jh>@/^s8(X=4X#h0NXlj66$%"BKo1Ag11^,"WNR=AY5Ut
+%35Z,*:dhQp44IciJ`<G)TPDnmi=\bKMfeA(M/q6?>_Ng(O5#5.=9rUJ@RF!mW6Y!d>[:#S:nCPgN#9D&NI]Ri6X'5]!SXa$mVpQt
+%U'3s*Z$8"(WM2Dg6.V&d9:o[%VkUSo>tOHuTA,6ZQAQ+g$HV#m3b20E""O/E=-'fqZSpIi41k,.S2CY@H4Xb6TfFXeJb!+^`0S.J
+%#udm5.RNR#S.GiIl227rO:'-?Uk]9"Ua"nPOgAe03Lh.&US?C"e5JNqL:XGH/me$G@gtJ8C+L:.3i.hsB!hrP\<$`u5?F<G<nYdU
+%IV1K_@]u\2bitLdZYdNWZkM0*MHonG&V7N5%5NNt!Q._kBt4eE/mf2J&JMi(MQ0+^38)[iK."E&V/b[P-Gd<WXM^2@.+F24V+S't
+%E'neoIgW<Qgo>K'O5nQeF[(^bfUJ9apVXa"JMk?+P`Z_)YGqc";OUY2EtD`C-Xq$+@_8)M[3PlM2HDUO<iKiJUXYYXFe\Vk>fX6G
+%0nPoETdY2rJ(1EI2I%0!cQleSm@A94#P<1&0M(D&YY*Pc8Fd!.jLoT_A8iI;BkE/Q0u<S/mt&M_J].JmOV6Gg+o27]VE,iY%V1k:
+%n@9H7P^3P6Fs)jJjKQ>'Uc_SE[E\bOW"o$`/<;/XX4]q)knC'WLL=F`c.2g7P!=H^]BP9C(P0](XMa<0Y,@OK4'ftrp_%P)-G[_I
+%dht,=8JnqSKj"&E-K@S,S>reS9^Dp"2bnH;4@9B[+4UjO9LA^,qbABeKa9Mf1bN$Rk_sQFYJ(ODJr"sR!i7"K+@7MLA7ZPZ@?Zdd
+%6s%b@#gq.$Sigkg?c%<!iEFS.U:>S]\[mKnRLZ@)jT/Q6`7RcEe4+$S]hYuE7Wfc1UEH=#;jEE?3Ot+/<(b"lG$,_k&V/)<Z6/sf
+%.X[Zl:^HlLTNI=0;73WUg@;1/F-]"Jc_4:04X;O&U;0J70psZBiK<7+R)fc(8GH0:'$K`*EFli4>3OAtVTu/YNBEm9:3hrUJr%ud
+%p#A?OO,_>n0QgOOOZm40OG99.,FudJ?5Q%?7bdjN)4d/?V6$P\V&kGF&a$oU0Zl`MFg=5T`6e[Zr2ChBB>\<Y5UO'O]ITkYTIirS
+%IQ%F-?fl5sc/ai7attcM+N_mXgk>@3C+[u@^?]@[buZrDGet3e881mO#nPJSS=M8AZ5umfUIh2;cAnI]jcs/r#0]&=i_?ncG,3=/
+%DNJV$:-[+@L6fQSVN];CL9Eq#L85!2EL-rMYRbl8+FC/hQAMN\S_sL(5`AaWgOsaDbsN7jP+kGC,WFLLh6cJH0J_ubKuHU0Fn@Hb
+%fMTpPeMIsp%1,m*!^mD#<>'t9(30&Yd*MBN<6p&f6.dfUjH80Da7>bkRWHbcO>T`C-]E+M.oKr`$a<1Kg(Z$8aa0WW^^MO==*56(
+%U,mRb8WdACM314hc';E.T"(1RCa9?M.e'+(LEl6M@A"%o`BfhpNb4r#fEp[i0k&-;@j7@-:5_#T78-kA^s02rm`%[Fq='?ERhflb
+%%!JV>;].rOAD0>D_Gat0.@bjma@mu%5L=Ol2c_[2@a!_e\<&RHqn/&Ql(2QS-bPY0"Lah;UokTO9<nqL.&r-&JmfD;Q@'cK5cWhM
+%F,"Eqof1nE$ckuF+UT1.pXi#_5,rl0d/[A+ID2,6Z&R7SNo%0u;+KA+<6+pl`I^0aZ&csiR:5-L-a85`\R_Yr),Ekh3$mVH>ao7r
+%eljqeV$RJF[ZM@lRU3G&:o2F]M!*@AaUnsNV\YiC:^%dU4]o:%ZU*&*EP.fC+ok8l.,$*o/uNXsc)P@@Oq9L/,jQD?&OiQbXf*A"
+%&]+o^M6)bU&!dNjE>2EgHU1BFR`!UtRluWH<Re;X;j/>&2F"uq$ddUpC,t%J>9.9<!m<#UV"b+W^=R#Y_/+FGH\(QdD%E)fRR\Po
+%(h:7T(=NVjc>4KR/_A0'Q4X0d'lO_dUL8X.)-;XPSMCYs!MZRP[nb4sCGP]8A%[-_hE]@B)-(>S\"["1KSYW"C2>.U'dl#=-FJ:;
+%o`,S5\!*TUipHJMC8MK"#\3)8<rHBYMQmoSY=7o5>W1?>=FLLhLPkejJJE#TWd%YQhT&Nob+k/_CHK%h])Q6DW1ZYAZ?W-U]Fe?_
+%%G#\.3C8@&/3>)t8ectW)]3Wa9R3Yf^'Bq8Fgg%1C#fcKO.rb9,.NTl4O!koTJ6PB&)]EIR:6Y'Beh1gRmVDS4'Sl?bu)7o+oS'4
+%"@tF$_jOfurAj='PuW'/Y;ff%opV!VSJ.Q#kiX6:"WQB^.BFs!N5u"`?ll``i:l*0H*E-5).:)`V7Z0ae/ktj2Y&"]cKAZ*V."/"
+%)MPC>dY_9lfMSu#qemFc1014)-+8D\14%o`"YDCsnAqW(K2JB>$.&Jm62@ct0([IE:8429obLdEe!'r:oe0NU2F]Fqbc1Y^l@-C,
+%pTm'Pj,*<U%dpAQ&eSu!n#G2WT2O)b*sEhA)_NG(cBddgOqs\WW2fP^nW>;hg.5j4d_e!(if^$4'Pjg;oP-!nn@)(WnI^U9!LPHL
+%eH[u*dh#^3Cr#-!D7#,7aoQe"Wg-HEc]h\rDWo@;;(7lLVSR,-+QMs:0RXd86_,\AR`_)Di3;BbeB\O$(g3/ol-3m26nE51;7k0d
+%"Os:_E.k/$9h?u-SFc*NLk:)p'kF7dPPIdIg$H^F6QN("@p2q*7gpH7PEHti%'*j#$!"3BNJqUB%E7:nUkJBQ#!Ji+W&\#&g70(k
+%`tm=qi5)GDdBZhn;&:;5/S%?.i^/<tWZ'_7@;1N^nj4>q.RY&eb$HB+;2>[HAi4a.9;34i61AVW\5c1_8jp's:)*o<CKIc`T`W.;
+%<QPB#a=5b-Wk"jFlr3SHJaI&]`4`.l]?OI0"E^<*O8uf>BJ(MC$)&6C&[!6<$Ba:r7G7(Ii6L"WF:P)A<<`c5_1O?j@gclr/KA8t
+%7Fg4qR(3CXUBBe++!fIF(6.$G<p\<6i:hG*K[,mp*T8D7/`]#kcZW8+pY"d\p'-(VY@mt^N#\mmo-:9TIhgH.ok#VM"o>e_<mA\]
+%[0joqp5gH=[&,gE%iGgG]p@p[%.PpMk#ltpmNcF2D,%ggK]jqRB-1OOcGC6ai"DQN*pqWug7:5G.-JF"N-:SI$:APURR,*d2PI7T
+%>G(3u/b0nJa]a#Vi_iL1Uk)b%8ld61[hu<-'IJ4LW1Rk.cmb(((S4ToF9rd6YQT$`K9)I!Kl8#%&'[`u(!L6i[1>u%PE5egW\U3$
+%k[66h.dkCP'a]=jV4k)e.Iajq%DC2a&r>a'M&U$Pf'1N%ml>l93@f=F$M;NA)K*QmVe6#W*,ptdU;ugqj:XsN\7@6)>/Y41#&IfY
+%fPAnK`F[ZCFi^RE,pWZ\4_Gk@Fi^EQ9t-!Diu!`if">0W-5%$a"ZkQEXZ5#bbZ9nMB"))<Sf%'cgs6cnaPK$T]u1WFPc5Cf>ou0'
+%N[u+`)g]4uZ`]@V$_/(D>4aRDSAq4jObU?8_faQf+rD'Y^"1'AD<B'QJ%=O<f\=T*m157/!E1^GEuUMIBE4mq5-GF_F$Y1l71l7e
+%.GscGb-7UG^P>$l=D+@\KD-kBfi`:8n@k?kd&?#h$T!rcf)u6%kqVJQR>#[,oeq&];+H(;)Os?[4*&X3/f`-a2pK^XlDjVEn9lE_
+%6.$MWAn]Y%*9%$H:Y09hlQ*N]4+p&oj)SjV%&Id_Wm%<tZ35'$<7;>V"bc4Fr7RJD8?%rhdUFn6dQClI0Jhp"8jFqp]sJ5YhOJdA
+%X!_,X9Pl8pJR9ll#4,fLd*>O@jC64*H;gMh<jaO!>gT3J;J4>cBHtmJ:O7obF6,"5"p*TC1uY)@7!Qq!M\Td-(0OL@Qna-9,*%'Y
+%/#[>)m*jpBSflZGo;jV-?:Df$<Df'F4m/BslEp#b)c_*qh9liZ8\&^/$NjiD;4YNMNjWR1/;N"ueET9bf#@(8<Hi`$`X/b%I8j+J
+%%#biY;?=31BY2YI_"u`E#I&_sUD;epBB1Rg2n,;Zn`8]R.GYBkR0HJ\L0^!QU+Q1%PT&Vb-"A0ob2Zd57Qu:*-+!:HgC+Z>SY+%o
+%*Dr#8D5A.-Y!ad(g"hdd<B1ZGM2'>rPr3#$<CNd"4Q9VOe?S;W@X--a<Y[ZbI_[$cqeQAFaP39.MMe\MeLqNHg/'YrO]'0WI,-6!
+%5EZKD"uVQd-_5r<B>VI)Fj\ob<*!PdLEOLTT$gGZ@$7Q$8fRR\p<ASG_!cfl:cC/4"!ai!);:EW@^K5W;^,-DH35b[$?*3ibkXT+
+%0QK%0\(L;=Pu]&ti=U2)JiS`GE?\;T7ZFD1WHHL[F6`7`!B\Rq25ZrLLEI/r(-YM47Bou@Qo(8-n^8JgR\h,;dAnl09hDa!;o`%K
+%8e`YmH-U&3N_j`C]EAWD:WM!X,33f&JlMuD"hr\SnQ%HgH"X:(/%&Pu-pT`gG#QNNH'XObOj4E^gU33p[R$o7-W\2c%4\eYj%?C$
+%WF"LdY@*HS;TERp,^S]]%AS^:l<o?a&L-@pWn'!2[]A-Yo!$2-e.AWdVdu+8YVrG&,i>O6MjW3'*r;`9UMMNt.\bA2k29!"k^3DG
+%0l*kYpY2QTUFZpBl>>Zs>,V$t2$Xma6V\bYN^_U%+qg2`d1A/C9gS1UKsG-W6d=OTYU!3hH$T]IW[GCpfTaGQI8G]]&_TP/B1+s,
+%pC..:Wmda[S/G;!&9T+fJXk,kCr*Y=$:PN#@&YSP7n1Qj2".O4!5:g+[[6fi1c,EdT%LVf*q[FdT<k*FMal5t5tj2=#%cmRD'Pkp
+%d8RAdU[!(`\d4K$59<Ut5pS*D\PuKp*mRU3/^?i)A47H2ZA@ZD[p8Sj_D&Z<MO.5=8GAc9JSqlCacHFf(B(u2W@?]JhqejLlCp:3
+%EZu:;>/b/RPZA`34%61n)V'G#'%3*&:Ru^#^'$CEZ#m$@[i'ka((tX4Z`8pqjVhZ.aoupa-XqX1/8F<1,&/rclFJ$P"jL"[XR-WE
+%4Fim^Qs%#_TkI&D3g\44\+sF4bXk4q(.\lIm^`LAfe=rt")b9dVp>kg<j9RTa4D[)L/l91)[Y#cd(H5Hg<Ju<9t<a%F$A8j1Cf4"
+%-RS>hbsFC8_AcX09rTscA'N4A$pocQWDBok_*-XT]4qeU7Sb6'`=Q1^`2[-;],M'ERcYHqhV)RTkeq3IK,dRO]BTMXGIH2(:Ag$S
+%T__8aPNVB(4()9H)tUC>%3UW691J1oF*e<691WUd#?YZm9`L!pbf&YnTtm)NjJjaP'%BtLBii.7J2?u-WN:HBqQ6_p-W)<Z/-2c(
+%N]/"V;sf3`L0j,rWj@LI6]\`^NMt9>&na-NA.(01K<,aJTV9IGq62>_%ZaJnEs`XACQ$7Q8m&-BU,UC)eIS>Tc.Cr#%H!ROZRLpI
+%4LCkbY7rUh$2[3GW`^(COO[O^"m_4_:'8i*.Le$="m'f<Bipqblk"3L-A$C&-4ufZSu?f;'e$"2FYsL2%Ge<(3QVoD,r37\<tIDt
+%:R2`Sd>FshfldnR3jOG8K%ER>]j+D^),?3@#'-#4*I`Uf4gGcmn3Nb"-(.72SfC^/1Eh(^(8\9Np*O^6L66^Ldo4(p;cGHl-.sIb
+%l'nS,DR6H*XhEq-:k?P&10NGqLfeZNOB$HuK\AIJb9QEirchadDrFEt>9]Sm1mCT+S'0Meprq1+Zu!Z7m*cH1ObQHiNF($(36c2.
+%H7-_<el4F-&r_i?NEV*Dr(9`*gP[1/WhK8I<M;o8A%ajWhr@E7h?*]?bXSDj"dfLbmKh.=&\GJ(CXH=dddUh(YedLiL[Zd!hTbKH
+%;&!]5g4gISf21J&RW!&N^XV[7aMoDkN>$SA72iQ+`IWB.oMgY"T:S:_hN"qD4;.`jYU5Ah:n>Iq:$SNf1'C3>%:iUt,M5+^9G*C]
+%1?No/Ph[j$fcCa+H6L8Z.0b6I7LT])0.p'fKR1rH.@l8#h:P\Wf<^:Cg0%FeGsaJnF`kdXo>Dp!hjc0JD`u=XUcAu+kO#p^qiR4Q
+%,Q0\#q7Uii@?E6!_)&_S3!juBe2_UXNG""g$TcmaHZHMc#`0TWs.!Z9TQiV)]AURqWgQ0&+:GL%`SgtGAeGSYp0(A1F=<ke_-4pZ
+%7hkZtkj;nG%@T8IBEm]T!kK0d*h4-q/O\6Q_j$cIA[iW^$%E/%+>oYf,pSYLHS]O-Vcq[pGT-a9$p$8;#&bPY8j5UVH-AZAnI\?.
+%%]8=s*md>D2"M<AeNGFMQ&pf:pa=*Z#GO*j-:I'sZhjWt<sr"sU#9A:fJI0q@ct:M[oc@YC,LQ2k7!YJX&,947F;q14M_mP7$q@m
+%_MA1%J8kl*cJQ9I'#)Bm$'XC)OV+g)1^q0D@kba#g-jH^:%@.4O$/WcoWFj%<TQX\;5,,%\j3-?'o+?k3)6/A<)hOR1`n.',uI/g
+%ck.FQR1Z//!e>YWG"1>:1'c=^DOBX6ZVA,*P?'.mYT@fN'TuqfpOSMJaJ+FEBT+'Kl]MiI4VC"XBo<O'%M>4gfhC^4/Nep='Gr^p
+%QSd["9KS!uiB$7("D94MCp\i9$3\k:`%t#oH98]m=Ualdg<fJ9'Cf*dANf_#Vss#gf*J6V%GmKtGAmOL89U?%l>rC(FnAM>KRGJE
+%bWV!UiMcma>87QD/I9g#Rmn*i[)`o!M3E^!nE*[g,n^dM(f<*((q3KfCjY;s)0#0t<m&:@E@3hMoZdG:_]jp'as`53Fqg^KG!WBc
+%U-,VT12abKq]hbH:_&%lV5XcgYUW0oIAUQJm3SP;RE=(].E0S4eNf_bs2t0o50'oO^5p?c\Q7oIo"n9EHU>h4V,I%r^ir-N0uI6X
+%oBQR%<c"YgmXgJn=IY'V=#Uh)_Qtl!j]eVSAiaLTmBLkT1P`e!.+i0)D@2WVVsAlq0VRX!l^1&l<@54p735k]a(=WSB!89Wi^Aq@
+%M<d;bqoRAk4fe$!=/8UFf=eXI"k1adEJ(jZPG8uMP!SFJ0rmfl0XYqkhV%3%1lDApY=IYsa9kd;rpMm`FKrXSN6:FK7WDG]elq"\
+%^Dk$\].TL_KTXcH%mCAI,U\Cu>>UcBT;mZ#H(_(Zo.Z_Pmb)+KIP<!72^N*sN+lgDGLH5r_a;oo-e-s)QZ7&-bbn2RRPn0'$ti6l
+%4Hucq1(D?8J9t3fK!F,H"rn@CTNUY+#=rYTCLAA!-+^dJ:VG*dacNC/A")kHnTIS1h`c89)pm6e?&rCE2!I\s7jKM(=N99_<m)C"
+%>qpK?:DUo)m/r53YQrTa`^s-gW)rM,kcW>V<N771W2!3Kqe\:!VdQeE(k@rKN/55>'(.#6E@=jU"`It.\N2R,C@+[V*_,%&7cj85
+%EHnFPa6+B,X(6pj9&^7h:O@l9oED6iFfOBK:nWTjaDd^f`#Xr^+lZ7tb3*4'7gF^Epq&(Epn84Mk!'_O$5#(;;Uc?m]fcTX!7l6H
+%Wn'p4rTij5REP]&H=`RuGO!.Z!*Q`8joqdX,``W_,)=K0M'8FF2]s=!?SN\IG"SJAbqk(3=@rQ*YJMh?@agVNroAaqZ6F=!4(9-*
+%7@ffg\EckN7J^2+6Af<C[TeH1h+`W,D,+[F7Wo9p>nlUK73kBZ4Y^)Xj.,Ad_]BGc"be4alaL.emXb>9gYK\&,=NEK"(O)1"\Vp8
+%0oQ@?#C2-,gBr,UCoHW6_V0D&me)U1aHcHmam]KVRCjsDCd?ZU7*@nCq=L%?i3?>@eBUD5/,Hh0$:`.KF*/W3ZQ!NAp/Z]b,\t`N
+%g_;+89R@^["_2.;8L`kiM!M-?G:)f(0Rt\#EtX3hpo8p#0Ks(bQl0s6AUlL/R(VO_]1QU"Q&0h>K7]F$X]W"4U';H=MT5M?pJlQ:
+%oW>Q+`nasqY9G<XpZqL4>e6n8Wqp,:JNPjh^@(qh/#JH212kc:QG=(W$W2KnMecpJ$fk>;<ei"kcjNgGdD='YRmHT;2De"?`ns_Q
+%iPfCrNB"ag7okgkp*5+9aoJ6ZNQ1n:K0`%la,Psi@/u_GnT]rbUok@q?-#bSL/ijN$R7.-=rrcZ#Q[L;-=q#00LVtPkHB]HMDN\\
+%Ji)?#!BtEA+t$I/WX"''%>H^!Ou<H$h:&m^&5<_96am^<cE+mZrT)J.-U\4UE)\*)obqB.)l^.WAk/T'RAf@1K&IN7kGM4Y!N\P7
+%(ed4_iBQ.S$JML#G^R)0k\uhmZYUXKb-6RZCcKd4OD`Xe@,rRI3)Fci#7HWI0F$TM@'\dE#6ei"Q4t?(A@&(p';<J*+[EN0AgkT>
+%:^8JO:%50\T!k.9,!$i[Z:n:=Ca+%)YlN(VWdq_Spsc\;K%?kZ`@@p=9+OQn@08R.J9"*CK^LPd3RcoV^*4'VO-%Tn*>&0D9pl0'
+%e@Fho`K&mde(,]Vem]RtX;=PNg9[Hl+sr4E8JS%s7?MpJGR_>6,!4mQfe\c@bdo,f@2;gJ8jlEe@MO,*jAa]'kTq#c=u9*N1==rV
+%<&>aDN3T.O5fsSq@pP^$Ug6pj00R--1stk"i6`I/G>Q@A-F9i[b#*`4-#t_aI9'K3*?:/+=@;8ZCfgWnd^]NA&6TDq(rd]9F-mYJ
+%:$.Q@@mmtnb,`U3O=d,_L`rOpK&Y0/aI4Wp!SYCalM%5XSDTa9E%"+b\/luCX1#T'Fj$d:E^_>Xd$p>VUi:8L6e?]aJZX6"QY%`$
+%Ys"P\Hlqpd"CQaD@tOk>Obh-lF;;8TTc2^+:jddf;8HT#[M3#9G&jcIck=U'ZQ_J=YS1MYMZAmm[hN?Zlm=KX(KVsp;<5@\4A8dQ
+%?%Ml(6$o7eOWprrF_W+8n1X*+Tactb3F,\YEg6=FhZi!FX8`^"QW0;1['U_iLg!N"T:gO!bS:^OP_NN9I09^r<"39-2!b!1m,f`a
+%AK)i8>cqX\mNd6!_&7FmR64/DRbNj;<Mc.TIDIP-lqeq0[@/*D0u26D*+FF5oc9YTBI(Y0e_GdbB>+!DXWtlO;H7^+lKX%cC+^@@
+%-_acg.DQ25P7]9uc281$Yb.%%_KTAicr,"RK7,]7l.A@&<d.rga3`N4a]Ptq([o`LA4&[9;;[M7O,1?*$F6@71mK,1#Ll4uRhC-e
+%Nc00e=R5<MV+>O=.om`*CG_bHmPtjf;*hS@?gq*I"N54nQ!)g@&4Re97o?dXbd;3Te:Cas73gU+MRR_;X?\9sY;/=u./s/(_3Wm#
+%^W6'tNc;"mgBd-uF)$djU@%3&kA)/__;l!\A00o-'JE_<_V,)WFN%%]gPp#%D&DV]GO#OMXIQiDF[*#a!TfMH2%F3@fGO,@$4,YQ
+%VTNEdj9nf*6R]cnY#@E'0QF)p`\!=BPuY#LeI[o?4\Za-@_/!?9ndRYpp0%uduIjP*S(cnlAW,D/85s]P.1l`*")X96:-99!jU*>
+%Ec>f.DtFAuSgmIsmAS\'PN_#Ek(sF%,;;ltN@TMk['CHRN00XCoCOg1j$BEUo%,!S"Q;!M\X]p@*KK:#ij2?R'F^t]W'KHjKb4lj
+%=!p&73JnoQf>Mom+^d$5SjXG\;5L(H;'/D5AYQ#/m95Uf5k2D;P*i=+R?sFar2S-(l&ur2X[[]/m?*T4-<q,`S$s_JAmql.Zi#67
+%qqWX9\CChP-sJjf@dqHJ8/q@gWcaZ?Y;&jAXE[$N#a5g"$Paq`0"r.!cUAL&D\1U^;2NYH+4\ho('VM=<37sd#7JND;(^R^[h&Nd
+%i\c-$6SnL@efBYW%&qLlY$5I^jj:M"a@Q$fUEoSrZMLGhAh-SAW?1<T\,qrNLmV2@KJ(:mF084Cq%^3r-*X[f=@=8#nh]&P+tK!#
+%<YDFLAFQQY6.';=C!D&]D.9g3V$dm.(!/k\Bm6CVTNI=Vc0:Et'Zj<f5++e1B#)B<m(9U!:jUjG$BK"o"&ptqU&$KRXl95i->1i@
+%Rbr#O>#gma//G>;1_-[^6uX":7$'^a=uRuVR72a#W`sgrA.[)*GEQi?p5_E?[/a&,WZs`m0l*M'_f!lmF1!kKi,-FCbnj#/:s0n-
+%eWUQ<d"p[\@+EhcHI]F[,6P&UU,_Yk%7^Z(YD-Ddl[K@!dQ.B-g/fQ28s\r%Nr[Np5,)fI>1M>,=lZQZKqWT&.O'ngc6Nqba'&MF
+%=K;qm#l@kH7beD[>[iT.dD[Sc3t1&Wh(J)K=K83V$^`XkO7p[_T2q\#]K^MC<2V'cmY:-q`"'TT#d^3HYd>[DMct(*'W3c,$tGpX
+%V%D<'3?'Mp$aF9HK:4^nHMm%@9g$d]&M-7S.iA>V.T7g8c#ZbDb\JX@r)QL=*2DGdnRa!iY6f8iphJ8b0/hWa12[]FP[qDpI9/!5
+%5cuS=okURX;Fk!)%?WuW)t:Z.hFtat\fTTg_GdCh[f1SCG3X`I7"$YR7uFmt[qS[.BQm99o?Acq9\FfQI'`m`M&;?&'L\oCR)(hQ
+%T%o)kH/3cH!!i\>gVY_tbH_t:,Lr`q&B15A<oL8=pg?nR@O;7#bYVU[pQb#BF$Q/klA-F2:(J4b)J"shKb--6DtCY>q3>n'.e*9(
+%Fs*5=AhZDuZT6<]]Urqu#brbGJB#kG;4S=hL*Vq7>hO<O=ur$b"OU\W<tu/'YeI4([:tW_-<EU:gMX?fit0SWQK3?d5]_IG+0L;K
+%OJ+ZmH_0US@35V&XWcQ4O7oFGE2Wekel+="1iLV2KC(;U/Rb8:92SE)9gn[-(YBhaH34gfZU0[8C?lW<5uia'%(d^e[LP,D`T!(D
+%@KF#Ud76_]-dRM!n3ZaJ#n4E!_6pB@M\ean,bfTplAi4YY]Zh;R_0Ej9SfoNQ7;08+hPD@P%Qj3P'.GbKrG9NGpJ5PO3<FmZJO$d
+%ndH<(GS),4>A:*i$`tNh&d"5D9P)=,YJ'L9O:i`o!o>0f;&rFeD\4;GZMdWd_j#9JSDk-XB]O=59`dPDfO8E(4ZY%moYdb]K(s1N
+%K+KVJV"I7`\,)W:lNpgE?ScemX>*!E"4c"0h*LSE\?#a29\ZBM&AIP5!C)O_Jd%r,37$"r0VD$V=;KAJBbLI[OX81'\dL:U+BZ,D
+%5Xj6<'%7;oBa]LDe%u7(k\L;6UA+#u?(+(,:^%/u6W7-4L/g$,&5aZ7lDuugG9B-gA_5Y5\(0L2p\[b)"kP-C7Q/n(.lggIHdhoO
+%Xs:D:l,M9K91/a^f7:n#<BH9f20=J,L,`GTSsD07hl8+0<`Gf"7"eeY5h$2X7.bO(##G<3/<.fVNO'g:&TL.XL*n'c9JuVT&<&q6
+%/EL7V/?:hE-'9=UqHAoMmlGuBYSWQAZ+ra"9!(++EA7_(f+hhgJRFYkTK]t&=\2]&Z=bFt[?N(<8^n$k7E#[=\Tes:>TZO<P/k3:
+%U3:?5qV4htV[Po_H%Y(N)P.4_5C?<bW07Rg.7/<eIBVdpOemegapeR8Fq)b.e;=Su-IBE,7>HX*i4*'^jNDF#nuh4UCD$qYZf%<e
+%<6`:%m*'=i,+b"RK+bDjEQJd>Xq$.a'f*'U<WT8MZ?\C4c([UK=SiGA\XHs>dj%pn'WtVcjZ9@La[JdP3j]-)8fdt$fG`:\6g5p1
+%@L4I7Vcn*;/Uq]C`k+9;b09aAliF>MfF9$>ZK7ogZ*u>BalJ$uFJ5<O_I4F9Wet<f9kpU>i=1*_UU.2*<X\nGjO4?_$l!M%3h1#u
+%WEl&m&Fk<9gQ;(4(36Z6NJWeI$.WAB/6t!#TI.a=gX_V4C8Erp'9=d.9Y06HQ93?mU8t0X2OK?GP4T;'bSV,B<D.`2-o%Ng=a-lH
+%c)R.s&aQ0iQ`Hjr<M8b=+?0LNP>3p,jKfjE)7HCkm,GC`D+mY=8rg,j,ReL2'i)>M>%TRjX/Zu+/Z,Q\+=(GcCkf2]eIG61^6ZfW
+%)1@Yf'\fglkpi6CE9tfALO6JpN2*Hi`VF>dXu5eO!VWaW;)K^L)n&-R:YZ*b(-mQr7TAn<^])$j,dWJmQ+_;?YB'8enjdilFE1HX
+%!b%S)@?!6oLE.%"mHKMdfs7J-E1<6B=HsFs<)lKm#Fb$<17Rs:"5W=ea_nhl.?+pBI6VPnFEM$oJq:Gah'k$+D10U]_Tl6WCeCTU
+%hAgO5/YI-:(0t;FAt6>kR:bLG;mm#;OkE8\h',Eq[r>q:?*C*%eRfh"%ge"$"%CuQ$#t9A9Q6Ia%OO3FRgV)RWaV",O'u%/3pK(]
+%<AMPtZ$JCn9]FuLY#s49bT8%E_E2=Z3"KGeU'M,2<m9YNp]aTDFDEl7P-E`cCSgkN:C^GC77*Xc&i,YdcD^\O!H(N[K(HmqZ%=L:
+%^^tV_c)^1K,kI>M/DiRb4?_9AU#JE8MGR"mV'q<5,*_XaXH*'<))M@WZf"N;M$]BoM$BV+WMqI3/Ac@;Sj+=na\X?1K<T@,B,Wn>
+%[hFH%//('3p;hkq?K'\A"E@gVqTPrO:aPQ$E#()B-lJCDSaE@qf]gRE(mrJbEI`W-RiD@Jd)6&q3q02(g_^%&75Tub%u._i7*P4@
+%T?d!?D%)>"'1tS'YpLAq#NHh-"mW,T-0,,F]b"'>!+j6K$Lo@",!Rj<aC<.&U)FS6)>Ff0hi&^Ke3sT(]bN9HaG%NuNU9l+%?cF#
+%LGV:u>3nM+<QpA7JBnh!4:Nea57+%58(8Cci0)@:(\h<hUSaGR(@i205XR<N4P_%AJ9EFO:]+b7j=hQ;VLkoHYg47HL'>MVnV7\f
+%:U-9Y2tD2B;V;8mP\(ioO<u@g-j2mm$q@O:aH]K<N5/^`*/?(h+-d98]I1#-kg@1m!pm`s<*:JW';ZJ=q1$eH0k:Xp._u:[_r9SD
+%3js7&Y^<67([Y?q53E,XJc)%ek15s*$FJY4DUqF==E1.O>+P,El7.l5&_t("i5EA*!:`n!nETm"TVImO:mW.L8b9kTNX/+IB20-8
+%S`Dha]AgZ-(X2Q,++ssrE*jMgD;Gen*p";NMZk356<E6!)nW;,CB*H%rUA\@LO]3QePAF,n5o"<It.(^UYFD(Spu-:GB^^5&`Q=$
+%B9tP-npCCaF)ueYI!Va[5B)Ag+2!%f_#b6+n8Ee_Ieh%GL]:[OIlaCCD[ug;?gdE*U&Ng8W)M=fD:raK:IU8Hd/qob5$O.j-35(R
+%pf>L"jJe<3V<-Su+D8FMSO5u0!rZbonFM4db8(TYfi$gR(A%%]#CbpP?i&*1F7&HEWk$K?7^2`ils+)ejittH8liWA-%0dbW%Z_!
+%InjRU=)Ck*81'tinZi!E-(JP%:lo1%U8sHcn/H+&Zs8o;=([4)<Ad$<mbT-JA#oCWI"&Zu<tClb+=P$:l]E.Yni&mS9_=gL$'I,<
+%9ebZ3<P*N3<.4Ch+p`H$Q_PVcCJpKLFNnI0A1C7&.Sr60i5->%P\jNpi.NR'f4"'diaZ%`VlCq$?P*upY5(GtV.?LRGWdQf1G$e-
+%pgDXqY`O?b<'V:(3"3tW!B>&^LqJM"/:5Psa'Jr'K,b:1[htS2D#8j6/9Ag3<SMN?Z$]n0]i'-Ob/@O2[%N7j81pLhLDGa&?he\7
+%1M>t-3g("D;sQM4%O_l/i(J'`>;`J9"CZRhl<db)g-o;2>*@2W`ZK%$WfpDJ9EkbJD-;Q:b)Fn$)a0Q+bXEd7X[1dW`.fm5l1Qg"
+%C,g"Wp[`_1C,%!r@UlNW$KFYK1M;:Ll=RpTs',T$E@]RI"2s3SU81!feu;DjS,s_H;+h/Dla`-5'+!K79HntMB#t-39)o(-&h/b-
+%%t@>nFKtm4;CDiGZU`J^=/[hp3t8Z0Plk]BRq2TO[l\.2Q3cm3%A^^X#YEIn(SHCs8MRD`2.ulbi'6!40`P?VPme6@Y(<9Fb&/83
+%<AB+Q^Tsr^PledeBO11q-[C]oi`.+AP\u,W?(`2S@Q"J1-4m9ebtiW$C0+Nj>U$rr30uY7?P8.9l6_XYj/gs'VnPXA[q44>.tcTu
+%k=,>a._35HQ_4bIjL/iN?_6LNiBH=mLe96X!V6kk)G<'s=Ms+`84JiMUiDU9k<'hM8r/">\P7'5q.>8,?7O_f..)c<r).VFKLe^8
+%BA&kZpQ=_=SO^uDKdCp\(5r`fp/0UU(,jYVXDqcs@Q">q4a4FF\H4$4>0^I57oDpuIC!AU;gN]:F3=5Wr,%cBS@SX]#j6`40nc/L
+%UK#XBElu=:oa7tFgJ#aJH!BbUJ7b.sI.1rR8ku]tSm7RHb(\O",hXU,>0,RbJP4.O$114uTsb88NNOf);KLi*Ie()I(V*ceIREkh
+%_Gq-52RWIk#T'daW\\CI@ZG!=$bm$h6u)AH%dYLU&;.("kB]#[cGkVZb^G&bEWAU9DQp?M(e`OXW$cT<&<<Pc&pZNpLSH6?0YJNN
+%nu"rLT.5E:eOtk/ghMH79FK#kMeZT.LY.,gA)s%fAJ5MH6`qAKV\Op*eN2,LHUMi,,oVkAPr.ko(.=UL:;$EoH+W_/c[*GE.6U7*
+%QoZ1C7U<PTkPG*]\LEiR)pj4&(BtaHi;N>jf9M75jPm?g))ipON[t`JY:,WnWFUh^FQGn^aF9:WJ==-N;+0C#OT;k,]E8>VOPIm'
+%JHBYS:%G42NF$DfY"I9U9qt$eQ[1]o=6l.Wq3)%Jqr7o'hVS4jo&B*.`Qe5GT+?FXOPXIYK&4BALCZSZ]=kk&G'NJNO$:4dG^]P&
+%(O,%Ao_l\RQ\'_!r;V>LWq/f9T"5>UkofA7'k!A&)Kf0@n;m<lYU2;+E3-[#03R=$NN=aC>5&d#S%nH(e\BZF,(Z(d+UY9CFe"Bn
+%0<Wbj4^1e&=pdc<X5Y2kW8iX0p=j_o38$*N`PG(*H(p'j8r2T\G]_C(.k#eLS-Dr@C0HdQM9S`@Z^)'R5"B_0qZ!e=ha1b+l),tr
+%(<;Euj+2%74X^mKqY'lcGQ$cS9=C*Si$`NUDnT)5/J!hgG-@/NdfqmbBH8DL)r&UN'9K2Ka9n\;RW!?0FOMWh#/JL!"jgN%pFWj[
+%;:1.R0j=l@h1(2Y6c'W4LLCUqNuND8L-M5Z5"WC`Ko_ZQ:1o.Vcf$*,\fB4HKkf.SNPSNZm5j`3Q[P!ZYk\\7fMg3"`%iVJD^T#6
+%0`5%s%O_RpB%KHDoOERM[&9HuoU7n&UH/nu"78'VWY<$`?Cf&\%[EDOk!:%"_Mr_ks#)2>Bdj*'#\ZRAD!3c8\_!86&=!"K@2A?%
+%j>0hZ\5h?u^<r&T<kk"tb=GLo^%`0qeRBLHZrFJ22TlmsQR3h)$kp'NC_\9M<-'^Z&BnT:"4-J;)+=6u;:pJe%7[pfJ5@Yb`b_09
+%@]$5*.@SFl[T1Bn5.b!O1a1C_V+%0VR7L?n=e-fcKup`lcad09M`L(MBs(&)^PL4h[Va,`_'=7\o-GM6no+g9TL5:P?cZA86"\3F
+%;W67.DN]bc#l-N<WB<t=/#:_%p<>'^/d)G@lbb6GBk3PWpshH&CJ=lZ-Y%2.<8"@q]D_?h[O1*+W&XWi*1%&)hU5-/ZK?+6,b9aq
+%<n_G@i1c@H?,>'T`0bL?=4nQJ)J2NrJ[HV=!k@_<h$(Q!!MMfhX](!NMW--)*6*FaO0o'i"5O\:=G])LeCeFK3"2+Z7A'\b0Le^X
+%^fOK8,!rUaBgYD=mt"m7]VWN>Wmp@OX4iXS;sVJQ]&2aM!^\Ms!uJnp:j!tD/W90n6lcIUc0l`YmKeqD6?5#&ni3/VaP4@B0Qf;+
+%(=$V+5uq8#-ac4;PY"Ph/Ob(1$QPA:/d/Ha8jjG.Tc?gfruH-!@YPA4hY+se:d'O0M9#e8\.OOk7%WQ!&cE_=h'PTA$<O\R`X1+d
+%2=!$,L05^l)DX6s<1qI,!c8@hV;(`V9FMPi0#Re\*[$e=!D3r-WEG.bUPBD-:+2OJKERWmY/JIU+Tc@*%\PKYJMAkrV@V"MOdcBV
+%AH[Q.(ljI/\5**&(dSBO\27mqq*9-p5ZiLX4fGf%8+lr25A%"t/mgmr\P1MsTJQhfOWohk1s_#EV'(`^;>!p%'L'n*:,eeM##A0O
+%=.k7#5TkTZSN%NSeLc&4LoTBtU2&daj)i*DO\FIEE6HX(B'KoZ=M?(TeQD3qGe3ii1DM`SQNu(,AddJ1"&s/uP.(dV')cDQ`b>rf
+%QoT9sRmkA3:T^ebq`s,gGW0`2L=)Fp2m*6+`fM]#E:>\UEPAq8o_\',(M8ar73bP1&Yao6oLE<sCa<Y`Je$;)%P/:s#*BWD<eM^O
+%nWF_kY=,NY3^=B*&MjQ6_[J,_h+Io[WrQ<D%FlTBd=@N>)D!S<,H;^i'$0GYo3+!]1UIGg_D&6`Jg61qD5^7k!f>%-Xq!T]1lqQg
+%Qn#W2jA=7SMC&T?$@+s%C"=,T>5sMH<J)kV[mtm%+.TT$"W&M@cCVJ(;(aVHGgm*nC2Hue&J`eIh[hV_P"L7MP!Qb]S^XIV(OS/T
+%\o:\0q![4YI76r_H#NTW^7H=prA/tlNK9/-JMKI6-&"7q*;122cb8+39`Q"\-@:jnnF0=_o)%2!YL^g<h=#nRm[)2TqSRr4pYj47
+%HdD+,bBGaiQ&(i&^-c/NDTj7h>G@Ob@U2_DEl;,[!0U22B:=G2A0BZ#$F'^Q22SIGU#HDdQE+SW,GhYaS`1?*5]RJ=WKk\Cc>S(j
+%/+I.CWi1tnZ$34BEEL@Se))]/;C0:_-NmT_]R%Yfk>LlHW"_lR**F")MY#4^f[hS6,[.\pZGigt*.l&eEdsosIQ0.b0pIEf\E\$!
+%Dc+f^(s#X<9L'--']":s!Y6t?>fu=fgp!4a$+n$SY5TT6$sf"Oe-r4J,fo*^Ruk6bpRIt]G*?X]_P/!\gMgiVoWm_U/`a(t+Fs@4
+%8'[2o;m@]U1U%3Y7,kQ(C+r>d5S`&@@2tKeM^+QAV^L"DAfWpmGr1cF%&o?Xl)MTG4(NFW?f5$O"<89]>SiKaV2/BZU/#c,ol<S'
+%<+adCBXaF/I;(PXIUEFk?"QLRdW*i^Aehqt"g3^oF^X%+$RbTnW+r%DQ?VOa<@Diti1bR$obr(&OrnKRel*"gLYUI<<ll+uF6>=o
+%$?GBm6VCFu%e/5pIF;PbL6`'*EOB+5N>Mt!d$3TR7$FSM[R:/uJpunmJ8V=qQ(AmWW"()hViu/TF_E:7)b>cbAbA0kME+W-(3:4_
+%&EX7&HU@>ArDbEI"G,p9VIbnK^iL]2V*tJjTq&ne^P@/gDoPM04]ZqdDOL_Z$5JfbPmkch.e!F"`H09_PMq\#F[lV7!s99QX9N(\
+%CnBLT[U%:4/='X*\?G,\.dq*MA5?!]l/_W+_kP/84B2!!W;m:+Y$$MsrQ2EK(+SS9$'HiZ2q+c.']E.,d71q!HI+5Fpcb)n*^dnW
+%<1q?Hr=G]upj>X:m%UXG!4(rX9Yb+He5`3Y<0.6I%c9X\VC,7G1lm85c]kJ1oRn]p=b(WlLH]ub-:#a/ih>.6)K\A7oj1jC(*5e7
+%f8a&E:=tMI"bd%+'_iIr4-5pS'+@TQ@OC]$aW>c5A/[:VM6XSmT]T(YV9+.Q^,N<u.9uURAb(V#VN)f(Q_;hHAkCuo&aG21lnP&W
+%[)Zk!$Ph[H8g+l8NgX3q8J0Y;0l#%YSq0JP_BGN"6[=iFdln>oU?%V)3J<<71Hk3R+.0#4-%@N(i59M_+J14sc=V[H,GYgAhbt4K
+%4SZgL0@^)JiVJ#=Z!6U[&)-Ln#Bc]!ON/A(P?%NZg"UlF$S8t#ce`LJX*-*bVi.B5[Mis-F$iD25nX'`bDs+NQ0sBOs+^>_g*rXV
+%5C[tVkj!EaFBQ]J^\WY#Q1o`UDirrWq;lVM:QD<"@1S,(D]acgT-G`44O&:Tj:'.9P2J&OaOq3PO^kW,5Bk<"6r'5NKo'L/TG%#J
+%9+`<OA<'h@U@pj<,oCN51$+YMRdoRO#=arc6#Yql2QjUAr>[N\^-o/d+8BktNsR&gAI##4H7N9>aCH-Ok?])fafB*d*jYZUSg]sX
+%A.BF[ag!]BB@eU\U,EO3<["g@ZY"`r=s^aKSP%A+4Aho"B1PalTT*WfE^+l@Wk`LGX=tYneIXn#71d5*WM2??Ga\Y?ZP`Hgq#oe]
+%-R.]1XU_D;I:sutX[]Z-@'2aIjudLgEdWVq%]ot*KELY`@#;1!YbTY&"NY+B$B1[C3qHmEYH:6.-fehoWqaAc/CqZ_94*c<FDg>X
+%;$2[gD6a5+(SE=)7l_^<U/E51I@7-%/V]R-PtEem&]UpT7YD8fo!MWJ1"<2NmJ(7qQF@(/DPl3d$\R4A]>;20dCrqL=_"1E?fDP!
+%eki$HP('&hbrT=k>-l.5UMP.O9,P&Td<^?-!kDFY.'&Wl-T)opotZC3"8$b:FprSpFZ0O^@<0DO*KsTR,V@c<23mX!J4+L=RkaJS
+%Uidhhn+VEq.c%5,CJZ3%/.D/=PgtS'X0>g.)f>?/_4"%q]_]I>6Af3mC=TW0N@5NP904hm*J9ksh2V@3lhA;@IJjXiLP"/B;uI=g
+%&7Kf?op-bAWdrY+)SqP(@j>0i/=^QGS6YAGk5//<iO)&?7D:SCBgGT2*)p]A9W@:pk-Dr)q*FEdlMt_K1:1!eJ`\Nl/fTudfKs!X
+%IM0cr65th[V-8_>U>K:/>#Ch=(kf?q?"<kD'!'r>arb^&h0lSO-K6-Il,Cofb<"N49E"@ROBLY9s7"s=?;AB4a&fI2J,f5aIig?3
+%*k_7+dhbf?.Z48gr9!q1nb2J,gS`*HpYYnXKDb90q:4$WZeP)<cS$rYjR6Hg\GG,[%NjRK5.s"lGlGMuMS=Rbpu":fmi?iGiq)cB
+%2jK`(!C[Mt=g%&^#N>(9%XBMG<?5sah`O&Lkm,o/#5ZFF0+o)]W_dka:)sie?f!pCVt6h,X&Hu7nfMbq?[[+*/DY<1ii;]@s6oQK
+%VrpjIhYq/Dp#<=<RqhoXn]C=`ajos;%h;k!rC&r"EHQa-MRM6..fAB#POlC&>h/NCmIB]Cj5nh1o:p`?0X'Bj&D('5'n>cCj%l#)
+%-VAAY;peseG^ad_F)AZS/fX@5Wqu58d^(l6ouY2?MlWn6TA3_$H8h2OWqOD]J,J2)9[Dh"rnUm%?WjY=Lo8Dplg\]up\lX,HL^k*
+%M+mfk,n90ZG'S4Ur8@Ok,NBQ?;uVff`I9<g$t3u*jVNFA5[X?1$/rs.$DAa6dM=#?jG+9@dReQXE&9$DC&.9BV;@:s9!PloWJ;sI
+%e=/r'<BIlS4KG%qr!2Sf^2-p:U\p`PQD4E-Iiap;s#rC[_n59k3/#_bIldQ8]Aha3cRf+f_3hlhJ,-(Q&"*LinrHK/]:R$Y=Oo91
+%FnHQUS)4nWhoO!589lW,:P:ibOEpf8UQ=bchj4(TmbR>^2,?CjcSC0>,nS45T<ep2OmrO5Y*%Z.VsY@n1=(I:Se1_2D49C2Msk[+
+%_MVE"GeFkCD4:q`<@>%7'_B<'G\3eHm&*=8O%Z)e"h>/WXG*`G3.u!&b8]'HEA[-Iqjc[%b><2ZaJ]VmLtr:@r0-5u/jCrfO^2Vb
+%`ilogpN2-CRnZ]$k_QGXmZ%7D]"n("V@3@Wm/l2%RkDWt[gVemY!&1KGGt-$!&n3WLArTE#71m0C!!E)0Ns(SKTm$2q\hN8\#OG_
+%GJV\AXlFVt=L&?+jH<XkfcJ-sIL^i'fhF]Ol/s2<d3F^XL<Pi[PAk$?gm'L5inhe7]jZ"6aDD+qg9e3L5thATj2\%kTs'.T`)mke
+%(4&k?G/5U>U\W)o`#H_5K'%5ro$m]=e%Ue4@GLIVqtD_PhE?oR)Mc#qGYlRJI2NRq009)^pku$?%5!X]-o\gFWV)?.rK$FCDlD?n
+%*q8a$r/WBXaW6hWrUo:"2mc73A9f0<>]YPI0)bg>*:rgPk*D?GMmTuV+B!eJo$5uARq<1j#/0r<oDdZV\6o%CFSX+#Isc;2kH!XD
+%#9Wm?k/Es1pm8nU/7!_qlpscg>_L^9TASEU_VQKF0$!YSo*6@bG]@s'q%71&Gl6Rtjbou%0/'M"C0\K%r;?K`jrah\qS(a4>3+kE
+%55O@.r8P&dqU&NSo[3K8bDYnE/B7.WR`"/%[l;@^=76OOYts6RqrOf#F#\Zd1I*1Oq-FCJFUn+6IXcWe`Nuo!VCjOKh]8&Yqqg`9
+%dnA-?r;=Cg*k9;MD]^P'T&8Cqki;6_eXHfOC4teP\f:s[/dD`6iMS?dndI#@G'7dRpMWio(65".rq>j>n=EWTSR4GJdB[Hsn,;jY
+%j55?8]_UsDVtZ/7%E&)(me4V4a#=J^nBY1N^"'F#+U`],RXkT0U2eB*:L8B)$,9f-*,&L`>LfE/io4JG<-C.uWMR(/^2I\4#9\Vh
+%*`2^q#5%]0c-t:2GP@'Xm1u6%"CG_=o*8b,hJW(J;3&ukh4P9Bq"t)>]Qd.fnfRY]/LUJ[nr*+ogE.I1HUdJu/`6Hpor#:^YFj^i
+%o&d]9$+G8(q#sRkEec+*koFKb(CD##X6[C\hsG]`FF^H,CCH&`"91h%I(qki/]3%PI>u-%&+g+:V")L4U@FeXkh"pdmp6-9U];Ek
+%:Q.7.rK783YZJ]lq<Nfc3aVeu8G1s/MnA#M_ailK:Z([_nX[h)r[e<*YB>tu*8,bdU[8nJ4j"dP?J`=U?9S5<j6^Jd*+(ol3T,>]
+%C!^4FaZ,09+o!A8`kf6A_%;"H=6D:[r58*4qq^h`^H&A:V2$^nWt4?JiDT>qr(!cMl?Tr0Tr[dsa`ZV[Q`j_%Sc;iAI7rGq"'[B`
+%PC(n/rNncGm;^!'ir?Z*V<X+YV7n25i,.q4pXB(jqYpNlb?%K"(XJ0"Mc\lH+Ba3=%J(%o);^3<obWP=?VQ^_k_WS7+$EsHiOr$i
+%cYq.%4[";nCmcAcUnBCr2U.N)6Qac%6N1.@-jg?HQK6pF4^0E4kbGojBYN6m=MK^ap`j*b!ro0`Ah:I+>4ETM:FlG#0Aa!DYYdTZ
+%B@-22ma,\,*9B^qaotCN7kQ;ELMpkFIY?<#4-"].]Y&K<o9s3dn,<fF(VJj6<Vg4=aue!XSUNm&p@[7ljUI3*^>D'n55t3Pl/D6o
+%mAl0,-1Kt:D8WPagt]TW?)kFthQ(C9lOJ>A.aGP(EMfjqe$Rc:ZqG:sY?n3f;lJkT?G3jpI<WUOXMSN_?i4;RL-Ig/r^+?m&%C_o
+%^V5+f?E2'7"'>@8):TkRghW8S7Te/!4.(-I@,?kHkh@-%cM2t,]GonO[l]t#hdFkCDD:fgo"TpJlhd`!H<5-281]!!Q6Jas;I7>\
+%Bu8SJ+F/l-nr)6=0+X[;5C`Oh:HP!*PDeU*kKapsLb=>/K#t1:C$DE[R!AViQA#Vi/Ag#0as"N'B'?oU=#W5W1Yk1(H@<ti@>-q\
+%rJYB?Pc79%nacTeA]K4EI`\4Q=NP2_hgG4aip'P\J9uY5lLs4AH)5t6!l<ROebS1U=3$6F?N'Q<"-gR%>8k8o^&%YF7P=IZ22L.q
+%lc&9ti_R9]gjSXSr"eaaHes@HIer>S7h4G&^YV?I7%r(^IQ7,NVm#MhUV=IR]RF42-$,1J^:AUdXZ9?Mae'l93Y1,Q,K5_*=+:)F
+%r8ql7b$W?8kpMtC2kja<bDg=AaTT>Rs%/FWUE9?.jD+]<W7ela-;NZ0`O`ZZMo7"WFAuTg_qh-k@G%q/`6*QSr:p0fdX2"EkOD@A
+%Pde7cIs69`]Qs'Wq:Efjo?2@FLA9AEJc7A!iOqa\Iq*-U>ot2GYPko>h%*^5p(NqnWbh5>e[5;>p$JYAn]:1aOn$^=k.P_q4+]Vq
+%^nD>0gOGrI:Tb2d#N*Ae:[3shH$_XpIW>2KmKKSj2p.oWO-do)^Q:\$mB(Vcm$1(?Lm1D/k"RQ<Y*m;rp;4)@/ck*.[*Mljf%`[b
+%-d$]`\#M*#3Qb)Xd8&1-:R$cBY(oN8nmXk@pZbNM(a:9@Lgg:8<88o7R.o&Or-_r=]"HC5>pe:6b6r1=AYOVPmC[DPiCj3kH&qpg
+%HoVRis6DqT8*$:`8ROf5*EUrr%DX\/.3F#S6/K&dglKQ8r0,1K?ci^>]DUZHn&<CuGLj,s/oE>74BXj/?^BdIIla0N[Pt@=VF=gP
+%,,Yk9Vi%#\*PU<>#4$V"@==IOG^a`(HptQX=oJ3Vp"e=-[oBmbI"&a,?8J5BEVTE,]B6"so@'l<C"Iai[=:Dt4Fa?OZcF?:O&qZ4
+%R^`sg7/q`3m#1IJ47;_/QPZ9BZ#o"Oc^FcWO$_pnL+QX`jmQ6GgZ-h>7P.*CI/<4)[\.6i#p4HeO?MJ35!k^aVT81QL$A/0Z^lTU
+%%.s8dB6UOt0,L&9q!)gAH1Ch#qnPl)3mAi*#D9j>+9201r;)T8J7b">r:;"oIIY&^0>DS'_I'6[cJQRVq];/_Z#'0E7E,*ej76.F
+%>t=/93:K$pns"URP:e`lA5I_Z:AUU!LY'#m$iSgUh"*VfSr^(@9lYXRm.U#!:OciHJ"=l`Vc[frJ@3B'/lR%[;CmJ8iS"eDbpE;/
+%n&bI34Xc"*62Gd41#tm&g:ndqnK6_dps1n.a(NGnCUtGk+7l$RC;+V:`jXT.!WMdSe3:Wo-1gp'.u`]Zh4q\+U5_,I0MZNR`IFjc
+%_)DGun6J*&;<AtC+r3/Z:$*RH^GJSJ<0$aWKQM<`FV(5(TCa^"p_UjB'8cNHQ`.VdoAHB5i_f.3L"3\<%hE/sP[]nc4TE[d3;d/-
+%*NT5`*@MZN#1LC&iV*C7r.qc7s06OURq3q<rn#(m5InFUH"FX2pdU1`jQkKljdQ'ki>Hi<D`FN?hqpQpd./W6Bi:ghc``AP0&]QQ
+%r8`DS.J/Diro<&1=0IXnf?:08DuPZ,s5.-GfMOlIR)VHobl:?no)4<4kZmaWUH^SZpt=WU?OQh?h"Om5#2W#IrADr/_u?iG/Q@r=
+%p$eHcUM]l5qDUSb*"r&`'jCV6Z\+KIIf.+S0.WC>;>;re?Uh"ge`BXIEm\p<0PUtp>L;(N_qBD:E;T[k*$5,c>BT6DkMBM=8dcCn
+%F\D?!cJ?oXC$sTJE,aQLBt<.k^P492B9H_3q)cjQDam/X=g;-Zm[4hrIf@UL`VKjgZ^DZ$durDSN1b6\4rGZa<+hjbI<[S%K213?
+%DpN?n*O,b=MT5UX>%-^RH<nF3@BD)afsJ2:^UR=1qDbZ4kB+XuroN\S*Areg@lC0YAM]mP1jAXPIoknt;e\CkUGU<InlIEE^"pou
+%.*at^"rSIVRo5/npr2RR-aEej[3__g:1]<P\)YuKWD$L_`Ml@+R:()QVrN$pA/t3cJQVqhFU6QJ>&Sfd9lr)-\UH_e#5He!6"!nt
+%l<$\"qT#3MW9f('%sk%dZ.@Br=9k1>jn[HoMs%R)?iB95C0D@[)Feu>Q[D"64?9ndHLMl#17&tJH#[nH]Qnq3guH`+.FdM)F_j](
+%oe=!?*e$lk=J$W`TD>Jkq.Hbs54K4bop(JrF(tIf]64e(3?e=T<3c=T.\c:b[hM/K]_qCR]<_BgWqiYQJB\<u`UD,k"V18Y^:(>j
+%LED"VZ3E^SYEJ_Om./]_8pmq'BD4obb\/SDPcKockC;X43;XQcP8P^&p@/+[cfMM-:HtCopqc^71miLb-Lu54mpH(dJ&m/L_=!i,
+%b]]^$:Y=:B4"ChrJ%0psqW4nu5(2stWB0\?-W5'aqs.>HG@+UiGl!kd]d\`W)dC$8JM3Jkc0JG(JWl(BFF!QO.lI%ZWEdteBWCGQ
+%D!".VH8P37bMsBHG<ad+qJU:8IEQ$^"nTmjq!dG!'lD3,B-(tLD63a1rYmbXT$^oX\9NG8]UaOlIWteLB7KgZ^FtWcqJC\:rToRk
+%kEtqq\C>J"Ski-g/1::5n`&iQmD:u'O8P5iMiuD(O2ma!/A"#8O&@fi'\`LS_s"n&QCL#*V.E.%r4U)1mpZ(ih'+knH?jsd]Xdh/
+%dbNs5"#Tp?qkL,+W8PkjQciueFa<q3i=3tP99D3*hc/gKYO>f3^,u8\S5.8E4o)5V]-I3Jff)*u^A6#nfq*-]@d`_=R5NesY*o=Q
+%p%d/"h4G3ja3TfJ;Y"b*k)1%b:QJ<IpXSD.*lK`"<e"G8nE.^K`TPDfV]C#l]NJk5qW3W:QZks#HMdM_n#glucPFYNa1KqV-Ur?(
+%ro`=D]l%hL&b+5SXIO2,OGS;WA7<\XNf0Rgh`mXeckmOQZ.\04K]V%cn5i7;HLS\1Y5N>P?p8u-qSE4/J6(pPgUDXe#N,>O&:8k*
+%g@E.hO]'>_E`iOtWs?hO/DQj?fnWZ+\um):J+0WPDB>l(Zotl;as1dK=gK9T-s*([?3[6rVG(@qo"k?Pc"-)m`=/O<rhpPR#;*m0
+%T>m^@Df,CnUoK=XTIc_H>/F^tYuEB!BKQ!;q.=p.Ph>8#Asnrb/c,@o%OgOteR<m^N9=Y/_Q*p6/i3B_6#U8onWE8h%U'-5g0<^+
+%,-(&)d3GJ=I4ioGO&/?FRuu=MUFmJ1;'u-^/c,?,_g^&Je1pg2*m_fCKJ`9"p!:ecqZV25rtNN3PnHnQ/Do8NM+61J6b@);lM=IS
+%H.Q6Vf!KA_QWu$2!F)utMGed2bE&e9>0'91@8&^d7T^uonD"k7[*FB8%;H4:;56@8[QmtZ9+B(&;Q2dIX3k:V*W7!!Z0t1i[j/ID
+%0hPV1U2DqVl<@"+Pkj+X=*r)M'BfK#Dp+Fk:9i56(+/%1Sj3.ECnH==oaG%F%f95[EFYUnF!R[9b+uPM"i$+A5XA2INmZJOGV4.a
+%1en%^Z]V/CATm97P4g@@1@9CPct>AV<ep"1OUp<Ub`84Q;'rJ^_=,h]kB0S%%dWFm4;YUAcCA;,2Z:b\0mKN?4,G9=8'+6ReAJ2,
+%;sO3Y9m,&kh:ArOm?_'McA6DY$#7jD$sKT(Nk$f(>=M.CTgf?7KL[UhchM1s)(2@KQZnZ<7FtLur&WPohlS-s^%HM0U5K\[A55tM
+%Q4qcXjTIo<cb4_6VsHBo0#/_Ge@LnORTn[fD0Ico],B]=>9.nECHI_RYftKa-7F"BMuGoJ!t'?`F]`!0j13g%co;'i6RJa\.he/U
+%^5;CWe>'Idc)hJfmkOAV'.gJrOU5d[e?Y9m5XA2I%dWFm4;YUAcCCQomd7<l[p-D(1@FOMiniOV\is+mhmM$Zo#@i??ZN-J9X"fs
+%)k#Xan)ISpgP1:;(\f)"$.*!^M+^!V0'XQEMmbm/p(eL&hup9J^igfl?W#e-EgLfafeG@r.tp%u0aUiTHNF4MWs)((/hBhGjN9U$
+%[%WF+#[Ve.'Z(NZQotJQLF4K2)A]oS-UHt`,RBs3"><<[mpE4IO^\s!#9]UgWnM\!Wk;5=`)&!-8^2qkHCsb=Sm]-"`Y4#/HNK3r
+%)&ZjY!"O5Te'Cj4Le5ClG_5182<,!pdn7i(<ftjG%M%\cGE1>jmuI)E<0:WUSD@UOPmE/pWr!Zk%eE7'$Jc1m\#HM_+em_be8;h_
+%Yf,U[CsFf$ff&FOlNtXXis@,K9C<)h@'(1iM0[+(e3;%Z:I+GV.Sh`]Y1s\0Lcd+U+dMR#AOjX)QgrHl<)3R9[Fs"8anC.oW^Q2!
+%i!1BrJ6ZSH!P)Mc0k)OH,HU%E_0XFQ`"U(9Uceb/NFkb%QA6'T"<:=?mUmq/j@K?aQZ(Ma49=!7;I[RI7BKI/iF'>hkFGT%(f*E"
+%dk&eU+Wt"r3)H[?B.,gb-:'1elS]<Q1m,P+OR1Or\*^35&sFuSH-90!gWZ]*:Z-Tc$(B"]!W_]m5hHa#L"0LMM'ns1qe/bjhRuiE
+%:3co$\I`#,>)SDqKeDO[i9_INo(J&O6LoQnm2JF9_il3+JBS]%?p-g9ZmTOg1'1l[!"RS,c6Jo'hBVCoLk96t=Rn/_Q%/tERXU!c
+%6VIR$/*WR_-Qlc1-0A;Z@YE8O*70'#>\901ee9mJAne=c!eO$rnH?:mU$+2&"MW6"?g)[^?U@/irISpV<JMltY/o0sVD?n<?<)6%
+%c<3riH/f225c]I?QjX;&^#Tf%d.Z$([&rm%.7BaAF!5QeC:,&k$XM&ATX/PFWO6XQ'9_h]cFu$?4Rp.7>D;a>\*IBc=$Q3)-i%V3
+%q.(kE='g=2m`+_9mDFB8Y'-`1TD03SO&+s+H$l2IM5PXhT>-EPe,@bQLeO0)o(gZ)p1D)>I6&IZe#M/ZIJs.-*Y/dB'>\uRT%E#;
+%EC_TUpY3<8a5+,&Iq@/cGj'?mQr6WdgK,.S^Dqc2:3um7p6pJ`q(g2+4+$)\I6=KM(UI@PIJgBRr<K^u^Rk~>
+%AI9_PrivateDataEnd

--- a/Papers/quant-ph_0405174/irregular.eps
+++ b/Papers/quant-ph_0405174/irregular.eps
@@ -1,0 +1,6695 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (irregular.eps)
+%%CreationDate: (1/28/2004) (2:33 AM)
+%%BoundingBox: 183 413 395 572
+%%HiResBoundingBox: 183.6391 413.5003 394.5 571.8793
+%%DocumentProcessColors: Cyan Magenta Yellow Black
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_pattern_AI5 1.0 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Color
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -486 1044 1 1392 962 18 0 1 4 54 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_pattern_AI5 1.1 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Pattern Operators)
+%%Version: 1.1 0
+%%CreationDate: (03/26/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/@
+{
+} def
+/&
+{
+} def
+/dp
+{
+	dup null eq
+	{
+		pop
+		_dp 0 ne
+		{
+			0 1 _dp 1 sub _dl mod
+			{
+				_da exch get 3 get
+			} for
+			_dp 1 sub _dl mod 1 add packedarray
+			_da 0 get aload pop 8 -1 roll 5 -1 roll pop 4 1 roll
+			definepattern pop
+		} if
+	}
+	{
+		_dp 0 ne _dp _dl mod 0 eq and
+		{
+			null dp
+		} if
+		7 packedarray _da exch _dp _dl mod exch put
+		_dp _dl mod _da 0 get 4 get 2 packedarray
+		/_dp _dp 1 add def
+	} ifelse
+} def
+/E
+{
+	_ed begin
+	dup 0 get type /arraytype ne
+	{
+		0
+		{
+			dup 1 add index type /arraytype eq
+			{
+				1 add
+			}
+			{
+				exit
+			} ifelse
+		} loop
+		array astore
+	} if
+	/_dd exch def
+	/_ury exch def
+	/_urx exch def
+	/_lly exch def
+	/_llx exch def
+	/_n exch def
+	/_y 0 def
+	/_dl 4 def
+	/_dp 0 def
+	/_da _dl array def
+	0 1 _dd length 1 sub
+	{
+		/_d exch _dd exch get def
+		0 2 _d length 2 sub
+		{
+			/_x exch def
+			/_c _d _x get _ ne def
+			/_r _d _x 1 add get cvlit def
+			_r _ ne
+			{
+				_urx _llx sub _ury _lly sub
+				[
+				1 0 0 1 0 0
+				]
+				[
+				/save cvx
+				_llx neg _lly neg /translate cvx
+				_c
+				{
+					nc /begin cvx
+				} if
+				_r dup type /stringtype eq
+				{
+					cvx
+				}
+				{
+					{
+						exec
+					} /forall cvx
+				} ifelse
+				_c
+				{
+					/end cvx
+				} if
+				/restore cvx
+				] cvx
+				/_fn 12 _n length add string def
+				_y _fn cvs pop
+				/_y _y 1 add def
+				_fn 12 _n putinterval
+				_fn _c false dp
+				_d exch _x 1 add exch put
+			} if
+		} for
+	} for
+	null dp
+	_n _dd /_pd
+ end
+	xput
+} def
+/fc
+{
+	_fm dup concatmatrix pop
+} def
+/p
+{
+	/_fm exch ddef
+	9 -2 roll _pm translate fc
+	7 -2 roll _pm scale fc
+	5 -1 roll _pm rotate fc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate fc
+		1 -1 _pm scale fc
+		neg _pm rotate fc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate fc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore fc
+	neg _pm rotate fc
+	_pd exch get /_fdd exch ddef
+	/_pf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					patternfill
+				}
+				{
+					pop
+					fill
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_psf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					9 copy 6 npop patternashow
+				}
+				{
+					pop
+					6 copy 3 npop hvashow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		sw rmoveto
+	} ddef
+	/_pjsf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					12 copy 6 npop patternawidthshow
+				}
+				{
+					pop 9 copy 3 npop hvawidthshow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+/sc
+{
+	_sm dup concatmatrix pop
+} def
+/P
+{
+	/_sm exch ddef
+	9 -2 roll _pm translate sc
+	7 -2 roll _pm scale sc
+	5 -1 roll _pm rotate sc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate sc
+		1 -1 _pm scale sc
+		neg _pm rotate sc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate sc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore sc
+	neg _pm rotate sc
+	_pd exch get /_sdd exch ddef
+	/_ps
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					patternstroke
+				}
+				{
+					pop stroke
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_pss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					10 copy 6 npop patternashowstroke
+				}
+				{
+					pop 7 copy 3 npop ss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop sw rmoveto
+	} ddef
+	/_pjss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					13 copy 6 npop patternawidthshowstroke
+				}
+				{
+					pop 10 copy 3 npop jss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+end
+userdict /Adobe_pattern_AI5 18 dict dup begin
+put
+/initialize
+{
+	/definepattern where
+	{
+		pop
+	}
+	{
+	 begin
+	 begin
+		Adobe_pattern_AI5 begin
+		Adobe_pattern_AI5
+		{
+			dup xcheck
+			{
+				bind
+			} if
+			pop pop
+		} forall
+		mark
+		cachestatus 7 1 roll pop pop pop pop exch pop exch
+		{
+			{
+				10000 add
+				dup 2 index gt
+				{
+					exit
+				} if
+				dup setcachelimit
+			} loop
+		} stopped
+		cleartomark
+	 end 	
+		
+	 end
+	 end
+		
+		Adobe_pattern_AI5 begin
+	} ifelse
+} def
+/terminate
+{
+	currentdict Adobe_pattern_AI5 eq
+	{
+	 end
+	} if
+} def
+errordict
+/nocurrentpoint
+{
+	pop
+	stop
+} put
+errordict
+/invalidaccess
+{
+	pop
+	stop
+} put
+/patternencoding
+256 array def
+0 1 255
+{
+	patternencoding exch ( ) 2 copy exch 0 exch put cvn put
+} for
+/definepattern
+{
+	17 dict begin
+	/uniform exch def
+	/cache exch def
+	/key exch def
+	/procarray exch def
+	/mtx exch matrix invertmatrix def
+	/height exch def
+	/width exch def
+	/ctm matrix currentmatrix def
+	/ptm matrix def
+	/str 32 string def
+	/slice 9 dict def
+	slice /s 1 put
+	slice /q 256 procarray length div sqrt floor cvi put
+	slice /b 0 put
+	/FontBBox
+	[
+	0 0 0 0
+	] def
+	/FontMatrix mtx matrix copy def
+	/Encoding patternencoding def
+	/FontType 3 def
+	/BuildChar
+	{
+		exch
+	 begin
+		/setstrokeadjust where {pop true setstrokeadjust} if
+		slice begin
+		dup q dup mul mod s idiv /i exch def
+		dup q dup mul mod s mod /j exch def
+		q dup mul idiv procarray exch get
+		/xl j width s div mul def
+		/xg j 1 add width s div mul def
+		/yl i height s div mul def
+		/yg i 1 add height s div mul def
+		uniform
+		{
+			1 1
+		}
+		{
+			width 0 dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+			0 height dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+		} ifelse
+		width 0 cache
+		{
+			xl 4 index mul yl 4 index mul xg 6 index mul yg 6 index mul
+			setcachedevice
+		}
+		{
+			setcharwidth
+		} ifelse
+		gsave
+		scale
+		newpath
+		xl yl moveto
+		xg yl lineto
+		xg yg lineto
+		xl yg lineto
+		closepath
+		clip
+		newpath
+	 end
+	 end
+		exec
+		grestore
+	} def
+	key currentdict definefont
+ end
+} def
+/patterncachesize
+{
+	gsave
+	newpath
+	0 0 moveto
+	width 0 lineto
+	width height lineto
+	0 height lineto
+	closepath
+	patternmatrix setmatrix
+	pathbbox
+	exch ceiling 4 -1 roll floor sub 3 1 roll
+	ceiling exch floor sub
+	mul 1 add
+	grestore
+} def
+/patterncachelimit
+{
+	cachestatus 7 1 roll 6 npop 8 mul
+} def
+/patternpath
+{
+	exch dup begin
+	setfont
+	ctm setmatrix
+	concat
+	slice exch /b exch slice /q get dup mul mul put
+	FontMatrix concat
+	uniform
+	{
+		width 0 dtransform round width div exch round width div exch
+		0 height dtransform round height div exch height div exch
+		0 0 transform round exch round exch
+		ptm astore setmatrix
+	}
+	{
+		ptm currentmatrix pop
+	} ifelse
+	{
+		currentpoint
+	} stopped not
+	{
+		2 npop
+		pathbbox
+		true
+		4 index 3 index eq
+		4 index 3 index eq
+		and
+		{
+			pop false
+			{
+				{
+					2 npop
+				}
+				{
+					3 npop true
+				}
+				{
+					7 npop true
+				}
+				{
+					pop true
+				} pathforall
+			} stopped
+			{
+				5 npop true
+			} if
+		} if
+		{
+			height div ceiling height mul 4 1 roll
+			width div ceiling width mul 4 1 roll
+			height div floor height mul 4 1 roll
+			width div floor width mul 4 1 roll
+			2 index sub height div ceiling cvi exch
+			3 index sub width div ceiling cvi exch
+			4 2 roll moveto
+			FontMatrix mtx invertmatrix
+			dup dup 4 get exch 5 get rmoveto
+			ptm ptm concatmatrix pop
+			slice /s
+			patterncachesize patterncachelimit div ceiling sqrt ceiling cvi
+			dup slice /q get gt
+			{
+				pop slice /q get
+			} if
+			put
+			0 1 slice /s get dup mul 1 sub
+			{
+				slice /b get add
+				gsave
+				0 1 str length 1 sub
+				{
+					str exch 2 index put
+				} for
+				pop
+				dup
+				{
+					gsave
+					ptm setmatrix
+					1 index str length idiv
+					{
+						str show
+					} repeat
+					1 index str length mod str exch 0 exch getinterval show
+					grestore
+					0 height rmoveto
+				} repeat
+				grestore
+			} for
+			2 npop
+		}
+		{
+			4 npop
+		} ifelse
+	} if
+ end
+} def
+/patternclip
+{
+	_eo {eoclip} {clip} ifelse
+} def
+/patternstrokepath
+{
+	strokepath
+} def
+/patternmatrix
+matrix def
+/patternfill
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternclip
+	Adobe_pattern_AI5 /patternpath get exec
+	grestore
+	newpath
+} def
+/patternstroke
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternstrokepath
+	true
+	{
+		{
+			{
+				newpath
+				moveto
+			}
+			{
+				lineto
+			}
+			{
+				curveto
+			}
+			{
+				closepath
+				3 copy
+				Adobe_pattern_AI5 /patternfill get exec
+			} pathforall
+			3 npop
+		} stopped
+		{
+			5 npop
+			patternclip
+			Adobe_pattern_AI5 /patternfill get exec
+		} if
+	}
+	{
+		patternclip
+		Adobe_pattern_AI5 /patternfill get exec
+	} ifelse
+	grestore
+	newpath
+} def
+/vpatternawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index 5 index 5 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	3 npop
+} def
+/hpatternawidthshow
+{
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		9 index 9 index 9 index
+		Adobe_pattern_AI5 /patternfill get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	8 npop
+} def
+/patternashow
+{
+0 0 0 6 3 roll
+patternawidthshow
+} def
+/patternawidthshow
+{
+	6 index type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get 7 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshow } { vpatternawidthshow } ifelse
+} def
+/vpatternawidthshowstroke
+{
+	7 1 roll
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			3 index setmatrix
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			4 index setmatrix
+			7 index 7 index 7 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	4 npop
+} def
+/hpatternawidthshowstroke
+{
+	7 1 roll
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		7 index setmatrix
+		10 index 10 index 10 index
+		Adobe_pattern_AI5 /patternstroke get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	9 npop
+} def
+/patternashowstroke
+{
+	0 0 0 7 3 roll
+	patternawidthshowstroke
+} def
+/patternawidthshowstroke
+{
+	7 index type /dicttype eq
+	{
+		patternmatrix /patternmatrix get 8 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshowstroke } { vpatternawidthshowstroke } ifelse
+} def
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_pattern_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginPattern: (Neues Muster)
+(Neues Muster) 1 1.0386 9.1499 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.025 1.0193 m
+1.025 13.6004 L
+9.1749 13.6004 L
+9.1749 1.0193 L
+1.025 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.8128 13.5908 m
+9.1999 13.5908 L
+9.1999 12.902 L
+1.4714 1.0096 L
+1.05 1.0096 L
+1.05 1.6457 L
+8.8128 13.5908 L
+f1.05 12.9743 m
+1.05 13.6197 L
+1.4694 13.6197 L
+1.05 12.9743 L
+f9.1999 1.5733 m
+9.1999 1 L
+8.8273 1 L
+9.1999 1.5733 L
+f1.6371 13.6741 m
+1.25 13.6741 L
+1.25 12.9853 L
+8.9785 1.093 L
+9.3999 1.093 L
+9.3999 1.729 L
+1.6371 13.6741 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrfk1)
+(shrfk1) 1.05 1.0386 9.1999 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+9.1749 1.0193 m
+9.1749 13.6004 L
+1.025 13.6004 L
+1.025 1.0193 L
+9.1749 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.3871 13.5908 m
+1 13.5908 L
+1 12.902 L
+8.7285 1.0097 L
+9.1499 1.0097 L
+9.1499 1.6457 L
+1.3871 13.5908 L
+f9.1499 12.9743 m
+9.1499 13.6197 L
+8.7305 13.6197 L
+9.1499 12.9743 L
+f1 1.5733 m
+1 1 L
+1.3726 1 L
+1 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrfk2)
+(shrfk2) 1 1.0386 9.1499 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.025 1.0193 m
+1.025 13.6004 L
+9.1749 13.6004 L
+9.1749 1.0193 L
+1.025 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.8128 13.5908 m
+9.1999 13.5908 L
+9.1999 12.902 L
+1.4714 1.0096 L
+1.05 1.0096 L
+1.05 1.6457 L
+8.8128 13.5908 L
+f1.05 12.9743 m
+1.05 13.6197 L
+1.4694 13.6197 L
+1.05 12.9743 L
+f9.1999 1.5733 m
+9.1999 1 L
+8.8273 1 L
+9.1999 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrf2)
+(shrf2) 1.125 1.0833 21.5 28.2083 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+21.4375 1.0416 m
+21.4375 28.1666 L
+1.0625 28.1666 L
+1.0625 1.0416 L
+21.4375 1.0416 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.9679 28.1458 m
+1 28.1458 L
+1 26.6608 L
+20.3215 1.0208 L
+21.375 1.0208 L
+21.375 2.3921 L
+1.9679 28.1458 L
+f21.375 26.8168 m
+21.375 28.2083 L
+20.3264 28.2083 L
+21.375 26.8168 L
+f1 2.2361 m
+1 1 L
+1.9315 1 L
+1 2.2361 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrf3)
+(shrf3) 1 1.0833 21.375 28.2083 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0625 1.0416 m
+1.0625 28.1666 L
+21.4375 28.1666 L
+21.4375 1.0416 L
+1.0625 1.0416 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.5321 28.1458 m
+21.5 28.1458 L
+21.5 26.6608 L
+2.1785 1.0208 L
+1.125 1.0208 L
+1.125 2.3921 L
+20.5321 28.1458 L
+f1.125 26.8168 m
+1.125 28.2083 L
+2.1736 28.2083 L
+1.125 26.8168 L
+f21.5 2.2361 m
+21.5 1 L
+20.5685 1 L
+21.5 2.2361 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+(shrf2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrf2) Pc
+(shrf3) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrf3) Pc
+(shrfk1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrfk1) Pc
+(shrfk2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrfk2) Pc
+(Neues Muster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Neues Muster) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+q1 Ap
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+394.5 568.6968 m
+394.5 413.5003 L
+183.6391 413.5003 L
+183.6391 568.6968 L
+394.5 568.6968 L
+hWn0 Ap
+0 O
+0.0274 0.0196 0.5059 0 k
+0 R
+0 0 0 1 K
+1 j 2 w674.5 298 m
+B(shrfk1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+0 j 4 w191.875 491.6561 m
+308.375 491.4061 l
+308.375 414.6561 l
+230.375 413.9061 l
+230.125 374.9061 l
+269.875 375.1561 l
+269.875 452.9061 l
+191.375 452.6561 l
+191.875 491.6561 l
+bQ0 A
+0 O
+(shrfk2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+0 R
+0 0 0 1 K
+800 Ar
+0 J 0 j 4 w 4 M []0 d%AI3_Note:0 D
+0 XR
+231.5 569.875 m
+348 569.625 l
+348 492.875 l
+270 492.125 l
+269.75 453.125 l
+309.5 453.375 l
+309.5 531.125 l
+231 530.875 l
+231.5 569.875 l
+buu1 w191.9987 530.375 m
+387.4987 529.875 l
+S191.9987 492 m
+387.4987 491.5 l
+S191.9987 453.625 m
+387.4987 453.125 l
+S191.9987 415.25 m
+387.4987 414.75 l
+S191.9987 568.75 m
+387.4987 568.25 l
+SUu230.6 415.75 m
+230.6 569.25 l
+S269.7 415.75 m
+269.7 569.25 l
+S191.5 415.75 m
+191.5 569.25 l
+S308.8 415.75 m
+308.8 569.25 l
+S347.9 415.75 m
+347.9 569.25 l
+S387 415.75 m
+387 569.25 l
+SUU0 O
+(Neues Muster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+4 w230.6391 569.6968 m
+269.6667 569.3333 l
+269.5 531 l
+230.5 531 l
+230.6391 569.6968 l
+b270.5558 492.1817 m
+309.5833 491.8183 l
+309.4167 453.485 l
+270.4167 453.485 l
+270.5558 492.1817 l
+bLB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_pattern_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/margolus0.eps
+++ b/Papers/quant-ph_0405174/margolus0.eps
@@ -1,0 +1,5691 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (margolus0.eps)
+%%CreationDate: (12/18/2003) (1:45 PM)
+%%BoundingBox: 181 296 412 535
+%%HiResBoundingBox: 181.3333 296.6667 411.3333 534
+%%DocumentProcessColors: Black
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Black&White
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -66 708 2 1384 924 18 0 1 8 88 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+q1 Ap
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+411.3333 296.6667 m
+411.3333 534 L
+181.3333 534 L
+181.3333 296.6667 L
+411.3333 296.6667 L
+hWnu0 R
+0 0 0 1 K
+3 w236.6686 478.0039 m
+236.6686 551.2539 L
+163.1686 551.2539 L
+163.1686 478.0039 L
+236.6686 478.0039 L
+s314.2467 478.0039 m
+314.2467 551.2539 L
+240.7467 551.2539 L
+240.7467 478.0039 L
+314.2467 478.0039 L
+s391.8249 478.0039 m
+391.8249 551.2539 L
+318.3249 551.2539 L
+318.3249 478.0039 L
+391.8249 478.0039 L
+s469.403 478.0039 m
+469.403 551.2539 L
+395.903 551.2539 L
+395.903 478.0039 L
+469.403 478.0039 L
+s236.6686 400.554 m
+236.6686 473.804 L
+163.1686 473.804 L
+163.1686 400.554 L
+236.6686 400.554 L
+s314.2467 400.554 m
+314.2467 473.804 L
+240.7467 473.804 L
+240.7467 400.554 L
+314.2467 400.554 L
+s391.8249 400.554 m
+391.8249 473.804 L
+318.3249 473.804 L
+318.3249 400.554 L
+391.8249 400.554 L
+s469.403 400.554 m
+469.403 473.804 L
+395.903 473.804 L
+395.903 400.554 L
+469.403 400.554 L
+s236.6686 323.1042 m
+236.6686 396.3542 L
+163.1686 396.3542 L
+163.1686 323.1042 L
+236.6686 323.1042 L
+s314.2467 323.1042 m
+314.2467 396.3542 L
+240.7467 396.3542 L
+240.7467 323.1042 L
+314.2467 323.1042 L
+s391.8249 323.1042 m
+391.8249 396.3542 L
+318.3249 396.3542 L
+318.3249 323.1042 L
+391.8249 323.1042 L
+s469.403 323.1042 m
+469.403 396.3542 L
+395.903 396.3542 L
+395.903 323.1042 L
+469.403 323.1042 L
+s236.6686 245.6543 m
+236.6686 318.9043 L
+163.1686 318.9043 L
+163.1686 245.6543 L
+236.6686 245.6543 L
+s314.2467 245.6543 m
+314.2467 318.9043 L
+240.7467 318.9043 L
+240.7467 245.6543 L
+314.2467 245.6543 L
+s391.8249 245.6543 m
+391.8249 318.9043 L
+318.3249 318.9043 L
+318.3249 245.6543 L
+391.8249 245.6543 L
+s469.403 245.6543 m
+469.403 318.9043 L
+395.903 318.9043 L
+395.903 245.6543 L
+469.403 245.6543 L
+sUu1 J 2 w [7 7 ]0 d197.7161 516.5498 m
+197.7161 589.7998 L
+123.2161 589.7998 L
+123.2161 516.5498 L
+197.7161 516.5498 L
+s275.2943 516.5498 m
+275.2943 589.7998 L
+201.7943 589.7998 L
+201.7943 516.5498 L
+275.2943 516.5498 L
+s352.8724 516.5498 m
+352.8724 589.7998 L
+279.3724 589.7998 L
+279.3724 516.5498 L
+352.8724 516.5498 L
+s430.4505 516.5498 m
+430.4505 589.7998 L
+356.9505 589.7998 L
+356.9505 516.5498 L
+430.4505 516.5498 L
+s197.7161 439.0999 m
+197.7161 512.3499 L
+124.2161 512.3499 L
+124.2161 439.0999 L
+197.7161 439.0999 L
+s1 j275.2943 439.0999 m
+275.2943 512.3499 L
+201.7943 512.3499 L
+201.7943 439.0999 L
+275.2943 439.0999 L
+s0 j352.8724 439.0999 m
+352.8724 512.3499 L
+279.3724 512.3499 L
+279.3724 439.0999 L
+352.8724 439.0999 L
+s430.4505 439.0999 m
+430.4505 512.3499 L
+356.9505 512.3499 L
+356.9505 439.0999 L
+430.4505 439.0999 L
+s197.7161 361.6501 m
+197.7161 434.9001 L
+124.2161 434.9001 L
+124.2161 361.6501 L
+197.7161 361.6501 L
+s275.2943 361.6501 m
+275.2943 434.9001 L
+201.7943 434.9001 L
+201.7943 361.6501 L
+275.2943 361.6501 L
+s352.8724 361.6501 m
+352.8724 434.9001 L
+279.3724 434.9001 L
+279.3724 361.6501 L
+352.8724 361.6501 L
+s430.4505 361.6501 m
+430.4505 434.9001 L
+356.9505 434.9001 L
+356.9505 361.6501 L
+430.4505 361.6501 L
+s197.7161 284.2002 m
+197.7161 357.4502 L
+124.2161 357.4502 L
+124.2161 284.2002 L
+197.7161 284.2002 L
+s275.2943 284.2002 m
+275.2943 357.4502 L
+201.7943 357.4502 L
+201.7943 284.2002 L
+275.2943 284.2002 L
+s352.8724 284.2002 m
+352.8724 357.4502 L
+279.3724 357.4502 L
+279.3724 284.2002 L
+352.8724 284.2002 L
+s430.4505 284.2002 m
+430.4505 357.4502 L
+356.9505 357.4502 L
+356.9505 284.2002 L
+430.4505 284.2002 L
+sUQLB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/margolusT.eps
+++ b/Papers/quant-ph_0405174/margolusT.eps
@@ -1,0 +1,8193 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (margolusT.eps)
+%%CreationDate: (12/18/2003) (3:53 PM)
+%%BoundingBox: 35 68 386 415
+%%HiResBoundingBox: 35 68 386 415
+%%DocumentProcessColors: Cyan Magenta Yellow Black
+%%DocumentFonts: TimesNewRomanPS-BoldMT
+%%+ TimesNewRomanPS-ItalicMT
+%%DocumentSuppliedFonts: TimesNewRomanPS-BoldMT
+%%+ TimesNewRomanPS-ItalicMT
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_typography_AI5 1.0 1
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_pattern_AI5 1.0 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Color
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -366 852 1 1384 924 18 0 1 -4 85 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginResource: procset Adobe_typography_AI5 1.0 1
+%%Title: (Typography Operators)
+%%Version: 1.0 1
+%%CreationDate:(6/10/1996) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_pattern_AI5 1.1 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Pattern Operators)
+%%Version: 1.1 0
+%%CreationDate: (03/26/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/@
+{
+} def
+/&
+{
+} def
+/dp
+{
+	dup null eq
+	{
+		pop
+		_dp 0 ne
+		{
+			0 1 _dp 1 sub _dl mod
+			{
+				_da exch get 3 get
+			} for
+			_dp 1 sub _dl mod 1 add packedarray
+			_da 0 get aload pop 8 -1 roll 5 -1 roll pop 4 1 roll
+			definepattern pop
+		} if
+	}
+	{
+		_dp 0 ne _dp _dl mod 0 eq and
+		{
+			null dp
+		} if
+		7 packedarray _da exch _dp _dl mod exch put
+		_dp _dl mod _da 0 get 4 get 2 packedarray
+		/_dp _dp 1 add def
+	} ifelse
+} def
+/E
+{
+	_ed begin
+	dup 0 get type /arraytype ne
+	{
+		0
+		{
+			dup 1 add index type /arraytype eq
+			{
+				1 add
+			}
+			{
+				exit
+			} ifelse
+		} loop
+		array astore
+	} if
+	/_dd exch def
+	/_ury exch def
+	/_urx exch def
+	/_lly exch def
+	/_llx exch def
+	/_n exch def
+	/_y 0 def
+	/_dl 4 def
+	/_dp 0 def
+	/_da _dl array def
+	0 1 _dd length 1 sub
+	{
+		/_d exch _dd exch get def
+		0 2 _d length 2 sub
+		{
+			/_x exch def
+			/_c _d _x get _ ne def
+			/_r _d _x 1 add get cvlit def
+			_r _ ne
+			{
+				_urx _llx sub _ury _lly sub
+				[
+				1 0 0 1 0 0
+				]
+				[
+				/save cvx
+				_llx neg _lly neg /translate cvx
+				_c
+				{
+					nc /begin cvx
+				} if
+				_r dup type /stringtype eq
+				{
+					cvx
+				}
+				{
+					{
+						exec
+					} /forall cvx
+				} ifelse
+				_c
+				{
+					/end cvx
+				} if
+				/restore cvx
+				] cvx
+				/_fn 12 _n length add string def
+				_y _fn cvs pop
+				/_y _y 1 add def
+				_fn 12 _n putinterval
+				_fn _c false dp
+				_d exch _x 1 add exch put
+			} if
+		} for
+	} for
+	null dp
+	_n _dd /_pd
+ end
+	xput
+} def
+/fc
+{
+	_fm dup concatmatrix pop
+} def
+/p
+{
+	/_fm exch ddef
+	9 -2 roll _pm translate fc
+	7 -2 roll _pm scale fc
+	5 -1 roll _pm rotate fc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate fc
+		1 -1 _pm scale fc
+		neg _pm rotate fc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate fc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore fc
+	neg _pm rotate fc
+	_pd exch get /_fdd exch ddef
+	/_pf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					patternfill
+				}
+				{
+					pop
+					fill
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_psf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					9 copy 6 npop patternashow
+				}
+				{
+					pop
+					6 copy 3 npop hvashow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		sw rmoveto
+	} ddef
+	/_pjsf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					12 copy 6 npop patternawidthshow
+				}
+				{
+					pop 9 copy 3 npop hvawidthshow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+/sc
+{
+	_sm dup concatmatrix pop
+} def
+/P
+{
+	/_sm exch ddef
+	9 -2 roll _pm translate sc
+	7 -2 roll _pm scale sc
+	5 -1 roll _pm rotate sc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate sc
+		1 -1 _pm scale sc
+		neg _pm rotate sc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate sc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore sc
+	neg _pm rotate sc
+	_pd exch get /_sdd exch ddef
+	/_ps
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					patternstroke
+				}
+				{
+					pop stroke
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_pss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					10 copy 6 npop patternashowstroke
+				}
+				{
+					pop 7 copy 3 npop ss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop sw rmoveto
+	} ddef
+	/_pjss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					13 copy 6 npop patternawidthshowstroke
+				}
+				{
+					pop 10 copy 3 npop jss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+end
+userdict /Adobe_pattern_AI5 18 dict dup begin
+put
+/initialize
+{
+	/definepattern where
+	{
+		pop
+	}
+	{
+	 begin
+	 begin
+		Adobe_pattern_AI5 begin
+		Adobe_pattern_AI5
+		{
+			dup xcheck
+			{
+				bind
+			} if
+			pop pop
+		} forall
+		mark
+		cachestatus 7 1 roll pop pop pop pop exch pop exch
+		{
+			{
+				10000 add
+				dup 2 index gt
+				{
+					exit
+				} if
+				dup setcachelimit
+			} loop
+		} stopped
+		cleartomark
+	 end 	
+		
+	 end
+	 end
+		
+		Adobe_pattern_AI5 begin
+	} ifelse
+} def
+/terminate
+{
+	currentdict Adobe_pattern_AI5 eq
+	{
+	 end
+	} if
+} def
+errordict
+/nocurrentpoint
+{
+	pop
+	stop
+} put
+errordict
+/invalidaccess
+{
+	pop
+	stop
+} put
+/patternencoding
+256 array def
+0 1 255
+{
+	patternencoding exch ( ) 2 copy exch 0 exch put cvn put
+} for
+/definepattern
+{
+	17 dict begin
+	/uniform exch def
+	/cache exch def
+	/key exch def
+	/procarray exch def
+	/mtx exch matrix invertmatrix def
+	/height exch def
+	/width exch def
+	/ctm matrix currentmatrix def
+	/ptm matrix def
+	/str 32 string def
+	/slice 9 dict def
+	slice /s 1 put
+	slice /q 256 procarray length div sqrt floor cvi put
+	slice /b 0 put
+	/FontBBox
+	[
+	0 0 0 0
+	] def
+	/FontMatrix mtx matrix copy def
+	/Encoding patternencoding def
+	/FontType 3 def
+	/BuildChar
+	{
+		exch
+	 begin
+		/setstrokeadjust where {pop true setstrokeadjust} if
+		slice begin
+		dup q dup mul mod s idiv /i exch def
+		dup q dup mul mod s mod /j exch def
+		q dup mul idiv procarray exch get
+		/xl j width s div mul def
+		/xg j 1 add width s div mul def
+		/yl i height s div mul def
+		/yg i 1 add height s div mul def
+		uniform
+		{
+			1 1
+		}
+		{
+			width 0 dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+			0 height dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+		} ifelse
+		width 0 cache
+		{
+			xl 4 index mul yl 4 index mul xg 6 index mul yg 6 index mul
+			setcachedevice
+		}
+		{
+			setcharwidth
+		} ifelse
+		gsave
+		scale
+		newpath
+		xl yl moveto
+		xg yl lineto
+		xg yg lineto
+		xl yg lineto
+		closepath
+		clip
+		newpath
+	 end
+	 end
+		exec
+		grestore
+	} def
+	key currentdict definefont
+ end
+} def
+/patterncachesize
+{
+	gsave
+	newpath
+	0 0 moveto
+	width 0 lineto
+	width height lineto
+	0 height lineto
+	closepath
+	patternmatrix setmatrix
+	pathbbox
+	exch ceiling 4 -1 roll floor sub 3 1 roll
+	ceiling exch floor sub
+	mul 1 add
+	grestore
+} def
+/patterncachelimit
+{
+	cachestatus 7 1 roll 6 npop 8 mul
+} def
+/patternpath
+{
+	exch dup begin
+	setfont
+	ctm setmatrix
+	concat
+	slice exch /b exch slice /q get dup mul mul put
+	FontMatrix concat
+	uniform
+	{
+		width 0 dtransform round width div exch round width div exch
+		0 height dtransform round height div exch height div exch
+		0 0 transform round exch round exch
+		ptm astore setmatrix
+	}
+	{
+		ptm currentmatrix pop
+	} ifelse
+	{
+		currentpoint
+	} stopped not
+	{
+		2 npop
+		pathbbox
+		true
+		4 index 3 index eq
+		4 index 3 index eq
+		and
+		{
+			pop false
+			{
+				{
+					2 npop
+				}
+				{
+					3 npop true
+				}
+				{
+					7 npop true
+				}
+				{
+					pop true
+				} pathforall
+			} stopped
+			{
+				5 npop true
+			} if
+		} if
+		{
+			height div ceiling height mul 4 1 roll
+			width div ceiling width mul 4 1 roll
+			height div floor height mul 4 1 roll
+			width div floor width mul 4 1 roll
+			2 index sub height div ceiling cvi exch
+			3 index sub width div ceiling cvi exch
+			4 2 roll moveto
+			FontMatrix mtx invertmatrix
+			dup dup 4 get exch 5 get rmoveto
+			ptm ptm concatmatrix pop
+			slice /s
+			patterncachesize patterncachelimit div ceiling sqrt ceiling cvi
+			dup slice /q get gt
+			{
+				pop slice /q get
+			} if
+			put
+			0 1 slice /s get dup mul 1 sub
+			{
+				slice /b get add
+				gsave
+				0 1 str length 1 sub
+				{
+					str exch 2 index put
+				} for
+				pop
+				dup
+				{
+					gsave
+					ptm setmatrix
+					1 index str length idiv
+					{
+						str show
+					} repeat
+					1 index str length mod str exch 0 exch getinterval show
+					grestore
+					0 height rmoveto
+				} repeat
+				grestore
+			} for
+			2 npop
+		}
+		{
+			4 npop
+		} ifelse
+	} if
+ end
+} def
+/patternclip
+{
+	_eo {eoclip} {clip} ifelse
+} def
+/patternstrokepath
+{
+	strokepath
+} def
+/patternmatrix
+matrix def
+/patternfill
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternclip
+	Adobe_pattern_AI5 /patternpath get exec
+	grestore
+	newpath
+} def
+/patternstroke
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternstrokepath
+	true
+	{
+		{
+			{
+				newpath
+				moveto
+			}
+			{
+				lineto
+			}
+			{
+				curveto
+			}
+			{
+				closepath
+				3 copy
+				Adobe_pattern_AI5 /patternfill get exec
+			} pathforall
+			3 npop
+		} stopped
+		{
+			5 npop
+			patternclip
+			Adobe_pattern_AI5 /patternfill get exec
+		} if
+	}
+	{
+		patternclip
+		Adobe_pattern_AI5 /patternfill get exec
+	} ifelse
+	grestore
+	newpath
+} def
+/vpatternawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index 5 index 5 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	3 npop
+} def
+/hpatternawidthshow
+{
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		9 index 9 index 9 index
+		Adobe_pattern_AI5 /patternfill get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	8 npop
+} def
+/patternashow
+{
+0 0 0 6 3 roll
+patternawidthshow
+} def
+/patternawidthshow
+{
+	6 index type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get 7 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshow } { vpatternawidthshow } ifelse
+} def
+/vpatternawidthshowstroke
+{
+	7 1 roll
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			3 index setmatrix
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			4 index setmatrix
+			7 index 7 index 7 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	4 npop
+} def
+/hpatternawidthshowstroke
+{
+	7 1 roll
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		7 index setmatrix
+		10 index 10 index 10 index
+		Adobe_pattern_AI5 /patternstroke get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	9 npop
+} def
+/patternashowstroke
+{
+	0 0 0 7 3 roll
+	patternawidthshowstroke
+} def
+/patternawidthshowstroke
+{
+	7 index type /dicttype eq
+	{
+		patternmatrix /patternmatrix get 8 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshowstroke } { vpatternawidthshowstroke } ifelse
+} def
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_pattern_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginRider
+currentpacking true setpacking
+%%BeginFont: TimesNewRomanPS-BoldMT
+/TimesNewRomanPS-BoldMT
+15 dict dup begin
+/FontName /TimesNewRomanPS-BoldMT def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 1024 def
+/FontDescent -314 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+3 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K31 {
+{
+newpath
+317 692 m
+66 578 l
+75 560 l
+100 571 121 576 138 576 c
+149 576 158 573 166 568 c
+175 562 180 556 183 548 c
+186 540 188 520 188 488 c
+188 138 l
+188 95 186 68 181 56 c
+177 44 169 35 156 28 c
+144 21 123 18 94 18 c
+76 18 l
+76 0 l
+434 0 l
+434 18 l
+419 18 l
+393 18 374 22 363 29 c
+351 36 343 46 340 58 c
+336 69 334 96 334 138 c
+334 692 l
+317 692 l
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+3 dict dup begin
+/KA 797 def
+/KD 797 def
+/K31 512 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+%%BeginFont: TimesNewRomanPS-ItalicMT
+/TimesNewRomanPS-ItalicMT
+15 dict dup begin
+/FontName /TimesNewRomanPS-ItalicMT def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 1024 def
+/FontDescent -314 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+3 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K30 {
+{
+newpath
+237 646 m
+184 599 140 531 106 441 c
+77 364 62 287 62 211 c
+62 134 77 77 106 42 c
+135 6 171 -12 214 -12 c
+241 -12 264 -7 284 3 c
+318 21 351 49 382 89 c
+421 139 452 199 474 268 c
+495 336 506 404 506 470 c
+506 547 491 603 462 639 c
+433 674 397 692 355 692 c
+311 692 272 677 237 646 c
+237 646 l
+closepath
+408 640 m
+423 622 430 595 430 558 c
+430 469 408 354 364 212 c
+337 125 304 64 266 28 c
+252 15 235 8 214 8 c
+193 8 175 17 160 34 c
+145 51 138 77 138 111 c
+138 181 150 265 175 364 c
+194 439 215 501 236 549 c
+257 597 277 628 297 643 c
+316 658 336 666 355 666 c
+375 666 393 657 408 640 c
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+3 dict dup begin
+/KA 797 def
+/KD 797 def
+/K30 512 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+setpacking
+%AI3_EndRider
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _TimesNewRomanPS-BoldMT TimesNewRomanPS-BoldMT
+[/_TimesNewRomanPS-BoldMT/TimesNewRomanPS-BoldMT 0 0 0 TZ%AI3_EndEncoding TrueType%AI55J_Tsume: None
+%AI3_BeginEncoding: _TimesNewRomanPS-ItalicMT TimesNewRomanPS-ItalicMT
+[/_TimesNewRomanPS-ItalicMT/TimesNewRomanPS-ItalicMT 0 0 0 TZ%AI3_EndEncoding TrueType%AI3_BeginPattern: (shl)
+(shl) 1.05 1.0386 9.1999 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+9.1749 1.0193 m
+9.1749 13.6004 L
+1.025 13.6004 L
+1.025 1.0193 L
+9.1749 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.3871 13.5908 m
+1 13.5908 L
+1 12.902 L
+8.7285 1.0097 L
+9.1499 1.0097 L
+9.1499 1.6457 L
+1.3871 13.5908 L
+f9.1499 12.9743 m
+9.1499 13.6197 L
+8.7305 13.6197 L
+9.1499 12.9743 L
+f1 1.5733 m
+1 1 L
+1.3726 1 L
+1 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shft)
+(shft) 1 1.0386 9.1499 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.025 1.0193 m
+1.025 13.6004 L
+9.1749 13.6004 L
+9.1749 1.0193 L
+1.025 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.8128 13.5908 m
+9.1999 13.5908 L
+9.1999 12.902 L
+1.4714 1.0096 L
+1.05 1.0096 L
+1.05 1.6457 L
+8.8128 13.5908 L
+f1.05 12.9743 m
+1.05 13.6197 L
+1.4694 13.6197 L
+1.05 12.9743 L
+f9.1999 1.5733 m
+9.1999 1 L
+8.8273 1 L
+9.1999 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+(shft) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shft) Pc
+(shl) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shl) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+q1 Ap
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+386 68 m
+386 415 L
+35 415 L
+35 68 L
+386 68 L
+hWnuu0 O
+(shl) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+279.0128 248.4449 m
+279.0128 314 L
+215 314 L
+215 248.4449 L
+279.0128 248.4449 L
+f132.0064 246.2224 m
+132.0064 311.7775 L
+67.9936 311.7775 L
+67.9936 246.2224 L
+132.0064 246.2224 L
+f134.0064 102.2224 m
+134.0064 167.7775 L
+69.9936 167.7775 L
+69.9936 102.2224 L
+134.0064 102.2224 L
+f280.0064 99.2224 m
+280.0064 164.7775 L
+215.9936 164.7775 L
+215.9936 99.2224 L
+280.0064 99.2224 L
+fUuq0 Ap
+300 Ar
+-8.3622 458.8199 m
+-8.3622 24.9449 l
+425.5128 24.9449 l
+425.5128 458.8199 l
+HWNq-8.3622 24.9449 m
+-8.3622 458.8199 l
+425.5128 458.8199 l
+425.5128 24.9449 l
+-8.3622 24.9449 l
+HWN0 O
+0.2274 0.1608 0.1294 0.0196 k
+-7.4872 386.4449 m
+-7.4872 385.4449 l
+424.5128 385.4449 l
+424.5128 386.4449 l
+-7.4872 386.4449 l
+F352.0128 25.9449 m
+353.0128 25.9449 l
+353.0128 457.9449 l
+352.0128 457.9449 l
+352.0128 25.9449 l
+F-7.4872 314.4449 m
+-7.4872 313.4449 l
+424.5128 313.4449 l
+424.5128 314.4449 l
+-7.4872 314.4449 l
+F-7.4872 242.1949 m
+-7.4872 241.1949 l
+424.5128 241.1949 l
+424.5128 242.1949 l
+-7.4872 242.1949 l
+F-7.4872 170.4449 m
+-7.4872 169.4449 l
+424.5128 169.4449 l
+424.5128 170.4449 l
+-7.4872 170.4449 l
+F-7.4872 98.4449 m
+-7.4872 97.4449 l
+424.5128 97.4449 l
+424.5128 98.4449 l
+-7.4872 98.4449 l
+F64.0128 25.9449 m
+65.0128 25.9449 l
+65.0128 457.9449 l
+64.0128 457.9449 l
+64.0128 25.9449 l
+F136.0128 25.9449 m
+137.0128 25.9449 l
+137.0128 457.9449 l
+136.0128 457.9449 l
+136.0128 25.9449 l
+F208.0128 25.9449 m
+209.0128 25.9449 l
+209.0128 457.9449 l
+208.0128 457.9449 l
+208.0128 25.9449 l
+F280.0128 25.9449 m
+281.0128 25.9449 l
+281.0128 457.9449 l
+280.0128 457.9449 l
+280.0128 25.9449 l
+F0 R
+0 0 0 1 K
+4 w 10 M134.2628 167.6949 m
+134.2628 316.1949 l
+282.7628 316.1949 l
+282.7628 167.6949 l
+134.2628 167.6949 l
+134.2628 167.6949 l
+s0 O
+0 0 0 1 k
+1 w 4 M215.0128 386.4449 m
+213.0128 386.4449 l
+213.0128 378.4449 l
+215.0128 378.4449 l
+215.0128 386.4449 l
+F215.0128 372.4449 m
+213.0128 372.4449 l
+213.0128 364.4449 l
+215.0128 364.4449 l
+215.0128 372.4449 l
+F215.0128 358.4449 m
+213.0128 358.4449 l
+213.0128 350.4449 l
+215.0128 350.4449 l
+215.0128 358.4449 l
+F215.0128 344.4449 m
+213.0128 344.4449 l
+213.0128 336.4449 l
+215.0128 336.4449 l
+215.0128 344.4449 l
+F215.0128 330.4449 m
+213.0128 330.4449 l
+213.0128 322.4449 l
+215.0128 322.4449 l
+215.0128 330.4449 l
+F215.0128 316.4449 m
+213.0128 316.4449 l
+213.0128 308.4449 l
+215.0128 308.4449 l
+215.0128 316.4449 l
+F215.0128 302.4449 m
+213.0128 302.4449 l
+213.0128 294.4449 l
+215.0128 294.4449 l
+215.0128 302.4449 l
+F215.0128 288.4449 m
+213.0128 288.4449 l
+213.0128 280.4449 l
+215.0128 280.4449 l
+215.0128 288.4449 l
+F215.0128 274.4449 m
+213.0128 274.4449 l
+213.0128 266.4449 l
+215.0128 266.4449 l
+215.0128 274.4449 l
+F215.0128 260.4449 m
+213.0128 260.4449 l
+213.0128 252.4449 l
+215.0128 252.4449 l
+215.0128 260.4449 l
+F215.0128 248.4449 m
+215.0128 246.4449 l
+223.0128 246.4449 l
+223.0128 248.4449 l
+215.0128 248.4449 l
+F229.0128 248.4449 m
+229.0128 246.4449 l
+237.0128 246.4449 l
+237.0128 248.4449 l
+229.0128 248.4449 l
+F243.0128 248.4449 m
+243.0128 246.4449 l
+251.0128 246.4449 l
+251.0128 248.4449 l
+243.0128 248.4449 l
+F257.0128 248.4449 m
+257.0128 246.4449 l
+265.0128 246.4449 l
+265.0128 248.4449 l
+257.0128 248.4449 l
+F271.0128 248.4449 m
+271.0128 246.4449 l
+279.0128 246.4449 l
+279.0128 248.4449 l
+271.0128 248.4449 l
+F285.0128 248.4449 m
+285.0128 246.4449 l
+293.0128 246.4449 l
+293.0128 248.4449 l
+285.0128 248.4449 l
+F299.0128 248.4449 m
+299.0128 246.4449 l
+307.0128 246.4449 l
+307.0128 248.4449 l
+299.0128 248.4449 l
+F313.0128 248.4449 m
+313.0128 246.4449 l
+321.0128 246.4449 l
+321.0128 248.4449 l
+313.0128 248.4449 l
+F327.0128 248.4449 m
+327.0128 246.4449 l
+335.0128 246.4449 l
+335.0128 248.4449 l
+327.0128 248.4449 l
+F341.0128 248.4449 m
+341.0128 246.4449 l
+349.0128 246.4449 l
+349.0128 248.4449 l
+341.0128 248.4449 l
+F352.0128 249.4449 m
+354.0128 249.4449 l
+354.0128 257.4449 l
+352.0128 257.4449 l
+352.0128 249.4449 l
+F352.0128 263.4449 m
+354.0128 263.4449 l
+354.0128 271.4449 l
+352.0128 271.4449 l
+352.0128 263.4449 l
+F352.0128 277.4449 m
+354.0128 277.4449 l
+354.0128 285.4449 l
+352.0128 285.4449 l
+352.0128 277.4449 l
+F352.0128 291.4449 m
+354.0128 291.4449 l
+354.0128 299.4449 l
+352.0128 299.4449 l
+352.0128 291.4449 l
+F352.0128 305.4449 m
+354.0128 305.4449 l
+354.0128 313.4449 l
+352.0128 313.4449 l
+352.0128 305.4449 l
+F352.0128 319.4449 m
+354.0128 319.4449 l
+354.0128 327.4449 l
+352.0128 327.4449 l
+352.0128 319.4449 l
+F352.0128 333.4449 m
+354.0128 333.4449 l
+354.0128 341.4449 l
+352.0128 341.4449 l
+352.0128 333.4449 l
+F352.0128 347.4449 m
+354.0128 347.4449 l
+354.0128 355.4449 l
+352.0128 355.4449 l
+352.0128 347.4449 l
+F352.0128 361.4449 m
+354.0128 361.4449 l
+354.0128 369.4449 l
+352.0128 369.4449 l
+352.0128 361.4449 l
+F352.0128 375.4449 m
+354.0128 375.4449 l
+354.0128 383.4449 l
+352.0128 383.4449 l
+352.0128 375.4449 l
+F350.0128 385.4449 m
+350.0128 387.4449 l
+342.0128 387.4449 l
+342.0128 385.4449 l
+350.0128 385.4449 l
+F336.0128 385.4449 m
+336.0128 387.4449 l
+328.0128 387.4449 l
+328.0128 385.4449 l
+336.0128 385.4449 l
+F322.0128 385.4449 m
+322.0128 387.4449 l
+314.0128 387.4449 l
+314.0128 385.4449 l
+322.0128 385.4449 l
+F308.0128 385.4449 m
+308.0128 387.4449 l
+300.0128 387.4449 l
+300.0128 385.4449 l
+308.0128 385.4449 l
+F294.0128 385.4449 m
+294.0128 387.4449 l
+286.0128 387.4449 l
+286.0128 385.4449 l
+294.0128 385.4449 l
+F280.0128 385.4449 m
+280.0128 387.4449 l
+272.0128 387.4449 l
+272.0128 385.4449 l
+280.0128 385.4449 l
+F266.0128 385.4449 m
+266.0128 387.4449 l
+258.0128 387.4449 l
+258.0128 385.4449 l
+266.0128 385.4449 l
+F252.0128 385.4449 m
+252.0128 387.4449 l
+244.0128 387.4449 l
+244.0128 385.4449 l
+252.0128 385.4449 l
+F238.0128 385.4449 m
+238.0128 387.4449 l
+230.0128 387.4449 l
+230.0128 385.4449 l
+238.0128 385.4449 l
+F224.0128 385.4449 m
+224.0128 387.4449 l
+216.0128 387.4449 l
+216.0128 385.4449 l
+224.0128 385.4449 l
+F67.3878 235.5699 m
+71.8878 235.5699 l
+71.8878 237.5699 l
+66.3878 237.5699 l
+65.3878 237.5699 l
+65.3878 236.5699 l
+65.3878 228.5699 l
+67.3878 228.5699 l
+67.3878 235.5699 l
+F67.3878 222.5699 m
+65.3878 222.5699 l
+65.3878 214.5699 l
+67.3878 214.5699 l
+67.3878 222.5699 l
+F67.3878 208.5699 m
+65.3878 208.5699 l
+65.3878 200.5699 l
+67.3878 200.5699 l
+67.3878 208.5699 l
+F67.3878 194.5699 m
+65.3878 194.5699 l
+65.3878 186.5699 l
+67.3878 186.5699 l
+67.3878 194.5699 l
+F67.3878 180.5699 m
+65.3878 180.5699 l
+65.3878 172.5699 l
+67.3878 172.5699 l
+67.3878 180.5699 l
+F67.3878 166.5699 m
+65.3878 166.5699 l
+65.3878 158.5699 l
+67.3878 158.5699 l
+67.3878 166.5699 l
+F67.3878 152.5699 m
+65.3878 152.5699 l
+65.3878 144.5699 l
+67.3878 144.5699 l
+67.3878 152.5699 l
+F67.3878 138.5699 m
+65.3878 138.5699 l
+65.3878 130.5699 l
+67.3878 130.5699 l
+67.3878 138.5699 l
+F67.3878 124.5699 m
+65.3878 124.5699 l
+65.3878 116.5699 l
+67.3878 116.5699 l
+67.3878 124.5699 l
+F67.3878 110.5699 m
+65.3878 110.5699 l
+65.3878 102.5699 l
+67.3878 102.5699 l
+67.3878 110.5699 l
+F68.5128 99.6949 m
+68.5128 97.6949 l
+76.5128 97.6949 l
+76.5128 99.6949 l
+68.5128 99.6949 l
+F82.5128 99.6949 m
+82.5128 97.6949 l
+90.5128 97.6949 l
+90.5128 99.6949 l
+82.5128 99.6949 l
+F96.5128 99.6949 m
+96.5128 97.6949 l
+104.5128 97.6949 l
+104.5128 99.6949 l
+96.5128 99.6949 l
+F110.5128 99.6949 m
+110.5128 97.6949 l
+118.5128 97.6949 l
+118.5128 99.6949 l
+110.5128 99.6949 l
+F124.5128 99.6949 m
+124.5128 97.6949 l
+132.5128 97.6949 l
+132.5128 99.6949 l
+124.5128 99.6949 l
+F138.5128 99.6949 m
+138.5128 97.6949 l
+146.5128 97.6949 l
+146.5128 99.6949 l
+138.5128 99.6949 l
+F152.5128 99.6949 m
+152.5128 97.6949 l
+160.5128 97.6949 l
+160.5128 99.6949 l
+152.5128 99.6949 l
+F166.5128 99.6949 m
+166.5128 97.6949 l
+174.5128 97.6949 l
+174.5128 99.6949 l
+166.5128 99.6949 l
+F180.5128 99.6949 m
+180.5128 97.6949 l
+188.5128 97.6949 l
+188.5128 99.6949 l
+180.5128 99.6949 l
+F194.5128 99.6949 m
+194.5128 97.6949 l
+202.5128 97.6949 l
+202.5128 99.6949 l
+194.5128 99.6949 l
+F203.2628 102.9449 m
+205.2628 102.9449 l
+205.2628 110.9449 l
+203.2628 110.9449 l
+203.2628 102.9449 l
+F203.2628 116.9449 m
+205.2628 116.9449 l
+205.2628 124.9449 l
+203.2628 124.9449 l
+203.2628 116.9449 l
+F203.2628 130.9449 m
+205.2628 130.9449 l
+205.2628 138.9449 l
+203.2628 138.9449 l
+203.2628 130.9449 l
+F203.2628 144.9449 m
+205.2628 144.9449 l
+205.2628 152.9449 l
+203.2628 152.9449 l
+203.2628 144.9449 l
+F203.2628 158.9449 m
+205.2628 158.9449 l
+205.2628 166.9449 l
+203.2628 166.9449 l
+203.2628 158.9449 l
+F203.2628 172.9449 m
+205.2628 172.9449 l
+205.2628 180.9449 l
+203.2628 180.9449 l
+203.2628 172.9449 l
+F203.2628 186.9449 m
+205.2628 186.9449 l
+205.2628 194.9449 l
+203.2628 194.9449 l
+203.2628 186.9449 l
+F203.2628 200.9449 m
+205.2628 200.9449 l
+205.2628 208.9449 l
+203.2628 208.9449 l
+203.2628 200.9449 l
+F203.2628 214.9449 m
+205.2628 214.9449 l
+205.2628 222.9449 l
+203.2628 222.9449 l
+203.2628 214.9449 l
+F203.2628 228.9449 m
+205.2628 228.9449 l
+205.2628 236.5699 l
+205.2628 237.5699 l
+204.2628 237.5699 l
+203.8878 237.5699 l
+203.8878 236.5699 l
+203.2628 236.5699 l
+203.2628 228.9449 l
+F197.8878 235.5699 m
+197.8878 237.5699 l
+189.8878 237.5699 l
+189.8878 235.5699 l
+197.8878 235.5699 l
+F183.8878 235.5699 m
+183.8878 237.5699 l
+175.8878 237.5699 l
+175.8878 235.5699 l
+183.8878 235.5699 l
+F169.8878 235.5699 m
+169.8878 237.5699 l
+161.8878 237.5699 l
+161.8878 235.5699 l
+169.8878 235.5699 l
+F155.8878 235.5699 m
+155.8878 237.5699 l
+147.8878 237.5699 l
+147.8878 235.5699 l
+155.8878 235.5699 l
+F141.8878 235.5699 m
+141.8878 237.5699 l
+133.8878 237.5699 l
+133.8878 235.5699 l
+141.8878 235.5699 l
+F127.8878 235.5699 m
+127.8878 237.5699 l
+119.8878 237.5699 l
+119.8878 235.5699 l
+127.8878 235.5699 l
+F113.8878 235.5699 m
+113.8878 237.5699 l
+105.8878 237.5699 l
+105.8878 235.5699 l
+113.8878 235.5699 l
+F99.8878 235.5699 m
+99.8878 237.5699 l
+91.8878 237.5699 l
+91.8878 235.5699 l
+99.8878 235.5699 l
+F85.8878 235.5699 m
+85.8878 237.5699 l
+77.8878 237.5699 l
+77.8878 235.5699 l
+85.8878 235.5699 l
+F215.0128 237.6949 m
+213.0128 237.6949 l
+213.0128 229.6949 l
+215.0128 229.6949 l
+215.0128 237.6949 l
+F215.0128 223.6949 m
+213.0128 223.6949 l
+213.0128 215.6949 l
+215.0128 215.6949 l
+215.0128 223.6949 l
+F215.0128 209.6949 m
+213.0128 209.6949 l
+213.0128 201.6949 l
+215.0128 201.6949 l
+215.0128 209.6949 l
+F215.0128 195.6949 m
+213.0128 195.6949 l
+213.0128 187.6949 l
+215.0128 187.6949 l
+215.0128 195.6949 l
+F215.0128 181.6949 m
+213.0128 181.6949 l
+213.0128 173.6949 l
+215.0128 173.6949 l
+215.0128 181.6949 l
+F215.0128 167.6949 m
+213.0128 167.6949 l
+213.0128 159.6949 l
+215.0128 159.6949 l
+215.0128 167.6949 l
+F215.0128 153.6949 m
+213.0128 153.6949 l
+213.0128 145.6949 l
+215.0128 145.6949 l
+215.0128 153.6949 l
+F215.0128 139.6949 m
+213.0128 139.6949 l
+213.0128 131.6949 l
+215.0128 131.6949 l
+215.0128 139.6949 l
+F215.0128 125.6949 m
+213.0128 125.6949 l
+213.0128 117.6949 l
+215.0128 117.6949 l
+215.0128 125.6949 l
+F215.0128 111.6949 m
+213.0128 111.6949 l
+213.0128 103.6949 l
+215.0128 103.6949 l
+215.0128 111.6949 l
+F215.0128 99.6949 m
+215.0128 97.6949 l
+223.0128 97.6949 l
+223.0128 99.6949 l
+215.0128 99.6949 l
+F229.0128 99.6949 m
+229.0128 97.6949 l
+237.0128 97.6949 l
+237.0128 99.6949 l
+229.0128 99.6949 l
+F243.0128 99.6949 m
+243.0128 97.6949 l
+251.0128 97.6949 l
+251.0128 99.6949 l
+243.0128 99.6949 l
+F257.0128 99.6949 m
+257.0128 97.6949 l
+265.0128 97.6949 l
+265.0128 99.6949 l
+257.0128 99.6949 l
+F271.0128 99.6949 m
+271.0128 97.6949 l
+279.0128 97.6949 l
+279.0128 99.6949 l
+271.0128 99.6949 l
+F285.0128 99.6949 m
+285.0128 97.6949 l
+293.0128 97.6949 l
+293.0128 99.6949 l
+285.0128 99.6949 l
+F299.0128 99.6949 m
+299.0128 97.6949 l
+307.0128 97.6949 l
+307.0128 99.6949 l
+299.0128 99.6949 l
+F313.0128 99.6949 m
+313.0128 97.6949 l
+321.0128 97.6949 l
+321.0128 99.6949 l
+313.0128 99.6949 l
+F327.0128 99.6949 m
+327.0128 97.6949 l
+335.0128 97.6949 l
+335.0128 99.6949 l
+327.0128 99.6949 l
+F341.0128 99.6949 m
+341.0128 97.6949 l
+349.0128 97.6949 l
+349.0128 99.6949 l
+341.0128 99.6949 l
+F352.0128 100.6949 m
+354.0128 100.6949 l
+354.0128 108.6949 l
+352.0128 108.6949 l
+352.0128 100.6949 l
+F352.0128 114.6949 m
+354.0128 114.6949 l
+354.0128 122.6949 l
+352.0128 122.6949 l
+352.0128 114.6949 l
+F352.0128 128.6949 m
+354.0128 128.6949 l
+354.0128 136.6949 l
+352.0128 136.6949 l
+352.0128 128.6949 l
+F352.0128 142.6949 m
+354.0128 142.6949 l
+354.0128 150.6949 l
+352.0128 150.6949 l
+352.0128 142.6949 l
+F352.0128 156.6949 m
+354.0128 156.6949 l
+354.0128 164.6949 l
+352.0128 164.6949 l
+352.0128 156.6949 l
+F352.0128 170.6949 m
+354.0128 170.6949 l
+354.0128 178.6949 l
+352.0128 178.6949 l
+352.0128 170.6949 l
+F352.0128 184.6949 m
+354.0128 184.6949 l
+354.0128 192.6949 l
+352.0128 192.6949 l
+352.0128 184.6949 l
+F352.0128 198.6949 m
+354.0128 198.6949 l
+354.0128 206.6949 l
+352.0128 206.6949 l
+352.0128 198.6949 l
+F352.0128 212.6949 m
+354.0128 212.6949 l
+354.0128 220.6949 l
+352.0128 220.6949 l
+352.0128 212.6949 l
+F352.0128 226.6949 m
+354.0128 226.6949 l
+354.0128 234.6949 l
+352.0128 234.6949 l
+352.0128 226.6949 l
+F350.0128 236.6949 m
+350.0128 238.6949 l
+342.0128 238.6949 l
+342.0128 236.6949 l
+350.0128 236.6949 l
+F336.0128 236.6949 m
+336.0128 238.6949 l
+328.0128 238.6949 l
+328.0128 236.6949 l
+336.0128 236.6949 l
+F322.0128 236.6949 m
+322.0128 238.6949 l
+314.0128 238.6949 l
+314.0128 236.6949 l
+322.0128 236.6949 l
+F308.0128 236.6949 m
+308.0128 238.6949 l
+300.0128 238.6949 l
+300.0128 236.6949 l
+308.0128 236.6949 l
+F294.0128 236.6949 m
+294.0128 238.6949 l
+286.0128 238.6949 l
+286.0128 236.6949 l
+294.0128 236.6949 l
+F280.0128 236.6949 m
+280.0128 238.6949 l
+272.0128 238.6949 l
+272.0128 236.6949 l
+280.0128 236.6949 l
+F266.0128 236.6949 m
+266.0128 238.6949 l
+258.0128 238.6949 l
+258.0128 236.6949 l
+266.0128 236.6949 l
+F252.0128 236.6949 m
+252.0128 238.6949 l
+244.0128 238.6949 l
+244.0128 236.6949 l
+252.0128 236.6949 l
+F238.0128 236.6949 m
+238.0128 238.6949 l
+230.0128 238.6949 l
+230.0128 236.6949 l
+238.0128 236.6949 l
+F224.0128 236.6949 m
+224.0128 238.6949 l
+216.0128 238.6949 l
+216.0128 236.6949 l
+224.0128 236.6949 l
+F67.3878 386.4449 m
+65.3878 386.4449 l
+65.3878 378.4449 l
+67.3878 378.4449 l
+67.3878 386.4449 l
+F67.3878 372.4449 m
+65.3878 372.4449 l
+65.3878 364.4449 l
+67.3878 364.4449 l
+67.3878 372.4449 l
+F67.3878 358.4449 m
+65.3878 358.4449 l
+65.3878 350.4449 l
+67.3878 350.4449 l
+67.3878 358.4449 l
+F67.3878 344.4449 m
+65.3878 344.4449 l
+65.3878 336.4449 l
+67.3878 336.4449 l
+67.3878 344.4449 l
+F67.3878 330.4449 m
+65.3878 330.4449 l
+65.3878 322.4449 l
+67.3878 322.4449 l
+67.3878 330.4449 l
+F67.3878 316.4449 m
+65.3878 316.4449 l
+65.3878 308.4449 l
+67.3878 308.4449 l
+67.3878 316.4449 l
+F67.3878 302.4449 m
+65.3878 302.4449 l
+65.3878 294.4449 l
+67.3878 294.4449 l
+67.3878 302.4449 l
+F67.3878 288.4449 m
+65.3878 288.4449 l
+65.3878 280.4449 l
+67.3878 280.4449 l
+67.3878 288.4449 l
+F67.3878 274.4449 m
+65.3878 274.4449 l
+65.3878 266.4449 l
+67.3878 266.4449 l
+67.3878 274.4449 l
+F67.3878 260.4449 m
+65.3878 260.4449 l
+65.3878 252.4449 l
+67.3878 252.4449 l
+67.3878 260.4449 l
+F67.3878 248.4449 m
+67.3878 246.4449 l
+75.3878 246.4449 l
+75.3878 248.4449 l
+67.3878 248.4449 l
+F81.3878 248.4449 m
+81.3878 246.4449 l
+89.3878 246.4449 l
+89.3878 248.4449 l
+81.3878 248.4449 l
+F95.3878 248.4449 m
+95.3878 246.4449 l
+103.3878 246.4449 l
+103.3878 248.4449 l
+95.3878 248.4449 l
+F109.3878 248.4449 m
+109.3878 246.4449 l
+117.3878 246.4449 l
+117.3878 248.4449 l
+109.3878 248.4449 l
+F123.3878 248.4449 m
+123.3878 246.4449 l
+131.3878 246.4449 l
+131.3878 248.4449 l
+123.3878 248.4449 l
+F137.3878 248.4449 m
+137.3878 246.4449 l
+145.3878 246.4449 l
+145.3878 248.4449 l
+137.3878 248.4449 l
+F151.3878 248.4449 m
+151.3878 246.4449 l
+159.3878 246.4449 l
+159.3878 248.4449 l
+151.3878 248.4449 l
+F165.3878 248.4449 m
+165.3878 246.4449 l
+173.3878 246.4449 l
+173.3878 248.4449 l
+165.3878 248.4449 l
+F179.3878 248.4449 m
+179.3878 246.4449 l
+187.3878 246.4449 l
+187.3878 248.4449 l
+179.3878 248.4449 l
+F193.3878 248.4449 m
+193.3878 246.4449 l
+201.3878 246.4449 l
+201.3878 248.4449 l
+193.3878 248.4449 l
+F204.3878 249.4449 m
+206.3878 249.4449 l
+206.3878 257.4449 l
+204.3878 257.4449 l
+204.3878 249.4449 l
+F204.3878 263.4449 m
+206.3878 263.4449 l
+206.3878 271.4449 l
+204.3878 271.4449 l
+204.3878 263.4449 l
+F204.3878 277.4449 m
+206.3878 277.4449 l
+206.3878 285.4449 l
+204.3878 285.4449 l
+204.3878 277.4449 l
+F204.3878 291.4449 m
+206.3878 291.4449 l
+206.3878 299.4449 l
+204.3878 299.4449 l
+204.3878 291.4449 l
+F204.3878 305.4449 m
+206.3878 305.4449 l
+206.3878 313.4449 l
+204.3878 313.4449 l
+204.3878 305.4449 l
+F204.3878 319.4449 m
+206.3878 319.4449 l
+206.3878 327.4449 l
+204.3878 327.4449 l
+204.3878 319.4449 l
+F204.3878 333.4449 m
+206.3878 333.4449 l
+206.3878 341.4449 l
+204.3878 341.4449 l
+204.3878 333.4449 l
+F204.3878 347.4449 m
+206.3878 347.4449 l
+206.3878 355.4449 l
+204.3878 355.4449 l
+204.3878 347.4449 l
+F204.3878 361.4449 m
+206.3878 361.4449 l
+206.3878 369.4449 l
+204.3878 369.4449 l
+204.3878 361.4449 l
+F204.3878 375.4449 m
+206.3878 375.4449 l
+206.3878 383.4449 l
+204.3878 383.4449 l
+204.3878 375.4449 l
+F202.3878 385.4449 m
+202.3878 387.4449 l
+194.3878 387.4449 l
+194.3878 385.4449 l
+202.3878 385.4449 l
+F188.3878 385.4449 m
+188.3878 387.4449 l
+180.3878 387.4449 l
+180.3878 385.4449 l
+188.3878 385.4449 l
+F174.3878 385.4449 m
+174.3878 387.4449 l
+166.3878 387.4449 l
+166.3878 385.4449 l
+174.3878 385.4449 l
+F160.3878 385.4449 m
+160.3878 387.4449 l
+152.3878 387.4449 l
+152.3878 385.4449 l
+160.3878 385.4449 l
+F146.3878 385.4449 m
+146.3878 387.4449 l
+138.3878 387.4449 l
+138.3878 385.4449 l
+146.3878 385.4449 l
+F132.3878 385.4449 m
+132.3878 387.4449 l
+124.3878 387.4449 l
+124.3878 385.4449 l
+132.3878 385.4449 l
+F118.3878 385.4449 m
+118.3878 387.4449 l
+110.3878 387.4449 l
+110.3878 385.4449 l
+118.3878 385.4449 l
+F104.3878 385.4449 m
+104.3878 387.4449 l
+96.3878 387.4449 l
+96.3878 385.4449 l
+104.3878 385.4449 l
+F90.3878 385.4449 m
+90.3878 387.4449 l
+82.3878 387.4449 l
+82.3878 385.4449 l
+90.3878 385.4449 l
+F76.3878 385.4449 m
+76.3878 387.4449 l
+68.3878 387.4449 l
+68.3878 385.4449 l
+76.3878 385.4449 l
+FQQU0 A
+0 To
+1 0 0 1 154 186 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+%_ 0 50 XQ
+/_TimesNewRomanPS-ItalicMT 53 53 -16.2519 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+1 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 XbXB0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(0) Tx 1 0 Tk
+(\r) TX 
+TO
+u1 Ap
+0 0 0 0 k
+259 257.5 m
+259 300.5 L
+233 300.5 L
+233 257.5 L
+259 257.5 L
+f0 To
+1 0 0 1 234 260.5 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 1 k
+/_TimesNewRomanPS-BoldMT 53 53 -16.2519 Tf
+(1) Tx 1 0 Tk
+(\r) TX 
+TO
+UUQLB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_pattern_AI5 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/pegacyc.eps
+++ b/Papers/quant-ph_0405174/pegacyc.eps
@@ -1,0 +1,8783 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (pegacyc.eps)
+%%CreationDate: (12/29/2003) (2:49 PM)
+%%BoundingBox: -19 22 684 776
+%%HiResBoundingBox: -18.8544 22.4377 683.3337 775.8089
+%%DocumentProcessColors: Cyan Yellow Black
+%%DocumentFonts: TimesNewRomanPS-ItalicMT
+%%DocumentSuppliedFonts: TimesNewRomanPS-ItalicMT
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_typography_AI5 1.0 1
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_pattern_AI5 1.0 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Color
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -666 1188 -1.5 1384 924 26 0 0 8 88 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginResource: procset Adobe_typography_AI5 1.0 1
+%%Title: (Typography Operators)
+%%Version: 1.0 1
+%%CreationDate:(6/10/1996) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_pattern_AI5 1.1 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Pattern Operators)
+%%Version: 1.1 0
+%%CreationDate: (03/26/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/@
+{
+} def
+/&
+{
+} def
+/dp
+{
+	dup null eq
+	{
+		pop
+		_dp 0 ne
+		{
+			0 1 _dp 1 sub _dl mod
+			{
+				_da exch get 3 get
+			} for
+			_dp 1 sub _dl mod 1 add packedarray
+			_da 0 get aload pop 8 -1 roll 5 -1 roll pop 4 1 roll
+			definepattern pop
+		} if
+	}
+	{
+		_dp 0 ne _dp _dl mod 0 eq and
+		{
+			null dp
+		} if
+		7 packedarray _da exch _dp _dl mod exch put
+		_dp _dl mod _da 0 get 4 get 2 packedarray
+		/_dp _dp 1 add def
+	} ifelse
+} def
+/E
+{
+	_ed begin
+	dup 0 get type /arraytype ne
+	{
+		0
+		{
+			dup 1 add index type /arraytype eq
+			{
+				1 add
+			}
+			{
+				exit
+			} ifelse
+		} loop
+		array astore
+	} if
+	/_dd exch def
+	/_ury exch def
+	/_urx exch def
+	/_lly exch def
+	/_llx exch def
+	/_n exch def
+	/_y 0 def
+	/_dl 4 def
+	/_dp 0 def
+	/_da _dl array def
+	0 1 _dd length 1 sub
+	{
+		/_d exch _dd exch get def
+		0 2 _d length 2 sub
+		{
+			/_x exch def
+			/_c _d _x get _ ne def
+			/_r _d _x 1 add get cvlit def
+			_r _ ne
+			{
+				_urx _llx sub _ury _lly sub
+				[
+				1 0 0 1 0 0
+				]
+				[
+				/save cvx
+				_llx neg _lly neg /translate cvx
+				_c
+				{
+					nc /begin cvx
+				} if
+				_r dup type /stringtype eq
+				{
+					cvx
+				}
+				{
+					{
+						exec
+					} /forall cvx
+				} ifelse
+				_c
+				{
+					/end cvx
+				} if
+				/restore cvx
+				] cvx
+				/_fn 12 _n length add string def
+				_y _fn cvs pop
+				/_y _y 1 add def
+				_fn 12 _n putinterval
+				_fn _c false dp
+				_d exch _x 1 add exch put
+			} if
+		} for
+	} for
+	null dp
+	_n _dd /_pd
+ end
+	xput
+} def
+/fc
+{
+	_fm dup concatmatrix pop
+} def
+/p
+{
+	/_fm exch ddef
+	9 -2 roll _pm translate fc
+	7 -2 roll _pm scale fc
+	5 -1 roll _pm rotate fc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate fc
+		1 -1 _pm scale fc
+		neg _pm rotate fc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate fc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore fc
+	neg _pm rotate fc
+	_pd exch get /_fdd exch ddef
+	/_pf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					patternfill
+				}
+				{
+					pop
+					fill
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_psf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					9 copy 6 npop patternashow
+				}
+				{
+					pop
+					6 copy 3 npop hvashow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		sw rmoveto
+	} ddef
+	/_pjsf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					12 copy 6 npop patternawidthshow
+				}
+				{
+					pop 9 copy 3 npop hvawidthshow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+/sc
+{
+	_sm dup concatmatrix pop
+} def
+/P
+{
+	/_sm exch ddef
+	9 -2 roll _pm translate sc
+	7 -2 roll _pm scale sc
+	5 -1 roll _pm rotate sc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate sc
+		1 -1 _pm scale sc
+		neg _pm rotate sc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate sc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore sc
+	neg _pm rotate sc
+	_pd exch get /_sdd exch ddef
+	/_ps
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					patternstroke
+				}
+				{
+					pop stroke
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_pss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					10 copy 6 npop patternashowstroke
+				}
+				{
+					pop 7 copy 3 npop ss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop sw rmoveto
+	} ddef
+	/_pjss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					13 copy 6 npop patternawidthshowstroke
+				}
+				{
+					pop 10 copy 3 npop jss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+end
+userdict /Adobe_pattern_AI5 18 dict dup begin
+put
+/initialize
+{
+	/definepattern where
+	{
+		pop
+	}
+	{
+	 begin
+	 begin
+		Adobe_pattern_AI5 begin
+		Adobe_pattern_AI5
+		{
+			dup xcheck
+			{
+				bind
+			} if
+			pop pop
+		} forall
+		mark
+		cachestatus 7 1 roll pop pop pop pop exch pop exch
+		{
+			{
+				10000 add
+				dup 2 index gt
+				{
+					exit
+				} if
+				dup setcachelimit
+			} loop
+		} stopped
+		cleartomark
+	 end 	
+		
+	 end
+	 end
+		
+		Adobe_pattern_AI5 begin
+	} ifelse
+} def
+/terminate
+{
+	currentdict Adobe_pattern_AI5 eq
+	{
+	 end
+	} if
+} def
+errordict
+/nocurrentpoint
+{
+	pop
+	stop
+} put
+errordict
+/invalidaccess
+{
+	pop
+	stop
+} put
+/patternencoding
+256 array def
+0 1 255
+{
+	patternencoding exch ( ) 2 copy exch 0 exch put cvn put
+} for
+/definepattern
+{
+	17 dict begin
+	/uniform exch def
+	/cache exch def
+	/key exch def
+	/procarray exch def
+	/mtx exch matrix invertmatrix def
+	/height exch def
+	/width exch def
+	/ctm matrix currentmatrix def
+	/ptm matrix def
+	/str 32 string def
+	/slice 9 dict def
+	slice /s 1 put
+	slice /q 256 procarray length div sqrt floor cvi put
+	slice /b 0 put
+	/FontBBox
+	[
+	0 0 0 0
+	] def
+	/FontMatrix mtx matrix copy def
+	/Encoding patternencoding def
+	/FontType 3 def
+	/BuildChar
+	{
+		exch
+	 begin
+		/setstrokeadjust where {pop true setstrokeadjust} if
+		slice begin
+		dup q dup mul mod s idiv /i exch def
+		dup q dup mul mod s mod /j exch def
+		q dup mul idiv procarray exch get
+		/xl j width s div mul def
+		/xg j 1 add width s div mul def
+		/yl i height s div mul def
+		/yg i 1 add height s div mul def
+		uniform
+		{
+			1 1
+		}
+		{
+			width 0 dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+			0 height dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+		} ifelse
+		width 0 cache
+		{
+			xl 4 index mul yl 4 index mul xg 6 index mul yg 6 index mul
+			setcachedevice
+		}
+		{
+			setcharwidth
+		} ifelse
+		gsave
+		scale
+		newpath
+		xl yl moveto
+		xg yl lineto
+		xg yg lineto
+		xl yg lineto
+		closepath
+		clip
+		newpath
+	 end
+	 end
+		exec
+		grestore
+	} def
+	key currentdict definefont
+ end
+} def
+/patterncachesize
+{
+	gsave
+	newpath
+	0 0 moveto
+	width 0 lineto
+	width height lineto
+	0 height lineto
+	closepath
+	patternmatrix setmatrix
+	pathbbox
+	exch ceiling 4 -1 roll floor sub 3 1 roll
+	ceiling exch floor sub
+	mul 1 add
+	grestore
+} def
+/patterncachelimit
+{
+	cachestatus 7 1 roll 6 npop 8 mul
+} def
+/patternpath
+{
+	exch dup begin
+	setfont
+	ctm setmatrix
+	concat
+	slice exch /b exch slice /q get dup mul mul put
+	FontMatrix concat
+	uniform
+	{
+		width 0 dtransform round width div exch round width div exch
+		0 height dtransform round height div exch height div exch
+		0 0 transform round exch round exch
+		ptm astore setmatrix
+	}
+	{
+		ptm currentmatrix pop
+	} ifelse
+	{
+		currentpoint
+	} stopped not
+	{
+		2 npop
+		pathbbox
+		true
+		4 index 3 index eq
+		4 index 3 index eq
+		and
+		{
+			pop false
+			{
+				{
+					2 npop
+				}
+				{
+					3 npop true
+				}
+				{
+					7 npop true
+				}
+				{
+					pop true
+				} pathforall
+			} stopped
+			{
+				5 npop true
+			} if
+		} if
+		{
+			height div ceiling height mul 4 1 roll
+			width div ceiling width mul 4 1 roll
+			height div floor height mul 4 1 roll
+			width div floor width mul 4 1 roll
+			2 index sub height div ceiling cvi exch
+			3 index sub width div ceiling cvi exch
+			4 2 roll moveto
+			FontMatrix mtx invertmatrix
+			dup dup 4 get exch 5 get rmoveto
+			ptm ptm concatmatrix pop
+			slice /s
+			patterncachesize patterncachelimit div ceiling sqrt ceiling cvi
+			dup slice /q get gt
+			{
+				pop slice /q get
+			} if
+			put
+			0 1 slice /s get dup mul 1 sub
+			{
+				slice /b get add
+				gsave
+				0 1 str length 1 sub
+				{
+					str exch 2 index put
+				} for
+				pop
+				dup
+				{
+					gsave
+					ptm setmatrix
+					1 index str length idiv
+					{
+						str show
+					} repeat
+					1 index str length mod str exch 0 exch getinterval show
+					grestore
+					0 height rmoveto
+				} repeat
+				grestore
+			} for
+			2 npop
+		}
+		{
+			4 npop
+		} ifelse
+	} if
+ end
+} def
+/patternclip
+{
+	_eo {eoclip} {clip} ifelse
+} def
+/patternstrokepath
+{
+	strokepath
+} def
+/patternmatrix
+matrix def
+/patternfill
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternclip
+	Adobe_pattern_AI5 /patternpath get exec
+	grestore
+	newpath
+} def
+/patternstroke
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternstrokepath
+	true
+	{
+		{
+			{
+				newpath
+				moveto
+			}
+			{
+				lineto
+			}
+			{
+				curveto
+			}
+			{
+				closepath
+				3 copy
+				Adobe_pattern_AI5 /patternfill get exec
+			} pathforall
+			3 npop
+		} stopped
+		{
+			5 npop
+			patternclip
+			Adobe_pattern_AI5 /patternfill get exec
+		} if
+	}
+	{
+		patternclip
+		Adobe_pattern_AI5 /patternfill get exec
+	} ifelse
+	grestore
+	newpath
+} def
+/vpatternawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index 5 index 5 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	3 npop
+} def
+/hpatternawidthshow
+{
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		9 index 9 index 9 index
+		Adobe_pattern_AI5 /patternfill get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	8 npop
+} def
+/patternashow
+{
+0 0 0 6 3 roll
+patternawidthshow
+} def
+/patternawidthshow
+{
+	6 index type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get 7 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshow } { vpatternawidthshow } ifelse
+} def
+/vpatternawidthshowstroke
+{
+	7 1 roll
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			3 index setmatrix
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			4 index setmatrix
+			7 index 7 index 7 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	4 npop
+} def
+/hpatternawidthshowstroke
+{
+	7 1 roll
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		7 index setmatrix
+		10 index 10 index 10 index
+		Adobe_pattern_AI5 /patternstroke get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	9 npop
+} def
+/patternashowstroke
+{
+	0 0 0 7 3 roll
+	patternawidthshowstroke
+} def
+/patternawidthshowstroke
+{
+	7 index type /dicttype eq
+	{
+		patternmatrix /patternmatrix get 8 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshowstroke } { vpatternawidthshowstroke } ifelse
+} def
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_pattern_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginRider
+currentpacking true setpacking
+%%BeginFont: TimesNewRomanPS-ItalicMT
+/TimesNewRomanPS-ItalicMT
+15 dict dup begin
+/FontName /TimesNewRomanPS-ItalicMT def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 1024 def
+/FontDescent -314 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+5 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K3D {
+{
+newpath
+100 402 m
+642 402 l
+642 444 l
+100 444 l
+100 402 l
+closepath
+100 238 m
+642 238 l
+642 280 l
+100 280 l
+100 238 l
+closepath
+} exec
+fill
+} bind def
+/K55 {
+{
+newpath
+130 660 m
+168 658 192 654 202 647 c
+211 640 216 630 216 618 c
+216 602 211 578 202 544 c
+133 314 l
+123 278 116 252 114 238 c
+110 215 108 194 108 174 c
+108 125 129 80 171 42 c
+213 3 268 -16 337 -16 c
+397 -16 447 -4 487 20 c
+527 43 557 73 576 108 c
+595 143 617 204 642 289 c
+718 553 l
+728 589 738 614 746 626 c
+754 639 764 648 775 653 c
+786 658 805 660 830 660 c
+836 678 l
+621 678 l
+616 660 l
+647 658 667 654 677 646 c
+687 638 693 628 693 617 c
+693 602 685 568 670 516 c
+611 309 l
+599 270 585 231 570 192 c
+554 153 537 122 519 100 c
+500 77 478 59 451 47 c
+425 34 395 28 360 28 c
+308 28 266 41 235 66 c
+204 92 188 123 188 160 c
+188 177 190 196 194 215 c
+197 229 205 259 218 304 c
+293 557 l
+303 590 312 613 321 626 c
+330 638 340 647 353 652 c
+365 657 386 659 416 660 c
+421 678 l
+135 678 l
+130 660 l
+closepath
+} exec
+fill
+} bind def
+/K56 {
+{
+newpath
+176 -16 m
+556 504 l
+595 558 624 593 642 611 c
+660 629 678 642 696 651 c
+706 656 719 659 735 660 c
+740 678 l
+538 678 l
+532 660 l
+553 659 568 655 575 648 c
+583 641 587 634 587 625 c
+587 617 584 608 579 598 c
+572 583 554 556 525 517 c
+259 152 l
+299 559 l
+303 593 306 614 309 622 c
+316 636 324 645 335 651 c
+346 657 366 660 395 660 c
+400 678 l
+135 678 l
+130 660 l
+148 660 l
+172 660 190 655 201 645 c
+212 635 218 622 218 607 c
+218 597 216 578 214 549 c
+158 -16 l
+176 -16 l
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+5 dict dup begin
+/KA 797 def
+/KD 797 def
+/K3D 691 def
+/K55 740 def
+/K56 626 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+setpacking
+%AI3_EndRider
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _TimesNewRomanPS-ItalicMT TimesNewRomanPS-ItalicMT
+[/_TimesNewRomanPS-ItalicMT/TimesNewRomanPS-ItalicMT 0 0 0 TZ%AI3_EndEncoding TrueType%AI3_BeginPattern: (pe0c)
+(pe0c) 30.9998 15.75 148.3332 135.0834 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.6667 100.4167 m
+56.3333 113.75 44 110.1667 57.6667 116 c
+82.0774 126.4192 77 122.4167 83 121.0833 c
+89 119.75 88.9167 121.75 89.1667 119.75 c
+89.7384 115.1758 85.7232 109.7179 76.1667 98.25 c
+68.6667 89.25 65.6667 86.4167 65.6667 81.0833 c
+65.6667 75.75 67.1667 78.5 65.6667 78.4167 c
+44.2151 77.2246 44.833 76.9984 43.6667 75.0833 c
+36.9167 64 35.9167 64 37 62.4167 c
+42.5965 54.2373 50.9167 45.75 51.6667 46.25 c
+60.2659 51.9828 61.8155 53.9628 60.6667 55.75 c
+58.4167 59.25 56.4167 58.75 52.4167 62.5 c
+48.4167 66.25 53.1667 67.75 y
+72.9167 61.25 76.6667 56.75 76.6667 52.25 c
+76.6667 48 77.9167 48.25 68.1667 43.5 c
+59.3683 39.2136 51.9167 40.25 51.6667 39.0833 c
+49.0909 27.0635 50.8185 37.7911 48.3333 26.4167 c
+45.5597 13.722 46.9167 15.75 y
+S149.3333 101.3333 m
+130.0793 94.7917 128.1667 89.25 y
+129.9167 83.5 129.9167 81.75 v
+129.9167 80 130.4167 80.25 129.9167 78.25 c
+129.4167 76.25 129.4167 75.25 127.1667 76.25 c
+118.3483 80.1693 119.5074 80.2501 110.1667 80.25 c
+108.9167 80.25 108.6733 88.9615 115.6667 97.5 c
+137.1667 123.75 140.82 117.6185 139.1667 122.5 c
+135.6667 132.8333 133.3333 135.1667 y
+S59.1667 16 m
+59.6667 29 59.9167 29.5 y
+82.4167 33 91.1667 36.5 y
+95.1667 42.25 l
+97.6667 37.75 l
+97.6667 36.75 101.1667 36.25 v
+125.276 32.8058 123.9167 34.5 124.1667 33 c
+124.4167 31.5 125.1667 31.5 y
+128.1667 31.5 127.8333 30.4167 128.1667 29 c
+128.9722 25.5767 128.5 26.4167 129.4167 24 c
+132.2652 16.49 131.9167 18.5 132.9167 17.25 c
+133.9167 16 134.1667 15.75 y
+S45.9167 135 m
+43.9167 131.5 43.9167 131.25 y
+56.6667 116.75 l
+64.4167 128 l
+58.3333 132.75 l
+58.6667 135.4167 l
+S%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.8941 0 0.0431 0 k
+ 0.8941 0 0.0431 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M [2 ]0 d%AI3_Note:0 D
+0 XR
+89.6667 15.75 m
+90 135.25 l
+F%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M [2 ]0 d%AI3_Note:0 D
+0 XR
+89.6667 15.75 m
+90 135.25 l
+S%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.8941 0 0.0431 0 k
+ 0.8941 0 0.0431 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M [2 ]0 d%AI3_Note:0 D
+0 XR
+148.1667 75.9167 m
+30.8333 76.25 l
+F%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M [2 ]0 d%AI3_Note:0 D
+0 XR
+148.1667 75.9167 m
+30.8333 76.25 l
+S2 w []0 d30.9998 135.0834 m
+30.9998 15.75 l
+148.3332 15.75 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (inv)
+(inv) 2.5 2.5 119.8334 121.8334 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3 w 1 M [3 6 ]0 d%AI3_Note:0 D
+0 XR
+61 2.4167 m
+61.3334 121.9167 l
+S119.8334 62.0001 m
+2.5001 62.3334 l
+S1 w 4 M []0 d3 122.3334 m
+3 3 l
+120.3334 3 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+(inv) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(inv) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+u0 O
+(pe0c) 0 0 1 1 0 0 0 0 0 [1 0 0 1 -9.2612 -55.7195] p
+0 R
+0.4863 0 0.0118 0 K
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+548.3337 450.6252 m
+Bq1 Ap
+682.667 467.0002 m
+682.667 767.0002 L
+386.667 767.0002 L
+386.667 467.0002 L
+682.667 467.0002 L
+hWnQ0 A
+q800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+683.3337 471.0002 m
+683.3337 765.0002 L
+384.3337 765.0002 L
+384.3337 471.0002 L
+683.3337 471.0002 L
+hWnu593.3339 797.0006 m
+710.6673 797.0006 L
+710.6673 677.6672 L
+593.3339 677.6672 L
+593.3339 797.0006 L
+n0 Ap
+0 R
+0 0 0 1 K
+592.0008 762.3339 m
+618.6674 775.6672 606.3341 772.0839 620.0008 777.9172 c
+644.4115 788.3364 639.3341 784.3339 645.3341 783.0005 c
+651.3341 781.6672 651.2508 783.6672 651.5008 781.6672 c
+652.0725 777.093 648.0573 771.6351 638.5008 760.1672 c
+631.0008 751.1672 628.0008 748.3339 628.0008 743.0005 c
+628.0008 737.6672 629.5008 740.4172 628.0008 740.3339 c
+606.5492 739.1418 607.1671 738.9156 606.0008 737.0005 c
+599.2508 725.9172 598.2508 725.9172 599.3341 724.3339 c
+604.9306 716.1545 613.2508 707.6672 614.0008 708.1672 c
+622.6 713.9 624.1496 715.88 623.0008 717.6672 c
+620.7508 721.1672 618.7508 720.6672 614.7508 724.4172 c
+610.7508 728.1672 615.5008 729.6672 y
+635.2508 723.1672 639.0008 718.6672 639.0008 714.1672 c
+639.0008 709.9172 640.2508 710.1672 630.5008 705.4172 c
+621.7024 701.1308 614.2508 702.1672 614.0008 701.0005 c
+611.425 688.9807 613.1526 699.7083 610.6674 688.3339 c
+607.8938 675.6392 609.2508 677.6672 y
+S711.6674 763.2505 m
+692.4134 756.7089 690.5008 751.1672 y
+692.2508 745.4172 692.2508 743.6672 v
+692.2508 741.9172 692.7508 742.1672 692.2508 740.1672 c
+691.7508 738.1672 691.7508 737.1672 689.5008 738.1672 c
+680.6824 742.0865 681.8415 742.1673 672.5008 742.1672 c
+671.2508 742.1672 671.0074 750.8787 678.0008 759.4172 c
+699.5008 785.6672 703.1541 779.5357 701.5008 784.4172 c
+698.0008 794.7505 695.6674 797.0839 y
+S621.5008 677.9172 m
+622.0008 690.9172 622.2508 691.4172 y
+644.7508 694.9172 653.5008 698.4172 y
+657.5008 704.1672 l
+660.0008 699.6672 l
+660.0008 698.6672 663.5008 698.1672 v
+687.6101 694.723 686.2508 696.4172 686.5008 694.9172 c
+686.7508 693.4172 687.5008 693.4172 y
+690.5008 693.4172 690.1674 692.3339 690.5008 690.9172 c
+691.3063 687.4939 690.8341 688.3339 691.7508 685.9172 c
+694.5993 678.4073 694.2508 680.4172 695.2508 679.1672 c
+696.2508 677.9172 696.5008 677.6672 y
+S608.2508 796.9172 m
+606.2508 793.4172 606.2508 793.1672 y
+619.0008 778.6672 l
+626.7508 789.9172 l
+620.6674 794.6672 l
+621.0008 797.3339 l
+S1 M [1 4 1 4 ]0 d652.7248 678.8286 m
+653.0581 798.3286 l
+S711.5581 738.412 m
+594.2248 738.7453 l
+SUu1 Ap
+4 M []0 d593.3339 677.6672 m
+710.6673 677.6672 L
+710.6673 558.3338 L
+593.3339 558.3338 L
+593.3339 677.6672 L
+n0 Ap
+0 R
+0 0 0 1 K
+4 w592.0008 643.0005 m
+618.6674 656.3338 606.3341 652.7505 620.0008 658.5838 c
+644.4115 669.003 639.3341 665.0005 645.3341 663.6671 c
+651.3341 662.3338 651.2508 664.3338 651.5008 662.3338 c
+652.0725 657.7596 648.0573 652.3017 638.5008 640.8338 c
+631.0008 631.8338 628.0008 629.0005 628.0008 623.6671 c
+628.0008 618.3338 629.5008 621.0838 628.0008 621.0005 c
+606.5492 619.8084 607.1671 619.5822 606.0008 617.6671 c
+599.2508 606.5838 598.2508 606.5838 599.3341 605.0005 c
+604.9306 596.8211 613.2508 588.3338 614.0008 588.8338 c
+622.6 594.5666 624.1496 596.5466 623.0008 598.3338 c
+620.7508 601.8338 618.7508 601.3338 614.7508 605.0838 c
+610.7508 608.8338 615.5008 610.3338 y
+635.2508 603.8338 639.0008 599.3338 639.0008 594.8338 c
+639.0008 590.5838 640.2508 590.8338 630.5008 586.0838 c
+621.7024 581.7974 614.2508 582.8338 614.0008 581.6671 c
+611.425 569.6473 613.1526 580.3749 610.6674 569.0005 c
+607.8938 556.3058 609.2508 558.3338 y
+S1 w711.6674 643.9171 m
+692.4134 637.3755 690.5008 631.8338 y
+692.2508 626.0838 692.2508 624.3338 v
+692.2508 622.5838 692.7508 622.8338 692.2508 620.8338 c
+691.7508 618.8338 691.7508 617.8338 689.5008 618.8338 c
+680.6824 622.7531 681.8415 622.8339 672.5008 622.8338 c
+671.2508 622.8338 671.0074 631.5453 678.0008 640.0838 c
+699.5008 666.3338 703.1541 660.2023 701.5008 665.0838 c
+698.0008 675.4171 695.6674 677.7505 y
+S621.5008 558.5838 m
+622.0008 571.5838 622.2508 572.0838 y
+644.7508 575.5838 653.5008 579.0838 y
+657.5008 584.8338 l
+660.0008 580.3338 l
+660.0008 579.3338 663.5008 578.8338 v
+687.6101 575.3896 686.2508 577.0838 686.5008 575.5838 c
+686.7508 574.0838 687.5008 574.0838 y
+690.5008 574.0838 690.1674 573.0005 690.5008 571.5838 c
+691.3063 568.1605 690.8341 569.0005 691.7508 566.5838 c
+694.5993 559.0739 694.2508 561.0838 695.2508 559.8338 c
+696.2508 558.5838 696.5008 558.3338 y
+S608.2508 677.5838 m
+606.2508 674.0838 606.2508 673.8338 y
+619.0008 659.3338 l
+626.7508 670.5838 l
+620.6674 675.3338 l
+621.0008 678.0005 l
+S1 M [1 4 1 4 ]0 d652.7248 559.4952 m
+653.0581 678.9952 l
+S711.5581 619.0786 m
+594.2248 619.4119 l
+SUu1 Ap
+4 M []0 d593.3339 558.3338 m
+710.6673 558.3338 L
+710.6673 439.0004 L
+593.3339 439.0004 L
+593.3339 558.3338 L
+n0 Ap
+0 R
+0 0 0 1 K
+592.0008 523.6671 m
+618.6674 537.0004 606.3341 533.4171 620.0008 539.2504 c
+644.4115 549.6696 639.3341 545.6671 645.3341 544.3337 c
+651.3341 543.0004 651.2508 545.0004 651.5008 543.0004 c
+652.0725 538.4262 648.0573 532.9683 638.5008 521.5004 c
+631.0008 512.5004 628.0008 509.6671 628.0008 504.3337 c
+628.0008 499.0004 629.5008 501.7504 628.0008 501.6671 c
+606.5492 500.475 607.1671 500.2488 606.0008 498.3337 c
+599.2508 487.2504 598.2508 487.2504 599.3341 485.6671 c
+604.9306 477.4877 613.2508 469.0004 614.0008 469.5004 c
+622.6 475.2332 624.1496 477.2132 623.0008 479.0004 c
+620.7508 482.5004 618.7508 482.0004 614.7508 485.7504 c
+610.7508 489.5004 615.5008 491.0004 y
+635.2508 484.5004 639.0008 480.0004 639.0008 475.5004 c
+639.0008 471.2504 640.2508 471.5004 630.5008 466.7504 c
+621.7024 462.464 614.2508 463.5004 614.0008 462.3337 c
+611.425 450.3139 613.1526 461.0415 610.6674 449.6671 c
+607.8938 436.9724 609.2508 439.0004 y
+S711.6674 524.5837 m
+692.4134 518.0421 690.5008 512.5004 y
+692.2508 506.7504 692.2508 505.0004 v
+692.2508 503.2504 692.7508 503.5004 692.2508 501.5004 c
+691.7508 499.5004 691.7508 498.5004 689.5008 499.5004 c
+680.6824 503.4197 681.8415 503.5005 672.5008 503.5004 c
+671.2508 503.5004 671.0074 512.2119 678.0008 520.7504 c
+699.5008 547.0004 703.1541 540.8689 701.5008 545.7504 c
+698.0008 556.0837 695.6674 558.4171 y
+S621.5008 439.2504 m
+622.0008 452.2504 622.2508 452.7504 y
+644.7508 456.2504 653.5008 459.7504 y
+657.5008 465.5004 l
+660.0008 461.0004 l
+660.0008 460.0004 663.5008 459.5004 v
+687.6101 456.0562 686.2508 457.7504 686.5008 456.2504 c
+686.7508 454.7504 687.5008 454.7504 y
+690.5008 454.7504 690.1674 453.6671 690.5008 452.2504 c
+691.3063 448.8271 690.8341 449.6671 691.7508 447.2504 c
+694.5993 439.7405 694.2508 441.7504 695.2508 440.5004 c
+696.2508 439.2504 696.5008 439.0004 y
+S608.2508 558.2504 m
+606.2508 554.7504 606.2508 554.5004 y
+619.0008 540.0004 l
+626.7508 551.2504 l
+620.6674 556.0004 l
+621.0008 558.6671 l
+S1 M [1 4 1 4 ]0 d652.7248 440.1618 m
+653.0581 559.6618 l
+S711.5581 499.7452 m
+594.2248 500.0785 l
+SUu1 Ap
+4 M []0 d476.0005 797.0006 m
+593.3339 797.0006 L
+593.3339 677.6672 L
+476.0005 677.6672 L
+476.0005 797.0006 L
+n0 Ap
+0 R
+0 0 0 1 K
+474.6674 762.3339 m
+501.334 775.6672 489.0007 772.0839 502.6674 777.9172 c
+527.0781 788.3364 522.0007 784.3339 528.0007 783.0005 c
+534.0007 781.6672 533.9174 783.6672 534.1674 781.6672 c
+534.7391 777.093 530.7239 771.6351 521.1674 760.1672 c
+513.6674 751.1672 510.6674 748.3339 510.6674 743.0005 c
+510.6674 737.6672 512.1674 740.4172 510.6674 740.3339 c
+489.2158 739.1418 489.8337 738.9156 488.6674 737.0005 c
+481.9174 725.9172 480.9174 725.9172 482.0007 724.3339 c
+487.5972 716.1545 495.9174 707.6672 496.6674 708.1672 c
+505.2666 713.9 506.8162 715.88 505.6674 717.6672 c
+503.4174 721.1672 501.4174 720.6672 497.4174 724.4172 c
+493.4174 728.1672 498.1674 729.6672 y
+517.9174 723.1672 521.6674 718.6672 521.6674 714.1672 c
+521.6674 709.9172 522.9174 710.1672 513.1674 705.4172 c
+504.369 701.1308 496.9174 702.1672 496.6674 701.0005 c
+494.0916 688.9807 495.8192 699.7083 493.334 688.3339 c
+490.5604 675.6392 491.9174 677.6672 y
+S594.334 763.2505 m
+575.08 756.7089 573.1674 751.1672 y
+574.9174 745.4172 574.9174 743.6672 v
+574.9174 741.9172 575.4174 742.1672 574.9174 740.1672 c
+574.4174 738.1672 574.4174 737.1672 572.1674 738.1672 c
+563.349 742.0865 564.5081 742.1673 555.1674 742.1672 c
+553.9174 742.1672 553.674 750.8787 560.6674 759.4172 c
+582.1674 785.6672 585.8207 779.5357 584.1674 784.4172 c
+580.6674 794.7505 578.334 797.0839 y
+S4 w504.1674 677.9172 m
+504.6674 690.9172 504.9174 691.4172 y
+527.4174 694.9172 536.1674 698.4172 y
+540.1674 704.1672 l
+542.6674 699.6672 l
+542.6674 698.6672 546.1674 698.1672 v
+570.2767 694.723 568.9174 696.4172 569.1674 694.9172 c
+569.4174 693.4172 570.1674 693.4172 y
+573.1674 693.4172 572.834 692.3339 573.1674 690.9172 c
+573.9729 687.4939 573.5007 688.3339 574.4174 685.9172 c
+577.2659 678.4073 576.9174 680.4172 577.9174 679.1672 c
+578.9174 677.9172 579.1674 677.6672 y
+S1 w490.9174 796.9172 m
+488.9174 793.4172 488.9174 793.1672 y
+501.6674 778.6672 l
+509.4174 789.9172 l
+503.334 794.6672 l
+503.6674 797.3339 l
+S1 M [1 4 1 4 ]0 d535.3914 678.8286 m
+535.7247 798.3286 l
+S594.2247 738.412 m
+476.8914 738.7453 l
+SUu1 Ap
+4 M []0 d476.0005 677.6672 m
+593.3339 677.6672 L
+593.3339 558.3338 L
+476.0005 558.3338 L
+476.0005 677.6672 L
+n0 Ap
+0 R
+0 0 0 1 K
+4 w502.6674 658.5838 m
+527.0781 669.003 522.0007 665.0005 528.0007 663.6671 c
+534.0007 662.3338 533.9174 664.3338 534.1674 662.3338 c
+534.7391 657.7596 530.7239 652.3017 521.1674 640.8338 c
+513.6674 631.8338 510.6674 629.0005 510.6674 623.6671 c
+510.6674 618.3338 512.1674 621.0838 510.6674 621.0005 c
+489.2158 619.8084 489.8337 619.5822 488.6674 617.6671 c
+481.9174 606.5838 480.9174 606.5838 482.0007 605.0005 c
+487.5972 596.8211 495.9174 588.3338 496.6674 588.8338 c
+505.2666 594.5666 506.8162 596.5466 505.6674 598.3338 c
+503.4174 601.8338 501.4174 601.3338 497.4174 605.0838 c
+493.4174 608.8338 498.1674 610.3338 y
+517.9174 603.8338 521.6674 599.3338 521.6674 594.8338 c
+521.6674 590.5838 522.9174 590.8338 513.1674 586.0838 c
+504.369 581.7974 496.9174 582.8338 496.6674 581.6671 c
+494.0916 569.6473 495.8192 580.3749 493.334 569.0005 c
+490.5604 556.3058 491.9174 558.3338 y
+S3 w474.6674 643.0005 m
+S4 w594.334 643.9171 m
+575.08 637.3755 573.1674 631.8338 y
+574.9174 626.0838 574.9174 624.3338 v
+574.9174 622.5838 575.4174 622.8338 574.9174 620.8338 c
+574.4174 618.8338 574.4174 617.8338 572.1674 618.8338 c
+563.349 622.7531 564.5081 622.8339 555.1674 622.8338 c
+553.9174 622.8338 553.674 631.5453 560.6674 640.0838 c
+582.1674 666.3338 585.8207 660.2023 584.1674 665.0838 c
+580.6674 675.4171 578.334 677.7505 y
+S504.1674 558.5838 m
+504.6674 571.5838 504.9174 572.0838 y
+527.4174 575.5838 536.1674 579.0838 y
+540.1674 584.8338 l
+542.6674 580.3338 l
+542.6674 579.3338 546.1674 578.8338 v
+570.2767 575.3896 568.9174 577.0838 569.1674 575.5838 c
+569.4174 574.0838 570.1674 574.0838 y
+573.1674 574.0838 572.834 573.0005 573.1674 571.5838 c
+573.9729 568.1605 573.5007 569.0005 574.4174 566.5838 c
+577.2659 559.0739 576.9174 561.0838 577.9174 559.8338 c
+578.9174 558.5838 579.1674 558.3338 y
+S1 w490.9174 677.5838 m
+488.9174 674.0838 488.9174 673.8338 y
+501.6674 659.3338 l
+509.4174 670.5838 l
+503.334 675.3338 l
+503.6674 678.0005 l
+S1 M [1 4 1 4 ]0 d535.3914 559.4952 m
+535.7247 678.9952 l
+S594.2247 619.0786 m
+476.8914 619.4119 l
+SUu1 Ap
+4 M []0 d476.0005 558.3338 m
+593.3339 558.3338 L
+593.3339 439.0004 L
+476.0005 439.0004 L
+476.0005 558.3338 L
+n0 Ap
+0 R
+0 0 0 1 K
+474.6674 523.6671 m
+501.334 537.0004 489.0007 533.4171 502.6674 539.2504 c
+527.0781 549.6696 522.0007 545.6671 528.0007 544.3337 c
+534.0007 543.0004 533.9174 545.0004 534.1674 543.0004 c
+534.7391 538.4262 530.7239 532.9683 521.1674 521.5004 c
+513.6674 512.5004 510.6674 509.6671 510.6674 504.3337 c
+510.6674 499.0004 512.1674 501.7504 510.6674 501.6671 c
+489.2158 500.475 489.8337 500.2488 488.6674 498.3337 c
+481.9174 487.2504 480.9174 487.2504 482.0007 485.6671 c
+487.5972 477.4877 495.9174 469.0004 496.6674 469.5004 c
+505.2666 475.2332 506.8162 477.2132 505.6674 479.0004 c
+503.4174 482.5004 501.4174 482.0004 497.4174 485.7504 c
+493.4174 489.5004 498.1674 491.0004 y
+517.9174 484.5004 521.6674 480.0004 521.6674 475.5004 c
+521.6674 471.2504 522.9174 471.5004 513.1674 466.7504 c
+504.369 462.464 496.9174 463.5004 496.6674 462.3337 c
+494.0916 450.3139 495.8192 461.0415 493.334 449.6671 c
+490.5604 436.9724 491.9174 439.0004 y
+S4 w619.0837 539.5002 m
+602.8337 528.2502 573.1674 512.5004 y
+574.9174 506.7504 574.9174 505.0004 v
+574.9174 503.2504 575.4174 503.5004 574.9174 501.5004 c
+574.4174 499.5004 574.4174 498.5004 572.1674 499.5004 c
+563.349 503.4197 564.5081 503.5005 555.1674 503.5004 c
+553.9174 503.5004 553.674 512.2119 560.6674 520.7504 c
+582.1674 547.0004 585.8207 540.8689 584.1674 545.7504 c
+580.6674 556.0837 578.334 558.4171 y
+S1 w504.1674 439.2504 m
+504.6674 452.2504 504.9174 452.7504 y
+527.4174 456.2504 536.1674 459.7504 y
+540.1674 465.5004 l
+542.6674 461.0004 l
+542.6674 460.0004 546.1674 459.5004 v
+570.2767 456.0562 568.9174 457.7504 569.1674 456.2504 c
+569.4174 454.7504 570.1674 454.7504 y
+573.1674 454.7504 572.834 453.6671 573.1674 452.2504 c
+573.9729 448.8271 573.5007 449.6671 574.4174 447.2504 c
+577.2659 439.7405 576.9174 441.7504 577.9174 440.5004 c
+578.9174 439.2504 579.1674 439.0004 y
+S4 w492.0837 559.5002 m
+490.0837 556.0002 488.9174 554.5004 y
+501.6674 540.0004 l
+509.4174 551.2504 l
+503.334 556.0004 l
+503.6674 558.6671 l
+S1 w 1 M [1 4 1 4 ]0 d535.3914 440.1618 m
+535.7247 559.6618 l
+S594.2247 499.7452 m
+476.8914 500.0785 l
+SUu1 Ap
+4 M []0 d358.6671 797.0006 m
+476.0005 797.0006 L
+476.0005 677.6672 L
+358.6671 677.6672 L
+358.6671 797.0006 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.334 762.3339 m
+384.0006 775.6672 371.6673 772.0839 385.334 777.9172 c
+409.7447 788.3364 404.6673 784.3339 410.6673 783.0005 c
+416.6673 781.6672 416.584 783.6672 416.834 781.6672 c
+417.4057 777.093 413.3905 771.6351 403.834 760.1672 c
+396.334 751.1672 393.334 748.3339 393.334 743.0005 c
+393.334 737.6672 394.834 740.4172 393.334 740.3339 c
+371.8824 739.1418 372.5003 738.9156 371.334 737.0005 c
+364.584 725.9172 363.584 725.9172 364.6673 724.3339 c
+370.2638 716.1545 378.584 707.6672 379.334 708.1672 c
+387.9332 713.9 389.4828 715.88 388.334 717.6672 c
+386.084 721.1672 384.084 720.6672 380.084 724.4172 c
+376.084 728.1672 380.834 729.6672 y
+400.584 723.1672 404.334 718.6672 404.334 714.1672 c
+404.334 709.9172 405.584 710.1672 395.834 705.4172 c
+387.0356 701.1308 379.584 702.1672 379.334 701.0005 c
+376.7582 688.9807 378.4858 699.7083 376.0006 688.3339 c
+373.227 675.6392 374.584 677.6672 y
+S477.0006 763.2505 m
+457.7466 756.7089 455.834 751.1672 y
+457.584 745.4172 457.584 743.6672 v
+457.584 741.9172 458.084 742.1672 457.584 740.1672 c
+457.084 738.1672 457.084 737.1672 454.834 738.1672 c
+446.0156 742.0865 447.1747 742.1673 437.834 742.1672 c
+436.584 742.1672 436.3406 750.8787 443.334 759.4172 c
+464.834 785.6672 468.4873 779.5357 466.834 784.4172 c
+463.334 794.7505 461.0006 797.0839 y
+S386.834 677.9172 m
+387.334 690.9172 387.584 691.4172 y
+410.084 694.9172 418.834 698.4172 y
+422.834 704.1672 l
+425.334 699.6672 l
+425.334 698.6672 428.834 698.1672 v
+452.9433 694.723 451.584 696.4172 451.834 694.9172 c
+452.084 693.4172 452.834 693.4172 y
+455.834 693.4172 455.5006 692.3339 455.834 690.9172 c
+456.6395 687.4939 456.1673 688.3339 457.084 685.9172 c
+459.9325 678.4073 459.584 680.4172 460.584 679.1672 c
+461.584 677.9172 461.834 677.6672 y
+S373.584 796.9172 m
+371.584 793.4172 371.584 793.1672 y
+384.334 778.6672 l
+392.084 789.9172 l
+386.0006 794.6672 l
+386.334 797.3339 l
+S1 M [1 4 1 4 ]0 d418.058 678.8286 m
+418.3913 798.3286 l
+S476.8913 738.412 m
+359.558 738.7453 l
+SUu1 Ap
+4 M []0 d358.6671 677.6672 m
+476.0005 677.6672 L
+476.0005 558.3338 L
+358.6671 558.3338 L
+358.6671 677.6672 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.334 643.0005 m
+384.0006 656.3338 371.6673 652.7505 385.334 658.5838 c
+409.7447 669.003 404.6673 665.0005 410.6673 663.6671 c
+416.6673 662.3338 416.584 664.3338 416.834 662.3338 c
+417.4057 657.7596 413.3905 652.3017 403.834 640.8338 c
+396.334 631.8338 393.334 629.0005 393.334 623.6671 c
+393.334 618.3338 394.834 621.0838 393.334 621.0005 c
+371.8824 619.8084 372.5003 619.5822 371.334 617.6671 c
+364.584 606.5838 363.584 606.5838 364.6673 605.0005 c
+370.2638 596.8211 378.584 588.3338 379.334 588.8338 c
+387.9332 594.5666 389.4828 596.5466 388.334 598.3338 c
+386.084 601.8338 384.084 601.3338 380.084 605.0838 c
+376.084 608.8338 380.834 610.3338 y
+400.584 603.8338 404.334 599.3338 404.334 594.8338 c
+404.334 590.5838 405.584 590.8338 395.834 586.0838 c
+387.0356 581.7974 379.584 582.8338 379.334 581.6671 c
+376.7582 569.6473 378.4858 580.3749 376.0006 569.0005 c
+373.227 556.3058 374.584 558.3338 y
+S503.8337 658.5002 m
+484.5797 651.9586 455.834 631.8338 y
+457.584 626.0838 457.584 624.3338 v
+457.584 622.5838 458.084 622.8338 457.584 620.8338 c
+457.084 618.8338 457.084 617.8338 454.834 618.8338 c
+446.0156 622.7531 447.1747 622.8339 437.834 622.8338 c
+436.584 622.8338 436.3406 631.5453 443.334 640.0838 c
+464.834 666.3338 468.4873 660.2023 466.834 665.0838 c
+463.334 675.4171 461.0006 677.7505 y
+S386.834 558.5838 m
+387.334 571.5838 387.584 572.0838 y
+410.084 575.5838 418.834 579.0838 y
+422.834 584.8338 l
+425.334 580.3338 l
+425.334 579.3338 428.834 578.8338 v
+452.9433 575.3896 451.584 577.0838 451.834 575.5838 c
+452.084 574.0838 452.834 574.0838 y
+455.834 574.0838 455.5006 573.0005 455.834 571.5838 c
+456.6395 568.1605 456.1673 569.0005 457.084 566.5838 c
+459.9325 559.0739 459.584 561.0838 460.584 559.8338 c
+461.584 558.5838 461.834 558.3338 y
+S373.584 677.5838 m
+371.584 674.0838 371.584 673.8338 y
+384.334 659.3338 l
+392.084 670.5838 l
+386.0006 675.3338 l
+386.334 678.0005 l
+S1 M [1 4 1 4 ]0 d418.058 559.4952 m
+418.3913 678.9952 l
+S476.8913 619.0786 m
+359.558 619.4119 l
+SUu1 Ap
+4 M []0 d358.6671 558.3338 m
+476.0005 558.3338 L
+476.0005 439.0004 L
+358.6671 439.0004 L
+358.6671 558.3338 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.334 523.6671 m
+384.0006 537.0004 371.6673 533.4171 385.334 539.2504 c
+409.7447 549.6696 404.6673 545.6671 410.6673 544.3337 c
+416.6673 543.0004 416.584 545.0004 416.834 543.0004 c
+417.4057 538.4262 413.3905 532.9683 403.834 521.5004 c
+396.334 512.5004 393.334 509.6671 393.334 504.3337 c
+393.334 499.0004 394.834 501.7504 393.334 501.6671 c
+371.8824 500.475 372.5003 500.2488 371.334 498.3337 c
+364.584 487.2504 363.584 487.2504 364.6673 485.6671 c
+370.2638 477.4877 378.584 469.0004 379.334 469.5004 c
+387.9332 475.2332 389.4828 477.2132 388.334 479.0004 c
+386.084 482.5004 384.084 482.0004 380.084 485.7504 c
+376.084 489.5004 380.834 491.0004 y
+400.584 484.5004 404.334 480.0004 404.334 475.5004 c
+404.334 471.2504 405.584 471.5004 395.834 466.7504 c
+387.0356 462.464 379.584 463.5004 379.334 462.3337 c
+376.7582 450.3139 378.4858 461.0415 376.0006 449.6671 c
+373.227 436.9724 374.584 439.0004 y
+S477.0006 524.5837 m
+457.7466 518.0421 455.834 512.5004 y
+457.584 506.7504 457.584 505.0004 v
+457.584 503.2504 458.084 503.5004 457.584 501.5004 c
+457.084 499.5004 457.084 498.5004 454.834 499.5004 c
+446.0156 503.4197 447.1747 503.5005 437.834 503.5004 c
+436.584 503.5004 436.3406 512.2119 443.334 520.7504 c
+464.834 547.0004 468.4873 540.8689 466.834 545.7504 c
+463.334 556.0837 461.0006 558.4171 y
+S386.834 439.2504 m
+387.334 452.2504 387.584 452.7504 y
+410.084 456.2504 418.834 459.7504 y
+422.834 465.5004 l
+425.334 461.0004 l
+425.334 460.0004 428.834 459.5004 v
+452.9433 456.0562 451.584 457.7504 451.834 456.2504 c
+452.084 454.7504 452.834 454.7504 y
+455.834 454.7504 455.5006 453.6671 455.834 452.2504 c
+456.6395 448.8271 456.1673 449.6671 457.084 447.2504 c
+459.9325 439.7405 459.584 441.7504 460.584 440.5004 c
+461.584 439.2504 461.834 439.0004 y
+S373.584 558.2504 m
+371.584 554.7504 371.584 554.5004 y
+384.334 540.0004 l
+392.084 551.2504 l
+386.0006 556.0004 l
+386.334 558.6671 l
+S1 M [1 4 1 4 ]0 d418.058 440.1618 m
+418.3913 559.6618 l
+S476.8913 499.7452 m
+359.558 500.0785 l
+SUQ0 A
+0 R
+0 0 0 1 K
+800 Ar
+0 J 0 j 4 w 4 M []0 d%AI3_Note:0 D
+0 XR
+502.5837 659.4168 m
+510.3337 670.6668 l
+504.2503 675.4168 l
+504.5837 678.0835 l
+S609.0837 559.7502 m
+607.0837 556.2502 606.7087 554.1252 y
+619.4587 539.6252 l
+SU0 To
+1 0 0 1 313 590 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+1 w%_ 0 50 XQ
+/_TimesNewRomanPS-ItalicMT 48 48 -14.7187 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+1 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 XbXB0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 To
+1 0 0 1 312.668 180.3594 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+0 To
+1 0 0 1 514.5268 391.4299 0 Tp
+0 Tv
+TP
+0 Tr
+/_TimesNewRomanPS-ItalicMT 60 60 -18.3984 Tf
+(=) Tx 1 0 Tk
+(\r) TX 
+TO
+uuq1 Ap
+279.1457 485.1423 m
+279.1457 775.8089 L
+-18.8544 775.8089 L
+-18.8544 485.1423 L
+279.1457 485.1423 L
+hWnuu0 Ap
+187.7292 678.4965 m
+187.7292 797.83 L
+305.0626 797.83 L
+305.0626 678.4965 L
+187.7292 678.4965 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 678.4132 m
+246.5626 797.9132 l
+S305.0626 737.9967 m
+187.7293 738.33 l
+S4 M []0 d188.2292 798.33 m
+188.2292 678.9965 l
+305.5626 678.9965 l
+SUUuu187.7292 559.1631 m
+187.7292 678.4965 L
+305.0626 678.4965 L
+305.0626 559.1631 L
+187.7292 559.1631 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 559.0798 m
+246.5626 678.5798 l
+S305.0626 618.6632 m
+187.7293 618.9965 l
+S4 M []0 d188.2292 678.9965 m
+188.2292 559.6631 l
+305.5626 559.6631 l
+SUUuu187.7292 439.8297 m
+187.7292 559.1631 L
+305.0626 559.1631 L
+305.0626 439.8297 L
+187.7292 439.8297 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 439.7464 m
+246.5626 559.2464 l
+S305.0626 499.3298 m
+187.7293 499.6631 l
+S4 M []0 d188.2292 559.6631 m
+188.2292 440.3297 l
+305.5626 440.3297 l
+SUUuu70.3958 678.4965 m
+70.3958 797.83 L
+187.7292 797.83 L
+187.7292 678.4965 L
+70.3958 678.4965 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 678.4132 m
+129.2292 797.9132 l
+S187.7292 737.9967 m
+70.3959 738.33 l
+S4 M []0 d70.8958 798.33 m
+70.8958 678.9965 l
+188.2292 678.9965 l
+SUUuu70.3958 559.1631 m
+70.3958 678.4965 L
+187.7292 678.4965 L
+187.7292 559.1631 L
+70.3958 559.1631 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 559.0798 m
+129.2292 678.5798 l
+S187.7292 618.6632 m
+70.3959 618.9965 l
+S4 M []0 d70.8958 678.9965 m
+70.8958 559.6631 l
+188.2292 559.6631 l
+SUUuu70.3958 439.8297 m
+70.3958 559.1631 L
+187.7292 559.1631 L
+187.7292 439.8297 L
+70.3958 439.8297 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 439.7464 m
+129.2292 559.2464 l
+S187.7292 499.3298 m
+70.3959 499.6631 l
+S4 M []0 d70.8958 559.6631 m
+70.8958 440.3297 l
+188.2292 440.3297 l
+SUUuu-46.9376 678.4965 m
+-46.9376 797.83 L
+70.3958 797.83 L
+70.3958 678.4965 L
+-46.9376 678.4965 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 678.4132 m
+11.8958 797.9132 l
+S70.3958 737.9967 m
+-46.9375 738.33 l
+S4 M []0 d-46.4376 798.33 m
+-46.4376 678.9965 l
+70.8958 678.9965 l
+SUUuu-46.9376 559.1631 m
+-46.9376 678.4965 L
+70.3958 678.4965 L
+70.3958 559.1631 L
+-46.9376 559.1631 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 559.0798 m
+11.8958 678.5798 l
+S70.3958 618.6632 m
+-46.9375 618.9965 l
+S4 M []0 d-46.4376 678.9965 m
+-46.4376 559.6631 l
+70.8958 559.6631 l
+SUUuu-46.9376 439.8297 m
+-46.9376 559.1631 L
+70.3958 559.1631 L
+70.3958 439.8297 L
+-46.9376 439.8297 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 439.7464 m
+11.8958 559.2464 l
+S70.3958 499.3298 m
+-46.9375 499.6631 l
+S4 M []0 d-46.4376 559.6631 m
+-46.4376 440.3297 l
+70.8958 440.3297 l
+SUUQU0 A
+1 Ap
+0 R
+0 0 0 1 K
+800 Ar
+0 J 0 j 4 w 4 M []0 d%AI3_Note:0 D
+0 XR
+187.7292 559.1631 m
+187.7292 678.4965 L
+70.3958 678.4965 L
+70.3958 559.1631 L
+187.7292 559.1631 L
+sU0 To
+1 0 0 1 97.3398 391.4299 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+1 w%_ 0 50 XQ
+/_TimesNewRomanPS-ItalicMT 60 60 -18.3984 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+1 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 XbXB0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(=) Tx 1 0 Tk
+(\r) TX 
+TO
+uuq279.1457 55.7836 m
+279.1457 346.4503 L
+-18.8544 346.4503 L
+-18.8544 55.7836 L
+279.1457 55.7836 L
+hWnuu0 Ap
+187.7292 249.1379 m
+187.7292 368.4713 L
+305.0626 368.4713 L
+305.0626 249.1379 L
+187.7292 249.1379 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 249.0546 m
+246.5626 368.5546 l
+S305.0626 308.638 m
+187.7293 308.9713 l
+S4 M []0 d188.2292 368.9713 m
+188.2292 249.6379 l
+305.5626 249.6379 l
+SUUuu187.7292 129.8045 m
+187.7292 249.1379 L
+305.0626 249.1379 L
+305.0626 129.8045 L
+187.7292 129.8045 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 129.7212 m
+246.5626 249.2212 l
+S305.0626 189.3046 m
+187.7293 189.6379 l
+S4 M []0 d188.2292 249.6379 m
+188.2292 130.3045 l
+305.5626 130.3045 l
+SUUuu187.7292 10.4711 m
+187.7292 129.8045 L
+305.0626 129.8045 L
+305.0626 10.4711 L
+187.7292 10.4711 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d246.2292 10.3878 m
+246.5626 129.8878 l
+S305.0626 69.9712 m
+187.7293 70.3045 l
+S4 M []0 d188.2292 130.3045 m
+188.2292 10.9711 l
+305.5626 10.9711 l
+SUUuu70.3958 249.1379 m
+70.3958 368.4713 L
+187.7292 368.4713 L
+187.7292 249.1379 L
+70.3958 249.1379 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 249.0546 m
+129.2292 368.5546 l
+S187.7292 308.638 m
+70.3959 308.9713 l
+S4 M []0 d70.8958 368.9713 m
+70.8958 249.6379 l
+188.2292 249.6379 l
+SUUuu70.3958 129.8045 m
+70.3958 249.1379 L
+187.7292 249.1379 L
+187.7292 129.8045 L
+70.3958 129.8045 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 129.7212 m
+129.2292 249.2212 l
+S187.7292 189.3046 m
+70.3959 189.6379 l
+S4 M []0 d70.8958 249.6379 m
+70.8958 130.3045 l
+188.2292 130.3045 l
+SUUuu70.3958 10.4711 m
+70.3958 129.8045 L
+187.7292 129.8045 L
+187.7292 10.4711 L
+70.3958 10.4711 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d128.8958 10.3878 m
+129.2292 129.8878 l
+S187.7292 69.9712 m
+70.3959 70.3045 l
+S4 M []0 d70.8958 130.3045 m
+70.8958 10.9711 l
+188.2292 10.9711 l
+SUUuu-46.9376 249.1379 m
+-46.9376 368.4713 L
+70.3958 368.4713 L
+70.3958 249.1379 L
+-46.9376 249.1379 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 249.0546 m
+11.8958 368.5546 l
+S70.3958 308.638 m
+-46.9375 308.9713 l
+S4 M []0 d-46.4376 368.9713 m
+-46.4376 249.6379 l
+70.8958 249.6379 l
+SUUuu-46.9376 129.8045 m
+-46.9376 249.1379 L
+70.3958 249.1379 L
+70.3958 129.8045 L
+-46.9376 129.8045 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 129.7212 m
+11.8958 249.2212 l
+S70.3958 189.3046 m
+-46.9375 189.6379 l
+S4 M []0 d-46.4376 249.6379 m
+-46.4376 130.3045 l
+70.8958 130.3045 l
+SUUuu-46.9376 10.4711 m
+-46.9376 129.8045 L
+70.3958 129.8045 L
+70.3958 10.4711 L
+-46.9376 10.4711 L
+n0 R
+0 0 0 1 K
+1 M [1 4 1 4 ]0 d11.5624 10.3878 m
+11.8958 129.8878 l
+S70.3958 69.9712 m
+-46.9375 70.3045 l
+S4 M []0 d-46.4376 130.3045 m
+-46.4376 10.9711 l
+70.8958 10.9711 l
+SUUQU0 A
+1 Ap
+0 R
+0 0 0 1 K
+800 Ar
+1 J 0 j 4 w 4 M [1 4 1 4 ]0 d%AI3_Note:0 D
+0 XR
+245.5 191 m
+245.5 310.5 L
+128.5 310.5 L
+128.5 191 L
+245.5 191 L
+sUuu0 Ap
+0 O
+(pe0c) 0 0 1 1 0 0 0 0 0 [1 0 0 1 5.8196 -35.1986] p
+0.4863 0 0.0118 0 K
+0 J 1 w []0 d548.3311 22.4377 m
+Bq1 Ap
+682.6644 38.8127 m
+682.6644 338.8127 L
+386.6644 338.8127 L
+386.6644 38.8127 L
+682.6644 38.8127 L
+hWnQ0 A
+q800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+683.3311 42.8127 m
+683.3311 336.8127 L
+384.3311 336.8127 L
+384.3311 42.8127 L
+683.3311 42.8127 L
+hWnu593.3313 368.8131 m
+710.6647 368.8131 L
+710.6647 249.4797 L
+593.3313 249.4797 L
+593.3313 368.8131 L
+n0 Ap
+0 R
+0 0 0 1 K
+591.9982 334.1464 m
+618.6648 347.4797 606.3315 343.8964 619.9982 349.7297 c
+644.4089 360.1489 639.3315 356.1464 645.3315 354.813 c
+651.3315 353.4797 651.2482 355.4797 651.4982 353.4797 c
+652.0699 348.9055 648.0547 343.4476 638.4982 331.9797 c
+630.9982 322.9797 627.9982 320.1464 627.9982 314.813 c
+627.9982 309.4797 629.4982 312.2297 627.9982 312.1464 c
+606.5466 310.9543 607.1645 310.7281 605.9982 308.813 c
+599.2482 297.7297 598.2482 297.7297 599.3315 296.1464 c
+604.928 287.967 613.2482 279.4797 613.9982 279.9797 c
+622.5974 285.7125 624.147 287.6925 622.9982 289.4797 c
+620.7482 292.9797 618.7482 292.4797 614.7482 296.2297 c
+610.7482 299.9797 615.4982 301.4797 y
+635.2482 294.9797 638.9982 290.4797 638.9982 285.9797 c
+638.9982 281.7297 640.2482 281.9797 630.4982 277.2297 c
+621.6998 272.9433 614.2482 273.9797 613.9982 272.813 c
+611.4224 260.7932 613.15 271.5208 610.6648 260.1464 c
+607.8912 247.4517 609.2482 249.4797 y
+S711.6648 335.063 m
+692.4108 328.5214 690.4982 322.9797 y
+692.2482 317.2297 692.2482 315.4797 v
+692.2482 313.7297 692.7482 313.9797 692.2482 311.9797 c
+691.7482 309.9797 691.7482 308.9797 689.4982 309.9797 c
+680.6798 313.899 681.8389 313.9798 672.4982 313.9797 c
+671.2482 313.9797 671.0048 322.6912 677.9982 331.2297 c
+699.4982 357.4797 703.1515 351.3482 701.4982 356.2297 c
+697.9982 366.563 695.6648 368.8964 y
+S621.4982 249.7297 m
+621.9982 262.7297 622.2482 263.2297 y
+644.7482 266.7297 653.4982 270.2297 y
+657.4982 275.9797 l
+659.9982 271.4797 l
+659.9982 270.4797 663.4982 269.9797 v
+687.6075 266.5355 686.2482 268.2297 686.4982 266.7297 c
+686.7482 265.2297 687.4982 265.2297 y
+690.4982 265.2297 690.1648 264.1464 690.4982 262.7297 c
+691.3037 259.3064 690.8315 260.1464 691.7482 257.7297 c
+694.5967 250.2198 694.2482 252.2297 695.2482 250.9797 c
+696.2482 249.7297 696.4982 249.4797 y
+S608.2482 368.7297 m
+606.2482 365.2297 606.2482 364.9797 y
+618.9982 350.4797 l
+626.7482 361.7297 l
+620.6648 366.4797 l
+620.9982 369.1464 l
+S1 M [1 4 1 4 ]0 d652.7222 250.6411 m
+653.0555 370.1411 l
+S711.5555 310.2245 m
+594.2222 310.5578 l
+SUu1 Ap
+4 M []0 d593.3313 249.4797 m
+710.6647 249.4797 L
+710.6647 130.1463 L
+593.3313 130.1463 L
+593.3313 249.4797 L
+n0 Ap
+0 R
+0 0 0 1 K
+591.9982 214.813 m
+618.6648 228.1463 606.3315 224.563 619.9982 230.3963 c
+644.4089 240.8155 639.3315 236.813 645.3315 235.4796 c
+651.3315 234.1463 651.2482 236.1463 651.4982 234.1463 c
+652.0699 229.5721 648.0547 224.1142 638.4982 212.6463 c
+630.9982 203.6463 627.9982 200.813 627.9982 195.4796 c
+627.9982 190.1463 629.4982 192.8963 627.9982 192.813 c
+606.5466 191.6209 607.1645 191.3947 605.9982 189.4796 c
+599.2482 178.3963 598.2482 178.3963 599.3315 176.813 c
+604.928 168.6336 613.2482 160.1463 613.9982 160.6463 c
+622.5974 166.3791 624.147 168.3591 622.9982 170.1463 c
+620.7482 173.6463 618.7482 173.1463 614.7482 176.8963 c
+610.7482 180.6463 615.4982 182.1463 y
+635.2482 175.6463 638.9982 171.1463 638.9982 166.6463 c
+638.9982 162.3963 640.2482 162.6463 630.4982 157.8963 c
+621.6998 153.6099 614.2482 154.6463 613.9982 153.4796 c
+611.4224 141.4598 613.15 152.1874 610.6648 140.813 c
+607.8912 128.1183 609.2482 130.1463 y
+S711.6648 215.7296 m
+692.4108 209.188 690.4982 203.6463 y
+692.2482 197.8963 692.2482 196.1463 v
+692.2482 194.3963 692.7482 194.6463 692.2482 192.6463 c
+691.7482 190.6463 691.7482 189.6463 689.4982 190.6463 c
+680.6798 194.5656 681.8389 194.6464 672.4982 194.6463 c
+671.2482 194.6463 671.0048 203.3578 677.9982 211.8963 c
+699.4982 238.1463 703.1515 232.0148 701.4982 236.8963 c
+697.9982 247.2296 695.6648 249.563 y
+S621.4982 130.3963 m
+621.9982 143.3963 622.2482 143.8963 y
+644.7482 147.3963 653.4982 150.8963 y
+657.4982 156.6463 l
+659.9982 152.1463 l
+659.9982 151.1463 663.4982 150.6463 v
+687.6075 147.2021 686.2482 148.8963 686.4982 147.3963 c
+686.7482 145.8963 687.4982 145.8963 y
+690.4982 145.8963 690.1648 144.813 690.4982 143.3963 c
+691.3037 139.973 690.8315 140.813 691.7482 138.3963 c
+694.5967 130.8864 694.2482 132.8963 695.2482 131.6463 c
+696.2482 130.3963 696.4982 130.1463 y
+S608.2482 249.3963 m
+606.2482 245.8963 606.2482 245.6463 y
+618.9982 231.1463 l
+626.7482 242.3963 l
+620.6648 247.1463 l
+620.9982 249.813 l
+S1 M [1 4 1 4 ]0 d652.7222 131.3077 m
+653.0555 250.8077 l
+S711.5555 190.8911 m
+594.2222 191.2244 l
+SUu1 Ap
+4 M []0 d593.3313 130.1463 m
+710.6647 130.1463 L
+710.6647 10.8129 L
+593.3313 10.8129 L
+593.3313 130.1463 L
+n0 Ap
+0 R
+0 0 0 1 K
+591.9982 95.4796 m
+618.6648 108.8129 606.3315 105.2296 619.9982 111.0629 c
+644.4089 121.4821 639.3315 117.4796 645.3315 116.1462 c
+651.3315 114.8129 651.2482 116.8129 651.4982 114.8129 c
+652.0699 110.2387 648.0547 104.7808 638.4982 93.3129 c
+630.9982 84.3129 627.9982 81.4796 627.9982 76.1462 c
+627.9982 70.8129 629.4982 73.5629 627.9982 73.4796 c
+606.5466 72.2875 607.1645 72.0613 605.9982 70.1462 c
+599.2482 59.0629 598.2482 59.0629 599.3315 57.4796 c
+604.928 49.3002 613.2482 40.8129 613.9982 41.3129 c
+622.5974 47.0457 624.147 49.0257 622.9982 50.8129 c
+620.7482 54.3129 618.7482 53.8129 614.7482 57.5629 c
+610.7482 61.3129 615.4982 62.8129 y
+635.2482 56.3129 638.9982 51.8129 638.9982 47.3129 c
+638.9982 43.0629 640.2482 43.3129 630.4982 38.5629 c
+621.6998 34.2765 614.2482 35.3129 613.9982 34.1462 c
+611.4224 22.1264 613.15 32.854 610.6648 21.4796 c
+607.8912 8.7849 609.2482 10.8129 y
+S711.6648 96.3962 m
+692.4108 89.8546 690.4982 84.3129 y
+692.2482 78.5629 692.2482 76.8129 v
+692.2482 75.0629 692.7482 75.3129 692.2482 73.3129 c
+691.7482 71.3129 691.7482 70.3129 689.4982 71.3129 c
+680.6798 75.2322 681.8389 75.313 672.4982 75.3129 c
+671.2482 75.3129 671.0048 84.0244 677.9982 92.5629 c
+699.4982 118.8129 703.1515 112.6814 701.4982 117.5629 c
+697.9982 127.8962 695.6648 130.2296 y
+S621.4982 11.0629 m
+621.9982 24.0629 622.2482 24.5629 y
+644.7482 28.0629 653.4982 31.5629 y
+657.4982 37.3129 l
+659.9982 32.8129 l
+659.9982 31.8129 663.4982 31.3129 v
+687.6075 27.8687 686.2482 29.5629 686.4982 28.0629 c
+686.7482 26.5629 687.4982 26.5629 y
+690.4982 26.5629 690.1648 25.4796 690.4982 24.0629 c
+691.3037 20.6396 690.8315 21.4796 691.7482 19.0629 c
+694.5967 11.553 694.2482 13.5629 695.2482 12.3129 c
+696.2482 11.0629 696.4982 10.8129 y
+S608.2482 130.0629 m
+606.2482 126.5629 606.2482 126.3129 y
+618.9982 111.8129 l
+626.7482 123.0629 l
+620.6648 127.8129 l
+620.9982 130.4796 l
+S1 M [1 4 1 4 ]0 d652.7222 11.9743 m
+653.0555 131.4743 l
+S711.5555 71.5577 m
+594.2222 71.891 l
+SUu1 Ap
+4 M []0 d475.9979 368.8131 m
+593.3313 368.8131 L
+593.3313 249.4797 L
+475.9979 249.4797 L
+475.9979 368.8131 L
+n0 Ap
+0 R
+0 0 0 1 K
+474.6648 334.1464 m
+501.3314 347.4797 488.9981 343.8964 502.6648 349.7297 c
+527.0755 360.1489 521.9981 356.1464 527.9981 354.813 c
+533.9981 353.4797 533.9148 355.4797 534.1648 353.4797 c
+534.7365 348.9055 530.7213 343.4476 521.1648 331.9797 c
+513.6648 322.9797 510.6648 320.1464 510.6648 314.813 c
+510.6648 309.4797 512.1648 312.2297 510.6648 312.1464 c
+489.2132 310.9543 489.8311 310.7281 488.6648 308.813 c
+481.9148 297.7297 480.9148 297.7297 481.9981 296.1464 c
+487.5946 287.967 495.9148 279.4797 496.6648 279.9797 c
+505.264 285.7125 506.8136 287.6925 505.6648 289.4797 c
+503.4148 292.9797 501.4148 292.4797 497.4148 296.2297 c
+493.4148 299.9797 498.1648 301.4797 y
+517.9148 294.9797 521.6648 290.4797 521.6648 285.9797 c
+521.6648 281.7297 522.9148 281.9797 513.1648 277.2297 c
+504.3664 272.9433 496.9148 273.9797 496.6648 272.813 c
+494.089 260.7932 495.8166 271.5208 493.3314 260.1464 c
+490.5578 247.4517 491.9148 249.4797 y
+S594.3314 335.063 m
+575.0774 328.5214 573.1648 322.9797 y
+574.9148 317.2297 574.9148 315.4797 v
+574.9148 313.7297 575.4148 313.9797 574.9148 311.9797 c
+574.4148 309.9797 574.4148 308.9797 572.1648 309.9797 c
+563.3464 313.899 564.5055 313.9798 555.1648 313.9797 c
+553.9148 313.9797 553.6714 322.6912 560.6648 331.2297 c
+582.1648 357.4797 585.8181 351.3482 584.1648 356.2297 c
+580.6648 366.563 578.3314 368.8964 y
+S504.1648 249.7297 m
+504.6648 262.7297 504.9148 263.2297 y
+527.4148 266.7297 536.1648 270.2297 y
+540.1648 275.9797 l
+542.6648 271.4797 l
+542.6648 270.4797 546.1648 269.9797 v
+570.2741 266.5355 568.9148 268.2297 569.1648 266.7297 c
+569.4148 265.2297 570.1648 265.2297 y
+573.1648 265.2297 572.8314 264.1464 573.1648 262.7297 c
+573.9703 259.3064 573.4981 260.1464 574.4148 257.7297 c
+577.2633 250.2198 576.9148 252.2297 577.9148 250.9797 c
+578.9148 249.7297 579.1648 249.4797 y
+S490.9148 368.7297 m
+488.9148 365.2297 488.9148 364.9797 y
+501.6648 350.4797 l
+509.4148 361.7297 l
+503.3314 366.4797 l
+503.6648 369.1464 l
+S1 M [1 4 1 4 ]0 d535.3888 250.6411 m
+535.7221 370.1411 l
+S594.2221 310.2245 m
+476.8888 310.5578 l
+SUu1 Ap
+4 M []0 d475.9979 249.4797 m
+593.3313 249.4797 L
+593.3313 130.1463 L
+475.9979 130.1463 L
+475.9979 249.4797 L
+n0 Ap
+0 R
+0 0 0 1 K
+502.6648 230.3963 m
+527.0755 240.8155 521.9981 236.813 527.9981 235.4796 c
+533.9981 234.1463 533.9148 236.1463 534.1648 234.1463 c
+534.7365 229.5721 530.7213 224.1142 521.1648 212.6463 c
+513.6648 203.6463 510.6648 200.813 510.6648 195.4796 c
+510.6648 190.1463 512.1648 192.8963 510.6648 192.813 c
+489.2132 191.6209 489.8311 191.3947 488.6648 189.4796 c
+481.9148 178.3963 480.9148 178.3963 481.9981 176.813 c
+487.5946 168.6336 495.9148 160.1463 496.6648 160.6463 c
+505.264 166.3791 506.8136 168.3591 505.6648 170.1463 c
+503.4148 173.6463 501.4148 173.1463 497.4148 176.8963 c
+493.4148 180.6463 498.1648 182.1463 y
+517.9148 175.6463 521.6648 171.1463 521.6648 166.6463 c
+521.6648 162.3963 522.9148 162.6463 513.1648 157.8963 c
+504.3664 153.6099 496.9148 154.6463 496.6648 153.4796 c
+494.089 141.4598 495.8166 152.1874 493.3314 140.813 c
+490.5578 128.1183 491.9148 130.1463 y
+S3 w474.6648 214.813 m
+S1 w594.3314 215.7296 m
+575.0774 209.188 573.1648 203.6463 y
+574.9148 197.8963 574.9148 196.1463 v
+574.9148 194.3963 575.4148 194.6463 574.9148 192.6463 c
+574.4148 190.6463 574.4148 189.6463 572.1648 190.6463 c
+563.3464 194.5656 564.5055 194.6464 555.1648 194.6463 c
+553.9148 194.6463 553.6714 203.3578 560.6648 211.8963 c
+582.1648 238.1463 585.8181 232.0148 584.1648 236.8963 c
+580.6648 247.2296 578.3314 249.563 y
+S504.1648 130.3963 m
+504.6648 143.3963 504.9148 143.8963 y
+527.4148 147.3963 536.1648 150.8963 y
+540.1648 156.6463 l
+542.6648 152.1463 l
+542.6648 151.1463 546.1648 150.6463 v
+570.2741 147.2021 568.9148 148.8963 569.1648 147.3963 c
+569.4148 145.8963 570.1648 145.8963 y
+573.1648 145.8963 572.8314 144.813 573.1648 143.3963 c
+573.9703 139.973 573.4981 140.813 574.4148 138.3963 c
+577.2633 130.8864 576.9148 132.8963 577.9148 131.6463 c
+578.9148 130.3963 579.1648 130.1463 y
+S490.9148 249.3963 m
+488.9148 245.8963 488.9148 245.6463 y
+501.6648 231.1463 l
+509.4148 242.3963 l
+503.3314 247.1463 l
+503.6648 249.813 l
+S1 M [1 4 1 4 ]0 d535.3888 131.3077 m
+535.7221 250.8077 l
+S594.2221 190.8911 m
+476.8888 191.2244 l
+SUu1 Ap
+4 M []0 d475.9979 130.1463 m
+593.3313 130.1463 L
+593.3313 10.8129 L
+475.9979 10.8129 L
+475.9979 130.1463 L
+n0 Ap
+0 R
+0 0 0 1 K
+474.6648 95.4796 m
+501.3314 108.8129 488.9981 105.2296 502.6648 111.0629 c
+527.0755 121.4821 521.9981 117.4796 527.9981 116.1462 c
+533.9981 114.8129 533.9148 116.8129 534.1648 114.8129 c
+534.7365 110.2387 530.7213 104.7808 521.1648 93.3129 c
+513.6648 84.3129 510.6648 81.4796 510.6648 76.1462 c
+510.6648 70.8129 512.1648 73.5629 510.6648 73.4796 c
+489.2132 72.2875 489.8311 72.0613 488.6648 70.1462 c
+481.9148 59.0629 480.9148 59.0629 481.9981 57.4796 c
+487.5946 49.3002 495.9148 40.8129 496.6648 41.3129 c
+505.264 47.0457 506.8136 49.0257 505.6648 50.8129 c
+503.4148 54.3129 501.4148 53.8129 497.4148 57.5629 c
+493.4148 61.3129 498.1648 62.8129 y
+517.9148 56.3129 521.6648 51.8129 521.6648 47.3129 c
+521.6648 43.0629 522.9148 43.3129 513.1648 38.5629 c
+504.3664 34.2765 496.9148 35.3129 496.6648 34.1462 c
+494.089 22.1264 495.8166 32.854 493.3314 21.4796 c
+490.5578 8.7849 491.9148 10.8129 y
+S619.0811 111.3127 m
+602.8311 100.0627 573.1648 84.3129 y
+574.9148 78.5629 574.9148 76.8129 v
+574.9148 75.0629 575.4148 75.3129 574.9148 73.3129 c
+574.4148 71.3129 574.4148 70.3129 572.1648 71.3129 c
+563.3464 75.2322 564.5055 75.313 555.1648 75.3129 c
+553.9148 75.3129 553.6714 84.0244 560.6648 92.5629 c
+582.1648 118.8129 585.8181 112.6814 584.1648 117.5629 c
+580.6648 127.8962 578.3314 130.2296 y
+S504.1648 11.0629 m
+504.6648 24.0629 504.9148 24.5629 y
+527.4148 28.0629 536.1648 31.5629 y
+540.1648 37.3129 l
+542.6648 32.8129 l
+542.6648 31.8129 546.1648 31.3129 v
+570.2741 27.8687 568.9148 29.5629 569.1648 28.0629 c
+569.4148 26.5629 570.1648 26.5629 y
+573.1648 26.5629 572.8314 25.4796 573.1648 24.0629 c
+573.9703 20.6396 573.4981 21.4796 574.4148 19.0629 c
+577.2633 11.553 576.9148 13.5629 577.9148 12.3129 c
+578.9148 11.0629 579.1648 10.8129 y
+S492.0811 131.3127 m
+490.0811 127.8127 488.9148 126.3129 y
+501.6648 111.8129 l
+509.4148 123.0629 l
+503.3314 127.8129 l
+503.6648 130.4796 l
+S1 M [1 4 1 4 ]0 d535.3888 11.9743 m
+535.7221 131.4743 l
+S594.2221 71.5577 m
+476.8888 71.891 l
+SUu1 Ap
+4 M []0 d358.6645 368.8131 m
+475.9979 368.8131 L
+475.9979 249.4797 L
+358.6645 249.4797 L
+358.6645 368.8131 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.3314 334.1464 m
+383.998 347.4797 371.6647 343.8964 385.3314 349.7297 c
+409.7421 360.1489 404.6647 356.1464 410.6647 354.813 c
+416.6647 353.4797 416.5814 355.4797 416.8314 353.4797 c
+417.4031 348.9055 413.3879 343.4476 403.8314 331.9797 c
+396.3314 322.9797 393.3314 320.1464 393.3314 314.813 c
+393.3314 309.4797 394.8314 312.2297 393.3314 312.1464 c
+371.8798 310.9543 372.4977 310.7281 371.3314 308.813 c
+364.5814 297.7297 363.5814 297.7297 364.6647 296.1464 c
+370.2612 287.967 378.5814 279.4797 379.3314 279.9797 c
+387.9306 285.7125 389.4802 287.6925 388.3314 289.4797 c
+386.0814 292.9797 384.0814 292.4797 380.0814 296.2297 c
+376.0814 299.9797 380.8314 301.4797 y
+400.5814 294.9797 404.3314 290.4797 404.3314 285.9797 c
+404.3314 281.7297 405.5814 281.9797 395.8314 277.2297 c
+387.033 272.9433 379.5814 273.9797 379.3314 272.813 c
+376.7556 260.7932 378.4832 271.5208 375.998 260.1464 c
+373.2244 247.4517 374.5814 249.4797 y
+S476.998 335.063 m
+457.744 328.5214 455.8314 322.9797 y
+457.5814 317.2297 457.5814 315.4797 v
+457.5814 313.7297 458.0814 313.9797 457.5814 311.9797 c
+457.0814 309.9797 457.0814 308.9797 454.8314 309.9797 c
+446.013 313.899 447.1721 313.9798 437.8314 313.9797 c
+436.5814 313.9797 436.338 322.6912 443.3314 331.2297 c
+464.8314 357.4797 468.4847 351.3482 466.8314 356.2297 c
+463.3314 366.563 460.998 368.8964 y
+S386.8314 249.7297 m
+387.3314 262.7297 387.5814 263.2297 y
+410.0814 266.7297 418.8314 270.2297 y
+422.8314 275.9797 l
+425.3314 271.4797 l
+425.3314 270.4797 428.8314 269.9797 v
+452.9407 266.5355 451.5814 268.2297 451.8314 266.7297 c
+452.0814 265.2297 452.8314 265.2297 y
+455.8314 265.2297 455.498 264.1464 455.8314 262.7297 c
+456.6369 259.3064 456.1647 260.1464 457.0814 257.7297 c
+459.9299 250.2198 459.5814 252.2297 460.5814 250.9797 c
+461.5814 249.7297 461.8314 249.4797 y
+S373.5814 368.7297 m
+371.5814 365.2297 371.5814 364.9797 y
+384.3314 350.4797 l
+392.0814 361.7297 l
+385.998 366.4797 l
+386.3314 369.1464 l
+S1 M [1 4 1 4 ]0 d418.0554 250.6411 m
+418.3887 370.1411 l
+S476.8887 310.2245 m
+359.5554 310.5578 l
+SUu1 Ap
+4 M []0 d358.6645 249.4797 m
+475.9979 249.4797 L
+475.9979 130.1463 L
+358.6645 130.1463 L
+358.6645 249.4797 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.3314 214.813 m
+383.998 228.1463 371.6647 224.563 385.3314 230.3963 c
+409.7421 240.8155 404.6647 236.813 410.6647 235.4796 c
+416.6647 234.1463 416.5814 236.1463 416.8314 234.1463 c
+417.4031 229.5721 413.3879 224.1142 403.8314 212.6463 c
+396.3314 203.6463 393.3314 200.813 393.3314 195.4796 c
+393.3314 190.1463 394.8314 192.8963 393.3314 192.813 c
+371.8798 191.6209 372.4977 191.3947 371.3314 189.4796 c
+364.5814 178.3963 363.5814 178.3963 364.6647 176.813 c
+370.2612 168.6336 378.5814 160.1463 379.3314 160.6463 c
+387.9306 166.3791 389.4802 168.3591 388.3314 170.1463 c
+386.0814 173.6463 384.0814 173.1463 380.0814 176.8963 c
+376.0814 180.6463 380.8314 182.1463 y
+400.5814 175.6463 404.3314 171.1463 404.3314 166.6463 c
+404.3314 162.3963 405.5814 162.6463 395.8314 157.8963 c
+387.033 153.6099 379.5814 154.6463 379.3314 153.4796 c
+376.7556 141.4598 378.4832 152.1874 375.998 140.813 c
+373.2244 128.1183 374.5814 130.1463 y
+S503.8311 230.3127 m
+484.5771 223.7711 455.8314 203.6463 y
+457.5814 197.8963 457.5814 196.1463 v
+457.5814 194.3963 458.0814 194.6463 457.5814 192.6463 c
+457.0814 190.6463 457.0814 189.6463 454.8314 190.6463 c
+446.013 194.5656 447.1721 194.6464 437.8314 194.6463 c
+436.5814 194.6463 436.338 203.3578 443.3314 211.8963 c
+464.8314 238.1463 468.4847 232.0148 466.8314 236.8963 c
+463.3314 247.2296 460.998 249.563 y
+S386.8314 130.3963 m
+387.3314 143.3963 387.5814 143.8963 y
+410.0814 147.3963 418.8314 150.8963 y
+422.8314 156.6463 l
+425.3314 152.1463 l
+425.3314 151.1463 428.8314 150.6463 v
+452.9407 147.2021 451.5814 148.8963 451.8314 147.3963 c
+452.0814 145.8963 452.8314 145.8963 y
+455.8314 145.8963 455.498 144.813 455.8314 143.3963 c
+456.6369 139.973 456.1647 140.813 457.0814 138.3963 c
+459.9299 130.8864 459.5814 132.8963 460.5814 131.6463 c
+461.5814 130.3963 461.8314 130.1463 y
+S373.5814 249.3963 m
+371.5814 245.8963 371.5814 245.6463 y
+384.3314 231.1463 l
+392.0814 242.3963 l
+385.998 247.1463 l
+386.3314 249.813 l
+S1 M [1 4 1 4 ]0 d418.0554 131.3077 m
+418.3887 250.8077 l
+S476.8887 190.8911 m
+359.5554 191.2244 l
+SUu1 Ap
+4 M []0 d358.6645 130.1463 m
+475.9979 130.1463 L
+475.9979 10.8129 L
+358.6645 10.8129 L
+358.6645 130.1463 L
+n0 Ap
+0 R
+0 0 0 1 K
+357.3314 95.4796 m
+383.998 108.8129 371.6647 105.2296 385.3314 111.0629 c
+409.7421 121.4821 404.6647 117.4796 410.6647 116.1462 c
+416.6647 114.8129 416.5814 116.8129 416.8314 114.8129 c
+417.4031 110.2387 413.3879 104.7808 403.8314 93.3129 c
+396.3314 84.3129 393.3314 81.4796 393.3314 76.1462 c
+393.3314 70.8129 394.8314 73.5629 393.3314 73.4796 c
+371.8798 72.2875 372.4977 72.0613 371.3314 70.1462 c
+364.5814 59.0629 363.5814 59.0629 364.6647 57.4796 c
+370.2612 49.3002 378.5814 40.8129 379.3314 41.3129 c
+387.9306 47.0457 389.4802 49.0257 388.3314 50.8129 c
+386.0814 54.3129 384.0814 53.8129 380.0814 57.5629 c
+376.0814 61.3129 380.8314 62.8129 y
+400.5814 56.3129 404.3314 51.8129 404.3314 47.3129 c
+404.3314 43.0629 405.5814 43.3129 395.8314 38.5629 c
+387.033 34.2765 379.5814 35.3129 379.3314 34.1462 c
+376.7556 22.1264 378.4832 32.854 375.998 21.4796 c
+373.2244 8.7849 374.5814 10.8129 y
+S476.998 96.3962 m
+457.744 89.8546 455.8314 84.3129 y
+457.5814 78.5629 457.5814 76.8129 v
+457.5814 75.0629 458.0814 75.3129 457.5814 73.3129 c
+457.0814 71.3129 457.0814 70.3129 454.8314 71.3129 c
+446.013 75.2322 447.1721 75.313 437.8314 75.3129 c
+436.5814 75.3129 436.338 84.0244 443.3314 92.5629 c
+464.8314 118.8129 468.4847 112.6814 466.8314 117.5629 c
+463.3314 127.8962 460.998 130.2296 y
+S386.8314 11.0629 m
+387.3314 24.0629 387.5814 24.5629 y
+410.0814 28.0629 418.8314 31.5629 y
+422.8314 37.3129 l
+425.3314 32.8129 l
+425.3314 31.8129 428.8314 31.3129 v
+452.9407 27.8687 451.5814 29.5629 451.8314 28.0629 c
+452.0814 26.5629 452.8314 26.5629 y
+455.8314 26.5629 455.498 25.4796 455.8314 24.0629 c
+456.6369 20.6396 456.1647 21.4796 457.0814 19.0629 c
+459.9299 11.553 459.5814 13.5629 460.5814 12.3129 c
+461.5814 11.0629 461.8314 10.8129 y
+S373.5814 130.0629 m
+371.5814 126.5629 371.5814 126.3129 y
+384.3314 111.8129 l
+392.0814 123.0629 l
+385.998 127.8129 l
+386.3314 130.4796 l
+S1 M [1 4 1 4 ]0 d418.0554 11.9743 m
+418.3887 131.4743 l
+S476.8887 71.5577 m
+359.5554 71.891 l
+SUQ0 A
+0 R
+0 0 0 1 K
+800 Ar
+0 J 0 j 3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+504.5811 249.896 m
+S510.3311 242.4793 m
+S502.5811 231.2293 m
+S619.4561 111.4377 m
+S606.7061 125.9377 m
+S609.0811 131.5627 m
+SU1 Ap
+1 J 4 w [1 4 1 4 ]0 d652.2754 192.75 m
+652.2754 312.25 L
+535.2754 312.25 L
+535.2754 192.75 L
+652.2754 192.75 L
+sUuu0 Ap
+1 j []0 d284 575.5 m
+293.5 578.5 309.8333 579.8333 317.8333 580.5 c
+324.5101 581.0564 333.2718 581.4359 349 579.5 c
+359.8333 578.1667 376.5 573 y
+367 586.5 l
+S376.5 573 m
+363 568 l
+SUu164.5343 364.3753 m
+161.5343 373.8753 160.201 390.2087 159.5343 398.2087 c
+158.978 404.8854 158.5984 413.6471 160.5343 429.3753 c
+161.8677 440.2087 167.0343 456.8753 y
+153.5343 447.3753 l
+S167.0343 456.8753 m
+172.0343 443.3753 l
+SUu369.2422 242.0625 m
+359.7422 239.0625 343.4089 237.7292 335.4089 237.0625 c
+328.7321 236.5061 319.9704 236.1266 304.2422 238.0625 c
+293.4089 239.3958 276.7422 244.5625 y
+286.2422 231.0625 l
+S276.7422 244.5625 m
+290.2422 249.5625 l
+SUu490 455.6667 m
+493 446.1667 494.3333 429.8333 495 421.8333 c
+495.5564 415.1566 495.9359 406.3949 494 390.6667 c
+492.6667 379.8333 487.5 363.1667 y
+501 372.6667 l
+S487.5 363.1667 m
+482.5 376.6667 l
+SUULB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_pattern_AI5 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/pegpiece.eps
+++ b/Papers/quant-ph_0405174/pegpiece.eps
@@ -1,0 +1,6575 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (pegpiece.eps)
+%%CreationDate: (12/29/2003) (7:02 PM)
+%%BoundingBox: 223 275 427 509
+%%HiResBoundingBox: 223.554 275.5926 426.6448 508.4074
+%%DocumentProcessColors: Black
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_pattern_AI5 1.0 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Black&White
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -366 852 1 1384 924 18 0 1 8 88 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_pattern_AI5 1.1 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Pattern Operators)
+%%Version: 1.1 0
+%%CreationDate: (03/26/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/@
+{
+} def
+/&
+{
+} def
+/dp
+{
+	dup null eq
+	{
+		pop
+		_dp 0 ne
+		{
+			0 1 _dp 1 sub _dl mod
+			{
+				_da exch get 3 get
+			} for
+			_dp 1 sub _dl mod 1 add packedarray
+			_da 0 get aload pop 8 -1 roll 5 -1 roll pop 4 1 roll
+			definepattern pop
+		} if
+	}
+	{
+		_dp 0 ne _dp _dl mod 0 eq and
+		{
+			null dp
+		} if
+		7 packedarray _da exch _dp _dl mod exch put
+		_dp _dl mod _da 0 get 4 get 2 packedarray
+		/_dp _dp 1 add def
+	} ifelse
+} def
+/E
+{
+	_ed begin
+	dup 0 get type /arraytype ne
+	{
+		0
+		{
+			dup 1 add index type /arraytype eq
+			{
+				1 add
+			}
+			{
+				exit
+			} ifelse
+		} loop
+		array astore
+	} if
+	/_dd exch def
+	/_ury exch def
+	/_urx exch def
+	/_lly exch def
+	/_llx exch def
+	/_n exch def
+	/_y 0 def
+	/_dl 4 def
+	/_dp 0 def
+	/_da _dl array def
+	0 1 _dd length 1 sub
+	{
+		/_d exch _dd exch get def
+		0 2 _d length 2 sub
+		{
+			/_x exch def
+			/_c _d _x get _ ne def
+			/_r _d _x 1 add get cvlit def
+			_r _ ne
+			{
+				_urx _llx sub _ury _lly sub
+				[
+				1 0 0 1 0 0
+				]
+				[
+				/save cvx
+				_llx neg _lly neg /translate cvx
+				_c
+				{
+					nc /begin cvx
+				} if
+				_r dup type /stringtype eq
+				{
+					cvx
+				}
+				{
+					{
+						exec
+					} /forall cvx
+				} ifelse
+				_c
+				{
+					/end cvx
+				} if
+				/restore cvx
+				] cvx
+				/_fn 12 _n length add string def
+				_y _fn cvs pop
+				/_y _y 1 add def
+				_fn 12 _n putinterval
+				_fn _c false dp
+				_d exch _x 1 add exch put
+			} if
+		} for
+	} for
+	null dp
+	_n _dd /_pd
+ end
+	xput
+} def
+/fc
+{
+	_fm dup concatmatrix pop
+} def
+/p
+{
+	/_fm exch ddef
+	9 -2 roll _pm translate fc
+	7 -2 roll _pm scale fc
+	5 -1 roll _pm rotate fc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate fc
+		1 -1 _pm scale fc
+		neg _pm rotate fc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate fc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore fc
+	neg _pm rotate fc
+	_pd exch get /_fdd exch ddef
+	/_pf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					patternfill
+				}
+				{
+					pop
+					fill
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_psf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					9 copy 6 npop patternashow
+				}
+				{
+					pop
+					6 copy 3 npop hvashow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		sw rmoveto
+	} ddef
+	/_pjsf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					12 copy 6 npop patternawidthshow
+				}
+				{
+					pop 9 copy 3 npop hvawidthshow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+/sc
+{
+	_sm dup concatmatrix pop
+} def
+/P
+{
+	/_sm exch ddef
+	9 -2 roll _pm translate sc
+	7 -2 roll _pm scale sc
+	5 -1 roll _pm rotate sc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate sc
+		1 -1 _pm scale sc
+		neg _pm rotate sc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate sc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore sc
+	neg _pm rotate sc
+	_pd exch get /_sdd exch ddef
+	/_ps
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					patternstroke
+				}
+				{
+					pop stroke
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_pss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					10 copy 6 npop patternashowstroke
+				}
+				{
+					pop 7 copy 3 npop ss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop sw rmoveto
+	} ddef
+	/_pjss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					13 copy 6 npop patternawidthshowstroke
+				}
+				{
+					pop 10 copy 3 npop jss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+end
+userdict /Adobe_pattern_AI5 18 dict dup begin
+put
+/initialize
+{
+	/definepattern where
+	{
+		pop
+	}
+	{
+	 begin
+	 begin
+		Adobe_pattern_AI5 begin
+		Adobe_pattern_AI5
+		{
+			dup xcheck
+			{
+				bind
+			} if
+			pop pop
+		} forall
+		mark
+		cachestatus 7 1 roll pop pop pop pop exch pop exch
+		{
+			{
+				10000 add
+				dup 2 index gt
+				{
+					exit
+				} if
+				dup setcachelimit
+			} loop
+		} stopped
+		cleartomark
+	 end 	
+		
+	 end
+	 end
+		
+		Adobe_pattern_AI5 begin
+	} ifelse
+} def
+/terminate
+{
+	currentdict Adobe_pattern_AI5 eq
+	{
+	 end
+	} if
+} def
+errordict
+/nocurrentpoint
+{
+	pop
+	stop
+} put
+errordict
+/invalidaccess
+{
+	pop
+	stop
+} put
+/patternencoding
+256 array def
+0 1 255
+{
+	patternencoding exch ( ) 2 copy exch 0 exch put cvn put
+} for
+/definepattern
+{
+	17 dict begin
+	/uniform exch def
+	/cache exch def
+	/key exch def
+	/procarray exch def
+	/mtx exch matrix invertmatrix def
+	/height exch def
+	/width exch def
+	/ctm matrix currentmatrix def
+	/ptm matrix def
+	/str 32 string def
+	/slice 9 dict def
+	slice /s 1 put
+	slice /q 256 procarray length div sqrt floor cvi put
+	slice /b 0 put
+	/FontBBox
+	[
+	0 0 0 0
+	] def
+	/FontMatrix mtx matrix copy def
+	/Encoding patternencoding def
+	/FontType 3 def
+	/BuildChar
+	{
+		exch
+	 begin
+		/setstrokeadjust where {pop true setstrokeadjust} if
+		slice begin
+		dup q dup mul mod s idiv /i exch def
+		dup q dup mul mod s mod /j exch def
+		q dup mul idiv procarray exch get
+		/xl j width s div mul def
+		/xg j 1 add width s div mul def
+		/yl i height s div mul def
+		/yg i 1 add height s div mul def
+		uniform
+		{
+			1 1
+		}
+		{
+			width 0 dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+			0 height dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+		} ifelse
+		width 0 cache
+		{
+			xl 4 index mul yl 4 index mul xg 6 index mul yg 6 index mul
+			setcachedevice
+		}
+		{
+			setcharwidth
+		} ifelse
+		gsave
+		scale
+		newpath
+		xl yl moveto
+		xg yl lineto
+		xg yg lineto
+		xl yg lineto
+		closepath
+		clip
+		newpath
+	 end
+	 end
+		exec
+		grestore
+	} def
+	key currentdict definefont
+ end
+} def
+/patterncachesize
+{
+	gsave
+	newpath
+	0 0 moveto
+	width 0 lineto
+	width height lineto
+	0 height lineto
+	closepath
+	patternmatrix setmatrix
+	pathbbox
+	exch ceiling 4 -1 roll floor sub 3 1 roll
+	ceiling exch floor sub
+	mul 1 add
+	grestore
+} def
+/patterncachelimit
+{
+	cachestatus 7 1 roll 6 npop 8 mul
+} def
+/patternpath
+{
+	exch dup begin
+	setfont
+	ctm setmatrix
+	concat
+	slice exch /b exch slice /q get dup mul mul put
+	FontMatrix concat
+	uniform
+	{
+		width 0 dtransform round width div exch round width div exch
+		0 height dtransform round height div exch height div exch
+		0 0 transform round exch round exch
+		ptm astore setmatrix
+	}
+	{
+		ptm currentmatrix pop
+	} ifelse
+	{
+		currentpoint
+	} stopped not
+	{
+		2 npop
+		pathbbox
+		true
+		4 index 3 index eq
+		4 index 3 index eq
+		and
+		{
+			pop false
+			{
+				{
+					2 npop
+				}
+				{
+					3 npop true
+				}
+				{
+					7 npop true
+				}
+				{
+					pop true
+				} pathforall
+			} stopped
+			{
+				5 npop true
+			} if
+		} if
+		{
+			height div ceiling height mul 4 1 roll
+			width div ceiling width mul 4 1 roll
+			height div floor height mul 4 1 roll
+			width div floor width mul 4 1 roll
+			2 index sub height div ceiling cvi exch
+			3 index sub width div ceiling cvi exch
+			4 2 roll moveto
+			FontMatrix mtx invertmatrix
+			dup dup 4 get exch 5 get rmoveto
+			ptm ptm concatmatrix pop
+			slice /s
+			patterncachesize patterncachelimit div ceiling sqrt ceiling cvi
+			dup slice /q get gt
+			{
+				pop slice /q get
+			} if
+			put
+			0 1 slice /s get dup mul 1 sub
+			{
+				slice /b get add
+				gsave
+				0 1 str length 1 sub
+				{
+					str exch 2 index put
+				} for
+				pop
+				dup
+				{
+					gsave
+					ptm setmatrix
+					1 index str length idiv
+					{
+						str show
+					} repeat
+					1 index str length mod str exch 0 exch getinterval show
+					grestore
+					0 height rmoveto
+				} repeat
+				grestore
+			} for
+			2 npop
+		}
+		{
+			4 npop
+		} ifelse
+	} if
+ end
+} def
+/patternclip
+{
+	_eo {eoclip} {clip} ifelse
+} def
+/patternstrokepath
+{
+	strokepath
+} def
+/patternmatrix
+matrix def
+/patternfill
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternclip
+	Adobe_pattern_AI5 /patternpath get exec
+	grestore
+	newpath
+} def
+/patternstroke
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternstrokepath
+	true
+	{
+		{
+			{
+				newpath
+				moveto
+			}
+			{
+				lineto
+			}
+			{
+				curveto
+			}
+			{
+				closepath
+				3 copy
+				Adobe_pattern_AI5 /patternfill get exec
+			} pathforall
+			3 npop
+		} stopped
+		{
+			5 npop
+			patternclip
+			Adobe_pattern_AI5 /patternfill get exec
+		} if
+	}
+	{
+		patternclip
+		Adobe_pattern_AI5 /patternfill get exec
+	} ifelse
+	grestore
+	newpath
+} def
+/vpatternawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index 5 index 5 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	3 npop
+} def
+/hpatternawidthshow
+{
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		9 index 9 index 9 index
+		Adobe_pattern_AI5 /patternfill get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	8 npop
+} def
+/patternashow
+{
+0 0 0 6 3 roll
+patternawidthshow
+} def
+/patternawidthshow
+{
+	6 index type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get 7 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshow } { vpatternawidthshow } ifelse
+} def
+/vpatternawidthshowstroke
+{
+	7 1 roll
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			3 index setmatrix
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			4 index setmatrix
+			7 index 7 index 7 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	4 npop
+} def
+/hpatternawidthshowstroke
+{
+	7 1 roll
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		7 index setmatrix
+		10 index 10 index 10 index
+		Adobe_pattern_AI5 /patternstroke get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	9 npop
+} def
+/patternashowstroke
+{
+	0 0 0 7 3 roll
+	patternawidthshowstroke
+} def
+/patternawidthshowstroke
+{
+	7 index type /dicttype eq
+	{
+		patternmatrix /patternmatrix get 8 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshowstroke } { vpatternawidthshowstroke } ifelse
+} def
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_pattern_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginPattern: (drt1)
+(drt1) 1 1 17.5 15 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.6483 11.9465 m
+9.5417 2.7082 l
+9.4995 5.3629 l
+12.5001 5.1766 l
+2.6483 11.9465 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (drt2)
+(drt2) 1 1 17.5 15 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+13.0715 12.4975 m
+3.8331 5.6041 l
+6.4879 5.6463 l
+6.3016 2.6457 l
+13.0715 12.4975 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (drt3)
+(drt3) 1 1 17 15.5 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.102 4.7198 m
+4.2086 13.9582 l
+4.2508 11.3034 l
+1.2502 11.4897 l
+11.102 4.7198 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (drt4)
+(drt4) 1 1 14.5 17.5 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+3.1366 7.4406 m
+12.375 14.334 l
+9.7202 14.2918 l
+9.9065 17.2924 l
+3.1366 7.4406 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+u0 O
+(drt2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+0 R
+0 0 0 1 K
+800 Ar
+0 J 1 j 2 w 4 M []0 d%AI3_Note:0 D
+0 XR
+402.3104 424.2276 m
+402.6363 422.9027 403.1262 424.0923 402.3104 424.2276 C
+402.3104 424.2276 L
+b329.2586 426.074 m
+328.0086 426.074 327.7653 434.7855 334.7586 443.324 c
+356.2586 469.574 359.9121 463.4425 358.2586 468.324 c
+354.7586 478.6573 353.2586 480.9074 Y
+351.3572 481.6475 348.5086 489.1574 v
+347.5921 491.5741 348.0642 490.7341 347.2586 494.1574 c
+346.9253 495.5741 347.2586 496.6574 344.2586 496.6574 C
+343.5086 496.6574 343.2586 498.1574 v
+343.0086 499.6574 344.3681 497.9632 320.2586 501.4074 c
+316.7586 501.9074 316.7586 502.9074 Y
+314.2586 507.4074 L
+310.2586 501.6574 L
+310.0901 501.5905 309.753 501.4695 V
+309.753 423.074 L
+344.0341 423.074 L
+337.5655 426.0076 337.7277 426.0741 329.2586 426.074 c
+b419.4253 466.9073 m
+413.4253 468.2407 418.5028 472.2432 394.0922 461.824 c
+380.5451 456.0417 392.5379 459.5089 366.7765 446.5839 C
+349.0635 440.2951 347.2586 435.074 Y
+349.0086 429.324 349.0086 427.574 v
+349.0086 425.824 349.5086 426.074 349.0086 424.074 c
+348.9149 423.6986 348.8385 423.3724 348.7617 423.074 C
+385.1583 423.074 L
+388.1728 423.4227 393.2589 423.7499 402.0922 424.2407 c
+402.1749 424.2453 402.2452 424.2384 402.3104 424.2276 C
+402.19 424.7173 402.0922 425.5473 402.0922 426.9073 c
+402.0922 432.2407 405.0922 435.074 412.5922 444.074 c
+422.1486 455.5419 426.1638 460.9998 425.5922 465.574 c
+425.3422 467.574 425.4253 465.574 419.4253 466.9073 c
+bU(drt1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+0 j 1 M246.7407 494.6283 m
+246.4907 494.1283 245.9907 481.1283 V
+246.0736 478.6279 L
+252.1569 473.8779 L
+245.3182 462.5449 L
+269.7288 472.9641 263.824 468.2116 269.824 466.8782 c
+275.824 465.5449 275.7407 467.5449 275.9907 465.5449 c
+276.5624 460.9707 272.5472 455.5128 262.9907 444.0449 c
+255.4907 435.0449 252.4907 432.2116 252.4907 426.8782 c
+252.4907 425.5182 252.5885 424.6882 252.7089 424.1985 C
+252.6437 424.2093 252.5735 424.2162 252.4907 424.2116 c
+243.6574 423.7207 238.5714 423.3936 235.5569 423.0449 C
+276.9849 423.0449 L
+276.9849 501.2653 L
+274.1219 500.2838 264.9223 497.4566 246.7407 494.6283 C
+b(drt4) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+231.5863 393.8426 m
+224.8363 382.7593 223.8363 382.7593 224.9196 381.176 c
+230.516 372.9966 238.8363 364.5093 239.5863 365.0093 c
+248.1855 370.7421 249.7351 372.7221 248.5863 374.5093 c
+246.3363 378.0093 244.3363 377.5093 240.3363 381.2593 c
+236.3363 385.0093 241.0863 386.5093 Y
+260.8363 380.0093 264.5863 375.5093 264.5863 371.0093 c
+264.5863 366.7593 265.8363 367.0093 256.0863 362.2593 c
+247.2879 357.9729 239.8363 359.0093 239.5863 357.8426 c
+237.0104 345.8228 238.738 356.5504 236.2528 345.176 c
+234.7414 338.2579 234.4573 335.7161 234.5111 334.8318 C
+232.8182 331.9471 231.8363 330.6759 Y
+244.5863 316.1759 L
+252.3363 327.4259 L
+246.2528 332.1759 L
+246.5863 334.8426 L
+247.0863 334.7593 L
+247.5863 347.7593 247.8363 348.2593 Y
+266.0178 351.0875 275.2174 353.9147 278.0805 354.8962 C
+278.0805 396.0093 L
+236.6525 396.0093 L
+232.3462 395.5112 232.2723 394.9691 231.5863 393.8426 c
+b(drt3) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+383.8816 395.5926 m
+347.485 395.5926 L
+347.1526 394.3016 346.8097 393.7803 344.9821 394.5926 c
+344.1591 394.9584 343.4232 395.2906 342.7574 395.5926 C
+307.9763 395.5926 L
+307.9763 354.4796 L
+308.6563 354.7127 308.9821 354.8426 Y
+312.9821 360.5926 L
+315.4821 356.0926 L
+315.4821 355.0926 318.9821 354.5926 v
+343.0914 351.1484 341.7321 352.8426 341.9821 351.3426 c
+342.2321 349.8426 342.9821 349.8426 Y
+345.9821 349.8426 345.6487 348.7593 345.9821 347.3426 c
+346.7875 343.9193 346.3153 344.7593 347.2321 342.3426 c
+350.0805 334.8327 349.7321 336.8426 350.7321 335.5926 c
+351.7321 334.3426 351.9821 334.0926 Y
+353.4821 331.8425 356.9821 321.5092 v
+358.6354 316.6277 354.9821 322.7592 333.4821 296.5092 c
+326.4887 287.9707 326.7321 279.2592 327.9821 279.2592 c
+336.1165 279.2593 336.2904 279.1969 342.023 276.5926 C
+347.5709 276.5926 L
+347.6209 276.8004 347.6726 277.0216 347.7321 277.2592 c
+348.2321 279.2592 347.7321 279.0092 347.7321 280.7592 c
+347.7321 282.5092 345.9821 288.2592 Y
+375.6484 304.009 391.8984 315.259 V
+392.2734 315.384 L
+379.5234 329.884 L
+379.8934 331.5928 383.4821 344.7593 v
+386.5438 355.9922 384.2397 345.4061 386.8155 357.4259 c
+387.0655 358.5926 394.5171 357.5562 403.3155 361.8426 c
+413.0655 366.5926 411.8155 366.3426 411.8155 370.5926 c
+411.8155 375.0926 408.0655 379.5926 388.3155 386.0926 C
+383.5655 384.5926 387.5655 380.8426 v
+391.5655 377.0926 393.5655 377.5926 395.8155 374.0926 c
+396.9643 372.3054 395.4147 370.3254 386.8155 364.5926 c
+386.0655 364.0926 377.7453 372.5799 372.1488 380.7593 c
+371.0655 382.3426 372.0655 382.3426 378.8155 393.4259 c
+379.5015 394.5524 379.5754 395.0945 383.8816 395.5926 C
+bLB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_pattern_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/peribound.eps
+++ b/Papers/quant-ph_0405174/peribound.eps
@@ -1,0 +1,6757 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (Vorname Nachname) (Firma)
+%%Title: (peribound.eps)
+%%CreationDate: (12/17/2003) (5:51 PM)
+%%BoundingBox: 93 286 519 662
+%%HiResBoundingBox: 93 286.5 519 661.5
+%%DocumentProcessColors: Cyan Magenta Yellow Black
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_pattern_AI5 1.0 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Color
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: 18 672 2 1384 924 18 0 1 143 149 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_pattern_AI5 1.1 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Pattern Operators)
+%%Version: 1.1 0
+%%CreationDate: (03/26/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/@
+{
+} def
+/&
+{
+} def
+/dp
+{
+	dup null eq
+	{
+		pop
+		_dp 0 ne
+		{
+			0 1 _dp 1 sub _dl mod
+			{
+				_da exch get 3 get
+			} for
+			_dp 1 sub _dl mod 1 add packedarray
+			_da 0 get aload pop 8 -1 roll 5 -1 roll pop 4 1 roll
+			definepattern pop
+		} if
+	}
+	{
+		_dp 0 ne _dp _dl mod 0 eq and
+		{
+			null dp
+		} if
+		7 packedarray _da exch _dp _dl mod exch put
+		_dp _dl mod _da 0 get 4 get 2 packedarray
+		/_dp _dp 1 add def
+	} ifelse
+} def
+/E
+{
+	_ed begin
+	dup 0 get type /arraytype ne
+	{
+		0
+		{
+			dup 1 add index type /arraytype eq
+			{
+				1 add
+			}
+			{
+				exit
+			} ifelse
+		} loop
+		array astore
+	} if
+	/_dd exch def
+	/_ury exch def
+	/_urx exch def
+	/_lly exch def
+	/_llx exch def
+	/_n exch def
+	/_y 0 def
+	/_dl 4 def
+	/_dp 0 def
+	/_da _dl array def
+	0 1 _dd length 1 sub
+	{
+		/_d exch _dd exch get def
+		0 2 _d length 2 sub
+		{
+			/_x exch def
+			/_c _d _x get _ ne def
+			/_r _d _x 1 add get cvlit def
+			_r _ ne
+			{
+				_urx _llx sub _ury _lly sub
+				[
+				1 0 0 1 0 0
+				]
+				[
+				/save cvx
+				_llx neg _lly neg /translate cvx
+				_c
+				{
+					nc /begin cvx
+				} if
+				_r dup type /stringtype eq
+				{
+					cvx
+				}
+				{
+					{
+						exec
+					} /forall cvx
+				} ifelse
+				_c
+				{
+					/end cvx
+				} if
+				/restore cvx
+				] cvx
+				/_fn 12 _n length add string def
+				_y _fn cvs pop
+				/_y _y 1 add def
+				_fn 12 _n putinterval
+				_fn _c false dp
+				_d exch _x 1 add exch put
+			} if
+		} for
+	} for
+	null dp
+	_n _dd /_pd
+ end
+	xput
+} def
+/fc
+{
+	_fm dup concatmatrix pop
+} def
+/p
+{
+	/_fm exch ddef
+	9 -2 roll _pm translate fc
+	7 -2 roll _pm scale fc
+	5 -1 roll _pm rotate fc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate fc
+		1 -1 _pm scale fc
+		neg _pm rotate fc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate fc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore fc
+	neg _pm rotate fc
+	_pd exch get /_fdd exch ddef
+	/_pf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					patternfill
+				}
+				{
+					pop
+					fill
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_psf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					9 copy 6 npop patternashow
+				}
+				{
+					pop
+					6 copy 3 npop hvashow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		sw rmoveto
+	} ddef
+	/_pjsf
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _fdd length 1 sub
+		{
+			/_fd exch _fdd exch get ddef
+			_fd
+			0 2 _fd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _fc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _fm
+					12 copy 6 npop patternawidthshow
+				}
+				{
+					pop 9 copy 3 npop hvawidthshow
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+/sc
+{
+	_sm dup concatmatrix pop
+} def
+/P
+{
+	/_sm exch ddef
+	9 -2 roll _pm translate sc
+	7 -2 roll _pm scale sc
+	5 -1 roll _pm rotate sc
+	4 -2 roll exch 0 ne
+	{
+		dup _pm rotate sc
+		1 -1 _pm scale sc
+		neg _pm rotate sc
+	}
+	{
+		pop
+	} ifelse
+	dup _pm rotate sc
+	exch dup sin exch cos div 1 0 0 1 0 6 2 roll
+	_pm astore sc
+	neg _pm rotate sc
+	_pd exch get /_sdd exch ddef
+	/_ps
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					patternstroke
+				}
+				{
+					pop stroke
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		newpath
+	} ddef
+	/_pss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					10 copy 6 npop patternashowstroke
+				}
+				{
+					pop 7 copy 3 npop ss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop sw rmoveto
+	} ddef
+	/_pjss
+	{
+		save
+		/_doClip 0 ddef
+		0 1 _sdd length 1 sub
+		{
+			/_sd exch _sdd exch get ddef
+			_sd
+			0 2 _sd length 2 sub
+			{
+				gsave
+				2 copy get dup _ ne
+				{
+					cvx exec _sc
+				}
+				{
+					pop
+				} ifelse
+				2 copy 1 add get dup _ ne
+				{
+					aload pop findfont _sm
+					13 copy 6 npop patternawidthshowstroke
+				}
+				{
+					pop 10 copy 3 npop jss
+				} ifelse
+				grestore
+				pop
+			} for
+			pop
+		} for
+		restore
+		pop swj rmoveto
+	} ddef
+	/_lp /none ddef
+} def
+end
+userdict /Adobe_pattern_AI5 18 dict dup begin
+put
+/initialize
+{
+	/definepattern where
+	{
+		pop
+	}
+	{
+	 begin
+	 begin
+		Adobe_pattern_AI5 begin
+		Adobe_pattern_AI5
+		{
+			dup xcheck
+			{
+				bind
+			} if
+			pop pop
+		} forall
+		mark
+		cachestatus 7 1 roll pop pop pop pop exch pop exch
+		{
+			{
+				10000 add
+				dup 2 index gt
+				{
+					exit
+				} if
+				dup setcachelimit
+			} loop
+		} stopped
+		cleartomark
+	 end 	
+		
+	 end
+	 end
+		
+		Adobe_pattern_AI5 begin
+	} ifelse
+} def
+/terminate
+{
+	currentdict Adobe_pattern_AI5 eq
+	{
+	 end
+	} if
+} def
+errordict
+/nocurrentpoint
+{
+	pop
+	stop
+} put
+errordict
+/invalidaccess
+{
+	pop
+	stop
+} put
+/patternencoding
+256 array def
+0 1 255
+{
+	patternencoding exch ( ) 2 copy exch 0 exch put cvn put
+} for
+/definepattern
+{
+	17 dict begin
+	/uniform exch def
+	/cache exch def
+	/key exch def
+	/procarray exch def
+	/mtx exch matrix invertmatrix def
+	/height exch def
+	/width exch def
+	/ctm matrix currentmatrix def
+	/ptm matrix def
+	/str 32 string def
+	/slice 9 dict def
+	slice /s 1 put
+	slice /q 256 procarray length div sqrt floor cvi put
+	slice /b 0 put
+	/FontBBox
+	[
+	0 0 0 0
+	] def
+	/FontMatrix mtx matrix copy def
+	/Encoding patternencoding def
+	/FontType 3 def
+	/BuildChar
+	{
+		exch
+	 begin
+		/setstrokeadjust where {pop true setstrokeadjust} if
+		slice begin
+		dup q dup mul mod s idiv /i exch def
+		dup q dup mul mod s mod /j exch def
+		q dup mul idiv procarray exch get
+		/xl j width s div mul def
+		/xg j 1 add width s div mul def
+		/yl i height s div mul def
+		/yg i 1 add height s div mul def
+		uniform
+		{
+			1 1
+		}
+		{
+			width 0 dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+			0 height dtransform
+			dup mul exch dup mul add sqrt dup 1 add exch div
+		} ifelse
+		width 0 cache
+		{
+			xl 4 index mul yl 4 index mul xg 6 index mul yg 6 index mul
+			setcachedevice
+		}
+		{
+			setcharwidth
+		} ifelse
+		gsave
+		scale
+		newpath
+		xl yl moveto
+		xg yl lineto
+		xg yg lineto
+		xl yg lineto
+		closepath
+		clip
+		newpath
+	 end
+	 end
+		exec
+		grestore
+	} def
+	key currentdict definefont
+ end
+} def
+/patterncachesize
+{
+	gsave
+	newpath
+	0 0 moveto
+	width 0 lineto
+	width height lineto
+	0 height lineto
+	closepath
+	patternmatrix setmatrix
+	pathbbox
+	exch ceiling 4 -1 roll floor sub 3 1 roll
+	ceiling exch floor sub
+	mul 1 add
+	grestore
+} def
+/patterncachelimit
+{
+	cachestatus 7 1 roll 6 npop 8 mul
+} def
+/patternpath
+{
+	exch dup begin
+	setfont
+	ctm setmatrix
+	concat
+	slice exch /b exch slice /q get dup mul mul put
+	FontMatrix concat
+	uniform
+	{
+		width 0 dtransform round width div exch round width div exch
+		0 height dtransform round height div exch height div exch
+		0 0 transform round exch round exch
+		ptm astore setmatrix
+	}
+	{
+		ptm currentmatrix pop
+	} ifelse
+	{
+		currentpoint
+	} stopped not
+	{
+		2 npop
+		pathbbox
+		true
+		4 index 3 index eq
+		4 index 3 index eq
+		and
+		{
+			pop false
+			{
+				{
+					2 npop
+				}
+				{
+					3 npop true
+				}
+				{
+					7 npop true
+				}
+				{
+					pop true
+				} pathforall
+			} stopped
+			{
+				5 npop true
+			} if
+		} if
+		{
+			height div ceiling height mul 4 1 roll
+			width div ceiling width mul 4 1 roll
+			height div floor height mul 4 1 roll
+			width div floor width mul 4 1 roll
+			2 index sub height div ceiling cvi exch
+			3 index sub width div ceiling cvi exch
+			4 2 roll moveto
+			FontMatrix mtx invertmatrix
+			dup dup 4 get exch 5 get rmoveto
+			ptm ptm concatmatrix pop
+			slice /s
+			patterncachesize patterncachelimit div ceiling sqrt ceiling cvi
+			dup slice /q get gt
+			{
+				pop slice /q get
+			} if
+			put
+			0 1 slice /s get dup mul 1 sub
+			{
+				slice /b get add
+				gsave
+				0 1 str length 1 sub
+				{
+					str exch 2 index put
+				} for
+				pop
+				dup
+				{
+					gsave
+					ptm setmatrix
+					1 index str length idiv
+					{
+						str show
+					} repeat
+					1 index str length mod str exch 0 exch getinterval show
+					grestore
+					0 height rmoveto
+				} repeat
+				grestore
+			} for
+			2 npop
+		}
+		{
+			4 npop
+		} ifelse
+	} if
+ end
+} def
+/patternclip
+{
+	_eo {eoclip} {clip} ifelse
+} def
+/patternstrokepath
+{
+	strokepath
+} def
+/patternmatrix
+matrix def
+/patternfill
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternclip
+	Adobe_pattern_AI5 /patternpath get exec
+	grestore
+	newpath
+} def
+/patternstroke
+{
+	dup type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get
+	} if
+	gsave
+	patternstrokepath
+	true
+	{
+		{
+			{
+				newpath
+				moveto
+			}
+			{
+				lineto
+			}
+			{
+				curveto
+			}
+			{
+				closepath
+				3 copy
+				Adobe_pattern_AI5 /patternfill get exec
+			} pathforall
+			3 npop
+		} stopped
+		{
+			5 npop
+			patternclip
+			Adobe_pattern_AI5 /patternfill get exec
+		} if
+	}
+	{
+		patternclip
+		Adobe_pattern_AI5 /patternfill get exec
+	} ifelse
+	grestore
+	newpath
+} def
+/vpatternawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index 5 index 5 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternfill get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	3 npop
+} def
+/hpatternawidthshow
+{
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		9 index 9 index 9 index
+		Adobe_pattern_AI5 /patternfill get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	8 npop
+} def
+/patternashow
+{
+0 0 0 6 3 roll
+patternawidthshow
+} def
+/patternawidthshow
+{
+	6 index type /dicttype eq
+	{
+		Adobe_pattern_AI5 /patternmatrix get 7 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshow } { vpatternawidthshow } ifelse
+} def
+/vpatternawidthshowstroke
+{
+	7 1 roll
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			3 index setmatrix
+			6 index 6 index 6 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_hvwb eq { _hvcx _hvcy rmoveto } if
+			_hvax _hvay rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			_hvax sub
+			3 index _hvwb eq { _hvcx sub } if
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+			gsave
+			2 index false charpath
+			4 index setmatrix
+			7 index 7 index 7 index Adobe_pattern_AI5 /patternstroke get exec
+			grestore
+			newpath moveto pop pop
+		} ifelse
+	} cforall
+	4 npop
+} def
+/hpatternawidthshowstroke
+{
+	7 1 roll
+	{
+		dup cstring exch
+		gsave
+		3 index eq { 5 index 5 index rmoveto } if
+		false charpath currentpoint
+		7 index setmatrix
+		10 index 10 index 10 index
+		Adobe_pattern_AI5 /patternstroke get exec
+		grestore
+		newpath moveto
+		2 copy rmoveto
+	} cforall
+	9 npop
+} def
+/patternashowstroke
+{
+	0 0 0 7 3 roll
+	patternawidthshowstroke
+} def
+/patternawidthshowstroke
+{
+	7 index type /dicttype eq
+	{
+		patternmatrix /patternmatrix get 8 1 roll
+	} if
+	_lineorientation 0 eq { hpatternawidthshowstroke } { vpatternawidthshowstroke } ifelse
+} def
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_pattern_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginPattern: (shrfk1)
+(shrfk1) 1.05 1.0386 9.1999 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+9.1749 1.0193 m
+9.1749 13.6004 L
+1.025 13.6004 L
+1.025 1.0193 L
+9.1749 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.3871 13.5908 m
+1 13.5908 L
+1 12.902 L
+8.7285 1.0097 L
+9.1499 1.0097 L
+9.1499 1.6457 L
+1.3871 13.5908 L
+f9.1499 12.9743 m
+9.1499 13.6197 L
+8.7305 13.6197 L
+9.1499 12.9743 L
+f1 1.5733 m
+1 1 L
+1.3726 1 L
+1 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrfk2)
+(shrfk2) 1 1.0386 9.1499 13.6197 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.025 1.0193 m
+1.025 13.6004 L
+9.1749 13.6004 L
+9.1749 1.0193 L
+1.025 1.0193 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.8128 13.5908 m
+9.1999 13.5908 L
+9.1999 12.902 L
+1.4714 1.0096 L
+1.05 1.0096 L
+1.05 1.6457 L
+8.8128 13.5908 L
+f1.05 12.9743 m
+1.05 13.6197 L
+1.4694 13.6197 L
+1.05 12.9743 L
+f9.1999 1.5733 m
+9.1999 1 L
+8.8273 1 L
+9.1999 1.5733 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrf2)
+(shrf2) 1.125 1.0833 21.5 28.2083 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+21.4375 1.0416 m
+21.4375 28.1666 L
+1.0625 28.1666 L
+1.0625 1.0416 L
+21.4375 1.0416 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.9679 28.1458 m
+1 28.1458 L
+1 26.6608 L
+20.3215 1.0208 L
+21.375 1.0208 L
+21.375 2.3921 L
+1.9679 28.1458 L
+f21.375 26.8168 m
+21.375 28.2083 L
+20.3264 28.2083 L
+21.375 26.8168 L
+f1 2.2361 m
+1 1 L
+1.9315 1 L
+1 2.2361 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (shrf3)
+(shrf3) 1 1.0833 21.375 28.2083 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0 k
+ 0 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0625 1.0416 m
+1.0625 28.1666 L
+21.4375 28.1666 L
+21.4375 1.0416 L
+1.0625 1.0416 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.5321 28.1458 m
+21.5 28.1458 L
+21.5 26.6608 L
+2.1785 1.0208 L
+1.125 1.0208 L
+1.125 2.3921 L
+20.5321 28.1458 L
+f1.125 26.8168 m
+1.125 28.2083 L
+2.1736 28.2083 L
+1.125 26.8168 L
+f21.5 2.2361 m
+21.5 1 L
+20.5685 1 L
+21.5 2.2361 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+(shrf2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrf2) Pc
+(shrf3) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrf3) Pc
+(shrfk1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrfk1) Pc
+(shrfk2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(shrfk2) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+q1 Ap
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+519 286.5 m
+519 661.5 L
+93 661.5 L
+93 286.5 L
+519 286.5 L
+hWnuuu0 Ap
+0 O
+0.0274 0.0196 0.5059 0 k
+0 R
+0 0 0 1 K
+1 j 2 w74.8844 707.8862 m
+74.8844 236.8191 l
+B346.5093 707.8862 m
+346.5093 236.8191 l
+B230.0986 707.8862 m
+230.0986 236.8191 l
+B268.9022 707.8862 m
+268.9022 236.8191 l
+B152.4915 707.8862 m
+152.4915 236.8191 l
+B191.295 707.8862 m
+191.295 236.8191 l
+B462.9199 707.8862 m
+462.9199 236.8191 l
+B385.3128 707.8862 m
+385.3128 236.8191 l
+B113.6879 707.8862 m
+113.6879 236.8191 l
+B540.5271 707.8862 m
+540.5271 236.8191 l
+B424.1164 707.8862 m
+424.1164 236.8191 l
+B501.7235 707.8862 m
+501.7235 236.8191 l
+B307.7057 707.8862 m
+307.7057 236.8191 l
+BUu46 414.1473 m
+569.4114 414.1473 l
+B46 297.7366 m
+569.4114 297.7366 l
+B46 336.5402 m
+569.4114 336.5402 l
+B46 258.9331 m
+569.4114 258.9331 l
+B46 685.7722 m
+569.4114 685.7722 l
+B46 530.558 m
+569.4114 530.558 l
+B46 646.9687 m
+569.4114 646.9687 l
+B46 452.9509 m
+569.4114 452.9509 l
+B46 608.1651 m
+569.4114 608.1651 l
+B46 491.7544 m
+569.4114 491.7544 l
+B46 569.3616 m
+569.4114 569.3616 l
+B46 375.3438 m
+569.4114 375.3438 l
+BUU*u
+0 0 0 0 k
+1 D
+38.9166 715.25 m
+38.9166 225.25 L
+575.9166 225.25 L
+575.9166 715.25 L
+38.9166 715.25 L
+b0 D
+424.9166 414.25 m
+114.9166 298.25 L
+190.9166 530.25 L
+501.9166 647.25 L
+424.9166 414.25 L
+b*U
+uu0 j 1 w [1 8 ]0 d75.1762 708.2627 m
+75.1762 237.1956 l
+S346.8011 708.2627 m
+346.8011 237.1956 l
+S230.3904 708.2627 m
+230.3904 237.1956 l
+S269.194 708.2627 m
+269.194 237.1956 l
+S152.7833 708.2627 m
+152.7833 237.1956 l
+S191.5868 708.2627 m
+191.5868 237.1956 l
+S463.2117 708.2627 m
+463.2117 237.1956 l
+S385.6046 708.2627 m
+385.6046 237.1956 l
+S113.9797 708.2627 m
+113.9797 237.1956 l
+S540.8189 708.2627 m
+540.8189 237.1956 l
+S424.4082 708.2627 m
+424.4082 237.1956 l
+S502.0153 708.2627 m
+502.0153 237.1956 l
+S307.9975 708.2627 m
+307.9975 237.1956 l
+SUu46.2918 414.5238 m
+569.7032 414.5238 l
+S46.2918 298.1131 m
+569.7032 298.1131 l
+S46.2918 336.9167 m
+569.7032 336.9167 l
+S47.2918 260.3096 m
+570.7032 260.3096 l
+S46.2918 686.1487 m
+569.7032 686.1487 l
+S46.2918 530.9345 m
+569.7032 530.9345 l
+S46.2918 647.3452 m
+569.7032 647.3452 l
+S46.2918 453.3274 m
+569.7032 453.3274 l
+S46.2918 608.5416 m
+569.7032 608.5416 l
+S46.2918 492.1309 m
+569.7032 492.1309 l
+S46.2918 569.7381 m
+569.7032 569.7381 l
+S46.2918 375.7203 m
+569.7032 375.7203 l
+SUU0 O
+0.0274 0.0196 0.5059 0 k
+1 j 2 w []0 d674.5 298 m
+B(shrfk1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+0 j 4 w229.875 491.6561 m
+346.375 491.4061 l
+346.375 414.6561 l
+268.375 413.9061 l
+268.125 374.9061 l
+307.875 375.1561 l
+307.875 452.9061 l
+229.375 452.6561 l
+229.875 491.6561 l
+buu(shrfk2) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+3 w151.5 375.7234 m
+140.4777 375.6174 L
+127.6448 336.4436 L
+151.5 336.5936 L
+151.5 375.7234 L
+b190 452.8436 m
+165.7929 452.8955 L
+151.5 409.2647 L
+151.5 375.7234 L
+190 376.0936 L
+190 452.8436 L
+bUu425.0625 491.6561 m
+424.8125 452.6561 L
+436.3668 452.7288 L
+449.3083 491.8892 L
+425.0625 491.6561 L
+b386.5625 569.4061 m
+386.0625 530.4061 L
+462.1171 530.6483 L
+474.8628 569.2166 L
+386.5625 569.4061 L
+bUUUQ0 A
+u0 O
+0.0274 0.88 0.5059 0 k
+0 R
+0 0 0 1 K
+800 Ar
+0 J 1 j 2 w 4 M []0 d%AI3_Note:0 D
+0 XR
+120.3414 311.2527 m
+116 298 L
+128.6151 302.7205 L
+127.1467 306.5784 124.145 309.6769 120.3414 311.2527 C
+b430.3936 427.2947 m
+428.584 428.0689 426.5927 428.5 424.5 428.5 c
+416.2159 428.5 409.5 421.7842 409.5 413.5 c
+409.5 411.6291 409.858 409.8456 410.4838 408.194 C
+426 414 L
+430.3936 427.2947 L
+b207.5 530.5 m
+207.5 532.257 207.1822 533.936 206.6271 535.5028 C
+192 530 L
+187.5318 516.3602 L
+189.0888 515.8129 190.756 515.5 192.5 515.5 c
+200.7842 515.5 207.5 522.2159 207.5 530.5 c
+b488.3729 641.4972 m
+489.9506 637.0438 493.5578 633.5521 498.0958 632.1599 C
+503 647 L
+488.3729 641.4972 L
+bULB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_pattern_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/qbit.eps
+++ b/Papers/quant-ph_0405174/qbit.eps
@@ -1,0 +1,6961 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (U Schomaecker) (TU Braunschweig)
+%%Title: (qbit.eps)
+%%CreationDate: (4/26/2003) (6:26 PM)
+%%BoundingBox: 87 521 317 780
+%%HiResBoundingBox: 87 521 316.6036 779.8332
+%%DocumentProcessColors: Black
+%%DocumentFonts: Euclid-Italic
+%%+ SymbolMT
+%%DocumentSuppliedFonts: Euclid-Italic
+%%+ SymbolMT
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_typography_AI5 1.0 1
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Black&White
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -110 812 1.5 1008 646 18 0 1 8 80 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginResource: procset Adobe_typography_AI5 1.0 1
+%%Title: (Typography Operators)
+%%Version: 1.0 1
+%%CreationDate:(6/10/1996) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginRider
+currentpacking true setpacking
+%%BeginFont: Euclid-Italic
+/Euclid-Italic
+15 dict dup begin
+/FontName /Euclid-Italic def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 986 def
+/FontDescent -324 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+9 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K28 {
+{
+newpath
+542 751 m
+502 719 467 683 437 645 c
+406 607 380 566 357 524 c
+334 481 314 437 298 392 c
+282 347 268 302 257 256 c
+245 210 237 165 230 119 c
+224 74 222 30 223 -12 c
+225 -55 231 -95 242 -134 c
+253 -172 271 -207 294 -239 c
+295 -242 296 -244 295 -246 c
+295 -248 293 -251 290 -253 c
+288 -255 285 -256 283 -256 c
+280 -256 l
+278 -256 276 -255 275 -254 c
+245 -223 223 -187 207 -148 c
+191 -110 181 -68 176 -24 c
+171 20 170 66 175 113 c
+180 161 188 208 200 256 c
+212 304 228 351 247 398 c
+266 445 289 491 316 535 c
+343 579 374 621 409 660 c
+444 699 484 735 528 766 c
+531 767 534 768 536 768 c
+540 768 543 767 545 765 c
+546 762 547 760 546 758 c
+546 756 544 753 542 751 c
+542 751 l
+closepath
+} exec
+fill
+} bind def
+/K29 {
+{
+newpath
+317 113 m
+298 66 275 20 248 -24 c
+221 -68 190 -110 155 -148 c
+120 -187 80 -223 35 -254 c
+31 -255 29 -256 28 -256 c
+24 -256 20 -255 19 -253 c
+17 -252 17 -249 18 -246 c
+18 -244 19 -241 22 -239 c
+62 -207 97 -172 127 -134 c
+157 -95 184 -55 207 -12 c
+230 30 249 74 265 119 c
+281 165 295 210 307 256 c
+318 302 327 347 333 392 c
+340 437 342 481 341 524 c
+339 566 333 607 322 645 c
+310 683 293 719 270 751 c
+269 753 268 755 269 758 c
+270 760 271 763 273 765 c
+276 767 278 768 281 768 c
+284 768 l
+286 768 288 767 289 766 c
+319 735 341 699 357 660 c
+373 621 383 579 388 535 c
+393 491 394 445 389 398 c
+384 351 376 304 364 256 c
+352 208 336 161 317 113 c
+closepath
+} exec
+fill
+} bind def
+/K43 {
+{
+newpath
+771 438 m
+770 431 766 428 759 428 c
+748 428 l
+742 428 739 431 741 438 c
+746 471 747 502 744 533 c
+741 563 734 590 722 613 c
+710 636 694 655 673 669 c
+653 683 628 690 598 690 c
+563 690 527 681 492 664 c
+456 646 424 622 396 593 c
+362 558 336 520 317 478 c
+298 437 284 394 273 351 c
+261 306 254 263 252 222 c
+250 180 257 142 274 107 c
+287 78 308 54 334 37 c
+361 19 392 10 428 10 c
+458 10 487 16 515 29 c
+543 42 569 60 593 82 c
+616 104 637 129 654 157 c
+672 186 684 217 693 249 c
+694 255 698 259 705 259 c
+716 259 l
+723 259 725 255 723 249 c
+714 212 700 178 679 146 c
+659 113 635 85 607 60 c
+579 36 548 16 514 1 c
+481 -14 446 -22 411 -22 c
+366 -22 326 -12 291 7 c
+255 27 227 53 205 87 c
+183 124 169 165 165 210 c
+160 255 164 302 175 350 c
+188 398 207 445 235 490 c
+262 535 296 576 337 613 c
+375 646 417 673 462 692 c
+507 712 552 722 597 722 c
+633 722 663 714 688 698 c
+713 682 732 661 747 634 c
+820 717 l
+822 720 825 722 829 722 c
+833 722 l
+839 722 841 719 840 712 c
+771 438 l
+closepath
+} exec
+fill
+} bind def
+/K4C {
+{
+newpath
+554 10 m
+551 3 547 0 539 0 c
+72 0 l
+69 0 66 1 65 3 c
+63 5 63 8 64 11 c
+66 20 l
+67 23 68 26 71 28 c
+74 31 77 32 80 32 c
+96 32 111 32 125 33 c
+139 33 150 35 157 38 c
+165 42 171 52 175 69 c
+316 632 l
+320 648 319 658 313 662 c
+307 665 298 667 284 668 c
+270 669 255 669 239 669 c
+236 669 233 670 231 672 c
+230 674 230 677 231 680 c
+233 688 l
+236 696 241 700 247 700 c
+293 698 339 697 385 697 c
+431 697 478 698 525 700 c
+528 700 531 699 533 697 c
+534 695 534 692 533 688 c
+531 680 l
+530 677 529 674 526 672 c
+523 670 520 669 517 669 c
+498 669 480 669 461 668 c
+442 667 428 665 418 662 c
+409 658 402 648 398 632 c
+258 69 l
+253 51 251 40 253 36 c
+256 33 267 32 285 32 c
+373 32 l
+397 32 421 36 445 43 c
+470 50 492 62 512 79 c
+535 99 555 124 569 156 c
+583 187 597 220 609 253 c
+611 260 615 263 622 263 c
+631 263 l
+638 263 641 260 640 252 c
+554 10 l
+closepath
+} exec
+fill
+} bind def
+/K50 {
+{
+newpath
+706 436 m
+688 413 668 394 644 377 c
+618 359 590 345 561 336 c
+531 327 502 322 474 322 c
+321 322 l
+258 69 l
+253 52 254 42 260 38 c
+265 35 275 33 289 33 c
+303 32 318 32 333 32 c
+341 32 344 28 343 20 c
+341 11 l
+338 4 333 0 326 0 c
+242 4 158 4 73 0 c
+66 0 63 4 64 11 c
+66 20 l
+68 28 73 32 80 32 c
+96 32 111 32 125 33 c
+140 33 151 35 158 38 c
+166 43 172 53 176 69 c
+316 631 l
+320 648 319 658 314 661 c
+308 664 299 666 285 667 c
+271 668 256 668 240 668 c
+233 668 230 672 231 680 c
+234 688 l
+235 696 240 700 247 700 c
+568 700 l
+597 700 623 695 648 686 c
+672 677 693 663 711 645 c
+727 627 738 607 743 583 c
+749 560 749 535 742 509 c
+735 483 723 459 706 436 c
+closepath
+656 571 m
+658 591 654 609 644 625 c
+632 641 617 652 598 658 c
+578 665 558 668 536 668 c
+442 668 l
+423 668 412 666 408 663 c
+404 659 400 649 396 631 c
+325 350 l
+456 350 l
+478 350 500 353 523 360 c
+545 366 566 377 585 393 c
+603 409 616 427 625 447 c
+633 468 640 488 646 509 c
+651 530 655 550 656 571 c
+closepath
+} exec
+fill
+} bind def
+/K52 {
+{
+newpath
+725 54 m
+718 40 709 28 699 16 c
+689 5 677 -4 665 -11 c
+652 -18 639 -22 624 -22 c
+577 -22 542 -9 519 16 c
+495 41 490 77 501 124 c
+524 214 l
+528 231 529 247 527 262 c
+525 278 520 291 512 302 c
+504 314 494 322 482 329 c
+470 335 455 339 439 339 c
+322 339 l
+255 69 l
+250 53 251 43 258 39 c
+263 35 273 33 287 33 c
+301 33 316 33 331 33 c
+339 33 342 28 340 20 c
+337 12 l
+335 4 330 1 323 1 c
+241 5 157 5 73 1 c
+66 1 63 4 64 12 c
+66 20 l
+68 28 73 33 80 33 c
+96 33 111 33 125 33 c
+140 33 151 35 158 39 c
+166 43 172 54 176 69 c
+316 632 l
+320 649 319 659 314 661 c
+308 665 299 667 285 668 c
+271 668 256 669 240 669 c
+233 669 230 672 231 680 c
+234 689 l
+235 697 240 701 247 701 c
+529 701 l
+560 701 590 696 618 688 c
+646 679 670 665 691 646 c
+708 630 720 611 729 589 c
+737 566 737 542 731 516 c
+725 490 712 467 692 445 c
+673 424 651 406 626 391 c
+609 381 592 372 574 365 c
+556 359 539 353 521 349 c
+549 338 571 321 587 299 c
+604 277 610 250 607 217 c
+598 127 l
+593 88 593 57 596 34 c
+598 12 610 1 630 1 c
+648 1 664 10 678 29 c
+692 47 702 70 709 97 c
+712 104 717 108 724 108 c
+732 108 l
+739 108 742 104 741 97 c
+737 82 732 68 725 54 c
+closepath
+643 576 m
+643 596 638 613 626 627 c
+613 642 596 653 576 659 c
+555 665 532 669 508 669 c
+442 669 l
+423 669 412 667 408 663 c
+404 660 400 650 396 632 c
+328 363 l
+432 363 l
+456 363 479 366 503 372 c
+526 378 549 389 570 404 c
+588 418 602 435 611 455 c
+621 475 628 495 633 516 c
+} exec {
+639 536 642 556 643 576 c
+closepath
+} exec
+fill
+} bind def
+/K55 {
+{
+newpath
+876 680 m
+875 676 873 673 871 671 c
+868 669 865 668 861 668 c
+849 668 837 667 825 665 c
+813 663 802 658 792 651 c
+783 645 777 638 772 630 c
+767 621 763 612 760 603 c
+668 234 l
+660 201 647 169 629 139 c
+611 108 589 80 561 54 c
+537 31 511 13 482 -1 c
+453 -15 423 -22 393 -22 c
+361 -22 332 -15 306 -2 c
+281 11 261 29 245 53 c
+228 77 217 105 214 136 c
+210 168 212 200 220 234 c
+321 631 l
+325 648 324 657 318 661 c
+312 664 302 666 288 667 c
+274 668 260 668 244 668 c
+240 668 238 669 236 671 c
+234 673 234 676 236 680 c
+238 688 l
+240 696 245 700 252 700 c
+335 697 420 697 505 700 c
+512 700 516 696 514 688 c
+511 680 l
+510 672 505 668 498 668 c
+482 668 467 668 453 667 c
+438 666 427 664 420 661 c
+412 657 407 648 403 631 c
+303 234 l
+296 205 291 177 289 149 c
+288 122 292 96 302 73 c
+311 54 324 39 341 27 c
+358 16 378 10 401 10 c
+425 10 450 16 475 27 c
+500 39 523 55 544 74 c
+568 96 587 121 602 149 c
+617 177 629 205 636 234 c
+728 603 l
+731 612 732 621 731 630 c
+730 638 726 645 721 651 c
+714 658 705 663 694 665 c
+684 667 673 668 660 668 c
+656 668 654 669 652 671 c
+650 673 650 676 651 680 c
+653 688 l
+654 692 656 695 659 697 c
+661 699 664 700 668 700 c
+734 697 801 697 870 700 c
+873 700 875 699 877 697 c
+879 695 879 692 878 688 c
+876 680 l
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+9 dict dup begin
+/KA 1024 def
+/KD 1024 def
+/K28 419 def
+/K29 419 def
+/K43 732 def
+/K4C 642 def
+/K50 694 def
+/K52 746 def
+/K55 761 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+%%BeginFont: SymbolMT
+/SymbolMT
+15 dict dup begin
+/FontName /SymbolMT def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 1024 def
+/FontDescent -225 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+3 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K6A {
+{
+newpath
+213 40 m
+189 58 169 85 154 121 c
+138 157 130 200 130 251 c
+130 321 142 372 165 404 c
+188 436 214 454 244 456 c
+244 474 l
+214 473 188 469 167 461 c
+146 453 126 440 106 421 c
+86 403 69 377 55 345 c
+41 313 34 279 34 241 c
+34 197 45 155 66 113 c
+88 72 116 41 150 21 c
+184 1 227 -12 278 -16 c
+278 -222 l
+334 -222 l
+334 -16 l
+390 -12 435 1 470 21 c
+504 41 532 72 554 113 c
+575 155 586 198 586 242 c
+586 308 566 363 526 408 c
+486 452 441 474 390 474 c
+355 474 327 463 307 441 c
+288 419 278 383 278 331 c
+278 12 l
+250 19 228 28 213 40 c
+213 40 l
+closepath
+334 313 m
+334 354 338 381 347 393 c
+356 406 368 412 382 412 c
+410 412 435 398 457 369 c
+487 329 502 279 502 219 c
+502 176 495 139 480 108 c
+465 78 443 54 415 38 c
+394 26 367 18 334 14 c
+334 313 l
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+3 dict dup begin
+/KA 615 def
+/KD 615 def
+/K6A 618 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+setpacking
+%AI3_EndRider
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _Euclid-Italic Euclid-Italic
+[/_Euclid-Italic/Euclid-Italic 0 0 0 TZ%AI3_EndEncoding TrueType%AI55J_Tsume: None
+%AI3_BeginEncoding: _SymbolMT SymbolMT
+[/_SymbolMT/SymbolMT 0 0 0 TZ%AI3_EndEncoding TrueType%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+1 Ap
+0 O
+1 g
+0 R
+1 G
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+193.6667 549.3333 m
+193.6667 579.3333 L
+187 579.3333 L
+187 549.3333 L
+193.6667 549.3333 L
+bu0 Ap
+0 G
+153.523 570 m
+153.523 521 l
+S262.9034 570 m
+262.9034 521 l
+S226.4432 570 m
+226.4432 521 l
+S189.9831 570 m
+189.9831 521 l
+S299.3635 570 m
+299.3635 521 l
+Su1 Ap
+0 O
+1 g
+201.3333 546 m
+201.3333 562.6667 L
+143.6666 562.6667 L
+143.6666 546 L
+201.3333 546 L
+b0 To
+1 0 0 1 166.3333 552.3333 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 1 k
+%_ 0 50 XQ
+/_SymbolMT 18 18 -3.9551 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+1 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 XbXB0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(j) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu1 g
+0 R
+0 G
+236.8542 525.3108 m
+236.8542 541.9775 L
+179.1875 541.9775 L
+179.1875 525.3108 L
+236.8542 525.3108 L
+b0 To
+1 0 0 1 201.8542 531.6442 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 1 k
+(j) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu1 g
+0 R
+0 G
+274.1875 546.29 m
+274.1875 562.9567 L
+216.5208 562.9567 L
+216.5208 546.29 L
+274.1875 546.29 L
+b0 To
+1 0 0 1 239.1875 552.6234 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 1 k
+(j) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu1 g
+0 R
+0 G
+309.8542 525.665 m
+309.8542 542.3317 L
+252.1875 542.3317 L
+252.1875 525.665 L
+309.8542 525.665 L
+b0 To
+1 0 0 1 274.8542 531.9984 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 1 k
+(j) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu1 g
+0 R
+0 G
+165.3953 524.123 m
+165.3953 541.7262 L
+136.7322 541.7262 L
+136.7322 524.123 L
+165.3953 524.123 L
+b1 G
+135.3894 521.6715 m
+135.3894 544.2476 L
+140.6446 544.2476 L
+140.6446 521.6715 L
+135.3894 521.6715 L
+bU0 G
+314.7189 546.0908 m
+314.7189 563.7182 L
+289.0781 563.7182 L
+289.0781 546.0908 L
+314.7189 546.0908 L
+b1 G
+315.6986 545.2789 m
+315.6986 564.596 L
+311.5874 564.596 L
+311.5874 545.2789 L
+315.6986 545.2789 L
+bUu0 G
+165.4849 742.1769 m
+165.4849 767.5103 L
+141.4849 767.5103 L
+141.4849 742.1769 L
+165.4849 742.1769 L
+s0 To
+1 0 0 1 144.7261 749.1769 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+/_Euclid-Italic 18 17.3339 -5.6879 Tf
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 Ap
+0 R
+0 G
+153.4849 742.1769 m
+153.4849 730.5103 l
+S1 Ap
+274.8653 742.1769 m
+274.8653 767.5103 L
+250.8652 767.5103 L
+250.8652 742.1769 L
+274.8653 742.1769 L
+s0 To
+1 0 0 1 254.1065 749.1769 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 Ap
+0 R
+0 G
+262.8653 742.1769 m
+262.8653 730.5103 l
+S1 Ap
+238.4052 742.1769 m
+238.4052 767.5103 L
+214.4051 767.5103 L
+214.4051 742.1769 L
+238.4052 742.1769 L
+s0 To
+1 0 0 1 217.6464 749.1769 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 Ap
+0 R
+0 G
+226.4051 742.1769 m
+226.4051 730.5103 l
+S1 Ap
+201.9451 742.1769 m
+201.9451 767.5103 L
+177.945 767.5103 L
+177.945 742.1769 L
+201.9451 742.1769 L
+s0 To
+1 0 0 1 181.1862 749.1769 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 Ap
+0 R
+0 G
+189.945 742.1769 m
+189.945 730.5103 l
+S1 Ap
+311.3254 742.1769 m
+311.3254 767.5103 L
+287.3254 767.5103 L
+287.3254 742.1769 L
+311.3254 742.1769 L
+s0 To
+1 0 0 1 290.5666 749.1769 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+0 Ap
+0 R
+0 G
+299.3254 742.1769 m
+299.3254 730.5103 l
+S153.0798 779.8332 m
+153.0798 768.1667 l
+S262.4602 779.8332 m
+262.4602 768.1667 l
+S226 779.8332 m
+226 768.1667 l
+S189.5399 779.8332 m
+189.5399 768.1667 l
+S298.9203 779.8332 m
+298.9203 768.1667 l
+SUu154.1516 709.8318 m
+154.1516 696.1651 l
+190.9619 669.4985 l
+190.6286 660.4985 l
+S191.0359 710.2901 m
+191.0359 696.6235 l
+227.2953 668.1651 l
+227.5129 660.9568 l
+S227.6193 709.8943 m
+227.6193 696.2276 l
+263.8786 667.7693 l
+264.0962 660.561 l
+S263.5568 709.9568 m
+263.5568 696.2901 l
+299.8161 667.8318 l
+300.0338 660.6235 l
+S138.9619 679.8318 m
+154.2745 667.9985 l
+154.4921 660.7901 l
+S298.2651 709.6235 m
+298.2651 695.9568 l
+316.2953 681.8318 l
+SUu299.6065 639.855 m
+299.5402 626.1886 l
+262.6012 599.7011 l
+262.8909 590.6997 l
+S262.7251 640.4923 m
+262.6588 626.8259 l
+226.2621 598.544 l
+226.0096 591.337 l
+S226.1406 640.274 m
+226.0743 626.6076 l
+189.6776 598.3258 l
+189.425 591.1187 l
+S190.2041 640.5108 m
+190.1378 626.8444 l
+153.7411 598.5627 l
+153.4885 591.3555 l
+S314.6503 609.7819 m
+299.2806 598.0231 l
+299.0281 590.816 l
+S155.5143 639.3458 m
+155.448 625.6795 l
+137.3497 611.6422 l
+SU0 To
+1 0 0 1 87 752 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 1 k
+/_Euclid-Italic 14 13.482 -4.4239 Tf
+(\(C\)) Tx 1 0 Tk
+(\r) TX 
+TO
+0 To
+1 0 0 1 87 683.1376 0 Tp
+0 Tv
+TP
+0 Tr
+(\(R\)) Tx 1 0 Tk
+(\r) TX 
+TO
+0 To
+1 0 0 1 87 606.8043 0 Tp
+0 Tv
+TP
+0 Tr
+(\(L\)) Tx 1 0 Tk
+(\r) TX 
+TO
+0 To
+1 0 0 1 87 542.1376 0 Tp
+0 Tv
+TP
+0 Tr
+(\(P\)) Tx 1 0 Tk
+(\r) TX 
+TO
+LB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/Papers/quant-ph_0405174/qca.tex
+++ b/Papers/quant-ph_0405174/qca.tex
@@ -1,0 +1,2363 @@
+\documentclass[aps,twoside,twocolumn]{revtex4}
+
+\usepackage{amsmath}
+\usepackage{amsfonts}
+\usepackage{amssymb}
+\usepackage{epsfig}
+
+
+\def\jtitle#1{#1}   % use this line to include titles of journal articles
+%\def\jtitle#1{}     % and this in order not to
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{corr}[theorem]{Corollary}
+\def\proof{\par\vskip12pt\noindent{\it Proof}}
+\def\qed{\leavevmode\unskip\penalty9999 \hbox{}\nobreak\hfill
+     \quad\hbox{\leavevmode  \hbox to.77778em{%
+               \hfil\vrule   \vbox to.675em%
+               {\hrule width.6em\vfil\hrule}\vrule\hfil}}}
+
+\def\AA{{\cal A}}\def\BB{{\cal B}}\def\CC{{\cal C}}\def\DD{{\cal D}}\def\EE{{\cal E}}
+\def\HH{{\cal H}}
+\def\MM{{\cal M}}\def\ZZ{{\cal Z}}
+\def\idty{\hbox{\rm\openone}}
+\def\tr{{\rm tr}}
+\def\sym{{\rm sym}}
+\def\norm#1{\left\Vert{#1}\right\Vert}
+\def\stsp#1{{\frak S}(#1)}% state space
+\def\bigtimes{\mathop{\times}}
+
+\def\Prob{{\mathbb P}}
+\def\MFalg{{\cal M\mkern-3mu\cal F}(A,B)}
+\def\Cx{{\mathbb{C}}}\def\Ir{\hbox{$\mathbb{Z}$}}
+\def\ket#1{\vert#1\rangle}
+\def\bra#1{\langle#1\vert}
+\def\ketbra#1#2{\vert#1\rangle\langle#2\vert}
+\def\braket#1#2{\right\langle#1\mid\vert#2\left\rangle}
+\def\Nei{{\cal N}}% Neighbourhood scheme
+\def\loclat{{\cal L}} % quotient lattice for local rules
+\def\qone{{\bf1}}
+\def\dtwos{d^{\,2^{\scriptstyle s}}}
+\def\grule{T}
+\def\lrule{\grule_0}
+\def\brule{\grule_\Box}
+
+\def\spp{{\bf s}} %linear support of subspace of tensor product
+\def\Spp{{\bf S}} % support algebra
+
+\def\OO{{\mathcal O}}
+\def\AO#1{{\mathfrak A}({\OO}_{#1})}
+\def\spacelike{\hbox{$/\mkern-9mu\backslash$}}
+\def\Field{{\mathbb F}}
+
+\begin{document}
+%* Top Matter
+\title{Reversible Quantum Cellular Automata}
+\author{B. Schumacher}
+\email{schumacherb@kenyon.edu} \affiliation{Kenyon College, Dept.
+of Physics, Gambier, Ohio 43022-9623, USA}
+\author{R.~F. Werner}
+\email{R.Werner@TU-BS.DE} \affiliation{Inst. Math. Phys.,
+TU-Braunschweig, Mendelssohnstra{\ss}e 3,
+  D-38106 Braunschweig, Germany}
+\begin{abstract}
+We define quantum cellular automata as infinite quantum lattice
+systems with discrete time dynamics, such that the time step
+commutes with lattice translations and has strictly finite
+propagation speed. In contrast to earlier definitions this allows
+us to give an explicit characterization of all local rules
+generating such automata. The same local rules also generate the
+global time step for automata with periodic boundary conditions.
+Our main structure theorem asserts that any quantum cellular
+automaton is structurally reversible, i.e., that it can be
+obtained by applying two blockwise unitary operations in a
+generalized Margolus partitioning scheme. This implies that, in
+contrast to the classical case, the inverse of a nearest neighbor
+quantum cellular automaton is again a nearest neighbor automaton.
+
+We present several construction methods for quantum cellular
+automata, based on unitaries commuting with their translates, on
+the quantization of (arbitrary) reversible classical cellular
+automata, on quantum circuits, and on Clifford transformations
+with respect to a description of the single cells by finite Weyl
+systems. Moreover, we indicate how quantum random walks can be
+considered as special cases of cellular automata, namely by
+restricting a quantum lattice gas automaton with local particle
+number conservation to the single particle sector.
+
+\end{abstract}
+\maketitle
+
+\section{Introduction}
+The idea of generalizing the classical notion of cellular automata
+to the quantum regime is certainly not new. Indeed, it is already
+present in Feynman's famous paper \cite{Feynman} from 1982, in
+which he argues that quantum computation might more powerful than
+classical. However, although there have been several formal
+definitions of quantum cellular automata over the years, the
+theory is not in good shape at the moment, and a systematic
+exploration of the general properties of such systems on the one
+hand and of the potential for computational applications on the
+other has hardly begun. We believe that this is partly due to
+deficiencies of the existing approaches, and therefore propose a
+new one, which is very natural, and only requires a few basic
+assumptions: a discrete cell structure with a finite quantum
+system for every cell and translation symmetry, a discrete time
+step for the global system, reversibility, and finite propagation
+speed.
+
+Quantum cellular automata (``QCAs'') are of interest to several
+fields. There are obvious connections to the statistical mechanics
+of lattice systems, and potential applications to ultraviolet
+regularization of quantum field theories. In Quantum Computer
+Science they appear as one natural model of computation extending
+the well-developed theory of classical cellular automata into the
+quantum domain. But also the experimental side is rapidly
+developing: quantum computing in optical lattices \cite{optlat}
+and arrays of microtraps \cite{mictrap} are among the most
+promising candidates for the first quantum computer that does
+useful computations \cite{QdCA}. It is typical for such systems
+that the addressing of individual cells is much harder than a
+change of external parameters affecting all cells in the same way
+\cite{Benjamin}. But this is just the theoretical description of a
+cellular automaton. Possible tasks, which have the same built-in
+translation invariance are simulations of solid state models.
+Typically classical simulations run into problems already for
+moderate systems sizes, precisely because of the dimension and
+complexity explosion which Feynman noted, and for which he
+proposed quantum computation as a cure. The theory presented in
+this paper can be considered as providing the first elements of an
+assembly language for such simulations.
+
+The problems which have plagued previous attempts to define QCAs
+begin with the definition of a system of infinitely many cells.
+Consider the simplest operation such an automaton should be able
+to perform: applying the same unitary transformation separately to
+each cell. This would involve multiplying infinitely many phases,
+so there is really no well-defined unitary operator describing the
+global state change. Therefore, the quantization approach ``just
+make the transition function unitary'' does not work very well.
+Similarly, the notion of state vectors as amplitude assignments to
+uncountably many classical configurations is ill-defined. But this
+would be a candidate for the ``configurations'' of a QCA, which
+causes problems for a definition of QCAs in terms of
+configurations and their transformations. Various approaches
+\cite{Watrous,vanDam,Gruska,santa,Feynman} will be described and
+commented in Section~\ref{sec:others}. A constructive method to
+obtain QCAs, which is common to most of these approaches
+(including ours) is partitioning the system into blocks of cells,
+applying blockwise unitary transformations, and possibly iterating
+such operations. Model studies based on such constructions (e.g.,
+\cite{Brennen}) therefore produce results independently of the
+definition problems.
+
+In order to arrive at a satisfactory notion of QCAs, it is helpful
+to draw on ideas from a discipline, which has been dealing with
+infinite arrays of simple quantum systems for a long time, i.e.,
+the statistical mechanics of quantum spin systems. Infinite
+systems have been considered particularly in the algebraic
+approach to such systems \cite{BraRo}. The basic idea is to focus
+on the observables rather than the states, i.e., to work in the
+Heisenberg picture rather than the Schr\"odinger picture
+\cite{Paschen}. The main advantage is that in contrast to
+localized states, it does make sense speak of local observables
+\cite{Haag}, i.e., observables requiring a measurement only of a
+finite collection of cells. The global transition rule of a
+cellular automaton is then a transformation $T$ on the observable
+algebra of the infinite system. As always in the Heisenberg
+picture, the interpretation of such a transformation is that
+`preparing a state, running the automaton for one step, and then
+measuring the observable $A$' gives exactly the same expectations
+as preparing the same state and measuring $T(A)$. As always, $T$
+must be completely positive and satisfy $T(\idty)=\idty$. But more
+importantly we can state the crucial localization property of
+QCAs: When $A$ is localized on a region $\Lambda$ of the lattice,
+then $T(A)$ should be localized in
+$\Lambda+\Nei=\{x+n|\;x\in\Lambda,\ n\in\Nei\}$, where $\Nei$ is
+the {\it neighborhood scheme} of the QCA.
+
+To our knowledge, this view of QCAs was first used in \cite{RiWe},
+where the approach to equilibrium in a QCA with irreversible local
+rules (based on a partitioning scheme) was investigated. The
+general picture of QCAs remained unsatisfactory, however, because
+the partitioning scheme seemed a rather special way of
+constructing a QCA. For a satisfactory theory of QCAs we demand
+that there should be a direct connection between the {\it global
+transition rule} $T$ and the {\it local transition rule}: If we
+know the global transition rule, we should be able to extract
+immediately the local rule in a unique way, and conversely, from
+the local rule we should be able to synthesize the global rule.
+The class of global rules should have an axiomatic specification,
+the most important of which would be the existence of a finite
+neighborhood scheme in the above sense. On the other hand, for the
+local transition rules we would prefer a {\it constructive
+characterization}. That is, there should be a procedure for
+obtaining all local rules leading to global rules with the
+specified properties, in which all choices are clearly
+parameterized.
+
+The partitioning QCAs of \cite{RiWe} failed to meet these
+requirements, because they provided a construction, but no
+axiomatic characterization of the global rules obtained in this
+way. In particular, it remained unclear whether two steps of such
+an automaton could be considered as a single step of an automaton
+with enlarged neighborhood scheme. The idea enabling the present
+paper was that all these difficulties vanish if we restrict to the
+class of {\it reversible} QCAs. The axiomatic characterization is
+extremely simple: In addition to the above locality condition we
+assume that the global rule must have an inverse, which is again
+an admissible quantum channel. This is equivalent to saying that
+$T$ must be an automorphism of the observable algebra. Then the
+local rule is simply the restriction of this automorphism to the
+algebra of a single cell. Conversely, since every observable can
+be obtained as a linear combination of products of single-cell
+observables, the local rule determines the global automorphism.
+This allows us to subsume all the known constructions of QCAs, but
+also to prove a general structure theorem: every reversible QCA is
+structurally reversible, i.e., we can write the local rule in a
+partitioning scheme involving two unitary matrices, which makes it
+apparent how the global rule can be unitarily implemented on
+arbitrarily large regions, and how to obtain the local rule of the
+inverse.
+
+A further bonus from our proof of the structure theorem is that it
+does not actually require the global rule to be an automorphism:
+it works under the prima facie much weaker assumption that the
+global rule is a homomorphism (and not necessarily onto). Then
+invertibility follows (see Corollary~\ref{cor:invert} below).
+Therefore, invertibility was not included in Definition~1, which
+makes it much easier to verify whether a proposed rule is indeed a
+QCA.
+
+The structural invertibility was an open problem in the theory of
+classical reversible cellular automata in higher dimensional
+lattices until recently \cite{Kari1}. Hence, since our proof of
+the quantum result is rather simple, it appears that some proofs
+in the classical domain can be simplified by going quantum.
+
+Our paper is organized as follows: In Section~\ref{sec:def}, we
+begin with the axiomatic definition of QCAs in the sense described
+above. Its counterpart, the constructive description is given in
+the form of a collection of basic constructions and examples in
+Section~\ref{sec:basicon}. It turns out that one of these
+constructions, based on partitioning, is already sufficient to
+obtain all QCAs in the sense of our definition. This rather
+surprising result is stated and proved in Section~\ref{sec:struc}.
+The ideas of the proof also allows us to give an explicit
+parameterization of the simplest class of QCAs: nearest neighbor
+automata in one dimension with one qubit per cell. As mentioned in
+the introduction, the current literature on the subject is mostly
+based on a definition we do not find satisfactory. We discuss
+these, and some further related definitions, in more detail in
+Section~\ref{sec:others}. Finally, in an appendix we provide some
+mathematical background on finite dimensional C*-algebras, which
+play a key role in the proof of Theorem~\ref{mainthm}.
+
+
+
+
+\section{Definition of QCAs}\label{sec:def}
+We consider an infinite cubic array of cells, labelled by integer
+vectors $x\in\Ir^s$, where $s\geq1$ is the spatial dimension of
+the lattice \cite{otherlat}. Each cell contains a $d$-level
+quantum system with the same finite $d\geq2$. That is to say, with
+each cell $x\in\Ir^s$, we associate the observable algebra $\AA_x$
+of the cell, and each of these algebras is an isomorphic copy of
+the algebra of complex $d\times d$-matrices.  When
+$\Lambda\subset\Ir^s$ is a finite subset, we denote by
+$\AA(\Lambda)$ the algebra of observables belonging to all cells
+in $\Lambda$, i.e., the tensor product
+$\bigotimes_{x\in\Lambda}\AA_x$. By tensoring with unit operators
+on $\Lambda_2\setminus\Lambda_1$ we consider $\AA(\Lambda_1)$ as a
+subalgebra of $\AA(\Lambda_2)$, whenever
+$\Lambda_1\subset\Lambda_2$. In this way the product $A_1A_2$ of
+$A_i\in\AA(\Lambda_i)$ becomes a well-defined element of
+$\AA(\Lambda_1\cup\Lambda_2)$. Moreover, tensoring with the
+identity does not change the norm, so we get a normed algebra of
+{\it local observables}, whose completion is called the {\it
+quasi-local algebra}\cite{BraRo}, and will be denoted by
+$\AA(\Ir^s)$. Similarly, for other infinite subsets
+$\Lambda\subset\Ir^s$ we define $\AA(\Lambda)$ as the closure of
+the union of all $\AA(\Lambda')$ with $\Lambda'\subset \Lambda$
+finite.
+
+When $x\in\Ir^s$ is a {\it lattice translation}, we denote by
+$\tau_x$ the isomorphism from each $\AA_y$ to $\AA_{x+y}$, and its
+extensions from $\AA(\Lambda)\to\AA(\Lambda+x)$, by shifting every
+site. Here we have used the notation
+$\Lambda+x=\{y+x|y\in\Lambda\}$ for shifted lattice subsets, which
+we also extend to
+$\Lambda_1+\Lambda_2=\{x_1+x_2|x_i\in\Lambda_i\}$.
+
+A {\it state} $\omega$ of the spin system is a linear functional
+on $\AA(\Ir^s)$, which is positive in the sense that
+$\omega(X^*X)\geq0$ and normalized as $\omega(\idty)=1$.
+Equivalently, a state is given by a family $\omega_\Lambda$ of
+density operators on $(\Cx^d)^{\otimes\Lambda}$ (for each finite
+$\Lambda$), such that
+ $\omega(X)=\tr(\omega_\Lambda X)$ for $X\in\AA(\Lambda)$. The
+local density matrices have to satisfy the consistency condition
+that, for $\Lambda_1\subset\Lambda_2$, $\omega_{\Lambda_1}$ is
+obtained from $\omega_{\Lambda_2}$ by tracing out all tensor
+factors in $\Lambda_2\setminus\Lambda_1$. Note that a state does
+not correspond to a configuration of a classical automaton, but
+rather to a probability distribution over global configurations.
+
+\begin{definition}
+ A {\bf Quantum Cellular Automaton}
+ with neighborhood scheme $\Nei\subset\Ir^s$
+ is an homomorphism $\grule:\AA(\Ir^s)\to\AA(\Ir^s)$ of the quasi-local
+algebra, which commutes with lattice translations, and satisfies
+the locality condition
+ $\grule(\AA(\Lambda))\subset\AA(\Lambda+\Nei)$ for every finite
+set $\Lambda\subset\Ir^s$.
+ The local {\bf transition rule} of a cellular automaton is the
+homomorphism $\lrule:\AA_0\to\AA(\Nei)$. \end{definition}
+
+Note that a unitary operator for the time evolution is not necessary in
+this formulation. Instead we have replaced it by its action on
+observables. Of course, the time step has to be read in the Heisenberg
+picture. That is,  measuring some local observable $A\in\AA(\Lambda)$ at
+time $t+1$ is equivalent to measuring the observable $\grule(A)$ at time
+$t$. The transition rule thus describes this backwards calculation for a
+single cell. $\lrule(\AA_0)$ is some isomorphic copy of the one-cell
+algebra embedded in a possibly quite complicated way into the algebra of
+neighboring cells. The relationship between the global evolution and the
+one-site transition rule is as simple as it should be:
+
+\begin{lemma}\label{lem:localrule}{\ }\newline
+ (1) The global homomorphism $\grule$ is uniquely determined by the
+local transition rule $\lrule$. \newline
+ (2) A homomorphism $\lrule:\AA_0\to\AA(\Nei)$ is the transition
+rule of a cellular automaton if and only if for all $x\in\Ir^s$ such that
+$\Nei\cap(\Nei+x)\neq\emptyset$ the algebras $\lrule(\AA_0)$ and
+$\tau_x\bigl(\lrule(\AA_0)\bigr)$ commute elementwise. \end{lemma}
+
+\proof:\quad  By translation invariance the action of
+$\grule_x:\AA_x\to\AA(\Nei+x)$ is determined as
+$\grule_x(A_x)=\tau_x\lrule\tau_{-x}(A_x)$ on all other cells.
+Moreover, because $\grule$ is a homomorphism, the extension to any
+local algebra is also fixed. Explicitly, consider a product
+$\bigotimes_{x\in\Lambda}A_x=\prod_{x\in\Lambda}A_x$ of one-site
+operators. This equation just expresses our identification of the
+one site algebras $\AA_x$ with subalgebras of $\AA(\Lambda)$ by
+tensoring with unit operators. Then the homomorphism property of
+the global evolution requires that
+\begin{equation}\label{alfaglobal}
+  \grule\left(\bigotimes_{x\in\Lambda} A_x\right)
+    =\prod_{x\in\Lambda} \grule_x(A_x)\;.
+\end{equation}
+ Note that the product on the right hand side cannot be replaced
+by a tensor product, because the factors have overlapping
+localization regions $x+\Nei$. Moreover, the argument of $\grule$
+is a product of commuting factors, hence so is the right hand
+side. Hence the the commutativity condition (2) is necessary.
+
+Conversely, if the factors $\grule_x(A_x)$ commute, their product
+is unambiguously defined. Since every local observable can be
+expressed as a linear combination of tensor products,
+Eq.~(\ref{alfaglobal}) defines a homomorphism on the local
+algebra, as required.  This shows the converse of (2), and since
+we have given an explicit formula of $\grule$ in terms of $\lrule$
+it also shows (1). \qed
+
+
+
+It is clear that the commutation condition of the Lemma can be
+expressed as a finite set of equations, and can therefore be
+verified effectively. Since only a small portion of the lattice is
+needed in this verification, the same steps are needed to check
+local transition rules fore QCAs on graphs which locally look like
+$\Ir^s$. Such graphs can be seen as integer lattices with {\it
+periodic boundary conditions}. The only condition we will need to
+impose is that the periods for the boundary condition are not too
+small compared with the size of neighborhood scheme $\Nei$ (a
+condition called ``regularity'' below). No algebraic conditions on
+the homomorphism $\lrule$ are needed. Therefore we can turn the
+construction around, and immediately get a QCA on the infinite
+lattice from a QCA with finitely many cells. Since for finitely
+many cells a homomorphism is always just implemented by a unitary
+matrix, this allows us to define QCAs even for the infinite
+system, just by specifying unitary matrices with suitable
+properties.
+
+Let us describe the periodic boundary QCAs more precisely and see
+what conditions are needed for the neighborhoods. The cells of a
+system with periodic boundary conditions arise from the cells in
+$\Ir^s$ by identifying certain cells, namely all those differing
+by a vector $\gamma$ in some subgroup $\Gamma\subset\Ir^s$. The
+set of cells is thus identified with the quotient
+$\loclat=\Ir^s/\Gamma$. For each point in $x\in\loclat$, i.e.,
+each equivalence class $x=x_0+\Gamma$ of identified cells, only
+one observable algebra is given. The sites $\loclat$ can be
+represented in a so called fundamental domain of $\Gamma$ like the
+parallelogram in Fig.~\ref{figlattis}. But there seems to be no
+way to draw this nicely as a set of square cells.
+
+For points $x=(x_0+\Gamma)\in\loclat$, i.e., we can define the
+translation $x+n=x_0+n+\Gamma$. Consider now a neighborhood scheme
+$\Nei\subset\Ir^s$. The neighborhood of $x\in\loclat$ is then
+$x+\Nei\subset\loclat$. Note that as far as the model with
+periodic boundary conditions is concerned we could change each
+$n\in\Nei$ by a lattice vector in $\Gamma$ without changing the
+neighborhood of any point. But since we are interested in the
+connection with the infinite model, we do not admit this
+ambiguity. The neighborhood scheme is called {\it regular} for the
+given periodic structure given by $\loclat$, if the equations we
+have to check for the commutation rule of a cellular automaton are
+the same in both cases. Since these equations depend only on the
+intersections between translates of $\Nei$ we only need to make
+sure that the geometry of intersections is the same. So suppose
+that neighborhoods on $\loclat$ intersect, say
+$(x+\Nei)\cap(y+\Nei)\neq\emptyset$. This means that there is a
+translation $m\in\Ir^s$ such that $x+m=y$ and also
+$\Nei\cap(m+\Nei)\neq\emptyset$. Clearly, the first condition
+determines $m$ up to a lattice translation $\Gamma$, and the
+second is an intersection condition on the infinite lattice.
+Obviously, $x+(\Nei\cap(\Nei+m))\subset(x+\Nei)\cap(y+\Nei)$. But
+the inclusion could be strict if there is more than one $m$ with
+the required properties. This is precisely the case regularity
+must exclude. To summarize, we call a neighborhood scheme
+$\Nei\subset\Ir^s$ {\it regular} for a subgroup
+$\Gamma\subset\Ir^s$, if $\Nei\cap(m+\Nei)\neq\emptyset$ and
+$n\in\Gamma$, $n\neq0$, imply that $\Nei\cap(m+n+\Nei)=\emptyset$.
+A more compact equivalent form is
+$(\Nei+\Nei-\Nei-\Nei)\cap\Gamma=\{0\}$. An example of a regular
+neighborhood is given in Figure~\ref{figlattis}. That the same
+neighborhood becomes non-regular for a smaller lattice is shown in
+Fig.~\ref{figirreg}.
+
+
+
+\begin{figure}[htb]
+\epsfxsize=5cm \epsffile{peribound.eps}
+ \caption{\label{figlattis}{\it Periodic boundary conditions.
+ The parallelogram represents the given finite lattice $\loclat$,
+ where cells cut by opposite boundaries must be suitably joined.
+ The marks on the corners join up to a full circle.
+ Two translates of the same neighbourhood are shown.
+ It is regular, because the geometry of intersections is
+ the same as on the infinite plane.  }}
+\end{figure}
+
+
+\begin{figure}[htb]
+\epsfxsize=2.5cm \epsffile{irregular.eps}
+ \caption{\label{figirreg}{\it The same neighborhood scheme
+ is not regular on a 5$\times$4 torus: Again we have two translates,
+ but their intersection (cross-hatched) cannot be realized on the
+ infinite square lattice as intersection of two such neighborhoods.  }}
+\end{figure}
+
+
+
+
+
+ Then checking condition (2) of the Lemma for the QCA
+on $\loclat$ and for the QCA on $\Ir^s$ are exactly equivalent. We
+call this useful principle the {\it Wrapping Lemma:}
+
+\begin{lemma} The QCA transition rules on a finite lattice
+$\loclat$ with respect to a regular neighborhood scheme $\Nei$ are
+in one-to-one correspondence with the transition rules for QCAs on
+$\Ir^s$ with the same neighborhood scheme. \end{lemma}
+
+
+\par
+
+
+
+\section{Basic Construction Methods}\label{sec:basicon}
+\subsection{Commuting Unitaries and Phases }\label{sec:communitary}
+Consider a unitary operator $U_0$ in some local algebra
+$\AA(\widetilde\Nei)$, which commutes with all its translates
+$U_x=\tau_x(U_0)$, up to a phase. That is, we require that there
+are complex numbers $\zeta_x$ with $|\zeta_x|=1$ such that
+$U_0\tau_x(U_0)=\zeta_x\tau_x(U_0)U_0$ for
+$(\widetilde\Nei+x)\cap\widetilde\Nei\neq\emptyset$. This is
+equivalent to
+\begin{equation}\label{localprojective}
+  U_xU_y=\zeta_{y-x}\;U_yU_x
+\end{equation}
+We can then formally define a unitary operator
+\begin{equation}\label{infUnitary}
+    \mbox{``\ }U=\prod_{{x\in\Ir^s}} U_x
+    \mbox{\ ''.}
+\end{equation}
+ Here the the scare quotes indicate that there is no way this
+infinite product can be made sense of. However, we can define
+instead the action of this ``operator'' on local observables. To
+this end, note that the actions $A\mapsto U_x^*AU_x$ commute for
+different $x$. Moreover, if $x+\Nei$ does not intersect the
+localization region of $A$, this action is the identity.
+Therefore, in the infinite product of these operations only a
+finite set is {\it not} the identity, and their product defines an
+automorphism $\grule$. More formally, we have
+\begin{equation}\label{commutealpha}
+  \grule(A)=\lim_{\Lambda\nearrow\Ir^s} U_\Lambda^*AU_\Lambda\;,
+\end{equation}
+ where $A\in\AA(\Ir^s)$, and
+ $U_\Lambda=\prod_{{x\in\Lambda}}U_x$.
+The limit is over any sequence of finite sets, eventually
+absorbing all lattice points, and if $A$ is localized in a finite
+region, the limit is actually constant for sufficiently large
+$\Lambda$.
+
+ The local transition rule is found by
+applying $\grule$ to a single cell. This gives the neighborhood scheme
+\begin{equation}\label{neiCommute}
+  \Nei=\bigcup_x\{\widetilde\Nei+x| 0\in\widetilde\Nei+x\}
+      =\widetilde\Nei-\widetilde\Nei\;.
+\end{equation}
+
+We mention three special cases of this construction:
+\begin{itemize}
+\item When $\widetilde\Nei=\Nei=\{0\}$, we have to choose a unitary operator
+$U_0\in\AA_0$ acting on a single cell. Thus the cellular automaton
+acts  by applying the same unitary rotation separately to every
+cell.
+\item Fix a basis in $\Cx^d$ and
+consider any unitary $U_0$ which is diagonal in the corresponding
+product basis. Clearly, this guarantees that $U_0$ commutes with
+its translates. That is, we can generate a QCA by an arbitrary
+choice of {\it local phases} in some computational basis. A
+prominent example is an Ising interaction
+\begin{equation}\label{ising}
+    H=(\idty-\sigma_3)\otimes(\idty-\sigma_3)
+\end{equation}
+turned on for a suitable finite time (e.g., $t=\pi/4$), which
+generates the initial entangled state of a one-way quantum
+computer \cite{onewaycomp} together with a cellwise Hadamard
+rotation. \item Choose at every site a family of unitaries $V_p$,
+$p=1,\ldots,d^2$ commuting up to a phase. Examples are the Pauli
+matrices for $d=2$, or a discrete Weyl system. Then $U_0$ can be
+any finite product of operators from this family, localized on
+neighboring cells. The automata generated in this way form a
+group.
+\end{itemize}
+
+\noindent For all QCAs constructed from commuting unitaries we
+have the strange property that they show {\it no propagation}, in
+the sense that the localization region does not increase when we
+iterate the automaton. The reason is that $n$ steps are
+implemented by a product of commuting unitaries, each of which
+appears $n$ times. Hence it is exactly equivalent to take instead
+a single step with the basic unitary operator $U_0$ replaced by
+$U_0^n$.
+
+Of course, most QCAs do have propagation. For example, we could
+take a single step constructed from commuting unitaries, followed
+by a site-wise rotation along a skew axis. Another rich class of
+propagating QCAs is given in the next section.
+
+\subsection{Quantization of Classical Reversible CAs}\label{sec:classical}
+A typical feature of the local phase automata is that they leave
+invariant the algebra of operators diagonal in the chosen basis.
+This algebra $\DD$ is the quasi-local algebra of a classical CA
+embedded into the quantum system, which has $d$ states per cell,
+when $\AA_x$ is the algebra of $d\times d$-matrices. It is
+therefore natural to look for cellular automata, which leave this
+classical subalgebra $\DD$ invariant as a set, but not
+elementwise. Clearly, such QCAs induce a classical CA on the
+classical subsystem. In fact, {\it every} reversible classical CA
+can be obtained in this way.
+
+Intuitively, this is seen as follows: the classical CA can be run
+with periodic boundary conditions, for simplicity, so we have only
+a finite set $\loclat$ of cells. It then defines a permutation of
+the $d^{|\loclat|}$ classical configurations, which we can
+interpret immediately as a unitary permutation operator $U$. This
+unitary operator is now used to implement the local evolution of
+the QCA. All we need to verify is that for $A\in\AA_0$ the
+evolution $U^*AU$ is indeed contained in some local algebra
+$\AA(\Nei)$ for some regular neighborhood $\Nei$. Then the
+wrapping Lemma asserts that the QCA is also well-defined on the
+infinite lattice.
+
+However, this argument must be more subtle than it looks: it is
+well known, that the injectivity of a classical CA on the infinite
+lattice implies the existence of an inverse CA \cite{Rich}, but
+the inverse is hard to compute, because there is no a priori upper
+bound on its neighborhood size. Superficially, the inverse
+neighborhoods do not seem to enter the above argument. However,
+the argument for the locality $U^*AU\in\AA(\Nei)$ requires more
+than the locality of the classical rule and the unitarity of $U$.
+Consider, for example, the rule
+\begin{equation}\label{xorautomat}
+ c^{t+1}_{x}=c^{t}_{x+1}+c^{t}_{x}+c^{t}_{x-1}\;,
+\end{equation}
+ where $c^{t}_{x}\in\{0,1\}$, and addition is mod$2$. With
+periodic boundary conditions of length $L$ this is an invertible
+transformation unless $L$ is divisible by 3. This proviso is not
+of the form ``for sufficiently large $L$...'' , which means that
+the classical automaton does not allow a local inversion, i.e.,
+there is no inverse cellular automaton. By the wrapping Lemma, it
+is clear that for this rule we cannot find a quantum version
+either\cite{classicalW}. This shows that the {\it local}
+invertibility of the classical CA must enter the argument.  We
+therefore assume now that the classical CA is locally invertible,
+and the lattice $\loclat$ is chosen sufficiently large, so that
+the neighborhood schemes for both the classical automaton and its
+inverse are regular for $\loclat$.
+
+The classical configurations are functions
+$\underline{a}:\loclat\to A$, where $A=\{1,\ldots,d\}$ denotes the
+set of classical states for each cell, and at the same time labels
+the computational basis of $\Cx^d$. We will write
+$\underline{a}\in A^\loclat$, and denote by
+$\underline{a}_x=\underline{a}(x)$ the value of the cell $x$ in
+configuration $\underline{a}$.
+
+Extending this to a product basis, each configuration
+$\underline{a}\in A^\loclat$ determines a basis vector
+$\ket{\underline{a}}$. Then the global unitary transition operator
+is defined by $U\ket{\underline{a}}=\ket{F({\underline{a}})}$,
+where $F$ denotes the global classical transition function. The
+transition rule of the QCA is determined by computing all matrix
+elements of the operator $\lrule(\ketbra{c_0}{e_0})$, i.e.,
+\begin{eqnarray}\label{classmat}
+  \bigl\langle \underline{a}\bigr|\lrule(\ketbra{c_0}{e_0}) \bigl|\underline{b}\bigr\rangle
+  &=&\bigl\langle \underline{a}\bigr|U^*(\ketbra{c_0}{e_0}\otimes
+                                          \idty^{\loclat\setminus\{0\}})U
+        \bigl|\underline{b}\bigr\rangle
+      \nonumber\\
+  &=&\bigl\langle F(\underline{a})\bigr|(\ketbra{c_0}{e_0}\otimes
+                         \idty^{\loclat\setminus\{0\}})
+\bigl|F(\underline{b})\bigr\rangle
+      \nonumber
+\end{eqnarray}
+This expression is $=1$, if
+\begin{eqnarray}\label{transCCA}
+    \mbox{if}\  F(\underline{a})_0&=&c_0,\quad
+                F(\underline{b})_0=e_0,\ \nonumber\\
+    \mbox{and}\ F(\underline{a})_x&=&F(\underline{b})_x
+                 \quad\mbox{for}\  x\neq0
+\end{eqnarray}
+and $=0$ otherwise. We have to show that this is of the form
+$X\otimes\idty^{\otimes\loclat\setminus\Nei}$.
+
+\begin{lemma}\label{classlem}Let $F$ be a classical cellular automaton
+with neighborhood scheme $\Nei_C$, which has an inverse automaton
+with neighborhood scheme $\Nei_I$. Then $\grule$ as defined above
+is a QCA with neighborhood scheme $\Nei=\Nei_C-\Nei_C-\Nei_I$.
+\end{lemma}
+
+Of course, this Lemma only gives an upper bound on the size of the
+neighborhood scheme. Depending on the particular automaton, $\Nei$
+may be much smaller.
+
+\proof\/: We have to show that for all $e_0,c_0$, the operator
+$\lrule(\ketbra{c_0}{e_0})$ is of the form
+$X\otimes\idty^{\otimes\loclat\setminus\Nei}$ with
+$X\in\AA(\Nei)$. This is equivalent to two conditions: on the one
+hand the matrix elements $\bigl\langle
+\underline{a}\bigr|\lrule(\ketbra{c_0}{e_0})
+\bigl|\underline{b}\bigr\rangle$ must vanish, whenever $a_x\neq
+b_x$ for some point $x\notin\Nei$, and, moreover, the value of the
+matrix elements must be independent of $a_x$ for such $x$.
+
+Suppose that the matrix element is non-zero, i.e.,
+condition~(\ref{transCCA}) holds. Then for all $y$ such that
+$y+\Nei_I\neq0$ the computation of the the values of $a_y$ and
+$b_y$ from $F(\underline{a})$ and $F(\underline{b})$ will give the
+same values of $a_y$ and $b_y$. In other words, the diagonality
+condition holds for $y\notin(-\Nei_I)$.
+
+The dependence of the matrix element on $a_x$ is also governed by
+condition~(\ref{transCCA}): since the matrix elements can only be
+$0$ or $1$, we have to show that the validity of the condition
+does not depend on $a_x$ for $x\notin\Nei$, given the range of
+equality of $a'$s and $b'$s established in the previous paragraph.
+Indeed, once that diagonality is established, one can see that
+most of the conditions~(\ref{transCCA}) become redundant. If $x$
+is such that $(x+\Nei_C)\cap(-\Nei_I)=\emptyset$, then
+$F(\underline{a})_x$ and $F(\underline{b})_x$ are computed by the
+local rule of $F$ from identical data, so they must be equal. It
+therefore suffices to consider the condition for those finitely
+many $x$ for which a dependence remains possible, i.e.,
+$x\in(-\Nei_C-\Nei_I)$. But then only those $a_y$ enter, which
+contribute to $F(\underline{a})_x$ via the local rule (and
+similarly for $\underline{b}$). This restricts $y$ to
+$(\Nei_C-\Nei_C-\Nei_I)$, and this is what the Lemma claims as the
+localization region. \qed
+
+
+\subsection{Partitioning}
+The easiest way to build a cellular automaton with readily
+verified locality properties is based on the cellwise unitary
+rotations, with the modification of changing the partitioning of
+the system into cells \cite{Lloyd}. The typical construction would
+thus be:
+\begin{enumerate}
+ \item possibly divide the given cells into suitable subcells, by
+writing the one-cell Hilbert space $\Cx^d$ as a tensor product of
+other spaces.
+ \item partition the set of cells of the previous step into blocks in some periodic
+ way: every cell now belongs to exactly one block, and any two blocks
+ are connected by a lattice translation.
+ \item apply the same unitary operator to each block algebra.
+ \item possibly repeat this procedure with different block
+       partitions
+ \item possibly split and regroup once again to come back to the original pattern of
+$d$-dimensional cells.
+\end{enumerate}
+
+Every step in this construction is well-defined for the global
+system for the same reason that cell-wise rotations are valid QCA
+operations. Moreover, the unitary operators doing each of the
+steps are essentially arbitrary, and by just inverting the steps
+we can immediately construct the inverse QCA. This is why
+partitioned cellular automata are sometimes called {\it
+structurally reversible}. Moreover, the partitioning idea allows
+one to construct QCAs from {\it irreversible} local rules just as
+easily as reversible ones \cite{Brennen,RiWe}.
+
+Our main theorem (Theorem~\ref{mainthm} below) will tell us that
+{\it every} QCA can be written in partitioned form. For nearest
+neighbor automata it is sufficient to take two steps in which
+cells are grouped in cubes of side 2, possibly with a choice of
+unequal cell sizes in the intermediate step (see
+Section~\ref{sec:margolus}). This is known as the Margolus
+partitioning scheme (see Figure~\ref{margolus}).
+
+\begin{figure}[htb]
+{\epsfxsize=5cm \epsffile{margolus0.eps}
+ \caption{\label{margolus}{\it The Margolus partitioning scheme in $s=2$ dimensions.
+ Operations are alternatingly applied to the solid and to the dashed
+ partitioning into $2\times2$ squares. The square shape of the cells is irrelevant,
+ as they only serve to label localized quantum systems.}}}
+\end{figure}
+
+
+
+\subsection{Circuits}
+
+Of course, it is natural to think of a cellular automaton as a
+physical device, which just happens to be infinitely extended (or
+periodically closed). This suggests building QCAs from some basic
+supply of circuit elements, whose properties will then ensure that
+the overall operation makes sense. The mathematical details of the
+description must then work out automatically, because ``Hardware
+cannot lie''. Consider the following example
+
+\begin{figure}[htb]
+\epsfxsize=5cm \epsffile{circuit1.eps}
+ \caption{\label{circ1}{\it A proposed QCA circuit.}}
+\end{figure}
+
+Here the flow of information is from top to bottom. The symbol
+stands for a CNOT gate, by which the bit on the line with circle
+and cross (the ``target bit'') is flipped if and only if the value
+of the bit on the line with the fat dot (the ``control bit'') is
+``$1$''. This is a standard gate also for quantum computation. We
+can readily compute the action of this device on classical
+information: each output bit depends only on the input on the same
+line and the line one step to the right. Presumably, this would
+also be the description of the action on computational basis
+states in the quantum case. So can we not just build this device,
+and construct its proper mathematical description along with the
+hardware?
+
+The problem with this automaton becomes apparent already when we
+try to compute its classical inverse: this requires at each switch
+to know the value of a control bit, which is not yet determined.
+In fact, the inverse does not exist, because the initial states
+``all {\tt1}'' and ``all {\tt0}'' are both mapped to ``all
+{\tt0}''. So this device is not reversible, even classically.
+(Incidentally, this also holds for periodic boundary conditions,
+so it is not a problem of infinite size).  What went wrong? The
+problem is the {\it timing} of the gates. In fact, in the usual
+gate model of quantum computation it is assumed that each gate is
+executed at a certain time. Here the times overlap, and if we
+insist on the gates being executed, say from the left to the
+right, we either need infinitely many operation times per step, or
+we run into time ordering problems at the boundary condition.
+
+One way to avoid this problem is to insist on some finite number
+of clock cycles per QCA step, that each gate is executed in one of
+these cycles, and that the gates running in the same cycle do not
+access the same registers. An ``unscrambled version'' of the above
+impossible QCA is drawn in Fig.~\ref{circ2}
+
+\begin{figure}[htb]
+\epsfxsize=5cm \epsffile{circuit2.eps}
+ \caption{\label{circ2}{\it An operational QCA circuit
+         taking two clock cycles}}
+\end{figure}
+
+Clearly, this is a partitioning QCA and, in fact, the description
+we just gave of a circuit with timing constraints is nothing but
+the definition of a partitioning QCA.
+
+\subsection{Clifford automata}
+
+In the implementations of quantum computation there is often a
+separation between ``easily implemented'' operations and others,
+which may be more costly. For example, ''linear'' transformations
+on the quantum light field can be performed with mirrors, beam
+splitters and phase plates, whereas squeezing or photon number
+counting are more costly. A similar choice of a subgroup of
+``easy'' operations for qubit quantum computation is the group of
+transformations, which take tensor products of Pauli matrices into
+tensor products of Pauli matrices, the so called {\it Clifford
+group}\cite{cliff}. Indeed in some implementations these play a
+special role, and can be executed in parallel \cite{onewaycomp}.
+Clearly, it is important to understand this subgroup completely,
+although it is also clear that such transformations alone will not
+allow quantum computational speedup.
+
+The natural mathematical setting for the investigation of Clifford
+QCAs are discrete Weyl systems, with a finite Weyl system acting
+at each site, and the tensor products of one-site Weyl operators
+generating a Weyl system with infinitely many degrees of freedom.
+If the local Weyl system has prime dimension $d$, one can give a
+very explicit description of the group of Clifford QCAs, which
+will be presented elsewhere \cite{OurCliff}. For illustration let
+us just take qubit automata $d=2$ in one dimension.
+
+What is needed to define such an automaton? Since the Pauli
+matrices $\sigma_x$ and $\sigma_z$ generate the one site algebra,
+we only need to specify the two operators $\lrule(\sigma_x)$ and
+$\lrule(\sigma_y)$. The Clifford property means that these two
+operators must be tensor products of Pauli matrices, so we have
+\begin{eqnarray}\label{CQCAstring}
+    \lrule(\sigma_x)&=&\sigma_{\xi_{-N}}\otimes\cdots\sigma_{\xi_{0}}
+                               \otimes\cdots\sigma_{\xi_{N}}
+                               \equiv\sigma(\xi)\\
+    \lrule(\sigma_x)&=&\sigma_{\eta_{-N}}\otimes\cdots\sigma_{\eta_{0}}
+                               \otimes\cdots\sigma_{\eta_{N}}
+                               \equiv\sigma(\eta)\;,\nonumber
+\end{eqnarray}
+where each $\xi_i,\eta_i$ can take the values $0,x,y,z$, with
+$\sigma_0=\idty$. Now the two strings
+$\xi=(\xi_{-N},\ldots,\xi_{N})$ and
+$\eta=(\eta_{-N},\ldots,\eta_{N})$ completely characterize the
+automaton. But which strings are allowed? From the general theory
+we immediately get the necessary and sufficient conditions:
+$\sigma(\xi)$ must commute with all its translates, the same holds
+for $\sigma(\eta)$. Moreover, $\sigma(\xi)$ commutes with
+$\tau_i(\sigma(\eta))$ for $i\neq0$ and anti-commutes for $i=0$.
+Since tensor products of Pauli matrices always either commute or
+anti-commute, one can run a computer search for all examples with
+low neighborhood size $N$. This turns up the surprising result
+that (up to a common translation) the strings $\xi$ and $\eta$
+must be {\it palindromes}, i.e., $\xi_{-k}=\xi_k$.
+
+The general theory \cite{OurCliff} confirms this, and moreover
+etablishes an isomorphism of the group of Clifford QCAs with the
+group of $2\times2$-matrices,
+\begin{equation}\label{CQCAmat}
+    \left(\begin{array}{cc}
+     \xi_+(z)&\eta_+(z)\\\xi_-(z)&\eta_-(z)
+     \end{array}\right)\;,
+\end{equation}
+whose entries are polynomials over the two-element field
+$\Field_2=\{0,1\}$ in one indeterminate $z$, such that the
+determinate is the constant polynomial $1$. Here the coefficients
+of $\xi_\pm$ are bit strings which together determine the string
+$\xi_0,\xi_1,\ldots\xi_N$ used in Eq.~(\ref{CQCAstring}).
+
+One can also find a simple set of generators: Apart from one-site
+transformations and the shift only one QCA is needed:
+\begin{eqnarray}\label{CQCAxzx}
+    \lrule(\sigma_x)&=&\idty\otimes\sigma_{z}
+                   \otimes\idty\\
+    \lrule(\sigma_x)&=&\sigma_{z}\otimes\sigma_{x}\otimes\sigma_{z}\;,\nonumber
+\end{eqnarray}
+possibly, however, acting not between neighboring sites as written
+here, but between sites at a fixed distance $L$, so that the chain
+breaks up into $L$ non-interacting chains.
+
+The prototype (\ref{CQCAxzx}) has a number of interesting
+properties. For example, the iterates $T^t(\sigma(\zeta))$ of an
+initial Pauli product $\sigma(\zeta)$ have a specific form: they
+consist of a Pauli product moving to the left, and  another one
+moving to the right, each at maximal speed, and the expanding
+space between these patterns is filled by one of four
+possibilities: all $\idty$, all $\sigma_y$ or an alternating
+patterns of $\sigma_x\otimes\sigma_y$, or the same shifted by one
+cell.
+
+
+
+\section{Structure}\label{sec:struc}
+In this section we will employ the commutativity property of
+transition rules to get some information about the structure of
+possible rules, aiming at the proof that all QCA transition rules
+can be understood in a partitioning scheme.
+
+Without loss of generality, we consider only nearest neighbor
+rules on a cubic lattice. For a non-cubic lattice we can choose a
+family of basic cells (a ``fundamental domain'') such that all
+cells are generated from these basic ones by translation
+symmetries. By considering the fundamental domain and its
+translates as new cells, we effectively get a family of lattice
+cells labelled by $\Ir^s$. If the neighborhood scheme involves
+more than nearest neighbors, we can again enlarge cells. Of
+course, these operations partly destroy the underlying lattice
+symmetry, so that operations on regrouped cells may fail to have
+the translation (or other) symmetry of the original lattice.
+However, for the proof of structural invertibility a regrouped
+lattice of ``supercells'' works just as well.
+
+We begin by describing the geometry of the generalized Margolus
+partitioning scheme. In the following subsection we state the main
+theorem: this scheme indeed suffices for all QCAs. The proof
+relies on the concept of ``support algebras'', and is described in
+Subsection~\ref{sec:supp}. When the support algebras are abelian,
+one can characterize the possible QCAs at the single cell level,
+without partitioning (see Subsection~\ref{sec:abelianDD}). This
+allows us to determine explicitly all nearest neighbor qubit
+automata in one dimension (Section~\ref{sec:qubits}).
+
+
+\subsection{Generalized Margolus Partitioning}
+\label{sec:margolus}
+
+Consider a cellular automaton with one-site algebra $\AA_0=\MM_d$,
+lattice $\Ir^s$, and {\it nearest neighborhood}
+scheme:
+\begin{equation}\label{NN}
+  \Nei=\{x\in\Ir^s|\  \forall_i|x_i|\leq1\}\;.
+\end{equation}
+We will use a cell grouping introduced by
+Margolus \cite{MarTo}. In this scheme one ``supercell'' is the
+unit cube
+\begin{equation}\label{cube}
+  \Box=\{x\in\Ir^s|\ \forall_i x_i=0,1\}\;,
+\end{equation}
+which consists of $2^s$ cells. The even translates $\Box+2x$ with
+$x\in\Ir^s$ cover the whole lattice. We denote by $Q$ the set of
+$2^s$ {\it quadrant vectors} $q\in\Ir^s$ for which each component
+is $q_i\in\{-1,+1\}$ (see Fig~\ref{margolusT}). In particular the
+vector into the positive quadrant (with all $q_i=+1$) will be
+denoted by $\qone$. Note that the sum of two quadrant vectors is
+an even lattice translation in $2\Ir^s$. Moreover, the $2^s$ cubes
+$\Box+q$ for $q\in Q$ are disjoint and their union contains all
+neighborhoods of cells in $\Box$. Just like the even translates of
+$\Box$, the cubes $\Box+\qone+2x$ with $x\in\Ir^s$ form a
+partition of the lattice (compare Fig.~\ref{margolus}).
+
+\begin{figure}[htb]
+\epsfxsize=5cm \epsffile{margolusT.eps}
+ \caption{\label{margolusT}{\it The Margolus scheme in $s=2$ dimensions.
+ The basic cube `` $\Box$'' is at the center, with the origin marked ``\,$0$''.
+ The shaded squares are reached from the origin by quadrant vectors.
+ Dashed outlines mark the copies $\Box+q$ shifted by quadrant vectors.}}
+\end{figure}
+
+A partitioned automaton based on the Margolus scheme would
+alternatingly apply blockwise unitary transformations to the cubes
+in the two partitions. But not every QCA can be written in this
+way. A good counterexample is the shift in the quadrant direction
+$\qone$. Here the entire quantum information in the $\Ir^s$ cells
+$\Box$ will have to be moved to $\Box+\qone$ although these blocks
+have only a single cell as overlap. It turns out, however, that a
+slight generalization of the Margolus scheme suffices to represent
+every QCA: all we have to do is to allow different cell sizes in
+the intermediate step. For the rest of this subsection we will
+explain the resulting scheme.
+
+With each quadrant vector $q\in Q$ we associate an observable
+algebra $\BB_q\subset\AA(\Box+q)$, which is isomorphic to the
+algebra of $n(q)\times n(q)$-matrices for some integer $n(q)$.
+Since $\BB_q$ is contained in a local algebra, it makes sense to
+consider its (even) translates $\tau_x(\BB_q)\subset\AA(\Box+q+x)$
+with $x\in2\Ir^s$. In particular, $\AA(\Box+\qone)$ contains all
+the algebras $\tau_{\qone-q}(\BB_q)$. A crucial assumption of our
+construction is that these subalgebras of $\AA(\Box+\qone)$
+commute, and together span $\AA(\Box+q)$. This is possible if and
+only if the equation
+\begin{equation}\label{blockdims}
+   \prod_{q\in Q}n(q)=\dtwos
+\end{equation}
+holds for the matrix dimensions. Note that each cell $\AA(\Box+x)$
+has this dimension, whether or not $x$ is even or not.
+
+The local rule of an automaton now defines (and is defined by) a
+homomorphism
+\begin{equation}\label{locMarg}
+    \brule:\AA(\Box)\to\prod_{q\in Q}\BB_q\;.
+\end{equation}
+Since the dimensions of domain and range are the same, such a
+homomorphism is necessarily an isomorphism, i.e., we can find
+suitable bases in each cell and for each of the matrix algebras
+$\BB_q$ such that $\brule(A)=UAU^*$ for a unitary operator
+\begin{equation}\label{bruleU}
+    U:\bigotimes_{x\in\Box}\Cx^d\longrightarrow\bigotimes_q
+                       \Cx^{n(q)}\;.
+\end{equation}
+Such a unitary operator by itself does not fix a QCA, because if
+we only take $\BB_q$ as an abstract matrix algebra, we still need
+to specify how $\tau_{\qone-q}\BB_q$ is contained in
+$\AA(\Box+\qone)$ or, equivalently,  to specify the isomorphism of
+$\bigotimes_q\tau_{\qone-q}\BB_q$ with $\AA(\Box+\qone)$. This
+will be affected by another unitary operator
+\begin{equation}\label{bruleV}
+    V:\bigotimes_q \Cx^{n(q)}\longrightarrow\bigotimes_{x\in\Box+\qone}\Cx^d\;.
+\end{equation}
+
+Any pair of unitaries $(U,V)$ according to
+Eqs.~(\ref{bruleU},\ref{bruleV}) specifies a transformation $T$ on
+local algebras, which satisfies all requirements for a cellular
+automaton, except translation invariance: $T$ only commutes with
+even translations. The scheme in one and two lattice dimensions is
+visualized in Figures~\ref{margolus1}-\ref{figchops}.
+
+\begin{figure}[htb]
+\epsfxsize=5cm \epsffile{test.eps}
+ \caption{\label{margolus1}{\it Generalized Margolus Scheme in $s=1$ dimension.
+ The algebras $\BB_{+1}$ and $\BB_{-1}$ are symbolized by the different size cells
+ in the intermediate step.}}
+\end{figure}
+
+\begin{figure}[htb]
+\epsfxsize=7cm \epsffile{pegacyc.eps}
+ \caption{\label{pegasus}{\it Generalized Margolus Scheme in $s=2$ dimensions.
+ The four subalgebras $\BB_q$ are symbolized by the shapes in Fig.~\ref{figchops}.
+ The tesselation is due to M.C. Escher (1956). }}
+\end{figure}
+%
+%\vskip40pt
+\begin{figure}[htb]
+\epsfxsize=3cm \epsffile{pegpiece.eps}
+ \caption{\label{figchops}{\it The four shapes representing the algebras
+ $\BB_q$ in Fig.~\ref{pegasus}. The arrows indicate the appropriate quadrant vectors $q$.
+}}
+\end{figure}
+
+
+If we want $\grule$, as constructed from unitaries $U$ and $V$, to
+be a proper cellular automaton with full translation invariance,
+there will be additional conditions on these unitaries.
+Unfortunately, these conditions are not easily written down and
+solved in the general case. We also note that $U$ and $V$ are not
+uniquely determined by the automaton: we have the freedom to
+choose a basis in every $\Cx^{n(q)}$. Changing this basis amounts
+to a cellwise rotation included in $U$, which is immediately
+undone by the $V$-step. The key feature of automata in a
+partitioned scheme is {\it structural reversibility}, as described
+in the following Lemma.
+
+\begin{lemma}\label{invMarge}
+Let $\grule$ be a homomorphism constructed from unitaries $(U,V)$
+in the generalized Margolus scheme. Then $\grule$ is invertible,
+and $\grule^{-1}$ is also a generalized Margolus automaton.
+Moreover, if $\grule$ commutes with all (not just even)
+translations, then both $\grule$ and $\grule^{-1}$ are nearest
+neighbor QCAs.
+\end{lemma}
+
+\proof: The Margolus unitaries defining $\grule^{-1}$ are
+$(V^*,U^*)$. To check the localization properties, it is helpful
+not to think of these transformations in the apparently
+time-asymmetric scheme of Fig.~\ref{pegasus}, but to take $\BB_q$
+as an algebra localized in the intersection of the cubes $\Box$
+and $(\Box+q)$, i.e., as localized at the cell $(\qone+q)/2$. Note
+that $\grule^{-1}$ is a two-sided inverse, and hence uniquely
+determined by $\grule$.
+
+Therefore, if $\grule$ commutes with all translations, so does
+$\grule^{-1}$. It remains to check that if $\grule$ is a Margolus
+automaton commuting with translations, it is actually a nearest
+neighbor automaton, i.e., a QCA with neighborhood scheme $\Nei$
+from (\ref{NN}). Since, for every $x\in\Box$, we have
+$0\in(\Box-x)$, we have
+\begin{equation}
+   \grule(\AA_0)
+      \subset\grule(\AA(\Box-x))
+      \subset\bigotimes_{q\in Q} \AA(\Box+q-x)\;.
+\end{equation}
+Since this is valid for {\it all} $x\in\Box$, we have
+$\grule(\AA_0)\subset\AA(\widetilde\Nei)$, with
+\begin{equation}\label{neimarg}
+    \widetilde\Nei=\bigcap_{x\in\,\Box}\bigcup_{q\in Q}(\Box+q-x)=\Nei
+\end{equation}
+ \qed
+
+
+
+
+\subsection{Main Theorem}
+
+\vbox{
+\begin{theorem}\label{mainthm}
+Let $\grule$ be the global transition homomorphism of a nearest
+neighbor quantum cellular automaton on the lattice $\Ir^s$ with
+single-cell algebra $\AA_0=\MM_d$. Then $\grule$ can be
+represented in the generalized Margolus partitioning scheme, i.e.,
+$\grule$ restricts to an isomorphism
+\begin{equation}
+    \grule:\AA(\Box)\longrightarrow \bigotimes_{q\in Q}\BB_q \;,
+\end{equation}
+where for each quadrant vector $q\in Q$, the subalgebra
+$\BB_q\subset\AA(\Box+q)$ is a full matrix algebra,
+$\BB_q\cong\MM_{n(q)}$. These algebras and the matrix dimensions
+$n(q)$, which satisfy Eq.~(\ref{blockdims}), are uniquely
+determined by $\grule$.
+\end{theorem}
+}
+
+
+Combining this with Lemma~\ref{invMarge}, we get
+
+\begin{corr}\label{cor:invert}
+The inverse of a nearest neighbor QCA exists, and is a nearest
+neighbor QCA.
+\end{corr}
+
+Note that this result is in stark contrast to the classical
+situation. In the classical case the inverse of an injective CA is
+a CA, i.e., locally invertible, but it is a highly non-trivial
+matter to determine the neighborhood scheme of the inverse, which
+can be much larger than the neighborhood of the automaton itself.
+This is not a contradiction with the observation that every
+classical CA can be quantized (see Section~\ref{sec:classical}):
+In order to construct a QCA from a classical CA, we needed the
+neighborhood size of the inverse.
+
+The proof of the Theorem will be given in
+subsection~\ref{sec:proof}. The key idea is to  construct
+$\BB_q\subset\AA(\Box+q)$ explicitly from the inclusion
+$\grule(\AA(\Box))\subset\bigotimes_q\AA(\Box+q)$. This
+construction, which will also be useful independently, will be
+described in the next section.
+
+
+\subsection{Support Algebras of Local Rules}\label{sec:supp}
+
+By definition, the transition rule $\lrule$ maps one cell algebra
+into a tensor product of neighboring ones. Therefore we need to
+investigate just how one subalgebra can sit inside a tensor
+product of others.
+
+Consider a subalgebra $\AA\subset\BB_1\otimes\BB_2$ of tensor
+product. For the moment let us forget about the multiplication
+laws, and just consider these as vector spaces, with the tensor
+product known from the (multi-)linear algebra of finite
+dimensional vector spaces. Then we can expand each $a\in\AA$ into
+a sum $a=\sum_\mu b_\mu^{(1)}\otimes b_\mu^{(2)}$. But we might
+get by just using a small subset of operators $b_\mu^{(i)}$. The
+smallest subspace of $\BB_1$ sufficient for these expansions will
+be called the {\it support} of $\AA$ on the first factor, and will
+be denoted by $\spp(\AA,\BB_1)$. For a more formal definition note
+that each $a\in\AA$ can be expanded uniquely in the form
+$a=\sum_\mu a_\mu\otimes e_\mu$, where $\{e_\mu\}$ is fixed a
+basis of $\BB_2$. Then $\spp(\AA,\BB_1)$ is the linear span of all
+$a_\mu$ in this expansion, and is clearly independent of the basis
+$\{e_\mu\}$ chosen for $\BB_2$. Then it is clear that
+$b_\mu^{(i)}\in \spp(\AA,\BB_i)$ indeed suffice to expand every
+$a\in\AA$, i.e.,
+\begin{equation}\label{a2supp}
+  \AA\subset \spp(\AA,\BB_1)\otimes \spp(\AA,\BB_2)
+      \subset\BB_1\otimes\BB_2\;.
+\end{equation}
+The analogous relation for $\AA$ contained in a tensor product of
+more factors is seen in the same way.
+
+Now we remember the algebraic structure: $\spp(\AA,\BB_i)$ is a
+linear subspace of a C*-algebra, so we can define the {\it support
+algebra} $\Spp(\AA,\BB_i)$ of $\AA\subset \bigotimes_i\BB_i$ on
+one factor $\BB_i$ as the subalgebra of $\BB_i$ generated by the
+elements of $\spp(\AA,\BB_i)$ \cite{Zanardi}. Then we also have
+\begin{equation}\label{a2Supp}
+  \AA\subset \Spp(\AA,\BB_1)\otimes \Spp(\AA,\BB_2)
+      \subset\BB_1\otimes\BB_2\;.
+\end{equation}
+ Note that since any observable algebra $\AA$ is closed under adjoints, so is
+$\Spp(\AA,\BB_1)$. The crucial fact we need about such inclusions
+is the following:
+
+\begin{lemma} \label{sppcomm}
+Let $\AA_1\subset\BB_1\otimes\BB_2$ and
+$\AA_2\subset\BB_2\otimes\BB_3$ be subalgebras such that
+$\AA_1\otimes\idty_3$ and $\idty_1\otimes\AA_2$ commute in
+$\BB_1\otimes\BB_2\otimes\BB_3$. Then $\Spp(\AA_1,\BB_2)$ and
+$\Spp(\AA_2,\BB_2)$ commute in $\BB_2$.
+\end{lemma}
+
+\proof:\quad Pick bases $\{e_\mu\}\subset\BB_1$ and
+$\{e'_\nu\}\subset\BB_2$, and let $a\in\AA_1$ and $a'\in\AA_2$.
+Then we may expand uniquely: $a=\sum_\mu e_\mu\otimes a_\mu$ and
+$a'=\sum_\nu a'_\nu\otimes e'_\nu$. Then by assumption
+\begin{displaymath}
+ 0=[a\otimes\idty_3,\idty_1\otimes a']
+  =\sum_{\mu\nu}e_\mu\otimes [a_\mu,a'_\nu]\otimes e'_\nu \;.
+\end{displaymath}
+Now since the elements $e_\mu\otimes e'_\nu$ are a basis of
+$\BB_1\otimes\BB_3$, this expansion is unique, so we must have
+$[a_\mu,a'_\nu]=0$ for all $\mu,\nu$. Clearly, this property also
+transfers to the algebras generated by the $a_\mu$ and $a'_\nu$,
+i.e., to the support algebras noted in the Lemma. \qed
+
+
+\subsection{Proof of the Main Theorem}\label{sec:proof}
+
+We apply the construction of support algebras to the inclusion
+\begin{equation}\label{inclusion}
+  \grule(\AA(\Box))\subset\bigotimes_q\AA(\Box+q)
+\end{equation}
+and define
+\begin{equation}\label{defBBq}
+    \BB_q=\Spp(\grule(\AA(\Box)),\AA(\Box+q))\;.
+\end{equation}
+
+
+As a finite dimensional C*-algebra, each $\BB_q$ is isomorphic to
+$\BB_q=\bigoplus_\mu\MM_{n(q,\mu)}$ (See
+Proposition~\ref{Csform}). Now $\grule(\AA(\Box))$ is
+homomorphically embedded into $\bigotimes_q\BB_q$, with
+$\grule(\idty)=\idty$. Hence by Proposition~\ref{Cshom} we know
+that for any choice of summands $\mu_q$ we must have that
+$\dtwos$, the matrix dimension of $\AA(\Box)$, divides
+$\prod_qn(q,\mu_q)$. This gives a lower bound on the block sizes.
+
+In order to get an upper bound, consider the support algebras
+contained in some shifted cube, such as $\Box+\qone$. These are
+\begin{eqnarray}
+ \Spp\Bigl(\grule(\AA(\Box+\qone-q))&,&\AA(\Box+\qone)\Bigr)
+  \nonumber\\
+  &=&\tau_{\qone-q}\Spp\Bigl(\grule(\AA(\Box)),\AA(\Box+q)\Bigr)
+  \nonumber\\
+  &=&\tau_{\qone-q}(\BB_q)\;
+\end{eqnarray}
+Since the $\AA(\Box+\qone-q)$ commute, so do their images under
+$\grule$ and, by Lemma~\ref{sppcomm}, so do the algebras
+$\tau_{\qone-q}(\BB_q)\subset\AA(\Box+\qone)$. However, we do not
+know a priori that these algebras are contained in
+$\AA(\Box+\qone)$ like a tensor product: When
+$z_{q,\mu_q}\in\BB_q$ is a central projection onto one of the
+matrix blocks of $\BB_q$, it is clear that the product
+$\prod_qz_{q,\mu_q}$ is a central element of the algebra generated
+by the $\BB_q$, but it might be zero. On the other hand, there
+must be {\it some} choice of blocks $\mu_q$, for which this is
+non-zero, and for this combination $\prod_q\MM_{n(q,\mu_q)}$,
+which is isomorphic to $\MM_n$ with $n=\prod_qn(q,\mu_q)$, is a
+direct summand of $\prod_q\BB_q\subset\AA(\Box+\qone)$. Hence we
+get the inequality
+\begin{equation}\label{dimineq}
+   \dtwos\geq\prod_qn(q,\mu_q)\;.
+\end{equation}
+
+
+On the other hand, by the first step, the left hand side divides
+the right hand side of this inequality, so the we must have
+equality. This also implies that only one summand can be present
+in $\BB_q$, so we get $\BB_q\cong\MM_{n(q)}$ with
+$n(q)=n(q,\mu_q)$. That $\grule$ is an isomorphism from
+$\AA(\Box)$ onto $\bigotimes_q\BB_q$ follows by a direct dimension
+count, since a *-homomorphism between full matrix algebras of
+equal dimension can only be zero or an isomorphism. \qed
+
+
+\subsection{QCAs with abelian neighborhood}\label{sec:abelianDD}
+In a sense, Theorem~\ref{mainthm} gives a complete constructive
+procedure for QCAs in terms of the two unitary operators $U$, $V$
+with a constraint. Unfortunately, however, it does not seem to be
+easy to give a general solution of  the constraint equations
+expressing the translation invariance (rather than the invariance
+by even translations). Therefore it is suggestive to repeat the
+analysis of support algebras also on the single cell level.
+Setting
+\begin{equation}\label{Dlocal}
+  \DD_x=\Spp\bigl(\lrule(\AA_0), \AA_x\bigr)
+\end{equation}
+we have
+\begin{equation}\label{Dlocalsub}
+  \lrule(\AA_0) \subset\bigotimes_{x\in\Nei}\DD_x
+\end{equation}
+It is clear that since $\lrule(\AA_0)$ is non-abelian, at least
+one of the algebras $\DD_x$ must also be non-abelian. The simplest
+case in this regard will be when all $\DD_x$ are abelian and
+commute with each other, except one, say $\DD_0$, which then has
+to isomorphic to the full cell algebra $\AA_0$ by
+Prop.\ref{Cshom}. Since all $\DD_x$ commute, we can jointly
+diagonalize them and this fixes a canonical basis for every cell.
+When $\ket\mu$ denotes the basis vectors, we can write the local
+transition rule as
+\begin{equation}\label{conditionalrule}
+  \lrule(A)
+  =\sum_{\mu_\Nei} U(\mu_\Nei)^*AU(\mu_\Nei)\otimes
+    \bigotimes_{0\neq x\in\Nei}\ketbra{\mu_x}{\mu_x}\;,
+\end{equation}
+ where the sum runs over all tuples $\mu_\Nei$ of basis labels
+$\mu_x$ for $x\in\Nei, x\neq0$ and, for each such tuple, $U(\mu_\Nei)$ is
+a unitary operator. Thus $\lrule$ describes a {\it conditional unitary
+operation} on cell $0$, where the conditioning is in some fixed
+``computational basis''.
+
+We now need to analyze the constraints on these unitaries needed to make
+this homomorphism $\lrule$ a local transition rule. As a first step we
+look at the simplest case:
+
+\begin{lemma} Let $U_\mu,V_\nu\in\MM_d$ be unitary operators ($\mu,\nu=1,\ldots,d$)
+such that, for all $A,B\in\MM_d$,
+\begin{equation}\label{condscommute}
+   \sum_{\mu\nu}\Bigl[U_\mu^*AU_\mu\otimes\ketbra\mu\mu,\;
+                      \ketbra\nu\nu\otimes V_\nu^*BV_\nu\Bigr]=0
+\end{equation}
+Then there are unitary $U,V\in\MM_d$ such that, for all $\mu$,
+$U^*U_\mu$ and $V^*V_\mu$ are diagonal.
+\end{lemma}
+
+\proof :\quad Let us abbreviate $A_\mu=U_\mu^*AU_\mu$,
+$B_\nu=V_\nu^*BV_\nu$, and take the matrix element of equation
+(\ref{condscommute}) in the product basis vectors
+$\bra{\alpha\beta}\cdots\ket{\gamma\delta}$. This gives
+\begin{equation}
+  \bra\alpha A_\beta\ket\gamma\; \bra\beta B_\gamma\ket\delta
+  =\bra\alpha A_\delta\ket\gamma\; \bra\beta B_\alpha\ket\delta
+  \nonumber
+\end{equation}
+ Now set $B=V_\alpha\ketbra{\beta'}{\delta'}V_\alpha^*$, with
+ $\beta'\neq\beta$. Then $B_\alpha=\ketbra{\beta'}{\delta'}$, and
+ $\bra\beta B_\alpha\ket\delta=0$, and the right hand side vanishes.
+Hence, for every $A$ and every $\delta'$
+\begin{equation}
+  \bra\alpha A_\beta\ket\gamma\;
+  \bra\beta V_\gamma^* V_\alpha\ket{\beta'}
+  \bra{\delta'}V_\alpha^*V_\gamma \ket\delta
+  =0.
+  \nonumber
+\end{equation}
+Now the first factor can be made non-zero by an appropriate choice
+of $A$, and the third factor can be made non-zero by choosing
+$\delta'$, because the unitary operator $V_\alpha^*V_\gamma$
+cannot annihilate $\ket\delta$. It follows that
+ $\bra\beta V_\gamma^* V_\alpha\ket{\beta'}=0$ vanishes for all
+indices, or $V_\gamma^* V_\alpha$ is diagonal for all
+$\alpha,\gamma$. Hence the Lemma follows with $V=V_1$, and the
+statement for $U$ follows by symmetry.\qed
+
+Let us apply this Lemma to the one-dimensional nearest neighbor
+case. Then a local rule of the form (\ref{conditionalrule}) can be
+written as
+\begin{equation}\label{conditionalrule1D}
+  \lrule(A)
+  =\sum_{\mu\nu} \ketbra\mu\mu\otimes U_{\mu\nu}^*AU_{\mu\nu}
+                    \otimes\ketbra{\nu}{\nu};.
+\end{equation}
+ The remaining commutation condition is, for arbitrary one-site
+ observables $A,B$,
+\begin{eqnarray}\label{commute1D}
+  0&=&[\lrule(A)\otimes\idty, \idty\otimes\lrule(B)]
+                                \nonumber\\
+  &=&\sum_{\mu\nu\mu'\nu'} \ketbra\mu\mu\otimes
+    \Bigr[U_{\mu\nu}^*AU_{\mu\nu}\otimes\ketbra{\nu}{\nu},
+                                    \nonumber\\ &&\qquad
+      \ketbra{\mu'}{\mu'}\otimes U_{\mu'\nu'}^*BU_{\mu'\nu'}
+    \Bigr]\otimes\ketbra{\nu'}{\nu'}
+\end{eqnarray}
+Hence we can apply the Lemma to the commutator separately for
+every pair $\mu,\nu'$, and we find that up to a common unitary all
+$U_{\mu\nu}$ have to commute. Again, up to a cell-wise unitary
+rotation, we can choose the common eigenbasis of the $U_{\mu\nu}$
+as the same basis in which the conditions are written, i.e.,
+\begin{equation}\label{phase1D}
+  U_{\mu\nu}=\sum_\kappa u(\mu\kappa\nu) \ketbra\kappa\kappa \;,
+\end{equation}
+ with some phase function $u$ depending on three neighboring basis
+labels. However, this phase function $u$ is not arbitrary:
+unitaries of the form (\ref{phase1D}) in this way may still fail
+to satisfy (\ref{commute1D}). If we insert $A=\ketbra ab$ and
+$B=\ketbra{a'}{b'}$ we get the functional equation
+\begin{equation}\label{uuuu}
+   \frac{u(\mu b a')}{u(\mu a a')}\cdot \frac{u(bb'\nu')}{u(ba'\nu')}
+  =\frac{u(\mu b b')}{u(\mu a b')}\cdot \frac{u(ab'\nu')}{u(aa'\nu')}\;.
+\end{equation}
+Since we want to classify solutions up to a cell-wise rotation, we
+can take one of the unitaries $U_{\mu\nu}$ to be the identity, say
+$U_{11}=\idty$, or $u(1x1)=1$. Moreover, an overall phase of
+$U_{\mu\nu}$ is irrelevant, and we can choose this so
+$u(\mu1\nu)=1$. Then in (\ref{uuuu}) we take $a=b'=\nu'=1$, which
+gives
+\begin{equation}\label{uuuusolve}
+  u(\mu ba')=u(\mu b1)u(ba'1)
+\end{equation}
+ Thus $u$ is already determined by the two-variable function
+$(a,b)\mapsto u(a,b,1)$. It is easy to check that any choice of
+this function yields a solution of (\ref{uuuu}) via
+(\ref{uuuusolve}).
+
+We can summarize the result as follows:
+
+\begin{proposition}\label{prop:abelianDD}
+ Let $\lrule$ be the local transition rule of
+a QCA such that $\DD_1$ and $\DD_{-1}$ are both abelian. Then,
+with respect to a basis in which these algebras are diagonal,
+there is a phase gate on $\Cx^d\otimes \Cx^d$:
+\begin{equation}\label{phasegate}
+  U=\sum_{ab}u(a,b)\ketbra{ab}{ab} \;,
+\end{equation}
+ normalized such that $u(1,b)=u(b,1)=1$, and a one-site unitary
+ $V$ such that
+\begin{eqnarray}\label{phasealfa}
+ \lrule(A)&=&X^*(\idty\otimes V^*AV\otimes\idty)X \qquad \mbox{with}\nonumber\\
+  X&=& (U\otimes\idty_3)(\idty_1\otimes U)\;. \nonumber
+\end{eqnarray}
+\end{proposition}
+
+
+\subsection{Unilateral Automata}
+
+Another case of automata in one dimension, which can be characterized
+completely, are automata with neighborhood scheme $\Nei=\{0,1\}$ (or,
+symmetrically, $\Nei=\{-1,0\}$). The analysis is almost identical to that
+of Theorem~\ref{mainthm}, and gives full matrix algebras
+$\DD_i=\Spp(\lrule(\AA_0),\AA_i)=\MM_{n_i}$ and such that $n_0n_1=d$. As
+in the case of the Theorem, the local rules combines an arbitrary unitary
+$U:\Cx^d\to\Cx^{n_0}\otimes\Cx^{n_1}$ with a unitary
+$V:\Cx^{n_1}\otimes\Cx^{n_0}\to\Cx^d$.  We only mention these to state
+the following classification of the simplest case:
+
+\subsection{Nearest neighbor qubit automata in one
+dimension}\label{sec:qubits}
+
+Consider the right and left support algebras
+$\DD_{-1},\DD_{0},\DD_{+1}$ as in (\ref{Dlocal}). These are
+subalgebras of the $2\times2$-matrices, which leaves three
+possibilities: each of these algebras can either be trivial
+($\DD_i=\Cx\idty$), an abelian two-state algebra (isomorphic to
+the diagonal matrices, or the full algebra $\MM_2$.
+
+Suppose that at least one of the algebras  $\DD_{\pm1}$, say
+$\DD_{-1}$, is trivial. Then we have a unilateral automaton. Since
+$n_0n_1=2$ we must have either $n_0=2, n_1=1$, a cell-wise unitary
+rotation or $n_0=1, n_1=2$ a right shift, possibly combined with a
+cell-wise rotation.
+
+Suppose that none of the algebras $\DD_{\pm1}$ is trivial. Then
+because $\DD_{-1}$ commutes with $\DD_{+1}$ neither algebra can be
+the full matrix algebra, since that would force the other to be
+trivial. It follows that both are abelian, and commute. Hence
+after a basis change (by another cell-wise rotation) we can take
+$\DD_{-1}=\DD_{+1}$ as the algebra of diagonal
+$2\times2$-matrices. This brings us into the situation of
+Section~\ref{sec:abelianDD}, and we find a phase rotation.
+Choosing the normalization in Proposition~\ref{prop:abelianDD}, we
+have only one free parameter left, i.e., we have an automaton
+built from commuting unitaries $U_x$ (cf.
+Section~\ref{sec:basicon}), which are {\it phase gates}
+\begin{equation}\label{phigate}
+  U_x=\left(\begin{matrix}1&0&0&0\\0&1&0&0\\0&0&1&0\\
+             0&0&0&e^{i\phi}
+       \end{matrix}\right)\;.
+\end{equation}
+
+The classification is hence complete. It is represented in
+Fig.\ref{qbit}.
+\begin{figure}[htb]
+\epsfxsize=6cm \epsffile{qbit.eps}
+ \caption{\label{qbit}{\it All nearest neighbor qubit automata arise by combining
+  cell-wise unitary rotations $(C)$ with right shifts  $(R)$, left shifts $(L)$,
+  or phase gates $(P)$.}}
+\end{figure}
+
+It is interesting to compare this with the classical case, which
+can be stated very similarly: then the only cell-wise operations
+are identity and global flip. Of course, the possibility of phase
+gates does not arise, leaving 6 classical possibilities.
+
+Beyond qubits, a good classification exists for Clifford automata
+in prime dimension \cite{OurCliff}. However, for general
+three-level systems the classification is likely to be
+complicated, since there is already a host of reversible classical
+nearest neighbor automata.
+
+\section{Other Approaches}\label{sec:others}
+In this section we take a look at the various proposals for
+defining QCAs, and show how they relate to the approach taken in
+this paper.
+
+\subsection{Feynman, and Transition Quasi-Probabilities}\label{sec:Feynman}
+The idea of a quantum cellular automaton is clearly present in
+Feynmans's famous 1981 lecture \cite{Feynman}. Although he
+suggests not only that a theory might and should be developed, and
+that it might even be taken seriously as fundamental physical
+theory, he does not actually develop a notion of QCAs in this
+article. The context in which he does write down a transition rule
+for a QCA, is where he discusses the possibility of simulating a
+QCA with a probabilistic cellular automaton. He emphasizes that
+this would involve something like negative transition
+probabilities and closes this section saying ``... I wanted to
+explain that if I try my best to make the equations look as near
+as possible to what would be imitable by a classical probabilistic
+computer, I get into trouble''.
+
+Feynman's idea for making a QCA look as classical as possible is
+to replace ``transition probabilities'' by Wigner function-like
+``transition quasi-probabilities''. This approach is an
+interesting contribution to the definition of {\it irreversible}
+QCAs, which is still plagued with problems. However, as Feynman is
+clearly aware, it fails, and it is instructive to analyze this
+failure in the case of reversible automata.
+
+The transition function of a classical probabilistic cellular
+automaton (for a set $S$ of single-cell states) is a set of
+probabilities $M(s'|s_{\Nei})$ specifying the probability of
+finding a state $s'\in S$, when the configuration of the neighbors
+at the previous time step is $s_\Nei$. Using the ``simultaneous
+and independent update rule'' the probability for finding a
+configuration $s_\Lambda$ in a finite region $\Lambda\subset\Ir^s$
+becomes
+\begin{equation}\label{PCA}
+  M(s'_\Lambda|s)=\prod_{x\in\Lambda}M(s'_x|s_{\Nei+x})\;.
+\end{equation}
+Note that this is readily read as a statement in the Heisenberg
+picture: the probability for $s'_\Lambda$ is expressed as the
+expectation of a random variable in the previous time step, namely
+the right hand side of (\ref{PCA}), considered as a function of
+the variables $s_x$. In the quantum case, $M(s'|s_\Nei)$ would
+then become an observable in $\AA_\Nei$, depending in a linear
+(and completely positive) way on an observable $s'\in\AA_0$. This
+is precisely a description of the local transition rule $\lrule$.
+Note that the commutation condition for local rules
+(Lemma~\ref{lem:localrule}) implies that the product is
+well-defined, independently of the ordering of the factors. In a
+more general quantum context, such as irreversible QCA evolutions
+for which the global rule will not respect the product,  we cannot
+be sure of this property: additional information about the
+ordering of factors in (\ref{PCA}) would have to be supplied, but
+even an ordering fixed by some convention would not prevent the
+evolution from sometimes taking hermitian elements to
+non-hermitian elements.
+
+This latter problem: the ordering of factors and the hermiticity
+is neatly solved by Feynman's approach of quasi-probabilities. He
+expands all qubit operators in a special basis of four hermitian
+operators $F(\xi)\in\MM_2$, $\xi\in\{{++},{+-},{-+},{--}\}$:
+\begin{equation}\label{Feyman_Wigner}
+  F_{uv}=\left(\begin{matrix}
+             (1+u)/2  &v(1-iu)/4\\
+             v(1+iu)/4& (1-u)/2
+          \end{matrix}\right) \;, (u,v=\pm1)\;.
+\end{equation}
+The expectations $f_\rho(\xi)=\tr(\rho F(\xi))$ of these operators
+are the analogs of the Wigner function (see \cite{Wootters,Paz}
+for later elaborations on Wigner functions in finite dimension).
+Of course, by taking tensor products of these operators we get
+Wigner functions for multi-qubit systems. Now we can expand the
+transition rule for a single cell in Wigner operators:
+\begin{equation}\label{alfa0Wig}
+  \lrule(F(\eta_0))
+    =\sum_{\xi_\Nei}M(\eta_0|\xi_\Nei)
+      \bigotimes_{x\in\Nei} F(\xi_x) \;,
+\end{equation}
+ with the transition quasi-probabilities $M(\eta_0|\xi_\Nei)$.
+These are usually not positive, but this is a minor inconvenience
+as long as the physical transition operator $\grule$ is positive.
+Equation~(\ref{alfa0Wig}) is just an expansion of the local rule
+in a basis of Wigner operators, so a local rule is completely
+equivalent to a set of transition quasi-probabilities. The
+difference between the quasi-probability approach and ours is how
+the global rule is constructed. Let us consider, for simplicity,
+the image of a two-site observable $F(\eta_1)\otimes F(\eta_2)$
+under a one-dimensional nearest neighbor automaton. According to
+(\ref{PCA}), transition probabilities must be combined as
+\begin{equation}\label{alfa1Wig}
+\begin{array}{l}\displaystyle
+  \grule_{\rm quasi}(F(\eta_1)\otimes F(\eta_2))\\ \displaystyle
+   {}\quad=\sum_{\xi_0,\xi_1,\xi_2,\xi_3}M(\eta_1|\xi_0,\xi_1,\xi_2)
+             M(\eta_2|\xi_1,\xi_2,\xi_3)
+   \rule[-25pt]{0pt}{45pt}\\
+   \displaystyle{}\ \qquad\qquad\times
+    F(\xi_0)\otimes F(\xi_1)\otimes F(\xi_2)\otimes F(\xi_3)\;.
+\end{array}
+\end{equation}
+ We can extend this to arbitrarily large configurations to get the
+time evolution of an automaton in the Heisenberg picture. Since
+the transition quasi-probabilities are real, this evolution will
+automatically preserve hermiticity, and since $\sum_\xi
+F(\xi)=\idty$ all normalization and locality properties will
+automatically come out correctly. Of course, there will be no
+operator ordering problem, since we multiply at the level of
+functions, and all this will work for probabilistic irreversible
+and reversible transition rules alike.
+
+On the other hand, under the homomorphism $\grule$ the tensor
+product $F(\eta_1)\otimes F(\eta_2)$ is evolved to
+\begin{equation}\label{alfa2Wig}
+\begin{array}{l}\displaystyle
+  \grule(F(\eta_1)\otimes F(\eta_2))\\ \displaystyle
+    {}\ = \sum_{{\xi_0,\xi_1,\xi_2,\xi_3}\atop{\xi'_0,\xi'_1,\xi'_2,\xi'_3}}
+             M(\eta_1|\xi_0,\xi_1,\xi_2)
+             M(\eta_2|\xi'_1,\xi'_2,\xi'_3)
+    \rule[-25pt]{0pt}{45pt}\\\displaystyle
+           {}\quad \times
+    F(\xi_0)\otimes F(\xi_1)F(\xi'_1)
+       \otimes F(\xi_2)F(\xi'_2)\otimes F(\xi'_3)
+\end{array}
+\end{equation}
+Then (\ref{alfa1Wig})=(\ref{alfa2Wig}), iff
+$F(\xi)F(\eta)=\delta_{\xi\eta}F(\xi)$, which is obviously true
+for the minimal projections in a classical observable algebra, but
+obviously false for the Wigner operators. So the automata studied
+in this paper are not (or not in general) representable as
+quasi-probabilistic CAs.
+
+Feynman uses the approach based on (\ref{alfa1Wig}) only as a
+caricature of a quantum process. He points out that negative
+transition quasi-probabilities exclude a simulation of the global
+time step (\ref{PCA}) by successive independent random trials. For
+him this indicates the increased complexity of quantum
+computation.
+
+Whether or not this approach  works as a definition of (possibly
+also irreversible) QCAs hinges on the question of positivity.
+Non-positive transition probabilities would not be serious if they
+lead to the construction of a legitimate (i.e., completely
+positive) global transition rule. Unfortunately, however, there is
+no indication that quantum positivity improves in the passage from
+local to global rule. This can be seen already for a simple phase
+gate array, i.e., (P) in Fig.~\ref{qbit}. For generic phase angle
+$\varphi$ neither the local transition nor the global transition
+e.g., the expression (\ref{alfa2Wig}), have positive transition
+quasi-probabilities, although, of course, they correspond to
+completely positive operations. On the other hand, the two-site
+transition rule (\ref{alfa1Wig}) takes some positive operators
+into non-positive ones.
+
+An interesting special case occurs for phase angle $\phi=\pi$. In
+that case, the local rule does give rise to positive, and even
+{\it deterministic} transition quasi-probabilities.  They belong
+to a classical deterministic CA, which like the phase gate QCA is
+its own inverse. But if it is applied as in (\ref{alfa1Wig}), it
+violates positivity.
+
+
+
+\subsection{Watrous et al.}
+One of the first serious attempts at the definition of QCAs was by
+Watrous \cite{Watrous}. It is based on another ``quantization'' of
+the transition probability formula (\ref{PCA}), inspired by
+Feynman's notion that in quantum theory one must replace
+probabilities by amplitudes. Thus one tries a product formula like
+(\ref{PCA}) for the transition amplitudes, presumably defining in
+this way the unitary transition operator for the whole process:
+\begin{equation}\label{watrousCA}
+ U(a|b)=\prod_x  u(a_x|b_{\Nei+x})\;,
+\end{equation}
+ where $a,b$ are classical configurations, labelling the basis
+states of the QCA, and $b_{\Nei+x}$ is the configuration $b$
+restricted to the neighborhood of $x$. The function $u$ plays the
+role of the local transition rule. Basically the same definition
+is also used in van Dam \cite{vanDam}, where it is phrased as an
+assignment of a a product vector to every basis state in the
+computational basis. Further work in this approach is to be found
+in \cite{santa}, and in the textbook \cite{Gruska}, or a recent
+introduction \cite{Aoun}. For the sake of discussion let us call
+an automaton defined by (\ref{watrousCA}) a WQCA.  There are
+several problems with this formula:
+
+\begin{enumerate}
+\item
+ The infinite product may not be defined. This may be resolved by
+either introducing a ``quiescent state'' which is invariant under
+the evolution, and considering only superpositions of
+configurations which are quiescent outside a finite region
+\cite{Watrous,santa}, or to look at periodic boundary conditions
+only \cite{vanDam}. Either approach works, but none of these
+workarounds is necessary in our definition.
+
+\item $U$ from (\ref{watrousCA}) has no reason to be unitary, and
+most of the time it isn't. In other words, there is no
+straightforward way of characterizing those local transition
+amplitudes $u$ for which the formula does indeed define an
+isometric (or stronger: a unitary) operator, in which case the
+rule is called ``well-formed'' (or unitary). Whereas positivity
+and normalization of the local rule $M$ on the right hand side of
+(\ref{PCA}) guarantee the corresponding properties for the global
+evolution, no equally simple criterion exists for well-formedness
+(but see \cite{santa} for algorithms in the one-dimensional case).
+
+\item Many unitary operators are not of the form
+(\ref{watrousCA}). To begin with, the definition depends on the
+choice of a preferred basis. In general, the product of two WQCA
+unitaries need not be a WQCA (with larger neighborhood), and the
+inverse of a WQCA may fail to be a WQCA. This
+makes it hard to build a general theory on this definition.
+\newline
+ To get an example of these phenomena note that a necessary
+condition for a unitary of Watrous form is that the computational
+basis states are mapped to product states. Moreover, if we follow
+the unitary operator by a site-wise unitary rotation, or precede
+it by a product of phase gates (i.e., introducing additional phase
+factors independent of the output labels $a_x$), we stay in this
+class. But now consider a sitewise Hadamard rotation, followed by
+a product of phase gates. It is easy to verify that such a map
+does not take the computational basis states to product states (or
+Briegel's one-way computers would not work.) So this is not a
+WQCA, although it is the product of two WQCAs, and its inverse is
+also a WQCA .
+
+\item Even in the cases where the formula does work, such as,
+e.g., for the multiplication by local phases, the size of the
+neighborhood in (\ref{watrousCA}) is not the neighborhood scheme
+describing the propagation of observable effects (the $\Nei$ of
+our definition), but rather the $\widetilde\Nei$ from
+Section~\ref{sec:communitary}. In fact, it is not even clear
+whether a WQCA is necessarily local in our sense: We did not
+manage to exclude the possibility that a local measurement after
+one time step might allow inferences about arbitrarily distant
+modifications of the state.
+
+\item in the original paper \cite{Watrous}, Watrous also looks at
+partitioned automata. Since we prove that all QCAs can be obtained
+by a partitioning scheme, it might seem that WQCA$\supset$QCA, in
+seeming contradiction to the Example in 3 above. However, Watrous
+uses only a special case of partitioning, namely a unitary
+followed by a permutation of subcells. Only if we extend the class
+of WQCAs and include all their products, we get all QCAs.
+
+
+\end{enumerate}
+To summarize: Judged by the criteria in the introduction, the
+notion of Watrous is not a satisfactory formalization of the idea
+of quantum cellular automata. What is lacking is the easy passage
+from local to global rules, and from global axiomatic to local
+constructive description. For all problems involving the iteration
+of automata, the fact that the class is not closed under
+composition and inverse, puts a premature end to studies based on
+WQCAs.
+
+
+\subsection{Richter and Werner}
+
+As mentioned earlier, the observable-based approach underlying our
+definition was first used in \cite{RiWe} by one of us, but with a
+focus on the irreversible case. In that paper partitioning
+(dissipative cell evolution combined with permutation of subcells)
+was used to allow a free construction satisfying a global locality
+condition.
+
+It is not so clear what should replace the axiomatic definition in
+the irreversible case. A possible condition is to just replace the
+local rule $\lrule$ by a completely positive map, and insist on
+commutativity as before. This does define a global evolution step
+\cite{RiWe,Tak}. In view of the reversible case this would seem
+like a good definition. However, it is again not clear whether the
+composition of two such transformations will again be of the same
+kind. Nor is it clear how to describe the class of transformations
+obtained by several such ``simultaneous independent update''
+steps.
+
+It turns out that the analysis of Theorem~\ref{mainthm} can partly
+be repeated in the irreversible case, thereby reducing the
+possibilities somewhat. This line will be pursued elsewhere.
+
+
+\subsection{Wolfram}
+In a recent thick book \cite{Wolfram} S. Wolfram has argued that
+the that the universe might be a big cellular automaton following
+simple rules (see also \cite{Zuse}). Wolfram uses only classical
+structures, expressing the belief, however, that quantum
+structures might emerge from classical rules generating sufficient
+complexity. Since Einstein failed with a program like that (he
+thought of overdetermined non-linear field equations, rather than
+CAs) it would be nice to see the details worked out.
+
+\subsection{Quantum random walks}
+The term ``Quantum cellular automaton'' has sometimes been used
+\cite{Zeilinger,Iwo,Meyer,konno} for a unitary evolution of a
+particle on a discretized space. The total Hilbert space of such a
+system is $\ell^2(\Ir^s)$, the space of square summable complex
+functions on the lattice, i.e., the direct sum rather than the
+tensor product of the one-cell spaces. The classical analogue of
+such a system is a single classical particle moving on a lattice,
+e.g., in a random walk. Therefore much better terminology to call
+these quantum systems {\it quantum random walks}, rather than
+cellular automata. Such systems have been proposed for purposes of
+quantum computation, in particular for search problems on graphs
+(see \cite{Kempe} for a review).
+
+Quantum random walks require localization properties not unlike
+those of QCAs. To see the connection it is interesting to consider
+the connection between classical random walks and CAs: A random
+walk can be seen as a special CA, with each cell either empty or
+occupied, started in a configuration with exactly one occupied
+cell. Of course, the overall CA dynamics should respect this
+constraint. Because the CA rule is local we can then also put
+arbitrarily many particles on the lattice, and the dynamics is
+well-defined by the random walk, as long as the particles do not
+collide. What happens on collision is a piece of information which
+must be supplied in order to make a random walk into a CA, i.e.,
+in order to pass from a random walk to a (possibly
+``interacting'') {\it diffusion}.
+
+Consider a QCA with a special ``empty'' state specified for the
+single cell algebra. This means that we can define a global
+quantity {\it particle number}, which ought to be conserved by the
+QCA. Technically this is the infinite sum of 0's and 1's, and not
+a well defined observable. However, we can consider this formal
+sum as a lattice interaction generating the time evolution of
+``gauge transformations'', acting as an infinite product of
+unitaries, as in Section~\ref{sec:communitary}. For a QCA
+commuting with such transformations, the ``one-particle'' Hilbert
+space can be defined, and the QCA dynamics restricted to this
+subspace is a unitary evolution of the random walk type. Note that
+we have not assumed that the dimension $d$ of the one-site algebra
+is $2$, i.e., occupied cells (``particles'') may have an internal
+structure. This turns out to be necessary: a standard classical
+random walk, with only the empty/occupied distinction and nearest
+neighbor interaction cannot be reversible. Similarly, a unitary on
+$\ell^2(\Ir^s)$ cannot be strictly local \cite{Zeilinger}, and we
+do need internal states \cite{Meyer2}. If there is only one
+particle, this is the same as saying that we have only the
+empty/occupied distinction for the cells, but we have also a
+``quantum coin'' which helps determining the steps.
+
+The standard model of a quantum random walk \cite{Kempe} uses a
+qubit coin, i.e., three states for the QCA. All random walks with
+such a coin are parameterized by a single unitary
+$2\times2$-matrix $U$: we can describe the internal states
+(``chirality'' \cite{konno}) as ``go right'' and ``go left''. A
+trivial, but globally well-defined evolution step is defined by
+following these instructions. The general case arises by following
+this with a sitewise unitary rotation by $U$, representing the
+quantum coin flip.
+
+Now the question arises: can we consider such random walks as the
+one-particle component of a QCA allowing arbitrarily many
+particles? Indeed this is possible, even in many ways, and it
+would be very interesting to classify all possibilities, hence all
+``interactions''. One possibility is to second quantize the random
+walk, which leads to a Boson system allowing, at each site, an
+arbitrary number of particles. It is clear from the formalism of
+second quantization that all the locality properties required of a
+QCA are then satisfied. Clearly, this is the non-interacting
+option. If we insist on finitely many states per cell we introduce
+some kind of hard core interaction. A trivial way of doing it with
+four states is this: Consider two infinite qubit chains, called
+the left moving and the right moving chain. The ``free'' time
+evolution $S$ is indeed shifting the two chains separately
+according to this description. Now at each lattice site we take
+the right moving and the left moving one-site algebras together to
+define a single cell of the QCA, with the four states labelled
+`empty', `R', `L', and `RL'. We then select a unitary $U$ leaving
+the empty and the doubly occupied state invariant, but shuffling
+the `R' and `L' states as before. Clearly, the combination of the
+free evolution $S$ with the sitewise application of $U$ defines a
+QCA whose one-particle sector is the given random walk.
+
+
+\subsection{Spacetime localized algebras}
+
+A quantum field theory can be considered from two equivalent
+points of view. On the one hand one can consider the fields at
+some time fixed time as the basic dynamical variables, e.g., the
+Cauchy data at time zero. On the other hand, for the discussion of
+relativistic causality, it is convenient to consider as
+fundamental the family of algebras $\AO{}$ associated with the
+measurements in some space-time region $\mathcal O$ \cite{Haag}.
+Similarly, one can look at a QCA from these two points of view,
+the ``Cauchy data'' point of view being what we described so far.
+For the space-time view consider the extended lattice $\Ir^{s+1}$
+of space-time points $(x,t)$, with $x\in\Ir^s$, the same spatial
+lattice as before, and $t\in\Ir$ a discrete time point.
+
+The global C*-algebra will be the same as before, but we introduce
+additional subalgebras, namely
+\begin{equation}\label{Axt}
+    \AA_{x,t}=\grule^{-t}(\AA_x)\;.
+\end{equation}
+Since $\grule$ commutes with lattice translations we can define a
+joint set of space-time translations $\grule_{x,t}$, combining a
+lattice translation by $x$ with $\grule^{-t}$. For any subset
+$\OO\subset\Ir^{s+1}$ we define $\AO{}$ as the C*-algebra
+generated by all the $\AA_{x,t}$ with $(x,t)\in\OO$. In order to
+study the localization properties of of these algebras, let us say
+that a sequence of lattice points
+\begin{equation}\label{slpath}
+    (x_0,t_0),\ (x_1,t_0+1),\ (x_2,t_0+2),\ldots,(x_N,t_N)
+\end{equation}
+is (forward) {\it timelike}, if $x_{k+1}-x_k\in\Nei$ for all $k$.
+Then we define two regions $\OO_1,\OO_2\subset\Ir^{s+1}$ to be
+{\it spacelike separated} (notation: $\OO_1\spacelike\OO_2$), if
+no timelike curve passes through some point of $\OO_1$ and also
+through some point of $\OO_2$. Moreover, we say that $\OO_1$ is
+{\it causally dependent} on $\OO_2$ (notation:
+$\OO_1\vartriangleleft\OO_2$), if every timelike curve which
+passes through (any point of) $\OO_1$ also passes through $\OO_2$.
+
+Then it is clear that $\OO_1\spacelike\OO_2$ implies that $\AO1$
+and $\AO2$ commute elementwise. Moreover, if $\OO_2$ is a finite
+set of lattice points $(x,t)$, all with the same $t$, and if
+$\OO_1\vartriangleleft\OO_2$, then $\AO1\subset\AO2$.
+
+Conversely, if we have a net of local algebras $\AO{}$, defined
+for arbitrary finite subsets $\OO$ of the spacetime-lattice, if
+the spacetime translations act by automorphism of the total
+algebra such that $T_{(x,t)}(\AO{})={\mathfrak A}({\OO}+(x,t))$,
+and that the above locality properties hold, then the time zero
+algebras form a QCA in the sense of Section~\ref{sec:def}.
+
+This way of viewing QCAs may indeed be useful for making the
+connection to relativistic field theories, or for a detailed study
+of the growth of localization regions.
+
+
+
+\subsection{Non-commuting cells}
+As is standard in quantum theory we described the cells of the
+automaton as subsystems in the usual tensor product sense. In a
+slightly more axiomatic style we could have postulated, that
+arbitrary measurements in separate cells can be carried out
+jointly, implying the commutation between the different cells.
+While this is certainly very natural, more general commutation
+rules between cells may be considered. An obvious example are
+anti-commutation rules, i.e., we could think of a Fermi gas on a
+lattice. This would, of course, change the requirements on local
+rules, but it is quite clear how to adapt our definition to that
+case.
+
+Another very interesting deviation from commuting cells is studied
+in \cite{Seiler}, in connection with non-commutative analogs of
+2-surfaces with constant negative curvature, the sine-Gordon
+equation, and 2-dimensional lattice systems in  magnetic field
+(Hofstadter butterfly). Roughly speaking the structure
+investigated has has a single variable, say a unitary $Q_x$, at
+each cell ``$x$''. Non-commutativity comes in, because any pair of
+neighboring unitaries forms a discrete Weyl system. At distances
+$\geq2$ the variables commute. It is clear that (reversible)
+dynamical rules can be described exactly along the lines of our
+definition, as automorphisms respecting this algebraic structure,
+and also the localization (up to a finite enlargement of
+localization regions). Of course, this is not the place to explore
+such structures, and we point again to the book \cite{Seiler} for
+more material.
+
+\appendix
+\section{Finite Dimensional C*-algebras}\label{APPCstar}
+
+Almost all the hard work in any textbook on C*-algebras goes into
+aspects of the theory, which become entirely trivial for finite
+dimensional C*-algebras. Of course, some algebras in this paper
+are infinite dimensional, notably the quasi-local C*-algebra
+describing the infinite system. But the key arguments use only the
+finite dimensional structure. Therefore we will give in this
+Appendix a quick summary of C*-algebra theory as it applies to the
+finite dimensional case.
+
+In order to make the paper more accessible to communities in which
+algebraic terminology is less current (e.g., most theoretical
+physicists, and classical computer scientists) we start out with
+an extended glossary, in which the basic notions are defined and
+some basic facts are noted. This will be followed by some
+structure theorems which we need in the body of the paper. Of
+course, all this cannot replace a serious textbook. We recommend
+\cite{BraRo,Tak,Dix}.
+
+
+\subsection{C*-Glossary}
+
+The operations making up the abstract structure of C*-algebras are
+inspired by those known from algebras of operators on a Hilbert
+space. In fact, every algebra of operators on a finite dimensional
+Hilbert space, which is also closed under taking adjoints,
+satisfies the definition, and every abstract C*-algebra is
+isomorphic to an operator algebra. The following list of relevant
+operations and concepts may serve as a glossary. The algebra under
+consideration is usually denoted by $\AA$.
+
+\begin{itemize}
+\item {\it Addition} and multiplication by {\it complex scalars}. This makes
+$\AA$ a vector space over $\Cx$, which we assume to be finite
+dimensional from now on.
+
+\item {\it Multiplication}.  We denote the product by $AB\in\AA$,
+when $A,B\in\AA$. The product is distributive and associative (but
+not necessarily commutative). If the algebra is commutative or
+``abelian'' the system under consideration is classical.
+
+\item The {\it adjoint} or ``star operation'' denoted by $A^*\in\AA$,
+when $A\in\AA$. This is conjugate linear (or ``antilinear''),
+which means that $(\lambda A)^*=\overline{\lambda}A^*$, and
+$(A+B)^*=A^*+B^*$. The adjoint satisfies $(AB)^*=B^*A^*$.
+Physicists often write $A^\dagger$ for the adjoint.
+
+\item The {\it norm}, which is a positive number $\norm{A}$
+associated with each $A\in\AA$. With respect to the algebraic
+structures, the norm satisfies $\norm{A+B}\leq\norm A+\norm B$,
+$\norm{\lambda A}=|\lambda|\;\norm A$, $\norm{AB}\leq\norm A\norm
+B$ and $\norm{A^*A}=\norm A^2$. $\norm A=0$ implies $A=0$. In
+contrast to the general case, the norm is uniquely determined by
+the algebraic structures.
+
+\item An {\it identity}. In contrast to the general case, in finite
+dimensional C*-algebras there is always a unique element $\idty$
+satisfying $\idty A=A\idty=A$.
+\item A {\it homomorphism} between C*-algebras is a map $\Phi:\AA\to\BB$
+between C*-algebras, preserving the algebraic structures. That is,
+$\Phi$ is linear, $\Phi(AB)=\Phi(A)\Phi(B)$, and
+$\Phi(A^*)=\Phi(A)^*$. The latter property is sometimes emphasized
+by speaking of *-homomorphims. Homomorphisms $\Phi:\AA\to\AA$ are
+called {\it endomorphisms} of $\AA$, and if an inverse
+homomorphism exists, $\Phi$ is called an {\it isomorphism} or an
+{\it automorphism} (if $\AA=\BB$). For general homomorphisms,
+$\Phi(\idty)$ is a projection in $\BB$. If $\Phi(\idty)=\idty$, we
+call it {\it unital}.
+\item An {\it ordering}. We write $A\geq0$, if there is a
+$B\in\AA$ such that $A=B^*B$. The set of positive elements is a
+convex cone in the set of hermitian ($A^*=A$) elements. In an
+operator algebra, the positive elements are precisely those
+hermitian ones with all eigenvalues non-negative.
+\item The {\it center} of $\AA$ is the subalgebra $\ZZ(\AA)\subset\AA$ of
+elements $Z$ such that $ZA=AZ$ for all $A\in\AA$.
+\item A {\it state} on $\AA$ is a linear functional
+$\omega:\AA\to\Cx$ which is positive (i.e.,  $A\geq0$ implies
+$\omega(A)\geq0$) and normalized (i.e., $\omega(\idty)=1$).
+\item A {\it trace} on $\AA$ is a positive linear functional $\tau$ such
+that $\tau(AB)=\tau(BA)$.
+
+\item a positive linear functional $\omega$ is called {\it
+faithful} if $A\geq0$ and $\omega(A)=0$ imply $A=0$. Every finite
+dimensional C*-algebra has a faithful trace. On an operator
+algebra, the usual trace of operators (which we will denote by
+$\tr$) is an example.
+\item Given a faithful trace $\tau$, every positive linear
+functional can be written as $\omega(A)=\tau(\rho A)$, for a
+unique $\rho\in\AA$, $\rho\geq0$,  which is called the {\it
+density operator} of $\omega$ with respect to $\tau$. $\omega$ is
+also a trace iff $\rho\in\ZZ(\AA)$.
+
+\item An element $P\in\AA$ is a called a {\it projection} if $P^*=P=P^2$.
+It is called a {\it minimal projection} if for any projection $Q$,
+$Q\leq P$ implies $Q=0$ or $Q=P$.
+
+\item The {\it direct sum} $\AA=\bigoplus_\mu\AA_\mu$ of a finite collection of
+finite dimensional C*-algebras $\AA_\mu$ is the vector space
+direct sum, i.e., elements are tuples of components
+$A_\mu\in\AA_\mu$, with componentwise algebraic operations. In
+operator algebras each term in the sum corresponds to a diagonal
+block in a block matrix decomposition.
+\item The {\it tensor product} $\AA=\bigotimes_\mu\AA_\mu$ is the
+vector space tensor product, with product and adjoint defined as
+the unique linear (resp. conjugate linear) extensions of
+$(\otimes_\mu A_\mu)(\otimes_\mu B_\mu)=\otimes_\mu (A_\mu B_\mu)$
+and $(\otimes_\mu A_\mu)^*=\otimes_\mu A_\mu^*$. In operator
+algebras one forms this product by taking first the tensor
+products of the underlying Hilbert spaces, and taking the algebra
+generated by all tensor product operators.
+\end{itemize}
+
+\noindent The first four items on this list are the definition of
+C*-algebras. Note that order and unit are explicitly defined
+in terms of the algebraic structure (linear operations,
+multiplication and adjoint), and the norm is also defined
+explicitly as
+\begin{equation}\label{defnorm}
+  \norm A=\inf\{\lambda>0| \exists_B\;A^*A+B^*B=\lambda^2\idty\}
+\end{equation}
+It might thus seem superfluous to list the norm among the defining
+elements. In the infinite dimensional case it is needed, of
+course, to formulate the topological completeness requirement (and
+completeness is needed in turn to construct $B$ in
+(\ref{defnorm})). However, even in the finite dimensional case the
+implication $(\norm A=0)\Rightarrow (A=0)$ carries non-trivial
+information by excluding the existence of nonzero elements $A_i$
+such that $\sum_iA_i^*A_i=0$.
+
+\subsection{C*-structure}
+
+Consider a single Hermitian element $A\in\AA$. Then since $\AA$ is
+finite dimensional, the powers $A^n$ must be linearly dependent,
+i.e., there is a characteristic polynomial $p(A)=\sum_kc_kA^k=0$.
+From this one readily constructs polynomials $p_\ell$ such that
+$p_\ell(A)$ is a projection, and
+\begin{equation}\label{babyspectral}
+  A=\sum_\ell a_\ell p_\ell(A)
+\end{equation}
+where $a_\ell$ are the distinct roots of $p(a)=0$. This is called
+the {\it spectral theorem}. It implies, in particular, that any
+finite dimensional C*-algebra has many projections (which may fail
+in infinite dimension).
+
+This fact will be used in the following fundamental structure
+theorem. Recall that by $\MM_n$ we denote the algebra of complex
+$n\times n$ matrices.
+
+\begin{proposition}\label{Csform}
+Every finite dimensional C*-algebra $\AA$ is
+characterized uniquely up to isomorphism by a finite sequence
+$n_1\geq n_2\geq\cdots\geq1$ of numbers such that
+\begin{equation}\label{isoCstar}
+  \AA \cong\bigoplus_\mu \MM_{n_\mu}\;.
+\end{equation}
+\end{proposition}
+
+The basic idea of the proof is to consider the center of $\AA$,
+which is a finite dimensional abelian C*-algebra. The minimal
+projections $z_\mu$ of the center decompose the algebra into a
+direct sum $\AA=\bigoplus_\mu z_\mu\AA$, in which each of the
+summands has trivial center. The building blocks $z_\mu\AA$ are
+then seen to be isomorphic to full matrix algebras $\MM_{n_\mu}$,
+where $n_\mu$ is the maximal number of mutually orthogonal
+projections in $z_\mu\AA$.
+
+
+\begin{proposition}\label{Cshom}
+If $\Phi:\MM_d\to \bigoplus_\mu\MM_{n(\mu)}$ is a *-homomorphism
+such that $\Phi(\idty)=\idty$, each $n(\mu)$ has to be divisible
+by $d$.
+\end{proposition}
+
+By considering the composition of the given homomorphism with the
+projection onto one summand, which is also a homomorphism, we can
+consider the case of a single summand. Thus $\Phi$ becomes a
+representation of $\MM_d$ on a Hilbert space of dimension
+$n(\mu)$, which can be decomposed into irreducible
+representations. It is a basic property of $\MM_d$, however, that
+all its irreducible representations are unitarily equivalent to
+the defining representation on $\Cx^d$, so $n(\mu)$ must be $d$
+times the multiplicity (number of isomorphic irreducible summands)
+of this representation.
+
+
+\begin{proposition}\label{Cscom}
+If $\AA\cong\bigoplus_\mu \MM_{n(\mu)}$ and $\BB\cong\bigoplus_\nu
+\MM_{m(\nu)}$ are commuting subalgebras of $\BB(\HH)$, the algebra
+$\AA\BB$ is also decomposed into direct summands, each of which
+arises by multiplying a summand form each of the algebras. These
+occur with  integer multiplicities $r_{\mu\nu}\geq0$ such that
+\begin{equation}\label{multip}
+ \sum_{\mu\nu}r_{\mu\nu}n(\mu)m(\nu)
+  =\dim\HH\;.
+\end{equation}
+\end{proposition}
+
+Let $A_\mu\in\MM_{n(\mu)}\subset\AA$ and
+$B_\nu\in\MM_{m(\nu)}\subset\BB$ be elements from the respective
+blocks. Then $A_\mu\otimes B_\nu\mapsto A_\mu B_\nu$ is a
+representation of $\MM_{n(\mu)\cdot
+m(\nu)}\cong\MM_{n(\mu)}\otimes\MM_{m(\nu)}$ on $\HH$, which may
+however be zero since we cannot guarantee that it preserves the
+identity. The rest of the argument is as for the previous
+proposition.
+
+
+
+
+\section{Acknowledgements}
+The main lines of this paper were conceived in March 2003, in
+discussions at the Centro Ettore Majorana in Erice , whose
+hospitality we acknowledge. We also benefited from discussions
+with I. Cirac, M. Wilkens, and C.H. Bennett.
+
+
+\begin{thebibliography}{99}
+
+\bibitem{Feynman}R. Feynman, Simulating physics with computers,
+{\it Int. J. Theor. Phys. \bf21} (1982) 467-488, Reprinted in
+A.J.G. Hey (ed.), {\it Feynman and Computation}, Perseus Books
+1999.
+
+\bibitem{optlat}O. Mandel, M. Greiner, A. Widera, T. Rom, T.W. H\"ansch,
+  and I. Bloch,
+  \jtitle{Coherent transport of neutral atoms in spin-dependent optical
+     lattice potentials,}
+  {\it Phys. Rev. Lett. \bf91}, 010407 (2003)
+
+\bibitem{mictrap}R. Dumke, M. Volk, T. Muether, F.B.J.
+   Buchkremer, G. Birkl, and W. Ertmer,
+   \jtitle{ Microoptical Realization of Arrays of Selectively Addressable
+    Dipole Traps: A Scalable Configuration for Quantum Computation
+    with Atomic Qubits,}
+   {\it Phys. Rev. Lett. \bf89}, 097903 (2002) and quant-ph/0110140
+
+\bibitem{QdCA} Further away are proposals based on arrays of
+quantum dots, which are also published under the heading ``quantum
+cellular automata''. These are ideas for new hardware for {\it
+classical} computing, possibly replacing CMOS technology. In order
+to avoid confusion with the ideas in which quantum coherence plays
+a key role (as it does in our paper), many authors from that
+community are now using the more precise term ``quantum {\it dot}
+cellular automata''. For an overview see the home page of the
+Notre Dame group (www.nd.edu/\~{}qcahome), or: P.D. Tougaw, C.S.
+Lent, \jtitle{Logical devices implemented using quantum cellular
+automata,} {\it J.Appl.Phys. \bf75} (1994) 1818.
+
+\bibitem{Benjamin} S. C. Benjamin,
+  \jtitle{Schemes for parallel quantum computation without local
+  control of qubits,}
+  {\it Phys. Rev. A \bf61} 020301 (2000)
+
+\bibitem{Watrous}J. Watrous: On one-dimensional quantum cellular automata.
+In Proceedings of the 36th Annual Symposium on Foundations of
+Computer Science, 1995, pp.~528--537.
+
+\bibitem{vanDam}W. van Dam: Quantum cellular automata, Master
+Thesis, Computer Science Nijmegen, Summer 1996
+
+\bibitem{Gruska}J. Gruska: {\it Quantum Computing}, (McGraw-Hill,
+Cambridge 1999). QCAs are treated in Section 4.3.
+
+\bibitem{santa}C. D\"urr and M. Santha: A decision procedure for
+unitary linear quantum cellular automata,
+quant-ph/9604007;\newline
+ C. D\"urr, H. L\^eTanh and M. Santha,
+ \jtitle{A decision procedure for
+           well-formed linear quantum cellular automata,}
+ {\it Rand. Struct. Algorithms \bf11}, 381-394 (1997)
+ and cs.DS/9906024
+
+\bibitem{Brennen}G. K. Brennen and J. E. Williams,
+   \jtitle{Entanglement dynamics in 1D quantum cellular automata, }
+   quant-ph/0306056
+
+\bibitem{BraRo}O. Bratteli and D. Robinson:
+{\it Operator algebras and quantum statistical mechanics}, vol. I
+(Springer 1979)
+
+\bibitem{Paschen}A C*-algebraic framework was also applied to QCAs
+in a recent thesis. However, it was applied to the state side,
+rather than the observables, making locality properties harder to
+see. K. Paschen: \"Uber Reversibilit\"at, Nicht-Determiniertheit
+und Quantenrechnen in Zellularautomaten, Dissertation in
+Informatik (PhD Thesis in Computer Science), Karlsruhe 2002
+
+\bibitem{Haag}R. Haag: {\it Local quantum physics}, Springer 1996
+
+\bibitem{RiWe}S. Richter and R.F. Werner,
+  \jtitle{Ergodicity of quantum cellular automata,}
+  {\it J. Stat. Phys. \bf82} (1996) 963-998 and cond-mat/9504001
+
+\bibitem{Kari1}J. Kari,
+  \jtitle{On the circuit depth of structurally reversible cellular automata,}
+   {\it Fund.Inform. \bf34} (2003) 1–-15
+
+\bibitem{otherlat}The basic concepts in this paragraph work in any lattice
+structure. In fact, they do not even require translation
+invariance and could be formulated for possibly different spins
+(given by possibly infinite dimensional C*-algebras) localized on
+the nodes of a finite or infinite graph.
+
+\bibitem{onewaycomp}R. Raussendorf, D. E. Browne and H.-J. Briegel,
+   \jtitle{The one-way quantum computer - a non-network model of quantum
+           computation,}
+   {\it J. Mod. Opt \bf 49}, 1299 (2002).
+
+\bibitem{Rich}D. Richardson,
+   \jtitle{Tesselation with local transformations,}
+   {\it J.Comp.Syst.Sci. \bf6} (1972) 373--388
+
+\bibitem{classicalW}What appears here as a pathology is allowed in
+the (periodic boundary version) of Watrous QCAs, i.e., the
+Wrapping Lemma fails for that structure. A more systematic
+study of the possibility shown by our example was carried out in\\
+S. Inokuchi, Y. Mizoguchi,
+ \jtitle{Generalized partitioned quantum
+cellular automata and quantumization of classical CA,}
+quant-ph/0312102.
+
+\bibitem{Lloyd}S. Lloyd,
+    \jtitle{A potentially realizable quantum computer,}
+    {\it Science \bf261}, 1569--1571 (1993)
+
+\bibitem{cliff} We follow this terminology, although it is not clear what
+Clifford had to with this. In field theory these transformations
+would be called ``quasi-free'', or ``Bogolyubov automorphisms'',
+in phase space quantum mechanics ``metaplectic transformations''.
+
+\bibitem{OurCliff}D. Schlingemann, R.F. Werner, The structure of
+Clifford quantum cellular automata, in preparation.
+
+\bibitem{MarTo}T. Toffoli and M. Margolus,
+ \jtitle{Invertible Cellular automata: a review,}
+ {\it Physica D\bf 45}(1990) 229-253
+
+\bibitem{Zanardi}The support algebra of a single element, an
+interaction Hamiltonian was also introduced under the name
+``interaction algebra'' by P.Zanardi: Stabilization of quantum
+information: a unified dynamical-algebraic approach,
+quant-ph/0203008
+
+\bibitem{Wootters} K.S. Gibbons, M.J. Hoffman, W.K. Wootters,
+  \jtitle{Discrete phase space based on finite fields,}
+  quant-ph/0401155
+
+\bibitem{Paz}J. P. Paz: Discrete Wigner functions and the phase space representation of
+quantum teleportation, quant-ph/0204150
+
+\bibitem{Aoun}B. Aoun, M. Tarifi, Quantum cellular automata,
+quant-ph/0401123.
+
+\bibitem{Tak}M. Takesaki, {\it Theory of operator algebras, I},
+Springer 1979
+
+\bibitem{Wolfram} S. Wolfram, {\it A new kind of science},
+(Self-published, Wolfram Media Inc. 2002)
+
+\bibitem{Zuse} K. Zuse, {\it Rechnender Raum},
+Schriften zur Datenverarbeitung, Band 1, Vieweg,
+ Braunschweig 1969.
+
+\bibitem{Zeilinger}G. Gr\"ossing and A. Zeilinger,
+  \jtitle{Quantum cellular automata,}
+  {\it Complex Systems \bf2}, 197--208 (1988)
+
+\bibitem{Iwo}I. Bialynicki-Birula,
+  \jtitle{Weyl, Dirac, and Maxwell equations on a lattice as unitary cellular automata, }
+  {\it Phys. Rev. D \bf49}, 6920--6927 (1994)
+
+\bibitem{Meyer}D. A. Meyer,
+  \jtitle{From quantum cellular automata to quantum lattice gases, }
+  {\it J. Stat. Phys. \bf85},551--574 (1996)
+
+\bibitem{konno}N. Konno, K. Mitsuda, T. Soshi, H.J. Yoo,
+  \jtitle{Quantum walks and reversible cellular automata},
+  quant-ph/0403107
+
+\bibitem{Kempe}J. Kempe,
+ \jtitle{Quantum random walks: an introductory overview,}
+ {\it Contemp.Phys. \bf44} (2003) 307 -– 327
+
+\bibitem{Meyer2}D. A. Meyer: Unitarity in one dimensional nonlinear
+quantum cellular automata, quant-ph/9605023;
+ From quantum cellular automata to quantum lattice gases, {\it
+ J.Stat.Phys. \bf85} (1996) 551--574
+
+\bibitem{Seiler}A.I. Bobenko, R. Seiler (eds.),
+ {it Discrete integrable geometry and physics},
+ Clarendon Press, Oxford 1999. The book has several articles
+ connecting to the strucutre mentionend in the text. It is best to
+ pick up the pointers in the introduction by the editors.
+
+\bibitem{Dix}J. Dixmier, {\it C*-algebras}, North Holland 1977
+
+
+
+
+
+
+\end{thebibliography}
+\end{document}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\bibitem{Durand}J. Durand-Lose: Representing reversible cellular
+automata with reversible block cellular automata. In R. Cori, J.
+Mazoyer, M. Morvan, and R. Mosery, (eds.): Discrete models,
+combinatorics, computation and geometry (DM-CCG'01), volume AA.
+Dicrete Mathematics and Theoretical Computer Science, 2001.
+
+
+\bibitem{Boykett}T. Boykett: Efficient exhasutive enumeration of reversible one
+dimensional cellular automata, manuscript 40 pages.
+http://verdi.algebra.uni-linz.ac.at/~tim/enumeration.ps.gz
+
+\bibitem{Zhmud}E.M. Zhmud, {\it Math. USSR Sbornik}, {\bf15}
+(1971)7-29, and {\bf 16} (1972)1-16.
+
+\
+
+[25] G. ’t Hooft, K.Isler and S. Kalitzin, “Quantum field
+theoretic behavior of a deterministic cellular automaton”, Nucl.
+Phys.B386,495 (1992).
+
+[26] K. Svozil, “Are quantum fields cellular automata?”, Physics
+Letters A, 153, (1986).
+
+[27] M.D. Kostin, “Cellular automata for quantum systems”, J.
+Phys. A 26, L209 (1993).

--- a/Papers/quant-ph_0405174/test.eps
+++ b/Papers/quant-ph_0405174/test.eps
@@ -1,0 +1,6988 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: Adobe Illustrator(TM) 7.0
+%%For: (U Schomaecker) (TU Braunschweig)
+%%Title: (test.eps)
+%%CreationDate: (4/9/2003) (5:51 PM)
+%%BoundingBox: -65 414 627 762
+%%HiResBoundingBox: -64.5 414.5 627 761.8335
+%%DocumentProcessColors: Black
+%%DocumentFonts: Euclid-Italic
+%%DocumentSuppliedFonts: Euclid-Italic
+%%DocumentSuppliedResources: procset Adobe_level2_AI5 1.2 0
+%%+ procset Adobe_typography_AI5 1.0 1
+%%+ procset Adobe_ColorImage_AI6 1.1 0
+%%+ procset Adobe_Illustrator_AI5 1.2 0
+%%+ procset Adobe_cshow 2.0 8
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Black&White
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%%CMYKCustomColor: 1 0 0.55 0 (Aqua)
+%%+ 0.8 0.05 0 0 (Azur)
+%%+ 1 0.5 0 0 (Blau)
+%%+ 0.5 0.4 0.3 0 (Blaugrau)
+%%+ 0.5 0.85 1 0 (Braun)
+%%+ 1 0.9 0.1 0 (Dunkelblau)
+%%+ 0.05 0.2 0.95 0 (Gold)
+%%+ 0.75 0.05 1 0 (Grasgr\374n)
+%%+ 0.45 0.9 0 0 (Lila)
+%%+ 0 0.45 1 0 (Orange)
+%%+ 0.15 1 1 0 (Rot)
+%%+ 1 0.55 1 0 (Tannengr\374n)
+%%AI6_ColorSeparationSet: 1 1 (AI6 Default Color Separation Set) 
+%%+ Options: 1 16 0 1 0 1 1 1 0 1 1 1 1 18 0 0 0 0 0 0 0 0 -1 -1
+%%+ PPD: 1 21 0 0 60 45 2 2 1 0 0 1 0 0 0 0 0 0 0 0 0 0 () 
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 22 -12 589 803
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 595.2756 841.8898
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 0 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -450 864 -1.5 1008 646 18 0 1 8 80 0 0
+%AI5_OpenViewLayers: 7
+%%PageOrigin:22 -12
+%%AI3_PaperRect:-14 828 581 -14
+%%AI3_Margin:14 -13 -14 14
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%%EndComments
+%%BeginProlog
+%%BeginResource: procset Adobe_level2_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 5.0 Level 2 Emulation)
+%%Version: 1.2 0
+%%CreationDate: (04/10/93) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+%%EndResource
+%%BeginResource: procset Adobe_typography_AI5 1.0 1
+%%Title: (Typography Operators)
+%%Version: 1.0 1
+%%CreationDate:(6/10/1996) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+%%EndResource
+%%BeginProcSet: Adobe_ColorImage_AI6 1.1 0
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+%%EndProcSet
+%%BeginResource: procset Adobe_Illustrator_AI5 1.2 0
+%%Title: (Adobe Illustrator (R) Version 7.0 Full Prolog)
+%%Version: 1.2 0
+%%CreationDate: (3/7/1994) ()
+%%Copyright: ((C) 1987-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+%%EndResource
+%%BeginResource: procset Adobe_cshow 2.0 8
+%%Title: (Writing System Operators)
+%%Version: 2.0 8
+%%CreationDate: (1/23/89) ()
+%%Copyright: ((C) 1992-1996 Adobe Systems Incorporated All Rights Reserved)
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+%%EndResource
+%%EndProlog
+%%BeginSetup
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+%AI3_BeginRider
+currentpacking true setpacking
+%%BeginFont: Euclid-Italic
+/Euclid-Italic
+15 dict dup begin
+/FontName /Euclid-Italic def
+/FontType 3 def
+/FontMatrix [ 0.000977 0 0 0.000977 0 0 ] def
+/FontAscent 986 def
+/FontDescent -324 def
+/FontScript 0 def
+/FontBBox [ 0 -512 1024 1024 ] def
+/Encoding 256 array dup 0 1 255 { /.notdef put dup } for pop def
+/l /lineto load def
+/m /moveto load def
+/c /curveto load def
+/BuildChar {
+	Adobe_Illustrator_AI5_vars exch /_bitlobyte exch put
+	Adobe_Illustrator_AI5_vars exch /_bitfont exch put
+	Adobe_Illustrator_AI5_vars /_bithibyte 0 put
+
+	_bitlobyte 16 4 string cvrs dup length (K) dup length
+	dup 4 -1 roll add string Adobe_Illustrator_AI5_vars exch /_bitkey exch put
+	exch _bitkey copy pop _bitkey exch 3 -1 roll putinterval
+	_bitfont /CharMetrics get _bitkey cvn get 0 setcharwidth
+	_bitfont /CharStrings get _bitkey cvn get exec
+} bind def
+4 dict dup begin
+/KA {
+} bind def
+/KD {
+} bind def
+/K55 {
+{
+newpath
+876 680 m
+875 676 873 673 871 671 c
+868 669 865 668 861 668 c
+849 668 837 667 825 665 c
+813 663 802 658 792 651 c
+783 645 777 638 772 630 c
+767 621 763 612 760 603 c
+668 234 l
+660 201 647 169 629 139 c
+611 108 589 80 561 54 c
+537 31 511 13 482 -1 c
+453 -15 423 -22 393 -22 c
+361 -22 332 -15 306 -2 c
+281 11 261 29 245 53 c
+228 77 217 105 214 136 c
+210 168 212 200 220 234 c
+321 631 l
+325 648 324 657 318 661 c
+312 664 302 666 288 667 c
+274 668 260 668 244 668 c
+240 668 238 669 236 671 c
+234 673 234 676 236 680 c
+238 688 l
+240 696 245 700 252 700 c
+335 697 420 697 505 700 c
+512 700 516 696 514 688 c
+511 680 l
+510 672 505 668 498 668 c
+482 668 467 668 453 667 c
+438 666 427 664 420 661 c
+412 657 407 648 403 631 c
+303 234 l
+296 205 291 177 289 149 c
+288 122 292 96 302 73 c
+311 54 324 39 341 27 c
+358 16 378 10 401 10 c
+425 10 450 16 475 27 c
+500 39 523 55 544 74 c
+568 96 587 121 602 149 c
+617 177 629 205 636 234 c
+728 603 l
+731 612 732 621 731 630 c
+730 638 726 645 721 651 c
+714 658 705 663 694 665 c
+684 667 673 668 660 668 c
+656 668 654 669 652 671 c
+650 673 650 676 651 680 c
+653 688 l
+654 692 656 695 659 697 c
+661 699 664 700 668 700 c
+734 697 801 697 870 700 c
+873 700 875 699 877 697 c
+879 695 879 692 878 688 c
+876 680 l
+closepath
+} exec
+fill
+} bind def
+/K56 {
+{
+newpath
+887 680 m
+886 672 881 668 874 668 c
+863 668 852 667 842 664 c
+832 661 822 657 812 651 c
+803 645 794 637 786 628 c
+778 619 771 609 764 599 c
+400 -11 l
+396 -18 390 -22 382 -22 c
+373 -22 l
+365 -22 360 -18 360 -11 c
+298 627 l
+297 636 295 643 294 649 c
+292 654 290 658 286 661 c
+280 664 272 666 262 667 c
+251 668 239 668 226 668 c
+223 668 220 669 219 671 c
+217 673 217 676 218 680 c
+220 688 l
+221 692 222 695 225 697 c
+228 699 231 700 234 700 c
+272 698 310 697 348 697 c
+385 698 424 699 462 700 c
+465 700 468 699 470 697 c
+471 695 472 692 470 688 c
+468 680 l
+468 676 466 673 463 671 c
+460 669 457 668 454 668 c
+442 668 431 667 421 666 c
+411 665 402 663 392 658 c
+384 653 380 645 381 634 c
+393 545 402 456 409 367 c
+416 277 424 188 432 98 c
+735 606 l
+740 613 743 621 744 629 c
+744 636 743 643 740 649 c
+731 662 716 668 695 668 c
+688 668 685 672 686 680 c
+688 688 l
+691 696 696 700 703 700 c
+732 699 761 698 791 697 c
+820 697 850 698 881 700 c
+888 700 891 696 890 688 c
+887 680 l
+closepath
+} exec
+fill
+} bind def
+end /CharStrings exch def
+4 dict dup begin
+/KA 1024 def
+/KD 1024 def
+/K55 761 def
+/K56 761 def
+end /CharMetrics exch def
+end
+definefont pop
+%%EndFont
+setpacking
+%AI3_EndRider
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _Euclid-Italic Euclid-Italic
+[/_Euclid-Italic/Euclid-Italic 0 0 0 TZ%AI3_EndEncoding TrueType%AI5_Begin_NonPrintingNp%AI3_BeginPattern: (Backsteine)
+(Backsteine) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S1.6 62.809 m
+73.6 62.809 L
+S1.6 55.609 m
+73.6 55.609 L
+S1.6 48.408 m
+73.6 48.408 L
+S1.6 41.208 m
+73.6 41.208 L
+S1.6 34.007 m
+73.6 34.007 L
+S1.6 26.807 m
+73.6 26.807 L
+S1.6 19.606 m
+73.6 19.606 L
+S1.6 12.406 m
+73.6 12.406 L
+S1.6 5.206 m
+73.6 5.206 L
+S70.01 70.01 m
+70.01 62.822 l
+S55.61 70.01 m
+55.61 62.822 L
+S41.21 70.01 m
+41.21 62.822 L
+S26.81 70.01 m
+26.81 62.822 L
+S12.41 70.01 m
+12.41 62.822 L
+S70.01 55.572 m
+70.01 48.385 l
+S55.61 55.572 m
+55.61 48.385 L
+S41.21 55.572 m
+41.21 48.385 L
+S26.81 55.572 m
+26.81 48.385 L
+S12.41 55.572 m
+12.41 48.385 L
+S70.01 41.197 m
+70.01 34.01 l
+S55.61 41.197 m
+55.61 34.01 L
+S41.21 41.197 m
+41.21 34.01 L
+S26.81 41.197 m
+26.81 34.01 L
+S12.41 41.197 m
+12.41 34.01 L
+S70.01 26.822 m
+70.01 19.635 l
+S55.61 26.822 m
+55.61 19.635 L
+S41.21 26.822 m
+41.21 19.635 L
+S26.81 26.822 m
+26.81 19.635 L
+S12.41 26.822 m
+12.41 19.635 L
+S70.01 12.385 m
+70.01 5.197 l
+S55.61 12.385 m
+55.61 5.197 L
+S41.21 12.385 m
+41.21 5.197 L
+S26.81 12.385 m
+26.81 5.197 L
+S12.41 12.385 m
+12.41 5.197 L
+S62.797 5.197 m
+62.797 1.6 L
+S48.397 5.197 m
+48.397 1.6 L
+S33.997 5.197 m
+33.997 1.6 L
+S19.597 5.197 m
+19.597 1.6 L
+S5.197 5.197 m
+5.197 1.6 l
+S62.797 19.635 m
+62.797 12.447 L
+S48.397 19.635 m
+48.397 12.447 L
+S33.997 19.635 m
+33.997 12.447 L
+S19.597 19.635 m
+19.597 12.447 L
+S5.197 19.635 m
+5.197 12.447 l
+S62.797 34.01 m
+62.797 26.822 L
+S48.397 34.01 m
+48.397 26.822 L
+S19.597 34.01 m
+19.597 26.822 L
+S5.197 34.01 m
+5.197 26.822 l
+S62.797 48.385 m
+62.797 41.197 L
+S48.397 48.385 m
+48.397 41.197 L
+S33.997 48.385 m
+33.997 41.197 L
+S19.597 48.385 m
+19.597 41.197 L
+S5.197 48.385 m
+5.197 41.197 l
+S62.797 62.822 m
+62.797 55.635 L
+S48.397 62.822 m
+48.397 55.635 L
+S33.997 62.822 m
+33.997 55.635 L
+S19.597 62.822 m
+19.597 55.635 L
+S5.197 62.822 m
+5.197 55.635 l
+S62.797 73.5589 m
+62.797 70.072 L
+S48.397 73.5589 m
+48.397 70.072 L
+S33.997 73.5589 m
+33.997 70.072 L
+S19.597 73.5589 m
+19.597 70.072 L
+S5.197 73.5589 m
+5.197 70.072 l
+S33.997 34.01 m
+33.997 26.822 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bl\344tter)
+(Bl\344tter) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Au\337en)
+(Dpllinie1.2.Au\337en) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Innen)
+(Dpllinie1.2.Innen) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Dpllinie1.2.Kante)
+(Dpllinie1.2.Kante) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Ecke.Au\337en)
+(Ecke.Au\337en) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Konfetti)
+(Konfetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S9.1 8.617 m
+6.85 6.867 l
+S78.1 68.617 m
+74.85 67.867 l
+S76.85 56.867 m
+74.35 55.117 l
+S79.6 51.617 m
+76.6 51.617 l
+S76.35 44.117 m
+73.6 45.867 l
+S78.6 35.867 m
+76.6 34.367 l
+S76.1 23.867 m
+73.35 26.117 l
+S78.1 12.867 m
+73.85 13.617 l
+S68.35 14.617 m
+66.1 12.867 l
+S76.6 30.617 m
+73.6 30.617 l
+S62.85 58.117 m
+60.956 60.941 l
+S32.85 59.617 m
+31.196 62.181 l
+S47.891 64.061 m
+49.744 66.742 l
+S72.814 2.769 m
+73.928 5.729 l
+S67.976 2.633 m
+67.35 5.909 l
+S61.85 27.617 m
+59.956 30.441 l
+S53.504 56.053 m
+51.85 58.617 l
+S52.762 1.779 m
+52.876 4.776 l
+S45.391 5.311 m
+47.244 7.992 l
+S37.062 3.375 m
+35.639 5.43 l
+S55.165 34.828 m
+57.518 37.491 l
+S20.795 3.242 m
+22.12 5.193 l
+S14.097 4.747 m
+15.008 8.965 l
+S9.736 1.91 m
+8.073 4.225 l
+S31.891 5.573 m
+32.005 8.571 l
+S12.1 70.367 m
+15.6 68.867 l
+S9.35 54.867 m
+9.6 58.117 l
+S12.85 31.867 m
+14.35 28.117 l
+S10.1 37.367 m
+12.35 41.117 l
+S34.1 71.117 m
+31.85 68.617 l
+S38.35 71.117 m
+41.6 68.367 l
+S55.1 71.117 m
+58.35 69.117 l
+S57.35 65.117 m
+55.35 61.867 l
+S64.35 66.367 m
+69.35 68.617 l
+S71.85 62.867 m
+69.35 61.117 l
+S23.6 70.867 m
+23.6 67.867 l
+S20.6 65.867 m
+17.35 65.367 l
+S24.85 61.367 m
+25.35 58.117 l
+S25.85 65.867 m
+29.35 66.617 l
+S14.1 54.117 m
+16.85 56.117 l
+S12.35 11.617 m
+12.6 15.617 l
+S12.1 19.867 m
+14.35 22.367 l
+S26.1 9.867 m
+23.6 13.367 l
+S34.6 47.117 m
+32.1 45.367 l
+S62.6 41.867 m
+59.85 43.367 l
+S31.6 35.617 m
+27.85 36.367 l
+S36.35 26.117 m
+34.35 24.617 l
+S33.85 14.117 m
+31.1 16.367 l
+S37.1 9.867 m
+35.1 11.117 l
+S34.35 20.867 m
+31.35 20.867 l
+S44.6 56.617 m
+42.1 54.867 l
+S47.35 51.367 m
+44.35 51.367 l
+S44.1 43.867 m
+41.35 45.617 l
+S43.35 33.117 m
+42.6 30.617 l
+S43.85 23.617 m
+41.1 25.867 l
+S44.35 15.617 m
+42.35 16.867 l
+S67.823 31.1 m
+64.823 31.1 l
+S27.1 32.617 m
+29.6 30.867 l
+S31.85 55.117 m
+34.85 55.117 l
+S19.6 40.867 m
+22.1 39.117 l
+S16.85 35.617 m
+19.85 35.617 l
+S20.1 28.117 m
+22.85 29.867 l
+S52.1 42.617 m
+54.484 44.178 l
+S52.437 50.146 m
+54.821 48.325 l
+S59.572 54.133 m
+59.35 51.117 l
+S50.185 10.055 m
+53.234 9.928 l
+S51.187 15.896 m
+53.571 14.075 l
+S58.322 19.883 m
+59.445 16.823 l
+S53.1 32.117 m
+50.6 30.367 l
+S52.85 24.617 m
+49.6 25.617 l
+S61.85 9.117 m
+59.1 10.867 l
+S69.35 34.617 m
+66.6 36.367 l
+S67.1 23.617 m
+65.1 22.117 l
+S24.435 46.055 m
+27.484 45.928 l
+S25.437 51.896 m
+27.821 50.075 l
+S62.6 47.117 m
+65.321 46.575 l
+S19.85 19.867 m
+20.35 16.617 l
+S21.85 21.867 m
+25.35 22.617 l
+S37.6 62.867 m
+41.6 62.117 l
+S38.323 42.1 m
+38.823 38.6 l
+S69.35 52.617 m
+66.85 53.867 l
+S14.85 62.117 m
+18.1 59.367 l
+S9.6 46.117 m
+7.1 44.367 l
+S20.6 51.617 m
+18.6 50.117 l
+S46.141 70.811 m
+47.994 73.492 l
+S69.391 40.561 m
+71.244 43.242 l
+S38.641 49.311 m
+39.35 52.117 l
+S25.141 16.811 m
+25.85 19.617 l
+S36.6 32.867 m
+34.6 31.367 l
+S6.1 68.617 m
+2.85 67.867 l
+S4.85 56.867 m
+2.35 55.117 l
+S7.6 51.617 m
+4.6 51.617 l
+S6.6 35.867 m
+4.6 34.367 l
+S6.1 12.867 m
+1.85 13.617 l
+S4.6 30.617 m
+1.6 30.617 l
+S72.814 74.769 m
+73.928 77.729 l
+S67.976 74.633 m
+67.35 77.909 l
+S52.762 73.779 m
+52.876 76.776 l
+S37.062 75.375 m
+35.639 77.43 l
+S20.795 75.242 m
+22.12 77.193 l
+S9.736 73.91 m
+8.073 76.225 l
+S10.1 23.617 m
+6.35 24.367 l
+S73.217 18.276 m
+71.323 21.1 l
+S28.823 39.6 m
+29.505 42.389 l
+S49.6 38.617 m
+47.6 37.117 l
+S60.323 73.6 m
+62.323 76.6 l
+S60.323 1.6 m
+62.323 4.6 l
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Kreise)
+(Kreise) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.4 0.7 1 0 k
+ 0.4 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Au\337en)
+(Lorbeer.Au\337en) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Innen)
+(Lorbeer.Innen) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Lorbeer.Kante)
+(Lorbeer.Kante) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.au\337en/innen1)
+(Pfeil 1.2.au\337en/innen1) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Pfeil 1.2.Kante)
+(Pfeil 1.2.Kante) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Punkte)
+(Punkte) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rauten)
+(Rauten) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.2 0 1 0 k
+ 0.2 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.75 0.9 0 0 k
+ 0.75 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schachbrettmuster)
+(Schachbrettmuster) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.9 1 0 k
+ 0 0.9 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Schuppen)
+(Schuppen) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sechseck)
+(Sechseck) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+20.538 30.244 m
+S26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s20.537 11.148 m
+S26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s53.614 30.244 m
+S59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s53.614 11.148 m
+S59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s20.538 68.436 m
+S26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s20.538 49.34 m
+S26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s53.614 68.436 m
+S59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s53.614 49.34 m
+S59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s4 20.696 m
+S3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S37.075 20.696 m
+S42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s37.076 58.888 m
+S42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s70.151 20.696 m
+S70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S70.152 58.888 m
+S70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S4 58.888 m
+S3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Seil.Kante)
+(Seil.Kante) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stern.Kante)
+(Stern.Kante) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Sterne)
+(Sterne) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Streifen)
+(Streifen) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d%AI3_Note:0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S8.2 22.6001 m
+80.7 22.6001 L
+S8.2 37.0002 m
+80.7 37.0002 L
+S8.2 51.4 m
+80.7 51.4 L
+S8.2 65.8001 m
+80.7 65.8001 L
+S8.2 15.4 m
+80.7 15.4 L
+S8.2 29.8001 m
+80.7 29.8001 L
+S8.2 44.2 m
+80.7 44.2 L
+S8.2 58.6001 m
+80.7 58.6001 L
+S8.2 73.0002 m
+80.7 73.0002 L
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Wellen-transparent)
+(Wellen-transparent) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d%AI3_Note:1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d%AI3_Note:0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--%AI5_Begin_NonPrintingNp12 Bn
+%AI5_BeginGradient: (Chrom)
+(Chrom) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Lila, Orange, Blau)
+(Gelb, Lila, Orange, Blau) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Orange-Radial)
+(Gelb, Orange-Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gelb, Violett-Radial)
+(Gelb, Violett-Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Gr\374n, Blau)
+(Gr\374n, Blau) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Gr\374n, Lila)
+(Orange, Gr\374n, Lila) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Regenbogen)
+(Regenbogen) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rosa, Gelb, Gr\374n)
+(Rosa, Gelb, Gr\374n) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Schwarz,Wei\337)
+(Schwarz,Wei\337) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Stahlgrau)
+(Stahlgrau) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Violett, Rot, Gelb)
+(Violett, Rot, Gelb) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Wei\337-Rot-Radial)
+(Wei\337-Rot-Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blau) 0 x
+(Blau) Pc
+0.5 0.4 0.3 0 (Blaugrau) 0 x
+(Blaugrau) Pc
+0.8 0.05 0 0 (Azur) 0 x
+(Azur) Pc
+0.5 0.85 1 0 (Braun) 0 x
+(Braun) Pc
+1 0.9 0.1 0 (Dunkelblau) 0 x
+(Dunkelblau) Pc
+1 0.55 1 0 (Tannengr\374n) 0 x
+(Tannengr\374n) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grasgr\374n) 0 x
+(Grasgr\374n) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Rot) 0 x
+(Rot) Pc
+0.45 0.9 0 0 (Lila) 0 x
+(Lila) Pc
+Bb
+2 (Schwarz,Wei\337) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Schwarz,Wei\337) Pc
+Bb
+2 (Chrom) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrom) Pc
+Bb
+2 (Gr\374n, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gr\374n, Blau) Pc
+Bb
+2 (Orange, Gr\374n, Lila) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Gr\374n, Lila) Pc
+Bb
+2 (Rosa, Gelb, Gr\374n) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rosa, Gelb, Gr\374n) Pc
+Bb
+2 (Violett, Rot, Gelb) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Violett, Rot, Gelb) Pc
+Bb
+2 (Regenbogen) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Regenbogen) Pc
+Bb
+2 (Stahlgrau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Stahlgrau) Pc
+Bb
+0 0 0 0 Bh
+2 (Wei\337-Rot-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Wei\337-Rot-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Orange-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Orange-Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Gelb, Violett-Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Violett-Radial\012  0) Pc
+Bb
+2 (Gelb, Lila, Orange, Blau) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Gelb, Lila, Orange, Blau) Pc
+(Pfeil 1.2.au\337en/innen1) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.au\337en/innen1) Pc
+(Pfeil 1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Pfeil 1.2.Kante) Pc
+(Backsteine) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Backsteine) Pc
+(Schachbrettmuster) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schachbrettmuster) Pc
+(Konfetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Konfetti) Pc
+(Dpllinie1.2.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Innen) Pc
+(Dpllinie1.2.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Au\337en) Pc
+(Dpllinie1.2.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Dpllinie1.2.Kante) Pc
+(Rauten) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rauten) Pc
+(Sechseck) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sechseck) Pc
+(Lorbeer.Innen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Innen) Pc
+(Lorbeer.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Au\337en) Pc
+(Lorbeer.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Lorbeer.Kante) Pc
+(Bl\344tter) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bl\344tter) Pc
+(Punkte) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Punkte) Pc
+(Kreise) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Kreise) Pc
+(Seil.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Seil.Kante) Pc
+(Schuppen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Schuppen) Pc
+(Stern.Kante) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stern.Kante) Pc
+(Sterne) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Sterne) Pc
+(Streifen) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Streifen) Pc
+(Ecke.Au\337en) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Ecke.Au\337en) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Wellen-transparent) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Wellen-transparent) Pc
+PB
+%AI5_EndPalette
+%%EndSetup
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Ebene 1) Ln
+0 A
+u1 Ap
+0 O
+0 0 0 0 k
+0 R
+0 0 0 1 K
+800 Ar
+0 J 0 j 3 w 4 M []0 d%AI3_Note:0 D
+0 XR
+-18 715.3335 m
+-18 760.3335 L
+-63 760.3335 L
+-63 715.3335 L
+-18 715.3335 L
+b40.5 715.3335 m
+40.5 760.3335 L
+-4.5 760.3335 L
+-4.5 715.3335 L
+40.5 715.3335 L
+b157.5 715.3335 m
+157.5 760.3335 L
+112.5 760.3335 L
+112.5 715.3335 L
+157.5 715.3335 L
+b99.0001 715.3335 m
+99.0001 760.3335 L
+54 760.3335 L
+54 715.3335 L
+99.0001 715.3335 L
+b450 715.3335 m
+450 760.3335 L
+405 760.3335 L
+405 715.3335 L
+450 715.3335 L
+b508.5 715.3335 m
+508.5 760.3335 L
+463.5 760.3335 L
+463.5 715.3335 L
+508.5 715.3335 L
+b625.5 715.3335 m
+625.5 760.3335 L
+580.5 760.3335 L
+580.5 715.3335 L
+625.5 715.3335 L
+b567.0001 715.3335 m
+567.0001 760.3335 L
+522 760.3335 L
+522 715.3335 L
+567.0001 715.3335 L
+b216 715.3335 m
+216 760.3335 L
+171 760.3335 L
+171 715.3335 L
+216 715.3335 L
+b274.5 715.3335 m
+274.5 760.3335 L
+229.5 760.3335 L
+229.5 715.3335 L
+274.5 715.3335 L
+b391.5 715.3335 m
+391.5 760.3335 L
+346.5 760.3335 L
+346.5 715.3335 L
+391.5 715.3335 L
+b333.0001 715.3335 m
+333.0001 760.3335 L
+288 760.3335 L
+288 715.3335 L
+333.0001 715.3335 L
+b-3.0002 565.6667 m
+-3.0002 610.6667 L
+-63 610.6667 L
+-63 565.6667 L
+-3.0002 565.6667 L
+b40.5 565.6667 m
+40.5 610.6667 L
+10.4998 610.6667 L
+10.4998 565.6667 L
+40.5 565.6667 L
+b113.9998 565.6667 m
+113.9998 610.6667 L
+54 610.6667 L
+54 565.6667 L
+113.9998 565.6667 L
+b157.5 565.6667 m
+157.5 610.6667 L
+127.4998 610.6667 L
+127.4998 565.6667 L
+157.5 565.6667 L
+b347.9998 565.6667 m
+347.9998 610.6667 L
+288 610.6667 L
+288 565.6667 L
+347.9998 565.6667 L
+b391.5 565.6667 m
+391.5 610.6667 L
+361.4998 610.6667 L
+361.4998 565.6667 L
+391.5 565.6667 L
+b230.9998 565.6667 m
+230.9998 610.6667 L
+171 610.6667 L
+171 565.6667 L
+230.9998 565.6667 L
+b274.5 565.6667 m
+274.5 610.6667 L
+244.4998 610.6667 L
+244.4998 565.6667 L
+274.5 565.6667 L
+b464.9998 565.6667 m
+464.9998 610.6667 L
+405 610.6667 L
+405 565.6667 L
+464.9998 565.6667 L
+b508.5 565.6667 m
+508.5 610.6667 L
+478.4998 610.6667 L
+478.4998 565.6667 L
+508.5 565.6667 L
+b581.9998 565.6667 m
+581.9998 610.6667 L
+522 610.6667 L
+522 565.6667 L
+581.9998 565.6667 L
+b625.5 565.6667 m
+625.5 610.6667 L
+595.4998 610.6667 L
+595.4998 565.6667 L
+625.5 565.6667 L
+b-18 416 m
+-18 461 L
+-63 461 L
+-63 416 L
+-18 416 L
+b40.5 416 m
+40.5 461 L
+-4.5 461 L
+-4.5 416 L
+40.5 416 L
+b157.5 416 m
+157.5 461 L
+112.5 461 L
+112.5 416 L
+157.5 416 L
+b99.0001 416 m
+99.0001 461 L
+54 461 L
+54 416 L
+99.0001 416 L
+b450 416 m
+450 461 L
+405 461 L
+405 416 L
+450 416 L
+b508.5 416 m
+508.5 461 L
+463.5 461 L
+463.5 416 L
+508.5 416 L
+b625.5 416 m
+625.5 461 L
+580.5 461 L
+580.5 416 L
+625.5 416 L
+b567.0001 416 m
+567.0001 461 L
+522 461 L
+522 416 L
+567.0001 416 L
+b216 416 m
+216 461 L
+171 461 L
+171 416 L
+216 416 L
+b274.5 416 m
+274.5 461 L
+229.5 461 L
+229.5 416 L
+274.5 416 L
+b391.5 416 m
+391.5 461 L
+346.5 461 L
+346.5 416 L
+391.5 416 L
+b333.0001 416 m
+333.0001 461 L
+288 461 L
+288 416 L
+333.0001 416 L
+bu*u
+0 Ap
+0 0 0 1 k
+1 w104.2974 692 m
+104.2975 695.6772 95.9889 698.475 90.7853 698.4716 c
+73.3402 698.9718 L
+60.543 698.9754 52.9998 702.5619 52.9999 706.6439 c
+53.0001 711.9998 L
+57.3402 712.1385 L
+57.5068 707.9718 L
+57.5068 705.1741 64.2938 703.1385 69.3402 703.1385 c
+88.0068 702.9718 L
+99.9344 702.491 104.924 699.3564 105.6091 697.7556 c
+105.8375 697.7556 L
+106.4085 699.3564 110.9799 701.9713 122.3133 703.1379 c
+140.98 703.3046 L
+146.3133 702.8046 151.8282 704.3713 153.8402 706.8051 c
+153.6735 711.8051 L
+158.0004 711.9987 L
+158.0002 706.6428 L
+156.9799 701.9713 149.0003 699.6413 139.6386 699.6414 c
+123.9719 699.1414 L
+115.6434 699.1415 107.8134 695.8151 107.8133 692.1379 C
+104.2974 692 l
+f*U
+*u
+107.7026 639.8119 m
+107.7026 636.1347 116.0112 633.337 121.2148 633.3405 c
+138.66 632.8406 L
+151.4571 632.8371 159.0003 629.2508 159.0003 625.1688 c
+159.0003 619.8129 L
+154.6602 619.6741 L
+154.4934 623.8408 L
+154.4935 626.6386 147.7064 628.674 142.66 628.674 c
+123.9934 628.8403 L
+112.0658 629.321 107.0761 632.4555 106.391 634.0563 c
+106.1626 634.0563 L
+105.5916 632.4554 101.0202 629.8405 89.6869 628.6737 c
+71.0202 628.5068 L
+65.6869 629.0067 60.172 627.4399 58.1601 625.006 c
+58.3268 620.006 L
+54 619.8124 L
+54 625.1683 L
+55.0202 629.8398 62.9998 632.1699 72.3616 632.1699 c
+88.0282 632.6702 L
+96.3567 632.6702 104.1867 635.9967 104.1867 639.6739 C
+107.7026 639.8119 l
+f*U
+0 To
+1 0 0 1 85 650.3051 0 Tp
+0 Tv
+TP
+0 Tr
+%_ 0 50 XQ
+/_Euclid-Italic 48 46.2239 -15.1677 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+1 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 XbXB0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+221.1841 692 m
+221.1842 695.6772 212.8757 698.475 207.672 698.4716 c
+190.2269 698.9718 L
+177.4297 698.9754 169.8866 702.5619 169.8866 706.6439 c
+169.8868 711.9998 L
+174.2269 712.1385 L
+174.3936 707.9718 L
+174.3935 705.1741 181.1805 703.1385 186.2269 703.1385 c
+204.8936 702.9718 L
+216.8211 702.491 221.8108 699.3564 222.4958 697.7556 c
+222.7242 697.7556 L
+223.2952 699.3564 227.8667 701.9713 239.2 703.1379 c
+257.8667 703.3046 L
+263.2 702.8046 268.7149 704.3713 270.7269 706.8051 c
+270.5602 711.8051 L
+274.8871 711.9987 L
+274.8869 706.6428 L
+273.8667 701.9713 265.887 699.6413 256.5253 699.6414 c
+240.8587 699.1414 L
+232.5302 699.1415 224.7001 695.8151 224.7 692.1379 C
+221.1841 692 l
+f*U
+*u
+224.5893 639.8119 m
+224.5893 636.1347 232.8979 633.337 238.1015 633.3405 c
+255.5467 632.8406 L
+268.3438 632.8371 275.8871 629.2508 275.8871 625.1688 c
+275.887 619.8129 L
+271.5469 619.6741 L
+271.3802 623.8408 L
+271.3802 626.6386 264.5932 628.674 259.5467 628.674 c
+240.8801 628.8403 L
+228.9525 629.321 223.9628 632.4555 223.2777 634.0563 c
+223.0493 634.0563 L
+222.4784 632.4554 217.9069 629.8405 206.5736 628.6737 c
+187.907 628.5068 L
+182.5736 629.0067 177.0587 627.4399 175.0468 625.006 c
+175.2135 620.006 L
+170.8867 619.8124 L
+170.8867 625.1683 L
+171.9069 629.8398 179.8865 632.1699 189.2483 632.1699 c
+204.9149 632.6702 L
+213.2434 632.6702 221.0734 635.9967 221.0735 639.6739 C
+224.5893 639.8119 l
+f*U
+0 To
+1 0 0 1 201.8867 650.3051 0 Tp
+0 Tv
+TP
+0 Tr
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+338.0708 692 m
+338.0709 695.6772 329.7624 698.475 324.5587 698.4716 c
+307.1136 698.9718 L
+294.3165 698.9754 286.7733 702.5619 286.7734 706.6439 c
+286.7735 711.9998 L
+291.1136 712.1385 L
+291.2803 707.9718 L
+291.2802 705.1741 298.0672 703.1385 303.1136 703.1385 c
+321.7803 702.9718 L
+333.7078 702.491 338.6975 699.3564 339.3826 697.7556 c
+339.611 697.7556 L
+340.1819 699.3564 344.7534 701.9713 356.0867 703.1379 c
+374.7534 703.3046 L
+380.0867 702.8046 385.6017 704.3713 387.6136 706.8051 c
+387.4469 711.8051 L
+391.7738 711.9987 L
+391.7737 706.6428 L
+390.7534 701.9713 382.7738 699.6413 373.412 699.6414 c
+357.7454 699.1414 L
+349.4169 699.1415 341.5868 695.8151 341.5867 692.1379 C
+338.0708 692 l
+f*U
+*u
+341.4761 639.8119 m
+341.4761 636.1347 349.7846 633.337 354.9883 633.3405 c
+372.4334 632.8406 L
+385.2305 632.8371 392.7738 629.2508 392.7738 625.1688 c
+392.7737 619.8129 L
+388.4336 619.6741 L
+388.2669 623.8408 L
+388.2669 626.6386 381.4799 628.674 376.4335 628.674 c
+357.7668 628.8403 L
+345.8393 629.321 340.8495 632.4555 340.1644 634.0563 c
+339.936 634.0563 L
+339.3651 632.4554 334.7937 629.8405 323.4604 628.6737 c
+304.7937 628.5068 L
+299.4603 629.0067 293.9454 627.4399 291.9335 625.006 c
+292.1003 620.006 L
+287.7734 619.8124 L
+287.7735 625.1683 L
+288.7937 629.8398 296.7733 632.1699 306.135 632.1699 c
+321.8016 632.6702 L
+330.1301 632.6702 337.9602 635.9967 337.9602 639.6739 C
+341.4761 639.8119 l
+f*U
+0 To
+1 0 0 1 318.7734 650.3051 0 Tp
+0 Tv
+TP
+0 Tr
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+454.9576 692 m
+454.9576 695.6772 446.6491 698.475 441.4455 698.4716 c
+424.0003 698.9718 L
+411.2032 698.9754 403.66 702.5619 403.6601 706.6439 c
+403.6602 711.9998 L
+408.0003 712.1385 L
+408.167 707.9718 L
+408.1669 705.1741 414.9539 703.1385 420.0003 703.1385 c
+438.667 702.9718 L
+450.5945 702.491 455.5842 699.3564 456.2693 697.7556 c
+456.4977 697.7556 L
+457.0687 699.3564 461.6401 701.9713 472.9734 703.1379 c
+491.6401 703.3046 L
+496.9734 702.8046 502.4884 704.3713 504.5003 706.8051 c
+504.3337 711.8051 L
+508.6605 711.9987 L
+508.6604 706.6428 L
+507.6401 701.9713 499.6605 699.6413 490.2987 699.6414 c
+474.6321 699.1414 L
+466.3036 699.1415 458.4735 695.8151 458.4734 692.1379 C
+454.9576 692 l
+f*U
+*u
+458.3628 639.8119 m
+458.3628 636.1347 466.6714 633.337 471.875 633.3405 c
+489.3201 632.8406 L
+502.1173 632.8371 509.6605 629.2508 509.6605 625.1688 c
+509.6604 619.8129 L
+505.3203 619.6741 L
+505.1536 623.8408 L
+505.1536 626.6386 498.3666 628.674 493.3202 628.674 c
+474.6535 628.8403 L
+462.726 629.321 457.7363 632.4555 457.0511 634.0563 c
+456.8227 634.0563 L
+456.2518 632.4554 451.6804 629.8405 440.3471 628.6737 c
+421.6804 628.5068 L
+416.3471 629.0067 410.8321 627.4399 408.8202 625.006 c
+408.987 620.006 L
+404.6601 619.8124 L
+404.6602 625.1683 L
+405.6804 629.8398 413.66 632.1699 423.0217 632.1699 c
+438.6884 632.6702 L
+447.0169 632.6702 454.8469 635.9967 454.8469 639.6739 C
+458.3628 639.8119 l
+f*U
+0 To
+1 0 0 1 435.6602 650.3051 0 Tp
+0 Tv
+TP
+0 Tr
+(U) Tx 1 0 Tk
+(\r) TX 
+TO
+Uuu*u
+59.2975 540.8887 m
+59.2976 544.5659 50.9891 547.3638 45.7854 547.3603 c
+28.3403 547.8605 L
+15.5431 547.8641 8 551.4506 8 555.5326 c
+8.0002 560.8885 L
+12.3403 561.0272 L
+12.507 556.8605 L
+12.5069 554.0628 19.2939 552.0272 24.3403 552.0272 c
+43.007 551.8605 L
+54.9345 551.3797 59.9242 548.2451 60.6092 546.6443 c
+60.8376 546.6443 L
+61.4086 548.2451 65.9801 550.86 77.3134 552.0266 c
+95.9801 552.1933 L
+101.3134 551.6933 106.8283 553.26 108.8403 555.6938 c
+108.6736 560.6938 L
+113.0005 560.8874 L
+113.0003 555.5315 L
+111.9801 550.86 104.0004 548.53 94.6387 548.5301 c
+78.9721 548.0301 L
+70.6436 548.0302 62.8135 544.7038 62.8134 541.0266 C
+59.2975 540.8887 l
+f*U
+*u
+47.7027 489.7631 m
+47.7027 486.0859 56.0113 483.2882 61.2149 483.2917 c
+78.6601 482.7918 L
+91.4572 482.7883 99.0005 479.202 99.0005 475.12 c
+99.0004 469.7641 L
+94.6603 469.6253 L
+94.4936 473.792 L
+94.4936 476.5898 87.7066 478.6252 82.6602 478.6252 c
+63.9935 478.7915 L
+52.0659 479.2722 47.0762 482.4067 46.3911 484.0075 c
+46.1627 484.0075 L
+45.5918 482.4066 41.0204 479.7917 29.687 478.6249 c
+11.0204 478.458 L
+5.687 478.9579 0.1721 477.3911 -1.8398 474.9572 c
+-1.673 469.9572 L
+-5.9999 469.7636 L
+-5.9998 475.1195 L
+-4.9796 479.791 3 482.1211 12.3617 482.1212 c
+28.0283 482.6214 L
+36.3568 482.6214 44.1868 485.9479 44.1869 489.6251 C
+47.7027 489.7631 l
+f*U
+0 To
+1 0 0 1 31 500.7844 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+176.7192 540.8887 m
+176.7192 544.5659 168.4107 547.3638 163.2071 547.3603 c
+145.7619 547.8605 L
+132.9648 547.8641 125.4216 551.4506 125.4217 555.5326 c
+125.4218 560.8885 L
+129.7619 561.0272 L
+129.9286 556.8605 L
+129.9285 554.0628 136.7155 552.0272 141.7619 552.0272 c
+160.4286 551.8605 L
+172.3561 551.3797 177.3458 548.2451 178.0309 546.6443 c
+178.2593 546.6443 L
+178.8303 548.2451 183.4017 550.86 194.7351 552.0266 c
+213.4017 552.1933 L
+218.7351 551.6933 224.25 553.26 226.2619 555.6938 c
+226.0953 560.6938 L
+230.4221 560.8874 L
+230.422 555.5315 L
+229.4017 550.86 221.4221 548.53 212.0604 548.5301 c
+196.3937 548.0301 L
+188.0652 548.0302 180.2351 544.7038 180.2351 541.0266 C
+176.7192 540.8887 l
+f*U
+*u
+165.1244 489.7631 m
+165.1244 486.0859 173.433 483.2882 178.6366 483.2917 c
+196.0817 482.7918 L
+208.8789 482.7883 216.4221 479.202 216.4221 475.12 c
+216.422 469.7641 L
+212.082 469.6253 L
+211.9152 473.792 L
+211.9152 476.5898 205.1282 478.6252 200.0818 478.6252 c
+181.4151 478.7915 L
+169.4876 479.2722 164.4979 482.4067 163.8128 484.0075 c
+163.5844 484.0075 L
+163.0134 482.4066 158.442 479.7917 147.1087 478.6249 c
+128.442 478.458 L
+123.1087 478.9579 117.5938 477.3911 115.5818 474.9572 c
+115.7486 469.9572 L
+111.4217 469.7636 L
+111.4218 475.1195 L
+112.442 479.791 120.4216 482.1211 129.7833 482.1212 c
+145.45 482.6214 L
+153.7785 482.6214 161.6085 485.9479 161.6085 489.6251 C
+165.1244 489.7631 l
+f*U
+0 To
+1 0 0 1 148.4216 500.7844 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+294.1408 540.8887 m
+294.1409 544.5659 285.8323 547.3638 280.6287 547.3603 c
+263.1836 547.8605 L
+250.3864 547.8641 242.8433 551.4506 242.8433 555.5326 c
+242.8435 560.8885 L
+247.1836 561.0272 L
+247.3502 556.8605 L
+247.3502 554.0628 254.1372 552.0272 259.1836 552.0272 c
+277.8502 551.8605 L
+289.7778 551.3797 294.7675 548.2451 295.4525 546.6443 c
+295.6809 546.6443 L
+296.2519 548.2451 300.8234 550.86 312.1567 552.0266 c
+330.8234 552.1933 L
+336.1567 551.6933 341.6716 553.26 343.6836 555.6938 c
+343.5169 560.6938 L
+347.8438 560.8874 L
+347.8436 555.5315 L
+346.8234 550.86 338.8437 548.53 329.482 548.5301 c
+313.8153 548.0301 L
+305.4869 548.0302 297.6568 544.7038 297.6567 541.0266 C
+294.1408 540.8887 l
+f*U
+*u
+282.546 489.7631 m
+282.546 486.0859 290.8546 483.2882 296.0582 483.2917 c
+313.5034 482.7918 L
+326.3005 482.7883 333.8438 479.202 333.8437 475.12 c
+333.8437 469.7641 L
+329.5036 469.6253 L
+329.3368 473.792 L
+329.3369 476.5898 322.5498 478.6252 317.5034 478.6252 c
+298.8368 478.7915 L
+286.9092 479.2722 281.9195 482.4067 281.2344 484.0075 c
+281.006 484.0075 L
+280.4351 482.4066 275.8636 479.7917 264.5303 478.6249 c
+245.8637 478.458 L
+240.5303 478.9579 235.0154 477.3911 233.0035 474.9572 c
+233.1702 469.9572 L
+228.8434 469.7636 L
+228.8434 475.1195 L
+229.8636 479.791 237.8432 482.1211 247.205 482.1212 c
+262.8716 482.6214 L
+271.2001 482.6214 279.0301 485.9479 279.0302 489.6251 C
+282.546 489.7631 l
+f*U
+0 To
+1 0 0 1 265.8433 500.7844 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+411.5625 540.8887 m
+411.5625 544.5659 403.254 547.3638 398.0504 547.3603 c
+380.6052 547.8605 L
+367.8081 547.8641 360.2649 551.4506 360.265 555.5326 c
+360.2651 560.8885 L
+364.6052 561.0272 L
+364.7719 556.8605 L
+364.7718 554.0628 371.5588 552.0272 376.6052 552.0272 c
+395.2719 551.8605 L
+407.1994 551.3797 412.1891 548.2451 412.8742 546.6443 c
+413.1026 546.6443 L
+413.6736 548.2451 418.245 550.86 429.5783 552.0266 c
+448.245 552.1933 L
+453.5783 551.6933 459.0933 553.26 461.1052 555.6938 c
+460.9386 560.6938 L
+465.2654 560.8874 L
+465.2653 555.5315 L
+464.245 550.86 456.2654 548.53 446.9037 548.5301 c
+431.237 548.0301 L
+422.9085 548.0302 415.0784 544.7038 415.0783 541.0266 C
+411.5625 540.8887 l
+f*U
+*u
+399.9677 489.7631 m
+399.9677 486.0859 408.2763 483.2882 413.4799 483.2917 c
+430.925 482.7918 L
+443.7222 482.7883 451.2654 479.202 451.2654 475.12 c
+451.2653 469.7641 L
+446.9252 469.6253 L
+446.7585 473.792 L
+446.7585 476.5898 439.9715 478.6252 434.9251 478.6252 c
+416.2584 478.7915 L
+404.3309 479.2722 399.3412 482.4067 398.656 484.0075 c
+398.4277 484.0075 L
+397.8567 482.4066 393.2853 479.7917 381.952 478.6249 c
+363.2853 478.458 L
+357.952 478.9579 352.4371 477.3911 350.4251 474.9572 c
+350.5919 469.9572 L
+346.265 469.7636 L
+346.2651 475.1195 L
+347.2853 479.791 355.2649 482.1211 364.6266 482.1212 c
+380.2933 482.6214 L
+388.6218 482.6214 396.4518 485.9479 396.4518 489.6251 C
+399.9677 489.7631 l
+f*U
+0 To
+1 0 0 1 383.2649 500.7844 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+Uu*u
+528.9841 540.8887 m
+528.9842 544.5659 520.6756 547.3638 515.472 547.3603 c
+498.0269 547.8605 L
+485.2297 547.8641 477.6865 551.4506 477.6866 555.5326 c
+477.6868 560.8885 L
+482.0269 561.0272 L
+482.1935 556.8605 L
+482.1935 554.0628 488.9805 552.0272 494.0269 552.0272 c
+512.6935 551.8605 L
+524.6211 551.3797 529.6107 548.2451 530.2958 546.6443 c
+530.5242 546.6443 L
+531.0952 548.2451 535.6667 550.86 547 552.0266 c
+565.6667 552.1933 L
+571 551.6933 576.5149 553.26 578.5269 555.6938 c
+578.3602 560.6938 L
+582.6871 560.8874 L
+582.6869 555.5315 L
+581.6667 550.86 573.687 548.53 564.3253 548.5301 c
+548.6586 548.0301 L
+540.3302 548.0302 532.5001 544.7038 532.5 541.0266 C
+528.9841 540.8887 l
+f*U
+*u
+517.3893 489.7631 m
+517.3893 486.0859 525.6979 483.2882 530.9015 483.2917 c
+548.3467 482.7918 L
+561.1438 482.7883 568.6871 479.202 568.687 475.12 c
+568.687 469.7641 L
+564.3469 469.6253 L
+564.1801 473.792 L
+564.1802 476.5898 557.3931 478.6252 552.3467 478.6252 c
+533.6801 478.7915 L
+521.7525 479.2722 516.7628 482.4067 516.0777 484.0075 c
+515.8493 484.0075 L
+515.2783 482.4066 510.7069 479.7917 499.3736 478.6249 c
+480.707 478.458 L
+475.3736 478.9579 469.8587 477.3911 467.8468 474.9572 c
+468.0135 469.9572 L
+463.6867 469.7636 L
+463.6867 475.1195 L
+464.7069 479.791 472.6865 482.1211 482.0483 482.1212 c
+497.7149 482.6214 L
+506.0434 482.6214 513.8734 485.9479 513.8735 489.6251 C
+517.3893 489.7631 l
+f*U
+0 To
+1 0 0 1 500.6866 500.7844 0 Tp
+0 Tv
+TP
+0 Tr
+(V) Tx 1 0 Tk
+(\r) TX 
+TO
+UUULB
+%AI5_EndLayer--
+%%PageTrailer
+gsave annotatepage grestore showpage
+%%Trailer
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+%%EOF

--- a/TNLean/QCA/RelativeCommutant.lean
+++ b/TNLean/QCA/RelativeCommutant.lean
@@ -14,8 +14,8 @@ complementary subregion is exactly the matrix algebra on the retained subregion.
 statement in the algebraic local algebra characterizes finite support by commutation with every
 observable supported in a disjoint finite region.
 
-These are source-independent finite-dimensional and algebraic-local facts. They do not assert the
-norm-completed support characterization of Schumacher--Werner.
+These are source-independent finite-dimensional and algebraic-local facts. They are not statements
+of Schumacher--Werner.
 
 ## Main results
 
@@ -167,8 +167,9 @@ variable {d : ℕ} [NeZero d] {x : AlgebraicLocalAlgebra d} {Λ : Finset ℤ}
 /-- An algebraic-local observable is supported in a finite region exactly when it commutes with
 every algebraic-local observable supported in a disjoint finite region.
 
-This is an algebraic-local consequence of the finite relative-commutant theorem. It is not the
-norm-completed support characterization in Schumacher--Werner, Theorem 6 and Corollary 7. -/
+This is an algebraic-local consequence of the finite relative-commutant theorem. It is not stated
+by Schumacher--Werner; their Theorem 6 and Corollary 7 instead give the generalized Margolus
+structure and inverse locality for nearest-neighbor QCAs. -/
 theorem supportedIn_iff_commute_disjoint :
     SupportedIn x Λ ↔
       ∀ Γ, Disjoint Γ Λ →

--- a/TNLean/QCA/RelativeCommutant.lean
+++ b/TNLean/QCA/RelativeCommutant.lean
@@ -168,8 +168,8 @@ variable {d : ℕ} [NeZero d] {x : AlgebraicLocalAlgebra d} {Λ : Finset ℤ}
 every algebraic-local observable supported in a disjoint finite region.
 
 This is an algebraic-local consequence of the finite relative-commutant theorem. It is not stated
-by Schumacher--Werner; their Theorem 6 and Corollary 7 instead give the generalized Margolus
-structure and inverse locality for nearest-neighbor QCAs. -/
+by Schumacher--Werner. Their Theorem 6 gives the generalized Margolus structure, and Corollary 7
+says that the inverse of a nearest-neighbor QCA exists and is a nearest-neighbor QCA. -/
 theorem supportedIn_iff_commute_disjoint :
     SupportedIn x Λ ↔
       ∀ Γ, Disjoint Γ Λ →

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8348,8 +8348,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         Y\in\iota_\Gamma(\mathcal A_\Gamma)\bigr)\Longrightarrow XY=YX.
   \end{align}
   This is an algebraic-local statement. It does not assert the corresponding
-  characterization in the norm completion and is not Schumacher--Werner
-  Theorem~6 or Corollary~7.
+  characterization in the norm completion and is not stated by
+  Schumacher--Werner. Their Theorem~6 gives the generalized Margolus structure,
+  and Corollary~7 says that the inverse of a nearest-neighbor QCA exists and is a
+  nearest-neighbor QCA.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## What changed

- vendor the complete official arXiv source archive for Schumacher-Werner, quant-ph/0405174, under `Papers/quant-ph_0405174/`
- record the exact title, authors, and arXiv license metadata in `Papers/NOTICE.md`
- verify Definition 1, Lemma 5, Theorem 6, and Corollary 7 against the source and correct one inaccurate relative-commutant attribution

## Source verification

- Definition 1 is forward-only: `qca.tex:309-318`
- the paper says invertibility was omitted because it follows later: `qca.tex:226-233`
- Lemma 5: generalized Margolus automata and their inverses, `qca.tex:1045-1052`
- Theorem 6: nearest-neighbor QCA has generalized Margolus form, `qca.tex:1087-1101`
- Corollary 7: the inverse exists and is nearest-neighbor, `qca.tex:1105-1110`

## Validation

- all 11 vendored files matched a fresh official arXiv source download byte-for-byte
- no generated build artifacts were added
- NOTICE/source-directory and theorem-numbering assertions passed
- static file-policy, oversized-file, numbered-module, prose, whitespace, and diff checks passed

Closes #6539.