### PR TITLE
refactor(qic): split the foundational word layer

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -134,7 +134,7 @@ theorem mem_cumulativeSpan_of_mem_algSpan (A : MPSTensor d D)
   | mem x hxS =>
     rcases hxS with ⟨i, rfl⟩
     refine ⟨1, ?_⟩
-    simpa only [evalWord, Matrix.mul_one] using
+    simpa only [Kraus.evalWord, Matrix.mul_one] using
       (mem_cumulativeSpan_generator (A := A) (n := 1) (w := [i]) (by simp))
   | algebraMap r =>
     refine ⟨0, ?_⟩

--- a/TNLean/Channel/KrausIterateChoi.lean
+++ b/TNLean/Channel/KrausIterateChoi.lean
@@ -38,7 +38,7 @@ private theorem span_normalized_uncurry_words_eq_top_iff
         (Set.range fun σ : Fin m → Fin r =>
           fun p : Fin D × Fin D =>
             ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
-              MPSTensor.evalWord K (List.ofFn σ) p.1 p.2) = ⊤ ↔
+              Kraus.evalWord K (List.ofFn σ) p.1 p.2) = ⊤ ↔
       wordSpan K m = ⊤ := by
   let e : Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] ((Fin D × Fin D) → ℂ) :=
     (LinearEquiv.curry ℂ ℂ (Fin D) (Fin D)).symm
@@ -52,31 +52,31 @@ private theorem span_normalized_uncurry_words_eq_top_iff
   have hscale :
       Submodule.span ℂ
           (Set.range fun σ : Fin m → Fin r =>
-            c • e (MPSTensor.evalWord K (List.ofFn σ))) =
+            c • e (Kraus.evalWord K (List.ofFn σ))) =
         Submodule.span ℂ
           (Set.range fun σ : Fin m → Fin r =>
-            e (MPSTensor.evalWord K (List.ofFn σ))) := by
+            e (Kraus.evalWord K (List.ofFn σ))) := by
     apply le_antisymm
     · apply Submodule.span_le.mpr
       rintro _ ⟨σ, rfl⟩
       exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
     · apply Submodule.span_le.mpr
       rintro _ ⟨σ, rfl⟩
-      change e (MPSTensor.evalWord K (List.ofFn σ)) ∈ _
-      rw [← inv_smul_smul₀ hc (e (MPSTensor.evalWord K (List.ofFn σ)))]
+      change e (Kraus.evalWord K (List.ofFn σ)) ∈ _
+      rw [← inv_smul_smul₀ hc (e (Kraus.evalWord K (List.ofFn σ)))]
       exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
   have hmap :
       Submodule.map e.toLinearMap (wordSpan K m) =
         Submodule.span ℂ
           (Set.range fun σ : Fin m → Fin r =>
-            e (MPSTensor.evalWord K (List.ofFn σ))) := by
+            e (Kraus.evalWord K (List.ofFn σ))) := by
     rw [wordSpan, Submodule.map_span]
     congr 1
     ext v
     simp
   change Submodule.span ℂ
       (Set.range fun σ : Fin m → Fin r =>
-        c • e (MPSTensor.evalWord K (List.ofFn σ))) = ⊤ ↔ _
+        c • e (Kraus.evalWord K (List.ofFn σ))) = ⊤ ↔ _
   rw [hscale, ← hmap]
   exact Submodule.map_eq_top_iff
 
@@ -89,7 +89,7 @@ theorem choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top
       wordSpan K m = ⊤ := by
   let wordEquiv := Fintype.equivFin (Fin m → Fin r)
   let W : Fin (Fintype.card (Fin m → Fin r)) → Matrix (Fin D) (Fin D) ℂ :=
-    fun j => MPSTensor.evalWord K (List.ofFn (wordEquiv.symm j))
+    fun j => Kraus.evalWord K (List.ofFn (wordEquiv.symm j))
   have hW : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       ((mapLM K) ^ m) X = ∑ j, W j * X * (W j)ᴴ := by
     intro X
@@ -105,7 +105,7 @@ theorem choiMatrix_mapLM_pow_posDef_iff_wordSpan_eq_top
         Set.range (fun σ : Fin m → Fin r =>
           fun p : Fin D × Fin D =>
             ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
-              MPSTensor.evalWord K (List.ofFn σ) p.1 p.2) := by
+              Kraus.evalWord K (List.ofFn σ) p.1 p.2) := by
     ext v
     constructor
     · rintro ⟨j, rfl⟩

--- a/TNLean/Kraus/Blocking.lean
+++ b/TNLean/Kraus/Blocking.lean
@@ -177,23 +177,24 @@ lemma blockKron_mul_conjTranspose (L : ℕ) (P : Matrix (Fin d) (Fin d) ℂ)
   rw [blockKron_conjTranspose, ← blockKron_mul, hP, blockKron_one]
 
 /-- Block (coarse-grain) an MPS tensor by grouping `L` physical sites into one. -/
-noncomputable def blockTensor (A : MPSTensor d D) (L : ℕ) :
-    MPSTensor (blockPhysDim d L) D :=
-  fun i => evalWord A (wordOfBlock d L i)
+noncomputable def blockTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ) :
+    Fin (blockPhysDim d L) → Matrix (Fin D) (Fin D) ℂ :=
+  fun i => Kraus.evalWord A (wordOfBlock d L i)
 
-@[simp] lemma blockTensor_one_apply (A : MPSTensor d D) (i : Fin (blockPhysDim d 1)) :
+@[simp] lemma blockTensor_one_apply (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (i : Fin (blockPhysDim d 1)) :
     blockTensor (d := d) (D := D) A 1 i = A (singleBlockEquiv d i) := by
-  simp [blockTensor, MPSTensor.evalWord]
+  simp [blockTensor, Kraus.evalWord]
 
 /-- Equivalence between `N`-block injectivity and injectivity of the blocked
 tensor `blockTensor A N`. -/
-lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+lemma isNBlkInjective_iff_blockTensor_isInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical
   have hRange :
       Set.range (fun i : Fin (blockPhysDim d N) =>
-        evalWord A (List.ofFn (decodeBlock d N i))) =
-        Set.range (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
+        Kraus.evalWord A (List.ofFn (decodeBlock d N i))) =
+        Set.range (fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) := by
     ext M
     constructor
     · rintro ⟨i, rfl⟩
@@ -205,8 +206,8 @@ lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
   have hSpan :
       Submodule.span ℂ
           (Set.range fun i : Fin (blockPhysDim d N) =>
-            evalWord A (List.ofFn (decodeBlock d N i))) =
-        Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
+            Kraus.evalWord A (List.ofFn (decodeBlock d N i))) =
+        Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) := by
     simp [hRange]
   exact ⟨hSpan.trans, hSpan.symm.trans⟩
 
@@ -228,18 +229,19 @@ lemma flattenBlockedWord_cons (d L : ℕ) (i : Fin (blockPhysDim d L))
   | nil => simp [flattenBlockedWord]
   | cons i w ih => simp [flattenBlockedWord_cons, ih]
 
-lemma evalWord_blockTensor (A : MPSTensor d D) (L : ℕ) :
+lemma evalWord_blockTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ) :
     ∀ w : List (Fin (blockPhysDim d L)),
-      evalWord (blockTensor (d := d) (D := D) A L) w =
-        evalWord A (flattenBlockedWord d L w) := by
+      Kraus.evalWord (blockTensor (d := d) (D := D) A L) w =
+        Kraus.evalWord A (flattenBlockedWord d L w) := by
   intro w
   induction w with
   | nil =>
-      simp [flattenBlockedWord, evalWord]
+      simp [flattenBlockedWord, Kraus.evalWord]
   | cons i w ih =>
       -- Flattening splits off the first block word:
       -- `flattenBlockedWord (i :: w) = wordOfBlock i ++ flattenBlockedWord w`.
-      simp [evalWord, blockTensor, flattenBlockedWord_cons, ih, evalWord_append]
+      simp [Kraus.evalWord, blockTensor, flattenBlockedWord_cons, ih,
+        Kraus.evalWord_append]
 
 /-- Length of a flattened blocked word. -/
 lemma length_flattenBlockedWord (d L : ℕ) :
@@ -300,23 +302,23 @@ lemma ofFn_blockedConfigEquiv (d N L : ℕ)
   change (List.ofFn fun j : Fin L => decodeBlock d L (σ i) j) = (wordOfBlock d L ∘ σ) i
   simp [wordOfBlock, Function.comp]
 
-private theorem evalWord_pointwise_conjTranspose_reverse (A : MPSTensor d D) :
-    ∀ w : List (Fin d), (evalWord (fun i => (A i)ᴴ) w)ᴴ = evalWord A w.reverse := by
+private theorem evalWord_pointwise_conjTranspose_reverse (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    ∀ w : List (Fin d), (Kraus.evalWord (fun i => (A i)ᴴ) w)ᴴ = Kraus.evalWord A w.reverse := by
   intro w
   induction w with
   | nil =>
-      simp [evalWord]
+      simp [Kraus.evalWord]
   | cons i w ih =>
-      simp [evalWord, Matrix.conjTranspose_mul, ih, evalWord_append, List.reverse_cons,
-        Matrix.conjTranspose_conjTranspose]
+      simp [Kraus.evalWord, Matrix.conjTranspose_mul, ih, Kraus.evalWord_append,
+        List.reverse_cons, Matrix.conjTranspose_conjTranspose]
 
 /-- Left-canonical normalization propagates from one site to words of every fixed length. -/
 theorem sum_evalWord_conjTranspose_mul_evalWord
-    (A : MPSTensor d D)
+    (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∀ L : ℕ,
       ∑ σ : Fin L → Fin d,
-        (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ) = 1 := by
+        (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ) = 1 := by
   intro L
   induction L with
   | zero =>
@@ -326,70 +328,70 @@ theorem sum_evalWord_conjTranspose_mul_evalWord
         Fin.consEquiv (fun _ => Fin d)
       calc
         ∑ σ : Fin (L + 1) → Fin d,
-            (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ)
+            (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ)
           = ∑ p : Fin d × (Fin L → Fin d),
-              (evalWord A (List.ofFn (e p)))ᴴ * evalWord A (List.ofFn (e p)) := by
+              (Kraus.evalWord A (List.ofFn (e p)))ᴴ * Kraus.evalWord A (List.ofFn (e p)) := by
                 simpa [e] using
                   (Fintype.sum_equiv e
                     (f := fun p : Fin d × (Fin L → Fin d) =>
-                      (evalWord A (List.ofFn (e p)))ᴴ * evalWord A (List.ofFn (e p)))
+                      (Kraus.evalWord A (List.ofFn (e p)))ᴴ * Kraus.evalWord A (List.ofFn (e p)))
                     (g := fun σ : Fin (L + 1) → Fin d =>
-                      (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ))
+                      (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ))
                     (by intro p; rfl)).symm
         _ = ∑ τ : Fin L → Fin d,
               ∑ i : Fin d,
-                (evalWord A (List.ofFn (e (i, τ))))ᴴ *
-                  evalWord A (List.ofFn (e (i, τ))) := by
+                (Kraus.evalWord A (List.ofFn (e (i, τ))))ᴴ *
+                  Kraus.evalWord A (List.ofFn (e (i, τ))) := by
                 simpa using
                   (Fintype.sum_prod_type_right'
                     (f := fun i : Fin d => fun τ : Fin L → Fin d =>
-                      (evalWord A (List.ofFn (e (i, τ))))ᴴ *
-                        evalWord A (List.ofFn (e (i, τ)))))
+                      (Kraus.evalWord A (List.ofFn (e (i, τ))))ᴴ *
+                        Kraus.evalWord A (List.ofFn (e (i, τ)))))
         _ = ∑ τ : Fin L → Fin d,
-              (evalWord A (List.ofFn τ))ᴴ * evalWord A (List.ofFn τ) := by
+              (Kraus.evalWord A (List.ofFn τ))ᴴ * Kraus.evalWord A (List.ofFn τ) := by
                 refine Finset.sum_congr rfl ?_
                 intro τ _
                 have hτ :
                     ∑ i : Fin d,
-                      (evalWord A (List.ofFn (Fin.cons i τ)))ᴴ *
-                        evalWord A (List.ofFn (Fin.cons i τ)) =
-                    (evalWord A (List.ofFn τ))ᴴ * evalWord A (List.ofFn τ) := by
+                      (Kraus.evalWord A (List.ofFn (Fin.cons i τ)))ᴴ *
+                        Kraus.evalWord A (List.ofFn (Fin.cons i τ)) =
+                    (Kraus.evalWord A (List.ofFn τ))ᴴ * Kraus.evalWord A (List.ofFn τ) := by
                   calc
                     ∑ i : Fin d,
-                        (evalWord A (List.ofFn (Fin.cons i τ)))ᴴ *
-                          evalWord A (List.ofFn (Fin.cons i τ))
+                        (Kraus.evalWord A (List.ofFn (Fin.cons i τ)))ᴴ *
+                          Kraus.evalWord A (List.ofFn (Fin.cons i τ))
                       = ∑ i : Fin d,
-                          (evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i *
-                            evalWord A (List.ofFn τ) := by
+                          (Kraus.evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i *
+                            Kraus.evalWord A (List.ofFn τ) := by
                               simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
-                    _ = (evalWord A (List.ofFn τ))ᴴ *
+                    _ = (Kraus.evalWord A (List.ofFn τ))ᴴ *
                           (∑ i : Fin d, (A i)ᴴ * A i) *
-                          evalWord A (List.ofFn τ) := by
+                          Kraus.evalWord A (List.ofFn τ) := by
                             have hsum_right :
                                 ∑ i : Fin d,
-                                    (evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i *
-                                      evalWord A (List.ofFn τ)
+                                    (Kraus.evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i *
+                                      Kraus.evalWord A (List.ofFn τ)
                                   = (∑ i : Fin d,
-                                      (evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i) *
-                                      evalWord A (List.ofFn τ) := by
+                                      (Kraus.evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i) *
+                                      Kraus.evalWord A (List.ofFn τ) := by
                                     simpa [Matrix.mul_assoc] using
                                       (Finset.sum_mul
                                         (s := (Finset.univ : Finset (Fin d)))
                                         (f := fun i : Fin d =>
-                                          (evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i)
-                                        (a := evalWord A (List.ofFn τ))).symm
+                                          (Kraus.evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i)
+                                        (a := Kraus.evalWord A (List.ofFn τ))).symm
                             have hsum_left :
                                 ∑ i : Fin d,
-                                    (evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i
-                                  = (evalWord A (List.ofFn τ))ᴴ *
+                                    (Kraus.evalWord A (List.ofFn τ))ᴴ * (A i)ᴴ * A i
+                                  = (Kraus.evalWord A (List.ofFn τ))ᴴ *
                                       ∑ i : Fin d, (A i)ᴴ * A i := by
                                     simpa [Matrix.mul_assoc] using
                                       (Finset.mul_sum
                                         (s := (Finset.univ : Finset (Fin d)))
-                                        (a := (evalWord A (List.ofFn τ))ᴴ)
+                                        (a := (Kraus.evalWord A (List.ofFn τ))ᴴ)
                                         (f := fun i : Fin d => (A i)ᴴ * A i)).symm
                             rw [hsum_right, hsum_left]
-                    _ = (evalWord A (List.ofFn τ))ᴴ * evalWord A (List.ofFn τ) := by
+                    _ = (Kraus.evalWord A (List.ofFn τ))ᴴ * Kraus.evalWord A (List.ofFn τ) := by
                           rw [hLeft]
                           simp
                 simpa [e] using hτ
@@ -408,24 +410,24 @@ then the same equation holds after replacing letters by words of length \(L\):
 This is the iterated form of the normalization used in arXiv:quant-ph/0608197,
 Theorem 12, proof line 1450. -/
 theorem sum_evalWord_mul_conjTranspose_evalWord
-    (A : MPSTensor d D)
+    (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :
     ∀ L : ℕ,
       ∑ ρ : Fin L → Fin d,
-        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1 := by
+        Kraus.evalWord A (List.ofFn ρ) * (Kraus.evalWord A (List.ofFn ρ))ᴴ = 1 := by
   classical
   intro L
-  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  let Aadj : Fin d → Matrix (Fin D) (Fin D) ℂ := fun i => (A i)ᴴ
   have hLeft : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
     simpa [Aadj] using hRight
   let revEquiv : (Fin L → Fin d) ≃ (Fin L → Fin d) :=
     Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))
   calc
     ∑ ρ : Fin L → Fin d,
-        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
+        Kraus.evalWord A (List.ofFn ρ) * (Kraus.evalWord A (List.ofFn ρ))ᴴ
       = ∑ ρ : Fin L → Fin d,
-          (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
-            evalWord Aadj (List.ofFn (revEquiv ρ)) := by
+          (Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
+            Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)) := by
             refine Finset.sum_congr rfl ?_
             intro ρ _
             have hword :
@@ -433,30 +435,30 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
               simpa [revEquiv, Equiv.arrowCongr, Function.comp_def] using
                 (List.ofFn_reverse ρ).symm
             have hAdjEval :
-                (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
-                  evalWord A (List.ofFn ρ) := by
+                (Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
+                  Kraus.evalWord A (List.ofFn ρ) := by
               simpa [Aadj, hword] using
                 evalWord_pointwise_conjTranspose_reverse (A := A) (List.ofFn (revEquiv ρ))
             have hEvalAdj :
-                evalWord Aadj (List.ofFn (revEquiv ρ)) =
-                  (evalWord A (List.ofFn ρ))ᴴ := by
+                Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)) =
+                  (Kraus.evalWord A (List.ofFn ρ))ᴴ := by
               simpa using congrArg Matrix.conjTranspose hAdjEval
             rw [hAdjEval, hEvalAdj]
     _ = ∑ ρ : Fin L → Fin d,
-          (evalWord Aadj (List.ofFn ρ))ᴴ * evalWord Aadj (List.ofFn ρ) := by
+          (Kraus.evalWord Aadj (List.ofFn ρ))ᴴ * Kraus.evalWord Aadj (List.ofFn ρ) := by
           simpa [revEquiv] using
             (Fintype.sum_equiv revEquiv
               (f := fun ρ : Fin L → Fin d =>
-                (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
-                  evalWord Aadj (List.ofFn (revEquiv ρ)))
+                (Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
+                  Kraus.evalWord Aadj (List.ofFn (revEquiv ρ)))
               (g := fun ρ : Fin L → Fin d =>
-                (evalWord Aadj (List.ofFn ρ))ᴴ * evalWord Aadj (List.ofFn ρ))
+                (Kraus.evalWord Aadj (List.ofFn ρ))ᴴ * Kraus.evalWord Aadj (List.ofFn ρ))
               (by intro ρ; rfl))
     _ = 1 := sum_evalWord_conjTranspose_mul_evalWord (A := Aadj) hLeft L
 
 /-- Left-canonical normalization is preserved by physical blocking. -/
 theorem leftCanonical_blockTensor
-    (A : MPSTensor d D) (L : ℕ)
+    (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∑ i : Fin (blockPhysDim d L),
       (blockTensor (d := d) (D := D) A L i)ᴴ *
@@ -468,28 +470,28 @@ theorem leftCanonical_blockTensor
         (blockTensor (d := d) (D := D) A L i)ᴴ *
           blockTensor (d := d) (D := D) A L i
       = ∑ σ : Fin L → Fin d,
-          (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ) := by
+          (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ) := by
             change
               (∑ i : Fin (blockPhysDim d L),
-                (evalWord A (List.ofFn (e i)))ᴴ * evalWord A (List.ofFn (e i))) =
+                (Kraus.evalWord A (List.ofFn (e i)))ᴴ * Kraus.evalWord A (List.ofFn (e i))) =
                 ∑ σ : Fin L → Fin d,
-                  (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ)
+                  (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ)
             exact
               Fintype.sum_equiv e
                 (fun i : Fin (blockPhysDim d L) =>
-                  (evalWord A (List.ofFn (e i)))ᴴ * evalWord A (List.ofFn (e i)))
+                  (Kraus.evalWord A (List.ofFn (e i)))ᴴ * Kraus.evalWord A (List.ofFn (e i)))
                 (fun σ : Fin L → Fin d =>
-                  (evalWord A (List.ofFn σ))ᴴ * evalWord A (List.ofFn σ))
+                  (Kraus.evalWord A (List.ofFn σ))ᴴ * Kraus.evalWord A (List.ofFn σ))
                 (by intro i; rfl)
     _ = 1 := sum_evalWord_conjTranspose_mul_evalWord (A := A) hLeft L
 
 /-! ### Evaluation on repeated words -/
 
 /-- Evaluating a repeated single-letter word gives a matrix power. -/
-lemma evalWord_replicate (A : MPSTensor d D) (i : Fin d) (L : ℕ) :
-    evalWord A (List.replicate L i) = (A i) ^ L := by
+lemma evalWord_replicate (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (i : Fin d) (L : ℕ) :
+    Kraus.evalWord A (List.replicate L i) = (A i) ^ L := by
   induction L with
   | zero => simp
-  | succ n ih => rw [List.replicate_succ, evalWord, ih, pow_succ']
+  | succ n ih => rw [List.replicate_succ, Kraus.evalWord, ih, pow_succ']
 
 end MPSTensor

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -16,8 +16,7 @@ Kraus-family-only library out of `TNLean`'s matrix-product-state development.
 
 The exact word-span API is stated in `namespace Kraus`. The established
 injectivity and normality declarations remain in `namespace MPSTensor` until
-a dedicated compatibility rename; see `TNLean/Kraus/Word.lean`'s module
-docstring.
+the MPS declarations using these predicates are changed simultaneously.
 
 ## Main declarations
 

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -38,17 +38,17 @@ variable {d D : ℕ}
 
 /-- Algebraic injectivity (spanning formulation): the matrices `{A i}` span the full matrix
 algebra `Matrix (Fin D) (Fin D) ℂ`. -/
-def IsInjective (A : MPSTensor d D) : Prop :=
+def IsInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   Submodule.span ℂ (Set.range A) = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
 /-- Unfolded form of `IsInjective`: the span of the range of `A` equals `⊤`. -/
-lemma IsInjective.span_eq_top {A : MPSTensor d D} (hA : IsInjective A) :
+lemma IsInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) :
     Submodule.span ℂ (Set.range A) = ⊤ := hA
 
 /-- Multiplication of every physical letter by a nonzero scalar preserves
 injectivity. -/
 theorem IsInjective.smul
-    {c : ℂ} {A : MPSTensor d D} (hA : IsInjective A) (hc : c ≠ 0) :
+    {c : ℂ} {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) (hc : c ≠ 0) :
     IsInjective (fun i ↦ c • A i) := by
   unfold IsInjective at hA ⊢
   calc
@@ -68,7 +68,7 @@ theorem IsInjective.smul
     _ = ⊤ := hA
 
 /-- An injective MPS tensor on `D ≥ 1` bond dimension implies `d ≥ 1`. -/
-theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
+theorem neZero_d_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ} [NeZero D]
     (hA : IsInjective A) : NeZero d := by
   by_contra h
   simp only [not_neZero] at h
@@ -81,13 +81,13 @@ theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
 `A^{i₁} * ⋯ * A^{i_N}` spans the full matrix algebra.
 
 We index the blocked tensors by `σ : Fin N → Fin d`, i.e. words of length `N`. -/
-def IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop :=
+def IsNBlkInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) : Prop :=
   Kraus.wordSpan A N = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
 /-- The literal-span form of block injectivity, for proofs that act on the generators. -/
-theorem IsNBlkInjective.span_eq_top {A : MPSTensor d D} {N : ℕ}
+theorem IsNBlkInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {N : ℕ}
     (hA : IsNBlkInjective A N) :
-    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by
+    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) = ⊤ := by
   simpa only [IsNBlkInjective, Kraus.wordSpan] using hA
 
 /-- Normality means eventual block injectivity at a positive length:
@@ -97,35 +97,35 @@ Here the witness is required to be positive in order to exclude the empty word,
 whose value is the identity independently of the tensor. This is consistent with
 the positive word lengths used by Sanz--Pérez-García--Wolf--Cirac,
 arXiv:0909.5347, in the definition following equation (1). -/
-def IsNormal (A : MPSTensor d D) : Prop :=
+def IsNormal (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∃ N : ℕ, 0 < N ∧ IsNBlkInjective (d := d) (D := D) A N
 
-@[simp] lemma isNormal_iff (A : MPSTensor d D) :
+@[simp] lemma isNormal_iff (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     IsNormal A ↔ ∃ N, 0 < N ∧ IsNBlkInjective A N := Iff.rfl
 
 /-- Algebraic injectivity gives `1`-block injectivity. -/
-theorem isNBlkInjective_one_of_isInjective {A : MPSTensor d D}
+theorem isNBlkInjective_one_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ}
     (h : IsInjective A) : IsNBlkInjective A 1 := by
   unfold IsNBlkInjective
   have hrange : (Set.range fun σ : Fin 1 → Fin d =>
-      evalWord A (List.ofFn σ)) = Set.range A := by
+      Kraus.evalWord A (List.ofFn σ)) = Set.range A := by
     ext M
     simp only [Set.mem_range]
     constructor
     · rintro ⟨σ, hσ⟩
       refine ⟨σ 0, ?_⟩
       simpa only [List.ofFn_succ, List.ofFn_zero,
-        evalWord_cons, evalWord_nil, mul_one] using hσ
+        Kraus.evalWord_cons, Kraus.evalWord_nil, mul_one] using hσ
     · rintro ⟨i, hi⟩
       refine ⟨fun _ => i, ?_⟩
       simpa only [List.ofFn_succ, List.ofFn_zero,
-        evalWord_cons, evalWord_nil, mul_one] using hi
+        Kraus.evalWord_cons, Kraus.evalWord_nil, mul_one] using hi
   rw [Kraus.wordSpan, hrange]
   exact h
 
 /-- Algebraic injectivity (1-block) implies normality (eventual block injectivity).
 This is the trivial direction: injectivity is `IsNBlkInjective 1`. -/
-lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) :
+lemma IsInjective.isNormal {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (h : IsInjective A) :
     IsNormal A :=
   ⟨1, Nat.zero_lt_one, isNBlkInjective_one_of_isInjective h⟩
 

--- a/TNLean/Kraus/InvariantProjection.lean
+++ b/TNLean/Kraus/InvariantProjection.lean
@@ -45,13 +45,13 @@ variable {d D : ℕ}
 a Hermitian idempotent `P` with `P ≠ 0`, `P ≠ 1`, and `(1 - P) * A i * P = 0` for every `i`.
 
 This is the negation of "irreducible with respect to invariant subspaces". -/
-def HasInvariantProj (A : MPSTensor d D) : Prop :=
+def HasInvariantProj (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∃ P : Matrix (Fin D) (Fin D) ℂ,
     IsOrthogonalProjection P ∧ P ≠ 0 ∧ P ≠ 1 ∧ (∀ i : Fin d, (1 - P) * A i * P = 0)
 
 /-- `IsIrreducibleTensor A` holds if `A` admits no nontrivial invariant orthogonal projection.
 This is the "irreducible" condition used in the canonical-form reduction. -/
-def IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
+def IsIrreducibleTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ¬ HasInvariantProj A
 
 end MPSTensor

--- a/TNLean/Kraus/InvariantProjection.lean
+++ b/TNLean/Kraus/InvariantProjection.lean
@@ -23,10 +23,9 @@ the cast lemmas, and the iterated block-decomposition capstone
 `exists_irreducible_blockDecomp`) stay on the matrix-product-state side, in
 `TNLean/MPS/CanonicalForm/Reduction.lean`.
 
-**Pending:** these declarations keep `namespace MPSTensor` for now. The
-rename to `namespace Kraus` is deferred to a dedicated mechanical sweep
-across the ~429 files that reference this vocabulary; see
-`TNLean/Kraus/Word.lean`'s module docstring.
+The established predicates remain in `namespace MPSTensor` because the
+canonical-form development uses these names throughout. A change of namespace
+belongs with a simultaneous change of those declarations.
 
 ## Main declarations
 

--- a/TNLean/Kraus/MapIterate.lean
+++ b/TNLean/Kraus/MapIterate.lean
@@ -32,8 +32,8 @@ theorem mapLM_pow_apply (K : Fin d → Mat) (N : ℕ) :
     ∀ X : Mat,
       ((mapLM K) ^ N) X =
         ∑ σ : Fin N → Fin d,
-          MPSTensor.evalWord K (List.ofFn σ) * X *
-            (MPSTensor.evalWord K (List.ofFn σ))ᴴ := by
+          Kraus.evalWord K (List.ofFn σ) * X *
+            (Kraus.evalWord K (List.ofFn σ))ᴴ := by
   induction N with
   | zero =>
       intro X

--- a/TNLean/Kraus/MixedMap.lean
+++ b/TNLean/Kraus/MixedMap.lean
@@ -80,8 +80,8 @@ theorem mixedMapLM_pow_apply (A : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ)
     ∀ X : Matrix (Fin D₁) (Fin D₂) ℂ,
       ((mixedMapLM A B) ^ N) X =
         ∑ σ : Fin N → Fin d,
-          MPSTensor.evalWord A (List.ofFn σ) * X *
-            (MPSTensor.evalWord B (List.ofFn σ))ᴴ := by
+          Kraus.evalWord A (List.ofFn σ) * X *
+            (Kraus.evalWord B (List.ofFn σ))ᴴ := by
   classical
   induction N with
   | zero =>

--- a/TNLean/Kraus/MixedMap/Gap.lean
+++ b/TNLean/Kraus/MixedMap/Gap.lean
@@ -662,8 +662,8 @@ private theorem dim_eq_of_modulus_one_mixedMapLM_eigenvector
     exists_posSemidef_fixedPoint_gauge_of_irreducible_TP A hA_irr hA_tp
   obtain ⟨ρB, SB, hρB_psd, hρB_ne, hρB_fix, hSB_det, hSB_u, hSB_mul⟩ :=
     exists_posSemidef_fixedPoint_gauge_of_irreducible_TP B hB_irr hB_tp
-  let A' : MPSTensor d D₁ := gaugeFamily SA A
-  let B' : MPSTensor d D₂ := gaugeFamily SB B
+  let A' : Fin d → Matrix (Fin D₁) (Fin D₁) ℂ := gaugeFamily SA A
+  let B' : Fin d → Matrix (Fin D₂) (Fin D₂) ℂ := gaugeFamily SB B
   let X' : Matrix (Fin D₁) (Fin D₂) ℂ := gaugeMixedEigenvector SA SB X
   obtain ⟨hA'unital, hB'unital, hX'ne, hInter1, hInter2⟩ :=
     gauged_rectangular_intertwiner_properties

--- a/TNLean/Kraus/MultiBlockWord.lean
+++ b/TNLean/Kraus/MultiBlockWord.lean
@@ -13,7 +13,7 @@ import Mathlib.LinearAlgebra.Matrix.Reindex
 # Word evaluation over arbitrary finite index types
 
 This file carries the word-evaluation layer of the channel side: a
-generalization of `MPSTensor.evalWord` to matrices indexed by an arbitrary
+generalization of `Kraus.evalWord` to matrices indexed by an arbitrary
 finite type (in particular, the `Σ`-type indices produced by
 `Matrix.blockDiagonal'`), together with compatibility lemmas identifying it
 with the canonical `Fin D`-indexed `evalWord`. It is
@@ -31,7 +31,7 @@ open scoped Matrix BigOperators
 
 /-- Word evaluation for a family of square matrices indexed by `Fin d`.
 
-This is the same recursion as `MPSTensor.evalWord`, but it works for matrices indexed by an
+This is the same recursion as `Kraus.evalWord`, but it works for matrices indexed by an
 arbitrary finite type (in particular, the `Σ`-type indices produced by `Matrix.blockDiagonal'`). -/
 def evalWord {d : ℕ} {n : Type*} [Fintype n] [DecidableEq n]
     (A : Fin d → Matrix n n ℂ) : List (Fin d) → Matrix n n ℂ
@@ -87,24 +87,24 @@ end BlockDiagonal
 namespace MPSTensor
 
 /-- On `Fin D` indices, the auxiliary `evalWord` from `MultiBlockWord.lean` agrees with
-`MPSTensor.evalWord`. -/
-@[simp] lemma evalWord_aux_eq {d D : ℕ} (A : MPSTensor d D) (w : List (Fin d)) :
-    _root_.evalWord A w = MPSTensor.evalWord A w := by
+`Kraus.evalWord`. -/
+@[simp] lemma evalWord_aux_eq {d D : ℕ} (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)) :
+    _root_.evalWord A w = Kraus.evalWord A w := by
   induction w with
-  | nil => simp [MPSTensor.evalWord, _root_.evalWord]
-  | cons i w ih => simp [MPSTensor.evalWord, _root_.evalWord, ih]
+  | nil => simp [Kraus.evalWord, _root_.evalWord]
+  | cons i w ih => simp [Kraus.evalWord, _root_.evalWord, ih]
 
-/-- `MPSTensor.evalWord` commutes with reindexing along an equivalence. -/
+/-- `Kraus.evalWord` commutes with reindexing along an equivalence. -/
 lemma evalWord_reindex {d D : ℕ} {m : Type*} [Fintype m] [DecidableEq m]
     (e : m ≃ Fin D) (A : Fin d → Matrix m m ℂ) :
     ∀ w : List (Fin d),
-      MPSTensor.evalWord (fun i => (Matrix.reindex e e) (A i)) w =
+      Kraus.evalWord (fun i => (Matrix.reindex e e) (A i)) w =
         (Matrix.reindex e e) (_root_.evalWord A w) := by
   classical
   intro w; induction w with
-  | nil => simp [MPSTensor.evalWord, _root_.evalWord]
+  | nil => simp [Kraus.evalWord, _root_.evalWord]
   | cons _ _ ih =>
-      simp only [MPSTensor.evalWord, _root_.evalWord, ih]
+      simp only [Kraus.evalWord, _root_.evalWord, ih]
       simp [Matrix.submatrix_mul_equiv]
 
 end MPSTensor

--- a/TNLean/Kraus/MultiBlockWord.lean
+++ b/TNLean/Kraus/MultiBlockWord.lean
@@ -20,11 +20,11 @@ with the canonical `Fin D`-indexed `evalWord`. It is
 part of the extraction of a Kraus-family-only library out of
 `TNLean`'s matrix-product-state development.
 
-**Pending:** `evalWord_aux_eq` and `evalWord_reindex` keep `namespace
-MPSTensor` for now. The rename to `namespace Kraus` is deferred to a
-dedicated mechanical sweep across the ~429 files that reference this
-vocabulary; see
-`TNLean/Kraus/Word.lean`'s module docstring.
+The established names `MPSTensor.evalWord_aux_eq` and
+`MPSTensor.evalWord_reindex` are retained because the MPS development uses
+them throughout. Their statements concern arbitrary finite matrix families;
+a simultaneous change of namespace belongs with the declarations that use
+these names.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/Kraus/TracePairing.lean
+++ b/TNLean/Kraus/TracePairing.lean
@@ -35,28 +35,28 @@ theorem sum_normSq_trace_conjTranspose_mul_evalWord
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ)
     (B : Matrix (Fin D) (Fin D) ℂ) :
     (∑ σ : Fin n → Fin d,
-        ‖Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))‖ ^ 2 : ℝ) =
+        ‖Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ))‖ ^ 2 : ℝ) =
       (∑ i : Fin D, ∑ k : Fin D,
         (Bᴴ * ((mapLM K) ^ n)
           (Matrix.single i k 1) * B) i k).re := by
   -- Rewrite LHS: ‖z‖² = (z * star z).re since z * star z = ↑(‖z‖²)
   have hlhs : (∑ σ : Fin n → Fin d,
-      ‖Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))‖ ^ 2 : ℝ) =
+      ‖Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ))‖ ^ 2 : ℝ) =
     (∑ σ : Fin n → Fin d,
-      Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) *
-        star (Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)))).re := by
+      Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)) *
+        star (Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)))).re := by
     rw [Complex.re_sum]
     congr 1
     ext σ
-    rw [← Complex.normSq_eq_norm_sq (Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)))]
+    rw [← Complex.normSq_eq_norm_sq (Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)))]
     simpa using
       (congrArg Complex.re
-        (Complex.mul_conj (Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))))).symm
+        (Complex.mul_conj (Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ))))).symm
   rw [hlhs]
   have hcomplex :
       (∑ σ : Fin n → Fin d,
-          Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) *
-            star (Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)))) =
+          Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)) *
+            star (Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)))) =
         ∑ i : Fin D, ∑ k : Fin D,
           (Bᴴ * ((mapLM K) ^ n)
             (Matrix.single i k 1) * B) i k := by
@@ -65,18 +65,18 @@ theorem sum_normSq_trace_conjTranspose_mul_evalWord
     -- Push B† and B through the σ-sum and extract entries.
     have hpush : ∀ (i k : Fin D),
         (Bᴴ * (∑ σ : Fin n → Fin d,
-          MPSTensor.evalWord K (List.ofFn σ) * Matrix.single i k (1 : ℂ) *
-            (MPSTensor.evalWord K (List.ofFn σ))ᴴ) * B) i k =
+          Kraus.evalWord K (List.ofFn σ) * Matrix.single i k (1 : ℂ) *
+            (Kraus.evalWord K (List.ofFn σ))ᴴ) * B) i k =
         ∑ σ : Fin n → Fin d,
-          (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i *
-            ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k := by
+          (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i *
+            ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k := by
       intro i k
       have hdist : Bᴴ * (∑ σ : Fin n → Fin d,
-          MPSTensor.evalWord K (List.ofFn σ) * Matrix.single i k 1 *
-            (MPSTensor.evalWord K (List.ofFn σ))ᴴ) * B =
+          Kraus.evalWord K (List.ofFn σ) * Matrix.single i k 1 *
+            (Kraus.evalWord K (List.ofFn σ))ᴴ) * B =
           ∑ σ : Fin n → Fin d,
-            Bᴴ * MPSTensor.evalWord K (List.ofFn σ) * Matrix.single i k 1 *
-              ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) := by
+            Bᴴ * Kraus.evalWord K (List.ofFn σ) * Matrix.single i k 1 *
+              ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) := by
         rw [Matrix.mul_sum, Finset.sum_mul]
         congr 1
         ext σ
@@ -85,40 +85,40 @@ theorem sum_normSq_trace_conjTranspose_mul_evalWord
       congr 1
       ext σ
       exact entry_mul_single_mul
