### PR TITLE
feat(MPU): add factor-parametric source equations

### DIFF
--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -69,28 +69,27 @@ theorem sum_sourceX₁_mul_sourceU
     _ = _ := by
       rw [← Matrix.mul_apply, sourceX₁_mul_sourceY₁_apply]
 
-/-- The open two-site matrix product factors through $X_1$, $u$, and $Y_2$.
+namespace SourceFactors
 
-Source: arXiv:1703.09188, equation `SVDforms2`, lines 526--530, and equation
-`uu`, lines 536--537. -/
-theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+/-- The open two-site product factors through $X_1,u,Y_2$ for any supplied
+source factorization.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `uu`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
     (U i₁ j₁ * U i₂ j₂) α γ =
       ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
-        sourceX₁ U ρ hρ (α, j₁) r * sourceU U ρ hρ (l, r) (i₁, i₂) *
-          sourceY₂ U l (j₂, γ) := by
+        S.X₁ (α, j₁) r * sourceU U S (l, r) (i₁, i₂) * S.Y₂ l (j₂, γ) := by
   classical
   simp only [Matrix.mul_apply]
   have h₁ (β : Fin D) : U i₁ j₁ α β =
-      ∑ r : Fin r[U], sourceX₁ U ρ hρ (α, j₁) r *
-        sourceY₁ U ρ hρ r (i₁, β) := by
-    simpa only [Matrix.mul_apply] using
-      (sourceX₁_mul_sourceY₁_apply U ρ hρ α j₁ i₁ β).symm
+      ∑ r : Fin r[U], S.X₁ (α, j₁) r * S.Y₁ r (i₁, β) := by
+    simpa only [Matrix.mul_apply] using (X₁_mul_Y₁_apply U S α j₁ i₁ β).symm
   have h₂ (β : Fin D) : U i₂ j₂ β γ =
-      ∑ l : Fin ℓ[U], sourceX₂ U (β, i₂) l * sourceY₂ U l (j₂, γ) := by
-    simpa only [Matrix.mul_apply] using
-      (sourceX₂_mul_sourceY₂_apply U β i₂ j₂ γ).symm
+      ∑ l : Fin ℓ[U], S.X₂ (β, i₂) l * S.Y₂ l (j₂, γ) := by
+    simpa only [Matrix.mul_apply] using (X₂_mul_Y₂_apply U S β i₂ j₂ γ).symm
   simp_rw [h₁, h₂, Finset.sum_mul_sum]
   simp_rw [sourceU_apply, Finset.mul_sum, Finset.sum_mul]
   rw [Finset.sum_comm]
@@ -102,6 +101,23 @@ theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
   apply Finset.sum_congr rfl
   intro β _
   ring
+
+end SourceFactors
+
+/-- The open two-site matrix product factors through $X_1$, $u$, and $Y_2$.
+
+Source: arXiv:1703.09188, equation `SVDforms2`, lines 526--530, and equation
+`uu`, lines 536--537. -/
+theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
+    (U i₁ j₁ * U i₂ j₂) α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        sourceX₁ U ρ hρ (α, j₁) r * sourceU U ρ hρ (l, r) (i₁, i₂) *
+          sourceY₂ U l (j₂, γ) := by
+  simpa [sourceFactors, sourceFactors_sourceU] using
+    SourceFactors.mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂ U
+      (sourceFactors U ρ hρ) i₁ j₁ i₂ j₂ α γ
 
 /-- Pair-index reformulation of the open two-site factorization. The output
 pair is \(q\), while \(j\) is the input pair. The name \(p\) remains reserved for the

