### PR TITLE
doc(Channel/Schwarz): correct equality proof sketch

### DIFF
--- a/TNLean/Channel/Schwarz/TwoVariableEquality.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableEquality.lean
@@ -15,12 +15,12 @@ holds for every `A`, and for `A` at which equality is attained, the
 pseudoinverse sandwich `E(A†B) · pinv(E(B†B)) · E(B†X)` agrees with
 `E(A†X)` for *every* `X`, not only `X = A`.
 
-The proof is Wolf's `t A + X` quadratic-in-`t` completing-the-square
-argument: expanding the (matrix-valued) nonnegative quadratic form of the
-Schwarz inequality at `A + t X` for real `t`, the `t²`-coefficient vanishes
-at the equality point `A`, so the remaining linear-in-`t` term must vanish
-identically; applying this at `X` and at `i X` and combining isolates the
-one-sided identity Eq. (5.5).
+The proof uses Wolf's quadratic argument.  At an equality point `A`, the
+constant term in the nonnegative quadratic form associated with `A + t X`
+vanishes, while its quadratic coefficient is nonnegative.  Evaluating first
+for real `t` and then with `X` replaced by `i X` forces both linear terms to
+vanish; combining the resulting identities gives the one-sided identity
+Eq. (5.5).
 
 ## Main definitions
 


### PR DESCRIPTION
## Summary

- correct the module-level proof sketch for Wolf's two-variable Schwarz equality criterion
- state that the equality hypothesis removes the constant term, while the quadratic term remains nonnegative
- explain how the real and imaginary specializations eliminate both linear terms

## Verification

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- no theorem statement or proof is changed

Closes LionSR/QICLean#281