### PR TITLE
doc(channel): record Kraus invariance and gauge results

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -207,6 +207,7 @@ outer square-root factors yields
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:left_canonical_gauge}
     Self-adjointness of $\rho^{1/2}$ gives
     \begin{align}
         B_i^\dagger B_i

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -189,7 +189,8 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:trace_mul_map_eq_trace_adjointMap_mul}
+    \uses{lem:trace_mul_map_eq_trace_adjointMap_mul,
+        thm:kraus_map_eq_transfer_map}
     Apply Lemma~\ref{lem:trace_mul_map_eq_trace_adjointMap_mul} to the Kraus
     map determined by $(K_i)_i$. Identifying this Kraus map and its adjoint
     with the corresponding transfer maps gives the stated identity.

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -620,6 +620,7 @@ and~\cite{Evans1978Spectral}.
 \end{definition}
 
 \begin{theorem}[Left-canonical (trace-preserving) gauge]\label{thm:left_canonical_gauge}
+    \lean{Kraus.gauged_isTP_of_map_conjTranspose_fixedPoint}
     \lean{gauged_tracePreserving}
     \uses{def:tp_kraus}
     \leanok

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -211,6 +211,38 @@ and~\cite{Evans1978Spectral}.
     identity.
 \end{proof}
 
+\begin{theorem}[Invariant compression implies vanishing lower corners]
+    \label{thm:kraus_invariant_compression_lower_zero}
+    \lean{Kraus.invariance_implies_lowerZero}
+    \leanok
+    \uses{def:kraus_map}
+    Let $K$ be a finite matrix family with Kraus map $E$, and let $Q$ be an
+    orthogonal projection. If
+    \begin{align}
+        Q E(QXQ)Q
+         & =E(QXQ)
+        \notag
+    \end{align}
+    for every $X\in\MN{D}$, then $(\Id-Q)K_iQ=0$ for every $i$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Set $M_i=(\Id-Q)K_iQ$. Multiplying the compression identity by $\Id-Q$
+    on the left gives the first equality below. Taking $X=\Id$, multiplying on
+    the right by $\Id-Q$, and expanding the Kraus sum gives the second:
+    \begin{align}
+        (\Id-Q)E(QXQ)
+         & =0,
+        \notag\\
+        (\Id-Q)E(Q)(\Id-Q)
+         & =\sum_i M_iM_i^\dagger=0.
+        \notag
+    \end{align}
+    Each matrix $M_iM_i^\dagger$ is positive semidefinite. Hence every term in
+    the vanishing sum is zero, and therefore $M_i=0$ for every $i$.
+\end{proof}
+
 \begin{theorem}[Invariant support compression for a CP fixed point]
     \label{thm:cp_fixed_support_invariant}
     \lean{Kraus.invariantCompression_of_supportProj_fixed_by_cpMap}


### PR DESCRIPTION
### Motivation

- Chapter 6 records that vanishing lower Kraus corners imply invariant compression, but omits the converse proved in `TNLean/Channel/FixedPoint/SupportInvariance.lean:128–154`.
- The channel reorganization in LionSR/TNLean#6564 left two blueprint dependencies incomplete: the transfer-map identification used by trace adjointness and the general trace-preserving gauge theorem in `TNLean/Channel/GaugeConjugation.lean:30–55`.
- The gauge statement is the normalization from Wolf, *Quantum Channels & Operations*, Section 6.2: if (S†S = σ) and (σ) is fixed by the conjugate-transposed Kraus map, then (S K_i S^{-1}) is trace-preserving.

### Description

- Add the invariant-compression converse beside its forward implication, with the proof that a vanishing sum of positive semidefinite matrices (M_i M_i†) forces every lower corner (M_i = (I-Q)K_iQ) to vanish.
- Associate `Kraus.gauged_isTP_of_map_conjTranspose_fixedPoint` with the left-canonical gauge entry and record its use by the square-root specialization.
- Record `thm:kraus_map_eq_transfer_map` in the proof dependencies of the trace-adjointness lemma.

### Testing

- `lake env lean TNLean/Channel/GaugeConjugation.lean`
- `lake env lean TNLean/Channel/FixedPoint/SupportInvariance.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` — 7,983/7,983 entries synchronized
- Exact `checkdecls` verification for `Kraus.invariance_implies_lowerZero`

Closes LionSR/QICLean#331
Closes LionSR/TNLean#6597
Closes LionSR/QICLean#335
Advances LionSR/TNLean#6560

### Agent assistance

- TeXRA leanBlueprint drafted the invariant-compression entry. TeXRA leanOrchestrator checked the statements against their Lean declarations, completed the dependency annotations, and ran the local gates.