### PR TITLE
refactor(analysis): relocate spectral-radius lemmas

### DIFF
--- a/TNLean/Analysis/SpectralRadius.lean
+++ b/TNLean/Analysis/SpectralRadius.lean
@@ -78,4 +78,13 @@ theorem spectralRadius_eq_one_of_ne_zero
     simpa using (@le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ a) _
       (fun z _ => (‖z‖₊ : ENNReal)) 1 hone)
 
+/-- An idempotent with spectral radius below one is zero. -/
+theorem eq_zero_of_spectralRadius_lt_one
+    {A : Type*} [NormedRing A] [NormedAlgebra ℂ A]
+    {a : A} (ha : IsIdempotentElem a) (h : spectralRadius ℂ a < 1) :
+    a = 0 := by
+  by_contra ha_ne
+  rw [ha.spectralRadius_eq_one_of_ne_zero ha_ne] at h
+  exact (lt_irrefl 1) h
+
 end IsIdempotentElem

--- a/TNLean/Analysis/SpectralRadiusPowerDecay.lean
+++ b/TNLean/Analysis/SpectralRadiusPowerDecay.lean
@@ -19,7 +19,10 @@ strictly below one converge to zero.  This follows from Gelfand's formula
 ## Main results
 
 - `pow_tendsto_zero_of_spectralRadius_lt_one`
+- `geometric_bound_of_spectralRadius_lt_one`
 -/
+
+open scoped ENNReal NNReal
 
 /-- **Powers tend to zero when spectral radius < 1.** -/
 theorem pow_tendsto_zero_of_spectralRadius_lt_one
@@ -39,3 +42,61 @@ theorem pow_tendsto_zero_of_spectralRadius_lt_one
   · filter_upwards [hev] with n hn
     rw [← coe_nnnorm, ← NNReal.coe_pow]; exact_mod_cast hn.le
   · exact tendsto_pow_atTop_nhds_zero_of_lt_one r.coe_nonneg (by exact_mod_cast hr_lt_one)
