### PR TITLE
feat(MPU): compute cyclic-shift source ranks

### DIFF
--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -9,3 +9,4 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.MPU.Examples
 
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.Examples.ShiftSourceRanks

--- a/TNLean/MPS/MPU/Examples/ShiftSourceRanks.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceRanks.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.Shift
+import Mathlib.LinearAlgebra.Matrix.Vec
+
+/-!
+# Source cuts and ranks of the cyclic shifts
+
+This module computes the raw source cuts and source ranks of the primitive
+right- and left-shift tensors from arXiv:1703.09188, lines 450--477 and
+1980--1987.
+
+For the right shift, the first source cut is the identity on the doubled
+physical index. The second is the outer product of the vectorized identity
+with itself. The left-shift formulas follow by physical adjunction.
+
+No compact-SVD factors or standard-form data are chosen here.
+-/
+
+namespace MPOTensor
+
+open scoped Matrix
+
+/-- The first raw source cut of the right-shift tensor is the identity on the
+product of two physical indices.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem sourceCutM₁_rightShiftTensor (d : ℕ) :
+    sourceCutM₁ (rightShiftTensor d) = 1 := by
+  ext row col
+  rcases row with ⟨α, j⟩
+  rcases col with ⟨i, β⟩
+  simp [sourceCutM₁, rightShiftTensor, Matrix.single_apply, Matrix.one_apply,
+    Prod.ext_iff, eq_comm]
+
+/-- The second raw source cut of the right-shift tensor is the outer product
+of the vectorized identity with itself.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem sourceCutM₂_rightShiftTensor (d : ℕ) :
+    sourceCutM₂ (rightShiftTensor d) =
+      Matrix.vecMulVec (1 : Matrix (Fin d) (Fin d) ℂ).vec
+        (1 : Matrix (Fin d) (Fin d) ℂ).vec := by
+  ext row col
+  rcases row with ⟨α, i⟩
+  rcases col with ⟨j, β⟩
+  by_cases hαi : α = i <;> by_cases hjβ : j = β <;>
+    simp [sourceCutM₂, rightShiftTensor, Matrix.vecMulVec_apply,
+      hαi, hjβ, eq_comm]
+
+/-- The right source rank of the right shift is $d^2$, including at $d=0$.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem rightRank_rightShiftTensor (d : ℕ) :
+    r[rightShiftTensor d] = d * d := by
+  rw [rightRank, sourceCutM₁_rightShiftTensor, Matrix.rank_one]
+  simp
+
+/-- The left source rank of the right shift is one for positive physical
+dimension.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem leftRank_rightShiftTensor (d : ℕ) [NeZero d] :
+    ℓ[rightShiftTensor d] = 1 := by
+  rw [leftRank, sourceCutM₂_rightShiftTensor]
+  let i : Fin d := Classical.choice (inferInstance : Nonempty (Fin d))
+  let v := (1 : Matrix (Fin d) (Fin d) ℂ).vec
+  have hle : (Matrix.vecMulVec v v).rank ≤ 1 := Matrix.rank_vecMulVec_le v v
+  have hminor :
+      (Matrix.vecMulVec v v).submatrix (fun _ : Fin 1 ↦ (i, i))
+          (fun _ : Fin 1 ↦ (i, i)) = 1 := by
+    ext a b
+    simp [v, Matrix.vecMulVec_apply, Matrix.one_apply, Subsingleton.elim a b]
+  have hlower := Matrix.rank_submatrix_le (Matrix.vecMulVec v v)
+    (fun _ : Fin 1 ↦ (i, i)) (fun _ : Fin 1 ↦ (i, i))
+  rw [hminor, Matrix.rank_one] at hlower
+  simpa using Nat.le_antisymm hle hlower
+
+/-- The first raw source cut of the left-shift tensor is the outer product of
+the vectorized identity with itself.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem sourceCutM₁_leftShiftTensor (d : ℕ) :
+    sourceCutM₁ (leftShiftTensor d) =
+      Matrix.vecMulVec (1 : Matrix (Fin d) (Fin d) ℂ).vec
+        (1 : Matrix (Fin d) (Fin d) ℂ).vec := by
+  rw [leftShiftTensor, sourceCutM₁_physicalAdjointTensor,
+    sourceCutM₂_rightShiftTensor]
+  ext row col
+  simp only [Matrix.map_apply, Matrix.vecMulVec_apply, Matrix.vec]
+  by_cases hr : row.2 = row.1 <;> by_cases hc : col.2 = col.1 <;>
+    simp [Matrix.one_apply, hr, hc]
+
+/-- The second raw source cut of the left-shift tensor is the identity on the
+product of two physical indices.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem sourceCutM₂_leftShiftTensor (d : ℕ) :
+    sourceCutM₂ (leftShiftTensor d) = 1 := by
+  rw [leftShiftTensor, sourceCutM₂_physicalAdjointTensor,
+    sourceCutM₁_rightShiftTensor]
+  ext row col
+  simp [Matrix.one_apply]
+
+/-- The right source rank of the left shift is one for positive physical
+dimension. This follows from physical adjunction and the right-shift left-rank
+calculation.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem rightRank_leftShiftTensor (d : ℕ) [NeZero d] :
+    r[leftShiftTensor d] = 1 := by
+  rw [leftShiftTensor, rightRank_physicalAdjointTensor,
+    leftRank_rightShiftTensor]
+
+/-- The left source rank of the left shift is $d^2$, including at $d=0$.
+This follows from physical adjunction and the right-shift right-rank
+calculation.
+
+Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
+theorem leftRank_leftShiftTensor (d : ℕ) :
+    ℓ[leftShiftTensor d] = d * d := by
+  rw [leftShiftTensor, leftRank_physicalAdjointTensor,
+    rightRank_rightShiftTensor]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSourceRanks.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceRanks.lean
@@ -4,28 +4,29 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.SourceCuts
+import Mathlib.LinearAlgebra.Matrix.Rank
 import Mathlib.LinearAlgebra.Matrix.Vec
 
 /-!
 # Source cuts and ranks of the cyclic shifts
 
