### PR TITLE
ci(tenkz): recognize indented ATX headings

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -99,16 +99,33 @@ SKETCHROW
         for (i = 0; i < indent; i++) probe = probe " "
         probe = probe "```tex"
         if (fencerun(probe) != 3 || fc != "`" || frest != "tex") exit 70
+        if (atxlevel(substr(probe, 1, indent) "## Section") != 2) exit 71
       }
       if (fencerun("    ```tex") != 0) exit 70
+      if (atxlevel("    ## Section") != 0 ||
+          atxlevel("####### Section") != 0 ||
+          atxlevel("##Section") != 0 ||
+          atxlevel("#6235") != 0 || atxlevel("###") != 3) exit 71
+    }
+    # Markdown gives fences and ATX headings the same indentation allowance.
+    function markdownline(line,    indent) {
+      while (substr(line, indent + 1, 1) == " ") indent++
+      if (indent > 3) return ""
+      return substr(line, indent + 1)
+    }
+    # The level of an ATX heading, or zero when the line is not one.
+    function atxlevel(line,    copy, h, separator) {
+      copy = markdownline(line)
+      while (substr(copy, h + 1, 1) == "#") h++
+      if (h == 0 || h > 6) return 0
+      separator = substr(copy, h + 1, 1)
+      if (separator != "" && separator != " ") return 0
+      return h
     }
     # The run of fence characters opening or closing a fence on this line:
     # its length, with the character in fc and the trailing text in frest.
-    function fencerun(line,    copy, indent, i) {
-      copy = line
-      while (substr(copy, indent + 1, 1) == " ") indent++
-      if (indent > 3) return 0
-      copy = substr(copy, indent + 1)
+    function fencerun(line,    copy, i) {
+      copy = markdownline(line)
       fc = substr(copy, 1, 1)
       if (fc != "`" && fc != "~") return 0
       i = 0
@@ -130,10 +147,9 @@ SKETCHROW
         next
       }
       if (!s && index($0, heading) == 1) { s = 1; next }
-      if (s && !f && substr($0, 1, 1) == "#") {
-        h = 0
-        while (substr($0, h + 1, 1) == "#") h++
-        if (h <= level && substr($0, h + 1, 1) == " ") exit
+      if (s && !f) {
+        h = atxlevel($0)
+        if (h != 0 && h <= level) exit
       }
       n = fencerun($0)
       if (n >= 3) {

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -105,6 +105,7 @@ SKETCHROW
       if (atxlevel("    ## Section") != 0 ||
           atxlevel("####### Section") != 0 ||
           atxlevel("##Section") != 0 ||
+          atxlevel("##\tSection") != 2 ||
           atxlevel("#6235") != 0 || atxlevel("###") != 3) exit 71
     }
     # Markdown gives fences and ATX headings the same indentation allowance.
@@ -119,7 +120,7 @@ SKETCHROW
       while (substr(copy, h + 1, 1) == "#") h++
       if (h == 0 || h > 6) return 0
       separator = substr(copy, h + 1, 1)
-      if (separator != "" && separator != " ") return 0
+      if (separator != "" && separator != " " && separator != "\t") return 0
       return h
     }
     # The run of fence characters opening or closing a fence on this line:

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -81,8 +81,9 @@ ${#sketch_rows[@]}" >&2
 # also marks the line of the fence it consumed, and the marks are compared
 # after the loop: the count guard and pairwise-distinct marks together force
 # a bijection between the contract's fences and this table's rows.  A
-# heading is a hash run followed by a space, so a reference such as #6235
-# at the head of a prose line stops nothing; fences are tracked by their
+# heading has up to three leading spaces, one to six hashes, and then a space,
+# tab, or line end.  Thus a reference such as #6235 stops nothing; fences are
+# tracked by their
 # own delimiter — character and length, closing on a run at least as long,
 # as Markdown reads them — so a heading-shaped or backtick line inside any
 # fenced block neither arms nor stops a scan.


### PR DESCRIPTION
### Motivation

- The printed-example extractor stopped only at ATX headings beginning in column zero, although the language contract is Markdown and permits up to three leading spaces.
- A missing example could therefore bind a later fence across an indented same-or-higher heading. This closes the gap described in LionSR/tenkz#217.

### Description

- Add one portable `markdownline` helper for the shared zero-to-three-space indentation rule used by fences and headings.
- Add `atxlevel` to recognize one-to-six hashes followed by a space, a tab, or the end of the line.
- Stop a row scan when such a heading has level no greater than the row heading.
- Pin the boundary cases in the existing AWK startup witnesses: zero through three spaces, four spaces, seven hashes, a missing separator, `#6235`, and an empty heading body.

Only `scripts/tenkz_kernel_probes.sh` changes. The contract document and all generated records and pixels remain unchanged.

### Testing

- `bash -n scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_kernel_probes.sh`
  - 8 printed examples compile and audit; 7 match fixtures verbatim
  - 163 review regressions
  - 11 sugar equivalences
  - 14 pinned record streams
  - kernel pixels unchanged
- `python3 scripts/tenkz_shrink.py gate`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 tests/tenkz/release-harness/selftest.py`
- `python3 tests/tenkz/release-harness/supervisor.py check-inventory`
- `python3 tests/tenkz/release-harness/supervisor.py run-all`

Watched failure: the section 9 fence was removed temporarily, `## 10. Tombstones` was indented by two spaces, and an equal replacement fence was placed beneath that later heading. The fence count remained eight, while the hardened gate failed at the section 9 row with the existing “could not be extracted” message. The mutation was then reverted, and the clean contract passed the full gate.

Closes LionSR/tenkz#217