### PR TITLE
refactor(qic): split invariant projection predicates

### DIFF
--- a/TNLean/Kraus/InvariantProjection.lean
+++ b/TNLean/Kraus/InvariantProjection.lean
@@ -19,9 +19,9 @@ a nontrivial invariant orthogonal projection.
 * `Kraus.HasInvariantProj` states that a finite matrix family has a nontrivial
   invariant orthogonal projection.
 * `Kraus.IsIrreducibleFamily` states that no such projection exists.
-* `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor` shows that an irreducible
+* `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily` shows that an irreducible
   family defines an irreducible Kraus map.
-* `Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM` proves the converse.
+* `Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM` proves the converse.
 -/
 
 namespace Kraus
@@ -44,7 +44,7 @@ def IsIrreducibleFamily (K : Fin d → Mat) : Prop :=
 
 /-- A finite matrix family with no nontrivial invariant orthogonal projection defines an
 irreducible Kraus map. -/
-theorem isIrreducibleMap_mapLM_of_isIrreducibleTensor
+theorem isIrreducibleMap_mapLM_of_isIrreducibleFamily
     (K : Fin d → Mat) (hIrr : IsIrreducibleFamily K) :
     IsIrreducibleMap (mapLM K) := by
   intro P hProj hInv
@@ -57,7 +57,7 @@ theorem isIrreducibleMap_mapLM_of_isIrreducibleTensor
 
 /-- If the finite Kraus map is irreducible, then its matrix family has no nontrivial
 invariant orthogonal projection. -/
-theorem isIrreducibleTensor_of_isIrreducibleMap_mapLM
+theorem isIrreducibleFamily_of_isIrreducibleMap_mapLM
     (K : Fin d → Mat) (hIrr : IsIrreducibleMap (mapLM K)) :
     IsIrreducibleFamily K := by
   intro ⟨P, hProj, hP0, hP1, hLower⟩

--- a/TNLean/Kraus/InvariantProjection.lean
+++ b/TNLean/Kraus/InvariantProjection.lean
@@ -6,54 +6,23 @@ Authors: TNLean contributors
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.FixedPoint.SupportInvariance
 import TNLean.Channel.Irreducible.Basic
-import TNLean.Kraus.Word
 
 /-!
-# Invariant orthogonal projections and irreducibility of a finite Kraus family
+# Invariant orthogonal projections for finite matrix families
 
-This file carries the word-evaluation layer of the channel side:
-`HasInvariantProj` and `IsIrreducibleTensor`, the predicates used by the
-canonical-form iterated block-decomposition argument to detect a nontrivial
-invariant orthogonal projection for a finite Kraus family. It is part of
-the extraction of a Kraus-family-only library out of `TNLean`'s
-matrix-product-state development.
-
-The consequences of these predicates (rescaling and conjugation invariance,
-the cast lemmas, and the iterated block-decomposition capstone
-`exists_irreducible_blockDecomp`) stay on the matrix-product-state side, in
-`TNLean/MPS/CanonicalForm/Reduction.lean`.
-
-The established predicates remain in `namespace MPSTensor` because the
-canonical-form development uses these names throughout. A change of namespace
-belongs with a simultaneous change of those declarations.
+A finite family of square matrices is irreducible when it has no nontrivial
+invariant subspace. In finite dimension, this is equivalent to the absence of
+a nontrivial invariant orthogonal projection.
 
 ## Main declarations
 
-* `HasInvariantProj` — existence of a nontrivial invariant orthogonal projection
-* `IsIrreducibleTensor` — no nontrivial invariant orthogonal projection exists
-* `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor` — tensor irreducibility implies
-  irreducibility of the associated finite Kraus map
-* `Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM` — the converse implication
+* `Kraus.HasInvariantProj` states that a finite matrix family has a nontrivial
+  invariant orthogonal projection.
+* `Kraus.IsIrreducibleFamily` states that no such projection exists.
+* `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor` shows that an irreducible
+  family defines an irreducible Kraus map.
+* `Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM` proves the converse.
 -/