+
+/-- Gelfand's formula: if `spectralRadius(T) < 1`, then `‖T ^ n‖ ≤ C · r ^ n`
+for some `C > 0` and `0 < r < 1`, uniformly in `n`. -/
+theorem geometric_bound_of_spectralRadius_lt_one
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
+    (T : V →L[ℂ] V)
+    (hT : spectralRadius ℂ T < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
+      ∀ n : ℕ, ‖T ^ n‖ ≤ C * r ^ n := by
+  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp hT
+  have hr_lt_one : (r : ℝ) < 1 := by
+    exact_mod_cast hr_below
+  have hr_pos : 0 < (r : ℝ) := by
+    exact_mod_cast (lt_of_le_of_lt
+      (show (0 : ℝ≥0∞) ≤ spectralRadius ℂ T from bot_le) hr_above)
+  have hev :
+      ∀ᶠ n in Filter.atTop, ‖T ^ n‖₊ < r ^ n := by
+    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius T
+    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
+      Filter.eventually_gt_atTop 0] with n hn hn_pos
+    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
+    rw [ENNReal.rpow_natCast] at hn
+    exact_mod_cast hn
+  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
+  let S : ℝ := Finset.sum (Finset.range N) fun k => ‖T ^ k‖ / (r : ℝ) ^ k
+  let C : ℝ := S + 1
+  refine ⟨C, r, by positivity, hr_pos, hr_lt_one, ?_⟩
+  intro n
+  by_cases hn : N ≤ n
+  · have hnorm : ‖T ^ n‖ ≤ (r : ℝ) ^ n := by
+      exact_mod_cast (hN n hn).le
+    have hC_ge_one : 1 ≤ C := by
+      have hS_nonneg : 0 ≤ S := by
+        dsimp [S]
+        positivity
+      dsimp [C]
+      linarith
+    calc
+      ‖T ^ n‖ ≤ (r : ℝ) ^ n := hnorm
+      _ = 1 * (r : ℝ) ^ n := by ring
+      _ ≤ C * (r : ℝ) ^ n := by
+        gcongr
+  · have hn_lt : n < N := Nat.lt_of_not_ge hn
+    have hterm : ‖T ^ n‖ / (r : ℝ) ^ n ≤ S := by
+      dsimp [S]
+      exact Finset.single_le_sum
+        (f := fun k => ‖T ^ k‖ / (r : ℝ) ^ k)
+        (by intro k hk; positivity)
+        (Finset.mem_range.mpr hn_lt)
+    have hterm' : ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := by
+      exact (div_le_iff₀ (pow_pos hr_pos n)).1 hterm
+    have hS_le_C : S ≤ C := by
+      dsimp [C]
+      linarith
+    calc
+      ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
+      _ ≤ C * (r : ℝ) ^ n := by
+        gcongr

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -46,7 +46,7 @@ theorem groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
         (D : ℝ) ^ 3 * (C * r ^ n) ^ 2 := by
   let N := transferMap A - fixedPointProj ρ htr
   let T := (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N
-  rcases geometric_bound_of_spectralRadius_lt_one T (by simpa [T, N] using hgap) with
+  rcases _root_.geometric_bound_of_spectralRadius_lt_one T (by simpa [T, N] using hgap) with
     ⟨C, r, hC, hr_pos, hr_lt_one, hbound⟩
   refine ⟨C, r, hC, hr_pos, hr_lt_one, ?_⟩
   intro n hn

--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -147,7 +147,7 @@ theorem IsPrimitiveMPS.tailVirtualMapES_norm_four_pow_uniform
     convert hP.complementary_transfer_map_gap using 1
     congr 2
   obtain ⟨C, r, hC, hr_pos, hr_lt_one, hgeom⟩ :=
-    geometric_bound_of_spectralRadius_lt_one T hgap
+    _root_.geometric_bound_of_spectralRadius_lt_one T hgap
   let B := ‖P 1‖ + C * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖
   let Q := (D : ℝ) * (‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ ^ 2 + B ^ 2) + 1
   have hD : 0 ≤ (D : ℝ) := Nat.cast_nonneg D

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -529,8 +529,6 @@ private lemma mixedTransferMap₂_eq_zero_of_isIdempotentElem
   let : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
   let : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
   let : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
-  have : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
-  have hComplete : CompleteSpace (V →L[ℂ] V) := FiniteDimensional.complete ℂ _
   have hSpectF : spectralRadius ℂ F' < 1 := by
     change spectralRadius ℂ
       (((Module.End.toContinuousLinearMap V)
@@ -539,8 +537,8 @@ private lemma mixedTransferMap₂_eq_zero_of_isIdempotentElem
     exact hsr
   have hidem' : IsIdempotentElem F' := hidem.map Φ
   have hF'0 : F' = 0 :=
-    @IsIdempotentElem.eq_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
-      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
+    @_root_.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V))
       (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hidem' hSpectF
   have hF0 : Φ (mixedTransferMap₂ A B) = Φ 0 := by rw [map_zero]; exact hF'0
   exact Φ.injective hF0

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -19,8 +19,8 @@ a lower bound on `1 - ρ`).
 
 ## Building blocks (already formalized elsewhere)
 
-* `MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
-  `Spectral/TransferOperatorGapCommon.lean` — a uniform geometric operator-norm
+* `geometric_bound_of_spectralRadius_lt_one` in
+  `Analysis/SpectralRadiusPowerDecay.lean` — a uniform geometric operator-norm
   bound when spectral radius < 1
 * `compl_eigenvalue_norm_lt_one_of_primitive` in `Peripheral/Spectrum.lean` —
   primitive channels have a complementary transfer-map gap
@@ -134,7 +134,7 @@ private theorem geometric_apply_bound_of_spectralRadius_lt_one
     (hT : spectralRadius ℂ T < 1) :
     ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
       ∀ n : ℕ, ∀ x : V, ‖(T ^ n) x‖ ≤ C * r ^ n * ‖x‖ := by
-  rcases geometric_bound_of_spectralRadius_lt_one T hT with
+  rcases _root_.geometric_bound_of_spectralRadius_lt_one T hT with
     ⟨C, r, hC, hr_pos, hr_lt_one, hpow⟩
   refine ⟨C, r, hC, hr_pos, hr_lt_one, ?_⟩
   intro n x
@@ -269,8 +269,8 @@ primitivity.
 Traceless matrices lie in `ker(P) = range(E - P)`, where `E - P` has spectral
 radius < 1, so their iterates decay geometrically. The bound is the pointwise
 form `geometric_apply_bound_of_spectralRadius_lt_one` of
-`MPSTensor.geometric_bound_of_spectralRadius_lt_one` in
-`Spectral/TransferOperatorGapCommon.lean`. -/
+`geometric_bound_of_spectralRadius_lt_one` in
+`Analysis/SpectralRadiusPowerDecay.lean`. -/
 theorem correlation_length_bound [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -13,7 +13,7 @@ import TNLean.Spectral.FrobeniusNorm
 
 Dimension-independent eigenvector iteration, trace-preserving word sums, and
 Frobenius-square identities used by both square and rectangular mixed-transfer
-gap theorems. Deprecated aliases preserve the former `MPSTensor` names of the
+gap theorems. Compatibility aliases preserve the former `MPSTensor` names of the
 general spectral-radius results now in `TNLean.Analysis`.
 
 ## Main results
@@ -112,7 +112,7 @@ lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i =
   rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
   simp [Matrix.trace_one, Fintype.card_fin]
 
-/-! ### Deprecated spectral-radius aliases -/
+/-! ### Compatibility aliases for spectral-radius results -/
 
 @[deprecated _root_.geometric_bound_of_spectralRadius_lt_one (since := "2026-08-19")]
 alias geometric_bound_of_spectralRadius_lt_one :=

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -3,26 +3,26 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.SpectralRadius
 import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.FrobeniusNorm
-import Mathlib.Analysis.Normed.Algebra.GelfandFormula
-import Mathlib.Analysis.SpecificLimits.Normed
 
 /-!
 # Common infrastructure for square and rectangular transfer gaps
 
-Dimension-independent eigenvector iteration, trace-preserving word sums,
-Frobenius-square identities, and Banach-algebra power convergence used by both
-square and rectangular mixed-transfer gap theorems.
+Dimension-independent eigenvector iteration, trace-preserving word sums, and
+Frobenius-square identities used by both square and rectangular mixed-transfer
+gap theorems. Deprecated aliases preserve the former `MPSTensor` names of the
+general spectral-radius results now in `TNLean.Analysis`.
 
 ## Main results
 
-- `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
-- `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one`
-
-The power-convergence statement `pow_tendsto_zero_of_spectralRadius_lt_one`
-lives in `TNLean.Analysis.SpectralRadiusPowerDecay`.
+- `MPSTensor.eigenvector_pow`
+- `MPSTensor.word_conjTranspose_mul_sum`
+- `MPSTensor.trace_transferMap`
+- `MPSTensor.sum_frobSq_right`
+- `MPSTensor.sum_frobSq_words`
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -112,82 +112,19 @@ lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i =
   rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
   simp [Matrix.trace_one, Fintype.card_fin]
 
-/-! ### Power convergence from spectral radius bound -/
+/-! ### Deprecated spectral-radius aliases -/
 
-/-- Gelfand's formula: if `spectralRadius(T) < 1`, then `‖T ^ n‖ ≤ C · r ^ n`
-for some `C > 0` and `0 < r < 1`, uniformly in `n`. -/
-theorem geometric_bound_of_spectralRadius_lt_one
-    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
-    (T : V →L[ℂ] V)
-    (hT : spectralRadius ℂ T < 1) :
-    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
-      ∀ n : ℕ, ‖T ^ n‖ ≤ C * r ^ n := by
-  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp hT
-  have hr_lt_one : (r : ℝ) < 1 := by
-    exact_mod_cast hr_below
-  have hr_pos : 0 < (r : ℝ) := by
-    exact_mod_cast (lt_of_le_of_lt
-      (show (0 : ℝ≥0∞) ≤ spectralRadius ℂ T from bot_le) hr_above)
-  have hev :
-      ∀ᶠ n in Filter.atTop, ‖T ^ n‖₊ < r ^ n := by
-    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius T
-    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
-      Filter.eventually_gt_atTop 0] with n hn hn_pos
-    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
-    rw [ENNReal.rpow_natCast] at hn
-    exact_mod_cast hn
-  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
-  let S : ℝ := Finset.sum (Finset.range N) fun k => ‖T ^ k‖ / (r : ℝ) ^ k
-  let C : ℝ := S + 1
-  refine ⟨C, r, by positivity, hr_pos, hr_lt_one, ?_⟩
-  intro n
-  by_cases hn : N ≤ n
-  · have hnorm : ‖T ^ n‖ ≤ (r : ℝ) ^ n := by
-      exact_mod_cast (hN n hn).le
-    have hC_ge_one : 1 ≤ C := by
-      have hS_nonneg : 0 ≤ S := by
-        dsimp [S]
-        positivity
-      dsimp [C]
-      linarith
-    calc
-      ‖T ^ n‖ ≤ (r : ℝ) ^ n := hnorm
-      _ = 1 * (r : ℝ) ^ n := by ring
-      _ ≤ C * (r : ℝ) ^ n := by
-        gcongr
-  · have hn_lt : n < N := Nat.lt_of_not_ge hn
-    have hterm : ‖T ^ n‖ / (r : ℝ) ^ n ≤ S := by
-      dsimp [S]
-      exact Finset.single_le_sum
-        (f := fun k => ‖T ^ k‖ / (r : ℝ) ^ k)
-        (by intro k hk; positivity)
-        (Finset.mem_range.mpr hn_lt)
-    have hterm' : ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := by
-      exact (div_le_iff₀ (pow_pos hr_pos n)).1 hterm
-    have hS_le_C : S ≤ C := by
-      dsimp [C]
-      linarith
-    calc
-      ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
-      _ ≤ C * (r : ℝ) ^ n := by
-        gcongr
+@[deprecated _root_.geometric_bound_of_spectralRadius_lt_one (since := "2026-08-19")]
+alias geometric_bound_of_spectralRadius_lt_one :=
+  _root_.geometric_bound_of_spectralRadius_lt_one
 
 @[deprecated _root_.pow_tendsto_zero_of_spectralRadius_lt_one (since := "2026-08-19")]
