### PR TITLE
chore(ci): call the paper-gaps CLI directly, dropping the shims

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -12,8 +12,6 @@ on:
       - 'blueprint/src/**'
       - 'docs/paper-gaps/**'
       - 'texra-blueprint.toml'
-      - 'scripts/package-paper-gaps.sh'
-      - 'scripts/build-paper-gaps.sh'
       # Trees the paper-gap reference check scans (texra-blueprint
       # paper-gaps check); without these the check never runs
       # on merge pushes that only touch a scanned file.

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -63,7 +63,7 @@ jobs:
         run: python3 scripts/blueprint_bibtex.py
 
       - name: Build paper-gap PDFs
-        run: bash scripts/build-paper-gaps.sh
+        run: texra-blueprint --root . paper-gaps build
 
       - name: Build blueprint
         working-directory: blueprint
@@ -114,7 +114,7 @@ jobs:
             cp blueprint/print/print12.pdf site-blueprint/blueprint-ch01-12.pdf
           fi
           cp -r docbuild/.lake/build/doc site-docs/docs
-          ./scripts/package-paper-gaps.sh site-docs/paper-gaps
+          texra-blueprint --root . paper-gaps site site-docs/paper-gaps
           python3 scripts/write_badges.py site-badges
 
       # Runs in Docker and produces root-owned output; keep it after the

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -96,8 +96,6 @@ on:
       - 'docs/paper-gaps/**/*.tex'
       - 'docs/paper-gaps/**/*.bib'
       - 'texra-blueprint.toml'
-      - 'scripts/package-paper-gaps.sh'
-      - 'scripts/build-paper-gaps.sh'
       # Trees the paper-gap reference check scans (texra-blueprint
       # paper-gaps check); without these the check never runs
       # on PRs that only touch a scanned file.
@@ -275,8 +273,6 @@ jobs:
               - 'blueprint/comments/**'
               - 'docs/**/*.md'
               - 'texra-blueprint.toml'
-              - 'scripts/package-paper-gaps.sh'
-              - 'scripts/build-paper-gaps.sh'
             corpus:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'

--- a/scripts/build-paper-gaps.sh
+++ b/scripts/build-paper-gaps.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Compile all paper-gap notes in docs/paper-gaps/ to PDF.
-# Thin wrapper over the texra-blueprint CLI.
-set -euo pipefail
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-texra-blueprint --root "$REPO_ROOT" paper-gaps build

--- a/scripts/package-paper-gaps.sh
+++ b/scripts/package-paper-gaps.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Package the paper-gap notes for the Pages site (index, PDFs, BibTeX).
-# Thin wrapper over the texra-blueprint CLI so workflow calls keep their
-# interface. Usage: package-paper-gaps.sh OUT_DIR
-set -euo pipefail
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-texra-blueprint --root "$REPO_ROOT" paper-gaps site "$1"


### PR DESCRIPTION
`scripts/build-paper-gaps.sh` and `scripts/package-paper-gaps.sh` were 3-line wrappers around `texra-blueprint paper-gaps build|site`; QICLean and MIPStarRE call the CLI directly, so the shims were pure design divergence. Replaces the two docgen.yml call sites with direct CLI invocations, deletes the scripts, and removes their path-filter entries from blueprint.yml and pr-ci.yml. All three workflows pass yaml.safe_load; no references remain (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1JhvqcFXFEh75YEAKiS4