### PR TITLE
refactor(channel/peripheral): blocking-free roots of unity for irreducible channels

### DIFF
--- a/TNLean/Channel/Peripheral/AdjointSpectrum.lean
+++ b/TNLean/Channel/Peripheral/AdjointSpectrum.lean
@@ -127,7 +127,7 @@ lemma mapLM_conjTranspose_eq_adjoint (K : Fin d → Mat) :
     simpa only [mapLM_apply] using
       (trace_mul_map_eq_trace_adjointMap_mul (K := fun i => (K i)ᴴ) Y (Xᴴ))
   have hadj : adjointMap (fun i => (K i)ᴴ) Y = mapLM K Y := by
-    simp [adjointMap, mapLM_apply, map, Matrix.conjTranspose_conjTranspose]
+    rw [mapLM_apply, adjointMap_conjTranspose_eq_map]
   calc
     Matrix.trace (Y * (mapLM (fun i => (K i)ᴴ) X)ᴴ)
         = Matrix.trace (Y * mapLM (fun i => (K i)ᴴ) (Xᴴ)) := by

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -17,8 +17,8 @@ import TNLean.Channel.Determinant.Bound
 /-!
 # Channel-level formulations for peripheral spectrum and primitivity
 
-This file collects the general channel-level consequences of the MPS-specific
-peripheral-spectrum theory from Wolf Chapter 6.
+This file collects the general channel-level results on the peripheral
+spectrum from Wolf Chapter 6.
 
 ## Main results
 
@@ -31,10 +31,10 @@ peripheral-spectrum theory from Wolf Chapter 6.
 * `compl_eigenvalue_norm_lt_one_of_primitive_of_irreducible_channel`:
   primitive irreducible channels have a strict complementary transfer-map gap
 
-The proofs reduce general channels to finite Kraus maps: trace preservation
-makes the conjugate-transposed family unital, the irreducible fixed point is
-positive definite, and the unital roots-of-unity theorem transports back
-across the adjoint.
+The roots-of-unity proof reduces the channel to a finite Kraus family:
+trace preservation makes the conjugate-transposed family unital, the fixed
+point of an irreducible channel is positive definite, and the unital
+roots-of-unity theorem transports back across the adjoint.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal ENNReal
@@ -144,12 +144,22 @@ theorem fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible_channel
 
 /-- Peripheral eigenvalues of an irreducible channel are roots of unity.
 
-Choose a Kraus representation `E = Kraus.mapLM K`. Trace preservation makes the
-conjugate-transposed family unital, the irreducible channel has a positive
-definite fixed point, and that fixed point is an adjoint fixed point of the
-conjugate-transposed family. The unital roots-of-unity theorem (Wolf Theorem
-6.6(1)) applies there, and peripheral eigenvalues transport back across the
-adjoint as complex conjugates. -/
+Choose a Kraus representation `E X = ∑ i, K i * X * (K i)ᴴ`. Trace preservation
+is the identity `∑ i, (K i)ᴴ * K i = 1`, which is exactly unitality of the
+conjugate-transposed family `L i = (K i)ᴴ`. Irreducibility makes the fixed
+point `ρ` positive definite, and `∑ i, K i * ρ * (K i)ᴴ = E ρ = ρ` says that `ρ`
+is a fixed point of the adjoint of the Kraus map of `L`. The roots-of-unity
+theorem for irreducible unital Kraus maps with a positive definite adjoint
+fixed point (the completely positive specialization of Wolf Theorem 6.6(1))
+applies to `L`, and the peripheral eigenvalues of the two maps are related by
+conjugation, so `star μ ^ p = 1` gives `μ ^ p = 1`.
+
+**Scope restriction (complete positivity):** Wolf Theorem 6.6(1) assumes an
+irreducible positive unital Schwarz map and concludes that the peripheral
+spectrum is exactly a cyclic group of order `m ≤ d²`; this declaration assumes
+complete positivity (via `IsChannel`) and concludes only that each peripheral
+eigenvalue is *some* root of unity. See
+`docs/paper-gaps/wolf_thm6_6_kraus_scope.tex`. -/
 theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hE : IsChannel E) (hIrr : IsIrreducibleMap E) :
