### PR TITLE
docs(wielandt): retain rank-one span source pointer

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -96,7 +96,10 @@ theorem vectorSpreadSpan_eq_top_of_cumulativeVectorSpan_eq_top_of_eigenvector
   Kraus.vectorSpreadSpan_eq_top_of_cumulativeVectorSpan_eq_top_of_eigenvector
     A φ n i₀ μ hμ heig htop
 
-/-- Vector spanning and a basis of rank-one operators imply full matrix spanning. -/
+/-- Vector spanning and a basis of rank-one operators imply full matrix spanning.
+
+The channel-generic statement `Kraus.wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis`
+records the connection with arXiv:0909.5347, Lemma 2(b). -/
 theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis
     (A : MPSTensor d D) (φ : Fin D → ℂ) {n m : ℕ}
     (hVec : vectorSpreadSpan A φ n = ⊤)


### PR DESCRIPTION
## Summary

Restore a discoverable source pointer on the MPS-facing rank-one span theorem after its channel-generic proof moved to namespace `Kraus` in LionSR/TNLean#6650.

The canonical Kraus theorem remains the single source of the detailed paper comparison and Fitting-extraction discussion. This compatibility docstring now directs downstream readers to that theorem and identifies arXiv:0909.5347, Lemma 2(b).

No declaration, statement, or proof changes.

## Validation

- `lake build TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan` (2,720 jobs)
- `git diff --check`

Follow-up to LionSR/TNLean#6650.
Advances LionSR/QICLean#340.