-This module computes the raw source cuts and source ranks of the primitive
+This module computes the raw source cuts and source ranks of the cyclic
 right- and left-shift tensors from arXiv:1703.09188, lines 450--477 and
 1980--1987.
 
-For the right shift, the first source cut is the identity on the doubled
-physical index. The second is the outer product of the vectorized identity
-with itself. The left-shift formulas follow by physical adjunction.
+For the right shift, the first source cut is the identity on the source-cut
+$(\text{virtual}, \text{physical})$ product index. The second is the outer
+product of the vectorized identity with itself. The left-shift formulas follow
+by physical adjunction.
 
 No compact-SVD factors or standard-form data are chosen here.
 -/
 
 namespace MPOTensor
 
-open scoped Matrix
-
 /-- The first raw source cut of the right-shift tensor is the identity on the
-product of two physical indices.
+source-cut $(\text{virtual}, \text{physical})$ product index.
 
 Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
 theorem sourceCutM₁_rightShiftTensor (d : ℕ) :
@@ -66,7 +67,7 @@ Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
 theorem leftRank_rightShiftTensor (d : ℕ) [NeZero d] :
     ℓ[rightShiftTensor d] = 1 := by
   rw [leftRank, sourceCutM₂_rightShiftTensor]
-  let i : Fin d := Classical.choice (inferInstance : Nonempty (Fin d))
+  let i : Fin d := 0
   let v := (1 : Matrix (Fin d) (Fin d) ℂ).vec
   have hle : (Matrix.vecMulVec v v).rank ≤ 1 := Matrix.rank_vecMulVec_le v v
   have hminor :
@@ -95,7 +96,7 @@ theorem sourceCutM₁_leftShiftTensor (d : ℕ) :
     simp [Matrix.one_apply, hr, hc]
 
 /-- The second raw source cut of the left-shift tensor is the identity on the
-product of two physical indices.
+source-cut $(\text{virtual}, \text{physical})$ product index.
 
 Source: arXiv:1703.09188, lines 450--477 and 1980--1987. -/
 theorem sourceCutM₂_leftShiftTensor (d : ℕ) :

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7290,6 +7290,55 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     its unitarity.
 \end{proof}
 
