### PR TITLE
feat(MPS/MPU): define strict equivalence under symmetry

### DIFF
--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.MPU.PhysicalAncilla
 
 This file formalizes strict equivalence and equivalence after attaching physical
 identity ancillas and then blocking, following arXiv:1703.09188, lines 706--724.
-It also formalizes the symmetry-preserving versions from lines 1345--1364.
+It also formalizes strict equivalence under symmetry from lines 1340--1354.
 
 The virtual bond dimension is fixed along every path. The source does not specify
 a stabilization that compares tensors of different virtual bond dimensions, so
@@ -26,8 +26,6 @@ only the canonical-form condition from the paper is omitted along the path.
   attachment and a common positive blocking length.
 * `MPOTensor.FiniteChainOperatorSymmetry`: an operator action at specified chain lengths.
 * `MPOTensor.StrictlyEquivalentUnderSymmetry`: strict equivalence through invariant MPUs.
-* `MPOTensor.EquivalentUnderSymmetry`: symmetry-preserving equivalence after ancillas
-  and blocking.
 -/
 
 namespace MPOTensor
@@ -41,8 +39,8 @@ The action is defined for every physical dimension, but no continuity, linearity
 or compatibility between different chain lengths is assumed at this abstract
 level.
 
-Source: arXiv:1703.09188, Definitions `def:strictly-equivalent-symmetry` and
-`def:equivalent-symmetry`, lines 1345--1364. -/
+Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
+lines 1345--1354. -/
 structure FiniteChainOperatorSymmetry where
   applicable : Set ℕ
   action : {d N : ℕ} →
@@ -88,11 +86,13 @@ def StrictlyEquivalent (U : MPOTensor da D) (V : MPOTensor db D)
 `S` when they are joined by a continuous path of MPUs invariant under `S` at
 every applicable chain length.
 
+Lines 1340--1343 introduce this definition in full analogy with
+`def:strictly-equivalent-tensors`, whose endpoints are in canonical form.
 Canonical form is required only at the endpoints. The physical dimension is
 identified explicitly, and the virtual bond dimension remains fixed along the
 path.
 
-**Scope restriction (arXiv:1703.09188, lines 1345--1364):** the paper does not
+**Scope restriction (arXiv:1703.09188, lines 1340--1354):** the paper does not
 specify a stabilization for unequal raw virtual bond dimensions, so this
 definition only compares tensors in one fixed ambient bond dimension. See
 `docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
@@ -146,40 +146,5 @@ def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
             (blockTensor (tensorPhysicalId U pa) k)
             (blockTensor (tensorPhysicalId V pb) k)
             (blockedAncillaPhysicalDim_eq k hphys)
-
-/-- Two fixed-bond MPU tensors are equivalent under `S` when positive coprime
-identity ancillas equalize their physical dimensions and a common positive
-blocking makes the enlarged tensors strictly equivalent under `S`.
-
-Ancillas are attached before blocking. The virtual bond dimension is unchanged.
-
-**Scope restriction (arXiv:1703.09188, lines 1345--1364):** the bond dimension
-\(D\) is fixed. No heterogeneous raw-bond stabilization is asserted. See
-`docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
-
-Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`,
-lines 1356--1364. -/
-def EquivalentUnderSymmetry (S : FiniteChainOperatorSymmetry)
-    (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
-  IsMPU U ∧ IsMPU V ∧
-    ∃ k pa pb : ℕ,
-      0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
-        ∃ hphys : pa * da = pb * db,
-          StrictlyEquivalentUnderSymmetry S
-            (blockTensor (tensorPhysicalId U pa) k)
-            (blockTensor (tensorPhysicalId V pb) k)
-            (blockedAncillaPhysicalDim_eq k hphys)
-
-/-- Forgetting symmetry invariance from a stabilized symmetry-preserving path
-gives ordinary MPU equivalence.
-
-Source: arXiv:1703.09188, Definitions `def:equivalent-tensors` and
-`def:equivalent-symmetry`, lines 716--724 and 1356--1364. -/
-theorem EquivalentUnderSymmetry.toEquivalent {S : FiniteChainOperatorSymmetry}
-    {U : MPOTensor da D} {V : MPOTensor db D}
-    (h : EquivalentUnderSymmetry S U V) : Equivalent U V := by
-  rcases h with ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys, hstrict⟩
-  exact ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys,
-    hstrict.toStrictlyEquivalent⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -37,7 +37,7 @@ variable {da db D : ℕ}
 /-- A finite-chain operator symmetry consists of an action on every finite-chain
 operator space and a set of chain lengths on which that action is imposed.
 
-The action is uniform in the physical dimension but no continuity, linearity,
+The action is defined for every physical dimension, but no continuity, linearity,
 or compatibility between different chain lengths is assumed at this abstract
 level.
 
@@ -91,6 +91,11 @@ every applicable chain length.
 Canonical form is required only at the endpoints. The physical dimension is
 identified explicitly, and the virtual bond dimension remains fixed along the
 path.
+
+**Scope restriction (arXiv:1703.09188, lines 1345--1364):** the paper does not
+specify a stabilization for unequal raw virtual bond dimensions, so this
+definition only compares tensors in one fixed ambient bond dimension. See
+`docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
 
 Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
 lines 1345--1354. -/