-        (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))
-        ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) i k
+        (Bᴴ * Kraus.evalWord K (List.ofFn σ))
+        ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) i k
     simp_rw [hpush]
     rw [show (∑ i : Fin D, ∑ k : Fin D, ∑ σ : Fin n → Fin d,
-          (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i *
-            ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k) =
+          (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i *
+            ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k) =
         ∑ σ : Fin n → Fin d, ∑ i : Fin D, ∑ k : Fin D,
-          (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i *
-            ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k from by
+          (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i *
+            ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k from by
       simpa using Finset.sum_comm_cycle
         (s := (Finset.univ : Finset (Fin D)))
         (t := (Finset.univ : Finset (Fin D)))
         (u := (Finset.univ : Finset (Fin n → Fin d)))
         (f := fun i k σ =>
-          (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i *
-            ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k)]
+          (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i *
+            ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k)]
     congr 1
     ext σ
     have hfactor :
         ∑ i : Fin D, ∑ k : Fin D,
-          (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i *
-            ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k =
-        (∑ i, (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i) *
-          (∑ k, ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k) := by
+          (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i *
+            ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k =
+        (∑ i, (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i) *
+          (∑ k, ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k) := by
       simpa using (Fintype.sum_mul_sum
-        (f := fun i : Fin D => (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) i i)
-        (g := fun k : Fin D => ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B) k k)).symm
+        (f := fun i : Fin D => (Bᴴ * Kraus.evalWord K (List.ofFn σ)) i i)
+        (g := fun k : Fin D => ((Kraus.evalWord K (List.ofFn σ))ᴴ * B) k k)).symm
     rw [hfactor]
-    change Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) *
-      star (Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))) =
-      Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) *
-        Matrix.trace ((MPSTensor.evalWord K (List.ofFn σ))ᴴ * B)
+    change Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)) *
+      star (Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ))) =
+      Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)) *
+        Matrix.trace ((Kraus.evalWord K (List.ofFn σ))ᴴ * B)
     congr 1
-    rw [← Matrix.trace_conjTranspose (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))]
+    rw [← Matrix.trace_conjTranspose (Bᴴ * Kraus.evalWord K (List.ofFn σ))]
     simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
   exact congrArg Complex.re hcomplex
 

--- a/TNLean/Kraus/Wielandt/Primitivity/StronglyIrreducibleToFullWordSpan.lean
+++ b/TNLean/Kraus/Wielandt/Primitivity/StronglyIrreducibleToFullWordSpan.lean
@@ -188,9 +188,9 @@ private theorem wordSpan_eq_top_of_tracePairBilin_re_pos
     rwa [hMdef, ne_eq, rep_eq_zero_iff]
   -- φ vanishes on generators: tr(M · A_σ) = 0
   have hvanish : ∀ σ : Fin n → Fin d,
-      Matrix.trace (M * MPSTensor.evalWord K (List.ofFn σ)) = 0 := by
+      Matrix.trace (M * Kraus.evalWord K (List.ofFn σ)) = 0 := by
     intro σ
-    rw [← phi_eq_trace_mul φ (MPSTensor.evalWord K (List.ofFn σ))]
+    rw [← phi_eq_trace_mul φ (Kraus.evalWord K (List.ofFn σ))]
     exact (Submodule.mem_dualAnnihilator φ).mp hφmem _
       (Submodule.subset_span ⟨σ, rfl⟩)
   -- Set B = M†, so tr(B† A_σ) = tr(M A_σ) = 0
@@ -198,7 +198,7 @@ private theorem wordSpan_eq_top_of_tracePairBilin_re_pos
   have hBne : B ≠ 0 :=
     fun h => hMne (Matrix.conjTranspose_eq_zero.mp h)
   have hBvanish : ∀ σ : Fin n → Fin d,
-      Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ)) = 0 := by
+      Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ)) = 0 := by
     intro σ
     rw [hBdef, Matrix.conjTranspose_conjTranspose]
     exact hvanish σ
@@ -209,7 +209,7 @@ private theorem wordSpan_eq_top_of_tracePairBilin_re_pos
     sum_normSq_trace_conjTranspose_mul_evalWord K n B
   -- LHS = 0 since all traces vanish
   have hlhs : (∑ σ : Fin n → Fin d,
-      ‖Matrix.trace (Bᴴ * MPSTensor.evalWord K (List.ofFn σ))‖ ^ 2
+      ‖Matrix.trace (Bᴴ * Kraus.evalWord K (List.ofFn σ))‖ ^ 2
         : ℝ) = 0 := by
     apply Finset.sum_eq_zero; intro σ _; simp [hBvanish σ]
   -- tracePairBilin is definitionally the RHS of the identity

--- a/TNLean/Kraus/Wielandt/Primitivity/VectorSpreadPositivity.lean
+++ b/TNLean/Kraus/Wielandt/Primitivity/VectorSpreadPositivity.lean
@@ -55,12 +55,12 @@ of the rank-one matrices associated with all words of that length. -/
 theorem mapLM_pow_rankOne_eq_sum (K : Fin d → Mat) (q : ℕ) (φ : Fin D → ℂ) :
     ((mapLM K) ^ q) (vecMulVec φ (star φ)) =
       ∑ σ : Fin q → Fin d,
-        vecMulVec (MPSTensor.evalWord K (List.ofFn σ) *ᵥ φ)
-          (star (MPSTensor.evalWord K (List.ofFn σ) *ᵥ φ)) := by
+        vecMulVec (Kraus.evalWord K (List.ofFn σ) *ᵥ φ)
+          (star (Kraus.evalWord K (List.ofFn σ) *ᵥ φ)) := by
   rw [mapLM_pow_apply]
   congr 1
   ext σ : 1
-  exact sandwich_vecMulVec (MPSTensor.evalWord K (List.ofFn σ)) φ
+  exact sandwich_vecMulVec (Kraus.evalWord K (List.ofFn σ)) φ
 
 /-- A fixed-length full vector spread makes the corresponding iterate of the
 Kraus map positive definite on every nonzero rank-one positive matrix. -/
@@ -165,28 +165,28 @@ private lemma mul_proj_eq_of_invariant {P : Mat} (M : Mat)
 private lemma evalWord_mul_proj_eq {P : Mat} (hP_idem : P * P = P)
     (K : Fin d → Mat) (hinv : ∀ i : Fin d, (1 - P) * K i * P = 0)
     (w : List (Fin d)) :
-    MPSTensor.evalWord K w * P = P * MPSTensor.evalWord K w * P := by
+    Kraus.evalWord K w * P = P * Kraus.evalWord K w * P := by
   induction w with
-  | nil => simp [MPSTensor.evalWord, hP_idem]
+  | nil => simp [Kraus.evalWord, hP_idem]
   | cons i w ih =>
-      simp only [MPSTensor.evalWord]
+      simp only [Kraus.evalWord]
       have hi : K i * P = P * K i * P := mul_proj_eq_of_invariant (K i) (hinv i)
       calc
-        K i * MPSTensor.evalWord K w * P
-            = K i * (MPSTensor.evalWord K w * P) := Matrix.mul_assoc _ _ _
-        _ = K i * (P * MPSTensor.evalWord K w * P) := by rw [ih]
-        _ = K i * P * (MPSTensor.evalWord K w * P) := by noncomm_ring
-        _ = P * K i * P * (MPSTensor.evalWord K w * P) := by rw [hi]
-        _ = P * K i * (P * MPSTensor.evalWord K w * P) := by noncomm_ring
-        _ = P * K i * (MPSTensor.evalWord K w * P) := by rw [← ih]
-        _ = P * (K i * MPSTensor.evalWord K w) * P := by noncomm_ring
+        K i * Kraus.evalWord K w * P
+            = K i * (Kraus.evalWord K w * P) := Matrix.mul_assoc _ _ _
+        _ = K i * (P * Kraus.evalWord K w * P) := by rw [ih]
+        _ = K i * P * (Kraus.evalWord K w * P) := by noncomm_ring
+        _ = P * K i * P * (Kraus.evalWord K w * P) := by rw [hi]
+        _ = P * K i * (P * Kraus.evalWord K w * P) := by noncomm_ring
+        _ = P * K i * (Kraus.evalWord K w * P) := by rw [← ih]
+        _ = P * (K i * Kraus.evalWord K w) * P := by noncomm_ring
 
 private lemma evalWord_mulVec_mem_range_of_proj {P : Mat} (hP_idem : P * P = P)
     (K : Fin d → Mat) (hinv : ∀ i : Fin d, (1 - P) * K i * P = 0)
     (φ : Fin D → ℂ) (hφ_range : P *ᵥ φ = φ) (w : List (Fin d)) :
-    MPSTensor.evalWord K w *ᵥ φ ∈ LinearMap.range (Matrix.mulVecLin P) := by
+    Kraus.evalWord K w *ᵥ φ ∈ LinearMap.range (Matrix.mulVecLin P) := by
   rw [LinearMap.mem_range]
-  use (MPSTensor.evalWord K w * P) *ᵥ φ
+  use (Kraus.evalWord K w * P) *ᵥ φ
   simp only [Matrix.mulVecLin_apply]
   rw [Matrix.mulVec_mulVec]
   conv_rhs => rw [← hφ_range, Matrix.mulVec_mulVec]

--- a/TNLean/Kraus/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Construction.lean
@@ -36,9 +36,9 @@ theorem wordSpan_transposeFamily_eq_top_of_wordSpan_eq_top
   unfold wordSpan at h ⊢
   have hrange :
       Set.range (fun σ : Fin N → Fin d =>
-        MPSTensor.evalWord (transposeFamily K) (List.ofFn σ)) =
+        Kraus.evalWord (transposeFamily K) (List.ofFn σ)) =
         Set.range (fun σ : Fin N → Fin d =>
-          (MPSTensor.evalWord K (List.ofFn σ))ᵀ) := by
+          (Kraus.evalWord K (List.ofFn σ))ᵀ) := by
     ext M
     constructor
     · rintro ⟨σ, rfl⟩
@@ -59,28 +59,28 @@ theorem wordSpan_transposeFamily_eq_top_of_wordSpan_eq_top
       Submodule.map
           (e : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
           (Submodule.span ℂ
-            (Set.range fun σ : Fin N → Fin d => MPSTensor.evalWord K (List.ofFn σ))) =
+            (Set.range fun σ : Fin N → Fin d => Kraus.evalWord K (List.ofFn σ))) =
         Submodule.span ℂ
           (Set.range fun σ : Fin N → Fin d =>
-            (MPSTensor.evalWord K (List.ofFn σ))ᵀ) := by
+            (Kraus.evalWord K (List.ofFn σ))ᵀ) := by
     rw [Submodule.map_span]
     have hrange' :
         (fun M : Matrix (Fin D) (Fin D) ℂ => Mᵀ) ''
-            Set.range (fun σ : Fin N → Fin d => MPSTensor.evalWord K (List.ofFn σ)) =
+            Set.range (fun σ : Fin N → Fin d => Kraus.evalWord K (List.ofFn σ)) =
           Set.range fun σ : Fin N → Fin d =>
-            (MPSTensor.evalWord K (List.ofFn σ))ᵀ := by
+            (Kraus.evalWord K (List.ofFn σ))ᵀ := by
       simpa [Function.comp_def] using
         (Set.range_comp (fun M : Matrix (Fin D) (Fin D) ℂ => Mᵀ)
-          (fun σ : Fin N → Fin d => MPSTensor.evalWord K (List.ofFn σ))).symm
+          (fun σ : Fin N → Fin d => Kraus.evalWord K (List.ofFn σ))).symm
     simp [e, hrange']
   calc
     Submodule.span ℂ
         (Set.range fun σ : Fin N → Fin d =>
-          (MPSTensor.evalWord K (List.ofFn σ))ᵀ) =
+          (Kraus.evalWord K (List.ofFn σ))ᵀ) =
         Submodule.map
           (e : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
           (Submodule.span ℂ
-            (Set.range fun σ : Fin N → Fin d => MPSTensor.evalWord K (List.ofFn σ))) := by
+            (Set.range fun σ : Fin N → Fin d => Kraus.evalWord K (List.ofFn σ))) := by
       symm
       exact hmap
     _ = Submodule.map
@@ -105,9 +105,9 @@ theorem cumulativeSpan_transposeFamily_eq_top_of_cumulativeSpan_eq_top
     rw [Submodule.map_span]
     have hset :
         (fun M : Matrix (Fin D) (Fin D) ℂ => Mᵀ) ''
-            {M | ∃ w : List (Fin d), w.length ≤ N ∧ M = MPSTensor.evalWord K w} =
+            {M | ∃ w : List (Fin d), w.length ≤ N ∧ M = Kraus.evalWord K w} =
           {M | ∃ w : List (Fin d), w.length ≤ N ∧
-            M = MPSTensor.evalWord (transposeFamily K) w} := by
+            M = Kraus.evalWord (transposeFamily K) w} := by
       ext M
       constructor
       · rintro ⟨M', ⟨w, hw, rfl⟩, hM⟩
@@ -115,7 +115,7 @@ theorem cumulativeSpan_transposeFamily_eq_top_of_cumulativeSpan_eq_top
         rw [← hM]
         simpa [transposeFamily] using evalWord_transpose K w
       · rintro ⟨w, hw, hM⟩
-        refine ⟨MPSTensor.evalWord K w.reverse, ⟨w.reverse, by simpa using hw, rfl⟩, ?_⟩
+        refine ⟨Kraus.evalWord K w.reverse, ⟨w.reverse, by simpa using hw, rfl⟩, ?_⟩
         rw [hM]
         simpa [transposeFamily] using evalWord_transpose K w.reverse
     simp [e, hset]
@@ -144,21 +144,21 @@ noncomputable def rowSpreadSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (ψ : Fin D → ℂ) (n : ℕ) :
     Submodule ℂ (Fin D → ℂ) :=
   Submodule.span ℂ (Set.range fun σ : Fin n → Fin d =>
-    Matrix.vecMul ψ (MPSTensor.evalWord K (List.ofFn σ)))
+    Matrix.vecMul ψ (Kraus.evalWord K (List.ofFn σ)))
 
 private theorem vecMul_evalWord_ofFn_eq_evalWord_transposeFamily_mulVec
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (ψ : Fin D → ℂ)
     {n : ℕ} (σ : Fin n → Fin d) :
-    Matrix.vecMul ψ (MPSTensor.evalWord K (List.ofFn σ)) =
-      MPSTensor.evalWord (transposeFamily K) (List.ofFn (σ ∘ Fin.rev)) *ᵥ ψ := by
+    Matrix.vecMul ψ (Kraus.evalWord K (List.ofFn σ)) =
+      Kraus.evalWord (transposeFamily K) (List.ofFn (σ ∘ Fin.rev)) *ᵥ ψ := by
   calc
-    Matrix.vecMul ψ (MPSTensor.evalWord K (List.ofFn σ)) =
-        (MPSTensor.evalWord K (List.ofFn σ))ᵀ *ᵥ ψ := by
+    Matrix.vecMul ψ (Kraus.evalWord K (List.ofFn σ)) =
+        (Kraus.evalWord K (List.ofFn σ))ᵀ *ᵥ ψ := by
       simpa using Matrix.vecMul_transpose
-        (A := (MPSTensor.evalWord K (List.ofFn σ))ᵀ) (x := ψ)
-    _ = MPSTensor.evalWord (transposeFamily K) (List.ofFn σ).reverse *ᵥ ψ := by
+        (A := (Kraus.evalWord K (List.ofFn σ))ᵀ) (x := ψ)
+    _ = Kraus.evalWord (transposeFamily K) (List.ofFn σ).reverse *ᵥ ψ := by
       simp [evalWord_transpose]
-    _ = MPSTensor.evalWord (transposeFamily K) (List.ofFn (σ ∘ Fin.rev)) *ᵥ ψ := by
+    _ = Kraus.evalWord (transposeFamily K) (List.ofFn (σ ∘ Fin.rev)) *ᵥ ψ := by
       simp [List.ofFn_reverse]
 
 /-- Row spreading is vector spreading for the pointwise-transposed family. -/
@@ -196,12 +196,12 @@ theorem map_wordSpan_eq_rowSpreadSpan
   rw [Submodule.map_span]
   have hrange :
       (Set.range fun σ : Fin n → Fin d =>
-        Matrix.vecMul ψ (MPSTensor.evalWord K (List.ofFn σ))) =
+        Matrix.vecMul ψ (Kraus.evalWord K (List.ofFn σ))) =
         (fun M : Matrix (Fin D) (Fin D) ℂ => Matrix.vecMul ψ M) ''
-          (Set.range fun σ : Fin n → Fin d => MPSTensor.evalWord K (List.ofFn σ)) := by
+          (Set.range fun σ : Fin n → Fin d => Kraus.evalWord K (List.ofFn σ)) := by
     simpa [Function.comp_def] using
       (Set.range_comp (fun M : Matrix (Fin D) (Fin D) ℂ => Matrix.vecMul ψ M)
-        (fun σ : Fin n → Fin d => MPSTensor.evalWord K (List.ofFn σ)))
+        (fun σ : Fin n → Fin d => Kraus.evalWord K (List.ofFn σ)))
   simp [hrange]
 
 /-- Full row spread realizes every standard basis row by a word-span matrix. -/

--- a/TNLean/Kraus/Wielandt/RankOne/Element.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Element.lean
@@ -26,16 +26,16 @@ variable {d D : ℕ}
 /-- A power of an evaluated word belongs to the word span at the multiplied length. -/
 theorem evalWord_pow_mem_wordSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)) (k : ℕ) :
-    (MPSTensor.evalWord K w) ^ k ∈ wordSpan K (k * w.length) := by
+    (Kraus.evalWord K w) ^ k ∈ wordSpan K (k * w.length) := by
   classical
   induction k with
   | zero =>
       simp
   | succ k ih =>
-      have hw : MPSTensor.evalWord K w ∈ wordSpan K w.length :=
+      have hw : Kraus.evalWord K w ∈ wordSpan K w.length :=
         evalWord_mem_wordSpan K w
       have hprod :
-          (MPSTensor.evalWord K w) ^ k * MPSTensor.evalWord K w ∈
+          (Kraus.evalWord K w) ^ k * Kraus.evalWord K w ∈
             wordSpan K (k * w.length + w.length) := by
         rw [wordSpan_add]
         exact Submodule.mul_mem_mul ih hw
@@ -51,27 +51,27 @@ theorem exists_nonzero_pow_evalWord_mem_wordSpan_range_le
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (w₀ : List (Fin d))
     (μ : ℂ) (φ : Fin D → ℂ)
     (hμ : μ ≠ 0) (hφ : φ ≠ 0)
