### PR TITLE
refactor(tenkz): retire the sentenced nudge= pair

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3287,3 +3287,27 @@ hundred lines of clearance-envelope geometry), reachable only from a
 direct-call test after the key left, is demolished with that test and its
 two golden rows -- the string-probe suite stands at 28 artifacts,
 byte-identical.
+
+### 2026-08-22 — the sentenced nudge= pair is retired
+
+The two displacement keys sentenced by amendment seven — `nudge=` on atoms
+and on marks — held live parser rows and registry rows while the amendment's
+mechanism was already the law: extent comes from counts, and a label takes
+its station against measured ink, the `label pos=` auto ordering standing on
+the first free face since #6168. Both keys were read by no render code and
+written by no case, blueprint figure, manual example, or slide, so this is
+the retirement bookkeeping the sentenced-key header promised, performed as
+for `up=`/`down=` (#6335) and the inert-key triple above. The refusal
+fixtures `n_atom_nudge_key.tex` and `n_mark_nudge_key.tex` pin the
+unknown-key answer, and the contract's section 10 row for the pair is
+unchanged: a basis member, an ordinary address, or the label station rule.
+
+Meters: m1 kernel 60 → 58 (census 83 → 81), m2 parser paths 72 → 70;
+`tests/tenkz/census-baseline.json` moves in this change.
+Extension-gate: #6356 — the parser-leaf identity change is the two
+removals themselves; no key is added.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:kernel-atom:nudge | retired: sentenced by amendment seven, read by nothing, written by nothing; permanent |
+| flag:consumers:key:kernel-mark:nudge | retired: sentenced by amendment seven, the label station rule landed in #6168; permanent |

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -79,7 +79,6 @@ kernel-\allowbreak{}atom & \texttt{species} & declared-\allowbreak{}name & empty
 kernel-\allowbreak{}atom & \texttt{pairing~cross} & indexed-\allowbreak{}crossing-\allowbreak{}list & empty & Per-\allowbreak{}instance \allowbreak{}crossings \allowbreak{}of \allowbreak{}generated \allowbreak{}skin \allowbreak{}pairings. \\
 kernel-\allowbreak{}atom & \texttt{size} & size-\allowbreak{}class & m & Per-\allowbreak{}atom \allowbreak{}metric \allowbreak{}size \allowbreak{}class. \\
 kernel-\allowbreak{}atom & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant; \allowbreak{}auto \allowbreak{}takes \allowbreak{}the \allowbreak{}first \allowbreak{}free \allowbreak{}face \allowbreak{}in \allowbreak{}the \allowbreak{}order \allowbreak{}s,\allowbreak{} \allowbreak{}n,\allowbreak{} \allowbreak{}e,\allowbreak{} \allowbreak{}w,\allowbreak{} \allowbreak{}and \allowbreak{}south \allowbreak{}when \allowbreak{}every \allowbreak{}face \allowbreak{}carries \allowbreak{}ink. \\
-kernel-\allowbreak{}atom & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
 kernel-\allowbreak{}atom & \texttt{void} & void-\allowbreak{}policy & unset & Hole \allowbreak{}or \allowbreak{}removed \allowbreak{}site. \\
 kernel-\allowbreak{}atom & \texttt{physical} & physical-\allowbreak{}policy & unset & Site's \allowbreak{}own \allowbreak{}answer \allowbreak{}to \allowbreak{}the \allowbreak{}picture's \allowbreak{}physical \allowbreak{}policy. \\
 kernel-\allowbreak{}atom & \texttt{conjugate} & flag & false & Tombstoned; \allowbreak{}stored,\allowbreak{} \allowbreak{}read \allowbreak{}by \allowbreak{}nothing. \allowbreak{}Sunset \allowbreak{}1.0. \\
@@ -101,7 +100,6 @@ kernel-\allowbreak{}mark & \texttt{form} & enum(\allowbreak{}bracket\textbar{}\a
 kernel-\allowbreak{}mark & \texttt{slot} & semantic-\allowbreak{}slot & selected & Semantic \allowbreak{}tint. \\
 kernel-\allowbreak{}mark & \texttt{species} & declared-\allowbreak{}name & empty & Semantic \allowbreak{}species. \\
 kernel-\allowbreak{}mark & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant. \\
-kernel-\allowbreak{}mark & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
 kernel-\allowbreak{}mark & \texttt{name} & identifier & generated & Addressable \allowbreak{}name. \\
 kernel-\allowbreak{}mark & \texttt{tint} & flag & false & Interior \allowbreak{}tint \allowbreak{}under \allowbreak{}the \allowbreak{}contour. \\
 kernel-\allowbreak{}setup & \texttt{pitch} & length & em-\allowbreak{}relative & Base \allowbreak{}metric. \\

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2622,6 +2622,8 @@ for contract_negative in \
   n_wire_bend_key \
   n_wire_around_key \
   n_mark_inset_key \
+  n_atom_nudge_key \
+  n_mark_nudge_key \
   n_malformed_via \
   n_malformed_cross \
   n_malformed_mark_target \
@@ -2702,6 +2704,10 @@ do
   [ "$contract_negative" = n_wire_around_key ] &&
     expected='[TKZ-LANG-UNKNOWN-KEY]'
   [ "$contract_negative" = n_mark_inset_key ] &&
+    expected='[TKZ-LANG-UNKNOWN-KEY]'
+  [ "$contract_negative" = n_atom_nudge_key ] &&
+    expected='[TKZ-LANG-UNKNOWN-KEY]'
+  [ "$contract_negative" = n_mark_nudge_key ] &&
     expected='[TKZ-LANG-UNKNOWN-KEY]'
   [ "$contract_negative" = n_signature_carrier_port ] &&
     expected='[TKZ-EQ-SIGNATURE]'

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -6,14 +6,14 @@
       "commands": 12,
       "environments": 2,
       "escape": 0,
-      "kernel": 60,
+      "kernel": 58,
       "sugar": 9
     }
   },
   "m2_parser_paths": {
     "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-    "identity_sha256": "ede71b34c3301096e2729c3e2a73824cfa74556f77d12f4b26289286c3ccba0f",
-    "value": 72
+    "identity_sha256": "db281b35b885627a1c04a61f6748eea2071c3f90b6b7dc488b067b2f7b0fdeaf",
+    "value": 70
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",

--- a/tests/tenkz/kernel/negative/n_atom_nudge_key.tex
+++ b/tests/tenkz/kernel/negative/n_atom_nudge_key.tex
@@ -1,0 +1,9 @@
+% Negative: the retired atom `nudge=` displacement key has no parser path.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, bonds=none]
+  \tn[nudge={0.25,0}]{A}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_mark_nudge_key.tex
+++ b/tests/tenkz/kernel/negative/n_mark_nudge_key.tex
@@ -1,0 +1,11 @@
+% Negative: the retired mark `nudge=` displacement key has no parser path.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, bonds=none]
+  \tn[at=(1,1), skin=box, name=a]{A}
+  \tn[at=(1,2), skin=box, name=b]{B}
+  \tnmark[form=enclosure, nudge={0,0.25}]{(1,1) .. (1,2)}{$X$}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1281,7 +1281,6 @@
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { size }
   { s, m, l } { size }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { label~pos } { label-pos }
