### PR TITLE
refactor(kraus): expose mapLM irreducibility equivalence

### DIFF
--- a/TNLean/Kraus/InvariantProjection.lean
+++ b/TNLean/Kraus/InvariantProjection.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.OrthogonalProjection
+import TNLean.Channel.FixedPoint.SupportInvariance
+import TNLean.Channel.Irreducible.Basic
 import TNLean.Kraus.Word
 
 /-!
@@ -30,6 +32,9 @@ across the ~429 files that reference this vocabulary; see
 
 * `HasInvariantProj` — existence of a nontrivial invariant orthogonal projection
 * `IsIrreducibleTensor` — no nontrivial invariant orthogonal projection exists
+* `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor` — tensor irreducibility implies
+  irreducibility of the associated finite Kraus map
+* `Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM` — the converse implication
 -/
 
 namespace MPSTensor
@@ -50,3 +55,34 @@ def IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
   ¬ HasInvariantProj A
 
 end MPSTensor
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- A finite Kraus family with no nontrivial invariant orthogonal projection defines an
+irreducible Kraus map. -/
+theorem isIrreducibleMap_mapLM_of_isIrreducibleTensor
+    (K : Fin d → Mat) (hIrr : MPSTensor.IsIrreducibleTensor K) :
+    IsIrreducibleMap (mapLM K) := by
+  intro P hProj hInv
+  have hLower : ∀ i : Fin d, (1 - P) * K i * P = 0 :=
+    invariance_implies_lowerZero K P hProj fun X => by
+      simpa only [mapLM_apply] using hInv X
+  by_contra h_neither
+  push Not at h_neither
+  exact hIrr ⟨P, hProj, h_neither.1, h_neither.2, hLower⟩
+
+/-- If the finite Kraus map is irreducible, then its Kraus family has no nontrivial
+invariant orthogonal projection. -/
+theorem isIrreducibleTensor_of_isIrreducibleMap_mapLM
+    (K : Fin d → Mat) (hIrr : IsIrreducibleMap (mapLM K)) :
+    MPSTensor.IsIrreducibleTensor K := by
+  intro ⟨P, hProj, hP0, hP1, hLower⟩
+  have hInv : ∀ X, P * mapLM K (P * X * P) * P = mapLM K (P * X * P) := fun X => by
+    simpa only [mapLM_apply] using lowerZero_implies_invariance K P hProj hLower X
+  exact (hIrr P hProj hInv).elim hP0 hP1
+
+end Kraus

--- a/TNLean/MPS/Core/TransferChannel.lean
+++ b/TNLean/MPS/Core/TransferChannel.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.KrausMap
+import TNLean.Kraus.InvariantProjection
 import TNLean.MPS.Core.Transfer
 
 /-!
@@ -19,6 +20,9 @@ properties in transfer-map notation.
 * `Kraus.mapLM_eq_transferMap`: the generic Kraus map and the MPS transfer map agree.
 * `Kraus.isIrreducibleMap_mapLM_of_transferMap`: transfer-map irreducibility in Kraus-map
   notation.
+* `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor`: irreducibility of a finite
+  matrix family gives irreducibility of its transfer map.
+* `Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap`: the converse implication.
 * `Kraus.isChannel_transferMap`: the MPS transfer map of a trace-preserving Kraus family is
   a channel.
 * `trace_mul_transferMap_adjoint`: the generic Kraus trace-adjoint identity in MPS
@@ -48,6 +52,22 @@ theorem isIrreducibleMap_mapLM_of_transferMap (K : Fin d → Mat)
     (hIrr : IsIrreducibleMap (MPSTensor.transferMap (d := d) (D := D) K)) :
     IsIrreducibleMap (mapLM K) := by
   simpa only [mapLM_eq_transferMap] using hIrr
