### PR TITLE
feat(MPS/MPDO): bound the non-Cartesian normalizing coefficient

### DIFF
--- a/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
+++ b/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
@@ -25,6 +25,192 @@ namespace MPOTensor.NonCartesianActiveSectorCandidate
 
 /-! ### Normal representative before scalar absorption -/
 
+/-! #### An exact upper bound for the normalizing coefficient -/
+
+/-- A positive test matrix used to bound the Perron eigenvalue of the
+candidate's associated completely positive map.
+
+This is a counterexample-specific helper for the coefficient normalization
+`|μ_k| ≤ 1` in arXiv:1606.00608, line 246, not a theorem asserted in the
+source. -/
+private def normalizingCoefficientWitness : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![20, 0; 0, 1]
+
+/-- The exact value of the candidate's adjoint transfer map on the test
+matrix. -/
+private lemma adjointMap_normalizingCoefficientWitness :
+    Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness =
+      !![75 / 8, 9 / 40; 9 / 40, 303 / 5000] := by
+  have hletter (p q : Fin 4) :
+      tensor.toMPSTensor (finProdFinEquiv (p, q)) =
+        if p = q then sectorMatrix p else 0 := by
+    change tensor (finProdFinEquiv (p, q)).divNat
+        (finProdFinEquiv (p, q)).modNat = _
+    rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+    rfl
+  have hadj :
+      Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness =
+        ∑ k : Fin 4,
+          (sectorMatrix k)ᴴ * normalizingCoefficientWitness * sectorMatrix k := by
+    rw [Kraus.adjointMap_apply]
+    rw [← Equiv.sum_comp (finProdFinEquiv : Fin 4 × Fin 4 ≃ Fin (4 * 4))]
+    rw [Fintype.sum_prod_type]
+    simp_rw [hletter]
+    simp [Fin.sum_univ_four]
+  rw [hadj]
+  ext i j
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Fin.sum_univ_two,
+    Matrix.conjTranspose_apply]
+  fin_cases i <;> fin_cases j
+  all_goals
+    simp only [normalizingCoefficientWitness, sectorMatrix, leftPairing,
+      rightPairing, Fin.sum_univ_four, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.cons_val_two, Matrix.cons_val_three, Matrix.of_apply,
+      Matrix.vecMulVec]
+    norm_num [Matrix.star_apply]
+
+private def normalizingCoefficientGapFactor : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![1, -9 / 425; 0, 1]
+
+private def normalizingCoefficientGapDiagonal :
+    Matrix (Fin 2) (Fin 2) ℂ :=
+  Matrix.diagonal ![85 / 8, 19861 / 21250]
+
+/-- The exact positive-definite gap between the test matrix and its adjoint
+transfer image.
+
+Its `Uᴴ D U` factorization has diagonal entries `85 / 8` and
+`19861 / 21250`, hence determinant `19861 / 2000`. -/
+private lemma normalizingCoefficientWitness_sub_adjointMap_posDef :
+    (normalizingCoefficientWitness -
+      Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness).PosDef := by
+  have hFactorization :
+      normalizingCoefficientWitness -
+          Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness =
+        normalizingCoefficientGapFactorᴴ * normalizingCoefficientGapDiagonal *
+          normalizingCoefficientGapFactor := by
+    rw [adjointMap_normalizingCoefficientWitness]
+    ext i j
+    fin_cases i <;> fin_cases j
+    all_goals
+      simp only [normalizingCoefficientWitness, normalizingCoefficientGapFactor,
+        normalizingCoefficientGapDiagonal, Matrix.mul_apply,
+        Fin.sum_univ_two, Matrix.conjTranspose_apply]
+      norm_num
+  rw [hFactorization]
+  have hDiagonal : normalizingCoefficientGapDiagonal.PosDef := by
+    apply Matrix.PosDef.diagonal
+    intro i
+    fin_cases i <;> norm_num [normalizingCoefficientGapDiagonal]
+  apply hDiagonal.conjTranspose_mul_mul_same
+  intro x y hxy
+  have h1 : x 1 = y 1 := by
+    have := congrFun hxy (1 : Fin 2)
+    simpa [normalizingCoefficientGapFactor, Matrix.mulVec, dotProduct,
+      Fin.sum_univ_two] using this
+  funext i
+  fin_cases i
+  · have h0 := congrFun hxy (0 : Fin 2)
+    simp only [Matrix.mulVec, dotProduct, normalizingCoefficientGapFactor,
+      Fin.isValue, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_fin_one, Matrix.cons_val_zero, Fin.sum_univ_two,
+      one_mul, Matrix.cons_val_one] at h0
+    rw [h1] at h0
+    simpa using h0
+  · exact h1
+
+/-- The positive test matrix is positive definite. -/
+private lemma normalizingCoefficientWitness_posDef :
+    normalizingCoefficientWitness.PosDef := by
+  rw [show normalizingCoefficientWitness = Matrix.diagonal ![(20 : ℂ), 1] by
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      norm_num [normalizingCoefficientWitness]]
+  apply Matrix.PosDef.diagonal
+  intro i
+  fin_cases i <;> norm_num
+
+/-- A positive-definite eigenmatrix of the candidate's associated completely
+positive map has eigenvalue at most one.
+
+This is the one-sector estimate needed for the coefficient bound in
+arXiv:1606.00608, line 246. It is a counterexample helper, not the source
+theorem: the source additionally normalizes an ambient simple biCF tensor so
+that one of all its sector coefficients has modulus one. -/
+lemma transferMap_posDef_eigenvalue_le_one
+    {rho : Matrix (Fin 2) (Fin 2) ℂ} {r : ℝ}
+    (hrho : rho.PosDef)
+    (hEig : Kraus.transferMap tensor.toMPSTensor rho = (r : ℂ) • rho) :
+    r ≤ 1 := by
+  have htraceNonneg :
+      0 ≤ Matrix.trace (normalizingCoefficientWitness * rho) :=
+    Matrix.PosSemidef.trace_mul_nonneg
+      normalizingCoefficientWitness_posDef.posSemidef hrho.posSemidef
+  have htraceNe :
+      Matrix.trace (normalizingCoefficientWitness * rho) ≠ 0 := by
+    intro hzero
+    exact (Matrix.PosDef.isUnit hrho).ne_zero
+      (Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
+        hrho.posSemidef normalizingCoefficientWitness_posDef hzero)
+  have htracePos :
+      0 < Matrix.trace (normalizingCoefficientWitness * rho) :=
+    lt_of_le_of_ne htraceNonneg
+      (by simpa only [ne_eq, eq_comm] using htraceNe)
+  have hgapNonneg :
+      0 ≤ Matrix.trace
+        ((normalizingCoefficientWitness -
+          Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness) *
+            rho) :=
+    Matrix.PosSemidef.trace_mul_nonneg
+      normalizingCoefficientWitness_sub_adjointMap_posDef.posSemidef
+      hrho.posSemidef
+  have hEigMap :
+      Kraus.map tensor.toMPSTensor rho = (r : ℂ) • rho := by
+    rw [← Kraus.mapLM_apply, Kraus.mapLM_eq_transferMap]
+    exact hEig
+  have hgapTrace :
+      Matrix.trace
+          ((normalizingCoefficientWitness -
+            Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness) *
+              rho) =
+        (((1 - r : ℝ) : ℂ) *
+          Matrix.trace (normalizingCoefficientWitness * rho)) := by
+    calc
+      Matrix.trace
+          ((normalizingCoefficientWitness -
+            Kraus.adjointMap tensor.toMPSTensor normalizingCoefficientWitness) *
+              rho) =
+          Matrix.trace (normalizingCoefficientWitness * rho) -
+            Matrix.trace
+              (Kraus.adjointMap tensor.toMPSTensor
+                normalizingCoefficientWitness * rho) := by
+              rw [Matrix.sub_mul, Matrix.trace_sub]
+      _ = Matrix.trace (normalizingCoefficientWitness * rho) -
+            Matrix.trace
+              (normalizingCoefficientWitness *
+                Kraus.map tensor.toMPSTensor rho) := by
+              rw [Kraus.trace_mul_map_eq_trace_adjointMap_mul]
+      _ = Matrix.trace (normalizingCoefficientWitness * rho) -
+            Matrix.trace
+              (normalizingCoefficientWitness * ((r : ℂ) • rho)) := by
+              rw [hEigMap]
+      _ = (((1 - r : ℝ) : ℂ) *
+            Matrix.trace (normalizingCoefficientWitness * rho)) := by
+              rw [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul]
+              push_cast
+              ring
+  rw [hgapTrace] at hgapNonneg
+  have hrealNonneg :
+      0 ≤ (1 - r) *
+        (Matrix.trace (normalizingCoefficientWitness * rho)).re := by
+    simpa only [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im,
+      zero_mul, sub_zero] using (Complex.nonneg_iff.mp hgapNonneg).1
+  have htraceRealPos :
+      0 < (Matrix.trace (normalizingCoefficientWitness * rho)).re :=
+    (Complex.pos_iff.mp htracePos).1
+  nlinarith
+
 /-- The associated MPS tensor has a nonzero letter. -/
 lemma exists_toMPSTensor_apply_ne_zero :
     ∃ i, tensor.toMPSTensor i ≠ 0 := by