@@ -147,6 +152,10 @@ identity ancillas equalize their physical dimensions and a common positive
 blocking makes the enlarged tensors strictly equivalent under `S`.
 
 Ancillas are attached before blocking. The virtual bond dimension is unchanged.
+
+**Scope restriction (arXiv:1703.09188, lines 1345--1364):** the bond dimension
+\(D\) is fixed. No heterogeneous raw-bond stabilization is asserted. See
+`docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
 
 Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`,
 lines 1356--1364. -/

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -12,6 +12,7 @@ import TNLean.MPS.MPU.PhysicalAncilla
 
 This file formalizes strict equivalence and equivalence after attaching physical
 identity ancillas and then blocking, following arXiv:1703.09188, lines 706--724.
+It also formalizes the symmetry-preserving versions from lines 1345--1364.
 
 The virtual bond dimension is fixed along every path. The source does not specify
 a stabilization that compares tensors of different virtual bond dimensions, so
@@ -23,11 +24,44 @@ only the canonical-form condition from the paper is omitted along the path.
 * `MPOTensor.StrictlyEquivalent`: path connectedness inside the fixed-bond MPU locus.
 * `MPOTensor.Equivalent`: strict equivalence after positive identity-ancilla
   attachment and a common positive blocking length.
+* `MPOTensor.FiniteChainOperatorSymmetry`: an operator action at specified chain lengths.
+* `MPOTensor.StrictlyEquivalentUnderSymmetry`: strict equivalence through invariant MPUs.
+* `MPOTensor.EquivalentUnderSymmetry`: symmetry-preserving equivalence after ancillas
+  and blocking.
 -/
 
 namespace MPOTensor
 
 variable {da db D : ℕ}
