### PR TITLE
refactor(spectral): use Kraus mixed-map bounds

### DIFF
--- a/TNLean/MPS/Core/TransferChannel.lean
+++ b/TNLean/MPS/Core/TransferChannel.lean
@@ -26,6 +26,7 @@ properties in transfer-map notation.
 * `Kraus.isIrreducibleTensor_of_isIrreducibleMap_transferMap`: the converse implication.
 * `Kraus.isChannel_transferMap`: the MPS transfer map of a trace-preserving Kraus family is
   a channel.
+* `MPSTensor.trace_transferMap`: trace preservation in transfer-map notation.
 * `MPSTensor.transferMap_pow_apply'`: iterates of a transfer map are sums over Kraus words.
 * `trace_mul_transferMap_adjoint`: the generic Kraus trace-adjoint identity in MPS
   transfer-map notation.
@@ -82,6 +83,13 @@ end Kraus
 namespace MPSTensor
 
 variable {d : ℕ}
+
+/-- The standard transfer map preserves trace for a trace-preserving Kraus family. -/
+theorem trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
+    (hA : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    Matrix.trace (transferMap (d := d) (D := D) A Z) = Matrix.trace Z := by
+  rw [← Kraus.mapLM_eq_transferMap]
+  exact Kraus.isTracePreservingMap_mapLM_of_isTP A hA Z
 
 /-- Iterating the transfer map gives the sum over word evaluations. -/
 theorem transferMap_pow_apply' (A : MPSTensor d D) (N : ℕ) :

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.Analysis.SpectralRadius
 import TNLean.Analysis.SpectralRadiusPowerDecay
-import TNLean.Spectral.MixedTransfer
 
 /-!
 # Common infrastructure for square and rectangular transfer gaps
@@ -20,11 +19,7 @@ spectral-radius results now in `TNLean.Analysis`.
 - `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one`
 -/
 
-open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
-
 namespace MPSTensor
-
-variable {d D : ℕ}
 
 /-! ### Compatibility aliases for spectral-radius results -/
 

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -6,22 +6,18 @@ Authors: TNLean contributors
 import TNLean.Analysis.SpectralRadius
 import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Spectral.MixedTransfer
-import TNLean.Spectral.FrobeniusNorm
 
 /-!
 # Common infrastructure for square and rectangular transfer gaps
 
-Dimension-independent eigenvector iteration, trace-preserving word sums, and
-Frobenius-square identities used by both square and rectangular mixed-transfer
-gap theorems. Compatibility aliases preserve the former `MPSTensor` names of the
-general spectral-radius results now in `TNLean.Analysis`.
+Compatibility aliases preserve the former `MPSTensor` names of the general
+spectral-radius results now in `TNLean.Analysis`.
 
 ## Main results
 
-- `MPSTensor.word_conjTranspose_mul_sum`
-- `MPSTensor.trace_transferMap`
-- `MPSTensor.sum_frobSq_right`
-- `MPSTensor.sum_frobSq_words`
+- `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
+- `MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one`
+- `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one`
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -29,75 +25,6 @@ open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-! ### Hilbert–Schmidt contraction estimates -/
-
-/-- Iterated TP condition: `∑_σ evalWord(K,σ)† evalWord(K,σ) = I`. -/
-lemma word_conjTranspose_mul_sum (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1) (n : ℕ) :
-    ∑ σ : Fin n → Fin d,
-      (evalWord K (List.ofFn σ))ᴴ * evalWord K (List.ofFn σ) = 1 := by
-  induction n with
-  | zero => simp [Finset.univ_unique]
-  | succ n ih =>
-    rw [← (Fin.consEquiv (fun _ : Fin (n + 1) => Fin d)).sum_comp]
-    rw [Fintype.sum_prod_type]
-    rw [Finset.sum_comm]
-    exact (Finset.sum_congr rfl (fun τ _ => by
-      have hsum :
-          (∑ a : Fin d, (K a)ᴴ * (K a * evalWord K (List.ofFn τ))) =
-            evalWord K (List.ofFn τ) := by
-        calc
-          (∑ a : Fin d, (K a)ᴴ * (K a * evalWord K (List.ofFn τ)))
-              = (∑ a : Fin d, (K a)ᴴ * K a) * evalWord K (List.ofFn τ) := by
-                simp_rw [← Matrix.mul_assoc]
-                rw [← Matrix.sum_mul]
-          _ = evalWord K (List.ofFn τ) := by
-                rw [hK, Matrix.one_mul]
-      simpa [Fin.consEquiv_apply, List.ofFn_cons, evalWord_cons,
-        Matrix.conjTranspose_mul, Matrix.mul_assoc, ← Matrix.mul_sum] using
-        congrArg (fun M => (evalWord K (List.ofFn τ))ᴴ * M) hsum)).trans ih
-
-/-- The standard transfer map preserves trace (for TP tensors). -/
-lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
-    (hA : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    Matrix.trace (transferMap (d := d) (D := D) A Z) = Matrix.trace Z := by
-  rw [transferMap_apply, Matrix.trace_sum]
-  conv_lhs => arg 2; ext i; rw [show Matrix.trace (A i * Z * (A i)ᴴ) =
-    Matrix.trace ((A i)ᴴ * A i * Z) from by
-      rw [Matrix.trace_mul_comm (A i * Z) _, Matrix.mul_assoc]]
-  rw [← Matrix.trace_sum, ← Finset.sum_mul, hA, one_mul]
-
-private lemma trace_cycle_for_frobSq_right {D₁ D₂ : ℕ}
-    (v : Matrix (Fin D₁) (Fin D₂) ℂ) (M : Matrix (Fin D₂) (Fin D₂) ℂ) :
-    ((v * Mᴴ)ᴴ * (v * Mᴴ)).trace = (Mᴴ * M * (vᴴ * v)).trace := by
-  have h1 : (v * Mᴴ)ᴴ = M * vᴴ := by
-    simp [Matrix.conjTranspose_mul]
-  rw [h1]
-  rw [Matrix.mul_assoc M vᴴ _, ← Matrix.mul_assoc vᴴ v Mᴴ,
-    ← Matrix.mul_assoc M (vᴴ * v) Mᴴ,
-    Matrix.trace_mul_comm (M * (vᴴ * v)) Mᴴ,
-    ← Matrix.mul_assoc Mᴴ M (vᴴ * v)]
-
-/-- Right multiplication by trace-preserving word products preserves the Frobenius square
-after summing over all words. -/
-lemma sum_frobSq_right {D₁ D₂ : ℕ}
-    (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    (v : Matrix (Fin D₁) (Fin D₂) ℂ) (n : ℕ) :
-    ∑ σ : Fin n → Fin d, frobSq (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq v := by
-  simp_rw [frobSq_trace]
-  conv_lhs => arg 2; ext σ; rw [trace_cycle_for_frobSq_right v (evalWord B (List.ofFn σ))]
-  rw [← Complex.re_sum, ← Matrix.trace_sum, ← Finset.sum_mul,
-      word_conjTranspose_mul_sum B hB n, Matrix.one_mul]
-
-/-- The Frobenius squares of all trace-preserving word products of a fixed length sum to the
-bond dimension. -/
-lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
-    (n : ℕ) :
-    ∑ σ : Fin n → Fin d, frobSq (evalWord K (List.ofFn σ)) = (D : ℝ) := by
-  simp only [frobSq_trace]
-  rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
-  simp [Matrix.trace_one, Fintype.card_fin]
 
 /-! ### Compatibility aliases for spectral-radius results -/
 

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Kraus.MixedMap.SpectralRadius
 import TNLean.Spectral.TransferOperatorGapCommon
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
-import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 /-!
 # Normalized rectangular transfer-operator bounds
@@ -59,66 +59,7 @@ theorem mixedTransferSpectralRadius₂_eq
         ((Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ))
           (mixedTransferMap₂ A B)) := rfl
 
-/-! ## Rectangular Frobenius norm and Euclidean-space embedding
-
-The general definitions `frobSq`, `matToES`, and their basic lemmas are imported from
-`TNLean.Spectral.FrobeniusNorm`.  Mathlib's native Frobenius-norm
-submultiplicativity gives the mixed-shape estimate used below. -/
-
-/-! ## Hilbert–Schmidt contraction for the rectangular mixed transfer -/
-
-section HSContraction
-
-/-- **Uniform Frobenius-norm bound**: `‖F₂^n(X)‖_F² ≤ D₁² · ‖X‖_F²`
-for the rectangular mixed transfer operator. -/
-private lemma hs_contraction_rect [NeZero D₁] [NeZero D₂]
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (X : Matrix (Fin D₁) (Fin D₂) ℂ)
-    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1) (n : ℕ) :
-    frobSq (((mixedTransferMap₂ A B) ^ n) X) ≤ (D₁ : ℝ) ^ 2 * frobSq X := by
-  rw [mixedTransferMap₂_pow_apply, show (∑ σ : Fin n → Fin d,
-    evalWord A (List.ofFn σ) * X * (evalWord B (List.ofFn σ))ᴴ) =
-    (∑ σ : Fin n → Fin d,
-    evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ)) from by
-    congr 1; ext σ; rw [Matrix.mul_assoc]]
-  rw [show frobSq (∑ σ : Fin n → Fin d,
-    evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ)) =
-    ‖matToES (∑ σ : Fin n → Fin d,
-    evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ^ 2 from
-    (norm_matToES_sq _).symm]
-  set fA := fun σ : Fin n → Fin d => ‖matToES (evalWord A (List.ofFn σ))‖ with hfA_def
-  set fB := fun σ : Fin n → Fin d =>
-    ‖matToES (X * (evalWord B (List.ofFn σ))ᴴ)‖ with hfB_def
-  have h_chain : ‖matToES (∑ σ : Fin n → Fin d,
-    evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ≤
-    ∑ σ : Fin n → Fin d, fA σ * fB σ :=
-    ((by rw [matToES_finset_sum]; exact norm_sum_le _ _) : ‖matToES _‖ ≤ _).trans
-      (Finset.sum_le_sum fun σ _ => by
-        simpa [hfA_def, hfB_def, norm_matToES_eq_frobenius_norm] using
-          Matrix.frobenius_norm_mul (evalWord A (List.ofFn σ))
-            (X * (evalWord B (List.ofFn σ))ᴴ))
-  have h_A : ∑ σ : Fin n → Fin d, fA σ ^ 2 = (D₁ : ℝ) := by
-    simp_rw [hfA_def, norm_matToES_sq]; exact sum_frobSq_words A hA_norm n
-  have h_B : ∑ σ : Fin n → Fin d, fB σ ^ 2 = frobSq X := by
-    simp_rw [hfB_def, norm_matToES_sq]; exact sum_frobSq_right B hB_norm X n
-  calc ‖matToES _‖ ^ 2
-      ≤ (∑ σ : Fin n → Fin d, fA σ * fB σ) ^ 2 :=
-        pow_le_pow_left₀ (norm_nonneg _) h_chain 2
-    _ ≤ (∑ σ, fA σ ^ 2) * (∑ σ, fB σ ^ 2) :=
-        Finset.sum_mul_sq_le_sq_mul_sq Finset.univ fA fB
-    _ = (D₁ : ℝ) * frobSq X := by rw [h_A, h_B]
-    _ ≤ (D₁ : ℝ) ^ 2 * frobSq X := by
-        nlinarith [sq_nonneg ((D₁ : ℝ) - 1),
-          show 0 ≤ frobSq X from by
-            rw [frobSq]
-            exact sq_nonneg _,
-          show (1 : ℝ) ≤ D₁ from by exact_mod_cast NeZero.one_le (n := D₁)]
-
-end HSContraction
-
-/-! ## Eigenvalue bound -/
-
-section EigenvalueBound
+/-! ## Eigenvalue and spectral-radius bounds -/
 
 /-- Every eigenvalue of the rectangular mixed transfer operator has modulus ≤ 1. -/
 theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
@@ -126,56 +67,16 @@ theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
     (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
     (μ : ℂ) (hμ : Module.End.HasEigenvalue (mixedTransferMap₂ A B) μ) :
-    ‖μ‖ ≤ 1 := by
-  obtain ⟨v, hv_mem, hv_ne⟩ := hμ.exists_hasEigenvector
-  have hv : Module.End.HasEigenvector (mixedTransferMap₂ A B) μ v :=
-    ⟨hv_mem, hv_ne⟩
-  by_contra h_gt; push Not at h_gt
-  have h_pos : 0 < frobSq v := by
-    rw [frobSq]
-    let : NormedAddCommGroup (Matrix (Fin D₁) (Fin D₂) ℂ) :=
-      Matrix.frobeniusNormedAddCommGroup
-    exact sq_pos_of_ne_zero (norm_ne_zero_iff.mpr hv_ne)
-  have h_bound : ∀ n : ℕ, ‖μ‖ ^ (2 * n) ≤ (D₁ : ℝ) ^ 2 := fun n => by
-    have h1 := hs_contraction_rect A B v hA_norm hB_norm n
-    rw [Module.End.HasEigenvector.pow_apply hv n] at h1
-    simp only [frobSq_smul, norm_pow] at h1
-    calc ‖μ‖ ^ (2 * n) = (‖μ‖ ^ n) ^ 2 := by ring
-    _ ≤ _ := le_of_mul_le_mul_right (by linarith) h_pos
-  have htend := tendsto_pow_atTop_atTop_of_one_lt (by nlinarith : 1 < ‖μ‖ ^ 2)
-  rw [Filter.tendsto_atTop_atTop] at htend
-  obtain ⟨n, hn⟩ := htend ((D₁ : ℝ) ^ 2 + 1)
-  linarith [h_bound n, show (‖μ‖ ^ 2) ^ n = ‖μ‖ ^ (2 * n) from by ring, hn n le_rfl]
+    ‖μ‖ ≤ 1 :=
+  Kraus.eigenvalue_norm_le_one_mixedMapLM_of_isTP A B hA_norm hB_norm μ hμ
 
 /-- **Spectral radius bound**: `ρ(F₂) ≤ 1` for normalized tensors. -/
 theorem spectralRadius_mixedTransfer₂_le_one
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1) :
-    mixedTransferSpectralRadius₂ A B ≤ 1 := by
-  rw [mixedTransferSpectralRadius₂_eq]
-  rcases eq_or_ne D₁ 0 with rfl | hD₁
-  · have : Subsingleton (Matrix (Fin 0) (Fin D₂) ℂ) := ⟨fun a b => by ext i; exact i.elim0⟩
-    have : Subsingleton (Matrix (Fin 0) (Fin D₂) ℂ →L[ℂ] Matrix (Fin 0) (Fin D₂) ℂ) :=
-      ContinuousLinearMap.uniqueOfLeft.instSubsingleton
-    rw [spectrum.SpectralRadius.of_subsingleton]; exact zero_le
-  · rcases eq_or_ne D₂ 0 with rfl | hD₂
-    · have : Subsingleton (Matrix (Fin D₁) (Fin 0) ℂ) := ⟨fun a b => by
-        ext i j
-        exact j.elim0⟩
-      have : Subsingleton (Matrix (Fin D₁) (Fin 0) ℂ →L[ℂ] Matrix (Fin D₁) (Fin 0) ℂ) :=
-        ContinuousLinearMap.uniqueOfLeft.instSubsingleton
-      rw [spectrum.SpectralRadius.of_subsingleton]; exact zero_le
-    · have : NeZero D₁ := ⟨hD₁⟩
-      have : NeZero D₂ := ⟨hD₂⟩
-      have h_spec := AlgEquiv.spectrum_eq (Module.End.toContinuousLinearMap
-        (Matrix (Fin D₁) (Fin D₂) ℂ)) (mixedTransferMap₂ A B)
-      apply iSup₂_le; intro k hk
-      rw [ENNReal.coe_le_one_iff]
-      exact_mod_cast eigenvalue_norm_le_one₂ A B hA_norm hB_norm k
-        (Module.End.hasEigenvalue_iff_mem_spectrum.mpr (h_spec ▸ hk))
-
-end EigenvalueBound
+    mixedTransferSpectralRadius₂ A B ≤ 1 :=
+  Kraus.mixedMapSpectralRadius_le_one_of_isTP A B hA_norm hB_norm
 
 /-! ## Power decay -/
 
@@ -209,7 +110,7 @@ theorem mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one
       (((Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ))
         (mixedTransferMap₂ A B)) :
           Matrix (Fin D₁) (Fin D₂) ℂ →L[ℂ] Matrix (Fin D₁) (Fin D₂) ℂ) < 1
-    simpa only [mixedTransferSpectralRadius₂] using h
+    simpa only [mixedTransferSpectralRadius₂_eq] using h
   have hF : Filter.Tendsto (fun n => F ^ n) Filter.atTop (nhds 0) :=
     @_root_.pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
       (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Kraus.MixedMap.SpectralRadius
+import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.TransferOperatorGapCommon
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
 

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -170,61 +170,6 @@ Euclidean space.
     (\ref{eq:spectral_frob_sq}).
 \end{proof}
 
-The following estimate records an independent Frobenius-norm argument for
-the rectangular mixed transfer.  The proof of
-Theorem~\ref{thm:eigenvalue_bound_rect} instead uses the block-diagonal
-embedding described there.  We retain this estimate as useful analytic
-background.  Its statement is phrased over normalized MPS tensors of fixed
-bond dimensions, so it belongs alongside
-Definition~\ref{def:mixed_transfer_rect} and Definition~\ref{def:frob_sq}.
-
-\begin{lemma}[Uniform Frobenius bound for the rectangular mixed transfer power]%
-    \label{lem:hs_contraction_rect}
-    \uses{def:mixed_transfer_rect, def:frob_sq}
-    Let $A$ and $B$ be normalized MPS tensors of bond dimensions
-    $D_1\geq1$ and $D_2\geq1$. For every $X\in M_{D_1\times D_2}(\C)$ and
-    $n\geq0$,
-    \begin{align}
-        \|(F_{AB}^{\mathrm{rect}})^n(X)\|_F^2
-         & \leq D_1^2\,\|X\|_F^2.
-        \label{eq:spectral_hs_contraction_rect}
-    \end{align}
-\end{lemma}
-
-\begin{proof}
-    \uses{thm:mixed_pow, lem:norm_mat_to_es}
-    The word expansion (\ref{eq:spectral_mixed_power}) writes
-    $(F_{AB}^{\mathrm{rect}})^n(X)=\sum_\sigma A^\sigma(X(B^\sigma)^\dagger)$,
-    a sum over words $\sigma$ of length $n$. Embedding into Euclidean space by
-    $\opvec$ (Definition~\ref{def:mat_to_es}), the triangle inequality and the
-    Frobenius submultiplicativity $\|MN\|_F\leq\|M\|_F\|N\|_F$ give
-    \begin{align}
-        \|\opvec((F_{AB}^{\mathrm{rect}})^n(X))\|
-         & \leq\sum_\sigma\|A^\sigma\|_F\,\|X(B^\sigma)^\dagger\|_F.
-        \notag
-    \end{align}
-    Cauchy--Schwarz over the word index bounds the right side by
-    $\left(\sum_\sigma\|A^\sigma\|_F^2\right)^{1/2}
-        \left(\sum_\sigma\|X(B^\sigma)^\dagger\|_F^2\right)^{1/2}$.
-    The trace-preserving normalization of $A$ gives
-    $\sum_\sigma(A^\sigma)^\dagger A^\sigma=\Id_{D_1}$, so
-    $\sum_\sigma\|A^\sigma\|_F^2=D_1$; the same normalization for $B$ gives
-    $\sum_\sigma(B^\sigma)^\dagger B^\sigma=\Id_{D_2}$, which forces the
-    exact identity $\sum_\sigma\|X(B^\sigma)^\dagger\|_F^2=\|X\|_F^2$ (both
-    sides equal $\re\tr(X^\dagger X)$ after expanding by the same
-    normalization). Hence
-    $\|(F_{AB}^{\mathrm{rect}})^n(X)\|_F\leq\sqrt{D_1} \|X\|_F\leq
-        D_1\,\|X\|_F$, giving (\ref{eq:spectral_hs_contraction_rect}).
-\end{proof}
-
-Lemma~\ref{lem:hs_contraction_rect} also gives an alternative proof of
-the conclusion of Theorem~\ref{thm:eigenvalue_bound_rect}.  Indeed, if
-$F_{AB}^{\mathrm{rect}}(X)=\mu X$ with $X\neq0$, then
-$(F_{AB}^{\mathrm{rect}})^n(X)=\mu^nX$, and the lemma gives
-$|\mu|^{2n}\|X\|_F^2\leq D_1^2\|X\|_F^2$ for every $n$.  Since
-$\|X\|_F>0$, the case $|\mu|>1$ contradicts
-$|\mu|^{2n}\to\infty$.
-
 \begin{lemma}[Rectangular spectral radius bound]\label{thm:spectral_radius_le_one_rect}
     \lean{MPSTensor.spectralRadius_mixedTransfer₂_le_one}
     \leanok

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -2,11 +2,11 @@
 \label{ch:spectral_supporting_results}
 
 This appendix supports Chapter~\ref{ch:spectral}. It proves the algebraic
-mixed-transfer identities, the Frobenius-norm apparatus behind the eigenvalue
-bounds, the peripheral intertwiners behind the gauge-rigidity theorems, the
-Banach-algebra convergence facts behind the overlap-decay theorems, the
-rank-one Perron projection behind the primitive overlap limit, and the
-cyclic-decomposition machinery that removes peripheral periodicity.
+mixed-transfer identities, an auxiliary trace-positivity result, the
+peripheral intertwiners behind the gauge-rigidity theorems, the Banach-algebra
+convergence facts behind the overlap-decay theorems, the rank-one Perron
+projection behind the primitive overlap limit, and the cyclic-decomposition
+machinery that removes peripheral periodicity.
 
 \section{Mixed-transfer powers and overlap traces}
 \label{sec:app_spectral_mixed_trace}
@@ -93,17 +93,7 @@ matrix-unit indices gives
     \notag
 \end{align}
 
-\section{Frobenius estimates and eigenvalue bounds}
-\label{sec:app_spectral_frobenius}
-
-This section proves the trace positivity fact
-(Lemma~\ref{lem:psd_trace_product_nonneg}) and the detailed Frobenius-norm
-estimate behind the rectangular eigenvalue bound
-(Theorem~\ref{thm:eigenvalue_bound_rect}), of which
-Theorem~\ref{thm:eigenvalue_bound} is the equal-bond-dimension case
-$D_1=D_2=D$. The estimate uses the Frobenius (Hilbert--Schmidt) norm
-$\|{\cdot}\|_F$ on rectangular matrices and an isometric embedding into
-Euclidean space.
+\section{Auxiliary trace positivity}
 
 \begin{lemma}[Trace product of positive semidefinite matrices]
     \label{lem:psd_trace_product_nonneg}
@@ -125,62 +115,21 @@ Euclidean space.
     because $U^\dagger AU\geq0$ and $\Lambda_{ii}\geq0$ for every $i$.
 \end{proof}
 
-\begin{definition}[Frobenius norm squared]\label{def:frob_sq}
-    \lean{MPSTensor.frobSq}
-    \leanok
-    For a possibly rectangular matrix $X\in M_{m\times n}(\C)$, its
-    \emph{Frobenius norm squared} is
-    \begin{align}
-        \|X\|_F^2
-         & :=\sum_{i=0}^{m-1}\sum_{j=0}^{n-1}|X_{ij}|^2.
-        \label{eq:spectral_frob_sq}
-    \end{align}
-\end{definition}
-
-\begin{lemma}[Trace formula for Frobenius norm]\label{lem:frob_sq_trace}
-    \lean{MPSTensor.frobSq_trace}
-    \lean{Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq}
-    \leanok
-    \uses{def:frob_sq}
-    One has $\|X\|_F^2=\re\tr(X^\dagger X)$.
-\end{lemma}
-
-\begin{proof}\leanok
-    Expand the matrix product and trace entry by entry.
-\end{proof}
-
-\begin{definition}[Euclidean-space embedding]\label{def:mat_to_es}
-    \lean{MPSTensor.matToES}
-    \leanok
-    Flattening matrix entries defines an isometric embedding
-    $\opvec:M_{m\times n}(\C)\to\C^{mn}$ with respect to the Frobenius
-    norm: $\|\opvec(X)\|^2=\|X\|_F^2$.
-\end{definition}
-
-\begin{lemma}[Norm of embedded matrix]\label{lem:norm_mat_to_es}
-    \lean{MPSTensor.norm_matToES_sq}
-    \leanok
-    \uses{def:mat_to_es, def:frob_sq}
-    One has $\|\opvec(X)\|^2=\|X\|_F^2$.
-\end{lemma}
-
-\begin{proof}\leanok
-    Both sides equal $\sum_{i,j}\lVert X_{ij}\rVert^2$: the left side by
-    the Euclidean entry-norm formula and the right side by
-    (\ref{eq:spectral_frob_sq}).
-\end{proof}
+\section{Rectangular spectral-radius formulation}
 
 \begin{lemma}[Rectangular spectral radius bound]\label{thm:spectral_radius_le_one_rect}
     \lean{MPSTensor.spectralRadius_mixedTransfer₂_le_one}
     \leanok
-    \uses{def:mixed_transfer_rect, thm:eigenvalue_bound_rect}
+    \uses{def:mixed_transfer_rect, thm:kraus_mixed_tp_spectral_radius_bound}
     For normalized tensors of bond dimensions $D_1$ and $D_2$,
     $\rho_{\spec}(F_{AB}^{\mathrm{rect}})\leq1$.
 \end{lemma}
 
 \begin{proof}\leanok
-    On a finite-dimensional space every spectral value is an eigenvalue, and
-    each satisfies $|\mu|\leq1$ by Theorem~\ref{thm:eigenvalue_bound_rect}.
+    This is the MPS formulation of
+    Theorem~\ref{thm:kraus_mixed_tp_spectral_radius_bound}: the rectangular
+    mixed transfer is the mixed Kraus map, and the two tensor normalization
+    identities are its trace-preserving hypotheses.
 \end{proof}
 
 \section{Peripheral intertwiners and gauge rigidity}

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -170,13 +170,13 @@ Euclidean space.
     (\ref{eq:spectral_frob_sq}).
 \end{proof}
 
-The following internal estimate is folded into a private supporting lemma
-in the formalization and is recorded here, untagged, purely as an
-exposition step toward Theorem~\ref{thm:eigenvalue_bound_rect}. Its
-statement is phrased over normalized MPS tensors of fixed bond dimensions,
-so it belongs with the tensor-network-side rump of this appendix alongside
-Definition~\ref{def:mixed_transfer_rect} and Definition~\ref{def:frob_sq},
-not with the channel-generic material extracted elsewhere in this chapter.
+The following estimate records an independent Frobenius-norm argument for
+the rectangular mixed transfer.  The proof of
+Theorem~\ref{thm:eigenvalue_bound_rect} instead uses the block-diagonal
+embedding described there.  We retain this estimate as useful analytic
+background.  Its statement is phrased over normalized MPS tensors of fixed
+bond dimensions, so it belongs alongside
+Definition~\ref{def:mixed_transfer_rect} and Definition~\ref{def:frob_sq}.
 
 \begin{lemma}[Uniform Frobenius bound for the rectangular mixed transfer power]%
     \label{lem:hs_contraction_rect}
@@ -217,12 +217,13 @@ not with the channel-generic material extracted elsewhere in this chapter.
         D_1\,\|X\|_F$, giving (\ref{eq:spectral_hs_contraction_rect}).
 \end{proof}
 
-Theorem~\ref{thm:eigenvalue_bound_rect} follows directly from
-Lemma~\ref{lem:hs_contraction_rect}: if $F_{AB}^{\mathrm{rect}}(X)=\mu X$
-with $X\neq0$, iterating gives $(F_{AB}^{\mathrm{rect}})^n(X)=\mu^nX$, and
-Lemma~\ref{lem:hs_contraction_rect} gives $|\mu|^{2n}\|X\|_F^2\leq
-    D_1^2\|X\|_F^2$ for every $n$; since $\|X\|_F>0$, if $|\mu|>1$ then
-$|\mu|^{2n}\to\infty$, contradicting the uniform bound, so $|\mu|\leq1$.
+Lemma~\ref{lem:hs_contraction_rect} also gives an alternative proof of
+the conclusion of Theorem~\ref{thm:eigenvalue_bound_rect}.  Indeed, if
+$F_{AB}^{\mathrm{rect}}(X)=\mu X$ with $X\neq0$, then
+$(F_{AB}^{\mathrm{rect}})^n(X)=\mu^nX$, and the lemma gives
+$|\mu|^{2n}\|X\|_F^2\leq D_1^2\|X\|_F^2$ for every $n$.  Since
+$\|X\|_F>0$, the case $|\mu|>1$ contradicts
+$|\mu|^{2n}\to\infty$.
 
 \begin{lemma}[Rectangular spectral radius bound]\label{thm:spectral_radius_le_one_rect}
     \lean{MPSTensor.spectralRadius_mixedTransfer₂_le_one}

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -136,6 +136,7 @@ mixed-transfer eigenvector.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:kraus_tp_eigenvalue_bound}
     Set $C_i=A_i\oplus B_i$.  The two normalization identities imply
     $\sum_i C_i^\dagger C_i=\Id_{D_1+D_2}$, so the Kraus map $E_C$ is
     trace preserving.  Embed $X\in M_{D_1\times D_2}(\C)$ as the

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -96,15 +96,13 @@ transfer power.
 
 \section{Eigenvalue bound and transfer-operator gap}
 
-The eigenvalue bound embeds the rectangular mixed transfer into a
-trace-preserving map on a larger square matrix algebra.  Namely, the
-block-diagonal family $C_i=A_i\oplus B_i$ is trace preserving, and its
-Kraus map preserves the subspace of upper-right blocks.  The induced map
-on that subspace is precisely the rectangular mixed transfer.  The general
-eigenvalue bound for trace-preserving Kraus maps therefore applies.  For
-the rigidity theorem, one gauges $A$ and $B$ separately using positive
-fixed points of their transfer maps to obtain unital Kraus families, and
-then applies the Kadison--Schwarz equality argument
+The rectangular eigenvalue bound is the MPS formulation of the generic
+bound for trace-preserving mixed Kraus maps.  Under the identification of
+the rectangular mixed transfer with the mixed Kraus map, the two tensor
+normalizations are precisely the trace-preserving conditions.  For the
+rigidity theorem, one gauges $A$ and $B$ separately using positive fixed
+points of their transfer maps to obtain unital Kraus families, and then
+applies the Kadison--Schwarz equality argument
 (\cite[Theorem~5.3]{Wolf2012Quantum}) to a block embedding of a
 mixed-transfer eigenvector.
 
@@ -136,23 +134,12 @@ mixed-transfer eigenvector.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:kraus_tp_eigenvalue_bound}
-    Set $C_i=A_i\oplus B_i$.  The two normalization identities imply
-    $\sum_i C_i^\dagger C_i=\Id_{D_1+D_2}$, so the Kraus map $E_C$ is
-    trace preserving.  Embed $X\in M_{D_1\times D_2}(\C)$ as the
-    upper-right block
-
-    \[
-        \iota(X)=\begin{pmatrix}0&X\\0&0\end{pmatrix}.
-    \]
-
-    Direct block multiplication gives
-    $E_C(\iota(X))=\iota(F_{AB}^{\mathrm{rect}}(X))$, and $\iota$ is
-    injective.  Thus an eigenvector $X\neq0$ of
-    $F_{AB}^{\mathrm{rect}}$ with eigenvalue $\mu$ gives the nonzero
-    eigenvector $\iota(X)$ of $E_C$ with the same eigenvalue.  Every
-    eigenvalue of a trace-preserving Kraus map lies in the closed unit disk,
-    hence $|\mu|\leq1$.
+    \uses{thm:kraus_mixed_tp_eigenvalue_bound}
+    This is the MPS formulation of
+    Theorem~\ref{thm:kraus_mixed_tp_eigenvalue_bound}: the map
+    $F_{AB}^{\mathrm{rect}}$ is the mixed Kraus map of the two matrix
+    families, and the normalizations of $A$ and $B$ are exactly its two
+    trace-preserving hypotheses.
 \end{proof}
 
 \begin{lemma}[Spectral radius bound]\label{thm:spectral_radius_le_one}

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -96,14 +96,17 @@ transfer power.
 
 \section{Eigenvalue bound and transfer-operator gap}
 
-The eigenvalue bound uses the Frobenius (Hilbert--Schmidt) norm
-$\|{\cdot}\|_F$ on the finite-dimensional matrix algebra and the trace
-positivity of two positive semidefinite matrices; both are proved in
-Section~\ref{sec:app_spectral_frobenius}. For the rigidity
-theorem, one gauges $A$ and $B$ separately using positive fixed points of
-their transfer maps to obtain unital Kraus families, and then applies the
-Kadison--Schwarz equality argument (\cite[Theorem~5.3]{Wolf2012Quantum}) to
-a block embedding of a mixed-transfer eigenvector.
+The eigenvalue bound embeds the rectangular mixed transfer into a
+trace-preserving map on a larger square matrix algebra.  Namely, the
+block-diagonal family $C_i=A_i\oplus B_i$ is trace preserving, and its
+Kraus map preserves the subspace of upper-right blocks.  The induced map
+on that subspace is precisely the rectangular mixed transfer.  The general
+eigenvalue bound for trace-preserving Kraus maps therefore applies.  For
+the rigidity theorem, one gauges $A$ and $B$ separately using positive
+fixed points of their transfer maps to obtain unital Kraus families, and
+then applies the Kadison--Schwarz equality argument
+(\cite[Theorem~5.3]{Wolf2012Quantum}) to a block embedding of a
+mixed-transfer eigenvector.
 
 \begin{theorem}[Eigenvalue bound]\label{thm:eigenvalue_bound}
     \lean{MPSTensor.eigenvalue_norm_le_one}
@@ -117,11 +120,10 @@ a block embedding of a mixed-transfer eigenvector.
     \leanok
     \uses{thm:eigenvalue_bound_rect}
     This is the equal-bond-dimension case $D_1=D_2=D$ of
-    Theorem~\ref{thm:eigenvalue_bound_rect}, which gives the full
-    Cauchy--Schwarz estimate via the Frobenius-norm apparatus of
-    Section~\ref{sec:app_spectral_frobenius}. The argument uses
-    only the trace-preserving normalization (\ref{eq:spec_tp_normalization})
-    and does not appeal to Perron--Frobenius theory.
+    Theorem~\ref{thm:eigenvalue_bound_rect}.  The argument uses only the
+    trace-preserving normalization (\ref{eq:spec_tp_normalization}) and the
+    general eigenvalue bound for trace-preserving Kraus maps; it does not
+    appeal to Perron--Frobenius theory.
 \end{proof}
 
 \begin{theorem}[Rectangular eigenvalue bound]\label{thm:eigenvalue_bound_rect}
@@ -134,15 +136,22 @@ a block embedding of a mixed-transfer eigenvector.
 \end{theorem}
 
 \begin{proof}\leanok
-    A uniform Frobenius bound
-    $\|(F_{AB}^{\mathrm{rect}})^n(X)\|_F^2\leq D_1^2\|X\|_F^2$ follows from
-    the word expansion, the Frobenius submultiplicativity
-    $\|MN\|_F\leq\|M\|_F\|N\|_F$, and Cauchy--Schwarz applied to the
-    trace-preserving normalization of $A$ and $B$
-    (Section~\ref{sec:app_spectral_frobenius}). If
-    $F_{AB}^{\mathrm{rect}}(X)=\mu X$ with $X\neq0$, iterating gives
-    $|\mu|^{2n}\|X\|_F^2\leq D_1^2\|X\|_F^2$ for every $n$, forcing
-    $|\mu|\leq1$.
+    Set $C_i=A_i\oplus B_i$.  The two normalization identities imply
+    $\sum_i C_i^\dagger C_i=\Id_{D_1+D_2}$, so the Kraus map $E_C$ is
+    trace preserving.  Embed $X\in M_{D_1\times D_2}(\C)$ as the
+    upper-right block
+
+    \[
+        \iota(X)=\begin{pmatrix}0&X\\0&0\end{pmatrix}.
+    \]
+
+    Direct block multiplication gives
+    $E_C(\iota(X))=\iota(F_{AB}^{\mathrm{rect}}(X))$, and $\iota$ is
+    injective.  Thus an eigenvector $X\neq0$ of
+    $F_{AB}^{\mathrm{rect}}$ with eigenvalue $\mu$ gives the nonzero
+    eigenvector $\iota(X)$ of $E_C$ with the same eigenvalue.  Every
+    eigenvalue of a trace-preserving Kraus map lies in the closed unit disk,
+    hence $|\mu|\leq1$.
 \end{proof}
 
 \begin{lemma}[Spectral radius bound]\label{thm:spectral_radius_le_one}


### PR DESCRIPTION
## What changed

- replace the rectangular normalized Frobenius contraction proof with the Kraus mixed-map eigenvalue and spectral-radius bounds
- move `trace_transferMap` to the sanctioned MPS/QIC comparison module
- remove three now-unused Frobenius word helpers
- preserve all established compatibility-facing `MPSTensor` declarations and exact signatures
- make the mixed-transfer dependency direct and remove unused common-module imports and scopes
- present the MPS eigenvalue and spectral-radius entries as formulations of the generic mixed-Kraus theorems
- remove the orphaned Frobenius blueprint subsection while retaining the independently used trace-positivity result

The final three blueprint commits are required fixes for resolved review threads. They align the proof narrative, record the exact mixed-Kraus dependencies, and remove the orphaned Frobenius material. They are part of LionSR/TNLean#6670's reviewed child delta and must not be dropped during future main transplants.

## Validation

- `lake build TNLean.Spectral.TransferOperatorGapRectNormalized` (8748 jobs, current main-based head)
- import-direction check: 477 files, 0 violations
- changed-prose and `git diff --check`: pass
- blueprint source sync: 7,997/7,997 theorem-like entries complete
- generated import aggregators: 58 files cover 1472 production modules
- removed Frobenius-label scan: 0 remaining references
- deleted-helper scan: 0 Lean occurrences for all three removed names
- range-diff: all five child commits patch-identical to the reviewed series; the first two are also patch-identical to overwritten head `ee3206f8b`

The branch is based directly on live `origin/main` at `245d42fa1`. No obsolete parent or feature-branch commits remain. No full build or cache fetch was run.

Advances LionSR/QICLean#341 and LionSR/TNLean#6560.
