### PR TITLE
feat(MPS/MPDO): prove Example 4.12 four-site SSA defect

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -90,6 +90,7 @@ import TNLean.MPS.MPDO.CPSVExample411BinarySupport
 import TNLean.MPS.MPDO.CPSVExample411Entropy
 import TNLean.MPS.MPDO.CPSVExample411SourceZCL
 import TNLean.MPS.MPDO.CPSVExample411Spectrum
+import TNLean.MPS.MPDO.CPSVExample412FourCycleEntropy
 import TNLean.MPS.MPDO.CPSVExample412Literal
 import TNLean.MPS.MPDO.CPSVExample412NormalizedRFP
 import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic

--- a/TNLean/MPS/MPDO/CPSVExample412FourCycleEntropy.lean
+++ b/TNLean/MPS/MPDO/CPSVExample412FourCycleEntropy.lean
@@ -1,0 +1,360 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.EntropyDecomposition
+import TNLean.MPS.MPDO.CPSVExample412Literal
+
+/-!
+# The four-site entropy obstruction in CPSV16 Example 4.12
+
+For the literal tensor of CPSV16 Example 4.12, the normalized four-site state is
+the uniform distribution on the eight even-parity binary configurations.  We
+regard the four sites as the tripartite system
+\[
+  A=\{0\},\qquad B=\{1,3\},\qquad C=\{2\}.
+\]
+The three proper marginals entering strong subadditivity are maximally mixed,
+whereas the full state has only eight nonzero eigenvalues.  Consequently
+\[
+  S(ABC)=3\log 2,\quad S(B)=2\log 2,\quad
+  S(AB)=S(BC)=3\log 2,
+\]
+and equality in strong subadditivity fails.
+
+This finite entropy calculation supplies the state-specific obstruction needed
+for the source claim that Example 4.12 is not of the simple commuting form.  The
+separate implication from a four-cycle GSNNCH representation to the relevant
+Markov equality is not asserted here.
+
+## Reference
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Example 4.12,
+  lines 932--938.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.CPSVExample412Literal
+
+/-- Decode the two-site subsystem $B=\{1,3\}$ from one four-dimensional
+basis label.
+
+Source state: CPSV16, arXiv:1606.00608, Example 4.12, lines 932--937. -/
+def fourCycleMiddleBits (b : Fin 4) : Fin 2 × Fin 2 :=
+  (finProdFinEquiv (m := 2) (n := 2)).symm b
+
+/-- The real eigenvalue of $\sigma_z$ at a binary basis label.
+
+Source: CPSV16, arXiv:1606.00608, Example 4.12, lines 935--937. -/
+def siteSignReal (i : Fin 2) : ℝ :=
+  if i = 0 then 1 else -1
+
+@[simp] private lemma siteSignReal_zero : siteSignReal 0 = 1 := by
+  simp [siteSignReal]
+
+@[simp] private lemma siteSignReal_one : siteSignReal 1 = -1 := by
+  simp [siteSignReal]
+
+/-- The four-site basis regrouping for
+$A=\{0\}$, $B=\{1,3\}$, and $C=\{2\}$.  The two binary labels in $B$ are
+encoded as one element of `Fin 4`.
+
+Source state: CPSV16, arXiv:1606.00608, Example 4.12, lines 932--937. -/
+def fourCycleTripartiteEquiv :
+    (Fin 2 × Fin 4 × Fin 2) ≃ (Fin 4 → Fin 2) where
+  toFun x := ![x.1,
+    (fourCycleMiddleBits x.2.1).1,
+    x.2.2,
+    (fourCycleMiddleBits x.2.1).2]
+  invFun σ := (σ 0, finProdFinEquiv (m := 2) (n := 2) (σ 1, σ 3), σ 2)
+  left_inv x := by
+    obtain ⟨a, b, c⟩ := x
+    ext <;> simp [fourCycleMiddleBits]
+  right_inv σ := by
+    funext i
+    fin_cases i <;> simp [fourCycleMiddleBits]
+
+/-- The normalized four-site Example 4.12 state in the tripartite basis
+$A=\{0\}$, $B=\{1,3\}$, $C=\{2\}$.
+
+Source state: CPSV16, arXiv:1606.00608, Example 4.12, equations at
+lines 933--937. -/
+noncomputable def fourCycleTripartiteState :
+    Matrix (Fin 2 × Fin 4 × Fin 2) (Fin 2 × Fin 4 × Fin 2) ℂ :=
+  (normalizedMPO M 4).submatrix fourCycleTripartiteEquiv fourCycleTripartiteEquiv
+
+/-- The diagonal probability of a tripartite basis vector in the normalized
+four-site state: $1/8$ for even parity and zero for odd parity.
+
+Source formula: CPSV16, arXiv:1606.00608, Example 4.12, lines 933--937. -/
+noncomputable def fourCycleWeight (x : Fin 2 × Fin 4 × Fin 2) : ℝ :=
+  (1 + siteSignReal x.1 * siteSignReal (fourCycleMiddleBits x.2.1).1 *
+    siteSignReal x.2.2 * siteSignReal (fourCycleMiddleBits x.2.1).2) / 16
+
+private lemma siteSign_eq_siteSignReal (i : Fin 2) :
+    siteSign i = (siteSignReal i : ℂ) := by
+  fin_cases i <;> norm_num [siteSign, siteSignReal, sigmaZ, SpinCover.pauli]
+
+private lemma configurationSign_fourCycle (x : Fin 2 × Fin 4 × Fin 2) :
+    configurationSign (fourCycleTripartiteEquiv x) =
+      (siteSignReal x.1 * siteSignReal (fourCycleMiddleBits x.2.1).1 *
+        siteSignReal x.2.2 * siteSignReal (fourCycleMiddleBits x.2.1).2 : ℝ) := by
+  rw [configurationSign, Fin.prod_univ_four]
+  change siteSign x.1 * siteSign (fourCycleMiddleBits x.2.1).1 *
+      siteSign x.2.2 * siteSign (fourCycleMiddleBits x.2.1).2 = _
+  simp only [siteSign_eq_siteSignReal]
+  push_cast
+  ring
+
+/-- The regrouped normalized four-site state is diagonal, with uniform weight
+$1/8$ on the eight even-parity configurations.
+
+Source formula: CPSV16, arXiv:1606.00608, Example 4.12, lines 933--937. -/
+theorem fourCycleTripartiteState_eq_diagonal :
+    fourCycleTripartiteState =
+      Matrix.diagonal fun x => (fourCycleWeight x : ℂ) := by
+  rw [fourCycleTripartiteState, normalizedMPO, trace_rho 4 (by omega), rho_eq_diagonal]
+  ext x y
+  by_cases hxy : x = y
+  · subst y
+    simp only [Matrix.submatrix_apply, Matrix.smul_apply, Matrix.diagonal_apply_eq,
+      smul_eq_mul]
+    rw [configurationSign_fourCycle]
+    simp only [fourCycleWeight]
+    push_cast
+    norm_num
+    ring
+  · simp [Matrix.submatrix_apply, Matrix.diagonal_apply_ne _ hxy,
+      Matrix.diagonal_apply_ne _ (fourCycleTripartiteEquiv.injective.ne hxy)]
+
+/-- The regrouped four-site state is Hermitian.
+
+Source state: CPSV16, arXiv:1606.00608, Example 4.12, lines 933--937. -/
+theorem fourCycleTripartiteState_isHermitian :
+    fourCycleTripartiteState.IsHermitian := by
+  exact (normalizedMPO_isHermitian M 4 (M_isMPDO 4 (by omega))).submatrix
+    fourCycleTripartiteEquiv
+
+private lemma sum_fourCycleWeight_C (a : Fin 2) (b : Fin 4) :
+    ∑ c : Fin 2, fourCycleWeight (a, b, c) = 1 / 8 := by
+  rw [Fin.sum_univ_two]
+  simp only [fourCycleWeight, siteSignReal_zero, siteSignReal_one]
+  ring
+
+private lemma sum_fourCycleWeight_A (b : Fin 4) (c : Fin 2) :
+    ∑ a : Fin 2, fourCycleWeight (a, b, c) = 1 / 8 := by
+  rw [Fin.sum_univ_two]
+  simp only [fourCycleWeight, siteSignReal_zero, siteSignReal_one]
+  ring
+
+private lemma sum_fourCycleWeight_AC (b : Fin 4) :
+    ∑ a : Fin 2, ∑ c : Fin 2, fourCycleWeight (a, b, c) = 1 / 4 := by
+  simp_rw [sum_fourCycleWeight_C]
+  rw [Fin.sum_univ_two]
+  norm_num
+
+/-- The $AB$ marginal of the four-site state is maximally mixed on eight
+dimensions.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceC_fourCycleTripartiteState :
+    Matrix.traceC_ABC fourCycleTripartiteState =
+      (8 : ℂ)⁻¹ • (1 : Matrix (Fin 2 × Fin 4) (Fin 2 × Fin 4) ℂ) := by
+  rw [fourCycleTripartiteState_eq_diagonal]
+  ext x y
+  by_cases hxy : x = y
+  · subst y
+    simp only [Matrix.traceC_ABC, Matrix.diagonal_apply_eq, Matrix.smul_apply,
+      Matrix.one_apply_eq, smul_eq_mul, mul_one]
+    obtain ⟨a, b⟩ := x
+    norm_cast
+    simpa using congrArg (fun r : ℝ => (r : ℂ)) (sum_fourCycleWeight_C a b)
+  · have hneq : ∀ c : Fin 2, (x.1, x.2, c) ≠ (y.1, y.2, c) := by
+      intro c h
+      apply hxy
+      exact congrArg (fun z : Fin 2 × Fin 4 × Fin 2 => (z.1, z.2.1)) h
+    simp [Matrix.traceC_ABC, hxy, hneq]
+
+/-- The $BC$ marginal of the four-site state is maximally mixed on eight
+dimensions.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceA_fourCycleTripartiteState :
+    Matrix.traceA_ABC fourCycleTripartiteState =
+      (8 : ℂ)⁻¹ • (1 : Matrix (Fin 4 × Fin 2) (Fin 4 × Fin 2) ℂ) := by
+  rw [fourCycleTripartiteState_eq_diagonal]
+  ext x y
+  by_cases hxy : x = y
+  · subst y
+    simp only [Matrix.traceA_ABC, Matrix.diagonal_apply_eq, Matrix.smul_apply,
+      Matrix.one_apply_eq, smul_eq_mul, mul_one]
+    obtain ⟨b, c⟩ := x
+    norm_cast
+    simpa using congrArg (fun r : ℝ => (r : ℂ)) (sum_fourCycleWeight_A b c)
+  · have hneq : ∀ a : Fin 2, (a, x.1, x.2) ≠ (a, y.1, y.2) := by
+      intro a h
+      apply hxy
+      exact congrArg (fun z : Fin 2 × Fin 4 × Fin 2 => z.2) h
+    simp [Matrix.traceA_ABC, hxy, hneq]
+
+/-- The $B$ marginal of the four-site state is maximally mixed on four
+dimensions.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceAC_fourCycleTripartiteState :
+    Matrix.traceAC_ABC fourCycleTripartiteState =
+      (4 : ℂ)⁻¹ • (1 : Matrix (Fin 4) (Fin 4) ℂ) := by
+  rw [fourCycleTripartiteState_eq_diagonal]
+  ext x y
+  by_cases hxy : x = y
+  · subst y
+    simp only [Matrix.traceAC_ABC, Matrix.diagonal_apply_eq, Matrix.smul_apply,
+      Matrix.one_apply_eq, smul_eq_mul, mul_one]
+    norm_cast
+    simpa using congrArg (fun r : ℝ => (r : ℂ)) (sum_fourCycleWeight_AC x)
+  · have hneq : ∀ a c : Fin 2, (a, x, c) ≠ (a, y, c) := by
+      intro a c h
+      apply hxy
+      exact congrArg (fun z : Fin 2 × Fin 4 × Fin 2 => z.2.1) h
+    simp [Matrix.traceAC_ABC, hxy, hneq]
+
+/-- A maximally mixed state on a finite basis of cardinality $d$ has entropy
+$\log d$.
+
+Source: Wolf, *Quantum Channels & Operations*, Section 8.2. -/
+private theorem vonNeumannEntropy_inv_card_smul_one
+    {n : Type*} [Fintype n] [DecidableEq n] (d : ℕ)
+    (hcard : Fintype.card n = d) (hd : 0 < d)
+    (hρ : (((d : ℂ)⁻¹) • (1 : Matrix n n ℂ)).IsHermitian) :
+    vonNeumannEntropy (((d : ℂ)⁻¹) • (1 : Matrix n n ℂ)) hρ =
+      Real.log d := by
+  have heq : ((d : ℂ)⁻¹) • (1 : Matrix n n ℂ) =
+      Matrix.diagonal (fun _ : n => (((d : ℝ)⁻¹ : ℝ) : ℂ)) := by
+    rw [Matrix.smul_one_eq_diagonal]
+    ext i j
+    simp
+  let hdiag : (Matrix.diagonal fun _ : n => (((d : ℝ)⁻¹ : ℝ) : ℂ)).IsHermitian :=
+    Matrix.isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext i
+      simp)
+  rw [vonNeumannEntropy_congr heq hρ hdiag, Matrix.vonNeumannEntropy_diagonal]
+  rw [Finset.sum_const, Finset.card_univ, hcard, nsmul_eq_mul]
+  simp [Real.negMulLog, hd.ne', Real.log_inv]
+
+/-- The entropy of the normalized four-site Example 4.12 state is
+$3\log 2$.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem fourCycleTripartiteState_entropy :
+    vonNeumannEntropy fourCycleTripartiteState
+      fourCycleTripartiteState_isHermitian = 3 * Real.log 2 := by
+  let hd : (Matrix.diagonal fun x : Fin 2 × Fin 4 × Fin 2 =>
+      (fourCycleWeight x : ℂ)).IsHermitian :=
+    Matrix.isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext x
+      simp [Complex.conj_ofReal])
+  rw [vonNeumannEntropy_congr fourCycleTripartiteState_eq_diagonal
+    fourCycleTripartiteState_isHermitian hd, Matrix.vonNeumannEntropy_diagonal]
+  rw [Fintype.sum_prod_type]
+  simp_rw [Fintype.sum_prod_type]
+  simp_rw [← Equiv.sum_comp (finProdFinEquiv : Fin 2 × Fin 2 ≃ Fin 4)]
+  simp_rw [Fintype.sum_prod_type]
+  rw [Fin.sum_univ_two]
+  simp_rw [Fin.sum_univ_two]
+  norm_num [fourCycleWeight, fourCycleMiddleBits, siteSignReal,
+    Real.negMulLog_zero]
+  rw [Real.negMulLog]
+  rw [show (1 / 8 : ℝ) = (8 : ℝ)⁻¹ by norm_num, Real.log_inv]
+  rw [show (8 : ℝ) = 2 ^ 3 by norm_num, Real.log_pow]
+  norm_num
+  ring
+
+/-- The entropy of the $AB$ marginal is $3\log 2$.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceC_fourCycleTripartiteState_entropy :
+    vonNeumannEntropy (Matrix.traceC_ABC fourCycleTripartiteState)
+      (Matrix.traceC_ABC_isHermitian fourCycleTripartiteState_isHermitian) =
+        3 * Real.log 2 := by
+  let hscaled : (((8 : ℂ)⁻¹) •
+      (1 : Matrix (Fin 2 × Fin 4) (Fin 2 × Fin 4) ℂ)).IsHermitian :=
+    (Matrix.isHermitian_one (n := Fin 2 × Fin 4) (α := ℂ)).smul (by
+      simp [IsSelfAdjoint])
+  calc
+    _ = vonNeumannEntropy
+        (((8 : ℂ)⁻¹) • (1 : Matrix (Fin 2 × Fin 4) (Fin 2 × Fin 4) ℂ))
+        hscaled := vonNeumannEntropy_congr traceC_fourCycleTripartiteState _ _
+    _ = Real.log 8 := vonNeumannEntropy_inv_card_smul_one 8 (by simp) (by omega) hscaled
+    _ = 3 * Real.log 2 := by
+      rw [show (8 : ℝ) = 2 ^ 3 by norm_num, Real.log_pow]
+      norm_num
+
+/-- The entropy of the $BC$ marginal is $3\log 2$.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceA_fourCycleTripartiteState_entropy :
+    vonNeumannEntropy (Matrix.traceA_ABC fourCycleTripartiteState)
+      (Matrix.traceA_ABC_isHermitian fourCycleTripartiteState_isHermitian) =
+        3 * Real.log 2 := by
+  let hscaled : (((8 : ℂ)⁻¹) •
+      (1 : Matrix (Fin 4 × Fin 2) (Fin 4 × Fin 2) ℂ)).IsHermitian :=
+    (Matrix.isHermitian_one (n := Fin 4 × Fin 2) (α := ℂ)).smul (by
+      simp [IsSelfAdjoint])
+  calc
+    _ = vonNeumannEntropy
+        (((8 : ℂ)⁻¹) • (1 : Matrix (Fin 4 × Fin 2) (Fin 4 × Fin 2) ℂ))
+        hscaled := vonNeumannEntropy_congr traceA_fourCycleTripartiteState _ _
+    _ = Real.log 8 := vonNeumannEntropy_inv_card_smul_one 8 (by simp) (by omega) hscaled
+    _ = 3 * Real.log 2 := by
+      rw [show (8 : ℝ) = 2 ^ 3 by norm_num, Real.log_pow]
+      norm_num
+
+/-- The entropy of the $B$ marginal is $2\log 2$.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem traceAC_fourCycleTripartiteState_entropy :
+    vonNeumannEntropy (Matrix.traceAC_ABC fourCycleTripartiteState)
+      (Matrix.traceAC_ABC_isHermitian fourCycleTripartiteState_isHermitian) =
+        2 * Real.log 2 := by
+  let hscaled : (((4 : ℂ)⁻¹) • (1 : Matrix (Fin 4) (Fin 4) ℂ)).IsHermitian :=
+    (Matrix.isHermitian_one (n := Fin 4) (α := ℂ)).smul (by
+      simp [IsSelfAdjoint])
+  calc
+    _ = vonNeumannEntropy (((4 : ℂ)⁻¹) • (1 : Matrix (Fin 4) (Fin 4) ℂ))
+        hscaled := vonNeumannEntropy_congr traceAC_fourCycleTripartiteState _ _
+    _ = Real.log 4 := vonNeumannEntropy_inv_card_smul_one 4 (by simp) (by omega) hscaled
+    _ = 2 * Real.log 2 := by
+      rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]
+      norm_num
+
+/-- The four-site Example 4.12 state fails equality in strong subadditivity
+for $A=\{0\}$, $B=\{1,3\}$, and $C=\{2\}$.
+
+This is the finite entropy obstruction behind the source statement that the
+state is not of the simple commuting form.  The GSNNCH-to-Markov implication is
+a separate assertion.
+
+Derived from the state formula in CPSV16, arXiv:1606.00608,
+Example 4.12, lines 933--937. -/
+theorem fourCycleTripartiteState_not_isSSAEquality :
+    ¬ IsSSAEquality fourCycleTripartiteState
+      fourCycleTripartiteState_isHermitian := by
+  rw [IsSSAEquality, fourCycleTripartiteState_entropy,
+    traceAC_fourCycleTripartiteState_entropy,
+    traceC_fourCycleTripartiteState_entropy,
+    traceA_fourCycleTripartiteState_entropy]
+  have hlog : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  linarith
+
+end MPOTensor.CPSVExample412Literal

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1077,6 +1077,7 @@ This is the calculation in
         thm:cpsv_example412_literal_formula,
         thm:cpsv_example412_literal_sal,
         thm:cpsv_example412_literal_zcl_rfp_gap,