@@ -38,14 +224,19 @@ lemma exists_toMPSTensor_apply_ne_zero :
 /-- The candidate is a nonzero scalar multiple of a CPSV normal tensor.
 
 The scalar is the positive square root of the Perron value of the unnormalized
-transfer map.  Algebraic one-site injectivity supplies primitivity; after the
-scalar normalization, a Perron gauge gives a left-canonical representative,
-and normal-tensor status is transported back through that gauge.
+completely positive map. Algebraic one-site injectivity supplies primitivity;
+after the scalar normalization, a Perron gauge gives a left-canonical
+representative, and normal-tensor status is transported back through that
+gauge. The exact test-matrix estimate above gives the one-sector bound
+`|μ| ≤ 1`.
 
-Source: arXiv:1606.00608, lines 224--235. -/
+This is a counterexample helper for arXiv:1606.00608, lines 224--246.  It does
+not establish the source's ambient convention that at least one coefficient
+among all simple-biCF sectors has modulus one. -/
 theorem exists_normalTensor_scalar_representation :
     ∃ (A : MPOTensor 4 2) (mu : ℂ),
-      mu ≠ 0 ∧ tensor = mu • A ∧ A.toMPSTensor.IsNormalTensor := by
+      mu ≠ 0 ∧ ‖mu‖ ≤ 1 ∧ tensor = mu • A ∧
+        A.toMPSTensor.IsNormalTensor := by
   let _ : NeZero 2 := ⟨by omega⟩
   have hNormal : Kraus.IsNormal tensor.toMPSTensor :=
     Kraus.IsInjective.isNormal tensor_isInjective
