### PR TITLE
fix(tenkz): record the full trace ink on both emission paths

### DIFF
--- a/docs/tenkz/TNLOG.md
+++ b/docs/tenkz/TNLOG.md
@@ -188,8 +188,8 @@ the drawn dashes would in fact have cleared it. The same doctrine covers the
 `origin=mark` record above and the trace halo below -- every one of them
 would rather over-claim ink than leave a real collision unrecorded.
 
-A `trace` route's own `stroke` field carries the *halo's* half-width, not
-the colour band alone: `trace/.style` (`tex/tenkz/tenkz-core.code.tex`,
+A `trace` route's own `stroke` field carries the wider of its two
+layers, never the colour band alone: `trace/.style` (`tex/tenkz/tenkz-core.code.tex`,
 the `trace` style) paints a `preaction` paper halo of line width
 `wirewidth + crossgap` under the visible band, and a label sitting in that
 annulus is erased just as surely as one sitting on the band itself, and the

--- a/docs/tenkz/TNLOG.md
+++ b/docs/tenkz/TNLOG.md
@@ -192,10 +192,14 @@ A `trace` route's own `stroke` field carries the *halo's* half-width, not
 the colour band alone: `trace/.style` (`tex/tenkz/tenkz-core.code.tex`,
 the `trace` style) paints a `preaction` paper halo of line width
 `wirewidth + crossgap` under the visible band, and a label sitting in that
-annulus is erased just as surely as one sitting on the band itself. Recording
-only the band's half-width would leave that annulus unflagged, so the
-`origin=trace` record's `stroke` is `(wirewidth + crossgap) / 2` and the
-audit's label-on-ink test never sees the narrower, wrong number.
+annulus is erased just as surely as one sitting on the band itself, and the
+foreground stroke inherits the restylable `bond` class, so a widened bond
+draws past the fixed halo sum. Recording either layer alone would leave the
+other's ink unflagged, so the `origin=trace` record's `stroke` is the wider
+of `(wirewidth + crossgap) / 2` and the resolved foreground half stroke, on
+both trace paths -- the after-atom return and the queued multi-row pair
+trace alike -- and the audit's label-on-ink test never sees a narrower,
+wrong number.
 
 ## 4. Order
 

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -2280,8 +2280,13 @@ def main() -> int:
         # (120586) and the widened band (131072) sits on drawn foreground
         # the halo-only record missed.
         styled_run = next(
-            event for event in styled_traces
-            if event.attrs["points"].startswith("0,530808;0,1310253;"))
+            (event for event in styled_traces
+             if event.attrs["points"].startswith("0,530808;0,1310253;")),
+            None)
+        if styled_run is None:
+            raise AssertionError(
+                "the restyled trace lost its west rise; its records were: "
+                + "; ".join(event.raw for event in styled_traces))
         styled_log = styled_trace_audit.log_path.read_text(encoding="utf-8")
         styled_log += (
             "label-use|picture=k1\n"
@@ -2319,8 +2324,13 @@ def main() -> int:
                 "a queued pair trace did not record the halo band: "
                 + "; ".join(event.raw for event in pair_traces))
         pair_run = next(
-            event for event in pair_traces
-            if event.attrs["points"].startswith("0,0;0,779436;"))
+            (event for event in pair_traces
+             if event.attrs["points"].startswith("0,0;0,779436;")),
+            None)
+        if pair_run is None:
+            raise AssertionError(
+                "the pair trace lost its west rise; its records were: "
+                + "; ".join(event.raw for event in pair_traces))
         pair_log = pair_audit.log_path.read_text(encoding="utf-8")
         pair_log += (
             "label-use|picture=k1\n"

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -513,6 +513,31 @@ STYLED_SOURCE = r"""
 \end{document}
 """
 
+STYLED_TRACE_SOURCE = r"""
+\documentclass{standalone}
+\usepackage{tenkz}
+\tikzset{bond/.append style={line width=4pt}}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, physical=updown, trace=physical,
+              west=open, east=open]
+  \tn[skin=mpo]{M} & \tn[skin=mpo]{M}
+\end{tenkz}
+\end{document}
+"""
+
+PAIR_TRACE_SOURCE = r"""
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=2, physical=updown, trace=physical]
+  \tn[skin=box]{A} & \tn[skin=box]{B} \\
+  \tn[skin=box]{C} & \tn[skin=box]{D}
+\end{tenkz}
+\end{document}
+"""
+
 NESTED_CLAIM_SOURCE = r"""
 \documentclass{standalone}
 \usepackage{tenkz}
@@ -2232,6 +2257,89 @@ def main() -> int:
                 "a label in the trace's paper-halo annulus, clear of the "
                 "coloured band's old half stroke, was not flagged: "
                 + "; ".join(f.msg for f in halo_audit.findings))
+
+        # The trace's two emission paths each understated the drawn ink in
+        # one direction (#6359).  The foreground stroke inherits the
+        # restylable `bond` style, so a widened bond draws past the fixed
+        # halo sum: the after-atom record must follow the resolved width,
+        # and a label on that outer foreground ink must read as ink.
+        styled_trace_status, styled_trace_audit = audit_status(
+            compile_tex("styled-trace.tex", STYLED_TRACE_SOURCE))
+        styled_traces = [event for event in styled_trace_audit.events("k1")
+                         if event.kind == "wire-ink"
+                         and event.attrs.get("origin") == "trace"]
+        if styled_trace_status != 0 or not styled_traces or any(
+                event.attrs.get("stroke") != "131072"
+                for event in styled_traces):
+            raise AssertionError(
+                "a restyled-bond trace did not record its widened "
+                "foreground: "
+                + "; ".join(event.raw for event in styled_traces))
+        # The record's first run is the vertical rise at the trace's own
+        # west x; a label strictly between the old halo half stroke
+        # (120586) and the widened band (131072) sits on drawn foreground
+        # the halo-only record missed.
+        styled_run = next(
+            event for event in styled_traces
+            if event.attrs["points"].startswith("0,530808;0,1310253;"))
+        styled_log = styled_trace_audit.log_path.read_text(encoding="utf-8")
+        styled_log += (
+            "label-use|picture=k1\n"
+            "bbox|picture=k1|class=label|id=98|owner=0|"
+            "xmin=125000|xmax=126000|ymin=700000|ymax=703000|"
+            "shape=rect|radius=0|station=n|provenance=auto\n"
+        )
+        styled_seeded = work / "styled-trace-seeded.tnlog"
+        styled_seeded.write_text(styled_log, encoding="utf-8")
+        styled_seed_status, styled_seed_audit = audit_status(styled_seeded)
+        styled_found = [
+            finding for finding in styled_seed_audit.findings
+            if finding.rule == "label-on-ink"
+            and "trace route" in finding.msg]
+        if styled_seed_status != 1 or len(styled_found) != 1:
+            raise AssertionError(
+                "a label on a restyled trace's outer foreground ink was "
+                "not flagged: "
+                + "; ".join(f.msg for f in styled_seed_audit.findings))
+
+        # And the queued path: a multi-row physical pair trace rides the
+        # queued index route, whose capture reads only the foreground; the
+        # paper halo is painted crossgap/2 beyond it.  The record takes
+        # the wider of the two, and a label in the halo's annulus beyond
+        # the foreground band must read as ink.
+        pair_status, pair_audit = audit_status(
+            compile_tex("pair-trace.tex", PAIR_TRACE_SOURCE))
+        pair_traces = [event for event in pair_audit.events("k1")
+                       if event.kind == "wire-ink"
+                       and event.attrs.get("origin") == "trace"]
+        if pair_status != 0 or not pair_traces or any(
+                event.attrs.get("stroke") != "120586"
+                for event in pair_traces):
+            raise AssertionError(
+                "a queued pair trace did not record the halo band: "
+                + "; ".join(event.raw for event in pair_traces))
+        pair_run = next(
+            event for event in pair_traces
+            if event.attrs["points"].startswith("0,0;0,779436;"))
+        pair_log = pair_audit.log_path.read_text(encoding="utf-8")
+        pair_log += (
+            "label-use|picture=k1\n"
+            "bbox|picture=k1|class=label|id=97|owner=0|"
+            "xmin=30000|xmax=33000|ymin=300000|ymax=303000|"
+            "shape=rect|radius=0|station=n|provenance=auto\n"
+        )
+        pair_seeded = work / "pair-trace-seeded.tnlog"
+        pair_seeded.write_text(pair_log, encoding="utf-8")
+        pair_seed_status, pair_seed_audit = audit_status(pair_seeded)
+        pair_found = [
+            finding for finding in pair_seed_audit.findings
+            if finding.rule == "label-on-ink"
+            and "trace route" in finding.msg]
+        if pair_seed_status != 1 or len(pair_found) != 1:
+            raise AssertionError(
+                "a label in a queued trace's halo annulus was not "
+                "flagged: "
+                + "; ".join(f.msg for f in pair_seed_audit.findings))
 
         # A directed wire's Straight Barb postaction paints ink the
         # centreline walk cannot see (#6330 review, direction-mark ink).

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11549,6 +11549,14 @@
 % the queued index class.  The path is still saved first -- unregistered,
 % purely as the measured object -- and the stroke replays that saved path,
 % so the auditor and the renderer read one resolved route here too.
+% One authority for the trace halo's half-width in scaled points: both
+% trace emission paths widen their band by this same number, so a change
+% to the halo sum lands once.
+\cs_new:Npn \__tenkz_kernel_r_trace_halo_sp:
+  {
+    \dim_to_decimal_in_sp:n
+      { ( \__tenkz_dim:n {wirewidth} + \__tenkz_dim:n {crossgap} ) / 2 }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_r_trace_stroke:nn #1#2
   {
     \__tenkz_kernel_r_sid:nN {#1} \l__tenkz_kernel_r_sid_tl
@@ -11573,11 +11581,7 @@
         \fp_eval:n
           {
             max ( \g__tenkz_kernel_ink_width_tl ,
-                  \dim_to_decimal_in_sp:n
-                    {
-                      ( \__tenkz_dim:n {wirewidth}
-                        + \__tenkz_dim:n {crossgap} ) / 2
-                    } )
+                  \__tenkz_kernel_r_trace_halo_sp: )
           }
       }
     \__tenkz_kernel_r_wire_ink_event:nn {#1} { trace }
@@ -16772,11 +16776,7 @@
             \fp_eval:n
               {
                 max ( \l__tenkz_kernel_ink_stroke_tl ,
-                      \dim_to_decimal_in_sp:n
-                        {
-                          ( \__tenkz_dim:n {wirewidth}
-                            + \__tenkz_dim:n {crossgap} ) / 2
-                        } )
+                      \__tenkz_kernel_r_trace_halo_sp: )
               }
           }
       }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11558,20 +11558,29 @@
 \cs_new_protected:Npn \__tenkz_kernel_r_trace_stroke_aux:nn #1#2
   {
     \path [ spath/save = {#1} ] #2 ;
-    % The `trace` style's preaction paints a paper halo of line width
-    % wirewidth + crossgap (tenkz-core.code.tex, the `trace` style), a fixed
-    % sum the style hard-codes rather than deriving from the resolved
-    % colour-band width, so the record matches that same fixed sum exactly:
-    % recording only the band's half-width would leave the halo's own
-    % annulus -- crossgap/2 beyond the band -- invisible to the audit, and a
-    % label sitting there is erased with no finding (#6330 review).
+    % A trace paints two layers: a foreground stroke inheriting the
+    % restylable `bond` style and a paper preaction halo of the fixed sum
+    % wirewidth + crossgap (tenkz-core.code.tex, the `trace` style).  The
+    % record must dominate the union of the two (#6359): the capture key
+    % rides the one real stroke to read the resolved foreground width, and
+    % the recorded band is the wider of that and the halo, so neither a
+    % label erased in the halo's annulus nor one standing on a widened
+    % foreground's outer ink can evade the audit.
+    \__tenkz_render_stroke:nn
+      { trace , spath/use = {#1} , tenkz~ink~capture~width } { }
     \tl_set:Ne \l__tenkz_kernel_ink_stroke_tl
       {
-        \dim_to_decimal_in_sp:n
-          { ( \__tenkz_dim:n {wirewidth} + \__tenkz_dim:n {crossgap} ) / 2 }
+        \fp_eval:n
+          {
+            max ( \g__tenkz_kernel_ink_width_tl ,
+                  \dim_to_decimal_in_sp:n
+                    {
+                      ( \__tenkz_dim:n {wirewidth}
+                        + \__tenkz_dim:n {crossgap} ) / 2
+                    } )
+          }
       }
     \__tenkz_kernel_r_wire_ink_event:nn {#1} { trace }
-    \__tenkz_render_stroke:nn { trace , spath/use = {#1} } { }
   }
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_event:nn #1#2
   {
@@ -16752,6 +16761,25 @@
       \l__tenkz_kernel_r_wire_style_tl { }
     \tl_set_eq:NN \l__tenkz_kernel_ink_stroke_tl
       \g__tenkz_kernel_ink_width_tl
+    % A queued trace paints the same paper halo as the after-atom path,
+    % crossgap/2 beyond the captured foreground band; the record takes
+    % the wider of the two, so a label in the halo's annulus is read
+    % (#6359).
+    \str_if_eq:VnT \l__tenkz_kernel_ink_origin_tl {trace}
+      {
+        \tl_set:Ne \l__tenkz_kernel_ink_stroke_tl
+          {
+            \fp_eval:n
+              {
+                max ( \l__tenkz_kernel_ink_stroke_tl ,
+                      \dim_to_decimal_in_sp:n
+                        {
+                          ( \__tenkz_dim:n {wirewidth}
+                            + \__tenkz_dim:n {crossgap} ) / 2
+                        } )
+              }
+          }
+      }
     \exp_args:NVV \__tenkz_kernel_r_wire_ink_event:nn
       \l__tenkz_kernel_r_sid_tl \l__tenkz_kernel_ink_origin_tl
     \tl_clear:N \l__tenkz_kernel_ink_origin_tl


### PR DESCRIPTION
Closes LionSR/tenkz#222.

A trace paints two layers — a foreground stroke inheriting the restylable `bond` style and a paper preaction halo of the fixed sum `wirewidth + crossgap` — and each of the two trace emission paths recorded one layer only, understating the drawn ink in one direction each: the after-atom return hard-coded the halo sum, so a widened bond drew foreground past the recorded band; the queued multi-row pair trace captured the resolved foreground only, so the halo's annulus was painted and never recorded.

Both paths now record **max(halo, resolved foreground)**: the after-atom path reads the width off its one real stroke through the capture key (same event order as before), and the queued path widens its captured band exactly when the origin is trace.

Seeded per the issue: the overlap suite compiles a restyled-bond trace (records its widened foreground; a label seeded on the outer foreground ink reads HARD) and a default pair trace (records the halo band; a label seeded in the annulus reads HARD). TNLOG's trace-stroke sentence states the max on both paths. No pinned stream moves: default after-atom traces already recorded the halo sum, and no pinned fixture reaches the queued pair-trace path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kkKii8Q9ZeWTr2bqkNxP4
