### PR TITLE
feat(Channel): formalize anti-linear spectral conjugacy

### DIFF
--- a/TNLean/Channel/Peripheral.lean
+++ b/TNLean/Channel/Peripheral.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Channel.Peripheral
 
 import TNLean.Channel.Peripheral.AdjointSpectrum
+import TNLean.Channel.Peripheral.AntilinearConjugation
 import TNLean.Channel.Peripheral.AsymptoticImage
 import TNLean.Channel.Peripheral.CesaroRecurrence
 import TNLean.Channel.Peripheral.ClosureFixedPointKraus

--- a/TNLean/Channel/Peripheral/AntilinearConjugation.lean
+++ b/TNLean/Channel/Peripheral/AntilinearConjugation.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Peripheral.Spectrum
+import Mathlib.Analysis.Matrix.Normed
+
+/-!
+# Anti-linear conjugation and spectrum
+
+Entrywise complex conjugation `σ X = X.map (starRingEnd ℂ)` is an anti-linear
+involution of the matrix space. Conjugating a matrix endomorphism `Φ` by `σ`
+produces the linear endomorphism `σ ∘ Φ ∘ σ`, and this transport conjugates all
+spectral data: the spectrum, the eigenvalues, and the peripheral eigenvalues of
+`σ ∘ Φ ∘ σ` are the complex conjugates of those of `Φ`, while the spectral
+radius and peripheral-spectrum primitivity are invariant.
+
+These statements transport the spectral clauses of the normal-tensor definition
+of arXiv:1606.00608, lines 231--235, across entrywise conjugation of the tensor,
+since entrywise conjugation of a tensor conjugates its transfer map
+anti-linearly.
+
+## Main definitions
+
+* `entrywiseConjTransport`: the transport `Φ ↦ σ ∘ Φ ∘ σ` of a matrix
+  endomorphism along entrywise conjugation.
+* `entrywiseConjTransportRingEquiv`: the same transport as a ring automorphism
+  of the endomorphism ring.
+
+## Main results
+
+* `spectrum_entrywiseConjTransport`: the spectrum of `σ ∘ Φ ∘ σ` is the complex
+  conjugate of the spectrum of `Φ`.
+* `hasEigenvalue_entrywiseConjTransport_iff`: eigenvalues conjugate accordingly.
+* `peripheralEigenvalues_entrywiseConjTransport`: the peripheral eigenvalues of
+  `σ ∘ Φ ∘ σ` are the complex conjugates of those of `Φ`.
+* `spectralRadius_entrywiseConjTransport`: the spectral radius is invariant.
+* `IsPrimitive.entrywiseConjTransport_iff`: primitivity is invariant.
+-/
+
+open scoped Matrix ComplexOrder BigOperators NNReal ENNReal Matrix.Norms.Operator
+
+variable {D : ℕ}
+
+namespace Matrix
+
+/-- Entrywise conjugation of a matrix is an involution. -/
+@[simp] theorem map_starRingEnd_map_starRingEnd {m n : Type*} (X : Matrix m n ℂ) :
+    (X.map (starRingEnd ℂ)).map (starRingEnd ℂ) = X := by
+  ext i j
+  simp [Matrix.map_apply]
+
+/-- Entrywise conjugation of a matrix is an involution, composed-function form. -/
+@[simp] theorem map_starRingEnd_comp_starRingEnd {m n : Type*} (X : Matrix m n ℂ) :
+    X.map (⇑(starRingEnd ℂ) ∘ ⇑(starRingEnd ℂ)) = X := by
+  ext i j
+  simp [Matrix.map_apply]
+
+/-- Entrywise conjugation is anti-linear: it conjugates scalars. -/
+theorem map_smul_starRingEnd {m n : Type*} (c : ℂ) (X : Matrix m n ℂ) :
+    (c • X).map (starRingEnd ℂ) = star c • X.map (starRingEnd ℂ) := by
+  ext i j
+  simp [Matrix.map_apply]
+
+end Matrix
+
+/-- Transport of a matrix endomorphism along entrywise complex conjugation:
+`Φ ↦ σ ∘ Φ ∘ σ`, where `σ X = X.map (starRingEnd ℂ)` is the anti-linear
+involution given by entrywise conjugation. Both anti-linear factors conjugate
+the scalars, so the composite is again linear.
+
+This is the anti-linear conjugacy through which entrywise conjugation of a
+tensor acts on its transfer map (arXiv:1606.00608, lines 219--225). -/
+noncomputable def entrywiseConjTransport
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
+  toFun X := (Φ (X.map (starRingEnd ℂ))).map (starRingEnd ℂ)
+  map_add' X Y := by
+    rw [Matrix.map_add (starRingEnd ℂ) (map_add (starRingEnd ℂ)) X Y, map_add,
+      Matrix.map_add (starRingEnd ℂ) (map_add (starRingEnd ℂ))]
+  map_smul' c X := by
+    rw [Matrix.map_smul_starRingEnd, map_smul, Matrix.map_smul_starRingEnd, star_star]
+    rfl
+
+@[simp] theorem entrywiseConjTransport_apply
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    entrywiseConjTransport Φ X = (Φ (X.map (starRingEnd ℂ))).map (starRingEnd ℂ) := rfl
+
+/-- Transport along entrywise conjugation is an involution on endomorphisms. -/
+@[simp] theorem entrywiseConjTransport_entrywiseConjTransport
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    entrywiseConjTransport (entrywiseConjTransport Φ) = Φ := by
+  apply LinearMap.ext
+  intro X
+  simp
+
+/-- Transport along entrywise conjugation is multiplicative for composition. -/
+theorem entrywiseConjTransport_mul
+    (Φ Ψ : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) :
+    entrywiseConjTransport (Φ * Ψ) =
+      entrywiseConjTransport Φ * entrywiseConjTransport Ψ := by
+  apply LinearMap.ext
+  intro X
+  simp [Module.End.mul_apply]
+
+/-- Transport along entrywise conjugation sends the scalar `μ` to `conj μ`. -/
+theorem entrywiseConjTransport_algebraMap (μ : ℂ) :
+    entrywiseConjTransport
+        (algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) μ) =
+      algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) (star μ) := by
+  apply LinearMap.ext
+  intro X
+  rw [entrywiseConjTransport_apply, Module.algebraMap_end_apply,
+    Module.algebraMap_end_apply, Matrix.map_smul_starRingEnd,
+    Matrix.map_starRingEnd_map_starRingEnd]
+
+/-- Transport along entrywise conjugation as a ring automorphism of the
+endomorphism ring of the matrix space. On scalars it acts by complex
+conjugation (`entrywiseConjTransport_algebraMap`), so it is a ring
+automorphism but not an algebra automorphism. -/
+noncomputable def entrywiseConjTransportRingEquiv (D : ℕ) :
+    Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) ≃+*
+      Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) where
+  toFun := entrywiseConjTransport
+  invFun := entrywiseConjTransport
+  left_inv := entrywiseConjTransport_entrywiseConjTransport
+  right_inv := entrywiseConjTransport_entrywiseConjTransport
+  map_mul' := entrywiseConjTransport_mul
+  map_add' Φ Ψ := by
+    apply LinearMap.ext
+    intro X
+    simp [Matrix.map_add (starRingEnd ℂ) (map_add (starRingEnd ℂ))]
+
+/-- The spectrum of the anti-linear conjugate `σ ∘ Φ ∘ σ` is the complex
+conjugate of the spectrum of `Φ`.
+
+This is the spectral half of the anti-linear conjugacy used to transport the
+normalization of arXiv:1606.00608, lines 224--225, across entrywise
+conjugation. -/
+theorem spectrum_entrywiseConjTransport
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    spectrum ℂ (entrywiseConjTransport Φ) = star '' spectrum ℂ Φ := by
+  have key : ∀ μ : ℂ,
+      μ ∈ spectrum ℂ (entrywiseConjTransport Φ) ↔ star μ ∈ spectrum ℂ Φ := by
+    intro μ
+    rw [spectrum.mem_iff, spectrum.mem_iff]
+    have hmap :
+        (entrywiseConjTransportRingEquiv D)
+            (algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) (star μ) - Φ) =
+          algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) μ -
+            entrywiseConjTransport Φ := by
+      rw [map_sub]
+      congr 1
+      rw [show ((entrywiseConjTransportRingEquiv D)
+          (algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) (star μ))) =
+        entrywiseConjTransport
+          (algebraMap ℂ (Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) (star μ)) from rfl,
+        entrywiseConjTransport_algebraMap, star_star]
+    rw [← hmap]
+    exact not_congr (MulEquiv.isUnit_map (entrywiseConjTransportRingEquiv D))
+  ext μ
+  rw [Set.mem_image, key μ]
+  constructor
+  · intro h
+    exact ⟨star μ, h, star_star μ⟩
+  · rintro ⟨ν, hν, rfl⟩
+    simpa [star_star] using hν
+
+/-- Eigenvalues of the anti-linear conjugate `σ ∘ Φ ∘ σ` are the complex
+conjugates of the eigenvalues of `Φ`: an eigenvector transports to its
+entrywise conjugate. Supports the transport of clause (ii) of the
+normal-tensor definition, arXiv:1606.00608, lines 233--235. -/
+theorem hasEigenvalue_entrywiseConjTransport_iff
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (μ : ℂ) :
+    Module.End.HasEigenvalue (entrywiseConjTransport Φ) μ ↔
+      Module.End.HasEigenvalue Φ (star μ) := by
+  have forward :
+      ∀ (Ψ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (ν : ℂ),
+        Module.End.HasEigenvalue (entrywiseConjTransport Ψ) ν →
+          Module.End.HasEigenvalue Ψ (star ν) := by
+    intro Ψ ν h
+    obtain ⟨v, hv⟩ := h.exists_hasEigenvector
+    apply hasEigenvalue_of_eigenvector_eq Ψ (star ν) (v.map (starRingEnd ℂ))
+    · have happ := congrArg (fun M => M.map (starRingEnd ℂ)) hv.apply_eq_smul
+      simpa [Matrix.map_smul_starRingEnd] using happ
+    · intro h0
+      apply hv.2
+      have := congrArg (fun M => M.map (starRingEnd ℂ)) h0
+      simpa using this
+  constructor
+  · exact forward Φ μ
+  · intro h
+    have h' : Module.End.HasEigenvalue
+        (entrywiseConjTransport (entrywiseConjTransport Φ)) (star μ) := by
+      rw [entrywiseConjTransport_entrywiseConjTransport]
+      exact h
+    simpa [star_star] using forward (entrywiseConjTransport Φ) (star μ) h'
+
+/-- The peripheral eigenvalues of the anti-linear conjugate `σ ∘ Φ ∘ σ` are the
+complex conjugates of the peripheral eigenvalues of `Φ`. Supports the transport
+of clause (ii) of the normal-tensor definition, arXiv:1606.00608, lines
+233--235. -/
+theorem peripheralEigenvalues_entrywiseConjTransport
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    peripheralEigenvalues (entrywiseConjTransport Φ) =
+      star '' peripheralEigenvalues Φ := by
+  ext μ
+  simp only [peripheralEigenvalues, Set.mem_ofPred_eq, Set.mem_image]
+  constructor
+  · rintro ⟨hEig, hNorm⟩
+    exact ⟨star μ, ⟨(hasEigenvalue_entrywiseConjTransport_iff Φ μ).1 hEig,
+      by simpa only [norm_star] using hNorm⟩, star_star μ⟩
+  · rintro ⟨ν, ⟨hEig, hNorm⟩, rfl⟩
+    refine ⟨(hasEigenvalue_entrywiseConjTransport_iff Φ (star ν)).2 ?_,
+      by simpa only [norm_star] using hNorm⟩
+    simpa [star_star] using hEig
+
+/-- Peripheral-spectrum primitivity is invariant under anti-linear conjugation
+by entrywise conjugation: the peripheral eigenvalues conjugate, and `{1}` is
+fixed by conjugation. Supports the transport of clause (ii) of the
+normal-tensor definition, arXiv:1606.00608, lines 233--235. -/
+theorem IsPrimitive.entrywiseConjTransport_iff
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    _root_.IsPrimitive (entrywiseConjTransport Φ) ↔ _root_.IsPrimitive Φ := by
+  rw [isPrimitive_iff, isPrimitive_iff, peripheralEigenvalues_entrywiseConjTransport]
+  constructor
+  · intro h
+    have := congrArg (star '' ·) h
+    simpa [Set.image_image] using this
+  · intro h
+    simp [h]
+
+/-- The spectral radius is invariant under anti-linear conjugation by entrywise
+conjugation, since the spectrum conjugates and conjugation preserves the
+modulus. This transports the spectral-radius-one normalization of
+arXiv:1606.00608, lines 224--225 and 233--235, across entrywise conjugation. -/
+theorem spectralRadius_entrywiseConjTransport
+    (Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (entrywiseConjTransport Φ)) =
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) Φ) := by
+  have hspec :
+      spectrum ℂ
+          ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+            (entrywiseConjTransport Φ)) =
+        star ''
+          spectrum ℂ
+            ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) Φ) := by
+    rw [AlgEquiv.spectrum_eq, AlgEquiv.spectrum_eq, spectrum_entrywiseConjTransport]
+  rw [spectralRadius, spectralRadius, hspec, iSup_image]
+  simp only [nnnorm_star]

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Peripheral.AntilinearConjugation
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 
 /-!
