### PR TITLE
refactor(qic): move two-sided rank-one range theorem to Algebra

### DIFF
--- a/TNLean/Algebra/MatrixMulRange.lean
+++ b/TNLean/Algebra/MatrixMulRange.lean
@@ -17,7 +17,8 @@ This file collects basic linear-algebra facts about the range of the linear map
 
 Left multiplication acts independently on columns: `(P * X).col j = P *ᵥ (X.col j)`.
 Consequently, the range of left multiplication consists exactly of matrices whose columns lie
-in `LinearMap.range (Matrix.toLin' P)`, and it has dimension `D * Matrix.rank P`.
+in `LinearMap.range (Matrix.toLin' P)`, and it has dimension `D * Matrix.rank P`. The final
+theorem gives the corresponding rank-one fact for two-sided multiplication.
 -/
 
 open scoped Matrix
@@ -142,5 +143,24 @@ theorem finrank_range_mulLeft
           simp [Module.finrank_pi_fintype, Fintype.card_fin]
     _ = D * Matrix.rank P := by
           rw [Matrix.rank, Matrix.toLin'_apply']
+
+/-- A rank-one matrix belongs to the range of two-sided multiplication when its defining
+vectors belong to the corresponding one-sided ranges. -/
+theorem vecMulVec_mem_range_mulLeft_mulRight
+    (P Q : Matrix (Fin D) (Fin D) ℂ)
+    (φ ψ : Fin D → ℂ)
+    (hφ : φ ∈ LinearMap.range (Matrix.toLin' P))
+    (hψ : ψ ∈ LinearMap.range Q.vecMulLinear) :
+    Matrix.vecMulVec φ ψ ∈
+      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) := by
+  rcases (LinearMap.mem_range).1 hφ with ⟨y, hy⟩
+  rcases (LinearMap.mem_range).1 hψ with ⟨z, hz⟩
+  have hy' : P *ᵥ y = φ := by
+    simpa [Matrix.toLin'_apply] using hy
+  have hz' : z ᵥ* Q = ψ := by
+    simpa [Matrix.vecMulLinear_apply] using hz
+  simpa [LinearMap.comp_apply, Matrix.vecMulVec_mul, Matrix.mul_vecMulVec, hy', hz'] using
+    LinearMap.mem_range_self
+      ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) (Matrix.vecMulVec y z)
 
 end Matrix

--- a/TNLean/Wielandt/RankOne/Manufacture.lean
+++ b/TNLean/Wielandt/RankOne/Manufacture.lean
@@ -3,19 +3,12 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Matrix.Mul
-import Mathlib.LinearAlgebra.Matrix.ToLin
+import TNLean.Algebra.MatrixMulRange
 
 /-!
-# Manufacturing a rank-one matrix in the range of two-sided multiplication
+# Rank-one matrices in ranges of two-sided multiplication
 
-This file proves a lemma used in the rank-one step of the Wielandt proof:
-
-If a column vector `φ` lies in the range of left-multiplication by `P` (as a linear map on
-vectors), and a row vector `ψ` lies in the range of right-multiplication by `Q` (again as a
-linear map on vectors), then the rank-one matrix `Matrix.vecMulVec φ ψ` lies in the range of the
-(two-sided) linear map `X ↦ P * X * Q`.
+The theorem below is used in the rank-one step of the Wielandt proof.
 -/
 
 open scoped Matrix
@@ -24,23 +17,15 @@ namespace MPSTensor
 
 variable {D : ℕ}
 
+/-- A rank-one matrix belongs to the range of two-sided multiplication when its defining
+vectors belong to the corresponding one-sided ranges. -/
 theorem vecMulVec_mem_range_mulLeft_mulRight
     (P Q : Matrix (Fin D) (Fin D) ℂ)
     (φ ψ : Fin D → ℂ)
     (hφ : φ ∈ LinearMap.range (Matrix.toLin' P))
     (hψ : ψ ∈ LinearMap.range (Q.vecMulLinear)) :
     Matrix.vecMulVec φ ψ ∈
-      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) := by
-  -- Pick `y` with `P *ᵥ y = φ` and `z` with `z ᵥ* Q = ψ`.
-  rcases (LinearMap.mem_range).1 hφ with ⟨y, hy⟩
-  rcases (LinearMap.mem_range).1 hψ with ⟨z, hz⟩
-  have hy' : P *ᵥ y = φ := by
-    simpa [Matrix.toLin'_apply] using hy
-  have hz' : z ᵥ* Q = ψ := by
-    simpa [Matrix.vecMulLinear_apply] using hz
-  -- Witness `X := Matrix.vecMulVec y z`.
-  simpa [LinearMap.comp_apply, Matrix.vecMulVec_mul, Matrix.mul_vecMulVec, hy', hz'] using
-    LinearMap.mem_range_self
-      ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) (Matrix.vecMulVec y z)
+      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) :=
+  Matrix.vecMulVec_mem_range_mulLeft_mulRight P Q φ ψ hφ hψ
 
 end MPSTensor


### PR DESCRIPTION
## What changed

- move the matrix-generic `vecMulVec_mem_range_mulLeft_mulRight` theorem into `TNLean.Algebra.MatrixMulRange` under `namespace Matrix`
- retain the existing `MPSTensor.vecMulVec_mem_range_mulLeft_mulRight` statement as a thin compatibility theorem
- replace the Wielandt module's direct Mathlib imports with the neutral algebra module

## Dependency

LionSR/TNLean#6645 is merged. This branch is rebased directly onto current `main` at `540204572`.

## Validation

- `lake build TNLean.Algebra.MatrixMulRange TNLean.Wielandt.RankOne.Manufacture TNLean.Wielandt.RankOne.ExtractionFull TNLean.Algebra TNLean.Wielandt.RankOne`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root . --base-ref origin/main`: 439 files, 0 import-direction violations, 0 namespace-ratchet violations
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- diff-added proof-integrity blocker scan: clean
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- focused diff inventory: exactly the neutral theorem target and compatibility module

Advances LionSR/QICLean#340.
Advances LionSR/TNLean#6560.

