### PR TITLE
refactor(spectral): use Mathlib eigenvector power theorem

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -18,7 +18,6 @@ general spectral-radius results now in `TNLean.Analysis`.
 
 ## Main results
 
-- `MPSTensor.eigenvector_pow`
 - `MPSTensor.word_conjTranspose_mul_sum`
 - `MPSTensor.trace_transferMap`
 - `MPSTensor.sum_frobSq_right`
@@ -30,18 +29,6 @@ open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-! ### Eigenvector iteration -/
-
-/-- If `F(v) = μ • v`, then `F^n(v) = μ^n • v`. -/
-lemma eigenvector_pow {V : Type*} [AddCommMonoid V] [Module ℂ V]
-    (F : V →ₗ[ℂ] V) (v : V) (μ : ℂ) (h : F v = μ • v) (n : ℕ) :
-    (F ^ n) v = μ ^ n • v := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    change (F ^ n) (F v) = _
-    rw [h, map_smul, ih, smul_smul, mul_comm]; ring_nf
 
 /-! ### Hilbert–Schmidt contraction estimates -/
 

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -128,9 +128,8 @@ theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
     (μ : ℂ) (hμ : Module.End.HasEigenvalue (mixedTransferMap₂ A B) μ) :
     ‖μ‖ ≤ 1 := by
   obtain ⟨v, hv_mem, hv_ne⟩ := hμ.exists_hasEigenvector
-  have hFv := Module.End.mem_eigenspace_iff.mp hv_mem
   have hv : Module.End.HasEigenvector (mixedTransferMap₂ A B) μ v :=
-    ⟨Module.End.mem_eigenspace_iff.mpr hFv, hv_ne⟩
+    ⟨hv_mem, hv_ne⟩
   by_contra h_gt; push Not at h_gt
   have h_pos : 0 < frobSq v := by
     rw [frobSq]

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -129,6 +129,8 @@ theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
     ‖μ‖ ≤ 1 := by
   obtain ⟨v, hv_mem, hv_ne⟩ := hμ.exists_hasEigenvector
   have hFv := Module.End.mem_eigenspace_iff.mp hv_mem
+  have hv : Module.End.HasEigenvector (mixedTransferMap₂ A B) μ v :=
+    ⟨Module.End.mem_eigenspace_iff.mpr hFv, hv_ne⟩
   by_contra h_gt; push Not at h_gt
   have h_pos : 0 < frobSq v := by
     rw [frobSq]
@@ -137,7 +139,7 @@ theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
     exact sq_pos_of_ne_zero (norm_ne_zero_iff.mpr hv_ne)
   have h_bound : ∀ n : ℕ, ‖μ‖ ^ (2 * n) ≤ (D₁ : ℝ) ^ 2 := fun n => by
     have h1 := hs_contraction_rect A B v hA_norm hB_norm n
-    rw [eigenvector_pow _ v μ hFv n] at h1
+    rw [Module.End.HasEigenvector.pow_apply hv n] at h1
     simp only [frobSq_smul, norm_pow] at h1
     calc ‖μ‖ ^ (2 * n) = (‖μ‖ ^ n) ^ 2 := by ring
     _ ≤ _ := le_of_mul_le_mul_right (by linarith) h_pos


### PR DESCRIPTION
## What changed

- remove the local `MPSTensor.eigenvector_pow` duplicate
- construct the existing `Module.End.HasEigenvector` witness in the rectangular normalized transfer-gap proof
- use Mathlib's exact `Module.End.HasEigenvector.pow_apply` theorem

All public theorem statements are unchanged. This is disjoint from the active LionSR/QICLean#341 Wave-0 branch.

## Validation

- targeted build of both touched modules (3014 jobs)
- import-direction check: 436 files, 0 violations
- generated aggregators: 55 files, 1455 modules
- reader-facing prose and proof-integrity checks
- repository-wide audit confirms no local `eigenvector_pow` remains
- `git diff --check origin/main...HEAD`

Advances LionSR/QICLean#341.
Advances LionSR/TNLean#6560.
