### PR TITLE
fix(blueprint): use defined Kraus word-span notation

### DIFF
--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -379,7 +379,7 @@ Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
     For a finite Kraus family $K_0,\ldots,K_{d-1}\in\MN{D}$ and
     $N\in\mathbb N$, define
     \begin{align}
-        S_N(K)&=\Span\{K_{i_1}\cdots K_{i_N}:0\leq i_j<d\}.
+        S_N(K)&=\operatorname{span}\{K_{i_1}\cdots K_{i_N}:0\leq i_j<d\}.
         \notag
     \end{align}
     The empty product is the identity matrix.


### PR DESCRIPTION
## Summary

Replace the undefined `\Span` control sequence in the exact Kraus word-span definition by the standard `\operatorname{span}` notation used elsewhere in the blueprint.

The change repairs the standalone Blueprint failure in run 32329641028. It does not alter the mathematical statement.

## Validation

- `leanblueprint pdf` (1,114-page PDF completed)
- `leanblueprint web`
- `git diff --check`