### PR TITLE
doc(blueprint): cite paper-gap notes as bibliography references

### DIFF
--- a/.github/allowed-tools.json
+++ b/.github/allowed-tools.json
@@ -1,7 +1,7 @@
 {
   "lean-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-review-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),Bash(gh pr *),Bash(gh api *),mcp__github__*",
-  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.2),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
+  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.4),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-linter-warning-auto-fix": "Read,Edit,Glob,Grep,Bash(python3 *),Bash(lake build),Bash(lake build *),Bash(lake env),Bash(lake env *),Bash(git diff *),Bash(git status),Bash(grep *),Bash(rg *)",
   "claude-interactive": "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *),mcp__github__*",
   "blueprint-prose-review": "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(grep *),mcp__github__*",

--- a/.github/prompts/auto-fix-blueprint-prompt.md
+++ b/.github/prompts/auto-fix-blueprint-prompt.md
@@ -15,7 +15,7 @@ Instructions:
 3. The blueprint `.tex` files are in `blueprint/src/chapter/`. The blueprint configuration is in `blueprint/src/`.
 4. You can test your fix locally by running:
 
-   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.2`
+   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.4`
    - `cd blueprint && leanblueprint web`
 
    Check that no `ERROR` lines appear in the output.

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Run mentioned agent
         id: agent

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Check native tenkz sources and picture pipeline
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -776,7 +776,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 
       - name: Lint tenkz picture sources
         if: env.TEX_CHANGED == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ rg -n "sorry|axiom" TNLean/Path/To/File.lean || true
 
 # Blueprint validation. Requires leanblueprint plus the pinned shared
 # plasTeX plugin (blueprint/src/plastex.cfg loads it unconditionally):
-#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.2'
+#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
 # Run after lake build succeeds.
 cd blueprint && leanblueprint checkdecls
 

--- a/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
+++ b/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
@@ -201,7 +201,7 @@ construction is in Section~\ref{sec:app_wielandt_blocking_support}.
     representative family is assumed to have been selected; this statement does
     not reconstruct the full CPSV sector decomposition with repeated copies
     inside one sector. This scope restriction is recorded in
-    \path{docs/paper-gaps/cpsv16_ft_one_copy_scope_restriction.tex}.
+    \cite{gap:cpsv16_ft_one_copy_scope_restriction}.
 \end{corollary}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -879,7 +879,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     zero-weight block contributes nothing to any positive-length matrix product
     vector. Thus the theorem does not claim coverage of every syntactically
     listed block. The comparison is recorded in
-    \path{docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex}.
+    \cite{gap:cpsv16_bnt_characterization_active_blocks}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt_definitions_and_characterization.tex
+++ b/blueprint/src/chapter/ch10_bnt_definitions_and_characterization.tex
@@ -117,7 +117,7 @@
     Removing the zero-weight summands leaves every positive-length MPV
     unchanged and restores the nonzero-weight hypothesis of the source
     phase-class argument. The comparison is recorded in
-    \path{docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex}.
+    \cite{gap:cpsv16_bnt_characterization_active_blocks}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -1429,7 +1429,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     unit-modulus weight imposed immediately before it. The hypothesis above
     is exactly the exclusion of this degenerate case. The normalization issue
     and the proportional-MPV comparison are documented in
-    \path{docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex}.
+    \cite{gap:cpsv16_cf_normalization_and_proportional_comparison}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3019,7 +3019,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     zero excitation projection, the operator-product norm can be smaller. In
     any case this is not the quantity controlled by the cited principal-angle
     estimates. The comparison is documented in
-    \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
+    \cite{gap:cpgsv21_martingale_overlap}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -615,7 +615,7 @@
     $\eta<1$ in that case. It isolates the
     finite-row martingale argument once such a bound is supplied; the gap with the
     cited principal-angle estimates is documented in the paper-gap note
-    \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
+    \cite{gap:cpgsv21_martingale_overlap}.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch15_examples_majumdar_ghosh.tex
+++ b/blueprint/src/chapter/ch15_examples_majumdar_ghosh.tex
@@ -140,7 +140,7 @@ resonating valence-bond state.
     supplying the relative sign. The contracted tensor is the $D = 3$
     representative in Definition~\ref{def:majumdar_ghosh_tensor}. The
     source-notation gap and the missing matrix-product-vector identification are
-    recorded in \path{docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex}.
+    recorded in \cite{gap:rmp_majumdar_ghosh_tensor_gap}.
 \end{remark}
 
 The remaining target for the Majumdar--Ghosh example is the ground-space

