### PR TITLE
feat(QCA): lift site blocking algebraically

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.QCA
 
+import TNLean.QCA.AlgebraicBlocking
 import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.Blocking
 import TNLean.QCA.DisjointSupport

--- a/TNLean/QCA/AlgebraicBlocking.lean
+++ b/TNLean/QCA/AlgebraicBlocking.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.Blocking
+import TNLean.QCA.LocalNorm
+
+/-!
+# Blocking algebraic-local observables
+
+Finite-region site blocking commutes with the canonical identity-tensor inclusions.  It therefore
+extends from finite local algebras to an equivalence of algebraic local algebras.  For the reverse
+map, an arbitrary original region is enlarged to the expansion of its finite block hull; an
+original region need not itself be the expansion of a blocked region.
+
+This file concerns the algebraic local algebra only.  It does not extend blocking to the
+quasi-local completion or transport translations, propagation conditions, or quantum cellular
+automata.
+
+## Main definitions
+
+* `SpinChain.blockHull` — the finite set of blocks meeting an original finite region.
+* `SpinChain.algebraicLocalBlocking` — site blocking as an algebraic-local star-algebra
+  equivalence.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2308 and
+  2313--2320.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- The finite set of blocks that meet an original finite region. -/
+def blockHull (L : ℕ) [NeZero L] (Δ : Finset ℤ) : Finset ℤ :=
+  Δ.image fun z ↦ (Int.divModEquiv L z).1
+
+/-- An original region is contained in the expansion of its block hull. -/
+lemma subset_expandedRegion_blockHull (L : ℕ) [NeZero L] (Δ : Finset ℤ) :
+    Δ ⊆ expandedRegion L (blockHull L Δ) := by
+  intro z hz
+  rw [mem_expandedRegion]
+  exact Finset.mem_image.mpr ⟨z, hz, rfl⟩
+
+/-- Taking the block hull is monotone. -/
+lemma blockHull_mono {L : ℕ} [NeZero L] {Δ Θ : Finset ℤ} (h : Δ ⊆ Θ) :
+    blockHull L Δ ⊆ blockHull L Θ :=
+  Finset.image_mono _ h
+
+private lemma restrict_blocking_symm {d L : ℕ} [NeZero L] {Λ Γ : Finset ℤ}
+    (h : Λ ⊆ Γ) (x : Config d (expandedRegion L Γ)) :
+    Config.restrict h ((Config.blocking d L Γ).symm x) =
+      (Config.blocking d L Λ).symm (Config.restrict (expandedRegion_mono h) x) := by
+  apply (Config.blocking d L Λ).injective
+  simpa only [Equiv.apply_symm_apply] using
+    (Config.restrict_blocking h ((Config.blocking d L Γ).symm x)).symm
+
+private lemma blocking_complement_eq_iff {d L : ℕ} [NeZero L] {Λ Γ : Finset ℤ}
+    (h : Λ ⊆ Γ) (x y : Config d (expandedRegion L Γ)) :
+    (Config.splitEquiv h ((Config.blocking d L Γ).symm x)).2 =
+        (Config.splitEquiv h ((Config.blocking d L Γ).symm y)).2 ↔
+      (Config.splitEquiv (expandedRegion_mono h) x).2 =
+        (Config.splitEquiv (expandedRegion_mono h) y).2 := by
+  constructor
+  · intro hxy
+    funext z
+    let q : Γ := ⟨(Int.divModEquiv L z).1,
+      (mem_expandedRegion L Γ z).mp (Finset.mem_sdiff.mp z.2).1⟩
+    have hq : (q : ℤ) ∉ Λ := by
+      intro hqΛ
+      exact (Finset.mem_sdiff.mp z.2).2 ((mem_expandedRegion L Λ z).mpr hqΛ)
+    have hz := congrFun hxy ⟨q, Finset.mem_sdiff.mpr ⟨q.2, hq⟩⟩
+    let zΓ : expandedRegion L Γ := ⟨z, (Finset.mem_sdiff.mp z.2).1⟩
+    calc
+      x zΓ = Config.blocking d L Γ ((Config.blocking d L Γ).symm x) zΓ := by
+        rw [Equiv.apply_symm_apply]
+      _ = MPSTensor.decodeBlockEquiv d L
+          (((Config.blocking d L Γ).symm x) q) (Int.divModEquiv L z).2 := by
+        rw [Config.blocking_apply]
+        congr 2
+      _ = MPSTensor.decodeBlockEquiv d L
+          (((Config.blocking d L Γ).symm y) q) (Int.divModEquiv L z).2 := by
+        exact congrArg
+          (fun w ↦ MPSTensor.decodeBlockEquiv d L w (Int.divModEquiv L z).2) hz
+      _ = Config.blocking d L Γ ((Config.blocking d L Γ).symm y) zΓ := by
+        rw [Config.blocking_apply]
+        congr 2
+      _ = y zΓ := by rw [Equiv.apply_symm_apply]
+  · intro hxy
+    funext q
+    apply (MPSTensor.decodeBlockEquiv d L).injective
+    funext r
+    let qΓ : Γ := ⟨q, (Finset.mem_sdiff.mp q.2).1⟩
+    let z : expandedRegion L Γ :=
+      ⟨(Int.divModEquiv L).symm ((qΓ : ℤ), r),
+        mem_expandedRegion_blockSite L Γ qΓ r⟩
+    have hzΛ : (z : ℤ) ∉ expandedRegion L Λ := by
+      rw [mem_expandedRegion]
+      have hzq : (Int.divModEquiv L (z : ℤ)).1 = (qΓ : ℤ) := by
+        exact congrArg Prod.fst ((Int.divModEquiv L).apply_symm_apply ((qΓ : ℤ), r))
+      rw [hzq]
+      exact (Finset.mem_sdiff.mp q.2).2
+    have hz := congrFun hxy ⟨z, Finset.mem_sdiff.mpr ⟨z.2, hzΛ⟩⟩
+    change MPSTensor.decodeBlockEquiv d L ((Config.blocking d L Γ).symm x qΓ) r =
+      MPSTensor.decodeBlockEquiv d L ((Config.blocking d L Γ).symm y qΓ) r
+    calc
+      _ = x ((blockSiteEquiv L Γ).symm (qΓ, r)) := by
+        rw [Config.blocking_symm_apply, Equiv.apply_symm_apply]
+      _ = x z := by congr 1
+      _ = y z := hz
+      _ = y ((blockSiteEquiv L Γ).symm (qΓ, r)) := by congr 1
+      _ = _ := by rw [Config.blocking_symm_apply, Equiv.apply_symm_apply]
+
+/-- Finite-region blocking commutes with canonical local inclusions. -/
+lemma localBlocking_localInclusion {d L : ℕ} [NeZero L] {Λ Γ : Finset ℤ}
+    (h : Λ ⊆ Γ) (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    localBlocking d L Γ (localInclusion h A) =
+      localInclusion (expandedRegion_mono h) (localBlocking d L Λ A) := by
+  ext x y
+  rw [localBlocking_apply, localInclusion_apply, localInclusion_apply, localBlocking_apply,
+    restrict_blocking_symm h x, restrict_blocking_symm h y]
+  by_cases hxy :
+      (Config.splitEquiv h ((Config.blocking d L Γ).symm x)).2 =
+        (Config.splitEquiv h ((Config.blocking d L Γ).symm y)).2
+  · simp only [hxy, ite_true, mul_one]
+    rw [blocking_complement_eq_iff h x y] at hxy
+    simp only [hxy, ite_true, mul_one]
+  · simp only [hxy, ite_false, mul_zero]
+    rw [blocking_complement_eq_iff h x y] at hxy
+    simp only [hxy, ite_false, mul_zero]
+
+/-- Forward blocking of finite representatives induces a star-algebra homomorphism on the
+algebraic local algebra. -/
+noncomputable def algebraicLocalBlockingHom (d L : ℕ) [NeZero L] :
+    AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L) →⋆ₐ[ℂ]
+      AlgebraicLocalAlgebra d :=
+  algebraicLocalAlgebraLift
+    (fun Λ ↦ (localObservable d (expandedRegion L Λ)).comp
+      (localBlocking d L Λ).toStarAlgHom)
+    (by
+      intro Λ Γ h A
+      change localObservable d (expandedRegion L Γ)
+          (localBlocking d L Γ (localInclusion h A)) =
+        localObservable d (expandedRegion L Λ) (localBlocking d L Λ A)
+      rw [localBlocking_localInclusion]
+      exact localObservable_localInclusion d (expandedRegion_mono h) _)
+
+/-- Forward algebraic-local blocking evaluates by finite blocking on every local
+representative. -/
+@[simp]
+lemma algebraicLocalBlockingHom_localObservable (d L : ℕ) [NeZero L]
+    (Λ : Finset ℤ) (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    algebraicLocalBlockingHom d L (localObservable _ Λ A) =
+      localObservable d (expandedRegion L Λ) (localBlocking d L Λ A) :=
+  rfl
+
+/-- Enlarging to the block hull and then undoing finite blocking induces the reverse
+algebraic-local homomorphism. -/
+noncomputable def algebraicLocalUnblockingHom (d L : ℕ) [NeZero L] :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ]
+      AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L) :=
+  algebraicLocalAlgebraLift
+    (fun Δ ↦ (localObservable (MPSTensor.blockPhysDim d L) (blockHull L Δ)).comp
+      ((localBlocking d L (blockHull L Δ)).symm.toStarAlgHom.comp
+        (localInclusion (subset_expandedRegion_blockHull L Δ))))
+    (by
+      intro Δ Θ h A
+      let hHull : blockHull L Δ ⊆ blockHull L Θ := blockHull_mono h
+      let hΔ : Δ ⊆ expandedRegion L (blockHull L Δ) := subset_expandedRegion_blockHull L Δ
+      let hΘ : Θ ⊆ expandedRegion L (blockHull L Θ) := subset_expandedRegion_blockHull L Θ
+      have horiginal :
+          localInclusion hΘ (localInclusion h A) =
+            localInclusion (expandedRegion_mono hHull) (localInclusion hΔ A) := by
+        rw [← StarAlgHom.comp_apply, localInclusion_trans,
+          ← StarAlgHom.comp_apply, localInclusion_trans]
+      have hblocked :
+          (localBlocking d L (blockHull L Θ)).symm
+              (localInclusion hΘ (localInclusion h A)) =
+            localInclusion hHull
+              ((localBlocking d L (blockHull L Δ)).symm (localInclusion hΔ A)) := by
+        apply (localBlocking d L (blockHull L Θ)).injective
+        calc
+          localBlocking d L (blockHull L Θ)
+              ((localBlocking d L (blockHull L Θ)).symm
+                (localInclusion hΘ (localInclusion h A))) =
+              localInclusion hΘ (localInclusion h A) := Equiv.apply_symm_apply _ _
+          _ = localInclusion (expandedRegion_mono hHull) (localInclusion hΔ A) := horiginal
+          _ = localBlocking d L (blockHull L Θ)
+              (localInclusion hHull
+                ((localBlocking d L (blockHull L Δ)).symm (localInclusion hΔ A))) := by
+            rw [localBlocking_localInclusion]
+            exact congrArg (localInclusion (expandedRegion_mono hHull))
+              (Equiv.apply_symm_apply (localBlocking d L (blockHull L Δ)).toEquiv
+                (localInclusion hΔ A)).symm
+      change localObservable _ (blockHull L Θ)
+          ((localBlocking d L (blockHull L Θ)).symm
+            (localInclusion hΘ (localInclusion h A))) =
+        localObservable _ (blockHull L Δ)
+          ((localBlocking d L (blockHull L Δ)).symm (localInclusion hΔ A))
+      rw [hblocked]
+      exact localObservable_localInclusion _ hHull _)
+
+/-- Reverse algebraic-local blocking evaluates by enlarging a finite region to its block hull and
+undoing finite blocking. -/
+@[simp]
+lemma algebraicLocalUnblockingHom_localObservable (d L : ℕ) [NeZero L]
+    (Δ : Finset ℤ) (A : LocalAlgebra d Δ) :
+    algebraicLocalUnblockingHom d L (localObservable d Δ A) =
+      localObservable (MPSTensor.blockPhysDim d L) (blockHull L Δ)
+        ((localBlocking d L (blockHull L Δ)).symm
+          (localInclusion (subset_expandedRegion_blockHull L Δ) A)) :=
+  rfl
+
+private lemma algebraicLocalBlockingHom_injective (d L : ℕ) [NeZero d] [NeZero L] :
+    Function.Injective (algebraicLocalBlockingHom d L) := by
+  intro X Y hXY
+  obtain ⟨Λ, A, rfl⟩ := DirectLimit.exists_eq_mk
+    (localAlgebraMap (MPSTensor.blockPhysDim d L)) X
+  obtain ⟨Γ, B, rfl⟩ := DirectLimit.exists_eq_mk
+    (localAlgebraMap (MPSTensor.blockPhysDim d L)) Y
+  let Ω := Λ ∪ Γ
+  let hΛ : Λ ⊆ Ω := Finset.subset_union_left
+  let hΓ : Γ ⊆ Ω := Finset.subset_union_right
+  have hExpanded :
+      localInclusion (expandedRegion_mono hΛ) (localBlocking d L Λ A) =
+        localInclusion (expandedRegion_mono hΓ) (localBlocking d L Γ B) := by
+    apply localObservable_injective d (expandedRegion L Ω)
+    calc
+      localObservable d (expandedRegion L Ω)
+          (localInclusion (expandedRegion_mono hΛ) (localBlocking d L Λ A)) =
+        localObservable d (expandedRegion L Λ) (localBlocking d L Λ A) :=
+          localObservable_localInclusion d (expandedRegion_mono hΛ) _
+      _ = localObservable d (expandedRegion L Γ) (localBlocking d L Γ B) := hXY
+      _ = localObservable d (expandedRegion L Ω)
+          (localInclusion (expandedRegion_mono hΓ) (localBlocking d L Γ B)) :=
+          (localObservable_localInclusion d (expandedRegion_mono hΓ) _).symm
+  have hFinite : localInclusion hΛ A = localInclusion hΓ B := by
+    apply (localBlocking d L Ω).injective
+    calc
+      localBlocking d L Ω (localInclusion hΛ A) =
+          localInclusion (expandedRegion_mono hΛ) (localBlocking d L Λ A) :=
+        localBlocking_localInclusion hΛ A
+      _ = localInclusion (expandedRegion_mono hΓ) (localBlocking d L Γ B) := hExpanded
+      _ = localBlocking d L Ω (localInclusion hΓ B) :=
+        (localBlocking_localInclusion hΓ B).symm
+  calc
+    localObservable _ Λ A = localObservable _ Ω (localInclusion hΛ A) :=
+      (localObservable_localInclusion _ hΛ A).symm
+    _ = localObservable _ Ω (localInclusion hΓ B) := congrArg (localObservable _ Ω) hFinite
+    _ = localObservable _ Γ B := localObservable_localInclusion _ hΓ B
+
+/-- Forward blocking after block-hull unblocking is the identity on original algebraic-local
+observables. -/
+lemma algebraicLocalBlockingHom_comp_unblockingHom (d L : ℕ) [NeZero L] :
+    (algebraicLocalBlockingHom d L).comp (algebraicLocalUnblockingHom d L) =
+      StarAlgHom.id ℂ (AlgebraicLocalAlgebra d) := by
+  apply algebraicLocalAlgebra_starAlgHom_ext
+  intro Δ
+  ext A
+  change algebraicLocalBlockingHom d L
+      (algebraicLocalUnblockingHom d L (localObservable d Δ A)) = localObservable d Δ A
+  rw [algebraicLocalUnblockingHom_localObservable,
+    algebraicLocalBlockingHom_localObservable]
+  let B := localInclusion (subset_expandedRegion_blockHull L Δ) A
+  calc
+    localObservable d (expandedRegion L (blockHull L Δ))
+        (localBlocking d L (blockHull L Δ)
+          ((localBlocking d L (blockHull L Δ)).symm B)) =
+      localObservable d (expandedRegion L (blockHull L Δ)) B := by
+        exact congrArg (localObservable d (expandedRegion L (blockHull L Δ)))
+          (Equiv.apply_symm_apply (localBlocking d L (blockHull L Δ)).toEquiv B)
+    _ = localObservable d Δ A :=
+      localObservable_localInclusion d (subset_expandedRegion_blockHull L Δ) A
+
+/-- Block-hull unblocking after forward blocking is the identity on blocked algebraic-local
+observables. -/
+lemma algebraicLocalUnblockingHom_comp_blockingHom (d L : ℕ) [NeZero d] [NeZero L] :
+    (algebraicLocalUnblockingHom d L).comp (algebraicLocalBlockingHom d L) =
+      StarAlgHom.id ℂ (AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) := by
+  apply algebraicLocalAlgebra_starAlgHom_ext
+  intro Λ
+  ext A
+  apply algebraicLocalBlockingHom_injective d L
+  change algebraicLocalBlockingHom d L
+      (algebraicLocalUnblockingHom d L
+        (algebraicLocalBlockingHom d L (localObservable _ Λ A))) =
+    algebraicLocalBlockingHom d L (localObservable _ Λ A)
+  rw [← StarAlgHom.comp_apply, algebraicLocalBlockingHom_comp_unblockingHom]
+  rfl
+
+/-- Blocking consecutive groups of `L` sites gives an equivalence between the blocked and
+original algebraic local algebras. -/
+noncomputable def algebraicLocalBlocking (d L : ℕ) [NeZero d] [NeZero L] :
+    AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L) ≃⋆ₐ[ℂ]
+      AlgebraicLocalAlgebra d :=
+  StarAlgEquiv.ofBijective (algebraicLocalBlockingHom d L) ⟨
+    algebraicLocalBlockingHom_injective d L,
+    fun A ↦ ⟨algebraicLocalUnblockingHom d L A, by
+      rw [← StarAlgHom.comp_apply, algebraicLocalBlockingHom_comp_unblockingHom]
+      rfl⟩⟩
+
+/-- Algebraic-local blocking has the same underlying map as its forward lift. -/
+@[simp]
+lemma algebraicLocalBlocking_apply (d L : ℕ) [NeZero d] [NeZero L]
+    (A : AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    algebraicLocalBlocking d L A = algebraicLocalBlockingHom d L A :=
+  StarAlgEquiv.ofBijective_apply _ _
+
+/-- Algebraic-local blocking sends a finite blocked representative to its expanded original
+representative. -/
+lemma algebraicLocalBlocking_localObservable (d L : ℕ) [NeZero d] [NeZero L]
+    (Λ : Finset ℤ) (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    algebraicLocalBlocking d L (localObservable _ Λ A) =
+      localObservable d (expandedRegion L Λ) (localBlocking d L Λ A) := by
+  rw [algebraicLocalBlocking_apply]
+  exact algebraicLocalBlockingHom_localObservable d L Λ A
+
+/-- Algebraic-local blocking preserves the operator norm. -/
+lemma algebraicLocalBlocking_norm (d L : ℕ) [NeZero d] [NeZero L]
+    (A : AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    ‖algebraicLocalBlocking d L A‖ = ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change ‖algebraicLocalBlocking d L (localObservable _ Λ A)‖ =
+        ‖localObservable _ Λ A‖
+      rw [algebraicLocalBlocking_localObservable, norm_localObservable,
+        localBlocking_norm, norm_localObservable]
+
+/-- Algebraic-local blocking is an operator-norm isometry. -/
+lemma algebraicLocalBlocking_isometry (d L : ℕ) [NeZero d] [NeZero L] :
+    Isometry (algebraicLocalBlocking d L) := by
+  rw [isometry_iff_dist_eq]
+  intro A B
+  rw [dist_eq_norm, dist_eq_norm, ← map_sub]
+  exact algebraicLocalBlocking_norm d L (A - B)
+
+end SpinChain

--- a/TNLean/QCA/AlgebraicBlocking.lean
+++ b/TNLean/QCA/AlgebraicBlocking.lean
@@ -295,7 +295,10 @@ lemma algebraicLocalUnblockingHom_comp_blockingHom (d L : ℕ) [NeZero d] [NeZer
   rfl
 
 /-- Blocking consecutive groups of `L` sites gives an equivalence between the blocked and
-original algebraic local algebras. -/
+original algebraic local algebras.
+
+This is the site-grouping operation used in Cirac--Perez-Garcia--Schuch--Verstraete,
+arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
 noncomputable def algebraicLocalBlocking (d L : ℕ) [NeZero d] [NeZero L] :
     AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L) ≃⋆ₐ[ℂ]
       AlgebraicLocalAlgebra d :=

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9552,8 +9552,8 @@ $\omega^{-1}$.
     This is the finite set of length-$L$ blocks that meet $\Delta$.
 \end{definition}
 
-\begin{theorem}[Block-hull containment and monotonicity]
-    \label{thm:qca_block_hull_properties}
+\begin{lemma}[Block-hull containment and monotonicity]
+    \label{lem:qca_block_hull_properties}
     \lean{SpinChain.subset_expandedRegion_blockHull,SpinChain.blockHull_mono}
     \leanok
     \uses{def:qca_block_hull, def:qca_expanded_region}
@@ -9566,7 +9566,7 @@ $\omega^{-1}$.
     Moreover, $\Delta\subseteq\Theta$ implies
     $\operatorname{Hull}_L(\Delta)\subseteq
     \operatorname{Hull}_L(\Theta)$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     \uses{def:qca_block_hull, thm:qca_expanded_region_coordinates}
@@ -9575,8 +9575,8 @@ $\omega^{-1}$.
     by retaining the same witness $z$ in the larger region.
 \end{proof}
 
-\begin{theorem}[Blocking commutes with finite local inclusions]
-    \label{thm:qca_local_blocking_inclusion}
+\begin{lemma}[Blocking commutes with finite local inclusions]
+    \label{lem:qca_local_blocking_inclusion}
     \lean{SpinChain.localBlocking_localInclusion}
     \leanok
     \uses{def:qca_local_blocking, thm:qca_configuration_blocking_formulas,
@@ -9589,7 +9589,7 @@ $\omega^{-1}$.
         &=\iota_{\widehat\Lambda_L,\widehat\Gamma_L}\,
           \mathcal B_{L,\Lambda}.
     \end{align}
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:qca_local_blocking_formulas,
@@ -9605,8 +9605,8 @@ $\omega^{-1}$.
     \lean{SpinChain.algebraicLocalBlockingHom,
         SpinChain.algebraicLocalUnblockingHom}
     \leanok
-    \uses{def:qca_algebraic_local_algebra, thm:qca_block_hull_properties,
-        thm:qca_local_blocking_inclusion}
+    \uses{def:qca_algebraic_local_algebra, lem:qca_block_hull_properties,
+        lem:qca_local_blocking_inclusion}
     Let $L>0$.  The compatible finite blocking maps induce a star-algebra
     homomorphism
     \begin{align}
@@ -9624,15 +9624,15 @@ $\omega^{-1}$.
     $\Delta$ itself to be an expanded region.
 \end{definition}
 
-\begin{theorem}[Evaluation of the algebraic-local blocking maps]
-    \label{thm:qca_algebraic_blocking_maps_evaluation}
+\begin{lemma}[Evaluation of the algebraic-local blocking maps]
+    \label{lem:qca_algebraic_blocking_maps_evaluation}
     \lean{SpinChain.algebraicLocalBlockingHom_localObservable,
         SpinChain.algebraicLocalUnblockingHom_localObservable,
         SpinChain.algebraicLocalBlockingHom_comp_unblockingHom,
         SpinChain.algebraicLocalUnblockingHom_comp_blockingHom}
     \leanok
     \uses{def:qca_algebraic_blocking_maps,
-        thm:qca_block_hull_properties}
+        lem:qca_block_hull_properties}
     Let $L>0$.  The forward map applies finite blocking to a representative on
     $\Lambda$ and regards the result as supported on $\widehat\Lambda_L$.  The
     reverse map enlarges a representative on $\Delta$ to the expansion of its
@@ -9647,11 +9647,11 @@ $\omega^{-1}$.
     \end{align}
     The first identity holds for every on-site dimension $d$; the second also
     assumes $d>0$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:qca_local_blocking_inclusion,
-        thm:qca_block_hull_properties}
+    \uses{lem:qca_local_blocking_inclusion,
+        lem:qca_block_hull_properties}
     These are the evaluation formulas for the two compatible-family lifts.
     Forward compatibility is the commuting square.  Reverse compatibility
     follows by monotonicity of block hulls, composition of local inclusions,
@@ -9666,7 +9666,7 @@ $\omega^{-1}$.
     \lean{SpinChain.algebraicLocalBlocking}
     \leanok
     \uses{def:qca_algebraic_blocking_maps,
-        thm:qca_algebraic_blocking_maps_evaluation}
+        lem:qca_algebraic_blocking_maps_evaluation}
     For $d>0$ and $L>0$, forward blocking gives a star-algebra equivalence
     \begin{align}
         \mathcal A_{\mathrm{loc}}^{(d^L)}
@@ -9679,22 +9679,22 @@ $\omega^{-1}$.
     circuit representation, or transport a quantum cellular automaton.
 \end{definition}
 
-\begin{theorem}[Algebraic-local blocking formulas and norm]
-    \label{thm:qca_algebraic_blocking_formulas}
+\begin{lemma}[Algebraic-local blocking formulas and norm]
+    \label{lem:qca_algebraic_blocking_formulas}
     \lean{SpinChain.algebraicLocalBlocking_apply,
         SpinChain.algebraicLocalBlocking_localObservable,
         SpinChain.algebraicLocalBlocking_norm,
         SpinChain.algebraicLocalBlocking_isometry}
     \leanok
     \uses{def:qca_algebraic_blocking,
-        thm:qca_algebraic_blocking_maps_evaluation}
+        lem:qca_algebraic_blocking_maps_evaluation}
     Let $d>0$ and $L>0$.  The equivalence agrees with the forward lift and
     sends every finite representative to its finite blocking on the expanded
     region.  It preserves the algebraic-local operator norm and is an isometry.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:qca_algebraic_blocking_maps_evaluation,