+
+/-- An irreducible finite matrix family has an irreducible MPS transfer map. -/
+theorem isIrreducibleMap_transferMap_of_isIrreducibleTensor
+    (K : Fin d → Mat) (hIrr : MPSTensor.IsIrreducibleTensor K) :
+    IsIrreducibleMap (MPSTensor.transferMap (d := d) (D := D) K) := by
+  rw [← mapLM_eq_transferMap]
+  exact isIrreducibleMap_mapLM_of_isIrreducibleTensor K hIrr
+
+/-- Irreducibility of the MPS transfer map implies irreducibility of its finite
+matrix family. -/
+theorem isIrreducibleTensor_of_isIrreducibleMap_transferMap
+    (K : Fin d → Mat)
+    (hIrr : IsIrreducibleMap (MPSTensor.transferMap (d := d) (D := D) K)) :
+    MPSTensor.IsIrreducibleTensor K :=
+  isIrreducibleTensor_of_isIrreducibleMap_mapLM K
+    (isIrreducibleMap_mapLM_of_transferMap K hIrr)
 
 /-- The MPS transfer map of a trace-preserving finite Kraus family is a quantum channel. -/
 theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.Algebra.MatrixAux
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
+import TNLean.MPS.Core.TransferChannel
 import TNLean.QPF.Assembly
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 
@@ -80,14 +81,8 @@ the irreducibility hypothesis. -/
 theorem isIrreducibleCP_transferMap_of_isIrreducibleTensor
     (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
     IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-  intro P hProj hInv
-  -- Use the invariance to get the lower-zero condition
-  have hLower := invariance_implies_lowerZero A P hProj hInv
-  -- If P ≠ 0 and P ≠ 1, then A has a nontrivial invariant projection
-  by_contra h_neither
-  push Not at h_neither
-  obtain ⟨hP0, hP1⟩ := h_neither
-  exact hIrr ⟨P, hProj, hP0, hP1, hLower⟩
+  rw [← Kraus.mapLM_eq_transferMap]
+  exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
 
 /-- **Irreducible CP map ⇒ irreducible tensor.**
 
@@ -102,13 +97,8 @@ theorem isIrreducibleTensor_of_isIrreducibleMap
     (A : MPSTensor d D)
     (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A)) :
     IsIrreducibleTensor A := by
-  intro ⟨P, hProj, hP0, hP1, hLower⟩
-  -- Build the invariance condition from the lower-zero condition
-  have hInv := lowerZero_implies_invariance A P hProj hLower
-  -- Apply irreducibility of the transfer map
-  have hTrivial := hIrr P hProj hInv
-  -- But P is nontrivial: P ≠ 0 and P ≠ 1
-  exact hTrivial.elim hP0 hP1
+  apply Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
+  simpa only [Kraus.mapLM_eq_transferMap] using hIrr
 
 /-! ## Part 2: CFII-style diagonal positive-definite fixed point -/
 

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -80,9 +80,8 @@ If `P ≠ 0` and `P ≠ 1`, this would witness `HasInvariantProj A`, contradicti
 the irreducibility hypothesis. -/
 theorem isIrreducibleCP_transferMap_of_isIrreducibleTensor
     (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-  rw [← Kraus.mapLM_eq_transferMap]
-  exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
+    IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+  Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hIrr
 
 /-- **Irreducible CP map ⇒ irreducible tensor.**
 
@@ -96,9 +95,8 @@ this contradicts the irreducibility of `E`. -/
 theorem isIrreducibleTensor_of_isIrreducibleMap
     (A : MPSTensor d D)
     (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A)) :
-    IsIrreducibleTensor A := by
-  apply Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
-  simpa only [Kraus.mapLM_eq_transferMap] using hIrr
+    IsIrreducibleTensor A :=
+  Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap A hIrr
 
 /-! ## Part 2: CFII-style diagonal positive-definite fixed point -/
 

--- a/TNLean/Spectral/PeripheralToTransferMapGap.lean
+++ b/TNLean/Spectral/PeripheralToTransferMapGap.lean
@@ -7,7 +7,8 @@ import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Spectral.TransferOperatorGap
 import TNLean.QPF.Assembly
-import TNLean.MPS.Irreducible.FormII
+import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.TransferChannel
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.MPS.Core.CPPrimitive
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
@@ -274,8 +275,9 @@ theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible
     X = 0 := by
   set E := transferMap (d := d) (D := D) A
   have hIrrMap : IsIrreducibleMap E := by
