### PR TITLE
QCA: assemble compatible finite-local automorphisms

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -13,6 +13,7 @@ import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.Blocking
 import TNLean.QCA.BlockingQCA
 import TNLean.QCA.BlockingTranslation
+import TNLean.QCA.CompatibleLocalAutomorphism
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation
 import TNLean.QCA.InversePropagation

--- a/TNLean/QCA/CompatibleLocalAutomorphism.lean
+++ b/TNLean/QCA/CompatibleLocalAutomorphism.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.IsQCA
+
+/-!
+# Compatible finite-local actions on the quasi-local algebra
+
+A pair of compatible families of finite-region star-algebra homomorphisms, inverse after passage to
+algebraic-local observables, determines a star-algebra equivalence of the algebraic local algebra.
+If the forward family preserves the local operator norm, mutual invertibility makes both induced
+maps isometries, so the equivalence extends to the quasi-local completion. Finite-region support and
+unit-translation formulas for the forward family then imply finite propagation, translation
+covariance, and the QCA predicate for the completed automorphism.
+
+The hypotheses in this file are deliberately stated for the supplied finite-local families. No
+stabilization of finite-chain observables, quantitative propagation radius, standard-form theorem,
+or MPU-to-QCA construction is asserted.
+
+## Main definitions
+
+* `SpinChain.CompatibleLocalAutomorphism` — mutually inverse compatible finite-local families.
+* `SpinChain.CompatibleLocalAutomorphism.algebraicEquiv` — the induced algebraic-local
+  star-algebra equivalence.
+* `SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv` — its extension to the completion.
+* `SpinChain.CompatibleLocalAutomorphism.ForwardNormPreserving` — the explicit local norm
+  hypothesis; inverse norm preservation follows from mutual invertibility.
+* `SpinChain.CompatibleLocalAutomorphism.MapsSupportWithin` — a finite-local support bound.
+* `SpinChain.CompatibleLocalAutomorphism.CommutesWithUnitTranslation` — the finite-local unit
+  translation formula.
+
+## Main results
+
+* Dense algebraic-local and finite-region evaluation formulas for the algebraic and completed
+  equivalences and their inverses.
+* Local norm preservation implies forward and inverse isometry.
+* A finite-local support bound implies `SpinChain.PropagatesWithin` for the completion.
+* The finite-local unit-translation formula implies `SpinChain.TranslationCovariant`.
+* Together these hypotheses imply `SpinChain.IsQCA`.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2306.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- Mutually inverse compatible finite-local actions on the algebraic local algebra.
+
+Each family starts on every finite-region algebra and takes values in the algebraic direct limit.
+Compatibility says that enlarging the source region does not change the resulting local observable.
+The last two fields say that the compatible lifts are inverse on every finite-region representative;
+the universal property then makes them inverse on the whole algebraic local algebra.
+
+Source context: arXiv:1703.09188, Appendix, lines 2292--2306, where compatible local actions are
+assembled on the local algebra and then extended to its norm completion. -/
+structure CompatibleLocalAutomorphism (d : ℕ) where
+  /-- The forward finite-local family. -/
+  forward : (Λ : Finset ℤ) → LocalAlgebra d Λ →⋆ₐ[ℂ] AlgebraicLocalAlgebra d
+  /-- The inverse finite-local family. -/
+  inverse : (Λ : Finset ℤ) → LocalAlgebra d Λ →⋆ₐ[ℂ] AlgebraicLocalAlgebra d
+  /-- The forward family is compatible with canonical inclusions. -/
+  forward_compatible : ∀ (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ),
+    forward Γ (localInclusion h A) = forward Λ A
+  /-- The inverse family is compatible with canonical inclusions. -/
+  inverse_compatible : ∀ (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ),
+    inverse Γ (localInclusion h A) = inverse Λ A
+  /-- Applying the lifted inverse after the forward family fixes every finite representative. -/
+  inverse_forward : ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+    algebraicLocalAlgebraLift inverse inverse_compatible (forward Λ A) =
+      localObservable d Λ A
+  /-- Applying the lifted forward map after the inverse family fixes every finite representative. -/
+  forward_inverse : ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+    algebraicLocalAlgebraLift forward forward_compatible (inverse Λ A) =
+      localObservable d Λ A
+
+namespace CompatibleLocalAutomorphism
+
+variable {d : ℕ} (F : CompatibleLocalAutomorphism d)
+
+/-- The star-algebra homomorphism induced by the compatible forward finite-local family. -/
+noncomputable def forwardHom :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
+  algebraicLocalAlgebraLift F.forward F.forward_compatible
+
+/-- The star-algebra homomorphism induced by the compatible inverse finite-local family. -/
+noncomputable def inverseHom :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
+  algebraicLocalAlgebraLift F.inverse F.inverse_compatible
+
+/-- The forward algebraic-local map agrees with the supplied finite-local family. -/
+@[simp]
+lemma forwardHom_localObservable (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    F.forwardHom (localObservable d Λ A) = F.forward Λ A :=
+  rfl
+
+/-- The inverse algebraic-local map agrees with the supplied finite-local family. -/
+@[simp]
+lemma inverseHom_localObservable (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    F.inverseHom (localObservable d Λ A) = F.inverse Λ A :=
+  rfl
+
+/-- Compatible mutually inverse finite-local families induce a star-algebra equivalence of the
+algebraic local algebra. -/
+noncomputable def algebraicEquiv :
+    AlgebraicLocalAlgebra d ≃⋆ₐ[ℂ] AlgebraicLocalAlgebra d where
+  toFun := F.forwardHom
+  invFun := F.inverseHom
+  left_inv A := by
+    induction A using DirectLimit.induction with
+    | _ Λ A => exact F.inverse_forward Λ A
+  right_inv A := by
+    induction A using DirectLimit.induction with
+    | _ Λ A => exact F.forward_inverse Λ A
+  map_add' A B := map_add F.forwardHom A B
+  map_mul' A B := map_mul F.forwardHom A B
+  map_smul' c A := map_smul F.forwardHom c A
+  map_star' A := map_star F.forwardHom A
+
+/-- The algebraic-local equivalence evaluates by the lifted forward homomorphism. -/
+@[simp]
+lemma algebraicEquiv_apply (A : AlgebraicLocalAlgebra d) :
+    F.algebraicEquiv A = F.forwardHom A :=
+  rfl
+
+/-- The inverse algebraic-local equivalence evaluates by the lifted inverse homomorphism. -/
+@[simp]
+lemma algebraicEquiv_symm_apply (A : AlgebraicLocalAlgebra d) :
+    F.algebraicEquiv.symm A = F.inverseHom A :=
+  rfl
+
+/-- The forward finite-local family preserves the operator norm on every finite region. -/
+def ForwardNormPreserving [NeZero d] : Prop :=
+  ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ), ‖F.forward Λ A‖ = ‖A‖
+
+variable [NeZero d]
+
+/-- A local forward norm formula extends to every algebraic-local observable. -/
+lemma norm_algebraicEquiv (hF : F.ForwardNormPreserving)
+    (A : AlgebraicLocalAlgebra d) : ‖F.algebraicEquiv A‖ = ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change ‖F.forward Λ A‖ = ‖localObservable d Λ A‖
+      rw [hF, norm_localObservable]
+
+/-- The induced forward algebraic-local equivalence is an isometry when the forward finite-local
+family preserves norm. -/
+lemma algebraicEquiv_isometry (hF : F.ForwardNormPreserving) :
+    Isometry F.algebraicEquiv := by
+  rw [isometry_iff_dist_eq]
+  intro A B
+  rw [dist_eq_norm, dist_eq_norm, ← map_sub, norm_algebraicEquiv F hF]
+
+/-- Mutual invertibility makes the inverse algebraic-local equivalence an isometry whenever the
+forward family preserves norm. -/
+lemma algebraicEquiv_symm_isometry (hF : F.ForwardNormPreserving) :
+    Isometry F.algebraicEquiv.symm :=
+  (F.algebraicEquiv_isometry hF).right_inv F.algebraicEquiv.apply_symm_apply
+
+/-- The inverse algebraic-local equivalence preserves norm; no separate inverse norm hypothesis is
+needed. -/
+lemma norm_algebraicEquiv_symm (hF : F.ForwardNormPreserving)
+    (A : AlgebraicLocalAlgebra d) : ‖F.algebraicEquiv.symm A‖ = ‖A‖ :=
+  (F.algebraicEquiv_symm_isometry hF).norm_map_of_map_zero
+    (map_zero F.algebraicEquiv.symm) A
+
+/-- The algebraic-local equivalence extends to a star-algebra equivalence of the quasi-local
+completion when its forward finite-local family preserves norm. -/
+noncomputable def quasiLocalEquiv (hF : F.ForwardNormPreserving) :
+    QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  UniformSpace.Completion.mapStarAlgEquiv F.algebraicEquiv
+    (F.algebraicEquiv_isometry hF).continuous
+    (F.algebraicEquiv_symm_isometry hF).continuous
+
+/-- The completed equivalence agrees with the algebraic-local equivalence on the dense canonical
+subalgebra. -/
+@[simp]
+lemma quasiLocalEquiv_algebraicToQuasiLocal
+    (hF : F.ForwardNormPreserving) (A : AlgebraicLocalAlgebra d) :
+    F.quasiLocalEquiv hF (algebraicToQuasiLocal d A) =
+      algebraicToQuasiLocal d (F.algebraicEquiv A) :=
+  UniformSpace.Completion.mapStarAlgEquiv_coe _ _ _ A
+
+/-- The inverse completed equivalence agrees with the inverse algebraic-local equivalence on the
+dense canonical subalgebra. -/
+@[simp]
+lemma quasiLocalEquiv_symm_algebraicToQuasiLocal
+    (hF : F.ForwardNormPreserving) (A : AlgebraicLocalAlgebra d) :
+    (F.quasiLocalEquiv hF).symm (algebraicToQuasiLocal d A) =
+      algebraicToQuasiLocal d (F.algebraicEquiv.symm A) := by
+  exact UniformSpace.Completion.mapStarAlgEquiv_coe
+    F.algebraicEquiv.symm
+    (F.algebraicEquiv_symm_isometry hF).continuous
+    (F.algebraicEquiv_isometry hF).continuous A
+
+/-- The completed equivalence evaluates on a finite-region observable by the supplied forward
+finite-local family. -/
+lemma quasiLocalEquiv_quasiLocalObservable
+    (hF : F.ForwardNormPreserving) (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    F.quasiLocalEquiv hF (quasiLocalObservable d Λ A) =
+      algebraicToQuasiLocal d (F.forward Λ A) := by
+  rw [quasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalEquiv_algebraicToQuasiLocal, algebraicEquiv_apply,
+    forwardHom_localObservable]
+
+/-- The inverse completed equivalence evaluates on a finite-region observable by the supplied
+inverse finite-local family. -/
+lemma quasiLocalEquiv_symm_quasiLocalObservable
+    (hF : F.ForwardNormPreserving) (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    (F.quasiLocalEquiv hF).symm (quasiLocalObservable d Λ A) =
+      algebraicToQuasiLocal d (F.inverse Λ A) := by
+  rw [quasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalEquiv_symm_algebraicToQuasiLocal, algebraicEquiv_symm_apply,
+    inverseHom_localObservable]
+
+/-- A finite-local support bound for the forward family: an observable initially represented in
+`Λ` is sent to one represented in `Λ + 𝓝`. -/
+def MapsSupportWithin (𝓝 : Finset ℤ) : Prop :=
+  ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+    SupportedIn (F.forward Λ A) (regionSumset Λ 𝓝)
+
+/-- The forward family commutes with unit translation on every finite-region representative. -/
+def CommutesWithUnitTranslation : Prop :=
+  ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+    F.forward (translateRegion 1 Λ) (localTranslation d 1 Λ A) =
+      algebraicLocalTranslation d 1 (F.forward Λ A)
+
+/-- A finite-local support bound gives the same propagation neighborhood for the completed
+automorphism. -/
+theorem propagatesWithin_quasiLocalEquiv
+    (hF : F.ForwardNormPreserving) {𝓝 : Finset ℤ} (hsupp : F.MapsSupportWithin 𝓝) :
+    PropagatesWithin (F.quasiLocalEquiv hF) 𝓝 := by
+  intro Λ x hx
+  obtain ⟨A, rfl⟩ := hx
+  rw [quasiLocalEquiv_quasiLocalObservable]
+  obtain ⟨B, hB⟩ := hsupp Λ A
+  exact ⟨B, by rw [quasiLocalObservable, StarAlgHom.comp_apply, hB]⟩
+
+omit [NeZero d] in
+/-- The finite-local unit-translation formula implies commutation of the induced algebraic-local
+map with unit translation. -/
+lemma algebraicEquiv_commutes_unitTranslation (htrans : F.CommutesWithUnitTranslation)
+    (A : AlgebraicLocalAlgebra d) :
+    F.algebraicEquiv (algebraicLocalTranslation d 1 A) =
+      algebraicLocalTranslation d 1 (F.algebraicEquiv A) := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change F.algebraicEquiv
+          (algebraicLocalTranslation d 1 (localObservable d Λ A)) =
+        algebraicLocalTranslation d 1 (F.algebraicEquiv (localObservable d Λ A))
+      rw [algebraicLocalTranslation_localObservable, algebraicEquiv_apply,
+        forwardHom_localObservable, algebraicEquiv_apply, forwardHom_localObservable,
+        htrans]
+
+/-- The finite-local unit-translation formula implies translation covariance of the completed
+automorphism. -/
+theorem translationCovariant_quasiLocalEquiv
+    (hF : F.ForwardNormPreserving) (htrans : F.CommutesWithUnitTranslation) :
+    TranslationCovariant (F.quasiLocalEquiv hF) := by
+  rw [translationCovariant_iff_commute_one]
+  change F.quasiLocalEquiv hF * quasiLocalTranslation d 1 =
+    quasiLocalTranslation d 1 * F.quasiLocalEquiv hF
+  ext A
+  simp only [StarAlgEquiv.mul_apply]
+  induction A using UniformSpace.Completion.induction_on with
+  | hp =>
+      exact isClosed_eq
+        ((StarAlgEquiv.isometry (F.quasiLocalEquiv hF)).continuous.comp
+          (quasiLocalTranslation_isometry d 1).continuous)
+        ((quasiLocalTranslation_isometry d 1).continuous.comp
+          (StarAlgEquiv.isometry (F.quasiLocalEquiv hF)).continuous)
+  | ih A =>
+      change F.quasiLocalEquiv hF
+          (quasiLocalTranslation d 1 (algebraicToQuasiLocal d A)) =
+        quasiLocalTranslation d 1
+          (F.quasiLocalEquiv hF (algebraicToQuasiLocal d A))
+      simp only [quasiLocalTranslation_algebraicToQuasiLocal,
+        quasiLocalEquiv_algebraicToQuasiLocal]
+      rw [F.algebraicEquiv_commutes_unitTranslation htrans]
+
+/-- Compatible finite-local actions satisfying local norm, support, and unit-translation formulas
+assemble to a QCA of the quasi-local completion. -/
+theorem isQCA_quasiLocalEquiv
+    (hF : F.ForwardNormPreserving) {𝓝 : Finset ℤ} (hsupp : F.MapsSupportWithin 𝓝)
+    (htrans : F.CommutesWithUnitTranslation) :
+    IsQCA (F.quasiLocalEquiv hF) :=
+  IsQCA.mk (F.translationCovariant_quasiLocalEquiv hF htrans)
+    ⟨𝓝, F.propagatesWithin_quasiLocalEquiv hF hsupp⟩
+
+end CompatibleLocalAutomorphism
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10359,3 +10359,414 @@ the converse theorem.
     Lemma~\ref{lem:qca_finite_propagation_blocked} and
     Lemma~\ref{lem:qca_translation_covariant_blocked}, respectively.
 \end{proof}
+
+Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
+local action associated with an MPU by eventual finite-chain conjugation.  In
+lines~2300--2306, eventual constancy is used to obtain a norm-preserving
+star-algebra automorphism of $\mathcal A_{\mathrm{loc}}$, together with a
+translation formula and the support bound
+$\mathcal N=[-4D^4,4D^4]\cap\mathbb Z$, and then to extend this automorphism to
+$\mathcal A$.  The results below isolate the direct-limit and completion
+argument.  They begin with compatible forward and inverse finite-local actions
+and assume a forward norm formula, a support bound, and a unit-translation
+formula.  The inverse norm formula follows from forward isometry and mutual
+invertibility.  The numerical radius above belongs to the MPU-specific
+stabilization argument: the generic result below neither proves that radius nor
+constructs the finite-local actions from an MPU.  It also does not provide the
+blocked circuit or MPU standard form discussed at line~2308.
+
+\begin{definition}[Compatible finite-local automorphism data]
+    \label{def:qca_compatible_local_automorphism}
+    \lean{SpinChain.CompatibleLocalAutomorphism}
+    \leanok
+    \uses{thm:qca_algebraic_local_algebra_universal}
+    For each finite region $\Lambda$, let
+    \begin{align}
+        f_\Lambda,g_\Lambda\colon\mathcal A_\Lambda
+        &\longrightarrow\mathcal A_{\mathrm{loc}}
+    \end{align}
+    be star-algebra homomorphisms such that, whenever
+    $\Lambda\subseteq\Gamma$,
+    \begin{align}
+        f_\Gamma\circ\iota_{\Lambda,\Gamma}&=f_\Lambda,&
+        g_\Gamma\circ\iota_{\Lambda,\Gamma}&=g_\Lambda.
+    \end{align}
+    Let $f,g\colon\mathcal A_{\mathrm{loc}}\to
+    \mathcal A_{\mathrm{loc}}$ be the maps induced by these compatible
+    families.  Compatible finite-local automorphism data require
+    \begin{align}
+        g(f_\Lambda(A))&=\iota_\Lambda(A),&
+        f(g_\Lambda(A))&=\iota_\Lambda(A)
+    \end{align}
+    for every $A\in\mathcal A_\Lambda$.
+\end{definition}
+
+\begin{definition}[Induced algebraic-local homomorphisms]
+    \label{def:qca_compatible_local_homs}
+    \lean{SpinChain.CompatibleLocalAutomorphism.forwardHom,
+        SpinChain.CompatibleLocalAutomorphism.inverseHom}
+    \leanok
+    \uses{def:qca_compatible_local_automorphism,
+        thm:qca_algebraic_local_algebra_universal}
+    The compatible families induce star-algebra homomorphisms
+    \begin{align}
+        f,g\colon\mathcal A_{\mathrm{loc}}
+        &\longrightarrow\mathcal A_{\mathrm{loc}}.
+    \end{align}
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{thm:qca_algebraic_local_algebra_universal}
+    Apply the star-algebra universal property to each compatible family.
+\end{proof}
+
+\begin{lemma}[Evaluation of the induced homomorphisms]
+    \label{lem:qca_compatible_local_homs_evaluation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.forwardHom_localObservable,
+        SpinChain.CompatibleLocalAutomorphism.inverseHom_localObservable}
+    \leanok
+    \uses{def:qca_compatible_local_homs}
+    For every finite region $\Lambda$ and $A\in\mathcal A_\Lambda$,
+    \begin{align}
+        f(\iota_\Lambda(A))&=f_\Lambda(A),&
+        g(\iota_\Lambda(A))&=g_\Lambda(A).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:qca_algebraic_local_algebra_universal}
+    These are the evaluation identities supplied by the universal property.
+\end{proof}
+
+\begin{definition}[Induced algebraic-local equivalence]
+    \label{def:qca_compatible_algebraic_equiv}
+    \lean{SpinChain.CompatibleLocalAutomorphism.algebraicEquiv}
+    \leanok
+    \uses{def:qca_compatible_local_automorphism,
+        def:qca_compatible_local_homs}
+    Compatible finite-local automorphism data determine a star-algebra
+    equivalence
+    \begin{align}
+        F\colon\mathcal A_{\mathrm{loc}}
+        &\simeq\mathcal A_{\mathrm{loc}}
+    \end{align}
+    whose forward and inverse maps are $f$ and $g$, respectively.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{def:qca_compatible_local_automorphism,
+        lem:qca_compatible_local_homs_evaluation}
+    Induct on finite-region representatives in the algebraic direct limit.
+    The two inverse assumptions give
+    \begin{align}
+        g(f(\iota_\Lambda(A)))&=g(f_\Lambda(A))=\iota_\Lambda(A),\\
+        f(g(\iota_\Lambda(A)))&=f(g_\Lambda(A))=\iota_\Lambda(A).
+    \end{align}
+    Thus $f$ and $g$ are mutually inverse.
+\end{proof}
+
+\begin{lemma}[Evaluation of the algebraic equivalence]
+    \label{lem:qca_compatible_algebraic_equiv_evaluation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.algebraicEquiv_apply,
+        SpinChain.CompatibleLocalAutomorphism.algebraicEquiv_symm_apply}
+    \leanok
+    \uses{def:qca_compatible_algebraic_equiv,
+        def:qca_compatible_local_homs}
+    For every $A\in\mathcal A_{\mathrm{loc}}$,
+    \begin{align}
+        F(A)&=f(A),&F^{-1}(A)&=g(A).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_compatible_algebraic_equiv}
+    Both identities follow from the defining forward and inverse maps of $F$.
+\end{proof}
+
+\begin{definition}[Forward local norm hypothesis]
+    \label{def:qca_compatible_local_norm}
+    \lean{SpinChain.CompatibleLocalAutomorphism.ForwardNormPreserving}
+    \leanok
+    \uses{def:qca_compatible_local_automorphism,
+        def:qca_algebraic_local_operator_norm}
+    Assume $d>0$.  The forward local norm hypothesis is
+    \begin{align}
+        \lVert f_\Lambda(A)\rVert&=\lVert A\rVert
+    \end{align}
+    for every finite region $\Lambda$ and every $A\in\mathcal A_\Lambda$.
+\end{definition}
+
+\begin{lemma}[Forward algebraic norm formula]
+    \label{lem:qca_compatible_algebraic_norm}
+    \lean{SpinChain.CompatibleLocalAutomorphism.norm_algebraicEquiv}
+    \leanok
+    \uses{def:qca_compatible_algebraic_equiv,
+        def:qca_compatible_local_norm,
+        def:qca_algebraic_local_operator_norm}
+    Under the forward local norm hypothesis, every
+    $A\in\mathcal A_{\mathrm{loc}}$ satisfies
+    \begin{align}
+        \lVert F(A)\rVert&=\lVert A\rVert.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_algebraic_equiv_evaluation,
+        lem:qca_compatible_local_homs_evaluation,
+        def:qca_algebraic_local_operator_norm}
+    Induct on finite-region representatives.  For
+    $A=\iota_\Lambda(A_\Lambda)$,
+    \begin{align}
+        \lVert F(A)\rVert
+        &=\lVert f_\Lambda(A_\Lambda)\rVert
+         =\lVert A_\Lambda\rVert
+         =\lVert A\rVert.
+    \end{align}
+\end{proof}
+
+\begin{lemma}[Forward and inverse algebraic isometries]
+    \label{lem:qca_compatible_algebraic_isometry}
+    \lean{SpinChain.CompatibleLocalAutomorphism.algebraicEquiv_isometry,
+        SpinChain.CompatibleLocalAutomorphism.algebraicEquiv_symm_isometry}
+    \leanok
+    \uses{lem:qca_compatible_algebraic_norm,
+        def:qca_compatible_algebraic_equiv}
+    Under the forward local norm hypothesis, for all
+    $A,B\in\mathcal A_{\mathrm{loc}}$,
+    \begin{align}
+        \lVert F(A)-F(B)\rVert&=\lVert A-B\rVert,&
+        \lVert F^{-1}(A)-F^{-1}(B)\rVert&=\lVert A-B\rVert.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_algebraic_norm,
+        def:qca_compatible_algebraic_equiv}
+    Apply the forward norm identity to $A-B$ to prove that $F$ is an isometry.
+    Since $F\circ F^{-1}$ is the identity, the right-inverse law then makes
+    $F^{-1}$ an isometry as well.
+\end{proof}
+
+\begin{lemma}[Inverse algebraic norm formula]
+    \label{lem:qca_compatible_algebraic_inverse_norm}
+    \lean{SpinChain.CompatibleLocalAutomorphism.norm_algebraicEquiv_symm}
+    \leanok
+    \uses{lem:qca_compatible_algebraic_isometry}
+    Under the forward local norm hypothesis, every
+    $A\in\mathcal A_{\mathrm{loc}}$ satisfies
+    \begin{align}
+        \lVert F^{-1}(A)\rVert&=\lVert A\rVert.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_algebraic_isometry}
+    Apply the inverse isometry to the distance from $A$ to $0$ and use
+    $F^{-1}(0)=0$.
+\end{proof}
+
+\begin{definition}[Completed compatible local automorphism]
+    \label{def:qca_compatible_quasi_local_equiv}
+    \lean{SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv}
+    \leanok
+    \uses{def:qca_compatible_algebraic_equiv,
+        lem:qca_compatible_algebraic_isometry,
+        def:completion_star_alg_equiv}
+    Under the forward local norm hypothesis, the algebraic equivalence extends
+    to a star-algebra equivalence
+    \begin{align}
+        \overline F\colon\mathcal A&\simeq\mathcal A
+    \end{align}
+    of the quasi-local completion.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_algebraic_isometry,
+        def:completion_star_alg_equiv}
+    The forward norm formula makes $F$ an isometry, and the inverse law makes
+    $F^{-1}$ an isometry.  Apply the completion extension for star-algebra
+    equivalences to these two continuous maps.
+\end{proof}
+
+\begin{lemma}[Dense evaluation of the completed automorphism]
+    \label{lem:qca_compatible_quasi_local_dense_evaluation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv_algebraicToQuasiLocal,
+        SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv_symm_algebraicToQuasiLocal}
+    \leanok
+    \uses{def:qca_compatible_quasi_local_equiv,
+        def:completion_star_alg_equiv}
+    Let $j\colon\mathcal A_{\mathrm{loc}}\to\mathcal A$ be the canonical
+    completion map.  For every $A\in\mathcal A_{\mathrm{loc}}$,
+    \begin{align}
+        \overline F(j(A))&=j(F(A)),&
+        \overline F^{-1}(j(A))&=j(F^{-1}(A)).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_compatible_quasi_local_equiv,
+        def:completion_star_alg_equiv}
+    These are the canonical-image formulas for the continuous extension of a
+    star-algebra equivalence and for its inverse.
+\end{proof}
+
+\begin{lemma}[Finite evaluation of the completed automorphism]
+    \label{lem:qca_compatible_quasi_local_finite_evaluation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv_quasiLocalObservable,
+        SpinChain.CompatibleLocalAutomorphism.quasiLocalEquiv_symm_quasiLocalObservable}
+    \leanok
+    \uses{lem:qca_compatible_quasi_local_dense_evaluation,
+        lem:qca_compatible_algebraic_equiv_evaluation,
+        lem:qca_compatible_local_homs_evaluation,
+        def:qca_quasi_local_observable}
+    For every finite region $\Lambda$ and $A\in\mathcal A_\Lambda$,
+    \begin{align}
+        \overline F(j_\Lambda(A))&=j(f_\Lambda(A)),&
+        \overline F^{-1}(j_\Lambda(A))&=j(g_\Lambda(A)).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_quasi_local_dense_evaluation,
+        lem:qca_compatible_algebraic_equiv_evaluation,
+        lem:qca_compatible_local_homs_evaluation}
+    Substitute $j_\Lambda=j\circ\iota_\Lambda$ into the dense evaluation
+    formulas and use
+    $F(\iota_\Lambda(A))=f_\Lambda(A)$ and
+    $F^{-1}(\iota_\Lambda(A))=g_\Lambda(A)$.
+\end{proof}
+
+\begin{definition}[Finite-local support bound]
+    \label{def:qca_compatible_local_support_bound}
+    \lean{SpinChain.CompatibleLocalAutomorphism.MapsSupportWithin}
+    \leanok
+    \uses{def:qca_compatible_local_automorphism,
+        def:qca_supported_in,def:qca_region_sumset}
+    For a finite neighborhood $\mathcal N\subset\mathbb Z$, the forward family
+    has support bound $\mathcal N$ if
+    \begin{align}
+        f_\Lambda(A)&\in
+        \iota_{\Lambda+\mathcal N}
+        (\mathcal A_{\Lambda+\mathcal N})
+    \end{align}
+    for every finite region $\Lambda$ and every $A\in\mathcal A_\Lambda$.
+\end{definition}
+
+\begin{theorem}[Propagation from a finite-local support bound]
+    \label{thm:qca_compatible_local_propagation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.propagatesWithin_quasiLocalEquiv}
+    \leanok
+    \uses{def:qca_compatible_local_support_bound,
+        lem:qca_compatible_quasi_local_finite_evaluation,
+        def:qca_propagates_within}
+    If the forward family has support bound $\mathcal N$, then the completed
+    automorphism $\overline F$ propagates within $\mathcal N$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_compatible_local_support_bound,
+        lem:qca_compatible_quasi_local_finite_evaluation}
+    Let $X=j_\Lambda(A)$ be supported in $\Lambda$.  Choose
+    $B\in\mathcal A_{\Lambda+\mathcal N}$ such that
+    $f_\Lambda(A)=\iota_{\Lambda+\mathcal N}(B)$.  Then
+    \begin{align}
+        \overline F(X)
+        &=j(f_\Lambda(A))
+         =j_{\Lambda+\mathcal N}(B),
+    \end{align}
+    so the image is supported in $\Lambda+\mathcal N$.
+\end{proof}
+
+\begin{definition}[Finite-local unit-translation formula]
+    \label{def:qca_compatible_local_unit_translation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.CommutesWithUnitTranslation}
+    \leanok
+    \uses{def:qca_compatible_local_automorphism,
+        def:qca_algebraic_local_translation}
+    The forward family commutes with unit translation if, for every finite
+    region $\Lambda$ and every $A\in\mathcal A_\Lambda$,
+    \begin{align}
+        f_{\Lambda+1}(\tau_{1,\Lambda}(A))
+        &=\tau_1(f_\Lambda(A)).
+    \end{align}
+\end{definition}
+
+\begin{lemma}[Algebraic commutation with unit translation]
+    \label{lem:qca_compatible_algebraic_unit_translation}
+    \lean{SpinChain.CompatibleLocalAutomorphism.algebraicEquiv_commutes_unitTranslation}
+    \leanok
+    \uses{def:qca_compatible_local_unit_translation,
+        def:qca_compatible_algebraic_equiv,
+        def:qca_algebraic_local_translation}
+    If the finite-local unit-translation formula holds, then every
+    $A\in\mathcal A_{\mathrm{loc}}$ satisfies
+    \begin{align}
+        F(\tau_1(A))&=\tau_1(F(A)).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_compatible_local_unit_translation,
+        lem:qca_compatible_algebraic_equiv_evaluation,
+        lem:qca_compatible_local_homs_evaluation,
+        def:qca_algebraic_local_translation}
+    Induct on finite-region representatives and write
+    $A=\iota_\Lambda(A_\Lambda)$.  Then
+    \begin{align}
+        F(\tau_1(A))
+        &=f_{\Lambda+1}(\tau_{1,\Lambda}(A_\Lambda))
+         =\tau_1(f_\Lambda(A_\Lambda))
+         =\tau_1(F(A)).
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Translation covariance from unit translation]
+    \label{thm:qca_compatible_translation_covariant}
+    \lean{SpinChain.CompatibleLocalAutomorphism.translationCovariant_quasiLocalEquiv}
+    \leanok
+    \uses{lem:qca_compatible_algebraic_unit_translation,
+        lem:qca_compatible_quasi_local_dense_evaluation,
+        def:qca_quasi_local_translation,
+        thm:qca_translation_covariant_iff_commute_one}
+    If the finite-local unit-translation formula holds, then the completed
+    automorphism $\overline F$ is translation covariant.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_compatible_algebraic_unit_translation,
+        lem:qca_compatible_quasi_local_dense_evaluation,
+        def:qca_quasi_local_translation,
+        thm:qca_translation_covariant_iff_commute_one}
+    By Theorem~\ref{thm:qca_translation_covariant_iff_commute_one}, it suffices
+    to prove that $\overline F$ commutes with translation by one site.  Induct
+    on the completion.  On every $A\in\mathcal A_{\mathrm{loc}}$,
+    \begin{align}
+        \overline F(\overline\tau_1(j(A)))
+        &=j(F(\tau_1(A)))
+         =j(\tau_1(F(A)))
+         =\overline\tau_1(\overline F(j(A))).
+    \end{align}
+    The equality set is closed because both composites are continuous, so the
+    identity extends from the canonical dense subalgebra to the completion.
+\end{proof}
+
+\begin{theorem}[QCA assembled from compatible finite-local actions]
+    \label{thm:qca_compatible_local_automorphism}
+    \lean{SpinChain.CompatibleLocalAutomorphism.isQCA_quasiLocalEquiv}
+    \leanok
+    \uses{def:qca_compatible_quasi_local_equiv,
+        thm:qca_compatible_local_propagation,
+        thm:qca_compatible_translation_covariant,def:qca}
+    Let $d>0$.  Suppose the compatible forward family preserves the local
+    operator norm, has a finite support bound, and satisfies the finite-local
+    unit-translation formula.  Then the completed automorphism $\overline F$ is
+    a one-dimensional QCA.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_compatible_local_propagation,
+        thm:qca_compatible_translation_covariant}
+    The support hypothesis supplies a finite forward propagation neighborhood,
+    while the unit-translation formula supplies translation covariance.  These
+    are exactly the two defining properties of a one-dimensional QCA.
+\end{proof}


