### PR TITLE
doc(Channel): correct Wolf stationary-span citation

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -19,7 +19,7 @@ that span it.
 ## Source
 
 * M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.5; local
-  source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1204--1218.
+  source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1204--1212.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -10,7 +10,7 @@ import Mathlib.LinearAlgebra.Dimension.Finite
 /-!
 # Fixed-point subspace spanned by positive-semidefinite fixed points
 
-This file proves Wolf Corollary 6.8 (Linearly independent stationary states)
+This file proves Wolf Corollary 6.5 (Linearly independent stationary states)
 in full: the fixed-point subspace of a positive trace-preserving linear map is
 spanned (over ℂ) by stationary density matrices, and when the subspace has
 dimension `r`, there exist `r` linearly independent stationary density matrices
@@ -18,7 +18,7 @@ that span it.
 
 ## Source
 
-* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.8; local
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.5; local
   source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1204--1218.
 -/
 
@@ -141,7 +141,7 @@ lemma stationaryDensity_of_posSemidef_fixedPoint
     fixed_point := h_fix
   }
 
-/-- **Wolf Corollary 6.8, spanning statement.**
+/-- **Wolf Corollary 6.5, spanning statement.**
 
 The fixed-point subspace of a positive trace-preserving linear map is spanned
 (over ℂ) by stationary density matrices (PSD, trace 1, fixed by `E`).
@@ -189,7 +189,7 @@ theorem fixedPointsSubmodule_spanned_by_stationaryDensities
     rw [h_span_P] at h_span_le
     exact h_span_le
 
-/-- **Wolf Corollary 6.8 (Linearly independent stationary states).**
+/-- **Wolf Corollary 6.5 (Linearly independent stationary states).**
 
 Let `E` be a positive trace-preserving linear map on `M_D(ℂ)`.  The fixed-point
 subspace `F_E = {X | E X = X}` is finite-dimensional.  Let `r = dim_ℂ F_E`.
@@ -200,7 +200,7 @@ span equals `F_E`.
 Equivalently, the fixed-point space has a basis consisting entirely of
 stationary density matrices.
 
-Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.8;
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.5;
 local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
 lines 1204--1212. -/
 theorem exists_stationaryDensity_basis_of_fixedPointsSubmodule

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -1120,7 +1120,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     $\rho_1,\dots,\rho_r$ (positive semidefinite, trace~1, fixed by~$E$)
     whose $\mathbb C$-linear span equals $\mathcal F_E$.
 
-    This is Wolf Corollary~6.8 (Linearly independent stationary states).
+    This is Wolf Corollary~6.5 (Linearly independent stationary states).
 \end{corollary}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/brouwer_general_compact_convex.tex
@@ -72,7 +72,7 @@ this gap:
 
 The missing general statement does \emph{not} block the formalization of Wolf
 Theorem~6.11 (Stationary states), Proposition~6.8 (Positive fixed-points), or
-Corollary~6.8 (spanning by stationary density matrices).  These results rely
+Corollary~6.5 (spanning by stationary density matrices).  These results rely
 only on the density-matrix version of Brouwer, which is already proved.
 The general compact-convex Brouwer is not used anywhere in the current
 formalization.

--- a/docs/wolf_source_numbering.md
+++ b/docs/wolf_source_numbering.md
@@ -5,19 +5,21 @@ of M. Wolf, *Quantum Channels & Operations: Guided Tour*.  Their automatically
 rendered theorem numbers are not, in general, the theorem numbers of the
 published notes.
 
-The shared declarations in `preamble.tex` use one theorem counter, reset by
-section.  In particular, `ch06_spectral_properties.tex` has been transcribed as
-one section, whereas the published chapter has several sections.  Lemmas,
-propositions, corollaries, examples, problems, and remarks therefore contribute
-to one unbroken local counter.  The two numberings agree near the beginning of
-the chapter and diverge later.
+The shared declarations in `Notes/WolfNoteTexSource/preamble.tex` use one
+theorem counter, reset by section.  Chapter 6 overrides those declarations:
+`ch06_spectral_properties.tex` undefines the shared environments and gives
+propositions, corollaries, lemmas, definitions, examples, and remarks separate
+section-scoped counters.  Since that file is one section numbered 6, its fifth
+corollary is rendered as Corollary 6.5.  Equation numbers have an independent
+counter; in particular, 6.29 is an equation number, not the local number of
+this corollary.
 
 Wolf's own cross-references in the chapter are the primary local evidence for
 the published numbering.  For example, the proof of *Unique fixed points of
 full rank* and the proof of *Asymptotic image* both cite Corollary 6.5 for the
-result *Linearly independent stationary states*.  The local counter renders
-that result as 6.29; neither the local rendering nor the formerly used number
-6.8 is the published citation.
+result *Linearly independent stationary states*.  The local corollary counter
+also renders that result as 6.5; the formerly used number 6.8 is not the
+published citation.
 
 When adding a source reference, use the following order of evidence:
 

--- a/docs/wolf_source_numbering.md
+++ b/docs/wolf_source_numbering.md
@@ -1,0 +1,31 @@
+# Numbering in the local Wolf transcription
+
+The files in `Notes/WolfNoteTexSource/` are a useful searchable transcription
+of M. Wolf, *Quantum Channels & Operations: Guided Tour*.  Their automatically
+rendered theorem numbers are not, in general, the theorem numbers of the
+published notes.
+
+The shared declarations in `preamble.tex` use one theorem counter, reset by
+section.  In particular, `ch06_spectral_properties.tex` has been transcribed as
+one section, whereas the published chapter has several sections.  Lemmas,
+propositions, corollaries, examples, problems, and remarks therefore contribute
+to one unbroken local counter.  The two numberings agree near the beginning of
+the chapter and diverge later.
+
+Wolf's own cross-references in the chapter are the primary local evidence for
+the published numbering.  For example, the proof of *Unique fixed points of
+full rank* and the proof of *Asymptotic image* both cite Corollary 6.5 for the
+result *Linearly independent stationary states*.  The local counter renders
+that result as 6.29; neither the local rendering nor the formerly used number
+6.8 is the published citation.
+
+When adding a source reference, use the following order of evidence:
+
+1. Wolf's explicit cross-reference in the text;
+2. the number in the published notes;
+3. if neither is available, the result's title and a line range in the local
+   source, without an inferred theorem number.
+
+The same caution applies to every chapter whose local section structure differs
+from the published notes.  A number should not be inferred solely from a local
+rendering.


### PR DESCRIPTION
## Summary

- correct every live Chapter 6 citation of *Linearly independent stationary states* from Corollary 6.8 to Wolf Corollary 6.5
- align the Lean module, blueprint, and paper-gap note with Wolf’s own cross-references
- document why theorem numbers must not be inferred from the local transcription’s rendered counter
- separate the cross-chapter audit into LionSR/QICLean#346, where its broader source-verification scope can be reviewed independently

## Source check

The proof of *Unique fixed points of full rank* and the proof of *Asymptotic image* in `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` both refer to *Linearly independent stationary states* as Corollary 6.5.

## Validation

- `lake env lean TNLean/Channel/FixedPoint/StationarySpan.lean`
- no remaining live `Corollary 6.8` stationary-span citations outside dated audit material
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Closes LionSR/QICLean#326. Follow-up: LionSR/QICLean#346.