### PR TITLE
doc(tenkz): align language prose with behavior

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -228,7 +228,7 @@ ends' faces, and the stroke follows the resolved endpoint type (§5).
 | `form=` | small-enum | `bracket` `enclosure` `label` | `label` |
 | `species=` | identifier | — | empty |
 | `tint` | flag | — | false |
-| `label pos=` | angle | a bearing in the host's own axes, or `auto` | `auto` |
+| `label pos=` | angle | a bearing in the host's own axes; omit the key for automatic placement | `auto` |
 | `name=` | identifier | — | generated |
 
 A mark takes the `species=` that atoms and wires already carry, with the same
@@ -338,9 +338,10 @@ spanning atom at a midway or on-wire address keeps every slot a
 frame-anchored one would. A cell named without a member
 index denotes the whole cell, which is what a cell means to a selection.
 
-Every record class is addressable by name, generated names included, and the
-picture is a record (§2). It answers to `picture`, which is how a route or a
-mark names the whole diagram without a second grammar for doing so.
+Atoms, wires, and pictures are addressable by name, generated names included.
+A mark's generated `name=` is recorded but no address grammar resolves it.
+The picture answers to `picture`, which is how a route or a mark names the
+whole diagram without a second grammar for doing so.
 
 A **selector** names a set of records — one address, a braced comma-separated
 list, a range, or one selector less another:
@@ -924,9 +925,9 @@ triangle with nothing declared. A declared skin
 pairings; a pairing is a WIRE whose endpoints are the skin's own ports.
 Skins contain no free ink: an element that is not a port or a pairing of
 ports is not declarable. A declared species
-(`\tndeclare{species}{flux}{hue=source:red}`) binds semantic ink;
-`hue=source:*` values reproduce a cited paper's palette instead of the house
-cycle.
+(`\tndeclare{species}{flux}{hue=source:red}`) binds semantic ink. The
+`source:` prefix records provenance, while the literal colour after it is the
+colour used; it does not retrieve or reproduce a cited palette.
 
 ### Declaration keys (3)
 
@@ -1079,7 +1080,7 @@ row is what names where the meaning went.
 | `trace style=racetrack` | closure depth follows the selection the closure clears (§5) |
 | `inline`, `compact` | math-style sensing + `size=`; a page-constrained picture declares `metrics=compact` (§2.2) |
 | `sizes=` | `size=` on the picture or atom; the bundled metric table is fixed |
-| `theme=` | the house theme binds at load; a cited palette reaches ink through `\tndeclare{species}{<name>}{hue=source:<colour>}` |
+| `theme=` | the house theme binds at load; source-tagged literal ink is declared by `\tndeclare{species}{<name>}{hue=source:<colour>}` |
 | `via=` | `route={<side> of <selector>}` where the waypoint cleared records (§12.3); nothing where it only bent a line past cells that hold none (§12.1), and nothing on a wound string, whose class is already its path (§5, §12.2) |
 | `bend=` | nothing: an arc leaves and enters along its ends' faces |
 | `weight=` | nothing: the port type decides the stroke, and multiplicity is mathematics carried by the index label |
@@ -1292,8 +1293,8 @@ the whole picture.
    coded hard error.
 5. Open ink is declared content: the boundary signature is computed from
    port and wire records and written to the event stream.
-6. Raw TikZ is not public syntax. Themes rebind ink and typography; they add
-   no topology.
+6. Raw TikZ is not public syntax. The house theme binds ink and typography at
+   load; species declarations may replace semantic ink by a literal colour.
 7. One concept, one canonical spelling; sugar is declared, expanded, and
    tested; tombstones never return.
 

--- a/docs/tenkz/chapters2/ch-catalogue.tex
+++ b/docs/tenkz/chapters2/ch-catalogue.tex
@@ -122,8 +122,7 @@ different: it closes the applicable pair of physical ports at each site.
 
 Identifying all four sides gives a torus.  A closed string on that frame is
 then classified by its two winding numbers.  The two fundamental cycles below
