### PR TITLE
docs(MPDO): synchronize projector channel proof path

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -373,17 +373,17 @@ section.
 \end{theorem}
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_rectangular_kraus_map_cptp}
-    Choose Kraus operators $(A_{s,a})_a$ for $\Phi_s$, and set
-    $B_{s,a}=A_{s,a}P_s$. These operators give the displayed map, and
+    \uses{lem:mpdo_compressed_cp_sum, lem:mpdo_projector_controlled_trace_selection}
+    Lemma~\ref{lem:mpdo_compressed_cp_sum} shows that the displayed map is
+    completely positive. By
+    Lemma~\ref{lem:mpdo_projector_controlled_trace_selection},
     \begin{align}
-        \sum_{s,a}B_{s,a}^\dagger B_{s,a}
-         & =\sum_sP_s^\dagger
-        \left(\sum_aA_{s,a}^\dagger A_{s,a}\right)P_s
-        =\sum_sP_s=I_H.
+        \tr\bigl(\Phi(X)\bigr)
+         & =\tr\Bigl(\Bigl(\sum_sP_s\Bigr)X\Bigr)
+        =\tr(X),
         \notag
     \end{align}
-    Apply Theorem~\ref{thm:mpdo_rectangular_kraus_map_cptp}.
+    where the last equality uses $\sum_sP_s=I_H$. Thus $\Phi$ is a channel.
 \end{proof}
 
 \begin{definition}[Right partial trace]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1228,17 +1228,20 @@ current counts and full location lists).
   a projector-controlled sum of linear maps over it, use the orthogonal
   selector identity to retain the matching sector, and finish with the
   sectorwise closure equation.
-- **Seen:** four paired coarse-graining/refinement occurrences in
-  `TNLean/MPS/MPDO/BNTChannelComposition.lean`, across
-  `exists_chainCoordinateRFP_of_projectiveSectorDecomposition` and
-  `exists_chainCoordinateRFP_of_orthogonalSectorDecomposition` (2026-08-20).
-- **Abstraction (proposed):** a helper for one direction, parametrized by the
-  two closure lengths and the sectorwise map equation, if a second file needs
-  the same projector-selected finite-sum argument.
-- **Notes:** all occurrences are presently in one file, below the two-file
-  promotion threshold. The coarse-graining and refinement maps have opposite
-  matrix dimensions, so a useful abstraction must not conceal their
-  orientation.
+- **Seen:** four call sites in
+  `TNLean/MPS/MPDO/BNTChannelComposition.lean`, one coarse-graining/refinement
+  pair in each of `exists_chainCoordinateRFP_of_projectiveSectorDecomposition`
+  and `exists_chainCoordinateRFP_of_orthogonalSectorDecomposition`
+  (2026-08-20).
+- **Abstraction (file-local):** the private theorem
+  `sum_comp_singleKrausMap_firstSiteMatrix_properties` (lines 445--513)
+  extracts all four copies. It is parametrized by `n` and `m`, corresponding
+  to input and output chain lengths `n + 1` and `m + 1`, the sectorwise maps
+  `F`, and their closure equation.
+- **Notes:** all call sites remain in one file, and no further occurrences are
+  identified, so the pattern remains below the promotion threshold. The
+  parameters `n` and `m` retain the opposite matrix orientations of the
+  coarse-graining and refinement maps explicitly.
 
 ### explicit finite-generator word-tuple spanning — candidate
 - **Pattern:** unfold `MPSTensor.WordTupleSpanTop`, place one or more explicit


### PR DESCRIPTION
## What changed

- updates `thm:mpdo_projective_resolution_channel_cptp` to cite and describe the current complete-positivity plus trace-selection proof;
- records the implemented file-local `sum_comp_singleKrausMap_firstSiteMatrix_properties` abstraction and its four call sites in the tactic ledger;
- keeps the channel theorem classified as a conditional helper and the ledger pattern as a candidate below the promotion threshold.

## Statement-integrity audit

- **Paper assumptions vs. Lean assumptions:** CPSV16 Proposition `prop2to5` assumes SAL and ZCL and says to project first into each local subspace. The Lean helper instead assumes a supplied finite resolution by star projections and supplied trace-preserving completely positive sector maps. This is an intentional project-derived conditional helper, not the source proposition.
- **Paper conclusion vs. Lean conclusion:** the paper concludes existence of the two renormalization channels. The helper only proves that a projector-controlled sum of already supplied sector channels is trace-preserving and completely positive. The blueprint retains this restricted conclusion.
- **Relevant definitions:** `singleKrausMap`, star/orthogonal projection, `IsKrausCP`, and `IsKrausCPTP`.
- **Proof status:** sorry-free and axiom-free. The current Lean proof combines `isKrausCP_sum_comp_singleKrausMap` with `trace_sum_comp_singleKrausMap_of_starProjections`, then packages complete positivity and trace preservation as CPTP.
- **Faithfulness verdict:** the statement remains a faithful conditional helper for the projection-first assembly at CPSV16 Appendix C.2, lines 1810-1817. The repaired discrepancy was **proof-path drift**, not statement drift. The tactic-ledger discrepancy was stale tracking metadata.
- **Issues addressed:** closes #6856; closes #6857; supports #232.

The issue text proposed a third `\uses` label for the generic CP-plus-trace packaging theorem. That label does not exist in the current blueprint after the QICLean extraction, so the dependency list uses the two existing mathematical lemmas and states the packaging conclusion directly.

## Validation

```text
git diff --check
python3 scripts/check_tenkz_dispositions.py  # 199 blueprint occurrences and 9 fixtures reconcile
cd blueprint/src
TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex  # twice
# 913 pages; zero undefined Reference warnings
```

No Lean declaration or `\lean{}` tag changed, so no Lean rebuild is required.

