### PR TITLE
feat(MPS/MPDO): certify Example 4.10 correlated-flip weight entropies

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -88,6 +88,7 @@ import TNLean.MPS.MPDO.BondTwoSingletonPhysicalGauge
 import TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.CPSVBNTTheoremEquivalence
 import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVExample410CorrelatedFlip
 import TNLean.MPS.MPDO.CPSVExample411Ambient
 import TNLean.MPS.MPDO.CPSVExample411BinarySupport
 import TNLean.MPS.MPDO.CPSVExample411Entropy

--- a/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
@@ -172,11 +172,11 @@ theorem twoBondWeight_false_false : twoBondWeight false false = 7 / 16 := by
 probability $3/16$.
 
 Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
-theorem twoBondWeight_of_ne_false_false (u v : Bool) (h : ¬(u = false ∧ v = false)) :
+theorem twoBondWeight_of_pair_ne_false_false (u v : Bool) (h : (u, v) ≠ (false, false)) :
     twoBondWeight u v = 3 / 16 := by
   rcases u <;> rcases v <;>
     first
-      | exact absurd ⟨rfl, rfl⟩ h
+      | exact absurd rfl h
       | norm_num [twoBondWeight, flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
 
 /-- The one-bond distribution is the marginal of the bond pattern
@@ -197,7 +197,7 @@ theorem twoBondWeight_eq_marginal (u v : Bool) :
     twoBondWeight u v = ∑ w : Bool, ∑ x : Bool, bondWeight (u, v, w, x) := by
   rw [bondWeight_eq_bondWeightValue]
   rcases u <;> rcases v <;>
-    norm_num [twoBondWeight_false_false, twoBondWeight_of_ne_false_false, bondWeightValue,
+    norm_num [twoBondWeight_false_false, twoBondWeight_of_pair_ne_false_false, bondWeightValue,
       Fintype.sum_bool]
 
 /-- The weight family of a one-spin window: the two boundary bond halves are
@@ -223,19 +223,25 @@ lines 897--905. -/
 noncomputable def windowWeightThree (x : Bool × Bool × Bool × Bool) : ℝ :=
   twoBondWeight x.2.1 x.2.2.1 / 4
 
-/-- The one-spin window weights are normalized. -/
+/-- The one-spin window weights are normalized.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
 theorem sum_windowWeightOne : ∑ x : Bool × Bool, windowWeightOne x = 1 := by
   norm_num [windowWeightOne, Fintype.sum_prod_type, Fintype.sum_bool]
 
-/-- The two-spin window weights are normalized. -/
+/-- The two-spin window weights are normalized.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
 theorem sum_windowWeightTwo : ∑ x : Bool × Bool × Bool, windowWeightTwo x = 1 := by
   norm_num [windowWeightTwo, oneBondWeight_false, oneBondWeight_true,
     Fintype.sum_prod_type, Fintype.sum_bool]
 
-/-- The three-spin window weights are normalized. -/
+/-- The three-spin window weights are normalized.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
 theorem sum_windowWeightThree :
     ∑ x : Bool × Bool × Bool × Bool, windowWeightThree x = 1 := by
-  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_ne_false_false,
+  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_pair_ne_false_false,
     Fintype.sum_prod_type, Fintype.sum_bool]
 
 /-- The natural-logarithm entropy of the one-spin window weights.
@@ -346,7 +352,7 @@ Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
 theorem entropyThree_eq :
     entropyThree = 6 * log 2 - 7 / 16 * log 7 - 9 / 16 * log 3 := by
   rw [entropyThree]
-  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_ne_false_false,
+  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_pair_ne_false_false,
     Fintype.sum_prod_type, Fintype.sum_bool, negMulLog_seven_sixtyfourths,
     negMulLog_three_sixtyfourths]
   ring

--- a/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
@@ -26,8 +26,9 @@ three, and four consecutive spins, and their natural-logarithm entropies.  The
 mutual-information defect of these weight families equals one sixteenth of the
 exact logarithm certified in the arithmetic module, hence is strictly positive.
 
-The weight families list precisely the values displayed for the reduced
-density operators in the source at flip probability one quarter.  Identifying
+The weight families list precisely the reduced-state spectra computed in the
+paper-gap note at flip probability one quarter; the source prints only the
+channel and the four entropy decimals.  Identifying
 them with the spectra of the reductions of a corrected tensor, and proving the
 zero-correlation-length and area-law clauses of the example, are the remaining
 operator-level obligations.
@@ -77,7 +78,7 @@ flipped Bell state exactly when the flips at spins $n$ and $n+1$ disagree,
 with spin five identified with spin one.
 
 Derived from the Bell-pair ring of CPSV16, arXiv:1606.00608, Example 4.10,
-lines 897--899. -/
+line 900. -/
 def bondPattern (s : Bool × Bool × Bool × Bool) : Bool × Bool × Bool × Bool :=
   (xor s.1 s.2.1, xor s.2.1 s.2.2.1, xor s.2.2.1 s.2.2.2, xor s.2.2.2 s.1)
 
@@ -203,23 +204,29 @@ theorem twoBondWeight_eq_marginal (u v : Bool) :
 /-- The weight family of a one-spin window: the two boundary bond halves are
 maximally mixed, giving the uniform distribution on four labels.
 
-Displayed one-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
-lines 897--905. -/
+Spectrum of the one-spin reduction computed in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`; the source states only
+the channel and the entropy values (CPSV16, arXiv:1606.00608, Example 4.10,
+lines 900--904). -/
 noncomputable def windowWeightOne : Bool × Bool → ℝ := fun _ ↦ 1 / 4
 
 /-- The weight family of a two-spin window: one interior bond label together
 with two maximally mixed boundary bond halves.
 
-Displayed two-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
-lines 897--905. -/
+Spectrum of the two-spin reduction computed in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`; the source states only
+the channel and the entropy values (CPSV16, arXiv:1606.00608, Example 4.10,
+lines 900--904). -/
 noncomputable def windowWeightTwo (x : Bool × Bool × Bool) : ℝ :=
   oneBondWeight x.2.1 / 4
 
 /-- The weight family of a three-spin window: two consecutive interior bond
 labels together with two maximally mixed boundary bond halves.
 
