### PR TITLE
feat(QCA): reduce finite propagation to nearest-neighbor range

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -21,6 +21,7 @@ import TNLean.QCA.IsQCA
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm
+import TNLean.QCA.NearestNeighborBlocking
 import TNLean.QCA.QuasiLocal
 import TNLean.QCA.QuasiLocalBlocking
 import TNLean.QCA.QuasiLocalCommutant

--- a/TNLean/QCA/NearestNeighborBlocking.lean
+++ b/TNLean/QCA/NearestNeighborBlocking.lean
@@ -129,7 +129,7 @@ namespace IsQCA
 
 /-- Every one-dimensional QCA becomes a nearest-neighbor QCA after some positive site blocking.
 
-This packages propagation normalization and preservation of the QCA axioms. It does not
+This combines propagation normalization with preservation of the QCA axioms. It does not
 construct the Schumacher--Werner support algebras or circuit, nor an MPU standard form.
 
 Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,

--- a/TNLean/QCA/NearestNeighborBlocking.lean
+++ b/TNLean/QCA/NearestNeighborBlocking.lean
@@ -38,7 +38,10 @@ namespace SpinChain
 /-- If every original displacement has absolute value strictly smaller than the block length, then
 all carry-aware blocked displacements are nearest-neighbor displacements.
 
-The statement also covers the empty neighborhood without an additional hypothesis. -/
+The statement also covers the empty neighborhood without an additional hypothesis.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 lemma blockedNeighborhood_subset_Icc_one (L : ℕ) [NeZero L] (𝓝 : Finset ℤ)
     (h𝓝 : ∀ n ∈ 𝓝, Int.natAbs n < L) :
     blockedNeighborhood L 𝓝 ⊆ Finset.Icc (-1) 1 := by
@@ -68,14 +71,20 @@ lemma blockedNeighborhood_subset_Icc_one (L : ℕ) [NeZero L] (𝓝 : Finset ℤ
     omega
 
 /-- A strict bound on the supremum of the absolute displacements forces the carry-aware blocked
-neighborhood to be nearest-neighbor. -/
+neighborhood to be nearest-neighbor.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 lemma blockedNeighborhood_subset_Icc_one_of_sup (L : ℕ) [NeZero L] (𝓝 : Finset ℤ)
     (h𝓝 : 𝓝.sup Int.natAbs < L) :
     blockedNeighborhood L 𝓝 ⊆ Finset.Icc (-1) 1 :=
   blockedNeighborhood_subset_Icc_one L 𝓝 fun _ hn => lt_of_le_of_lt (Finset.le_sup hn) h𝓝
 
 /-- Blocking by one more than the largest absolute displacement canonically makes the
-carry-aware neighborhood nearest-neighbor.  For the empty neighborhood this chooses length one. -/
+carry-aware neighborhood nearest-neighbor.  For the empty neighborhood this chooses length one.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 lemma blockedNeighborhood_subset_Icc_one_sup_add_one (𝓝 : Finset ℤ) :
     blockedNeighborhood (𝓝.sup Int.natAbs + 1) 𝓝 ⊆ Finset.Icc (-1) 1 := by
   let _ : NeZero (𝓝.sup Int.natAbs + 1) := ⟨Nat.succ_ne_zero _⟩
@@ -84,7 +93,10 @@ lemma blockedNeighborhood_subset_Icc_one_sup_add_one (𝓝 : Finset ℤ) :
 namespace PropagatesWithin
 
 /-- A propagation bound becomes nearest-neighbor after blocking by more than every absolute
-original displacement. -/
+original displacement.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 lemma blocked_nearest_neighbor {d L : ℕ} [NeZero d] [NeZero L]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
     (hω : PropagatesWithin ω 𝓝) (h𝓝 : ∀ n ∈ 𝓝, Int.natAbs n < L) :
@@ -96,7 +108,10 @@ end PropagatesWithin
 namespace HasFinitePropagation
 
 /-- Every finite forward propagation bound becomes nearest-neighbor after some positive site
-blocking.  The witness is one more than the supremum of the absolute displacements. -/
+blocking.  The witness is one more than the supremum of the absolute displacements.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : HasFinitePropagation ω) :
@@ -115,7 +130,10 @@ namespace IsQCA
 /-- Every one-dimensional QCA becomes a nearest-neighbor QCA after some positive site blocking.
 
 This packages propagation normalization and preservation of the QCA axioms. It does not
