### PR TITLE
doc(conventions): degenerate readings are conventions, not gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,12 @@ one-page paper-gap note. The convention must not be modeled:
 - no per-declaration marker stamped across a whole module; one marker on
   the definition or in the module docstring suffices.
 
+The marker rule applies to every marker family, not only degenerate
+readings: one `**Scope restriction**` or `**Local fix**` marker per
+(restriction, module), placed on the module docstring or the defining
+declaration; a per-declaration marker is justified only when that
+declaration's restriction differs from the module's.
+
 Every item on that list multiplies downstream statements and hypothesis
 lists and makes further proof writing harder. When an audit finds such a
 reading, the repair is to delete the scaffolding, not to document it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,39 @@ the statement smuggles an unwarranted hypothesis). The lighter markers
 are for deviations that are mathematically correct as stated, just
 narrower or differently phrased than the source.
 
+#### Degenerate readings are conventions, not gaps
+
+A source definition read hyper-literally often admits a degenerate case
+that its authors plainly do not intend: a canonical-form summand with
+coefficient zero, a basis member that contributes nothing at every
+length, a sector of probability zero, an empty block padding the bond
+dimension. Such a reading is **not** a faithfulness gap. The intended
+reading is adopted as the library's convention, baked into the definition
+(a `≠ 0` or `0 <` field), and recorded once as a **Local fix** with a
+one-page paper-gap note. The convention must not be modeled:
+
+- no parallel predicate families (`raw` versus `active`, `literal` versus
+  `normalized`) with bridge lemmas between them;
+- no counterexample modules refuting the literal reading;
+- no `\notready` "printed status" blueprint nodes beside the formalized
+  theorem;
+- no side hypotheses (`∀ k, μ k ≠ 0`) repeated on every downstream
+  statement when the definition already carries them;
+- no per-declaration marker stamped across a whole module; one marker on
+  the definition or in the module docstring suffices.
+
+Every item on that list multiplies downstream statements and hypothesis
+lists and makes further proof writing harder. When an audit finds such a
+reading, the repair is to delete the scaffolding, not to document it.
+The 2026-08-23 nonzero-coefficient cleanup
+(`docs/audits/2026-08-23_nonzero_coefficient_convention.md`) removed
+about 2,300 lines built around one such reading.
+
+A genuine source error is different: a printed claim that fails on
+nondegenerate data (an explicit tensor with nonzero weights, a wrong
+exponent, an off-by-one chain length) keeps its counterexample and its
+**Local fix** or **false-source** record.
+
 A paper-realignment PR may:
 
 - Delete fields, hypotheses, or whole theorems that are documented as

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -58,6 +58,18 @@ whereas the formal route might use convergence of a sequence. These are
 different mechanisms, and the note should say which hypotheses each mechanism
 uses.
 
+A note is \emph{not} an invitation to model a degenerate reading. When a
+source definition, read to the letter, admits a case its authors do not
+intend (a direct-sum summand with coefficient zero, a basis member whose
+coefficient vanishes at every length, a sector of probability zero, an empty
+block padding a bond dimension), the intended reading is adopted as a
+convention and written into the definition. One short note of kind
+\path{local-correction} records the reading. The degenerate case receives no
+parallel definition, no counterexample, no status entry in the blueprint, and
+no hypothesis repeated on downstream statements; such apparatus is deleted
+when found. A note of kind \path{false-source} is reserved for a printed
+claim that fails on nondegenerate data.
+
 \section{Form of the note}
 
 The note should introduce the relevant notation before using it. It should


### PR DESCRIPTION
## Summary

Records the lesson from #6963 (the nonzero-coefficient cleanup, about 2,300 lines removed) so that source-faithfulness audits stop regrowing the same apparatus.

- `CLAUDE.md`, faithfulness section: new subsection *Degenerate readings are conventions, not gaps* — when a source definition read to the letter admits a case its authors do not intend (zero-coefficient summands, everywhere-vanishing basis members, probability-zero sectors, empty padding blocks), the intended reading goes into the definition as a field and is recorded once as a Local fix; the degenerate case gets no parallel predicate family, no refuting counterexample module, no printed-status blueprint node, no repeated downstream side hypotheses, and no per-declaration marker stamping. Genuine source errors (claims failing on nondegenerate data) keep their counterexample and false-source record.
- `docs/paper-gaps/policy.tex`, *When a note is needed*: the same rule in the note policy, with the kind assignment (local-correction for an adopted reading; false-source reserved for claims failing on nondegenerate data).

Documentation only.

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E