### PR TITLE
doc(Channel): audit Wolf Chapter 3 numbering

### DIFF
--- a/TNLean/Analysis/MatrixTraceInequalities.lean
+++ b/TNLean/Analysis/MatrixTraceInequalities.lean
@@ -14,11 +14,11 @@ import TNLean.Algebra.PerronFrobenius.RankOne
 
 This module records finite-dimensional matrix trace inequalities used in
 Wolf's discussion of Lorentz cones for positive maps. The first result is the
-forward implication in Wolf, Chapter 3, Proposition 3.9: if `A ≥ 0`, then
+forward implication in Wolf, Chapter 3, Proposition 3.7: if `A ≥ 0`, then
 `tr(A^2) ≤ tr(A)^2`.
 
 The converse recorded here is the trace-nonnegative form.  The printed squared
-condition in Wolf, Chapter 3, Proposition 3.9 needs this sign condition; a
+condition in Wolf, Chapter 3, Proposition 3.7 needs this sign condition; a
 negative scalar matrix satisfies the squared inequality but is not positive
 semidefinite.
 
@@ -86,7 +86,7 @@ private lemma ofReal_sq_re (r : ℝ) : Complex.re ((r : ℂ) ^ 2) = r ^ 2 := by
       congrArg Complex.re hpow
     _ = r ^ 2 := Complex.ofReal_re _
 
-/-- Wolf Chapter 3, Proposition 3.9, forward implication.
+/-- Wolf Chapter 3, Proposition 3.7, forward implication.
 
 If `A` is positive semidefinite, then the real trace of `A ^ 2` is bounded by
 the square of the real trace of `A`. In eigenvalues this is
@@ -113,7 +113,7 @@ theorem PosSemidef.trace_sq_re_le_trace_re_sq
       rw [hlam]
       exact hA.eigenvalues_nonneg i)
 
-/-- Wolf Chapter 3, Proposition 3.9, trace-nonnegative converse.
+/-- Wolf Chapter 3, Proposition 3.7, trace-nonnegative converse.
 
 Let `A` be Hermitian with nonnegative real trace. If
 `(d - 1) Re tr(A ^ 2) ≤ (Re tr A)^2`, then `A` is positive semidefinite.

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -53,7 +53,7 @@ with composition. We also relate it to the Kraus representation.
   preserving after conjugating the input by the invertible `X = T*(1)^{-1/2}`
 * `unitaryConjLM_mapsPSDConeOnto` and
   `unitaryConjLM_comp_transpose_mapsPSDConeOnto`: direction (3) ⇒ (1) of Wolf
-  Chapter 3, Proposition 3.8 — conjugation `X ↦ Y X Y†` and its transpose
+  Chapter 3, Proposition 3.6 — conjugation `X ↦ Y X Y†` and its transpose
   variant `X ↦ Y Xᵀ Y†` by an invertible `Y` map the positive semidefinite
   cone onto itself
 
@@ -720,9 +720,9 @@ theorem IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one
 
 end UnitaryConjugation
 
-/-! ### Proposition 3.8: automorphisms of the positive semidefinite cone
+/-! ### Proposition 3.6: automorphisms of the positive semidefinite cone
 
-Wolf Chapter 3, §3.5, Proposition 3.8 (Automorphisms and rank preserving maps),
+Wolf Chapter 3, §3.5, Proposition 3.6 (Automorphisms and rank preserving maps),
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 652--686.
 
 For a linear map `T : M_D(ℂ) → M_D(ℂ)` the following are equivalent:
@@ -741,7 +741,7 @@ and are not formalized here. -/
 section ConePreservation
 
 /-- A linear map `T : M_D(ℂ) → M_D(ℂ)` **maps the positive semidefinite cone onto
-itself** (condition (1) of Wolf Chapter 3, Proposition 3.8) if it sends positive
+itself** (condition (1) of Wolf Chapter 3, Proposition 3.6) if it sends positive
 semidefinite matrices to positive semidefinite matrices and every positive
 semidefinite matrix arises as the image of one. -/
 def MapsPSDConeOnto
@@ -751,7 +751,7 @@ def MapsPSDConeOnto
 
 /-- Conjugation `Ad_Y(X) = Y X Y†` by an invertible matrix maps the positive
 semidefinite cone onto itself. This is the conjugation half of direction