--- a/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_sic_povms.tex
@@ -190,7 +190,7 @@ and for the eigenvalues in \cite[Chapter~2, Proposition ``SIC POVMs'',
     assertion printed in \cite[Chapter~2, Proposition ``SIC POVMs'',
         lines~816--823]{Wolf2012Quantum} is false when $d=1<n$: every $P_i$ then
     equals $[1]$. This deviation is recorded in the QICLean paper-gap note
-    \path{https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf}.
+    \cite{gap:wolf_sic_povm_linear_independence}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
@@ -121,7 +121,7 @@
     here instead demands trace separation simultaneously across every block,
     including gauge-equivalent copies, and so excludes decompositions with
     repeated normal tensors. Documented in
-    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    \cite{gap:cpgsv17_bicf_block_separation}.
 \end{lemma}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
@@ -48,7 +48,7 @@
     canonical-form hypotheses. The sharp $3D^5$ representative-separation
     bound is Theorem~\ref{thm:sharp_bnt_block_separation}; its detailed source
     comparison is recorded in
-    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    \cite{gap:cpgsv17_bicf_block_separation}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1683,7 +1683,7 @@ logarithmic divergence, or a comparison with relative entropy.
     The same example as
     Theorem~\ref{thm:parity_mpdo_no_thermodynamic_limit} makes the iterated
     mutual-information limit false; see
-    \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}. The
+    \cite{gap:cpgsv17_mpdo_mutual_information_bound}. The
     channel-image implication is
     Theorem~\ref{thm:local_channel_image_mutual_info_bound}, and the pure-state
     instance is Proposition~\ref{prop:pure_mutual_info_bound} below. The

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -193,7 +193,7 @@
     Thus normalized periodic marginals need not converge under the hypotheses
     of \cite[Proposition~4.5, lines~801--806]{Cirac2016MPDO_arXiv}. The mutual
     information of this same family is computed in
-    \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}.
+    \cite{gap:cpgsv17_mpdo_mutual_information_bound}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -131,7 +131,7 @@
     \textbf{Local fix (blocked coefficient exponent):} CPSV16 Appendix C.4,
     line~2013 prints $m_\gamma^L/n_\gamma$. The line-2008 tensor scaling and
     line~2040 give $(m_\gamma/n_\gamma)^L$. This is documented in
-    \path{docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex}.
+    \cite{gap:cpsv16_blocked_operator_trace_ratio_exponent}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -421,14 +421,14 @@
     \textbf{Scope restriction (active product BNT):} The conclusion gives
     only one-way coverage of active product corners. It does not assert that
     every blocked BNT label occurs. This is documented in
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (per-pair support):} Appendix~C.4, lines~2011--2029 of
     \cite{Cirac2016MPDO_arXiv} compares a sum over all retained copy pairs and
     does not isolate a fixed pair. Here fixed-pair support follows from the
     exact squared reconstruction and the canonical direct-sum corner; a zero
     pair contributes an empty active family. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -609,7 +609,7 @@
     \textbf{Local fix (Figure-11 fixed-pair support):} A copy pair with no
     active corner is represented by an empty family; no unsupported corner is
     inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 \end{definition}
 
 \begin{theorem}[Positive original-label corner decomposition]
@@ -638,7 +638,7 @@
     \textbf{Local fix (Figure-11 fixed-pair support):} Empty active families
     remain empty. Exact weighted reconstruction and positivity of the outer
     copy weight imply that the corresponding raw product vanishes. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -697,16 +697,16 @@
     \textbf{Scope restriction (active product BNT):} Only active product
     corners are retained. A label absent from the distinguished copy pair
     has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} The distinguished copy
     pair may have an empty active family; no unsupported corner is inserted.
-    See \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    See \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
     a coisometry onto the active direct sum. Exact reconstruction includes
     any common zero corner discarded by the forward map. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -739,16 +739,16 @@
     \textbf{Scope restriction (active product BNT):} Only active product
     corners occur. A label absent from a fixed product pair has zero fusion
     multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
     may have no active corner, and no unsupported sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
     a coisometry onto the active direct sum, and its adjoint gives the exact
     reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -794,16 +794,16 @@
     \textbf{Scope restriction (active product BNT):} Only active product
     corners occur. A label absent from a fixed product pair has zero fusion
     multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
     may have no active corner, and no unsupported sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
     a coisometry onto the active direct sum, and its adjoint gives the exact
     reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -853,16 +853,16 @@
     \textbf{Scope restriction (active product BNT):} Only active product
     corners occur. A label absent from a fixed product pair has zero fusion
     multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
     may have no active corner, and no unsupported sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
     a coisometry onto the active direct sum, and its adjoint gives the exact
     reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -954,16 +954,16 @@
     \textbf{Scope restriction (active product BNT):} Only active product
     corners occur. A label absent from a fixed product pair has zero fusion
     multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
     may have no active corner, and no unsupported sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
     a coisometry onto the active direct sum, and its adjoint gives the exact
     reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -295,11 +295,11 @@
     comparison needed to normalize the exact sector gauges is supplied by
     Theorem~\ref{thm:mpdo_bnt_mixed_prefix_unitary_sector_conjugacy}, as
     recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 
     \textbf{Local fix (zero-sector complement):} The physical maps are
     completed on the discarded complements as recorded in
-    \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+    \cite{gap:cpgsv17_vertical_isometry_zero_sector}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -970,7 +970,7 @@
         \notag
     \end{align}
     This restriction is documented in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
     The mixed-prefix comparison below proves the Gram identity without
     constructing a same-sided raw corner for the two-site blocking.
 \end{theorem}
