### PR TITLE
refactor(Kraus): remove unused gauge locals

### DIFF
--- a/TNLean/Kraus/MixedMap/GaugeRigidity.lean
+++ b/TNLean/Kraus/MixedMap/GaugeRigidity.lean
@@ -347,11 +347,6 @@ theorem mapLM_congruence_fixedPoint_of_gauge_fixedPoint
     (hσ : mapLM (gaugeFamily S A) σ = σ) :
     mapLM A (S * σ * Sᴴ) = S * σ * Sᴴ := by
   let A' : Fin d → Matrix (Fin D) (Fin D) ℂ := gaugeFamily S A
-  have hSh_det : (Sᴴ).det ≠ 0 := by
-    simpa [Matrix.det_conjTranspose] using star_ne_zero.mpr hS.ne_zero
-  have hSh_u : IsUnit (Sᴴ).det := Ne.isUnit hSh_det
-  have hSh_inv_mul : (Sᴴ)⁻¹ * Sᴴ = (1 : Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.nonsing_inv_mul Sᴴ hSh_u
   have hAiS : ∀ i : Fin d, A i * S = S * A' i := by
     intro i
     simpa [A', gaugeFamily, Matrix.mul_assoc] using


### PR DESCRIPTION
## What changed

- remove the unused local facts `hSh_det`, `hSh_u`, and `hSh_inv_mul` from `mapLM_congruence_fixedPoint_of_gauge_fixedPoint`
- leave the theorem statement and proof behavior unchanged

Follow-up to the late review finding on merged PR LionSR/TNLean#6665: https://github.com/LionSR/TNLean/pull/6665#discussion_r3819144203

Advances LionSR/QICLean#341 and LionSR/TNLean#6560.

## Validation

- `lake build TNLean.Kraus.MixedMap.GaugeRigidity`
- `lake build lint_style && lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root . --base-ref origin/main`
- `git diff --check origin/main -- TNLean/Kraus/MixedMap/GaugeRigidity.lean`
