### PR TITLE
refactor(channel): share normalized finite-Kraus setup

### DIFF
--- a/TNLean/Channel/KrausMap.lean
+++ b/TNLean/Channel/KrausMap.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixAux
-import TNLean.Channel.Basic
+import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Schwarz.Basic
 
 /-!
@@ -20,6 +20,8 @@ $E(X) = \sum_i K_i X K_i^\dagger$ with positivity, complete positivity, and trac
 * `Kraus.isTracePreservingMap_mapLM_of_isTP`: the Kraus normalization implies trace
   preservation.
 * `Kraus.isChannel_mapLM`: a trace-preserving finite Kraus family defines a channel.
+* `IsChannel.exists_kraus_map_eq_and_normalized`: every channel has a finite Kraus
+  representation satisfying the trace-preserving normalization.
 * `Kraus.mapLM_ne_zero_of_exists_ne_zero`: a finite Kraus map with a nonzero
   Kraus operator is nonzero.
 * `Kraus.trace_mul_mapLM_adjoint`: the trace-adjoint identity for a linear map
@@ -29,9 +31,22 @@ $E(X) = \sum_i K_i X K_i^\dagger$ with positivity, complete positivity, and trac
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset Complex
 
-namespace Kraus
-
 variable {d D : ℕ}
+
+/-- Every channel admits a finite Kraus family that represents the map and
+satisfies the trace-preserving normalization. -/
+theorem IsChannel.exists_kraus_map_eq_and_normalized
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hE : IsChannel E) :
+    ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
+      E = Kraus.mapLM K ∧ ∑ i : Fin r, (K i)ᴴ * K i = 1 := by
+  obtain ⟨r, K, hK⟩ := hE.cp
+  have hE_eq : E = Kraus.mapLM K :=
+    LinearMap.ext fun X => by
+      simpa only [Kraus.mapLM_apply, Kraus.map_apply] using hK X
+  exact ⟨r, K, hE_eq, kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp⟩
+
+namespace Kraus
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -11,7 +11,7 @@ import TNLean.Channel.Irreducible.AdjointFamily
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
-import TNLean.Channel.KrausRepresentation
+import TNLean.Channel.KrausMap
 import TNLean.Channel.Determinant.Bound
 
 /-!
@@ -165,15 +165,9 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
     (hE : IsChannel E) (hIrr : IsIrreducibleMap E) :
     ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
   classical
-  obtain ⟨r, K, hK⟩ := hE.cp
-  have hE_eq : E = Kraus.mapLM K := by
-    apply LinearMap.ext
-    intro X
-    simpa [Kraus.mapLM_apply, Kraus.map_apply] using hK X
+  obtain ⟨r, K, hE_eq, hK_tp⟩ := hE.exists_kraus_map_eq_and_normalized
   have hIrrK : IsIrreducibleMap (Kraus.mapLM K) := by
     simpa [hE_eq] using hIrr
-  have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
-    kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp
   -- The conjugate-transposed family is unital.
   have hL_unital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) (fun i => (K i)ᴴ) :=
     KadisonSchwarz.isUnitalKraus_conjTranspose (K := K) hK_tp

--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.FixedPoint.CanonicalGauge
+import TNLean.Channel.KrausMap
 import TNLean.Channel.Semigroup.Primitivity.Basic
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal TNOperatorSpace
@@ -236,11 +237,7 @@ theorem peripheral_powers_closed_of_irreducible_channel_with_fixed [NeZero D]
     ∀ n : ℕ, μ ^ n ∈ peripheralEigenvalues E := by
   classical
   -- ── Step 1: Kraus representation ──
-  obtain ⟨r, K, hK⟩ := hE.cp
-  have hE_eq : E = Kraus.mapLM K :=
-    LinearMap.ext fun X => by simpa [Kraus.mapLM_apply, Kraus.map_apply] using hK X
-  have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
-    kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp
+  obtain ⟨r, K, hE_eq, hK_tp⟩ := hE.exists_kraus_map_eq_and_normalized
   -- ── Step 2: Square root S = CFC.sqrt σ ──
   let S : Mat := CFC.sqrt σ
   have hS_herm : Sᴴ = S := Matrix.conjTranspose_cfc_sqrt (ρ := σ)

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -729,13 +729,13 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
     \leanok
     \uses{def:channel, thm:kraus_sum_conjTranspose_mul_of_tp}
     Every quantum channel $E : \MN{D} \to \MN{D}$ admits a finite family
