### PR TITLE
refactor(spectral): specialize mixed-map power decay

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Analysis.SpectralRadiusPowerDecay
+import TNLean.Kraus.MixedMap.Gap
 import TNLean.Kraus.MixedMap.SpectralRadius
 import TNLean.Spectral.MixedTransfer
 
@@ -92,42 +92,8 @@ theorem mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one
     (h : mixedTransferSpectralRadius₂ A B < 1)
     (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
     Filter.Tendsto (fun n => ((mixedTransferMap₂ A B) ^ n) X)
-      Filter.atTop (nhds 0) := by
-  let V := Matrix (Fin D₁) (Fin D₂) ℂ
-  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) := Module.End.toContinuousLinearMap V
-  let F : V →L[ℂ] V := Φ (mixedTransferMap₂ A B)
-  let : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
-  let : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
-  let : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
-  let : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
-  let : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
-  have : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
-  have hComplete : CompleteSpace (V →L[ℂ] V) :=
-    FiniteDimensional.complete ℂ (V →L[ℂ] V)
-  let : CompleteSpace (V →L[ℂ] V) := hComplete
-  have hSpectralRadius : spectralRadius ℂ F < 1 := by
-    change spectralRadius ℂ
-      (((Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ))
-        (mixedTransferMap₂ A B)) :
-          Matrix (Fin D₁) (Fin D₂) ℂ →L[ℂ] Matrix (Fin D₁) (Fin D₂) ℂ) < 1
-    simpa only [mixedTransferSpectralRadius₂_eq] using h
-  have hF : Filter.Tendsto (fun n => F ^ n) Filter.atTop (nhds 0) :=
-    @_root_.pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
-      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
-      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V))
-      F hSpectralRadius
-  have hEval : Filter.Tendsto (fun n => (F ^ n) X) Filter.atTop (nhds 0) := by
-    apply squeeze_zero_norm' (a := fun n => ‖F ^ n‖ * ‖X‖)
-    · exact Filter.Eventually.of_forall fun n => (F ^ n).le_opNorm X
-    · simpa using (tendsto_norm_zero.comp hF).mul_const ‖X‖
-  have hApply : ∀ n, (F ^ n) X = ((mixedTransferMap₂ A B) ^ n) X := by
-    intro n
-    have hPow :
-        (F ^ n : V →L[ℂ] V) = Φ ((mixedTransferMap₂ A B) ^ n) := by
-      exact (map_pow Φ (mixedTransferMap₂ A B) n).symm
-    rw [hPow]
-    rfl
-  exact hEval.congr hApply
+      Filter.atTop (nhds 0) :=
+  Kraus.mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one A B h X
 
 /-!
 Strict dimension-mismatch consequences are intentionally downstream in


### PR DESCRIPTION
## What changed

- preserve `MPSTensor.mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one`
- prove it by direct specialization of `Kraus.mixedMapLM_pow_tendsto_zero_of_spectralRadius_lt_one`
- remove the duplicated continuous-linear-map and spectral-radius argument
- import both direct theorem owners, `TNLean.Kraus.MixedMap.Gap` and `TNLean.Kraus.MixedMap.SpectralRadius`

## Parent preservation

PRs LionSR/TNLean#6683 and LionSR/TNLean#6694 are merged. This final head is one child commit on exact `main` `de98e794b9c4429292ce0843550fe87eb5b4ea65`. It preserves the removal of `TransferOperatorGapCommon` and the direct Gelfand-formula import. After LionSR/TNLean#6683, `eigenvalue_norm_le_one₂` remains free of `NeZero D₁` and `NeZero D₂` assumptions. The now-unused intermediate `SpectralRadiusPowerDecay` import was removed in response to review.

## Validation

- `lake build TNLean.Spectral.TransferOperatorGapRectNormalized TNLean.Spectral.TransferOperatorGapNT` (8768 jobs)
- import direction: 493 QIC-bound files, 0 violations, 0 namespace-ratchet violations
- generated import aggregators: 60 files covering 1483 production modules
- reader-facing prose check
- forbidden Lean token check and direct proof-integrity scan
- blueprint source sync: 8005/8005 theorem-like entries
- exact one-file scope, parent-invariant checks, and `git diff --check`

Advances LionSR/QICLean#341.
Advances LionSR/TNLean#6560.