-construct the Schumacher--Werner support algebras or circuit, nor an MPU standard form. -/
+construct the Schumacher--Werner support algebras or circuit, nor an MPU standard form.
+
+Source context: Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+line 2308, before the Schumacher--Werner structure theorem. -/
 theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : IsQCA ω) :

--- a/TNLean/QCA/NearestNeighborBlocking.lean
+++ b/TNLean/QCA/NearestNeighborBlocking.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.BlockingQCA
+
+/-!
+# Nearest-neighbor propagation after site blocking
+
+A finite original-lattice propagation neighborhood becomes nearest-neighbor after grouping more
+sites than the absolute value of every displacement.  The carry-aware blocked neighborhood is then
+contained in the integer interval `Finset.Icc (-1) 1`.
+
+This only normalizes a finite propagation bound before applying the Schumacher--Werner structure
+theorem.  It does not construct support algebras, finite-depth circuits, or an MPU standard form.
+
+## Main results
+
+* `SpinChain.blockedNeighborhood_subset_Icc_one` — a strict displacement bound gives only
+  nearest-neighbor carries.
+* `SpinChain.blockedNeighborhood_subset_Icc_one_of_sup` — the corresponding supremum criterion.
+* `SpinChain.blockedNeighborhood_subset_Icc_one_sup_add_one` — the canonical block length.
+* `SpinChain.PropagatesWithin.blocked_nearestNeighbor` — transport a bounded neighborhood to a
+  nearest-neighbor propagation bound.
+* `SpinChain.HasFinitePropagation.exists_blocked_nearestNeighbor` — every finite propagation bound
+  becomes nearest-neighbor after a positive blocking.
+* `SpinChain.IsQCA.exists_blocked_nearestNeighbor` — the same blocking preserves the QCA property.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2308.
+* Schumacher--Werner, quant-ph/0405174, Theorem 6.
+-/
+
+namespace SpinChain
+
+/-- If every original displacement has absolute value strictly smaller than the block length, then
+all carry-aware blocked displacements are nearest-neighbor displacements.
+
+The statement also covers the empty neighborhood without an additional hypothesis. -/
+lemma blockedNeighborhood_subset_Icc_one (L : ℕ) [NeZero L] (𝓝 : Finset ℤ)
+    (h𝓝 : ∀ n ∈ 𝓝, Int.natAbs n < L) :
+    blockedNeighborhood L 𝓝 ⊆ Finset.Icc (-1) 1 := by
+  intro b hb
+  rw [mem_blockedNeighborhood_iff_exists_eq] at hb
+  obtain ⟨r, s, n, hn, hrs⟩ := hb
+  have hnabs : |n| < (L : ℤ) := by
+    rw [Int.abs_eq_natAbs]
+    exact_mod_cast h𝓝 n hn
+  rw [abs_lt] at hnabs
+  rw [Finset.mem_Icc]
+  have hL : (0 : ℤ) < L := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne L)
+  have hr0 : (0 : ℤ) ≤ r := by exact_mod_cast r.zero_le
+  have hrL : (r : ℤ) < L := by exact_mod_cast r.isLt
+  have hs0 : (0 : ℤ) ≤ s := by exact_mod_cast s.zero_le
+  have hsL : (s : ℤ) < L := by exact_mod_cast s.isLt
+  constructor
+  · by_contra hb
+    have hb' : b ≤ -2 := by omega
+    have hmul : b * (L : ℤ) ≤ -2 * L :=
+      Int.mul_le_mul_of_nonneg_right hb' (le_of_lt hL)
+    omega
+  · by_contra hb
+    have hb' : 2 ≤ b := by omega
+    have hmul : 2 * (L : ℤ) ≤ b * L :=
+      Int.mul_le_mul_of_nonneg_right hb' (le_of_lt hL)
+    omega
+
+/-- A strict bound on the supremum of the absolute displacements forces the carry-aware blocked
+neighborhood to be nearest-neighbor. -/
+lemma blockedNeighborhood_subset_Icc_one_of_sup (L : ℕ) [NeZero L] (𝓝 : Finset ℤ)
+    (h𝓝 : 𝓝.sup Int.natAbs < L) :
+    blockedNeighborhood L 𝓝 ⊆ Finset.Icc (-1) 1 :=
+  blockedNeighborhood_subset_Icc_one L 𝓝 fun _ hn => lt_of_le_of_lt (Finset.le_sup hn) h𝓝
+
+/-- Blocking by one more than the largest absolute displacement canonically makes the
+carry-aware neighborhood nearest-neighbor.  For the empty neighborhood this chooses length one. -/
+lemma blockedNeighborhood_subset_Icc_one_sup_add_one (𝓝 : Finset ℤ) :
+    blockedNeighborhood (𝓝.sup Int.natAbs + 1) 𝓝 ⊆ Finset.Icc (-1) 1 := by
+  let _ : NeZero (𝓝.sup Int.natAbs + 1) := ⟨Nat.succ_ne_zero _⟩
+  exact blockedNeighborhood_subset_Icc_one_of_sup _ 𝓝 (Nat.lt_succ_self _)
+
+namespace PropagatesWithin
+
+/-- A propagation bound becomes nearest-neighbor after blocking by more than every absolute
+original displacement. -/
+lemma blocked_nearestNeighbor {d L : ℕ} [NeZero d] [NeZero L]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+    (hω : PropagatesWithin ω 𝓝) (h𝓝 : ∀ n ∈ 𝓝, Int.natAbs n < L) :
+    PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) :=
+  hω.blocked.mono (blockedNeighborhood_subset_Icc_one L 𝓝 h𝓝)
+
+end PropagatesWithin
+
+namespace HasFinitePropagation
+
+/-- Every finite forward propagation bound becomes nearest-neighbor after some positive site
+blocking.  The witness is one more than the supremum of the absolute displacements. -/
+theorem exists_blocked_nearestNeighbor {d : ℕ} [NeZero d]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : HasFinitePropagation ω) :
+    ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
+      PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) := by
+  obtain ⟨𝓝, h𝓝⟩ := hω
+  let L := 𝓝.sup Int.natAbs + 1
+  let _ : NeZero L := ⟨Nat.succ_ne_zero _⟩
+  refine ⟨L, inferInstance, Nat.zero_lt_succ _, ?_⟩
+  exact h𝓝.blocked.mono (blockedNeighborhood_subset_Icc_one_sup_add_one 𝓝)
+
+end HasFinitePropagation
+
+namespace IsQCA
+
+/-- Every one-dimensional QCA becomes a nearest-neighbor QCA after some positive site blocking.
+
+This packages propagation normalization and preservation of the QCA axioms. It does not
+construct the Schumacher--Werner support algebras or circuit, nor an MPU standard form. -/
+theorem exists_blocked_nearestNeighbor {d : ℕ} [NeZero d]
+    {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : IsQCA ω) :
+    ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
+      IsQCA (blockedAutomorphism d L ω) ∧
+        PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) := by
+  obtain ⟨L, hL, hLpos, hprop⟩ := hω.hasFinitePropagation.exists_blocked_nearestNeighbor
+  exact ⟨L, hL, hLpos, hω.blocked, hprop⟩
+
+end IsQCA
+
+end SpinChain

