### PR TITLE
feat(PEPS): realize virtual operation on staircase windows

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -132,6 +132,7 @@ import TNLean.PEPS.TorusWindowPeeling.WindowIndependence
 import TNLean.PEPS.TorusWindowRealizes
 import TNLean.PEPS.TorusWindowRegion
 import TNLean.PEPS.TorusWindowSingleCrossingObstruction
+import TNLean.PEPS.TorusWindowVirtualOperationFamily
 import TNLean.PEPS.TorusWindowWitness
 import TNLean.PEPS.TorusWitnessCapstone
 import TNLean.PEPS.TorusWitnessTranslate

--- a/TNLean/PEPS/RegionBlock.lean
+++ b/TNLean/PEPS/RegionBlock.lean
@@ -31,6 +31,7 @@ import TNLean.PEPS.RegionBlock.GaugeInjectivity2
 import TNLean.PEPS.RegionBlock.InsertResidual
 import TNLean.PEPS.RegionBlock.InsertSplit
 import TNLean.PEPS.RegionBlock.Insertion
+import TNLean.PEPS.RegionBlock.InteriorBondInsertion
 import TNLean.PEPS.RegionBlock.KernelDescent
 import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean/PEPS/RegionBlock.lean
+++ b/TNLean/PEPS/RegionBlock.lean
@@ -33,6 +33,7 @@ import TNLean.PEPS.RegionBlock.InsertSplit
 import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.RegionBlock.InteriorBondInsertion
 import TNLean.PEPS.RegionBlock.KernelDescent
+import TNLean.PEPS.RegionBlock.PhysicalOperation
 import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
 import TNLean.PEPS.RegionBlock.Realization
 import TNLean.PEPS.RegionBlock.Recovery

--- a/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
+++ b/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
@@ -22,10 +22,12 @@ Thus the assembled deformed state is
 \]
 where `p_A(R)` is the non-boundary bond product and `E_A` is the coefficient obtained by
 inserting `X` on `e` in the closed network.  The singleton contains the ordered left endpoint,
-so no transpose is introduced.  This is the interior-bond case of the paper's statement that
-one virtual operation is a physical operation on every window containing an endpoint.  The
-extension uses the same contraction operation of adjoining genuine tensors that occurs later
-in the sketch's end-region comparison.
+so no transpose is introduced.  This supplies the insert used for the interior-bond case of the
+paper's staircase.  For an injective window, `physicalOpOfRegionInsert_realizes` separately turns
+this insert into an actual physical operator on the window.  The closed-state extension identity
+below supplies the common-state calculation; it is not being used by itself as a local physical
+realization.  The extension uses the same contraction operation of adjoining genuine tensors that
+occurs later in the sketch's end-region comparison.
 
 ## References
 
@@ -90,6 +92,9 @@ region times the closed-network coefficient with the same virtual operation on t
 The extension identity adjoins the genuine tensors without changing the closed state.  The
 normalizing ratio cancels the singleton's non-boundary bond product.  Since the singleton
 contains the ordered left endpoint of `e`, the boundary orientation is the identity.
+
+This is a closed-state identity.  The open-boundary physical realization on an injective region is
+`physicalOpOfRegionInsert_realizes` in `TNLean/PEPS/RegionBlock/PhysicalOperation.lean`.
 
 Source: arXiv:1804.04964, the virtual-operation realization at lines 2320--2321 of
 `Papers/1804.04964/paper_normal.tex`; compare the tensor adjoining at lines 2415--2444. -/

