### PR TITLE
feat(Channel/Schwarz): prove pseudoinverse Schur equivalence

### DIFF
--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -153,9 +153,10 @@ theorem mul_supportProj_self (hA : A.IsHermitian) : A * hA.supportProj = A := by
 matrix \(B\), then the support projection of \(A\) absorbs \(B\) on the
 right. -/
 theorem mul_supportProj_eq_self_of_mulVec_kernel_le
-    (hA : A.IsHermitian) {B : Matrix n n ℂ}
+    {m : Type*} [Finite m] (hA : A.IsHermitian) {B : Matrix m n ℂ}
     (hker : ∀ v : n → ℂ, A *ᵥ v = 0 → B *ᵥ v = 0) :
     B * hA.supportProj = B := by
+  let := Fintype.ofFinite m
   have hAcomp : A * (1 - hA.supportProj) = 0 := by
     rw [Matrix.mul_sub, Matrix.mul_one, hA.mul_supportProj_self, sub_self]
   have hBcomp : B * (1 - hA.supportProj) = 0 := by

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -21,15 +21,15 @@ Working towards Wolf's Theorem 5.2: for a self-adjoint 2×2 block matrix
 
 * `ker_subset_of_block_psd` : the kernel-inclusion half of (1) ⟹ (2)
 * `block_quadratic_form` : the quadratic-form expansion of the block matrix
+* `blockMatrix_posSemidef_iff` : the equivalence of the block positivity and
+  pseudoinverse Schur-complement conditions in Wolf's Theorem 5.2
 * `R_mul_pinv_eq_supportProj`, `pinv_mul_self_eq_supportProj`,
   `supportProj_mul_pinv_eq_pinv`, `pinv_isHermitian` : pseudoinverse algebra for
   PSD `R`, building on the general `Matrix.PosSemidef.supportProj_sq_eq_supportProj`
 
 ## Remaining gap towards Wolf Thm 5.2
 
-The Schur-complement-PSD half of (1) ⟹ (2) (quadratic-form minimisation with
-`y = -R⁺Q†x`), the converse (2) ⟹ (1) (completing the square), and the
-contraction equivalence (2) ⇔ (3) are not formalized here; see
+The contraction equivalence (2) ⇔ (3) is not yet formalized; see
 `docs/paper-gaps/schur_complement_tfae.tex`.
 
 ## Implementation notes
@@ -202,5 +202,105 @@ theorem supportProj_mul_pinv_eq_pinv (R : Matrix (Fin D₂) (Fin D₂) ℂ)
         rw [Douglas.pinv, Matrix.mul_assoc]
     _ = Rᴴ * (Matrix.posSemidef_self_mul_conjTranspose R).supportInv := by rw [key]
     _ = Douglas.pinv R := by rw [Douglas.pinv]
