### PR TITLE
feat(kraus): bound mixed-map spectral radius

### DIFF
--- a/TNLean/Kraus.lean
+++ b/TNLean/Kraus.lean
@@ -13,6 +13,7 @@ import TNLean.Kraus.Injectivity
 import TNLean.Kraus.InvariantProjection
 import TNLean.Kraus.MapIterate
 import TNLean.Kraus.MixedMap
+import TNLean.Kraus.MixedMap.SpectralRadius
 import TNLean.Kraus.MultiBlockWord
 import TNLean.Kraus.Wielandt
 import TNLean.Kraus.Word

--- a/TNLean/Kraus/MixedMap/SpectralRadius.lean
+++ b/TNLean/Kraus/MixedMap/SpectralRadius.lean
@@ -22,6 +22,10 @@ trace-preserving Kraus maps.
 * `Kraus.mixedMapSpectralRadius` — spectral radius of a rectangular mixed map.
 * `Kraus.eigenvalue_norm_le_one_mixedMapLM_of_isTP` — mixed-map eigenvalue bound.
 * `Kraus.mixedMapSpectralRadius_le_one_of_isTP` — mixed-map spectral-radius bound.
+
+## References
+
+* M. M. Wolf, *Quantum Channels & Operations*, Proposition 6.1.
 -/
 
 open scoped Matrix TNOperatorSpace

