### PR TITLE
refactor(analysis): shared toEuclideanLin multiplicity and review follow-ups

### DIFF
--- a/TNLean/Analysis/MatrixReducedProjection.lean
+++ b/TNLean/Analysis/MatrixReducedProjection.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.OrthogonalProjection
+import TNLean.Analysis.TraceNormAbs
 import TNLean.Analysis.TwoProjectionReducedProjection
 
 /-!
@@ -18,15 +19,6 @@ right factor from `LinearMap.IsSymmetricProjection.reducedProjection`.
 namespace Matrix
 
 variable {D : ℕ}
-
-private theorem toEuclideanLin_mul (A B : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.toEuclideanLin (A * B) =
-      (Matrix.toEuclideanLin A).comp (Matrix.toEuclideanLin B) := by
-  change Matrix.toLin (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis (A * B) = _
-  exact Matrix.toLin_mul (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis A B
 
 private theorem isSymmetricProjection_toEuclideanLin
     {P : Matrix (Fin D) (Fin D) ℂ} (hP : IsOrthogonalProjection P) :

--- a/TNLean/Analysis/TraceNormAbs.lean
+++ b/TNLean/Analysis/TraceNormAbs.lean
@@ -68,6 +68,16 @@ namespace Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n] {D : ℕ}
 
+/-- Multiplicativity of `Matrix.toEuclideanLin`: matrix multiplication becomes
+composition of Euclidean linear maps. -/
+theorem toEuclideanLin_mul (A B : Matrix n n ℂ) :
+    toEuclideanLin (A * B) = (toEuclideanLin A).comp (toEuclideanLin B) := by
+  change Matrix.toLin (EuclideanSpace.basisFun n ℂ).toBasis
+      (EuclideanSpace.basisFun n ℂ).toBasis (A * B) = _
+  exact Matrix.toLin_mul (EuclideanSpace.basisFun n ℂ).toBasis
+    (EuclideanSpace.basisFun n ℂ).toBasis
+    (EuclideanSpace.basisFun n ℂ).toBasis A B
+
 /-- The symmetric map $T^\dagger \circ T$, where $T$ is `Matrix.toEuclideanLin A`,
 is represented by the positive-semidefinite matrix $A^\dagger A$. -/
 theorem adjoint_toEuclideanLin_comp_self (A : Matrix n n ℂ) :

--- a/TNLean/Channel/Peripheral/WeightedCesaro.lean
+++ b/TNLean/Channel/Peripheral/WeightedCesaro.lean
@@ -89,7 +89,7 @@ private theorem pow_apply_of_mem_eigenspace {f : Module.End ℂ V} {μ : ℂ} {x
   | succ n ih =>
       rw [pow_succ']
       change f ((f ^ n) x) = _
-      rw [ih, map_smul, Module.End.mem_eigenspace_iff.mp hx, smul_smul, pow_succ', mul_comm]
+      rw [ih, map_smul, Module.End.mem_eigenspace_iff.mp hx, smul_smul, pow_succ]
 
 end Definition
 

--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.TraceNormAbs
 import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import Mathlib.Analysis.InnerProductSpace.JointEigenspace
@@ -54,11 +55,7 @@ the Euclidean linear map level. -/
 lemma toEuclideanLin_mul (A B : Matrix (Fin D) (Fin D) ℂ) :
     (Matrix.toEuclideanLin A : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D)) *
       Matrix.toEuclideanLin B = Matrix.toEuclideanLin (A * B) := by
-  rw [Module.End.mul_eq_comp]
-  simpa only [Matrix.toEuclideanLin_eq_toLin_orthonormal] using
-    (Matrix.toLin_mul (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis A B).symm
+  simpa only [Module.End.mul_eq_comp] using (Matrix.toEuclideanLin_mul A B).symm
 
 end Internal
 

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -171,6 +171,7 @@
 \begin{proof}\leanok
     \uses{cor:dirichlet_phase_recurrence,
         def:peripheral_spectral_projections,
+        lem:non_peripheral_pow_vanishing,
         thm:peripheral_jordan_trivial,
         thm:positive_trace_preserving_mean_ergodic_projection}
     Bounded forward orbits imply that every eigenvalue has modulus at most

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -108,7 +108,7 @@ channel:
 \begin{theorem}[Stinespring dual representation]\label{thm:stinespring_dual_representation}
     \lean{stinespring_dual_representation}
     \leanok
-    \uses{def:stinespring_v, def:cp_map, thm:stinespring_v_conjTranspose_mul}
+    \uses{def:stinespring_v, def:trace_pairing_adjoint}
     Let $K_j:\C^{d}\to\C^{d'}$, $j=0,\dots,r-1$, be an arbitrary family of
     matrices and let $V=\sum_j K_j\otimes\ket{j}$. Then, for every observable
     $A\in\MN{d'}$ on the output space,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -506,6 +506,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Euclidean linear-map multiplicativity
+- **Pattern:** prove that `Matrix.toEuclideanLin (A * B)` is the composition of the
+  Euclidean linear maps represented by `A` and `B` by expanding both sides through
+  `Matrix.toLin_mul` in the standard orthonormal basis.
+- **Reuse:** `Matrix.toEuclideanLin_mul` in `TNLean/Analysis/TraceNormAbs.lean` is the shared
+  layer-0 statement.
+- **Result:** `TNLean/Analysis/MatrixReducedProjection.lean` uses the shared theorem directly,
+  and `PositiveOnAbelian.Internal.toEuclideanLin_mul` remains as a compatibility wrapper for
+  its three existing Channel call sites. The two-copy candidate was promoted early as required
+  by issue #6525, preventing a third layer-crossing copy.
+
 ### One-step cyclic-forward offset
 - **Identity:** `MPSTensor.cyclicForwardSite_one_offset` states that the old starting site has
   offset `N - 1` from its one-step cyclic successor.
@@ -1063,6 +1074,19 @@ abstracted — record why, so it is not re-proposed).
 
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
+
+### powers on an eigenspace — candidate
+- **Pattern:** prove `(f ^ n) x = μ ^ n • x` from `x ∈ f.eigenspace μ`, either by induction
+  using `Module.End.mem_eigenspace_iff` or by splitting on `x = 0` before applying
+  `HasEigenvector.pow_apply`.
+- **Seen:** 2 occurrences across `TNLean/Channel/Peripheral/WeightedCesaro.lean` and
+  `TNLean/Channel/Peripheral/CesaroRecurrence.lean` (review on 2026-08-17).
+- **Abstraction (proposed):** if a third occurrence appears, promote the private
+  `pow_apply_of_mem_eigenspace` next to the shared `Module.End.eigenspace` API and refactor
+  the case-split variant to use it.
+- **Notes:** This is below the rule-of-three threshold. The induction handles the zero vector
+  without constructing a `HasEigenvector`; keep the helper private until another independent
+  consumer fixes the useful public location.
 
 ### quasi-local translation laws in automorphism-group form — candidate
 - **Pattern:** convert translation composition, symmetry, and identity laws from


### PR DESCRIPTION
## What changed

Four review follow-ups from the just-merged PRs LionSR/TNLean#6303, LionSR/TNLean#6344, LionSR/TNLean#6513:

- LionSR/QICLean#329: lem:non_peripheral_pow_vanishing added to the proof uses of thm:peripheral_projection_recurrent_subsequence.
- LionSR/QICLean#328: thm:stinespring_dual_representation statement uses corrected (stale def:cp_map and proof-only entries dropped; def:trace_pairing_adjoint added).
- LionSR/TNLean#6525: Matrix.toEuclideanLin_mul promoted to the shared layer-0 module TNLean/Analysis/TraceNormAbs.lean; private copy removed; PositiveOnAbelian.Internal delegates; ledger entry added.
- LionSR/QICLean#330: dead mul_comm removed; eigenspace-power pattern recorded.

## Validation

Targeted lake build green for all touched modules and aggregators; double lualatex zero undefined References; checkdecls zero missing.

Closes LionSR/QICLean#328, closes LionSR/QICLean#329, closes LionSR/QICLean#330, closes LionSR/TNLean#6525