--- a/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
+++ b/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.TorusWindowPeeling.WindowIndependence
+
+/-!
+# Insertion of a virtual operation on an interior bond
+
+Let `e` be a bond whose two endpoints lie in a region `R`.  A virtual operation `X` on `e`
+can be represented by an insert on `R` as follows.  First regard `e` as a boundary edge of
+the singleton containing its ordered left endpoint and apply the boundary-bond insert there.
+Then adjoin the genuine tensors at the remaining vertices of `R` by `extendInsert`.  The
+extension identity preserves the resulting closed state.  Finally, the ratio of the two
+non-boundary bond products changes its normalization from that of the singleton to that of
+`R`.
+
+Thus the assembled deformed state is
+\[
+  p_A(R)\,E_A(e,\omega,X),
+\]
+where `p_A(R)` is the non-boundary bond product and `E_A` is the coefficient obtained by
+inserting `X` on `e` in the closed network.  The singleton contains the ordered left endpoint,
+so no transpose is introduced.  This is the interior-bond case of the paper's statement that
+one virtual operation is a physical operation on every window containing an endpoint.  The
+extension uses the same contraction operation of adjoining genuine tensors that occurs later
+in the sketch's end-region comparison.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair
+  states generating the same state*, arXiv:1804.04964, the virtual-operation realization
+  at lines 2320--2321 and the later tensor-adjoining comparison at lines 2415--2444 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+omit [Fintype V] [DecidableRel G.Adj] in
+private theorem edgeLeftVertices_subset_of_mem (e : Edge G) {R : Finset V}
+    (hleft : e.1.1 ∈ R) : edgeLeftVertices e ⊆ R := by
+  intro v hv
+  rw [mem_edgeLeftVertices] at hv
+  simpa [hv] using hleft
+
+omit [Fintype V] [DecidableRel G.Adj] in
+private theorem isRegionBoundaryEdge_edgeLeftVertices (e : Edge G) :
+    IsRegionBoundaryEdge (G := G) (edgeLeftVertices e) e := by
+  rw [IsRegionBoundaryEdge]
+  left
+  constructor
+  · simp [edgeLeftVertices]
+  · simpa [edgeLeftVertices] using (edgeLeft_ne_edgeRight e).symm
+
+/-- The insert on a region `R` representing a virtual operation `X` on an interior bond `e`.
+
+The operation is first inserted on the singleton containing the ordered left endpoint of `e`.
+The remaining genuine tensors of `R` are then adjoined by `extendInsert`, and the result is
+rescaled from the singleton's non-boundary bond product to that of `R`.
+
+Source: arXiv:1804.04964, the virtual-operation realization at lines 2320--2321 of
+`Papers/1804.04964/paper_normal.tex`; compare the tensor adjoining at lines 2415--2444. -/
+noncomputable def interiorBondInsertedRegionInsert (A : Tensor G d) (R : Finset V)
+    (e : Edge G) (hends : e.1.1 ∈ R ∧ e.1.2 ∈ R)
+    (X : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    RegionInsert (G := G) (d := d) A R :=
+  let hsub : edgeLeftVertices e ⊆ R := edgeLeftVertices_subset_of_mem e hends.1
+  let hbd : IsRegionBoundaryEdge (G := G) (edgeLeftVertices e) e :=
+    isRegionBoundaryEdge_edgeLeftVertices e
+  fun ν σ ↦
+    (regionInteriorBondProd (G := G) A R : ℂ) *
+      (regionInteriorBondProd (G := G) A (edgeLeftVertices e) : ℂ)⁻¹ *
+        extendInsert (G := G) hsub
+          (bondInsertedRegionInsert (G := G) A (edgeLeftVertices e) ⟨e, hbd⟩ X) ν σ
+
+/-- The assembled state of an interior-bond insert is the non-boundary bond product of the
+region times the closed-network coefficient with the same virtual operation on that bond:
+\[
+  \Psi^{\mathrm{as}}_{A,R,I^{\mathrm{int}}_{R,e,X}}(\omega)
+  = p_A(R) E_A(e,\omega,X).
+\]
+
+The extension identity adjoins the genuine tensors without changing the closed state.  The
+normalizing ratio cancels the singleton's non-boundary bond product.  Since the singleton
+contains the ordered left endpoint of `e`, the boundary orientation is the identity.
+
+Source: arXiv:1804.04964, the virtual-operation realization at lines 2320--2321 of
+`Papers/1804.04964/paper_normal.tex`; compare the tensor adjoining at lines 2415--2444. -/
+theorem deformedRegionStateAssembled_interiorBondInserted_eq_smul_edgeInsertedCoeff
+    (A : Tensor G d) (R : Finset V) (e : Edge G)
+    (hends : e.1.1 ∈ R ∧ e.1.2 ∈ R)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
+    (X : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) (cfg : V → Fin d) :
+    deformedRegionStateAssembled (G := G) A R
+        (interiorBondInsertedRegionInsert (G := G) A R e hends X) cfg =
+      regionInteriorBondProd (G := G) A R •
+        edgeInsertedCoeff (G := G) A e cfg X := by
+  classical
+  rw [interiorBondInsertedRegionInsert]
+  rw [deformedRegionStateAssembled_const_smul]
+  rw [← deformedRegionState_extend (edgeLeftVertices_subset_of_mem e hends.1) hpos]
+  rw [deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff]
+  simp only [regionEdgeOrient, edgeLeftVertices, Finset.mem_singleton, ite_true]
+  rw [nsmul_eq_mul, nsmul_eq_mul]
+  have hne : (regionInteriorBondProd (G := G) A (edgeLeftVertices e) : ℂ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (regionInteriorBondProd_pos (G := G) A (edgeLeftVertices e) hpos).ne'
+  rw [edgeLeftVertices] at hne
+  field_simp [hne]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
+++ b/TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean
@@ -67,6 +67,11 @@ The operation is first inserted on the singleton containing the ordered left end
 The remaining genuine tensors of `R` are then adjoined by `extendInsert`, and the result is
 rescaled from the singleton's non-boundary bond product to that of `R`.
 
+The right-endpoint membership in `hends` records the paper's interior-bond geometry.  The
+construction uses the left-endpoint membership to choose the singleton on which the operation is
+first inserted; adjoining the rest of `R` then includes the right endpoint among the genuine
+tensors.
+
 Source: arXiv:1804.04964, the virtual-operation realization at lines 2320--2321 of
 `Papers/1804.04964/paper_normal.tex`; compare the tensor adjoining at lines 2415--2444. -/
 noncomputable def interiorBondInsertedRegionInsert (A : Tensor G d) (R : Finset V)

--- a/TNLean/PEPS/RegionBlock/PhysicalOperation.lean
+++ b/TNLean/PEPS/RegionBlock/PhysicalOperation.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.RegionBlock.Recovery5
+import TNLean.PEPS.TorusDeformedWindow
+
+/-!
+# Physical realization of a region insert
+
+Let `R` be an injective region.  Its genuine blocked tensors, indexed by the virtual boundary
+configuration, are linearly independent.  Consequently, any insert `C` with the same virtual
+boundary and physical spaces is obtained by applying one linear operator to the physical leg of
+the genuine block.  A chosen left inverse of the blocked-tensor map gives this operator explicitly.
+
+This is the linear-algebraic meaning of the paper's phrase that a virtual operation on the
+highlighted bond is a physical operation on an injective window.  Unlike equality after closing the
+window against its complement, the theorem below is an open-boundary identity for every boundary
+configuration.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair
+  states generating the same state*, arXiv:1804.04964, the virtual/physical operation
+  correspondence at lines 2320--2321 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- The physical operator on an injective region realizing a prescribed region insert.
+
+First use the chosen left inverse of the genuine blocked-tensor map to read a physical vector as
+virtual-boundary coefficients.  Then take the corresponding linear combination of the prescribed
+insert family.
+
+Source: arXiv:1804.04964, the virtual/physical operation correspondence at lines 2320--2321 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def physicalOpOfRegionInsert (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ) :=
+  (Fintype.linearCombination ℂ C).comp (regionBlockedLeftInverse (G := G) A R hR)
+
+/-- The physical operator of an insert sends every genuine open-boundary block to the
+corresponding member of the insert family:
+\[
+  O_C\bigl(T_{A,R}(\mu)\bigr)=C(\mu).
+\]
+
+Thus the realization holds before contracting the window with its complement.
+
+Source: arXiv:1804.04964, the virtual/physical operation correspondence at lines 2320--2321 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem physicalOpOfRegionInsert_realizes (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (C : RegionInsert (G := G) (d := d) A R)
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    physicalOpOfRegionInsert (G := G) A R hR C
+        (regionBlockedWeight (G := G) A R μ) = C μ := by
+  classical
+  rw [physicalOpOfRegionInsert, LinearMap.comp_apply,
+    regionBlockedLeftInverse_regionBlockedWeight,
+    Fintype.linearCombination_apply_single, one_smul]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowBondLocal.lean
+++ b/TNLean/PEPS/TorusWindowBondLocal.lean
@@ -7,7 +7,7 @@ import TNLean.PEPS.TorusWindowMult
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 
 /-!
-# The window witness from two-directional bond locality on the left end window
+# A conditional window witness from bond locality on the left end window
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of `Papers/1804.04964/paper_normal.tex`) feeds
@@ -17,8 +17,9 @@ identity on the reference edge `e`.  The reduction
 produces the witness from the two cross-tensor coefficient transfers and the forward-transfer
 multiplicativity.  This file restates that reduction with its two coefficient-transfer inputs
 replaced by the single block-frame predicate they reduce to --- *bond locality of the transfer
-kernel* on the left end window --- so the unconditional window witness assembles from exactly the
-two genuinely-new staircase residuals: two-directional bond locality and forward multiplicativity.
+kernel* on the left end window.  This is a conditional packaging theorem.  Bond locality and
+forward multiplicativity are not hypotheses of the source corollary, and this file does not assert
+that the paper's staircase argument factors through them.
 
 ## The packaging
 
@@ -34,10 +35,10 @@ through their legs on `e`.  Feeding the two directions of bond locality through
 the forward multiplicativity `hmul` over the chosen forward transfer completes the input the witness
 reduction consumes.
 
-This isolates the residual of the window route to exactly the two block-frame inputs.  Everything
-else --- the four window/host injectivities, the additivity, homogeneity, identity preservation, the
-two-sided inverse, the Skolem--Noether read-off, and the witness packaging --- is the unconditional
-region-level algebra discharged here from the torus arc-window injectivity hypotheses.
+Under these additional inputs, everything else --- the four window/host injectivities, the
+additivity, homogeneity, identity preservation, the two-sided inverse, the Skolem--Noether read-off,
+and the witness packaging --- is the unconditional region-level algebra discharged here from the
+torus arc-window injectivity hypotheses.
 
 ## The port verdict
 
@@ -50,11 +51,10 @@ touches the reference edge `e` with one endpoint, so the `e`-leg is a single
 `Fin (bondDim e)` index --- a vector, not a square matrix --- and window injectivity
 `RegionBlockedTensorInjective` is linear independence across the window's whole multi-bond
 perimeter, not a single-bond matrix-algebra span.  No per-window square-matrix family exists, so the
-matrix-intertwining route does not transfer per window; the forward multiplicativity must come from
-the cross-tensor physical-realization homomorphism, whose region read-off currently needs the
-single-vertex spanning `span_stateOpenCoeff_eq_top` at `e`'s in-region endpoint (absent for a normal
-tensor).  This is the residual `hbondAB`/`hbondBA`/`hmul` packaged here, recorded in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+matrix-intertwining route does not transfer per window.  The present conditional theorem obtains
+the transfer from bond locality and takes multiplicativity as an input.  The source-faithful route
+instead compares the overlapping physical operations and recovers the fixed-edge virtual operation
+as in Lemma 5; see `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
 
 ## References
 
@@ -214,14 +214,13 @@ theorem windowCoeffTransferBA_of_bondLocal {A B : Tensor (torusGraph width heigh
     ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega) (by omega)
       ha0 haw hbh⟩ hbondBA
 
-/-! ### The unconditional window witness from two-directional bond locality
+/-! ### The conditional window witness from two-directional bond locality
 
 Feeding the two coefficient transfers built from bond locality, together with the forward
 multiplicativity over the chosen forward transfer, to the witness reduction
-`exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer`.  The witness assembles from exactly the
-two genuinely-new staircase residuals --- two-directional bond locality `hbondAB`/`hbondBA` and
-forward multiplicativity `hmul` --- with every region/host injectivity discharged from the torus
-arc-window hypotheses. -/
+`exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer`.  With the additional bond-locality and
+multiplicativity inputs, every region/host injectivity is discharged from the torus arc-window
+hypotheses. -/
 
 /-- **The window-region witness from two-directional bond locality on the left end window.**
 
@@ -235,13 +234,11 @@ block-frame predicate the cross-tensor coefficient transfer reduces to
 (`bondLocal_iff_coeffTransfer`, unconditional on the window/host injectivity available at the
 minimal size).
 
-This is the §5.2 packaging with the two coefficient-transfer inputs of
+This is a conditional §5.2 packaging with the two coefficient-transfer inputs of
 `exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer` replaced by the single block-frame
-predicate `IsBondLocalTransferKernel` they reduce to.  The residual is exactly
-`hbondAB`/`hbondBA`/`hmul`: the forward multiplicativity is the cross-tensor physical-realization
-homomorphism the one-dimensional matrix-intertwining port cannot supply per window (the `e`-leg is a
-vector, not a square matrix), and bond locality is the single-vertex-spanning content
-`span_stateOpenCoeff_eq_top` at `e`'s in-region endpoint, absent for a normal tensor.
+predicate `IsBondLocalTransferKernel` they reduce to.  These inputs are stronger than the source
+corollary and are not marked as its remaining proof obligations.  The source-faithful residual is
+the Lemma 5 converse for the overlapping physical operations at lines 2368--2444.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;

--- a/TNLean/PEPS/TorusWindowBondLocal.lean
+++ b/TNLean/PEPS/TorusWindowBondLocal.lean
@@ -54,14 +54,16 @@ perimeter, not a single-bond matrix-algebra span.  No per-window square-matrix f
 matrix-intertwining route does not transfer per window.  The present conditional theorem obtains
 the transfer from bond locality and takes multiplicativity as an input.  The source-faithful route
 instead compares the overlapping physical operations and recovers the fixed-edge virtual operation
-as in Lemma 5; see `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+as in Lemma 5; see the subsections ``What the sketch asserts, and what remains to be extracted''
+and ``The window family around an edge'' in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 
 ## References
 
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
   generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
   2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
-  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2.
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 -/
 
 open scoped BigOperators Matrix
@@ -85,7 +87,7 @@ coefficient.  This is `coeffTransfer_of_bondLocal` on the left window, with the 
 injectivity and host injectivity discharged from the torus arc-window hypotheses.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem windowCoeffTransferAB_of_bondLocal {A B : Tensor (torusGraph width height) d}
     {L K a b : ℕ}
     (hA : NormalTorusArcWindowInjectivityHypotheses L K
@@ -152,7 +154,7 @@ reference edge `e` of the left window for `B`, a matrix `M` for `A` with matchin
 coefficient.  This is `coeffTransfer_of_bondLocal` on the left window with the two tensors swapped.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem windowCoeffTransferBA_of_bondLocal {A B : Tensor (torusGraph width height) d}
     {L K a b : ℕ}
     (hA : NormalTorusArcWindowInjectivityHypotheses L K
@@ -234,7 +236,7 @@ block-frame predicate the cross-tensor coefficient transfer reduces to
 (`bondLocal_iff_coeffTransfer`, unconditional on the window/host injectivity available at the
 minimal size).
 
-This is a conditional §5.2 packaging with the two coefficient-transfer inputs of
+This is a conditional coefficient-transfer packaging with the two inputs of
 `exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer` replaced by the single block-frame
 predicate `IsBondLocalTransferKernel` they reduce to.  These inputs are stronger than the source
 corollary and are not marked as its remaining proof obligations.  The source-faithful residual is
@@ -242,7 +244,7 @@ the Lemma 5 converse for the overlapping physical operations at lines 2368--2444
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2. -/
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem exists_windowEdgeCoeffIdentityWitness_of_bondLocal
     {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
     (hA : NormalTorusArcWindowInjectivityHypotheses L K

--- a/TNLean/PEPS/TorusWindowPeeling/WindowIndependence.lean
+++ b/TNLean/PEPS/TorusWindowPeeling/WindowIndependence.lean
@@ -49,7 +49,8 @@ complement contraction.
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
   generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
   2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
-  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+  subsection ``The common-state family is complete'' in
+  `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 -/
 
 open scoped BigOperators Matrix
@@ -84,7 +85,7 @@ interior-bond multiple of the edge-inserted coefficient; the restriction round-t
 `assembleRegionσ_restrict` reassembles `cfg` from its two restrictions.
 
 Source: arXiv:1804.04964, Section 3, lines 1205--1210 of `Papers/1804.04964/paper_normal.tex`;
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff (R : Finset V)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) (cfg : V → Fin d) :
@@ -130,7 +131,7 @@ either window.  See `staircaseVirtualOperationPhysicalOp_realizes` for that open
 
 Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex` (a virtual operation on a bond is a physical operation on any
-window containing an endpoint); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+window containing an endpoint); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem bondInserted_windowIndependent (R₁ R₂ : Finset V) (e : Edge G)
     (hf : IsRegionBoundaryEdge (G := G) R₁ e) (hg : IsRegionBoundaryEdge (G := G) R₂ e)
     (M₁ M₂ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)

--- a/TNLean/PEPS/TorusWindowPeeling/WindowIndependence.lean
+++ b/TNLean/PEPS/TorusWindowPeeling/WindowIndependence.lean
@@ -17,9 +17,12 @@ extracts the bond operator on the distinguished edge `e` from the open-boundary 
 That peeling consumes a family of inserts on the staircase windows all sharing one deformed state,
 with the two end windows carrying the bond-inserted inserts of `M` and `M'`.  The sketch describes
 this family as the realization of one virtual operation on the bond `e` as a physical operation on
-any window containing an endpoint of `e`; this file supplies the load-bearing fact behind that
-correspondence: the deformed state of a bond-inserted insert is **window-independent** up to the
-window's interior-bond multiplicity.
+any window containing an endpoint of `e`; this file supplies the closed-state coefficient identity
+and normalization used in that construction: the deformed state of a bond-inserted insert is
+**window-independent** up to the window's interior-bond multiplicity.  Equality after complementary
+contraction is not itself a local physical realization.  The latter is the open-boundary theorem
+`staircaseVirtualOperationPhysicalOp_realizes` in
+`TNLean/PEPS/TorusWindowVirtualOperationFamily.lean`.
 
 ## The window-independence
 
@@ -35,11 +38,11 @@ assembled deformed state is exactly the region-inserted coefficient
 restriction round-trip `assembleRegionσ_restrict`.  Cross-multiplying by the two interior-bond
 products cancels the region-dependent scalars and equates the two assembled deformed states.
 
-This is the realization of the sketch's ``a virtual operation on a given bond is a physical
-operation on any window containing an endpoint'' for the two end windows of the staircase, which
-carry the bond-inserted inserts the peeling consumes.  The two end windows sit on opposite sides of
-`e`, so their orientations differ by a transpose; the general statement carries the orientation
-explicitly, and the same-side corollary specializes it.
+This is the closed-state identity used for the two end windows of the staircase.  The two end
+windows sit on opposite sides of `e`, so their orientations differ by a transpose; the general
+statement carries the orientation explicitly, and the same-side corollary specializes it.  The
+physical-operator construction is a separate open-boundary result and does not follow from this
+complement contraction.
 
 ## References
 
@@ -121,9 +124,9 @@ edge-inserted coefficient (`deformedRegionStateAssembled_bondInserted_eq_smul_ed
 since the edge-inserted coefficient mentions only the shared edge and the two orientations agree;
 cross-multiplying by the interior-bond products matches the two scalars.
 
-This is the realization of the sketch's correspondence between one virtual operation on the bond and
-the physical operation on either window containing an endpoint of it, for windows where the bond is
-a boundary edge.
+This is the window-independent closed-state coefficient identity for boundary-edge inserts.  It is
+one input to the staircase construction, but does not by itself construct the physical operator on
+either window.  See `staircaseVirtualOperationPhysicalOp_realizes` for that open-boundary identity.
 
 Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex` (a virtual operation on a bond is a physical operation on any

--- a/TNLean/PEPS/TorusWindowRealizes.lean
+++ b/TNLean/PEPS/TorusWindowRealizes.lean
@@ -62,7 +62,7 @@ operation by the Lemma 5 converse (`paper_normal.tex`, lines 2368--2444).
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
   generating the same state*, arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Section 3, Lemma
   `inj_isomorph`, lines 254--586 of `Papers/1804.04964/paper_normal.tex`, and the corollary at lines
-  2297--2318; the filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1,
+  2297--2318; the filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`;
   and the conditional single-vertex endpoint-spanning construction in
   `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 -/
@@ -93,7 +93,7 @@ unconditional region injectivity `regionInsertedCoeff_injective`
 (`TNLean/PEPS/RegionBlock/Algebra.lean`), the read-off side that window and host injectivity power.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem windowRegionInsertedCoeff_injective
     {B : Tensor (torusGraph width height) d} {L K a b : ℕ}
     (hB : NormalTorusArcWindowInjectivityHypotheses L K
@@ -161,7 +161,7 @@ lines 2368--2444, as recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`. -/
 theorem exists_windowEdgeCoeffIdentityWitness_of_realizes
     {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
     (hA : NormalTorusArcWindowInjectivityHypotheses L K

--- a/TNLean/PEPS/TorusWindowRealizes.lean
+++ b/TNLean/PEPS/TorusWindowRealizes.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.PEPS.TorusWindowMult
 
 /-!
-# The window-region witness from the single-vertex realization on the left end window
+# A conditional window-region witness from single-vertex realization
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of `Papers/1804.04964/paper_normal.tex`) feeds
@@ -16,8 +16,9 @@ identity on the reference edge `e`.  The reduction
 produces the witness from three separate inputs: the two cross-tensor coefficient transfers
 `htransferAB`/`htransferBA` and the forward-transfer multiplicativity `hmul`.  This file collapses
 all three of those inputs to a single block of data --- the region physical-to-virtual realization
-on the left end window, in each direction --- and records the two facts that fix the precise
-boundary of the construction.
+on the left end window, in each direction.  This is a useful conditional implication.  Its
+single-vertex hypotheses are stronger than normality and are not part of the source-faithful
+overlapping-window route.
 
 ## The injectivity engine is available from window and host injectivity
 
@@ -32,7 +33,7 @@ with no single-vertex spanning.  This is the affirmative half of the boundary: w
 injectivity *do* power the read-off side --- the inserted matrix is determined by its window
 coefficient.
 
-## The multiplicativity is the single-vertex realization residual
+## Multiplicativity supplied by the conditional realization
 
 What window and host injectivity do *not* supply is the multiplicativity `hmul`.  The forward
 transfer of a product `M * M'` on the reference edge is a single matrix product on the bond; reading
@@ -45,16 +46,16 @@ level: there is no internal sum over an intermediate bond configuration to split
 composition of two separate insertions, so the injectivity engine, although it reduces `hmul` to a
 coefficient identity, cannot produce that identity on its own.
 
-`exists_windowEdgeCoeffIdentityWitness_of_realizes` therefore takes the two-directional realization
-in place of the three transfer inputs: `regionInsertionTransfer_of_realizes`
+`exists_windowEdgeCoeffIdentityWitness_of_realizes` takes the two-directional realization in place
+of the three transfer inputs: `regionInsertionTransfer_of_realizes`
 (`TNLean/PEPS/RegionBlock/Recovery3.lean`) builds the transfer datum from it, supplying the
 coefficient transfers, the unital field, *and* the multiplicativity in one step
 (`regionTransferMatrix_mul_of_realizes`), and the datum feeds the landed witness packaging
-`exists_windowEdgeCoeffIdentityWitness_of_transfer`.  This is the precise statement of what the
-staircase must supply: the single-vertex realization on the window, in each direction, with the
-matched bond dimensions and the same state, is the irreducible core the corollary still needs.  The
-host injectivity is the single-window complement at the minimal size, in contrast to the rectangle
-red block's host, which fails there.
+`exists_windowEdgeCoeffIdentityWitness_of_transfer`.  The host injectivity is the single-window
+complement at the minimal size, in contrast to the rectangle red block's host, which fails there.
+The paper does not require the single-vertex realization used here: its proof sketch instead
+compares physical operations on the overlapping windows and recovers the fixed-edge virtual
+operation by the Lemma 5 converse (`paper_normal.tex`, lines 2368--2444).
 
 ## References
 
@@ -62,7 +63,7 @@ red block's host, which fails there.
   generating the same state*, arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Section 3, Lemma
   `inj_isomorph`, lines 254--586 of `Papers/1804.04964/paper_normal.tex`, and the corollary at lines
   2297--2318; the filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1,
-  and the single-vertex endpoint-spanning residual in
+  and the conditional single-vertex endpoint-spanning construction in
   `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 -/
 
@@ -130,15 +131,15 @@ theorem windowRegionInsertedCoeff_injective
     ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge B (by omega) (by omega)
       ha0 haw hbh⟩ M M' hMM'
 
-/-! ### The window witness from the two-directional single-vertex realization
+/-! ### A conditional window witness from two-directional single-vertex realization
 
 The region physical-to-virtual realization on the left end window, in each direction, builds the
 `RegionInsertionTransfer` datum through `regionInsertionTransfer_of_realizes` --- supplying the two
 coefficient transfers, the unital field, and the forward multiplicativity together --- and the
 datum feeds the landed witness packaging `exists_windowEdgeCoeffIdentityWitness_of_transfer`.  This
 collapses the three separate inputs of `exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer`
-(`htransferAB`, `htransferBA`, `hmul`) to one block of data, isolating the irreducible core: the
-single-vertex realization at `e`'s in-region endpoint. -/
+(`htransferAB`, `htransferBA`, `hmul`) to one block of data.  It is a conditional strengthening,
+not the statement that the source's staircase argument must supply. -/
 
 /-- **The window-region witness from the single-vertex realization.**
 
@@ -154,9 +155,9 @@ realizations --- the coefficient transfers, the unital field, and the forward mu
 one step --- and `exists_windowEdgeCoeffIdentityWitness_of_transfer` packages it into the witness.
 The host injectivity is the single-window complement at the minimal size; the region injectivity is
 the window injectivity from the arc-window hypotheses.  This collapses the three separate transfer
-inputs to a single realization datum and is the precise statement of what the staircase must supply
-for the multiplicativity: the single-vertex realization at `e`'s in-region endpoint, absent for a
-normal tensor and recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+inputs to a single realization datum under the additional single-vertex hypotheses.  The
+source-faithful route does not assume those hypotheses; it uses the overlapping-window converse at
+lines 2368--2444, as recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;

--- a/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
+++ b/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.InteriorBondInsertion
+import TNLean.PEPS.RegionBlock.PhysicalOperation
 import TNLean.PEPS.TorusWindowBondUniform
 import TNLean.PEPS.TorusWindowFamilyCrossing
 import TNLean.PEPS.TorusWindowPeeling.SingleBond
@@ -24,10 +25,11 @@ arXiv:1804.04964:
 
 Every assembled deformed state is the non-boundary bond product of its window times the same
 closed-network coefficient `E_B(e, ω, X)`.  Translation invariance makes those products equal,
-so the entire family has one common deformed state.  Applying the existing single-bond peeling
-then equates the first-window coefficient with `Xᵀ` and the last-window coefficient with `X`.
-This transpose agrees with the ordered-endpoint convention of Lemma 5, where the right-end
-physical operation occurs in the map from `O₃ᵀ` to `X`.
+so the entire family has one common deformed state.  Independently, window injectivity gives an
+explicit physical operator `Oⱼ(X)` whose action on every open-boundary genuine block is the insert
+`Cⱼ(X)`.  The direct region-to-edge identities equate the first-window coefficient with `Xᵀ`
+and the last-window coefficient with `X`.  This transpose agrees with the ordered-endpoint
+convention of Lemma 5, where the right-end physical operation occurs in the map from `O₃ᵀ` to `X`.
 
 The construction follows the paper's actual operation: it keeps the distinguished bond `e`
 fixed and adjoins genuine tensors to a window.  No auxiliary matrix-span or different-bond
@@ -85,6 +87,69 @@ noncomputable def staircaseVirtualOperationInsert {a b : ℕ}
       (referenceEdge_endpoints_mem_staircaseWindow_of_interior hL hK haw hyh
         (Nat.one_le_iff_ne_zero.mpr hj0) (lt_of_not_ge hjL)) X
 
+/-- The physical operator `Oⱼ(X)` on the `j`-th injective staircase window that realizes the
+insert `Cⱼ(X)`.
+
+The arc-window hypotheses make `Wⱼ` injective.  The chosen left inverse of its blocked-tensor map
+therefore turns the open-boundary insert family `Cⱼ(X)` into one linear operator on the physical
+space of the window.
+
+Source: arXiv:1804.04964, the virtual/physical operation correspondence at lines 2320--2321 and
+the displayed staircase windows at lines 2323--2366 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def staircaseVirtualOperationPhysicalOp {a b : ℕ}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (j : ℕ) :
+    (RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j) → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j) → ℂ) :=
+  physicalOpOfRegionInsert (G := torusGraph width height) B
+    (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+    (by
+      have hi := h.staircaseWindow_injective ((a : ZMod width), (b : ZMod height)) j
+      rwa [regionInjectivityDataOf_isInjective] at hi)
+    (staircaseVirtualOperationInsert (B := B) hL hK haw hyh X j)
+
+/-- The operator `Oⱼ(X)` realizes `Cⱼ(X)` as an open-boundary identity.  For every virtual
+boundary configuration `μ`,
+\[
+  O_j(X)\bigl(T_{B,W_j}(\mu)\bigr)=C_j(X)(\mu).
+\]
+
+In particular, the common-state theorem below is not being used to infer a local physical
+realization after closing the complement: the physical operator is exhibited first, on the
+window's full physical space.
+
+Source: arXiv:1804.04964, the virtual/physical operation correspondence at lines 2320--2321 and
+the displayed staircase windows at lines 2323--2366 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseVirtualOperationPhysicalOp_realizes {a b : ℕ}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (j : ℕ)
+    (μ : RegionBoundaryConfig (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)) :
+    staircaseVirtualOperationPhysicalOp (B := B) h hL hK haw hyh X j
+        (regionBlockedWeight (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j) μ) =
+      staircaseVirtualOperationInsert (B := B) hL hK haw hyh X j μ := by
+  unfold staircaseVirtualOperationPhysicalOp
+  apply physicalOpOfRegionInsert_realizes
+
 /-- On the first staircase window the virtual-operation family is the boundary insert of
 `Xᵀ`.  Its boundary orientation transposes once more, so the closed-network operation is `X`.
 
@@ -140,7 +205,6 @@ theorem deformedRegionStateAssembled_staircaseVirtualOperationInsert {a b j : �
     (hTI : IsTorusTranslationInvariant B)
     (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
     (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
-    (_hj : j < L + K)
     (X : Matrix
       (Fin (B.bondDim (horizontalStaircaseReferenceEdge
         ((a : ZMod width), (b : ZMod height)) L K)))
@@ -182,26 +246,22 @@ theorem deformedRegionStateAssembled_staircaseVirtualOperationInsert {a b j : �
         (hpos := hpos)]
       rw [regionInteriorBondProd_staircaseWindow_eq hTI _ L K j 0]
 
-/-- The virtual-operation family supplies the common-state hypothesis of the single-bond
-peeling.  Consequently, the coefficient on the first window with `Xᵀ` inserted equals the
-coefficient on the last window with `X` inserted.
+/-- The coefficient on the first window with `Xᵀ` inserted equals the coefficient on the last
+window with `X` inserted.
 
-The hypotheses here are exactly those of the existing end-window peeling theorem together with
-translation invariance, which identifies the normalizing bond products.  This is a
-single-tensor end-window identity, not yet the cross-tensor gauge conjugation.
+This is the direct coefficient-level shadow of the virtual-operation family.  The region-to-edge
+identity sends both sides to the coefficient with `X` on the same reference edge, and translation
+invariance identifies their non-boundary bond products.  No injectivity or complement hypothesis
+is needed for this equality.  The open-boundary physical realization is the separate theorem
+`staircaseVirtualOperationPhysicalOp_realizes`.
 
 Source: arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the two-dimensional proof sketch at
 lines 2320--2444 of `Papers/1804.04964/paper_normal.tex`. -/
 theorem regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation {a b : ℕ}
-    (h : NormalTorusArcWindowInjectivityHypotheses L K
-      (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hUB : RegionInjectivityUnionClosure
-      (regionInjectivityDataOf (G := torusGraph width height) B))
     (hTI : IsTorusTranslationInvariant B)
-    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
     (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
     (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
-    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (hyh : 2 * K + 1 ≤ height)
     (X : Matrix
       (Fin (B.bondDim (horizontalStaircaseReferenceEdge
         ((a : ZMod width), (b : ZMod height)) L K)))
@@ -220,19 +280,36 @@ theorem regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation {a b : ℕ}
           (by omega) (by omega) ha0 haw hbh⟩ X
         (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
         (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) := by
-  apply regionInsertedCoeff_endWindows_eq_of_staircase h hUB hpos hL hK ha0 haw hbh hxw hyh
-    Xᵀ X (staircaseVirtualOperationInsert (B := B) (by omega) (by omega) haw (by omega) X)
-    (fun cfg ↦
-      regionInteriorBondProd (G := torusGraph width height) B
-          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0) •
-        edgeInsertedCoeff (G := torusGraph width height) B
-          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) cfg X)
-  · intro j hj
-    funext cfg
-    exact deformedRegionStateAssembled_staircaseVirtualOperationInsert hTI hpos
-      (by omega) (by omega) haw (by omega) hj X cfg
-  · exact staircaseVirtualOperationInsert_zero (by omega) (by omega) haw (by omega) X
-  · exact staircaseVirtualOperationInsert_last (by omega) (by omega) haw (by omega) X
+  rw [regionInsertedCoeff_eq_smul_edgeInsertedCoeff,
+    regionInsertedCoeff_eq_smul_edgeInsertedCoeff]
+  have hcfg0 :
+      assembleRegionσ (V := TorusVertex width height) (d := d)
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+          (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+          (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) = cfg :=
+    assembleRegionσ_restrict _ cfg
+  have hcfgLast :
+      assembleRegionσ (V := TorusVertex width height) (d := d)
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+          (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+          (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) = cfg :=
+    assembleRegionσ_restrict _ cfg
+  rw [hcfg0, hcfgLast]
+  have hleft0 :
+      (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K).1.1 ∉
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0 := by
+    rw [referenceEdge_leftEndpoint_mem_staircaseWindow (by omega) (by omega) haw (by omega)]
+    omega
+  have hleftLast :
+      (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1) := by
+    rw [referenceEdge_leftEndpoint_mem_staircaseWindow (by omega) (by omega) haw (by omega)]
+    omega
+  simp only [regionEdgeOrient, hleft0, hleftLast, ite_false, ite_true,
+    Matrix.transpose_transpose]
+  rw [regionInteriorBondProd_staircaseWindow_eq hTI _ L K 0 (L + K - 1)]
 
 end Torus
 

--- a/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
+++ b/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.RegionBlock.InteriorBondInsertion
+import TNLean.PEPS.TorusWindowBondUniform
+import TNLean.PEPS.TorusWindowFamilyCrossing
+import TNLean.PEPS.TorusWindowPeeling.SingleBond
+
+/-!
+# One virtual operation on the staircase window family
+
+Fix the horizontal reference edge `e` and a virtual operation `X` on it.  The staircase
+windows are divided exactly as in the proof of the two-dimensional corollary of
+arXiv:1804.04964:
+
+* `W₀` contains only the ordered right endpoint of `e`; it carries the boundary insert of
+  `Xᵀ`, whose boundary orientation is `X`;
+* `W₁, …, W_{L-1}` contain both endpoints of `e`; they carry the interior-bond insert of
+  `X`;
+* `W_L, …, W_{L+K-1}` contain only the ordered left endpoint of `e`; they carry the boundary
+  insert of `X`.
+
+Every assembled deformed state is the non-boundary bond product of its window times the same
+closed-network coefficient `E_B(e, ω, X)`.  Translation invariance makes those products equal,
+so the entire family has one common deformed state.  Applying the existing single-bond peeling
+then equates the first-window coefficient with `Xᵀ` and the last-window coefficient with `X`.
+This transpose agrees with the ordered-endpoint convention of Lemma 5, where the right-end
+physical operation occurs in the map from `O₃ᵀ` to `X`.
+
+The construction follows the paper's actual operation: it keeps the distinguished bond `e`
+fixed and adjoins genuine tensors to a window.  No auxiliary matrix-span or different-bond
+transport is introduced.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair
+  states generating the same state*, arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the
+  two-dimensional corollary and proof sketch at lines 2297--2444 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {d : ℕ} {L K : ℕ} {B : Tensor (torusGraph width height) d}
+
+/-- The insert family realizing one virtual operation `X` on the horizontal reference edge.
+
+The first window, which contains only the ordered right endpoint, carries `Xᵀ`.  Windows
+strictly between `0` and `L` contain both endpoints and use the interior-bond insert.  Windows
+from `L` onward contain the ordered left endpoint and carry `X`.  The intended indices are
+`0 ≤ j < L + K`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def staircaseVirtualOperationInsert {a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (j : ℕ) : RegionInsert (G := torusGraph width height) (d := d) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j) :=
+  if hj0 : j = 0 then
+    bondInsertedRegionInsert (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+      ⟨_, isRegionBoundaryEdge_staircaseWindow_referenceEdge hL hK haw hyh (Or.inl hj0)⟩ Xᵀ
+  else if hjL : L ≤ j then
+    bondInsertedRegionInsert (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+      ⟨_, isRegionBoundaryEdge_staircaseWindow_referenceEdge hL hK haw hyh (Or.inr hjL)⟩ X
+  else
+    interiorBondInsertedRegionInsert (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)
+      (referenceEdge_endpoints_mem_staircaseWindow_of_interior hL hK haw hyh
+        (Nat.one_le_iff_ne_zero.mpr hj0) (lt_of_not_ge hjL)) X
+
+/-- On the first staircase window the virtual-operation family is the boundary insert of
+`Xᵀ`.  Its boundary orientation transposes once more, so the closed-network operation is `X`.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the proof sketch at lines
+2320--2444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseVirtualOperationInsert_zero {a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    staircaseVirtualOperationInsert (B := B) hL hK haw hyh X 0 =
+      bondInsertedRegionInsert (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_referenceEdge hL hK haw hyh
+          (Or.inl rfl)⟩ Xᵀ := by
+  simp [staircaseVirtualOperationInsert]
+
+/-- On the last staircase window the virtual-operation family is the boundary insert of `X`.
+The window contains the ordered left endpoint, so its boundary orientation is the identity.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the proof sketch at lines
+2320--2444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseVirtualOperationInsert_last {a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    staircaseVirtualOperationInsert (B := B) hL hK haw hyh X (L + K - 1) =
+      bondInsertedRegionInsert (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_referenceEdge hL hK haw hyh
+          (Or.inr (by omega))⟩ X := by
+  simp [staircaseVirtualOperationInsert, show L + K - 1 ≠ 0 by omega,
+    show L ≤ L + K - 1 by omega]
+
+/-- Every insert in the staircase family realizes the same closed-network virtual operation.
+
+For `0 ≤ j < L + K`, its assembled deformed state is
+\[
+  p_B(W_0) E_B(e,\omega,X).
+\]
+The three index ranges use, respectively, the right-end boundary insert of `Xᵀ`, the
+interior-bond insert of `X`, and the left-end boundary insert of `X`.  Translation invariance
+identifies the non-boundary bond products of all the translated `L × K` windows.
+
+Source: arXiv:1804.04964, the two-dimensional corollary and proof sketch at lines
+2297--2444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem deformedRegionStateAssembled_staircaseVirtualOperationInsert {a b j : ℕ}
+    (hTI : IsTorusTranslationInvariant B)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (_hj : j < L + K)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (cfg : TorusVertex width height → Fin d) :
+    deformedRegionStateAssembled (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+        (staircaseVirtualOperationInsert (B := B) hL hK haw hyh X j) cfg =
+      regionInteriorBondProd (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0) •
+        edgeInsertedCoeff (G := torusGraph width height) B
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) cfg X := by
+  classical
+  by_cases hj0 : j = 0
+  · subst j
+    rw [staircaseVirtualOperationInsert_zero]
+    rw [deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff]
+    have hleft :
+        (horizontalStaircaseReferenceEdge
+          ((a : ZMod width), (b : ZMod height)) L K).1.1 ∉
+          staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0 := by
+      rw [referenceEdge_leftEndpoint_mem_staircaseWindow hL hK haw hyh]
+      omega
+    simp [regionEdgeOrient, hleft]
+  · by_cases hjL : L ≤ j
+    · simp only [staircaseVirtualOperationInsert, hj0, ↓reduceDIte, hjL]
+      rw [deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff]
+      have hleft :
+          (horizontalStaircaseReferenceEdge
+            ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
+            staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j := by
+        rw [referenceEdge_leftEndpoint_mem_staircaseWindow hL hK haw hyh]
+        omega
+      simp only [regionEdgeOrient, hleft, ite_true]
+      rw [regionInteriorBondProd_staircaseWindow_eq hTI _ L K j 0]
+    · simp only [staircaseVirtualOperationInsert, hj0, hjL, ↓reduceDIte]
+      rw [deformedRegionStateAssembled_interiorBondInserted_eq_smul_edgeInsertedCoeff
+        (hpos := hpos)]
+      rw [regionInteriorBondProd_staircaseWindow_eq hTI _ L K j 0]
+
+/-- The virtual-operation family supplies the common-state hypothesis of the single-bond
+peeling.  Consequently, the coefficient on the first window with `Xᵀ` inserted equals the
+coefficient on the last window with `X` inserted.
+
+The hypotheses here are exactly those of the existing end-window peeling theorem together with
+translation invariance, which identifies the normalizing bond products.  This is a
+single-tensor end-window identity, not yet the cross-tensor gauge conjugation.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the two-dimensional proof sketch at
+lines 2320--2444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation {a b : ℕ}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hTI : IsTorusTranslationInvariant B)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (X : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (cfg : TorusVertex width height → Fin d) :
+    regionInsertedCoeff (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge B
+          (by omega) (by omega) ha0 haw hbh⟩ Xᵀ
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) =
+      regionInsertedCoeff (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_last_referenceEdge B
+          (by omega) (by omega) ha0 haw hbh⟩ X
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) := by
+  apply regionInsertedCoeff_endWindows_eq_of_staircase h hUB hpos hL hK ha0 haw hbh hxw hyh
+    Xᵀ X (staircaseVirtualOperationInsert (B := B) (by omega) (by omega) haw (by omega) X)
+    (fun cfg ↦
+      regionInteriorBondProd (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0) •
+        edgeInsertedCoeff (G := torusGraph width height) B
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) cfg X)
+  · intro j hj
+    funext cfg
+    exact deformedRegionStateAssembled_staircaseVirtualOperationInsert hTI hpos
+      (by omega) (by omega) haw (by omega) hj X cfg
+  · exact staircaseVirtualOperationInsert_zero (by omega) (by omega) haw (by omega) X
+  · exact staircaseVirtualOperationInsert_last (by omega) (by omega) haw (by omega) X
+
+end Torus
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_torus_single_bond_peeling.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_single_bond_peeling.tex
@@ -239,6 +239,7 @@
 \end{proof}
 
 \input{chapter/ch24_peps_ft_torus_window_independence}
+\input{chapter/ch24_peps_ft_torus_virtual_operation_family}
 
 \begin{definition}[Window-region coefficient-identity witness]
     \label{def:peps_window_edge_coeff_identity_witness}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -1,5 +1,45 @@
 \paragraph{One virtual operation on every staircase window.}
 
+The construction below formalizes the forward virtual/physical-operation
+correspondence in the proof sketch of the two-dimensional corollary
+\cite[corollary after Lemma~5, lines~2297--2444]{Molnar2018NormalPEPS}.
+
+\begin{definition}[Physical operator of a region insert]%
+    \label{def:peps_physical_operator_of_region_insert}
+    \lean{TNLean.PEPS.physicalOpOfRegionInsert}
+    \leanok
+    \uses{def:peps_region_out_endpoint_block_inverse}
+    Let $R$ be an injective region and let
+    $C=\{C(\mu)\}_{\mu\in\partial R}$ be any family in its physical
+    space, indexed by the virtual boundary configurations.  If $L_{A,R}$
+    is a left inverse of the blocked tensor map, define
+    \begin{align}
+        O_C
+         &=\left(c\longmapsto\sum_{\mu}c_\mu C(\mu)\right)L_{A,R}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Open-boundary realization of a region insert]%
+    \label{thm:peps_physical_operator_of_region_insert_realizes}
+    \lean{TNLean.PEPS.physicalOpOfRegionInsert_realizes}
+    \leanok
+    \uses{def:peps_physical_operator_of_region_insert}
+    For every virtual boundary configuration $\mu$,
+    \begin{align}
+        O_C\bigl(T_{A,R}(\mu)\bigr)&=C(\mu).
+        \notag
+    \end{align}
+    Thus the insert is obtained from the genuine region block by one
+    physical operator before the region is contracted with its complement.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The left inverse sends $T_{A,R}(\mu)$ to the standard basis vector
+    indexed by $\mu$, and the displayed linear combination sends that basis
+    vector to $C(\mu)$.
+\end{proof}
+
 \begin{definition}[Interior-bond region insert]%
     \label{def:peps_interior_bond_inserted_region_insert}
     \lean{TNLean.PEPS.interiorBondInsertedRegionInsert}
@@ -47,7 +87,7 @@
     \label{def:peps_staircase_virtual_operation_insert}
     \lean{TNLean.PEPS.staircaseVirtualOperationInsert}
     \leanok
-    \uses{def:peps_interior_bond_inserted_region_insert, lem:peps_reference_edge_left_endpoint_staircase_window, lem:peps_reference_edge_right_endpoint_staircase_window}
+    \uses{def:peps_bond_inserted_region_insert, def:peps_interior_bond_inserted_region_insert, lem:peps_reference_edge_boundary_windows, lem:peps_reference_edge_interior_windows}
     Let $e$ be the horizontal reference edge and let
     $X\in\MN{D_B(e)}$.  Define an insert $C_j(X)$ on each staircase window
     $W_j$, for $0\le j<L+K$, by
@@ -66,6 +106,29 @@
     only the ordered left endpoint.  The transpose in the first case makes
     all three boundary orientations represent the same matrix $X$.
 \end{definition}
+
+\begin{theorem}[Physical operators on the staircase windows]%
+    \label{thm:peps_staircase_virtual_operation_physical_realization}
+    \lean{TNLean.PEPS.staircaseVirtualOperationPhysicalOp}
+    \lean{TNLean.PEPS.staircaseVirtualOperationPhysicalOp_realizes}
+    \leanok
+    \uses{def:peps_staircase_virtual_operation_insert, thm:peps_physical_operator_of_region_insert_realizes}
+    Suppose every $L\times K$ window is injective.  For every
+    $0\leq j<L+K$, there is a physical operator $O_j(X)$ on the physical
+    space of $W_j$ such that
+    \begin{align}
+        O_j(X)\bigl(T_{B,W_j}(\mu)\bigr)&=C_j(X)(\mu)
+        \qquad (\mu\in\partial W_j).
+        \notag
+    \end{align}
+    Hence the virtual operation is realized locally on each window, before
+    any contraction with the complementary tensor network.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Each staircase window is an $L\times K$ translate and is therefore
+    injective.  Apply the open-boundary realization theorem to $C_j(X)$.
+\end{proof}
 
 \begin{lemma}[The two end inserts of the staircase family]%
     \label{lem:peps_staircase_virtual_operation_end_inserts}
@@ -116,12 +179,10 @@
     \label{thm:peps_end_window_identity_staircase_virtual_operation}
     \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
     \leanok
-    \uses{lem:peps_staircase_virtual_operation_end_inserts, thm:peps_staircase_virtual_operation_common_state, thm:peps_regionInsertedCoeff_endWindows_eq_of_staircase}
-    Suppose the window-injectivity and union-closure hypotheses of the
-    single-bond peeling hold, the tensor is translation invariant, all bond
-    dimensions are positive, and the staircase satisfies the same size
-    bounds.  Then for every $X\in\MN{D_B(e)}$ and every global physical
-    configuration $\omega$,
+    \uses{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff, thm:peps_regionInteriorBondProd_staircaseWindow_eq}
+    Suppose the tensor is translation invariant and the staircase satisfies
+    the stated size bounds.  Then for every $X\in\MN{D_B(e)}$ and every
+    global physical configuration $\omega$,
     \begin{align}
         C_B(W_0,e,X^{\mathsf T};\omega|_{W_0},
             \omega|_{V\setminus W_0})
@@ -133,8 +194,8 @@
 \end{theorem}
 \begin{proof}
     \leanok
-    Use the family $C_j(X)$.  Its end members are the required boundary
-    inserts and all members have the common state
-    $P_B(W_0)E_B(e,\cdot,X)$.  The single-bond peeling therefore gives the
-    stated coefficient identity.
+    The region-to-edge identity sends both sides to the edge coefficient
+    with $X$ on the same reference edge: the first boundary orientation
+    transposes $X^{\mathsf T}$, while the last fixes $X$.  Translation
+    invariance identifies the two non-boundary bond products.
 \end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -1,0 +1,140 @@
+\paragraph{One virtual operation on every staircase window.}
+
+\begin{definition}[Interior-bond region insert]%
+    \label{def:peps_interior_bond_inserted_region_insert}
+    \lean{TNLean.PEPS.interiorBondInsertedRegionInsert}
+    \leanok
+    \uses{def:peps_bond_inserted_region_insert, def:peps_corner_extension}
+    Let $e=\{u,w\}$ be an ordered edge whose two endpoints lie in a region
+    $R$, with $u$ its ordered left endpoint, and let
+    $X\in\MN{D_A(e)}$.  Write $U=\{u\}$ and let $I_{A,U,e,X}$ be the
+    boundary-bond insert on $U$.  The interior-bond insert on $R$ is
+    \begin{align}
+        I^{\mathrm{int}}_{A,R,e,X}
+         & =
+        \frac{P_A(R)}{P_A(U)}
+        \Ext_{U\subseteq R}(I_{A,U,e,X}).
+        \notag
+    \end{align}
+    Thus the genuine tensors at the vertices of $R\setminus U$ are adjoined
+    to a boundary insertion of $X$ on $e$, with the normalization changed
+    from the non-boundary bond product of $U$ to that of $R$.
+\end{definition}
+
+\begin{theorem}[Closed state of an interior-bond insert]%
+    \label{thm:peps_interior_bond_inserted_state}
+    \lean{TNLean.PEPS.deformedRegionStateAssembled_interiorBondInserted_eq_smul_edgeInsertedCoeff}
+    \leanok
+    \uses{def:peps_interior_bond_inserted_region_insert, thm:peps_corner_extension_state_preserves, thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
+    Suppose all bond dimensions are positive.  For every global physical
+    configuration $\omega$,
+    \begin{align}
+        \Psi^{\mathrm{as}}_{A,R,I^{\mathrm{int}}_{A,R,e,X}}(\omega)
+         & =P_A(R)E_A(e,\omega,X).
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    Corner extension preserves the closed state.  On the singleton $U$, the
+    boundary orientation is the identity because $U$ contains the ordered
+    left endpoint of $e$.  Hence its boundary insert has assembled state
+    $P_A(U)E_A(e,\omega,X)$.  The factor $P_A(R)/P_A(U)$ cancels $P_A(U)$
+    and gives the displayed identity.
+\end{proof}
+
+\begin{definition}[Staircase family for one virtual operation]%
+    \label{def:peps_staircase_virtual_operation_insert}
+    \lean{TNLean.PEPS.staircaseVirtualOperationInsert}
+    \leanok
+    \uses{def:peps_interior_bond_inserted_region_insert, lem:peps_reference_edge_left_endpoint_staircase_window, lem:peps_reference_edge_right_endpoint_staircase_window}
+    Let $e$ be the horizontal reference edge and let
+    $X\in\MN{D_B(e)}$.  Define an insert $C_j(X)$ on each staircase window
+    $W_j$, for $0\le j<L+K$, by
+    \begin{align}
+        C_j(X)
+         & =
+        \begin{cases}
+          I_{B,W_0,e,X^{\mathsf T}}, & j=0,\\
+          I^{\mathrm{int}}_{B,W_j,e,X}, & 1\le j<L,\\
+          I_{B,W_j,e,X}, & L\le j<L+K.
+        \end{cases}
+        \notag
+    \end{align}
+    The first window contains only the ordered right endpoint of $e$, the
+    middle windows contain both endpoints, and the remaining windows contain
+    only the ordered left endpoint.  The transpose in the first case makes
+    all three boundary orientations represent the same matrix $X$.
+\end{definition}
+
+\begin{lemma}[The two end inserts of the staircase family]%
+    \label{lem:peps_staircase_virtual_operation_end_inserts}
+    \lean{TNLean.PEPS.staircaseVirtualOperationInsert_zero}
+    \lean{TNLean.PEPS.staircaseVirtualOperationInsert_last}
+    \leanok
+    \uses{def:peps_staircase_virtual_operation_insert}
+    The end members of the family are
+    \begin{align}
+        C_0(X)&=I_{B,W_0,e,X^{\mathsf T}},
+        &
+        C_{L+K-1}(X)&=I_{B,W_{L+K-1},e,X}.
+        \notag
+    \end{align}
+\end{lemma}
+\begin{proof}
+    \leanok
+    The first identity is the $j=0$ case of the definition.  Since $K>0$,
+    the last index satisfies $L\le L+K-1$, which gives the second identity.
+\end{proof}
+
+\begin{theorem}[Common state of the staircase virtual-operation family]%
+    \label{thm:peps_staircase_virtual_operation_common_state}
+    \lean{TNLean.PEPS.deformedRegionStateAssembled_staircaseVirtualOperationInsert}
+    \leanok
+    \uses{def:peps_staircase_virtual_operation_insert, thm:peps_interior_bond_inserted_state, thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff, thm:peps_regionInteriorBondProd_staircaseWindow_eq}
+    Let $B$ be translation invariant and suppose all its bond dimensions are
+    positive.  Then for $0\le j<L+K$ and every global physical configuration
+    $\omega$,
+    \begin{align}
+        \Psi^{\mathrm{as}}_{B,W_j,C_j(X)}(\omega)
+         & =P_B(W_0)E_B(e,\omega,X).
+        \notag
+    \end{align}
+    In particular, all $L+K$ inserts have one common deformed state.
+\end{theorem}
+\begin{proof}
+    \leanok
+    On $W_0$, the boundary orientation sends $X^{\mathsf T}$ to $X$.
+    On $W_1,\ldots,W_{L-1}$, apply the interior-bond identity.  On the
+    remaining windows the ordered left endpoint lies in the window, so the
+    boundary orientation fixes $X$.  Each case gives
+    $P_B(W_j)E_B(e,\omega,X)$.  Translation invariance identifies
+    $P_B(W_j)$ with $P_B(W_0)$.
+\end{proof}
+
+\begin{theorem}[End-window identity for one virtual operation]%
+    \label{thm:peps_end_window_identity_staircase_virtual_operation}
+    \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
+    \leanok
+    \uses{lem:peps_staircase_virtual_operation_end_inserts, thm:peps_staircase_virtual_operation_common_state, thm:peps_regionInsertedCoeff_endWindows_eq_of_staircase}
+    Suppose the window-injectivity and union-closure hypotheses of the
+    single-bond peeling hold, the tensor is translation invariant, all bond
+    dimensions are positive, and the staircase satisfies the same size
+    bounds.  Then for every $X\in\MN{D_B(e)}$ and every global physical
+    configuration $\omega$,
+    \begin{align}
+        C_B(W_0,e,X^{\mathsf T};\omega|_{W_0},
+            \omega|_{V\setminus W_0})
+         & =
+        C_B(W_{L+K-1},e,X;\omega|_{W_{L+K-1}},
+            \omega|_{V\setminus W_{L+K-1}}).
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    Use the family $C_j(X)$.  Its end members are the required boundary
+    inserts and all members have the common state
+    $P_B(W_0)E_B(e,\cdot,X)$.  The single-bond peeling therefore gives the
+    stated coefficient identity.
+\end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -112,7 +112,9 @@ correspondence in the proof sketch of the two-dimensional corollary
     \lean{TNLean.PEPS.staircaseVirtualOperationPhysicalOp}
     \lean{TNLean.PEPS.staircaseVirtualOperationPhysicalOp_realizes}
     \leanok
-    \uses{def:peps_staircase_virtual_operation_insert, thm:peps_physical_operator_of_region_insert_realizes}
+    \uses{def:peps_staircase_virtual_operation_insert,
+        def:peps_physical_operator_of_region_insert,
+        thm:peps_physical_operator_of_region_insert_realizes}
     Suppose every $L\times K$ window is injective.  For every
     $0\leq j<L+K$, there is a physical operator $O_j(X)$ on the physical
     space of $W_j$ such that
@@ -154,7 +156,12 @@ correspondence in the proof sketch of the two-dimensional corollary
     \label{thm:peps_staircase_virtual_operation_common_state}
     \lean{TNLean.PEPS.deformedRegionStateAssembled_staircaseVirtualOperationInsert}
     \leanok
-    \uses{def:peps_staircase_virtual_operation_insert, thm:peps_interior_bond_inserted_state, thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff, thm:peps_regionInteriorBondProd_staircaseWindow_eq}
+    \uses{def:peps_staircase_virtual_operation_insert,
+        lem:peps_staircase_virtual_operation_end_inserts,
+        lem:peps_reference_edge_left_endpoint_staircase_window,
+        thm:peps_interior_bond_inserted_state,
+        thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff,
+        thm:peps_regionInteriorBondProd_staircaseWindow_eq}
     Let $B$ be translation invariant and suppose all its bond dimensions are
     positive.  Then for $0\le j<L+K$ and every global physical configuration
     $\omega$,
@@ -179,7 +186,10 @@ correspondence in the proof sketch of the two-dimensional corollary
     \label{thm:peps_end_window_identity_staircase_virtual_operation}
     \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
     \leanok
-    \uses{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff, thm:peps_regionInteriorBondProd_staircaseWindow_eq}
+    \uses{lem:peps_assembleRegionSigma_restrict,
+        lem:peps_reference_edge_left_endpoint_staircase_window,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff,
+        thm:peps_regionInteriorBondProd_staircaseWindow_eq}
     Suppose the tensor is translation invariant and the staircase satisfies
     the stated size bounds.  Then for every $X\in\MN{D_B(e)}$ and every
     global physical configuration $\omega$,

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -149,8 +149,8 @@ $D_{23} \times D_{23}$ object on the single bond.} and window injectivity is
 precisely the statement that these matrices span the full bond algebra, which
 is what makes the homomorphism extraction go through.
 
-In two dimensions the window straddling a bond no longer has this structure.
-An $L \times K$ window touches the reference edge $e$ with \emph{one}
+In two dimensions an end window used for the bond read-off no longer has this
+structure.  An end $L \times K$ window touches the reference edge $e$ with \emph{one}
 endpoint, so the leg of $e$ inside an end window is a single
 $\mathrm{Fin}(\mathrm{bondDim}\,e)$ index, not a pair; reading the window
 block at fixed external legs gives a \emph{vector} on
@@ -1489,7 +1489,7 @@ these products span the full matrix algebra at the single bond; the cross-bond
 pushing is then the intertwining-span read-off
 \leanid{exists\_bondOperator\_of\_intertwine\_span} (same file, line~74), and
 the homomorphism is \leanid{MPSChainTensor.exists\_insertionHom} fed by the
-same window span. The two-dimensional $L \times K$ window touches the
+same window span. The two-dimensional end $L \times K$ window touches the
 reference bond with \emph{one} endpoint, so its bond-restricted family is a
 family of \emph{vectors}, never a square-matrix span, and the window's whole
 perimeter is open. The one-dimensional mechanism that powered the precedent
@@ -1528,8 +1528,8 @@ this audit.
 This audit remains a valid obstruction to the indicated coarse-frame
 substitute, but that substitute is not needed for the common-state family.
 
-The open research content the previous subsection isolated --- whether a
-per-bond coarse frame exists at the minimal size for an intermediate bond,
+The question posed by the earlier analysis --- whether a per-bond coarse
+frame exists at the minimal size for an intermediate bond,
 where the partner block is a neighbouring window rather than the diagonally
 opposite one, or whether those crossings inherit the same
 $\mathrm{univ}\setminus S$-type non-injectivity --- is now settled, in the

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -107,10 +107,12 @@ equally be done with a virtual operation on the highlighted
 edge.''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321} and
 \path{Papers/1804.04964/paper_normal.tex:2368}.} The formalization separates
 the two directions of this correspondence.  The forward direction ---
-realizing a fixed virtual operation $X$ on every staircase window --- is now
-complete.  The converse, which must compare the two tensor families and
-recover the algebra homomorphism carried by $X$, is the remaining extraction
-problem.
+realizing a fixed virtual operation $X$ by a physical operator $O_j(X)$ on
+every staircase window --- is now complete: the open-boundary identity
+$O_j(X)T_{B,W_j}(\mu)=C_j(X)(\mu)$ is proved for every virtual boundary
+configuration~$\mu$.  The converse, which must compare the two tensor
+families and recover the algebra homomorphism carried by $X$, is the
+remaining extraction problem.
 
 The sketch supplies this converse by the reduction ``we only need to prove a
 statement similar to Lemma~5''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321}.}
@@ -169,7 +171,8 @@ no such span.
 \medskip
 \noindent\textbf{Formalization verdict.} The published argument is explicitly
 a sketch.  The consecutive-window comparison, corner completion, and forward
-realization of one virtual operation on all windows are now formalized.  What
+open-boundary physical realization of one virtual operation on all windows are
+now formalized.  What
 remains is the cross-tensor converse and the homomorphism extraction
 corresponding to Lemma~5's maps $O_1\mapsto X$ and
 $O_3^{\mathsf T}\mapsto X$.  The failed single-window span above is an
@@ -227,6 +230,9 @@ and the now-uniform interior-bond rescaling
 common-state family
 (\leanid{TNLean.PEPS.interiorBondInsertedRegionInsert} and
 \leanid{TNLean.PEPS.staircaseVirtualOperationInsert}), together with its
+open-boundary physical operators
+(\leanid{TNLean.PEPS.physicalOpOfRegionInsert} and
+\leanid{TNLean.PEPS.staircaseVirtualOperationPhysicalOp\_realizes}), and its
 end-window coefficient identity
 \leanid{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
 (\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean} and
@@ -242,7 +248,9 @@ remaining gate is the cross-tensor transfer and its multiplicativity.
 The same-tensor operation family is no longer missing.  For a fixed matrix
 $X$ on $e$, the first window carries $X^{\mathsf T}$, the windows
 $W_1,\ldots,W_{L-1}$ carry the interior-bond insert of $X$, and the remaining
-windows carry the boundary insert of $X$.  All have common state
+windows carry the boundary insert of $X$.  Window injectivity defines
+$O_j(X)$ and proves $O_j(X)T_{B,W_j}(\mu)=C_j(X)(\mu)$ before complementary
+contraction; all these inserts also have common closed state
 $P_B(W_0)E_B(e,\cdot,X)$.  The outstanding input is instead the cross-tensor
 coefficient transfer between $A$ and $B$ and its multiplicativity
 \leanid{hmul}, the two-dimensional counterpart of Lemma~5's algebra
@@ -306,8 +314,9 @@ corollary is false or that no source-faithful proof exists.
 \paragraph{5. Reading the source faithfully.}
 The paper keeps one highlighted edge fixed and compares physical operations
 on overlapping regions; it does not introduce a chain of different bonds or
-a single-window square-matrix span.  The forward correspondence and its
-transpose convention now follow this description literally.  The remaining
+a single-window square-matrix span.  The forward correspondence, its
+open-boundary physical operators, and its transpose convention now follow
+this description literally.  The remaining
 formal work is to expand the sketch's converse comparison far enough to obtain
 the cross-tensor homomorphism, using Lemma~5's $O_1$ and
 $O_3^{\mathsf T}$ notation and composition argument.
@@ -1332,9 +1341,15 @@ interior construction
 \leanid{TNLean.PEPS.interiorBondInsertedRegionInsert}
 (\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean}) starts from the ordered left
 endpoint and adjoins the genuine tensors of the window by corner extension.  This formalizes
-the forward realization asserted at lines 2320--2321 and uses the same adjoining contraction
-that appears in the end-region comparison at lines 2415--2444.  Its assembled state is the
-window's non-boundary bond product times $\mathrm{edgeInsertedCoeff}(e,M)$.  Translation
+the virtual insert asserted at lines 2320--2321 and uses the same adjoining contraction
+that appears in the end-region comparison at lines 2415--2444.  The physical operator itself is
+\leanid{TNLean.PEPS.staircaseVirtualOperationPhysicalOp}: it is the prescribed insert
+linear combination composed with a left inverse of the injective window block.  The theorem
+\leanid{TNLean.PEPS.staircaseVirtualOperationPhysicalOp\_realizes} proves the source's
+open-boundary statement
+$O_j(M)T_{B,W_j}(\mu)=C_j(M)(\mu)$ for every~$\mu$, before complementary contraction.
+The insert's assembled state is the window's non-boundary bond product times
+$\mathrm{edgeInsertedCoeff}(e,M)$.  Translation
 invariance makes that product uniform over the staircase, proving one common deformed
 state for all $L+K$ inserts.
 
@@ -1342,7 +1357,9 @@ Consequently
 \leanid{TNLean.PEPS.regionInsertedCoeff\_endWindows\_eq\_staircaseVirtualOperation}
 supplies the source-faithful single-tensor identity between the first-window insertion of
 $M^{\mathsf T}$ and the last-window insertion of $M$.  This closes the common-state-family
-residual.  It does not by itself construct the cross-tensor transfer from $A$ to $B$ or
+residual.  This end-window coefficient identity follows directly from the two region-to-edge
+identities and translation invariance; it needs neither complement inversion nor a peeling
+hypothesis.  It does not by itself construct the cross-tensor transfer from $A$ to $B$ or
 prove that transfer multiplicative; those are the remaining Lemma~5-style comparison
 steps.
 

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -93,7 +93,7 @@ in \path{TNLean/PEPS/CycleMPSChainOverlapCapstone.lean}.} which delivers
 the one-dimensional Fundamental Theorem at $n \geq 2L+1$ in place of the
 three-block bound $n \geq 3L$.
 
-\subsection{What the sketch asserts, and where the Lemma~5 analogy fails}
+\subsection{What the sketch asserts, and what remains to be extracted}
 
 The sketch is explicitly labelled ``Sketch of
 proof''\footnote{\path{Papers/1804.04964/paper_normal.tex:2320}.} and its
@@ -105,10 +105,12 @@ conversely ``any [\,$L+K$\,] physical operators on the above regions that
 transforms the PEPS into the same state means that the transformation can
 equally be done with a virtual operation on the highlighted
 edge.''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321} and
-\path{Papers/1804.04964/paper_normal.tex:2368}.} This converse is exactly the
-cross-bond-pushing the formalization isolates as its one residual: from a
-common state on the window chain, recover a single matrix $X$ on the edge
-together with the two factorizations through the end windows.
+\path{Papers/1804.04964/paper_normal.tex:2368}.} The formalization separates
+the two directions of this correspondence.  The forward direction ---
+realizing a fixed virtual operation $X$ on every staircase window --- is now
+complete.  The converse, which must compare the two tensor families and
+recover the algebra homomorphism carried by $X$, is the remaining extraction
+problem.
 
 The sketch supplies this converse by the reduction ``we only need to prove a
 statement similar to Lemma~5''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321}.}
@@ -157,24 +159,21 @@ windows, one from each; no single window supplies a square-matrix family, and
 folding a window's external perimeter into a second
 $\mathrm{Fin}(\mathrm{bondDim}\,e)$ index would require
 $\prod_{\text{external legs}}\mathrm{bondDim} = \mathrm{bondDim}\,e$, false in
-general. So the structural fact that powers the closing move of Lemma~5 --- a
-window product is a square matrix on the pushed bond --- is absent for the
-non-square $L \times K$ window, and the reduction ``similar to Lemma~5'' does
-not carry the extraction of $X$ in two dimensions. The sketch glosses this
-dimensional gap.
+general.  Thus a direct port of the one-dimensional single-window matrix-span
+proof is not available.  This rules out that particular proof path; it does
+not show that the paper's overlapping-window comparison is false.  In
+particular, it must not be conflated with the forward virtual-operation
+family, which keeps the same distinguished edge $e$ throughout and requires
+no such span.
 
 \medskip
-\noindent\textbf{Source-rigor verdict.} The published corollary proof is a
-sketch. Its consecutive-window agreement and corner-completion steps are
-rigorous and transfer to two dimensions; its final extraction of the single
-edge matrix $X$ is asserted by analogy to Lemma~5, and that analogy fails
-because the square-window geometry Lemma~5's closing read-off relies on is not
-present for a two-dimensional $L \times K$ window. The sketch therefore does
-not rigorously establish the corollary from $L \times K$-region injectivity at
-the minimal size: the cross-bond-pushing correspondence it asserts is the one
-step it does not derive. This is a faithfulness/correctness finding about the
-published sketch; it is not a defect in the formalization, which captures the
-source's hypothesis set exactly (see the faithfulness verdict below).
+\noindent\textbf{Formalization verdict.} The published argument is explicitly
+a sketch.  The consecutive-window comparison, corner completion, and forward
+realization of one virtual operation on all windows are now formalized.  What
+remains is the cross-tensor converse and the homomorphism extraction
+corresponding to Lemma~5's maps $O_1\mapsto X$ and
+$O_3^{\mathsf T}\mapsto X$.  The failed single-window span above is an
+invented auxiliary route, not a statement made or required by the paper.
 
 \section{Consolidated account}
 
@@ -224,27 +223,37 @@ the Skolem--Noether read-off
 and the now-uniform interior-bond rescaling
 \leanid{TNLean.PEPS.regionInteriorBondProd_staircaseWindow_eq}
 (\path{TNLean/PEPS/TorusWindowBondTransport.lean},
-\path{TorusWindowBondUniform.lean}); and the back-half assembly that re-anchors
+\path{TorusWindowBondUniform.lean}); the interior-bond insert and the complete
+common-state family
+(\leanid{TNLean.PEPS.interiorBondInsertedRegionInsert} and
+\leanid{TNLean.PEPS.staircaseVirtualOperationInsert}), together with its
+end-window coefficient identity
+\leanid{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
+(\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean} and
+\path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}); and the back-half
+assembly that re-anchors
 the torus Theorem~3 layers to the $(L+1) \times (K+1)$ comparison pair. Every
 inverted region is a union of one-orientation $L \times K$ window translates,
 host-decomposable at $n \geq 2L+1$, $m \geq 2K+1$. The development is
-minimal-size-ready and gated on one input alone.
+minimal-size-ready through the single-tensor virtual-operation family.  The
+remaining gate is the cross-tensor transfer and its multiplicativity.
 
-\paragraph{3. The irreducible obstruction.}
-The one missing input is the forward-transfer multiplicativity
-\leanid{hmul} at the reference edge: the homomorphism
-$M \cdot M' \mapsto (\text{transfer of }M)\,(\text{transfer of }M')$. This is
-the cross-bond-pushing of Part~1 --- the realization of one virtual operation
-$M$ on $e$ as a coherent physical operation on every window of the chain,
-composed across the chain. Reading it off requires either single-vertex
-injectivity at the edge endpoint
-(\leanid{TNLean.PEPS.span_stateOpenCoeff_eq_top}, from
-\leanid{TNLean.PEPS.IsVertexInjective}) or a coherent three-block coarse frame
-around the bond
-(\leanid{TNLean.PEPS.coeffTransferMap_mul_of_coherentFrames}).
+\paragraph{3. The remaining cross-tensor extraction.}
+The same-tensor operation family is no longer missing.  For a fixed matrix
+$X$ on $e$, the first window carries $X^{\mathsf T}$, the windows
+$W_1,\ldots,W_{L-1}$ carry the interior-bond insert of $X$, and the remaining
+windows carry the boundary insert of $X$.  All have common state
+$P_B(W_0)E_B(e,\cdot,X)$.  The outstanding input is instead the cross-tensor
+coefficient transfer between $A$ and $B$ and its multiplicativity
+\leanid{hmul}, the two-dimensional counterpart of Lemma~5's algebra
+homomorphisms.  Existing single-window and coarse-three-site attempts do not
+derive that input at the minimal size; a source-faithful extraction must use
+the actual overlapping-window comparison rather than assume a matrix span.
 
-\paragraph{4. Every closing route is machine-checked impossible at the
-minimal size.}
+\paragraph{4. Auxiliary closing routes ruled out at the minimal size.}
+The following findings rule out particular substitutes for the paper's
+overlapping-window argument.  They do not constitute a proof that the source
+corollary is false or that no source-faithful proof exists.
 \begin{itemize}
   \item \emph{Single-vertex injectivity is unavailable.} Normality is by
     definition \emph{weaker} than single-vertex injectivity: a normal tensor
@@ -276,12 +285,12 @@ minimal size.}
     (\leanid{TNLean.PEPS.horizontalStaircasePair_ne_arcRectangle}). This is a
     joint unsatisfiability, settled combinatorially in
     \path{TNLean/PEPS/TorusWindowSingleCrossingObstruction.lean}.
-  \item \emph{Translation invariance dissolves only the rescaling
-    sub-wall.} The corollary's torus translation invariance equalizes the
-    per-step interior-bond rescalings
-    (\leanid{TNLean.PEPS.regionInteriorBondProd_staircaseWindow_eq}), removing
-    the sub-obstruction the plane setting could not, but it does not supply the
-    cross-bond pushing.
+  \item \emph{Translation invariance supplies the common normalization.}
+    The corollary's torus translation invariance equalizes the non-boundary
+    bond products of all staircase windows
+    (\leanid{TNLean.PEPS.regionInteriorBondProd_staircaseWindow_eq}).  Together
+    with the interior-bond insert, this completes the common-state family; it
+    does not by itself compare the two tensor families.
   \item \emph{The row-and-column one-dimensional reduction fails.} Treating
     each row as one coarse site and applying the one-dimensional theorem
     row-wise and column-wise cannot reach the per-edge conclusion: a
@@ -294,23 +303,20 @@ minimal size.}
     \path{TNLean/PEPS/TorusRowColumnReductionObstruction.lean}).
 \end{itemize}
 
-\paragraph{5. The source-rigor verdict.}
-The published corollary proof is a sketch that asserts the cross-bond-pushing
-correspondence by analogy to Lemma~5; that analogy fails dimensionally,
-because the square-window geometry Lemma~5's closing read-off relies on is
-absent for the non-square two-dimensional window (Part~1 above). The sketch's
-consecutive-window agreement and corner completion are rigorous; the
-extraction of the single edge matrix is the step it asserts without
-derivation.
+\paragraph{5. Reading the source faithfully.}
+The paper keeps one highlighted edge fixed and compares physical operations
+on overlapping regions; it does not introduce a chain of different bonds or
+a single-window square-matrix span.  The forward correspondence and its
+transpose convention now follow this description literally.  The remaining
+formal work is to expand the sketch's converse comparison far enough to obtain
+the cross-tensor homomorphism, using Lemma~5's $O_1$ and
+$O_3^{\mathsf T}$ notation and composition argument.
 
 \paragraph{6. Status.}
-The corollary remains \emph{unformalized}: no blueprint entry
-claims it, it carries the \texttt{notready} marker, and no \texttt{leanok}
-marks it. It is not closeable from its stated
-hypotheses by any route rigorously explored here. Closing it would require
-either a new mathematical idea evading the machine-checked impossibilities
-above, or the source supplying the missing cross-bond-pushing argument that
-its sketch only asserts.
+The corollary remains \emph{unformalized}: no blueprint entry claims it, it
+carries the \texttt{notready} marker, and no \texttt{leanok} marks it.  The
+same-tensor family requested in issue~\#2780 is complete; the remaining work
+is the cross-tensor transfer and homomorphism extraction tracked separately.
 
 \section{The filled-in derivation}
 
@@ -341,10 +347,17 @@ vertical edge the construction is transposed in the roles of the two
 axes with the same $L \times K$ window shape: $K+1$ vertical slides
 followed by $L-1$ horizontal ones.
 
-A virtual operation $M$ on the bond $e$ is realized as a deformation of
-any single window containing an endpoint of $e$: invert the injective
-window tensor and recontract with $M$ inserted on the bond. The
-two-dimensional analogue of Lemma~5 is the converse. Suppose each
+A virtual operation $X$ on the bond $e$ is represented on every window by
+keeping the same distinguished edge fixed.  The first window, which contains
+only the ordered right endpoint, carries the boundary insert of
+$X^{\mathsf T}$; the windows $W_1,\dots,W_{L-1}$ carry the interior-bond
+insert obtained by adjoining their genuine tensors to a one-endpoint insert;
+and the remaining windows carry the boundary insert of $X$.  Translation
+invariance identifies the non-boundary bond products, so all these inserts
+produce the common state $P_A(W_0)E_A(e,\cdot,X)$.  This is formalized in
+\path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}.
+
+The two-dimensional analogue of Lemma~5 also has a converse. Suppose each
 window $W_j$ carries a deformed tensor $C_j$ (an arbitrary tensor with
 the boundary structure of $W_j$) and all the deformed states agree:
 replacing $T_{W_j}$ by $C_j$ in the torus contraction yields one common
@@ -1164,15 +1177,17 @@ What remains is therefore exactly the staircase \emph{coefficient transfer} on t
 window: for each inserted matrix $M$ on $A$'s edge $e$ a matching matrix $N$ on $B$ with
 equal window coefficient
 ($\text{\path{htransferAB}}$), its reverse ($\text{\path{htransferBA}}$), and the multiplicativity of
-the chosen forward transfer ($\text{\path{hmul}}$).  Two pieces feed the transfer.  First, the
-bond-inserted \emph{family} the single-bond peeling consumes: an insert on every
-staircase window all sharing one deformed state, with the two end windows carrying the
-bond-inserted inserts of $M$ and $M'$.  For the windows containing both endpoints of $e$
-the bond is interior, so the insert is the $M$-on-interior-bond deformation of the
-genuine block, and the common state is the closed torus state with $M$ inserted on $e$
---- the ``a virtual operation on a given bond is a physical operation on any window
-containing an endpoint'' correspondence of the sketch, not yet built as an insert family.
-Second, the cross-tensor multiplicative transfer: the homomorphism the rectangle route
+the chosen forward transfer ($\text{\path{hmul}}$).  The same-tensor family that feeds the
+single-bond peeling is now complete.  The first window carries the boundary insert of
+$M^{\mathsf T}$, the windows $W_1,\ldots,W_{L-1}$ carry the interior-bond insert of $M$,
+and the remaining windows carry the boundary insert of $M$.  Their common state is the
+closed torus state with $M$ inserted on the same edge $e$, with the common
+non-boundary-bond factor supplied by translation invariance.  The construction and its
+end-window identity are
+$\text{\path{staircaseVirtualOperationInsert}}$ and
+$\text{\path{regionInsertedCoeff\_endWindows\_eq\_staircaseVirtualOperation}}$.
+
+The residual is the cross-tensor multiplicative transfer: the homomorphism the rectangle route
 reads from the physical realization of the inserted operator.  The region-level recovery
 $\text{\path{regionInsertionTransfer\_of\_realizes}}$ derives all three transfer fields ---
 $\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and $\text{\path{hmul}}$ --- from one region
@@ -1270,23 +1285,13 @@ side ($\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and the whole re
 algebra) \emph{is} powered by window and single-window-complement injectivity, both
 available at the minimal size; only the homomorphism is not.
 
-The block-level construction the staircase must supply is therefore precisely a
-coarse blocking frame around $e$ whose three regions are all injective at the minimal
-size and whose red-to-blue crossing is the singleton $\{e\}$ --- equivalently, a
-coefficient transfer on the window that is \emph{independently} known to be
-multiplicative, since the multiplicativity is the homomorphism of the physical
-insertion operator and no single-window read-off makes it one. The source's sketched
-overlapping-window realization is that the same virtual operation $M$ on $e$ is a
-physical operation on \emph{every} window of the staircase chain, all sharing one
-deformed state; the chain of consecutive-window inversions (landed at the
-state-equality level as $\text{\path{staircasePair\_insert\_eq\_open}}$, never inverting
-$\mathrm{univ}\setminus S$) transports $M$ around the corner, and the homomorphism
-$M\cdot M' \mapsto$ (transfer of $M$)\,(transfer of $M'$) is read from the composition
-of two such transports across the chain, not from any one window's block. Building
-that insert-family transport --- the ``a virtual operation on a given bond is a
-physical operation on any window containing an endpoint'' correspondence as an actual
-insert family with the composition law --- is the residual, and it is a
-\emph{block-level} (insert-family-and-chain) construction, not a single-window span.
+The source's sketched overlapping-window realization keeps the same virtual operation
+$M$ on $e$ while representing it on every staircase window.  That common-state family
+is now built below.  It closes the single-operation part of this discussion but not the
+cross-tensor homomorphism: the remaining task is to compare the two tensor families and
+show that the resulting coefficient transfer respects products, following Lemma~5's
+composition of the maps from $O_1$ and $O_3^{\mathsf T}$ rather than a single-window
+span or an assumed coarse frame.
 
 \subsection{The foundation that lands}
 
@@ -1302,107 +1307,55 @@ only the coefficient transfer can obtain the multiplicativity from a frame. It m
 the verdict auditable in Lean: the window route's $\text{\path{hmul}}$ is one application of
 this theorem with $\mathrm{red}=W$, and the unmet hypothesis is exactly the frame's
 $\text{\path{complement\_injective}}$ at $\mathrm{univ}\setminus S$, the documented
-obstruction. The remaining work is the insert-family transport that produces a
-multiplicative window coefficient transfer without a single-window red-block frame.
+obstruction.  This theorem remains available for any future coherent frame, but the
+fixed-edge common-state family below does not require such a frame.  The remaining work
+is the cross-tensor multiplicativity argument.
 
-\subsection{The per-step bond-insert transport, and where the chain composition
-walls}
+\subsection{The common-state family is complete}
 
-The insert-family transport called for above factors into per-step transports between
-\emph{consecutive} windows, and the single load-bearing per-step transport is now built:
-\leanid{TNLean.PEPS.horizontalStaircaseConsecutiveWindow\_bondTransport\_extend\_eq}
-(\path{TNLean/PEPS/TorusWindowBondTransport.lean}). For a sliding-arm index $j < L$, given
-the consecutive windows $W_j$ and $W_{j+1}$ sharing a bond $g$ as a boundary edge and
-inserted matrices $M_1, M_2$ on $g$ whose orientations through the two windows agree, the
-corner-extended bond inserts on the injective overlap $U_j = W_j \cup W_{j+1}$ are equal.
-The window-independence of the bond insertion
-(\leanid{TNLean.PEPS.bondInserted\_windowIndependent}) makes the two inserts'
-deformed states cross-proportional --- the interior-bond product of one window times the
-state of the other matches the swapped product --- and rescaling each by the \emph{other}
-window's interior-bond product turns that cross-proportionality into an honest equality of
-states, which the consecutive-window comparison
-(\leanid{TNLean.PEPS.horizontalStaircaseConsecutiveWindow\_extend\_eq}) strips to the
-open-boundary equality on $U_j$ by inverting the injective $(L+1)\times K$ rectangle, never
-$\mathrm{univ}\setminus S$. This is the genuine per-step transport through the injective
-overlap.
+The earlier analysis incorrectly claimed that the intermediate staircase windows contain
+neither endpoint of the reference edge and therefore require transport across different
+bonds.  The machine-checked endpoint classification gives the opposite conclusion:
+$W_1,\ldots,W_{L-1}$ contain both endpoints of $e$, while
+$W_L,\ldots,W_{L+K-1}$ contain its ordered left endpoint.  Every window in the source's
+family therefore contains at least one endpoint of the same distinguished edge $e$.
 
-Two facts pin where the chain composition stops short of the multiplicativity. First, the
-\emph{telescoping engine itself exists}: the patch chaining
-\leanid{TNLean.PEPS.staircasePatch\_insert\_eq} already composes per-step equalities into
-one comparison of the two end windows on the patch, and the end-pair peeling
-\leanid{TNLean.PEPS.regionInsertedCoeff\_endWindows\_eq\_of\_staircase} reads that off as the
-single-tensor relation $\text{\path{regionInsertedCoeff}}(W_0, M) = \text{\path{regionInsertedCoeff}}
-(W_{L+K-1}, M')$. So the chain composition delivers the \emph{single-operation}
-window-independence, end to end, with the injective overlaps mediating.
+The missing family is now
+\leanid{TNLean.PEPS.staircaseVirtualOperationInsert}
+(\path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}).  It uses the boundary insert
+of $M^{\mathsf T}$ on $W_0$, the interior-bond insert of $M$ on
+$W_1,\ldots,W_{L-1}$, and the boundary insert of $M$ on the remaining windows.  The
+interior construction
+\leanid{TNLean.PEPS.interiorBondInsertedRegionInsert}
+(\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean}) starts from the ordered left
+endpoint and adjoins the genuine tensors of the window by corner extension.  This formalizes
+the forward realization asserted at lines 2320--2321 and uses the same adjoining contraction
+that appears in the end-region comparison at lines 2415--2444.  Its assembled state is the
+window's non-boundary bond product times $\mathrm{edgeInsertedCoeff}(e,M)$.  Translation
+invariance makes that product uniform over the staircase, proving one common deformed
+state for all $L+K$ inserts.
 
-Second, that engine consumes a family of inserts on \emph{all} $L+K$ windows
-\emph{sharing one common deformed state}, with the two end inserts the bond inserts of $M$
-and $M'$. The per-step transport does not assemble such a family. Two sub-obstructions sit
-here, and they have different status under the corollary's hypotheses.
+Consequently
+\leanid{TNLean.PEPS.regionInsertedCoeff\_endWindows\_eq\_staircaseVirtualOperation}
+supplies the source-faithful single-tensor identity between the first-window insertion of
+$M^{\mathsf T}$ and the last-window insertion of $M$.  This closes the common-state-family
+residual.  It does not by itself construct the cross-tensor transfer from $A$ to $B$ or
+prove that transfer multiplicative; those are the remaining Lemma~5-style comparison
+steps.
 
-\emph{The interior-bond rescaling is uniform under the corollary's translation invariance.}
-The per-step transport agrees the two scaled inserts only up to the
-\emph{neighbour-dependent} interior-bond rescaling: step $j$ scales by $\mathrm{ribp}(W_{j+1})$
-on the left and $\mathrm{ribp}(W_j)$ on the right, and a telescoping to one common state needs
-all the interior-bond products equal. The corollary is the strengthening of the \emph{torus}
-Theorem~3, whose tensors are translation invariant, and the two end windows are diagonally
-offset $L\times K$ translates of one another --- indeed every staircase window is a translate
-of every other. So the interior-bond products are all equal:
-\leanid{TNLean.PEPS.regionInteriorBondProd\_staircaseWindow\_eq}
-(\path{TNLean/PEPS/TorusWindowBondUniform.lean}) derives this from the bond-dimension
-invariance of a translation-invariant tensor under translation
-(\leanid{TNLean.PEPS.bondDim\_translateEdge\_of\_translationInvariant}) reindexing the
-interior-bond product (\leanid{TNLean.PEPS.regionInteriorBondProd\_map}). With the products
-uniform the per-step rescalings agree across the chain, and this sub-obstruction --- the one
-the normal-PEPS \emph{plane} setting could not dissolve --- is removed by the corollary's
-translation invariance.
-
-\emph{The cross-bond pushing on the intermediate windows is the genuine residual.} The bond
-$e$ is a boundary edge of only the two end windows; the intermediate windows touch neither
-endpoint of $e$, so a bond insert of $M$ on them is not even typed. Consecutive windows
-$W_j$, $W_{j+1}$ share a bond $g_j$ \emph{other} than $e$, and the per-step transport relates
-a bond insert on $g_j$ in $W_j$ to one on the \emph{same} $g_j$ in $W_{j+1}$. But a window
-$W_j$ shares the bond $g_{j-1}$ with its left neighbour and the \emph{different} bond $g_j$
-with its right neighbour, so chaining the two incident per-step transports through one insert
-$C_j$ requires that $C_j$ realize the operation on $g_{j-1}$ and on $g_j$ simultaneously ---
-i.e. that the closed-state deformation $\mathrm{edgeInsertedCoeff}(g_{j-1}, M)$ equals
-$\mathrm{edgeInsertedCoeff}(g_j, M')$ for a matched $M'$. That is the two-dimensional
-bond-operator pushing: inverting the injective window $W_j$ to read $M$'s physical action off
-one boundary bond and re-express it on another. The deformed window tensor realizing this is
-the residual the per-step transport does not supply.
-
-This is exactly the unbuilt construction: the two-dimensional bond-operator extraction that
-builds, from one virtual operation $M$ on $e$, the common-state family of deformed window
-tensors on all $L+K$ windows --- the matrix-tensor analogue of
-\leanid{MPSChainTensor.overlapWindow\_exists\_bondOperator}. Its missing ingredient is the
-window-inversion that pushes the operation across distinct boundary bonds, and that inversion
-reads $M$'s action off the in-region endpoint of the boundary bond, which is the endpoint
-spanning \leanid{TNLean.PEPS.span\_stateOpenCoeff\_eq\_top} --- available from
-\emph{single-vertex} injectivity, not from region injectivity. With that family the end-pair
-peeling fires and the homomorphism $M \cdot M' \mapsto (\text{transfer of } M)\,(\text{transfer
-of } M')$ would be read from composing two transports as in
-\leanid{MPSChainTensor.exists\_insertionHom}, whose multiplicativity step
-($\text{\path{eq\_of\_span\_mul\_left}}$) consumes the same window-product span. The per-step transport
-and the now-uniform rescaling are the foundation of that extraction; the extraction itself ---
-the deformed-window-tensor family on the intermediate windows, requiring the endpoint span ---
-is the unbuilt block-level construction, and it is the same endpoint-spanning residual the
-coarse three-site route hits as the non-injective $\mathrm{univ}\setminus S$ at the minimal
-size. The translation invariance of the corollary removes the rescaling sub-obstruction but
-not this one.
-
-\section{Faithfulness verdict: normality is not a dropped hypothesis, and the
-obstruction is the source's own block-level pushing}
+\section{Normality audit and retired auxiliary routes}
 
 This section answers a hypothesis-faithfulness question raised against the
 campaign: the source corollary assumes \emph{normal} 2D PEPS tensors
 \emph{such that every $L \times K$ region is injective}, and a reading of the
 campaign suspected that ``normal'' is a second, stronger hypothesis the
-campaign's window-injectivity bundle dropped --- one that would supply the
-single-vertex endpoint spanning the cross-bond pushing wants, and so unblock
-the corollary. The verdict is that this reading is incorrect on the
-mathematics. Normality is not a separate stronger hypothesis here; the
-campaign faithfully captured the source's hypothesis set; and the obstruction
-recorded above is genuine, not an artifact of a weakened hypothesis.
+campaign's window-injectivity bundle dropped.  The normality audit below
+remains valid: normality is not a separate stronger hypothesis here, and the
+formalization captures the source's hypothesis set.  The subsequent
+cross-bond and per-bond-coarse-frame discussions are retained only as audits
+of discarded auxiliary routes.  They were based on the false premise that
+intermediate staircase windows contain neither endpoint of the reference
+edge, and are superseded by the common-state construction above.
 
 \subsection{What ``normal'' means in the source, and why it is not stronger
 than region injectivity}
@@ -1471,14 +1424,18 @@ machinery already exploits exactly this:
 forward-transfer multiplicativity from three blocked-region injectivities
 \emph{with no single-vertex injectivity}, the super-vertex injectivity
 standing in for the single-vertex spanning. So the campaign does have a
-coarse substitute for the endpoint span; the question is only whether it is
-available for the regions the corollary's cross-bond pushing needs, at the
-minimal size.
+coarse multiplicativity theorem when such a frame is available.  It is not
+needed for the forward fixed-edge family; whether it participates in the
+remaining cross-tensor extraction is a separate question.
 
-\subsection{Why the coarse substitute does not reach the intermediate windows,
-and why the one-dimensional precedent does not port}
+\subsection{Retired route: a coarse substitute on different boundary bonds}
 
-The cross-bond pushing on an intermediate window $W_j$ must read the inserted
+This subsection records an auxiliary route that is no longer part of the
+formalization plan.  The staircase family does not need to move the operation
+between the bonds denoted below by $g_{j-1}$ and $g_j$; it keeps the same
+reference edge $e$ in every window.
+
+The discarded route proposed that an intermediate window $W_j$ read the inserted
 operation off the in-region endpoint of one boundary bond $g_{j-1}$ and
 re-express it on a \emph{different} boundary bond $g_j$ of the same window.
 Blocking $W_j$ to one super-vertex does make $g_{j-1}$ and $g_j$ two legs of
@@ -1524,7 +1481,10 @@ that ``the two-dimensional analogue does not exist'' is therefore correct and
 not a mis-analysis: it is the absence of the square-window geometry, not the
 absence of a normality hypothesis.
 
-\subsection{Verdict and the precise route}
+\subsection{Retired verdict for the different-bond route}
+
+The verdict in this subsection concerns only the discarded construction just
+described.  It is not the current verdict on the paper's fixed-edge argument.
 
 The verdict, sharpened by the
 hypothesis audit, is that the obstruction is not removable by adding a
@@ -1570,8 +1530,10 @@ landed foundation; the per-bond coarse frame for the simultaneous two-bond
 realization is the unbuilt block-level construction. No hypothesis change to
 the capstone is warranted by this audit.
 
-\subsection{The per-bond coarse frame does not exist at the minimal size, for
-any single-crossing window pair}
+\subsection{Retired audit: per-bond coarse frames at the minimal size}
+
+This audit remains a valid obstruction to the indicated coarse-frame
+substitute, but that substitute is not needed for the common-state family.
 
 The open research content the previous subsection isolated --- whether a
 per-bond coarse frame exists at the minimal size for an intermediate bond,
@@ -1630,10 +1592,9 @@ not help either, since a cyclic rectangle admits no bipartition into two regions
 each injective (each containing an $L\times K$ window) with a single edge between
 them: the rectangle is two-edge-connected, so any bipartition into two
 non-degenerate parts has at least two crossing edges. The per-bond coarse frame
-is therefore unbuildable at the minimal size for every bond of the chain, which
-confirms verdict \textbf{(b)} and redirects the residual to the insert-family
-chain transport of the previous subsection rather than to a per-bond coarse
-frame. The geometry is in
+is therefore unbuildable at the minimal size for every bond of the chain.  This
+rules out that auxiliary frame, but it no longer redirects the formalization:
+the fixed-edge insert family is complete.  The geometry is in
 \path{TNLean/PEPS/TorusWindowSingleCrossingObstruction.lean}.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -699,12 +699,12 @@ unions, all of which decompose at $(2L+1)\times(2K+1)$.
 
 \section{Formalization plan}
 
-The geometry and state-equality layers of the derivation above are complete;
-the cross-bond-pushing multiplicativity is the irreducible obstruction
-identified in the consolidated account, and the layer list below should be
-read as the plan for everything \emph{except} that one input. The build is a
-campaign comparable to the landed three-block witness production, in
-independently landable layers:
+The geometry, state-equality, and forward fixed-edge-operation layers of the
+derivation above are complete.  The remaining source step is the converse at
+lines 2368--2444: from physical operations on the overlapping windows that
+produce one state, recover the virtual operation $X$ on the highlighted edge
+and prove the Lemma~5 maps from $O_1$ and $O_3^{\mathsf T}$ are algebra
+homomorphisms.  The layer list below records the campaign around that step:
 
 \begin{enumerate}
   \item \emph{Window geometry} (no tensors): the one-orientation
@@ -722,8 +722,11 @@ independently landable layers:
   \item \emph{Chaining and corner stripping}: extension of an
     open-boundary equality by contraction, and the completion-inversion
     step removing the corner block.
-  \item \emph{The single-crossing extraction} on the staircase pair,
-    reusing the existing single-boundary-edge comparison engine.
+  \item \emph{The Lemma~5 converse on the staircase}: compare the first and
+    last physical operations after adjoining the genuine corner tensors,
+    invert the resulting regions, recover the unique virtual operation $X$,
+    and prove the $O_1\mapsto X$ and $O_3^{\mathsf T}\mapsto X$
+    homomorphisms by composition.
   \item \emph{The per-edge witness}: the insertion correspondence and
     Skolem--Noether at one reference edge per orientation, producing
     the same coefficient-identity witness shape the landed translation
@@ -1486,49 +1489,22 @@ absence of a normality hypothesis.
 The verdict in this subsection concerns only the discarded construction just
 described.  It is not the current verdict on the paper's fixed-edge argument.
 
-The verdict, sharpened by the
-hypothesis audit, is that the obstruction is not removable by adding a
-hypothesis: \emph{the source genuinely needs region injectivity only,
-the campaign captured that hypothesis faithfully, and the obstruction is real
-and intrinsic to the source's own block-level pushing.} Normality is not the
-dropped hypothesis; there is nothing to add. The corollary's hypotheses are
-faithfully captured and admit no counterexample, but the source's sketch is
-\emph{not} a rigorous proof: as Part~1 records, it asserts the cross-bond
-pushing by a Lemma~5 analogy that fails dimensionally. That pushing is a
-\emph{block-level} construction, the two-dimensional analogue of the
-one-dimensional window inversion, and it is not a single-window span nor a
-single-vertex span. At the corollary's minimal size the natural
-coarse frame carrying it (red block the left end window, single-crossing
-partner the right end window) has third block $\mathrm{univ}\setminus S$, which
-is not injective; this is the documented wall, and it is a wall of the
-\emph{construction}, not of the hypotheses.
+The discarded route tried to move an operation between two different
+boundary bonds of one intermediate window.  A direct one-dimensional
+matrix-span argument does not type in that geometry, while the natural
+three-block replacement has the non-injective host described below.  These
+facts rule out that auxiliary construction under the corollary hypotheses;
+they do not identify a missing hypothesis of the paper or obstruct its
+fixed-edge comparison.
 
-The route to the corollary is therefore the one this note already prescribes,
-and it does \emph{not} involve adding a normality or single-vertex hypothesis.
-It is the deformed-window-tensor family on all $L+K$ windows sharing one common
-state, built so that each intermediate window $W_j$ carries the simultaneous
-realization of the operation on its two incident boundary bonds $g_{j-1}$ and
-$g_j$ --- the two-dimensional bond-operator extraction, the matrix-tensor
-analogue of \leanid{MPSChainTensor.overlapWindow\_exists\_bondOperator}. Its
-single missing ingredient is the window-inversion that pushes one operation
-across two distinct boundary bonds of one window. That ingredient is supplied
-not by single-vertex injectivity and not by window injectivity alone, but by a
-coarse blocking frame around \emph{each intermediate bond crossing} whose three
-regions are injective at the minimal size and whose single red-to-blue crossing
-is the relevant bond --- the same coarse-three-site mechanism
-(\leanid{coeffTransferMap\_mul\_of\_coherentFrames}) the back half already uses,
-applied per intermediate bond rather than at the end-pair crossing. The
-research content that remains is whether such a per-bond coarse frame exists at
-the minimal size for the intermediate bonds (where the partner block is a
-\emph{neighbouring} window, not the diagonally opposite one), or whether those
-crossings inherit the same $\mathrm{univ}\setminus S$-type non-injectivity. The
-per-step transport \leanid{TNLean.PEPS.horizontalStaircaseConsecutiveWindow\_%
-bondTransport\_extend\_eq} (\path{TNLean/PEPS/TorusWindowBondTransport.lean})
-and the now-uniform interior-bond rescaling
-(\leanid{TNLean.PEPS.regionInteriorBondProd\_staircaseWindow\_eq}) are the
-landed foundation; the per-bond coarse frame for the simultaneous two-bond
-realization is the unbuilt block-level construction. No hypothesis change to
-the capstone is warranted by this audit.
+The source keeps the highlighted edge $e$ fixed.  Every staircase window
+contains at least one endpoint of $e$, and the common-state family constructed
+above realizes the same $X$ on that edge throughout.  Thus no different-bond
+push or per-intermediate-bond coarse frame belongs to the remaining plan.  The
+remaining task is the converse comparison of the physical operations, with
+the corner adjoining and inversion at lines 2415--2444 and the composition
+argument of Lemma~5.  No hypothesis change to the capstone is warranted by
+this audit.
 
 \subsection{Retired audit: per-bond coarse frames at the minimal size}
 

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -1363,232 +1363,68 @@ hypothesis.  It does not by itself construct the cross-tensor transfer from $A$ 
 prove that transfer multiplicative; those are the remaining Lemma~5-style comparison
 steps.
 
-\section{Normality audit and retired auxiliary routes}
+\section{Normality and discarded stronger routes}
 
-This section answers a hypothesis-faithfulness question raised against the
-campaign: the source corollary assumes \emph{normal} 2D PEPS tensors
-\emph{such that every $L \times K$ region is injective}, and a reading of the
-campaign suspected that ``normal'' is a second, stronger hypothesis the
-campaign's window-injectivity bundle dropped.  The normality audit below
-remains valid: normality is not a separate stronger hypothesis here, and the
-formalization captures the source's hypothesis set.  The subsequent
-cross-bond and per-bond-coarse-frame discussions are retained only as audits
-of discarded auxiliary routes.  They were based on the false premise that
-intermediate staircase windows contain neither endpoint of the reference
-edge, and are superseded by the common-state construction above.
+The source calls a PEPS normal when blocking suitable regions produces an
+injective tensor.\footnote{\path{Papers/1804.04964/paper_normal.tex:1318}.}
+In the corollary under consideration, every $L\times K$ rectangle is assumed
+injective, so those rectangles themselves witness normality.  No
+single-vertex injectivity is asserted.  This distinction is essential:
+single-vertex injectivity is strictly stronger than injectivity after
+blocking, and therefore cannot be inserted into a formal statement of the
+corollary.
 
-\subsection{What ``normal'' means in the source, and why it is not stronger
-than region injectivity}
+The formal window hypothesis has exactly this content: every cyclic
+$L\times K$ window is injective as a map from its virtual boundary space to
+its physical space.\footnote{Formal declarations:
+\leanid{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses} and
+\leanid{TNLean.PEPS.RegionBlockedTensorInjective}.}  It neither assumes
+single-vertex injectivity nor omits a further normality condition from the
+source.
 
-The source defines normality as a region-blocking
-condition.\footnote{\path{Papers/1804.04964/paper_normal.tex:1318}: ``We call
-a PEPS \emph{normal}, if blocking tensors in certain regions results in
-injective tensors.''} A tensor (or region) is injective in the source's
-sense when, ``interpreted as a map from the virtual space to the physical
-one,'' it is
-injective.\footnote{\path{Papers/1804.04964/paper_normal.tex:980}.} The
-corollary's clause ``every $L \times K$ region is injective'' names the
-``certain regions'' of the normality definition: the $L \times K$ rectangles
-are the blocking regions that witness normality. So ``normal $\dots$ such
-that every $L \times K$ region is injective'' is not normality \emph{plus} a
-region condition; the region condition \emph{is} the operative content of
-normality for this corollary, exactly as the one-dimensional companion reads
-``normal $\dots$ with the property that blocking $L$ consecutive sites results
-in an injective
-tensor''\footnote{\path{Papers/1804.04964/paper_normal.tex:2258}; the same
-phrasing recurs at the $n \geq 3L$
-corollary, \path{Papers/1804.04964/paper_normal.tex:1664}.} --- there
-``blocking $L$ sites is injective'' is the witness and nothing single-site is
-assumed.
+Two stronger mechanisms available elsewhere in the development are therefore
+only conditional alternatives.  The first reads a bond operation from a
+single vertex and requires single-vertex injectivity.  The second proves
+multiplicativity from a coherent three-region blocking frame.\footnote{Formal
+declaration:
+\leanid{TNLean.PEPS.coeffTransferMap\_mul\_of\_coherentFrames}.}  Neither
+hypothesis occurs in the corollary, and neither is needed for the forward
+fixed-edge family proved above.
 
-Crucially, normality is by definition \emph{weaker} than single-vertex
-injectivity, not stronger. A normal tensor is precisely one that need
-\emph{not} be injective at a single site but \emph{becomes} injective after
-blocking; the canonical normal-but-not-injective examples (a single site whose
-physical dimension is below its bond dimension) have linearly dependent
-single-site components and so fail
-\leanid{TNLean.PEPS.IsVertexInjective}. Therefore normality cannot supply the
-single-vertex endpoint spanning \leanid{TNLean.PEPS.span_stateOpenCoeff_eq_top}
-(\path{TNLean/PEPS/RegionBlock/Recovery3.lean}), whose hypothesis is
-\leanid{TNLean.PEPS.IsVertexInjective}~$B$ at the in-region endpoint, derived
-from linear independence of the single-vertex complement family
-(\leanid{vertexComplementTensorInjective\_of\_isVertexInjective}). The
-hypothesised mechanism --- ``normality gives the single-vertex span region
-injectivity lacks'' --- asks normality to deliver a property strictly above
-itself.
+\subsection{Why the different-bond auxiliary route is irrelevant}
 
-\subsection{The campaign captured the source hypothesis faithfully}
+The paper keeps one highlighted edge $e$ fixed.  The first staircase window
+contains its ordered right endpoint, the next $L-1$ windows contain both
+endpoints, and the remaining windows contain its ordered left endpoint.
+Consequently, the same matrix $X$ can be represented on every window; there
+is no step in which an operation must be transported from one boundary bond
+to a different boundary bond of the same window.
 
-The campaign's bundle
-\leanid{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses}
-(\path{TNLean/PEPS/TorusWindowComplement.lean}, line~180) carries a single
-field, \leanid{arcWindow\_injective}: every cyclic $L \times K$ window is
-injective, where window injectivity is
-\leanid{TNLean.PEPS.RegionBlockedTensorInjective}
-(\path{TNLean/PEPS/RegionBlock/Basic.lean}, line~118), the linear independence
-of the $L \times K$-blocked tensor family read as a map from the window's
-boundary configuration to its physical configuration. This is the source's
-``$L \times K$ region is injective'' verbatim, and it is the \emph{whole} of
-the source's normality hypothesis for the corollary. The bundle adds no
-single-vertex field and drops no normality field: there is no source field to
-drop, because the source never assumes single-vertex injectivity. The
-faithfulness rule is satisfied --- the Lean hypothesis set neither exceeds nor
-falls short of the source's.
+Such a transport would in any case require information not contained in
+window injectivity.  A two-dimensional window is injective with respect to
+its whole multi-bond perimeter.  After all other boundary legs are fixed, its
+restriction to two selected bonds need not span a square matrix algebra.  The
+one-dimensional overlapping-window argument has no such difficulty because
+a chain window has exactly two virtual boundary legs, so its blocked tensors
+are already square matrices on the bond.
 
-A blocked $L \times K$ window read as one super-vertex has \emph{its} component
-map equal to \leanid{regionBlockedTensorFamily}, so window injectivity is the
-super-vertex injectivity of the coarse tensor. The coarse three-site
-machinery already exploits exactly this:
-\leanid{TNLean.PEPS.coeffTransferMap\_mul\_of\_coherentFrames}
-(\path{TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean}) derives the
-forward-transfer multiplicativity from three blocked-region injectivities
-\emph{with no single-vertex injectivity}, the super-vertex injectivity
-standing in for the single-vertex spanning. So the campaign does have a
-coarse multiplicativity theorem when such a frame is available.  It is not
-needed for the forward fixed-edge family; whether it participates in the
-remaining cross-tensor extraction is a separate question.
+The natural three-region substitute also lies outside the source route at the
+minimal size.  Two $L\times K$ windows with a single crossing edge form the
+diagonally offset staircase pair, whose union is not a cyclic rectangle.  On
+the shared row the complement has fewer than $L$ consecutive columns, so the
+window-union argument used elsewhere does not supply injectivity of the third
+region of a coherent frame.\footnote{Formal geometry:
+\leanid{TNLean.PEPS.horizontalStaircasePair\_ne\_arcRectangle} and
+\leanid{TNLean.PEPS.horizontalStaircasePair\_complement\_band\_lt\_window}
+in \path{TNLean/PEPS/TorusWindowSingleCrossingObstruction.lean}.}
 
-\subsection{Retired route: a coarse substitute on different boundary bonds}
-
-This subsection records an auxiliary route that is no longer part of the
-formalization plan.  The staircase family does not need to move the operation
-between the bonds denoted below by $g_{j-1}$ and $g_j$; it keeps the same
-reference edge $e$ in every window.
-
-The discarded route proposed that an intermediate window $W_j$ read the inserted
-operation off the in-region endpoint of one boundary bond $g_{j-1}$ and
-re-express it on a \emph{different} boundary bond $g_j$ of the same window.
-Blocking $W_j$ to one super-vertex does make $g_{j-1}$ and $g_j$ two legs of
-one injective super-vertex, and the super-vertex injectivity
-\leanid{RegionBlockedTensorInjective}~$W_j$ is in hand. But that injectivity
-is linear independence across the window's \emph{whole multi-bond perimeter},
-not a single-bond matrix-algebra span between $g_{j-1}$ and $g_j$. The
-operation pushed across a single bond pair is a square matrix on
-$\mathrm{Fin}(\mathrm{bondDim}\,g)$; reading it off requires the family of
-window blocks, restricted to the two bonds $g_{j-1}, g_j$ at fixed remaining
-external legs, to span the full
-$\mathrm{Mat}_{\mathrm{bondDim}\,g}$. That single-bond-pair span is
-\emph{strictly stronger} than window injectivity and does not follow from it,
-for the same dimension-count reason the per-window square-matrix family fails
-to exist (the section on the multiplicativity verdict): folding the perimeter
-into a second $\mathrm{Fin}(\mathrm{bondDim}\,g)$ index would force
-$\prod_{\text{other external legs}}\mathrm{bondDim} = \mathrm{bondDim}\,g$,
-false in general.
-
-This is exactly where the one-dimensional precedent fails to port, and the
-reason is geometric, not a missing hypothesis. The formalized
-one-dimensional overlapping-window extraction
-\leanid{MPSChainTensor.overlapWindow\_exists\_bondOperator}
-(\path{TNLean/PEPS/CycleMPSChainOverlapWindow.lean}, line~356) consumes only
-\leanid{IsWindowInjective}~$A\;L$ --- window (region) injectivity, never
-single-site injectivity --- and \emph{succeeds}. It succeeds because a
-length-$L$ one-dimensional window has exactly two virtual legs, a left bond
-and a right bond, both of dimension $D$, so the window product \emph{is} a
-$D \times D$ matrix and window injectivity is precisely the statement that
-these products span the full matrix algebra at the single bond; the cross-bond
-pushing is then the intertwining-span read-off
-\leanid{exists\_bondOperator\_of\_intertwine\_span} (same file, line~74), and
-the homomorphism is \leanid{MPSChainTensor.exists\_insertionHom} fed by the
-same window span. The two-dimensional end $L \times K$ window touches the
-reference bond with \emph{one} endpoint, so its bond-restricted family is a
-family of \emph{vectors}, never a square-matrix span, and the window's whole
-perimeter is open. The one-dimensional mechanism that powered the precedent
-\emph{is} window-injectivity-only --- the precedent never needed single-site
-injectivity --- but its enabling fact, ``window product is a square matrix on
-the pushed bond,'' is a property of the square one-dimensional window geometry
-that the non-square $L \times K$ window does not have. The campaign's analysis
-that ``the two-dimensional analogue does not exist'' is therefore correct and
-not a mis-analysis: it is the absence of the square-window geometry, not the
-absence of a normality hypothesis.
-
-\subsection{Retired verdict for the different-bond route}
-
-The verdict in this subsection concerns only the discarded construction just
-described.  It is not the current verdict on the paper's fixed-edge argument.
-
-The discarded route tried to move an operation between two different
-boundary bonds of one intermediate window.  A direct one-dimensional
-matrix-span argument does not type in that geometry, while the natural
-three-block replacement has the non-injective host described below.  These
-facts rule out that auxiliary construction under the corollary hypotheses;
-they do not identify a missing hypothesis of the paper or obstruct its
-fixed-edge comparison.
-
-The source keeps the highlighted edge $e$ fixed.  Every staircase window
-contains at least one endpoint of $e$, and the common-state family constructed
-above realizes the same $X$ on that edge throughout.  Thus no different-bond
-push or per-intermediate-bond coarse frame belongs to the remaining plan.  The
-remaining task is the converse comparison of the physical operations, with
-the corner adjoining and inversion at lines 2415--2444 and the composition
-argument of Lemma~5.  No hypothesis change to the capstone is warranted by
-this audit.
-
-\subsection{Retired audit: per-bond coarse frames at the minimal size}
-
-This audit remains a valid obstruction to the indicated coarse-frame
-substitute, but that substitute is not needed for the common-state family.
-
-The question posed by the earlier analysis --- whether a per-bond coarse
-frame exists at the minimal size for an intermediate bond,
-where the partner block is a neighbouring window rather than the diagonally
-opposite one, or whether those crossings inherit the same
-$\mathrm{univ}\setminus S$-type non-injectivity --- is now settled, in the
-negative, by the geometry of the single-crossing partition. The settlement is
-purely combinatorial and applies to \emph{every} single-crossing $L\times K$
-window pair, intermediate or end-pair.
-
-A coarse frame around a bond $e$ feeds the multiplicativity engine
-\leanid{TNLean.PEPS.coeffTransferMap\_mul\_of\_coherentFrames} only through a
-partition of the lattice into three injective regions, red, blue, and the
-complement of their union, with $e$ the single red-to-blue crossing. The third
-region is forced to be $\mathrm{univ}\setminus(\mathrm{red}\cup\mathrm{blue})$.
-The only landed source of complement injectivity at the minimal sizes
-$2L+1\le\mathrm{width}$, $2K+1\le\mathrm{height}$ is the two-band decomposition
-of the complement of a \emph{single cyclic rectangle}
-(\leanid{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses.windowComplement%
-\_injective} and its consecutive-union counterparts): the complement of a
-$w\times h$ cyclic rectangle splits into a full-height band of $\mathrm{width}-w$
-columns and a $w\times(\mathrm{height}-h)$ leftover, both injective when
-$w\le\mathrm{width}-L$ and $h\le\mathrm{height}-K$. Injectivity of the third
-region by this machinery therefore requires
-$\mathrm{red}\cup\mathrm{blue}$ to be a single cyclic rectangle.
-
-But two $L\times K$ windows cross at a single lattice edge only when they are
-the diagonally offset staircase pair: column-adjacent across one shared row
-(\leanid{TNLean.PEPS.isCrossingEdge\_horizontalStaircase}). Their union then
-covers all $2L$ contiguous columns at the shared row
-(\leanid{TNLean.PEPS.horizontalStaircasePair\_row\_span}) while the rows above
-and below it carry only one window's $L$ columns, so the union is a staircase,
-not a rectangle. The product structure of a cyclic rectangle --- membership is a
-column condition and a row condition read independently --- forces the swapped
-corner $(a+2L-1,\,b)$ to belong whenever the three corners $(a,\,b+K-1)$,
-$(a+2L-1,\,b+K-1)$, $(a,\,b)$ do; the swapped corner lies outside the union, so
-the union is not any cyclic rectangle
-(\leanid{TNLean.PEPS.horizontalStaircasePair\_ne\_arcRectangle}). At the minimal
-width the obstruction is quantitative as well: the complement band at the shared
-row is $\mathrm{width}-2L<L$ columns wide
-(\leanid{TNLean.PEPS.horizontalStaircasePair\_complement\_band\_lt\_window}), so
-no $L\times K$ window translate passing through that row avoids the union
-(\leanid{TNLean.PEPS.horizontalStaircasePair\_window\_meets\_row}), and the
-complement is not a union of injective window translates.
-
-This is the precise conflict, and it is a joint unsatisfiability of two of the
-frame's conditions: the single-crossing requirement forces the diagonal offset,
-the diagonal offset forces the double-width row span, and the double-width row
-span forces the union out of the cyclic-rectangle class, which is the only class
-whose complement the landed machinery proves injective. Choosing a
-\emph{neighbouring} window as the partner does not escape this: a window sharing
-more than the single edge $e$ with red is not a single-crossing partner, and a
-single-crossing partner is, up to translation, the diagonal offset itself.
-Enlarging red or blue beyond a single window to make the union a rectangle does
-not help either, since a cyclic rectangle admits no bipartition into two regions
-each injective (each containing an $L\times K$ window) with a single edge between
-them: the rectangle is two-edge-connected, so any bipartition into two
-non-degenerate parts has at least two crossing edges. The per-bond coarse frame
-is therefore unbuildable at the minimal size for every bond of the chain.  This
-rules out that auxiliary frame, but it no longer redirects the formalization:
-the fixed-edge insert family is complete.  The geometry is in
-\path{TNLean/PEPS/TorusWindowSingleCrossingObstruction.lean}.
+These observations rule out two auxiliary shortcuts; they do not challenge
+the paper's fixed-edge comparison.  The remaining source step is the converse
+at lines 2368--2444: compare the physical operations on the overlapping
+windows, adjoin and invert the two corner regions, recover the unique virtual
+operation $X$, and prove the maps $O_1\mapsto X$ and
+$O_3^{\mathsf T}\mapsto X$ multiplicative by the composition argument of
+Lemma~5.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- define the insert representing a virtual matrix on an interior bond of a region;
- construct the physical operator of an arbitrary insert on an injective region and prove its open-boundary realization identity;
- assemble the full staircase family for one fixed virtual operation, with the source orientation `Xᵀ` on the first window and `X` on the last;
- exhibit a physical operator `O_j(X)` on every injective staircase window before contracting the complement;
- prove that translation invariance gives one common deformed state on all `L + K` windows;
- prove the end-window coefficient identity directly from the two region-to-edge identities and translation invariance, without the former peeling hypotheses;
- synchronize the PEPS blueprint and correct the paper-gap note to retire the different-bond route based on an incorrect endpoint classification;
- reclassify the single-vertex and bond-locality window modules as conditional implications, not source-level residuals.

## Mathematical content

Let `e` be the horizontal reference edge and `X` a matrix on `e`. The insert family is

- the boundary insert of `Xᵀ` on `W₀`, which contains only the ordered right endpoint;
- the interior-bond insert of `X` on `W₁, …, W_{L-1}`, which contain both endpoints;
- the boundary insert of `X` on `W_L, …, W_{L+K-1}`, which contain the ordered left endpoint.

For an injective region `R` and an insert family `C`, define

`O_C = linearCombination(C) ∘ regionBlockedLeftInverse(A, R)`.

The theorem `physicalOpOfRegionInsert_realizes` proves

`O_C (T_{A,R}(μ)) = C(μ)`

for every virtual boundary configuration `μ`. Instantiating this construction with the staircase insert gives the paper's physical operator `O_j(X)` on each window. This is an open-boundary identity; it is not inferred from equality after complementary contraction.

For the interior insert, start from the boundary insert on the singleton containing the ordered left endpoint, adjoin the genuine tensors of the window by corner extension, and rescale from the singleton non-boundary bond product to that of the window. Its assembled state is `P_B(W_j) E_B(e, ω, X)`. Translation invariance identifies `P_B(W_j)` with `P_B(W₀)`, so all family members have the common state `P_B(W₀) E_B(e, ω, X)`.

The first and last region coefficients both reduce directly to the edge coefficient with `X` on the same fixed edge: the first boundary orientation transposes `Xᵀ`, while the last fixes `X`. Translation invariance identifies their non-boundary bond products. This completes the forward virtual/physical-operation family requested in #2780. It does not claim the remaining cross-tensor converse or homomorphism extraction in #5456.

## Source alignment

- arXiv:1804.04964, `paper_normal.tex:2320-2321`: one virtual operation on the highlighted bond is physical on every displayed region;
- `paper_normal.tex:2323-2366`: the displayed staircase-window geometry and the same highlighted edge throughout;
- `paper_normal.tex:2044-2045, 2129, 2252`: the `O₁` / `O₃ᵀ` orientation and algebra-homomorphism convention;
- `paper_normal.tex:2368-2444`: the converse overlapping-window comparison, which remains the cross-tensor extraction problem.

The previous gap-note claim that intermediate windows contain neither endpoint of `e` contradicted the landed endpoint lemmas. The note now records the checked split `W₀` / `W₁, …, W_{L-1}` / `W_L, …, W_{L+K-1}` and marks the different-bond and per-bond-coarse-frame discussions as retired auxiliary routes.

## Verification

- focused linter-bearing builds of the changed PEPS modules;
- full `lake build` (10,285 jobs);
- kernel `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`;
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the changed proof modules;
- `python3 scripts/generate_import_aggregators.py --check`;
- `lake env lean scripts/LintStyle.lean`;
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`;
- `python3 scripts/tactic_pattern_scan.py`;
- PEPS-enabled blueprint web parse and `leanblueprint checkdecls`, with all eleven new declaration links present; the full PEPS parse retains the unrelated pre-existing unresolved label `def:non_ti_chain`;
- `python3 scripts/test_tenkz_peps_torus.py`.

Closes #2780.
Advances #5456.
Refs #5457 and #2738.
