### PR TITLE
refactor(kraus): single-source List.ofFn reversal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,7 @@ follow-up, not against the temporary `sorry` count.
 
 | Name | Kind | Use when | Defined in |
 |---|---|---|---|
+| `List.ofFn_reverse` | helper theorem | Reversing a `List.ofFn`-indexed finite word by precomposition with `Fin.rev` | `TNLean/Kraus/Word.lean` |
 | `verticalAssembledTensor_apply_copy_same` | helper theorem | Evaluating an assembled vertical tensor at two coordinates in the same retained multiplicity copy | `TNLean/MPS/MPDO/VerticalSectorCoordinates.lean` |
 | `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_of_openBoundary` | helper theorem | Closing block-diagonal boundaries from an open-boundary representation and a simultaneous span across the complementary global cut | `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean` |
 | `BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace` | helper theorem | Assembling membership in the sum of open-boundary block spaces into one weighted block-diagonal boundary matrix | `TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean` |

--- a/TNLean/Kraus/Blocking.lean
+++ b/TNLean/Kraus/Blocking.lean
@@ -300,21 +300,6 @@ lemma ofFn_blockedConfigEquiv (d N L : ℕ)
   change (List.ofFn fun j : Fin L => decodeBlock d L (σ i) j) = (wordOfBlock d L ∘ σ) i
   simp [wordOfBlock, Function.comp]
 
-private theorem list_ofFn_comp_fin_rev {L : ℕ} {α : Type*} (σ : Fin L → α) :
-    List.ofFn (σ ∘ Fin.rev) = (List.ofFn σ).reverse := by
-  calc
-    List.ofFn (σ ∘ Fin.rev)
-        = List.map (σ ∘ Fin.rev) (List.finRange L) := by
-          simp [List.ofFn_eq_map]
-    _ = List.map σ (List.map Fin.rev (List.finRange L)) := by
-          simp [List.map_map, Function.comp_def]
-    _ = List.map σ (List.finRange L).reverse := by
-          simp [List.finRange_reverse]
-    _ = (List.map σ (List.finRange L)).reverse := by
-          simp [List.map_reverse]
-    _ = (List.ofFn σ).reverse := by
-          simp [List.ofFn_eq_map]
-
 private theorem evalWord_pointwise_conjTranspose_reverse (A : MPSTensor d D) :
     ∀ w : List (Fin d), (evalWord (fun i => (A i)ᴴ) w)ᴴ = evalWord A w.reverse := by
   intro w
@@ -446,7 +431,7 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
             have hword :
                 List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse := by
               simpa [revEquiv, Equiv.arrowCongr, Function.comp_def] using
