### PR TITLE
doc(blueprint): repair boundary-decomposition dependencies and source citations

### DIFF
--- a/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
+++ b/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
@@ -19,7 +19,8 @@ transformation applies at every chain length.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Appendix C.2, lines 1646--1665 and 1810--1825.
+  bicanonical-form gauge convention at lines 1666--1674, and Appendix C.2,
+  lines 1646--1665 and 1810--1825.
 -/
 
 open scoped Matrix BigOperators
@@ -78,8 +79,9 @@ The formula holds at every length with one boundary transformation
 \(G^{-1}XG\). In particular, its specializations at the two closure lengths
 in Definition 4.1 use the same representative boundary matrices.
 
-Source: arXiv:1606.00608, canonical form at lines 237--246 and Appendix C.2,
-lines 1646--1665 and 1810--1825. -/
+Source: arXiv:1606.00608, canonical form at lines 237--246, bicanonical-form
+gauge convention at lines 1666--1674, and Appendix C.2, lines 1646--1665 and
+1810--1825. -/
 theorem physCloseN_eq_sum_flatBasis_of_gauge_toTensor
     (S : MPSTensor.SectorDecomposition (d * d))
     (M : MPOTensor d S.totalDim)

--- a/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
+++ b/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
@@ -19,7 +19,7 @@ transformation applies at every chain length.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  bicanonical-form gauge convention at lines 1666--1674, and Appendix C.2,
+  gauge-matrix similarity convention at lines 186--195, and Appendix C.2,
   lines 1646--1665 and 1810--1825.
 -/
 
@@ -79,9 +79,9 @@ The formula holds at every length with one boundary transformation
 \(G^{-1}XG\). In particular, its specializations at the two closure lengths
 in Definition 4.1 use the same representative boundary matrices.
 
-Source: arXiv:1606.00608, canonical form at lines 237--246, bicanonical-form
-gauge convention at lines 1666--1674, and Appendix C.2, lines 1646--1665 and
-1810--1825. -/
+Source: arXiv:1606.00608, canonical form at lines 237--246, gauge-matrix
+similarity convention at lines 186--195, and Appendix C.2, lines 1646--1665
+and 1810--1825. -/
 theorem physCloseN_eq_sum_flatBasis_of_gauge_toTensor
     (S : MPSTensor.SectorDecomposition (d * d))
     (M : MPOTensor d S.totalDim)

--- a/TNLean/MPS/SharedInfra/BoundaryDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/BoundaryDecomposition.lean
@@ -99,8 +99,8 @@ theorem trace_evalWord_toTensorFromBlocks_mul
 
 /-- Moving an invertible virtual gauge from a tensor word to its boundary.
 
