### PR TITLE
refactor(qic): split injectivity and normality predicates

### DIFF
--- a/TNLean/Kraus/Blocking.lean
+++ b/TNLean/Kraus/Blocking.lean
@@ -189,7 +189,7 @@ noncomputable def blockTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : �
 /-- Equivalence between `N`-block injectivity and injectivity of the blocked
 tensor `blockTensor A N`. -/
 lemma isNBlkInjective_iff_blockTensor_isInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) :
-    IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
+    Kraus.IsNBlkInjective A N ↔ Kraus.IsInjective (blockTensor A N) := by
   classical
   have hRange :
       Set.range (fun i : Fin (blockPhysDim d N) =>
@@ -202,7 +202,7 @@ lemma isNBlkInjective_iff_blockTensor_isInjective (A : Fin d → Matrix (Fin D) 
     · rintro ⟨σ, rfl⟩
       exact ⟨Fin.cast (blockPhysDim_eq_pow d N).symm (finFunctionFinEquiv σ), by
         simp [decodeBlock, Fin.cast_cast]⟩
-  unfold IsNBlkInjective IsInjective blockTensor
+  unfold Kraus.IsNBlkInjective Kraus.IsInjective blockTensor
   have hSpan :
       Submodule.span ℂ
           (Set.range fun i : Fin (blockPhysDim d N) =>

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -61,7 +61,7 @@ theorem IsInjective.smul
         simp [hc]
     _ = ⊤ := hA
 
-/-- An injective MPS tensor on `D ≥ 1` bond dimension implies `d ≥ 1`. -/
+/-- An injective finite Kraus family on a bond space of dimension `D ≥ 1` has `d ≥ 1`. -/
 theorem neZero_d_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ} [NeZero D]
     (hA : IsInjective A) : NeZero d := by
   by_contra h

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -9,27 +9,22 @@ import TNLean.Channel.Schwarz.Basic
 /-!
 # Injectivity and normality of finite Kraus families
 
-This file carries the word-evaluation layer of the channel side: algebraic
-injectivity, block injectivity, and normality of a finite Kraus family, and
-their elementary consequences. It is part of the extraction of a
-Kraus-family-only library out of `TNLean`'s matrix-product-state development.
-
-The exact word-span API is stated in `namespace Kraus`. The established
-injectivity and normality declarations remain in `namespace MPSTensor` until
-the MPS declarations using these predicates are changed simultaneously.
+For a finite matrix family $K = (K_i)_i$, this file defines algebraic
+injectivity, block injectivity, and normality, together with their elementary
+consequences. All declarations are stated in `namespace Kraus`.
 
 ## Main declarations
 
 * `Kraus.wordSpan` — the span of all Kraus words of a fixed length
 * `Kraus.HasEventuallyFullWordSpan` — all sufficiently long word spans are full
-* `IsInjective` — the matrices of a Kraus family span the full matrix algebra
-* `IsNBlkInjective` — injectivity after blocking `N` letters into words
-* `IsNormal` — eventual block injectivity at some positive blocking length
+* `Kraus.IsInjective` — the matrices of a Kraus family span the full matrix algebra
+* `Kraus.IsNBlkInjective` — injectivity after blocking `N` letters into words
+* `Kraus.IsNormal` — eventual block injectivity at some positive blocking length
 -/
 
 open scoped Matrix BigOperators
 
-namespace MPSTensor
+namespace Kraus
 
 variable {d D : ℕ}
 
@@ -127,12 +122,6 @@ This is the trivial direction: injectivity is `IsNBlkInjective 1`. -/
 lemma IsInjective.isNormal {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (h : IsInjective A) :
     IsNormal A :=
   ⟨1, Nat.zero_lt_one, isNBlkInjective_one_of_isInjective h⟩
-
-end MPSTensor
-
-namespace Kraus
-
-variable {d D : ℕ}
 
 /-! ### Trace-preserving propagation -/
 

--- a/TNLean/Kraus/Injectivity.lean
+++ b/TNLean/Kraus/Injectivity.lean
@@ -15,11 +15,11 @@ consequences. All declarations are stated in `namespace Kraus`.
 
 ## Main declarations
 
-* `Kraus.wordSpan` — the span of all Kraus words of a fixed length
-* `Kraus.HasEventuallyFullWordSpan` — all sufficiently long word spans are full
-* `Kraus.IsInjective` — the matrices of a Kraus family span the full matrix algebra
-* `Kraus.IsNBlkInjective` — injectivity after blocking `N` letters into words
-* `Kraus.IsNormal` — eventual block injectivity at some positive blocking length
+* `Kraus.wordSpan`: the span of all Kraus words of a fixed length
+* `Kraus.HasEventuallyFullWordSpan`: all sufficiently long word spans are full
+* `Kraus.IsInjective`: the matrices of a Kraus family span the full matrix algebra
+* `Kraus.IsNBlkInjective`: injectivity after blocking `N` letters into words
+* `Kraus.IsNormal`: eventual block injectivity at some positive blocking length
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Kraus/Wielandt/RankOne/ExtractionFull.lean
@@ -125,7 +125,7 @@ theorem exists_rankOne_mem_wordSpan_blockTensor [NeZero D]
     exact heigψ'
   let data := blockedTensorRangeData K N₀ σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ
   have hBtop : wordSpan data.B N₀ = ⊤ := by
-    have hInjective : MPSTensor.IsInjective (MPSTensor.blockTensor K N₀) :=
+    have hInjective : Kraus.IsInjective (MPSTensor.blockTensor K N₀) :=
       (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective K N₀).mp hN₀
     have hB1 : wordSpan data.B 1 = ⊤ := by
       rw [wordSpan_one, data.hB]

--- a/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Kraus/Wielandt/RectangularSpan/Basic.lean
@@ -84,7 +84,7 @@ span, then a fixed-length word span is the full matrix algebra.
 This is the conditional algebraic step in arXiv:0909.5347, Lemma 2(b). -/
 theorem wielandt_lemma2b_conditional [NeZero D]
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (hNormal : MPSTensor.IsNormal K)
+    (hNormal : Kraus.IsNormal K)
     (i₀ : Fin d) (μ : ℂ) (hμ : μ ≠ 0)
     (φ : Fin D → ℂ) (hφ : φ ≠ 0)
     (heigφ : K i₀ *ᵥ φ = μ • φ)
@@ -95,7 +95,7 @@ theorem wielandt_lemma2b_conditional [NeZero D]
     wordSpan K ((D - 1) + (m + (D - 1))) = ⊤ := by
   obtain ⟨N, _hNpos, hN⟩ := hNormal
   have hWord : wordSpan K N = ⊤ := by
-    simpa [wordSpan, MPSTensor.IsNBlkInjective] using hN
+    simpa [wordSpan, Kraus.IsNBlkInjective] using hN
   have hCum : cumulativeSpan K N = ⊤ := by
     apply eq_top_iff.mpr
     rw [← hWord]

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -91,7 +91,11 @@ theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
     IsNormal (mapStar A) := by
   obtain ⟨N, hN, hInj⟩ := hA
   refine ⟨N, hN, ?_⟩
+  change Kraus.IsNBlkInjective A N at hInj
+  change Kraus.IsNBlkInjective (mapStar A) N
   rw [isNBlkInjective_iff_blockTensor_isInjective] at hInj ⊢
+  change IsInjective (blockTensor A N) at hInj
+  change IsInjective (blockTensor (mapStar A) N)
   have hConj := hInj.mapStar
   convert hConj using 1
   ext σ β α

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -92,10 +92,10 @@ theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
   obtain ⟨N, hN, hInj⟩ := hA
   refine ⟨N, hN, ?_⟩
   change Kraus.IsNBlkInjective A N at hInj
-  change Kraus.IsNBlkInjective (mapStar A) N
+  change Kraus.IsNBlkInjective (MPSTensor.mapStar A) N
   rw [isNBlkInjective_iff_blockTensor_isInjective] at hInj ⊢
   change IsInjective (blockTensor A N) at hInj
-  change IsInjective (blockTensor (mapStar A) N)
+  change IsInjective (blockTensor (MPSTensor.mapStar A) N)
   have hConj := hInj.mapStar
   convert hConj using 1
   ext σ β α

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -34,8 +34,8 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
     (hA : MPSTensor.IsNBlkInjective A L) :
     IsInjective (blockedChain A L n) := by
   intro k
-  simpa [blockedChain] using
-    (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
+  simp only [blockedChain]
+  exact (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
 /-- **Fundamental Theorem for blocked chains**.
 

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.Core.CanonicalNormalization
 import TNLean.MPS.Core.CorrelationReduction
 import TNLean.MPS.Core.Correlations
 import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Core.Injectivity
 import TNLean.MPS.Core.InvariantProjection
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Core.MultiBlockWord

--- a/TNLean/MPS/Core/Injectivity.lean
+++ b/TNLean/MPS/Core/Injectivity.lean
@@ -28,7 +28,7 @@ variable {d D : ℕ}
 
 /-- Algebraic injectivity: the tensor matrices span the full matrix algebra. -/
 def IsInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  Kraus.IsInjective A
+  Submodule.span ℂ (Set.range A) = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
 /-- The span of an injective tensor's matrices is the full matrix algebra. -/
 lemma IsInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) :
@@ -48,7 +48,7 @@ theorem neZero_d_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ} [NeZe
 
 /-- Block injectivity: words of length $N$ span the full matrix algebra. -/
 def IsNBlkInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) : Prop :=
-  Kraus.IsNBlkInjective A N
+  Kraus.wordSpan A N = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
 
 /-- The literal-span form of block injectivity. -/
 theorem IsNBlkInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {N : ℕ}
@@ -58,7 +58,7 @@ theorem IsNBlkInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {
 
 /-- Normality means block injectivity at some positive word length. -/
 def IsNormal (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  Kraus.IsNormal A
+  ∃ N : ℕ, 0 < N ∧ IsNBlkInjective (d := d) (D := D) A N
 
 @[simp] lemma isNormal_iff (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     IsNormal A ↔ ∃ N, 0 < N ∧ IsNBlkInjective A N := Iff.rfl

--- a/TNLean/MPS/Core/Injectivity.lean
+++ b/TNLean/MPS/Core/Injectivity.lean
@@ -20,21 +20,57 @@ MPS names.
 * `MPSTensor.IsNormal` — block injectivity holds at some positive length
 -/
 
+open scoped Matrix
+
 namespace MPSTensor
 
-export Kraus (IsInjective IsNBlkInjective IsNormal isNBlkInjective_one_of_isInjective
-  isNormal_iff neZero_d_of_isInjective)
+variable {d D : ℕ}
 
-namespace IsInjective
+/-- Algebraic injectivity: the tensor matrices span the full matrix algebra. -/
+def IsInjective (A : MPSTensor d D) : Prop :=
+  Kraus.IsInjective A
 
-export Kraus.IsInjective (isNormal smul span_eq_top)
+/-- The span of an injective tensor's matrices is the full matrix algebra. -/
+lemma IsInjective.span_eq_top {A : MPSTensor d D} (hA : IsInjective A) :
+    Submodule.span ℂ (Set.range A) = ⊤ :=
+  Kraus.IsInjective.span_eq_top hA
 
-end IsInjective
+/-- Multiplication of every tensor matrix by a nonzero scalar preserves injectivity. -/
+theorem IsInjective.smul
+    {c : ℂ} {A : MPSTensor d D} (hA : IsInjective A) (hc : c ≠ 0) :
+    IsInjective (fun i ↦ c • A i) :=
+  Kraus.IsInjective.smul hA hc
 
-namespace IsNBlkInjective
+/-- An injective tensor with nonzero bond dimension has nonzero physical dimension. -/
+theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
+    (hA : IsInjective A) : NeZero d :=
+  Kraus.neZero_d_of_isInjective hA
 
-export Kraus.IsNBlkInjective (span_eq_top)
+/-- Block injectivity: words of length $N$ span the full matrix algebra. -/
+def IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop :=
+  Kraus.IsNBlkInjective A N
 
-end IsNBlkInjective
+/-- The literal-span form of block injectivity. -/
+theorem IsNBlkInjective.span_eq_top {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) :
+    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ :=
+  Kraus.IsNBlkInjective.span_eq_top hA
+
+/-- Normality means block injectivity at some positive word length. -/
+def IsNormal (A : MPSTensor d D) : Prop :=
+  Kraus.IsNormal A
+
+@[simp] lemma isNormal_iff (A : MPSTensor d D) :
+    IsNormal A ↔ ∃ N, 0 < N ∧ IsNBlkInjective A N := Iff.rfl
+
+/-- Algebraic injectivity gives one-block injectivity. -/
+theorem isNBlkInjective_one_of_isInjective {A : MPSTensor d D}
+    (h : IsInjective A) : IsNBlkInjective A 1 :=
+  Kraus.isNBlkInjective_one_of_isInjective h
+
+/-- Algebraic injectivity implies normality. -/
+lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) :
+    IsNormal A :=
+  Kraus.IsInjective.isNormal h
 
 end MPSTensor

--- a/TNLean/MPS/Core/Injectivity.lean
+++ b/TNLean/MPS/Core/Injectivity.lean
@@ -15,9 +15,9 @@ MPS names.
 
 ## Main declarations
 
-* `MPSTensor.IsInjective` — the one-site matrices span the full matrix algebra
-* `MPSTensor.IsNBlkInjective` — words of length $N$ span the full matrix algebra
-* `MPSTensor.IsNormal` — block injectivity holds at some positive length
+* `MPSTensor.IsInjective`: the one-site matrices span the full matrix algebra
+* `MPSTensor.IsNBlkInjective`: words of length $N$ span the full matrix algebra
+* `MPSTensor.IsNormal`: block injectivity holds at some positive length
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/Core/Injectivity.lean
+++ b/TNLean/MPS/Core/Injectivity.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Kraus.Injectivity
+import TNLean.MPS.Core.Word
+
+/-!
+# Injectivity and normality of matrix product tensors
+
+The injectivity and normality predicates for a matrix product tensor are the
+corresponding finite-family predicates. This file preserves their established
+MPS names.
+
+## Main declarations
+
+* `MPSTensor.IsInjective` — the one-site matrices span the full matrix algebra
+* `MPSTensor.IsNBlkInjective` — words of length $N$ span the full matrix algebra
+* `MPSTensor.IsNormal` — block injectivity holds at some positive length
+-/
+
+namespace MPSTensor
+
+export Kraus (IsInjective IsNBlkInjective IsNormal isNBlkInjective_one_of_isInjective
+  isNormal_iff neZero_d_of_isInjective)
+
+namespace IsInjective
+
+export Kraus.IsInjective (isNormal smul span_eq_top)
+
+end IsInjective
+
+namespace IsNBlkInjective
+
+export Kraus.IsNBlkInjective (span_eq_top)
+
+end IsNBlkInjective
+
+end MPSTensor

--- a/TNLean/MPS/Core/Injectivity.lean
+++ b/TNLean/MPS/Core/Injectivity.lean
@@ -27,49 +27,49 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- Algebraic injectivity: the tensor matrices span the full matrix algebra. -/
-def IsInjective (A : MPSTensor d D) : Prop :=
+def IsInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   Kraus.IsInjective A
 
 /-- The span of an injective tensor's matrices is the full matrix algebra. -/
-lemma IsInjective.span_eq_top {A : MPSTensor d D} (hA : IsInjective A) :
+lemma IsInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) :
     Submodule.span ℂ (Set.range A) = ⊤ :=
   Kraus.IsInjective.span_eq_top hA
 
 /-- Multiplication of every tensor matrix by a nonzero scalar preserves injectivity. -/
 theorem IsInjective.smul
-    {c : ℂ} {A : MPSTensor d D} (hA : IsInjective A) (hc : c ≠ 0) :
+    {c : ℂ} {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : IsInjective A) (hc : c ≠ 0) :
     IsInjective (fun i ↦ c • A i) :=
   Kraus.IsInjective.smul hA hc
 
 /-- An injective tensor with nonzero bond dimension has nonzero physical dimension. -/
-theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
+theorem neZero_d_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ} [NeZero D]
     (hA : IsInjective A) : NeZero d :=
   Kraus.neZero_d_of_isInjective hA
 
 /-- Block injectivity: words of length $N$ span the full matrix algebra. -/
-def IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop :=
+def IsNBlkInjective (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) : Prop :=
   Kraus.IsNBlkInjective A N
 
 /-- The literal-span form of block injectivity. -/
-theorem IsNBlkInjective.span_eq_top {A : MPSTensor d D} {N : ℕ}
+theorem IsNBlkInjective.span_eq_top {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {N : ℕ}
     (hA : IsNBlkInjective A N) :
-    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ :=
+    Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => Kraus.evalWord A (List.ofFn σ)) = ⊤ :=
   Kraus.IsNBlkInjective.span_eq_top hA
 
 /-- Normality means block injectivity at some positive word length. -/
-def IsNormal (A : MPSTensor d D) : Prop :=
+def IsNormal (A : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   Kraus.IsNormal A
 
-@[simp] lemma isNormal_iff (A : MPSTensor d D) :
+@[simp] lemma isNormal_iff (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     IsNormal A ↔ ∃ N, 0 < N ∧ IsNBlkInjective A N := Iff.rfl
 
 /-- Algebraic injectivity gives one-block injectivity. -/
-theorem isNBlkInjective_one_of_isInjective {A : MPSTensor d D}
+theorem isNBlkInjective_one_of_isInjective {A : Fin d → Matrix (Fin D) (Fin D) ℂ}
     (h : IsInjective A) : IsNBlkInjective A 1 :=
   Kraus.isNBlkInjective_one_of_isInjective h
 
 /-- Algebraic injectivity implies normality. -/
-lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) :
+lemma IsInjective.isNormal {A : Fin d → Matrix (Fin D) (Fin D) ℂ} (h : IsInjective A) :
     IsNormal A :=
   Kraus.IsInjective.isNormal h
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -308,7 +308,7 @@ theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
     (hA : IsInjective A) (hGauge : GaugeEquiv A B) :
     IsInjective B := by
   obtain ⟨X, hX⟩ := hGauge
-  rw [IsInjective, eq_top_iff]
+  rw [IsInjective, Kraus.IsInjective, eq_top_iff]
   intro M _
   have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
       Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
@@ -343,7 +343,7 @@ theorem isNBlkInjective_of_gaugeEquiv {A B : MPSTensor d D} {N : ℕ}
     (hA : IsNBlkInjective A N) (hGauge : GaugeEquiv A B) :
     IsNBlkInjective B N := by
   obtain ⟨X, hX⟩ := hGauge
-  rw [IsNBlkInjective, eq_top_iff]
+  rw [IsNBlkInjective, Kraus.IsNBlkInjective, eq_top_iff]
   intro M _
   have hA' : Submodule.span ℂ
       (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -307,7 +307,7 @@ theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
     (hA : IsInjective A) (hGauge : GaugeEquiv A B) :
     IsInjective B := by
   obtain ⟨X, hX⟩ := hGauge
-  rw [IsInjective, Kraus.IsInjective, eq_top_iff]
+  rw [IsInjective, eq_top_iff]
   intro M _
   have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
       Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
@@ -342,7 +342,7 @@ theorem isNBlkInjective_of_gaugeEquiv {A B : MPSTensor d D} {N : ℕ}
     (hA : IsNBlkInjective A N) (hGauge : GaugeEquiv A B) :
     IsNBlkInjective B N := by
   obtain ⟨X, hX⟩ := hGauge
-  rw [IsNBlkInjective, Kraus.IsNBlkInjective, eq_top_iff]
+  rw [IsNBlkInjective, eq_top_iff]
   intro M _
   have hA' : Submodule.span ℂ
       (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) = ⊤ := by

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -9,7 +9,7 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Order.Filter.AtTopBot.Basic
 import TNLean.MPS.Core.Word
-import TNLean.Kraus.Injectivity
+import TNLean.MPS.Core.Injectivity
 
 /-!
 # Basic definitions for matrix product state tensors

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -17,12 +17,11 @@ import TNLean.MPS.Core.Injectivity
 This file contains the core definitions used throughout the MPS development:
 MPV coefficients, gauge equivalence, and the word-to-state lemmas connecting
 them to word evaluation, injectivity, and normality. The `MPSTensor` abbrev
-itself and the established MPS word-evaluation names live in
-`TNLean/MPS/Core/Word.lean`. The underlying finite-family word evaluation
-lives in `TNLean/Kraus/Word.lean`, while injectivity, block injectivity, and
-normality live in `TNLean/Kraus/Injectivity.lean`. This file keeps only the
-matrix-product-vector vocabulary and the gauge-invariance lemmas for
-`evalWord`, `SameMPV`, and eventual block injectivity.
+itself and the established tensor names for word evaluation and injectivity
+live in `TNLean/MPS/Core/Word.lean` and `TNLean/MPS/Core/Injectivity.lean`.
+Their finite-family owners are in the corresponding `TNLean/Kraus` modules.
+This file contains the matrix-product-vector vocabulary and the gauge-invariance
+lemmas for `evalWord`, `SameMPV`, and eventual block injectivity.
 
 ## Main declarations
 

--- a/TNLean/Wielandt/RankOne/Products.lean
+++ b/TNLean/Wielandt/RankOne/Products.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Kraus.Wielandt.RankOne.Products
-import TNLean.Kraus.Injectivity
+import TNLean.MPS.Core.Injectivity
 import TNLean.MPS.Core.Word
 
 /-!

--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Kraus.Injectivity
+import TNLean.MPS.Core.Injectivity
 import TNLean.Kraus.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.MPS.Core.Word
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,8 +15,8 @@ is deliberately source-faithful.
 ### `MPSTensor.IsNormal`
 
 - **Declaration:** `MPSTensor.IsNormal (A : MPSTensor d D) : Prop`.
-- **Defined in:** `TNLean/Kraus/Injectivity.lean` (still `namespace MPSTensor`;
-  the rename to `namespace Kraus` is pending issue #6560).
+- **Defined in:** `TNLean/MPS/Core/Injectivity.lean`; the finite-family owner is
+  `Kraus.IsNormal` in `TNLean/Kraus/Injectivity.lean`.
 - **Meaning:** there is a positive word length `N` for which the length-`N`
   products of the matrices of `A` span the full `D × D` matrix algebra; equivalently,
   `A` becomes injective after blocking `N` sites.
@@ -248,8 +248,8 @@ interfaces.
 #### `MPSTensor.IsInjective`
 
 - **Declaration:** `MPSTensor.IsInjective (A : MPSTensor d D) : Prop`.
-- **Defined in:** `TNLean/Kraus/Injectivity.lean` (still `namespace MPSTensor`;
-  the rename to `namespace Kraus` is pending issue #6560).
+- **Defined in:** `TNLean/MPS/Core/Injectivity.lean`; the finite-family owner is
+  `Kraus.IsInjective` in `TNLean/Kraus/Injectivity.lean`.
 - **Meaning:** the one-site matrices `{A i}` span the full matrix algebra; this
   is the linear-algebraic injectivity of the tensor as a virtual-to-physical map.
 - **Source:** arXiv:1804.04964 §2,
@@ -265,8 +265,8 @@ interfaces.
 
 - **Declaration:**
   `MPSTensor.IsNBlkInjective (A : MPSTensor d D) (N : ℕ) : Prop`.
-- **Defined in:** `TNLean/Kraus/Injectivity.lean` (still `namespace MPSTensor`;
-  the rename to `namespace Kraus` is pending issue #6560).
+- **Defined in:** `TNLean/MPS/Core/Injectivity.lean`; the finite-family owner is
+  `Kraus.IsNBlkInjective` in `TNLean/Kraus/Injectivity.lean`.
 - **Meaning:** products indexed by all words of exactly length `N` span the full
   matrix algebra.
 - **Source:** arXiv:0909.5347, equation (1) and the following definition of

--- a/docs/import_structure.md
+++ b/docs/import_structure.md
@@ -38,7 +38,7 @@ were formerly documented inline in `TNLean.lean`:
 | 2 | `Channel`, `Entropy` | Quantum channels; Choi, Kraus, and Stinespring theory; entropy and recovery. |
 | 2b | `Channel.Schwarz` and related analysis | Schwarz inequalities, operator convexity and monotonicity, and relative-entropy results. |
 | 2c | `Channel.FixedPoint`, `Channel.Irreducible`, `Channel.Peripheral`, `Channel.Semigroup`, `Channel.KoashiImoto`, `QPF`, `Spectral` | Fixed points, quantum Perron--Frobenius theory, peripheral spectrum, spectral gaps, semigroups, and the common invariant algebra of jointly invariant states. |
-| 2d | `Kraus` | Word evaluation, injectivity, block injectivity, normality, and invariant orthogonal projections of a finite Kraus family. Extracted from the matrix-product-state layer (issue #6560, phase 1b); matrix-product-state compatibility predicates remain in `MPS.Core`. |
+| 2d | `Kraus` | Word evaluation, injectivity, block injectivity, normality, and invariant orthogonal projections of a finite Kraus family. These notions are stated in `namespace Kraus`, while the established matrix-product-state compatibility predicates remain in `MPS.Core`. |
 | 3 | `MPS.Chain`, `MPS.Core`, `MPS.Overlap` | Matrix-product tensor definitions, words, blocking, transfer matrices, and overlaps. |
 | 3b | `MPS.MPDO` | MPO, MPDO, and LPDO foundations. |
 | 4 | `MPS.FundamentalTheorem`, `MPS.Symmetry` | The single-block fundamental theorem and symmetry consequences. |

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -611,7 +611,7 @@ abstracted — record why, so it is not re-proposed).
   `IsNBlkInjective` hypothesis after the predicate was single-sourced through
   `Kraus.wordSpan`.
 - **Reuse:** `MPSTensor.IsNBlkInjective.span_eq_top` in
-  `TNLean/Kraus/Injectivity.lean` supplies the literal span equality.
+  `TNLean/MPS/Core/Injectivity.lean` supplies the literal span equality.
 - **Call sites:** the odd- and even-length Majumdar-Ghosh obstructions and the
   diagonal-restriction non-normality counterexample.
 


### PR DESCRIPTION
## What changed

- place the proof-owning injectivity, block-injectivity, and normality predicates under neutral `Kraus` names in `TNLean/Kraus/Injectivity.lean`
- express every QIC-side consumer through those finite-family predicates
- preserve the ten established `MPSTensor` declarations, their exact signatures, direct unfolding behavior, and four blueprint declarations in `TNLean/MPS/Core/Injectivity.lean`
- point MPS importers and the generated core aggregator to the MPS declaration owner
- bridge both blocked-chain and conjugation consumers explicitly across the preserved MPS predicates

Thus the finite-family module owns the mathematics, while the MPS module retains the names used throughout the tensor development without changing their meanings.

## Dependency order

This pull request is based directly on merged `main` at LionSR/TNLean#6759. Its exact head is `080cb8a4a`; the final fourteen-file delta includes the hosted-build repair in `TNLean/MPS/CanonicalForm/Conjugation.lean` and a prose-only cleanup of the new declaration summaries. The sequential rebase keeps the shared `TNLean/MPS/Core.lean` aggregator conflict-free.

## Validation

- focused owner, affected-consumer, blocked-chain, and complete MPS core build before the ancestry-only transplant: 8,865 jobs
- all ten established `MPSTensor` signatures agree byte-for-byte with the parent statements
- generated import aggregators: 60 files covering 1,492 production modules
- import direction: 497 QIC-bound files, with no direction or namespace-ratchet violations
- import-direction test suite: 28 tests
- no QIC mover retains an `MPSTensor` injectivity or normality predicate
- reader-facing prose, proof-integrity, tactic-pattern, and diff checks
- hosted full build and blueprint declaration check required before merge

Closes LionSR/TNLean#6747.
Advances LionSR/TNLean#6622, LionSR/QICLean#340, and LionSR/TNLean#6560.
