### PR TITLE
feat(MPS/MPU): prove source-index additivity

### DIFF
--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -34,6 +34,8 @@ of the chosen simple blocking, is not asserted here.
 
 * `MPOTensor.sourceIndexValue_eq_of_common_rank_scale`: cancellation of a
   supplied common positive rank scale.
+* `MPOTensor.sourceIndexValue_eq_add_of_common_rank_product`: additivity from
+  supplied source-rank product identities with a common positive factor.
 * `MPOTensor.sourceIndexValue_eq_logb_rightRank_div`: the right-rank formula
   under a supplied rank-product equality.
 * `MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div`: the left-rank formula
@@ -42,7 +44,7 @@ of the chosen simple blocking, is not asserted here.
 
 namespace MPOTensor
 
-variable {d D e E : ℕ}
+variable {d D e E f F : ℕ}
 
 /-- The source-index value of a specified tensor with positive right and left
 source-cut ranks:
@@ -73,6 +75,39 @@ theorem sourceIndexValue_eq_of_common_rank_scale
   have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hrU.ne'
   have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU.ne'
   rw [Real.logb_mul hcReal hrReal, Real.logb_mul hcReal hℓReal]
+  ring
+
+/-- Suppose the right and left source ranks of specified tensors $U$, $V$, and
+$W$ satisfy
+$$
+r[W] = c\,r[U]r[V], \qquad \ell[W] = c\,\ell[U]\ell[V]
+$$
+for a positive natural number $c$. Then the base-$2$ source-index value of $W$
+is the sum of those of $U$ and $V$.
+
+This is the logarithmic cancellation in arXiv:1703.09188, Theorem `IndexTh`
+(ii), lines 837--845. It is a specified-tensor logarithmic cancellation lemma,
+not the public blocking-independent MPU index. -/
+theorem sourceIndexValue_eq_add_of_common_rank_product
+    (U : MPOTensor d D) (V : MPOTensor e E) (W : MPOTensor f F)
+    (c : ℕ) (hc : 0 < c)
+    (hrU : 0 < r[U]) (hℓU : 0 < ℓ[U])
+    (hrV : 0 < r[V]) (hℓV : 0 < ℓ[V])
+    (hrW : 0 < r[W]) (hℓW : 0 < ℓ[W])
+    (hr : r[W] = c * r[U] * r[V]) (hℓ : ℓ[W] = c * ℓ[U] * ℓ[V]) :
+    sourceIndexValue W hrW hℓW =
+      sourceIndexValue U hrU hℓU + sourceIndexValue V hrV hℓV := by
+  rw [sourceIndexValue, sourceIndexValue, sourceIndexValue, hr, hℓ,
+    Nat.cast_mul, Nat.cast_mul, Nat.cast_mul, Nat.cast_mul]
+  have hcReal : (c : ℝ) ≠ 0 := by exact_mod_cast hc.ne'
+  have hrUReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hrU.ne'
+  have hℓUReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU.ne'
+  have hrVReal : (r[V] : ℝ) ≠ 0 := by exact_mod_cast hrV.ne'
+  have hℓVReal : (ℓ[V] : ℝ) ≠ 0 := by exact_mod_cast hℓV.ne'
+  rw [Real.logb_mul (mul_ne_zero hcReal hrUReal) hrVReal,
+    Real.logb_mul hcReal hrUReal,
+    Real.logb_mul (mul_ne_zero hcReal hℓUReal) hℓVReal,
+    Real.logb_mul hcReal hℓUReal]
   ring
 
 /-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is positive, then

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4721,6 +4721,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{theorem}[Auxiliary source-index identities]
     \label{thm:mpu_specified_source_index_identities}
     \lean{MPOTensor.sourceIndexValue_eq_of_common_rank_scale,
+        MPOTensor.sourceIndexValue_eq_add_of_common_rank_product,
         MPOTensor.sourceIndexValue_eq_logb_rightRank_div,
         MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div}
     \leanok
@@ -4736,6 +4737,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \operatorname{ind}_{\mathrm{src}}(\mathcal V)
          & =\operatorname{ind}_{\mathrm{src}}(\mathcal U).
     \end{align}
