### PR TITLE
doc(blueprint): cite the companion quantum-channel volume at interface references

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -8,7 +8,7 @@ calculations used in Chapter~\ref{ch:qpf}.
 \label{sec:app_qpf_density}
 
 Write $\mc{D}_D$ for the density matrices of
-the corresponding definition in the companion quantum-channel volume. The next results provide the compact
+the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. The next results provide the compact
 convex domain and the limit argument used for channel fixed points.
 
 \begin{theorem}[Density matrices are compact]\label{thm:density_compact}
@@ -58,7 +58,7 @@ convex domain and the limit argument used for channel fixed points.
 
 \begin{proof}\leanok
     Complete positivity implies positivity by
-    the corresponding theorem in the companion quantum-channel volume, so $E(\rho) \ge 0$; trace preservation
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, so $E(\rho) \ge 0$; trace preservation
     gives $\tr(E(\rho)) = \tr(\rho) = 1$.
 \end{proof}
 

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -127,7 +127,7 @@ matrix-unit indices gives
 
 \begin{proof}\leanok
     This is the MPS formulation of
-    the corresponding theorem in the companion quantum-channel volume: the rectangular
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}: the rectangular
     mixed transfer is the mixed Kraus map, and the two tensor normalization
     identities are its trace-preserving hypotheses.
 \end{proof}
@@ -194,7 +194,7 @@ dimension once they are invertible.
     maps give a faithful weighted trace for the block map. Applying the
     Kadison--Schwarz inequality to $Y$ and pairing its positive semidefinite
     gap with this fixed point shows that the gap vanishes. The Kraus
-    relation of the corresponding theorem in the companion quantum-channel volume then gives
+    relation of the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} then gives
     $Y(C^i)^\dagger=\mu(C^i)^\dagger Y$; applying the same argument to the
     complementary product gives $C^iY=\mu YC^i$. Expanding these block
     relations gives (\ref{eq:spectral_gauged_intertwining}).
@@ -318,14 +318,14 @@ This section proves the rank-one Perron limit
 convergence (Theorem~\ref{thm:primitive_overlap}). Let $E:\MN{D}\to\MN{D}$
 be trace-preserving with a fixed point $\rho\neq0$, $\tr(\rho)\neq0$. Write
 $P:=P_\rho$ for the fixed-point projection of
-the corresponding definition in the companion quantum-channel volume (Chapter~\ref{ch:channels}),
+the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint} (Chapter~\ref{ch:channels}),
 \begin{align}
     P(X)
      & =\frac{\tr(X)}{\tr(\rho)}\rho,
     \notag
 \end{align}
 and $N:=E-P$ for the complementary part. The power decomposition
-(the corresponding theorem in the companion quantum-channel volume, Chapter~\ref{ch:channels}) gives
+(the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, Chapter~\ref{ch:channels}) gives
 $E^n=P+N^n$ for $n\geq1$.
 
 \begin{lemma}[Trace of the fixed-point projection]\label{lem:fixedPointProj_trace}
@@ -355,7 +355,7 @@ $O_{AA}(N)=\Tr(\E_A^N)$, so Theorem~\ref{thm:trace_pow_one} yields the
 primitive self-overlap limit of Theorem~\ref{thm:primitive_overlap}. The
 hypothesis $\rho_{\spec}(N)<1$ is exactly the complementary transfer-map gap
 that the complementary spectral-radius theorem for primitive maps
-(the corresponding theorem in the companion quantum-channel volume, Chapter~\ref{ch:channels})
+(the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, Chapter~\ref{ch:channels})
 supplies: for a primitive $E$ all eigenvalues bounded by $1$ in modulus and
 no trace-zero fixed point, every eigenvalue of $N=E-P$ has modulus strictly
 less than $1$, and since $\MN{D}$ is finite-dimensional this bounds the
@@ -429,7 +429,7 @@ projections, and tracking how the channel shifts the resulting corners.
     \leanok
     \uses{thm:psd_fp_pd_irred}
     By the Kadison--Schwarz inequality
-    (established in the companion quantum-channel volume), the gap
+    (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}), the gap
     $G=E(X^\dagger X)-E(X)^\dagger E(X)$ is positive semidefinite.
     Pairing $G$ with the positive-definite adjoint fixed point and using
     $E(X)=\mu X$ and $|\mu|=1$ gives weighted trace zero, hence $G=0$.
@@ -455,7 +455,7 @@ projections, and tracking how the channel shifts the resulting corners.
     Take eigenvectors $X$ and $Y$ for $\mu$ and $\nu$, respectively.
     The Kadison--Schwarz equality at $X$ places $X$ in the multiplicative
     domain. Thus the right multiplicative identity
-    (established in the companion quantum-channel volume) gives
+    (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) gives
     $E(YX)=E(Y)E(X)=(\nu\mu)YX$.
     Since $X$ and $Y$ are invertible by
     Lemma~\ref{lem:isUnit_peripheral_eigenvector}, $YX\ne 0$, and
