### PR TITLE
ci(scripts): guard import direction across the channel boundary

### DIFF
--- a/.github/workflows/import-completeness.yml
+++ b/.github/workflows/import-completeness.yml
@@ -10,6 +10,9 @@ on:
       - 'scripts/generate_import_aggregators.py'
       - 'scripts/lean_import_syntax.py'
       - 'scripts/test_generate_import_aggregators.py'
+      - 'scripts/check_import_direction.py'
+      - 'scripts/test_check_import_direction.py'
+      - 'scripts/qic_layer0_modules.txt'
       - '.github/workflows/import-completeness.yml'
   pull_request:
     types: [opened, synchronize, reopened]
@@ -19,6 +22,9 @@ on:
       - 'scripts/generate_import_aggregators.py'
       - 'scripts/lean_import_syntax.py'
       - 'scripts/test_generate_import_aggregators.py'
+      - 'scripts/check_import_direction.py'
+      - 'scripts/test_check_import_direction.py'
+      - 'scripts/qic_layer0_modules.txt'
       - '.github/workflows/import-completeness.yml'
   workflow_dispatch:
 
@@ -33,7 +39,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      # fetch-depth: 0 is required for the import-direction guard's
+      # namespace-ratchet merge-base lookup below.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -41,3 +51,35 @@ jobs:
         run: PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v
       - name: Check generated import aggregators
         run: PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check
+      - name: Test import-direction guard
+        run: PYTHONPATH=scripts python3 scripts/test_check_import_direction.py -v
+
+      # Fetch the pull-request/push base so the `namespace MPSTensor` ratchet
+      # can tell a newly proposed allowlist entry from an inherited one (same
+      # pattern as scripts/check_numbered_lean_files.py in pr-ci.yml).
+      - name: Fetch base for the namespace-ratchet allowlist
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Check import direction across the channel boundary (pull request)
+        if: github.event_name == 'pull_request'
+        run: >
+          PYTHONPATH=scripts python3 scripts/check_import_direction.py
+          --root .
+          --base-ref "origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Check import direction across the channel boundary (push)
+        if: github.event_name == 'push'
+        run: >
+          PYTHONPATH=scripts python3 scripts/check_import_direction.py
+          --root .
+          --base-ref "${{ github.event.before }}"
+
+      - name: Check import direction across the channel boundary (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: >
+          PYTHONPATH=scripts python3 scripts/check_import_direction.py
+          --root .
+          --base-ref HEAD^

--- a/scripts/check_import_direction.py
+++ b/scripts/check_import_direction.py
@@ -53,17 +53,11 @@ FORBIDDEN_PREFIXES: tuple[str, ...] = (
 
 NAMESPACE_MPSTENSOR_RE = re.compile(r"(?m)^[ \t]*namespace\s+MPSTensor\b")
 
-# Shrinking-only ratchet (see scripts/check_numbered_lean_files.py). Seeded
-# with the offender found by
-# `rg -l "namespace MPSTensor" TNLean/Channel TNLean/Entropy` when this
-# checker was introduced. New entries are rejected; existing entries are
-# expected to be cleared by the in-flight edge-cutting PRs tracked under
-# ISSUE_CITATION.
-NAMESPACE_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "TNLean/Channel/PerronFrobenius/Existence.lean",
-    }
-)
+# Shrinking-only ratchet (see scripts/check_numbered_lean_files.py). The
+# boundary directories carry no `namespace MPSTensor` declarations today, so
+# the allowlist is empty; the ratchet rejects any new entry, keeping the
+# QIC-bound set free of tensor-network namespaces.
+NAMESPACE_ALLOWLIST: frozenset[str] = frozenset()
 
 
 def _forbidden_module(module: str) -> bool:

