### PR TITLE
refactor(wielandt): relocate/eliminate primitivity-layer QIC-boundary imports

### DIFF
--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -7,7 +7,6 @@ import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Wielandt.Primitivity.Normal
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
-import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.Matrix.Spectrum
 

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Wielandt.Primitivity.Normal
-import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.Kraus.InvariantProjection
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.Matrix.Spectrum

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
+import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 
 /-!
 # Proposition 3, (a) → (c): Spectral perturbation and conclusion

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -8,7 +8,6 @@ import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.QPF.PosDef
-import TNLean.Spectral.MixedTransfer
 
 /-!
 # Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` route


### PR DESCRIPTION
## Summary

Phase 1b of the QIC/TNLean split (tracking issue #6560): audits the
remaining `TNLean/Wielandt/Primitivity/` and
`TNLean/Spectral/TransferOperatorGapNT.lean` imports of TN-side modules and
applies the mechanical fixes found.

- `ToNormal.lean`: dropped `import TNLean.Spectral.MixedTransfer`, which was
  unused in the file.
- `ImpliesStronglyIrreducible.lean`: dropped
  `import TNLean.MPS.CanonicalForm.BlockingViaAdjoint`. It was only needed
  by `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`, used
  exclusively in `ImpliesStronglyIrreducibleAux.lean`; that file now imports
  `BlockingViaAdjoint` directly instead of relying on the transitive import.
- `ImpliesStronglyIrreducible.lean`: replaced
  `import TNLean.MPS.CanonicalForm.Reduction` with
  `import TNLean.Kraus.InvariantProjection`. The file only used
  `HasInvariantProj` and `IsIrreducibleTensor`, both of which now live in
  `Kraus/InvariantProjection.lean` after the word-evaluation-layer split;
  none of `Reduction.lean`'s own consequences
  (`isIrreducibleTensor_smul`, `exists_irreducible_blockDecomp`, …) were used.

The remaining edges in this area are entangled with `MPSTensor.transferMap`
(`TNLean/MPS/Core/Transfer.lean`), which has not itself moved to the Kraus
side yet, and are documented as follow-up items rather than acted on here
(see the classification table below).

## Classification table

| Edge (importer → imported) | Declaration(s) used | Class | Action / substitute |
|---|---|---|---|
| `ToNormal.lean` → `Spectral.MixedTransfer` | none (unused import) | mechanical | removed |
| `ImpliesStronglyIrreducible.lean` → `CanonicalForm.BlockingViaAdjoint` | none in this file; `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor` used only in `ImpliesStronglyIrreducibleAux.lean` | mechanical | import moved to the actual consumer (`ImpliesStronglyIrreducibleAux.lean`) |
| `ImpliesStronglyIrreducible.lean` → `MPS.CanonicalForm.Reduction` | `HasInvariantProj`, `IsIrreducibleTensor` | (a) already relocated upstream | repointed to `Kraus.InvariantProjection` directly; edge eliminated |
| `ToNormal.lean` → `MPS.Core.CPPrimitive` | `MPSTensor.transferMap_isChannel` | (b) | channel-level and small, but built on `MPSTensor.transferMap`, not yet identified with `Kraus.mapLM`. `TNLean/MPS/Core/TransferChannel.lean` already supplies the bridge pattern (`Kraus.mapLM_eq_transferMap`, `Kraus.isChannel_transferMap`); a faithful move would add a `Kraus.mapLM`-native corollary there/in `Channel/` and have the MPS wrapper call it, mirroring `Kraus.isChannel_transferMap`. |
| `ToNormal.lean` → `MPS.Irreducible.FormII` | `isIrreducibleCP_transferMap_of_isIrreducibleTensor` | (b) | `IsIrreducibleTensor` is now Kraus-side, but the theorem's conclusion is stated for `MPSTensor.transferMap`, not `Kraus.mapLM`. Its proof already routes through Kraus-native `Kraus.invariance_implies_lowerZero`/`lowerZero_implies_invariance` (`Channel/FixedPoint/SupportInvariance.lean`), so a `Kraus.mapLM`-native version (`IsIrreducibleTensor A → IsIrreducibleMap (Kraus.mapLM A)`) is a near-verbatim copy that belongs next to `IsIrreducibleTensor` in `Kraus/InvariantProjection.lean`; `FormII.lean`'s version would become a one-line corollary via `Kraus.mapLM_eq_transferMap`, matching the `TransferChannel.lean` pattern. Same story for the converse `isIrreducibleTensor_of_isIrreducibleMap`, used by `PrimitiveBridge.lean`. Not attempted here: touches a declaration with 4+ call sites in `Spectral/TransferOperatorGapNT.lean` plus `ToNormal.lean`/`PrimitiveBridge.lean`, an area with recent concurrent activity. |
| `ToNormal.lean` → `MPS.Structure.PrimitivityBridge` | `IsPrimitiveMPS` (structure) | (b) | channel-level statement (no mpv/SameMPV), but its fields are typed over `MPSTensor.transferMap`; moving it requires either moving `transferMap` itself or restating in terms of `Kraus.mapLM`, both real design decisions affecting the sibling `overlap_tendsto_one` theorems that *do* need `mpvOverlap` (state-level) and must stay put. |
| `ToNormal.lean` → `QPF.PosDef` | `posSemidef_fixedPoint_isPosDef_of_irreducible` | (b) | Thin `MPSTensor.transferMap` specialization of the already QIC-side `posDef_of_posSemidef_fixedPoint_irreducible_cp` (`Channel/Irreducible/FixedPoint.lean`). Same `transferMap`/`Kraus.mapLM` blocker as above. |
| `Normal.lean` → `MPS.Structure.PrimitivityBridge` | `IsPrimitiveMPS`, `HasPrimitiveFixedPoint` | (b) | same as above |
| `Normal.lean` → `Spectral.MixedTransfer` | `transferMap_pow_apply'` | (b) | genuinely used; entangled with `evalWord`/`transferMap` iterated-power expansion, no Kraus-native analogue found |
| `PrimitiveBridge.lean` → `MPS.Irreducible.FormII` (single line in scope) | `isIrreducibleTensor_of_isIrreducibleMap` | (b) | converse of the FormII item above; same substitute plan |
| `TransferOperatorGapNT.lean` → `MPS.Irreducible.FormII` | `isIrreducibleCP_transferMap_of_isIrreducibleTensor` (4 call sites) | (b) | same substitute plan; file also mixes in genuinely state-level `mpvOverlap`/`GaugePhaseEquiv` results, so only the specific declaration is a relocation candidate, not the file |
| `TracePairing.lean` → `Spectral.MixedTransfer`, `Spectral.TraceExpansion` | (n/a) | not an edge | `Spectral` is QIC-side; left untouched per instructions (file also imports `MPS.Core.Transfer`, owned by a concurrent agent) |

## Verification

- `lake env lean` on all three changed files, plus `lake build` on each and
  a downstream importer (`ImpliesIrreducible.lean`, `ImpliesStronglyIrreducibleAux.lean`,
  `Equivalence.lean`, `PrimitiveBridge.lean`, `StronglyIrreducibleToFullRank.lean`):
  all succeed.
- `rg "sorry|axiom"` on the changed files: empty.
- `python3 scripts/check_reader_facing_prose.py`: no new violations.
- `python3 scripts/check_import_direction.py`: 0 violations (unaffected by
  this change; it guards the opposite direction).
- No file layout changes, so import aggregators were not regenerated.

Tracking issue: LionSR/TNLean#6560 (phase 1b).