### PR TITLE
feat(QCA): extend site blocking quasi-locally

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -19,6 +19,7 @@ import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm
 import TNLean.QCA.QuasiLocal
+import TNLean.QCA.QuasiLocalBlocking
 import TNLean.QCA.QuasiLocalCommutant
 import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset

--- a/TNLean/QCA/AlgebraicBlocking.lean
+++ b/TNLean/QCA/AlgebraicBlocking.lean
@@ -53,6 +53,20 @@ lemma blockHull_mono {L : ℕ} [NeZero L] {Δ Θ : Finset ℤ} (h : Δ ⊆ Θ) :
     blockHull L Δ ⊆ blockHull L Θ :=
   Finset.image_mono _ h
 
+/-- The block hull of an expanded blocked region is the original blocked region. -/
+@[simp]
+lemma blockHull_expandedRegion (L : ℕ) [NeZero L] (Λ : Finset ℤ) :
+    blockHull L (expandedRegion L Λ) = Λ := by
+  ext x
+  simp only [blockHull, Finset.mem_image, mem_expandedRegion]
+  constructor
+  · rintro ⟨a, ha, rfl⟩
+    exact ha
+  · intro hx
+    refine ⟨(Int.divModEquiv L).symm (x, 0), ?_, ?_⟩
+    · simpa only [Equiv.apply_symm_apply] using hx
+    · exact congrArg Prod.fst ((Int.divModEquiv L).apply_symm_apply (x, 0))
+
 private lemma restrict_blocking_symm {d L : ℕ} [NeZero L] {Λ Γ : Finset ℤ}
     (h : Λ ⊆ Γ) (x : Config d (expandedRegion L Γ)) :
     Config.restrict h ((Config.blocking d L Γ).symm x) =
@@ -324,6 +338,41 @@ lemma algebraicLocalBlocking_localObservable (d L : ℕ) [NeZero d] [NeZero L]
   rw [algebraicLocalBlocking_apply]
   exact algebraicLocalBlockingHom_localObservable d L Λ A
 
+/-- The inverse algebraic-local blocking equivalence is the block-hull unblocking homomorphism. -/
+@[simp]
+lemma algebraicLocalBlocking_symm_apply (d L : ℕ) [NeZero d] [NeZero L]
+    (A : AlgebraicLocalAlgebra d) :
+    (algebraicLocalBlocking d L).symm A = algebraicLocalUnblockingHom d L A := by
+  rw [StarAlgEquiv.symm_apply_eq, algebraicLocalBlocking_apply,
+    ← StarAlgHom.comp_apply, algebraicLocalBlockingHom_comp_unblockingHom]
+  rfl
+
+/-- Inverse algebraic-local blocking enlarges an arbitrary original finite region to its block hull
+and then applies inverse finite blocking. -/
+lemma algebraicLocalBlocking_symm_localObservable (d L : ℕ) [NeZero d] [NeZero L]
+    (Δ : Finset ℤ) (A : LocalAlgebra d Δ) :
+    (algebraicLocalBlocking d L).symm (localObservable d Δ A) =
+      localObservable (MPSTensor.blockPhysDim d L) (blockHull L Δ)
+        ((localBlocking d L (blockHull L Δ)).symm
+          (localInclusion (subset_expandedRegion_blockHull L Δ) A)) := by
+  rw [algebraicLocalBlocking_symm_apply,
+    algebraicLocalUnblockingHom_localObservable]
+
+/-- On an expanded region, inverse algebraic-local blocking has the exact inverse finite-blocking
+formula, with no block-hull enlargement remaining. -/
+lemma algebraicLocalBlocking_symm_localObservable_expandedRegion
+    (d L : ℕ) [NeZero d] [NeZero L] (Λ : Finset ℤ)
+    (A : LocalAlgebra d (expandedRegion L Λ)) :
+    (algebraicLocalBlocking d L).symm (localObservable d (expandedRegion L Λ) A) =
+      localObservable (MPSTensor.blockPhysDim d L) Λ ((localBlocking d L Λ).symm A) := by
+  apply (algebraicLocalBlocking d L).injective
+  change algebraicLocalBlocking d L
+      ((algebraicLocalBlocking d L).symm (localObservable d (expandedRegion L Λ) A)) =
+    algebraicLocalBlocking d L
+      (localObservable (MPSTensor.blockPhysDim d L) Λ ((localBlocking d L Λ).symm A))
+  rw [StarAlgEquiv.apply_symm_apply, algebraicLocalBlocking_localObservable,
+    StarAlgEquiv.apply_symm_apply]
+
 /-- Algebraic-local blocking preserves the operator norm. -/
 lemma algebraicLocalBlocking_norm (d L : ℕ) [NeZero d] [NeZero L]
     (A : AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) :
