### PR TITLE
doc(blueprint): relocate channel-side entries to their moving chapters

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
+++ b/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
@@ -46,6 +46,19 @@ duality used by the positive-retraction and fixed-point arguments.
     $T(A^\dagger)=T(A^\ast)=T(A)^\ast=T(A)^\dagger$.
 \end{proof}
 
+\begin{theorem}[Nondegeneracy of the trace pairing]\label{thm:trace_nondeg}
+    \lean{Matrix.trace_mul_right_eq_zero_iff}
+    \leanok
+    For $M \in \MN{D}$, $\tr(M N) = 0$ for all $N \in \MN{D}$ if and only if
+    $M = 0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Testing against the matrix unit $E_{ji}$ gives $\tr(M E_{ji}) = M_{ij}$, so
+    $\tr(M N) = 0$ for all~$N$ forces every entry of~$M$ to vanish.
+\end{proof}
+
 \begin{theorem}[Trace-pairing adjoint identity]\label{thm:trace_pairing_adjoint_identity}
     \lean{Matrix.trace_traceAdjointMap_mul}
     \leanok

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -172,7 +172,11 @@ Euclidean space.
 
 The following internal estimate is folded into a private supporting lemma
 in the formalization and is recorded here, untagged, purely as an
-exposition step toward Theorem~\ref{thm:eigenvalue_bound_rect}.
+exposition step toward Theorem~\ref{thm:eigenvalue_bound_rect}. Its
+statement is phrased over normalized MPS tensors of fixed bond dimensions,
+so it belongs with the tensor-network-side rump of this appendix alongside
+Definition~\ref{def:mixed_transfer_rect} and Definition~\ref{def:frob_sq},
+not with the channel-generic material extracted elsewhere in this chapter.
 
 \begin{lemma}[Uniform Frobenius bound for the rectangular mixed transfer power]%
     \label{lem:hs_contraction_rect}

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
@@ -143,39 +143,10 @@ The results below turn reducing projections into support isometries, compress te
     satisfies (\ref{eq:canonical_projection_isometry}).
 \end{proof}
 
-\begin{lemma}[Rectangular Gram equality gives a unitary]
-    \label{lem:exists_unitary_mul_eq_of_gram_eq}
-    \lean{Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq}
-    \leanok
-    \uses{}
-    Let $A,B:\C^n\to\C^m$ be linear maps with
-    $B^\dagger B=A^\dagger A$. Then there is a unitary
-    $U$ on $\C^m$ such that $B=UA$.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    Let $\mathcal R_A=\operatorname{ran}A$ and
-    $\mathcal R_B=\operatorname{ran}B$. Define
-    $V:\mathcal R_A\to\mathcal R_B$ by $V(Ax)=Bx$. This is well defined:
-    if $Ax=Ay$, then
-    \begin{align}
-        \lVert B(x-y)\rVert^2
-         & =\langle x-y,B^\dagger B(x-y)\rangle
-        =\langle x-y,A^\dagger A(x-y)\rangle
-        =\lVert A(x-y)\rVert^2=0.
-        \notag
-    \end{align}
-    The same calculation, with two vectors and polarization, gives
-    $\langle V(Ax),V(Ay)\rangle=\langle Ax,Ay\rangle$. Thus $V$ is an
-    isometry onto $\mathcal R_B$. In particular,
-    $\dim\mathcal R_A=\dim\mathcal R_B$, so their orthogonal complements
-    in $\C^m$ have equal dimension. Choose a unitary
-    $V^\perp:\mathcal R_A^\perp\to\mathcal R_B^\perp$ and set
-    $U=V\oplus V^\perp$ with respect to the two orthogonal decompositions of
-    $\C^m$. Then $U$ is unitary and $UAx=Bx$ for every $x\in\C^n$; hence
-    $B=UA$.
-\end{proof}
+The rectangular Gram-equality criterion that turns $B^\dagger B=A^\dagger A$
+into a unitary $U$ with $B=UA$ is a generic algebra fact, proved as
+Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq} in
+Appendix~\ref{ch:channel_asymptotics_supporting_results}.
 
 \begin{lemma}[Corner tensors inherit projector closure]
     \label{lem:projector_closure_corner}

