### PR TITLE
fix(wielandt): repair cumulative-span consumer after split

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
@@ -227,7 +227,7 @@ theorem cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top
   -- f maps cumulativeSpan into cumulativeVectorSpan
   have himage : Submodule.map f (cumulativeSpan A N) ≤
       cumulativeVectorSpan A φ N := by
-    rw [cumulativeSpan, Submodule.map_span]
+    rw [cumulativeSpan, Kraus.cumulativeSpan, Submodule.map_span]
     apply Submodule.span_mono
     rintro v ⟨M, ⟨w, hw, rfl⟩, rfl⟩
     exact ⟨w, hw, rfl⟩


### PR DESCRIPTION
## What changed

- unfold the new `Kraus.cumulativeSpan` definition before applying `Submodule.map_span`
- restore compilation of `EigenvectorSpreading` after LionSR/TNLean#6637 split the transfer-free span API

## Validation

- `lake build TNLean.Wielandt.SpanGrowth.EigenvectorSpreading`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`

Fixes the build regression introduced by LionSR/TNLean#6637.
Advances LionSR/QICLean#340.