### PR TITLE
refactor(wielandt): import the word layer from its Kraus modules

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Wielandt.RectangularSpan.Growth
-import TNLean.MPS.Core.RepeatedWord
+import TNLean.Kraus.Blocking
 
 /-!
 # Rectangular span universality auxiliary lemmas: rank-one and eigenvector parts

--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Defs
+import TNLean.Kraus.Word
+import TNLean.Kraus.Injectivity
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
-import TNLean.MPS.Core.Blocking
+import TNLean.Kraus.Blocking
 
 import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Data.Matrix.Basis


### PR DESCRIPTION
## Summary

Part of the QICLean split, phase 1b (PR-W3/W4), tracked by #6560.

Repoints the three remaining `TNLean.MPS` imports in the Wielandt
`SpanGrowth`/`RankOne`/`RectangularSpan` subtrees at the `TNLean/Kraus/`
word-evaluation modules introduced by #6595, so these subtrees now import
`TNLean/Kraus/` directly and no longer depend on `TNLean/MPS/`:

- `TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean`:
  `TNLean.MPS.Defs` -> `TNLean.Kraus.Word` + `TNLean.Kraus.Injectivity`
  (uses `MPSTensor`, `evalWord`, `IsNBlkInjective`, `IsNormal`)
- `TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`:
  `TNLean.MPS.Core.Blocking` -> `TNLean.Kraus.Blocking`
  (uses `blockTensor`, `flattenBlockedWord`, `evalWord_blockTensor`,
  `length_flattenBlockedWord`)
- `TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean`:
  `TNLean.MPS.Core.RepeatedWord` -> `TNLean.Kraus.Blocking`
  (uses `evalWord_replicate`, which moved there)

`Wielandt/Primitivity`, `Wielandt/Inequality`, and
`WolfChapter6TNIndex.lean` are left untouched; those are a later phase-1b
slice.

## Test plan

- [x] `lake build` on each of the three changed files and one downstream
  importer per subtree (`CumulativeToWordSpan`, `RankOne/BoundedWord`,
  `RectangularSpan/UniversalityAux/Sharp`) all succeed
- [x] `rg -n "sorry|axiom"` on the changed files is empty
- [x] `rg -n "^import TNLean\.MPS"` over `Wielandt/SpanGrowth`,
  `Wielandt/RankOne`, `Wielandt/RectangularSpan` is empty