### PR TITLE
feat(MPS/MPDO): transport two-four channels to blocking

### DIFF
--- a/TNLean/MPS/MPDO/RFPViaTSBlocking.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSBlocking.lean
@@ -17,6 +17,8 @@ the condition.
 
 ## Main result
 
+* `MPOTensor.blockTwo_isRFPViaTS_of_two_four_maps`: two-to-four and four-to-two
+  physical channels give renormalization maps for the two-site block.
 * `MPOTensor.IsRFPViaTS.blockTwo`: a renormalization fixed point remains one
   after two neighboring physical sites are blocked together.
 
@@ -133,24 +135,82 @@ private theorem coarseningSquaredMap_physClose4
   exact LinearMap.congr_fun (physCloseN_two_eq_physClose2 M) X
 
 private noncomputable def blockedRefinementMap
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    (T : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × (Fin d × (Fin d × Fin d)))
+        (Fin d × (Fin d × (Fin d × Fin d))) ℂ) :
     Matrix (Fin (d * d)) (Fin (d * d)) ℂ →ₗ[ℂ]
       Matrix (Fin (d * d) × Fin (d * d))
         (Fin (d * d) × Fin (d * d)) ℂ :=
   Matrix.equivReindexMap (blockedPairEquiv d).symm ∘ₗ
-    refinementSquaredMap T ∘ₗ
+    T ∘ₗ
       Matrix.equivReindexMap (blockedIndexEquiv d)
 
 private noncomputable def blockedCoarseningMap
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ) :
+    (S : Matrix (Fin d × (Fin d × (Fin d × Fin d)))
+        (Fin d × (Fin d × (Fin d × Fin d))) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
     Matrix (Fin (d * d) × Fin (d * d))
         (Fin (d * d) × Fin (d * d)) ℂ →ₗ[ℂ]
       Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   Matrix.equivReindexMap (blockedIndexEquiv d).symm ∘ₗ
-    coarseningSquaredMap S ∘ₗ
+    S ∘ₗ
       Matrix.equivReindexMap (blockedPairEquiv d)
+
+/-- Trace-preserving completely positive maps between the two-site and
+four-site physical closures give a renormalization fixed point after two-site
+blocking, once transported through the canonical blocked coordinates.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 645--659, and the blocked
+two-to-four channel equations used at lines 1819--1825. -/
+theorem blockTwo_isRFPViaTS_of_two_four_maps
+    (M : MPOTensor d D)
+    (S₂₄ : Matrix (Fin d × (Fin d × (Fin d × Fin d)))
+        (Fin d × (Fin d × (Fin d × Fin d))) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (T₂₄ : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × (Fin d × (Fin d × Fin d)))
+        (Fin d × (Fin d × (Fin d × Fin d))) ℂ)
+    (hS : IsKrausCPTP S₂₄) (hT : IsKrausCPTP T₂₄)
+    (hSclose : ∀ X, S₂₄ (physClose4 M X) = physClose2 M X)
+    (hTclose : ∀ X, T₂₄ (physClose2 M X) = physClose4 M X) :
+    IsRFPViaTS (blockTwo M) := by
+  refine ⟨blockedCoarseningMap S₂₄, blockedRefinementMap T₂₄, ?_, ?_, ?_, ?_⟩
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp
+        (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d)) hS)
+      (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d).symm)
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp
+        (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d)) hT)
+      (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d).symm)
+  · intro X
+    change Matrix.reindex (blockedIndexEquiv d).symm (blockedIndexEquiv d).symm
+        (S₂₄
+          (Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+            (physClose2 (MPOTensor.blockTwo M) X))) =
+      physClose1 (MPOTensor.blockTwo M) X
+    rw [show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+        (physClose2 (MPOTensor.blockTwo M) X) = physClose4 M X by
+      exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 M) X]
+    rw [hSclose X]
+    rw [← show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+        (physClose1 (MPOTensor.blockTwo M) X) = physClose2 M X by
+      exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 M) X]
+    simp
+  · intro X
+    change Matrix.reindex (blockedPairEquiv d).symm (blockedPairEquiv d).symm
+        (T₂₄
+          (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+            (physClose1 (MPOTensor.blockTwo M) X))) =
+      physClose2 (MPOTensor.blockTwo M) X
+    rw [show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+        (physClose1 (MPOTensor.blockTwo M) X) = physClose2 M X by
+      exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 M) X]
+    rw [hTclose X]
+    rw [← show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+        (physClose2 (MPOTensor.blockTwo M) X) = physClose4 M X by
+      exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 M) X]
+    simp
 
 /-- A tensor satisfying the trace-preserving completely positive map condition
 of Definition 4.1 remains a renormalization fixed point after two neighboring
@@ -163,44 +223,11 @@ twice-applied channel construction for Theorem 4.9 at lines 1810--1825. -/
 theorem IsRFPViaTS.blockTwo {M : MPOTensor d D} (h : IsRFPViaTS M) :
     IsRFPViaTS (blockTwo M) := by
   obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := h
