### PR TITLE
doc(Channel): correct Wolf transfer-matrix citations

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -609,7 +609,7 @@ theorem scalar_of_filtering_min {R : Matrix n n ℂ} (hR : R.PosSemidef)
         have hzero : R i j = 0 := Complex.ext hre him
         simp [hij, hzero]
 
-/-- Wolf §2.3 AM--GM stationarity core: a positive semidefinite matrix whose real trace
+/-- Wolf §2.4 AM--GM stationarity core: a positive semidefinite matrix whose real trace
 pairing is minimized by the identity among determinant-one filters is scalar. -/
 theorem posDef_scalar_of_filtering_min {D : ℕ} {R : Matrix (Fin D) (Fin D) ℂ}
     (hR : R.PosSemidef)

--- a/TNLean/Analysis/MatrixTraceInequalities.lean
+++ b/TNLean/Analysis/MatrixTraceInequalities.lean
@@ -27,7 +27,7 @@ product/sum form (`pow_card_mul_prod_le_sum_pow`) and its
 positive-semidefinite trace--determinant specialisation
 `Dᴰ · det M ≤ (tr M)ᴰ`, with the equality case characterising scalar matrices.
 These are the eigenvalue estimate underlying the optimality ("AGM iteration")
-step of Wolf, Section 2.3, Proposition 2.8.
+step of Wolf, Section 2.4, Proposition 2.8.
 
 ## References
 
@@ -43,7 +43,7 @@ section AMGM
 /-- **AM–GM in product/sum form.**  For a nonnegative family `f : Fin D → ℝ`,
 `Dᴰ · ∏ f ≤ (∑ f)ᴰ`.  This is the polynomial form of the
 arithmetic–geometric-mean inequality with uniform weights `1 / D`.  Wolf
-Section 2.3 applies it to the eigenvalues of a Choi matrix in the optimality
+Section 2.4 applies it to the eigenvalues of a Choi matrix in the optimality
 ("AGM iteration") step of Proposition 2.8.  Both sides agree when `D = 0`
 (empty product `1`, empty sum `0`, and `0 ^ 0 = 1`). -/
 lemma pow_card_mul_prod_le_sum_pow {D : ℕ} (f : Fin D → ℝ) (hf : ∀ i, 0 ≤ f i) :
@@ -200,7 +200,7 @@ theorem IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_r
 `D × D` complex matrix `M`, `Dᴰ · det M ≤ (tr M)ᴰ` as real numbers (both
 `det M` and `tr M` are real for a Hermitian matrix).  This is the eigenvalue
 AM–GM estimate underlying the optimality ("AGM iteration") step of Wolf
-Proposition 2.8 (Section 2.3): `det M = ∏ λᵢ` and `tr M = ∑ λᵢ` for the
+Proposition 2.8 (Section 2.4): `det M = ∏ λᵢ` and `tr M = ∑ λᵢ` for the
 nonnegative eigenvalues `λᵢ`, so the bound is `pow_card_mul_prod_le_sum_pow`
 applied to the eigenvalue family. -/
 theorem PosSemidef.pow_card_mul_det_re_le_trace_re_pow {D : ℕ}
@@ -221,7 +221,7 @@ positive-semidefinite `D × D` complex matrix `M`, the bound
 `Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow` is an equality exactly
 when `M` is the scalar matrix `(tr M / D) · 1` — equivalently, when all
 eigenvalues coincide.  This is the equality case of the AM–GM step in Wolf
-Proposition 2.8 (Section 2.3): the "AGM iteration" terminates precisely at
+Proposition 2.8 (Section 2.4): the "AGM iteration" terminates precisely at
 scalar (maximally mixed) blocks. -/
 theorem PosSemidef.pow_card_mul_det_re_eq_trace_re_pow_iff {D : ℕ}
     {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.PosSemidef) :

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -9,7 +9,7 @@ import TNLean.Channel.LorentzNormalForm.NormalForm
 import TNLean.Channel.LorentzNormalForm.QubitNormalForm
 
 /-!
-# Lorentz normal form for quantum channels (Wolf Section 2.3, Propositions 2.8–2.11)
+# Lorentz normal form for quantum channels (Wolf Section 2.4, Propositions 2.8–2.11)
 
 Thin module assembling the normal-form development for quantum channels under
 filtering operations from four focused sub-modules.
@@ -29,5 +29,5 @@ filtering operations from four focused sub-modules.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4][Wolf2012QChannels]
 -/

--- a/TNLean/Channel/LorentzNormalForm/Basic.lean
+++ b/TNLean/Channel/LorentzNormalForm/Basic.lean
@@ -13,7 +13,7 @@ import TNLean.Analysis.MarginalSupport
 # Lorentz normal form: filtering operations and doubly-stochastic maps
 
 This module collects the shared definitions and matrix-algebra lemmas for the
