### PR TITLE
fix(qic): keep TeX environments atomic

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -136,13 +136,17 @@ disposition. QICLean keeps QIC items and TNLean keeps TN items at the original
 path. Retained item bytes must not change.
 
 The report also simulates the text outside item spans in chapter and appendix
-files. Blank lines and item boundaries divide that text into complete
-paragraph-like blocks. A standalone `\input` command is its own block. Build
-support files remain unchanged apart from this input filtering. A top-level
-leaf prose file with no items or inputs, such as the common introduction, stays
-on both sides. A file defining a non-item label referenced directly by a
-retained item is selected for that side, and the ordinary input ancestor closure
-is then added. This label rule does not select the other inputs of that file.
+files. A complete balanced TeX environment containing no item line is one
+atomic block, including its nested environments and all blank or comment-only
+lines. Outside such environments, blank lines and item boundaries divide the
+text into paragraph-like blocks. A standalone `\input` command is its own
+block. Build support files remain unchanged apart from this input filtering. A
+mismatched, unmatched, or unterminated TeX environment blocks the freeze. A
+top-level leaf prose file with no items or inputs, such as the common
+introduction, stays on both sides. A file defining a non-item label referenced
+directly by a retained item is selected for that side, and the ordinary input
+ancestor closure is then added. This label rule does not select the other inputs
+of that file.
 In a selected file, a non-input block is retained on the maximal set of sides on
 which all its `\ref` and `\eqref` targets resolve. An input block is retained
 exactly on the sides where its target file is selected. References from retained

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -37,6 +37,7 @@ ENV_BEGIN_RE = re.compile(r"\\begin\{(" + "|".join(ENVIRONMENTS) + r")\}")
 ENV_END_RE = re.compile(r"\\end\{(" + "|".join(ENVIRONMENTS) + r")\}")
 PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
 PROOF_END_RE = re.compile(r"\\end\{proof\}")
+ENV_TOKEN_RE = re.compile(r"\\(begin|end)\{([^}]+)\}")
 LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
 LEAN_RE = re.compile(r"\\lean\{([^}]*)\}", re.DOTALL)
 USES_RE = re.compile(r"\\uses\{([^}]*)\}", re.DOTALL)
@@ -236,12 +237,62 @@ def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
     return sorted(records, key=lambda item: (item.file, item.line, item.primary_label or ""))
 
 
+def _atomic_non_item_environment_ranges(
+    source_lines: list[str], covered: set[int], relative_root: str
+) -> dict[int, int]:
+    """Return maximal balanced TeX environments that contain no item line."""
+    stack: list[tuple[str, int]] = []
+    ranges: list[tuple[int, int]] = []
+    for line_no, line in enumerate(source_lines, start=1):
+        cleaned_line = _strip_tex_comments(line)
+        for token in ENV_TOKEN_RE.finditer(cleaned_line):
+            action, environment = token.groups()
+            if action == "begin":
+                stack.append((environment, line_no))
+                continue
+            if not stack:
+                raise ValueError(
+                    f"unmatched \\end{{{environment}}} at {relative_root}:{line_no}"
+                )
+            opened, opened_line = stack.pop()
+            if opened != environment:
+                raise ValueError(
+                    f"mismatched environment at {relative_root}:{line_no}: "
+                    f"opened {opened} at line {opened_line}, closed {environment}"
+                )
+            ranges.append((opened_line, line_no))
+    if stack:
+        environment, opened_line = stack[-1]
+        raise ValueError(
+            f"unterminated environment {environment} opened at "
+            f"{relative_root}:{opened_line}"
+        )
+
+    candidates = [
+        (start, end)
+        for start, end in ranges
+        if not any(line in covered for line in range(start, end + 1))
+    ]
+    maximal: list[tuple[int, int]] = []
+    for start, end in sorted(candidates, key=lambda span: (span[0], -span[1])):
+        contained = any(
+            parent_start <= start and end <= parent_end
+            for parent_start, parent_end in maximal
+        )
+        if contained:
+            continue
+        maximal.append((start, end))
+    return dict(maximal)
+
+
 def blueprint_non_item_blocks(
     blueprint_src: Path, environments: list[BlueprintEnvironment]
 ) -> list[NonItemBlock]:
     """Partition text outside item spans into paragraph-like blocks.
 
-    Blank lines and item boundaries split blocks. Router ``\\input`` commands
+    Complete balanced TeX environments containing no item line are atomic,
+    including nested environments and blank or comment-only lines. Elsewhere,
+    blank lines and item boundaries split blocks. Router ``\\input`` commands
     are single-line blocks so each simulated output can prune them without
     pulling in every sibling chapter.
     """
