### PR TITLE
doc(MPS/MPDO): synchronize CPSV example completion status

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1254,7 +1254,8 @@ This is the calculation in
 \end{theorem}
 
 % CPSV16 Examples 4.10--4.12, lines 897--942.
-% Tracking: issues #5984 and #6302; Example 4.10 was completed under #6301, and Example 4.12 remains under #5919.
+% Completion: corrected fixed-$p=1/4$ Example 4.10 under #6301, literal periodic
+% Example 4.11 under #6302, and literal and normalized Example 4.12 under #6038.
 % Entropy corrections: docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
 % Example 4.11's literal finite periodic family is now proved to fail both SAL
 % and source-facing ZCL. Example 4.12's normalized channel equations are proved;

--- a/docs/audits/2026-08-10-cpsv16-every-label-audit.md
+++ b/docs/audits/2026-08-10-cpsv16-every-label-audit.md
@@ -153,7 +153,7 @@ the printed statement.
 | Lemma A.5 | none since the nonzero-coefficient convention; anchor on `thm:bounded_power_sum_multiset` | `thm:bounded_power_sum_multiset` |
 | Corollary A.6 | none since the nonzero-coefficient convention; anchor on `cor:sector_bnt_proportional_unitary_sector_match` | unitary refinements in Chapter 11 |
 | Proposition C.14 | `thm:cpsv_prop_c14_printed_status` | `thm:mpdo_canonical_bnt_proportional_sectors_zcl_sal` |
-| Examples 4.10--4.12 | `thm:cpsv_examples410_412_status` | Example 4.10 is complete for the corrected fixed-$p=1/4$ witness under #6301; Example 4.11 is classified under #6302; Example 4.12 has the literal normalization obstruction, normalized channel equations, strict four-site SSA defect, and full GSNNCH exclusion complete, with the line-246 unit-weight boundary recorded |
+| Examples 4.10--4.12 | `thm:cpsv_examples410_412_status` | Example 4.10 is complete for the corrected fixed-$p=1/4$ witness under #6301; Example 4.11's printed SAL clause is refuted and its printed non-ZCL clause is verified under #6302; Example 4.12 has the literal normalization obstruction, normalized channel equations, strict four-site SSA defect, and full GSNNCH exclusion complete under #6038, with the line-246 unit-weight boundary recorded |
 | Appendix D `RFP-gauge` | `thm:cpsv_rfp_gauge_printed_status` | cube-phase obstruction plus active issue #5920 |
 | Appendix D Fibonacci periodic rank formula | `thm:cpsv_fibonacci_periodic_rank`; `thm:cpsv_fibonacci_operator_rank_not_geometric`; `thm:cpsv_fibonacci_not_strong_rfp` | complete periodic rank formula, non-geometricity, and $\lnot\,\mathrm{IsStrongRFP}$ conclusion |
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -203,9 +203,11 @@ For MPDO renormalization fixed points:
 - `cpsv16_exact_arithmetic_scope.tex` records the scope boundary of the
   certified four-site arithmetic for Examples~4.10 and~4.11. The exact integer
   comparisons and logarithmic ratios are machine-checked. For the corrected
-  fixed-$p=1/4$ Example~4.10 tensor, the reduced spectra, entropy comparison,
-  and non-SAL conclusion are also complete; the Example~4.11 source claim
-  remains tracked separately.
+  fixed-$p=1/4$ Example~4.10 tensor and the literal four-site Example~4.11
+  family, the reduced spectra, entropy comparisons, and non-SAL conclusions
+  are complete. The finite-marginal calculation for Example~4.11 independently
+  verifies the printed non-ZCL clause. The resolved scope restriction is that
+  the arithmetic statements alone do not establish these tensor conclusions.
 
 For the non-periodic MPS Fundamental Theorem background:
 

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{scope-restriction}{open}
+\gapnote{scope-restriction}{resolved}
 
 \section{Source statements and derived comparisons}
 
@@ -70,15 +70,27 @@ area-law conclusion.  For the corrected fixed-$p=1/4$ Example~4.10 tensor,
 four-site root multisets and
 \doclink{TNLean/MPS/MPDO/CPSVExample410Entropy} derives $I_2>I_1$ and the
 source-ZCL, non-SAL conclusion.  This completes \ghissue{6301} without
-asserting the universal parameter range printed in the source.  The
-corresponding Example~4.11 source claim remains under \ghissue{6302}.
+asserting the universal parameter range printed in the source.  For the
+literal Example~4.11 family at four sites,
+\doclink{TNLean/MPS/MPDO/CPSVExample411Entropy} derives $I_2>I_1$ and the
+failure of SAL, while
+\doclink{TNLean/MPS/MPDO/CPSVExample411SourceZCL} independently proves the
+failure of source ZCL from finite-marginal instability, both for the effective
+binary model and for its ambient two-qubit realization.  This completes
+\ghissue{6302}: the printed SAL clause is refuted and the printed non-ZCL
+clause is verified.  Neither conclusion follows from the arithmetic module
+alone.
 
 \section{Verdict}
 
-\textbf{Verdict: scope restriction.}  The arithmetic endpoints are certified.
-For corrected Example~4.10 at $p=1/4$, separate tensor and entropy modules now
-connect those endpoints to the formal non-SAL witness.  These project-derived
-four-site results do not formalize the printed universal-in-$p$ claim, and the
-Example~4.11 source claim remains separate.
+\textbf{Verdict: scope restriction.}  The arithmetic endpoints are certified
+and connected to the corresponding tensor statements.  For corrected
+Example~4.10 at $p=1/4$, the tensor and entropy results give source ZCL without
+SAL.  For the literal four-site Example~4.11 family, the entropy result refutes
+the printed SAL clause and the finite-marginal result verifies the independent
+non-ZCL clause.  The resolved restriction is that the arithmetic statements
+alone prove neither tensor spectra nor area-law conclusions.  These
+project-derived finite-ring results do not formalize the universal-in-$p$
+claim of Example~4.10 or any thermodynamic statement for Example~4.11.
 
 \end{document}


### PR DESCRIPTION
### Motivation

- A delayed post-merge review on PR #6973 identified status prose that still treated completed CPSV16 Example 4.11 work as open: [discussion_r3838549737](https://github.com/LionSR/TNLean/pull/6973#discussion_r3838549737).
- CPSV16 Examples 4.10–4.12 occur at lines 897–939 of `Papers/1606.00608/MPDO-22-12-17-2.tex`; their corrected or source-classifying branches are complete under #6301, #6302, and #6038.
- The paper-gap note, its index entry, the Blueprint maintenance comment, and the CPSV16 label audit should state the same present mathematical status.

### Description

- Mark `cpsv16_exact_arithmetic_scope.tex` resolved and record the completed Example 4.11 entropy, non-SAL, and independent non-ZCL conclusions.
- Synchronize `docs/paper-gaps/README.md` with that resolved scope.
- Replace stale current-tracking prose in the Chapter 21 maintenance comment by the three completed issue assignments.
- Make the Examples 4.10–4.12 row of the CPSV16 label audit state the completed classifications directly.
- Leave all mathematical statements, Lean declarations, source-faithfulness boundaries, and `\leanok`/`\notready` tags unchanged.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/audit_cpsv16_labels.py`
- `python3 scripts/test_audit_cpsv16_labels.py`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 6730/6730 entries synchronized
- two `pdflatex` passes for `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`, with no overfull boxes or undefined references
- `git diff --check origin/main...HEAD`

Addresses #7008
Addresses #5984
