### PR TITLE
fix(wielandt): repair relocated span consumers

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -42,7 +42,8 @@ theorem boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
   have hMaps : LinearMap.mulLeft ℂ X = LinearMap.mulRight ℂ Y := by
     apply LinearMap.ext_on_range
       (v := fun α : Fin S → Fin d ↦ evalWord A (List.ofFn α))
-    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A S).mpr hBlk
+    · simpa [wordSpan, Kraus.wordSpan] using
+        (wordSpan_eq_top_iff_isNBlkInjective A S).mpr hBlk
     · intro α
       simpa only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply] using
         hIntertwine α

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -74,7 +74,8 @@ private theorem exists_right_factor_of_block_letter_compatibility
     fun σ => evalWord A (List.ofFn σ)
   have hSurj : Function.Surjective (Fintype.linearCombination ℂ gen) := by
     apply (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ gen).mp
-    simpa [gen, wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    simpa [gen, wordSpan, Kraus.wordSpan] using
+      (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
   obtain ⟨c, hc⟩ := hSurj (1 : Matrix (Fin D) (Fin D) ℂ)
   have hc' : ∑ τ, c τ • gen τ = (1 : Matrix (Fin D) (Fin D) ℂ) := by
     simpa [Fintype.linearCombination_apply] using hc
@@ -208,7 +209,8 @@ theorem commutes_block_words_of_commutes_long_words_of_isNBlkInjective
     fun σ => evalWord A (List.ofFn σ)
   have hSurj : Function.Surjective (Fintype.linearCombination ℂ gen) := by
     apply (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ gen).mp
-    simpa [gen, wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    simpa [gen, wordSpan, Kraus.wordSpan] using
+      (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
   obtain ⟨c, hc⟩ := hSurj (1 : Matrix (Fin D) (Fin D) ℂ)
   have hc' : ∑ σ, c σ • gen σ = (1 : Matrix (Fin D) (Fin D) ℂ) := by
     simpa [Fintype.linearCombination_apply] using hc
@@ -240,7 +242,8 @@ theorem commutes_all_of_commutes_long_words_of_isNBlkInjective
   have hφ : LinearMap.mulLeft ℂ X = LinearMap.mulRight ℂ X := by
     apply LinearMap.ext_on_range
       (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    · simpa [wordSpan, Kraus.wordSpan] using
+        (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
     · intro σ
       simpa [LinearMap.mulLeft_apply, LinearMap.mulRight_apply] using hBlock σ
   intro M

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -60,7 +60,8 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
         = LinearMap.mulRight ℂ (Y σ_comp) := by
       apply LinearMap.ext_on_range
         (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+      · simpa [wordSpan, Kraus.wordSpan] using
+          (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
       · intro σ_tail
         simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
           LinearMap.mulRight_apply]

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -252,7 +252,7 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
         (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
       apply LinearMap.ext_on_range
         (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using hwordL
+      · simpa [wordSpan, Kraus.wordSpan] using hwordL
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX
@@ -277,7 +277,7 @@ theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
         (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
       apply LinearMap.ext_on_range
         (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using hWord
+      · simpa [wordSpan, Kraus.wordSpan] using hWord
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -79,7 +79,7 @@ private theorem allZero_contradiction [NeZero D]
       have hright : LinearMap.mulRight ℂ (evalWord A w₂) = 0 := by
         apply LinearMap.ext_on_range
           (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-          (hv := by rwa [← wordSpan])
+          (hv := by simpa only [wordSpan, Kraus.wordSpan] using hws)
         intro σ₁
         simp [LinearMap.mulRight_apply, hmul_zero σ₁]
       -- Taking M = 1: evalWord A w₂ = 0.
@@ -120,7 +120,7 @@ theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
         (LinearMap.mulRight ℂ (evalWord A w₂)) = 0 := by
       apply LinearMap.ext_on_range
         (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-        (hv := by rwa [← wordSpan])
+        (hv := by simpa only [wordSpan, Kraus.wordSpan] using hws)
       intro σ₁
       simp only [LinearMap.comp_apply, LinearMap.mulRight_apply,
         Matrix.traceLinearMap_apply]

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -332,7 +332,7 @@ private theorem eq_zero_of_trace_evalWord_mul_eq_zero {A : MPSTensor d D}
       (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
     apply LinearMap.ext_on_range
       (v := fun σ : Fin k → Fin d => evalWord A (List.ofFn σ))
-    · simpa [wordSpan] using hwordK
+    · simpa [wordSpan, Kraus.wordSpan] using hwordK
     · intro σ
       simp [Matrix.traceLinearMap_apply, h σ]
   exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -876,7 +876,8 @@ theorem left_witness_unique_of_isNBlkInjective
   have hmul : LinearMap.mulRight ℂ Y₁ = LinearMap.mulRight ℂ Y₂ := by
     apply LinearMap.ext_on_range
       (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    · simpa [wordSpan, Kraus.wordSpan] using
+        (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
     · intro σ
       simpa [LinearMap.mulRight_apply] using hword σ
   have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * Y₁ =
@@ -931,7 +932,8 @@ theorem boundary_matrix_commutes {A : MPSTensor d D} [NeZero D]
         LinearMap.mulRight ℂ (Y τ) := by
       apply LinearMap.ext_on_range
         (v := fun σ : Fin (L - 1) → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using wordSpan_eq_top_of_isInjective hA (by omega : 0 < L - 1)
+      · simpa [wordSpan, Kraus.wordSpan] using
+          wordSpan_eq_top_of_isInjective hA (by omega : 0 < L - 1)
       · intro σ_tail
         simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
                     LinearMap.mulRight_apply]
@@ -967,7 +969,7 @@ theorem boundary_matrix_commutes {A : MPSTensor d D} [NeZero D]
       have hφ : LinearMap.mulLeft ℂ (X * M₁ - M₁ * X) = 0 := by
         apply LinearMap.ext_on_range
           (v := fun f : Fin (M + 1 - L) → Fin d => evalWord A (List.ofFn f))
-        · simpa [wordSpan] using wordSpan_eq_top_of_isInjective hA hML'
+        · simpa [wordSpan, Kraus.wordSpan] using wordSpan_eq_top_of_isInjective hA hML'
         · intro f
           simp only [LinearMap.mulLeft_apply, LinearMap.zero_apply]
           let τ₀ : Fin (M + 1) → Fin d := fun k =>

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -150,10 +150,7 @@ private theorem geometric_apply_bound_of_spectralRadius_lt_one
 /-- The word span at length 1 equals the span of the Kraus operators. -/
 theorem wordSpan_one_eq_span_range (A : MPSTensor d D) :
     wordSpan A 1 = Submodule.span ℂ (Set.range A) := by
-  simp only [wordSpan]
-  congr 1; ext y; constructor
-  · rintro ⟨σ, rfl⟩; exact ⟨σ 0, by simp [evalWord]⟩
-  · rintro ⟨i, rfl⟩; exact ⟨fun _ => i, by simp [evalWord]⟩
+  exact Kraus.wordSpan_one A
 
 /-- An injective MPS tensor has eventually full Kraus rank (at index 1). -/
 theorem hasEventuallyFullKrausRank_of_injective (A : MPSTensor d D)

--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -164,7 +164,7 @@ theorem cumulativeSpan_transposeTensor_eq_top_of_cumulativeSpan_eq_top
       Submodule.map (e : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
           (cumulativeSpan A N) =
         cumulativeSpan (transposeTensor A) N := by
-    unfold cumulativeSpan
+    unfold cumulativeSpan Kraus.cumulativeSpan
     rw [Submodule.map_span]
     have hset :
         (fun M : Matrix (Fin D) (Fin D) ℂ => Mᵀ) ''
@@ -275,7 +275,7 @@ theorem map_wordSpan_eq_rowSpreadSpan
       rowSpreadSpan A ψ n := by
   classical
   -- Unfold everything down to spans of ranges.
-  unfold vecMulLinearMap wordSpan rowSpreadSpan
+  unfold vecMulLinearMap wordSpan Kraus.wordSpan rowSpreadSpan
   -- `Submodule.map` distributes over `Submodule.span`.
   rw [Submodule.map_span]
   -- Rewrite the RHS as an image of a range (so both sides match).

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -370,8 +370,9 @@ theorem rectSpan_succ_eq_iSup_mulRight
   apply le_antisymm
   · -- ≤: generators of rectSpan P A (n+1) decompose via right-multiplication
     change Submodule.map (LinearMap.mulLeft ℂ P) (wordSpan A (n + 1)) ≤ _
-    rw [wordSpan_succ_eq_mul_right, wordSpan, wordSpan, Submodule.span_mul_span,
-        Submodule.map_span]
+    rw [wordSpan_succ_eq_mul_right]
+    unfold wordSpan Kraus.wordSpan
+    rw [Submodule.span_mul_span, Submodule.map_span]
     apply Submodule.span_le.mpr
     rintro _ ⟨_, ⟨M₁, ⟨σ₁, rfl⟩, M₂, ⟨σ₂, rfl⟩, rfl⟩, rfl⟩
     have hM₂ := evalWord_ofFn_one A σ₂

--- a/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
@@ -227,7 +227,8 @@ theorem cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top
   -- f maps cumulativeSpan into cumulativeVectorSpan
   have himage : Submodule.map f (cumulativeSpan A N) ≤
       cumulativeVectorSpan A φ N := by
-    rw [cumulativeSpan, Submodule.map_span]
+    unfold cumulativeSpan Kraus.cumulativeSpan
+    rw [Submodule.map_span]
     apply Submodule.span_mono
     rintro v ⟨M, ⟨w, hw, rfl⟩, rfl⟩
     exact ⟨w, hw, rfl⟩

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -57,7 +57,7 @@ theorem map_wordSpan_eq_vectorSpreadSpan
       vectorSpreadSpan A φ n := by
   classical
   -- Unfold everything down to spans of ranges.
-  unfold mulVecLinearMap wordSpan vectorSpreadSpan
+  unfold mulVecLinearMap wordSpan Kraus.wordSpan vectorSpreadSpan
   -- `Submodule.map` distributes over `Submodule.span`.
   rw [Submodule.map_span]
   -- Rewrite the RHS as an image of a range (so both sides match).
@@ -80,26 +80,7 @@ theorem map_wordSpan_eq_vectorSpreadSpan
 /-- Products of length-`m` and length-`n` word spans lie in the length-`m+n` word span. -/
 theorem wordSpan_mul_le (A : MPSTensor d D) (m n : ℕ) :
     wordSpan A m * wordSpan A n ≤ wordSpan A (m + n) := by
-  classical
-  -- Reduce to generators using `span_mul_span`.
-  --
-  -- `wordSpan A k = span (range (σ ↦ evalWord A (List.ofFn σ)))`.
-  -- Therefore the product is the span of products of generators.
-  simp only [wordSpan, Submodule.span_mul_span]
-  -- Now show each generator product is a length-`m+n` word product.
-  apply Submodule.span_le.mpr
-  intro x hx
-  rcases (Set.mem_mul.mp hx) with ⟨x₁, hx₁, x₂, hx₂, rfl⟩
-  rcases hx₁ with ⟨σ₁, rfl⟩
-  rcases hx₂ with ⟨σ₂, rfl⟩
-  -- The product is the evaluation of the concatenated word.
-  have hmem :
-      evalWord A (List.ofFn σ₁ ++ List.ofFn σ₂) ∈ wordSpan A (m + n) := by
-    -- `evalWord_mem_wordSpan` gives membership at the exact length.
-    simpa [List.length_append] using
-      (evalWord_mem_wordSpan A (List.ofFn σ₁ ++ List.ofFn σ₂))
-  -- Rewrite the product using `evalWord_append`.
-  simpa [wordSpan, evalWord_append] using hmem
+  exact le_of_eq (Kraus.wordSpan_add A m n).symm
 
 /-- If `wordSpan A N = ⊤`, then `wordSpan A (k * N) = ⊤` for any `k ≥ 1`. -/
 theorem wordSpan_top_of_mul (A : MPSTensor d D) {N : ℕ}


### PR DESCRIPTION
Closes #6640.

The Kraus word-span and cumulative-span moves left several downstream proofs relying on the former tensor-side definitions unfolding in one step. The authoritative main build failed in EigenvectorSpreading and ParentHamiltonian.Nonvanishing; a complete audit also found four latent instances in the same dependency cone.

This change unfolds the Kraus-owned definitions explicitly at generator-level arguments. It replaces the duplicated proof that products of exact word spans lie in the summed-length span by the exact Kraus.wordSpan_add factorization, removing twenty lines. The length-one span proof similarly reuses Kraus.wordSpan_one. No theorem statement or hypothesis changes.

Verification:
- targeted build of all six repaired modules on the current main branch
- their spectral and Wielandt dependency cone builds successfully (8854 jobs)
- import-direction guard: no violations
- generated import aggregators: current
- proof-integrity search: no exceptions
- full repository CI required before merge.