### PR TITLE
refactor(kraus): own cumulative-span eigenvector extraction

### DIFF
--- a/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.MatrixNonzeroTraceEigenvalue
 import TNLean.Kraus.Wielandt.SpanGrowth.CumulativeSpan
 
 /-!
@@ -46,6 +47,21 @@ theorem exists_nonzero_trace_word_of_cumulativeSpan_eq_top [NeZero D]
     simp only [Matrix.trace_one, Fintype.card_fin, ne_eq, Nat.cast_eq_zero]
     exact_mod_cast NeZero.ne D
   exact htrI (hzero 1 hI)
+
+/-- Full cumulative span gives a bounded-length word with an eigenvector whose
+eigenvalue is nonzero.
+
+Paper anchor: proof of Theorem 1, case (1) in arXiv:0909.5347. -/
+theorem exists_eigenvector_of_cumulativeSpan_eq_top [NeZero D]
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ}
+    (hcs : cumulativeSpan K N = ⊤) :
+    ∃ (w : List (Fin d)) (μ : ℂ) (φ : Fin D → ℂ),
+      w.length ≤ N ∧ μ ≠ 0 ∧ φ ≠ 0 ∧
+      MPSTensor.evalWord K w *ᵥ φ = μ • φ := by
+  obtain ⟨w, hw, htr⟩ := exists_nonzero_trace_word_of_cumulativeSpan_eq_top K hcs
+  obtain ⟨μ, φ, hμ, hφ, heig⟩ :=
+    _root_.exists_eigenvector_of_trace_ne_zero _ htr
+  exact ⟨w, μ, φ, hw, hμ, hφ, heig⟩
 
 /-- If the identity belongs to the length-`L` word span, then multiplication by
 that identity embeds every length-`n` word span into the length-`n + L` span. -/

--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import TNLean.Kraus.Wielandt.SpanGrowth.CumulativeToWordSpan
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
-import TNLean.Wielandt.RankOne.Products
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.BurnsideTheorem
 
@@ -145,10 +144,7 @@ theorem exists_eigenvector_of_cumulativeSpan_eq_top [NeZero D]
     (A : MPSTensor d D) {N : ℕ} (hcs : cumulativeSpan A N = ⊤) :
     ∃ (w : List (Fin d)) (μ : ℂ) (φ : Fin D → ℂ),
       w.length ≤ N ∧ μ ≠ 0 ∧ φ ≠ 0 ∧
-      evalWord A w *ᵥ φ = μ • φ := by
-  obtain ⟨w, hw, htr⟩ := exists_nonzero_trace_word_of_cumulativeSpan_eq_top A hcs
-  obtain ⟨μ, φ, hμ, hφ, heig⟩ :=
-    _root_.exists_eigenvector_of_trace_ne_zero _ htr
-  exact ⟨w, μ, φ, hw, hμ, hφ, heig⟩
+      evalWord A w *ᵥ φ = μ • φ :=
+  Kraus.exists_eigenvector_of_cumulativeSpan_eq_top A hcs
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -385,6 +385,28 @@ eventual exact-word spanning, and spectral strong irreducibility.
     Hence $T_{D^2-d'+1}(A)=\MN{D}$.
 \end{proof}
 
+\begin{theorem}[Eigenvector extraction from a full cumulative span]
+    \label{thm:eigenvector_from_full_cumulative_span}
+    \lean{Kraus.exists_eigenvector_of_cumulativeSpan_eq_top}
+    \lean{MPSTensor.exists_eigenvector_of_cumulativeSpan_eq_top}
+    \leanok
+    \uses{def:cumulative_span, thm:eigenvector_from_trace}
+    Let $D>0$ and suppose $T_N(K)=\MN{D}$. Then there are a word $w$, a
+    nonzero scalar $\mu$, and a nonzero vector $\varphi\in\C^D$ such that
+    \begin{align}
+        |w| & \le N,
+        & K^w\varphi & =\mu\varphi.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Since the identity lies in $T_N(K)$ and has nonzero trace, some word of
+    length at most $N$ has nonzero trace. Such a matrix has a nonzero
+    eigenvalue and a corresponding nonzero eigenvector by
+    Theorem~\ref{thm:eigenvector_from_trace}.
+\end{proof}
+
 \begin{theorem}[Sharp nonzero trace product for a primitive channel]%
     \label{thm:nonzero_trace_word_primitive_sharp}
     \lean{MPSTensor.exists_nonzero_trace_word_of_isPrimitivePaper_sharp_pos}


### PR DESCRIPTION
## What changed

- add `Kraus.exists_eigenvector_of_cumulativeSpan_eq_top` from the Kraus-owned nonzero-trace word theorem and the matrix eigenvector extractor
- preserve `MPSTensor.exists_eigenvector_of_cumulativeSpan_eq_top` as a direct reformulation
- remove the no-longer-needed tensor-side `RankOne.Products` import

## Validation

- targeted builds: both `CumulativeToWordSpan` modules plus `TNLean.Kraus.Wielandt.SpanGrowth`, `TNLean.Wielandt.SpanGrowth`, `TNLean.Kraus.Wielandt`, and `TNLean.Wielandt`
- generated import aggregators: current, 59 files covering 1477 production modules
- import direction: 485 QIC-bound files, 0 violations
- reader-facing prose: clean
- proof-integrity token gate and explicit changed-file scan: clean
- blueprint-Lean sync: 7997/7997 theorem-like entries
- line length and `git diff --check`: clean

Advances LionSR/QICLean#340 and LionSR/TNLean#6560.

The reviewed head also adds a source-faithful blueprint entry for the canonical Kraus theorem and its MPS reformulation; blueprint–Lean synchronization passes for 8,001/8,001 entries.