--- a/TNLean/Kraus/MixedMap/SpectralRadius.lean
+++ b/TNLean/Kraus/MixedMap/SpectralRadius.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Peripheral.SpectralRadius
+import TNLean.Kraus.MixedMap
+
+import Mathlib.Data.Matrix.Block
+import Mathlib.LinearAlgebra.Matrix.Reindex
+
+/-!
+# Spectral radius of mixed finite-family maps
+
+For two trace-preserving finite matrix families, every eigenvalue of their rectangular mixed map
+has norm at most one. The proof embeds the mixed map into the upper-right corner of the Kraus map
+of the block-diagonal family $A_i \oplus B_i$ and applies the spectral bound for
+trace-preserving Kraus maps.
+
+## Main declarations
+
+* `Kraus.mixedMapSpectralRadius` — spectral radius of a rectangular mixed map.
+* `Kraus.eigenvalue_norm_le_one_mixedMapLM_of_isTP` — mixed-map eigenvalue bound.
+* `Kraus.mixedMapSpectralRadius_le_one_of_isTP` — mixed-map spectral-radius bound.
+-/
+
+open scoped Matrix TNOperatorSpace
+
+namespace Kraus
+
+variable {d D₁ D₂ : ℕ}
+
+/-- The spectral radius of the mixed map of two finite matrix families. -/
+noncomputable def mixedMapSpectralRadius
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ) : ENNReal :=
+  spectralRadius ℂ
+    (Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ) (mixedMapLM A B))
+
+private noncomputable def sumFinReindexAlgEquiv :
+    Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ ≃ₐ[ℂ]
+      Matrix (Fin (D₁ + D₂)) (Fin (D₁ + D₂)) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ finSumFinEquiv
+
+private theorem sumFinReindexAlgEquiv_conjTranspose
+    (M : Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ) :
+    (sumFinReindexAlgEquiv M)ᴴ = sumFinReindexAlgEquiv Mᴴ := by
+  simp [sumFinReindexAlgEquiv]
+
+private noncomputable def fromBlocksTopLeftLM :
+    Matrix (Fin D₁) (Fin D₁) ℂ →ₗ[ℂ]
+      Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ where
+  toFun X := Matrix.fromBlocks X 0 0 0
+  map_add' X Y := by ext (i | i) (j | j) <;> simp
+  map_smul' c X := by ext (i | i) (j | j) <;> simp
+
+private noncomputable def fromBlocksBottomRightLM :
+    Matrix (Fin D₂) (Fin D₂) ℂ →ₗ[ℂ]
+      Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ where
+  toFun X := Matrix.fromBlocks 0 0 0 X
+  map_add' X Y := by ext (i | i) (j | j) <;> simp
+  map_smul' c X := by ext (i | i) (j | j) <;> simp
+
+private noncomputable def fromBlocksUpperRightLM :
+    Matrix (Fin D₁) (Fin D₂) ℂ →ₗ[ℂ]
+      Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ where
+  toFun X := Matrix.fromBlocks 0 X 0 0
+  map_add' X Y := by ext (i | i) (j | j) <;> simp
+  map_smul' c X := by ext (i | i) (j | j) <;> simp
+
+private noncomputable def blockDiagonalFamily
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ) :
+    Fin d → Matrix (Fin (D₁ + D₂)) (Fin (D₁ + D₂)) ℂ :=
+  fun i ↦ sumFinReindexAlgEquiv (Matrix.fromBlocks (A i) 0 0 (B i))
+
+private theorem blockDiagonalFamily_isTP
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hA : IsTP A) (hB : IsTP B) :
+    IsTP (blockDiagonalFamily A B) := by
+  classical
+  rw [IsTP]
+  have hTerm (i : Fin d) :
+      (blockDiagonalFamily A B i)ᴴ * blockDiagonalFamily A B i =
+        sumFinReindexAlgEquiv
+          (Matrix.fromBlocks ((A i)ᴴ * A i) 0 0 ((B i)ᴴ * B i)) := by
+    rw [blockDiagonalFamily, sumFinReindexAlgEquiv_conjTranspose,
+      ← map_mul]
+    simp [Matrix.fromBlocks_conjTranspose, Matrix.fromBlocks_multiply]
+  simp_rw [hTerm]
+  rw [← map_sum, ← map_one (sumFinReindexAlgEquiv (D₁ := D₁) (D₂ := D₂))]
+  have hBlocks :
+      (∑ i, Matrix.fromBlocks ((A i)ᴴ * A i) 0 0 ((B i)ᴴ * B i)) = 1 := by
+    calc
+      _ = ∑ i, (fromBlocksTopLeftLM ((A i)ᴴ * A i) +
+          fromBlocksBottomRightLM ((B i)ᴴ * B i)) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        ext (r | r) (c | c) <;>
+          simp [fromBlocksTopLeftLM, fromBlocksBottomRightLM]
+      _ = (∑ i, fromBlocksTopLeftLM ((A i)ᴴ * A i)) +
+          ∑ i, fromBlocksBottomRightLM ((B i)ᴴ * B i) := Finset.sum_add_distrib
+      _ = fromBlocksTopLeftLM (∑ i, (A i)ᴴ * A i) +
+          fromBlocksBottomRightLM (∑ i, (B i)ᴴ * B i) := by rw [map_sum, map_sum]
+      _ = 1 := by
+        rw [show (∑ i, (A i)ᴴ * A i) = 1 from hA,
+          show (∑ i, (B i)ᴴ * B i) = 1 from hB]
+        ext (r | r) (c | c) <;>
+          simp [fromBlocksTopLeftLM, fromBlocksBottomRightLM, Matrix.one_apply]
+  exact congrArg (sumFinReindexAlgEquiv (D₁ := D₁) (D₂ := D₂)) hBlocks
+
+private noncomputable def upperRightBlock
+    (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
+    Matrix (Fin (D₁ + D₂)) (Fin (D₁ + D₂)) ℂ :=
+  sumFinReindexAlgEquiv (fromBlocksUpperRightLM X)
+
+private theorem upperRightBlock_ne_zero
+    {X : Matrix (Fin D₁) (Fin D₂) ℂ} (hX : X ≠ 0) :
+    upperRightBlock X ≠ 0 := by
+  intro h
+  apply hX
+  have hBlock : Matrix.fromBlocks (0 : Matrix (Fin D₁) (Fin D₁) ℂ) X
+      (0 : Matrix (Fin D₂) (Fin D₁) ℂ) (0 : Matrix (Fin D₂) (Fin D₂) ℂ) = 0 := by
+    apply (sumFinReindexAlgEquiv (D₁ := D₁) (D₂ := D₂)).injective
+    simpa [upperRightBlock, fromBlocksUpperRightLM] using h
+  have hBlock₁₂ := congrArg Matrix.toBlocks₁₂ hBlock
+  rw [Matrix.toBlocks_fromBlocks₁₂] at hBlock₁₂
+  exact hBlock₁₂.trans rfl
+
+private theorem mapLM_blockDiagonalFamily_upperRightBlock
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ)
+    (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
+    mapLM (blockDiagonalFamily A B) (upperRightBlock X) =
+      upperRightBlock (mixedMapLM A B X) := by
+  classical
+  rw [mapLM_apply, map_apply]
+  have hTerm (i : Fin d) :
+      blockDiagonalFamily A B i * upperRightBlock X *
+          (blockDiagonalFamily A B i)ᴴ =
+        sumFinReindexAlgEquiv
+          (Matrix.fromBlocks 0 (A i * X * (B i)ᴴ) 0 0) := by
+    rw [blockDiagonalFamily, upperRightBlock, fromBlocksUpperRightLM,
+      sumFinReindexAlgEquiv_conjTranspose, ← map_mul, ← map_mul]
+    simp [Matrix.fromBlocks_conjTranspose, Matrix.fromBlocks_multiply]
+  simp_rw [hTerm]
+  rw [upperRightBlock, ← map_sum]
+  refine congrArg (sumFinReindexAlgEquiv (D₁ := D₁) (D₂ := D₂)) ?_
+  change ∑ i, fromBlocksUpperRightLM (A i * X * (B i)ᴴ) =
+    fromBlocksUpperRightLM (mixedMapLM A B X)
+  rw [mixedMapLM_apply, map_sum]
+
+/-- Every eigenvalue of the mixed map of two trace-preserving finite matrix families has norm at
+most one. -/
+theorem eigenvalue_norm_le_one_mixedMapLM_of_isTP
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hA : IsTP A) (hB : IsTP B)
+    (μ : ℂ) (hμ : Module.End.HasEigenvalue (mixedMapLM A B) μ) :
+    ‖μ‖ ≤ 1 := by
+  obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+  have hLift : Module.End.HasEigenvector
+      (mapLM (blockDiagonalFamily A B)) μ (upperRightBlock X) := by
+    refine ⟨Module.End.mem_eigenspace_iff.mpr ?_, upperRightBlock_ne_zero hX.2⟩
+    rw [mapLM_blockDiagonalFamily_upperRightBlock, hX.apply_eq_smul]
+    change sumFinReindexAlgEquiv (fromBlocksUpperRightLM (μ • X)) =
+      μ • sumFinReindexAlgEquiv (fromBlocksUpperRightLM X)
+    rw [(fromBlocksUpperRightLM (D₁ := D₁) (D₂ := D₂)).map_smul]
+    exact (sumFinReindexAlgEquiv (D₁ := D₁) (D₂ := D₂)).toLinearMap.map_smul μ
+      (fromBlocksUpperRightLM X)
+  exact eigenvalue_norm_le_one_of_isTP (blockDiagonalFamily A B)
+    (blockDiagonalFamily_isTP A B hA hB) μ
+    (Module.End.hasEigenvalue_of_hasEigenvector hLift)
+
+/-- The mixed map of two trace-preserving finite matrix families has spectral radius at most one. -/
+theorem mixedMapSpectralRadius_le_one_of_isTP
+    (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
+    (B : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hA : IsTP A) (hB : IsTP B) :
+    mixedMapSpectralRadius A B ≤ 1 := by
+  exact spectralRadius_le_one_of_forall_eigenvalue_norm_le_one (mixedMapLM A B)
+    (eigenvalue_norm_le_one_mixedMapLM_of_isTP A B hA hB)
+
+end Kraus

--- a/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
+++ b/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
@@ -118,6 +118,79 @@
     bounds each of them by $1$.
 \end{proof}
 
+\begin{definition}[Spectral radius of a rectangular mixed Kraus map]
+    \label{def:kraus_mixed_map_spectral_radius}
+    \lean{Kraus.mixedMapSpectralRadius}
+    \leanok
+    Let $\{A_i\}_{i=0}^{d-1}\subseteq\MN{D_1}$ and
+    $\{B_i\}_{i=0}^{d-1}\subseteq\MN{D_2}$. Their rectangular mixed Kraus
+    map is the endomorphism of $M_{D_1\times D_2}(\C)$ given by
+    \begin{align}
+        \mathcal M_{A,B}(X)
+         & =\sum_{i=0}^{d-1}A_iXB_i^\dagger.
+        \notag
+    \end{align}
+    Its spectral radius is denoted by $\varrho(\mathcal M_{A,B})$.
+\end{definition}
+
+\begin{theorem}[Eigenvalue bound for a trace-preserving mixed Kraus map]
+    \label{thm:kraus_mixed_tp_eigenvalue_bound}
+    \lean{Kraus.eigenvalue_norm_le_one_mixedMapLM_of_isTP}
+    \leanok
+    \uses{def:kraus_mixed_map_spectral_radius, def:tp_kraus}
+    Suppose that
+    \begin{align}
+        \sum_{i=0}^{d-1}A_i^\dagger A_i&=\Id_{D_1},
+        \notag\\
+        \sum_{i=0}^{d-1}B_i^\dagger B_i&=\Id_{D_2}.
+        \notag
+    \end{align}
+    Every eigenvalue $\mu$ of $\mathcal M_{A,B}$ satisfies $|\mu|\leq1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_tp_eigenvalue_bound}
+    For each $i$, set
+    $C_i=\begin{psmallmatrix}A_i&0\\0&B_i\end{psmallmatrix}$ and embed a
+    rectangular matrix $X$ as
+    $J(X)=\begin{psmallmatrix}0&X\\0&0\end{psmallmatrix}$. Then
+    \begin{align}
+        \sum_{i=0}^{d-1}C_i^\dagger C_i
+         &=\begin{pmatrix}\Id_{D_1}&0\\0&\Id_{D_2}\end{pmatrix},
+        \notag\\
+        \mathcal K_C(J(X))
+         &=J\bigl(\mathcal M_{A,B}(X)\bigr).
+        \notag
+    \end{align}
+    Hence a nonzero eigenvector $X$ of $\mathcal M_{A,B}$ with eigenvalue
+    $\mu$ gives the nonzero eigenvector $J(X)$ of the trace-preserving Kraus
+    map $\mathcal K_C$ with the same eigenvalue.
+    Theorem~\ref{thm:kraus_tp_eigenvalue_bound} gives $|\mu|\leq1$.
+\end{proof}
+
+\begin{theorem}[Spectral-radius bound for a trace-preserving mixed Kraus map]
+    \label{thm:kraus_mixed_tp_spectral_radius_bound}
+    \lean{Kraus.mixedMapSpectralRadius_le_one_of_isTP}
+    \leanok
+    \uses{def:kraus_mixed_map_spectral_radius, def:tp_kraus}
+    Suppose that
+    \begin{align}
+        \sum_{i=0}^{d-1}A_i^\dagger A_i&=\Id_{D_1},
+        \notag\\
+        \sum_{i=0}^{d-1}B_i^\dagger B_i&=\Id_{D_2}.
+        \notag
+    \end{align}
+    Then $\varrho(\mathcal M_{A,B})\leq1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_mixed_tp_eigenvalue_bound}
+    On the finite-dimensional space $M_{D_1\times D_2}(\C)$, every spectral
+    value is an eigenvalue. Theorem~\ref{thm:kraus_mixed_tp_eigenvalue_bound}
+    bounds the modulus of each spectral value by $1$, so the spectral radius
+    is at most $1$.
+\end{proof}
+
 \section{Fixed-point projection}
 
 \begin{definition}[Fixed-point projection]\label{def:fixed_point_proj}


