### PR TITLE
doc(ci): distinguish elaboration from linter checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,9 @@ Examples:
 
 ### Testing
 <!-- What was verified and how. -->
-<!-- Examples: `lake env lean TNLean/Foo/Bar.lean`, `lake build TNLean`,
-     `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`. -->
+<!-- Examples: `lake build TNLean.Foo.Bar`, `lake build TNLean`,
+     `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`. A bare `lake env lean`
+     is a fast elaboration check that does not apply the package leanOptions. -->
 
 -
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ cd blueprint && leanblueprint pdf
 
 - `relaxedAutoImplicit = false` — strict implicit arguments, no auto-implicit
 - `pp.unicode.fun = true` — pretty-prints `fun a ↦ b`
+- `weak.linter.mathlibStandardSet = true` — enables Mathlib's standard linters
+  during `lake build`; the `weak.` value is a default that source options may
+  override
 - `maxSynthPendingDepth = 3` — typeclass synthesis depth limit
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ lake exe cache get
 
 # Only after the cache fetch succeeds:
 lake build
+# Linter-bearing verification of one module (uses the package leanOptions):
+lake build TNLean.Path.To.File
+# Optional fast elaboration only; this does not use the package leanOptions:
 lake env lean TNLean/Path/To/File.lean
 ```
 # Check for sorrys/axioms in changed files

--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ lake build
 # Equivalently, build the public Lean library target.
 lake build TNLean
 
-# Check a single file during development.
+# Verify one module with the package Lean options and Mathlib standard linters.
+lake build TNLean.MPS.FundamentalTheorem.Basic
+
+# Optional fast elaboration only; this does not apply the package Lean options.
 lake env lean TNLean/MPS/FundamentalTheorem/Basic.lean
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,8 +64,11 @@ Every PR body must contain three sections:
 
 ### Testing
 - What was verified and how.
-- Examples: `lake env lean TNLean/Foo/Bar.lean`, `lake build TNLean`,
-  `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`.
+- Examples: `lake build TNLean.Foo.Bar`, `lake build TNLean`,
+  `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`. A bare
+  `lake env lean TNLean/Foo/Bar.lean` is a fast elaboration check, but it does
+  not apply the package `leanOptions` and therefore does not run the Mathlib
+  standard linter set.
 
 ---
 Addresses #N

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -42,7 +42,9 @@ At an identical commit, run the desired `lake build` or `lake env lean`
 command and Lake will reuse the full build. After a cross-commit seed, run
 `lake build` first so TNLean is rebuilt against the seeded dependencies. For a
 targeted check that applies the package `leanOptions`, including the Mathlib
-standard linter set, run `lake build TNLean.Path.To.File`. A bare
+standard linter set, run `lake build TNLean.Path.To.File`. Linter diagnostics
+appear only when Lake re-elaborates the module; an unchanged, already-built
+module produces no new diagnostics. A bare
 `lake env lean TNLean/Path/To/File.lean` remains useful for fast elaboration,
 but it does not apply those package options and is not a linter-bearing local
 verification.

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -40,8 +40,12 @@ TNLean `.olean` files whose declarations no longer match the target source.
 
 At an identical commit, run the desired `lake build` or `lake env lean`
 command and Lake will reuse the full build. After a cross-commit seed, run
-`lake build` first so TNLean is rebuilt against the seeded dependencies; only
-then run targeted `lake env lean` checks.
+`lake build` first so TNLean is rebuilt against the seeded dependencies. For a
+targeted check that applies the package `leanOptions`, including the Mathlib
+standard linter set, run `lake build TNLean.Path.To.File`. A bare
+`lake env lean TNLean/Path/To/File.lean` remains useful for fast elaboration,
+but it does not apply those package options and is not a linter-bearing local
+verification.
 
 ## Sort build timings
 


### PR DESCRIPTION
## Summary

- Documents `lake build TNLean.Path.To.File` as the single-module check that applies the package `leanOptions`, including the Mathlib standard linter set.
- Retains bare `lake env lean TNLean/Path/To/File.lean` as a fast elaboration check and states its limitation beside each recommendation.
- Applies the distinction consistently in the assistant instructions, README, pull-request template, contribution guide, and cache guide. The newly added getting-started guide is handled by #6787.

## Testing

- `lake build` completed successfully: 10,259 jobs.
- A temporary uncommitted theorem with an unused `Fintype` hypothesis was silent under `lake env lean TNLean/LinterProbe.lean` and produced the expected `linter.unusedFintypeInType` warning under `lake build TNLean.LinterProbe`; the probe was then removed.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff origin/main...HEAD --check`

Closes #6340