--- a/TNLean/QCA/NearestNeighborBlocking.lean
+++ b/TNLean/QCA/NearestNeighborBlocking.lean
@@ -21,11 +21,11 @@ theorem.  It does not construct support algebras, finite-depth circuits, or an M
   nearest-neighbor carries.
 * `SpinChain.blockedNeighborhood_subset_Icc_one_of_sup` — the corresponding supremum criterion.
 * `SpinChain.blockedNeighborhood_subset_Icc_one_sup_add_one` — the canonical block length.
-* `SpinChain.PropagatesWithin.blocked_nearestNeighbor` — transport a bounded neighborhood to a
+* `SpinChain.PropagatesWithin.blocked_nearest_neighbor` — transport a bounded neighborhood to a
   nearest-neighbor propagation bound.
-* `SpinChain.HasFinitePropagation.exists_blocked_nearestNeighbor` — every finite propagation bound
+* `SpinChain.HasFinitePropagation.exists_blocked_nearest_neighbor` — every finite propagation bound
   becomes nearest-neighbor after a positive blocking.
-* `SpinChain.IsQCA.exists_blocked_nearestNeighbor` — the same blocking preserves the QCA property.
+* `SpinChain.IsQCA.exists_blocked_nearest_neighbor` — the same blocking preserves the QCA property.
 
 ## References
 
@@ -85,7 +85,7 @@ namespace PropagatesWithin
 
 /-- A propagation bound becomes nearest-neighbor after blocking by more than every absolute
 original displacement. -/
