### PR TITLE
QCA: transport finite propagation and covariance through blocking

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.QCA.AlgebraicBlocking
 import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.Blocking
+import TNLean.QCA.BlockingQCA
 import TNLean.QCA.BlockingTranslation
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation

--- a/TNLean/QCA/BlockingQCA.lean
+++ b/TNLean/QCA/BlockingQCA.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.BlockingTranslation
+import TNLean.QCA.IsQCA
+
+/-!
+# Transporting quantum cellular automata through site blocking
+
+Conjugating an original-chain automorphism by the quasi-local site-blocking equivalence produces
+an automorphism of the blocked chain.  A finite original propagation neighborhood induces the
+carry-aware blocked neighborhood from `BlockingTranslation`, while blocked unit translation
+corresponds exactly to original translation by one block length.
+
+Only the forward implications needed for blocking a QCA are asserted here.  In particular,
+commutation with original translation by `L` need not imply covariance under original unit
+translation.
+
+## Main definitions
+
+* `SpinChain.blockedAutomorphism` — the conjugate `B⁻¹ ω B` on the blocked chain.
+
+## Main results
+
+* `SpinChain.PropagatesWithin.blocked` — carry-aware transport of a propagation neighborhood.
+* `SpinChain.HasFinitePropagation.blocked` — finite forward propagation survives blocking.
+* `SpinChain.translationCovariant_blockedAutomorphism_iff` — blocked translation covariance is
+  exactly commutation with original translation by `L`.
+* `SpinChain.TranslationCovariant.blocked` — original translation covariance survives blocking.
+* `SpinChain.IsQCA.blocked` — a QCA remains a QCA after site blocking.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2308.
+-/
+
+namespace SpinChain
+
+/-- Conjugate an original-chain star-automorphism by the quasi-local blocking equivalence.
+
+If `B` denotes `quasiLocalBlocking d L`, then this is the blocked-chain automorphism
+`B⁻¹ ω B`.
+
+Source: arXiv:1703.09188, Appendix, line 2308. -/
+noncomputable def blockedAutomorphism (d L : ℕ) [NeZero d] [NeZero L]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) :
+    QuasiLocalAlgebra (MPSTensor.blockPhysDim d L) ≃⋆ₐ[ℂ]
+      QuasiLocalAlgebra (MPSTensor.blockPhysDim d L) :=
+  ((quasiLocalBlocking d L).trans ω).trans (quasiLocalBlocking d L).symm
+
+/-- Evaluation of the blocked automorphism displays the conjugation orientation explicitly. -/
+@[simp]
+lemma blockedAutomorphism_apply (d L : ℕ) [NeZero d] [NeZero L]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d)
+    (A : QuasiLocalAlgebra (MPSTensor.blockPhysDim d L)) :
+    blockedAutomorphism d L ω A =
+      (quasiLocalBlocking d L).symm (ω (quasiLocalBlocking d L A)) :=
+  rfl
+
+/-- Blocking commutes with taking the inverse automorphism. -/
+@[simp]
+lemma blockedAutomorphism_symm (d L : ℕ) [NeZero d] [NeZero L]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) :
+    (blockedAutomorphism d L ω).symm = blockedAutomorphism d L ω.symm := by
+  ext A
+  rw [StarAlgEquiv.symm_apply_eq]
+  simp only [blockedAutomorphism_apply, StarAlgEquiv.apply_symm_apply,
+    StarAlgEquiv.symm_apply_apply]
+
+namespace PropagatesWithin
+
+/-- A propagation neighborhood transports through site blocking to its exact carry-aware blocked
+neighborhood.
+
+Source context: arXiv:1703.09188, Appendix, line 2308. -/
+lemma blocked {d L : ℕ} [NeZero d] [NeZero L]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+    (hω : PropagatesWithin ω 𝓝) :
+    PropagatesWithin (blockedAutomorphism d L ω) (blockedNeighborhood L 𝓝) := by
+  intro Λ A hA
+  have hblocked := quasiLocalBlocking_supportedIn d L hA
+  have himage := hω (expandedRegion L Λ) (quasiLocalBlocking d L A) hblocked
+  have hreverse := quasiLocalBlocking_symm_supportedIn d L himage
+  rw [blockHull_regionSumset_expandedRegion] at hreverse
+  simpa only [blockedAutomorphism_apply] using hreverse
+
+end PropagatesWithin
+
+namespace HasFinitePropagation
+
+/-- Finite forward propagation is preserved by site blocking. -/
+lemma blocked {d L : ℕ} [NeZero d] [NeZero L]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : HasFinitePropagation ω) : HasFinitePropagation (blockedAutomorphism d L ω) := by
+  obtain ⟨𝓝, h𝓝⟩ := hω
+  exact ⟨blockedNeighborhood L 𝓝, h𝓝.blocked⟩
+
+end HasFinitePropagation
+
+/-- Translation covariance of the blocked automorphism is equivalent to commutation of the
+original automorphism with translation by one whole block.
+
+This does not characterize covariance under original unit translation when `L ≠ 1`.
+Source context: arXiv:1703.09188, Appendix, line 2308. -/
+theorem translationCovariant_blockedAutomorphism_iff
+    (d L : ℕ) [NeZero d] [NeZero L]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) :
+    TranslationCovariant (blockedAutomorphism d L ω) ↔
+      Commute ω (quasiLocalTranslation d (L : ℤ)) := by
+  rw [translationCovariant_iff_commute_one]
+  constructor
+  · intro h
+    change ω * quasiLocalTranslation d (L : ℤ) = quasiLocalTranslation d (L : ℤ) * ω
+    ext A
+    let X := (quasiLocalBlocking d L).symm A
+    have hX := DFunLike.congr_fun h.eq X
+    have hBX := congrArg (quasiLocalBlocking d L) hX
+    simpa only [StarAlgEquiv.mul_apply, blockedAutomorphism_apply, X,
+      StarAlgEquiv.apply_symm_apply, StarAlgEquiv.symm_apply_apply,
+      quasiLocalBlocking_translation, one_mul] using hBX
+  · intro h
+    change blockedAutomorphism d L ω * quasiLocalTranslation _ 1 =
+      quasiLocalTranslation _ 1 * blockedAutomorphism d L ω
+    ext A
+    change blockedAutomorphism d L ω (quasiLocalTranslation _ 1 A) =
+      quasiLocalTranslation _ 1 (blockedAutomorphism d L ω A)
+    have hA : ω (quasiLocalTranslation d (L : ℤ) (quasiLocalBlocking d L A)) =
+        quasiLocalTranslation d (L : ℤ) (ω (quasiLocalBlocking d L A)) := by
+      simpa only [StarAlgEquiv.mul_apply] using
+        DFunLike.congr_fun h.eq (quasiLocalBlocking d L A)
+    rw [blockedAutomorphism_apply, quasiLocalBlocking_translation, one_mul, hA,
+      blockedAutomorphism_apply]
+    rw [StarAlgEquiv.symm_apply_eq, quasiLocalBlocking_translation, one_mul,
+      StarAlgEquiv.apply_symm_apply]
+
+namespace TranslationCovariant
+
+/-- Translation covariance is preserved by site blocking.
+
+Only this forward implication is valid in general: blocked unit covariance records commutation of
+the original automorphism with translation by `L`, not necessarily by one site.
+Source context: arXiv:1703.09188, Appendix, line 2308. -/
+lemma blocked {d L : ℕ} [NeZero d] [NeZero L]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : TranslationCovariant ω) : TranslationCovariant (blockedAutomorphism d L ω) :=
+  (translationCovariant_blockedAutomorphism_iff d L ω).2 (hω (L : ℤ))
+
+end TranslationCovariant
+
+namespace IsQCA
+
+/-- A one-dimensional QCA remains a QCA after grouping `L` consecutive sites into one blocked
+site.
+
+Source: arXiv:1703.09188, Appendix, line 2308. -/
+lemma blocked {d L : ℕ} [NeZero d] [NeZero L]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : IsQCA ω) : IsQCA (blockedAutomorphism d L ω) :=
+  ⟨hω.translationCovariant.blocked, hω.hasFinitePropagation.blocked⟩
+
+end IsQCA
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10127,3 +10127,184 @@ $\omega^{-1}$.
     Lemma~\ref{lem:qca_algebraic_blocking_translation}.  They therefore agree
     on the completion.
 \end{proof}
