### PR TITLE
style(channel): drop an inert open declaration in GaugeConjugation

### DIFF
--- a/TNLean/Channel/GaugeConjugation.lean
+++ b/TNLean/Channel/GaugeConjugation.lean
@@ -16,7 +16,6 @@ in `TNLean.Channel.KrausGauge`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
-open Matrix Finset
 
 namespace Kraus
 


### PR DESCRIPTION
Follow-up to #6564's review: the unscoped `open Matrix Finset` at the top of `TNLean/Channel/GaugeConjugation.lean` binds nothing — every reference in the file is fully qualified, and the `ᴴ`/big-operator notations come from the scoped opens on the preceding line. Removing it.