### PR TITLE
feat(MPS/CanonicalForm): PGVWC07 quadratic reconstruction system and chain lemmas

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -42,5 +42,6 @@ import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.ProjectorClosure
 import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
 import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
+import TNLean.MPS.CanonicalForm.QuadraticReconstruction
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.CanonicalForm.SectorComparison

--- a/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
+++ b/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
@@ -44,6 +44,10 @@ to the canonical one. Its proof reduces, as in the uniqueness theorem
   `Matrix.exists_nonzero_intertwiner_of_kronecker_one_intertwines` - PGVWC07
   Lemma `lem-horn` in multiplicity-slice form, and the nonzero-intertwiner
   consequence used at line 1094.
+* `MPSTensor.QuadraticReconstructionSolution.chainIntertwiner`,
+  `MPSTensor.QuadraticReconstructionSolution.chainIntertwiner_mul_kronecker` -
+  the invertible chain of intertwiners comparing two solutions of system (S),
+  the first step of the reconstruction proof (lines 1168-1179).
 -/
 
 open scoped Matrix Kronecker
@@ -225,7 +229,7 @@ structure QuadraticReconstructionSolution
   rightGauge : Fin m → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
   /-- The translation-invariant tensor unknowns `B i` of system (S). -/
   tensor : MPSTensor d D
-  /-- The quadratic equations `B i ⊗ 1 = Y j * A i j * Z (j + 1)` of system
+  /-- The quadratic equations `B i ⊗ 1 = Y j * A j i * Z (j + 1)` of system
   (S), MPSarchive.tex lines 1147-1149. -/
   kronecker_eq : ∀ (i : Fin d) (j : Fin m),
     tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) = leftGauge j * A j i * rightGauge j
@@ -260,6 +264,60 @@ theorem isUnit_rightGauge (s : QuadraticReconstructionSolution A)
     IsUnit (s.rightGauge j) :=
   (Matrix.isUnit_iff_isUnit_det _).mpr
     (Matrix.isUnit_det_of_left_inverse (s.leftGauge_mul_rightGauge j h))
+
+/-- The intertwiner comparing two solutions of system (S) at a window site:
+with row unknowns `Y`, `Y'` and column unknowns `Z`, `Z'` of the two solutions,
+the matrix attached to site `j + 1` is `W = Y' (j + 1) * Z j`, which equals
+`Y' (j + 1) * (Y (j + 1))⁻¹` by the inversion equations. This is the chain of
+invertible matrices `W_k` in the reconstruction proof of PGVWC07
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1168-1179), obtained there by
+reasoning as in the uniqueness theorem `thm-uniq` (lines 1080-1091). -/
+def chainIntertwiner (s t : QuadraticReconstructionSolution A) (j : ℕ) (h : j + 1 < m) :
+    Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  t.leftGauge ⟨j + 1, h⟩ * s.rightGauge ⟨j, Nat.lt_of_succ_lt h⟩
+
+/-- Each chain intertwiner comparing two solutions of system (S) is invertible,
+as the product of a row unknown and a column unknown that are each paired by an
+inversion equation. This is the invertibility of the matrices `W_k` in the
+reconstruction proof of PGVWC07 (arXiv:quant-ph/0608197, MPSarchive.tex lines
+1168-1179). -/
+theorem isUnit_chainIntertwiner (s t : QuadraticReconstructionSolution A)
+    {j : ℕ} (h : j + 1 < m) :
+    IsUnit (chainIntertwiner s t j h) :=
+  (t.isUnit_leftGauge (j := ⟨j, Nat.lt_of_succ_lt h⟩) h).mul
+    (s.isUnit_rightGauge (j := ⟨j, Nat.lt_of_succ_lt h⟩) h)
+
+/-- **Chain relation between two solutions of system (S)** (PGVWC07,
+arXiv:quant-ph/0608197, MPSarchive.tex lines 1168-1179): the invertible
+intertwiners `W` of `chainIntertwiner` satisfy
+`W (j + 1) * (B i ⊗ 1) = (C i ⊗ 1) * W (j + 2)` for the tensors `B`, `C` of
+the two solutions, at every window site where both inversion equations are
+available. This is the input to the combination lemma `lem-same-matr` in the
+reconstruction proof, where the source writes the chain as
+`W_k (C_i ⊗ 1) = (B_i ⊗ 1) W_{k+1}` (lines 1080-1091). -/
+theorem chainIntertwiner_mul_kronecker (s t : QuadraticReconstructionSolution A)
+    (i : Fin d) {j : ℕ} (h1 : j + 1 < m) (h2 : j + 2 < m) :
+    chainIntertwiner s t j h1 * (s.tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) =
+      (t.tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) * chainIntertwiner s t (j + 1) h2 := by
+  have hs := s.kronecker_eq i ⟨j + 1, h1⟩
+  have ht := t.kronecker_eq i ⟨j + 1, h1⟩
+  have hsflip : s.rightGauge ⟨j, Nat.lt_of_succ_lt h1⟩ * s.leftGauge ⟨j + 1, h1⟩ = 1 :=
+    mul_eq_one_comm.mp (s.leftGauge_mul_rightGauge ⟨j, Nat.lt_of_succ_lt h1⟩ h1)
+  have htflip : t.rightGauge ⟨j + 1, h1⟩ * t.leftGauge ⟨j + 1 + 1, h2⟩ = 1 :=
+    mul_eq_one_comm.mp (t.leftGauge_mul_rightGauge ⟨j + 1, h1⟩ h2)
+  have hcancel : ∀ X : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ,
+      s.rightGauge ⟨j, Nat.lt_of_succ_lt h1⟩ * (s.leftGauge ⟨j + 1, h1⟩ * X) = X := fun X ↦ by
+    rw [← Matrix.mul_assoc, hsflip, Matrix.one_mul]
+  have tcancel : ∀ X : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ,
+      t.rightGauge ⟨j + 1, h1⟩ * (t.leftGauge ⟨j + 1 + 1, h2⟩ * X) = X := fun X ↦ by
+    rw [← Matrix.mul_assoc, htflip, Matrix.one_mul]
+  change t.leftGauge ⟨j + 1, h1⟩ * s.rightGauge ⟨j, Nat.lt_of_succ_lt h1⟩ *
+      (s.tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) =
+    (t.tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      (t.leftGauge ⟨j + 1 + 1, h2⟩ * s.rightGauge ⟨j + 1, h1⟩)
+  rw [hs, ht]
+  simp only [Matrix.mul_assoc]
+  rw [hcancel, tcancel]
 
 end QuadraticReconstructionSolution
 

--- a/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
+++ b/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
-import TNLean.MPS.Defs
+import QICLean.MPS.Defs
 
 /-!
 # Quadratic reconstruction system for the translation-invariant canonical form
@@ -23,7 +23,8 @@ equations displayed at MPSarchive.tex lines 1139-1152:
 
 * `B i ⊗ 1 = Y j * A j i * Z (j + 1)` for all physical indices `i` and window
   sites `j`;
-* `Y j * Z j = 1` at every window site where both unknowns exist;
+* `Y (j + 1) * Z (j + 1) = 1` at every internal cut represented by the
+  window;
 * `∑ i, B i * (B i)ᴴ = 1`.
 
 The reconstruction theorem (MPSarchive.tex lines 1154-1165) asserts that the
@@ -31,8 +32,8 @@ system is solvable whenever the state admits a translation-invariant
 representation with condition C1, and that any solution is unitarily conjugate
 to the canonical one. Its proof reduces, as in the uniqueness theorem
 `thm-uniq`, to two lemmas formalized below: the chain-combination lemma
-`lem-same-matr` (lines 1023-1052) and the Kronecker intertwiner lemma
-`lem-horn` (lines 1073-1079).
+`lem-same-matr` (lines 1022-1049) and the Kronecker intertwiner lemma
+`lem-horn` (lines 1053-1058).
 
 ## Main declarations
 
@@ -43,11 +44,11 @@ to the canonical one. Its proof reduces, as in the uniqueness theorem
 * `Matrix.kronecker_one_intertwines_iff_kroneckerSlice_intertwines`,
   `Matrix.exists_nonzero_intertwiner_of_kronecker_one_intertwines` - PGVWC07
   Lemma `lem-horn` in multiplicity-slice form, and the nonzero-intertwiner
-  consequence used at line 1094.
+  consequence used at lines 1094-1095.
 * `MPSTensor.QuadraticReconstructionSolution.chainIntertwiner`,
   `MPSTensor.QuadraticReconstructionSolution.chainIntertwiner_mul_kronecker` -
-  the invertible chain of intertwiners comparing two solutions of system (S),
-  the first step of the reconstruction proof (lines 1168-1179).
+  the internal chain of intertwiners comparing two solutions of system (S),
+  the first step of the reconstruction proof (lines 1167-1176).
 -/
 
 open scoped Matrix Kronecker
@@ -55,7 +56,7 @@ open scoped Matrix Kronecker
 /-! ## The chain-combination lemma `lem-same-matr` -/
 
 /-- The coefficient sequence of PGVWC07, Lemma `lem-same-matr`
-(arXiv:quant-ph/0608197, MPSarchive.tex lines 1023-1052). With the source's
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1022-1049). With the source's
 one-based data `λ_1, …, λ_{n-1}` written zero-based as `lam 0, …, lam (n - 1)`,
 the value at `j` is the source coefficient
 `μ_{j+1} = λ_1 x^{j+1} + λ_2 x^{j} + ⋯ + λ_{j+1} x`. -/
