### PR TITLE
refactor(channel): relocate PSD eigenvector upgrade

### DIFF
--- a/TNLean/Channel/Irreducible/Growth/OneStep.lean
+++ b/TNLean/Channel/Irreducible/Growth/OneStep.lean
@@ -24,6 +24,8 @@ i.e. $A$ is positive definite.
 
 * `posDef_of_ker_subset_irreducible_cp` — structural one-step lemma used in the
   dimension-descent proof of the growth condition.
+* `posDef_of_posSemidef_eigenvector_irreducible_cp` — nonzero PSD eigenvectors
+  with positive eigenvalue are positive definite.
 
 ## References
 
@@ -247,5 +249,28 @@ theorem posDef_of_ker_subset_irreducible_cp
   rcases hQ_zero_or_one with h | h
   · exact hQ_ne_zero h
   · exact hQ_ne_one (by convert h)
+
+/-! ## PSD eigenvector → PosDef (Wolf 6.3(2), upgrade) -/
+
+/-- **PSD eigenvectors of irreducible CP maps are PosDef** (Wolf Theorem 6.3(2)).
+
+If `E` is an irreducible CP map and `E ρ = r • ρ` with `ρ` PSD nonzero and
+`r > 0`, then `ρ` is positive definite.
+
+The key observation is that `E ρ = r • ρ` with `r > 0` implies
+`ker(ρ) = ker(E(ρ))` (since `ker(r • ρ) = ker(ρ)`). By
+`posDef_of_ker_subset_irreducible_cp`, the inclusion `ker(ρ) ⊆ ker(E(ρ))`
+under irreducible CP forces `ρ` to be PosDef. -/
+theorem posDef_of_posSemidef_eigenvector_irreducible_cp
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ)
+    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0) (_ : 0 < r)
+    (hEig : E ρ = (r : ℂ) • ρ) :
+    ρ.PosDef := by
+  apply posDef_of_ker_subset_irreducible_cp E hCP hIrr ρ hρ_psd hρ_ne
+  -- Show ker(ρ) ⊆ ker(E(ρ)): since E(ρ) = r • ρ, (E ρ) *ᵥ v = r • (ρ *ᵥ v) = 0
+  intro v hv
+  rw [hEig, Matrix.smul_mulVec, hv, smul_zero]
 
 end OneStep

--- a/TNLean/Channel/Irreducible/PerronFrobenius.lean
+++ b/TNLean/Channel/Irreducible/PerronFrobenius.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Irreducible.FixedPointUniqueness
-import TNLean.Channel.Irreducible.Growth
+import TNLean.Channel.Irreducible.Growth.OneStep
 import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.Scaling
 
@@ -16,8 +16,6 @@ positive maps on `M_D(ℂ)` needed for Wolf's Theorem 6.3, items 2 and 3.
 
 ## Main results
 
-* `posDef_of_posSemidef_eigenvector_irreducible_cp`:
-  nonzero PSD eigenvectors with positive eigenvalue are positive definite.
 * `exists_posDef_eigenvector_of_irreducible_cp`:
   every nonzero irreducible CP map admits a positive-definite eigenvector with
   positive eigenvalue.
@@ -36,29 +34,6 @@ open scoped Matrix MatrixOrder Pointwise ComplexOrder BigOperators
 open Matrix Finset
 
 variable {D : ℕ}
-
-/-! ## PSD eigenvector → PosDef (Wolf 6.3(2), upgrade) -/
-
-/-- **PSD eigenvectors of irreducible CP maps are PosDef** (Wolf Theorem 6.3(2)).
-
-If `E` is an irreducible CP map and `E ρ = r • ρ` with `ρ` PSD nonzero and
-`r > 0`, then `ρ` is positive definite.
-
-The key observation is that `E ρ = r • ρ` with `r > 0` implies
-`ker(ρ) = ker(E(ρ))` (since `ker(r • ρ) = ker(ρ)`). By
-`posDef_of_ker_subset_irreducible_cp`, the inclusion `ker(ρ) ⊆ ker(E(ρ))`
-under irreducible CP forces `ρ` to be PosDef. -/
-theorem posDef_of_posSemidef_eigenvector_irreducible_cp
-    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ)
-    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0) (_ : 0 < r)
-    (hEig : E ρ = (r : ℂ) • ρ) :
-    ρ.PosDef := by
-  apply posDef_of_ker_subset_irreducible_cp E hCP hIrr ρ hρ_psd hρ_ne
-  -- Show ker(ρ) ⊆ ker(E(ρ)): since E(ρ) = r • ρ, (E ρ) *ᵥ v = r • (ρ *ᵥ v) = 0
-  intro v hv
-  rw [hEig, Matrix.smul_mulVec, hv, smul_zero]
 
 /-! ## Existence of PosDef eigenvector (Wolf 6.3(2), existence) -/
 

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -209,8 +209,8 @@ theorem exists_posDef_adjoint_eigenvector
       hcp.isPositiveMap (hNZ := hNZ)
   -- Step 5: Upgrade PSD → PosDef (Wolf Theorem 6.3(2)).
   have hσ_pd : σ.PosDef :=