### PR DESCRIPTION
Closes #6992.

## Summary

- define compatible forward/inverse finite-local star-hom families and lift them through the algebraic direct limit
- package the mutually inverse lifts as an algebraic-local star equivalence with finite representative formulas
- derive forward and inverse algebraic isometries from a single forward local norm hypothesis, then extend to the quasi-local completion
- expose dense and finite-region evaluation formulas in both directions
- give finite-local support and unit-translation hypotheses implying propagation, translation covariance, and `IsQCA`
- add declaration-specific, formula-driven Chapter 28 coverage for all 24 public declarations

This is the generic direct-limit/completion assembly layer for the forward MPU-to-QCA construction. It does not assert eventual stabilization of finite-chain conjugations, derive the paper's $[-4D^4,4D^4]$ neighborhood, construct the finite-local families from an MPU, or prove standard form.

## Verification

- `lake env lean TNLean/QCA/CompatibleLocalAutomorphism.lean`
- `lake build TNLean.QCA.CompatibleLocalAutomorphism TNLean.QCA`
- generated QCA aggregate current
- focused declaration checking and reverse coverage for all 24 declarations
- Chapter 28 synchronization `750/750`, with no stale links in this block
- Blueprint web and PDF builds
- reader-facing prose, proof-integrity, tactic-pattern, whitespace, line-length, and `git diff --check`

The repository-wide declaration check remains blocked by unrelated pre-existing stale root-build declarations; none belongs to this PR.