@@ -56,9 +247,14 @@ theorem exists_normalTensor_scalar_representation :
   obtain ⟨rho, r, hrho, hr, hEig⟩ :=
     MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible tensor.toMPSTensor
       hIrr exists_toMPSTensor_apply_ne_zero
+  have hr_le_one : r ≤ 1 :=
+    transferMap_posDef_eigenvalue_le_one hrho hEig
   let mu : ℂ := ((Real.sqrt r : ℝ) : ℂ)
   have hmu : mu ≠ 0 :=
     Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr hr).ne'
+  have hmu_norm : ‖mu‖ ≤ 1 := by
+    simpa [mu, Complex.norm_real, abs_of_nonneg (Real.sqrt_nonneg r)] using
+      (Real.sqrt_le_one.mpr hr_le_one)
   let A : MPOTensor 4 2 := mu⁻¹ • tensor
   have hrecover : tensor = mu • A := by
     ext i j beta alpha
@@ -110,7 +306,7 @@ theorem exists_normalTensor_scalar_representation :
     MPSTensor.isNormalTensor_of_isNormal_leftCanonical _ hGaugeNormal hLeft
   have hANormalTensor : A.toMPSTensor.IsNormalTensor :=
     hGaugeNormalTensor.of_gaugeEquiv hGauge
-  exact ⟨A, mu, hmu, hrecover, hANormalTensor⟩
+  exact ⟨A, mu, hmu, hmu_norm, hrecover, hANormalTensor⟩
 
 /-- Counterexample to the low-level implication asserting that injectivity,
 SAL, literal physical-trace idempotence, and being a nonzero scalar multiple
@@ -128,7 +324,7 @@ theorem full_lowLevel_counterexample :
       physTraceTransfer K * physTraceTransfer K = physTraceTransfer K ∧
       (¬∃ F : PhysicalSectorFactorization K,
         Nonempty F.NeighboringTraceFactorization) := by
