### PR TITLE
refactor(mps): use canonical matrix square-root lemmas

### DIFF
--- a/TNLean/MPS/Core/TPGauge.lean
+++ b/TNLean/MPS/Core/TPGauge.lean
@@ -40,26 +40,6 @@ open Matrix Finset Complex
 
 variable {d D : ℕ}
 
-/-! ## Auxiliary lemmas about `CFC.sqrt` for positive definite matrices -/
-
-/-- For a positive definite matrix `ρ`, the CFC square root satisfies `sqrt ρ * sqrt ρ = ρ`. -/
-lemma cfc_sqrt_mul_self_of_posDef (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
-    CFC.sqrt ρ * CFC.sqrt ρ = ρ := by
-  have hnonneg : (0 : Matrix (Fin D) (Fin D) ℂ) ≤ ρ := hρ.posSemidef.nonneg
-  simpa using (CFC.sqrt_mul_sqrt_self ρ hnonneg)
-
-/-- `CFC.sqrt ρ` is Hermitian (self-adjoint). -/
-lemma conjTranspose_cfc_sqrt (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    (CFC.sqrt ρ)ᴴ = CFC.sqrt ρ :=
-  Matrix.conjTranspose_cfc_sqrt ρ
-
-/-- If `ρ` is positive definite, then `det (CFC.sqrt ρ)` is a unit.
-
-(We will use this to rewrite `S * S⁻¹ = 1` for `S := CFC.sqrt ρ`.) -/
-lemma isUnit_det_cfc_sqrt_of_posDef (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
-    IsUnit (Matrix.det (CFC.sqrt ρ)) :=
-  Matrix.PosDef.isUnit_det_cfc_sqrt hρ
-
 /-! ## TP gauge construction -/
 
 /-- Gauge-transformed tensor `B i = ρ^{1/2} A i ρ^{-1/2}`.
@@ -137,7 +117,7 @@ theorem gaugeEquiv_tpGauge (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ)
     Matrix.GeneralLinearGroup.mk'' (CFC.sqrt ρ)
       (by
         -- `mk''` needs `IsUnit det`.
-        simpa using isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ)
+        simpa using Matrix.PosDef.isUnit_det_cfc_sqrt hρ)
   refine ⟨X, ?_⟩
   intro i
   -- `X⁻¹` coerces to the (nonsingular) matrix inverse.
@@ -195,13 +175,13 @@ theorem spectralUnitalGauge_isUnital_of_transferMap_eigenvector
     rw [show c = (↑((Real.sqrt r)⁻¹) : ℂ) from rfl, ← Complex.ofReal_mul, hcc,
       Complex.ofReal_inv]
   have hS_mul : S * S = ρ := by
-    simpa [S] using cfc_sqrt_mul_self_of_posDef (D := D) ρ hρ
+    simpa [S] using CFC.sqrt_mul_sqrt_self ρ hρ.posSemidef.nonneg
   have hS_herm : Sᴴ = S := by
-    simpa [S] using conjTranspose_cfc_sqrt (D := D) ρ
+    simpa [S] using Matrix.conjTranspose_cfc_sqrt ρ
   have hSS : S * Sᴴ = ρ := by
     simpa [hS_herm] using hS_mul
   have hdet : IsUnit S.det := by
-    simpa [S] using isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ
+    simpa [S] using Matrix.PosDef.isUnit_det_cfc_sqrt hρ
   have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hdet
   have hdetT : IsUnit (Sᴴ.det) := by
     simpa [Matrix.det_conjTranspose] using (IsUnit.star hdet)
@@ -278,7 +258,7 @@ theorem gaugeEquiv_unitalGauge
   let X : GL (Fin D) ℂ :=
     Matrix.GeneralLinearGroup.mk'' (CFC.sqrt ρ)
       (by
-        simpa using isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ)
+        simpa using Matrix.PosDef.isUnit_det_cfc_sqrt hρ)
   refine ⟨X⁻¹, ?_⟩
   intro i
   simp [unitalGauge, X]

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.MatrixSqrt
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition
@@ -118,7 +119,7 @@ theorem spectralUnitalGauge_schwarz_setup [NeZero D]
     have hs : Real.sqrt rad ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr hrad)
     exact_mod_cast inv_ne_zero hs
   have hSunit : IsUnit (CFC.sqrt ρ) :=
