### PR TITLE
refactor(qic): stabilize matrix real-scalar instance name

### DIFF
--- a/TNLean/Algebra/MatrixOperatorSpace.lean
+++ b/TNLean/Algebra/MatrixOperatorSpace.lean
@@ -51,7 +51,7 @@ section MatrixInstances
 
 variable (n : Type*) [Fintype n] [DecidableEq n]
 
-instance : NormedSpace ℝ (Matrix n n ℂ) :=
+instance instNormedSpaceRealMatrixComplex : NormedSpace ℝ (Matrix n n ℂ) :=
   NormedSpace.restrictScalars ℝ ℂ (Matrix n n ℂ)
 
 omit [DecidableEq n] [Fintype n] in

--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -235,7 +235,7 @@ theorem hasDerivAt_expSemigroup_apply
     (X : Matrix (Fin D) (Fin D) ℂ) (t : ℝ) :
     @HasDerivAt ℝ _ (Matrix (Fin D) (Fin D) ℂ)
       Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-      (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+      (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
       PseudoMetricSpace.toUniformSpace.toTopologicalSpace
       (inferInstance : ContinuousSMul ℝ (Matrix (Fin D) (Fin D) ℂ))
       (fun u : ℝ => expSemigroup L u X) (expSemigroup L t (L X)) t := by
@@ -258,7 +258,7 @@ theorem hasDerivAt_expSemigroup_apply
         (Matrix (Fin D) (Fin D) ℂ)
         Matrix.linftyOpNormedAddCommGroup
         (show NormedSpace ℝ (Matrix (Fin D) (Fin D) ℂ) from
-          TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+          TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
         (f := fun u : ℝ => expSemigroupCLM (endEquiv L) u)
         (f' := expSemigroupCLM (endEquiv L) t * endEquiv L)
         (x := t)

--- a/TNLean/Channel/Semigroup/Kernel.lean
+++ b/TNLean/Channel/Semigroup/Kernel.lean
@@ -86,47 +86,47 @@ theorem expSemigroup_apply_eq_self_of_generator_apply_eq_zero
   let : AddCommGroup Mat := Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
   let : NormedAddCommGroup Mat := Matrix.linftyOpNormedAddCommGroup
   let : Module ℝ Mat :=
-    (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+    (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
   let : TopologicalSpace Mat := PseudoMetricSpace.toUniformSpace.toTopologicalSpace
   let : NormedSpace ℝ Mat :=
-    TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)
+    TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)
   let : ContinuousSMul ℝ Mat := inferInstance
   intro t _ht
   have hdiff :
       @Differentiable ℝ _ ℝ _ _ _ Mat
         Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-        (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+        (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
         PseudoMetricSpace.toUniformSpace.toTopologicalSpace
         (fun u : ℝ => expSemigroup L u X) := by
     intro u
     exact @HasDerivAt.differentiableAt ℝ _ Mat
       Matrix.linftyOpNormedAddCommGroup
-      (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+      (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
       (f := fun u : ℝ => expSemigroup L u X) (f' := (expSemigroup L u) (L X)) (x := u)
       (hasDerivAt_expSemigroup_apply (L := L) X u)
   have hderiv :
       ∀ u : ℝ,
         @deriv ℝ _ Mat
           Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-          (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+          (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
           PseudoMetricSpace.toUniformSpace.toTopologicalSpace
           (fun s : ℝ => expSemigroup L s X) u = 0 := by
     intro u
     have hu :
         @HasDerivAt ℝ _ Mat
           Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-          (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+          (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
           PseudoMetricSpace.toUniformSpace.toTopologicalSpace
           (inferInstance : ContinuousSMul ℝ Mat)
           (fun u : ℝ => expSemigroup L u X) 0 u := by
       simpa [hX] using (hasDerivAt_expSemigroup_apply (L := L) X u)
     exact @HasDerivAt.deriv ℝ _ Mat
       Matrix.linftyOpNormedAddCommGroup
-      (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+      (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
       (f := fun u : ℝ => expSemigroup L u X) (f' := 0) (x := u) hu
   have hconst := @is_const_of_deriv_eq_zero ℝ Mat _
     Matrix.linftyOpNormedAddCommGroup
-    (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+    (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
     (f := fun u : ℝ => expSemigroup L u X) hdiff hderiv 0 t
   simpa [expSemigroup_zero] using hconst.symm
 
@@ -138,39 +138,39 @@ theorem generator_apply_eq_zero_of_expSemigroup_apply_eq_self
   have hd₁ :
       @HasDerivWithinAt ℝ _ Mat
         Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-        (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+        (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
         PseudoMetricSpace.toUniformSpace.toTopologicalSpace
         (inferInstance : ContinuousSMul ℝ Mat)
         (fun u : ℝ => expSemigroup L u X) (L X) (Set.Ici 0) 0 := by
     have hAt :
         @HasDerivAt ℝ _ Mat
           Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-          (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+          (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
           PseudoMetricSpace.toUniformSpace.toTopologicalSpace
           (inferInstance : ContinuousSMul ℝ Mat)
           (fun u : ℝ => expSemigroup L u X) (L X) 0 := by
       simpa [expSemigroup_zero] using hasDerivAt_expSemigroup_apply (L := L) X 0
     exact @HasDerivAt.hasDerivWithinAt ℝ _ Mat
       Matrix.linftyOpNormedAddCommGroup
-      (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+      (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
       (f := fun u : ℝ => expSemigroup L u X) (f' := L X) (x := 0) (s := Set.Ici 0)
       hAt
   have hd₂' :
       @HasDerivWithinAt ℝ _ Mat
         Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-        (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+        (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
         PseudoMetricSpace.toUniformSpace.toTopologicalSpace
         (inferInstance : ContinuousSMul ℝ Mat)
         (fun _ : ℝ => X) 0 (Set.Ici 0) 0 := by
     exact @HasDerivAt.hasDerivWithinAt ℝ _ Mat
       Matrix.linftyOpNormedAddCommGroup
-      (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D))
+      (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D))
       (f := fun _ : ℝ => X) (f' := 0) (x := 0) (s := Set.Ici 0)
       (hasDerivAt_const (x := 0) (c := X))
   have hd₂ :
       @HasDerivWithinAt ℝ _ Mat
         Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
-        (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+        (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
         PseudoMetricSpace.toUniformSpace.toTopologicalSpace
         (inferInstance : ContinuousSMul ℝ Mat)
         (fun u : ℝ => expSemigroup L u X) 0 (Set.Ici 0) 0 :=

--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -81,10 +81,10 @@ theorem expSemigroup_apply_eigenvector
   let : AddCommGroup Mat := Matrix.linftyOpNormedAddCommGroup.toAddCommGroup
   let : NormedAddCommGroup Mat := Matrix.linftyOpNormedAddCommGroup
   let : Module ℝ Mat :=
-    (TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)).toModule
+    (TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)).toModule
   let : TopologicalSpace Mat := PseudoMetricSpace.toUniformSpace.toTopologicalSpace
   let : NormedSpace ℝ Mat :=
-    TNOperatorSpace.instNormedSpaceRealMatrixComplex_tNLean (Fin D)
+    TNOperatorSpace.instNormedSpaceRealMatrixComplex (Fin D)
   let : ContinuousSMul ℝ Mat := inferInstance
   let : IsScalarTower ℝ ℂ Mat := by infer_instance
   let c : ℝ → ℂ := fun u => Complex.exp (-((u : ℂ) * μ))


### PR DESCRIPTION
## Summary

- gives the real-scalar matrix `NormedSpace` instance a stable explicit name
- replaces all 18 references to the root-name-derived `_tNLean` identifier
- removes a deterministic failure from the TNLean to QICLean module-prefix rename

## Validation

- `lake build TNLean.Algebra.MatrixOperatorSpace TNLean.Channel.Semigroup.Basic TNLean.Channel.Semigroup.Kernel TNLean.Channel.Semigroup.Primitivity.Helpers`
- `git grep -n '_tNLean\b' -- 'TNLean/**/*.lean'` returned no matches
- `git diff --check`

No Lake cache was fetched or rebuilt. No full local build was run.

Closes #6800.
Advances #6622 and #6560.
