### PR TITLE
feat(mps/core): add TP gauge eigenvector theorem

### DIFF
--- a/TNLean/MPS/Core/TPGauge.lean
+++ b/TNLean/MPS/Core/TPGauge.lean
@@ -96,7 +96,7 @@ theorem tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint
 
 Assume `ρ` is positive definite and
 `E_A†(ρ) = rρ` for a positive real number `r`. Then applying `tpGauge` after
-rescaling `A` by `r⁻¹ᐟ²` gives a trace-preserving tensor. -/
+rescaling `A` by `r^{-1/2}` gives a trace-preserving tensor. -/
 theorem tpGauge_isTP_of_transferMap_conjTranspose_eigenvector
     (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ)
     (hρ : ρ.PosDef)

--- a/TNLean/MPS/Core/TPGauge.lean
+++ b/TNLean/MPS/Core/TPGauge.lean
@@ -92,6 +92,41 @@ theorem tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint
   Kraus.tpGauge_isTP_of_map_conjTranspose_fixedPoint A ρ hρ (by
     simpa [Kraus.mapLM_apply, Kraus.map_apply, MPSTensor.transferMap_apply] using hfix)
 
+/-- **TP normalisation from a positive adjoint-transfer-map eigenvector.**
+
+Assume `ρ` is positive definite and
+`E_A†(ρ) = rρ` for a positive real number `r`. Then applying `tpGauge` after
+rescaling `A` by `r⁻¹ᐟ²` gives a trace-preserving tensor. -/
+theorem tpGauge_isTP_of_transferMap_conjTranspose_eigenvector
+    (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ)
+    (hρ : ρ.PosDef)
+    (hr : 0 < r)
+    (heig : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ρ = (r : ℂ) • ρ) :
+    ∑ i : Fin d,
+      (tpGauge (d := d) (D := D)
+        (fun j => (↑((Real.sqrt r)⁻¹) : ℂ) • A j) ρ i)ᴴ *
+      tpGauge (d := d) (D := D)
+        (fun j => (↑((Real.sqrt r)⁻¹) : ℂ) • A j) ρ i = 1 := by
+  let c : ℝ := (Real.sqrt r)⁻¹
+  let A' : MPSTensor d D := fun i => (↑c : ℂ) • A i
+  have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
+    rw [RCLike.star_def, Complex.conj_ofReal]
+  have hcc : c * c = r⁻¹ := by
+    rw [show c = (Real.sqrt r)⁻¹ from rfl, ← sq, inv_pow, Real.sq_sqrt hr.le]
+  have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
+    rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
+  have hfix : transferMap (d := d) (D := D) (fun i => (A' i)ᴴ) ρ = ρ := by
+    simp only [A', transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
+      Matrix.mul_smul, smul_smul, star_star]
+    simp_rw [hstar_c, hc_sq]
+    rw [← Finset.smul_sum]
+    have hsum : ∑ i : Fin d, (A i)ᴴ * ρ * ((A i)ᴴ)ᴴ =
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ρ := by
+      simp [transferMap_apply]
+    rw [hsum, heig, smul_smul, inv_mul_cancel₀, one_smul]
+    exact_mod_cast hr.ne'
+  exact tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A' ρ hρ hfix
+
 /-- The gauge-transformed tensor `tpGauge A ρ` is gauge-equivalent to `A`
 (hence has the same MPV). -/
 theorem gaugeEquiv_tpGauge (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -95,43 +95,12 @@ theorem exists_tp_data_of_irreducible
       -- B is gauge-equivalent to the rescaled tensor
       GaugeEquiv (d := d) (D := D)
         (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
-  -- Get the PosDef adjoint eigenvector.
   obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
     exists_posDef_adjoint_eigenvector A hIrr hA
-  -- Define the rescaled tensor.
-  set c := (Real.sqrt r)⁻¹ with hc_def
-  set A' : MPSTensor d D := fun i => (↑c : ℂ) • A i with hA'_def
-  -- Auxiliary lemma: star of a real-coerced scalar is itself.
-  have hstar_c : star (↑c : ℂ) = (↑c : ℂ) := by
-    rw [RCLike.star_def, Complex.conj_ofReal]
-  -- Key scalar identity.
-  have hcc : (c : ℝ) * c = r⁻¹ := by
-    rw [hc_def, ← sq, inv_pow, Real.sq_sqrt hr_pos.le]
-  have hc_sq : (↑c : ℂ) * (↑c : ℂ) = (↑r : ℂ)⁻¹ := by
-    rw [← Complex.ofReal_mul, hcc, Complex.ofReal_inv]
-  -- σ is a PosDef fixed point of transferMap(fun i => (A' i)ᴴ).
-  have hA'_fix : transferMap (d := d) (D := D) (fun i => (A' i)ᴴ) σ = σ := by
-    simp only [hA'_def, transferMap_apply, Matrix.conjTranspose_smul, Matrix.smul_mul,
-      Matrix.mul_smul, smul_smul, star_star]
-    simp_rw [hstar_c, hc_sq]
-    rw [← Finset.smul_sum]
-    have h_sum : ∑ i : Fin d, (A i)ᴴ * σ * ((A i)ᴴ)ᴴ =
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ := by
-      simp [transferMap_apply]
-    rw [h_sum, hσ_eig, smul_smul, inv_mul_cancel₀, one_smul]
-    exact_mod_cast hr_pos.ne'
-  -- Apply tpGauge.
-  set B := tpGauge (d := d) (D := D) A' σ with hB_def
-  have hB_tp : ∑ i : Fin d, (B i)ᴴ * B i = 1 :=
-    tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A' σ hσ_pd hA'_fix
-  have hB_gauge : GaugeEquiv (d := d) (D := D) A' B :=
-    gaugeEquiv_tpGauge A' σ hσ_pd
-  refine ⟨B, r, σ, hσ_pd, hr_pos, ?_, hB_tp, ?_⟩
-  -- Explicit form of B.
-  · intro i
-    rfl
-  -- GaugeEquiv: A' matches the stated rescaled tensor.
-  · convert hB_gauge using 1
+  let A' : MPSTensor d D := fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i
+  let B := tpGauge (d := d) (D := D) A' σ
+  refine ⟨B, r, σ, hσ_pd, hr_pos, fun i => rfl, ?_, gaugeEquiv_tpGauge A' σ hσ_pd⟩
+  exact tpGauge_isTP_of_transferMap_conjTranspose_eigenvector A σ r hσ_pd hr_pos hσ_eig
 
 /-- **Unital gauge data for an irreducible MPS tensor.**
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -672,6 +672,29 @@ and~\cite{Evans1978Spectral}.
     appears in Section~\ref{sec:app_qpf_gauge}.
 \end{proof}
 
+\begin{theorem}[Square-root trace-preserving gauge from an adjoint eigenvector]%
+    \label{thm:tp_gauge_from_adjoint_eigenvector}
+    \lean{MPSTensor.tpGauge_isTP_of_transferMap_conjTranspose_eigenvector}
+    \leanok
+    \uses{thm:tp_gauge_from_adjoint_fixed}
+    Let $\sigma$ be positive definite and satisfy
+    $\sum_i (A^i)^\dagger \sigma A^i = r\sigma$ for $r>0$.
+    Define
+    \begin{align}
+        B^i
+         & = \sigma^{1/2}(r^{-1/2}A^i)\sigma^{-1/2}.
+        \label{eq:qpf_tp_gauge_eigenvector}
+    \end{align}
+    Then $B$ is trace-preserving:
+    $\sum_i (B^i)^\dagger B^i = \Id$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Rescale $A$ by $r^{-1/2}$. The adjoint transfer map is quadratic in
+    the tensor, so the eigenvector equation becomes a fixed-point equation.
+    Theorem~\ref{thm:tp_gauge_from_adjoint_fixed} then gives the result.
+\end{proof}
+
 
 \begin{remark}\leanok
     The right-canonical gauge of Theorem~\ref{thm:right_canonical_gauge}
@@ -874,15 +897,15 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:posDef_adjoint_eigenvector, thm:tp_gauge_from_adjoint_fixed,
+    \uses{thm:posDef_adjoint_eigenvector, thm:tp_gauge_from_adjoint_eigenvector,
         lem:tp_gauge_equiv}
     By Theorem~\ref{thm:posDef_adjoint_eigenvector},
     obtain $\sigma$ positive definite and $r > 0$ with
     $\E_A^\dagger(\sigma) = r\sigma$.
     Set $c = r^{-1/2}$ and $A'^i = cA^i$.
     Then $\E_{A'}^\dagger(\sigma) = \sigma$.
-    By the square-root trace-preserving gauge construction
-    (Theorem~\ref{thm:tp_gauge_from_adjoint_fixed}), the tensor defined by
+    By the square-root trace-preserving eigenvector gauge construction
+    (Theorem~\ref{thm:tp_gauge_from_adjoint_eigenvector}), the tensor defined by
     (\ref{eq:qpf_irred_tp_gauge}) satisfies
     $\sum_i (B^i)^\dagger B^i = \Id$.
     Lemma~\ref{lem:tp_gauge_equiv} gives the required gauge equivalence to


### PR DESCRIPTION
### Summary

- add the eigenvector-form TP-gauge theorem symmetric to the spectral unital-gauge API
- internalize the `r^{-1/2}` fixed-point rescaling in the reusable helper
- collapse `exists_tp_data_of_irreducible` to one theorem application
- add and use the matching blueprint entry

### Testing

- `lake build TNLean.MPS.Core.TPGauge TNLean.MPS.Irreducible.PerronGauge` (8792 jobs after rebasing onto merged prerequisites)
- Lean diagnostics clean
- blueprint source synchronization: 7,984/7,984
- changed-file integrity scan
- reader-facing prose and diff checks

Closes #6588
Advances #6560