### PR TITLE
feat(algebra): characterize positive finite frame operators

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -29,6 +29,7 @@ import TNLean.Algebra.EventuallyConstantCycleWeights
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.FiniteCycleCoboundary
+import TNLean.Algebra.FrameOperator
 import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers

--- a/TNLean/Algebra/FrameOperator.lean
+++ b/TNLean/Algebra/FrameOperator.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Finite frame operators
+
+This file characterizes when the frame operator of a finite family of complex vectors is
+positive definite. The criterion is that the family spans the ambient coordinate space.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+open Module
+
+namespace Matrix
+
+variable {ι n : Type*} [Fintype ι] [Finite n]
+
+/-- The sum of the rank-one operators `|v i⟩⟨v i|` is positive definite exactly when the
+finite family `v` spans the ambient complex coordinate space. -/
+theorem posDef_sum_vecMulVec_iff_span_eq_top (v : ι → n → ℂ) :
+    (∑ i : ι, vecMulVec (v i) (star (v i))).PosDef ↔
+      Submodule.span ℂ (Set.range v) = ⊤ := by
+  classical
+  let _ := Fintype.ofFinite n
+  let B : Matrix n ι ℂ := fun j i => v i j
+  have hsum : ∑ i : ι, vecMulVec (v i) (star (v i)) = B * Bᴴ := by
+    ext j k
+    rw [Matrix.sum_apply, mul_apply]
+    congr 1
+  have hspan : Submodule.span ℂ (Set.range v) = ⊤ ↔ Function.Surjective B.mulVec := by
+    change Submodule.span ℂ (Set.range v) = ⊤ ↔ Function.Surjective B.mulVecLin
+    rw [← LinearMap.range_eq_top, Matrix.range_mulVecLin]
+    have hcol : B.col = v := by
+      funext i j
+      rfl
+    rw [hcol]
+  rw [hsum, hspan]
+  constructor
+  · intro hpd
+    have hdet : IsUnit (B * Bᴴ).det := (isUnit_iff_isUnit_det (B * Bᴴ)).mp hpd.isUnit
+    rw [Matrix.mulVec_surjective_iff_exists_right_inverse]
+    refine ⟨Bᴴ * (B * Bᴴ)⁻¹, ?_⟩
+    rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hdet]
+  · intro hsurj
+    obtain ⟨C, hC⟩ := Matrix.mulVec_surjective_iff_exists_right_inverse.mp hsurj
+    have hinj : Function.Injective B.vecMul := by
+      intro x y hxy
+      have h := congr_arg (fun z => z ᵥ* C) hxy
+      simpa [Matrix.vecMul_vecMul, hC] using h
+    simpa using Matrix.PosDef.one.mul_mul_conjTranspose_same hinj
+
+end Matrix

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FrameOperator
 import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Wielandt.Primitivity.Normal
 import TNLean.Kraus.InvariantProjection
@@ -81,76 +82,8 @@ when x ≠ 0 since {vᵢ} spans. -/
 theorem posDef_sum_vecMulVec_of_span_eq_top {ι : Type*} [Fintype ι]
     (v : ι → (Fin D → ℂ))
     (hspan : Submodule.span ℂ (Set.range v) = ⊤) :
