### PR TITLE
refactor(algebra): remove support projection shim

### DIFF
--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -417,62 +417,19 @@ theorem supportProj_mul_conjTranspose_mul_self (B : Matrix m n ℂ) :
   rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at hPB
   exact hPB.symm
 
-variable {D : ℕ}
-
-/-- The `Fin`-indexed support projection of a positive-semidefinite matrix. -/
-noncomputable def supportProj (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
-    Matrix (Fin D) (Fin D) ℂ := hρ.supportProj
-
-/-- The `Fin`-indexed support projection is orthogonal. -/
-theorem isOrthogonalProjection_supportProj (ρ : Matrix (Fin D) (Fin D) ℂ)
-    (hρ : ρ.PosSemidef) : IsOrthogonalProjection (supportProj ρ hρ) :=
-  hρ.isOrthogonalProjection_supportProj
-
-/-- The `Fin`-indexed support projection absorbs its matrix on the left. -/
-theorem supportProj_mul (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
-    supportProj ρ hρ * ρ = ρ := hρ.supportProj_mul_self
-
-/-- The `Fin`-indexed support projection absorbs its matrix on the right. -/
-theorem mul_supportProj (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
-    ρ * supportProj ρ hρ = ρ := hρ.mul_supportProj_self
-
-/-- The `Fin`-indexed support projection vanishes on the kernel of its matrix. -/
-theorem supportProj_mulVec_eq_zero_of_mulVec_eq_zero
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef)
-    (v : Fin D → ℂ) (hv : ρ *ᵥ v = 0) : supportProj ρ hρ *ᵥ v = 0 :=
-  hρ.supportProj_mulVec_eq_zero_of_mulVec_eq_zero v hv
-
-/-- The `Fin`-indexed support projection factors through its matrix. -/
-theorem exists_supportProj_eq_mul (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
-    ∃ W : Matrix (Fin D) (Fin D) ℂ, supportProj ρ hρ = ρ * W :=
-  hρ.exists_supportProj_eq_mul
-
-/-- The support projection of a nonzero `Fin`-indexed matrix is nonzero. -/
-theorem supportProj_ne_zero_of_ne_zero
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) (hne : ρ ≠ 0) :
-    supportProj ρ hρ ≠ 0 := hρ.supportProj_ne_zero_of_ne_zero hne
-
-/-- The support projection of a non-positive-definite `Fin`-indexed matrix is not one. -/
-theorem supportProj_ne_one_of_not_posDef
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) (hnotPD : ¬ ρ.PosDef) :
-    supportProj ρ hρ ≠ 1 := hρ.supportProj_ne_one_of_not_posDef hnotPD
-
-/-- The support projection of `Y Yᴴ` fixes `Y`. -/
-theorem supportProj_mul_left_eq_self {k : ℕ} (Y : Matrix (Fin D) (Fin k) ℂ) :
-    supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) * Y = Y :=
-  Matrix.supportProj_mul_conjTranspose_mul_self Y
-
+omit [DecidableEq n] in
 /-- Range invariance passes from a spanning matrix to its support projection. -/
