### PR TITLE
ci(workflows): adopt texra-blueprint web and bump the pin to v0.3.6

### DIFF
--- a/.github/allowed-tools.json
+++ b/.github/allowed-tools.json
@@ -1,7 +1,7 @@
 {
   "lean-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-review-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),Bash(gh pr *),Bash(gh api *),mcp__github__*",
-  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.4),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
+  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.6),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-linter-warning-auto-fix": "Read,Edit,Glob,Grep,Bash(python3 *),Bash(lake build),Bash(lake build *),Bash(lake env),Bash(lake env *),Bash(git diff *),Bash(git status),Bash(grep *),Bash(rg *)",
   "claude-interactive": "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *),mcp__github__*",
   "blueprint-prose-review": "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(grep *),mcp__github__*",

--- a/.github/prompts/auto-fix-blueprint-prompt.md
+++ b/.github/prompts/auto-fix-blueprint-prompt.md
@@ -15,7 +15,7 @@ Instructions:
 3. The blueprint `.tex` files are in `blueprint/src/chapter/`. The blueprint configuration is in `blueprint/src/`.
 4. You can test your fix locally by running:
 
-   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.4`
+   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.6`
    - `cd blueprint && leanblueprint web`
 
    Check that no `ERROR` lines appear in the output.

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Run mentioned agent
         id: agent

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Check native tenkz sources and picture pipeline
         run: |