+    \uses{lem:qca_algebraic_blocking_maps_evaluation,
         thm:qca_local_blocking_formulas,
         def:qca_algebraic_local_operator_norm}
     The reverse block-hull construction is a right inverse of forward blocking,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9563,7 +9563,7 @@ $\omega^{-1}$.
         \Delta\subseteq
         \widehat{\operatorname{Hull}_L(\Delta)}_L.
     \end{align}
-    Moreover, $\Delta\subseteq\Theta$ implies
+    If $\Delta\subseteq\Theta$, then
     $\operatorname{Hull}_L(\Delta)\subseteq
     \operatorname{Hull}_L(\Theta)$.
 \end{lemma}
@@ -9594,10 +9594,25 @@ $\omega^{-1}$.
 \begin{proof}\leanok
     \uses{thm:qca_local_blocking_formulas,
         thm:qca_configuration_blocking_formulas}
-    Restriction of decoded configurations commutes with blocking.  Equality on
-    the complementary blocked sites is equivalent to equality on all original
-    sites in $\widehat\Gamma_L\setminus\widehat\Lambda_L$.  Substitution into
-    the matrix-entry formula for the canonical inclusion proves the square.
+    For configurations $x,y$ on $\widehat\Gamma_L$, let $\widetilde x$ and
+    $\widetilde y$ be their block encodings on $\Gamma$.  The two matrix
+    entries in the commuting square are
+    \begin{align}
+        \bigl[\mathcal B_{L,\Gamma}
+          (\iota_{\Lambda,\Gamma}(A))\bigr]_{x,y}
+        &=A_{\widetilde x|_\Lambda,\widetilde y|_\Lambda}
+          \mathbf 1_{\{\widetilde x|_{\Gamma\setminus\Lambda}
+                         =\widetilde y|_{\Gamma\setminus\Lambda}\}},\\
+        \bigl[\iota_{\widehat\Lambda_L,\widehat\Gamma_L}
+          (\mathcal B_{L,\Lambda}(A))\bigr]_{x,y}
+        &=A_{\widetilde x|_\Lambda,\widetilde y|_\Lambda}
+          \mathbf 1_{\{x|_{\widehat\Gamma_L\setminus\widehat\Lambda_L}
+                         =y|_{\widehat\Gamma_L\setminus\widehat\Lambda_L}\}}.
+    \end{align}
+    Restriction commutes with block encoding, and decoding identifies
+    $\Gamma\setminus\Lambda$ with the original sites in
+    $\widehat\Gamma_L\setminus\widehat\Lambda_L$.  Hence the two indicator
+    conditions are equivalent and the entries agree.
 \end{proof}
 
 \begin{definition}[Forward and reverse algebraic-local blocking maps]