+
+/-- A finite-chain operator symmetry consists of an action on every finite-chain
+operator space and a set of chain lengths on which that action is imposed.
+
+The action is uniform in the physical dimension but no continuity, linearity,
+or compatibility between different chain lengths is assumed at this abstract
+level.
+
+Source: arXiv:1703.09188, Definitions `def:strictly-equivalent-symmetry` and
+`def:equivalent-symmetry`, lines 1345--1364. -/
+structure FiniteChainOperatorSymmetry where
+  applicable : Set ℕ
+  action : {d N : ℕ} →
+    Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ →
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ
+
+/-- A matrix product operator tensor is invariant under a finite-chain symmetry
+when every applicable periodic operator satisfies
+\(\mathcal S[W^{(N)}]=W^{(N)}\).
+
+**Local fix (arXiv:1703.09188, line 1353):** the displayed source equation
+repeats the transformed operator on both sides. The intended right-hand side is
+the original operator. See `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+
+Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
+lines 1345--1354. -/
+def IsInvariantUnderSymmetry (S : FiniteChainOperatorSymmetry)
+    (W : MPOTensor da D) : Prop :=
+  ∀ ⦃N : ℕ⦄, N ∈ S.applicable → S.action (mpo W N) = mpo W N
 
 /-- Two fixed-bond MPU tensors in canonical form are strictly equivalent when,
 after explicitly identifying their physical dimensions, they are joined by a
@@ -49,6 +83,34 @@ def StrictlyEquivalent (U : MPOTensor da D) (V : MPOTensor db D)
     MPSTensor.IsMPUCanonicalForm V.toMPSTensor ∧
       JoinedIn {W : MPOTensor db D | IsMPU W}
         (reindexPhysical (finCongr hphys).symm U) V
+
+/-- Two fixed-bond canonical-form MPU tensors are strictly equivalent under
+`S` when they are joined by a continuous path of MPUs invariant under `S` at
+every applicable chain length.
+
+Canonical form is required only at the endpoints. The physical dimension is
+identified explicitly, and the virtual bond dimension remains fixed along the
+path.
+
+Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
+lines 1345--1354. -/
+def StrictlyEquivalentUnderSymmetry (S : FiniteChainOperatorSymmetry)
+    (U : MPOTensor da D) (V : MPOTensor db D) (hphys : da = db) : Prop :=
+  MPSTensor.IsMPUCanonicalForm U.toMPSTensor ∧
+    MPSTensor.IsMPUCanonicalForm V.toMPSTensor ∧
+      JoinedIn {W : MPOTensor db D | IsMPU W ∧ IsInvariantUnderSymmetry S W}
+        (reindexPhysical (finCongr hphys).symm U) V
+
+/-- Forgetting symmetry invariance from a strict symmetry-preserving path gives
+ordinary strict equivalence.
+
+Source: arXiv:1703.09188, Definitions `def:strictly-equivalent-tensors` and
+`def:strictly-equivalent-symmetry`, lines 708--714 and 1345--1354. -/
+theorem StrictlyEquivalentUnderSymmetry.toStrictlyEquivalent
+    {S : FiniteChainOperatorSymmetry} {U : MPOTensor da D} {V : MPOTensor db D}
+    {hphys : da = db} (h : StrictlyEquivalentUnderSymmetry S U V hphys) :
+    StrictlyEquivalent U V hphys :=
+  ⟨h.1, h.2.1, h.2.2.mono fun _ hW ↦ hW.1⟩
 
 private theorem blockedAncillaPhysicalDim_eq (k : ℕ) {pa pb : ℕ}
     (hphys : pa * da = pb * db) :
@@ -79,5 +141,36 @@ def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
             (blockTensor (tensorPhysicalId U pa) k)
             (blockTensor (tensorPhysicalId V pb) k)
             (blockedAncillaPhysicalDim_eq k hphys)
+
+/-- Two fixed-bond MPU tensors are equivalent under `S` when positive coprime
+identity ancillas equalize their physical dimensions and a common positive
+blocking makes the enlarged tensors strictly equivalent under `S`.
+
+Ancillas are attached before blocking. The virtual bond dimension is unchanged.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`,
+lines 1356--1364. -/
+def EquivalentUnderSymmetry (S : FiniteChainOperatorSymmetry)
+    (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
+  IsMPU U ∧ IsMPU V ∧
+    ∃ k pa pb : ℕ,
+      0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
+        ∃ hphys : pa * da = pb * db,
+          StrictlyEquivalentUnderSymmetry S
+            (blockTensor (tensorPhysicalId U pa) k)
+            (blockTensor (tensorPhysicalId V pb) k)
+            (blockedAncillaPhysicalDim_eq k hphys)
+
+/-- Forgetting symmetry invariance from a stabilized symmetry-preserving path
+gives ordinary MPU equivalence.
+
+Source: arXiv:1703.09188, Definitions `def:equivalent-tensors` and
+`def:equivalent-symmetry`, lines 716--724 and 1356--1364. -/
+theorem EquivalentUnderSymmetry.toEquivalent {S : FiniteChainOperatorSymmetry}
+    {U : MPOTensor da D} {V : MPOTensor db D}
+    (h : EquivalentUnderSymmetry S U V) : Equivalent U V := by
+  rcases h with ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys, hstrict⟩
+  exact ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys,
+    hstrict.toStrictlyEquivalent⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6445,24 +6445,60 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \subsection{Equivalence under symmetries}
 
+\begin{definition}[Finite-chain operator symmetry]
+    \label{def:mpu_finite_chain_operator_symmetry}
+    \lean{MPOTensor.FiniteChainOperatorSymmetry,
+        MPOTensor.IsInvariantUnderSymmetry}
+    \leanok
+    A finite-chain operator symmetry $\mathcal S$ specifies a set $A$ of
+    applicable chain lengths and, for every physical dimension $d$ and length
+    $N$, a map
+    \begin{align}
+        \mathcal S_{d,N}\colon
+        \operatorname{Mat}_{d^N}(\mathbb C)
+        &\longrightarrow \operatorname{Mat}_{d^N}(\mathbb C).
+    \end{align}
+    An MPO tensor $\mathcal W$ is invariant under $\mathcal S$ if
+    \begin{align}
+        \mathcal S_{d,N}[W^{(N)}] & =W^{(N)}
+    \end{align}
+    for every $N\in A$.
+    % Source lines: paper_v2.tex 1345--1354.
+\end{definition}
+
 \begin{definition}[Strict equivalence under a symmetry]
     \label{def:strictly-equivalent-symmetry}
-    \notready
-    \discussion{6017}
-    \uses{def:strictly-equivalent-tensors}
+    \lean{MPOTensor.StrictlyEquivalentUnderSymmetry}
+    \leanok
+    \discussion{6948}
+    \uses{def:strictly-equivalent-tensors, def:mpu_finite_chain_operator_symmetry}
     % **Local fix:** paper_v2.tex 1345--1353 repeats the symmetry-transformed
     % operator on the right-hand side. Invariance requires the original MPU.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    Two tensors $\mathcal U$ and $\mathcal V$ are strictly equivalent under a
-    symmetry $\mathcal S$ if they have the same physical dimension and there is
-    a continuous path $\mathcal W(p)$ of MPU tensors from $\mathcal U$ to
-    $\mathcal V$, not necessarily in canonical form, such that
+    Fix a virtual bond dimension $D$. Two canonical-form tensors $\mathcal U$
+    and $\mathcal V$ are strictly equivalent under a symmetry $\mathcal S$ if
+    they have the same physical dimension and there is a continuous path
+    $\mathcal W(p)$ of fixed-bond MPU tensors from $\mathcal U$ to $\mathcal V$,
+    not necessarily in canonical form, such that
     \begin{align}
         \mathcal S[W^{(N)}(p)] & =W^{(N)}(p)
     \end{align}
-    for every $p\in[0,1]$ and every chain length under consideration.
+    for every $p\in[0,1]$ and every applicable chain length $N$.
     % Source lines: paper_v2.tex 1340--1354.
 \end{definition}
+
+\begin{lemma}[Forgetting symmetry from strict equivalence]
+    \label{lem:mpu_strict_symmetry_equivalence_forget}
+    \lean{MPOTensor.StrictlyEquivalentUnderSymmetry.toStrictlyEquivalent}
+    \leanok
+    \uses{def:strictly-equivalent-symmetry, def:strictly-equivalent-tensors}
+    Strict equivalence under a symmetry implies strict equivalence.
+\end{lemma}
+
+\begin{proof}\leanok
+    The same path lies in the larger locus obtained by forgetting invariance
+    under $\mathcal S$.
+\end{proof}
 
 \begin{definition}[Admissible strict equivalence under a symmetry]
     \label{def:mpu_admissible_strict_symmetry_equivalence}
@@ -6487,16 +6523,37 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Equivalence under a symmetry]
     \label{def:equivalent-symmetry}