+        thm:cpsv_example412_four_cycle_ssa_defect,
         thm:cpsv_example412_normalized_rfp_maps}
     The three examples in
     \cite[Examples~4.10--4.12, lines~897--942]{Cirac2016MPDO_arXiv} assert the
@@ -1115,6 +1116,13 @@ This is the calculation in
         \rho^{(N)}&=I^{\otimes N}+\sigma_z^{\otimes N}.
         \notag
     \end{align}
+    For the normalized four-site state, the tripartition
+    $A=\{0\}$, $B=\{1,3\}$, $C=\{2\}$ has a strict
+    strong-subadditivity inequality: the two three-site marginals have entropy
+    $3\log 2$, the middle marginal has entropy $2\log 2$, and the full state
+    has entropy $3\log 2$.  This supplies the finite entropy obstruction; the
+    implication from a simple commuting representation on the four-cycle to
+    equality for this tripartition is a separate assertion.
     The source asserts that this tensor has saturation of the area law and zero
     correlation length, is not of the simple commuting form, and is nevertheless
     a renormalization fixed point.  The literal printed tensor is unnormalized:
@@ -1729,6 +1737,75 @@ This is the calculation in
     entropy of the resulting maximally mixed state is $L\log 2$; the two block
     terms in the mutual information then add to $N\log 2$ independently of the
     cut.
