### PR TITLE
feat(MPS/MPDO): prove scale-covariant vertical coefficient transport

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -354,4 +354,5 @@ import TNLean.MPS.MPDO.VerticalSectorRetractions
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSpectral
+import TNLean.MPS.MPDO.VerticalTransportCoefficientCovariance
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
+++ b/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
@@ -15,8 +15,8 @@ clauses; the explicit counterexample is in
 `TNLean/MPS/MPDO/VerticalCoefficientPresentationCounterexample.lean`.  This
 file proves the positive replacement statement: once an explicit vertical
 transport is assumed between the two per-length operator families, consisting
-of a label equivalence \(e\), nonzero scalars \(s_\alpha\), and per-length
-algebra isomorphisms \(\Phi_L\) with
+of a label equivalence \(e\), nonzero scalars \(s_\alpha\), and algebra
+isomorphisms \(\Phi_L\) at each positive length with
 \[
   O'_L(\alpha) = s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr),
 \]
@@ -75,9 +75,9 @@ variable {Λ Λ' : Type*} {O O' : ℕ → Type*}
 /-- Explicit vertical transport between two BNT-label operator families.
 
 The transport consists of a label equivalence \(e\), nonzero scalars
-\(s_\alpha\), and, at each length, a linear equivalence \(\Phi_L\) of the
-ambient algebras respecting products, such that for every label \(\alpha\)
-and every positive length \(L\),
+\(s_\alpha\), and, at each positive length, a linear equivalence \(\Phi_L\)
+of the ambient algebras respecting products, such that for every label
+\(\alpha\) and every positive length \(L\),
 \[
   O'_L(\alpha) = s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr).
 \]
@@ -110,26 +110,27 @@ structure BNTVerticalTransport
   Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
   eq:vertical-coefficient-explicit-transport. -/
   scale_ne_zero : ∀ α : Λ', scale α ≠ 0
-  /-- The length-\(L\) algebra isomorphism \(\Phi_L\), as a linear
-  equivalence of the ambient algebras.
+  /-- The algebra isomorphism \(\Phi_L\) at each positive length \(L\), as
+  a linear equivalence of the ambient algebras.
 
   Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
   eq:vertical-coefficient-explicit-transport. -/
