### PR TITLE
doc(paper-gaps): replace \date{\today} with the authored dates

### DIFF
--- a/docs/paper-gaps/dccsp17_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/dccsp17_normal_canonical_irreducible_form_weights.tex
@@ -8,7 +8,7 @@
 
 \title{Phase-Normalized Weights in the Normal-Canonical Implication to Irreducible Form}
 \author{}
-\date{\today}
+\date{2026-06-17}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/knabe88_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe88_finite_range_coefficient.tex
@@ -9,7 +9,7 @@
 
 \title{The Finite-Range Cyclic Knabe Coefficient}
 \author{}
-\date{\today}
+\date{2026-08-17}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
+++ b/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
@@ -9,7 +9,7 @@
 \title{Scope Note: The AKLT On-Site $\mathrm{SO}(3)$ Symmetry Is Formalized;
 Its Cohomological Classification Is Not}
 \author{}
-\date{\today}
+\date{2026-06-04}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
The paper-gaps index shows every note dated 2026-08-22 because the date column preferred git last-modified and #6879 renamed every note file today. texra-blueprint v0.3.7 fixes the column to prefer the authored `\date` — this PR fixes the three TNLean notes whose date was a floating `\today` (true dates recovered via `git log --follow` across the renames: dccsp17 → 2026-06-17, knabe88 → 2026-08-17, rmp_aklt → 2026-06-04). The QICLean counterpart PR handles its nine `\today` notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4