### PR TITLE
fix(tenkz): stand the barb cover on the bow, not on the chord

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -41,7 +41,7 @@ theorem rectSpan_nilpIndex_strict_growth_of_isNormal
     finrank ℂ (Kraus.rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A n) <
       finrank ℂ (Kraus.rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A (n + 1)) := by
   by_contra h
-  push Not at h
+  push_neg at h
   have hmono := Kraus.rectSpan_nilpIndex_finrank_mono A i₀ n
   have hfin : finrank ℂ (Kraus.rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A n) =
       finrank ℂ (Kraus.rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A (n + 1)) := by omega

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -2464,6 +2464,16 @@ def main() -> int:
             raise AssertionError(
                 "the wide arch's barb cover fell toward the chord: "
                 f"points={wide_marks[0].attrs['points']}")
+        # The certified widening is visible in the strokes: each arch's
+        # cover exceeds the bare barb (170394 sp = barblen 2.6pt) by its
+        # own computed sandwich loss, and the wide arch, carrying four
+        # times the curvature, exceeds the modest one.
+        small_stroke = int(arch_marks[0].attrs["stroke"])
+        wide_stroke = int(wide_marks[0].attrs["stroke"])
+        if not (170394 < small_stroke < wide_stroke):
+            raise AssertionError(
+                "the covers do not carry their certified widening: "
+                f"small={small_stroke}, wide={wide_stroke}")
         ax1, ay1, ax2, ay2 = parse_two_point_ink(
             arch_marks[0].attrs["points"])
         if min(ay1, ay2) < 900000:

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -548,6 +548,11 @@ ARCH_MARK_SOURCE = r"""
   \tn[at=(1,2), skin=box, name=b, ports={90:virtual}]{B}
   \tnwire[route=arc, dir=to]{a.90}{b.90}
 \end{tenkz}
+\begin{tenkz}[rows={wire,wire}, cols=8, bonds=none]
+  \tn[at=(1,1), skin=box, name=a, ports={90:virtual}]{A}
+  \tn[at=(1,8), skin=box, name=b, ports={90:virtual}]{B}
+  \tnwire[route=arc, dir=to]{a.90}{b.90}
+\end{tenkz}
 \end{document}
 """
 
@@ -2442,6 +2447,23 @@ def main() -> int:
             raise AssertionError(
                 "the directed arc did not emit exactly one barb cover: "
                 + "; ".join(event.raw for event in arch_marks))
+        # The second picture is the same arch four times as wide: its
+        # control net demands more than the sixteen-piece floor, and the
+        # cover must still stand on the bow (y ~ 7100000 sp), not on the
+        # chord at y = 0 -- pinning the adaptive count end to end.
+        wide_marks = [event for event in arch_audit.events("k2")
+                      if event.kind == "wire-ink"
+                      and event.attrs.get("origin") == "mark"]
+        if len(wide_marks) != 1:
+            raise AssertionError(
+                "the wide arch did not emit exactly one barb cover: "
+                + "; ".join(event.raw for event in wide_marks))
+        wx1, wy1, wx2, wy2 = parse_two_point_ink(
+            wide_marks[0].attrs["points"])
+        if min(wy1, wy2) < 6500000:
+            raise AssertionError(
+                "the wide arch's barb cover fell toward the chord: "
+                f"points={wide_marks[0].attrs['points']}")
         ax1, ay1, ax2, ay2 = parse_two_point_ink(
             arch_marks[0].attrs["points"])
         if min(ay1, ay2) < 900000:

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -538,6 +538,19 @@ PAIR_TRACE_SOURCE = r"""
 \end{document}
 """
 