@@ -1051,7 +1051,7 @@
     \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv} is invoked
     in \cite[Appendix~C.4, lines~2048--2057]{Cirac2016MPDO_arXiv}.  It is
     recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1206,7 +1206,7 @@
     (\ref{eq:mpdo_bnt_identity_oblique_opposite}). The mixed-prefix comparison
     below derives the target under the standing canonical-form and positivity
     assumptions. This distinction is recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1275,7 +1275,7 @@
     the star-compatible comparison for the raw representative. The
     mixed-prefix theorem below supplies it under the standing assumptions, as
     recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1336,7 +1336,7 @@
     \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv} is invoked
     in \cite[Appendix~C.4, lines~2048--2057]{Cirac2016MPDO_arXiv}.  The
     distinction from the unsuccessful direct two-site comparison is recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex
@@ -24,7 +24,7 @@
     not an additional hypothesis of the arbitrary-chain source statement.
     This distinction is
     documented in
-    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+    \cite{gap:cpsv16_topological_projector_recursion}.
 \end{definition}
 
 \begin{theorem}[Projection property of the full-support specialization]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -286,7 +286,7 @@ together with the derivation of the same-length product law from them.
     product bond space. The unrestricted source statement permits a common
     zero corner and instead gives a coisometry onto the active direct sum,
     together with exact reconstruction. This distinction is documented in
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{definition}
 
 \begin{definition}[Active-support fusion coisometry family]
@@ -321,7 +321,7 @@ together with the derivation of the same-length product law from them.
     retained-row orientation of Proposition~4.13. Thus its fusion maps are
     coisometries onto the active sectors; exact reconstruction records the
     discarded common zero corner. This convention is documented in
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{definition}
 
 For fixed labels $\alpha,\beta$, put

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -261,16 +261,16 @@
     \textbf{Scope restriction (active product BNT):} For each fixed product
     pair, only its active normal corners occur; an absent label has zero fusion
     multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
     may have an empty active family, so no unsupported normal sector is added.
-    See \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    See \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):} Each fusion map is a
     coisometry onto the active direct sum, and its adjoint reconstructs the
     whole product tensor, including any discarded common zero corner. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -298,7 +298,7 @@
     \textbf{Scope restriction (BNT-refined horizontal form):}
     the normalized BNT-refined horizontal hypothesis is stronger than the
     literal CPSV canonical-form hypothesis.
-    See \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    See \cite{gap:cpgsv17_vertical_cf_grouping}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:vertical_cf_of_horizontal_cf, thm:mpdo_transported_vertical_sector_coefficient_comparison, thm:mpdo_transported_vertical_product_positive_fusion_decomposition, thm:mpdo_paired_vertical_decompositions_fusion}
@@ -393,22 +393,22 @@
     \textbf{Scope restriction (active product BNT):} Only nonzero product
     corners occur in (iii$_{\mathrm{act}}$); a sector absent from a fixed
     product pair has zero fusion multiplicity.  This is recorded in
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (fixed-pair support and coisometry):} A fixed pair may
     have empty active support, and the retained-row fusion map is a
     coisometry.  These points are recorded in
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex} and
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support} and
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Local fix (mixed one-site/two-site prefix):} The implication
     (ii)$\Rightarrow$(i) uses the marked comparison recorded in
-    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    \cite{gap:cpsv16_two_site_sector_unitary_gauge_gap}.
 
     \textbf{Local fix (zero-sector complement):} The physical maps in
     (ii)$\Rightarrow$(i) are completed on the discarded complements as
     recorded in
-    \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+    \cite{gap:cpgsv17_vertical_isometry_zero_sector}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -181,13 +181,13 @@
     $\widetilde U_N$ is $W_N^\dagger$, the adjoint of the retained-row
     coisometry used above. Exact reverse fusion uses the active-support
     reconstruction of Appendix~C.4, lines~2020--2029. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Scope restriction (fixed initial label):} This theorem concerns one
     chosen initial label and list of appended labels. The following theorem
     performs the vertical-canonical assembly over all labels and multiplicity
     coordinates. The commutator remains outside the present result; see
-    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+    \cite{gap:cpsv16_topological_projector_recursion}.
 \end{theorem}
 \begin{proof}\leanok\uses{thm:mpdo_bnt_length_independent_zipper}
     The base case has no appended labels and represents the one-site chain;
@@ -236,7 +236,7 @@
     \textbf{Local fix (terminal trace orientation):} The trace closes the
     horizontal operator leg and leaves the two bond indices of $M_\gamma$
     open. See
-    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+    \cite{gap:cpsv16_topological_projector_recursion}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:mpdo_algebra_clause_terminal_transfer_positivity}
@@ -327,21 +327,21 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the fusion clause. A normal label
     absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Local fix (rectangular vertical map):}
     the reverse equality uses exact retained-sector reconstruction rather
     than a square-unitary identity. See
-    \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+    \cite{gap:cpgsv17_vertical_isometry_zero_sector}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_topological_projector_recursion, lem:mpdo_sitewise_physical_coordinate_congruence}
@@ -386,7 +386,7 @@
     exact reconstruction from the retained nonzero sectors of
     Proposition~4.13 and Appendix~C.4, lines~2020--2029, not a square-unitary
     identity. See
-    \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+    \cite{gap:cpgsv17_vertical_isometry_zero_sector}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor, thm:mpdo_topological_projector_recursion, lem:mpdo_sitewise_physical_coordinate_congruence}
@@ -505,16 +505,16 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the fusion clause. A normal label
     absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{definition}
 
 \begin{definition}[Terminal spectral refinement data]%
