### PR TITLE
feat(MPS/MPDO): transport neighboring trace factorizations

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -11,7 +11,9 @@ import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 
 This file identifies the two-site and four-site closures in the physical
 sector coordinates of Proposition C.7 with unitary congruences of the
-corresponding closures in the original physical coordinates.
+corresponding closures in the original physical coordinates.  It also proves
+that the physical-sector factorization and its neighboring trace factorization
+are invariant under a square unitary change of physical coordinates.
 
 ## References
 
@@ -30,7 +32,7 @@ Recorded in
 `docs/paper-gaps/cpsv16_active_physical_support_compression.tex`.
 -/
 
-open scoped Matrix Kronecker
+open scoped Matrix Kronecker ComplexOrder
 
 namespace MPOTensor.PhysicalSectorFactorization
 
@@ -116,6 +118,194 @@ theorem changePhysicalBasis_smul
   intro x _
   simpa only [mul_comm, mul_left_comm, mul_assoc] using
     (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
+
+/-- Regard a physical-sector factorization in square changed physical
+coordinates as a factorization of the original tensor.
+
+If the given factorization uses the physical isometry $U$, the transported
+factorization uses $UV$.  Its sector decomposition and its left and right
+tensor families are retained literally.
+
+The factorization data transported here are those of arXiv:1606.00608,
+Appendix C.2, equations `AppUkU=rl` and `etarl`, lines 1381--1450.  This
+coordinate-invariance construction is project-internal and is not a statement
+printed in that source.  The matrix $V$ is the physical coordinate change, not
+the source isometry $U$. -/
+noncomputable def ofChangePhysicalBasis
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (F : PhysicalSectorFactorization (changePhysicalBasis V K)) :
+    PhysicalSectorFactorization K where
+  sectorCount := F.sectorCount
+  leftDim := F.leftDim
+  rightDim := F.rightDim
+  leftDim_pos := F.leftDim_pos
+  rightDim_pos := F.rightDim_pos
+  sectorEquiv := F.sectorEquiv
+  physicalIsometry := F.physicalIsometry * V
+  physicalIsometry_isometry := by
+    rw [Matrix.conjTranspose_mul]
+    calc
+      (Vᴴ * F.physicalIsometryᴴ) * (F.physicalIsometry * V) =
+          Vᴴ * (F.physicalIsometryᴴ * F.physicalIsometry) * V := by
+        simp only [Matrix.mul_assoc]
+      _ = 1 := by rw [F.physicalIsometry_isometry, Matrix.mul_one, hV]
+  leftTensor := F.leftTensor
+  rightTensor := F.rightTensor
+  factorization := by
+    intro beta alpha
+    rw [← F.factorization beta alpha]
+    apply congrArg (Matrix.reindex F.sectorEquiv F.sectorEquiv)
+    change
+      (F.physicalIsometry * V) * physicalSlice K beta alpha *
+          (F.physicalIsometry * V)ᴴ =
+        F.physicalIsometry *
+          (V * physicalSlice K beta alpha * Vᴴ) *
+            F.physicalIsometryᴴ
+    rw [Matrix.conjTranspose_mul]
+    simp only [Matrix.mul_assoc]
+
+/-- Changing square physical coordinates transports a physical-sector
+factorization by replacing its source isometry $U$ with $UV^\dagger$.
+
+All sector data and both tensor families are retained literally.  This is the
+inverse construction to `ofChangePhysicalBasis` for a square isometry.
+
+The factorization data are from arXiv:1606.00608, Appendix C.2, equations
+`AppUkU=rl` and `etarl`, lines 1381--1450.  The coordinate transport itself is
+project-internal and is not printed in that source. -/
+noncomputable def toChangePhysicalBasis
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (F : PhysicalSectorFactorization K) :
+    PhysicalSectorFactorization (changePhysicalBasis V K) where
+  sectorCount := F.sectorCount
+  leftDim := F.leftDim
+  rightDim := F.rightDim
+  leftDim_pos := F.leftDim_pos
+  rightDim_pos := F.rightDim_pos
+  sectorEquiv := F.sectorEquiv
+  physicalIsometry := F.physicalIsometry * Vᴴ
+  physicalIsometry_isometry := by
+    have hVV : V * Vᴴ = 1 := mul_eq_one_comm.mpr hV
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    calc
+      (V * F.physicalIsometryᴴ) * (F.physicalIsometry * Vᴴ) =
+          V * (F.physicalIsometryᴴ * F.physicalIsometry) * Vᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = 1 := by rw [F.physicalIsometry_isometry, Matrix.mul_one, hVV]
+  leftTensor := F.leftTensor
+  rightTensor := F.rightTensor
+  factorization := by
+    intro beta alpha
+    rw [← F.factorization beta alpha]
+    apply congrArg (Matrix.reindex F.sectorEquiv F.sectorEquiv)
+    change
+      (F.physicalIsometry * Vᴴ) *
+          (V * physicalSlice K beta alpha * Vᴴ) *
+            (F.physicalIsometry * Vᴴ)ᴴ =
+        F.physicalIsometry * physicalSlice K beta alpha *
+          F.physicalIsometryᴴ
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    calc
+      (F.physicalIsometry * Vᴴ) *
+            (V * physicalSlice K beta alpha * Vᴴ) *
+              (V * F.physicalIsometryᴴ) =
+          F.physicalIsometry *
+              ((Vᴴ * V) * physicalSlice K beta alpha * (Vᴴ * V)) *
+            F.physicalIsometryᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = F.physicalIsometry * physicalSlice K beta alpha *
+          F.physicalIsometryᴴ := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+
+/-- Pulling a factorization back through a square physical coordinate change
+leaves every neighboring operator unchanged. -/
+@[simp] theorem ofChangePhysicalBasis_neighboringOperator
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (F : PhysicalSectorFactorization (changePhysicalBasis V K))
+    (k h : Fin F.sectorCount) :
+    (F.ofChangePhysicalBasis V hV).neighboringOperator k h =
+      F.neighboringOperator k h :=
+  rfl
+
+/-- Changing square physical coordinates leaves every neighboring operator of
+the transported factorization unchanged. -/
+@[simp] theorem toChangePhysicalBasis_neighboringOperator
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    (F.toChangePhysicalBasis V hV).neighboringOperator k h =
+      F.neighboringOperator k h :=
+  rfl
+
+/-- Transport a neighboring trace factorization from square changed physical
+coordinates back to the original tensor.
+
+The matrices $\eta_{k,h}$ and the real coefficient families $a_k,b_h$ are
+unchanged.  Thus positivity, the trace identities
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$, and
+$\sum_k a_kb_k=1$ are the given clauses themselves.
+
+The transported data are those of arXiv:1606.00608, Appendix C.2, lines
+1381--1450.  Their invariance under an additional square physical coordinate
+change is a project-derived observation, not a statement of that source. -/
+noncomputable def NeighboringTraceFactorization.ofChangePhysicalBasis
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    {F : PhysicalSectorFactorization (changePhysicalBasis V K)}
+    (H : NeighboringTraceFactorization F) :
+    NeighboringTraceFactorization (F.ofChangePhysicalBasis V hV) where
+  neighboringOperator_pos := by
+    intro k h
+    change (F.neighboringOperator k h).PosSemidef
+    exact H.neighboringOperator_pos k h
+  a := H.a
+  b := H.b
+  trace_neighboringOperator := by
+    intro k h
+    change (F.neighboringOperator k h).trace = ((H.a k * H.b h : ℝ) : ℂ)
+    exact H.trace_neighboringOperator k h
+  sum_mul := H.sum_mul
+
+/-- Transport a neighboring trace factorization through a square physical
+coordinate change.
+
+The neighboring operators $\eta_{k,h}$ and the coefficient families $a_k,b_h$
+are retained literally.  This is the project-derived reverse construction to
+`NeighboringTraceFactorization.ofChangePhysicalBasis`; it is not printed in
+arXiv:1606.00608. -/
+noncomputable def NeighboringTraceFactorization.toChangePhysicalBasis
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    {F : PhysicalSectorFactorization K} (H : NeighboringTraceFactorization F) :
+    NeighboringTraceFactorization (F.toChangePhysicalBasis V hV) where
+  neighboringOperator_pos := by
+    intro k h
+    change (F.neighboringOperator k h).PosSemidef
+    exact H.neighboringOperator_pos k h
+  a := H.a
+  b := H.b
+  trace_neighboringOperator := by
+    intro k h
+    change (F.neighboringOperator k h).trace = ((H.a k * H.b h : ℝ) : ℂ)
+    exact H.trace_neighboringOperator k h
+  sum_mul := H.sum_mul
+
+/-- Existence of a neighboring trace factorization is invariant under a square
+isometric change of physical coordinates.
+
+This theorem transports the $\eta_{k,h}$, $a_k$, and $b_h$ data appearing in
+arXiv:1606.00608, Theorem 4.9(iv) and Appendix C.2, lines 1381--1450.  The
+coordinate-invariance equivalence itself is project-derived and is not a
+statement printed in that source. -/
+theorem exists_neighboringTraceFactorization_changePhysicalBasis_iff
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1) :
+    (∃ F : PhysicalSectorFactorization K,
+        Nonempty F.NeighboringTraceFactorization) ↔
+      ∃ F : PhysicalSectorFactorization (changePhysicalBasis V K),
+        Nonempty F.NeighboringTraceFactorization := by
+  constructor
+  · rintro ⟨F, ⟨H⟩⟩
+    exact ⟨F.toChangePhysicalBasis V hV,
+      ⟨H.toChangePhysicalBasis V hV⟩⟩
+  · rintro ⟨F, ⟨H⟩⟩
+    exact ⟨F.ofChangePhysicalBasis V hV,
+      ⟨H.ofChangePhysicalBasis V hV⟩⟩
 
 theorem sectorCoordinateTensor_eq_changePhysicalBasis
     (F : PhysicalSectorFactorization K) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -920,6 +920,52 @@
     \cite[Appendix~C.2, lines~1389--1403]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+% This coordinate-invariance theorem is project-derived.  It transports the