+\end{proof}
+
+% Project-derived four-site consequence of CPSV16 Example 4.12, lines 932--938.
+\begin{definition}[Four-site tripartition in Example 4.12]
+    \label{def:cpsv_example412_four_cycle_tripartition}
+    \lean{MPOTensor.CPSVExample412Literal.fourCycleMiddleBits,
+        MPOTensor.CPSVExample412Literal.siteSignReal,
+        MPOTensor.CPSVExample412Literal.fourCycleTripartiteEquiv,
+        MPOTensor.CPSVExample412Literal.fourCycleTripartiteState,
+        MPOTensor.CPSVExample412Literal.fourCycleWeight}
+    \leanok
+    \uses{def:cpsv_example412_configuration_sign,
+        thm:cpsv_example412_literal_formula}
+    For the state in
+    \cite[Example~4.12, lines~932--938]{Cirac2016MPDO_arXiv}, at $N=4$
+    regard the sites as
+    $A=\{0\}$, $B=\{1,3\}$, and $C=\{2\}$.  Encode the two binary labels
+    $(b_1,b_3)$ as one four-dimensional label $b$, and write
+    $z_a\in\{1,-1\}$ for the eigenvalue of $\sigma_z$ at $a$.  In the basis
+    $(a,b,c)\leftrightarrow(a,b_1,c,b_3)$, let $\rho_{ABC}$ be the normalized
+    four-site state and set
+    \begin{align}
+        w(a,b,c)&=\frac{1+z_a z_{b_1}z_c z_{b_3}}{16}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Four-site failure of strong-subadditivity equality]
+    \label{thm:cpsv_example412_four_cycle_ssa_defect}
+    \lean{MPOTensor.CPSVExample412Literal.fourCycleTripartiteState_eq_diagonal,
+        MPOTensor.CPSVExample412Literal.fourCycleTripartiteState_isHermitian,
+        MPOTensor.CPSVExample412Literal.traceC_fourCycleTripartiteState,
+        MPOTensor.CPSVExample412Literal.traceA_fourCycleTripartiteState,
+        MPOTensor.CPSVExample412Literal.traceAC_fourCycleTripartiteState,
+        MPOTensor.CPSVExample412Literal.fourCycleTripartiteState_entropy,
+        MPOTensor.CPSVExample412Literal.traceC_fourCycleTripartiteState_entropy,
+        MPOTensor.CPSVExample412Literal.traceA_fourCycleTripartiteState_entropy,
+        MPOTensor.CPSVExample412Literal.traceAC_fourCycleTripartiteState_entropy,
+        MPOTensor.CPSVExample412Literal.fourCycleTripartiteState_not_isSSAEquality}
+    \leanok
+    \uses{def:cpsv_example412_four_cycle_tripartition, def:ssa_equality}
+    The normalized four-site state is diagonal with probability $1/8$ on the
+    eight even-parity configurations and zero on the eight odd-parity
+    configurations.  Its relevant marginals are
+    \begin{align}
+        \rho_{AB}&=\frac{I_8}{8},
+        &\rho_{BC}&=\frac{I_8}{8},
+        &\rho_B&=\frac{I_4}{4}.
+        \notag
+    \end{align}
+    Consequently,
+    \begin{align}
+        S(ABC)&=3\log 2,
+        &S(B)&=2\log 2,
+        &S(AB)&=S(BC)=3\log 2,
+        \notag
+    \end{align}
+    so $S(ABC)+S(B)=5\log 2<6\log 2=S(AB)+S(BC)$.  Thus equality in
+    strong subadditivity fails for this tripartition.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:cpsv_example412_literal_formula}
+    The diagonal coefficient is
+    $(1+z_a z_{b_1}z_c z_{b_3})/16$.  Summing over either $a$ or $c$ cancels
+    the signed term, giving $I_8/8$; summing over both gives $I_4/4$.
+    There are eight nonzero coefficients, all equal to $1/8$, so the full
+    entropy is $8[-(1/8)\log(1/8)]=3\log 2$.  The three maximally mixed
+    marginals have the displayed entropies, and $\log 2>0$ gives the strict
+    inequality.
 \end{proof}
 
 \begin{theorem}[Scale-two transfer relation and the literal ZCL--RFP obstruction]

