### PR TITLE
style(blueprint): fix the leftover latexindent line and re-enforce the check

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -821,21 +821,8 @@ jobs:
           find blueprint/src tex/tenkz/examples -name '*.tex' -not -path '*/Packages/*' -print0 \
             | xargs -0 -r chktex -q -l blueprint/.chktexrc
 
-      # continue-on-error: the runner's latexindent 3.23.6 (TeX Live 2023,
-      # texlive-extra-utils on ubuntu-latest) is intermittently
-      # nondeterministic in `-k` check mode on
-      # blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex (a ragged
-      # 4-column \begin{align} block at lines 482-484): the file is
-      # correctly formatted -- 32/32 isolated and full-tree stress-mode
-      # invocations pass, and -w -s is a no-op on it -- yet the real
-      # pull_request-triggered check step has failed on it 3/3 times
-      # (LionSR/TNLean#6874, then twice more on main after the merge).
-      # Re-enforce once the flake is root-caused (candidates: pin an exact
-      # latexindent release rather than tracking apt's texlive-extra-utils,
-      # or restructure the align block to a uniform column count).
       - name: Check LaTeX formatting (latexindent)
         if: env.TEX_CHANGED == 'true'
-        continue-on-error: true
         timeout-minutes: 5
         run: |
           set -e

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -269,7 +269,7 @@
     chain length $N$, the normalized density operators agree:
     \begin{align}
         \tr\!\left[\rho^{(N)}(cM)\right]^{-1}\rho^{(N)}(cM)
-        &=\tr\!\left[\rho^{(N)}(M)\right]^{-1}\rho^{(N)}(M),
+         & =\tr\!\left[\rho^{(N)}(M)\right]^{-1}\rho^{(N)}(M),
         \notag
     \end{align}
     with the inverse of zero understood to be zero.


### PR DESCRIPTION
## Summary

#6874 ran `latexindent -l blueprint/latexindent.yaml -w -s` over the full
scoped tree but converged to a fixed point that still left one line
unformatted: line 272 of `blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex`
(`&=` where the file's other 15 alignment lines all read ` & =`). #6876
worked around the resulting CI failures by un-enforcing the check.

This PR:

1. Fixes that one leftover line. Verified by running the formatter to a
   *stable fixed point* this time -- write pass, then a full check pass
   over all 254 scoped files, repeated until two consecutive check passes
   are clean -- using CI's own latexindent (3.23.6, TeX Live 2023 via
   `texlive-extra-utils` on `ubuntu-latest`) via a throwaway workflow run,
   not a local install. Converged after one write pass; two consecutive
   full-tree check passes both reported zero warnings.
2. Confirmed the four files #6875 touched since #6874
   (`blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex`,
   `ch08_wielandt_fixed_length_and_normality.tex`,
   `ch08_wielandt_word_span_and_block_injectivity.tex`, and
   `appendix/ft_mps/ch08_wielandt.tex`) are already latexindent-clean --
   no new drift from that merge. #6875 did not delete any scoped files.
3. Re-enforces the "Check LaTeX formatting (latexindent)" step, reverting
   #6876's `continue-on-error: true` and its pending-flake comment, which
   is what #6876 said should happen once a full formatting pass landed.

Only one `.tex` line changed; whitespace-only (stripped of all
whitespace, before/after are byte-identical).

## Test plan

- [x] Whitespace-only change verified for the one modified file.
- [x] `leanblueprint web` builds without error.
- [x] `scripts/check_tenkz_dispositions.py` passes (unchanged; the edit
      doesn't shift any line count).
- [x] `scripts/check_tenkz_demolition.py` passes.
- [ ] This PR's own CI run of "Check LaTeX formatting (latexindent)"
      (now enforcing) is green.