### PR TITLE
chore(MPDO): precise Appendix C.4 citations and dead wrapper removal

### DIFF
--- a/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
@@ -59,7 +59,7 @@ This statement deliberately keeps the positive-length hypothesis.  Theorem
 IV.13(ii) does not constrain the artificial length-zero value of the formal
 coefficient family.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+Appendix C.4, lines 2020--2042 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 @[deprecated "Unpack the witness and use `BNTLabelTheoremWitness.coeff_eq_ofChi_coeff`."
   (since := "2026-08-15")]
@@ -79,7 +79,7 @@ family determined by its \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 This only rephrases the positive-length coefficient identity carried by the
 witness; it does not construct the witness from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+Appendix C.4, lines 2020--2042 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 @[deprecated "Unpack the witness and use the `ofChi` source predicates directly."
   (since := "2026-08-15")]
@@ -100,7 +100,7 @@ written with the canonical coefficient family determined by its
 This only rephrases the positive-length coefficient identity carried by the
 witness; it does not construct the witness from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+Appendix C.4, lines 2020--2042 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 @[deprecated "Unpack the witness and use the `ofChi` source equations directly."
   (since := "2026-08-15")]

--- a/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
@@ -461,25 +461,4 @@ theorem gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm :
     gaugeDeformedSymbolBlocks
     (fun a ↦ gaugeDeformedSymbolTensor_isNormalTensor a)).isCPSVCanonicalForm
 
-/-- The concrete deformation satisfies the tensor-attached algebra clause and
-literal horizontal canonical-form premises of CPSV16, Theorem 4.14(ii), but is
-not an MPDO.
-
-The failure occurs already at length two.  Accordingly this theorem is not a
-full-contract counterexample and does not construct an
-`IdentityMarkedRealization`; it isolates all-length MPDO positivity as the
-failed standing hypothesis in this family.  Source: CPSV16, Appendix C.4,
-lines 2048--2057, and Theorem 4.14(ii). -/
-@[deprecated "Use `gaugeDeformedBaseMPOBNTAlgebraTensorClause`,
-  `gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm`, and
-  `gaugeDeformedBaseMPO_gauge_not_isMPDO` directly." (since := "2026-08-16")]
-theorem gaugeDeformedBaseMPO_algebraClause_canonicalForm_not_isMPDO :
-    Nonempty (BNTAlgebraTensorClause (gaugeDeformedBaseMPO gauge)) ∧
-      MPSTensor.IsCPSVCanonicalForm
-        (gaugeDeformedBaseMPO gauge).toMPSTensor ∧
-      ¬ IsMPDO (gaugeDeformedBaseMPO gauge) :=
-  ⟨⟨gaugeDeformedBaseMPOBNTAlgebraTensorClause⟩,
-    gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm,
-    gaugeDeformedBaseMPO_gauge_not_isMPDO⟩
-
 end MPOTensor.BondTwoSingletonBaseModel


### PR DESCRIPTION
## What changed

- **#6502**: the three `ofChi`-derived witness docstrings in `BNTTheoremWitnessConsequences.lean` (`exists_positive_length_coeff_eq_ofChi`, `exists_source_ofChi_predicates`, `exists_source_ofChi_equations`) now cite the diagonal \\chi-construction range Appendix C.4 lines 2020-2042, matching the sibling docstrings.
- **#6503**: the unconsumed conjunction wrapper `gaugeDeformedBaseMPO_algebraClause_canonicalForm_not_isMPDO` is deleted, riding this module-touching PR so the changed-module rebuild cost is shared (route 1 of the issue). The three component theorems remain preferred and cited by `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.

## Validation

- `lake build TNLean.MPS.MPDO.BNTTheoremWitnessConsequences TNLean.MPS.MPDO.BondTwoSingletonPhysicalGauge`: green (8991 jobs).
- No docstring/blueprint tag referenced the wrapper (grep-verified; only the audit document names it, as history).

Closes #6502, closes #6503