-    (Matrix.isUnit_iff_isUnit_det _).mpr (isUnit_det_cfc_sqrt_of_posDef ρ hρ)
+    (Matrix.isUnit_iff_isUnit_det _).mpr (Matrix.PosDef.isUnit_det_cfc_sqrt hρ)
   have hIrrK : IsIrreducibleTensor (spectralUnitalGauge B rad ρ) := by
     have h := isIrreducibleTensor_smul_conj B hIrr hSunit hcne
     exact h
@@ -165,8 +166,8 @@ theorem hasEigenvalue_transferMap_spectralUnitalGauge
     Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
   have hXne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
   set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt ρ with hS
-  have hSdet : IsUnit S.det := isUnit_det_cfc_sqrt_of_posDef ρ hρ
-  have hSH : Sᴴ = S := conjTranspose_cfc_sqrt ρ
+  have hSdet : IsUnit S.det := Matrix.PosDef.isUnit_det_cfc_sqrt hρ
+  have hSH : Sᴴ = S := Matrix.conjTranspose_cfc_sqrt ρ
   have hSinvH : (S⁻¹)ᴴ = S⁻¹ := by rw [Matrix.conjTranspose_nonsing_inv, hSH]
   set c : ℂ := (↑((Real.sqrt rad)⁻¹) : ℂ) with hc
   have hcstar : star c = c := by rw [hc, RCLike.star_def, Complex.conj_ofReal]
@@ -313,7 +314,7 @@ theorem exists_displaced_invariant_projector_of_periodic_vector
     fun k => by rw [← Kraus.mapLM_eq_transferMap]; exact hcyclicLM k
   -- Notation for the square root of the eigenvector and the scaling factor.
   set S : Matrix (Fin n) (Fin n) ℂ := CFC.sqrt ρ with hS
-  have hSdet : IsUnit S.det := MPSTensor.isUnit_det_cfc_sqrt_of_posDef ρ hρ
+  have hSdet : IsUnit S.det := Matrix.PosDef.isUnit_det_cfc_sqrt hρ
   set c : ℂ := (↑((Real.sqrt rad)⁻¹) : ℂ) with hc
   have hcne : c ≠ 0 := by
     have hs : Real.sqrt rad ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr hrad)

--- a/TNLean/MPS/Periodic/Normalization.lean
+++ b/TNLean/MPS/Periodic/Normalization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Periodic.Defs
@@ -50,7 +51,7 @@ theorem IsSpectrallyPeriodic.exists_isPeriodic_tpGauge
     exists_tpGauge_of_irreducible_spectralRadius_one
       hA.irreducible hA.spectral_radius_one
   have hSdet : (CFC.sqrt σ).det ≠ 0 :=
-    (isUnit_det_cfc_sqrt_of_posDef σ hσ).ne_zero
+    (Matrix.PosDef.isUnit_det_cfc_sqrt hσ).ne_zero
   have hSinvDet : ((CFC.sqrt σ)⁻¹).det ≠ 0 := by
     simpa [Matrix.det_nonsing_inv] using inv_ne_zero hSdet
   have hPeripheral :

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexPhasePositivity
+import TNLean.Analysis.MatrixSqrt
 import TNLean.MPS.Symmetry.StringOrderDefs
 import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.Core.TPGauge
@@ -57,9 +58,9 @@ lemma transferMap_tpGauge_eq_similarityMap
       similarityMap (D := D) (CFC.sqrt σ)⁻¹ (transferMap A) := by
   set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt σ
   have hS_det : IsUnit S.det := by