@@ -21,6 +22,9 @@ and the transfer-map fixed-point equations used in canonical forms.
 * `MPSTensor.IsNormal.mapStar`: conjugation preserves normality.
 * `MPSTensor.IsLeftCanonical.mapStar`: conjugation preserves left-canonical normalization.
 * `MPSTensor.GaugeEquiv.mapStar`: conjugation preserves gauge equivalence.
+* `MPSTensor.transferMap_mapStar_eq_entrywiseConjTransport`: conjugating the tensor
+  conjugates its transfer map anti-linearly, as an operator identity.
+* `MPSTensor.IsIrreducibleTensor.mapStar`: conjugation preserves irreducibility.
 * `MPSTensor.IsNormalTensor.mapStar`: conjugation preserves normalized normal tensors.
 -/
 
@@ -68,10 +72,7 @@ theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
             exact Matrix.map_add _ (map_add (starRingEnd ℂ)) Y Z]
         exact Submodule.add_mem _ hY hZ
     | smul c Y _ hY =>
-        rw [show (c • Y).map (starRingEnd ℂ) =
-          star c • Y.map (starRingEnd ℂ) by
-            ext i j
-            simp [Matrix.map_apply]]
+        rw [Matrix.map_smul_starRingEnd]
         exact Submodule.smul_mem _ (star c) hY
   have := hconj _ hmem
   convert this using 1