-theorem one_sub_supportProj_mul_mul_supportProj_eq_zero {k : ℕ}
-    (Y : Matrix (Fin D) (Fin k) ℂ) {A : Matrix (Fin D) (Fin D) ℂ}
-    {G : Matrix (Fin k) (Fin k) ℂ} (hAY : A * Y = Y * G) :
-    (1 - supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)) * A *
-      supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) = 0 := by
-  obtain ⟨W, hW⟩ :=
-    exists_supportProj_eq_mul (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
-  set π := supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
+theorem one_sub_supportProj_mul_mul_supportProj_eq_zero
+    (Y : Matrix m n ℂ) {A : Matrix m m ℂ} {G : Matrix n n ℂ} (hAY : A * Y = Y * G) :
+    (1 - (posSemidef_self_mul_conjTranspose Y).supportProj) * A *
+      (posSemidef_self_mul_conjTranspose Y).supportProj = 0 := by
+  let hYY := posSemidef_self_mul_conjTranspose Y
+  obtain ⟨W, hW⟩ := hYY.exists_supportProj_eq_mul
+  set π := hYY.supportProj
   have hY : (1 - π) * Y = 0 := by
-    rw [Matrix.sub_mul, Matrix.one_mul, supportProj_mul_left_eq_self Y, sub_self]
+    rw [Matrix.sub_mul, Matrix.one_mul]
+    change Y - (isHermitian_mul_conjTranspose_self Y).supportProj * Y = 0
+    rw [supportProj_mul_conjTranspose_mul_self, sub_self]
   calc
     (1 - π) * A * π = (1 - π) * A * (Y * Yᴴ * W) := by rw [← hW]
     _ = (1 - π) * (A * Y) * (Yᴴ * W) := by simp only [Matrix.mul_assoc]

--- a/TNLean/Archive/BlockingPeriodicityCFII2.lean
+++ b/TNLean/Archive/BlockingPeriodicityCFII2.lean
@@ -319,11 +319,11 @@ section SupportProj
 /-- The support projector has the same range as the original PSD matrix. -/
 lemma range_mulVecLin_supportProj_eq
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
-    LinearMap.range (Matrix.mulVecLin (Matrix.supportProj (D := D) ρ hρ)) =
+    LinearMap.range (Matrix.mulVecLin hρ.supportProj) =
       LinearMap.range (Matrix.mulVecLin ρ) := by
   classical
-  let Q : Matrix (Fin D) (Fin D) ℂ := Matrix.supportProj (D := D) ρ hρ
-  have hQρ : Q * ρ = ρ := Matrix.supportProj_mul (D := D) (ρ := ρ) hρ
+  let Q : Matrix (Fin D) (Fin D) ℂ := hρ.supportProj
+  have hQρ : Q * ρ = ρ := hρ.supportProj_mul_self
   -- Range inclusion `range ρ ≤ range Q` from `Q * ρ = ρ`.
   have hrange : LinearMap.range (Matrix.mulVecLin ρ) ≤ LinearMap.range (Matrix.mulVecLin Q) := by
     intro y hy
@@ -333,7 +333,7 @@ lemma range_mulVecLin_supportProj_eq
   -- Kernel inclusion `ker ρ ≤ ker Q` from the kernel lemma.
   have hker : LinearMap.ker (Matrix.mulVecLin ρ) ≤ LinearMap.ker (Matrix.mulVecLin Q) := by
     intro x hx
-    exact Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero (D := D) ρ hρ x hx
+    exact hρ.supportProj_mulVec_eq_zero_of_mulVec_eq_zero x hx
   have hker_fin :
       Module.finrank ℂ ↥(LinearMap.ker (Matrix.mulVecLin ρ)) ≤
         Module.finrank ℂ ↥(LinearMap.ker (Matrix.mulVecLin Q)) :=
@@ -495,9 +495,9 @@ lemma hasInvariantProj_of_hasInvariantProj_unitalize
     have hρ_eq : ρ = (S * P) * (S * P)ᴴ := by
       simpa using hSP.symm
     simpa [hρ_eq] using Matrix.posSemidef_self_mul_conjTranspose (S * P)
-  let Q : Matrix (Fin D) (Fin D) ℂ := Matrix.supportProj (D := D) ρ hρ_psd
+  let Q : Matrix (Fin D) (Fin D) ℂ := hρ_psd.supportProj
   have hQproj : IsOrthogonalProjection Q :=
-    Matrix.isOrthogonalProjection_supportProj (D := D) (ρ := ρ) (hρ := hρ_psd)
+    hρ_psd.isOrthogonalProjection_supportProj
   -- Nontriviality of `Q`.
   have hρ_ne : ρ ≠ 0 := by
     intro h0
@@ -513,7 +513,7 @@ lemma hasInvariantProj_of_hasInvariantProj_unitalize
     have : P = 0 := by
       simpa [hSPS] using h0'
     exact hP0 this
-  have hQ0 : Q ≠ 0 := Matrix.supportProj_ne_zero_of_ne_zero (D := D) ρ hρ_psd hρ_ne
+  have hQ0 : Q ≠ 0 := hρ_psd.supportProj_ne_zero_of_ne_zero hρ_ne
   have hnotPD : ¬ ρ.PosDef := by
     intro hρPD
     have hρunit : IsUnit ρ := Matrix.PosDef.isUnit hρPD
@@ -539,7 +539,7 @@ lemma hasInvariantProj_of_hasInvariantProj_unitalize
       have := congrArg (fun M => M * Pinv) hPP
       simpa [Matrix.mul_assoc, hPinv] using this
     exact hP1 this
-  have hQ1 : Q ≠ 1 := Matrix.supportProj_ne_one_of_not_posDef (D := D) ρ hρ_psd hnotPD
+  have hQ1 : Q ≠ 1 := hρ_psd.supportProj_ne_one_of_not_posDef hnotPD
   -- Range equality: `range(Q) = range(ρ)`.
   have hRange : LinearMap.range (Matrix.mulVecLin Q) = LinearMap.range (Matrix.mulVecLin ρ) := by
     simpa [Q] using (range_mulVecLin_supportProj_eq (D := D) ρ hρ_psd)

--- a/TNLean/Channel/FixedPoint/MaximalRank.lean
+++ b/TNLean/Channel/FixedPoint/MaximalRank.lean
@@ -101,8 +101,8 @@ theorem maximalSupport_of_maximalRank
     have hQ₀0 : Q₀ = 0 := by
       refine Matrix.ext_of_mulVec_single fun j => ?_
       rw [hQ₀def, Matrix.zero_mulVec]
-      exact Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
-        (ρ := ρ₀) (hρ := hρ₀_psd) _ (by rw [hρ₀0, Matrix.zero_mulVec])
+      exact hρ₀_psd.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ (by
+        rw [hρ₀0, Matrix.zero_mulVec])
     intro X hX
     have hX0 : X = 0 := by
       have h := hmax X hX
@@ -175,8 +175,7 @@ theorem maximalSupport_of_maximalRank
       have hsub : P * (1 - Q₀) = 0 := by
         refine Matrix.ext_of_mulVec_single fun j => ?_
         rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
-        refine Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
-          (ρ := ρ) (hρ := hρ_psd) _ ?_
+        refine hρ_psd.supportProj_mulVec_eq_zero_of_mulVec_eq_zero _ ?_
         rw [Matrix.mulVec_mulVec,
           show ρ * (1 - Q₀) = 0 by rw [Matrix.mul_sub, Matrix.mul_one, hρQ₀, sub_self],
           Matrix.zero_mulVec]

--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -44,16 +44,16 @@ theorem support_proj_fixed
     {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E) {ρ : Mat}
     (hρ_psd : ρ.PosSemidef) (hρ_fix : E ρ = ρ) :
     ∀ X : Mat,
-      Matrix.supportProj (D := D) ρ hρ_psd *
-        E (Matrix.supportProj (D := D) ρ hρ_psd * X *
-          Matrix.supportProj (D := D) ρ hρ_psd) *
-        Matrix.supportProj (D := D) ρ hρ_psd =
-      E (Matrix.supportProj (D := D) ρ hρ_psd * X *
-        Matrix.supportProj (D := D) ρ hρ_psd) := by
+      hρ_psd.supportProj *
+        E (hρ_psd.supportProj * X *
+          hρ_psd.supportProj) *
+        hρ_psd.supportProj =
+      E (hρ_psd.supportProj * X *
+        hρ_psd.supportProj) := by
   have hInv :=
     Kraus.invariantCompression_of_supportProj_fixed_by_cpMap hE.cp hρ_psd hρ_fix
   intro X
-  simpa [Kraus.stationaryProj, Matrix.supportProj] using hInv.2 X
+  simpa [Kraus.stationaryProj] using hInv.2 X
 
 /-- Chosen stationary state of an irreducible channel. -/
 noncomputable def stationaryState
@@ -86,18 +86,14 @@ channel. -/
 noncomputable def stationarySupport
     (E : Mat →ₗ[ℂ] Mat) (hE : IsChannel E)
     (hIrr : IsIrreducibleMap E) (hD : 0 < D) : Mat :=
-  Matrix.supportProj (D := D)
-    (stationaryState E hE hIrr hD)
-    (stationaryState_spec (E := E) hE hIrr hD).1.1
+  (stationaryState_spec (E := E) hE hIrr hD).1.1.supportProj
 
 lemma stationarySupport_isOrthogonalProjection
     {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
     (hIrr : IsIrreducibleMap E) (hD : 0 < D) :
     IsOrthogonalProjection (stationarySupport E hE hIrr hD) := by
   simpa [stationarySupport] using
-    (Matrix.isOrthogonalProjection_supportProj (D := D)
-      (ρ := stationaryState E hE hIrr hD)
-      (hρ := (stationaryState_spec (E := E) hE hIrr hD).1.1))
+    (stationaryState_spec (E := E) hE hIrr hD).1.1.isOrthogonalProjection_supportProj
 
 lemma stationarySupport_invariant
     {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
@@ -146,8 +142,7 @@ theorem stationarySupport_eq_one
       stationaryState_ne_zero (E := E) hE hIrr hD
     have hP_ne : P ≠ 0 := by
       simpa [P, stationarySupport] using
-        (Matrix.supportProj_ne_zero_of_ne_zero
-          (ρ := stationaryState E hE hIrr hD) hρ_psd hρ_ne)
+        hρ_psd.supportProj_ne_zero_of_ne_zero hρ_ne
     exact hP_ne hP0
   · simpa [P] using hP1
 

--- a/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
@@ -103,13 +103,13 @@ theorem wolf_prop_7_6_one_implies_three
     simpa [hρ_zero] using hρ_mem.2
   have hρ_not_pd : ¬ ρ₀.PosDef :=
     not_posDef_of_proj_sandwich_eq_self hQ_nt.1 hQ_nt.2.2 hQρ
-  let P : Mat := Matrix.supportProj (D := D) ρ₀ hρ_psd
+  let P : Mat := hρ_psd.supportProj
   have hP_proj : IsOrthogonalProjection P :=
-    Matrix.isOrthogonalProjection_supportProj (D := D) (ρ := ρ₀) (hρ := hρ_psd)
+    hρ_psd.isOrthogonalProjection_supportProj
   have hP0 : P ≠ 0 :=
-    Matrix.supportProj_ne_zero_of_ne_zero ρ₀ hρ_psd hρ_ne
+    hρ_psd.supportProj_ne_zero_of_ne_zero hρ_ne
   have hP1 : P ≠ 1 :=
-    Matrix.supportProj_ne_one_of_not_posDef ρ₀ hρ_psd hρ_not_pd
+    hρ_psd.supportProj_ne_one_of_not_posDef hρ_not_pd
   refine ⟨P, ⟨hP_proj, hP0, hP1⟩, ?_⟩
   intro t ht X
   have hChannel : IsChannel (expSemigroup L t) := hGKSL t ht
@@ -117,7 +117,7 @@ theorem wolf_prop_7_6_one_implies_three
       IsOrthogonalProjection P ∧
         (∀ Y : Mat, P * expSemigroup L t (P * Y * P) * P =
           expSemigroup L t (P * Y * P)) := by
-    simpa [P, Kraus.stationaryProj, Matrix.supportProj] using
+    simpa [P, Kraus.stationaryProj] using
       (Kraus.invariantCompression_of_supportProj_fixed_by_cpMap
         hChannel.cp hρ_psd (hρ_fix t ht))
   exact hInv.2 X

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -115,9 +115,9 @@ theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
     exact hXdet.star
   set Y : Matrix (Fin D) (Fin D) ℂ := X * P with hY
   set π : Matrix (Fin D) (Fin D) ℂ :=
-    Matrix.supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
-  refine ⟨π, Matrix.isOrthogonalProjection_supportProj (D := D) (ρ := Y * Yᴴ)
-    (hρ := Matrix.posSemidef_self_mul_conjTranspose Y), ?_, ?_, ?_⟩
+    (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj with hπ
+  refine ⟨π, (Matrix.posSemidef_self_mul_conjTranspose
+    Y).isOrthogonalProjection_supportProj, ?_, ?_, ?_⟩
   · -- `π ≠ 0` because `Y ≠ 0`.
     have hYne : Y ≠ 0 := by
       intro h0
@@ -126,8 +126,7 @@ theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
         _ = 0 := by rw [← hY, h0, Matrix.mul_zero]
     have hSne : Y * Yᴴ ≠ 0 := fun h0 =>
       hYne (Matrix.self_mul_conjTranspose_eq_zero.mp h0)
-    exact Matrix.supportProj_ne_zero_of_ne_zero (Y * Yᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose Y) hSne
+    exact (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj_ne_zero_of_ne_zero hSne
   · -- `π ≠ 1`: a nonzero vector in the kernel of `P` transports to the
     -- kernel of `Y * Yᴴ`, hence of `π`.
     have h1Pne : (1 : Matrix (Fin D) (Fin D) ℂ) - P ≠ 0 := by
@@ -163,8 +162,8 @@ theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
       rw [hYY, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, hXHv, hPw,
         Matrix.mulVec_zero]
     have hπv : π *ᵥ v = 0 :=
-      Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero (Y * Yᴴ)
-        (Matrix.posSemidef_self_mul_conjTranspose Y) v hSv
+      (Matrix.posSemidef_self_mul_conjTranspose
+        Y).supportProj_mulVec_eq_zero_of_mulVec_eq_zero v hSv
     intro h1
     apply hvne
     rw [← Matrix.one_mulVec v, ← h1, hπv]

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -56,11 +56,11 @@ theorem lowerZero_of_posSemidef_fixedPoint
     (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hρ_psd : ρ.PosSemidef)
     (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ) :
-    let P := Matrix.supportProj (D := D) ρ hρ_psd
+    let P := hρ_psd.supportProj
     IsOrthogonalProjection P ∧ (∀ i : Fin d, (1 - P) * A i * P = 0) := by
   have hρ_fix' : Kraus.map A ρ = ρ := by
     simpa [Kraus.map, transferMap_apply] using hρ_fix
-  simpa [Kraus.stationaryProj, Matrix.supportProj] using
+  simpa [Kraus.stationaryProj] using
     (Kraus.lowerZero_of_posSemidef_fixedPoint A ρ hρ_psd hρ_fix')
 
 /-! ## Nontriviality lemmas for the support projection
@@ -193,7 +193,7 @@ theorem exists_twoBlock_decomp_of_posSemidef_fixedPoint
       (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
       SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
   classical
-  let P : Matrix (Fin D) (Fin D) ℂ := Matrix.supportProj (D := D) ρ hρ_psd
+  let P : Matrix (Fin D) (Fin D) ℂ := hρ_psd.supportProj
   have hP : IsOrthogonalProjection P ∧ (∀ i : Fin d, (1 - P) * A i * P = 0) := by
     simpa [P] using
       (lowerZero_of_posSemidef_fixedPoint (d := d) (D := D) A ρ hρ_psd hρ_fix)
@@ -209,8 +209,8 @@ each iteration strictly reduces the bond dimension.
 
 The proof composes:
 1. `lowerZero_of_posSemidef_fixedPoint` — support projection is invariant,
-2. `Matrix.supportProj_ne_zero_of_ne_zero` — `P ≠ 0` from `ρ ≠ 0`,
-3. `Matrix.supportProj_ne_one_of_not_posDef` — `P ≠ 1` from `¬ρ.PosDef`,
+2. `Matrix.PosSemidef.supportProj_ne_zero_of_ne_zero` — `P ≠ 0` from `ρ ≠ 0`,
+3. `Matrix.PosSemidef.supportProj_ne_one_of_not_posDef` — `P ≠ 1` from `¬ρ.PosDef`,
 4. `exists_twoBlock_decomp_of_lowerZero_strict` — strict dimension bounds.
 
 References:
@@ -232,14 +232,14 @@ theorem exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict
       ∃ (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
         SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
   -- Step 1: obtain the invariant support projection
-  let P : Matrix (Fin D) (Fin D) ℂ := Matrix.supportProj (D := D) ρ hρ_psd
+  let P : Matrix (Fin D) (Fin D) ℂ := hρ_psd.supportProj
   have hP_inv : IsOrthogonalProjection P ∧ (∀ i : Fin d, (1 - P) * A i * P = 0) := by
     simpa [P] using
       (lowerZero_of_posSemidef_fixedPoint (d := d) (D := D) A ρ hρ_psd hρ_fix)
   -- Step 2: P ≠ 0 from ρ ≠ 0
-  have hP0 : P ≠ 0 := Matrix.supportProj_ne_zero_of_ne_zero ρ hρ_psd hρ_ne
+  have hP0 : P ≠ 0 := hρ_psd.supportProj_ne_zero_of_ne_zero hρ_ne
   -- Step 3: P ≠ 1 from ¬ρ.PosDef
-  have hP1 : P ≠ 1 := Matrix.supportProj_ne_one_of_not_posDef ρ hρ_psd hρ_not_pd
+  have hP1 : P ≠ 1 := hρ_psd.supportProj_ne_one_of_not_posDef hρ_not_pd
   -- Step 4: apply strict decomposition
   exact exists_twoBlock_decomp_of_lowerZero_strict A P hP_inv.1 hP_inv.2 hP0 hP1
 

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -103,9 +103,7 @@ noncomputable def physicalSliceColumns (K : MPOTensor d D) :
 
 /-- The orthogonal projection onto the span of all columns of all physical slices. -/
 noncomputable def physicalSupportProj (K : MPOTensor d D) : Matrix (Fin d) (Fin d) ℂ :=
-  Matrix.supportProj
-    (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-    (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
+  (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K)).supportProj
 
 /-- The product index selects the corresponding virtual pair and physical column. -/
 @[simp] theorem physicalSliceColumns_apply_finProdFinEquiv (K : MPOTensor d D)
@@ -117,10 +115,10 @@ noncomputable def physicalSupportProj (K : MPOTensor d D) : Matrix (Fin d) (Fin 
 theorem supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
     {k l : ℕ} (Y : Matrix (Fin d) (Fin k) ℂ) (Z : Matrix (Fin d) (Fin l) ℂ)
     (hYZ : Yᴴ * Z = 0) :
-    Matrix.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) *
-      Matrix.supportProj (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z) = 0 := by
-  let πY := Matrix.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
-  let πZ := Matrix.supportProj (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z)
+    (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj *
+      (Matrix.posSemidef_self_mul_conjTranspose Z).supportProj = 0 := by
+  let πY := (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj
+  let πZ := (Matrix.posSemidef_self_mul_conjTranspose Z).supportProj
   have hπYZ : πY * Z = 0 := by
     ext i j
     have hmat : (Y * Yᴴ) * Z = 0 :=
@@ -129,11 +127,10 @@ theorem supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
       funext a
       have hEntry := congrArg (fun A : Matrix (Fin d) (Fin l) ℂ ↦ A a j) hmat
       simpa [Matrix.mulVec, dotProduct, Matrix.mul_apply] using hEntry
-    have hsupport := Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
-      (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) (fun a ↦ Z a j) hker
+    have hsupport := (Matrix.posSemidef_self_mul_conjTranspose
+      Y).supportProj_mulVec_eq_zero_of_mulVec_eq_zero (fun a ↦ Z a j) hker
     simpa [πY, Matrix.mul_apply, Matrix.mulVec, dotProduct] using congrFun hsupport i
-  obtain ⟨W, hW⟩ := Matrix.exists_supportProj_eq_mul
-    (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z)
+  obtain ⟨W, hW⟩ := (Matrix.posSemidef_self_mul_conjTranspose Z).exists_supportProj_eq_mul
   have hπZ : πZ = Z * Zᴴ * W := by simpa [πZ] using hW
   calc
     πY * πZ = πY * (Z * Zᴴ * W) := by rw [hπZ]
@@ -144,7 +141,10 @@ theorem supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
 left. -/
 theorem physicalSupportProj_mul_physicalSlice (K : MPOTensor d D) (β α : Fin D) :
     physicalSupportProj K * physicalSlice K β α = physicalSlice K β α := by
-  have hColumns := Matrix.supportProj_mul_left_eq_self (physicalSliceColumns K)
+  have hColumns :
+      physicalSupportProj K * physicalSliceColumns K = physicalSliceColumns K := by
+    simpa [physicalSupportProj, Matrix.PosSemidef.supportProj] using
+      Matrix.supportProj_mul_conjTranspose_mul_self (physicalSliceColumns K)
   ext i j
   have hEntry := congrArg
     (fun A : Matrix (Fin d) (Fin (D * D * d)) ℂ ↦
@@ -166,15 +166,11 @@ theorem mul_physicalSupportProj_eq_self_of_forall_mul_physicalSlice_eq
       P * (physicalSliceColumns K * (physicalSliceColumns K)ᴴ) =
         physicalSliceColumns K * (physicalSliceColumns K)ᴴ := by
     rw [← Matrix.mul_assoc, hColumns]
-  obtain ⟨W, hW⟩ := Matrix.exists_supportProj_eq_mul
-    (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-    (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
-  change P * Matrix.supportProj
-      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K)) =
-    Matrix.supportProj
-      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
+  obtain ⟨W, hW⟩ := (Matrix.posSemidef_self_mul_conjTranspose
+      (physicalSliceColumns K)).exists_supportProj_eq_mul
+  change P * (Matrix.posSemidef_self_mul_conjTranspose
+      (physicalSliceColumns K)).supportProj =
+    (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K)).supportProj
   rw [hW, ← Matrix.mul_assoc, hGram]
 
 /-- Adjoint closure makes the same physical support projection fix every slice on the right. -/
@@ -189,9 +185,8 @@ theorem physicalSlice_mul_physicalSupportProj_of_isInjective_isMPDO
     rw [hAdj β α, Matrix.mul_sum]
     simp_rw [Matrix.mul_sum, Matrix.mul_smul, physicalSupportProj_mul_physicalSlice]
   have hHerm : (physicalSupportProj K).IsHermitian :=
-    (Matrix.isOrthogonalProjection_supportProj
-      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))).1
+    ((Matrix.posSemidef_self_mul_conjTranspose
+      (physicalSliceColumns K)).isOrthogonalProjection_supportProj).1
   have hstar := congrArg Matrix.conjTranspose hleftAdj
   simpa [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, hHerm.eq] using hstar
 
@@ -301,9 +296,8 @@ theorem exists_pairwise_orthogonal_twoSided_physicalSupport
   let P : Fin g → Matrix (Fin d) (Fin d) ℂ := fun x ↦ physicalSupportProj (K x)
   refine ⟨P, ?_, ?_, ?_⟩
   · intro x
-    exact Matrix.isOrthogonalProjection_supportProj
-      (physicalSliceColumns (K x) * (physicalSliceColumns (K x))ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns (K x)))
+    exact (Matrix.posSemidef_self_mul_conjTranspose
+        (physicalSliceColumns (K x))).isOrthogonalProjection_supportProj
   · intro x y hxy
     exact supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
       (physicalSliceColumns (K x)) (physicalSliceColumns (K y))

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -368,10 +368,9 @@ theorem exists_displaced_invariant_projector_of_periodic_vector
   -- cyclic sector `V S · ran (P 0)`.
   set Y : Matrix (Fin d) (Fin n) ℂ := V * S * P 0 with hY
   set π : Matrix (Fin d) (Fin d) ℂ :=
-    Matrix.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+    (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj with hπ
   have hπproj : IsOrthogonalProjection π :=
-    Matrix.isOrthogonalProjection_supportProj (ρ := Y * Yᴴ)
-      (hρ := Matrix.posSemidef_self_mul_conjTranspose Y)
+    (Matrix.posSemidef_self_mul_conjTranspose Y).isOrthogonalProjection_supportProj
   have hQproj : IsOrthogonalProjection (1 - π) := hπproj.one_sub
   -- Left cancellation of `V * S`.
   have hVScancel : ∀ {Z Z' : Matrix (Fin n) (Fin n) ℂ},
@@ -463,7 +462,7 @@ theorem exists_displaced_invariant_projector_of_periodic_vector
               rw [Matrix.smul_mul]; simp only [Matrix.mul_assoc]
           _ = c⁻¹ • (V * S * (P (0 - 1) * K v)) := by rw [hKv0]
       -- `π` fixes `Y` and absorbs the letter action.
-      have hπY : π * Y = Y := Matrix.supportProj_mul_left_eq_self Y
+      have hπY : π * Y = Y := Matrix.supportProj_mul_conjTranspose_mul_self Y
       have hfix' : π * (verticalTensor M v * Y) = verticalTensor M v * Y := by
         have hAπ : verticalTensor M v * π = π * (verticalTensor M v * π) := by
           have h0 := hletter v
@@ -480,8 +479,7 @@ theorem exists_displaced_invariant_projector_of_periodic_vector
           _ = verticalTensor M v * π * Y := by rw [← hAπ]
           _ = verticalTensor M v * Y := by rw [Matrix.mul_assoc, hπY]
       -- Express the fixed equation through the support factorization.
-      obtain ⟨W, hW⟩ := Matrix.exists_supportProj_eq_mul (Y * Yᴴ)
-        (Matrix.posSemidef_self_mul_conjTranspose Y)
+      obtain ⟨W, hW⟩ := (Matrix.posSemidef_self_mul_conjTranspose Y).exists_supportProj_eq_mul
       have hππ : π = Y * (Yᴴ * W) := by rw [hπ, hW, Matrix.mul_assoc]
       have hZ : V * S * (P (0 - 1) * K v) =
           V * S * (P 0 * (Yᴴ * W * (V * S * (P (0 - 1) * K v)))) := by

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveBond.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveBond.lean
@@ -71,9 +71,8 @@ theorem exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice
     mul_physicalSupportProj_eq_self_of_forall_mul_physicalSlice_eq
       K P (fun β α ↦ (hSupport β α).1)
   have hQ : IsOrthogonalProjection Q :=
-    Matrix.isOrthogonalProjection_supportProj
-      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
+    (Matrix.posSemidef_self_mul_conjTranspose
+      (physicalSliceColumns K)).isOrthogonalProjection_supportProj
   have hQP : Q * P = Q := by
     have h := congrArg Matrix.conjTranspose hPQ
     rwa [Matrix.conjTranspose_mul, hQ.1.eq, hP.1.eq] at h

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveRestriction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveRestriction.lean
@@ -786,10 +786,8 @@ theorem activePhysicalSupportProj_eq_physicalSupportProj
   have hQHerm : Q.IsHermitian :=
     F.isOrthogonalProjection_activePhysicalSupportProj.1
   have hSHerm : S.IsHermitian :=
-    (Matrix.isOrthogonalProjection_supportProj
-      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose
-        (physicalSliceColumns K))).1
+    (Matrix.posSemidef_self_mul_conjTranspose
+      (physicalSliceColumns K)).isOrthogonalProjection_supportProj.1
   have hQS' := congrArg Matrix.conjTranspose hSQ
   have hQSQ : Q * S = Q := by
     simpa [Matrix.conjTranspose_mul, hQHerm.eq, hSHerm.eq] using hQS'

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
@@ -379,8 +379,8 @@ This section records the positive Perron eigenpair, its spectral normalization, 
 
 \begin{lemma}[Range factorization of the support projection]
     \label{lem:support_proj_range_factorization}
-    \lean{Matrix.exists_supportProj_eq_mul}
-    \lean{Matrix.supportProj_mul_left_eq_self}
+    \lean{Matrix.PosSemidef.exists_supportProj_eq_mul}
+    \lean{Matrix.supportProj_mul_conjTranspose_mul_self}
     \lean{Matrix.one_sub_supportProj_mul_mul_supportProj_eq_zero}
     \leanok
     \uses{def:support_proj}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -146,7 +146,7 @@ and~\cite{Evans1978Spectral}.
 \end{proof}
 
 \begin{definition}[Support projection]\label{def:support_proj}
-    \lean{Matrix.supportProj}
+    \lean{Matrix.PosSemidef.supportProj}
     \leanok
     For a positive semidefinite matrix $\rho\ge0$, the \emph{support
         projection} $P$ is the orthogonal projection onto the range of $\rho$.

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -289,7 +289,7 @@ sector is positive definite.
 
 \begin{lemma}[Support projection annihilates the kernel]%
     \label{lem:supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
-    \lean{Matrix.supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
+    \lean{Matrix.PosSemidef.supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
     \leanok
     Let $\rho\succeq0$ on $\C^D$, with support projection
     $P=\supp(\rho)$. For every $v\in\C^D$, if $\rho v=0$, then $Pv=0$.


### PR DESCRIPTION
### Summary

- remove the Fin-indexed `Matrix.supportProj` definition and trivial re-export lemmas
- retarget channel, MPS, archive, and blueprint consumers to the general `Matrix.PosSemidef` API
- generalize the surviving range-invariance theorem to arbitrary finite index types

### Testing

- targeted builds for the foundation and five principal downstream modules
- direct Lean check and clean diagnostics for the remaining changed consumers
- no stale removed shim names; no changed-file `sorry` or `axiom`
- blueprint source synchronization: 7,983/7,983
- all five changed blueprint declarations checked directly
- reader-facing prose and diff checks
- one complete blueprint PDF pass

Closes #6578
Advances #6560