### PR TITLE
refactor(wielandt): alias neutral matrix range APIs

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Ranges.lean
+++ b/TNLean/Wielandt/RectangularSpan/Ranges.lean
@@ -32,12 +32,12 @@ theorem mem_range_mulLeft_iff_cols
   Matrix.mem_range_mulLeft_iff_cols P M
 
 /-- Compatibility name for `Matrix.colRangeSubmodule`. -/
-noncomputable def colRangeSubmodule (P : Matrix (Fin D) (Fin D) ℂ) :
+noncomputable abbrev colRangeSubmodule (P : Matrix (Fin D) (Fin D) ℂ) :
     Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Matrix.colRangeSubmodule P
 
 /-- Compatibility name for `Matrix.colRangeSubmoduleEquiv`. -/
-noncomputable def colRangeSubmoduleEquiv (P : Matrix (Fin D) (Fin D) ℂ) :
+noncomputable abbrev colRangeSubmoduleEquiv (P : Matrix (Fin D) (Fin D) ℂ) :
     colRangeSubmodule (D := D) P ≃ₗ[ℂ]
       (Fin D → LinearMap.range (Matrix.toLin' P)) :=
   Matrix.colRangeSubmoduleEquiv P


### PR DESCRIPTION
## What changed

- make the two established `MPSTensor` column-range compatibility names definitional aliases of the canonical `Matrix` constructions
- preserve every theorem statement and downstream name
- remove the remaining duplicate ownership left after LionSR/TNLean#6645

## Validation

- `TNLean.Wielandt.RectangularSpan.Ranges` and the complete `UniversalityAux.Sharp` dependency chain built successfully before rebasing this identical two-line change onto merged `main`: 3,040 jobs
- changed-file proof-integrity and `git diff --check`: clean
- full exact-head GitHub CI required before merge

Advances LionSR/QICLean#340.
Advances LionSR/TNLean#6560.