### PR TITLE
docs(qic): record deploy-key authentication

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -275,29 +275,31 @@ not tag a PR head that differs from the merged commit.
 ## 8. Private dependency authentication
 
 TNLean's ordinary `GITHUB_TOKEN` cannot clone a different private repository.
-Before opening the TNLean PR, create a fine-grained token or GitHub App token
-with read-only Contents access to `LionSR/QICLean`, and store it in TNLean as
-`QICLEAN_READ_TOKEN`. Never write the token to a file, command trace, PR body,
+QICLean therefore has a read-only deploy key, and TNLean stores the matching
+private key as the Actions secret `QICLEAN_DEPLOY_KEY`. The release dependency
+must use the SSH URL `git@github.com:LionSR/QICLean.git`; public Lake dependencies
+continue to use HTTPS. Never write the private key to a command trace, PR body,
 or Lake configuration.
 
-Every TNLean workflow that invokes Lake must configure authenticated HTTPS
-before Lake resolves dependencies:
+Every TNLean workflow that invokes Lake must install the key before Lake resolves
+dependencies:
 
 ```yaml
 - name: Authenticate private QICLean dependency
   env:
-    QICLEAN_READ_TOKEN: ${{ secrets.QICLEAN_READ_TOKEN }}
+    QICLEAN_DEPLOY_KEY: ${{ secrets.QICLEAN_DEPLOY_KEY }}
   run: |
-    test -n "$QICLEAN_READ_TOKEN"
-    git config --global \
-      url."https://x-access-token:${QICLEAN_READ_TOKEN}@github.com/".insteadOf \
-      "https://github.com/"
+    test -n "$QICLEAN_DEPLOY_KEY"
+    install -d -m 700 "$HOME/.ssh"
+    printf '%s\n' "$QICLEAN_DEPLOY_KEY" > "$HOME/.ssh/id_ed25519"
+    chmod 600 "$HOME/.ssh/id_ed25519"
+    ssh-keyscan -t ed25519 github.com >> "$HOME/.ssh/known_hosts"
 ```
 
-The secret must be available to push and same-repository pull-request builds.
-Fork pull requests do not receive it, so the repository policy must either run
-trusted maintainer builds after review or use a read-only GitHub App that issues
-a short-lived token. Document this limitation in `CONTRIBUTING.md`.
+The QICLean repository setting must keep this deploy key read-only. The secret
+must be available to push and same-repository pull-request builds. Fork pull
+requests do not receive it, so the repository policy must run a trusted
+maintainer build after review. Document this limitation in `CONTRIBUTING.md`.
 
 ## 9. TNLean integration
 


### PR DESCRIPTION
## What changed

- record the provisioned read-only QICLean deploy-key authentication
- use the private repository's SSH URL without rewriting public Lake dependencies
- give every Lake workflow the exact key-installation step required before dependency resolution
- retain the same-repository and fork-PR security limitation explicitly

This updates the extraction runbook only. Workflow changes remain part of the final TNLean integration PR after the QICLean release exists.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- no stale `QICLEAN_READ_TOKEN`, fine-grained-token, or authenticated-HTTPS instructions remain
- `git diff --check`

Advances #6622
Advances #6560
