### PR TITLE
refactor(spectral): remove rectangular trace-decay wrapper

### DIFF
--- a/TNLean/Spectral/MPVOverlapDecayRect.lean
+++ b/TNLean/Spectral/MPVOverlapDecayRect.lean
@@ -33,15 +33,6 @@ variable {d D₁ D₂ : ℕ}
 
 local notation "V" => Matrix (Fin D₁) (Fin D₂) ℂ
 
-/-- Rectangular-matrix specialization of
-`ContinuousLinearMap.tendsto_trace_pow_of_tendsto_zero`. -/
-lemma tendsto_trace_pow_of_tendsto_zero_rect
-    (F : V →L[ℂ] V)
-    (hF : Tendsto (fun n ↦ F ^ n) atTop (nhds 0)) :
-    Tendsto (fun n ↦ LinearMap.trace ℂ V ((F ^ n : V →L[ℂ] V) : V →ₗ[ℂ] V))
-      atTop (nhds (0 : ℂ)) :=
-  ContinuousLinearMap.tendsto_trace_pow_of_tendsto_zero F hF
-
 /-- If the rectangular mixed transfer map has spectral radius `< 1`, then `mpvOverlap → 0`. -/
 theorem mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one
     [NeZero D₁] [NeZero D₂]
@@ -74,7 +65,7 @@ theorem mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one
   have htr0 :
       Tendsto (fun n => LinearMap.trace ℂ V ((F' ^ n : V →L[ℂ] V) : V →ₗ[ℂ] V))
         atTop (nhds (0 : ℂ)) :=
-    tendsto_trace_pow_of_tendsto_zero_rect (D₁ := D₁) (D₂ := D₂) (F := F') hpow0
+    ContinuousLinearMap.tendsto_trace_pow_of_tendsto_zero F' hpow0
   -- Identify `trace(F'^n)` with `trace((mixedTransferMap₂ A B)^n)`.
   have htr0' :
       Tendsto

--- a/docs/audits/2026-08-20_trace_decay_pass_through.md
+++ b/docs/audits/2026-08-20_trace_decay_pass_through.md
@@ -1,0 +1,13 @@
+# Rectangular trace-decay pass-through deletion audit
+
+This cleanup uses the repository-local exact-pass-through exception in
+`docs/MATHLIB_style.md` §Deprecation.
+
+| Removed declaration | Direct replacement |
+|---|---|
+| `MPSTensor.tendsto_trace_pow_of_tendsto_zero_rect` | `ContinuousLinearMap.tendsto_trace_pow_of_tendsto_zero` |
+
+The removed public theorem was an exact pass-through wrapper with no independent
+mathematical content. Its sole non-Archive Lean use now calls the replacement
+directly. A repository-wide exact-name search found no remaining non-Archive use
+or blueprint `\lean{...}` tag for the removed declaration.


### PR DESCRIPTION
## What changed

- Delete the public exact pass-through wrapper `MPSTensor.tendsto_trace_pow_of_tendsto_zero_rect` from `TNLean/Spectral/MPVOverlapDecayRect.lean`.
- Replace its sole use with the canonical `ContinuousLinearMap.tendsto_trace_pow_of_tendsto_zero` theorem.
- Keep the direct `TNLean.Analysis.OperatorNormConvergence` import and preserve every public rectangular MPV decay theorem.
- Record the deletion and replacement in `docs/audits/2026-08-20_trace_decay_pass_through.md`.

This removal explicitly uses the repository-local exact-pass-through exception in `docs/MATHLIB_style.md` §Deprecation. The deleted public theorem only forwarded to the existing continuous-linear-map theorem, had one non-Archive consumer, and had no blueprint tag.

The reviewed two-file child was replayed onto exact `main` after LionSR/TNLean#6694 merged. `git range-diff` reports both child commits unchanged, and the old and new child diffs have the same stable patch ID and byte-identical binary patch.

## Validation

- Prior patch-identical `lake build TNLean.Spectral.MPVOverlapDecayRect` passed at 3060 jobs, and the prior hosted full build passed. A duplicate local build was not started after transplant because another active build owned the `TNLean.Spectral` cone.
- `python3 scripts/generate_import_aggregators.py --root . --check` (59 generated files, 1482 production modules)
- `python3 scripts/check_import_direction.py --root . --base-ref origin/main` (491 files, 0 import-direction violations, 0 namespace-ratchet violations)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --warn-missing-blueprint --changed-files TNLean/Spectral/MPVOverlapDecayRect.lean --diff-base origin/main --diff-head HEAD` (8004/8004 source sync; one expected reverse-coverage warning for the surviving untagged theorem)
- wrapper reference scan: 0 remaining active Lean or blueprint references
- exact two-file scope, audit mapping, trust-token scan, and `git diff --check`

Advances LionSR/QICLean#341.
Advances LionSR/TNLean#6560.