--- a/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
+++ b/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
@@ -238,6 +238,40 @@ Theorem~\ref{thm:channel_exists_stinespring_open_system_unitary}. Its
 zero-extension consequence completes the fixed-point decomposition in
 Theorem~\ref{thm:wolf_6_14}.
 
+\begin{lemma}[Rectangular Gram equality gives a unitary]
+    \label{lem:exists_unitary_mul_eq_of_gram_eq}
+    \lean{Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq}
+    \leanok
+    \uses{}
+    Let $A,B:\C^n\to\C^m$ be linear maps with
+    $B^\dagger B=A^\dagger A$. Then there is a unitary
+    $U$ on $\C^m$ such that $B=UA$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let $\mathcal R_A=\operatorname{ran}A$ and
+    $\mathcal R_B=\operatorname{ran}B$. Define
+    $V:\mathcal R_A\to\mathcal R_B$ by $V(Ax)=Bx$. This is well defined:
+    if $Ax=Ay$, then
+    \begin{align}
+        \lVert B(x-y)\rVert^2
+         & =\langle x-y,B^\dagger B(x-y)\rangle
+        =\langle x-y,A^\dagger A(x-y)\rangle
+        =\lVert A(x-y)\rVert^2=0.
+        \notag
+    \end{align}
+    The same calculation, with two vectors and polarization, gives
+    $\langle V(Ax),V(Ay)\rangle=\langle Ax,Ay\rangle$. Thus $V$ is an
+    isometry onto $\mathcal R_B$. In particular,
+    $\dim\mathcal R_A=\dim\mathcal R_B$, so their orthogonal complements
+    in $\C^m$ have equal dimension. Choose a unitary
+    $V^\perp:\mathcal R_A^\perp\to\mathcal R_B^\perp$ and set
+    $U=V\oplus V^\perp$ with respect to the two orthogonal decompositions of
+    $\C^m$. Then $U$ is unitary and $UAx=Bx$ for every $x\in\C^n$; hence
+    $B=UA$.
+\end{proof}
+
 \begin{theorem}[Unitary completion of an isometric inclusion]
     \label{thm:isometric_inclusion_zero_extension}
     \lean{Matrix.exists_unitary_zero_extension_eq}

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -15,18 +15,9 @@ Chapter~\ref{ch:ft_proof}.
 
 \section{The multiplicative linear extension}
 
-\begin{theorem}[Nondegeneracy of the trace pairing]\label{thm:trace_nondeg}
-    \lean{Matrix.trace_mul_right_eq_zero_iff}
-    \leanok
-    For $M \in \MN{D}$, $\tr(M N) = 0$ for all $N \in \MN{D}$ if and only if
-    $M = 0$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Testing against the matrix unit $E_{ji}$ gives $\tr(M E_{ji}) = M_{ij}$, so
-    $\tr(M N) = 0$ for all~$N$ forces every entry of~$M$ to vanish.
-\end{proof}
+Nondegeneracy of the trace pairing on $\MN{D}$ is a generic algebra fact,
+proved as Theorem~\ref{thm:trace_nondeg} in
+Appendix~\ref{ch:schwarz_supporting_results}.
 
 \begin{lemma}[Same matrix-product vectors give trace agreement]\label{lem:same_mpv_trace}
     \lean{MPSTensor.SameMPV.trace_evalWord}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -588,7 +588,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{theorem}[Left-canonical (trace-preserving) gauge]\label{thm:left_canonical_gauge}
     \lean{gauged_tracePreserving}