@@ -94,10 +94,12 @@ jobs:
 
           leanblueprint pdf
 
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know (unrecognized
+          # command/environment, default-renderer fallback) — the gate that
+          # pr-ci.yml applies to a branch. The log is kept for the label
+          # checks below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
 
           if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::warning::Blueprint has unresolved labels (see ERROR lines above)"
@@ -105,19 +107,6 @@ jobs:
           if grep -q "WARNING: File not found:" "$tmp_output_file"; then
             echo "::error::Blueprint has missing files (see WARNING lines above)"
             exit 1
-          fi
-          # A command plasTeX does not know reaches the page through whichever
-          # template happens to share its name, and a node with no template at
-          # all reaches it through the fallback. Both produced reader-visible
-          # corruption from a build that reported success, so neither may be
-          # published. This is the gate that pr-ci.yml applies to a branch.
-          if grep -qE "WARNING: (unrecognized command/environment|Using default renderer)" \
-               "$tmp_output_file"; then
-            echo "::error::Blueprint uses a command the web renderer does not know; declare it in blueprint/src/Packages/tnlean_patches.py or the texra-blueprint plugin"
-            exit 1
-          fi
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
           if grep -R "tenkz SVG unavailable" blueprint/web --include='*.html'; then
             echo "::error::Blueprint contains unrendered tenkz SVG placeholders"

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
@@ -72,27 +72,16 @@ jobs:
           set -o pipefail
           tmp_output_file="$(mktemp)"
 
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know (unrecognized
+          # command/environment, default-renderer fallback) — the gate that
+          # pr-ci.yml applies to a branch. The log is kept for the label
+          # check below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
 
           if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
             exit 1
-          fi
-          # A command plasTeX does not know reaches the page through whichever
-          # template happens to share its name, and a node with no template at
-          # all reaches it through the fallback. Both produced reader-visible
-          # corruption from a build that reported success, so neither may be
-          # published. This is the gate that pr-ci.yml applies to a branch.
-          if grep -qE "WARNING: (unrecognized command/environment|Using default renderer)" \
-               "$tmp_output_file"; then
-            echo "::error::Blueprint uses a command the web renderer does not know; declare it in blueprint/src/Packages/tnlean_patches.py or the texra-blueprint plugin"
-            exit 1
-          fi
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
           if grep -R "tenkz SVG unavailable" web --include='*.html'; then
             echo "::error::Blueprint contains unrendered tenkz SVG placeholders"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -776,7 +776,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 
       - name: Lint tenkz picture sources
         if: env.TEX_CHANGED == 'true'
@@ -891,18 +891,18 @@ jobs:
         if: env.TEX_CHANGED == 'true'
         run: python3 scripts/blueprint_bibtex.py
 
-      - name: Run leanblueprint web and check for errors
+      - name: Run texra-blueprint web and check for errors
         if: env.TEX_CHANGED == 'true'
         working-directory: blueprint
         run: |
           set -o pipefail
           tmp_output_file="$(mktemp)"
 
-          # Run leanblueprint, streaming output to the log and capturing it to a file
-          set +o pipefail
-          leanblueprint web 2>&1 | tee "$tmp_output_file"
-          cmd_status=${PIPESTATUS[0]}
-          set -o pipefail
+          # texra-blueprint web wraps leanblueprint web and fails when the
+          # renderer meets a command it does not know (unrecognized
+          # command/environment, default-renderer fallback); the log is kept
+          # for the label checks below.
+          texra-blueprint web 2>&1 | tee "$tmp_output_file"
 
           # Check for blueprint ERROR lines in the captured output
           if grep -q "^ERROR:" "$tmp_output_file"; then
@@ -911,21 +911,6 @@ jobs:
           fi
           if grep -q "WARNING: File not found:" "$tmp_output_file"; then
             echo "::warning::Blueprint has missing file references (see WARNING lines above)"
-          fi
-
-          # A command plasTeX does not know reaches the page through whichever
-          # template happens to share its name, and a node with no template at
-          # all reaches it through the fallback. Both produced reader-visible
-          # corruption from a build that reported success, so both fail here.
-          if grep -qE "WARNING: (unrecognized command/environment|Using default renderer)" \
-               "$tmp_output_file"; then
-            echo "::error::Blueprint uses a command the web renderer does not know; declare it in blueprint/src/Packages/tnlean_patches.py or the texra-blueprint plugin"
-            exit 1
-          fi
-
-          # If leanblueprint itself failed, propagate its exit status
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
           fi
 
       # Every blueprint picture compiled standalone during the web build and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ rg -n "sorry|axiom" TNLean/Path/To/File.lean || true
 
 # Blueprint validation. Requires leanblueprint plus the pinned shared
 # plasTeX plugin (blueprint/src/plastex.cfg loads it unconditionally):
-#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.4'
+#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
 # Run after lake build succeeds.
 cd blueprint && leanblueprint checkdecls
 


### PR DESCRIPTION
Migrates the repo to texra-blueprint v0.3.6, whose `texra-blueprint web` subcommand is the canonical strict wrapper around `leanblueprint web` (fails on `WARNING: unrecognized command/environment` and `WARNING: Using default renderer`).

## Changes

- **Pin bump v0.3.4 → v0.3.6** at all 7 sites: `blueprint.yml`, `docgen.yml`, `pr-ci.yml`, `agent-mention.yml`, `.github/allowed-tools.json`, `.github/prompts/auto-fix-blueprint-prompt.md`, `CLAUDE.md`.
- **Renderer gate replacement** in `pr-ci.yml`, `docgen.yml`, and `blueprint.yml`: the inline `tee + grep -qE "WARNING: (unrecognized command/environment|Using default renderer)"` gate is replaced by a `texra-blueprint web` invocation (same working directory, same following steps). The `set +o pipefail` / `PIPESTATUS` dance is gone; `set -o pipefail` propagates the wrapper's exit status.
- **Extra greps beyond the renderer vocabulary are kept**, running right after `texra-blueprint web` in the same step: the `^ERROR:` unresolved-label check, the `WARNING: File not found:` check (warning in pr-ci, hard failure in blueprint.yml), and the `tenkz SVG unavailable` page sweep in docgen/blueprint. The `tee` into the log file is kept because these label checks read it.

## Verification

With v0.3.6 installed locally:

- `texra-blueprint web` from `blueprint/` (after `scripts/blueprint_bibtex.py`): exit 0 on the current tree.
- `texra-blueprint paper-gaps check`: exit 0 (95 referenced slugs resolve).
- `yaml.safe_load` passes on all four touched workflows; `allowed-tools.json` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4
