### PR TITLE
doc(Channel): restore entropy citation site

### DIFF
--- a/docs/wolf_theorem_numbering_audit.md
+++ b/docs/wolf_theorem_numbering_audit.md
@@ -516,7 +516,8 @@ or 11 occurs in the directories examined here.
 
 The Chapter 4 search finds many unqualified numerical near matches. Inspection
 shows that they refer to other sources, principally the matrix-product density
-operator paper of Cirac, Pérez-García, Schuch, and Verstraete. The files
+operator paper of Cirac, Pérez-García, Schuch, and Verstraete. The entropy
+development in `TNLean/Entropy/ClassicalMutualInformation.lean`, the files
 `TNLean/MPS/MPDO/DiagonalCutRank.lean` and
 `TNLean/MPS/MPDO/DiagonalFiniteChain.lean`, the corresponding blueprint entry
 in `ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex`, and the note


### PR DESCRIPTION
## Summary

- restores `TNLean/Entropy/ClassicalMutualInformation.lean` to the Chapter 4 Riazanov–Vyalyi citation inventory
- makes the audit's subsequent exhaustive statement true again
- leaves the zero-live-Wolf-citation conclusion unchanged

## Validation

- confirmed the entropy module cites arXiv:1704.06507, Theorem 4.1 in its module documentation, references, and main theorem documentation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passed
- `git diff --check` — passed

Closes LionSR/QICLean#357.