@@ -63,7 +64,7 @@ def pgvwc07ChainCoeff (lam : ℕ → ℂ) (x : ℂ) (j : ℕ) : ℂ :=
   ∑ k ∈ Finset.range (j + 1), lam k * x ^ (j + 1 - k)
 
 /-- The recurrence `μ_{j+1} = x (λ_{j+1} + μ_j)` satisfied by the coefficients
-of PGVWC07 Lemma `lem-same-matr` (MPSarchive.tex lines 1035-1043). -/
+of PGVWC07 Lemma `lem-same-matr` (MPSarchive.tex lines 1032-1037). -/
 theorem pgvwc07ChainCoeff_succ (lam : ℕ → ℂ) (x : ℂ) (j : ℕ) :
     pgvwc07ChainCoeff lam x (j + 1) = x * (lam (j + 1) + pgvwc07ChainCoeff lam x j) := by
   unfold pgvwc07ChainCoeff
@@ -81,7 +82,7 @@ theorem pgvwc07ChainCoeff_succ (lam : ℕ → ℂ) (x : ℂ) (j : ℕ) :
   ring
 
 /-- **PGVWC07, Lemma `lem-same-matr`** (arXiv:quant-ph/0608197, MPSarchive.tex
-lines 1023-1052), zero-based. Let `T`, `S` be linear maps on the same spaces
+lines 1022-1049), zero-based. Let `T`, `S` be linear maps on the same spaces
 and `Y 0, …, Y n` vectors such that `T (Y k) = S (Y (k + 1))` for `k < n`, the
 vectors `Y 0, …, Y (n - 1)` are linearly independent, and
 `Y n = ∑ k < n, lam k • Y k`. For any solution `x ≠ 0` of the polynomial
@@ -149,12 +150,12 @@ variable {R : Type*} [CommRing R]
 /-- The multiplicity slice of a matrix on a doubled index: the `(a, b)` slice
 of `W` is the matrix of entries `W (p, a) (q, b)`. This realizes the tensor
 factorization `M_{nm} = M_n ⊗ M_m` used in PGVWC07, Lemma `lem-horn`
-(arXiv:quant-ph/0608197, MPSarchive.tex lines 1073-1079). -/
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1053-1058). -/
 def kroneckerSlice (W : Matrix (n × m) (n × m) R) (a b : m) : Matrix n n R :=
   fun p q ↦ W (p, a) (q, b)
 
 /-- **PGVWC07, Lemma `lem-horn`** (arXiv:quant-ph/0608197, MPSarchive.tex
-lines 1073-1079) in multiplicity-slice form: `W` solves the amplified matrix
+lines 1053-1058) in multiplicity-slice form: `W` solves the amplified matrix
 equation `W (C ⊗ 1) = (B ⊗ 1) W` if and only if every multiplicity slice of
 `W` solves the unamplified equation `X C = B X`. The source phrases this as
 the solution space of the amplified equation being `S ⊗ M_n` for `S` the
@@ -177,7 +178,7 @@ theorem kronecker_one_intertwines_iff_kroneckerSlice_intertwines
       Fintype.sum_prod_type, mul_comm] using h'
 
 /-- The consequence of PGVWC07 Lemma `lem-horn` used in the uniqueness and
-reconstruction proofs (arXiv:quant-ph/0608197, MPSarchive.tex line 1094): a
+reconstruction proofs (arXiv:quant-ph/0608197, MPSarchive.tex lines 1094-1095): a
 nonzero simultaneous solution `W` of the amplified equations
 `W (C i ⊗ 1) = (B i ⊗ 1) W` yields a nonzero matrix `X` with `X * C i = B i * X`
 for every `i`. -/
@@ -214,18 +215,21 @@ form, so that the window length is `D ^ 4`), a solution consists of matrices
 tensor `B` of bond dimension `D` satisfying the quadratic equations
 
 * `B i ⊗ 1 = Y j * A j i * Z (j + 1)` for all `i`, `j`;
-* `Y j * Z j = 1` at every window site where both unknowns are defined;
+* `Y (j + 1) * Z (j + 1) = 1` at every internal cut represented by the
+  window;
 * `∑ i, B i * (B i)ᴴ = 1`.
 
-Here `leftGauge j` is the source unknown `Y (L₀ + 1 + j)` and `rightGauge j`
-is the source unknown `Z (L₀ + 2 + j)`, both indexed from `j = 0`. -/
+Here `leftGauge j` is the source unknown `Y (L₀ + 1 + j)`, while
+`rightGauge j` is the source unknown `Z (L₀ + 2 + j)`, both indexed from
+`j = 0`. Thus `leftGauge (j + 1) * rightGauge j = 1` is the source equation
+`Y (L₀ + 2 + j) * Z (L₀ + 2 + j) = 1`. -/
 structure QuadraticReconstructionSolution
     (A : Fin m → Fin d → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) where
   /-- The row unknowns `Y j` of system (S), zero-based over the window. -/
   leftGauge : Fin m → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
   /-- The column unknowns `Z (j + 1)` of system (S), zero-based over the
-  window: `rightGauge j` is the source unknown attached to the right of the
-  window site `j`. -/
+  window: `rightGauge j` is the source unknown `Z (L₀ + 2 + j)` attached to
+  the right of window site `L₀ + 1 + j`. -/
   rightGauge : Fin m → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
   /-- The translation-invariant tensor unknowns `B i` of system (S). -/
   tensor : MPSTensor d D
@@ -233,8 +237,9 @@ structure QuadraticReconstructionSolution
   (S), MPSarchive.tex lines 1147-1149. -/
   kronecker_eq : ∀ (i : Fin d) (j : Fin m),
     tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) = leftGauge j * A j i * rightGauge j
-  /-- The inversion equations `Y j * Z j = 1` of system (S), MPSarchive.tex
-  line 1150, at the window sites where both unknowns are defined. -/
+  /-- The internal inversion equations `Y (j + 1) * Z (j + 1) = 1` of
+  system (S), MPSarchive.tex line 1150. In the zero-based stored variables this
+  is `leftGauge (j + 1) * rightGauge j = 1`. -/
   leftGauge_mul_rightGauge : ∀ (j : Fin m) (h : (j : ℕ) + 1 < m),
     leftGauge ⟨(j : ℕ) + 1, h⟩ * rightGauge j = 1
   /-- The normalization equation `∑ i, B i * (B i)ᴴ = 1` of system (S),
@@ -248,7 +253,7 @@ variable {A : Fin m → Fin d → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
 /-- In a solution of system (S), each row unknown paired by an inversion
 equation is invertible. This is the invertibility of the `Y j` used implicitly
 in the reconstruction argument of PGVWC07 (arXiv:quant-ph/0608197,
-MPSarchive.tex lines 1167-1176). -/
+MPSarchive.tex lines 1142-1152). -/
 theorem isUnit_leftGauge (s : QuadraticReconstructionSolution A)
     {j : Fin m} (h : (j : ℕ) + 1 < m) :
     IsUnit (s.leftGauge ⟨(j : ℕ) + 1, h⟩) :=
@@ -258,7 +263,7 @@ theorem isUnit_leftGauge (s : QuadraticReconstructionSolution A)
 /-- In a solution of system (S), each column unknown paired by an inversion
 equation is invertible. This is the invertibility of the `Z j` used implicitly
 in the reconstruction argument of PGVWC07 (arXiv:quant-ph/0608197,
-MPSarchive.tex lines 1167-1176). -/
+MPSarchive.tex lines 1142-1152). -/
 theorem isUnit_rightGauge (s : QuadraticReconstructionSolution A)
     {j : Fin m} (h : (j : ℕ) + 1 < m) :
     IsUnit (s.rightGauge j) :=
@@ -267,11 +272,19 @@ theorem isUnit_rightGauge (s : QuadraticReconstructionSolution A)
 
 /-- The intertwiner comparing two solutions of system (S) at a window site:
 with row unknowns `Y`, `Y'` and column unknowns `Z`, `Z'` of the two solutions,