-alias pow_tendsto_zero_of_spectralRadius_lt_one := _root_.pow_tendsto_zero_of_spectralRadius_lt_one
+alias pow_tendsto_zero_of_spectralRadius_lt_one :=
+  _root_.pow_tendsto_zero_of_spectralRadius_lt_one
 
-/-- **An idempotent with spectral radius below one is zero.** In a complex Banach
-algebra, the powers of such an element converge to `0` while every positive power
-equals the element itself. -/
-theorem IsIdempotentElem.eq_zero_of_spectralRadius_lt_one
-    {A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A]
-    {a : A} (ha : IsIdempotentElem a) (h : spectralRadius ℂ a < 1) :
-    a = 0 := by
-  have hpow := _root_.pow_tendsto_zero_of_spectralRadius_lt_one a h
-  have hshift : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds 0) :=
-    hpow.comp (Filter.tendsto_add_atTop_nat 1)
-  have hconst : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds a) := by
-    simp only [ha.pow_succ_eq]
-    exact tendsto_const_nhds
-  exact tendsto_nhds_unique hconst hshift
+@[deprecated _root_.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one
+  (since := "2026-08-19")]
+alias IsIdempotentElem.eq_zero_of_spectralRadius_lt_one :=
+  _root_.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one
 
 end MPSTensor

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -426,7 +426,7 @@ proved in Section~\ref{sec:app_spectral_decay}.
 
 \begin{lemma}[An idempotent below unit spectral radius vanishes]%
     \label{lem:idempotent_spectral_radius_zero}