-    \uses{def:left_canonical_tensor}
+    \uses{def:tp_kraus}
     \leanok
     Let $\sigma$ be a fixed point of the adjoint transfer map
     $\sum_i (A^i)^\dagger \sigma A^i = \sigma$,

--- a/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
@@ -157,6 +157,126 @@ range, or its adjoint's range, is commutative.
     Lemma~\ref{lem:cp_from_positivity_commutative_domain}.
 \end{proof}
 
+\section{Partial trace over subsystems}
+
+The following support-projector absorption theorems and the partial trace
+over the left factor of a bipartite space are generic bipartite-operator
+facts, with no tensor-network content; they are relocated here from the
+parent-Hamiltonian marginal-support chapter, whose own tripartite-lift
+content (Chapter~\ref{ch:parent_hamiltonian}) cites them across the chapter
+boundary.
+
+\begin{theorem}[Left absorption by the marginal support projector]
+    \label{thm:marginal_support_left_absorption}
+    \lean{Matrix.PosSemidef.leftKroneckerEmbed_supportProj_mul_self}
+    \leanok
+    \uses{lem:trace_lift_left_factor_mul}
+    Let $\rho$ be positive semidefinite on $H_L\otimes H_R$, and let $P_L$ be
+    the orthogonal projector onto the support of $\tr_R\rho$. Then
+    $(P_L\otimes\Id_R)\rho=\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Set $Q_L=\Id_L-P_L$. Since $Q_L\tr_R\rho=0$, the adjoint identity gives
+    \begin{align}
+        \tr((Q_L\otimes\Id_R)\rho)
+        &=\tr(Q_L\tr_R\rho) =0.
+        \notag
+    \end{align}
+    Positivity of $\rho$ then implies
+    $(Q_L\otimes\Id_R)\rho=0$. Finally,
+    $\Id_{L\otimes R}-(Q_L\otimes\Id_R)=P_L\otimes\Id_R$ gives the claim.
+\end{proof}
+
+\begin{theorem}[Right absorption by the marginal support projector]
+    \label{thm:marginal_support_right_absorption}
+    \lean{Matrix.PosSemidef.mul_leftKroneckerEmbed_supportProj_self}
+    \leanok
+    \uses{thm:marginal_support_left_absorption}
+    Under the same assumptions,
+    $\rho(P_L\otimes\Id_R)=\rho$.
+    For $H_L=H_A\otimes H_X$ and $H_R=H_B$, the two absorption identities are
+    precisely the $P_{AX}$ support-projector identities in
+    \cite[Appendix~D.2, lines 2228--2235]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply $(\cdot)^\dagger$ to the left absorption identity. Since
+    $\rho^\dagger=\rho$ and
+    $(P_L\otimes\Id_R)^\dagger=P_L\otimes\Id_R$,
+    \begin{align}
+        \rho(P_L\otimes\Id_R)
+        &=[(P_L\otimes\Id_R)\rho]^\dagger =\rho^\dagger =\rho.
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{definition}[Partial trace over the left factor]
+    \label{def:partial_trace_left}
+    \lean{Matrix.partialTraceLeft, Matrix.partialTraceLeft_apply}
+    \leanok
+    For an operator $\rho$ on $H_L\otimes H_R$, define
+    $(\tr_L\rho)_{r,s}:=\sum_l\rho_{(l,r),(l,s)}$.
+\end{definition}
+
+\begin{theorem}[Left absorption by the right marginal support]
+    \label{thm:right_marginal_support_left_absorption}
+    \lean{Matrix.PosSemidef.rightKroneckerEmbed_supportProj_mul_self}
+    \leanok
+    \uses{thm:partial_trace_left_pos,lem:trace_lift_right_factor_mul}
+    Let $\rho$ be positive semidefinite. If $P_R$ is the support projector of
+    $\tr_L\rho$, then
+    $(\Id_L\otimes P_R)\rho=\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Set $Q=\Id_R-P_R$. The preceding trace identity gives
+    \begin{align}
+        \tr((\Id_L\otimes Q)\rho)
+        &=\tr(Q\tr_L\rho) =0,
+        \notag
+    \end{align}
+    since $P_R$ is the support projector of $\tr_L\rho$. Positivity of
+    $\rho$ then gives $(\Id_L\otimes Q)\rho=0$, and hence
+    $(\Id_L\otimes P_R)\rho=\rho$.
+\end{proof}
+
+\begin{theorem}[Right absorption by the right marginal support]
+    \label{thm:right_marginal_support_right_absorption}
+    \lean{Matrix.PosSemidef.mul_rightKroneckerEmbed_supportProj_self}
+    \leanok
+    \uses{thm:right_marginal_support_left_absorption}
+    Under the same assumptions,
+    $\rho(\Id_L\otimes P_R)=\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take adjoints in the left absorption identity.
+\end{proof}
+
+\begin{definition}[State-preparation map]
+    \label{def:mpdo_state_preparation_map}
+    \lean{Matrix.preparationMap}
+    \leanok
+    Let $\rho$ be a matrix on a finite-dimensional space $B$. The
+    state-preparation map from matrices on $A$ to matrices on $A\otimes B$ is
+    \begin{align}
+        \mathcal P_\rho(X)&=X\otimes\rho.
+        \notag
+    \end{align}
+    This is the elementary preparation operation used in the maps
+    $\mathcal T_1$ and $\mathcal S_1$ of
+    \cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv}.
+    It is relocated here from the MPDO renormalization chapter
+    (Chapter~\ref{ch:mpdo_rfp}), whose Kraus-action and
+    conditional-expectation consequences for the density-operator setting
+    cite it across the chapter boundary.
+\end{definition}
+
 \section{Extending completely positive maps from operator systems}
 
 An \emph{operator system} inside a finite-dimensional $C^*$-algebra is a

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
@@ -31,60 +31,19 @@
     on $H_R$.
 \end{proof}
 