-\__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { nudge } { nudge }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { void }
   { open, sealed } { void }
 % A site may answer the picture's physical policy for itself: the policy
@@ -1347,7 +1346,6 @@
   { selected, secondary, complement, collar, neutral } { slot }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { species } { species }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { label~pos } { label-pos }
-\__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { nudge } { nudge }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { name } { name }
 \__tenkz_kernel_flag:nnn    { tenkz-kernel-mark } { tint } { tint }
 \__tenkz_kernel_unknown:nn  { tenkz-kernel-mark } { mark }

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -57,8 +57,6 @@
 % removes the parser row; the ledger status moves with the parser and not
 % before, which is how every retirement here has been booked since session 0.
 %
-%   kernel-mark:nudge      a label takes a station against measured ink
-%   kernel-atom:nudge      an off-cell record is a basis member or an address
 %   kernel-wire:via        a waypoint is a side of a selection
 %   kernel-wire:weight     the port type decides the stroke
 %
@@ -66,6 +64,9 @@
 % rows were removed (the inert-key retirement, #6194/#6249): their
 % tombstone rows stand at the foot of this file, and around=, never
 % sentenced but equally inert, left with them.
+% The nudge= pair left the same way (#6356): amendment seven's mechanism
+% -- extent from counts, labels from ink -- had already landed, so the
+% retirement was bookkeeping, and its tombstone rows stand below.
 %
 % One sentence was overturned by the corpus it was passed on.
 % kernel-picture:check stood condemned as an audit switch the author should
@@ -182,7 +183,6 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{pairing~cross}{indexed-crossing-list}{empty}{kernel}{Per-instance crossings of generated skin pairings.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{size}{size-class}{m}{kernel}{Per-atom metric size class.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{label~pos}{angle}{auto}{kernel}{Label quadrant; auto takes the first free face in the order s, n, e, w, and south when every face carries ink.}
-\__tenkz_language_registry_key:nnnnnn {kernel-atom}{nudge}{pair}{zero}{kernel}{Quarter-pitch displacement.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{void}{void-policy}{unset}{kernel}{Hole or removed site.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{physical}{physical-policy}{unset}{kernel}{Site's own answer to the picture's physical policy.}
 % Issue 5383: stored but never read by ink passes or the signature fold.
@@ -229,7 +229,6 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{slot}{semantic-slot}{selected}{kernel}{Semantic tint.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{species}{declared-name}{empty}{kernel}{Semantic species.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{label~pos}{angle}{auto}{kernel}{Label quadrant.}
-\__tenkz_language_registry_key:nnnnnn {kernel-mark}{nudge}{pair}{zero}{kernel}{Quarter-pitch displacement.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{name}{identifier}{generated}{kernel}{Addressable name.}
 % Extension-gate: #5570.  The flag reads the way the corpus draws: a mark is
 % a contour, and a region that carries paper under it says so.
@@ -295,6 +294,16 @@
   {no successor: the key recorded a list and detoured nothing, so delete
     it; a detour an author intends is route={<side> of <selector>}, a
     side of a selection whose crossing set answers the claim}
+%
+% The sentenced nudge= pair, retired 2026-08-22 (#6356): amendment seven's
+% replacement doctrine was already landed, so nothing displaces by hand.
+% One row carries both scopes, as the contract's section 10 states it,
+% because the ledger holds one spelling per row for the lint to match.
+\__tenkz_language_registry_tombstone:nnn {kernel-atom}{nudge}
+  {no successor, on either scope: an off-cell atom is a basis member or
+    an address, and a mark's label takes its station against measured
+    ink -- label pos= names a bearing, and auto stands on the first
+    free face}
 %
 % The four mark forms below took a record and drew nothing.  What the sources
 % brace, the benchmark already brackets (rmp-ii-spectrum-transfer); what they


### PR DESCRIPTION
Closes LionSR/tenkz#219. Part of LionSR/tenkz#13 item 1 (the four sentenced keys: `up=`/`down=` closed in LionSR/TNLean#6335, `nudge=` closed here; `via=` and `weight=` remain).

Amendment seven's mechanism — extent from counts, labels from ink — landed long ago: the label station rule stands as the `label pos=` auto ordering since LionSR/TNLean#6168, and an off-cell atom is a basis member or an address. The two displacement keys the amendment sentenced, `nudge=` on atoms and on marks, still held live parser rows, read by no render code (`grep '{nudge}'` matches only the two registrations) and written by nothing in the corpus, blueprint, manual, or slides.

The rows leave; **one tombstone row carries both scopes**, exactly as the contract's §10 states the pair, because the ledger holds one spelling per row for the lint to match; `n_atom_nudge_key.tex` and `n_mark_nudge_key.tex` pin the unknown-key answer. Census 83 → 81, parser paths 72 → 70, booked as a dated SHRINK session with the baseline moved in the same change. Extension-gate: LionSR/tenkz#219.

Standard closeout: language check, kernel probes, manual doctests, lint — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kkKii8Q9ZeWTr2bqkNxP4