-    (∑ i : ι, vecMulVec (v i) (star (v i))).PosDef := by
-  rw [Matrix.posDef_iff_dotProduct_mulVec]
-  constructor
-  · -- Hermitian: (vv†)† = vv†
-    change (∑ i : ι, vecMulVec (v i) (star (v i))).IsHermitian
-    change (∑ i : ι, vecMulVec (v i) (star (v i)))ᴴ = _
-    simp only [conjTranspose_sum, conjTranspose_vecMulVec, star_star]
-  · -- Positive definite: ⟨x, Mx⟩ > 0 for x ≠ 0
-    intro x hx
-    -- Expand: star x ⬝ᵥ (Σ vv† *ᵥ x) = Σ (star x ⬝ᵥ (vv† *ᵥ x))
-    simp only [Matrix.sum_mulVec, dotProduct_sum, vecMulVec_mulVec]
-    -- Each term: star x ⬝ᵥ (op(star v ⬝ᵥ x) • v) = (star v ⬝ᵥ x) * (star x ⬝ᵥ v)
-    -- We'll show each is = ↑(‖star x ⬝ᵥ v i‖²) and the sum is positive
-    -- Step 1: Show the sum is a real number ≥ 0, cast to ℂ
-    suffices h : (0 : ℝ) < ∑ i : ι, ‖star x ⬝ᵥ v i‖ ^ 2 by
-      have heq : ∑ i : ι, star x ⬝ᵥ (MulOpposite.op (star (v i) ⬝ᵥ x) • v i) =
-          ↑(∑ i : ι, ‖star x ⬝ᵥ v i‖ ^ 2) := by
-        push_cast
-        congr 1; ext i
-        -- Goal: star x ⬝ᵥ (op(star v ⬝ᵥ x) • v) = ↑‖star x ⬝ᵥ v‖²
-        -- Simplify MulOpposite scalar action to multiplication
-        rw [show MulOpposite.op (star (v i) ⬝ᵥ x) • v i =
-            (star (v i) ⬝ᵥ x) • v i from by
-          ext j; simp [MulOpposite.smul_eq_mul_unop, mul_comm]]
-        rw [dotProduct_smul, smul_eq_mul]
-        have hconj : star (v i) ⬝ᵥ x = starRingEnd ℂ (star x ⬝ᵥ v i) := by
-          simp [dotProduct, map_sum, mul_comm]
-        rw [hconj, mul_comm, Complex.mul_conj, ← Complex.sq_norm]
-        push_cast; rfl
-      rw [heq]
-      exact_mod_cast h
-    -- Step 2: Show the real sum is positive
-    apply Finset.sum_pos'
-    · intro i _; positivity
-    · -- There exists i with ⟨v i, x⟩ ≠ 0
-      by_contra hall
-      push Not at hall
-      have horth : ∀ i, star x ⬝ᵥ v i = 0 := by
-        intro i
-        have h1 := hall i (Finset.mem_univ i)
-        have h2 : (0 : ℝ) ≤ ‖star x ⬝ᵥ v i‖ ^ 2 := sq_nonneg _
-        have h3 : ‖star x ⬝ᵥ v i‖ ^ 2 = 0 := le_antisymm h1 h2
-        rwa [sq_eq_zero_iff, norm_eq_zero] at h3
-      -- x is orthogonal to span of {v i}
-      have horth_span : ∀ w ∈ Submodule.span ℂ (Set.range v), star x ⬝ᵥ w = 0 := by
-        intro w hw
-        induction hw using Submodule.span_induction with
-        | mem w hw =>
-          obtain ⟨i, rfl⟩ := hw; exact horth i
-        | zero => simp
-        | add w₁ w₂ _ _ h₁ h₂ => rw [dotProduct_add, h₁, h₂, add_zero]
-        | smul c w₁ _ hw₁ => rw [dotProduct_smul, hw₁, smul_zero]
-      -- star x ⬝ᵥ x = 0
-      have hxx : star x ⬝ᵥ x = 0 := horth_span x (hspan ▸ Submodule.mem_top)
-      -- But star x ⬝ᵥ x = Σ |x_j|² > 0 for x ≠ 0
-      have hxx_real : star x ⬝ᵥ x = ↑(∑ j : Fin D, Complex.normSq (x j)) := by
-        simp only [dotProduct, Pi.star_apply]
-        push_cast
-        congr 1; ext j
-        rw [show star (x j) * x j = x j * starRingEnd ℂ (x j) from by
-          simp [mul_comm]]
-        rw [Complex.mul_conj]
-      rw [hxx_real] at hxx
-      have hne : ∃ j, x j ≠ 0 := by
-        by_contra h; push Not at h; exact hx (funext h)
-      obtain ⟨j, hj⟩ := hne
-      have hpos : (0 : ℝ) < ∑ k : Fin D, Complex.normSq (x k) :=
-        Finset.sum_pos' (fun k _ => Complex.normSq_nonneg _)
-          ⟨j, Finset.mem_univ _, Complex.normSq_pos.mpr hj⟩
-      exact absurd (Complex.ofReal_eq_zero.mp hxx) (ne_of_gt hpos)
+    (∑ i : ι, vecMulVec (v i) (star (v i))).PosDef :=
+  (Matrix.posDef_sum_vecMulVec_iff_span_eq_top v).2 hspan
 
 /-! ## Part 4: Transfer map on rank-one is PosDef under primitivity -/
 

--- a/blueprint/src/chapter/ch04_channels_positive_map_and_channel_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_positive_map_and_channel_foundations.tex
@@ -20,6 +20,28 @@
     $Y - X \ge 0$.
 \end{remark}
 
+\begin{theorem}[Finite frame criterion]
+    \label{thm:finite_frame_posdef}
+    \lean{Matrix.posDef_sum_vecMulVec_iff_span_eq_top}
+    \leanok
+    Let $(v_i)_{i\in I}$ be a finite family in $\C^n$. Then
+    \begin{align}
+        \sum_{i\in I}\ketbra{v_i}{v_i}>0
+        \quad\Longleftrightarrow\quad
+        \operatorname{span}\{v_i:i\in I\}=\C^n.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $B:\C^I\to\C^n$ be the synthesis map with columns $v_i$.
+    The frame operator is $BB^\dagger$, while the vectors span exactly when
+    $B$ is surjective. A right inverse of $B$ makes $B^\dagger$ injective,
+    which gives positive definiteness of $BB^\dagger$. Conversely, if
+    $BB^\dagger$ is positive definite, then
+    $B^\dagger(BB^\dagger)^{-1}$ is a right inverse of $B$.
+\end{proof}
+
 \begin{definition}[Completely positive map]\label{def:cp_map}
     \lean{IsCPMap}
     \leanok


### PR DESCRIPTION
## What changed

- add `Matrix.posDef_sum_vecMulVec_iff_span_eq_top` for a finite family of complex coordinate vectors
- prove the equivalence through the rectangular synthesis matrix `B`, identifying the frame operator with `B * Bᴴ` and spanning with surjectivity of `B.mulVec`
- preserve `MPSTensor.posDef_sum_vecMulVec_of_span_eq_top` as a thin specialization of the neutral theorem
- add the generated algebra import and blueprint coverage for the finite-frame criterion

Advances LionSR/QICLean#332

## Validation

- `lake build TNLean.Algebra.FrameOperator TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible` (8812 jobs, passed)
- `python3 scripts/generate_import_aggregators.py --check` (53 aggregators, 1452 production modules)
- `python3 scripts/check_import_direction.py --root . --base-ref origin/main` (431 QIC-bound files, 0 violations)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- changed-file proof-integrity scan found no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`

## Caveat

Per the shared resource constraint, this branch did not run a full build or fetch a cache. The strict blueprint declaration-resolution check was not rerun because it requires the complete root build; the new declaration itself and its only refactored consumer both compile in the targeted build above.
