### PR TITLE
fix(tenkz): make sugar flags last wins

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -1014,6 +1014,12 @@ policy for the shared leg; write the ports for the lone one.
 | `role=` | `species=` (the four prelude species) |
 | `\tndeclareatom` | `\tndeclare{atom}` |
 
+The flag sugars `sandwich` and `planes` obey the order of the option list.
+A bare or true spelling applies the displayed expansion. A later false
+spelling retracts fields still owned by that expansion and restores the values
+which preceded it. A direct `rows=` or `frame=` spelling becomes authoritative,
+so a subsequent false does not disturb the author's value.
+
 S4 status (2026-08-09): the registry is the existence test, so the table
 above is the sugar ledger's *target* inventory, not a claim that every row
 is spelled today. `\tnpic` is deferred — it lands with math-style sensing

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1309,14 +1309,42 @@ for false_field in closed conjugate outline; do
     exit 1
   fi
 done
-# The sugar flags: the first picture's bare sandwich populates its op
-# and bra rows (two populated atoms); the sandwich=false picture keeps
-# the default wire row; and the third picture keeps its explicit
-# rows={ket,op,bra}, whose empty ket and bra cells are populated.  Thus
-# the file holds four populated atoms and seven in all.
+picture_atom_count() {
+  awk -F'|' -v wanted="id=$1" '
+    $1 == "picture" { active = ($2 == wanted); next }
+    active && $1 == "atom" { count++ }
+    END { print count + 0 }
+  ' "$WORK/r_false_flags.tnlog"
+}
+# A false with no active sandwich preserves the author's rows, a false after
+# a true retracts the expansion, and retraction restores a field which the
+# author wrote before that true.  A direct field written after the true also
+# survives, because it has relinquished the sugar's ownership.
+[ "$(picture_atom_count k3)" -eq 3 ] &&
+  [ "$(picture_atom_count k4)" -eq 1 ] &&
+  [ "$(picture_atom_count k5)" -eq 3 ] &&
+  [ "$(picture_atom_count k6)" -eq 1 ] || {
+  echo "FAIL: sandwich=false violated last-wins field ownership" >&2
+  exit 1
+}
+# The four planes=false orderings leave no plane-frame event.  The final live
+# planes spelling is a positive control and contributes the unique such event.
+false_flag_frames=$(grep -c '^frame|.*|map=plane|' \
+  "$WORK/r_false_flags.tnlog" || true)
+[ "$false_flag_frames" -eq 1 ] &&
+  awk -F'|' '
+    $1 == "picture" { active = ($2 == "id=k11"); next }
+    active && $1 == "frame" && $0 ~ /\|map=plane\|/ { found = 1 }
+    END { exit !found }
+  ' "$WORK/r_false_flags.tnlog" || {
+  echo "FAIL: planes=false violated last-wins field ownership" >&2
+  exit 1
+}
+# The populated placeholders in the three sandwich pictures are retained;
+# every other picture holds its one authored atom.
 false_flag_pop=$(grep -c '^atom|.*|populated=' "$WORK/r_false_flags.tnlog" || true)
 false_flag_atoms=$(grep -c '^atom|' "$WORK/r_false_flags.tnlog" || true)