-    $K_1,\ldots,K_r \in \MN{D}$ such that, for every $X \in \MN{D}$,
+    $(K_i)_i$ in $\MN{D}$ such that, for every $X \in \MN{D}$,
     \[
-        E(X)=\sum_{i=1}^r K_i X K_i^\dagger,
+        E(X)=\sum_i K_i X K_i^\dagger,
     \]
     and
     \[
-        \sum_{i=1}^r K_i^\dagger K_i=\Id.
+        \sum_i K_i^\dagger K_i=\Id.
     \]
 \end{theorem}
 

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -723,6 +723,31 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
     $\sum_i K_i^\dagger K_i = \Id$.
 \end{proof}
 
+\begin{theorem}[Normalized Kraus representation of a channel]
+    \label{thm:exists_kraus_map_eq_and_normalized}
+    \lean{IsChannel.exists_kraus_map_eq_and_normalized}
+    \leanok
+    \uses{def:channel, thm:kraus_sum_conjTranspose_mul_of_tp}
+    Every quantum channel $E : \MN{D} \to \MN{D}$ admits a finite family
+    $K_1,\ldots,K_r \in \MN{D}$ such that, for every $X \in \MN{D}$,
+    \[
+        E(X)=\sum_{i=1}^r K_i X K_i^\dagger,
+    \]
+    and
+    \[
+        \sum_{i=1}^r K_i^\dagger K_i=\Id.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:channel, thm:kraus_sum_conjTranspose_mul_of_tp}
+    Complete positivity gives a finite Kraus family satisfying
+    $E(X)=\sum_i K_i X K_i^\dagger$. Since $E$ is trace-preserving,
+    Theorem~\ref{thm:kraus_sum_conjTranspose_mul_of_tp} gives
+    $\sum_i K_i^\dagger K_i=\Id$.
+\end{proof}
+
 \begin{theorem}[Kraus normalization implies trace preservation]\label{thm:kraus_tp_of_sum_conjTranspose_mul}
     \lean{kraus_tp_of_sum_conjTranspose_mul}
     \leanok

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -506,6 +506,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Finite Kraus setup for channels
+- **Seen:** 2 occurrences in `Channel/Peripheral/IrreducibleChannel.lean` and
+  `Channel/Semigroup/Primitivity/Helpers.lean` before promotion (issue #6576).
+- **Abstraction:** `IsChannel.exists_kraus_map_eq_and_normalized` in
+  `TNLean/Channel/KrausMap.lean` packages a finite Kraus family, the equality with
+  its Kraus linear map, and the trace-preserving normalization.
+- **Notes:** issue #6576 deliberately promoted this two-copy pattern before a third
+  occurrence because both peripheral arguments require the complete setup. Each
+  caller now uses one `obtain`; the refactor has a net Lean-source delta of
+  6 lines (22 added, 16 removed).
+
 ### Euclidean linear-map multiplicativity
 - **Pattern:** prove that `Matrix.toEuclideanLin (A * B)` is the composition of the
   Euclidean linear maps represented by `A` and `B` by expanding both sides through


### PR DESCRIPTION
## Summary

- add `IsChannel.exists_kraus_map_eq_and_normalized` in `Channel/KrausMap`, packaging a finite Kraus family, map equality, and trace-preserving normalization
- replace the duplicated setup in the irreducible-channel roots-of-unity proof and the peripheral-power closure proof
- add the blueprint theorem and record the deliberate two-occurrence promotion in the tactic ledger

## Validation

- `lake build TNLean.Channel.KrausMap TNLean.Channel.Peripheral.IrreducibleChannel TNLean.Channel.Semigroup.Primitivity.Helpers` (8794 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (7984/7984 source entries, 70/70 in the edited chapter)
- double `lualatex` with `TEXINPUTS="../../tex/tenkz//:"` (1104 pages, 0 undefined cross-references)
- `python3 scripts/check_import_direction.py --root .` (318 files, 0 import or namespace violations)
- `python3 scripts/check_reader_facing_prose.py`
- `git diff --check origin/main...HEAD`

Closes LionSR/QICLean#333
Advances LionSR/TNLean#6560
