### PR TITLE
refactor(analysis): relocate the spectral-radius power-decay lemma

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -57,6 +57,7 @@ import TNLean.Analysis.SandwichedRenyi
 import TNLean.Analysis.SandwichedRenyiTwo
 import TNLean.Analysis.SchattenNorm
 import TNLean.Analysis.SpectralQuadraticForm
+import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Analysis.SuperoperatorResolvent
 import TNLean.Analysis.SupportCompressedEntropy
 import TNLean.Analysis.SupportCompression

--- a/TNLean/Analysis/SpectralRadiusPowerDecay.lean
+++ b/TNLean/Analysis/SpectralRadiusPowerDecay.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
-import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Analysis.Normed.Group.Continuity
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import Mathlib.Analysis.SpecificLimits.Basic
 
 /-!
 # Power decay below spectral radius one
@@ -26,7 +28,7 @@ theorem pow_tendsto_zero_of_spectralRadius_lt_one
     Filter.Tendsto (fun n => a ^ n) Filter.atTop (nhds 0) := by
   obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp h
   have hr_lt_one : r < 1 := ENNReal.coe_lt_coe.mp (by rwa [ENNReal.coe_one])
-  have hev2 : ∀ᶠ n in Filter.atTop, ‖a ^ n‖₊ < r ^ n := by
+  have hev : ∀ᶠ n in Filter.atTop, ‖a ^ n‖₊ < r ^ n := by
     have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius a
     filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
       Filter.eventually_gt_atTop 0] with n hn hn_pos
@@ -34,6 +36,6 @@ theorem pow_tendsto_zero_of_spectralRadius_lt_one
     rw [ENNReal.rpow_natCast] at hn
     exact_mod_cast hn
   apply squeeze_zero_norm' (a := fun n => (r : ℝ) ^ n)
-  · filter_upwards [hev2] with n hn
+  · filter_upwards [hev] with n hn
     rw [← coe_nnnorm, ← NNReal.coe_pow]; exact_mod_cast hn.le
   · exact tendsto_pow_atTop_nhds_zero_of_lt_one r.coe_nonneg (by exact_mod_cast hr_lt_one)

--- a/TNLean/Analysis/SpectralRadiusPowerDecay.lean
+++ b/TNLean/Analysis/SpectralRadiusPowerDecay.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Normed.Algebra.GelfandFormula
+import Mathlib.Analysis.SpecificLimits.Normed
+
+/-!
+# Power decay below spectral radius one
+
+In a complex Banach algebra, the powers of an element whose spectral radius is
+strictly below one converge to zero.  This follows from Gelfand's formula
+`spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius`: eventually
+`‖a ^ n‖ ≤ r ^ n` for any `r` strictly between the spectral radius and one.
+
+## Main results
+
+- `pow_tendsto_zero_of_spectralRadius_lt_one`
+-/
+
+/-- **Powers tend to zero when spectral radius < 1.** -/
+theorem pow_tendsto_zero_of_spectralRadius_lt_one
+    {A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A]
+    (a : A) (h : spectralRadius ℂ a < 1) :
+    Filter.Tendsto (fun n => a ^ n) Filter.atTop (nhds 0) := by
+  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp h
+  have hr_lt_one : r < 1 := ENNReal.coe_lt_coe.mp (by rwa [ENNReal.coe_one])
+  have hev2 : ∀ᶠ n in Filter.atTop, ‖a ^ n‖₊ < r ^ n := by
+    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius a
+    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
+      Filter.eventually_gt_atTop 0] with n hn hn_pos
+    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
+    rw [ENNReal.rpow_natCast] at hn
+    exact_mod_cast hn
+  apply squeeze_zero_norm' (a := fun n => (r : ℝ) ^ n)
+  · filter_upwards [hev2] with n hn
+    rw [← coe_nnnorm, ← NNReal.coe_pow]; exact_mod_cast hn.le
+  · exact tendsto_pow_atTop_nhds_zero_of_lt_one r.coe_nonneg (by exact_mod_cast hr_lt_one)

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -13,7 +13,6 @@ import TNLean.Channel.Peripheral.PeriodicityRemoval
 import TNLean.Channel.Peripheral.ClosureFixedPointKraus
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.Primitive
-import TNLean.Spectral.TransferOperatorGap
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.NumberTheory.Real.Irrational
 

