### PR TITLE
refactor(qic): split matrix fitting namespace boundary

### DIFF
--- a/TNLean/Analysis/MatrixFittingRange.lean
+++ b/TNLean/Analysis/MatrixFittingRange.lean
@@ -18,7 +18,7 @@ Fitting summand, the stabilized range of an endomorphism, and injectivity on tha
 open scoped Matrix
 open Module
 
-namespace MPSTensor
+namespace Matrix
 
 variable {D : ℕ}
 
@@ -141,7 +141,9 @@ theorem fitting_nilpotent_pow_eq_zero
     _ = 0 := zero_mul _
 
 
-namespace WielandtRankOne
+end Matrix
+
+namespace Module.End
 
 /-- On `V = Fin D → ℂ`, the zero generalized eigenspace is the kernel of `f ^ D`. -/
 private lemma maxGenEigenspace_zero_eq_ker_pow
@@ -215,9 +217,9 @@ theorem range_pow_le_iSup_maxGenEigenspace_ne_zero
     simpa [map_add] using Submodule.add_mem W hv₁ hv₂
 
 
-end WielandtRankOne
+end Module.End
 
-namespace WielandtRankOne
+namespace Module.End
 
 /-- Coercing a restricted endomorphism back to the ambient space commutes with powers.
 
@@ -337,9 +339,9 @@ theorem range_pow_eq_iSup_maxGenEigenspace_ne_zero
   · exact iSup_maxGenEigenspace_ne_zero_le_range_pow (D := D) f
 
 
-end WielandtRankOne
+end Module.End
 
-namespace WielandtRankOne
+namespace Module.End
 
 /-! ## Invariance of the range of `f^D` under `f` -/
 
@@ -396,7 +398,7 @@ theorem disjoint_ker_range_pow (f : End ℂ (Fin D → ℂ)) :
       (⨆ (μ : ℂ) (_ : μ ≠ 0), f.maxGenEigenspace μ) :=
     disjoint_ker_iSup_maxGenEigenspace_ne_zero (D := D) f
   -- Rewrite the RHS via `range_pow_eq_iSup_maxGenEigenspace_ne_zero`.
-  simpa [WielandtRankOne.range_pow_eq_iSup_maxGenEigenspace_ne_zero (D := D) f] using hdisj
+  simpa [Module.End.range_pow_eq_iSup_maxGenEigenspace_ne_zero (D := D) f] using hdisj
 
 /-- The restriction of `f` to `range (f^D)` has trivial kernel. -/
 theorem ker_restrict_range_pow_eq_bot (f : End ℂ (Fin D → ℂ)) :
@@ -420,9 +422,7 @@ theorem isUnit_restrict_range_pow (f : End ℂ (Fin D → ℂ)) :
     ker_restrict_range_pow_eq_bot (D := D) f
   exact (LinearMap.isUnit_iff_ker_eq_bot (f := f.restrict (mapsTo_range_pow (D := D) f))).2 hker
 
-end WielandtRankOne
-
-end MPSTensor
+end Module.End
 
 /-! ## Matrix corollary -/
 
