### PR TITLE
doc(qic): isolate deploy-key SSH trust inputs

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -302,9 +302,11 @@ host-key list:
     printf '%s\n' \
       'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' \
       > "$QICLEAN_SSH_DIR/github_known_hosts"
-    QICLEAN_SSH_COMMAND="ssh -i $QICLEAN_SSH_DIR/deploy_key -o IdentitiesOnly=yes"
-    QICLEAN_SSH_COMMAND+=" -o UserKnownHostsFile=$QICLEAN_SSH_DIR/github_known_hosts"
-    QICLEAN_SSH_COMMAND+=" -o StrictHostKeyChecking=yes"
+    QICLEAN_SSH_COMMAND="ssh -i \"$QICLEAN_SSH_DIR/deploy_key\""
+    QICLEAN_SSH_COMMAND="$QICLEAN_SSH_COMMAND -o IdentitiesOnly=yes"
+    QICLEAN_SSH_COMMAND="$QICLEAN_SSH_COMMAND -o UserKnownHostsFile=\"$QICLEAN_SSH_DIR/github_known_hosts\""
+    QICLEAN_SSH_COMMAND="$QICLEAN_SSH_COMMAND -o GlobalKnownHostsFile=/dev/null"
+    QICLEAN_SSH_COMMAND="$QICLEAN_SSH_COMMAND -o StrictHostKeyChecking=yes"
     printf 'GIT_SSH_COMMAND=%s\n' "$QICLEAN_SSH_COMMAND" >> "$GITHUB_ENV"
 ```
 


### PR DESCRIPTION
## Summary

This exact-head follow-up to #6741 lands the review correction that arrived as the first pull request auto-merged:

- replace Bash-specific `+=` with POSIX-shell assignments
- retain explicit quoting around the dedicated key and host-key paths
- set `GlobalKnownHostsFile=/dev/null`, so SSH consults only the pinned GitHub host key

## Validation

- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`

Follow-up to #6741
Follow-up to #6736
Advances #6622
Advances #6560