### PR TITLE
refactor(mps): split primitive fixed-point predicates

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.Overlap.CastDecay
 import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.SharedInfra.SectorDecomposition
-import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Spectral.TransferOperatorGapNT
 
 /-!

--- a/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Spectral.PeripheralToTransferMapGap
 
 /-!

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.OperatorNormFrobenius
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
-import TNLean.MPS.Structure.PrimitivityBridge
+import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Spectral.TransferOperatorGapCommon
 
 /-!

--- a/TNLean/MPS/Structure.lean
+++ b/TNLean/MPS/Structure.lean
@@ -12,4 +12,5 @@ import TNLean.MPS.Structure.BlockPermutation
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.Structure.InvariantSubspaceDecomp.Basic
 import TNLean.MPS.Structure.LinearExtension
+import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.MPS.Structure.PrimitivityBridge

--- a/TNLean/MPS/Structure/PrimitiveFixedPoint.lean
+++ b/TNLean/MPS/Structure/PrimitiveFixedPoint.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Primitive
+import TNLean.MPS.Core.Transfer
+
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.Normed.Operator.CompleteCodomain
+
+/-!
+# Complementary transfer-map gap predicates
+
+This module defines the complementary transfer-map gap formulation of primitivity for
+matrix product state tensors.
+
+## Main definitions
+
+* `IsPrimitiveMPS`: an MPS tensor is primitive if the complement of its
+  transfer-map fixed-point projection has spectral radius strictly less than 1.
+* `HasPrimitiveFixedPoint`: the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
+-/
+
+open scoped Matrix Matrix.Norms.Operator ComplexOrder BigOperators
+open Matrix
+
+namespace MPSTensor
+
+/-- An MPS tensor is **primitive** (with witness `ρ`) if the complement of its
+transfer-map fixed-point projection has spectral radius strictly less than `1`.
+
+The fixed point `ρ` is a parameter rather than an existentially quantified field, so that
+subsequent lemmas can directly access it without choice. For the existential formulation,
+see `HasPrimitiveFixedPoint`.
+
+This is the operational definition used in the proof chain. The connection to the standard
+peripheral-spectrum predicate `_root_.IsPrimitive`, the transfer-map formulation
+`MPSTensor.IsPeripherallyPrimitive`, and the spreading predicate
+`MPSTensor.IsPrimitivePaper` is deferred to later connection results. -/
+structure IsPrimitiveMPS {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) : Prop where
+  /-- Left-canonical (trace-preserving) normalization:
+  `∑ᵢ Aᵢ† Aᵢ = I`. -/
+  norm : ∑ i : Fin d, (A i)ᴴ * A i = 1
+  /-- The fixed point is nonzero. -/
+  fixedPoint_ne_zero : ρ ≠ 0
+  /-- The fixed point is positive semidefinite. -/
+  fixedPoint_psd : ρ.PosSemidef
+  /-- The transfer map fixes this point: `E(ρ) = ρ`. -/
+  fixedPoint_is_fixed : transferMap (d := d) (D := D) A ρ = ρ
+  /-- Complementary transfer-map gap: the complement of the fixed-point projection has
+  spectral radius `< 1`. -/
+  complementary_transfer_map_gap :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          ((transferMap (d := d) (D := D) A) -
+            fixedPointProj (D := D) ρ
+              (by
+                intro h
+                exact
+                  fixedPoint_ne_zero
+                    ((Matrix.PosSemidef.trace_eq_zero_iff fixedPoint_psd).1 h)))) <
+        1
+
+/-- An MPS tensor **has a primitive fixed point** if there exists a PSD fixed point `ρ`
+with `IsPrimitiveMPS A ρ`.
+
+Equivalently, this is the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
+It is the MPS-specific complementary transfer-map gap formulation, distinct from
+the generic peripheral-spectrum predicate `_root_.IsPrimitive`, the transfer-map
+formulation `MPSTensor.IsPeripherallyPrimitive`, and the spreading predicate
+`MPSTensor.IsPrimitivePaper`. -/
+def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
+  ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ
+
+end MPSTensor

