### PR TITLE
fix(Channel/Schwarz): correct Wolf contraction criterion

### DIFF
--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -27,14 +27,19 @@ substantive when `P` is singular: `P = 0`, `Q = R = 1` is a counterexample.
 * `block_quadratic_form` : the quadratic-form expansion of the block matrix
 * `blockMatrix_posSemidef_iff` : the equivalence of the block positivity and
   pseudoinverse Schur-complement conditions in Wolf's Theorem 5.2
+* `blockMatrix_posSemidef_iff_contraction` : the corrected contraction
+  criterion with both support conditions
+* `wolf_condition_three_not_sufficient` : a scalar counterexample to the
+  contraction criterion as printed
 * `R_mul_pinv_eq_supportProj`, `pinv_mul_self_eq_supportProj`,
   `supportProj_mul_pinv_eq_pinv`, `pinv_isHermitian` : pseudoinverse algebra for
   PSD `R`, building on the general `Matrix.PosSemidef.supportProj_sq_eq_supportProj`
 
-## Remaining gap towards Wolf Thm 5.2
+## Source correction for Wolf Thm 5.2
 
-The corrected contraction equivalence (2) ⇔ (3), with both support conditions,
-is not yet formalized; see `docs/paper-gaps/schur_complement_tfae.tex`.
+Conditions (1) and (2) are equivalent as printed. Condition (3) becomes
+equivalent to them after adding `ker(P) ⊆ ker(Q†)`. The printed version is
+false; see `docs/paper-gaps/schur_complement_tfae.tex`.
 
 ## Implementation notes
 
@@ -207,6 +212,25 @@ theorem supportProj_mul_pinv_eq_pinv (R : Matrix (Fin D₂) (Fin D₂) ℂ)
     _ = Rᴴ * (Matrix.posSemidef_self_mul_conjTranspose R).supportInv := by rw [key]
     _ = Douglas.pinv R := by rw [Douglas.pinv]
 
+/-- On a positive-semidefinite matrix, the Moore--Penrose pseudoinverse agrees
+with the generalized inverse obtained by inverting on the support.
+
+This identifies the two inverse-on-the-support conventions in Wolf,
+*Quantum Channels & Operations*, Theorem 5.2; see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 114--116. -/
+theorem pinv_eq_supportInv (R : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hR : R.PosSemidef) :
+    Douglas.pinv R = hR.supportInv := by
+  have hInvR : hR.supportInv * R = hR.supportProj := hR.supportInv_mul_self
+  calc
+    Douglas.pinv R = hR.supportProj * Douglas.pinv R :=
+      (supportProj_mul_pinv_eq_pinv R hR).symm
+    _ = (hR.supportInv * R) * Douglas.pinv R :=
+      (congrArg (· * Douglas.pinv R) hInvR).symm
+    _ = hR.supportInv * (R * Douglas.pinv R) := Matrix.mul_assoc _ _ _
+    _ = hR.supportInv * hR.supportProj := by rw [R_mul_pinv_eq_supportProj R hR]
+    _ = hR.supportInv := hR.supportInv_mul_supportProj
+
 /-! ### Pseudoinverse Schur-complement equivalence -/
 
 /-- Completing the square for a block quadratic form using the pseudoinverse
@@ -306,5 +330,207 @@ theorem blockMatrix_posSemidef_iff
   · rintro ⟨hker, hS⟩
     exact blockMatrix_posSemidef_of_schurComplement_posSemidef
       P Q R hP hR hker hS
