### PR TITLE
chore(blueprint): texra-blueprint v0.3.2 — wip status and modified dates

### DIFF
--- a/.github/allowed-tools.json
+++ b/.github/allowed-tools.json
@@ -1,7 +1,7 @@
 {
   "lean-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-review-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),Bash(gh pr *),Bash(gh api *),mcp__github__*",
-  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.1),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
+  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.2),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-linter-warning-auto-fix": "Read,Edit,Glob,Grep,Bash(python3 *),Bash(lake build),Bash(lake build *),Bash(lake env),Bash(lake env *),Bash(git diff *),Bash(git status),Bash(grep *),Bash(rg *)",
   "claude-interactive": "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *),mcp__github__*",
   "blueprint-prose-review": "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(grep *),mcp__github__*",

--- a/.github/prompts/auto-fix-blueprint-prompt.md
+++ b/.github/prompts/auto-fix-blueprint-prompt.md
@@ -15,7 +15,7 @@ Instructions:
 3. The blueprint `.tex` files are in `blueprint/src/chapter/`. The blueprint configuration is in `blueprint/src/`.
 4. You can test your fix locally by running:
 
-   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.1`
+   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.2`
    - `cd blueprint && leanblueprint web`
 
    Check that no `ERROR` lines appear in the output.

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Run mentioned agent
         id: agent

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Check native tenkz sources and picture pipeline
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -776,7 +776,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 
       - name: Lint tenkz picture sources
         if: env.TEX_CHANGED == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ rg -n "sorry|axiom" TNLean/Path/To/File.lean || true
 
 # Blueprint validation. Requires leanblueprint plus the pinned shared
 # plasTeX plugin (blueprint/src/plastex.cfg loads it unconditionally):
-#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.1'
+#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
 # Run after lake build succeeds.
 cd blueprint && leanblueprint checkdecls
 

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -43,6 +43,7 @@
 
 % Verdict marker: \gapnote{<kind>}{<status>}. Kind is the policy
 % classification (clarification, local-correction, scope-restriction,
-% unfaithful, false-source, open-gap); status is open, resolved, or
-% historical. Machine-read by the site index; prints a verdict line.
+% unfaithful, false-source, open-gap); status is open, wip (elimination
+% underway), resolved, or historical. Machine-read by the site index;
+% prints a verdict line.
 \newcommand{\gapnote}[2]{\par\noindent\textbf{Verdict:} #1 (#2).\par}

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -132,10 +132,12 @@ machine-readably with \verb|\gapnote{<kind>}{<status>}| directly after
 \verb|\maketitle|: the kind in the kebab-cased vocabulary above
 (\path{clarification}, \path{local-correction}, \path{scope-restriction},
 \path{unfaithful}, \path{false-source}, \path{open-gap}) and the status
-one of \path{open}, \path{resolved}, or \path{historical}. Severity is
-derived from the kind, so it is never stated separately. A resolved note
-keeps its classification and changes only its status; the published index
-lists open notes first and dims the resolved ones.
+one of \path{open}, \path{wip}, \path{resolved}, or \path{historical};
+\path{wip} marks a gap whose elimination is actively underway and still
+counts as live. Severity is derived from the kind, so it is never stated
+separately. A resolved note keeps its classification and changes only its
+status; the published index lists live notes first and dims the resolved
+ones.
 
 A local correction records a small adjustment whose corrected statement is still
 available in the cited argument. A scope restriction records a theorem proved


### PR DESCRIPTION
Pin bump: the index gains a `wip` status (live debt whose elimination is underway — counted with open, own chip, 'N in progress' in the summary) and the date column now shows each note's last git modification instead of the authored `\date` (which keeps feeding the BibTeX year). Mark a note in-progress by changing its marker to `\gapnote{<kind>}{wip}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4