--- a/TNLean/MPS/Structure/PrimitivityBridge.lean
+++ b/TNLean/MPS/Structure/PrimitivityBridge.lean
@@ -3,103 +3,23 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Spectral.PrimitiveOverlap
 
 /-!
-# Complementary transfer-map gap primitivity and MPV overlap convergence
-
-This module connects the **complementary transfer-map gap** formulation of
-primitivity to the overlap and canonical-form hypotheses used elsewhere in the
-library.
-
-## Main definitions
-
-* `IsPrimitiveMPS`: an MPS tensor is primitive if the complement of its
-  transfer-map fixed-point projection has spectral radius strictly less than 1.
-* `HasPrimitiveFixedPoint`: the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
-  This is the MPS-specific complementary transfer-map gap predicate used in later
-  arguments.
+# MPV overlap convergence from complementary transfer-map gap primitivity
 
 ## Main results
 
 * `IsPrimitiveMPS.overlap_tendsto_one`: a primitive MPS tensor has self-overlap converging
-  to 1. This directly applies `mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`.
-* `HasPrimitiveFixedPoint.overlap_tendsto_one`: existential formulation for the same conclusion.
-
-## Design notes
-
-This file supplies one corner of the codebase's primitivity vocabulary:
-
-* `_root_.IsPrimitive` in `TNLean/Channel/Peripheral/Spectrum.lean` is the canonical
-  peripheral-spectrum predicate for an arbitrary linear map.
-* `MPSTensor.IsPeripherallyPrimitive` in
-  `TNLean/Wielandt/Primitivity/Definitions.lean` is the transfer-map formulation around
-  `_root_.IsPrimitive`.
-* `MPSTensor.IsPrimitivePaper` in
-  `TNLean/Wielandt/Primitivity/Definitions.lean` is the uniform
-  spreading definition.
-* `HasPrimitiveFixedPoint` here is the existential complementary transfer-map
-  gap formulation used by the MPS proof chain.
-
-The connection between `IsPrimitiveMPS` / `HasPrimitiveFixedPoint` and the standard algebraic
-notions is deferred to peripheral spectrum theory.
+  to 1.
+* `HasPrimitiveFixedPoint.overlap_tendsto_one`: existential formulation for the same
+  conclusion.
 -/
 
-open scoped Matrix ComplexOrder BigOperators
 open Matrix Filter
 
 namespace MPSTensor
-
-/-! ## Part 1: IsPrimitiveMPS -/
-
-/-- An MPS tensor is **primitive** (with witness `ρ`) if the complement of its
-transfer-map fixed-point projection has spectral radius strictly less than `1`.
-
-The fixed point `ρ` is a parameter rather than an existentially quantified field, so that
-subsequent lemmas can directly access it without choice. For the existential formulation,
-see `HasPrimitiveFixedPoint`.
-
-This is the operational definition used in the proof chain. The connection to the standard
-peripheral-spectrum predicate `_root_.IsPrimitive`, the transfer-map formulation
-`MPSTensor.IsPeripherallyPrimitive`, and the spreading predicate
-`MPSTensor.IsPrimitivePaper` is deferred to later connection results. -/
-structure IsPrimitiveMPS {d D : ℕ} [NeZero D]
-    (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) : Prop where
-  /-- Left-canonical (trace-preserving) normalization:
-  `∑ᵢ Aᵢ† Aᵢ = I`. -/
-  norm : ∑ i : Fin d, (A i)ᴴ * A i = 1
-  /-- The fixed point is nonzero. -/
-  fixedPoint_ne_zero : ρ ≠ 0
-  /-- The fixed point is positive semidefinite. -/
-  fixedPoint_psd : ρ.PosSemidef
-  /-- The transfer map fixes this point: `E(ρ) = ρ`. -/
-  fixedPoint_is_fixed : transferMap (d := d) (D := D) A ρ = ρ
-  /-- Complementary transfer-map gap: the complement of the fixed-point projection has
-  spectral radius `< 1`. -/
-  complementary_transfer_map_gap :
-      spectralRadius ℂ
-        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
-          ((transferMap (d := d) (D := D) A) -
-            fixedPointProj (D := D) ρ
-              (by
-                intro h
-                exact
-                  fixedPoint_ne_zero
-                    ((Matrix.PosSemidef.trace_eq_zero_iff fixedPoint_psd).1 h)))) <
-        1
-
-/-- An MPS tensor **has a primitive fixed point** if there exists a PSD fixed point `ρ`
-with `IsPrimitiveMPS A ρ`.
-
-Equivalently, this is the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
-It is the MPS-specific complementary transfer-map gap formulation, distinct from
-the generic peripheral-spectrum predicate `_root_.IsPrimitive`, the transfer-map
-formulation `MPSTensor.IsPeripherallyPrimitive`, and the spreading predicate
-`MPSTensor.IsPrimitivePaper`. -/
-def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
-  ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ
-
-/-! ## Part 2: Derive overlap → 1 from primitivity -/
 
 /-- A primitive MPS tensor has self-overlap converging to 1.
 