-\begin{theorem}[Left absorption by the marginal support projector]
-    \label{thm:marginal_support_left_absorption}
-    \lean{Matrix.PosSemidef.leftKroneckerEmbed_supportProj_mul_self}
-    \leanok
-    \uses{lem:trace_lift_left_factor_mul}
-    Let $\rho$ be positive semidefinite on $H_L\otimes H_R$, and let $P_L$ be
-    the orthogonal projector onto the support of $\tr_R\rho$. Then
-    $(P_L\otimes\Id_R)\rho=\rho$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Set $Q_L=\Id_L-P_L$. Since $Q_L\tr_R\rho=0$, the adjoint identity gives
-    \begin{align}
-        \tr((Q_L\otimes\Id_R)\rho)
-        &=\tr(Q_L\tr_R\rho) =0.
-        \notag
-    \end{align}
-    Positivity of $\rho$ then implies
-    $(Q_L\otimes\Id_R)\rho=0$. Finally,
-    $\Id_{L\otimes R}-(Q_L\otimes\Id_R)=P_L\otimes\Id_R$ gives the claim.
-\end{proof}
-
-\begin{theorem}[Right absorption by the marginal support projector]
-    \label{thm:marginal_support_right_absorption}
-    \lean{Matrix.PosSemidef.mul_leftKroneckerEmbed_supportProj_self}
-    \leanok
-    \uses{thm:marginal_support_left_absorption}
-    Under the same assumptions,
-    $\rho(P_L\otimes\Id_R)=\rho$.
-    For $H_L=H_A\otimes H_X$ and $H_R=H_B$, the two absorption identities are
-    precisely the $P_{AX}$ support-projector identities in
-    \cite[Appendix~D.2, lines 2228--2235]{Cirac2016MPDO_arXiv}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Apply $(\cdot)^\dagger$ to the left absorption identity. Since
-    $\rho^\dagger=\rho$ and
-    $(P_L\otimes\Id_R)^\dagger=P_L\otimes\Id_R$,
-    \begin{align}
-        \rho(P_L\otimes\Id_R)
-        &=[(P_L\otimes\Id_R)\rho]^\dagger =\rho^\dagger =\rho.
-        \notag
-    \end{align}
-\end{proof}
-
-\begin{definition}[Partial trace over the left factor]
-    \label{def:partial_trace_left}
-    \lean{Matrix.partialTraceLeft, Matrix.partialTraceLeft_apply}
-    \leanok
-    For an operator $\rho$ on $H_L\otimes H_R$, define
-    $(\tr_L\rho)_{r,s}:=\sum_l\rho_{(l,r),(l,s)}$.
-\end{definition}
+Left and right absorption by the marginal support projector — for $\rho$
+positive semidefinite on $H_L\otimes H_R$ with $P_L$ the orthogonal
+projector onto the support of $\tr_R\rho$, the identities
+$(P_L\otimes\Id_R)\rho=\rho$ and $\rho(P_L\otimes\Id_R)=\rho$, which for
+$H_L=H_A\otimes H_X$ and $H_R=H_B$ are precisely the $P_{AX}$
+support-projector identities in \cite[Appendix~D.2, lines
+2228--2235]{Cirac2016MPDO_arXiv} — are pure bipartite-operator facts with no
+tensor-network content, proved as
+Theorem~\ref{thm:marginal_support_left_absorption} and
+Theorem~\ref{thm:marginal_support_right_absorption} in
+Chapter~\ref{ch:aux_channel_theory}. The partial trace over the left factor
+that they and the absorption theorems below are stated against is
+Definition~\ref{def:partial_trace_left}, in the same chapter.
 
 \begin{theorem}[Hermiticity of the left partial trace]
     \label{thm:partial_trace_left_hermitian}
