### PR TITLE
feat(channel): specialize Kraus Choi decomposition

### DIFF
--- a/TNLean/Channel/KrausRank.lean
+++ b/TNLean/Channel/KrausRank.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Fintype.Card
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.Schwarz.Basic
 
 /-!
 # Kraus-cardinality and Choi-rank correspondence
@@ -35,6 +36,8 @@ definitionally `ChoiJamiolkowski.choiMatrix`).
 * `Channel.hasKrausCard_mono` — zero-padding enlarges a Kraus family.
 * `Channel.choiMatrix_eq_sum_vecMulVec_of_kraus` — the Choi matrix of a Kraus
   map is a sum of rank-one outer products.
+* `Channel.choiMatrix_mapLM_eq_sum_vecMulVec` — the square specialization for
+  the concrete finite Kraus linear map.
 * `Channel.choiRank_le_of_hasKrausCard` — any `r`-operator Kraus family gives
   the upper bound `choiRank T ≤ r`.
 * `Channel.choiRank_le_of_hasKrausRankLE` — the same upper bound for bounded
@@ -176,6 +179,21 @@ theorem choiMatrix_eq_sum_vecMulVec_of_kraus {r : ℕ}
     congrArg (fun M => M i₁ j₁)
       (Matrix.mul_single_mul_conjTranspose_eq_vecMulVec
         (K := K x) (c := c) i₂ j₂)
+
+/-- The square Choi matrix of `Kraus.mapLM K` is the normalized sum of the outer
+products of the vectorized Kraus operators. This specializes
+`choiMatrix_eq_sum_vecMulVec_of_kraus` without changing its output-input orientation. -/
+theorem choiMatrix_mapLM_eq_sum_vecMulVec {r D : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    ChoiJamiolkowski.choiMatrix (Kraus.mapLM K) =
+      ∑ j : Fin r,
+        Matrix.vecMulVec
+          (fun p : Fin D × Fin D => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * K j p.1 p.2)
+          (star fun p : Fin D × Fin D =>
+            ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * K j p.1 p.2) := by
+  rw [← ChoiRectangular.choiMatrix_eq_choiJamiolkowski]
+  exact choiMatrix_eq_sum_vecMulVec_of_kraus K (Kraus.mapLM K) fun X => by
+    rw [Kraus.mapLM_apply, Kraus.map_apply]
 
 /-- A Choi-matrix decomposition into rank-one outer products yields a Kraus
 family indexed by the same finite type. -/

--- a/blueprint/src/chapter/ch04_channels_choi_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_choi_foundations.tex
@@ -167,10 +167,36 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
     $i_1=j_2$ and $i_2=j_1$.
 \end{proof}
 
+\begin{theorem}[Choi decomposition of a Kraus map]\label{thm:choi_kraus_outer_product}
+    \lean{Channel.choiMatrix_mapLM_eq_sum_vecMulVec}
+    \leanok
+    \uses{def:choi_matrix}
+    Let $D\geq1$ and let
+    $T(X)=\sum_{i=0}^{r-1}K_iXK_i^\dagger$. Define the vector $v_i$ by
+    $(v_i)_{(a,b)}=D^{-1/2}K_i(a,b)$, without transposing the matrix indices.
+    Then
+    \begin{align}
+        \tau_T
+        &= \sum_{i=0}^{r-1}\ketbra{v_i}{v_i}.
+        \label{eq:representations_choi_kraus_outer_product}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:choi_matrix}
+    The $(i_2,j_2)$ slice of $\ketbra{\Omega}{\Omega}$ is
+    $D^{-1}E_{i_2j_2}$. Therefore the
+    $((i_1,i_2),(j_1,j_2))$ entry of the Choi matrix is
+    \begin{align}
+        \frac{1}{D}\sum_x K_x(i_1,i_2)\overline{K_x(j_1,j_2)},
+    \end{align}
+    which is the corresponding entry of the stated sum of outer products.
+\end{proof}
+
 \begin{theorem}[Complete positivity iff the Choi matrix is positive semidefinite]\label{thm:cp_iff_choi_posSemidef}
     \lean{ChoiJamiolkowski.cp_iff_choi_posSemidef}
     \leanok
-    \uses{def:choi_matrix, def:cp_map}
+    \uses{def:choi_matrix, def:cp_map, thm:choi_kraus_outer_product}
     Let $D\geq1$. A linear map $T : \MN{D} \to \MN{D}$ is completely
     positive (in the Kraus sense) if and only if its Choi matrix $\tau \ge 0$.
     This is the $d=d'$ specialization of
@@ -181,7 +207,7 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
 
 \begin{proof}
     \leanok
-    \uses{def:choi_matrix, def:cp_map}
+    \uses{def:choi_matrix, def:cp_map, thm:choi_kraus_outer_product}
     ($\Rightarrow$) If $T(X) = \sum_i K_i X K_i^\dagger$, then
     $\tau = \sum_i \ketbra{v_i}{v_i}$ where
     $(v_i)_{(a,b)} = c\,K_i(a,b)$ and $c = 1/\sqrt{D}$.


### PR DESCRIPTION
## What changed

- add `Channel.choiMatrix_mapLM_eq_sum_vecMulVec`, the square `Kraus.mapLM` specialization of the existing rectangular Choi/Kraus outer-product identity
- derive it from `Channel.choiMatrix_eq_sum_vecMulVec_of_kraus` through `Kraus.mapLM_apply`, `Kraus.map_apply`, and `ChoiRectangular.choiMatrix_eq_choiJamiolkowski`, without a second entrywise proof
- record the normalized vectorization convention $v_j(a,b)=D^{-1/2}K_j(a,b)$ in the Choi blueprint and preserve the existing output-input index orientation

## Validation

- `lake build TNLean.Channel.KrausRank` (3043 jobs)
- `python3 scripts/blueprint_lean_sync.py --root .` (7984/7984, in sync)
- `python3 scripts/check_import_direction.py --root . --base-ref origin/main` (0 violations)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` (0 violations)
- `git diff origin/main...HEAD --check`
- changed-file `sorry`/`axiom` grep: no matches
- generated `print.tnlog` absent and `print.pdf` unchanged

## Caveats

Per the requested targeted-check policy, this branch did not run a full repository build, a fresh cache fetch, or a post-rebase full blueprint PDF build. The source-sync checker resolves the new blueprint tag, and the changed Lean target builds cleanly.

Advances LionSR/QICLean#332
