### PR TITLE
fix(blueprint): state component-map hypotheses exactly

### DIFF
--- a/blueprint/src/chapter/ch23_algebraic_ft_injective_chains_and_product_algebra.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_injective_chains_and_product_algebra.tex
@@ -326,8 +326,8 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
 
 \subsection{Block permutation algebra}
 
-The block ideals used below are those of
-Definition~\ref{def:block_ideal}.
+The $k$-th block ideal consists of the tuples that vanish outside the
+$k$-th coordinate, as in Definition~\ref{def:block_ideal}.
 
 \begin{theorem}[Each block ideal is an atom]\label{thm:block_ideal_atom}
     \lean{TwoSidedIdeal.isAtom_blockIdeal}

--- a/blueprint/src/chapter/ch23_algebraic_ft_injective_chains_and_product_algebra.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_injective_chains_and_product_algebra.tex
@@ -326,18 +326,8 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
 
 \subsection{Block permutation algebra}
 
-\begin{definition}[Block ideal]\label{def:block_ideal}
-    \lean{TwoSidedIdeal.blockIdeal}
-    \leanok
-    Let $\{R_k\}_{k=0}^{r-1}$ be simple rings.
-    The $k$-th \emph{block ideal} in $\prod_{j=0}^{r-1} R_j$ is
-    \begin{align}
-        I_k
-        &:=\left\{x \in \prod_{j=0}^{r-1} R_j :
-            x_j = 0 \text{ for } j \neq k\right\}.
-        \notag
-    \end{align}
-\end{definition}
+The block ideals used below are those of
+Definition~\ref{def:block_ideal}.
 
 \begin{theorem}[Each block ideal is an atom]\label{thm:block_ideal_atom}
     \lean{TwoSidedIdeal.isAtom_blockIdeal}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
@@ -161,9 +161,23 @@
     Schwarz condition to exclude transposition.
 \end{proof}
 
+\begin{definition}[Block ideal]\label{def:block_ideal}
+    \lean{TwoSidedIdeal.blockIdeal}
+    \leanok
+    Let $\{R_i\}_{i\in I}$ be a finite family of simple rings. The $i$-th
+    \emph{block ideal} in $\prod_{k\in I}R_k$ is
+    \begin{align}
+        I_i
+        &:=\left\{x \in \prod_{k\in I}R_k :
+            x_k = 0 \text{ for } k \neq i\right\}.
+        \notag
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Summand matching and dimension preservation]\label{thm:dim_preserved}
     \lean{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix}
     \leanok
+    \uses{def:block_ideal}
     Let $\{D_i\}_{i\in I}$ and $\{E_j\}_{j\in J}$ be positive integers.
     A star-algebra isomorphism
     \begin{align}
@@ -187,19 +201,6 @@
     $D_i=E_{\sigma(i)}$.
 \end{proof}
 
-\begin{definition}[Block ideal]\label{def:block_ideal}
-    \lean{TwoSidedIdeal.blockIdeal}
-    \leanok
-    Let $\{R_i\}_{i\in I}$ be a finite family of simple rings. The $i$-th
-    \emph{block ideal} in $\prod_{k\in I}R_k$ is
-    \begin{align}
-        I_i
-        &:=\left\{x \in \prod_{k\in I}R_k :
-            x_k = 0 \text{ for } k \neq i\right\}.
-        \notag
-    \end{align}
-\end{definition}
-
 \begin{theorem}[Paired component maps are bijections]
     \label{thm:component_map_bijective}
     \lean{TwoSidedIdeal.mem_blockIdeal_iff}
@@ -213,7 +214,8 @@
     \leanok
     \uses{def:block_ideal}
     Let $I$ and $J$ be finite, and let $\{R_i\}_{i\in I}$ and
