### PR TITLE
feat(MPS/MPDO): specialize active trace relations to literal ZCL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,3 +324,4 @@ follow-up, not against the temporary `sorry` count.
 | `SpinChain.quasiLocalTranslation_one` | helper theorem | Rewriting the identity automorphism as quasi-local translation by zero | `TNLean/QCA/QuasiLocalTranslation.lean` |
 | `Kraus.map_compressed_fixedPoint` | helper theorem | Preserving a supported fixed point under finite-Kraus compression along an isometry | `TNLean/Channel/KrausCornerCompression.lean` |
 | `MPSTensor.eq_zero_of_forall_trace_mul_right_eq_zero` | helper theorem | Concluding that a matrix is zero from vanishing trace pairings against every one-site matrix of an injective tensor | `TNLean/Algebra/TracePairing.lean` |
+| `MPOTensor.IsSAL.physTraceTransfer_ne_zero` | helper theorem | Deriving nonvanishing of the one-site physical-trace transfer from the positive-length normalization clause in saturation of the area law | `TNLean/MPS/MPDO/SALTraceTransfer.lean` |

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -288,6 +288,7 @@ import TNLean.MPS.MPDO.RescalingStableSourceSimple
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut
 import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity
+import TNLean.MPS.MPDO.SALTraceTransfer
 import TNLean.MPS.MPDO.SectorChainFiberContraction
 import TNLean.MPS.MPDO.SectorCompressionSeparation
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -7,6 +7,7 @@ import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.LocalOrthogonalSumAreaLaw
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
+import TNLean.MPS.MPDO.SALTraceTransfer
 import TNLean.MPS.MPDO.SimpleLocalStructure
 
 /-!
@@ -438,13 +439,8 @@ theorem commonWeightAbsorbedBasisMPOTensor_caseII_properties_of_literal_ZCL
     simpa using hEq i
   have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
     fun N _hN σ ↦ (hGauge.sameMPV N σ).symm
-  have hTransfer : physTraceTransfer M ≠ 0 := by
-    intro hZero
-    exact (Classical.choose_spec hSAL).1 1 Nat.zero_lt_one (by
-      rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer, hZero]
-      simp)
   have hSourceZCL : IsSourceZCL M :=
-    isSourceZCL_of_physTraceTransfer_sq M hTransfer hZCL_sq
+    hSAL.isSourceZCL_of_physTraceTransfer_sq hZCL_sq
   exact ⟨commonWeightAbsorbedBasisMPOTensor_isInjective S hWeight hSpan s,
     commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
       M S hM hWeight hnonNil hSpan hSAL s,

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
 import TNLean.MPS.MPDO.ActiveSectorTraceMatrixZCL
+import TNLean.MPS.MPDO.SALTraceTransfer
 
 /-!
 # Zero correlation length on the active inverse-map trace matrix
@@ -139,5 +140,34 @@ theorem exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL
           (Classical.choose hSAL) hZCL
   exact ⟨F₀.rephase z, hη.p, lam, hlam, hη.hp_nonneg, hη.hp_sum,
     hpos, hprim, hrel⟩
