### PR TITLE
doc(tenkz): identify registry sweep provenance

### DIFF
--- a/docs/tenkz/REGISTRY-SWEEP-2026-08-22.md
+++ b/docs/tenkz/REGISTRY-SWEEP-2026-08-22.md
@@ -5,8 +5,11 @@ implementation by compiling: what the key accepts, what it changes on the
 page, the stated default, the description, and the cited consumers.  Eight
 compile agents swept the sixty-seven key rows; fifty stood accurate and
 seventeen took a correction, executed in the change that adds this record.
-Source line numbers below refer to the sweep-time tree; named functions are
-the stable anchors in the current source.
+This record first appeared in commit
+`dd1790a2cae5847d561a88200e7a56a4494d0764`. The numeric source coordinates
+below were captured by eight isolated sweep worktrees while other tenkz
+changes were landing, so they do not refer to one common source revision.
+The named functions and macros are the stable anchors in the current source.
 Two agent verdicts were themselves corrected on re-review before anything
 moved: `kernel-wire:crossing` is read by the hull-route habit pass
 (`route_habit`), which the sweep's scenarios never exercised, and the


### PR DESCRIPTION
## Summary

- identify the commit in which the registry-sweep evidence record first appeared
- state that its numeric coordinates came from eight isolated sweep worktrees during concurrent tenkz changes, rather than from one common revision
- direct later readers to the named functions and macros as stable source anchors

The `kernel-wire:kind` paragraph already contains the corrected conclusion: authored `kind=pairing` is refused, while declared skins generate pairing records internally. No further rewrite of that paragraph is needed.

## Verification

- full release-harness self-test
- release inventory check
- all release assertions
- release readiness check
- release policy pins
- `git diff --check`

Closes LionSR/tenkz#238