-  obtain ⟨A, mu, hmu, hrecover, hNormal⟩ :=
+  obtain ⟨A, mu, hmu, _, hrecover, hNormal⟩ :=
     exists_normalTensor_scalar_representation
   exact ⟨tensor, A, mu, hmu, hrecover, hNormal, tensor_isInjective,
     tensor_isSAL, physTraceTransfer_tensor_idempotent,

--- a/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
+++ b/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
@@ -70,9 +70,13 @@ private lemma adjointMap_normalizingCoefficientWitness :
       Matrix.vecMulVec]
     norm_num [Matrix.star_apply]
 
+/-- The upper-triangular factor in the exact congruence certificate for the
+positive-definite adjoint-transfer gap. -/
 private def normalizingCoefficientGapFactor : Matrix (Fin 2) (Fin 2) ℂ :=
   !![1, -9 / 425; 0, 1]
 
+/-- The positive diagonal factor in the exact congruence certificate for the
+adjoint-transfer gap. -/
 private def normalizingCoefficientGapDiagonal :
     Matrix (Fin 2) (Fin 2) ℂ :=
   Matrix.diagonal ![85 / 8, 19861 / 21250]
@@ -310,7 +314,8 @@ theorem exists_normalTensor_scalar_representation :
 
 /-- Counterexample to the low-level implication asserting that injectivity,
 SAL, literal physical-trace idempotence, and being a nonzero scalar multiple
-of a normal tensor yield a neighboring trace factorization.
+of a normal tensor with coefficient norm at most one yield a neighboring trace
+factorization.
 
 This theorem does not package the ambient simple-biCF canonical reconstruction
 or the global unit-weight convention assumed in arXiv:1606.00608, lines
@@ -319,14 +324,14 @@ implication `(ii) ⇒ (iv)`. See `docs/paper-gaps/cpgsv17_pf_rank_one.tex` and
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 theorem full_lowLevel_counterexample :
     ∃ (K A : MPOTensor 4 2) (mu : ℂ),
-      mu ≠ 0 ∧ K = mu • A ∧ A.toMPSTensor.IsNormalTensor ∧
+      mu ≠ 0 ∧ ‖mu‖ ≤ 1 ∧ K = mu • A ∧ A.toMPSTensor.IsNormalTensor ∧
       K.IsInjective ∧ K.IsSAL ∧
       physTraceTransfer K * physTraceTransfer K = physTraceTransfer K ∧
       (¬∃ F : PhysicalSectorFactorization K,
         Nonempty F.NeighboringTraceFactorization) := by
-  obtain ⟨A, mu, hmu, _, hrecover, hNormal⟩ :=
+  obtain ⟨A, mu, hmu, hmu_norm, hrecover, hNormal⟩ :=
     exists_normalTensor_scalar_representation
-  exact ⟨tensor, A, mu, hmu, hrecover, hNormal, tensor_isInjective,
+  exact ⟨tensor, A, mu, hmu, hmu_norm, hrecover, hNormal, tensor_isInjective,
     tensor_isSAL, physTraceTransfer_tensor_idempotent,
     not_exists_neighboringTraceFactorization⟩
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2630,14 +2630,16 @@ This is the calculation in
 
 \begin{theorem}[Counterexample to the low-level absorbed-sector implication]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure_counterexample}
-    \lean{MPOTensor.NonCartesianActiveSectorCandidate.full_lowLevel_counterexample}
+    \lean{MPOTensor.NonCartesianActiveSectorCandidate.exists_normalTensor_scalar_representation,
+        MPOTensor.NonCartesianActiveSectorCandidate.full_lowLevel_counterexample}
     \leanok
     \uses{def:is_sal, def:mpo_physical_trace_transfer,
         def:mpdo_physical_sector_factorization,
         def:mpdo_neighboring_trace_factorization}
     There are tensors $K,A$ of physical dimension four and virtual dimension
-    two, and a nonzero scalar $\mu$, such that $K=\mu A$, the tensor $A$ is
-    normal, and $K$ is injective, satisfies the strong area law, and obeys
+    two, and a nonzero scalar $\mu$ with $|\mu|\leq 1$, such that $K=\mu A$,
+    the tensor $A$ is normal, and $K$ is injective, satisfies the strong area
+    law, and obeys
     \begin{align}
         \mathcal T_K^2&=\mathcal T_K.
         \notag
