### PR TITLE
feat(MPS/ParentHamiltonian): half-chain Schmidt spectrum of the dual fixed point

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -50,6 +50,7 @@ import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+import TNLean.MPS.ParentHamiltonian.HalfChainSchmidt
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.LimitingGramMetric

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -1,0 +1,436 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import TNLean.Algebra.OperatorNormFrobenius
+import TNLean.Analysis.SpectralRadiusPowerDecay
+import TNLean.Channel.Primitive
+import TNLean.MPS.Core.TransferChannel
+import TNLean.MPS.Overlap.Basic
+
+/-!
+# Half-chain Schmidt reduction for a translation-invariant MPS ring
+
+On a ring of `2 L` sites the translation-invariant MPS coefficient at a split
+configuration `(σ, τ)` is `tr(A_σ A_τ) = ∑_{α,β} ⟨α|A_σ|β⟩ ⟨β|A_τ|α⟩`, so the
+state is the image of a boundary pairing under the two half-chain families
+`|Ψ_{α,β}⟩ = ∑_σ ⟨α|A_σ|β⟩ |σ⟩`.  This file formalizes the
+Schmidt-decomposition calculation behind the half-chain interpretation of the
+dual fixed point: the unnormalized half-chain reduced density matrix factors
+exactly through the half-chain overlap Gram matrix, its characteristic
+polynomial agrees (away from zero) with that of a `D² × D²` comparison matrix
+built from the `L`-fold transfer map, and the Gram entries converge
+geometrically to the entries of the rank-one fixed-point projection, with rate
+controlled by the subleading spectrum of the transfer map.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 6 ("Interpretation of
+`Λ`", `MPSarchive.tex` lines 987--993) and the Schmidt-decomposition
+calculation at lines 970--985.  The gauge convention here places the
+trace-preserving direction on the transfer map itself, so the source's
+positive diagonal dual fixed point `Λ` appears as the fixed point of
+`transferMap A`; the source's unit fixed point corresponds to the dual
+(trace-adjoint) direction.
+
+## Main results
+
+- `MPSTensor.halfChainKernel_eq_mul`: the ring coefficient kernel factors
+  through the half-chain families (lines 970--976).
+- `MPSTensor.halfChainGram_apply_eq_transferMap_pow`: the half-chain overlap
+  Gram entries are matrix elements of the `L`-fold transfer map on matrix
+  units (the display `⟨Ψ_{α,β}|Ψ_{α',β'}⟩ = ⟨α'|E^{N/2}(|β'⟩⟨β|)|α⟩`,
+  lines 977--979).
+- `MPSTensor.halfChainReducedMatrix_eq_mul_swap_gram`: the unnormalized
+  half-chain reduced density matrix equals `Ψ W Ψᴴ` with `W` the
+  index-swapped Gram matrix of the complementary half (lines 979--985).
+- `MPSTensor.charpoly_halfChainReducedMatrix`: away from zero, the spectrum
+  of the half-chain reduced density matrix is that of the `D² × D²`
+  comparison matrix `W · G`.
+- `MPSTensor.exists_geometric_bound_halfChainGram_sub_fixedPointProj`: the
+  transfer-error term, geometric in `L` under a complementary spectral-radius
+  gap (the correction "of the order `|ν₂|^{N/2}`", lines 979--981).
+- `MPSTensor.fixedPointProj_single_entry_diagonal`: for diagonal `Λ` the
+  limiting Gram matrix is the diagonal matrix of eigenvalues of `Λ`
+  (the display `λ_α δ_{α,α'} δ_{β,β'}`, line 979).
+-/
+
+open scoped Matrix Matrix.Norms.L2Operator ComplexOrder
+open Matrix Polynomial
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The half-chain family of PGVWC07: the matrix whose column at boundary pair
+`(α, β)` is the half-chain vector `|Ψ_{α,β}⟩ = ∑_σ ⟨α|A_σ|β⟩ |σ⟩`.
+Source: arXiv:quant-ph/0608197, lines 970--976. -/
+noncomputable def halfChainMatrix (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Cfg d L) (Fin D × Fin D) ℂ :=
+  Matrix.of fun σ p => evalWord A (List.ofFn σ) p.1 p.2
+
+@[simp]
+theorem halfChainMatrix_apply (A : MPSTensor d D) (L : ℕ) (σ : Cfg d L)
+    (p : Fin D × Fin D) :
+    halfChainMatrix A L σ p = evalWord A (List.ofFn σ) p.1 p.2 := rfl
+
+/-- The complementary half-chain family with swapped boundary indices: the row
+at `(α, β)` is the vector `|Ψ_{β,α}⟩` appearing on the second half of the ring
+in `|ψ⟩ = ∑_{α,β} |Ψ_{α,β}⟩ |Ψ_{β,α}⟩`.
+Source: arXiv:quant-ph/0608197, lines 970--976. -/
+noncomputable def halfChainSwapMatrix (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Fin D × Fin D) (Cfg d L) ℂ :=
+  Matrix.of fun p τ => evalWord A (List.ofFn τ) p.2 p.1
+
+@[simp]
+theorem halfChainSwapMatrix_apply (A : MPSTensor d D) (L : ℕ)
+    (p : Fin D × Fin D) (τ : Cfg d L) :
+    halfChainSwapMatrix A L p τ = evalWord A (List.ofFn τ) p.2 p.1 := rfl
+
+/-- The coefficient kernel of the ring of `2 L` sites, read as a matrix over
+the two half-chain configuration spaces: the entry at `(σ, τ)` is the MPS
+coefficient `tr(A_σ A_τ)` of the joined configuration.
+Source: arXiv:quant-ph/0608197, lines 970--976. -/
+noncomputable def halfChainKernel (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Cfg d L) (Cfg d L) ℂ :=
+  Matrix.of fun σ τ => mpv A (Fin.append σ τ)
+
+@[simp]
+theorem halfChainKernel_apply (A : MPSTensor d D) (L : ℕ) (σ τ : Cfg d L) :
+    halfChainKernel A L σ τ = mpv A (Fin.append σ τ) := rfl
+
+/-- Splitting the ring trace at the two boundaries: the coefficient kernel is
+the product of the half-chain family with its index-swapped complement.  This
+is the resolution of the identity producing
+`|ψ⟩ = ∑_{α,β} |Ψ_{α,β}⟩ |Ψ_{β,α}⟩`.
+Source: arXiv:quant-ph/0608197, lines 970--976. -/
+theorem halfChainKernel_eq_mul (A : MPSTensor d D) (L : ℕ) :
+    halfChainKernel A L = halfChainMatrix A L * halfChainSwapMatrix A L := by
+  ext σ τ
+  rw [halfChainKernel_apply, mpv_eq, coeff_eq, List.ofFn_fin_append, evalWord_append,
+    Matrix.mul_apply]
+  simp [Matrix.trace, Matrix.mul_apply, Fintype.sum_prod_type]
+
+/-- The unnormalized half-chain reduced density matrix of the ring state on
+`2 L` sites: the second half of the ring is traced out from the rank-one state
+built from the coefficient kernel.
+Source: arXiv:quant-ph/0608197, lines 979--985. -/
+noncomputable def halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Cfg d L) (Cfg d L) ℂ :=
+  halfChainKernel A L * (halfChainKernel A L)ᴴ
+
+/-- Entrywise, the half-chain reduced density matrix is the partial trace of
+the ring state over the complementary half-chain configurations. -/
+theorem halfChainReducedMatrix_apply (A : MPSTensor d D) (L : ℕ) (σ σ' : Cfg d L) :
+    halfChainReducedMatrix A L σ σ' =
+      ∑ τ : Cfg d L, mpv A (Fin.append σ τ) * star (mpv A (Fin.append σ' τ)) := by
+  simp [halfChainReducedMatrix, Matrix.mul_apply]
+
+/-- The half-chain reduced density matrix is positive semidefinite. -/
+theorem posSemidef_halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
+    (halfChainReducedMatrix A L).PosSemidef :=
+  Matrix.posSemidef_self_mul_conjTranspose _
+
+/-- The half-chain overlap Gram matrix
+`G_{(α,β),(α',β')} = ⟨Ψ_{α,β}|Ψ_{α',β'}⟩`.
+Source: arXiv:quant-ph/0608197, lines 977--979. -/
+noncomputable def halfChainGram (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  (halfChainMatrix A L)ᴴ * halfChainMatrix A L
+
+/-- The half-chain overlap is a matrix element of the iterated transfer map on
+a matrix unit: `⟨Ψ_{α,β}|Ψ_{α',β'}⟩ = (E^L(|β'⟩⟨β|))_{α',α}`.
+Source: arXiv:quant-ph/0608197, the display at lines 977--979. -/
+theorem halfChainGram_apply_eq_transferMap_pow (A : MPSTensor d D) (L : ℕ)
+    (p q : Fin D × Fin D) :
+    halfChainGram A L p q =
+      (((transferMap (d := d) (D := D) A) ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1 := by
+  classical
+  have hmul (W : Matrix (Fin D) (Fin D) ℂ) (a b c e : Fin D) :
+      ((W * Matrix.single c a 1 * Wᴴ : Matrix (Fin D) (Fin D) ℂ) e b) =
+        W e c * star (W b a) := by
+    rw [Matrix.mul_apply]
+    calc
+      ∑ j, ((W * Matrix.single c a 1 : Matrix (Fin D) (Fin D) ℂ) e j) * Wᴴ j b =
+          ((W * Matrix.single c a 1 : Matrix (Fin D) (Fin D) ℂ) e a) * Wᴴ a b := by
+        apply Finset.sum_eq_single a
+        · intro j _ hja
+          rw [Matrix.mul_apply]
+          simp [hja.symm]
+        · simp
+      _ = W e c * star (W b a) := by
+        rw [Matrix.mul_apply]
+        simp [Matrix.single_apply]
+  rw [halfChainGram, Matrix.mul_apply, transferMap_pow_apply' A L, Matrix.sum_apply]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  rw [hmul (evalWord A (List.ofFn σ)) p.2 p.1 q.2 q.1]
+  simp [mul_comm]
+
+/-- The Gram matrix of the complementary half-chain family is the transpose of
+the boundary-swapped Gram matrix of the first half. -/
+theorem halfChainSwapMatrix_mul_conjTranspose (A : MPSTensor d D) (L : ℕ) :
+    halfChainSwapMatrix A L * (halfChainSwapMatrix A L)ᴴ =
+      ((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ := by
+  ext p q
+  simp only [Matrix.mul_apply, halfChainSwapMatrix_apply, Matrix.conjTranspose_apply,
+    Matrix.transpose_apply, Matrix.submatrix_apply, Prod.fst_swap, Prod.snd_swap,
+    halfChainGram, halfChainMatrix_apply]
+  exact Finset.sum_congr rfl fun τ _ => mul_comm _ _
+
+/-- The Schmidt-decomposition calculation of PGVWC07: the unnormalized
+half-chain reduced density matrix factors exactly as `Ψ (S Gᵀ S) Ψᴴ`, where
+`Ψ` is the half-chain family, `G` the half-chain Gram matrix, and `S` the swap
+of the two boundary indices.
+Source: arXiv:quant-ph/0608197, lines 979--985. -/
+theorem halfChainReducedMatrix_eq_mul_swap_gram (A : MPSTensor d D) (L : ℕ) :
+    halfChainReducedMatrix A L =
+      halfChainMatrix A L *
+        (((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ *
+          (halfChainMatrix A L)ᴴ) := by
+  rw [halfChainReducedMatrix, halfChainKernel_eq_mul, ← halfChainSwapMatrix_mul_conjTranspose,
+    Matrix.conjTranspose_mul]
+  simp only [Matrix.mul_assoc]
+
+/-- Away from zero, the spectrum of the half-chain reduced density matrix is
+computed by the `D² × D²` comparison matrix `(S Gᵀ S) · G` built from the
+half-chain Gram matrix: the two characteristic polynomials agree after
+matching the trivial kernel factors.  This reduces the half-chain spectral
+comparison of PGVWC07, Theorem 6, to the boundary comparison matrix.
+Source: arXiv:quant-ph/0608197, lines 979--993. -/
+theorem charpoly_halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
+    X ^ (D * D) * (halfChainReducedMatrix A L).charpoly =
+      X ^ d ^ L *
+        (((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ *
+          halfChainGram A L).charpoly := by
+  have h := Matrix.charpoly_mul_comm' (halfChainMatrix A L)
+    (((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ * (halfChainMatrix A L)ᴴ)
+  rw [← halfChainReducedMatrix_eq_mul_swap_gram, Matrix.mul_assoc,
+    show (halfChainMatrix A L)ᴴ * halfChainMatrix A L = halfChainGram A L from rfl] at h
+  simpa [Fintype.card_prod, Fintype.card_fin, Fintype.card_fun] using h
+
+section Convergence
+
+/-- Transfer-error control for the half-chain overlaps: if the transfer map is
+trace preserving with fixed point `Λ` and the complementary part of the
+transfer map has spectral radius below one, then every half-chain Gram entry
+converges geometrically to the corresponding entry of the rank-one fixed-point
+projection, uniformly in the boundary indices.  This is the correction term
+"of the order `|ν₂|^{N/2}`" controlled by the subleading spectrum.
+Source: arXiv:quant-ph/0608197, lines 977--981. -/
+theorem exists_geometric_bound_halfChainGram_sub_fixedPointProj
+    (A : MPSTensor d D) (Λ : Matrix (Fin D) (Fin D) ℂ)
+    (htr : Matrix.trace Λ ≠ 0)
+    (hTP : IsTracePreservingMap (transferMap A))
+    (hΛ : transferMap A Λ = Λ)
+    (hgap : spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap A - fixedPointProj Λ htr)) < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ L, 1 ≤ L → ∀ p q : Fin D × Fin D,
+      ‖halfChainGram A L p q -
+        fixedPointProj Λ htr (Matrix.single q.2 p.2 1) q.1 p.1‖ ≤ C * r ^ L := by
+  set N := transferMap (d := d) (D := D) A - fixedPointProj Λ htr with hN
+  set T := (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N with hT
+  obtain ⟨C, r, hC, hr0, hr1, hbound⟩ :=
+    geometric_bound_of_spectralRadius_lt_one T (by simpa [hT, hN] using hgap)
+  refine ⟨C, r, hC, hr0, hr1, fun L hL p q => ?_⟩
+  have hpow : (transferMap (d := d) (D := D) A) ^ L = fixedPointProj Λ htr + N ^ L :=
+    pow_eq_fixedPointProj_add_compl_pow (E := transferMap A) (ρ := Λ) htr hTP hΛ hL
+  have hentry : halfChainGram A L p q -
+      fixedPointProj Λ htr (Matrix.single q.2 p.2 1) q.1 p.1 =
+      ((N ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1 := by
+    rw [halfChainGram_apply_eq_transferMap_pow, hpow]
+    simp [Matrix.add_apply]
+  rw [hentry]
+  have hentry_le : ‖((N ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1‖ ≤
+      ‖(N ^ L) (Matrix.single q.2 p.2 1)‖ := by
+    have hsum := Matrix.sum_column_norm_sq_le_norm_sq ((N ^ L) (Matrix.single q.2 p.2 1)) p.1
+    have hterm : ‖((N ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1‖ ^ 2 ≤
+        ∑ k, ‖((N ^ L) (Matrix.single q.2 p.2 1)) k p.1‖ ^ 2 :=
+      Finset.single_le_sum
+        (f := fun k => ‖((N ^ L) (Matrix.single q.2 p.2 1)) k p.1‖ ^ 2)
+        (fun k _ => sq_nonneg _) (Finset.mem_univ q.1)
+    nlinarith [norm_nonneg (((N ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1),
+      norm_nonneg ((N ^ L) (Matrix.single q.2 p.2 1))]
+  have hop : ‖(N ^ L) (Matrix.single q.2 p.2 1)‖ ≤ ‖T ^ L‖ := by
+    have happly : (N ^ L) (Matrix.single q.2 p.2 1) = (T ^ L) (Matrix.single q.2 p.2 1) := by
+      rw [hT, ← map_pow]
+      rfl
+    calc ‖(N ^ L) (Matrix.single q.2 p.2 1)‖
+        = ‖(T ^ L) (Matrix.single q.2 p.2 1)‖ := by rw [happly]
+      _ ≤ ‖T ^ L‖ * ‖(Matrix.single q.2 p.2 1 : Matrix (Fin D) (Fin D) ℂ)‖ :=
+          (T ^ L).le_opNorm _
+      _ = ‖T ^ L‖ := by rw [Matrix.l2_opNorm_single_one, mul_one]
+  calc ‖((N ^ L) (Matrix.single q.2 p.2 1)) q.1 p.1‖
+      ≤ ‖(N ^ L) (Matrix.single q.2 p.2 1)‖ := hentry_le
+    _ ≤ ‖T ^ L‖ := hop
+    _ ≤ C * r ^ L := hbound L
+
+/-- For a positive diagonal fixed point `Λ = diag(λ_1, …, λ_D)` the limiting
+Gram entries reproduce the source's display `λ_α δ_{α,α'} δ_{β,β'}` up to the
+trace normalization: the limiting Gram matrix is diagonal in the boundary
+pairs with entry `λ_α / tr Λ` at `(α, β)`.
+Source: arXiv:quant-ph/0608197, line 979. -/
+theorem fixedPointProj_single_entry_diagonal
+    (lam : Fin D → ℂ) (htr : Matrix.trace (Matrix.diagonal lam) ≠ 0)
+    (p q : Fin D × Fin D) :
+    fixedPointProj (Matrix.diagonal lam) htr (Matrix.single q.2 p.2 1) q.1 p.1 =
+      Matrix.diagonal
+        (fun x : Fin D × Fin D => lam x.1 / Matrix.trace (Matrix.diagonal lam)) p q := by
+  rcases p with ⟨a, b⟩
+  rcases q with ⟨a', b'⟩
+  have happ : fixedPointProj (Matrix.diagonal lam) htr
+      (Matrix.single b' b 1 : Matrix (Fin D) (Fin D) ℂ) =
+      (Matrix.trace (Matrix.single b' b 1 : Matrix (Fin D) (Fin D) ℂ) /
+        Matrix.trace (Matrix.diagonal lam)) • Matrix.diagonal lam := rfl
+  rw [happ, Matrix.smul_apply, smul_eq_mul]
+  by_cases hb : b' = b
+  · subst hb
+    rw [Matrix.trace_single_eq_same]
+    by_cases ha : a' = a
+    · subst ha
+      rw [Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq, div_mul_eq_mul_div, one_mul]
+    · rw [Matrix.diagonal_apply_ne lam ha, mul_zero,
+        Matrix.diagonal_apply_ne _ (fun h => ha ((Prod.ext_iff.mp h).1).symm)]
+  · rw [Matrix.trace_single_eq_of_ne b' b (1 : ℂ) hb, zero_div, zero_mul,
+      Matrix.diagonal_apply_ne _ (fun h => hb ((Prod.ext_iff.mp h).2).symm)]
+
+/-- Entrywise perturbation bound for a matrix product: if both factors are
+entrywise within `ε` of limiting matrices whose entries are bounded by `B`,
+then the product is entrywise within `card n * (ε * (B + ε) + B * ε)` of the
+limiting product. -/
+private theorem entrywise_mul_bound {n : Type*} [Fintype n]
+    (X X₀ Y Y₀ : Matrix n n ℂ) {ε B : ℝ} (hε : 0 ≤ ε) (hB : 0 ≤ B)
+    (hX : ∀ p q, ‖X p q - X₀ p q‖ ≤ ε) (hY : ∀ p q, ‖Y p q - Y₀ p q‖ ≤ ε)
+    (hX₀ : ∀ p q, ‖X₀ p q‖ ≤ B) (hY₀ : ∀ p q, ‖Y₀ p q‖ ≤ B) (p q : n) :
+    ‖(X * Y) p q - (X₀ * Y₀) p q‖ ≤ (Fintype.card n : ℝ) * (ε * (B + ε) + B * ε) := by
+  have hterm : ∀ k, ‖X p k * Y k q - X₀ p k * Y₀ k q‖ ≤ ε * (B + ε) + B * ε := by
+    intro k
+    have hY' : ‖Y k q‖ ≤ B + ε :=
+      calc ‖Y k q‖ = ‖Y₀ k q + (Y k q - Y₀ k q)‖ := by rw [add_sub_cancel]
+        _ ≤ ‖Y₀ k q‖ + ‖Y k q - Y₀ k q‖ := norm_add_le _ _
+        _ ≤ B + ε := add_le_add (hY₀ k q) (hY k q)
+    have hsplit : X p k * Y k q - X₀ p k * Y₀ k q =
+        (X p k - X₀ p k) * Y k q + X₀ p k * (Y k q - Y₀ k q) := by ring
+    rw [hsplit]
+    calc ‖(X p k - X₀ p k) * Y k q + X₀ p k * (Y k q - Y₀ k q)‖
+        ≤ ‖(X p k - X₀ p k) * Y k q‖ + ‖X₀ p k * (Y k q - Y₀ k q)‖ := norm_add_le _ _
+      _ ≤ ε * (B + ε) + B * ε := by
+          rw [norm_mul, norm_mul]
+          exact add_le_add (mul_le_mul (hX p k) hY' (norm_nonneg _) hε)
+            (mul_le_mul (hX₀ p k) (hY k q) (norm_nonneg _) hB)
+  calc ‖(X * Y) p q - (X₀ * Y₀) p q‖
+      = ‖∑ k, (X p k * Y k q - X₀ p k * Y₀ k q)‖ := by
+        rw [Matrix.mul_apply, Matrix.mul_apply, Finset.sum_sub_distrib]
+    _ ≤ ∑ k, ‖X p k * Y k q - X₀ p k * Y₀ k q‖ := norm_sum_le _ _
+    _ ≤ Finset.univ.card • (ε * (B + ε) + B * ε) :=
+        Finset.sum_le_card_nsmul Finset.univ
+          (fun k => ‖X p k * Y k q - X₀ p k * Y₀ k q‖) (ε * (B + ε) + B * ε)
+          (fun k _ => hterm k)
+    _ = (Fintype.card n : ℝ) * (ε * (B + ε) + B * ε) := by
+        rw [Finset.card_univ, nsmul_eq_mul]
+
+/-- The boundary comparison matrix of the half-chain Schmidt calculation
+converges entrywise, geometrically in the half-chain length, to the diagonal
+matrix with entries `λ_α λ_β / (tr Λ)²`: the trace normalization of
+`Λ ⊗ Λ` for the positive diagonal fixed point `Λ = diag(λ_1, …, λ_D)`.
+Together with `charpoly_halfChainReducedMatrix` this expresses the half-chain
+interpretation of `Λ` at the level of the boundary comparison matrix: the
+nonzero spectrum of the half-chain reduced density matrix is that of a matrix
+converging geometrically to `Λ ⊗ Λ` up to the trace normalization.
+Source: arXiv:quant-ph/0608197, Theorem 6 ("Interpretation of `Λ`",
+`MPSarchive.tex` lines 987--993). -/
+theorem exists_geometric_bound_halfChainComparison_sub_diagonal
+    (A : MPSTensor d D) (lam : Fin D → ℂ)
+    (htr : Matrix.trace (Matrix.diagonal lam) ≠ 0)
+    (hTP : IsTracePreservingMap (transferMap A))
+    (hΛ : transferMap A (Matrix.diagonal lam) = Matrix.diagonal lam)
+    (hgap : spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap A - fixedPointProj (Matrix.diagonal lam) htr)) < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ L, 1 ≤ L → ∀ p q : Fin D × Fin D,
+      ‖(((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ * halfChainGram A L) p q -
+        Matrix.diagonal (fun x : Fin D × Fin D =>
+          lam x.1 * lam x.2 / Matrix.trace (Matrix.diagonal lam) ^ 2) p q‖ ≤ C * r ^ L := by
+  classical
+  obtain ⟨C, r, hC, hr0, hr1, hbound⟩ :=
+    exists_geometric_bound_halfChainGram_sub_fixedPointProj A (Matrix.diagonal lam) htr hTP hΛ hgap
+  set t : ℂ := Matrix.trace (Matrix.diagonal lam) with ht_def
+  set B : ℝ := (∑ a, ‖lam a‖) / ‖t‖ with hB_def
+  have hB : 0 ≤ B := div_nonneg (Finset.sum_nonneg fun _ _ => norm_nonneg _) (norm_nonneg _)
+  have htpos : 0 < ‖t‖ := norm_pos_iff.mpr htr
+  have hentryB : ∀ i : Fin D, ‖lam i / t‖ ≤ B := by
+    intro i
+    rw [norm_div, hB_def]
+    have hsum : ‖lam i‖ ≤ ∑ a, ‖lam a‖ :=
+      Finset.single_le_sum (f := fun a => ‖lam a‖) (fun a _ => norm_nonneg _)
+        (Finset.mem_univ i)
+    gcongr
+  set Ginf : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+    Matrix.diagonal (fun x : Fin D × Fin D => lam x.1 / t) with hGinf_def
+  set Winf : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+    Matrix.diagonal (fun x : Fin D × Fin D => lam x.2 / t) with hWinf_def
+  have hGinfB : ∀ p q : Fin D × Fin D, ‖Ginf p q‖ ≤ B := by
+    intro p q
+    by_cases h : p = q
+    · subst h
+      rw [hGinf_def, Matrix.diagonal_apply_eq]
+      exact hentryB p.1
+    · rw [hGinf_def, Matrix.diagonal_apply_ne _ h]
+      simpa using hB
+  have hWinfB : ∀ p q : Fin D × Fin D, ‖Winf p q‖ ≤ B := by
+    intro p q
+    by_cases h : p = q
+    · subst h
+      rw [hWinf_def, Matrix.diagonal_apply_eq]
+      exact hentryB p.2
+    · rw [hWinf_def, Matrix.diagonal_apply_ne _ h]
+      simpa using hB
+  have hGL : ∀ L, 1 ≤ L → ∀ p q : Fin D × Fin D,
+      ‖halfChainGram A L p q - Ginf p q‖ ≤ C * r ^ L := by
+    intro L hL p q
+    have h := hbound L hL p q
+    rwa [fixedPointProj_single_entry_diagonal lam htr p q] at h
+  have hWL : ∀ L, 1 ≤ L → ∀ p q : Fin D × Fin D,
+      ‖((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ p q - Winf p q‖ ≤ C * r ^ L := by
+    intro L hL p q
+    have h := hGL L hL q.swap p.swap
+    have hentry : ((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ p q =
+        halfChainGram A L q.swap p.swap := rfl
+    have hlim : Winf p q = Ginf q.swap p.swap := by
+      by_cases hpq : p = q
+      · subst hpq
+        rw [hWinf_def, hGinf_def, Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq,
+          Prod.fst_swap]
+      · rw [hWinf_def, hGinf_def, Matrix.diagonal_apply_ne _ hpq,
+          Matrix.diagonal_apply_ne _ (fun hc => hpq (Prod.swap_injective hc).symm)]
+    rw [hentry, hlim]
+    exact h
+  have hprod : Winf * Ginf =
+      Matrix.diagonal (fun x : Fin D × Fin D => lam x.1 * lam x.2 / t ^ 2) := by
+    rw [hWinf_def, hGinf_def, Matrix.diagonal_mul_diagonal]
+    congr 1
+    funext x
+    ring
+  have hDD : (0 : ℝ) ≤ (D * D : ℝ) := by positivity
+  have hK : (0 : ℝ) < (D * D : ℝ) * (C * (B + C) + B * C) + 1 := by
+    have h2 : (0 : ℝ) ≤ C * (B + C) + B * C := by
+      nlinarith [mul_nonneg hB hC.le, mul_nonneg hC.le hC.le]
+    nlinarith [mul_nonneg hDD h2]
+  refine ⟨(D * D : ℝ) * (C * (B + C) + B * C) + 1, r, hK, hr0, hr1, ?_⟩
+  intro L hL p q
+  have hrL0 : 0 < r ^ L := pow_pos hr0 L
+  have hrL1 : r ^ L ≤ 1 := pow_le_one₀ hr0.le hr1.le
+  have hmul := entrywise_mul_bound
+    (((halfChainGram A L).submatrix Prod.swap Prod.swap)ᵀ) Winf (halfChainGram A L) Ginf
+    (mul_nonneg hC.le (pow_nonneg hr0.le L)) hB (hWL L hL) (hGL L hL) hWinfB hGinfB p q
+  rw [hprod] at hmul
+  have hcard : (Fintype.card (Fin D × Fin D) : ℝ) = (D * D : ℝ) := by
+    simp [Fintype.card_prod]
+  rw [hcard] at hmul
+  refine hmul.trans ?_
+  nlinarith [mul_nonneg (mul_nonneg (mul_nonneg hDD (mul_nonneg hC.le hC.le)) hrL0.le)
+    (sub_nonneg.mpr hrL1), hrL0.le]
+
+end Convergence
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -5,9 +5,9 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
 import TNLean.Algebra.OperatorNormFrobenius
-import TNLean.Analysis.SpectralRadiusPowerDecay
-import TNLean.Channel.Primitive
-import TNLean.MPS.Core.TransferChannel
+import QICLean.Analysis.SpectralRadiusPowerDecay
+import QICLean.Channel.Primitive
+import QICLean.MPS.Core.TransferChannel
 import TNLean.MPS.Overlap.Basic
 
 /-!

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -72,7 +72,7 @@ positive diagonal dual fixed point `Λ` appears as the fixed point of
 -/
 
 open scoped Matrix Matrix.Norms.L2Operator ComplexOrder
-open Matrix Polynomial
+open Polynomial
 
 namespace MPSTensor
 

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -13,17 +13,22 @@ import TNLean.MPS.Overlap.Basic
 /-!
 # Half-chain Schmidt reduction for a translation-invariant MPS ring
 
-On a ring of `2 L` sites the translation-invariant MPS coefficient at a split
-configuration `(σ, τ)` is `tr(A_σ A_τ) = ∑_{α,β} ⟨α|A_σ|β⟩ ⟨β|A_τ|α⟩`, so the
+On a ring of \(2L\) sites the translation-invariant MPS coefficient at a split
+configuration \((\sigma, \tau)\) is
+\(\mathrm{tr}(A^\sigma A^\tau)
+  = \sum_{\alpha,\beta} \langle\alpha|A^\sigma|\beta\rangle
+    \langle\beta|A^\tau|\alpha\rangle\), so the
 state is the image of a boundary pairing under the two half-chain families
-`|Ψ_{α,β}⟩ = ∑_σ ⟨α|A_σ|β⟩ |σ⟩`.  This file formalizes the
+\(|\Psi_{\alpha,\beta}\rangle
+  = \sum_\sigma \langle\alpha|A^\sigma|\beta\rangle\,|\sigma\rangle\).
+This file formalizes the
 Schmidt-decomposition calculation behind the half-chain interpretation of the
 dual fixed point: the unnormalized half-chain reduced density matrix factors
 exactly through the half-chain overlap Gram matrix, its characteristic
-polynomial agrees (away from zero) with that of a `D² × D²` comparison matrix
-built from the `L`-fold transfer map, and the Gram entries converge
-geometrically to the entries of the rank-one fixed-point projection, with rate
-controlled by the subleading spectrum of the transfer map.
+polynomial agrees (away from zero) with that of a \(D^2 \times D^2\)
+comparison matrix built from the \(L\)-fold transfer map, and the Gram entries
+converge geometrically to the entries of the rank-one fixed-point projection,
+with rate controlled by the subleading spectrum of the transfer map.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 6 ("Interpretation of
 `Λ`", `MPSarchive.tex` lines 987--993) and the Schmidt-decomposition
@@ -38,21 +43,32 @@ positive diagonal dual fixed point `Λ` appears as the fixed point of
 - `MPSTensor.halfChainKernel_eq_mul`: the ring coefficient kernel factors
   through the half-chain families (lines 970--976).
 - `MPSTensor.halfChainGram_apply_eq_transferMap_pow`: the half-chain overlap
-  Gram entries are matrix elements of the `L`-fold transfer map on matrix
-  units (the display `⟨Ψ_{α,β}|Ψ_{α',β'}⟩ = ⟨α'|E^{N/2}(|β'⟩⟨β|)|α⟩`,
+  Gram entries are matrix elements of the \(L\)-fold transfer map on matrix
+  units (the display
+  \(\langle\Psi_{\alpha,\beta}|\Psi_{\alpha',\beta'}\rangle
+    = \langle\alpha'|\mathcal E^{N/2}(|\beta'\rangle\langle\beta|)
+      |\alpha\rangle\),
   lines 977--979).
 - `MPSTensor.halfChainReducedMatrix_eq_mul_swap_gram`: the unnormalized
-  half-chain reduced density matrix equals `Ψ W Ψᴴ` with `W` the
-  index-swapped Gram matrix of the complementary half (lines 979--985).
+  half-chain reduced density matrix equals \(\Psi W \Psi^\dagger\) with
+  \(W\) the index-swapped Gram matrix of the complementary half
+  (lines 979--985).
 - `MPSTensor.charpoly_halfChainReducedMatrix`: away from zero, the spectrum
-  of the half-chain reduced density matrix is that of the `D² × D²`
-  comparison matrix `W · G`.
+  of the half-chain reduced density matrix is that of the
+  \(D^2 \times D^2\) comparison matrix \(WG\).
 - `MPSTensor.exists_geometric_bound_halfChainGram_sub_fixedPointProj`: the
-  transfer-error term, geometric in `L` under a complementary spectral-radius
-  gap (the correction "of the order `|ν₂|^{N/2}`", lines 979--981).
-- `MPSTensor.fixedPointProj_single_entry_diagonal`: for diagonal `Λ` the
-  limiting Gram matrix is the diagonal matrix of eigenvalues of `Λ`
-  (the display `λ_α δ_{α,α'} δ_{β,β'}`, line 979).
+  transfer-error term, geometric in \(L\) under a complementary
+  spectral-radius gap (the correction of the order \(|\nu_2|^{N/2}\),
+  lines 979--981).
+- `MPSTensor.fixedPointProj_single_entry_diagonal`: for diagonal \(\Lambda\)
+  the limiting Gram matrix is the diagonal matrix of eigenvalues of
+  \(\Lambda\) (the display
+  \(\lambda_\alpha \delta_{\alpha,\alpha'} \delta_{\beta,\beta'}\),
+  line 979).
+- `MPSTensor.exists_geometric_bound_halfChainComparison_sub_diagonal`: the
+  comparison matrix converges entrywise, geometrically in \(L\), to the
+  diagonal matrix with entries
+  \(\lambda_\alpha \lambda_\beta / \mathrm{tr}(\Lambda)^2\).
 -/
 
 open scoped Matrix Matrix.Norms.L2Operator ComplexOrder
@@ -63,7 +79,9 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- The half-chain family of PGVWC07: the matrix whose column at boundary pair
-`(α, β)` is the half-chain vector `|Ψ_{α,β}⟩ = ∑_σ ⟨α|A_σ|β⟩ |σ⟩`.
+\((\alpha, \beta)\) is the half-chain vector
+\(|\Psi_{\alpha,\beta}\rangle
+  = \sum_\sigma \langle\alpha|A^\sigma|\beta\rangle\,|\sigma\rangle\).
 Source: arXiv:quant-ph/0608197, lines 970--976. -/
 noncomputable def halfChainMatrix (A : MPSTensor d D) (L : ℕ) :
     Matrix (Cfg d L) (Fin D × Fin D) ℂ :=
@@ -75,8 +93,10 @@ theorem halfChainMatrix_apply (A : MPSTensor d D) (L : ℕ) (σ : Cfg d L)
     halfChainMatrix A L σ p = evalWord A (List.ofFn σ) p.1 p.2 := rfl
 
 /-- The complementary half-chain family with swapped boundary indices: the row
-at `(α, β)` is the vector `|Ψ_{β,α}⟩` appearing on the second half of the ring
-in `|ψ⟩ = ∑_{α,β} |Ψ_{α,β}⟩ |Ψ_{β,α}⟩`.
+at \((\alpha, \beta)\) is the vector \(|\Psi_{\beta,\alpha}\rangle\) appearing
+on the second half of the ring in
+\(|\psi\rangle = \sum_{\alpha,\beta}
+  |\Psi_{\alpha,\beta}\rangle |\Psi_{\beta,\alpha}\rangle\).
 Source: arXiv:quant-ph/0608197, lines 970--976. -/
 noncomputable def halfChainSwapMatrix (A : MPSTensor d D) (L : ℕ) :
     Matrix (Fin D × Fin D) (Cfg d L) ℂ :=
@@ -87,9 +107,10 @@ theorem halfChainSwapMatrix_apply (A : MPSTensor d D) (L : ℕ)
     (p : Fin D × Fin D) (τ : Cfg d L) :
     halfChainSwapMatrix A L p τ = evalWord A (List.ofFn τ) p.2 p.1 := rfl
 
-/-- The coefficient kernel of the ring of `2 L` sites, read as a matrix over
-the two half-chain configuration spaces: the entry at `(σ, τ)` is the MPS
-coefficient `tr(A_σ A_τ)` of the joined configuration.
+/-- The coefficient kernel of the ring of \(2L\) sites, read as a matrix over
+the two half-chain configuration spaces: the entry at \((\sigma, \tau)\) is
+the MPS coefficient \(\mathrm{tr}(A^\sigma A^\tau)\) of the joined
+configuration.
 Source: arXiv:quant-ph/0608197, lines 970--976. -/
 noncomputable def halfChainKernel (A : MPSTensor d D) (L : ℕ) :
     Matrix (Cfg d L) (Cfg d L) ℂ :=
@@ -102,7 +123,8 @@ theorem halfChainKernel_apply (A : MPSTensor d D) (L : ℕ) (σ τ : Cfg d L) :
 /-- Splitting the ring trace at the two boundaries: the coefficient kernel is
 the product of the half-chain family with its index-swapped complement.  This
 is the resolution of the identity producing
-`|ψ⟩ = ∑_{α,β} |Ψ_{α,β}⟩ |Ψ_{β,α}⟩`.
+\(|\psi\rangle = \sum_{\alpha,\beta}
+  |\Psi_{\alpha,\beta}\rangle |\Psi_{\beta,\alpha}\rangle\).
 Source: arXiv:quant-ph/0608197, lines 970--976. -/
 theorem halfChainKernel_eq_mul (A : MPSTensor d D) (L : ℕ) :
     halfChainKernel A L = halfChainMatrix A L * halfChainSwapMatrix A L := by
@@ -112,8 +134,8 @@ theorem halfChainKernel_eq_mul (A : MPSTensor d D) (L : ℕ) :
   simp [Matrix.trace, Matrix.mul_apply, Fintype.sum_prod_type]
 
 /-- The unnormalized half-chain reduced density matrix of the ring state on
-`2 L` sites: the second half of the ring is traced out from the rank-one state
-built from the coefficient kernel.
+\(2L\) sites: the second half of the ring is traced out from the rank-one
+state built from the coefficient kernel.
 Source: arXiv:quant-ph/0608197, lines 979--985. -/
 noncomputable def halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
     Matrix (Cfg d L) (Cfg d L) ℂ :=
@@ -132,14 +154,18 @@ theorem posSemidef_halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
   Matrix.posSemidef_self_mul_conjTranspose _
 
 /-- The half-chain overlap Gram matrix
-`G_{(α,β),(α',β')} = ⟨Ψ_{α,β}|Ψ_{α',β'}⟩`.
+\(G_{(\alpha,\beta),(\alpha',\beta')}
+  = \langle\Psi_{\alpha,\beta}|\Psi_{\alpha',\beta'}\rangle\).
 Source: arXiv:quant-ph/0608197, lines 977--979. -/
 noncomputable def halfChainGram (A : MPSTensor d D) (L : ℕ) :
     Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
   (halfChainMatrix A L)ᴴ * halfChainMatrix A L
 
 /-- The half-chain overlap is a matrix element of the iterated transfer map on
-a matrix unit: `⟨Ψ_{α,β}|Ψ_{α',β'}⟩ = (E^L(|β'⟩⟨β|))_{α',α}`.
+a matrix unit:
+\(\langle\Psi_{\alpha,\beta}|\Psi_{\alpha',\beta'}\rangle
+  = \langle\alpha'|\mathcal E^{L}(|\beta'\rangle\langle\beta|)
+    |\alpha\rangle\).
 Source: arXiv:quant-ph/0608197, the display at lines 977--979. -/
 theorem halfChainGram_apply_eq_transferMap_pow (A : MPSTensor d D) (L : ℕ)
     (p q : Fin D × Fin D) :
@@ -178,9 +204,10 @@ theorem halfChainSwapMatrix_mul_conjTranspose (A : MPSTensor d D) (L : ℕ) :
   exact Finset.sum_congr rfl fun τ _ => mul_comm _ _
 
 /-- The Schmidt-decomposition calculation of PGVWC07: the unnormalized
-half-chain reduced density matrix factors exactly as `Ψ (S Gᵀ S) Ψᴴ`, where
-`Ψ` is the half-chain family, `G` the half-chain Gram matrix, and `S` the swap
-of the two boundary indices.
+half-chain reduced density matrix factors exactly as
+\(\Psi (S G^{\mathsf T} S) \Psi^\dagger\), where \(\Psi\) is the half-chain
+family, \(G\) the half-chain Gram matrix, and \(S\) the swap of the two
+boundary indices.
 Source: arXiv:quant-ph/0608197, lines 979--985. -/
 theorem halfChainReducedMatrix_eq_mul_swap_gram (A : MPSTensor d D) (L : ℕ) :
     halfChainReducedMatrix A L =
@@ -192,10 +219,11 @@ theorem halfChainReducedMatrix_eq_mul_swap_gram (A : MPSTensor d D) (L : ℕ) :
   simp only [Matrix.mul_assoc]
 
 /-- Away from zero, the spectrum of the half-chain reduced density matrix is
-computed by the `D² × D²` comparison matrix `(S Gᵀ S) · G` built from the
-half-chain Gram matrix: the two characteristic polynomials agree after
-matching the trivial kernel factors.  This reduces the half-chain spectral
-comparison of PGVWC07, Theorem 6, to the boundary comparison matrix.
+computed by the \(D^2 \times D^2\) comparison matrix
+\((S G^{\mathsf T} S) G\) built from the half-chain Gram matrix: the two
+characteristic polynomials agree after matching the trivial kernel factors.
+This reduces the half-chain spectral comparison of PGVWC07, Theorem 6, to the
+boundary comparison matrix.
 Source: arXiv:quant-ph/0608197, lines 979--993. -/
 theorem charpoly_halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
     X ^ (D * D) * (halfChainReducedMatrix A L).charpoly =
@@ -211,11 +239,12 @@ theorem charpoly_halfChainReducedMatrix (A : MPSTensor d D) (L : ℕ) :
 section Convergence
 
 /-- Transfer-error control for the half-chain overlaps: if the transfer map is
-trace preserving with fixed point `Λ` and the complementary part of the
-transfer map has spectral radius below one, then every half-chain Gram entry
-converges geometrically to the corresponding entry of the rank-one fixed-point
-projection, uniformly in the boundary indices.  This is the correction term
-"of the order `|ν₂|^{N/2}`" controlled by the subleading spectrum.
+trace preserving with fixed point \(\Lambda\) and the complementary part of
+the transfer map has spectral radius below one, then every half-chain Gram
+entry converges geometrically to the corresponding entry of the rank-one
+fixed-point projection, uniformly in the boundary indices.  This is the
+correction term of the order \(|\nu_2|^{N/2}\) controlled by the subleading
+spectrum.
 Source: arXiv:quant-ph/0608197, lines 977--981. -/
 theorem exists_geometric_bound_halfChainGram_sub_fixedPointProj
     (A : MPSTensor d D) (Λ : Matrix (Fin D) (Fin D) ℂ)
@@ -265,10 +294,13 @@ theorem exists_geometric_bound_halfChainGram_sub_fixedPointProj
     _ ≤ ‖T ^ L‖ := hop
     _ ≤ C * r ^ L := hbound L
 
-/-- For a positive diagonal fixed point `Λ = diag(λ_1, …, λ_D)` the limiting
-Gram entries reproduce the source's display `λ_α δ_{α,α'} δ_{β,β'}` up to the
+/-- For a positive diagonal fixed point
+\(\Lambda = \mathrm{diag}(\lambda_1, \ldots, \lambda_D)\) the limiting Gram
+entries reproduce the source's display
+\(\lambda_\alpha \delta_{\alpha,\alpha'} \delta_{\beta,\beta'}\) up to the
 trace normalization: the limiting Gram matrix is diagonal in the boundary
-pairs with entry `λ_α / tr Λ` at `(α, β)`.
+pairs with entry \(\lambda_\alpha / \mathrm{tr}(\Lambda)\) at
+\((\alpha, \beta)\).
 Source: arXiv:quant-ph/0608197, line 979. -/
 theorem fixedPointProj_single_entry_diagonal
     (lam : Fin D → ℂ) (htr : Matrix.trace (Matrix.diagonal lam) ≠ 0)
@@ -295,9 +327,10 @@ theorem fixedPointProj_single_entry_diagonal
       Matrix.diagonal_apply_ne _ (fun h => hb ((Prod.ext_iff.mp h).2).symm)]
 
 /-- Entrywise perturbation bound for a matrix product: if both factors are
-entrywise within `ε` of limiting matrices whose entries are bounded by `B`,
-then the product is entrywise within `card n * (ε * (B + ε) + B * ε)` of the
-limiting product. -/
+entrywise within \(\varepsilon\) of limiting matrices whose entries are
+bounded by \(B\), then the product is entrywise within
+\(|n| (\varepsilon (B + \varepsilon) + B \varepsilon)\) of the limiting
+product, where \(|n|\) is the size of the index type. -/
 private theorem entrywise_mul_bound {n : Type*} [Fintype n]
     (X X₀ Y Y₀ : Matrix n n ℂ) {ε B : ℝ} (hε : 0 ≤ ε) (hB : 0 ≤ B)
     (hX : ∀ p q, ‖X p q - X₀ p q‖ ≤ ε) (hY : ∀ p q, ‖Y p q - Y₀ p q‖ ≤ ε)
@@ -331,14 +364,17 @@ private theorem entrywise_mul_bound {n : Type*} [Fintype n]
 
 /-- The boundary comparison matrix of the half-chain Schmidt calculation
 converges entrywise, geometrically in the half-chain length, to the diagonal
-matrix with entries `λ_α λ_β / (tr Λ)²`: the trace normalization of
-`Λ ⊗ Λ` for the positive diagonal fixed point `Λ = diag(λ_1, …, λ_D)`.
+matrix with entries
+\(\lambda_\alpha \lambda_\beta / \mathrm{tr}(\Lambda)^2\): the trace
+normalization of \(\Lambda \otimes \Lambda\) for the positive diagonal fixed
+point \(\Lambda = \mathrm{diag}(\lambda_1, \ldots, \lambda_D)\).
 Together with `charpoly_halfChainReducedMatrix` this expresses the half-chain
-interpretation of `Λ` at the level of the boundary comparison matrix: the
-nonzero spectrum of the half-chain reduced density matrix is that of a matrix
-converging geometrically to `Λ ⊗ Λ` up to the trace normalization.
-Source: arXiv:quant-ph/0608197, Theorem 6 ("Interpretation of `Λ`",
-`MPSarchive.tex` lines 987--993). -/
+interpretation of \(\Lambda\) at the level of the boundary comparison matrix:
+the nonzero spectrum of the half-chain reduced density matrix is that of a
+matrix converging geometrically to \(\Lambda \otimes \Lambda\) up to the
+trace normalization.
+Source: arXiv:quant-ph/0608197, Theorem 6 ("Interpretation of \(\Lambda\)"),
+`MPSarchive.tex` lines 987--993. -/
 theorem exists_geometric_bound_halfChainComparison_sub_diagonal
     (A : MPSTensor d D) (lam : Fin D → ℂ)
     (htr : Matrix.trace (Matrix.diagonal lam) ≠ 0)

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -58,8 +58,8 @@ positive diagonal dual fixed point `Λ` appears as the fixed point of
   \(D^2 \times D^2\) comparison matrix \(WG\).
 - `MPSTensor.exists_geometric_bound_halfChainGram_sub_fixedPointProj`: the
   transfer-error term, geometric in \(L\) under a complementary
-  spectral-radius gap (the correction of the order \(|\nu_2|^{N/2}\),
-  lines 979--981).
+  spectral-radius gap.  The decay radius is chosen strictly above the
+  complementary spectral radius and below one (lines 979--981).
 - `MPSTensor.fixedPointProj_single_entry_diagonal`: for diagonal \(\Lambda\)
   the limiting Gram matrix is the diagonal matrix of eigenvalues of
   \(\Lambda\) (the display
@@ -242,9 +242,10 @@ section Convergence
 trace preserving with fixed point \(\Lambda\) and the complementary part of
 the transfer map has spectral radius below one, then every half-chain Gram
 entry converges geometrically to the corresponding entry of the rank-one
-fixed-point projection, uniformly in the boundary indices.  This is the
-correction term of the order \(|\nu_2|^{N/2}\) controlled by the subleading
-spectrum.
+fixed-point projection, uniformly in the boundary indices.  The proof chooses
+a decay radius strictly above the complementary spectral radius and below one;
+without a semisimplicity hypothesis it does not assert decay at the spectral
+radius itself.
 Source: arXiv:quant-ph/0608197, lines 977--981. -/
 theorem exists_geometric_bound_halfChainGram_sub_fixedPointProj
     (A : MPSTensor d D) (Λ : Matrix (Fin D) (Fin D) ℂ)
@@ -294,7 +295,7 @@ theorem exists_geometric_bound_halfChainGram_sub_fixedPointProj
     _ ≤ ‖T ^ L‖ := hop
     _ ≤ C * r ^ L := hbound L
 
-/-- For a positive diagonal fixed point
+/-- For a diagonal fixed point
 \(\Lambda = \mathrm{diag}(\lambda_1, \ldots, \lambda_D)\) the limiting Gram
 entries reproduce the source's display
 \(\lambda_\alpha \delta_{\alpha,\alpha'} \delta_{\beta,\beta'}\) up to the
@@ -366,8 +367,8 @@ private theorem entrywise_mul_bound {n : Type*} [Fintype n]
 converges entrywise, geometrically in the half-chain length, to the diagonal
 matrix with entries
 \(\lambda_\alpha \lambda_\beta / \mathrm{tr}(\Lambda)^2\): the trace
-normalization of \(\Lambda \otimes \Lambda\) for the positive diagonal fixed
-point \(\Lambda = \mathrm{diag}(\lambda_1, \ldots, \lambda_D)\).
+normalization of \(\Lambda \otimes \Lambda\) for the diagonal fixed point
+\(\Lambda = \mathrm{diag}(\lambda_1, \ldots, \lambda_D)\).
 Together with `charpoly_halfChainReducedMatrix` this expresses the half-chain
 interpretation of \(\Lambda\) at the level of the boundary comparison matrix:
 the nonzero spectrum of the half-chain reduced density matrix is that of a

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -29,3 +29,4 @@ ground spaces arising from several normal blocks.
 \input{chapter/ch13_parent_hamiltonian_normal_boundary}
 \input{chapter/ch13_parent_hamiltonian_normal_closing}
 \input{chapter/ch13_parent_hamiltonian_normal_closing_reverse}
+\input{chapter/ch13_parent_hamiltonian_half_chain_schmidt}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -188,8 +188,7 @@ conjugate-transposed tensor.
 
 \begin{proof}
     \leanok
-    \uses{thm:half_chain_schmidt_factorization,
-        lem:matrix_rectangular_charpoly_cyclicity}
+    \uses{thm:half_chain_schmidt_factorization, lem:matrix_rectangular_charpoly_cyclicity}
     Apply the rectangular cyclicity of the characteristic polynomial to the
     factorization (\ref{eq:half_chain_factorization}), regrouping the product
     as $\Psi$ times $(SG^{\mathsf T}S)\Psi^{\dagger}$; the reversed product is
@@ -229,8 +228,7 @@ conjugate-transposed tensor.
 
 \begin{proof}
     \leanok
-    \uses{lem:half_chain_gram_transfer,
-        thm:geometric_bound_of_spectral_radius_lt_one}
+    \uses{lem:half_chain_gram_transfer, thm:geometric_bound_of_spectral_radius_lt_one}
     Write $\E_A^{L}=P_{\Lambda}+(\E_A-P_{\Lambda})^{L}$ for $L\geq1$ by the
     power decomposition. By (\ref{eq:half_chain_gram_transfer}) the deviation
     of a Gram entry from the fixed-point projection entry is an entry of

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -268,7 +268,8 @@ conjugate-transposed tensor.
     \label{thm:half_chain_comparison_geometric}
     \lean{MPSTensor.exists_geometric_bound_halfChainComparison_sub_diagonal}
     \leanok
-    \uses{thm:half_chain_gram_geometric, lem:half_chain_gram_limit_diagonal}
+    \uses{def:half_chain_gram, def:transfer_map, def:fixed_point_proj,
+        def:trace_preserving}
     Let $A$ have trace-preserving transfer map with diagonal fixed point
     $\Lambda=\operatorname{diag}(\lambda_1,\ldots,\lambda_D)$,
     $\tr(\Lambda)\neq0$, satisfying the spectral condition

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -1,0 +1,308 @@
+\section{Half-chain Schmidt spectrum and the dual fixed point}%
+\label{sec:half_chain_schmidt}
+
+This section formalizes the half-chain interpretation of the positive diagonal
+fixed point $\Lambda$ of \cite[Theorem~6]{PerezGarcia2007Matrix}. On a ring of
+$2L$ sites the matrix product vector splits at the two boundaries into a pair
+of half-chain families, the overlaps of the half-chain vectors are matrix
+elements of the $L$-fold transfer map, and the unnormalized half-chain reduced
+density matrix factors exactly through the half-chain Gram matrix. Away from
+zero, its spectrum is that of a boundary comparison matrix of size $D^2$, and
+under the generic spectral condition of the source that comparison matrix
+converges entrywise, geometrically in $L$, to the diagonal matrix with entries
+$\lambda_\alpha\lambda_\beta$ up to the trace normalization of $\Lambda$. The
+finite-size convention throughout is the ring of $N=2L$ sites split into two
+halves of $L$ sites each.
+
+The source states its canonical form with a trace-preserving dual map and a
+positive diagonal fixed point $\Lambda$ of that dual. Here the trace-preserving
+direction is placed on the transfer map itself and $\Lambda$ is its fixed
+point; the two conventions are exchanged by passing to the
+conjugate-transposed tensor.
+
+\begin{definition}[Half-chain boundary families]%
+    \label{def:half_chain_family}
+    \lean{MPSTensor.halfChainMatrix}
+    \lean{MPSTensor.halfChainMatrix_apply}
+    \lean{MPSTensor.halfChainSwapMatrix}
+    \lean{MPSTensor.halfChainSwapMatrix_apply}
+    \leanok
+    \uses{def:mps_tensor, def:eval_word}
+    For a tensor $A$ and a half-chain length $L$, the \emph{half-chain family}
+    is the matrix $\Psi$ with rows indexed by configurations
+    $\sigma\in\Fin{d}^L$ and columns indexed by boundary pairs
+    $(\alpha,\beta)$, whose column at $(\alpha,\beta)$ is the half-chain
+    vector
+    \begin{align}
+        \ket{\Psi_{\alpha,\beta}}
+        &=\sum_{\sigma}
+        \bra{\alpha}A^{\sigma}\ket{\beta}\,\ket{\sigma}.
+        \label{eq:half_chain_vector}
+    \end{align}
+    The \emph{complementary family} $\Phi$ is the matrix with rows indexed by
+    boundary pairs and columns by configurations, whose row at
+    $(\alpha,\beta)$ is the vector $\ket{\Psi_{\beta,\alpha}}$ with the two
+    boundary indices swapped.
+\end{definition}
+
+\begin{definition}[Half-chain coefficient kernel]%
+    \label{def:half_chain_kernel}
+    \lean{MPSTensor.halfChainKernel}
+    \lean{MPSTensor.halfChainKernel_apply}
+    \leanok
+    \uses{def:mpv}
+    The \emph{coefficient kernel} of the ring of $2L$ sites is the matrix over
+    the two half-chain configuration spaces whose entry at $(\sigma,\tau)$ is
+    the matrix product vector component
+    $V^{(2L)}(A)_{\sigma\tau}=\tr(A^{\sigma}A^{\tau})$ of the joined
+    configuration.
+\end{definition}
+
+\begin{lemma}[Splitting of the ring state at the two boundaries]%
+    \label{lem:half_chain_kernel_split}
+    \lean{MPSTensor.halfChainKernel_eq_mul}
+    \leanok
+    \uses{def:half_chain_family, def:half_chain_kernel}
+    The coefficient kernel factors as the product $\Psi\Phi$ of the
+    half-chain family with its complementary family. Equivalently,
+    \begin{align}
+        \ket{\psi}
+        &=\sum_{\alpha,\beta}
+        \ket{\Psi_{\alpha,\beta}}\ket{\Psi_{\beta,\alpha}}.
+        \label{eq:half_chain_resolution}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Insert the resolution of the identity
+    $\sum_{\beta}\ket{\beta}\bra{\beta}$ at the two cut bonds of the ring
+    trace: $\tr(A^{\sigma}A^{\tau})
+    =\sum_{\alpha,\beta}\bra{\alpha}A^{\sigma}\ket{\beta}
+    \bra{\beta}A^{\tau}\ket{\alpha}$.
+\end{proof}
+
+\begin{definition}[Half-chain reduced density matrix]%
+    \label{def:half_chain_reduced}
+    \lean{MPSTensor.halfChainReducedMatrix}
+    \lean{MPSTensor.halfChainReducedMatrix_apply}
+    \lean{MPSTensor.posSemidef_halfChainReducedMatrix}
+    \leanok
+    \uses{def:half_chain_kernel}
+    The \emph{unnormalized half-chain reduced density matrix} of the ring
+    state on $2L$ sites is $\rho_L=KK^{\dagger}$ with $K$ the coefficient
+    kernel. Entrywise this is the partial trace of the unnormalized ring state
+    over the complementary half,
+    \begin{align}
+        (\rho_L)_{\sigma\sigma'}
+        &=\sum_{\tau}
+        V^{(2L)}(A)_{\sigma\tau}\,
+        \overline{V^{(2L)}(A)_{\sigma'\tau}},
+        \label{eq:half_chain_reduced_entry}
+    \end{align}
+    and $\rho_L$ is positive semidefinite.
+\end{definition}
+
+\begin{definition}[Half-chain Gram matrix]%
+    \label{def:half_chain_gram}
+    \lean{MPSTensor.halfChainGram}
+    \leanok
+    \uses{def:half_chain_family}
+    The \emph{half-chain Gram matrix} is $G=\Psi^{\dagger}\Psi$, the matrix of
+    overlaps
+    $G_{(\alpha,\beta),(\alpha',\beta')}
+    =\braket{\Psi_{\alpha,\beta}}{\Psi_{\alpha',\beta'}}$ of the half-chain
+    vectors.
+\end{definition}
+
+\begin{lemma}[Half-chain overlaps through the transfer map]%
+    \label{lem:half_chain_gram_transfer}
+    \lean{MPSTensor.halfChainGram_apply_eq_transferMap_pow}
+    \leanok
+    \uses{def:half_chain_gram, def:transfer_map}
+    The half-chain overlaps are matrix elements of the $L$-fold transfer map
+    on matrix units:
+    \begin{align}
+        \braket{\Psi_{\alpha,\beta}}{\Psi_{\alpha',\beta'}}
+        &=\bra{\alpha'}\E_A^{L}
+        \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}.
+        \label{eq:half_chain_gram_transfer}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand the overlap as a sum over configurations of products
+    $\bra{\alpha'}A^{\sigma}\ket{\beta'}
+    \overline{\bra{\alpha}A^{\sigma}\ket{\beta}}$ and recognize the entry of
+    $\sum_{\sigma}A^{\sigma}\ket{\beta'}\bra{\beta}(A^{\sigma})^{\dagger}$,
+    which is the $L$-fold transfer map applied to the matrix unit.
+\end{proof}
+
+\begin{theorem}[Half-chain Schmidt factorization]%
+    \label{thm:half_chain_schmidt_factorization}
+    \lean{MPSTensor.halfChainReducedMatrix_eq_mul_swap_gram}
+    \lean{MPSTensor.halfChainSwapMatrix_mul_conjTranspose}
+    \leanok
+    \uses{def:half_chain_reduced, def:half_chain_gram}
+    Let $S$ denote the swap of the two boundary indices. The unnormalized
+    half-chain reduced density matrix factors exactly as
+    \begin{align}
+        \rho_L
+        &=\Psi\,\bigl(SG^{\mathsf T}S\bigr)\,\Psi^{\dagger},
+        \label{eq:half_chain_factorization}
+    \end{align}
+    where $SG^{\mathsf T}S$ is the Gram matrix of the complementary family.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:half_chain_kernel_split}
+    By the splitting $K=\Psi\Phi$ of
+    Lemma~\ref{lem:half_chain_kernel_split},
+    $\rho_L=\Psi(\Phi\Phi^{\dagger})\Psi^{\dagger}$, and the Gram matrix
+    $\Phi\Phi^{\dagger}$ of the complementary family is the transpose of the
+    boundary-swapped half-chain Gram matrix.
+\end{proof}
+
+\begin{theorem}[Boundary comparison of the half-chain spectrum]%
+    \label{thm:half_chain_charpoly}
+    \lean{MPSTensor.charpoly_halfChainReducedMatrix}
+    \leanok
+    \uses{def:half_chain_reduced, def:half_chain_gram}
+    The characteristic polynomials of the half-chain reduced density matrix
+    and of the boundary comparison matrix $(SG^{\mathsf T}S)G$ of size $D^2$
+    agree after matching the trivial kernel factors:
+    \begin{align}
+        X^{D^2}\,\chi_{\rho_L}(X)
+        &=X^{d^L}\,\chi_{(SG^{\mathsf T}S)G}(X).
+        \label{eq:half_chain_charpoly}
+    \end{align}
+    In particular the nonzero spectrum of $\rho_L$, with multiplicities, is
+    that of the boundary comparison matrix.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:half_chain_schmidt_factorization,
+        lem:matrix_rectangular_charpoly_cyclicity}
+    Apply the rectangular cyclicity of the characteristic polynomial to the
+    factorization (\ref{eq:half_chain_factorization}), regrouping the product
+    as $\Psi$ times $(SG^{\mathsf T}S)\Psi^{\dagger}$; the reversed product is
+    $(SG^{\mathsf T}S)\Psi^{\dagger}\Psi=(SG^{\mathsf T}S)G$.
+\end{proof}
+
+\begin{theorem}[Geometric transfer error of the half-chain overlaps]%
+    \label{thm:half_chain_gram_geometric}
+    \lean{MPSTensor.exists_geometric_bound_halfChainGram_sub_fixedPointProj}
+    \leanok
+    \uses{def:half_chain_gram, def:transfer_map, def:fixed_point_proj,
+        def:trace_preserving}
+    Let $A$ have trace-preserving transfer map $\E_A$ with fixed point
+    $\Lambda$, $\tr(\Lambda)\neq0$, and suppose
+    \begin{align}
+        \rho_{\mathrm{spec}}\bigl(\E_A-P_{\Lambda}\bigr)&<1,
+        \label{eq:half_chain_c2_gap}
+    \end{align}
+    where $P_{\Lambda}$ is the fixed-point projection. Then there are
+    constants $C>0$ and $0<r<1$ such that for every $L\geq1$ and all boundary
+    pairs,
+    \begin{align}
+        \Bigl|
+        G_{(\alpha,\beta),(\alpha',\beta')}
+        -\bra{\alpha'}P_{\Lambda}
+        \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}
+        \Bigr|
+        &\leq C r^{L}.
+        \label{eq:half_chain_gram_geometric}
+    \end{align}
+    The hypothesis (\ref{eq:half_chain_c2_gap}) expresses the generic
+    condition C2 of \cite{PerezGarcia2007Matrix} in the trace-preserving
+    gauge: apart from the simple eigenvalue one, the spectrum of $\E_A$ lies
+    strictly inside the unit disc, and the correction term is of the order of
+    the subleading spectral radius, the bound of order $|\nu_2|^{N/2}$ of the
+    source.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:half_chain_gram_transfer, thm:pow_decomp,
+        thm:geometric_bound_of_spectral_radius_lt_one}
+    Write $\E_A^{L}=P_{\Lambda}+(\E_A-P_{\Lambda})^{L}$ for $L\geq1$ by the
+    power decomposition. By (\ref{eq:half_chain_gram_transfer}) the deviation
+    of a Gram entry from the fixed-point projection entry is an entry of
+    $(\E_A-P_{\Lambda})^{L}$ applied to a matrix unit, bounded by the operator
+    norm of the $L$-th power, which decays geometrically below unit spectral
+    radius.
+\end{proof}
+
+\begin{lemma}[Diagonal limit of the half-chain overlaps]%
+    \label{lem:half_chain_gram_limit_diagonal}
+    \lean{MPSTensor.fixedPointProj_single_entry_diagonal}
+    \leanok
+    \uses{def:fixed_point_proj}
+    For a diagonal fixed point
+    $\Lambda=\operatorname{diag}(\lambda_1,\ldots,\lambda_D)$ with
+    $\tr(\Lambda)\neq0$, the limiting overlaps form a diagonal matrix in the
+    boundary pairs:
+    \begin{align}
+        \bra{\alpha'}P_{\Lambda}
+        \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}
+        &=\frac{\lambda_\alpha}{\tr(\Lambda)}\,
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+        \label{eq:half_chain_limit_diagonal}
+    \end{align}
+    For $\tr(\Lambda)=1$ this is the display
+    $\lambda_\alpha\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$ of
+    \cite{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Evaluate the fixed-point projection on the matrix unit: its trace is
+    $\delta_{\beta,\beta'}$, and the diagonal entry of $\Lambda$ at
+    $(\alpha',\alpha)$ is $\lambda_\alpha\delta_{\alpha,\alpha'}$.
+\end{proof}
+
+\begin{theorem}[Geometric convergence to the doubled fixed-point spectrum]%
+    \label{thm:half_chain_comparison_geometric}
+    \lean{MPSTensor.exists_geometric_bound_halfChainComparison_sub_diagonal}
+    \leanok
+    \uses{thm:half_chain_gram_geometric, lem:half_chain_gram_limit_diagonal}
+    Let $A$ have trace-preserving transfer map with diagonal fixed point
+    $\Lambda=\operatorname{diag}(\lambda_1,\ldots,\lambda_D)$,
+    $\tr(\Lambda)\neq0$, satisfying the spectral condition
+    (\ref{eq:half_chain_c2_gap}). Then there are constants $C>0$ and $0<r<1$
+    such that for every $L\geq1$ the boundary comparison matrix satisfies,
+    entrywise,
+    \begin{align}
+        \Bigl|
+        \bigl((SG^{\mathsf T}S)G\bigr)_{(\alpha,\beta),(\alpha',\beta')}
+        -\frac{\lambda_\alpha\lambda_\beta}{\tr(\Lambda)^2}\,
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
+        \Bigr|
+        &\leq C r^{L}.
+        \label{eq:half_chain_comparison_geometric}
+    \end{align}
+    The limiting matrix is the diagonal matrix $\Lambda\otimes\Lambda$ up to
+    the trace normalization. Together with
+    Theorem~\ref{thm:half_chain_charpoly}, the nonzero spectrum of the
+    half-chain reduced density matrix on the ring of $2L$ sites is that of a
+    $D^2\times D^2$ matrix converging entrywise, geometrically in $L$, to
+    $\Lambda\otimes\Lambda/\tr(\Lambda)^2$. The remaining passage to the
+    convergence of the eigenvalues themselves is the continuity of the
+    spectrum of a matrix in its entries and is not part of this section.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:half_chain_gram_geometric, lem:half_chain_gram_limit_diagonal}
+    Both factors of the comparison matrix are entrywise within $Cr^{L}$ of
+    their diagonal limits by Theorem~\ref{thm:half_chain_gram_geometric} and
+    Lemma~\ref{lem:half_chain_gram_limit_diagonal}, the swapped-transposed
+    factor because swapping and transposing permute entries and exchange the
+    two diagonal weights. The limit entries are bounded, so the product
+    deviates from the product of the limits by at most a constant multiple of
+    $r^{L}$, with constant $D^2\bigl(C(B+C)+BC\bigr)+1$ for an entry bound
+    $B$ on the limits.
+\end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -39,7 +39,7 @@ conjugate-transposed tensor.
     vector
     \begin{align}
         \ket{\Psi_{\alpha,\beta}}
-        &=\sum_{\sigma}
+         & =\sum_{\sigma}
         \bra{\alpha}A^{\sigma}\ket{\beta}\,\ket{\sigma}.
         \label{eq:half_chain_vector}
     \end{align}
@@ -71,7 +71,7 @@ conjugate-transposed tensor.
     half-chain family with its complementary family. Equivalently,
     \begin{align}
         \ket{\psi}
-        &=\sum_{\alpha,\beta}
+         & =\sum_{\alpha,\beta}
         \ket{\Psi_{\alpha,\beta}}\ket{\Psi_{\beta,\alpha}}.
         \label{eq:half_chain_resolution}
     \end{align}
@@ -82,8 +82,8 @@ conjugate-transposed tensor.
     Insert the resolution of the identity
     $\sum_{\beta}\ket{\beta}\bra{\beta}$ at the two cut bonds of the ring
     trace: $\tr(A^{\sigma}A^{\tau})
-    =\sum_{\alpha,\beta}\bra{\alpha}A^{\sigma}\ket{\beta}
-    \bra{\beta}A^{\tau}\ket{\alpha}$.
+        =\sum_{\alpha,\beta}\bra{\alpha}A^{\sigma}\ket{\beta}
+        \bra{\beta}A^{\tau}\ket{\alpha}$.
 \end{proof}
 
 \begin{definition}[Half-chain reduced density matrix]%
@@ -99,7 +99,7 @@ conjugate-transposed tensor.
     over the complementary half,
     \begin{align}
         (\rho_L)_{\sigma\sigma'}
-        &=\sum_{\tau}
+         & =\sum_{\tau}
         V^{(2L)}(A)_{\sigma\tau}\,
         \overline{V^{(2L)}(A)_{\sigma'\tau}},
         \label{eq:half_chain_reduced_entry}
@@ -115,7 +115,7 @@ conjugate-transposed tensor.
     The \emph{half-chain Gram matrix} is $G=\Psi^{\dagger}\Psi$, the matrix of
     overlaps
     $G_{(\alpha,\beta),(\alpha',\beta')}
-    =\braket{\Psi_{\alpha,\beta}}{\Psi_{\alpha',\beta'}}$ of the half-chain
+        =\braket{\Psi_{\alpha,\beta}}{\Psi_{\alpha',\beta'}}$ of the half-chain
     vectors.
 \end{definition}
 
@@ -128,7 +128,7 @@ conjugate-transposed tensor.
     on matrix units:
     \begin{align}
         \braket{\Psi_{\alpha,\beta}}{\Psi_{\alpha',\beta'}}
-        &=\bra{\alpha'}\E_A^{L}
+         & =\bra{\alpha'}\E_A^{L}
         \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}.
         \label{eq:half_chain_gram_transfer}
     \end{align}
@@ -138,7 +138,7 @@ conjugate-transposed tensor.
     \leanok
     Expand the overlap as a sum over configurations of products
     $\bra{\alpha'}A^{\sigma}\ket{\beta'}
-    \overline{\bra{\alpha}A^{\sigma}\ket{\beta}}$ and recognize the entry of
+        \overline{\bra{\alpha}A^{\sigma}\ket{\beta}}$ and recognize the entry of
     $\sum_{\sigma}A^{\sigma}\ket{\beta'}\bra{\beta}(A^{\sigma})^{\dagger}$,
     which is the $L$-fold transfer map applied to the matrix unit.
 \end{proof}
@@ -153,7 +153,7 @@ conjugate-transposed tensor.
     half-chain reduced density matrix factors exactly as
     \begin{align}
         \rho_L
-        &=\Psi\,\bigl(SG^{\mathsf T}S\bigr)\,\Psi^{\dagger},
+         & =\Psi\,\bigl(SG^{\mathsf T}S\bigr)\,\Psi^{\dagger},
         \label{eq:half_chain_factorization}
     \end{align}
     where $SG^{\mathsf T}S$ is the Gram matrix of the complementary family.
@@ -179,7 +179,7 @@ conjugate-transposed tensor.
     agree after matching the trivial kernel factors:
     \begin{align}
         X^{D^2}\,\chi_{\rho_L}(X)
-        &=X^{d^L}\,\chi_{(SG^{\mathsf T}S)G}(X).
+         & =X^{d^L}\,\chi_{(SG^{\mathsf T}S)G}(X).
         \label{eq:half_chain_charpoly}
     \end{align}
     In particular the nonzero spectrum of $\rho_L$, with multiplicities, is
@@ -203,7 +203,7 @@ conjugate-transposed tensor.
     Let $A$ have trace-preserving transfer map $\E_A$ with fixed point
     $\Lambda$, $\tr(\Lambda)\neq0$, and suppose
     \begin{align}
-        \rho_{\mathrm{spec}}\bigl(\E_A-P_{\Lambda}\bigr)&<1,
+        \rho_{\mathrm{spec}}\bigl(\E_A-P_{\Lambda}\bigr) & <1,
         \label{eq:half_chain_c2_gap}
     \end{align}
     where $P_{\Lambda}$ is the fixed-point projection. Then there are
@@ -215,15 +215,16 @@ conjugate-transposed tensor.
         -\bra{\alpha'}P_{\Lambda}
         \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}
         \Bigr|
-        &\leq C r^{L}.
+         & \leq C r^{L}.
         \label{eq:half_chain_gram_geometric}
     \end{align}
     The hypothesis (\ref{eq:half_chain_c2_gap}) expresses the generic
     condition C2 of \cite{PerezGarcia2007Matrix} in the trace-preserving
     gauge: apart from the simple eigenvalue one, the spectrum of $\E_A$ lies
-    strictly inside the unit disc, and the correction term is of the order of
-    the subleading spectral radius, the bound of order $|\nu_2|^{N/2}$ of the
-    source.
+    strictly inside the unit disc. The proof chooses $r$ strictly between the
+    spectral radius of $\E_A-P_{\Lambda}$ and one. Without a semisimplicity
+    assumption on the subleading spectrum, the theorem does not assert the
+    same estimate with $r$ equal to that spectral radius.
 \end{theorem}
 
 \begin{proof}
@@ -248,7 +249,7 @@ conjugate-transposed tensor.
     \begin{align}
         \bra{\alpha'}P_{\Lambda}
         \bigl(\ket{\beta'}\bra{\beta}\bigr)\ket{\alpha}
-        &=\frac{\lambda_\alpha}{\tr(\Lambda)}\,
+         & =\frac{\lambda_\alpha}{\tr(\Lambda)}\,
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
         \label{eq:half_chain_limit_diagonal}
     \end{align}
@@ -281,7 +282,7 @@ conjugate-transposed tensor.
         -\frac{\lambda_\alpha\lambda_\beta}{\tr(\Lambda)^2}\,
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
         \Bigr|
-        &\leq C r^{L}.
+         & \leq C r^{L}.
         \label{eq:half_chain_comparison_geometric}
     \end{align}
     The limiting matrix is the diagonal matrix $\Lambda\otimes\Lambda$ up to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -1,18 +1,22 @@
 \section{Half-chain Schmidt spectrum and the dual fixed point}%
 \label{sec:half_chain_schmidt}
 
-This section formalizes the half-chain interpretation of the positive diagonal
-fixed point $\Lambda$ of \cite[Theorem~6]{PerezGarcia2007Matrix}. On a ring of
-$2L$ sites the matrix product vector splits at the two boundaries into a pair
-of half-chain families, the overlaps of the half-chain vectors are matrix
-elements of the $L$-fold transfer map, and the unnormalized half-chain reduced
-density matrix factors exactly through the half-chain Gram matrix. Away from
-zero, its spectrum is that of a boundary comparison matrix of size $D^2$, and
-under the generic spectral condition of the source that comparison matrix
-converges entrywise, geometrically in $L$, to the diagonal matrix with entries
-$\lambda_\alpha\lambda_\beta$ up to the trace normalization of $\Lambda$. The
-finite-size convention throughout is the ring of $N=2L$ sites split into two
-halves of $L$ sites each.
+This section carries out the Schmidt-decomposition step behind the half-chain
+interpretation of the positive diagonal fixed point $\Lambda$ of
+\cite[Theorem~6]{PerezGarcia2007Matrix}; it does not establish the full
+statement of that theorem. On a ring of $2L$ sites the matrix product vector
+splits at the two boundaries into a pair of half-chain families, the overlaps
+of the half-chain vectors are matrix elements of the $L$-fold transfer map,
+and the unnormalized half-chain reduced density matrix factors exactly through
+the half-chain Gram matrix. Away from zero, its spectrum is that of a boundary
+comparison matrix of size $D^2$, and under the generic spectral condition of
+the source that comparison matrix converges entrywise, geometrically in $L$,
+to the diagonal matrix with entries $\lambda_\alpha\lambda_\beta$ up to the
+trace normalization of $\Lambda$. Two conclusions of the source remain outside
+this section: the passage from entrywise convergence of the comparison matrix
+to convergence of its eigenvalues, and the normalization of the finite-size
+reduced density matrix to unit trace. The finite-size convention throughout is
+the ring of $N=2L$ sites split into two halves of $L$ sites each.
 
 The source states its canonical form with a trace-preserving dual map and a
 positive diagonal fixed point $\Lambda$ of that dual. Here the trace-preserving

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex
@@ -200,8 +200,7 @@ conjugate-transposed tensor.
     \label{thm:half_chain_gram_geometric}
     \lean{MPSTensor.exists_geometric_bound_halfChainGram_sub_fixedPointProj}
     \leanok
-    \uses{def:half_chain_gram, def:transfer_map, def:fixed_point_proj,
-        def:trace_preserving}
+    \uses{def:half_chain_gram, def:transfer_map}
     Let $A$ have trace-preserving transfer map $\E_A$ with fixed point
     $\Lambda$, $\tr(\Lambda)\neq0$, and suppose
     \begin{align}
@@ -230,7 +229,7 @@ conjugate-transposed tensor.
 
 \begin{proof}
     \leanok
-    \uses{lem:half_chain_gram_transfer, thm:pow_decomp,
+    \uses{lem:half_chain_gram_transfer,
         thm:geometric_bound_of_spectral_radius_lt_one}
     Write $\E_A^{L}=P_{\Lambda}+(\E_A-P_{\Lambda})^{L}$ for $L\geq1$ by the
     power decomposition. By (\ref{eq:half_chain_gram_transfer}) the deviation
@@ -244,7 +243,6 @@ conjugate-transposed tensor.
     \label{lem:half_chain_gram_limit_diagonal}
     \lean{MPSTensor.fixedPointProj_single_entry_diagonal}
     \leanok
-    \uses{def:fixed_point_proj}
     For a diagonal fixed point
     $\Lambda=\operatorname{diag}(\lambda_1,\ldots,\lambda_D)$ with
     $\tr(\Lambda)\neq0$, the limiting overlaps form a diagonal matrix in the
@@ -272,8 +270,7 @@ conjugate-transposed tensor.
     \label{thm:half_chain_comparison_geometric}
     \lean{MPSTensor.exists_geometric_bound_halfChainComparison_sub_diagonal}
     \leanok
-    \uses{def:half_chain_gram, def:transfer_map, def:fixed_point_proj,
-        def:trace_preserving}
+    \uses{def:half_chain_gram, def:transfer_map}
     Let $A$ have trace-preserving transfer map with diagonal fixed point
     $\Lambda=\operatorname{diag}(\lambda_1,\ldots,\lambda_D)$,
     $\tr(\Lambda)\neq0$, satisfying the spectral condition


### PR DESCRIPTION
## Summary

Formalizes the Schmidt-decomposition calculation behind the half-chain interpretation of the dual fixed point, PGVWC07 Theorem 6 ("Interpretation of $\Lambda$", arXiv:quant-ph/0608197, `MPSarchive.tex` lines 987–993, calculation at lines 970–985), in a new module `TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean` with a matching blueprint section.

Part of #6088. Part of #6085.

## Statement-integrity audit

**Paper assumptions** (lines 955–985): a TI MPS in the TI canonical form of Theorem 4 (unital one-block gauge with positive diagonal dual fixed point $\Lambda$), satisfying condition C2 (the transfer map has only one eigenvalue of magnitude one); ring of $N$ sites split into halves of $N/2$ sites.

**Lean assumptions**: an MPS tensor whose transfer map $\mathcal E_A(X)=\sum_i A^i X (A^i)^\dagger$ is trace preserving with fixed point $\Lambda$ ($\tr\Lambda\neq0$; diagonal $\Lambda$ where the paper display needs it), and $\rho_{\mathrm{spec}}(\mathcal E_A - P_\Lambda) < 1$ with $P_\Lambda$ the fixed-point projection. The trace-preserving direction is placed on the transfer map itself rather than on its dual; the two conventions are exchanged by replacing the tensor by its conjugate transpose (documented in the module docstring and the blueprint section). The spectral-radius hypothesis is the C2 condition in this gauge; the exact factorization results carry no hypothesis at all, matching the source calculation which is purely algebraic before the C2 approximation step.

**Paper conclusion vs Lean conclusion**, per stage of the source calculation:

| Source passage | Lean result | Status |
|---|---|---|
| $|\psi\rangle=\sum_{\alpha\beta}|\Psi_{\alpha\beta}\rangle|\Psi_{\beta\alpha}\rangle$ (lines 970–976) | `halfChainKernel_eq_mul` | proved, exact, hypothesis-free |
| $\langle\Psi_{\alpha\beta}|\Psi_{\alpha'\beta'}\rangle=\langle\alpha'|\mathcal E^{N/2}(|\beta'\rangle\langle\beta|)|\alpha\rangle$ (lines 977–979) | `halfChainGram_apply_eq_transferMap_pow` | proved, exact |
| Schmidt structure of the half-chain reduced state (lines 979–985) | `halfChainReducedMatrix_eq_mul_swap_gram` (exact factorization $\rho_L=\Psi(SG^{\mathsf T}S)\Psi^\dagger$), `charpoly_halfChainReducedMatrix` (nonzero spectrum of $\rho_L$ = spectrum of the $D^2\times D^2$ comparison matrix, via characteristic polynomials) | proved, exact |
| corrections of order $|\nu_2|^{N/2}$ (lines 979–981) | `exists_geometric_bound_halfChainGram_sub_fixedPointProj`: entrywise bound $Cr^L$ uniform in the boundary indices, under the C2 spectral-radius hypothesis | proved |
| $\lambda_\alpha\delta_{\alpha\alpha'}\delta_{\beta\beta'}$ (line 979) | `fixedPointProj_single_entry_diagonal` (with the explicit $\tr\Lambda$ normalization the source fixes to 1) | proved |
| Theorem 6: spectrum of the half-chain reduced density operator converges to $\Lambda\otimes\Lambda$ | `exists_geometric_bound_halfChainComparison_sub_diagonal`: the comparison matrix converges entrywise, geometrically in $L$, to $\Lambda\otimes\Lambda/\tr(\Lambda)^2$; combined with the characteristic-polynomial identity this pins the nonzero spectrum of $\rho_L$ to a matrix converging to $\Lambda\otimes\Lambda$ up to normalization | proved at the comparison-matrix level |

**Finite-size convention and convergence mode** (as the issue requires): ring of $2L$ sites split into two halves of $L$ sites; the reduced matrix is the unnormalized partial trace of the rank-one ring state; convergence is entrywise with an explicit geometric rate $Cr^L$, $r<1$, controlled by the subleading spectrum through the spectral radius of $\mathcal E_A-P_\Lambda$.

**Faithfulness verdict**: faithful as far as it goes; no hypothesis beyond the source's canonical form plus C2 is used, and the exact identities are hypothesis-free. The blueprint entries state their own hypotheses and none is labelled as Theorem 6 itself. The remaining obligation for the full Theorem 6 statement is the passage from entrywise convergence of the comparison matrix to convergence of its eigenvalues (continuity of the spectrum in the matrix entries), plus the normalization of the state, which follows from the same limit because the limiting comparison matrix has trace $(\sum_\alpha\lambda_\alpha)^2/\tr(\Lambda)^2=1$. This is stated explicitly in the blueprint section and in the issue.

## Blueprint

New section `blueprint/src/chapter/ch13_parent_hamiltonian_half_chain_schmidt.tex` (input from the chapter file), all entries `\lean{}`-tagged and `\leanok` (all proofs complete, no `sorry`, no `axiom`).

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.HalfChainSchmidt` — success, no warnings
- `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean` — clean
- `python3 scripts/generate_import_aggregators.py` — aggregators regenerated (one-line addition)
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` then `--warn-missing-blueprint --changed-files ... --diff-base origin/main --diff-head HEAD` — in sync, no missing entries

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E