@@ -132,24 +133,6 @@ theorem GaugeEquiv.mapStar {A B : MPSTensor d D} (h : GaugeEquiv A B) :
   rw [mapStar_apply, mapStar_apply, hX i, Matrix.map_mul, Matrix.map_mul]
   rfl
 
-/-- Entrywise complex conjugation preserves CPSV normal tensors.
-
-The proof uses the pure trace-preserving Perron gauge associated with the
-normal tensor, conjugates that gauge, and transports normality back. Entrywise
-conjugation transports the spectral-radius-one normalization of
-arXiv:1606.00608, lines 224--235, together with the gauge relation at lines
-264--268. -/
-theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A) :
-    IsNormalTensor (mapStar A) := by
-  let : NeZero D := ⟨hA.bondDim_ne_zero⟩
-  obtain ⟨σ, _hσ, _hσfix, hLeft, hGauge, _hPrim, _hIrr⟩ := hA.exists_tpGauge
-  have hGaugeNormal : IsNormalTensor (tpGauge (d := d) (D := D) A σ) :=
-    hA.of_gaugeEquiv hGauge.symm
-  have hGaugeStarNormal :
-      IsNormalTensor (MPSTensor.mapStar (tpGauge (d := d) (D := D) A σ)) :=
-    isNormalTensor_of_isNormal_leftCanonical _ hGaugeNormal.isNormal.mapStar hLeft.mapStar
-  exact hGaugeStarNormal.of_gaugeEquiv hGauge.mapStar
-
 /-- A diagonal positive-definite complex matrix is fixed by entrywise conjugation. -/
 theorem map_star_eq_self_of_posDef_isDiag
     {n : ℕ} {Λ : Matrix (Fin n) (Fin n) ℂ} (hΛpos : Λ.PosDef) (hΛdiag : Λ.IsDiag) :