+
+/-- Every injective MPO tensor satisfying the strong area law and literal
+idempotence of the physical-trace transfer admits the same positive
+physical-sector factorization and primitive normalized active trace matrix as
+in the source-ZCL theorem.
+
+This specialization retains the square--cube relation; it does not assert
+idempotence or rank one for the active trace matrix, and hence does not by
+itself construct the two-to-four-site channels.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4--C.5 (`propSN` and
+`SALZCL`), lines 1406--1497. The conclusion stops before the invalid rank-one
+inference at lines 1498--1499. -/
+theorem exists_activeTraceMatrix_relations_of_isSAL_of_literal_ZCL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K)
+    (hZCL_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
+    ∃ (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ) (lam : ℝ),
+      0 < lam ∧
+        (∀ k, 0 ≤ p k) ∧
+          (∑ k, p k) = 1 ∧
+            (∀ k h, (F.neighboringOperator k h).PosSemidef) ∧
+              Matrix.IsPrimitive (F.activeSectorTraceMatrix p) ∧
+                let T := F.activeSectorTraceMatrix p
+                ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+                  ∀ N : ℕ, 0 < N →
+                    Matrix.trace ((lam⁻¹ • T) ^ N) =
+                      Matrix.trace (lam⁻¹ • T) :=
+  exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL K hK hSAL
+    (hSAL.isSourceZCL_of_physTraceTransfer_sq hZCL_sq)
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -150,6 +150,14 @@ This specialization retains the square--cube relation; it does not assert
 idempotence or rank one for the active trace matrix, and hence does not by
 itself construct the two-to-four-site channels.
 
+**Local fix (inactive sectors):** Zero-weight sectors remain in the physical
+factorization and are omitted only from the auxiliary trace matrix. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+**Local fix (periodicity):** The inherited primitivity proof uses closed walks
+of lengths two and three in place of blocking periodic components. See the
+same paper-gap note.
+
 Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4--C.5 (`propSN` and
 `SALZCL`), lines 1406--1497. The conclusion stops before the invalid rank-one
 inference at lines 1498--1499. -/

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Entropy.MutualInformationDataProcessing
 import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.RFPViaTSGlobal
+import TNLean.MPS.MPDO.SALTraceTransfer
 
 /-!
 # Saturation of the area law for MPDO renormalization fixed points
@@ -477,13 +478,8 @@ theorem isSourceZCL_and_isSAL_of_isRFPViaTS_of_trace_ne_zero
     (M : MPOTensor d D) (hM : IsMPDO M)
     (hTrace : ∀ N, 0 < N → Matrix.trace (mpo M N) ≠ 0)
     (hRFP : IsRFPViaTS M) : IsSourceZCL M ∧ IsSAL M := by
-  have hTransfer : physTraceTransfer M ≠ 0 := by
-    intro hZero
-    apply hTrace 1 Nat.zero_lt_one
-    rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer, hZero]
-    simp
-  exact ⟨isSourceZCL_of_isRFPViaTS M hRFP hTransfer,
-    isSAL_of_isRFPViaTS_of_trace_ne_zero M hM hTrace hRFP⟩
+  have hSAL := isSAL_of_isRFPViaTS_of_trace_ne_zero M hM hTrace hRFP
+  exact ⟨isSourceZCL_of_isRFPViaTS M hRFP hSAL.physTraceTransfer_ne_zero, hSAL⟩
 
 /-- A matrix product density operator in normalized BNT-refined horizontal
 form satisfying the local renormalization fixed-point equations obeys the

--- a/TNLean/MPS/MPDO/SALTraceTransfer.lean
+++ b/TNLean/MPS/MPDO/SALTraceTransfer.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.SectorTrace
+
+/-!
+# Trace-transfer consequences of saturation of the area law
+
+The normalization clause in saturation of the area law makes the one-site
+physical-trace transfer nonzero. Consequently, literal idempotence of that
+matrix implies the scale-invariant source zero-correlation-length relation.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.6 and Appendix C.2, lines 1406--1497
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- Saturation of the area law forces the physical-trace transfer to be
+nonzero: its vanishing would make the one-site periodic operator have zero
+trace, contrary to the normalization clause in SAL.
+
+Source: arXiv:1606.00608, Definition 4.6 (line 811), together with the
+one-site vertical-loop trace identity used in Appendix C.2. -/
+theorem IsSAL.physTraceTransfer_ne_zero (hSAL : IsSAL M) :
+    physTraceTransfer M ≠ 0 := by
+  intro hZero
+  exact (Classical.choose_spec hSAL).1 1 Nat.zero_lt_one (by
+    rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer, hZero]
+    simp)
+
+/-- Under saturation of the area law, literal idempotence of the
+physical-trace transfer implies source zero correlation length.
+
+Source: arXiv:1606.00608, Definition 4.2 (lines 735--739) and Definition 4.6
+(line 811). -/
+theorem IsSAL.isSourceZCL_of_physTraceTransfer_sq (hSAL : IsSAL M)
+    (hSq : physTraceTransfer M * physTraceTransfer M = physTraceTransfer M) :
+    IsSourceZCL M :=
+  MPOTensor.isSourceZCL_of_physTraceTransfer_sq M hSAL.physTraceTransfer_ne_zero hSq
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -428,16 +428,55 @@
     identities.
 \end{proof}
 
