### PR TITLE
ci(scripts): accept the zero-argument frozenset as an emptied allowlist

### DIFF
--- a/scripts/check_import_direction.py
+++ b/scripts/check_import_direction.py
@@ -230,10 +230,14 @@ def _allowlist_from_source(source: str, variable_name: str) -> frozenset[str]:
             not isinstance(value, ast.Call)
             or not isinstance(value.func, ast.Name)
             or value.func.id != "frozenset"
-            or len(value.args) != 1
+            or len(value.args) > 1
             or value.keywords
         ):
             raise ValueError(f"{variable_name} must be a literal frozenset")
+        # Python has no empty-set literal, so an emptied allowlist is written
+        # as the zero-argument call `frozenset()`.
+        if not value.args:
+            return frozenset()
         parsed = ast.literal_eval(value.args[0])
         if not isinstance(parsed, set) or not all(isinstance(entry, str) for entry in parsed):
             raise ValueError(f"{variable_name} must contain only literal paths")

--- a/scripts/test_check_import_direction.py
+++ b/scripts/test_check_import_direction.py
@@ -302,6 +302,20 @@ class MergeBaseAllowlistTests(unittest.TestCase):
                 for error in errors)
         )
 
+    def test_emptied_allowlist_at_base_parses_as_empty(self) -> None:
+        # Python has no empty-set literal, so a fully cleared allowlist is
+        # written as the zero-argument call `frozenset()`; the baseline
+        # parser must accept that form once it reaches the merge base.
+        self._write_checker("")
+        self._commit("cleared allowlist baseline")
+        base_ref = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True, stdout=subprocess.PIPE, text=True,
+        ).stdout.strip()
+
+        baseline = guard._namespace_allowlist_at_merge_base(self.root, base_ref)
+        self.assertEqual(baseline, frozenset())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hotfix for the import-direction guard merged in #6581: its namespace-ratchet baseline parser required `frozenset({...})` with exactly one literal argument, but the allowlist was cleared in that same PR using the only spelling Python has for an empty set — the zero-argument `frozenset()`. Once that spelling reached the merge base, the parser raised `NAMESPACE_ALLOWLIST must be a literal frozenset` and the guard failed every pull request (first seen on #6604). This parses the zero-argument form as the empty allowlist and adds a regression test (19/19 passing; checker verified green against current main as merge base).