--- a/docs/paper-gaps/cpsv16_example_4_12_normalization.tex
+++ b/docs/paper-gaps/cpsv16_example_4_12_normalization.tex
@@ -127,11 +127,28 @@ canonical-form convention in Definition~4.1.  This boundary is also recorded
 in
 \path{docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex}.
 
+The independent four-site entropy calculation is also complete.  For the
+normalized state, regroup the sites as $A=\{0\}$, $B=\{1,3\}$, and
+$C=\{2\}$.  The $AB$ and $BC$ marginals are $I_8/8$, the $B$ marginal is
+$I_4/4$, and the full state is uniform on eight even-parity configurations.
+Thus
+\[
+  S(ABC)=3\log 2,
+  \qquad S(B)=2\log 2,
+  \qquad S(AB)=S(BC)=3\log 2,
+\]
+so equality in strong subadditivity fails by the strictly positive defect
+$\log 2$.  This proves the state-specific Markov obstruction without using the
+normalized fixed-point maps.
+
 The full GSNNCH exclusion is already a statement about the normalized family
 because \leanid{MPOTensor.IsGSNNCH} quantifies over
 \leanid{MPOTensor.normalizedMPO}. It may therefore be proved as
 $\neg\operatorname{IsGSNNCH}(M)$ for the printed tensor and remains tracked in