+
+Line~2308 of \cite{Cirac2017MPU} invokes a converse representation theorem:
+after blocking finitely many sites, the restriction of every one-dimensional
+QCA to the local algebra is represented by a depth-two circuit of
+nearest-neighbor unitaries, and hence by an MPU in standard form.  The results
+below concern the preceding change of grouping.  A
+given QCA remains a QCA under any prescribed finite blocking.  This one-way
+transport alone does not produce the circuit or MPU representation asserted by
+the converse theorem.
+
+\begin{definition}[Blocked automorphism]
+    \label{def:qca_blocked_automorphism}
+    \lean{SpinChain.blockedAutomorphism}
+    \leanok
+    \uses{def:qca_quasi_local_blocking}
+    Let $d,L>0$, let
+    $\overline{\mathcal B}_L\colon\mathcal A^{(d^L)}\simeq\mathcal A^{(d)}$
+    be the quasi-local blocking equivalence, and let $\omega$ be a star-algebra
+    automorphism of $\mathcal A^{(d)}$.  The induced automorphism of the blocked
+    chain is
+    \begin{align}
+        \omega^{[L]}
+        &=\overline{\mathcal B}_L^{-1}\circ\omega\circ
+          \overline{\mathcal B}_L.
+    \end{align}
+\end{definition}
+
+\begin{lemma}[Evaluation of the blocked automorphism]
+    \label{lem:qca_blocked_automorphism_apply}
+    \lean{SpinChain.blockedAutomorphism_apply}
+    \leanok
+    \uses{def:qca_blocked_automorphism}
+    For every $X\in\mathcal A^{(d^L)}$,
+    \begin{align}
+        \omega^{[L]}(X)
+        &=\overline{\mathcal B}_L^{-1}
+          \bigl(\omega(\overline{\mathcal B}_L(X))\bigr).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_blocked_automorphism}
+    This is the evaluation formula for the defining conjugation.
+\end{proof}
+
+\begin{lemma}[Inverse of the blocked automorphism]
+    \label{lem:qca_blocked_automorphism_symm}
+    \lean{SpinChain.blockedAutomorphism_symm}
+    \leanok
+    \uses{def:qca_blocked_automorphism}
+    The inverse of the blocked automorphism is the blocked inverse:
+    \begin{align}
+        (\omega^{[L]})^{-1}
+        &=(\omega^{-1})^{[L]}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_automorphism_apply}
+    Evaluate both sides on a blocked-chain observable.  The blocking equivalence
+    and its inverse cancel on the two sides of $\omega^{-1}$.
+\end{proof}
+
+\begin{lemma}[Propagation neighborhood after site blocking]
+    \label{lem:qca_propagates_within_blocked}
+    \lean{SpinChain.PropagatesWithin.blocked}
+    \leanok
+    \uses{def:qca_blocked_automorphism,def:qca_blocked_neighborhood,
+        def:qca_propagates_within}
+    Let $\mathcal N\subset\mathbb Z$ be finite.  If $\omega$ propagates within
+    $\mathcal N$, then $\omega^{[L]}$ propagates within the carry-aware blocked
+    neighborhood $\mathcal C_L(\mathcal N)$.  Explicitly, for every finite
+    blocked region $\Lambda$ and every $X\in\mathcal A^{(d^L)}$ supported in
+    $\Lambda$, the observable $\omega^{[L]}(X)$ is supported in
+    $\Lambda+\mathcal C_L(\mathcal N)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_automorphism_apply,
+        lem:qca_quasi_local_blocking_support,
+        lem:qca_block_hull_region_sumset}
+    Forward blocking sends support in $\Lambda$ to support in
+    $\widehat\Lambda_L$.  Apply the propagation bound for $\omega$, then apply
+    inverse blocking.  The resulting support is
+    \begin{align}
+        \operatorname{Hull}_L
+        \bigl(\widehat\Lambda_L+\mathcal N\bigr)
+        &=\Lambda+\mathcal C_L(\mathcal N)
+    \end{align}
+    by the exact carry-aware block-hull identity.
+\end{proof}
+
+\begin{lemma}[Finite propagation after site blocking]
+    \label{lem:qca_finite_propagation_blocked}
+    \lean{SpinChain.HasFinitePropagation.blocked}
+    \leanok
+    \uses{def:qca_blocked_automorphism,def:qca_finite_propagation,
+        lem:qca_propagates_within_blocked}
+    If $\omega$ has finite forward propagation, then $\omega^{[L]}$ has finite
+    forward propagation.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_propagates_within_blocked}
+    Choose a finite propagation neighborhood $\mathcal N$ for $\omega$.
+    Lemma~\ref{lem:qca_propagates_within_blocked} gives the finite neighborhood
+    $\mathcal C_L(\mathcal N)$ for $\omega^{[L]}$.
+\end{proof}
+
+\begin{theorem}[Translation covariance of the blocked automorphism]
+    \label{thm:qca_blocked_translation_covariant_iff}
+    \lean{SpinChain.translationCovariant_blockedAutomorphism_iff}
+    \leanok
+    \uses{def:qca_blocked_automorphism,def:qca_translation_covariant,
+        def:qca_quasi_local_translation}
+    The blocked automorphism is translation covariant if and only if the
+    original automorphism commutes with translation by one whole block:
+    \begin{align}
+        \omega^{[L]}\text{ is translation covariant}
+        \quad\Longleftrightarrow\quad
+        \omega\circ\overline\tau^{(d)}_L
+        &=\overline\tau^{(d)}_L\circ\omega.
+    \end{align}
+    Thus blocked unit-translation covariance records commutation of $\omega$
+    with translation by $L$, not necessarily commutation with original unit
+    translation.  For $L\neq1$, the latter condition can be strictly stronger.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_automorphism_apply,
+        thm:qca_translation_covariant_iff_commute_one,
+        lem:qca_quasi_local_blocking_translation}
+    By Theorem~\ref{thm:qca_translation_covariant_iff_commute_one}, translation
+    covariance on the blocked chain is equivalent to commutation with blocked
+    unit translation.  Under $\overline{\mathcal B}_L$, blocked unit translation
+    corresponds to original translation by $L$.  Conjugating the commutation
+    identity by the blocking equivalence proves both implications.
+\end{proof}
+
+\begin{lemma}[Translation covariance after site blocking]
+    \label{lem:qca_translation_covariant_blocked}
+    \lean{SpinChain.TranslationCovariant.blocked}
+    \leanok
+    \uses{def:qca_blocked_automorphism,def:qca_translation_covariant,
+        thm:qca_blocked_translation_covariant_iff}
+    If $\omega$ is translation covariant, then $\omega^{[L]}$ is translation
+    covariant.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:qca_blocked_translation_covariant_iff}
+    Translation covariance of $\omega$ gives commutation with
+    $\overline\tau^{(d)}_L$.  Apply
+    Theorem~\ref{thm:qca_blocked_translation_covariant_iff}.
+\end{proof}
+
+\begin{lemma}[QCA transport through site blocking]
+    \label{lem:qca_blocked}
+    \lean{SpinChain.IsQCA.blocked}
+    \leanok
+    \uses{def:qca,def:qca_blocked_automorphism,
+        lem:qca_finite_propagation_blocked,
+        lem:qca_translation_covariant_blocked}
+    Let $d,L>0$.  If $\omega$ is a one-dimensional QCA on
+    $\mathcal A^{(d)}$, then
+    \begin{align}
+        \omega^{[L]}
+        &=\overline{\mathcal B}_L^{-1}\circ\omega\circ
+          \overline{\mathcal B}_L
+    \end{align}
+    is a one-dimensional QCA on $\mathcal A^{(d^L)}$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_finite_propagation_blocked,
+        lem:qca_translation_covariant_blocked}
+    The two defining properties of a one-dimensional QCA are finite forward
+    propagation and translation covariance.  They are preserved by
+    Lemma~\ref{lem:qca_finite_propagation_blocked} and
+    Lemma~\ref{lem:qca_translation_covariant_blocked}, respectively.
+\end{proof}