### PR DESCRIPTION
## What changed

- define the spectral radius of the QIC-native rectangular `Kraus.mixedMapLM`
- prove every mixed-map eigenvalue has norm at most one for two trace-preserving Kraus families
- derive the mixed-map spectral-radius bound
- prove the eigenvalue bound by embedding the mixed map into the upper-right block of a block-diagonal trace-preserving Kraus map
- add separate blueprint definition and theorem entries for all three new Kraus declarations, without attaching them to the stricter MPS-tensor results

## Validation

- `lake build TNLean.Kraus.MixedMap.SpectralRadius`
- `lake build TNLean.Kraus`
- `python3 scripts/generate_import_aggregators.py --check` (55 generated files, 1463 production modules)
- `python3 scripts/check_import_direction.py --base-ref origin/main` (441 QIC-bound files, 0 violations)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7997/7997 blueprint entries in sync)
- `./scripts/build_blueprint_ch01_12.sh` (250-page focused volume compiled)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- exact-scope, declaration-uniqueness, line-length, `git diff --check`, and `#print axioms` checks

The main-relative diff contains the two Lean files plus `blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex`. It adds no MPS mixed-transfer wrappers and does not modify the ch07 rectangular-spectrum entries.

Advances LionSR/QICLean#341.
Advances LionSR/TNLean#6560.
