### PR TITLE
fix(blueprint): resolve deferred declaration ownership

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -209,9 +209,9 @@ partial traces.
 \begin{theorem}[Spectral bound for a vectorized unital Kraus map]
     \label{thm:unital_kraus_frobenius_spectral_radius}
     \lean{IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one}
-    \lean{spectralRadius_le_one_of_forall_eigenvalue_norm_le_one}
     \leanok
     \uses{thm:unital_kraus_eigenvalue_bound,
+        thm:kraus_tp_spectral_radius_bound,
         def:frobenius_superoperator_transport}
     Let $E:\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be a completely
     positive map with $E(\Id)=\Id$.  Then the spectral radius of its
@@ -722,7 +722,6 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
 \end{tenkzequation}
 
 \begin{theorem}[Trace preservation implies Kraus normalization]\label{thm:kraus_sum_conjTranspose_mul_of_tp}
-    \lean{kraus_sum_conjTranspose_mul_of_tp}
     \leanok
     \uses{def:cp_map, def:trace_preserving}
     If $T(X) = \sum_i K_i X K_i^\dagger$ is trace-preserving, then
@@ -731,7 +730,7 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
 
 \begin{proof}
     \leanok
-    \uses{def:trace_preserving}
+    \uses{def:trace_preserving, thm:kraus_rect_normalization}
     For any $N$,
     \begin{align}
         \tr\left(\left(\sum_i K_i^\dagger K_i\right)N\right)
@@ -810,7 +809,6 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{theorem}[Isometric mixing preserves the Kraus map]
     \label{thm:kraus_same_map_of_isometry_combination}
-    \lean{kraus_same_map_of_isometry_combination}
     \leanok
     \uses{def:cp_map}
     Let $W$ be an isometry between two Kraus index spaces, so $W^\dagger W = \Id$.
@@ -820,6 +818,7 @@ extends to isometric mixing between different Kraus index spaces.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:kraus_rect_freedom}
     Expand the Kraus sums, interchange the finite summations, and use
     $W^\dagger W = \Id$ to collapse the coefficient matrix.
 \end{proof}
@@ -844,7 +843,6 @@ extends to isometric mixing between different Kraus index spaces.
 \end{proof}
 
 \begin{theorem}[Dual map equality from primal map equality]\label{thm:kraus_dual_eq_of_map_eq}
-    \lean{kraus_dual_eq_of_map_eq}
     \leanok
     \uses{def:cp_map}
     If two Kraus families satisfy
@@ -856,6 +854,7 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{proof}
     \leanok