-  map : ∀ L : ℕ, O L ≃ₗ[ℂ] O' L
+  map : ∀ L : ℕ, 0 < L → (O L ≃ₗ[ℂ] O' L)
   /-- Each \(\Phi_L\) respects products, so it is an isomorphism of
   algebras.
 
   Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
   eq:vertical-coefficient-explicit-transport. -/
-  map_mul : ∀ (L : ℕ) (x y : O L), map L (x * y) = map L x * map L y
+  map_mul : ∀ (L : ℕ) (hL : 0 < L) (x y : O L),
+    map L hL (x * y) = map L hL x * map L hL y
   /-- The transport relation
   \(O'_L(\alpha) = s_\alpha^L\,\Phi_L(O_L(e\alpha))\) at every positive
   length.
 
   Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
   eq:vertical-coefficient-explicit-transport. -/
-  transport : ∀ L : ℕ, 0 < L → ∀ α : Λ',
-    op'.operator L α = scale α ^ L • map L (op.operator L (relabel α))
+  transport : ∀ (L : ℕ) (hL : 0 < L), ∀ α : Λ',
+    op'.operator L α = scale α ^ L • map L hL (op.operator L (relabel α))
 
 namespace BNTVerticalTransport
 
@@ -155,6 +156,8 @@ noncomputable def transportedCoefficients (T : BNTVerticalTransport op op')
   coeff L α β γ := (T.scale α * T.scale β / T.scale γ) ^ L *
     c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ)
 
+/-- Unfolds the transported coefficients along a vertical transport: relabel
+the three indices and multiply by the \(L\)-th power of the scale ratio. -/
 @[simp]
 theorem transportedCoefficients_coeff (T : BNTVerticalTransport op op')
     (c : BNTLabelCoefficientFamily Λ) (L : ℕ) (α β γ : Λ') :
@@ -186,30 +189,31 @@ theorem hasSameLengthProductForm_transported
     op'.HasSameLengthProductForm (T.transportedCoefficients c) := by
   intro L hL α β
   calc op'.operator L α * op'.operator L β
-      = (T.scale α ^ L • T.map L (op.operator L (T.relabel α))) *
-          (T.scale β ^ L • T.map L (op.operator L (T.relabel β))) := by
+      = (T.scale α ^ L • T.map L hL (op.operator L (T.relabel α))) *
+          (T.scale β ^ L • T.map L hL (op.operator L (T.relabel β))) := by
         rw [T.transport L hL α, T.transport L hL β]
     _ = (T.scale α * T.scale β) ^ L •
-          T.map L (op.operator L (T.relabel α) * op.operator L (T.relabel β)) := by
+          T.map L hL
+            (op.operator L (T.relabel α) * op.operator L (T.relabel β)) := by
         rw [smul_mul_smul_comm, ← T.map_mul, mul_pow]
     _ = ∑ δ : Λ,
           ((T.scale α * T.scale β) ^ L *
             c.coeff L (T.relabel α) (T.relabel β) δ) •
-            T.map L (op.operator L δ) := by
+            T.map L hL (op.operator L δ) := by
         rw [h L hL, map_sum, Finset.smul_sum]
         simp_rw [map_smul, smul_smul]
     _ = ∑ γ : Λ',
           ((T.scale α * T.scale β) ^ L *
             c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ)) •
-            T.map L (op.operator L (T.relabel γ)) :=
+            T.map L hL (op.operator L (T.relabel γ)) :=
         (Equiv.sum_comp T.relabel fun δ ↦
           ((T.scale α * T.scale β) ^ L *
             c.coeff L (T.relabel α) (T.relabel β) δ) •
-            T.map L (op.operator L δ)).symm
+            T.map L hL (op.operator L δ)).symm
     _ = ∑ γ : Λ',
           (T.transportedCoefficients c).coeff L α β γ • op'.operator L γ := by
         refine Finset.sum_congr rfl fun γ _ ↦ ?_
-        have hΦ : T.map L (op.operator L (T.relabel γ)) =
+        have hΦ : T.map L hL (op.operator L (T.relabel γ)) =
             (T.scale γ ^ L)⁻¹ • op'.operator L γ := by
           rw [T.transport L hL γ,
             inv_smul_smul₀ (pow_ne_zero L (T.scale_ne_zero γ))]

--- a/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
+++ b/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
@@ -1,0 +1,331 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTAssociativity
+
+/-!
+# Scale-covariant comparison of vertical BNT coefficients under transport
+
+Bare horizontal periodic equality between two MPO tensors does not determine
+the structure coefficients of their tensor-attached vertical BNT algebra
+clauses; the explicit counterexample is in
+`TNLean/MPS/MPDO/VerticalCoefficientPresentationCounterexample.lean`.  This
+file proves the positive replacement statement: once an explicit vertical
+transport is assumed between the two per-length operator families, consisting
+of a label equivalence \(e\), nonzero scalars \(s_\alpha\), and per-length
+algebra isomorphisms \(\Phi_L\) with
+\[
+  O'_L(\alpha) = s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr),
+\]
+then at every positive length at which the target operators are linearly
+independent, uniqueness of the product expansion forces the scale-covariant
+comparison law
+\[
+  {c'}^{(L)}_{\alpha,\beta,\gamma}
+    = \Bigl(\frac{s_\alpha s_\beta}{s_\gamma}\Bigr)^{L}
+      c^{(L)}_{e\alpha,e\beta,e\gamma}.
+\]
+Exact coefficient equality after relabelling follows under the additional
+normalization condition \(s_\alpha s_\beta = s_\gamma\) on every product
+triple with nonvanishing coefficient.  The transport keeps the normalization
+scale explicit, exactly as the source comparison retains the positive ratio
+\(m_\alpha/n_{\sigma(\alpha)}\) instead of discarding it.
+
+Deriving the transport itself from two literal horizontal canonical
+presentations, and extending the comparison to every positive length from
+bare horizontal periodic equality, are separate statements not proved here;
+the counterexample shows they require more than periodic equality.
+
+## Main results
+
+* `BNTVerticalTransport`: the explicit transport between two BNT-label
+  operator families.
+* `BNTVerticalTransport.hasSameLengthProductForm_transported`: the target
+  family satisfies the same-length product law with the scale-transported
+  coefficients.
+* `BNTVerticalTransport.coeff_covariance_of_linearIndependentAt`: the
+  scale-covariant comparison law at a linearly independent length.
+* `BNTVerticalTransport.coeff_eq_of_linearIndependentAt_of_scale_compatible`:
+  exact coefficient equality after relabelling under the normalization
+  condition.
+* `BNTAlgebraTensorClause.coeff_covariance_of_verticalTransport` and
+  `BNTAlgebraTensorClause.coeff_eq_of_verticalTransport_of_scale_compatible`:
+  the same two conclusions for the coefficient families of two
+  tensor-attached vertical BNT algebra clauses.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14(ii), lines 972--985, and the retained scale ratio in
+  Appendix C.4, lines 1997--2008
+* `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
+  eq:vertical-coefficient-explicit-transport and
+  eq:vertical-coefficient-covariance
+-/
+
+open scoped BigOperators
+
+namespace MPOTensor
+
+variable {Λ Λ' : Type*} {O O' : ℕ → Type*}
+
+/-- Explicit vertical transport between two BNT-label operator families.
+
+The transport consists of a label equivalence \(e\), nonzero scalars
+\(s_\alpha\), and, at each length, a linear equivalence \(\Phi_L\) of the
+ambient algebras respecting products, such that for every label \(\alpha\)
+and every positive length \(L\),
+\[
+  O'_L(\alpha) = s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr).
+\]
+This is the hypothesis under which the vertical BNT structure coefficients of
+two presentations can be compared; without it the comparison fails, as the
+counterexample in
+`TNLean/MPS/MPDO/VerticalCoefficientPresentationCounterexample.lean` shows.
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+eq:vertical-coefficient-explicit-transport, following the retained ratio
+\(m_\alpha/n_{\sigma(\alpha)}\) in CPSV16, Appendix C.4, arXiv:1606.00608,
+lines 1997--2008 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTVerticalTransport
+    [∀ L, AddCommMonoid (O L)] [∀ L, Module ℂ (O L)] [∀ L, Mul (O L)]
+    [∀ L, AddCommMonoid (O' L)] [∀ L, Module ℂ (O' L)] [∀ L, Mul (O' L)]
+    (op : BNTLabelOperatorFamily Λ O) (op' : BNTLabelOperatorFamily Λ' O') where
+  /-- The label equivalence \(e\) matching target labels to source labels.
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport. -/
+  relabel : Λ' ≃ Λ
+  /-- The per-label normalization scale \(s_\alpha\).
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport; the retained ratio in CPSV16,
+  Appendix C.4, arXiv:1606.00608, lines 1997--2008. -/
+  scale : Λ' → ℂ
+  /-- Every normalization scale is nonzero.
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport. -/
+  scale_ne_zero : ∀ α : Λ', scale α ≠ 0
+  /-- The length-\(L\) algebra isomorphism \(\Phi_L\), as a linear
+  equivalence of the ambient algebras.
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport. -/
+  map : ∀ L : ℕ, O L ≃ₗ[ℂ] O' L
+  /-- Each \(\Phi_L\) respects products, so it is an isomorphism of
+  algebras.
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport. -/
+  map_mul : ∀ (L : ℕ) (x y : O L), map L (x * y) = map L x * map L y
+  /-- The transport relation
+  \(O'_L(\alpha) = s_\alpha^L\,\Phi_L(O_L(e\alpha))\) at every positive
+  length.
+
+  Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+  eq:vertical-coefficient-explicit-transport. -/
+  transport : ∀ L : ℕ, 0 < L → ∀ α : Λ',
+    op'.operator L α = scale α ^ L • map L (op.operator L (relabel α))
+
+namespace BNTVerticalTransport
+
+variable [∀ L, AddCommMonoid (O L)] [∀ L, Module ℂ (O L)] [∀ L, Mul (O L)]
+  {op : BNTLabelOperatorFamily Λ O}
+
+section Transported
+
+variable [∀ L, AddCommMonoid (O' L)] [∀ L, Module ℂ (O' L)] [∀ L, Mul (O' L)]
+  {op' : BNTLabelOperatorFamily Λ' O'}
+
+/-- The coefficient family obtained by transporting
+\(c^{(L)}_{\alpha,\beta,\gamma}\) along a vertical transport: relabel the
+three indices and multiply by the scale ratio,
+\[
+  \Bigl(\frac{s_\alpha s_\beta}{s_\gamma}\Bigr)^{L}
+    c^{(L)}_{e\alpha,e\beta,e\gamma}.
+\]
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+eq:vertical-coefficient-covariance. -/
+noncomputable def transportedCoefficients (T : BNTVerticalTransport op op')
+    (c : BNTLabelCoefficientFamily Λ) : BNTLabelCoefficientFamily Λ' where
+  coeff L α β γ := (T.scale α * T.scale β / T.scale γ) ^ L *
+    c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ)
+
+@[simp]
+theorem transportedCoefficients_coeff (T : BNTVerticalTransport op op')
+    (c : BNTLabelCoefficientFamily Λ) (L : ℕ) (α β γ : Λ') :
+    (T.transportedCoefficients c).coeff L α β γ =
+      (T.scale α * T.scale β / T.scale γ) ^ L *
+        c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) :=
+  rfl
+
+end Transported
+
+variable [Fintype Λ] [Fintype Λ']
+  [∀ L, NonUnitalRing (O' L)] [∀ L, Module ℂ (O' L)]
+  [∀ L, SMulCommClass ℂ (O' L) (O' L)] [∀ L, IsScalarTower ℂ (O' L) (O' L)]
+  {op' : BNTLabelOperatorFamily Λ' O'}
+
+/-- Transporting the same-length product law: if the source family expands
+products with coefficients \(c^{(L)}_{\alpha,\beta,\gamma}\), the target
+family of a vertical transport expands products with the transported
+coefficients
+\(\bigl(s_\alpha s_\beta/s_\gamma\bigr)^{L}
+c^{(L)}_{e\alpha,e\beta,e\gamma}\).
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+eq:vertical-coefficient-covariance, applying \(\Phi_L\) to the product law of
+arXiv:1606.00608, Theorem 4.14(ii), eq:algebra, lines 972--985. -/
+theorem hasSameLengthProductForm_transported
+    (T : BNTVerticalTransport op op') {c : BNTLabelCoefficientFamily Λ}
+    (h : op.HasSameLengthProductForm c) :
+    op'.HasSameLengthProductForm (T.transportedCoefficients c) := by
+  intro L hL α β
+  calc op'.operator L α * op'.operator L β
+      = (T.scale α ^ L • T.map L (op.operator L (T.relabel α))) *
+          (T.scale β ^ L • T.map L (op.operator L (T.relabel β))) := by
+        rw [T.transport L hL α, T.transport L hL β]
+    _ = (T.scale α * T.scale β) ^ L •
+          T.map L (op.operator L (T.relabel α) * op.operator L (T.relabel β)) := by
+        rw [smul_mul_smul_comm, ← T.map_mul, mul_pow]
+    _ = ∑ δ : Λ,
+          ((T.scale α * T.scale β) ^ L *
+            c.coeff L (T.relabel α) (T.relabel β) δ) •
+            T.map L (op.operator L δ) := by
+        rw [h L hL, map_sum, Finset.smul_sum]
+        simp_rw [map_smul, smul_smul]
+    _ = ∑ γ : Λ',
+          ((T.scale α * T.scale β) ^ L *
+            c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ)) •
+            T.map L (op.operator L (T.relabel γ)) :=
+        (Equiv.sum_comp T.relabel fun δ ↦
+          ((T.scale α * T.scale β) ^ L *
+            c.coeff L (T.relabel α) (T.relabel β) δ) •
+            T.map L (op.operator L δ)).symm
+    _ = ∑ γ : Λ',
+          (T.transportedCoefficients c).coeff L α β γ • op'.operator L γ := by
+        refine Finset.sum_congr rfl fun γ _ ↦ ?_
+        have hΦ : T.map L (op.operator L (T.relabel γ)) =
+            (T.scale γ ^ L)⁻¹ • op'.operator L γ := by
+          rw [T.transport L hL γ,
+            inv_smul_smul₀ (pow_ne_zero L (T.scale_ne_zero γ))]
+        rw [hΦ, smul_smul, transportedCoefficients_coeff, div_pow,
+          div_eq_mul_inv]
+        ring_nf
+
+/-- **Scale covariance of the vertical BNT structure coefficients.**  Under
+an explicit vertical transport, at every positive length at which the target
+operators are linearly independent, uniqueness of the product expansion
+forces
+\[
+  {c'}^{(L)}_{\alpha,\beta,\gamma}
+    = \Bigl(\frac{s_\alpha s_\beta}{s_\gamma}\Bigr)^{L}
+      c^{(L)}_{e\alpha,e\beta,e\gamma}.
+\]
+This is the positive counterpart of the counterexample in
+`TNLean/MPS/MPDO/VerticalCoefficientPresentationCounterexample.lean`: the
+comparison holds with the normalization scale kept explicit, not with the
+scale discarded.
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+eq:vertical-coefficient-covariance, following the retained ratio
+\(m_\alpha/n_{\sigma(\alpha)}\) in CPSV16, Appendix C.4, arXiv:1606.00608,
+lines 1997--2008 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem coeff_covariance_of_linearIndependentAt
+    (T : BNTVerticalTransport op op')
+    {c : BNTLabelCoefficientFamily Λ} {c' : BNTLabelCoefficientFamily Λ'}
+    (h : op.HasSameLengthProductForm c)
+    (h' : op'.HasSameLengthProductForm c')
+    {L : ℕ} (hL : 0 < L) (hli : op'.LinearIndependentAt L) (α β γ : Λ') :
+    c'.coeff L α β γ =
+      (T.scale α * T.scale β / T.scale γ) ^ L *
+        c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) :=
+  BNTLabelOperatorFamily.HasSameLengthProductForm.coeff_eq_of_linearIndependentAt
+    h' (T.hasSameLengthProductForm_transported h) hL hli α β γ
+
+/-- **Exact coefficient equality after relabelling.**  Under an explicit
+vertical transport whose scales satisfy the normalization condition
+\(s_\alpha s_\beta = s_\gamma\) on every product triple with nonvanishing
+source coefficient, the scale ratio in the covariance law is one, and the
+structure coefficients agree after relabelling at every positive linearly
+independent length.
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, the
+normalization condition following eq:vertical-coefficient-covariance. -/
+theorem coeff_eq_of_linearIndependentAt_of_scale_compatible
+    (T : BNTVerticalTransport op op')
+    {c : BNTLabelCoefficientFamily Λ} {c' : BNTLabelCoefficientFamily Λ'}
+    (h : op.HasSameLengthProductForm c)
+    (h' : op'.HasSameLengthProductForm c')
+    {L : ℕ} (hL : 0 < L) (hli : op'.LinearIndependentAt L)
+    (hs : ∀ α β γ : Λ',
+      c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) ≠ 0 →
+        T.scale α * T.scale β = T.scale γ)
+    (α β γ : Λ') :
+    c'.coeff L α β γ =
+      c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) := by
+  rw [T.coeff_covariance_of_linearIndependentAt h h' hL hli α β γ]
+  by_cases hc : c.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) = 0
+  · rw [hc, mul_zero]
+  · rw [hs α β γ hc, div_self (T.scale_ne_zero γ), one_pow, one_mul]
+
+end BNTVerticalTransport
+
+namespace BNTAlgebraTensorClause
+
+variable {d D d' D' : ℕ} {M : MPOTensor d D} {M' : MPOTensor d' D'}
+
+/-- Scale covariance for the coefficient families of two tensor-attached
+vertical BNT algebra clauses: an explicit vertical transport between their
+operator families forces
+\[
+  {c'}^{(L)}_{\alpha,\beta,\gamma}
+    = \Bigl(\frac{s_\alpha s_\beta}{s_\gamma}\Bigr)^{L}
+      c^{(L)}_{e\alpha,e\beta,e\gamma}
+\]
+at every positive length at which the target operators are linearly
+independent.
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`,
+eq:vertical-coefficient-covariance, for the algebra clauses of
+arXiv:1606.00608, Theorem 4.14(ii), lines 972--985. -/
+theorem coeff_covariance_of_verticalTransport
+    (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')
+    (T : BNTVerticalTransport H.operators H'.operators)
+    {L : ℕ} (hL : 0 < L) (hli : H'.operators.LinearIndependentAt L)
+    (α β γ : Fin H'.labelCount) :
+    H'.coeffs.coeff L α β γ =
+      (T.scale α * T.scale β / T.scale γ) ^ L *
+        H.coeffs.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) :=
+  T.coeff_covariance_of_linearIndependentAt
+    H.algebraClause.sameLengthProduct H'.algebraClause.sameLengthProduct
+    hL hli α β γ
+
+/-- Exact equality after relabelling for the coefficient families of two
+tensor-attached vertical BNT algebra clauses, under an explicit vertical
+transport whose scales satisfy \(s_\alpha s_\beta = s_\gamma\) on every
+product triple with nonvanishing source coefficient.
+
+Source: `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, the
+normalization condition following eq:vertical-coefficient-covariance. -/
+theorem coeff_eq_of_verticalTransport_of_scale_compatible
+    (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')
+    (T : BNTVerticalTransport H.operators H'.operators)
+    {L : ℕ} (hL : 0 < L) (hli : H'.operators.LinearIndependentAt L)
+    (hs : ∀ α β γ : Fin H'.labelCount,
+      H.coeffs.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) ≠ 0 →
+        T.scale α * T.scale β = T.scale γ)
+    (α β γ : Fin H'.labelCount) :
+    H'.coeffs.coeff L α β γ =
+      H.coeffs.coeff L (T.relabel α) (T.relabel β) (T.relabel γ) :=
+  T.coeff_eq_of_linearIndependentAt_of_scale_compatible
+    H.algebraClause.sameLengthProduct H'.algebraClause.sameLengthProduct
+    hL hli hs α β γ
+
+end BNTAlgebraTensorClause
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1590,15 +1590,16 @@
 \begin{definition}[Explicit vertical transport between labelled operator families]%
     \label{def:mpdo_bnt_vertical_transport}
     \lean{MPOTensor.BNTVerticalTransport}
-    \lean{MPOTensor.BNTVerticalTransport.transportedCoefficients}
+    \lean{MPOTensor.BNTVerticalTransport.transportedCoefficients,
+        MPOTensor.BNTVerticalTransport.transportedCoefficients_coeff}
     \leanok
     \uses{def:mpdo_bnt_label_operator_family,
         def:mpdo_bnt_label_coefficient_family}
     An \emph{explicit vertical transport} between two BNT-label operator
     families with operators $O_L$ and $O'_L$ consists of a label
-    equivalence $e$, nonzero scalars $s_\alpha$, and, at each length, an
-    isomorphism $\Phi_L$ of the ambient algebras, such that for every
-    label $\alpha$ and every positive length $L$,
+    equivalence $e$, nonzero scalars $s_\alpha$, and, at each positive
+    length, an isomorphism $\Phi_L$ of the ambient algebras, such that for
+    every label $\alpha$ and every positive length $L$,
     \begin{align}
         O'_L(\alpha)&=s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr).
         \notag
@@ -1665,8 +1666,7 @@
         thm:mpdo_bnt_vertical_transport_product_form,
         thm:mpdo_bnt_label_coeff_unique,
         def:mpdo_bnt_label_linear_independent,
-        def:mpdo_bnt_algebra_tensor_clause,
-        thm:mpdo_vertical_coefficients_not_presentation_invariant}
+        def:mpdo_bnt_algebra_tensor_clause}
     Let two BNT-label operator families satisfying the same-length product
     law, with coefficients $c^{(L)}_{\alpha,\beta,\gamma}$ and
     ${c'}^{(L)}_{\alpha,\beta,\gamma}$, be related by an explicit vertical

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1584,6 +1584,155 @@
     The first family is constant.  The last two displayed values are unequal.
 \end{proof}
 
+% Positive counterpart of the preceding counterexample: the comparison of
+% vertical BNT coefficients holds once an explicit transport is assumed,
+% with the normalization scale kept explicit.
+\begin{definition}[Explicit vertical transport between labelled operator families]%
+    \label{def:mpdo_bnt_vertical_transport}
+    \lean{MPOTensor.BNTVerticalTransport}
+    \lean{MPOTensor.BNTVerticalTransport.transportedCoefficients}
+    \leanok
+    \uses{def:mpdo_bnt_label_operator_family,
+        def:mpdo_bnt_label_coefficient_family}
+    An \emph{explicit vertical transport} between two BNT-label operator
+    families with operators $O_L$ and $O'_L$ consists of a label
+    equivalence $e$, nonzero scalars $s_\alpha$, and, at each length, an
+    isomorphism $\Phi_L$ of the ambient algebras, such that for every
+    label $\alpha$ and every positive length $L$,
+    \begin{align}
+        O'_L(\alpha)&=s_\alpha^L\,\Phi_L\bigl(O_L(e\alpha)\bigr).
+        \notag
+    \end{align}
+    The \emph{transported coefficient family} of a coefficient system
+    $c^{(L)}_{\alpha,\beta,\gamma}$ has coefficients
+    \begin{align}
+        \left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^{L}
+        c^{(L)}_{e\alpha,e\beta,e\gamma}.
+        \notag
+    \end{align}
+    The scalars $s_\alpha$ keep the normalization explicit, in the way the
+    comparison in \cite[Appendix~C.4]{Cirac2016MPDO_arXiv} retains the
+    positive ratio $m_\alpha/n_{\sigma(\alpha)}$ instead of discarding the
+    normalization scale.
+\end{definition}
+
+\begin{theorem}[Transport of the same-length product law]%
+    \label{thm:mpdo_bnt_vertical_transport_product_form}
+    \lean{MPOTensor.BNTVerticalTransport.%
+        hasSameLengthProductForm_transported}
+    \leanok
+    \uses{def:mpdo_bnt_vertical_transport,
+        def:mpdo_bnt_label_same_length_product_form}
+    Let two BNT-label operator families be related by an explicit vertical
+    transport.  If the source family satisfies the same-length product law
+    with coefficients $c^{(L)}_{\alpha,\beta,\gamma}$, then the target
+    family satisfies the same-length product law with the transported
+    coefficients.
+\end{theorem}
+\begin{proof}\leanok
+    Fix a positive length $L$ and target labels $\alpha$ and $\beta$.
+    Substituting the transport relation and using that $\Phi_L$ is linear
+    and multiplicative,
+    \begin{align}
+        O'_L(\alpha)O'_L(\beta)
+        &=(s_\alpha s_\beta)^L\,
+            \Phi_L\bigl(O_L(e\alpha)O_L(e\beta)\bigr)
+        \notag\\
+        &=(s_\alpha s_\beta)^L
+            \sum_\delta c^{(L)}_{e\alpha,e\beta,\delta}\,
+            \Phi_L\bigl(O_L(\delta)\bigr).
+        \notag
+    \end{align}
+    Reindexing the sum by $\delta=e\gamma$ and inverting the transport
+    relation, $\Phi_L\bigl(O_L(e\gamma)\bigr)=s_\gamma^{-L}O'_L(\gamma)$,
+    so the product equals
+    \begin{align}
+        \sum_\gamma
+        \left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^{L}
+        c^{(L)}_{e\alpha,e\beta,e\gamma}\,O'_L(\gamma).
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Scale covariance of vertical BNT coefficients under explicit transport]%
+    \label{thm:mpdo_bnt_vertical_coefficient_covariance}
+    \lean{MPOTensor.BNTVerticalTransport.%
+        coeff_covariance_of_linearIndependentAt}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        coeff_covariance_of_verticalTransport}
+    \leanok
+    \uses{def:mpdo_bnt_vertical_transport,
+        thm:mpdo_bnt_vertical_transport_product_form,
+        thm:mpdo_bnt_label_coeff_unique,
+        def:mpdo_bnt_label_linear_independent,
+        def:mpdo_bnt_algebra_tensor_clause,
+        thm:mpdo_vertical_coefficients_not_presentation_invariant}
+    Let two BNT-label operator families satisfying the same-length product
+    law, with coefficients $c^{(L)}_{\alpha,\beta,\gamma}$ and
+    ${c'}^{(L)}_{\alpha,\beta,\gamma}$, be related by an explicit vertical
+    transport.  At every positive length $L$ at which the target operators
+    are linearly independent,
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        &=\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^{L}
+            c^{(L)}_{e\alpha,e\beta,e\gamma}.
+        \notag
+    \end{align}
+    The same law holds for the coefficient families of two tensor-attached
+    vertical BNT algebra clauses whose operator families are related by an
+    explicit vertical transport.  This is the positive counterpart of
+    Theorem~\ref{thm:mpdo_vertical_coefficients_not_presentation_invariant}:
+    there the two one-label presentations have scales $1$ and $4/5$, no
+    transport with compatible scales exists, and the coefficients differ,
+    while under an explicit transport the comparison holds with the scale
+    ratio retained.
+\end{theorem}
+\begin{proof}\leanok
+    By Theorem~\ref{thm:mpdo_bnt_vertical_transport_product_form}, the
+    target family satisfies the same-length product law with the
+    transported coefficients as well as with
+    ${c'}^{(L)}_{\alpha,\beta,\gamma}$.  Linear independence of the target
+    operators at length $L$ makes the coefficients of the product expansion
+    unique, by Theorem~\ref{thm:mpdo_bnt_label_coeff_unique}, so the two
+    coefficient systems agree at length $L$.
+\end{proof}
+
+\begin{theorem}[Coefficient equality under compatible normalization scales]%
+    \label{thm:mpdo_bnt_vertical_coefficient_equality}
+    \lean{MPOTensor.BNTVerticalTransport.%
+        coeff_eq_of_linearIndependentAt_of_scale_compatible}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        coeff_eq_of_verticalTransport_of_scale_compatible}
+    \leanok
+    \uses{thm:mpdo_bnt_vertical_coefficient_covariance,
+        def:mpdo_bnt_vertical_transport,
+        def:mpdo_bnt_algebra_tensor_clause}
+    In the setting of
+    Theorem~\ref{thm:mpdo_bnt_vertical_coefficient_covariance}, suppose in
+    addition that the normalization scales satisfy
+    \begin{align}
+        s_\alpha s_\beta&=s_\gamma
+        \notag
+    \end{align}
+    on every triple of labels with
+    $c^{(L)}_{e\alpha,e\beta,e\gamma}\neq 0$.  Then at every positive
+    length $L$ at which the target operators are linearly independent, the
+    coefficients agree after relabelling:
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        &=c^{(L)}_{e\alpha,e\beta,e\gamma}.
+        \notag
+    \end{align}
+    The same equality holds for the coefficient families of two
+    tensor-attached vertical BNT algebra clauses.
+\end{theorem}
+\begin{proof}\leanok
+    If $c^{(L)}_{e\alpha,e\beta,e\gamma}=0$, both sides of the covariance
+    law vanish.  Otherwise the compatibility condition makes the scale
+    ratio equal to one, and the covariance law reduces to the displayed
+    equality.
+\end{proof}
+
 \begin{theorem}[Associativity constraint on the structure coefficients]%
     \label{thm:mpdo_bnt_label_coeff_associativity}
     \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.%

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -511,6 +511,23 @@ canonical presentations, and extending
 separate statements and are not supplied by bare horizontal periodic
 equality.
 
+The transport hypothesis
+\eqref{eq:vertical-coefficient-explicit-transport}, the covariance law
+\eqref{eq:vertical-coefficient-covariance} at every positive length where
+the target operators are linearly independent, and the exact-equality
+corollary under the normalization condition $s_\alpha s_\beta=s_\gamma$ on
+every triple with nonvanishing source coefficient are formalized in
+\path{TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean}: the
+hypothesis is
+\leanid{MPOTensor.BNTVerticalTransport}, the covariance law is
+\leanid{MPOTensor.BNTVerticalTransport.coeff_covariance_of_linearIndependentAt},
+and the corollary is
+\leanid{MPOTensor.BNTVerticalTransport.%
+coeff_eq_of_linearIndependentAt_of_scale_compatible},
+each with a version for two tensor-attached vertical BNT algebra clauses.
+Deriving the transport from two literal horizontal canonical presentations
+and the every-positive-length extension remain unformalized.
+
 \section{Formalization boundary}
 
 \textbf{Verdict: three distinct formal predicates.} The documented active


### PR DESCRIPTION
Formalizes the scale-covariant comparison law for tensor-attached vertical BNT structure coefficients under an explicit vertical transport, the positive counterpart of the presentation counterexample merged in #6809.

## What is proved

New module `TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean`:

- `MPOTensor.BNTVerticalTransport` — the explicit-transport hypothesis between two BNT-label operator families: a label equivalence `e`, nonzero scalars `s_α`, and per-length algebra isomorphisms `Φ_L` (linear equivalences respecting products) with `O'_L(α) = s_α^L • Φ_L (O_L (e α))` for every positive length.
- `MPOTensor.BNTVerticalTransport.transportedCoefficients` and `MPOTensor.BNTVerticalTransport.hasSameLengthProductForm_transported` — applying `Φ_L` to the source product expansion shows the target family satisfies the same-length product law with coefficients `(s_α s_β / s_γ)^L · c^{(L)}_{eα,eβ,eγ}`.
- `MPOTensor.BNTVerticalTransport.coeff_covariance_of_linearIndependentAt` — at any positive length where the target operators are linearly independent, uniqueness of the product expansion (the existing `coeff_eq_of_linearIndependentAt`) gives the covariance law `c'^{(L)}_{α,β,γ} = (s_α s_β / s_γ)^L · c^{(L)}_{eα,eβ,eγ}`.
- `MPOTensor.BNTVerticalTransport.coeff_eq_of_linearIndependentAt_of_scale_compatible` — exact coefficient equality after relabelling under the normalization condition `s_α s_β = s_γ` on every triple with nonvanishing source coefficient.
- `MPOTensor.BNTAlgebraTensorClause.coeff_covariance_of_verticalTransport` and `MPOTensor.BNTAlgebraTensorClause.coeff_eq_of_verticalTransport_of_scale_compatible` — the same two conclusions for the coefficient families of two tensor-attached vertical BNT algebra clauses.

Blueprint: four new entries in `blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex` (`def:mpdo_bnt_vertical_transport`, `thm:mpdo_bnt_vertical_transport_product_form`, `thm:mpdo_bnt_vertical_coefficient_covariance`, `thm:mpdo_bnt_vertical_coefficient_equality`), with `thm:mpdo_vertical_coefficients_not_presentation_invariant` linked as the motivating boundary case. The paper-gap note `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex` now records which parts of its transport section are formalized.

## Statement-integrity audit

- **Source of the statement.** This formalizes a project-derived statement, not a printed source theorem. The authoritative statement is the paper-gap note `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations `eq:vertical-coefficient-explicit-transport` and `eq:vertical-coefficient-covariance` (added by #6809), anchored to CPSV16, arXiv:1606.00608, Appendix C.4, lines 1997–2008, where the source comparison retains the positive ratio `m_α/n_{σ(α)}` rather than discarding the normalization scale. CPSV16 does not display the covariance law itself; the blueprint entries and docstrings state this provenance explicitly.
- **Note assumptions vs Lean assumptions.** The note assumes a label equivalence, nonzero scalars, and algebra isomorphisms with the displayed transport relation at every positive length; the Lean structure carries exactly these fields (the isomorphism is a linear equivalence with a product-compatibility field, i.e. a non-unital algebra isomorphism) plus the ambient same-length product laws of the two coefficient systems, which the note treats as standing (they are the algebra-clause fields of both presentations, per Theorem 4.14(ii)). Linear independence of the target operators at the compared length is assumed by the note ("at a positive length where the target operators are linearly independent") and by the Lean theorem. No hypothesis beyond the note's was added.
- **Note conclusion vs Lean conclusion.** Identical: `c'^{(L)}_{α,β,γ} = (s_α s_β / s_γ)^L · c^{(L)}_{eα,eβ,eγ}` at the linearly independent length, and exact equality after relabelling under `s_α s_β = s_γ` on active triples ("active" formalized as nonvanishing source coefficient at that length, which under the covariance law is equivalent to nonvanishing target coefficient).
- **Relevant definitions.** Reuses the existing `BNTLabelOperatorFamily`, `BNTLabelCoefficientFamily`, `HasSameLengthProductForm`, `LinearIndependentAt`, the uniqueness lemma `HasSameLengthProductForm.coeff_eq_of_linearIndependentAt`, and `BNTAlgebraTensorClause`; no coefficient or product-law notion is restated.
- **Proof status.** All proofs complete; no `sorry`, no axioms.
- **Faithfulness verdict.** Faithful to the paper-gap note's statement; honestly labelled as project-derived rather than as a CPSV16 theorem throughout (docstrings, blueprint prose, and the note itself). Out of scope, exactly as the note and issue delimit: deriving the transport hypothesis from two literal horizontal canonical presentations, and extending the covariance law to every positive length from bare horizontal periodic equality, remain unformalized and are recorded as such in the note.

Closes #6813

## Validation

- `lake build TNLean.MPS.MPDO.VerticalTransportCoefficientCovariance` and `lake build TNLean.MPS.MPDO` — green, no warnings in changed files.
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean` — clean.
- `python3 scripts/generate_import_aggregators.py` — aggregator regenerated (`TNLean/MPS/MPDO.lean`).
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` and `--warn-missing-blueprint --changed-files … --diff-base origin/main --diff-head HEAD` — blueprint and Lean in sync; no missing blueprint coverage.
- `python3 scripts/check_reader_facing_prose.py` — no violations in changed files.
- `python3 scripts/tactic_pattern_scan.py` — no new repeated patterns from this change.

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E
