### PR TITLE
doc(blueprint): fix paper-gap bibliography labels and title casing

### DIFF
--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -668,7 +668,7 @@
 
 @techreport{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure,
   author      = {The {TNLean} contributors},
-  title       = {The SAL to Eta-Local Structure Step in Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2},
+  title       = {The {SAL} to Eta-Local Structure Step in {Cirac}--{Perez-Garcia}--{Schuch}--{Verstraete} 2017 Appendix {C}.2},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpgsv17\_mpdo\_sal\_zcl\_eta\_local\_structure},
@@ -698,7 +698,7 @@
 
 @techreport{gap:cpgsv21_martingale_overlap,
   author      = {The {TNLean} contributors},
-  title       = {The Martingale Principal-Angle Estimate for MPS Parent Hamiltonians},
+  title       = {The Martingale Principal-Angle Estimate for {MPS} Parent {Hamiltonians}},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpgsv21\_martingale\_overlap},
@@ -718,7 +718,7 @@
 
 @techreport{gap:cpsv16_bnt_characterization_active_blocks,
   author      = {The {TNLean} contributors},
-  title       = {Active Canonical-Form Blocks in the BNT Characterization},
+  title       = {Active Canonical-Form Blocks in the {BNT} Characterization},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_bnt\_characterization\_active\_blocks},
@@ -728,7 +728,7 @@
 
 @techreport{gap:cpsv16_bnt_uniqueness_zero_coefficient,
   author      = {The {TNLean} contributors},
-  title       = {BNT Uniqueness and Zero Coefficients in CPSV16},
+  title       = {{BNT} Uniqueness and Zero Coefficients in {CPSV16}},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_bnt\_uniqueness\_zero\_coefficient},
@@ -738,7 +738,7 @@
 
 @techreport{gap:cpsv16_cf_normalization_and_proportional_comparison,
   author      = {The {TNLean} contributors},
-  title       = {Canonical-Form Weight Normalization and the Proportional MPV Comparison},
+  title       = {Canonical-Form Weight Normalization and the Proportional {MPV} Comparison},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_cf\_normalization\_and\_proportional\_comparison},
@@ -758,7 +758,7 @@
 
 @techreport{gap:cpsv16_figure11_per_pair_support,
   author      = {The {TNLean} contributors},
-  title       = {Per-Pair Support in the CPSV16 Figure 11 Decomposition},
+  title       = {Per-Pair Support in the {CPSV16} Figure 11 Decomposition},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_figure11\_per\_pair\_support},
@@ -778,7 +778,7 @@
 
 @techreport{gap:cpsv16_pure_zcl_adjacent_gap_cid_scope,
   author      = {The {TNLean} contributors},
-  title       = {Adjacent regions obstruct the unrestricted CID forward implication in Cirac--Perez-Garcia--Schuch--Verstraete 2017},
+  title       = {Adjacent regions obstruct the unrestricted {CID} forward implication in {Cirac}--{Perez-Garcia}--{Schuch}--{Verstraete} 2017},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_pure\_zcl\_adjacent\_gap\_cid\_scope},
@@ -788,7 +788,7 @@
 
 @techreport{gap:cpsv16_rfp_isometry_scope,
   author      = {The {TNLean} contributors},
-  title       = {Per-block RFP Isometry Form and the Source Isometry Condition in CPSV16},
+  title       = {Per-block {RFP} Isometry Form and the Source Isometry Condition in {CPSV16}},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_rfp\_isometry\_scope},
@@ -798,7 +798,7 @@
 
 @techreport{gap:cpsv16_topological_gibbs_length_one,
   author      = {The {TNLean} contributors},
-  title       = {The Domain Boundary of the Topological Gibbs Decomposition},
+  title       = {The Domain Boundary of the Topological {Gibbs} Decomposition},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_topological\_gibbs\_length\_one},
@@ -808,7 +808,7 @@
 
 @techreport{gap:cpsv16_topological_gibbs_physical_complement,
   author      = {The {TNLean} contributors},
-  title       = {The Physical Complement in the Topological Gibbs Decomposition},
+  title       = {The Physical Complement in the Topological {Gibbs} Decomposition},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {cpsv16\_topological\_gibbs\_physical\_complement},
@@ -838,7 +838,7 @@
 
 @techreport{gap:dccsp17_periodic_overlap_route_alignment,
   author      = {The {TNLean} contributors},
-  title       = {Proof-Route Alignment for the Periodic Overlap Dichotomy (de las Cuevas--Cirac--Schuch--Pérez-García)},
+  title       = {Proof-Route Alignment for the Periodic Overlap Dichotomy ({de las Cuevas}--{Cirac}--{Schuch}--{P\'erez-Garc\'ia})},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {dccsp17\_periodic\_overlap\_route\_alignment},
@@ -848,7 +848,7 @@
 
 @techreport{gap:peps_normal_ft_section3_route,
   author      = {The {TNLean} contributors},
-  title       = {Normal PEPS Fundamental Theorem: Section 3 Route},
+  title       = {Normal {PEPS} Fundamental Theorem: Section 3 Route},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {peps\_normal\_ft\_section3\_route},
@@ -858,7 +858,7 @@
 
 @techreport{gap:rmp_majumdar_ghosh_tensor_gap,
   author      = {The {TNLean} contributors},
-  title       = {Source-Notation Gap: The Majumdar--Ghosh Example Tensor},
+  title       = {Source-Notation Gap: The {Majumdar}--{Ghosh} Example Tensor},
   institution = {TNLean},
   type        = {Paper-gap note},
   number      = {rmp\_majumdar\_ghosh\_tensor\_gap},
@@ -868,7 +868,7 @@
 
 @techreport{gap:wolf_sic_povm_linear_independence,
   author      = {The {QICLean} contributors},
-  title       = {SIC--POVM Equality Families: the One-Dimensional Degeneracy},
+  title       = {{SIC}--{POVM} Equality Families: the One-Dimensional Degeneracy},
   institution = {QICLean},
   type        = {Paper-gap note},
   number      = {wolf\_sic\_povm\_linear\_independence},

--- a/scripts/blueprint_bibtex.py
+++ b/scripts/blueprint_bibtex.py
@@ -42,7 +42,19 @@ def bibtex_alpha_abbrev(parts: list[str]) -> str:
 
 
 class BibTeXAlphaLabelStyle(AlphaLabelStyle):
-    """Alpha labels with BibTeX-like initials for TeX-accented surnames."""
+    """Alpha labels with BibTeX-like initials for TeX-accented surnames.
+
+    Paper-gap notes (``type = {Paper-gap note}``) are labelled by their entry-key
+    slug instead of the author/year alpha label: every such note shares the same
+    contributor author and year, so alpha labels degenerate into indistinct
+    ``con26a``/``con26b``-style suffixes that identify nothing.
+    """
+
+    def format_label(self, entry):
+        if entry.fields.get("type") == "Paper-gap note":
+            slug = entry.key.split(":", 1)[-1]
+            return slug.replace("_", r"\_")
+        return super().format_label(entry)
 
     def format_lab_names(self, persons):
         numnames = len(persons)


### PR DESCRIPTION
Closes #6913. Closes #6914.

## Summary

Fixes the two bibliography defects in the 23 `@techreport{gap:<slug>, ...}` entries added by #6911 (as amended by c3d9975). The identical fix is applied to QICLean in LionSR/QICLean#63 so the two repositories stay in sync.

### Title casing (#6913)

Both consumers of `blueprint/src/references.bib` — real BibTeX with `\bibliographystyle{alpha}` (`print.tex`) and pybtex's alpha style (`scripts/blueprint_bibtex.py` for the web build) — sentence-case titles, so unprotected acronyms and proper nouns were lower-cased on render ("sal", "bnt", "cpsv16", "cirac–perez-garcia–schuch–verstraete", "majumdar–ghosh", "gibbs", …). Each acronym/proper noun is now wrapped in its own `{}` group, matching the file's pre-existing convention (`{SAL}`, `{MPS}`, `{BNT}`, `{CPSV16}`, `{MPV}`, `{CID}`, `{RFP}`, `{PEPS}`, `{SIC}`, `{POVM}`, `{Gibbs}`, `{Hamiltonians}`, the CPGSV/DCCSP author names, `Appendix {C}.2`). The one accented name is written with TeX accents (`{P\'erez-Garc\'ia}`) per the file's convention.

### Citation labels (#6914)

All 22 local gap entries share `author = {The {TNLean} contributors}` and `year = {2026}`, so the alpha label degenerates to the same base (`con26`, from the last name "contributors") for every note; both render paths then fall back to opaque `con26a`/`con26b`… suffixes — and the suffix assignment differs between the web and PDF builds, so the same visible label named different notes in the two outputs. Following the option recommended in #6914, the pybtex label style in `scripts/blueprint_bibtex.py` now labels `type = {Paper-gap note}` entries by their entry-key slug, e.g. `[cpsv16_rfp_isometry_scope]` — distinct, stable, self-identifying, and matching the note's report number.

A per-entry `key` field was investigated first and ruled out by direct test: `alpha.bst` consults `key` only when `author` is absent (with author present the label was unchanged), and even without an author it uses only the first three characters of the key (`[cps26]`), which cannot disambiguate these entries — while also dropping the author from the rendered entry. No pure-`.bib` mechanism overrides alpha labels while keeping the author field, and vendoring a modified `alpha.bst` was judged too invasive. The PDF build therefore keeps real BibTeX's native suffix disambiguation (verified distinct, `con26a`…), where each rendered entry's report number still carries the slug; the web blueprint — the primary deliverable — gets the informative slug labels.

## Verification

- `python3 scripts/blueprint_bibtex.py` regenerates `web.bbl` (gitignored, not committed): all 23 gap entries get distinct slug labels; non-gap entries are unaffected.
- `leanblueprint web` (miniforge environment with the texra_blueprint plugin): the rendered bibliography shows 22 distinct slug-labelled gap items with case-preserved titles ("The SAL to eta-local structure step in Cirac–Perez-Garcia–Schuch–Verstraete 2017 appendix C.2", "Source-notation gap: the Majumdar–Ghosh example tensor", "SIC–POVM equality families", …), and every inline `\cite{gap:...}` renders with its slug label; no `con26*` label remains anywhere in the generated site.
- Standalone `pdflatex`+`bibtex` (alpha style, as in `print.tex`) on a scratch document citing six gap entries: labels `con26a`–`con26f` are distinct and the titles render with case preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4