### PR TITLE
refactor(analysis): matrix-level unit selector and follow-ups

### DIFF
--- a/TNLean/Analysis/MatrixReducedProjection.lean
+++ b/TNLean/Analysis/MatrixReducedProjection.lean
@@ -126,7 +126,10 @@ theorem exists_reducedProjection_rightFactor
     simpa [T, Y] using he
 
 /-- Positive-semidefinite matrices supply invertible support-inverse extensions and an
-invertible right factor for the reduced projection of their support projections. -/
+invertible right factor for the reduced projection of their support projections.
+
+Source: `Papers/1703.09188/paper_v2.tex:786-804`, the invertible outer factors
+X, Z, Y with X L = P, R Z = Q, and P Q Y = the reduced projection. -/
 theorem exists_units_supportInvExtension_reducedProjection_rightFactor
     {L R : Matrix (Fin D) (Fin D) ℂ} (hL : L.PosSemidef) (hR : R.PosSemidef) :
     ∃ X Z Y : Matrix (Fin D) (Fin D) ℂ,

--- a/TNLean/Analysis/MatrixReducedProjection.lean
+++ b/TNLean/Analysis/MatrixReducedProjection.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.OrthogonalProjection
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Analysis.TwoProjectionReducedProjection
 
@@ -15,6 +16,8 @@ standard finite-dimensional complex Euclidean space as a square matrix. For orth
 projection matrices, it transfers the projection identities, transversality, and invertible
 right factor from `LinearMap.IsSymmetricProjection.reducedProjection`.
 -/
+
+open scoped ComplexOrder
 
 namespace Matrix
 
@@ -121,5 +124,25 @@ theorem exists_reducedProjection_rightFactor
   · apply Matrix.toEuclideanLin.injective
     rw [toEuclideanLin_mul, toEuclideanLin_mul]
     simpa [T, Y] using he
+
+/-- Positive-semidefinite matrices supply invertible support-inverse extensions and an
+invertible right factor for the reduced projection of their support projections. -/
+theorem exists_units_supportInvExtension_reducedProjection_rightFactor
+    {L R : Matrix (Fin D) (Fin D) ℂ} (hL : L.PosSemidef) (hR : R.PosSemidef) :
+    ∃ X Z Y : Matrix (Fin D) (Fin D) ℂ,
+      IsUnit X ∧ IsUnit Z ∧ IsUnit Y ∧
+      X * L = hL.supportProj ∧ R * Z = hR.supportProj ∧
+      hL.supportProj * hR.supportProj * Y =
+        reducedProjection hL.supportProj hR.supportProj := by
+  have hP : IsOrthogonalProjection hL.supportProj :=
+    hL.isOrthogonalProjection_supportProj
+  obtain ⟨Y, hY, hTQY⟩ := exists_reducedProjection_rightFactor
+    (P := hL.supportProj) (Q := hR.supportProj) hP
+  have hPQY : hL.supportProj * hR.supportProj * Y =
+      reducedProjection hL.supportProj hR.supportProj := by
+    rw [← reducedProjection_mul_second hP, hTQY]
+  exact ⟨hL.supportInvExtension, hR.supportInvExtension, Y,
+    hL.isUnit_supportInvExtension, hR.isUnit_supportInvExtension, hY,
+    hL.supportInvExtension_mul_self, hR.self_mul_supportInvExtension, hPQY⟩
 
 end Matrix

--- a/TNLean/MPS/MPU/ReducedToHatTransport.lean
+++ b/TNLean/MPS/MPU/ReducedToHatTransport.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.MatrixReducedProjection
-import TNLean.Analysis.MatrixSqrt
 import TNLean.MPS.MPU.VirtualSandwich
 
 open scoped ComplexOrder
@@ -125,15 +124,6 @@ theorem exists_units_for_hat_reducedProjection
       X * L = hL.supportProj ∧ R * Z = hR.supportProj ∧
       hL.supportProj * hR.supportProj * Y =
         Matrix.reducedProjection hL.supportProj hR.supportProj := by
