### PR TITLE
fix(blueprint): restore MPU product notation

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4984,9 +4984,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     tensors of common physical dimension $d$. For their product tensor,
     four-site blocking satisfies
     \begin{align}
-        r[(\mathcal U\mathcal V)_4]
+        r[(\mathcal U\mathbin{\cdot}\mathcal V)_4]
          & \leq d^2 r[\mathcal U]r[\mathcal V], \\
-        \ell[(\mathcal U\mathcal V)_4]
+        \ell[(\mathcal U\mathbin{\cdot}\mathcal V)_4]
          & \leq d^2 \ell[\mathcal U]\ell[\mathcal V].
     \end{align}
     No unitarity or simplicity assumption is required.
@@ -5006,7 +5006,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     source leg from each factor. Thus, for suitable rectangular matrices
     $A_{1,4}$ and $B_{1,4}$,
     \begin{align}
-        M_1((\mathcal U\mathcal V)_4) & =A_{1,4}B_{1,4},
+        M_1((\mathcal U\mathbin{\cdot}\mathcal V)_4) & =A_{1,4}B_{1,4},
     \end{align}
     where the columns of $A_{1,4}$ and the rows of $B_{1,4}$ are indexed by
     \begin{align}
@@ -5017,7 +5017,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Consequently,
     \begin{align}
-        r[(\mathcal U\mathcal V)_4]
+        r[(\mathcal U\mathbin{\cdot}\mathcal V)_4]
          &=\operatorname{rank}(A_{1,4}B_{1,4})
         \leq\dim(\mathcal K_1)
         =d^2r[\mathcal U]r[\mathcal V].
@@ -5026,7 +5026,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     order $(j_2,j_1)$ and source order $(r,\ell)$. For suitable rectangular
     matrices $A_{2,4}$ and $B_{2,4}$,
     \begin{align}
-        M_2((\mathcal U\mathcal V)_4) & =A_{2,4}B_{2,4},
+        M_2((\mathcal U\mathbin{\cdot}\mathcal V)_4) & =A_{2,4}B_{2,4},
     \end{align}
     where the intermediate space is
     \begin{align}
@@ -5037,7 +5037,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Hence
     \begin{align}
-        \ell[(\mathcal U\mathcal V)_4]
+        \ell[(\mathcal U\mathbin{\cdot}\mathcal V)_4]
          &=\operatorname{rank}(A_{2,4}B_{2,4})
         \leq\dim(\mathcal K_2)
         =d^2\ell[\mathcal U]\ell[\mathcal V].


### PR DESCRIPTION
### Motivation

- PR #7006 formalized the four-site source-rank bounds used in the composition part of the MPU Index Theorem.
- A late review found that its new Chapter 28 formulas wrote the product tensor by bare juxtaposition, although Definition `def:mpdo_operator_product` establishes the explicit product notation. In these tensor formulas, the explicit symbol removes a genuine ambiguity with contraction.
- This narrow follow-up addresses that review without changing any mathematical statement.

### Description

- Replace the six occurrences of `\\mathcal U\\mathcal V` introduced by #7006 with `\\mathcal U\\mathbin{\\cdot}\\mathcal V`.
- Apply the correction consistently in the rank statement, both cut factorizations, and both rank estimates.
- Leave the Lean declarations and proofs unchanged.

Agent-assisted: Codex (GPT-5) identified and applied the repair; LionSR reviewed the change and is accountable for it.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/*.tex`
- `leanblueprint checkdecls`
- `leanblueprint web`

---

Closes #7042.
Follow-up to #7006 and #6999.
Addresses https://github.com/LionSR/TNLean/pull/7006#discussion_r3839224412