+\begin{theorem}[Source cuts and ranks of the cyclic shifts]
+    \label{thm:mpu_shift_source_cuts_ranks}
+    \lean{MPOTensor.sourceCutM₁_rightShiftTensor}
+    \lean{MPOTensor.sourceCutM₂_rightShiftTensor}
+    \lean{MPOTensor.rightRank_rightShiftTensor}
+    \lean{MPOTensor.leftRank_rightShiftTensor}
+    \lean{MPOTensor.sourceCutM₁_leftShiftTensor}
+    \lean{MPOTensor.sourceCutM₂_leftShiftTensor}
+    \lean{MPOTensor.rightRank_leftShiftTensor}
+    \lean{MPOTensor.leftRank_leftShiftTensor}
+    \leanok
+    \uses{def:mpu_shift_tensors, def:mpu_source_matrix_one, def:mpu_source_matrix_two, def:mpu_right_rank, def:mpu_left_rank}
+    Let $A$ be the right-shift tensor and let
+    $z_{(\alpha,i)}=\delta_{\alpha i}$ be the vectorized identity. Its raw
+    source cuts are
+    \begin{align}
+        M_1(A) & =\Id, \\
+        M_2(A) & =zz^{\mathsf T}.
+    \end{align}
+    For the left-shift tensor $A^\sharp$ they are
+    \begin{align}
+        M_1(A^\sharp) & =zz^{\mathsf T}, \\
+        M_2(A^\sharp) & =\Id.
+    \end{align}
+    In every physical dimension, including $d=0$,
+    \begin{align}
+        r(A)            & =d^2, \\
+        \ell(A^\sharp) & =d^2.
+    \end{align}
+    If $d>0$, the remaining two ranks are
+    \begin{align}
+        \ell(A)       & =1, \\
+        r(A^\sharp)   & =1.
+    \end{align}
+    These are the raw source-cut quantities from
+    \cite[Section~III]{Cirac2017MPU}; no choice of source factors is involved.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_physical_adjoint_source_cuts, thm:mpu_physical_adjoint_source_ranks}
+    The entry formula $A^{ij}_{\alpha\beta}
+    =\delta_{i\alpha}\delta_{j\beta}$ gives $M_1(A)=\Id$ and
+    $M_2(A)=zz^{\mathsf T}$. Hence the first rank is $d^2$. For $d>0$, the
+    vector $z$ has a nonzero diagonal coordinate, so its outer product has
+    rank one. Physical adjunction exchanges the two cuts and their ranks,
+    which gives all four left-shift formulas without a second rank
+    calculation.
+\end{proof}
+
 \begin{definition}[Three topological-insulator shift MPUs]
     \label{threeMPU}
     \lean{MPOTensor.identityMPUTensor}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7329,7 +7329,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_physical_adjoint_source_cuts, thm:mpu_physical_adjoint_source_ranks}
+    \uses{def:mpu_shift_tensors, def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two, def:mpu_right_rank, def:mpu_left_rank,
+        thm:mpu_physical_adjoint_source_cuts, thm:mpu_physical_adjoint_source_ranks}
     The entry formula $A^{ij}_{\alpha\beta}
     =\delta_{i\alpha}\delta_{j\beta}$ gives $M_1(A)=\Id$ and
     $M_2(A)=zz^{\mathsf T}$. Hence the first rank is $d^2$. For $d>0$, the


### PR DESCRIPTION
## What changed

- compute the right-shift source cuts as the identity and the outer product of the vectorized identity
- derive the exact right-shift source ranks, including the `d = 0` boundary
- derive the left-shift cuts and ranks through physical adjunction
- add the source-faithful Chapter 28 theorem node before the three shift-family examples

This is only the raw source-rank layer. It does not claim source unitarity, standard form, `ThmFund1`, a public index, or equality with compact-SVD choices.

## Validation

- targeted module and aggregator build (9063 jobs)
- full `lake build` from the exact warmed cache (10278 jobs)
- Blueprint source synchronization (6677/6677; Chapter 28 718/718)
- strict Blueprint declaration check
- two `lualatex` passes with zero undefined non-citation references
- generated import aggregator check (36 aggregators, 1018 modules)
- proof-integrity grep and `git diff --check`
- exact-head source/style review approved at `9bb0c3c5dd20fc05a564834432f6117af8749830`

Closes #6985
Advances #6288
Advances #6289



