### PR TITLE
fix(tenkz): make the label bearing default spellable

### DIFF
--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -297,7 +297,8 @@ def _parser_leaf_keys_from_texts(texts: Iterable[str]) -> set[tuple[str, str]]:
 # kernel families in the parser-path census.
 _KERNEL_HELPER = re.compile(
     r"\\__tenkz_kernel_"
-    r"(?:value:nnn|choice:nnnn|flag:nnn|positive_integer:nnnnnn|side:nn)\s*"
+    r"(?:value:nnn|choice:nnnn|flag:nnn|positive_integer:nnnnnn|side:nn"
+    r"|label_pos:nn)\s*"
     r"\{\s*tenkz-kernel-([a-z]+(?:-[a-z]+)*)\s*\}\s*\{\s*([^}]+?)\s*\}"
 )
 _KERNEL_BLOCK = re.compile(

--- a/tests/tenkz/kernel/regression/r_label_pos_auto.tex
+++ b/tests/tenkz/kernel/regression/r_label_pos_auto.tex
@@ -1,0 +1,83 @@
+% Regression: the registry default of `label pos` is the word auto -- the
+% automatic chooser -- so the word must be spellable.  Spelling the default
+% is saying nothing: B spells auto and stands where A, who spelled nothing,
+% stands; C spells a bearing and then auto, and the auto retracts the
+% bearing, last wins.  D spells a braced spaced bearing, which stages its
+% trimmed word: the compass reader answers words, so an untrimmed stage
+% would crash the bearing arithmetic, and D compiling at all is the claim.
+% The chooser answers for A, B, and C and is asked nothing by D.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \l__tenkz_test_pos_count_int
+\tl_new:N \l__tenkz_test_pos_label_tl
+\cs_new_eq:NN
+  \__tenkz_test_pos_auto:nN \__tenkz_kernel_r_label_auto_side:nN
+\cs_set_protected:Npn \__tenkz_kernel_r_label_auto_side:nN #1#2
+  {
+    \__tenkz_test_pos_auto:nN {#1} #2
+    \int_gincr:N \l__tenkz_test_pos_count_int
+    \__tenkz_model_get:nnN {#1} {label} \l__tenkz_test_pos_label_tl
+    \str_case:VnF \l__tenkz_test_pos_label_tl
+      {
+        {A}
+          {
+            \str_if_eq:VnF #2 {e}
+              { \errmessage{the~unspelled~default~answered~the~wrong~face} }
+          }
+        {B}
+          {
+            \str_if_eq:VnF #2 {e}
+              { \errmessage{the~spelled~default~answered~the~wrong~face} }
+          }
+        {C}
+          {
+            \str_if_eq:VnF #2 {e}
+              { \errmessage{a~retracted~bearing~answered~the~wrong~face} }
+          }
+      }
+      { \errmessage{an~explicit~bearing~reached~the~automatic~chooser} }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+% Nothing spelled: the carrier runs north-south through the bead and the
+% chooser takes east, the first free face after the carried pair.
+\begin{tenkz}[lattice={3x1}, bonds=none]
+  \tn[at=(1,1), name=P]{}
+  \tn[at=(3,1), name=Q]{}
+  \tnwire[name=W]{P}{Q}
+  \tn[at=on W 0.5, skin=dot]{A}
+\end{tenkz}
+% The default spelled: auto stages no bearing, and the bead stands where A
+% stands.
+\begin{tenkz}[lattice={3x1}, bonds=none]
+  \tn[at=(1,1), name=P0]{}
+  \tn[at=(3,1), name=Q0]{}
+  \tnwire[name=W0]{P0}{Q0}
+  \tn[at=on W0 0.5, skin=dot, label pos=auto]{B}
+\end{tenkz}
+% A bearing retracted: the later auto removes the staged north, last wins,
+% and the chooser answers as if nothing had been spelled.
+\begin{tenkz}[lattice={3x1}, bonds=none]
+  \tn[at=(1,1), name=P1]{}
+  \tn[at=(3,1), name=Q1]{}
+  \tnwire[name=W1]{P1}{Q1}
+  \tn[at=on W1 0.5, skin=dot, label pos=n, label pos=auto]{C}
+\end{tenkz}
+% A braced spaced bearing: the stage takes the trimmed word, so the compass
+% reader meets e, not a spaced word it would carry into the arithmetic.
+\begin{tenkz}[lattice={3x1}, bonds=none]
+  \tn[at=(1,1), name=P2]{}
+  \tn[at=(3,1), name=Q2]{}
+  \tnwire[name=W2]{P2}{Q2}
+  \tn[at=on W2 0.5, skin=dot, label pos={ e }]{D}
+\end{tenkz}
+\ExplSyntaxOn
+\int_compare:nNnF { \l__tenkz_test_pos_count_int } = {3}
+  { \errmessage{the~spellable~default~fixture~did~not~ask~three~answers} }
+\ExplSyntaxOff
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -903,9 +903,11 @@
       { \tl_use:N \l__tenkz_kernel_list_item_tl }
   }
 
-% crossing= is the string's habit: the order it takes at every crossing it
-% makes, stated once instead of once per crossing.  `alternate' flips along
-% the order the string meets them, and `alternate=under' anchors the first.
+% crossing= orders the crossing set a hull route derives: one order for
+% every crossing the route makes, stated once instead of once per crossing.
+% A free string derives no crossing set, so its crossings answer to cross=
+% alone.  `alternate' flips along the order the string meets them, and
+% `alternate=under' anchors the first.
 \cs_new_protected:Npn \__tenkz_kernel_crossing:n #1
   {
     \tl_set:Nn \l__tenkz_kernel_list_item_tl {#1}
@@ -971,6 +973,29 @@
   {
     \keys_define:nn {#1}
       { #2 .code:n = { \__tenkz_kernel_stage_put:nn {#3} {##1} } }
+  }
+% A label bearing's registry default is the word auto -- the automatic
+% chooser -- so the word must be spellable.  Spelling the default is saying
+% nothing: auto stages no bearing and retracts one an earlier spelling
+% staged, the last-wins doctrine the alphabet already follows.  The stage
+% takes the trimmed word the comparison read, since a braced key value may
+% arrive spaced and the compass reader answers words, not spaced words.
+\cs_new_protected:Npn \__tenkz_kernel_label_pos:nn #1#2
+  {
+    \keys_define:nn {#1}
+      {
+        #2 .code:n =
+          {
+            \tl_set:Nn \l__tenkz_kernel_list_item_tl {##1}
+            \tl_trim_spaces:N \l__tenkz_kernel_list_item_tl
+            \str_if_eq:VnTF \l__tenkz_kernel_list_item_tl {auto}
+              { \prop_remove:Nn \l__tenkz_kernel_stage_prop {label-pos} }
+              {
+                \__tenkz_kernel_stage_put:ne {label-pos}
+                  { \tl_use:N \l__tenkz_kernel_list_item_tl }
+              }
+          }
+      }
   }
 % A side takes one word of the policy alphabet, and the cup word takes the
 % matrix that stands on its bend.  The matrix is a second slot on the same
@@ -1400,7 +1425,7 @@
   { tenkz-kernel-atom } { pairing~cross } { pairing-cross }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { size }
   { s, m, l } { size }
-\__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { label~pos } { label-pos }
+\__tenkz_kernel_label_pos:nn { tenkz-kernel-atom } { label~pos }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { void }
   { open, sealed } { void }
 % A site may answer the picture's physical policy for itself: the policy
@@ -1464,7 +1489,7 @@
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-mark } { slot }
   { selected, secondary, complement, collar, neutral } { slot }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { species } { species }
-\__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { label~pos } { label-pos }
+\__tenkz_kernel_label_pos:nn { tenkz-kernel-mark } { label~pos }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { name } { name }
 \__tenkz_kernel_flag:nnn    { tenkz-kernel-mark } { tint } { tint }
 \__tenkz_kernel_unknown:nn  { tenkz-kernel-mark } { mark }


### PR DESCRIPTION
Rebuilt on main after the weekend's merges superseded four of the five originally ported doc fixes (registry crossing comment, mark addressability, doctrine theme line, catalogue theme phrase — all now on main in their own wording).

What remains, re-authored against the refactored key layer:

- **`label pos=auto` was unspellable**: the plain value key staged the literal word and the compass reader carried it into `\fp_eval` ("Unknown fp word auto"). One shared `\__tenkz_kernel_label_pos:nn {family} {key}` helper now defines the key for both the atom and mark scopes.
- **`auto` retracts a staged bearing** (last-wins): a later `auto` removes `label-pos` from the stage, so `label pos=n, label pos=auto` answers to the automatic chooser.
- **The stage takes the trimmed word**: a braced spaced bearing (`label pos={ s }`) previously staged untrimmed and crashed the same way downstream.
- **Kernel crossing comment truth-synced**: the "string's habit" claim the LionSR/tenkz#197 sweep falsified now reads as the registry does — `crossing=` orders the crossing set a hull route derives; a free string's crossings answer to `cross=` alone.
- **Census extractor** reads the new helper spelling, so both `label pos` leaves keep their census identity (meters unchanged against baseline).
- **New regression fixture** `r_label_pos_auto.tex` pins all three key behaviors; it fails against the unpatched kernel and passes with the fix.

Battery: kernel probes green (164 review regressions, pixels byte-identical), language check 114 records PASS, census meters unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
