### PR TITLE
feat(MPS/MPU): add finite-chain conjugation

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
 import TNLean.MPS.MPU.FactorFreeSandwich
+import TNLean.MPS.MPU.FiniteChainConjugation
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm

--- a/TNLean/MPS/MPU/FiniteChainConjugation.lean
+++ b/TNLean/MPS/MPU/FiniteChainConjugation.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Basic
+import TNLean.QCA.LocalLimit
+import Mathlib.Data.Finset.Sort
+
+/-!
+# Finite-chain conjugation by a matrix product unitary
+
+This file isolates the finite-size expression
+\(U^{(N)} A_L U^{(N)\dagger}\) that occurs before the stabilization limit in
+`eq:appendix-1`.  A periodic MPU matrix is reindexed from the cyclic sites
+`Fin N` to an integer interval of length `N`; a local observable is extended to
+that interval by tensoring with the identity and then conjugated by the
+reindexed unitary.
+
+No stabilization, propagation bound, translation covariance, quasi-local
+automorphism, or QCA is asserted here.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188,
+  equation `eq:appendix-1`, lines 2300--2306.
+-/
+
+open scoped Matrix
+
+namespace SpinChain
+
+/-- The half-open integer interval of `N` consecutive sites beginning at `a`.
+
+This is the chosen finite chain used to interpret the finite-size operator
+\(U^{(N)}\) in arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainRegion (a : ℤ) (N : ℕ) : Finset ℤ :=
+  Finset.Ico a (a + N)
+
+@[simp]
+lemma card_finiteChainRegion (a : ℤ) (N : ℕ) : (finiteChainRegion a N).card = N := by
+  simp [finiteChainRegion, Int.card_Ico]
+
+/-- The increasing identification of the cyclic site labels `Fin N` with the
+chosen integer interval of length `N`.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainSiteEquiv (a : ℤ) (N : ℕ) :
+    Fin N ≃ finiteChainRegion a N :=
+  ((finiteChainRegion a N).orderIsoOfFin (card_finiteChainRegion a N)).toEquiv
+
+/-- Reindex a periodic length-`N` configuration as a configuration on the
+chosen integer interval.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainConfigEquiv (d N : ℕ) (a : ℤ) :
+    (Fin N → Fin d) ≃ Config d (finiteChainRegion a N) :=
+  Equiv.arrowCongr (finiteChainSiteEquiv a N) (Equiv.refl (Fin d))
+
+/-- The periodic matrix-product operator \(U^{(N)}\), reindexed to the
+configuration basis of the chosen finite integer interval.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainMPOMatrix {d D : ℕ} (U : MPOTensor d D)
+    (N : ℕ) (a : ℤ) : LocalAlgebra d (finiteChainRegion a N) :=
+  CStarMatrix.ofMatrixStarAlgEquiv
+    (Matrix.reindex (finiteChainConfigEquiv d N a) (finiteChainConfigEquiv d N a)
+      (MPOTensor.mpo U N))
+
+/-- For the paper's explicit convention `N > 1`, the reindexed finite-chain
+operator \(U^{(N)}\) is unitary.
+
+Source: arXiv:1703.09188, equations `UisUnitary` and `eq:appendix-1`,
+lines 327--335 and 2300--2306. -/
+noncomputable def finiteChainMPUUnitary {d D : ℕ} {U : MPOTensor d D}
+    (hU : U.IsMPU) {N : ℕ} (hN : 1 < N) (a : ℤ) :
+    unitary (LocalAlgebra d (finiteChainRegion a N)) := by
+  let e := finiteChainConfigEquiv d N a
+  let M := Matrix.reindex e e (MPOTensor.mpo U N)
+  have hM : M ∈ Matrix.unitaryGroup (Config d (finiteChainRegion a N)) ℂ :=
+    Matrix.reindex_mem_unitaryGroup e (MPOTensor.mpo U N) (hU.mpo_mem_unitaryGroup hN)
+  refine ⟨finiteChainMPOMatrix U N a, ?_⟩
+  change star M * M = 1 ∧ M * star M = 1
+  exact ⟨Matrix.mem_unitaryGroup_iff'.mp hM, Matrix.mem_unitaryGroup_iff.mp hM⟩
+
+/-- Conjugation by the finite-chain MPU unitary, in the source order
+\(A\mapsto U^{(N)} A U^{(N)\dagger}\).
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainConjugation {d D : ℕ} {U : MPOTensor d D}
+    (hU : U.IsMPU) {N : ℕ} (hN : 1 < N) (a : ℤ) :
+    LocalAlgebra d (finiteChainRegion a N) ≃⋆ₐ[ℂ]
+      LocalAlgebra d (finiteChainRegion a N) :=
+  Unitary.conjStarAlgAut ℂ _ (finiteChainMPUUnitary hU hN a)
+
+/-- Finite-chain conjugation has the pointwise formula
+\(U^{(N)} A U^{(N)\dagger}\), with the factors in the order used in
+`eq:appendix-1`.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+@[simp]
+lemma finiteChainConjugation_apply {d D : ℕ} {U : MPOTensor d D}
+    (hU : U.IsMPU) {N : ℕ} (hN : 1 < N) (a : ℤ)
+    (A : LocalAlgebra d (finiteChainRegion a N)) :
+    finiteChainConjugation hU hN a A =
+      finiteChainMPOMatrix U N a * A * star (finiteChainMPOMatrix U N a) :=
+  rfl
+
+/-- Include an observable `A` supported on `Λ` into the chosen finite interval,
+apply the finite-chain conjugation \(U^{(N)} A_L U^{(N)\dagger}\), and regard the
+result as an algebraic local observable.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+noncomputable def finiteChainLocalObservable {d D : ℕ} {U : MPOTensor d D}
+    (hU : U.IsMPU) {N : ℕ} (hN : 1 < N) (a : ℤ) {Λ : Finset ℤ}
+    (hΛ : Λ ⊆ finiteChainRegion a N) :
+    LocalAlgebra d Λ →⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
+  (localObservable d (finiteChainRegion a N)).comp
+    ((finiteChainConjugation hU hN a).toStarAlgHom.comp (localInclusion hΛ))
+
+/-- The local-observable map is exactly the finite-`N` term
+\(U^{(N)} A_L U^{(N)\dagger}\) from `eq:appendix-1`.
+
+Source: arXiv:1703.09188, equation `eq:appendix-1`, lines 2300--2306. -/
+@[simp]
+lemma finiteChainLocalObservable_apply {d D : ℕ} {U : MPOTensor d D}
+    (hU : U.IsMPU) {N : ℕ} (hN : 1 < N) (a : ℤ) {Λ : Finset ℤ}
+    (hΛ : Λ ⊆ finiteChainRegion a N) (A : LocalAlgebra d Λ) :
+    finiteChainLocalObservable hU hN a hΛ A =
+      localObservable d (finiteChainRegion a N)
+        (finiteChainMPOMatrix U N a * localInclusion hΛ A *
+          star (finiteChainMPOMatrix U N a)) :=
+  rfl
+
+end SpinChain