--- a/TNLean/MPS/MPU/SourceUV.lean
+++ b/TNLean/MPS/MPU/SourceUV.lean
@@ -22,6 +22,64 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
+namespace SourceFactors
+
+/-- The paper's source tensor $u : d^2 \to \ell\times r$ associated with supplied
+source factors. The row order is `(left source, right source)` and the physical
+column order is `(first ket site, second ket site)`.
+
+Source: arXiv:1703.09188, equation `uu` and Figure `II_umatrix.png`, lines
+532--540. -/
+def sourceU {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    Matrix (Fin ℓ[U] × Fin r[U]) (Fin d × Fin d) ℂ :=
+  fun (l, r) (i₁, i₂) ↦ ∑ β : Fin D, S.Y₁ r (i₁, β) * S.X₂ (β, i₂) l
+
+/-- The paper's source tensor $v : r\times\ell \to d^2$ associated with supplied
+source factors. The physical row order is `(first bra site, second bra site)`
+and the column order is `(right source, left source)`.
+
+Source: arXiv:1703.09188, equation `vdagger` and Figure `II_vmatrix.png`, lines
+532--540. -/
+def sourceV {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    Matrix (Fin d × Fin d) (Fin r[U] × Fin ℓ[U]) ℂ :=
+  fun (j₁, j₂) (r, l) ↦ ∑ α : Fin D, S.X₁ (α, j₁) r * S.Y₂ l (j₂, α)
+
+/-- Entry formula for the source tensor $u$ associated with supplied factors.
+
+Source: arXiv:1703.09188, equation `uu`, lines 532--540. -/
+@[simp] theorem sourceU_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
+    sourceU U S (l, r) (i₁, i₂) =
+      ∑ β : Fin D, S.Y₁ r (i₁, β) * S.X₂ (β, i₂) l := rfl
+
+/-- Entry formula for the source tensor $v$ associated with supplied factors.
+
+Source: arXiv:1703.09188, equation `vdagger`, lines 532--540. -/
+@[simp] theorem sourceV_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) (j₁ j₂ : Fin d) (r : Fin r[U]) (l : Fin ℓ[U]) :
+    sourceV U S (j₁, j₂) (r, l) =
+      ∑ α : Fin D, S.X₁ (α, j₁) r * S.Y₂ l (j₂, α) := rfl
+
+/-- Entry form of the first source-cut factorization for supplied factors.
+
+Source: arXiv:1703.09188, equations `X1Y1` and `SVDforms2`, lines 508--528. -/
+@[simp] theorem X₁_mul_Y₁_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) (α : Fin D) (j i : Fin d) (β : Fin D) :
+    (S.X₁ * S.Y₁) (α, j) (i, β) = U i j α β := by
+  rw [← S.sourceCutM₁_eq]
+  rfl
+
+/-- Entry form of the second source-cut factorization for supplied factors.
+
+Source: arXiv:1703.09188, equations `X2Y2` and `SVDforms2`, lines 508--528. -/
+@[simp] theorem X₂_mul_Y₂_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) (α : Fin D) (i j : Fin d) (β : Fin D) :
+    (S.X₂ * S.Y₂) (α, i) (j, β) = U i j α β := by
+  rw [← S.sourceCutM₂_eq]
+  rfl
+
+end SourceFactors
+
 /-- The paper's source tensor $u : d^2 \to \ell\times r$.
 
 The row order is `(left source, right source)` and the physical column order is