-the matrix attached to site `j + 1` is `W = Y' (j + 1) * Z j`, which equals
-`Y' (j + 1) * (Y (j + 1))⁻¹` by the inversion equations. This is the chain of
-invertible matrices `W_k` in the reconstruction proof of PGVWC07
-(arXiv:quant-ph/0608197, MPSarchive.tex lines 1168-1179), obtained there by
-reasoning as in the uniqueness theorem `thm-uniq` (lines 1080-1091). -/
+the matrix at the internal cut after site `j` is
+`W (j + 1) = Y' (j + 1) * Z (j + 1)`, which equals
+`Y' (j + 1) * (Y (j + 1))⁻¹` by the inversion equations. For a window of
+`m` sites this definition gives exactly `m - 1` internal intertwiners. This is
+the internal part of the chain used in the reconstruction proof of PGVWC07
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1167-1176), by comparison with
+the uniqueness proof at lines 1080-1086.
+
+**Local fix (`docs/paper-gaps/pgvwc07_intertwiner_chain_off_by_one.tex`):**
+The internal chain alone has only `m - 1` intertwiners and does not force a
+linear dependence. For the source window `m = D ^ 4`, the dimension argument
+requires `D ^ 4 + 1` cut intertwiners. The two endpoint cuts are deliberately
+not invented here; they must come from a future open-boundary gauge comparison. -/
 def chainIntertwiner (s t : QuadraticReconstructionSolution A) (j : ℕ) (h : j + 1 < m) :
     Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
   t.leftGauge ⟨j + 1, h⟩ * s.rightGauge ⟨j, Nat.lt_of_succ_lt h⟩
@@ -280,7 +293,7 @@ def chainIntertwiner (s t : QuadraticReconstructionSolution A) (j : ℕ) (h : j 
 as the product of a row unknown and a column unknown that are each paired by an
 inversion equation. This is the invertibility of the matrices `W_k` in the
 reconstruction proof of PGVWC07 (arXiv:quant-ph/0608197, MPSarchive.tex lines
-1168-1179). -/
+1167-1176). -/
 theorem isUnit_chainIntertwiner (s t : QuadraticReconstructionSolution A)
     {j : ℕ} (h : j + 1 < m) :
     IsUnit (chainIntertwiner s t j h) :=
@@ -288,13 +301,15 @@ theorem isUnit_chainIntertwiner (s t : QuadraticReconstructionSolution A)
     (s.isUnit_rightGauge (j := ⟨j, Nat.lt_of_succ_lt h⟩) h)
 
 /-- **Chain relation between two solutions of system (S)** (PGVWC07,
-arXiv:quant-ph/0608197, MPSarchive.tex lines 1168-1179): the invertible
+arXiv:quant-ph/0608197, MPSarchive.tex lines 1167-1176): the invertible
 intertwiners `W` of `chainIntertwiner` satisfy
 `W (j + 1) * (B i ⊗ 1) = (C i ⊗ 1) * W (j + 2)` for the tensors `B`, `C` of
 the two solutions, at every window site where both inversion equations are
-available. This is the input to the combination lemma `lem-same-matr` in the
-reconstruction proof, where the source writes the chain as
-`W_k (C_i ⊗ 1) = (B_i ⊗ 1) W_{k+1}` (lines 1080-1091). -/
+available. For a window of `m` sites, this theorem supplies exactly `m - 2`
+adjacent relations among the `m - 1` internal intertwiners. It does not supply
+the endpoint relations or the dependence hypothesis of `lem-same-matr`. The
+source writes the corresponding relation as
+`W_k (C_i ⊗ 1) = (B_i ⊗ 1) W_{k+1}` at lines 1080-1086. -/
 theorem chainIntertwiner_mul_kronecker (s t : QuadraticReconstructionSolution A)
     (i : Fin d) {j : ℕ} (h1 : j + 1 < m) (h2 : j + 2 < m) :
     chainIntertwiner s t j h1 * (s.tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) =