-    $\{S_j\}_{j\in J}$ be families of simple rings. Suppose that
+    $\{S_j\}_{j\in J}$ be families of simple rings. Write $I_i$ and $J_j$ for
+    the corresponding block ideals. Suppose that
     $T : \prod_{i\in I}R_i \to \prod_{j\in J}S_j$ is a ring isomorphism and
     that an equivalence $\sigma:I\simeq J$ satisfies
     $T(I_i)=J_{\sigma(i)}$ for every $i\in I$. Then, for each $i\in I$, the map

--- a/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
@@ -187,6 +187,19 @@
     $D_i=E_{\sigma(i)}$.
 \end{proof}
 
+\begin{definition}[Block ideal]\label{def:block_ideal}
+    \lean{TwoSidedIdeal.blockIdeal}
+    \leanok
+    Let $\{R_i\}_{i\in I}$ be a finite family of simple rings. The $i$-th
+    \emph{block ideal} in $\prod_{k\in I}R_k$ is
+    \begin{align}
+        I_i
+        &:=\left\{x \in \prod_{k\in I}R_k :
+            x_k = 0 \text{ for } k \neq i\right\}.
+        \notag
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Paired component maps are bijections]
     \label{thm:component_map_bijective}
     \lean{TwoSidedIdeal.mem_blockIdeal_iff}
@@ -198,9 +211,12 @@
     \lean{TwoSidedIdeal.blockComponentMap_surjective}
     \lean{TwoSidedIdeal.blockComponentMap_bijective}
     \leanok
-    Let $T : \prod_{i\in I}R_i \to \prod_{j\in J}S_j$ be a ring isomorphism,
-    and suppose that an equivalence $\sigma:I\simeq J$ matches the block ideals
-    in both directions under $T$ and $T^{-1}$. Then, for each $i\in I$, the map
+    \uses{def:block_ideal}
+    Let $I$ and $J$ be finite, and let $\{R_i\}_{i\in I}$ and
+    $\{S_j\}_{j\in J}$ be families of simple rings. Suppose that
+    $T : \prod_{i\in I}R_i \to \prod_{j\in J}S_j$ is a ring isomorphism and
+    that an equivalence $\sigma:I\simeq J$ satisfies
+    $T(I_i)=J_{\sigma(i)}$ for every $i\in I$. Then, for each $i\in I$, the map
     \begin{align}
         x
         &\longmapsto
@@ -211,10 +227,10 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    The matching hypotheses force elements supported in the $i$-th block to
+    The matching hypothesis forces elements supported in the $i$-th block to
     remain supported in the $\sigma(i)$-th block. Injectivity follows from
-    injectivity of $T$. For surjectivity, apply the same argument to $T^{-1}$
-    and the inverse matching.
+    injectivity of $T$. The forward block equalities and bijectivity of $T$
+    give the corresponding equalities for $T^{-1}$, which yield surjectivity.
 \end{proof}
 
 \begin{theorem}[Paired component maps for products of matrix algebras]


### PR DESCRIPTION
## Summary

- state the paired component-map theorem with the finite simple-ring hypotheses used by Lean;
- assume only forward block-ideal matching and identify inverse matching as a consequence;
- move the block-ideal definition into the included channel-asymptotics chapter and record the direct dependency.

PR #6764 fixed the web reference by moving the component-map items into the included chapter. This follow-up fixes the remaining statement and dependency mismatch found during the exact-head audit after that PR merged.

## Validation

- `python3 scripts/qic_blueprint_boundary_report.py` (1,463 QIC items, 3,115 TN items, 0 mixed items; this patch adds no reverse edge, while the current post-#6756 base has 7 temporary QIC-to-TN edges tracked by the remaining namespace-split stack)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (8,075/8,075 entries)
- `python3 scripts/test_check_tenkz_dispositions.py`
- `python3 scripts/check_tenkz_dispositions.py`
- `leanblueprint web` and direct inspection of the rendered component-map links, with no unresolved reference
- two `lualatex` passes with `TEXINPUTS='../../tex/tenkz//:'`, with no undefined references
- `git diff --check`

Advances #6622 and #6560.