@@ -45,6 +103,22 @@ noncomputable def sourceV (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     Matrix (Fin d × Fin d) (Fin r[U] × Fin ℓ[U]) ℂ :=
   fun (j₁, j₂) (r, l) ↦ ∑ α : Fin D,
     sourceX₁ U ρ hρ (α, j₁) r * sourceY₂ U l (j₂, α)
+
+/-- The compact-SVD source factors recover the existing source tensor $u$.
+
+Source: arXiv:1703.09188, equations `eq:sf-svd` and `uu`, lines 479--540. -/
+@[simp] theorem sourceFactors_sourceU
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    SourceFactors.sourceU U (sourceFactors U ρ hρ) = sourceU U ρ hρ := by
+  rfl
+
+/-- The compact-SVD source factors recover the existing source tensor $v$.
+
+Source: arXiv:1703.09188, equations `eq:sf-svd` and `vdagger`, lines 479--540. -/
+@[simp] theorem sourceFactors_sourceV
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    SourceFactors.sourceV U (sourceFactors U ρ hρ) = sourceV U ρ hρ := by
+  rfl
 
 /-- Stable entry formula for $u$ in the exact solid/dotted leg order.
 

--- a/TNLean/MPS/MPU/StandardForm.lean
+++ b/TNLean/MPS/MPU/StandardForm.lean
@@ -26,6 +26,109 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
+namespace SourceFactors
+
+/-- The open two-site product factors through $X_1,u,Y_2$ for any supplied
+source factorization.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `uu`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
+    (U i₁ j₁ * U i₂ j₂) α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        S.X₁ (α, j₁) r * sourceU U S (l, r) (i₁, i₂) * S.Y₂ l (j₂, γ) := by
+  classical
+  simp only [Matrix.mul_apply]
+  have h₁ (β : Fin D) : U i₁ j₁ α β =
+      ∑ r : Fin r[U], S.X₁ (α, j₁) r * S.Y₁ r (i₁, β) := by
+    simpa only [Matrix.mul_apply] using (X₁_mul_Y₁_apply U S α j₁ i₁ β).symm
+  have h₂ (β : Fin D) : U i₂ j₂ β γ =
+      ∑ l : Fin ℓ[U], S.X₂ (β, i₂) l * S.Y₂ l (j₂, γ) := by
+    simpa only [Matrix.mul_apply] using (X₂_mul_Y₂_apply U S β i₂ j₂ γ).symm
+  simp_rw [h₁, h₂, Finset.sum_mul_sum]
+  simp_rw [sourceU_apply, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  apply Finset.sum_congr rfl
+  intro β _
+  ring
+
+/-- The concrete two-site block factors through $X_1,u,Y_2$ for any supplied
+source factorization. The decoded source row has order `(l, r)`.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `uu`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem blockTwo_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (i j : Fin (d * d)) (α γ : Fin D) :
+    blockTwo U i j α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        S.X₁ (α, (finProdFinEquiv.symm j).1) r *
+          sourceU U S (l, r) (finProdFinEquiv.symm i) *
+            S.Y₂ l ((finProdFinEquiv.symm j).2, γ) := by
+  exact mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂ U S
+    (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1
+    (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2 α γ
+
+/-- The reflected open two-site product factors through $X_2,v,Y_1$ for any
+supplied source factorization. The physical row of $v$ is `(j₂, j₁)`, and its
+source column is `(r, l)`.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `vdagger`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem mul_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
+    (U i₁ j₁ * U i₂ j₂) α γ =
+      ∑ l : Fin ℓ[U], ∑ r : Fin r[U],
+        S.X₂ (α, i₁) l * sourceV U S (j₂, j₁) (r, l) * S.Y₁ r (i₂, γ) := by
+  classical
+  simp only [Matrix.mul_apply]
+  have h₁ (β : Fin D) : U i₁ j₁ α β =
+      ∑ l : Fin ℓ[U], S.X₂ (α, i₁) l * S.Y₂ l (j₁, β) := by
+    simpa only [Matrix.mul_apply] using (X₂_mul_Y₂_apply U S α i₁ j₁ β).symm
+  have h₂ (β : Fin D) : U i₂ j₂ β γ =
+      ∑ r : Fin r[U], S.X₁ (β, j₂) r * S.Y₁ r (i₂, γ) := by
+    simpa only [Matrix.mul_apply] using (X₁_mul_Y₁_apply U S β j₂ i₂ γ).symm
+  simp_rw [h₁, h₂, Finset.sum_mul_sum]
+  simp_rw [sourceV_apply, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  apply Finset.sum_congr rfl
+  intro β _
+  ring
+
+/-- The concrete two-site block has the reflected $X_2,v,Y_1$ form for any
+supplied source factorization. Its physical row and source column retain the
+orders `(j₂, j₁)` and `(r, l)`.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `vdagger`, and `StandardForm`,
+lines 526--540 and 603--617. -/
+theorem blockTwo_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (i j : Fin (d * d)) (α γ : Fin D) :
+    blockTwo U i j α γ =
+      ∑ l : Fin ℓ[U], ∑ r : Fin r[U],
+        S.X₂ (α, (finProdFinEquiv.symm i).1) l *
+          sourceV U S
+            ((finProdFinEquiv.symm j).2, (finProdFinEquiv.symm j).1) (r, l) *
+            S.Y₁ r ((finProdFinEquiv.symm i).2, γ) := by
+  exact mul_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁ U S
+    (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1
+    (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2 α γ
+
+end SourceFactors
+
 /-- The concrete two-site block factors through the paper's $X_1,u,Y_2$ form.
 The decoded ket and bra pairs retain the source tensor's row order `(l, r)`.
 
@@ -39,8 +142,9 @@ theorem blockTwo_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
         sourceX₁ U ρ hρ (α, (finProdFinEquiv.symm j).1) r *
           sourceU U ρ hρ (l, r) (finProdFinEquiv.symm i) *
             sourceY₂ U l ((finProdFinEquiv.symm j).2, γ) := by
-  exact mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair U ρ hρ
-    (finProdFinEquiv.symm i) (finProdFinEquiv.symm j) α γ
+  simpa [sourceFactors, sourceFactors_sourceU] using
+    SourceFactors.blockTwo_apply_eq_sum_X₁_mul_sourceU_mul_Y₂ U
+      (sourceFactors U ρ hρ) i j α γ
 
 /-- The reflected open two-site product factors through the paper's
 $X_2,v,Y_1$ form. The physical row of $v$ is explicitly `(j₂, j₁)`, and its
@@ -55,28 +159,9 @@ theorem mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁
       ∑ l : Fin ℓ[U], ∑ r : Fin r[U],
         sourceX₂ U (α, i₁) l * sourceV U ρ hρ (j₂, j₁) (r, l) *
           sourceY₁ U ρ hρ r (i₂, γ) := by
-  classical
-  simp only [Matrix.mul_apply]
-  have h₁ (β : Fin D) : U i₁ j₁ α β =
-      ∑ l : Fin ℓ[U], sourceX₂ U (α, i₁) l * sourceY₂ U l (j₁, β) := by
-    simpa only [Matrix.mul_apply] using
-      (sourceX₂_mul_sourceY₂_apply U α i₁ j₁ β).symm
-  have h₂ (β : Fin D) : U i₂ j₂ β γ =
-      ∑ r : Fin r[U], sourceX₁ U ρ hρ (β, j₂) r *
-        sourceY₁ U ρ hρ r (i₂, γ) := by
-    simpa only [Matrix.mul_apply] using
-      (sourceX₁_mul_sourceY₁_apply U ρ hρ β j₂ i₂ γ).symm
-  simp_rw [h₁, h₂, Finset.sum_mul_sum]
-  simp_rw [sourceV_apply, Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro l _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro r _
-  apply Finset.sum_congr rfl
-  intro β _
-  ring
+  simpa [sourceFactors, sourceFactors_sourceV] using
+    SourceFactors.mul_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁ U
+      (sourceFactors U ρ hρ) i₁ j₁ i₂ j₂ α γ
 
 /-- The concrete two-site block in the reflected paper form $X_2,v,Y_1$.
 The standard product-index decoding exposes `(j₂, j₁)` and `(r, l)` without an

--- a/TNLean/MPS/MPU/StandardForm.lean
+++ b/TNLean/MPS/MPU/StandardForm.lean
@@ -28,37 +28,6 @@ variable {d D : ℕ} (U : MPOTensor d D)
 
 namespace SourceFactors
 
-/-- The open two-site product factors through $X_1,u,Y_2$ for any supplied
-source factorization.
-
-Source: arXiv:1703.09188, equations `SVDforms2`, `uu`, and `StandardForm`,
-lines 526--540 and 603--617. -/
-theorem mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
-    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
-    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
-    (U i₁ j₁ * U i₂ j₂) α γ =
-      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
-        S.X₁ (α, j₁) r * sourceU U S (l, r) (i₁, i₂) * S.Y₂ l (j₂, γ) := by
-  classical
-  simp only [Matrix.mul_apply]
-  have h₁ (β : Fin D) : U i₁ j₁ α β =
-      ∑ r : Fin r[U], S.X₁ (α, j₁) r * S.Y₁ r (i₁, β) := by
-    simpa only [Matrix.mul_apply] using (X₁_mul_Y₁_apply U S α j₁ i₁ β).symm
-  have h₂ (β : Fin D) : U i₂ j₂ β γ =
-      ∑ l : Fin ℓ[U], S.X₂ (β, i₂) l * S.Y₂ l (j₂, γ) := by
-    simpa only [Matrix.mul_apply] using (X₂_mul_Y₂_apply U S β i₂ j₂ γ).symm
-  simp_rw [h₁, h₂, Finset.sum_mul_sum]
-  simp_rw [sourceU_apply, Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro r _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro l _
-  apply Finset.sum_congr rfl
-  intro β _
-  ring
-
 /-- The concrete two-site block factors through $X_1,u,Y_2$ for any supplied
 source factorization. The decoded source row has order `(l, r)`.
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2249,7 +2249,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Entry forms of the source-cut factorizations]
     \label{thm:mpu_source_factorization_entries}
-    \lean{MPOTensor.sourceX₁_mul_sourceY₁_apply,
+    \lean{MPOTensor.SourceFactors.X₁_mul_Y₁_apply,
+        MPOTensor.SourceFactors.X₂_mul_Y₂_apply,
+        MPOTensor.sourceX₁_mul_sourceY₁_apply,
         MPOTensor.sourceX₂_mul_sourceY₂_apply}
     \leanok
     \uses{thm:mpu_source_factorizations, def:mpu_source_matrix_one, def:mpu_source_matrix_two}
@@ -2381,13 +2383,20 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Source tensors $u$ and $v$]
     \label{def:mpu_source_uv}
-    \lean{MPOTensor.sourceU,MPOTensor.sourceV,
+    \lean{MPOTensor.SourceFactors.sourceU,
+        MPOTensor.SourceFactors.sourceV,
+        MPOTensor.SourceFactors.sourceU_apply,
+        MPOTensor.SourceFactors.sourceV_apply,
+        MPOTensor.sourceFactors_sourceU,
+        MPOTensor.sourceFactors_sourceV,
+        MPOTensor.sourceU,MPOTensor.sourceV,
         MPOTensor.sourceU_apply,MPOTensor.sourceV_apply,
         MPOTensor.sourceU_conjTranspose_apply,
         MPOTensor.sourceV_conjTranspose_apply}
     \leanok
     \uses{def:mpu_weighted_source_factors}
-    For a positive definite source weight $\rho$, define
+    Given any six source factors satisfying the two source-cut
+    factorizations and their normalization identities, define
     \begin{align}
         u & : \mathbb C^d\otimes\mathbb C^d
         \longrightarrow \mathbb C^\ell\otimes\mathbb C^r, \\
@@ -2404,7 +2413,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     The source legs of $u$ have order $\ell\times r$, whereas those of $v$
     have order $r\times\ell$. These are the two source tensors introduced
     after the source-cut decompositions in \cite[Section~III]{Cirac2017MPU}.
-    The entry formulas also fix the conjugate-transpose orientation.
+    The entry formulas also fix the conjugate-transpose orientation. The
+    compact singular-value decompositions above give one such choice and
+    recover the same tensors $u$ and $v$.
 \end{definition}
 
 \begin{theorem}[Exact translated two-site source factorization]
@@ -2448,7 +2459,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Open two-site source factorization]
     \label{thm:mpu_source_u_open_two_site}
-    \lean{MPOTensor.sum_sourceX₁_mul_sourceU,
+    \lean{MPOTensor.SourceFactors.mul_apply_eq_sum_X₁_mul_sourceU_mul_Y₂,
+        MPOTensor.SourceFactors.blockTwo_apply_eq_sum_X₁_mul_sourceU_mul_Y₂,
+        MPOTensor.sum_sourceX₁_mul_sourceU,
         MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂,
         MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair,
         MPOTensor.blockTwo_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂}
@@ -2490,7 +2503,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Reflected open two-site source factorization]
     \label{thm:mpu_source_v_open_two_site}
-    \lean{MPOTensor.mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁,
+    \lean{MPOTensor.SourceFactors.mul_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁,
+        MPOTensor.SourceFactors.blockTwo_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁,
+        MPOTensor.mul_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁,
         MPOTensor.blockTwo_apply_eq_sum_sourceX₂_mul_sourceV_reflected_mul_sourceY₁}
     \leanok
     \uses{def:mpu_source_uv, def:mpdo_two_site_blocking,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2395,8 +2395,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.sourceV_conjTranspose_apply}
     \leanok
     \uses{def:mpu_weighted_source_factors}
-    Given any six source factors satisfying the two source-cut
-    factorizations and their normalization identities, define
+    Given source-cut decompositions $M_1=X_1Y_1$ and $M_2=X_2Y_2$, define
     \begin{align}
         u & : \mathbb C^d\otimes\mathbb C^d
         \longrightarrow \mathbb C^\ell\otimes\mathbb C^r, \\
@@ -2413,9 +2412,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     The source legs of $u$ have order $\ell\times r$, whereas those of $v$
     have order $r\times\ell$. These are the two source tensors introduced
     after the source-cut decompositions in \cite[Section~III]{Cirac2017MPU}.
-    The entry formulas also fix the conjugate-transpose orientation. The
-    compact singular-value decompositions above give one such choice and
-    recover the same tensors $u$ and $v$.
+    The entry formulas also fix the conjugate-transpose orientation. A
+    supplied source-factor witness provides these decompositions. The fixed
+    compact-SVD factors specialize the formulas to the previously defined
+    tensors.
 \end{definition}
 
 \begin{theorem}[Exact translated two-site source factorization]


### PR DESCRIPTION
## What changed

- define source tensors `u` and `v` for supplied `MPOTensor.SourceFactors`
- add entry identities and specialization to the project's fixed compact-SVD factors
- generalize the source-u and reflected source-v open-leg equations while preserving the paper's leg orders
- make the existing choice-based source-u proof a specialization of the factor-parametric theorem
- extend the existing Chapter 28 nodes without claiming shift formulas, source unitarity, `ThmFund1`, or a public standard-form package

This exposes explicit factor choices for later shift-family witnesses without asserting a choice-dependent swap equality.

## Validation

- `lake build TNLean.MPS.MPU.SourceUV TNLean.MPS.MPU.SourceUOpenTail TNLean.MPS.MPU.StandardForm` (3167/3167)
- Blueprint source synchronization and strict declaration check (6650/6650)
- two `lualatex` passes with project `TEXINPUTS`, zero undefined cross-references
- `git diff --check`
- exact-head review: approved at `786a1a3bea8988e7c47a1e7625f44fadf3f97229`

Closes #6959
Advances #6288