--- a/scripts/check_import_direction.py
+++ b/scripts/check_import_direction.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Guard the import direction across the channel/tensor-network boundary.
+
+``TNLean/Channel``, ``TNLean/Entropy``, and (once created) ``TNLean/Kraus``
+hold the quantum-channel and entropy theory being prepared for extraction
+into a standalone library, QICLean (issue LionSR/TNLean#6560). Until that
+extraction lands, these directories — together with the foundation modules
+listed in ``scripts/qic_layer0_modules.txt`` — form the QIC-bound set and
+must not import the tensor-network side of the monorepo: ``TNLean.MPS``,
+``TNLean.QPF``, ``TNLean.Wielandt``, ``TNLean.Spectral``, ``TNLean.PEPS``,
+``TNLean.QCA``, or ``TNLean.PiAlgebra``.
+
+A secondary, shrinking-only ratchet (the pattern used by
+``check_numbered_lean_files.py``) forbids new ``namespace MPSTensor``
+declarations inside ``TNLean/Channel`` and ``TNLean/Entropy`` files outside
+a hardcoded allowlist of known offenders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+import re
+import subprocess
+
+from lean_import_syntax import IMPORT_COMMAND_RE, strip_lean_comments
+
+ISSUE_CITATION = "issue LionSR/TNLean#6560"
+
+# Directories whose entire tree is QIC-bound. `TNLean/Kraus` does not exist
+# yet (Phase 3 of the tracked extraction creates it); scanning tolerates its
+# absence.
+QIC_BOUND_DIRECTORIES: tuple[str, ...] = ("TNLean/Channel", "TNLean/Entropy", "TNLean/Kraus")
+
+# Only these two directories are scanned for the `namespace MPSTensor` ratchet;
+# `TNLean/Kraus` is not yet populated and manifest-only entries are exempt.
+NAMESPACE_CHECK_DIRECTORIES: tuple[str, ...] = ("TNLean/Channel", "TNLean/Entropy")
+
+MANIFEST_PATH = Path("scripts/qic_layer0_modules.txt")
+
+# Module prefixes belonging to the tensor-network side of the boundary. A
+# QIC-bound file may not import any of these, exactly or as a sub-module.
+FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "TNLean.MPS",
+    "TNLean.QPF",
+    "TNLean.Wielandt",
+    "TNLean.Spectral",
+    "TNLean.PEPS",
+    "TNLean.QCA",
+    "TNLean.PiAlgebra",
+)
+
+NAMESPACE_MPSTENSOR_RE = re.compile(r"(?m)^[ \t]*namespace\s+MPSTensor\b")
+
+# Shrinking-only ratchet (see scripts/check_numbered_lean_files.py). Seeded
+# with the offender found by
+# `rg -l "namespace MPSTensor" TNLean/Channel TNLean/Entropy` when this
+# checker was introduced. New entries are rejected; existing entries are
+# expected to be cleared by the in-flight edge-cutting PRs tracked under
+# ISSUE_CITATION.
+NAMESPACE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "TNLean/Channel/PerronFrobenius/Existence.lean",
+    }
+)
+
+
+def _forbidden_module(module: str) -> bool:
+    return any(
+        module == prefix or module.startswith(f"{prefix}.") for prefix in FORBIDDEN_PREFIXES
+    )
+
+
+def imports_of(path: Path) -> tuple[list[tuple[int, str]], str | None]:
+    """Return the ``(line, module)`` import commands in *path*, or a parse error.
+
+    Unlike ``lean_import_syntax.pure_import_modules``, this tolerates lines
+    that are not import commands: QIC-bound files are ordinary Lean modules,
+    not import-only aggregators.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        return [], f"cannot read file: {error}"
+    uncommented, error = strip_lean_comments(source)
+    if error is not None:
+        return [], error
+    imports: list[tuple[int, str]] = []
+    for line_no, line in enumerate(uncommented.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = IMPORT_COMMAND_RE.fullmatch(stripped)
+        if match is not None:
+            imports.append((line_no, match.group(1)))
+    return imports, None
+
+
+def qic_bound_directory_files(root: Path) -> set[Path]:
+    """Return QIC-bound ``.lean`` files found by scanning the bound directories."""
+    files: set[Path] = set()
+    for directory in QIC_BOUND_DIRECTORIES:
+        dir_path = root / directory
+        if not dir_path.is_dir():
+            continue
+        files.update(path.relative_to(root) for path in dir_path.rglob("*.lean"))
+    return files
+
+
+def manifest_entries(root: Path) -> tuple[list[tuple[int, Path]], list[str]]:
+    """Parse ``MANIFEST_PATH`` and return its ``(line, path)`` entries and errors."""
+    manifest_path = root / MANIFEST_PATH
+    entries: list[tuple[int, Path]] = []
+    errors: list[str] = []
+    if not manifest_path.is_file():
+        errors.append(f"{MANIFEST_PATH}: manifest file is missing")
+        return entries, errors
+    for line_no, raw_line in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append((line_no, Path(line)))
+    return entries, errors
+
+
+def check_manifest_hygiene(root: Path, entries: list[tuple[int, Path]]) -> list[str]:
+    """Return an error for every manifest entry whose file no longer exists."""
+    errors: list[str] = []
+    for line_no, relative in entries:
+        if not (root / relative).is_file():
+            errors.append(
+                f"{MANIFEST_PATH}:{line_no}: stale manifest entry {relative.as_posix()} "
+                "— file no longer exists, remove it from the manifest"
+            )
+    return errors
+
+
+def check_import_direction(root: Path) -> tuple[list[str], int]:
+    """Check the forbidden-import rule; return (errors, files checked)."""
+    manifest_entries_list, manifest_errors = manifest_entries(root)
+    errors = list(manifest_errors)
+    errors.extend(check_manifest_hygiene(root, manifest_entries_list))
+
+    manifest_files = {
+        relative for _, relative in manifest_entries_list if (root / relative).is_file()
+    }
+    targets = qic_bound_directory_files(root) | manifest_files
+    checked = 0
+    for relative in sorted(targets, key=lambda path: path.as_posix()):
+        path = root / relative
+        if path.suffix != ".lean" or not path.is_file():
+            continue
+        checked += 1
+        imports, error = imports_of(path)
+        if error is not None:
+            errors.append(f"{relative.as_posix()}: cannot parse imports: {error}")
+            continue
+        for line_no, module in imports:
+            if _forbidden_module(module):
+                errors.append(
+                    f"{relative.as_posix()}:{line_no}: forbidden import `{module}` — "
+                    "QIC-bound files must not import the tensor-network side of the "
+                    f"boundary ({ISSUE_CITATION})"
+                )
+    return errors, checked
+
+
+def channel_entropy_namespace_offenders(root: Path) -> set[str]:
+    """Return QIC-bound files declaring ``namespace MPSTensor``."""
+    offenders: set[str] = set()
+    for directory in NAMESPACE_CHECK_DIRECTORIES:
+        dir_path = root / directory
+        if not dir_path.is_dir():
+            continue
+        for path in dir_path.rglob("*.lean"):
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            uncommented, error = strip_lean_comments(source)
+            if error is not None:
+                continue
+            if NAMESPACE_MPSTENSOR_RE.search(uncommented):
+                offenders.add(path.relative_to(root).as_posix())
+    return offenders
+
+
+def check_namespace_ratchet(
+    root: Path,
+    allowlist: frozenset[str] = NAMESPACE_ALLOWLIST,
+    base_allowlist: frozenset[str] | None = None,
+) -> list[str]:
+    """Check the `namespace MPSTensor` ratchet; return violation messages."""
+    errors: list[str] = []
+    offenders = channel_entropy_namespace_offenders(root)
+
+    if base_allowlist is not None:
+        for entry in sorted(allowlist - base_allowlist):
+            errors.append(
+                f"{entry}: added to NAMESPACE_ALLOWLIST; this set may only shrink"
+            )
+
+    for entry in sorted(allowlist):
+        if entry not in offenders:
+            errors.append(
+                f"{entry}: stale NAMESPACE_ALLOWLIST entry; remove it now that the "
+                "declaration is gone"
+            )
+
+    unexplained = offenders - allowlist
+    for entry in sorted(unexplained):
+        errors.append(
+            f"{entry}: new `namespace MPSTensor` declaration inside the QIC-bound "
+            f"layer; move it to the MPS side or extend NAMESPACE_ALLOWLIST with "
+            f"justification ({ISSUE_CITATION})"
+        )
+    return errors
+
+
+def _allowlist_from_source(source: str, variable_name: str) -> frozenset[str]:
+    """Read a literal ``frozenset`` module-level assignment from checker source."""
+    tree = ast.parse(source)
+    for statement in tree.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+        if not any(
+            isinstance(target, ast.Name) and target.id == variable_name for target in targets
+        ):
+            continue
+        value = statement.value
+        if (
+            not isinstance(value, ast.Call)
+            or not isinstance(value.func, ast.Name)
+            or value.func.id != "frozenset"
+            or len(value.args) != 1
+            or value.keywords
+        ):
+            raise ValueError(f"{variable_name} must be a literal frozenset")
+        parsed = ast.literal_eval(value.args[0])
+        if not isinstance(parsed, set) or not all(isinstance(entry, str) for entry in parsed):
+            raise ValueError(f"{variable_name} must contain only literal paths")
+        return frozenset(parsed)
+    raise ValueError(f"{variable_name} assignment not found")
+
+
+def _namespace_allowlist_at_merge_base(root: Path, base_ref: str) -> frozenset[str] | None:
+    """Return NAMESPACE_ALLOWLIST at the merge base with *base_ref*.
+
+    ``None`` is returned only while this checker is first introduced and is
+    therefore absent from the base revision.
+    """
+    merge_base = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "HEAD", base_ref],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if merge_base.returncode != 0:
+        raise ValueError(f"cannot find merge base with {base_ref}: {merge_base.stderr.strip()}")
+    base_commit = merge_base.stdout.strip()
+    result = subprocess.run(
+        ["git", "-C", str(root), "show", f"{base_commit}:scripts/check_import_direction.py"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        missing_path = (
+            "does not exist in" in result.stderr or "exists on disk, but not in" in result.stderr
+        )
+        if missing_path:
+            return None
+        raise ValueError(
+            f"cannot read checker at merge base {base_commit}: {result.stderr.strip()}"
+        )
+    return _allowlist_from_source(result.stdout, "NAMESPACE_ALLOWLIST")
+
+
+def check_all(root: Path, base_allowlist: frozenset[str] | None = None) -> int:
+    """Run both checks against *root* and return a process exit status."""
+    import_errors, checked = check_import_direction(root)
+    namespace_errors = check_namespace_ratchet(
+        root, allowlist=NAMESPACE_ALLOWLIST, base_allowlist=base_allowlist
+    )
+    errors = import_errors + namespace_errors
+
+    for message in errors:
+        path = message.split(":", 1)[0]
+        print(f"::error file={path},title=Import-direction guard::{message}")
+
+    print(
+        f"Checked {checked} QIC-bound Lean file(s) against the tensor-network "
+        f"import boundary: {len(import_errors)} import-direction violation(s), "
+        f"{len(namespace_errors)} namespace-ratchet violation(s)."
+    )
+    if errors:
+        print(f"::error::Import-direction guard failed ({ISSUE_CITATION}).")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Guard the import direction across the channel/tensor-network boundary."
+    )
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root")
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "Pull-request merge-base ref used to enforce that the "
+            "namespace-ratchet allowlist only shrinks"
+        ),
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    base_allowlist: frozenset[str] | None = None
+    if args.base_ref is not None:
+        try:
+            base_allowlist = _namespace_allowlist_at_merge_base(root, args.base_ref)
+        except (SyntaxError, ValueError) as error:
+            print(f"::error title=Import-direction guard failed::{error}")
+            return 1
+        if base_allowlist is None:
+            print(
+                "Initializing the namespace-ratchet baseline: the checker is absent "
+                f"from {args.base_ref}."
+            )
+    return check_all(root, base_allowlist=base_allowlist)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qic_layer0_modules.txt
+++ b/scripts/qic_layer0_modules.txt
@@ -1,0 +1,16 @@
+# Foundation modules assigned to the extracted quantum-channel library
+# (QICLean; see issue LionSR/TNLean#6560, Phase 3). Each entry is a
+# repository-relative Lean file path, one per line; blank lines and lines
+# starting with `#` are ignored.
+#
+# This manifest is the future single source of truth for the extraction
+# file list. Until the layer-0 foundation modules (Algebra/, Analysis/,
+# Topology/, Axioms/ files that only the channel/entropy layer depends on)
+# are identified and assigned here, this file stays empty: today the
+# channel/tensor-network boundary is enforced only for TNLean/Channel/,
+# TNLean/Entropy/, and TNLean/Kraus/, checked directly by directory in
+# scripts/check_import_direction.py.
+#
+# scripts/check_import_direction.py additionally enforces that every entry
+# below names a file that still exists (a stale-entry check), so this
+# manifest cannot silently drift from the tree as files move or get renamed.

--- a/scripts/test_check_import_direction.py
+++ b/scripts/test_check_import_direction.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Unit tests for the channel/tensor-network import-direction guard."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import check_import_direction as guard
+
+
+class ImportDirectionGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, relative: str, content: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def write_manifest(self, content: str) -> Path:
+        return self.write(str(guard.MANIFEST_PATH), content)
+
+    def capture_check_all(self) -> tuple[int, str]:
+        # Isolate tests from the real repository's seeded NAMESPACE_ALLOWLIST
+        # offender, which does not exist in these synthetic temp trees.
+        output = io.StringIO()
+        with mock.patch.object(guard, "NAMESPACE_ALLOWLIST", frozenset()), \
+                contextlib.redirect_stdout(output):
+            status = guard.check_all(self.root)
+        return status, output.getvalue()
+
+    # -- Clean pass ---------------------------------------------------------
+
+    def test_clean_tree_passes(self) -> None:
+        self.write_manifest("# empty manifest\n")
+        self.write(
+            "TNLean/Channel/Basic.lean",
+            "import TNLean.Algebra.Matrix\nimport TNLean.Channel.Choi\n\ndef foo := 1\n",
+        )
+        status, output = self.capture_check_all()
+        self.assertEqual(status, 0)
+        self.assertIn("0 import-direction violation(s)", output)
+        self.assertIn("0 namespace-ratchet violation(s)", output)
+
+    def test_absent_qic_directories_are_tolerated(self) -> None:
+        # TNLean/Kraus does not exist yet; TNLean/Channel and TNLean/Entropy
+        # are absent too in this synthetic tree. The checker must not crash.
+        self.write_manifest("# empty manifest\n")
+        status, output = self.capture_check_all()
+        self.assertEqual(status, 0)
+        self.assertIn("Checked 0 QIC-bound Lean file(s)", output)
+
+    # -- Forbidden import -----------------------------------------------------
+
+    def test_forbidden_import_reported(self) -> None:
+        self.write_manifest("")
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "import TNLean.Channel.Basic\nimport TNLean.MPS.Core.TPGauge\n",
+        )
+        errors, checked = guard.check_import_direction(self.root)
+        self.assertEqual(checked, 1)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("TNLean/Channel/Foo.lean:2", errors[0])
+        self.assertIn("TNLean.MPS.Core.TPGauge", errors[0])
+        self.assertIn("LionSR/TNLean#6560", errors[0])
+
+    def test_every_forbidden_prefix_is_rejected(self) -> None:
+        self.write_manifest("")
+        forbidden_modules = (
+            "TNLean.MPS.Core.TPGauge",
+            "TNLean.QPF.Uniqueness",
+            "TNLean.Wielandt.Basic",
+            "TNLean.Spectral.Radius",
+            "TNLean.PEPS.Basic",
+            "TNLean.QCA.Basic",
+            "TNLean.PiAlgebra.Basic",
+        )
+        content = "\n".join(f"import {module}" for module in forbidden_modules) + "\n"
+        self.write("TNLean/Channel/Foo.lean", content)
+        errors, _ = guard.check_import_direction(self.root)
+        self.assertEqual(len(errors), len(forbidden_modules))
+        for module in forbidden_modules:
+            self.assertTrue(any(module in error for error in errors), module)
+
+    def test_allowed_channel_side_imports_are_not_flagged(self) -> None:
+        self.write_manifest("")
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "import TNLean.Channel.Choi\nimport TNLean.Entropy.Basic\n"
+            "import TNLean.Algebra.Matrix\n",
+        )
+        errors, _ = guard.check_import_direction(self.root)
+        self.assertEqual(errors, [])
+
+    # -- Comment masking ------------------------------------------------------
+
+    def test_comment_masked_import_ignored(self) -> None:
+        self.write_manifest("")
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "-- import TNLean.MPS.Core.TPGauge\n"
+            "/- import TNLean.QPF.Uniqueness -/\n"
+            "import TNLean.Channel.Basic\n",
+        )
+        errors, checked = guard.check_import_direction(self.root)
+        self.assertEqual(checked, 1)
+        self.assertEqual(errors, [])
+
+    # -- Manifest entries -------------------------------------------------------
+
+    def test_manifest_listed_file_violation(self) -> None:
+        self.write(
+            "TNLean/Algebra/QicFoundation.lean",
+            "import TNLean.MPS.Core.TPGauge\n",
+        )
+        self.write_manifest("TNLean/Algebra/QicFoundation.lean\n")
+        errors, checked = guard.check_import_direction(self.root)
+        self.assertEqual(checked, 1)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("TNLean/Algebra/QicFoundation.lean:1", errors[0])
+        self.assertIn("TNLean.MPS.Core.TPGauge", errors[0])
+
+    def test_manifest_comments_and_blank_lines_are_skipped(self) -> None:
+        self.write("TNLean/Algebra/QicFoundation.lean", "def foo := 1\n")
+        self.write_manifest(
+            "# a header comment\n\nTNLean/Algebra/QicFoundation.lean\n\n"
+        )
+        entries, errors = guard.manifest_entries(self.root)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0][1], Path("TNLean/Algebra/QicFoundation.lean"))
+
+    def test_stale_manifest_entry(self) -> None:
+        self.write_manifest("TNLean/Algebra/DoesNotExist.lean\n")
+        errors, _ = guard.check_import_direction(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("stale manifest entry", errors[0])
+        self.assertIn("TNLean/Algebra/DoesNotExist.lean", errors[0])
+
+    def test_missing_manifest_file_is_an_error(self) -> None:
+        # No manifest written at all.
+        errors, _ = guard.check_import_direction(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("manifest file is missing", errors[0])
+
+    # -- Namespace ratchet ------------------------------------------------------
+
+    def test_new_namespace_declaration_outside_allowlist_is_rejected(self) -> None:
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "namespace MPSTensor\n\ndef bar := 1\n\nend MPSTensor\n",
+        )
+        errors = guard.check_namespace_ratchet(self.root, allowlist=frozenset())
+        self.assertEqual(len(errors), 1)
+        self.assertIn("TNLean/Channel/Foo.lean", errors[0])
+        self.assertIn("new `namespace MPSTensor`", errors[0])
+
+    def test_allowlisted_namespace_declaration_is_accepted(self) -> None:
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "namespace MPSTensor\n\ndef bar := 1\n\nend MPSTensor\n",
+        )
+        errors = guard.check_namespace_ratchet(
+            self.root, allowlist=frozenset({"TNLean/Channel/Foo.lean"})
+        )
+        self.assertEqual(errors, [])
+
+    def test_commented_out_namespace_declaration_is_ignored(self) -> None:
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "-- namespace MPSTensor\ndef bar := 1\n",
+        )
+        errors = guard.check_namespace_ratchet(self.root, allowlist=frozenset())
+        self.assertEqual(errors, [])
+
+    def test_stale_namespace_allowlist_entry_is_rejected(self) -> None:
+        self.write("TNLean/Channel/Foo.lean", "def bar := 1\n")
+        errors = guard.check_namespace_ratchet(
+            self.root, allowlist=frozenset({"TNLean/Channel/Foo.lean"})
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("stale NAMESPACE_ALLOWLIST entry", errors[0])
+
+    def test_ratchet_rejects_allowlist_growth_against_base(self) -> None:
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "namespace MPSTensor\nend MPSTensor\n",
+        )
+        self.write(
+            "TNLean/Channel/Bar.lean",
+            "namespace MPSTensor\nend MPSTensor\n",
+        )
+        current = frozenset({"TNLean/Channel/Foo.lean", "TNLean/Channel/Bar.lean"})
+        base = frozenset({"TNLean/Channel/Foo.lean"})
+        errors = guard.check_namespace_ratchet(self.root, allowlist=current, base_allowlist=base)
+        self.assertTrue(
+            any("TNLean/Channel/Bar.lean: added to NAMESPACE_ALLOWLIST" in error
+                for error in errors)
+        )
+
+    def test_ratchet_accepts_shrinking_allowlist_against_base(self) -> None:
+        self.write(
+            "TNLean/Channel/Foo.lean",
+            "namespace MPSTensor\nend MPSTensor\n",
+        )
+        current = frozenset({"TNLean/Channel/Foo.lean"})
+        base = frozenset({"TNLean/Channel/Foo.lean", "TNLean/Channel/Removed.lean"})
+        errors = guard.check_namespace_ratchet(self.root, allowlist=current, base_allowlist=base)
+        self.assertEqual(errors, [])
+
+
+class MergeBaseAllowlistTests(unittest.TestCase):
+    """End-to-end tests for the git-merge-base ratchet, mirroring
+    check_numbered_lean_files.py's `_debt_allowlist_at_merge_base` tests."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _commit(self, message: str) -> None:
+        subprocess.run(
+            [
+                "git", "-C", str(self.root),
+                "-c", "user.name=Test",
+                "-c", "user.email=test@example.com",
+                "commit", "-qm", message,
+            ],
+            check=True,
+        )
+
+    def _write_checker(self, allowlist_repr: str) -> None:
+        checker = self.root / "scripts" / "check_import_direction.py"
+        checker.parent.mkdir(parents=True, exist_ok=True)
+        checker.write_text(
+            f"NAMESPACE_ALLOWLIST: frozenset[str] = frozenset({allowlist_repr})\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "scripts/check_import_direction.py"],
+            check=True,
+        )
+
+    def test_missing_checker_at_base_initializes_baseline(self) -> None:
+        (self.root / "README.md").write_text("placeholder\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", "README.md"], check=True)
+        self._commit("initial commit without the checker")
+        base_ref = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True, stdout=subprocess.PIPE, text=True,
+        ).stdout.strip()
+
+        self._write_checker("{'TNLean/Channel/Foo.lean'}")
+        self._commit("introduce the checker")
+
+        baseline = guard._namespace_allowlist_at_merge_base(self.root, base_ref)
+        self.assertIsNone(baseline)
+
+    def test_growth_against_recorded_baseline_is_rejected(self) -> None:
+        self._write_checker("{'TNLean/Channel/Foo.lean'}")
+        self._commit("baseline")
+        base_ref = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True, stdout=subprocess.PIPE, text=True,
+        ).stdout.strip()
+
+        self._write_checker("{'TNLean/Channel/Foo.lean', 'TNLean/Channel/Bar.lean'}")
+        self._commit("proposed growth")
+
+        baseline = guard._namespace_allowlist_at_merge_base(self.root, base_ref)
+        self.assertEqual(baseline, frozenset({"TNLean/Channel/Foo.lean"}))
+
+        (self.root / "TNLean/Channel").mkdir(parents=True, exist_ok=True)
+        (self.root / "TNLean/Channel/Foo.lean").write_text(
+            "namespace MPSTensor\nend MPSTensor\n", encoding="utf-8"
+        )
+        (self.root / "TNLean/Channel/Bar.lean").write_text(
+            "namespace MPSTensor\nend MPSTensor\n", encoding="utf-8"
+        )
+        errors = guard.check_namespace_ratchet(
+            self.root,
+            allowlist=frozenset({"TNLean/Channel/Foo.lean", "TNLean/Channel/Bar.lean"}),
+            base_allowlist=baseline,
+        )
+        self.assertTrue(
+            any("TNLean/Channel/Bar.lean: added to NAMESPACE_ALLOWLIST" in error
+                for error in errors)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 2 of #6560: a CI import-direction guard for the channel/tensor-network
boundary, opened as a **draft** since it is designed to land last, after the
in-flight Phase 1 edge-cutting PRs merge.

- `scripts/check_import_direction.py` checks that every QIC-bound file
  (everything under `TNLean/Channel/`, `TNLean/Entropy/`, `TNLean/Kraus/`
  once it exists, plus anything listed in the new
  `scripts/qic_layer0_modules.txt` manifest) does not import
  `TNLean.MPS.*`, `TNLean.QPF.*`, `TNLean.Wielandt.*`, `TNLean.Spectral.*`,
  `TNLean.PEPS.*`, `TNLean.QCA.*`, or `TNLean.PiAlgebra.*`. Lean comments are
  stripped via the shared `lean_import_syntax.strip_lean_comments` helper
  before matching.
- A secondary, shrinking-only ratchet (the `check_numbered_lean_files.py`
  pattern) forbids new `namespace MPSTensor` declarations inside
  `TNLean/Channel/` and `TNLean/Entropy/` outside a seeded allowlist.
- `scripts/qic_layer0_modules.txt` is created empty with a header comment;
  it is the future single source of truth for the layer-0 foundation
  modules assigned to the QICLean extraction (Phase 3). The checker
  errors on any manifest entry whose file no longer exists.
- Wired into `.github/workflows/import-completeness.yml`'s `check` job
  (same pattern as the existing generator-check steps), with
  `fetch-depth: 0` added so the ratchet's merge-base lookup works, and a
  pull-request/push/workflow_dispatch `--base-ref` branch mirroring how
  `check_numbered_lean_files.py` is wired in `pr-ci.yml`.

## Current state: fails by design

Run today, the checker fails, listing the 13 remaining import edges
(across 8 files) that the in-flight Phase 1 edge-cutting PRs under #6560
are removing. This is the burn-down list; the guard is designed to be
born green once those PRs land, at which point this PR flips out of draft:

- `TNLean/Channel/Irreducible/KrausSetup.lean:7` — `TNLean.MPS.Core.TransferChannel`
- `TNLean/Channel/Irreducible/PerronFrobenius.lean:8` — `TNLean.QPF.Uniqueness`
- `TNLean/Channel/Irreducible/SpectralRadius.lean:12` — `TNLean.MPS.Core.TPGauge`
- `TNLean/Channel/Irreducible/SpectralRadius.lean:13` — `TNLean.Spectral.Radius`
- `TNLean/Channel/Irreducible/SpectralRadius.lean:14` — `TNLean.Spectral.TransferOperatorGap`
- `TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean:8` — `TNLean.QPF.Uniqueness`
- `TNLean/Channel/Peripheral/IrreducibleChannel.lean:12` — `TNLean.MPS.CanonicalForm.BlockingViaAdjoint`
- `TNLean/Channel/Peripheral/IrreducibleChannel.lean:13` — `TNLean.Spectral.TransferOperatorGap`
- `TNLean/Channel/PerronFrobenius/Existence.lean:10` — `TNLean.MPS.Irreducible.Adjoint`
- `TNLean/Channel/PerronFrobenius/Existence.lean:11` — `TNLean.MPS.Core.TPGauge`
- `TNLean/Channel/PerronFrobenius/Existence.lean:12` — `TNLean.MPS.Core.CPPrimitive`
- `TNLean/Channel/PerronFrobenius/Existence.lean:13` — `TNLean.QPF.PosDef`
- `TNLean/Channel/Semigroup/Primitivity/Basic.lean:16` — `TNLean.Spectral.TransferOperatorGap`

The `namespace MPSTensor` ratchet is already clean: its one seeded
allowlist entry (`TNLean/Channel/PerronFrobenius/Existence.lean`) matches
the current single offender, found via
`rg -l "namespace MPSTensor" TNLean/Channel TNLean/Entropy`.

## Test plan

- [x] `PYTHONPATH=scripts python3 scripts/test_check_import_direction.py -v`
      — 18 tests, all pass (clean tree, forbidden import, comment-masked
      import ignored, manifest-listed file violation, stale manifest entry,
      missing manifest, ratchet allowlist growth/shrink, stale allowlist
      entry, merge-base baseline initialization and growth rejection).
- [x] `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root .`
      — currently exits 1, listing exactly the 13 edges above (expected;
      this PR is a draft precisely because of them).
- No `lake build` run; this is a python-only change and does not touch any
  `.lean` file.

Cites #6560. No review loop needed while this stays draft.