+\begin{lemma}[SAL makes the physical-trace transfer nonzero]
+    \label{lem:mpdo_sal_phys_trace_transfer_nonzero}
+    \lean{MPOTensor.IsSAL.physTraceTransfer_ne_zero}
+    \leanok
+    \uses{def:is_sal, def:mpo_physical_trace_transfer}
+    If an MPO tensor ${\cal K}$ satisfies SAL, then its physical-trace
+    transfer is nonzero:
+    \begin{align}
+        \mathcal T_{\cal K}&\ne0. \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_trace_loop_chain}
+    The SAL normalization at one site gives a nonzero trace for the one-site
+    periodic operator. Lemma~\ref{lem:mpdo_trace_loop_chain} identifies this
+    trace with that of $\mathcal T_{\cal K}$, which therefore cannot vanish.
+\end{proof}
+
+\begin{theorem}[SAL and literal idempotence imply source zero correlation length]
+    \label{thm:mpdo_sal_literal_idempotence_source_zcl}
+    \lean{MPOTensor.IsSAL.isSourceZCL_of_physTraceTransfer_sq}
+    \leanok
+    \uses{def:is_sal, def:mpo_physical_trace_transfer, def:mpo_source_zcl}
+    If ${\cal K}$ satisfies SAL and
+    \begin{align}
+        \mathcal T_{\cal K}^2&=\mathcal T_{\cal K}, \notag
+    \end{align}
+    then ${\cal K}$ has source zero correlation length.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_sal_phys_trace_transfer_nonzero,
+      thm:mpo_source_zcl_of_physical_trace_idempotent}
+    The preceding lemma gives $\mathcal T_{\cal K}\ne0$. Apply
+    Theorem~\ref{thm:mpo_source_zcl_of_physical_trace_idempotent}.
+\end{proof}
+
 \begin{theorem}[Literal-ZCL specialization of the active trace relations]%
     \label{thm:mpdo_active_trace_matrix_literal_zcl_relations}
     \lean{MPOTensor.%
       exists_activeTraceMatrix_relations_of_isSAL_of_literal_ZCL}
     \leanok
-    \uses{def:is_sal, def:mpo_source_zcl,
-      thm:mpdo_active_trace_matrix_zcl_relations}
+    \uses{def:injective, def:is_sal, def:mpo_physical_trace_transfer,
+      def:mpdo_physical_sector_factorization,
+      def:mpdo_active_sector_trace_matrix}
     Let ${\cal K}$ be injective and satisfy SAL and the literal identity
     \begin{align}
-        \mathcal B_{\cal K}^2&=\mathcal B_{\cal K}. \notag
+        \mathcal T_{\cal K}^2&=\mathcal T_{\cal K}. \notag
     \end{align}
     Then ${\cal K}$ admits a physical-sector factorization, nonnegative
     weights of sum one, and positive semidefinite neighboring operators for
@@ -453,9 +492,12 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_sal_literal_idempotence_source_zcl,
+      thm:mpdo_active_trace_matrix_zcl_relations}
     SAL makes the one-site periodic trace nonzero, and hence
-    $\mathcal B_{\cal K}\ne0$. Literal idempotence therefore implies source
-    zero correlation length. Apply
+    $\mathcal T_{\cal K}\ne0$.
+    Theorem~\ref{thm:mpdo_sal_literal_idempotence_source_zcl} therefore gives
+    source zero correlation length. Apply
     Theorem~\ref{thm:mpdo_active_trace_matrix_zcl_relations}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -483,12 +483,11 @@
     which the active trace matrix $T^*$ is primitive. For some
     $\lambda>0$, the normalized matrix
     $\widehat T^*=\lambda^{-1}T^*$ satisfies
-    $(\widehat T^*)^2=(\widehat T^*)^3$ and
+    $(\widehat T^*)^2=(\widehat T^*)^3$ and, for every positive integer $N$,
     \begin{align}
-        \tr((\widehat T^*)^N)&=\tr(\widehat T^*) \notag
+        \tr((\widehat T^*)^N)&=\tr(\widehat T^*). \notag
     \end{align}