--- a/TNLean/Spectral/PeripheralToTransferMapGap.lean
+++ b/TNLean/Spectral/PeripheralToTransferMapGap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Structure.PrimitivityBridge
+import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Spectral.TransferOperatorGap
 import TNLean.QPF.Assembly

--- a/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
@@ -27,7 +27,7 @@ complementary aperiodicity input is recovered from strong irreducibility
 - Cirac, Pérez-García, Schuch, Verstraete, arXiv:1606.00608, Section 2.3
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix Matrix.Norms.L2Operator ComplexOrder BigOperators
 open Matrix Filter MPSTensor
 
 namespace MPSTensor

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Structure.PrimitivityBridge
+import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Spectral.MixedTransfer
 
 /-!

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Kraus.MapIterate
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Structure.PrimitiveFixedPoint
-import TNLean.Spectral.MixedTransfer
 
 /-!
 # Primitivity consequences for MPS transfer maps
@@ -56,13 +57,14 @@ theorem transferMap_pow_fixed {A : MPSTensor d D}
     rw [pow_succ, Module.End.mul_apply, hfix, ih]
 
 /-- The iterated transfer map expands as a sum over word products.
-Re-states `transferMap_pow_apply'` in a form convenient for our arguments. -/
+Re-states `Kraus.mapLM_pow_apply` in transfer-map notation. -/
 theorem transferMap_pow_apply_eq_sum (A : MPSTensor d D) (n : ℕ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     ((transferMap (d := d) (D := D) A) ^ n) X =
       ∑ σ : Fin n → Fin d,
-        evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn σ))ᴴ :=
-  transferMap_pow_apply' A n X
+        evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn σ))ᴴ := by
+  rw [← Kraus.mapLM_eq_transferMap]
+  exact Kraus.mapLM_pow_apply A n X
 
 /-! ## Part 2: Nonzero word products from primitivity -/
 

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -62,7 +62,7 @@ The proof chains:
    → `HasPrimitiveFixedPoint A`
    via `hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible`
 3. every nonzero PSD fixed point of an irreducible transfer map is PosDef, via
-   `posSemidef_fixedPoint_isPosDef_of_irreducible`
+   `posDef_of_isIrreducibleMap_of_isPrimitiveMPS`
 -/
 theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
     (A : MPSTensor d D)
@@ -75,8 +75,7 @@ theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
   obtain ⟨ρ', hPrimMPS⟩ :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrrT hNorm hPrim
   have hρ'PD : ρ'.PosDef :=
-    posSemidef_fixedPoint_isPosDef_of_irreducible A hIrrMap ρ'
-      hPrimMPS.fixedPoint_psd hPrimMPS.fixedPoint_ne_zero hPrimMPS.fixedPoint_is_fixed
+    posDef_of_isIrreducibleMap_of_isPrimitiveMPS hPrimMPS hIrrMap
   exact ⟨ρ', hPrimMPS, hρ'PD⟩
 
 /-- A primitive MPS tensor in the complementary-gap sense is peripherally primitive in

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -3,11 +3,13 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.SpectralRadiusPowerDecay
+import TNLean.Channel.Irreducible.FixedPoint
 import TNLean.Channel.Primitive
 import TNLean.Kraus.InvariantProjection
 import TNLean.MPS.Core.TransferChannel