@@ -262,6 +313,11 @@ def blueprint_non_item_blocks(
             covered.update(range(start, end + 1))
 
         current: list[tuple[int, str]] = []
+        atomic_ranges = (
+            _atomic_non_item_environment_ranges(source_lines, covered, relative_root)
+            if is_content_file
+            else {}
+        )
 
         def flush() -> None:
             nonlocal current
@@ -291,9 +347,22 @@ def blueprint_non_item_blocks(
             )
             current = []
 
-        for line_no, line in enumerate(source_lines, start=1):
+        line_no = 1
+        while line_no <= len(source_lines):
+            line = source_lines[line_no - 1]
             if line_no in covered:
                 flush()
+                line_no += 1
+                continue
+            atomic_end = atomic_ranges.get(line_no)
+            if atomic_end is not None:
+                flush()
+                current = [
+                    (atomic_line, source_lines[atomic_line - 1])
+                    for atomic_line in range(line_no, atomic_end + 1)
+                ]
+                flush()
+                line_no = atomic_end + 1
                 continue
             cleaned_line = _strip_tex_comments(line)
             input_match = INPUT_LINE_RE.fullmatch(cleaned_line)
@@ -309,14 +378,18 @@ def blueprint_non_item_blocks(
                         input_payload=input_match.group(1),
                     )
                 )
+                line_no += 1
                 continue
             if not is_content_file:
                 flush()
+                line_no += 1
                 continue
             if not cleaned_line.strip():
                 flush()
+                line_no += 1
                 continue
             current.append((line_no, line))
+            line_no += 1
         flush()
     return sorted(records, key=lambda item: (item.file, item.line, item.end_line))
 

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -407,6 +407,59 @@ See Theorem~\ref{missing:label}.
         self.assertEqual(report["reference_edge_counts"].get("unclassified"), 1)
 
     @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_nested_non_item_environment_is_atomic_across_comments_and_blanks(
+        self, _source_sha
+    ) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+Opening material.
+\begin{center}
+% explanatory comment
+
+See Theorem~\ref{thm:tn}.
+\end{center}
+\label{fig:atomic}
+\end{figure}
+
+\begin{theorem}\label{thm:tn}
+\lean{MPSTensor.staying}
+\end{theorem}
+"""
+        )
+        report = boundary_report(self.root)
+        blocks = [
+            block
+            for block in report["non_item_blocks"]
+            if block["file"] == "src/chapter/ch01.tex"
+        ]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["line"], 5)
+        self.assertEqual(blocks[0]["end_line"], 13)
+        self.assertEqual(blocks[0]["labels"], ["fig:atomic"])
+        self.assertEqual(blocks[0]["references"], ["thm:tn"])
+        self.assertEqual(blocks[0]["disposition"], "tn")
+
+    def test_rejects_unbalanced_non_item_environment(self) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+Body.
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"unterminated environment figure opened at src/chapter/ch01.tex:5",
+        ):
+            boundary_report(self.root)
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
     def test_unknown_non_item_reference_is_reported(self, _source_sha) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}
@@ -450,6 +503,37 @@ This paragraph cites Theorem~\ref{missing:label}.
         self.assertIn(
             "src/chapter/intro.tex", report["simulated_tn_source_files"]
         )
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_non_item_environment_is_atomic_across_blank_and_comment_lines(
+        self, _source_sha
+    ) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+\begin{center}
+QIC picture.
+
+% explanatory comment
+\end{center}
+\caption{See Theorem~\ref{thm:qic}.}
+\end{figure}
+"""
+        )
+        report = boundary_report(self.root)
+        figure_blocks = [
+            block
+            for block in report["non_item_blocks"]
+            if block["file"] == "src/chapter/ch01.tex"
+            and block["line"] == 5
+        ]
+        self.assertEqual(len(figure_blocks), 1)
+        self.assertEqual(figure_blocks[0]["end_line"], 12)
+        self.assertEqual(figure_blocks[0]["disposition"], "qic")
+        self.assertEqual(report["simulated_output_errors"], [])
 
     @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
     def test_percent_continued_reference_payload_is_normalized(self, _source_sha) -> None:


### PR DESCRIPTION
## What changed

- treat each complete balanced TeX environment outside theorem-like item spans as one atomic block
- preserve nested environments and intervening blank or comment-only lines in the same disposition
- reject mismatched, unmatched, and unterminated environments before producing a freeze report
- add focused tests for the figure structure that exposed the defect, nested environments, and unbalanced input
- state the atomicity rule explicitly in the extraction runbook

This is a follow-up to #6806. It addresses the exact-head review finding that a figure in `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` could be divided between the two simulated outputs, leaving an opening environment on the QIC side and its closing commands on the TN side.

The exact schema-v4 report at `6bdaa53110d86e94886ad926791b029bd49ded64` has 1,477 QIC items and 3,332 TN items. It has zero mixed or unresolved items, zero QIC-to-TN or unclassified edges, and zero simulated-output errors. The checked-in blueprint and TN-interface manifests remain byte-for-byte unchanged.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` (22 tests)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- two byte-identical schema-v4 reports
- generated blueprint and interface manifests match the checked-in files byte-for-byte
- `python3 scripts/check_import_direction.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_tenkz_policy.py`
- `git diff origin/main...HEAD --check`

No Lean source changed. Hosted full CI remains authoritative.

Closes #6817. Advances #6622 and #6560.
