### PR TITLE
feat(QCA): add finite-region site blocking

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.QCA
 
 import TNLean.QCA.AlgebraicTranslation
+import TNLean.QCA.Blocking
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation
 import TNLean.QCA.InversePropagation

--- a/TNLean/QCA/Blocking.lean
+++ b/TNLean/QCA/Blocking.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Logic.Equiv.Fin.Basic
+import TNLean.MPS.Core.Blocking
+import TNLean.QCA.LocalAlgebra
+
+/-!
+# Blocking sites in a one-dimensional spin chain
+
+For a positive block length `L`, this file groups the consecutive original sites
+`L * x, ..., L * x + L - 1` into the blocked site `x`.  It constructs the expanded original
+region, the corresponding equivalence of configurations, and the induced equivalence of finite
+local observable algebras.
+
+The compatibility with local inclusions, the algebraic-local and quasi-local extensions, and
+transport of QCA predicates are deliberately left to the next layer.
+
+## Main definitions
+
+* `SpinChain.expandedRegion` — the original sites belonging to a finite blocked region.
+* `SpinChain.blockSiteEquiv` — block coordinates `x, r` for an expanded original site.
+* `SpinChain.Config.blocking` — blocked configurations as configurations on the expanded region.
+* `SpinChain.localBlocking` — the induced finite local star-algebra equivalence.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2308 and
+  2313--2320.
+-/
+
+namespace SpinChain
+
+/-- The original sites obtained by expanding every blocked site `x` into the consecutive sites
+`L * x, ..., L * x + L - 1`.
+
+The inverse of `Int.divModEquiv L` fixes the order: the residue `r : Fin L` labels the site
+`L * x + r` inside block `x`.
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+def expandedRegion (L : ℕ) [NeZero L] (Λ : Finset ℤ) : Finset ℤ :=
+  (Λ.product (Finset.univ : Finset (Fin L))).map (Int.divModEquiv L).symm.toEmbedding
+
+/-- Membership in an expanded region is membership of the quotient block coordinate in the
+blocked region.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+@[simp]
+lemma mem_expandedRegion (L : ℕ) [NeZero L] (Λ : Finset ℤ) (z : ℤ) :
+    z ∈ expandedRegion L Λ ↔ (Int.divModEquiv L z).1 ∈ Λ := by
+  simp [expandedRegion]
+
+/-- Expanding regions is monotone. -/
+lemma expandedRegion_mono {L : ℕ} [NeZero L] {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ) :
+    expandedRegion L Λ ⊆ expandedRegion L Γ := by
+  intro z hz
+  simpa only [mem_expandedRegion] using h (mem_expandedRegion L Λ z |>.mp hz)
+
+/-- The expanded site with block coordinate `x` and residue `r` is `L * x + r`. -/
+@[simp]
+lemma mem_expandedRegion_blockSite (L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (x : Λ) (r : Fin L) :
+    (Int.divModEquiv L).symm ((x : ℤ), r) ∈ expandedRegion L Λ := by
+  simpa only [mem_expandedRegion, Equiv.apply_symm_apply] using x.2
+
+/-- Expanded original sites are equivalent to a blocked site together with a residue inside that
+block.  Residues increase in the source's consecutive-site order.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+def blockSiteEquiv (L : ℕ) [NeZero L] (Λ : Finset ℤ) :
+    expandedRegion L Λ ≃ Λ × Fin L where
+  toFun z :=
+    (⟨(Int.divModEquiv L z).1, (mem_expandedRegion L Λ z).mp z.2⟩,
+      (Int.divModEquiv L z).2)
+  invFun p :=
+    ⟨(Int.divModEquiv L).symm ((p.1 : ℤ), p.2), mem_expandedRegion_blockSite L Λ p.1 p.2⟩
+  left_inv z := by
+    apply Subtype.ext
+    exact (Int.divModEquiv L).symm_apply_apply z
+  right_inv p := by
+    apply Prod.ext
+    · apply Subtype.ext
+      exact congrArg Prod.fst ((Int.divModEquiv L).apply_symm_apply ((p.1 : ℤ), p.2))
+    · apply Fin.ext
+      exact congrArg (fun q : ℤ × Fin L ↦ q.2.val)
+        ((Int.divModEquiv L).apply_symm_apply ((p.1 : ℤ), p.2))
+
+/-- The first block coordinate of an expanded site is its quotient by the block length. -/
+@[simp]
+lemma blockSiteEquiv_apply_fst_val (L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (z : expandedRegion L Λ) :
+    ((blockSiteEquiv L Λ z).1 : ℤ) = (Int.divModEquiv L z).1 := rfl
+
+/-- The second block coordinate of an expanded site is its residue modulo the block length. -/
+@[simp]
+lemma blockSiteEquiv_apply_snd (L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (z : expandedRegion L Λ) :
+    (blockSiteEquiv L Λ z).2 = (Int.divModEquiv L z).2 := rfl
+
+/-- The site with block coordinates `(x, r)` has integer coordinate `x * L + r`. -/
+@[simp]
+lemma blockSiteEquiv_symm_apply_val (L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (p : Λ × Fin L) :
+    ((blockSiteEquiv L Λ).symm p : ℤ) = (p.1 : ℤ) * L + p.2 := rfl
+
+namespace Config
+
+/-- A blocked configuration is equivalent to a configuration on the consecutively expanded
+original region.  A blocked spin is decoded from `Fin (d^L)` into its length-`L` word using
+`MPSTensor.decodeBlockEquiv`.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+noncomputable def blocking (d L : ℕ) [NeZero L] (Λ : Finset ℤ) :
+    Config (MPSTensor.blockPhysDim d L) Λ ≃ Config d (expandedRegion L Λ) :=
+  ((Equiv.refl Λ).arrowCongr (MPSTensor.decodeBlockEquiv d L)).trans
+    ((Equiv.curry Λ (Fin L) (Fin d)).symm.trans
+      ((blockSiteEquiv L Λ).symm.arrowCongr (Equiv.refl (Fin d))))
+
+/-- Evaluation of an expanded configuration reads the corresponding residue of the decoded
+blocked spin. -/
+@[simp]
+lemma blocking_apply (d L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (x : Config (MPSTensor.blockPhysDim d L) Λ) (z : expandedRegion L Λ) :
+    blocking d L Λ x z =
+      MPSTensor.decodeBlockEquiv d L (x (blockSiteEquiv L Λ z).1)
+        (blockSiteEquiv L Λ z).2 := rfl
+
+/-- Re-encoding an expanded configuration at a blocked site collects its `L` consecutive
+residues in increasing order. -/
+@[simp]
+lemma blocking_symm_apply (d L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (x : Config d (expandedRegion L Λ)) (i : Λ) :
+    (blocking d L Λ).symm x i =
+      (MPSTensor.decodeBlockEquiv d L).symm
+        (fun r ↦ x ((blockSiteEquiv L Λ).symm (i, r))) := rfl
+
+/-- Decoding blocked configurations commutes with restriction to a smaller blocked region. -/
+lemma restrict_blocking {d L : ℕ} [NeZero L] {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (x : Config (MPSTensor.blockPhysDim d L) Γ) :
+    restrict (expandedRegion_mono h) (blocking d L Γ x) =
+      blocking d L Λ (restrict h x) := by
+  funext z
+  rfl
+
+end Config
+
+/-- Blocking sites induces a star-algebra equivalence from observables on a finite blocked region
+to observables on its consecutively expanded original region.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+noncomputable def localBlocking (d L : ℕ) [NeZero L] (Λ : Finset ℤ) :
+    LocalAlgebra (MPSTensor.blockPhysDim d L) Λ ≃⋆ₐ[ℂ]
+      LocalAlgebra d (expandedRegion L Λ) :=
+  CStarMatrix.reindexₐ ℂ ℂ (Config.blocking d L Λ)
+
+/-- Entrywise evaluation of finite-region blocking. -/
+@[simp]
+lemma localBlocking_apply (d L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ)
+    (x y : Config d (expandedRegion L Λ)) :
+    localBlocking d L Λ A x y =
+      A ((Config.blocking d L Λ).symm x) ((Config.blocking d L Λ).symm y) := rfl
+
+open scoped ComplexOrder in
+/-- Finite-region blocking preserves the C-star operator norm. -/
+@[simp]
+lemma localBlocking_norm (d L : ℕ) [NeZero L] (Λ : Finset ℤ)
+    (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    ‖localBlocking d L Λ A‖ = ‖A‖ :=
+  StarAlgEquiv.norm_map (localBlocking d L Λ) A
+
+open scoped ComplexOrder in
+/-- Finite-region blocking is an operator-norm isometry. -/
+lemma localBlocking_isometry (d L : ℕ) [NeZero L] (Λ : Finset ℤ) :
+    Isometry (localBlocking d L Λ) :=
+  StarAlgEquiv.isometry (localBlocking d L Λ)
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9433,3 +9433,108 @@ $\omega^{-1}$.
     inversion.  These are the two defining properties of a quantum cellular
     automaton.
 \end{proof}
+
+\begin{definition}[Expansion of a blocked region]
+    \label{def:qca_expanded_region}
+    \lean{SpinChain.expandedRegion,SpinChain.blockSiteEquiv}
+    \leanok
+    Let $L>0$ be a block length and let $\Lambda\subset\mathbb Z$ be finite.
+    The expansion of $\Lambda$ is
+    \begin{align}
+        \widehat\Lambda_L
+        &=\{Lx+r:x\in\Lambda,\ 0\leq r<L\}.
+    \end{align}
+    Every $z\in\widehat\Lambda_L$ has unique block coordinates $(x,r)$ with
+    $x\in\Lambda$ and $0\leq r<L$.  Increasing $r$ gives the consecutive-site
+    order within the block.  This is the finite-region site grouping used in
+    \cite[lines~2308 and 2313--2320]{Cirac2017MPU}; it does not assert the
+    QCA-to-MPU converse stated at line~2308.
+\end{definition}
+
+\begin{theorem}[Coordinates and monotonicity of expanded regions]
+    \label{thm:qca_expanded_region_coordinates}
+    \lean{SpinChain.mem_expandedRegion,SpinChain.expandedRegion_mono,
+        SpinChain.mem_expandedRegion_blockSite,
+        SpinChain.blockSiteEquiv_apply_fst_val,
+        SpinChain.blockSiteEquiv_apply_snd,
+        SpinChain.blockSiteEquiv_symm_apply_val}
+    \leanok
+    \uses{def:qca_expanded_region}
+    An integer $z$ belongs to $\widehat\Lambda_L$ exactly when its quotient by
+    $L$ belongs to $\Lambda$.  The inverse block-coordinate map sends $(x,r)$
+    to $Lx+r$, and $\Lambda\subseteq\Gamma$ implies
+    $\widehat\Lambda_L\subseteq\widehat\Gamma_L$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_expanded_region}
+    Apply Euclidean division by the positive integer $L$.  Its quotient and
+    residue are unique, the residue lies in $\{0,\ldots,L-1\}$, and taking the
+    inverse coordinates gives $Lx+r$.  Monotonicity follows by retaining the
+    same quotient and residue.
+\end{proof}
+
+\begin{definition}[Blocking equivalence for finite configurations]
+    \label{def:qca_configuration_blocking}
+    \lean{SpinChain.Config.blocking}
+    \leanok
+    \uses{def:qca_expanded_region}
+    For on-site dimension $d$, configurations of $d^L$-level blocked spins on
+    $\Lambda$ are equivalent to configurations of $d$-level spins on
+    $\widehat\Lambda_L$.  The blocked label at $x$ is decoded into its ordered
+    length-$L$ word, and its $r$th letter is placed at $Lx+r$.
+\end{definition}
+
+\begin{theorem}[Evaluation and restriction of blocked configurations]
+    \label{thm:qca_configuration_blocking_formulas}
+    \lean{SpinChain.Config.blocking_apply,
+        SpinChain.Config.blocking_symm_apply,
+        SpinChain.Config.restrict_blocking}
+    \leanok
+    \uses{def:qca_configuration_blocking, thm:qca_expanded_region_coordinates}
+    Evaluation at $Lx+r$ reads the $r$th letter of the blocked spin at $x$.
+    Conversely, encoding collects these letters in increasing residue order.
+    At the configuration level, decoding commutes with restriction from
+    $\Gamma$ to $\Lambda\subseteq\Gamma$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_configuration_blocking, thm:qca_expanded_region_coordinates}
+    The two evaluation formulas are the inverse laws for the ordered word
+    encoding.  Restriction preserves the quotient block coordinate and residue,
+    so both sides have the same value at every expanded site.
+\end{proof}
+
+\begin{definition}[Finite local-algebra blocking equivalence]
+    \label{def:qca_local_blocking}
+    \lean{SpinChain.localBlocking}
+    \leanok
+    \uses{def:qca_local_algebra, def:qca_configuration_blocking}
+    Reindexing matrix rows and columns by the configuration blocking
+    equivalence gives a star-algebra equivalence
+    \begin{align}
+        \mathcal A^{(d^L)}_\Lambda
+        &\simeq \mathcal A^{(d)}_{\widehat\Lambda_L}.
+    \end{align}
+    This is only a finite-region equivalence.  No compatibility with local
+    inclusions, extension to the algebraic-local or quasi-local algebra,
+    propagation statement, or transport of quantum cellular automata is
+    asserted here.
+\end{definition}
+
+\begin{theorem}[Finite local-algebra blocking formulas]
+    \label{thm:qca_local_blocking_formulas}
+    \lean{SpinChain.localBlocking_apply,SpinChain.localBlocking_norm,
+        SpinChain.localBlocking_isometry}
+    \leanok
+    \uses{def:qca_local_blocking}
+    Matrix entries are transported by applying the inverse configuration
+    equivalence to both indices.  The blocking equivalence preserves the
+    operator norm and is an isometry.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_local_blocking}
+    The entry formula is matrix reindexing.  A star-algebra equivalence between
+    finite matrix algebras preserves the C-star norm and hence distances.
+\end{proof}


### PR DESCRIPTION
## Summary

- group each blocked site `x` into the consecutive original sites `L*x, ..., L*x+L-1` using `Int.divModEquiv`
- identify blocked configurations with configurations on the expanded finite region through the existing `MPSTensor.decodeBlockEquiv`
- prove configuration restriction compatibility and define the induced finite local star-algebra equivalence with entry, norm, and isometry laws
- add the generated QCA aggregate import and formula-driven Chapter 28 coverage

## Source and scope

This is the finite-region site-grouping foundation used by the QCA appendix of arXiv:1703.09188, especially line 2308 and the grouping at lines 2313–2320.

It does **not** claim local-inclusion naturality, an algebraic/quasi-local extension, support or translation transport, the Schumacher–Werner depth-two theorem, or the QCA-to-MPU converse. Those remain tracked by #6955 and #6028.

## Verification

- `lake env lean TNLean/QCA/Blocking.lean`
- `lake env lean TNLean/QCA.lean`
- `lake build TNLean.QCA.Blocking`
- Lean diagnostics: no errors, warnings, or hints
- generated import-aggregator tests
- Blueprint sync and reverse coverage: Chapter 28 `666/666`, no changed declaration missing
- `git diff --check`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Closes #6957