+    \uses{thm:kraus_rect_freedom}
     Use the trace pairing: for all $X$,
     \begin{align}
         \tr\left(X^\dagger
@@ -873,7 +872,6 @@ extends to isometric mixing between different Kraus index spaces.
 \end{proof}
 
 \begin{theorem}[Equal Stinespring Gramians]\label{thm:kraus_conjTranspose_mul_eq_of_map_eq}
-    \lean{kraus_conjTranspose_mul_eq_of_map_eq}
     \leanok
     \uses{thm:kraus_dual_eq_of_map_eq}
     If two Kraus families define the same CPM, then
@@ -882,6 +880,7 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{proof}
     \leanok
+    \uses{thm:kraus_rect_freedom, thm:kraus_dual_eq_of_map_eq}
     Specialise Theorem~\ref{thm:kraus_dual_eq_of_map_eq} at $Y = \Id$.
 \end{proof}
 
@@ -902,7 +901,6 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{theorem}[Isometric freedom of Kraus representations]
     \label{thm:kraus_isometry_freedom_iff}
-    \lean{kraus_isometry_freedom_iff}
     \leanok
     \uses{thm:kraus_rectangular_freedom'}
     Let $\{B_\alpha\}_{\alpha \in \iota_1}$ and $\{A_j\}_{j \in \iota_2}$
@@ -919,6 +917,7 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{proof}
     \leanok
+    \uses{thm:kraus_rect_freedom}
     The implication $(1) \Rightarrow (2)$ is
     Theorem~\ref{thm:kraus_rectangular_freedom'}.
     Conversely, expand $\sum_\alpha B_\alpha X B_\alpha^\dagger$ using
@@ -929,7 +928,6 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{theorem}[Unitary freedom of Kraus representations]
     \label{thm:kraus_unitary_freedom_iff}
-    \lean{kraus_unitary_freedom_iff}
     \leanok
     \uses{thm:kraus_isometry_freedom_iff}
     Let $\{B_\alpha\}_{\alpha \in \iota}$ and $\{A_j\}_{j \in \iota}$
@@ -945,6 +943,7 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{proof}
     \leanok
+    \uses{thm:kraus_rect_freedom, thm:kraus_isometry_freedom_iff}
     Apply Theorem~\ref{thm:kraus_isometry_freedom_iff} with
     $|\iota| = |\iota|$.
     In the square case an isometry matrix is unitary, and the converse is
@@ -953,14 +952,12 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{remark}[Choi rank and minimal Kraus cardinality]
     \label{rem:choi_rank_eq_min_kraus_cardinality}
-    \lean{Channel.HasKrausCard, Channel.HasKrausRankLE, Channel.choiRank,
-        Channel.choiRank_le_of_hasKrausCard,
-        Channel.choiRank_le_of_hasKrausRankLE,
-        Channel.hasKrausCard_choiRank_of_cp,
+    \lean{Channel.choiRank_le_of_hasKrausRankLE,
         Channel.hasKrausRankLE_choiRank_of_cp,
         Channel.hasKrausRankLE_choiRank_of_cptp}
     \leanok
-    \uses{def:choi_matrix, def:cp_map}
+    \uses{def:choi_matrix, def:cp_map, def:kraus_rank_rect,
+        thm:kraus_rect_rank_minimal}
     If a completely positive map admits a Kraus representation with exactly $r$
     operators, then its Choi matrix is a sum of $r$ rank-one outer products.
     Consequently, $\rank(\tau_E) \le r$.
@@ -972,6 +969,7 @@ extends to isometric mixing between different Kraus index spaces.
 
 \begin{proof}
     \leanok
+    \uses{thm:kraus_rect_rank_minimal}
     For the forward implication, expand the Choi matrix using the Kraus formula
     and write $\tau_E = \sum_j v_j v_j^\dagger$ with one vector $v_j$ for each
     Kraus operator. The column space of this sum lies in the span of the $r$

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -956,8 +956,7 @@ extends to isometric mixing between different Kraus index spaces.
         Channel.hasKrausRankLE_choiRank_of_cp,
         Channel.hasKrausRankLE_choiRank_of_cptp}
     \leanok
-    \uses{def:choi_matrix, def:cp_map, def:kraus_rank_rect,
-        thm:kraus_rect_rank_minimal}
+    \uses{def:choi_matrix, def:cp_map, def:kraus_rank_rect}
     If a completely positive map admits a Kraus representation with exactly $r$
     operators, then its Choi matrix is a sum of $r$ rank-one outer products.
     Consequently, $\rank(\tau_E) \le r$.

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -211,7 +211,6 @@ partial traces.
     \lean{IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one}
     \leanok
     \uses{thm:unital_kraus_eigenvalue_bound,
-        thm:kraus_tp_spectral_radius_bound,
         def:frobenius_superoperator_transport}
     Let $E:\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be a completely
     positive map with $E(\Id)=\Id$.  Then the spectral radius of its
@@ -221,6 +220,7 @@ partial traces.
 \begin{proof}
     \leanok
     \uses{thm:unital_kraus_eigenvalue_bound,
+        thm:kraus_tp_spectral_radius_bound,
         def:frobenius_superoperator_transport}
     A unital completely positive map is contractive in the matrix operator
     norm, so every eigenvalue has modulus at most one.  The spectral radius

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -194,8 +194,6 @@
 
 \begin{definition}[Virtual per-block linear extension]%
     \label{def:mpdo_virtual_perBlockLinearExtension}
-    \lean{MPSTensor.perBlockLinearExtension}
-    \lean{MPSTensor.perBlockLinearExtension_spec}
     \leanok
     \uses{def:injective, def:same_mpv}
     For injective families $A_k$ and $B_k$ with the same closed matrix
@@ -206,7 +204,6 @@
 
 \begin{theorem}[Multiplicativity of the virtual per-block extension]%
     \label{thm:mpdo_virtual_perBlockLinearExtension_mul}
-    \lean{MPSTensor.perBlockLinearExtension_mul}
     \leanok
     \uses{def:mpdo_virtual_perBlockLinearExtension}
     The per-block extension satisfies $T_k(MN)=T_k(M)T_k(N)$ for all
@@ -221,7 +218,6 @@
 
 \begin{theorem}[Bijectivity of the virtual per-block extension]%
     \label{thm:mpdo_virtual_perBlockLinearExtension_bijective}
-    \lean{MPSTensor.perBlockLinearExtension_bijective}
     \leanok
     \uses{def:mpdo_virtual_perBlockLinearExtension}
     The per-block extension $T_k$ is bijective.
@@ -238,7 +234,6 @@
 
 \begin{theorem}[Positive virtual per-block extensions are unitarily implemented]%
     \label{thm:mpdo_positive_perBlockLinearExtension_unitary}
-    \lean{MPSTensor.exists_unitary_conj_of_positive_perBlockLinearExtension}
     \leanok
     \uses{def:mpdo_virtual_perBlockLinearExtension}
     If $T_k$ is positive, then there is a unitary matrix $U_k$ such that

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
@@ -159,7 +159,6 @@ chains, one tensor per site, which is the setting of
 \begin{lemma}[State coefficients of the cycle tensor]%
     \label{lem:stateCoeff_cycleTensorOfMPS}
     \lean{MPSTensor.evalWord_ofFn_apply}
-    \lean{MPSTensor.trace_evalWord_eq_sum_cyclic}
     \lean{TNLean.PEPS.stateCoeff_cycleTensorOfMPS}
     \leanok
     \uses{def:cycleTensorOfMPS, def:peps_stateCoeff, def:mpv}

--- a/docs/audits/2026-08-20_blueprint_declaration_ownership.md
+++ b/docs/audits/2026-08-20_blueprint_declaration_ownership.md
@@ -1,0 +1,68 @@
+# Blueprint declaration ownership for shared results
+
+This note records the ownership convention used to resolve the declaration clusters
+identified in issue #6244.  It precedes the corresponding changes to the blueprint.
+
+## Convention
+
+Each Lean declaration has exactly one blueprint entry carrying its `\lean{...}` tag.
+That entry is the one in which the result has its most general mathematical role.  A
+later specialization, application, or recap cites the owning entry through `\uses`:
+
+- a statement cites the owner only when the owned result is needed to formulate the
+  statement;
+- a proof cites the owner only when the argument uses the owned result.
+
+Displayed order alone does not determine ownership.  In particular, a contextual
+application does not acquire ownership merely because it occurs before the general
+discussion in the compiled book.
+
+## Channel representations: Chapters 4 and 16
+
+Chapter 4 owns the shared declarations.  It develops rectangular Kraus maps and the
+corresponding Choi theory, while Chapter 16 explicitly presents itself as a continuation
+and recap of this earlier channel theory.  The twelve shared declarations are:
+
+- `Channel.HasKrausCard`;
+- `Channel.HasKrausRankLE`;
+- `Channel.choiRank`;
+- `Channel.choiRank_le_of_hasKrausCard`;
+- `Channel.hasKrausCard_choiRank_of_cp`;
+- `kraus_conjTranspose_mul_eq_of_map_eq`;
+- `kraus_dual_eq_of_map_eq`;
+- `kraus_isometry_freedom_iff`;
+- `kraus_same_map_of_isometry_combination`;
+- `kraus_sum_conjTranspose_mul_of_tp`;
+- `kraus_unitary_freedom_iff`;
+- `spectralRadius_le_one_of_forall_eigenvalue_norm_le_one`.
+
+The Chapter 16 entries cite the appropriate Chapter 4 owner through proof dependencies,
+except for the Choi-rank remark, whose statement depends on the Chapter 4 definition and
+minimality theorem.
+
+## Per-block linear extensions: Chapters 21 and 23
+
+Chapter 23 owns the shared declarations because it develops the per-block linear
+extension as part of the general algebraic Fundamental Theorem.  Chapter 21 uses the
+same construction in the more specific MPDO/RFP discussion.  The five shared
+declarations are:
+
+- `MPSTensor.perBlockLinearExtension`;
+- `MPSTensor.perBlockLinearExtension_spec`;
+- `MPSTensor.perBlockLinearExtension_mul`;
+- `MPSTensor.perBlockLinearExtension_bijective`;
+- `MPSTensor.exists_unitary_conj_of_positive_perBlockLinearExtension`.
+
+The Chapter 21 definition cites the Chapter 23 definition at statement level.  Its two
+structural theorems and the unitary-implementation theorem cite the corresponding
+Chapter 23 results in their proofs.
+
+## Cyclic trace expansion: Chapters 13 and 24
+
+Chapter 13 owns `MPSTensor.trace_evalWord_eq_sum_cyclic`: it states the general cyclic
+trace expansion for a closed MPS chain.  Chapter 24 uses this identity to identify the
+coefficients of a cycle PEPS tensor, so the proof of that identification cites the
+Chapter 13 theorem.
+
+All eighteen shared declarations therefore have an unambiguous general owner.  No case
+in these three clusters needs to retain two ownership tags.

--- a/docs/audits/2026-08-20_blueprint_declaration_ownership.md
+++ b/docs/audits/2026-08-20_blueprint_declaration_ownership.md
@@ -7,7 +7,8 @@ identified in issue #6244.  It precedes the corresponding changes to the bluepri
 
 Each Lean declaration has exactly one blueprint entry carrying its `\lean{...}` tag.
 That entry is the one in which the result has its most general mathematical role.  A
-later specialization, application, or recap cites the owning entry through `\uses`:
+later specialization, application, or recap in the same compiled volume cites the
+owning entry through `\uses`:
 
 - a statement cites the owner only when the owned result is needed to formulate the
   statement;
@@ -16,6 +17,13 @@ later specialization, application, or recap cites the owning entry through `\use
 Displayed order alone does not determine ownership.  In particular, a contextual
 application does not acquire ownership merely because it occurs before the general
 discussion in the compiled book.
+
+At present, Chapters 23 and 24 are excluded from `blueprint/src/content.tex`.  A
+dependency edge between one of those chapters and the compiled Chapters 13 or 21 is
+therefore unresolved by `leanblueprint`.  In such a cross-scope case the contextual
+entry relinquishes its duplicate `\lean{...}` tag, but does not acquire an invalid
+`\uses` edge.  The edge should be added when both entries belong to a common compiled
+volume.
 
 ## Channel representations: Chapters 4 and 16
 
@@ -53,16 +61,22 @@ declarations are:
 - `MPSTensor.perBlockLinearExtension_bijective`;
 - `MPSTensor.exists_unitary_conj_of_positive_perBlockLinearExtension`.
 
-The Chapter 21 definition cites the Chapter 23 definition at statement level.  Its two
-structural theorems and the unitary-implementation theorem cite the corresponding
-Chapter 23 results in their proofs.
+These are presently cross-scope cases: Chapter 21 belongs to the full-book router,
+whereas Chapter 23 is excluded from it.  The Chapter 21 entries therefore relinquish
+their duplicate ownership tags without adding unresolved dependencies.  Once Chapter
+23 and Chapter 21 occur in a common compiled volume, the Chapter 21 definition should
+cite the Chapter 23 definition at statement level, and its structural results should
+cite the corresponding Chapter 23 results at proof level.
 
 ## Cyclic trace expansion: Chapters 13 and 24
 
 Chapter 13 owns `MPSTensor.trace_evalWord_eq_sum_cyclic`: it states the general cyclic
 trace expansion for a closed MPS chain.  Chapter 24 uses this identity to identify the
 coefficients of a cycle PEPS tensor, so the proof of that identification cites the
-Chapter 13 theorem.
+Chapter 13 theorem mathematically.  Since Chapter 24 is currently excluded from the
+full-book router, this dependency cannot yet be represented by a resolvable `\uses`
+edge.  The Chapter 24 entry relinquishes its duplicate ownership tag, and the edge
+should be added when the two chapters occur in a common compiled volume.
 
 All eighteen shared declarations therefore have an unambiguous general owner.  No case
 in these three clusters needs to retain two ownership tags.

--- a/docs/audits/2026-08-20_blueprint_declaration_ownership.md
+++ b/docs/audits/2026-08-20_blueprint_declaration_ownership.md
@@ -45,8 +45,8 @@ and recap of this earlier channel theory.  The twelve shared declarations are:
 - `spectralRadius_le_one_of_forall_eigenvalue_norm_le_one`.
 
 The Chapter 16 entries cite the appropriate Chapter 4 owner through proof dependencies,
-except for the Choi-rank remark, whose statement depends on the Chapter 4 definition and
-minimality theorem.
+except for the Choi-rank remark: its statement depends on the Chapter 4 rank definition,
+whereas its proof depends on the minimality theorem.
 
 ## Per-block linear extensions: Chapters 21 and 23
 


### PR DESCRIPTION
## Summary

- records the reader-facing rule that each Lean declaration has one general blueprint owner
- assigns Chapter 4 as the owner of the twelve shared channel-representation declarations and makes the Chapter 16 recap cite those owner entries
- assigns Chapter 23 as the owner of the five general per-block extension declarations and Chapter 13 as the owner of the cyclic trace expansion
- removes the corresponding duplicate tags from Chapters 21 and 24
- records the present cross-scope exception: Chapters 23 and 24 are outside the compiled full-book router, so unresolved dependency edges are deferred until the entries share a compiled volume

The complete eighteen-declaration inventory and the ownership decision are recorded in `docs/audits/2026-08-20_blueprint_declaration_ownership.md`. This convention was committed before the ownership edits.

## Validation

- `lake build` — passed (10,263 jobs)
- `leanblueprint checkdecls` — passed
- `leanblueprint web` — passed
- `leanblueprint pdf` — passed (1,131 pages)
- rendered-PDF inspection of the changed Chapter 16 and Chapter 21 regions — no layout defects
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed (8,100/8,100 declarations)
- `python3 scripts/tenkz_lint.py` on all three changed chapter files — no findings
- reader-facing prose check — passed
- `git diff --check` — passed
- exact duplicate inventory — each of the eighteen declarations occurs under exactly one `\\lean` tag

Closes #6244.