### PR TITLE
feat(MPS/MPDO): prove vertical coefficient covariance

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -355,4 +355,5 @@ import TNLean.MPS.MPDO.VerticalSectorRetractions
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSpectral
+import TNLean.MPS.MPDO.VerticalTransportCoefficientCovariance
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
+++ b/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAssociativity
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+
+/-!
+# Covariance of BNT coefficients under vertical transport
+
+This file records the change-of-normalization law for the structure
+coefficients of two explicitly identified vertical BNT operator families.  An
+algebra isomorphism identifies the ambient operator algebras at each length,
+while a nonzero scalar attached to each label records the normalization of its
+representative.  Linear independence then determines the transformed
+coefficients uniquely.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 1997--2008
+-/
+
+open scoped BigOperators
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTLabelOperatorFamily
+
+variable {Λ Λ' : Type*} {O O' : ℕ → Type*}
+
+/-- Explicit transport between two vertical BNT operator families.
+
+The label equivalence identifies sectors, the nonzero scalars record the
+normalization of their representatives, and the algebra isomorphism identifies
+the ambient operator algebras at each length.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
+`eq:vertical-coefficient-explicit-transport` and
+`eq:vertical-coefficient-covariance`. -/
+structure ExplicitVerticalTransport
+    [∀ L, Semiring (O L)] [∀ L, Algebra ℂ (O L)]
+    [∀ L, Semiring (O' L)] [∀ L, Algebra ℂ (O' L)]
+    (op : BNTLabelOperatorFamily Λ O) (op' : BNTLabelOperatorFamily Λ' O') where
+  /-- Identification of target labels with source labels. -/
+  labelEquiv : Λ' ≃ Λ
+  /-- Relative normalization of each target representative. -/
+  scale : Λ' → ℂ
+  /-- Every relative normalization is nonzero. -/
+  scale_ne_zero : ∀ α, scale α ≠ 0
+  /-- Identification of the ambient operator algebras at each length. -/
+  algebraEquiv : ∀ L, O L ≃ₐ[ℂ] O' L
+  /-- The target representative is the transported source representative,
+  multiplied by the corresponding length power of its normalization. -/
+  operator_eq : ∀ L α,
+    op'.operator L α = scale α ^ L • algebraEquiv L (op.operator L (labelEquiv α))
+
+/-- The coefficient family obtained by explicit vertical transport.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+`eq:vertical-coefficient-covariance`. -/
+def verticalTransportCoefficients
+    (c : BNTLabelCoefficientFamily Λ) (e : Λ' ≃ Λ) (s : Λ' → ℂ) :
+    BNTLabelCoefficientFamily Λ' where
+  coeff L α β γ := ((s α * s β) / s γ) ^ L * c.coeff L (e α) (e β) (e γ)
+
+variable [Fintype Λ] [Fintype Λ']
+  [∀ L, Ring (O L)] [∀ L, Algebra ℂ (O L)]
+  [∀ L, Ring (O' L)] [∀ L, Algebra ℂ (O' L)]
+
+/-- Explicit vertical transport carries a same-length product law to the
+scale-covariant coefficient family.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
+`eq:vertical-coefficient-explicit-transport` and
+`eq:vertical-coefficient-covariance`. -/
+theorem ExplicitVerticalTransport.hasSameLengthProductForm_verticalTransport
+    {op : BNTLabelOperatorFamily Λ O} {op' : BNTLabelOperatorFamily Λ' O'}
+    {c : BNTLabelCoefficientFamily Λ}
+    (T : ExplicitVerticalTransport op op') (h : op.HasSameLengthProductForm c) :
+    op'.HasSameLengthProductForm (verticalTransportCoefficients c T.labelEquiv T.scale) := by
+  intro L hL α β
+  rw [T.operator_eq, T.operator_eq]
+  rw [smul_mul_smul, ← map_mul]
+  rw [h L hL]
+  simp only [map_sum, map_smul]
+  rw [Finset.smul_sum]
+  rw [← T.labelEquiv.sum_comp]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [T.operator_eq]
+  simp only [verticalTransportCoefficients, smul_smul]
+  congr 1
+  have hscalePow :
+      ((T.scale α * T.scale β) / T.scale γ) ^ L * T.scale γ ^ L =
+        (T.scale α * T.scale β) ^ L := by
+    rw [div_pow, div_mul_cancel₀ _ (pow_ne_zero L (T.scale_ne_zero γ))]
+  rw [← mul_pow (T.scale α) (T.scale β)]
+  calc
+    (T.scale α * T.scale β) ^ L *
+        c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) =
+      c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) *
+        (T.scale α * T.scale β) ^ L := mul_comm _ _
+    _ = c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) *
+        (((T.scale α * T.scale β) / T.scale γ) ^ L * T.scale γ ^ L) := by
+      rw [hscalePow]
+    _ = ((T.scale α * T.scale β) / T.scale γ) ^ L *
+        c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) *
+          T.scale γ ^ L := by ring
+
+/-- At a linearly independent positive length, explicit vertical transport
+forces the scale-covariant comparison law for the structure coefficients.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+`eq:vertical-coefficient-covariance`. -/
+theorem ExplicitVerticalTransport.coeff_eq_verticalTransport_of_linearIndependentAt
+    {op : BNTLabelOperatorFamily Λ O} {op' : BNTLabelOperatorFamily Λ' O'}
+    {c : BNTLabelCoefficientFamily Λ} {c' : BNTLabelCoefficientFamily Λ'}
+    (T : ExplicitVerticalTransport op op') (h : op.HasSameLengthProductForm c)
+    (h' : op'.HasSameLengthProductForm c') {L : ℕ} (hL : 0 < L)
+    (hli : op'.LinearIndependentAt L) (α β γ : Λ') :
+    c'.coeff L α β γ =
+      ((T.scale α * T.scale β) / T.scale γ) ^ L *
+        c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) := by
+  symm
+  exact (T.hasSameLengthProductForm_verticalTransport h).coeff_eq_of_linearIndependentAt
+    h' hL hli α β γ
+
+/-- If the normalizations multiply compatibly on a product triple, explicit
+vertical transport preserves its structure coefficient exactly.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+`eq:vertical-coefficient-covariance`. -/
+theorem ExplicitVerticalTransport.coeff_eq_of_scale_mul_eq_of_linearIndependentAt
+    {op : BNTLabelOperatorFamily Λ O} {op' : BNTLabelOperatorFamily Λ' O'}
+    {c : BNTLabelCoefficientFamily Λ} {c' : BNTLabelCoefficientFamily Λ'}
+    (T : ExplicitVerticalTransport op op') (h : op.HasSameLengthProductForm c)
+    (h' : op'.HasSameLengthProductForm c') {L : ℕ} (hL : 0 < L)
+    (hli : op'.LinearIndependentAt L) {α β γ : Λ'}
+    (hscale : T.scale α * T.scale β = T.scale γ) :
+    c'.coeff L α β γ =
+      c.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) := by
+  rw [T.coeff_eq_verticalTransport_of_linearIndependentAt h h' hL hli]
+  rw [hscale, div_self (T.scale_ne_zero γ), one_pow, one_mul]
+
+end BNTLabelOperatorFamily
+
+namespace BNTAlgebraTensorClause
+
+variable {d D d' D' : ℕ} {M : MPOTensor d D} {M' : MPOTensor d' D'}
+
+/-- Explicit vertical transport between two tensor-attached BNT clauses gives
+the scale-covariant comparison law for their structure coefficients.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+`eq:vertical-coefficient-covariance`. -/
+theorem coeff_eq_of_explicitVerticalTransport
+    (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')
+    (T : BNTLabelOperatorFamily.ExplicitVerticalTransport H.operators H'.operators)
+    {L : ℕ} (hL : 0 < L) (hli : H'.operators.LinearIndependentAt L)
+    (α β γ : Fin H'.labelCount) :
+    H'.coeffs.coeff L α β γ =
+      ((T.scale α * T.scale β) / T.scale γ) ^ L *
+        H.coeffs.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) :=
+  T.coeff_eq_verticalTransport_of_linearIndependentAt
+    H.algebraClause.sameLengthProduct H'.algebraClause.sameLengthProduct hL hli α β γ
+
+/-- Under multiplicative compatibility of the representative normalizations,
+explicit vertical transport preserves a tensor-attached structure coefficient
+exactly.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+`eq:vertical-coefficient-covariance`. -/
+theorem coeff_eq_of_explicitVerticalTransport_of_scale_mul_eq
+    (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')
+    (T : BNTLabelOperatorFamily.ExplicitVerticalTransport H.operators H'.operators)
+    {L : ℕ} (hL : 0 < L) (hli : H'.operators.LinearIndependentAt L)
+    {α β γ : Fin H'.labelCount} (hscale : T.scale α * T.scale β = T.scale γ) :
+    H'.coeffs.coeff L α β γ =
+      H.coeffs.coeff L (T.labelEquiv α) (T.labelEquiv β) (T.labelEquiv γ) :=
+  T.coeff_eq_of_scale_mul_eq_of_linearIndependentAt
+    H.algebraClause.sameLengthProduct H'.algebraClause.sameLengthProduct hL hli hscale
+
+end BNTAlgebraTensorClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
+++ b/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
@@ -36,7 +36,7 @@ variable {Λ Λ' : Type*} {O O' : ℕ → Type*}
 
 The label equivalence identifies sectors, the nonzero scalars record the
 normalization of their representatives, and the algebra isomorphism identifies
-the ambient operator algebras at each length.
+the ambient operator algebras at each positive length.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
@@ -52,12 +52,13 @@ structure ExplicitVerticalTransport
   scale : Λ' → ℂ
   /-- Every relative normalization is nonzero. -/
   scale_ne_zero : ∀ α, scale α ≠ 0
-  /-- Identification of the ambient operator algebras at each length. -/
-  algebraEquiv : ∀ L, O L ≃ₐ[ℂ] O' L
+  /-- Identification of the ambient operator algebras at each positive length. -/
+  algebraEquiv : ∀ L, 0 < L → O L ≃ₐ[ℂ] O' L
   /-- The target representative is the transported source representative,
   multiplied by the corresponding length power of its normalization. -/
-  operator_eq : ∀ L α,
-    op'.operator L α = scale α ^ L • algebraEquiv L (op.operator L (labelEquiv α))
+  operator_eq : ∀ L (hL : 0 < L) α,
+    op'.operator L α =
+      scale α ^ L • algebraEquiv L hL (op.operator L (labelEquiv α))
 
 /-- The coefficient family obtained by explicit vertical transport.
 
@@ -86,7 +87,7 @@ theorem ExplicitVerticalTransport.hasSameLengthProductForm_verticalTransport
     (T : ExplicitVerticalTransport op op') (h : op.HasSameLengthProductForm c) :
     op'.HasSameLengthProductForm (verticalTransportCoefficients c T.labelEquiv T.scale) := by
   intro L hL α β
-  rw [T.operator_eq, T.operator_eq]
+  rw [T.operator_eq L hL α, T.operator_eq L hL β]
   rw [smul_mul_smul, ← map_mul]
   rw [h L hL]
   simp only [map_sum, map_smul]
@@ -94,7 +95,7 @@ theorem ExplicitVerticalTransport.hasSameLengthProductForm_verticalTransport
   rw [← T.labelEquiv.sum_comp]
   apply Finset.sum_congr rfl
   intro γ _
-  rw [T.operator_eq]
+  rw [T.operator_eq L hL γ]
   simp only [verticalTransportCoefficients, smul_smul]
   congr 1
   have hscalePow :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1454,6 +1454,70 @@
     zero.
 \end{proof}
 
+\begin{definition}[Explicit transport of vertical BNT representatives]%
+    \label{def:mpdo_vertical_bnt_explicit_transport}
+    \lean{MPOTensor.BNTLabelOperatorFamily.ExplicitVerticalTransport}
+    \leanok
+    \uses{def:mpdo_bnt_label_operator_family}
+    Let $(O_L(\alpha))_{\alpha\in\Lambda}$ and
+    $(O'_L(\alpha))_{\alpha\in\Lambda'}$ be two labelled operator families.
+    An explicit vertical transport consists of a bijection
+    $e:\Lambda'\to\Lambda$, nonzero scalars $s_\alpha$, and algebra
+    isomorphisms $\Phi_L$ between the ambient operator algebras such that
+    \begin{align}
+        O'_L(\alpha)=s_\alpha^L\Phi_L(O_L(e(\alpha)))
+        \notag
+    \end{align}
+    for every length and every target label.
+\end{definition}
+
+\begin{theorem}[Scale covariance of vertically transported BNT coefficients]%
+    \label{thm:mpdo_vertical_bnt_coefficient_covariance}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        coeff_eq_of_explicitVerticalTransport}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_vertical_bnt_explicit_transport,
+        def:mpdo_bnt_label_linear_independent,
+        thm:mpdo_bnt_label_coeff_unique,
+        thm:mpdo_vertical_coefficients_not_presentation_invariant}
+    Suppose that two tensor-attached vertical BNT presentations are related
+    by an explicit vertical transport.  At every positive length $L$ at
+    which the target operators are linearly independent, their structure
+    coefficients satisfy
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+          c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}\leanok
+    Transport the source product expansion through $\Phi_L$ and substitute
+    the three normalization identities.  Reindex the resulting sum by $e$.
+    Since each $s_\gamma$ is nonzero, its length power cancels, leaving the
+    displayed coefficient family.  Uniqueness of the expansion in the
+    linearly independent target operators gives the result.
+\end{proof}
+
+\begin{corollary}[Exact coefficient comparison under compatible normalization]%
+    \label{cor:mpdo_vertical_bnt_coefficient_transport_exact}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        coeff_eq_of_explicitVerticalTransport_of_scale_mul_eq}
+    \leanok
+    \uses{thm:mpdo_vertical_bnt_coefficient_covariance}
+    Under the hypotheses of the preceding theorem, if
+    $s_\alpha s_\beta=s_\gamma$, then
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        \notag
+    \end{align}
+\end{corollary}
+\begin{proof}\leanok
+    The scale factor in the covariance law is one.
+\end{proof}
+
 % Project-derived counterexample to the cross-presentation assertion formerly
 % proposed in #6395.  CPSV16 does not state this assertion.
 \begin{definition}[Horizontally gauge-equivalent tensors with distinct vertical normalizations]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1468,10 +1468,63 @@
         O'_L(\alpha)=s_\alpha^L\Phi_L(O_L(e(\alpha)))
         \notag
     \end{align}
-    for every length and every target label.
+    for every positive length and every target label.
 \end{definition}
 
-\begin{theorem}[Scale covariance of vertically transported BNT coefficients]%
+\begin{definition}[Coefficient family transported by vertical normalization]%
+    \label{def:mpdo_vertical_bnt_transported_coefficients}
+    \lean{MPOTensor.BNTLabelOperatorFamily.verticalTransportCoefficients}
+    \leanok
+    \uses{def:mpdo_bnt_label_coefficient_family}
+    Given a label bijection $e:\Lambda'\to\Lambda$ and nonzero scalars
+    $s_\alpha$, the transported coefficient family is
+    \begin{align}
+        \widetilde c^{(L)}_{\alpha,\beta,\gamma}
+        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+          c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Transport of the same-length product law]%
+    \label{thm:mpdo_vertical_bnt_product_transport}
+    \lean{MPOTensor.BNTLabelOperatorFamily.ExplicitVerticalTransport.%
+        hasSameLengthProductForm_verticalTransport}
+    \leanok
+    \uses{def:mpdo_vertical_bnt_explicit_transport,
+        def:mpdo_vertical_bnt_transported_coefficients,
+        def:mpdo_bnt_label_same_length_product_form}
+    An explicit vertical transport carries a same-length product law to the
+    transported coefficient family.
+\end{theorem}
+\begin{proof}\leanok
+    Apply $\Phi_L$ to the source product expansion and reindex the resulting
+    finite sum by $e$.  Substitution of the representative normalizations
+    produces the transported coefficients; the nonzero factor
+    $s_\gamma^L$ cancels in every summand.
+\end{proof}
+
+\begin{theorem}[Abstract covariance of vertically transported coefficients]%
+    \label{thm:mpdo_vertical_bnt_coefficient_covariance_abstract}
+    \lean{MPOTensor.BNTLabelOperatorFamily.ExplicitVerticalTransport.%
+        coeff_eq_verticalTransport_of_linearIndependentAt}
+    \leanok
+    \uses{def:mpdo_bnt_label_linear_independent,
+        thm:mpdo_bnt_label_coeff_unique,
+        thm:mpdo_vertical_bnt_product_transport}
+    Suppose that source and target operator families satisfy same-length
+    product laws and are related by an explicit vertical transport.  At a
+    positive length where the target operators are linearly independent,
+    the target coefficient family equals the transported source coefficient
+    family.
+\end{theorem}
+\begin{proof}\leanok
+    The preceding theorem gives a second product expansion of the target
+    operators.  Uniqueness of coefficients in a linearly independent family
+    identifies it with the given target expansion.
+\end{proof}
+
+\begin{theorem}[Scale covariance of tensor-attached BNT coefficients]%
     \label{thm:mpdo_vertical_bnt_coefficient_covariance}
     \lean{MPOTensor.BNTAlgebraTensorClause.%
         coeff_eq_of_explicitVerticalTransport}
@@ -1479,8 +1532,7 @@
     \uses{def:mpdo_bnt_algebra_tensor_clause,
         def:mpdo_vertical_bnt_explicit_transport,
         def:mpdo_bnt_label_linear_independent,
-        thm:mpdo_bnt_label_coeff_unique,
-        thm:mpdo_vertical_coefficients_not_presentation_invariant}
+        thm:mpdo_vertical_bnt_coefficient_covariance_abstract}
     Suppose that two tensor-attached vertical BNT presentations are related
     by an explicit vertical transport.  At every positive length $L$ at
     which the target operators are linearly independent, their structure
@@ -1491,21 +1543,40 @@
           c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
+    Theorem~\ref{thm:mpdo_vertical_coefficients_not_presentation_invariant}
+    shows why a bare equality of horizontal periodic families cannot replace
+    the explicit transport hypothesis.
 \end{theorem}
 \begin{proof}\leanok
-    Transport the source product expansion through $\Phi_L$ and substitute
-    the three normalization identities.  Reindex the resulting sum by $e$.
-    Since each $s_\gamma$ is nonzero, its length power cancels, leaving the
-    displayed coefficient family.  Uniqueness of the expansion in the
-    linearly independent target operators gives the result.
+    Apply the abstract covariance theorem to the product laws carried by the
+    two tensor-attached BNT clauses.
 \end{proof}
 
-\begin{corollary}[Exact coefficient comparison under compatible normalization]%
-    \label{cor:mpdo_vertical_bnt_coefficient_transport_exact}
+\begin{theorem}[Abstract exact comparison under compatible normalization]%
+    \label{thm:mpdo_vertical_bnt_coefficient_transport_exact_abstract}
+    \lean{MPOTensor.BNTLabelOperatorFamily.ExplicitVerticalTransport.%
+        coeff_eq_of_scale_mul_eq_of_linearIndependentAt}
+    \leanok
+    \uses{thm:mpdo_vertical_bnt_coefficient_covariance_abstract}
+    Under the hypotheses of the abstract covariance theorem, if
+    $s_\alpha s_\beta=s_\gamma$, then
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}\leanok
+    The scale factor in the covariance law is one.
+\end{proof}
+
+\begin{theorem}[Exact tensor-attached comparison under compatible normalization]%
+    \label{thm:mpdo_vertical_bnt_coefficient_transport_exact}
     \lean{MPOTensor.BNTAlgebraTensorClause.%
         coeff_eq_of_explicitVerticalTransport_of_scale_mul_eq}
     \leanok
-    \uses{thm:mpdo_vertical_bnt_coefficient_covariance}
+    \uses{def:mpdo_bnt_algebra_tensor_clause,
+        thm:mpdo_vertical_bnt_coefficient_transport_exact_abstract}
     Under the hypotheses of the preceding theorem, if
     $s_\alpha s_\beta=s_\gamma$, then
     \begin{align}
@@ -1513,7 +1584,7 @@
         =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
-\end{corollary}
+\end{theorem}
 \begin{proof}\leanok
     The scale factor in the covariance law is one.
 \end{proof}


### PR DESCRIPTION
## Mathematical content

This pull request formalizes the scale-covariant comparison law identified after the vertical-presentation counterexample. It introduces explicit vertical transport by a label equivalence, nonzero label scalars, and lengthwise complex-algebra isomorphisms satisfying

```text
O′_L(α) = s_α^L · Φ_L(O_L(e α)).
```

Transporting the source product expansion and using linear independence of the target operators proves

```text
c′⁽ˡ⁾_{α,β,γ} = ((s_α s_β) / s_γ)^L c⁽ˡ⁾_{eα,eβ,eγ}.
```

A tensor-attached specialization applies the abstract result to two `BNTAlgebraTensorClause` witnesses. A corollary gives exact equality when `s_α s_β = s_γ`. No horizontal periodic-equality hypothesis is used or claimed to produce the transport data.

The blueprint records the transport definition, covariance theorem, and exact-normalization corollary, and links the covariance theorem to the counterexample that shows why explicit transport is necessary.

## Validation

- `lake env lean TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_import_direction.py --root .`
- proof-integrity and line-length scans on the new Lean module
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`

The local `leanblueprint checkdecls` executable used a stale root `TNLean.olean` and consequently also reported numerous declarations already present on main as missing; hosted full CI is authoritative for that compiled-root check.

Closes #6813.