@@ -580,16 +580,16 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the fusion clause. A normal label
     absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{theorem}
 \begin{proof}\leanok
     Positivity of the physical density operator makes each terminal bond
@@ -717,12 +717,12 @@
     sectors. Applying the adjoint retained-row map reconstructs the physical
     density operator, but does not provide a Hamiltonian or projectors on the
     original physical space. This restriction is recorded in
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the local interaction is defined on two spins, so these data are indexed
     by $L=N+2$. The length-one boundary is recorded in
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{definition}
 
 \begin{theorem}[Active-sector fusion gives a retained-coordinate commuting
@@ -777,17 +777,17 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the fusion clause. A normal label
     absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family, and no unsupported
     normal sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction of the product tensor. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Scope restriction (retained vertical coordinates):}
     the formula is an equality for $R_L$ on the retained vertical space, not
@@ -795,13 +795,13 @@
     \cite[lines~1013--1016]{Cirac2016MPDO_arXiv}. Exact reconstruction by the
     adjoint retained-row map is weaker than the existence of physical
     projectors and a finite physical Hamiltonian. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$. Definition~4.8 of~
     \cite{Cirac2016MPDO_arXiv} defines $h$ on two spins but does not state a
     length-one convention; see
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:mpdo_fusion_clause_topological_density_decomposition, cor:mpdo_fusion_clause_topological_density_factor_commutator, thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
@@ -844,12 +844,12 @@
     sectors. Applying the adjoint retained-row map reconstructs the physical
     density operator, but does not provide a Hamiltonian or projectors on the
     original physical space. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$; no length-one two-site convention
     is asserted. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{theorem}
 \begin{proof}\leanok
     Select the active-sector fusion clause supplied by the renormalization
@@ -894,29 +894,29 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the fusion clause. A normal label
     absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family, and no unsupported
     normal sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction of the product tensor. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Local fix (physical complement):}
     the retained one-site energy is compressed to physical coordinates and
     extended by zero energy on the orthogonal complement. The retained
     projectors are transported through the adjoint sitewise coisometry. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$. Definition~4.8 of
     \cite{Cirac2016MPDO_arXiv} defines the local interaction on two spins but
     gives no length-one convention. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{theorem}
 \begin{proof}\leanok
     Put $V$ for the retained-row coisometry and $k$ for the retained
@@ -964,12 +964,12 @@
     the retained one-site energy is compressed to physical coordinates and
     extended by zero energy on the orthogonal complement. The retained
     projectors are transported through the adjoint sitewise coisometry. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$; no length-one two-site convention
     is asserted. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{theorem}
 \begin{proof}\leanok
     Select the active-sector fusion clause supplied by the renormalization