### PR DESCRIPTION
Closes #6977.

## Summary

- define the blocked conjugate automorphism explicitly as $B_L^{-1}\omega B_L$, with evaluation and inverse formulas
- transport fixed and existential finite propagation through the exact carry-aware blocked neighborhood
- characterize blocked unit-translation covariance exactly as commutation of the original automorphism with translation by one block length
- prove the valid forward transports of translation covariance and `IsQCA`
- add declaration-specific, formula-driven Chapter 28 coverage

The PR deliberately does not claim the invalid converse from blocked unit covariance to original unit covariance. Prescribed site blocking preserves a QCA; it does not by itself supply the depth-two circuit/MPU representation from the external structure theorem.

## Verification

- `lake env lean TNLean/QCA/BlockingQCA.lean`
- `lake build TNLean.QCA.BlockingQCA`
- `lake build TNLean.QCA`
- generated aggregate imports current
- Blueprint synchronization: Chapter 28 `726/726`, overall `6685/6685`
- changed-declaration reverse coverage for all eight public declarations
- Blueprint web build and dependency graph generation
- reader-facing prose, whitespace, line-length, integrity, tactic-pattern, and `git diff --check`

The global declaration check remains blocked by unrelated pre-existing stale root-build omissions; none of this PR's declarations is among them.
