### PR TITLE
fix(Channel): correct Wolf Chapter 5 attributions

### DIFF
--- a/TNLean/Analysis/LiebConcavity.lean
+++ b/TNLean/Analysis/LiebConcavity.lean
@@ -163,7 +163,7 @@ The remaining Mathlib or local formalization gaps are:
 ## References
 
 * [R. Bhatia, *Matrix Analysis*, Springer GTM 169, Chapter V]
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 5.1]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13]
 * [F. Hansen, G. K. Pedersen, *Jensen's operator inequality*, 2003]
 * [E. H. Lieb, *Convex trace functions and the Wigner--Yanase--Dyson
   conjecture*, 1973]
@@ -285,7 +285,7 @@ private lemma positiveMap_rpowIntegrand₁₂_cfcₙ_jensen
   simpa [cfcₙ_rpowIntegrand₁₂_eq_cfc hA hp ht,
     cfcₙ_rpowIntegrand₁₂_eq_cfc hTA hp ht] using hpoint
 
-/-- **Operator Jensen for concave `rpow`** (Wolf Theorem 5.1, `p ∈ [0, 1]`).
+/-- **Operator Jensen for concave `rpow`** (Wolf Theorem 5.13, `p ∈ [0, 1]`).
 
 For a positive subunital map `T` and `p ∈ [0, 1]`:
   `T(A ^ p) ≤ (T A) ^ p`.
@@ -294,7 +294,7 @@ Follows from operator concavity of `rpow` (Bhatia, Chapter V) combined with
 the Hansen--Pedersen operator Jensen inequality for positive subunital maps.
 
 References:
-* Wolf, Theorem 5.1
+* Wolf, Theorem 5.13
 * Hansen--Pedersen, *Jensen's operator inequality*, 2003 -/
 theorem posMap_rpow_concave_jensen
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
@@ -441,7 +441,7 @@ private lemma tendsto_rpow_exponent_two {M : Mat} (hM : 0 ≤ M) :
   case tendsto =>
     exact tendstoUniformlyOn_rpow_exponent_two (spectrum ℝ M) hspec_compact
 
-/-- **Operator Jensen for convex `rpow`** (Wolf Theorem 5.1, `p ∈ [1, 2]`).
+/-- **Operator Jensen for convex `rpow`** (Wolf Theorem 5.11, `p ∈ [1, 2]`).
 
 For a positive subunital map `T` and `p ∈ [1, 2]`:
   `(T A) ^ p ≤ T(A ^ p)`.
@@ -450,7 +450,7 @@ Follows from operator convexity of `rpow` (Bhatia, Chapter V) combined with
 the Hansen--Pedersen operator Jensen inequality for positive subunital maps.
 
 References:
-* Wolf, Theorem 5.1
+* Wolf, Theorem 5.11
 * Hansen--Pedersen, *Jensen's operator inequality*, 2003 -/
 theorem posMap_rpow_convex_jensen
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
@@ -540,7 +540,7 @@ theorem posMap_rpow_convex_jensen
     exact le_of_tendsto_of_tendsto hlimF hlimG hle
   · exact hcore p ⟨hp1, hp2⟩
 
-/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.1, log case).
+/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.13, log case).
 
 For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
@@ -551,7 +551,7 @@ Follows by applying the concave real-power theorem to `(A ^ p - 1) / p` for
 subunitality.
 
 References:
-* Wolf, Theorem 5.1
+* Wolf, Theorem 5.13
 * Hansen--Pedersen, *Jensen's operator inequality*, 2003 -/
 theorem posMap_log_concave_jensen
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))

