### PR TITLE
refactor(wielandt): clarify eigenvector theorem dependencies

### DIFF
--- a/TNLean/Kraus/Wielandt/RankOne/Products.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Products.lean
@@ -23,6 +23,9 @@ variable {d D : ℕ}
 /-- If an exact word span is full, some word of length at most `D ^ 2` evaluates to a matrix with
 a nonzero eigenvalue and a corresponding nonzero eigenvector.
 
+The coarse length bound and exact-span hypothesis are inherited from
+`exists_nonzero_trace_word`, where their relation to the paper is documented.
+
 Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
 theorem exists_word_eigenvector [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ}

--- a/TNLean/Wielandt/RankOne/Products.lean
+++ b/TNLean/Wielandt/RankOne/Products.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Kraus.Wielandt.RankOne.Products
-import TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct
+import TNLean.Kraus.Injectivity
 
 /-!
 # Eigenvectors from Wielandt word products


### PR DESCRIPTION
## Summary

Apply two review improvements that were prepared while LionSR/TNLean#6662 was merging:

- import `TNLean.Kraus.Injectivity` directly in the MPS compatibility module, since its remaining tensor-specific hypothesis is `IsNormal`
- point the Kraus eigenvector theorem to `exists_nonzero_trace_word`, where the coarse length bound and exact-span hypothesis are compared with arXiv:0909.5347

No declaration, theorem statement, or proof changes.

## Validation

- replayed onto current `main`
- `lake build TNLean.Kraus.Wielandt.RankOne.Products TNLean.Wielandt.RankOne.Products` (3,009 jobs)
- `git diff --check origin/main...HEAD`

Follow-up to LionSR/TNLean#6662.
Advances LionSR/QICLean#340.
