### PR TITLE
doc(qic): align vector-span notation

### DIFF
--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -45,11 +45,11 @@ Section~\ref{sec:app_wielandt_cumulative_support}.
     \uses{def:kraus_eval_word}
     The \emph{fixed-length vector span} at length~$n$ is
     \begin{align}
-        H_n(A,\varphi)
-         & =\spn_{\C}\{A^w\varphi:|w|=n\}\subseteq\C^D.
+        H_n(K,\varphi)
+         & =\spn_{\C}\{K^w\varphi:|w|=n\}\subseteq\C^D.
         \notag
     \end{align}
-    This is $S_n(A)\ket{\varphi}$ in the notation
+    This is $S_n(K)\ket{\varphi}$ in the notation
     of~\cite{Sanz2010Quantum}.
 \end{definition}
 


### PR DESCRIPTION
## Summary

- use $K$ consistently for the finite Kraus family in the fixed-length vector span
- reserve $A$ for the adjacent MPS-tensor specialization

This follows up the valid late review finding on #6798, which was merged before that review was submitted.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`