+    Let $\mathcal U$, $\mathcal V$, and $\mathcal W$ instead have positive
+    source ranks and suppose that
+    \begin{align}
+        r_{\mathcal W} & =c r_{\mathcal U}r_{\mathcal V}, \\
+        \ell_{\mathcal W} & =c\ell_{\mathcal U}\ell_{\mathcal V}.
+    \end{align}
+    for a positive $c$. Then
+    \begin{align}
+        \operatorname{ind}_{\mathrm{src}}(\mathcal W)
+         & =\operatorname{ind}_{\mathrm{src}}(\mathcal U)
+          +\operatorname{ind}_{\mathrm{src}}(\mathcal V).
+    \end{align}
     If $d$, $r_{\mathcal U}$, and $\ell_{\mathcal U}$ are positive and a
     specified tensor has $r_{\mathcal U}\ell_{\mathcal U}=d^2$, then
     \begin{align}
@@ -4743,16 +4756,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\log_2\frac{r_{\mathcal U}}d
         =-\log_2\frac{\ell_{\mathcal U}}d.
     \end{align}
-    % Auxiliary to paper_v2.tex lines 681--704; issue 6255.
+    % Auxiliary to paper_v2.tex lines 681--704 and IndexTh lines 837--845;
+    % issues 6255 and 6923.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpu_specified_source_index_value}
     Expand the definition. For common scaling, apply
     $\log_2(cx)=\log_2c+\log_2x$ to both ranks and cancel the two copies of
-    $\log_2c$. For the equivalent formulas, apply the same product identity to
-    $r_{\mathcal U}\ell_{\mathcal U}=d^2$ and use
-    $\log_2(x/y)=\log_2x-\log_2y$.
+    $\log_2c$. For the three-tensor identity, apply the product formula twice
+    to each rank and cancel the common term. For the equivalent formulas,
+    apply the same product identity to $r_{\mathcal U}\ell_{\mathcal U}=d^2$
+    and use $\log_2(x/y)=\log_2x-\log_2y$.
 \end{proof}
 
 \begin{definition}[Index]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4743,7 +4743,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         r_{\mathcal W} & =c r_{\mathcal U}r_{\mathcal V}, \\
         \ell_{\mathcal W} & =c\ell_{\mathcal U}\ell_{\mathcal V}.
     \end{align}
-    for a positive $c$. Then
+    where $c$ is a positive integer. Then
     \begin{align}
         \operatorname{ind}_{\mathrm{src}}(\mathcal W)
          & =\operatorname{ind}_{\mathrm{src}}(\mathcal U)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4741,7 +4741,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     source ranks and suppose that
     \begin{align}
         r_{\mathcal W} & =c r_{\mathcal U}r_{\mathcal V}, \\
-        \ell_{\mathcal W} & =c\ell_{\mathcal U}\ell_{\mathcal V}.
+        \ell_{\mathcal W} & =c\ell_{\mathcal U}\ell_{\mathcal V},
     \end{align}
     where $c$ is a positive integer. Then
     \begin{align}


### PR DESCRIPTION
## What changed

- add `MPOTensor.sourceIndexValue_eq_add_of_common_rank_product` for specified tensors with supplied positive source ranks and the identities `r[W] = c * r[U] * r[V]` and `ℓ[W] = c * ℓ[U] * ℓ[V]`
- prove the exact base-2 logarithmic cancellation with `Real.logb_mul`
- extend the existing Chapter 28 auxiliary source-index identity node, while keeping the public blocking-independent MPU index explicitly out of scope

The statement follows the logarithmic step in `paper_v2.tex`, `IndexTh` (ii), lines 837--845. It adds no MPU, simplicity, standard-form, composition, or blocking hypotheses.

## Validation

After rebasing exact head `c03f4606da6dbafa36c6479c17ce10f482208ae5` onto `6177c502250015084aadc1ebff921d571ae2b132`, which includes QICLean v0.1.2:

- `lake build TNLean.MPS.MPU.SourceIndexValue` passed, 2725 jobs
- style and proof-integrity checks passed
- Blueprint source synchronization passed, with Chapter 28 at 643/643
- Blueprint compiled twice with no undefined cross-references; standalone citation warnings remain
- `git diff --check` passed and the worktree is clean

Closes #6923.
Advances #6016.