-import TNLean.MPS.Structure.PrimitivityBridge
-import TNLean.QPF.PosDef
+import TNLean.MPS.Structure.PrimitiveFixedPoint
+import Mathlib.Analysis.Normed.Operator.CompleteCodomain
 
 /-!
 # Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` route
@@ -55,7 +57,7 @@ not as the final primitive-to-normal theorem.
   arXiv:1606.00608](https://arxiv.org/abs/1606.00608), Appendix A
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix ComplexOrder BigOperators Matrix.Norms.L2Operator
 open Matrix Filter MPSTensor
 
 namespace MPSTensor
@@ -163,15 +165,19 @@ theorem IsPrimitiveMPS.transferMap_trace_preserving
 If `ρ` is the PSD fixed point in `IsPrimitiveMPS A ρ` and the transfer
 map is irreducible, then `ρ` is positive definite.
 
-This is the Perron–Frobenius `PosDef` result from `TNLean.QPF.PosDef`
-specialized to the fixed point already present in `IsPrimitiveMPS`. -/
+This is the channel-level Perron–Frobenius `PosDef` result specialized to the
+fixed point already present in `IsPrimitiveMPS`. -/
 theorem posDef_of_isIrreducibleMap_of_isPrimitiveMPS
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ)
     (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A)) :
     ρ.PosDef :=
-  posSemidef_fixedPoint_isPosDef_of_irreducible A hIrr ρ
-    hP.fixedPoint_psd hP.fixedPoint_ne_zero hP.fixedPoint_is_fixed
+  posDef_of_posSemidef_fixedPoint_irreducible_cp
+    (Kraus.mapLM A) (Kraus.isCPMap_mapLM A)
+    (Kraus.isIrreducibleMap_mapLM_of_transferMap A hIrr) ρ
+    hP.fixedPoint_psd hP.fixedPoint_ne_zero
+    (by
+      simpa only [Kraus.mapLM_eq_transferMap] using hP.fixedPoint_is_fixed)
 
 omit [NeZero D] in
 /-- Irreducibility of a tensor gives irreducibility of its transfer map. -/
@@ -182,8 +188,8 @@ theorem isIrreducibleMap_of_isIrreducibleTensor
 
 /-- **IsIrreducibleTensor ⟹ PosDef** for primitive tensors.
 
-Combines the implication `IsIrreducibleTensor → IsIrreducibleMap` with
-`posSemidef_fixedPoint_isPosDef_of_irreducible`. -/
+Combines the implication `IsIrreducibleTensor → IsIrreducibleMap` with the
+channel-level positive-definite fixed-point theorem. -/
 theorem posDef_of_isIrreducibleTensor_of_isPrimitiveMPS
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ)


### PR DESCRIPTION
## What changed

- move `IsPrimitiveMPS` and `HasPrimitiveFixedPoint` unchanged into the predicate-only module `MPS/Structure/PrimitiveFixedPoint`
- leave the two state-level overlap corollaries in `PrimitivityBridge`
- repoint predicate-only and state-level consumers to their direct owners
- remove `ToNormal`'s `QPF.PosDef` dependency
- prove the existing positive-definiteness theorem through `Kraus.mapLM` and the channel irreducible fixed-point theorem
- derive the transfer-map iterate formula directly from `Kraus.mapLM_pow_apply`
- open the scoped matrix operator norm exactly where continuous-linear-map convergence is used

## Validation

- replayed the child-only change from #6639 onto current `main` at `9af564a01`
- `lake build TNLean.Wielandt.Primitivity.ImpliesIrreducible TNLean.Wielandt.Primitivity.PrimitiveBridge`: 8,803 jobs completed successfully
- generated-aggregator and import-direction checks
- changed reader-facing prose check
- proof-integrity token scan
- `git diff --check`

Closes #6616.
Advances #6560.