-lemma blocked_nearestNeighbor {d L : ℕ} [NeZero d] [NeZero L]
+lemma blocked_nearest_neighbor {d L : ℕ} [NeZero d] [NeZero L]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
     (hω : PropagatesWithin ω 𝓝) (h𝓝 : ∀ n ∈ 𝓝, Int.natAbs n < L) :
     PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) :=
@@ -97,7 +97,7 @@ namespace HasFinitePropagation
 
 /-- Every finite forward propagation bound becomes nearest-neighbor after some positive site
 blocking.  The witness is one more than the supremum of the absolute displacements. -/
-theorem exists_blocked_nearestNeighbor {d : ℕ} [NeZero d]
+theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : HasFinitePropagation ω) :
     ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
@@ -116,13 +116,13 @@ namespace IsQCA
 
 This packages propagation normalization and preservation of the QCA axioms. It does not
 construct the Schumacher--Werner support algebras or circuit, nor an MPU standard form. -/
-theorem exists_blocked_nearestNeighbor {d : ℕ} [NeZero d]
+theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : IsQCA ω) :
     ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
       IsQCA (blockedAutomorphism d L ω) ∧
         PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) := by
-  obtain ⟨L, hL, hLpos, hprop⟩ := hω.hasFinitePropagation.exists_blocked_nearestNeighbor
+  obtain ⟨L, hL, hLpos, hprop⟩ := hω.hasFinitePropagation.exists_blocked_nearest_neighbor
   exact ⟨L, hL, hLpos, hω.blocked, hprop⟩
 
 end IsQCA

--- a/TNLean/QCA/NearestNeighborBlocking.lean
+++ b/TNLean/QCA/NearestNeighborBlocking.lean
@@ -100,12 +100,12 @@ blocking.  The witness is one more than the supremum of the absolute displacemen
 theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : HasFinitePropagation ω) :
-    ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
+    ∃ (L : ℕ) (_ : NeZero L),
       PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) := by
   obtain ⟨𝓝, h𝓝⟩ := hω
   let L := 𝓝.sup Int.natAbs + 1
   let _ : NeZero L := ⟨Nat.succ_ne_zero _⟩
-  refine ⟨L, inferInstance, Nat.zero_lt_succ _, ?_⟩
+  refine ⟨L, inferInstance, ?_⟩
   exact h𝓝.blocked.mono (blockedNeighborhood_subset_Icc_one_sup_add_one 𝓝)
 
 end HasFinitePropagation
@@ -119,11 +119,11 @@ construct the Schumacher--Werner support algebras or circuit, nor an MPU standar
 theorem exists_blocked_nearest_neighbor {d : ℕ} [NeZero d]
     {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
     (hω : IsQCA ω) :
-    ∃ (L : ℕ) (_ : NeZero L) (_ : 0 < L),
+    ∃ (L : ℕ) (_ : NeZero L),
       IsQCA (blockedAutomorphism d L ω) ∧
         PropagatesWithin (blockedAutomorphism d L ω) (Finset.Icc (-1) 1) := by
-  obtain ⟨L, hL, hLpos, hprop⟩ := hω.hasFinitePropagation.exists_blocked_nearest_neighbor
-  exact ⟨L, hL, hLpos, hω.blocked, hprop⟩
+  obtain ⟨L, hL, hprop⟩ := hω.hasFinitePropagation.exists_blocked_nearest_neighbor
+  exact ⟨L, hL, hω.blocked, hprop⟩
 
 end IsQCA
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10371,7 +10371,7 @@ any part of that external structure theorem beyond this change of grouping.
     \label{lem:qca_blocked_neighborhood_subset_nearest_neighbor}
     \lean{SpinChain.blockedNeighborhood_subset_Icc_one}
     \leanok
-    \uses{lem:qca_blocked_neighborhood_membership}
+    \uses{def:qca_blocked_neighborhood}
     Let $L>0$ and let $\mathcal N\subset\mathbb Z$ be finite.  If
     $|n|<L$ for every $n\in\mathcal N$, then
     \begin{align}
@@ -10396,7 +10396,7 @@ any part of that external structure theorem beyond this change of grouping.
     \label{lem:qca_blocked_neighborhood_subset_nearest_neighbor_sup}
     \lean{SpinChain.blockedNeighborhood_subset_Icc_one_of_sup}
     \leanok
-    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor}
+    \uses{def:qca_blocked_neighborhood}
     Let $L>0$ and let $\mathcal N\subset\mathbb Z$ be finite.  If
     \begin{align}
         \sup_{n\in\mathcal N}|n|&<L,
