### PR TITLE
doc(channel): split the Wolf chapter-6 index across the boundary

### DIFF
--- a/TNLean/Channel/FixedPoint/CanonicalGauge.lean
+++ b/TNLean/Channel/FixedPoint/CanonicalGauge.lean
@@ -3,37 +3,35 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.QPF.Assembly
-import TNLean.Spectral.MixedTransfer
+import TNLean.Channel.Schwarz.Basic
 
 /-!
-# Canonical gauge normalizations from transfer fixed points
+# Canonical gauge normalizations from Kraus-map fixed points
 
 This file states the two standard one-sided similarity gauges extracted from
-fixed points of the transfer map and its adjoint. It is **not** a formalization
+fixed points of a finite Kraus map and its adjoint. It is **not** a formalization
 of a doubly stochastic gauge. Instead, `gauged_unital` gives the
 right-canonical/unital gauge, while `gauged_tracePreserving` gives the
 left-canonical/trace-preserving gauge.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
-open MPSTensor
 
 variable {d D : ℕ}
 
 section CanonicalGauge
 
-variable [DecidableEq (Fin D)] [NeZero D]
+variable [DecidableEq (Fin D)]
 
-omit [NeZero D] in
 /-- If `S` is invertible and `S * S† = ρ`, then the gauged operators
-`A'_i = S⁻¹ A_i S` satisfy `∑ A'_i A'_i† = I` whenever `E_A(ρ) = ρ`.
-This is the standard **right-canonical** gauge construction. -/
+`A'_i = S⁻¹ A_i S` satisfy `∑ A'_i A'_i† = I` whenever the Kraus map of `A`
+fixes `ρ`. This is the standard **right-canonical** gauge construction. -/
 theorem gauged_unital