@@ -9605,8 +9620,8 @@ $\omega^{-1}$.
     \lean{SpinChain.algebraicLocalBlockingHom,
         SpinChain.algebraicLocalUnblockingHom}
     \leanok
-    \uses{def:qca_algebraic_local_algebra, lem:qca_block_hull_properties,
-        lem:qca_local_blocking_inclusion}
+    \uses{def:qca_algebraic_local_algebra, def:qca_local_blocking,
+        def:qca_block_hull}
     Let $L>0$.  The compatible finite blocking maps induce a star-algebra
     homomorphism
     \begin{align}
@@ -9623,6 +9638,31 @@ $\omega^{-1}$.
     blocking is inverted.  Thus the reverse construction does not require
     $\Delta$ itself to be an expanded region.
 \end{definition}
+
+\begin{proof}\leanok
+    \uses{lem:qca_block_hull_properties,
+        lem:qca_local_blocking_inclusion,
+        thm:qca_algebraic_local_algebra_universal}
+    For $\Lambda\subseteq\Gamma$, the finite commuting square gives
+    \begin{align}
+        \iota_{\widehat\Gamma_L}
+          \mathcal B_{L,\Gamma}(\iota_{\Lambda,\Gamma}(A))
+        &=\iota_{\widehat\Lambda_L}\mathcal B_{L,\Lambda}(A),
+    \end{align}
+    so the forward finite-region maps form a compatible family.  For the
+    reverse family, block-hull monotonicity sends $\Delta\subseteq\Theta$ to
+    $\operatorname{Hull}_L(\Delta)\subseteq
+    \operatorname{Hull}_L(\Theta)$.  Transitivity of the canonical inclusions
+    and the inverse commuting square then give
+    \begin{align}
+        \iota_{\operatorname{Hull}_L(\Theta)}
+          \mathcal U_{L,\Theta}(\iota_{\Delta,\Theta}(A))
+        &=\iota_{\operatorname{Hull}_L(\Delta)}
+          \mathcal U_{L,\Delta}(A).
+    \end{align}
+    The universal property of the algebraic direct limit therefore induces
+    both star-algebra homomorphisms.
+\end{proof}
 
 \begin{lemma}[Evaluation of the algebraic-local blocking maps]
     \label{lem:qca_algebraic_blocking_maps_evaluation}
