### PR TITLE
doc(wielandt): state the index boundary as direct imports

### DIFF
--- a/TNLean/Wielandt/WolfChapter6TNIndex.lean
+++ b/TNLean/Wielandt/WolfChapter6TNIndex.lean
@@ -25,8 +25,10 @@ theorem.
 
 The channel-level sections of the index are in
 `TNLean.Channel.WolfChapter6Index`; that module contains the entries whose
-formalization lives in the quantum-channel layer and does not depend on the
-tensor-network layer.
+formalization lives in the quantum-channel layer and does not directly import
+the tensor-network layer. A residual transitive dependence remains through the
+Perron--Frobenius modules while the decoupling of the channel layer is in
+progress.
 
 No new proofs are introduced here; this is a documentation-only index module.
 


### PR DESCRIPTION
Follow-up to #6573, addressing the remaining review item that arrived between that PR's final CI run and its merge: the new index module's docstring claimed the channel-side index "does not depend on the tensor-network layer", which is accurate only for direct imports — a transitive dependence remains through the Perron–Frobenius modules until the #6560 decoupling completes. The sentence now states the direct-import boundary and notes the residual transitive dependence. Documentation-only.