-
-namespace MPSTensor
-
-variable {d D : ℕ}
-
-/-- `HasInvariantProj A` holds if there is a *nontrivial* invariant orthogonal projection for `A`:
-a Hermitian idempotent `P` with `P ≠ 0`, `P ≠ 1`, and `(1 - P) * A i * P = 0` for every `i`.
-
-This is the negation of "irreducible with respect to invariant subspaces". -/
-def HasInvariantProj (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  ∃ P : Matrix (Fin D) (Fin D) ℂ,
-    IsOrthogonalProjection P ∧ P ≠ 0 ∧ P ≠ 1 ∧ (∀ i : Fin d, (1 - P) * A i * P = 0)
-
-/-- `IsIrreducibleTensor A` holds if `A` admits no nontrivial invariant orthogonal projection.
-This is the "irreducible" condition used in the canonical-form reduction. -/
-def IsIrreducibleTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  ¬ HasInvariantProj A
-
-end MPSTensor
 
 namespace Kraus
 
@@ -61,10 +30,22 @@ variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- A finite Kraus family with no nontrivial invariant orthogonal projection defines an
+/-- A finite matrix family has a nontrivial invariant orthogonal projection if there is a
+Hermitian idempotent $P$, distinct from $0$ and $1$, such that
+$(1-P)K_iP=0$ for every family index $i$. -/
+def HasInvariantProj (K : Fin d → Mat) : Prop :=
+  ∃ P : Mat,
+    IsOrthogonalProjection P ∧ P ≠ 0 ∧ P ≠ 1 ∧ (∀ i : Fin d, (1 - P) * K i * P = 0)
+
+/-- A finite matrix family is irreducible if it has no nontrivial invariant orthogonal
+projection. -/
+def IsIrreducibleFamily (K : Fin d → Mat) : Prop :=
+  ¬ HasInvariantProj K
+
+/-- A finite matrix family with no nontrivial invariant orthogonal projection defines an
 irreducible Kraus map. -/
 theorem isIrreducibleMap_mapLM_of_isIrreducibleTensor
-    (K : Fin d → Mat) (hIrr : MPSTensor.IsIrreducibleTensor K) :
+    (K : Fin d → Mat) (hIrr : IsIrreducibleFamily K) :
     IsIrreducibleMap (mapLM K) := by
   intro P hProj hInv
   have hLower : ∀ i : Fin d, (1 - P) * K i * P = 0 :=
@@ -74,11 +55,11 @@ theorem isIrreducibleMap_mapLM_of_isIrreducibleTensor
   push Not at h_neither
   exact hIrr ⟨P, hProj, h_neither.1, h_neither.2, hLower⟩
 
-/-- If the finite Kraus map is irreducible, then its Kraus family has no nontrivial
+/-- If the finite Kraus map is irreducible, then its matrix family has no nontrivial
 invariant orthogonal projection. -/
 theorem isIrreducibleTensor_of_isIrreducibleMap_mapLM
     (K : Fin d → Mat) (hIrr : IsIrreducibleMap (mapLM K)) :
-    MPSTensor.IsIrreducibleTensor K := by
+    IsIrreducibleFamily K := by
   intro ⟨P, hProj, hP0, hP1, hLower⟩
   have hInv : ∀ X, P * mapLM K (P * X * P) * P = mapLM K (P * X * P) := fun X => by
     simpa only [mapLM_apply] using lowerZero_implies_invariance K P hProj hLower X

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.Algebra.PosSemidefSupport
-import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.InvariantProjection
 
 /-!
 # Iterated invariant-projection splitting: irreducible block decomposition
@@ -63,8 +63,8 @@ variable {d D : ℕ}
 
 /-! ## Irreducibility definitions
 
-`HasInvariantProj` and `IsIrreducibleTensor` now live in
-`TNLean/Kraus/InvariantProjection.lean`. -/
+`HasInvariantProj` and `IsIrreducibleTensor` are the MPS forms of the finite-family
+predicates in `Kraus`. -/
 
 /-- Nonzero scalar rescaling preserves tensor irreducibility. -/
 theorem isIrreducibleTensor_smul

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.Core.CanonicalNormalization
 import TNLean.MPS.Core.CorrelationReduction
 import TNLean.MPS.Core.Correlations
 import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.MPS.Core.PhysicalReindexTransport

--- a/TNLean/MPS/Core/InvariantProjection.lean
+++ b/TNLean/MPS/Core/InvariantProjection.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.Word
+
+/-!
+# Invariant orthogonal projections for matrix product tensors
+
+A matrix product tensor is irreducible when its matrix family has no nontrivial
+invariant orthogonal projection. This file preserves the established MPS names
+for the two finite-family predicates.
+
+## Main declarations
+
+* `MPSTensor.HasInvariantProj` states that a tensor has a nontrivial invariant
+  orthogonal projection.
+* `MPSTensor.IsIrreducibleTensor` states that no such projection exists.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A matrix product tensor has a nontrivial invariant orthogonal projection if its
+finite matrix family has one. -/
+def HasInvariantProj (A : MPSTensor d D) : Prop :=
+  Kraus.HasInvariantProj A
+
+/-- A matrix product tensor is irreducible if its finite matrix family has no nontrivial
+invariant orthogonal projection. -/
+def IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
+  ¬ HasInvariantProj A
+
+end MPSTensor

--- a/TNLean/MPS/Core/TransferChannel.lean
+++ b/TNLean/MPS/Core/TransferChannel.lean
@@ -61,7 +61,7 @@ theorem isIrreducibleMap_transferMap_of_isIrreducibleTensor
     (K : Fin d → Mat) (hIrr : MPSTensor.IsIrreducibleTensor K) :
     IsIrreducibleMap (MPSTensor.transferMap (d := d) (D := D) K) := by
   rw [← mapLM_eq_transferMap]
-  exact isIrreducibleMap_mapLM_of_isIrreducibleTensor K hIrr
+  exact isIrreducibleMap_mapLM_of_isIrreducibleFamily K hIrr
 
 /-- Irreducibility of the MPS transfer map implies irreducibility of its finite
 matrix family. -/
@@ -69,7 +69,7 @@ theorem isIrreducibleTensor_of_isIrreducibleMap_transferMap
     (K : Fin d → Mat)
     (hIrr : IsIrreducibleMap (MPSTensor.transferMap (d := d) (D := D) K)) :
     MPSTensor.IsIrreducibleTensor K :=
-  isIrreducibleTensor_of_isIrreducibleMap_mapLM K
+  isIrreducibleFamily_of_isIrreducibleMap_mapLM K
     (isIrreducibleMap_mapLM_of_transferMap K hIrr)
 
 /-- The MPS transfer map of a trace-preserving finite Kraus family is a quantum channel. -/

--- a/TNLean/MPS/Core/TransferChannel.lean
+++ b/TNLean/MPS/Core/TransferChannel.lean
@@ -5,8 +5,8 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.KrausMap
-import TNLean.Kraus.InvariantProjection
 import TNLean.Kraus.MapIterate
+import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.Transfer
 
 /-!

--- a/TNLean/Spectral/TransferOperatorGapInjective.lean
+++ b/TNLean/Spectral/TransferOperatorGapInjective.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Spectral.TransferOperatorGapNT
-import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.Core.TransferChannel
 

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -38,7 +38,7 @@ theorem gaugePhaseEquiv_of_krausGaugePhaseEquiv
 private theorem irreducibleMap_of_irreducibleTensor
     (A : MPSTensor d D) (hA : IsIrreducibleTensor A) :
     IsIrreducibleMap (Kraus.mapLM A) :=
-  Kraus.isIrreducibleMap_mapLM_of_isIrreducibleTensor A hA
+  Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hA
 
 /-- If the mixed transfer spectral radius of two irreducible left-canonical tensors is at least
 `1`, then the tensors are gauge-phase equivalent. -/

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -135,7 +135,7 @@ theorem isIrreducibleTensor_of_isPrimitivePaper
     (hPrim : IsPrimitivePaper A) :
     IsIrreducibleTensor A := by
   obtain ⟨q, _, hq⟩ := hPrim
-  exact Kraus.isIrreducibleTensor_of_isIrreducibleMap_mapLM A
+  exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
     (Kraus.isIrreducibleMap_mapLM_of_vectorSpreadSpan_eq_top A hq)
 
 end MPSTensor

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Core.Transfer
 import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Spectral.PeripheralToTransferMapGap
-import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.InvariantProjection
 import TNLean.Wielandt.Primitivity.ToNormal
 import TNLean.Channel.Primitive
 import TNLean.Channel.Irreducible.FromSpectral

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.Analysis.SpectralRadiusPowerDecay
 import TNLean.Channel.Irreducible.FixedPoint
 import TNLean.Channel.Primitive
-import TNLean.Kraus.InvariantProjection
+import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Structure.PrimitiveFixedPoint
 import Mathlib.Analysis.Normed.Operator.CompleteCodomain

--- a/docs/import_structure.md
+++ b/docs/import_structure.md
@@ -36,7 +36,7 @@ were formerly documented inline in `TNLean.lean`:
 | 2 | `Channel`, `Entropy` | Quantum channels; Choi, Kraus, and Stinespring theory; entropy and recovery. |
 | 2b | `Channel.Schwarz` and related analysis | Schwarz inequalities, operator convexity and monotonicity, and relative-entropy results. |
 | 2c | `Channel.FixedPoint`, `Channel.Irreducible`, `Channel.Peripheral`, `Channel.Semigroup`, `Channel.KoashiImoto`, `QPF`, `Spectral` | Fixed points, quantum Perron--Frobenius theory, peripheral spectrum, spectral gaps, semigroups, and the common invariant algebra of jointly invariant states. |
-| 2d | `Kraus` | Word evaluation, injectivity, block injectivity, normality, and invariant orthogonal projections of a finite Kraus family. Extracted from the matrix-product-state layer (issue #6560, phase 1b); declarations currently still declare `namespace MPSTensor` pending a dedicated namespace-rename sweep. |
+| 2d | `Kraus` | Word evaluation, injectivity, block injectivity, normality, and invariant orthogonal projections of a finite Kraus family. Extracted from the matrix-product-state layer (issue #6560, phase 1b); matrix-product-state compatibility predicates remain in `MPS.Core`. |
 | 3 | `MPS.Chain`, `MPS.Core`, `MPS.Overlap` | Matrix-product tensor definitions, words, blocking, transfer matrices, and overlaps. |
 | 3b | `MPS.MPDO` | MPO, MPDO, and LPDO foundations. |
 | 4 | `MPS.FundamentalTheorem`, `MPS.Symmetry` | The single-block fundamental theorem and symmetry consequences. |


### PR DESCRIPTION
## What changed

- define `Kraus.HasInvariantProj` and `Kraus.IsIrreducibleFamily` as the finite-family predicates in `TNLean/Kraus/InvariantProjection.lean`
- state both Kraus-map irreducibility implications entirely through these QIC-owned predicates
- preserve `MPSTensor.HasInvariantProj` and `MPSTensor.IsIrreducibleTensor`, with their previous mathematical meanings and blueprint declarations, in `TNLean/MPS/Core/InvariantProjection.lean`
- point the MPS consumers to that owner and register the new MPS core module
- update the architecture table to record that MPS compatibility predicates remain in `MPS.Core`

For a matrix product tensor `A`, the preserved predicate is definitionally the assertion that the underlying finite family `A` has no nontrivial invariant orthogonal projection.

## Mathematical-language rename

The two Kraus bridge theorems now use `IsIrreducibleFamily` in their names rather than `IsIrreducibleTensor`. The old names described a finite matrix family as a tensor and no longer matched their QIC-owned statements. No deprecated aliases are retained because they would preserve the misleading terminology; every direct consumer is updated in this pull request.

## Dependency order

The foundational word split LionSR/TNLean#6756 has merged, and this branch is rebased directly onto `main` at merge commit `53d3e966e`. Pull requests LionSR/TNLean#6759, LionSR/TNLean#6760, and LionSR/TNLean#6773 form the sequential child stack.

## Validation

- focused build of the Kraus owner, the MPS predicate owner, and changed consumers: 8,840 jobs
- focused build of the late Wielandt consumer identified in review: 3,069 jobs
- generated import aggregators: 60 files covering 1,489 production modules
- import direction: 497 QIC-bound files, with no direction or namespace-ratchet violations
- no `MPSTensor` declaration remains in `TNLean/Kraus/InvariantProjection.lean`
- repo-wide search finds no old bridge theorem name
- reader-facing prose, proof-integrity, diff, and tactic-pattern checks
- hosted full build and blueprint declaration check required before merge

Closes LionSR/TNLean#6748.
Advances LionSR/TNLean#6622, LionSR/QICLean#340, and LionSR/TNLean#6560.