@@ -10419,7 +10419,7 @@ any part of that external structure theorem beyond this change of grouping.
     \label{lem:qca_blocked_neighborhood_canonical_nearest_neighbor}
     \lean{SpinChain.blockedNeighborhood_subset_Icc_one_sup_add_one}
     \leanok
-    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor_sup}
+    \uses{def:qca_blocked_neighborhood}
     For every finite $\mathcal N\subset\mathbb Z$, define
     \begin{align}
         L_{\mathcal N}&=1+\sup_{n\in\mathcal N}|n|.
@@ -10440,11 +10440,9 @@ any part of that external structure theorem beyond this change of grouping.
 
 \begin{lemma}[Nearest-neighbor propagation after a bounded blocking]
     \label{lem:qca_propagates_within_blocked_nearest_neighbor}
-    \lean{SpinChain.PropagatesWithin.blocked_nearestNeighbor}
+    \lean{SpinChain.PropagatesWithin.blocked_nearest_neighbor}
     \leanok
-    \uses{lem:qca_propagates_within_blocked,
-        lem:qca_blocked_neighborhood_subset_nearest_neighbor,
-        lem:qca_propagation_neighborhood_mono}
+    \uses{def:qca_propagates_within, def:qca_blocked_automorphism}
     Let $d,L>0$.  Suppose that $\omega$ propagates within the finite
     neighborhood $\mathcal N$ and that $|n|<L$ for every $n\in\mathcal N$.
     For every finite blocked region $\Lambda$ and every observable
@@ -10467,11 +10465,10 @@ any part of that external structure theorem beyond this change of grouping.
 
 \begin{theorem}[Finite propagation becomes nearest-neighbor]
     \label{thm:qca_finite_propagation_exists_blocked_nearest_neighbor}
-    \lean{SpinChain.HasFinitePropagation.exists_blocked_nearestNeighbor}
+    \lean{SpinChain.HasFinitePropagation.exists_blocked_nearest_neighbor}
     \leanok
-    \uses{lem:qca_propagates_within_blocked,
-        lem:qca_blocked_neighborhood_canonical_nearest_neighbor,
-        lem:qca_propagation_neighborhood_mono}
+    \uses{def:qca_finite_propagation, def:qca_propagates_within,
+        def:qca_blocked_automorphism}
     Let $d>0$.  If $\omega$ has finite forward propagation, then there exists
     a positive integer $L$ such that, for every finite blocked region
     $\Lambda$ and every observable $X\in\mathcal A^{(d^L)}$ supported in
@@ -10494,10 +10491,10 @@ any part of that external structure theorem beyond this change of grouping.
 
 \begin{theorem}[A QCA becomes nearest-neighbor after blocking]
     \label{thm:qca_exists_blocked_nearest_neighbor}
-    \lean{SpinChain.IsQCA.exists_blocked_nearestNeighbor}
+    \lean{SpinChain.IsQCA.exists_blocked_nearest_neighbor}
     \leanok
-    \uses{lem:qca_blocked,
-        thm:qca_finite_propagation_exists_blocked_nearest_neighbor}
+    \uses{def:qca, def:qca_blocked_automorphism,
+        def:qca_propagates_within}
     Let $d>0$ and let $\omega$ be a one-dimensional QCA on
     $\mathcal A^{(d)}$.  There exists a positive integer $L$ such that
     $\omega^{[L]}$ is a QCA on $\mathcal A^{(d^L)}$ and, for every finite

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10360,6 +10360,164 @@ the converse theorem.
     Lemma~\ref{lem:qca_translation_covariant_blocked}, respectively.
 \end{proof}
 
