### PR TITLE
feat(Algebra): characterize trace-purity equality

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -102,6 +102,7 @@ import TNLean.Algebra.StarSubalgebraSpatial
 import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 import TNLean.Algebra.TracePairing
 import TNLean.Algebra.TracePowerCharPoly
+import TNLean.Algebra.TracePurity
 import TNLean.Algebra.TraceReindex
 import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.ZModCyclicSums

--- a/TNLean/Algebra/TracePurity.lean
+++ b/TNLean/Algebra/TracePurity.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FiniteCauchySchwarz
+import TNLean.Algebra.HermitianTracePower
+import TNLean.Algebra.OrthogonalProjection
+import TNLean.Algebra.PosSemidefSupport
+
+/-!
+# Trace-square and purity equality criteria
+
+This file proves two spectral equality criteria for finite complex matrices. For a
+Hermitian matrix, the square of the trace is at most the dimension times the trace
+of the square, with equality precisely for scalar matrices. For a positive
+semidefinite matrix of Hilbert--Schmidt norm one, the trace is at least one, with
+equality precisely for rank-one orthogonal projections.
+
+## Main results
+
+* `Matrix.IsHermitian.trace_re_sq_le_card_mul_trace_sq_re`
+* `Matrix.IsHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff`
+* `Matrix.PosSemidef.one_le_trace_re_of_trace_sq_eq_one`
+* `Matrix.PosSemidef.trace_re_eq_one_iff_isRankOneOrthogonalProjection`
+
+## References
+
+* Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+  equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+  lines 802--815
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+variable {D : ℕ}
+
+/-- A rank-one orthogonal projection is a Hermitian idempotent matrix of rank one.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs";
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 807--815. -/
+def IsRankOneOrthogonalProjection (P : Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  IsOrthogonalProjection P ∧ P.rank = 1
+
+namespace Matrix
+
+private theorem IsHermitian.trace_re_eq_sum_eigenvalues
+    {Q : Matrix (Fin D) (Fin D) ℂ} (hQ : Q.IsHermitian) :
+    Q.trace.re = ∑ i, hQ.eigenvalues i := by
+  rw [hQ.trace_eq_sum_eigenvalues, Complex.re_sum]
+  simp
+
+private theorem IsHermitian.trace_sq_re_eq_sum_eigenvalues_sq
+    {Q : Matrix (Fin D) (Fin D) ℂ} (hQ : Q.IsHermitian) :
+    (Q ^ 2).trace.re = ∑ i, (hQ.eigenvalues i) ^ 2 := by
+  rw [hQ.trace_pow_eq_sum_eigenvalues_pow, Complex.re_sum]
+  apply Finset.sum_congr rfl
+  intro i hi
+  exact (congrArg Complex.re (Complex.ofReal_pow (hQ.eigenvalues i) 2)).symm
+
+/-- For a Hermitian matrix, the square of its real trace is at most the dimension
+times the real trace of its square.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. -/
+theorem IsHermitian.trace_re_sq_le_card_mul_trace_sq_re
+    {Q : Matrix (Fin D) (Fin D) ℂ} (hQ : Q.IsHermitian) :
+    Q.trace.re ^ 2 ≤ D * (Q ^ 2).trace.re := by
+  rw [hQ.trace_re_eq_sum_eigenvalues, hQ.trace_sq_re_eq_sum_eigenvalues_sq]
+  simpa using
+    (sq_sum_le_card_mul_sum_sq (s := Finset.univ) (f := hQ.eigenvalues))
+
+/-- Equality in the Hermitian trace-square inequality holds precisely for real
+scalar multiples of the identity.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. -/
+theorem IsHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff
+    {Q : Matrix (Fin D) (Fin D) ℂ} (hQ : Q.IsHermitian) :
+    Q.trace.re ^ 2 = D * (Q ^ 2).trace.re ↔
+      ∃ r : ℝ, Q = (r : ℂ) • 1 := by
+  constructor
+  · intro heq
+    have heq' : (∑ i, hQ.eigenvalues i) ^ 2 = D * ∑ i, (hQ.eigenvalues i) ^ 2 := by
+      rw [← hQ.trace_re_eq_sum_eigenvalues, ← hQ.trace_sq_re_eq_sum_eigenvalues_sq]
+      exact heq
+    have hconst : ∀ i : Fin D, ∀ j : Fin D, hQ.eigenvalues i = hQ.eigenvalues j := by
+      have h := (Finset.sq_sum_eq_card_mul_sum_sq_iff
+        (s := Finset.univ) (f := hQ.eigenvalues)).mp (by simpa using heq')
+      exact fun i j ↦ h i (Finset.mem_univ i) j (Finset.mem_univ j)
+    cases isEmpty_or_nonempty (Fin D) with
+    | inl hD =>
+        refine ⟨0, Subsingleton.elim _ _⟩
+    | inr hD =>
+        let i : Fin D := Classical.choice hD
+        refine ⟨hQ.eigenvalues i, ?_⟩
+        let U := hQ.eigenvectorUnitary
+        let Δ : Matrix (Fin D) (Fin D) ℂ :=
+          Matrix.diagonal (RCLike.ofReal ∘ hQ.eigenvalues)
+        have hspec : Q = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := by
+          simpa [Δ, U] using hQ.spectral_theorem
+        have hΔ : Δ = (hQ.eigenvalues i : ℂ) • 1 := by
+          ext j k
+          by_cases hjk : j = k
+          · subst k
+            simp [Δ, hconst j i]
+          · simp [Δ, hjk]
+        calc
+          Q = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := hspec
+          _ = (hQ.eigenvalues i : ℂ) • 1 := by rw [hΔ]; simp
+  · rintro ⟨r, rfl⟩
+    simp [pow_two]
+    ring
+
+/-- A positive semidefinite matrix whose squared trace norm is one has trace at
+least one.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. -/
+theorem PosSemidef.one_le_trace_re_of_trace_sq_eq_one
+    {P : Matrix (Fin D) (Fin D) ℂ} (hP : P.PosSemidef)
+    (hpurity : (P ^ 2).trace = 1) :
+    1 ≤ P.trace.re := by
+  let lam : Fin D → ℝ := hP.isHermitian.eigenvalues
+  have hsum : P.trace.re = ∑ i, lam i := hP.isHermitian.trace_re_eq_sum_eigenvalues
+  have hsq : ∑ i, (lam i) ^ 2 = 1 := by
+    have h := hP.isHermitian.trace_sq_re_eq_sum_eigenvalues_sq
+    rw [hpurity] at h
+    simpa using h.symm
+  have hnonneg : ∀ i, 0 ≤ lam i := hP.eigenvalues_nonneg
+  have hsum_nonneg : 0 ≤ ∑ i, lam i := Finset.sum_nonneg fun i _ ↦ hnonneg i
+  have hsq_le : ∑ i, (lam i) ^ 2 ≤ (∑ i, lam i) ^ 2 :=
+    Finset.sum_sq_le_sq_sum_of_nonneg fun i _ ↦ hnonneg i
+  rw [hsum]
+  nlinarith
+
+/-- Under unit squared trace norm, a positive semidefinite matrix has trace one
+precisely when it is a rank-one orthogonal projection.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 2, Proposition "SIC POVMs",
+equations (2.31)--(2.32); `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 802--815. -/
+theorem PosSemidef.trace_re_eq_one_iff_isRankOneOrthogonalProjection
+    {P : Matrix (Fin D) (Fin D) ℂ} (hP : P.PosSemidef)
+    (hpurity : (P ^ 2).trace = 1) :
+    P.trace.re = 1 ↔ IsRankOneOrthogonalProjection P := by
+  let lam : Fin D → ℝ := hP.isHermitian.eigenvalues
+  have htrace : P.trace.re = ∑ i, lam i := hP.isHermitian.trace_re_eq_sum_eigenvalues
+  have hsq : ∑ i, (lam i) ^ 2 = 1 := by
+    have h := hP.isHermitian.trace_sq_re_eq_sum_eigenvalues_sq
+    rw [hpurity] at h
+    simpa using h.symm
+  constructor
+  · intro htrace_one
+    have hsum : ∑ i, lam i = 1 := htrace.symm.trans htrace_one
+    have hnonneg : ∀ i, 0 ≤ lam i := hP.eigenvalues_nonneg
+    have hle_one : ∀ i, lam i ≤ 1 := by
+      intro i
+      calc
+        lam i ≤ ∑ j, lam j :=
+          Finset.single_le_sum (fun j _ ↦ hnonneg j) (Finset.mem_univ i)
+        _ = 1 := hsum
+    have hterm_nonneg : ∀ i, 0 ≤ lam i * (1 - lam i) := fun i ↦
+      mul_nonneg (hnonneg i) (sub_nonneg.mpr (hle_one i))
+    have hsum_term : ∑ i, lam i * (1 - lam i) = 0 := by
+      calc
+        ∑ i, lam i * (1 - lam i) = (∑ i, lam i) - ∑ i, (lam i) ^ 2 := by
+          simp_rw [mul_sub, mul_one, pow_two]
+          rw [Finset.sum_sub_distrib]
+        _ = 0 := by rw [hsum, hsq]; norm_num
+    have heig_idem : ∀ i, (lam i) ^ 2 = lam i := by
+      intro i
+      have hi := congrFun
+        (Fintype.sum_eq_zero_iff_of_nonneg hterm_nonneg |>.mp hsum_term) i
+      have hi' : lam i * (1 - lam i) = 0 := by simpa using hi
+      nlinarith
+    have hidem : P * P = P := by
+      let U := hP.isHermitian.eigenvectorUnitary
+      let Δ : Matrix (Fin D) (Fin D) ℂ :=
+        Matrix.diagonal (RCLike.ofReal ∘ hP.isHermitian.eigenvalues)
+      have hspec : P = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := by
+        simpa [Δ, U] using hP.isHermitian.spectral_theorem
+      have hΔidem : Δ * Δ = Δ := by
+        rw [Matrix.diagonal_mul_diagonal]
+        congr 1
+        funext i
+        change (lam i : ℂ) * (lam i : ℂ) = (lam i : ℂ)
+        have hi := heig_idem i
+        rw [pow_two] at hi
+        exact_mod_cast hi
+      calc
+        P * P =
+            (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ *
+              (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := by
+                rw [hspec]
+        _ = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) (Δ * Δ) := by
+          rw [map_mul]
+        _ = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := by rw [hΔidem]
+        _ = P := hspec.symm
+    refine ⟨⟨hP.isHermitian, hidem⟩, ?_⟩
+    have hrank_re := hP.isHermitian.rank_eq_trace_re_of_idem hidem
+    rw [htrace_one] at hrank_re
+    exact_mod_cast hrank_re
+  · rintro ⟨hproj, hrank⟩
+    have hrank_re := hproj.1.rank_eq_trace_re_of_idem hproj.2
+    rw [hrank] at hrank_re
+    norm_num at hrank_re ⊢
+    exact hrank_re.symm
+
+end Matrix

--- a/TNLean/Algebra/TracePurity.lean
+++ b/TNLean/Algebra/TracePurity.lean
@@ -111,7 +111,10 @@ theorem IsHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff
           Q = (Unitary.conjStarAlgAut ℂ (Matrix (Fin D) (Fin D) ℂ) U) Δ := hspec
           _ = (hQ.eigenvalues i : ℂ) • 1 := by rw [hΔ]; simp
   · rintro ⟨r, rfl⟩
-    simp [pow_two]
+    simp only [Complex.coe_smul, trace_smul, trace_one, Fintype.card_fin,
+      Complex.real_smul, Complex.mul_re, Complex.ofReal_re, Complex.natCast_re,
+      Complex.ofReal_im, Complex.natCast_im, mul_zero, sub_zero, pow_two,
+      Algebra.mul_smul_comm, mul_one, Complex.mul_im, zero_mul, add_zero]
     ring
 
 /-- A positive semidefinite matrix whose squared trace norm is one has trace at

--- a/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
@@ -29,3 +29,95 @@
 This criterion is the equality condition invoked for the off-diagonal overlaps
 and for the eigenvalues in \cite[Chapter~2, Proposition ``SIC POVMs'',
 equations~(2.31)--(2.32)]{Wolf2012Quantum}.
+
+\section{Trace-square and purity equality}
+
+\begin{definition}[Rank-one orthogonal projection]
+    \label{def:sic_rank_one_orthogonal_projection}
+    \lean{IsRankOneOrthogonalProjection}
+    \leanok
+    \uses{def:orthogonal_projection_channel}
+    A matrix $P\in\MN{D}$ is a rank-one orthogonal projection if
+    $P=P^\dagger$, $P^2=P$, and $\rank P=1$.
+\end{definition}
+
+\begin{theorem}[Hermitian trace-square inequality]
+    \label{thm:sic_hermitian_trace_square}
+    \lean{Matrix.IsHermitian.trace_re_sq_le_card_mul_trace_sq_re}
+    \leanok
+    If $Q\in\MN{D}$ is Hermitian, then
+    \begin{align}
+        \tr(Q)^2\le D\tr(Q^2).
+        \label{eq:sic_hermitian_trace_square}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:hermitian_trace_power_sum}
+    Let $\lambda_0,\ldots,\lambda_{D-1}$ be the eigenvalues of $Q$.
+    The spectral theorem and finite Cauchy--Schwarz give
+    \begin{align}
+        \tr(Q)^2
+        =\left(\sum_i\lambda_i\right)^2
+        \le D\sum_i\lambda_i^2
+        =D\tr(Q^2).
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Equality in the Hermitian trace-square inequality]
+    \label{thm:sic_hermitian_trace_square_equality}
+    \lean{Matrix.IsHermitian.trace_re_sq_eq_card_mul_trace_sq_re_iff}
+    \leanok
+    A Hermitian matrix $Q\in\MN{D}$ satisfies equality
+    in~(\ref{eq:sic_hermitian_trace_square}) if and only if
+    $Q=r\Id$ for some $r\in\R$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:finite_cauchy_schwarz_equality, thm:hermitian_trace_power_sum}
+    Equality holds precisely when all eigenvalues of $Q$ coincide. If their
+    common value is $r$, unitary diagonalization gives
+    $Q=U(r\Id)U^\dagger=r\Id$. The converse follows by direct substitution.
+    When $D=0$, every matrix is the zero matrix, so the same conclusion holds.
+\end{proof}
+
+\begin{theorem}[Trace bound at unit purity]
+    \label{thm:sic_psd_unit_purity_trace}
+    \lean{Matrix.PosSemidef.one_le_trace_re_of_trace_sq_eq_one}
+    \leanok
+    If $P\in\MN{D}$ is positive semidefinite and $\tr(P^2)=1$, then
+    $\tr(P)\ge 1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:hermitian_trace_power_sum}
+    Write the non-negative eigenvalues of $P$ as $\lambda_i$. Then
+    \begin{align}
+        1=\sum_i\lambda_i^2
+        \le\left(\sum_i\lambda_i\right)^2
+        =\tr(P)^2.
+    \end{align}
+    Since $\tr(P)=\sum_i\lambda_i\ge0$, the assertion follows.
+\end{proof}
+
+\begin{theorem}[Equality at unit purity]
+    \label{thm:sic_psd_unit_purity_equality}
+    \lean{Matrix.PosSemidef.trace_re_eq_one_iff_isRankOneOrthogonalProjection}
+    \leanok
+    \uses{def:sic_rank_one_orthogonal_projection}
+    Suppose that $P\in\MN{D}$ is positive semidefinite and $\tr(P^2)=1$.
+    Then $\tr(P)=1$ if and only if $P$ is a rank-one orthogonal projection.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:hermitian_trace_power_sum}
+    If $\tr(P)=1$, the non-negative eigenvalues satisfy
+    \begin{align}
+        \sum_i\lambda_i=\sum_i\lambda_i^2=1.
+    \end{align}
+    Each $\lambda_i$ lies in $[0,1]$, and
+    $\sum_i\lambda_i(1-\lambda_i)=0$. Hence every eigenvalue is either zero
+    or one. Thus $P^2=P$, and its rank equals its trace, namely one. Conversely,
+    a rank-one orthogonal projection has one unit eigenvalue and all remaining
+    eigenvalues zero, so its trace is one.
+\end{proof}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1207,6 +1207,22 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### transport of diagonal spectral identities — candidate
+- **Pattern:** diagonalize a Hermitian matrix as a unitary conjugate of its
+  eigenvalue diagonal, prove a scalar or polynomial identity on that diagonal,
+  and transport the identity back through the conjugation algebra
+  automorphism.
+- **Seen:** three occurrences in
+  `TNLean/Algebra/HermitianTracePower.lean` and
+  `TNLean/Algebra/TracePurity.lean` (two occurrences), recorded 2026-08-21.
+- **Abstraction:** a proposed Hermitian spectral-transport lemma exposing the
+  diagonalization equality and preserving polynomial identities through the
+  conjugation algebra automorphism.
+- **Notes:** the three conclusions differ: a trace-power formula, scalarity
+  from constant eigenvalues, and idempotency from idempotent eigenvalues. A
+  useful abstraction should remove the repeated diagonalization argument
+  without hiding these distinct mathematical steps.
+
 ### projector-selected sector closure assembly — candidate
 - **Pattern:** expand a closure as a finite sum of sector closures, distribute
   a projector-controlled sum of linear maps over it, use the orthogonal


### PR DESCRIPTION
## Summary

- prove the Hermitian trace-square inequality using the spectral theorem and finite Cauchy–Schwarz
- characterize equality by real scalar multiples of the identity, including the zero-dimensional case
- prove the unit-purity trace lower bound for positive semidefinite matrices
- characterize its equality case as rank-one orthogonal projections
- extend the SIC-POVM blueprint section with source-faithful statements and spectral proofs

This is the matrix equality-criterion layer required before the overlap counting argument in LionSR/QICLean#322.

## Verification

- lake env lean TNLean/Algebra/TracePurity.lean
- lake build (10,274 targets)
- python3 scripts/generate_import_aggregators.py --check
- python3 scripts/check_reader_facing_prose.py --diff-base origin/main
- PYTHONPATH=scripts python3 scripts/qic_blueprint_boundary_report.py
- python3 scripts/tactic_pattern_scan.py
- python3 scripts/blueprint_lean_sync.py --update-lean-decls
- lake exe checkdecls blueprint/lean_decls
- leanblueprint pdf (1,142 pages); pages 418–419 inspected visually
- kernel axiom audit: only propext, Classical.choice, and Quot.sound

Closes LionSR/QICLean#321.