### PR TITLE
doc(MPS/MPU): complete reduced-to-hat hypothesis account

### DIFF
--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -6,7 +6,16 @@
 \DeclareUnicodeCharacter{2099}{\ifmmode{}_{n}\else\textsubscript{n}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
-\newcommand{\leanid}[1]{\textsf{\detokenize{#1}}}
+\ExplSyntaxOn
+\NewDocumentCommand{\leanid}{m}{
+  \group_begin:
+  \urlstyle{sf}
+  \tl_set:Nn \l_tmpa_tl {#1}
+  \tl_replace_all:Nnn \l_tmpa_tl {\_} {_}
+  \exp_args:NV \path \l_tmpa_tl
+  \group_end:
+}
+\ExplSyntaxOff
 \providecommand{\tr}{\operatorname{tr}}
 \newcommand{\tnleanIssueBase}{https://github.com/LionSR/TNLean/issues/}
 \newcommand{\tnleanPrBase}{https://github.com/LionSR/TNLean/pull/}

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -8,12 +8,16 @@
 \newcommand{\Lean}{\textsc{Lean}}
 \ExplSyntaxOn
 \NewDocumentCommand{\leanid}{m}{
-  \group_begin:
-  \urlstyle{sf}
-  \tl_set:Nn \l_tmpa_tl {#1}
-  \tl_replace_all:Nnn \l_tmpa_tl {\_} {_}
-  \exp_args:NV \path \l_tmpa_tl
-  \group_end:
+  \ifmmode
+    \textsf{\detokenize{#1}}
+  \else
+    \group_begin:
+    \urlstyle{sf}
+    \tl_set:Nn \l_tmpa_tl {#1}
+    \tl_replace_all:Nnn \l_tmpa_tl {\_} {_}
+    \exp_args:NV \path \l_tmpa_tl
+    \group_end:
+  \fi
 }
 \ExplSyntaxOff
 \providecommand{\tr}{\operatorname{tr}}

--- a/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
+++ b/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
@@ -3,7 +3,6 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 \input{command}
-\renewcommand{\leanid}[1]{\begingroup\urlstyle{sf}\path{#1}\endgroup}
 \title{The Supplied Fixed Pair in the Reduced-Representative Step of Proposition IV.5}
 \author{}
 \date{2026-08-16}

--- a/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
+++ b/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
@@ -3,6 +3,7 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 \input{command}
+\renewcommand{\leanid}[1]{\begingroup\urlstyle{sf}\path{#1}\endgroup}
 \title{The Supplied Fixed Pair in the Reduced-Representative Step of Proposition IV.5}
 \author{}
 \date{2026-08-16}
@@ -67,27 +68,32 @@ tensor after blocking.
 
 \section{Affected declarations}
 The declaration
-\leanid{MPOTensor.mpo\_virtualSandwich\_reducedProjection\_eq} assumes the
-letterwise absorptions $W^{ij}P=W^{ij}$ and $QW^{ij}=W^{ij}$.
-\leanid{MPOTensor.transferMap\_virtualSandwich\_reducedProjection} assumes the
+\leanid{MPOTensor.mpo_virtualSandwich_reducedProjection_eq} assumes the
+orthogonal-projection property of $P$ and the letterwise absorptions
+$W^{ij}P=W^{ij}$ and $QW^{ij}=W^{ij}$.
+\leanid{MPOTensor.transferMap_virtualSandwich_reducedProjection} assumes the
 rank-one transfer formula. The declarations
-\leanid{MPOTensor.trace\_compressed\_fixed\_pair\_reducedProjection} and
-\leanid{MPOTensor.compressed\_fixed\_pair\_posDef\_reducedProjection} assume,
-respectively, the two-sided support absorptions of $L$ and $R$ together with
-$\tr(LR)=1$, and the positive pair $L,R\succeq0$ with its support projections;
-the latter also assumes an isometry $V$ onto the range of $T$.
+\leanid{MPOTensor.trace_compressed_fixed_pair_reducedProjection} and
+\leanid{MPOTensor.compressed_fixed_pair_posDef_reducedProjection} assume,
+respectively, that $P$ and $Q$ are orthogonal projections, the two-sided
+support absorptions of $L$ and $R$, and $\tr(LR)=1$; and that
+$L,R\succeq0$ have support projections $P,Q$. The latter also assumes an
+isometry $V$ onto the range of $T$.
 
 The comparison declaration
-\leanid{MPOTensor.virtualSandwich\_hat\_eq\_reducedProjection} assumes the
-factor equations $XL=P$, $RZ=Q$, and $PQY=T$ together with the letterwise
-absorptions. The rank equalities
-\leanid{MPOTensor.rightRank\_hat\_eq\_reducedProjection} and
-\leanid{MPOTensor.leftRank\_hat\_eq\_reducedProjection} use the same supplied
+\leanid{MPOTensor.virtualSandwich_hat_eq_reducedProjection} assumes the
+orthogonal-projection property of $P$, the factor equations $XL=P$, $RZ=Q$,
+and $PQY=T$, and the letterwise absorptions. The rank equalities
+\leanid{MPOTensor.rightRank_hat_eq_reducedProjection} and
+\leanid{MPOTensor.leftRank_hat_eq_reducedProjection} use the same supplied
 data and additionally assume that $X$, $Z$, and $Y$ are invertible. Finally,
-\leanid{MPOTensor.exists\_units\_for\_hat\_reducedProjection} assumes positive
-semidefinite fixed matrices $L$ and $R$ and supplies the invertible ambient
-support-inverse extensions $X$ and $Z$, together with an invertible
-right factor $Y$ satisfying $PQY=T$.
+\leanid{MPOTensor.exists_units_for_hat_reducedProjection} assumes only
+$L,R\succeq0$ and supplies the invertible ambient support-inverse extensions
+$X$ and $Z$, together with an invertible right factor $Y$ satisfying
+$PQY=T$. Its matrix theorem,
+\leanid{Matrix.exists_units_supportInvExtension_reducedProjection_rightFactor},
+has the same positive-semidefinite hypotheses and assumes no fixed-point,
+normalization, or absorption identity.
 
 \section{Elimination plan}
 The restriction is removed by formalizing the missing supplier: the blocking


### PR DESCRIPTION
## Mathematical correction

- record the explicit orthogonal-projection hypotheses in the reduced-representative and reduced-to-hat comparisons
- distinguish supplied projections from support projections derived from positive semidefiniteness
- state that the ambient unit supplier assumes only $L,R \succeq 0$, with no fixed-point, normalization, or absorption identity
- trace the same hypothesis boundary to the underlying matrix theorem

The revision is folded into the existing affected-declarations account, as required by the paper-gap policy. It does not change the verdict or any Lean declaration.

## Typesetting

The shared `paper-gaps/command.tex` definition of `\leanid` now permits long declaration names to break at punctuation in prose. It accepts both the current raw-underscore spelling and the older escaped-underscore spelling, while retaining the former short form in mathematics. This removes visible right-margin truncation and preserves a common directory-wide notation.

## Validation

- checked the account against `ReducedRepresentative.lean`, `ReducedToHatTransport.lean`, and `MatrixReducedProjection.lean`
- standalone target-note `latexmk` build with bibliography: clean, with no overfull boxes
- visual inspection of all three target-note pages
- compiled and rendered `wolf_cor67_maximal_support_restriction.tex` to verify legacy escaped-underscore compatibility
- compiled and rendered `policy.tex` to verify the mathematical-mode compatibility branch
- reader-facing prose check
- `git diff --check`

Closes #6553.