-    posDef_of_ker_subset_irreducible_cp _ hcp hIrrAdj σ hσ_psd hσ_ne
-      (fun v hv => by rw [hσ_eig, Matrix.smul_mulVec, hv, smul_zero])
+    posDef_of_posSemidef_eigenvector_irreducible_cp
+      _ hcp hIrrAdj σ r hσ_psd hσ_ne hr_pos hσ_eig
   exact ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩
 
 end Kraus

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -135,7 +135,7 @@ Channel-level (general irreducible CP maps):
 * `posDef_of_posSemidef_fixedPoint_irreducible_cp` — `TNLean.Channel.Irreducible.FixedPoint`:
   nonzero PSD fixed point → PosDef
 * `posDef_of_posSemidef_eigenvector_irreducible_cp` —
-  `TNLean.Channel.Irreducible.PerronFrobenius`: PSD eigenvector → PosDef
+  `TNLean.Channel.Irreducible.Growth.OneStep`: PSD eigenvector → PosDef
 * `exists_posDef_eigenvector_of_irreducible_cp`: ∃ PosDef eigenvector with `r > 0`
 * `posSemidef_eigenvector_unique_of_irreducible_cp`: uniqueness up to scalar
 

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -368,7 +368,7 @@ outer square-root factors yields
 
 \begin{proof}\leanok
     \uses{thm:pf_eigenvector_existence, thm:adjoint_transfer_ne_zero,
-        thm:kernel_inclusion_pd_irred, thm:kraus_conjTranspose_irreducible,
+        thm:psd_eigenvector_pd_irred, thm:kraus_conjTranspose_irreducible,
         thm:kraus_map_cp}
     The conjugate-transposed family $\{K_i^\dagger\}$ has the same Kraus map
     as the adjoint of $\mathcal K_K$, so it is completely positive
@@ -379,10 +379,8 @@ outer square-root factors yields
     matrix, and
     Theorem~\ref{thm:pf_eigenvector_existence} applies, giving
     $\sigma \ge 0$, $\sigma \neq 0$, and $r > 0$ with
-    $\sum_i K_i^\dagger \sigma K_i = r\sigma$. Since
-    $\ker\sigma \subseteq \ker\bigl(\sum_i K_i^\dagger \sigma K_i\bigr)$
-    follows immediately from this eigenvector equation,
-    Theorem~\ref{thm:kernel_inclusion_pd_irred} gives that $\sigma$ is
+    $\sum_i K_i^\dagger \sigma K_i = r\sigma$.
+    Theorem~\ref{thm:psd_eigenvector_pd_irred} then gives that $\sigma$ is
     positive definite.
 \end{proof}
 


### PR DESCRIPTION
### Summary

- move `posDef_of_posSemidef_eigenvector_irreducible_cp` next to its kernel-inclusion dependency in `Growth/OneStep`
- replace the inline positive-definiteness upgrade in the Kraus adjoint eigenvector construction
- update the Wolf index location and blueprint proof dependency

### Testing

- targeted builds for `Growth.OneStep`, `Irreducible.PerronFrobenius`, `PerronFrobenius.Existence`, `Irreducible.Ergodicity`, and `WolfChapter6Index`
- Lean diagnostics clean
- blueprint source synchronization: 7,983/7,983
- changed-file unsafe-placeholder scan
- reader-facing prose and diff checks

Closes LionSR/QICLean#334
Advances LionSR/TNLean#6560