--- a/TNLean/Analysis/LiebConcavity.lean
+++ b/TNLean/Analysis/LiebConcavity.lean
@@ -163,7 +163,8 @@ The remaining Mathlib or local formalization gaps are:
 ## References
 
 * [R. Bhatia, *Matrix Analysis*, Springer GTM 169, Chapter V]
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13,
+  and Corollary 5.2(3)]
 * [F. Hansen, G. K. Pedersen, *Jensen's operator inequality*, 2003]
 * [E. H. Lieb, *Convex trace functions and the Wigner--Yanase--Dyson
   conjecture*, 1973]
@@ -540,7 +541,7 @@ theorem posMap_rpow_convex_jensen
     exact le_of_tendsto_of_tendsto hlimF hlimG hle
   · exact hcore p ⟨hp1, hp2⟩
 
-/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.13, log case).
+/-- **Operator Jensen for concave `log`** (Wolf Corollary 5.2(3)).
 
 For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
@@ -550,8 +551,14 @@ Follows by applying the concave real-power theorem to `(A ^ p - 1) / p` for
 `CFC.tendsto_cfc_rpow_sub_one_log`. Requires unitality (`T 1 = 1`), not merely
 subunitality.
 
+**Local fix (unital logarithm inequality):** Wolf Corollary 5.2(3) states the
+result for a positive subunital map, but that statement fails because `log` is
+unbounded below at zero. The present theorem uses the necessary unital
+hypothesis. This correction is documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
+
 References:
-* Wolf, Theorem 5.13
+* Wolf, Corollary 5.2(3)
 * Hansen--Pedersen, *Jensen's operator inequality*, 2003 -/
 theorem posMap_log_concave_jensen
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))

--- a/TNLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/TNLean/Channel/Schwarz/OperatorConvexity.lean
@@ -49,7 +49,8 @@ These are consumed by the Corollary 5.2 proofs in `OperatorMonotone.lean`.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13,
+  and Corollary 5.2(3)]
 * [F. Hansen, G. K. Pedersen, *Jensen's operator inequality*, 2003]
 -/
 
@@ -101,7 +102,7 @@ theorem IsPositiveMap.rpow_convex_jensen
     (T A) ^ p ≤ T (A ^ p) :=
   posMap_rpow_convex_jensen hT hSub hp hA
 
-/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.13 applied to `log`).
+/-- **Operator Jensen for concave `log`** (Wolf Corollary 5.2(3)).
 
 For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
@@ -110,6 +111,12 @@ This is obtained as the right limit of the concave real-power Jensen theorem
 for positive subunital maps. Note: unlike the `rpow` variants, the `log`
 Jensen inequality requires unitality (`T 1 = 1`), not merely subunitality
 (`T 1 ≤ 1`).
+
+**Local fix (unital logarithm inequality):** Wolf Corollary 5.2(3) states the
+result for a positive subunital map, but that statement fails because `log` is
+unbounded below at zero. The present theorem uses the necessary unital
+hypothesis. This correction is documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
 
 Proved from `posMap_log_concave_jensen` in `TNLean.Analysis.LiebConcavity`. -/
 theorem IsPositiveMap.log_concave_jensen