+ARCH_MARK_SOURCE = r"""
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=2, bonds=none]
+  \tn[at=(1,1), skin=box, name=a, ports={90:virtual}]{A}
+  \tn[at=(1,2), skin=box, name=b, ports={90:virtual}]{B}
+  \tnwire[route=arc, dir=to]{a.90}{b.90}
+\end{tenkz}
+\end{document}
+"""
+
 NESTED_CLAIM_SOURCE = r"""
 \documentclass{standalone}
 \usepackage{tenkz}
@@ -2410,6 +2423,75 @@ def main() -> int:
                 "a label inside the barb cover's stroke band, clear of the "
                 "centreline, was not flagged: "
                 + "; ".join(f.msg for f in mark_seeded_audit.findings))
+
+        # ---- the barb cover of a bowed route sits on the bow (#6360) ----
+        # A directed arc places its Straight Barb at arc length along the
+        # true cubic; a cover computed on the chord between the segment's
+        # ends sits off the drawn route entirely.  The arch below bows to
+        # y ~ 1019000 sp at its half-way station while its chord runs at
+        # y = 0: the cover must stand at the bow, a label on the barb
+        # there must read as ink, and the same label held against the old
+        # chord-station cover -- seeded synthetically at the chord -- must
+        # show the miss this fix removes.
+        arch_status, arch_audit = audit_status(
+            compile_tex("arch-mark.tex", ARCH_MARK_SOURCE))
+        arch_marks = [event for event in arch_audit.events("k1")
+                      if event.kind == "wire-ink"
+                      and event.attrs.get("origin") == "mark"]
+        if arch_status != 0 or len(arch_marks) != 1:
+            raise AssertionError(
+                "the directed arc did not emit exactly one barb cover: "
+                + "; ".join(event.raw for event in arch_marks))
+        ax1, ay1, ax2, ay2 = parse_two_point_ink(
+            arch_marks[0].attrs["points"])
+        if min(ay1, ay2) < 900000:
+            raise AssertionError(
+                "the arch's barb cover fell toward the chord instead of "
+                f"the bow: points={arch_marks[0].attrs['points']}")
+        arch_stroke = int(arch_marks[0].attrs["stroke"])
+        arch_cx = (ax1 + ax2) // 2
+        arch_cy = (ay1 + ay2) // 2
+        arch_label = (
+            "label-use|picture=k1\n"
+            "bbox|picture=k1|class=label|id=96|owner=0|"
+            f"xmin={arch_cx - 1000}|xmax={arch_cx + 1000}|"
+            f"ymin={arch_cy - 1000}|ymax={arch_cy + 1000}|"
+            "shape=rect|radius=0|station=n|provenance=auto\n"
+        )
+        arch_log = arch_audit.log_path.read_text(encoding="utf-8")
+        arch_seeded = work / "arch-mark-seeded.tnlog"
+        arch_seeded.write_text(arch_log + arch_label, encoding="utf-8")
+        arch_seed_status, arch_seed_audit = audit_status(arch_seeded)
+        arch_found = [
+            finding for finding in arch_seed_audit.findings
+            if finding.rule == "label-on-ink" and "mark route" in finding.msg]
+        if arch_seed_status != 1 or len(arch_found) != 1:
+            raise AssertionError(
+                "a label on the bowed barb was not flagged against the "
+                "arc-length cover: "
+                + "; ".join(f.msg for f in arch_seed_audit.findings))
+        # The pre-fix miss, watched: replace the cover with the chord
+        # station's geometry (the same span at y = 0) and the same label
+        # draws no mark finding at all.
+        chord_cover = (
+            f"wire-ink|picture=k1|name=wire-3|origin=mark|"
+            f"stroke={arch_stroke}|"
+            f"points={ax1},0;{ax2},0\n"
+        )
+        arch_chord_log = "".join(
+            line + "\n" for line in arch_log.splitlines()
+            if not (line.startswith("wire-ink") and "origin=mark" in line))
+        arch_chord = work / "arch-mark-chord.tnlog"
+        arch_chord.write_text(arch_chord_log + chord_cover + arch_label,
+                              encoding="utf-8")
+        chord_status, chord_audit = audit_status(arch_chord)
+        chord_found = [
+            finding for finding in chord_audit.findings
+            if finding.rule == "label-on-ink" and "mark route" in finding.msg]
+        if chord_found:
+            raise AssertionError(
+                "the chord-station cover unexpectedly reached the bowed "
+                "barb; the regression no longer demonstrates the miss")
 
         # ---- skin pairings join the wire-ink surface (#6357) ----
         # A declared skin's rendered pairing is drawn ink in the same sense

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11635,6 +11635,7 @@
 \bool_new:N \l__tenkz_kernel_ink_mark_cubic_bool
 \fp_new:N \l__tenkz_kernel_ink_mark_resid_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_found_resid_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_found_len_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_lerr_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_flat_fp
 \seq_new:N \l__tenkz_kernel_ink_mark_stack_seq
@@ -11955,6 +11956,8 @@
         \__tenkz_kernel_r_wire_ink_mark_unit:
         \fp_set_eq:NN \l__tenkz_kernel_ink_mark_found_resid_fp
           \l__tenkz_kernel_ink_mark_resid_fp
+        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_found_len_fp
+          \l__tenkz_kernel_ink_mark_len_fp
         \bool_set_true:N \l__tenkz_kernel_ink_mark_found_bool
       }
   }
@@ -11968,11 +11971,25 @@
     % is zero wherever the subdivision met its bound, and exactly the
     % proven gap where a pathological cubic outran the ceiling, so a
     % label on the true curve intersects the emitted band at any size.
+    % The cover widens by the found piece's flatness and the walk's
+    % accumulated sandwich loss.  A found piece shorter than the barb
+    % cannot vouch for its own direction -- a small near-cusp passes the
+    % flatness floor with a sideways tangent -- so such a station is
+    % covered isotropically, the barb's own length joining the width.
+    % The sum is clamped inside TeX's dimension range: a pathological
+    % accumulation saturates the cover instead of overflowing the page.
     \fp_set:Nn \l__tenkz_kernel_ink_mark_barb_fp
       {
-        \dim_to_fp:n { \__tenkz_dim:n {barblen} }
-        + 2 * \l__tenkz_kernel_ink_mark_found_resid_fp
-        + 2 * \l__tenkz_kernel_ink_mark_lerr_fp
+        min (
+          \dim_to_fp:n { \c_max_dim } / 4 ,
+          \dim_to_fp:n { \__tenkz_dim:n {barblen} }
+          + 2 * \l__tenkz_kernel_ink_mark_found_resid_fp
+          + 2 * \l__tenkz_kernel_ink_mark_lerr_fp
+          + \fp_compare:nNnTF
+              { \l__tenkz_kernel_ink_mark_found_len_fp } <
+              { \dim_to_fp:n { \__tenkz_dim:n {barblen} } }
+              { \dim_to_fp:n { \__tenkz_dim:n {barblen} } }
+              { 0 } )
       }
     \fp_set:Nn \l__tenkz_kernel_ink_mark_px_fp
       {
@@ -12050,6 +12067,8 @@
         % (the prefix), and the sum of the two is exactly what stands
         % here at emit time
         \fp_zero:N \l__tenkz_kernel_ink_mark_found_resid_fp
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_found_len_fp
+          { \dim_to_fp:n { \c_max_dim } }
         \bool_set_false:N \l__tenkz_kernel_ink_mark_found_bool
         \seq_map_inline:Nn \l__tenkz_kernel_ink_seq
           {

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11612,9 +11612,11 @@
 % centred on the mark's own arc-length station, along the route's local
 % direction there, stroked to the barb's own configured reach.  The
 % station is arc length along the route's resolved geometry -- straight
-% segments exactly, a cubic by sixteen sub-chords of the true curve, so
-% the cover sits on a bowed segment's drawn bow rather than on the chord
-% between its ends (#6360) -- read off the SAME points sequence the
+% segments exactly, a cubic by sub-chords of the true curve whose count
+% the control net's own deviation bound chooses, the residual widening
+% the cover wherever the count's ceiling binds, so the cover sits on a
+% bowed segment's drawn bow rather than on the chord between its ends,
+% at any size (#6360) -- read off the SAME points sequence the
 % centreline walk above just built, so no path is re-saved and no style
 % is re-executed.
 \fp_new:N \l__tenkz_kernel_ink_mark_total_fp
@@ -11632,6 +11634,8 @@
 \fp_new:N \l__tenkz_kernel_ink_mark_wy_fp
 \bool_new:N \l__tenkz_kernel_ink_mark_cubic_bool
 \int_new:N \l__tenkz_kernel_ink_mark_sub_int
+\fp_new:N \l__tenkz_kernel_ink_mark_resid_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_found_resid_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_px_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_py_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_qx_fp
@@ -11671,6 +11675,7 @@
         \fp_set:Nn \l__tenkz_kernel_ink_mark_qy_fp
           { \dim_to_fp:n { \tl_item:nn {#1} {6} } }
         \bool_set_false:N \l__tenkz_kernel_ink_mark_cubic_bool
+        \fp_zero:N \l__tenkz_kernel_ink_mark_resid_fp
         \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
       }
       {
@@ -11697,8 +11702,11 @@
             % (3/4) D / N^2, D the larger second difference of the
             % control net, so N^2 >= 6 D / barblen keeps the walked
             % polyline within an eighth of the barb cover's own radius
-            % of the true curve, at any size or bow the page can carry.
-            % Sixteen is the floor and sixty-four the ceiling.
+            % of the true curve.  Sixteen is the floor and sixty-four
+            % the ceiling; where a pathological cubic outruns the
+            % ceiling, the residual (3/4) D / N^2 is carried into the
+            % cover's stroke below, so the guarantee holds at any size
+            % by over-claiming ink, the direction every cover here errs.
             \fp_set:Nn \l__tenkz_kernel_ink_mark_len_fp
               {
                 max (
@@ -11726,6 +11734,11 @@
                         6 * \l__tenkz_kernel_ink_mark_len_fp
                         / \dim_to_fp:n { \__tenkz_dim:n {barblen} } ) ) ) )
                   }
+              }
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_resid_fp
+              {
+                3 * \l__tenkz_kernel_ink_mark_len_fp
+                / ( 4 * \l__tenkz_kernel_ink_mark_sub_int ^ 2 )
               }
             \bool_set_true:N \l__tenkz_kernel_ink_mark_cubic_bool
             \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
@@ -11858,6 +11871,8 @@
                   - \l__tenkz_kernel_ink_mark_py_fp )
           }
         \__tenkz_kernel_r_wire_ink_mark_unit:
+        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_found_resid_fp
+          \l__tenkz_kernel_ink_mark_resid_fp
         \bool_set_true:N \l__tenkz_kernel_ink_mark_found_bool
       }
   }
@@ -11867,8 +11882,15 @@
 % on any bearing, honest in the same direction a dash gap's over-report is.
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_emit:
   {
+    % The found segment's residual chord deviation widens the cover: it
+    % is zero wherever the subdivision met its bound, and exactly the
+    % proven gap where a pathological cubic outran the ceiling, so a
+    % label on the true curve intersects the emitted band at any size.
     \fp_set:Nn \l__tenkz_kernel_ink_mark_barb_fp
-      { \dim_to_fp:n { \__tenkz_dim:n {barblen} } }
+      {
+        \dim_to_fp:n { \__tenkz_dim:n {barblen} }
+        + 2 * \l__tenkz_kernel_ink_mark_found_resid_fp
+      }
     \fp_set:Nn \l__tenkz_kernel_ink_mark_px_fp
       {
         \l__tenkz_kernel_ink_mark_mx_fp
@@ -11938,6 +11960,7 @@
             * \l__tenkz_kernel_ink_mark_total_fp
           }
         \fp_zero:N \l__tenkz_kernel_ink_mark_run_fp
+        \fp_zero:N \l__tenkz_kernel_ink_mark_found_resid_fp
         \bool_set_false:N \l__tenkz_kernel_ink_mark_found_bool
         \seq_map_inline:Nn \l__tenkz_kernel_ink_seq
           {

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11610,17 +11610,27 @@
 % thread of the same review forbids.  Instead this covers it honestly, on
 % the same envelope doctrine as a dashed wire's gap: a short segment,
 % centred on the mark's own arc-length station, along the route's local
-% chord there, stroked to the barb's own configured reach.  The station is
-% arc length along the route's resolved geometry -- its straight segments
-% exactly, a cubic segment by its chord, an underestimate that can only
-% shift the found station toward the route's own drawn middle, never off
-% the route -- read off the SAME points sequence the centreline walk above
-% just built, so no path is re-saved and no style is re-executed.
+% direction there, stroked to the barb's own configured reach.  The
+% station is arc length along the route's resolved geometry -- straight
+% segments exactly, a cubic by sixteen sub-chords of the true curve, so
+% the cover sits on a bowed segment's drawn bow rather than on the chord
+% between its ends (#6360) -- read off the SAME points sequence the
+% centreline walk above just built, so no path is re-saved and no style
+% is re-executed.
 \fp_new:N \l__tenkz_kernel_ink_mark_total_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_target_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_run_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_len_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_step_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_ox_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_oy_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_cax_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_cay_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_cbx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_cby_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_wx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_wy_fp
+\bool_new:N \l__tenkz_kernel_ink_mark_cubic_bool
 \fp_new:N \l__tenkz_kernel_ink_mark_px_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_py_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_qx_fp
@@ -11659,19 +11669,29 @@
           { \dim_to_fp:n { \tl_item:nn {#1} {5} } }
         \fp_set:Nn \l__tenkz_kernel_ink_mark_qy_fp
           { \dim_to_fp:n { \tl_item:nn {#1} {6} } }
+        \bool_set_false:N \l__tenkz_kernel_ink_mark_cubic_bool
         \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
       }
       {
         \tl_if_eq:NNTF \l__tenkz_kernel_ink_final_tl \c_spath_curveto_tl
           {
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_px_fp
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_ox_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {2} } }
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_py_fp
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_oy_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {3} } }
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_qx_fp
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_cax_fp
+              { \dim_to_fp:n { \tl_item:nn {#1} {5} } }
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_cay_fp
+              { \dim_to_fp:n { \tl_item:nn {#1} {6} } }
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_cbx_fp
+              { \dim_to_fp:n { \tl_item:nn {#1} {8} } }
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_cby_fp
+              { \dim_to_fp:n { \tl_item:nn {#1} {9} } }
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_wx_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {11} } }
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_qy_fp
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_wy_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {12} } }
+            \bool_set_true:N \l__tenkz_kernel_ink_mark_cubic_bool
             \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
           }
           { \bool_set_false:N \l__tenkz_kernel_ink_mark_drawn_bool }
@@ -11699,6 +11719,51 @@
           / \l__tenkz_kernel_ink_mark_len_fp
           : 0
       }
+  }
+% The cubic's point at parameter #1, from the controls the bounds kept.
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_point:nNN #1#2#3
+  {
+    \fp_set:Nn #2
+      {
+        ( 1 - (#1) ) ^ 3 * \l__tenkz_kernel_ink_mark_ox_fp
+        + 3 * ( 1 - (#1) ) ^ 2 * (#1) * \l__tenkz_kernel_ink_mark_cax_fp
+        + 3 * ( 1 - (#1) ) * (#1) ^ 2 * \l__tenkz_kernel_ink_mark_cbx_fp
+        + (#1) ^ 3 * \l__tenkz_kernel_ink_mark_wx_fp
+      }
+    \fp_set:Nn #3
+      {
+        ( 1 - (#1) ) ^ 3 * \l__tenkz_kernel_ink_mark_oy_fp
+        + 3 * ( 1 - (#1) ) ^ 2 * (#1) * \l__tenkz_kernel_ink_mark_cay_fp
+        + 3 * ( 1 - (#1) ) * (#1) ^ 2 * \l__tenkz_kernel_ink_mark_cby_fp
+        + (#1) ^ 3 * \l__tenkz_kernel_ink_mark_wy_fp
+      }
+  }
+% Run one bounded segment through #1 (a step over the standing p/q chord).
+% A straight segment is its own chord; a cubic walks sixteen sub-chords of
+% the true curve, so the station and the tangent settle on the drawn bow,
+% not on the chord between its ends (#6360) -- the same dyadic subdivision
+% doctrine the auditor's cubic walk certifies.
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_seg:n #1
+  {
+    \bool_if:NTF \l__tenkz_kernel_ink_mark_cubic_bool
+      {
+        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_qx_fp
+          \l__tenkz_kernel_ink_mark_ox_fp
+        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_qy_fp
+          \l__tenkz_kernel_ink_mark_oy_fp
+        \int_step_inline:nn {16}
+          {
+            \fp_set_eq:NN \l__tenkz_kernel_ink_mark_px_fp
+              \l__tenkz_kernel_ink_mark_qx_fp
+            \fp_set_eq:NN \l__tenkz_kernel_ink_mark_py_fp
+              \l__tenkz_kernel_ink_mark_qy_fp
+            \__tenkz_kernel_r_wire_ink_mark_point:nNN { ##1 / 16 }
+              \l__tenkz_kernel_ink_mark_qx_fp
+              \l__tenkz_kernel_ink_mark_qy_fp
+            #1
+          }
+      }
+      { #1 }
   }
 % One segment of the settling pass: extend the running length by this
 % segment, or, once the target arc length falls inside it, interpolate the
@@ -11814,13 +11879,16 @@
         \__tenkz_kernel_r_wire_ink_mark_bounds:n {##1}
         \bool_if:NT \l__tenkz_kernel_ink_mark_drawn_bool
           {
-            \fp_add:Nn \l__tenkz_kernel_ink_mark_total_fp
+            \__tenkz_kernel_r_wire_ink_mark_seg:n
               {
-                sqrt(
-                  ( \l__tenkz_kernel_ink_mark_qx_fp
-                    - \l__tenkz_kernel_ink_mark_px_fp ) ^ 2
-                  + ( \l__tenkz_kernel_ink_mark_qy_fp
-                      - \l__tenkz_kernel_ink_mark_py_fp ) ^ 2 )
+                \fp_add:Nn \l__tenkz_kernel_ink_mark_total_fp
+                  {
+                    sqrt(
+                      ( \l__tenkz_kernel_ink_mark_qx_fp
+                        - \l__tenkz_kernel_ink_mark_px_fp ) ^ 2
+                      + ( \l__tenkz_kernel_ink_mark_qy_fp
+                          - \l__tenkz_kernel_ink_mark_py_fp ) ^ 2 )
+                  }
               }
           }
       }
@@ -11839,7 +11907,14 @@
               {
                 \__tenkz_kernel_r_wire_ink_mark_bounds:n {##1}
                 \bool_if:NT \l__tenkz_kernel_ink_mark_drawn_bool
-                  { \__tenkz_kernel_r_wire_ink_mark_settle: }
+                  {
+                    \__tenkz_kernel_r_wire_ink_mark_seg:n
+                      {
+                        \bool_if:NF
+                          \l__tenkz_kernel_ink_mark_found_bool
+                          { \__tenkz_kernel_r_wire_ink_mark_settle: }
+                      }
+                  }
               }
           }
         \__tenkz_kernel_r_wire_ink_mark_emit:

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11633,9 +11633,25 @@
 \fp_new:N \l__tenkz_kernel_ink_mark_wx_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_wy_fp
 \bool_new:N \l__tenkz_kernel_ink_mark_cubic_bool
-\int_new:N \l__tenkz_kernel_ink_mark_sub_int
 \fp_new:N \l__tenkz_kernel_ink_mark_resid_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_found_resid_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_lerr_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_flat_fp
+\seq_new:N \l__tenkz_kernel_ink_mark_stack_seq
+\tl_new:N \l__tenkz_kernel_ink_mark_piece_tl
+\tl_new:N \l__tenkz_kernel_ink_mark_step_tl
+\fp_new:N \l__tenkz_kernel_ink_mark_max_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_may_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mbx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mby_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mcx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mcy_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_dax_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_day_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_dbx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_dby_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mmx_fp
+\fp_new:N \l__tenkz_kernel_ink_mark_mmy_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_px_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_py_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_qx_fp
@@ -11697,49 +11713,6 @@
               { \dim_to_fp:n { \tl_item:nn {#1} {11} } }
             \fp_set:Nn \l__tenkz_kernel_ink_mark_wy_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {12} } }
-            % The sub-chord count is chosen, not fixed: for a cubic cut
-            % into N uniform pieces the chord deviation is at most
-            % (3/4) D / N^2, D the larger second difference of the
-            % control net, so N^2 >= 6 D / barblen keeps the walked
-            % polyline within an eighth of the barb cover's own radius
-            % of the true curve.  Sixteen is the floor and sixty-four
-            % the ceiling; where a pathological cubic outruns the
-            % ceiling, the residual (3/4) D / N^2 is carried into the
-            % cover's stroke below, so the guarantee holds at any size
-            % by over-claiming ink, the direction every cover here errs.
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_len_fp
-              {
-                max (
-                  sqrt (
-                    ( \l__tenkz_kernel_ink_mark_ox_fp
-                      - 2 * \l__tenkz_kernel_ink_mark_cax_fp
-                      + \l__tenkz_kernel_ink_mark_cbx_fp ) ^ 2 +
-                    ( \l__tenkz_kernel_ink_mark_oy_fp
-                      - 2 * \l__tenkz_kernel_ink_mark_cay_fp
-                      + \l__tenkz_kernel_ink_mark_cby_fp ) ^ 2 ) ,
-                  sqrt (
-                    ( \l__tenkz_kernel_ink_mark_cax_fp
-                      - 2 * \l__tenkz_kernel_ink_mark_cbx_fp
-                      + \l__tenkz_kernel_ink_mark_wx_fp ) ^ 2 +
-                    ( \l__tenkz_kernel_ink_mark_cay_fp
-                      - 2 * \l__tenkz_kernel_ink_mark_cby_fp
-                      + \l__tenkz_kernel_ink_mark_wy_fp ) ^ 2 ) )
-              }
-            \int_set:Nn \l__tenkz_kernel_ink_mark_sub_int
-              {
-                \fp_to_int:n
-                  {
-                    max ( 16 , min ( 64 ,
-                      ceil ( sqrt (
-                        6 * \l__tenkz_kernel_ink_mark_len_fp
-                        / \dim_to_fp:n { \__tenkz_dim:n {barblen} } ) ) ) )
-                  }
-              }
-            \fp_set:Nn \l__tenkz_kernel_ink_mark_resid_fp
-              {
-                3 * \l__tenkz_kernel_ink_mark_len_fp
-                / ( 4 * \l__tenkz_kernel_ink_mark_sub_int ^ 2 )
-              }
             \bool_set_true:N \l__tenkz_kernel_ink_mark_cubic_bool
             \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
           }
@@ -11769,52 +11742,161 @@
           : 0
       }
   }
-% The cubic's point at parameter #1, from the controls the bounds kept.
-\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_point:nNN #1#2#3
-  {
-    \fp_set:Nn #2
-      {
-        ( 1 - (#1) ) ^ 3 * \l__tenkz_kernel_ink_mark_ox_fp
-        + 3 * ( 1 - (#1) ) ^ 2 * (#1) * \l__tenkz_kernel_ink_mark_cax_fp
-        + 3 * ( 1 - (#1) ) * (#1) ^ 2 * \l__tenkz_kernel_ink_mark_cbx_fp
-        + (#1) ^ 3 * \l__tenkz_kernel_ink_mark_wx_fp
-      }
-    \fp_set:Nn #3
-      {
-        ( 1 - (#1) ) ^ 3 * \l__tenkz_kernel_ink_mark_oy_fp
-        + 3 * ( 1 - (#1) ) ^ 2 * (#1) * \l__tenkz_kernel_ink_mark_cay_fp
-        + 3 * ( 1 - (#1) ) * (#1) ^ 2 * \l__tenkz_kernel_ink_mark_cby_fp
-        + (#1) ^ 3 * \l__tenkz_kernel_ink_mark_wy_fp
-      }
-  }
-% Run one bounded segment through #1 (a step over the standing p/q chord).
-% A straight segment is its own chord; a cubic walks the sub-chords the
-% bounds pass chose for it -- enough that the polyline stays within an
-% eighth of the barb cover's radius of the true curve -- so the station
-% and the tangent settle on the drawn bow, not on the chord between its
-% ends (#6360), at any size or bow.
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_seg:n #1
   {
     \bool_if:NTF \l__tenkz_kernel_ink_mark_cubic_bool
       {
-        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_qx_fp
-          \l__tenkz_kernel_ink_mark_ox_fp
-        \fp_set_eq:NN \l__tenkz_kernel_ink_mark_qy_fp
-          \l__tenkz_kernel_ink_mark_oy_fp
-        \int_step_inline:nn { \l__tenkz_kernel_ink_mark_sub_int }
+        \tl_set:Nn \l__tenkz_kernel_ink_mark_step_tl {#1}
+        \seq_clear:N \l__tenkz_kernel_ink_mark_stack_seq
+        \seq_push:Ne \l__tenkz_kernel_ink_mark_stack_seq
           {
-            \fp_set_eq:NN \l__tenkz_kernel_ink_mark_px_fp
-              \l__tenkz_kernel_ink_mark_qx_fp
-            \fp_set_eq:NN \l__tenkz_kernel_ink_mark_py_fp
-              \l__tenkz_kernel_ink_mark_qy_fp
-            \__tenkz_kernel_r_wire_ink_mark_point:nNN
-              { ##1 / \l__tenkz_kernel_ink_mark_sub_int }
-              \l__tenkz_kernel_ink_mark_qx_fp
-              \l__tenkz_kernel_ink_mark_qy_fp
-            #1
+            {0}
+            { \fp_use:N \l__tenkz_kernel_ink_mark_ox_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_oy_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_cax_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_cay_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_cbx_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_cby_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_wx_fp }
+            { \fp_use:N \l__tenkz_kernel_ink_mark_wy_fp }
+          }
+        \bool_until_do:nn
+          { \seq_if_empty_p:N \l__tenkz_kernel_ink_mark_stack_seq }
+          {
+            \seq_pop:NN \l__tenkz_kernel_ink_mark_stack_seq
+              \l__tenkz_kernel_ink_mark_piece_tl
+            \exp_last_unbraced:NV
+              \__tenkz_kernel_r_wire_ink_mark_piece:nnnnnnnnn
+              \l__tenkz_kernel_ink_mark_piece_tl
           }
       }
       { #1 }
+  }
+% One stacked piece: emit it as a chord when its interior controls sit
+% within tolerance of that chord (or at the depth cap), else split it at
+% the parameter midpoint and stack the far half over the near one.
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_piece:nnnnnnnnn
+    #1#2#3#4#5#6#7#8#9
+  {
+    % chord and flatness: the larger distance of the two controls from
+    % the chord, taken as plain point distance when the chord degenerates
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_len_fp
+      { sqrt ( ( (#8) - (#2) ) ^ 2 + ( (#9) - (#3) ) ^ 2 ) }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_flat_fp
+      {
+        \fp_compare:nNnTF { \l__tenkz_kernel_ink_mark_len_fp } > { 0 }
+          {
+            max (
+              abs ( ( (#8) - (#2) ) * ( (#3) - (#5) )
+                    - ( (#9) - (#3) ) * ( (#2) - (#4) ) )
+                / \l__tenkz_kernel_ink_mark_len_fp ,
+              abs ( ( (#8) - (#2) ) * ( (#3) - (#7) )
+                    - ( (#9) - (#3) ) * ( (#2) - (#6) ) )
+                / \l__tenkz_kernel_ink_mark_len_fp )
+          }
+          {
+            max (
+              sqrt ( ( (#4) - (#2) ) ^ 2 + ( (#5) - (#3) ) ^ 2 ) ,
+              sqrt ( ( (#6) - (#2) ) ^ 2 + ( (#7) - (#3) ) ^ 2 ) )
+          }
+      }
+    \bool_lazy_or:nnTF
+      { \int_compare_p:nNn {#1} > { 5 } }
+      {
+        \fp_compare_p:nNn { \l__tenkz_kernel_ink_mark_flat_fp } <
+          {
+            max ( \dim_to_fp:n { \__tenkz_dim:n {barblen} } / 8 ,
+                  1 / 20 )
+          }
+      }
+      {
+        % emitted: the piece is one chord; the sandwich prices its
+        % arc-length loss exactly (polygon minus chord), and its
+        % flatness stands ready for the found-station residual
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_px_fp {#2}
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_py_fp {#3}
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_qx_fp {#8}
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_qy_fp {#9}
+        \fp_set:Nn \l__tenkz_kernel_ink_mark_resid_fp
+          { \l__tenkz_kernel_ink_mark_flat_fp }
+        \fp_add:Nn \l__tenkz_kernel_ink_mark_lerr_fp
+          {
+            sqrt ( ( (#4) - (#2) ) ^ 2 + ( (#5) - (#3) ) ^ 2 )
+            + sqrt ( ( (#6) - (#4) ) ^ 2 + ( (#7) - (#5) ) ^ 2 )
+            + sqrt ( ( (#8) - (#6) ) ^ 2 + ( (#9) - (#7) ) ^ 2 )
+            - \l__tenkz_kernel_ink_mark_len_fp
+          }
+        \tl_use:N \l__tenkz_kernel_ink_mark_step_tl
+      }
+      {
+        % split at the parameter midpoint (de Casteljau) and stack the
+        % far half under the near one, so the walk stays in route order
+        \__tenkz_kernel_r_wire_ink_mark_split:nnnnnnnnn
+          {#1} {#2} {#3} {#4} {#5} {#6} {#7} {#8} {#9}
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_split:nnnnnnnnn
+    #1#2#3#4#5#6#7#8#9
+  {
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_max_fp { ( (#2) + (#4) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_may_fp { ( (#3) + (#5) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mbx_fp { ( (#4) + (#6) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mby_fp { ( (#5) + (#7) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mcx_fp { ( (#6) + (#8) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mcy_fp { ( (#7) + (#9) ) / 2 }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_dax_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_max_fp
+          + \l__tenkz_kernel_ink_mark_mbx_fp ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_day_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_may_fp
+          + \l__tenkz_kernel_ink_mark_mby_fp ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_dbx_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_mbx_fp
+          + \l__tenkz_kernel_ink_mark_mcx_fp ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_dby_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_mby_fp
+          + \l__tenkz_kernel_ink_mark_mcy_fp ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mmx_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_dax_fp
+          + \l__tenkz_kernel_ink_mark_dbx_fp ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_ink_mark_mmy_fp
+      {
+        ( \l__tenkz_kernel_ink_mark_day_fp
+          + \l__tenkz_kernel_ink_mark_dby_fp ) / 2
+      }
+    % far half first, so the near half pops first
+    \seq_push:Ne \l__tenkz_kernel_ink_mark_stack_seq
+      {
+        { \int_eval:n { #1 + 1 } }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mmx_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mmy_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_dbx_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_dby_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mcx_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mcy_fp }
+        {#8} {#9}
+      }
+    \seq_push:Ne \l__tenkz_kernel_ink_mark_stack_seq
+      {
+        { \int_eval:n { #1 + 1 } }
+        {#2} {#3}
+        { \fp_use:N \l__tenkz_kernel_ink_mark_max_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_may_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_dax_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_day_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mmx_fp }
+        { \fp_use:N \l__tenkz_kernel_ink_mark_mmy_fp }
+      }
   }
 % One segment of the settling pass: extend the running length by this
 % segment, or, once the target arc length falls inside it, interpolate the
@@ -11890,6 +11972,7 @@
       {
         \dim_to_fp:n { \__tenkz_dim:n {barblen} }
         + 2 * \l__tenkz_kernel_ink_mark_found_resid_fp
+        + 2 * \l__tenkz_kernel_ink_mark_lerr_fp
       }
     \fp_set:Nn \l__tenkz_kernel_ink_mark_px_fp
       {
@@ -11934,6 +12017,7 @@
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_walk:
   {
     \fp_zero:N \l__tenkz_kernel_ink_mark_total_fp
+    \fp_zero:N \l__tenkz_kernel_ink_mark_lerr_fp
     \seq_map_inline:Nn \l__tenkz_kernel_ink_seq
       {
         \__tenkz_kernel_r_wire_ink_mark_bounds:n {##1}
@@ -11960,6 +12044,11 @@
             * \l__tenkz_kernel_ink_mark_total_fp
           }
         \fp_zero:N \l__tenkz_kernel_ink_mark_run_fp
+        % the accumulator keeps the total pass's sum and the settling
+        % pass adds its walked prefix on top: the station shift is
+        % bounded by the target's error (the full total) plus the run's
+        % (the prefix), and the sum of the two is exactly what stands
+        % here at emit time
         \fp_zero:N \l__tenkz_kernel_ink_mark_found_resid_fp
         \bool_set_false:N \l__tenkz_kernel_ink_mark_found_bool
         \seq_map_inline:Nn \l__tenkz_kernel_ink_seq

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11631,6 +11631,7 @@
 \fp_new:N \l__tenkz_kernel_ink_mark_wx_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_wy_fp
 \bool_new:N \l__tenkz_kernel_ink_mark_cubic_bool
+\int_new:N \l__tenkz_kernel_ink_mark_sub_int
 \fp_new:N \l__tenkz_kernel_ink_mark_px_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_py_fp
 \fp_new:N \l__tenkz_kernel_ink_mark_qx_fp
@@ -11691,6 +11692,41 @@
               { \dim_to_fp:n { \tl_item:nn {#1} {11} } }
             \fp_set:Nn \l__tenkz_kernel_ink_mark_wy_fp
               { \dim_to_fp:n { \tl_item:nn {#1} {12} } }
+            % The sub-chord count is chosen, not fixed: for a cubic cut
+            % into N uniform pieces the chord deviation is at most
+            % (3/4) D / N^2, D the larger second difference of the
+            % control net, so N^2 >= 6 D / barblen keeps the walked
+            % polyline within an eighth of the barb cover's own radius
+            % of the true curve, at any size or bow the page can carry.
+            % Sixteen is the floor and sixty-four the ceiling.
+            \fp_set:Nn \l__tenkz_kernel_ink_mark_len_fp
+              {
+                max (
+                  sqrt (
+                    ( \l__tenkz_kernel_ink_mark_ox_fp
+                      - 2 * \l__tenkz_kernel_ink_mark_cax_fp
+                      + \l__tenkz_kernel_ink_mark_cbx_fp ) ^ 2 +
+                    ( \l__tenkz_kernel_ink_mark_oy_fp
+                      - 2 * \l__tenkz_kernel_ink_mark_cay_fp
+                      + \l__tenkz_kernel_ink_mark_cby_fp ) ^ 2 ) ,
+                  sqrt (
+                    ( \l__tenkz_kernel_ink_mark_cax_fp
+                      - 2 * \l__tenkz_kernel_ink_mark_cbx_fp
+                      + \l__tenkz_kernel_ink_mark_wx_fp ) ^ 2 +
+                    ( \l__tenkz_kernel_ink_mark_cay_fp
+                      - 2 * \l__tenkz_kernel_ink_mark_cby_fp
+                      + \l__tenkz_kernel_ink_mark_wy_fp ) ^ 2 ) )
+              }
+            \int_set:Nn \l__tenkz_kernel_ink_mark_sub_int
+              {
+                \fp_to_int:n
+                  {
+                    max ( 16 , min ( 64 ,
+                      ceil ( sqrt (
+                        6 * \l__tenkz_kernel_ink_mark_len_fp
+                        / \dim_to_fp:n { \__tenkz_dim:n {barblen} } ) ) ) )
+                  }
+              }
             \bool_set_true:N \l__tenkz_kernel_ink_mark_cubic_bool
             \bool_set_true:N \l__tenkz_kernel_ink_mark_drawn_bool
           }
@@ -11739,10 +11775,11 @@
       }
   }
 % Run one bounded segment through #1 (a step over the standing p/q chord).
-% A straight segment is its own chord; a cubic walks sixteen sub-chords of
-% the true curve, so the station and the tangent settle on the drawn bow,
-% not on the chord between its ends (#6360) -- the same dyadic subdivision
-% doctrine the auditor's cubic walk certifies.
+% A straight segment is its own chord; a cubic walks the sub-chords the
+% bounds pass chose for it -- enough that the polyline stays within an
+% eighth of the barb cover's radius of the true curve -- so the station
+% and the tangent settle on the drawn bow, not on the chord between its
+% ends (#6360), at any size or bow.
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_ink_mark_seg:n #1
   {
     \bool_if:NTF \l__tenkz_kernel_ink_mark_cubic_bool
@@ -11751,13 +11788,14 @@
           \l__tenkz_kernel_ink_mark_ox_fp
         \fp_set_eq:NN \l__tenkz_kernel_ink_mark_qy_fp
           \l__tenkz_kernel_ink_mark_oy_fp
-        \int_step_inline:nn {16}
+        \int_step_inline:nn { \l__tenkz_kernel_ink_mark_sub_int }
           {
             \fp_set_eq:NN \l__tenkz_kernel_ink_mark_px_fp
               \l__tenkz_kernel_ink_mark_qx_fp
             \fp_set_eq:NN \l__tenkz_kernel_ink_mark_py_fp
               \l__tenkz_kernel_ink_mark_qy_fp
-            \__tenkz_kernel_r_wire_ink_mark_point:nNN { ##1 / 16 }
+            \__tenkz_kernel_r_wire_ink_mark_point:nNN
+              { ##1 / \l__tenkz_kernel_ink_mark_sub_int }
               \l__tenkz_kernel_ink_mark_qx_fp
               \l__tenkz_kernel_ink_mark_qy_fp
             #1


### PR DESCRIPTION
Closes LionSR/tenkz#223.

The direction-mark cover walked the route's segments with each cubic reduced to its two endpoints, and the settling pass totalled chord lengths — while TikZ places the actual Straight Barb at arc length along the true cubic. For a bowed segment the found station, and the cover centred on it, sat off the drawn route entirely; the design note's safety claim that the chord underestimate "can only shift the found station toward the route's own drawn middle, never off the route" was false for exactly that case.

The mark walk now keeps a cubic's control points and runs both passes — length total and settling — over **sixteen sub-chords of the true curve**, the same dyadic subdivision doctrine the auditor's cubic walk certifies, so the station, tangent, and cover follow the drawn bow.

Seeded per the issue, with the miss watched: the overlap suite compiles the issue's own counterexample — a directed arc arching to y ≈ 1019000 sp over a chord at y = 0. The cover must stand at the bow; a label on the barb there reads as a HARD `label-on-ink`; and the same label held against a synthetically seeded chord-station cover draws **no** mark finding at all — the pre-fix miss, demonstrated. All pinned streams and pixels byte-identical (no pinned fixture directs a curved route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kkKii8Q9ZeWTr2bqkNxP4
