### PR TITLE
doc(MPS/MPDO): distinguish Proposition C.7 attribution

### DIFF
--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -1253,12 +1253,15 @@ but it is not an unqualified counterexample to Theorem~4.9 because it fails the
 paper's literal ZCL diagram. Independently, the repeated-copy theorem above
 refutes the exact printed implication (iv)$\Rightarrow$(v). The source-context
 (ii)$\Rightarrow$(iv) factorization remains \ghissue{6775}. Once it is
-supplied, Proposition~\texttt{3to5}, its twice-applied channels, and the
-conditional combination through the orthogonal outer physical sectors give
-(ii)$\Rightarrow$(v). Those channel constructions are formalized in
-\ghissue{6632}, and their trace-preserving completion outside the active
-support resolves \ghissue{6807}. The project-derived direct sector-mixing
-alternative in \ghissue{6793} is retired in favor of this source route.
+supplied, the Proposition~\texttt{3to5} construction and its twice-applied
+channels for one representative are formalized by
+\leanid{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.%
+blockTwo_isRFPViaTS}.
+Combining those supplied channel pairs through the orthogonal outer physical
+sectors then gives (ii)$\Rightarrow$(v); that combination is formalized in
+\ghissue{6632}, and its trace-preserving completion outside the active support
+resolves \ghissue{6807}. The project-derived direct sector-mixing alternative
+in \ghissue{6793} is retired in favor of this source route.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

The post-merge review of #7022 identified one attribution ambiguity in the concluding paragraph of the CPSV16 rank-one paper-gap note. The paragraph grouped the one-representative Proposition C.7 channel helper with the outer-sector assembly delivered by #6632.

### Description

- Attribute the Proposition C.7 construction and twice-applied representative channels to `MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS`.
- Attribute only the combination of supplied representative channel pairs through orthogonal outer physical sectors to #6632.
- Preserve the source order in Proposition C.15, the open factorization obligation #6775, the completion boundary #6807, and the retirement of #6793.

This changes no mathematical statement, Lean declaration, or Blueprint readiness tag.

### Testing

- focused `latexmk` build of `docs/paper-gaps/cpgsv17_pf_rank_one.tex` (22 pages)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check origin/main...HEAD`

Follow-up to #7022, discussion_r3839360150.

Closes #7051