### PR TITLE
ci: add the QICLean build directory to the shared cache paths

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -194,6 +194,7 @@ env:
     .lake/build
     .lake/packages/Gametheory/.lake/build
     .lake/packages/checkdecls/.lake/build
+    .lake/packages/qiclean/.lake/build
 
 jobs:
   # Per-job change gating. Push and dispatch runs skip this and run


### PR DESCRIPTION
Adds `.lake/packages/qiclean/.lake/build` to `BUILD_CACHE_PATHS` in pr-ci.yml (the only workflow defining it). QICLean compiles as a prerequisite of every `lake build` since the extraction (#6865) but was never cached, so cache-restored runs recompiled the whole library.

Closes #6871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4