@@ -511,7 +511,7 @@ projections, and tracking how the channel shifts the resulting corners.
 \begin{proof}\leanok
     The Kadison--Schwarz equality at the unitary eigenvector places $U$ in
     the multiplicative domain, so the right multiplicative identity
-    (established in the companion quantum-channel volume) gives
+    (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) gives
     $E(U^n)=E(U)^n=\mu^nU^n$ by induction on $n$.
 \end{proof}
 

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -593,7 +593,7 @@ The first theorem derives the overlap condition from a prepared primitive family
     positive semidefinite fixed point $\rho$ of $\E_{A_k}$ with fixed-point
     projector $P$; primitivity gives the complementary gap
     $\rho_{\spec}(\E_{A_k}-P)<1$
-    (the corresponding theorem in the companion quantum-channel volume).
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}).
     Theorem~\ref{thm:primitive_overlap} then yields
     $O_{A_kA_k}(N)\to1$.
 \end{proof}

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
@@ -145,7 +145,7 @@ The results below turn reducing projections into support isometries, compress te
 
 The rectangular Gram-equality criterion that turns $B^\dagger B=A^\dagger A$
 into a unitary $U$ with $B=UA$ is a generic algebra fact, proved in the
-companion quantum-channel volume.
+companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 
 \begin{lemma}[Corner tensors inherit projector closure]
     \label{lem:projector_closure_corner}

--- a/blueprint/src/appendix/ft_mps/ch10_bnt_power_sums_and_sector_bookkeeping.tex
+++ b/blueprint/src/appendix/ft_mps/ch10_bnt_power_sums_and_sector_bookkeeping.tex
@@ -97,7 +97,7 @@ bond dimension $D_{\mathrm{tot}}=\sum_j r_jD_j$.
     Construct diagonal matrices $\diag(\alpha)$ and
     $\diag(\beta)$. The power-sum hypothesis gives
     $\tr(\diag(\alpha)^k) = \tr(\diag(\beta)^k)$.
-    By the corresponding theorem in the companion quantum-channel volume, the characteristic
+    By the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, the characteristic
     polynomials agree: $\prod_i (X - \alpha_i) = \prod_i (X - \beta_i)$.
     Extracting roots gives multiset equality.
 \end{proof}

--- a/blueprint/src/appendix/ft_mps/ch12_symmetry_transfer_and_limits.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry_transfer_and_limits.tex
@@ -53,7 +53,7 @@ physical endpoint correlator of Definition~\ref{def:physical_string_order_param}
 \end{lemma}
 
 \begin{proof}\leanok
-    the corresponding theorem in the companion quantum-channel volume applies to the
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} applies to the
     unitary combination defining $B_u$. Equivalently, expand
     $B_u^n=\sum_{n'}\overline{u_{n'n}}A^{n'}$. The coefficient of
     $A^jX(A^k)^\dagger$ in $\E_{B_u}(X)$ is
@@ -133,7 +133,7 @@ placed in one trace-preserving gauge obtained from their common transfer map.
     \leanok
     This is exactly the usual invariance of a Kraus decomposition under a
     unitary change of Kraus operators; see
-    the corresponding theorem in the companion quantum-channel volume.
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -16,7 +16,7 @@ Chapter~\ref{ch:ft_proof}.
 \section{The multiplicative linear extension}
 
 Nondegeneracy of the trace pairing on $\MN{D}$ is a generic algebra fact,
-proved in the companion quantum-channel volume.
+proved in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 
 \begin{lemma}[Same matrix-product vectors give trace agreement]\label{lem:same_mpv_trace}
     \lean{MPSTensor.SameMPV.trace_evalWord}
@@ -66,7 +66,7 @@ family $\{A^i\}$ under the trace.
     If $\Phi_A(M) = 0$, then (\ref{eq:single_trace_pairing}) gives
     $\tr(M A^i) = 0$ for every~$i$. The $\{A^i\}$ span $\MN{D}$, so
     $\tr(M N) = 0$ for all~$N$, and $M = 0$ by
-    the corresponding theorem in the companion quantum-channel volume.
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 \end{proof}
 
 \begin{lemma}[Injectivity transfers across a range inclusion]%

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -170,7 +170,7 @@
 
 \begin{proof}\leanok
     It is already written in the Kraus form
-    (established in the companion quantum-channel volume), with Kraus operators
+    (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}), with Kraus operators
     $\{A^i\}$.
 \end{proof}
 
@@ -186,7 +186,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the corresponding lemma in the companion quantum-channel volume to the Kraus
+    Apply the corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} to the Kraus
     map determined by $(K_i)_i$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -491,7 +491,7 @@ and~\cite{Evans1978Spectral}.
     eigenvector $\tau > 0$ with eigenvalue $t > 0$:
     $E^\dagger(\tau) = t\tau$.
     For any nonzero positive semidefinite $X$ with $E(X) = sX$, the
-    trace-pairing identity (established in the companion quantum-channel volume) yields
+    trace-pairing identity (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) yields
     \begin{align}
         s\tr(\tau X)
          & = \tr(\tau E(X))