@@ -992,17 +992,17 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the selected fusion clause. A normal
     label absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family, and no unsupported
     normal sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction of the product tensor. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 \end{definition}
 
 \begin{theorem}[Literal CPSV physical-coordinate commuting Gibbs decomposition
@@ -1047,29 +1047,29 @@
     \textbf{Scope restriction (active product BNT):}
     only nonzero product corners occur in the selected fusion clause. A normal
     label absent from a fixed product pair has zero fusion multiplicity. See
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    \cite{gap:cpsv16_bnt_uniqueness_zero_coefficient}.
 
     \textbf{Local fix (Figure-11 fixed-pair support):}
     a fixed product pair may have an empty active family, and no unsupported
     normal sector is inserted. See
-    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+    \cite{gap:cpsv16_figure11_per_pair_support}.
 
     \textbf{Local fix (Figure-11 fusion coisometry):}
     the retained-row fusion map is a coisometry onto the active direct sum,
     and its adjoint gives exact reconstruction of the product tensor. See
-    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+    \cite{gap:cpsv16_figure11_fusion_coisometry}.
 
     \textbf{Local fix (physical complement):}
     the retained one-site energy is compressed to physical coordinates and
     extended by zero energy on the orthogonal complement. The retained
     projectors are transported through the adjoint sitewise coisometry. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+    \cite{gap:cpsv16_topological_gibbs_physical_complement}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved exactly for $L=N+2$. Definition~4.8 of~
     \cite{Cirac2016MPDO_arXiv} defines the local interaction on two spins but
     gives no length-one convention. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    \cite{gap:cpsv16_topological_gibbs_length_one}.
 \end{theorem}
 \begin{proof}\leanok
     Choose the active-sector fusion clause supplied by

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -315,7 +315,7 @@
     lines~1719--1732 of the same appendix.
     The closing entry $R_s(\beta_3,\alpha_1)$ is the corrected tail-index
     orientation of the display at lines~1422--1438, recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    \cite{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_coherent_positive_rephasing.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_coherent_positive_rephasing.tex
@@ -540,7 +540,7 @@
     \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}. Its derivation
     for the zero-weight reparameterized inverse-map factorization is treated in
     Theorem~\ref{thm:mpdo_eta_coherent_positive_choice} and recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    \cite{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure}.
 \end{theorem}
 % The recurrence gap is documented in
 % docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -174,7 +174,7 @@ strong subadditivity for a normalized three-site reduced state.
 
     The closing entry ${(R_s)}_{\beta_3,\alpha_1}$ is the corrected tail-index
     orientation of the display at lines~1422--1438, recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    \cite{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -207,7 +207,7 @@ strong subadditivity for a normalized three-site reduced state.
 
     The nonzero closing entry uses the corrected orientation
     ${(R_s)}_{\beta_3,\alpha_1}$ recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    \cite{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -345,7 +345,7 @@ strong subadditivity for a normalized three-site reduced state.
     The endpoint corrects the strict inequality printed at source line~1771:
     Definition~4.6 and the concluding comparison both require
     $m=\lfloor N/2\rfloor$. This local correction is recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    \cite{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure}.
 \end{theorem}
 
 \begin{proof}
@@ -945,7 +945,7 @@ strong subadditivity for a normalized three-site reduced state.
     normalized state at every physical chain length. This is the biCF
     hypothesis imposed at the start of Case II in the source; its relation
     with finite physical blocking is recorded in
-    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    \cite{gap:cpgsv17_bicf_block_separation}.
     This supplies the strict form of the sector normalization used in
     \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -1006,7 +1006,7 @@ strong subadditivity for a normalized three-site reduced state.
     hypothesis imposed at the start of Case II in
     \cite[line~1628]{Cirac2016MPDO_arXiv}. Its relation with finite physical
     blocking is recorded in
-    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}. The entropy
+    \cite{gap:cpgsv17_bicf_block_separation}. The entropy
     conclusion is the argument of
     \cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv}.
 \end{theorem}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -280,7 +280,7 @@
     the phrase ``basis of periodic vectors''. The theorem recorded here
     proves independence only along the common-multiple subsequence $pN$ and
     omits the spanning assertion. The corresponding paper-gap
-    note, \path{docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex},
+    note, \cite{gap:dccsp17_periodic_overlap_route_alignment},
     Section ``Scope restriction: independence without spanning'', records
     this restriction and its elimination plan.
 \end{theorem}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -10,7 +10,7 @@ all sites share one physical dimension $d$ and all bonds one bond
 dimension $D$; the source poses no restriction on the local dimensions of
 the site-dependent tensors, and the uniform-dimension restriction is
 recorded in the route note
-(\path{docs/paper-gaps/peps_normal_ft_section3_route.tex}).
+(\cite{gap:peps_normal_ft_section3_route}).
 
 \begin{definition}[Arc products and window injectivity of a site-dependent
         chain]%

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_rectangular_injectivity.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_rectangular_injectivity.tex
@@ -280,7 +280,7 @@
     interior. The fixed origin window has its corner forced and so has no
     rectangular cover; the source object is the full-lattice complement $A_3$,
     which has room only at an interior edge. The source comparison is recorded
-    in \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+    in \cite{gap:peps_normal_ft_section3_route}.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
@@ -309,7 +309,7 @@
     only at edges with interior margins. Edges near the lattice boundary of the
     open rectangular model lack such margins; on a translation-invariant lattice
     every edge is interior. The source comparison is recorded in
-    \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+    \cite{gap:peps_normal_ft_section3_route}.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -772,7 +772,7 @@
     in Theorem~3.11, whereas the reference tensor at line~1300 has coefficients
     $\sqrt{(\rho_j)_{\alpha,\alpha}}$, which forces the factor $\sqrt{\rho_j}$
     used above. This repair is documented in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    \cite{gap:cpsv16_rfp_isometry_scope}.
 \end{theorem}
 
 % CPSV16 Corollary 3.12 (`III_cor3`), lines 583--590.
@@ -829,7 +829,7 @@
     coefficients $\sqrt{(\rho_j)_{\alpha,\alpha}}$, which forces the factor
     $\sqrt{\rho_j}$ used above. The source defect and the corrected active
     statement are documented in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    \cite{gap:cpsv16_rfp_isometry_scope}.
 \end{corollary}
 
 \begin{theorem}[Ambiguity of the literal repeated-phase display]%

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -355,7 +355,7 @@ ambient bond space.
     coefficients $\sqrt{\Lambda_\alpha}$. These equations force the repaired
     form $A^i=X\sqrt{\rho}\,U^iX^{-1}$ used in this definition. The correction
     is documented in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    \cite{gap:cpsv16_rfp_isometry_scope}.
 
     Explicitly, the reference tensor is
     \begin{align}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -124,7 +124,7 @@
     $\E_A^n=\E_A$, which follows from idempotence only for $n\geq1$. Adjacent
     regions insert $\E_A^0=\Id$ and are included in the source definition. This
     gap is recorded in
-    \path{docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex}.
+    \cite{gap:cpsv16_pure_zcl_adjacent_gap_cid_scope}.
     Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp} proves the repaired
     forward implication when both complementary gaps are positive. It does not
     prove the unrestricted biconditional in
@@ -166,7 +166,7 @@
 
     \textbf{Source gap (adjacent regions).} The obstruction and its scope are
     recorded in
-    \path{docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex}.
+    \cite{gap:cpsv16_pure_zcl_adjacent_gap_cid_scope}.
     Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp} repairs only the
     forward correlation statement when both complementary gaps are positive;
     it does not establish the printed unrestricted three-way equivalence. That

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -637,3 +637,239 @@
   archiveprefix = {arXiv},
   note         = {Preprint, arXiv:1704.06507},
 }