@@ -165,8 +175,8 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp
   -- The conjugate-transposed family is unital.
-  have hL_unital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) (fun i => (K i)ᴴ) := by
-    simpa [KadisonSchwarz.IsUnitalKraus, Matrix.conjTranspose_conjTranspose] using hK_tp
+  have hL_unital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) (fun i => (K i)ᴴ) :=
+    KadisonSchwarz.isUnitalKraus_conjTranspose (K := K) hK_tp
   -- The irreducible channel has a positive definite fixed point, which is an
   -- adjoint fixed point of the conjugate-transposed family.
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
@@ -174,11 +184,7 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
   have hρ_pd : ρ.PosDef :=
     posDef_of_posSemidef_fixedPoint_irreducible_cp E hE.cp hIrr ρ hρ_psd hρ_ne hρ_fix
   have hfixL : Kraus.adjointMap (fun i => (K i)ᴴ) ρ = ρ := by
-    have hEρ : Kraus.adjointMap (fun i => (K i)ᴴ) ρ = E ρ := by
-      rw [hE_eq]
-      simp [Kraus.adjointMap_apply, Kraus.mapLM_apply, Kraus.map_apply,
-        Matrix.conjTranspose_conjTranspose]
-    rw [hEρ, hρ_fix]
+    rw [Kraus.adjointMap_conjTranspose_eq_map, ← Kraus.mapLM_apply, ← hE_eq, hρ_fix]
   have hIrrL : IsIrreducibleMap (Kraus.mapLM fun i => (K i)ᴴ) :=
     Kraus.isIrreducibleMap_mapLM_conjTranspose K hIrrK
   -- Transport the peripheral eigenvalue across the adjoint and back.
@@ -192,8 +198,7 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
     Kraus.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint
       (fun i => (K i)ᴴ) hL_unital ρ hρ_pd hfixL hIrrL (star μ) hstar
   refine ⟨p, hp_pos, ?_⟩
-  have h := congrArg star hpow
-  simpa using h
+  simpa using congrArg star hpow
 
 /-- Channel-level formulation for `compl_eigenvalue_norm_lt_one_of_primitive`.
 

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -4,13 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Peripheral.Spectrum
+import TNLean.Channel.Peripheral.AdjointSpectrum
+import TNLean.Channel.Peripheral.ClosureFixedPointKraus
 import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.Channel.Irreducible.AdjointFamily
 import TNLean.Channel.Irreducible.PerronFrobenius
+import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Determinant.Bound
-import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
-import TNLean.Spectral.TransferOperatorGap
 
 /-!
 # Channel-level formulations for peripheral spectrum and primitivity
@@ -29,8 +31,10 @@ peripheral-spectrum theory from Wolf Chapter 6.
 * `compl_eigenvalue_norm_lt_one_of_primitive_of_irreducible_channel`:
   primitive irreducible channels have a strict complementary transfer-map gap
 
-The proofs reduce general channels to Kraus transfer maps and then reuse the
-existing MPS blocking / periodicity-removal formalization.
+The proofs reduce general channels to finite Kraus maps: trace preservation
+makes the conjugate-transposed family unital, the irreducible fixed point is
+positive definite, and the unital roots-of-unity theorem transports back
+across the adjoint.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal ENNReal
@@ -140,37 +144,56 @@ theorem fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible_channel
 
 /-- Peripheral eigenvalues of an irreducible channel are roots of unity.
 