-(3) ⇒ (1) of Wolf Chapter 3, Proposition 3.8. -/
+(3) ⇒ (1) of Wolf Chapter 3, Proposition 3.6. -/
 theorem unitaryConjLM_mapsPSDConeOnto
     (Y : Matrix (Fin D) (Fin D) ℂ) (hY : IsUnit Y.det) :
     MapsPSDConeOnto (unitaryConjLM Y) := by
@@ -767,7 +767,7 @@ theorem unitaryConjLM_mapsPSDConeOnto
 
 /-- The transpose conjugation `X ↦ Y Xᵀ Y†` by an invertible matrix maps the
 positive semidefinite cone onto itself. This is the transpose half of direction
-(3) ⇒ (1) of Wolf Chapter 3, Proposition 3.8. -/
+(3) ⇒ (1) of Wolf Chapter 3, Proposition 3.6. -/
 theorem unitaryConjLM_comp_transpose_mapsPSDConeOnto
     (Y : Matrix (Fin D) (Fin D) ℂ) (hY : IsUnit Y.det) :
     MapsPSDConeOnto

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -68,7 +68,7 @@
 The results in this section are ordinary singular value decompositions in the
 general complex matrix-algebraic setting. They are useful for transfer matrices, but
 they are not the real $3\times3$ singular value decomposition arising from the
-$\SO(3)$ action on the traceless Pauli block of a qubit channel in
+    $\mathrm{SO}(3)$ action on the traceless Pauli block of a qubit channel in
 \cite[Section~2.4]{Wolf2012Quantum}. The Lorentz normal form theorem
 (Theorem~\ref{thm:lorentz_normal_form_qubit}) instead uses general invertible
 Kraus-rank-one completely positive filterings. Its proof requires the

--- a/blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex
@@ -87,7 +87,7 @@ positivity: they are surjective on the positive semidefinite cone.
     A linear map $T:\MN{D}\to\MN{D}$ \emph{maps the positive semidefinite cone
         onto itself} if $T$ is positive and every positive semidefinite matrix is
     the image under $T$ of a positive semidefinite matrix. This is condition
-    (1) of \cite[Proposition~3.8]{Wolf2012Quantum}.
+    (1) of \cite[Proposition~3.6]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{theorem}[Conjugations preserve the positive semidefinite cone]
@@ -99,7 +99,7 @@ positivity: they are surjective on the positive semidefinite cone.
     Let $Y\in\MN{D}$ be invertible. Then the map $X\mapsto YXY^\dagger$ and the
     map $X\mapsto YX^TY^\dagger$ each map the positive semidefinite cone onto
     itself. This is the implication (3) $\Rightarrow$ (1) of
-    \cite[Proposition~3.8]{Wolf2012Quantum}.
+    \cite[Proposition~3.6]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch25_positive_not_cp_trace_normalization_and_lorentz_cone.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_trace_normalization_and_lorentz_cone.tex
@@ -67,7 +67,7 @@
     then $A$ is positive semidefinite.
 
     This is the trace-non-negative form of the converse in
-    \cite[Proposition~3.9]{Wolf2012Quantum}. The unrestricted squared
+    \cite[Proposition~3.7]{Wolf2012Quantum}. The unrestricted squared
     implication printed there is false without a trace-sign condition: for
     $A=-\Id$, one has $\tr(A)^2=D^2\ge D(D-1)=(D-1)\tr(A^2)$, although $A$ is
     not positive semidefinite.

--- a/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
+++ b/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
@@ -16,8 +16,8 @@
 
 \section{The assertion}
 