-    (A : MPSTensor d D) (S : Matrix (Fin D) (Fin D) ℂ) (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (S : Matrix (Fin D) (Fin D) ℂ) (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hS_inv : S.det ≠ 0)
     (hSS : S * Sᴴ = ρ)
-    (hfix : transferMap (d := d) (D := D) A ρ = ρ) :
+    (hfix : Kraus.map A ρ = ρ) :
     ∑ i : Fin d, (S⁻¹ * A i * S) * (S⁻¹ * A i * S)ᴴ = 1 := by
   have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S (Ne.isUnit hS_inv)
   have hSmul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S (Ne.isUnit hS_inv)
@@ -55,24 +53,24 @@ theorem gauged_unital
   -- Each term is S⁻¹ * (A i * ρ * (A i)ᴴ) * Sᴴ⁻¹ = (S⁻¹ * (A i * ρ * (A i)ᴴ)) * Sᴴ⁻¹
   -- Use Finset.sum_mul (reversed) and Finset.mul_sum (reversed)
   have h_sum_eq : ∑ i : Fin d, A i * ρ * (A i)ᴴ = ρ := by
-    rw [← transferMap_apply]; exact hfix
+    rw [← Kraus.map_apply]; exact hfix
   -- Rewrite: ∑ i, S⁻¹ * (A i * ρ * (A i)ᴴ) * Sᴴ⁻¹
   --        = (∑ i, S⁻¹ * (A i * ρ * (A i)ᴴ)) * Sᴴ⁻¹
   --        = (S⁻¹ * ∑ i, (A i * ρ * (A i)ᴴ)) * Sᴴ⁻¹
   rw [← Finset.sum_mul, ← Finset.mul_sum, h_sum_eq, ← hSS,
       Matrix.mul_assoc, Matrix.mul_assoc, hStmul_inv, Matrix.mul_one, hSinv_mul]
 
-omit [NeZero D] in
 /-- If `S` is invertible and `Sᴴ * S = σ`, then the gauged operators
-`A'_i = S * A_i * S⁻¹` satisfy `∑ A'_iᴴ * A'_i = I` whenever
-`E_A†(σ) = σ`.
+`A'_i = S * A_i * S⁻¹` satisfy `∑ A'_iᴴ * A'_i = I` whenever the Kraus map of
+the conjugate-transposed family fixes `σ`.
 
 This is the trace-preserving (left-canonical) analogue of `gauged_unital`. -/
 theorem gauged_tracePreserving
-    (A : MPSTensor d D) (S : Matrix (Fin D) (Fin D) ℂ) (σ : Matrix (Fin D) (Fin D) ℂ)
+    (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (S : Matrix (Fin D) (Fin D) ℂ) (σ : Matrix (Fin D) (Fin D) ℂ)
     (hS_inv : S.det ≠ 0)
     (hStS : Sᴴ * S = σ)
-    (hfix : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ) :
+    (hfix : Kraus.map (fun i => (A i)ᴴ) σ = σ) :
     ∑ i : Fin d, (S * A i * S⁻¹)ᴴ * (S * A i * S⁻¹) = 1 := by
   have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S (Ne.isUnit hS_inv)
   have hSmul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S (Ne.isUnit hS_inv)
@@ -90,7 +88,7 @@ theorem gauged_tracePreserving
     simp [Matrix.mul_assoc, ← hStS]
   simp_rw [h_term]
   have h_sum_eq : ∑ i : Fin d, (A i)ᴴ * σ * A i = σ := by
-    simpa [transferMap_apply] using hfix
+    simpa [Kraus.map_apply] using hfix
   rw [← Finset.sum_mul, ← Finset.mul_sum, h_sum_eq, ← hStS,
     Matrix.mul_assoc, Matrix.mul_assoc, hSmul_inv, Matrix.mul_one, hStinv_mul]
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -35,8 +35,6 @@ import TNLean.Channel.Irreducible.FromSpectral
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.Channel.Irreducible.Similarity
-import TNLean.QPF.Assembly
-import TNLean.Wielandt.Primitivity.Equivalence
 import TNLean.Channel.WolfChapter6Wrappers
 
 /-!
@@ -51,6 +49,14 @@ Each entry lists the Wolf result, its status (fully formalized / partially
 formalized / not yet formalized), and the Lean declaration(s) that correspond.
 
 No new proofs are introduced here; this is a documentation-only index module.
+
+This module covers the sections of Wolf Chapter 6 whose formalization lives in
+the quantum-channel layer.  The sections formalized in the tensor-network layer
+— the Kraus-span primitivity characterizations (Theorem 6.8), the quantum
+Wielandt inequality (Theorem 6.9), the unique-fixed-point theorem for tensors
+with eventually full Kraus rank (Theorem 6.15), and the quantum
+Perron–Frobenius assembly — are indexed in
+`TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ---
 
@@ -133,11 +139,8 @@ Channel-level (general irreducible CP maps):
 * `exists_posDef_eigenvector_of_irreducible_cp`: ∃ PosDef eigenvector with `r > 0`
 * `posSemidef_eigenvector_unique_of_irreducible_cp`: uniqueness up to scalar
 
-MPS/QPF-level (transfer maps):
-* `posSemidef_fixedPoint_isPosDef` — `TNLean.QPF.PosDef`
-* `posSemidef_fixedPoint_isPosDef_of_irreducible`
-* `posSemidef_fixedPoint_unique` — `TNLean.QPF.Uniqueness`
-* `posSemidef_fixedPoint_unique_of_irreducible`
+The transfer-map specializations of these fixed-point consequences are indexed
+in `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 **Item 3** (uniqueness of positive eigenvalue):
 * `eigenvalue_unique_of_irreducible_cp` — `TNLean.Channel.Irreducible.PerronFrobenius`
@@ -232,35 +235,18 @@ The abstract positive unital Schwarz-map theorem remains open; see
 * `IsPrimitive` — `TNLean.Channel.Peripheral.Spectrum`
 * `isPrimitive_of_compl_eigenvalues_lt_one` / `compl_eigenvalue_norm_lt_one_of_primitive`
 
-Other items: PARTIALLY via transfer-operator gap formalization in `TNLean.Spectral.*`.
+Other items: PARTIALLY via the transfer-operator gap formalization on the
+tensor-network side; see `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ### Wolf Theorem 6.8 (CP primitive maps, Kraus span characterizations)
 
-* `IsPrimitivePaper` — `TNLean.Wielandt.Primitivity.Definitions`
-  (item 3: `Kₘ = M_d(ℂ)` for `m ≥ q`)
-* Pairwise equivalences from Proposition 3:
-  * `primitivePaper_iff_hasEventuallyFullKrausRank` / `primitivePaper_iff_stronglyIrreducible`
-    (in `TNLean.Wielandt.Primitivity.Equivalence`)
-  * `hasEventuallyFullKrausRank_iff_isNormal`
-    (in `TNLean.Wielandt.Primitivity.Definitions`)
-* Formulated Wolf-facing formulations:
-  * `wolf_theorem_6_8_kraus_span`
-  * `wolf_theorem_6_8_conjunction`
-  (in `TNLean.Wielandt.Primitivity.Equivalence`)
+Formalized in the tensor-network layer; indexed in
+`TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ### Wolf Theorem 6.9 (Quantum Wielandt inequality)
 
-Current formal statements live in `TNLean.Wielandt.Inequality.Bounds`:
-* `qIndex_le_iIndex_of_isPrimitivePaper`
-* `wordSpan_eq_top_of_isPrimitivePaper_of_isUnit` /
-  `iIndex_le_of_isPrimitivePaper_of_isUnit`
-* `wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector` /
-  `iIndex_le_sq_of_noninvertible_eigenvector`
-
-The positive-definite primitive-to-normal theorem is
-`MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef` in
-`TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`; it is not the
-Wielandt index bound itself.
+Formalized in the tensor-network layer; indexed in
+`TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ---
 
@@ -642,23 +628,8 @@ explicit density-block formula is developed in
 
 ### Wolf Theorem 6.15 (Unique fixed point from full Kraus-word span) — FORMALIZED
 
-* `MPSTensor.wolf_theorem_6_15` (`TNLean.Wielandt.Primitivity.Equivalence`) —
-  for a normalized MPS tensor `A` (`∑ᵢ Aᵢ† Aᵢ = 1`) with eventually full Kraus
-  rank (homogeneous words of some fixed length in the Kraus operators span the
-  full matrix algebra), there exists a unique positive definite density matrix
-  `ρ` such that every fixed point of the transfer map `E_A` is a scalar
-  multiple of `ρ`.
-
-The proof routes through Proposition 3:
-`MPSTensor.isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank` turns the
-span hypothesis into strong irreducibility, then
-`MPSTensor.isPrimitiveMPS_of_isStronglyIrreduciblePaper` supplies a
-positive-definite fixed point together with peripheral primitivity and
-irreducibility of `E_A`; the complementary transfer-map gap around that fixed
-point (`MPSTensor.IsPrimitiveMPS.fixedPoint_unique`) then forces every fixed
-point to be a scalar multiple of it. This differs from the source's own `T^n`
-/ Corollary 6.5 argument but reuses only already-formalized Wolf Chapter 6
-machinery (Proposition 3).
+Formalized in the tensor-network layer; indexed in
+`TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ---
 
@@ -727,8 +698,6 @@ clause 3.
 
 ## The quantum Perron–Frobenius theorem
 
-* `quantum_perron_frobenius` — `TNLean.QPF.Assembly`
-  Combines existence + positive definiteness + uniqueness (Wolf Theorem 6.3).
-
-* `injective_transfer_unique_fixed_point'` — same, without `0 < D` hypothesis.
+The assembled quantum Perron–Frobenius theorem for transfer maps lives in the
+tensor-network layer; it is indexed in `TNLean.Wielandt.WolfChapter6TNIndex`.
 -/

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -54,8 +54,8 @@ This module covers the sections of Wolf Chapter 6 whose formalization lives in
 the quantum-channel layer.  The sections formalized in the tensor-network layer
 — the Kraus-span primitivity characterizations (Theorem 6.8), the quantum
 Wielandt inequality (Theorem 6.9), the unique-fixed-point theorem for tensors
-with eventually full Kraus rank (Theorem 6.15), and the quantum
-Perron–Frobenius assembly — are indexed in
+with eventually full Kraus rank (Theorem 6.15), and the assembled quantum
+Perron–Frobenius theorem — are indexed in
 `TNLean.Wielandt.WolfChapter6TNIndex`.
 
 ---

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -210,10 +210,10 @@ theorem gauged_intertwining_core
   let X' : Matrix (Fin D₁) (Fin D₂) ℂ := gaugeEigenvector SA SB X
   have hA'unital : ∑ i : Fin d, A' i * (A' i)ᴴ = 1 := by
     simpa [A', gaugeTensor] using
-      gauged_unital A SA ρA hSA_det hSA_mul hρA_fix
+      gauged_unital A SA ρA hSA_det hSA_mul (by simpa [Kraus.map_apply] using hρA_fix)
   have hB'unital : ∑ i : Fin d, B' i * (B' i)ᴴ = 1 := by
     simpa [B', gaugeTensor] using
-      gauged_unital B SB ρB hSB_det hSB_mul hρB_fix
+      gauged_unital B SB ρB hSB_det hSB_mul (by simpa [Kraus.map_apply] using hρB_fix)
   have hX'ne : X' ≠ 0 := by
     intro h0
     apply hX

--- a/TNLean/Wielandt.lean
+++ b/TNLean/Wielandt.lean
@@ -14,3 +14,4 @@ import TNLean.Wielandt.Primitivity
 import TNLean.Wielandt.RankOne
 import TNLean.Wielandt.RectangularSpan
 import TNLean.Wielandt.SpanGrowth
+import TNLean.Wielandt.WolfChapter6TNIndex

--- a/TNLean/Wielandt/WolfChapter6TNIndex.lean
+++ b/TNLean/Wielandt/WolfChapter6TNIndex.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QPF.Assembly
+import TNLean.Wielandt.Primitivity.Definitions
+import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
+import TNLean.Wielandt.Primitivity.Equivalence
+import TNLean.Wielandt.Inequality.Bounds
+
+/-!
+# Wolf Chapter 6 index: tensor-network side
+
+This module is the tensor-network half of the navigational index for
+
+> M. Wolf, *Quantum Channels & Operations: Guided Tour* (2012), Chapter 6.
+
+It records the sections of Wolf Chapter 6 whose formalization lives in the
+tensor-network layer (`TNLean.Wielandt.*`, `TNLean.QPF.*`, `TNLean.MPS.*`,
+`TNLean.Spectral.*`): the Kraus-span primitivity characterizations, the
+quantum Wielandt inequality, the unique-fixed-point theorem for tensors with
+eventually full Kraus rank, and the quantum Perron–Frobenius assembly.
+
+The channel-level sections of the index are in
+`TNLean.Channel.WolfChapter6Index`; that module contains the entries whose
+formalization lives in the quantum-channel layer and does not depend on the
+tensor-network layer.
+
+No new proofs are introduced here; this is a documentation-only index module.
+
+---
+
+## Section 6.2 Irreducible maps and Perron–Frobenius theory
+
+### Wolf Theorem 6.3 (Spectral radius of irreducible maps) — TRANSFER-MAP SPECIALIZATIONS
+
+The channel-level entries for Theorem 6.3 are in
+`TNLean.Channel.WolfChapter6Index`.  The transfer-map specializations of the
+fixed-point consequences of items 2–3 (strict positivity and PSD uniqueness):
+
+* `posSemidef_fixedPoint_isPosDef` — `TNLean.QPF.PosDef`
+* `posSemidef_fixedPoint_isPosDef_of_irreducible`
+* `posSemidef_fixedPoint_unique` — `TNLean.QPF.Uniqueness`
+* `posSemidef_fixedPoint_unique_of_irreducible`
+
+---
+
+## Section 6.3 Primitive maps
+
+### Wolf Theorem 6.7 (Primitive maps, 4 equivalent conditions) — TRANSFER-OPERATOR GAP SIDE
+
+Item 4 (trivial peripheral spectrum, PD eigenvector) is channel-level; see
+`TNLean.Channel.WolfChapter6Index`.  The other items are PARTIALLY covered via
+the transfer-operator gap formalization in `TNLean.Spectral.*`.
+
+### Wolf Theorem 6.8 (CP primitive maps, Kraus span characterizations)
+
+* `IsPrimitivePaper` — `TNLean.Wielandt.Primitivity.Definitions`
+  (item 3: `Kₘ = M_d(ℂ)` for `m ≥ q`)
+* Pairwise equivalences from Proposition 3:
+  * `primitivePaper_iff_hasEventuallyFullKrausRank` / `primitivePaper_iff_stronglyIrreducible`
+    (in `TNLean.Wielandt.Primitivity.Equivalence`)
+  * `hasEventuallyFullKrausRank_iff_isNormal`
+    (in `TNLean.Wielandt.Primitivity.Definitions`)
+* Formulated Wolf-facing formulations:
+  * `wolf_theorem_6_8_kraus_span`
+  * `wolf_theorem_6_8_conjunction`
+  (in `TNLean.Wielandt.Primitivity.Equivalence`)
+
+### Wolf Theorem 6.9 (Quantum Wielandt inequality)
+
+Current formal statements live in `TNLean.Wielandt.Inequality.Bounds`:
+* `qIndex_le_iIndex_of_isPrimitivePaper`
+* `wordSpan_eq_top_of_isPrimitivePaper_of_isUnit` /
+  `iIndex_le_of_isPrimitivePaper_of_isUnit`
+* `wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector` /
+  `iIndex_le_sq_of_noninvertible_eigenvector`
+
+The positive-definite primitive-to-normal theorem is
+`MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef` in
+`TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`; it is not the
+Wielandt index bound itself.
+
+---
+
+## Section 6.4 Fixed points
+
+### Wolf Theorem 6.15 (Unique fixed point from full Kraus-word span) — FORMALIZED
+
+* `MPSTensor.wolf_theorem_6_15` (`TNLean.Wielandt.Primitivity.Equivalence`) —
+  for a normalized MPS tensor `A` (`∑ᵢ Aᵢ† Aᵢ = 1`) with eventually full Kraus
+  rank (homogeneous words of some fixed length in the Kraus operators span the
+  full matrix algebra), there exists a unique positive definite density matrix
+  `ρ` such that every fixed point of the transfer map `E_A` is a scalar
+  multiple of `ρ`.
+
+The proof routes through Proposition 3:
+`MPSTensor.isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank` turns the
+span hypothesis into strong irreducibility, then
+`MPSTensor.isPrimitiveMPS_of_isStronglyIrreduciblePaper` supplies a
+positive-definite fixed point together with peripheral primitivity and
+irreducibility of `E_A`; the complementary transfer-map gap around that fixed
+point (`MPSTensor.IsPrimitiveMPS.fixedPoint_unique`) then forces every fixed
+point to be a scalar multiple of it. This differs from the source's own `T^n`
+/ Corollary 6.5 argument but reuses only already-formalized Wolf Chapter 6
+machinery (Proposition 3).
+
+---
+
+## The quantum Perron–Frobenius theorem
+
+* `quantum_perron_frobenius` — `TNLean.QPF.Assembly`
+  Combines existence + positive definiteness + uniqueness (Wolf Theorem 6.3).
+
+* `injective_transfer_unique_fixed_point'` — same, without `0 < D` hypothesis.
+-/

--- a/TNLean/Wielandt/WolfChapter6TNIndex.lean
+++ b/TNLean/Wielandt/WolfChapter6TNIndex.lean
@@ -20,7 +20,8 @@ It records the sections of Wolf Chapter 6 whose formalization lives in the
 tensor-network layer (`TNLean.Wielandt.*`, `TNLean.QPF.*`, `TNLean.MPS.*`,
 `TNLean.Spectral.*`): the Kraus-span primitivity characterizations, the
 quantum Wielandt inequality, the unique-fixed-point theorem for tensors with
-eventually full Kraus rank, and the quantum Perron–Frobenius assembly.
+eventually full Kraus rank, and the assembled quantum Perron–Frobenius
+theorem.
 
 The channel-level sections of the index are in
 `TNLean.Channel.WolfChapter6Index`; that module contains the entries whose


### PR DESCRIPTION
Part of #6560 (decoupling the quantum-channel layer from the MPS layer).

## What this does

* **`TNLean/Channel/WolfChapter6Index.lean`** no longer imports `TNLean.QPF.Assembly` or `TNLean.Wielandt.Primitivity.Equivalence`. The index entries whose formalization lives in the tensor-network layer are excised into a new module:
  * Wolf Theorem 6.8 (CP primitive maps, Kraus span characterizations),
  * Wolf Theorem 6.9 (quantum Wielandt inequality),
  * Wolf Theorem 6.15 (unique fixed point from full Kraus-word span),
  * the transfer-map specializations of Wolf Theorem 6.3,
  * the assembled quantum Perron–Frobenius theorem.
* **`TNLean/Wielandt/WolfChapter6TNIndex.lean`** (new) is the tensor-network half of the index; the two halves cross-reference each other by module name.
* **`TNLean/Channel/FixedPoint/CanonicalGauge.lean`** is restated over the generic finite Kraus map `Kraus.map` from `TNLean.Channel.Schwarz.Basic`, dropping its `TNLean.QPF.Assembly` and `TNLean.Spectral.MixedTransfer` imports. The names and conclusions of `gauged_unital` and `gauged_tracePreserving` are unchanged; only the fixed-point hypothesis is phrased through `Kraus.map` instead of the MPS transfer map. `TNLean.Channel.Semigroup.Primitivity.Helpers` compiles unmodified; `TNLean.Spectral.GaugeConstruction` adapts its two call sites with one-line `simpa` bridges.
* `TNLean/Wielandt.lean` aggregator regenerated.

## Verification

* `lake build TNLean.Channel.WolfChapter6Index TNLean.Wielandt.WolfChapter6TNIndex TNLean.Channel.FixedPoint.CanonicalGauge TNLean.Spectral.GaugeConstruction TNLean.Channel.Semigroup.Primitivity.Helpers TNLean.MPS.Symmetry.StringOrderAux TNLean.Channel TNLean.Wielandt` — no errors, no warnings.
* `rg "^import TNLean.(MPS|QPF|Wielandt|Spectral)"` on the two channel files is empty.
* No `sorry`/`axiom`; `scripts/generate_import_aggregators.py --check` current; `scripts/blueprint_lean_sync.py` in sync.