### PR TITLE
feat(MPU): add conditional source-index blocking bridge

### DIFF
--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -88,8 +88,10 @@ Then the specified source-index values of the two blocked tensors agree.
 
 This composes the rank-growth and logarithmic-cancellation steps in
 arXiv:1703.09188, Proposition IV.2, lines 697--704. The endpoint product
-identities and rank positivity are explicit hypotheses; this theorem neither
-chooses a simple blocking nor asserts the public blocking-independent index.
+identities are explicit hypotheses. Their positivity consequences supply the
+rank positivity required by the specified source-index value. This theorem
+neither chooses a simple blocking nor asserts the public blocking-independent
+index.
 
 **Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
 with Theorem III.8 and the blocked physical dimension $d^k$, the endpoint
@@ -97,12 +99,24 @@ product is $d^{2k}$. See
 `docs/paper-gaps/mpu_blocking_rank_product_exponent.tex`. -/
 theorem sourceIndexValue_blockTensor_eq_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
-    (hr₀ : 0 < r[blockTensor U k₀]) (hℓ₀ : 0 < ℓ[blockTensor U k₀])
-    (hr : 0 < r[blockTensor U k]) (hℓ : 0 < ℓ[blockTensor U k])
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
     (hprod : r[blockTensor U k] * ℓ[blockTensor U k] = d ^ (2 * k)) :
-    sourceIndexValue (blockTensor U k) hr hℓ =
-      sourceIndexValue (blockTensor U k₀) hr₀ hℓ₀ := by
+    sourceIndexValue (blockTensor U k)
+        (Nat.pos_of_mul_pos_right (hprod.symm ▸ Nat.pow_pos hd))
+        (Nat.pos_of_mul_pos_left (hprod.symm ▸ Nat.pow_pos hd)) =
+      sourceIndexValue (blockTensor U k₀)
+        (Nat.pos_of_mul_pos_right (hprod₀.symm ▸ Nat.pow_pos hd))
+        (Nat.pos_of_mul_pos_left (hprod₀.symm ▸ Nat.pow_pos hd)) := by
+  have hr : 0 < r[blockTensor U k] :=
+    Nat.pos_of_mul_pos_right (hprod.symm ▸ Nat.pow_pos hd)
+  have hℓ : 0 < ℓ[blockTensor U k] :=
+    Nat.pos_of_mul_pos_left (hprod.symm ▸ Nat.pow_pos hd)
+  have hr₀ : 0 < r[blockTensor U k₀] :=
+    Nat.pos_of_mul_pos_right (hprod₀.symm ▸ Nat.pow_pos hd)
+  have hℓ₀ : 0 < ℓ[blockTensor U k₀] :=
+    Nat.pos_of_mul_pos_left (hprod₀.symm ▸ Nat.pow_pos hd)
+  change sourceIndexValue (blockTensor U k) hr hℓ =
+    sourceIndexValue (blockTensor U k₀) hr₀ hℓ₀
   obtain ⟨hrScale, hℓScale⟩ :=
     blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod
   exact sourceIndexValue_eq_of_common_rank_scale

--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.SourceCuts
+import TNLean.MPS.MPU.BlockingRanks
 import Mathlib.Analysis.SpecialFunctions.Log.Base
 
 /-!
@@ -34,6 +34,8 @@ of the chosen simple blocking, is not asserted here.
 
 * `MPOTensor.sourceIndexValue_eq_of_common_rank_scale`: cancellation of a
   supplied common positive rank scale.
+* `MPOTensor.sourceIndexValue_blockTensor_eq_of_products`: blocking invariance
+  under supplied endpoint rank-product identities.
 * `MPOTensor.sourceIndexValue_eq_add_of_common_rank_product`: additivity from
   supplied source-rank product identities with a common positive factor.
 * `MPOTensor.sourceIndexValue_eq_logb_rightRank_div`: the right-rank formula
@@ -76,6 +78,36 @@ theorem sourceIndexValue_eq_of_common_rank_scale
   have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU.ne'
   rw [Real.logb_mul hcReal hrReal, Real.logb_mul hcReal hℓReal]
   ring