+
+/-! ### Pseudoinverse Schur-complement equivalence -/
+
+/-- Completing the square for a block quadratic form using the pseudoinverse
+of its lower-right block.
+
+This is the quadratic identity underlying conditions (1) and (2) of Wolf,
+*Quantum Channels & Operations*, Theorem 5.2; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 103--118. -/
+theorem schur_complement_quadratic_form
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hR : R.PosSemidef)
+    (hker : ∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0)
+    (x : Fin D₁ → ℂ) (y : Fin D₂ → ℂ) :
+    (star (Sum.elim x y)) ᵥ* (blockMatrix P Q R) ⬝ᵥ (Sum.elim x y) =
+      (star ((Douglas.pinv R * Qᴴ) *ᵥ x + y)) ᵥ* R ⬝ᵥ
+        ((Douglas.pinv R * Qᴴ) *ᵥ x + y) +
+      (star x) ᵥ* (schurComplement P Q R) ⬝ᵥ x := by
+  classical
+  have hQ : Q * hR.supportProj = Q :=
+    hR.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  have hQH : hR.supportProj * Qᴴ = Qᴴ := by
+    have h := congrArg Matrix.conjTranspose hQ
+    simpa [Matrix.conjTranspose_mul, hR.supportProj_isHermitian.eq] using h
+  have hKR : Douglas.pinv R * R = hR.supportProj :=
+    pinv_mul_self_eq_supportProj R hR
+  have hRK : R * Douglas.pinv R = hR.supportProj :=
+    R_mul_pinv_eq_supportProj R hR
+  have hRQ : R * (Douglas.pinv R * Qᴴ) = Qᴴ := by
+    calc
+      R * (Douglas.pinv R * Qᴴ) = (R * Douglas.pinv R) * Qᴴ :=
+        (Matrix.mul_assoc _ _ _).symm
+      _ = hR.supportProj * Qᴴ := by rw [hRK]
+      _ = Qᴴ := hQH
+  simp [blockMatrix, schurComplement, Function.star_sumElim, vecMul_fromBlocks,
+    add_vecMul, dotProduct_mulVec, vecMul_sub, Matrix.mul_assoc,
+    (pinv_isHermitian R hR).eq, star_mulVec, hQ, hKR, hRQ]
+  abel
+
+/-- Positivity of a block matrix implies positivity of its pseudoinverse Schur
+complement.
+
+This is the Schur-complement part of (1) implies (2) in Wolf, *Quantum
+Channels & Operations*, Theorem 5.2; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 103--118. -/
+theorem schurComplement_posSemidef_of_blockMatrix_posSemidef
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef)
+    (hM : (blockMatrix P Q R).PosSemidef) :
+    (schurComplement P Q R).PosSemidef := by
+  have hker := ker_subset_of_block_psd P Q R hM
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ fun x => ?_
+  · exact hP.isHermitian.sub
+      (Matrix.isHermitian_mul_mul_conjTranspose Q (pinv_isHermitian R hR))
+  have hnonneg := hM.dotProduct_mulVec_nonneg
+    (Sum.elim x (-((Douglas.pinv R * Qᴴ) *ᵥ x)))
+  rw [dotProduct_mulVec, schur_complement_quadratic_form P Q R hR hker] at hnonneg
+  simpa [← dotProduct_mulVec] using hnonneg
+
+/-- The kernel and pseudoinverse Schur-complement conditions imply positivity
+of the block matrix.
+
+This is (2) implies (1) in Wolf, *Quantum Channels & Operations*, Theorem 5.2;
+see `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 103--118. -/
+theorem blockMatrix_posSemidef_of_schurComplement_posSemidef
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef)
+    (hker : ∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0)
+    (hS : (schurComplement P Q R).PosSemidef) :
+    (blockMatrix P Q R).PosSemidef := by
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg
+    (blockMatrix_isHermitian P Q R hP.isHermitian hR.isHermitian) fun z => ?_
+  rw [dotProduct_mulVec, ← Sum.elim_comp_inl_inr z,
+    schur_complement_quadratic_form P Q R hR hker]
+  exact add_nonneg
+    (by simpa only [dotProduct_mulVec] using (hR.dotProduct_mulVec_nonneg
+      ((Douglas.pinv R * Qᴴ) *ᵥ (z ∘ Sum.inl) + z ∘ Sum.inr)))
+    (by simpa only [dotProduct_mulVec] using
+      (hS.dotProduct_mulVec_nonneg (z ∘ Sum.inl)))
+
+/-- A block matrix is positive semidefinite if and only if the kernel of its
+lower-right block is contained in the kernel of the off-diagonal block and its
+pseudoinverse Schur complement is positive semidefinite.
+
+This is the equivalence of conditions (1) and (2) in Wolf, *Quantum Channels &
+Operations*, Theorem 5.2; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 103--118. -/
+theorem blockMatrix_posSemidef_iff
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef) :
+    (blockMatrix P Q R).PosSemidef ↔
+      (∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0) ∧
+        (schurComplement P Q R).PosSemidef := by
+  constructor
+  · intro hM
+    exact ⟨ker_subset_of_block_psd P Q R hM,
+      schurComplement_posSemidef_of_blockMatrix_posSemidef P Q R hP hR hM⟩
+  · rintro ⟨hker, hS⟩
+    exact blockMatrix_posSemidef_of_schurComplement_posSemidef
+      P Q R hP hR hker hS
 
 end SchurComplement

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -15,7 +15,11 @@ Working towards Wolf's Theorem 5.2: for a self-adjoint 2×2 block matrix
 
 1. `M` is PSD
 2. `ker(R) ⊆ ker(Q)` and the pseudoinverse Schur complement `P − Q·R⁺·Q†` is PSD
-3. `ker(R) ⊆ ker(Q)` and `‖P^{-1/2}·Q·R^{-1/2}‖ ≤ 1` (contraction form)
+3. `ker(R) ⊆ ker(Q)`, `ker(P) ⊆ ker(Q†)`, and
+   `‖P^{-1/2}·Q·R^{-1/2}‖ ≤ 1` (corrected contraction form)
+
+Wolf's printed condition (3) omits the left-support condition. The omission is
+substantive when `P` is singular: `P = 0`, `Q = R = 1` is a counterexample.
 
 ## Main results
 
@@ -29,8 +33,8 @@ Working towards Wolf's Theorem 5.2: for a self-adjoint 2×2 block matrix
 
 ## Remaining gap towards Wolf Thm 5.2
 
-The contraction equivalence (2) ⇔ (3) is not yet formalized; see
-`docs/paper-gaps/schur_complement_tfae.tex`.
+The corrected contraction equivalence (2) ⇔ (3), with both support conditions,
+is not yet formalized; see `docs/paper-gaps/schur_complement_tfae.tex`.
 
 ## Implementation notes
 

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -1,5 +1,19 @@
 \section{Douglas Factorization}\label{sec:douglas}
 
+\begin{definition}[Support projection of a Hermitian matrix]
+  \label{def:hermitian_support_projection}
+  \lean{Matrix.IsHermitian.supportProj,
+    Matrix.IsHermitian.supportProj_isHermitian,
+    Matrix.IsHermitian.mul_supportProj_self}
+  \leanok
+  Let $A$ be Hermitian, with spectral decomposition
+  $A=U\diag(\lambda_i)U^\dagger$. Its support projection is
+  \begin{align}
+    P_A=U\diag(\mathbf 1_{\lambda_i\ne 0})U^\dagger,
+  \end{align}
+  the orthogonal projection onto the range of $A$.
+\end{definition}
+
 \begin{theorem}[Douglas factorisation]\label{thm:douglas_tfae}
   \lean{Douglas.douglas_tfae}
   \uses{def:pinv, lem:mul_pinv_eq_supportProj}
@@ -23,7 +37,7 @@
 \begin{lemma}[Pseudoinverse-factorization identity]\label{lem:mul_pinv_eq_supportProj}
   \lean{Douglas.mul_pinv_eq_supportProj}
   \leanok
-  \uses{def:pinv}
+  \uses{def:pinv, def:hermitian_support_projection}
   $B \cdot B^+ = P_{\mathrm{supp}}(B B^\dagger)$,
   where $P_{\mathrm{supp}}(X)$ denotes the support projection of $X$
   (the orthogonal projection onto the range of $X$).

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -39,6 +39,20 @@
   $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$ is Hermitian.
 \end{lemma}
 
+\begin{theorem}[Quadratic form of the block matrix]
+  \label{thm:block_quadratic_form}
+  \lean{SchurComplement.block_quadratic_form}
+  \leanok
+  \uses{def:blockMatrix}
+  For vectors $x\in\mathbb C^{D_1}$ and $y\in\mathbb C^{D_2}$,
+  \begin{align}
+    \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
+      \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
+      \begin{pmatrix}x\\y\end{pmatrix}
+    =x^\dagger P x+x^\dagger Qy+y^\dagger Q^\dagger x+y^\dagger Ry.
+  \end{align}
+\end{theorem}
+
 \begin{definition}[Schur complement]\label{def:schurComplement}
   \lean{SchurComplement.schurComplement}
   \leanok
@@ -55,6 +69,13 @@
   $Q\operatorname{supp}(R)=Q$.
 \end{theorem}
 
+\begin{proof}\leanok
+  Since $R(1-\operatorname{supp}(R))=0$, the kernel inclusion gives
+  $Q(1-\operatorname{supp}(R))=0$. Expanding this equality yields
+  $Q-Q\operatorname{supp}(R)=0$, and hence
+  $Q\operatorname{supp}(R)=Q$.
+\end{proof}
+
 \begin{theorem}[Pseudoinverse support identities]
   \label{thm:schur_pinv_support_identities}
   \lean{SchurComplement.R_mul_pinv_eq_supportProj}
@@ -64,7 +85,8 @@
   \leanok
   \uses{def:pinv}
   If $R$ is positive semi-definite, then
-  $RR^+=R^+R=\operatorname{supp}(R)$ and $R^+$ is Hermitian.
+  $RR^+=R^+R=\operatorname{supp}(R)$,
+  $\operatorname{supp}(R)R^+=R^+$, and $R^+$ is Hermitian.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -83,6 +105,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:block_quadratic_form}
   A vector in $\ker(R)$ has zero quadratic form in the lower-right principal
   subspace. Positivity therefore places the corresponding block vector in
   the kernel of the full matrix, whose upper component is $Qy$.
@@ -125,8 +148,7 @@
 
 \begin{proof}\leanok
   \uses{thm:block_psd_kernel_inclusion,
-    thm:schur_complement_quadratic_form,
-    thm:schur_pinv_support_identities}
+    thm:schur_complement_quadratic_form}
   By Theorem~\ref{thm:block_psd_kernel_inclusion},
   $\ker(R)\subseteq\ker(Q)$. In
   Theorem~\ref{thm:schur_complement_quadratic_form}, take

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -4,17 +4,17 @@
   \notready
   \uses{def:schurComplement, def:blockMatrix}
   Let $P \in \MN{D_1}$, $R \in \MN{D_2}$ be positive semi-definite
-  and $Q \in \MN{D_1,D_2}$ such that $\ker(R) \subseteq \ker(Q)$.
-  Wolf's Theorem~5.2 states that the following are equivalent:
+  and let $Q \in \MN{D_1,D_2}$. Wolf's Theorem~5.2 states that the
+  following are equivalent:
   \begin{enumerate}
     \item The block matrix $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$ is PSD,
-    \item $P \ge Q R^+ Q^\dagger$ (pseudoinverse Schur complement),
-    \item $Q = P^{1/2} K R^{1/2}$ for a contraction $K$ with $\|K\|_\infty \le 1$.
+    \item $\ker(R) \subseteq \ker(Q)$ and
+      $P \ge Q R^+ Q^\dagger$,
+    \item $\ker(R) \subseteq \ker(Q)$ and
+      $\|P^{-1/2}Q R^{-1/2}\|_\infty \le 1$.
   \end{enumerate}
   Here $R^+$ denotes the pseudoinverse (inverse on the support) and the
-  square roots $P^{1/2}, R^{1/2}$ are the positive semidefinite square roots,
-  with their inverses extended by zero on the kernel.
-% The proof is deferred (paper-gap schur_complement_tfae).
+  inverse square roots are extended by zero on the respective kernels.
 \end{theorem}
 
 \begin{definition}[Block matrix]\label{def:blockMatrix}
@@ -38,3 +38,139 @@
   \uses{def:pinv}
   The pseudoinverse Schur complement $P - Q R^+ Q^\dagger$.
 \end{definition}
+
+\begin{theorem}[Support absorption under kernel inclusion]
+  \label{thm:support_absorption_of_kernel_inclusion}
+  \lean{Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le}
+  \leanok
+  Let $R$ be Hermitian and let $Q$ be a matrix with the same column index
+  such that $\ker(R)\subseteq\ker(Q)$. Then
+  $Q\operatorname{supp}(R)=Q$.
+\end{theorem}
+
+\begin{theorem}[Pseudoinverse support identities]
+  \label{thm:schur_pinv_support_identities}
+  \lean{SchurComplement.R_mul_pinv_eq_supportProj}
+  \lean{SchurComplement.pinv_mul_self_eq_supportProj}
+  \lean{SchurComplement.supportProj_mul_pinv_eq_pinv}
+  \lean{SchurComplement.pinv_isHermitian}
+  \leanok
+  \uses{def:pinv}
+  If $R$ is positive semi-definite, then
+  $RR^+=R^+R=\operatorname{supp}(R)$ and $R^+$ is Hermitian.
+\end{theorem}
+
+\begin{proof}\leanok
+  These identities follow from the support inverse and the spectral calculus
+  of the Hermitian matrix $R$.
+\end{proof}
+
+\begin{theorem}[Kernel inclusion from block positivity]
+  \label{thm:block_psd_kernel_inclusion}
+  \lean{SchurComplement.ker_subset_of_block_psd}
+  \leanok
+  \uses{def:blockMatrix}
+  If $\begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}$ is positive
+  semi-definite, then $\ker(R)\subseteq\ker(Q)$.
+\end{theorem}
+
+\begin{proof}\leanok
+  A vector in $\ker(R)$ has zero quadratic form in the lower-right principal
+  subspace. Positivity therefore places the corresponding block vector in
+  the kernel of the full matrix, whose upper component is $Qy$.
+\end{proof}
+
+\begin{theorem}[Pseudoinverse completion of the square]
+  \label{thm:schur_complement_quadratic_form}
+  \lean{SchurComplement.schur_complement_quadratic_form}
+  \leanok
+  \uses{def:blockMatrix, def:schurComplement}
+  If $R$ is positive semi-definite and
+  $\ker(R)\subseteq\ker(Q)$, then
+  \begin{align}
+    \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
+      \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
+      \begin{pmatrix}x\\y\end{pmatrix}
+    &=(R^+Q^\dagger x+y)^\dagger R(R^+Q^\dagger x+y)
+      +x^\dagger(P-QR^+Q^\dagger)x.
+  \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:support_absorption_of_kernel_inclusion,
+    thm:schur_pinv_support_identities}
+  The kernel inclusion gives
+  $Q\operatorname{supp}(R)=Q$. Expanding the right-hand side and using
+  $RR^+=R^+R=\operatorname{supp}(R)$ and $(R^+)^\dagger=R^+$ yields the
+  four terms of the block quadratic form.
+\end{proof}
+
+\begin{theorem}[Schur-complement positivity from block positivity]
+  \label{thm:schur_complement_psd_of_block_psd}
+  \lean{SchurComplement.schurComplement_posSemidef_of_blockMatrix_posSemidef}
+  \leanok
+  \uses{def:blockMatrix, def:schurComplement}
+  If $P$ and $R$ are positive semi-definite and
+  $\begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}$ is positive
+  semi-definite, then $P-QR^+Q^\dagger$ is positive semi-definite.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:block_psd_kernel_inclusion,
+    thm:schur_complement_quadratic_form,
+    thm:schur_pinv_support_identities}
+  By Theorem~\ref{thm:block_psd_kernel_inclusion},
+  $\ker(R)\subseteq\ker(Q)$. In
+  Theorem~\ref{thm:schur_complement_quadratic_form}, take
+  $y=-R^+Q^\dagger x$. The completed-square term vanishes, and positivity of
+  the block matrix gives
+  $x^\dagger(P-QR^+Q^\dagger)x\ge 0$ for every $x$.
+\end{proof}
+
+\begin{theorem}[Block positivity from Schur-complement positivity]
+  \label{thm:block_psd_of_schur_complement_psd}
+  \lean{SchurComplement.blockMatrix_posSemidef_of_schurComplement_posSemidef}
+  \leanok
+  \uses{def:blockMatrix, def:schurComplement}
+  Suppose that $P$ and $R$ are positive semi-definite,
+  $\ker(R)\subseteq\ker(Q)$, and $P-QR^+Q^\dagger$ is positive
+  semi-definite. Then
+  $\begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}$ is positive
+  semi-definite.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{lem:blockMatrix_isHermitian,
+    thm:schur_complement_quadratic_form}
+  Theorem~\ref{thm:schur_complement_quadratic_form} writes every quadratic
+  form of the block matrix as the sum of quadratic forms of $R$ and of
+  $P-QR^+Q^\dagger$. Both are nonnegative.
+\end{proof}
+
+\begin{theorem}[Block positivity and the pseudoinverse Schur complement]
+  \label{thm:block_psd_iff_schur_complement_psd}
+  \lean{SchurComplement.blockMatrix_posSemidef_iff}
+  \leanok
+  \uses{def:blockMatrix, def:schurComplement}
+  Let $P$ and $R$ be positive semi-definite. Then
+  \begin{align}
+    \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}\ge 0
+    \quad\Longleftrightarrow\quad
+    \ker(R)\subseteq\ker(Q)
+    \ \text{and}\ P-QR^+Q^\dagger\ge 0.
+  \end{align}
+
+  \textbf{Scope restriction (Wolf Theorem 5.2, conditions (1) and (2)):}
+  This proves exactly the first two conditions of the source theorem. The
+  contraction condition (3) remains open, as recorded in
+  \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:block_psd_kernel_inclusion,
+    thm:schur_complement_psd_of_block_psd,
+    thm:block_psd_of_schur_complement_psd}
+  The forward implication combines kernel inclusion with positivity of the
+  Schur complement. The reverse implication is
+  Theorem~\ref{thm:block_psd_of_schur_complement_psd}.
+\end{proof}

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -53,6 +53,12 @@
   \end{align}
 \end{theorem}
 
+\begin{proof}\leanok
+  Multiplication by the block matrix sends $(x,y)$ to
+  $(Px+Qy,Q^\dagger x+Ry)$. Taking the inner product with $(x,y)$ and
+  distributing over both sums gives the four displayed terms.
+\end{proof}
+
 \begin{definition}[Schur complement]\label{def:schurComplement}
   \lean{SchurComplement.schurComplement}
   \leanok
@@ -148,7 +154,8 @@
 
 \begin{proof}\leanok
   \uses{thm:block_psd_kernel_inclusion,
-    thm:schur_complement_quadratic_form}
+    thm:schur_complement_quadratic_form,
+    thm:schur_pinv_support_identities}
   By Theorem~\ref{thm:block_psd_kernel_inclusion},
   $\ker(R)\subseteq\ker(Q)$. In
   Theorem~\ref{thm:schur_complement_quadratic_form}, take

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -15,6 +15,13 @@
   \end{enumerate}
   Here $R^+$ denotes the pseudoinverse (inverse on the support) and the
   inverse square roots are extended by zero on the respective kernels.
+
+  \textbf{Local fix (Wolf Theorem 5.2, condition (3)):}
+  The third condition is false as printed when $P$ is singular. For
+  $P=0$ and $Q=R=1$ in dimension one, the printed condition holds but the
+  block matrix is not positive semi-definite. The missing condition is
+  $\ker(P)\subseteq\ker(Q^\dagger)$; see
+  \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
 \end{theorem}
 
 \begin{definition}[Block matrix]\label{def:blockMatrix}
@@ -61,6 +68,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{lem:mul_pinv_eq_supportProj}
   These identities follow from the support inverse and the spectral calculus
   of the Hermitian matrix $R$.
 \end{proof}
@@ -162,7 +170,8 @@
 
   \textbf{Scope restriction (Wolf Theorem 5.2, conditions (1) and (2)):}
   This proves exactly the first two conditions of the source theorem. The
-  contraction condition (3) remains open, as recorded in
+  printed contraction condition (3) is false in the singular case; its
+  corrected form remains to be formalized, as recorded in
   \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -70,6 +70,7 @@
   \label{thm:support_absorption_of_kernel_inclusion}
   \lean{Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le}
   \leanok
+  \uses{def:hermitian_support_projection}
   Let $R$ be Hermitian and let $Q$ be a matrix with the same column index
   such that $\ker(R)\subseteq\ker(Q)$. Then
   $Q\operatorname{supp}(R)=Q$.
@@ -89,7 +90,7 @@
   \lean{SchurComplement.supportProj_mul_pinv_eq_pinv}
   \lean{SchurComplement.pinv_isHermitian}
   \leanok
-  \uses{def:pinv}
+  \uses{def:pinv, def:hermitian_support_projection}
   If $R$ is positive semi-definite, then
   $RR^+=R^+R=\operatorname{supp}(R)$,
   $\operatorname{supp}(R)R^+=R^+$, and $R^+$ is Hermitian.
@@ -97,8 +98,14 @@
 
 \begin{proof}\leanok
   \uses{lem:mul_pinv_eq_supportProj}
-  These identities follow from the support inverse and the spectral calculus
-  of the Hermitian matrix $R$.
+  The pseudoinverse-factorization identity, together with equality of the
+  supports of $R^2$ and $R$, gives $RR^+=\operatorname{supp}(R)$.
+  The spectral calculus shows that the support inverse of $R^2$ commutes with
+  $R$; the definition of $R^+$ then shows that $R^+$ is Hermitian. Taking
+  adjoints in the first identity gives
+  $R^+R=\operatorname{supp}(R)$. Finally, write $R=\sqrt R\sqrt R$.
+  The support projection absorbs $\sqrt R$, and the defining factorization of
+  $R^+$ therefore gives $\operatorname{supp}(R)R^+=R^+$.
 \end{proof}
 
 \begin{theorem}[Kernel inclusion from block positivity]
@@ -156,6 +163,8 @@
   \uses{thm:block_psd_kernel_inclusion,
     thm:schur_complement_quadratic_form,
     thm:schur_pinv_support_identities}
+  Since $P$ and $R^+$ are Hermitian, so are $QR^+Q^\dagger$ and
+  $P-QR^+Q^\dagger$.
   By Theorem~\ref{thm:block_psd_kernel_inclusion},
   $\ker(R)\subseteq\ker(Q)$. In
   Theorem~\ref{thm:schur_complement_quadratic_form}, take

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -810,21 +810,6 @@
     $\mathcal R_\sigma(X)$ does not change its value.
 \end{proof}
 
-\begin{definition}[Support projection of a Hermitian matrix]
-    \label{def:hermitian_support_projection}
-    \lean{Matrix.IsHermitian.supportProj,
-        Matrix.IsHermitian.supportProj_isHermitian,
-        Matrix.IsHermitian.mul_supportProj_self}
-    \leanok
-    Let $A$ be Hermitian, with spectral decomposition
-    $A=U\diag(\lambda_i)U^\dagger$. Its support projection is
-    \begin{align}
-        P_A
-        &=U\diag(\mathbf 1_{\lambda_i\ne 0})U^\dagger.
-        \label{eq:entropy_hermitian_support}
-    \end{align}
-\end{definition}
-
 \begin{theorem}[Support projection absorption under kernel inclusion]
     \label{thm:support_projection_absorption_kernel_inclusion}
     \lean{Matrix.IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -7,9 +7,9 @@
 
 \input{command}
 
-\title{Schur Complement TFAE --- Contraction Gap}
+\title{Schur Complement TFAE --- Missing Left-Support Condition}
 \author{}
-\date{2026-08-04}
+\date{2026-08-21}
 
 \begin{document}
 \maketitle
@@ -32,6 +32,19 @@ equivalent:
   \item $\ker(R) \subseteq \ker(Q)$ and
     $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
 \end{enumerate}
+
+The third condition is false as printed when $P$ is singular. Indeed, take
+$P=0$ and $Q=R=1$ in dimension one. Then
+$\ker(R)\subseteq\ker(Q)$ and the support inverse gives
+$P^{-1/2}QR^{-1/2}=0$, so the printed contraction bound holds. On the other
+hand,
+\begin{align}
+  \begin{pmatrix}1&-1\end{pmatrix}
+  \begin{pmatrix}0&1\\1&1\end{pmatrix}
+  \begin{pmatrix}1\\-1\end{pmatrix}=-1,
+\end{align}
+and hence the block matrix is not positive semi-definite. The missing
+left-support condition is $\ker(P)\subseteq\ker(Q^\dagger)$.
 
 \section{What is formalized}
 The objects entering the statement are formalised: the block matrix itself,
@@ -61,7 +74,8 @@ support absorption $Q\operatorname{supp}(R)=Q$ and the pseudoinverse identities
 $RR^+=R^+R=\operatorname{supp}(R)$ and $(R^+)^\dagger=R^+$.
 
 \section{What remains}
-It remains to prove (2)$\Longleftrightarrow$(3). Algebraic manipulation with
+It remains to formalize the corrected form of
+(2)$\Longleftrightarrow$(3), with both kernel inclusions. Algebraic manipulation with
 $P^{1/2}$ and $R^{1/2}$ identifies $P \ge Q R^{+} Q^\dagger$ with the contraction
 bound $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$. The reverse route uses the
 operator-norm characterization $\|L\| \le 1 \iff L L^\dagger \le I$ and the
@@ -69,8 +83,10 @@ support extensions of both inverse square roots. These operator-norm and
 support-factorization statements are not yet formalized in the required form.
 
 \section{Verdict}
-Wolf Theorem~5.2 is partially formalized: conditions (1) and (2) are proved
-equivalent without any additional hypothesis. Only the contraction equivalence
-(2)$\Longleftrightarrow$(3) remains open, tracked in \ghissue{5501}.
+Conditions (1) and (2) of Wolf Theorem~5.2 are formalized without any
+additional hypothesis. Condition (3) is false as printed; the counterexample
+above is decisive. Formalization of the counterexample and of the corrected
+contraction equivalence, with $\ker(P)\subseteq\ker(Q^\dagger)$ adjoined, is
+tracked in \ghissue{5501}.
 
 \end{document}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Schur Complement TFAE --- Open Gap}
+\title{Schur Complement TFAE --- Contraction Gap}
 \author{}
 \date{2026-08-04}
 
@@ -40,42 +40,37 @@ Schur complement $P - Q R^{+} Q^\dagger$.\footnote{Formal declarations:
 \leanid{SchurComplement.blockMatrix}, \leanid{SchurComplement.blockMatrix_isHermitian},
 and \leanid{SchurComplement.schurComplement} in
 \doclink{TNLean/Channel/Schwarz/SchurComplement}.}
-The kernel-inclusion half of (1)$\Rightarrow$(2) is proved: if the block matrix
-is PSD then $\ker(R) \subseteq \ker(Q)$.\footnote{Formal declaration:
-\leanid{SchurComplement.ker_subset_of_block_psd}.} The proof uses the
-quadratic-form expansion of the block
-matrix\footnote{\leanid{SchurComplement.block_quadratic_form}.}
-together with the pseudoinverse/support-projection algebra for PSD $R$: $R R^{+} = R^{+}R
-= \operatorname{supportProj}(R)$, $\operatorname{supportProj}(R)\,R^{+} = R^{+}$, $R^{+}$
-is Hermitian, and $R^2$ has the same support projection as $R$.\footnote{Formal
-declarations: \leanid{SchurComplement.R_mul_pinv_eq_supportProj},
-\leanid{SchurComplement.pinv_mul_self_eq_supportProj},
-\leanid{SchurComplement.supportProj_mul_pinv_eq_pinv},
-\leanid{SchurComplement.pinv_isHermitian}, and
-\leanid{SchurComplement.supportProj_sq_eq_supportProj}.}
+Conditions (1) and (2) are equivalent with the source's exact hypotheses:
+the block matrix is PSD if and only if $\ker(R)\subseteq\ker(Q)$ and
+$P-QR^+Q^\dagger$ is PSD.\footnote{Formal declaration:
+\leanid{SchurComplement.blockMatrix_posSemidef_iff}.}
+The forward implication combines the kernel inclusion
+\leanid{SchurComplement.ker_subset_of_block_psd} with quadratic-form
+minimisation at $y=-R^+Q^\dagger x$. The reverse implication uses the completed
+square
+\begin{align}
+  \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
+  \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
+  \begin{pmatrix}x\\y\end{pmatrix}
+  &=(R^+Q^\dagger x+y)^\dagger R(R^+Q^\dagger x+y)
+    +x^\dagger(P-QR^+Q^\dagger)x.
+\end{align}
+This identity is formalized as
+\leanid{SchurComplement.schur_complement_quadratic_form}. It rests on the
+support absorption $Q\operatorname{supp}(R)=Q$ and the pseudoinverse identities
+$RR^+=R^+R=\operatorname{supp}(R)$ and $(R^+)^\dagger=R^+$.
 
 \section{What remains}
-The standard argument has three steps, of which only the kernel-inclusion part
-of the first is formalized:
-\begin{enumerate}
-  \item[(1)$\Rightarrow$(2), Schur half] Quadratic-form minimisation: for the block matrix
-    $\bigl[\begin{smallmatrix} P & Q \\ Q^\dagger & R \end{smallmatrix}\bigr]$,
-    the optimal choice $y = -R^{+} Q^\dagger x$ gives
-    $x^\dagger (P - Q R^{+} Q^\dagger) x \ge 0$ for all~$x$. Not formalized.
-  \item[(2)$\Rightarrow$(1)] Completing the square using $\ker(R) \subseteq \ker(Q)$
-    and $P \ge Q R^{+} Q^\dagger$ to exhibit the block matrix as PSD. Not formalized.
-  \item[(2)$\Rightarrow$(3) and (3)$\Rightarrow$(1)] Algebraic manipulation with
-    $P^{1/2}$ and $R^{1/2}$ identifies $P \ge Q R^{+} Q^\dagger$ with the contraction
-    bound $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$, and the operator-norm characterisation
-    $\|L\| \le 1 \iff L L^\dagger \le I$ recovers the block PSD decomposition via
-    $K = P^{-1/2} Q R^{-1/2}$. Not formalized; requires additional operator-norm lemmas.
-\end{enumerate}
+It remains to prove (2)$\Longleftrightarrow$(3). Algebraic manipulation with
+$P^{1/2}$ and $R^{1/2}$ identifies $P \ge Q R^{+} Q^\dagger$ with the contraction
+bound $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$. The reverse route uses the
+operator-norm characterization $\|L\| \le 1 \iff L L^\dagger \le I$ and the
+support extensions of both inverse square roots. These operator-norm and
+support-factorization statements are not yet formalized in the required form.
 
 \section{Verdict}
-Wolf Theorem~5.2 is an \emph{open gap}: only the kernel-inclusion half of
-(1)$\Rightarrow$(2), together with the pseudoinverse/support-projection algebra
-it depends on, is formalized. The Schur-complement-PSD half of (1)$\Rightarrow$(2),
-the converse (2)$\Rightarrow$(1), and the contraction equivalence
-(2)$\Longleftrightarrow$(3) remain open, tracked in \ghissue{5511}.
+Wolf Theorem~5.2 is partially formalized: conditions (1) and (2) are proved
+equivalent without any additional hypothesis. Only the contraction equivalence
+(2)$\Longleftrightarrow$(3) remains open, tracked in \ghissue{5501}.
 
 \end{document}


### PR DESCRIPTION
## Summary

This proves the equivalence of conditions (1) and (2) in Wolf, *Quantum Channels & Operations*, Theorem 5.2, with the source’s exact hypotheses:

- block positivity implies both the kernel inclusion and positivity of the pseudoinverse Schur complement;
- the kernel inclusion and Schur-complement positivity imply block positivity;
- the central identity is a completed square using the pseudoinverse on the support.

The support-absorption lemma is generalized to rectangular off-diagonal matrices. The blueprint, module account, and paper-gap note also record a defect in Wolf’s printed condition (3): for singular `P`, it lacks the necessary left-support condition `ker(P) ⊆ ker(Q†)`. The scalar counterexample and corrected contraction equivalence are treated in LionSR/QICLean#277.

## Verification

- `lake build TNLean.Algebra.PosSemidefSupport TNLean.Channel.Schwarz.SchurComplement`
- `lake exe lint_style TNLean/Algebra/PosSemidefSupport.lean TNLean/Channel/Schwarz/SchurComplement.lean`
- reader-facing prose check
- bidirectional blueprint coverage check
- `git diff --check`
- `#print axioms` on the new results: only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Closes LionSR/QICLean#278.