@@ -160,21 +143,75 @@ theorem map_star_eq_self_of_posDef_isDiag
     simpa [Matrix.map_apply] using hΛpos.1.apply i i
   · simp [Matrix.map_apply, hΛdiag hij]
 
+/-- The transfer map of an entrywise-conjugated tensor is the anti-linear conjugate of the
+original transfer map: as operators on the matrix space, conjugating the tensor conjugates
+the transfer map of arXiv:1606.00608, lines 219--225, by the entrywise-conjugation
+involution on both sides. -/
+theorem transferMap_mapStar_eq_entrywiseConjTransport (A : MPSTensor d D) :
+    transferMap (mapStar A) =
+      entrywiseConjTransport (transferMap (d := d) (D := D) A) := by
+  classical
+  apply LinearMap.ext
+  intro X
+  rw [entrywiseConjTransport_apply]
+  simp only [transferMap_apply]
+  rw [show (∑ i, A i * X.map (starRingEnd ℂ) * (A i)ᴴ).map (starRingEnd ℂ) =
+      ∑ i, (A i * X.map (starRingEnd ℂ) * (A i)ᴴ).map (starRingEnd ℂ) by
+    exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Matrix.map_mul, Matrix.map_mul, Matrix.map_starRingEnd_map_starRingEnd,
+    Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
+  rfl
+
 /-- The transfer map of an entrywise-conjugated tensor is the conjugate of the original
-transfer map on conjugated inputs. -/
+transfer map on conjugated inputs: the pointwise form of the operator identity
+`transferMap_mapStar_eq_entrywiseConjTransport` (arXiv:1606.00608, lines 219--225). -/
 theorem transferMap_mapStar (A : MPSTensor d D)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (mapStar A) (X.map (starRingEnd ℂ)) =
       (transferMap A X).map (starRingEnd ℂ) := by
-  classical
-  simp only [transferMap_apply]
-  rw [show (∑ i, A i * X * (A i)ᴴ).map (starRingEnd ℂ) =
-      ∑ i, (A i * X * (A i)ᴴ).map (starRingEnd ℂ) by
-    exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [Matrix.map_mul, Matrix.map_mul,
-    Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
-  rfl
+  rw [transferMap_mapStar_eq_entrywiseConjTransport, entrywiseConjTransport_apply,
+    Matrix.map_starRingEnd_map_starRingEnd]
+
+/-- Entrywise conjugation preserves irreducibility: an invariant orthogonal projection of
+the conjugated tensor conjugates entrywise to an invariant orthogonal projection of the
+original tensor. Transports the no-nontrivial-invariant-projection clause of the
+normal-tensor definition, arXiv:1606.00608, lines 233--235. -/
+theorem IsIrreducibleTensor.mapStar {A : MPSTensor d D} (hA : IsIrreducibleTensor A) :
+    IsIrreducibleTensor (mapStar A) := by
+  rintro ⟨P, ⟨hHerm, hIdem⟩, hP0, hP1, hLower⟩
+  refine hA ⟨P.map (starRingEnd ℂ), ⟨?_, ?_⟩, ?_, ?_, fun i ↦ ?_⟩
+  · exact (hHerm.map (starRingEnd ℂ) (by simp [Function.Semiconj])).eq
+  · rw [← Matrix.map_mul, hIdem]
+  · intro h0
+    apply hP0
+    have := congrArg (fun M => M.map (starRingEnd ℂ)) h0
+    simpa using this
+  · intro h1
+    apply hP1
+    have := congrArg (fun M => M.map (starRingEnd ℂ)) h1
+    simpa using this
+  · have hi := congrArg ((starRingEnd ℂ).mapMatrix) (hLower i)
+    simp only [map_mul, map_sub, map_one, map_zero, RingHom.mapMatrix_apply] at hi
+    simpa using hi
+
+/-- Entrywise complex conjugation preserves CPSV normal tensors.
+
+The proof is the direct spectral one: entrywise conjugation of the tensor conjugates the
+transfer map anti-linearly, which conjugates its spectrum, preserves its spectral radius,
+preserves primitivity, and preserves irreducibility. This transports both clauses of the
+normal-tensor definition of arXiv:1606.00608, lines 224--235, across entrywise
+conjugation. -/
+theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A) :
+    IsNormalTensor (mapStar A) where
+  no_invariant_proj := hA.no_invariant_proj.mapStar
+  spectral_radius_one := by
+    rw [transferMap_mapStar_eq_entrywiseConjTransport,
+      spectralRadius_entrywiseConjTransport]
+    exact hA.spectral_radius_one
+  primitive_transfer := by
+    rw [transferMap_mapStar_eq_entrywiseConjTransport]
+    exact (IsPrimitive.entrywiseConjTransport_iff _).2 hA.primitive_transfer
 
 end MPSTensor

--- a/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
+++ b/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
@@ -602,3 +602,88 @@ preservation by the weighted-trace argument in
     Hence $\nu\tr(X)=0$ and therefore $\nu=0$. In either case,
     $|\nu|<1$.
 \end{proof}
+
+\section{Anti-linear conjugation of the spectrum}
+
+Entrywise complex conjugation is an anti-linear involution of the matrix
+space. Conjugating a linear map on both sides by this involution yields a
+linear map again, and all spectral data conjugate accordingly. These facts
+transport the spectral clauses of the normal-tensor definition of
+\cite{Cirac2016MPDO_arXiv} across entrywise conjugation of a tensor.
+
+\begin{definition}[Entrywise-conjugation transport]%
+    \label{def:entrywise_conj_transport}
+    \lean{entrywiseConjTransport}
+    \lean{entrywiseConjTransportRingEquiv}
+    \leanok
+    Let $\sigma:\MN D\to\MN D$ denote entrywise complex conjugation,
+    $\sigma(X)=\overline X$. The \emph{transport along entrywise conjugation}
+    of a linear map $\Phi:\MN D\to\MN D$ is
+    \begin{align}
+        \Phi\longmapsto\sigma\circ\Phi\circ\sigma.
+        \label{eq:entrywise_conj_transport}
+    \end{align}
+    Both factors $\sigma$ conjugate the scalars, so the transported map is
+    again linear. The transport is an involution, respects sums and
+    composition, and sends the scalar $\mu$ to $\overline\mu$; it is therefore
+    a ring automorphism of the endomorphism ring that conjugates the scalars.
+\end{definition}
+
+\begin{theorem}[Spectrum under anti-linear conjugation]%
+    \label{thm:entrywise_conj_transport_spectrum}
+    \lean{spectrum_entrywiseConjTransport}
+    \lean{hasEigenvalue_entrywiseConjTransport_iff}
+    \leanok
+    \uses{def:entrywise_conj_transport}
+    For every linear map $\Phi:\MN D\to\MN D$,
+    \begin{align}
+        \operatorname{spec}(\sigma\circ\Phi\circ\sigma)
+        &=\overline{\operatorname{spec}(\Phi)},
+        \label{eq:entrywise_conj_spectrum}
+    \end{align}
+    and $\mu$ is an eigenvalue of $\sigma\circ\Phi\circ\sigma$ if and only if
+    $\overline\mu$ is an eigenvalue of $\Phi$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:entrywise_conj_transport}
+    The transport sends $\overline\mu\,\Id-\Phi$ to
+    $\mu\,\Id-\sigma\circ\Phi\circ\sigma$, and a ring automorphism preserves
+    invertibility, which gives~(\ref{eq:entrywise_conj_spectrum}). For the
+    eigenvalue statement, if
+    $(\sigma\circ\Phi\circ\sigma)(V)=\mu V$ with $V\neq0$, then applying
+    $\sigma$ to both sides gives
+    $\Phi(\overline V)=\overline\mu\,\overline V$ with $\overline V\neq0$;
+    the converse follows because the transport is an involution.
+\end{proof}
+
+\begin{theorem}[Peripheral data under anti-linear conjugation]%
+    \label{thm:entrywise_conj_transport_peripheral}
+    \lean{peripheralEigenvalues_entrywiseConjTransport}
+    \lean{spectralRadius_entrywiseConjTransport}
+    \lean{IsPrimitive.entrywiseConjTransport_iff}
+    \leanok
+    \uses{def:entrywise_conj_transport, def:peripheral_eigenvalues,
+        def:primitive_channel}
+    For every linear map $\Phi:\MN D\to\MN D$, the peripheral eigenvalues of
+    $\sigma\circ\Phi\circ\sigma$ are the complex conjugates of the peripheral
+    eigenvalues of $\Phi$, the spectral radii agree,
+    \begin{align}
+        r(\sigma\circ\Phi\circ\sigma)&=r(\Phi),
+        \label{eq:entrywise_conj_spectral_radius}
+    \end{align}
+    and $\sigma\circ\Phi\circ\sigma$ is primitive if and only if $\Phi$ is
+    primitive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entrywise_conj_transport_spectrum}
+    Complex conjugation preserves the modulus. Conjugating the spectrum and
+    the eigenvalues by Theorem~\ref{thm:entrywise_conj_transport_spectrum}
+    therefore preserves the supremum of the moduli of the spectral values,
+    which gives~(\ref{eq:entrywise_conj_spectral_radius}), and maps the
+    unit-circle eigenvalues of $\Phi$ onto those of
+    $\sigma\circ\Phi\circ\sigma$. Since $\{1\}$ is fixed by conjugation, the
+    peripheral eigenvalues equal $\{1\}$ after transport if and only if they
+    do before.
+\end{proof}

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -347,22 +347,24 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \label{thm:cpsv_map_star_preservation}
     \lean{MPSTensor.IsLeftCanonical.mapStar}
     \lean{MPSTensor.GaugeEquiv.mapStar}