+
+% -------------------------------------------------------------------------
+%  Paper-gap notes (cite as \cite{gap:<slug>}; the url field carries the
+%  published PDF of the note, on this repository's site for local notes and
+%  on the owning repository's site for cross-repository citations).
+% -------------------------------------------------------------------------
+
+@techreport{gap:cpgsv17_bicf_block_separation,
+  author      = {The {TNLean} contributors},
+  title       = {Sharp Finite-Length Block Separation for Canonical-Form Tensors},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv17\_bicf\_block\_separation},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_bicf_block_separation.pdf},
+}
+
+@techreport{gap:cpgsv17_mpdo_mutual_information_bound,
+  author      = {The {TNLean} contributors},
+  title       = {The Mutual-Information Bound for Matrix Product Density Operators},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv17\_mpdo\_mutual\_information\_bound},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf},
+}
+
+@techreport{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure,
+  author      = {The {TNLean} contributors},
+  title       = {The SAL to Eta-Local Structure Step in Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv17\_mpdo\_sal\_zcl\_eta\_local\_structure},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.pdf},
+}
+
+@techreport{gap:cpgsv17_vertical_cf_grouping,
+  author      = {The {TNLean} contributors},
+  title       = {Vertical Canonical-Form Grouping in Proposition 4.13},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv17\_vertical\_cf\_grouping},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_cf_grouping.pdf},
+}
+
+@techreport{gap:cpgsv17_vertical_isometry_zero_sector,
+  author      = {The {TNLean} contributors},
+  title       = {The Vertical Canonical Form Retains Only the Nonzero Physical Sectors},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv17\_vertical\_isometry\_zero\_sector},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_isometry_zero_sector.pdf},
+}
+
+@techreport{gap:cpgsv21_martingale_overlap,
+  author      = {The {TNLean} contributors},
+  title       = {The Martingale Principal-Angle Estimate for MPS Parent Hamiltonians},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpgsv21\_martingale\_overlap},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf},
+}
+
+@techreport{gap:cpsv16_blocked_operator_trace_ratio_exponent,
+  author      = {The {TNLean} contributors},
+  title       = {The Trace-Ratio Exponent in the Blocked Vertical-Operator Formula},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_blocked\_operator\_trace\_ratio\_exponent},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.pdf},
+}
+
+@techreport{gap:cpsv16_bnt_characterization_active_blocks,
+  author      = {The {TNLean} contributors},
+  title       = {Active Canonical-Form Blocks in the BNT Characterization},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_bnt\_characterization\_active\_blocks},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_characterization_active_blocks.pdf},
+}
+
+@techreport{gap:cpsv16_bnt_uniqueness_zero_coefficient,
+  author      = {The {TNLean} contributors},
+  title       = {BNT Uniqueness and Zero Coefficients in CPSV16},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_bnt\_uniqueness\_zero\_coefficient},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.pdf},
+}
+
+@techreport{gap:cpsv16_cf_normalization_and_proportional_comparison,
+  author      = {The {TNLean} contributors},
+  title       = {Canonical-Form Weight Normalization and the Proportional MPV Comparison},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_cf\_normalization\_and\_proportional\_comparison},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.pdf},
+}
+
+@techreport{gap:cpsv16_figure11_fusion_coisometry,
+  author      = {The {TNLean} contributors},
+  title       = {The Figure 11 Fusion Map Is a Coisometry onto the Active Sectors},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_figure11\_fusion\_coisometry},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_fusion_coisometry.pdf},
+}
+
+@techreport{gap:cpsv16_figure11_per_pair_support,
+  author      = {The {TNLean} contributors},
+  title       = {Per-Pair Support in the CPSV16 Figure 11 Decomposition},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_figure11\_per\_pair\_support},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_per_pair_support.pdf},
+}
+
+@techreport{gap:cpsv16_ft_one_copy_scope_restriction,
+  author      = {The {TNLean} contributors},
+  title       = {Basis-of-Representatives Scope Restriction in the Fundamental Theorem Formalization},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_ft\_one\_copy\_scope\_restriction},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ft_one_copy_scope_restriction.pdf},
+}
+
+@techreport{gap:cpsv16_pure_zcl_adjacent_gap_cid_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Adjacent regions obstruct the unrestricted CID forward implication in Cirac--Perez-Garcia--Schuch--Verstraete 2017},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_pure\_zcl\_adjacent\_gap\_cid\_scope},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.pdf},
+}
+
+@techreport{gap:cpsv16_rfp_isometry_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Per-block RFP Isometry Form and the Source Isometry Condition in CPSV16},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_rfp\_isometry\_scope},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_rfp_isometry_scope.pdf},
+}
+
+@techreport{gap:cpsv16_topological_gibbs_length_one,
+  author      = {The {TNLean} contributors},
+  title       = {The Domain Boundary of the Topological Gibbs Decomposition},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_topological\_gibbs\_length\_one},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_length_one.pdf},
+}
+
+@techreport{gap:cpsv16_topological_gibbs_physical_complement,
+  author      = {The {TNLean} contributors},
+  title       = {The Physical Complement in the Topological Gibbs Decomposition},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_topological\_gibbs\_physical\_complement},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_physical_complement.pdf},
+}
+
+@techreport{gap:cpsv16_topological_projector_recursion,
+  author      = {The {TNLean} contributors},
+  title       = {The Arbitrary-Chain Topological Projector Recursion},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_topological\_projector\_recursion},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_projector_recursion.pdf},
+}
+
+@techreport{gap:cpsv16_two_site_sector_unitary_gauge_gap,
+  author      = {The {TNLean} contributors},
+  title       = {A Mixed-Prefix Repair of the Two-Site Sector Comparison},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {cpsv16\_two\_site\_sector\_unitary\_gauge\_gap},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.pdf},
+}
+
+@techreport{gap:dccsp17_periodic_overlap_route_alignment,
+  author      = {The {TNLean} contributors},
+  title       = {Proof-Route Alignment for the Periodic Overlap Dichotomy (de las Cuevas--Cirac--Schuch--Pérez-García)},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {dccsp17\_periodic\_overlap\_route\_alignment},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf},
+}
+
+@techreport{gap:peps_normal_ft_section3_route,
+  author      = {The {TNLean} contributors},
+  title       = {Normal PEPS Fundamental Theorem: Section 3 Route},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {peps\_normal\_ft\_section3\_route},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/peps_normal_ft_section3_route.pdf},
+}
+
+@techreport{gap:rmp_majumdar_ghosh_tensor_gap,
+  author      = {The {TNLean} contributors},
+  title       = {Source-Notation Gap: The Majumdar--Ghosh Example Tensor},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {rmp\_majumdar\_ghosh\_tensor\_gap},
+  year        = {2026},
+  url         = {https://sirui-lu.com/TNLean/paper-gaps/rmp_majumdar_ghosh_tensor_gap.pdf},
+}
+
+@techreport{gap:wolf_sic_povm_linear_independence,
+  author      = {The {QICLean} contributors},
+  title       = {SIC--POVM Equality Families: the One-Dimensional Degeneracy},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_sic\_povm\_linear\_independence},
+  year        = {2026},
+  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf},
+}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -639,9 +639,11 @@
 }
 
 % -------------------------------------------------------------------------