-Displayed three-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
-lines 897--905. -/
+Spectrum of the three-spin reduction computed in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`; the source states only
+the channel and the entropy values (CPSV16, arXiv:1606.00608, Example 4.10,
+lines 900--904). -/
 noncomputable def windowWeightThree (x : Bool × Bool × Bool × Bool) : ℝ :=
   twoBondWeight x.2.1 x.2.2.1 / 4
 
@@ -246,25 +253,25 @@ theorem sum_windowWeightThree :
 
 /-- The natural-logarithm entropy of the one-spin window weights.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 noncomputable def entropyOne : ℝ := ∑ x : Bool × Bool, negMulLog (windowWeightOne x)
 
 /-- The natural-logarithm entropy of the two-spin window weights.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 noncomputable def entropyTwo : ℝ :=
   ∑ x : Bool × Bool × Bool, negMulLog (windowWeightTwo x)
 
 /-- The natural-logarithm entropy of the three-spin window weights.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 noncomputable def entropyThree : ℝ :=
   ∑ x : Bool × Bool × Bool × Bool, negMulLog (windowWeightThree x)
 
 /-- The natural-logarithm entropy of the bond pattern distribution, the
 four-spin window weights.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 noncomputable def entropyFour : ℝ :=
   ∑ t : Bool × Bool × Bool × Bool, negMulLog (bondWeight t)
 
@@ -327,7 +334,7 @@ private lemma negMulLog_nine_128ths :
 
 /-- The one-spin entropy is $2\ln 2$, that is, two bits.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 theorem entropyOne_eq : entropyOne = 2 * log 2 := by
   rw [entropyOne]
   norm_num [windowWeightOne, Fintype.sum_prod_type, Fintype.sum_bool, negMulLog_quarter]
@@ -336,7 +343,7 @@ theorem entropyOne_eq : entropyOne = 2 * log 2 := by
 /-- The exact two-spin entropy in natural logarithms; divided by $\ln 2$ it is
 the displayed decimal $2.9544$.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 theorem entropyTwo_eq :
     entropyTwo = 5 * log 2 - 5 / 8 * log 5 - 3 / 8 * log 3 := by
   rw [entropyTwo]
@@ -348,7 +355,7 @@ theorem entropyTwo_eq :
 /-- The exact three-spin entropy in natural logarithms; divided by $\ln 2$ it
 is the displayed decimal $3.8802$.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 theorem entropyThree_eq :
     entropyThree = 6 * log 2 - 7 / 16 * log 7 - 9 / 16 * log 3 := by
   rw [entropyThree]
@@ -360,7 +367,7 @@ theorem entropyThree_eq :
 /-- The exact four-spin entropy in natural logarithms; divided by $\ln 2$ it is
 the displayed decimal $2.7839$.
 
-Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, line 904. -/
 theorem entropyFour_eq :
     entropyFour =
       7 * log 2 - 41 / 128 * log 41 - 57 / 64 * log 3 - 15 / 32 * log 5 := by

--- a/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
@@ -33,6 +33,11 @@ them with the spectra of the reductions of a corrected tensor, and proving the
 zero-correlation-length and area-law clauses of the example, are the remaining
 operator-level obligations.
 
+**Local fix (left-right correlated flip):** the printed channel at source
+lines 901--902 applies both Pauli factors to the left qubit.  Here the second
+factor acts on the right qubit, as derived in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`.
+
 **Scope restriction (classical weight layer):** the uniform boundary factors
 record maximally mixed halves of the boundary bonds, and the identification of
 these weight families with reduced-state spectra is not made in this module.
@@ -72,6 +77,12 @@ channels act independently.
 Source channel: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
 noncomputable def flipProb (s : Bool × Bool × Bool × Bool) : ℝ :=
   flipWeight s.1 * flipWeight s.2.1 * flipWeight s.2.2.1 * flipWeight s.2.2.2
+
+/-- Every flip configuration has nonnegative probability.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem flipProb_nonneg (s : Bool × Bool × Bool × Bool) : 0 ≤ flipProb s := by
+  rcases s with ⟨_ | _, _ | _, _ | _, _ | _⟩ <;> norm_num [flipProb, flipWeight]
 
 /-- The bond difference pattern of a flip configuration: bond $n$ carries the
 flipped Bell state exactly when the flips at spins $n$ and $n+1$ disagree,