-    (heig : MPSTensor.evalWord K w₀ *ᵥ φ = μ • φ) :
+    (heig : Kraus.evalWord K w₀ *ᵥ φ = μ • φ) :
     ∃ P : Matrix (Fin D) (Fin D) ℂ,
       P ∈ wordSpan K (D * w₀.length) ∧
       P ≠ 0 ∧
       LinearMap.range (Matrix.toLin' P) ≤
         ⨆ (ν : ℂ) (_ : ν ≠ 0),
-          End.maxGenEigenspace (Matrix.toLin' (MPSTensor.evalWord K w₀)) ν := by
+          End.maxGenEigenspace (Matrix.toLin' (Kraus.evalWord K w₀)) ν := by
   classical
-  refine ⟨(MPSTensor.evalWord K w₀) ^ D, ?_, ?_, ?_⟩
+  refine ⟨(Kraus.evalWord K w₀) ^ D, ?_, ?_, ?_⟩
   · simpa [Nat.mul_comm] using evalWord_pow_mem_wordSpan K w₀ D
-  · have hpow : ((MPSTensor.evalWord K w₀) ^ D) *ᵥ φ = μ ^ D • φ :=
+  · have hpow : ((Kraus.evalWord K w₀) ^ D) *ᵥ φ = μ ^ D • φ :=
       Matrix.pow_mulVec_eq_smul_of_mulVec_eq_smul
-        (M := MPSTensor.evalWord K w₀) (φ := φ) (μ := μ) heig D
+        (M := Kraus.evalWord K w₀) (φ := φ) (μ := μ) heig D
     have hμpow : μ ^ D ≠ 0 := pow_ne_zero _ hμ
     intro hP0
-    have hzero : ((MPSTensor.evalWord K w₀) ^ D) *ᵥ φ = 0 := by
+    have hzero : ((Kraus.evalWord K w₀) ^ D) *ᵥ φ = 0 := by
       simp [hP0]
     have : μ ^ D • φ = 0 := by
       simpa [hpow] using hzero
     exact hφ (smul_eq_zero.mp this |>.resolve_left hμpow)
-  · let f : End ℂ (Fin D → ℂ) := Matrix.toLin' (MPSTensor.evalWord K w₀)
+  · let f : End ℂ (Fin D → ℂ) := Matrix.toLin' (Kraus.evalWord K w₀)
     have hrange :
         LinearMap.range (f ^ D) ≤
           ⨆ (ν : ℂ) (_ : ν ≠ 0), End.maxGenEigenspace f ν :=

--- a/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Extraction.lean
@@ -24,7 +24,7 @@ variable {d D : ℕ}
 Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
 theorem exists_nonzero_trace_word_of_wordSpan_eq_top [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
-    ∃ σ : Fin N → Fin d, (MPSTensor.evalWord K (List.ofFn σ)).trace ≠ 0 := by
+    ∃ σ : Fin N → Fin d, (Kraus.evalWord K (List.ofFn σ)).trace ≠ 0 := by
   by_contra hall
   push Not at hall
   have hI : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan K N :=
@@ -48,7 +48,7 @@ theorem exists_eigenvector_of_wordSpan_eq_top [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ} (htop : wordSpan K N = ⊤) :
     ∃ (σ : Fin N → Fin d) (μ : ℂ) (φ : Fin D → ℂ),
       μ ≠ 0 ∧ φ ≠ 0 ∧
-      MPSTensor.evalWord K (List.ofFn σ) *ᵥ φ = μ • φ := by
+      Kraus.evalWord K (List.ofFn σ) *ᵥ φ = μ • φ := by
   obtain ⟨σ, hσ⟩ := exists_nonzero_trace_word_of_wordSpan_eq_top K htop
   obtain ⟨μ, φ, hμ, hφ, heig⟩ := exists_eigenvector_of_trace_ne_zero _ hσ
   exact ⟨σ, μ, φ, hμ, hφ, heig⟩

--- a/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
@@ -28,9 +28,9 @@ variable {d D : ℕ}
 theorem pow_single_mem_wordSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (i : Fin d) :
     (K i) ^ D ∈ wordSpan K D := by
-  have heq : K i = MPSTensor.evalWord K [i] := by simp [MPSTensor.evalWord]
+  have heq : K i = Kraus.evalWord K [i] := by simp [Kraus.evalWord]
   have hmem :
-      (MPSTensor.evalWord K [i]) ^ D ∈
+      (Kraus.evalWord K [i]) ^ D ∈
         wordSpan K (D * ([i] : List (Fin d)).length) :=
     evalWord_pow_mem_wordSpan K [i] D
   rw [show D * ([i] : List (Fin d)).length = D from by simp] at hmem
@@ -52,17 +52,17 @@ private noncomputable def blockedTensorRangeData
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ)
     (σ₀ τ₀ : Fin L → Fin d) (φ ψ : Fin D → ℂ) (μ ν : ℂ)
     (hμ : μ ≠ 0) (hν : ν ≠ 0)
-    (heigφ : MPSTensor.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ)
-    (heigψ : (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ) :
+    (heigφ : Kraus.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ)
+    (heigψ : (Kraus.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ) :
     BlockedTensorRangeData K L σ₀ τ₀ φ ψ := by
   let B := MPSTensor.blockTensor K L
   let i₀ : Fin (MPSTensor.blockPhysDim d L) :=
     (MPSTensor.decodeBlockEquiv d L).symm σ₀
   let i₁ : Fin (MPSTensor.blockPhysDim d L) :=
     (MPSTensor.decodeBlockEquiv d L).symm τ₀
-  have hBi₀ : B i₀ = MPSTensor.evalWord K (List.ofFn σ₀) := by
+  have hBi₀ : B i₀ = Kraus.evalWord K (List.ofFn σ₀) := by
     simp [B, i₀, MPSTensor.blockTensor, MPSTensor.wordOfBlock]
-  have hBi₁ : B i₁ = MPSTensor.evalWord K (List.ofFn τ₀) := by
+  have hBi₁ : B i₁ = Kraus.evalWord K (List.ofFn τ₀) := by
     simp [B, i₁, MPSTensor.blockTensor, MPSTensor.wordOfBlock]
   refine
     { B := B
@@ -75,10 +75,10 @@ private noncomputable def blockedTensorRangeData
       hψ_range := ?_ }
   · simpa [hBi₀] using
       Matrix.mem_range_toLin'_pow_of_eigenvector
-        (M := MPSTensor.evalWord K (List.ofFn σ₀)) (φ := φ) (μ := μ) hμ heigφ
+        (M := Kraus.evalWord K (List.ofFn σ₀)) (φ := φ) (μ := μ) hμ heigφ
   · simpa [hBi₁] using
       Matrix.mem_range_vecMulLinear_pow_of_transpose_eigenvector
-        (M := MPSTensor.evalWord K (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ
+        (M := Kraus.evalWord K (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ
 
 private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top
     {K : Fin d → Matrix (Fin D) (Fin D) ℂ} {L : ℕ}
@@ -106,8 +106,8 @@ theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
     ∃ (σ₀ τ₀ : Fin N₀ → Fin d)
       (φ ψ : Fin D → ℂ) (μ ν : ℂ) (m_blocked : ℕ),
       φ ≠ 0 ∧ ψ ≠ 0 ∧ μ ≠ 0 ∧ ν ≠ 0 ∧
-      MPSTensor.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ ∧
-      (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ ∧
+      Kraus.evalWord K (List.ofFn σ₀) *ᵥ φ = μ • φ ∧
+      (Kraus.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ ∧
       Matrix.vecMulVec φ ψ ∈
         wordSpan (MPSTensor.blockTensor K N₀) m_blocked := by
   classical
@@ -120,7 +120,7 @@ theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
   let τ₀ : Fin N₀ → Fin d := τ₀' ∘ Fin.rev
   have hτ₀_eq : List.ofFn τ₀ = (List.ofFn τ₀').reverse :=
     (List.ofFn_reverse τ₀').symm
-  have heigψ : (MPSTensor.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ := by
+  have heigψ : (Kraus.evalWord K (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ := by
     rw [hτ₀_eq, evalWord_transpose K (List.ofFn τ₀').reverse, List.reverse_reverse]
     exact heigψ'
   let data := blockedTensorRangeData K N₀ σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ

--- a/TNLean/Kraus/Wielandt/RankOne/Products.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/Products.lean
@@ -14,7 +14,6 @@ nonzero eigenvalue and a corresponding nonzero eigenvector.
 -/
 
 open scoped Matrix
-open MPSTensor
 
 namespace Kraus
 
@@ -34,7 +33,7 @@ theorem exists_word_eigenvector [NeZero D]
       w₀.length ≤ D ^ 2 ∧
       μ ≠ 0 ∧
       φ ≠ 0 ∧
-      evalWord K w₀ *ᵥ φ = μ • φ := by
+      Kraus.evalWord K w₀ *ᵥ φ = μ • φ := by
   obtain ⟨w₀, hw₀_len, hw₀_tr⟩ := exists_nonzero_trace_word K hN
   obtain ⟨μ, φ, hμ, hφ, heig⟩ := exists_eigenvector_of_trace_ne_zero _ hw₀_tr
   exact ⟨w₀, μ, φ, hw₀_len, hμ, hφ, heig⟩

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
@@ -66,7 +66,7 @@ private theorem map_transpose_wordSpan
     simpa [List.ofFn_reverse, hrev] using
       (evalWord_transpose K (List.ofFn σ)).symm
   · rintro ⟨σ, rfl⟩
-    refine ⟨MPSTensor.evalWord K (List.ofFn (σ ∘ Fin.rev)), ⟨σ ∘ Fin.rev, rfl⟩, ?_⟩
+    refine ⟨Kraus.evalWord K (List.ofFn (σ ∘ Fin.rev)), ⟨σ ∘ Fin.rev, rfl⟩, ?_⟩
     have hrev : ((σ ∘ Fin.rev) ∘ Fin.rev) = σ := by
       funext i
       simpa only [Function.comp_apply] using congrArg σ (Fin.rev_rev i)

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Growth.lean
@@ -43,7 +43,7 @@ theorem mulLeft_mem_rectSpan_pow_succ
     calc M₀ * (M₀ ^ D) = M₀ ^ (D + 1) := by simp [pow_succ']
       _ = (M₀ ^ D) * M₀ := by simp [pow_succ]
   have hM₀ : M₀ ∈ wordSpan K 1 := by
-    simpa [M₀, MPSTensor.evalWord] using
+    simpa [M₀, Kraus.evalWord] using
       evalWord_mem_wordSpan K ([i₀] : List (Fin d))
   have hM₀M : M₀ * M ∈ wordSpan K (n + 1) := by
     have : M₀ * M ∈ (wordSpan K 1) * (wordSpan K n) := Submodule.mul_mem_mul hM₀ hM

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Universality.lean
@@ -305,11 +305,11 @@ variable {d D : ℕ}
 
 /-- For a one-letter word \(\sigma\), its evaluation is \(K^{\sigma}=K_{\sigma(0)}\). -/
 private lemma evalWord_ofFn_one (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (σ : Fin 1 → Fin d) :
-    MPSTensor.evalWord K (List.ofFn σ) = K (σ 0) := by
+    Kraus.evalWord K (List.ofFn σ) = K (σ 0) := by
   have h : List.ofFn σ = [σ 0] := by
     apply List.ext_getElem <;> simp
   rw [h]
-  simp [MPSTensor.evalWord]
+  simp [Kraus.evalWord]
 
 /-- Each generator `K j` lies in `wordSpan K 1`. -/
 private lemma gen_mem_wordSpan_one (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (j : Fin d) :
@@ -340,8 +340,8 @@ theorem rectSpan_succ_eq_iSup_mulRight
     simp only [LinearMap.mulLeft_apply, hM₂]
     rw [← Matrix.mul_assoc]
     apply Submodule.mem_iSup_of_mem (σ₂ 0)
-    exact Submodule.mem_map.mpr ⟨P * MPSTensor.evalWord K (List.ofFn σ₁),
-      Submodule.mem_map.mpr ⟨MPSTensor.evalWord K (List.ofFn σ₁),
+    exact Submodule.mem_map.mpr ⟨P * Kraus.evalWord K (List.ofFn σ₁),
+      Submodule.mem_map.mpr ⟨Kraus.evalWord K (List.ofFn σ₁),
         Submodule.subset_span ⟨σ₁, rfl⟩, rfl⟩,
       by simp [LinearMap.mulRight_apply]⟩
   · -- ≥: right-multiplied rectSpan elements lie in rectSpan at next level
@@ -465,7 +465,7 @@ private theorem gen_mul_mem_wordSpan_succ (K : Fin d → Matrix (Fin D) (Fin D) 
     {M : Matrix (Fin D) (Fin D) ℂ} {n : ℕ} (hM : M ∈ wordSpan K n) :
     (K i₀) * M ∈ wordSpan K (n + 1) := by
   have hA : K i₀ ∈ wordSpan K 1 := by
-    simpa [MPSTensor.evalWord] using evalWord_mem_wordSpan K ([i₀] : List (Fin d))
+    simpa [Kraus.evalWord] using evalWord_mem_wordSpan K ([i₀] : List (Fin d))
   have hmul : (K i₀) * M ∈ (wordSpan K 1) * (wordSpan K n) :=
     Submodule.mul_mem_mul hA hM
   simpa [Nat.add_comm] using (wordSpan_mul_le K 1 n) hmul

--- a/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -125,7 +125,7 @@ variable {d D : ℕ}
 
 /-- **The D-th power of a Kraus operator lies in wordSpan K D.**
 
-The matrix `(K i₀)^D` equals `evalWord K [i₀, …, i₀]` (D copies), which is a
+The matrix `(K i₀)^D` equals `Kraus.evalWord K [i₀, …, i₀]` (D copies), which is a
 word of length `D`. Hence it lies in `wordSpan K D` by definition.
 
 This is the "power membership" ingredient needed by

--- a/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
@@ -57,7 +57,7 @@ theorem mulLeft_mem_rectSpan_nilpIndex_succ
     calc M₀ * (M₀ ^ r) = M₀ ^ (r + 1) := by simp [pow_succ']
       _ = (M₀ ^ r) * M₀ := by simp [pow_succ]
   have hM₀ : M₀ ∈ wordSpan K 1 := by
-    simpa [M₀, MPSTensor.evalWord] using
+    simpa [M₀, Kraus.evalWord] using
       evalWord_mem_wordSpan K ([i₀] : List (Fin d))
   have hM₀M : M₀ * M ∈ wordSpan K (n + 1) := by
     have : M₀ * M ∈ (wordSpan K 1) * (wordSpan K n) := Submodule.mul_mem_mul hM₀ hM

--- a/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -30,8 +30,8 @@ variable {d D : ℕ}
 /-- Evaluation of a nonempty word splits into its first letter and remaining suffix. -/
 theorem evalWord_ofFn_succ (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {n : ℕ}
     (σ : Fin (n + 1) → Fin d) :
-    MPSTensor.evalWord K (List.ofFn σ) =
-      K (σ 0) * MPSTensor.evalWord K (List.ofFn (σ ∘ Fin.succ)) := by
+    Kraus.evalWord K (List.ofFn σ) =
+      K (σ 0) * Kraus.evalWord K (List.ofFn (σ ∘ Fin.succ)) := by
   rw [List.ofFn_succ]
   rfl
 
@@ -53,13 +53,13 @@ theorem wordSpan_succ_eq_mul_left
 def cumulativeSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
     Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Submodule.span ℂ
-    {X | ∃ w : List (Fin d), w.length ≤ n ∧ X = MPSTensor.evalWord K w}
+    {X | ∃ w : List (Fin d), w.length ≤ n ∧ X = Kraus.evalWord K w}
 
 /-- An evaluated word of length at most `n` belongs to `cumulativeSpan K n`. -/
 theorem mem_cumulativeSpan_generator
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {n : ℕ}
     {w : List (Fin d)} (hw : w.length ≤ n) :
-    MPSTensor.evalWord K w ∈ cumulativeSpan K n :=
+    Kraus.evalWord K w ∈ cumulativeSpan K n :=
   Submodule.subset_span ⟨w, hw, rfl⟩
 
 /-- An exact word span is contained in every sufficiently large cumulative span. -/
@@ -68,7 +68,7 @@ theorem wordSpan_le_cumulativeSpan
     wordSpan K m ≤ cumulativeSpan K n := by
   apply Submodule.span_le.mpr
   rintro X ⟨σ, rfl⟩
-  change MPSTensor.evalWord K (List.ofFn σ) ∈ _
+  change Kraus.evalWord K (List.ofFn σ) ∈ _
   apply mem_cumulativeSpan_generator
   simpa only [List.length_ofFn]
 
@@ -101,10 +101,10 @@ theorem left_mul_mem_cumulativeSpan
     rw [Submodule.map_le_iff_le_comap]
     apply Submodule.span_le.mpr
     rintro _ ⟨w, hw, rfl⟩
-    change (LinearMap.mulLeft ℂ (K i)) (MPSTensor.evalWord K w) ∈
+    change (LinearMap.mulLeft ℂ (K i)) (Kraus.evalWord K w) ∈
       cumulativeSpan K n
     simp only [LinearMap.mulLeft_apply]
-    change MPSTensor.evalWord K (i :: w) ∈ cumulativeSpan K n
+    change Kraus.evalWord K (i :: w) ∈ cumulativeSpan K n
     by_cases hle : w.length + 1 ≤ n
     · exact mem_cumulativeSpan_generator K (by simpa)
     · have hlen : (i :: w).length = n + 1 := by
@@ -127,15 +127,15 @@ theorem cumulativeSpan_stable
         wordSpan_le_cumulativeSpan K le_rfl
       _ = cumulativeSpan K n := h.symm
   have hword_all : ∀ w : List (Fin d), n < w.length →
-      MPSTensor.evalWord K w ∈ cumulativeSpan K n := by
+      Kraus.evalWord K w ∈ cumulativeSpan K n := by
     intro w hw
     induction w with
     | nil => simp at hw
     | cons i w ih =>
-      simp only [MPSTensor.evalWord]
+      simp only [Kraus.evalWord]
       by_cases hw' : n < w.length
       · exact left_mul_mem_cumulativeSpan K hstab i _ (ih hw')
-      · have hmem : MPSTensor.evalWord K w ∈ cumulativeSpan K n :=
+      · have hmem : Kraus.evalWord K w ∈ cumulativeSpan K n :=
           mem_cumulativeSpan_generator K (by omega)
         exact left_mul_mem_cumulativeSpan K hstab i _ hmem
   intro m hm
@@ -173,7 +173,7 @@ theorem cumulativeSpan_finrank_strict_mono
 theorem one_mem_cumulativeSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
     (1 : Matrix (Fin D) (Fin D) ℂ) ∈ cumulativeSpan K n :=
-  Submodule.subset_span ⟨[], by simp, by simp [MPSTensor.evalWord]⟩
+  Submodule.subset_span ⟨[], by simp, by simp [Kraus.evalWord]⟩
 
 /-- Zero-length words do not span the full matrix algebra when `2 ≤ D`. -/
 theorem wordSpan_zero_ne_top_of_two_le [NeZero D]

--- a/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -30,7 +30,7 @@ variable {d D : ℕ}
 theorem exists_nonzero_trace_word_of_cumulativeSpan_eq_top [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ}
     (hcs : cumulativeSpan K N = ⊤) :
-    ∃ w : List (Fin d), w.length ≤ N ∧ Matrix.trace (MPSTensor.evalWord K w) ≠ 0 := by
+    ∃ w : List (Fin d), w.length ≤ N ∧ Matrix.trace (Kraus.evalWord K w) ≠ 0 := by
   by_contra hall
   push Not at hall
   set trMap : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ :=
@@ -57,7 +57,7 @@ theorem exists_eigenvector_of_cumulativeSpan_eq_top [NeZero D]
     (hcs : cumulativeSpan K N = ⊤) :
     ∃ (w : List (Fin d)) (μ : ℂ) (φ : Fin D → ℂ),
       w.length ≤ N ∧ μ ≠ 0 ∧ φ ≠ 0 ∧
-      MPSTensor.evalWord K w *ᵥ φ = μ • φ := by
+      Kraus.evalWord K w *ᵥ φ = μ • φ := by
   obtain ⟨w, hw, htr⟩ := exists_nonzero_trace_word_of_cumulativeSpan_eq_top K hcs
   obtain ⟨μ, φ, hμ, hφ, heig⟩ :=
     _root_.exists_eigenvector_of_trace_ne_zero _ htr
@@ -123,7 +123,7 @@ theorem wordSpan_succ_eq_top_of_unital_of_wordSpan_eq_top
   rw [hdecomp]
   refine Submodule.sum_mem _ fun a _ => ?_
   have hLeft : K a ∈ wordSpan K 1 := by
-    simpa [MPSTensor.evalWord] using
+    simpa [Kraus.evalWord] using
       evalWord_mem_wordSpan K ([a] : List (Fin d))
   have hRight : (K a)ᴴ * X ∈ wordSpan K n := by
     rw [hTop]

--- a/TNLean/Kraus/Wielandt/SpanGrowth/EigenvectorSpreading.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/EigenvectorSpreading.lean
@@ -52,18 +52,18 @@ variable {d D : ℕ}
 
 /-! ### vectorSpreadSpan: H_n(K, φ) -/
 
-/-- H_n(K, φ) = span of {MPSTensor.evalWord K w *ᵥ φ : w has length n}.
+/-- H_n(K, φ) = span of {Kraus.evalWord K w *ᵥ φ : w has length n}.
 Paper: "H_n(K,φ) := S_n(K)|φ⟩" (arXiv:0909.5347, after equation (3)) -/
 def vectorSpreadSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (φ : Fin D → ℂ) (n : ℕ) :
     Submodule ℂ (Fin D → ℂ) :=
   Submodule.span ℂ (Set.range fun σ : Fin n → Fin d =>
-    (MPSTensor.evalWord K (List.ofFn σ)) *ᵥ φ)
+    (Kraus.evalWord K (List.ofFn σ)) *ᵥ φ)
 
 /-- Any word product of correct length applied to φ is in vectorSpreadSpan. -/
 theorem evalWord_mulVec_mem_vectorSpreadSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (φ : Fin D → ℂ)
     (w : List (Fin d)) :
-    MPSTensor.evalWord K w *ᵥ φ ∈ vectorSpreadSpan K φ w.length := by
+    Kraus.evalWord K w *ᵥ φ ∈ vectorSpreadSpan K φ w.length := by
   apply Submodule.subset_span
   exact ⟨w.get, by simp [List.ofFn_get]⟩
 
@@ -74,13 +74,13 @@ Paper: $K_n(K, φ) := \operatorname{span}\{H_m(K, φ) : m \le n\}$. -/
 def cumulativeVectorSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (φ : Fin D → ℂ) (n : ℕ) :
     Submodule ℂ (Fin D → ℂ) :=
   Submodule.span ℂ
-    {v | ∃ w : List (Fin d), w.length ≤ n ∧ v = MPSTensor.evalWord K w *ᵥ φ}
+    {v | ∃ w : List (Fin d), w.length ≤ n ∧ v = Kraus.evalWord K w *ᵥ φ}
 
 /-- Membership in the generating set of cumulativeVectorSpan. -/
 theorem mem_cumulativeVectorSpan_generator
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (φ : Fin D → ℂ) {n : ℕ}
     {w : List (Fin d)} (hw : w.length ≤ n) :
-    MPSTensor.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n :=
+    Kraus.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n :=
   Submodule.subset_span ⟨w, hw, rfl⟩
 
 /-- vectorSpreadSpan K φ m ≤ cumulativeVectorSpan K φ n when m ≤ n. -/
@@ -116,8 +116,8 @@ theorem cumulativeVectorSpan_mono'
 /-- Applying `K i` to a word product vector gives a longer word product vector. -/
 private theorem evalWord_cons_mulVec (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (i : Fin d)
     (w : List (Fin d)) (φ : Fin D → ℂ) :
-    MPSTensor.evalWord K (i :: w) *ᵥ φ = K i *ᵥ (MPSTensor.evalWord K w *ᵥ φ) := by
-  change (K i * MPSTensor.evalWord K w) *ᵥ φ = _
+    Kraus.evalWord K (i :: w) *ᵥ φ = K i *ᵥ (Kraus.evalWord K w *ᵥ φ) := by
+  change (K i * Kraus.evalWord K w) *ᵥ φ = _
   exact (Matrix.mulVec_mulVec _ _ _).symm
 
 /-- Key closure: applying K i to vectors in K_n sends them into K_{n+1},
@@ -132,7 +132,7 @@ private theorem mulVec_Ki_mem_cumulativeVectorSpan_succ
     rw [Submodule.map_le_iff_le_comap]
     apply Submodule.span_le.mpr
     rintro u ⟨w, hw, rfl⟩
-    change (Matrix.mulVecLin (K i)) (MPSTensor.evalWord K w *ᵥ φ) ∈
+    change (Matrix.mulVecLin (K i)) (Kraus.evalWord K w *ᵥ φ) ∈
       cumulativeVectorSpan K φ (n + 1)
     simp only [Matrix.mulVecLin_apply]
     rw [← evalWord_cons_mulVec]
@@ -162,7 +162,7 @@ theorem cumulativeVectorSpan_stable
           vectorSpreadSpan_le_cumulativeVectorSpan K φ (le_refl _)
       _ = cumulativeVectorSpan K φ n := h.symm
   have hword_all : ∀ (w : List (Fin d)),
-      n < w.length → MPSTensor.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n := by
+      n < w.length → Kraus.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n := by
     intro w hw
     induction w with
     | nil => simp at hw
@@ -170,7 +170,7 @@ theorem cumulativeVectorSpan_stable
       rw [evalWord_cons_mulVec]
       by_cases hw' : n < w.length
       · exact mulVec_Ki_mem_cumulativeVectorSpan_stable K φ h i (ih hw')
-      · have : MPSTensor.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n :=
+      · have : Kraus.evalWord K w *ᵥ φ ∈ cumulativeVectorSpan K φ n :=
           mem_cumulativeVectorSpan_generator K φ (by omega)
         exact mulVec_Ki_mem_cumulativeVectorSpan_stable K φ h i this
   intro m hm
@@ -184,11 +184,11 @@ theorem cumulativeVectorSpan_stable
 
 /-! ### Anchor membership -/
 
-/-- φ is in K_n for all n ≥ 0 (since MPSTensor.evalWord K [] *ᵥ φ = φ). -/
+/-- φ is in K_n for all n ≥ 0 (since Kraus.evalWord K [] *ᵥ φ = φ). -/
 theorem phi_mem_cumulativeVectorSpan
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (φ : Fin D → ℂ) (n : ℕ) :
     φ ∈ cumulativeVectorSpan K φ n := by
-  simpa [MPSTensor.evalWord] using
+  simpa [Kraus.evalWord] using
     (mem_cumulativeVectorSpan_generator
       (K := K) (φ := φ) (w := []) (n := n) (by simp))
 
@@ -217,7 +217,7 @@ theorem cumulativeVectorSpan_finrank_strict_mono
 /-- If `cumulativeSpan K N = ⊤` (all D×D matrices are linear combinations
 of word products), then `cumulativeVectorSpan K φ N = ⊤` for any nonzero φ.
 
-The argument: since every matrix is a linear combination of MPSTensor.evalWord K w,
+The argument: since every matrix is a linear combination of Kraus.evalWord K w,
 the standard basis matrix `Matrix.single j k 1` is in the span.
 Then `(Matrix.single j k 1) *ᵥ φ = φ k • e_j` is in K_N.
 Since φ ≠ 0, some φ k ≠ 0, so e_j ∈ K_N for all j, hence K_N = ⊤. -/

--- a/TNLean/Kraus/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -70,16 +70,16 @@ theorem wordSpan_finrank_le (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ)
 /-- A length-one word evaluates to the corresponding tensor entry. -/
 theorem evalWord_ofFn_one_eq
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (σ : Fin 1 → Fin d) :
-    MPSTensor.evalWord K (List.ofFn σ) = K (σ 0) := by
+    Kraus.evalWord K (List.ofFn σ) = K (σ 0) := by
   have h : List.ofFn σ = [σ 0] := by
     apply List.ext_getElem <;> simp
   rw [h]
-  simp [MPSTensor.evalWord]
+  simp [Kraus.evalWord]
 
 /-- Every family element belongs to the one-step word span `S₁(K)`. -/
 theorem apply_mem_wordSpan_one (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (i : Fin d) :
     K i ∈ wordSpan K 1 := by
-  simpa [MPSTensor.evalWord] using evalWord_mem_wordSpan K ([i] : List (Fin d))
+  simpa [Kraus.evalWord] using evalWord_mem_wordSpan K ([i] : List (Fin d))
 
 /-- Add a one-step span element as a redundant first generator.
 
@@ -162,10 +162,10 @@ theorem mulLeft_image_wordSpan_le_succ (K : Fin d → Matrix (Fin D) (Fin D) ℂ
   apply Submodule.map_le_iff_le_comap.mpr
   apply Submodule.span_le.mpr
   rintro M ⟨σ, rfl⟩
-  change (LinearMap.mulLeft ℂ (K i₀)) (MPSTensor.evalWord K (List.ofFn σ)) ∈
+  change (LinearMap.mulLeft ℂ (K i₀)) (Kraus.evalWord K (List.ofFn σ)) ∈
     wordSpan K (n + 1)
   simp only [LinearMap.mulLeft_apply]
-  change MPSTensor.evalWord K (i₀ :: List.ofFn σ) ∈ wordSpan K (n + 1)
+  change Kraus.evalWord K (i₀ :: List.ofFn σ) ∈ wordSpan K (n + 1)
   apply Submodule.subset_span
   exact ⟨Fin.cons i₀ σ, by simp [List.ofFn_succ]⟩
 

--- a/TNLean/Kraus/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
@@ -40,7 +40,6 @@ linearly independent, `dim(S₁(K)) = d` and the bounds coincide.
 -/
 
 open scoped Matrix
-open MPSTensor
 
 namespace Kraus
 
@@ -136,7 +135,7 @@ theorem cumulativeSpan_eq_top [NeZero D]
 
 /-- **Lemma 1** (arXiv:0909.5347), main statement:
 Assuming some exact word span is full, there exists a word `w` of length ≤ D² such
-that `tr(evalWord K w) ≠ 0`.
+that `tr(Kraus.evalWord K w) ≠ 0`.
 
 Paper: "If E_A is primitive, then there exists K^(n) ∈ S_n(K)
 with n ≤ D²−d+1 such that tr(K^(n)) ≠ 0."
@@ -148,7 +147,7 @@ theorem exists_nonzero_trace_word [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ}
     (hN : wordSpan K N = ⊤) :
     ∃ w : List (Fin d),
-      w.length ≤ D ^ 2 ∧ Matrix.trace (evalWord K w) ≠ 0 :=
+      w.length ≤ D ^ 2 ∧ Matrix.trace (Kraus.evalWord K w) ≠ 0 :=
   exists_nonzero_trace_word_of_cumulativeSpan_eq_top K
     (cumulativeSpan_eq_top K hN)
 
@@ -316,7 +315,7 @@ theorem cumulativeSpan_eq_top_of_wordSpan_eq_top_sharp [NeZero D]
 
 /-- **Lemma 1, sharp version** (arXiv:0909.5347):
 Assuming some exact word span is full, there exists a word `w` of length
-≤ D² − dim(S₁(K)) + 1 such that `tr(evalWord K w) ≠ 0`.
+≤ D² − dim(S₁(K)) + 1 such that `tr(Kraus.evalWord K w) ≠ 0`.
 
 Paper: "If E_A is primitive, then there exists K^(n) ∈ S_n(K)
 with n ≤ D²−d+1 such that tr(K^(n)) ≠ 0."
@@ -330,7 +329,7 @@ theorem exists_nonzero_trace_word_sharp [NeZero D]
     (hN : wordSpan K N = ⊤) :
     ∃ w : List (Fin d),
       w.length ≤ D ^ 2 - Module.finrank ℂ (wordSpan K 1) + 1 ∧
-        Matrix.trace (evalWord K w) ≠ 0 :=
+        Matrix.trace (Kraus.evalWord K w) ≠ 0 :=
   exists_nonzero_trace_word_of_cumulativeSpan_eq_top K
     (cumulativeSpan_eq_top_of_wordSpan_eq_top_sharp K hN)
 
@@ -341,20 +340,20 @@ sharp bound. This gives a positive-length word with nonzero trace, which is
 needed for the blocking argument in Theorem 1 case (1).
 
 The key insight is that the positive-level cumulative span
-`V_n = span{evalWord K w : 1 ≤ |w| ≤ n}` satisfies the same growth and
+`V_n = span{Kraus.evalWord K w : 1 ≤ |w| ≤ n}` satisfies the same growth and
 stabilization properties as the full cumulative span `T_n`, so
 `V_{D²−d'+1} = M_D(ℂ)` for positive `D`. -/
 
 /-- **Lemma 1, sharp positive-length version** (arXiv:0909.5347):
 For positive `D`, assume a positive exact word span is full. Then there exists a
 **positive-length** word `w` with
-`|w| ≤ D² − dim(S₁(K)) + 1` such that `tr(evalWord K w) ≠ 0`.
+`|w| ≤ D² − dim(S₁(K)) + 1` such that `tr(Kraus.evalWord K w) ≠ 0`.
 
 This strengthens `exists_nonzero_trace_word_sharp` by additionally requiring
 `1 ≤ w.length`, which is needed for the blocking argument in Theorem 1 case (1).
 
 The proof shows that the positive-level cumulative span
-`V_{D²−d'+1} = span{evalWord K w : 1 ≤ |w| ≤ D²−d'+1}`
+`V_{D²−d'+1} = span{Kraus.evalWord K w : 1 ≤ |w| ≤ D²−d'+1}`
 equals `M_D(ℂ)`, so it cannot be contained in `ker(trace)`. -/
 theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ) {N : ℕ}
@@ -362,15 +361,15 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
     ∃ (w : List (Fin d)),
       1 ≤ w.length ∧
       w.length ≤ D ^ 2 - Module.finrank ℂ (wordSpan K 1) + 1 ∧
-        Matrix.trace (evalWord K w) ≠ 0 := by
+        Matrix.trace (Kraus.evalWord K w) ≠ 0 := by
   by_contra hall
   push Not at hall
-  -- hall : ∀ w, 1 ≤ |w| → |w| ≤ bound → tr(evalWord K w) = 0
+  -- hall : ∀ w, 1 ≤ |w| → |w| ≤ bound → tr(Kraus.evalWord K w) = 0
   -- Define the positive-level cumulative span
   set bound := D ^ 2 - Module.finrank ℂ (wordSpan K 1) + 1 with hbound_def
   set V : ℕ → Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     fun n => Submodule.span ℂ
-      {M | ∃ w : List (Fin d), 1 ≤ w.length ∧ w.length ≤ n ∧ M = evalWord K w}
+      {M | ∃ w : List (Fin d), 1 ≤ w.length ∧ w.length ≤ n ∧ M = Kraus.evalWord K w}
   -- Step 1: V 1 ≥ wordSpan K 1 (hence dim ≥ krausRank)
   have hV1_ge : wordSpan K 1 ≤ V 1 := by
     apply Submodule.span_le.mpr
@@ -413,10 +412,10 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       rw [Submodule.map_le_iff_le_comap]
       apply Submodule.span_le.mpr
       rintro M ⟨w, hw1, hw2, rfl⟩
-      change (LinearMap.mulLeft ℂ (K i)) (evalWord K w) ∈ V n
+      change (LinearMap.mulLeft ℂ (K i)) (Kraus.evalWord K w) ∈ V n
       simp only [LinearMap.mulLeft_apply]
-      -- K i * evalWord K w = evalWord K (i :: w)
-      change evalWord K (i :: w) ∈ V n
+      -- K i * Kraus.evalWord K w = Kraus.evalWord K (i :: w)
+      change Kraus.evalWord K (i :: w) ∈ V n
       by_cases hle : w.length + 1 ≤ n
       · exact Submodule.subset_span ⟨i :: w,
           by
@@ -425,14 +424,14 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
           by simpa only [List.length_cons] using hle,
           rfl⟩
       · -- |i :: w| = |w| + 1 > n, so |w| = n, |i :: w| = n + 1
-        have : evalWord K (i :: w) ∈ wordSpan K (n + 1) := by
+        have : Kraus.evalWord K (i :: w) ∈ wordSpan K (n + 1) := by
           have hlen : (i :: w).length = n + 1 := by simp [List.length_cons]; omega
           have hmem := evalWord_mem_wordSpan K (i :: w)
           rw [hlen] at hmem; exact hmem
         exact hws this
     -- By induction: all word products of length ≥ 1 are in V n
     have hword_all : ∀ (w : List (Fin d)),
-        1 ≤ w.length → evalWord K w ∈ V n := by
+        1 ≤ w.length → Kraus.evalWord K w ∈ V n := by
       intro w hw1
       by_cases hw2 : w.length ≤ n
       · apply Submodule.subset_span
@@ -458,7 +457,7 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
                   simpa only [List.length_cons] using
                     Nat.succ_le_succ (Nat.zero_le t.length)
             by_cases hw3 : w.length ≤ n
-            · -- |w| ≤ n, so evalWord K w ∈ V n directly
+            · -- |w| ≤ n, so Kraus.evalWord K w ∈ V n directly
               exact hleft i _ (Submodule.subset_span ⟨w, hw1', hw3, rfl⟩)
             · -- |w| > n, use ih
               exact hleft i _ (ih hw1' hw3)
@@ -565,7 +564,7 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       (Matrix.traceLinearMap (Fin D) ℂ ℂ)
       (0 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ)
       {M | ∃ w : List (Fin d), 1 ≤ w.length ∧ w.length ≤ bound ∧
-        M = evalWord K w} := by
+        M = Kraus.evalWord K w} := by
     rintro M ⟨w, hw1, hw2, rfl⟩
     simp only [Matrix.traceLinearMap_apply, LinearMap.zero_apply]
     exact hall w hw1 hw2

--- a/TNLean/Kraus/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Kraus/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -59,13 +59,13 @@ theorem map_wordSpan_eq_vectorSpreadSpan
   -- Rewrite the RHS as an image of a range (so both sides match).
   -- (`Set.range (g ∘ f) = g '' Set.range f`)
   have hrange :
-      (Set.range fun σ : Fin n → Fin d => MPSTensor.evalWord K (List.ofFn σ) *ᵥ φ) =
+      (Set.range fun σ : Fin n → Fin d => Kraus.evalWord K (List.ofFn σ) *ᵥ φ) =
         (fun M : Matrix (Fin D) (Fin D) ℂ => M *ᵥ φ) ''
-          (Set.range fun σ : Fin n → Fin d => MPSTensor.evalWord K (List.ofFn σ)) := by
+          (Set.range fun σ : Fin n → Fin d => Kraus.evalWord K (List.ofFn σ)) := by
     ext v
     constructor
     · rintro ⟨σ, rfl⟩
-      exact ⟨MPSTensor.evalWord K (List.ofFn σ), ⟨σ, rfl⟩, rfl⟩
+      exact ⟨Kraus.evalWord K (List.ofFn σ), ⟨σ, rfl⟩, rfl⟩
     · rintro ⟨M, ⟨σ, rfl⟩, rfl⟩
       exact ⟨σ, rfl⟩
   -- Finish by rewriting.
@@ -146,19 +146,19 @@ theorem cumulativeVectorSpan_le_vectorSpreadSpan_of_eigenvector
     have : w.length + (n - w.length) = n := Nat.add_sub_of_le hw
     simp [w', k, List.length_append, this]
   -- Compute the padded action on `φ`.
-  have hrep : MPSTensor.evalWord K (List.replicate k i₀) *ᵥ φ = μ ^ k • φ := by
+  have hrep : Kraus.evalWord K (List.replicate k i₀) *ᵥ φ = μ ^ k • φ := by
     induction k with
     | zero =>
       simp
     | succ k ih =>
       -- `replicate (k+1) i₀ = i₀ :: replicate k i₀`.
       calc
-        MPSTensor.evalWord K (List.replicate (k + 1) i₀) *ᵥ φ
-            = (K i₀ * MPSTensor.evalWord K (List.replicate k i₀)) *ᵥ φ := by
+        Kraus.evalWord K (List.replicate (k + 1) i₀) *ᵥ φ
+            = (K i₀ * Kraus.evalWord K (List.replicate k i₀)) *ᵥ φ := by
                 simp [List.replicate_succ]
-        _ = K i₀ *ᵥ (MPSTensor.evalWord K (List.replicate k i₀) *ᵥ φ) := by
+        _ = K i₀ *ᵥ (Kraus.evalWord K (List.replicate k i₀) *ᵥ φ) := by
               exact (Matrix.mulVec_mulVec φ (K i₀)
-                (MPSTensor.evalWord K (List.replicate k i₀))).symm
+                (Kraus.evalWord K (List.replicate k i₀))).symm
         _ = K i₀ *ᵥ (μ ^ k • φ) := by
               simp [ih]
         _ = μ ^ k • (K i₀ *ᵥ φ) := by
@@ -168,39 +168,39 @@ theorem cumulativeVectorSpan_le_vectorSpreadSpan_of_eigenvector
         _ = μ ^ (k + 1) • φ := by
               simp [pow_succ, smul_smul]
   have hpad :
-      MPSTensor.evalWord K w' *ᵥ φ = μ ^ k • (MPSTensor.evalWord K w *ᵥ φ) := by
+      Kraus.evalWord K w' *ᵥ φ = μ ^ k • (Kraus.evalWord K w *ᵥ φ) := by
     -- Use `evalWord_append` and then apply the eigenvector scaling lemma.
     calc
-      MPSTensor.evalWord K w' *ᵥ φ
-          = (MPSTensor.evalWord K w *
-              MPSTensor.evalWord K (List.replicate k i₀)) *ᵥ φ := by
-            simp [w', MPSTensor.evalWord_append]
-      _ = MPSTensor.evalWord K w *ᵥ
-          (MPSTensor.evalWord K (List.replicate k i₀) *ᵥ φ) := by
-            exact (Matrix.mulVec_mulVec φ (MPSTensor.evalWord K w)
-              (MPSTensor.evalWord K (List.replicate k i₀))).symm
-      _ = MPSTensor.evalWord K w *ᵥ (μ ^ k • φ) := by
+      Kraus.evalWord K w' *ᵥ φ
+          = (Kraus.evalWord K w *
+              Kraus.evalWord K (List.replicate k i₀)) *ᵥ φ := by
+            simp [w', Kraus.evalWord_append]
+      _ = Kraus.evalWord K w *ᵥ
+          (Kraus.evalWord K (List.replicate k i₀) *ᵥ φ) := by
+            exact (Matrix.mulVec_mulVec φ (Kraus.evalWord K w)
+              (Kraus.evalWord K (List.replicate k i₀))).symm
+      _ = Kraus.evalWord K w *ᵥ (μ ^ k • φ) := by
             simp [hrep]
-      _ = μ ^ k • (MPSTensor.evalWord K w *ᵥ φ) := by
+      _ = μ ^ k • (Kraus.evalWord K w *ᵥ φ) := by
             simp [Matrix.mulVec_smul]
   -- The padded vector lies in the fixed-length span.
-  have hmem' : MPSTensor.evalWord K w' *ᵥ φ ∈ vectorSpreadSpan K φ n := by
+  have hmem' : Kraus.evalWord K w' *ᵥ φ ∈ vectorSpreadSpan K φ n := by
     -- It is a generator at length `n`.
     have := evalWord_mulVec_mem_vectorSpreadSpan (K := K) (φ := φ) w'
     simpa [hw'] using this
-  -- Rescale by `(μ^k)⁻¹` to get back `MPSTensor.evalWord K w *ᵥ φ`.
+  -- Rescale by `(μ^k)⁻¹` to get back `Kraus.evalWord K w *ᵥ φ`.
   have hk0 : μ ^ k ≠ 0 := by
     exact pow_ne_zero _ hμ
-  have : (μ ^ k)⁻¹ • (MPSTensor.evalWord K w' *ᵥ φ) = MPSTensor.evalWord K w *ᵥ φ := by
-    -- From `hpad : MPSTensor.evalWord w' * φ = μ^k • MPSTensor.evalWord w * φ`.
+  have : (μ ^ k)⁻¹ • (Kraus.evalWord K w' *ᵥ φ) = Kraus.evalWord K w *ᵥ φ := by
+    -- From `hpad : Kraus.evalWord w' * φ = μ^k • Kraus.evalWord w * φ`.
     -- Multiply by `(μ^k)⁻¹`.
     calc
-      (μ ^ k)⁻¹ • (MPSTensor.evalWord K w' *ᵥ φ)
-          = (μ ^ k)⁻¹ • (μ ^ k • (MPSTensor.evalWord K w *ᵥ φ)) := by
+      (μ ^ k)⁻¹ • (Kraus.evalWord K w' *ᵥ φ)
+          = (μ ^ k)⁻¹ • (μ ^ k • (Kraus.evalWord K w *ᵥ φ)) := by
               simp [hpad]
-      _ = ((μ ^ k)⁻¹ * μ ^ k) • (MPSTensor.evalWord K w *ᵥ φ) := by
+      _ = ((μ ^ k)⁻¹ * μ ^ k) • (Kraus.evalWord K w *ᵥ φ) := by
             simp [smul_smul]
-      _ = MPSTensor.evalWord K w *ᵥ φ := by
+      _ = Kraus.evalWord K w *ᵥ φ := by
             simp [inv_mul_cancel₀ hk0]
   -- Conclude by closure under scalar multiplication.
   -- (`vectorSpreadSpan` is a submodule.)

--- a/TNLean/Kraus/Word.lean
+++ b/TNLean/Kraus/Word.lean
@@ -13,30 +13,17 @@ import Mathlib.LinearAlgebra.Matrix.Trace
 /-!
 # Word evaluation for finite Kraus families
 
-This file carries the word-evaluation layer of the channel side: `evalWord`,
-its multiplicativity and intertwining lemmas, physical reindexing, and the
-trace/similarity-invariance fact used to build the MPV coefficient. It also
-carries the `MPSTensor` abbrev itself, so that `TNLean/MPS/Defs.lean` and
-every other Kraus module can obtain the abbrev by importing this file without
-a dependency cycle. It is part of the extraction of a
-Kraus-family-only library out of `TNLean`'s matrix-product-state
-development.
-
-**Pending:** these declarations keep `namespace MPSTensor` for now. The
-rename to `namespace Kraus`, which matches the vocabulary already used under
-`TNLean/Channel/`, is deferred to a dedicated mechanical sweep across the
-~429 files that reference this vocabulary (word layer and `Wielandt/`
-together). Declarations here use the `MPSTensor` abbrev, not the raw
-function type, precisely so that this sweep does not also have to repair the
-generalized-field-notation call sites (`A.evalWord`, `hA.isNormal`, …) that
-rely on `MPSTensor` being the head symbol of the argument type.
+For a finite matrix family $K = (K_i)_i$ and a word
+$w = [i_1, \ldots, i_n]$, `Kraus.evalWord K w` is the ordered product
+$K_{i_1} \cdots K_{i_n}$. This file proves its basic multiplicative,
+intertwining, reindexing, and transpose properties.
 
 ## Main declarations
 
 * `List.ofFn_reverse` — reversing `List.ofFn` precomposes its function with `Fin.rev`
-* `MPSTensor` — a `Fin d`-indexed family of `D×D` complex matrices
-* `evalWord` — the matrix product associated with a word of physical indices
-* `evalWord_intertwine` — a rectangular letter intertwiner also intertwines every word
+* `Kraus.evalWord` — the matrix product associated with a word of physical indices
+* `Kraus.evalWord_append` — evaluation sends concatenation to multiplication
+* `Kraus.evalWord_intertwine` — a letter intertwiner also intertwines every word
 -/
 
 open scoped Matrix
@@ -57,99 +44,94 @@ theorem ofFn_reverse {n : ℕ} {α : Type*} (f : Fin n → α) :
 
 end List
 
-/-- A (periodic, translation-invariant) tensor generating an MPV family:
-a family of `D×D` matrices indexed by a physical index in `Fin d`.
-
-The name `MPSTensor` is kept for compatibility with the literature and the
-existing Lean development. -/
-abbrev MPSTensor (d D : ℕ) := Fin d → Matrix (Fin D) (Fin D) ℂ
-
-namespace MPSTensor
+namespace Kraus
 
 variable {d D : ℕ}
 
-/-- Evaluate a word `w = [i₁, i₂, …, iₙ]` by multiplying the corresponding matrices
-`A i₁ * A i₂ * ⋯ * A iₙ`. Returns `1` for the empty word. -/
-def evalWord (A : MPSTensor d D) : List (Fin d) → Matrix (Fin D) (Fin D) ℂ
+/-- Evaluate a word $w = [i_1, i_2, \ldots, i_n]$ by multiplying the corresponding
+matrices $K_{i_1} K_{i_2} \cdots K_{i_n}$. The empty word evaluates to the identity. -/
+def evalWord (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    List (Fin d) → Matrix (Fin D) (Fin D) ℂ
   | [] => 1
-  | i :: w => A i * evalWord A w
+  | i :: w => K i * evalWord K w
 
 /-- The empty word evaluates to the identity. -/
-@[simp] lemma evalWord_nil (A : MPSTensor d D) : evalWord A [] = 1 := rfl
+@[simp] lemma evalWord_nil (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    evalWord K [] = 1 := rfl
 
-/-- The word with head $i$ followed by $w$ evaluates to $A_i$ times the evaluation of $w$. -/
-@[simp] lemma evalWord_cons (A : MPSTensor d D) (i : Fin d) (w : List (Fin d)) :
-    evalWord A (i :: w) = A i * evalWord A w := rfl
+/-- The word with head $i$ followed by $w$ evaluates to $K_i$ times the evaluation of $w$. -/
+@[simp] lemma evalWord_cons (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (i : Fin d) (w : List (Fin d)) :
+    evalWord K (i :: w) = K i * evalWord K w := rfl
 
-/-- A rectangular matrix that intertwines every letter of two tensors also intertwines
+/-- A rectangular matrix that intertwines every letter of two families also intertwines
 all their word evaluations. -/
-lemma evalWord_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
-    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, A i * V = V * B i) :
-    ∀ w : List (Fin d), evalWord A w * V = V * evalWord B w := by
+lemma evalWord_intertwine {n : ℕ}
+    (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (L : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, K i * V = V * L i) :
+    ∀ w : List (Fin d), evalWord K w * V = V * evalWord L w := by
   intro w
   induction w with
   | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
   | cons i w ih =>
       rw [evalWord_cons, evalWord_cons]
       calc
-        A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
-        _ = A i * (V * evalWord B w) := by rw [ih]
-        _ = (A i * V) * evalWord B w := (Matrix.mul_assoc _ _ _).symm
-        _ = (V * B i) * evalWord B w := by rw [hInt i]
-        _ = V * (B i * evalWord B w) := Matrix.mul_assoc _ _ _
+        K i * evalWord K w * V = K i * (evalWord K w * V) := Matrix.mul_assoc _ _ _
+        _ = K i * (V * evalWord L w) := by rw [ih]
+        _ = (K i * V) * evalWord L w := (Matrix.mul_assoc _ _ _).symm
+        _ = (V * L i) * evalWord L w := by rw [hInt i]
+        _ = V * (L i * evalWord L w) := Matrix.mul_assoc _ _ _
 
-/-- Multiplicativity of word evaluation:
-`evalWord A (w1 ++ w2) = evalWord A w1 * evalWord A w2`. -/
-lemma evalWord_append (A : MPSTensor d D) :
-    ∀ w1 w2 : List (Fin d), evalWord A (w1 ++ w2) = evalWord A w1 * evalWord A w2 := by
-  intro w1 w2
-  induction w1 with
+/-- Word evaluation sends concatenation to multiplication. -/
+lemma evalWord_append (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    ∀ w₁ w₂ : List (Fin d), evalWord K (w₁ ++ w₂) = evalWord K w₁ * evalWord K w₂ := by
+  intro w₁ w₂
+  induction w₁ with
   | nil => simp [evalWord]
-  | cons i w1 ih => simp [evalWord, ih, Matrix.mul_assoc]
+  | cons i w₁ ih => simp [evalWord, ih, Matrix.mul_assoc]
 
-/-- If `P` commutes with every letter of `A`, then it commutes with every evaluated word. -/
+/-- If $P$ commutes with every letter of $K$, then it commutes with every evaluated word. -/
 lemma commutes_evalWord_of_commutes_letters
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D)
-    (hComm : ∀ i : Fin d, P * A i = A i * P) :
-    ∀ w : List (Fin d), P * evalWord A w = evalWord A w * P := by
+    (P : Matrix (Fin D) (Fin D) ℂ) (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (hComm : ∀ i : Fin d, P * K i = K i * P) :
+    ∀ w : List (Fin d), P * evalWord K w = evalWord K w * P := by
   intro w
   induction w with
   | nil =>
       simp only [evalWord, Matrix.one_mul, Matrix.mul_one]
   | cons i w ih =>
       simp only [evalWord]
-      calc P * (A i * evalWord A w)
-          = A i * (evalWord A w * P) := by
-            rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hComm i, Matrix.mul_assoc,
-              Matrix.mul_assoc, ih]
-        _ = A i * evalWord A w * P := by rw [← Matrix.mul_assoc]
+      calc
+        P * (K i * evalWord K w) = K i * (evalWord K w * P) := by
+          rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hComm i, Matrix.mul_assoc,
+            Matrix.mul_assoc, ih]
+        _ = K i * evalWord K w * P := by rw [← Matrix.mul_assoc]
 
-/-- Scaling of word evaluation:
-scaling every matrix by a scalar `ζ` scales `evalWord` by the factor
-`ζ ^ w.length`. -/
-lemma evalWord_smul (ζ : ℂ) (A : MPSTensor d D) :
-    ∀ w : List (Fin d), evalWord (fun i => ζ • A i) w = (ζ ^ w.length) • evalWord A w := by
+/-- Scaling every matrix by $\zeta$ scales a word evaluation by $\zeta^{|w|}$. -/
+lemma evalWord_smul (ζ : ℂ) (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+    ∀ w : List (Fin d), evalWord (fun i => ζ • K i) w = (ζ ^ w.length) • evalWord K w := by
   intro w
   induction w with
   | nil => simp [evalWord]
   | cons i w ih =>
       simp [evalWord, ih, pow_succ, smul_smul]
 
-/-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
+/-- Reindex the physical alphabet of a finite matrix family. -/
 noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
-    (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
-  fun i => A (f i)
+    (K : Fin d₂ → Matrix (Fin D) (Fin D) ℂ) :
+    Fin d₁ → Matrix (Fin D) (Fin D) ℂ :=
+  fun i => K (f i)
 
 /-- Word evaluation after physical reindexing is word evaluation on the mapped word. -/
 theorem evalWord_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
-    (A : MPSTensor d₂ D) (w : List (Fin d₁)) :
-    evalWord (reindexPhysical f A) w = evalWord A (w.map f) := by
+    (K : Fin d₂ → Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d₁)) :
+    evalWord (reindexPhysical f K) w = evalWord K (w.map f) := by
   induction w with
   | nil => simp
   | cons i w ih => simp [evalWord, reindexPhysical, ih]
 
-/-- Cyclicity of trace gives invariance under similarity:
-`trace (X * M * X⁻¹) = trace M` for `X ∈ GL`. -/
+/-- Cyclicity of trace gives invariance under similarity. -/
 lemma trace_conj_eq (X : GL (Fin D) ℂ) (M : Matrix (Fin D) (Fin D) ℂ) :
     Matrix.trace
         ((X : Matrix (Fin D) (Fin D) ℂ) * M *
@@ -158,22 +140,14 @@ lemma trace_conj_eq (X : GL (Fin D) ℂ) (M : Matrix (Fin D) (Fin D) ℂ) :
   simpa [Matrix.mul_assoc] using Matrix.trace_mul_cycle
       (X : Matrix (Fin D) (Fin D) ℂ) M ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
 
-end MPSTensor
-
-namespace Kraus
-
-variable {d D : ℕ}
-
 /-- Transposing a word product reverses the word. -/
-theorem evalWord_transpose
-    (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
+theorem evalWord_transpose (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     ∀ w : List (Fin d),
-      (MPSTensor.evalWord K w)ᵀ =
-        MPSTensor.evalWord (fun i ↦ (K i)ᵀ) w.reverse := by
+      (evalWord K w)ᵀ = evalWord (fun i ↦ (K i)ᵀ) w.reverse := by
   intro w
   induction w with
-  | nil => simp [MPSTensor.evalWord]
+  | nil => simp [evalWord]
   | cons i w ih =>
-      simp [MPSTensor.evalWord, Matrix.transpose_mul, ih, MPSTensor.evalWord_append]
+      simp [evalWord, Matrix.transpose_mul, ih, evalWord_append]
 
 end Kraus

--- a/TNLean/Kraus/WordSpan.lean
+++ b/TNLean/Kraus/WordSpan.lean
@@ -31,12 +31,12 @@ variable {d D : ℕ}
 def wordSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) :
     Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Submodule.span ℂ (Set.range fun σ : Fin N → Fin d =>
-    MPSTensor.evalWord K (List.ofFn σ))
+    Kraus.evalWord K (List.ofFn σ))
 
 /-- Every evaluated word belongs to the word span at its length. -/
 theorem evalWord_mem_wordSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (w : List (Fin d)) :
-    MPSTensor.evalWord K w ∈ wordSpan K w.length := by
+    Kraus.evalWord K w ∈ wordSpan K w.length := by
   apply Submodule.subset_span
   exact ⟨w.get, by simp [List.ofFn_get]⟩
 
@@ -62,9 +62,9 @@ theorem evalWord_mem_wordSpan (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   simp only [Set.mem_range]
   constructor
   · rintro ⟨σ, rfl⟩
-    exact ⟨σ 0, by simp [MPSTensor.evalWord]⟩
+    exact ⟨σ 0, by simp [Kraus.evalWord]⟩
   · rintro ⟨i, rfl⟩
-    exact ⟨fun _ => i, by simp [MPSTensor.evalWord]⟩
+    exact ⟨fun _ => i, by simp [Kraus.evalWord]⟩
 
 /-- Word spans factor exactly under addition of word lengths. -/
 theorem wordSpan_add (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (m n : ℕ) :
@@ -73,18 +73,18 @@ theorem wordSpan_add (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (m n : ℕ) :
   apply le_antisymm
   · apply Submodule.span_le.mpr
     rintro _ ⟨σ, rfl⟩
-    change MPSTensor.evalWord K (List.ofFn σ) ∈ _
+    change Kraus.evalWord K (List.ofFn σ) ∈ _
     let σ₁ : Fin m → Fin d := fun i => σ (Fin.castLE (by omega) i)
     let σ₂ : Fin n → Fin d := fun i => σ (Fin.natAdd m i)
     rw [show List.ofFn σ = List.ofFn σ₁ ++ List.ofFn σ₂ from List.ofFn_add,
-      MPSTensor.evalWord_append]
+      Kraus.evalWord_append]
     exact Submodule.mul_mem_mul
       (Submodule.subset_span ⟨σ₁, rfl⟩)
       (Submodule.subset_span ⟨σ₂, rfl⟩)
   · rw [wordSpan, wordSpan, Submodule.span_mul_span]
     apply Submodule.span_le.mpr
     rintro _ ⟨X, ⟨σ₁, rfl⟩, Y, ⟨σ₂, rfl⟩, rfl⟩
-    simpa [List.length_append, MPSTensor.evalWord_append] using
+    simpa [List.length_append, Kraus.evalWord_append] using
       evalWord_mem_wordSpan K (List.ofFn σ₁ ++ List.ofFn σ₂)
 
 /-- A successor word span is obtained by multiplying on the right by the

--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -74,7 +74,7 @@ noncomputable def reindexPhysical {A : MPSTensor d₂ D}
   coisometric := data.coisometric
   reconstruct := by
     intro i
-    simpa [MPSTensor.reindexPhysical, toTensorFromBlocks] using data.reconstruct (e i)
+    simpa [Kraus.reindexPhysical, toTensorFromBlocks] using data.reconstruct (e i)
 
 end CPSVCanonicalFormData
 

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -81,9 +81,9 @@ theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
 private theorem evalWord_mapStar (A : MPSTensor d D) (w : List (Fin d)) :
     evalWord (mapStar A) w = (evalWord A w).map (starRingEnd ℂ) := by
   induction w with
-  | nil => simp [evalWord]
+  | nil => simp [Kraus.evalWord]
   | cons i w ih =>
-      simp only [evalWord, mapStar_apply, ih]
+      simp only [Kraus.evalWord, mapStar_apply, ih]
       exact ((starRingEnd ℂ).mapMatrix.map_mul (A i) (evalWord A w)).symm
 
 /-- Entrywise conjugation preserves positive-length block injectivity, hence normality. -/

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -81,7 +81,7 @@ theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
 private theorem evalWord_mapStar (A : MPSTensor d D) (w : List (Fin d)) :
     evalWord (mapStar A) w = (evalWord A w).map (starRingEnd ℂ) := by
   induction w with
-  | nil => simp [Kraus.evalWord]
+  | nil => simp
   | cons i w ih =>
       simp only [Kraus.evalWord, mapStar_apply, ih]
       exact ((starRingEnd ℂ).mapMatrix.map_mul (A i) (evalWord A w)).symm

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Basic.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Basic.lean
@@ -48,9 +48,9 @@ lemma left_mul_evalWord_leftSectorTensor_of_commutes
   intro w
   induction w with
   | nil =>
-      simp only [evalWord]
+      simp only [Kraus.evalWord]
   | cons i w ih =>
-      simp only [leftSectorTensor, evalWord]
+      simp only [leftSectorTensor, Kraus.evalWord]
       calc P * (P * A i * evalWord (leftSectorTensor P A) w)
           = P * P * A i * evalWord (leftSectorTensor P A) w := by
             simp only [Matrix.mul_assoc]

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -220,7 +220,7 @@ theorem evalWord_eq_zero_of_all_zero (A : MPSTensor d D)
   | nil =>
       exact (hw rfl).elim
   | cons i w =>
-      simp only [evalWord, hzero i, zero_mul]
+      simp only [Kraus.evalWord, hzero i, zero_mul]
 
 /-- An all-zero tensor contributes zero to the MPV for every positive system size. -/
 theorem mpv_eq_zero_of_all_zero (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -428,7 +428,7 @@ private theorem blockTensor_eq_commonReindexedBlock_of_word_eq
     blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k := by
   funext i
   rw [commonReindexedBlock, cast_physDim_apply (F.blockPhysDim_nested_eq k)]
-  simp [reindexPhysical, blockTensor, hWord i]
+  simp [Kraus.reindexPhysical, blockTensor, hWord i]
 
 /-- Direct blocking of one original block is the relabeled common block when the
 canonical identification with the iterated alphabet agrees with consecutive grouping of the

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -25,4 +25,5 @@ import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Core.TransferMatrix
 import TNLean.MPS.Core.TransferPeripheral
+import TNLean.MPS.Core.Word
 import TNLean.MPS.Core.WordFactor

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -539,7 +539,7 @@ theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
       rw [blockTensor_blockTensor_eq_reindex A m n]
     _ = blockTensor (d := d) (D := D) A (m * n) := by
       ext i
-      simp [reindexPhysical, iteratedBlockIndex_directToIteratedBlockIndex d m n]
+      simp [Kraus.reindexPhysical, iteratedBlockIndex_directToIteratedBlockIndex d m n]
 
 /-- Refine a tensor already blocked by `p` through a further length-`L` blocking, but expose
 the resulting physical alphabet as the direct length-`p * L` alphabet.

--- a/TNLean/MPS/Core/PhysicalReindexTransport.lean
+++ b/TNLean/MPS/Core/PhysicalReindexTransport.lean
@@ -65,7 +65,7 @@ theorem leftCanonical_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ �
     (∑ i : Fin d₁,
         (reindexPhysical e A i)ᴴ * reindexPhysical e A i = 1) ↔
       (∑ i : Fin d₂, (A i)ᴴ * A i = 1) := by
-  simp only [reindexPhysical]
+  simp only [Kraus.reindexPhysical]
   have hsum :
       (∑ i : Fin d₁, (A (e i))ᴴ * A (e i)) =
         ∑ i : Fin d₂, (A i)ᴴ * A i :=
@@ -91,7 +91,7 @@ theorem hasInvariantProj_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁
   · rintro ⟨P, hPproj, hP0, hP1, hLower⟩
     refine ⟨P, hPproj, hP0, hP1, ?_⟩
     intro i
-    simpa [reindexPhysical] using hLower (e.symm i)
+    simpa [Kraus.reindexPhysical] using hLower (e.symm i)
   · rintro ⟨P, hPproj, hP0, hP1, hLower⟩
     exact ⟨P, hPproj, hP0, hP1, fun i => hLower (e i)⟩
 
@@ -111,7 +111,7 @@ theorem isInjective_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ ≃ 
     · rintro ⟨i, rfl⟩
       exact ⟨e i, rfl⟩
     · rintro ⟨i, rfl⟩
-      exact ⟨e.symm i, by simp [reindexPhysical]⟩
+      exact ⟨e.symm i, by simp [Kraus.reindexPhysical]⟩
   simp [IsInjective, hRange]
 
 /-- Reindexing both tensors by a physical-index equivalence preserves gauge-phase equivalence. -/
@@ -123,11 +123,11 @@ theorem gaugePhaseEquiv_reindexPhysical_equiv {d₁ d₂ D : ℕ}
   · rintro ⟨X, ζ, hζ, hXB⟩
     refine ⟨X, ζ, hζ, ?_⟩
     intro i
-    simpa [reindexPhysical] using hXB (e.symm i)
+    simpa [Kraus.reindexPhysical] using hXB (e.symm i)
   · rintro ⟨X, ζ, hζ, hXB⟩
     refine ⟨X, ζ, hζ, ?_⟩
     intro i
-    simpa [reindexPhysical] using hXB (e i)
+    simpa [Kraus.reindexPhysical] using hXB (e i)
 
 /-- Reindexing both tensors by a physical-index equivalence preserves their
 closed MPV overlap.

--- a/TNLean/MPS/Core/Word.lean
+++ b/TNLean/MPS/Core/Word.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Kraus.Word
+
+/-!
+# Word evaluation for matrix product tensors
+
+A matrix product tensor is a finite family of square matrices. Its word
+product is the finite-Kraus word evaluation. This file preserves the
+established MPS names for that construction and its basic properties.
+
+## Main declarations
+
+* `MPSTensor` — a `Fin d`-indexed family of $D \times D$ complex matrices
+* `MPSTensor.evalWord` — the product associated with a physical word
+* `MPSTensor.evalWord_append` — evaluation sends concatenation to multiplication
+-/
+
+open scoped Matrix
+
+/-- A periodic translation-invariant matrix product tensor: a family of
+$D \times D$ matrices indexed by a physical index in `Fin d`. -/
+abbrev MPSTensor (d D : ℕ) := Fin d → Matrix (Fin D) (Fin D) ℂ
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Evaluate a word $w = [i_1, i_2, \ldots, i_n]$ by multiplying the corresponding
+matrices $A_{i_1} A_{i_2} \cdots A_{i_n}$. The empty word evaluates to the identity. -/
+abbrev evalWord (A : MPSTensor d D) :
+    List (Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+  Kraus.evalWord A
+
+/-- The empty word evaluates to the identity. -/
+@[simp] lemma evalWord_nil (A : MPSTensor d D) : evalWord A [] = 1 :=
+  Kraus.evalWord_nil A
+
+/-- The word with head $i$ followed by $w$ evaluates to $A_i$ times the evaluation of $w$. -/
+@[simp] lemma evalWord_cons (A : MPSTensor d D) (i : Fin d) (w : List (Fin d)) :
+    evalWord A (i :: w) = A i * evalWord A w :=
+  Kraus.evalWord_cons A i w
+
+/-- A rectangular matrix that intertwines every letter of two tensors also intertwines
+all their word evaluations. -/
+lemma evalWord_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, A i * V = V * B i) :
+    ∀ w : List (Fin d), evalWord A w * V = V * evalWord B w :=
+  Kraus.evalWord_intertwine A B V hInt
+
+/-- Word evaluation sends concatenation to multiplication. -/
+lemma evalWord_append (A : MPSTensor d D) :
+    ∀ w₁ w₂ : List (Fin d), evalWord A (w₁ ++ w₂) = evalWord A w₁ * evalWord A w₂ :=
+  Kraus.evalWord_append A
+
+/-- If $P$ commutes with every letter of $A$, then it commutes with every evaluated word. -/
+lemma commutes_evalWord_of_commutes_letters
+    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D)
+    (hComm : ∀ i : Fin d, P * A i = A i * P) :
+    ∀ w : List (Fin d), P * evalWord A w = evalWord A w * P :=
+  Kraus.commutes_evalWord_of_commutes_letters P A hComm
+
+/-- Scaling every tensor matrix by $\zeta$ scales a word product by $\zeta^{|w|}$. -/
+lemma evalWord_smul (ζ : ℂ) (A : MPSTensor d D) :
+    ∀ w : List (Fin d), evalWord (fun i => ζ • A i) w = (ζ ^ w.length) • evalWord A w :=
+  Kraus.evalWord_smul ζ A
+
+/-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
+noncomputable abbrev reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
+  Kraus.reindexPhysical f A
+
+/-- Word evaluation after physical reindexing is word evaluation on the mapped word. -/
+theorem evalWord_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) (w : List (Fin d₁)) :
+    evalWord (reindexPhysical f A) w = evalWord A (w.map f) :=
+  Kraus.evalWord_reindexPhysical f A w
+
+/-- Cyclicity of trace gives invariance under similarity. -/
+lemma trace_conj_eq (X : GL (Fin D) ℂ) (M : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace
+        ((X : Matrix (Fin D) (Fin D) ℂ) * M *
+          ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) =
+      Matrix.trace M :=
+  Kraus.trace_conj_eq X M
+
+end MPSTensor

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -17,9 +17,10 @@ import TNLean.Kraus.Injectivity
 This file contains the core definitions used throughout the MPS development:
 MPV coefficients, gauge equivalence, and the word-to-state lemmas connecting
 them to word evaluation, injectivity, and normality. The `MPSTensor` abbrev
-itself, together with word evaluation, injectivity, block injectivity, and
-normality, now live in `TNLean/Kraus/Word.lean` and
-`TNLean/Kraus/Injectivity.lean`; this file imports them and keeps only the
+itself and the established MPS word-evaluation names live in
+`TNLean/MPS/Core/Word.lean`. The underlying finite-family word evaluation
+lives in `TNLean/Kraus/Word.lean`, while injectivity, block injectivity, and
+normality live in `TNLean/Kraus/Injectivity.lean`. This file keeps only the
 matrix-product-vector vocabulary and the gauge-invariance lemmas for
 `evalWord`, `SameMPV`, and eventual block injectivity.
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.List.OfFn
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Order.Filter.AtTopBot.Basic
-import TNLean.Kraus.Word
+import TNLean.MPS.Core.Word
 import TNLean.Kraus.Injectivity
 
 /-!

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -120,7 +120,8 @@ theorem wordSpan_eq_top_of_isInjective
         simp only [Algebra.mul_smul_comm, evalWord_append, evalWord_cons,
           evalWord_nil, mul_one]
       dsimp only
-      rw [key]
+      rw [show Kraus.evalWord A (List.ofFn σ) =
+          ∑ i, c i • Kraus.evalWord A (List.ofFn σ ++ [i]) from key]
       exact Submodule.sum_mem _ fun i _ =>
         Submodule.smul_mem _ _ (by
           have := evalWord_mem_wordSpan A (List.ofFn σ ++ [i])

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -208,7 +208,11 @@ theorem blockTensor_toTensor (P : SectorDecomposition d) (p : ℕ) :
       (fun s ↦ MPSTensor.blockTensor (P.flatBasis s) p)
   funext i
   rw [MPSTensor.blockTensor]
-  rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
+  have h := evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal
+    P.flatWeight P.flatBasis (wordOfBlock d p i)
+  change Kraus.evalWord
+      (toTensorFromBlocks (d := d) P.flatWeight P.flatBasis) (wordOfBlock d p i) = _ at h
+  rw [h]
   simp only [toTensorFromBlocks, length_wordOfBlock]
   rfl
 

--- a/TNLean/MPS/MPDO/BondTwoSingletonBaseModel.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonBaseModel.lean
@@ -429,7 +429,7 @@ theorem normalizedSingletonTensor_isNormalTensor :
     MPSTensor.IsNormalTensor normalizedSingletonTensor := by
   have hs : ((singletonScale : ℝ) : ℂ) ≠ 0 := by
     exact_mod_cast ne_of_gt singletonScale_pos
-  have hNormal : normalizedSingletonTensor.IsNormal :=
+  have hNormal : MPSTensor.IsNormal normalizedSingletonTensor :=
     (singletonTensor_isInjective.smul hs).isNormal
   exact MPSTensor.isNormalTensor_of_isNormal_leftCanonical
     normalizedSingletonTensor hNormal normalizedSingletonTensor_isLeftCanonical

--- a/TNLean/MPS/MPDO/BondTwoSingletonGramBoundary.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonGramBoundary.lean
@@ -63,7 +63,7 @@ lemma singletonTensor_diagonal (a b : I) :
   simp [singletonTensor]
 
 /-- The four diagonal letters span the full bond-two matrix algebra. -/
-lemma singletonTensor_isInjective : singletonTensor.IsInjective := by
+lemma singletonTensor_isInjective : MPSTensor.IsInjective singletonTensor := by
   rw [MPSTensor.IsInjective, eq_top_iff]
   intro M _
   have hsingle : ∀ a b : I, Matrix.single a b (1 : ℂ) ∈
@@ -79,7 +79,7 @@ lemma singletonTensor_isInjective : singletonTensor.IsInjective := by
   exact Submodule.smul_mem _ _ (hsingle a b)
 
 /-- The singleton retained tensor is normal at word length one. -/
-lemma singletonTensor_isNormal : singletonTensor.IsNormal :=
+lemma singletonTensor_isNormal : MPSTensor.IsNormal singletonTensor :=
   singletonTensor_isInjective.isNormal
 
 /-- The terminal all-ones matrix of the singleton tensor. -/

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Kraus.Word
+import TNLean.MPS.Core.Word
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
 import Mathlib.LinearAlgebra.Matrix.PosDef

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -146,11 +146,9 @@ theorem toMPSTensor_blockTensor (M : MPOTensor d D) {L : ℕ} :
       MPSTensor.reindexPhysical (blockedDoubledIndexEquiv d L)
         (MPSTensor.blockTensor M.toMPSTensor L) := by
   funext ij
-  simp only [toMPSTensor, blockTensor_apply, MPSTensor.reindexPhysical,
-    MPSTensor.blockTensor]
-  simp only [MPSTensor.wordOfBlock, MPOTensor.evalWord_ofFn,
-    MPSTensor.evalWord_ofFn_eq_prod]
-  simp only [toMPSTensor, decodeBlock_blockedDoubledIndexEquiv,
+  simp [toMPSTensor, blockTensor_apply, Kraus.reindexPhysical,
+    MPSTensor.blockTensor, MPSTensor.wordOfBlock, MPOTensor.evalWord_ofFn,
+    MPSTensor.evalWord_ofFn_eq_prod, decodeBlock_blockedDoubledIndexEquiv,
     MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
 
 /-- Injectivity of an MPO block is the injectivity of the corresponding block
@@ -265,8 +263,8 @@ theorem toMPSTensor_blockTwo (M : MPOTensor d D) :
       MPSTensor.reindexPhysical (twoSiteDoubledIndexEquiv d)
         (MPSTensor.blockTensor M.toMPSTensor 2) := by
   funext ij
-  simp [toMPSTensor, blockTwo, MPSTensor.reindexPhysical,
-    MPSTensor.blockTensor, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
+  simp [toMPSTensor, blockTwo, Kraus.reindexPhysical,
+    MPSTensor.blockTensor, Kraus.evalWord, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
     blockedDoubledIndexEquiv, MPSTensor.wordOfBlock, Equiv.arrowCongr]
 
 /-- The concrete two-site blocking is the general length-two blocking after

--- a/TNLean/MPS/MPDO/PositiveMinimalRealizationCounterexample.lean
+++ b/TNLean/MPS/MPDO/PositiveMinimalRealizationCounterexample.lean
@@ -90,8 +90,8 @@ def gaugedTensor : MPSTensor 4 2 :=
       ((gauge⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)
 
 /-- The four displayed matrices span the full two-by-two matrix algebra. -/
-lemma tensor_isInjective : tensor.IsInjective := by
-  rw [IsInjective, eq_top_iff]
+lemma tensor_isInjective : MPSTensor.IsInjective tensor := by
+  rw [MPSTensor.IsInjective, eq_top_iff]
   intro M _
   have mem : ∀ i : Fin 4, tensor i ∈ Submodule.span ℂ (Set.range tensor) :=
     fun i ↦ Submodule.subset_span ⟨i, rfl⟩
@@ -123,7 +123,7 @@ lemma tensor_isInjective : tensor.IsInjective := by
     (Submodule.smul_mem _ _ (hspan 1 0))) (Submodule.smul_mem _ _ (hspan 1 1))
 
 /-- The source tensor is normal already at word length one. -/
-lemma tensor_isNormal : tensor.IsNormal :=
+lemma tensor_isNormal : MPSTensor.IsNormal tensor :=
   tensor_isInjective.isNormal
 
 /-- The two tensors are related by the displayed nonunitary similarity. -/
@@ -131,11 +131,11 @@ lemma tensor_gaugeEquiv_gaugedTensor : GaugeEquiv tensor gaugedTensor :=
   ⟨gauge, fun _ ↦ rfl⟩
 
 /-- The conjugated tensor remains injective. -/
-lemma gaugedTensor_isInjective : gaugedTensor.IsInjective :=
+lemma gaugedTensor_isInjective : MPSTensor.IsInjective gaugedTensor :=
   isInjective_of_gaugeEquiv tensor_isInjective tensor_gaugeEquiv_gaugedTensor
 
 /-- The conjugated tensor remains normal. -/
-lemma gaugedTensor_isNormal : gaugedTensor.IsNormal :=
+lemma gaugedTensor_isNormal : MPSTensor.IsNormal gaugedTensor :=
   isNormal_of_gaugeEquiv tensor_isNormal tensor_gaugeEquiv_gaugedTensor
 
 /-- The two tensors have identical positive-length closed matrix product
@@ -279,8 +279,8 @@ Both tensors are injective and normal, and they are related by an exact
 invertible gauge.  Nevertheless, no square isometry compresses the second
 tensor to a positive scalar multiple of the first. -/
 theorem sameMPV₂Pos_does_not_force_positive_isometric_realization :
-    tensor.IsInjective ∧ tensor.IsNormal ∧
-      gaugedTensor.IsInjective ∧ gaugedTensor.IsNormal ∧
+    MPSTensor.IsInjective tensor ∧ MPSTensor.IsNormal tensor ∧
+      MPSTensor.IsInjective gaugedTensor ∧ MPSTensor.IsNormal gaugedTensor ∧
       GaugeEquiv tensor gaugedTensor ∧ SameMPV₂Pos tensor gaugedTensor ∧
       ¬ ∃ (c : ℝ) (V : Matrix (Fin 2) (Fin 2) ℂ),
         0 < c ∧ Vᴴ * V = 1 ∧

--- a/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
+++ b/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
@@ -122,7 +122,7 @@ theorem exists_verticalComponent_eq_smul_single (p q : Fin 4) :
   simp only [pp, qq, Prod.eta, Equiv.apply_symm_apply]
 
 /-- The normalized vertical component is injective at one site. -/
-theorem verticalComponent_isInjective : verticalComponent.IsInjective := by
+theorem verticalComponent_isInjective : MPSTensor.IsInjective verticalComponent := by
   unfold MPSTensor.IsInjective
   apply le_antisymm le_top
   rw [← (Matrix.stdBasis ℂ (Fin 4) (Fin 4)).span_eq]
@@ -166,7 +166,7 @@ theorem verticalComponent_isLeftCanonical : verticalComponent.IsLeftCanonical :=
     Matrix.submatrix_one_equiv]
 
 /-- Algebraic injectivity makes the normalized vertical component normal. -/
-theorem verticalComponent_isNormal : verticalComponent.IsNormal :=
+theorem verticalComponent_isNormal : MPSTensor.IsNormal verticalComponent :=
   verticalComponent_isInjective.isNormal
 
 /-- The normalized vertical component is a CPSV normal tensor. -/

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -41,8 +41,8 @@ theorem wordTupleSpanTop_blockTensor_one
         blockedConfigEquiv d 1 L σ (Fin.cast (Nat.one_mul L).symm i)
       refine ⟨τ, ?_⟩
       funext j
-      change evalWord (B j) (List.ofFn τ) =
-        evalWord (blockTensor (B j) L) (List.ofFn σ)
+      change Kraus.evalWord (B j) (List.ofFn τ) =
+        Kraus.evalWord (blockTensor (B j) L) (List.ofFn σ)
       rw [evalWord_blockTensor]
       have hτ : List.ofFn τ = flattenBlockedWord d L (List.ofFn σ) := by
         calc
@@ -59,8 +59,8 @@ theorem wordTupleSpanTop_blockTensor_one
         (blockedConfigEquiv d 1 L).symm τ'
       refine ⟨σ, ?_⟩
       funext j
-      change evalWord (blockTensor (B j) L) (List.ofFn σ) =
-        evalWord (B j) (List.ofFn τ)
+      change Kraus.evalWord (blockTensor (B j) L) (List.ofFn σ) =
+        Kraus.evalWord (B j) (List.ofFn τ)
       rw [evalWord_blockTensor]
       have hcfg : blockedConfigEquiv d 1 L σ = τ' := by
         simp [σ]

--- a/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
+++ b/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
@@ -116,12 +116,23 @@ theorem mpo_verticalBNTMPO_eq_pow_smul_of_unitary_reindex
   have hReindex : MPSTensor.SameMPV₂ A₁ A₁' := by
     mpv_ext
     simp only [MPSTensor.mpv, MPSTensor.coeff]
-    change Matrix.trace (MPSTensor.evalWord A₁ (List.ofFn σ)) =
-      Matrix.trace (MPSTensor.evalWord
+    change Matrix.trace (Kraus.evalWord A₁ (List.ofFn σ)) =
+      Matrix.trace (Kraus.evalWord
         (fun ab => Matrix.reindex (finCongr hDim) (finCongr hDim) (A₁ ab))
         (List.ofFn σ))
-    rw [MPSTensor.evalWord_reindex, Matrix.trace_reindex]
-    simp
+    have hEval := MPSTensor.evalWord_reindex (e := finCongr hDim) (A := A₁)
+      (List.ofFn σ)
+    calc
+      Matrix.trace (Kraus.evalWord A₁ (List.ofFn σ)) =
+          Matrix.trace (_root_.evalWord A₁ (List.ofFn σ)) := by
+            rw [MPSTensor.evalWord_aux_eq]
+      _ = Matrix.trace (Matrix.reindex (finCongr hDim) (finCongr hDim)
+          (_root_.evalWord A₁ (List.ofFn σ))) := by
+            symm
+            apply Matrix.trace_reindex
+      _ = Matrix.trace (Kraus.evalWord
+          (fun ab => Matrix.reindex (finCongr hDim) (finCongr hDim) (A₁ ab))
+          (List.ofFn σ)) := congrArg Matrix.trace hEval.symm
   have hScaled (N : ℕ) (σ : Fin N → Fin (D * D)) :
       MPSTensor.mpv A₂ σ = c ^ N * MPSTensor.mpv A₁' σ := by
     have hA₂ : A₂ = fun ab => c • ((V : Matrix (Fin n₂) (Fin n₂) ℂ) *

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -357,7 +357,8 @@ theorem normalizedFlattening_blockTensor (U : MPOTensor d D) (p : ℕ) :
         (MPSTensor.blockTensor U.normalizedFlattening p) := by
   funext ij
   rw [normalizedFlattening, toMPSTensor_blockTensor]
-  simp only [MPSTensor.reindexPhysical, MPSTensor.blockTensor]
+  simp only [Kraus.reindexPhysical]
+  simp only [MPSTensor.blockTensor]
   change _ = MPSTensor.evalWord
     (fun i => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor i) _
   rw [MPSTensor.evalWord_smul, MPSTensor.length_wordOfBlock]

--- a/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
+++ b/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
@@ -60,7 +60,7 @@ theorem normalizedFlattening_physicalAdjointTensor (U : MPOTensor d D) :
   ext ij β α
   rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
     exact (finProdFinEquiv.apply_symm_apply ij).symm]
-  simp [normalizedFlattening, MPSTensor.reindexPhysical, MPSTensor.mapStar,
+  simp [normalizedFlattening, Kraus.reindexPhysical, MPSTensor.mapStar,
     MPOTensor.toMPSTensor, Matrix.smul_apply, Matrix.map_apply, RCLike.star_def]
 
 end MPOTensor
@@ -108,7 +108,7 @@ noncomputable def physicalAdjointNormalizedFlattening
           MPSTensor.toTensorFromBlocks (fun k ↦ star (data.weights k))
             (fun k ↦ MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
               (MPSTensor.mapStar (data.blocks k))) i := by
-      simp only [MPSTensor.toTensorFromBlocks, MPSTensor.reindexPhysical]
+      simp only [MPSTensor.toTensorFromBlocks, Kraus.reindexPhysical]
       rw [show ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
           (Matrix.blockDiagonal' fun k => data.weights k •
             data.blocks k (MPOTensor.physicalPairSwapEquiv d i))).map (starRingEnd ℂ) =

--- a/TNLean/MPS/MPU/PhysicalAncilla.lean
+++ b/TNLean/MPS/MPU/PhysicalAncilla.lean
@@ -306,7 +306,7 @@ theorem normalizedFlattening_tensorPhysicalId (U : MPOTensor d D)
       (finProdFinEquiv (finProdFinEquiv (i, a), finProdFinEquiv (j, b))) =
         normalizedDiagonalLift U.normalizedFlattening x
           (finProdFinEquiv (finProdFinEquiv (i, j), finProdFinEquiv (a, b))) by
-      simp [MPSTensor.reindexPhysical]]
+      simp [Kraus.reindexPhysical]]
   ext β α
   simp only [Matrix.smul_apply]
   rw [tensorPhysicalId_apply, normalizedDiagonalLift_apply,

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Kraus.Word
+import TNLean.MPS.Core.Word
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SuppliedWitnessReblocking

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -67,8 +67,8 @@ private theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
   ext σ
   simp only [blockedThreeConfigLinearIsometryEquiv, LinearIsometryEquiv.trans_apply,
     tailBoundaryMapES_apply, reassocTailBoundaryMapES, ContinuousLinearMap.comp_apply]
-  change Matrix.trace (MPSTensor.evalWord (blockTensor A p) (List.ofFn _) * _) =
-    Matrix.trace (MPSTensor.evalWord A (List.ofFn _) * _)
+  change Matrix.trace (Kraus.evalWord (blockTensor A p) (List.ofFn _) * _) =
+    Matrix.trace (Kraus.evalWord A (List.ofFn _) * _)
   congr 2
   rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
   congr 1
@@ -107,8 +107,8 @@ private theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
   ext σ
   simp only [blockedThreeConfigLinearIsometryEquiv, LinearIsometryEquiv.trans_apply,
     leftBoundaryMapES_apply]
-  change Matrix.trace (MPSTensor.evalWord (blockTensor A p) (List.ofFn _) * _) =
-    Matrix.trace (MPSTensor.evalWord A (List.ofFn _) * _)
+  change Matrix.trace (Kraus.evalWord (blockTensor A p) (List.ofFn _) * _) =
+    Matrix.trace (Kraus.evalWord A (List.ofFn _) * _)
   congr 2
   · rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
     congr 1

--- a/TNLean/MPS/Periodic/Overlap/SectorOverlapTransport.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorOverlapTransport.lean
@@ -60,7 +60,7 @@ private lemma evalWord_ofFn_eq_init_mul_last {L' : ℕ} (A : MPSTensor d D)
   rw [List.ofFn_succ']
   rw [show (List.ofFn fun i => σ (Fin.castSucc i)) = List.ofFn (Fin.init σ) from rfl]
   rw [List.concat_eq_append, evalWord_append]
-  simp [evalWord_cons, evalWord_nil]
+  simp
 
 /-- **Per-configuration trace covariance** under one-site rotation (eq:Aoffdiag,
 arXiv:1708.00029 lines 985--1002).  Given the single-site off-diagonal shift
@@ -126,8 +126,13 @@ private lemma sectorOverlap_eq_physical_sum {m : ℕ} [NeZero D] [NeZero m]
       (PA u * evalWord A (List.ofFn τ)).trace *
         star ((PB v * evalWord B (List.ofFn τ)).trace))]
   refine Finset.sum_congr rfl fun σ _ => ?_
-  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedConfigEquiv,
-    ← evalWord_blockTensor, ← evalWord_blockTensor]
+  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedConfigEquiv]
+  change
+    (PA u * Kraus.evalWord (blockTensor A m) (List.ofFn σ)).trace *
+        star ((PB v * Kraus.evalWord (blockTensor B m) (List.ofFn σ)).trace) =
+      (PA u * Kraus.evalWord A (flattenBlockedWord d m (List.ofFn σ))).trace *
+        star ((PB v * Kraus.evalWord B (flattenBlockedWord d m (List.ofFn σ))).trace)
+  rw [← evalWord_blockTensor, ← evalWord_blockTensor]
 
 /-- **One-step transport of the cross sector overlap** (positive lengths,
 arXiv:1708.00029 lines 985--1002).  For `N ≥ 1`, the cross overlap of compressed

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp/Basic.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp/Basic.lean
@@ -156,30 +156,30 @@ theorem sameMPV_conj_unitary (A : MPSTensor d D) (U : ↥(Matrix.unitaryGroup (F
     exact Unitary.mul_star_self_of_mem U.2
   -- Word evaluation is conjugated.
   have hEval :
-      MPSTensor.evalWord
+      Kraus.evalWord
           (fun i => star (U : Matrix (Fin D) (Fin D) ℂ) * A i * (U : Matrix _ _ ℂ)) w =
-        star (U : Matrix (Fin D) (Fin D) ℂ) * MPSTensor.evalWord A w * (U : Matrix _ _ ℂ) := by
+        star (U : Matrix (Fin D) (Fin D) ℂ) * Kraus.evalWord A w * (U : Matrix _ _ ℂ) := by
     -- Induction on the word.
     induction w with
     | nil =>
         -- Empty word: `evalWord _ [] = 1`.
-        simp [MPSTensor.evalWord, h_star_mul]
+        simp [Kraus.evalWord, h_star_mul]
     | cons i w ih =>
         -- Unfold one step and rewrite the tail using `ih`.
-        simp only [MPSTensor.evalWord, ih]
+        simp only [Kraus.evalWord, ih]
         -- Now reassociate to expose the factor `U * star U`, then simplify using unitarity.
         calc
           star (U : Matrix (Fin D) (Fin D) ℂ) * A i * (U : Matrix _ _ ℂ) *
-              (star (U : Matrix (Fin D) (Fin D) ℂ) * MPSTensor.evalWord A w * (U : Matrix _ _ ℂ))
+              (star (U : Matrix (Fin D) (Fin D) ℂ) * Kraus.evalWord A w * (U : Matrix _ _ ℂ))
               = star (U : Matrix (Fin D) (Fin D) ℂ) * A i *
                   ((U : Matrix (Fin D) (Fin D) ℂ) * star (U : Matrix (Fin D) (Fin D) ℂ)) *
-                    MPSTensor.evalWord A w * (U : Matrix _ _ ℂ) := by
+                    Kraus.evalWord A w * (U : Matrix _ _ ℂ) := by
                   noncomm_ring
           _ = star (U : Matrix (Fin D) (Fin D) ℂ) * A i *
-                  MPSTensor.evalWord A w * (U : Matrix _ _ ℂ) := by
+                  Kraus.evalWord A w * (U : Matrix _ _ ℂ) := by
                   simp [h_mul_star]
           _ = star (U : Matrix (Fin D) (Fin D) ℂ) *
-                  (A i * MPSTensor.evalWord A w) * (U : Matrix _ _ ℂ) := by
+                  (A i * Kraus.evalWord A w) * (U : Matrix _ _ ℂ) := by
                   noncomm_ring
   -- Trace cyclicity cancels the conjugation.
   calc

--- a/TNLean/MPS/Symmetry/Defs.lean
+++ b/TNLean/MPS/Symmetry/Defs.lean
@@ -152,7 +152,13 @@ lemma twistedTensor_blockTensor_comm
   funext I
   rw [twistedTensor]
   simp only [blockKronAction_apply, blockKron, blockTensor, wordOfBlock]
-  rw [evalWord_twistedTensor_ofFn A U g (decodeBlock d L I)]
+  have hEval :
+      Kraus.evalWord (twistedTensor A U g) (List.ofFn (decodeBlock d L I)) =
+        ∑ v : Fin L → Fin d,
+          (∏ k : Fin L, (U g) (decodeBlock d L I k) (v k)) •
+            Kraus.evalWord A (List.ofFn v) :=
+    evalWord_twistedTensor_ofFn A U g (decodeBlock d L I)
+  rw [hEval]
   -- Reindex the sum over words by the blocked index.
   rw [← (decodeBlockEquiv d L).sum_comp]
   refine Finset.sum_congr rfl (fun J _ => ?_)

--- a/TNLean/Wielandt/RankOne/Products.lean
+++ b/TNLean/Wielandt/RankOne/Products.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Kraus.Wielandt.RankOne.Products
 import TNLean.Kraus.Injectivity
+import TNLean.MPS.Core.Word
 
 /-!
 # Eigenvectors from Wielandt word products

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -99,11 +99,9 @@ theorem wordSpan_le_wordSpan_blockTensor (A : MPSTensor d D) (L n : ℕ) :
     have hσ : List.ofFn σ = [] := by
       apply List.eq_nil_of_length_eq_zero
       simp [hempty]
-    rw [hσ]; simp only [evalWord]
-    have : (1 : Matrix (Fin D) (Fin D) ℂ) = evalWord (blockTensor (d := d) (D := D) A L) [] := by
-      simp [evalWord]
-    rw [this]
-    exact evalWord_mem_wordSpan _ []
+    rw [hσ]
+    simpa only [Kraus.evalWord, List.length_nil] using
+      (evalWord_mem_wordSpan (blockTensor (d := d) (D := D) A L) [])
   | succ n ih =>
     intro σ
     -- Factor the word into first block + rest
@@ -117,7 +115,7 @@ theorem wordSpan_le_wordSpan_blockTensor (A : MPSTensor d D) (L n : ℕ) :
     have hfirst : evalWord A (List.ofFn σ₀) ∈ wordSpan B 1 := by
       rw [hfirst_eq]
       apply Submodule.subset_span
-      exact ⟨fun _ => σ₀_enc, by simp [evalWord]⟩
+      exact ⟨fun _ => σ₀_enc, by simp [Kraus.evalWord]⟩
     -- Second factor: in wordSpan B n by induction
     have hsecond : evalWord A (List.ofFn σ') ∈ wordSpan B n := ih σ'
     -- Product is in wordSpan B (1 + n) = wordSpan B (n + 1)

--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Kraus.Injectivity
 import TNLean.Kraus.Wielandt.SpanGrowth.CumulativeSpan
+import TNLean.MPS.Core.Word
 
 /-!
 # Cumulative word spans and TN injectivity


### PR DESCRIPTION
## What changed

- move finite-family word evaluation and its algebraic properties to `Kraus` in `TNLean/Kraus/Word.lean`
- add `TNLean/MPS/Core/Word.lean`, containing the `MPSTensor` abbreviation and the established MPS word names as exact reformulations of the Kraus definitions
- migrate the QIC-side consumers to the neutral `Kraus` names
- update the direct MPS importers and the generated `TNLean/MPS/Core.lean` aggregator
- unfold `Kraus.evalWord` or `Kraus.reindexPhysical` explicitly in the few proofs where the namespace separation changes simplification
- retain `List.ofFn_reverse`, retain `Kraus.evalWord_transpose` as the proof owner, and preserve the three blueprint declarations for `MPSTensor.evalWord`, `MPSTensor.evalWord_append`, and `MPSTensor.evalWord_smul`

### Declaration correspondence

| Established MPS name | Finite-family owner |
|---|---|
| `MPSTensor.evalWord` | `Kraus.evalWord` |
| `MPSTensor.evalWord_nil` / `evalWord_cons` | `Kraus.evalWord_nil` / `evalWord_cons` |
| `MPSTensor.evalWord_intertwine` | `Kraus.evalWord_intertwine` |
| `MPSTensor.evalWord_append` | `Kraus.evalWord_append` |
| `MPSTensor.commutes_evalWord_of_commutes_letters` | `Kraus.commutes_evalWord_of_commutes_letters` |
| `MPSTensor.evalWord_smul` | `Kraus.evalWord_smul` |
| `MPSTensor.reindexPhysical` | `Kraus.reindexPhysical` |
| `MPSTensor.evalWord_reindexPhysical` | `Kraus.evalWord_reindexPhysical` |
| `MPSTensor.trace_conj_eq` | `Kraus.trace_conj_eq` |

The MPS names remain available with their previous statements, so this separation changes ownership without changing the public mathematical statements.

Exact base: `8eb60d596` (current `main` after LionSR/TNLean#6755).

## Validation

- `lake build TNLean.MPS.FundamentalTheorem.FiniteLength TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily`
- `lake build TNLean.Kraus.MultiBlockWord TNLean.Kraus.Injectivity TNLean.Kraus.InvariantProjection TNLean.MPS.Defs`
- generated import aggregators: 60 files covering 1488 production modules
- import direction: 497 QIC-bound files, with no direction or namespace-ratchet violations
- blueprint correspondence: 8,041 unique declarations and 8,075/8,075 entries
- reader-facing prose, proof-integrity, numbered-module, oversized-module, and diff checks
- hosted full build required before merge

Closes LionSR/TNLean#6745.
Advances LionSR/TNLean#6622, LionSR/QICLean#340, and LionSR/TNLean#6560.
