### PR TITLE
fix(imports): repair direct dependencies after PerronGauge split

### DIFF
--- a/TNLean/Channel/KrausMap.lean
+++ b/TNLean/Channel/KrausMap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.Basic
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -137,7 +137,7 @@ We use `MPSTensor.exists_irreducible_blockDecomp` from `Reduction.lean` directly
 ## (2) Perron–Frobenius / trace-preserving gauge for irreducible blocks
 
 We use `MPSTensor.exists_tp_data_of_irreducible` from
-`Channel/PerronFrobenius/Existence.lean` directly below.
+`MPS/Irreducible/PerronGauge.lean` directly below.
 -/
 
 

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -7,6 +7,7 @@ import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Irreducible.Adjoint
+import TNLean.MPS.Irreducible.FormII
 
 /-!
 # Perron–Frobenius gauges for irreducible MPS tensors


### PR DESCRIPTION
## Summary

- add the direct `MatrixAux` dependency to `Channel/KrausMap`
- add the direct `FormII` dependency to `MPS/Irreducible/PerronGauge`
- correct the stale source-module reference in canonical-form existence

## Validation

- `lake build TNLean.Channel.KrausMap TNLean.MPS.Irreducible.PerronGauge TNLean.MPS.CanonicalForm.Existence`
- `python3 scripts/check_channel_import_direction.py` (318 files, 0 import violations, 0 namespace violations)
- `python3 scripts/check_reader_facing_prose.py`
- `git diff --check origin/main...HEAD`

Closes #6591
Advances #6560