### PR TITLE
feat(Algebra): characterize finite Cauchy equality

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -28,6 +28,7 @@ import TNLean.Algebra.EqualRangeRightFactor
 import TNLean.Algebra.EventuallyConstantCycleWeights
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.Algebra.FiniteCauchySchwarz
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FrameOperator
 import TNLean.Algebra.FrobeniusHilbert

--- a/TNLean/Algebra/FiniteCauchySchwarz.lean
+++ b/TNLean/Algebra/FiniteCauchySchwarz.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.Order.Chebyshev
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+
+/-!
+# Equality in the finite Cauchy--Schwarz inequality
+
+For a finite family of real numbers, this file characterizes equality in
+\[
+  \left(\sum_{i\in S} f_i\right)^2
+    \leq |S|\sum_{i\in S} f_i^2.
+\]
+The proof uses the sum of the squared pairwise differences. It applies without a
+nonemptiness assumption, so the empty and singleton cases are included.
+
+## Main results
+
+* `Finset.sum_pairwise_sq_sub`: the pairwise-difference form of the variance identity.
+* `Finset.sq_sum_eq_card_mul_sum_sq_iff`: equality holds exactly when the family is
+  constant on the finite set.
+
+## References
+
+* Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+  equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+  lines 802--815
+-/
+
+open scoped BigOperators
+
+namespace Finset
+
+variable {ι : Type*} (s : Finset ι) (f : ι → ℝ)
+
+/-- The sum of the squared pairwise differences equals twice the unnormalized variance.
+
+This identity is valid for every finite set, including the empty set.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. The identity records the equality case used there. -/
+lemma sum_pairwise_sq_sub :
+    (∑ i ∈ s, ∑ j ∈ s, (f i - f j) ^ 2) =
+      2 * ((s.card : ℝ) * ∑ i ∈ s, (f i) ^ 2 - (∑ i ∈ s, f i) ^ 2) := by
+  calc
+    (∑ i ∈ s, ∑ j ∈ s, (f i - f j) ^ 2) =
+        ∑ i ∈ s, ∑ j ∈ s, ((f i) ^ 2 + (f j) ^ 2 - 2 * f i * f j) := by
+      apply sum_congr rfl
+      intro i hi
+      apply sum_congr rfl
+      intro j hj
+      ring
+    _ = 2 * ((s.card : ℝ) * ∑ i ∈ s, (f i) ^ 2 - (∑ i ∈ s, f i) ^ 2) := by
+      simp_rw [sum_sub_distrib, sum_add_distrib]
+      simp only [sum_const, nsmul_eq_mul]
+      have hcross :
+          (∑ i ∈ s, ∑ j ∈ s, 2 * f i * f j) =
+            2 * (∑ i ∈ s, f i) * (∑ j ∈ s, f j) := by
+        calc
+          (∑ i ∈ s, ∑ j ∈ s, 2 * f i * f j) =
+              2 * (∑ i ∈ s, ∑ j ∈ s, f i * f j) := by
+            symm
+            rw [mul_sum]
+            apply sum_congr rfl
+            intro i hi
+            rw [mul_sum]
+            apply sum_congr rfl
+            intro j hj
+            ring
+          _ = 2 * (∑ i ∈ s, f i) * (∑ j ∈ s, f j) := by
+            rw [← sum_mul_sum]
+            ring
+      rw [hcross]
+      rw [← mul_sum]
+      ring
+
+/-- Equality in the finite Cauchy--Schwarz inequality holds exactly when the family is
+constant on the finite set.
+
+The pairwise formulation treats the empty and singleton cases without separate
+hypotheses: in both cases the constancy condition and the equality are automatic.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. -/
+theorem sq_sum_eq_card_mul_sum_sq_iff :
+    (∑ i ∈ s, f i) ^ 2 = s.card * ∑ i ∈ s, (f i) ^ 2 ↔
+      ∀ i ∈ s, ∀ j ∈ s, f i = f j := by
+  constructor
+  · intro h i hi j hj
+    have hsum : (∑ i ∈ s, ∑ j ∈ s, (f i - f j) ^ 2) = 0 := by
+      rw [sum_pairwise_sq_sub]
+      nlinarith
+    have houter : ∀ x ∈ s, 0 ≤ ∑ y ∈ s, (f x - f y) ^ 2 := by
+      intro x hx
+      exact sum_nonneg fun y hy ↦ sq_nonneg _
+    have hinner := (sum_eq_zero_iff_of_nonneg houter).mp hsum i hi
+    have hterm :=
+      (sum_eq_zero_iff_of_nonneg (fun y hy ↦ sq_nonneg (f i - f y))).mp hinner j hj
+    nlinarith
+  · intro h
+    by_cases hs : s.Nonempty
+    · obtain ⟨i, hi⟩ := hs
+      have hf : ∀ j ∈ s, f j = f i := fun j hj ↦ h j hj i hi
+      calc
+        (∑ j ∈ s, f j) ^ 2 = ((s.card : ℝ) * f i) ^ 2 := by
+          rw [sum_eq_card_nsmul hf]
+          simp
+        _ = s.card * ∑ j ∈ s, (f j) ^ 2 := by
+          rw [sum_eq_card_nsmul (fun j hj ↦ congrArg (· ^ 2) (hf j hj))]
+          ring
+    · simp at hs
+      simp [hs]
+
+end Finset

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -6,7 +6,8 @@ finite-dimensional quantum channels from \cite[Chapter~2]{Wolf2012Quantum}:
 Kraus representation theorems, Stinespring and Naimark dilations, ordered
 completely positive maps, Radon--Nikodym and open-system representations,
 trace-pairing expansions, SVD and Lorentz normal forms, and the channel