@@ -437,10 +437,10 @@ by A₁ preserves linear independence 'given that A₁ is invertible on its
 range'. -/
 theorem isUnit_restrict_range_toLin'_pow (M : Matrix (Fin D) (Fin D) ℂ) :
     IsUnit ((Matrix.toLin' M).restrict
-      (MPSTensor.WielandtRankOne.mapsTo_range_pow (D := D) (f := Matrix.toLin' M))) := by
+      (Module.End.mapsTo_range_pow (D := D) (f := Matrix.toLin' M))) := by
   -- Apply the abstract lemma to `f = Matrix.toLin' M`.
   simpa [Matrix.toLin'_pow] using
-    (MPSTensor.WielandtRankOne.isUnit_restrict_range_pow
+    (Module.End.isUnit_restrict_range_pow
       (D := D) (f := Matrix.toLin' M))
 
 /-! ## Pointwise matrix injectivity -/
@@ -455,7 +455,7 @@ theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
   classical
   let f : End ℂ (Fin D → ℂ) := Matrix.toLin' M
   have hdisj : Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) :=
-    MPSTensor.WielandtRankOne.disjoint_ker_range_pow (D := D) (f := f)
+    Module.End.disjoint_ker_range_pow (D := D) (f := f)
   have hv' : v ∈ LinearMap.range (f ^ D) := by
     simpa only [f, Matrix.toLin'_pow] using hv
   have hker : v ∈ LinearMap.ker f := by
@@ -504,18 +504,3 @@ theorem eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
 
 
 end Matrix
-
-namespace MPSTensor.WielandtRankOne
-
-@[deprecated Matrix.isUnit_restrict_range_toLin'_pow (since := "2026-08-20")]
-alias isUnit_restrict_range_toLin'_pow := Matrix.isUnit_restrict_range_toLin'_pow
-
-@[deprecated Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow (since := "2026-08-20")]
-alias vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow :=
-  Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
-
-@[deprecated Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow (since := "2026-08-20")]
-alias matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow :=
-  Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
-
-end MPSTensor.WielandtRankOne

--- a/TNLean/Kraus/Wielandt/RankOne/Element.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Element.lean
@@ -62,7 +62,7 @@ theorem exists_nonzero_pow_evalWord_mem_wordSpan_range_le
   refine ⟨(MPSTensor.evalWord K w₀) ^ D, ?_, ?_, ?_⟩
   · simpa [Nat.mul_comm] using evalWord_pow_mem_wordSpan K w₀ D
   · have hpow : ((MPSTensor.evalWord K w₀) ^ D) *ᵥ φ = μ ^ D • φ :=
-      MPSTensor.pow_mulVec_eq_smul_of_mulVec_eq_smul
+      Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul
         (M := MPSTensor.evalWord K w₀) (φ := φ) (μ := μ) heig D
     have hμpow : μ ^ D ≠ 0 := pow_ne_zero _ hμ
     intro hP0
@@ -75,7 +75,7 @@ theorem exists_nonzero_pow_evalWord_mem_wordSpan_range_le
     have hrange :
         LinearMap.range (f ^ D) ≤
           ⨆ (ν : ℂ) (_ : ν ≠ 0), End.maxGenEigenspace f ν :=
-      MPSTensor.WielandtRankOne.range_pow_le_iSup_maxGenEigenspace_ne_zero
+      Module.End.range_pow_le_iSup_maxGenEigenspace_ne_zero
         (D := D) f
     simpa [f, Matrix.toLin'_pow] using hrange
 

--- a/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
@@ -74,10 +74,10 @@ private noncomputable def blockedTensorRangeData
       hφ_range := ?_
       hψ_range := ?_ }
   · simpa [hBi₀] using
-      MPSTensor.mem_range_toLin'_pow_of_eigenvector
+      Matrix.mem_range_toLin'_pow_of_eigenvector
         (M := MPSTensor.evalWord K (List.ofFn σ₀)) (φ := φ) (μ := μ) hμ heigφ
   · simpa [hBi₁] using
-      MPSTensor.mem_range_vecMulLinear_pow_of_transpose_eigenvector
+      Matrix.mem_range_vecMulLinear_pow_of_transpose_eigenvector
         (M := MPSTensor.evalWord K (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ
 
 private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top

--- a/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -155,7 +155,7 @@ theorem eigenvector_mem_range_toLin_pow
     (heig : K i₀ *ᵥ φ = μ • φ) :
     φ ∈ LinearMap.range (Matrix.toLin' ((K i₀) ^ D)) := by
   have hpow : (K i₀ ^ D) *ᵥ φ = (μ ^ D) • φ :=
-    MPSTensor.pow_mulVec_eq_smul_of_mulVec_eq_smul (K i₀) φ μ heig D
+    Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul (K i₀) φ μ heig D
   rw [LinearMap.mem_range]
   refine ⟨(μ⁻¹ ^ D) • φ, ?_⟩
   rw [Matrix.toLin'_apply, Matrix.mulVec_smul, hpow, smul_smul,
@@ -168,7 +168,7 @@ theorem eigenvector_mem_range_toLin_pow'
     (heig : K i₀ *ᵥ φ = μ • φ) :
     φ ∈ LinearMap.range (Matrix.toLin' ((K i₀) ^ k)) := by
   have hpow : (K i₀ ^ k) *ᵥ φ = (μ ^ k) • φ :=
-    MPSTensor.pow_mulVec_eq_smul_of_mulVec_eq_smul (K i₀) φ μ heig k
+    Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul (K i₀) φ μ heig k
   rw [LinearMap.mem_range]
   refine ⟨(μ⁻¹ ^ k) • φ, ?_⟩
   rw [Matrix.toLin'_apply, Matrix.mulVec_smul, hpow, smul_smul,

--- a/TNLean/Wielandt/RankOne.lean
+++ b/TNLean/Wielandt/RankOne.lean
@@ -10,4 +10,5 @@ Authors: TNLean contributors
 
 import TNLean.Wielandt.RankOne.Construction
 import TNLean.Wielandt.RankOne.ExtractionFull
+import TNLean.Wielandt.RankOne.MatrixFittingRange
 import TNLean.Wielandt.RankOne.Products

--- a/TNLean/Wielandt/RankOne/MatrixFittingRange.lean
+++ b/TNLean/Wielandt/RankOne/MatrixFittingRange.lean
@@ -12,7 +12,71 @@ This module preserves the established matrix-product-tensor names for the neutra
 results about injectivity on stabilized ranges.
 -/
 
+namespace MPSTensor
+
+@[deprecated Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul (since := "2026-08-20")]
+alias pow_mulVec_eq_smul_of_mulVec_eq_smul :=
+  Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul
+
+@[deprecated Matrix.mem_range_toLin'_of_eigenvector (since := "2026-08-20")]
+alias mem_range_toLin'_of_eigenvector := Matrix.mem_range_toLin'_of_eigenvector
+
+@[deprecated Matrix.mem_range_vecMulLinear_of_transpose_eigenvector (since := "2026-08-20")]
+alias mem_range_vecMulLinear_of_transpose_eigenvector :=
+  Matrix.mem_range_vecMulLinear_of_transpose_eigenvector
+
+@[deprecated Matrix.mem_range_toLin'_pow_of_eigenvector (since := "2026-08-20")]
+alias mem_range_toLin'_pow_of_eigenvector := Matrix.mem_range_toLin'_pow_of_eigenvector
+
+@[deprecated Matrix.mem_range_vecMulLinear_pow_of_transpose_eigenvector
+  (since := "2026-08-20")]
+alias mem_range_vecMulLinear_pow_of_transpose_eigenvector :=
+  Matrix.mem_range_vecMulLinear_pow_of_transpose_eigenvector
+
+@[deprecated Matrix.fitting_nilpotent_bound (since := "2026-08-20")]
+alias fitting_nilpotent_bound := Matrix.fitting_nilpotent_bound
+
+@[deprecated Matrix.fitting_nilpotent_pow_eq_zero (since := "2026-08-20")]
+alias fitting_nilpotent_pow_eq_zero := Matrix.fitting_nilpotent_pow_eq_zero
+
+end MPSTensor
+
 namespace MPSTensor.WielandtRankOne
+
+@[deprecated Module.End.range_pow_le_iSup_maxGenEigenspace_ne_zero
+  (since := "2026-08-20")]
+alias range_pow_le_iSup_maxGenEigenspace_ne_zero :=
+  Module.End.range_pow_le_iSup_maxGenEigenspace_ne_zero
+
+@[deprecated Module.End.iSup_maxGenEigenspace_ne_zero_le_range_pow
+  (since := "2026-08-20")]
+alias iSup_maxGenEigenspace_ne_zero_le_range_pow :=
+  Module.End.iSup_maxGenEigenspace_ne_zero_le_range_pow
+
+@[deprecated Module.End.range_pow_eq_iSup_maxGenEigenspace_ne_zero
+  (since := "2026-08-20")]
+alias range_pow_eq_iSup_maxGenEigenspace_ne_zero :=
+  Module.End.range_pow_eq_iSup_maxGenEigenspace_ne_zero
+
+@[deprecated Module.End.mapsTo_range_pow (since := "2026-08-20")]
+alias mapsTo_range_pow := Module.End.mapsTo_range_pow
+
+@[deprecated Module.End.ker_le_maxGenEigenspace_zero (since := "2026-08-20")]
+alias ker_le_maxGenEigenspace_zero := Module.End.ker_le_maxGenEigenspace_zero
+
+@[deprecated Module.End.disjoint_ker_iSup_maxGenEigenspace_ne_zero
+  (since := "2026-08-20")]
+alias disjoint_ker_iSup_maxGenEigenspace_ne_zero :=
+  Module.End.disjoint_ker_iSup_maxGenEigenspace_ne_zero
+
+@[deprecated Module.End.disjoint_ker_range_pow (since := "2026-08-20")]
+alias disjoint_ker_range_pow := Module.End.disjoint_ker_range_pow
+
+@[deprecated Module.End.ker_restrict_range_pow_eq_bot (since := "2026-08-20")]
+alias ker_restrict_range_pow_eq_bot := Module.End.ker_restrict_range_pow_eq_bot
+
+@[deprecated Module.End.isUnit_restrict_range_pow (since := "2026-08-20")]
+alias isUnit_restrict_range_pow := Module.End.isUnit_restrict_range_pow
 
 @[deprecated Matrix.isUnit_restrict_range_toLin'_pow (since := "2026-08-20")]
 alias isUnit_restrict_range_toLin'_pow := Matrix.isUnit_restrict_range_toLin'_pow

--- a/TNLean/Wielandt/RankOne/MatrixFittingRange.lean
+++ b/TNLean/Wielandt/RankOne/MatrixFittingRange.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixFittingRange
+
+/-!
+# Matrix fitting-range compatibility names
+
+This module preserves the established matrix-product-tensor names for the neutral matrix
+results about injectivity on stabilized ranges.
+-/
+
+namespace MPSTensor.WielandtRankOne
+
+@[deprecated Matrix.isUnit_restrict_range_toLin'_pow (since := "2026-08-20")]
+alias isUnit_restrict_range_toLin'_pow := Matrix.isUnit_restrict_range_toLin'_pow
+
+@[deprecated Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow (since := "2026-08-20")]
+alias vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow :=
+  Matrix.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
+
+@[deprecated Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow (since := "2026-08-20")]
+alias matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow :=
+  Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+
+end MPSTensor.WielandtRankOne


### PR DESCRIPTION
## What changed

- moves seven matrix-vector and matrix-range declarations from `MPSTensor` to `Matrix` without changing their statements or proofs
- moves nine finite-dimensional Fitting and stabilized-range declarations from `MPSTensor.WielandtRankOne` to `Module.End`
- migrates all QIC-bound consumers to the neutral owners
- preserves every former public name as a deprecated alias in the TN-only `TNLean.Wielandt.RankOne.MatrixFittingRange` module, including the three aliases introduced by LionSR/TNLean#6724
- registers the compatibility module in the generated rank-one aggregator

## Declaration ownership

The QIC mover now contains only neutral `Matrix.*` and `Module.End.*` declarations. The TN-only compatibility module retains the seven former `MPSTensor.*` names, the nine former `MPSTensor.WielandtRankOne.*` names, and the three established matrix-corollary aliases.

## Validation

- focused build: 3049/3049 jobs on the initial relocation
- direct compilation of the compatibility module after the review fix
- generated aggregators: 60 files, 1482 production modules
- import direction: 496 QIC-bound files, 0 import violations, 0 namespace-ratchet violations
- blueprint declaration synchronization, proof-integrity, and diff checks passed

Closes LionSR/TNLean#6744.
Advances LionSR/TNLean#6622, LionSR/QICLean#340, and LionSR/TNLean#6560.