-Wolf's Proposition~3.9 states two elementary trace inequalities for Hermitian
-matrices.\footnote{\cite[Proposition~3.9]{Wolf2012Quantum};
+Wolf's Proposition~3.7 states two elementary trace inequalities for Hermitian
+matrices.\footnote{\cite[Proposition~3.7]{Wolf2012Quantum};
 local source \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
 lines 693--722.}  The forward implication says that a positive semidefinite
 matrix satisfies
@@ -27,7 +27,7 @@ matrix satisfies
 The converse is printed as
 \begin{align}
   \tr(A)^2 \ge (d-1)\tr(A^2) \Longrightarrow A \ge 0.
-  \tag{\path{Wolf Prop. 3.9 converse}}
+  \tag{\path{Wolf Prop. 3.7 converse}}
 \end{align}
 
 \section{The point at issue}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -60,8 +60,7 @@ The proposition occurs at the end of the discussion of automorphisms of the
 positive cone in Chapter~3.  Its first part gives the elementary necessary
 inequality for a positive semidefinite Hermitian matrix; the second part is
 intended to characterize the corresponding Lorentz cone.  Chapter~3,
-Proposition~3.7 in the local PDF (book p.~66; cited as Proposition~3.9 in a
-different numbering used by the formalization) states, for Hermitian $A$,
+Proposition~3.7 in the local PDF (book p.~66) states, for Hermitian $A$,
 \begin{equation}\tag{printed converse}
   \operatorname{tr}(A)^2\geq(d-1)\operatorname{tr}(A^2)
   \quad\Longrightarrow\quad A\geq0.

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -150,3 +150,117 @@ is not the real SVD of the qubit `3 × 3` block discussed in that passage.
 - `TNLean/Algebra/MatrixAux.lean`
 - `TNLean/Analysis/MatrixTraceInequalities.lean`
 - `blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex`
+
+## Chapter 3: Positive, but not completely positive
+
+The first five live theorem citations agree with the printed notes. Two later
+citations used numbers from a divergent transcription counter: the printed
+numbers are Proposition 3.6 for automorphisms of the positive semidefinite cone
+and Proposition 3.7 for the Lorentz-cone trace inequalities.
+
+| Former citation | Printed citation | Result title | Archived PDF | Local transcription | Verdict |
+|---|---|---|---:|---:|---|
+| Proposition 3.1 | Proposition 3.1 | Choi--Jamiołkowski criterion for n-positive maps | PDF page 2; printed page 54 | lines 89--98 | Correct |
+| Lemma 3.1 | Lemma 3.1 | Maximal overlap with fixed Schmidt rank | PDF page 3; printed page 55 | lines 119--128 | Correct |
+| Proposition 3.2 | Proposition 3.2 | Spectral criterion for n-positivity | PDF page 4; printed page 56 | lines 153--164 | Correct |
+| Proposition 3.3 | Proposition 3.3 | Entanglement witnesses | PDF page 5; printed page 57 | lines 229--233 | Correct |
+| Proposition 3.4 | Proposition 3.4 | Positive maps and entanglement | PDF page 5; printed page 57 | lines 250--253 | Correct |
+| Proposition 3.8 | Proposition 3.6 | Automorphisms and rank-preserving maps | PDF page 13; printed page 65 | lines 652--660 | Corrected |
+| Proposition 3.9 | Proposition 3.7 | Confining Lorentz cones | PDF page 14; printed page 66 | lines 693--699 | Corrected |
+| Example 3.1 | Example 3.1 | Positive maps and entanglement witnesses | PDF pages 6--8; printed pages 58--60 | lines 307--400 | Correct |
+
+The citation “Example 3.1 (Proposition 3.2)” attached to the reduction-map
+positivity theorem has two distinct roles and is retained. Example 3.1 states
+the reduction-map family, whereas Proposition 3.2 supplies the spectral
+criterion used to establish its positivity threshold.
+
+### Citing files
+
+**Proposition 3.1**
+
+- `TNLean/Channel/NPositivitySpectralCriterion.lean`
+- `TNLean/Channel/SchmidtRank.lean`
+- `TNLean/Channel/Schwarz/ChoiCompression.lean`
+- `TNLean/Channel/Schwarz/TwoPositive.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex`
+- `blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex`
+- `docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`
+- `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`
+
+**Lemma 3.1**
+
+- `TNLean/Analysis/KyFanNorm.lean`
+- `TNLean/Channel/MaximalOverlap.lean`
+- `TNLean/Channel/NPositivityChainStrict.lean`
+- `TNLean/Channel/NPositivitySpectralCriterion.lean`
+- `TNLean/Channel/SchmidtRank.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex`
+- `docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex`
+- `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`
+
+**Proposition 3.2**
+
+- `TNLean/Channel/NPositivityChainStrict.lean`
+- `TNLean/Channel/NPositivitySpectralCriterion.lean`
+- `TNLean/Channel/ReductionCriterion.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex`
+- `blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex`
+- `docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex`
+- `docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`
+- `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`
+
+**Proposition 3.3**
+
+- `TNLean/Algebra/MatrixRankClosed.lean`
+- `TNLean/Channel/EntanglementWitness.lean`
+- `TNLean/Channel/PositiveMapDetection.lean`
+- `TNLean/Channel/SchmidtNumber.lean`
+- `TNLean/Channel/SchmidtNumberCompact.lean`
+- `blueprint/src/appendix/full_only/ch25_schmidt_number_and_witnesses.tex`
+- `blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_entanglement.tex`
+
+**Proposition 3.4**
+
+- `TNLean/Channel/PositiveMapDetection.lean`
+- `TNLean/Channel/SchmidtNumber.lean`
+- `TNLean/Channel/SchmidtNumberFactors.lean`
+- `TNLean/Channel/Separable.lean`
+- `blueprint/src/appendix/full_only/ch25_schmidt_number_and_witnesses.tex`
+- `blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_entanglement.tex`
+
+**Proposition 3.6**
+
+- `TNLean/Channel/TransferMatrix.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex`
+
+**Proposition 3.7**
+
+- `TNLean/Analysis/MatrixTraceInequalities.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_trace_normalization_and_lorentz_cone.tex`
+- `docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex`
+- `docs/paper-gaps/wolf_lecture_notes_errata.tex`
+
+**Example 3.1**
+
+- `TNLean/Algebra/HermitianHelpers.lean`
+- `TNLean/Channel/BreuerHallIndecomposable.lean`
+- `TNLean/Channel/BreuerHallMap.lean`
+- `TNLean/Channel/ChoiTypeMap.lean`
+- `TNLean/Channel/PartialTranspose.lean`
+- `TNLean/Channel/PositiveExamples.lean`
+- `TNLean/Channel/ReductionCriterion.lean`
+- `TNLean/Channel/SchmidtNumber.lean`
+- `TNLean/Channel/SchmidtNumberFactors.lean`
+- `TNLean/Channel/Separable.lean`
+- `blueprint/src/chapter/ch25_positive_not_cp_choi_and_decomposable_maps.tex`
+- `blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex`
+- `docs/paper-gaps/README.md`
+- `docs/paper-gaps/breuer_hall_even_dim_restriction.tex`
+- `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`
+
+### Reproducibility
+
+The enumeration uses the same directories and exclusions as the Chapter 1
+audit. Each result was checked against
+`Notes/WolfNotePDF/ch03_positive_not_completely.pdf`; the line ranges above
+refer only to the searchable transcription and do not determine numbering.


### PR DESCRIPTION
## Summary

- audit every live Wolf Chapter 3 theorem-like citation against the printed chapter PDF
- confirm Propositions 3.1–3.4, Lemma 3.1, and Example 3.1
- correct the two citations taken from a divergent transcription counter:
  - Proposition 3.8 to printed Proposition 3.6 for automorphisms and rank-preserving maps
  - Proposition 3.9 to printed Proposition 3.7 for the Lorentz-cone trace inequalities
- record source pages, transcription ranges, citing files, and the distinct roles of Example 3.1 and Proposition 3.2 for the reduction map

This is stacked on LionSR/TNLean#6753 because both pull requests extend the shared Wolf numbering audit. After LionSR/TNLean#6753 merges, this pull request should target `main` without retaining unrelated Chapter 2 changes.

## Source verification

The authoritative printed source is `Notes/WolfNotePDF/ch03_positive_not_completely.pdf`:

- Proposition 3.1: PDF page 2, printed page 54
- Lemma 3.1: PDF page 3, printed page 55
- Proposition 3.2: PDF page 4, printed page 56
- Propositions 3.3 and 3.4: PDF page 5, printed page 57
- Example 3.1: PDF pages 6–8, printed pages 58–60
- Proposition 3.6: PDF page 13, printed page 65
- Proposition 3.7: PDF page 14, printed page 66

The searchable transcription supplies the line ranges recorded in the audit, but not the numbering.

## Validation

- `lake env lean TNLean/Channel/TransferMatrix.lean`
- `lake env lean TNLean/Analysis/MatrixTraceInequalities.lean`
- `python3 scripts/blueprint_lean_sync.py --ci` (8044/8044)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/docs/issue-6750-wolf-transfer-numbering --ci`
- `git diff --check`

Closes LionSR/QICLean#350.
Part of LionSR/QICLean#346.