+    \lean{MPSTensor.IsNormal.mapStar}
     \lean{MPSTensor.IsNormalTensor.mapStar}
     \leanok
-    \uses{def:left_canonical_tensor,def:nt_cpsv,def:gauge_equiv}
+    \uses{def:left_canonical_tensor,def:nt_cpsv,def:gauge_equiv,def:normal}
     For a tensor or matrix, an overline denotes entrywise conjugation. If $A$
     and $B$ are gauge equivalent through $X$, then $\overline A$ and
     $\overline B$ are gauge equivalent through $\overline X$. If $A$ is
-    left-canonical, then $\overline A$ is left-canonical. Independently, if $A$
+    left-canonical, then $\overline A$ is left-canonical. If $A$ is
+    algebraically normal, then $\overline A$ is algebraically normal.
+    Independently, if $A$
     is a CPSV normal tensor, then $\overline A$ is a CPSV normal tensor.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:left_canonical_tensor,def:gauge_equiv,
-        thm:cpsv_normal_bond_dim_pos,thm:cpsv_normal_tp_gauge,
-        thm:cpsv_normal_eventually_injective,
-        thm:cpsv_normal_tensor_gauge_transport,
-        thm:is_normal_tensor_of_is_normal_left_canonical}
+    \uses{def:left_canonical_tensor,def:gauge_equiv,def:normal,def:nt_cpsv,
+        thm:cpsv_map_star_transfer_fixed_point,
+        thm:cpsv_map_star_irreducible,
+        thm:entrywise_conj_transport_peripheral}
     Entrywise conjugating $B^i=X A^i X^{-1}$ gives
     $\overline{B^i}=\overline X\,\overline{A^i}\,(\overline X)^{-1}$.
     Conjugating the left-canonical identity gives