-  have hP : IsOrthogonalProjection hL.supportProj :=
-    hL.isOrthogonalProjection_supportProj
-  obtain ⟨Y, hY, hTQY⟩ := Matrix.exists_reducedProjection_rightFactor
-    (P := hL.supportProj) (Q := hR.supportProj) hP
-  have hPQY : hL.supportProj * hR.supportProj * Y =
-      Matrix.reducedProjection hL.supportProj hR.supportProj := by
-    rw [← Matrix.reducedProjection_mul_second hP, hTQY]
-  exact ⟨hL.supportInvExtension, hR.supportInvExtension, Y,
-    hL.isUnit_supportInvExtension, hR.isUnit_supportInvExtension, hY,
-    hL.supportInvExtension_mul_self, hR.self_mul_supportInvExtension, hPQY⟩
+  exact Matrix.exists_units_supportInvExtension_reducedProjection_rightFactor hL hR
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5792,7 +5792,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \lean{MPOTensor.virtualSandwich_hat_eq_reducedProjection,
     MPOTensor.rightRank_hat_eq_reducedProjection,
     MPOTensor.leftRank_hat_eq_reducedProjection,
-    MPOTensor.exists_units_for_hat_reducedProjection}
+    MPOTensor.exists_units_for_hat_reducedProjection,
+    Matrix.exists_units_supportInvExtension_reducedProjection_rightFactor}
   \leanok
   \uses{def:mpo_family,def:support_proj,def:mpu_virtual_sandwich,
     def:mpu_matrix_reduced_projection,def:mpu_right_rank,def:mpu_left_rank,

--- a/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
+++ b/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
@@ -66,17 +66,28 @@ the fixed pair, whereas the source claims the conclusions for every MPU
 tensor after blocking.
 
 \section{Affected declarations}
-The affected declarations are
-\leanid{MPOTensor.mpo\_virtualSandwich\_reducedProjection\_eq},
-\leanid{MPOTensor.transferMap\_virtualSandwich\_reducedProjection},
-\leanid{MPOTensor.trace\_compressed\_fixed\_pair\_reducedProjection}, and
-\leanid{MPOTensor.compressed\_fixed\_pair\_posDef\_reducedProjection}. Each
-takes part of the fixed-pair data as an explicit hypothesis: the letterwise
-absorptions $W^{ij}P=W^{ij}$ and $QW^{ij}=W^{ij}$ in the first, the rank-one
-transfer formula in the second, the two-sided support absorptions of $L$ and
-$R$ together with $\tr(LR)=1$ in the third, and the positive pair $L,R\succeq0$
-with its support projections in the last, which additionally takes an isometry
-$V$ onto the range of $T$.
+The declaration
+\leanid{MPOTensor.mpo\_virtualSandwich\_reducedProjection\_eq} assumes the
+letterwise absorptions $W^{ij}P=W^{ij}$ and $QW^{ij}=W^{ij}$.
+\leanid{MPOTensor.transferMap\_virtualSandwich\_reducedProjection} assumes the
+rank-one transfer formula. The declarations
+\leanid{MPOTensor.trace\_compressed\_fixed\_pair\_reducedProjection} and
+\leanid{MPOTensor.compressed\_fixed\_pair\_posDef\_reducedProjection} assume,
+respectively, the two-sided support absorptions of $L$ and $R$ together with
+$\tr(LR)=1$, and the positive pair $L,R\succeq0$ with its support projections;
+the latter also assumes an isometry $V$ onto the range of $T$.
+
+The comparison declaration
+\leanid{MPOTensor.virtualSandwich\_hat\_eq\_reducedProjection} assumes the
+factor equations $XL=P$, $RZ=Q$, and $PQY=T$ together with the letterwise
+absorptions. The rank equalities
+\leanid{MPOTensor.rightRank\_hat\_eq\_reducedProjection} and
+\leanid{MPOTensor.leftRank\_hat\_eq\_reducedProjection} use the same supplied
+data and additionally assume that $X$, $Z$, and $Y$ are invertible. Finally,
+\leanid{MPOTensor.exists\_units\_for\_hat\_reducedProjection} assumes positive
+semidefinite fixed matrices $L$ and $R$ and supplies the invertible ambient
+support-inverse extensions $X$ and $Z$, together with an invertible
+right factor $Y$ satisfying $PQY=T$.
 
 \section{Elimination plan}
 The restriction is removed by formalizing the missing supplier: the blocking


### PR DESCRIPTION
## What changed

- **#6548**: new Analysis-layer theorem `Matrix.exists_units_supportInvExtension_reducedProjection_rightFactor` in `MatrixReducedProjection.lean` (for PSD $L,R$: invertible $X,Z,Y$ with $XL=P$, $RZ=Q$, $PQY=\tilde P$ via support-inverse extensions and the reduced-projection right factor). `MPOTensor.exists_units_for_hat_reducedProjection` becomes a one-line specialization (blueprint tag stable); the now-redundant `MatrixSqrt` import is dropped.
- **#6547**: the supplied-fixed-pair gap note's Affected-declarations section now coherently covers the four reduced-to-hat declarations with their hypothesis slices (per policy §Revision, folded in, not appended).
- **#6545**: no change — the `InvariantProjection` import is NOT dead: the module directly uses `verticalTensor_ketLeftMul` / `verticalTensor_braRightMul` declared only there (verified by removal failing the build). Closing as invalid-by-evidence; the issue's premise is incorrect.

## Validation

- Targeted builds green (`MatrixReducedProjection`, `ReducedToHatTransport`, `BondTwoSingletonPhysicalGauge`); aggregators current (53/1438); blueprint sync 7944 refs, 0 missing; gap note compiles standalone.

Closes #6547, closes #6548. Closes #6545 as not-a-defect (import is semantically required; evidence in the issue thread).