### PR TITLE
feat(channel): characterize positive Choi iterates

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -40,6 +40,7 @@ import TNLean.Channel.KrausCPTP
 import TNLean.Channel.KrausCornerCompression
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.KrausGauge
+import TNLean.Channel.KrausIterateChoi
 import TNLean.Channel.KrausMap
 import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRectangular

--- a/TNLean/Channel/KrausIterateChoi.lean
+++ b/TNLean/Channel/KrausIterateChoi.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FrameOperator
+import TNLean.Channel.KrausRank
+import TNLean.Kraus.Injectivity
+import TNLean.Kraus.MapIterate
+
+/-!
+# Positive-definite Choi matrices of finite Kraus-map iterates
+
+For a finite Kraus family `K`, the operators in the `m`-fold iterate are the
+length-`m` Kraus words. Its Choi matrix is therefore the frame operator of the
+normalized vectorized words. The Choi matrix is positive definite exactly when
+those words span the full matrix algebra.
+
+## Main declarations
+
+* `Kraus.choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top` characterizes one
+  fixed iterate.
+* `Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_hasEventuallyFullWordSpan`
+  gives the corresponding eventual statement.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace Kraus
+
+variable {r D : ℕ}
+
+private theorem span_normalized_uncurry_words_eq_top_iff
+    [NeZero D] (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (m : ℕ) :
+    Submodule.span ℂ
+        (Set.range fun σ : Fin m → Fin r =>
+          fun p : Fin D × Fin D =>
+            ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
+              MPSTensor.evalWord K (List.ofFn σ) p.1 p.2) = ⊤ ↔
+      wordSpan K m = ⊤ := by
+  let e : Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] ((Fin D × Fin D) → ℂ) :=
+    (LinearEquiv.curry ℂ ℂ (Fin D) (Fin D)).symm
+  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  have hD : D ≠ 0 := NeZero.ne D
+  have hsqrtR : (D : ℝ).sqrt ≠ 0 :=
+    (Real.sqrt_ne_zero (Nat.cast_nonneg D)).2 (Nat.cast_ne_zero.2 hD)
+  have hsqrtC : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+    exact_mod_cast hsqrtR
+  have hc : c ≠ 0 := one_div_ne_zero hsqrtC
+  have hscale :
+      Submodule.span ℂ
+          (Set.range fun σ : Fin m → Fin r =>
+            c • e (MPSTensor.evalWord K (List.ofFn σ))) =
+        Submodule.span ℂ
+          (Set.range fun σ : Fin m → Fin r =>
+            e (MPSTensor.evalWord K (List.ofFn σ))) := by
+    apply le_antisymm
+    · apply Submodule.span_le.mpr
+      rintro _ ⟨σ, rfl⟩
+      exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
+    · apply Submodule.span_le.mpr
+      rintro _ ⟨σ, rfl⟩
+      change e (MPSTensor.evalWord K (List.ofFn σ)) ∈ _
+      rw [← inv_smul_smul₀ hc (e (MPSTensor.evalWord K (List.ofFn σ)))]
+      exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
+  have hmap :
+      Submodule.map e.toLinearMap (wordSpan K m) =
+        Submodule.span ℂ
+          (Set.range fun σ : Fin m → Fin r =>
+            e (MPSTensor.evalWord K (List.ofFn σ))) := by
+    rw [wordSpan, Submodule.map_span]
+    congr 1
+    ext v
+    simp
+  change Submodule.span ℂ
+      (Set.range fun σ : Fin m → Fin r =>
+        c • e (MPSTensor.evalWord K (List.ofFn σ))) = ⊤ ↔ _
+  rw [hscale, ← hmap]
+  exact Submodule.map_eq_top_iff
+
+/-- Wolf, Section 6.8, items 3 and 4 at a fixed iterate: the Choi matrix of a
+finite Kraus-map iterate is positive definite exactly when the Kraus words of
+that length span the full matrix algebra. -/
+theorem choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top
+    [NeZero D] (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (m : ℕ) :
+    (ChoiJamiolkowski.choiMatrix ((mapLM K) ^ m)).PosDef ↔
+      wordSpan K m = ⊤ := by
+  let wordEquiv := Fintype.equivFin (Fin m → Fin r)
+  let W : Fin (Fintype.card (Fin m → Fin r)) → Matrix (Fin D) (Fin D) ℂ :=
+    fun j => MPSTensor.evalWord K (List.ofFn (wordEquiv.symm j))
+  have hW : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ((mapLM K) ^ m) X = ∑ j, W j * X * (W j)ᴴ := by
+    intro X
+    rw [mapLM_pow_apply]
+    exact Fintype.sum_equiv wordEquiv _ _ fun σ => by simp [W]
+  rw [← ChoiRectangular.choiMatrix_eq_choiJamiolkowski]
+  rw [Channel.choiMatrix_eq_sum_vecMulVec_of_kraus W ((mapLM K) ^ m) hW]
+  rw [Matrix.posDef_sum_vecMulVec_iff_span_eq_top]
+  have hrange :
+      Set.range (fun j =>
+          fun p : Fin D × Fin D =>
+            ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * W j p.1 p.2) =
+        Set.range (fun σ : Fin m → Fin r =>
+          fun p : Fin D × Fin D =>
+            ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
+              MPSTensor.evalWord K (List.ofFn σ) p.1 p.2) := by
+    ext v
+    constructor
+    · rintro ⟨j, rfl⟩
+      exact ⟨wordEquiv.symm j, rfl⟩
+    · rintro ⟨σ, rfl⟩
+      refine ⟨wordEquiv σ, ?_⟩
+      simp [W]
+  rw [hrange]
+  exact span_normalized_uncurry_words_eq_top_iff K m
+
+/-- Wolf, Section 6.8, items 3 and 4 in eventual form: a finite Kraus family
+has eventually full word span exactly when the Choi matrices of all sufficiently
+large iterates are positive definite. -/
+theorem eventually_choiMatrix_mapLM_pow_posDef_iff_hasEventuallyFullWordSpan
+    [NeZero D] (K : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    (∀ᶠ m : ℕ in Filter.atTop,
+      (ChoiJamiolkowski.choiMatrix ((mapLM K) ^ m)).PosDef) ↔
+      HasEventuallyFullWordSpan K := by
+  constructor
+  · intro h
+    filter_upwards [h] with m hm
+    exact (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mp hm
+  · intro h
+    filter_upwards [h] with m hm
+    exact (choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top K m).mpr hm
+
+end Kraus

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -12,6 +12,7 @@ are not prerequisites for the matrix-product-state Fundamental Theorem.
 %% =========================================================
 
 \input{chapter/ch16_channel_representations_choi_and_kraus}
+\input{chapter/ch16_channel_representations_kraus_iterate_choi}
 \input{chapter/ch16_channel_representations_ensemble_equivalence}
 \input{chapter/ch16_channel_representations_dilations_and_ordered_cp}
 \input{chapter/ch16_channel_representations_normal_forms_and_determinant}

--- a/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
@@ -1,0 +1,74 @@
+\section{Choi positivity and exact Kraus-word spans}
+\label{sec:kraus_iterate_choi}
+
+Let $D\geq1$, let $(K_i)_{i\in I}$ be a finite family in $\MN{D}$, and define
+\begin{align}
+    E(X)&=\sum_{i\in I}K_iXK_i^\dagger.
+    \notag
+\end{align}
+For a word $\sigma=(\sigma_0,\ldots,\sigma_{m-1})\in I^m$, write
+\begin{align}
+    K_\sigma&=K_{\sigma_0}\cdots K_{\sigma_{m-1}},
+    &
+    \mathcal S_m&=\operatorname{span}\{K_\sigma:\sigma\in I^m\}.
+    \notag
+\end{align}
+The empty product is the identity matrix.
+
+\begin{theorem}[Positive-definite Choi matrix at a fixed iterate]
+    \label{thm:kraus_iterate_choi_posdef_iff_word_span}
+    \lean{Kraus.choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top}
+    \leanok
+    \uses{thm:kraus_map_iterate_word_expansion,
+        thm:choi_kraus_outer_product,
+        thm:finite_frame_posdef}
+    Let $\tau_{E^m}$ be the normalized Choi matrix of the $m$-fold iterate of
+    $E$. Then
+    \begin{align}
+        \tau_{E^m}>0
+        \quad\Longleftrightarrow\quad
+        \mathcal S_m=\MN{D}.
+        \label{eq:kraus_iterate_choi_posdef_iff_word_span}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_map_iterate_word_expansion,
+        thm:choi_kraus_outer_product,
+        thm:finite_frame_posdef}
+    The Kraus operators of $E^m$ are the matrices $K_\sigma$ with
+    $\sigma\in I^m$. Hence
+    \begin{align}
+        \tau_{E^m}
+        &=\sum_{\sigma\in I^m}\ketbra{v_\sigma}{v_\sigma},
+        &
+        (v_\sigma)_{(a,b)}
+        &=D^{-1/2}(K_\sigma)_{ab}.
+        \notag
+    \end{align}
+    The matrix indices retain their row--column order. Since $D^{-1/2}\neq0$,
+    the vectors $v_\sigma$ span $\C^{D\times D}$ exactly when the matrices
+    $K_\sigma$ span $\MN{D}$. The finite-frame criterion now gives
+    Equation~\eqref{eq:kraus_iterate_choi_posdef_iff_word_span}.
+\end{proof}
+
+\begin{corollary}[Eventual Choi positivity]
+    \label{cor:kraus_iterate_eventual_choi_posdef}
+    \lean{Kraus.eventually_choiMatrix_mapLM_pow_posDef_iff_hasEventuallyFullWordSpan}
+    \leanok
+    \uses{thm:kraus_iterate_choi_posdef_iff_word_span}
+    The following conditions are equivalent:
+    \begin{enumerate}
+        \item $\tau_{E^m}>0$ for every sufficiently large $m$;
+        \item $\mathcal S_m=\MN{D}$ for every sufficiently large $m$.
+    \end{enumerate}
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_iterate_choi_posdef_iff_word_span}
+    Apply
+    Equation~\eqref{eq:kraus_iterate_choi_posdef_iff_word_span} pointwise for
+    every sufficiently large $m$.
+\end{proof}


### PR DESCRIPTION
## What changed

- characterize positive definiteness of the Choi matrix of `(Kraus.mapLM K) ^ m` by `Kraus.wordSpan K m = ⊤`
- derive the literal eventual equivalence with `Kraus.HasEventuallyFullWordSpan`
- add formula-first Chapter 16 blueprint coverage and the generated Channel import

The proof reuses the merged finite-map iterate expansion, exact Choi decomposition, finite-frame criterion, and Kraus word-span API.

## Validation

- `lake build TNLean.Channel.KrausIterateChoi` (3048 jobs)
- `python3 scripts/check_import_direction.py` (433 files, 0 violations)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/generate_import_aggregators.py --check` (53 files, 1454 modules)
- `git diff --check origin/main...HEAD`
- no `sorry`, `admit`, `axiom`, `unsafeCast`, or `native_decide` in changed Lean source

Advances LionSR/QICLean#332
Advances LionSR/TNLean#6560