### PR TITLE
refactor(kraus): single-source block injectivity word span

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -65,7 +65,7 @@ theorem span_range_evalWord_mul_nonzero_mul_evalWord_eq_top {A : MPSTensor d D}
         simpa [LinearMap.mulLeft_apply, Matrix.smul_mul] using
           congrArg (fun M => a • M) (Matrix.mul_assoc R X T) }
   have hspanE : Submodule.span ℂ E = ⊤ := by
-    simpa [E, IsNBlkInjective] using hA
+    simpa [E, IsNBlkInjective, Kraus.wordSpan] using hA
   have htop_map :
       Submodule.map₂ sandwich
           (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -65,7 +65,7 @@ theorem span_range_evalWord_mul_nonzero_mul_evalWord_eq_top {A : MPSTensor d D}
         simpa [LinearMap.mulLeft_apply, Matrix.smul_mul] using
           congrArg (fun M => a • M) (Matrix.mul_assoc R X T) }
   have hspanE : Submodule.span ℂ E = ⊤ := by
-    simpa [E, IsNBlkInjective, Kraus.wordSpan] using hA
+    simpa [E] using hA.span_eq_top
   have htop_map :
       Submodule.map₂ sandwich
           (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -84,6 +84,12 @@ We index the blocked tensors by `σ : Fin N → Fin d`, i.e. words of length `N`
 def IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop :=
   Kraus.wordSpan A N = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
+/-- The literal-span form of block injectivity, for proofs that act on the generators. -/
+theorem IsNBlkInjective.span_eq_top {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) :
+    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by
+  simpa only [IsNBlkInjective, Kraus.wordSpan] using hA
+
 /-- Normality means eventual block injectivity at a positive length:
 there exists `N ≥ 1` such that the tensor is `N`-block-injective.
 

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -82,8 +82,7 @@ theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
 
 We index the blocked tensors by `σ : Fin N → Fin d`, i.e. words of length `N`. -/
 def IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop :=
-  Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ))
-    = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
+  Kraus.wordSpan A N = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
 /-- Normality means eventual block injectivity at a positive length:
 there exists `N ≥ 1` such that the tensor is `N`-block-injective.
@@ -115,7 +114,7 @@ theorem isNBlkInjective_one_of_isInjective {A : MPSTensor d D}
       refine ⟨fun _ => i, ?_⟩
       simpa only [List.ofFn_succ, List.ofFn_zero,
         evalWord_cons, evalWord_nil, mul_one] using hi
-  rw [hrange]
+  rw [Kraus.wordSpan, hrange]
   exact h
 
 /-- Algebraic injectivity (1-block) implies normality (eventual block injectivity).

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -344,10 +344,13 @@ theorem isNBlkInjective_of_gaugeEquiv {A B : MPSTensor d D} {N : ℕ}
   obtain ⟨X, hX⟩ := hGauge
   rw [IsNBlkInjective, eq_top_iff]
   intro M _
+  have hA' : Submodule.span ℂ
+      (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by
+    simpa [IsNBlkInjective, Kraus.wordSpan] using hA
   have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
       Submodule.span ℂ
         (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) :=
-    hA ▸ Submodule.mem_top
+    hA' ▸ Submodule.mem_top
   have hConj : ∀ Y ∈ Submodule.span ℂ
       (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)),
       (X : Matrix _ _ ℂ) * Y *

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -346,7 +346,7 @@ theorem isNBlkInjective_of_gaugeEquiv {A B : MPSTensor d D} {N : ℕ}
   intro M _
   have hA' : Submodule.span ℂ
       (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by
-    simpa [IsNBlkInjective, Kraus.wordSpan] using hA
+    exact hA.span_eq_top
   have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
       Submodule.span ℂ
         (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) :=

--- a/TNLean/MPS/Examples/MajumdarGhosh.lean
+++ b/TNLean/MPS/Examples/MajumdarGhosh.lean
@@ -277,7 +277,7 @@ theorem majumdarGhosh_not_isNBlkInjective_of_odd {N : ℕ} (hN : Odd N) :
   intro h
   have hmem : Matrix.single (2 : Fin 3) (2 : Fin 3) (1 : ℂ) ∈
       Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
-        evalWord majumdarGhoshTensor (List.ofFn σ)) := h ▸ Submodule.mem_top
+        evalWord majumdarGhoshTensor (List.ofFn σ)) := h.span_eq_top ▸ Submodule.mem_top
   suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
       evalWord majumdarGhoshTensor (List.ofFn σ)), M 2 2 = 0 by
     have h1 := hzero _ hmem
