### PR TITLE
refactor(canonical-form): reuse Kraus map nonzero lemma

### DIFF
--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Channel.Irreducible.PerronFrobenius
@@ -258,12 +259,8 @@ theorem exists_posDef_transferMap_eigenvector_of_irreducible {n : ℕ} [NeZero n
     ∃ (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
       ρ.PosDef ∧ 0 < r ∧ transferMap (d := d) (D := n) B ρ = (r : ℂ) • ρ := by
   have hne : transferMap (d := d) (D := n) B ≠ 0 := by
-    intro h0
-    obtain ⟨i, hi⟩ := hB
-    have h1 : transferMap (d := d) (D := n) B 1 = 0 := by rw [h0]; simp
-    rw [transferMap_apply] at h1
-    simp only [Matrix.mul_one] at h1
-    exact hi (Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero (fun j => B j) h1 i)
+    simpa only [Kraus.mapLM_eq_transferMap] using
+      Kraus.mapLM_ne_zero_of_exists_ne_zero B hB
   obtain ⟨ρ, r, hρ, hr, hEig⟩ :=
     exists_posDef_eigenvector_of_irreducible_cp (transferMap (d := d) (D := n) B)
       (transferMap_isCPMap B)

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1565,20 +1565,19 @@ spectral split → block extraction → MPV calculation → strict bounds
   orthogonality. This removes seven local constructions/proofs and reduces the
   theorem proof from 387 to 346 lines (41 lines net), with no new declaration.
 
-### nonzero Kraus map via evaluation at the identity — candidate
+### nonzero Kraus map via evaluation at the identity — resolved
 - **Pattern:** show a finite Kraus map is nonzero by evaluating at `1`, reducing to
   `∑ᵢ Kᵢ Kᵢᴴ = 0`, and concluding each `Kᵢ = 0` from positive semidefiniteness of the
   summands via `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`.
-- **Seen:** 2 occurrences — the packaged `Kraus.mapLM_ne_zero_of_exists_ne_zero`
-  (`TNLean/Channel/KrausMap.lean`) and the still-inlined six-line copy inside
+- **Seen:** the generic proof in `Kraus.mapLM_ne_zero_of_exists_ne_zero`
+  (`TNLean/Channel/KrausMap.lean`) and one former inline duplicate in
   `MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible`
-  (`TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean:270-277`), noted in the
-  2026-08 Perron–Frobenius gauge-split review.
-- **Abstraction (proposed):** replace the inlined copy with
-  `Kraus.mapLM_ne_zero_of_exists_ne_zero _ hB` composed with
+  (`TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean`).
+- **Reuse:** the transfer-map theorem now applies
+  `Kraus.mapLM_ne_zero_of_exists_ne_zero B hB` and rewrites the result with
   `Kraus.mapLM_eq_transferMap`.
-- **Notes:** below the rule-of-three threshold; revisit if a third inline copy
-  appears.
+- **Result:** the inline evaluation-at-identity proof is removed; no duplicate
+  implementation remains.
 
 ### irreducibility transfer to the conjugate-transposed family — candidate
 - **Pattern:** prove that irreducibility passes to the conjugate-transposed Kraus


### PR DESCRIPTION
### Summary

- replace the inline transfer-map nonzero proof with `Kraus.mapLM_ne_zero_of_exists_ne_zero`
- transport the result through `Kraus.mapLM_eq_transferMap`
- mark the matching tactic-ledger candidate as resolved

### Testing

- `lake build TNLean.MPS.CanonicalForm.ProjectorClosureSpectral` (8846 jobs)
- Lean diagnostics clean
- changed-file `sorry`/`axiom` scan
- reader-facing prose check
- `git diff --check`

Closes #6589
Closes #6592
Advances #6560