### PR TITLE
feat(Channel/Schwarz): generalize Wolf inequality dimensions

### DIFF
--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -91,17 +91,20 @@ theorem factorization_of_forall_mulVec_mem_range
 support inverse from `Matrix.PosSemidef.supportInv`. This is Wolf's
 "inverse on the range": `B * B⁺` is the support projection of `B Bᴴ`
 (`mul_pinv_eq_supportProj`). -/
-noncomputable def pinv (B : Mat) : Mat :=
+noncomputable def pinv {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix n n ℂ) : Matrix n n ℂ :=
   Bᴴ * (Matrix.PosSemidef.supportInv (Matrix.posSemidef_self_mul_conjTranspose B))
 
 /-- The matrix `B * Bᴴ` is positive semidefinite (the PSD certificate used
 throughout the Douglas development for the support-inverse `(B Bᴴ)⁻¹_supp`). -/
-abbrev posSemidefBB (B : Mat) : (B * Bᴴ).PosSemidef :=
+abbrev posSemidefBB {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix n n ℂ) : (B * Bᴴ).PosSemidef :=
   Matrix.posSemidef_self_mul_conjTranspose B
 
 /-- The pseudoinverse is a right inverse on the support: `B * B⁺` equals the
 support projection of `B * Bᴴ`. -/
-theorem mul_pinv_eq_supportProj (B : Mat) :
+theorem mul_pinv_eq_supportProj {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix n n ℂ) :
     B * pinv B = (posSemidefBB B).supportProj := by
   unfold pinv
   have h := (posSemidefBB B).self_mul_supportInv

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -123,7 +123,8 @@ theorem ker_subset_of_block_psd (P : Matrix (Fin D₁) (Fin D₁) ℂ)
 
 /-- For PSD `R`, `R * pinv R = supportProj R`: the pseudoinverse is a right
 support-inverse. -/
-theorem R_mul_pinv_eq_supportProj (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hR : R.PosSemidef) :
+theorem R_mul_pinv_eq_supportProj {n : Type*} [Fintype n] [DecidableEq n]
+    (R : Matrix n n ℂ) (hR : R.PosSemidef) :
     R * (Douglas.pinv R) = hR.supportProj := by
   rw [Douglas.mul_pinv_eq_supportProj R]
   exact hR.supportProj_sq_eq_supportProj

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -77,7 +77,7 @@ so the theorem here applies strictly beyond the CP case.
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n p : Type*} [Fintype n] [DecidableEq n]
 
 /-- The equivalence `α × Fin 2 ≃ α ⊕ α` that sends `(a, 0)` to `Sum.inl a`
 and `(a, 1)` to `Sum.inr a`.  Used to reindex block matrices between the
@@ -114,8 +114,8 @@ theorem finTwoSumEquiv_symm_inr {α : Type*} (a : α) :
 
 /-! ## Definitions of n-positivity -/
 
-/-- A linear map `E : M_n(ℂ) → M_n(ℂ)` is **k-positive** if the ampliation
-`E ⊗ id_k : M_n(ℂ) ⊗ M_k(ℂ) → M_n(ℂ) ⊗ M_k(ℂ)` is a positive map.
+/-- A linear map `E : M_n(ℂ) → M_p(ℂ)` is **k-positive** if the ampliation
+`E ⊗ id_k : M_n(ℂ) ⊗ M_k(ℂ) → M_p(ℂ) ⊗ M_k(ℂ)` is a positive map.
 
 We represent `M_n(ℂ) ⊗ M_k(ℂ)` as `M_{n×k}(ℂ)` via the Kronecker product
 identification, and the ampliation acts blockwise:
@@ -128,27 +128,30 @@ matches the block-matrix arguments used in `KadisonSchwarz.lean`. A
 definition but would require additional formalization to connect with the
 existing Kraus-based proofs.
 
-**Index convention**: We use `(n × Fin k)` indexing where `n` is the inner
-(algebra) index and `Fin k` is the outer (ampliation) index. This is the
-transpose of the standard Kronecker convention `(Fin k × n)`, but is
-mathematically equivalent (PSD-ness is invariant under simultaneous row/column
-permutation). -/
-def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+**Index convention**: The domain uses `(n × Fin k)` and the codomain uses
+`(p × Fin k)`, with the matrix-algebra index first and the ampliation index
+second. This is the transpose of the standard Kronecker convention, and is
+equivalent to it by simultaneous row and column permutation.
+
+This is Wolf, *Quantum Channels & Operations*, Chapter 3, Section 3.1. -/
+def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) : Prop :=
   ∀ X : Matrix (n × Fin k) (n × Fin k) ℂ,
     X.PosSemidef →
