### PR TITLE
refactor(MPS/MPU): localize composition sum normalization

### DIFF
--- a/TNLean/MPS/MPU/CompositionRanks.lean
+++ b/TNLean/MPS/MPU/CompositionRanks.lean
@@ -23,6 +23,13 @@ namespace MPOTensor
 
 variable {d D₁ D₂ : ℕ}
 
+/-- The left local factor in the two-site source-tensor $u$ factorization.  These
+local factors are substituted into `compositionCutLeft` and
+`compositionCutRight` to obtain the Chapter 28 factors $A_{1,4}$ and
+$B_{1,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def rightBlockLeft (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     Matrix (Fin D₁ × Fin (d * d)) (Fin d × Fin r[U]) ℂ :=
@@ -30,6 +37,11 @@ private noncomputable def rightBlockLeft (U : MPOTensor d D₁)
     if j₂ = (finProdFinEquiv.symm J).2 then
       S.X₁ (a, (finProdFinEquiv.symm J).1) r else 0
 
+/-- The right local factor in the two-site source-tensor $u$ factorization used to
+construct the Chapter 28 factors $A_{1,4}$ and $B_{1,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def rightBlockRight (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     Matrix (Fin d × Fin r[U]) (Fin (d * d) × Fin D₁) ℂ :=
@@ -37,6 +49,12 @@ private noncomputable def rightBlockRight (U : MPOTensor d D₁)
     SourceFactors.sourceU U S (l, r) (finProdFinEquiv.symm I) *
       S.Y₂ l (j₂, b)
 
+/-- The two-site right-cut factorization through the paper's source tensor
+$u$; it is applied to both product factors before assembling
+$M_1((\mathcal U\mathbin{\cdot}\mathcal V)_4)=A_{1,4}B_{1,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private theorem sourceCutM₁_blockTwo_factorization (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     sourceCutM₁ (blockTwo U) = rightBlockLeft U S * rightBlockRight U S := by
@@ -51,6 +69,12 @@ private theorem sourceCutM₁_blockTwo_factorization (U : MPOTensor d D₁)
     simp only [hx, ite_false, zero_mul, Finset.sum_const_zero]
   · simp
 
+/-- The left local factor in the reflected two-site source-tensor $v$ factorization.
+These local factors are substituted into the generic four-site cut factors to
+obtain the Chapter 28 matrices $A_{2,4}$ and $B_{2,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `vdagger`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def leftBlockLeft (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     Matrix (Fin D₁ × Fin (d * d)) (Fin d × Fin ℓ[U]) ℂ :=
@@ -58,6 +82,11 @@ private noncomputable def leftBlockLeft (U : MPOTensor d D₁)
     if i₂ = (finProdFinEquiv.symm I).2 then
       S.X₂ (a, (finProdFinEquiv.symm I).1) l else 0
 
+/-- The right local factor in the reflected two-site source-tensor $v$ factorization
+used to construct the Chapter 28 matrices $A_{2,4}$ and $B_{2,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `vdagger`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def leftBlockRight (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     Matrix (Fin d × Fin ℓ[U]) (Fin (d * d) × Fin D₁) ℂ :=
@@ -66,6 +95,12 @@ private noncomputable def leftBlockRight (U : MPOTensor d D₁)
       ((finProdFinEquiv.symm J).2, (finProdFinEquiv.symm J).1) (r, l) *
         S.Y₁ r (i₂, b)
 
+/-- The two-site left-cut factorization through the reflected source tensor
+$v$; it is applied to both product factors before assembling
+$M_2((\mathcal U\mathbin{\cdot}\mathcal V)_4)=A_{2,4}B_{2,4}$.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `vdagger`, lines 526--543,
+and Theorem `IndexTh` (ii), lines 837--845. -/
 private theorem sourceCutM₂_blockTwo_factorization (U : MPOTensor d D₁)
     {ρ : Matrix (Fin D₁) (Fin D₁) ℂ} (S : SourceFactors U ρ) :
     sourceCutM₂ (blockTwo U) = leftBlockLeft U S * leftBlockRight U S := by
@@ -117,6 +152,37 @@ private theorem sum_eight_cut_shuffle
       rfl
     _ = _ := by simp only [Fintype.sum_prod_type]
 
+private theorem sum_eight_cut_factorization
+    {X Y J K T₁ T₂ S₁ S₂ : Type*}
+    [Fintype X] [Fintype Y] [Fintype J] [Fintype K]
+    [Fintype T₁] [Fintype T₂] [Fintype S₁] [Fintype S₂]
+    (a : J → T₁ → ℂ) (b : T₁ → X → ℂ)
+    (c : T₂ → ℂ) (d : T₂ → J → Y → ℂ)
+    (e : X → K → S₁ → ℂ) (f : S₁ → ℂ)
+    (g : Y → S₂ → ℂ) (h : S₂ → K → ℂ) :
+    (∑ x, ∑ y,
+      (∑ j, (∑ t₁, a j t₁ * b t₁ x) * ∑ t₂, c t₂ * d t₂ j y) *
+        ∑ k, (∑ s₁, e x k s₁ * f s₁) * ∑ s₂, g y s₂ * h s₂ k) =
+      ∑ ts : T₁ × S₂,
+        (∑ j, a j ts.1 * ∑ t₂, ∑ y, c t₂ * d t₂ j y * g y ts.2) *
+          ∑ x, ∑ k, ∑ s₁, b ts.1 x * e x k s₁ * f s₁ * h ts.2 k := by
+  simp only [Fintype.sum_prod_type, Finset.sum_mul, Finset.mul_sum]
+  rw [sum_eight_cut_shuffle]
+  refine Finset.sum_congr rfl fun t₁ _ => ?_
+  refine Finset.sum_congr rfl fun s₂ _ => ?_
+  refine Finset.sum_congr rfl fun x _ => ?_
+  refine Finset.sum_congr rfl fun k _ => ?_
+  refine Finset.sum_congr rfl fun s₁ _ => ?_
+  refine Finset.sum_congr rfl fun j _ => ?_
+  refine Finset.sum_congr rfl fun t₂ _ => ?_
+  refine Finset.sum_congr rfl fun y _ => ?_
+  ac_rfl
+
+/-- The left rectangular factor of the generic four-site product cut.  With
+the source-tensor $u$ local factors it is the Chapter 28 matrix $A_{1,4}$;
+with the reflected source-tensor $v$ local factors it is $A_{2,4}$.
+
+Source: arXiv:1703.09188, Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def compositionCutLeft
     (L₁ : Matrix (Fin E₁ × Fin q) ι₁ ℂ)
     (R₂ : Matrix ι₂ (Fin q × Fin E₂) ℂ)
@@ -131,6 +197,11 @@ private noncomputable def compositionCutLeft
       ∑ t : ι₂, ∑ y : Fin E₂,
         L₂ (c, K₁) t * R₂ t (J, y) * L₂ (y, K₂) rs.2
 
+/-- The right rectangular factor of the generic four-site product cut.  With
+the source-tensor $u$ local factors it is the Chapter 28 matrix $B_{1,4}$;
+with the reflected source-tensor $v$ local factors it is $B_{2,4}$.
+
+Source: arXiv:1703.09188, Theorem `IndexTh` (ii), lines 837--845. -/
 private noncomputable def compositionCutRight
     (R₁ : Matrix ι₁ (Fin q × Fin E₁) ℂ)
     (L₁ : Matrix (Fin E₁ × Fin q) ι₁ ℂ)
@@ -144,9 +215,6 @@ private noncomputable def compositionCutRight
     ∑ x : Fin E₁, ∑ J : Fin q, ∑ t : ι₁,
       R₁ rs.1 (I₁, x) * L₁ (x, J) t * R₁ t (I₂, e) * R₂ rs.2 (J, f)
 
-set_option maxHeartbeats 800000 in
--- Expanding the four local tensors and permuting the resulting eight finite sums
--- exceeds the project default before normalization identifies both expressions.
 private theorem sourceCutM₁_blockTwo_mulTensor_factorization
     (A : MPOTensor q E₁) (B : MPOTensor q E₂)
     (L₁ : Matrix (Fin E₁ × Fin q) ι₁ ℂ)
@@ -177,9 +245,15 @@ private theorem sourceCutM₁_blockTwo_mulTensor_factorization
   rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
   simp only [Equiv.symm_apply_apply]
   simp_rw [hA, hB]
-  simp only [Fintype.sum_prod_type, Finset.sum_mul, Finset.mul_sum]
-  rw [sum_eight_cut_shuffle]
-  simp only [mul_assoc, mul_left_comm, mul_comm]
+  exact sum_eight_cut_factorization
+    (fun j t₁ ↦ L₁ (a, j) t₁)
+    (fun t₁ x ↦ R₁ t₁ (I₁, x))
+    (fun t₂ ↦ L₂ (c, K₁) t₂)
+    (fun t₂ j y ↦ R₂ t₂ (j, y))
+    (fun x k s₁ ↦ L₁ (x, k) s₁)
+    (fun s₁ ↦ R₁ s₁ (I₂, e))
+    (fun y s₂ ↦ L₂ (y, K₂) s₂)
+    (fun s₂ k ↦ R₂ s₂ (k, f))
 
 end GenericCut
 
@@ -221,14 +295,14 @@ private theorem leftRank_blockTwo_mulTensor_reindexPhysical {d' : ℕ}
 
 private theorem rightRank_blockTwo_eq_blockTensor_two (U : MPOTensor d D₁) :
     r[blockTwo U] = r[blockTensor U 2] := by
-  have h : blockTwo U = reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) := by
-    exact blockTwo_eq_blockTensor_reindex U
+  have h : blockTwo U = reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) :=
+    blockTwo_eq_blockTensor_reindex U
   rw [h, rightRank_reindexPhysical]
 
 private theorem leftRank_blockTwo_eq_blockTensor_two (U : MPOTensor d D₁) :
     ℓ[blockTwo U] = ℓ[blockTensor U 2] := by
-  have h : blockTwo U = reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) := by
-    exact blockTwo_eq_blockTensor_reindex U
+  have h : blockTwo U = reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) :=
+    blockTwo_eq_blockTensor_reindex U
   rw [h, leftRank_reindexPhysical]
 
 private theorem rightRank_blockTwo_mulTensor_blockTwo_le
@@ -360,10 +434,10 @@ theorem rightRank_blockTensor_mulTensor_four_le
     (mulTensor (blockTensor U 2) (blockTensor V 2))]
   rw [← rightRank_blockTwo_mulTensor_reindexPhysical (twoSiteBlockEquiv d)
     (blockTensor U 2) (blockTensor V 2)]
-  have hU : reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) = blockTwo U := by
-    exact (blockTwo_eq_blockTensor_reindex U).symm
-  have hV : reindexPhysical (twoSiteBlockEquiv d) (blockTensor V 2) = blockTwo V := by
-    exact (blockTwo_eq_blockTensor_reindex V).symm
+  have hU : reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) = blockTwo U :=
+    (blockTwo_eq_blockTensor_reindex U).symm
+  have hV : reindexPhysical (twoSiteBlockEquiv d) (blockTensor V 2) = blockTwo V :=
+    (blockTwo_eq_blockTensor_reindex V).symm
   rw [hU, hV]
   exact rightRank_blockTwo_mulTensor_blockTwo_le U V
 
@@ -388,10 +462,10 @@ theorem leftRank_blockTensor_mulTensor_four_le
     (mulTensor (blockTensor U 2) (blockTensor V 2))]
   rw [← leftRank_blockTwo_mulTensor_reindexPhysical (twoSiteBlockEquiv d)
     (blockTensor U 2) (blockTensor V 2)]
-  have hU : reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) = blockTwo U := by
-    exact (blockTwo_eq_blockTensor_reindex U).symm
-  have hV : reindexPhysical (twoSiteBlockEquiv d) (blockTensor V 2) = blockTwo V := by
-    exact (blockTwo_eq_blockTensor_reindex V).symm
+  have hU : reindexPhysical (twoSiteBlockEquiv d) (blockTensor U 2) = blockTwo U :=
+    (blockTwo_eq_blockTensor_reindex U).symm
+  have hV : reindexPhysical (twoSiteBlockEquiv d) (blockTensor V 2) = blockTwo V :=
+    (blockTwo_eq_blockTensor_reindex V).symm
   rw [hU, hV]
   exact leftRank_blockTwo_mulTensor_blockTwo_le U V
 

--- a/TNLean/MPS/MPU/CompositionRanks.lean
+++ b/TNLean/MPS/MPU/CompositionRanks.lean
@@ -152,6 +152,9 @@ private theorem sum_eight_cut_shuffle
       rfl
     _ = _ := by simp only [Fintype.sum_prod_type]
 
+/-- Expand the product of four two-factor finite sums over the eight indices `X`, `Y`,
+`J`, `K`, `T₁`, `T₂`, `S₁`, `S₂`, permute them by `sum_eight_cut_shuffle`, and
+reassemble the result into the `T₁ × S₂` cut factorization used below. -/
 private theorem sum_eight_cut_factorization
     {X Y J K T₁ T₂ S₁ S₂ : Type*}
     [Fintype X] [Fintype Y] [Fintype J] [Fintype K]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -602,6 +602,25 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Four-site composition sum normalization
+- **Pattern:** expand a four-site product cut into eight finite indices, permute
+  those indices once, and compare only the resulting scalar summands modulo
+  associativity and commutativity of multiplication.
+- **Reuse:** the private `sum_eight_cut_factorization` lemma in
+  `TNLean/MPS/MPU/CompositionRanks.lean` performs the distributivity step on
+  abstract scalar functions.  Its proof descends through all eight sums by
+  explicit congruences and closes the scalar identity with `ac_rfl`; the
+  concrete source-tensor $u$ proof now instantiates this lemma without constructing a
+  distributed matrix-entry expression.
+- **Performance:** the cached target build before the refactor reported 25 s.
+  Profiler counts fell from 16,129,355 heartbeats in the former concrete proof
+  to 10,252,678 in the abstract helper plus 3,646,777 at its concrete call site
+  (13,899,455 total, a 13.8% reduction).  Post-refactor local wall runs
+  reported 72--89 s while unrelated checkouts were rebuilding dependencies
+  and saturating the host, so they are not comparable; the heartbeat reduction
+  projects the uncontended target below 22 s, with the isolated PR check serving
+  as the authoritative verification of the 25 s limit.
+
 ### Block entropy from real characteristic roots
 - **Pattern:** derive a block entropy from a known real multiset of characteristic roots.
 - **Reuse:** `MPOTensor.blockEntropy_of_charpoly_roots_eq` in

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -613,13 +613,13 @@ abstracted — record why, so it is not re-proposed).
   concrete source-tensor $u$ proof now instantiates this lemma without constructing a
   distributed matrix-entry expression.
 - **Performance:** the cached target build before the refactor reported 25 s.
-  Profiler counts fell from 16,129,355 heartbeats in the former concrete proof
-  to 10,252,678 in the abstract helper plus 3,646,777 at its concrete call site
-  (13,899,455 total, a 13.8% reduction).  Post-refactor local wall runs
-  reported 72--89 s while unrelated checkouts were rebuilding dependencies
-  and saturating the host, so they are not comparable; the heartbeat reduction
-  projects the uncontended target below 22 s, with the isolated PR check serving
-  as the authoritative verification of the 25 s limit.
+  Profiler-reported cumulative module-elaboration totals fell from 16,129,355
+  heartbeats before the refactor to 13,899,455 after it, a 13.8% reduction.
+  These are module-level cumulative measurements, not per-proof costs.
+  Post-refactor local wall runs reported 72--89 s while unrelated checkouts were
+  rebuilding dependencies and saturating the host, so they are not comparable;
+  the heartbeat reduction projects the uncontended target below 22 s, with the
+  isolated PR check serving as the authoritative verification of the 25 s limit.
 
 ### Block entropy from real characteristic roots
 - **Pattern:** derive a block entropy from a known real multiset of characteristic roots.


### PR DESCRIPTION
### Motivation

- PR #7006 proved the four-site source-rank bounds used in the composition part of the MPU Index Theorem, but its concrete eight-sum normalization required a local heartbeat override and crossed the changed-module timing boundary.
- The source constructs the four-site product from the two standard-form factorizations: `Papers/1703.09188/paper_v2.tex`, lines 837--845, says, “We now express U_{2k} and U'_{2k} in SF and use them to build W_{4k}.” Chapter 28 records the resulting rectangular factors as $A_{1,4},B_{1,4}$ and their reflected analogues $A_{2,4},B_{2,4}$ (`blueprint/src/chapter/ch28_mpu.tex`, lines 5002--5045).
- Issue #7047 requests a bounded normalization refactor that preserves these separate source-tensor $u$ and reflected source-tensor $v$ arguments.

### Description

- Add a private scalar `sum_eight_cut_factorization` lemma. It performs distributivity on abstract scalar functions, applies the existing eight-index permutation once, descends through all eight sums by explicit `Finset.sum_congr` steps, and closes only the scalar summand with `ac_rfl`.
- Instantiate that lemma in the concrete source-$u$ factorization, removing `set_option maxHeartbeats 800000` and the global commutative normalization of the expanded matrix-entry expression.
- Add source-mapping docstrings to the private source-$u$ and reflected source-$v$ factor scaffolding, identifying its role in $A_{1,4},B_{1,4},A_{2,4},B_{2,4}$.
- Replace the six requested `by exact` witnesses by direct terms. The separate reflected source-$v$ proof through `physicalFlip` and `reindexBond` is otherwise unchanged.
- Record the completed pattern and performance measurements in `docs/tactic_patterns.md`. No Blueprint file and no work tracked by #7026 is changed.

### Testing

- `lake build TNLean.MPS.MPU.CompositionRanks`
- `rg -n 'sorry|admit|axiom|native_decide|unsafeCast|set_option maxHeartbeats|trace\\.profiler' TNLean/MPS/MPU/CompositionRanks.lean`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- The profiler reported cumulative module-elaboration totals of 16,129,355 heartbeats before the refactor and 13,899,455 after it (13.8% fewer); these are module totals, not per-proof costs.
- The cached pre-refactor module build reported 25 s. At exact head `fb826310c3d3bda23590796564a9455b3e31528a`, CI built `TNLean.MPS.MPU.CompositionRanks` in 5.3 s, and the changed-module timing check passed.
- Exact-head CI regenerated the Blueprint declaration list and completed both the Blueprint compilation check and `checkdecls` successfully. No Blueprint source is changed.

---

Closes #7047.
Follow-up to #7006 and #6999; contributes to #6016.

### Agent assistance

Codex (GPT-5) implemented and checked the bounded Lean refactor and prepared the source mapping and performance ledger. LionSR is assigned for review and remains accountable for the change.