@@ -371,26 +373,35 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         &=\overline{\sum_i(A^i)^\dagger A^i}
          =\overline{\Id}=\Id.
     \end{align}
-    For the normal-tensor assertion, put $A$ into the trace-preserving Perron
-    gauge supplied by Theorem~\ref{thm:cpsv_normal_tp_gauge}. Gauge transport
-    preserves normal-tensor status, and entrywise conjugation preserves the
-    gauge relation. The Perron representative is trace-preserving, hence
-    left-canonical, and conjugation preserves this identity. Moreover,
-    \lean{MPSTensor.IsNormal.mapStar}
-    entrywise conjugation preserves its positive-length block injectivity.
-    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} therefore
-    makes the conjugated representative a CPSV normal tensor. Transporting
-    back through the conjugated gauge gives the result for $\overline A$.
+    Entrywise conjugation maps the span of the length-$N$ products of $A$
+    onto the span of those of $\overline A$, so it preserves positive-length
+    block injectivity and hence algebraic normality.
+    For the normal-tensor assertion, the transfer map of $\overline A$ is the
+    anti-linear conjugate $\sigma\circ\E_A\circ\sigma$
+    by~(\ref{eq:cpsv_map_star_transfer_operator}). By
+    Theorem~\ref{thm:entrywise_conj_transport_peripheral} this conjugation
+    preserves the spectral radius and primitivity, and by
+    Theorem~\ref{thm:cpsv_map_star_irreducible} entrywise conjugation
+    preserves irreducibility. Hence both clauses of
+    Definition~\ref{def:nt_cpsv} hold for $\overline A$.
 \end{proof}
 
 \begin{theorem}[Transfer maps and positive diagonal matrices under
     entrywise conjugation]
     \label{thm:cpsv_map_star_transfer_fixed_point}
