### PR TITLE
refactor(analysis): expose pointwise spectral power bound

### DIFF
--- a/TNLean/Analysis/SpectralRadiusPowerDecay.lean
+++ b/TNLean/Analysis/SpectralRadiusPowerDecay.lean
@@ -21,6 +21,7 @@ strictly below one converge to zero.  This follows from Gelfand's formula
 
 - `pow_tendsto_zero_of_spectralRadius_lt_one`
 - `geometric_bound_of_spectralRadius_lt_one`
+- `geometric_apply_bound_of_spectralRadius_lt_one`
 - `uniform_eigenvalue_gap_of_finite_lt_one`
 - `uniform_eigenvalue_gap_of_finiteDimensional_lt_one`
 -/
@@ -103,6 +104,18 @@ theorem geometric_bound_of_spectralRadius_lt_one
       ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
       _ ≤ C * (r : ℝ) ^ n := by
         gcongr
+
+/-- If `spectralRadius(T) < 1`, then the powers of `T` satisfy the pointwise bound
+`‖T ^ n x‖ ≤ C · r ^ n · ‖x‖` for some `C > 0` and `0 < r < 1`. -/
+theorem geometric_apply_bound_of_spectralRadius_lt_one
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
+    (T : V →L[ℂ] V)
+    (hT : spectralRadius ℂ T < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
+      ∀ n : ℕ, ∀ x : V, ‖(T ^ n) x‖ ≤ C * r ^ n * ‖x‖ := by
+  rcases geometric_bound_of_spectralRadius_lt_one T hT with
+    ⟨C, r, hC, hr_pos, hr_lt_one, hpow⟩
+  exact ⟨C, r, hC, hr_pos, hr_lt_one, fun n x => (T ^ n).le_of_opNorm_le (hpow n) x⟩
 
 /-! ## Uniform eigenvalue gaps -/
 

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -126,25 +126,6 @@ private theorem spectralRadius_compl_lt_one_of_primitive_fixedPoint [NeZero D]
     exact (NNReal.coe_lt_one).1 this
   exact ⟨htrρ, by simpa [E] using hgap⟩
 
-/-- Pointwise version of `geometric_bound_of_spectralRadius_lt_one`:
-if `spectralRadius(T) < 1`, then `‖T ^ n x‖ ≤ C · r ^ n · ‖x‖`. -/
-private theorem geometric_apply_bound_of_spectralRadius_lt_one
-    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
-    (T : V →L[ℂ] V)
-    (hT : spectralRadius ℂ T < 1) :
-    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
-      ∀ n : ℕ, ∀ x : V, ‖(T ^ n) x‖ ≤ C * r ^ n * ‖x‖ := by
-  rcases _root_.geometric_bound_of_spectralRadius_lt_one T hT with
-    ⟨C, r, hC, hr_pos, hr_lt_one, hpow⟩
-  refine ⟨C, r, hC, hr_pos, hr_lt_one, ?_⟩
-  intro n x
-  calc
-    ‖(T ^ n) x‖ ≤ ‖T ^ n‖ * ‖x‖ := by
-      simpa using (ContinuousLinearMap.le_opNorm (T ^ n) x)
-    _ ≤ (C * r ^ n) * ‖x‖ := by
-      exact mul_le_mul_of_nonneg_right (hpow n) (norm_nonneg x)
-    _ = C * r ^ n * ‖x‖ := by ring
-
 /-! ## Auxiliary lemmas -/
 
 /-- The word span at length 1 equals the span of the Kraus operators. -/
@@ -210,7 +191,7 @@ theorem exponential_convergence_of_primitive [NeZero D]
           simp [hρ0]
         exact (ne_of_gt hρ_pd.trace_pos) htr0)
       hρ_fix huniq_fp