@@ -147,42 +106,13 @@
     \end{align}
 \end{proof}
 
-\begin{theorem}[Left absorption by the right marginal support]
-    \label{thm:right_marginal_support_left_absorption}
-    \lean{Matrix.PosSemidef.rightKroneckerEmbed_supportProj_mul_self}
-    \leanok
-    \uses{thm:partial_trace_left_pos,lem:trace_lift_right_factor_mul}
-    Let $\rho$ be positive semidefinite. If $P_R$ is the support projector of
-    $\tr_L\rho$, then
-    $(\Id_L\otimes P_R)\rho=\rho$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Set $Q=\Id_R-P_R$. The preceding trace identity gives
-    \begin{align}
-        \tr((\Id_L\otimes Q)\rho)
-        &=\tr(Q\tr_L\rho) =0,
-        \notag
-    \end{align}
-    since $P_R$ is the support projector of $\tr_L\rho$. Positivity of
-    $\rho$ then gives $(\Id_L\otimes Q)\rho=0$, and hence
-    $(\Id_L\otimes P_R)\rho=\rho$.
-\end{proof}
-
-\begin{theorem}[Right absorption by the right marginal support]
-    \label{thm:right_marginal_support_right_absorption}
-    \lean{Matrix.PosSemidef.mul_rightKroneckerEmbed_supportProj_self}
-    \leanok
-    \uses{thm:right_marginal_support_left_absorption}
-    Under the same assumptions,
-    $\rho(\Id_L\otimes P_R)=\rho$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Take adjoints in the left absorption identity.
-\end{proof}
+Left and right absorption by the right marginal support — for $\rho\geq0$
+and $P_R$ the support projector of $\tr_L\rho$, the identities
+$(\Id_L\otimes P_R)\rho=\rho$ and $\rho(\Id_L\otimes P_R)=\rho$ — are the
+same kind of generic bipartite-operator fact, proved as
+Theorem~\ref{thm:right_marginal_support_left_absorption} and
+Theorem~\ref{thm:right_marginal_support_right_absorption} alongside the
+left-marginal absorption theorems above, in Chapter~\ref{ch:aux_channel_theory}.
 
 We now use the explicit tripartite indexing
 $H_A\otimes(H_X\otimes H_B)$. Reassociation identifies it with

