### PR TITLE
style(kraus): remove banned bridge prose

### DIFF
--- a/TNLean/Kraus/Blocking.lean
+++ b/TNLean/Kraus/Blocking.lean
@@ -29,9 +29,9 @@ word), formerly in `TNLean/MPS/Core/RepeatedWord.lean`, since it is a
 low-level word-product identity of the same flavor as the blocking lemmas
 here.
 
-The MPV-level bridge lemmas that used blocking results (`mpv_blockTensor_one`
+The MPV-level lemmas that use blocking results (`mpv_blockTensor_one`
 and `SameMPV.blockTensor`) stay on the matrix-product-state side, in
-`TNLean/MPS/Core/Blocking.lean`. A third former bridge lemma,
+`TNLean/MPS/Core/Blocking.lean`. A third former compatibility lemma,
 `mpv_blockTensor_eq_mpv`, had zero call sites (repo-wide, including
 generalized field notation) and was deleted rather than carried across the
 split.

--- a/TNLean/Kraus/MultiBlockWord.lean
+++ b/TNLean/Kraus/MultiBlockWord.lean
@@ -15,8 +15,8 @@ import Mathlib.LinearAlgebra.Matrix.Reindex
 This file carries the word-evaluation layer of the channel side: a
 generalization of `MPSTensor.evalWord` to matrices indexed by an arbitrary
 finite type (in particular, the `Σ`-type indices produced by
-`Matrix.blockDiagonal'`), together with the block-diagonal compatibility
-lemmas and the bridge back to the canonical `Fin D`-indexed `evalWord`. It is
+`Matrix.blockDiagonal'`), together with compatibility lemmas identifying it
+with the canonical `Fin D`-indexed `evalWord`. It is
 part of the extraction of a Kraus-family-only library out of
 `TNLean`'s matrix-product-state development.
 

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -7,17 +7,17 @@ import TNLean.MPS.Defs
 import TNLean.Kraus.Blocking
 
 /-!
-# Matrix-product-vector bridge for physical blocking
+# Matrix-product vectors under physical blocking
 
 The word-evaluation content of physical blocking (`blockPhysDim`, `wordOfBlock`,
 `blockTensor`, `blockKron`, `evalWord_blockTensor`, canonical-normalization
 propagation, `leftCanonical_blockTensor`) now lives in
 `TNLean/Kraus/Blocking.lean`. This file keeps
-the surviving matrix-product-vector bridge lemmas that transport `mpv`/`SameMPV`
-through physical blocking. `mpv_blockTensor_eq_mpv` was also a bridge lemma
-here; it had zero call sites (repo-wide, including generalized field notation)
-and was deleted rather than carried across the split — the actually-used
-flattened-word `mpv` bridge lives in `TNLean/MPS/Core/BlockingInfrastructure.lean`.
+the surviving matrix-product-vector lemmas that transport `mpv`/`SameMPV`
+through physical blocking. The former compatibility lemma
+`mpv_blockTensor_eq_mpv` had zero call sites (repo-wide, including generalized
+field notation) and was deleted rather than carried across the split. The used
+flattened-word `mpv` lemma lives in `TNLean/MPS/Core/BlockingInfrastructure.lean`.
 
 ## Main results
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -15,14 +15,13 @@ import TNLean.Kraus.Injectivity
 # Basic definitions for matrix product state tensors
 
 This file contains the core definitions used throughout the MPS development:
-MPV coefficients, gauge equivalence, and the WORD-to-STATE bridge lemmas
-connecting them to word evaluation, injectivity, and normality. The
-`MPSTensor` abbrev itself, together with word evaluation, injectivity, block
-injectivity, and normality, now live in `TNLean/Kraus/Word.lean` and
-`TNLean/Kraus/Injectivity.lean`; this file
-imports them and keeps only the matrix-product-vector vocabulary and the
-gauge-invariance bridge lemmas for `evalWord`, `SameMPV`, and eventual block
-injectivity.
+MPV coefficients, gauge equivalence, and the word-to-state lemmas connecting
+them to word evaluation, injectivity, and normality. The `MPSTensor` abbrev
+itself, together with word evaluation, injectivity, block injectivity, and
+normality, now live in `TNLean/Kraus/Word.lean` and
+`TNLean/Kraus/Injectivity.lean`; this file imports them and keeps only the
+matrix-product-vector vocabulary and the gauge-invariance lemmas for
+`evalWord`, `SameMPV`, and eventual block injectivity.
 
 ## Main declarations
 


### PR DESCRIPTION
### Summary

- replace the four word-layer docstring uses of the banned connection noun `bridge`
- keep declaration names, statements, imports, and proofs unchanged
- use precise alternatives: compatibility lemmas, transport lemmas, and word-to-state lemmas

### Testing

- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- targeted `rg` confirms no remaining `bridge` occurrence in the four flagged files
- `git diff --check`

Closes #6603
Advances #6560