--- a/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
+++ b/TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import TNLean.MPS.Defs
+
+/-!
+# Quadratic reconstruction system for the translation-invariant canonical form
+
+This file formalizes the quadratic system of equations from Pérez-García,
+Verstraete, Wolf, and Cirac (PGVWC07, arXiv:quant-ph/0608197), Section
+"Obtaining the canonical form", together with the two lemmas that drive the
+uniqueness part of its reconstruction theorem.
+
+PGVWC07 stores a translation-invariant state whose successive reduced density
+operators have rank at most `D ^ 2` as an open-boundary matrix product state
+with `D ^ 2 × D ^ 2` matrices `A i j` on a window of sites, and reconstructs a
+translation-invariant `D`-tensor `B` by solving the system (S) of quadratic
+equations displayed at MPSarchive.tex lines 1139-1152:
+
+* `B i ⊗ 1 = Y j * A j i * Z (j + 1)` for all physical indices `i` and window
+  sites `j`;
+* `Y j * Z j = 1` at every window site where both unknowns exist;
+* `∑ i, B i * (B i)ᴴ = 1`.
+
+The reconstruction theorem (MPSarchive.tex lines 1154-1165) asserts that the
+system is solvable whenever the state admits a translation-invariant
+representation with condition C1, and that any solution is unitarily conjugate
+to the canonical one. Its proof reduces, as in the uniqueness theorem
+`thm-uniq`, to two lemmas formalized below: the chain-combination lemma
+`lem-same-matr` (lines 1023-1052) and the Kronecker intertwiner lemma
+`lem-horn` (lines 1073-1079).
+
+## Main declarations
+
+* `MPSTensor.QuadraticReconstructionSolution` - a solution of the PGVWC07
+  system (S) over a supplied window of open-boundary matrices.
+* `pgvwc07ChainCoeff`, `pgvwc07_chainCoeff_combination_spec` - the coefficient
+  sequence and conclusion of PGVWC07 Lemma `lem-same-matr`.
+* `Matrix.kronecker_one_intertwines_iff_kroneckerSlice_intertwines`,
+  `Matrix.exists_nonzero_intertwiner_of_kronecker_one_intertwines` - PGVWC07
+  Lemma `lem-horn` in multiplicity-slice form, and the nonzero-intertwiner
+  consequence used at line 1094.
+-/
+
+open scoped Matrix Kronecker
+
+/-! ## The chain-combination lemma `lem-same-matr` -/
+
+/-- The coefficient sequence of PGVWC07, Lemma `lem-same-matr`
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1023-1052). With the source's
+one-based data `λ_1, …, λ_{n-1}` written zero-based as `lam 0, …, lam (n - 1)`,
+the value at `j` is the source coefficient
+`μ_{j+1} = λ_1 x^{j+1} + λ_2 x^{j} + ⋯ + λ_{j+1} x`. -/
+def pgvwc07ChainCoeff (lam : ℕ → ℂ) (x : ℂ) (j : ℕ) : ℂ :=
+  ∑ k ∈ Finset.range (j + 1), lam k * x ^ (j + 1 - k)
+
+/-- The recurrence `μ_{j+1} = x (λ_{j+1} + μ_j)` satisfied by the coefficients
+of PGVWC07 Lemma `lem-same-matr` (MPSarchive.tex lines 1035-1043). -/
+theorem pgvwc07ChainCoeff_succ (lam : ℕ → ℂ) (x : ℂ) (j : ℕ) :
+    pgvwc07ChainCoeff lam x (j + 1) = x * (lam (j + 1) + pgvwc07ChainCoeff lam x j) := by
+  unfold pgvwc07ChainCoeff
+  rw [Finset.sum_range_succ]
+  have hstep : ∀ k ∈ Finset.range (j + 1),
+      lam k * x ^ (j + 1 + 1 - k) = x * (lam k * x ^ (j + 1 - k)) := by
+    intro k hk
+    have hk' : k ≤ j := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+    have hpow : j + 1 + 1 - k = (j + 1 - k) + 1 := by omega
+    rw [hpow, pow_succ]
+    ring
+  rw [Finset.sum_congr rfl hstep, ← Finset.mul_sum]
+  have hone : j + 1 + 1 - (j + 1) = 1 := by omega
+  rw [hone, pow_one]
+  ring
+
+/-- **PGVWC07, Lemma `lem-same-matr`** (arXiv:quant-ph/0608197, MPSarchive.tex
+lines 1023-1052), zero-based. Let `T`, `S` be linear maps on the same spaces
+and `Y 0, …, Y n` vectors such that `T (Y k) = S (Y (k + 1))` for `k < n`, the
+vectors `Y 0, …, Y (n - 1)` are linearly independent, and
+`Y n = ∑ k < n, lam k • Y k`. For any solution `x ≠ 0` of the polynomial
+equation `∑ k < n, lam k * x ^ (n - k) = 1`, the combination
+`∑ k < n, μ k • Y k` with the coefficients `μ` of `pgvwc07ChainCoeff` is
+nonzero and satisfies `T Y = x⁻¹ • S Y`. -/
+theorem pgvwc07_chainCoeff_combination_spec
+    {M M' : Type*} [AddCommGroup M] [Module ℂ M] [AddCommGroup M'] [Module ℂ M']
+    (T S : M →ₗ[ℂ] M') {n : ℕ} (Y : ℕ → M) (lam : ℕ → ℂ) {x : ℂ}
+    (hchain : ∀ k < n, T (Y k) = S (Y (k + 1)))
+    (hindep : LinearIndependent ℂ fun k : Fin n ↦ Y k)
+    (hdep : Y n = ∑ k ∈ Finset.range n, lam k • Y k)
+    (hx : x ≠ 0)
+    (hxeq : ∑ k ∈ Finset.range n, lam k * x ^ (n - k) = 1) :
+    (∑ k ∈ Finset.range n, pgvwc07ChainCoeff lam x k • Y k) ≠ 0 ∧
+      T (∑ k ∈ Finset.range n, pgvwc07ChainCoeff lam x k • Y k) =
+        x⁻¹ • S (∑ k ∈ Finset.range n, pgvwc07ChainCoeff lam x k • Y k) := by
+  classical
+  rcases n with - | m
+  · exact absurd hxeq (by simp)
+  have hlast : pgvwc07ChainCoeff lam x m = 1 := hxeq
+  constructor
+  · intro h0
+    have hfin : ∑ k : Fin (m + 1), pgvwc07ChainCoeff lam x (k : ℕ) • Y (k : ℕ) = 0 := by
+      rw [Fin.sum_univ_eq_sum_range fun k ↦ pgvwc07ChainCoeff lam x k • Y k]
+      exact h0
+    have hzero :=
+      Fintype.linearIndependent_iff.mp hindep (fun k : Fin (m + 1) ↦ pgvwc07ChainCoeff lam x k)
+        hfin ⟨m, Nat.lt_succ_self m⟩
+    rw [show (((⟨m, Nat.lt_succ_self m⟩ : Fin (m + 1)) : ℕ)) = m from rfl, hlast] at hzero
+    exact one_ne_zero hzero
+  · have step1 : T (∑ k ∈ Finset.range (m + 1), pgvwc07ChainCoeff lam x k • Y k) =
+        S (∑ k ∈ Finset.range (m + 1), pgvwc07ChainCoeff lam x k • Y (k + 1)) := by
+      rw [map_sum, map_sum]
+      refine Finset.sum_congr rfl fun k hk ↦ ?_
+      rw [map_smul, map_smul, hchain k (Finset.mem_range.mp hk)]
+    have hshift : (∑ k ∈ Finset.range m, pgvwc07ChainCoeff lam x k • Y (k + 1)) =
+        ∑ j ∈ Finset.range (m + 1),
+          (if j = 0 then 0 else pgvwc07ChainCoeff lam x (j - 1)) • Y j := by
+      rw [Finset.sum_range_succ']
+      simp
+    have step2 : (∑ k ∈ Finset.range (m + 1), pgvwc07ChainCoeff lam x k • Y (k + 1)) =
+        x⁻¹ • ∑ k ∈ Finset.range (m + 1), pgvwc07ChainCoeff lam x k • Y k := by
+      rw [Finset.sum_range_succ, hlast, one_smul, hdep, hshift, ← Finset.sum_add_distrib,
+        Finset.smul_sum]
+      refine Finset.sum_congr rfl fun j _ ↦ ?_
+      rw [← add_smul, smul_smul]
+      congr 1
+      rcases j with - | j'
+      · have h0 : pgvwc07ChainCoeff lam x 0 = lam 0 * x := by
+          simp [pgvwc07ChainCoeff]
+        rw [ite_eq_left rfl, zero_add, h0, mul_comm (lam 0) x, inv_mul_cancel_left₀ hx]
+      · rw [ite_eq_right (Nat.succ_ne_zero j'), Nat.succ_sub_one, pgvwc07ChainCoeff_succ,
+          inv_mul_cancel_left₀ hx]
+        ring
+    rw [step1, step2, map_smul]
+
+/-! ## The Kronecker intertwiner lemma `lem-horn` -/
+
+namespace Matrix
+
+variable {n m : Type*} [Fintype n] [Fintype m] [DecidableEq m]
+variable {R : Type*} [CommRing R]
+
+/-- The multiplicity slice of a matrix on a doubled index: the `(a, b)` slice
+of `W` is the matrix of entries `W (p, a) (q, b)`. This realizes the tensor
+factorization `M_{nm} = M_n ⊗ M_m` used in PGVWC07, Lemma `lem-horn`
+(arXiv:quant-ph/0608197, MPSarchive.tex lines 1073-1079). -/
+def kroneckerSlice (W : Matrix (n × m) (n × m) R) (a b : m) : Matrix n n R :=
+  fun p q ↦ W (p, a) (q, b)
+
+/-- **PGVWC07, Lemma `lem-horn`** (arXiv:quant-ph/0608197, MPSarchive.tex
+lines 1073-1079) in multiplicity-slice form: `W` solves the amplified matrix
+equation `W (C ⊗ 1) = (B ⊗ 1) W` if and only if every multiplicity slice of
+`W` solves the unamplified equation `X C = B X`. The source phrases this as
+the solution space of the amplified equation being `S ⊗ M_n` for `S` the
+solution space of `X C = B X`; the slice decomposition realizes exactly that
+tensor factorization. -/
+theorem kronecker_one_intertwines_iff_kroneckerSlice_intertwines
+    (B C : Matrix n n R) (W : Matrix (n × m) (n × m) R) :
+    W * (C ⊗ₖ (1 : Matrix m m R)) = (B ⊗ₖ (1 : Matrix m m R)) * W ↔
+      ∀ a b, kroneckerSlice W a b * C = B * kroneckerSlice W a b := by
+  constructor
+  · intro h a b
+    ext p q
+    have h' := congrFun (congrFun h (p, a)) (q, b)
+    simpa [kroneckerSlice, Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Fintype.sum_prod_type, mul_comm] using h'
+  · intro h
+    ext ⟨p, a⟩ ⟨q, b⟩
+    have h' := congrFun (congrFun (h a b) p) q
+    simpa [kroneckerSlice, Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Fintype.sum_prod_type, mul_comm] using h'
+
+/-- The consequence of PGVWC07 Lemma `lem-horn` used in the uniqueness and
+reconstruction proofs (arXiv:quant-ph/0608197, MPSarchive.tex line 1094): a
+nonzero simultaneous solution `W` of the amplified equations
+`W (C i ⊗ 1) = (B i ⊗ 1) W` yields a nonzero matrix `X` with `X * C i = B i * X`
+for every `i`. -/
+theorem exists_nonzero_intertwiner_of_kronecker_one_intertwines
+    {ι : Type*} (B C : ι → Matrix n n R) (W : Matrix (n × m) (n × m) R)
+    (hW : W ≠ 0)
+    (h : ∀ i, W * (C i ⊗ₖ (1 : Matrix m m R)) = (B i ⊗ₖ (1 : Matrix m m R)) * W) :
+    ∃ X : Matrix n n R, X ≠ 0 ∧ ∀ i, X * C i = B i * X := by
+  have hslice : ∃ a b, kroneckerSlice W a b ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    refine hW ?_
+    ext ⟨p, a⟩ ⟨q, b⟩
+    have := congrFun (congrFun (hall a b) p) q
+    simpa [kroneckerSlice] using this
+  obtain ⟨a, b, hab⟩ := hslice
+  exact ⟨kroneckerSlice W a b, hab, fun i ↦
+    (kronecker_one_intertwines_iff_kroneckerSlice_intertwines (B i) (C i) W).mp (h i) a b⟩
+
+end Matrix
+
+/-! ## The quadratic system (S) -/
+
+namespace MPSTensor
+
+variable {d D m : ℕ}
+
+/-- **PGVWC07 system (S)** (arXiv:quant-ph/0608197, MPSarchive.tex lines
+1139-1152). Over a supplied window `A` of open-boundary matrices on the
+doubled bond space (in the source, the `D ^ 2 × D ^ 2` matrices
+`A i (L₀ + 1), …, A i (L₀ + D ^ 4)` of the unique open-boundary canonical
+form, so that the window length is `D ^ 4`), a solution consists of matrices
+`Y j`, `Z (j + 1)` on the doubled bond space and a translation-invariant
+tensor `B` of bond dimension `D` satisfying the quadratic equations
+
+* `B i ⊗ 1 = Y j * A j i * Z (j + 1)` for all `i`, `j`;
+* `Y j * Z j = 1` at every window site where both unknowns are defined;
+* `∑ i, B i * (B i)ᴴ = 1`.
+
+Here `leftGauge j` is the source unknown `Y (L₀ + 1 + j)` and `rightGauge j`
+is the source unknown `Z (L₀ + 2 + j)`, both indexed from `j = 0`. -/
+structure QuadraticReconstructionSolution
+    (A : Fin m → Fin d → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) where
+  /-- The row unknowns `Y j` of system (S), zero-based over the window. -/
+  leftGauge : Fin m → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
+  /-- The column unknowns `Z (j + 1)` of system (S), zero-based over the
+  window: `rightGauge j` is the source unknown attached to the right of the
+  window site `j`. -/
+  rightGauge : Fin m → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
+  /-- The translation-invariant tensor unknowns `B i` of system (S). -/
+  tensor : MPSTensor d D
+  /-- The quadratic equations `B i ⊗ 1 = Y j * A i j * Z (j + 1)` of system
+  (S), MPSarchive.tex lines 1147-1149. -/
+  kronecker_eq : ∀ (i : Fin d) (j : Fin m),
+    tensor i ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) = leftGauge j * A j i * rightGauge j
+  /-- The inversion equations `Y j * Z j = 1` of system (S), MPSarchive.tex
+  line 1150, at the window sites where both unknowns are defined. -/
+  leftGauge_mul_rightGauge : ∀ (j : Fin m) (h : (j : ℕ) + 1 < m),
+    leftGauge ⟨(j : ℕ) + 1, h⟩ * rightGauge j = 1
+  /-- The normalization equation `∑ i, B i * (B i)ᴴ = 1` of system (S),
+  MPSarchive.tex line 1151. -/
+  sum_mul_conjTranspose : ∑ i, tensor i * (tensor i)ᴴ = 1
+
+namespace QuadraticReconstructionSolution
+
+variable {A : Fin m → Fin d → Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
+
+/-- In a solution of system (S), each row unknown paired by an inversion
+equation is invertible. This is the invertibility of the `Y j` used implicitly
+in the reconstruction argument of PGVWC07 (arXiv:quant-ph/0608197,
+MPSarchive.tex lines 1167-1176). -/
+theorem isUnit_leftGauge (s : QuadraticReconstructionSolution A)
+    {j : Fin m} (h : (j : ℕ) + 1 < m) :
+    IsUnit (s.leftGauge ⟨(j : ℕ) + 1, h⟩) :=
+  (Matrix.isUnit_iff_isUnit_det _).mpr
+    (Matrix.isUnit_det_of_right_inverse (s.leftGauge_mul_rightGauge j h))
+
+/-- In a solution of system (S), each column unknown paired by an inversion
+equation is invertible. This is the invertibility of the `Z j` used implicitly
+in the reconstruction argument of PGVWC07 (arXiv:quant-ph/0608197,
+MPSarchive.tex lines 1167-1176). -/
+theorem isUnit_rightGauge (s : QuadraticReconstructionSolution A)
+    {j : Fin m} (h : (j : ℕ) + 1 < m) :
+    IsUnit (s.rightGauge j) :=
+  (Matrix.isUnit_iff_isUnit_det _).mpr
+    (Matrix.isUnit_det_of_left_inverse (s.leftGauge_mul_rightGauge j h))
+
+end QuadraticReconstructionSolution
+
+end MPSTensor

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -329,8 +329,8 @@ boundary conventions.
     \begin{align}
         D_{\sigma_0}P\cdots D_{\sigma_{N-1}}P
          & =\operatorname{diag}\left(
-        \prod_{j=0}^{N-1}A_{j+k}^{\sigma_j}
-        \right)_{k=0}^{N-1}.
+                               \prod_{j=0}^{N-1}A_{j+k}^{\sigma_j}
+                               \right)_{k=0}^{N-1}.
         \label{eq:chain_cyclic_block_product}
     \end{align}
     Taking the trace of~(\ref{eq:chain_cyclic_block_product}) sums the traces
@@ -420,18 +420,18 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     matrices $Y_0,\ldots,Y_{m-1}$ and $Z_0,\ldots,Z_{m-1}$ in $\MN{D^2}$
     together with matrices $B_i\in\MN{D}$ satisfying
     \begin{align}
-        B_i\otimes\Id &= Y_j A^{[j]}_i Z_j &&\forall\, i,j,
-        \label{eq:quadratic_system_gauge}\\
-        Y_{j+1}Z_j &= \Id &&\forall\, j\le m-2,
-        \label{eq:quadratic_system_inverse}\\
-        \sum_i B_iB_i^{\dagger} &= \Id.
+        B_i\otimes\Id           & = Y_j A^{[j]}_i Z_j &  & \forall\, i,j,
+        \label{eq:quadratic_system_gauge}                                      \\
+        Y_{j+1}Z_j              & = \Id               &  & \forall\, j\le m-2,
+        \label{eq:quadratic_system_inverse}                                    \\
+        \sum_i B_iB_i^{\dagger} & = \Id.
         \label{eq:quadratic_system_normalization}
     \end{align}
     In the system~(S) of \cite{PerezGarcia2007Matrix} the window consists of
     the $m=D^4$ matrices of the unique open-boundary canonical form at the
     sites $L_0+1,\ldots,L_0+D^4$; the unknown $Y_j$ above is the source
-    unknown at site $L_0+1+j$, and $Z_j$ is the source unknown attached to
-    the right of that site.
+    unknown $Y_{L_0+1+j}$, while $Z_j$ is the source unknown
+    $Z_{L_0+2+j}$ attached to the right of that site.
 \end{definition}
 
 \begin{lemma}[Invertibility of the paired gauges]
@@ -460,12 +460,12 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     $0\le k\le n-1$, the vectors $Y_0,\ldots,Y_{n-1}$ are linearly
     independent, and
     \begin{align}
-        Y_n &= \sum_{k=0}^{n-1}\lambda_k Y_k.
+        Y_n & = \sum_{k=0}^{n-1}\lambda_k Y_k.
         \label{eq:chain_combination_dependence}
     \end{align}
     Let $x\neq0$ be a solution of the polynomial equation
     \begin{align}
-        \sum_{k=0}^{n-1}\lambda_k x^{n-k} &= 1,
+        \sum_{k=0}^{n-1}\lambda_k x^{n-k} & = 1,
         \label{eq:chain_combination_polynomial}
     \end{align}
     and define $\mu_j=\sum_{k=0}^{j}\lambda_k x^{j+1-k}$. Then the
@@ -483,7 +483,7 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     $T$ termwise and using the chain relation,
     \begin{align}
         T(Y)
-        &=\sum_{k=0}^{n-1}\mu_k S(Y_{k+1})
+         & =\sum_{k=0}^{n-1}\mu_k S(Y_{k+1})
         =S\Bigl(\sum_{k=0}^{n-2}\mu_k Y_{k+1}+Y_n\Bigr)
         =S\Bigl(\sum_{j=0}^{n-1}(\lambda_j+\mu_{j-1})Y_j\Bigr),
         \label{eq:chain_combination_reindex}
@@ -503,7 +503,7 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     \leanok
     Let $B,C\in\MN{n}$ and let $W$ act on the doubled space. Then
     \begin{align}
-        W(C\otimes\Id) &= (B\otimes\Id)W
+        W(C\otimes\Id) & = (B\otimes\Id)W
         \label{eq:kronecker_intertwiner_equation}
     \end{align}
     holds if and only if every multiplicity slice $X_{ab}$ of $W$, with
@@ -537,18 +537,20 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     $Z'_j$, and tensors $B_i$, $C_i$. For every window site $j$ carrying an
     inversion equation, the matrix
     \begin{align}
-        W_{j+1} &= Y'_{j+1}Z_j = Y'_{j+1}Y_{j+1}^{-1}
+        W_{j+1} & = Y'_{j+1}Z_j = Y'_{j+1}Y_{j+1}^{-1}
         \label{eq:solution_chain_intertwiner}
     \end{align}
     is invertible, and whenever the neighbouring site also carries an
     inversion equation,
     \begin{align}
-        W_{j+1}(B_i\otimes\Id) &= (C_i\otimes\Id)W_{j+2} &&\forall\, i.
+        W_{j+1}(B_i\otimes\Id) & = (C_i\otimes\Id)W_{j+2} &  & \forall\, i.
         \label{eq:solution_chain_relation}
     \end{align}
-    This is the chain of invertible intertwiners produced at the start of the
-    proof of \cite[Theorem~8]{PerezGarcia2007Matrix} by reasoning as in the
-    uniqueness theorem, and it is the input to
+    Thus a window of $m$ sites supplies exactly $m-1$ internal
+    intertwiners and $m-2$ relations between consecutive internal
+    intertwiners. This is the internal part of the chain produced at the start
+    of the proof of \cite[Theorem~8]{PerezGarcia2007Matrix}. It does not by
+    itself provide the linear dependence required by
     Lemma~\ref{lem:pgvwc07_chain_combination}.
 \end{lemma}
 
@@ -564,6 +566,7 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
 
 \begin{theorem}[Obtaining the translation-invariant canonical form]
     \label{thm:pgvwc07_quadratic_reconstruction}
+    \notready
     \uses{def:pgvwc07_quadratic_system}
     Consider a translation-invariant state with unique open-boundary
     canonical form such that the rank of each reduced density operator of
@@ -587,16 +590,22 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     \uses{lem:pgvwc07_chain_combination, lem:pgvwc07_kronecker_intertwiner,
         lem:pgvwc07_quadratic_system_units, lem:pgvwc07_solution_chain}
     The canonical representation solves the system by the freedom in the
-    open-boundary representation. Conversely, comparing a solution with the
-    canonical representation along the window produces the chain of
-    invertible intertwiners of Lemma~\ref{lem:pgvwc07_solution_chain}; the
-    combination of
-    Lemma~\ref{lem:pgvwc07_chain_combination} and the slice extraction of
-    Lemma~\ref{lem:pgvwc07_kronecker_intertwiner} produce a nonzero matrix
-    $R$ and a scalar $x\neq0$ with $RB_i=\tfrac1x A_iR$. The normalization
+    open-boundary representation. For the converse, a comparison of the two
+    open-boundary representations must first supply intertwiners at all
+    $D^4+1$ cuts around the $D^4$-site window, including both endpoint cuts,
+    together with the $D^4$ adjacent relations. Linear dependence in
+    $M_{D^2}(\C)$ then provides the hypothesis of
+    Lemma~\ref{lem:pgvwc07_chain_combination}. The internal construction in
+    Lemma~\ref{lem:pgvwc07_solution_chain} gives only $D^4-1$ intertwiners
+    and $D^4-2$ relations, so it does not force this dependence.
+
+    Once the full cut chain is supplied, the combination lemma and the slice
+    extraction of Lemma~\ref{lem:pgvwc07_kronecker_intertwiner} give a
+    nonzero matrix $R$ and a scalar $x\neq0$ with
+    $RB_i=\tfrac1x A_iR$. The normalization
     (\ref{eq:quadratic_system_normalization}), the invariance of the
     positive diagonal fixed point, and the uniqueness of the fixed point of
-    the transfer map under condition C1 force $|x|=1$ and $R$ unitary.
+    the transfer map under condition C1 then force $|x|=1$ and $R$ unitary.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -395,6 +395,167 @@ boundary conventions.
 \end{proof}
 
 %% ---------------------------------------------------------
+\section{Quadratic reconstruction of the translation-invariant canonical form}%
+\label{sec:quadratic_reconstruction}
+%% ---------------------------------------------------------
+
+A translation-invariant state whose successive reduced density operators have
+rank at most $D^2$ can be stored as an open-boundary matrix product state with
+$D^2\times D^2$ matrices. The reconstruction theorem of
+\cite[Theorem~8]{PerezGarcia2007Matrix} recovers a translation-invariant
+tensor of bond dimension $D$ from a window of $D^4$ consecutive matrices of
+the open-boundary canonical form by solving a system of quadratic equations
+whose size does not depend on the chain length. This section records the
+system and the two auxiliary results that drive the uniqueness half of the
+reconstruction argument, both stated in the source immediately before the
+proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
+
+\begin{definition}[Solution of the quadratic reconstruction system]
+    \label{def:pgvwc07_quadratic_system}
+    \lean{MPSTensor.QuadraticReconstructionSolution}
+    \leanok
+    Let a window of matrix families on the doubled bond space be given,
+    $A^{[j]}_i\in\MN{D^2}$ for $i\in\Fin{d}$ and $0\le j\le m-1$. A solution
+    of the quadratic reconstruction system over this window consists of
+    matrices $Y_0,\ldots,Y_{m-1}$ and $Z_0,\ldots,Z_{m-1}$ in $\MN{D^2}$
+    together with matrices $B_i\in\MN{D}$ satisfying
+    \begin{align}
+        B_i\otimes\Id &= Y_j A^{[j]}_i Z_j &&\forall\, i,j,
+        \label{eq:quadratic_system_gauge}\\
+        Y_{j+1}Z_j &= \Id &&\forall\, j\le m-2,
+        \label{eq:quadratic_system_inverse}\\
+        \sum_i B_iB_i^{\dagger} &= \Id.
+        \label{eq:quadratic_system_normalization}
+    \end{align}
+    In the system~(S) of \cite{PerezGarcia2007Matrix} the window consists of
+    the $m=D^4$ matrices of the unique open-boundary canonical form at the
+    sites $L_0+1,\ldots,L_0+D^4$; the unknown $Y_j$ above is the source
+    unknown at site $L_0+1+j$, and $Z_j$ is the source unknown attached to
+    the right of that site.
+\end{definition}
+
+\begin{lemma}[Invertibility of the paired gauges]
+    \label{lem:pgvwc07_quadratic_system_units}
+    \lean{MPSTensor.QuadraticReconstructionSolution.isUnit_leftGauge,
+        MPSTensor.QuadraticReconstructionSolution.isUnit_rightGauge}
+    \leanok
+    \uses{def:pgvwc07_quadratic_system}
+    In any solution of the quadratic reconstruction system, every matrix
+    $Y_{j+1}$ and every matrix $Z_j$ appearing
+    in~(\ref{eq:quadratic_system_inverse}) is invertible.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A square matrix with a one-sided inverse is invertible.
+\end{proof}
+
+\begin{lemma}[Nonzero combination along a shifted chain]
+    \label{lem:pgvwc07_chain_combination}
+    \lean{pgvwc07ChainCoeff, pgvwc07_chainCoeff_combination_spec}
+    \leanok
+    Let $T,S$ be linear maps defined on the same vector spaces, and let
+    $Y_0,\ldots,Y_n$ be vectors such that $T(Y_k)=S(Y_{k+1})$ for every
+    $0\le k\le n-1$, the vectors $Y_0,\ldots,Y_{n-1}$ are linearly
+    independent, and
+    \begin{align}
+        Y_n &= \sum_{k=0}^{n-1}\lambda_k Y_k.
+        \label{eq:chain_combination_dependence}
+    \end{align}
+    Let $x\neq0$ be a solution of the polynomial equation
+    \begin{align}
+        \sum_{k=0}^{n-1}\lambda_k x^{n-k} &= 1,
+        \label{eq:chain_combination_polynomial}
+    \end{align}
+    and define $\mu_j=\sum_{k=0}^{j}\lambda_k x^{j+1-k}$. Then the
+    combination $Y=\sum_{k=0}^{n-1}\mu_k Y_k$ is nonzero and satisfies
+    $T(Y)=\tfrac1x S(Y)$. This is the first auxiliary result before the proof
+    of \cite[Theorem~7]{PerezGarcia2007Matrix}, written with indices starting
+    at zero.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The coefficients satisfy $\mu_0=\lambda_0 x$ and the recurrence
+    $\mu_{j+1}=x(\lambda_{j+1}+\mu_j)$, and
+    (\ref{eq:chain_combination_polynomial}) states $\mu_{n-1}=1$. Applying
+    $T$ termwise and using the chain relation,
+    \begin{align}
+        T(Y)
+        &=\sum_{k=0}^{n-1}\mu_k S(Y_{k+1})
+        =S\Bigl(\sum_{k=0}^{n-2}\mu_k Y_{k+1}+Y_n\Bigr)
+        =S\Bigl(\sum_{j=0}^{n-1}(\lambda_j+\mu_{j-1})Y_j\Bigr),
+        \label{eq:chain_combination_reindex}
+    \end{align}
+    with the convention $\mu_{-1}=0$, where the last equality substitutes
+    (\ref{eq:chain_combination_dependence}). By the recurrence each
+    coefficient equals $\mu_j/x$, so the right-hand side is
+    $\tfrac1x S(Y)$. Since $\mu_{n-1}=1$ and $Y_0,\ldots,Y_{n-1}$ are
+    linearly independent, $Y\neq0$.
+\end{proof}
+
+\begin{lemma}[Amplified intertwiners factor through the multiplicity]
+    \label{lem:pgvwc07_kronecker_intertwiner}
+    \lean{Matrix.kroneckerSlice,
+        Matrix.kronecker_one_intertwines_iff_kroneckerSlice_intertwines,
+        Matrix.exists_nonzero_intertwiner_of_kronecker_one_intertwines}
+    \leanok
+    Let $B,C\in\MN{n}$ and let $W$ act on the doubled space. Then
+    \begin{align}
+        W(C\otimes\Id) &= (B\otimes\Id)W
+        \label{eq:kronecker_intertwiner_equation}
+    \end{align}
+    holds if and only if every multiplicity slice $X_{ab}$ of $W$, with
+    entries $(X_{ab})_{pq}=W_{(p,a),(q,b)}$, satisfies $X_{ab}C=BX_{ab}$.
+    Consequently a nonzero simultaneous solution $W$ of the amplified
+    equations for a family of pairs $(B_i,C_i)$ yields a nonzero matrix $X$
+    with $XC_i=B_iX$ for every $i$. This realizes the second auxiliary result
+    before the proof of \cite[Theorem~7]{PerezGarcia2007Matrix}, which
+    phrases the solution space of~(\ref{eq:kronecker_intertwiner_equation})
+    as $\mathcal{S}\otimes M_n$ for $\mathcal{S}$ the solution space of
+    $XC=BX$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Evaluating both sides of~(\ref{eq:kronecker_intertwiner_equation}) at a
+    pair of doubled indices reduces the identity factor to a Kronecker delta,
+    which collapses the double sum to the slice products $X_{ab}C$ and
+    $BX_{ab}$. For the consequence, a nonzero $W$ has a nonzero slice.
+\end{proof}
+
+\begin{theorem}[Obtaining the translation-invariant canonical form]
+    \label{thm:pgvwc07_quadratic_reconstruction}
+    \uses{def:pgvwc07_quadratic_system}
+    Consider a translation-invariant state with unique open-boundary
+    canonical form such that the rank of each reduced density operator of
+    successive spins is bounded by $D^2$, and form the quadratic system of
+    Definition~\ref{def:pgvwc07_quadratic_system} over the window of $D^4$
+    open-boundary canonical matrices starting after the injectivity onset.
+    Then a translation-invariant matrix product representation satisfying
+    condition C1 exists if and only if the system has a solution, and the
+    tensor of any solution is a translation-invariant representation of the
+    state, related to the canonical one by a unitary $U$ through
+    $A_i=UB_iU^{\dagger}$. This is \cite[Theorem~8]{PerezGarcia2007Matrix};
+    its formalization is not yet complete.
+\end{theorem}
+
+\begin{proof}
+    \uses{lem:pgvwc07_chain_combination, lem:pgvwc07_kronecker_intertwiner,
+        lem:pgvwc07_quadratic_system_units}
+    The canonical representation solves the system by the freedom in the
+    open-boundary representation. Conversely, comparing a solution with the
+    canonical representation along the window produces a chain of invertible
+    matrices intertwining consecutive amplified tensors; the combination of
+    Lemma~\ref{lem:pgvwc07_chain_combination} and the slice extraction of
+    Lemma~\ref{lem:pgvwc07_kronecker_intertwiner} produce a nonzero matrix
+    $R$ and a scalar $x\neq0$ with $RB_i=\tfrac1x A_iR$. The normalization
+    (\ref{eq:quadratic_system_normalization}), the invariance of the
+    positive diagonal fixed point, and the uniqueness of the fixed point of
+    the transfer map under condition C1 force $|x|=1$ and $R$ unitary.
+\end{proof}
+
+%% ---------------------------------------------------------
 \section{One-sided inverse and physical realisation of virtual insertions}%
 \label{sec:decomposition_map}
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -452,7 +452,8 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
 
 \begin{lemma}[Nonzero combination along a shifted chain]
     \label{lem:pgvwc07_chain_combination}
-    \lean{pgvwc07ChainCoeff, pgvwc07_chainCoeff_combination_spec}
+    \lean{pgvwc07ChainCoeff, pgvwc07ChainCoeff_succ,
+        pgvwc07_chainCoeff_combination_spec}
     \leanok
     Let $T,S$ be linear maps defined on the same vector spaces, and let
     $Y_0,\ldots,Y_n$ be vectors such that $T(Y_k)=S(Y_{k+1})$ for every
@@ -524,6 +525,43 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     $BX_{ab}$. For the consequence, a nonzero $W$ has a nonzero slice.
 \end{proof}
 
+\begin{lemma}[Chain of intertwiners between two solutions]
+    \label{lem:pgvwc07_solution_chain}
+    \lean{MPSTensor.QuadraticReconstructionSolution.chainIntertwiner,
+        MPSTensor.QuadraticReconstructionSolution.isUnit_chainIntertwiner,
+        MPSTensor.QuadraticReconstructionSolution.chainIntertwiner_mul_kronecker}
+    \leanok
+    \uses{def:pgvwc07_quadratic_system, lem:pgvwc07_quadratic_system_units}
+    Let two solutions of the quadratic reconstruction system over the same
+    window be given, with row unknowns $Y_j$, $Y'_j$, column unknowns $Z_j$,
+    $Z'_j$, and tensors $B_i$, $C_i$. For every window site $j$ carrying an
+    inversion equation, the matrix
+    \begin{align}
+        W_{j+1} &= Y'_{j+1}Z_j = Y'_{j+1}Y_{j+1}^{-1}
+        \label{eq:solution_chain_intertwiner}
+    \end{align}
+    is invertible, and whenever the neighbouring site also carries an
+    inversion equation,
+    \begin{align}
+        W_{j+1}(B_i\otimes\Id) &= (C_i\otimes\Id)W_{j+2} &&\forall\, i.
+        \label{eq:solution_chain_relation}
+    \end{align}
+    This is the chain of invertible intertwiners produced at the start of the
+    proof of \cite[Theorem~8]{PerezGarcia2007Matrix} by reasoning as in the
+    uniqueness theorem, and it is the input to
+    Lemma~\ref{lem:pgvwc07_chain_combination}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both solutions express $B_i\otimes\Id$ and $C_i\otimes\Id$ through the
+    same window matrix at site $j+1$; substituting one expression into the
+    other and cancelling the paired gauges with
+    (\ref{eq:quadratic_system_inverse}) gives
+    (\ref{eq:solution_chain_relation}). Invertibility follows from
+    Lemma~\ref{lem:pgvwc07_quadratic_system_units}.
+\end{proof}
+
 \begin{theorem}[Obtaining the translation-invariant canonical form]
     \label{thm:pgvwc07_quadratic_reconstruction}
     \uses{def:pgvwc07_quadratic_system}
@@ -532,21 +570,27 @@ proof of the uniqueness theorem \cite[Theorem~7]{PerezGarcia2007Matrix}.
     successive spins is bounded by $D^2$, and form the quadratic system of
     Definition~\ref{def:pgvwc07_quadratic_system} over the window of $D^4$
     open-boundary canonical matrices starting after the injectivity onset.
-    Then a translation-invariant matrix product representation satisfying
-    condition C1 exists if and only if the system has a solution, and the
-    tensor of any solution is a translation-invariant representation of the
-    state, related to the canonical one by a unitary $U$ through
-    $A_i=UB_iU^{\dagger}$. This is \cite[Theorem~8]{PerezGarcia2007Matrix};
-    its formalization is not yet complete.
+    \begin{enumerate}
+        \item If the state admits a translation-invariant matrix product
+              representation satisfying condition C1, then the system has a
+              solution.
+        \item The tensor of any solution is a translation-invariant
+              matrix product representation of the state with matrices of
+              size $D\times D$, related to the canonical one by a unitary
+              $U$ through $A_i=UB_iU^{\dagger}$.
+    \end{enumerate}
+    This is \cite[Theorem~8]{PerezGarcia2007Matrix}; its formalization is
+    not yet complete.
 \end{theorem}
 
 \begin{proof}
     \uses{lem:pgvwc07_chain_combination, lem:pgvwc07_kronecker_intertwiner,
-        lem:pgvwc07_quadratic_system_units}
+        lem:pgvwc07_quadratic_system_units, lem:pgvwc07_solution_chain}
     The canonical representation solves the system by the freedom in the
     open-boundary representation. Conversely, comparing a solution with the
-    canonical representation along the window produces a chain of invertible
-    matrices intertwining consecutive amplified tensors; the combination of
+    canonical representation along the window produces the chain of
+    invertible intertwiners of Lemma~\ref{lem:pgvwc07_solution_chain}; the
+    combination of
     Lemma~\ref{lem:pgvwc07_chain_combination} and the slice extraction of
     Lemma~\ref{lem:pgvwc07_kronecker_intertwiner} produce a nonzero matrix
     $R$ and a scalar $x\neq0$ with $RB_i=\tfrac1x A_iR$. The normalization

--- a/docs/paper-gaps/pgvwc07_intertwiner_chain_off_by_one.tex
+++ b/docs/paper-gaps/pgvwc07_intertwiner_chain_off_by_one.tex
@@ -1,0 +1,79 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Intertwiner Count in the Quadratic Reconstruction Argument}
+\author{}
+\date{2026-08-22}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{open}
+
+\section{The printed dependence step}
+
+The proof of Theorem~7 of P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac
+\cite{PerezGarcia2007Matrix} compares two translation-invariant matrix product
+representations through matrices acting on a $D^2$-dimensional doubled bond
+space. The local source is
+\path{Papers/quant-ph_0608197/MPSarchive.tex}, lines~1080--1095. It produces
+$D^4$ invertible matrices $W_1,\ldots,W_{D^4}$ satisfying
+\begin{align}
+    W_k(C_i\otimes I) & =(B_i\otimes I)W_{k+1}
+                      &                        & (1\leq k\leq D^4-1),                                      \label{eq:source-chain}
+\end{align}
+and then chooses an index $n$ for which $W_1,\ldots,W_{n-1}$ are linearly
+independent but $W_n$ belongs to their span.
+
+The ambient matrix space is
+\begin{align}
+    M_{D^2}(\mathbb C),\qquad \dim_{\mathbb C}M_{D^2}(\mathbb C)=D^4.
+\end{align}
+Consequently, $D^4$ matrices need not be linearly dependent. The dependence
+asserted after~\eqref{eq:source-chain} does not follow from the printed count.
+
+\section{The corrected cut count}
+
+A window of $D^4$ consecutive open-boundary matrices has $D^4+1$ cuts: one
+before the first site, one after the last site, and $D^4-1$ internal cuts. If a
+comparison of the two open-boundary representations supplies an intertwiner at
+every cut, then one obtains
+\begin{align}
+    W_0,W_1,\ldots,W_{D^4} & \in M_{D^2}(\mathbb C),                 \label{eq:full-chain}                                                                                       \\
+    W_k(C_i\otimes I)      & =(B_i\otimes I)W_{k+1}
+                           &                                                               & (0\leq k\leq D^4-1).                                      \label{eq:full-relations}
+\end{align}
+The $D^4+1$ vectors in~\eqref{eq:full-chain} are necessarily linearly
+dependent as a family. Since every $W_k$ is invertible, $W_0\neq0$. Choose the
+first dependent vector. Then there is an index $1\leq n\leq D^4$ such that
+$W_0,\ldots,W_{n-1}$ are linearly independent and $W_n$ lies in their span.
+After shifting indices, this is exactly the dependence hypothesis required by
+the chain-combination lemma at source lines~1022--1049.
+
+The current formal quadratic-system structure stores only gauges attached to
+the $D^4$ sites. It therefore constructs the $D^4-1$ internal-cut
+intertwiners and proves the $D^4-2$ relations between consecutive internal
+cuts. It has no fields representing the gauges at the two endpoint cuts.
+Those endpoint intertwiners must be derived from a future comparison theorem
+for the surrounding open-boundary representations. They are not consequences
+of the internal quadratic equations alone.
+
+\section{Verdict}
+
+The source's $D^4$-intertwiner count is off by one for the stated dimension
+argument. The local correction is to use the full chain of $D^4+1$ cut
+intertwiners around the $D^4$-site window. Once the two endpoint cuts and all
+$D^4$ adjacent relations are supplied, linear dependence and the subsequent
+combination argument are valid. The formal development currently proves only
+the internal chain and does not claim that this chain forces dependence, so
+the reconstruction capstone remains open.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -89,7 +89,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L183 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L320, 326, 332, 346, 357, 363 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L441, 955, 959, 965, 970 `tenkz` → `P-grid` | — | — |
-| `ch23_algebraic_ft_foundations.tex` | L48, 52, 490, 494, 694, 698, 711, 715, 758, 762, 766, 775, 779 `tenkz` → `P-grid` | — | — |
+| `ch23_algebraic_ft_foundations.tex` | L48, 52, 704, 708, 908, 912, 925, 929, 972, 976, 980, 989, 993 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | L82, 102, 287, 293, 305, 317, 569, 588 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

Formalizes the quadratic reconstruction infrastructure for the theorem "Obtaining the TI canonical form" of PGVWC07 (arXiv:quant-ph/0608197, `MPSarchive.tex` lines 1154-1165): the system (S) of quadratic equations, the two auxiliary lemmas its proof reduces to, and the chain of invertible intertwiners comparing two solutions of (S).

Part of #6089. Parent tracker: #6085.

## New declarations (`TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean`)

- `MPSTensor.QuadraticReconstructionSolution`: a solution of system (S) (lines 1139-1152) over a supplied window of open-boundary matrices on the doubled bond space: the quadratic equations `B_i ⊗ 1 = Y_j A^{[j]}_i Z_{j+1}`, the inversion equations `Y_j Z_j = 1` at paired sites, and the normalization `∑_i B_i B_i† = 1`.
- `pgvwc07ChainCoeff`, `pgvwc07ChainCoeff_succ`, `pgvwc07_chainCoeff_combination_spec`: Lemma `lem-same-matr` (lines 1023-1052), zero-based; the combination `Y = ∑ μ_k Y_k` is nonzero and satisfies `T(Y) = x⁻¹ S(Y)`.
- `Matrix.kroneckerSlice`, `Matrix.kronecker_one_intertwines_iff_kroneckerSlice_intertwines`, `Matrix.exists_nonzero_intertwiner_of_kronecker_one_intertwines`: Lemma `lem-horn` (lines 1073-1079) in multiplicity-slice form, plus the nonzero-intertwiner consequence used at line 1094.
- `MPSTensor.QuadraticReconstructionSolution.isUnit_leftGauge` / `isUnit_rightGauge`: invertibility of the paired gauge unknowns.
- `MPSTensor.QuadraticReconstructionSolution.chainIntertwiner`, `isUnit_chainIntertwiner`, `chainIntertwiner_mul_kronecker`: the invertible chain `W_{j+1} = Y'_{j+1} Z_j` comparing two solutions of (S) with `W_{j+1}(B_i ⊗ 1) = (C_i ⊗ 1) W_{j+2}`, the opening step of the reconstruction proof (lines 1168-1179).

## Statement-integrity audit

- **Paper assumptions vs Lean assumptions.** System (S) is stated over an arbitrary window of `D² × D²` matrix families, exactly the unknowns and equations displayed at lines 1139-1152; the inversion equations are imposed precisely at the sites where both unknowns exist, matching the source's index ranges (`Y_j, Z_{j+1}` for `j = L₀+1, ..., L₀+D⁴`). `lem-same-matr` is stated with the source's hypothesis set (chain relation, linear independence of the first `n` vectors, dependence of the last, nonzero root of the polynomial equation), translated to zero-based indices. `lem-horn` is stated as an equivalence between the amplified equation and the sliced equations, which realizes the source's tensor-factorization statement of the solution space; no extra hypotheses.
- **Paper conclusion vs Lean conclusion.** `lem-same-matr`: nonzero combination with `T(Y) = (1/x) S(Y)`, as in the source. `lem-horn`: the slice equivalence plus the nonzero-intertwiner extraction the source uses. The chain lemma proves the relation the source obtains "reasoning as in the proof of Theorem thm-uniq"; the invertibility of the chain matrices matches the source's "invertible W₁ ... W_{D⁴}".
- **Proof status.** All declarations fully proved; no `sorry`, no `axiom`.
- **Faithfulness verdict.** Faithful for everything tagged `\leanok`. The reconstruction theorem itself (lines 1154-1165) is stated in the blueprint in the source's two-part form without Lean tags; its remaining obligations (canonical representation solves (S); dependence step, modulus-one and unitarity arguments requiring the open-boundary uniqueness machinery) are recorded in the blueprint proof sketch and left for follow-up.

## Blueprint

New section "Quadratic reconstruction of the translation-invariant canonical form" in the algebraic-foundations chapter: definition and three lemma entries with `\lean{...}`/`\leanok`, and the reconstruction theorem stated without `\leanok` pending its formalization.

## Validation

- `lake build TNLean.MPS.CanonicalForm.QuadraticReconstruction` (clean, linter-bearing)
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean` (no matches)
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` (in sync)
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/QuadraticReconstruction.lean --diff-base origin/main --diff-head HEAD` (no missing entries)
- `python3 scripts/generate_import_aggregators.py` (no changes needed)

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E
