### PR TITLE
doc(docs): add a getting-started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ the fundamental-theorem part that is being released first. The generated
 [API documentation](https://lionsr.github.io/TNLean/docs/) covers every
 declaration in the Lean source.
 
+New to the repository? [`docs/getting_started.md`](docs/getting_started.md)
+walks through building the library, finding your way around the source, and
+making a first contribution.
+
 The agent-driven workflow used to build this library is described in the
 companion paper: S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization
 of Tensor Network Theory*,

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ source-faithfulness requirements.
 - `ci-automation.md`
 - `counterexamples.md`
 - `deploy.md`
+- `getting_started.md`
 - `paper-gaps/`
 - `pr_review_management.md`
 - `prose_style.md`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,255 @@
+# Getting started
+
+This page is the onboarding path for a mathematician or Lean user arriving at
+TNLean for the first time. It gets the library building, orients you in the
+source tree, and points to the conventions you need before opening a pull
+request. It complements `CLAUDE.md`, which is written for AI coding agents;
+this page is written for you.
+
+Before writing code, read
+[`.github/CONTRIBUTION_POLICY.md`](../.github/CONTRIBUTION_POLICY.md). Code
+contributions are scoped to an assigned issue and require working knowledge of
+quantum information theory and tensor networks — issues and corrections are
+welcome from anyone, but unsolicited pull requests are not reviewed.
+
+## 1. What you need
+
+- **elan**, the Lean version manager. Once it is installed, running any Lean
+  command inside the repository installs the toolchain pinned in
+  `lean-toolchain` (`leanprover/lean4:v4.34.0-rc1`) automatically — you do not
+  need to install Lean yourself or match a version by hand.
+- **VS Code** with the Lean 4 extension. This is what the project is
+  developed with; it gives you the interactive goal view, hover information,
+  and jump-to-definition you need to read and write proofs. Other editors
+  with an LSP client (Emacs, Neovim, Helix) can also work with Lean's
+  language server, but the extension is the path most contributors use and
+  the one these instructions assume.
+- **git**.
+- **About 10 GB of free disk**, mostly for the downloaded Mathlib build
+  artifacts and the `.lake` directory; a full local build with cache is
+  closer to 20 GB.
+
+## 2. Build the library
+
+Clone the repository and fetch the prebuilt Mathlib artifacts before doing
+anything else:
+
+```bash
+git clone https://github.com/LionSR/TNLean.git
+cd TNLean
+
+# Download pre-built Mathlib artifacts. Do this before any build.
+lake exe cache get
+```
+
+> **Why this order matters.** `lake exe cache get` downloads Mathlib's
+> compiled `.olean` files instead of compiling Mathlib from source. If you
+> skip it and run `lake build` directly, Lake will not find prebuilt
+> Mathlib artifacts and will compile the entire Mathlib library locally —
+> a build that takes hours instead of minutes. Always run `cache get`
+> first, and again after any Lean/Mathlib toolchain update.
+
+Then build:
+
+```bash
+lake build
+```
+
+What to expect: Mathlib itself comes from the cache and does not recompile.
+TNLean's own several-hundred modules are not distributed as a cache and
+compile locally; a full build takes a while the first time (subsequent
+builds only recompile what you changed). `lake build` with no arguments
+builds the default target, which is the whole `TNLean` library; you can also
+build just the library with `lake build TNLean`, or type-check a single file
+without building its downstream dependents:
+
+```bash
+lake env lean TNLean/MPS/FundamentalTheorem/Basic.lean
+```
+
+Once the build succeeds, open the repository folder in VS Code
+(`code .`). The Lean 4 extension will start the language server; open any
+`.lean` file, click into a proof, and the goal panel should show you the
+proof state at the cursor. If it does not, check the extension's output panel
+— a stale or partial build is the usual cause (see
+[Troubleshooting](#6-troubleshooting)).
+
+## 3. Find your way around
+
+### The layer map
+
+The source under `TNLean/` is organized into numbered conceptual layers, each
+importable only from the ones before it. The full table, including the finer
+sublayers, is in
+[`docs/import_structure.md`](import_structure.md); in outline:
+
+| Layer | Directories | Content |
+|---|---|---|
+| 0 – 1 | `Algebra`, `Analysis`, `Topology` | Matrix algebra, trace pairings, Gram matrices, convergence and fixed-point results (including the Brouwer fixed-point theorem). |
+| 2 | `Channel`, `Entropy`, `Kraus` | Quantum channels (Choi, Kraus, Stinespring representations), von Neumann entropy, and word evaluation / injectivity / normality for finite Kraus families. |
+| 2b – 2c | `Channel/Schwarz`, `Channel/FixedPoint`, `Channel/Irreducible`, `Channel/Peripheral`, `Channel/Semigroup`, `QPF`, `Spectral` | Kadison–Schwarz inequalities, quantum Perron–Frobenius theory, peripheral spectra, quantum Markov semigroups. |
+| 3 | `MPS/Core`, `MPS/Chain`, `MPS/Overlap` | Matrix product state tensors, blocking, transfer maps, overlap matrices. |
+| 3b | `MPS/MPDO` | Matrix-product density operator foundations. |
+| 4 | `MPS/FundamentalTheorem`, `MPS/Symmetry` | The single-block fundamental theorem, gauge equivalence, on-site and virtual symmetries. |
+| 5 | `MPS/BNT`, `MPS/CanonicalForm`, `MPS/Irreducible`, `MPS/Periodic`, `MPS/Structure` | Multi-block canonical forms and the general fundamental theorem. |
+| 5b | `MPS/RFP` | Renormalization fixed points. |
+| 6 | `Wielandt` | The quantum Wielandt inequality and primitivity. |
+
+`PiAlgebra` carries algebraic variants of the fundamental theorem, `PEPS` the
+two-dimensional generalization, and `MPS/ParentHamiltonian`,
+`MPS/Examples` the parent-Hamiltonian and worked-example material. Everything
+lives under a single import surface, `TNLean.lean`, which is generated by
+`scripts/generate_import_aggregators.py` — never edit it or the directory
+aggregators by hand.
+
+### Key definitions
+
+A handful of names recur throughout the library and are worth knowing before
+you start reading:
+
+| Name | What it is | Defined in |
+|---|---|---|
+| `MPSTensor d D` | A `Fin d`-indexed family of `D × D` complex matrices — the tensor `A^i` of a matrix product state. | `TNLean/Kraus/Word.lean` |
+| `evalWord` | The matrix product `A_{i_1} A_{i_2} \cdots A_{i_n}` along a word of physical indices. | `TNLean/Kraus/Word.lean` |
+| `IsInjective` | The matrices of a tensor span the full matrix algebra. | `TNLean/Kraus/Injectivity.lean` |
+| `IsNormal` | The tensor becomes injective after blocking sites (eventual full Kraus rank). | `TNLean/Kraus/Injectivity.lean` |
+| `transferMap` | The completely positive map $E_A(X) = \sum_i A_i X A_i^\dagger$. | `TNLean/MPS/Core/Transfer.lean` |
+| `SameMPV` / `GaugeEquiv` | Two tensors generate the same states at every system size / are related by conjugation `B i = X * A i * X⁻¹`. | `TNLean/MPS/Defs.lean` |
+| `fundamentalTheorem_singleBlock` | The single-block fundamental theorem: injective + same states implies gauge equivalent. | `TNLean/MPS/FundamentalTheorem/Basic.lean` |
+
+For anything not in this short list — what a predicate means, which source it
+comes from, and which bridges between similarly named predicates are
+sanctioned — check [`docs/glossary.md`](glossary.md) before assuming two
+names are interchangeable; the library deliberately keeps several
+source-faithful formulations of related ideas that are not aliases of one
+another.
+
+### The blueprint and the generated documentation
+
+The [blueprint](https://lionsr.github.io/TNLean/blueprint/) is the
+mathematical map of the library: it states every definition and theorem in
+ordinary mathematical language and links each one to its Lean declaration.
+Read it alongside the source rather than instead of it. It is also available
+as a [full PDF](https://lionsr.github.io/TNLean/blueprint.pdf) and, for the
+released fundamental-theorem material specifically, a
+[separate PDF](https://lionsr.github.io/TNLean/blueprint-ch01-12.pdf). The
+generated [API documentation](https://lionsr.github.io/TNLean/docs/) covers
+every declaration in the Lean source with signatures and docstrings, and is
+the fastest way to look up a lemma by name.
+
+## 4. A first reading path
+
+If your goal is to understand the fundamental theorem of matrix product
+states, this is a concrete path through the source, in reading order,
+alongside the corresponding blueprint chapters:
+
+1. `TNLean/Kraus/Word.lean` — `MPSTensor`, `evalWord`. The basic objects: a
+   tensor is a family of matrices, and a word evaluates to a matrix product.
+2. `TNLean/MPS/Defs.lean` — `mpv` (the matrix-product-vector coefficient),
+   `SameMPV`, `GaugeEquiv`. What it means for two tensors to generate the
+   same states, and what a gauge transformation is. Read alongside
+   `blueprint/src/chapter/ch02_mps.tex`.
+3. `TNLean/Kraus/Injectivity.lean` — `IsInjective`, `IsNormal`. The spanning
+   condition the single-block theorem needs.
+4. `TNLean/MPS/Structure/LinearExtension.lean` and
+   `TNLean/Algebra/SkolemNoether.lean` — the two algebraic facts the proof
+   assembles: the unique multiplicative linear extension taking `A` to `B`,
+   and that every automorphism of a matrix algebra is inner.
+5. `TNLean/MPS/FundamentalTheorem/Basic.lean` — `fundamentalTheorem_singleBlock`
+   itself, built from the previous two files. Read alongside
+   `blueprint/src/chapter/ch03_single.tex`, "The Single-Block Fundamental
+   Theorem".
+
+From there, `blueprint/src/chapter/ch09_canonical.tex` through
+`ch11_fundamental_theorem_core.tex` and the corresponding
+`TNLean/MPS/CanonicalForm/`, `TNLean/MPS/BNT/` source cover the general,
+multi-block case.
+
+## 5. Make your first change
+
+Before opening a pull request, skim the conventions below; each links to the
+document that spells it out in full.
+
+**Naming.** Definitions are `camelCase`, predicates are named `IsFoo`,
+theorems and lemmas are `snake_case`, and files are `CamelCase.lean`. The
+full capitalization rules and the symbol-to-name dictionary (how to spell
+`⊗`, `≤`, `⁻¹`, and so on in an identifier) are in
+[`docs/MATHLIB_naming.md`](MATHLIB_naming.md).
+
+**Style.** Line length, variable-letter conventions (`A`, `B` for MPS
+tensors, `E` for channels, `d`/`D` for physical/bond dimension), and tactic
+formatting follow [`docs/MATHLIB_style.md`](MATHLIB_style.md), with a small
+number of project additions collected in
+[`docs/CONTRIBUTING.md`](CONTRIBUTING.md#6-lean-code-style).
+
+**Docstrings.** Every new `def`, `structure`, `class`, and significant
+`theorem` needs a docstring, and every file needs a module header with a
+`## Main definitions` list and a `## References` section citing the source
+paper. The Markdown and LaTeX conventions for writing them are in
+[`docs/MATHLIB_doc.md`](MATHLIB_doc.md).
+
+**Proof integrity.** Finished work must not contain `sorry`, `admit`, or a
+new `axiom`; a small set of other patterns (`native_decide`, unsafe casts,
+disabled timeouts) are also blockers or warnings. The complete list, and what
+counts as an acceptable exception, is in
+[`docs/PROOF_INTEGRITY.md`](PROOF_INTEGRITY.md).
+
+**Prose.** Docstrings, blueprint prose, issues, and pull request text should
+read as mathematics, not software documentation: no Lean identifiers inside
+blueprint prose, no software-engineering metaphors ("pipeline", "wrapper",
+"boilerplate"), and none of the stock filler phrasing that AI writing tends
+to reach for. The banned terms and their replacements are in
+[`docs/prose_style.md`](prose_style.md).
+
+**Local checks.** Before pushing, run what CI will run:
+
+```bash
+# Sorrys and axioms in the files you touched.
+rg -n "sorry|axiom" TNLean/Path/To/File.lean || true
+
+# Text-based style linter (whitespace, line endings, module naming).
+lake exe lint_style
+
+# Reader-facing prose patterns (tracker/label shorthand in docstrings, blueprint, etc.).
+python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
+
+# If you touched the blueprint, after a successful `lake build`:
+cd blueprint && leanblueprint checkdecls
+```
+
+**PR title.** `type(scope): short description`, where `type` is one of
+`feat`, `fix`, `refactor`, `doc`, `style`, `ci`, `chore`, and `scope` is a
+shortened module path with the `TNLean/` prefix dropped (`MPS/Symmetry`,
+`Channel`, `blueprint+docgen`, …). The full convention, including the
+required PR body sections (Motivation / Description / Testing), is in
+[`docs/CONTRIBUTING.md`](CONTRIBUTING.md#1-pull-request-conventions).
+
+**What CI runs.** Opening a pull request against a Lean or blueprint file
+triggers a build with the Mathlib cache, the text-based style linter, and a
+check that every `\lean{}` tag in the blueprint resolves
+(`leanblueprint checkdecls`); touching blueprint sources additionally runs
+the reader-facing prose check and a LaTeX lint. A separate automated review
+pass then checks the diff against the Mathlib style guide and the proof
+integrity rules above. The full list of workflows and what each one checks
+is in [`docs/CONTRIBUTING.md`](CONTRIBUTING.md#7-ci--automation).
+
+## 6. Troubleshooting
+
+**A `lake build` that looks like it is compiling all of Mathlib.** You
+skipped `lake exe cache get`, or ran it before a toolchain/Mathlib bump
+invalidated the cache. Stop the build, run `lake exe cache get`, and build
+again.
+
+**Lean version mismatch.** elan reads `lean-toolchain` in the repository
+root and switches automatically; you should not need to install or select a
+Lean version by hand. If VS Code reports the wrong version, restart the Lean
+server (`Lean 4: Restart Server` in the command palette) after confirming
+`lean --version` at the command line matches the pinned toolchain.
+
+**Stale build products after switching branches or pulling.** Lake usually
+recompiles what changed, but a corrupted or half-written `.lake/build` can
+produce confusing errors. `lake clean` removes local build output (Mathlib's
+cached artifacts are untouched); rerun `lake build` afterward.
+
+**Something else.** Open an issue on the
+[GitHub issue tracker](https://github.com/LionSR/TNLean/issues).


### PR DESCRIPTION
### Motivation
- The repository has a polished README and deep convention docs under `docs/`, but no single document that walks a newcomer from zero to a first contribution.
- This is human-contributor onboarding; it complements the agent-facing `CLAUDE.md` rather than replacing it.

### Description
- Add `docs/getting_started.md`: environment prerequisites, the Mathlib-cache build trap (`lake exe cache get` before any build), the conceptual layer map and a key-definitions table, a concrete first reading path through the single-block fundamental theorem alongside its blueprint chapters, the naming/style/docstring/proof-integrity/prose conventions with pointers, the local checks and PR-title convention, a one-paragraph CI tour, and a troubleshooting section.
- Link the new guide from `README.md` near the blueprint/docs paragraph.
- Add an entry for it in `docs/README.md`'s TNLean-owned policy index.
- Every command, file path, and declaration name referenced was checked against `main` (`git grep`, reading the cited files, and the CI workflow definitions); no new external URLs were introduced beyond the ones already published in `README.md`.

### Testing
- Documentation-only change; no `.lean` files touched, no build run.
- Verified all internal links resolve (`docs/import_structure.md`, `docs/glossary.md`, `docs/MATHLIB_naming.md`, `docs/MATHLIB_style.md`, `docs/MATHLIB_doc.md`, `docs/PROOF_INTEGRITY.md`, `docs/prose_style.md`, `docs/CONTRIBUTING.md` anchors, `.github/CONTRIBUTION_POLICY.md`).
- Verified `MPSTensor`, `evalWord`, `IsInjective`, `IsNormal`, `transferMap`, `SameMPV`, `GaugeEquiv`, `fundamentalTheorem_singleBlock` all still exist at the cited paths on `main` via `git grep`.
- Confirmed the reader-facing prose checker (`scripts/check_reader_facing_prose.py`) only scans `.lean` and `blueprint/src/**/*.tex`, so this Markdown-only change is out of its scope.

---
Addresses none (documentation improvement, not tied to an issue)