### PR TITLE
refactor(kraus): own full rank-one extraction

### DIFF
--- a/TNLean/Kraus/Wielandt/RankOne.lean
+++ b/TNLean/Kraus/Wielandt/RankOne.lean
@@ -12,4 +12,5 @@ import TNLean.Kraus.Wielandt.RankOne.BoundedWord
 import TNLean.Kraus.Wielandt.RankOne.Construction
 import TNLean.Kraus.Wielandt.RankOne.Element
 import TNLean.Kraus.Wielandt.RankOne.Extraction
+import TNLean.Kraus.Wielandt.RankOne.ExtractionFull
 import TNLean.Kraus.Wielandt.RankOne.Products

--- a/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixMulRange
+import TNLean.Kraus.Blocking
+import TNLean.Kraus.Wielandt.RankOne.BoundedWord
+import TNLean.Kraus.Wielandt.RankOne.Construction
+import TNLean.Kraus.Wielandt.RankOne.Element
+import TNLean.Kraus.Wielandt.RankOne.Extraction
+
+/-!
+# Full rank-one extraction for finite matrix families
+
+This module constructs the bounded rank-one element used in Sanz, Pérez-García,
+Wolf, and Cirac, arXiv:0909.5347, Lemma 2(b), for an arbitrary finite family of
+square matrices whose fixed-length word span is full.
+-/
+
+open scoped Matrix
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- A power of one matrix in a finite family belongs to the corresponding word span. -/
+theorem pow_single_mem_wordSpan
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (i : Fin d) :
+    (K i) ^ D ∈ wordSpan K D := by
+  have heq : K i = MPSTensor.evalWord K [i] := by simp [MPSTensor.evalWord]
+  have hmem :
+      (MPSTensor.evalWord K [i]) ^ D ∈
+        wordSpan K (D * ([i] : List (Fin d)).length) :=
+    evalWord_pow_mem_wordSpan K [i] D
+  rw [show D * ([i] : List (Fin d)).length = D from by simp] at hmem
+  rwa [← heq] at hmem
+
+private structure BlockedTensorRangeData
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ)
+    (σ₀ τ₀ : Fin L → Fin d) (φ ψ : Fin D → ℂ) where
+  B : Fin (MPSTensor.blockPhysDim d L) → Matrix (Fin D) (Fin D) ℂ
+  P : Matrix (Fin D) (Fin D) ℂ
+  Q : Matrix (Fin D) (Fin D) ℂ
+  hB : B = MPSTensor.blockTensor K L
+  hP : P ∈ wordSpan B D
+  hQ : Q ∈ wordSpan B D
+  hφ_range : φ ∈ LinearMap.range (Matrix.toLin' P)
+  hψ_range : ψ ∈ LinearMap.range (Q.vecMulLinear)
+
+private noncomputable def blockedTensorRangeData
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ)
+    (σ₀ τ₀ : Fin L → Fin d) (φ ψ : Fin D → ℂ) (μ ν : ℂ)
+    (hμ : μ ≠ 0) (hν : ν ≠ 0)
+    (heigφ : MPSTensor.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ)
+    (heigψ : (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ) :
+    BlockedTensorRangeData K L σ₀ τ₀ φ ψ := by
+  let B := MPSTensor.blockTensor K L
+  let i₀ : Fin (MPSTensor.blockPhysDim d L) :=
+    (MPSTensor.decodeBlockEquiv d L).symm σ₀
+  let i₁ : Fin (MPSTensor.blockPhysDim d L) :=
+    (MPSTensor.decodeBlockEquiv d L).symm τ₀
+  have hBi₀ : B i₀ = MPSTensor.evalWord K (List.ofFn σ₀) := by
+    simp [B, i₀, MPSTensor.blockTensor, MPSTensor.wordOfBlock]
+  have hBi₁ : B i₁ = MPSTensor.evalWord K (List.ofFn τ₀) := by
+    simp [B, i₁, MPSTensor.blockTensor, MPSTensor.wordOfBlock]
+  refine
+    { B := B
+      P := (B i₀) ^ D
+      Q := (B i₁) ^ D
+      hB := rfl
+      hP := pow_single_mem_wordSpan B i₀
+      hQ := pow_single_mem_wordSpan B i₁
+      hφ_range := ?_
+      hψ_range := ?_ }
+  · simpa [hBi₀] using
+      MPSTensor.mem_range_toLin'_pow_of_eigenvector
+        (M := MPSTensor.evalWord K (List.ofFn σ₀)) (φ := φ) (μ := μ) hμ heigφ
+  · simpa [hBi₁] using
+      MPSTensor.mem_range_vecMulLinear_pow_of_transpose_eigenvector
+        (M := MPSTensor.evalWord K (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ
+
+private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top
+    {K : Fin d → Matrix (Fin D) (Fin D) ℂ} {L : ℕ}
+    {σ₀ τ₀ : Fin L → Fin d} {φ ψ : Fin D → ℂ}
+    (data : BlockedTensorRangeData K L σ₀ τ₀ φ ψ)
+    {N : ℕ} (htop : wordSpan data.B N = ⊤) :
+    Matrix.vecMulVec φ ψ ∈ wordSpan data.B (D + N + D) := by
+  have hrange_le :
+      LinearMap.range
+          ((LinearMap.mulLeft ℂ data.P).comp (LinearMap.mulRight ℂ data.Q)) ≤
+        wordSpan data.B (D + N + D) := by
+    rw [← biRectSpan_eq_range_of_wordSpan_eq_top data.P data.Q data.B htop]
+    exact biRectSpan_le_wordSpan data.B data.P data.Q data.hP data.hQ
+  exact hrange_le (Matrix.vecMulVec_mem_range_mulLeft_mulRight
+    data.P data.Q φ ψ data.hφ_range data.hψ_range)
+
+/-- **Full rank-one extraction for Wielandt Lemma 2(b).**
+
+A positive level at which a finite matrix family's word span is full yields
+nonzero right and transpose eigenvectors and a rank-one element in a bounded
+word span of the blocked family. -/
+theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N₀ : ℕ}
+    (hN₀ : wordSpan K N₀ = ⊤) (hN₀pos : 0 < N₀) :
+    ∃ (σ₀ τ₀ : Fin N₀ → Fin d)
+      (φ ψ : Fin D → ℂ) (μ ν : ℂ) (m_blocked : ℕ),
+      φ ≠ 0 ∧ ψ ≠ 0 ∧ μ ≠ 0 ∧ ν ≠ 0 ∧
+      MPSTensor.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ ∧
+      (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ ∧
+      Matrix.vecMulVec φ ψ ∈
+        wordSpan (MPSTensor.blockTensor K N₀) m_blocked := by
+  classical
+  obtain ⟨σ₀, μ, φ, hμ, hφ, heigφ⟩ :=
+    exists_eigenvector_of_wordSpan_eq_top K hN₀
+  have hN₀T : wordSpan (transposeFamily K) N₀ = ⊤ :=
+    wordSpan_transposeFamily_eq_top_of_wordSpan_eq_top K hN₀
+  obtain ⟨τ₀', ν, ψ, hν, hψ, heigψ'⟩ :=
+    exists_eigenvector_of_wordSpan_eq_top (transposeFamily K) hN₀T
+  let τ₀ : Fin N₀ → Fin d := τ₀' ∘ Fin.rev
+  have hτ₀_eq : List.ofFn τ₀ = (List.ofFn τ₀').reverse :=
+    (List.ofFn_reverse τ₀').symm
+  have heigψ : (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ := by
+    rw [hτ₀_eq, evalWord_transpose K (List.ofFn τ₀').reverse, List.reverse_reverse]
+    exact heigψ'
+  let data := blockedTensorRangeData K N₀ σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ
+  have hBtop : wordSpan data.B N₀ = ⊤ := by
+    have hInjective : MPSTensor.IsInjective (MPSTensor.blockTensor K N₀) :=
+      (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective K N₀).mp hN₀
+    have hB1 : wordSpan data.B 1 = ⊤ := by
+      rw [wordSpan_one, data.hB]
+      exact hInjective
+    simpa using wordSpan_top_of_mul data.B hB1 N₀ hN₀pos
+  exact ⟨σ₀, τ₀, φ, ψ, μ, ν, D + N₀ + D,
+    hφ, hψ, hμ, hν, heigφ, heigψ, by
+      simpa [data.hB] using data.rankOne_mem_wordSpan_of_wordSpan_eq_top hBtop⟩
+
+end Kraus

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Kraus.Wielandt.RankOne.ExtractionFull
-import TNLean.Wielandt.RankOne.BoundedWord
 import TNLean.Wielandt.RectangularSpan.Basic
 
 /-!

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -24,9 +24,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-@[deprecated (since := "2026-08-20")] alias
-  pow_single_mem_wordSpan := Kraus.pow_single_mem_wordSpan
-
 /-- **Full rank-one extraction for Wielandt Lemma 2(b).**
 
 Under a positive normality witness, this produces nonzero right and transpose

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Kraus.Wielandt.RankOne.ExtractionFull
+import TNLean.Wielandt.RankOne.BoundedWord
 import TNLean.Wielandt.RectangularSpan.Basic
 
 /-!

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -24,6 +24,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+@[deprecated (since := "2026-08-20")] alias
+  pow_single_mem_wordSpan := Kraus.pow_single_mem_wordSpan
+
 /-- **Full rank-one extraction for Wielandt Lemma 2(b).**
 
 Under a positive normality witness, this produces nonzero right and transpose

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -3,40 +3,15 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.MatrixMulRange
-import TNLean.Kraus.Wielandt.RankOne.Element
-import TNLean.Wielandt.RankOne.BoundedWord
-import TNLean.Wielandt.RankOne.Extraction
+import TNLean.Kraus.Wielandt.RankOne.ExtractionFull
 import TNLean.Wielandt.RectangularSpan.Basic
 
 /-!
-# Full rank-one extraction for Wielandt Lemma 2(b)
+# Full rank-one extraction for MPS tensors
 
-This file closes the final gap in Wielandt's Lemma 2(b) by producing a rank-one
-element `Matrix.vecMulVec φ ψ` inside a bounded word span of a blocked tensor.
-
-## Strategy
-
-1. **Key observation:** When `wordSpan A N₀ = ⊤` (from normality), the identity `I` lies
-   in the span of length-`N₀` word evaluations. Since `tr(I) = D ≠ 0` and trace is linear,
-   at least one length-`N₀` word evaluation has nonzero trace — hence a nonzero eigenvalue.
-
-2. **Blocking at L = N₀:** Setting the blocking length to the normality witness gives
-   single-index eigenvectors of the blocked tensor with nonzero eigenvalues for both the
-   column and row (transpose) sides.
-
-3. **Two-sided range embedding:** Setting `P = M₀^D` and `Q = M₁^D` (powers of the
-   eigenvector words), and using a normality witness `N₁` for the blocked tensor `B`
-   with `wordSpan B N₁ = ⊤`, the rank-one matrix `vecMulVec φ ψ` lies in
-   `wordSpan B (D + N₁ + D)`.
-
-## Main results
-
-The exact-span word and eigenvector inputs are provided by
-`TNLean.Wielandt.RankOne.Extraction`.
-
-- `exists_rankOne_mem_wordSpan_blockTensor`: the rank-one extraction theorem.
-- `wielandt_lemma2b`: the unconditional Lemma 2(b).
+This file preserves the paper-facing MPS rank-one extraction theorem and proves
+Wielandt Lemma 2(b). The finite-family construction is in
+`TNLean.Kraus.Wielandt.RankOne.ExtractionFull`.
 
 ## References
 
@@ -49,97 +24,10 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Linear-algebra lemmas -/
-
-section LinearAlgebraLemmas
-
-/-- `(B i)^D ∈ wordSpan B D`. -/
-theorem pow_single_mem_wordSpan (B : MPSTensor d D) (i : Fin d) :
-    (B i) ^ D ∈ wordSpan B D := by
-  have heq : (B i) = evalWord B [i] := by simp [evalWord]
-  have hmem : (evalWord B [i]) ^ D ∈ wordSpan B (D * ([i] : List (Fin d)).length) :=
-    Kraus.evalWord_pow_mem_wordSpan B [i] D
-  rw [show D * ([i] : List (Fin d)).length = D from by simp] at hmem
-  rwa [← heq] at hmem
-
-private structure BlockedTensorRangeData
-    (A : MPSTensor d D) (L : ℕ) (σ₀ τ₀ : Fin L → Fin d)
-    (φ ψ : Fin D → ℂ) where
-  B : MPSTensor (blockPhysDim d L) D
-  P : Matrix (Fin D) (Fin D) ℂ
-  Q : Matrix (Fin D) (Fin D) ℂ
-  hB : B = blockTensor (d := d) (D := D) A L
-  hP : P ∈ wordSpan B D
-  hQ : Q ∈ wordSpan B D
-  hφ_range : φ ∈ LinearMap.range (Matrix.toLin' P)
-  hψ_range : ψ ∈ LinearMap.range (Q.vecMulLinear)
-
-private noncomputable def blockedTensorRangeData
-    (A : MPSTensor d D) (L : ℕ) (σ₀ τ₀ : Fin L → Fin d)
-    (φ ψ : Fin D → ℂ) (μ ν : ℂ)
-    (hμ : μ ≠ 0) (hν : ν ≠ 0)
-    (heigφ : evalWord A (List.ofFn σ₀) *ᵥ φ = μ • φ)
-    (heigψ : (evalWord A (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ) :
-    BlockedTensorRangeData (d := d) (D := D) A L σ₀ τ₀ φ ψ := by
-  let B : MPSTensor (blockPhysDim d L) D :=
-    blockTensor (d := d) (D := D) A L
-  let i₀ : Fin (blockPhysDim d L) := encodeBlock d L σ₀
-  let i₁ : Fin (blockPhysDim d L) := encodeBlock d L τ₀
-  have hBi₀ : B i₀ = evalWord A (List.ofFn σ₀) := by
-    simpa [B, i₀] using blockTensor_apply_encodeBlock A L σ₀
-  have hBi₁ : B i₁ = evalWord A (List.ofFn τ₀) := by
-    simpa [B, i₁] using blockTensor_apply_encodeBlock A L τ₀
-  refine
-    { B := B
-      P := (B i₀) ^ D
-      Q := (B i₁) ^ D
-      hB := rfl
-      hP := pow_single_mem_wordSpan B i₀
-      hQ := pow_single_mem_wordSpan B i₁
-      hφ_range := ?_
-      hψ_range := ?_ }
-  · simpa [hBi₀] using
-      (mem_range_toLin'_pow_of_eigenvector
-        (M := evalWord A (List.ofFn σ₀)) (φ := φ) (μ := μ) hμ heigφ)
-  · simpa [hBi₁] using
-      (mem_range_vecMulLinear_pow_of_transpose_eigenvector
-        (M := evalWord A (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ)
-
-private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top
-    {A : MPSTensor d D} {L : ℕ} {σ₀ τ₀ : Fin L → Fin d}
-    {φ ψ : Fin D → ℂ}
-    (data : BlockedTensorRangeData (d := d) (D := D) A L σ₀ τ₀ φ ψ)
-    {N : ℕ} (htop : wordSpan data.B N = ⊤) :
-    Matrix.vecMulVec φ ψ ∈ wordSpan data.B (D + N + D) := by
-  have hrange_le :
-      LinearMap.range ((LinearMap.mulLeft ℂ data.P).comp (LinearMap.mulRight ℂ data.Q)) ≤
-        wordSpan data.B (D + N + D) := by
-    rw [← biRectSpan_eq_range_of_wordSpan_eq_top
-      (d := blockPhysDim d L) (D := D) data.P data.Q data.B htop]
-    exact biRectSpan_le_wordSpan (d := blockPhysDim d L) (D := D)
-      data.B data.P data.Q data.hP data.hQ
-  exact hrange_le (Matrix.vecMulVec_mem_range_mulLeft_mulRight
-    data.P data.Q φ ψ data.hφ_range data.hψ_range)
-
-end LinearAlgebraLemmas
-
-/-! ## Main rank-one extraction -/
-
-section RankOneExtraction
-
 /-- **Full rank-one extraction for Wielandt Lemma 2(b).**
 
-Under a positive normality witness `N₀ ≥ 1`, produces all data for the blocked
-fixed-length matrix spanning theorem:
-- word functions `σ₀`, `τ₀` of length `N₀` with eigenvector conditions,
-- `vecMulVec φ ψ ∈ wordSpan (blockTensor A N₀) (D + N₀ + D)`.
-
-The key insight: since `wordSpan A N₀ = ⊤` and `tr(I) = D ≠ 0`, at least one
-length-`N₀` word has nonzero trace, providing eigenvectors on both sides.
-The rank-one matrix is then embedded via the two-sided multiplication map
-`X ↦ P * X * Q`, where `P, Q ∈ wordSpan B D` and the middle factor `X`
-comes from the full blocked word span `wordSpan B N₀ = ⊤`.
-This is the blocked-tensor normality witness used in the `D + N₀ + D` bound. -/
+Under a positive normality witness, this produces nonzero right and transpose
+eigenvectors and a rank-one element in a bounded word span of the blocked tensor. -/
 theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
     (A : MPSTensor d D) {N₀ : ℕ} (hN₀ : IsNBlkInjective A N₀) (hN₀pos : 0 < N₀) :
     ∃ (σ₀ τ₀ : Fin N₀ → Fin d)
@@ -149,74 +37,18 @@ theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
       (evalWord A (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ ∧
       Matrix.vecMulVec φ ψ ∈
         wordSpan (blockTensor (d := d) (D := D) A N₀) m_blocked := by
-  classical
-  set L := N₀
-  have hL : 0 < L := hN₀pos
-  have hN₀_top : wordSpan A N₀ = ⊤ :=
-    (wordSpan_eq_top_iff_isNBlkInjective A N₀).mpr hN₀
-  -- Step 1: Column eigenvector from wordSpan A N₀ = ⊤
-  obtain ⟨σ₀, μ, φ, hμ, hφ, heigφ⟩ :=
-    exists_eigenvector_of_wordSpan_eq_top A hN₀_top
-  -- Step 2: Row eigenvector from wordSpan (transposeTensor A) N₀ = ⊤
-  have hN₀T : IsNBlkInjective (d := d) (D := D) (transposeTensor A) N₀ :=
-    IsNBlkInjective_transposeTensor hN₀
-  have hN₀T_top : wordSpan (transposeTensor A) N₀ = ⊤ :=
-    (wordSpan_eq_top_iff_isNBlkInjective (transposeTensor A) N₀).mpr hN₀T
-  obtain ⟨τ₀', ν, ψ, hν, hψ, heigψ'⟩ :=
-    exists_eigenvector_of_wordSpan_eq_top (transposeTensor A) hN₀T_top
-  -- Convert: evalWord (transposeTensor A) (List.ofFn τ₀') *ᵥ ψ = ν • ψ
-  -- ⟹ (evalWord A (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ  where τ₀ = τ₀' ∘ Fin.rev
-  set τ₀ : Fin L → Fin d := τ₀' ∘ Fin.rev
-  have hτ₀_eq : List.ofFn τ₀ = (List.ofFn τ₀').reverse :=
-    (List.ofFn_reverse τ₀').symm
-  have heigψ : (evalWord A (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ := by
-    rw [hτ₀_eq]
-    -- Goal: (evalWord A (List.ofFn τ₀').reverse)ᵀ *ᵥ ψ = ν • ψ
-    -- By evalWord_transpose: (evalWord A w)ᵀ = evalWord (transposeTensor A) w.reverse
-    rw [evalWord_transpose A (List.ofFn τ₀').reverse, List.reverse_reverse]
-    exact heigψ'
-  let data :=
-    blockedTensorRangeData A L σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ
-  have hBtop : wordSpan data.B N₀ = ⊤ := by
-    have htopNL : wordSpan A (N₀ * L) = ⊤ := by
-      rw [show N₀ * L = L * N₀ from by ring]
-      exact wordSpan_top_of_mul A hN₀_top L hL
-    have hle : wordSpan A (N₀ * L) ≤ wordSpan data.B N₀ := by
-      simpa [data.hB] using wordSpan_le_wordSpan_blockTensor A L N₀
-    exact eq_top_iff.mpr (htopNL ▸ hle)
-  exact ⟨σ₀, τ₀, φ, ψ, μ, ν, D + N₀ + D,
-    hφ, hψ, hμ, hν, heigφ, heigψ, by
-      simpa [L, data.hB] using
-        data.rankOne_mem_wordSpan_of_wordSpan_eq_top hBtop⟩
-
-end RankOneExtraction
-
-/-! ## Unconditional Wielandt Lemma 2(b) -/
-
-section WielandtLemma2b
+  change Kraus.wordSpan A N₀ = ⊤ at hN₀
+  exact Kraus.exists_rankOne_mem_wordSpan_blockTensor A hN₀ hN₀pos
 
 /-- **Wielandt Lemma 2(b), unconditional version.**
 
-For any `IsNormal` MPS tensor `A` with `[NeZero D]`, there exists `N` such that
-`wordSpan A N = ⊤`.
-
-This combines the rank-one extraction with the blocked fixed-length matrix spanning theorem.
-
-Writing `B := blockTensor A N₀` for the positive normality witness `N₀`, the rank-one
-extraction gives
-  `vecMulVec φ ψ ∈ wordSpan B (D + N₀ + D)`, where the middle `N₀` is the
-  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked
-fixed-length matrix spanning then produces
-`wordSpan A ((4D - 2 + N₀) * N₀) = ⊤`.
-
-The bound `N = (4D - 2 + N₀) * N₀` is coarse. -/
+For any normal MPS tensor `A` with positive bond dimension, some fixed-length
+word span is the full matrix algebra. -/
 theorem wielandt_lemma2b [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     ∃ N : ℕ, wordSpan A N = ⊤ := by
   classical
   obtain ⟨N₀, hN₀pos, hN₀⟩ := hN
-  have hN₀_top : wordSpan A N₀ = ⊤ :=
-    (wordSpan_eq_top_iff_isNBlkInjective A N₀).mpr hN₀
   obtain ⟨σ₀, τ₀, φ, ψ, μ, ν, m_blocked,
       hφ, hψ, hμ, hν, heigφ, heigψ, hRankOne⟩ :=
     exists_rankOne_mem_wordSpan_blockTensor A hN₀ hN₀pos
@@ -224,7 +56,5 @@ theorem wielandt_lemma2b [NeZero D]
     wielandt_blocked_assembly A ⟨N₀, hN₀pos, hN₀⟩ N₀ hN₀pos
       σ₀ φ hφ μ hμ heigφ
       τ₀ ψ hψ ν hν heigψ hRankOne⟩
-
-end WielandtLemma2b
 
 end MPSTensor

--- a/docs/audits/2026-08-20_issue6706_extractionfull_pass_through.md
+++ b/docs/audits/2026-08-20_issue6706_extractionfull_pass_through.md
@@ -1,0 +1,14 @@
+# Issue #6706: full rank-one extraction pass-through deletion audit
+
+This cleanup uses the repository-local exact pass-through exception in
+`docs/MATHLIB_style.md` §Deprecation. The removed declaration had no independent
+mathematical content:
+
+- `MPSTensor.pow_single_mem_wordSpan` forwarded exactly to
+  `Kraus.pow_single_mem_wordSpan`.
+
+A repository-wide search found no active TNLean or Archive caller of the old
+name, and no blueprint `\lean{...}` tag cites it. The exact alias therefore
+qualifies for immediate removal under that exception rather than a deprecation
+period. `Kraus.pow_single_mem_wordSpan` remains the canonical theorem and sole
+proof owner.


### PR DESCRIPTION
## What changed

- move the five finite-family rank-one extraction declarations to `Kraus.Wielandt.RankOne.ExtractionFull`
- use the merged Kraus eigenvector, two-sided span, blocking, and matrix-range APIs directly
- preserve `MPSTensor.exists_rankOne_mem_wordSpan_blockTensor` as a direct compatibility theorem
- keep `MPSTensor.wielandt_lemma2b` on the tensor-network-facing surface
- register the new module in the generated Kraus RankOne aggregator
- remove exact pass-through alias `MPSTensor.pow_single_mem_wordSpan` in favor of `Kraus.pow_single_mem_wordSpan`, using the repository-local exact-pass-through exception in `docs/MATHLIB_style.md`; repository-wide search found no active or Archive caller and no blueprint tag for the old name
- do not retain the compatibility-shell import `TNLean.Wielandt.RankOne.BoundedWord`; the focused LionSR/TNLean#6708 audit already documents that shell’s deletion and absence of live consumers

## Validation

- targeted builds for both ExtractionFull modules and `MatrixSpanExistence`
- Kraus and MPS RankOne/Wielandt aggregator builds
- generated-aggregator, import-direction, forbidden-token, changed-prose, proof-integrity, numbered-module, blueprint-sync, and diff checks

Advances LionSR/QICLean#340 and LionSR/TNLean#6560.

Transplanted after LionSR/TNLean#6696 merged onto exact `main` `f1f23f319599f1b3b5ef19e2aa848ef122665a6a`. The original child at `8057b7f867416e4908b34c9f76e7452284e2d088` was range-identical to reviewed head `b54c4fa1719110f596466c3b83f6fe1c2faadb99`. Current head `6251193ba486a28cbd3cb3fa73b3af8b2467df8a` removes both bot regressions: the deprecated exact alias and the compatibility-shell `BoundedWord` import. The required repository-local exception is recorded in `docs/audits/2026-08-20_issue6706_extractionfull_pass_through.md`, while LionSR/TNLean#6708 owns the focused shell-retirement audit.


