### PR TITLE
refactor(channel/peripheral): channel-level uniqueness in PeripheralUnitary

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Channel.Irreducible.FixedPointUniqueness
 import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
+import TNLean.MPS.Core.CPPrimitive
 
 /-!
 # Peripheral unitaries for irreducible Schwarz maps
@@ -31,7 +32,7 @@ Kraus families.
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset Complex
-open MPSTensor (transferMap transferMap_apply)
+open MPSTensor (transferMap transferMap_apply transferMap_isCPMap)
 
 namespace Kraus
 
@@ -63,9 +64,8 @@ private theorem hermitian_fixed_eq_scalar_of_irreducible_unital
               rw [LinearMap.map_smul]
       _ = H - (c0 : ℂ) • 1 := by simp only [hfix, hone_fix, Complex.coe_smul]
   have hone_psd : (1 : MatrixAlg D).PosSemidef := Matrix.PosSemidef.one
-  have hCP : IsCPMap (transferMap (d := r) (D := D) K) := by
-    rw [← Kraus.mapLM_eq_transferMap]; exact Kraus.isCPMap_mapLM K
-  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K) hCP hIrr
+  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K)
+      (transferMap_isCPMap K) hIrr
       (1 : MatrixAlg D) (H - (c0 : ℂ) • 1) hone_psd one_ne_zero hshift_psd hone_fix hshift_fix with
     ⟨d, hd⟩
   refine ⟨d + c0, ?_⟩
@@ -224,9 +224,8 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
   have hone_fix : transferMap (d := r) (D := D) K (1 : MatrixAlg D) = 1 := by
     simpa [MPSTensor.transferMap_apply, KadisonSchwarz.krausMap,
       KadisonSchwarz.IsUnitalKraus] using hUnital
-  have hCP : IsCPMap (transferMap (d := r) (D := D) K) := by
-    rw [← Kraus.mapLM_eq_transferMap]; exact Kraus.isCPMap_mapLM K
-  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K) hCP hIrr
+  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K)
+      (transferMap_isCPMap K) hIrr
       (1 : MatrixAlg D) (Xᴴ * X) hone_psd one_ne_zero hXX_psd hone_fix hXX_fix with ⟨c, hXX_scalar⟩
   have hc_ne0 : c ≠ 0 := by
     intro hc0

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Irreducible.FixedPointUniqueness
 import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
-import TNLean.QPF.Uniqueness
 
 /-!
 # Peripheral unitaries for irreducible Schwarz maps
@@ -31,7 +31,7 @@ Kraus families.
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset Complex
-open MPSTensor (transferMap transferMap_apply posSemidef_fixedPoint_unique_of_irreducible)
+open MPSTensor (transferMap transferMap_apply)
 
 namespace Kraus
 
@@ -63,7 +63,9 @@ private theorem hermitian_fixed_eq_scalar_of_irreducible_unital
               rw [LinearMap.map_smul]
       _ = H - (c0 : ℂ) • 1 := by simp only [hfix, hone_fix, Complex.coe_smul]
   have hone_psd : (1 : MatrixAlg D).PosSemidef := Matrix.PosSemidef.one
-  rcases posSemidef_fixedPoint_unique_of_irreducible (A := K) hIrr
+  have hCP : IsCPMap (transferMap (d := r) (D := D) K) := by
+    rw [← Kraus.mapLM_eq_transferMap]; exact Kraus.isCPMap_mapLM K
+  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K) hCP hIrr
       (1 : MatrixAlg D) (H - (c0 : ℂ) • 1) hone_psd one_ne_zero hshift_psd hone_fix hshift_fix with
     ⟨d, hd⟩
   refine ⟨d + c0, ?_⟩
@@ -222,7 +224,9 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
   have hone_fix : transferMap (d := r) (D := D) K (1 : MatrixAlg D) = 1 := by
     simpa [MPSTensor.transferMap_apply, KadisonSchwarz.krausMap,
       KadisonSchwarz.IsUnitalKraus] using hUnital
-  rcases posSemidef_fixedPoint_unique_of_irreducible (A := K) hIrr
+  have hCP : IsCPMap (transferMap (d := r) (D := D) K) := by
+    rw [← Kraus.mapLM_eq_transferMap]; exact Kraus.isCPMap_mapLM K
+  rcases posSemidef_fixedPoint_unique_of_irreducible_cp (transferMap (d := r) (D := D) K) hCP hIrr
       (1 : MatrixAlg D) (Xᴴ * X) hone_psd one_ne_zero hXX_psd hone_fix hXX_fix with ⟨c, hXX_scalar⟩
   have hc_ne0 : c ≠ 0 := by
     intro hc0

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -573,14 +573,14 @@ projections, and tracking how the channel shifts the resulting corners.
     \label{lem:irreducible_unital_fixed_points_scalar}
     \lean{Kraus.fixed_eq_scalar_of_irreducible_unital}
     \leanok
-    \uses{thm:psd_fp_unique_irred}
+    \uses{thm:psd_fp_unique_irred_cp}
     If $E$ is irreducible and unital, then every fixed point of $E$ is a
     scalar multiple of $\Id$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    \uses{thm:psd_fp_unique_irred}
+    \uses{thm:psd_fp_unique_irred_cp}
     If $E(X)=X$, then the Hermitian matrices
     $X+X^\dagger$ and $\mathrm{i}(X-X^\dagger)$ are also fixed by $E$.
     The positive-semidefinite fixed-point uniqueness theorem gives
@@ -594,7 +594,7 @@ projections, and tracking how the channel shifts the resulting corners.
     \lean{Kraus.exists_peripheral_unitary_of_irreducible_schwarz}
     \leanok
     \uses{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint,
-        thm:psd_fp_unique_irred}
+        thm:psd_fp_unique_irred_cp}
     For an irreducible unital Schwarz map with faithful adjoint fixed point,
     each peripheral eigenvalue admits a unitary eigenvector.
 \end{lemma}


### PR DESCRIPTION
## Summary
- Rewires `PeripheralUnitary.lean` to call the channel-level fixed-point uniqueness lemma `posSemidef_fixedPoint_unique_of_irreducible_cp` (`TNLean/Channel/Irreducible/FixedPointUniqueness.lean`, hoisted in #6561) directly, in place of the MPS-transfer-map-local wrapper `posSemidef_fixedPoint_unique_of_irreducible` (`TNLean/QPF/Uniqueness.lean`), at both call sites.
- Supplies the required `IsCPMap` hypothesis with `transferMap_isCPMap K` (`TNLean/MPS/Core/CPPrimitive.lean`) instead of the previous `Kraus.mapLM_eq_transferMap`/`Kraus.isCPMap_mapLM` derivation, removing a redundant round trip through `Kraus.mapLM` and this file's only reference to a `TNLean.MPS.Core.TransferChannel`-defined lemma.
- No theorem signatures change; internal proof-term construction only.
- Updates two stale `\uses{thm:psd_fp_unique_irred}` blueprint tags in `ch07_spectral.tex` to `\uses{thm:psd_fp_unique_irred_cp}`, matching the lemma now actually invoked.

Part of #6560; item 3 of #6569.

## Test plan
- `lake build TNLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary` — success.
- `lake build` on the four direct importers (`TNLean.MPS.Irreducible.ScalarFixedPoint`, `TNLean.Channel.Peripheral`, `TNLean.Channel.Peripheral.CyclicDecomposition`, `TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition`) — success.
- `rg -n "sorry|axiom"` on the changed file — clean.
- `scripts/blueprint_lean_sync.py` — in sync.