### PR TITLE
QCA: add scaled blocking translations and carry-aware neighborhoods

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.QCA.AlgebraicBlocking
 import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.Blocking
+import TNLean.QCA.BlockingTranslation
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation
 import TNLean.QCA.InversePropagation

--- a/TNLean/QCA/BlockingTranslation.lean
+++ b/TNLean/QCA/BlockingTranslation.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.QuasiLocalBlocking
+import TNLean.QCA.QuasiLocalTranslation
+import TNLean.QCA.RegionSumset
+
+/-!
+# Translation geometry for blocked spin chains
+
+Grouping `L` consecutive original sites into one blocked site scales a blocked displacement `a`
+to the original displacement `a * L`.  An original displacement can also cross a block boundary,
+with the resulting blocked displacement depending on the residue of the starting site.  This file
+packages all such carries in `blockedNeighborhood` and proves the exact finite-region identity
+needed to transport propagation bounds through blocking.
+
+## Main definitions
+
+* `SpinChain.blockedNeighborhood` — the carry-aware neighborhood on the blocked lattice.
+
+## Main results
+
+* `SpinChain.expandedRegion_translateRegion` — blocked translations scale by `L`.
+* `SpinChain.algebraicLocalBlocking_translation` — algebraic blocking intertwines scaled
+  translations.
+* `SpinChain.quasiLocalBlocking_translation` — quasi-local blocking intertwines scaled
+  translations.
+* `SpinChain.mem_blockedNeighborhood` — quotient/remainder characterization of all carries.
+* `SpinChain.blockHull_regionSumset_expandedRegion` — exact carry-aware block-hull identity.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2308 and
+  2313--2320.
+-/
+
+namespace SpinChain
+
+private lemma divModEquiv_fst_sub_mul (L : ℕ) [NeZero L] (z a : ℤ) :
+    (Int.divModEquiv L (z - a * L)).1 = (Int.divModEquiv L z).1 - a := by
+  simp only [Int.divModEquiv_apply]
+  rw [show z - a * (L : ℤ) = z + (-a) * L by ring,
+    Int.add_mul_ediv_right]
+  · ring
+  · exact_mod_cast NeZero.ne L
+
+/-- Expanding a blocked region translated by `a` gives the original expanded region translated by
+`a * L`.  This includes negative block coordinates and negative displacements.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma expandedRegion_translateRegion (L : ℕ) [NeZero L] (a : ℤ) (Λ : Finset ℤ) :
+    expandedRegion L (translateRegion a Λ) =
+      translateRegion (a * L) (expandedRegion L Λ) := by
+  ext z
+  simp only [mem_expandedRegion, mem_translateRegion]
+  rw [divModEquiv_fst_sub_mul]
+
+/-- The blocked-lattice neighborhood induced by an original-lattice neighborhood `𝓝`.
+
+The starting residue ranges over the full reference block `expandedRegion L {0}`.  Thus the block
+hull records every possible carry of `r + n`, where `r` is a residue and `n ∈ 𝓝`; using only
+`blockHull L 𝓝` would miss boundary-crossing carries.
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+def blockedNeighborhood (L : ℕ) [NeZero L] (𝓝 : Finset ℤ) : Finset ℤ :=
+  blockHull L (regionSumset (expandedRegion L {0}) 𝓝)
+
+/-- Membership in the carry-aware blocked neighborhood is characterized by a starting residue and
+an original displacement whose sum has the given quotient block coordinate.  Since
+`Int.divModEquiv` uses Euclidean division, this statement applies without a sign restriction.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma mem_blockedNeighborhood (L : ℕ) [NeZero L] (𝓝 : Finset ℤ) (b : ℤ) :
+    b ∈ blockedNeighborhood L 𝓝 ↔
+      ∃ r : Fin L, ∃ n ∈ 𝓝, (Int.divModEquiv L ((r : ℤ) + n)).1 = b := by
+  simp only [blockedNeighborhood, blockHull, Finset.mem_image, mem_regionSumset,
+    mem_expandedRegion, Finset.mem_singleton]
+  constructor
+  · rintro ⟨z, ⟨i, hi, n, hn, rfl⟩, rfl⟩
+    have hi0 : (Int.divModEquiv L i).1 = 0 := hi
+    let r := (Int.divModEquiv L i).2
+    refine ⟨r, n, hn, ?_⟩
+    have hi_repr := (Int.divModEquiv L).symm_apply_apply i
+    rw [Int.divModEquiv_symm_apply] at hi_repr
+    change (Int.divModEquiv L ((r : ℤ) + n)).1 = _
+    rw [← hi_repr]
+    simp only [hi0, zero_mul, zero_add]
+    rfl
+  · rintro ⟨r, n, hn, hbn⟩
+    let i : ℤ := (Int.divModEquiv L).symm (0, r)
+    refine ⟨i + n, ?_, ?_⟩
+    · refine ⟨i, ?_, n, hn, rfl⟩
+      simp only [i, Equiv.apply_symm_apply]
+    · simpa only [i, Int.divModEquiv_symm_apply, zero_mul, zero_add] using hbn
+
+/-- Equivalently, a blocked displacement belongs to `blockedNeighborhood L 𝓝` exactly when some
+input residue and displacement decompose into that quotient and an output residue.  The two
+residues expose the within-block carry explicitly, including for negative displacements.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma mem_blockedNeighborhood_iff_exists_eq
+    (L : ℕ) [NeZero L] (𝓝 : Finset ℤ) (b : ℤ) :
+    b ∈ blockedNeighborhood L 𝓝 ↔
+      ∃ r s : Fin L, ∃ n ∈ 𝓝, (r : ℤ) + n = b * L + s := by
+  rw [mem_blockedNeighborhood]
+  constructor
+  · rintro ⟨r, n, hn, hq⟩
+    let s := (Int.divModEquiv L ((r : ℤ) + n)).2
+    refine ⟨r, s, n, hn, ?_⟩
+    have hrepr := (Int.divModEquiv L).symm_apply_apply ((r : ℤ) + n)
+    rw [Int.divModEquiv_symm_apply, hq] at hrepr
+    exact hrepr.symm
+  · rintro ⟨r, s, n, hn, hrs⟩
+    refine ⟨r, n, hn, ?_⟩
+    have hpair : Int.divModEquiv L ((r : ℤ) + n) = (b, s) := by
+      apply (Int.divModEquiv L).symm.injective
+      rw [Equiv.symm_apply_apply, Int.divModEquiv_symm_apply, hrs]
+    exact congrArg Prod.fst hpair
+
+private lemma divModEquiv_fst_add_block (L : ℕ) [NeZero L] (x z : ℤ) :
+    (Int.divModEquiv L (x * L + z)).1 = x + (Int.divModEquiv L z).1 := by
+  simp only [Int.divModEquiv_apply]
+  rw [add_comm, Int.add_mul_ediv_right]
+  · ring
+  · exact_mod_cast NeZero.ne L
+
+/-- Taking the block hull after adding an original neighborhood to an expanded blocked region is
+exactly addition by the carry-aware blocked neighborhood.
+
+For an expanded site `x * L + r` and displacement `n`, the output block is
+`x + ((r + n) / L)`; ranging over all residues gives precisely `blockedNeighborhood L 𝓝`.
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma blockHull_regionSumset_expandedRegion (L : ℕ) [NeZero L]
+    (Λ 𝓝 : Finset ℤ) :
+    blockHull L (regionSumset (expandedRegion L Λ) 𝓝) =
+      regionSumset Λ (blockedNeighborhood L 𝓝) := by
+  ext b
+  simp only [blockHull, Finset.mem_image, mem_regionSumset, mem_expandedRegion,
+    mem_blockedNeighborhood]
+  constructor
+  · rintro ⟨z, ⟨i, hi, n, hn, rfl⟩, rfl⟩
+    let x := (Int.divModEquiv L i).1
+    let r := (Int.divModEquiv L i).2
+    have hi_repr := (Int.divModEquiv L).symm_apply_apply i
+    rw [Int.divModEquiv_symm_apply] at hi_repr
+    refine ⟨x, hi, (Int.divModEquiv L ((r : ℤ) + n)).1, ?_, ?_⟩
+    · exact ⟨r, n, hn, rfl⟩
+    · rw [← hi_repr]
+      change x + (Int.divModEquiv L ((r : ℤ) + n)).1 =
+        (Int.divModEquiv L (x * L + (r : ℤ) + n)).1
+      rw [show x * (L : ℤ) + (r : ℤ) + n = x * L + ((r : ℤ) + n) by ring,
+        divModEquiv_fst_add_block]
+  · rintro ⟨x, hx, q, ⟨r, n, hn, hq⟩, rfl⟩
+    let i : ℤ := (Int.divModEquiv L).symm (x, r)
+    refine ⟨i + n, ?_, ?_⟩
+    · refine ⟨i, ?_, n, hn, rfl⟩
+      simpa only [i, Equiv.apply_symm_apply] using hx
+    · rw [show i = x * L + (r : ℤ) by simp [i, Int.divModEquiv_symm_apply]]
+      rw [show x * (L : ℤ) + (r : ℤ) + n = x * L + ((r : ℤ) + n) by ring,
+        divModEquiv_fst_add_block, hq]
+
+/-- Adding an original neighborhood to an expanded blocked region is contained in the expansion
+of the exact carry-aware blocked sumset.  This is the support-transport form of
+`blockHull_regionSumset_expandedRegion`. -/
+lemma regionSumset_expandedRegion_subset (L : ℕ) [NeZero L] (Λ 𝓝 : Finset ℤ) :
+    regionSumset (expandedRegion L Λ) 𝓝 ⊆
+      expandedRegion L (regionSumset Λ (blockedNeighborhood L 𝓝)) := by
+  rw [← blockHull_regionSumset_expandedRegion]
+  exact subset_expandedRegion_blockHull L _
+
+private lemma expandedRegion_translateRegion_subset (L : ℕ) [NeZero L]
+    (a : ℤ) (Λ : Finset ℤ) :
+    expandedRegion L (translateRegion a Λ) ⊆
+      translateRegion (a * L) (expandedRegion L Λ) := by
+  rw [expandedRegion_translateRegion]
+
+private lemma localBlocking_translation (d L : ℕ) [NeZero L] (a : ℤ)
+    (Λ : Finset ℤ) (A : LocalAlgebra (MPSTensor.blockPhysDim d L) Λ) :
+    localInclusion (expandedRegion_translateRegion_subset L a Λ)
+        (localBlocking d L (translateRegion a Λ)
+          (localTranslation (MPSTensor.blockPhysDim d L) a Λ A)) =
+      localTranslation d (a * L) (expandedRegion L Λ) (localBlocking d L Λ A) := by
+  ext x y
+  rw [localInclusion_apply]
+  have hreverse : translateRegion (a * L) (expandedRegion L Λ) ⊆
+      expandedRegion L (translateRegion a Λ) := by
+    rw [expandedRegion_translateRegion]
+  have hcomp :
+      (Config.splitEquiv (expandedRegion_translateRegion_subset L a Λ) x).2 =
+        (Config.splitEquiv (expandedRegion_translateRegion_subset L a Λ) y).2 := by
+    funext i
+    exact False.elim ((Finset.mem_sdiff.mp i.2).2
+      (hreverse (Finset.mem_sdiff.mp i.2).1))
+  rw [ite_eq_left hcomp, mul_one, localBlocking_apply, localTranslation_apply,
+    localTranslation_apply, localBlocking_apply]
+  have hconfig (w : Config d (translateRegion (a * L) (expandedRegion L Λ))) :
+      (Config.translation (MPSTensor.blockPhysDim d L) a Λ).symm
+          ((Config.blocking d L (translateRegion a Λ)).symm
+            (Config.restrict (expandedRegion_translateRegion_subset L a Λ) w)) =
+        (Config.blocking d L Λ).symm
+          ((Config.translation d (a * L) (expandedRegion L Λ)).symm w) := by
+    funext i
+    apply (MPSTensor.decodeBlockEquiv d L).injective
+    funext r
+    rw [Config.translation_symm_apply, Config.blocking_symm_apply,
+      Config.blocking_symm_apply]
+    simp only [Equiv.apply_symm_apply]
+    rw [Config.translation_symm_apply]
+    change w _ = w _
+    congr 1
+    apply Subtype.ext
+    simp only [siteTranslation_apply_val, blockSiteEquiv_symm_apply_val]
+    ring
+  rw [hconfig x, hconfig y]
+
+/-- Algebraic-local blocking intertwines blocked translation by `a` with original translation by
+`a * L`.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma algebraicLocalBlocking_translation (d L : ℕ) [NeZero d] [NeZero L] (a : ℤ)
+    (A : AlgebraicLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    algebraicLocalBlocking d L (algebraicLocalTranslation _ a A) =
+      algebraicLocalTranslation d (a * L) (algebraicLocalBlocking d L A) := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change algebraicLocalBlocking d L
+          (algebraicLocalTranslation _ a (localObservable _ Λ A)) =
+        algebraicLocalTranslation d (a * L)
+          (algebraicLocalBlocking d L (localObservable _ Λ A))
+      rw [algebraicLocalTranslation_localObservable,
+        algebraicLocalBlocking_localObservable,
+        algebraicLocalBlocking_localObservable,
+        algebraicLocalTranslation_localObservable]
+      rw [← localObservable_localInclusion d
+        (expandedRegion_translateRegion_subset L a Λ)]
+      exact congrArg (localObservable d (translateRegion (a * L) (expandedRegion L Λ)))
+        (localBlocking_translation d L a Λ A)
+
+/-- Quasi-local blocking intertwines blocked translation by `a` with original translation by
+`a * L`.
+
+Source: arXiv:1703.09188, Appendix, lines 2308 and 2313--2320. -/
+lemma quasiLocalBlocking_translation (d L : ℕ) [NeZero d] [NeZero L] (a : ℤ)
+    (A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    quasiLocalBlocking d L (quasiLocalTranslation _ a A) =
+      quasiLocalTranslation d (a * L) (quasiLocalBlocking d L A) := by
+  induction A using UniformSpace.Completion.induction_on with
+  | hp =>
+      change IsClosed {A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L) |
+        quasiLocalBlocking d L (quasiLocalTranslation _ a A) =
+          quasiLocalTranslation d (a * L) (quasiLocalBlocking d L A)}
+      exact isClosed_eq
+        ((quasiLocalBlocking_isometry d L).continuous.comp
+          (quasiLocalTranslation_isometry _ a).continuous)
+        ((quasiLocalTranslation_isometry d (a * L)).continuous.comp
+          (quasiLocalBlocking_isometry d L).continuous)
+  | ih A =>
+      change quasiLocalBlocking d L
+          (quasiLocalTranslation _ a (algebraicToQuasiLocal _ A)) =
+        quasiLocalTranslation d (a * L)
+          (quasiLocalBlocking d L (algebraicToQuasiLocal _ A))
+      rw [quasiLocalTranslation_algebraicToQuasiLocal,
+        quasiLocalBlocking_algebraicToQuasiLocal,
+        quasiLocalBlocking_algebraicToQuasiLocal,
+        quasiLocalTranslation_algebraicToQuasiLocal,
+        algebraicLocalBlocking_translation]
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9941,3 +9941,189 @@ $\omega^{-1}$.
     exact statement, apply inverse blocking and simplify the inverse composite
     and the block hull of the expanded region.
 \end{proof}
+
+\begin{lemma}[Expansion of a translated blocked region]
+    \label{lem:qca_expanded_region_translation}
+    \lean{SpinChain.expandedRegion_translateRegion}
+    \leanok
+    \uses{def:qca_translate_region,def:qca_expanded_region}
+    Let $L>0$, let $a\in\mathbb Z$, and let $\Lambda\subset\mathbb Z$ be a
+    finite blocked region.  Then
+    \begin{align}
+        \widehat{\Lambda+a}_L
+        &=\widehat\Lambda_L+aL.
+    \end{align}
+    This is the translation rule for the site grouping used in
+    \cite[lines~2308 and 2313--2320]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:qca_expanded_region_coordinates}
+    Write each original site uniquely as $xL+r$, with $0\leq r<L$.
+    Translation of the blocked coordinate by $a$ sends this site to
+    $(x+a)L+r=xL+r+aL$.  The argument is unchanged when $x$ or $a$ is
+    negative.
+\end{proof}
+
+\begin{definition}[Carry-aware blocked neighborhood]
+    \label{def:qca_blocked_neighborhood}
+    \lean{SpinChain.blockedNeighborhood}
+    \leanok
+    \uses{def:qca_expanded_region,def:qca_block_hull,def:qca_region_sumset}
+    Let $L>0$ and let $\mathcal N\subset\mathbb Z$ be a finite original-lattice
+    neighborhood.  Write $\widehat{\{0\}}_L=\{0,\ldots,L-1\}$ for the sites in
+    the reference block.  Define the induced blocked-lattice neighborhood by
+    \begin{align}
+        \mathcal C_L(\mathcal N)
+        &=\operatorname{Hull}_L
+          \bigl(\widehat{\{0\}}_L+\mathcal N\bigr).
+    \end{align}
+    The full reference block is included because the block reached after a
+    displacement can depend on the starting residue.  This is the finite-region
+    geometry implicit in the grouping of sites in
+    \cite[lines~2308 and 2313--2320]{Cirac2017MPU}.
+\end{definition}
+
+\begin{lemma}[Residue description of the blocked neighborhood]
+    \label{lem:qca_blocked_neighborhood_membership}
+    \lean{SpinChain.mem_blockedNeighborhood,
+        SpinChain.mem_blockedNeighborhood_iff_exists_eq}
+    \leanok
+    \uses{def:qca_blocked_neighborhood,thm:qca_expanded_region_coordinates}
+    Let $L>0$, let $\mathcal N\subset\mathbb Z$ be finite, and let
+    $b\in\mathbb Z$.  Then
+    \begin{align}
+        b\in\mathcal C_L(\mathcal N)
+        \quad\Longleftrightarrow\quad
+        &\exists r\in\{0,\ldots,L-1\},\ \exists n\in\mathcal N,
+        \quad \left\lfloor\frac{r+n}{L}\right\rfloor=b,             \\
+        \quad\Longleftrightarrow\quad
+        &\exists r,s\in\{0,\ldots,L-1\},\ \exists n\in\mathcal N,
+        \quad r+n=bL+s.
+    \end{align}
+    The quotient is the Euclidean quotient by the positive integer $L$.
+    Consequently these formulas include negative displacements and both
+    positive and negative block carries.  In general,
+    $\operatorname{Hull}_L(\mathcal N)$ alone omits some carries caused by the
+    starting residue.  This makes explicit the boundary geometry implicit in
+    \cite[lines~2313--2320]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_blocked_neighborhood,def:qca_block_hull,
+        thm:qca_expanded_region_coordinates}
+    An element of $\widehat{\{0\}}_L+\mathcal N$ has the form $r+n$ with
+    $0\leq r<L$ and $n\in\mathcal N$.  Taking its block coordinate gives the
+    first equivalence.  Euclidean division writes $r+n=bL+s$ with the unique
+    remainder $0\leq s<L$, which gives the second equivalence without any sign
+    restriction on $n$.
+\end{proof}
+
+\begin{lemma}[Exact block hull after adding a neighborhood]
+    \label{lem:qca_block_hull_region_sumset}
+    \lean{SpinChain.blockHull_regionSumset_expandedRegion}
+    \leanok
+    \uses{def:qca_blocked_neighborhood,def:qca_region_sumset,
+        def:qca_expanded_region,def:qca_block_hull}
+    Let $L>0$.  For every finite blocked region $\Lambda$ and every finite
+    original-lattice neighborhood $\mathcal N$,
+    \begin{align}
+        \operatorname{Hull}_L
+        \bigl(\widehat\Lambda_L+\mathcal N\bigr)
+        &=\Lambda+\mathcal C_L(\mathcal N).
+    \end{align}
+    This is the exact finite-region carry identity associated with the site
+    grouping in \cite[lines~2313--2320]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_neighborhood_membership,
+        thm:qca_expanded_region_coordinates}
+    Write an expanded site as $xL+r$, where $x\in\Lambda$ and $0\leq r<L$.
+    For $n\in\mathcal N$, Euclidean division gives
+    \begin{align}
+        \left\lfloor\frac{xL+r+n}{L}\right\rfloor
+        &=x+\left\lfloor\frac{r+n}{L}\right\rfloor.
+    \end{align}
+    The second summand ranges over exactly $\mathcal C_L(\mathcal N)$ by
+    Lemma~\ref{lem:qca_blocked_neighborhood_membership}.  This proves both
+    inclusions, including for negative $x$ and $n$.
+\end{proof}
+
+\begin{lemma}[Carry-aware expansion containment]
+    \label{lem:qca_region_sumset_expanded_region_subset}
+    \lean{SpinChain.regionSumset_expandedRegion_subset}
+    \leanok
+    \uses{lem:qca_block_hull_region_sumset,lem:qca_block_hull_properties}
+    Let $L>0$.  For every finite blocked region $\Lambda$ and every finite
+    original-lattice neighborhood $\mathcal N$,
+    \begin{align}
+        \widehat\Lambda_L+\mathcal N
+        &\subseteq
+        \widehat{\Lambda+\mathcal C_L(\mathcal N)}_L.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_block_hull_region_sumset,lem:qca_block_hull_properties}
+    Every finite original region is contained in the expansion of its block
+    hull.  Apply this containment to
+    $\widehat\Lambda_L+\mathcal N$ and use
+    Lemma~\ref{lem:qca_block_hull_region_sumset} to identify that hull.
+\end{proof}
+
+\begin{lemma}[Algebraic-local blocking intertwines scaled translations]
+    \label{lem:qca_algebraic_blocking_translation}
+    \lean{SpinChain.algebraicLocalBlocking_translation}
+    \leanok
+    \uses{lem:qca_expanded_region_translation,def:qca_algebraic_blocking,
+        def:qca_algebraic_local_translation}
+    Let $d,L>0$.  If $\mathcal B_L$ denotes the algebraic-local blocking
+    equivalence, then for every $a\in\mathbb Z$,
+    \begin{align}
+        \mathcal B_L\,\tau^{(d^L)}_a
+        &=\tau^{(d)}_{aL}\,\mathcal B_L.
+    \end{align}
+    This is the translation rule induced by the blocking of sites used in
+    \cite[lines~2308 and 2313--2320]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_expanded_region_translation,
+        lem:qca_algebraic_blocking_formulas,
+        def:qca_algebraic_local_translation}
+    On a representative supported in a finite blocked region $\Lambda$, both
+    sides apply the same matrix reindexing.  Their supports agree because
+    \begin{align}
+        \widehat{\Lambda+a}_L
+        &=\widehat\Lambda_L+aL.
+    \end{align}
+    Equality on all finite-region representatives proves the identity on the
+    algebraic direct limit.
+\end{proof}
+
+\begin{lemma}[Quasi-local blocking intertwines scaled translations]
+    \label{lem:qca_quasi_local_blocking_translation}
+    \lean{SpinChain.quasiLocalBlocking_translation}
+    \leanok
+    \uses{lem:qca_algebraic_blocking_translation,
+        def:qca_quasi_local_blocking,def:qca_quasi_local_translation}
+    Let $d,L>0$.  If $\overline{\mathcal B}_L$ denotes the quasi-local blocking
+    equivalence, then for every $a\in\mathbb Z$,
+    \begin{align}
+        \overline{\mathcal B}_L\,\overline\tau^{(d^L)}_a
+        &=\overline\tau^{(d)}_{aL}\,\overline{\mathcal B}_L.
+    \end{align}
+    This is the completion of the translation rule induced by the site grouping
+    in \cite[lines~2308 and 2313--2320]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_algebraic_blocking_translation,
+        lem:qca_quasi_local_blocking_formulas,
+        def:qca_quasi_local_translation}
+    The two sides are continuous maps on the quasi-local algebra.  On the dense
+    algebraic-local subalgebra their values agree by
+    Lemma~\ref{lem:qca_algebraic_blocking_translation}.  They therefore agree
+    on the completion.
+\end{proof}


### PR DESCRIPTION
Closes #6976.

## Summary

- prove that translation by `a` on the blocked lattice becomes translation by `a * L` on the original lattice, at the region, algebraic-local, and quasi-local levels
- define the exact carry-aware blocked neighborhood by ranging over all residues in a block, with quotient and quotient/remainder membership formulas
- prove the exact block-hull/region-sumset identity and the support-ready expanded-region containment
- add formula-driven Chapter 28 coverage for all eight public declarations

The geometry uses `Int.divModEquiv`, so negative sites, negative displacements, and both directions of carry are included. It does not use the false carry-free candidate `blockHull L 𝓝`.

## Verification

- `lake env lean TNLean/QCA/BlockingTranslation.lean`
- `lake build TNLean.QCA.BlockingTranslation`
- `lake build TNLean.QCA`
- generated aggregate imports current
- Blueprint synchronization and reverse coverage: Chapter 28 `718/718`
- Blueprint web and PDF builds
- reader-facing prose, whitespace, line-length, no-bypass, and `git diff --check`

Full repository declaration checking remains blocked by unrelated pre-existing stale root-build omissions; none of this PR's declarations is among them.