--- a/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
@@ -39,6 +39,22 @@ assumed Hermitian.
     which is \cite[Equation~(2.20)]{Wolf2012Quantum} with $F_\alpha=G_\alpha$.
 \end{definition}
 
+\begin{definition}[Transfer matrix of a matrix endomorphism]
+    \label{def:mpu_transfer_matrix}
+    \lean{transferMatrix}
+    \leanok
+    Let $E_{k\ell}$ denote the matrix unit with its only nonzero entry in
+    row $k$ and column $\ell$.  The transfer matrix $\widehat T$ is the
+    matrix indexed by pairs of bond indices with entries
+    \begin{align}
+        \widehat T_{(j,i),(\ell,k)}
+        &:=(T(E_{k\ell}))_{ij}.
+    \end{align}
+    Equivalently, this is the matrix of $T$ under the column-stacking
+    identification $M_D(\mathbb C)\cong\mathbb C^{D^2}$: the matrix-units
+    special case of Definition~\ref{def:transfer_matrix_of_basis}.
+\end{definition}
+
 \begin{lemma}[Coordinates in a Hilbert--Schmidt orthonormal basis]
     \label{lem:hilbert_schmidt_orthonormal_coordinates}
     \lean{HilbertSchmidtOrthonormal.repr_apply,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -374,20 +374,13 @@ section.
     Theorem~\ref{thm:mpdo_rectangular_kraus_map_cptp} applies.
 \end{proof}
 
-\begin{definition}[State-preparation map]
-    \label{def:mpdo_state_preparation_map}
-    \lean{Matrix.preparationMap}
-    \leanok
-    Let $\rho$ be a matrix on a finite-dimensional space $B$. The
-    state-preparation map from matrices on $A$ to matrices on $A\otimes B$ is
-    \begin{align}
-        \mathcal P_\rho(X)&=X\otimes\rho.
-        \notag
-    \end{align}
-    This is the elementary preparation operation used in the maps
-    $\mathcal T_1$ and $\mathcal S_1$ of
-    \cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv}.
-\end{definition}
+The state-preparation map $\mathcal P_\rho(X)=X\otimes\rho$ from matrices on
+$A$ to matrices on $A\otimes B$, the elementary preparation operation used
+in the maps $\mathcal T_1$ and $\mathcal S_1$ of
+\cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv},
+is a fully generic construction with no MPDO-specific content, stated as
+Definition~\ref{def:mpdo_state_preparation_map} in
+Chapter~\ref{ch:aux_channel_theory}.
 
 \begin{definition}[Preparation Kraus operators]
     \label{def:mpdo_state_preparation_kraus}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3524,22 +3524,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \section{Transfer-matrix identities}
 
 Let $D$ be a positive integer and let
-$T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.
-
-\begin{definition}[Transfer matrix of a matrix endomorphism]
-    \label{def:mpu_transfer_matrix}
-    \lean{transferMatrix}
-    \leanok
-    Let $E_{k\ell}$ denote the matrix unit with its only nonzero entry in
-    row $k$ and column $\ell$.  The transfer matrix $\widehat T$ is the
-    matrix indexed by pairs of bond indices with entries
-    \begin{align}
-        \widehat T_{(j,i),(\ell,k)}
-        &:=(T(E_{k\ell}))_{ij}.
-    \end{align}
-    Equivalently, this is the matrix of $T$ under the column-stacking
-    identification $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
-\end{definition}
+$T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map. The transfer matrix
+$\widehat T$ of $T$ under the column-stacking identification
+$M_D(\mathbb C)\cong\mathbb C^{D^2}$ is
+Definition~\ref{def:mpu_transfer_matrix} in
+Section~\ref{sec:self_dual_channels}, the matrix-units special case of the
+one-family transfer matrix of Definition~\ref{def:transfer_matrix_of_basis}.
 
 \begin{theorem}[Functoriality of transfer matrices]
     \label{thm:mpu_transfer_matrix_functoriality}