-Choose a Kraus representation `E = transferMap K`, use trace preservation to
-show `K` is left-canonical, convert irreducibility of `E` into tensor
-irreducibility, and then apply the existing blocking-periodicity theorem. -/
+Choose a Kraus representation `E = Kraus.mapLM K`. Trace preservation makes the
+conjugate-transposed family unital, the irreducible channel has a positive
+definite fixed point, and that fixed point is an adjoint fixed point of the
+conjugate-transposed family. The unital roots-of-unity theorem (Wolf Theorem
+6.6(1)) applies there, and peripheral eigenvalues transport back across the
+adjoint as complex conjugates. -/
 theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hE : IsChannel E) (hIrr : IsIrreducibleMap E) :
     ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
   classical
   obtain ⟨r, K, hK⟩ := hE.cp
-  have hE_eq : E = MPSTensor.transferMap (d := r) (D := D) K := by
+  have hE_eq : E = Kraus.mapLM K := by
     apply LinearMap.ext
     intro X
-    simpa [MPSTensor.transferMap_apply] using hK X
-  have hIrrK_map : IsIrreducibleMap (MPSTensor.transferMap (d := r) (D := D) K) := by
+    simpa [Kraus.mapLM_apply, Kraus.map_apply] using hK X
+  have hIrrK : IsIrreducibleMap (Kraus.mapLM K) := by
     simpa [hE_eq] using hIrr
-  have hIrrK : MPSTensor.IsIrreducibleTensor (d := r) (D := D) K :=
-    MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp
-  obtain ⟨p, hp_pos, hPrimP⟩ :=
-    MPSTensor.exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor
-      (A := K) hK_tp hIrrK (Nat.pos_of_ne_zero (NeZero.ne D))
-  rw [MPSTensor.transferMap_blockTensor] at hPrimP
+  -- The conjugate-transposed family is unital.
+  have hL_unital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) (fun i => (K i)ᴴ) := by
+    simpa [KadisonSchwarz.IsUnitalKraus, Matrix.conjTranspose_conjTranspose] using hK_tp
+  -- The irreducible channel has a positive definite fixed point, which is an
+  -- adjoint fixed point of the conjugate-transposed family.
+  obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
+    hE.exists_posSemidef_fixedPoint (E := E) (Nat.pos_of_ne_zero (NeZero.ne D))
+  have hρ_pd : ρ.PosDef :=
+    posDef_of_posSemidef_fixedPoint_irreducible_cp E hE.cp hIrr ρ hρ_psd hρ_ne hρ_fix
+  have hfixL : Kraus.adjointMap (fun i => (K i)ᴴ) ρ = ρ := by
+    have hEρ : Kraus.adjointMap (fun i => (K i)ᴴ) ρ = E ρ := by
+      rw [hE_eq]
+      simp [Kraus.adjointMap_apply, Kraus.mapLM_apply, Kraus.map_apply,
+        Matrix.conjTranspose_conjTranspose]
+    rw [hEρ, hρ_fix]
+  have hIrrL : IsIrreducibleMap (Kraus.mapLM fun i => (K i)ᴴ) :=
+    Kraus.isIrreducibleMap_mapLM_conjTranspose K hIrrK
+  -- Transport the peripheral eigenvalue across the adjoint and back.
   intro μ hμ
-  rcases hμ with ⟨hμ_eig, hμ_norm⟩
-  have hμp_eig : Module.End.HasEigenvalue
-      ((MPSTensor.transferMap (d := r) (D := D) K) ^ p) (μ ^ p) := by
-    simpa [hE_eq] using hμ_eig.pow p
-  have hμp_norm : ‖μ ^ p‖ = 1 := by
-    simp [norm_pow, hμ_norm]
-  exact ⟨p, hp_pos, hPrimP.unique_peripheral (μ ^ p) hμp_eig hμp_norm⟩
+  have hμE : μ ∈ peripheralEigenvalues (Kraus.mapLM K) := by
+    rwa [hE_eq] at hμ
+  have hstar : star μ ∈ peripheralEigenvalues (Kraus.mapLM fun i => (K i)ᴴ) := by
+    rw [Kraus.peripheralEigenvalues_mapLM_conjTranspose]
+    exact ⟨μ, hμE, rfl⟩
+  obtain ⟨p, hp_pos, hpow⟩ :=
+    Kraus.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint
+      (fun i => (K i)ᴴ) hL_unital ρ hρ_pd hfixL hIrrL (star μ) hstar
+  refine ⟨p, hp_pos, ?_⟩
+  have h := congrArg star hpow
+  simpa using h
 
 /-- Channel-level formulation for `compl_eigenvalue_norm_lt_one_of_primitive`.
 

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -59,6 +59,13 @@ omit [DecidableEq n] in
 lemma adjointMap_apply (K : ι → Matrix n n ℂ) (X : Matrix n n ℂ) :
     adjointMap K X = ∑ i : ι, (K i)ᴴ * X * K i := rfl
 