-                list_ofFn_comp_fin_rev (σ := ρ)
+                (List.ofFn_reverse ρ).symm
             have hAdjEval :
                 (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
                   evalWord A (List.ofFn ρ) := by

--- a/TNLean/Kraus/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Construction.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Fin.Tuple.Basic
-import Mathlib.Data.List.FinRange
 import TNLean.Kraus.Word
 import TNLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
 
@@ -17,22 +16,6 @@ arXiv:0909.5347, Lemma 2(b).
 -/
 
 open scoped Matrix
-
-namespace List
-
-/-- Reversing `List.ofFn` precomposes the indexing function with `Fin.rev`. -/
-theorem ofFn_reverse {n : ℕ} {α : Type*} (f : Fin n → α) :
-    (List.ofFn f).reverse = List.ofFn (f ∘ Fin.rev) := by
-  calc
-    (List.ofFn f).reverse = (List.map f (List.finRange n)).reverse := by
-      simp only [List.ofFn_eq_map]
-    _ = List.map f (List.finRange n).reverse := by simp only [List.map_reverse]
-    _ = List.map f (List.map Fin.rev (List.finRange n)) := by
-      simp only [List.finRange_reverse]
-    _ = List.map (f ∘ Fin.rev) (List.finRange n) := by simp only [List.map_map]
-    _ = List.ofFn (f ∘ Fin.rev) := by simp only [List.ofFn_eq_map]
-
-end List
 
 namespace Kraus
 

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Fin.Tuple.Basic
-import Mathlib.Data.List.FinRange
 import Mathlib.Data.Matrix.Mul
 import TNLean.Kraus.Injectivity
 import TNLean.Kraus.Word
@@ -19,22 +18,6 @@ from Sanz, Pérez-García, Wolf, and Cirac, arXiv:0909.5347, Lemma 2(b).
 -/
 
 open scoped Matrix
-
-namespace List
-
-/-- Reversing `List.ofFn` precomposes the indexing function with `Fin.rev`. -/
-private theorem ofFn_reverse {n : ℕ} {α : Type*} (f : Fin n → α) :
-    (List.ofFn f).reverse = List.ofFn (f ∘ Fin.rev) := by
-  calc
-    (List.ofFn f).reverse = (List.map f (List.finRange n)).reverse := by
-      simp only [List.ofFn_eq_map]
-    _ = List.map f (List.finRange n).reverse := by simp only [List.map_reverse]
-    _ = List.map f (List.map Fin.rev (List.finRange n)) := by
-      simp only [List.finRange_reverse]
-    _ = List.map (f ∘ Fin.rev) (List.finRange n) := by simp only [List.map_map]
-    _ = List.ofFn (f ∘ Fin.rev) := by simp only [List.ofFn_eq_map]
-
-end List
 
 namespace Kraus
 

--- a/TNLean/Kraus/Word.lean
+++ b/TNLean/Kraus/Word.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Fin.Tuple.Basic
+import Mathlib.Data.List.FinRange
 import Mathlib.Data.List.OfFn
 import Mathlib.Data.Matrix.Mul
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
@@ -32,12 +34,29 @@ rely on `MPSTensor` being the head symbol of the argument type.
 
 ## Main declarations
 
+* `List.ofFn_reverse` — reversing `List.ofFn` precomposes its function with `Fin.rev`
 * `MPSTensor` — a `Fin d`-indexed family of `D×D` complex matrices
 * `evalWord` — the matrix product associated with a word of physical indices
 * `evalWord_intertwine` — a rectangular letter intertwiner also intertwines every word
 -/
 
 open scoped Matrix
+
+namespace List
+
+/-- Reversing `List.ofFn` precomposes the indexing function with `Fin.rev`. -/
+theorem ofFn_reverse {n : ℕ} {α : Type*} (f : Fin n → α) :
+    (List.ofFn f).reverse = List.ofFn (f ∘ Fin.rev) := by
+  calc
+    (List.ofFn f).reverse = (List.map f (List.finRange n)).reverse := by
+      simp only [List.ofFn_eq_map]
+    _ = List.map f (List.finRange n).reverse := by simp only [List.map_reverse]
+    _ = List.map f (List.map Fin.rev (List.finRange n)) := by
+      simp only [List.finRange_reverse]
+    _ = List.map (f ∘ Fin.rev) (List.finRange n) := by simp only [List.map_map]
+    _ = List.ofFn (f ∘ Fin.rev) := by simp only [List.ofFn_eq_map]
+
+end List
 
 /-- A (periodic, translation-invariant) tensor generating an MPV family:
 a family of `D×D` matrices indexed by a physical index in `Fin d`.

--- a/TNLean/Kraus/Word.lean
+++ b/TNLean/Kraus/Word.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.FinRange
 import Mathlib.Data.List.OfFn
 import Mathlib.Data.Matrix.Mul

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Kraus.Word
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
 import Mathlib.LinearAlgebra.Matrix.PosDef
@@ -293,20 +294,6 @@ theorem evalWord_adjointTensor (M : MPOTensor d D) :
               (by simp only [List.length_reverse]; exact hlen.symm),
             evalWord_cons, evalWord_nil, Matrix.mul_one, Matrix.conjTranspose_mul]
 
-/-- Reading a configuration through the index reversal `Fin.rev` reverses the
-associated word. -/
-private theorem ofFn_comp_rev {α : Type*} {N : ℕ} (σ : Fin N → α) :
-    List.ofFn (fun k => σ (Fin.rev k)) = (List.ofFn σ).reverse := by
-  apply List.ext_getElem
-  · simp
-  · intro k h1 h2
-    simp only [List.length_ofFn] at h1
-    rw [List.getElem_ofFn, List.getElem_reverse, List.getElem_ofFn]
-    congr 1
-    ext
-    simp only [Fin.val_rev, List.length_ofFn]
-    omega
-
 /-- The adjoint tensor generates the adjoint operator family up to spatial
 reflection: entrywise,
 $H^{(N)}(M^\dagger)_{\sigma\tau}
@@ -319,7 +306,8 @@ theorem mpo_adjointTensor (M : MPOTensor d D) {N : ℕ} (σ τ : Fin N → Fin d
       star (mpo M N (fun k => τ (Fin.rev k)) (fun k => σ (Fin.rev k))) := by
   simp only [mpo_apply, mpoMatrixEntry]
   rw [evalWord_adjointTensor M _ _ (by simp), ← Matrix.trace_conjTranspose,
-    ofFn_comp_rev, ofFn_comp_rev]
+    List.ofFn_reverse τ, List.ofFn_reverse σ]
+  rfl
 
 /-! ### Transfer map -/
 

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Kraus.Word
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SuppliedWitnessReblocking
@@ -57,12 +58,8 @@ noncomputable def blockWordReverseEquiv (d K : ℕ) :
       congr 1
       funext k
       simp