-%  Paper-gap notes (cite as \cite{gap:<slug>}; the url field carries the
-%  published PDF of the note, on this repository's site for local notes and
-%  on the owning repository's site for cross-repository citations).
+%  Paper-gap notes (cite as \cite{gap:<slug>}; the note field carries the
+%  published PDF of the note as a \url link, because the alpha bibliography
+%  style omits the url field for techreport entries in the PDF build. The
+%  link points to this repository's site for local notes and to the owning
+%  repository's site for cross-repository citations).
 % -------------------------------------------------------------------------
 
 @techreport{gap:cpgsv17_bicf_block_separation,
@@ -651,7 +653,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv17\_bicf\_block\_separation},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_bicf_block_separation.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_bicf_block_separation.pdf}},
 }
 
 @techreport{gap:cpgsv17_mpdo_mutual_information_bound,
@@ -661,7 +663,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv17\_mpdo\_mutual\_information\_bound},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf}},
 }
 
 @techreport{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure,
@@ -671,7 +673,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv17\_mpdo\_sal\_zcl\_eta\_local\_structure},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.pdf}},
 }
 
 @techreport{gap:cpgsv17_vertical_cf_grouping,
@@ -681,7 +683,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv17\_vertical\_cf\_grouping},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_cf_grouping.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_cf_grouping.pdf}},
 }
 
 @techreport{gap:cpgsv17_vertical_isometry_zero_sector,
@@ -691,7 +693,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv17\_vertical\_isometry\_zero\_sector},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_isometry_zero_sector.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv17_vertical_isometry_zero_sector.pdf}},
 }
 
 @techreport{gap:cpgsv21_martingale_overlap,
@@ -701,7 +703,7 @@
   type        = {Paper-gap note},
   number      = {cpgsv21\_martingale\_overlap},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpgsv21_martingale_overlap.pdf}},
 }
 
 @techreport{gap:cpsv16_blocked_operator_trace_ratio_exponent,
@@ -711,7 +713,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_blocked\_operator\_trace\_ratio\_exponent},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.pdf}},
 }
 
 @techreport{gap:cpsv16_bnt_characterization_active_blocks,
@@ -721,7 +723,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_bnt\_characterization\_active\_blocks},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_characterization_active_blocks.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_characterization_active_blocks.pdf}},
 }
 
 @techreport{gap:cpsv16_bnt_uniqueness_zero_coefficient,
@@ -731,7 +733,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_bnt\_uniqueness\_zero\_coefficient},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.pdf}},
 }
 
 @techreport{gap:cpsv16_cf_normalization_and_proportional_comparison,
@@ -741,7 +743,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_cf\_normalization\_and\_proportional\_comparison},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.pdf}},
 }
 
 @techreport{gap:cpsv16_figure11_fusion_coisometry,
@@ -751,7 +753,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_figure11\_fusion\_coisometry},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_fusion_coisometry.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_fusion_coisometry.pdf}},
 }
 
 @techreport{gap:cpsv16_figure11_per_pair_support,
@@ -761,7 +763,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_figure11\_per\_pair\_support},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_per_pair_support.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_figure11_per_pair_support.pdf}},
 }
 
 @techreport{gap:cpsv16_ft_one_copy_scope_restriction,
@@ -771,7 +773,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_ft\_one\_copy\_scope\_restriction},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ft_one_copy_scope_restriction.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_ft_one_copy_scope_restriction.pdf}},
 }
 
 @techreport{gap:cpsv16_pure_zcl_adjacent_gap_cid_scope,
@@ -781,7 +783,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_pure\_zcl\_adjacent\_gap\_cid\_scope},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.pdf}},
 }
 
 @techreport{gap:cpsv16_rfp_isometry_scope,
@@ -791,7 +793,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_rfp\_isometry\_scope},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_rfp_isometry_scope.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_rfp_isometry_scope.pdf}},
 }
 
 @techreport{gap:cpsv16_topological_gibbs_length_one,
@@ -801,7 +803,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_topological\_gibbs\_length\_one},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_length_one.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_length_one.pdf}},
 }
 
 @techreport{gap:cpsv16_topological_gibbs_physical_complement,
@@ -811,7 +813,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_topological\_gibbs\_physical\_complement},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_physical_complement.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_gibbs_physical_complement.pdf}},
 }
 
 @techreport{gap:cpsv16_topological_projector_recursion,
@@ -821,7 +823,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_topological\_projector\_recursion},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_projector_recursion.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_topological_projector_recursion.pdf}},
 }
 
 @techreport{gap:cpsv16_two_site_sector_unitary_gauge_gap,
@@ -831,7 +833,7 @@
   type        = {Paper-gap note},
   number      = {cpsv16\_two\_site\_sector\_unitary\_gauge\_gap},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.pdf}},
 }
 
 @techreport{gap:dccsp17_periodic_overlap_route_alignment,
@@ -841,7 +843,7 @@
   type        = {Paper-gap note},
   number      = {dccsp17\_periodic\_overlap\_route\_alignment},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf}},
 }
 
 @techreport{gap:peps_normal_ft_section3_route,
@@ -851,7 +853,7 @@
   type        = {Paper-gap note},
   number      = {peps\_normal\_ft\_section3\_route},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/peps_normal_ft_section3_route.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/peps_normal_ft_section3_route.pdf}},
 }
 
 @techreport{gap:rmp_majumdar_ghosh_tensor_gap,
@@ -861,7 +863,7 @@
   type        = {Paper-gap note},
   number      = {rmp\_majumdar\_ghosh\_tensor\_gap},
   year        = {2026},
-  url         = {https://sirui-lu.com/TNLean/paper-gaps/rmp_majumdar_ghosh_tensor_gap.pdf},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/rmp_majumdar_ghosh_tensor_gap.pdf}},
 }
 
 @techreport{gap:wolf_sic_povm_linear_independence,
@@ -871,5 +873,5 @@
   type        = {Paper-gap note},
   number      = {wolf\_sic\_povm\_linear\_independence},
   year        = {2026},
-  url         = {https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf}},
 }

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -121,6 +121,12 @@ A file name is permanent once other documents cite it; version suffixes are
 not used, since a note is revised in place (see Revision below) and its
 history is preserved by the repository.
 
