### PR TITLE
fix(mps): import trace transfer owner directly

### DIFF
--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixStabilization
 import TNLean.Algebra.MatrixPosDefTransport
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.TransferMatrix
 

--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Algebra.FinSum
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.SharedInfra.Scaling

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Primitive
+import TNLean.MPS.Core.TransferChannel
 import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.MPVOverlapTrace
 

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
+import TNLean.MPS.Core.TransferChannel
 
 /-!
 # Proposition 3, (a) → (c): Spectral perturbation and conclusion


### PR DESCRIPTION
## What changed

- add a direct `TNLean.MPS.Core.TransferChannel` import to each remaining module that calls `MPSTensor.trace_transferMap`
- cover MPU stabilization, tail virtual Gram bounds, RFP block orthogonality, primitive overlap, and the strongly-irreducible auxiliary proof
- keep ownership in `MPS/Core/TransferChannel` instead of relying on transitive spectral imports

## Validation

- exact scope: five files, one import-only addition per file
- confirmed every changed file directly calls `trace_transferMap`
- import-direction check: 480 files, 0 violations
- generated import aggregators: 58 files cover 1475 production modules
- changed-prose, forbidden-token, and diff checks passed
- no local build was started because multiple Lake builds were already active; hosted CI is authoritative

Follow-up to the downstream-import review on LionSR/TNLean#6670. Complements LionSR/TNLean#6690 without overlapping its lemma-classification or `GramConvergence` fixes, and excludes the `eigenvalue_norm_le_one₂` change owned by LionSR/TNLean#6683.

Advances LionSR/QICLean#341 and LionSR/TNLean#6560.
