### PR TITLE
fix(qic): reject nested standalone inputs

### DIFF
--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -136,12 +136,16 @@ disposition. QICLean keeps QIC items and TNLean keeps TN items at the original
 path. Retained item bytes must not change.
 
 The report also simulates the text outside item spans in chapter and appendix
-files. A complete balanced TeX environment containing no item line is one
-atomic block, including its nested environments and all blank or comment-only
-lines. Outside such environments, blank lines and item boundaries divide the
-text into paragraph-like blocks. A standalone `\input` command is its own
-block. Build support files remain unchanged apart from this input filtering. A
-mismatched, unmatched, or unterminated TeX environment blocks the freeze. A
+files. A complete balanced TeX environment containing no item line and spanning
+more than one source line is one atomic block, including its nested
+environments and all blank or comment-only lines. A single-line environment,
+such as an inline `smallmatrix`, remains part of its surrounding paragraph.
+An environment containing theorem-like item lines blocks the freeze. Outside
+such environments, blank lines and item boundaries divide the text into
+paragraph-like blocks. A standalone `\input` command is its own block, but a
+standalone input nested inside an atomic environment blocks the freeze. Build
+support files remain unchanged apart from this input filtering. A mismatched,
+unmatched, or unterminated TeX environment also blocks the freeze. A
 top-level leaf prose file with no items or inputs, such as the common
 introduction, stays on both sides. A file defining a non-item label referenced
 directly by a retained item is selected for that side, and the ordinary input

--- a/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
+++ b/docs/audits/2026-08-20_qiclean_atomic_extraction_runbook.md
@@ -143,7 +143,8 @@ such as an inline `smallmatrix`, remains part of its surrounding paragraph.
 An environment containing theorem-like item lines blocks the freeze. Outside
 such environments, blank lines and item boundaries divide the text into
 paragraph-like blocks. A standalone `\input` command is its own block, but a
-standalone input nested inside an atomic environment blocks the freeze. Build
+standalone input nested inside an atomic environment or theorem-like item
+blocks the freeze. Build
 support files remain unchanged apart from this input filtering. A mismatched,
 unmatched, or unterminated TeX environment also blocks the freeze. A
 top-level leaf prose file with no items or inputs, such as the common

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -240,7 +240,7 @@ def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
 def _atomic_non_item_environment_ranges(
     source_lines: list[str], item_spans: list[tuple[int, int]], relative_root: str
 ) -> dict[int, int]:
-    """Return maximal balanced TeX environments lying outside item spans."""
+    """Validate item inputs and return maximal environments outside item spans."""
     stack: list[tuple[str, int]] = []
     ranges: list[tuple[int, int]] = []
     for line_no, line in enumerate(source_lines, start=1):
@@ -267,6 +267,14 @@ def _atomic_non_item_environment_ranges(
             f"unterminated environment {environment} opened at "
             f"{relative_root}:{opened_line}"
         )
+
+    for item_start, item_end in item_spans:
+        for line_no in range(item_start, item_end + 1):
+            if INPUT_LINE_RE.fullmatch(_strip_tex_comments(source_lines[line_no - 1])):
+                raise ValueError(
+                    f"theorem-like item at {relative_root}:{item_start}-{item_end} "
+                    f"contains standalone \\input at line {line_no}"
+                )
 
     candidates: list[tuple[int, int]] = []
     for start, end in ranges:
@@ -315,9 +323,9 @@ def blueprint_non_item_blocks(
     Single-line environments remain in their surrounding paragraph. An outer
     environment containing item lines is rejected because partitioning it at
     the item boundary would produce malformed TeX. A standalone ``\\input``
-    nested inside an atomic environment is rejected because its target-file
-    dependency cannot be separated from that environment. Elsewhere, blank
-    lines and item boundaries split blocks. Router ``\\input`` commands
+    nested inside an atomic environment or a theorem-like item is rejected
+    because its target-file dependency cannot be separated from that span.
+    Elsewhere, blank lines and item boundaries split blocks. Router ``\\input`` commands
     are single-line blocks so each simulated output can prune them without
     pulling in every sibling chapter.
     """

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -295,6 +295,13 @@ def _atomic_non_item_environment_ranges(
         if contained:
             continue
         maximal.append((start, end))
+    for start, end in maximal:
+        for line_no in range(start, end + 1):
+            if INPUT_LINE_RE.fullmatch(_strip_tex_comments(source_lines[line_no - 1])):
+                raise ValueError(
+                    f"atomic environment at {relative_root}:{start}-{end} contains "
+                    f"standalone \\input at line {line_no}"
+                )
     return dict(maximal)
 
 
@@ -307,8 +314,10 @@ def blueprint_non_item_blocks(
     atomic, including nested environments and blank or comment-only lines.
     Single-line environments remain in their surrounding paragraph. An outer
     environment containing item lines is rejected because partitioning it at
-    the item boundary would produce malformed TeX. Elsewhere, blank lines and
-    item boundaries split blocks. Router ``\\input`` commands
+    the item boundary would produce malformed TeX. A standalone ``\\input``
+    nested inside an atomic environment is rejected because its target-file
+    dependency cannot be separated from that environment. Elsewhere, blank
+    lines and item boundaries split blocks. Router ``\\input`` commands
     are single-line blocks so each simulated output can prune them without
     pulling in every sibling chapter.
     """

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -489,6 +489,22 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_standalone_input_inside_theorem_item(self) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\input{chapter/picture}
+\end{theorem}
+"""
+        )
+        self.write_blueprint("Picture body.\n", "picture.tex")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"theorem-like item at src/chapter/ch01.tex:1-4 contains "
+            r"standalone \\input at line 3",
+        ):
+            boundary_report(self.root)
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -474,6 +474,21 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_standalone_input_inside_atomic_environment(self) -> None:
+        self.write_blueprint(
+            r"""\begin{figure}
+\input{chapter/picture}
+\end{figure}
+"""
+        )
+        self.write_blueprint("Picture body.\n", "picture.tex")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"atomic environment at src/chapter/ch01.tex:1-3 contains "
+            r"standalone \\input at line 2",
+        ):
+            boundary_report(self.root)
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}


### PR DESCRIPTION
## Summary

- reject a standalone `\input{...}` command nested inside an atomic non-item TeX environment
- report both the enclosing environment span and the input line
- add a regression test and state the fail-closed rule in the extraction runbook

An atomic environment is retained as one prose block, whereas the input-closure calculation only follows independent router blocks. Treating a nested input as ordinary prose therefore preserves the command but can omit its target file. Rejecting the structure prevents a broken extracted blueprint without splitting the enclosing environment.

This pull request is stacked on #6828, after the item-wrapper guard in #6826. It should be rebased onto `main` after those two pull requests merge.

Closes #6823.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` — 27 tests pass
- Python bytecode compilation passes
- two generated schema-v4 reports are byte-identical
- generated blueprint and TN-interface manifests match the checked-in files byte-for-byte
- zero simulated-output errors on the live blueprint
- `git diff --check` passes
- exact head: `9a6627ad2f421e8527876893e4f48c9e5a0c7cd0`
