### PR TITLE
feat(kraus): add finite-map iterate expansion

### DIFF
--- a/TNLean/Kraus.lean
+++ b/TNLean/Kraus.lean
@@ -11,5 +11,6 @@ Authors: TNLean contributors
 import TNLean.Kraus.Blocking
 import TNLean.Kraus.Injectivity
 import TNLean.Kraus.InvariantProjection
+import TNLean.Kraus.MapIterate
 import TNLean.Kraus.MultiBlockWord
 import TNLean.Kraus.Word

--- a/TNLean/Kraus/MapIterate.lean
+++ b/TNLean/Kraus/MapIterate.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.Basic
+import TNLean.Kraus.Word
+
+/-!
+# Iterates of a finite Kraus map
+
+The `N`-fold iterate of the Kraus map associated with a finite matrix family is the Kraus
+map whose operators are the products indexed by words of length `N`. This is the
+finite-family form of the composition rule for Kraus representations.
+
+## Main declaration
+
+* `Kraus.mapLM_pow_apply` — expansion of an iterated finite Kraus map as a sum over words.
+-/
+
+open scoped Matrix BigOperators
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The `N`-fold iterate of a finite Kraus map is the sum over all Kraus words of
+length `N`. -/
+theorem mapLM_pow_apply (K : Fin d → Mat) (N : ℕ) :
+    ∀ X : Mat,
+      ((mapLM K) ^ N) X =
+        ∑ σ : Fin N → Fin d,
+          MPSTensor.evalWord K (List.ofFn σ) * X *
+            (MPSTensor.evalWord K (List.ofFn σ))ᴴ := by
+  induction N with
+  | zero =>
+      intro X
+      simp [Finset.univ_unique]
+  | succ n ih =>
+      intro X
+      rw [pow_succ']
+      change mapLM K (((mapLM K) ^ n) X) = _
+      rw [ih]
+      simp only [mapLM_apply, map_apply, map_sum]
+      rw [Finset.sum_comm]
+      rw [← (Fin.consEquiv (fun _ : Fin (n + 1) => Fin d)).sum_comp]
+      rw [Fintype.sum_prod_type]
+      congr 1
+      funext i
+      apply Finset.sum_congr rfl
+      intro τ _
+      simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+end Kraus

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -184,6 +184,28 @@ partial traces.
     vectorization and its inverse.
 \end{proof}
 
+\begin{theorem}[Iterates of a finite Kraus map]
+    \label{thm:kraus_map_iterate_word_expansion}
+    \lean{Kraus.mapLM_pow_apply}
+    \leanok
+    Let $I$ be finite, let $(K_i)_{i\in I}$ be a family in $\MN{D}$, and set
+    $E(X)=\sum_i K_iXK_i^\dagger$. For every non-negative integer $N$,
+    \[
+        E^N(X)=\sum_{\sigma\in I^N}
+        K_{\sigma_0}\cdots K_{\sigma_{N-1}}X
+        K_{\sigma_{N-1}}^\dagger\cdots K_{\sigma_0}^\dagger.
+    \]
+    For $N=0$, the product is the identity matrix.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The assertion for $N=0$ is immediate. For the induction step, apply $E$
+    to the expansion for $E^N(X)$ and distribute the finite sums. Prepending
+    one letter to each word of length $N$ gives every word of length $N+1$
+    exactly once.
+\end{proof}
+
 \begin{theorem}[Spectral bound for a vectorized unital Kraus map]
     \label{thm:unital_kraus_frobenius_spectral_radius}
     \lean{IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -72,7 +72,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_choi_and_kraus.tex` | L696 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L718 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 377, 390, 441 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

Adds the missing QIC-native iteration theorem for a finite Kraus map. For a family `K`, `Kraus.mapLM_pow_apply` identifies the `N`-fold iterate of `Kraus.mapLM K` with the Kraus sum over all words of length `N`.

The theorem is stated directly for `Kraus.mapLM`. The tensor-network declarations `MPSTensor.transferMap` and `IsIrreducibleTensor` remain under `MPS/`, with `MPS/Core/TransferChannel.lean` retaining its role as the comparison between the two formulations. Thus the change follows the boundary fixed in LionSR/QICLean#338 and does not move tensor-network vocabulary into `TNLean/Kraus/`.

## Files

- `TNLean/Kraus/MapIterate.lean`: the exact word expansion `Kraus.mapLM_pow_apply`.
- `TNLean/Kraus.lean`: generated import for the new module.
- `blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex`: mathematical statement and proof outline.

## Validation

- `lake env lean TNLean/Kraus/MapIterate.lean`
- `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root . --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/main`
- reverse blueprint coverage check for `TNLean/Kraus/MapIterate.lean`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`

Closes LionSR/QICLean#338.