+
+/-- Suppose $k₀ \le k$, the physical dimension $d$ is positive, and the
+endpoint source ranks satisfy
+$$
+r_{k₀}\ell_{k₀}=d^{2k₀}, \qquad r_k\ell_k=d^{2k}.
+$$
+Then the specified source-index values of the two blocked tensors agree.
+
+This composes the rank-growth and logarithmic-cancellation steps in
+arXiv:1703.09188, Proposition IV.2, lines 697--704. The endpoint product
+identities and rank positivity are explicit hypotheses; this theorem neither
+chooses a simple blocking nor asserts the public blocking-independent index.
+
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
+with Theorem III.8 and the blocked physical dimension $d^k$, the endpoint
+product is $d^{2k}$. See
+`docs/paper-gaps/mpu_blocking_rank_product_exponent.tex`. -/
+theorem sourceIndexValue_blockTensor_eq_of_products (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) (hd : 0 < d)
+    (hr₀ : 0 < r[blockTensor U k₀]) (hℓ₀ : 0 < ℓ[blockTensor U k₀])
+    (hr : 0 < r[blockTensor U k]) (hℓ : 0 < ℓ[blockTensor U k])
+    (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
+    (hprod : r[blockTensor U k] * ℓ[blockTensor U k] = d ^ (2 * k)) :
+    sourceIndexValue (blockTensor U k) hr hℓ =
+      sourceIndexValue (blockTensor U k₀) hr₀ hℓ₀ := by
+  obtain ⟨hrScale, hℓScale⟩ :=
+    blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod
+  exact sourceIndexValue_eq_of_common_rank_scale
+    (blockTensor U k₀) (blockTensor U k) (d ^ (k - k₀)) (Nat.pow_pos hd)
+    hr₀ hℓ₀ hrScale hℓScale
 
 /-- Suppose the right and left source ranks of specified tensors $U$, $V$, and
 $W$ satisfy

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4808,6 +4808,41 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     and use $\log_2(x/y)=\log_2x-\log_2y$.
 \end{proof}
 
+\begin{theorem}[Conditional blocking invariance of the specified source-index value]
+    \label{thm:mpu_specified_source_index_blocking_invariance}
+    \lean{MPOTensor.sourceIndexValue_blockTensor_eq_of_products}
+    \leanok
+    \uses{def:mpu_specified_source_index_value, thm:mpu_specified_source_index_identities, thm:mpu_source_cut_rank_blocking_saturation}
+    Let $d>0$ and $k_0\leq k$. Suppose that all four endpoint source ranks
+    $r_{k_0}$, $\ell_{k_0}$, $r_k$, and $\ell_k$ are positive and satisfy
+    \begin{align}
+        r_{k_0}\ell_{k_0} & =d^{2k_0}, &
+        r_k\ell_k         & =d^{2k}.
+    \end{align}
+    Then the specified source-index values agree:
+    \begin{align}
+        \operatorname{ind}_{\mathrm{src}}(\mathcal U_k)
+         & =\operatorname{ind}_{\mathrm{src}}(\mathcal U_{k_0}).
+    \end{align}
+    This statement assumes the endpoint products; it neither selects a simple
+    blocking nor defines the public index.
+    % Auxiliary to paper_v2.tex lines 690--704; issue 6958.
+    % **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
+    % consistent blocked identity is $d^{2k}$. See
+    % docs/paper-gaps/mpu_blocking_rank_product_exponent.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_specified_source_index_identities, thm:mpu_source_cut_rank_blocking_saturation}
+    Exact blocking growth gives the common positive factor $d^{k-k_0}$:
+    \begin{align}
+        r_k    & =d^{k-k_0}r_{k_0}, &
+        \ell_k & =d^{k-k_0}\ell_{k_0}.
+    \end{align}
+    Its logarithm occurs once in each rank term and therefore cancels from
+    their difference.
+\end{proof}
+
 \begin{definition}[Index]
     \label{def:index}
     \notready
@@ -4852,7 +4887,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{index-well-defined}
     \notready
     \discussion{6014}