-  refine ⟨blockedCoarseningMap S, blockedRefinementMap T, ?_, ?_, ?_, ?_⟩
-  · exact isKrausCPTP_comp
-      (isKrausCPTP_comp
-        (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d))
-        (coarseningSquaredMap_isKrausCPTP hS))
-      (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d).symm)
-  · exact isKrausCPTP_comp
-      (isKrausCPTP_comp
-        (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d))
-        (refinementSquaredMap_isKrausCPTP hT))
-      (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d).symm)
-  · intro X
-    change Matrix.reindex (blockedIndexEquiv d).symm (blockedIndexEquiv d).symm
-        (coarseningSquaredMap S
-          (Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
-            (physClose2 (MPOTensor.blockTwo M) X))) =
-      physClose1 (MPOTensor.blockTwo M) X
-    rw [show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
-        (physClose2 (MPOTensor.blockTwo M) X) = physClose4 M X by
-      exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 M) X]
-    rw [coarseningSquaredMap_physClose4 M S hSclose X]
-    rw [← show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
-        (physClose1 (MPOTensor.blockTwo M) X) = physClose2 M X by
-      exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 M) X]
-    simp
-  · intro X
-    change Matrix.reindex (blockedPairEquiv d).symm (blockedPairEquiv d).symm
-        (refinementSquaredMap T
-          (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
-            (physClose1 (MPOTensor.blockTwo M) X))) =
-      physClose2 (MPOTensor.blockTwo M) X
-    rw [show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
-        (physClose1 (MPOTensor.blockTwo M) X) = physClose2 M X by
-      exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 M) X]
-    rw [refinementSquaredMap_physClose2 M T hTclose X]
-    rw [← show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
-        (physClose2 (MPOTensor.blockTwo M) X) = physClose4 M X by
-      exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 M) X]
-    simp
+  exact blockTwo_isRFPViaTS_of_two_four_maps M
+    (coarseningSquaredMap S) (refinementSquaredMap T)
+    (coarseningSquaredMap_isKrausCPTP hS)
+    (refinementSquaredMap_isKrausCPTP hT)
+    (coarseningSquaredMap_physClose4 M S hSclose)
+    (refinementSquaredMap_physClose2 M T hTclose)
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -82,6 +82,31 @@
     factorization.
 \end{proof}
 
+\begin{theorem}[Blocked renormalization maps from two-to-four maps]
+    \label{thm:mpdo_block_two_rfp_of_two_four_maps}
+    \lean{MPOTensor.blockTwo_isRFPViaTS_of_two_four_maps}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpdo_two_site_blocking}
+    Suppose that trace-preserving completely positive maps
+    $S_{24}$ and $T_{24}$ satisfy
+    \begin{align}
+        S_{24}[\mathcal K_4(X)]&=\mathcal K_2(X), &
+        T_{24}[\mathcal K_2(X)]&=\mathcal K_4(X) \notag
+    \end{align}
+    for every virtual matrix $X$. Then the two-site physical blocking
+    $K^{[2]}$ is a renormalization fixed point.
+\end{theorem}
+
+\begin{proof}\leanok
+    Identify the two-site physical space of $K$ with the one-site physical
+    space of $K^{[2]}$, and identify the four-site physical space of $K$ with
+    the two-site physical space of $K^{[2]}$. These identifications merely
+    permute orthonormal coordinates, so conjugating $S_{24}$ and $T_{24}$ by
+    them preserves complete positivity and trace preservation. The two
+    assumed closure identities then become precisely the two defining
+    renormalization identities for $K^{[2]}$.
+\end{proof}
+
 \begin{theorem}[Two-site blocking preserves renormalization maps]
     \label{thm:mpdo_rfp_via_ts_block_two}
     \lean{MPOTensor.IsRFPViaTS.blockTwo}
@@ -100,6 +125,7 @@
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_block_two_rfp_of_two_four_maps}
     Apply $T$ twice to the first physical site, first passing from two sites to
     three and then from three sites to four. This gives a trace-preserving
     completely positive map from the two-site closure to the four-site closure.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -91,7 +91,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L804, 817, 825, 832, 906, 913 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L329, 335, 341, 355, 366, 372 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L423, 942, 946, 952, 957 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L449, 968, 972, 978, 983 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 494, 498, 699, 703, 716, 720, 763, 767, 771, 780, 784 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- prove that trace-preserving completely positive maps between the two-site and four-site closure families induce renormalization maps for the two-site blocked tensor
- transport the maps through the canonical blocked physical coordinates
- factor the existing blocking-preservation theorem through this map-level result
- add the corresponding proved Blueprint theorem and proof

## Mathematical role

This isolates the exact map-level conclusion needed by issue #6793. It does not claim to construct the two-to-four maps from injectivity, the strong area law, and literal zero correlation length; that remains the substantive sector-mixing problem.

Advances #6793.

## Verification

- `lake env lean TNLean/MPS/MPDO/RFPViaTSBlocking.lean`
- `lake build TNLean.MPS.MPDO.RFPViaTSBlocking TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/feat/issue-6807-support-completion`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity and whitespace checks