-    simpa [S] using isUnit_det_cfc_sqrt_of_posDef (D := D) σ hσ
+    simpa [S] using Matrix.PosDef.isUnit_det_cfc_sqrt hσ
   have hS_herm : Sᴴ = S := by
-    simpa [S] using conjTranspose_cfc_sqrt (D := D) σ
+    simpa [S] using Matrix.conjTranspose_cfc_sqrt σ
   have hS_inv_inv : S⁻¹⁻¹ = S := Matrix.nonsing_inv_nonsing_inv S hS_det
   have hS_inv_herm : (S⁻¹)ᴴ = (Sᴴ)⁻¹ := Matrix.conjTranspose_nonsing_inv S
   have hS_inv_herm' : (S⁻¹)ᴴ = S⁻¹ := by simpa [hS_herm] using hS_inv_herm
@@ -93,7 +94,7 @@ lemma isPrimitive_transferMap_tpGauge_iff
       _root_.IsPrimitive (transferMap A) := by
   set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt σ
   have hS_det : S.det ≠ 0 := by
-    exact (isUnit_det_cfc_sqrt_of_posDef (D := D) σ hσ).ne_zero
+    exact (Matrix.PosDef.isUnit_det_cfc_sqrt hσ).ne_zero
   rw [transferMap_tpGauge_eq_similarityMap A σ hσ]
   exact IsPrimitive.similarityMap_iff S⁻¹ (by simpa [Matrix.det_nonsing_inv] using hS_det) _
 
@@ -107,7 +108,7 @@ lemma isIrreducibleTensor_tpGauge_of_isIrreducibleMap [NeZero D]
     IsIrreducibleTensor (d := d) (D := D) (tpGauge (d := d) (D := D) A σ) := by
   set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt σ
   have hS_det : S.det ≠ 0 := by
-    exact (isUnit_det_cfc_sqrt_of_posDef (D := D) σ hσ).ne_zero
+    exact (Matrix.PosDef.isUnit_det_cfc_sqrt hσ).ne_zero
   have hIrrSim :
       IsIrreducibleMap (similarityMap (D := D) S⁻¹ (transferMap A)) := by
     refine isIrreducibleMap_similarity (D := D) ?_ hIrr
@@ -234,9 +235,9 @@ noncomputable def twistedTPGaugeSetup [NeZero D]
       _ = σ := hσ_fixA
   let S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt σ
   have hS_herm : Sᴴ = S := by
-    simpa [S] using conjTranspose_cfc_sqrt (D := D) σ
+    simpa [S] using Matrix.conjTranspose_cfc_sqrt σ
   have hS_det : IsUnit (Matrix.det S) := by
-    simpa [S] using isUnit_det_cfc_sqrt_of_posDef (D := D) σ hσ_pd
+    simpa [S] using Matrix.PosDef.isUnit_det_cfc_sqrt hσ_pd
   have hS_mul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hS_det
   have hS_inv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hS_det
   have hS_detT : IsUnit (Matrix.det Sᴴ) := by


### PR DESCRIPTION
## What changed

- delete the three obsolete `MPSTensor` CFC square-root wrappers from `MPS/Core/TPGauge`
- use `CFC.sqrt_mul_sqrt_self`, `Matrix.conjTranspose_cfc_sqrt`, and `Matrix.PosDef.isUnit_det_cfc_sqrt` directly
- add direct `Analysis.MatrixSqrt` imports to the three external callers
- preserve every public gauge theorem statement

This is the final cleanup remaining in #6569 after #6633 and #6629 merged.

## Validation

- `lake build TNLean.MPS.Core.TPGauge`
- `lake build TNLean.MPS.Symmetry.StringOrderAux`
- `lake build TNLean.MPS.Periodic.Normalization`
- `lake build TNLean.MPS.MPDO.CyclicProjector`
- generated import aggregators current
- reader-facing prose and proof-integrity checks
- repository-wide audit confirms no obsolete wrapper references remain
- `git diff --check origin/main...HEAD`

Closes #6569.
Advances #6560.