-\ghissue{6045}. Transport to the separately named $\widehat M$ is optional
+\ghissue{6045}.  The remaining implication from a four-cycle GSNNCH
+representation to the Markov equality is tracked in \ghissue{6072}; only that
+implication is needed to combine the entropy defect with the GSNNCH
+hypothesis.  Transport to the separately named $\widehat M$ is optional
 packaging rather than a prerequisite for that result.
 
 \section{Verdict}
@@ -159,5 +176,16 @@ discharging the mathematical task tracked in \ghissue{6044}. They do not repair
 the incompatible line-246 unit-weight convention, so the formal verdict must
 remain separated into the false literal claim, the true normalized channel
 equations, and the still-open full GSNNCH exclusion in \ghissue{6045}.
+
+For the normalized four-site state,
+\leanid{MPOTensor.CPSVExample412Literal.fourCycleTripartiteState_not_isSSAEquality}
+proves the strict strong-subadditivity defect.  Its proof uses the exact
+marginals
+\leanid{MPOTensor.CPSVExample412Literal.traceC_fourCycleTripartiteState},
+\leanid{MPOTensor.CPSVExample412Literal.traceA_fourCycleTripartiteState}, and
+\leanid{MPOTensor.CPSVExample412Literal.traceAC_fourCycleTripartiteState},
+together with their entropy calculations.  This completes \ghissue{6073} but
+does not by itself assert failure of the GSNNCH form; that final inference still
+depends on \ghissue{6072}.
 
 \end{document}