+Line~2308 of \cite{Cirac2017MPU} invokes the external
+Schumacher--Werner structure theorem to obtain support algebras, a depth-two
+nearest-neighbor circuit, and an MPU in standard form.  The next statements
+establish only the elementary normalization of a finite propagation
+neighborhood to $[-1,1]\cap\mathbb Z$ by regrouping sites.  They do not prove
+any part of that external structure theorem beyond this change of grouping.
+
+\begin{lemma}[Nearest-neighbor carries from a strict displacement bound]
+    \label{lem:qca_blocked_neighborhood_subset_nearest_neighbor}
+    \lean{SpinChain.blockedNeighborhood_subset_Icc_one}
+    \leanok
+    \uses{lem:qca_blocked_neighborhood_membership}
+    Let $L>0$ and let $\mathcal N\subset\mathbb Z$ be finite.  If
+    $|n|<L$ for every $n\in\mathcal N$, then
+    \begin{align}
+        \mathcal C_L(\mathcal N)&\subseteq[-1,1]\cap\mathbb Z.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_neighborhood_membership}
+    If $\mathcal N=\varnothing$, membership in
+    $\mathcal C_L(\mathcal N)$ is impossible.  In general, a point
+    $b\in\mathcal C_L(\mathcal N)$ supplies residues $0\leq r,s<L$ and
+    $n\in\mathcal N$ such that
+    \begin{align}
+        r+n&=bL+s.
+    \end{align}
+    Since $-L<n<L$, the equality is incompatible with $b\leq-2$ and with
+    $b\geq2$.  Thus $-1\leq b\leq1$, including for negative displacements.
+\end{proof}
+
+\begin{lemma}[Supremum criterion for nearest-neighbor carries]
+    \label{lem:qca_blocked_neighborhood_subset_nearest_neighbor_sup}
+    \lean{SpinChain.blockedNeighborhood_subset_Icc_one_of_sup}
+    \leanok
+    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor}
+    Let $L>0$ and let $\mathcal N\subset\mathbb Z$ be finite.  If
+    \begin{align}
+        \sup_{n\in\mathcal N}|n|&<L,
+    \end{align}
+    then
+    \begin{align}
+        \mathcal C_L(\mathcal N)&\subseteq[-1,1]\cap\mathbb Z.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor}
+    Every $|n|$ is bounded above by the finite supremum, so the strict
+    supremum bound supplies the pointwise hypothesis.  When
+    $\mathcal N=\varnothing$, the supremum is $0$ and the conclusion is
+    vacuous.
+\end{proof}
+
+\begin{lemma}[Canonical nearest-neighbor block length]
+    \label{lem:qca_blocked_neighborhood_canonical_nearest_neighbor}
+    \lean{SpinChain.blockedNeighborhood_subset_Icc_one_sup_add_one}
+    \leanok
+    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor_sup}
+    For every finite $\mathcal N\subset\mathbb Z$, define
+    \begin{align}
+        L_{\mathcal N}&=1+\sup_{n\in\mathcal N}|n|.
+    \end{align}
+    Then $L_{\mathcal N}>0$ and
+    \begin{align}
+        \mathcal C_{L_{\mathcal N}}(\mathcal N)
+        &\subseteq[-1,1]\cap\mathbb Z.
+    \end{align}
+    With the finite-supremum convention, $L_{\varnothing}=1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked_neighborhood_subset_nearest_neighbor_sup}
+    The finite supremum is strictly smaller than its successor, which is
+    positive even when $\mathcal N$ is empty.
+\end{proof}
+
+\begin{lemma}[Nearest-neighbor propagation after a bounded blocking]
+    \label{lem:qca_propagates_within_blocked_nearest_neighbor}
+    \lean{SpinChain.PropagatesWithin.blocked_nearestNeighbor}
+    \leanok
+    \uses{lem:qca_propagates_within_blocked,
+        lem:qca_blocked_neighborhood_subset_nearest_neighbor,
+        lem:qca_propagation_neighborhood_mono}
+    Let $d,L>0$.  Suppose that $\omega$ propagates within the finite
+    neighborhood $\mathcal N$ and that $|n|<L$ for every $n\in\mathcal N$.
+    For every finite blocked region $\Lambda$ and every observable
+    $X\in\mathcal A^{(d^L)}$ supported in $\Lambda$, the observable
+    $\omega^{[L]}(X)$ is supported in
+    \begin{align}
+        \Lambda+([-1,1]\cap\mathbb Z).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_propagates_within_blocked,
+        lem:qca_blocked_neighborhood_subset_nearest_neighbor,
+        lem:qca_propagation_neighborhood_mono}
+    Blocking first gives propagation within $\mathcal C_L(\mathcal N)$.
+    The carry bound places this neighborhood inside
+    $[-1,1]\cap\mathbb Z$, and enlargement of propagation neighborhoods gives
+    the claim.
+\end{proof}
+
+\begin{theorem}[Finite propagation becomes nearest-neighbor]
+    \label{thm:qca_finite_propagation_exists_blocked_nearest_neighbor}
+    \lean{SpinChain.HasFinitePropagation.exists_blocked_nearestNeighbor}
+    \leanok
+    \uses{lem:qca_propagates_within_blocked,
+        lem:qca_blocked_neighborhood_canonical_nearest_neighbor,
+        lem:qca_propagation_neighborhood_mono}
+    Let $d>0$.  If $\omega$ has finite forward propagation, then there exists
+    a positive integer $L$ such that, for every finite blocked region
+    $\Lambda$ and every observable $X\in\mathcal A^{(d^L)}$ supported in
+    $\Lambda$, the observable $\omega^{[L]}(X)$ is supported in
+    \begin{align}
+        \Lambda+([-1,1]\cap\mathbb Z).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_propagates_within_blocked,
+        lem:qca_blocked_neighborhood_canonical_nearest_neighbor,
+        lem:qca_propagation_neighborhood_mono}
+    Choose a finite propagation neighborhood $\mathcal N$ and take
+    $L=1+\sup_{n\in\mathcal N}|n|$.  This $L$ is positive, including when
+    $\mathcal N$ is empty.  Blocking gives propagation within
+    $\mathcal C_L(\mathcal N)$; the canonical carry inclusion and propagation
+    monotonicity then give the nearest-neighbor bound.
+\end{proof}
+
+\begin{theorem}[A QCA becomes nearest-neighbor after blocking]
+    \label{thm:qca_exists_blocked_nearest_neighbor}
+    \lean{SpinChain.IsQCA.exists_blocked_nearestNeighbor}
+    \leanok
+    \uses{lem:qca_blocked,
+        thm:qca_finite_propagation_exists_blocked_nearest_neighbor}
+    Let $d>0$ and let $\omega$ be a one-dimensional QCA on
+    $\mathcal A^{(d)}$.  There exists a positive integer $L$ such that
+    $\omega^{[L]}$ is a QCA on $\mathcal A^{(d^L)}$ and, for every finite
+    blocked region $\Lambda$ and every observable
+    $X\in\mathcal A^{(d^L)}$ supported in $\Lambda$, the observable
+    $\omega^{[L]}(X)$ is supported in
+    \begin{align}
+        \Lambda+([-1,1]\cap\mathbb Z).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_blocked,
+        thm:qca_finite_propagation_exists_blocked_nearest_neighbor}
+    Apply the preceding theorem to the finite propagation of $\omega$, using
+    the canonical positive block length.  At the same length, site blocking
+    preserves both finite propagation and translation covariance, hence the
+    QCA property.
+\end{proof}
+
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
 local action associated with an MPU by eventual finite-chain conjugation.  In
 lines~2300--2306, eventual constancy is used to obtain a norm-preserving


