### PR TITLE
refactor(mps): isolate multi-block word compatibility

### DIFF
--- a/TNLean/Kraus/MultiBlockWord.lean
+++ b/TNLean/Kraus/MultiBlockWord.lean
@@ -7,24 +7,13 @@ import TNLean.Kraus.Word
 
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Data.Matrix.Block
-import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
 # Word evaluation over arbitrary finite index types
 
-This file carries the word-evaluation layer of the channel side: a
-generalization of `Kraus.evalWord` to matrices indexed by an arbitrary
-finite type (in particular, the `Σ`-type indices produced by
-`Matrix.blockDiagonal'`), together with compatibility lemmas identifying it
-with the canonical `Fin D`-indexed `evalWord`. It is
-part of the extraction of a Kraus-family-only library out of
-`TNLean`'s matrix-product-state development.
-
-The established names `MPSTensor.evalWord_aux_eq` and
-`MPSTensor.evalWord_reindex` are retained because the MPS development uses
-them throughout. Their statements concern arbitrary finite matrix families;
-a simultaneous change of namespace belongs with the declarations that use
-these names.
+This file defines word evaluation for square matrices indexed by an arbitrary finite type,
+including the `Σ`-type indices produced by `Matrix.blockDiagonal'`. It proves that word
+evaluation preserves block-diagonal families, with an optional scalar factor on each block.
 -/
 
 open scoped Matrix BigOperators
@@ -83,28 +72,3 @@ lemma evalWord_blockDiagonal'_smul
       simp [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm]
 
 end BlockDiagonal
-
-namespace MPSTensor
-
-/-- On `Fin D` indices, the auxiliary `evalWord` from `MultiBlockWord.lean` agrees with
-`Kraus.evalWord`. -/
-@[simp] lemma evalWord_aux_eq {d D : ℕ} (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)) :
-    _root_.evalWord A w = Kraus.evalWord A w := by
-  induction w with
-  | nil => simp [Kraus.evalWord, _root_.evalWord]
-  | cons i w ih => simp [Kraus.evalWord, _root_.evalWord, ih]
-
-/-- `Kraus.evalWord` commutes with reindexing along an equivalence. -/
-lemma evalWord_reindex {d D : ℕ} {m : Type*} [Fintype m] [DecidableEq m]
-    (e : m ≃ Fin D) (A : Fin d → Matrix m m ℂ) :
-    ∀ w : List (Fin d),
-      Kraus.evalWord (fun i => (Matrix.reindex e e) (A i)) w =
-        (Matrix.reindex e e) (_root_.evalWord A w) := by
-  classical
-  intro w; induction w with
-  | nil => simp [Kraus.evalWord, _root_.evalWord]
-  | cons _ _ ih =>
-      simp only [Kraus.evalWord, _root_.evalWord, ih]
-      simp [Matrix.submatrix_mul_equiv]
-
-end MPSTensor

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -18,6 +18,7 @@ import TNLean.MPS.Core.Correlations
 import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.Core.MultiBlockWord
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.RepeatedWord

--- a/TNLean/MPS/Core/MultiBlock.lean
+++ b/TNLean/MPS/Core/MultiBlock.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.TraceReindex
 import TNLean.MPS.Defs
-import TNLean.Kraus.MultiBlockWord
+import TNLean.MPS.Core.MultiBlockWord
 
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Data.Matrix.Block

--- a/TNLean/MPS/Core/MultiBlockWord.lean
+++ b/TNLean/MPS/Core/MultiBlockWord.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Kraus.MultiBlockWord
+import TNLean.MPS.Core.Word
+
+import Mathlib.LinearAlgebra.Matrix.Reindex
+
+/-!
+# Word evaluation over arbitrary finite index types for matrix product tensors
+
+The generic word evaluation on matrices indexed by an arbitrary finite type agrees with
+matrix product tensor word evaluation on `Fin` indices. It also commutes with reindexing
+along an equivalence.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+/-- On `Fin D` indices, the auxiliary word evaluation agrees with matrix product tensor
+word evaluation. -/
+@[simp] lemma evalWord_aux_eq {d D : ℕ} (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (w : List (Fin d)) :
+    _root_.evalWord A w = Kraus.evalWord A w := by
+  induction w with
+  | nil => simp [Kraus.evalWord, _root_.evalWord]
+  | cons i w ih => simp [Kraus.evalWord, _root_.evalWord, ih]
+
+/-- Matrix product tensor word evaluation commutes with reindexing along an equivalence. -/
+lemma evalWord_reindex {d D : ℕ} {m : Type*} [Fintype m] [DecidableEq m]
+    (e : m ≃ Fin D) (A : Fin d → Matrix m m ℂ) :
+    ∀ w : List (Fin d),
+      Kraus.evalWord (fun i => (Matrix.reindex e e) (A i)) w =
+        (Matrix.reindex e e) (_root_.evalWord A w) := by
+  classical
+  intro w; induction w with
+  | nil => simp [Kraus.evalWord, _root_.evalWord]
+  | cons _ _ ih =>
+      simp only [Kraus.evalWord, _root_.evalWord, ih]
+      simp [Matrix.submatrix_mul_equiv]
+
+end MPSTensor


### PR DESCRIPTION
## What changed

- move `MPSTensor.evalWord_aux_eq` and `MPSTensor.evalWord_reindex`, with unchanged statements, into the MPS module `TNLean.MPS.Core.MultiBlockWord`
- leave `TNLean.Kraus.MultiBlockWord` with only word evaluation over arbitrary finite matrix indices and its block-diagonal identities
- point `TNLean.MPS.Core.MultiBlock` to the MPS declaration owner and update the core aggregator
- keep the QIC module free of `MPSTensor` declarations and MPS imports

This is a four-file ownership separation and introduces no new mathematical statement.

## Dependency order

Rebased directly onto `main` after the invariant-projection owner split merged in LionSR/TNLean#6758. The pull-request delta remains the same four-file separation.

## Validation

- focused build of the two owners, their direct consumer, and the complete MPS core aggregator: 8,841 jobs
- generated import aggregators: 60 files covering 1,491 production modules
- import direction: 497 QIC-bound files, with no direction or namespace-ratchet violations
- reader-facing prose, proof-integrity, and diff checks
- hosted full build and blueprint declaration check required before merge

Closes LionSR/TNLean#6746.
Advances LionSR/TNLean#6622 and LionSR/TNLean#6560.