### PR TITLE
refactor(mps): make invariant predicate bridges abbreviations

### DIFF
--- a/TNLean/MPS/Core/InvariantProjection.lean
+++ b/TNLean/MPS/Core/InvariantProjection.lean
@@ -26,12 +26,12 @@ variable {d D : ℕ}
 
 /-- A matrix product tensor has a nontrivial invariant orthogonal projection if its
 finite matrix family has one. -/
-def HasInvariantProj (A : MPSTensor d D) : Prop :=
+abbrev HasInvariantProj (A : MPSTensor d D) : Prop :=
   Kraus.HasInvariantProj A
 
 /-- A matrix product tensor is irreducible if its finite matrix family has no nontrivial
 invariant orthogonal projection. -/
-def IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
+abbrev IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
   ¬ HasInvariantProj A
 
 end MPSTensor


### PR DESCRIPTION
## Summary

- Redeclares `MPSTensor.HasInvariantProj` and `MPSTensor.IsIrreducibleTensor` as abbreviations of the QIC-owned predicates.
- Matches the established compatibility pattern used by `MPSTensor.evalWord` and `MPSTensor.reindexPhysical`.
- Preserves both declaration names and mathematical statements while making their intended definitional unfolding explicit.

## Testing

- Focused build of the Kraus owner, MPS owner, transfer-channel consumer, both spectral-gap consumers, all three listed Wielandt consumers, and canonical-form reduction: 8,844 jobs.
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check` (60 files, 1,491 production modules)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- proof-integrity and diff checks

No blueprint update is required because the declaration names and statements are unchanged.

Closes #6783
Advances #6560