### PR TITLE
fix(ci): restrict ownership scans to import preambles

### DIFF
--- a/scripts/generate_import_aggregators.py
+++ b/scripts/generate_import_aggregators.py
@@ -125,9 +125,15 @@ def source_imported_modules(path: Path) -> set[str]:
     if error is not None:
         return set()
     modules: set[str] = set()
+    header_seen = False
     for line in uncommented.splitlines():
         command = line.strip()
         if not command:
+            continue
+        if command in {"prelude", "module"}:
+            if header_seen or modules:
+                return set()
+            header_seen = True
             continue
         match = IMPORT_COMMAND_RE.fullmatch(command)
         if match is not None:

--- a/scripts/generate_import_aggregators.py
+++ b/scripts/generate_import_aggregators.py
@@ -18,6 +18,7 @@ import re
 import sys
 
 from lean_import_syntax import (
+    IMPORT_COMMAND_RE,
     MODULE_NAME,
     pure_import_modules,
     strip_lean_comments,
@@ -128,15 +129,14 @@ def source_imported_modules(path: Path) -> set[str]:
         command = line.strip()
         if not command:
             continue
-        tokens = command.split()
-        if tokens[0] != "import":
-            break
-        imported = tokens[1:]
-        if not imported or any(
-            re.fullmatch(MODULE_NAME, module) is None for module in imported
-        ):
+        match = IMPORT_COMMAND_RE.fullmatch(command)
+        if match is not None:
+            modules.add(match.group(1))
+        elif command.split(maxsplit=1)[0] == "import":
+            # A malformed import makes the ownership path unverifiable.
             return set()
-        modules.update(imported)
+        else:
+            break
     return modules
 
 

--- a/scripts/generate_import_aggregators.py
+++ b/scripts/generate_import_aggregators.py
@@ -18,7 +18,6 @@ import re
 import sys
 
 from lean_import_syntax import (
-    IMPORT_COMMAND_RE,
     MODULE_NAME,
     pure_import_modules,
     strip_lean_comments,
@@ -116,7 +115,7 @@ def delegated_modules(aggregator: str, direct_imports: set[str]) -> set[str]:
 
 
 def source_imported_modules(path: Path) -> set[str]:
-    """Return the one-line imports in an arbitrary Lean source file."""
+    """Return imports from the leading command preamble of a Lean source file."""
     try:
         source = path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -126,9 +125,18 @@ def source_imported_modules(path: Path) -> set[str]:
         return set()
     modules: set[str] = set()
     for line in uncommented.splitlines():
-        match = IMPORT_COMMAND_RE.fullmatch(line.strip())
-        if match is not None:
-            modules.add(match.group(1))
+        command = line.strip()
+        if not command:
+            continue
+        tokens = command.split()
+        if tokens[0] != "import":
+            break
+        imported = tokens[1:]
+        if not imported or any(
+            re.fullmatch(MODULE_NAME, module) is None for module in imported
+        ):
+            return set()
+        modules.update(imported)
     return modules
 
 

--- a/scripts/generate_import_aggregators.py
+++ b/scripts/generate_import_aggregators.py
@@ -18,7 +18,6 @@ import re
 import sys
 
 from lean_import_syntax import (
-    IMPORT_COMMAND_RE,
     MODULE_NAME,
     pure_import_modules,
     strip_lean_comments,
@@ -30,6 +29,9 @@ GENERATED_MARKER_RE = re.compile(
 )
 GENERATED_PROVENANCE_RE = re.compile(
     rf"(?m)^-- Generated aggregator module: ({MODULE_NAME})$"
+)
+SOURCE_IMPORT_COMMAND_RE = re.compile(
+    rf"(?:(?:public\s+)?(?:meta\s+)?)import\s+(?:all\s+)?({MODULE_NAME})"
 )
 GENERATED_NOTICE = (
     "/-\n"
@@ -125,20 +127,26 @@ def source_imported_modules(path: Path) -> set[str]:
     if error is not None:
         return set()
     modules: set[str] = set()
-    header_seen = False
+    module_header_seen = False
+    prelude_seen = False
     for line in uncommented.splitlines():
         command = line.strip()
         if not command:
             continue
-        if command in {"prelude", "module"}:
-            if header_seen or modules:
+        if command == "module":
+            if module_header_seen or prelude_seen or modules:
                 return set()
-            header_seen = True
+            module_header_seen = True
             continue
-        match = IMPORT_COMMAND_RE.fullmatch(command)
+        if command == "prelude":
+            if prelude_seen or modules:
+                return set()
+            prelude_seen = True
+            continue
+        match = SOURCE_IMPORT_COMMAND_RE.fullmatch(command)
         if match is not None:
             modules.add(match.group(1))
-        elif command.split(maxsplit=1)[0] == "import":
+        elif "import" in command.split():
             # A malformed import makes the ownership path unverifiable.
             return set()
         else:

--- a/scripts/test_generate_import_aggregators.py
+++ b/scripts/test_generate_import_aggregators.py
@@ -233,20 +233,17 @@ class ImportAggregatorGeneratorTests(unittest.TestCase):
             for target in targets:
                 self.assertIn(target, missing)
 
-    def test_source_imported_modules_accepts_multiple_modules_per_line(self) -> None:
+    def test_source_imported_modules_rejects_malformed_import_preamble(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             source = self.write(
                 Path(temporary_directory),
                 "Owner.lean",
-                "import TNLean.First TNLean.Second\n"
-                "import TNLean.Third\n\n"
+                "import TNLean.First\n"
+                "import TNLean.Second TNLean.Third\n\n"
                 "def witness := 1\n",
             )
 
-            self.assertEqual(
-                GENERATOR.source_imported_modules(source),
-                {"TNLean.First", "TNLean.Second", "TNLean.Third"},
-            )
+            self.assertEqual(GENERATOR.source_imported_modules(source), set())
 
     def test_source_imported_modules_stops_before_import_shaped_text(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/test_generate_import_aggregators.py
+++ b/scripts/test_generate_import_aggregators.py
@@ -246,7 +246,7 @@ class ImportAggregatorGeneratorTests(unittest.TestCase):
             self.assertEqual(GENERATOR.source_imported_modules(source), set())
 
     def test_source_imported_modules_accepts_lean_header_before_imports(self) -> None:
-        for header in ("prelude", "module"):
+        for header in ("prelude", "module", "module\nprelude"):
             with self.subTest(header=header):
                 with tempfile.TemporaryDirectory() as temporary_directory:
                     source = self.write(
@@ -259,6 +259,32 @@ class ImportAggregatorGeneratorTests(unittest.TestCase):
                         GENERATOR.source_imported_modules(source),
                         {"TNLean.Real"},
                     )
+
+    def test_source_imported_modules_accepts_import_modifiers(self) -> None:
+        commands = (
+            "import TNLean.Ordinary",
+            "public import TNLean.Public",
+            "meta import TNLean.Meta",
+            "public meta import TNLean.PublicMeta",
+            "import all TNLean.All",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = self.write(
+                Path(temporary_directory),
+                "Owner.lean",
+                "\n".join(commands) + "\n\ndef witness := 1\n",
+            )
+
+            self.assertEqual(
+                GENERATOR.source_imported_modules(source),
+                {
+                    "TNLean.All",
+                    "TNLean.Meta",
+                    "TNLean.Ordinary",
+                    "TNLean.Public",
+                    "TNLean.PublicMeta",
+                },
+            )
 
     def test_source_imported_modules_stops_before_import_shaped_text(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/test_generate_import_aggregators.py
+++ b/scripts/test_generate_import_aggregators.py
@@ -233,6 +233,37 @@ class ImportAggregatorGeneratorTests(unittest.TestCase):
             for target in targets:
                 self.assertIn(target, missing)
 
+    def test_source_imported_modules_accepts_multiple_modules_per_line(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = self.write(
+                Path(temporary_directory),
+                "Owner.lean",
+                "import TNLean.First TNLean.Second\n"
+                "import TNLean.Third\n\n"
+                "def witness := 1\n",
+            )
+
+            self.assertEqual(
+                GENERATOR.source_imported_modules(source),
+                {"TNLean.First", "TNLean.Second", "TNLean.Third"},
+            )
+
+    def test_source_imported_modules_stops_before_import_shaped_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = self.write(
+                Path(temporary_directory),
+                "Owner.lean",
+                "import TNLean.Real\n\n"
+                "def quotedSource := \"\"\"\n"
+                "import TNLean.Inert\n"
+                "\"\"\"\n",
+            )
+
+            self.assertEqual(
+                GENERATOR.source_imported_modules(source),
+                {"TNLean.Real"},
+            )
+
     def test_check_rejects_omitted_import_despite_incidental_reachability(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/scripts/test_generate_import_aggregators.py
+++ b/scripts/test_generate_import_aggregators.py
@@ -245,6 +245,21 @@ class ImportAggregatorGeneratorTests(unittest.TestCase):
 
             self.assertEqual(GENERATOR.source_imported_modules(source), set())
 
+    def test_source_imported_modules_accepts_lean_header_before_imports(self) -> None:
+        for header in ("prelude", "module"):
+            with self.subTest(header=header):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    source = self.write(
+                        Path(temporary_directory),
+                        "Owner.lean",
+                        f"{header}\n\nimport TNLean.Real\n\ndef witness := 1\n",
+                    )
+
+                    self.assertEqual(
+                        GENERATOR.source_imported_modules(source),
+                        {"TNLean.Real"},
+                    )
+
     def test_source_imported_modules_stops_before_import_shaped_text(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             source = self.write(


### PR DESCRIPTION
## Summary

- Restricts handwritten ownership-edge scanning to the leading Lean module header.
- Recognizes the legal `module` and `prelude` headers, together with `public`, `meta`, and `all` import modifiers.
- Stops at the first ordinary command, so import-shaped lines inside later strings or quotations cannot count as ownership edges.
- Fails closed on malformed imports or misplaced headers and leaves the strict generated-file parser unchanged.
- Adds regressions for quoted import-shaped text, malformed preambles, legal headers, and import modifiers.

The pinned Lean parser rejects `import A B`; accordingly, #6780 has been closed as based on an incorrect premise rather than encoded into the scanner.

## Testing

- Direct pinned-Lean grammar probe: `import Mathlib.Data.Nat.Basic Mathlib.Data.List.Basic` is rejected with `unexpected identifier; expected command`.
- Parser grammar checked against `Lean/Parser/Module/Syntax.lean` from the pinned toolchain.
- `python3 scripts/test_generate_import_aggregators.py` (14 tests)
- `python3 scripts/generate_import_aggregators.py --check` (60 generated files, 1,491 production modules)
- `python3 -m py_compile scripts/generate_import_aggregators.py scripts/test_generate_import_aggregators.py`
- `ruff check scripts/generate_import_aggregators.py scripts/test_generate_import_aggregators.py`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`

Closes #6781