### PR TITLE
ci(qiclean): resynchronize frozen TN interface labels

### DIFF
--- a/docs/audits/data/qiclean/tn-interface-labels.txt
+++ b/docs/audits/data/qiclean/tn-interface-labels.txt
@@ -48,6 +48,7 @@ def:von_neumann_entropy
 eq:channel_kraus_representation
 eq:channel_power_decomp
 eq:gram_reshuffle_single
+eq:matrix_support_completion_agreement
 eq:mpu_reduced_projection_coordinate_identities
 eq:mpu_reduced_projection_transversality
 eq:spec_commutant_action
@@ -79,6 +80,8 @@ lem:linear_map_to_alg
 lem:matrix_one_sided_product_obstruction
 lem:matrix_sigma_block_inclusion
 lem:mpdo_coisometric_compression_trace
+lem:mpdo_compressed_cp_sum
+lem:mpdo_projector_controlled_trace_selection
 lem:mpdo_right_partial_trace_cptp
 lem:mpdo_single_kraus_map_cp
 lem:mpdo_state_preparation_cptp
@@ -188,6 +191,7 @@ thm:mpdo_direct_sum_faithful_fixed_family
 thm:mpdo_equiv_reindex_cptp
 thm:mpdo_faithful_uniform_density
 thm:mpdo_mutual_information_data_processing
+thm:mpdo_projective_resolution_channel_cptp
 thm:mpdo_rectangular_kraus_map_equiv
 thm:mpdo_single_kraus_map_cptp
 thm:mpdo_state_preparation_kraus_action


### PR DESCRIPTION
Closes #6833.

## Summary

This change regenerates the frozen TN-to-QIC interface-label manifest from exact TNLean `main` at source revision `5afa6fc25090d7df1bae3f7c55b85d4b4edbe9a1`, after the atomic-extraction parser corrections and the subsequent Blueprint dependency changes.

The exact schema-v4 report contains:

- 271 TN interface labels (previously 267);
- 1,479 QIC items and 3,345 TN items;
- 507 TN-to-QIC dependency edges;
- 140 TN-to-QIC item-reference edges;
- 44 TN-to-QIC non-item reference edges;
- zero QIC-to-TN dependency or reference edges;
- zero simulated-output errors.

The four newly required labels are:

- `eq:matrix_support_completion_agreement`;
- `lem:mpdo_compressed_cp_sum`;
- `lem:mpdo_projector_controlled_trace_selection`;
- `thm:mpdo_projective_resolution_channel_cptp`.

The first three arise from the support-completion dependency edge added after the issue was filed; the fourth is the projective-resolution dependency named in the issue.

## Determinism and frozen artifacts

Two independent schema-v4 JSON reports were byte-identical. Two independently generated interface manifests were byte-identical. The generated 163-file Blueprint manifest was byte-identical to both its second generation and the checked-in frozen file.

Artifact SHA-256 digests:

- report: `078c16955b6054462e696dbf775e3e924334b41dadd130d90093de27e1fd3bce`;
- Blueprint-file manifest: `2f99b1caf58eba87fd083442be137012b3d681e479ec33ec506f7ccb57fe17df`;
- TN-interface manifest: `2787968242c76141f38cc5b84cf81fa22b32796fd4ef66b909ecf57010150dc5`.

## Verification

- `PYTHONPATH=scripts python3 scripts/test_qic_blueprint_boundary_report.py -v` (32 tests)
- deterministic schema-v4 report comparison
- deterministic Blueprint-file and TN-interface manifest comparisons
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_check_import_direction.py -v`
- `PYTHONPATH=scripts python3 scripts/check_import_direction.py --root . --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (8,190/8,190)
- `python3 -m py_compile scripts/qic_blueprint_boundary_report.py scripts/test_qic_blueprint_boundary_report.py`
- `git diff --check`

No Lean source, theorem statement, proof, or Blueprint prose changes.