### PR TITLE
feat(MPS/MPU): formalize open-leg two-site standard forms

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -39,6 +39,7 @@ import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCounterexample
 import TNLean.MPS.MPU.SourceVIsometry
+import TNLean.MPS.MPU.StandardForm
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.SuppliedWitnessReblocking
 import TNLean.MPS.MPU.TensorProduct

--- a/TNLean/MPS/MPU/StandardForm.lean
+++ b/TNLean/MPS/MPU/StandardForm.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPU.SourceUOpenTail
+
+/-!
+# Open-leg two-site equations for the MPU standard form
+
+This file records the two local factorizations behind the standard-form figure
+in arXiv:1703.09188. The first factors a two-site block through $X_1$, $u$, and
+$Y_2$. The reflected equation factors the same block through $X_2$, $v$, and
+$Y_1$, retaining the paper's reversed physical order `(j₂, j₁)` and source order
+`(r, l)` in $v$.
+
+These identities are purely algebraic. They do not assert that $u$ or $v$ is an
+isometry or a unitary, and they do not define the paper's standard-form package.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- The concrete two-site block factors through the paper's $X_1,u,Y_2$ form.
+The decoded ket and bra pairs retain the source tensor's row order `(l, r)`.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `uu`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem blockTwo_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i j : Fin (d * d)) (α γ : Fin D) :
+    blockTwo U i j α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        sourceX₁ U ρ hρ (α, (finProdFinEquiv.symm j).1) r *
+          sourceU U ρ hρ (l, r) (finProdFinEquiv.symm i) *
+            sourceY₂ U l ((finProdFinEquiv.symm j).2, γ) := by
+  exact mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair U ρ hρ
+    (finProdFinEquiv.symm i) (finProdFinEquiv.symm j) α γ
+
+/-- The reflected open two-site product factors through the paper's
+$X_2,v,Y_1$ form. The physical row of $v$ is explicitly `(j₂, j₁)`, and its
+source column is explicitly `(r, l)`.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `vdagger`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
+    (U i₁ j₁ * U i₂ j₂) α γ =
+      ∑ l : Fin ℓ[U], ∑ r : Fin r[U],
+        sourceX₂ U (α, i₁) l * sourceV U ρ hρ (j₂, j₁) (r, l) *
+          sourceY₁ U ρ hρ r (i₂, γ) := by
+  classical
+  simp only [Matrix.mul_apply]
+  have h₁ (β : Fin D) : U i₁ j₁ α β =
+      ∑ l : Fin ℓ[U], sourceX₂ U (α, i₁) l * sourceY₂ U l (j₁, β) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₂_mul_sourceY₂_apply U α i₁ j₁ β).symm
+  have h₂ (β : Fin D) : U i₂ j₂ β γ =
+      ∑ r : Fin r[U], sourceX₁ U ρ hρ (β, j₂) r *
+        sourceY₁ U ρ hρ r (i₂, γ) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₁_mul_sourceY₁_apply U ρ hρ β j₂ i₂ γ).symm
+  simp_rw [h₁, h₂, Finset.sum_mul_sum]
+  simp_rw [sourceV_apply, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  apply Finset.sum_congr rfl
+  intro β _
+  ring
+
+/-- The concrete two-site block in the reflected paper form $X_2,v,Y_1$.
+The standard product-index decoding exposes `(j₂, j₁)` and `(r, l)` without an
+implicit identification of either order.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `vdagger`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem blockTwo_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i j : Fin (d * d)) (α γ : Fin D) :
+    blockTwo U i j α γ =
+      ∑ l : Fin ℓ[U], ∑ r : Fin r[U],
+        sourceX₂ U (α, (finProdFinEquiv.symm i).1) l *
+          sourceV U ρ hρ
+            ((finProdFinEquiv.symm j).2, (finProdFinEquiv.symm j).1) (r, l) *
+            sourceY₁ U ρ hρ r ((finProdFinEquiv.symm i).2, γ) := by
+  exact mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁ U ρ hρ
+    (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1
+    (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2 α γ
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2453,7 +2453,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair,
         MPOTensor.blockTwo_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂}
     \leanok
-    \uses{def:mpu_source_uv, thm:mpu_source_factorization_entries}
+    \uses{def:mpu_source_uv, def:mpdo_two_site_blocking,
+        thm:mpu_source_factorization_entries}
     For $q=(q_1,q_2)$ and $j=(j_1,j_2)$, the untraced two-site product is
     \begin{align}
         (\mathcal U^{q_1j_1}\mathcal U^{q_2j_2})_{\alpha,\gamma}
@@ -2492,7 +2493,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁,
         MPOTensor.blockTwo_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁}
     \leanok
