### PR TITLE
refactor(kraus): own exact-span rank-one extraction

### DIFF
--- a/TNLean/Kraus/Wielandt/RankOne.lean
+++ b/TNLean/Kraus/Wielandt/RankOne.lean
@@ -10,4 +10,5 @@ Authors: TNLean contributors
 
 import TNLean.Kraus.Wielandt.RankOne.BoundedWord
 import TNLean.Kraus.Wielandt.RankOne.Element
+import TNLean.Kraus.Wielandt.RankOne.Extraction
 import TNLean.Kraus.Wielandt.RankOne.Products

--- a/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
@@ -19,7 +19,9 @@ namespace Kraus
 
 variable {d D : ℕ}
 
-/-- If `wordSpan K N = ⊤` and `[NeZero D]`, some word of length `N` has nonzero trace. -/
+/-- If `wordSpan K N = ⊤` and `[NeZero D]`, some word of length `N` has nonzero trace.
+
+Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
 theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
     ∃ σ : Fin N → Fin d, (MPSTensor.evalWord K (List.ofFn σ)).trace ≠ 0 := by
@@ -39,7 +41,9 @@ theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
   exact htrI (LinearMap.mem_ker.mp (hker hI))
 
 /-- If `wordSpan K N = ⊤` and `[NeZero D]`, some word of length `N` has a nonzero eigenvalue
