### PR TITLE
doc(qic): add finite-family word-evaluation owner

### DIFF
--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -5,6 +5,18 @@ Section~\ref{sec:app_wielandt_exact_word_support}. The stabilization and
 spectral linear algebra behind the cumulative estimates are collected in
 Section~\ref{sec:app_wielandt_cumulative_support}.
 
+\begin{definition}[Word evaluation for a finite matrix family]
+    \label{def:kraus_eval_word}
+    \lean{Kraus.evalWord}
+    \leanok
+    Let $K=(K_i)_{i=0}^{d-1}$ be a finite family of $D\times D$ matrices.
+    For a word $w=(i_1,\ldots,i_n)$, its \emph{word evaluation} is
+    \[
+        K^w=K_{i_1}\cdots K_{i_n},
+    \]
+    with the empty word evaluated as the identity matrix.
+\end{definition}
+
 \begin{definition}[Word span]\label{def:word_span}
     \lean{MPSTensor.wordSpan}
     \leanok
@@ -29,7 +41,7 @@ Section~\ref{sec:app_wielandt_cumulative_support}.
 \begin{definition}[Fixed-length vector span]\label{def:vector_spread_span}
     \lean{Kraus.vectorSpreadSpan}
     \leanok
-    \uses{def:eval_word}
+    \uses{def:kraus_eval_word}
     The \emph{fixed-length vector span} at length~$n$ is
     \begin{align}
         H_n(A,\varphi)

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -9,10 +9,10 @@ Section~\ref{sec:app_wielandt_cumulative_support}.
     \label{def:kraus_eval_word}
     \lean{Kraus.evalWord}
     \leanok
-    Let $K=(K_i)_{i=0}^{d-1}$ be a finite family of $D\times D$ matrices.
+    Let $K=\{K^i\}_{i=0}^{d-1}$ be a finite family of $D\times D$ matrices.
     For a word $w=(i_1,\ldots,i_n)$, its \emph{word evaluation} is
     \begin{align}
-        K^w=K_{i_1}\cdots K_{i_n},
+        K^w=K^{i_1}\cdots K^{i_n},
         \notag
     \end{align}
     with the empty word evaluated as the identity matrix.

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -11,9 +11,10 @@ Section~\ref{sec:app_wielandt_cumulative_support}.
     \leanok
     Let $K=(K_i)_{i=0}^{d-1}$ be a finite family of $D\times D$ matrices.
     For a word $w=(i_1,\ldots,i_n)$, its \emph{word evaluation} is
-    \[
+    \begin{align}
         K^w=K_{i_1}\cdots K_{i_n},
-    \]
+        \notag
+    \end{align}
     with the empty word evaluated as the identity matrix.
 \end{definition}
 


### PR DESCRIPTION
## Summary

- adds a Chapter 8 definition of finite-family word evaluation tagged with `Kraus.evalWord`
- gives the QIC-owned definition the distinct label `def:kraus_eval_word`
- retargets the QIC-owned fixed-length vector span to that owner
- preserves the Chapter 2 `def:eval_word` entry and its `MPSTensor.evalWord` tag

## Boundary verification

The deterministic report changes from one reverse reference to none:

- QIC items: 1,450
- TN items: 3,135
- mixed items: 0
- QIC-to-TN `\uses` edges: 0

The two word-evaluation declarations each occur under exactly one blueprint owner.

## Validation

- `python3 scripts/qic_blueprint_boundary_report.py --root .` — 0 mixed items, 0 QIC-to-TN edges
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` — passed
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed (8,132/8,132)
- `leanblueprint web` — passed
- generated Chapter 8 HTML — verified the new declaration link and the retargeted dependency
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passed
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex` — no findings
- `git diff --check` — passed

Closes #6779.
Advances #6622 and #6560.