-    simpa only using
-      isIrreducibleCP_transferMap_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+    change IsIrreducibleMap (transferMap (d := d) (D := D) A)
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
   exact transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_hermitian_zero
     (A := A)
     (hHermitianZero := fun Y hYherm hYfix htrY =>
@@ -432,8 +434,9 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
             < 1 := by
   set E := transferMap (d := d) (D := D) A
   have hIrrMap : IsIrreducibleMap E := by
-    simpa only using
-      isIrreducibleCP_transferMap_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+    change IsIrreducibleMap (transferMap (d := d) (D := D) A)
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fixE⟩ :=
     (transferMap_isChannel (A := A) hNorm).exists_posSemidef_fixedPoint (E := E) hDpos

--- a/TNLean/Spectral/PeripheralToTransferMapGap.lean
+++ b/TNLean/Spectral/PeripheralToTransferMapGap.lean
@@ -274,10 +274,8 @@ theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible
     (htrX : Matrix.trace X = 0) :
     X = 0 := by
   set E := transferMap (d := d) (D := D) A
-  have hIrrMap : IsIrreducibleMap E := by
-    change IsIrreducibleMap (transferMap (d := d) (D := D) A)
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
+  have hIrrMap : IsIrreducibleMap E :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hIrr
   exact transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_hermitian_zero
     (A := A)
     (hHermitianZero := fun Y hYherm hYfix htrY =>
@@ -433,10 +431,8 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
               ((transferMap (d := d) (D := D) A) - fixedPointProj (D := D) ρ htr))
             < 1 := by
   set E := transferMap (d := d) (D := D) A
-  have hIrrMap : IsIrreducibleMap E := by
-    change IsIrreducibleMap (transferMap (d := d) (D := D) A)
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
+  have hIrrMap : IsIrreducibleMap E :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hIrr
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fixE⟩ :=
     (transferMap_isChannel (A := A) hNorm).exists_posSemidef_fixedPoint (E := E) hDpos

--- a/TNLean/Spectral/TransferOperatorGapInjective.lean
+++ b/TNLean/Spectral/TransferOperatorGapInjective.lean
@@ -26,9 +26,8 @@ variable {d D D₁ D₂ : ℕ}
 private lemma irreducibleTensor_of_injective
     (A : MPSTensor d D) (hA : IsInjective A) :
     IsIrreducibleTensor A :=
-  Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
-    (Kraus.isIrreducibleMap_mapLM_of_transferMap A
-      (injective_implies_irreducibleCP A hA))
+  Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap A
+    (injective_implies_irreducibleCP A hA)
 
 /-- **Eigenvalue rigidity** for normalized injective tensors. -/
 theorem modulus_one_eigenvalue_implies_gauge

--- a/TNLean/Spectral/TransferOperatorGapInjective.lean
+++ b/TNLean/Spectral/TransferOperatorGapInjective.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Spectral.TransferOperatorGapNT
+import TNLean.Kraus.InvariantProjection
 import TNLean.MPS.Core.CPPrimitive
+import TNLean.MPS.Core.TransferChannel
 
 /-!
 # Injective transfer-gap corollaries
@@ -24,8 +26,9 @@ variable {d D D₁ D₂ : ℕ}
 private lemma irreducibleTensor_of_injective
     (A : MPSTensor d D) (hA : IsInjective A) :
     IsIrreducibleTensor A :=
-  isIrreducibleTensor_of_isIrreducibleMap A
-    (injective_implies_irreducibleCP A hA)
+  Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
+    (Kraus.isIrreducibleMap_mapLM_of_transferMap A
+      (injective_implies_irreducibleCP A hA))
 
 /-- **Eigenvalue rigidity** for normalized injective tensors. -/
 theorem modulus_one_eigenvalue_implies_gauge

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -86,9 +86,8 @@ private lemma exists_irreducible_TP_fixedPoint_squareRoot [NeZero D]
         ρ.PosSemidef ∧ ρ ≠ 0 ∧ transferMap (d := d) (D := D) A ρ = ρ ∧
         S.det ≠ 0 ∧ S * Sᴴ = ρ := by
   classical
-  have hA_irrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
+  have hA_irrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hA_irr
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     exists_posSemidef_fixedPoint A hA_left (NeZero.pos D)
   have hρ_pd : ρ.PosDef :=
@@ -324,9 +323,8 @@ private lemma exists_posSemidef_fixedPoint_gauge_of_irreducible_TP {D : ℕ}
       S.det ≠ 0 ∧ IsUnit S.det ∧ S * Sᴴ = ρ := by
   classical
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
+  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hA_irr
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     exists_posSemidef_fixedPoint A hA_left hDpos
   have hρ_pd : ρ.PosDef :=
@@ -484,12 +482,10 @@ private lemma dim_eq_of_gram_fixedPoints_of_irreducible_TP
     (hσB_fix : transferMap (d := d) (D := D₂) B' σB = σB) :
     D₁ = D₂ := by
   classical
-  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D₁) A) := by
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
-  have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D₂) B) := by
-    rw [← Kraus.mapLM_eq_transferMap]
-    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor B hB_irr
+  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D₁) A) :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hA_irr
+  have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D₂) B) :=
+    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor B hB_irr
   have hσA_fix_gauge : transferMap (d := d) (D := D₁) (gaugeTensor SA A) σA = σA := by
     simpa only [hA'_eq] using hσA_fix
   have hσB_fix_gauge : transferMap (d := d) (D := D₂) (gaugeTensor SB B) σB = σB := by

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -7,7 +7,9 @@ import TNLean.Spectral.MPVOverlapDecayRect
 import TNLean.Spectral.TransferOperatorGapNormalized
 import TNLean.Spectral.GaugeConstruction
 import TNLean.Channel.PerronFrobenius.Existence
-import TNLean.MPS.Irreducible.FormII
+import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.TransferChannel
+import TNLean.QPF.Assembly
 import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.LinearAlgebra.Matrix.ToLin
 
@@ -84,8 +86,9 @@ private lemma exists_irreducible_TP_fixedPoint_squareRoot [NeZero D]
         ρ.PosSemidef ∧ ρ ≠ 0 ∧ transferMap (d := d) (D := D) A ρ = ρ ∧
         S.det ≠ 0 ∧ S * Sᴴ = ρ := by
   classical
-  have hA_irrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hA_irr
+  have hA_irrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     exists_posSemidef_fixedPoint A hA_left (NeZero.pos D)
   have hρ_pd : ρ.PosDef :=
@@ -321,8 +324,9 @@ private lemma exists_posSemidef_fixedPoint_gauge_of_irreducible_TP {D : ℕ}
       S.det ≠ 0 ∧ IsUnit S.det ∧ S * Sᴴ = ρ := by
   classical
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hA_irr
+  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     exists_posSemidef_fixedPoint A hA_left hDpos
   have hρ_pd : ρ.PosDef :=
@@ -480,10 +484,12 @@ private lemma dim_eq_of_gram_fixedPoints_of_irreducible_TP
     (hσB_fix : transferMap (d := d) (D := D₂) B' σB = σB) :
     D₁ = D₂ := by
   classical
-  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D₁) A) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hA_irr
-  have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D₂) B) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor B hB_irr
+  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D₁) A) := by
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA_irr
+  have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D₂) B) := by
+    rw [← Kraus.mapLM_eq_transferMap]
+    exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor B hB_irr
   have hσA_fix_gauge : transferMap (d := d) (D := D₁) (gaugeTensor SA A) σA = σA := by
     simpa only [hA'_eq] using hσA_fix
   have hσB_fix_gauge : transferMap (d := d) (D := D₂) (gaugeTensor SB B) σB = σB := by

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Core.Transfer
 import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Spectral.PeripheralToTransferMapGap
-import TNLean.MPS.Irreducible.FormII
+import TNLean.Kraus.InvariantProjection
 import TNLean.Wielandt.Primitivity.ToNormal
 import TNLean.Channel.Primitive
 import TNLean.Channel.Irreducible.FromSpectral
@@ -70,7 +70,9 @@ theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
     (hSI : IsStronglyIrreduciblePaper A) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ ∧ ρ.PosDef := by
   obtain ⟨_, _, _, hPrim, hIrrMap⟩ := hSI
-  have hIrrT : IsIrreducibleTensor A := isIrreducibleTensor_of_isIrreducibleMap A hIrrMap
+  have hIrrT : IsIrreducibleTensor A :=
+    Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
+      (Kraus.isIrreducibleMap_mapLM_of_transferMap A hIrrMap)
   obtain ⟨ρ', hPrimMPS⟩ :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrrT hNorm hPrim
   have hρ'PD : ρ'.PosDef :=

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -71,8 +71,7 @@ theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ ∧ ρ.PosDef := by
   obtain ⟨_, _, _, hPrim, hIrrMap⟩ := hSI
   have hIrrT : IsIrreducibleTensor A :=
-    Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
-      (Kraus.isIrreducibleMap_mapLM_of_transferMap A hIrrMap)
+    Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap A hIrrMap
   obtain ⟨ρ', hPrimMPS⟩ :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrrT hNorm hPrim
   have hρ'PD : ρ'.PosDef :=

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -177,9 +177,8 @@ omit [NeZero D] in
 /-- Irreducibility of a tensor gives irreducibility of its transfer map. -/
 theorem isIrreducibleMap_of_isIrreducibleTensor
     (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-  simpa only [Kraus.mapLM_eq_transferMap] using
-    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
+    IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+  Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor A hIrr
 
 /-- **IsIrreducibleTensor ⟹ PosDef** for primitive tensors.
 

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Primitive
+import TNLean.Kraus.InvariantProjection
 import TNLean.MPS.Core.TransferChannel
-import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.QPF.PosDef
 
@@ -177,8 +177,9 @@ omit [NeZero D] in
 /-- Irreducibility of a tensor gives irreducibility of its transfer map. -/
 theorem isIrreducibleMap_of_isIrreducibleTensor
     (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-  isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrr
+    IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
+  simpa only [Kraus.mapLM_eq_transferMap] using
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hIrr
 
 /-- **IsIrreducibleTensor ⟹ PosDef** for primitive tensors.
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -212,6 +212,24 @@ abstracted — record why, so it is not re-proposed).
   MPS compatibility import instead of `Channel.FixedPoint.MaximalSupport`; this
   intentional import-level change removes the former Channel-to-MPS dependency.
 
+### matrix-family irreducibility in transfer-map notation — promoted
+- **Pattern:** convert between irreducibility of a finite matrix family and
+  irreducibility of its MPS transfer map by passing through `Kraus.mapLM` and
+  `Kraus.mapLM_eq_transferMap`.
+- **Seen:** nine forward conversions and three converse conversions across
+  `MPS/Irreducible/FormII.lean`, `Spectral/PeripheralToTransferMapGap.lean`,
+  `Spectral/TransferOperatorGap{NT,Injective}.lean`, and
+  `Wielandt/Primitivity/{PrimitiveBridge,ToNormal}.lean` before promotion
+  (2026-08-20).
+- **Abstraction:**
+  `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleTensor` and
+  `Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap` in
+  `TNLean/MPS/Core/TransferChannel.lean`.
+- **Notes:** the compatibility module is the unique boundary between the
+  Kraus-owned irreducibility equivalence and transfer-map notation. Downstream
+  callers no longer repeat the equality conversion or import
+  `MPS.Irreducible.FormII` solely for this equivalence.
+
 ### pure gauge to heterogeneous repeated blocks — promoted
 - **Pattern:** convert `GaugeEquiv A B` to `HetRepeatedBlocks A B` by passing
   through `EquivalentBlocks`, choosing unit phase, and embedding the


### PR DESCRIPTION
## What changed

- prove the forward and converse equivalence between IsIrreducibleTensor K and irreducibility of Kraus.mapLM K directly in Kraus/InvariantProjection.lean, using the Kraus-side lower-zero and invariance lemmas
- preserve the two public FormII transfer-map theorems as thin compatibility corollaries
- remove the FormII import from primitivity and spectral callers that need only irreducibility
- centralize the nine forward and three converse mapLM/transferMap conversions in MPS/Core/TransferChannel.lean
- record this promoted proof pattern in docs/tactic_patterns.md

## Validation

- targeted build of TransferChannel, InvariantProjection, FormII, the spectral callers, and both primitivity callers: 8831 jobs passed on the rebased head
- import-direction guard: no violations across 437 QIC-bound files
- generated import aggregators: current, covering 1458 production modules
- changed-file proof-integrity and formatting checks: clean
- full GitHub CI required before merge

The transfer-map compatibility module is now the unique boundary between the Kraus-owned equivalence and MPS transfer-map notation. No theorem statement or hypothesis changes.

Closes LionSR/QICLean#337.
Advances LionSR/TNLean#6560.
