### PR TITLE
fix(qic): keep inline TeX environments in prose blocks

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -136,12 +136,15 @@ disposition. QICLean keeps QIC items and TNLean keeps TN items at the original
 path. Retained item bytes must not change.
 
 The report also simulates the text outside item spans in chapter and appendix
-files. A complete balanced TeX environment containing no item line is one
-atomic block, including its nested environments and all blank or comment-only
-lines. Outside such environments, blank lines and item boundaries divide the
-text into paragraph-like blocks. A standalone `\input` command is its own
-block. Build support files remain unchanged apart from this input filtering. A
-mismatched, unmatched, or unterminated TeX environment blocks the freeze. A
+files. A complete balanced TeX environment containing no item line and spanning
+more than one source line is one atomic block, including its nested
+environments and all blank or comment-only lines. A single-line environment,
+such as an inline `smallmatrix`, remains part of its surrounding paragraph.
+An environment containing theorem-like item lines blocks the freeze. Outside
+such environments, blank lines and item boundaries divide the text into
+paragraph-like blocks. A standalone `\input` command is its own block. Build
+support files remain unchanged apart from this input filtering. A mismatched,
+unmatched, or unterminated TeX environment also blocks the freeze. A
 top-level leaf prose file with no items or inputs, such as the common
 introduction, stays on both sides. A file defining a non-item label referenced
 directly by a retained item is selected for that side, and the ordinary input

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -303,8 +303,9 @@ def blueprint_non_item_blocks(
 ) -> list[NonItemBlock]:
     """Partition text outside item spans into paragraph-like blocks.
 
-    Complete balanced TeX environments containing no item line are atomic,
-    including nested environments and blank or comment-only lines. An outer
+    Multiline balanced TeX environments containing no item line are atomic,
+    including nested environments and blank or comment-only lines. A
+    single-line environment remains in its surrounding paragraph. An outer
     environment containing item lines is rejected because partitioning it at
     the item boundary would produce malformed TeX. Elsewhere, blank lines and
     item boundaries split blocks. Router ``\\input`` commands
@@ -373,6 +374,10 @@ def blueprint_non_item_blocks(
                 continue
             atomic_end = atomic_ranges.get(line_no)
             if atomic_end is not None:
+                if atomic_end == line_no:
+                    current.append((line_no, line))
+                    line_no += 1
+                    continue
                 flush()
                 current = [
                     (atomic_line, source_lines[atomic_line - 1])

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -567,6 +567,31 @@ QIC picture.
         self.assertEqual(report["simulated_output_errors"], [])
 
     @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_inline_environment_stays_in_surrounding_paragraph(
+        self, _source_sha
+    ) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+The matrix
+$J=\bigl(\begin{smallmatrix}0&1\\-1&0\end{smallmatrix}\bigr)$
+has the property in Theorem~\ref{thm:qic}.
+"""
+        )
+        report = boundary_report(self.root)
+        blocks = [
+            block
+            for block in report["non_item_blocks"]
+            if block["file"] == "src/chapter/ch01.tex"
+        ]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual((blocks[0]["line"], blocks[0]["end_line"]), (5, 7))
+        self.assertEqual(blocks[0]["references"], ["thm:qic"])
+        self.assertEqual(blocks[0]["disposition"], "qic")
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
     def test_percent_continued_reference_payload_is_normalized(self, _source_sha) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}


### PR DESCRIPTION
## Summary

- keep a balanced TeX environment whose opening and closing commands occur on one source line within its surrounding prose block
- retain multiline, item-free environments as independent atomic blocks
- add an inline-matrix regression test and state the distinction in the freeze runbook

Without this distinction, an inline `smallmatrix` separates the prose before it from a following reference. The reference then acquires a different disposition, so the freeze may silently omit part of one mathematical paragraph.

This pull request is stacked on #6826, which supplies the independent rejection rule for environments wrapping theorem-like items. After #6826 merges, this branch should be rebased onto `main` before merge.

Closes #6822.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` — 25 tests pass
- Python bytecode compilation passes
- two generated schema-v4 reports are byte-identical
- generated blueprint and TN-interface manifests match the checked-in files byte-for-byte
- 1,477 QIC items and 3,332 TN items
- 10,986 internal and 501 TN-to-QIC `uses` edges
- 3,427 internal and 138 TN-to-QIC item-reference edges
- 411 internal and 44 TN-to-QIC non-item-reference edges
- zero simulated-output errors
- `git diff --check` passes
- exact head: `ca260be878ba8b4b64550e50be35a4ddefe7c97c`