### PR TITLE
ci(tenkz): make fence indentation portable

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -92,12 +92,23 @@ for sketch_row in "${sketch_rows[@]}"; do
 $sketch_row
 SKETCHROW
   awk -v heading="$heading" -v mark="$WORK/$job.fenceline" '
-    BEGIN { while (substr(heading, level + 1, 1) == "#") level++ }
+    BEGIN {
+      while (substr(heading, level + 1, 1) == "#") level++
+      for (indent = 0; indent <= 3; indent++) {
+        probe = ""
+        for (i = 0; i < indent; i++) probe = probe " "
+        probe = probe "```tex"
+        if (fencerun(probe) != 3 || fc != "`" || frest != "tex") exit 70
+      }
+      if (fencerun("    ```tex") != 0) exit 70
+    }
     # The run of fence characters opening or closing a fence on this line:
     # its length, with the character in fc and the trailing text in frest.
-    function fencerun(line,    copy, i) {
+    function fencerun(line,    copy, indent, i) {
       copy = line
-      sub(/^ {0,3}/, "", copy)
+      while (substr(copy, indent + 1, 1) == " ") indent++
+      if (indent > 3) return 0
+      copy = substr(copy, indent + 1)
       fc = substr(copy, 1, 1)
       if (fc != "`" && fc != "~") return 0
       i = 0


### PR DESCRIPTION
Closes LionSR/tenkz#216.

## Summary

The printed-example extractor no longer uses the `{0,3}` ERE interval which mawk reads literally. Its `fencerun` function now counts leading spaces with `substr`, accepts zero through three, and rejects four or more as an indented code block.

An internal boundary witness checks all four accepted indentations, the fence character and trailing `tex` text, and the rejected four-space case. The witness passes under the local BSD awk; the `ubuntu-latest` tenkz-corpus job exercises the same code under mawk. Heading recognition and the column-zero contract-fence count are intentionally unchanged for the separate LionSR/tenkz#217 follow-up.

## Verification

- `bash -n scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_kernel_probes.sh`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `python3 tests/tenkz/release-harness/supervisor.py check-inventory`
- `python3 tests/tenkz/release-harness/supervisor.py run-all`