### PR DESCRIPTION
Blueprint-only follow-up to the reverse cross-boundary edge analysis posted on #6560 (comment 2026-08-19T10:22:22Z). That analysis found 32 `\uses` edges running from moving-chapter (channel-volume) entries onto TN-side labels, and classified 7 of the 32 as executable now without any Lean change. This PR applies exactly those 7 items. No Lean files are touched.

## Per-label moves

| Label | From | To | Kind |
|---|---|---|---|
| `thm:left_canonical_gauge` | `chapter/ch06_qpf.tex` | (unchanged location) | Reword: `\uses{def:left_canonical_tensor}` → `\uses{def:tp_kraus}`, matching its Kraus-generic Lean proof |
| `lem:hs_contraction_rect` | `appendix/ft_mps/ch07_spectral.tex` | (unchanged location) | Reword: prose note now records it as tensor-network-side content alongside `def:mixed_transfer_rect`/`def:frob_sq`, not channel-generic material |
| `thm:marginal_support_left_absorption`, `thm:marginal_support_right_absorption`, `def:partial_trace_left`, `thm:right_marginal_support_left_absorption`, `thm:right_marginal_support_right_absorption` | `chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex` | `chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex` (new "Partial trace over subsystems" section) | Relocate: pure bipartite-operator facts, Lean home already `Channel/` |
| `def:mpu_transfer_matrix` | `chapter/ch28_mpu.tex` | `chapter/ch16_channel_representations_self_dual.tex` (next to its generic sibling `def:transfer_matrix_of_basis`) | Relocate (bare definition only; its 18 MPU-specific downstream theorems stay in ch28) |
| `def:mpdo_state_preparation_map` | `chapter/ch21_mpdo_rfp_renormalization.tex` | `chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex` | Relocate (bare definition only; its 5 MPDO-specific consumers stay in ch21) |
| `thm:trace_nondeg` | `chapter/ch03_single.tex` | `appendix/ft_mps/ch05_schwarz.tex` | Relocate: layer-0 algebra fact, same precedent as the Skolem–Noether/BlockPermutation moves |
| `lem:exists_unitary_mul_eq_of_gram_eq` | `appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex` | `appendix/full_only/ch27_channel_asymptotics.tex` (its "Unitary extensions for fixed-point decompositions" section) | Relocate: layer-0 Gram/unitary algebra fact |

Every relocated environment keeps its label, `\lean{}` tags, `\uses{}` clause, statement text, and proof unchanged. Each origin chapter gets a short narrative sentence pointing at the new home via `\ref{}`/`\Chapter{}`/`\Section{}`, since `\uses` and `\ref` resolve document-globally and don't require reordering.

Out of scope (tracked against open Lean-PR checklist items per the #6560 analysis, not touched here): the `def:transfer_map`/`def:irreducible_tensor`/`def:gauge_equiv` gauge-corollary split, the Kraus-native peripheral-spectrum reword cluster, and the `thm:psd_fp_unique_irred` reword — all pending Lean restatements landing first.

## Verification

- `python3 scripts/blueprint_lean_sync.py` → in sync (7971/7971)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` → clean
- `leanblueprint checkdecls`: attempted; `lake exe checkdecls` requires a built `TNLean.olean`, which this blueprint-only PR does not build per policy (no `lake build`). Left to CI, which builds the project first.

## Test plan
- [x] `blueprint_lean_sync.py` in sync
- [x] `check_reader_facing_prose.py --ci` clean
- [ ] CI blueprint build + `leanblueprint checkdecls`