### PR TITLE
doc(tenkz): correct the arc-route retirement citation

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3311,3 +3311,10 @@ removals themselves; no key is added.
 |---|---|
 | flag:consumers:key:kernel-atom:nudge | retired: sentenced by amendment seven, read by nothing, written by nothing; permanent |
 | flag:consumers:key:kernel-mark:nudge | retired: sentenced by amendment seven, the label station rule landed in #6168; permanent |
+
+### 2026-08-23 — correction to the arc-route citation
+
+The two references to #6201 in the 2026-08-22 retirement of `bend=` should
+be read as references to #6881. Issue #6201 identified that `route=arc` drew
+no distinct curve; PR #6881 made the route leave and enter along its ends'
+faces. This correction is appended because shrink sessions are immutable.


### PR DESCRIPTION
### Motivation

- The 2026-08-22 `bend=` retirement twice attributes the executable `route=arc` behavior to issue LionSR/tenkz#198, although PR LionSR/TNLean#6881 implemented that behavior.
- `docs/tenkz/SHRINK.md` is an append-only evidence ledger, so its historical session bytes cannot be rewritten without failing the shrink gate.

### Description

- Append a dated correction stating that both historical `#6201` references must be read as `#6881`.
- Distinguish the roles precisely: LionSR/tenkz#198 reported that `route=arc` drew no distinct curve; LionSR/TNLean#6881 made the route follow its endpoint faces.
- Preserve the original session bytes and therefore the ledger audit trail.

### Testing

- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `git diff --check`

### Agent assistance

OpenAI Codex (GPT-5) identified the append-only gate constraint, prepared the correction, and ran the checks. Sirui Lu remains accountable for the change.

Closes LionSR/tenkz#230