### PR TITLE
refactor(channel/perron-frobenius): split MPS gauge corollaries out of Existence

### DIFF
--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Core.TransferChannel
-import TNLean.MPS.Irreducible.PerronGauge
+import TNLean.MPS.Irreducible.FormII
 
 /-!
 # Shared Kraus setup for irreducible CP maps
@@ -110,9 +110,12 @@ theorem exists_posDef_adjoint_eigenvector
     ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
       σ.PosDef ∧ 0 < r ∧
       MPSTensor.transferMap (d := hSetup.n) (D := D)
-        (fun i => (hSetup.K i)ᴴ) σ = (r : ℂ) • σ :=
-  MPSTensor.exists_posDef_adjoint_eigenvector
-    (d := hSetup.n) (D := D) hSetup.K hSetup.irreducible
-    (hSetup.exists_nonzero_kraus hE)
+        (fun i => (hSetup.K i)ᴴ) σ = (r : ℂ) • σ := by
+  obtain ⟨σ, r, hpd, hr, heig⟩ :=
+    Kraus.exists_posDef_adjoint_eigenvector (K := hSetup.K)
+      (Kraus.isIrreducibleMap_mapLM_of_transferMap _
+        (MPSTensor.isIrreducibleCP_transferMap_of_isIrreducibleTensor _ hSetup.irreducible))
+      (hSetup.exists_nonzero_kraus hE)
+  exact ⟨σ, r, hpd, hr, by rwa [Kraus.mapLM_eq_transferMap] at heig⟩
 
 end IrreducibleCPKrausSetup

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Core.TransferChannel
+import TNLean.MPS.Irreducible.PerronGauge
 
 /-!
 # Shared Kraus setup for irreducible CP maps

--- a/TNLean/Channel/Irreducible/PerronFrobenius.lean
+++ b/TNLean/Channel/Irreducible/PerronFrobenius.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Irreducible.Growth
 import TNLean.Channel.Irreducible.KrausSetup
+import TNLean.Channel.Irreducible.Scaling
 import TNLean.QPF.Uniqueness
 
 /-!

--- a/TNLean/Channel/KrausMap.lean
+++ b/TNLean/Channel/KrausMap.lean
@@ -19,6 +19,8 @@ $E(X) = \sum_i K_i X K_i^\dagger$ with positivity, complete positivity, and trac
 * `Kraus.isTracePreservingMap_mapLM_of_isTP`: the Kraus normalization implies trace
   preservation.
 * `Kraus.isChannel_mapLM`: a trace-preserving finite Kraus family defines a channel.
+* `Kraus.mapLM_ne_zero_of_exists_ne_zero`: a finite Kraus map with a nonzero
+  Kraus operator is nonzero.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
@@ -54,5 +56,16 @@ theorem isTracePreservingMap_mapLM_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
 /-- A trace-preserving finite Kraus family defines a quantum channel. -/
 theorem isChannel_mapLM (K : Fin d → Mat) (h_tp : IsTP K) : IsChannel (mapLM K) :=
   ⟨isCPMap_mapLM K, isTracePreservingMap_mapLM_of_isTP K h_tp⟩
+
+/-- A finite Kraus map with a nonzero Kraus operator is nonzero. -/
+theorem mapLM_ne_zero_of_exists_ne_zero
+    (K : Fin d → Mat) (hK : ∃ i, K i ≠ 0) :
+    mapLM K ≠ 0 := by
+  intro h
+  obtain ⟨i, hi⟩ := hK
+  have h1 : mapLM K (1 : Mat) = 0 := by
+    rw [h]; simp
+  simp only [mapLM_apply, map_apply, Matrix.mul_one] at h1
+  exact hi (Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero K h1 i)
 
 end Kraus

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -36,8 +36,6 @@ The required density-matrix Brouwer theorem is proved in
   (with nonvanishing hypothesis, eigenvalue `r > 0`)
 * `exists_posSemidef_eigenvector_general`: PSD eigenvector existence for *any*
   positive map (no nonvanishing hypothesis, eigenvalue `r ≥ 0`)
-* `Kraus.mapLM_ne_zero_of_exists_ne_zero`:
-    a finite Kraus map with a nonzero Kraus operator is nonzero
 * `Kraus.exists_posDef_adjoint_eigenvector`:
     PosDef eigenvector for the adjoint Kraus map of an irreducible family
 
@@ -166,17 +164,6 @@ theorem exists_posSemidef_eigenvector_general
 /-! ## Application to Kraus families -/
 
 namespace Kraus