-normal-form development of Wolf Section 2.3 (Equations (2.35)–(2.37)):
+normal-form development of Wolf Section 2.4 (Equations (2.35)–(2.37)):
 SL-filtering operations, the doubly-stochastic predicates, and the
 Kronecker-conjugation and partial-trace identities used by the minimisation
 argument.
@@ -40,7 +40,7 @@ argument.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker
@@ -53,7 +53,7 @@ section FilteringOperations
 
 /-- An `SLFiltering` for `D × D` matrices bundles a matrix `S` with
 `det S = 1` (and `S` invertible) together with its associated CP map
-`Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf Section 2.3. -/
+`Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf Section 2.4. -/
 structure SLFiltering (D : ℕ) where
   /-- The filtering matrix, with determinant 1. -/
   S : Matrix (Fin D) (Fin D) ℂ

--- a/TNLean/Channel/LorentzNormalForm/Infimum.lean
+++ b/TNLean/Channel/LorentzNormalForm/Infimum.lean
@@ -18,7 +18,7 @@ import Mathlib.Topology.MetricSpace.Bounded
 # Lorentz normal form: infimum attainment and the AM–GM optimality lemmas
 
 This module formalizes the compactness and optimality arguments of Wolf
-Section 2.3 (Equation (2.36)): for a positive-definite operator `τ` on
+Section 2.4 (Equation (2.36)): for a positive-definite operator `τ` on
 `ℂ^{d₂} ⊗ ℂ^{d₁}`, the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over
 `(S₁, S₂) ∈ SL(d₁, ℂ) × SL(d₂, ℂ)` is attained, and at the minimiser each
 partial trace saturates the trace–determinant AM–GM bound, hence is scalar.
@@ -35,7 +35,7 @@ partial trace saturates the trace–determinant AM–GM bound, hence is scalar.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
@@ -52,9 +52,9 @@ variable {D : ℕ}
 `S₁ ∈ SL(d₁, ℂ)`, `S₂ ∈ SL(d₂, ℂ)` is attained.  That is, the continuous
 function `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` achieves its minimum on
 the domain SL(d₁, ℂ) × SL(d₂, ℂ) — the two factors may have different
-dimensions (Wolf, Section 2.3, Equation (2.36)).
+dimensions (Wolf, Section 2.4, Equation (2.36)).
 
-**Proof** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
+**Proof** (Wolf Section 2.4).  Throughout, `‖·‖` denotes the Frobenius
 (Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bounds below are false
 for the operator norm (e.g. `‖I‖_op² = 1 < n`).  Writing `X = S₂ ⊗ₖ S₁`, the
 smallest-eigenvalue bound for a positive-definite matrix gives

--- a/TNLean/Channel/LorentzNormalForm/NormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/NormalForm.lean
@@ -26,7 +26,7 @@ square form is the equal-dimension specialization.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3,
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4,
   Proposition 2.9][Wolf2012QChannels]
 -/
 
@@ -56,7 +56,7 @@ classification of the possible doubly-stochastic normal forms.
 
 **Scope restriction (square case):** this is the equal-dimension case
 `T : Mₚ(ℂ) → Mₚ(ℂ)` (here `D × D → D × D`) of Wolf Proposition 2.9; the source
-(Wolf, *Quantum Channels & Operations*, Section 2.3) states it for a general
+(Wolf, *Quantum Channels & Operations*, Section 2.4) states it for a general
 `T : M_{d₁}(ℂ) → M_{d₂}(ℂ)` with separate filterings on each factor.  Documented
 in `docs/paper-gaps/wolf_prop28_square_case.tex`. -/
 theorem exists_normal_form_generic

--- a/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -10,7 +10,7 @@ import TNLean.Channel.Basic
 
 This module collects the Pauli-basis definitions and the three canonical-form
 predicates for qubit channels of Wolf Proposition 2.11