-cross once; the crossing order and the explicit crossing claim are recorded on
-the vertical cycle.
+cross once; the explicit crossing claim is recorded on the vertical cycle.
 
 \begin{tnexample}[
   formula={W_{(1,0)}W_{(0,1)}},
@@ -133,12 +132,12 @@ the vertical cycle.
     marked tensor stands at their declared crossing.},
   signature={kernel-boundary|signature=}]
 % Ink: surface=torus identifies every opposite side; wind= selects
-%   a homotopy class, and crossing=/cross= settle the intersection.
+%   a homotopy class, and cross= settles the named intersection.
 \tndeclare{species}{cycle}{hue=source:red}
 \begin{tenkz}[lattice={3x3}, surface=torus]
   \tnwire[kind=string, species=cycle, name=cx, closed, wind={1,0}]
   \tnwire[kind=string, species=cycle, name=cy, closed, wind={0,1},
-    crossing=under, cross={under at crossing of cy and cx}]
+    cross={under at crossing of cy and cx}]
   \tn[skin=box, role=marked, at=crossing of cx and cy,
       label pos=e]{i}
 \end{tenkz}

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -199,12 +199,9 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{species}{declared-name}{empty}{kernel}{Semantic species.}
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{wind}{pair}{zero}{kernel}{Homotopy class on traced frames.}
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{cross}{crossing-list}{empty}{kernel}{Declared over and under crossings.}
-% Extension-gate: #4779 -- crossing= is the string's habit, the order it
-% takes at every crossing it makes, stated once instead of once per
-% crossing, and it arrives with the route that derives a crossing set from
-% the side a string passes on.  cross= stays as the per-crossing exception.
-% Consumers: rmp-iii-a-pulling-through, rmp-workbench-iii-g-injective-pull,
-% rmp-workbench-iii-mpo-injective-white.
+% Extension-gate: #4779 -- crossing= supplies one order for the crossing set
+% derived by a hull route.  cross= remains the declaration of a crossing by
+% name, and is the only crossing spelling read by a free string.
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{crossing}{enum(over|under|alternate|alternate=over|alternate=under)}{empty}{kernel}{Default order for the crossings a hull route derives.}
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{dir}{direction-policy}{none}{kernel}{Direction mark of a directed index.}
 % Extension-gate: #5543 -- the sources draw two non-solid rails and no third:
@@ -305,9 +302,9 @@
 %
 % The inert setup theme= key retired 2026-08-23 (#6889): it stored an
 % identifier that no ink or render pass read.  The house palette is load-time
-% policy; a cited palette belongs to the species declaration it changes.
+% policy; a source-tagged literal colour belongs to its species declaration.
 \__tenkz_language_registry_tombstone:nnn {kernel-setup}{theme}
-  {the house theme binds at load; a cited palette reaches ink through
+  {the house theme binds at load; source-tagged literal ink is declared by
     \tndeclare{species}{<name>}{hue=source:<colour>}}
 %
 % The sentenced wire weight= key retired with its zero-demand bundle audit


### PR DESCRIPTION
## Summary

- describe `crossing=` only as the default order for crossings derived by a hull route, and remove an ineffective free-string spelling from the catalogue
- document mark `label pos=auto` as an omit-only default and mark names as recorded but not addressable
- state that `hue=source:<colour>` records provenance and uses the literal colour; it does not retrieve a cited palette
- align the retired `theme=` migration and sign-off doctrine with the load-time house theme

The stale `sizes=` and active `theme=` passages named in the issue were already removed when those keys retired in LionSR/TNLean#6974 and LionSR/TNLean#6978. This pull request preserves their current tombstone migrations and corrects the remaining claims.

## Verification

- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/test_tenkz_manual_doctest.py`
- `python3 scripts/tenkz_lint.py ...` (249 files, no findings)
- two `xelatex` passes over `docs/tenkz/manual2.tex`
- `python3 scripts/tenkz_audit.py docs/tenkz/manual2.tnlog` (no hard errors)
- full release-harness self-test, inventory, assertions, readiness, and pins
- `bash scripts/tenkz_corpus.sh`
- `git diff --check`

Closes LionSR/tenkz#237