### PR TITLE
doc(Channel): correct Wolf Kraus-freedom citation

### DIFF
--- a/TNLean/Channel/KrausUnitaryFreedom.lean
+++ b/TNLean/Channel/KrausUnitaryFreedom.lean
@@ -7,11 +7,11 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 import TNLean.Channel.KrausFreedom
 
 /-!
-# Unitary freedom of Kraus representations (Wolf Theorem 2.18 / Eq. (2.10))
+# Unitary freedom of Kraus representations (Wolf Theorem 2.1(4) / Eq. (2.10))
 
 This file restates the directional Kraus-freedom lemmas already proved in
 `TNLean.Channel.KrausRepresentation` and `TNLean.Channel.KrausFreedom` as
-iff statements matching Wolf Theorem 2.18 (ensemble equivalence, Eq. (2.10)).
+iff statements matching Wolf Theorem 2.1(4) (ensemble equivalence, Eq. (2.10)).
 
 ## Main results
 
@@ -23,7 +23,8 @@ iff statements matching Wolf Theorem 2.18 (ensemble equivalence, Eq. (2.10)).
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 2.18][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 2.1(4) and
+  Equation (2.10)][Wolf2012QChannels]
 -/
 
 open scoped Matrix
@@ -31,7 +32,7 @@ open Matrix Finset BigOperators
 
 variable {d d' : ℕ}
 
-/-- **Wolf Theorem 2.18 (isometric form)**: two finite Kraus families define the
+/-- **Wolf Theorem 2.1(4) (isometric form)**: two finite Kraus families define the
 same completely positive map if and only if, after padding the smaller family
 with zeros, they are related by an isometric mixing matrix. Stated for
 rectangular Kraus operators `Matrix (Fin d') (Fin d) ℂ`; the square form is
@@ -50,7 +51,7 @@ theorem kraus_isometry_freedom_iff
   rintro ⟨V, hV, hBA⟩
   exact kraus_same_map_of_isometry_combination (K := B) (K' := A) (W := V) hV hBA
 
-/-- **Wolf Theorem 2.18 (unitary form)**: if two Kraus families have the same
+/-- **Wolf Theorem 2.1(4) (unitary form)**: if two Kraus families have the same
 finite index type, then they define the same completely positive map if and only
 if they are related by a unitary mixing matrix. -/
 theorem kraus_unitary_freedom_iff

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -99,9 +99,9 @@ project import.
   - `kraus_rectangular_freedom` / `kraus_rectangular_freedom'`
     — Kraus freedom (necessary direction) ✓
   - `kraus_isometry_freedom_iff`
-    — Wolf Theorem 2.18 in isometric form, including zero-padding of the smaller family ✓
+    — Wolf Theorem 2.1(4) in isometric form, including zero-padding of the smaller family ✓
   - `kraus_unitary_freedom_iff`
-    — Wolf Theorem 2.18 in same-size unitary form ✓
+    — Wolf Theorem 2.1(4) in same-size unitary form ✓
   - `Channel.HasKrausCard` / `Channel.HasKrausRankLE` / `Channel.choiRank` /
     `Channel.hasKrausCard_mono` / `Channel.choiRank_le_of_hasKrausCard` /
     `Channel.hasKrausCard_choiRank_of_cp`

--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -160,7 +160,7 @@ theorem zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical
 /-- The transfer map is invariant under unitary rotation of the physical index:
 `E_{rotatePhysical u A} = E_A` when `u * uᴴ = 1`.
 
-This follows from unitary freedom of the Kraus representation (Theorem 2.18,
+This follows from unitary freedom of the Kraus representation (Theorem 2.1(4),
 Wolf *Quantum Channels & Operations*). -/
 theorem transferMap_rotatePhysical (A : MPSTensor d D) (u : Matrix (Fin d) (Fin d) ℂ)
     (hu : u * uᴴ = 1) :

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -52,7 +52,7 @@ every `τ : Fin N → Fin m`,
 This is the coefficient-expansion identity used in both directions of Theorem 4.1:
 in the forward direction it rewrites a refinement witness as `SameMPV` for the
 tensor \(C\), and in the reverse direction it expands the blocked witness
-produced by Wolf Theorem 2.18. -/
+produced by Wolf Theorem 2.1(4). -/
 theorem evalWord_sum_smul_ofFn
     {m : ℕ} (B : MPSTensor d D) (W : Matrix (Fin m) (Fin d) ℂ) :
     ∀ (N : ℕ) (τ : Fin N → Fin m),

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -130,7 +130,7 @@ The proof follows the paper (arXiv:1708.00029 Section 4.1, converse paragraph): 
 canonicalization we obtain `A : MPSTensor d D` with
 `transferMap B = transferMap (blockTensor A p)`; this matches two Kraus representations of
 the same CP map (`blockTensor A p` with `d^p` operators and `B` with `d` operators), so
-Wolf Theorem 2.18 (`kraus_isometry_freedom_iff`) supplies an isometry
+Wolf Theorem 2.1(4) (`kraus_isometry_freedom_iff`) supplies an isometry
 `V : Matrix (Fin (d^p)) (Fin d) ℂ` with `Vᴴ V = 1` and
 `blockTensor A p α = ∑_j V α j • B j`. Expanding `coeff (blockTensor A p) (ofFn τ)` with
 the auxiliary `evalWord_sum_smul_ofFn` and linearity of `trace` produces exactly the
@@ -144,7 +144,7 @@ theorem thm_4_1_p_refinement_reverse
   obtain ⟨A, hTransferEq⟩ := hInverse hB hDivisible
   classical
   -- `d ≤ d^p = blockPhysDim d p` whenever `p ≥ 1`: the Kraus-rank comparison needed by
-  -- Wolf Theorem 2.18.
+  -- Wolf Theorem 2.1(4).
   have hCard : Fintype.card (Fin d) ≤ Fintype.card (Fin (blockPhysDim d p)) := by
     simp only [Fintype.card_fin, blockPhysDim_eq_pow]
     exact Nat.le_self_pow hp.ne' d
@@ -158,7 +158,7 @@ theorem thm_4_1_p_refinement_reverse
     have hEq : transferMap (blockTensor A p) X = transferMap B X := by
       rw [← hTransferEq]
     simpa [transferMap_apply] using hEq
-  -- Extract the isometric mixing matrix `V` from Wolf Theorem 2.18.
+  -- Extract the isometric mixing matrix `V` from Wolf Theorem 2.1(4).
   obtain ⟨V, hV, hBA⟩ :=
     (kraus_isometry_freedom_iff (blockTensor A p) B hCard).mp hKraus
   refine ⟨A, V, hV, ?_⟩

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -404,7 +404,7 @@ theorem condC2_iff_condC3 :
 if `u` is unitary then `∑_i (∑_j u_{ij} A_j) X (∑_j u_{ij} A_j)† = ∑_i A_i X A_i†`.
 
 This is a thin adapter over `kraus_same_map_of_unitary_combination` from
-`TNLean.Channel.KrausRepresentation` (Theorem 2.18 in Wolf's "Quantum
+`TNLean.Channel.KrausRepresentation` (Theorem 2.1(4) in Wolf's "Quantum
 Channels & Operations"). -/
 lemma unitary_kraus_mixing
     (A : Fin d → Matrix (Fin D) (Fin D) ℂ)

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -90,3 +90,25 @@ followed by a number of the form `1.n`. It excludes `docs/audits/`,
 `docs/archive/`, `docs/reviews/`, `docs/slides/`, and `blueprint/comments/`.
 Each result-level file list above was then checked against the matching printed
 statement in `Notes/WolfNotePDF/ch01_deconstructing_quantum.pdf`.
+
+## Chapter 2: Representations of quantum channels
+
+The Chapter 2 audit is in progress. The first correction concerns the unitary
+freedom of Kraus representations.
+
+| Former citation | Printed citation | Result | Archived PDF | Local transcription | Verdict |
+|---|---|---|---:|---:|---|
+| Theorem 2.18 | Theorem 2.1(4), with Equation (2.10) | Kraus representation: freedom of the Kraus family | PDF pages 4--5; printed pages 36--37 | lines 229--253; item (4) at lines 249--251; Equation (2.10) at lines 277--284 | Corrected |
+
+The printed chapter has no Theorem 2.18. Equation (2.18), on printed page 41,
+defines a weighted Hilbert--Schmidt scalar product and is unrelated to Kraus
+freedom.
+
+### Files corrected for Theorem 2.1(4)
+
+- `TNLean/Channel/KrausUnitaryFreedom.lean`
+- `TNLean/Channel/WolfChapter2Index.lean`
+- `TNLean/MPS/Periodic/Applications.lean`
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean`
+- `TNLean/MPS/Symmetry/StringOrderDefs.lean`


### PR DESCRIPTION
## Summary

- replace the nonexistent “Wolf Theorem 2.18” citation with Theorem 2.1(4), the Kraus-freedom clause
- retain Equation (2.10) as the ensemble-equivalence formula used in the proof
- correct all six citing modules and record the discrepancy in the shared numbering audit

The printed notes use 2.18 for an unrelated weighted Hilbert--Schmidt scalar product.

## Validation

- visually inspected archived Chapter 2 PDF pages 4--5 and 9
- no remaining `Theorem 2.18` occurrence outside the historical audit row
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- targeted Lake build of all six affected modules (9062 jobs, successful)
- `git diff --check`

Closes LionSR/QICLean#347
Advances LionSR/QICLean#346