@@ -298,7 +298,7 @@ theorem majumdarGhosh_not_isNBlkInjective_of_even {N : ℕ} (hN : Even N) :
   intro h
   have hmem : Matrix.single (1 : Fin 3) (0 : Fin 3) (1 : ℂ) ∈
       Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
-        evalWord majumdarGhoshTensor (List.ofFn σ)) := h ▸ Submodule.mem_top
+        evalWord majumdarGhoshTensor (List.ofFn σ)) := h.span_eq_top ▸ Submodule.mem_top
   suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
       evalWord majumdarGhoshTensor (List.ofFn σ)), M 1 0 = 0 by
     have h1 := hzero _ hmem

--- a/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
@@ -118,7 +118,7 @@ private theorem diagBlock_diagonalRestrictionUnits_not_isNormal :
   have hmem : Matrix.single 0 1 (1 : ℂ) ∈
       Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
         evalWord (diagBlock diagonalRestrictionUnits) (List.ofFn σ)) :=
-    hN ▸ Submodule.mem_top
+    hN.span_eq_top ▸ Submodule.mem_top
   suffices hzero : ∀ M ∈
       Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
         evalWord (diagBlock diagonalRestrictionUnits) (List.ofFn σ)), M 0 1 = 0 by

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -232,7 +232,7 @@ theorem leftTraceWordMap_injective_of_isNBlkInjective {A : MPSTensor d D}
       (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ Z) = 0 := by
     apply LinearMap.ext_on_range
       (v := fun t : Fin L → Fin d => evalWord A (List.ofFn t))
-    · simpa [IsNBlkInjective, Kraus.wordSpan] using hA
+    · exact hA.span_eq_top
     · intro t
       simpa [leftTraceWordMap_apply, Matrix.traceLinearMap_apply] using
         congrArg (fun f => f t) hZ

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -232,7 +232,7 @@ theorem leftTraceWordMap_injective_of_isNBlkInjective {A : MPSTensor d D}
       (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ Z) = 0 := by
     apply LinearMap.ext_on_range
       (v := fun t : Fin L → Fin d => evalWord A (List.ofFn t))
-    · simpa [IsNBlkInjective] using hA
+    · simpa [IsNBlkInjective, Kraus.wordSpan] using hA
     · intro t
       simpa [leftTraceWordMap_apply, Matrix.traceLinearMap_apply] using
         congrArg (fun f => f t) hZ

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -234,7 +234,9 @@ theorem wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
   intro X _
   have hX : X k₀ ∈ Submodule.span ℂ
       (Set.range fun w : Fin L → Fin d ↦ evalWord (A k₀) (List.ofFn w)) := by
-    rw [hInj k₀]
+    rw [show Submodule.span ℂ
+      (Set.range fun w : Fin L → Fin d ↦ evalWord (A k₀) (List.ofFn w)) = ⊤ by
+        simpa [IsNBlkInjective, Kraus.wordSpan] using hInj k₀]
     exact Submodule.mem_top
   obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hX
   refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
@@ -559,7 +561,9 @@ theorem wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
         M k ∈ Submodule.span ℂ
           (Set.range fun u : Fin L → Fin d => evalWord (A k) (List.ofFn u)) := by
     intro k
-    rw [hInj k]
+    rw [show Submodule.span ℂ
+      (Set.range fun u : Fin L → Fin d => evalWord (A k) (List.ofFn u)) = ⊤ by
+        simpa [IsNBlkInjective, Kraus.wordSpan] using hInj k]
     exact Submodule.mem_top
   choose prefixCoeffs hprefix using
     fun k =>

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -236,7 +236,7 @@ theorem wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
       (Set.range fun w : Fin L → Fin d ↦ evalWord (A k₀) (List.ofFn w)) := by
     rw [show Submodule.span ℂ
       (Set.range fun w : Fin L → Fin d ↦ evalWord (A k₀) (List.ofFn w)) = ⊤ by
-        simpa [IsNBlkInjective, Kraus.wordSpan] using hInj k₀]
+        exact (hInj k₀).span_eq_top]
     exact Submodule.mem_top
   obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hX
   refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