-    \notready
-    \discussion{6017}
+    \lean{MPOTensor.EquivalentUnderSymmetry}
+    \leanok
+    \discussion{6948}
     \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors}
-    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
-    $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a
-    positive blocking length $k$ and coprime positive ancilla dimensions
-    $p_a,p_b$ with $p_ad_a=p_bd_b$ such that $(\mathcal U^{(p_a)})_k$ and
-    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under $\mathcal S$.
+    Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be MPU
+    tensors with physical dimensions $d_a$ and $d_b$. They are equivalent under
+    a symmetry $\mathcal S$ if there are a positive blocking length $k$ and
+    coprime positive ancilla dimensions $p_a,p_b$ with
+    \begin{align}
+        p_a d_a & =p_b d_b
+    \end{align}
+    such that $(\mathcal U^{(p_a)})_k$ and $(\mathcal V^{(p_b)})_k$ are strictly
+    equivalent under $\mathcal S$. Identity ancillas are attached before the
+    common blocking, and the virtual bond dimension remains fixed.
     % Source lines: paper_v2.tex 1356--1364.
 \end{definition}
+
+\begin{lemma}[Forgetting symmetry after blocking and ancillas]
+    \label{lem:mpu_symmetry_equivalence_forget}
+    \lean{MPOTensor.EquivalentUnderSymmetry.toEquivalent}
+    \leanok
+    \uses{def:equivalent-symmetry, def:equivalent-tensors,
+        lem:mpu_strict_symmetry_equivalence_forget}
+    Equivalence under a symmetry implies equivalence.
+\end{lemma}
+
+\begin{proof}\leanok
+    Keep the same blocking length, ancilla dimensions, and physical-dimension
+    equality, then forget symmetry from the strict equivalence of the enlarged
+    tensors.
+\end{proof}
 
 \begin{definition}[Admissible equivalence under a symmetry]
     \label{def:mpu_admissible_symmetry_equivalence}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6458,7 +6458,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \operatorname{Mat}_{d^N}(\mathbb C)
         &\longrightarrow \operatorname{Mat}_{d^N}(\mathbb C).
     \end{align}
