### PR TITLE
docs(wielandt): fix cumulative eigenvector blueprint dependencies

### DIFF
--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -390,17 +390,18 @@ eventual exact-word spanning, and spectral strong irreducibility.
     \lean{Kraus.exists_eigenvector_of_cumulativeSpan_eq_top}
     \lean{MPSTensor.exists_eigenvector_of_cumulativeSpan_eq_top}
     \leanok
-    \uses{def:cumulative_span, thm:eigenvector_from_trace}
+    \uses{def:cumulative_span}
     Let $D>0$ and suppose $T_N(K)=\MN{D}$. Then there are a word $w$, a
     nonzero scalar $\mu$, and a nonzero vector $\varphi\in\C^D$ such that
     \begin{align}
-        |w| & \le N,
-        & K^w\varphi & =\mu\varphi.
-        \notag
+        |w| & \le N, \notag\\
+        K^w\varphi & = \mu\varphi. \notag
     \end{align}
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}
+    \leanok
+    \uses{thm:eigenvector_from_trace}
     Since the identity lies in $T_N(K)$ and has nonzero trace, some word of
     length at most $N$ has nonzero trace. Such a matrix has a nonzero
     eigenvalue and a corresponding nonzero eigenvector by


### PR DESCRIPTION
## What changed

- move `thm:eigenvector_from_trace` from the cumulative-span eigenvector theorem dependencies to its proof dependencies
- keep `def:cumulative_span` on the theorem statement
- place the word-length bound and eigenvector equation on separate alignment rows

This is the blueprint-only review follow-up to merged LionSR/TNLean#6707.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`: 8001/8001 entries
- reader-facing prose check: clean
- three successful `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"`; no undefined cross-references, only standalone bibliography warnings
- `git diff --check`: clean
- exact scope: one blueprint source file

No Lean build was run for this blueprint-only repair.

Advances LionSR/QICLean#340 and LionSR/TNLean#6560.