-determinant. These results are important for the later channel theory, but they
+determinant, together with the finite Cauchy--Schwarz criterion used for SIC POVMs.
+These results are important for the later channel theory, but they
 are not prerequisites for the matrix-product-state Fundamental Theorem.
 
 %% =========================================================
@@ -18,3 +19,4 @@ are not prerequisites for the matrix-product-state Fundamental Theorem.
 \input{chapter/ch16_channel_representations_normal_forms_and_determinant}
 \input{chapter/ch16_channel_representations_determinant_choi_bound}
 \input{chapter/ch16_channel_representations_self_dual}
+\input{chapter/ch16_channel_representations_sic_povms}

--- a/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
@@ -1,0 +1,31 @@
+\section{Finite Cauchy--Schwarz equality}
+
+\begin{theorem}[Equality in finite Cauchy--Schwarz]
+    \label{thm:finite_cauchy_schwarz_equality}
+    \lean{Finset.sq_sum_eq_card_mul_sum_sq_iff}
+    \leanok
+    Let $S$ be a finite set and let $(x_i)_{i\in S}$ be real numbers. Then
+    \[
+        \left(\sum_{i\in S}x_i\right)^2
+        =|S|\sum_{i\in S}x_i^2
+    \]
+    if and only if $x_i=x_j$ for every $i,j\in S$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The variance identity gives
+    \[
+        \sum_{i,j\in S}(x_i-x_j)^2
+        =2\left(
+          |S|\sum_{i\in S}x_i^2-
+          \left(\sum_{i\in S}x_i\right)^2
+        \right).
+    \]
+    Since every summand on the left is non-negative, equality in
+    Cauchy--Schwarz holds precisely when every difference $x_i-x_j$ vanishes.
+    This argument also includes the empty and singleton cases.
+\end{proof}
+
+This criterion is the equality condition invoked for the off-diagonal overlaps
+and for the eigenvalues in \cite[Chapter~2, Proposition ``SIC POVMs'',
+equations~(2.31)--(2.32)]{Wolf2012Quantum}.


### PR DESCRIPTION
## Summary

- prove the pairwise square-difference identity for a finite real family
- characterize equality in the finite Cauchy–Schwarz bound by constancy on the index set
- include the empty and singleton cases without auxiliary nonemptiness hypotheses
- add the corresponding SIC-POVM blueprint section, following Wolf equations (2.31)–(2.32)

The equality criterion is stated as a reusable Finset theorem because it is the scalar input needed for the Hermitian trace inequality in LionSR/QICLean#321.

## Verification

- lake env lean TNLean/Algebra/FiniteCauchySchwarz.lean
- lake build (10,273 targets)
- python3 scripts/generate_import_aggregators.py --check
- PYTHONPATH=scripts python3 scripts/qic_blueprint_boundary_report.py
- python3 scripts/tactic_pattern_scan.py
- python3 scripts/blueprint_lean_sync.py --update-lean-decls
- lake exe checkdecls blueprint/lean_decls
- blueprint PDF rendered and the new page inspected
- kernel axiom audit: only propext, Classical.choice, and Quot.sound

Closes LionSR/QICLean#320.