### PR TITLE
doc(Channel/Schwarz): close unconditional inequality gap note

### DIFF
--- a/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
@@ -7,9 +7,10 @@ import TNLean.Channel.Schwarz.TwoVariable
 import TNLean.Channel.Schwarz.SchurComplement
 
 /-!
-# The unconditional two-variable operator Schwarz inequality
+# The equal-dimensional unconditional two-variable operator Schwarz inequality
 
-This file proves the unconditional form of Wolf's Theorem 5.3 (Eq. (5.4)):
+This file proves the equal-dimensional unconditional form of Wolf's Theorem 5.3
+(Eq. (5.4)):
 for a 2-positive map `E` and all `A, B`,
 `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, with the inverse taken on the
 range via the Moore–Penrose pseudoinverse `Douglas.pinv`.
@@ -25,6 +26,12 @@ than the `EuclideanSpace`/`PiLp` range-ker duality route that caused
 `whnf` timeouts (documented in
 `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`).
 
+**Scope restriction (equal dimensions):** Wolf states the theorem for
+$E:M_{d'}(\mathbb C)\to M_d(\mathbb C)$, while `Is2PositiveMap` currently
+describes only endomorphisms of one matrix algebra. The rectangular theorem
+remains unformalized. See
+`docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`.
+
 ## Main results
 
 * `ker_EBB_le_ker_EAB`: `ker(E(B†B)) ⊆ ker(E(A†B))`, the kernel-inclusion
@@ -33,8 +40,8 @@ than the `EuclideanSpace`/`PiLp` range-ker duality route that caused
   `E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`, i.e. the range inclusion
   `ran E(B†A) ⊆ ran E(B†B)` in pseudoinverse form.
 * `schwarz_two_variable_unconditional`: the unconditional inequality
-  `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, Wolf's Eq. (5.4) literally, no
-  witness vector assumed to exist.
+  `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, the equal-dimensional
+  specialization of Wolf's Eq. (5.4), with no witness vector assumed to exist.
 
 ## References
 
@@ -111,7 +118,12 @@ theorem EBB_mul_pinv_mul_EBA_eq (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMa
 with the inverse taken on the range via the Moore–Penrose pseudoinverse
 `Douglas.pinv`. Unlike `SchwarzTwoVariable.schwarz_two_variable`, no
 witness vector `w` is assumed to exist: the pseudoinverse witness
-`w = pinv(E(B†B)) · E(B†A) · v` is constructed explicitly for every `v`. -/
+`w = pinv(E(B†B)) · E(B†A) · v` is constructed explicitly for every `v`.
+
+**Scope restriction (equal dimensions):** Wolf allows a two-positive map
+$E:M_{d'}(\mathbb C)\to M_d(\mathbb C)$. This theorem treats $d'=d$ because
+`Is2PositiveMap` is presently defined only for endomorphisms. See
+`docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`. -/
 theorem schwarz_two_variable_unconditional (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
     (A B : Mat) :
     E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) ≤ E (Aᴴ * A) := by

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -501,8 +501,9 @@ positivity.
         \notag
     \end{align}
     where $(\cdot)^+$ is the Moore--Penrose pseudoinverse, i.e.\ the
-    inverse taken on the range. This is \cite[Eq.~(5.4)]{Wolf2012Quantum},
-    unconditional: no vector is assumed to exist.
+    inverse taken on the range. This is the equal-dimensional specialization
+    of \cite[Eq.~(5.4)]{Wolf2012Quantum}, unconditional: no vector is assumed
+    to exist. The cited theorem permits different input and output dimensions.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
+++ b/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
@@ -1,63 +1,124 @@
-\documentclass[11pt]{article}
+\documentclass{article}
+
 \usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Inverse on the Range in the Two-Variable Operator Schwarz Inequality}
+\author{}
+\date{2026-08-21}
+
 \begin{document}
-\section{Two-variable operator Schwarz inequality --- unconditional form}
-\label{sec:gap_two_variable_unconditional}
+\maketitle
 
-\subsection{Source}
-M.~Wolf, \emph{Quantum Channels \& Operations: Guided Tour}, Chapter~5,
-Theorem~5.3 (Eq.~5.4), local source
-\verb|Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex|, lines~180--190.
+\section{Source statement}
 
-\subsection{What is formalized}
-The conditional form \texttt{SchwarzTwoVariable.schwarz\_two\_variable}
-(Lean lemma \texttt{lem:two\_variable\_operator\_schwarz\_conditional}) is
-proved: for a 2-positive map $E$, for all $A,B$ and all vectors $v,w$ with
-$E(B^\dagger B)w = E(B^\dagger A)v$, we have
-$v^\dagger E(A^\dagger A)v \ge v^\dagger E(A^\dagger B)w$.
-This captures Wolf's Eq.~(5.4) in the sense that $w$ plays the role of
-$E(B^\dagger B)^{-1}E(B^\dagger A)v$ (the ``inverse on the range'' is
-exactly the condition $E(B^\dagger B)w = E(B^\dagger A)v$).
-
-\subsection{What is missing}
-The unconditional form (Theorem~5.3 as stated by Wolf) asserts that
-for every $v$, such a $w$ \emph{exists}.  Proving existence requires the
-finite-dimensional range/ker duality:
+Let $E\colon M_{d'}(\mathbb C)\to M_d(\mathbb C)$ be a two-positive linear
+map.  Theorem~5.3 of Wolf's \emph{Quantum Channels \& Operations: Guided
+Tour}, Chapter~5, asserts that for every $A,B\in M_{d'}(\mathbb C)$,
 \begin{align}
-    \operatorname{ran}(E(B^\dagger B))
-    = \ker(E(B^\dagger B))^\perp,
-    \notag
+  E(A^\dagger B)\,E(B^\dagger B)^{-1}\,E(B^\dagger A)
+  &\leq E(A^\dagger A),
+  \label{eq:schwarz}
 \end{align}
-where $\perp$ is the Hermitian dot-product orthogonal complement.
-The inclusion $\supseteq$ is equivalent to: for any $y$ orthogonal to the
-kernel, $y$ belongs to the range.  With this, the kernel inclusion
-$\ker(E(B^\dagger B)) \subseteq \ker(E(A^\dagger B))$ (which is already proved
-via the Schur-complement argument) implies
-$\operatorname{ran}(E(B^\dagger A)) \subseteq \operatorname{ran}(E(B^\dagger B))$,
-giving existence of $w$.
+where the inverse is taken on the range of $E(B^\dagger B)$.  The local
+source is
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, lines
+180--190.
 
-The range/ker duality is a standard finite-dimensional linear-algebra fact
-(for Hermitian matrices the column space equals the orthogonal complement of
-the nullspace).  Formalizing it requires the Euclidean-space inner-product
-structure on $\mathbb C^n$ ($\texttt{EuclideanSpace}$ or $\texttt{PiLp}$)
-and the adjoint/orthogonal-complement lemmas
-($\texttt{LinearMap.orthogonal\_ker}$,
-$\texttt{LinearMap.adjoint\_adjoint}$).
-Initial attempts to use these lemmas caused $\texttt{whnf}$ timeouts during
-typechecking of the proof body, likely due to the complexity of the
-$\texttt{PiLp}$ typeclass resolution.
+The formal theorem proves the specialization $d'=d$ without an additional
+witness hypothesis.  The inverse on the range is represented by the
+Moore--Penrose inverse.  The argument below applies to arbitrary $d'$ and $d$;
+the remaining restriction comes from the present definition of two-positivity,
+which is stated only for endomorphisms of one matrix algebra.
 
-\subsection{Elimination plan}
-The range/ker duality is being formalized in a separate module as part of
-the $\texttt{EuclideanSpace}$ inner-product infrastructure (tracked in a
-follow-up issue).  Once available, the unconditional theorem
-\texttt{schwarz\_two\_variable\_unconditional} will be proved as a corollary
-of the conditional lemma, and the $\texttt{\\leanok}$ tag will be restored
-on the theorem entry in the blueprint.
+\section{The range inverse}
 
-\subsection{Verdict}
-The two-variable operator Schwarz inequality is partially formalized:
-the pseudoinverse-free inequality (conditional on a witness $w$) is complete;
-the unconditional existence of the witness requires Euclidean-space
-range/ker duality, which is tracked as a gap.
+Put
+\begin{align}
+  P &= E(A^\dagger A), &
+  Z &= E(A^\dagger B), &
+  R &= E(B^\dagger B).
+\end{align}
+Two-positivity gives
+\begin{align}
+  \begin{pmatrix}
+    P & Z\\
+    Z^\dagger & R
+  \end{pmatrix}
+  &\geq 0.
+  \label{eq:block-positive}
+\end{align}
+The kernel clause of the Schur-complement theorem applied to
+\eqref{eq:block-positive} yields
+\begin{align}
+  \ker R &\subseteq \ker Z.
+  \label{eq:kernel-inclusion}
+\end{align}
+Let $R^+$ be the Moore--Penrose inverse of $R$, and let
+\begin{align}
+  s_R &= RR^+=R^+R
+\end{align}
+be the orthogonal projection onto the support of $R$.  Since $R$ is positive
+semidefinite, its support is $(\ker R)^\perp$.  Equation
+\eqref{eq:kernel-inclusion} is therefore equivalent to
+\begin{align}
+  Zs_R &= Z,
+  &
+  s_RZ^\dagger &= Z^\dagger.
+  \label{eq:support-absorption}
+\end{align}
+In particular,
+\begin{align}
+  R\bigl(R^+Z^\dagger\bigr) &= Z^\dagger.
+  \label{eq:range-witness}
+\end{align}
+Thus $R^+Z^\dagger v$ is the required preimage of $Z^\dagger v$ under $R$
+for every vector $v$.  This is precisely the meaning of the inverse on the
+range in \eqref{eq:schwarz}; no separate range--kernel duality argument is
+needed.
+
+The formal proof establishes \eqref{eq:kernel-inclusion}, then
+\eqref{eq:support-absorption}, and finally
+\eqref{eq:range-witness}.
+
+\section{Derivation of the inequality}
+
+For a fixed vector $v$, set
+\begin{align}
+  w &= R^+Z^\dagger v.
+\end{align}
+Equation~\eqref{eq:range-witness} gives $Rw=Z^\dagger v$.  The
+pseudoinverse-free quadratic-form consequence of
+\eqref{eq:block-positive} then gives
+\begin{align}
+  v^\dagger Pv
+  &\geq v^\dagger Zw
+   = v^\dagger ZR^+Z^\dagger v.
+\end{align}
+Since this holds for every $v$,
+\begin{align}
+  ZR^+Z^\dagger &\leq P,
+\end{align}
+which is \eqref{eq:schwarz}.\footnote{Formal declaration:
+  \leanid{schwarz_two_variable_unconditional} in the namespace
+  \leanid{SchwarzTwoVariable}.}
+
+\section{Verdict}
+
+Within the equal-dimensional specialization $d'=d$, there is no remaining
+witness hypothesis: the phrase ``inverse on the range'' is realized by the
+Moore--Penrose inverse, and the required range inclusion follows from
+support-projection absorption.  The earlier proposed use of an explicit
+Euclidean-space range--kernel duality is unnecessary.
+
+Wolf's statement allows independent input and output dimensions.  Since the
+formal notion of two-positivity presently applies only to
+$E:M_D(\mathbb C)\to M_D(\mathbb C)$, that rectangular generality remains
+unformalized.  The classification is therefore a resolved range-witness gap
+together with an equal-dimensional scope restriction.
+
 \end{document}


### PR DESCRIPTION
## Summary

- rewrite the obsolete paper-gap note as a present-tense account of the range inverse in Wolf's two-variable Schwarz inequality
- identify the Moore–Penrose witness through support-projection absorption, closing the former witness-existence gap
- record the remaining equal-dimensional scope restriction in the note, Lean docstring, and blueprint

## Mathematical route

For `R = E(B†B)` and `Z = E(A†B)`, positivity of the two-by-two block matrix gives `ker R ⊆ ker Z`. If `s_R = R R⁺` is the support projection, this gives `Z s_R = Z`, hence `R(R⁺ Z†) = Z†`. Substitution of the resulting range preimage into the conditional quadratic-form inequality yields the unconditional inequality.

Wolf permits `E : M_{d′}(ℂ) → M_d(ℂ)`, while the current `Is2PositiveMap` treats endomorphisms of one matrix algebra. The formal result is therefore the faithful `d′ = d` specialization, not yet the unrestricted source theorem.

## Verification

- focused Lean check of `TNLean/Channel/Schwarz/TwoVariableUnconditional.lean` using the established shared Mathlib cache
- `latexmk -pdf -interaction=nonstopmode -halt-on-error wolf_ch5_two_variable_unconditional.tex`
- visual inspection of both rendered pages
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Closes LionSR/QICLean#280