### PR TITLE
fix(qic): normalize blueprint report paths

### DIFF
--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -36,6 +36,11 @@ LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
 USES_RE = re.compile(r"\\uses\{([^}]*)\}", re.DOTALL)
 
 
+def normalized_relative_path(path: str) -> str:
+    """Return a repository-relative path with platform-independent separators."""
+    return path.replace("\\", "/")
+
+
 def blueprint_content_files(blueprint_src: Path) -> list[Path]:
     """Return theorem-bearing blueprint files in stable order."""
     files = list((blueprint_src / "chapter").glob("*.tex"))
@@ -102,13 +107,18 @@ def boundary_report(root: Path) -> dict[str, object]:
 
     parsed_environments = environment_uses(root / "blueprint" / "src")
     label_by_location = {
-        (str(item["file"]), int(item["line"]), str(item["environment"])): str(item["label"])
+        (
+            normalized_relative_path(str(item["file"])),
+            int(item["line"]),
+            str(item["environment"]),
+        ): str(item["label"])
         for item in parsed_environments
     }
     grouped: dict[tuple[str, int, str | None, str], list[str]] = defaultdict(list)
     for entry in collect_blueprint_entries(root / "blueprint" / "src"):
-        label = entry.label or label_by_location.get((entry.file, entry.line, entry.env_type))
-        grouped[(entry.file, entry.line, label, entry.env_type)].append(entry.lean_decl)
+        file = normalized_relative_path(entry.file)
+        label = entry.label or label_by_location.get((file, entry.line, entry.env_type))
+        grouped[(file, entry.line, label, entry.env_type)].append(entry.lean_decl)
 
     items: list[dict[str, object]] = []
     disposition_by_label: dict[str, str] = {}
@@ -121,8 +131,9 @@ def boundary_report(root: Path) -> dict[str, object]:
             if declaration is None:
                 unresolved.append(name)
                 continue
-            sources.append(declaration.file)
-            moving.append(declaration.file in movers)
+            declaration_file = normalized_relative_path(declaration.file)
+            sources.append(declaration_file)
+            moving.append(declaration_file in movers)
         if unresolved:
             disposition = "unresolved"
         elif moving and all(moving):

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -9,7 +9,11 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from qic_blueprint_boundary_report import boundary_report, environment_uses
+from qic_blueprint_boundary_report import (
+    boundary_report,
+    environment_uses,
+    normalized_relative_path,
+)
 
 
 class QICBlueprintBoundaryReportTests(unittest.TestCase):
@@ -34,6 +38,12 @@ class QICBlueprintBoundaryReportTests(unittest.TestCase):
 
     def write_blueprint(self, text: str) -> None:
         (self.root / "blueprint" / "src" / "chapter" / "ch01.tex").write_text(text)
+
+    def test_normalized_relative_path_accepts_windows_separators(self) -> None:
+        self.assertEqual(
+            normalized_relative_path(r"TNLean\Channel\Basic.lean"),
+            "TNLean/Channel/Basic.lean",
+        )
 
     def test_environment_uses_parses_multiline_payload(self) -> None:
         self.write_blueprint(
@@ -96,7 +106,10 @@ Body.
             [(edge["source"], edge["target"]) for edge in report["tn_to_qic_interface_edges"]],
             [("thm:tn", "thm:qic")],
         )
-        self.assertEqual(json.dumps(report, sort_keys=True), json.dumps(second_report, sort_keys=True))
+        self.assertEqual(
+            json.dumps(report, sort_keys=True),
+            json.dumps(second_report, sort_keys=True),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- normalize declaration and blueprint paths to POSIX separators before mover membership checks and location joins
- add a Windows-separator regression test
- wrap the existing determinism assertion to the project line limit

This addresses the substantive portability finding in #6695 review comment https://github.com/LionSR/TNLean/pull/6695#discussion_r3819539843.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py -v`
- `PYTHONPATH=scripts python3 scripts/qic_blueprint_boundary_report.py --root .` (483 mover paths on exact main)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- `git diff --check`
- no lines over 100 characters in the changed Python files

No Lean or Lake build was run, and no cache was fetched or copied.

Advances #6622 and #6560.
