### PR TITLE
refactor(kraus): own bounded two-sided word spans

### DIFF
--- a/TNLean/Kraus/Wielandt/RankOne.lean
+++ b/TNLean/Kraus/Wielandt/RankOne.lean
@@ -8,4 +8,5 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Kraus.Wielandt.RankOne
 
+import TNLean.Kraus.Wielandt.RankOne.BoundedWord
 import TNLean.Kraus.Wielandt.RankOne.Products

--- a/TNLean/Kraus/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/BoundedWord.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Kraus.WordSpan
+
+/-!
+# Bounded rank-one element in a word span
+
+This file introduces the two-sided span
+
+`biRectSpan P Q K n = span{ P * M * Q : M ∈ wordSpan K n }`
+
+for a finite family of square matrices. If the exact word span is full, this
+space is the full range of the map $X \mapsto PXQ$. If `P` and `Q` belong to
+bounded word spans, every element of the two-sided span belongs to a bounded
+word span.
+-/
+
+open scoped Matrix
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- The image of `wordSpan K n` under the map $X \mapsto PXQ$. -/
+noncomputable def biRectSpan
+    (P Q : Matrix (Fin D) (Fin D) ℂ)
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  Submodule.map ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q))
+    (wordSpan K n)
+
+/-- If the exact word span is full, the two-sided span is the full range of
+$X \mapsto PXQ$. -/
+theorem biRectSpan_eq_range_of_wordSpan_eq_top
+    (P Q : Matrix (Fin D) (Fin D) ℂ)
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {n : ℕ}
+    (htop : wordSpan K n = ⊤) :
+    biRectSpan P Q K n =
+      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) := by
+  rw [biRectSpan, htop, Submodule.map_top]
+
+private theorem mem_biRectSpan_iff
+    (P Q : Matrix (Fin D) (Fin D) ℂ)
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {n : ℕ}
+    {M : Matrix (Fin D) (Fin D) ℂ} :
+    M ∈ biRectSpan P Q K n ↔
+      ∃ X, X ∈ wordSpan K n ∧ P * X * Q = M := by
+  constructor
+  · intro hM
+    rcases Submodule.mem_map.mp hM with ⟨X, hX, rfl⟩
+    exact ⟨X, hX, by
+      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+        Matrix.mul_assoc]⟩
+  · rintro ⟨X, hX, hM⟩
+    rw [← hM]
+    exact Submodule.mem_map.mpr ⟨X, hX, by
+      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+        Matrix.mul_assoc]⟩
+
+/-- If `P` and `Q` belong to word spans of lengths `m₁` and `m₂`, respectively,
+then the two-sided span generated from words of length `n` lies in the word
+span of length `m₁ + n + m₂`. -/
+theorem biRectSpan_le_wordSpan
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {m₁ m₂ n : ℕ}
+    (P Q : Matrix (Fin D) (Fin D) ℂ)
+    (hP : P ∈ wordSpan K m₁) (hQ : Q ∈ wordSpan K m₂) :
+    biRectSpan P Q K n ≤ wordSpan K (m₁ + n + m₂) := by
+  intro M hM
+  rcases (mem_biRectSpan_iff P Q K).mp hM with ⟨Y, hY, rfl⟩
+  have hPY : P * Y ∈ wordSpan K (m₁ + n) := by
+    rw [wordSpan_add]
+    exact Submodule.mul_mem_mul hP hY
+  rw [wordSpan_add]
+  exact Submodule.mul_mem_mul hPY hQ
+
+end Kraus

--- a/TNLean/Kraus/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/BoundedWord.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.Kraus.WordSpan
 
 /-!
-# Bounded rank-one element in a word span
+# Bounded two-sided word spans
 
 This file introduces the two-sided span
 

--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -3,22 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Kraus.Wielandt.RankOne.BoundedWord
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
-import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 
 /-!
-# Bounded rank-one element in a blocked word span (Wielandt Lemma 2(b))
+# Bounded rank-one element in a blocked word span
 
-This file introduces a two-sided ("bi-rectangular") span
-
-`biRectSpan P Q B n = span{ P * M * Q : M ∈ wordSpan B n }`
-
-and develops the membership and conversion lemmas used by the rank-one
-extraction step in the Quantum Wielandt proof: if the exact word span is
-already full, the bi-rectangular span is the full two-sided range of the
-linear map $X \mapsto P * X * Q$ (`biRectSpan_eq_range_of_wordSpan_eq_top`), and if
-`P` and `Q` themselves lie in bounded word spans, the bi-rectangular span is
-contained in a bounded word span (`biRectSpan_le_wordSpan`).
+This file preserves the established `MPSTensor` interface to the transfer-free
+two-sided word-span results in `Kraus`.
 -/
 
 open scoped Matrix
@@ -27,58 +19,28 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Two-sided (bi-rectangular) span: image of `wordSpan B n` under right-multiplication by `Q`
-followed by left-multiplication by `P`.
-
-This is the linear span of all matrices of the form `P * M * Q` where
-`M` ranges over word products of length `n`. -/
-noncomputable def biRectSpan
+/-- Two-sided word span for an MPS tensor. -/
+noncomputable abbrev biRectSpan
     (P Q : Matrix (Fin D) (Fin D) ℂ) (B : MPSTensor d D) (n : ℕ) :
     Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
-  Submodule.map ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q))
-    (wordSpan B n)
+  Kraus.biRectSpan P Q B n
 