-    for every positive integer $N$. No idempotence or rank-one conclusion is
-    asserted.
+    No idempotence or rank-one conclusion is asserted.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -433,7 +433,7 @@
     \lean{MPOTensor.%
       exists_activeTraceMatrix_relations_of_isSAL_of_literal_ZCL}
     \leanok
-    \uses{def:is_sal, def:mpdo_source_zcl,
+    \uses{def:is_sal, def:mpo_source_zcl,
       thm:mpdo_active_trace_matrix_zcl_relations}
     Let ${\cal K}$ be injective and satisfy SAL and the literal identity
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -428,6 +428,37 @@
     identities.
 \end{proof}
 
+\begin{theorem}[Literal-ZCL specialization of the active trace relations]%
+    \label{thm:mpdo_active_trace_matrix_literal_zcl_relations}
+    \lean{MPOTensor.%
+      exists_activeTraceMatrix_relations_of_isSAL_of_literal_ZCL}
+    \leanok
+    \uses{def:is_sal, def:mpdo_source_zcl,
+      thm:mpdo_active_trace_matrix_zcl_relations}
+    Let ${\cal K}$ be injective and satisfy SAL and the literal identity
+    \begin{align}
+        \mathcal B_{\cal K}^2&=\mathcal B_{\cal K}. \notag
+    \end{align}
+    Then ${\cal K}$ admits a physical-sector factorization, nonnegative
+    weights of sum one, and positive semidefinite neighboring operators for
+    which the active trace matrix $T^*$ is primitive. For some
+    $\lambda>0$, the normalized matrix
+    $\widehat T^*=\lambda^{-1}T^*$ satisfies
+    $(\widehat T^*)^2=(\widehat T^*)^3$ and
+    \begin{align}
+        \tr((\widehat T^*)^N)&=\tr(\widehat T^*) \notag
+    \end{align}
+    for every positive integer $N$. No idempotence or rank-one conclusion is
+    asserted.
+\end{theorem}
+
+\begin{proof}\leanok
+    SAL makes the one-site periodic trace nonzero, and hence
+    $\mathcal B_{\cal K}\ne0$. Literal idempotence therefore implies source
+    zero correlation length. Apply
+    Theorem~\ref{thm:mpdo_active_trace_matrix_zcl_relations}.
+\end{proof}
+
 \begin{theorem}[Virtual spanning does not force active-sector idempotence]
     \label{thm:mpdo_virtual_spanning_active_trace_counterexample}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.%

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -324,6 +324,15 @@ and
 {\scriptsize\leanid{MPOTensor.exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL}}
 in \doclink{TNLean/MPS/MPDO/InverseMapActiveSectorZCL}.}
 
+If SAL is accompanied by the paper's literal identity
+$\mathcal B_{\mathcal K}^2=\mathcal B_{\mathcal K}$, the one-site
+normalization clause in SAL first gives $\mathcal B_{\mathcal K}\ne0$.
+Thus literal ZCL implies source ZCL, and the same primitive active trace
+matrix and normalized relations follow without any additional hypothesis.
+This specialization is formalized by
+\leanid{MPOTensor.exists_activeTraceMatrix_relations_of_isSAL_of_literal_ZCL}
+in \doclink{TNLean/MPS/MPDO/InverseMapActiveSectorZCL}.
+
 This conclusion is the scale-invariant consequence of the displayed operator
 equation; it does not imply that the normalized trace matrix is idempotent or
 semisimple, nor that it has rank one.  The remaining pairing route would have

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -324,7 +324,8 @@ and
 {\scriptsize\leanid{MPOTensor.exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL}}
 in \doclink{TNLean/MPS/MPDO/InverseMapActiveSectorZCL}.}
 
