### PR TITLE
doc(MPS/MPDO): display vertical transport identities

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1480,10 +1480,11 @@
     the transported coefficient family is
     \begin{align}
         \widetilde c^{(L)}_{\alpha,\beta,\gamma}
-        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+        &=\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
           c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
+    Here division is totalized by the convention $z/0=0$.
 \end{definition}
 
 \begin{theorem}[Transport of the same-length product law]%
@@ -1543,7 +1544,7 @@
     Theorem~\ref{thm:mpdo_vertical_bnt_product_transport} give
     \begin{align}
         \sum_\gamma c'^{(L)}_{\alpha,\beta,\gamma}O'_L(\gamma)
-        =O'_L(\alpha)O'_L(\beta)
+        &=O'_L(\alpha)O'_L(\beta)
         =\sum_\gamma
           \widetilde c^{(L)}_{\alpha,\beta,\gamma}O'_L(\gamma).
         \notag
@@ -1567,7 +1568,7 @@
     coefficients satisfy
     \begin{align}
         {c'}^{(L)}_{\alpha,\beta,\gamma}
-        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+        &=\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
           c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
@@ -1580,7 +1581,7 @@
     abstract covariance theorem.  Hence
     \begin{align}
         {c'}^{(L)}_{\alpha,\beta,\gamma}
-        =\widetilde c^{(L)}_{\alpha,\beta,\gamma}
+        &=\widetilde c^{(L)}_{\alpha,\beta,\gamma}
         =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
           c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
@@ -1597,7 +1598,7 @@
     $s_\alpha s_\beta=s_\gamma$, then
     \begin{align}
         {c'}^{(L)}_{\alpha,\beta,\gamma}
-        =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        &=c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
 \end{theorem}
@@ -1605,7 +1606,7 @@
     The compatible normalization and $s_\gamma\ne0$ give
     \begin{align}
         \left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
-        =\left(\frac{s_\gamma}{s_\gamma}\right)^L=1.
+        &=\left(\frac{s_\gamma}{s_\gamma}\right)^L=1.
         \notag
     \end{align}
     Substitution in the abstract covariance law gives the result.
@@ -1622,7 +1623,7 @@
     $s_\alpha s_\beta=s_\gamma$, then
     \begin{align}
         {c'}^{(L)}_{\alpha,\beta,\gamma}
-        =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        &=c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
         \notag
     \end{align}
 \end{theorem}
@@ -1630,7 +1631,7 @@
     The tensor-attached exact comparison is the specialization
     \begin{align}
         {c'}^{(L)}_{\alpha,\beta,\gamma}
-        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+        &=\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
           c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}
         =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)},
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1476,8 +1476,8 @@
     \lean{MPOTensor.BNTLabelOperatorFamily.verticalTransportCoefficients}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family}
-    Given a label bijection $e:\Lambda'\to\Lambda$ and nonzero scalars
-    $s_\alpha$, the transported coefficient family is
+    Given a label bijection $e:\Lambda'\to\Lambda$ and scalars $s_\alpha$,
+    the transported coefficient family is
     \begin{align}
         \widetilde c^{(L)}_{\alpha,\beta,\gamma}
         =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
@@ -1498,10 +1498,30 @@
     transported coefficient family.
 \end{theorem}
 \begin{proof}\leanok
-    Apply $\Phi_L$ to the source product expansion and reindex the resulting
-    finite sum by $e$.  Substitution of the representative normalizations
-    produces the transported coefficients; the nonzero factor
-    $s_\gamma^L$ cancels in every summand.
+    For every positive length $L$, multiplication of the two transported
+    representatives and the source product law give
+    \begin{align}
+        O'_L(\alpha)O'_L(\beta)
+        &=(s_\alpha s_\beta)^L
+          \Phi_L\bigl(O_L(e(\alpha))O_L(e(\beta))\bigr)
+        \notag\\
+        &=(s_\alpha s_\beta)^L
+          \sum_\delta c^{(L)}_{e(\alpha),e(\beta),\delta}
+          \Phi_L(O_L(\delta)).
+        \notag
+    \end{align}
+    Reindexing by $\delta=e(\gamma)$ and using $s_\gamma\ne0$ yields
+    \begin{align}
+        O'_L(\alpha)O'_L(\beta)
+        &=\sum_\gamma
+          \left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+          c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}
+          \,s_\gamma^L\Phi_L(O_L(e(\gamma)))
+        \notag\\
+        &=\sum_\gamma
+          \widetilde c^{(L)}_{\alpha,\beta,\gamma}O'_L(\gamma).
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Abstract covariance of vertically transported coefficients]%
@@ -1519,12 +1539,20 @@
     family.
 \end{theorem}
 \begin{proof}\leanok