+omit [DecidableEq n] in
+/-- The adjoint Kraus map of the conjugate-transposed family is the Kraus map of the
+original family. -/
+@[simp] theorem adjointMap_conjTranspose_eq_map (K : ι → Matrix n n ℂ) (X : Matrix n n ℂ) :
+    adjointMap (fun i => (K i)ᴴ) X = map K X := by
+  simp [adjointMap, map, Matrix.conjTranspose_conjTranspose]
+
 /-- The adjoint Kraus map as a `ℂ`-linear map: `adjointMapLM K X = ∑ᵢ Kᵢ† X Kᵢ`. -/
 noncomputable def adjointMapLM (K : ι → Matrix n n ℂ) : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where
   toFun := adjointMap K

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -41,8 +41,9 @@ density at the irreducible time with a primitive positive fractional slice.
 **Step B**: `T_t` irreducible + channel → peripheral eigenvalues of `T_t` are roots
 of unity (Wolf Theorem 6.6). This channel-level result is available as
 `peripheral_isRootOfUnity_of_irreducible_channel`, proved by choosing a Kraus
-representation, converting to an irreducible tensor, and applying the existing
-blocking-periodicity theorem.
+representation, reading trace preservation `∑ᵢ Kᵢ† Kᵢ = 1` as unitality of the
+conjugate-transposed family, and applying the roots-of-unity theorem for
+irreducible unital Kraus maps with a positive definite adjoint fixed point.
 
 **Step C**: For an irreducible channel `T_t` with period `p` (i.e., `μ^p = 1` for
 peripheral `μ`), the eigenvector `V` with `T_t V = μ V` satisfies


### PR DESCRIPTION
Part of #6560 (quantum-channel layer extraction), stacked on #6564. Cuts the last two MPS/Spectral import edges in `Channel/Peripheral/`: `IrreducibleChannel.lean` no longer imports `MPS.CanonicalForm.BlockingViaAdjoint` or `Spectral.TransferOperatorGap`.

## Changes

`peripheral_isRootOfUnity_of_irreducible_channel` is reproved through the channel-native Wolf 6.6 route instead of the MPS blocking-periodicity theorem: choose a Kraus representation `E = Kraus.mapLM K`; trace preservation makes the conjugate-transposed family unital; the irreducible channel's PSD fixed point is positive definite (`posDef_of_posSemidef_fixedPoint_irreducible_cp`) and is an adjoint fixed point of the conjugate-transposed family; the unital roots-of-unity theorem (`Kraus.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint`) applies there; peripheral eigenvalues transport back as complex conjugates via `Kraus.peripheralEigenvalues_mapLM_conjTranspose` (#6563). The theorem statement is unchanged; every other declaration in the file is untouched.

## Verification

`lake build` of `IrreducibleChannel` and its importers (`Semigroup/Primitivity/{Basic, IrreducibleAnalysis}`, the `Channel/Peripheral` aggregator): no errors, no warnings. This build also surfaced two latent issues in the ancestor branches, fixed there in dedicated commits (an instance-scoping fix in `AdjointSpectrum.lean` on the #6563 branch, and definitional-transparency fixes in `SpectralRadius`/`FromSpectral` on the #6564 branch): an earlier local verification of those branches had reused a stale compiled module, so their CI runs are the authoritative check.

No `sorry`/`axiom`; aggregators regenerated; no blueprint tags affected (the proof change is below statement level).