### PR TITLE
fix(tenkz): answer frame-readable label occupancy

### DIFF
--- a/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
+++ b/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
@@ -14,8 +14,12 @@
     \str_if_eq:nnT {#3} {tenkz-label-route-point}
       {
         \int_gincr:N \l__tenkz_test_frame_route_count_int
-        \str_if_eq:nnF {#1} {tenkz-bead-cup-1-2}
-          { \errmessage{closure~occupancy~did~not~read~the~frozen~bead~route} }
+        \str_case:nnF {#1}
+          {
+            {tenkz-bead-cup-1-2}   { }
+            {tenkz-bead-wrap-1}     { }
+          }
+          { \errmessage{closure~occupancy~did~not~read~a~frozen~bead~route} }
       }
     \__tenkz_test_frame_beadpath:nnn {#1} {#2} {#3}
   }
@@ -45,6 +49,11 @@
           {
             \str_if_eq:VnF #2 {s}
               { \errmessage{closure~bead~answered~the~wrong~face} }
+          }
+        {U}
+          {
+            \str_if_eq:VnF #2 {n}
+              { \errmessage{closure~corner~lost~one~of~its~two~faces} }
           }
       }
       { \errmessage{unexpected~label~in~frame-cell~fixture} }
@@ -88,10 +97,17 @@
     cross={over at crossing of probe and cup-1-2}]
     {1 n of T}{1 s of T}
 \end{tenkz}
+% At the first corner of a flat trace, the incoming and outgoing pieces take
+% two adjacent faces.  Reading only their common secant would call the corner
+% oblique and leave its south face falsely free.
+\begin{tenkz}[lattice={1x1}, bonds=none, west=trace, east=trace]
+  \tn[at=(1,1)]{}
+  \tn[at=on wrap-1 0.19449155, skin=dot]{U}
+\end{tenkz}
 \ExplSyntaxOn
-\int_compare:nNnF { \l__tenkz_test_frame_side_count_int } = {4}
-  { \errmessage{frame-cell~fixture~did~not~station~four~labels} }
-\int_compare:nNnF { \l__tenkz_test_frame_route_count_int } = {2}
-  { \errmessage{closure~occupancy~did~not~sample~the~frozen~route~twice} }
+\int_compare:nNnF { \l__tenkz_test_frame_side_count_int } = {5}
+  { \errmessage{frame-cell~fixture~did~not~station~five~labels} }
+\int_compare:nNnF { \l__tenkz_test_frame_route_count_int } = {6}
+  { \errmessage{closure~occupancy~did~not~sample~two~frozen~routes} }
 \ExplSyntaxOff
 \end{document}

--- a/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
+++ b/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
@@ -1,0 +1,78 @@
+% Regression: frame-readable wire records reserve the faces their ink uses.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \l__tenkz_test_frame_side_count_int
+\cs_new_eq:NN
+  \__tenkz_test_frame_side_auto:nN \__tenkz_kernel_r_label_auto_side:nN
+\cs_set_protected:Npn \__tenkz_kernel_r_label_auto_side:nN #1#2
+  {
+    \__tenkz_test_frame_side_auto:nN {#1} #2
+    \int_gincr:N \l__tenkz_test_frame_side_count_int
+    \__tenkz_model_get:nnN {#1} {label} \l_tmpa_tl
+    \str_case:VnF \l_tmpa_tl
+      {
+        {P}
+          {
+            \str_if_eq:VnF #2 {w}
+              { \errmessage{far~port~slot~answered~the~wrong~face} }
+          }
+        {Q}
+          {
+            \str_if_eq:VnF #2 {w}
+              { \errmessage{spanning~atom~name~answered~the~wrong~face} }
+          }
+        {R}
+          {
+            \str_if_eq:VnF #2 {n}
+              { \errmessage{generated~closure~answered~the~wrong~face} }
+          }
+        {T}
+          {
+            \str_if_eq:VnF #2 {s}
+              { \errmessage{closure~bead~answered~the~wrong~face} }
+          }
+      }
+      { \errmessage{unexpected~label~in~frame-cell~fixture} }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+% The far port lies on the second row of a spanning atom.  The horizontal
+% wire therefore takes the labelled atom's east face.
+\begin{tenkz}[lattice={3x3}, bonds=none]
+  \tn[at=(2,1), name=P, skin=dot,
+      ports={90:virtual,270:virtual}]{P}
+  \tn[at=(1,3), name=A, wires=2,
+      ports={180@2:virtual}]{}
+  \tn[at=(1,1), name=N]{} \tn[at=(3,1), name=S]{}
+  \tnwire{P.90}{N} \tnwire{P.270}{S} \tnwire{P}{A.180@2}
+\end{tenkz}
+% The bare name denotes the middle of the three-row rectangle, not its
+% anchor cell.  Its horizontal wire therefore takes the east face.
+\begin{tenkz}[lattice={3x3}, bonds=none]
+  \tn[at=(1,2), name=Q, skin=dot, wires=3,
+      ports={90:virtual,270:virtual}]{Q}
+  \tn[at=(1,1), name=QN]{}
+  \tn[at=(3,1), name=QS]{}
+  \tn[at=(2,3), name=QE]{}
+  \tnwire{Q.90}{QN} \tnwire{Q.270}{QS} \tnwire{Q}{QE}
+\end{tenkz}
+% A one-sided south trace leaves the boundary atom through its south face.
+\begin{tenkz}[lattice={1x1}, bonds=none, south=trace]
+  \tn[at=(1,1), skin=dot]{R}
+\end{tenkz}
+% A bead a quarter of the way round an east cup sees the saved curved route,
+% not the vertical chord between the cup's boundary sites.
+\begin{tenkz}[rows={wire,wire}, cols=1, bonds=none, east=cup]
+  \tn[at=(1,1)]{} \\ \tn[at=(2,1)]{}
+  \tn[at=on cup-1-2 0.25, skin=dot]{T}
+\end{tenkz}
+\ExplSyntaxOn
+\int_compare:nNnF { \l__tenkz_test_frame_side_count_int } = {4}
+  { \errmessage{frame-cell~fixture~did~not~station~four~labels} }
+\ExplSyntaxOff
+\end{document}

--- a/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
+++ b/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
@@ -5,8 +5,20 @@
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
 \int_new:N \l__tenkz_test_frame_side_count_int
+\int_new:N \l__tenkz_test_frame_route_count_int
 \cs_new_eq:NN
   \__tenkz_test_frame_side_auto:nN \__tenkz_kernel_r_label_auto_side:nN
+\cs_new_eq:NN \__tenkz_test_frame_beadpath:nnn \tenkz@string@beadpath
+\cs_set_protected:Npn \tenkz@string@beadpath #1#2#3
+  {
+    \str_if_eq:nnT {#3} {tenkz-label-route-point}
+      {
+        \int_gincr:N \l__tenkz_test_frame_route_count_int
+        \str_if_eq:nnF {#1} {tenkz-bead-cup-1-2}
+          { \errmessage{closure~occupancy~did~not~read~the~frozen~bead~route} }
+      }
+    \__tenkz_test_frame_beadpath:nnn {#1} {#2} {#3}
+  }
 \cs_set_protected:Npn \__tenkz_kernel_r_label_auto_side:nN #1#2
   {
     \__tenkz_test_frame_side_auto:nN {#1} #2
@@ -74,5 +86,7 @@
 \ExplSyntaxOn
 \int_compare:nNnF { \l__tenkz_test_frame_side_count_int } = {4}
   { \errmessage{frame-cell~fixture~did~not~station~four~labels} }
+\int_compare:nNnF { \l__tenkz_test_frame_route_count_int } = {2}
+  { \errmessage{closure~occupancy~did~not~sample~the~frozen~route~twice} }
 \ExplSyntaxOff
 \end{document}

--- a/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
+++ b/tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex
@@ -78,10 +78,15 @@
   \tn[at=(1,1), skin=dot]{R}
 \end{tenkz}
 % A bead a quarter of the way round an east cup sees the saved curved route,
-% not the vertical chord between the cup's boundary sites.
+% not the vertical chord between the cup's boundary sites.  The transverse
+% probe puts a declared crossing at the bead and cuts the live cup route; the
+% occupancy reading must retain the frozen, unsurgered route used to place T.
 \begin{tenkz}[rows={wire,wire}, cols=1, bonds=none, east=cup]
   \tn[at=(1,1)]{} \\ \tn[at=(2,1)]{}
-  \tn[at=on cup-1-2 0.25, skin=dot]{T}
+  \tn[at=on cup-1-2 0.25, name=T, skin=dot]{T}
+  \tnwire[kind=string, name=probe, crossing=over,
+    cross={over at crossing of probe and cup-1-2}]
+    {1 n of T}{1 s of T}
 \end{tenkz}
 \ExplSyntaxOn
 \int_compare:nNnF { \l__tenkz_test_frame_side_count_int } = {4}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -17300,6 +17300,10 @@
 \bool_new:N \l__tenkz_kernel_lab_span_bool
 \fp_new:N \l__tenkz_kernel_lab_before_x_fp
 \fp_new:N \l__tenkz_kernel_lab_before_y_fp
+\fp_new:N \l__tenkz_kernel_lab_centre_x_fp
+\fp_new:N \l__tenkz_kernel_lab_centre_y_fp
+\fp_const:Nn \c__tenkz_kernel_lab_route_sample_fp { 1 / 10000 }
+\fp_const:Nn \c__tenkz_kernel_lab_axis_tol_fp { 1 / 100 }
 % One pass over the frozen records fills the table the atom pass reads.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_occupancy:
   {
@@ -18016,77 +18020,80 @@
     \fp_set:Nn #4
       { \dim_to_fp:n { \use:c {pgf@y} } / \dim_to_fp:n { \tenkz@pitch } }
   }
+% One side of the route reserves the face reached from the bead centre.
+% Testing the two sides separately retains both faces at a sharp corner.  The
+% marking decoration returns scaled-point coordinates, so the small relative
+% tolerance recognizes an axial run without depending on its physical scale.
+\cs_new_protected:Npn \__tenkz_kernel_r_label_closure_run:nnn #1#2#3
+  {
+    \fp_compare:nNnT
+      {
+        abs( #3 - \l__tenkz_kernel_lab_centre_y_fp )
+      } < {
+        abs( #2 - \l__tenkz_kernel_lab_centre_x_fp )
+          * \c__tenkz_kernel_lab_axis_tol_fp
+      }
+      {
+        \fp_compare:nNnTF {#2} > { \l__tenkz_kernel_lab_centre_x_fp }
+          { \__tenkz_kernel_r_label_mark:nn {#1} {e} }
+          { \__tenkz_kernel_r_label_mark:nn {#1} {w} }
+      }
+    \fp_compare:nNnT
+      {
+        abs( #2 - \l__tenkz_kernel_lab_centre_x_fp )
+      } < {
+        abs( #3 - \l__tenkz_kernel_lab_centre_y_fp )
+          * \c__tenkz_kernel_lab_axis_tol_fp
+      }
+      {
+        \fp_compare:nNnTF {#3} > { \l__tenkz_kernel_lab_centre_y_fp }
+          { \__tenkz_kernel_r_label_mark:nn {#1} {n} }
+          { \__tenkz_kernel_r_label_mark:nn {#1} {s} }
+      }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_r_label_closure_bead:nn #1#2
   {
     \__tenkz_kernel_r_sid:nN {#1} \l__tenkz_kernel_r_sid_tl
     \__tenkz_string_inked:VTF \l__tenkz_kernel_r_sid_tl
       {
         \tl_set:Ne \l__tenkz_kernel_lab_via_tl
-          { \fp_eval:n { max(0,\l__tenkz_kernel_lab_t_tl - 1 / 10000) } }
+          {
+            \fp_eval:n
+              {
+                max
+                  ( 0 , \l__tenkz_kernel_lab_t_tl
+                    - \c__tenkz_kernel_lab_route_sample_fp )
+              }
+          }
         \exp_args:NVV \__tenkz_kernel_r_label_route_point:nnNN
           \l__tenkz_kernel_r_sid_tl
           \l__tenkz_kernel_lab_via_tl
           \l__tenkz_kernel_lab_before_x_fp
           \l__tenkz_kernel_lab_before_y_fp
+        \exp_args:NVV \__tenkz_kernel_r_label_route_point:nnNN
+          \l__tenkz_kernel_r_sid_tl
+          \l__tenkz_kernel_lab_t_tl
+          \l__tenkz_kernel_lab_centre_x_fp
+          \l__tenkz_kernel_lab_centre_y_fp
+        \__tenkz_kernel_r_label_closure_run:nnn {#2}
+          { \l__tenkz_kernel_lab_before_x_fp }
+          { \l__tenkz_kernel_lab_before_y_fp }
         \tl_set:Ne \l__tenkz_kernel_lab_via_tl
-          { \fp_eval:n { min(1,\l__tenkz_kernel_lab_t_tl + 1 / 10000) } }
+          {
+            \fp_eval:n
+              {
+                min
+                  ( 1 , \l__tenkz_kernel_lab_t_tl
+                    + \c__tenkz_kernel_lab_route_sample_fp )
+              }
+          }
         \exp_args:NVV \__tenkz_kernel_r_label_route_point:nnNN
           \l__tenkz_kernel_r_sid_tl
           \l__tenkz_kernel_lab_via_tl
           \l_tmpa_fp
           \l_tmpb_fp
-        \bool_lazy_and:nnT
-          {
-            \fp_compare_p:nNn
-              {
-                abs
-                  ( \l_tmpb_fp
-                    - \l__tenkz_kernel_lab_before_y_fp )
-              }
-              < { 1 / 1000 }
-          }
-          {
-            \fp_compare_p:nNn
-              {
-                abs
-                  ( \l_tmpa_fp
-                    - \l__tenkz_kernel_lab_before_x_fp )
-              }
-              > { 1 / 1000 }
-          }
-          {
-            \fp_compare:nNnTF
-              { \l_tmpa_fp }
-              > { \l__tenkz_kernel_lab_before_x_fp }
-              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {e} {w} }
-              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {w} {e} }
-          }
-        \bool_lazy_and:nnT
-          {
-            \fp_compare_p:nNn
-              {
-                abs
-                  ( \l_tmpa_fp
-                    - \l__tenkz_kernel_lab_before_x_fp )
-              }
-              < { 1 / 1000 }
-          }
-          {
-            \fp_compare_p:nNn
-              {
-                abs
-                  ( \l_tmpb_fp
-                    - \l__tenkz_kernel_lab_before_y_fp )
-              }
-              > { 1 / 1000 }
-          }
-          {
-            \fp_compare:nNnTF
-              { \l_tmpb_fp }
-              > { \l__tenkz_kernel_lab_before_y_fp }
-              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {n} {s} }
-              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {s} {n} }
-          }
+        \__tenkz_kernel_r_label_closure_run:nnn {#2}
+          { \l_tmpa_fp } { \l_tmpb_fp }
       }
       { \__tenkz_kernel_r_label_blind:n {#2} }
   }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -18102,8 +18102,8 @@
 % opposite.  An index wire between two cells runs along the axis those cells
 % share.  A string bending through its own waypoints turns where the route
 % says and reaches the bead by no face this stage can name; that gap is the
-% frame-cell reading's own limit, and the geometric station named in the
-% pull request answers it.
+% frame-cell reading's own limit, and the bearing reading tracked in issue
+% 6195 answers it.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_carrier_faces:nn #1#2
   {
     \__tenkz_model_get:nnN {#1} {origin} \l__tenkz_kernel_lab_owner_tl

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -18009,7 +18009,7 @@
 % corner and reserves no face, as every endpoint reading does.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_route_point:nnNN #1#2#3#4
   {
-    \tenkz@string@beadpath {#1} {#2} {tenkz-label-route-point}
+    \tenkz@string@beadpath {tenkz-bead-#1} {#2} {tenkz-label-route-point}
     \pgfpointanchor {tenkz-label-route-point} {center}
     \fp_set:Nn #3 { \dim_to_fp:n { \use:c {pgf@x} } }
     \fp_set:Nn #4 { \dim_to_fp:n { \use:c {pgf@y} } }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -17275,6 +17275,7 @@
 \tl_new:N \l__tenkz_kernel_lab_col_tl
 \tl_new:N \l__tenkz_kernel_lab_far_row_tl
 \tl_new:N \l__tenkz_kernel_lab_far_col_tl
+\tl_new:N \l__tenkz_kernel_lab_far_atom_tl
 \tl_new:N \l__tenkz_kernel_lab_from_tl
 \tl_new:N \l__tenkz_kernel_lab_to_tl
 \tl_new:N \l__tenkz_kernel_lab_host_tl
@@ -17297,6 +17298,8 @@
 \bool_new:N \l__tenkz_kernel_lab_cell_bool
 \bool_new:N \l__tenkz_kernel_lab_far_bool
 \bool_new:N \l__tenkz_kernel_lab_span_bool
+\fp_new:N \l__tenkz_kernel_lab_before_x_fp
+\fp_new:N \l__tenkz_kernel_lab_before_y_fp
 % One pass over the frozen records fills the table the atom pass reads.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_occupancy:
   {
@@ -17464,12 +17467,8 @@
                     % covering glyph hides that run, but a dot does not,
                     % so the atom's ink stays uncharted and its station is
                     % no promise.
-                    \__tenkz_kernel_any_cell_claim:eeN
-                      { \tl_use:N \l__tenkz_kernel_lab_far_row_tl }
-                      { \tl_use:N \l__tenkz_kernel_lab_far_col_tl }
-                      \l__tenkz_kernel_lab_owner_tl
                     \str_if_eq:VVTF
-                      \l__tenkz_kernel_lab_owner_tl
+                      \l__tenkz_kernel_lab_far_atom_tl
                       \l__tenkz_kernel_lab_atom_tl
                       {
                         \__tenkz_kernel_r_label_blind:V
@@ -17491,15 +17490,63 @@
 % The atom a wire endpoint stands on, and the cell it stands at.  A cell or
 % basis-member address names the cell outright and the frame answers which
 % atom claimed it, so an end anywhere in a spanning atom's rectangle finds
-% that atom; a bare record name IS the atom and answers its own cell.  Every
-% other production is a geometric construction rather than a station on an
-% atom, and answers false.
+% that atom; a bare record name IS the atom and answers the centre of the
+% rectangle it spans.  A port answers the particular boundary cell selected
+% by its face and slot.  Every other production is a geometric construction
+% rather than a station on an atom, and answers false.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_end_atom:nNNNN #1#2#3#4#5
   {
     \bool_set_false:N #5
     \tl_set:Nn #2 { \q_no_value }
     \str_case:en { \__tenkz_kernel_node_item:nn {#1} {kind} }
       {
+        {port}
+          {
+            \__tenkz_kernel_port_node_record:nN {#1} #2
+            \quark_if_no_value:NF #2
+              {
+                \exp_args:NV \__tenkz_kernel_atom_rc:nNNN #2 #3 #4 #5
+                \bool_if:NT #5
+                  {
+                    \exp_args:NV \__tenkz_kernel_r_span:nNN #2
+                      \l__tenkz_kernel_lab_wide_tl
+                      \l__tenkz_kernel_lab_rows_tl
+                    \__tenkz_kernel_r_face_side:e
+                      { \__tenkz_kernel_node_item:nn {#1} {face} }
+                    \tl_set:Nn \l_tmpa_tl {0}
+                    \tl_set:Nn \l_tmpb_tl {0}
+                    \str_case:Vn \l__tenkz_kernel_r_face_side_tl
+                      {
+                        {n}
+                          {
+                            \tl_set:Ne \l_tmpb_tl
+                              { \__tenkz_kernel_node_item:nn {#1} {slot} - 1 }
+                          }
+                        {s}
+                          {
+                            \tl_set:Ne \l_tmpa_tl
+                              { \l__tenkz_kernel_lab_rows_tl - 1 }
+                            \tl_set:Ne \l_tmpb_tl
+                              { \__tenkz_kernel_node_item:nn {#1} {slot} - 1 }
+                          }
+                        {e}
+                          {
+                            \tl_set:Ne \l_tmpa_tl
+                              { \__tenkz_kernel_node_item:nn {#1} {slot} - 1 }
+                            \tl_set:Ne \l_tmpb_tl
+                              { \l__tenkz_kernel_lab_wide_tl - 1 }
+                          }
+                        {w}
+                          {
+                            \tl_set:Ne \l_tmpa_tl
+                              { \__tenkz_kernel_node_item:nn {#1} {slot} - 1 }
+                          }
+                      }
+                    \tl_set:Ne #3 { \fp_eval:n { #3 + \l_tmpa_tl } }
+                    \tl_set:Ne #4 { \fp_eval:n { #4 + \l_tmpb_tl } }
+                  }
+              }
+          }
         {cell}
           {
             \tl_set:Ne #3 { \__tenkz_kernel_node_item:nn {#1} {row} }
@@ -17522,10 +17569,54 @@
             \prop_get:NeN \l__tenkz_kernel_named_prop
               { \__tenkz_kernel_node_item:nn {#1} {name} } #2
             \quark_if_no_value:NF #2
-              { \exp_args:NV \__tenkz_kernel_atom_rc:nNNN #2 #3 #4 #5 }
+              {
+                \exp_args:NV \__tenkz_kernel_atom_rc:nNNN #2 #3 #4 #5
+                \bool_if:NT #5
+                  {
+                    \exp_args:NV \__tenkz_kernel_r_span:nNN #2
+                      \l__tenkz_kernel_lab_wide_tl
+                      \l__tenkz_kernel_lab_rows_tl
+                    \tl_set:Ne #3
+                      {
+                        \fp_eval:n
+                          { #3 + ( \l__tenkz_kernel_lab_rows_tl - 1 ) / 2 }
+                      }
+                    \tl_set:Ne #4
+                      {
+                        \fp_eval:n
+                          { #4 + ( \l__tenkz_kernel_lab_wide_tl - 1 ) / 2 }
+                      }
+                  }
+              }
           }
       }
   }
+% A far waypoint needs a coordinate even when no atom occupies its cell.  All
+% other endpoint forms use the same atom-aware reading as a wire end, so port
+% slots and bare spanning names cannot acquire a second coordinate doctrine.
+\cs_new_protected:Npn \__tenkz_kernel_r_label_far_end:n #1
+  {
+    \str_if_eq:eeTF { \__tenkz_kernel_node_item:nn {#1} {kind} } {cell}
+      {
+        \tl_set:Ne \l__tenkz_kernel_lab_far_row_tl
+          { \__tenkz_kernel_node_item:nn {#1} {row} }
+        \tl_set:Ne \l__tenkz_kernel_lab_far_col_tl
+          { \__tenkz_kernel_node_item:nn {#1} {col} }
+        \__tenkz_kernel_any_cell_claim:eeN
+          { \tl_use:N \l__tenkz_kernel_lab_far_row_tl }
+          { \tl_use:N \l__tenkz_kernel_lab_far_col_tl }
+          \l__tenkz_kernel_lab_far_atom_tl
+        \bool_set_true:N \l__tenkz_kernel_lab_far_bool
+      }
+      {
+        \__tenkz_kernel_r_label_end_atom:nNNNN {#1}
+          \l__tenkz_kernel_lab_far_atom_tl
+          \l__tenkz_kernel_lab_far_row_tl
+          \l__tenkz_kernel_lab_far_col_tl
+          \l__tenkz_kernel_lab_far_bool
+      }
+  }
+\cs_generate_variant:Nn \__tenkz_kernel_r_label_far_end:n { V }
 % The cell the wire's ink leaves an endpoint toward.  A string route bends
 % at its waypoints, so the departure follows the waypoint on this endpoint's
 % own side of the route and not the far end the chord would suggest; every
@@ -17555,21 +17646,15 @@
           {
             \__tenkz_kernel_addr:VN \l__tenkz_kernel_lab_node_tl
               \l__tenkz_kernel_lab_node_tl
-            \exp_args:NV \__tenkz_kernel_bond_end_cell:nNNN
+            \__tenkz_kernel_r_label_far_end:V
               \l__tenkz_kernel_lab_node_tl
-              \l__tenkz_kernel_lab_far_row_tl
-              \l__tenkz_kernel_lab_far_col_tl
-              \l__tenkz_kernel_lab_far_bool
           }
       }
     \bool_if:NF \l__tenkz_kernel_lab_far_bool
       {
         \quark_if_no_value:nF {#2}
           {
-            \__tenkz_kernel_bond_end_cell:nNNN {#2}
-              \l__tenkz_kernel_lab_far_row_tl
-              \l__tenkz_kernel_lab_far_col_tl
-              \l__tenkz_kernel_lab_far_bool
+            \__tenkz_kernel_r_label_far_end:n {#2}
           }
       }
   }
@@ -17814,18 +17899,18 @@
   }
 \cs_new_protected:Npn \__tenkz_kernel_r_label_mark_axis:n #1
   {
-    \int_compare:nNnTF
+    \fp_compare:nNnTF
       { \l__tenkz_kernel_lab_far_row_tl } = { \l__tenkz_kernel_lab_row_tl }
       {
-        \int_compare:nNnT
+        \fp_compare:nNnT
           { \l__tenkz_kernel_lab_far_col_tl }
           < { \l__tenkz_kernel_lab_col_tl }
           { \__tenkz_kernel_r_label_mark_side:nn {#1} {w} }
-        \int_compare:nNnT
+        \fp_compare:nNnT
           { \l__tenkz_kernel_lab_far_col_tl }
           > { \l__tenkz_kernel_lab_col_tl }
           { \__tenkz_kernel_r_label_mark_side:nn {#1} {e} }
-        \int_compare:nNnTF
+        \fp_compare:nNnTF
           { \l__tenkz_kernel_lab_far_col_tl }
           = { \l__tenkz_kernel_lab_col_tl }
           {
@@ -17835,31 +17920,31 @@
             \__tenkz_kernel_r_label_blind:n {#1}
           }
           {
-            \int_compare:nNnT
+            \fp_compare:nNnT
               { \l__tenkz_kernel_lab_row_tl }
               = { \l__tenkz_kernel_lab_nlane_tl }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {n} }
-            \int_compare:nNnT
+            \fp_compare:nNnT
               { \l__tenkz_kernel_lab_row_tl }
               = { \l__tenkz_kernel_lab_slane_tl }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {s} }
           }
       }
       {
-        \int_compare:nNnT
+        \fp_compare:nNnT
           { \l__tenkz_kernel_lab_far_col_tl }
           = { \l__tenkz_kernel_lab_col_tl }
           {
-            \int_compare:nNnTF
+            \fp_compare:nNnTF
               { \l__tenkz_kernel_lab_far_row_tl }
               < { \l__tenkz_kernel_lab_row_tl }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {n} }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {s} }
-            \int_compare:nNnT
+            \fp_compare:nNnT
               { \l__tenkz_kernel_lab_col_tl }
               = { \l__tenkz_kernel_lab_wlane_tl }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {w} }
-            \int_compare:nNnT
+            \fp_compare:nNnT
               { \l__tenkz_kernel_lab_col_tl }
               = { \l__tenkz_kernel_lab_elane_tl }
               { \__tenkz_kernel_r_label_mark_side:nn {#1} {e} }
@@ -17917,6 +18002,92 @@
           }
       }
   }
+% A generated closure has no straight model chord: its saved route is the
+% geometry that `on <wire> t` already reads.  Sample that route on the two
+% sides of the bead, without emitting another bead event, and reserve a face
+% exactly when the local run is axial.  An oblique run leaves through a
+% corner and reserves no face, as every endpoint reading does.
+\cs_new_protected:Npn \__tenkz_kernel_r_label_route_point:nnNN #1#2#3#4
+  {
+    \tenkz@string@beadpath {#1} {#2} {tenkz-label-route-point}
+    \pgfpointanchor {tenkz-label-route-point} {center}
+    \fp_set:Nn #3 { \dim_to_fp:n { \use:c {pgf@x} } }
+    \fp_set:Nn #4 { \dim_to_fp:n { \use:c {pgf@y} } }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_label_closure_bead:nn #1#2
+  {
+    \__tenkz_kernel_r_sid:nN {#1} \l__tenkz_kernel_r_sid_tl
+    \__tenkz_string_inked:VTF \l__tenkz_kernel_r_sid_tl
+      {
+        \tl_set:Ne \l__tenkz_kernel_lab_via_tl
+          { \fp_eval:n { max(0,\l__tenkz_kernel_lab_t_tl - 1 / 10000) } }
+        \exp_args:NVV \__tenkz_kernel_r_label_route_point:nnNN
+          \l__tenkz_kernel_r_sid_tl
+          \l__tenkz_kernel_lab_via_tl
+          \l__tenkz_kernel_lab_before_x_fp
+          \l__tenkz_kernel_lab_before_y_fp
+        \tl_set:Ne \l__tenkz_kernel_lab_via_tl
+          { \fp_eval:n { min(1,\l__tenkz_kernel_lab_t_tl + 1 / 10000) } }
+        \exp_args:NVV \__tenkz_kernel_r_label_route_point:nnNN
+          \l__tenkz_kernel_r_sid_tl
+          \l__tenkz_kernel_lab_via_tl
+          \l_tmpa_fp
+          \l_tmpb_fp
+        \bool_lazy_and:nnT
+          {
+            \fp_compare_p:nNn
+              {
+                abs
+                  ( \l_tmpb_fp
+                    - \l__tenkz_kernel_lab_before_y_fp )
+              }
+              < { 1 / 1000 }
+          }
+          {
+            \fp_compare_p:nNn
+              {
+                abs
+                  ( \l_tmpa_fp
+                    - \l__tenkz_kernel_lab_before_x_fp )
+              }
+              > { 1 / 1000 }
+          }
+          {
+            \fp_compare:nNnTF
+              { \l_tmpa_fp }
+              > { \l__tenkz_kernel_lab_before_x_fp }
+              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {e} {w} }
+              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {w} {e} }
+          }
+        \bool_lazy_and:nnT
+          {
+            \fp_compare_p:nNn
+              {
+                abs
+                  ( \l_tmpa_fp
+                    - \l__tenkz_kernel_lab_before_x_fp )
+              }
+              < { 1 / 1000 }
+          }
+          {
+            \fp_compare_p:nNn
+              {
+                abs
+                  ( \l_tmpb_fp
+                    - \l__tenkz_kernel_lab_before_y_fp )
+              }
+              > { 1 / 1000 }
+          }
+          {
+            \fp_compare:nNnTF
+              { \l_tmpb_fp }
+              > { \l__tenkz_kernel_lab_before_y_fp }
+              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {n} {s} }
+              { \__tenkz_kernel_r_label_bead_mark:nnn {#2} {s} {n} }
+          }
+      }
+      { \__tenkz_kernel_r_label_blind:n {#2} }
+  }
 % A policy leg grows outward from the face its host names, so it leaves a
 % bead at the host end by that face and arrives at the tip from its
 % opposite.  An index wire between two cells runs along the axis those cells
@@ -17926,29 +18097,40 @@
 % pull request answers it.
 \cs_new_protected:Npn \__tenkz_kernel_r_label_carrier_faces:nn #1#2
   {
-    \__tenkz_model_get:nnN {#1} {face} \l__tenkz_kernel_lab_face_tl
-    \quark_if_no_value:NTF \l__tenkz_kernel_lab_face_tl
+    \__tenkz_model_get:nnN {#1} {origin} \l__tenkz_kernel_lab_owner_tl
+    \str_case:VnF \l__tenkz_kernel_lab_owner_tl
       {
-        \tl_set:Nn \l__tenkz_kernel_lab_via_tl { \q_no_value }
-        \__tenkz_model_get:nnN {#1} {kind} \l__tenkz_kernel_lab_node_tl
-        \str_if_eq:VnT \l__tenkz_kernel_lab_node_tl {string}
-          { \__tenkz_model_get:nnN {#1} {via} \l__tenkz_kernel_lab_via_tl }
-        \quark_if_no_value:NTF \l__tenkz_kernel_lab_via_tl
-          { \__tenkz_kernel_r_label_carrier_run:nn {#1} {#2} }
-          {
-            % a route that bends through its own waypoints reaches the
-            % bead by no face this stage can name
-            \__tenkz_kernel_r_label_blind:n {#2}
-          }
+        {cup}   { \__tenkz_kernel_r_label_closure_bead:nn {#1} {#2} }
+        {trace} { \__tenkz_kernel_r_label_closure_bead:nn {#1} {#2} }
       }
       {
-        \__tenkz_kernel_r_label_bead_mark:nnn {#2}
-          { \tl_use:N \l__tenkz_kernel_lab_face_tl }
+        \__tenkz_model_get:nnN {#1} {face} \l__tenkz_kernel_lab_face_tl
+        \quark_if_no_value:NTF \l__tenkz_kernel_lab_face_tl
           {
-            \fp_eval:n
+            \tl_set:Nn \l__tenkz_kernel_lab_via_tl { \q_no_value }
+            \__tenkz_model_get:nnN {#1} {kind} \l__tenkz_kernel_lab_node_tl
+            \str_if_eq:VnT \l__tenkz_kernel_lab_node_tl {string}
               {
-                \__tenkz_kernel_r_compass:n
-                  { \tl_use:N \l__tenkz_kernel_lab_face_tl } + 180
+                \__tenkz_model_get:nnN
+                  {#1} {via} \l__tenkz_kernel_lab_via_tl
+              }
+            \quark_if_no_value:NTF \l__tenkz_kernel_lab_via_tl
+              { \__tenkz_kernel_r_label_carrier_run:nn {#1} {#2} }
+              {
+                % a route that bends through its own waypoints reaches the
+                % bead by no face this stage can name
+                \__tenkz_kernel_r_label_blind:n {#2}
+              }
+          }
+          {
+            \__tenkz_kernel_r_label_bead_mark:nnn {#2}
+              { \tl_use:N \l__tenkz_kernel_lab_face_tl }
+              {
+                \fp_eval:n
+                  {
+                    \__tenkz_kernel_r_compass:n
+                      { \tl_use:N \l__tenkz_kernel_lab_face_tl } + 180
+                  }
               }
           }
       }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -18011,8 +18011,10 @@
   {
     \tenkz@string@beadpath {tenkz-bead-#1} {#2} {tenkz-label-route-point}
     \pgfpointanchor {tenkz-label-route-point} {center}
-    \fp_set:Nn #3 { \dim_to_fp:n { \use:c {pgf@x} } }
-    \fp_set:Nn #4 { \dim_to_fp:n { \use:c {pgf@y} } }
+    \fp_set:Nn #3
+      { \dim_to_fp:n { \use:c {pgf@x} } / \dim_to_fp:n { \tenkz@pitch } }
+    \fp_set:Nn #4
+      { \dim_to_fp:n { \use:c {pgf@y} } / \dim_to_fp:n { \tenkz@pitch } }
   }
 \cs_new_protected:Npn \__tenkz_kernel_r_label_closure_bead:nn #1#2
   {


### PR DESCRIPTION
Closes LionSR/tenkz#202.

A name is placed on the first face in the order south, north, east, west that carries no ink. This change completes the four cases whose answer is already present in the frozen frame data:

- a far port on a non-first slot is read at the boundary cell determined by its host, face, and slot;
- a bare name of a spanning atom is read at the centre of its rectangle;
- a generated closure continues to reserve the face named by its boundary record; and
- a bead on a generated cup or trace reads the same saved route used for its placement, reserving a face exactly when the local run is axial.

The endpoint-coordinate calculation is shared between ordinary wire ends and route waypoints, so these cases do not introduce a second interpretation of a port or a spanning name. The occupancy fill remains one pass over the frozen wire and atom records.

A four-picture regression fixture records the expected stations. The complete kernel corpus is unchanged outside that fixture.

Verification:
- `python3 scripts/test_tenkz_kernel_audit.py`
- `bash scripts/tenkz_kernel_probes.sh` (163 review regressions; all event streams and pixels unchanged)
- `python3 scripts/test_tenkz_label_overlap.py`
- `scripts/tenkz_golden.sh --check`
- `python3 scripts/tenkz_lint.py tests/tenkz/kernel/regression/r_label_auto_frame_cells.tex`
- `python3 scripts/tenkz_rmp.py book --all`