-    The preceding theorem gives a second product expansion of the target
-    operators.  Uniqueness of coefficients in a linearly independent family
-    identifies it with the given target expansion.
+    The target product law and
+    Theorem~\ref{thm:mpdo_vertical_bnt_product_transport} give
+    \begin{align}
+        \sum_\gamma c'^{(L)}_{\alpha,\beta,\gamma}O'_L(\gamma)
+        =O'_L(\alpha)O'_L(\beta)
+        =\sum_\gamma
+          \widetilde c^{(L)}_{\alpha,\beta,\gamma}O'_L(\gamma).
+        \notag
+    \end{align}
+    Linear independence of the target operators identifies the two
+    coefficient families term by term.
 \end{proof}
 
-\begin{theorem}[Scale covariance of tensor-attached BNT coefficients]%
+\begin{theorem}[Tensor-attached coefficient covariance]%
     \label{thm:mpdo_vertical_bnt_coefficient_covariance}
     \lean{MPOTensor.BNTAlgebraTensorClause.%
         coeff_eq_of_explicitVerticalTransport}
@@ -1548,8 +1576,15 @@
     the explicit transport hypothesis.
 \end{theorem}
 \begin{proof}\leanok
-    Apply the abstract covariance theorem to the product laws carried by the
-    two tensor-attached BNT clauses.
+    The two tensor-attached BNT clauses carry the product laws required by the
+    abstract covariance theorem.  Hence
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        =\widetilde c^{(L)}_{\alpha,\beta,\gamma}
+        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+          c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}.
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Abstract exact comparison under compatible normalization]%
@@ -1567,7 +1602,13 @@
     \end{align}
 \end{theorem}
 \begin{proof}\leanok
-    The scale factor in the covariance law is one.
+    The compatible normalization and $s_\gamma\ne0$ give
+    \begin{align}
+        \left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+        =\left(\frac{s_\gamma}{s_\gamma}\right)^L=1.
+        \notag
+    \end{align}
+    Substitution in the abstract covariance law gives the result.
 \end{proof}
 
 \begin{theorem}[Exact tensor-attached comparison under compatible normalization]%
@@ -1586,7 +1627,16 @@
     \end{align}
 \end{theorem}
 \begin{proof}\leanok
-    The scale factor in the covariance law is one.
+    The tensor-attached exact comparison is the specialization
+    \begin{align}
+        {c'}^{(L)}_{\alpha,\beta,\gamma}
+        =\left(\frac{s_\alpha s_\beta}{s_\gamma}\right)^L
+          c^{(L)}_{e(\alpha),e(\beta),e(\gamma)}
+        =c^{(L)}_{e(\alpha),e(\beta),e(\gamma)},
+        \notag
+    \end{align}
+    where the last equality uses $s_\alpha s_\beta=s_\gamma$ and
+    $s_\gamma\ne0$.
 \end{proof}
 
 % Project-derived counterexample to the cross-presentation assertion formerly


### PR DESCRIPTION
## Summary

This follow-up to #6835 aligns the Blueprint with the exact domain of `verticalTransportCoefficients`: the coefficient formula accepts arbitrary scalars, while nonvanishing belongs to the explicit transport structure.

The proof sketches now display the transported product expansion, the two coefficient expansions compared by linear independence, and the normalization identities used by the exact-comparison theorems. The shorter covariance heading also avoids the local overfull line found during document generation.

## Review origin

This addresses the exact-head review threads `PRRT_kwDORK8b986a_yfr`, `PRRT_kwDORK8b986a_um7`, and `PRRT_kwDORK8b986a_9gl` posted immediately before #6835 was merged.

## Validation

- Blueprint–Lean synchronization: 8180/8180
- `git diff --check`
- Full Blueprint PDF traversal reached and typeset the edited chapter without a TeX error; the long global build was stopped during a later pass after the edited chapter had completed.