-and a corresponding nonzero eigenvector. -/
+and a corresponding nonzero eigenvector.
+
+Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
 theorem exists_eigenvector_of_wordSpan_eq_top [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
     ∃ (σ : Fin N → Fin d) (μ : ℂ) (φ : Fin D → ℂ),

--- a/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixNonzeroTraceEigenvalue
+import TNLean.Kraus.WordSpan
+
+/-!
+# Eigenvectors from a full exact word span
+
+A full exact word span contains a word with nonzero trace. The corresponding word matrix has a
+nonzero eigenvalue and a nonzero eigenvector.
+-/
+
+open scoped Matrix
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- If `wordSpan K N = ⊤` and `[NeZero D]`, some word of length `N` has nonzero trace. -/
+theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
+    ∃ σ : Fin N → Fin d, (MPSTensor.evalWord K (List.ofFn σ)).trace ≠ 0 := by
+  by_contra hall
+  push Not at hall
+  have hI : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan K N :=
+    htop ▸ Submodule.mem_top
+  let trMap : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ :=
+    Matrix.traceLinearMap (Fin D) ℂ ℂ
+  have hker : wordSpan K N ≤ LinearMap.ker trMap := by
+    apply Submodule.span_le.mpr
+    rintro M ⟨σ, rfl⟩
+    exact LinearMap.mem_ker.mpr (hall σ)
+  have htrI : (1 : Matrix (Fin D) (Fin D) ℂ).trace ≠ 0 := by
+    simp only [Matrix.trace_one, Fintype.card_fin, ne_eq, Nat.cast_eq_zero]
+    exact_mod_cast NeZero.ne D
+  exact htrI (LinearMap.mem_ker.mp (hker hI))
+
+/-- If `wordSpan K N = ⊤` and `[NeZero D]`, some word of length `N` has a nonzero eigenvalue
+and a corresponding nonzero eigenvector. -/
+theorem exists_eigenvector_of_wordSpan_eq_top [NeZero D]
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
+    ∃ (σ : Fin N → Fin d) (μ : ℂ) (φ : Fin D → ℂ),
+      μ ≠ 0 ∧ φ ≠ 0 ∧
+      MPSTensor.evalWord K (List.ofFn σ) *ᵥ φ = μ • φ := by
+  obtain ⟨σ, hσ⟩ := exists_nonzero_trace_word_of_wordSpan_eq_top K htop
+  obtain ⟨μ, φ, hμ, hφ, heig⟩ := exists_eigenvector_of_trace_ne_zero _ hσ
+  exact ⟨σ, μ, φ, hμ, hφ, heig⟩
+
+end Kraus

--- a/TNLean/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Wielandt/RankOne/Extraction.lean
@@ -14,6 +14,10 @@ The Fitting range description formerly proved here now lives in
 `TNLean.Analysis.MatrixFittingRange`. The exact-span extraction results are restated from their
 finite-family versions. This module retains the established import surface for downstream rank-one
 extraction files.
+
+## References
+
+- arXiv:0909.5347, Theorem 1 proof, first paragraph
 -/
 
 open scoped Matrix

--- a/TNLean/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Wielandt/RankOne/Extraction.lean
@@ -4,12 +4,39 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.MatrixFittingRange
+import TNLean.Kraus.Wielandt.RankOne.Extraction
 import TNLean.Wielandt.RankOne.Element
 
 /-!
 # Rank-one extraction compatibility module
 
 The Fitting range description formerly proved here now lives in
-`TNLean.Analysis.MatrixFittingRange`. This module retains the established import surface for
-downstream rank-one extraction files.
+`TNLean.Analysis.MatrixFittingRange`. The exact-span extraction results are restated from their
+finite-family versions. This module retains the established import surface for downstream rank-one
+extraction files.
 -/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If `wordSpan A N = ⊤` and `[NeZero D]`, then there exists a word function
+`σ : Fin N → Fin d` such that `tr(evalWord A (List.ofFn σ)) ≠ 0`. -/
+theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
+    (A : MPSTensor d D) {N : ℕ} (htop : wordSpan A N = ⊤) :
+    ∃ σ : Fin N → Fin d, (evalWord A (List.ofFn σ)).trace ≠ 0 := by
+  exact Kraus.exists_nonzero_trace_word_of_wordSpan_eq_top A htop
+
+/-- If `wordSpan A N = ⊤` and `[NeZero D]`, then there exists a word function
+`σ : Fin N → Fin d` with `evalWord A (List.ofFn σ)` having a nonzero eigenvalue
+and eigenvector. -/
+theorem exists_eigenvector_of_wordSpan_eq_top [NeZero D]
+    (A : MPSTensor d D) {N : ℕ} (htop : wordSpan A N = ⊤) :
+    ∃ (σ : Fin N → Fin d) (μ : ℂ) (φ : Fin D → ℂ),
+      μ ≠ 0 ∧ φ ≠ 0 ∧
+      evalWord A (List.ofFn σ) *ᵥ φ = μ • φ := by
+  exact Kraus.exists_eigenvector_of_wordSpan_eq_top A htop
+
+end MPSTensor

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -165,55 +165,6 @@ private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top
 
 end LinearAlgebraLemmas
 
-/-! ## Nonzero-trace word extraction from a full word span -/
-
-section NonzeroTraceExtraction
-
-/-- If `wordSpan A N = ⊤` and `[NeZero D]`, then there exists a word function
-`σ : Fin N → Fin d` such that `tr(evalWord A (List.ofFn σ)) ≠ 0`.
-
-This follows because `I ∈ wordSpan A N = ⊤`, `tr(I) = D ≠ 0`, and trace is linear:
-if all generators had zero trace, everything in the span would too. -/
-theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
-    (A : MPSTensor d D) {N : ℕ} (htop : wordSpan A N = ⊤) :
-    ∃ σ : Fin N → Fin d, (evalWord A (List.ofFn σ)).trace ≠ 0 := by
-  by_contra hall
-  push Not at hall
-  have hall' : ∀ σ : Fin N → Fin d, (evalWord A (List.ofFn σ)).trace = 0 := hall
-  have hI : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A N := htop ▸ Submodule.mem_top
-  -- The trace linear map kills all generators, hence kills the span
-  set trMap : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ := Matrix.traceLinearMap (Fin D) ℂ ℂ
-  have hgen : ∀ M ∈ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)),
-      trMap M = 0 := by
-    rintro M ⟨σ, rfl⟩
-    exact hall' σ
-  have hker : wordSpan A N ≤ LinearMap.ker trMap := by
-    apply Submodule.span_le.mpr
-    intro M hM
-    exact LinearMap.mem_ker.mpr (hgen M hM)
-  have hzero : ∀ M ∈ wordSpan A N, M.trace = 0 := by
-    intro M hM
-    have := hker hM
-    exact LinearMap.mem_ker.mp this
-  have htrI : (1 : Matrix (Fin D) (Fin D) ℂ).trace ≠ 0 := by
-    simp only [Matrix.trace_one, Fintype.card_fin, ne_eq, Nat.cast_eq_zero]
-    exact_mod_cast NeZero.ne D
-  exact htrI (hzero 1 hI)
-
-/-- If `wordSpan A N = ⊤` and `[NeZero D]`, then there exists a word function
-`σ : Fin N → Fin d` with `evalWord A (List.ofFn σ)` having a nonzero eigenvalue
-and eigenvector. -/
-theorem exists_eigenvector_of_wordSpan_eq_top [NeZero D]
-    (A : MPSTensor d D) {N : ℕ} (htop : wordSpan A N = ⊤) :
-    ∃ (σ : Fin N → Fin d) (μ : ℂ) (φ : Fin D → ℂ),
-      μ ≠ 0 ∧ φ ≠ 0 ∧
-      evalWord A (List.ofFn σ) *ᵥ φ = μ • φ := by
-  obtain ⟨σ, hσ⟩ := exists_nonzero_trace_word_of_wordSpan_eq_top A htop
-  obtain ⟨μ, φ, hμ, hφ, heig⟩ := exists_eigenvector_of_trace_ne_zero _ hσ
-  exact ⟨σ, μ, φ, hμ, hφ, heig⟩
-
-end NonzeroTraceExtraction
-
 /-! ## Main rank-one extraction -/
 
 section RankOneExtraction

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -31,8 +31,9 @@ element `Matrix.vecMulVec φ ψ` inside a bounded word span of a blocked tensor.
 
 ## Main results
 
-- `exists_nonzero_trace_word_of_wordSpan_eq_top`: nonzero-trace word at any full span level.
-- `exists_eigenvector_of_wordSpan_eq_top`: eigenvector extraction from a full word span.
+The exact-span word and eigenvector inputs are provided by
+`TNLean.Wielandt.RankOne.Extraction`.
+
 - `exists_rankOne_mem_wordSpan_blockTensor`: the rank-one extraction theorem.
 - `wielandt_lemma2b`: the unconditional Lemma 2(b).
 


### PR DESCRIPTION
## What changed

- add exact-length Kraus word-span theorems producing a nonzero-trace word and a nonzero eigenvalue/eigenvector
- move the established MPSTensor specializations into the RankOne Extraction compatibility module
- remove only the duplicate declarations from ExtractionFull
- register the new Kraus RankOne module

## Validation

- targeted builds for both Extraction modules, ExtractionFull, MatrixSpanExistence, and RankOne aggregators
- generated-aggregator, import-direction, changed-prose, proof-integrity, line, numbered-module, and diff checks

Advances LionSR/QICLean#340 and LionSR/TNLean#6560.

Stacked on LionSR/TNLean#6664.