-  rcases geometric_apply_bound_of_spectralRadius_lt_one (T := Φ N) hgap with
+  rcases _root_.geometric_apply_bound_of_spectralRadius_lt_one (T := Φ N) hgap with
     ⟨C₀, r, hC₀_pos, hr_pos, hr_lt_one, hgeom⟩
   let P' : V →L[ℂ] V := Φ P
   let C : ℝ := C₀ + (1 + ‖P'‖)
@@ -291,7 +272,7 @@ theorem correlation_length_bound [NeZero D]
     ⟨ρ, _hρ_psd, _hρ_ne, hρ_fix, htrρ, hgap⟩
   let P : V →ₗ[ℂ] V := fixedPointProj (D := D) ρ htrρ
   let N : V →ₗ[ℂ] V := E - P
-  rcases geometric_apply_bound_of_spectralRadius_lt_one (T := Φ N) hgap with
+  rcases _root_.geometric_apply_bound_of_spectralRadius_lt_one (T := Φ N) hgap with
     ⟨C₀, r, hC₀_pos, hr_pos, hr_lt_one, hgeom⟩
   let C : ℝ := C₀ + 1
   let ξ : ℝ := 1 / (-Real.log r)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -516,6 +516,28 @@ orthogonal projector is the canonical representative used here.
     constant $C$ absorbs the finitely many remaining powers.
 \end{proof}
 
+\begin{theorem}[Pointwise geometric power bound below unit spectral radius]
+    \label{thm:geometric_apply_bound_of_spectral_radius_lt_one}
+    \lean{geometric_apply_bound_of_spectralRadius_lt_one}
+    \leanok
+    \uses{thm:geometric_bound_of_spectral_radius_lt_one}
+    Let $V$ be a complex Banach space and let $T\colon V\to V$ be a bounded
+    linear operator.  If $\rho_{\mathrm{spec}}(T)<1$, then there are real
+    constants $C,r$ with $C>0$ and $0<r<1$ such that
+    \begin{align}
+      \lVert T^n x\rVert&\leq C r^n\lVert x\rVert
+      \label{eq:geometric_apply_bound_of_spectral_radius_lt_one}
+    \end{align}
+    for every $n\in\N$ and $x\in V$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:geometric_bound_of_spectral_radius_lt_one}
+    Apply Theorem~\ref{thm:geometric_bound_of_spectral_radius_lt_one} and the
+    defining operator-norm inequality to $T^n x$.
+\end{proof}
+
 \begin{theorem}[Transfer--Gram Choi reshuffling]
     \label{thm:ground_space_gram_choi_reshuffling}
     \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1617, 1659 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L718 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add the public channel-generic theorem `geometric_apply_bound_of_spectralRadius_lt_one` to `TNLean.Analysis.SpectralRadiusPowerDecay`
- derive the pointwise estimate directly from `geometric_bound_of_spectralRadius_lt_one` via `ContinuousLinearMap.le_of_opNorm_le`
- replace both quantitative-gap callers with the shared theorem and remove the private duplicate
- add the requested mathematical blueprint entry for the public theorem
- preserve all caller statements

The new theorem has signature:

```lean
theorem geometric_apply_bound_of_spectralRadius_lt_one
    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
    (T : V →L[ℂ] V)
    (hT : spectralRadius ℂ T < 1) :
    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
      ∀ n : ℕ, ∀ x : V, ‖(T ^ n) x‖ ≤ C * r ^ n * ‖x‖
```

## Stack repair

After LionSR/TNLean#6647 merged, the child-only patch was transplanted onto current `main`. Its stable patch ID matches the former stacked child delta. A separate review-fix commit adds only the requested blueprint entry.

## Validation

- `lake build TNLean.Analysis.SpectralRadiusPowerDecay TNLean.Spectral.QuantitativeGap` (8838/8838)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` (56 generated files, 1465 production modules)
- `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root . --base-ref origin/main` (443 files, 0 import-direction violations, 0 namespace-ratchet violations)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_numbered_lean_files.py --root . --base-ref origin/main` (0 new violations)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (7995/7995 theorem-like entries in sync)
- `python3 scripts/test_check_tenkz_dispositions.py` and `python3 scripts/check_tenkz_dispositions.py` (202 blueprint occurrences and 9 fixtures reconcile)n- `git diff --check origin/main...HEAD`
- private duplicate scan (0 declarations)

Local full-document TeX validation currently reaches the inherited undefined `\Span` in the LionSR/TNLean#6624 word-span entry; LionSR/TNLean#6673 is the focused upstream repair and its blueprint check is green. No unrelated fix is duplicated here.

Advances LionSR/QICLean#341.
Advances LionSR/TNLean#6560.