### PR TITLE
docs(wielandt): remove banned relocation prose

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Ranges.lean
+++ b/TNLean/Wielandt/RectangularSpan/Ranges.lean
@@ -8,8 +8,8 @@ import TNLean.Algebra.MatrixMulRange
 /-!
 # Compatibility names for matrix left-multiplication ranges
 
-This module provides the original `MPSTensor` names for the neutral matrix API in
-`TNLean.Algebra.MatrixMulRange`, preserving existing rectangular-span arguments.
+This module restates matrix left-multiplication range results for MPS tensors,
+preserving existing rectangular-span arguments.
 -/
 
 open scoped Matrix

--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -14,8 +14,8 @@ import TNLean.Algebra.BurnsideTheorem
 # From cumulative span to word span for MPS tensors
 
 This file gives the MPS-facing consequences of the generic Kraus-family span
-results. The transfer-free statements are compatibility wrappers around the
-corresponding declarations in `Kraus`. The MPS-specific results connect exact
+results. The transfer-free statements are MPS restatements of the corresponding
+Kraus-family results. The MPS-specific results connect exact
 word-span fullness to block injectivity and normality.
 
 ## Main results
@@ -42,7 +42,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Compatibility wrappers for transfer-free span results -/
+/-! ## MPS restatements of transfer-free span results -/
 
 /-- If the cumulative span is full, some word of bounded length has nonzero trace. -/
 theorem exists_nonzero_trace_word_of_cumulativeSpan_eq_top [NeZero D]


### PR DESCRIPTION
## What changed

- replace the banned `API` term with a mathematical description of the left-multiplication range results
- describe the MPS declarations as restatements rather than compatibility wrappers
- rebase the exact two-file prose delta onto `d8dc2ce7f` while retaining the abbreviation changes merged in #6659

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- zero diagnostics in both edited files
- `lake build TNLean.Wielandt.RectangularSpan.Ranges TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan` (3130 jobs, warm cache)

Follow-up to #6645 and its prose review.