-    (Matrix.of fun (ip : n × Fin k) (jq : n × Fin k) =>
+    (Matrix.of fun (ip : p × Fin k) (jq : p × Fin k) =>
       (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1).PosSemidef
 
-/-- A linear map is **2-positive** if `E ⊗ id₂` is positive. -/
-def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+/-- A linear map is **2-positive** if `E ⊗ id₂` is positive; see Wolf,
+*Quantum Channels & Operations*, Chapter 3, Section 3.1. -/
+def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) : Prop :=
   IsNPositiveMap 2 E
 
 /-- The explicit blockwise ampliation `E ⊗ id_k` used in the definition of
-`k`-positivity. -/
-def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+`k`-positivity from Wolf, *Quantum Channels & Operations*, Chapter 3,
+Section 3.1. -/
+def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
     Matrix (n × Fin k) (n × Fin k) ℂ →ₗ[ℂ]
-      Matrix (n × Fin k) (n × Fin k) ℂ where
-  toFun X := Matrix.of fun (ip : n × Fin k) (jq : n × Fin k) =>
+      Matrix (p × Fin k) (p × Fin k) ℂ where
+  toFun X := Matrix.of fun (ip : p × Fin k) (jq : p × Fin k) =>
     (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
   map_add' X Y := by
     ext ip jq
@@ -166,7 +169,7 @@ def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ
 omit [Fintype n] [DecidableEq n] in
 /-- The definition of `k`-positivity is positivity of the blockwise ampliation. -/
 theorem isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation
-    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
     IsNPositiveMap k E ↔ IsPositiveMap (nPositiveAmpliation k E) := by
   rfl
 
@@ -176,7 +179,7 @@ Operations*, Proposition 3.1: `k`-positivity can be tested on pure states of the
 ampliated system. -/
 theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
     [Finite n]
-    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
     IsNPositiveMap k E ↔
       ∀ φ : n × Fin k → ℂ,
         (nPositiveAmpliation k E (Matrix.vecMulVec φ (star φ))).PosSemidef := by
@@ -199,7 +202,7 @@ theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
 omit [Fintype n] [DecidableEq n] in
 /-- One-positive maps are exactly positive maps. -/
 theorem isNPositiveMap_one_iff_isPositiveMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
     IsNPositiveMap 1 E ↔ IsPositiveMap E := by
   constructor
   · intro hE X hX
@@ -210,7 +213,7 @@ theorem isNPositiveMap_one_iff_isPositiveMap
       ext ip jq
       rfl
     have hY := hE X' hX'
-    let emb : n → n × Fin 1 := fun i => (i, 0)
+    let emb : p → p × Fin 1 := fun i => (i, 0)
     convert hY.submatrix emb using 1
     ext i j
     simp only [emb, X', Matrix.submatrix_apply, Matrix.of_apply]
@@ -218,17 +221,18 @@ theorem isNPositiveMap_one_iff_isPositiveMap
   · intro hE
     rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation]
     intro X hX
-    let e : n × Fin 1 ≃ n := Equiv.prodUnique n (Fin 1)
-    have hY : (Matrix.of fun (ip : n × Fin 1) (jq : n × Fin 1) =>
+    let eIn : n × Fin 1 ≃ n := Equiv.prodUnique n (Fin 1)
+    let eOut : p × Fin 1 ≃ p := Equiv.prodUnique p (Fin 1)
+    have hY : (Matrix.of fun (ip : p × Fin 1) (jq : p × Fin 1) =>
         E (Matrix.of fun i j => X (i, 0) (j, 0)) ip.1 jq.1).PosSemidef := by
       have hblock : (Matrix.of fun i j => X (i, 0) (j, 0)).PosSemidef := by
-        convert hX.submatrix e.symm using 1
+        convert hX.submatrix eIn.symm using 1
         ext i j
-        simp [e]
+        simp [eIn]
       have hEblock := hE _ hblock
-      convert hEblock.submatrix e using 1
+      convert hEblock.submatrix eOut using 1
       ext ip jq
-      simp [e]
+      simp [eOut]
     convert hY using 1
     ext ip jq
     have hip : ip.2 = 0 := Subsingleton.elim ip.2 0
@@ -654,9 +658,11 @@ omit [DecidableEq n] [Fintype n] in
 /-- 2-positive maps are positive.
 
 Apply the definition with `k = 1` embedded into `k = 2`: given PSD `X`,
-embed it as `diag(X, 0)` in `M_n ⊗ M_2`, apply 2-positivity to get PSD
-output, then extract the (0,0)-block which equals `E(X)`. -/
-theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+embed it as `diag(X, 0)` in the ampliated domain, apply 2-positivity, and
+extract the `(0,0)` block of the ampliated codomain, which equals `E(X)`.
+This is the positivity consequence used in Wolf, *Quantum Channels &
+Operations*, Theorem 5.3. -/
+theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (h : Is2PositiveMap E) : IsPositiveMap E := by
   intro X hX
   let e : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
@@ -667,7 +673,7 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n 
       posSemidef_fromBlocks_zero_zero hX
     simpa [X', Matrix.reindex_apply] using hdiag.submatrix e
   have hY' := h X' hX'
-  let emb : n → n × Fin 2 := fun i => (i, 0)
+  let emb : p → p × Fin 2 := fun i => (i, 0)
   convert hY'.submatrix emb using 1
   ext i j
   simp [emb, X', Matrix.reindex_apply, e]

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -265,8 +265,8 @@ omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint of a positive map between finite matrix algebras
 is positive.
 
-This is the rectangular trace-adjoint positivity used in Wolf, *Quantum
-Channels & Operations*, Chapter 3, lines 722--735 of
+This is the rectangular trace-adjoint positivity stated in Wolf, *Quantum
+Channels & Operations*, Chapter 3, lines 24--26 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem IsPositiveMap.traceAdjointMap
     [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
@@ -282,7 +282,7 @@ theorem IsPositiveMap.traceAdjointMap
 omit [Fintype n] [DecidableEq n] in
 /-- Positivity is invariant under the trace-pairing adjoint.
 
-Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 722--735 of
+Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 24--26 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem isPositiveMap_traceAdjointMap_iff
     [Finite n] [Fintype p]
@@ -368,9 +368,9 @@ omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint of a `k`-positive map between finite matrix
 algebras is `k`-positive.
 
-For `k = 2`, this is the trace-adjoint step in Wolf, *Quantum Channels &
-Operations*, Theorem 5.3; see
-`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
+Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 79--80 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. The case `k = 2`
+is used in Wolf's Theorem 5.3. -/
 theorem IsNPositiveMap.traceAdjointMap
     [Finite n] [Fintype p] {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (hE : IsNPositiveMap k E) : IsNPositiveMap k (Matrix.traceAdjointMap E) := by
@@ -382,8 +382,8 @@ theorem IsNPositiveMap.traceAdjointMap
 omit [Fintype n] [DecidableEq n] in
 /-- `k`-positivity is invariant under the trace-pairing adjoint.
 
-Source context: Wolf, *Quantum Channels & Operations*, Theorem 5.3,
-`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
+Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 79--80 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem isNPositiveMap_traceAdjointMap_iff
     [Finite n] [Fintype p]
     {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -77,7 +77,7 @@ so the theorem here applies strictly beyond the CP case.
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset
 
-variable {n p : Type*} [Fintype n] [DecidableEq n]
+variable {n n' : Type*} [Fintype n] [DecidableEq n]
 
 /-- The equivalence `α × Fin 2 ≃ α ⊕ α` that sends `(a, 0)` to `Sum.inl a`
 and `(a, 1)` to `Sum.inr a`.  Used to reindex block matrices between the
@@ -114,8 +114,8 @@ theorem finTwoSumEquiv_symm_inr {α : Type*} (a : α) :
 
 /-! ## Definitions of n-positivity -/
 
-/-- A linear map `E : M_n(ℂ) → M_p(ℂ)` is **k-positive** if the ampliation
-`E ⊗ id_k : M_n(ℂ) ⊗ M_k(ℂ) → M_p(ℂ) ⊗ M_k(ℂ)` is a positive map.
+/-- A linear map `E : M_n(ℂ) → M_{n'}(ℂ)` is **k-positive** if the ampliation
+`E ⊗ id_k : M_n(ℂ) ⊗ M_k(ℂ) → M_{n'}(ℂ) ⊗ M_k(ℂ)` is a positive map.
 
 We represent `M_n(ℂ) ⊗ M_k(ℂ)` as `M_{n×k}(ℂ)` via the Kronecker product
 identification, and the ampliation acts blockwise:
@@ -129,29 +129,29 @@ definition but would require additional formalization to connect with the
 existing Kraus-based proofs.
 
 **Index convention**: The domain uses `(n × Fin k)` and the codomain uses
-`(p × Fin k)`, with the matrix-algebra index first and the ampliation index
+`(n' × Fin k)`, with the matrix-algebra index first and the ampliation index
 second. This is the transpose of the standard Kronecker convention, and is
 equivalent to it by simultaneous row and column permutation.
 
 This is Wolf, *Quantum Channels & Operations*, Chapter 3, Section 3.1. -/
-def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) : Prop :=
+def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) : Prop :=
   ∀ X : Matrix (n × Fin k) (n × Fin k) ℂ,
     X.PosSemidef →
-    (Matrix.of fun (ip : p × Fin k) (jq : p × Fin k) =>
+    (Matrix.of fun (ip : n' × Fin k) (jq : n' × Fin k) =>
       (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1).PosSemidef
 
 /-- A linear map is **2-positive** if `E ⊗ id₂` is positive; see Wolf,
 *Quantum Channels & Operations*, Chapter 3, Section 3.1. -/
-def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) : Prop :=
+def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) : Prop :=
   IsNPositiveMap 2 E
 
 /-- The explicit blockwise ampliation `E ⊗ id_k` used in the definition of
 `k`-positivity from Wolf, *Quantum Channels & Operations*, Chapter 3,
 Section 3.1. -/
-def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
+def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) :
     Matrix (n × Fin k) (n × Fin k) ℂ →ₗ[ℂ]
-      Matrix (p × Fin k) (p × Fin k) ℂ where
-  toFun X := Matrix.of fun (ip : p × Fin k) (jq : p × Fin k) =>
+      Matrix (n' × Fin k) (n' × Fin k) ℂ where
+  toFun X := Matrix.of fun (ip : n' × Fin k) (jq : n' × Fin k) =>
     (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
   map_add' X Y := by
     ext ip jq
@@ -169,7 +169,7 @@ def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ
 omit [Fintype n] [DecidableEq n] in
 /-- The definition of `k`-positivity is positivity of the blockwise ampliation. -/
 theorem isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation
-    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) :
     IsNPositiveMap k E ↔ IsPositiveMap (nPositiveAmpliation k E) := by
   rfl
 
@@ -179,7 +179,7 @@ Operations*, Proposition 3.1: `k`-positivity can be tested on pure states of the
 ampliated system. -/
 theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
     [Finite n]
-    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) :
     IsNPositiveMap k E ↔
       ∀ φ : n × Fin k → ℂ,
         (nPositiveAmpliation k E (Matrix.vecMulVec φ (star φ))).PosSemidef := by
@@ -202,7 +202,7 @@ theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
 omit [Fintype n] [DecidableEq n] in
 /-- One-positive maps are exactly positive maps. -/
 theorem isNPositiveMap_one_iff_isPositiveMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ} :
     IsNPositiveMap 1 E ↔ IsPositiveMap E := by
   constructor
   · intro hE X hX
@@ -213,7 +213,7 @@ theorem isNPositiveMap_one_iff_isPositiveMap
       ext ip jq
       rfl
     have hY := hE X' hX'
-    let emb : p → p × Fin 1 := fun i => (i, 0)
+    let emb : n' → n' × Fin 1 := fun i => (i, 0)
     convert hY.submatrix emb using 1
     ext i j
     simp only [emb, X', Matrix.submatrix_apply, Matrix.of_apply]
@@ -222,8 +222,8 @@ theorem isNPositiveMap_one_iff_isPositiveMap
     rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation]
     intro X hX
     let eIn : n × Fin 1 ≃ n := Equiv.prodUnique n (Fin 1)
-    let eOut : p × Fin 1 ≃ p := Equiv.prodUnique p (Fin 1)
-    have hY : (Matrix.of fun (ip : p × Fin 1) (jq : p × Fin 1) =>
+    let eOut : n' × Fin 1 ≃ n' := Equiv.prodUnique n' (Fin 1)
+    have hY : (Matrix.of fun (ip : n' × Fin 1) (jq : n' × Fin 1) =>
         E (Matrix.of fun i j => X (i, 0) (j, 0)) ip.1 jq.1).PosSemidef := by
       have hblock : (Matrix.of fun i j => X (i, 0) (j, 0)).PosSemidef := by
         convert hX.submatrix eIn.symm using 1
@@ -241,8 +241,8 @@ theorem isNPositiveMap_one_iff_isPositiveMap
 
 omit [Fintype n] [DecidableEq n] in
 private theorem traceAdjointMap_map_isHermitian_of_isPositiveMap
-    [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
-    (hE : IsPositiveMap E) {X : Matrix p p ℂ} (hX : X.IsHermitian) :
+    [Finite n] [Fintype n'] {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ}
+    (hE : IsPositiveMap E) {X : Matrix n' n' ℂ} (hX : X.IsHermitian) :
     (Matrix.traceAdjointMap E X).IsHermitian := by
   let := Fintype.ofFinite n
   classical
@@ -269,7 +269,7 @@ This is the rectangular trace-adjoint positivity stated in Wolf, *Quantum
 Channels & Operations*, Chapter 3, lines 24--26 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem IsPositiveMap.traceAdjointMap
-    [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
+    [Finite n] [Fintype n'] {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ}
     (hE : IsPositiveMap E) : IsPositiveMap (Matrix.traceAdjointMap E) := by
   let := Fintype.ofFinite n
   intro X hX
@@ -285,8 +285,8 @@ omit [Fintype n] [DecidableEq n] in
 Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 24--26 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem isPositiveMap_traceAdjointMap_iff
-    [Finite n] [Fintype p]
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
+    [Finite n] [Fintype n']
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ} :
     IsPositiveMap (Matrix.traceAdjointMap E) ↔ IsPositiveMap E := by
   let := Fintype.ofFinite n
   classical
@@ -338,7 +338,7 @@ This is the rectangular ampliation identity underlying Wolf, *Quantum
 Channels & Operations*, Theorem 5.3; see
 `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
 theorem nPositiveAmpliation_traceAdjointMap
-    [Finite n] [Fintype p] (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
+    [Finite n] [Fintype n'] (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ) :
     nPositiveAmpliation k (Matrix.traceAdjointMap E) =
       Matrix.traceAdjointMap (nPositiveAmpliation k E) := by
   let := Fintype.ofFinite n
@@ -372,7 +372,7 @@ Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 79--80 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. The case `k = 2`
 is used in Wolf's Theorem 5.3. -/
 theorem IsNPositiveMap.traceAdjointMap
-    [Finite n] [Fintype p] {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
+    [Finite n] [Fintype n'] {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ}
     (hE : IsNPositiveMap k E) : IsNPositiveMap k (Matrix.traceAdjointMap E) := by
   let := Fintype.ofFinite n
   rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation] at hE ⊢
@@ -385,8 +385,8 @@ omit [Fintype n] [DecidableEq n] in
 Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 79--80 of
 `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem isNPositiveMap_traceAdjointMap_iff
-    [Finite n] [Fintype p]
-    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
+    [Finite n] [Fintype n']
+    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ} :
     IsNPositiveMap k (Matrix.traceAdjointMap E) ↔ IsNPositiveMap k E := by
   let := Fintype.ofFinite n
   classical
@@ -693,7 +693,7 @@ embed it as `diag(X, 0)` in the ampliated domain, apply 2-positivity, and
 extract the `(0,0)` block of the ampliated codomain, which equals `E(X)`.
 This is the positivity consequence used in Wolf, *Quantum Channels &
 Operations*, Theorem 5.3. -/
-theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
+theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n' n' ℂ}
     (h : Is2PositiveMap E) : IsPositiveMap E := by
   intro X hX
   let e : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
@@ -704,7 +704,7 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p 
       posSemidef_fromBlocks_zero_zero hX
     simpa [X', Matrix.reindex_apply] using hdiag.submatrix e
   have hY' := h X' hX'
-  let emb : p → p × Fin 2 := fun i => (i, 0)
+  let emb : n' → n' × Fin 2 := fun i => (i, 0)
   convert hY'.submatrix emb using 1
   ext i j
   simp [emb, X', Matrix.reindex_apply, e]

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -263,7 +263,11 @@ private theorem traceAdjointMap_map_isHermitian_of_isPositiveMap
 
 omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint of a positive map between finite matrix algebras
-is positive. -/
+is positive.
+
+This is the rectangular trace-adjoint positivity used in Wolf, *Quantum
+Channels & Operations*, Chapter 3, lines 722--735 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem IsPositiveMap.traceAdjointMap
     [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (hE : IsPositiveMap E) : IsPositiveMap (Matrix.traceAdjointMap E) := by
@@ -276,7 +280,10 @@ theorem IsPositiveMap.traceAdjointMap
   exact Matrix.PosSemidef.trace_mul_nonneg hX (hE B hB)
 
 omit [Fintype n] [DecidableEq n] in
-/-- Positivity is invariant under the trace-pairing adjoint. -/
+/-- Positivity is invariant under the trace-pairing adjoint.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 3, lines 722--735 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`. -/
 theorem isPositiveMap_traceAdjointMap_iff
     [Finite n] [Fintype p]
     {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
@@ -325,7 +332,11 @@ private theorem trace_mul_eq_sum_trace_blocks
 
 omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint commutes with the blockwise ampliation:
-`(E^{(k)})^* = (E^*)^{(k)}`. -/
+`(E^{(k)})^* = (E^*)^{(k)}`.
+
+This is the rectangular ampliation identity underlying Wolf, *Quantum
+Channels & Operations*, Theorem 5.3; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
 theorem nPositiveAmpliation_traceAdjointMap
     [Finite n] [Fintype p] (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
     nPositiveAmpliation k (Matrix.traceAdjointMap E) =
@@ -355,7 +366,11 @@ theorem nPositiveAmpliation_traceAdjointMap
 
 omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint of a `k`-positive map between finite matrix
-algebras is `k`-positive. -/
+algebras is `k`-positive.
+
+For `k = 2`, this is the trace-adjoint step in Wolf, *Quantum Channels &
+Operations*, Theorem 5.3; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
 theorem IsNPositiveMap.traceAdjointMap
     [Finite n] [Fintype p] {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (hE : IsNPositiveMap k E) : IsNPositiveMap k (Matrix.traceAdjointMap E) := by
@@ -365,7 +380,10 @@ theorem IsNPositiveMap.traceAdjointMap
   exact hE.traceAdjointMap
 
 omit [Fintype n] [DecidableEq n] in
-/-- `k`-positivity is invariant under the trace-pairing adjoint. -/
+/-- `k`-positivity is invariant under the trace-pairing adjoint.
+
+Source context: Wolf, *Quantum Channels & Operations*, Theorem 5.3,
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--193. -/
 theorem isNPositiveMap_traceAdjointMap_iff
     [Finite n] [Fintype p]
     {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -239,11 +239,12 @@ theorem isNPositiveMap_one_iff_isPositiveMap
     have hjq : jq.2 = 0 := Subsingleton.elim jq.2 0
     simp [nPositiveAmpliation, hip, hjq]
 
-omit [DecidableEq n] in
+omit [Fintype n] [DecidableEq n] in
 private theorem traceAdjointMap_map_isHermitian_of_isPositiveMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
-    (hE : IsPositiveMap E) {X : Matrix n n ℂ} (hX : X.IsHermitian) :
+    [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
+    (hE : IsPositiveMap E) {X : Matrix p p ℂ} (hX : X.IsHermitian) :
     (Matrix.traceAdjointMap E X).IsHermitian := by
+  let := Fintype.ofFinite n
   classical
   rw [Matrix.IsHermitian]
   ext i j
@@ -260,11 +261,13 @@ private theorem traceAdjointMap_map_isHermitian_of_isPositiveMap
     _ = Matrix.trace (X * E (Matrix.single j i 1)) := by
           rw [Matrix.trace_mul_comm]
 
-omit [DecidableEq n] in
-/-- The trace-pairing adjoint of a positive map is positive. -/
+omit [Fintype n] [DecidableEq n] in
+/-- The trace-pairing adjoint of a positive map between finite matrix algebras
+is positive. -/
 theorem IsPositiveMap.traceAdjointMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    [Finite n] [Fintype p] {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (hE : IsPositiveMap E) : IsPositiveMap (Matrix.traceAdjointMap E) := by
+  let := Fintype.ofFinite n
   intro X hX
   refine Matrix.PosSemidef.of_forall_trace_mul_nonneg
     (traceAdjointMap_map_isHermitian_of_isPositiveMap hE hX.1) ?_
@@ -272,11 +275,14 @@ theorem IsPositiveMap.traceAdjointMap
   rw [Matrix.trace_traceAdjointMap_mul]
   exact Matrix.PosSemidef.trace_mul_nonneg hX (hE B hB)
 
-omit [DecidableEq n] in
+omit [Fintype n] [DecidableEq n] in
 /-- Positivity is invariant under the trace-pairing adjoint. -/
 theorem isPositiveMap_traceAdjointMap_iff
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
+    [Finite n] [Fintype p]
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
     IsPositiveMap (Matrix.traceAdjointMap E) ↔ IsPositiveMap E := by
+  let := Fintype.ofFinite n
+  classical
   constructor
   · intro h
     have h' := h.traceAdjointMap
@@ -299,7 +305,8 @@ theorem isCPMap_traceAdjointMap_iff
 
 omit [DecidableEq n] in
 private theorem trace_mul_eq_sum_trace_blocks
-    (k : ℕ) (A B : Matrix (n × Fin k) (n × Fin k) ℂ) :
+    {q : Type*} [Fintype q]
+    (k : ℕ) (A B : Matrix (q × Fin k) (q × Fin k) ℂ) :
     Matrix.trace (A * B) =
       ∑ p : Fin k, ∑ q : Fin k,
         Matrix.trace
@@ -316,13 +323,14 @@ private theorem trace_mul_eq_sum_trace_blocks
     rw [Finset.sum_comm]
   rw [Finset.sum_comm]
 
-omit [DecidableEq n] in
+omit [Fintype n] [DecidableEq n] in
 /-- The trace-pairing adjoint commutes with the blockwise ampliation:
 `(E^{(k)})^* = (E^*)^{(k)}`. -/
 theorem nPositiveAmpliation_traceAdjointMap
-    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    [Finite n] [Fintype p] (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ) :
     nPositiveAmpliation k (Matrix.traceAdjointMap E) =
       Matrix.traceAdjointMap (nPositiveAmpliation k E) := by
+  let := Fintype.ofFinite n
   classical
   apply LinearMap.ext
   intro ρ
@@ -345,20 +353,25 @@ theorem nPositiveAmpliation_traceAdjointMap
         E (Matrix.of fun i j => X (i, q) (j, p)))
   rw [Matrix.trace_traceAdjointMap_mul]
 
-omit [DecidableEq n] in
-/-- The trace-pairing adjoint of a `k`-positive map is `k`-positive. -/
+omit [Fintype n] [DecidableEq n] in
+/-- The trace-pairing adjoint of a `k`-positive map between finite matrix
+algebras is `k`-positive. -/
 theorem IsNPositiveMap.traceAdjointMap
-    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    [Finite n] [Fintype p] {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ}
     (hE : IsNPositiveMap k E) : IsNPositiveMap k (Matrix.traceAdjointMap E) := by
+  let := Fintype.ofFinite n
   rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation] at hE ⊢
   rw [nPositiveAmpliation_traceAdjointMap]
   exact hE.traceAdjointMap
 
-omit [DecidableEq n] in
+omit [Fintype n] [DecidableEq n] in
 /-- `k`-positivity is invariant under the trace-pairing adjoint. -/
 theorem isNPositiveMap_traceAdjointMap_iff
-    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
+    [Finite n] [Fintype p]
+    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix p p ℂ} :
     IsNPositiveMap k (Matrix.traceAdjointMap E) ↔ IsNPositiveMap k E := by
+  let := Fintype.ofFinite n
+  classical
   constructor
   · intro h
     have h' := h.traceAdjointMap

--- a/TNLean/Channel/Schwarz/TwoVariable.lean
+++ b/TNLean/Channel/Schwarz/TwoVariable.lean
@@ -11,7 +11,8 @@ import Mathlib.Data.Matrix.Block
 # Two-variable operator Schwarz inequality
 
 This file proves the two-variable operator Schwarz inequality for 2-positive
-linear maps (Wolf, Theorem 5.3).
+linear maps between matrix algebras of independent finite dimensions (Wolf,
+Theorem 5.3).
 
 ## Main results
 
@@ -33,16 +34,17 @@ open Matrix Finset Complex
 
 namespace SchwarzTwoVariable
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
 
-local notation "Mat" => Matrix n n ℂ
+local notation "MatIn" => Matrix m m ℂ
+local notation "MatOut" => Matrix n n ℂ
 
-omit [DecidableEq n] in
+omit [DecidableEq m] in
 /-- The block matrix `C†C` for `C = [A B]` (horizontal concatenation) is PSD. -/
-lemma blockMatrix_CtC_posSemidef (A B : Mat) :
+lemma blockMatrix_CtC_posSemidef (A B : MatIn) :
     (Matrix.fromBlocks (Aᴴ * A) (Aᴴ * B) (Bᴴ * A) (Bᴴ * B) :
-      Matrix (n ⊕ n) (n ⊕ n) ℂ).PosSemidef := by
-  let C : Matrix n (n ⊕ n) ℂ := fun i j =>
+      Matrix (m ⊕ m) (m ⊕ m) ℂ).PosSemidef := by
+  let C : Matrix m (m ⊕ m) ℂ := fun i j =>
     match j with
     | Sum.inl a => A i a
     | Sum.inr b => B i b
@@ -62,29 +64,30 @@ lemma blockMatrix_CtC_posSemidef (A B : Mat) :
 
 /-! ### 2-positivity ampliation of the block matrix -/
 
-omit [DecidableEq n] in
+omit [DecidableEq m] [Fintype n] [DecidableEq n] in
 /-- The 2-positivity ampliation applied to the block matrix `C†C` yields a PSD
 `2×2` block matrix of the form `[[E(A†A), E(A†B)], [E(B†A), E(B†B)]]`. -/
-lemma ampliated_block_matrix_posSemidef (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
-    (A B : Mat) :
+lemma ampliated_block_matrix_posSemidef
+    (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E) (A B : MatIn) :
     (Matrix.fromBlocks (E (Aᴴ * A)) (E (Aᴴ * B)) (E (Bᴴ * A)) (E (Bᴴ * B)) :
       Matrix (n ⊕ n) (n ⊕ n) ℂ).PosSemidef := by
-  let P : Matrix (n ⊕ n) (n ⊕ n) ℂ :=
+  let P : Matrix (m ⊕ m) (m ⊕ m) ℂ :=
     Matrix.fromBlocks (Aᴴ * A) (Aᴴ * B) (Bᴴ * A) (Bᴴ * B)
   have hP : P.PosSemidef := blockMatrix_CtC_posSemidef A B
-  let e : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
-  let P' : Matrix (n × Fin 2) (n × Fin 2) ℂ := Matrix.reindex e.symm e.symm P
+  let eIn : m × Fin 2 ≃ m ⊕ m := finTwoSumEquiv m
+  let P' : Matrix (m × Fin 2) (m × Fin 2) ℂ := Matrix.reindex eIn.symm eIn.symm P
   have hP' : P'.PosSemidef := by
-    simpa [P', Matrix.reindex_apply] using hP.submatrix e
+    simpa [P', Matrix.reindex_apply] using hP.submatrix eIn
   have hY' := h2pos P' hP'
   set Y : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
     Matrix.of fun (ip : n × Fin 2) (jq : n × Fin 2) =>
       (E (Matrix.of fun i j => P' (i, ip.2) (j, jq.2))) ip.1 jq.1
     with hY_def
   have hY_psd : Y.PosSemidef := hY'
-  let Q : Matrix (n ⊕ n) (n ⊕ n) ℂ := Matrix.reindex e e Y
+  let eOut : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
+  let Q : Matrix (n ⊕ n) (n ⊕ n) ℂ := Matrix.reindex eOut eOut Y
   have hQ_psd : Q.PosSemidef := by
-    have hsub := hY_psd.submatrix e.symm
+    have hsub := hY_psd.submatrix eOut.symm
     simpa [Q, Matrix.reindex_apply, Matrix.submatrix_apply] using hsub
   have hP'Block (p q : Fin 2) :
       Matrix.of (fun i j => P' (i, p) (j, q)) =
@@ -94,21 +97,22 @@ lemma ampliated_block_matrix_posSemidef (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2Po
         | 1, 0 => Bᴴ * A
         | 1, 1 => Bᴴ * B := by
     fin_cases p <;> fin_cases q <;>
-      ext i j <;> simp [P', Matrix.reindex_apply, P, e, finTwoSumEquiv, finTwoEquiv]
+      ext i j <;> simp [P', Matrix.reindex_apply, P, eIn, finTwoSumEquiv, finTwoEquiv]
   have hQ_eq : Q =
       Matrix.fromBlocks (E (Aᴴ * A)) (E (Aᴴ * B)) (E (Bᴴ * A)) (E (Bᴴ * B)) := by
     ext i j
     rcases i with (i | i) <;> rcases j with (j | j) <;>
-      simp [Q, Y, hP'Block, e, Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.of_apply]
+      simp [Q, Y, hP'Block, eOut, Matrix.reindex_apply, Matrix.submatrix_apply,
+        Matrix.of_apply]
   rw [hQ_eq] at hQ_psd
   exact hQ_psd
 
 /-! ### Real-valued auxiliary lemmas -/
 
 -- (Uses `linear_eq_zero_of_quadratic_nonneg` from AbstractMultiplicativeDomain)
-omit [DecidableEq n] in
+omit [DecidableEq m] [DecidableEq n] in
 /-- A complex number `z† A z` for a PSD matrix `A` is nonnegative. -/
-private lemma dotProduct_mulVec_nonneg_of_posSemidef_block {A C B : Mat}
+private lemma dotProduct_mulVec_nonneg_of_posSemidef_block {A C B : MatOut}
     (h : (Matrix.fromBlocks A C Cᴴ B : Matrix (n ⊕ n) (n ⊕ n) ℂ).PosSemidef)
     (z : n → ℂ) :
     0 ≤ star z ⬝ᵥ (A.mulVec z) := by
@@ -127,7 +131,7 @@ omit [DecidableEq n] in
 
 For M = [[A, B], [C, D]] and x = (v, w), we have
 x† M x = v†A v + v†B w + w†C v + w†D w. -/
-private lemma fromBlocks_quadratic_form {A B C D : Mat} (v w : n → ℂ) :
+private lemma fromBlocks_quadratic_form {A B C D : MatOut} (v w : n → ℂ) :
     star (Sum.elim v w) ⬝ᵥ ((Matrix.fromBlocks A B C D).mulVec (Sum.elim v w)) =
     star v ⬝ᵥ (A.mulVec v) + star v ⬝ᵥ (B.mulVec w) +
     star w ⬝ᵥ (C.mulVec v) + star w ⬝ᵥ (D.mulVec w) := by
@@ -157,7 +161,7 @@ and Schur complements): the kernel of the bottom-right block is contained in
 the kernel of the off-diagonal block. It is the Schur-complement fact
 underlying the range-inclusion and well-definedness steps of the two-variable
 Schwarz inequality. -/
-lemma ker_inclusion_of_fromBlocks_posSemidef {A C B : Mat}
+lemma ker_inclusion_of_fromBlocks_posSemidef {A C B : MatOut}
     (h : (Matrix.fromBlocks A C Cᴴ B : Matrix (n ⊕ n) (n ⊕ n) ℂ).PosSemidef)
     (y : n → ℂ) (hy : B.mulVec y = 0) : C.mulVec y = 0 := by
   set z := C.mulVec y with hz_def
@@ -262,7 +266,7 @@ satisfying `Bmat * w = CstarMat * v`, the quadratic form yields
 `v† Amat v ≥ v† Cmat w`.  When the block matrix is Hermitian (as it is when PSD),
 `CstarMat = Cmat†` and this specializes to Wolf's Schur complement
 characterization (Theorem 5.2). -/
-lemma schwarz_inequality_of_fromBlocks_posSemidef {Amat Cmat CstarMat Bmat : Mat}
+lemma schwarz_inequality_of_fromBlocks_posSemidef {Amat Cmat CstarMat Bmat : MatOut}
     (h : (Matrix.fromBlocks Amat Cmat CstarMat Bmat :
       Matrix (n ⊕ n) (n ⊕ n) ℂ).PosSemidef)
     (v w : n → ℂ) (hwB : Bmat.mulVec w = CstarMat.mulVec v) :
@@ -296,16 +300,18 @@ lemma schwarz_inequality_of_fromBlocks_posSemidef {Amat Cmat CstarMat Bmat : Mat
 
 /-! ### Main theorem -/
 
-omit [DecidableEq n] in
+omit [DecidableEq m] [DecidableEq n] in
 /-- **Two-variable operator Schwarz inequality** (Wolf, Theorem 5.3).
 
-For a 2-positive linear map `E` and all matrices `A, B`, for all vectors `v, w`
-with `E(B†B) w = E(B†A) v`, we have `v† E(A†A) v ≥ v† E(A†B) w`.
+For a 2-positive linear map `E : M_m(ℂ) → M_n(ℂ)`, matrices `A, B ∈ M_m(ℂ)`,
+and vectors `v, w ∈ ℂⁿ` with `E(B†B) w = E(B†A) v`, we have
+`v† E(A†A) v ≥ v† E(A†B) w`.
 
 This is the pseudoinverse-free formulation of Wolf's Eq. (5.4):
 `E(A†B) E(B†B)⁻¹ E(B†A) ≤ E(A†A)` where the inverse is taken on the range. -/
-theorem schwarz_two_variable (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
-    (A B : Mat) (v w : n → ℂ) (hw : (E (Bᴴ * B)).mulVec w = (E (Bᴴ * A)).mulVec v) :
+theorem schwarz_two_variable (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E)
+    (A B : MatIn) (v w : n → ℂ)
+    (hw : (E (Bᴴ * B)).mulVec w = (E (Bᴴ * A)).mulVec v) :
     star v ⬝ᵥ ((E (Aᴴ * A)).mulVec v) ≥ star v ⬝ᵥ ((E (Aᴴ * B)).mulVec w) := by
   have h_block_psd := ampliated_block_matrix_posSemidef E h2pos A B
   exact schwarz_inequality_of_fromBlocks_posSemidef h_block_psd v w hw

--- a/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
@@ -7,10 +7,10 @@ import TNLean.Channel.Schwarz.TwoVariable
 import TNLean.Channel.Schwarz.SchurComplement
 
 /-!
-# The equal-dimensional unconditional two-variable operator Schwarz inequality
+# The unconditional two-variable operator Schwarz inequality
 
-This file proves the equal-dimensional unconditional form of Wolf's Theorem 5.3
-(Eq. (5.4)):
+This file proves Wolf's Theorem 5.3 (Eq. (5.4)) for independent finite input
+and output matrix algebras:
 for a 2-positive map `E` and all `A, B`,
 `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, with the inverse taken on the
 range via the Moore–Penrose pseudoinverse `Douglas.pinv`.
@@ -26,12 +26,6 @@ than the `EuclideanSpace`/`PiLp` range-ker duality route that caused
 `whnf` timeouts (documented in
 `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`).
 
-**Scope restriction (equal dimensions):** Wolf states the theorem for
-$E:M_{d'}(\mathbb C)\to M_d(\mathbb C)$, while `Is2PositiveMap` currently
-describes only endomorphisms of one matrix algebra. The rectangular theorem
-remains unformalized. See
-`docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`.
-
 ## Main results
 
 * `ker_EBB_le_ker_EAB`: `ker(E(B†B)) ⊆ ker(E(A†B))`, the kernel-inclusion
@@ -40,8 +34,8 @@ remains unformalized. See
   `E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`, i.e. the range inclusion
   `ran E(B†A) ⊆ ran E(B†B)` in pseudoinverse form.
 * `schwarz_two_variable_unconditional`: the unconditional inequality
-  `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, the equal-dimensional
-  specialization of Wolf's Eq. (5.4), with no witness vector assumed to exist.
+  `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, Wolf's Eq. (5.4), with no
+  witness vector assumed to exist.
 
 ## References
 
@@ -57,28 +51,34 @@ open Matrix
 
 namespace SchwarzTwoVariable
 
-variable {D : ℕ}
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
 
-local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+local notation "MatIn" => Matrix m m ℂ
+local notation "MatOut" => Matrix n n ℂ
 
+omit [DecidableEq m] [Fintype n] [DecidableEq n] in
 /-- The conjugate-transpose identity `E(B†A) = E(A†B)†`, for a 2-positive
 (hence positive) map `E`. -/
-theorem map_EBA_eq_conjTranspose_EAB (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
-    (A B : Mat) : E (Bᴴ * A) = (E (Aᴴ * B))ᴴ := by
+theorem map_EBA_eq_conjTranspose_EAB
+    [Finite n] (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E) (A B : MatIn) :
+    E (Bᴴ * A) = (E (Aᴴ * B))ᴴ := by
   have hPos : IsPositiveMap E := h2pos.isPositiveMap
   rw [← hPos.map_conjTranspose (Aᴴ * B)]
   congr 1
   rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
 
+omit [DecidableEq m] [DecidableEq n] in
 /-- The kernel of `E(B†B)` is contained in the kernel of `E(A†B)`: this is
 the Schur-complement kernel-absorption clause of Theorem 5.2 applied to the
 ampliated `2×2` block matrix `[[E(A†A), E(A†B)], [E(B†A), E(B†B)]]`. -/
-theorem ker_EBB_le_ker_EAB (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E) (A B : Mat)
-    (y : Fin D → ℂ) (hy : (E (Bᴴ * B)).mulVec y = 0) : (E (Aᴴ * B)).mulVec y = 0 := by
+theorem ker_EBB_le_ker_EAB
+    (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E) (A B : MatIn)
+    (y : n → ℂ) (hy : (E (Bᴴ * B)).mulVec y = 0) : (E (Aᴴ * B)).mulVec y = 0 := by
   have h_psd := ampliated_block_matrix_posSemidef E h2pos A B
   rw [map_EBA_eq_conjTranspose_EAB E h2pos A B] at h_psd
   exact ker_inclusion_of_fromBlocks_posSemidef h_psd y hy
 
+omit [DecidableEq m] in
 /-- The pseudoinverse `Douglas.pinv (E(B†B))` is a genuine right-inverse
 witness for `E(B†A)` on the support of `E(B†B)`:
 `E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`.
@@ -88,11 +88,12 @@ unconditional Schwarz inequality, obtained from `ker_EBB_le_ker_EAB` via the
 support-projection absorption lemma
 `Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le` and the
 pseudoinverse identity `Douglas.pinv (E(B†B)) · E(B†B) = supportProj`. -/
-theorem EBB_mul_pinv_mul_EBA_eq (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E) (A B : Mat) :
+theorem EBB_mul_pinv_mul_EBA_eq
+    (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E) (A B : MatIn) :
     (E (Bᴴ * B)) * (Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)) = E (Bᴴ * A) := by
   have hPos : IsPositiveMap E := h2pos.isPositiveMap
   have hR : (E (Bᴴ * B)).PosSemidef := hPos _ (Matrix.posSemidef_conjTranspose_mul_self B)
-  have hker : ∀ y : Fin D → ℂ,
+  have hker : ∀ y : n → ℂ,
       (E (Bᴴ * B)).mulVec y = 0 → (E (Aᴴ * B)).mulVec y = 0 :=
     ker_EBB_le_ker_EAB E h2pos A B
   have habsorb : (E (Aᴴ * B)) * hR.isHermitian.supportProj = E (Aᴴ * B) :=
@@ -110,6 +111,7 @@ theorem EBB_mul_pinv_mul_EBA_eq (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMa
       _ = hR.isHermitian.supportProj * (E (Aᴴ * B))ᴴ := by rw [hpinv_eq]
       _ = (E (Aᴴ * B))ᴴ := habsorb'
 
+omit [DecidableEq m] in
 /-- **The unconditional two-variable operator Schwarz inequality**
 (Wolf, Theorem 5.3, Eq. (5.4)). For a 2-positive map `E` and all `A, B`:
 
@@ -120,16 +122,15 @@ with the inverse taken on the range via the Moore–Penrose pseudoinverse
 witness vector `w` is assumed to exist: the pseudoinverse witness
 `w = pinv(E(B†B)) · E(B†A) · v` is constructed explicitly for every `v`.
 
-**Scope restriction (equal dimensions):** Wolf allows a two-positive map
-$E:M_{d'}(\mathbb C)\to M_d(\mathbb C)$. This theorem treats $d'=d$ because
-`Is2PositiveMap` is presently defined only for endomorphisms. See
-`docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`. -/
-theorem schwarz_two_variable_unconditional (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
-    (A B : Mat) :
+Wolf, *Quantum Channels & Operations*, Theorem 5.3 and Eq. (5.4), allows
+independent input and output dimensions; the declaration below has the same
+generality. -/
+theorem schwarz_two_variable_unconditional
+    (E : MatIn →ₗ[ℂ] MatOut) (h2pos : Is2PositiveMap E) (A B : MatIn) :
     E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) ≤ E (Aᴴ * A) := by
   rw [Matrix.le_iff]
   refine Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg (fun v => ?_)
-  set w : Fin D → ℂ := (Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)).mulVec v with hw_def
+  set w : n → ℂ := (Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)).mulVec v with hw_def
   have hw : (E (Bᴴ * B)).mulVec w = (E (Bᴴ * A)).mulVec v := by
     rw [hw_def, Matrix.mulVec_mulVec, EBB_mul_pinv_mul_EBA_eq E h2pos A B]
   have hineq := schwarz_two_variable E h2pos A B v w hw

--- a/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
@@ -36,6 +36,9 @@ than the `EuclideanSpace`/`PiLp` range-ker duality route that caused
 * `schwarz_two_variable_unconditional`: the unconditional inequality
   `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, Wolf's Eq. (5.4), with no
   witness vector assumed to exist.
+* `schwarz_two_variable_unconditional_of_traceAdjointMap`: Wolf's theorem in
+  its stated trace-adjoint form, with `E = T*` and the reverse map `T`
+  two-positive.
 
 ## References
 
@@ -140,5 +143,31 @@ theorem schwarz_two_variable_unconditional
   rw [heq] at hineq
   rw [Matrix.sub_mulVec, dotProduct_sub]
   exact sub_nonneg.mpr hineq
+
+omit [DecidableEq m] in
+/-- **Wolf's trace-adjoint form of the two-variable Schwarz inequality**
+(Wolf, Theorem 5.3, Eq. (5.4)). Let
+`E : M_m(ℂ) → M_n(ℂ)` be the positive trace adjoint of
+`T : M_n(ℂ) → M_m(ℂ)`. If `T` is two-positive, then for all `A, B ∈ M_m(ℂ)`,
+
+`E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`.
+
+This declaration records Wolf's stated hypotheses explicitly. Rectangular
+two-positivity is invariant under the trace adjoint, so the result follows
+from `schwarz_two_variable_unconditional` applied to `E`.
+
+Wolf, *Quantum Channels & Operations*, Theorem 5.3 and Eq. (5.4),
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180--190. -/
+theorem schwarz_two_variable_unconditional_of_traceAdjointMap
+    (E : MatIn →ₗ[ℂ] MatOut) (T : MatOut →ₗ[ℂ] MatIn)
+    (hE : E = Matrix.traceAdjointMap T) (_hEpos : IsPositiveMap E)
+    (hT2pos : Is2PositiveMap T) (A B : MatIn) :
+    E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) ≤ E (Aᴴ * A) := by
+  have hE2pos : Is2PositiveMap E := by
+    change IsNPositiveMap 2 E
+    rw [hE]
+    change IsNPositiveMap 2 T at hT2pos
+    exact hT2pos.traceAdjointMap
+  exact schwarz_two_variable_unconditional E hE2pos A B
 
 end SchwarzTwoVariable

--- a/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
+++ b/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
@@ -126,9 +126,9 @@ duality used by the positive-retraction and fixed-point arguments.
     \lean{IsPositiveMap.traceAdjointMap}
     \leanok
     \uses{def:trace_pairing_adjoint, thm:psd_trace_pairing_self_dual}
-    If $E : \MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive, then its
+    If $E : \MN{D}\to\MN{D'}$ is positive, then its
     trace-pairing adjoint
-    $E^* : \MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
+    $E^* : \MN{D'}\to\MN{D}$ is positive.
 \end{theorem}
 
 \begin{proof}
@@ -156,9 +156,9 @@ duality used by the positive-retraction and fixed-point arguments.
     \lean{isPositiveMap_traceAdjointMap_iff}
     \leanok
     \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
-    A linear map $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive if and
+    A linear map $E:\MN{D}\to\MN{D'}$ is positive if and
     only if its trace-pairing adjoint
-    $E^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
+    $E^*:\MN{D'}\to\MN{D}$ is positive.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
+++ b/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
@@ -126,8 +126,9 @@ duality used by the positive-retraction and fixed-point arguments.
     \lean{IsPositiveMap.traceAdjointMap}
     \leanok
     \uses{def:trace_pairing_adjoint, thm:psd_trace_pairing_self_dual}
-    If $E : \MN{D}\to\MN{D}$ is positive, then its trace-pairing adjoint $E^*$
-    is positive.
+    If $E : \MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive, then its
+    trace-pairing adjoint
+    $E^* : \MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
 \end{theorem}
 
 \begin{proof}
@@ -155,8 +156,9 @@ duality used by the positive-retraction and fixed-point arguments.
     \lean{isPositiveMap_traceAdjointMap_iff}
     \leanok
     \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
-    A linear map is positive if and only if its trace-pairing adjoint is
-    positive.
+    A linear map $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive if and
+    only if its trace-pairing adjoint
+    $E^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -394,8 +394,9 @@ positivity.
     \lean{SchwarzTwoVariable.schwarz_two_variable}
     \leanok
     \uses{def:2positive_map}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map.
-    For every $A,B\in\MN{D}$ and all vectors $v,w$ such that
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$ and all vectors
+    $v,w\in\mathbb C^{D_{\rm out}}$ such that
     $E(B^\dagger B)\,w = E(B^\dagger A)\,v$, we have
     \begin{align}
         v^\dagger\,E(A^\dagger A)\,v
@@ -430,8 +431,8 @@ positivity.
     \lean{SchwarzTwoVariable.map_EBA_eq_conjTranspose_EAB}
     \leanok
     \uses{def:2positive_map}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(B^\dagger A) & = E(A^\dagger B)^\dagger.
         \notag
@@ -449,8 +450,9 @@ positivity.
     \lean{SchwarzTwoVariable.ker_EBB_le_ker_EAB}
     \leanok
     \uses{def:2positive_map, thm:map_EBA_eq_conjTranspose_EAB}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$, $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$.
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
+    $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -471,8 +473,8 @@ positivity.
     \lean{SchwarzTwoVariable.EBB_mul_pinv_mul_EBA_eq}
     \leanok
     \uses{def:2positive_map, def:pinv, thm:ker_EBB_le_ker_EAB}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(B^\dagger B)\bigl(E(B^\dagger B)^{+}E(B^\dagger A)\bigr)
          & = E(B^\dagger A).
@@ -493,17 +495,17 @@ positivity.
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
     \leanok
     \uses{def:2positive_map, def:pinv}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
-    $A,B\in\MN{D}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
+    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
          & \le E(A^\dagger A),
         \notag
     \end{align}
     where $(\cdot)^+$ is the Moore--Penrose pseudoinverse, i.e.\ the
-    inverse taken on the range. This is the equal-dimensional specialization
-    of \cite[Eq.~(5.4)]{Wolf2012Quantum}, unconditional: no vector is assumed
-    to exist. The cited theorem permits different input and output dimensions.
+    inverse taken on the range. This is \cite[Eq.~(5.4)]{Wolf2012Quantum},
+    with its independent input and output dimensions and without an assumed
+    witness vector.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -492,11 +492,13 @@ positivity.
 
 \begin{theorem}[Two-variable operator Schwarz inequality]
     \label{thm:two_variable_operator_schwarz}
-    \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
+    \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
     \leanok
     \uses{def:2positive_map, def:pinv}
-    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be a $2$-positive
-    complex-linear map. For every $A,B\in\MN{D_{\rm in}}$,
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be positive and suppose
+    that $E=T^*$ for a two-positive map
+    $T:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$. For every
+    $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
         E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
          & \le E(A^\dagger A),

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -494,7 +494,8 @@ positivity.
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
     \leanok
-    \uses{def:2positive_map, def:pinv}
+    \uses{def:2positive_map, def:pinv,
+        thm:k_positive_trace_pairing_adjoint}
     Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be positive and suppose
     that $E=T^*$ for a two-positive map
     $T:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$. For every
@@ -511,7 +512,13 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:two_variable_operator_schwarz_conditional, thm:EBB_mul_pinv_mul_EBA_eq}
+    \uses{lem:two_variable_operator_schwarz_conditional,
+        thm:EBB_mul_pinv_mul_EBA_eq,
+        thm:k_positive_trace_pairing_adjoint}
+    By trace-adjoint invariance of two-positivity
+    (Theorem~\ref{thm:k_positive_trace_pairing_adjoint}), $E=T^*$ is
+    two-positive. Hence the preceding conditional and range-inclusion
+    results apply to $E$ with its rectangular input and output dimensions.
     For every $v$, the vector $w = E(B^\dagger B)^{+}E(B^\dagger A)\,v$
     satisfies the side condition $E(B^\dagger B)\,w = E(B^\dagger A)\,v$ of
     the conditional lemma

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -490,11 +490,35 @@ positivity.
     support projection, the displayed identity follows.
 \end{proof}
 
+\begin{lemma}[Two-variable Schwarz inequality for a two-positive map]
+    \label{lem:two_variable_operator_schwarz_two_positive}
+    \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
+    \leanok
+    \uses{lem:two_variable_operator_schwarz_conditional,
+        thm:EBB_mul_pinv_mul_EBA_eq}
+    Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be two-positive. Then, for
+    every $A,B\in\MN{D_{\rm in}}$,
+    \begin{align}
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
+         & \le E(A^\dagger A).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The range inclusion gives
+    $E(B^\dagger B)E(B^\dagger B)^+E(B^\dagger A)=E(B^\dagger A)$.
+    Thus, for every vector $v$, the choice
+    $w=E(B^\dagger B)^+E(B^\dagger A)v$ satisfies the hypothesis of the
+    conditional inequality. Substitution gives the result.
+\end{proof}
+
 \begin{theorem}[Two-variable operator Schwarz inequality]
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
     \leanok
     \uses{def:2positive_map, def:pinv,
+        lem:two_variable_operator_schwarz_two_positive,
         thm:k_positive_trace_pairing_adjoint}
     Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be positive and suppose
     that $E=T^*$ for a two-positive map
@@ -512,26 +536,14 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:two_variable_operator_schwarz_conditional,
-        thm:EBB_mul_pinv_mul_EBA_eq,
+    \uses{lem:two_variable_operator_schwarz_two_positive,
         thm:k_positive_trace_pairing_adjoint}
     By trace-adjoint invariance of two-positivity
     (Theorem~\ref{thm:k_positive_trace_pairing_adjoint}), $E=T^*$ is
-    two-positive. Hence the preceding conditional and range-inclusion
-    results apply to $E$ with its rectangular input and output dimensions.
-    For every $v$, the vector $w = E(B^\dagger B)^{+}E(B^\dagger A)\,v$
-    satisfies the side condition $E(B^\dagger B)\,w = E(B^\dagger A)\,v$ of
-    the conditional lemma
-    (Lemma~\ref{lem:two_variable_operator_schwarz_conditional}): this is
-    exactly Lemma~\ref{thm:EBB_mul_pinv_mul_EBA_eq} evaluated at $v$. The
-    kernel inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$,
-    obtained from the ampliated PSD block matrix of the conditional
-    lemma's proof,
-    gives $\operatorname{ran}(E(B^\dagger A))\subseteq
-    \operatorname{ran}(E(B^\dagger B))$, so the pseudoinverse is a genuine
-    right-inverse witness for $E(B^\dagger A)$ on the support of
-    $E(B^\dagger B)$. Applying the conditional lemma with this $w$ for
-    every $v$ gives the displayed matrix inequality.
+    two-positive. Hence
+    Lemma~\ref{lem:two_variable_operator_schwarz_two_positive} applies to
+    $E$ with its rectangular input and output dimensions. The resulting
+    inequality is precisely the displayed conclusion.
 \end{proof}
 
 \begin{definition}[Per-$B$ Schwarz hypothesis]\label{def:has_schwarz_inequality_for}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -518,7 +518,8 @@ positivity.
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
     \leanok
-    \uses{def:2positive_map, def:pinv}
+    \uses{def:positive_map, def:2positive_map, def:pinv,
+        def:trace_pairing_adjoint}
     Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be positive and suppose
     that $E=T^*$ for a two-positive map
     $T:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$. For every
@@ -557,7 +558,7 @@ positivity.
         \notag
     \end{align}
     for every $A\in\MN{D}$. A $2$-positive map satisfies this for every
-    $B$ (Theorem~\ref{thm:two_variable_operator_schwarz}).
+    $B$ (Theorem~\ref{thm:two_variable_operator_schwarz_two_positive}).
 \end{definition}
 
 \begin{definition}[Equality-attaining set]\label{def:equality_attaining}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -490,12 +490,11 @@ positivity.
     support projection, the displayed identity follows.
 \end{proof}
 
-\begin{lemma}[Two-variable Schwarz inequality for a two-positive map]
-    \label{lem:two_variable_operator_schwarz_two_positive}
+\begin{theorem}[Two-variable Schwarz inequality for a two-positive map]
+    \label{thm:two_variable_operator_schwarz_two_positive}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
     \leanok
-    \uses{lem:two_variable_operator_schwarz_conditional,
-        thm:EBB_mul_pinv_mul_EBA_eq}
+    \uses{def:2positive_map, def:pinv}
     Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be two-positive. Then, for
     every $A,B\in\MN{D_{\rm in}}$,
     \begin{align}
@@ -503,9 +502,11 @@ positivity.
          & \le E(A^\dagger A).
         \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:two_variable_operator_schwarz_conditional,
+        thm:EBB_mul_pinv_mul_EBA_eq}
     The range inclusion gives
     $E(B^\dagger B)E(B^\dagger B)^+E(B^\dagger A)=E(B^\dagger A)$.
     Thus, for every vector $v$, the choice
@@ -517,9 +518,7 @@ positivity.
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional_of_traceAdjointMap}
     \leanok
-    \uses{def:2positive_map, def:pinv,
-        lem:two_variable_operator_schwarz_two_positive,
-        thm:k_positive_trace_pairing_adjoint}
+    \uses{def:2positive_map, def:pinv}
     Let $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ be positive and suppose
     that $E=T^*$ for a two-positive map
     $T:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$. For every
@@ -536,12 +535,12 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:two_variable_operator_schwarz_two_positive,
+    \uses{thm:two_variable_operator_schwarz_two_positive,
         thm:k_positive_trace_pairing_adjoint}
     By trace-adjoint invariance of two-positivity
     (Theorem~\ref{thm:k_positive_trace_pairing_adjoint}), $E=T^*$ is
     two-positive. Hence
-    Lemma~\ref{lem:two_variable_operator_schwarz_two_positive} applies to
+    Theorem~\ref{thm:two_variable_operator_schwarz_two_positive} applies to
     $E$ with its rectangular input and output dimensions. The resulting
     inequality is precisely the displayed conclusion.
 \end{proof}

--- a/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
@@ -84,9 +84,9 @@ range, or its adjoint's range, is commutative.
     \lean{IsPositiveMap.traceAdjointMap}
     \leanok
     \uses{def:positive_map, def:trace_pairing_adjoint}
-    If $T:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive, then its
+    If $T:\MN{D}\to\MN{D'}$ is positive, then its
     trace-pairing adjoint
-    $T^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
+    $T^*:\MN{D'}\to\MN{D}$ is positive.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_positive_maps.tex
@@ -84,7 +84,9 @@ range, or its adjoint's range, is commutative.
     \lean{IsPositiveMap.traceAdjointMap}
     \leanok
     \uses{def:positive_map, def:trace_pairing_adjoint}
-    If $T:\MD\to\MD$ is positive, so is $T^*$.
+    If $T:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is positive, then its
+    trace-pairing adjoint
+    $T^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is positive.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -752,8 +752,9 @@ Section~\ref{sec:app_positive_not_cp_k_positive_closure}.
     \leanok
     \uses{def:blockwise_ampliation, def:trace_pairing_adjoint,
         thm:trace_pairing_adjoint_identity}
-    For every linear map $E : \MN{D}\to\MN{D}$, the trace-pairing adjoint
-    commutes with ampliation:
+    For every linear map
+    $E : \MN{D_{\rm in}}\to\MN{D_{\rm out}}$, the trace-pairing adjoint
+    commutes with the rectangular ampliation:
     \begin{align}
         (E^{(k)})^*
          & =(E^*)^{(k)}.
@@ -763,8 +764,9 @@ Section~\ref{sec:app_positive_not_cp_k_positive_closure}.
 
 \begin{proof}
     \leanok
-    For block matrices write $\rho_{pq}$ and $X_{pq}$ for their
-    $\MN{D}$-valued blocks. Expanding the trace by blocks and applying
+    For block matrices write $\rho_{pq}\in\MN{D_{\rm out}}$ and
+    $X_{pq}\in\MN{D_{\rm in}}$ for their blocks. Expanding the trace by
+    blocks and applying
     (\ref{eq:schwarz_trace_adjoint_pairing}) gives
     \begin{align}
         \tr((E^*)^{(k)}(\rho)X)
@@ -783,7 +785,8 @@ Section~\ref{sec:app_positive_not_cp_k_positive_closure}.
     \leanok
     \uses{def:k_positive_map, thm:trace_pairing_adjoint_ampliation,
         thm:trace_pairing_adjoint_positive}
-    If $E$ is $k$-positive, then $E^*$ is $k$-positive.
+    If $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is $k$-positive, then
+    $E^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is $k$-positive.
 \end{theorem}
 
 \begin{proof}
@@ -800,8 +803,9 @@ Section~\ref{sec:app_positive_not_cp_k_positive_closure}.
     \leanok
     \uses{thm:k_positive_trace_pairing_adjoint,
         thm:trace_pairing_adjoint_involutive}
-    A linear map is $k$-positive if and only if its trace-pairing adjoint is
-    $k$-positive.
+    A linear map $E:\MN{D_{\rm in}}\to\MN{D_{\rm out}}$ is $k$-positive
+    if and only if its trace-pairing adjoint
+    $E^*:\MN{D_{\rm out}}\to\MN{D_{\rm in}}$ is $k$-positive.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -12,8 +12,10 @@ rank-$k$ projection forms of the same condition.
 \begin{definition}[$k$-positive map]\label{def:k_positive_map}
     \lean{IsNPositiveMap}
     \leanok
-    A linear map $E : \MN{D} \to \MN{D}$ is $k$-positive if
-    $E \otimes \id_{k}$ is positive on $\MN{D} \otimes \MN{k}$.
+    A linear map $E : \MN{D_{\rm in}} \to \MN{D_{\rm out}}$ is $k$-positive
+    if $E \otimes \id_{k}$ is positive from
+    $\MN{D_{\rm in}} \otimes \MN{k}$ to
+    $\MN{D_{\rm out}} \otimes \MN{k}$.
 \end{definition}
 
 \begin{definition}[Two-positive map]

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -90,7 +90,9 @@ rank-$k$ projection forms of the same condition.
 \begin{definition}[Blockwise ampliation]\label{def:blockwise_ampliation}
     \lean{nPositiveAmpliation}
     \leanok
-    For a linear map $E : \MN{D}\to\MN{D}$, its $k$-fold ampliation acts on
+    For a linear map $E : \MN{D_{\rm in}}\to\MN{D_{\rm out}}$, its $k$-fold
+    ampliation maps $\MN{D_{\rm in}}\otimes\MN{k}$ to
+    $\MN{D_{\rm out}}\otimes\MN{k}$ and acts on
     block matrices by
     \begin{align}
         E^{(k)}(X)_{(i,p),(j,q)}

--- a/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
+++ b/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
@@ -102,13 +102,16 @@ Since this holds for every $v$,
   ZR^+Z^\dagger &\leq P,
 \end{align}
 which is \eqref{eq:schwarz}.\footnote{Formal declaration:
-  \leanid{schwarz_two_variable_unconditional} in the namespace
+  \leanid{schwarz_two_variable_unconditional_of_traceAdjointMap} in the namespace
   \leanid{SchwarzTwoVariable}.}
 
 \section{Verdict}
 
 There is no remaining hypothesis or dimensional restriction relative to
-Wolf's statement.  The phrase ``inverse on the range'' is realized by the
+Wolf's statement.  The formal theorem records the positive map as the trace
+adjoint $E=T^*$ of a two-positive reverse-direction map $T$; rectangular
+two-positivity of $E$ follows from invariance under the trace adjoint.  The
+phrase ``inverse on the range'' is realized by the
 Moore--Penrose inverse, and the required range inclusion follows from
 support-projection absorption.  The earlier proposed use of an explicit
 Euclidean-space range--kernel duality is unnecessary.  Thus the former gap is

--- a/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
+++ b/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
@@ -29,11 +29,9 @@ source is
 \path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, lines
 180--190.
 
-The formal theorem proves the specialization $d'=d$ without an additional
-witness hypothesis.  The inverse on the range is represented by the
-Moore--Penrose inverse.  The argument below applies to arbitrary $d'$ and $d$;
-the remaining restriction comes from the present definition of two-positivity,
-which is stated only for endomorphisms of one matrix algebra.
+The formal theorem has the same independent input and output dimensions and
+does not assume an additional witness.  The inverse on the range is represented
+by the Moore--Penrose inverse.
 
 \section{The range inverse}
 
@@ -109,16 +107,11 @@ which is \eqref{eq:schwarz}.\footnote{Formal declaration:
 
 \section{Verdict}
 
-Within the equal-dimensional specialization $d'=d$, there is no remaining
-witness hypothesis: the phrase ``inverse on the range'' is realized by the
+There is no remaining hypothesis or dimensional restriction relative to
+Wolf's statement.  The phrase ``inverse on the range'' is realized by the
 Moore--Penrose inverse, and the required range inclusion follows from
 support-projection absorption.  The earlier proposed use of an explicit
-Euclidean-space range--kernel duality is unnecessary.
-
-Wolf's statement allows independent input and output dimensions.  Since the
-formal notion of two-positivity presently applies only to
-$E:M_D(\mathbb C)\to M_D(\mathbb C)$, that rectangular generality remains
-unformalized.  The classification is therefore a resolved range-witness gap
-together with an equal-dimensional scope restriction.
+Euclidean-space range--kernel duality is unnecessary.  Thus the former gap is
+resolved.
 
 \end{document}

--- a/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
+++ b/docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex
@@ -16,9 +16,11 @@
 
 \section{Source statement}
 
-Let $E\colon M_{d'}(\mathbb C)\to M_d(\mathbb C)$ be a two-positive linear
-map.  Theorem~5.3 of Wolf's \emph{Quantum Channels \& Operations: Guided
-Tour}, Chapter~5, asserts that for every $A,B\in M_{d'}(\mathbb C)$,
+Let $E=T^*\colon M_{d'}(\mathbb C)\to M_d(\mathbb C)$ be a positive linear
+map, where the reverse-direction map
+$T\colon M_d(\mathbb C)\to M_{d'}(\mathbb C)$ is two-positive.
+Theorem~5.3 of Wolf's \emph{Quantum Channels \& Operations: Guided Tour},
+Chapter~5, asserts that for every $A,B\in M_{d'}(\mathbb C)$,
 \begin{align}
   E(A^\dagger B)\,E(B^\dagger B)^{-1}\,E(B^\dagger A)
   &\leq E(A^\dagger A),
@@ -29,9 +31,10 @@ source is
 \path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, lines
 180--190.
 
-The formal theorem has the same independent input and output dimensions and
-does not assume an additional witness.  The inverse on the range is represented
-by the Moore--Penrose inverse.
+Rectangular two-positivity is invariant under the trace adjoint, so $E=T^*$
+is two-positive. The formal theorem records Wolf's hypotheses with the same
+independent input and output dimensions and does not assume an additional
+witness. The inverse on the range is represented by the Moore--Penrose inverse.
 
 \section{The range inverse}
 


### PR DESCRIPTION
## Summary

- generalize `IsNPositiveMap`, `Is2PositiveMap`, and their blockwise ampliation to maps between independent matrix algebras;
- prove the conditional and unconditional two-variable Schwarz inequalities for `E : Matrix m m ℂ →ₗ[ℂ] Matrix n n ℂ`;
- generalize the Moore–Penrose support identities needed by the range witness, while retaining every existing endomorphism use as a direct specialization;
- align the blueprint and the paper-gap note with the unrestricted dimensions in Wolf, Chapter 5, Theorem 5.3 and Eq. (5.4).

The proof still proceeds through the positive two-by-two block matrix, kernel inclusion, support-projection absorption, and the witness `E(B†B)⁺ E(B†A) v`. No invertibility or witness-existence hypothesis is introduced.

## Validation

- `lake build`
- focused build of `TNLean.Channel.Schwarz.TwoVariableUnconditional`
- `#print axioms` for the block-positivity, kernel, range-witness, and final theorems
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- rendered and visually inspected `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`

Closes LionSR/QICLean#358.