@@ -563,7 +563,7 @@ theorem wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
     intro k
     rw [show Submodule.span ℂ
       (Set.range fun u : Fin L → Fin d => evalWord (A k) (List.ofFn u)) = ⊤ by
-        simpa [IsNBlkInjective, Kraus.wordSpan] using hInj k]
+        exact (hInj k).span_eq_top]
     exact Submodule.mem_top
   choose prefixCoeffs hprefix using
     fun k =>

--- a/TNLean/MPS/MPDO/FirstSiteBlocking.lean
+++ b/TNLean/MPS/MPDO/FirstSiteBlocking.lean
@@ -203,7 +203,7 @@ theorem insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq
       simp [hM]
   have hspan : Submodule.span ℂ
       (Set.range fun w : Fin L → Fin d => evalWord A (List.ofFn w)) = ⊤ := by
-    simpa [IsNBlkInjective, Kraus.wordSpan] using hInj
+    exact hInj.span_eq_top
   have hOne : Δ * (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
     hzero_span 1 (hspan.symm ▸ Submodule.mem_top)
   simpa using hOne

--- a/TNLean/MPS/MPDO/FirstSiteBlocking.lean
+++ b/TNLean/MPS/MPDO/FirstSiteBlocking.lean
@@ -201,8 +201,11 @@ theorem insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq
       simp [Matrix.mul_add, hM, hN]
     · intro c M _ hM
       simp [hM]
+  have hspan : Submodule.span ℂ
+      (Set.range fun w : Fin L → Fin d => evalWord A (List.ofFn w)) = ⊤ := by
+    simpa [IsNBlkInjective, Kraus.wordSpan] using hInj
   have hOne : Δ * (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
-    hzero_span 1 (hInj.symm ▸ Submodule.mem_top)
+    hzero_span 1 (hspan.symm ▸ Submodule.mem_top)
   simpa using hOne
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -96,7 +96,7 @@ private theorem neZero_d_of_isNBlkInjective [NeZero D]
       exact (σ ⟨0, hL₀⟩).elim0
     · intro hM
       cases hM
-  rw [IsNBlkInjective, hempty, Submodule.span_empty] at hInj
+  rw [IsNBlkInjective, Kraus.wordSpan, hempty, Submodule.span_empty] at hInj
   exact bot_ne_top hInj
 
 /-- Open-chain intersection property for block-injective tensors.

--- a/TNLean/MPS/Periodic/Overlap/SectorMatch/Basic.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorMatch/Basic.lean
@@ -60,7 +60,7 @@ private lemma isNBlkInjective_smul_of_ne
     {e n N : ℕ} (C : MPSTensor e n) (z : ℂ) (hz : z ≠ 0)
     (hC : IsNBlkInjective C N) :
     IsNBlkInjective (fun i => z • C i) N := by
-  rw [IsNBlkInjective, eq_top_iff] at hC ⊢
+  rw [IsNBlkInjective, Kraus.wordSpan, eq_top_iff] at hC ⊢
   intro X hXtop
   clear hXtop
   have hX : X ∈ Submodule.span ℂ

--- a/TNLean/PEPS/CycleMPSInjectivity.lean
+++ b/TNLean/PEPS/CycleMPSInjectivity.lean
@@ -388,7 +388,7 @@ theorem matrix_eq_zero_of_isNBlkInjective {L : ℕ} {A : MPSTensor d D}
         MPSTensor.evalWord A (List.ofFn x)) := by
       rw [show Submodule.span ℂ (Set.range fun x : Fin L → Fin d =>
         MPSTensor.evalWord A (List.ofFn x)) = ⊤ by
-          simpa [MPSTensor.IsNBlkInjective, Kraus.wordSpan] using hA]
+          exact hA.span_eq_top]
       exact Submodule.mem_top
     have hle : Submodule.span ℂ (Set.range fun x : Fin L → Fin d =>
         MPSTensor.evalWord A (List.ofFn x)) ≤