@@ -127,6 +138,13 @@ theorem bondWeight_eq_bondWeightValue : bondWeight = bondWeightValue := by
   rcases t with ⟨_ | _, _ | _, _ | _, _ | _⟩ <;>
     norm_num [bondWeight, bondWeightValue, bondPattern, flipProb, flipWeight,
       Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- Every bond pattern has nonnegative probability.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem bondWeight_nonneg (t : Bool × Bool × Bool × Bool) : 0 ≤ bondWeight t := by
+  rw [bondWeight_eq_bondWeightValue]
+  rcases t with ⟨_ | _, _ | _, _ | _, _ | _⟩ <;> norm_num [bondWeightValue]
 
 /-- The bond pattern distribution is normalized.
 
@@ -229,6 +247,28 @@ the channel and the entropy values (CPSV16, arXiv:1606.00608, Example 4.10,
 lines 900--904). -/
 noncomputable def windowWeightThree (x : Bool × Bool × Bool × Bool) : ℝ :=
   twoBondWeight x.2.1 x.2.2.1 / 4
+
+/-- Every one-spin window weight is nonnegative.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem windowWeightOne_nonneg (x : Bool × Bool) : 0 ≤ windowWeightOne x := by
+  norm_num [windowWeightOne]
+
+/-- Every two-spin window weight is nonnegative.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem windowWeightTwo_nonneg (x : Bool × Bool × Bool) : 0 ≤ windowWeightTwo x := by
+  rcases x with ⟨_, _ | _, _⟩ <;>
+    norm_num [windowWeightTwo, oneBondWeight_false, oneBondWeight_true]
+
+/-- Every three-spin window weight is nonnegative.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem windowWeightThree_nonneg (x : Bool × Bool × Bool × Bool) :
+    0 ≤ windowWeightThree x := by
+  rcases x with ⟨_, _ | _, _ | _, _⟩ <;>
+    norm_num [windowWeightThree, twoBondWeight_false_false,
+      twoBondWeight_of_pair_ne_false_false]
 
 /-- The one-spin window weights are normalized.
 

--- a/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean
@@ -1,0 +1,401 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.Data.Fintype.BigOperators
+import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic
+
+/-!
+# Correlated-flip weight layer for CPSV16 Example 4.10
+
+CPSV16 Example 4.10 places one maximally entangled qubit pair on each bond of a
+four-spin ring and applies, independently at every spin, the corrected
+correlated flip channel with flip probability one quarter.  A flip at spin $n$
+acts by one flip on each of the two bonds adjacent to $n$, and a joint flip
+configuration $s$ turns the pair on bond $n$ into the flipped Bell state
+exactly when the flips at spins $n$ and $n+1$ disagree.  The four-site state is
+therefore the mixture, over independent flip configurations, of orthonormal
+products of Bell states labelled by the cyclic difference pattern of $s$.
+
+This module records that derivation at the level of the label distributions.
+It defines the flip configuration distribution, its pushforward to bond
+difference patterns, the weight families attached to windows of one, two,
+three, and four consecutive spins, and their natural-logarithm entropies.  The
+mutual-information defect of these weight families equals one sixteenth of the
+exact logarithm certified in the arithmetic module, hence is strictly positive.
+
+The weight families list precisely the values displayed for the reduced
+density operators in the source at flip probability one quarter.  Identifying
+them with the spectra of the reductions of a corrected tensor, and proving the
+zero-correlation-length and area-law clauses of the example, are the remaining
+operator-level obligations.
+
+**Scope restriction (classical weight layer):** the uniform boundary factors
+record maximally mixed halves of the boundary bonds, and the identification of
+these weight families with reduced-state spectra is not made in this module.
+See `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`.
+
+## Main results
+
+* `bondWeight_eq_bondWeightValue`: closed form of the bond pattern distribution.
+* `entropyOne_eq`, `entropyTwo_eq`, `entropyThree_eq`, `entropyFour_eq`: the
+  exact natural-logarithm window entropies.
+* `mutualInfoTwo_sub_mutualInfoOne_eq`: the exact mutual-information defect.
+* `mutualInfoTwo_sub_mutualInfoOne_pos`: strict positivity of the defect.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Example 4.10,
+  lines 897--905.
+* `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`, for the corrected
+  channel and the exact four-spin calculation.
+-/
+
+namespace CPSVExample410CorrelatedFlip
+
+open Real
+
+/-- The probability of one on-site flip outcome of the corrected channel at
+flip probability one quarter; `true` marks a flip.
+
+Source channel: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905, with
+the left-right correction recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. -/
+noncomputable def flipWeight (b : Bool) : ℝ := if b then 1 / 4 else 3 / 4
+
+/-- The probability of a joint flip configuration on the four spins; the four
+channels act independently.
+
+Source channel: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+noncomputable def flipProb (s : Bool × Bool × Bool × Bool) : ℝ :=
+  flipWeight s.1 * flipWeight s.2.1 * flipWeight s.2.2.1 * flipWeight s.2.2.2
+
+/-- The bond difference pattern of a flip configuration: bond $n$ carries the
+flipped Bell state exactly when the flips at spins $n$ and $n+1$ disagree,
+with spin five identified with spin one.
+
+Derived from the Bell-pair ring of CPSV16, arXiv:1606.00608, Example 4.10,
+lines 897--899. -/
+def bondPattern (s : Bool × Bool × Bool × Bool) : Bool × Bool × Bool × Bool :=
+  (xor s.1 s.2.1, xor s.2.1 s.2.2.1, xor s.2.2.1 s.2.2.2, xor s.2.2.2 s.1)
+
+/-- The pushforward of the flip configuration distribution to bond difference
+patterns.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+noncomputable def bondWeight (t : Bool × Bool × Bool × Bool) : ℝ :=
+  ∑ s : Bool × Bool × Bool × Bool, if bondPattern s = t then flipProb s else 0
+
+/-- The closed form of the bond pattern distribution: weight $41/128$ on the
+unflipped pattern, $15/128$ on each of the four adjacent flipped pairs,
+$9/128$ on the two opposite flipped pairs and on the fully flipped pattern,
+and zero on the eight odd patterns.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+noncomputable def bondWeightValue : Bool × Bool × Bool × Bool → ℝ
+  | (false, false, false, false) => 41 / 128
+  | (true, true, false, false) => 15 / 128
+  | (false, true, true, false) => 15 / 128
+  | (false, false, true, true) => 15 / 128
+  | (true, false, false, true) => 15 / 128
+  | (true, false, true, false) => 9 / 128
+  | (false, true, false, true) => 9 / 128
+  | (true, true, true, true) => 9 / 128
+  | (true, false, false, false) => 0
+  | (false, true, false, false) => 0
+  | (false, false, true, false) => 0
+  | (false, false, false, true) => 0
+  | (true, true, true, false) => 0
+  | (true, true, false, true) => 0
+  | (true, false, true, true) => 0
+  | (false, true, true, true) => 0
+
+/-- The flip configuration distribution is normalized.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem sum_flipProb : ∑ s : Bool × Bool × Bool × Bool, flipProb s = 1 := by
+  norm_num [flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The bond pattern distribution takes exactly the closed-form values.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem bondWeight_eq_bondWeightValue : bondWeight = bondWeightValue := by
+  funext t
+  rcases t with ⟨_ | _, _ | _, _ | _, _ | _⟩ <;>
+    norm_num [bondWeight, bondWeightValue, bondPattern, flipProb, flipWeight,
+      Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The bond pattern distribution is normalized.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem sum_bondWeight : ∑ t : Bool × Bool × Bool × Bool, bondWeight t = 1 := by
+  rw [bondWeight_eq_bondWeightValue]
+  norm_num [bondWeightValue, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The distribution of a single bond label under the flip configuration
+distribution.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+noncomputable def oneBondWeight (u : Bool) : ℝ :=
+  ∑ s : Bool × Bool × Bool × Bool, if xor s.1 s.2.1 = u then flipProb s else 0
+
+/-- The joint distribution of two consecutive bond labels under the flip
+configuration distribution.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+noncomputable def twoBondWeight (u v : Bool) : ℝ :=
+  ∑ s : Bool × Bool × Bool × Bool,
+    if xor s.1 s.2.1 = u ∧ xor s.2.1 s.2.2.1 = v then flipProb s else 0
+
+/-- A single bond keeps its Bell state with probability $5/8$.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem oneBondWeight_false : oneBondWeight false = 5 / 8 := by
+  norm_num [oneBondWeight, flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- A single bond is flipped with probability $3/8$.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem oneBondWeight_true : oneBondWeight true = 3 / 8 := by
+  norm_num [oneBondWeight, flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- Two consecutive bonds both keep their Bell states with probability
+$7/16$.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem twoBondWeight_false_false : twoBondWeight false false = 7 / 16 := by
+  norm_num [twoBondWeight, flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- Each of the three remaining label pairs of two consecutive bonds has
+probability $3/16$.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem twoBondWeight_of_ne_false_false (u v : Bool) (h : ¬(u = false ∧ v = false)) :
+    twoBondWeight u v = 3 / 16 := by
+  rcases u <;> rcases v <;>
+    first
+      | exact absurd ⟨rfl, rfl⟩ h
+      | norm_num [twoBondWeight, flipProb, flipWeight, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The one-bond distribution is the marginal of the bond pattern
+distribution.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem oneBondWeight_eq_marginal (u : Bool) :
+    oneBondWeight u = ∑ v : Bool, ∑ w : Bool, ∑ x : Bool, bondWeight (u, v, w, x) := by
+  rw [bondWeight_eq_bondWeightValue]
+  rcases u <;>
+    norm_num [oneBondWeight_false, oneBondWeight_true, bondWeightValue, Fintype.sum_bool]
+
+/-- The two-bond distribution is the marginal of the bond pattern
+distribution.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem twoBondWeight_eq_marginal (u v : Bool) :
+    twoBondWeight u v = ∑ w : Bool, ∑ x : Bool, bondWeight (u, v, w, x) := by
+  rw [bondWeight_eq_bondWeightValue]
+  rcases u <;> rcases v <;>
+    norm_num [twoBondWeight_false_false, twoBondWeight_of_ne_false_false, bondWeightValue,
+      Fintype.sum_bool]
+
+/-- The weight family of a one-spin window: the two boundary bond halves are
+maximally mixed, giving the uniform distribution on four labels.
+
+Displayed one-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
+lines 897--905. -/
+noncomputable def windowWeightOne : Bool × Bool → ℝ := fun _ ↦ 1 / 4
+
+/-- The weight family of a two-spin window: one interior bond label together
+with two maximally mixed boundary bond halves.
+
+Displayed two-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
+lines 897--905. -/
+noncomputable def windowWeightTwo (x : Bool × Bool × Bool) : ℝ :=
+  oneBondWeight x.2.1 / 4
+
+/-- The weight family of a three-spin window: two consecutive interior bond
+labels together with two maximally mixed boundary bond halves.
+
+Displayed three-spin reduction: CPSV16, arXiv:1606.00608, Example 4.10,
+lines 897--905. -/
+noncomputable def windowWeightThree (x : Bool × Bool × Bool × Bool) : ℝ :=
+  twoBondWeight x.2.1 x.2.2.1 / 4
+
+/-- The one-spin window weights are normalized. -/
+theorem sum_windowWeightOne : ∑ x : Bool × Bool, windowWeightOne x = 1 := by
+  norm_num [windowWeightOne, Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The two-spin window weights are normalized. -/
+theorem sum_windowWeightTwo : ∑ x : Bool × Bool × Bool, windowWeightTwo x = 1 := by
+  norm_num [windowWeightTwo, oneBondWeight_false, oneBondWeight_true,
+    Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The three-spin window weights are normalized. -/
+theorem sum_windowWeightThree :
+    ∑ x : Bool × Bool × Bool × Bool, windowWeightThree x = 1 := by
+  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_ne_false_false,
+    Fintype.sum_prod_type, Fintype.sum_bool]
+
+/-- The natural-logarithm entropy of the one-spin window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+noncomputable def entropyOne : ℝ := ∑ x : Bool × Bool, negMulLog (windowWeightOne x)
+
+/-- The natural-logarithm entropy of the two-spin window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+noncomputable def entropyTwo : ℝ :=
+  ∑ x : Bool × Bool × Bool, negMulLog (windowWeightTwo x)
+
+/-- The natural-logarithm entropy of the three-spin window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+noncomputable def entropyThree : ℝ :=
+  ∑ x : Bool × Bool × Bool × Bool, negMulLog (windowWeightThree x)
+
+/-- The natural-logarithm entropy of the bond pattern distribution, the
+four-spin window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+noncomputable def entropyFour : ℝ :=
+  ∑ t : Bool × Bool × Bool × Bool, negMulLog (bondWeight t)
+
+private lemma negMulLog_quarter : negMulLog (1 / 4 : ℝ) = 1 / 4 * (2 * log 2) := by
+  rw [negMulLog, show (1 / 4 : ℝ) = 4⁻¹ by norm_num, log_inv,
+    show (4 : ℝ) = 2 ^ 2 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_five_thirtytwoths :
+    negMulLog (5 / 32 : ℝ) = 5 / 32 * (5 * log 2 - log 5) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (32 : ℝ) = 2 ^ 5 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_three_thirtytwoths :
+    negMulLog (3 / 32 : ℝ) = 3 / 32 * (5 * log 2 - log 3) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (32 : ℝ) = 2 ^ 5 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_seven_sixtyfourths :
+    negMulLog (7 / 64 : ℝ) = 7 / 64 * (6 * log 2 - log 7) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (64 : ℝ) = 2 ^ 6 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_three_sixtyfourths :
+    negMulLog (3 / 64 : ℝ) = 3 / 64 * (6 * log 2 - log 3) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (64 : ℝ) = 2 ^ 6 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_fortyone_128ths :
+    negMulLog (41 / 128 : ℝ) = 41 / 128 * (7 * log 2 - log 41) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (128 : ℝ) = 2 ^ 7 by norm_num, log_pow]
+  push_cast
+  ring
+
+private lemma negMulLog_fifteen_128ths :
+    negMulLog (15 / 128 : ℝ) = 15 / 128 * (7 * log 2 - log 3 - log 5) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (128 : ℝ) = 2 ^ 7 by norm_num, log_pow,
+    show (15 : ℝ) = 3 * 5 by norm_num, log_mul (by norm_num) (by norm_num)]
+  push_cast
+  ring
+
+private lemma negMulLog_nine_128ths :
+    negMulLog (9 / 128 : ℝ) = 9 / 128 * (7 * log 2 - 2 * log 3) := by
+  rw [negMulLog, log_div (by norm_num) (by norm_num),
+    show (128 : ℝ) = 2 ^ 7 by norm_num, log_pow,
+    show (9 : ℝ) = 3 ^ 2 by norm_num, log_pow]
+  push_cast
+  ring
+
+/-- The one-spin entropy is $2\ln 2$, that is, two bits.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+theorem entropyOne_eq : entropyOne = 2 * log 2 := by
+  rw [entropyOne]
+  norm_num [windowWeightOne, Fintype.sum_prod_type, Fintype.sum_bool, negMulLog_quarter]
+  ring
+
+/-- The exact two-spin entropy in natural logarithms; divided by $\ln 2$ it is
+the displayed decimal $2.9544$.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+theorem entropyTwo_eq :
+    entropyTwo = 5 * log 2 - 5 / 8 * log 5 - 3 / 8 * log 3 := by
+  rw [entropyTwo]
+  norm_num [windowWeightTwo, oneBondWeight_false, oneBondWeight_true,
+    Fintype.sum_prod_type, Fintype.sum_bool, negMulLog_five_thirtytwoths,
+    negMulLog_three_thirtytwoths]
+  ring
+
+/-- The exact three-spin entropy in natural logarithms; divided by $\ln 2$ it
+is the displayed decimal $3.8802$.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+theorem entropyThree_eq :
+    entropyThree = 6 * log 2 - 7 / 16 * log 7 - 9 / 16 * log 3 := by
+  rw [entropyThree]
+  norm_num [windowWeightThree, twoBondWeight_false_false, twoBondWeight_of_ne_false_false,
+    Fintype.sum_prod_type, Fintype.sum_bool, negMulLog_seven_sixtyfourths,
+    negMulLog_three_sixtyfourths]
+  ring
+
+/-- The exact four-spin entropy in natural logarithms; divided by $\ln 2$ it is
+the displayed decimal $2.7839$.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--903. -/
+theorem entropyFour_eq :
+    entropyFour =
+      7 * log 2 - 41 / 128 * log 41 - 57 / 64 * log 3 - 15 / 32 * log 5 := by
+  rw [entropyFour, bondWeight_eq_bondWeightValue]
+  norm_num [bondWeightValue, Fintype.sum_prod_type, Fintype.sum_bool,
+    negMulLog_fortyone_128ths, negMulLog_fifteen_128ths, negMulLog_nine_128ths]
+  ring
+
+/-- The mutual information of one spin against its complement in the four-spin
+window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--905. -/
+noncomputable def mutualInfoOne : ℝ := entropyOne + entropyThree - entropyFour
+
+/-- The mutual information of two consecutive spins against their complement
+in the four-spin window weights.
+
+Displayed value: CPSV16, arXiv:1606.00608, Example 4.10, lines 900--905. -/
+noncomputable def mutualInfoTwo : ℝ := 2 * entropyTwo - entropyFour
+
+/-- The exact mutual-information defect of the window weight families: one
+sixteenth of the logarithm of the certified integer ratio.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; the exact
+form is recorded in `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. -/
+theorem mutualInfoTwo_sub_mutualInfoOne_eq :
+    mutualInfoTwo - mutualInfoOne =
+      1 / 16 * Real.log (((2 : ℝ) ^ 32 * 7 ^ 7) / (3 ^ 3 * 5 ^ 20)) := by
+  rw [mutualInfoTwo, mutualInfoOne, entropyOne_eq, entropyTwo_eq, entropyThree_eq,
+    log_div (by norm_num) (by norm_num), log_mul (by norm_num) (by norm_num),
+    log_mul (by norm_num) (by norm_num), log_pow, log_pow, log_pow, log_pow]
+  push_cast
+  ring
+
+/-- The window weight families strictly violate saturation: the two-spin
+mutual information exceeds the one-spin mutual information.
+
+Derived from CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905, through
+the certified integer comparison. -/
+theorem mutualInfoTwo_sub_mutualInfoOne_pos : 0 < mutualInfoTwo - mutualInfoOne := by
+  rw [mutualInfoTwo_sub_mutualInfoOne_eq]
+  exact mul_pos (by norm_num) CPSVExamples410411Arithmetic.example410_log_ratio_pos
+
+end CPSVExample410CorrelatedFlip

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1380,7 +1380,9 @@ This is the calculation in
 \begin{theorem}[Exact bond-pattern distribution for Example 4.10]
     \label{thm:cpsv_example410_bond_distribution}
     \lean{CPSVExample410CorrelatedFlip.sum_flipProb,
+        CPSVExample410CorrelatedFlip.flipProb_nonneg,
         CPSVExample410CorrelatedFlip.bondWeight_eq_bondWeightValue,
+        CPSVExample410CorrelatedFlip.bondWeight_nonneg,
         CPSVExample410CorrelatedFlip.sum_bondWeight,
         CPSVExample410CorrelatedFlip.oneBondWeight_false,
         CPSVExample410CorrelatedFlip.oneBondWeight_true,
@@ -1388,6 +1390,9 @@ This is the calculation in
         CPSVExample410CorrelatedFlip.twoBondWeight_of_pair_ne_false_false,
         CPSVExample410CorrelatedFlip.oneBondWeight_eq_marginal,
         CPSVExample410CorrelatedFlip.twoBondWeight_eq_marginal,
+        CPSVExample410CorrelatedFlip.windowWeightOne_nonneg,
+        CPSVExample410CorrelatedFlip.windowWeightTwo_nonneg,
+        CPSVExample410CorrelatedFlip.windowWeightThree_nonneg,
         CPSVExample410CorrelatedFlip.sum_windowWeightOne,
         CPSVExample410CorrelatedFlip.sum_windowWeightTwo,
         CPSVExample410CorrelatedFlip.sum_windowWeightThree}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1072,8 +1072,8 @@ This is the calculation in
     \begin{align}
         \langle\sigma|\rho^{(N)}(K)|\tau\rangle
                                        & =\delta_{\sigma,\tau}\left(
-                                                              2^{-N}\mathbf 1_{\{\sigma_k\in\{0,1\}\ \forall k\}}
-        +\mathbf 1_{\{\sigma_k=2\ \forall k\}}\right),       \label{eq:caseii-ambient-mpo}                        \\
+        2^{-N}\mathbf 1_{\{\sigma_k\in\{0,1\}\ \forall k\}}
+        +\mathbf 1_{\{\sigma_k=2\ \forall k\}}\right),       \label{eq:caseii-ambient-mpo}        \\
         \operatorname{tr}\rho^{(N)}(K) & =2>0.                    \label{eq:caseii-ambient-trace}
     \end{align}
     Hence $K$ generates positive semidefinite operators. It satisfies the
@@ -1604,7 +1604,7 @@ This is the calculation in
     \begin{align}
         \mu_{N,L}(x)
          & =\frac{2^L\bigl(3^{N-L+1}+(-1)^{t(x)}\bigr)}
-            {2^{t(x)+2}(3^N+1)}.
+        {2^{t(x)+2}(3^N+1)}.
         \notag
     \end{align}
     This includes $L=1$ and $L=N$.  It is a project-derived consequence of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1263,7 +1263,10 @@ This is the calculation in
     \label{thm:cpsv_examples410_412_status}
     \notready
     \uses{def:is_rfp_via_ts, def:is_sal, def:mpdo_source_gsnnch,
-        def:mpo_source_zcl, thm:cpsv_example411_not_source_zcl,
+        def:mpo_source_zcl,
+        def:cpsv_example410_correlated_flip_weights,
+        thm:cpsv_example410_mutual_information_defect,
+        thm:cpsv_example411_not_source_zcl,
         thm:cpsv_example411_ambient_not_sal,
         thm:cpsv_example412_literal_formula,
         thm:cpsv_example412_literal_sal,
@@ -1336,6 +1339,168 @@ This is the calculation in
     four-site member of the normalized family and so does not compare
     commuting realizations at different chain lengths.
 \end{theorem}
+
+% Project-derived weight layer for CPSV16 Example 4.10, lines 897--905.
+% Scope restriction: classical weight families only; the identification with
+% reduced-state spectra of the corrected tensor is not part of these entries.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{definition}[Correlated-flip weight families for Example 4.10]
+    \label{def:cpsv_example410_correlated_flip_weights}
+    \lean{CPSVExample410CorrelatedFlip.flipWeight,
+        CPSVExample410CorrelatedFlip.flipProb,
+        CPSVExample410CorrelatedFlip.bondPattern,
+        CPSVExample410CorrelatedFlip.bondWeight,
+        CPSVExample410CorrelatedFlip.bondWeightValue,
+        CPSVExample410CorrelatedFlip.oneBondWeight,
+        CPSVExample410CorrelatedFlip.twoBondWeight,
+        CPSVExample410CorrelatedFlip.windowWeightOne,
+        CPSVExample410CorrelatedFlip.windowWeightTwo,
+        CPSVExample410CorrelatedFlip.windowWeightThree}
+    \leanok
+    Place one maximally entangled qubit pair on each bond of the four-spin
+    ring and apply, independently at every spin, the corrected correlated
+    flip with flip probability one quarter.  A joint flip configuration
+    $s\in\{0,1\}^4$ has probability
+    \begin{align}
+        P(s)&=\prod_{n=1}^4\left(\tfrac14\right)^{s_n}
+            \left(\tfrac34\right)^{1-s_n},
+        \notag
+    \end{align}
+    and its bond pattern $t\in\{0,1\}^4$ is $t_n=s_n\oplus s_{n+1}$, with
+    spin five identified with spin one.  Write $q$ for the pushforward of
+    $P$ to bond patterns.  The weight family of a window of $k$ consecutive
+    spins, $1\le k\le 3$, assigns to each configuration of its $k-1$
+    interior bond labels and its two boundary qubits one quarter of the
+    marginal probability of those interior labels; the four-spin window
+    weight family is $q$ itself.
+\end{definition}
+
+% Project-derived weight layer for CPSV16 Example 4.10, lines 897--905.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Exact bond-pattern distribution for Example 4.10]
+    \label{thm:cpsv_example410_bond_distribution}
+    \lean{CPSVExample410CorrelatedFlip.sum_flipProb,
+        CPSVExample410CorrelatedFlip.bondWeight_eq_bondWeightValue,
+        CPSVExample410CorrelatedFlip.sum_bondWeight,
+        CPSVExample410CorrelatedFlip.oneBondWeight_false,
+        CPSVExample410CorrelatedFlip.oneBondWeight_true,
+        CPSVExample410CorrelatedFlip.twoBondWeight_false_false,
+        CPSVExample410CorrelatedFlip.twoBondWeight_of_ne_false_false,
+        CPSVExample410CorrelatedFlip.oneBondWeight_eq_marginal,
+        CPSVExample410CorrelatedFlip.twoBondWeight_eq_marginal,
+        CPSVExample410CorrelatedFlip.sum_windowWeightOne,
+        CPSVExample410CorrelatedFlip.sum_windowWeightTwo,
+        CPSVExample410CorrelatedFlip.sum_windowWeightThree}
+    \leanok
+    \uses{def:cpsv_example410_correlated_flip_weights}
+    The bond-pattern distribution takes the value $41/128$ on the unflipped
+    pattern, $15/128$ on each of the four patterns flipping two cyclically
+    adjacent bonds, $9/128$ on the two patterns flipping two opposite bonds
+    and on the fully flipped pattern, and zero on the eight patterns with an
+    odd number of flipped bonds.  Its one-bond marginal is $(5/8,3/8)$, and
+    its two-adjacent-bond marginal assigns $7/16$ to the doubly unflipped
+    pair and $3/16$ to each of the three remaining pairs.  All the window
+    weight families are probability distributions.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cpsv_example410_correlated_flip_weights}
+    Each value is a finite sum of products of the factors $1/4$ and $3/4$
+    over the sixteen flip configurations, evaluated exactly.
+\end{proof}
+
+% Project-derived weight layer for CPSV16 Example 4.10, lines 897--905.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Exact window entropies for Example 4.10]
+    \label{thm:cpsv_example410_window_entropies}
+    \lean{CPSVExample410CorrelatedFlip.entropyOne,
+        CPSVExample410CorrelatedFlip.entropyTwo,
+        CPSVExample410CorrelatedFlip.entropyThree,
+        CPSVExample410CorrelatedFlip.entropyFour,
+        CPSVExample410CorrelatedFlip.entropyOne_eq,
+        CPSVExample410CorrelatedFlip.entropyTwo_eq,
+        CPSVExample410CorrelatedFlip.entropyThree_eq,
+        CPSVExample410CorrelatedFlip.entropyFour_eq}
+    \leanok
+    \uses{thm:cpsv_example410_bond_distribution}
+    Let $\tilde S_k$ denote the entropy $\sum_x h(w(x))$ of the window
+    weight family for $k$ consecutive spins, with $h(x)=-x\log x$ and $\log$
+    the natural logarithm.  Then
+    \begin{align}
+        \tilde S_1&=2\log 2,\notag\\
+        \tilde S_2&=5\log 2-\tfrac58\log 5-\tfrac38\log 3,\notag\\
+        \tilde S_3&=6\log 2-\tfrac7{16}\log 7-\tfrac9{16}\log 3,\notag\\
+        \tilde S_4&=7\log 2-\tfrac{41}{128}\log 41
+            -\tfrac{57}{64}\log 3-\tfrac{15}{32}\log 5.
+        \notag
+    \end{align}
+    Divided by $\log 2$ these are the printed decimals $2$, $2.9544$,
+    $3.8802$, and $2.7839$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_example410_bond_distribution}
+    The window weight families list the values
+    $(1/4)^{[4]}$; $(5/32)^{[4]},(3/32)^{[4]}$;
+    $(7/64)^{[4]},(3/64)^{[12]}$; and
+    $(41/128)^{[1]},(15/128)^{[4]},(9/128)^{[3]}$.
+    Summing $h$ over each family and expanding the logarithms of the
+    rational values gives the displayed closed forms.
+\end{proof}
+
+% Project-derived scalar certificate for CPSV16 Example 4.10.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Positivity of the Example 4.10 logarithmic ratio]
+    \label{thm:cpsv_example410_log_ratio_pos}
+    \lean{CPSVExamples410411Arithmetic.example410_integer_inequality,
+        CPSVExamples410411Arithmetic.example410_log_ratio_pos}
+    \leanok
+    The exact scalar ratio from the four-site calculation satisfies
+    \[
+      \log\!\left(
+        \frac{2^{32}7^7}{3^3 5^{20}}
+      \right)>0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The numerator and denominator are the integers
+    $2^{32}7^7=3537090251849728$ and $3^3 5^{20}=2574920654296875$, so the
+    ratio is greater than one and its logarithm is strictly positive.
+\end{proof}
+
+% Project-derived weight layer for CPSV16 Example 4.10, lines 897--905.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Exact mutual-information defect for Example 4.10]
+    \label{thm:cpsv_example410_mutual_information_defect}
+    \lean{CPSVExample410CorrelatedFlip.mutualInfoOne,
+        CPSVExample410CorrelatedFlip.mutualInfoTwo,
+        CPSVExample410CorrelatedFlip.mutualInfoTwo_sub_mutualInfoOne_eq,
+        CPSVExample410CorrelatedFlip.mutualInfoTwo_sub_mutualInfoOne_pos}
+    \leanok
+    \uses{thm:cpsv_example410_window_entropies}
+    For $\tilde I_1=\tilde S_1+\tilde S_3-\tilde S_4$ and
+    $\tilde I_2=2\tilde S_2-\tilde S_4$,
+    \begin{align}
+        \tilde I_2-\tilde I_1
+        &=\frac1{16}\log\!\left(
+            \frac{2^{32}7^7}{3^3 5^{20}}\right)>0.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_example410_window_entropies,
+        thm:cpsv_example410_log_ratio_pos}
+    Since $\tilde I_2-\tilde I_1=2\tilde S_2-\tilde S_1-\tilde S_3$,
+    substituting the closed forms and collecting logarithms gives the
+    displayed identity; positivity follows from the certified integer
+    comparison.
+\end{proof}
 
 % CPSV16 Example 4.11, lines 907--924.
 % Scope restriction: this is the effective supported model; the ambient

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1385,7 +1385,7 @@ This is the calculation in
         CPSVExample410CorrelatedFlip.oneBondWeight_false,
         CPSVExample410CorrelatedFlip.oneBondWeight_true,
         CPSVExample410CorrelatedFlip.twoBondWeight_false_false,
-        CPSVExample410CorrelatedFlip.twoBondWeight_of_ne_false_false,
+        CPSVExample410CorrelatedFlip.twoBondWeight_of_pair_ne_false_false,
         CPSVExample410CorrelatedFlip.oneBondWeight_eq_marginal,
         CPSVExample410CorrelatedFlip.twoBondWeight_eq_marginal,
         CPSVExample410CorrelatedFlip.sum_windowWeightOne,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1464,11 +1464,11 @@ This is the calculation in
         CPSVExamples410411Arithmetic.example410_log_ratio_pos}
     \leanok
     The exact scalar ratio from the four-site calculation satisfies
-    \[
+    \begin{align}
         \log\!\left(
         \frac{2^{32}7^7}{3^3 5^{20}}
-        \right)>0.
-    \]
+        \right) & >0. \notag
+    \end{align}
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1072,8 +1072,8 @@ This is the calculation in
     \begin{align}
         \langle\sigma|\rho^{(N)}(K)|\tau\rangle
                                        & =\delta_{\sigma,\tau}\left(
-        2^{-N}\mathbf 1_{\{\sigma_k\in\{0,1\}\ \forall k\}}
-        +\mathbf 1_{\{\sigma_k=2\ \forall k\}}\right),       \label{eq:caseii-ambient-mpo}        \\
+                                                              2^{-N}\mathbf 1_{\{\sigma_k\in\{0,1\}\ \forall k\}}
+        +\mathbf 1_{\{\sigma_k=2\ \forall k\}}\right),       \label{eq:caseii-ambient-mpo}                        \\
         \operatorname{tr}\rho^{(N)}(K) & =2>0.                    \label{eq:caseii-ambient-trace}
     \end{align}
     Hence $K$ generates positive semidefinite operators. It satisfies the
@@ -1362,8 +1362,8 @@ This is the calculation in
     flip with flip probability one quarter.  A joint flip configuration
     $s\in\{0,1\}^4$ has probability
     \begin{align}
-        P(s)&=\prod_{n=1}^4\left(\tfrac14\right)^{s_n}
-            \left(\tfrac34\right)^{1-s_n},
+        P(s) & =\prod_{n=1}^4\left(\tfrac14\right)^{s_n}
+        \left(\tfrac34\right)^{1-s_n},
         \notag
     \end{align}
     and its bond pattern $t\in\{0,1\}^4$ is $t_n=s_n\oplus s_{n+1}$, with
@@ -1434,11 +1434,11 @@ This is the calculation in
     weight family for $k$ consecutive spins, with $h(x)=-x\log x$ and $\log$
     the natural logarithm.  Then
     \begin{align}
-        \tilde S_1&=2\log 2,\notag\\
-        \tilde S_2&=5\log 2-\tfrac58\log 5-\tfrac38\log 3,\notag\\
-        \tilde S_3&=6\log 2-\tfrac7{16}\log 7-\tfrac9{16}\log 3,\notag\\
-        \tilde S_4&=7\log 2-\tfrac{41}{128}\log 41
-            -\tfrac{57}{64}\log 3-\tfrac{15}{32}\log 5.
+        \tilde S_1 & =2\log 2,\notag                                     \\
+        \tilde S_2 & =5\log 2-\tfrac58\log 5-\tfrac38\log 3,\notag       \\
+        \tilde S_3 & =6\log 2-\tfrac7{16}\log 7-\tfrac9{16}\log 3,\notag \\
+        \tilde S_4 & =7\log 2-\tfrac{41}{128}\log 41
+        -\tfrac{57}{64}\log 3-\tfrac{15}{32}\log 5.
         \notag
     \end{align}
     Divided by $\log 2$ these are the printed decimals $2$, $2.9544$,
@@ -1465,9 +1465,9 @@ This is the calculation in
     \leanok
     The exact scalar ratio from the four-site calculation satisfies
     \[
-      \log\!\left(
+        \log\!\left(
         \frac{2^{32}7^7}{3^3 5^{20}}
-      \right)>0.
+        \right)>0.
     \]
 \end{theorem}
 
@@ -1492,8 +1492,8 @@ This is the calculation in
     $\tilde I_2=2\tilde S_2-\tilde S_4$,
     \begin{align}
         \tilde I_2-\tilde I_1
-        &=\frac1{16}\log\!\left(
-            \frac{2^{32}7^7}{3^3 5^{20}}\right)>0.
+         & =\frac1{16}\log\!\left(
+        \frac{2^{32}7^7}{3^3 5^{20}}\right)>0.
         \notag
     \end{align}
 \end{theorem}
@@ -1604,7 +1604,7 @@ This is the calculation in
     \begin{align}
         \mu_{N,L}(x)
          & =\frac{2^L\bigl(3^{N-L+1}+(-1)^{t(x)}\bigr)}
-        {2^{t(x)+2}(3^N+1)}.
+            {2^{t(x)+2}(3^N+1)}.
         \notag
     \end{align}
     This includes $L=1$ and $L=N$.  It is a project-derived consequence of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1393,8 +1393,9 @@ This is the calculation in
         CPSVExample410CorrelatedFlip.sum_windowWeightThree}
     \leanok
     \uses{def:cpsv_example410_correlated_flip_weights}
-    The bond-pattern distribution takes the value $41/128$ on the unflipped
-    pattern, $15/128$ on each of the four patterns flipping two cyclically
+    The flip-configuration distribution is a probability distribution on
+    $\{0,1\}^4$.  The bond-pattern distribution takes the value $41/128$ on
+    the unflipped pattern, $15/128$ on each of the four patterns flipping two cyclically
     adjacent bonds, $9/128$ on the two patterns flipping two opposite bonds
     and on the fully flipped pattern, and zero on the eight patterns with an
     odd number of flipped bonds.  Its one-bond marginal is $(5/8,3/8)$, and

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1263,6 +1263,23 @@ current counts and full location lists).
   reconstruction pattern now; retain the explicit proofs until another
   direct word-tuple occurrence identifies a materially smaller theorem.
 
+### rational negMulLog prime-logarithm expansion — candidate
+- **Pattern:** rewrite `Real.negMulLog (a / b)` for an explicit rational into a
+  linear combination of logarithms of small primes: unfold `negMulLog`, split
+  the quotient with `Real.log_div`, express `b` (and composite `a`) as prime
+  powers, apply `Real.log_pow`/`Real.log_mul`, then `push_cast` and `ring`.
+- **Seen:** eight private lemmas in
+  `TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean`
+  (`negMulLog_quarter` through `negMulLog_nine_128ths`) (2026-08-21).
+- **Abstraction (proposed):** one lemma computing
+  `negMulLog ((a : ℝ) / 2 ^ k)` from the prime factorization of `a`, or a
+  small simp set bundling `negMulLog`, `Real.log_div`, `Real.log_pow`, and
+  `Real.log_mul` with the needed positivity side conditions.
+- **Notes:** all occurrences are presently in one file, below the two-file
+  promotion threshold. The sibling exact-entropy statements in
+  `TNLean/MPS/MPDO/CPSVExample411Entropy.lean` keep `negMulLog` values
+  unexpanded, so no second file uses the pattern yet.
+
 ### Hermitian extraction from a finite-order channel eigenvector — candidate
 - **Pattern:** from `E X = μ • X`, `X ≠ 0`, `μ ≠ 1`, and `μ ^ p = 1`,
   use trace preservation and the Hermitian parts `X + Xᴴ` and


### PR DESCRIPTION
## Summary

Part of #6301. This PR adds the classical weight layer for the corrected correlated-flip channel of CPSV16 Example 4.10 (label `ExZCLnoSAL`, `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 897-905) at flip probability 1/4:

- New module `TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean`:
  - the flip-configuration distribution of the corrected channel and its pushforward to cyclic bond difference patterns, with the exact closed form `41/128` (unflipped), `15/128` (four adjacent flipped pairs), `9/128` (two opposite flipped pairs and the fully flipped pattern), zero on odd patterns;
  - one-bond and two-adjacent-bond marginals `(5/8, 3/8)` and `(7/16, 3/16, 3/16, 3/16)`;
  - the window weight families for one to four consecutive spins, listing exactly the values `(1/4)^[4]`, `(5/32)^[4] (3/32)^[4]`, `(7/64)^[4] (3/64)^[12]`, `(41/128)^[1] (15/128)^[4] (9/128)^[3]` displayed for the reduced density operators in the corrected calculation;
  - their exact natural-logarithm entropies, whose base-2 values are the printed decimals 2, 2.9544, 3.8802, 2.7839;
  - the exact mutual-information defect `I2 - I1 = (1/16) ln(2^32 * 7^7 / (3^3 * 5^20))` and its strict positivity via the certified integer comparison from `CPSVExamples410411Arithmetic` (#6313).
- Blueprint: five new entries in `ch21_mpdo_rfp_simple_local_structure_capstone.tex` (weight-family definition, bond-pattern distribution, window entropies, Example 4.10 logarithmic-ratio positivity, mutual-information defect), plus the corresponding `\uses` additions to the printed-examples status node, which stays `\notready`.
- `docs/tactic_patterns.md`: candidate entry for the repeated rational `negMulLog` prime-logarithm expansion (eight occurrences, one file, below the promotion threshold).

## Statement-integrity audit

- **Paper assumptions:** the source prints the repeated-left-label channel, the `p = 0.25` decimal entropies, and a qualitative claim; the corrected left-right channel and the exact spectra are recorded in `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. The Lean statements assume nothing beyond the explicit rational data of that corrected calculation.
- **Paper conclusion vs Lean conclusion:** the Lean entropies are exact closed forms whose base-2 values reproduce all four printed decimals, and the defect identity with strict positivity matches the exact calculation in the paper-gap note. The printed universal phrase `p != 0, 1/2` is not formalized (it fails at `p = 1`), matching the note.
- **Scope restriction:** this is a classical weight layer. The identification of the weight families with the reduced-state spectra of a corrected MPO tensor, the source-ZCL clause, and the `IsSourceZCL` and non-`IsSAL` witness are not claimed here; the module docstring carries a `**Scope restriction**` marker referencing the paper-gap note, and the blueprint status node remains not ready.
- **Proof status:** all declarations fully proved; no `sorry`, no `axiom`.
- **Faithfulness verdict:** faithful as project-derived exact calculations behind the printed decimals, on the same footing as the merged Example 4.11 entropy entries; no source-labelled entry is marked as formalized by these declarations.

## Validation

```
lake exe cache get
lake build TNLean.MPS.MPDO.CPSVExample410CorrelatedFlip   # green
rg -n "sorry|axiom" TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean   # no hits
python3 scripts/blueprint_lean_sync.py --update-lean-decls               # in sync
python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint \
  --changed-files TNLean/MPS/MPDO/CPSVExample410CorrelatedFlip.lean \
  --diff-base origin/main --diff-head HEAD                               # no missing entries
```

Not run locally: `lake build TNLean.MPS.MPDO` (the touched aggregator) and `leanblueprint checkdecls`, which need the full library build; the local build store had no prebuilt project artifacts, so these are left to CI. The aggregator diff is a single line produced by `python3 scripts/generate_import_aggregators.py`, and the new module's own build covers its entire dependency chain.

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E