+    \lean{MPSTensor.transferMap_mapStar_eq_entrywiseConjTransport}
     \lean{MPSTensor.transferMap_mapStar}
     \lean{MPSTensor.map_star_eq_self_of_posDef_isDiag}
     \leanok
-    \uses{def:transfer_map}
-    For every tensor $A$ and matrix $X$,
+    \uses{def:transfer_map, def:entrywise_conj_transport}
+    Let $\sigma$ denote entrywise conjugation. For every tensor $A$, as
+    operators on the matrix space,
+    \begin{align}
+        \E_{\overline A}
+        &=\sigma\circ\E_A\circ\sigma;
+        \label{eq:cpsv_map_star_transfer_operator}
+    \end{align}
+    evaluating at $\overline X$ gives, for every matrix $X$,
     \begin{align}
         \E_{\overline A}(\overline X)
         &=\overline{\E_A(X)}.
@@ -404,11 +415,33 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:transfer_map}
-    Entrywise conjugation commutes with finite sums and matrix products, which
-    gives~(\ref{eq:cpsv_map_star_transfer}). The diagonal entries of a
+    \uses{def:transfer_map, def:entrywise_conj_transport}
+    Entrywise conjugation commutes with finite sums, matrix products, and
+    conjugate transposition, which
+    gives~(\ref{eq:cpsv_map_star_transfer_operator}) on every matrix, and
+    (\ref{eq:cpsv_map_star_transfer}) follows since $\sigma$ is an
+    involution. The diagonal entries of a
     positive-definite complex matrix are real, while all off-diagonal entries
     of a diagonal matrix vanish. This proves~(\ref{eq:cpsv_map_star_posdef_diag}).