@@ -9665,8 +9705,7 @@ $\omega^{-1}$.
     \label{def:qca_algebraic_blocking}
     \lean{SpinChain.algebraicLocalBlocking}
     \leanok
-    \uses{def:qca_algebraic_blocking_maps,
-        lem:qca_algebraic_blocking_maps_evaluation}
+    \uses{def:qca_algebraic_blocking_maps}
     For $d>0$ and $L>0$, forward blocking gives a star-algebra equivalence
     \begin{align}
         \mathcal A_{\mathrm{loc}}^{(d^L)}
@@ -9678,6 +9717,22 @@ $\omega^{-1}$.
     completion, intertwine translations, provide a propagation estimate or a
     circuit representation, or transport a quantum cellular automaton.
 \end{definition}
+
+\begin{proof}\leanok
+    \uses{lem:qca_algebraic_blocking_maps_evaluation,
+        thm:qca_local_observable_finite_support,
+        lem:qca_local_blocking_inclusion}
+    The identity $\mathcal B_L\mathcal U_L=\operatorname{id}$ makes
+    $\mathcal B_L$ surjective.  For injectivity, represent two blocked
+    observables on finite regions $\Lambda$ and $\Gamma$, enlarge both to
+    $\Omega=\Lambda\cup\Gamma$, and suppose their images under
+    $\mathcal B_L$ agree.  Injectivity of the canonical map from the finite
+    algebra on $\widehat\Omega_L$, followed by injectivity of
+    $\mathcal B_{L,\Omega}$ and the finite commuting square, gives equality of
+    the two representatives in the algebra on $\Omega$.  Thus
+    $\mathcal B_L$ is bijective, with inverse $\mathcal U_L$, and defines the
+    stated star-algebra equivalence.
+\end{proof}
 
 \begin{lemma}[Algebraic-local blocking formulas and norm]
     \label{lem:qca_algebraic_blocking_formulas}