-    _ = List.map (MPSTensor.decodeBlock d K i ∘ Fin.rev) (List.finRange K) := by
-      simp [List.ofFn_eq_map]
-    _ = List.map (MPSTensor.decodeBlock d K i) (List.finRange K).reverse := by
-      simp [List.map_map, Function.comp_def, List.finRange_reverse]
-    _ = (List.ofFn (MPSTensor.decodeBlock d K i)).reverse := by
-      simp [List.ofFn_eq_map, List.map_reverse]
+    _ = (List.ofFn (MPSTensor.decodeBlock d K i)).reverse :=
+      (List.ofFn_reverse (MPSTensor.decodeBlock d K i)).symm
 
 @[simp] theorem blockWordReverseEquiv_involutive
     (i : Fin (MPSTensor.blockPhysDim d K)) :

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -539,6 +539,14 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Reversing `List.ofFn` by `Fin.rev`
+- **Seen:** two former copies in
+  `TNLean/Kraus/Wielandt/RankOne/Construction.lean` and
+  `TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean`.
+- **Abstraction:** `List.ofFn_reverse` in `TNLean/Kraus/Word.lean`.
+- **Result:** both consumers use the shared theorem, reducing the Lean sources by
+  15 lines net.
+
 ### Finite Kraus setup for channels
 - **Seen:** 2 occurrences in `Channel/Peripheral/IrreducibleChannel.lean` and
   `Channel/Semigroup/Primitivity/Helpers.lean` before promotion (issue #6576).

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -540,12 +540,11 @@ abstracted — record why, so it is not re-proposed).
 ## Completed refactors
 
 ### Reversing `List.ofFn` by `Fin.rev`
-- **Seen:** two former copies in
-  `TNLean/Kraus/Wielandt/RankOne/Construction.lean` and
-  `TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean`.
+- **Seen:** five former proofs in `Kraus.Blocking`, `Kraus.Wielandt.RankOne.Construction`,
+  `Kraus.Wielandt.RectangularSpan.Basic`, `MPS.MPDO.Defs`, and
+  `MPS.MPU.SourceUReflectedKernel`.
 - **Abstraction:** `List.ofFn_reverse` in `TNLean/Kraus/Word.lean`.
-- **Result:** both consumers use the shared theorem, reducing the Lean sources by
-  15 lines net.
+- **Result:** all five consumers use the shared theorem directly.
 
 ### Finite Kraus setup for channels
 - **Seen:** 2 occurrences in `Channel/Peripheral/IrreducibleChannel.lean` and


### PR DESCRIPTION
## Summary

- place the pure identity `List.ofFn_reverse` in the low-level owner `TNLean.Kraus.Word`
- remove the duplicate public and private Wielandt proofs, plus exact private reproofs in `Kraus.Blocking` and `MPS.MPDO.Defs`
- shorten the specialized blocked-word reversal proof in `MPS.MPU.SourceUReflectedKernel` through the shared theorem
- remove the unnecessary `Mathlib.Data.Fin.Tuple.Basic` import from `Kraus.Word` and record the promoted helper in the tactic ledgers

The repository now has one proof owner and all five former proof sites use it directly.

## Verification

- `lake build TNLean.Kraus.Word TNLean.Kraus.Blocking TNLean.MPS.MPDO.Defs TNLean.MPS.MPU.SourceUReflectedKernel TNLean.Kraus.Wielandt.RankOne.Construction TNLean.Kraus.Wielandt.RectangularSpan.Basic` (9016 jobs)
- `python3 scripts/generate_import_aggregators.py --root . --check` (60 generated files, 1482 production modules)
- `python3 scripts/check_import_direction.py --root . --base-ref ae16a4cb4863595473542b7c2116d80d22ba1f4d` (493 files, 0/0 violations)
- proof-integrity and reader-facing-prose checks
- `python3 scripts/blueprint_lean_sync.py --root . --ci ...` (8005/8005 entries)
- repository-wide unique-owner, blueprint-absence, exact-scope, and `git diff --check` audits

Closes LionSR/QICLean#344.
Advances LionSR/QICLean#340 and LionSR/TNLean#6560.
