### PR TITLE
doc(Channel): verify zero-citation Wolf chapters

### DIFF
--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -473,7 +473,7 @@ audit. Each result was checked against
 `Notes/WolfNotePDF/ch07_semigroup_structure.pdf`; the line ranges above refer
 only to the searchable transcription and do not determine numbering.
 
-## Chapters 4 and 9--11: verified absence of live numbered citations
+## Chapters 4 and 9--11: no live numbered theorem-like citations
 
 No live numbered citation to a theorem-like result in Wolf Chapters 4, 9, 10,
 or 11 occurs in the directories examined here.
@@ -498,3 +498,6 @@ number of the form `4.n`, `9.n`, `10.n`, or `11.n`. It excludes
 `docs/audits/`, `docs/archive/`, `docs/reviews/`, `docs/slides/`, and
 `blueprint/comments/`. The Chapter 4 near matches were then checked for a
 nearby occurrence of `Wolf` and for the `Wolf2012Quantum` bibliography key.
+Definitions lie outside this result-numbering audit. In particular,
+`TNLean/Channel/Basic.lean` cites Wolf Definition 4.1; this is the sole live
+numbered Wolf citation from Chapter 4.

--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -472,3 +472,29 @@ The enumeration uses the same directories and exclusions as the Chapter 1
 audit. Each result was checked against
 `Notes/WolfNotePDF/ch07_semigroup_structure.pdf`; the line ranges above refer
 only to the searchable transcription and do not determine numbering.
+
+## Chapters 4 and 9--11: verified absence of live numbered citations
+
+No live numbered citation to a theorem-like result in Wolf Chapters 4, 9, 10,
+or 11 occurs in the directories examined here.
+
+The Chapter 4 search finds many unqualified numerical near matches. Inspection
+shows that they refer to other sources, principally the matrix-product density
+operator paper of Cirac, Pérez-García, Schuch, and Verstraete. Other matches
+refer to papers by De las Cuevas and coauthors or to internal blueprint labels.
+None is attributed to Wolf, and none uses the Wolf bibliography key.
+
+For Chapters 9--11, the general theorem-like-number search itself has no live
+match. Searches with the word `Wolf` on either side of the number, and searches
+requiring the `Wolf2012Quantum` bibliography key, also have no match for any of
+the four chapters.
+
+### Reproducibility
+
+The search covers `TNLean/`, `blueprint/src/`, and `docs/` for singular and
+plural forms of `Theorem`, `Proposition`, `Corollary`, `Lemma`, and `Example`,
+including abbreviated forms and either ordinary or nonbreaking spaces before a
+number of the form `4.n`, `9.n`, `10.n`, or `11.n`. It excludes
+`docs/audits/`, `docs/archive/`, `docs/reviews/`, `docs/slides/`, and
+`blueprint/comments/`. The Chapter 4 near matches were then checked for a
+nearby occurrence of `Wolf` and for the `Wolf2012Quantum` bibliography key.


### PR DESCRIPTION
## Summary

- verifies that no live numbered Wolf citation occurs for Chapters 4 or 9 through 11
- distinguishes the numerous Chapter 4 near matches belonging to other cited papers
- records the citation variants, directories, and exclusions used to establish the zero result

## Validation

- direct Wolf-name searches have zero matches for all four chapters
- Wolf bibliography-key searches have zero matches for all four chapters
- the reader-facing prose check and git diff --check pass

Rebased directly onto `main` after the Chapter 7 audit merged in LionSR/TNLean#6770. The pull-request delta is 29 lines in the shared audit.

Closes LionSR/QICLean#355