@@ -342,5 +391,11 @@ lemma algebraicLocalBlocking_isometry (d L : ℕ) [NeZero d] [NeZero L] :
   intro A B
   rw [dist_eq_norm, dist_eq_norm, ← map_sub]
   exact algebraicLocalBlocking_norm d L (A - B)
+
+/-- Inverse algebraic-local blocking is an operator-norm isometry. -/
+lemma algebraicLocalBlocking_symm_isometry (d L : ℕ) [NeZero d] [NeZero L] :
+    Isometry ((algebraicLocalBlocking d L).symm) :=
+  (algebraicLocalBlocking_isometry d L).right_inv
+    (algebraicLocalBlocking d L).apply_symm_apply
 
 end SpinChain

--- a/TNLean/QCA/QuasiLocalBlocking.lean
+++ b/TNLean/QCA/QuasiLocalBlocking.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.AlgebraicBlocking
+import TNLean.QCA.FinitePropagation
+
+/-!
+# Blocking quasi-local observables
+
+The algebraic-local site-blocking equivalence and its inverse are operator-norm isometries, so they
+extend to an equivalence of quasi-local completions.  On finite observables, forward blocking
+expands a blocked region, while reverse blocking uses the block hull of an arbitrary original
+region.  Consequently finite support transports in both directions, and support on an exactly
+expanded region is equivalent before and after blocking.
+
+This file only constructs the quasi-local completion and transports finite support.  It does not
+introduce scaled translations, blocked neighborhoods, propagation estimates, automorphism
+conjugation, or transport of the QCA predicate.
+
+## Main definitions
+
+* `SpinChain.quasiLocalBlocking` — site blocking on quasi-local observable algebras.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2308 and
+  2313--2320.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- Blocking consecutive groups of `L` sites extends to an equivalence between the blocked and
+original quasi-local observable algebras.
+
+This is the quasi-local completion of the site grouping used in
+Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+noncomputable def quasiLocalBlocking (d L : ℕ) [NeZero d] [NeZero L] :
+    QuasiLocalAlgebra (MPSTensor.blockPhysDim d L) ≃⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  UniformSpace.Completion.mapStarAlgEquiv
+    (algebraicLocalBlocking d L)
+    (algebraicLocalBlocking_isometry d L).continuous
+    (algebraicLocalBlocking_symm_isometry d L).continuous
+
+/-- Quasi-local blocking acts by the completion map of algebraic-local blocking. -/
+lemma quasiLocalBlocking_apply (d L : ℕ) [NeZero d] [NeZero L]
+    (A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    quasiLocalBlocking d L A =
+      UniformSpace.Completion.map (algebraicLocalBlocking d L) A :=
+  rfl
+
+/-- Quasi-local blocking agrees with algebraic-local blocking on the dense algebraic subalgebra. -/
+@[simp]
+lemma quasiLocalBlocking_algebraicToQuasiLocal (d L : ℕ) [NeZero d] [NeZero L]
+    (A : AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    quasiLocalBlocking d L (algebraicToQuasiLocal _ A) =
+      algebraicToQuasiLocal d (algebraicLocalBlocking d L A) :=
+  UniformSpace.Completion.mapStarAlgEquiv_coe _ _ _ A
+
+/-- Inverse quasi-local blocking agrees with inverse algebraic-local blocking on the dense
+algebraic subalgebra. -/
+@[simp]
+lemma quasiLocalBlocking_symm_algebraicToQuasiLocal (d L : ℕ) [NeZero d] [NeZero L]
+    (A : AlgebraicLocalAlgebra d) :
+    (quasiLocalBlocking d L).symm (algebraicToQuasiLocal d A) =
+      algebraicToQuasiLocal _ ((algebraicLocalBlocking d L).symm A) :=
+  UniformSpace.Completion.mapStarAlgEquiv_coe
+    (algebraicLocalBlocking d L).symm
+    (algebraicLocalBlocking_symm_isometry d L).continuous
+    (algebraicLocalBlocking_isometry d L).continuous A
+
+/-- Quasi-local blocking sends a finite blocked representative to its finite blocking on the
+expanded original region. -/
+lemma quasiLocalBlocking_quasiLocalObservable (d L : ℕ) [NeZero d] [NeZero L]
+    (Λ : Finset ℤ) (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    quasiLocalBlocking d L (quasiLocalObservable _ Λ A) =
+      quasiLocalObservable d (expandedRegion L Λ) (localBlocking d L Λ A) := by
+  simp only [quasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalBlocking_algebraicToQuasiLocal, algebraicLocalBlocking_localObservable]
+
+/-- Inverse quasi-local blocking enlarges an arbitrary finite original region to its block hull and
+then applies inverse finite blocking. -/
+lemma quasiLocalBlocking_symm_quasiLocalObservable (d L : ℕ) [NeZero d] [NeZero L]
+    (Δ : Finset ℤ) (A : LocalAlgebra d Δ) :
+    (quasiLocalBlocking d L).symm (quasiLocalObservable d Δ A) =
+      quasiLocalObservable _ (blockHull L Δ)
+        ((localBlocking d L (blockHull L Δ)).symm
+          (localInclusion (subset_expandedRegion_blockHull L Δ) A)) := by
+  simp only [quasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalBlocking_symm_algebraicToQuasiLocal,
+    algebraicLocalBlocking_symm_localObservable]
+
+/-- On an expanded region, inverse quasi-local blocking is exactly inverse finite blocking. -/
+lemma quasiLocalBlocking_symm_quasiLocalObservable_expandedRegion
+    (d L : ℕ) [NeZero d] [NeZero L] (Λ : Finset ℤ)
+    (A : LocalAlgebra d (expandedRegion L Λ)) :
+    (quasiLocalBlocking d L).symm
+        (quasiLocalObservable d (expandedRegion L Λ) A) =
+      quasiLocalObservable _ Λ ((localBlocking d L Λ).symm A) := by
+  simp only [quasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalBlocking_symm_algebraicToQuasiLocal,
+    algebraicLocalBlocking_symm_localObservable_expandedRegion]
+
+/-- Quasi-local blocking preserves the operator norm. -/
+@[simp]
+lemma norm_quasiLocalBlocking (d L : ℕ) [NeZero d] [NeZero L]
+    (A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    ‖quasiLocalBlocking d L A‖ = ‖A‖ :=
+  StarAlgEquiv.norm_map (quasiLocalBlocking d L) A
+
+/-- Quasi-local blocking is an operator-norm isometry. -/
+lemma quasiLocalBlocking_isometry (d L : ℕ) [NeZero d] [NeZero L] :
+    Isometry (quasiLocalBlocking d L) :=
+  StarAlgEquiv.isometry (quasiLocalBlocking d L)
+
+/-- Forward quasi-local blocking sends support in a blocked region to support in its expanded
+original region. -/
+lemma quasiLocalBlocking_supportedIn
+    (d L : ℕ) [NeZero d] [NeZero L]
+    {A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)} {Λ : Finset ℤ}
+    (hA : QuasiLocalSupportedIn A Λ) :
+    QuasiLocalSupportedIn (quasiLocalBlocking d L A) (expandedRegion L Λ) := by
+  obtain ⟨a, rfl⟩ := hA
+  exact ⟨localBlocking d L Λ a, (quasiLocalBlocking_quasiLocalObservable d L Λ a).symm⟩
+
+/-- Reverse quasi-local blocking sends support in an original region to support in its block
+hull. -/
+lemma quasiLocalBlocking_symm_supportedIn
+    (d L : ℕ) [NeZero d] [NeZero L]
+    {A : QuasiLocalAlgebra d} {Δ : Finset ℤ} (hA : QuasiLocalSupportedIn A Δ) :
+    QuasiLocalSupportedIn ((quasiLocalBlocking d L).symm A) (blockHull L Δ) := by
+  obtain ⟨a, rfl⟩ := hA
+  exact ⟨_, (quasiLocalBlocking_symm_quasiLocalObservable d L Δ a).symm⟩
+
+/-- A blocked observable is supported in `Λ` exactly when its quasi-local blocking is supported in
+the expanded original region. -/
+lemma quasiLocalBlocking_supportedIn_expandedRegion_iff
+    (d L : ℕ) [NeZero d] [NeZero L]
+    {A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)} {Λ : Finset ℤ} :
+    QuasiLocalSupportedIn (quasiLocalBlocking d L A) (expandedRegion L Λ) ↔
+      QuasiLocalSupportedIn A Λ := by
+  constructor
+  · intro hA
+    have h := quasiLocalBlocking_symm_supportedIn d L hA
+    simpa only [StarAlgEquiv.symm_apply_apply, blockHull_expandedRegion] using h
+  · exact quasiLocalBlocking_supportedIn d L
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9607,7 +9607,8 @@ $\omega^{-1}$.
 
 \begin{lemma}[Block-hull containment and monotonicity]
     \label{lem:qca_block_hull_properties}
-    \lean{SpinChain.subset_expandedRegion_blockHull,SpinChain.blockHull_mono}
+    \lean{SpinChain.subset_expandedRegion_blockHull,SpinChain.blockHull_mono,
+        SpinChain.blockHull_expandedRegion}
     \leanok
     \uses{def:qca_block_hull, def:qca_expanded_region}
     Let $L>0$.  Every finite original region is contained in the expansion of
@@ -9618,14 +9619,21 @@ $\omega^{-1}$.
     \end{align}
     If $\Delta\subseteq\Theta$, then
     $\operatorname{Hull}_L(\Delta)\subseteq
-    \operatorname{Hull}_L(\Theta)$.
+    \operatorname{Hull}_L(\Theta)$.  Expansion and block hull are exact in the
+    blocked direction:
+    \begin{align}
+        \operatorname{Hull}_L(\widehat\Lambda_L)&=\Lambda.
+    \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{def:qca_block_hull, thm:qca_expanded_region_coordinates}
     The quotient coordinate of each $z\in\Delta$ belongs to the image defining
     the hull, which proves containment after expansion.  Monotonicity follows
-    by retaining the same witness $z$ in the larger region.
+    by retaining the same witness $z$ in the larger region.  Finally, every
+    expanded site has quotient in $\Lambda$, while for each $x\in\Lambda$ the
+    site $Lx$ belongs to $\widehat\Lambda_L$ and has quotient $x$.  Hence
+    $\operatorname{Hull}_L(\widehat\Lambda_L)=\Lambda$.
 \end{proof}
 
 \begin{lemma}[Blocking commutes with finite local inclusions]
@@ -9791,23 +9799,169 @@ $\omega^{-1}$.
     \label{lem:qca_algebraic_blocking_formulas}
     \lean{SpinChain.algebraicLocalBlocking_apply,
         SpinChain.algebraicLocalBlocking_localObservable,
+        SpinChain.algebraicLocalBlocking_symm_apply,
+        SpinChain.algebraicLocalBlocking_symm_localObservable,
+        SpinChain.algebraicLocalBlocking_symm_localObservable_expandedRegion,
         SpinChain.algebraicLocalBlocking_norm,
-        SpinChain.algebraicLocalBlocking_isometry}
+        SpinChain.algebraicLocalBlocking_isometry,
+        SpinChain.algebraicLocalBlocking_symm_isometry}
     \leanok
     \uses{def:qca_algebraic_blocking,
         lem:qca_algebraic_blocking_maps_evaluation}
-    Let $d>0$ and $L>0$.  The equivalence agrees with the forward lift and
-    sends every finite representative to its finite blocking on the expanded
-    region.  It preserves the algebraic-local operator norm and is an isometry.
+    Let $d>0$ and $L>0$.  The equivalence agrees with the forward lift, and
+    its inverse agrees with the block-hull unblocking map.  For
+    $A\in\mathcal A^{(d^L)}_\Lambda$ and
+    $C\in\mathcal A^{(d)}_\Delta$,
+    \begin{align}
+      \mathcal B_L\bigl(\iota_\Lambda(A)\bigr)
+        &=\iota_{\widehat\Lambda_L}
+          \bigl(\mathcal B_{L,\Lambda}(A)\bigr),\\
+      \mathcal B_L^{-1}\bigl(\iota_\Delta(C)\bigr)
+        &=\iota_{\operatorname{Hull}_L(\Delta)}
+          \left(\mathcal B^{-1}_{L,\operatorname{Hull}_L(\Delta)}
+          \bigl(\iota_{\Delta,
+          \widehat{\operatorname{Hull}_L(\Delta)}_L}(C)\bigr)\right).
+    \end{align}
+    In particular, if $C\in\mathcal A^{(d)}_{\widehat\Lambda_L}$, then
+    \begin{align}
+      \mathcal B_L^{-1}\bigl(\iota_{\widehat\Lambda_L}(C)\bigr)
+        &=\iota_\Lambda\bigl(\mathcal B_{L,\Lambda}^{-1}(C)\bigr).
+    \end{align}
+    The forward and inverse maps are operator-norm isometries.  In particular,
+    each preserves the norm.
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{lem:qca_algebraic_blocking_maps_evaluation,
+        lem:qca_block_hull_properties,
         thm:qca_local_blocking_formulas,
         def:qca_algebraic_local_operator_norm}
-    The finite-representative formula is the defining formula for the forward
-    blocking homomorphism.  On such a representative, norm preservation
-    reduces to norm preservation by finite blocking and by the canonical local
-    inclusion; distance preservation follows by applying the norm identity to
-    differences.
+    The first two formulas are the evaluation identities for the forward and
+    reverse maps.  For an expanded region, the block-hull identity removes the
+    enlargement and leaves the inverse finite blocking equivalence.  On a
+    finite representative, forward norm preservation reduces to norm
+    preservation by finite blocking and by the canonical local inclusion;
+    distance preservation follows by applying the norm identity to
+    differences.  The inverse isometry follows from the forward isometry and
+    the right-inverse identity, rather than repeating the norm calculation.
+\end{proof}
+
+\begin{definition}[Quasi-local site-blocking equivalence]
+    \label{def:qca_quasi_local_blocking}
+    \lean{SpinChain.quasiLocalBlocking}
+    \leanok
+    \uses{def:qca_quasi_local_algebra, def:qca_algebraic_blocking,
+        lem:qca_algebraic_blocking_formulas}
+    For $d>0$ and $L>0$, site blocking extends uniquely by continuity to a
+    star-algebra equivalence
+    \begin{align}
+      \overline{\mathcal B}_L:
+      \mathcal A^{(d^L)}&\simeq\mathcal A^{(d)}.
+    \end{align}
+    This is only the completion of the change of site grouping used at
+    \cite[lines~2308 and 2313--2320]{Cirac2017MPU}.  This slice does not define
+    scaled translations or carry-aware neighborhoods, prove propagation
+    estimates, construct blocked automorphisms, transport the property of being
+    a quantum cellular automaton, realize a circuit, or reconstruct an MPU from
+    a quantum cellular automaton.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{lem:qca_algebraic_blocking_formulas, def:completion_star_alg_equiv}
+    The algebraic blocking equivalence and its inverse are isometries, hence
+    continuous.  Extending both maps to the operator-norm completions gives
+    mutually inverse star-algebra homomorphisms.
+\end{proof}
+
+\begin{lemma}[Quasi-local blocking evaluation and norm]
+    \label{lem:qca_quasi_local_blocking_formulas}
+    \lean{SpinChain.quasiLocalBlocking_apply,
+        SpinChain.quasiLocalBlocking_algebraicToQuasiLocal,
+        SpinChain.quasiLocalBlocking_symm_algebraicToQuasiLocal,
+        SpinChain.quasiLocalBlocking_quasiLocalObservable,
+        SpinChain.quasiLocalBlocking_symm_quasiLocalObservable,
+        SpinChain.quasiLocalBlocking_symm_quasiLocalObservable_expandedRegion,
+        SpinChain.norm_quasiLocalBlocking,
+        SpinChain.quasiLocalBlocking_isometry}
+    \leanok
+    \uses{def:qca_quasi_local_blocking, lem:qca_algebraic_blocking_formulas,
+        lem:qca_quasi_local_observable}
+    Let $d>0$ and $L>0$.  Write $j^{(d)}$ for the canonical map from the
+    algebraic-local algebra into its completion.  The underlying map of
+    $\overline{\mathcal B}_L$ is the continuous extension of $\mathcal B_L$,
+    and on the two dense algebraic-local subalgebras,
+    \begin{align}
+      \overline{\mathcal B}_L\bigl(j^{(d^L)}(A)\bigr)
+        &=j^{(d)}\bigl(\mathcal B_L(A)\bigr),\\
+      \overline{\mathcal B}_L^{-1}\bigl(j^{(d)}(C)\bigr)
+        &=j^{(d^L)}\bigl(\mathcal B_L^{-1}(C)\bigr).
+    \end{align}
+    For $A\in\mathcal A^{(d^L)}_\Lambda$ and
+    $C\in\mathcal A^{(d)}_\Delta$, these identities become
+    \begin{align}
+      \overline{\mathcal B}_L\bigl(j^{(d^L)}_\Lambda(A)\bigr)
+        &=j^{(d)}_{\widehat\Lambda_L}
+          \bigl(\mathcal B_{L,\Lambda}(A)\bigr),\\
+      \overline{\mathcal B}_L^{-1}\bigl(j^{(d)}_\Delta(C)\bigr)
+        &=j^{(d^L)}_{\operatorname{Hull}_L(\Delta)}
+          \left(\mathcal B^{-1}_{L,\operatorname{Hull}_L(\Delta)}
+          \bigl(\iota_{\Delta,
+          \widehat{\operatorname{Hull}_L(\Delta)}_L}(C)\bigr)\right).
+    \end{align}
+    If $C\in\mathcal A^{(d)}_{\widehat\Lambda_L}$, the inverse formula reduces
+    exactly to
+    \begin{align}
+      \overline{\mathcal B}_L^{-1}
+        \bigl(j^{(d)}_{\widehat\Lambda_L}(C)\bigr)
+        &=j^{(d^L)}_\Lambda\bigl(\mathcal B_{L,\Lambda}^{-1}(C)\bigr).
+    \end{align}
+    Finally, for all quasi-local observables $X$ and $Y$ on the blocked chain,
+    \begin{align}
+      \lVert\overline{\mathcal B}_L(X)\rVert&=\lVert X\rVert,\\
+      \lVert\overline{\mathcal B}_L(X)-
+        \overline{\mathcal B}_L(Y)\rVert&=\lVert X-Y\rVert.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:completion_star_alg_equiv, def:qca_quasi_local_observable,
+        lem:qca_algebraic_blocking_formulas, lem:qca_block_hull_properties}
+    The first identity is the defining completion map, and the two dense
+    formulas are its canonical-image formulas for the algebraic equivalence and
+    its inverse.  Composing them with the finite-region canonical maps gives the
+    two finite formulas.  The exact expanded-region formula uses
+    $\operatorname{Hull}_L(\widehat\Lambda_L)=\Lambda$.  A star-algebra
+    equivalence of C-star algebras preserves the norm; applying this to $X-Y$
+    gives distance preservation.
+\end{proof}
+
+\begin{lemma}[Support transport under site blocking]
+    \label{lem:qca_quasi_local_blocking_support}
+    \lean{SpinChain.quasiLocalBlocking_supportedIn,
+        SpinChain.quasiLocalBlocking_symm_supportedIn,
+        SpinChain.quasiLocalBlocking_supportedIn_expandedRegion_iff}
+    \leanok
+    \uses{lem:qca_quasi_local_blocking_formulas, def:qca_quasi_local_supported_in,
+        lem:qca_block_hull_properties}
+    Let $d>0$ and $L>0$.  If a blocked-chain observable $X$ is supported in
+    $\Lambda$, then $\overline{\mathcal B}_L(X)$ is supported in
+    $\widehat\Lambda_L$.  If an original-chain observable $Y$ is supported in
+    $\Delta$, then $\overline{\mathcal B}_L^{-1}(Y)$ is supported in
+    $\operatorname{Hull}_L(\Delta)$.  In particular, support transport is exact
+    on expanded regions:
+    \begin{align}
+      \overline{\mathcal B}_L(X)
+        \text{ is supported in }\widehat\Lambda_L
+      \quad\Longleftrightarrow\quad
+      X\text{ is supported in }\Lambda.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_quasi_local_blocking_formulas,
+        lem:qca_block_hull_properties}
+    Choose a finite-region representative and apply the corresponding forward
+    or inverse finite evaluation formula.  For the reverse implication in the
+    exact statement, apply inverse blocking and simplify the inverse composite
+    and the block hull of the expanded region.
 \end{proof}


### PR DESCRIPTION
Closes #6975

## Summary
- expose inverse algebraic-local blocking evaluation and isometry
- extend site blocking to a quasi-local star-algebra equivalence via completion
- prove dense and finite-observable evaluation formulas in both directions
- transport finite support forward by region expansion and backward by block hull, with an exact expanded-region characterization
- synchronize formula-driven Chapter 28 coverage for all 17 new public declarations

## Scope
This PR does not add scaled translations, carry-aware blocked neighborhoods, propagation transport, blocked automorphisms, `IsQCA` transport, circuit realization, or QCA-to-MPU reconstruction.

## Checks
- direct Lean checks for `AlgebraicBlocking`, `QuasiLocalBlocking`, and the QCA aggregate
- targeted cached module builds
- generated import aggregation
- Blueprint sync and changed-declaration reverse coverage
- reader-facing prose, whitespace, and proof-integrity checks