### PR DESCRIPTION
## Summary

- formalize the normalized four-site parity state derived from CPSV16 Example 4.12;
- compute the full state and the \(AB\), \(BC\), and \(B\) marginals exactly;
- prove
  \[
  S(ABC)=3\log 2,\qquad S(B)=2\log 2,\qquad
  S(AB)=S(BC)=3\log 2,
  \]
  and hence strict failure of strong-subadditivity equality for
  \(A=\{0\}\), \(B=\{1,3\}\), \(C=\{2\}\);
- add a separate Blueprint node and update the Example 4.12 paper-gap note without disturbing the merged normalized-RFP channel result.

Closes #6073.

## Statement-integrity audit

**Paper assumptions versus Lean assumptions.**  
CPSV16 Example 4.12, lines 932–939 of
`Papers/1606.00608/MPDO-22-12-17-2.tex`, supplies the parity-state formula.
The Lean theorem has no hypotheses. It specializes the normalized family to
\(N=4\) and uses an explicit equivalence to regroup the sites as
\(A=\{0\}\), \(B=\{1,3\}\), and \(C=\{2\}\). This equivalence is a finite-coordinate
encoding boundary, not an additional mathematical assumption.

**Paper conclusion versus Lean conclusion.**  
The paper does not print this entropy calculation as a separate proposition.
Lean proves the project-derived strict SSA defect only. It does not infer
\(\neg\operatorname{IsGSNNCH}\), does not use the normalized RFP maps, and does
not present the calculation as the paper's final non-GSNNCH assertion.
Issue #6072 remains the independent implication from a four-cycle GSNNCH
representation to Markov/SSA equality; #6045 combines that implication with
this theorem.

