### PR TITLE
feat(MPS/MPU): reduced-to-hat source-rank transport

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm
 import TNLean.MPS.MPU.PhysicalAncilla
 import TNLean.MPS.MPU.ReducedRepresentative
+import TNLean.MPS.MPU.ReducedToHatTransport
 import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.MatrixReducedProjection
 import TNLean.Analysis.MatrixSqrt
-import TNLean.MPS.MPU.ReducedRepresentative
 import TNLean.MPS.MPU.VirtualSandwich
 
 /-!
@@ -126,7 +126,7 @@ theorem exists_units_for_hat_reduced_projection
       hL.supportProj * hR.supportProj * Y =
         Matrix.reducedProjection hL.supportProj hR.supportProj := by
   have hP : IsOrthogonalProjection hL.supportProj :=
-    ⟨hL.supportProj_isHermitian, hL.isHermitian.supportProj_idem⟩
+    hL.isOrthogonalProjection_supportProj
   obtain ⟨Y, hY, hTQY⟩ := Matrix.exists_reducedProjection_rightFactor
     (P := hL.supportProj) (Q := hR.supportProj) hP
   have hPQY : hL.supportProj * hR.supportProj * Y =

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixSqrt
+import TNLean.MPS.MPU.ReducedRepresentative
+import TNLean.MPS.MPU.VirtualSandwich
+
+/-!
+# Source-rank comparison for the reduced and hatted representatives
+
+This module proves the matrix identity comparing the paper's hatted tensor
+$\widehat W=LWR$ with the reduced tensor $\widetilde W=\widetilde P W\widetilde P$,
+and then compares their two raw source-cut ranks.
+
+**Scope restriction (supplied fixed pair):** the identities defining the outer
+factors and the letterwise support absorptions are explicit hypotheses. They are
+not inferred from the bare MPU predicate. The source derives them after blocking
+and constructing a positive fixed pair. See
+`docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex`.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The exact comparison between the hatted tensor $\widehat W=LWR$ and the reduced
+representative $\widetilde W=\widetilde P W\widetilde P$:
+$$
+  X\widehat W(ZY)=PW(QY)=PQW(PQY)=\widetilde P W\widetilde P.
+$$
+All identities involving the fixed pair and its support absorptions are supplied.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
+theorem virtual_sandwich_hat_eq_reduced_projection
+    (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
+    (hP : IsOrthogonalProjection P)
+    (hXL : X * L = P) (hRZ : R * Z = Q)
+    (hPQY : P * Q * Y = Matrix.reducedProjection P Q)
+    (hWP : ∀ i j, W i j * P = W i j)
+    (hQW : ∀ i j, Q * W i j = W i j) :
+    virtualSandwich X (virtualSandwich L W R) (Z * Y) =
+      virtualSandwich (Matrix.reducedProjection P Q) W
+        (Matrix.reducedProjection P Q) := by
+  let T := Matrix.reducedProjection P Q
+  have hTQ : T * Q = P * Q := Matrix.reducedProjection_mul_second hP
+  funext i j
+  simp only [virtualSandwich_apply]
+  calc
+    X * (L * W i j * R) * (Z * Y) = P * W i j * Q * Y := by
+      calc
+        _ = (X * L) * W i j * (R * Z) * Y := by noncomm_ring
+        _ = P * W i j * Q * Y := by rw [hXL, hRZ]
+    _ = P * Q * W i j * P * Q * Y := by
+      symm
+      calc
+        _ = P * (Q * W i j) * P * Q * Y := by noncomm_ring
+        _ = P * W i j * P * Q * Y := by rw [hQW]
+        _ = P * (W i j * P) * Q * Y := by noncomm_ring
+        _ = P * W i j * Q * Y := by rw [hWP]
+    _ = T * W i j * T := by
+      calc
+        _ = (P * Q) * W i j * (P * Q * Y) := by noncomm_ring
+        _ = (T * Q) * W i j * T := by rw [hTQ, hPQY]
+        _ = T * (Q * W i j) * T := by noncomm_ring
+        _ = T * W i j * T := by rw [hQW]
+
+/-- If the three outer factors are invertible, the right source rank of the hatted
+representative equals that of the reduced representative.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
+theorem right_rank_hat_eq_reduced_projection
+    (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
+    (hP : IsOrthogonalProjection P)
+    (hXL : X * L = P) (hRZ : R * Z = Q)
+    (hPQY : P * Q * Y = Matrix.reducedProjection P Q)
+    (hWP : ∀ i j, W i j * P = W i j)
+    (hQW : ∀ i j, Q * W i j = W i j)
+    (hX : IsUnit X) (hZ : IsUnit Z) (hY : IsUnit Y) :
+    r[virtualSandwich L W R] =
+      r[virtualSandwich (Matrix.reducedProjection P Q) W
+        (Matrix.reducedProjection P Q)] := by
+  rw [← virtual_sandwich_hat_eq_reduced_projection W L R P Q X Z Y
+    hP hXL hRZ hPQY hWP hQW]
+  exact (rightRank_virtualSandwich X (virtualSandwich L W R) (Z * Y)
+    hX (hZ.mul hY)).symm
+
+/-- If the three outer factors are invertible, the left source rank of the hatted
+representative equals that of the reduced representative.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
+theorem left_rank_hat_eq_reduced_projection
+    (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
+    (hP : IsOrthogonalProjection P)
+    (hXL : X * L = P) (hRZ : R * Z = Q)
+    (hPQY : P * Q * Y = Matrix.reducedProjection P Q)
+    (hWP : ∀ i j, W i j * P = W i j)
+    (hQW : ∀ i j, Q * W i j = W i j)
+    (hX : IsUnit X) (hZ : IsUnit Z) (hY : IsUnit Y) :
+    ℓ[virtualSandwich L W R] =
+      ℓ[virtualSandwich (Matrix.reducedProjection P Q) W
+        (Matrix.reducedProjection P Q)] := by
+  rw [← virtual_sandwich_hat_eq_reduced_projection W L R P Q X Z Y
+    hP hXL hRZ hPQY hWP hQW]
+  exact (leftRank_virtualSandwich X (virtualSandwich L W R) (Z * Y)
+    hX (hZ.mul hY)).symm
+
+/-- Positive semidefinite fixed matrices supply invertible outer factors $X,Z,Y$
+with
+$$
+  XL=P,\qquad RZ=Q,\qquad PQY=\widetilde P,
+$$
+where $P$ and $Q$ are their support projections.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
+theorem exists_units_for_hat_reduced_projection
+    {L R : Matrix (Fin D) (Fin D) ℂ} (hL : L.PosSemidef) (hR : R.PosSemidef) :
+    ∃ X Z Y : Matrix (Fin D) (Fin D) ℂ,
+      IsUnit X ∧ IsUnit Z ∧ IsUnit Y ∧
+      X * L = hL.supportProj ∧ R * Z = hR.supportProj ∧
+      hL.supportProj * hR.supportProj * Y =
+        Matrix.reducedProjection hL.supportProj hR.supportProj := by
+  have hP : IsOrthogonalProjection hL.supportProj :=
+    ⟨hL.supportProj_isHermitian, hL.isHermitian.supportProj_idem⟩
+  obtain ⟨Y, hY, hTQY⟩ := Matrix.exists_reducedProjection_rightFactor
+    (P := hL.supportProj) (Q := hR.supportProj) hP
+  have hPQY : hL.supportProj * hR.supportProj * Y =
+      Matrix.reducedProjection hL.supportProj hR.supportProj := by
+    rw [← Matrix.reducedProjection_mul_second hP, hTQY]
+  exact ⟨hL.supportInvExtension, hR.supportInvExtension, Y,
+    hL.isUnit_supportInvExtension, hR.isUnit_supportInvExtension, hY,
+    hL.supportInvExtension_mul_self, hR.self_mul_supportInvExtension, hPQY⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -14,7 +14,7 @@ open scoped ComplexOrder
 
 This module proves the matrix identity comparing the paper's hatted tensor
 $\widehat W=LWR$ with the reduced tensor $\widetilde W=\widetilde P W\widetilde P$,
-and then compares their two raw source-cut ranks.
+and then compares their two raw source ranks.
 
 **Scope restriction (supplied fixed pair):** the identities defining the outer
 factors and the letterwise support absorptions are explicit hypotheses. They are
@@ -24,7 +24,6 @@ and constructing a positive fixed pair. See
 
 Source: `Papers/1703.09188/paper_v2.tex:786-804`.
 -/
-
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -37,7 +37,7 @@ $$
 All identities involving the fixed pair and its support absorptions are supplied.
 
 Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
-theorem virtual_sandwich_hat_eq_reduced_projection
+theorem virtualSandwich_hat_eq_reducedProjection
     (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
     (hP : IsOrthogonalProjection P)
     (hXL : X * L = P) (hRZ : R * Z = Q)
@@ -74,7 +74,7 @@ theorem virtual_sandwich_hat_eq_reduced_projection
 representative equals that of the reduced representative.
 
 Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
-theorem right_rank_hat_eq_reduced_projection
+theorem rightRank_hat_eq_reducedProjection
     (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
     (hP : IsOrthogonalProjection P)
     (hXL : X * L = P) (hRZ : R * Z = Q)
@@ -85,7 +85,7 @@ theorem right_rank_hat_eq_reduced_projection
     r[virtualSandwich L W R] =
       r[virtualSandwich (Matrix.reducedProjection P Q) W
         (Matrix.reducedProjection P Q)] := by
-  rw [← virtual_sandwich_hat_eq_reduced_projection W L R P Q X Z Y
+  rw [← virtualSandwich_hat_eq_reducedProjection W L R P Q X Z Y
     hP hXL hRZ hPQY hWP hQW]
   exact (rightRank_virtualSandwich X (virtualSandwich L W R) (Z * Y)
     hX (hZ.mul hY)).symm
@@ -94,7 +94,7 @@ theorem right_rank_hat_eq_reduced_projection
 representative equals that of the reduced representative.
 
 Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
-theorem left_rank_hat_eq_reduced_projection
+theorem leftRank_hat_eq_reducedProjection
     (W : MPOTensor d D) (L R P Q X Z Y : Matrix (Fin D) (Fin D) ℂ)
     (hP : IsOrthogonalProjection P)
     (hXL : X * L = P) (hRZ : R * Z = Q)
@@ -105,7 +105,7 @@ theorem left_rank_hat_eq_reduced_projection
     ℓ[virtualSandwich L W R] =
       ℓ[virtualSandwich (Matrix.reducedProjection P Q) W
         (Matrix.reducedProjection P Q)] := by
-  rw [← virtual_sandwich_hat_eq_reduced_projection W L R P Q X Z Y
+  rw [← virtualSandwich_hat_eq_reducedProjection W L R P Q X Z Y
     hP hXL hRZ hPQY hWP hQW]
   exact (leftRank_virtualSandwich X (virtualSandwich L W R) (Z * Y)
     hX (hZ.mul hY)).symm
@@ -118,7 +118,7 @@ $$
 where $P$ and $Q$ are their support projections.
 
 Source: `Papers/1703.09188/paper_v2.tex:786-804`. -/
-theorem exists_units_for_hat_reduced_projection
+theorem exists_units_for_hat_reducedProjection
     {L R : Matrix (Fin D) (Fin D) ℂ} (hL : L.PosSemidef) (hR : R.PosSemidef) :
     ∃ X Z Y : Matrix (Fin D) (Fin D) ℂ,
       IsUnit X ∧ IsUnit Z ∧ IsUnit Y ∧

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -7,6 +7,8 @@ import TNLean.Analysis.MatrixReducedProjection
 import TNLean.Analysis.MatrixSqrt
 import TNLean.MPS.MPU.VirtualSandwich
 
+open scoped ComplexOrder
+
 /-!
 # Source-rank comparison for the reduced and hatted representatives
 
@@ -23,7 +25,6 @@ and constructing a positive fixed pair. See
 Source: `Papers/1703.09188/paper_v2.tex:786-804`.
 -/
 
-open scoped Matrix ComplexOrder
 
 namespace MPOTensor
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5789,10 +5789,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Source-rank comparison of the hatted and reduced tensors]
   \label{thm:mpu_reduced_to_hat_source_ranks}
-  \lean{MPOTensor.virtual_sandwich_hat_eq_reduced_projection,
-    MPOTensor.right_rank_hat_eq_reduced_projection,
-    MPOTensor.left_rank_hat_eq_reduced_projection,
-    MPOTensor.exists_units_for_hat_reduced_projection}
+  \lean{MPOTensor.virtualSandwich_hat_eq_reducedProjection,
+    MPOTensor.rightRank_hat_eq_reducedProjection,
+    MPOTensor.leftRank_hat_eq_reducedProjection,
+    MPOTensor.exists_units_for_hat_reducedProjection}
   \leanok
   \uses{def:mpo_family,def:support_proj,def:mpu_virtual_sandwich,
     def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5795,7 +5795,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     MPOTensor.exists_units_for_hat_reduced_projection}
   \leanok
   \uses{def:support_proj,def:mpu_virtual_sandwich,
-    def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank}
+    def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank,
+    def:mpu_ambient_support_inverse_extension}
   Let $W=(W^{ij})$ be an MPO tensor, let $P$ be an orthogonal projection,
   let $Q$ be a square matrix of the same size, and set $\widetilde P$ equal
   to their reduced projection.
@@ -5819,10 +5820,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \ell[\widehat W]&=\ell[\widetilde W].
       \label{eq:mpu_reduced_hat_left_rank}
   \end{align}
-  If $L,R\succeq0$ and $P=\operatorname{supp}(L)$,
-  $Q=\operatorname{supp}(R)$, such invertible matrices may be chosen as
-  $X=L^++(I-P)$, $Z=R^++(I-Q)$, together with an invertible right factor $Y$
-  of the reduced projection.
+  The ranks agree because invariance under invertible outer factors
+  (Theorem~\ref{thm:mpu_virtual_sandwich_source_ranks}) gives
+  \begin{align}
+    r[\widehat W]&=r[X\widehat W(ZY)]=r[\widetilde W],
+    \notag\\
+    \ell[\widehat W]&=\ell[X\widehat W(ZY)]=\ell[\widetilde W],
+    \notag
+  \end{align}
+  the first equality in each line being the invariance identity with
+  invertible $X$ and $ZY$ and the second being
+  (\ref{eq:mpu_reduced_hat_chain_tilde}). If $L,R\succeq0$ and
+  $P=\operatorname{supp}(L)$, $Q=\operatorname{supp}(R)$, such invertible
+  matrices may be chosen as $X=L^++(\Id-P)$, $Z=R^++(\Id-Q)$, together
+  with an invertible right factor $Y$ of the reduced projection.
   % Scope restriction: the fixed pair, the equations XL=P and RZ=Q, and the
   % letterwise absorptions are supplied hypotheses, not consequences of a bare
   % MPU assumption. See

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5814,25 +5814,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \widetilde P W\widetilde P&=\widetilde W.
       \label{eq:mpu_reduced_hat_chain_tilde}
   \end{align}
-  Consequently,
+  If in addition $X$, $Z$, and $Y$ are invertible, then
   \begin{align}
     r[\widehat W]&=r[\widetilde W],\label{eq:mpu_reduced_hat_right_rank}\\
     \ell[\widehat W]&=\ell[\widetilde W].
       \label{eq:mpu_reduced_hat_left_rank}
-  \end{align}
-  The ranks agree because invariance under invertible outer factors
-  (Theorem~\ref{thm:mpu_virtual_sandwich_source_ranks}) gives
-  \begin{align}
-    r[\widehat W]&=r[X\widehat W(ZY)]=r[\widetilde W],
-    \notag\\
-    \ell[\widehat W]&=\ell[X\widehat W(ZY)]=\ell[\widetilde W],
-    \notag
-  \end{align}
-  the first equality in each line being the invariance identity with
-  invertible $X$ and $ZY$, and the second rewriting
-  $X\widehat W(ZY)$ through
-  (\ref{eq:mpu_reduced_hat_chain_pwqy})--(\ref{eq:mpu_reduced_hat_chain_reduced})
-  and (\ref{eq:mpu_reduced_hat_chain_tilde}) to $\widetilde W$. If $L,R\succeq0$ and
+  \end{align} If $L,R\succeq0$ and
   $P=\operatorname{supp}(L)$, $Q=\operatorname{supp}(R)$, such invertible
   matrices may be chosen as $X=L^++(\Id-P)$, $Z=R^++(\Id-Q)$, together
   with an invertible right factor $Y$ of the reduced projection.
@@ -5866,7 +5853,19 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   from $\widehat W$ by left multiplication by $X$ and right multiplication
   by $ZY$. Invertibility of these factors and the source ranks of a
   virtual sandwich (Theorem~\ref{thm:mpu_virtual_sandwich_source_ranks})
-  give (\ref{eq:mpu_reduced_hat_right_rank}) and
+  give
+  \begin{align}
+    r[\widehat W]&=r[X\widehat W(ZY)]=r[\widetilde W],
+    \notag\\
+    \ell[\widehat W]&=\ell[X\widehat W(ZY)]=\ell[\widetilde W],
+    \notag
+  \end{align}
+  the first equality in each line being the invariance identity with
+  invertible $X$ and $ZY$, and the second rewriting $X\widehat W(ZY)$
+  through
+  (\ref{eq:mpu_reduced_hat_chain_pwqy})--(\ref{eq:mpu_reduced_hat_chain_reduced})
+  and (\ref{eq:mpu_reduced_hat_chain_tilde}) to $\widetilde W$, which gives
+  (\ref{eq:mpu_reduced_hat_right_rank}) and
   (\ref{eq:mpu_reduced_hat_left_rank}). For positive semidefinite $L$ and
   $R$, their ambient support-inverse extensions supply $X$ and $Z$; the
   invertible right-factor identity for $\widetilde P Q$ supplies $Y$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5802,8 +5802,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   to their reduced projection.
   Assume, letter by letter, $W^{ij}P=W^{ij}=QW^{ij}$. Set
   $\widehat W^{ij}=LW^{ij}R$ and
-  $\widetilde W^{ij}=\widetilde P W^{ij}\widetilde P$. If $X,Z,Y$ are
-  invertible and satisfy $XL=P$, $RZ=Q$, and $PQY=\widetilde P$, then
+  $\widetilde W^{ij}=\widetilde P W^{ij}\widetilde P$. If $X,Z,Y$ satisfy
+  $XL=P$, $RZ=Q$, and $PQY=\widetilde P$, then
   \begin{align}
     X\widehat W ZY&=PWQY
       \label{eq:mpu_reduced_hat_chain_pwqy}\\
@@ -5840,6 +5840,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % letterwise absorptions are supplied hypotheses, not consequences of a bare
   % MPU assumption. See
   % docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex.
+  % The identity chain is formalized without the invertibility hypotheses
+  % (the paper takes X, Y, Z invertible at line 792); invertibility of X, Z, Y
+  % is used only for the rank conclusion.
   % Source lines: paper_v2.tex 786--804.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5787,6 +5787,73 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
 \end{proof}
 
+\begin{theorem}[Source-rank comparison of the hatted and reduced tensors]
+  \label{thm:mpu_reduced_to_hat_source_ranks}
+  \lean{MPOTensor.virtual_sandwich_hat_eq_reduced_projection,
+    MPOTensor.right_rank_hat_eq_reduced_projection,
+    MPOTensor.left_rank_hat_eq_reduced_projection,
+    MPOTensor.exists_units_for_hat_reduced_projection}
+  \leanok
+  \uses{def:support_proj,def:mpu_virtual_sandwich,
+    def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank}
+  Let $W=(W^{ij})$ be an MPO tensor, let $P$ be an orthogonal projection,
+  let $Q$ be a square matrix of the same size, and set $\widetilde P$ equal
+  to their reduced projection.
+  Assume, letter by letter, $W^{ij}P=W^{ij}=QW^{ij}$. Set
+  $\widehat W^{ij}=LW^{ij}R$ and
+  $\widetilde W^{ij}=\widetilde P W^{ij}\widetilde P$. If $X,Z,Y$ are
+  invertible and satisfy $XL=P$, $RZ=Q$, and $PQY=\widetilde P$, then
+  \begin{align}
+    X\widehat W ZY&=PWQY
+      \label{eq:mpu_reduced_hat_chain_pwqy}\\
+    PWQY&=PQWPQY
+      \label{eq:mpu_reduced_hat_chain_pqwpqy}\\
+    PQWPQY&=\widetilde P W\widetilde P
+      \label{eq:mpu_reduced_hat_chain_reduced}\\
+    \widetilde P W\widetilde P&=\widetilde W.
+      \label{eq:mpu_reduced_hat_chain_tilde}
+  \end{align}
+  Consequently,
+  \begin{align}
+    r[\widehat W]&=r[\widetilde W],\label{eq:mpu_reduced_hat_right_rank}\\
+    \ell[\widehat W]&=\ell[\widetilde W].
+      \label{eq:mpu_reduced_hat_left_rank}
+  \end{align}
+  If $L,R\succeq0$ and $P=\operatorname{supp}(L)$,
+  $Q=\operatorname{supp}(R)$, such invertible matrices may be chosen as
+  $X=L^++(I-P)$, $Z=R^++(I-Q)$, together with an invertible right factor $Y$
+  of the reduced projection.
+  % Scope restriction: the fixed pair, the equations XL=P and RZ=Q, and the
+  % letterwise absorptions are supplied hypotheses, not consequences of a bare
+  % MPU assumption. See
+  % docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex.
+  % Source lines: paper_v2.tex 786--804.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:mpu_virtual_sandwich,thm:mpu_matrix_reduced_projection,
+    thm:mpu_virtual_sandwich_source_ranks,
+    thm:mpu_ambient_support_inverse_extension}
+  Expanding each virtual sandwich and using $XL=P$ and $RZ=Q$ gives
+  (\ref{eq:mpu_reduced_hat_chain_pwqy}). The absorptions
+  $QW^{ij}=W^{ij}=W^{ij}P$ insert $Q$ on the left and $P$ on the right, which
+  gives (\ref{eq:mpu_reduced_hat_chain_pqwpqy}). Since
+  $\widetilde P Q=PQ$ and $PQY=\widetilde P$,
+  \begin{align}
+    PQW^{ij}PQY
+      &=(\widetilde P Q)W^{ij}\widetilde P
+       =\widetilde P W^{ij}\widetilde P.
+  \end{align}
+  This proves (\ref{eq:mpu_reduced_hat_chain_reduced}) and
+  (\ref{eq:mpu_reduced_hat_chain_tilde}). Thus $\widetilde W$ is obtained
+  from $\widehat W$ by left multiplication by $X$ and right multiplication
+  by $ZY$. Invertibility of these factors and the source-cut formulas for a
+  virtual sandwich give (\ref{eq:mpu_reduced_hat_right_rank}) and
+  (\ref{eq:mpu_reduced_hat_left_rank}). For positive semidefinite $L$ and
+  $R$, their ambient support-inverse extensions supply $X$ and $Z$; the
+  invertible right-factor identity for $\widetilde P Q$ supplies $Y$.
+\end{proof}
+
 \begin{theorem}[Lower semicontinuity of finite matrix rank]
   \label{thm:mpu_rank_lower_semicontinuous}
   \lean{Matrix.lowerSemicontinuous_rank,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5794,7 +5794,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     MPOTensor.left_rank_hat_eq_reduced_projection,
     MPOTensor.exists_units_for_hat_reduced_projection}
   \leanok
-  \uses{def:support_proj,def:mpu_virtual_sandwich,
+  \uses{def:mpo_family,def:support_proj,def:mpu_virtual_sandwich,
     def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank,
     def:mpu_ambient_support_inverse_extension}
   Let $W=(W^{ij})$ be an MPO tensor, let $P$ be an orthogonal projection,
@@ -5829,8 +5829,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \notag
   \end{align}
   the first equality in each line being the invariance identity with
-  invertible $X$ and $ZY$ and the second being
-  (\ref{eq:mpu_reduced_hat_chain_tilde}). If $L,R\succeq0$ and
+  invertible $X$ and $ZY$, and the second rewriting
+  $X\widehat W(ZY)$ through
+  (\ref{eq:mpu_reduced_hat_chain_pwqy})--(\ref{eq:mpu_reduced_hat_chain_reduced})
+  and (\ref{eq:mpu_reduced_hat_chain_tilde}) to $\widetilde W$. If $L,R\succeq0$ and
   $P=\operatorname{supp}(L)$, $Q=\operatorname{supp}(R)$, such invertible
   matrices may be chosen as $X=L^++(\Id-P)$, $Z=R^++(\Id-Q)$, together
   with an invertible right factor $Y$ of the reduced projection.
@@ -5842,7 +5844,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{def:mpu_virtual_sandwich,thm:mpu_matrix_reduced_projection,
+  \uses{def:support_proj,def:mpu_virtual_sandwich,
+    thm:mpu_matrix_reduced_projection,
     thm:mpu_virtual_sandwich_source_ranks,
     thm:mpu_ambient_support_inverse_extension}
   Expanding each virtual sandwich and using $XL=P$ and $RZ=Q$ gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5861,8 +5861,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   This proves (\ref{eq:mpu_reduced_hat_chain_reduced}) and
   (\ref{eq:mpu_reduced_hat_chain_tilde}). Thus $\widetilde W$ is obtained
   from $\widehat W$ by left multiplication by $X$ and right multiplication
-  by $ZY$. Invertibility of these factors and the source-cut formulas for a
-  virtual sandwich give (\ref{eq:mpu_reduced_hat_right_rank}) and
+  by $ZY$. Invertibility of these factors and the source ranks of a
+  virtual sandwich (Theorem~\ref{thm:mpu_virtual_sandwich_source_ranks})
+  give (\ref{eq:mpu_reduced_hat_right_rank}) and
   (\ref{eq:mpu_reduced_hat_left_rank}). For positive semidefinite $L$ and
   $R$, their ambient support-inverse extensions supply $X$ and $Z$; the
   invertible right-factor identity for $\widetilde P Q$ supplies $Y$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5797,9 +5797,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpo_family,def:support_proj,def:mpu_virtual_sandwich,
     def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank,
     def:mpu_ambient_support_inverse_extension}
-  Let $W=(W^{ij})$ be an MPO tensor, let $P$ be an orthogonal projection,
-  let $Q$ be a square matrix of the same size, and set $\widetilde P$ equal
-  to their reduced projection.
+  Let $W=(W^{ij})$ be an MPO tensor, let $L$, $R$, $X$, $Z$, $Y$ be square
+  matrices of the same size, let $P$ be an orthogonal projection, let $Q$
+  be a square matrix of the same size, and set $\widetilde P$ equal to
+  their reduced projection.
   Assume, letter by letter, $W^{ij}P=W^{ij}=QW^{ij}$. Set
   $\widehat W^{ij}=LW^{ij}R$ and
   $\widetilde W^{ij}=\widetilde P W^{ij}\widetilde P$. If $X,Z,Y$ satisfy
@@ -5840,8 +5841,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_ambient_support_inverse_extension}
   Expanding each virtual sandwich and using $XL=P$ and $RZ=Q$ gives
   (\ref{eq:mpu_reduced_hat_chain_pwqy}). The absorptions
-  $QW^{ij}=W^{ij}=W^{ij}P$ insert $Q$ on the left and $P$ on the right, which
-  gives (\ref{eq:mpu_reduced_hat_chain_pqwpqy}). Since
+  $QW^{ij}=W^{ij}=W^{ij}P$ give, letter by letter,
+  \begin{align}
+    PW^{ij}QY
+    &=P(QW^{ij})QY=PQ(W^{ij}P)QY=PQW^{ij}PQY,
+    \notag
+  \end{align}
+  which is (\ref{eq:mpu_reduced_hat_chain_pqwpqy}). Since
   $\widetilde P Q=PQ$ and $PQY=\widetilde P$,
   \begin{align}
     PQW^{ij}PQY


### PR DESCRIPTION
## What changed

Implements #6456 (parent #6137, continuity-index parent #6022; direct successor of the merged #6455/#6513). New module `TNLean/MPS/MPU/ReducedToHatTransport.lean`:

- `virtual_sandwich_hat_eq_reduced_projection`: the exact nested identity $X(LWR)(ZY) = PWQY = PQWPQY = \tilde P W \tilde P$ from the supplied identities $XL=P$, $RZ=Q$, $PQY=\tilde P$ and the letterwise absorptions (arXiv:1703.09188 paper_v2.tex:786-804, lines 792-797).
- `right_rank_hat_eq_reduced_projection` / `left_rank_hat_eq_reduced_projection`: $r[\hat W] = r[\tilde W]$ and $\ell[\hat W] = \ell[\tilde W]$ when $X,Z,Y$ are units.
- `exists_units_for_hat_reduced_projection`: thin selector — $X,Z$ from `Matrix.PosSemidef` support-inverse extensions of $L,R$; $Y$ from the #6455 reduced-projection right factor ($\tilde P Q = PQ$ bridges the paper's $PQY=\tilde P$).
- Chapter 28 node `thm:mpu_reduced_to_hat_source_ranks` with the displayed four-step equation chain, exact `\uses`, and a maintainer comment citing the supplied-fixed-pair gap note (same restriction as #6455: the fixed pair is supplied, not derived).

## Validation

- `lake build TNLean.MPS.MPU.ReducedToHatTransport TNLean.MPS.MPU`: green; no sorry; axioms only propext/Classical.choice/Quot.sound.
- Double `lualatex print.tex`: zero undefined References; sync 7971/7971; `leanblueprint checkdecls`: 0 missing.

Closes #6456