+\end{proof}
+
+\begin{theorem}[Irreducibility under entrywise conjugation]%
+    \label{thm:cpsv_map_star_irreducible}
+    \lean{MPSTensor.IsIrreducibleTensor.mapStar}
+    \leanok
+    \uses{def:irreducible_tensor}
+    If $A$ is irreducible, then $\overline A$ is irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:irreducible_tensor}
+    Suppose $P$ is a nontrivial invariant orthogonal projection for
+    $\overline A$, so $(\Id-P)\,\overline{A^i}\,P=0$ for every~$i$.
+    Conjugating entrywise gives
+    $(\Id-\overline P)A^i\overline P=0$, and $\overline P$ is again a
+    Hermitian idempotent distinct from $0$ and $\Id$. Hence $\overline P$ is
+    a nontrivial invariant orthogonal projection for $A$, contradicting the
+    irreducibility of~$A$.
 \end{proof}
 
 \begin{definition}[CPSV canonical form]

--- a/scripts/qic_blueprint_label_dispositions.csv
+++ b/scripts/qic_blueprint_label_dispositions.csv
@@ -12,8 +12,8 @@ item_id,source,environment,disposition,reason
 @src/chapter/ch08_wielandt_fixed_length_and_normality.tex:426,src/chapter/ch08_wielandt_fixed_length_and_normality.tex,remark,tn,tensor-network remark
 @src/chapter/ch08_wielandt_word_span_and_block_injectivity.tex:111,src/chapter/ch08_wielandt_word_span_and_block_injectivity.tex,remark,tn,tensor-network remark
 @src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex:314,src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex,remark,tn,tensor-network remark
-@src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex:913,src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex,remark,tn,tensor-network remark
-@src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex:925,src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex,remark,tn,tensor-network remark
+@src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex:946,src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex,remark,tn,tensor-network remark
+@src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex:958,src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex,remark,tn,tensor-network remark
 @src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex:415,src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex,remark,tn,tensor-network remark
 @src/chapter/ch15_examples_ghz.tex:154,src/chapter/ch15_examples_ghz.tex,remark,tn,tensor-network remark
 @src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex:140,src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex,remark,qic,quantum-information remark


### PR DESCRIPTION
Closes #6470.

## Mathematical content

This change formalizes the anti-linear spectral conjugacy induced by entrywise complex conjugation
```
Φ ↦ σ ∘ Φ ∘ σ,    σ(X) = X̄.
```
It proves that this transport conjugates the spectrum, eigenvalues, and peripheral eigenvalues, while preserving the spectral radius and peripheral-spectrum primitivity.

For MPS tensors, it proves the operator identity
```
E_{Ā} = σ ∘ E_A ∘ σ,
```
and transports irreducibility directly through conjugation. Consequently, `IsNormalTensor.mapStar` now follows directly from the two defining spectral clauses, without passing through a trace-preserving Perron gauge.

The accompanying blueprint entries state the anti-linear transport, its spectral consequences, the transfer-map identity, and irreducibility preservation. They cite arXiv:1606.00608, lines 219–235.

## Verification

- `lake build` — 10,272 targets passed
- focused builds for the new peripheral-spectrum module and canonical-form conjugation
- `leanblueprint checkdecls` — passed
- `leanblueprint pdf` — rendered 1,140 pages; no new layout warnings
- blueprint declaration synchronization — 8,200/8,200
- import-aggregator check — 1,501 modules
- kernel axiom audit — only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `axiom`, `admit`, `native_decide`, or other proof-integrity exceptions in the changed Lean files
- tactic repetition scan — no new repeated pattern attributable to this change
