### PR TITLE
doc(paper-gaps): codify QICLean ownership of the Wolf 6.6 scope note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,15 @@ a source theorem. The note must identify the missing hypothesis and the
 elimination plan (formalize the source-faithful version, derive the
 stricter version inside a particular argument, etc.).
 
+When the formalization of the source theorem lives in the QICLean
+companion library, the required note lives in QICLean's `docs/paper-gaps/`
+collection instead of this repository's (the Wolf notes were consolidated
+there by #6906). TNLean must still reference the note wherever the
+restriction is load-bearing: blueprint prose cites `\cite{gap:<slug>}`
+with a bibliography entry carrying the published URL; docstrings and
+`docs/` files cite the published URL directly. A local copy of a
+QICLean-owned note must not be reintroduced.
+
 This rule was retroactively codified after the equalMPS audit
 (`docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`) found that the
 proportionality-conditional Lean theorem was being treated as the

--- a/blueprint/src/chapter/ch07_spectral_peripheral_refinements_and_primitive_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_peripheral_refinements_and_primitive_overlap.tex
@@ -3,11 +3,10 @@
 Every result in this section concerning peripheral eigenvalues, cyclic
 projections, or peripheral eigenspaces is stated for a finite Kraus map and
 therefore assumes complete positivity. These results do not supply the abstract
-Schwarz-map case of Wolf Theorem~6.6.
+Schwarz-map case of Wolf Theorem~6.6; the restriction and its elimination plan
+are documented in the scope-restriction note
+\cite{gap:wolf_thm6_6_kraus_scope}.
 
-% Scope restriction (complete positivity): finite-Kraus specialization. See
-% https://sirui-lu.com/QICLean/paper-gaps/wolf_thm6_6_kraus_scope.pdf
-% (QICLean paper-gap note).
 \begin{theorem}[Transfer-map peripheral eigenvalues: cyclic structure]
     \label{thm:transfer_peripheral_cyclic_structure}
     \lean{PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -875,3 +875,13 @@
   year        = {2026},
   note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_sic_povm_linear_independence.pdf}},
 }
+
+@techreport{gap:wolf_thm6_6_kraus_scope,
+  author      = {The {QICLean} contributors},
+  title       = {Complete-Positivity Scope of the Peripheral Cyclicity Theorem},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {wolf\_thm6\_6\_kraus\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/wolf_thm6_6_kraus_scope.pdf}},
+}


### PR DESCRIPTION
## Summary

Resolves the Wolf Theorem 6.6 restoration question via option (b) of the issue, consistent with the post-migration ownership rule that all `wolf_*` paper-gap notes live in QICLean.

**The note is already restored.** `docs/paper-gaps/wolf_thm6_6_kraus_scope.tex` was carried into QICLean verbatim (only the Lean file path updated) by QICLean#60, still marked `\gapnote{scope-restriction}{open}`, with its `wolf` source key registered, referenced from QICLean's own blueprint, and published at https://sirui-lu.com/QICLean/paper-gaps/wolf_thm6_6_kraus_scope.pdf (verified: `texra-blueprint paper-gaps check` and `paper-gaps build` both exit 0 on QICLean main; the URL serves the PDF). Reintroducing a local TNLean copy would fork the note, so this PR instead:

- **CLAUDE.md/AGENTS.md**: records the companion-library carve-out under the paper-gap requirement (AGENTS.md:199-203) — when the formalization of a source theorem lives in QICLean, the required note lives in QICLean's `docs/paper-gaps/`, and TNLean references it via a `gap:<slug>` bibliography entry (blueprint prose) or the published URL (docstrings, `docs/`), never a local copy.
- **blueprint/src/references.bib**: adds the cross-repository `gap:wolf_thm6_6_kraus_scope` entry, following the existing QICLean-hosted `gap:wolf_sic_povm_linear_independence` pattern.
- **ch07 blueprint**: promotes the `%`-comment URL pointer (the unaddressed chatgpt-codex-connector flag on #6906) into a visible `\cite{gap:wolf_thm6_6_kraus_scope}` in the section prose that states the finite-Kraus/complete-positivity restriction.

`texra-blueprint paper-gaps check` passes in this branch (95 referenced slugs resolve, exit 0).

## Audit of the other #6906 pointers

Of the remaining five `%`-comment pointers (all in ch27 files): `wolf_cor66_kraus_hypothesis_restriction` is also `{open}` scope-restriction and `wolf_theorem6_14_fixed_point_projection_gap` is `{resolved}`; ten migrated `wolf_*` notes are `{open}` overall. The carve-out covers all of them uniformly. Their comment pointers were left untouched to avoid colliding with the in-flight blueprint-split work (#6873); promoting them to `\cite{gap:<slug>}` is a mechanical follow-up.

Closes #6907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4