### PR TITLE
fix(qic): reject item-wrapping TeX environments

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex
@@ -338,7 +338,6 @@
     same inverse regroupings as the corresponding global shifts.
 \end{definition}
 
-\begin{samepage}
 \begin{theorem}[The fiberwise shifts are trace-preserving completely positive]
     \label{thm:mpdo_fiberwise_shifts_cptp}
     \lean{MPOTensor.ExplicitEtaOperators.s2SectorMap_isKrausCPTP}
@@ -357,7 +356,6 @@
     therefore trace-preserving and completely positive by
     Theorem~\ref{thm:mpdo_equiv_reindex_cptp}.
 \end{proof}
-\end{samepage}
 
 To record the domains and codomains, set
 \begin{align}

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -238,9 +238,9 @@ def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
 
 
 def _atomic_non_item_environment_ranges(
-    source_lines: list[str], covered: set[int], relative_root: str
+    source_lines: list[str], item_spans: list[tuple[int, int]], relative_root: str
 ) -> dict[int, int]:
-    """Return maximal balanced TeX environments that contain no item line."""
+    """Return maximal balanced TeX environments lying outside item spans."""
     stack: list[tuple[str, int]] = []
     ranges: list[tuple[int, int]] = []
     for line_no, line in enumerate(source_lines, start=1):
@@ -270,20 +270,21 @@ def _atomic_non_item_environment_ranges(
 
     candidates: list[tuple[int, int]] = []
     for start, end in ranges:
-        has_covered = False
-        has_uncovered = False
-        for line in range(start, end + 1):
-            if line in covered:
-                has_covered = True
-            else:
-                has_uncovered = True
-            if has_covered and has_uncovered:
-                raise ValueError(
-                    f"environment at {relative_root}:{start}-{end} contains "
-                    "theorem-like item lines"
-                )
-        if has_covered:
+        contained_in_item = False
+        overlaps_item = False
+        for item_start, item_end in item_spans:
+            if item_start <= start and end <= item_end:
+                contained_in_item = True
+                break
+            if start <= item_end and item_start <= end:
+                overlaps_item = True
+        if contained_in_item:
             continue
+        if overlaps_item:
+            raise ValueError(
+                f"environment at {relative_root}:{start}-{end} contains "
+                "theorem-like item lines"
+            )
         candidates.append((start, end))
     maximal: list[tuple[int, int]] = []
     for start, end in sorted(candidates, key=lambda span: (span[0], -span[1])):
@@ -328,7 +329,9 @@ def blueprint_non_item_blocks(
 
         current: list[tuple[int, str]] = []
         atomic_ranges = (
-            _atomic_non_item_environment_ranges(source_lines, covered, relative_root)
+            _atomic_non_item_environment_ranges(
+                source_lines, spans_by_file.get(relative_root, []), relative_root
+            )
             if is_content_file
             else {}
         )

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -268,11 +268,17 @@ def _atomic_non_item_environment_ranges(
             f"{relative_root}:{opened_line}"
         )
 
-    candidates = [
-        (start, end)
-        for start, end in ranges
-        if not any(line in covered for line in range(start, end + 1))
-    ]
+    candidates: list[tuple[int, int]] = []
+    for start, end in ranges:
+        span = set(range(start, end + 1))
+        if span & covered:
+            if not span <= covered:
+                raise ValueError(
+                    f"environment at {relative_root}:{start}-{end} contains "
+                    "theorem-like item lines"
+                )
+            continue
+        candidates.append((start, end))
     maximal: list[tuple[int, int]] = []
     for start, end in sorted(candidates, key=lambda span: (span[0], -span[1])):
         contained = any(
@@ -291,8 +297,10 @@ def blueprint_non_item_blocks(
     """Partition text outside item spans into paragraph-like blocks.
 
     Complete balanced TeX environments containing no item line are atomic,
-    including nested environments and blank or comment-only lines. Elsewhere,
-    blank lines and item boundaries split blocks. Router ``\\input`` commands
+    including nested environments and blank or comment-only lines. An outer
+    environment containing item lines is rejected because partitioning it at
+    the item boundary would produce malformed TeX. Elsewhere, blank lines and
+    item boundaries split blocks. Router ``\\input`` commands
     are single-line blocks so each simulated output can prune them without
     pulling in every sibling chapter.
     """

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -270,13 +270,19 @@ def _atomic_non_item_environment_ranges(
 
     candidates: list[tuple[int, int]] = []
     for start, end in ranges:
-        span = set(range(start, end + 1))
-        if span & covered:
-            if not span <= covered:
+        has_covered = False
+        has_uncovered = False
+        for line in range(start, end + 1):
+            if line in covered:
+                has_covered = True
+            else:
+                has_uncovered = True
+            if has_covered and has_uncovered:
                 raise ValueError(
                     f"environment at {relative_root}:{start}-{end} contains "
                     "theorem-like item lines"
                 )
+        if has_covered:
             continue
         candidates.append((start, end))
     maximal: list[tuple[int, int]] = []

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -458,6 +458,22 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_wrapper_spanning_two_fully_covered_items(self) -> None:
+        self.write_blueprint(
+            r"""\begin{samepage}\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+\begin{theorem}\label{thm:tn}
+\lean{MPSTensor.staying}
+\end{theorem}\end{samepage}
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"environment at src/chapter/ch01.tex:1-6 contains theorem-like item lines",
+        ):
+            boundary_report(self.root)
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -443,6 +443,21 @@ See Theorem~\ref{thm:tn}.
         self.assertEqual(blocks[0]["references"], ["thm:tn"])
         self.assertEqual(blocks[0]["disposition"], "tn")
 
+    def test_rejects_non_item_environment_containing_item(self) -> None:
+        self.write_blueprint(
+            r"""\begin{figure}
+\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+\end{figure}
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"environment at src/chapter/ch01.tex:1-5 contains theorem-like item lines",
+        ):
+            boundary_report(self.root)
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}


### PR DESCRIPTION
## What changed

- reject a balanced outer TeX environment when it contains theorem-like item lines, instead of letting the simulated QIC/TN partition split its opening and closing commands
- remove the only live item-wrapping `samepage` environment, around `thm:mpdo_fiberwise_shifts_cptp`
- add a regression test proving the freeze fails closed on a `figure` wrapped around a theorem

The checked-in blueprint and TN-interface manifests remain byte-for-byte unchanged. The exact schema-v4 report still has 1,477 QIC items, 3,332 TN items, 163 blueprint paths, 267 TN interface labels, zero QIC-to-TN edges, and zero simulated-output errors.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` (24 tests)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- two byte-identical schema-v4 reports
- generated blueprint and interface manifests match the checked-in files byte-for-byte
- `python3 scripts/check_import_direction.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_tenkz_policy.py`
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`, with zero undefined cross-references
- `git diff --check`

No Lean source changed. Hosted full CI remains authoritative.

Closes #6821. Advances #6622 and #6560.