-(`Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.3): the
+(`Notes/WolfNoteTexSource/ch02_representations.tex`, Section 2.4): the
 diagonal, non-diagonal, and singular Lorentz normal forms.  The existence
 
 theorem is pending; see
@@ -26,7 +26,7 @@ theorem is pending; see
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.4][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -148,12 +148,12 @@ The correctly formulated theorem remains to be formalized. Its proof will need:
 - The Lorentz group classification of the filtering orbits;
 - The complete-positivity condition `λ₁ + λ₂ ≤ 1 + λ₃`.
 
-See Wolf Section 2.3 for the complete proof. -/
+See Wolf Section 2.4 for the complete proof. -/
 
 end LorentzNormalFormQubit
 
 /-
-## Connection to transfer-matrix normal forms (Wolf Section 2.3)
+## Connection to transfer-matrix normal forms (Wolf Section 2.4)
 
 The results above are stated at the level of CP maps. The corresponding
 transfer-matrix formulation is obtained by applying `transferMatrix` to both

--- a/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -155,9 +155,10 @@ end LorentzNormalFormQubit
 /-
 ## Connection to transfer-matrix normal forms (Wolf Section 2.3)
 
-The results above are stated at the level of CP maps.  The corresponding
-transfer-matrix formulation (Propositions 2.7-2.8 in the blueprint / TransferMatrix.lean)
-is obtained by applying `transferMatrix` to both sides.  The SVD normal form
+The results above are stated at the level of CP maps. The corresponding
+transfer-matrix formulation is obtained by applying `transferMatrix` to both
+sides; Wolf Section 2.4, lines 1000–1010, gives the qubit Pauli-transfer version
+of the unitary action. The SVD normal form
 (`Matrix.svd_of_isUnit`, `transferMatrix_svd_of_isUnit`) provides the
 algebraic engine: after SL-filterings, the transfer matrix of the doubly-stochastic
 map admits an SVD, which for D = 2 yields the Lorentz normal form decomposition.

--- a/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -158,10 +158,13 @@ end LorentzNormalFormQubit
 The results above are stated at the level of CP maps. The corresponding
 transfer-matrix formulation is obtained by applying `transferMatrix` to both
 sides; Wolf Section 2.4, lines 1000–1010, gives the qubit Pauli-transfer version
-of the unitary action. The SVD normal form
-(`Matrix.svd_of_isUnit`, `transferMatrix_svd_of_isUnit`) provides the
-algebraic engine: after SL-filterings, the transfer matrix of the doubly-stochastic
-map admits an SVD, which for D = 2 yields the Lorentz normal form decomposition.
+of the unitary action. The general complex singular value decompositions
+`Matrix.svd_of_isUnit` and `transferMatrix_svd_of_isUnit` concern invertible
+matrices and arbitrary unitary factors; they do not imply the Lorentz normal
+form and do not cover the singular channels in Wolf Proposition 2.11. A proof
+of the latter must use the restricted `SO(3)` action on the Pauli block, the
+Lorentz action induced by invertible filters, and the complete-positivity
+classification from Wolf Propositions 2.9 and 2.11.
 -/
 
 

--- a/TNLean/Channel/NormalForm.lean
+++ b/TNLean/Channel/NormalForm.lean
@@ -8,11 +8,15 @@ import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
 
 /-!
-# SVD normal form for (transfer) matrices (Wolf Section 2.3, Eqs. (2.35)-(2.40))
+# Singular value decompositions for (transfer) matrices
 
-This file formalizes the singular value decomposition (SVD) existence result
-from Wolf Section 2.3, which serves as the key technical building block for the
-transfer-matrix normal forms discussed there (Wolf Eqs. (2.38)-(2.40)).
+This file records singular value decomposition (SVD) existence results for
+general complex square matrices and transfer matrices.  They are elementary
+linear-algebraic results used in the normal-form development.
+
+Wolf Section 2.4 uses a real SVD only for the `3 × 3` block of a qubit
+transfer matrix.  The arbitrary-dimensional complex SVD proved here is more
+general and is not attributed to that passage.
 
 * **SVD for PSD matrices.** Every positive semi-definite complex square matrix
   admits a decomposition `M = U * diagonal σ * Uᴴ` with `U` unitary and `σ`
@@ -21,14 +25,14 @@ transfer-matrix normal forms discussed there (Wolf Eqs. (2.38)-(2.40)).
   admits a decomposition `M = U * diagonal σ * Vᴴ` with `U, V` unitary and
   `σ : n → ℝ` strictly positive.
 
-The full Wolf Section 2.3 Lorentz normal form (Proposition 2.9 / Proposition 2.11 for qubit
-channels) requires an optimization / compactness step to show the infimum of
-`tr τ'` over `SL(2, ℂ)` filterings is attained; that iterative argument is out
-of scope for this existence milestone and is tracked in the Chapter 2 index.
+The full Lorentz normal form of Wolf Section 2.4 (Propositions 2.9 and 2.11 for
+qubit channels) also requires a compactness argument showing that the infimum
+of `tr τ'` over `SL(2, ℂ)` filterings is attained.  That argument is developed
+in `TNLean.Channel.LorentzNormalForm`.
 
 The singular values produced here are not sorted and not proven unique;
-downstream Wolf Section 2.3 applications that need the sorted / unique variant will
-require additional work.
+the applications in Wolf Section 2.4 that require ordered or unique singular
+values need corresponding refinements.
 
 ## Main results
 
@@ -38,9 +42,6 @@ require additional work.
 * `transferMatrix_svd_of_isUnit` — SVD existence specialised to invertible
   transfer matrices of linear channel super-operators.
 
-## References
-
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -195,7 +196,7 @@ section TransferMatrixSVD
 
 variable {D : ℕ}
 
-/-- **SVD representation of a transfer matrix** (existence, Wolf Section 2.3).
+/-- **SVD representation of a transfer matrix.**
 Every invertible transfer matrix admits a singular value decomposition
 `T̂ = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ` strictly positive.
 

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -13,7 +13,7 @@ import Mathlib.LinearAlgebra.Eigenspace.Basic
 import Mathlib.Data.Matrix.Basis
 
 /-!
-# Transfer-matrix representation of channels (Wolf Section 2.2)
+# Transfer-matrix representation of channels (Wolf Section 2.3)
 
 This file defines the **transfer matrix** (matrix representation) of a linear
 map `T : M_D(ℂ) → M_D(ℂ)`. Given an ordered basis `{E_{kl}}` of standard
@@ -59,7 +59,7 @@ with composition. We also relate it to the Kraus representation.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.2][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
 -/
 
 open scoped Matrix BigOperators Kronecker MatrixOrder ComplexOrder
@@ -243,7 +243,7 @@ theorem transferMatrix_pow
 /-- Matrix trace of the transfer matrix equals the basis-independent operator trace.
 
 The nonzero bond-dimension assumption records the genuine matrix-algebra setting used in
-Wolf Section 2.2 and in the MPU transfer argument. -/
+Wolf Section 2.3 and in the MPU transfer argument. -/
 theorem trace_transferMatrix_eq_linearMap_trace [NeZero D]
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     Matrix.trace (transferMatrix T) =
@@ -324,15 +324,21 @@ theorem transferMatrix_kraus
   simp only [ite_and, mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
     Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, mul_comm]
 
-/-! ### Propositions 2.5-2.6: Transfer matrix characterizations of TP, unital, and HP maps -/
+/-! ### Transfer-matrix characterizations of TP, unital, and HP maps
+
+These are entrywise consequences of the transfer-matrix definition in Wolf
+Section 2.3, Equation (2.20), rather than numbered propositions. -/
 
 section TransferMatrixChar
 
-/-- **Proposition 2.6 (TP via transfer matrix)**: `T` is trace-preserving iff
+/-- **Trace preservation via the transfer matrix.** A map `T` is trace-preserving iff
 the column-diagonal sums of the transfer matrix give `δ_{kl}`:
 `∑_i T̂_{(i,i),(l,k)} = δ_{kl}`.
 
-This expresses the TP condition as a partial-trace constraint on `T̂`. -/
+This expresses the TP condition as a partial-trace constraint on `T̂`.
+
+Source: Wolf Section 2.3, Equation (2.20), and the matrix-unit basis discussion
+at `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 560–625. -/
 theorem transferMatrix_tp_iff
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     IsTracePreservingMap T ↔
@@ -369,9 +375,12 @@ theorem transferMatrix_tp_iff
             simp_rw [← Matrix.trace_smul, ← Matrix.trace_sum]
             rw [← sum_smul_single_eq X]
 
-/-- **Proposition 2.6 (Unital via transfer matrix)**: `T` is unital (`T 1 = 1`) iff
+/-- **Unitality via the transfer matrix.** A map `T` is unital (`T 1 = 1`) iff
 the row-diagonal sums of the transfer matrix give `δ_{ij}`:
-`∑_k T̂_{(j,i),(k,k)} = δ_{ij}`. -/
+`∑_k T̂_{(j,i),(k,k)} = δ_{ij}`.
+
+Source: Wolf Section 2.3, Equation (2.20), and the matrix-unit basis discussion
+at `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 560–625. -/
 theorem transferMatrix_unital_iff
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     T 1 = 1 ↔
@@ -390,9 +399,12 @@ theorem transferMatrix_unital_iff
     simp only [Matrix.sum_apply]
     have := h i j; simp only [transferMatrix_apply] at this; exact this
 
-/-- **Proposition 2.5 (Hermiticity-preserving via transfer matrix)**:
+/-- **Hermiticity preservation via the transfer matrix.**
 `T` preserves Hermiticity (`(T X)ᴴ = T Xᴴ` for all `X`) iff
-`T̂_{(j,i),(k,l)} = conj(T̂_{(i,j),(l,k)})` for all indices. -/
+`T̂_{(j,i),(k,l)} = conj(T̂_{(i,j),(l,k)})` for all indices.
+
+Source: Wolf Section 2.3, Equation (2.20), and the adjoint relation at
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 560–576. -/
 theorem transferMatrix_hermiticityPreserving_iff
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     (∀ X : Matrix (Fin D) (Fin D) ℂ, (T X)ᴴ = T Xᴴ) ↔
@@ -427,12 +439,12 @@ theorem transferMatrix_hermiticityPreserving_iff
 
 end TransferMatrixChar
 
-/-! ### Unitary conjugation maps (Wolf Section 2.3, preparation for Propositions 2.7-2.8)
+/-! ### Unitary conjugation maps
 
 The unitary conjugation `Ad_U(X) = U X U†` is the basic building block for
-the Lorentz normal form (Proposition 2.7). Its transfer matrix is `Ū ⊗ₖ U`,
-and composing with unitary conjugations transforms the transfer matrix by
-left/right multiplication — the algebraic engine behind normal forms. -/
+the unitary actions used in Wolf Section 2.4 before Proposition 2.11. Its
+transfer matrix is `Ū ⊗ₖ U`, and composing with unitary conjugations
+transforms the transfer matrix by left and right multiplication. -/
 
 section UnitaryConjugation
 
@@ -456,9 +468,13 @@ theorem unitaryConjLM_apply (U : Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     unitaryConjLM U X = U * X * Uᴴ := rfl
 
-/-- **Transfer matrix of unitary conjugation** (Wolf Proposition 2.7 ingredient):
+/-- **Transfer matrix of unitary conjugation.**
 `(Ad_U)^ = Ū ⊗ₖ U`, the Kronecker product of the entrywise conjugate
-of `U` with `U`. -/
+of `U` with `U`.
+
+This is the matrix-unit form of the unitary action discussed for qubit Pauli
+transfer matrices in Wolf Section 2.4; see
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 1000–1010. -/
 theorem transferMatrix_unitaryConj (U : Matrix (Fin D) (Fin D) ℂ) :
     transferMatrix (unitaryConjLM U) = U.map (starRingEnd ℂ) ⊗ₖ U := by
   have := transferMatrix_kraus (fun _ : Fin 1 => U) (unitaryConjLM U)
@@ -782,30 +798,21 @@ theorem unitaryConjLM_comp_transpose_mapsPSDConeOnto
 
 end ConePreservation
 
-/-! ### Propositions 2.7-2.8: Normal form decomposition via transfer matrix
+/-! ### Unitary conjugation of transfer matrices
 
-**Proposition 2.7** (Lorentz normal form): For any channel `T`, composing with
-unitary conjugations `Ad_{U₁}` and `Ad_{U₂}` yields a transfer matrix
-`(Ū₁ ⊗ U₁) * T̂ * (Ū₂ ⊗ U₂)`. By choosing `U₁, U₂` to diagonalize
-the 3×3 block (for qubits), one obtains the Lorentz normal form.
-
-**Proposition 2.8** (SVD representation): The singular value decomposition of
-the coefficient matrix `[tᵢⱼ]` in the trace-pairing expansion
-`T(ρ) = ∑ᵢⱼ tᵢⱼ σᵢ tr(σⱼ ρ)` yields the SVD representation
-`T(ρ) = ∑ₖ sₖ uₖ tr(vₖ ρ)` with orthonormal `{uₖ}`, `{vₖ}`.
-
-The key algebraic tool is `transferMatrix_unitaryConj_sandwich`, which
-shows how unitary conjugation acts on transfer matrices. -/
+Wolf Section 2.4, lines 1000–1010 of the local transcription, describes the
+left and right action of unitary conjugations on a qubit Pauli transfer matrix.
+The following identity gives its matrix-unit analogue in arbitrary dimension. -/
 
 section NormalForms
 
-/-- **Propositions 2.7-2.8 key identity**: The transfer matrix of `Ad_{U₁} ∘ T ∘ Ad_{U₂}`
+/-- **Transfer matrix under unitary conjugation.** The transfer matrix of
+`Ad_{U₁} ∘ T ∘ Ad_{U₂}`
 is `(Ū₁ ⊗ U₁) * T̂ * (Ū₂ ⊗ U₂)`.
 
-This is the algebraic engine behind the Lorentz normal form (Proposition 2.7)
-and the SVD representation (Proposition 2.8): by choosing unitaries `U₁, U₂`
-appropriately (e.g. via SVD of `T̂`), the transfer matrix can be brought
-to a diagonal or block-diagonal normal form. -/
+This is the matrix-unit analogue of the qubit Pauli-transfer identity in Wolf
+Section 2.4; see `Notes/WolfNoteTexSource/ch02_representations.tex`, lines
+1000–1010. -/
 theorem transferMatrix_unitaryConj_sandwich
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (U₁ U₂ : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -240,7 +240,7 @@ project import.
   - `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin` —
     the same statement with `Fin (max m n)` as common index set ✓
 
-### Section 2.2 Transfer matrix
+### Section 2.3 Transfer matrix
 
 * `transferMatrix` — the `D² × D²` matrix representing `T` in the
   standard-basis vectorization ✓
@@ -252,28 +252,31 @@ project import.
 * `MPSTensor.transferMatrix_eq` — MPS transfer-operator specialization, stated in
   `TNLean.MPS.Core.TransferMatrix`: `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✓
 
-### Section 2.2–2.3 Transfer matrix characterizations & normal forms (Propositions 2.5-2.8)
+### Sections 2.3–2.4 Transfer-matrix characterizations and unitary actions
 
-* `transferMatrix_tp_iff` — **Proposition 2.6**: TP ↔ column-diagonal sums = δ ✓
-* `transferMatrix_unital_iff` — **Proposition 2.6**: unital ↔ row-diagonal sums = δ ✓
-* `transferMatrix_hermiticityPreserving_iff` — **Proposition 2.5**: HP ↔ conjugation
-  symmetry of transfer matrix entries ✓
+* `transferMatrix_tp_iff` — Section 2.3, Equation (2.20), entrywise consequence:
+  TP ↔ column-diagonal sums = δ ✓
+* `transferMatrix_unital_iff` — Section 2.3, Equation (2.20), entrywise consequence:
+  unital ↔ row-diagonal sums = δ ✓
+* `transferMatrix_hermiticityPreserving_iff` — Section 2.3, Equation (2.20),
+  entrywise consequence: HP ↔ conjugation symmetry of transfer-matrix entries ✓
 * `unitaryConjLM` — unitary conjugation map `Ad_U(X) = U X U†` ✓
-* `transferMatrix_unitaryConj` — **Proposition 2.7 ingredient**: `(Ad_U)^ = Ū ⊗ₖ U` ✓
+* `transferMatrix_unitaryConj` — Section 2.4, lines 1000–1010, matrix-unit
+  analogue of the qubit unitary action: `(Ad_U)^ = Ū ⊗ₖ U` ✓
 * `unitaryConjLM_isChannel_of_unitary` — `Ad_U` is a channel for unitary `U` ✓
-* `transferMatrix_unitaryConj_sandwich` — **Propositions 2.7-2.8 key identity**:
+* `transferMatrix_unitaryConj_sandwich` — Section 2.4 unitary-action identity:
   `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✓
 
-### Section 2.3 SVD normal form (existence)
+### Section 2.4 SVD normal form (existence)
 
 * `Matrix.svd_of_posSemidef` — **SVD for PSD matrices** (spectral theorem
   formulated): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✓
 * `Matrix.svd_of_isUnit` — **SVD existence for invertible complex matrices**:
   `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✓
 * `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
-  matrix** (Wolf Section 2.3): every invertible transfer matrix admits an SVD ✓
+  matrix** (Wolf Section 2.4): every invertible transfer matrix admits an SVD ✓
 
-### Section 2.3 Lorentz normal form (existence)
+### Section 2.4 Lorentz normal form (existence)
 
 * `Wolf.SLFiltering` — **SL(d, ℂ)-filtering operation**: a CP map
   Φ(X) = S X S† with det(S) = 1 ✓ (definitional)

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -267,14 +267,14 @@ project import.
 * `transferMatrix_unitaryConj_sandwich` — Section 2.4 unitary-action identity:
   `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) * T̂ * (Ū₂⊗U₂)` ✓
 
-### Section 2.4 SVD normal form (existence)
+### General matrix SVD results
 
 * `Matrix.svd_of_posSemidef` — **SVD for PSD matrices** (spectral theorem
   formulated): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✓
 * `Matrix.svd_of_isUnit` — **SVD existence for invertible complex matrices**:
   `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✓
 * `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
-  matrix** (Wolf Section 2.4): every invertible transfer matrix admits an SVD ✓
+  matrix**: every invertible transfer matrix admits an SVD ✓
 
 ### Section 2.4 Lorentz normal form (existence)
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -265,7 +265,7 @@ project import.
   analogue of the qubit unitary action: `(Ad_U)^ = Ū ⊗ₖ U` ✓
 * `unitaryConjLM_isChannel_of_unitary` — `Ad_U` is a channel for unitary `U` ✓
 * `transferMatrix_unitaryConj_sandwich` — Section 2.4 unitary-action identity:
-  `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✓
+  `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) * T̂ * (Ū₂⊗U₂)` ✓
 
 ### Section 2.4 SVD normal form (existence)
 
@@ -348,11 +348,11 @@ project import.
 
 | Result | Notes |
 |--------|-------|
-| Section 2.3 Lorentz normal form (Proposition 2.11) | Correctly formulated
+| Section 2.4 Lorentz normal form (Proposition 2.11) | Correctly formulated
   statement and proof remain pending. Wolf uses general invertible Kraus-rank-one
   CP filters with scalar freedom; the former determinant-one formulation was
   false and was removed. The proof also needs the Lorentz-orbit classification. |
-| Section 2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
+| Section 2.4 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ## References
 

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -61,18 +61,18 @@
 \end{proof}
 
 %% =========================================================
-\section{SVD normal form (existence)}
+\section{General matrix singular value decompositions}
 \label{sec:svd_normal_form}
 %% =========================================================
 
-\cite[Section~2.4]{Wolf2012Quantum} discusses two families of normal forms for
-the transfer-matrix representation of a quantum channel: the \emph{singular
-    value decomposition} (SVD) and, for qubit channels, the \emph{Lorentz normal
-    form} obtained by general invertible Kraus-rank-one CP filtering operations.
-The SVD normal form is proved below. The Lorentz normal form theorem
-(Theorem~\ref{thm:lorentz_normal_form_qubit}) uses general invertible
-Kraus-rank-one completely positive filterings. Its proof requires the minimisation
-argument and Lorentz-orbit analysis in
+The results in this section are ordinary singular value decompositions in the
+general complex matrix-algebraic setting. They are useful for transfer matrices, but
+they are not the real $3\times3$ singular value decomposition arising from the
+$\SO(3)$ action on the traceless Pauli block of a qubit channel in
+\cite[Section~2.4]{Wolf2012Quantum}. The Lorentz normal form theorem
+(Theorem~\ref{thm:lorentz_normal_form_qubit}) instead uses general invertible
+Kraus-rank-one completely positive filterings. Its proof requires the
+minimisation argument and Lorentz-orbit analysis in
 \cite[Propositions~2.9 and~2.11]{Wolf2012Quantum}; see
 Section~\ref{sec:lorentz_normal_form}.
 
@@ -141,10 +141,9 @@ Section~\ref{sec:lorentz_normal_form}.
     Theorem~\ref{thm:svd_of_isUnit} produces the singular values as an
     unordered family, without the usual convention that $\sigma_i$ are sorted
     in non-increasing order or the statement that they are uniquely determined
-    by $M$. Downstream applications in \cite[Section~2.4]{Wolf2012Quantum},
-    such as trace-norm identities, polar decomposition, and the Lorentz normal
-    form, will typically require the sorted / unique variant; that refinement is
-    future work.
+    by $M$. Applications that distinguish individual singular values may also
+    require a non-increasing ordering and uniqueness of the resulting ordered
+    family. These refinements are not part of the present statement.
 \end{remark}
 
 %% =========================================================

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -65,7 +65,7 @@
 \label{sec:svd_normal_form}
 %% =========================================================
 
-\cite[Section~2.3]{Wolf2012Quantum} discusses two families of normal forms for
+\cite[Section~2.4]{Wolf2012Quantum} discusses two families of normal forms for
 the transfer-matrix representation of a quantum channel: the \emph{singular
     value decomposition} (SVD) and, for qubit channels, the \emph{Lorentz normal
     form} obtained by general invertible Kraus-rank-one CP filtering operations.
@@ -141,7 +141,7 @@ Section~\ref{sec:lorentz_normal_form}.
     Theorem~\ref{thm:svd_of_isUnit} produces the singular values as an
     unordered family, without the usual convention that $\sigma_i$ are sorted
     in non-increasing order or the statement that they are uniquely determined
-    by $M$. Downstream applications in \cite[Section~2.3]{Wolf2012Quantum},
+    by $M$. Downstream applications in \cite[Section~2.4]{Wolf2012Quantum},
     such as trace-norm identities, polar decomposition, and the Lorentz normal
     form, will typically require the sorted / unique variant; that refinement is
     future work.
@@ -153,7 +153,7 @@ Section~\ref{sec:lorentz_normal_form}.
 %% =========================================================
 
 This section states the existence theorems from
-\cite[Section~2.3]{Wolf2012Quantum}.
+\cite[Section~2.4]{Wolf2012Quantum}.
 % The existing Wolf.* declarations referenced in this section live in
 % TNLean/Channel/LorentzNormalForm.lean. The correctly formulated Proposition 2.11
 % has no Lean declaration yet; declaration tags are omitted for pending results.

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -133,10 +133,20 @@ statements.
 The transfer-matrix criteria are entrywise consequences of Equation (2.20),
 at lines 560–576, rather than numbered propositions. The unitary-conjugation
 formula is the arbitrary-dimensional matrix-unit analogue of the qubit
-Pauli-transfer discussion at lines 1000–1010.
+Pauli-transfer discussion at lines 1000–1010. The ordinary complex SVD of an
+arbitrary invertible transfer matrix is a general linear-algebraic result; it
+is not the real SVD of the qubit `3 × 3` block discussed in that passage.
 
 ### Files corrected
 
 - `TNLean/Channel/TransferMatrix.lean`
 - `TNLean/Channel/WolfChapter2Index.lean`
+- `TNLean/Channel/NormalForm.lean`
+- `TNLean/Channel/LorentzNormalForm.lean`
+- `TNLean/Channel/LorentzNormalForm/Basic.lean`
+- `TNLean/Channel/LorentzNormalForm/Infimum.lean`
+- `TNLean/Channel/LorentzNormalForm/NormalForm.lean`
 - `TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean`
+- `TNLean/Algebra/MatrixAux.lean`
+- `TNLean/Analysis/MatrixTraceInequalities.lean`
+- `blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex`

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -93,8 +93,10 @@ statement in `Notes/WolfNotePDF/ch01_deconstructing_quantum.pdf`.
 
 ## Chapter 2: Representations of quantum channels
 
-The Chapter 2 audit is in progress. The first correction concerns the unitary
-freedom of Kraus representations.
+The Chapter 2 audit is in progress. The corrections below concern the unitary
+freedom of Kraus representations and the transfer-matrix documentation.
+
+### Kraus-representation freedom
 
 | Former citation | Printed citation | Result | Archived PDF | Local transcription | Verdict |
 |---|---|---|---:|---:|---|
@@ -112,3 +114,29 @@ freedom.
 - `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
 - `TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean`
 - `TNLean/MPS/Symmetry/StringOrderDefs.lean`
+
+### Transfer matrices and normal forms
+
+The printed notes place linear maps as matrices in Section 2.3 and normal forms
+in Section 2.4. Several former references assigned elementary transfer-matrix
+identities to Propositions 2.5–2.8, but those propositions have different
+statements.
+
+| Former citation | Printed result | Archived PDF | Local transcription | Verdict |
+|---|---|---:|---:|---|
+| Proposition 2.5 | Environment-induced instruments | PDF page 8; printed page 40 | lines 447–456 | Removed from transfer-matrix criteria |
+| Proposition 2.6 | Self-dual channels | PDF page 10; printed page 42 | lines 578–600 | Removed from transfer-matrix criteria |
+| Proposition 2.7 | SIC POVMs | PDF page 14; printed page 46 | lines 790–800 | Removed from unitary-conjugation identities |
+| Proposition 2.8 | Generic normal form for a positive-definite Choi matrix | PDF page 16; printed page 48 | lines 894–899 | Removed from unitary-conjugation identities |
+| Proposition 2.11 | Lorentz normal form for qubit channels | PDF page 18; printed page 50 | lines 1021–1035 | Retained for the actual qubit theorem |
+
+The transfer-matrix criteria are entrywise consequences of Equation (2.20),
+at lines 560–576, rather than numbered propositions. The unitary-conjugation
+formula is the arbitrary-dimensional matrix-unit analogue of the qubit
+Pauli-transfer discussion at lines 1000–1010.
+
+### Files corrected
+
+- `TNLean/Channel/TransferMatrix.lean`
+- `TNLean/Channel/WolfChapter2Index.lean`
+- `TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean`


### PR DESCRIPTION
## Summary

- correct Wolf Chapter 2 citations for transfer-matrix criteria and unitary-action identities
- distinguish the general complex transfer-matrix SVD from Wolf's real qubit-block SVD
- correct the remaining normal-form citations from printed Section 2.3 to Section 2.4
- extend the shared numbering audit with the verified PDF pages and local transcription ranges

## Source verification

The printed Chapter 2 notes and the local TeX transcription show:

- transfer matrices in Section 2.3, with the entry formula at Equation (2.20)
- normal forms in Section 2.4
- Propositions 2.5–2.8 concern instruments, self-duality, SIC POVMs, and the generic Choi normal form, respectively
- the unitary qubit action and real SVD of the `3 × 3` block occur at transcription lines 1000–1010

## Validation

- targeted build of all affected Lean modules
- `python3 scripts/blueprint_lean_sync.py --ci` (8044/8044)
- `git diff --check`

Local `leanblueprint checkdecls` could not run because this worktree does not contain the generated `blueprint/lean_decls`; the hosted blueprint check supplies that validation.

Closes LionSR/QICLean#348.
Closes LionSR/QICLean#349.
Part of LionSR/QICLean#346.
