### PR TITLE
docs(kraus): add eventual vector-spread blueprint

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
@@ -15,6 +15,60 @@ For a word $\sigma=(\sigma_0,\ldots,\sigma_{m-1})\in I^m$, write
 \end{align}
 The empty product is the identity matrix.
 
+\begin{definition}[Eventually full vector spread]
+    \label{def:kraus_eventually_full_vector_spread}
+    \lean{Kraus.HasEventuallyFullVectorSpread}
+    \leanok
+    \uses{def:vector_spread_span}
+    For $\psi\in\C^D$ and $m\in\mathbb N$, define
+    \begin{align}
+        \mathcal H_m(K,\psi)
+        &=\operatorname{span}\{K_\sigma\psi:\sigma\in I^m\}.
+        \notag
+    \end{align}
+    The Kraus family has eventually full vector spread if, for every
+    sufficiently large $m$ and every nonzero $\psi\in\C^D$,
+    $\mathcal H_m(K,\psi)=\C^D$.
+\end{definition}
+
+\begin{theorem}[Full word span gives full vector spread]
+    \label{thm:kraus_vector_spread_of_word_span}
+    \lean{Kraus.vectorSpreadSpan_eq_top_of_wordSpan_eq_top}
+    \leanok
+    \uses{def:kraus_exact_word_span,def:vector_spread_span}
+    If $\mathcal S_m=\MN{D}$, then
+    $\mathcal H_m(K,\psi)=\C^D$ for every nonzero $\psi\in\C^D$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Choose $k$ with $\psi_k\neq0$. For $v\in\C^D$, the matrix
+    \begin{align}
+        X&=\sum_{j=0}^{D-1}\frac{v_j}{\psi_k}E_{jk}
+        \notag
+    \end{align}
+    satisfies $X\psi=v$. Hence the map $X\mapsto X\psi$ from $\MN{D}$ to
+    $\C^D$ is surjective. If $\mathcal S_m=\MN{D}$, its image is precisely
+    $\mathcal H_m(K,\psi)$.
+\end{proof}
+
+\begin{theorem}[Eventually full word span gives eventual vector spread]
+    \label{thm:kraus_eventually_full_vector_spread_of_word_span}
+    \lean{Kraus.hasEventuallyFullVectorSpread_of_hasEventuallyFullWordSpan}
+    \leanok
+    \uses{def:kraus_eventually_full_word_span,
+        def:kraus_eventually_full_vector_spread}
+    If $\mathcal S_m=\MN{D}$ for every sufficiently large $m$, then the
+    Kraus family has eventually full vector spread.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_vector_spread_of_word_span}
+    Apply Theorem~\ref{thm:kraus_vector_spread_of_word_span} at every
+    sufficiently large length.
+\end{proof}
+
 \begin{theorem}[Positive-definite Choi matrix at a fixed iterate]
     \label{thm:kraus_iterate_choi_posdef_iff_word_span}
     \lean{Kraus.choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top}
@@ -71,4 +125,23 @@ The empty product is the identity matrix.
     Apply
     Equation~\eqref{eq:kraus_iterate_choi_posdef_iff_word_span} pointwise for
     every sufficiently large $m$.
+\end{proof}
+
+
+\begin{theorem}[Eventual Choi positivity gives eventual vector spread]
+    \label{thm:kraus_eventually_full_vector_spread_of_choi_posdef}
+    \lean{Kraus.hasEventuallyFullVectorSpread_of_eventually_choiMatrix_mapLM_pow_posDef}
+    \leanok
+    \uses{def:kraus_eventually_full_vector_spread}
+    If $\tau_{E^m}>0$ for every sufficiently large $m$, then the Kraus family
+    has eventually full vector spread.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{cor:kraus_iterate_eventual_choi_posdef,
+        thm:kraus_eventually_full_vector_spread_of_word_span}
+    Corollary~\ref{cor:kraus_iterate_eventual_choi_posdef} gives
+    $\mathcal S_m=\MN{D}$ for every sufficiently large $m$. Apply
+    Theorem~\ref{thm:kraus_eventually_full_vector_spread_of_word_span}.
 \end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_kraus_iterate_choi.tex
@@ -22,13 +22,14 @@ The empty product is the identity matrix.
     \uses{def:vector_spread_span}
     For $\psi\in\C^D$ and $m\in\mathbb N$, define
     \begin{align}
-        \mathcal H_m(K,\psi)
+        H_m(K,\psi)
         &=\operatorname{span}\{K_\sigma\psi:\sigma\in I^m\}.
         \notag
     \end{align}
     The Kraus family has eventually full vector spread if, for every
     sufficiently large $m$ and every nonzero $\psi\in\C^D$,
-    $\mathcal H_m(K,\psi)=\C^D$.
+    $H_m(K,\psi)=\C^D$. This is
+    \cite[Theorem~6.8(2)]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{theorem}[Full word span gives full vector spread]
@@ -37,7 +38,7 @@ The empty product is the identity matrix.
     \leanok
     \uses{def:kraus_exact_word_span,def:vector_spread_span}
     If $\mathcal S_m=\MN{D}$, then
-    $\mathcal H_m(K,\psi)=\C^D$ for every nonzero $\psi\in\C^D$.
+    $H_m(K,\psi)=\C^D$ for every nonzero $\psi\in\C^D$.
 \end{theorem}
 
 \begin{proof}
@@ -49,7 +50,7 @@ The empty product is the identity matrix.
     \end{align}
     satisfies $X\psi=v$. Hence the map $X\mapsto X\psi$ from $\MN{D}$ to
     $\C^D$ is surjective. If $\mathcal S_m=\MN{D}$, its image is precisely
-    $\mathcal H_m(K,\psi)$.
+    $H_m(K,\psi)$.
 \end{proof}
 
 \begin{theorem}[Eventually full word span gives eventual vector spread]


### PR DESCRIPTION
## What changed

- define eventual full vector spread in the blueprint as Wolf, Theorem 6.8, item 2
- record the fixed-length and eventual implications from full Kraus-word span
- record the implication from eventual positive-definite Choi iterates
- connect the four formalized declarations to the existing word-span and Choi-positivity dependency chain
- use the established $H_m(K,\psi)$ notation throughout and cite Wolf, Theorem 6.8(2), explicitly

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD` (7,998/7,998 entries in sync)
- focused LuaLaTeX/BibTeX build of `ch16_channel_representations_kraus_iterate_choi.tex`: 3 pages, no undefined references or citations
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`

Local `leanblueprint checkdecls` reached the strict Lean checker but the shared warm `TNLean.olean` had an incompatible header. Hosted CI runs the checker after its complete Lean build.

Closes LionSR/QICLean#343.
Advances LionSR/QICLean#332 and LionSR/TNLean#6560.