-/-- If the exact word span is already full, the bi-rectangular span is the full two-sided
-range. -/
+/-- If the exact word span is full, the two-sided span is the full range of
+$X \mapsto PXQ$. -/
 theorem biRectSpan_eq_range_of_wordSpan_eq_top
     (P Q : Matrix (Fin D) (Fin D) ℂ) (B : MPSTensor d D) {n : ℕ}
     (htop : wordSpan B n = ⊤) :
     biRectSpan (d := d) (D := D) P Q B n =
-      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) := by
-  rw [biRectSpan, htop, Submodule.map_top]
+      LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) :=
+  Kraus.biRectSpan_eq_range_of_wordSpan_eq_top P Q B htop
 
-private theorem mem_biRectSpan_iff
-    (P Q : Matrix (Fin D) (Fin D) ℂ) (B : MPSTensor d D) {n : ℕ}
-    {M : Matrix (Fin D) (Fin D) ℂ} :
-    M ∈ biRectSpan (d := d) (D := D) P Q B n ↔
-      ∃ X, X ∈ wordSpan B n ∧ P * X * Q = M := by
-  constructor
-  · intro hM
-    rcases Submodule.mem_map.mp hM with ⟨X, hX, rfl⟩
-    exact ⟨X, hX, by
-      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
-        Matrix.mul_assoc]⟩
-  · rintro ⟨X, hX, hM⟩
-    rw [← hM]
-    exact Submodule.mem_map.mpr ⟨X, hX, by
-      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
-        Matrix.mul_assoc]⟩
-
-/-- Converting a bi-rectangular span element back into a bounded word span,
-assuming `P` and `Q` themselves lie in bounded word spans. -/
+/-- If the two outer matrices belong to bounded word spans, the two-sided span
+is contained in the word span at the sum of the three lengths. -/
 theorem biRectSpan_le_wordSpan
     (B : MPSTensor d D) {m₁ m₂ n : ℕ}
     (P Q : Matrix (Fin D) (Fin D) ℂ)
     (hP : P ∈ wordSpan B m₁) (hQ : Q ∈ wordSpan B m₂) :
-    biRectSpan (d := d) (D := D) P Q B n ≤ wordSpan B (m₁ + n + m₂) := by
-  classical
-  intro M hM
-  rcases (mem_biRectSpan_iff (d := d) (D := D) P Q B).mp hM with ⟨Y, hY, hM⟩
-  have hPY : P * Y ∈ wordSpan B (m₁ + n) := by
-    exact (wordSpan_mul_le B m₁ n) (Submodule.mul_mem_mul hP hY)
-  have hPYQ : (P * Y) * Q ∈ wordSpan B ((m₁ + n) + m₂) := by
-    exact (wordSpan_mul_le B (m₁ + n) m₂) (Submodule.mul_mem_mul hPY hQ)
-  rw [← hM]
-  simpa only [Matrix.mul_assoc, Nat.add_assoc] using hPYQ
+    biRectSpan (d := d) (D := D) P Q B n ≤ wordSpan B (m₁ + n + m₂) :=
+  Kraus.biRectSpan_le_wordSpan B P Q hP hQ
 
 end MPSTensor

--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -7,7 +7,7 @@ import TNLean.Kraus.Wielandt.RankOne.BoundedWord
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 
 /-!
-# Bounded rank-one element in a blocked word span
+# Bounded two-sided MPS word spans
 
 This file restates the `Kraus` two-sided word-span results using the `MPSTensor`
 word-span notation.

--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -9,8 +9,8 @@ import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 /-!
 # Bounded rank-one element in a blocked word span
 
-This file preserves the established `MPSTensor` interface to the transfer-free
-two-sided word-span results in `Kraus`.
+This file restates the `Kraus` two-sided word-span results using the `MPSTensor`
+word-span notation.
 -/
 
 open scoped Matrix
@@ -20,7 +20,7 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- Two-sided word span for an MPS tensor. -/
-noncomputable abbrev biRectSpan
+noncomputable def biRectSpan
     (P Q : Matrix (Fin D) (Fin D) ℂ) (B : MPSTensor d D) (n : ℕ) :
     Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Kraus.biRectSpan P Q B n


### PR DESCRIPTION
## What changed

- add the generic `Kraus.biRectSpan` construction and exact-fullness range theorem
- prove bounded two-sided multiplication stays in the corresponding longer word span using `Kraus.wordSpan_add`
- restate the results with the established `MPSTensor` word-span notation
- register the new module in the Kraus RankOne aggregator
- use a semireducible definition and mathematical module headings and prose, as requested in review

## Validation

- `lake build TNLean.Kraus.Wielandt.RankOne.BoundedWord TNLean.Kraus.Wielandt.RankOne TNLean.Wielandt.RankOne.BoundedWord TNLean.Wielandt.RankOne.ExtractionFull` (3044 jobs)
- post-review focused build of both `BoundedWord` modules (2717 jobs)
- generated import aggregators: 57 files covering 1469 production modules
- import direction: 448 QIC-bound files, 0 direction violations, 0 namespace-ratchet violations
- reader-facing prose, forbidden Lean tokens, line length, `git diff --check`, and banned added-prose checks
- `#print axioms` for the four new/restated theorems reports only `propext`, `Classical.choice`, and `Quot.sound`
- exact main-relative diff: 3 files, +94/-52

Advances LionSR/QICLean#340 and LionSR/TNLean#6560.