@@ -9697,11 +9752,9 @@ $\omega^{-1}$.
     \uses{lem:qca_algebraic_blocking_maps_evaluation,
         thm:qca_local_blocking_formulas,
         def:qca_algebraic_local_operator_norm}
-    The reverse block-hull construction is a right inverse of forward blocking,
-    while injectivity follows after enlarging two blocked representatives to
-    the union of their finite supports and using the finite commuting square.
-    This gives the star-algebra equivalence.  On a finite representative, norm
-    preservation reduces to norm preservation by finite blocking and by the
-    canonical local inclusion; distance preservation follows by applying the
-    norm identity to differences.
+    The finite-representative formula is the defining formula for the forward
+    blocking homomorphism.  On such a representative, norm preservation
+    reduces to norm preservation by finite blocking and by the canonical local
+    inclusion; distance preservation follows by applying the norm identity to
+    differences.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9516,10 +9516,10 @@ $\omega^{-1}$.
         \mathcal A^{(d^L)}_\Lambda
         &\simeq \mathcal A^{(d)}_{\widehat\Lambda_L}.
     \end{align}
-    This is only a finite-region equivalence.  No compatibility with local
-    inclusions, extension to the algebraic-local or quasi-local algebra,
-    propagation statement, or transport of quantum cellular automata is
-    asserted here.
+    This is the finite-region equivalence underlying the algebraic-local
+    blocking construction below.  No quasi-local completion, compatibility
+    with translations, propagation statement, circuit representation, or
+    transport of quantum cellular automata is asserted here.
 \end{definition}
 
 \begin{theorem}[Finite local-algebra blocking formulas]
