### PR TITLE
doc(MPS/MPDO): display active-support trace identities

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
@@ -35,7 +35,8 @@ it defines $T_{k,h}$ at lines 1452--1455 and proves primitivity through
 line 1471.  The congruence
 $\tilde\eta_{k,h} = (V^R_k \otimes V^L_h)^\dagger \eta_{k,h}
 (V^R_k \otimes V^L_h)$, its positive semidefiniteness, and the restriction of
-the trace factors $a_k,b_h$ are additional constructions. Recorded in
+the trace factors $a_k,b_h$, including the treatment of inactive sectors as
+zero blocks, are additional constructions. Recorded in
 `docs/paper-gaps/cpsv16_active_physical_support_compression.tex`.
 -/
 
@@ -120,9 +121,13 @@ theorem neighboringOperator_eq_sum_kronecker
 vanishes.
 
 Indeed, inactivity means that either every left factor or every right factor
-in the sector vanishes, so every summand in $\eta_{k,k}$ vanishes. This is the
-zero-block case of the factorization in arXiv:1606.00608, Appendix C.2,
-equations `AppUkU=rl` and `etarl`, lines 1381--1445. -/
+in the sector vanishes, so every summand in $\eta_{k,k}$ vanishes.
+
+Source context: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
+`etarl`, lines 1383--1450, defines the sector factorization and
+$\eta_{k,h}$; line 1434 selects physical indices $\alpha,\beta$ for which the
+scalar $m_{\beta,\alpha}$ is nonzero, thereby obtaining the direct-sum form
+`formK` on line 1436. -/
 theorem neighboringOperator_self_eq_zero_of_not_isActiveSector
     (F : PhysicalSectorFactorization K) {k : Fin F.sectorCount}
     (hk : ¬ F.IsActiveSector k) :

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
@@ -124,7 +124,7 @@ Indeed, inactivity means that either every left factor or every right factor
 in the sector vanishes, so every summand in $\eta_{k,k}$ vanishes.
 
 Source context: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
-`etarl`, lines 1383--1450, defines the sector factorization and
+`etarl`, lines 1383--1450, define the sector factorization and
 $\eta_{k,h}$; line 1434 selects physical indices $\alpha,\beta$ for which the
 scalar $m_{\beta,\alpha}$ is nonzero, thereby obtaining the direct-sum form
 `formK` on line 1436. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -729,12 +729,29 @@
         \notag
     \end{align}
     Positive semidefiniteness is preserved by this matrix congruence.
-    The range projections of $V_k^R$ and $V_h^L$ absorb
-    $\eta_{k,h}$ on both sides.  Cyclicity of trace therefore gives
+    The range projections of $V_k^R$ and $V_h^L$ satisfy the two-sided
+    absorption identity
+    \begin{align}
+        (P_k^R\otimes P_h^L)\eta_{k,h}
+        =\eta_{k,h}
+        =\eta_{k,h}(P_k^R\otimes P_h^L).
+        \notag
+    \end{align}
+    Cyclicity of trace therefore gives
     $\tr(\eta^{\mathrm{act}}_{k,h})=\tr(\eta_{k,h})$.  For an inactive
-    sector, $\eta_{k,k}=0$, hence $a_kb_k=0$.  Splitting the normalized sum
-    into its active and inactive parts and reindexing the active part proves
-    the final identity.
+    sector, $\eta_{k,k}=0$, hence $a_kb_k=0$.  Consequently, splitting the
+    normalized sum and reindexing its active part by $j\mapsto k(j)$ gives
+    \begin{align}
+        1 &= \sum_k a_kb_k
+        \notag \\
+          &=\sum_{\substack{k\\ k\ \mathrm{active}}}a_kb_k
+          +\sum_{\substack{k\\ k\ \mathrm{inactive}}}a_kb_k
+        \notag \\
+          &=\sum_j\widetilde a_j\widetilde b_j+0
+        \notag \\
+          &=\sum_j\widetilde a_j\widetilde b_j.
+        \notag
+    \end{align}
 \end{proof}
 
 % This theorem supplies the orthogonal-support step used in the completed

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -88,7 +88,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L770, 783, 791, 798, 868, 875 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L183 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L320, 326, 332, 346, 357, 363 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L442, 993, 997, 1003, 1008 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L442, 1010, 1014, 1020, 1025 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 704, 708, 908, 912, 925, 929, 972, 976, 980, 989, 993 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Motivation

The exact-head post-merge review of #7044 found three documentation gaps in the project-derived active physical-support trace transport. The Lean statements and proofs were already verified; this follow-up makes the two load-bearing identities and the scope boundary explicit for third-person readers.

## Description

- display the two-sided support identity `(P^R_k \otimes P^L_h) \eta_{k,h} = \eta_{k,h} = \eta_{k,h}(P^R_k \otimes P^L_h)` before trace cyclicity;
- display the active/inactive decomposition of `\sum_k a_k b_k` and its reindexing by `j \mapsto k(j)`;
- cite CPSV16 Appendix C.2 only for the sector factorization and `\eta_{k,h}`, while marking the inactive zero-block conclusion as a project-derived extension;
- keep the line-based `tenkz` disposition inventory synchronized after the Blueprint expansion.

The notation follows CPSV16. The support compression and inactive zero-block bookkeeping are auxiliary to the source argument, as recorded in `docs/paper-gaps/cpsv16_active_physical_support_compression.tex`.

## Testing

- `git diff --check`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `texra-blueprint paper-gaps check`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_oversized_lean_files.py`
- `python3 scripts/test_check_tenkz_demolition.py`
- `python3 scripts/check_tenkz_demolition.py`
- `python3 scripts/test_check_tenkz_dispositions.py`
- `python3 scripts/check_tenkz_dispositions.py`

Full hosted Lean and Blueprint CI is required before merge.

Closes #7061.
Follow-up to #7044.