--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Channel.Semigroup.Primitivity.Helpers
 import TNLean.Channel.Irreducible.FromSpectral
 import TNLean.Channel.Peripheral.IrreducibleChannel
@@ -37,7 +38,7 @@ theorem primitive_channel_pow_tendsto_zero_of_trace_zero [NeZero D]
   have hpow0 : Filter.Tendsto
       (fun n : ℕ => ((Module.End.toContinuousLinearMap Mat) (E - P)) ^ n)
       Filter.atTop (nhds 0) :=
-    MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one _ hsr_lt
+    pow_tendsto_zero_of_spectralRadius_lt_one _ hsr_lt
   have hNpow0 : Filter.Tendsto (fun n : ℕ => ((E - P) ^ n) X) Filter.atTop (nhds 0) := by
     have hEval : Continuous (fun A : Mat →L[ℂ] Mat => A X) :=
       (ContinuousLinearMap.apply ℂ Mat X).continuous

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -259,7 +259,7 @@ lemma stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one
           Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) < 1
     simpa using hsr
   have hpow : Filter.Tendsto (fun L => F' ^ L) Filter.atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one
+    @_root_.pow_tendsto_zero_of_spectralRadius_lt_one
       (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)
       ContinuousLinearMap.toNormedRing hComplete ContinuousLinearMap.toNormedAlgebra F' hsrF
   have hIter0 :

--- a/TNLean/Spectral/MPVOverlapDecayRect.lean
+++ b/TNLean/Spectral/MPVOverlapDecayRect.lean
@@ -77,7 +77,7 @@ theorem mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one
         (mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₂) A B)) : V →L[ℂ] V) < 1
     simpa only [] using hSpect
   have hpow0 : Tendsto (fun n => F' ^ n) atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+    @_root_.pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
       (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
       (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hSpectF
   have htr0 :

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -116,7 +116,7 @@ theorem linearMap_trace_pow_tendsto_one_of_spectralRadius_compl_lt_one
   have hNpow_clm : Filter.Tendsto (fun n => (Φ N) ^ n) Filter.atTop (nhds 0) :=
     by
       exact
-        @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+        @_root_.pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
           (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V))
           hComplete
           (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) (Φ N)

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -19,7 +19,7 @@ a lower bound on `1 - ρ`).
 
 ## Building blocks (already formalized elsewhere)
 
-* `pow_tendsto_zero_of_spectralRadius_lt_one` in `Spectral/TransferOperatorGap.lean` —
+* `pow_tendsto_zero_of_spectralRadius_lt_one` in `Analysis/SpectralRadiusPowerDecay.lean` —
   exponential convergence to zero when spectral radius < 1
 * `compl_eigenvalue_norm_lt_one_of_primitive` in `Peripheral/Spectrum.lean` —
   primitive channels have a complementary transfer-map gap
@@ -266,7 +266,7 @@ the complementary transfer-map gap, which exists because injectivity implies
 primitivity.
 
 This uses `pow_tendsto_zero_of_spectralRadius_lt_one` from
-`Spectral/TransferOperatorGap.lean` directly — traceless matrices lie in
+`Analysis/SpectralRadiusPowerDecay.lean` directly — traceless matrices lie in
 `ker(P) = range(E - P)`, where `E - P` has spectral radius < 1. -/
 theorem correlation_length_bound [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -19,8 +19,9 @@ a lower bound on `1 - ρ`).
 
 ## Building blocks (already formalized elsewhere)
 
-* `pow_tendsto_zero_of_spectralRadius_lt_one` in `Analysis/SpectralRadiusPowerDecay.lean` —
-  exponential convergence to zero when spectral radius < 1
+* `MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
+  `Spectral/TransferOperatorGapCommon.lean` — a uniform geometric operator-norm
+  bound when spectral radius < 1
 * `compl_eigenvalue_norm_lt_one_of_primitive` in `Peripheral/Spectrum.lean` —
   primitive channels have a complementary transfer-map gap
 * `cumulativeSpan_eq_top` in `Wielandt/SpanGrowth/NonzeroTraceProduct.lean` —
@@ -265,8 +266,9 @@ exponentially under the transfer map iteration. The rate is determined by
 the complementary transfer-map gap, which exists because injectivity implies
 primitivity.
 
-This uses `pow_tendsto_zero_of_spectralRadius_lt_one` from
-`Analysis/SpectralRadiusPowerDecay.lean` directly — traceless matrices lie in
+This goes through the local `geometric_apply_bound_of_spectralRadius_lt_one`,
+which delegates to `MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
+`Spectral/TransferOperatorGapCommon.lean` — traceless matrices lie in
 `ker(P) = range(E - P)`, where `E - P` has spectral radius < 1. -/
 theorem correlation_length_bound [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -266,10 +266,11 @@ exponentially under the transfer map iteration. The rate is determined by
 the complementary transfer-map gap, which exists because injectivity implies
 primitivity.
 
-This goes through the local `geometric_apply_bound_of_spectralRadius_lt_one`,
-which delegates to `MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
-`Spectral/TransferOperatorGapCommon.lean` — traceless matrices lie in
-`ker(P) = range(E - P)`, where `E - P` has spectral radius < 1. -/
+Traceless matrices lie in `ker(P) = range(E - P)`, where `E - P` has spectral
+radius < 1, so their iterates decay geometrically. The bound is the pointwise
+form `geometric_apply_bound_of_spectralRadius_lt_one` of
+`MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
+`Spectral/TransferOperatorGapCommon.lean`. -/
 theorem correlation_length_bound [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -172,6 +172,9 @@ theorem geometric_bound_of_spectralRadius_lt_one
       _ ≤ C * (r : ℝ) ^ n := by
         gcongr
 
+@[deprecated _root_.pow_tendsto_zero_of_spectralRadius_lt_one (since := "2026-08-19")]
+alias pow_tendsto_zero_of_spectralRadius_lt_one := _root_.pow_tendsto_zero_of_spectralRadius_lt_one
+
 /-- **An idempotent with spectral radius below one is zero.** In a complex Banach
 algebra, the powers of such an element converge to `0` while every positive power
 equals the element itself. -/
@@ -179,7 +182,7 @@ theorem IsIdempotentElem.eq_zero_of_spectralRadius_lt_one
     {A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A]
     {a : A} (ha : IsIdempotentElem a) (h : spectralRadius ℂ a < 1) :
     a = 0 := by
-  have hpow := pow_tendsto_zero_of_spectralRadius_lt_one a h
+  have hpow := _root_.pow_tendsto_zero_of_spectralRadius_lt_one a h
   have hshift : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds 0) :=
     hpow.comp (Filter.tendsto_add_atTop_nat 1)
   have hconst : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds a) := by

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.FrobeniusNorm
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
@@ -18,7 +19,10 @@ square and rectangular mixed-transfer gap theorems.
 ## Main results
 
 - `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
-- `MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one`
+- `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one`
+
+The power-convergence statement `pow_tendsto_zero_of_spectralRadius_lt_one`
+lives in `TNLean.Analysis.SpectralRadiusPowerDecay`.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -167,25 +171,6 @@ theorem geometric_bound_of_spectralRadius_lt_one
       ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
       _ ≤ C * (r : ℝ) ^ n := by
         gcongr
-
-/-- **Powers tend to zero when spectral radius < 1.** -/
-theorem pow_tendsto_zero_of_spectralRadius_lt_one
-    {A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A]
-    (a : A) (h : spectralRadius ℂ a < 1) :
-    Filter.Tendsto (fun n => a ^ n) Filter.atTop (nhds 0) := by
-  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp h
-  have hr_lt_one : r < 1 := ENNReal.coe_lt_coe.mp (by rwa [ENNReal.coe_one])
-  have hev2 : ∀ᶠ n in Filter.atTop, ‖a ^ n‖₊ < r ^ n := by
-    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius a
-    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
-      Filter.eventually_gt_atTop 0] with n hn hn_pos
-    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
-    rw [ENNReal.rpow_natCast] at hn
-    exact_mod_cast hn
-  apply squeeze_zero_norm' (a := fun n => (r : ℝ) ^ n)
-  · filter_upwards [hev2] with n hn
-    rw [← coe_nnnorm, ← NNReal.coe_pow]; exact_mod_cast hn.le
-  · exact tendsto_pow_atTop_nhds_zero_of_lt_one r.coe_nonneg (by exact_mod_cast hr_lt_one)
 
 /-- **An idempotent with spectral radius below one is zero.** In a complex Banach
 algebra, the powers of such an element converge to `0` while every positive power

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -210,7 +210,7 @@ theorem mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one
           Matrix (Fin D₁) (Fin D₂) ℂ →L[ℂ] Matrix (Fin D₁) (Fin D₂) ℂ) < 1
     simpa only [mixedTransferSpectralRadius₂] using h
   have hF : Filter.Tendsto (fun n => F ^ n) Filter.atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+    @_root_.pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
       (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
       (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V))
       F hSpectralRadius

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -138,7 +138,7 @@ theorem IsPrimitiveMPS.complement_pow_tendsto_zero
     let Ê := Φ (transferMap (d := d) (D := D) A -
       fixedPointProj (D := D) ρ hP.trace_ne_zero)
     Tendsto (fun n => Ê ^ n) atTop (nhds 0) :=
-  pow_tendsto_zero_of_spectralRadius_lt_one _ hP.complementary_transfer_map_gap
+  _root_.pow_tendsto_zero_of_spectralRadius_lt_one _ hP.complementary_transfer_map_gap
 
 /-! ## Part 2: Transfer map structure -/
 

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -357,7 +357,7 @@ the block-separation consequences of the transfer-operator gap.
 
 \begin{lemma}[Powers vanish below unit spectral radius]%
     \label{lem:spectral_radius_pow_zero}
-    \lean{MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one}
+    \lean{pow_tendsto_zero_of_spectralRadius_lt_one}
     \leanok
     Let $a$ be an element of a complex Banach algebra with
     $\rho_{\spec}(a)<1$. Then $a^n\to0$ as $n\to\infty$.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1521,10 +1521,12 @@ spectral split → block extraction → MPV calculation → strict bounds
   (hr : spectralRadius ℂ a < r)` and returning the eventual bound; both current
   call sites would discharge their local `have` block with one application
   (the `TransferOperatorGapCommon.lean` site at `A := V →L[ℂ] V`).
-- **Notes:** below the rule-of-three threshold (two occurrences). The two copies
-  now sit in different files and layers (layer 0 `Analysis` and layer 2c
-  `Spectral`) after the relocation, so promote on the next independent
-  occurrence rather than adding a cross-layer dependency for two call sites.
+- **Notes:** below the rule-of-three threshold (two occurrences); promote on
+  the next independent occurrence. `TNLean/Spectral/TransferOperatorGapCommon.lean`
+  already imports `TNLean.Analysis.SpectralRadiusPowerDecay` as of this
+  relocation, so extracting the shared step there would add no new import
+  edge — the deferral rests on the occurrence count alone, not on any
+  cross-layer dependency cost.
 
 ---
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1502,6 +1502,30 @@ spectral split → block extraction → MPV calculation → strict bounds
   $\delta_{\mathrm{cyclicForwardSite}\,i\,r}(i)
   = (N - (r \bmod N)) \bmod N$.
 
+### eventual near-spectral-radius geometric bound — candidate
+- **Pattern:** from `spectralRadius ℂ a < r`, derive
+  `∀ᶠ n in Filter.atTop, ‖a ^ n‖₊ < r ^ n` by combining Gelfand's formula
+  `spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius` with
+  `filter_upwards` on `gelfand.eventually (eventually_lt_nhds hr)` and
+  `Filter.eventually_gt_atTop 0`, then clearing the `n`-th root via
+  `ENNReal.rpow_inv_lt_iff` and `ENNReal.rpow_natCast`.
+- **Seen:** 2 occurrences: `have hev` in
+  `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
+  (`TNLean/Spectral/TransferOperatorGapCommon.lean:131-138`) and `have hev2` in
+  `pow_tendsto_zero_of_spectralRadius_lt_one`
+  (`TNLean/Analysis/SpectralRadiusPowerDecay.lean:29-35`), the latter after the
+  layer-0 relocation of the second theorem (PR #6570).
+- **Abstraction (proposed):** an `eventually_nnnorm_pow_lt_pow_of_spectralRadius_lt`
+  lemma in `TNLean/Analysis/SpectralRadiusPowerDecay.lean`, taking
+  `{A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A] (a : A) {r : ℝ≥0}
+  (hr : spectralRadius ℂ a < r)` and returning the eventual bound; both current
+  call sites would discharge their local `have` block with one application
+  (the `TransferOperatorGapCommon.lean` site at `A := V →L[ℂ] V`).
+- **Notes:** below the rule-of-three threshold (two occurrences). The two copies
+  now sit in different files and layers (layer 0 `Analysis` and layer 2c
+  `Spectral`) after the relocation, so promote on the next independent
+  occurrence rather than adding a cross-layer dependency for two call sites.
+
 ---
 
 ## Rejected

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1511,9 +1511,9 @@ spectral split → block extraction → MPV calculation → strict bounds
   `ENNReal.rpow_inv_lt_iff` and `ENNReal.rpow_natCast`.
 - **Seen:** 2 occurrences: `have hev` in
   `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
-  (`TNLean/Spectral/TransferOperatorGapCommon.lean:131-138`) and `have hev2` in
+  (`TNLean/Spectral/TransferOperatorGapCommon.lean:131-138`) and `have hev` in
   `pow_tendsto_zero_of_spectralRadius_lt_one`
-  (`TNLean/Analysis/SpectralRadiusPowerDecay.lean:29-35`), the latter after the
+  (`TNLean/Analysis/SpectralRadiusPowerDecay.lean:31-37`), the latter after the
   layer-0 relocation of the second theorem (PR #6570).
 - **Abstraction (proposed):** an `eventually_nnnorm_pow_lt_pow_of_spectralRadius_lt`
   lemma in `TNLean/Analysis/SpectralRadiusPowerDecay.lean`, taking


### PR DESCRIPTION
Part of #6560 (decoupling the quantum-channel layer from the Spectral/MPS layers).

`pow_tendsto_zero_of_spectralRadius_lt_one` is a fully generic Banach-algebra
statement (powers tend to zero when the spectral radius is below one, via the
Gelfand formula) that lived inside `namespace MPSTensor` in
`TNLean/Spectral/TransferOperatorGapCommon.lean`. Mathlib has no equivalent
lemma (checked `Mathlib/Analysis/Normed/Algebra/GelfandFormula.lean` and a
repo-wide search for spectral-radius power-decay statements), so this PR moves
it verbatim to a new layer-0 file `TNLean/Analysis/SpectralRadiusPowerDecay.lean`
at root namespace.

Changes:

- New `TNLean/Analysis/SpectralRadiusPowerDecay.lean` with the relocated lemma
  (statement and proof unchanged; only the `MPSTensor.` namespace prefix is
  dropped, since the statement carries no `MPSTensor`/MPS-specific data).
  Imports a specific `Mathlib.Analysis.*` module per lemma used, rather than
  the `SpecificLimits.Normed` umbrella.
- `TNLean/Spectral/TransferOperatorGapCommon.lean` imports the new file; its
  remaining declarations (including
  `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one`, which uses the
  relocated lemma) are unchanged. A
  `@[deprecated] alias MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one :=
  pow_tendsto_zero_of_spectralRadius_lt_one` is kept in this file, since
  `MPSTensor` itself is genuine mathematical terminology and the rename does
  not fall under the no-alias exception in `docs/CONTRIBUTING.md` Section
  Mathematical-language renames.
- `TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean` now imports
  `TNLean.Analysis.SpectralRadiusPowerDecay` directly and refers to the lemma
  by its root name.
- `TNLean/Channel/Semigroup/Primitivity/Basic.lean` drops
  `import TNLean.Spectral.TransferOperatorGap`, which it never used directly.
- Stale location references in `TNLean/Spectral/QuantitativeGap.lean`
  docstrings updated; blueprint `\lean{}` tag in
  `blueprint/src/appendix/ft_mps/ch07_spectral.tex` repointed to the root name.
- `TNLean/Analysis.lean` aggregator regenerated.

All other call sites (`Spectral/`, `Wielandt/`, `MPS/`) referred to the lemma
unqualified inside `namespace MPSTensor` sections and resolve to the root name
without edits; verified by a full `lake build`.

**Root-namespace placement is deliberate.** The lemma is declared at the root
namespace rather than under `namespace spectrum` or `namespace NormedRing`.
Mathlib's own nearest analogue, the generic power-decay fact
`tendsto_pow_atTop_nhds_zero_of_lt_one`
(`Mathlib/Analysis/SpecificLimits/Basic.lean:188`), is likewise declared at
the root namespace over a general scalar type, not inside a wrapping
namespace, even though Mathlib does namespace the Gelfand-formula input this
proof consumes (`spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius`).
Root placement here follows that precedent for a generic decay conclusion
rather than the directory-wide convention of the other 66 files under
`TNLean/Analysis/`, which mostly state facts about a specific algebraic
structure (`NormedRing`, `IsIdempotentElem`, ...) rather than a decay
conclusion in its own right.