-    \lean{MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one}
+    \lean{IsIdempotentElem.eq_zero_of_spectralRadius_lt_one}
     \leanok
     Let $a$ be an element of a complex Banach algebra with $a^2=a$ and
     $\rho_{\spec}(a)<1$. Then $a=0$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -497,7 +497,7 @@ orthogonal projector is the canonical representative used here.
 
 \begin{theorem}[Geometric power bound below unit spectral radius]
     \label{thm:geometric_bound_of_spectral_radius_lt_one}
-    \lean{MPSTensor.geometric_bound_of_spectralRadius_lt_one}
+    \lean{geometric_bound_of_spectralRadius_lt_one}
     \leanok
     Let $V$ be a complex Banach space and let $T\colon V\to V$ be a bounded
     linear operator.  If $\rho_{\mathrm{spec}}(T)<1$, then there are real

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -640,7 +640,7 @@ $\mathcal E_A(\rho)=\rho$, and
   \rho_{\mathrm{spec}}(\mathcal E_A-P_\rho)&<1.
 \end{align}
 The generic prerequisite
-\leanid{MPSTensor.geometric_bound_of_spectralRadius_lt_one} gives constants
+\leanid{geometric_bound_of_spectralRadius_lt_one} gives constants
 $C>0$ and $0<r<1$ with
 $\lVert(\mathcal E_A-P_\rho)^n\rVert\le Cr^n$ for every $n$.
 Combining the transfer-power decomposition, the exact Gram reshuffling identity,
@@ -732,7 +732,7 @@ and generic prerequisites now include:
     \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}), and subtraction
     compatibility is \leanid{Matrix.gramReshuffle_sub}.
   \item The generic geometric power estimate is
-    \leanid{MPSTensor.geometric_bound_of_spectralRadius_lt_one}.  Under nonzero
+    \leanid{geometric_bound_of_spectralRadius_lt_one}.  Under nonzero
     trace, trace preservation, the fixed-point equation, and complementary
     spectral radius below one, the quantitative and limiting physical Gram
     theorems are

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1510,23 +1510,20 @@ spectral split → block extraction → MPV calculation → strict bounds
   `Filter.eventually_gt_atTop 0`, then clearing the `n`-th root via
   `ENNReal.rpow_inv_lt_iff` and `ENNReal.rpow_natCast`.
 - **Seen:** 2 occurrences: `have hev` in