+
+/-! ### Corrected contraction criterion -/
+
+/-- The support-normalized off-diagonal block in the corrected contraction
+criterion for a positive block matrix.
+
+Wolf, *Quantum Channels & Operations*, Theorem 5.2, condition (3), uses this
+matrix; see `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116. -/
+noncomputable def schurContraction
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hP : P.PosSemidef) (hR : R.PosSemidef) :
+    Matrix (Fin D₁) (Fin D₂) ℂ :=
+  hP.supportInvSqrt * Q * hR.supportInvSqrt
+
+/-- The product of the support-normalized off-diagonal block with its adjoint
+is the support-normalized pseudoinverse Schur term.
+
+This is the algebraic identity used in Wolf, *Quantum Channels & Operations*,
+Theorem 5.2, conditions (2) and (3); see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 114--116. -/
+theorem schurContraction_mul_conjTranspose
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hP : P.PosSemidef) (hR : R.PosSemidef) :
+    schurContraction P Q R hP hR * (schurContraction P Q R hP hR)ᴴ =
+      hP.supportInvSqrt * (Q * Douglas.pinv R * Qᴴ) * hP.supportInvSqrt := by
+  rw [pinv_eq_supportInv R hR]
+  simp only [schurContraction, Matrix.conjTranspose_mul,
+    hP.supportInvSqrt_isHermitian.eq, hR.supportInvSqrt_isHermitian.eq,
+    Matrix.PosSemidef.supportInv]
+  simp only [Matrix.mul_assoc]
+
+/-- The pseudoinverse term in the Schur complement is positive semidefinite.
+
+This is the positive term compared with `P` in Wolf, *Quantum Channels &
+Operations*, Theorem 5.2, condition (2); see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 114--115. -/
+theorem schurTerm_posSemidef
+    (Q : Matrix (Fin D₁) (Fin D₂) ℂ) (R : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hR : R.PosSemidef) :
+    (Q * Douglas.pinv R * Qᴴ).PosSemidef := by
+  rw [pinv_eq_supportInv R hR]
+  simpa only [Matrix.conjTranspose_conjTranspose] using
+    hR.supportInv_posSemidef.conjTranspose_mul_mul_same Qᴴ
+
+/-- Schur-complement positivity forces the missing left-support condition on
+the off-diagonal block.
+
+This condition is implicit in condition (2) of Wolf, *Quantum Channels &
+Operations*, Theorem 5.2, but is absent from the printed condition (3); see
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 114--116. -/
+theorem ker_conjTranspose_subset_of_schurComplement_posSemidef
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (_hP : P.PosSemidef) (hR : R.PosSemidef)
+    (hkerR : ∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0)
+    (hS : (schurComplement P Q R).PosSemidef) :
+    ∀ v : Fin D₁ → ℂ, P *ᵥ v = 0 → Qᴴ *ᵥ v = 0 := by
+  let B := Q * Douglas.pinv R * Qᴴ
+  have hB : B.PosSemidef := schurTerm_posSemidef Q R hR
+  have hBS : B + schurComplement P Q R = P := by
+    simp only [B, schurComplement]
+    abel
+  have hQ : Q * hR.supportProj = Q :=
+    hR.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hkerR
+  have hQH : hR.supportProj * Qᴴ = Qᴴ := by
+    have h := congrArg Matrix.conjTranspose hQ
+    simpa [Matrix.conjTranspose_mul, hR.supportProj_isHermitian.eq] using h
+  intro v hv
+  have hvB : B *ᵥ v = 0 := by
+    apply hB.mulVec_eq_zero_left hS v
+    rw [hBS, hv]
+  let A := hR.supportInvSqrt * Qᴴ
+  have hBA : B = Aᴴ * A := by
+    dsimp only [B, A]
+    rw [pinv_eq_supportInv R hR]
+    simp only [Matrix.PosSemidef.supportInv, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose, hR.supportInvSqrt_isHermitian.eq,
+      Matrix.mul_assoc]
+  have hvA : A *ᵥ v = 0 := by
+    rw [hBA] at hvB
+    exact (Matrix.conjTranspose_mul_self_mulVec_eq_zero A v).mp hvB
+  have hz := congrArg
+    (fun w : Fin D₂ → ℂ ↦ hR.isHermitian.cfc Real.sqrt *ᵥ w) hvA
+  simpa only [A, Matrix.mulVec_mulVec, ← Matrix.mul_assoc,
+    hR.cfc_sqrt_mul_supportInvSqrt, hQH, Matrix.mulVec_zero] using hz
+
+/-- The pseudoinverse Schur complement is positive semidefinite exactly when
+the off-diagonal block obeys the left-support condition and its support
+normalization is a contraction.
+
+**Local fix (Wolf Theorem 5.2, condition (3)):** The printed condition (3) at
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116 omits
+`ker(P) ⊆ ker(Q†)`. Without this condition the implication to block positivity
+is false. The deviation and the scalar counterexample are recorded in
+`docs/paper-gaps/schur_complement_tfae.tex`. -/
+theorem schurComplement_posSemidef_iff_contraction
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef)
+    (hkerR : ∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0) :
+    (schurComplement P Q R).PosSemidef ↔
+      (∀ v : Fin D₁ → ℂ, P *ᵥ v = 0 → Qᴴ *ᵥ v = 0) ∧
+        ‖schurContraction P Q R hP hR‖ ≤ 1 := by
+  let B := Q * Douglas.pinv R * Qᴴ
+  let K := schurContraction P Q R hP hR
+  have hB : B.PosSemidef := schurTerm_posSemidef Q R hR
+  have hnorm :
+      ‖hP.supportInvSqrt * B * hP.supportInvSqrt‖ = ‖K‖ * ‖K‖ := by
+    calc
+      ‖hP.supportInvSqrt * B * hP.supportInvSqrt‖ = ‖K * Kᴴ‖ := by
+        apply congrArg norm
+        exact (schurContraction_mul_conjTranspose P Q R hP hR).symm
+      _ = ‖Kᴴᴴ * Kᴴ‖ := by rw [Matrix.conjTranspose_conjTranspose]
+      _ = ‖Kᴴ‖ * ‖Kᴴ‖ := Matrix.l2_opNorm_conjTranspose_mul_self Kᴴ
+      _ = ‖K‖ * ‖K‖ := by rw [Matrix.l2_opNorm_conjTranspose]
+  constructor
+  · intro hS
+    have hkerP := ker_conjTranspose_subset_of_schurComplement_posSemidef
+      P Q R hP hR hkerR hS
+    have hkerB : ∀ v : Fin D₁ → ℂ, P *ᵥ v = 0 → B *ᵥ v = 0 := by
+      intro v hv
+      dsimp only [B]
+      rw [Matrix.mul_assoc, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec,
+        hkerP v hv, Matrix.mulVec_zero, Matrix.mulVec_zero]
+    have hbound :=
+      (hP.sub_smul_posSemidef_iff hB one_pos hkerB).mp (by
+        simpa only [schurComplement, B, one_smul] using hS)
+    rw [one_mul, hnorm] at hbound
+    exact ⟨hkerP, by nlinarith [norm_nonneg K]⟩
+  · rintro ⟨hkerP, hK⟩
+    have hkerB : ∀ v : Fin D₁ → ℂ, P *ᵥ v = 0 → B *ᵥ v = 0 := by
+      intro v hv
+      dsimp only [B]
+      rw [Matrix.mul_assoc, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec,
+        hkerP v hv, Matrix.mulVec_zero, Matrix.mulVec_zero]
+    have hbound : 1 * ‖hP.supportInvSqrt * B * hP.supportInvSqrt‖ ≤ 1 := by
+      rw [one_mul, hnorm]
+      nlinarith [norm_nonneg K]
+    have hS := (hP.sub_smul_posSemidef_iff hB one_pos hkerB).mpr hbound
+    simpa only [schurComplement, B, one_smul] using hS
+
+/-- A positive block matrix is equivalent to the corrected singular
+contraction criterion, with support conditions on both sides of the
+off-diagonal block.
+
+**Local fix (Wolf Theorem 5.2, condition (3)):** The printed condition (3) at
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116 contains only
+the right-support condition. The left-support condition displayed here is
+necessary, as documented in `docs/paper-gaps/schur_complement_tfae.tex`. -/
+theorem blockMatrix_posSemidef_iff_contraction
+    (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef) :
+    (blockMatrix P Q R).PosSemidef ↔
+      (∀ v : Fin D₂ → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0) ∧
+      (∀ v : Fin D₁ → ℂ, P *ᵥ v = 0 → Qᴴ *ᵥ v = 0) ∧
+        ‖schurContraction P Q R hP hR‖ ≤ 1 := by
+  constructor
+  · intro hM
+    have hkerR := ker_subset_of_block_psd P Q R hM
+    have hS := schurComplement_posSemidef_of_blockMatrix_posSemidef
+      P Q R hP hR hM
+    exact ⟨hkerR, (schurComplement_posSemidef_iff_contraction
+      P Q R hP hR hkerR).mp hS⟩
+  · rintro ⟨hkerR, hkerP, hK⟩
+    have hS := (schurComplement_posSemidef_iff_contraction
+      P Q R hP hR hkerR).mpr ⟨hkerP, hK⟩
+    exact blockMatrix_posSemidef_of_schurComplement_posSemidef
+      P Q R hP hR hkerR hS
+
+/-- The contraction condition printed in Wolf's Theorem 5.2 does not imply
+block positivity in the singular case: take the scalar blocks
+`P = 0`, `Q = 1`, and `R = 1`.
+
+**Local fix (Wolf Theorem 5.2, condition (3)):** At
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 116, the printed
+condition lacks `ker(P) ⊆ ker(Q†)`. The normalized matrix is zero in this
+example, whereas the block quadratic form at `(1, -1)` equals `-1`. See
+`docs/paper-gaps/schur_complement_tfae.tex`. -/
+theorem wolf_condition_three_not_sufficient :
+    let P : Matrix (Fin 1) (Fin 1) ℂ := 0
+    let Q : Matrix (Fin 1) (Fin 1) ℂ := 1
+    let R : Matrix (Fin 1) (Fin 1) ℂ := 1
+    let hP : P.PosSemidef := Matrix.PosSemidef.zero
+    let hR : R.PosSemidef := Matrix.PosSemidef.one
+    (∀ v : Fin 1 → ℂ, R *ᵥ v = 0 → Q *ᵥ v = 0) ∧
+      ‖schurContraction P Q R hP hR‖ ≤ 1 ∧
+      ¬ (blockMatrix P Q R).PosSemidef := by
+  dsimp
+  refine ⟨?_, ?_, ?_⟩
+  · intro v hv
+    simpa using hv
+  · rw [schurContraction,
+      show (Matrix.PosSemidef.zero (n := Fin 1)).supportInvSqrt = 0 by
+      rw [Matrix.PosSemidef.supportInvSqrt,
+        ← Matrix.PosSemidef.zero.isHermitian.cfc_eq]
+      simp]
+    simp
+  · intro hM
+    have hnonneg := hM.dotProduct_mulVec_nonneg
+      (Sum.elim (1 : Fin 1 → ℂ) (-1 : Fin 1 → ℂ))
+    rw [block_quadratic_form] at hnonneg
+    norm_num [dotProduct, Matrix.mulVec, blockMatrix] at hnonneg
 
 end SchurComplement

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -66,20 +66,6 @@
   The pseudoinverse Schur complement $P - Q R^+ Q^\dagger$.
 \end{definition}
 
-\begin{theorem}[Block quadratic form]
-  \label{thm:block_quadratic_form}
-  \lean{SchurComplement.block_quadratic_form}
-  \leanok
-  \uses{def:blockMatrix}
-  For vectors $x$ and $y$,
-  \begin{align}
-    \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
-    \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
-    \begin{pmatrix}x\\y\end{pmatrix}
-    =x^\dagger Px+x^\dagger Qy+y^\dagger Q^\dagger x+y^\dagger Ry.
-  \end{align}
-\end{theorem}
-
 \begin{theorem}[Support absorption under kernel inclusion]
   \label{thm:support_absorption_of_kernel_inclusion}
   \lean{Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le}

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -1,6 +1,6 @@
 \section{Block Schur Complements}\label{sec:schur_complement}
 
-\begin{theorem}[Block Schur complement]\label{thm:schur_tfae}
+\begin{theorem}[Wolf's printed block Schur complement statement]\label{thm:schur_tfae}
   \notready
   \uses{def:schurComplement, def:blockMatrix}
   Let $P \in \MN{D_1}$, $R \in \MN{D_2}$ be positive semi-definite
@@ -17,10 +17,10 @@
   inverse square roots are extended by zero on the respective kernels.
 
   \textbf{Local fix (Wolf Theorem 5.2, condition (3)):}
-  The third condition is false as printed when $P$ is singular. For
-  $P=0$ and $Q=R=1$ in dimension one, the printed condition holds but the
-  block matrix is not positive semi-definite. The missing condition is
-  $\ker(P)\subseteq\ker(Q^\dagger)$; see
+  The third condition is false as printed when $P$ is singular. It becomes
+  equivalent to the first two after adjoining
+  $\ker(P)\subseteq\ker(Q^\dagger)$. The counterexample and corrected theorem
+  are recorded below and in
   \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
 \end{theorem}
 
@@ -65,6 +65,20 @@
   \uses{def:pinv}
   The pseudoinverse Schur complement $P - Q R^+ Q^\dagger$.
 \end{definition}
+
+\begin{theorem}[Block quadratic form]
+  \label{thm:block_quadratic_form}
+  \lean{SchurComplement.block_quadratic_form}
+  \leanok
+  \uses{def:blockMatrix}
+  For vectors $x$ and $y$,
+  \begin{align}
+    \begin{pmatrix}x\\y\end{pmatrix}^{\!\dagger}
+    \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}
+    \begin{pmatrix}x\\y\end{pmatrix}
+    =x^\dagger Px+x^\dagger Qy+y^\dagger Q^\dagger x+y^\dagger Ry.
+  \end{align}
+\end{theorem}
 
 \begin{theorem}[Support absorption under kernel inclusion]
   \label{thm:support_absorption_of_kernel_inclusion}
@@ -208,8 +222,7 @@
 
   \textbf{Scope restriction (Wolf Theorem 5.2, conditions (1) and (2)):}
   This proves exactly the first two conditions of the source theorem. The
-  printed contraction condition (3) is false in the singular case; its
-  corrected form remains to be formalized, as recorded in
+  printed contraction condition (3) is false in the singular case, as recorded in
   \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
 \end{theorem}
 
@@ -220,4 +233,147 @@
   The forward implication combines kernel inclusion with positivity of the
   Schur complement. The reverse implication is
   Theorem~\ref{thm:block_psd_of_schur_complement_psd}.
+\end{proof}
+
+\begin{theorem}[Pseudoinverse as inverse on the support]
+  \label{thm:schur_pinv_eq_support_inverse}
+  \lean{SchurComplement.pinv_eq_supportInv}
+  \leanok
+  \uses{def:pinv, thm:schur_pinv_support_identities}
+  If $R$ is positive semi-definite, then its Moore--Penrose pseudoinverse
+  agrees with the inverse obtained by inverting $R$ on its support and setting
+  it to zero on the kernel.
+\end{theorem}
+
+\begin{definition}[Support-normalized off-diagonal block]
+  \label{def:schur_contraction}
+  \lean{SchurComplement.schurContraction}
+  \leanok
+  For positive semi-definite $P$ and $R$, define
+  \begin{align}
+    K=P^{-1/2}QR^{-1/2},
+  \end{align}
+  where both inverse square roots vanish on the respective kernels.
+\end{definition}
+
+\begin{theorem}[Normalized Schur term]
+  \label{thm:schur_contraction_mul_adjoint}
+  \lean{SchurComplement.schurContraction_mul_conjTranspose}
+  \leanok
+  \uses{def:schur_contraction, thm:schur_pinv_eq_support_inverse}
+  The support-normalized off-diagonal block satisfies
+  \begin{align}
+    KK^\dagger=P^{-1/2}(QR^+Q^\dagger)P^{-1/2}.
+  \end{align}
+\end{theorem}
+
+\begin{theorem}[Positivity of the Schur term]
+  \label{thm:schur_term_psd}
+  \lean{SchurComplement.schurTerm_posSemidef}
+  \leanok
+  \uses{thm:schur_pinv_eq_support_inverse}
+  If $R$ is positive semi-definite, then $QR^+Q^\dagger$ is positive
+  semi-definite.
+\end{theorem}
+
+\begin{theorem}[Congruence criterion for domination]
+  \label{thm:psd_congruence_norm_criterion}
+  \lean{Matrix.PosSemidef.sub_smul_posSemidef_iff}
+  \leanok
+  Let $A$ and $B$ be positive semi-definite, let $c>0$, and suppose that
+  $\ker(A)\subseteq\ker(B)$. Then
+  \begin{align}
+    A-cB\ge0
+    \quad\Longleftrightarrow\quad
+    c\lVert A^{-1/2}BA^{-1/2}\rVert_\infty\le1,
+  \end{align}
+  where the inverse square root vanishes on $\ker(A)$.
+\end{theorem}
+
+\begin{theorem}[Left support from Schur-complement positivity]
+  \label{thm:left_support_of_schur_complement_psd}
+  \lean{SchurComplement.ker_conjTranspose_subset_of_schurComplement_posSemidef}
+  \leanok
+  \uses{def:schurComplement, thm:schur_term_psd,
+    thm:support_absorption_of_kernel_inclusion}
+  Suppose that $P$ and $R$ are positive semi-definite,
+  $\ker(R)\subseteq\ker(Q)$, and $P-QR^+Q^\dagger$ is positive
+  semi-definite. Then $\ker(P)\subseteq\ker(Q^\dagger)$.
+\end{theorem}
+
+\begin{theorem}[Corrected Schur-complement contraction criterion]
+  \label{thm:schur_complement_psd_iff_corrected_contraction}
+  \lean{SchurComplement.schurComplement_posSemidef_iff_contraction}
+  \leanok
+  \uses{def:schurComplement, def:schur_contraction}
+  Let $P$ and $R$ be positive semi-definite and suppose that
+  $\ker(R)\subseteq\ker(Q)$. Then
+  \begin{align}
+    P-QR^+Q^\dagger\ge0
+    \quad\Longleftrightarrow\quad
+    \ker(P)\subseteq\ker(Q^\dagger)
+    \ \text{and}\ \lVert P^{-1/2}QR^{-1/2}\rVert_\infty\le1.
+  \end{align}
+
+  \textbf{Local fix (Wolf Theorem 5.2, condition (3)):}
+  The left-support condition is necessary and is absent from the printed
+  statement. See
+  \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:psd_congruence_norm_criterion,
+    thm:schur_contraction_mul_adjoint, thm:schur_term_psd,
+    thm:left_support_of_schur_complement_psd}
+  Put $B=QR^+Q^\dagger$ and $K=P^{-1/2}QR^{-1/2}$. The two support conditions
+  allow congruence by $P^{-1/2}$ to identify $P-B\ge0$ with
+  $\lVert P^{-1/2}BP^{-1/2}\rVert_\infty\le1$. By
+  Theorem~\ref{thm:schur_contraction_mul_adjoint}, the matrix inside this norm
+  is $KK^\dagger$, whose norm is $\lVert K\rVert_\infty^2$.
+\end{proof}
+
+\begin{theorem}[Counterexample to Wolf's printed condition (3)]
+  \label{thm:wolf_schur_condition_three_counterexample}
+  \lean{SchurComplement.wolf_condition_three_not_sufficient}
+  \leanok
+  \uses{def:blockMatrix, def:schur_contraction,
+    thm:block_quadratic_form}
+  For the scalar blocks $P=0$ and $Q=R=1$, the printed kernel condition and
+  contraction bound hold, but
+  $\begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}$ is not positive
+  semi-definite.
+\end{theorem}
+
+\begin{proof}\leanok
+  The normalized off-diagonal block vanishes because $P^{-1/2}=0$. However,
+  the quadratic form of $\begin{pmatrix}0&1\\1&1\end{pmatrix}$ at $(1,-1)$
+  equals $-1$.
+\end{proof}
+
+\begin{theorem}[Corrected block contraction criterion]
+  \label{thm:block_psd_iff_corrected_contraction}
+  \lean{SchurComplement.blockMatrix_posSemidef_iff_contraction}
+  \leanok
+  \uses{def:blockMatrix, def:schur_contraction}
+  Let $P$ and $R$ be positive semi-definite. Then
+  \begin{align}
+    \begin{pmatrix}P&Q\\Q^\dagger&R\end{pmatrix}\ge0
+    \quad\Longleftrightarrow\quad
+    &\ker(R)\subseteq\ker(Q),\\
+    &\ker(P)\subseteq\ker(Q^\dagger),\\
+    &\lVert P^{-1/2}QR^{-1/2}\rVert_\infty\le1.
+  \end{align}
+
+  \textbf{Local fix (Wolf Theorem 5.2, condition (3)):}
+  This is the source statement with its missing left-support condition restored.
+  See \texttt{docs/paper-gaps/schur\_complement\_tfae.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:block_psd_kernel_inclusion,
+    thm:schur_complement_psd_of_block_psd,
+    thm:block_psd_of_schur_complement_psd,
+    thm:schur_complement_psd_iff_corrected_contraction}
+  Combine the pseudoinverse Schur-complement criterion with the corrected
+  contraction criterion.
 \end{proof}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -44,7 +44,11 @@ hand,
   \begin{pmatrix}1\\-1\end{pmatrix}=-1,
 \end{align}
 and hence the block matrix is not positive semi-definite. The missing
-left-support condition is $\ker(P)\subseteq\ker(Q^\dagger)$.
+condition is
+\begin{align}
+  \ker(P)\subseteq\ker(Q^\dagger).
+  \tag{left-support condition}
+\end{align}
 
 \section{What is formalized}
 The objects entering the statement are formalised: the block matrix itself,
@@ -73,20 +77,31 @@ This identity is formalized as
 support absorption $Q\operatorname{supp}(R)=Q$ and the pseudoinverse identities
 $RR^+=R^+R=\operatorname{supp}(R)$ and $(R^+)^\dagger=R^+$.
 
-\section{What remains}
-It remains to formalize the corrected form of
-(2)$\Longleftrightarrow$(3), with both kernel inclusions. Algebraic manipulation with
-$P^{1/2}$ and $R^{1/2}$ identifies $P \ge Q R^{+} Q^\dagger$ with the contraction
-bound $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$. The reverse route uses the
-operator-norm characterization $\|L\| \le 1 \iff L L^\dagger \le I$ and the
-support extensions of both inverse square roots. These operator-norm and
-support-factorization statements are not yet formalized in the required form.
+The scalar counterexample is formalized as
+\leanid{SchurComplement.wolf_condition_three_not_sufficient}. With the
+left-support condition added, all three conditions are equivalent. More
+precisely, let
+\begin{align}
+  K=P^{-1/2}QR^{-1/2},
+\end{align}
+where both inverse square roots vanish on their respective kernels. Under the
+two support conditions,
+\begin{align}
+  KK^\dagger
+    =P^{-1/2}(QR^+Q^\dagger)P^{-1/2}.
+\end{align}
+Consequently, $P-QR^+Q^\dagger\ge0$ is equivalent to $\lVert K\rVert_\infty\le1$.
+The corrected contraction equivalence is formalized as
+\leanid{SchurComplement.schurComplement_posSemidef_iff_contraction}, and its
+block-matrix form as
+\leanid{SchurComplement.blockMatrix_posSemidef_iff_contraction}.
 
 \section{Verdict}
-Conditions (1) and (2) of Wolf Theorem~5.2 are formalized without any
-additional hypothesis. Condition (3) is false as printed; the counterexample
-above is decisive. Formalization of the counterexample and of the corrected
-contraction equivalence, with $\ker(P)\subseteq\ker(Q^\dagger)$ adjoined, is
-tracked in \ghissue{5501}.
+Conditions (1) and (2) of Wolf Theorem~5.2 are correct as printed and are
+formalized without additional hypotheses. Condition (3) is false as printed;
+the scalar counterexample above is decisive. After adjoining the necessary
+left-support condition $\ker(P)\subseteq\ker(Q^\dagger)$, the three-way
+equivalence is formalized. Thus \ghissue{5501} is resolved by a source
+correction rather than by asserting the false printed statement.
 
 \end{document}


### PR DESCRIPTION
## Summary

- formalizes a one-dimensional counterexample to Wolf Theorem 5.2 condition (3) as printed in the singular case;
- defines the support-inverse-square-root contraction and proves the algebraic identities needed for the norm criterion;
- proves the corrected equivalence between pseudoinverse Schur-complement positivity and the contraction criterion;
- proves the resulting corrected block-positivity equivalence;
- updates the blueprint and paper-gap note so the false printed statement remains visibly unproved while the corrected theorem is marked complete.

## Mathematical correction

For P = 0 and Q = R = 1, the printed right-support condition and contraction bound hold, but the block matrix is not positive semidefinite. The corrected contraction condition requires both ker(R) ⊆ ker(Q) and ker(P) ⊆ ker(Q†).

With these two support conditions, the contraction norm bound is equivalent to positivity of P − Q R⁺ Q†, and hence to positivity of the block matrix by LionSR/TNLean#6851.

The source deviation and its resolution are recorded in `docs/paper-gaps/schur_complement_tfae.tex`.

## Validation

- focused build of `TNLean.Channel.Schwarz.SchurComplement`;
- blueprint declaration synchronization;
- reader-facing prose check;
- proof-integrity token scan;
- diff and whitespace check;
- prior axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`.

Closes LionSR/QICLean#277