--- a/TNLean/PEPS/CycleMPSInjectivity.lean
+++ b/TNLean/PEPS/CycleMPSInjectivity.lean
@@ -386,7 +386,10 @@ theorem matrix_eq_zero_of_isNBlkInjective {L : ℕ} {A : MPSTensor d D}
     intro M
     have hM : M ∈ Submodule.span ℂ (Set.range fun x : Fin L → Fin d =>
         MPSTensor.evalWord A (List.ofFn x)) := by
-      rw [hA]; exact Submodule.mem_top
+      rw [show Submodule.span ℂ (Set.range fun x : Fin L → Fin d =>
+        MPSTensor.evalWord A (List.ofFn x)) = ⊤ by
+          simpa [MPSTensor.IsNBlkInjective, Kraus.wordSpan] using hA]
+      exact Submodule.mem_top
     have hle : Submodule.span ℂ (Set.range fun x : Fin L → Fin d =>
         MPSTensor.evalWord A (List.ofFn x)) ≤
         LinearMap.ker ((Matrix.traceLinearMap (Fin D) ℂ ℂ).comp

--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -88,7 +88,7 @@ theorem IsNBlkInjective_transposeTensor
     IsNBlkInjective (d := d) (D := D) (transposeTensor A) N := by
   classical
   -- Unfold the definition: both sides are spans of ranges.
-  unfold IsNBlkInjective at h ⊢
+  unfold IsNBlkInjective Kraus.wordSpan at h ⊢
   -- First, identify the generating set for `transposeTensor A` as the transpose of the
   -- generating set for `A` (up to reindexing by `Fin.rev`).
   have hrange :

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -517,6 +517,15 @@ abstracted — record why, so it is not re-proposed).
   caller now uses one `obtain`; the refactor has a net Lean-source delta of
   6 lines (22 added, 16 removed).
 
+### Literal-span form of block injectivity
+- **Pattern:** recover the span of fixed-length word generators as `⊤` from an
+  `IsNBlkInjective` hypothesis after the predicate was single-sourced through
+  `Kraus.wordSpan`.
+- **Reuse:** `MPSTensor.IsNBlkInjective.span_eq_top` in
+  `TNLean/Kraus/Injectivity.lean` supplies the literal span equality.
+- **Call sites:** the odd- and even-length Majumdar-Ghosh obstructions and the
+  diagonal-restriction non-normality counterexample.
+
 ### Euclidean linear-map multiplicativity
 - **Pattern:** prove that `Matrix.toEuclideanLin (A * B)` is the composition of the
   Euclidean linear maps represented by `A` and `B` by expanding both sides through


### PR DESCRIPTION
## What changed

- restate `MPSTensor.IsNBlkInjective A N` directly as `Kraus.wordSpan A N = ⊤`
- add `MPSTensor.IsNBlkInjective.span_eq_top` for proofs that need the literal generator span
- update every consumer whose proof explicitly needs that literal span to use the common bridge
- repair the odd- and even-length Majumdar-Ghosh obstructions and the diagonal-restriction counterexample found by the hosted build
- keep the established public names while removing the second exact word-span construction

Together with #6637 and #6644, this leaves `Kraus.wordSpan` as the exact word-span owner while preserving the tensor/Wielandt compatibility surface.

## Validation

- targeted builds of `Kraus.Injectivity`, both Majumdar-Ghosh failure paths, and `BiCFDerivation.DiagonalRestrictionCounterexample`
- targeted build of all changed MPS, MPDO, periodic, parent-Hamiltonian, PEPS, and Wielandt callers
- post-rebase build through the literal-span consumers, rank-one construction, and parent-Hamiltonian unique-ground-state endpoint: 3,221 jobs passed
- generated import aggregators current
- import-direction guard: 0 violations and 0 namespace-ratchet violations across 437 QIC-bound files
- Lean module-policy checks: 0 new numbered-file violations and 0 oversized files
- changed-proof integrity search and `git diff --check` clean
- full exact-head GitHub CI required before merge

Closes #6631.
Advances #6560.
