### PR TITLE
refactor(analysis): relocate matrix Fitting corollaries

### DIFF
--- a/TNLean/Analysis/MatrixFittingRange.lean
+++ b/TNLean/Analysis/MatrixFittingRange.lean
@@ -420,7 +420,15 @@ theorem isUnit_restrict_range_pow (f : End ℂ (Fin D → ℂ)) :
     ker_restrict_range_pow_eq_bot (D := D) f
   exact (LinearMap.isUnit_iff_ker_eq_bot (f := f.restrict (mapsTo_range_pow (D := D) f))).2 hker
 
+end WielandtRankOne
+
+end MPSTensor
+
 /-! ## Matrix corollary -/
+
+namespace Matrix
+
+variable {D : ℕ}
 
 /-- Matrix formulation: `Matrix.toLin' M` restricts to an automorphism of
 `range (Matrix.toLin' (M^D))`.
@@ -429,10 +437,11 @@ by A₁ preserves linear independence 'given that A₁ is invertible on its
 range'. -/
 theorem isUnit_restrict_range_toLin'_pow (M : Matrix (Fin D) (Fin D) ℂ) :
     IsUnit ((Matrix.toLin' M).restrict
-      (mapsTo_range_pow (D := D) (f := Matrix.toLin' M))) := by
+      (MPSTensor.WielandtRankOne.mapsTo_range_pow (D := D) (f := Matrix.toLin' M))) := by
   -- Apply the abstract lemma to `f = Matrix.toLin' M`.
   simpa [Matrix.toLin'_pow] using
-    (isUnit_restrict_range_pow (D := D) (f := Matrix.toLin' M))
+    (MPSTensor.WielandtRankOne.isUnit_restrict_range_pow
+      (D := D) (f := Matrix.toLin' M))
 
 /-! ## Pointwise matrix injectivity -/
 
@@ -446,7 +455,7 @@ theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
   classical
   let f : End ℂ (Fin D → ℂ) := Matrix.toLin' M
   have hdisj : Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) :=
-    disjoint_ker_range_pow (D := D) (f := f)
+    MPSTensor.WielandtRankOne.disjoint_ker_range_pow (D := D) (f := f)
   have hv' : v ∈ LinearMap.range (f ^ D) := by
     simpa only [f, Matrix.toLin'_pow] using hv
   have hker : v ∈ LinearMap.ker f := by
@@ -461,7 +470,7 @@ theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
 /-- Matrix-level injectivity on the range of left multiplication by `M^D`.
 
 If `X ∈ range (mulLeft (M^D))` and `M * X = 0`, then `X = 0`. -/
-theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+theorem eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
     (M : Matrix (Fin D) (Fin D) ℂ) {X : Matrix (Fin D) (Fin D) ℂ}
     (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ (M ^ D)))
     (hMX : M * X = 0) : X = 0 := by
@@ -494,6 +503,4 @@ theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
   simpa [hzero] using hcol0 j
 
 
-end WielandtRankOne
-
-end MPSTensor
+end Matrix

--- a/TNLean/Analysis/MatrixFittingRange.lean
+++ b/TNLean/Analysis/MatrixFittingRange.lean
@@ -504,3 +504,18 @@ theorem eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
 
 
 end Matrix
+
+namespace MPSTensor.WielandtRankOne
+
+@[deprecated Matrix.isUnit_restrict_range_toLin'_pow (since := "2026-08-20")]
+alias isUnit_restrict_range_toLin'_pow := Matrix.isUnit_restrict_range_toLin'_pow
+
+@[deprecated Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow (since := "2026-08-20")]
+alias vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow :=
+  Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
+
+@[deprecated Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow (since := "2026-08-20")]
+alias matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow :=
+  Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+
+end MPSTensor.WielandtRankOne

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Growth.lean
@@ -84,7 +84,7 @@ theorem rectSpanLeftStep_injective (n : ℕ) :
   have hzRange : (x.1 - y.1) ∈ LinearMap.range (LinearMap.mulLeft ℂ ((K i₀) ^ D)) :=
     Submodule.sub_mem _ (hrect_le_range x.2) (hrect_le_range y.2)
   have hzero : x.1 - y.1 = 0 :=
-    MPSTensor.WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+    Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
       (D := D) (M := K i₀) (X := x.1 - y.1) hzRange hz
   exact Subtype.ext (by simpa [sub_eq_zero] using hzero)
 

--- a/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
@@ -85,7 +85,7 @@ private theorem matrix_eq_zero_of_mul_nilpIndex
     (hMX : (K i₀) * X = 0) : X = 0 := by
   have hXD : X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((K i₀) ^ D)) :=
     range_mulLeft_pow_nilpIndex_eq K i₀ ▸ hX
-  exact MPSTensor.WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+  exact Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
     (D := D) (M := K i₀) (X := X) hXD hMX
 
 /-- Linear map sending `rectSpan ((K i₀)^r) K n` to `rectSpan ((K i₀)^r) K (n+1)`


### PR DESCRIPTION
## What changed

- move the three single-matrix consequences at the end of `MatrixFittingRange.lean` from `MPSTensor.WielandtRankOne` into the `Matrix` namespace
- rename the matrix injectivity theorem to `Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow`
- preserve all three established `MPSTensor.WielandtRankOne` names as deprecated aliases dated `2026-08-20`
- keep both finite-Kraus rectangular-span consumers on the canonical `Matrix` theorem
- retain the preceding endomorphism-level Fitting development in its existing namespace

The moved statements depend only on one matrix and the Fitting decomposition; no tensor family appears in their hypotheses. `Matrix` remains the sole proof owner, while the deprecated names preserve downstream source compatibility.

## Validation

- `lake build TNLean.Analysis.MatrixFittingRange TNLean.Kraus.Wielandt.RectangularSpan.Basic TNLean.Kraus.Wielandt.RectangularSpan.Growth TNLean.Kraus.Wielandt.RectangularSpan.UniversalityAux.NilpIndex TNLean.Kraus.Wielandt.RectangularSpan` (3035 jobs)
- all three canonical names and all three compatibility names resolve with the original statements
- exactly two active consumers of `Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow`; no consumer regressed to an old namespace name
- generated aggregators: 60 files covering 1484 production modules
- import direction: 496 QIC-bound files, 0 import and 0 namespace-ratchet violations
- blueprint source sync: 8028/8028; reverse coverage reports the five pre-existing untagged changed declarations and no synchronization error
- proof-integrity, reader-facing prose, exact-scope, and diff checks

Closes LionSR/QICLean#345. Advances LionSR/QICLean#340 and LionSR/TNLean#6560.
