### PR TITLE
docs(qic): harden deploy-key authentication example

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -291,10 +291,22 @@ dependencies:
   run: |
     test -n "$QICLEAN_DEPLOY_KEY"
     install -d -m 700 "$HOME/.ssh"
-    printf '%s\n' "$QICLEAN_DEPLOY_KEY" > "$HOME/.ssh/id_ed25519"
-    chmod 600 "$HOME/.ssh/id_ed25519"
-    ssh-keyscan -t ed25519 github.com >> "$HOME/.ssh/known_hosts"
+    key_file="$HOME/.ssh/qiclean_deploy_key"
+    hosts_file="$HOME/.ssh/qiclean_known_hosts"
+    printf '%s\n' "$QICLEAN_DEPLOY_KEY" > "$key_file"
+    chmod 600 "$key_file"
+    printf '%s\n' \
+      'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' \
+      > "$hosts_file"
+    chmod 600 "$hosts_file"
+    printf '%s\n' \
+      "GIT_SSH_COMMAND=ssh -i $key_file -o IdentitiesOnly=yes -o UserKnownHostsFile=$hosts_file" \
+      >> "$GITHUB_ENV"
 ```
+
+The pinned host line is GitHub's published Ed25519 key, whose fingerprint is
+`SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU`. Update it only after
+checking the replacement against GitHub's published metadata.
 
 The QICLean repository setting must keep this deploy key read-only. The secret
 must be available to push and same-repository pull-request builds. Fork pull


### PR DESCRIPTION
## What changed

- use dedicated QICLean deploy-key and known-host files in the workflow example
- pin GitHub's published Ed25519 host key instead of trusting `ssh-keyscan`
- force the QICLean Git operation to use only that identity and host-key file
- record the published host-key fingerprint for future rotation checks

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- GitHub API `meta.ssh_keys` contains the exact pinned Ed25519 key
- `ssh-keygen -lf -` reports the documented `SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU` fingerprint

Closes #6736
Advances #6622
Advances #6560