@@ -2668,7 +2670,15 @@ This is the calculation in
     factors. The resulting neighboring trace matrix has a nonzero
     two-by-two minor, so it cannot equal $(a_kb_h)_{k,h}$. The four slices
     span the full two-by-two matrix algebra, and their displayed scalar
-    neighboring operators are positive. Finally, Perron normalization and a
-    canonical gauge express the tensor as a nonzero scalar multiple of a
-    normal tensor.
+    neighboring operators are positive. For the positive test matrix
+    $H=\operatorname{diag}(20,1)$, direct calculation gives
+    \begin{align}
+        H-\mathcal E_K^*(H)
+          &=\begin{pmatrix}85/8&-9/40\\-9/40&4697/5000\end{pmatrix}>0.
+        \notag
+    \end{align}
+    Pairing this inequality with a positive-definite Perron eigenmatrix of
+    $\mathcal E_K$ shows that its Perron value $r$ is at most one. Perron
+    normalization and a canonical gauge therefore express the tensor as
+    $K=\mu A$ with $A$ normal and $|\mu|=\sqrt r\leq1$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2630,7 +2630,8 @@ This is the calculation in
 
 \begin{theorem}[Counterexample to the low-level absorbed-sector implication]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure_counterexample}
-    \lean{MPOTensor.NonCartesianActiveSectorCandidate.exists_normalTensor_scalar_representation,
+    \lean{MPOTensor.NonCartesianActiveSectorCandidate.transferMap_posDef_eigenvalue_le_one,
+        MPOTensor.NonCartesianActiveSectorCandidate.exists_normalTensor_scalar_representation,
         MPOTensor.NonCartesianActiveSectorCandidate.full_lowLevel_counterexample}
     \leanok
     \uses{def:is_sal, def:mpo_physical_trace_transfer,


### PR DESCRIPTION
### Motivation

- In `Papers/1606.00608/MPDO-22-12-17-2.tex:217-246`, equation `eq:II_CF1` chooses the coefficients `μ_k` so that each associated completely positive map has spectral radius one; line 246 then states that "we can always choose `|μ_k| ≤ 1` and at least one of them equals one."
- The non-Cartesian candidate already had a normal-tensor scalar representation, but its coefficient had no proved upper bound. Issue #7010 isolates the candidate-specific estimate needed by the counterexample analysis in #6775.
- This is a helper for that analysis, not a formalization of CPSV16 Theorem 4.9: it neither constructs the ambient simple biCF tensor nor proves that one coefficient among all ambient sectors has modulus one.

### Description

- Evaluate the adjoint transfer map exactly at `H = diag(20, 1)`, obtaining `E†(H) = [[75/8, 9/40], [9/40, 303/5000]]`.
- Prove `H - E†(H)` positive definite by the exact factorization `Uᴴ D U`, where `U = [[1, -9/425], [0, 1]]` and `D = diag(85/8, 19861/21250)`. The determinant of the gap is `19861/2000`.
- Pair the subinvariance inequality with a positive-definite Perron eigenmatrix. Positivity and faithfulness of the trace pairing give a strictly positive `tr(Hρ)`, so `0 ≤ (1-r) tr(Hρ)` implies `r ≤ 1`.
- Strengthen both `exists_normalTensor_scalar_representation` and the public low-level counterexample with `‖μ‖ ≤ 1`. The exact matrix certificates remain private.
- Synchronize the existing Chapter 21 counterexample entry with the strengthened statement and its Perron-pairing proof. The entry remains explicitly a project counterexample, not a `\leanok` claim for the source theorem.
- Add short docstrings for the two private factors in the exact positive-definiteness certificate.

### Testing

- `lake env lean TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean`
- `lake build TNLean.MPS.MPDO.NonCartesianActiveSectorCounterexample`
- `lake build TNLean` after refreshing only the cached MPU/QCA import aggregators needed by the declaration checker
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci --changed-files TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean || true` (no matches)
- `python3 scripts/tactic_pattern_scan.py` (only existing repository-wide patterns; no new three-use pattern)
- `git diff --check`

---
Closes #7010
Addresses #6775

### Agent assistance

- OpenAI Codex (GPT-5): source comparison, exact matrix calculation, Lean proof construction, Blueprint synchronization, local verification, and pull-request preparation. LionSR reviewed the mathematical scope and is accountable for the change.