@@ -9537,4 +9537,171 @@ $\omega^{-1}$.
     \uses{def:qca_local_blocking}
     The entry formula is matrix reindexing.  A star-algebra equivalence between
     finite matrix algebras preserves the C-star norm and hence distances.
+\end{proof}
+
+\begin{definition}[Finite block hull]
+    \label{def:qca_block_hull}
+    \lean{SpinChain.blockHull}
+    \leanok
+    For $L>0$ and a finite original region $\Delta\subset\mathbb Z$, define
+    its block hull by
+    \begin{align}
+        \operatorname{Hull}_L(\Delta)
+        &=\{\lfloor z/L\rfloor:z\in\Delta\}.
+    \end{align}
+    This is the finite set of length-$L$ blocks that meet $\Delta$.
+\end{definition}
+
+\begin{theorem}[Block-hull containment and monotonicity]
+    \label{thm:qca_block_hull_properties}
+    \lean{SpinChain.subset_expandedRegion_blockHull,SpinChain.blockHull_mono}
+    \leanok
+    \uses{def:qca_block_hull, def:qca_expanded_region}
+    Let $L>0$.  Every finite original region is contained in the expansion of
+    its block hull,
+    \begin{align}
+        \Delta\subseteq
+        \widehat{\operatorname{Hull}_L(\Delta)}_L.
+    \end{align}
+    Moreover, $\Delta\subseteq\Theta$ implies
+    $\operatorname{Hull}_L(\Delta)\subseteq
+    \operatorname{Hull}_L(\Theta)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_block_hull, thm:qca_expanded_region_coordinates}
+    The quotient coordinate of each $z\in\Delta$ belongs to the image defining
+    the hull, which proves containment after expansion.  Monotonicity follows
+    by retaining the same witness $z$ in the larger region.
+\end{proof}
+
+\begin{theorem}[Blocking commutes with finite local inclusions]
+    \label{thm:qca_local_blocking_inclusion}
+    \lean{SpinChain.localBlocking_localInclusion}
+    \leanok
+    \uses{def:qca_local_blocking, thm:qca_configuration_blocking_formulas,
+        def:qca_local_inclusion}
+    Let $L>0$.  For finite blocked regions $\Lambda\subseteq\Gamma$, the
+    square formed by finite blocking and the two canonical local inclusions
+    commutes:
+    \begin{align}
+        \mathcal B_{L,\Gamma}\,\iota_{\Lambda,\Gamma}
+        &=\iota_{\widehat\Lambda_L,\widehat\Gamma_L}\,
+          \mathcal B_{L,\Lambda}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_local_blocking_formulas,
+        thm:qca_configuration_blocking_formulas}
+    Restriction of decoded configurations commutes with blocking.  Equality on
+    the complementary blocked sites is equivalent to equality on all original
+    sites in $\widehat\Gamma_L\setminus\widehat\Lambda_L$.  Substitution into
+    the matrix-entry formula for the canonical inclusion proves the square.
+\end{proof}
+
+\begin{definition}[Forward and reverse algebraic-local blocking maps]
+    \label{def:qca_algebraic_blocking_maps}
+    \lean{SpinChain.algebraicLocalBlockingHom,
+        SpinChain.algebraicLocalUnblockingHom}
+    \leanok
+    \uses{def:qca_algebraic_local_algebra, thm:qca_block_hull_properties,
+        thm:qca_local_blocking_inclusion}
+    Let $L>0$.  The compatible finite blocking maps induce a star-algebra
+    homomorphism
+    \begin{align}
+        \mathcal B_L:\mathcal A_{\mathrm{loc}}^{(d^L)}
+        \longrightarrow\mathcal A_{\mathrm{loc}}^{(d)}.
+    \end{align}
+    In the reverse direction there is a star-algebra homomorphism
+    \begin{align}
+        \mathcal U_L:\mathcal A_{\mathrm{loc}}^{(d)}
+        \longrightarrow\mathcal A_{\mathrm{loc}}^{(d^L)}.
+    \end{align}
+    A representative on an arbitrary original region $\Delta$ is first
+    included into $\widehat{\operatorname{Hull}_L(\Delta)}_L$ and then finite
+    blocking is inverted.  Thus the reverse construction does not require
+    $\Delta$ itself to be an expanded region.
+\end{definition}
+
+\begin{theorem}[Evaluation of the algebraic-local blocking maps]
+    \label{thm:qca_algebraic_blocking_maps_evaluation}
+    \lean{SpinChain.algebraicLocalBlockingHom_localObservable,
+        SpinChain.algebraicLocalUnblockingHom_localObservable,
+        SpinChain.algebraicLocalBlockingHom_comp_unblockingHom,
+        SpinChain.algebraicLocalUnblockingHom_comp_blockingHom}
+    \leanok
+    \uses{def:qca_algebraic_blocking_maps,
+        thm:qca_block_hull_properties}
+    Let $L>0$.  The forward map applies finite blocking to a representative on
+    $\Lambda$ and regards the result as supported on $\widehat\Lambda_L$.  The
+    reverse map enlarges a representative on $\Delta$ to the expansion of its
+    block hull, applies the inverse finite blocking equivalence, and regards
+    the result as supported on $\operatorname{Hull}_L(\Delta)$.  Their
+    composites have the orientations
+    \begin{align}
+        \mathcal B_L\mathcal U_L
+        &=\operatorname{id}_{\mathcal A_{\mathrm{loc}}^{(d)}},\\
+        \mathcal U_L\mathcal B_L
+        &=\operatorname{id}_{\mathcal A_{\mathrm{loc}}^{(d^L)}}.
+    \end{align}
+    The first identity holds for every on-site dimension $d$; the second also
+    assumes $d>0$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_local_blocking_inclusion,
+        thm:qca_block_hull_properties}
+    These are the evaluation formulas for the two compatible-family lifts.
+    Forward compatibility is the commuting square.  Reverse compatibility
+    follows by monotonicity of block hulls, composition of local inclusions,
+    and the same square applied in the inverse direction.  Forward blocking
+    after the reverse map reduces to the canonical inclusion of $\Delta$ into
+    its expanded block hull.  The other composite is the identity by
+    injectivity of the forward map.
+\end{proof}
+
+\begin{definition}[Algebraic-local site-blocking equivalence]
+    \label{def:qca_algebraic_blocking}
+    \lean{SpinChain.algebraicLocalBlocking}
+    \leanok
+    \uses{def:qca_algebraic_blocking_maps,
+        thm:qca_algebraic_blocking_maps_evaluation}
+    For $d>0$ and $L>0$, forward blocking gives a star-algebra equivalence
+    \begin{align}
+        \mathcal A_{\mathrm{loc}}^{(d^L)}
+        &\simeq \mathcal A_{\mathrm{loc}}^{(d)}.
+    \end{align}
+    This formalizes only the algebraic-local change of site grouping used at
+    lines~2308 and 2313--2320 of \cite{Cirac2017MPU}.  It does not assert the
+    QCA-to-MPU converse at line~2308, extend blocking to the quasi-local
+    completion, intertwine translations, provide a propagation estimate or a
+    circuit representation, or transport a quantum cellular automaton.
+\end{definition}
+
+\begin{theorem}[Algebraic-local blocking formulas and norm]
+    \label{thm:qca_algebraic_blocking_formulas}
+    \lean{SpinChain.algebraicLocalBlocking_apply,
+        SpinChain.algebraicLocalBlocking_localObservable,
+        SpinChain.algebraicLocalBlocking_norm,
+        SpinChain.algebraicLocalBlocking_isometry}
+    \leanok
+    \uses{def:qca_algebraic_blocking,
+        thm:qca_algebraic_blocking_maps_evaluation}
+    Let $d>0$ and $L>0$.  The equivalence agrees with the forward lift and
+    sends every finite representative to its finite blocking on the expanded
+    region.  It preserves the algebraic-local operator norm and is an isometry.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_algebraic_blocking_maps_evaluation,
+        thm:qca_local_blocking_formulas,
+        def:qca_algebraic_local_operator_norm}
+    The reverse block-hull construction is a right inverse of forward blocking,
+    while injectivity follows after enlarging two blocked representatives to
+    the union of their finite supports and using the finite commuting square.
+    This gives the star-algebra equivalence.  On a finite representative, norm
+    preservation reduces to norm preservation by finite blocking and by the
+    canonical local inclusion; distance preservation follows by applying the
+    norm identity to differences.
 \end{proof}


### PR DESCRIPTION
Closes #6961

## Summary
- prove finite site blocking commutes with canonical local inclusions
- define block hulls and forward/reverse algebraic-local blocking homomorphisms
- package the mutually inverse maps as a norm-preserving star-algebra equivalence
- synchronize Chapter 28 Blueprint coverage for all new declarations

## Scope
This is algebraic-local only. Quasi-local completion, scaled translations, propagation estimates, circuit representations, QCA transport, and the QCA-to-MPU converse remain outside this PR.

## Checks
- `lake env lean TNLean/QCA/AlgebraicBlocking.lean`
- `lake env lean TNLean/QCA.lean`
- `lake build TNLean.QCA.AlgebraicBlocking`
- generated import aggregator tests
- Blueprint sync and changed-declaration reverse coverage
- reader-facing prose, whitespace, and proof-integrity checks