--- a/TNLean/MPS/MPU/FiniteChainConjugation.lean
+++ b/TNLean/MPS/MPU/FiniteChainConjugation.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Data.Finset.Sort
 import TNLean.MPS.MPU.Basic
 import TNLean.QCA.LocalLimit
-import Mathlib.Data.Finset.Sort
 
 /-!
 # Finite-chain conjugation by a matrix product unitary

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7899,7 +7899,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         SpinChain.finiteChainSiteEquiv,SpinChain.finiteChainConfigEquiv,
         SpinChain.finiteChainMPOMatrix}
     \leanok
-    \uses{def:mpu, def:qca_local_algebra}
+    \uses{def:mpo_family, def:qca_local_algebra}
     For $a\in\mathbb Z$ and $N\in\mathbb N$, let
     $I_{a,N}=[a,a+N)\cap\mathbb Z$.  The increasing bijection
     $\{0,\ldots,N-1\}\simeq I_{a,N}$ identifies the periodic configuration
@@ -7914,7 +7914,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         SpinChain.finiteChainConjugation,
         SpinChain.finiteChainConjugation_apply}
     \leanok
-    \uses{def:mpu_finite_chain_realization}
+    \uses{def:mpu, def:mpu_finite_chain_realization}
     If $\mathcal U$ is an MPU and $N>1$, then $U_a^{(N)}$ is unitary and
     defines the star-algebra automorphism
     \begin{align}
@@ -7926,7 +7926,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{definition}
 
 \begin{proof}\leanok
-    \uses{def:mpu}
+    \uses{def:mpu, thm:mpu_reindex_unitary}
     Simultaneous reindexing preserves both unitarity equations for $U^{(N)}$.
     Conjugation by the resulting unitary preserves multiplication, the unit,
     complex scalars, and the adjoint.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7893,6 +7893,63 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \cite{Cirac2017MPU}.  No norm completion is taken.
 \end{definition}
 
