### PR TITLE
refactor(mps): hoist shared example tensors out of the RFP layer

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -7,9 +7,11 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus
 import TNLean.MPS.FundamentalTheorem.SectorBNT.SingleSector
 
 /-!
-# Concrete BNT canonical forms
+# Concrete tensors and BNT canonical forms
 
-These examples present one-sector BNT canonical forms built from a normal block
+The scalar unit tensor and diagonal phase-flip tensor below are elementary examples
+used by several MPS constructions. The remaining examples present one-sector BNT
+canonical forms built from a normal block
 `C`. The single-copy construction is provided by `singleSectorDecomposition`;
 the remaining examples illustrate nontrivial copy weights.
 
@@ -28,6 +30,15 @@ open scoped Matrix BigOperators
 open Filter Topology
 
 namespace MPSTensor
+
+/-! ## Elementary tensors -/
+
+/-- The one-letter bond-dimension-one tensor whose sole matrix is `1`. -/
+def scalarUnitTensor : MPSTensor 1 1 := fun _ => 1
+
+/-- The one-letter bond-dimension-two tensor whose sole matrix is `diag(1, -1)`. -/
+def phaseFlipTensor : MPSTensor 1 2 := fun _ => !![1, 0; 0, -1]
+
 namespace SectorBNT.Examples
 
 variable {d D : ℕ}

--- a/TNLean/MPS/MPDO/SimpleVanishingCounterexample.lean
+++ b/TNLean/MPS/MPDO/SimpleVanishingCounterexample.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
 import TNLean.MPS.MPDO.SourceSimpleTensor
-import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 
 /-!
 # Normalized simplicity with a vanishing positive-length MPO

--- a/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
+++ b/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
 import TNLean.MPS.RFP.StructuralFull
 
 /-!
@@ -30,9 +31,6 @@ open scoped Matrix BigOperators
 
 namespace MPSTensor
 
-/-- The one-dimensional representative normal tensor in the counterexample. -/
-def scalarUnitTensor : MPSTensor 1 1 := fun _ => 1
-
 private theorem scalarUnitTensor_transferMap :
     transferMap scalarUnitTensor = LinearMap.id := by
   apply LinearMap.ext
@@ -54,9 +52,6 @@ theorem scalarUnitTensor_isNormalTensor :
 def signPhase : Fin 2 → ℂ
   | 0 => 1
   | 1 => -1
-
-/-- Two phase copies of `scalarUnitTensor`, assembled on the bond direct sum. -/
-def phaseFlipTensor : MPSTensor 1 2 := fun _ => !![1, 0; 0, -1]
 
 /-- Both copy coefficients have unit modulus. -/
 lemma norm_signPhase (q : Fin 2) : ‖signPhase q‖ = 1 := by


### PR DESCRIPTION
## What changed

- `MPSTensor.scalarUnitTensor` and `MPSTensor.phaseFlipTensor` move to `TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean` (already imported by the MPDO consumer; its cone has no RFP dependency); names unchanged.
- `PhaseMultiplicityCounterexample.lean` imports the shared home (RFP-specific interpretation stays there); `SimpleVanishingCounterexample.lean` drops the RFP import.
- Cone verified: `TNLean.MPS.MPDO` no longer reaches `TNLean.MPS.RFP.StructuralFull`; the counterexample module reaches neither RFP module.

## Validation

- Targeted builds green (Examples, both consumers, `TNLean.MPS.MPDO`); aggregator regeneration + --check pass (1438 modules); blueprint sync 7945 refs / 0 missing; no \\lean tags moved.
- Note: a local timing run during concurrent builds measured SimpleVanishingCounterexample at 62s (above the 50s local diagnostic threshold); CI's changed-module timing gate is the authoritative check.

Closes #6511