### PR TITLE
ci(qic): bind mover report to source commit

### DIFF
--- a/scripts/check_import_direction.py
+++ b/scripts/check_import_direction.py
@@ -269,13 +269,27 @@ def namespaced_declarations(path: Path, relative: Path) -> list[dict[str, str | 
 
 
 def source_sha(root: Path) -> str:
-    """Return the exact source commit for the extraction inventory."""
-    result = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "HEAD"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
+    """Return the exact source commit for a clean extraction inventory."""
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain", "--untracked-files=all"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if status.stdout:
+            raise ValueError("cannot report a dirty source tree")
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() if error.stderr else str(error)
+        raise ValueError(f"cannot identify the source commit: {detail}") from error
     return result.stdout.strip()
 
 

--- a/scripts/check_import_direction.py
+++ b/scripts/check_import_direction.py
@@ -268,6 +268,17 @@ def namespaced_declarations(path: Path, relative: Path) -> list[dict[str, str | 
     return declarations
 
 
+def source_sha(root: Path) -> str:
+    """Return the exact source commit for the extraction inventory."""
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def report_inventory(root: Path) -> dict[str, object]:
     """Return a deterministic, read-only extraction inventory for the mover set."""
     closure_errors, _ = check_import_direction(root)
@@ -305,6 +316,7 @@ def report_inventory(root: Path) -> dict[str, object]:
 
     return {
         "schema_version": 1,
+        "source_sha": source_sha(root),
         "mover_paths": [
             path.as_posix() for path in sorted(movers, key=lambda item: item.as_posix())
         ],

--- a/scripts/test_check_import_direction.py
+++ b/scripts/test_check_import_direction.py
@@ -237,10 +237,12 @@ class ImportDirectionGuardTests(unittest.TestCase):
             "import TNLean.Channel.Basic\n",
         )
 
-        first = json.dumps(guard.report_inventory(self.root), indent=2, sort_keys=True)
-        second = json.dumps(guard.report_inventory(self.root), indent=2, sort_keys=True)
+        with mock.patch.object(guard, "source_sha", return_value="a" * 40):
+            first = json.dumps(guard.report_inventory(self.root), indent=2, sort_keys=True)
+            second = json.dumps(guard.report_inventory(self.root), indent=2, sort_keys=True)
         self.assertEqual(first, second)
         report = json.loads(first)
+        self.assertEqual(report["source_sha"], "a" * 40)
         self.assertEqual(
             report["mover_paths"],
             [

--- a/scripts/test_check_import_direction.py
+++ b/scripts/test_check_import_direction.py
@@ -196,6 +196,24 @@ class ImportDirectionGuardTests(unittest.TestCase):
 
     # -- Extraction report ----------------------------------------------------
 
+    def test_source_sha_rejects_dirty_tree(self) -> None:
+        dirty = subprocess.CompletedProcess([], 0, stdout=" M TNLean/Channel/Foo.lean\n", stderr="")
+        with mock.patch.object(guard.subprocess, "run", return_value=dirty):
+            with self.assertRaisesRegex(ValueError, "dirty source tree"):
+                guard.source_sha(self.root)
+
+    def test_source_sha_reports_git_failure(self) -> None:
+        failure = subprocess.CalledProcessError(128, ["git"], stderr="fatal: not a git repository")
+        with mock.patch.object(guard.subprocess, "run", side_effect=failure):
+            with self.assertRaisesRegex(ValueError, "not a git repository"):
+                guard.source_sha(self.root)
+
+    def test_source_sha_returns_clean_head(self) -> None:
+        clean = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        head = subprocess.CompletedProcess([], 0, stdout="a" * 40 + "\n", stderr="")
+        with mock.patch.object(guard.subprocess, "run", side_effect=[clean, head]):
+            self.assertEqual(guard.source_sha(self.root), "a" * 40)
+
     def test_report_declaration_read_failure_is_diagnostic(self) -> None:
         missing = self.root / "TNLean/Channel/Missing.lean"
         with self.assertRaisesRegex(ValueError, "cannot read declarations"):


### PR DESCRIPTION
## What changed

- add the exact TNLean source commit to `check_import_direction.py --report`
- test that `source_sha` is present while preserving byte-deterministic report output
- make the mover freeze self-authenticating before the history filter runs

This removes one verified blocker from the atomic extraction runbook. It does not run the history filter or change the mover set.

## Validation

- `PYTHONPATH=scripts python3 -m unittest -v scripts.test_check_import_direction` (25 tests)
- `python3 scripts/check_import_direction.py --root . --report` (twice, byte-identical)
- report `source_sha` equals the exact branch `HEAD`
- `python3 -m py_compile scripts/check_import_direction.py scripts/test_check_import_direction.py`
- `git diff --check`

Advances #6622
Advances #6560