### PR DESCRIPTION
### Motivation

- Cirac--Pérez-García--Schuch--Verstraete invoke nearest-neighbor form only after blocking a finite number of sites.
- This closes the elementary propagation-normalization step in #6993 without claiming the external support-algebra or Margolus theorem.
- Source: `Papers/1703.09188/paper_v2.tex`, Appendix, lines 2298--2308; the source says “after blocking a finite number of sites.”

### Description

- Prove that a carry-aware blocked neighborhood lies in \([-1,1]\cap\mathbb Z\) when every original displacement has absolute value below the block length.
- Give supremum-based and canonical \(L=\sup |n|+1\) forms, including the empty-neighborhood case \(L=1\).
- Transport fixed and existential finite propagation to nearest-neighbor range after blocking.
- Package a blocking length for which the blocked automorphism remains a QCA and has nearest-neighbor propagation.
- Add formula-driven Chapter 28 coverage.
- This does not construct support algebras, Margolus gates, a depth-two circuit, or an MPU standard form.

Agent-assisted: Codex (GPT-5) produced the implementation and review repairs; LionSR reviewed the change and is accountable for it.

### Testing

- `lake env lean TNLean/QCA/NearestNeighborBlocking.lean`
- `lake build TNLean.QCA.NearestNeighborBlocking TNLean.QCA`
- Generated aggregate imports checked.
- Blueprint declaration synchronization checked; web and PDF builds completed.
- `rg -n "sorry|axiom" TNLean/QCA/NearestNeighborBlocking.lean || true`

---

Closes #6993