+\begin{definition}[Finite-chain realization of a periodic MPU]
+    \label{def:mpu_finite_chain_realization}
+    \lean{SpinChain.finiteChainRegion,SpinChain.card_finiteChainRegion,
+        SpinChain.finiteChainSiteEquiv,SpinChain.finiteChainConfigEquiv,
+        SpinChain.finiteChainMPOMatrix}
+    \leanok
+    \uses{def:mpu, def:qca_local_algebra}
+    For $a\in\mathbb Z$ and $N\in\mathbb N$, let
+    $I_{a,N}=[a,a+N)\cap\mathbb Z$.  The increasing bijection
+    $\{0,\ldots,N-1\}\simeq I_{a,N}$ identifies the periodic configuration
+    basis with $\operatorname{Config}_d(I_{a,N})$.  In this basis, write
+    $U_{a}^{(N)}$ for the matrix obtained by simultaneously reindexing the rows
+    and columns of $U^{(N)}$.
+\end{definition}
+
+\begin{definition}[Finite-chain MPU conjugation]
+    \label{def:mpu_finite_chain_conjugation}
+    \lean{SpinChain.finiteChainMPUUnitary,
+        SpinChain.finiteChainConjugation,
+        SpinChain.finiteChainConjugation_apply}
+    \leanok
+    \uses{def:mpu_finite_chain_realization}
+    If $\mathcal U$ is an MPU and $N>1$, then $U_a^{(N)}$ is unitary and
+    defines the star-algebra automorphism
+    \begin{align}
+        \operatorname{Ad}_{U_a^{(N)}}(B)
+         & =U_a^{(N)}B\,U_a^{(N)\dagger}.
+    \end{align}
+    The factor order is the one in
+    \cite[lines~2300--2306]{Cirac2017MPU}.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{def:mpu}
+    Simultaneous reindexing preserves both unitarity equations for $U^{(N)}$.
+    Conjugation by the resulting unitary preserves multiplication, the unit,
+    complex scalars, and the adjoint.
+\end{proof}
+
+\begin{definition}[Finite-chain term on a local observable]
+    \label{def:mpu_finite_chain_local_observable}
+    \lean{SpinChain.finiteChainLocalObservable,
+        SpinChain.finiteChainLocalObservable_apply}
+    \leanok
+    \uses{def:qca_local_inclusion, def:qca_algebraic_local_algebra,
+        def:mpu_finite_chain_conjugation}
+    Let $\Lambda\subseteq I_{a,N}$ and $A\in\mathcal A_\Lambda$.  Set
+    $A_L=\iota_{\Lambda,I_{a,N}}(A)$.  For $N>1$, the finite-chain term in
+    \cite[lines~2300--2306]{Cirac2017MPU} is the star-algebra map
+    \begin{align}
+        \mathcal A_\Lambda&\longrightarrow\mathcal A_{\mathrm{loc}}, \\
+        A&\longmapsto
+        \iota_{I_{a,N}}\!\left(U_a^{(N)}A_LU_a^{(N)\dagger}\right).
+    \end{align}
+    No stabilization in $N$ is asserted.
+\end{definition}
+
 \begin{definition}[Operator norm on the local algebra]
     \label{def:qca_algebraic_local_operator_norm}
     \lean{SpinChain.algebraicLocalOperatorNorm,


### PR DESCRIPTION
## What changed

- identify the length-$N$ interval $I_{a,N}=[a,a+N)\cap\mathbb Z$ with the periodic site set and reindex `mpo U N` to its configuration basis
- package the reindexed operator as a unitary for the paper's explicit hypothesis $N>1$
- define finite-chain conjugation and the local-observable star-algebra map with the exact formula $U^{(N)}A_LU^{(N)\dagger}$
- add formula-first Chapter 28 coverage for the finite-chain realization, conjugation, and local-observable term

This PR does not assert stabilization, a support bound, translation covariance, a quasi-local automorphism, or a QCA.

## Validation

- `lake build TNLean.MPS.MPU.FiniteChainConjugation`
- `lake build TNLean.MPS.MPU.FiniteChainConjugation TNLean.MPS.MPU` (post-rebase build progressed through the refreshed cone until the command timeout; the changed module had already passed)
- `lake build lint_style`
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD --warn-missing-blueprint --changed-files TNLean/MPS/MPU/FiniteChainConjugation.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with `TEXINPUTS="../../tex/tenkz//:"`, 913 pages and no undefined cross-references
- `git diff --check`

Closes #6924.
Advances #6027.