-Source: arXiv:1606.00608, canonical gauge convention at lines 237--246 and
-Appendix C.2, lines 1646--1665. -/
+Source: arXiv:1606.00608, bicanonical-form gauge convention at lines
+1666--1674 and Appendix C.2, lines 1646--1665. -/
 theorem trace_evalWord_gauge_mul
     {A B : MPSTensor d D} (G : GL (Fin D) ℂ)
     (hG : ∀ i, B i =
@@ -138,8 +138,8 @@ The same transformed boundary is used at every word length. This is the
 arbitrary-boundary identity required when the one-site and two-site channel
 equations are combined over canonical sectors.
 
-Source: arXiv:1606.00608, canonical gauge convention at lines 237--246 and
-Appendix C.2, lines 1646--1665 and 1810--1825. -/
+Source: arXiv:1606.00608, bicanonical-form gauge convention at lines
+1666--1674 and Appendix C.2, lines 1646--1665 and 1810--1825. -/
 theorem trace_evalWord_gauge_toTensorFromBlocks_mul
     (weight : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (B : MPSTensor d (∑ j : Fin r, dim j))

--- a/TNLean/MPS/SharedInfra/BoundaryDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/BoundaryDecomposition.lean
@@ -99,8 +99,8 @@ theorem trace_evalWord_toTensorFromBlocks_mul
 
 /-- Moving an invertible virtual gauge from a tensor word to its boundary.
 
-Source: arXiv:1606.00608, bicanonical-form gauge convention at lines
-1666--1674 and Appendix C.2, lines 1646--1665. -/
+Source: arXiv:1606.00608, gauge-matrix similarity convention at lines
+186--195 and Appendix C.2, lines 1646--1665. -/
 theorem trace_evalWord_gauge_mul
     {A B : MPSTensor d D} (G : GL (Fin D) ℂ)
     (hG : ∀ i, B i =
@@ -138,8 +138,8 @@ The same transformed boundary is used at every word length. This is the
 arbitrary-boundary identity required when the one-site and two-site channel
 equations are combined over canonical sectors.
 
-Source: arXiv:1606.00608, bicanonical-form gauge convention at lines
-1666--1674 and Appendix C.2, lines 1646--1665 and 1810--1825. -/
+Source: arXiv:1606.00608, gauge-matrix similarity convention at lines
+186--195 and Appendix C.2, lines 1646--1665 and 1810--1825. -/
 theorem trace_evalWord_gauge_toTensorFromBlocks_mul
     (weight : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (B : MPSTensor d (∑ j : Fin r, dim j))

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -505,7 +505,7 @@
     \end{align}
     The conjugated boundary $G^{-1}XG$ is independent of the word length.
     This is the arbitrary-boundary form of the block calculation used in
-    \cite[Appendix~C.2, lines~1646--1665 and 1810--1825]
+    \cite[Appendix~C.2, lines~1646--1674 and 1810--1825]
       {Cirac2016MPDO_arXiv}.
 \end{theorem}
 
@@ -528,24 +528,40 @@
       MPOTensor.physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor}
     \leanok
     \uses{thm:mpdo_canonical_block_sum_arbitrary_boundary,
-      def:mpdo_common_sector_weight_absorption}
-    Let the complete tensor be exactly gauge equivalent, by an invertible
-    virtual matrix $G$, to a canonical BNT sum. Suppose that the repeated-copy
-    weights over each fixed BNT representative are equal, with no equality
-    required between different representatives. Absorb this common weight
-    into its representative. Then, for every length $N$ and every virtual
-    boundary $X$, the closure of the complete tensor is the sum of the
-    absorbed-representative closures. The boundary of a representative is the
-    sum of the diagonal copy blocks of $G^{-1}XG$ lying over that
-    representative. In particular, the same representative boundary map
-    applies at the two lengths entering the two channel equations of
-    Definition~\ref{def:is_rfp_via_ts}.
+      def:mpdo_common_sector_weight_absorption, def:phys_close}
+    Let the complete tensor $B$ be exactly gauge equivalent, by an invertible
+    virtual matrix $G$, to a sector decomposition: a finite family of basis
+    blocks $A_j$, $j=1,\ldots,g$, each carrying a copy multiplicity $r_j$ and
+    nonzero weights $\mu_{j,q}$, with no canonical-form or
+    basis-of-normal-tensors hypothesis imposed on the $A_j$. Suppose that the
+    repeated-copy weights over each basis block are equal, with no equality
+    required between different basis blocks, and absorb this common weight
+    into its representative $\mathcal K_j$ as in
+    Definition~\ref{def:mpdo_common_sector_weight_absorption}. Then, for every
+    length $N$ and every virtual boundary $X$, the physical closure of the
+    complete tensor is the sum of the absorbed-representative closures, with
+    the boundary of a representative given by the sum of the diagonal copy
+    blocks of $G^{-1}XG$ lying over it:
+    \begin{align}
+        B_N(X)
+         & =
+        \sum_{j=1}^g (\mathcal K_j)_N\Bigl(\sum_{q=1}^{r_j}
+          (G^{-1}XG)_{(j,q),(j,q)}\Bigr).
+        \notag
+    \end{align}
+    Neither the conjugation $X\mapsto G^{-1}XG$ nor the subsequent sum of
+    diagonal copy blocks depends on $N$. In particular, the same
+    representative boundary map applies at the two lengths entering the two
+    channel equations of Definition~\ref{def:is_rfp_via_ts}. This is the
+    arbitrary-boundary form of the block calculation used in
+    \cite[Appendix~C.2, lines~1646--1674 and 1810--1825]
+      {Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
     Apply Theorem~\ref{thm:mpdo_canonical_block_sum_arbitrary_boundary} to the
     block sum indexed by the individual copies. Reindex this finite sum by a
-    representative $s$ and a copy label $q$. For fixed $s$, all copy weights
+    representative $j$ and a copy label $q$. For fixed $j$, all copy weights
     are equal, so their common $N$-th power may be absorbed into the length
     $N$ word of the representative tensor. The remaining dependence on $q$
     is linear in the diagonal boundary block. Summing over $q$ therefore

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -505,7 +505,7 @@
     \end{align}
     The conjugated boundary $G^{-1}XG$ is independent of the word length.
     This is the arbitrary-boundary form of the block calculation used in
-    \cite[Appendix~C.2, lines~1646--1674 and 1810--1825]
+    \cite[lines~186--195 and Appendix~C.2, lines~1646--1665 and 1810--1825]
       {Cirac2016MPDO_arXiv}.
 \end{theorem}
 
@@ -529,11 +529,13 @@
     \leanok
     \uses{thm:mpdo_canonical_block_sum_arbitrary_boundary,
       def:mpdo_common_sector_weight_absorption, def:phys_close}
+    % The basis blocks are an arbitrary family: the linked declarations take
+    % a generic sector decomposition carrying no canonical-form or
+    % basis-of-normal-tensors witness.
     Let the complete tensor $B$ be exactly gauge equivalent, by an invertible
-    virtual matrix $G$, to a sector decomposition: a finite family of basis
-    blocks $A_j$, $j=1,\ldots,g$, each carrying a copy multiplicity $r_j$ and
-    nonzero weights $\mu_{j,q}$, with no canonical-form or
-    basis-of-normal-tensors hypothesis imposed on the $A_j$. Suppose that the
+    virtual matrix $G$, to a sector decomposition: an arbitrary finite family
+    of basis blocks $A_j$, $j=1,\ldots,g$, each carrying a copy multiplicity
+    $r_j$ and nonzero weights $\mu_{j,q}$. Suppose that the
     repeated-copy weights over each basis block are equal, with no equality
     required between different basis blocks, and absorb this common weight
     into its representative $\mathcal K_j$ as in
@@ -554,7 +556,7 @@
     representative boundary map applies at the two lengths entering the two
     channel equations of Definition~\ref{def:is_rfp_via_ts}. This is the
     arbitrary-boundary form of the block calculation used in
-    \cite[Appendix~C.2, lines~1646--1674 and 1810--1825]
+    \cite[lines~186--195 and Appendix~C.2, lines~1646--1665 and 1810--1825]
       {Cirac2016MPDO_arXiv}.
 \end{theorem}
 

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -1034,9 +1034,11 @@ statement is tracked in \ghissue{6632}, retargeted from the refuted raw
 The arbitrary-boundary part of this construction is now formalized by
 \leanid{MPSTensor.trace_evalWord_gauge_toTensorFromBlocks_mul} and
 \leanid{MPOTensor.%
-physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor}. If $X$ is an
-arbitrary virtual boundary, the boundary entering a fixed representative is
-the sum of the diagonal copy blocks of $G^{-1}XG$ over that representative.
+physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor}. Let $G$ be the
+invertible virtual matrix implementing the gauge equivalence between the raw
+tensor and its sector decomposition, and let $X$ be an arbitrary virtual
+boundary. The boundary entering a fixed representative is the sum of the
+diagonal copy blocks of $G^{-1}XG$ over that representative.
 The same transformation is valid at every chain length.  Copy-weight equality
 is used only among copies of one representative, so this calculation imposes
 no relation between distinct BNT coefficients.  The remaining content of


### PR DESCRIPTION
## Statement-integrity audit

**Paper assumptions vs. Lean assumptions.** Both touched theorems
(`MPOTensor.physCloseN_eq_sum_flatBasis_of_gauge_toTensor`,
`MPOTensor.physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor`)
take `S : MPSTensor.SectorDecomposition (d * d)`, a generic finite family of
basis blocks with multiplicity and weight data (`copies`, `weight`,
`totalDim`), with no `IsBNTCanonicalForm` witness anywhere in either proof.
`thm:mpdo_absorbed_representative_boundary_decomposition` previously called
this hypothesis a "canonical BNT sum," overstating the restriction and
colliding with the chapter's separately established `def:sector_bnt_cf`
("BNT canonical form") terminology. The statement now reads "a sector
decomposition" and explicitly disclaims any canonical-form or
basis-of-normal-tensors hypothesis on the basis blocks, matching
`def:sector_weight_data`.

**Paper conclusion vs. Lean conclusion.** Both theorems conclude an exact
equality of `physCloseN` values (a sum over basis-block/representative
closures with boundary given by diagonal copy blocks of the conjugated
boundary `G^{-1}XG`); the Lean conclusions are unchanged by this PR. Only
prose, the `\uses` graph, a displayed equation, and source-line citations
were edited.

**Relevant definitions.** `def:phys_close` (physical closure `M_N(X)`) is now
listed as a `\uses` dependency of
`thm:mpdo_absorbed_representative_boundary_decomposition`, since both cited
Lean theorems literally return `physCloseN`. `def:sector_weight_data` remains
reachable transitively via `def:mpdo_common_sector_weight_absorption`
(already listed), per the blueprint style guide's "keep `\uses` minimal,
transitive deps are automatic" rule.

**Proof status.** Unchanged; every edit in this PR is docstring/prose-only
(blueprint `.tex` statements, Lean doc comments, and a paper-gap note). No
Lean declaration signature, hypothesis, or proof term changed. Both touched
Lean files (`TNLean/MPS/SharedInfra/BoundaryDecomposition.lean`,
`TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean`) still elaborate and build
cleanly.

**Source verification (issue #6812).** Read
`Papers/1606.00608/MPDO-22-12-17-2.tex` directly:
- Lines 217-260 (specifically 237-246) are Definition "canonical form" (CF),
  eq:II_CF1, `A^i = ⊕_k μ_k A^i_k` with `A_k` normal tensors, plus the
  remark that `|μ_k| ≤ 1` may be chosen. No invertible virtual gauge matrix
  appears in this passage.
- Lines 1646-1690: lines 1646-1658 are Lemma `lemmus` (ZCL forces
  `μ_{j,q}` independent of `q`); lines 1660-1665 are equation CFK (absorbing
  the common weight into the representative); lines 1666-1674 state that,
  since `K` is in biCF, there exists an inverse tensor `K^{-1}` such that
  conjugating recovers the original tensor (eq. biCFK, eq. Kidentity) — a
  tensor identity, not an invertible virtual gauge.
- Lines 186-195 introduce the gauge-matrix similarity convention, with the
  displayed equation `B^i = X C^i X^{-1}` for a nonsingular matrix `X` —
  this is the passage matching the Lean hypothesis
  `∀ i, B i = G * A i * G⁻¹` (review round two corrected the first fix,
  which had cited the biCF inverse-tensor passage at 1666-1674).

The wrong "lines 237-246" anchor for the gauge hypothesis is corrected to
"gauge-matrix similarity convention at lines 186-195" in
`MPSTensor.trace_evalWord_gauge_mul`,
`MPSTensor.trace_evalWord_gauge_toTensorFromBlocks_mul` (both in
`TNLean/MPS/SharedInfra/BoundaryDecomposition.lean`), the module reference
list and the `physCloseN_eq_sum_flatBasis_of_gauge_toTensor` docstring in
`TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean`, and both blueprint theorems
`thm:mpdo_canonical_block_sum_arbitrary_boundary` and
`thm:mpdo_absorbed_representative_boundary_decomposition` (both now cite
lines 186--195 for the gauge convention alongside the unchanged Appendix
C.2 ranges 1646--1665 and 1810--1825).

**Faithfulness verdict.** No hypothesis or conclusion changed; this PR only
repairs terminology, a `\uses` dependency edge, a missing displayed equation,
and source-line citations so the blueprint and docstrings accurately
describe what the existing Lean theorems already state and prove. No new
`sorry`/`axiom`, no paper-realignment marker needed.

## Changes

- `blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex`:
  add `def:phys_close` to `thm:mpdo_absorbed_representative_boundary_decomposition`'s
  `\uses`; reword its hypothesis from "canonical BNT sum" to a generic
  sector-decomposition hypothesis with no canonical-form/BNT witness; add a
  displayed equation for the representative-boundary identity, in the same
  notation style as the sibling theorem immediately above it; cite lines
  186--195 for the gauge-matrix similarity convention in both theorems and
  state the arbitrary block family directly (signature comparison moved to
  a LaTeX comment).
- `TNLean/MPS/SharedInfra/BoundaryDecomposition.lean`,
  `TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean`: correct the wrong
  "canonical gauge convention at lines 237--246" citation to the verified
  "gauge-matrix similarity convention at lines 186--195" wherever it
  anchors the invertible-gauge hypothesis.
- `docs/paper-gaps/cpgsv17_pf_rank_one.tex`: introduce the gauge matrix `G`
  before its first use in `G^{-1}XG` (the boundary `X` was already
  introduced in the same sentence), per `docs/paper-gaps/policy.tex`.

## Validation

```
lake env lean TNLean/MPS/SharedInfra/BoundaryDecomposition.lean   # clean
lake build TNLean.MPS.SharedInfra.BoundaryDecomposition           # built successfully
lake build TNLean.MPS.MPDO.BNTBoundaryDecomposition                # built successfully (9217/9217 jobs)
python3 scripts/blueprint_lean_sync.py --update-lean-decls         # 8149/8149, 100% in sync
python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint \
  --changed-files TNLean/MPS/SharedInfra/BoundaryDecomposition.lean \
    TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean \
  --diff-base origin/main --diff-head HEAD                         # no missing blueprint entries
```

`leanblueprint checkdecls` was attempted but reported dozens of pre-existing
"missing" declarations unrelated to this PR's files (e.g.
`MPOTensor.CPSVExample412Literal.*`, `MPOTensor.VerticalCoefficientPresentationCounterexample.*`);
this is a partial-build artifact of not running a full `lake build` in this
worktree (forbidden by repo policy), not a regression introduced here — both
targeted modules built and elaborated cleanly on their own.

Closes #6810
Closes #6812

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E