-
-/-- A finite Kraus map with a nonzero Kraus operator is nonzero. -/
-theorem mapLM_ne_zero_of_exists_ne_zero
-    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (hK : ∃ i, K i ≠ 0) :
-    mapLM K ≠ 0 := by
-  intro h
-  obtain ⟨i, hi⟩ := hK
-  have h1 : mapLM K (1 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
-    rw [h]; simp
-  simp only [mapLM_apply, map_apply, Matrix.mul_one] at h1
-  exact hi (Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero K h1 i)
 
 /-- **PosDef eigenvector of the adjoint Kraus map**
 (combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -5,21 +5,21 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.PerronFrobenius.Normalization
 import TNLean.Channel.Irreducible.Scaling
+import TNLean.Channel.Irreducible.AdjointFamily
+import TNLean.Channel.Irreducible.FixedPoint
+import TNLean.Channel.KrausMap
 import TNLean.Algebra.MatrixAux
 import TNLean.Axioms.BrouwerFixedPoint
-import TNLean.MPS.Irreducible.Adjoint
-import TNLean.MPS.Core.TPGauge
-import TNLean.MPS.Core.CPPrimitive
-import TNLean.QPF.PosDef
 
 /-!
 # Perron–Frobenius eigenvector existence for CP maps
 
 This module provides the **existence** of a positive semidefinite eigenvector for
-a nonzero positive map on `M_D(ℂ)`, and derives from it:
+a nonzero positive map on `M_D(ℂ)`, and derives from it a PosDef eigenvector of
+the adjoint Kraus map of an irreducible Kraus family.
 
-* a PosDef fixed point for the adjoint transfer map of a rescaled irreducible tensor,
-* the existence of a TP-normalized tensor from an irreducible one (via `tpGauge`).
+The transfer-map specializations for MPS tensors (TP and unital gauge data of an
+irreducible tensor) live in `TNLean.MPS.Irreducible.PerronGauge`.
 
 ## Brouwer fixed-point theorem on density matrices
 
@@ -36,14 +36,10 @@ The required density-matrix Brouwer theorem is proved in
   (with nonvanishing hypothesis, eigenvalue `r > 0`)
 * `exists_posSemidef_eigenvector_general`: PSD eigenvector existence for *any*
   positive map (no nonvanishing hypothesis, eigenvalue `r ≥ 0`)
-* `MPSTensor.adjointTransferMap_ne_zero_of_nonzero`:
-    the adjoint transfer map is nonzero when some `A i ≠ 0`
-* `MPSTensor.exists_posDef_adjoint_eigenvector`:
-    PosDef eigenvector for the adjoint transfer map
-* `MPSTensor.exists_tp_data_of_irreducible`:
-    TP-normalized tensor from an irreducible one
-* `MPSTensor.exists_unital_data_of_irreducible`:
-    unital PGVWC07-orientation tensor from an irreducible one
+* `Kraus.mapLM_ne_zero_of_exists_ne_zero`:
+    a finite Kraus map with a nonzero Kraus operator is nonzero
+* `Kraus.exists_posDef_adjoint_eigenvector`:
+    PosDef eigenvector for the adjoint Kraus map of an irreducible family
 
 ## References
 
@@ -167,80 +163,67 @@ theorem exists_posSemidef_eigenvector_general
     obtain ⟨ρ₀, hρ₀_psd, hρ₀_ne, hEρ₀⟩ := hNZ
     exact ⟨ρ₀, 0, hρ₀_psd, hρ₀_ne, le_refl 0, by simp [hEρ₀]⟩
 
-/-! ## Application to MPS tensors -/
+/-! ## Application to Kraus families -/
 
-namespace MPSTensor
+namespace Kraus
 
-/-- The adjoint transfer map is nonzero when some Kraus operator is nonzero. -/
-theorem adjointTransferMap_ne_zero_of_nonzero
-    (A : MPSTensor d D) (hA : ∃ i, A i ≠ 0) :
-    transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ≠ 0 := by
+/-- A finite Kraus map with a nonzero Kraus operator is nonzero. -/
+theorem mapLM_ne_zero_of_exists_ne_zero
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (hK : ∃ i, K i ≠ 0) :
+    mapLM K ≠ 0 := by
   intro h
-  obtain ⟨i, hi⟩ := hA
-  -- If E = 0 then E(1) = 0.
-  have h1 : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) 1 = 0 := by
+  obtain ⟨i, hi⟩ := hK
+  have h1 : mapLM K (1 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
     rw [h]; simp
-  simp only [transferMap_apply, Matrix.mul_one] at h1
-  -- ∑ (A j)ᴴ * ((A j)ᴴ)ᴴ = 0, so each (A j)ᴴ = 0, so each A j = 0.
-  have h3 : ∀ j : Fin d, (A j)ᴴ = 0 :=
-    Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero (fun j => (A j)ᴴ) h1
-  have : (A i)ᴴ = 0 := h3 i
-  exact hi (Matrix.conjTranspose_eq_zero.mp this)
+  simp only [mapLM_apply, map_apply, Matrix.mul_one] at h1
+  exact hi (Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero K h1 i)
 
-/-- **PosDef fixed point of the adjoint transfer map (after rescaling)**
-(combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive definiteness).
+/-- **PosDef eigenvector of the adjoint Kraus map**
+(combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive
+definiteness).
 
-For an irreducible MPS tensor `A` with `D > 0` and some `A i ≠ 0`, there exist:
-* a positive definite matrix `σ`,
-* a positive real `r`,
-* such that `σ` is a PosDef fixed point of the adjoint transfer map of the
-  rescaled tensor `(1/√r) • A`.
+For an irreducible finite Kraus family `K` with `D > 0` and some `K i ≠ 0`, there
+exist a positive definite matrix `σ` and a positive real `r` with
+`∑ᵢ (K i)ᴴ σ K i = r • σ`.
 
-In other words: `∑ ((1/√r) • A i)ᴴ * σ * ((1/√r) • A i) = σ`.
-
-This is equivalent to saying `∑ (A i)ᴴ * σ * A i = r • σ` (eigenvector equation).
-
-This theorem is obtained by applying `exists_posSemidef_eigenvector` (Wolf Theorem 6.5)
-to the adjoint transfer map, noting that irreducibility transfers to that adjoint
-map because an invariant projection there would yield the complementary invariant
-projection for the original transfer map after taking adjoints, and then upgrading
-the resulting PSD fixed point to a PosDef one using irreducibility
-(Wolf Theorem 6.3 item 2). -/
+This theorem applies `exists_posSemidef_eigenvector` (Wolf Theorem 6.5) to the
+conjugate-transposed Kraus map, noting that irreducibility passes to that family,
+and then upgrades the resulting PSD eigenvector to a PosDef one using
+irreducibility (Wolf Theorem 6.3 item 2). -/
 theorem exists_posDef_adjoint_eigenvector
     [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
-    (hA : ∃ i, A i ≠ 0) :
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (hIrr : IsIrreducibleMap (mapLM K))
+    (hK : ∃ i, K i ≠ 0) :
     ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
       σ.PosDef ∧ 0 < r ∧
-      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = (r : ℂ) • σ := by
-  -- Step 1: The adjoint transfer map E†(X) = ∑ (A i)ᴴ X A i is CP.
-  have hcp : IsCPMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) :=
-    transferMap_isCPMap (fun i => (A i)ᴴ)
-  -- Step 2: E† is nonzero.
-  have hE_ne : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ≠ 0 :=
-    adjointTransferMap_ne_zero_of_nonzero A hA
-  -- Step 3: The adjoint transfer map is irreducible: if it had a nontrivial
-  -- invariant projection `P`, then taking adjoints would show that `1 - P`
-  -- is invariant for the original transfer map, contradicting `hIrr`. Hence
-  -- it does not annihilate nonzero PSD matrices.
-  have hIrrAdj : IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) :=
-    isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor A hIrr
+      mapLM (fun i => (K i)ᴴ) σ = (r : ℂ) • σ := by
+  -- Step 1: The conjugate-transposed Kraus map is CP.
+  have hcp : IsCPMap (mapLM fun i => (K i)ᴴ) := isCPMap_mapLM _
+  -- Step 2: It is nonzero.
+  have hK_adj : ∃ i, (K i)ᴴ ≠ 0 := by
+    obtain ⟨i, hi⟩ := hK
+    exact ⟨i, fun h => hi (Matrix.conjTranspose_eq_zero.mp h)⟩
+  have hE_ne : mapLM (fun i => (K i)ᴴ) ≠ 0 :=
+    mapLM_ne_zero_of_exists_ne_zero _ hK_adj
+  -- Step 3: Irreducibility passes to the conjugate-transposed family, so the map
+  -- does not annihilate nonzero PSD matrices.
+  have hIrrAdj : IsIrreducibleMap (mapLM fun i => (K i)ᴴ) :=
+    isIrreducibleMap_mapLM_conjTranspose K hIrr
   have hNZ :
       ∀ {ρ : Matrix (Fin D) (Fin D) ℂ}, ρ.PosSemidef → ρ ≠ 0 →
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ρ ≠ 0 :=
+        mapLM (fun i => (K i)ᴴ) ρ ≠ 0 :=
     IsIrreducibleMap.map_posSemidef_ne_zero
-      (E := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) hcp hIrrAdj hE_ne
+      (E := mapLM fun i => (K i)ᴴ) hcp hIrrAdj hE_ne
   -- Step 4: Get a PSD eigenvector by the core theorem.
   obtain ⟨σ, r, hσ_psd, hσ_ne, hr_pos, hσ_eig⟩ :=
     exists_posSemidef_eigenvector
-      (E := transferMap (d := d) (D := D) (fun i => (A i)ᴴ))
+      (E := mapLM fun i => (K i)ᴴ)
       hcp.isPositiveMap (hNZ := hNZ)
   -- Step 5: Upgrade PSD → PosDef.
-  -- Define the rescaled tensor T i = (1/√r) • (A i)ᴴ so that
-  -- transferMap T σ = σ (fixed point, not just eigenvector).
+  -- Define the rescaled family T i = (1/√r) • (K i)ᴴ so that mapLM T σ = σ.
   set c := (Real.sqrt r)⁻¹ with hc_def
-  set T : MPSTensor d D := fun i => (c : ℂ) • (A i)ᴴ
+  set T : Fin d → Matrix (Fin D) (Fin D) ℂ := fun i => (c : ℂ) • (K i)ᴴ
   -- Auxiliary lemma: star of a real-coerced scalar is itself.
   have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
     rw [RCLike.star_def, Complex.conj_ofReal]
@@ -249,155 +232,30 @@ theorem exists_posDef_adjoint_eigenvector
     rw [hc_def, ← sq, inv_pow, Real.sq_sqrt hr_pos.le]
   have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
     rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
-  -- Verify transferMap T σ = σ.
-  have hT_fix : transferMap (d := d) (D := D) T σ = σ := by
-    simp only [T, transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
+  -- Verify mapLM T σ = σ.
+  have hT_fix : mapLM T σ = σ := by
+    simp only [T, mapLM_apply, map_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
       Matrix.mul_smul, smul_smul]
     simp_rw [hstar_c, hc_sq]
     rw [← Finset.smul_sum]
-    -- The sum is the adjoint transfer map applied to σ.
-    have h_sum : ∑ i : Fin d, (A i)ᴴ * σ * ((A i)ᴴ)ᴴ =
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ := by
-      simp [transferMap_apply]
+    have h_sum : ∑ i : Fin d, (K i)ᴴ * σ * ((K i)ᴴ)ᴴ =
+        mapLM (fun i => (K i)ᴴ) σ := by
+      simp [mapLM_apply, map_apply]
     rw [h_sum, hσ_eig, smul_smul, inv_mul_cancel₀, one_smul]
     exact_mod_cast hr_pos.ne'
-  -- Verify IsIrreducibleMap (transferMap T).
-  -- Show transferMap T = (1/r) • transferMap (fun i => (A i)ᴴ).
-  have hT_eq : transferMap (d := d) (D := D) T =
-      (r : ℂ)⁻¹ • transferMap (d := d) (D := D) (fun i => (A i)ᴴ) := by
+  -- Verify IsIrreducibleMap (mapLM T) via mapLM T = (1/r) • mapLM (fun i => (K i)ᴴ).
+  have hT_eq : mapLM T = (r : ℂ)⁻¹ • mapLM fun i => (K i)ᴴ := by
     ext X
-    simp only [T, transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
+    simp only [T, mapLM_apply, map_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
       Matrix.mul_smul, smul_smul, LinearMap.smul_apply]
     simp_rw [hstar_c, hc_sq, ← Finset.smul_sum]
-  have hIrr_T : IsIrreducibleMap (transferMap (d := d) (D := D) T) := by
+  have hIrr_T : IsIrreducibleMap (mapLM T) := by
     rw [hT_eq]
     exact isIrreducibleMap_smul (inv_ne_zero (by exact_mod_cast hr_pos.ne')) hIrrAdj
   -- Apply the PSD → PosDef upgrade.
   have hσ_pd : σ.PosDef :=
-    posSemidef_fixedPoint_isPosDef_of_irreducible T hIrr_T σ hσ_psd hσ_ne hT_fix
+    posDef_of_posSemidef_fixedPoint_irreducible_cp _ (isCPMap_mapLM T)
+      hIrr_T σ hσ_psd hσ_ne hT_fix
   exact ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩
 
-/-- **TP / left-canonical gauge data for an irreducible MPS tensor.**
-
-For an irreducible MPS tensor `A` with `D > 0` and some `A i ≠ 0`, there exist:
-* a positive real `r` (the spectral radius of the adjoint transfer map),
-* a positive definite matrix `σ`,
-* such that the rescaled-and-gauged tensor `B i = σ^{1/2} ((1/√r) • A i) σ^{-1/2}`
-  satisfies the TP / left-canonical condition `∑ (B i)ᴴ * B i = 1`.
-
-The tensor `B` is gauge-equivalent to the rescaled tensor `(1/√r) • A`, hence has
-the same MPV as `A` up to a system-size-dependent factor `(1/√r)^N`.
-
-This theorem combines `exists_posDef_adjoint_eigenvector` with the explicit `tpGauge`
-construction. -/
-theorem exists_tp_data_of_irreducible
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
-    (hA : ∃ i, A i ≠ 0) :
-    ∃ (B : MPSTensor d D) (r : ℝ) (σ : Matrix (Fin D) (Fin D) ℂ),
-      σ.PosDef ∧ 0 < r ∧
-      -- B is the tpGauge of the rescaled tensor
-      (∀ i : Fin d,
-        B i = CFC.sqrt σ *
-          ((↑((Real.sqrt r)⁻¹) : ℂ) • A i) * (CFC.sqrt σ)⁻¹) ∧
-      -- B is TP
-      (∑ i : Fin d, (B i)ᴴ * B i = 1) ∧
-      -- B is gauge-equivalent to the rescaled tensor
-      GaugeEquiv (d := d) (D := D)
-        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
-  -- Get the PosDef adjoint eigenvector.
-  obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
-    exists_posDef_adjoint_eigenvector A hIrr hA
-  -- Define the rescaled tensor.
-  set c := (Real.sqrt r)⁻¹ with hc_def
-  set A' : MPSTensor d D := fun i => (↑c : ℂ) • A i with hA'_def
-  -- Auxiliary lemma: star of a real-coerced scalar is itself.
-  have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
-    rw [RCLike.star_def, Complex.conj_ofReal]
-  -- Key scalar identity.
-  have hcc : (c : ℝ) * c = r⁻¹ := by
-    rw [hc_def, ← sq, inv_pow, Real.sq_sqrt hr_pos.le]
-  have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
-    rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
-  -- σ is a PosDef fixed point of transferMap(fun i => (A' i)ᴴ).
-  have hA'_fix : transferMap (d := d) (D := D) (fun i => (A' i)ᴴ) σ = σ := by
-    simp only [hA'_def, transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
-      Matrix.mul_smul, smul_smul, star_star]
-    simp_rw [hstar_c, hc_sq]
-    rw [← Finset.smul_sum]
-    have h_sum : ∑ i : Fin d, (A i)ᴴ * σ * ((A i)ᴴ)ᴴ =
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ := by
-      simp [transferMap_apply]
-    rw [h_sum, hσ_eig, smul_smul, inv_mul_cancel₀, one_smul]
-    exact_mod_cast hr_pos.ne'
-  -- Apply tpGauge.
-  set B := tpGauge (d := d) (D := D) A' σ with hB_def
-  have hB_tp : ∑ i : Fin d, (B i)ᴴ * B i = 1 :=
-    tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A' σ hσ_pd hA'_fix
-  have hB_gauge : GaugeEquiv (d := d) (D := D) A' B :=
-    gaugeEquiv_tpGauge A' σ hσ_pd
-  refine ⟨B, r, σ, hσ_pd, hr_pos, ?_, hB_tp, ?_⟩
-  -- Explicit form of B.
-  · intro i
-    rfl
-  -- GaugeEquiv: A' matches the stated rescaled tensor.
-  · convert hB_gauge using 1
-
-/-- **Unital gauge data for an irreducible MPS tensor.**
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
-lines 765--770.  For an irreducible nonzero tensor, the Perron--Frobenius
-eigenvector of the transfer map gives a positive scalar `r` and a positive
-definite matrix `ρ`; the spectral gauge
-`B i = r^{-1/2} ρ^{-1/2} A i ρ^{1/2}` is unital and gauge-equivalent to the
-rescaled tensor `r^{-1/2} A`. -/
-theorem exists_unital_data_of_irreducible
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
-    (hA : ∃ i, A i ≠ 0) :
-    ∃ (B : MPSTensor d D) (r : ℝ) (ρ : Matrix (Fin D) (Fin D) ℂ),
-      ρ.PosDef ∧ 0 < r ∧
-      (∀ i : Fin d,
-        B i =
-          (↑((Real.sqrt r)⁻¹) : ℂ) •
-            ((CFC.sqrt ρ)⁻¹ * A i * CFC.sqrt ρ)) ∧
-      (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
-      GaugeEquiv (d := d) (D := D)
-        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
-  classical
-  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
-  have hIrrAdjMap :
-      IsIrreducibleMap (transferMap (d := d) (D := D) Aadj) := by
-    simpa [Aadj] using
-      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
-        (d := d) (D := D) A hIrr
-  have hIrrAdj : IsIrreducibleTensor (d := d) (D := D) Aadj :=
-    isIrreducibleTensor_of_isIrreducibleMap Aadj hIrrAdjMap
-  have hAadj : ∃ i, Aadj i ≠ 0 := by
-    rcases hA with ⟨i, hi⟩
-    refine ⟨i, ?_⟩
-    intro h
-    exact hi (Matrix.conjTranspose_eq_zero.mp (by simpa [Aadj] using h))
-  obtain ⟨ρ, r, hρ, hr, hρ_eig_adj⟩ :=
-    exists_posDef_adjoint_eigenvector (d := d) (D := D) Aadj hIrrAdj hAadj
-  have hρ_eig : transferMap (d := d) (D := D) A ρ = (r : ℂ) • ρ := by
-    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using hρ_eig_adj
-  let B : MPSTensor d D := spectralUnitalGauge (d := d) (D := D) A r ρ
-  have hB_unital : ∑ i : Fin d, B i * (B i)ᴴ = 1 := by
-    simpa [B] using
-      spectralUnitalGauge_isUnital_of_transferMap_eigenvector
-        (d := d) (D := D) A ρ r hρ hr hρ_eig
-  have hGauge : GaugeEquiv (d := d) (D := D)
-      (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
-    convert
-      gaugeEquiv_unitalGauge (d := d) (D := D)
-        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) ρ hρ using 1
-    ext i
-    simp [B, spectralUnitalGauge, unitalGauge]
-  refine ⟨B, r, ρ, hρ, hr, ?_, hB_unital, hGauge⟩
-  intro i
-  rfl
-
-end MPSTensor
+end Kraus

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.PerronFrobenius.Normalization
-import TNLean.Channel.Irreducible.Scaling
 import TNLean.Channel.Irreducible.AdjointFamily
-import TNLean.Channel.Irreducible.FixedPoint
+import TNLean.Channel.Irreducible.Growth.OneStep
 import TNLean.Channel.KrausMap
 import TNLean.Algebra.MatrixAux
 import TNLean.Axioms.BrouwerFixedPoint
@@ -18,8 +17,9 @@ This module provides the **existence** of a positive semidefinite eigenvector fo
 a nonzero positive map on `M_D(ℂ)`, and derives from it a PosDef eigenvector of
 the adjoint Kraus map of an irreducible Kraus family.
 
-The transfer-map specializations for MPS tensors (TP and unital gauge data of an
-irreducible tensor) live in `TNLean.MPS.Irreducible.PerronGauge`.
+The transfer-map specializations for MPS tensors (the trace-preserving and
+unital gauge normalizations of an irreducible tensor) live in
+`TNLean.MPS.Irreducible.PerronGauge`.
 
 ## Brouwer fixed-point theorem on density matrices
 
@@ -220,42 +220,10 @@ theorem exists_posDef_adjoint_eigenvector
     exists_posSemidef_eigenvector
       (E := mapLM fun i => (K i)ᴴ)
       hcp.isPositiveMap (hNZ := hNZ)
-  -- Step 5: Upgrade PSD → PosDef.
-  -- Define the rescaled family T i = (1/√r) • (K i)ᴴ so that mapLM T σ = σ.
-  set c := (Real.sqrt r)⁻¹ with hc_def
-  set T : Fin d → Matrix (Fin D) (Fin D) ℂ := fun i => (c : ℂ) • (K i)ᴴ
-  -- Auxiliary lemma: star of a real-coerced scalar is itself.
-  have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
-    rw [RCLike.star_def, Complex.conj_ofReal]
-  -- Key scalar identity: c * c = r⁻¹ in ℂ.
-  have hcc : (c : ℝ) * c = r⁻¹ := by
-    rw [hc_def, ← sq, inv_pow, Real.sq_sqrt hr_pos.le]
-  have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
-    rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
-  -- Verify mapLM T σ = σ.
-  have hT_fix : mapLM T σ = σ := by
-    simp only [T, mapLM_apply, map_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
-      Matrix.mul_smul, smul_smul]
-    simp_rw [hstar_c, hc_sq]
-    rw [← Finset.smul_sum]
-    have h_sum : ∑ i : Fin d, (K i)ᴴ * σ * ((K i)ᴴ)ᴴ =
-        mapLM (fun i => (K i)ᴴ) σ := by
-      simp [mapLM_apply, map_apply]
-    rw [h_sum, hσ_eig, smul_smul, inv_mul_cancel₀, one_smul]
-    exact_mod_cast hr_pos.ne'
-  -- Verify IsIrreducibleMap (mapLM T) via mapLM T = (1/r) • mapLM (fun i => (K i)ᴴ).
-  have hT_eq : mapLM T = (r : ℂ)⁻¹ • mapLM fun i => (K i)ᴴ := by
-    ext X
-    simp only [T, mapLM_apply, map_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
-      Matrix.mul_smul, smul_smul, LinearMap.smul_apply]
-    simp_rw [hstar_c, hc_sq, ← Finset.smul_sum]
-  have hIrr_T : IsIrreducibleMap (mapLM T) := by
-    rw [hT_eq]
-    exact isIrreducibleMap_smul (inv_ne_zero (by exact_mod_cast hr_pos.ne')) hIrrAdj
-  -- Apply the PSD → PosDef upgrade.
+  -- Step 5: Upgrade PSD → PosDef (Wolf Theorem 6.3(2)).
   have hσ_pd : σ.PosDef :=
-    posDef_of_posSemidef_fixedPoint_irreducible_cp _ (isCPMap_mapLM T)
-      hIrr_T σ hσ_psd hσ_ne hT_fix
+    posDef_of_ker_subset_irreducible_cp _ hcp hIrrAdj σ hσ_psd hσ_ne
+      (fun v hv => by rw [hσ_eig, Matrix.smul_mulVec, hv, smul_zero])
   exact ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩
 
 end Kraus

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Reduction
-import TNLean.Channel.PerronFrobenius.Existence
+import TNLean.MPS.Irreducible.PerronGauge
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -7,6 +7,7 @@ import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.Core.TransferChannel
+import TNLean.MPS.Irreducible.PerronGauge
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
 import TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain

--- a/TNLean/MPS/Irreducible.lean
+++ b/TNLean/MPS/Irreducible.lean
@@ -12,4 +12,5 @@ import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.FixedPointProjection
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.PeriodicBlocking
+import TNLean.MPS.Irreducible.PerronGauge
 import TNLean.MPS.Irreducible.ScalarFixedPoint

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PerronFrobenius.Existence
+import TNLean.MPS.Core.TransferChannel
+import TNLean.MPS.Core.TPGauge
+import TNLean.MPS.Irreducible.Adjoint
+
+/-!
+# Perron–Frobenius gauge data for irreducible MPS tensors
+
+The Perron–Frobenius eigenvector of the adjoint transfer map of an irreducible
+MPS tensor gives the standard trace-preserving and unital gauge normalizations.
+The channel-level eigenvector existence lives in
+`TNLean.Channel.PerronFrobenius.Existence`; this file states the transfer-map
+specializations and combines them with the explicit gauge constructions from
+`TNLean.MPS.Core.TPGauge`.
+
+## Main results
+
+* `MPSTensor.exists_posDef_adjoint_eigenvector`:
+    PosDef eigenvector for the adjoint transfer map
+* `MPSTensor.exists_tp_data_of_irreducible`:
+    TP-normalized tensor from an irreducible one
+* `MPSTensor.exists_unital_data_of_irreducible`:
+    unital PGVWC07-orientation tensor from an irreducible one
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2
+  Theorems 6.3/6.5][Wolf2012QChannels]
+* [Cirac et al., arXiv:1606.00608, Appendix A][Cirac2017Annals]
+* [Pérez-García et al., quant-ph/0608197, Theorem `Th:TIcanonical`][PerezGarcia2007]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset
+
+variable {d D : ℕ}
+
+namespace MPSTensor
+
+/-- **PosDef fixed point of the adjoint transfer map (after rescaling)**
+(combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive
+definiteness).
+
+For an irreducible MPS tensor `A` with `D > 0` and some `A i ≠ 0`, there exist a
+positive definite matrix `σ` and a positive real `r` with
+`∑ (A i)ᴴ * σ * A i = r • σ` (the adjoint eigenvector equation).
+
+This is the transfer-map form of `Kraus.exists_posDef_adjoint_eigenvector`. -/
+theorem exists_posDef_adjoint_eigenvector
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
+      σ.PosDef ∧ 0 < r ∧
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = (r : ℂ) • σ := by
+  have hIrrMap : IsIrreducibleMap (Kraus.mapLM A) := by
+    rw [Kraus.mapLM_eq_transferMap]
+    exact isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrr
+  obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
+    Kraus.exists_posDef_adjoint_eigenvector (K := A) hIrrMap hA
+  refine ⟨σ, r, hσ_pd, hr_pos, ?_⟩
+  rwa [Kraus.mapLM_eq_transferMap] at hσ_eig
+
+/-- **TP / left-canonical gauge data for an irreducible MPS tensor.**
+
+For an irreducible MPS tensor `A` with `D > 0` and some `A i ≠ 0`, there exist:
+* a positive real `r` (the spectral radius of the adjoint transfer map),
+* a positive definite matrix `σ`,
+* such that the rescaled-and-gauged tensor `B i = σ^{1/2} ((1/√r) • A i) σ^{-1/2}`
+  satisfies the TP / left-canonical condition `∑ (B i)ᴴ * B i = 1`.
+
+The tensor `B` is gauge-equivalent to the rescaled tensor `(1/√r) • A`, hence has
+the same MPV as `A` up to a system-size-dependent factor `(1/√r)^N`.
+
+This theorem combines `exists_posDef_adjoint_eigenvector` with the explicit `tpGauge`
+construction. -/
+theorem exists_tp_data_of_irreducible
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (B : MPSTensor d D) (r : ℝ) (σ : Matrix (Fin D) (Fin D) ℂ),
+      σ.PosDef ∧ 0 < r ∧
+      -- B is the tpGauge of the rescaled tensor
+      (∀ i : Fin d,
+        B i = CFC.sqrt σ *
+          ((↑((Real.sqrt r)⁻¹) : ℂ) • A i) * (CFC.sqrt σ)⁻¹) ∧
+      -- B is TP
+      (∑ i : Fin d, (B i)ᴴ * B i = 1) ∧
+      -- B is gauge-equivalent to the rescaled tensor
+      GaugeEquiv (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+  -- Get the PosDef adjoint eigenvector.
+  obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
+    exists_posDef_adjoint_eigenvector A hIrr hA
+  -- Define the rescaled tensor.
+  set c := (Real.sqrt r)⁻¹ with hc_def
+  set A' : MPSTensor d D := fun i => (↑c : ℂ) • A i with hA'_def
+  -- Auxiliary lemma: star of a real-coerced scalar is itself.
+  have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
+    rw [RCLike.star_def, Complex.conj_ofReal]
+  -- Key scalar identity.
+  have hcc : (c : ℝ) * c = r⁻¹ := by
+    rw [hc_def, ← sq, inv_pow, Real.sq_sqrt hr_pos.le]
+  have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
+    rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
+  -- σ is a PosDef fixed point of transferMap(fun i => (A' i)ᴴ).
+  have hA'_fix : transferMap (d := d) (D := D) (fun i => (A' i)ᴴ) σ = σ := by
+    simp only [hA'_def, transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
+      Matrix.mul_smul, smul_smul, star_star]
+    simp_rw [hstar_c, hc_sq]
+    rw [← Finset.smul_sum]
+    have h_sum : ∑ i : Fin d, (A i)ᴴ * σ * ((A i)ᴴ)ᴴ =
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ := by
+      simp [transferMap_apply]
+    rw [h_sum, hσ_eig, smul_smul, inv_mul_cancel₀, one_smul]
+    exact_mod_cast hr_pos.ne'
+  -- Apply tpGauge.
+  set B := tpGauge (d := d) (D := D) A' σ with hB_def
+  have hB_tp : ∑ i : Fin d, (B i)ᴴ * B i = 1 :=
+    tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A' σ hσ_pd hA'_fix
+  have hB_gauge : GaugeEquiv (d := d) (D := D) A' B :=
+    gaugeEquiv_tpGauge A' σ hσ_pd
+  refine ⟨B, r, σ, hσ_pd, hr_pos, ?_, hB_tp, ?_⟩
+  -- Explicit form of B.
+  · intro i
+    rfl
+  -- GaugeEquiv: A' matches the stated rescaled tensor.
+  · convert hB_gauge using 1
+
+/-- **Unital gauge data for an irreducible MPS tensor.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770.  For an irreducible nonzero tensor, the Perron--Frobenius
+eigenvector of the transfer map gives a positive scalar `r` and a positive
+definite matrix `ρ`; the spectral gauge
+`B i = r^{-1/2} ρ^{-1/2} A i ρ^{1/2}` is unital and gauge-equivalent to the
+rescaled tensor `r^{-1/2} A`. -/
+theorem exists_unital_data_of_irreducible
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (B : MPSTensor d D) (r : ℝ) (ρ : Matrix (Fin D) (Fin D) ℂ),
+      ρ.PosDef ∧ 0 < r ∧
+      (∀ i : Fin d,
+        B i =
+          (↑((Real.sqrt r)⁻¹) : ℂ) •
+            ((CFC.sqrt ρ)⁻¹ * A i * CFC.sqrt ρ)) ∧
+      (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+      GaugeEquiv (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+  classical
+  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  have hIrrAdjMap :
+      IsIrreducibleMap (transferMap (d := d) (D := D) Aadj) := by
+    simpa [Aadj] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
+        (d := d) (D := D) A hIrr
+  have hIrrAdj : IsIrreducibleTensor (d := d) (D := D) Aadj :=
+    isIrreducibleTensor_of_isIrreducibleMap Aadj hIrrAdjMap
+  have hAadj : ∃ i, Aadj i ≠ 0 := by
+    rcases hA with ⟨i, hi⟩
+    refine ⟨i, ?_⟩
+    intro h
+    exact hi (Matrix.conjTranspose_eq_zero.mp (by simpa [Aadj] using h))
+  obtain ⟨ρ, r, hρ, hr, hρ_eig_adj⟩ :=
+    exists_posDef_adjoint_eigenvector (d := d) (D := D) Aadj hIrrAdj hAadj
+  have hρ_eig : transferMap (d := d) (D := D) A ρ = (r : ℂ) • ρ := by
+    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using hρ_eig_adj
+  let B : MPSTensor d D := spectralUnitalGauge (d := d) (D := D) A r ρ
+  have hB_unital : ∑ i : Fin d, B i * (B i)ᴴ = 1 := by
+    simpa [B] using
+      spectralUnitalGauge_isUnital_of_transferMap_eigenvector
+        (d := d) (D := D) A ρ r hρ hr hρ_eig
+  have hGauge : GaugeEquiv (d := d) (D := D)
+      (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+    convert
+      gaugeEquiv_unitalGauge (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) ρ hρ using 1
+    ext i
+    simp [B, spectralUnitalGauge, unitalGauge]
+  refine ⟨B, r, ρ, hρ, hr, ?_, hB_unital, hGauge⟩
+  intro i
+  rfl
+
+end MPSTensor

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -36,7 +36,6 @@ specializations and combines them with the explicit gauge constructions from
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
-open Matrix Finset
 
 variable {d D : ℕ}
 
@@ -59,11 +58,10 @@ theorem exists_posDef_adjoint_eigenvector
     ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
       σ.PosDef ∧ 0 < r ∧
       transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = (r : ℂ) • σ := by
-  have hIrrMap : IsIrreducibleMap (Kraus.mapLM A) := by
-    rw [Kraus.mapLM_eq_transferMap]
-    exact isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrr
   obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
-    Kraus.exists_posDef_adjoint_eigenvector (K := A) hIrrMap hA
+    Kraus.exists_posDef_adjoint_eigenvector (K := A)
+      (Kraus.isIrreducibleMap_mapLM_of_transferMap _
+        (isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrr)) hA
   refine ⟨σ, r, hσ_pd, hr_pos, ?_⟩
   rwa [Kraus.mapLM_eq_transferMap] at hσ_eig
 

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Irreducible.Adjoint
 
 /-!
-# Perron–Frobenius gauge data for irreducible MPS tensors
+# Perron–Frobenius gauges for irreducible MPS tensors
 
 The Perron–Frobenius eigenvector of the adjoint transfer map of an irreducible
 MPS tensor gives the standard trace-preserving and unital gauge normalizations.
@@ -42,7 +42,7 @@ variable {d D : ℕ}
 
 namespace MPSTensor
 
-/-- **PosDef fixed point of the adjoint transfer map (after rescaling)**
+/-- **PosDef eigenvector of the adjoint transfer map**
 (combines Wolf Theorem 6.5 for existence with Wolf Theorem 6.3(2) for positive
 definiteness).
 

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -266,19 +266,60 @@ outer square-root factors yields
     \label{thm:adjoint_transfer_ne_zero}
     \lean{Kraus.mapLM_ne_zero_of_exists_ne_zero}
     \leanok
-    \uses{def:transfer_map}
-    If some Kraus operator $K^i \neq 0$, then the Kraus map
-    $X \mapsto \sum_i K^i X (K^i)^\dagger$ is nonzero. Applied to the
-    conjugate-transposed family, the adjoint transfer
-    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ of a tensor with some
-    $A^i \neq 0$ is nonzero.
+    \uses{def:kraus_map}
+    If some Kraus operator $K_i \neq 0$, then the Kraus map
+    $X \mapsto \sum_i K_i X K_i^\dagger$ is nonzero.
 \end{theorem}
 
 \begin{proof}\leanok
     If the map vanishes, evaluating at $\Id$ gives
-    $\sum_i K^i (K^i)^\dagger = 0$.
-    Since each summand $K^i (K^i)^\dagger$ is positive semidefinite,
-    each $K^i (K^i)^\dagger = 0$ and hence each $K^i = 0$.
+    $\sum_i K_i K_i^\dagger = 0$.
+    Since each summand $K_i K_i^\dagger$ is positive semidefinite,
+    each $K_i K_i^\dagger = 0$ and hence each $K_i = 0$.
+    Applying this to $K_i = (A^i)^\dagger$ and using
+    $A^i \neq 0 \iff (A^i)^\dagger \neq 0$ shows that the adjoint transfer
+    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ of a tensor with some
+    $A^i \neq 0$ is nonzero.
+\end{proof}
+
+\begin{theorem}[Positive-definite adjoint eigenvector for irreducible Kraus families]%
+    \label{thm:kraus_posdef_adjoint_eigenvector}
+    \lean{Kraus.exists_posDef_adjoint_eigenvector}
+    \leanok
+    \uses{def:kraus_map, def:irreducible_cp}
+    Let $\{K_i\}_{i=0}^{d-1}$ be a family with $D > 0$ and some
+    $K_i \neq 0$, whose Kraus map $\mathcal K_K$ is irreducible. Then there
+    exist a positive definite matrix~$\sigma$ and a positive real $r > 0$
+    such that
+    \begin{align}
+        \sum_i K_i^\dagger \sigma K_i
+         & = r\sigma.
+        \notag
+    \end{align}
+
+    This combines the eigenvector-existence part of
+    \cite[Theorem~6.5]{Wolf2012Quantum} with the irreducible upgrade to
+    positive definiteness (\cite[Theorem~6.3(2)]{Wolf2012Quantum}).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pf_eigenvector_existence, thm:adjoint_transfer_ne_zero,
+        thm:kernel_inclusion_pd_irred}
+    The conjugate-transposed family $\{K_i^\dagger\}$ has the same Kraus map
+    as the adjoint of $\mathcal K_K$, so it is completely positive, and by
+    Theorem~\ref{thm:adjoint_transfer_ne_zero} it is nonzero. Irreducibility
+    of $\mathcal K_K$ transfers to $\{K_i^\dagger\}$: if $P$ is invariant for
+    $\mathcal K_K$, so that $(\Id-P)K_iP=0$ for all $i$, then taking adjoints
+    gives $PK_i^\dagger(\Id-P)=0$, which means $\Id-P$ is invariant for the
+    Kraus map of $\{K_i^\dagger\}$. Hence the Kraus map of $\{K_i^\dagger\}$
+    does not annihilate any nonzero positive semidefinite matrix, and
+    Theorem~\ref{thm:pf_eigenvector_existence} applies, giving
+    $\sigma \ge 0$, $\sigma \neq 0$, and $r > 0$ with
+    $\sum_i K_i^\dagger \sigma K_i = r\sigma$. Since
+    $\ker\sigma \subseteq \ker\bigl(\sum_i K_i^\dagger \sigma K_i\bigr)$
+    follows immediately from this eigenvector equation,
+    Theorem~\ref{thm:kernel_inclusion_pd_irred} gives that $\sigma$ is
+    positive definite.
 \end{proof}
 
 \begin{theorem}[Real spectral-radius identity]

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -282,6 +282,21 @@ outer square-root factors yields
     $A^i \neq 0$ is nonzero.
 \end{proof}
 
+\begin{theorem}[Irreducibility passes to the conjugate-transposed Kraus family]%
+    \label{thm:kraus_conjTranspose_irreducible}
+    \lean{Kraus.isIrreducibleMap_mapLM_conjTranspose}
+    \leanok
+    \uses{def:kraus_map, def:irreducible_cp}
+    If the Kraus map of $\{K_i\}_{i=0}^{d-1}$ is irreducible, then so is the
+    Kraus map of the conjugate-transposed family $\{K_i^\dagger\}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $P$ is invariant for $\mathcal K_K$, so that $(\Id-P)K_iP=0$ for all
+    $i$, then taking adjoints gives $PK_i^\dagger(\Id-P)=0$, which means
+    $\Id-P$ is invariant for the Kraus map of $\{K_i^\dagger\}$.
+\end{proof}
+
 \begin{theorem}[Positive-definite adjoint eigenvector for irreducible Kraus families]%
     \label{thm:kraus_posdef_adjoint_eigenvector}
     \lean{Kraus.exists_posDef_adjoint_eigenvector}
@@ -304,15 +319,13 @@ outer square-root factors yields
 
 \begin{proof}\leanok
     \uses{thm:pf_eigenvector_existence, thm:adjoint_transfer_ne_zero,
-        thm:kernel_inclusion_pd_irred}
+        thm:kernel_inclusion_pd_irred, thm:kraus_conjTranspose_irreducible}
     The conjugate-transposed family $\{K_i^\dagger\}$ has the same Kraus map
     as the adjoint of $\mathcal K_K$, so it is completely positive, and by
-    Theorem~\ref{thm:adjoint_transfer_ne_zero} it is nonzero. Irreducibility
-    of $\mathcal K_K$ transfers to $\{K_i^\dagger\}$: if $P$ is invariant for
-    $\mathcal K_K$, so that $(\Id-P)K_iP=0$ for all $i$, then taking adjoints
-    gives $PK_i^\dagger(\Id-P)=0$, which means $\Id-P$ is invariant for the
-    Kraus map of $\{K_i^\dagger\}$. Hence the Kraus map of $\{K_i^\dagger\}$
-    does not annihilate any nonzero positive semidefinite matrix, and
+    Theorem~\ref{thm:adjoint_transfer_ne_zero} it is nonzero. By
+    Theorem~\ref{thm:kraus_conjTranspose_irreducible}, its Kraus map is
+    irreducible, so it does not annihilate any nonzero positive semidefinite
+    matrix, and
     Theorem~\ref{thm:pf_eigenvector_existence} applies, giving
     $\sigma \ge 0$, $\sigma \neq 0$, and $r > 0$ with
     $\sum_i K_i^\dagger \sigma K_i = r\sigma$. Since

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -292,9 +292,11 @@ outer square-root factors yields
 \end{theorem}
 
 \begin{proof}\leanok
-    If $P$ is invariant for $\mathcal K_K$, so that $(\Id-P)K_iP=0$ for all
-    $i$, then taking adjoints gives $PK_i^\dagger(\Id-P)=0$, which means
-    $\Id-P$ is invariant for the Kraus map of $\{K_i^\dagger\}$.
+    If $P$ is invariant for the Kraus map of $\{K_i^\dagger\}$, so that
+    $(\Id-P)K_i^\dagger P=0$ for all $i$, then taking adjoints gives
+    $PK_i(\Id-P)=0$, which means $\Id-P$ is invariant for $\mathcal K_K$.
+    Irreducibility of $\mathcal K_K$ forces $\Id-P \in \{0,\Id\}$, hence
+    $P \in \{0,\Id\}$, so the Kraus map of $\{K_i^\dagger\}$ is irreducible.
 \end{proof}
 
 \begin{theorem}[Positive-definite adjoint eigenvector for irreducible Kraus families]%

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -282,6 +282,19 @@ outer square-root factors yields
     $A^i \neq 0$ is nonzero.
 \end{proof}
 
+\begin{theorem}[Kraus maps are completely positive]%
+    \label{thm:kraus_map_cp}
+    \lean{Kraus.isCPMap_mapLM}
+    \leanok
+    \uses{def:kraus_map}
+    The Kraus map of a finite matrix family $\{K_i\}_{i=0}^{d-1}$ is
+    completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    The family $\{K_i\}$ itself is a Kraus representation of the map.
+\end{proof}
+
 \begin{theorem}[Irreducibility passes to the conjugate-transposed Kraus family]%
     \label{thm:kraus_conjTranspose_irreducible}
     \lean{Kraus.isIrreducibleMap_mapLM_conjTranspose}
@@ -292,9 +305,12 @@ outer square-root factors yields
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:kraus_lower_zero_invariant_compression}
     If $P$ is invariant for the Kraus map of $\{K_i^\dagger\}$, so that
     $(\Id-P)K_i^\dagger P=0$ for all $i$, then taking adjoints gives
-    $PK_i(\Id-P)=0$, which means $\Id-P$ is invariant for $\mathcal K_K$.
+    $PK_i(\Id-P)=0$; by
+    Theorem~\ref{thm:kraus_lower_zero_invariant_compression}, $\Id-P$ is
+    invariant for $\mathcal K_K$.
     Irreducibility of $\mathcal K_K$ forces $\Id-P \in \{0,\Id\}$, hence
     $P \in \{0,\Id\}$, so the Kraus map of $\{K_i^\dagger\}$ is irreducible.
 \end{proof}
@@ -321,9 +337,11 @@ outer square-root factors yields
 
 \begin{proof}\leanok
     \uses{thm:pf_eigenvector_existence, thm:adjoint_transfer_ne_zero,
-        thm:kernel_inclusion_pd_irred, thm:kraus_conjTranspose_irreducible}
+        thm:kernel_inclusion_pd_irred, thm:kraus_conjTranspose_irreducible,
+        thm:kraus_map_cp}
     The conjugate-transposed family $\{K_i^\dagger\}$ has the same Kraus map
-    as the adjoint of $\mathcal K_K$, so it is completely positive, and by
+    as the adjoint of $\mathcal K_K$, so it is completely positive
+    (Theorem~\ref{thm:kraus_map_cp}), and by
     Theorem~\ref{thm:adjoint_transfer_ne_zero} it is nonzero. By
     Theorem~\ref{thm:kraus_conjTranspose_irreducible}, its Kraus map is
     irreducible, so it does not annihilate any nonzero positive semidefinite

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -262,20 +262,23 @@ outer square-root factors yields
 \section{Auxiliary Perron reductions}
 \label{sec:app_qpf_perron}
 
-\begin{theorem}[Adjoint transfer map is nonzero]%
+\begin{theorem}[Nonzero Kraus maps]%
     \label{thm:adjoint_transfer_ne_zero}
-    \lean{MPSTensor.adjointTransferMap_ne_zero_of_nonzero}
+    \lean{Kraus.mapLM_ne_zero_of_exists_ne_zero}
     \leanok
     \uses{def:transfer_map}
-    If some Kraus operator $A^i \neq 0$, then the adjoint transfer
-    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ is nonzero.
+    If some Kraus operator $K^i \neq 0$, then the Kraus map
+    $X \mapsto \sum_i K^i X (K^i)^\dagger$ is nonzero. Applied to the
+    conjugate-transposed family, the adjoint transfer
+    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ of a tensor with some
+    $A^i \neq 0$ is nonzero.
 \end{theorem}
 
 \begin{proof}\leanok
-    If $\E_A^\dagger = 0$ then $\E_A^\dagger(\Id) = 0$,
-    so $\sum_i (A^i)^\dagger A^i = 0$.
-    Since each summand $(A^i)^\dagger A^i$ is positive semidefinite,
-    each $(A^i)^\dagger A^i = 0$ and hence each $A^i = 0$.
+    If the map vanishes, evaluating at $\Id$ gives
+    $\sum_i K^i (K^i)^\dagger = 0$.
+    Since each summand $K^i (K^i)^\dagger$ is positive semidefinite,
+    each $K^i (K^i)^\dagger = 0$ and hence each $K^i = 0$.
 \end{proof}
 
 \begin{theorem}[Real spectral-radius identity]

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -782,30 +782,15 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:pf_eigenvector_existence, thm:irred_map_smul,
-        thm:adjoint_transfer_ne_zero, thm:transfer_psd_fp_pd_irred}
-    By Theorem~\ref{thm:adjoint_transfer_ne_zero},
-    $\E_A^\dagger \neq 0$.
-    Since $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ is a
-    Kraus map, it is positive. Irreducibility of $A$ transfers to the
-    adjoint transfer map. More precisely, if $P$ is invariant for
-    $\E_A$, so that $(\Id-P)K_iP=0$ for all Kraus operators $K_i$, then
-    taking adjoints gives $PK_i^\dagger(\Id-P)=0$, which means $\Id-P$
-    is invariant for $\E_A^\dagger$. Hence $\E_A$
-    is irreducible if and only if $\E_A^\dagger$ is irreducible, and
-    together with $\E_A^\dagger \neq 0$ this implies
-    $\E_A^\dagger(\tau) \neq 0$ for every nonzero positive semidefinite
-    matrix $\tau$.
-    Hence Theorem~\ref{thm:pf_eigenvector_existence} applies to
-    $\E_A^\dagger$, giving $\sigma_0 \ge 0$, $\sigma_0\neq0$, and $r > 0$
-    with $\E_A^\dagger(\sigma_0) = r\sigma_0$.
-    Set $T^i = r^{-1/2}(A^i)^\dagger$.
-    Then $\E_T(\sigma_0) = \sigma_0$, and $\E_T$ is irreducible
-    by Theorem~\ref{thm:irred_map_smul}, since irreducibility of $\E_A$
-    transfers to the adjoint and is preserved under scaling.
-    Since $\E_T$ is irreducible with a positive semidefinite fixed point,
-    Theorem~\ref{thm:transfer_psd_fp_pd_irred} gives that $\sigma_0$ is positive
-    definite.
+    \uses{thm:kraus_posdef_adjoint_eigenvector, thm:kraus_map_eq_transfer_map,
+        def:irreducible_tensor}
+    Since $\mathcal K_A = \E_A$
+    (Theorem~\ref{thm:kraus_map_eq_transfer_map}), the family $A$ is
+    irreducible if and only if its Kraus map is, and applying
+    Theorem~\ref{thm:kraus_posdef_adjoint_eigenvector} to $K_i = A^i$ gives
+    a positive definite $\sigma$ and a positive real $r > 0$ with
+    $\sum_i (A^i)^\dagger \sigma A^i = r\sigma$, i.e.
+    $\E_A^\dagger(\sigma) = r\sigma$.
 \end{proof}
 
 \begin{theorem}[TP-gauge existence for irreducible tensors]%

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -763,6 +763,20 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Theorem~\ref{thm:pf_eigenvector_existence_general}.
 \end{proof}
 
+\begin{theorem}[Irreducibility of the transfer map of an irreducible tensor]%
+    \label{thm:transfer_map_irreducible_of_tensor}
+    \lean{MPSTensor.isIrreducibleCP_transferMap_of_isIrreducibleTensor}
+    \leanok
+    \uses{def:irreducible_tensor, def:transfer_map, def:irreducible_cp}
+    If an MPS tensor $A$ is irreducible, then its transfer map $\E_A$ is
+    irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+    An invariant projection for $\E_A$ is exactly an invariant projection
+    for the matrices $A^i$, so the two irreducibility notions coincide.
+\end{proof}
+
 \begin{theorem}[Positive-definite adjoint eigenvector for irreducible tensors]%
     \label{thm:posDef_adjoint_eigenvector}
     \lean{MPSTensor.exists_posDef_adjoint_eigenvector}
@@ -783,10 +797,11 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}\leanok
     \uses{thm:kraus_posdef_adjoint_eigenvector, thm:kraus_map_eq_transfer_map,
-        def:irreducible_tensor}
-    Since $\mathcal K_A = \E_A$
-    (Theorem~\ref{thm:kraus_map_eq_transfer_map}), the family $A$ is
-    irreducible if and only if its Kraus map is, and applying
+        thm:transfer_map_irreducible_of_tensor}
+    By Theorem~\ref{thm:transfer_map_irreducible_of_tensor}, $\E_A$ is
+    irreducible, and since $\mathcal K_A = \E_A$
+    (Theorem~\ref{thm:kraus_map_eq_transfer_map}), its Kraus map $\mathcal K_A$ is
+    irreducible too. Applying
     Theorem~\ref{thm:kraus_posdef_adjoint_eigenvector} to $K_i = A^i$ gives
     a positive definite $\sigma$ and a positive real $r > 0$ with
     $\sum_i (A^i)^\dagger \sigma A^i = r\sigma$, i.e.

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -803,11 +803,12 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}\leanok
     \uses{thm:kraus_posdef_adjoint_eigenvector, thm:kraus_map_eq_transfer_map,
+        thm:kraus_map_irreducible_of_transfer_map,
         thm:transfer_map_irreducible_of_tensor}
     By Theorem~\ref{thm:transfer_map_irreducible_of_tensor}, $\E_A$ is
     irreducible, and since $\mathcal K_A = \E_A$
     (Theorem~\ref{thm:kraus_map_eq_transfer_map}), its Kraus map $\mathcal K_A$ is
-    irreducible too. Applying
+    irreducible too (Theorem~\ref{thm:kraus_map_irreducible_of_transfer_map}). Applying
     Theorem~\ref{thm:kraus_posdef_adjoint_eigenvector} to $K_i = A^i$ gives
     a positive definite $\sigma$ and a positive real $r > 0$ with
     $\sum_i (A^i)^\dagger \sigma A^i = r\sigma$, i.e.

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -773,8 +773,14 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    An invariant projection for $\E_A$ is exactly an invariant projection
-    for the matrices $A^i$, so the two irreducibility notions coincide.
+    If $P$ is a nontrivial invariant projection for $\E_A$, then
+    \begin{align}
+        (\Id-P)A^iP
+         & = 0
+        \notag
+    \end{align}
+    for every $i$, which is exactly a nontrivial invariant projection for
+    the family $\{A^i\}$, contradicting irreducibility of $A$.
 \end{proof}
 
 \begin{theorem}[Positive-definite adjoint eigenvector for irreducible tensors]%

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1529,6 +1529,36 @@ spectral split → block extraction → MPV calculation → strict bounds
   orthogonality. This removes seven local constructions/proofs and reduces the
   theorem proof from 387 to 346 lines (41 lines net), with no new declaration.
 
+### nonzero Kraus map via evaluation at the identity — candidate
+- **Pattern:** show a finite Kraus map is nonzero by evaluating at `1`, reducing to
+  `∑ᵢ Kᵢ Kᵢᴴ = 0`, and concluding each `Kᵢ = 0` from positive semidefiniteness of the
+  summands via `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`.
+- **Seen:** 2 occurrences — the packaged `Kraus.mapLM_ne_zero_of_exists_ne_zero`
+  (`TNLean/Channel/KrausMap.lean`) and the still-inlined six-line copy inside
+  `MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible`
+  (`TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean:270-277`), noted in the
+  2026-08 Perron–Frobenius gauge-split review.
+- **Abstraction (proposed):** replace the inlined copy with
+  `Kraus.mapLM_ne_zero_of_exists_ne_zero _ hB` composed with
+  `Kraus.mapLM_eq_transferMap`.
+- **Notes:** below the rule-of-three threshold; revisit if a third inline copy
+  appears.
+
+### irreducibility transfer to the conjugate-transposed family — candidate
+- **Pattern:** prove that irreducibility passes to the conjugate-transposed Kraus
+  family by taking adjoints of the invariant-projection equation
+  `(1-P) Kᵢ P = 0` to get `P Kᵢᴴ (1-P) = 0`.
+- **Seen:** 2 occurrences — `Kraus.isIrreducibleMap_mapLM_conjTranspose`
+  (`TNLean/Channel/Irreducible/AdjointFamily.lean:41-68`) and
+  `MPSTensor.isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor`
+  (`TNLean/MPS/Irreducible/Adjoint.lean:39-83`), noted in the 2026-08
+  Perron–Frobenius gauge-split review.
+- **Abstraction (proposed):** derive the `MPSTensor` version as a two-line corollary
+  of the `Kraus` version via `Kraus.mapLM_eq_transferMap`, deleting the duplicated
+  84-line proof body.
+- **Notes:** below the rule-of-three threshold; the duplication predates the PR
+  that first noticed it (#6561) and both proofs are otherwise correct.
+
 ## Retired
 
 ### block_words — retired


### PR DESCRIPTION
Part of #6560 (quantum-channel layer extraction), stacked on #6561. Cuts 4 of the 19 channel→MPS import edges: `Channel/PerronFrobenius/Existence.lean` no longer imports `MPS.Irreducible.Adjoint`, `MPS.Core.TPGauge`, `MPS.Core.CPPrimitive`, or `QPF.PosDef`.

## Changes

- **`Channel/PerronFrobenius/Existence.lean`**: the Brouwer-based core theorems are unchanged. The `namespace MPSTensor` section is replaced by a Kraus-level one: `Kraus.exists_posDef_adjoint_eigenvector` (hypotheses `IsIrreducibleMap (Kraus.mapLM K)`, `∃ i, K i ≠ 0`; same proof over `mapLM`, with the PSD→PosDef upgrade now via the channel-level `posDef_of_posSemidef_fixedPoint_irreducible_cp` and adjoint irreducibility via `Kraus.isIrreducibleMap_mapLM_conjTranspose` from #6561) and `Kraus.mapLM_ne_zero_of_exists_ne_zero`.
- **New `MPS/Irreducible/PerronGauge.lean`**: the transfer-map specialization `MPSTensor.exists_posDef_adjoint_eigenvector` (thin bridge over the Kraus theorem) and the gauge theorems `exists_tp_data_of_irreducible` / `exists_unital_data_of_irreducible`, moved with names, statements, and proofs unchanged — the blueprint ch06 `\lean{}` tags for all three remain valid with no blueprint edit.
- **`MPSTensor.adjointTransferMap_ne_zero_of_nonzero` is removed** (no deprecated alias): it had no consumers outside its own file and is subsumed by `Kraus.mapLM_ne_zero_of_exists_ne_zero` applied to the conjugate-transposed family.
- **Consumers**: `MPS/CanonicalForm/Existence.lean` imports the new file instead of the channel module; `MPS/CanonicalForm/NormalTensorGauge.lean` and `Channel/Irreducible/KrausSetup.lean` gain the import (the KrausSetup edge is temporary — that file's MPS imports are removed by the planned Kraus-native `IrreducibleCPKrausSetup` PR).

## Verification

`lake build` of the changed modules plus `Channel/Irreducible/KrausSetup`, `MPS/CanonicalForm/{Existence, NormalTensorGauge, NormalReduction/TPGauge}`: no errors or warnings (8940 jobs). No `sorry`/`axiom`; import aggregators regenerated; blueprint tags unchanged and valid.