@@ -552,7 +552,7 @@ and~\cite{Evans1978Spectral}.
     the transfer map is a quantum channel
     (Theorem~\ref{thm:transfer_channel}).
     The Ces\`aro fixed-point theorem
-    (the corresponding theorem in the companion quantum-channel volume) then provides the
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) then provides the
     fixed point; injectivity is not needed for this step.
 \end{proof}
 
@@ -871,8 +871,8 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \uses{thm:kraus_posdef_adjoint_eigenvector, thm:transfer_map_irreducible_of_tensor}
     By Theorem~\ref{thm:transfer_map_irreducible_of_tensor}, $\E_A$ is
     irreducible, and since $\mathcal K_A = \E_A$
-    (the corresponding theorem in the companion quantum-channel volume), its Kraus map $\mathcal K_A$ is
-    irreducible too (the corresponding theorem in the companion quantum-channel volume). Applying
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}), its Kraus map $\mathcal K_A$ is
+    irreducible too (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}). Applying
     Theorem~\ref{thm:kraus_posdef_adjoint_eigenvector} to $K_i = A^i$ gives
     a positive definite $\sigma$ and a positive real $r > 0$ with
     $\sum_i (A^i)^\dagger \sigma A^i = r\sigma$, i.e.
@@ -1005,7 +1005,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Theorem~\ref{thm:kraus_tp_gauge_from_adjoint_fixed}; this produces a
     trace-preserving Kraus map $F$ similar to $r^{-1}E$.
     The trace-preserving spectral-radius bound
-    (the corresponding theorem in the companion quantum-channel volume) gives
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) gives
     $\rho_{\spec}(F)\leq1$.
     The conjugate of $\rho$ is a nonzero fixed point of $F$, so $1$ is an
     eigenvalue and $\rho_{\spec}(F)\geq1$. Hence

--- a/blueprint/src/chapter/ch07_spectral_introduction.tex
+++ b/blueprint/src/chapter/ch07_spectral_introduction.tex
@@ -6,7 +6,7 @@ channels and MPS transfer maps, following~\cite{PerezGarcia2007Matrix} and
 
 The first is \emph{peripheral} structure: for an irreducible unital Schwarz
 map with a faithful adjoint fixed point, the eigenvalues on the unit circle
-form a finite cyclic group (the corresponding theorem in the companion quantum-channel volume),
+form a finite cyclic group (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}),
 and under trace preservation the order of this group divides the bond
 dimension~$D$ (Theorem~\ref{thm:peripheral_cyclic_group}). Removing this
 period by unitary conjugation and cyclic corner projections produces the

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -135,7 +135,7 @@ mixed-transfer eigenvector.
 
 \begin{proof}\leanok
     This is the MPS formulation of
-    the corresponding theorem in the companion quantum-channel volume: the map
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}: the map
     $F_{AB}^{\mathrm{rect}}$ is the mixed Kraus map of the two matrix
     families, and the normalizations of $A$ and $B$ are exactly its two
     trace-preserving hypotheses.
@@ -206,7 +206,7 @@ mixed-transfer eigenvector.
     weighted trace for the block map. Applying the Kadison--Schwarz
     inequality to $Y$ and pairing its positive semidefinite gap with this
     fixed point shows that the gap vanishes. The Kraus relation of
-    the corresponding theorem in the companion quantum-channel volume then gives
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} then gives
     $Y(C^i)^\dagger=\mu(C^i)^\dagger Y$. Applying the same argument to the
     complementary product gives $C^iY=\mu YC^i$.
 

--- a/blueprint/src/chapter/ch07_spectral_peripheral_refinements_and_primitive_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_peripheral_refinements_and_primitive_overlap.tex
@@ -284,14 +284,14 @@ given in Section~\ref{sec:app_spectral_perron_projection}.
     \leanok
     Let $E$ be trace-preserving with fixed point $\rho$, where
     $\tr(\rho)\neq0$, and let $P$ be the fixed-point projection of
-    the corresponding definition in the companion quantum-channel volume. If
+    the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. If
     $\rho_{\spec}(E-P)<1$, then $\Tr(E^n)\to1$ as $n\to\infty$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{lem:fixedPointProj_trace}
-    By the power decomposition (established in the companion quantum-channel volume),
+    By the power decomposition (established in the companion quantum-channel volume~\cite{QICLean2026Blueprint}),
     $E^n=P+(E-P)^n$ for $n\geq1$. Since $\rho_{\spec}(E-P)<1$, the
     Gelfand formula gives $(E-P)^n\to0$, so
     $\Tr(E^n)\to\Tr(P)$. Lemma~\ref{lem:fixedPointProj_trace}

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -301,7 +301,7 @@ matrices, and let $\E_K$ be its Kraus map.
 \end{theorem}
 
 \begin{proof}\leanok
-    This is the corresponding theorem in the companion quantum-channel volume for the eigenspace of $\mu$.
+    This is the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} for the eigenspace of $\mu$.
 \end{proof}
 
 \begin{theorem}[Finite-order eigenmatrix is power-fixed]
@@ -313,7 +313,7 @@ matrices, and let $\E_K$ be its Kraus map.
 \end{theorem}
 
 \begin{proof}\leanok
-    the corresponding theorem in the companion quantum-channel volume gives $E^p(X)=\mu^pX=X$.
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives $E^p(X)=\mu^pX=X$.
 \end{proof}
 
 \begin{theorem}[Conjugate finite-order eigenmatrix is power-fixed]
@@ -484,7 +484,7 @@ matrices, and let $\E_K$ be its Kraus map.
 \begin{proof}\leanok
     \uses{thm:kraus_fixed_point_posdef_from_spreading}
     The normalization makes $\E_K$ a channel. The Ces\`aro fixed-point theorem,
-    the corresponding theorem in the companion quantum-channel volume, gives a nonzero positive-semidefinite
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, gives a nonzero positive-semidefinite
     fixed point. The common fixed-length spreading hypothesis makes this fixed
     point positive definite by
     Theorem~\ref{thm:kraus_fixed_point_posdef_from_spreading}.
@@ -511,11 +511,11 @@ matrices, and let $\E_K$ be its Kraus map.
 \begin{proof}\leanok
     \uses{thm:kraus_irreducible_from_spreading, thm:kraus-hermitian-power-fixed-point, thm:kraus-hermitian-power-fixed-point-zero}
     The normalization makes $\E_K$ a channel, so
-    the corresponding theorem in the companion quantum-channel volume gives a nonzero positive-semidefinite
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives a nonzero positive-semidefinite
     fixed point. This supplies the peripheral eigenvalue $1$.
     Theorem~\ref{thm:kraus_irreducible_from_spreading} gives irreducibility.
     Thus $\E_K$ is an irreducible channel. By
-    the corresponding theorem in the companion quantum-channel volume, every peripheral
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, every peripheral
     eigenvalue $\mu$ is a root of unity; choose $p>0$ with
     $\mu^p=1$.
 

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -360,7 +360,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     For the normal-tensor assertion, the transfer map of $\overline A$ is the
     anti-linear conjugate $\sigma\circ\E_A\circ\sigma$
     by~(\ref{eq:cpsv_map_star_transfer_operator}). By
-    the corresponding theorem in the companion quantum-channel volume this conjugation
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} this conjugation
     preserves the spectral radius and primitivity, and by
     Theorem~\ref{thm:cpsv_map_star_irreducible} entrywise conjugation
     preserves irreducibility. Hence both clauses of

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -446,15 +446,15 @@ then infer primitivity of the sector maps. This is the blocking step of
     Pass to the conjugate-transposed Kraus family $K_i:=(A^i)^\dagger$, which
     is unital with irreducible Kraus map. The TP fixed-point theorem for
     $\E_A$ provides a positive definite fixed point for the adjoint of $K$, so
-    the corresponding theorem in the companion quantum-channel volume shows that every peripheral
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} shows that every peripheral
     eigenvalue is a root of unity. Since $\sigma_\partial(\E_A)$ is finite
-    (the corresponding theorem in the companion quantum-channel volume),
-    the corresponding lemma in the companion quantum-channel volume gives a common exponent $p$ with
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}),
+    the corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives a common exponent $p$ with
     $\mu^p=1$ for every $\mu\in\sigma_\partial(\E_A)$, and
-    the corresponding lemma in the companion quantum-channel volume gives
+    the corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives
     $\sigma_\partial(\E_A^p)=\{1\}$. Blocking by $p$ takes the $p$th power of
     the transfer map, so $\E_{A^{[p]}}$ is primitive in the
-    peripheral-spectrum sense of the corresponding definition in the companion quantum-channel volume.
+    peripheral-spectrum sense of the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
     The blocked map need not remain irreducible: eigenvalue~$1$ may have several
     cyclic corners. The adjoint-fixed projections are therefore compressed
     before irreducibility and primitivity are asserted sector by sector in

--- a/blueprint/src/chapter/ch10_bnt_permutation_and_power_sums.tex
+++ b/blueprint/src/chapter/ch10_bnt_permutation_and_power_sums.tex
@@ -134,7 +134,7 @@ individual weights from these sums is a Newton--Girard problem: equal power sums
 determine equal characteristic polynomials, hence equal multisets of roots.
 
 The general matrix statement is
-the corresponding theorem in the companion quantum-channel volume. It identifies a characteristic polynomial
+the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. It identifies a characteristic polynomial
 from the first $n$ power-sum traces.
 
 The matched-sector comparison below applies the power-sum identities to a single

--- a/blueprint/src/chapter/ch12_symmetry_string_order.tex
+++ b/blueprint/src/chapter/ch12_symmetry_string_order.tex
@@ -540,7 +540,7 @@ physical state symmetry requires additional hypotheses.
     \end{tenkzequation}
     implies that the two $d$-element Kraus families $B$ and $A$ define the
     same transfer map.  Rectangular Kraus freedom
-    (the corresponding theorem in the companion quantum-channel volume) converts
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) converts
     $\E_B = \E_A$ into a unitary Kraus mixing matrix $u$ with
     $B^i = \sum_j u_{ij} A^j$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
@@ -38,7 +38,7 @@ $(P_L\otimes\Id_R)\rho=\rho$ and $\rho(P_L\otimes\Id_R)=\rho$, which for
 $H_L=H_A\otimes H_X$ and $H_R=H_B$ are precisely the $P_{AX}$
 support-projector identities in \cite[Appendix~D.2, lines
     2228--2235]{Cirac2016MPDO_arXiv} — are pure bipartite-operator facts with no
-tensor-network content, proved in the companion quantum-channel volume. The
+tensor-network content, proved in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. The
 partial trace over the left factor that they and the absorption theorems
 below are stated against is defined there as well.
 
@@ -104,8 +104,8 @@ Left and right absorption by the right marginal support — for $\rho\geq0$
 and $P_R$ the support projector of $\tr_L\rho$, the identities
 $(\Id_L\otimes P_R)\rho=\rho$ and $\rho(\Id_L\otimes P_R)=\rho$ — are the
 same kind of generic bipartite-operator fact, proved in the companion
-quantum-channel volume alongside the left-marginal absorption theorems
-above.
+quantum-channel volume~\cite{QICLean2026Blueprint} alongside the
+left-marginal absorption theorems above.
 
 We now use the explicit tripartite indexing
 $H_A\otimes(H_X\otimes H_B)$. Reassociation identifies it with

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -239,7 +239,7 @@ on decay rates.
     Chapter~\ref{ch:parent_hamiltonian_commuting_and_gap}.
     The complementary transfer-map gap $\rho(\E_A-P)<1$ is established for
     primitive channels
-    (the corresponding theorem in the companion quantum-channel volume, Chapter~\ref{ch:channels}).
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, Chapter~\ref{ch:channels}).
     The mixed-transfer gap needed for separation of non-equivalent canonical
     blocks is supplied for irreducible trace-preserving tensors
     (Theorem~\ref{thm:transfer_operator_gap_irr_tp}), and quantitative
@@ -313,7 +313,7 @@ single-tensor transfer map $\E_A$.
         \label{eq:correlations_channel_convergence}
     \end{align}
     The transfer-map gap $\delta$ exists by primitivity
-    (the corresponding theorem in the companion quantum-channel volume, the complementary transfer-map
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, the complementary transfer-map
     gap).
 \end{theorem}
 

--- a/blueprint/src/chapter/ch17_semigroup.tex
+++ b/blueprint/src/chapter/ch17_semigroup.tex
@@ -11,7 +11,7 @@ channels and characterizes their generators via the
 GKSL (Gorini--Kossakowski--Sudarshan--Lindblad) theorem,
 following~\cite[Chapter~7]{Wolf2012Quantum}.
 
-The companion quantum-channel volume establishes definitions and the basic
+The companion quantum-channel volume~\cite{QICLean2026Blueprint} establishes definitions and the basic
 exponential form, gives the Duhamel formula and perturbation bound, and
 develops the generator theory that proves the GKSL theorem.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -436,7 +436,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $S=\widetilde R_1\widetilde S R_2$. The scalar
     Newton--Girard power-sum identity needed to obtain the trace-power form is
     already available as
-    the corresponding theorem in the companion quantum-channel volume. To obtain the trace-power conclusion of
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. To obtain the trace-power conclusion of
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}, one must impose the
     BNT-label hypotheses as a separate condition, relate them to the one-site
     and two-site vertical canonical forms, and construct the maps in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1298,7 +1298,7 @@ terms of operator-Schmidt rank.
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the corresponding lemma in the companion quantum-channel volume to the function $x\mapsto x^s$.
+    Apply the corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} to the function $x\mapsto x^s$.
 \end{proof}
 
 \begin{theorem}[Real powers of positive tensor products]
@@ -1314,7 +1314,7 @@ terms of operator-Schmidt rank.
 
 \begin{proof}\leanok
     Apply
-    the corresponding theorem in the companion quantum-channel volume to
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} to
     $x\mapsto x^s$, using $(xy)^s=x^sy^s$ for $x,y\geq0$.
 \end{proof}
 
@@ -1558,10 +1558,10 @@ logarithmic divergence, or a comparison with relative entropy.
     Set $\omega=\rho_A\otimes\rho_B$. The marginals are positive semidefinite,
     $\tr\omega=1$, and Theorem~\ref{thm:product_marginals_kernel} gives
     $\ker\omega\subseteq\ker\rho_{AB}$. Reindex the product basis by a single
-    finite coordinate set. The corresponding lemma in the companion quantum-channel volume and
+    finite coordinate set. The corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} and
     Theorem~\ref{thm:sandwiched_renyi_two_submatrix_equiv} preserve the two
     functionals, so Theorem~\ref{thm:relative_entropy_q2_support} applies.
-    The corresponding theorem in the companion quantum-channel volume identifies its left
+    The corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} identifies its left
     side with mutual information. Thus, with
     $q=Q_2(\rho_{AB},\omega)$,
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -493,7 +493,7 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
     \uses{def:mpdo_ancillary_trace_map}
     The spin reduction obtained by tracing the ancillary index is
     trace-preserving completely positive: the ancillary trace map
-    $\tr_a$ satisfies the corresponding definition in the companion quantum-channel volume.
+    $\tr_a$ satisfies the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
     This is the structure described immediately after Definition~4.3 in
     \cite[lines~761--764]{Cirac2016MPDO_arXiv}.
 \end{definition}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -447,7 +447,7 @@ $A$ to matrices on $A\otimes B$, the elementary preparation operation used
 in the maps $\mathcal T_1$ and $\mathcal S_1$ of
 \cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv},
 is a fully generic construction with no MPDO-specific content, stated as
-the corresponding definition in the companion quantum-channel volume in
+the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint} in
 Chapter~\ref{ch:aux_channel_theory}.
 
 \begin{definition}[Preparation Kraus operators]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -400,7 +400,7 @@ strong subadditivity for a normalized three-site reduced state.
     This is the forward implication of the Hayashi equality
     characterization. The product-reference raw Petz formula, including its
     singular-support compression, is given by
-    the corresponding theorem in the companion quantum-channel volume. The singular-support
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. The singular-support
     equality-to-recovery theorem is still separate. Beyond it, the remaining
     structural ingredient is the family-level Koashi--Imoto decomposition and
     the induced action of the middle-system channel on its common direct-sum
@@ -578,7 +578,7 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1714--1737]{Cirac2016MPDO_arXiv}.
     The Hayashi decomposition uses the forward equality characterization of
     strong subadditivity recorded in
-    the corresponding theorem in the companion quantum-channel volume; no additional
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}; no additional
     analytic assumption is introduced here.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -845,7 +845,7 @@
     Hermiticity of $\eta_{k,h}$ gives
     $\eta_{k,h}^2=\eta_{k,h}\,\eta_{k,h}^\dagger$, which is positive
     semidefinite, so its trace is a non-negative real number. The upper
-    bound is the corresponding theorem in the companion quantum-channel volume applied
+    bound is the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} applied
     to $\eta_{k,h}$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -55,7 +55,7 @@
     $\{e^{2\pi i k/m}:0\le k<m\}$. This is the normalized form-II
     convention used later in the source.
     A $1$-periodic tensor is exactly an irreducible tensor with
-    primitive transfer map (the corresponding definition in the companion quantum-channel volume).
+    primitive transfer map (the corresponding definition in the companion quantum-channel volume~\cite{QICLean2026Blueprint}).
 \end{definition}
 
 \begin{theorem}[Perron normalization of spectrally periodic tensors]

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_cyclic_sectors.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_cyclic_sectors.tex
@@ -212,7 +212,7 @@
 
 \begin{proof}\leanok
     Since the peripheral spectrum of $\E_A$ consists of $m$-th roots
-    of unity, the corresponding lemma in the companion quantum-channel volume gives
+    of unity, the corresponding lemma in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives
     $\spec_{\mathrm{per}}(\E_A^m)=\{1\}$, hence $\zeta=1$. The cyclic trace
     gives $\tr U=\tr(P_uUP_v)=\tr(P_vP_uU)=0$.
 

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -549,7 +549,7 @@
         \notag
     \end{align}
     Hence $m_j=1$. The transfer map is primitive by
-    the corresponding theorem in the companion quantum-channel volume, and normality follows from
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, and normality follows from
     Theorem~\ref{thm:normal_tp_primitive_irred}. Gauge-phase distinctness is
     also part of the auxiliary BNT sector hypotheses. The equivalence now
     follows from

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -61,7 +61,7 @@ ambient bond space.
     nonzero-weight clauses are exactly the hypotheses. For each block,
     peripheral primitivity gives the complementary spectral gap
     $\rho_{\spec}(\E_{A_k}-P)<1$ by
-    the corresponding theorem in the companion quantum-channel volume.
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
     Theorem~\ref{thm:primitive_overlap} then yields
     $O_{A_kA_k}(N)\to1$.
 \end{proof}

--- a/blueprint/src/chapter/ch26_mps_rfp_physical_blocking.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_physical_blocking.tex
@@ -87,7 +87,7 @@
          & =\sum_jA^jX(A^j)^\dagger.
         \notag
     \end{align}
-    the corresponding theorem in the companion quantum-channel volume then supplies the isometry $V$
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} then supplies the isometry $V$
     relating the two Kraus families.
 \end{proof}
 

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -90,7 +90,7 @@
 \begin{proof}
     \leanok
     \uses{thm:mean_ergodic_projection_density_block_form, thm:posdef_left_kronecker_trace_one}
-    the corresponding theorem in the companion quantum-channel volume gives positivity, trace
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives positivity, trace
     preservation, a positive definite fixed point for $\widetilde T$, and the
     stated correspondence between the original and compressed fixed points.
     Directly from the trace pairing,
@@ -157,7 +157,7 @@
     Put $W=VU_c$. Then $W^*W=\Id_n$. Compare $W$ with the canonical
     inclusion of $\C^n$ as the second summand of
     $\C^{D-n}\oplus\C^n$. The two inclusions have the same Gram matrix, so
-    the corresponding theorem in the companion quantum-channel volume gives an ambient
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} gives an ambient
     unitary $U$ carrying the canonical inclusion to $W$. Hence, for every
     $A\in\MN{n}$,
     \begin{align}
@@ -189,15 +189,15 @@
 \begin{proof}
     \leanok
     Take the fixed point $\rho_0$ of
-    the corresponding theorem in the companion quantum-channel volume. Every fixed point $X$ of
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}. Every fixed point $X$ of
     $T$ satisfies $Q_0XQ_0=X$ for the support projection $Q_0$ of
-    $\rho_0$, so the corresponding theorem in the companion quantum-channel volume applies
+    $\rho_0$, so the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} applies
     to $X$ and produces the corner-supported $Y$.
 \end{proof}
 
 At the fixed point $\rho_0$, with the inverse square root taken on the
 support of $\rho_0$, the carrier of the $*$-subalgebra of
-the corresponding theorem in the companion quantum-channel volume therefore realizes
+the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} therefore realizes
 \begin{align}
     \rho_0^{-1/2}
     \{X\in\MN{D}\mid T(X)=X\}
@@ -285,7 +285,7 @@ support projection.
     \leanok
     \uses{lem:rank_stationaryProj, lem:trace_stationaryProj}
     Let $\rho_0$ be the fixed point of maximal support of
-    the corresponding theorem in the companion quantum-channel volume, with support projection
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, with support projection
     $Q_0$, and let $P$ be the support projection of $\rho$. If $\rho_0=0$,
     then every fixed point vanishes because $Q_0=0$ annihilates it, and the
     claim is trivial. Suppose that $\rho_0\neq0$. Its trace is then
@@ -343,13 +343,13 @@ support projection.
     \uses{thm:maximalSupport_of_maximalRank}
     By Theorem~\ref{thm:maximalSupport_of_maximalRank}, every fixed point
     $X$ of $T$ satisfies $QXQ=X$ for the support projection $Q$ of $\rho$,
-    so the corresponding theorem in the companion quantum-channel volume applies to $X$ and
+    so the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} applies to $X$ and
     produces the corner-supported $Y$.
 \end{proof}
 
 At every fixed point $\rho$ of maximum rank, with the inverse square root
 taken on the support of $\rho$, the carrier of the $*$-subalgebra of
-the corresponding theorem in the companion quantum-channel volume therefore realizes
+the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} therefore realizes
 the conjugated fixed-point set
 \begin{align}
     \rho^{-1/2}
@@ -364,7 +364,7 @@ of Corollary~6.7 of~\cite{Wolf2012Quantum}.
 This section collects criteria and equivalences from
 \cite[Theorems~6.7 and~6.8]{Wolf2012Quantum} that are used later. The
 completely positive exponential characterization corresponding to Wolf's
-Theorem~6.2 appears in the corresponding theorem in the companion quantum-channel volume.
+Theorem~6.2 appears in the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 
 \begin{definition}[Exact Kraus word spans]
     \label{def:kraus_exact_word_span}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -224,7 +224,7 @@ channel-level argument below uses its Kraus analogue.
     $\rho_\infty$ satisfying $E(\rho_\infty)=\rho_\infty$,
     $\rho_\infty>0$, and $\tr(\rho_\infty)=1$. Existence, uniqueness, and
     positive definiteness follow from
-    the corresponding theorem in the companion quantum-channel volume.
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}.
 \end{definition}
 
 \begin{definition}[Stationary support]\label{def:stationarySupport}
@@ -452,7 +452,7 @@ sector is positive definite.
     $\rho$ is a positive-definite fixed point by
     Theorem~\ref{thm:compression_on_support_posDef}. The structure theorem
     for fixed points of unital Schwarz maps with a positive-definite fixed
-    point (the corresponding theorem in the companion quantum-channel volume) makes the
+    point (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}) makes the
     compressed fixed points a $*$-algebra. The compression isomorphism is
     multiplicative and star-preserving, intertwines the compressed adjoint
     map with the corner-restricted map, and transports this structure back

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -641,7 +641,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
 \begin{proof}
     \leanok
     \uses{thm:starSubalgebra_wedderburnArtin}
-    By the corresponding theorem in the companion quantum-channel volume, the fixed-point set
+    By the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, the fixed-point set
     $\Fix(E)$ is a $*$-subalgebra of $\MN{D}$. Applying
     Theorem~\ref{thm:starSubalgebra_wedderburnArtin} gives the asserted
     product decomposition with each block size $d_k\geq1$.
@@ -717,7 +717,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \uses{thm:starSubalgebra_unitary_block_diagonal_iff}
     The fixed points of $E^*$ form a $*$-subalgebra of $\MN{D}$ because
     $E$ is trace-preserving with a positive definite fixed point
-    (the corresponding theorem in the companion quantum-channel volume).
+    (the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}).
     Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff} supplies
     the unitary $U$, the dimensions and multiplicities, and the equivalence
     between membership and the block form
@@ -747,7 +747,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \leanok
     \uses{thm:starSubalgebra_unitary_block_diagonal_iff}
     The fixed points of the unital map $E$ form a $*$-subalgebra of
-    $\MN{D}$ by the corresponding theorem in the companion quantum-channel volume, and
+    $\MN{D}$ by the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint}, and
     Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff} supplies
     the unitary and the equivalence.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1247,7 +1247,7 @@ nonzero spectrum as a set.
     and let $B$ be the rank-one diagonal idempotent from
     Lemma~\ref{lem:mpu_diagonal_one_at}.  For $1\le k\le n$ we have
     $\tr(A^k)=1=\tr(B^k)$.  The finite-range half of the Newton--Girard
-    the corresponding theorem in the companion quantum-channel volume then yields $\chi_A = \chi_B =
+    the corresponding theorem in the companion quantum-channel volume~\cite{QICLean2026Blueprint} then yields $\chi_A = \chi_B =
         X^{\,n-1}(X-1)$.
 \end{proof}
 
@@ -3437,9 +3437,10 @@ Let $D$ be a positive integer and let
 $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map. The transfer matrix
 $\widehat T$ of $T$ under the column-stacking identification
 $M_D(\mathbb C)\cong\mathbb C^{D^2}$ is defined in the companion
-quantum-channel volume, the matrix-units special case of the one-family
-transfer matrix of the corresponding definition in the companion
-quantum-channel volume.
+quantum-channel volume~\cite{QICLean2026Blueprint}, the matrix-units
+special case of the one-family transfer matrix of the corresponding
+definition in the companion quantum-channel
+volume~\cite{QICLean2026Blueprint}.
 
 \begin{theorem}[Functoriality of transfer matrices]
     \label{thm:mpu_transfer_matrix_functoriality}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -58,6 +58,15 @@
                   archival PDF at \url{https://mediatum.ub.tum.de/doc/1099654/1099654.pdf}},
 }
 
+@misc{QICLean2026Blueprint,
+  author       = {Lu, Sirui and Tjoa, Erickson and Cirac, J. Ignacio},
+  title        = {Quantum Information and Channels: A Formalization Blueprint},
+  year         = {2026},
+  howpublished = {Blueprint of the QICLean library, the companion
+                  quantum-channel volume of this development},
+  note         = {\url{https://sirui-lu.com/QICLean/blueprint/}},
+}
+
 @article{Wolf2008AreaLaws,
   author       = {Wolf, Michael M. and Verstraete, Frank and
                   Hastings, Matthew B. and Cirac, J. Ignacio},


### PR DESCRIPTION
## Motivation

Partial resolution of #6873. During CI stabilization of the extraction PR (#6865), the `\ref`/`\eqref` citations whose target labels moved to QICLean's blueprint were reworded to the bare prose phrase "the companion quantum-channel volume" — resolvable by no reader, exactly the residue #6873 records. QICLean has since published its blueprint at [sirui-lu.com/QICLean/blueprint/](https://sirui-lu.com/QICLean/blueprint/) (verified live), so the interface references can carry a proper citation.

## Description

- Adds a bibliography entry `QICLean2026Blueprint` for Lu–Tjoa–Cirac, *Quantum Information and Channels: A Formalization Blueprint* (title and authors taken from QICLean's own blueprint front matter), with the published URL in the note field, following the cross-repository citation pattern established for the QICLean paper-gap entries in `references.bib`.
- Attaches that citation at every "companion quantum-channel volume" reference: 79 occurrences across 35 chapter/appendix files (76 same-line plus 3 line-wrapped). A residual grep confirms no uncited occurrence remains.

**Not resolved here, left open on #6873:** restoring statement-level precision at these 79 sites (each now cites the companion volume as a whole, not the particular theorem the pre-#6865 `\ref` targeted), and the file-by-file disposition of the 47 mixed `.tex` files (splitting their remaining QIC-disposition entries into QICLean's blueprint versus keeping them as TN-side interface statements — a cross-repository restructuring beyond this documentation sweep).

## Testing

- `leanblueprint web` (miniforge environment with the texra_blueprint plugin): exit 0, no errors; the new citations render exactly as the existing `\cite{Wolf2012Quantum}`/`\cite{gap:...}` citations do, and appear in the built chapter pages.
- `texra-blueprint paper-gaps check`: exit 0 ("95 referenced slugs resolve").
- `grep -rn "quantum-channel volume" blueprint/src | grep -v QICLean2026Blueprint`: empty.

Part of #6873 (kept open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4