-    \uses{def:index, ThmFund1, thm:mpu_source_cut_rank_blocking, thm:mpu_source_cut_rank_blocking_saturation, thm:mpu_all_later_simple_blockings}
+    \uses{def:index, ThmFund1, thm:mpu_source_cut_rank_blocking, thm:mpu_source_cut_rank_blocking_saturation, thm:mpu_specified_source_index_blocking_invariance, thm:mpu_all_later_simple_blockings}
     The source index is independent of the chosen simple blocking. More
     precisely, if $k\geq k_0$ and both $\mathcal U_{k_0}$ and $\mathcal U_k$
     are simple, then

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4812,11 +4812,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_specified_source_index_blocking_invariance}
     \lean{MPOTensor.sourceIndexValue_blockTensor_eq_of_products}
     \leanok
-    \uses{def:mpu_specified_source_index_value, thm:mpu_specified_source_index_identities, thm:mpu_source_cut_rank_blocking_saturation}
-    Let $d>0$ and $k_0\leq k$. Suppose that all four endpoint source ranks
-    $r_{k_0}$, $\ell_{k_0}$, $r_k$, and $\ell_k$ are positive and satisfy
+    \uses{def:mpu_specified_source_index_value}
+    Let $d>0$ and $k_0\leq k$. Suppose that the endpoint source ranks satisfy
     \begin{align}
-        r_{k_0}\ell_{k_0} & =d^{2k_0}, &
+        r_{k_0}\ell_{k_0} & =d^{2k_0}, \\
         r_k\ell_k         & =d^{2k}.
     \end{align}
     Then the specified source-index values agree:
@@ -4833,10 +4832,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_specified_source_index_identities, thm:mpu_source_cut_rank_blocking_saturation}
+    \uses{thm:mpu_specified_source_index_identities,
+        thm:mpu_source_cut_rank_blocking_saturation}
     Exact blocking growth gives the common positive factor $d^{k-k_0}$:
     \begin{align}
-        r_k    & =d^{k-k_0}r_{k_0}, &
+        r_k    & =d^{k-k_0}r_{k_0}, \\
         \ell_k & =d^{k-k_0}\ell_{k_0}.
     \end{align}
     Its logarithm occurs once in each rank term and therefore cancels from
@@ -4887,7 +4887,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{index-well-defined}
     \notready
     \discussion{6014}
-    \uses{def:index, ThmFund1, thm:mpu_source_cut_rank_blocking, thm:mpu_source_cut_rank_blocking_saturation, thm:mpu_specified_source_index_blocking_invariance, thm:mpu_all_later_simple_blockings}
+    \uses{def:index, ThmFund1, thm:mpu_source_cut_rank_blocking,
+        thm:mpu_source_cut_rank_blocking_saturation,
+        thm:mpu_specified_source_index_blocking_invariance,
+        thm:mpu_all_later_simple_blockings}
     The source index is independent of the chosen simple blocking. More
     precisely, if $k\geq k_0$ and both $\mathcal U_{k_0}$ and $\mathcal U_k$
     are simple, then


### PR DESCRIPTION
## What changed

- add `MPOTensor.sourceIndexValue_blockTensor_eq_of_products`
- derive endpoint rank positivity from the supplied corrected product identities
- compose the existing blocking-rank saturation and common-scale logarithmic cancellation theorems
- add a separate Chapter 28 theorem node while leaving the public index and well-definedness proposition not ready

The theorem is conditional on
\[
r_{k_0}\ell_{k_0}=d^{2k_0},\qquad r_k\ell_k=d^{2k}.
\]
It does not assert `ThmFund1`, select a simple blocking, or define the public index.

## Validation

- `lake build TNLean.MPS.MPU.SourceIndexValue` (3164/3164)
- Blueprint source synchronization and strict declaration check (6639/6639)
- two `lualatex` passes with project `TEXINPUTS`, zero undefined cross-references
- `git diff --check`
- exact-head review: approved at `3f2ca3bdbef5ed4f74edb332bcc145746b714293`

Closes #6958
Advances #6014
