### PR TITLE
ci(blueprint): pin texra-blueprint v0.3.7

### DIFF
--- a/.github/allowed-tools.json
+++ b/.github/allowed-tools.json
@@ -1,7 +1,7 @@
 {
   "lean-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-review-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),Bash(gh pr *),Bash(gh api *),mcp__github__*",
-  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.6),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
+  "blueprint-auto-fix": "Edit,Write,Read,Glob,Grep,Bash(pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.7),Bash(cd blueprint && leanblueprint *),Bash(leanblueprint *),Bash(python3 scripts/*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git diff *),Bash(git status),mcp__github__*",
   "lean-linter-warning-auto-fix": "Read,Edit,Glob,Grep,Bash(python3 *),Bash(lake build),Bash(lake build *),Bash(lake env),Bash(lake env *),Bash(git diff *),Bash(git status),Bash(grep *),Bash(rg *)",
   "claude-interactive": "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *),mcp__github__*",
   "blueprint-prose-review": "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(grep *),mcp__github__*",

--- a/.github/prompts/auto-fix-blueprint-prompt.md
+++ b/.github/prompts/auto-fix-blueprint-prompt.md
@@ -15,7 +15,7 @@ Instructions:
 3. The blueprint `.tex` files are in `blueprint/src/chapter/`. The blueprint configuration is in `blueprint/src/`.
 4. You can test your fix locally by running:
 
-   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.6`
+   - `pip install leanblueprint plastex git+https://github.com/LionSR/texra-blueprint@v0.3.7`
    - `cd blueprint && leanblueprint web`
 
    Check that no `ERROR` lines appear in the output.

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Run mentioned agent
         id: agent

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Check native tenkz sources and picture pipeline
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -777,7 +777,7 @@ jobs:
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
         uses: texra-ai/lean-env-action/leanblueprint@v1
         with:
-          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+          extra-pip-packages: 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 
       - name: Lint tenkz picture sources
         if: env.TEX_CHANGED == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ rg -n "sorry|axiom" TNLean/Path/To/File.lean || true
 
 # Blueprint validation. Requires leanblueprint plus the pinned shared
 # plasTeX plugin (blueprint/src/plastex.cfg loads it unconditionally):
-#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.6'
+#   pip install leanblueprint 'git+https://github.com/LionSR/texra-blueprint@v0.3.7'
 # Run after lake build succeeds.
 cd blueprint && leanblueprint checkdecls
 


### PR DESCRIPTION
Sweeps every `texra-blueprint@v0.3.6` pin to v0.3.7 — the release whose paper-gaps index date column prefers the authored `\date` over git last-modified (the wolf-notes migration reset the git dates). Seven pin sites, no other change:

- `.github/workflows/agent-mention.yml`
- `.github/workflows/blueprint.yml`
- `.github/workflows/docgen.yml`
- `.github/workflows/pr-ci.yml`
- `.github/allowed-tools.json`
- `.github/prompts/auto-fix-blueprint-prompt.md`
- `CLAUDE.md`

All four touched workflows pass `yaml.safe_load`; the repo greps clean of v0.3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4