### PR TITLE
fix(qic): reject nested blueprint inputs

### DIFF
--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -285,6 +285,13 @@ def _atomic_non_item_environment_ranges(
                 f"environment at {relative_root}:{start}-{end} contains "
                 "theorem-like item lines"
             )
+        for line_no in range(start, end + 1):
+            cleaned_line = _strip_tex_comments(source_lines[line_no - 1])
+            if INPUT_LINE_RE.fullmatch(cleaned_line) is not None:
+                raise ValueError(
+                    f"standalone \\input at {relative_root}:{line_no} is nested "
+                    f"inside TeX environment {start}-{end}"
+                )
         candidates.append((start, end))
     maximal: list[tuple[int, int]] = []
     for start, end in sorted(candidates, key=lambda span: (span[0], -span[1])):
@@ -308,9 +315,10 @@ def blueprint_non_item_blocks(
     Single-line environments remain in their surrounding paragraph. An outer
     environment containing item lines is rejected because partitioning it at
     the item boundary would produce malformed TeX. Elsewhere, blank lines and
-    item boundaries split blocks. Router ``\\input`` commands
-    are single-line blocks so each simulated output can prune them without
-    pulling in every sibling chapter.
+    item boundaries split blocks. Top-level router ``\\input`` commands are
+    single-line blocks so each simulated output can prune them without pulling
+    in every sibling chapter; an ``\\input`` nested inside an atomic environment
+    is rejected because its dependency could not be tracked separately.
     """
     spans_by_file: dict[str, list[tuple[int, int]]] = {}
     for item in environments:

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -286,6 +286,8 @@ def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
             proof_depth = 0
             proof_started = False
             for line_no in range(statement_end_line + 1, next_statement_line):
+                if line_no in raw_text_lines:
+                    continue
                 line = source_lines[line_no - 1]
                 begins = len(PROOF_BEGIN_RE.findall(line))
                 ends = len(PROOF_END_RE.findall(line))
@@ -350,17 +352,42 @@ def _atomic_non_item_environment_ranges(
         for start, end in raw_text_ranges
         for line_no in range(start, end + 1)
     }
+    for line_no, line in enumerate(source_lines, start=1):
+        if line_no in raw_text_lines:
+            continue
+        cleaned_line = _strip_tex_comments(line)
+        if INPUT_LINE_RE.fullmatch(cleaned_line) is None:
+            continue
+        containing_environment = next(
+            (
+                (start, end)
+                for start, end in ranges
+                if start <= line_no <= end
+            ),
+            None,
+        )
+        if containing_environment is not None:
+            start, end = containing_environment
+            raise ValueError(
+                f"standalone \\input at {relative_root}:{line_no} is nested "
+                f"inside TeX environment {start}-{end}"
+            )
+        containing_item = next(
+            (
+                (start, end)
+                for start, end in item_spans
+                if start <= line_no <= end
+            ),
+            None,
+        )
+        if containing_item is not None:
+            start, end = containing_item
+            raise ValueError(
+                f"standalone \\input at {relative_root}:{line_no} is nested "
+                f"inside theorem-like item {start}-{end}"
+            )
     candidates: list[tuple[int, int]] = []
     for start, end in ranges:
-        for line_no in range(start, end + 1):
-            if line_no in raw_text_lines:
-                continue
-            cleaned_line = _strip_tex_comments(source_lines[line_no - 1])
-            if INPUT_LINE_RE.fullmatch(cleaned_line) is not None:
-                raise ValueError(
-                    f"standalone \\input at {relative_root}:{line_no} is nested "
-                    f"inside TeX environment {start}-{end}"
-                )
         contained_in_item = False
         overlaps_item = False
         for item_start, item_end in item_spans:

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -38,6 +38,17 @@ ENV_END_RE = re.compile(r"\\end\{(" + "|".join(ENVIRONMENTS) + r")\}")
 PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
 PROOF_END_RE = re.compile(r"\\end\{proof\}")
 ENV_TOKEN_RE = re.compile(r"\\(begin|end)\{([^}]+)\}")
+RAW_TEXT_ENVIRONMENTS = {
+    "verbatim",
+    "verbatim*",
+    "Verbatim",
+    "BVerbatim",
+    "LVerbatim",
+    "SaveVerbatim",
+    "lstlisting",
+    "minted",
+    "comment",
+}
 LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
 LEAN_RE = re.compile(r"\\lean\{([^}]*)\}", re.DOTALL)
 USES_RE = re.compile(r"\\uses\{([^}]*)\}", re.DOTALL)
@@ -243,6 +254,7 @@ def _atomic_non_item_environment_ranges(
     """Return maximal balanced TeX environments lying outside item spans."""
     stack: list[tuple[str, int]] = []
     ranges: list[tuple[int, int]] = []
+    raw_text_ranges: list[tuple[int, int]] = []
     for line_no, line in enumerate(source_lines, start=1):
         cleaned_line = _strip_tex_comments(line)
         for token in ENV_TOKEN_RE.finditer(cleaned_line):
@@ -261,6 +273,8 @@ def _atomic_non_item_environment_ranges(
                     f"opened {opened} at line {opened_line}, closed {environment}"
                 )
             ranges.append((opened_line, line_no))
+            if opened in RAW_TEXT_ENVIRONMENTS:
+                raw_text_ranges.append((opened_line, line_no))
     if stack:
         environment, opened_line = stack[-1]
         raise ValueError(
@@ -268,8 +282,22 @@ def _atomic_non_item_environment_ranges(
             f"{relative_root}:{opened_line}"
         )
 
+    raw_text_lines = {
+        line_no
+        for start, end in raw_text_ranges
+        for line_no in range(start, end + 1)
+    }
     candidates: list[tuple[int, int]] = []
     for start, end in ranges:
+        for line_no in range(start, end + 1):
+            if line_no in raw_text_lines:
+                continue
+            cleaned_line = _strip_tex_comments(source_lines[line_no - 1])
+            if INPUT_LINE_RE.fullmatch(cleaned_line) is not None:
+                raise ValueError(
+                    f"standalone \\input at {relative_root}:{line_no} is nested "
+                    f"inside TeX environment {start}-{end}"
+                )
         contained_in_item = False
         overlaps_item = False
         for item_start, item_end in item_spans:
@@ -285,13 +313,6 @@ def _atomic_non_item_environment_ranges(
                 f"environment at {relative_root}:{start}-{end} contains "
                 "theorem-like item lines"
             )
-        for line_no in range(start, end + 1):
-            cleaned_line = _strip_tex_comments(source_lines[line_no - 1])
-            if INPUT_LINE_RE.fullmatch(cleaned_line) is not None:
-                raise ValueError(
-                    f"standalone \\input at {relative_root}:{line_no} is nested "
-                    f"inside TeX environment {start}-{end}"
-                )
         candidates.append((start, end))
     maximal: list[tuple[int, int]] = []
     for start, end in sorted(candidates, key=lambda span: (span[0], -span[1])):
@@ -317,8 +338,9 @@ def blueprint_non_item_blocks(
     the item boundary would produce malformed TeX. Elsewhere, blank lines and
     item boundaries split blocks. Top-level router ``\\input`` commands are
     single-line blocks so each simulated output can prune them without pulling
-    in every sibling chapter; an ``\\input`` nested inside an atomic environment
+    in every sibling chapter; an ``\\input`` nested inside a TeX environment
     is rejected because its dependency could not be tracked separately.
+    Commands displayed inside raw-text environments are ignored.
     """
     spans_by_file: dict[str, list[tuple[int, int]]] = {}
     for item in environments:

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -152,15 +152,105 @@ class NonItemBlock:
         return f"@{self.file}:{self.line}-{self.end_line}"
 
 
+def _balanced_environment_ranges(
+    source_lines: list[str], relative_root: str
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    """Return balanced environment ranges while treating raw text as opaque."""
+    stack: list[tuple[str, int]] = []
+    ranges: list[tuple[int, int]] = []
+    raw_text_ranges: list[tuple[int, int]] = []
+    raw_environment: str | None = None
+    for line_no, line in enumerate(source_lines, start=1):
+        cursor = 0
+        while cursor < len(line):
+            if raw_environment is not None:
+                closing = re.search(
+                    rf"\\end\{{{re.escape(raw_environment)}\}}", line[cursor:]
+                )
+                if closing is None:
+                    break
+                cursor += closing.end()
+                opened, opened_line = stack.pop()
+                ranges.append((opened_line, line_no))
+                raw_text_ranges.append((opened_line, line_no))
+                raw_environment = None
+                continue
+
+            cleaned_suffix = _strip_tex_comments(line[cursor:])
+            token = ENV_TOKEN_RE.search(cleaned_suffix)
+            if token is None:
+                break
+            action, environment = token.groups()
+            cursor += token.end()
+            if action == "begin":
+                stack.append((environment, line_no))
+                if environment in RAW_TEXT_ENVIRONMENTS:
+                    raw_environment = environment
+                continue
+            if not stack:
+                raise ValueError(
+                    f"unmatched \\end{{{environment}}} at {relative_root}:{line_no}"
+                )
+            opened, opened_line = stack.pop()
+            if opened != environment:
+                raise ValueError(
+                    f"mismatched environment at {relative_root}:{line_no}: "
+                    f"opened {opened} at line {opened_line}, closed {environment}"
+                )
+            ranges.append((opened_line, line_no))
+    if stack:
+        environment, opened_line = stack[-1]
+        raise ValueError(
+            f"unterminated environment {environment} opened at "
+            f"{relative_root}:{opened_line}"
+        )
+    return ranges, raw_text_ranges
+
+
+def _raw_text_line_numbers(source_lines: list[str]) -> set[int]:
+    """Return lines whose TeX contents are interpreted as raw text."""
+    raw_environment: str | None = None
+    raw_start = 0
+    raw_lines: set[int] = set()
+    for line_no, line in enumerate(source_lines, start=1):
+        cursor = 0
+        while cursor < len(line):
+            if raw_environment is not None:
+                closing = re.search(
+                    rf"\\end\{{{re.escape(raw_environment)}\}}", line[cursor:]
+                )
+                if closing is None:
+                    break
+                raw_lines.update(range(raw_start, line_no + 1))
+                cursor += closing.end()
+                raw_environment = None
+                continue
+            cleaned_suffix = _strip_tex_comments(line[cursor:])
+            token = ENV_TOKEN_RE.search(cleaned_suffix)
+            if token is None:
+                break
+            action, environment = token.groups()
+            cursor += token.end()
+            if action == "begin" and environment in RAW_TEXT_ENVIRONMENTS:
+                raw_environment = environment
+                raw_start = line_no
+    if raw_environment is not None:
+        raw_lines.update(range(raw_start, len(source_lines) + 1))
+    return raw_lines
+
+
 def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
     """Parse theorem-like items, including an attached proof and intervening lines."""
     records: list[BlueprintEnvironment] = []
     for path in blueprint_content_files(blueprint_src):
         rel = path.relative_to(blueprint_src.parent).as_posix()
         source_lines = path.read_text(errors="replace").splitlines()
+        raw_text_lines = _raw_text_line_numbers(source_lines)
         stack: list[dict[str, object]] = []
         statements: list[dict[str, object]] = []
         for line_no, line in enumerate(source_lines, start=1):
+            if line_no in raw_text_lines:
+                continue
             begin = ENV_BEGIN_RE.search(line)
             if begin is not None:
                 stack.append(
@@ -252,36 +342,9 @@ def _atomic_non_item_environment_ranges(
     source_lines: list[str], item_spans: list[tuple[int, int]], relative_root: str
 ) -> dict[int, int]:
     """Return maximal balanced TeX environments lying outside item spans."""
-    stack: list[tuple[str, int]] = []
-    ranges: list[tuple[int, int]] = []
-    raw_text_ranges: list[tuple[int, int]] = []
-    for line_no, line in enumerate(source_lines, start=1):
-        cleaned_line = _strip_tex_comments(line)
-        for token in ENV_TOKEN_RE.finditer(cleaned_line):
-            action, environment = token.groups()
-            if action == "begin":
-                stack.append((environment, line_no))
-                continue
-            if not stack:
-                raise ValueError(
-                    f"unmatched \\end{{{environment}}} at {relative_root}:{line_no}"
-                )
-            opened, opened_line = stack.pop()
-            if opened != environment:
-                raise ValueError(
-                    f"mismatched environment at {relative_root}:{line_no}: "
-                    f"opened {opened} at line {opened_line}, closed {environment}"
-                )
-            ranges.append((opened_line, line_no))
-            if opened in RAW_TEXT_ENVIRONMENTS:
-                raw_text_ranges.append((opened_line, line_no))
-    if stack:
-        environment, opened_line = stack[-1]
-        raise ValueError(
-            f"unterminated environment {environment} opened at "
-            f"{relative_root}:{opened_line}"
-        )
-
+    ranges, raw_text_ranges = _balanced_environment_ranges(
+        source_lines, relative_root
+    )
     raw_text_lines = {
         line_no
         for start, end in raw_text_ranges

--- a/scripts/qic_blueprint_boundary_report.py
+++ b/scripts/qic_blueprint_boundary_report.py
@@ -239,6 +239,16 @@ def _raw_text_line_numbers(source_lines: list[str]) -> set[int]:
     return raw_lines
 
 
+def _source_text_without_raw_lines(
+    source_lines: list[str], raw_text_lines: set[int], start_line: int, end_line: int
+) -> str:
+    """Return a source interval with raw-text lines erased."""
+    return "\n".join(
+        "" if line_no in raw_text_lines else source_lines[line_no - 1]
+        for line_no in range(start_line, end_line + 1)
+    )
+
+
 def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
     """Parse theorem-like items, including an attached proof and intervening lines."""
     records: list[BlueprintEnvironment] = []
@@ -304,10 +314,12 @@ def blueprint_environments(blueprint_src: Path) -> list[BlueprintEnvironment]:
                     f"unterminated proof after {rel}:{statement_end_line}"
                 )
 
-            raw_statement_body = "\n".join(
-                source_lines[start_line - 1 : statement_end_line]
+            raw_statement_body = _source_text_without_raw_lines(
+                source_lines, raw_text_lines, start_line, statement_end_line
             )
-            raw_body = "\n".join(source_lines[start_line - 1 : item_end_line])
+            raw_body = _source_text_without_raw_lines(
+                source_lines, raw_text_lines, start_line, item_end_line
+            )
             body = _strip_tex_comments(raw_body)
             labels = tuple(LABEL_RE.findall(body))
             declarations: list[str] = []

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -474,6 +474,24 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_input_nested_in_non_item_environment(self) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+\input{chapter/picture}
+\end{figure}
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"standalone \\input at src/chapter/ch01.tex:6 is nested inside "
+            r"TeX environment 5-7",
+        ):
+            boundary_report(self.root)
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -530,6 +530,27 @@ See Theorem~\ref{thm:tn}.
             report["simulated_qic_source_files"],
         )
 
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_environment_tokens_in_raw_text_are_ignored(self, _source_sha) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+\begin{verbatim}
+\begin{theorem}
+Displayed literally.
+\end{theorem}
+\begin{center}
+\end{verbatim}
+\end{figure}
+"""
+        )
+        report = boundary_report(self.root)
+        self.assertEqual(report["environment_count"], 1)
+        self.assertEqual(report["simulated_output_errors"], [])
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -492,6 +492,44 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_input_nested_in_item_environment(self) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\input{chapter/proof-detail}
+\end{theorem}
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"standalone \\input at src/chapter/ch01.tex:3 is nested inside "
+            r"TeX environment 1-4",
+        ):
+            boundary_report(self.root)
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_literal_input_in_raw_text_environment_is_ignored(
+        self, _source_sha
+    ) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+
+\begin{figure}
+\begin{verbatim}
+\input{chapter/displayed-example}
+\end{verbatim}
+\end{figure}
+"""
+        )
+        report = boundary_report(self.root)
+        self.assertEqual(report["simulated_output_errors"], [])
+        self.assertNotIn(
+            "src/chapter/displayed-example.tex",
+            report["simulated_qic_source_files"],
+        )
+
     def test_rejects_unbalanced_non_item_environment(self) -> None:
         self.write_blueprint(
             r"""\begin{theorem}\label{thm:qic}

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -507,6 +507,24 @@ See Theorem~\ref{thm:tn}.
         ):
             boundary_report(self.root)
 
+    def test_rejects_input_between_statement_and_attached_proof(self) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+\input{chapter/proof-detail}
+\begin{proof}
+Proof.
+\end{proof}
+"""
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"standalone \\input at src/chapter/ch01.tex:4 is nested inside "
+            r"theorem-like item 1-7",
+        ):
+            boundary_report(self.root)
+
     @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
     def test_literal_input_in_raw_text_environment_is_ignored(
         self, _source_sha
@@ -549,6 +567,28 @@ Displayed literally.
         )
         report = boundary_report(self.root)
         self.assertEqual(report["environment_count"], 1)
+        self.assertEqual(report["simulated_output_errors"], [])
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_proof_tokens_in_raw_text_are_ignored(self, _source_sha) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+\begin{verbatim}
+\begin{proof}
+Displayed literally.
+\end{proof}
+\begin{proof}
+\end{verbatim}
+\begin{proof}
+Actual proof.
+\end{proof}
+"""
+        )
+        report = boundary_report(self.root)
+        self.assertEqual(report["environment_count"], 1)
+        self.assertEqual(report["items"][0]["end_line"], 12)
         self.assertEqual(report["simulated_output_errors"], [])
 
     def test_rejects_unbalanced_non_item_environment(self) -> None:

--- a/scripts/test_qic_blueprint_boundary_report.py
+++ b/scripts/test_qic_blueprint_boundary_report.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from qic_blueprint_boundary_report import (
     LEDGER_COLUMNS,
+    blueprint_environments,
     blueprint_file_manifest,
     boundary_report,
     environment_uses,
@@ -589,6 +590,32 @@ Actual proof.
         report = boundary_report(self.root)
         self.assertEqual(report["environment_count"], 1)
         self.assertEqual(report["items"][0]["end_line"], 12)
+        self.assertEqual(report["simulated_output_errors"], [])
+
+    @patch("qic_blueprint_boundary_report.source_sha", return_value="a" * 40)
+    def test_metadata_tokens_in_raw_text_are_ignored(self, _source_sha) -> None:
+        self.write_blueprint(
+            r"""\begin{theorem}\label{thm:qic}
+\lean{Kraus.moved}
+\end{theorem}
+\begin{verbatim}
+\label{thm:displayed}
+\lean{MPSTensor.staying}
+\uses{thm:missing}
+See Theorem~\ref{thm:missing}.
+\end{verbatim}
+\begin{proof}
+Proof.
+\end{proof}
+"""
+        )
+        report = boundary_report(self.root)
+        item = report["items"][0]
+        self.assertEqual(item["labels"], ["thm:qic"])
+        self.assertEqual(item["declarations"], ["Kraus.moved"])
+        environment = blueprint_environments(self.root / "blueprint" / "src")[0]
+        self.assertEqual(environment.uses, ())
+        self.assertEqual(environment.references, ())
         self.assertEqual(report["simulated_output_errors"], [])
 
     def test_rejects_unbalanced_non_item_environment(self) -> None:


### PR DESCRIPTION
## What changed

- reject a standalone `\input{...}` nested inside any parsed TeX environment, including theorem-like item spans
- report the exact file, input line, and enclosing environment range
- retain ordinary top-level router inputs as independently tracked blocks
- treat standard raw-text environments such as `verbatim`, `lstlisting`, and `minted` as opaque while scanning for TeX environments and input commands
- add regressions for non-item nesting, theorem-item nesting, literal verbatim input text, and literal environment tokens in raw text

Rejecting unsupported nested inputs makes the freeze fail closed instead of retaining an input command while silently omitting its target file. Treating raw text as opaque prevents displayed TeX syntax from creating spurious item spans or balance errors. The issue patch does not change either generated manifest relative to exact main.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py` (29 tests)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- two byte-identical schema-v4 reports
- generated blueprint and interface manifests are byte-for-byte identical to exact-main generation
- `python3 scripts/check_import_direction.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_tenkz_policy.py`
- `git diff --check`

No Lean or blueprint source changed. Hosted full CI remains authoritative.

Closes #6823. Advances #6622 and #6560.
