### PR TITLE
fix(qic): keep inline TeX in prose blocks

### DIFF
--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -303,8 +303,9 @@ def blueprint_non_item_blocks(
 ) -> list[NonItemBlock]:
     """Partition text outside item spans into paragraph-like blocks.
 
-    Complete balanced TeX environments containing no item line are atomic,
-    including nested environments and blank or comment-only lines. An outer
+    Complete balanced multi-line TeX environments containing no item line are
+    atomic, including nested environments and blank or comment-only lines.
+    Single-line environments remain in their surrounding paragraph. An outer
     environment containing item lines is rejected because partitioning it at
     the item boundary would produce malformed TeX. Elsewhere, blank lines and
     item boundaries split blocks. Router ``\\input`` commands
@@ -372,7 +373,7 @@ def blueprint_non_item_blocks(
                 line_no += 1
                 continue
             atomic_end = atomic_ranges.get(line_no)
-            if atomic_end is not None:
+            if atomic_end is not None and atomic_end > line_no:
                 flush()
                 current = [
                     (atomic_line, source_lines[atomic_line - 1])

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -536,6 +536,30 @@ This paragraph cites Theorem~\ref{missing:label}.
         )
 
     @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_inline_environment_remains_in_surrounding_paragraph(
+        self, _source_sha
+    ) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+The sentence begins on this line,
+contains $J=\bigl(\begin{smallmatrix}0&1\\-1&0\end{smallmatrix}\bigr)$ here,
+and ends on this line.
+"""
+        )
+        report = boundary_report(self.root)
+        blocks = [
+            block
+            for block in report["non_item_blocks"]
+            if block["file"] == "src/chapter/ch01.tex"
+        ]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["line"], 5)
+        self.assertEqual(blocks[0]["end_line"], 7)
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
     def test_non_item_environment_is_atomic_across_blank_and_comment_lines(
         self, _source_sha
     ) -> None:


### PR DESCRIPTION
## What changed

- keep a balanced TeX environment that begins and ends on one source line inside its surrounding prose block
- continue treating genuine multi-line environments as atomic blocks
- add a regression test matching the live inline `smallmatrix` sentence in Chapter 25

The issue patch does not change either generated freeze manifest relative to exact main. Current main already generates one additional TN interface label, `thm:mpdo_projective_resolution_channel_cptp`, after #6827; this PR neither introduces nor removes that independent drift.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` (25 tests)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- two byte-identical schema-v4 reports
- generated blueprint and interface manifests are byte-for-byte identical to exact-main generation
- `python3 scripts/check_import_direction.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_tenkz_policy.py`
- `git diff --check`

No Lean or blueprint source changed. Hosted full CI remains authoritative.

Closes #6822. Advances #6622 and #6560.