+Blueprint prose cites a note like any other source, with
+\verb|\cite{gap:<slug>}|; the bibliography entry carries the published URL
+of the note, whether the note lives in this repository or in another one.
+Lean docstrings and comments use the repository path form
+\path{docs/paper-gaps/<slug>.tex}.
+
 \section{Classification}
 
 The conclusion of a note should give a verdict. The usual classifications are:


### PR DESCRIPTION
Blueprint prose now cites a paper-gap note like any other source, with `\cite{gap:<slug>}` (natbib); the bibliography entry carries the published URL of the note. The URL lives only in the bibliography, never in prose.

- Converts all 104 repository-path prose citations (`\path{docs/paper-gaps/<slug>.tex}`) across 27 chapter files to `\cite{gap:<slug>}`.
- Converts the absolute-URL prose citation of the QICLean SIC-POVM note in `ch16_channel_representations_sic_povms.tex` (thm:sic_povm_equality_linear_independent) to the same cite form; its bibliography entry points at the QICLean site.
- Adds 23 `@techreport{gap:<slug>, ...}` entries to `blueprint/src/references.bib` (22 local TNLean notes, 1 QICLean note), copied from the generated `paper-gaps.bib`; `web.bbl` regenerated via `scripts/blueprint_bibtex.py`.
- Traceability references inside `%` comments keep the repository path form (2 commented `\path` occurrences and the bare-path comment mentions are untouched).
- Records the convention in `docs/paper-gaps/policy.tex` (Naming section): prose cites `\cite{gap:<slug>}`; Lean docstrings and comments keep `docs/paper-gaps/<slug>.tex`.
- Bumps every texra-blueprint pin v0.3.2 -> v0.3.4 (workflows, allowed-tools.json, prompts, CLAUDE.md).

Verified locally: `texra-blueprint --root . paper-gaps check` passes (95 referenced slugs resolve); `leanblueprint web` exits 0 with no errors, the converted citations render as bibliography references (anchor `sect0002.html#gap:<slug>`), and the bibliography entries link the published PDFs.

Fixes #6910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4