+% data in CPSV16 Theorem 4.9(iv), but is not a theorem stated in that source.
+\begin{theorem}[Unitary physical-coordinate invariance of neighboring trace factorizations]
+    \label{thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofChangePhysicalBasis,
+        MPOTensor.PhysicalSectorFactorization.toChangePhysicalBasis,
+        MPOTensor.PhysicalSectorFactorization.ofChangePhysicalBasis_neighboringOperator,
+        MPOTensor.PhysicalSectorFactorization.toChangePhysicalBasis_neighboringOperator,
+        MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.ofChangePhysicalBasis,
+        MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.toChangePhysicalBasis,
+        MPOTensor.PhysicalSectorFactorization.exists_neighboringTraceFactorization_changePhysicalBasis_iff}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization, def:mpdo_neighboring_trace_factorization}
+    Let $V$ be a square physical-space matrix with $V^\dagger V=\Id$, and
+    define ${\cal K}^V_{\beta,\alpha}
+    =V{\cal K}_{\beta,\alpha}V^\dagger$.  Then ${\cal K}$ admits a
+    physical-sector factorization with
+    \begin{align}
+        \eta_{k,h} & \geq 0,
+        \notag \\
+        \tr(\eta_{k,h}) & =a_kb_h,
+        \notag \\
+        \sum_k a_kb_k & =1.
+        \notag
+    \end{align}
+    if and only if ${\cal K}^V$ admits one.  The same sector spaces, tensors
+    $l_k,r_k$, neighboring operators $\eta_{k,h}$, and numbers $a_k,b_h$ may
+    be used on both sides.  This invariance is project-derived; the data being
+    transported are those of
+    \cite[Theorem~4.9(iv) and Appendix~C.2, lines~1381--1450]
+    {Cirac2016MPDO_arXiv}, but the equivalence itself is not stated there.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $V$ is square, $VV^\dagger=\Id$.  If the physical isometry for
+    ${\cal K}$ is $U$, use $UV^\dagger$ for ${\cal K}^V$; then
+    $(UV^\dagger){\cal K}^V_{\beta,\alpha}(UV^\dagger)^\dagger
+    =U{\cal K}_{\beta,\alpha}U^\dagger$.  Conversely, if the isometry for
+    ${\cal K}^V$ is $U'$, use $U'V$ for ${\cal K}$.  In both directions the
+    tensors $l_k,r_k$ are unchanged, so
+    $\eta_{k,h}=\sum_\gamma(r_k)_\gamma\otimes(l_h)_\gamma$ is unchanged.
+    The positivity, trace, and normalization identities therefore remain the
+    same identities.
+\end{proof}
+
 \begin{theorem}[Trace of the three-site neighboring operator]
     \label{thm:mpdo_physical_sector_three_site_neighboring_operator_trace}
     \lean{MPOTensor.PhysicalSectorFactorization.trace_threeSiteNeighboringOperator,


### PR DESCRIPTION
## Motivation

The active-physical-support counterexample route needs neighboring trace
factorizations to be independent of the chosen square unitary physical
coordinates.  Issue #7041 isolates this project-derived coordinate lemma.

The transported source data are the sector tensors and the
$\eta_{k,h},a_k,b_h$ factorization of CPSV16, Theorem 4.9(iv) and Appendix C.2,
lines 1381--1450.  The coordinate-invariance equivalence is not stated in
CPSV16.

## Description

- transports a physical-sector factorization in both directions by composing
  only its physical isometry with $V$ or $V^\dagger$;
- retains the sector equivalence, dimensions, $l_k$, and $r_k$ literally, so
  every neighboring operator $\eta_{k,h}$ is definitionally unchanged;
- transports positivity, $a_k$, $b_h$, the trace identities, and
  $\sum_k a_k b_k=1$ without additional hypotheses;
- packages the two constructions as an existential equivalence; and
- records the project-derived invariance in the Blueprint with `\leanok`
  proof status, without claiming that CPSV16 states the equivalence.

## Testing

- `lake build TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport`
- `lake exe lint_style`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- all seven Blueprint-linked declarations imported and checked through the
  focused target module
- `python3 scripts/tactic_pattern_scan.py --top 20 --show-locations 8`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/test_audit_cpsv16_labels.py`
- `python3 scripts/audit_cpsv16_labels.py`
- `texra-blueprint paper-gaps check`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex`

Closes #7041