-[ "$false_flag_pop" -eq 4 ] && [ "$false_flag_atoms" -eq 7 ] || {
+[ "$false_flag_pop" -eq 6 ] && [ "$false_flag_atoms" -eq 17 ] || {
   echo "FAIL: a false-valued sugar flag changed the chosen rows" >&2
   exit 1
 }

--- a/tests/tenkz/kernel/regression/r_false_flags.tex
+++ b/tests/tenkz/kernel/regression/r_false_flags.tex
@@ -1,4 +1,4 @@
-% Regression: explicit false disables flags instead of enabling them.
+% Regression: sugar flags are last-wins without overriding direct fields.
 \documentclass{standalone}
 \usepackage{tenkz}
 \makeatletter
@@ -22,5 +22,38 @@
 % False also leaves an explicitly chosen row policy untouched.
 \begin{tenkz}[rows={ket,op,bra}, sandwich=false, cols=1, bonds=none]
   \tn[at=(2,1), name=C]{C}
+\end{tenkz}
+% A later false retracts an earlier sugar expansion.
+\begin{tenkz}[sandwich, sandwich=false, cols=1, bonds=none]
+  \tn[name=D]{D}
+\end{tenkz}
+% Retraction restores an explicit field that preceded the true spelling.
+\begin{tenkz}
+    [rows={ket,op,bra}, sandwich, sandwich=false, cols=1, bonds=none]
+  \tn[at=(2,1), name=E]{E}
+\end{tenkz}
+% A direct field after the expansion relinquishes the sugar's ownership.
+\begin{tenkz}[sandwich, rows={wire}, sandwich=false, cols=1, bonds=none]
+  \tn[name=F]{F}
+\end{tenkz}
+% The same three orderings hold for the two-field planes expansion.
+\begin{tenkz}[frame=circle, planes=false, rows={wire}, cols=1, bonds=none]
+  \tn[name=G]{G}
+\end{tenkz}
+\begin{tenkz}[planes, planes=false, rows={wire}, cols=1, bonds=none]
+  \tn[name=H]{H}
+\end{tenkz}
+\begin{tenkz}
+    [frame=circle, planes, planes=false, rows={wire}, cols=1, bonds=none]
+  \tn[name=I]{I}
+\end{tenkz}
+\begin{tenkz}[planes, frame=circle, planes=false, rows={wire}, cols=1,
+    bonds=none]
+  \tn[name=J]{J}
+\end{tenkz}
+% A live planes spelling is the control showing that these tests can see the
+% expansion which the false-valued cases retract.
+\begin{tenkz}[planes, rows={wire}, cols=1, bonds=none]
+  \tn[name=K]{K}
 \end{tenkz}
 \end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -358,11 +358,65 @@
 % Key trees fill one staging table; each command copies it onto its record
 % and clears it, so one tree serves every use site.
 \prop_new:N \l__tenkz_kernel_stage_prop
+\prop_new:N \l__tenkz_kernel_sugar_active_prop
+\prop_new:N \l__tenkz_kernel_sugar_saved_prop
+\tl_new:N \l__tenkz_kernel_sugar_current_tl
 
 \cs_new_protected:Npn \__tenkz_kernel_stage_put:nn #1#2
   { \prop_put:Nnn \l__tenkz_kernel_stage_prop {#1} {#2} }
 \cs_new_protected:Npn \__tenkz_kernel_stage_put:ne #1#2
   { \prop_put:Nne \l__tenkz_kernel_stage_prop {#1} {#2} }
+
+% A sugar flag owns only the fields written by its own expansion.  Its first
+% true spelling saves the preceding values; a later false restores them.  A
+% direct author spelling relinquishes that ownership and therefore survives a
+% subsequent false.
+\cs_new_protected:Npn \__tenkz_kernel_sugar_save:nn #1#2
+  {
+    \prop_get:NnN
+      \l__tenkz_kernel_stage_prop {#2} \l__tenkz_kernel_scratch_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_scratch_tl
+      {
+        \prop_put:Nnn
+          \l__tenkz_kernel_sugar_saved_prop {#1/#2} { \q_no_value }
+      }
+      {
+        \prop_put:NnV
+          \l__tenkz_kernel_sugar_saved_prop {#1/#2}
+          \l__tenkz_kernel_scratch_tl
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_sugar_restore:nn #1#2
+  {
+    \prop_get:NnN
+      \l__tenkz_kernel_sugar_saved_prop {#1/#2}
+      \l__tenkz_kernel_scratch_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_scratch_tl
+      { \prop_remove:Nn \l__tenkz_kernel_stage_prop {#2} }
+      {
+        \prop_put:NnV
+          \l__tenkz_kernel_stage_prop {#2} \l__tenkz_kernel_scratch_tl
+      }
+    \prop_remove:Nn \l__tenkz_kernel_sugar_saved_prop {#1/#2}
+  }
+\cs_new_protected:Npn \__tenkz_kernel_sugar_abandon:nn #1#2
+  {
+    \tl_if_eq:NnF \l__tenkz_kernel_sugar_current_tl {#1}
+      {
+        \prop_remove:Nn \l__tenkz_kernel_sugar_active_prop {#1}
+        \clist_map_inline:nn {#2}
+          {
+            \prop_remove:Nn
+              \l__tenkz_kernel_sugar_saved_prop {#1/##1}
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_sugar_clear:
+  {
+    \prop_clear:N \l__tenkz_kernel_sugar_active_prop
+    \prop_clear:N \l__tenkz_kernel_sugar_saved_prop
+    \tl_clear:N \l__tenkz_kernel_sugar_current_tl
+  }
 
 % The contract writes cell addresses unbraced (`at=(1,2)` and
 % `at=(1,2,3)`).  A keyval comma splitter would tear them, so every option
@@ -1215,7 +1269,14 @@
 % ---------- picture keys -------------------------------------------------------
 % "Picture options declare topology and policy; they create no hidden atoms."
 
-\__tenkz_kernel_value:nnn   { tenkz-kernel-picture } { rows } { rows }
+\keys_define:nn { tenkz-kernel-picture }
+  {
+    rows .code:n =
+      {
+        \__tenkz_kernel_sugar_abandon:nn {sandwich} {rows}
+        \__tenkz_kernel_stage_put:nn {rows} {#1}
+      }
+  }
 % cols= carries the row's stated type: an illegal value refuses with the
 % picture-scope positive-integer diagnostic instead of a bare TeX
 % arithmetic error (#6198 sweep).
@@ -1224,7 +1285,11 @@
   { kernel-picture-positive } { \msg_error:nnee } { }
 \keys_define:nn {tenkz-kernel-picture}
   {
-    frame .code:n = { \__tenkz_kernel_frame:n {#1} }
+    frame .code:n =
+      {
+        \__tenkz_kernel_sugar_abandon:nn {planes} {frame,basis}
+        \__tenkz_kernel_frame:n {#1}
+      }
   }
 \__tenkz_kernel_side:nn { tenkz-kernel-picture } { west }
 \__tenkz_kernel_side:nn { tenkz-kernel-picture } { east }
@@ -1251,18 +1316,37 @@
 \__tenkz_kernel_value:nnn   { tenkz-kernel-picture } { check } { check }
 \__tenkz_kernel_unknown:nn  { tenkz-kernel-picture } { picture }
 
-% A flag-shaped sugar key carries flag semantics (#6198 sweep): true or
-% the bare spelling expands, false expands nothing, and any other value
-% refuses instead of silently behaving as true.
-\cs_new_protected:Npn \__tenkz_kernel_sugar_flag:nnn #1#2#3
+% A flag-shaped sugar key carries last-wins flag semantics (#6198 sweep):
+% true or the bare spelling expands, a later false retracts that expansion,
+% and any other value refuses instead of silently behaving as true.
+\cs_new_protected:Npn \__tenkz_kernel_sugar_flag:nnnn #1#2#3#4
   {
     \str_case:nnF {#2}
       {
-        {true}  {#3}
-        % A false-valued sugar flag is still the sugar spelling, so strict
-        % mode refuses it like the bare word, but it stages no fields.
+        {true}
+          {
+            \__tenkz_kernel_sugar:n {#1}
+            \prop_if_in:NnF \l__tenkz_kernel_sugar_active_prop {#1}
+              {
+                \clist_map_inline:nn {#3}
+                  { \__tenkz_kernel_sugar_save:nn {#1} {##1} }
+                \prop_put:Nnn
+                  \l__tenkz_kernel_sugar_active_prop {#1} {true}
+              }
+            \tl_set:Nn \l__tenkz_kernel_sugar_current_tl {#1}
+            #4
+            \tl_clear:N \l__tenkz_kernel_sugar_current_tl
+          }
         {false}
-          { \__tenkz_kernel_sugar:n {#1} }
+          {
+            \__tenkz_kernel_sugar:n {#1}
+            \prop_if_in:NnT \l__tenkz_kernel_sugar_active_prop {#1}
+              {
+                \clist_map_inline:nn {#3}
+                  { \__tenkz_kernel_sugar_restore:nn {#1} {##1} }
+                \prop_remove:Nn \l__tenkz_kernel_sugar_active_prop {#1}
+              }
+          }
       }
       {
         \msg_error:nneeee {tenkz}{kernel-choice}
@@ -1275,9 +1359,8 @@
   {
     sandwich .code:n =
       {
-        \__tenkz_kernel_sugar_flag:nnn {sandwich} {#1}
+        \__tenkz_kernel_sugar_flag:nnnn {sandwich} {#1} {rows}
           {
-            \__tenkz_kernel_sugar:n {sandwich}
             \keys_set:nn {tenkz-kernel-picture} {rows={ket,op,bra}}
           }
       },
@@ -1288,9 +1371,8 @@
     surface .code:n  = { \__tenkz_kernel_desugar_surface:n {#1} },
     planes .code:n =
       {
-        \__tenkz_kernel_sugar_flag:nnn {planes} {#1}
+        \__tenkz_kernel_sugar_flag:nnnn {planes} {#1} {frame,basis}
           {
-            \__tenkz_kernel_sugar:n {planes}
             \keys_set:nn {tenkz-kernel-picture}
               {frame={plane,basis={ket~at~(0,0),bra~at~(2,2)}}}
           }
@@ -21220,6 +21302,7 @@
     \prop_clear:N \l__tenkz_kernel_basis_east_prop
     \prop_clear:N \l__tenkz_kernel_basis_north_prop
     \prop_clear:N \l__tenkz_kernel_stage_prop
+    \__tenkz_kernel_sugar_clear:
     \seq_clear:N \l__tenkz_kernel_stack_seq
     \int_set:Nn \l__tenkz_kernel_row_int { 1 }
     \int_set:Nn \l__tenkz_kernel_col_int { 1 }
@@ -21272,6 +21355,7 @@
     \prop_map_inline:Nn \l__tenkz_kernel_policy_prop
       { \exp_args:Ne \__tenkz_model_record_picture:n { ##1 = { \exp_not:n {##2} } } }
     \prop_clear:N \l__tenkz_kernel_stage_prop
+    \__tenkz_kernel_sugar_clear:
     % The named metric profile acts once, here, on the group-local pitch:
     % the pitch is the one base dimension, so scaling it scales every named
     % ratio while the print-size floors hold (tenkz-metric.code.tex).


### PR DESCRIPTION
Closes LionSR/tenkz#235.

## Summary

The `sandwich` and `planes` sugar flags now obey option-list order. A true spelling saves the preceding values of the fields its expansion owns; a later false restores those values. If the author writes `rows=` or `frame=` directly after the expansion, that direct spelling becomes authoritative and survives a subsequent false.

The temporary ownership state exists only while picture options are parsed and is cleared through one staging-state function. No parser layer, public spelling, or TNLOG field is added. The package version remains unchanged: `docs/tenkz/ctan/UPLOAD-CHECKLIST.md` reserves version changes for the release-preparation change.

The regression covers both flags with false alone, true followed by false, an explicit field before true, and an explicit field after true. A live `planes` case proves that the frame-event assertion can see the expansion being retracted.

## Verification

- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_corpus.sh`
- `python3 tests/tenkz/release-harness/selftest.py`
- `python3 tests/tenkz/release-harness/supervisor.py check-inventory`
- `python3 tests/tenkz/release-harness/supervisor.py run-all`
- `python3 tests/tenkz/release-harness/supervisor.py check-readiness`
- `python3 tests/tenkz/release-harness/supervisor.py pins`