-If SAL is accompanied by the paper's literal identity
+Write $\mathcal B_{\mathcal K}$ for the physical-trace transfer of
+$\mathcal K$. If SAL is accompanied by the paper's literal identity
 $\mathcal B_{\mathcal K}^2=\mathcal B_{\mathcal K}$, the one-site
 normalization clause in SAL first gives $\mathcal B_{\mathcal K}\ne0$.
 Thus literal ZCL implies source ZCL, and the same primitive active trace

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,21 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### SAL nonvanishing of the physical-trace transfer — promoted
+- **Pattern:** contradict the positive-length trace clause in `IsSAL` at one
+  site by rewriting the periodic trace as the trace of the vertical loop and
+  then setting the physical-trace transfer equal to zero.
+- **Seen:** three occurrences across
+  `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`,
+  `TNLean/MPS/MPDO/RFPViaTSSAL.lean`, and
+  `TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean` before promotion
+  (2026-08-21).
+- **Abstraction:** `MPOTensor.IsSAL.physTraceTransfer_ne_zero` in
+  `TNLean/MPS/MPDO/SALTraceTransfer.lean`.
+- **Notes:** the two existing proofs now use the common theorem. The same module
+  records the immediate bridge from SAL and literal idempotence to source zero
+  correlation length.
+
 ### Powers on an eigenspace — promoted
 - **Pattern:** prove `(f ^ n) x = μ ^ n • x` from `x ∈ f.eigenspace μ`, either by induction
   using `Module.End.mem_eigenspace_iff` or by splitting on `x = 0` before applying

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -28,16 +28,15 @@ abstracted — record why, so it is not re-proposed).
 - **Pattern:** contradict the positive-length trace clause in `IsSAL` at one
   site by rewriting the periodic trace as the trace of the vertical loop and
   then setting the physical-trace transfer equal to zero.
-- **Seen:** three occurrences across
-  `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`,
-  `TNLean/MPS/MPDO/RFPViaTSSAL.lean`, and
-  `TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean` before promotion
+- **Seen:** two duplicated proofs in `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`
+  and `TNLean/MPS/MPDO/RFPViaTSSAL.lean`; the literal-idempotence bridge in
+  `TNLean/MPS/MPDO/SALTraceTransfer.lean` supplied the third use at promotion
   (2026-08-21).
 - **Abstraction:** `MPOTensor.IsSAL.physTraceTransfer_ne_zero` in
   `TNLean/MPS/MPDO/SALTraceTransfer.lean`.
-- **Notes:** the two existing proofs now use the common theorem. The same module
-  records the immediate bridge from SAL and literal idempotence to source zero
-  correlation length.
+- **Notes:** the two duplicated proofs now use the common theorem. The same
+  module records the immediate bridge from SAL and literal idempotence to
+  source zero correlation length.
 
 ### Powers on an eigenspace — promoted
 - **Pattern:** prove `(f ^ n) x = μ ^ n • x` from `x ∈ f.eigenspace μ`, either by induction


### PR DESCRIPTION
## Mathematical content

- prove that saturation of the area law forces the one-site physical-trace transfer to be nonzero
- derive source zero correlation length from SAL and literal physical-trace idempotence
- specialize the existing primitive active-trace-matrix theorem to the exact injectivity, SAL, and literal-ZCL hypotheses in #6793
- record the corresponding Blueprint theorem and update the rank-one paper-gap analysis
- replace the two earlier copies of the nonvanishing argument by the common theorem and record the promoted proof pattern

The conclusion gives a positive physical-sector factorization, a primitive active trace matrix, the normalized square--cube identity, and constant positive-power traces. It deliberately does not assert idempotence or rank one of the active trace matrix and does not construct the missing two-to-four-site channels. Thus this advances #6793 but does not close it.

This supersedes #6815, which closed automatically when its former intermediate base branch was merged and deleted. The exact rebased head is `905a0acd5bb168c1ee3a9bdbd2e8fa056fb78417`.

## Validation

- `lake env lean TNLean/MPS/MPDO/SALTraceTransfer.lean`
- prior full build of all affected modules and `TNLean` (10,270 jobs), before the ancestry-only rebase
- kernel axiom inspection for all three new theorems: only `propext`, `Classical.choice`, and `Quot.sound`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- reader-facing prose, forbidden-token, import-aggregator, tactic-pattern, tenkz-disposition, and whitespace checks

The earlier local `leanblueprint web` run reached the renderer but the installed plasTeX environment lacks the `leanblueprint` Python package hooks and aborted with pre-existing renderer errors. Hosted blueprint CI remains authoritative for web rendering.