-  `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
-  (`TNLean/Spectral/TransferOperatorGapCommon.lean:131-138`) and `have hev` in
-  `pow_tendsto_zero_of_spectralRadius_lt_one`
-  (`TNLean/Analysis/SpectralRadiusPowerDecay.lean:31-37`), the latter after the
-  layer-0 relocation of the second theorem (PR #6570).
+  `geometric_bound_of_spectralRadius_lt_one` and `have hev` in
+  `pow_tendsto_zero_of_spectralRadius_lt_one`, both in
+  `TNLean/Analysis/SpectralRadiusPowerDecay.lean`, after their layer-0
+  relocations (PR #6570 and issue #6585).
 - **Abstraction (proposed):** an `eventually_nnnorm_pow_lt_pow_of_spectralRadius_lt`
   lemma in `TNLean/Analysis/SpectralRadiusPowerDecay.lean`, taking
   `{A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A] (a : A) {r : ℝ≥0}
   (hr : spectralRadius ℂ a < r)` and returning the eventual bound; both current
   call sites would discharge their local `have` block with one application
-  (the `TransferOperatorGapCommon.lean` site at `A := V →L[ℂ] V`).
+  (the geometric-bound site at `A := V →L[ℂ] V`).
 - **Notes:** below the rule-of-three threshold (two occurrences); promote on
-  the next independent occurrence. `TNLean/Spectral/TransferOperatorGapCommon.lean`
-  already imports `TNLean.Analysis.SpectralRadiusPowerDecay` as of this
-  relocation, so extracting the shared step there would add no new import
-  edge — the deferral rests on the occurrence count alone, not on any
-  cross-layer dependency cost.
+  the next independent occurrence. Both current occurrences are already in
+  `TNLean/Analysis/SpectralRadiusPowerDecay.lean`, so the deferral rests on the
+  occurrence count alone, not on any import cost.
 ### star preserves the complex norm — candidate
 - **Pattern:** `simpa only [RCLike.star_def, RCLike.norm_conj]` to close a goal of the
   form `‖star μ‖ = 1` or `‖star μ‖ ≤ 1` from `‖μ‖ = 1` or `‖μ‖ ≤ 1`.


### PR DESCRIPTION
### Motivation

- `geometric_bound_of_spectralRadius_lt_one` and `IsIdempotentElem.eq_zero_of_spectralRadius_lt_one` are complex Banach-space facts with no MPS data, but still lived under `namespace MPSTensor`.
- The latter placement also prevented ordinary dot notation on the root `IsIdempotentElem` predicate outside an `MPSTensor` namespace. This follows up the layer-zero power-decay relocation in #6570.

### Description

- Move the geometric operator-power estimate to `TNLean/Analysis/SpectralRadiusPowerDecay.lean` at root scope.
- Add `IsIdempotentElem.eq_zero_of_spectralRadius_lt_one` beside the existing layer-zero spectral-radius API, deriving it from `spectralRadius_eq_one_of_ne_zero` and removing the unnecessary completeness assumption.
- Retain compatibility aliases under `MPSTensor` and qualify in-namespace consumers with `_root_` to keep the build warning-free.
- Update direct consumers, both blueprint tags, and live documentation references.

### Testing

- `lake build TNLean.Analysis.SpectralRadius TNLean.Analysis.SpectralRadiusPowerDecay TNLean.Spectral.TransferOperatorGapCommon TNLean.Spectral.QuantitativeGap TNLean.MPS.RFP.BNTOrthogonality TNLean.MPS.ParentHamiltonian.GramConvergence TNLean.MPS.ParentHamiltonian.TailVirtualGram` (`8873/8873`)
- `TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` (three passes; zero undefined cross-references)
- `rg -n "sorry|^axiom\\b"` over all changed Lean files
- stale-FQN scan over live Lean, blueprint, and documentation sources
- `git diff --check origin/main...HEAD`

---
Closes #6585
Advances #6560

### Agent assistance

- TeXRA leanSearch (GPT-5.6) searched Mathlib and identified the existing `IsIdempotentElem.spectralRadius_eq_one_of_ne_zero` API and minimal relocation surface. TeXRA lean (GPT-5.6) implemented and target-built the change. TeXRA leanOrchestrator reviewed the diff, rebased it onto current `main`, reran the target build, and ran the blueprint gates.
