### PR TITLE
refactor(wielandt): reuse the transfer-channel bridge

### DIFF
--- a/TNLean/MPS/Core/CPPrimitive.lean
+++ b/TNLean/MPS/Core/CPPrimitive.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Core.Transfer
+import TNLean.MPS.Core.TransferChannel
 import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Schwarz.KadisonSchwarz
@@ -107,11 +107,8 @@ is a quantum channel: completely positive and trace-preserving. -/
 theorem transferMap_isChannel
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    IsChannel (MPSTensor.transferMap (d := d) (D := D) A) := by
-  refine ⟨transferMap_isCPMap A, fun X => ?_⟩
-  simp only [transferMap_apply, Matrix.trace_sum]
-  conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-  rw [← Matrix.trace_sum, ← Finset.sum_mul, hNorm, one_mul]
+    IsChannel (MPSTensor.transferMap (d := d) (D := D) A) :=
+  Kraus.isChannel_transferMap A hNorm
 
 /-! ### Iterated transfer map
 

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Primitive
-import TNLean.MPS.Core.CPPrimitive
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.QPF.PosDef
@@ -147,7 +147,7 @@ theorem IsPrimitiveMPS.transferMap_isChannel
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) :
     IsChannel (transferMap (d := d) (D := D) A) :=
-  MPSTensor.transferMap_isChannel A hP.norm
+  Kraus.isChannel_transferMap A hP.norm
 
 /-- Preferred theorem stating that the transfer map attached to
 `IsPrimitiveMPS A ρ` is trace-preserving. -/


### PR DESCRIPTION
## What changed

- replace the `CPPrimitive` import in `Wielandt/Primitivity/ToNormal.lean` with `TransferChannel`
- prove `IsPrimitiveMPS.transferMap_isChannel` via `Kraus.isChannel_transferMap A hP.norm`
- preserve `MPSTensor.transferMap_isChannel` as a one-line corollary of the same Kraus theorem

## Validation

- `lake build TNLean.MPS.Core.CPPrimitive`
- `lake build TNLean.Wielandt.Primitivity.ToNormal`
- `python3 scripts/check_import_direction.py --root . --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `rg -n "\b(sorry|axiom)\b" TNLean/MPS/Core/CPPrimitive.lean TNLean/Wielandt/Primitivity/ToNormal.lean` (no matches)

Closes #6614