### PR TITLE
doc(MPS/MPDO): cite absorbed-basis gauge convention

### DIFF
--- a/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
+++ b/TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean
@@ -112,7 +112,8 @@ theorem physCloseN_eq_sum_flatBasis_of_gauge_toTensor
 copy sum is absorbed into the representative and the virtual boundary becomes
 the sum of its diagonal copy blocks.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1646--1665 and 1810--1825. -/
+Source: arXiv:1606.00608, gauge-matrix similarity convention at lines
+186--195, and Appendix C.2, lines 1646--1665 and 1810--1825. -/
 theorem physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor
     (S : MPSTensor.SectorDecomposition (d * d))
     (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),


### PR DESCRIPTION
Closes #6831.

## Summary

This change supplies the missing source anchor for the invertible-gauge hypothesis of `MPOTensor.physCloseN_eq_sum_commonWeightAbsorbedBasis_of_gauge_toTensor`.

The theorem already cited Appendix C.2 for the representative decomposition. Its docstring now also cites arXiv:1606.00608, lines 186--195, where the paper states the similarity convention

```text
B^i = X C^i X^{-1}.
```

This makes the source documentation consistent with the sibling flat-basis theorem carrying the same gauge hypothesis. No theorem statement or proof changes.

## Verification

- `lake env lean TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/BNTBoundaryDecomposition.lean` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`