### PR TITLE
doc(Channel): index Wolf Proposition 6.3

### DIFF
--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -39,6 +39,8 @@ complex linear combinations of two Hermitian matrices.
   nonincrease imply bounded forward orbits on every matrix.
 * `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`: the trace-preserving
   specialization.
+* `IsPositiveMap.tendsto_birkhoffAverage_meanErgodicProjection_of_tracePreserving`:
+  the Cesàro convergence assertion for positive trace-preserving maps.
 * `IsPositiveMap.meanErgodicProjection_isPositiveMap`: the mean-ergodic
   projection of a positive map is positive.
 * `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`: the
@@ -229,6 +231,21 @@ theorem IsPositiveMap.hasBoundedOrbits_of_tracePreserving
     (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
     T.HasBoundedOrbits :=
   hT.hasBoundedOrbits_of_traceNonincreasing hTP.isTraceNonincreasingMap
+
+/-- The Cesàro averages of a positive trace-preserving matrix endomorphism
+converge pointwise to its mean-ergodic projection.
+
+Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsPositiveMap.tendsto_birkhoffAverage_meanErgodicProjection_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Tendsto (birkhoffAverage ℂ T _root_.id · X) atTop
+      (𝓝 (LinearMap.meanErgodicProjection T
+        (hT.hasBoundedOrbits_of_tracePreserving hTP) X)) :=
+  LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection
+    (hT.hasBoundedOrbits_of_tracePreserving hTP) X
 
 /-- The finite-dimensional mean-ergodic projection of a positive matrix
 endomorphism is positive.

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -115,8 +115,9 @@ The three clauses of the proposition are represented by:
   increasing sequence $(n_i)$ for which $T^{n_i}\to T_\phi$;
 * `Module.End.peripheralWeightedProjection_eq_comp` —
   $T_\varphi=T\,T_\phi$;
-* `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection` —
-  the Cesàro means converge to $T_\infty$.
+* `IsPositiveMap.tendsto_birkhoffAverage_meanErgodicProjection_of_tracePreserving`
+  — the Cesàro means converge to $T_\infty$ for the positive trace-preserving
+  maps of the proposition.
 
 For the positive and trace-preserving conclusions concerning $T_\infty$:
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -107,6 +107,30 @@ positive maps alike, since $\operatorname{tr}[1\,T(1)] = d$ in both cases.
 Formerly documented as a scope restriction in
 `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`; that gap is now closed.
 
+### Wolf Proposition 6.3 (Cesàro means) — FORMALIZED
+
+For the mean-ergodic projection $T_\infty$:
+
+* `IsPositiveMap.meanErgodicProjection_isPositiveMap` — positivity;
+* `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap` — trace
+  preservation;
+* `IsCPMap.meanErgodicProjection_isCPMap` — complete positivity;
+* `IsChannel.meanErgodicProjection` — the resulting channel.
+
+These results are in `TNLean.Channel.FixedPoint.MeanErgodicProjection`.  For
+the peripheral projection $T_\varphi$ and its phase-weighted companion
+$T_\varphi'$:
+
+* `IsPositiveMap.peripheralProjection_isCPMap` — complete positivity of
+  $T_\varphi$;
+* `IsChannel.peripheralProjection` and
+  `IsChannel.peripheralWeightedProjection` — both maps are channels.
+
+These results are in `TNLean.Channel.Peripheral.CesaroRecurrence`.  Their
+hypotheses are those of Wolf's proposition: complete positivity and trace
+preservation.  The boundedness needed to form $T_\infty$ follows from
+`IsPositiveMap.hasBoundedOrbits_of_tracePreserving`.
+
 ## Section 6.2 Irreducible maps and Perron–Frobenius theory
 
 ### Wolf Theorem 6.2 (Irreducible positive maps) — ITEMS 1,2,4 FORMALIZED

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -109,7 +109,16 @@ Formerly documented as a scope restriction in
 
 ### Wolf Proposition 6.3 (Cesàro means) — FORMALIZED
 
-For the mean-ergodic projection $T_\infty$:
+The three clauses of the proposition are represented by:
+
+* `IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection` — an
+  increasing sequence $(n_i)$ for which $T^{n_i}\to T_\phi$;
+* `Module.End.peripheralWeightedProjection_eq_comp` —
+  $T_\varphi=T\,T_\phi$;
+* `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection` —
+  the Cesàro means converge to $T_\infty$.
+
+For the positive and trace-preserving conclusions concerning $T_\infty$:
 
 * `IsPositiveMap.meanErgodicProjection_isPositiveMap` — positivity;
 * `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap` — trace
@@ -118,17 +127,24 @@ For the mean-ergodic projection $T_\infty$:
 * `IsChannel.meanErgodicProjection` — the resulting channel.
 
 These results are in `TNLean.Channel.FixedPoint.MeanErgodicProjection`.  For
-the peripheral projection $T_\varphi$ and its phase-weighted companion
-$T_\varphi'$:
+the peripheral projection $T_\phi$ and the phase-weighted map $T_\varphi$:
 
+* `IsPositiveMap.peripheralProjection_isPositiveMap` and
+  `IsPositiveMap.peripheralProjection_isTracePreservingMap` — positivity and
+  trace preservation of $T_\phi$;
+* `IsPositiveMap.peripheralWeightedProjection_isPositiveMap` and
+  `IsPositiveMap.peripheralWeightedProjection_isTracePreservingMap` — the same
+  conclusions for $T_\varphi$;
 * `IsPositiveMap.peripheralProjection_isCPMap` — complete positivity of
-  $T_\varphi$;
+  $T_\phi$ under the completely positive hypothesis;
 * `IsChannel.peripheralProjection` and
-  `IsChannel.peripheralWeightedProjection` — both maps are channels.
+  `IsChannel.peripheralWeightedProjection` — both maps are channels in the
+  completely positive case.
 
-These results are in `TNLean.Channel.Peripheral.CesaroRecurrence`.  Their
-hypotheses are those of Wolf's proposition: complete positivity and trace
-preservation.  The boundedness needed to form $T_\infty$ follows from
+These results are in `TNLean.Channel.Peripheral.CesaroRecurrence`.  Thus the
+basic hypothesis is positivity together with trace preservation, exactly as in
+Wolf's statement; complete positivity gives the corresponding stronger
+conclusions.  The boundedness needed to form $T_\infty$ follows from
 `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`.
 
 ## Section 6.2 Irreducible maps and Perron–Frobenius theory

--- a/blueprint/src/chapter/ch27_channel_asymptotics_mean_ergodic.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_mean_ergodic.tex
@@ -165,6 +165,7 @@
 \begin{theorem}[Positive trace-preserving mean-ergodic projection]
     \label{thm:positive_trace_preserving_mean_ergodic_projection}
     \lean{IsPositiveMap.hasBoundedOrbits_of_tracePreserving,
+        IsPositiveMap.tendsto_birkhoffAverage_meanErgodicProjection_of_tracePreserving,
         IsPositiveMap.range_meanErgodicProjection_of_tracePreserving,
         IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving}
     \leanok
@@ -174,8 +175,9 @@
         thm:trace_preserving_mean_ergodic_projection,
         thm:unital_mean_ergodic_projection}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving. Then $T$ has
-    bounded orbits, and its mean-ergodic projection $P_T$ is positive and
-    trace-preserving. Its range is precisely the fixed-point space of $T$:
+    bounded orbits, its Ces\`aro averages converge pointwise to the
+    mean-ergodic projection $P_T$, and $P_T$ is positive and trace-preserving.
+    Its range is precisely the fixed-point space of $T$:
     \begin{align}
         \range(P_T) & =\ker(T-\Id), \notag \\
         P_T(X)=X    & \iff T(X)=X.


### PR DESCRIPTION
## Summary

- add the missing Wolf Proposition 6.3 entry to the Chapter 6 theorem index
- index clauses (i)–(iii): recurrent powers, the phase-weighted peripheral map, and Cesàro convergence
- record positivity, complete positivity, and trace preservation for the mean-ergodic and peripheral maps
- preserve Wolf’s notation and distinguish the positive-map statement from its completely positive strengthening

## Validation

- `lake env lean TNLean/Channel/WolfChapter6Index.lean`
- declaration-name audit for every indexed theorem
- `git diff --check`

Closes LionSR/QICLean#327.