### PR TITLE
fix(mps): preserve trace-transfer lemma API

### DIFF
--- a/TNLean/MPS/Core/TransferChannel.lean
+++ b/TNLean/MPS/Core/TransferChannel.lean
@@ -85,7 +85,7 @@ namespace MPSTensor
 variable {d : ℕ}
 
 /-- The standard transfer map preserves trace for a trace-preserving Kraus family. -/
-theorem trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
+lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
     (hA : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     Matrix.trace (transferMap (d := d) (D := D) A Z) = Matrix.trace Z := by
   rw [← Kraus.mapLM_eq_transferMap]

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.OperatorNormFrobenius
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Spectral.TransferOperatorGapCommon


### PR DESCRIPTION
## What changed

- restore `MPSTensor.trace_transferMap` from `theorem` to `lemma`, preserving its pre-#6670 declaration classification and matching `lem:trace_transfer_map_left_canonical`
- import `TNLean.MPS.Core.TransferChannel` directly in `GramConvergence`, which calls `trace_transferMap` and should not rely on the unrelated `TransferOperatorGapCommon` import path
- audit every other direct caller; no additional import changes are needed because those callers already receive the declaration through the feature modules they directly depend on

## Review follow-up

Addresses the two post-merge LionSR/TNLean#6670 findings:

- https://github.com/LionSR/TNLean/pull/6670#discussion_r3819154038
- https://github.com/LionSR/TNLean/pull/6670#discussion_r3819184014

## Validation

- `lake build TNLean.MPS.Core.TransferChannel TNLean.MPS.ParentHamiltonian.GramConvergence` (3149 jobs)
- import-direction check: 480 files, 0 violations
- reader-facing prose check: pass
- generated import aggregators: 58 files cover 1475 production modules
- `git diff --check`: pass
- changed-file proof-integrity scan: 0 forbidden tokens
- rebase range-diff: patch-identical onto current main

No cache fetch or full build was run.

Advances LionSR/QICLean#341 and LionSR/TNLean#6560.