-    \uses{def:mpu_source_uv, thm:mpu_source_factorization_entries}
+    \uses{def:mpu_source_uv, def:mpdo_two_site_blocking,
+        thm:mpu_source_factorization_entries}
     The reflected factorization of the same untraced two-site product is
     \begin{align}
         (\mathcal U^{i_1j_1}\mathcal U^{i_2j_2})_{\alpha,\gamma}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2450,7 +2450,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_source_u_open_two_site}
     \lean{MPOTensor.sum_sourceX₁_mul_sourceU,
         MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂,
-        MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair}
+        MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair,
+        MPOTensor.blockTwo_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂}
     \leanok
     \uses{def:mpu_source_uv, thm:mpu_source_factorization_entries}
     For $q=(q_1,q_2)$ and $j=(j_1,j_2)$, the untraced two-site product is
@@ -2481,7 +2482,41 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     Substitution and reordering of the scalar finite sums give the displayed
     partial contraction and the untraced two-site identity, with the virtual
-    indices $\alpha$ and $\gamma$ left open.
+    indices $\alpha$ and $\gamma$ left open. Encoding both physical pairs by
+    the standard equivalence $\Fin d\times\Fin d\simeq\Fin(d^2)$ gives the
+    corresponding formula for the concrete two-site block.
+\end{proof}
+
+\begin{theorem}[Reflected open two-site source factorization]
+    \label{thm:mpu_source_v_open_two_site}
+    \lean{MPOTensor.mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁,
+        MPOTensor.blockTwo_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁}
+    \leanok
+    \uses{def:mpu_source_uv, thm:mpu_source_factorization_entries}
+    The reflected factorization of the same untraced two-site product is
+    \begin{align}
+        (\mathcal U^{i_1j_1}\mathcal U^{i_2j_2})_{\alpha,\gamma}
+        =\sum_{l,r}(X_2)_{(\alpha,i_1),l}
+        v_{(j_2,j_1),(r,l)}(Y_1)_{r,(i_2,\gamma)}.
+    \end{align}
+    Thus the physical row of $v$ is $(j_2,j_1)$, while its source column is
+    $(r,l)$. Both orders remain explicit in the formula for the concrete
+    two-site block under $\Fin d\times\Fin d\simeq\Fin(d^2)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_source_uv, thm:mpu_source_factorization_entries}
+    Expand the first tensor letter through $M_2=X_2Y_2$ and the second through
+    $M_1=X_1Y_1$. Then
+    \begin{align}
+        \sum_\beta
+        (X_2)_{(\alpha,i_1),l}(Y_2)_{l,(j_1,\beta)}
+        (X_1)_{(\beta,j_2),r}(Y_1)_{r,(i_2,\gamma)}
+        = (X_2)_{(\alpha,i_1),l}
+        v_{(j_2,j_1),(r,l)}(Y_1)_{r,(i_2,\gamma)}.
+    \end{align}
+    Summing over $l$ and $r$ gives the result. The two-site block statement
+    follows by decoding its ket and bra indices into ordered pairs.
 \end{proof}
 
 \begin{theorem}[Open periodic-tail source expansion]
@@ -4610,7 +4645,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{SF}
     \notready
     \discussion{6019}
-    \uses{ThmFund1, def:mpu_source_uv}
+    \uses{ThmFund1, def:mpu_source_uv, thm:mpu_source_u_open_two_site,
+        thm:mpu_source_v_open_two_site}
     Let $\mathcal U$ be a simple tensor under the source's standing
     canonical-form-II convention. Its standard form is the depth-two form of
     the two-site block $\mathcal U_2$ determined by the source unitaries $u$ and


### PR DESCRIPTION
## What changed

- add the open-leg source-$u$ factorization for `blockTwo`, with the decoded physical pair and the $(l,r)$ source row explicit
- prove the reflected $X_2$-$v$-$Y_1$ factorization with the paper's printed $(j_2,j_1)$ physical reversal and $(r,l)$ source order, plus its concrete `blockTwo` form
- add only these algebraic dependencies to Chapter 28 and retain `SF` as `\notready`
- add the generated MPU import for the new `StandardForm` module

No source isometry, unitarity, or public standard-form package is asserted.

## Validation

After rebasing exact head `4f38c5050a7614046836b69644d49f8f00ae719d` onto `6177c502250015084aadc1ebff921d571ae2b132`, which includes QICLean v0.1.2:

- `lake build TNLean.MPS.MPU.StandardForm TNLean.MPS.MPU` passed, 9126 jobs
- style and proof-integrity checks passed
- generated-import tests and freshness check passed
- Blueprint source synchronization and changed-declaration coverage passed
- Blueprint compiled twice with no undefined cross-references; standalone citation warnings remain
- `git diff --check` passed and the worktree is clean

Closes #6925.
Advances #6019.