-    An MPO tensor $\mathcal W$ is invariant under $\mathcal S$ if
+    We suppress the subscripts on $\mathcal S_{d,N}$ when $d$ and $N$ are
+    understood. An MPO tensor $\mathcal W$ is invariant under $\mathcal S$ if
     \begin{align}
         \mathcal S_{d,N}[W^{(N)}] & =W^{(N)}
     \end{align}
@@ -6523,37 +6524,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Equivalence under a symmetry]
     \label{def:equivalent-symmetry}
-    \lean{MPOTensor.EquivalentUnderSymmetry}
-    \leanok
-    \discussion{6948}
+    \notready
+    \discussion{6017}
     \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors}
-    Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be MPU
-    tensors with physical dimensions $d_a$ and $d_b$. They are equivalent under
-    a symmetry $\mathcal S$ if there are a positive blocking length $k$ and
-    coprime positive ancilla dimensions $p_a,p_b$ with
-    \begin{align}
-        p_a d_a & =p_b d_b
-    \end{align}
-    such that $(\mathcal U^{(p_a)})_k$ and $(\mathcal V^{(p_b)})_k$ are strictly
-    equivalent under $\mathcal S$. Identity ancillas are attached before the
-    common blocking, and the virtual bond dimension remains fixed.
+    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
+    $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a
+    positive blocking length $k$ and coprime positive ancilla dimensions
+    $p_a,p_b$ with $p_ad_a=p_bd_b$ such that $(\mathcal U^{(p_a)})_k$ and
+    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under $\mathcal S$.
     % Source lines: paper_v2.tex 1356--1364.
 \end{definition}
-
-\begin{lemma}[Forgetting symmetry after blocking and ancillas]
-    \label{lem:mpu_symmetry_equivalence_forget}
-    \lean{MPOTensor.EquivalentUnderSymmetry.toEquivalent}
-    \leanok
-    \uses{def:equivalent-symmetry, def:equivalent-tensors,
-        lem:mpu_strict_symmetry_equivalence_forget}
-    Equivalence under a symmetry implies equivalence.
-\end{lemma}
-
-\begin{proof}\leanok
-    Keep the same blocking length, ancilla dimensions, and physical-dimension
-    equality, then forget symmetry from the strict equivalence of the enlarged
-    tensors.
-\end{proof}
 
 \begin{definition}[Admissible equivalence under a symmetry]
     \label{def:mpu_admissible_symmetry_equivalence}


### PR DESCRIPTION
## What changed

- define a finite-chain operator symmetry together with its applicable chain lengths
- formalize the corrected invariance equation $\mathcal S[W^{(N)}]=W^{(N)}$
- add fixed-bond strict MPU equivalence under symmetry
- add the forgetful theorem to the existing nonsymmetric strict relation
- synchronize the completed Chapter 28 strict definition while leaving stabilized equivalence and the standard-form path criterion unready

## Scope

This implements `def:strictly-equivalent-symmetry` from arXiv:1703.09188, lines 1340--1354. The canonical-form endpoint interpretation follows the source's stated full analogy with `def:strictly-equivalent-tensors`; the interior path need not be canonical.

Review exposed a separate source-level obligation for `def:equivalent-symmetry`: the original symmetry must be induced through identity ancillas and blocking, with chain lengths pulled back to multiples of the blocking length and operators reindexed between the original and blocked physical spaces. The PR deliberately leaves that node `\notready` rather than passing unrelated action components through blocking. It also does not add admissible variants, the standard-form characterization, source-unitarity claims, `FundamentalMPU`, `coruvSF`, or continuous source-factor choices.

## Validation

- `lake build TNLean.MPS.MPU.Equivalence` (`9000/9000`)
- Blueprint source sync (`6615/6615`)
- Blueprint compiled twice with `TEXINPUTS="../../tex/tenkz//:"`; 0 undefined references
- `git diff --check origin/main...HEAD`
- exact-head specialist review: no blocking findings

Closes #6948
Advances #6017
Advances #5704