--- a/TNLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/TNLean/Channel/Schwarz/OperatorConvexity.lean
@@ -49,7 +49,7 @@ These are consumed by the Corollary 5.2 proofs in `OperatorMonotone.lean`.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 5.1]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorems 5.11 and 5.13]
 * [F. Hansen, G. K. Pedersen, *Jensen's operator inequality*, 2003]
 -/
 
@@ -67,7 +67,7 @@ private local instance instOperatorConvexityNormedRing : NormedRing Mat :=
 private local instance instOperatorConvexityNormedAlgebra : NormedAlgebra ℂ Mat :=
   Matrix.instL2OpNormedAlgebra
 
-/-- **Operator Jensen for concave `rpow`** (Wolf Theorem 5.1 applied to
+/-- **Operator Jensen for concave `rpow`** (Wolf Theorem 5.13 applied to
 `x ↦ x ^ p` for `p ∈ [0, 1]`).
 
 For a positive subunital map `T` and `p ∈ [0, 1]`:
@@ -84,7 +84,7 @@ theorem IsPositiveMap.rpow_concave_jensen
     T (A ^ p) ≤ (T A) ^ p :=
   posMap_rpow_concave_jensen hT hSub hp hA
 
-/-- **Operator Jensen for convex `rpow`** (Wolf Theorem 5.1 applied to
+/-- **Operator Jensen for convex `rpow`** (Wolf Theorem 5.11 applied to
 `x ↦ x ^ p` for `p ∈ [1, 2]`).
 
 For a positive subunital map `T` and `p ∈ [1, 2]`:
@@ -101,7 +101,7 @@ theorem IsPositiveMap.rpow_convex_jensen
     (T A) ^ p ≤ T (A ^ p) :=
   posMap_rpow_convex_jensen hT hSub hp hA
 
-/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.1 applied to `log`).
+/-- **Operator Jensen for concave `log`** (Wolf Theorem 5.13 applied to `log`).
 
 For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.

--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -119,7 +119,12 @@ For a positive **unital** map `T` and positive-definite `A`:
 
 This is a direct instance of the concave Jensen inequality for `log`
 (from `OperatorConvexity.lean`). Note: requires unitality (`T 1 = 1`),
-not merely subunitality. -/
+not merely subunitality.
+
+**Local fix (unital logarithm inequality):** Wolf Corollary 5.2(3) states
+the inequality for a subunital map, but that form is false. The unital
+hypothesis used here is documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`. -/
 theorem IsPositiveMap.cor52_item3_log_of_subunital
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))
     {A : Mat} (hA : A.PosDef) :

--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -125,7 +125,7 @@ not merely subunitality.
 the inequality for a subunital map, but that form is false. The unital
 hypothesis used here is documented in
 `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`. -/
-theorem IsPositiveMap.cor52_item3_log_of_subunital
+theorem IsPositiveMap.cor52_item3_log_of_unital
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))
     {A : Mat} (hA : A.PosDef) :
     T (CFC.log A) ≤ CFC.log (T A) :=

--- a/blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex
@@ -595,8 +595,12 @@ matrix-order tools used independently of the Fundamental Theorem.
     \uses{def:positive_map, thm:posMap_rpow_concave_jensen}
     For a positive \emph{unital} map $T$ and positive-definite~$A$, one has
     $T(\log A)\le\log(T(A))$.
-    This is \cite[Theorem~5.13]{Wolf2012Quantum} for~$f=\log$.
-    Requires unitality ($T(\Id)=\Id$), not merely subunitality.
+    This is the unital form of \cite[Corollary~5.2(3)]{Wolf2012Quantum}.
+
+    \textbf{Local fix (unital logarithm inequality):} The printed corollary
+    assumes only subunitality, but that form fails because the logarithm is
+    unbounded below at zero. See
+    \path{docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex
@@ -596,11 +596,10 @@ matrix-order tools used independently of the Fundamental Theorem.
     For a positive \emph{unital} map $T$ and positive-definite~$A$, one has
     $T(\log A)\le\log(T(A))$.
     This is the unital form of \cite[Corollary~5.2(3)]{Wolf2012Quantum}.
-
-    \textbf{Local fix (unital logarithm inequality):} The printed corollary
-    assumes only subunitality, but that form fails because the logarithm is
-    unbounded below at zero. See
-    \path{docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex}.
+    % Local fix (unital logarithm inequality): the printed corollary assumes
+    % only subunitality, but that form fails because the logarithm is unbounded
+    % below at zero. See
+    % docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -60,7 +60,7 @@ Corollary~5.2.\footnote{%
     They are consumed by
     \leanid{cor52_item1_rpow_of_subunital},
     \leanid{cor52_item2_rpow_of_subunital}, and
-    \leanid{cor52_item3_log_of_subunital} in
+    \leanid{cor52_item3_log_of_unital} in
     \doclink{TNLean/Channel/Schwarz/OperatorMonotone}.}
 The first and third are concavity inequalities (for the operator-concave
 functions $x\mapsto x^p$ on $[0,1]$ and $x\mapsto\log x$); the second is a
@@ -127,7 +127,7 @@ hypothesises a positive map with $T(\mathbf 1)\le\mathbf 1$, which is exactly th
 \leanid{cor52_item2_rpow_of_subunital}.
 
 \paragraph{Local fix (log unitality).}  The logarithmic companion
-\leanid{cor52_item3_log_of_subunital} departs from this subunital hypothesis: it
+\leanid{cor52_item3_log_of_unital} departs from this subunital hypothesis: it
 assumes $T$ \emph{unital}, $T(\mathbf 1)=\mathbf 1$, rather than $T(\mathbf
 1)\le\mathbf 1$.  This is a deliberate strengthening, not an exact match to the
 subunital form of the source corollary: as recorded in \S\ref{ssec:assertions},

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -270,8 +270,9 @@ refer only to the searchable transcription and do not determine numbering.
 The printed chapter confirms all live Chapter 5 numbers except the former
 operator-Jensen references to Theorem 5.1. In the printed notes, Theorem 5.1
 is Douglas' theorem. The subunital Jensen inequality for convex powers is a
-case of Theorem 5.11, while the inequalities for concave powers and the
-logarithm are cases of Theorem 5.13.
+case of Theorem 5.11, and the corresponding inequality for concave powers is
+a case of Theorem 5.13.
+The logarithm inequality is Corollary 5.2(3).
 
 | Former citation | Printed citation | Result title | Archived PDF | Local transcription | Verdict |
 |---|---|---|---:|---:|---|

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -277,6 +277,7 @@ logarithm are cases of Theorem 5.13.
 |---|---|---|---:|---:|---|
 | Theorem 5.1 | Theorem 5.11 | Projection inequality from operator convexity | PDF page 9; printed page 81 | lines 627--655 | Corrected |
 | Theorem 5.1 | Theorem 5.13 | Operator monotonicity and positive maps | PDF page 11; printed page 83 | lines 714--759 | Corrected |
+| Theorem 5.1 | Corollary 5.2(3) | Logarithm inequality for positive maps | PDF page 11; printed page 83 | lines 761--768 | Corrected with unital local fix |
 | Theorem 5.2 | Theorem 5.2 | Block matrices and Schur complements | PDF page 2; printed page 74 | lines 103--118 | Correct |
 | Theorem 5.3 | Theorem 5.3 | Operator Schwarz inequality | PDF page 3; printed page 75 | lines 180--196 | Correct |
 | Proposition 5.1 | Proposition 5.1 | Schwarz inequality for commutative domains | PDF page 4; printed page 76 | lines 245--260 | Correct |
@@ -292,13 +293,16 @@ logarithm are cases of Theorem 5.13.
 | Theorem 5.17 | Theorem 5.17 | Convex functions and positive maps under the trace | PDF page 16; printed page 88 | lines 1039--1083 | Correct |
 | Example 5.3 | Example 5.3 | A Schwarz map which is not 2-positive | PDF page 5; printed page 77 | lines 354--378 | Correct |
 
-The two corrected rows distinguish the two conclusions that had formerly
-been assigned collectively to Theorem 5.1. For a positive subunital map,
+The corrected rows distinguish the conclusions that had formerly been
+assigned collectively to Theorem 5.1. For a positive subunital map,
 Theorem 5.11 gives Jensen's inequality for an operator-convex function with
 nonpositive value at zero. Theorem 5.13 gives the reversed inequality for an
 operator-monotone function with nonnegative value at zero. These apply,
-respectively, to powers with exponent in `[1, 2]`, and to powers with exponent
-in `[0, 1]` or the logarithm (with the usual positivity restrictions).
+respectively, to powers with exponent in `[1, 2]` and powers with exponent in
+`[0, 1]`. The logarithm inequality is Corollary 5.2(3). Its printed subunital
+form is false because the logarithm is unbounded below at zero, so the Lean
+theorem uses the necessary unital hypothesis, as documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
 
 ### Citing files
 

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -264,3 +264,114 @@ The enumeration uses the same directories and exclusions as the Chapter 1
 audit. Each result was checked against
 `Notes/WolfNotePDF/ch03_positive_not_completely.pdf`; the line ranges above
 refer only to the searchable transcription and do not determine numbering.
+
+## Chapter 5: Operator inequalities
+
+The printed chapter confirms all live Chapter 5 numbers except the former
+operator-Jensen references to Theorem 5.1. In the printed notes, Theorem 5.1
+is Douglas' theorem. The subunital Jensen inequality for convex powers is a
+case of Theorem 5.11, while the inequalities for concave powers and the
+logarithm are cases of Theorem 5.13.
+
+| Former citation | Printed citation | Result title | Archived PDF | Local transcription | Verdict |
+|---|---|---|---:|---:|---|
+| Theorem 5.1 | Theorem 5.11 | Projection inequality from operator convexity | PDF page 9; printed page 81 | lines 627--655 | Corrected |
+| Theorem 5.1 | Theorem 5.13 | Operator monotonicity and positive maps | PDF page 11; printed page 83 | lines 714--759 | Corrected |
+| Theorem 5.2 | Theorem 5.2 | Block matrices and Schur complements | PDF page 2; printed page 74 | lines 103--118 | Correct |
+| Theorem 5.3 | Theorem 5.3 | Operator Schwarz inequality | PDF page 3; printed page 75 | lines 180--196 | Correct |
+| Proposition 5.1 | Proposition 5.1 | Schwarz inequality for commutative domains | PDF page 4; printed page 76 | lines 245--260 | Correct |
+| Theorem 5.5 | Theorem 5.5 | Schwarz inequality for subnormal operators | PDF page 4; printed page 76 | lines 282--309 | Correct |
+| Theorem 5.6 | Theorem 5.6 | Schwarz inequality for commuting dominant operators | PDF page 5; printed page 77 | lines 311--323 | Correct |
+| Theorem 5.7 | Theorem 5.7 | Multiplicative domains | PDF page 6; printed page 78 | lines 399--407 | Correct |
+| Theorem 5.10 | Theorem 5.10 | Operator convexity from the projection inequality | PDF page 8; printed page 80 | lines 575--625 | Correct |
+| Theorem 5.11 | Theorem 5.11 | Projection inequality from operator convexity | PDF page 9; printed page 81 | lines 627--655 | Correct |
+| Theorem 5.12 | Theorem 5.12 | Operator convexity and unital positive maps | PDF page 10; printed page 82 | lines 657--697 | Correct |
+| Theorem 5.13 | Theorem 5.13 | Operator monotonicity and positive maps | PDF page 11; printed page 83 | lines 714--759 | Correct |
+| Corollary 5.2 | Corollary 5.2 | Power and logarithm inequalities for positive subunital maps | PDF page 11; printed page 83 | lines 761--777 | Correct |
+| Theorem 5.15 | Theorem 5.15 | Ando--Lieb joint concavity and convexity | PDF page 14; printed page 86 | lines 967--991 | Correct |
+| Theorem 5.17 | Theorem 5.17 | Convex functions and positive maps under the trace | PDF page 16; printed page 88 | lines 1039--1083 | Correct |
+| Example 5.3 | Example 5.3 | A Schwarz map which is not 2-positive | PDF page 5; printed page 77 | lines 354--378 | Correct |
+
+The two corrected rows distinguish the two conclusions that had formerly
+been assigned collectively to Theorem 5.1. For a positive subunital map,
+Theorem 5.11 gives Jensen's inequality for an operator-convex function with
+nonpositive value at zero. Theorem 5.13 gives the reversed inequality for an
+operator-monotone function with nonnegative value at zero. These apply,
+respectively, to powers with exponent in `[1, 2]`, and to powers with exponent
+in `[0, 1]` or the logarithm (with the usual positivity restrictions).
+
+### Citing files
+
+**Theorem 5.2**
+
+- `TNLean/Channel/Schwarz/SchurComplement.lean`
+- `TNLean/Channel/Schwarz/TwoVariable.lean`
+- `TNLean/Channel/Schwarz/TwoVariableUnconditional.lean`
+- `blueprint/src/chapter/ch05_schwarz_schur_complement.tex`
+- `docs/paper-gaps/schur_complement_tfae.tex`
+
+**Theorem 5.3**
+
+- `TNLean/Channel/Peripheral/ClosureFixedPointKraus.lean`
+- `TNLean/Channel/Schwarz/TwoVariable.lean`
+- `TNLean/Channel/Schwarz/TwoVariableEquality.lean`
+- `TNLean/Channel/Schwarz/TwoVariableUnconditional.lean`
+- `blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex`
+- `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`
+
+**Proposition 5.1**
+
+- `TNLean/Channel/Schwarz/PositiveOnAbelian.lean`
+- `TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean`
+- `TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean`
+- `TNLean/Channel/Schwarz/SchwarzNormal.lean`
+- `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`
+- `blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex`
+
+**Theorems 5.5 and 5.6**
+
+- `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`
+- `blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex`
+
+**Theorem 5.7**
+
+- `TNLean/Channel/Schwarz/MultiplicativeDomain.lean`
+- `TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean`
+- `blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex`
+
+**Theorems 5.10--5.13 and Corollary 5.2**
+
+- `TNLean/Analysis/LiebConcavity.lean`
+- `TNLean/Channel/Schwarz/OperatorConvexity.lean`
+- `TNLean/Channel/Schwarz/OperatorJensenAux.lean`
+- `TNLean/Channel/Schwarz/OperatorMonotone.lean`
+- `blueprint/src/chapter/ch18_operator_convexity.tex`
+- `blueprint/src/chapter/ch18_operator_convexity_schwarz_and_jensen.tex`
+- `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`
+
+**Theorem 5.15**
+
+- `TNLean/Analysis/LiebConcavity.lean`
+- `TNLean/Analysis/LiebSubBoundary.lean`
+- `blueprint/src/chapter/ch18_operator_convexity_lieb_and_resolvent.tex`
+- `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`
+
+**Theorem 5.17**
+
+- `TNLean/Analysis/OperatorConvexity.lean`
+
+**Example 5.3**
+
+- `TNLean/Channel/Schwarz/SchwarzNotCP.lean`
+- `blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex`
+- `blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_algebras.tex`
+- `docs/paper-gaps/wolf_lecture_notes_errata.tex`
+- `docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex`
+
+### Reproducibility
+
+The enumeration uses the same directories and exclusions as the Chapter 1
+audit, and also checks grouped citations such as “Theorems 5.10--5.13”. Each
+result was checked against
+`Notes/WolfNotePDF/ch05_operator_inequalities.pdf`; the line ranges above refer
+only to the searchable transcription and do not determine numbering.


### PR DESCRIPTION
## Summary

- verifies every live numbered Chapter 5 attribution against the archived printed chapter
- corrects the operator-Jensen citations formerly assigned to Theorem 5.1: convex powers use Theorem 5.11, concave powers use Theorem 5.13, and the logarithm uses Corollary 5.2(3)
- records printed and archived page numbers, transcription line ranges, verdicts, and citing files in the common audit
- documents the necessary unital restriction in the logarithm result at every public entry point

## Mathematical point

In the printed notes, Theorem 5.1 is Douglas' theorem and does not state an operator-Jensen inequality. Theorem 5.13 applies to operator-monotone functions on an interval beginning at zero with nonnegative value there, so it covers the concave powers but not the logarithm. The logarithm inequality is Corollary 5.2(3); its printed subunital form is false, and the formal theorem uses the necessary unital hypothesis recorded in `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.

## Mathematical-language rename

`IsPositiveMap.cor52_item3_log_of_subunital` is renamed to `IsPositiveMap.cor52_item3_log_of_unital`. The former name encoded the false subunital version of Wolf Corollary 5.2(3), whereas the theorem assumes unitality. No deprecated alias is retained because preserving the old name would preserve misleading mathematical terminology.

## Validation

- the changed Lean modules compile locally from cached Mathlib artifacts
- the live-source sweep finds no remaining Theorem 5.13 logarithm attribution or stale theorem name
- blueprint web rendering completes
- the reader-facing prose check and `git diff --check` pass
- no proof statement or proof body changes

Closes LionSR/QICLean#352.
