### PR TITLE
doc(MPS/MPDO): introduce two-four map quantifier

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -87,14 +87,15 @@
     \lean{MPOTensor.blockTwo_isRFPViaTS_of_two_four_maps}
     \leanok
     \uses{def:is_rfp_via_ts, def:mpdo_two_site_blocking}
-    Let $K$ be an MPO tensor. Suppose that trace-preserving completely positive maps
-    $S_{24}$ and $T_{24}$ satisfy
+    Let $K$ be an MPO tensor. Suppose that trace-preserving completely positive
+    maps $S_{24}$ and $T_{24}$ satisfy the following identities for every
+    virtual matrix $X$:
     \begin{align}
         S_{24}[\mathcal K_4(X)]&=\mathcal K_2(X), &
-        T_{24}[\mathcal K_2(X)]&=\mathcal K_4(X) \notag
+        T_{24}[\mathcal K_2(X)]&=\mathcal K_4(X). \notag
     \end{align}
-    for every virtual matrix $X$. Then the two-site physical blocking
-    $K^{[2]}$ is a renormalization fixed point.
+    Then the two-site physical blocking $K^{[2]}$ is a renormalization fixed
+    point.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -91,7 +91,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L804, 817, 825, 832, 906, 913 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L329, 335, 341, 355, 366, 372 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L452, 971, 975, 981, 986 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L453, 972, 976, 982, 987 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 494, 498, 699, 703, 716, 720, 763, 767, 771, 780, 784 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

The statement of the blocked renormalization theorem now introduces the universal quantifier before its displayed two-to-four map identities. The display is punctuated as part of the surrounding sentence.

This follows the mathematical prose convention in `docs/prose_style.md` and addresses the review observation inherited from #6808.

Closes #6836.

## Validation

- Blueprint–Lean synchronization: 8187/8187
- `git diff --check`