**Relevant definitions.**  
The new module defines the exact four-site reindexing, the normalized diagonal
weights \((1+z_0z_1z_2z_3)/16\), and the corresponding tripartite density
matrix. The conclusion uses the existing `Entropy.IsSSAEquality` predicate
and the established partial-trace conventions.

**Proof status.**  
Complete. The state is uniform on the eight even-parity configurations, the
two three-factor marginals are \(I_8/8\), and the middle marginal is \(I_4/4\).
There are no `sorry`, `admit`, `axiom`, `native_decide`,
`unsafeCast`, or kernel bypasses in the new module. The kernel-axiom audit of
the headline theorem reports only `propext`, `Classical.choice`, and
`Quot.sound`.

**Verdict on faithfulness.**  
This closes a **missing statement**: it is a faithful formal consequence of
the source state formula, with no invented hypotheses and with its
project-derived provenance stated explicitly. It leaves the separate missing
statement #6072 and the parent conclusion #6045 open.

## Issues and subissues

- closes #6073;
- advances parent #6045;
- leaves load-bearing #6072 open;
- does not change optional transport issue #6074.

## Validation

- `lake env lean TNLean/MPS/MPDO/CPSVExample412FourCycleEntropy.lean`
- `lake build TNLean.MPS.MPDO.CPSVExample412FourCycleEntropy`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/CPSVExample412FourCycleEntropy.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_import_direction.py --base-ref origin/main`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff origin/main..HEAD --check`
- exact proof-hazard and kernel-axiom scans on the new module and headline theorem
