### PR TITLE
feat(MPS/MPU): supply shift source factors

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -29,6 +29,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import TNLean.MPS.MPU.SourceIndexValue
 import TNLean.MPS.MPU.SourceUBoundary
 import TNLean.MPS.MPU.SourceUClosedNetwork

--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -9,4 +9,6 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.MPU.Examples
 
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.Examples.ShiftSourceFactors
+import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks

--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.MPU.Examples
 
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks

--- a/TNLean/MPS/MPU/Examples/ShiftSourceBlockedFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceBlockedFormulas.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
+import TNLean.MPS.MPU.StandardForm
+
+/-!
+# Blocked supplied source formulas for the cyclic-shift examples
+
+This module inserts the explicit supplied source matrices of
+`ShiftSourceFormulas` into the two open-leg factorizations of an actual
+two-site block.  It thereby realizes the superscript `(2)` in
+arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3` (lines 2018--2034),
+through the paper's definition `SF` (lines 603--622).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+private theorem shiftExampleU₂_sourceU_eq_identitySwapIdentity_apply
+    (d : ℕ) [NeZero d]
+    (lr : Fin ℓ[shiftExampleU₂ d] × Fin r[shiftExampleU₂ d])
+    (ij : Fin (d * d) × Fin (d * d)) :
+    SourceFactors.sourceU (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        lr ij =
+      identitySwapIdentityMatrix d
+        ((shiftExampleU₂SourceURowEquiv d).symm lr)
+        ((shiftTwoSitePhysicalEquiv d).symm ij) := by
+  have h := congrFun
+    (congrFun (shiftExampleU₂_sourceU_reindex_eq_identitySwapIdentity d)
+      ((shiftExampleU₂SourceURowEquiv d).symm lr))
+    ((shiftTwoSitePhysicalEquiv d).symm ij)
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm, Equiv.apply_symm_apply] using h
+
+/-- The supplied two-site block of $U_2$ has central gate
+$u_2^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the paper's four-spin order.
+The statement retains the two open source-factor boundaries $X_1$ and $Y_2$.
+
+Source: arXiv:1703.09188, definition `SF` and equation `eq:uv2_U2`
+(lines 603--622 and 2018--2026). -/
+theorem shiftExampleU₂_blockTwo_apply_eq_sum_X₁_mul_u₂_two_mul_Y₂
+    (d : ℕ) [NeZero d] (I J : Fin ((d * d) * (d * d)))
+    (α γ : Fin (d * d)) :
+    blockTwo (shiftExampleU₂ d) I J α γ =
+      ∑ r : Fin r[shiftExampleU₂ d], ∑ l : Fin ℓ[shiftExampleU₂ d],
+        (shiftExampleU₂SourceFactors d).X₁
+            (α, (finProdFinEquiv.symm J).1) r *
+          identitySwapIdentityMatrix d
+            ((shiftExampleU₂SourceURowEquiv d).symm (l, r))
+            ((shiftTwoSitePhysicalEquiv d).symm
+              (finProdFinEquiv.symm I)) *
+            (shiftExampleU₂SourceFactors d).Y₂ l
+              ((finProdFinEquiv.symm J).2, γ) := by
+  simpa only [shiftExampleU₂_sourceU_eq_identitySwapIdentity_apply] using
+    SourceFactors.blockTwo_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
+      (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d) I J α γ
+
+private theorem shiftExampleU₂_sourceV_eq_swapSwap_mul_identitySwapIdentity_apply
+    (d : ℕ) [NeZero d]
+    (ij : Fin (d * d) × Fin (d * d))
+    (rl : Fin r[shiftExampleU₂ d] × Fin ℓ[shiftExampleU₂ d]) :
+    SourceFactors.sourceV (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        ij rl =
+      (swapTensorSwapMatrix d * identitySwapIdentityMatrix d)
+        ((shiftTwoSitePhysicalEquiv d).symm ij)
+        ((shiftExampleU₂SourceVColumnEquiv d).symm rl) := by
+  have h := congrFun
+    (congrFun
+      (shiftExampleU₂_sourceV_reindex_eq_swapSwap_mul_identitySwapIdentity d)
+      ((shiftTwoSitePhysicalEquiv d).symm ij))
+    ((shiftExampleU₂SourceVColumnEquiv d).symm rl)
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm, Equiv.apply_symm_apply] using h
+
+/-- The reflected supplied two-site block of $U_2$ has central gate
+$v_2^{(2)}=(\mathbb S\otimes\mathbb S)
+(\Id\otimes\mathbb S\otimes\Id)$ in the paper's four-spin order.  The
+statement retains the two open source-factor boundaries $X_2$ and $Y_1$.
+
+Source: arXiv:1703.09188, definition `SF` and equation `eq:uv2_U2`
+(lines 603--622 and 2018--2026). -/
+theorem shiftExampleU₂_blockTwo_apply_eq_sum_X₂_mul_v₂_two_reflected_mul_Y₁
+    (d : ℕ) [NeZero d] (I J : Fin ((d * d) * (d * d)))
+    (α γ : Fin (d * d)) :
+    blockTwo (shiftExampleU₂ d) I J α γ =
+      ∑ l : Fin ℓ[shiftExampleU₂ d], ∑ r : Fin r[shiftExampleU₂ d],
+        (shiftExampleU₂SourceFactors d).X₂
+            (α, (finProdFinEquiv.symm I).1) l *
+          (swapTensorSwapMatrix d * identitySwapIdentityMatrix d)
+            ((shiftTwoSitePhysicalEquiv d).symm
+              ((finProdFinEquiv.symm J).2,
+                (finProdFinEquiv.symm J).1))
+            ((shiftExampleU₂SourceVColumnEquiv d).symm (r, l)) *
+            (shiftExampleU₂SourceFactors d).Y₁ r
+              ((finProdFinEquiv.symm I).2, γ) := by
+  simpa only [shiftExampleU₂_sourceV_eq_swapSwap_mul_identitySwapIdentity_apply] using
+    SourceFactors.blockTwo_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁
+      (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d) I J α γ
+
+private theorem shiftExampleU₃_sourceU_eq_identitySwapIdentity_mul_swapSwap_apply
+    (d : ℕ) [NeZero d]
+    (lr : Fin ℓ[shiftExampleU₃ d] × Fin r[shiftExampleU₃ d])
+    (ij : Fin (d * d) × Fin (d * d)) :
+    SourceFactors.sourceU (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        lr ij =
+      (identitySwapIdentityMatrix d * swapTensorSwapMatrix d)
+        ((shiftExampleU₃SourceURowEquiv d).symm lr)
+        ((shiftTwoSitePhysicalEquiv d).symm ij) := by
+  have h := congrFun
+    (congrFun
+      (shiftExampleU₃_sourceU_reindex_eq_identitySwapIdentity_mul_swapSwap d)
+      ((shiftExampleU₃SourceURowEquiv d).symm lr))
+    ((shiftTwoSitePhysicalEquiv d).symm ij)
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm, Equiv.apply_symm_apply] using h
+
+/-- The supplied two-site block of $U_3$ has central gate
+$u_3^{(2)}=(\Id\otimes\mathbb S\otimes\Id)
+(\mathbb S\otimes\mathbb S)$ in the paper's four-spin order.  The statement
+retains the two open source-factor boundaries $X_1$ and $Y_2$.
+
+Source: arXiv:1703.09188, definition `SF` and equation `eq:uv2_U3`
+(lines 603--622 and 2028--2034). -/
+theorem shiftExampleU₃_blockTwo_apply_eq_sum_X₁_mul_u₃_two_mul_Y₂
+    (d : ℕ) [NeZero d] (I J : Fin ((d * d) * (d * d)))
+    (α γ : Fin (d * d)) :
+    blockTwo (shiftExampleU₃ d) I J α γ =
+      ∑ r : Fin r[shiftExampleU₃ d], ∑ l : Fin ℓ[shiftExampleU₃ d],
+        (shiftExampleU₃SourceFactors d).X₁
+            (α, (finProdFinEquiv.symm J).1) r *
+          (identitySwapIdentityMatrix d * swapTensorSwapMatrix d)
+            ((shiftExampleU₃SourceURowEquiv d).symm (l, r))
+            ((shiftTwoSitePhysicalEquiv d).symm
+              (finProdFinEquiv.symm I)) *
+            (shiftExampleU₃SourceFactors d).Y₂ l
+              ((finProdFinEquiv.symm J).2, γ) := by
+  simpa only [shiftExampleU₃_sourceU_eq_identitySwapIdentity_mul_swapSwap_apply] using
+    SourceFactors.blockTwo_apply_eq_sum_X₁_mul_sourceU_mul_Y₂
+      (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d) I J α γ
+
+private theorem shiftExampleU₃_sourceV_eq_identitySwapIdentity_apply
+    (d : ℕ) [NeZero d]
+    (ij : Fin (d * d) × Fin (d * d))
+    (rl : Fin r[shiftExampleU₃ d] × Fin ℓ[shiftExampleU₃ d]) :
+    SourceFactors.sourceV (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        ij rl =
+      identitySwapIdentityMatrix d
+        ((shiftTwoSitePhysicalEquiv d).symm ij)
+        ((shiftExampleU₃SourceVColumnEquiv d).symm rl) := by
+  have h := congrFun
+    (congrFun (shiftExampleU₃_sourceV_reindex_eq_identitySwapIdentity d)
+      ((shiftTwoSitePhysicalEquiv d).symm ij))
+    ((shiftExampleU₃SourceVColumnEquiv d).symm rl)
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm, Equiv.apply_symm_apply] using h
+
+/-- The reflected supplied two-site block of $U_3$ has central gate
+$v_3^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the paper's four-spin order.
+The statement retains the two open source-factor boundaries $X_2$ and $Y_1$.
+
+Source: arXiv:1703.09188, definition `SF` and equation `eq:uv2_U3`
+(lines 603--622 and 2028--2034). -/
+theorem shiftExampleU₃_blockTwo_apply_eq_sum_X₂_mul_v₃_two_reflected_mul_Y₁
+    (d : ℕ) [NeZero d] (I J : Fin ((d * d) * (d * d)))
+    (α γ : Fin (d * d)) :
+    blockTwo (shiftExampleU₃ d) I J α γ =
+      ∑ l : Fin ℓ[shiftExampleU₃ d], ∑ r : Fin r[shiftExampleU₃ d],
+        (shiftExampleU₃SourceFactors d).X₂
+            (α, (finProdFinEquiv.symm I).1) l *
+          identitySwapIdentityMatrix d
+            ((shiftTwoSitePhysicalEquiv d).symm
+              ((finProdFinEquiv.symm J).2,
+                (finProdFinEquiv.symm J).1))
+            ((shiftExampleU₃SourceVColumnEquiv d).symm (r, l)) *
+            (shiftExampleU₃SourceFactors d).Y₁ r
+              ((finProdFinEquiv.symm I).2, γ) := by
+  simpa only [shiftExampleU₃_sourceV_eq_identitySwapIdentity_apply] using
+    SourceFactors.blockTwo_apply_eq_sum_X₂_mul_sourceV_reflected_mul_Y₁
+      (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d) I J α γ
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -1,0 +1,678 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ComplexSqrt
+import TNLean.MPS.MPU.Examples.ShiftSourceRanks
+import TNLean.MPS.MPU.SourceUV
+
+/-!
+# Supplied source factors for the cyclic-shift examples
+
+This module chooses the source factorizations used for the three shift families
+in arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3`
+(lines 2009--2034).  The choices are explicit; none of the statements below
+identifies these factors with the factors chosen by compact singular-value
+decomposition.
+-/
+
+open scoped Matrix Kronecker BigOperators
+
+namespace MPOTensor
+
+private noncomputable def sourceSqrt (d : ℕ) : ℂ :=
+  Real.sqrt d
+
+private theorem sourceSqrt_ne_zero (d : ℕ) [NeZero d] : sourceSqrt d ≠ 0 := by
+  unfold sourceSqrt
+  exact Complex.ofReal_ne_zero.mpr <|
+    Real.sqrt_ne_zero'.2 (by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d))
+
+private theorem sourceSqrt_sq (d : ℕ) : sourceSqrt d ^ 2 = (d : ℂ) := by
+  exact Complex.ofReal_sqrt_sq d (by positivity)
+
+private theorem sourceSqrt_inv_mul_nat_mul_inv (d : ℕ) [NeZero d] :
+    (sourceSqrt d)⁻¹ * (d : ℂ) * (sourceSqrt d)⁻¹ = 1 := by
+  rw [← sourceSqrt_sq]
+  field_simp [sourceSqrt_ne_zero d]
+
+private theorem nat_mul_sourceSqrt_inv_mul_inv (d : ℕ) [NeZero d] :
+    (d : ℂ) * ((sourceSqrt d)⁻¹ * (sourceSqrt d)⁻¹) = 1 := by
+  simpa [mul_comm, mul_left_comm, mul_assoc] using
+    sourceSqrt_inv_mul_nat_mul_inv d
+
+private noncomputable def normalizedIdentityVec (d : ℕ) : Fin d × Fin d → ℂ :=
+  (sourceSqrt d)⁻¹ • (1 : Matrix (Fin d) (Fin d) ℂ).vec
+
+private noncomputable def normalizedIdentityColumn (d : ℕ) :
+    Matrix (Fin d × Fin d) (Fin 1) ℂ :=
+  Matrix.replicateCol (Fin 1) (normalizedIdentityVec d)
+
+private theorem identityVec_star_dotProduct_identityVec (d : ℕ) :
+    star (1 : Matrix (Fin d) (Fin d) ℂ).vec ⬝ᵥ
+        (1 : Matrix (Fin d) (Fin d) ℂ).vec = d := by
+  rw [Matrix.star_vec_dotProduct_vec]
+  simp
+
+private theorem normalizedIdentityVec_star_dotProduct_normalizedIdentityVec
+    (d : ℕ) [NeZero d] :
+    star (normalizedIdentityVec d) ⬝ᵥ normalizedIdentityVec d = 1 := by
+  rw [normalizedIdentityVec, star_smul, smul_dotProduct, dotProduct_smul,
+    identityVec_star_dotProduct_identityVec]
+  simp only [smul_eq_mul, star_inv₀]
+  rw [show star (sourceSqrt d) = sourceSqrt d by simp [sourceSqrt]]
+  simpa [mul_comm, mul_left_comm, mul_assoc] using
+    sourceSqrt_inv_mul_nat_mul_inv d
+
+private theorem normalizedIdentityColumn_isIsometry (d : ℕ) [NeZero d] :
+    (normalizedIdentityColumn d).IsIsometry := by
+  rw [Matrix.IsIsometry, normalizedIdentityColumn,
+    Matrix.conjTranspose_replicateCol]
+  ext a b
+  simp [normalizedIdentityVec_star_dotProduct_normalizedIdentityVec d,
+    Matrix.one_apply, Subsingleton.elim a b]
+
+private theorem normalizedIdentityColumn_mul_scaled_conjTranspose (d : ℕ)
+    [NeZero d] :
+    normalizedIdentityColumn d *
+        ((d : ℂ) • (normalizedIdentityColumn d)ᴴ) =
+      Matrix.vecMulVec (1 : Matrix (Fin d) (Fin d) ℂ).vec
+        (1 : Matrix (Fin d) (Fin d) ℂ).vec := by
+  ext ⟨a, b⟩ ⟨c, e⟩
+  have hsstar : star (sourceSqrt d) = sourceSqrt d := by simp [sourceSqrt]
+  by_cases hab : b = a <;> by_cases hce : e = c <;>
+    simp [Matrix.mul_apply, normalizedIdentityColumn,
+      normalizedIdentityVec, Matrix.vecMulVec_apply, Matrix.vec,
+      hab, hce, hsstar, nat_mul_sourceSqrt_inv_mul_inv,
+      mul_comm, mul_left_comm]
+
+private theorem scaled_conjTranspose_mul_inverse_scaled_column (d : ℕ)
+    [NeZero d] :
+    ((d : ℂ) • (normalizedIdentityColumn d)ᴴ) *
+        ((d : ℂ)⁻¹ • normalizedIdentityColumn d) = 1 := by
+  calc
+    ((d : ℂ) • (normalizedIdentityColumn d)ᴴ) *
+        ((d : ℂ)⁻¹ • normalizedIdentityColumn d) =
+        ((d : ℂ) * (d : ℂ)⁻¹) •
+          ((normalizedIdentityColumn d)ᴴ * normalizedIdentityColumn d) := by
+            simp [Matrix.mul_smul, Matrix.smul_mul, smul_smul]
+    _ = 1 := by
+      rw [mul_inv_cancel₀ (by exact_mod_cast NeZero.ne d)]
+      simpa only [one_smul, Matrix.IsIsometry] using
+        normalizedIdentityColumn_isIsometry d
+
+/-- The product coordinates are the right source coordinates of the right shift.
+
+Source: arXiv:1703.09188, lines 2009--2034. -/
+noncomputable def rightShiftRightRankEquiv (d : ℕ) :
+    Fin d × Fin d ≃ Fin r[rightShiftTensor d] :=
+  finProdFinEquiv.trans (finCongr (rightRank_rightShiftTensor d).symm)
+
+/-- The unique coordinate is the left source coordinate of the right shift.
+
+Source: arXiv:1703.09188, lines 2009--2034. -/
+noncomputable def rightShiftLeftRankEquiv (d : ℕ) [NeZero d] :
+    Fin 1 ≃ Fin ℓ[rightShiftTensor d] :=
+  finCongr (leftRank_rightShiftTensor d).symm
+
+/-- The unique coordinate is the right source coordinate of the left shift.
+
+Source: arXiv:1703.09188, lines 2009--2034. -/
+noncomputable def leftShiftRightRankEquiv (d : ℕ) [NeZero d] :
+    Fin 1 ≃ Fin r[leftShiftTensor d] :=
+  finCongr (rightRank_leftShiftTensor d).symm
+
+/-- The product coordinates are the left source coordinates of the left shift.
+
+Source: arXiv:1703.09188, lines 2009--2034. -/
+noncomputable def leftShiftLeftRankEquiv (d : ℕ) :
+    Fin d × Fin d ≃ Fin ℓ[leftShiftTensor d] :=
+  finProdFinEquiv.trans (finCongr (leftRank_leftShiftTensor d).symm)
+
+/-- Remove the unique virtual coordinate from a source-cut row of the
+bond-one identity tensor.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+def identitySourceRowEquiv (d : ℕ) : Fin 1 × Fin d ≃ Fin d where
+  toFun x := x.2
+  invFun i := (0, i)
+  left_inv x := by ext <;> simp
+  right_inv _ := rfl
+
+/-- Remove the unique virtual coordinate from a source-cut column of the
+bond-one identity tensor.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+def identitySourceColumnEquiv (d : ℕ) : Fin d × Fin 1 ≃ Fin d where
+  toFun x := x.1
+  invFun i := (i, 0)
+  left_inv x := by ext <;> simp
+  right_inv _ := rfl
+
+@[simp] theorem identitySourceRowEquiv_apply (d : ℕ) (x : Fin 1 × Fin d) :
+    identitySourceRowEquiv d x = x.2 := rfl
+
+@[simp] theorem identitySourceRowEquiv_symm_apply (d : ℕ) (i : Fin d) :
+    (identitySourceRowEquiv d).symm i = (0, i) := rfl
+
+@[simp] theorem identitySourceColumnEquiv_apply (d : ℕ) (x : Fin d × Fin 1) :
+    identitySourceColumnEquiv d x = x.1 := rfl
+
+@[simp] theorem identitySourceColumnEquiv_symm_apply (d : ℕ) (i : Fin d) :
+    (identitySourceColumnEquiv d).symm i = (i, 0) := rfl
+
+/-- Both source cuts of the bond-one identity tensor are the identity after
+removing their unique virtual coordinates.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem sourceCutM₁_identityMPUTensor (d : ℕ) :
+    sourceCutM₁ (identityMPUTensor d) =
+      Matrix.reindex (identitySourceRowEquiv d).symm
+        (identitySourceColumnEquiv d).symm
+        (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  ext ⟨α, j⟩ ⟨i, β⟩
+  have hαβ : α = β := Subsingleton.elim _ _
+  by_cases hij : i = j
+  · simp [sourceCutM₁, identityMPUTensor, idTensor, Matrix.reindex_apply,
+      Matrix.one_apply, hij, hαβ]
+  · have hji : j ≠ i := Ne.symm hij
+    simp [sourceCutM₁, identityMPUTensor, idTensor, Matrix.reindex_apply,
+      Matrix.one_apply, hij, hji, hαβ]
+
+/-- The second source cut of the bond-one identity tensor is the same
+reindexed identity as its first source cut.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem sourceCutM₂_identityMPUTensor (d : ℕ) :
+    sourceCutM₂ (identityMPUTensor d) =
+      Matrix.reindex (identitySourceRowEquiv d).symm
+        (identitySourceColumnEquiv d).symm
+        (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  ext ⟨α, i⟩ ⟨j, β⟩
+  have hαβ : α = β := Subsingleton.elim _ _
+  by_cases hij : i = j <;>
+    simp [sourceCutM₂, identityMPUTensor, idTensor, Matrix.reindex_apply,
+      Matrix.one_apply, hij, hαβ]
+
+/-- The right source rank of the bond-one identity tensor is its physical
+dimension.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem rightRank_identityMPUTensor (d : ℕ) :
+    r[identityMPUTensor d] = d := by
+  rw [rightRank, sourceCutM₁_identityMPUTensor, Matrix.rank_reindex,
+    Matrix.rank_one]
+  simp
+
+/-- The left source rank of the bond-one identity tensor is its physical
+dimension.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem leftRank_identityMPUTensor (d : ℕ) :
+    ℓ[identityMPUTensor d] = d := by
+  rw [leftRank, sourceCutM₂_identityMPUTensor, Matrix.rank_reindex,
+    Matrix.rank_one]
+  simp
+
+/-- Physical coordinates are the right source coordinates of the bond-one
+identity tensor.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def identityRightRankEquiv (d : ℕ) :
+    Fin d ≃ Fin r[identityMPUTensor d] :=
+  finCongr (rightRank_identityMPUTensor d).symm
+
+/-- Physical coordinates are the left source coordinates of the bond-one
+identity tensor.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def identityLeftRankEquiv (d : ℕ) :
+    Fin d ≃ Fin ℓ[identityMPUTensor d] :=
+  finCongr (leftRank_identityMPUTensor d).symm
+
+/-- Explicit supplied source factors for the bond-one identity tensor.
+
+Both cuts are transported identity matrices.  This is the building block for
+$u_1=v_1=\Id\otimes\Id$ in arXiv:1703.09188, equation
+`eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def identitySourceFactors (d : ℕ) :
+    SourceFactors (identityMPUTensor d) (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
+  let eRow := identitySourceRowEquiv d
+  let eCol := identitySourceColumnEquiv d
+  let eR := identityRightRankEquiv d
+  let eL := identityLeftRankEquiv d
+  let X₁ : Matrix (Fin 1 × Fin d) (Fin r[identityMPUTensor d]) ℂ :=
+    Matrix.reindex eRow.symm eR (1 : Matrix (Fin d) (Fin d) ℂ)
+  let Y₁ : Matrix (Fin r[identityMPUTensor d]) (Fin d × Fin 1) ℂ :=
+    Matrix.reindex eR eCol.symm (1 : Matrix (Fin d) (Fin d) ℂ)
+  let Z₁ : Matrix (Fin d × Fin 1) (Fin r[identityMPUTensor d]) ℂ :=
+    Matrix.reindex eCol.symm eR (1 : Matrix (Fin d) (Fin d) ℂ)
+  let X₂ : Matrix (Fin 1 × Fin d) (Fin ℓ[identityMPUTensor d]) ℂ :=
+    Matrix.reindex eRow.symm eL (1 : Matrix (Fin d) (Fin d) ℂ)
+  let Y₂ : Matrix (Fin ℓ[identityMPUTensor d]) (Fin d × Fin 1) ℂ :=
+    Matrix.reindex eL eCol.symm (1 : Matrix (Fin d) (Fin d) ℂ)
+  let Z₂ : Matrix (Fin d × Fin 1) (Fin ℓ[identityMPUTensor d]) ℂ :=
+    Matrix.reindex eCol.symm eL (1 : Matrix (Fin d) (Fin d) ℂ)
+  have hone : (1 : Matrix (Fin d) (Fin d) ℂ).IsUnitaryBetween :=
+    ⟨by simp [Matrix.IsIsometry], by simp [Matrix.IsCoisometry]⟩
+  have hX₁ : X₁.IsUnitaryBetween :=
+    Matrix.IsUnitaryBetween.reindex _ hone eRow.symm eR
+  have hX₂ : X₂.IsUnitaryBetween :=
+    Matrix.IsUnitaryBetween.reindex _ hone eRow.symm eL
+  have hcut₁ : sourceCutM₁ (identityMPUTensor d) = X₁ * Y₁ := by
+    rw [sourceCutM₁_identityMPUTensor]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow.symm eCol.symm 1 =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow.symm eR 1 *
+        Matrix.reindexLinearEquiv ℂ ℂ eR eCol.symm 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow.symm eR eCol.symm,
+      Matrix.one_mul]
+  have hcut₂ : sourceCutM₂ (identityMPUTensor d) = X₂ * Y₂ := by
+    rw [sourceCutM₂_identityMPUTensor]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow.symm eCol.symm 1 =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow.symm eL 1 *
+        Matrix.reindexLinearEquiv ℂ ℂ eL eCol.symm 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow.symm eL eCol.symm,
+      Matrix.one_mul]
+  have hweighted : X₁ᴴ * sourceWeight (d := d)
+      (1 : Matrix (Fin 1) (Fin 1) ℂ) * X₁ = 1 := by
+    rw [show sourceWeight (d := d) (1 : Matrix (Fin 1) (Fin 1) ℂ) = 1 by
+      simp [sourceWeight]]
+    simpa [Matrix.IsIsometry] using hX₁.1
+  have hY₁Z₁ : Y₁ * Z₁ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eR eCol.symm 1 *
+        Matrix.reindexLinearEquiv ℂ ℂ eCol.symm eR 1 = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eR eCol.symm eR,
+      Matrix.one_mul, Matrix.reindexLinearEquiv_one]
+  have hY₂Z₂ : Y₂ * Z₂ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eL eCol.symm 1 *
+        Matrix.reindexLinearEquiv ℂ ℂ eCol.symm eL 1 = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eL eCol.symm eL,
+      Matrix.one_mul, Matrix.reindexLinearEquiv_one]
+  exact ⟨X₁, Y₁, Z₁, X₂, Y₂, Z₂, hcut₁, hcut₂,
+    hweighted, hX₂.1, hY₁Z₁, hY₂Z₂⟩
+
+/-- Explicit supplied source factors for the right-shift tensor.
+
+The first cut is the identity in the coordinates `rightShiftRightRankEquiv`.
+The second cut uses the normalized vectorization of the identity matrix.  This
+is the elementary right-shift factorization used in arXiv:1703.09188,
+equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (rightShiftTensor d) (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  let eR := rightShiftRightRankEquiv d
+  let eL := rightShiftLeftRankEquiv d
+  let P : Matrix (Fin d × Fin d) (Fin r[rightShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eR (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+  let C : Matrix (Fin d × Fin d) (Fin ℓ[rightShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eL (normalizedIdentityColumn d)
+  let R : Matrix (Fin ℓ[rightShiftTensor d]) (Fin d × Fin d) ℂ :=
+    Matrix.reindex eL (Equiv.refl _)
+      ((d : ℂ) • (normalizedIdentityColumn d)ᴴ)
+  let Z : Matrix (Fin d × Fin d) (Fin ℓ[rightShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eL
+      ((d : ℂ)⁻¹ • normalizedIdentityColumn d)
+  have hP : P.IsUnitaryBetween := by
+    apply Matrix.IsUnitaryBetween.reindex
+    exact ⟨by simp [Matrix.IsIsometry], by simp [Matrix.IsCoisometry]⟩
+  have hC : C.IsIsometry := by
+    exact Matrix.IsIsometry.reindex _ (normalizedIdentityColumn_isIsometry d)
+      (Equiv.refl _) eL
+  have hcut₁ : sourceCutM₁ (rightShiftTensor d) = P * Pᴴ := by
+    rw [sourceCutM₁_rightShiftTensor]
+    exact hP.2.symm
+  have hcut₂ : sourceCutM₂ (rightShiftTensor d) = C * R := by
+    rw [sourceCutM₂_rightShiftTensor]
+    change _ =
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) eL (normalizedIdentityColumn d) *
+        Matrix.reindexLinearEquiv ℂ ℂ eL (Equiv.refl _)
+          ((d : ℂ) • (normalizedIdentityColumn d)ᴴ)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) eL (Equiv.refl _),
+      normalizedIdentityColumn_mul_scaled_conjTranspose d]
+    rfl
+  have hweighted : Pᴴ * sourceWeight (d := d)
+      (1 : Matrix (Fin d) (Fin d) ℂ) * P = 1 := by
+    rw [show sourceWeight (d := d) (1 : Matrix (Fin d) (Fin d) ℂ) = 1 by
+      simp [sourceWeight]]
+    simpa [Matrix.IsIsometry] using hP.1
+  have hRZ : R * Z = 1 := by
+    change
+      Matrix.reindexLinearEquiv ℂ ℂ eL (Equiv.refl _)
+          ((d : ℂ) • (normalizedIdentityColumn d)ᴴ) *
+        Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) eL
+          ((d : ℂ)⁻¹ • normalizedIdentityColumn d) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eL (Equiv.refl _) eL,
+      scaled_conjTranspose_mul_inverse_scaled_column d,
+      Matrix.reindexLinearEquiv_one]
+  exact ⟨P, Pᴴ, P, C, R, Z, hcut₁, hcut₂, hweighted, hC,
+    hP.1, hRZ⟩
+
+/-- Explicit supplied source factors for the left-shift tensor.
+
+The first cut uses the normalized vectorization of the identity matrix.  The
+second cut is the identity in the coordinates `leftShiftLeftRankEquiv`.  This
+is the elementary left-shift factorization used in arXiv:1703.09188,
+equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+noncomputable def leftShiftSourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (leftShiftTensor d) (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  let eR := leftShiftRightRankEquiv d
+  let eL := leftShiftLeftRankEquiv d
+  let C : Matrix (Fin d × Fin d) (Fin r[leftShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eR (normalizedIdentityColumn d)
+  let R : Matrix (Fin r[leftShiftTensor d]) (Fin d × Fin d) ℂ :=
+    Matrix.reindex eR (Equiv.refl _)
+      ((d : ℂ) • (normalizedIdentityColumn d)ᴴ)
+  let Z : Matrix (Fin d × Fin d) (Fin r[leftShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eR
+      ((d : ℂ)⁻¹ • normalizedIdentityColumn d)
+  let P : Matrix (Fin d × Fin d) (Fin ℓ[leftShiftTensor d]) ℂ :=
+    Matrix.reindex (Equiv.refl _) eL
+      (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+  have hC : C.IsIsometry := by
+    exact Matrix.IsIsometry.reindex _ (normalizedIdentityColumn_isIsometry d)
+      (Equiv.refl _) eR
+  have hP : P.IsUnitaryBetween := by
+    apply Matrix.IsUnitaryBetween.reindex
+    exact ⟨by simp [Matrix.IsIsometry], by simp [Matrix.IsCoisometry]⟩
+  have hcut₁ : sourceCutM₁ (leftShiftTensor d) = C * R := by
+    rw [sourceCutM₁_leftShiftTensor]
+    change _ =
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) eR (normalizedIdentityColumn d) *
+        Matrix.reindexLinearEquiv ℂ ℂ eR (Equiv.refl _)
+          ((d : ℂ) • (normalizedIdentityColumn d)ᴴ)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) eR (Equiv.refl _),
+      normalizedIdentityColumn_mul_scaled_conjTranspose d]
+    rfl
+  have hcut₂ : sourceCutM₂ (leftShiftTensor d) = P * Pᴴ := by
+    rw [sourceCutM₂_leftShiftTensor]
+    exact hP.2.symm
+  have hweighted : Cᴴ * sourceWeight (d := d)
+      (1 : Matrix (Fin d) (Fin d) ℂ) * C = 1 := by
+    rw [show sourceWeight (d := d) (1 : Matrix (Fin d) (Fin d) ℂ) = 1 by
+      simp [sourceWeight]]
+    simpa [Matrix.IsIsometry] using hC
+  have hRZ : R * Z = 1 := by
+    change
+      Matrix.reindexLinearEquiv ℂ ℂ eR (Equiv.refl _)
+          ((d : ℂ) • (normalizedIdentityColumn d)ᴴ) *
+        Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) eR
+          ((d : ℂ)⁻¹ • normalizedIdentityColumn d) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eR (Equiv.refl _) eR,
+      scaled_conjTranspose_mul_inverse_scaled_column d,
+      Matrix.reindexLinearEquiv_one]
+  exact ⟨C, R, Z, P, Pᴴ, P, hcut₁, hcut₂, hweighted, hP.1,
+    hRZ, hP.1⟩
+
+/-- Product source coordinates, followed by the multiplicative right-rank
+identification for an independent tensor product.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+noncomputable def tensorProductRightRankEquiv
+    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
+    Fin r[U] × Fin r[V] ≃ Fin r[tensorProduct U V] :=
+  finProdFinEquiv.trans (finCongr (rightRank_tensorProduct U V).symm)
+
+/-- Product source coordinates, followed by the multiplicative left-rank
+identification for an independent tensor product.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+noncomputable def tensorProductLeftRankEquiv
+    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
+    Fin ℓ[U] × Fin ℓ[V] ≃ Fin ℓ[tensorProduct U V] :=
+  finProdFinEquiv.trans (finCongr (leftRank_tensorProduct U V).symm)
+
+private theorem tensorProductCutShuffle_symm_apply
+    (a b c f : ℕ) (x : Fin a × Fin b) (y : Fin c × Fin f) :
+    (tensorProductCutShuffle a b c f).symm
+        (finProdFinEquiv (x.1, y.1), finProdFinEquiv (x.2, y.2)) = (x, y) :=
+  (tensorProductCutShuffle a b c f).symm_apply_apply (x, y)
+
+private noncomputable def SourceFactors.independentTensorProduct
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ)) :
+    SourceFactors (tensorProduct U V)
+      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) := by
+  let eRow := tensorProductCutShuffle D d E e
+  let eCol := tensorProductCutShuffle d D e E
+  let eR := tensorProductRightRankEquiv U V
+  let eL := tensorProductLeftRankEquiv U V
+  let X₁ := Matrix.reindex eRow eR (S.X₁ ⊗ₖ T.X₁)
+  let Y₁ := Matrix.reindex eR eCol (S.Y₁ ⊗ₖ T.Y₁)
+  let Z₁ := Matrix.reindex eCol eR (S.Z₁ ⊗ₖ T.Z₁)
+  let X₂ := Matrix.reindex eRow eL (S.X₂ ⊗ₖ T.X₂)
+  let Y₂ := Matrix.reindex eL eCol (S.Y₂ ⊗ₖ T.Y₂)
+  let Z₂ := Matrix.reindex eCol eL (S.Z₂ ⊗ₖ T.Z₂)
+  have hSX₁ : S.X₁.IsIsometry := by
+    have h := S.X₁_weighted_isometry
+    rw [show sourceWeight (d := d) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 by
+      simp [sourceWeight]] at h
+    simpa [Matrix.IsIsometry] using h
+  have hTX₁ : T.X₁.IsIsometry := by
+    have h := T.X₁_weighted_isometry
+    rw [show sourceWeight (d := e) (1 : Matrix (Fin E) (Fin E) ℂ) = 1 by
+      simp [sourceWeight]] at h
+    simpa [Matrix.IsIsometry] using h
+  have hKX₁ : (S.X₁ ⊗ₖ T.X₁).IsIsometry := by
+    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul]
+    change (S.X₁ᴴ * S.X₁) ⊗ₖ (T.X₁ᴴ * T.X₁) = 1
+    rw [show S.X₁ᴴ * S.X₁ = 1 by exact hSX₁,
+      show T.X₁ᴴ * T.X₁ = 1 by exact hTX₁]
+    simp
+  have hKX₂ : (S.X₂ ⊗ₖ T.X₂).IsIsometry := by
+    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul]
+    change (S.X₂ᴴ * S.X₂) ⊗ₖ (T.X₂ᴴ * T.X₂) = 1
+    rw [show S.X₂ᴴ * S.X₂ = 1 by exact S.X₂_isometry,
+      show T.X₂ᴴ * T.X₂ = 1 by exact T.X₂_isometry]
+    simp
+  have hX₁ : X₁.IsIsometry :=
+    Matrix.IsIsometry.reindex _ hKX₁ eRow eR
+  have hX₂ : X₂.IsIsometry :=
+    Matrix.IsIsometry.reindex _ hKX₂ eRow eL
+  have hcut₁ : sourceCutM₁ (tensorProduct U V) = X₁ * Y₁ := by
+    rw [sourceCutM₁_tensorProduct, S.sourceCutM₁_eq, T.sourceCutM₁_eq]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
+        ((S.X₁ * S.Y₁) ⊗ₖ (T.X₁ * T.Y₁)) =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow eR (S.X₁ ⊗ₖ T.X₁) *
+        Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eR eCol,
+      Matrix.mul_kronecker_mul]
+  have hcut₂ : sourceCutM₂ (tensorProduct U V) = X₂ * Y₂ := by
+    rw [sourceCutM₂_tensorProduct, S.sourceCutM₂_eq, T.sourceCutM₂_eq]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
+        ((S.X₂ * S.Y₂) ⊗ₖ (T.X₂ * T.Y₂)) =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow eL (S.X₂ ⊗ₖ T.X₂) *
+        Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eL eCol,
+      Matrix.mul_kronecker_mul]
+  have hweighted : X₁ᴴ * sourceWeight (d := d * e)
+      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) * X₁ = 1 := by
+    rw [show sourceWeight (d := d * e)
+        (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) = 1 by
+      simp [sourceWeight]]
+    simpa [Matrix.IsIsometry] using hX₁
+  have hY₁Z₁ : Y₁ * Z₁ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁) *
+      Matrix.reindexLinearEquiv ℂ ℂ eCol eR (S.Z₁ ⊗ₖ T.Z₁) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eR eCol eR,
+      ← Matrix.mul_kronecker_mul, S.Y₁_mul_Z₁, T.Y₁_mul_Z₁]
+    simp
+  have hY₂Z₂ : Y₂ * Z₂ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂) *
+      Matrix.reindexLinearEquiv ℂ ℂ eCol eL (S.Z₂ ⊗ₖ T.Z₂) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eL eCol eL,
+      ← Matrix.mul_kronecker_mul, S.Y₂_mul_Z₂, T.Y₂_mul_Z₂]
+    simp
+  exact ⟨X₁, Y₁, Z₁, X₂, Y₂, Z₂, hcut₁, hcut₂,
+    hweighted, hX₂, hY₁Z₁, hY₂Z₂⟩
+
+private theorem SourceFactors.sourceU_independentTensorProduct_apply
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
+    (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) (rᵤ : Fin r[U]) (rᵥ : Fin r[V])
+    (i₁ i₂ : Fin d) (j₁ j₂ : Fin e) :
+    SourceFactors.sourceU (tensorProduct U V)
+        (SourceFactors.independentTensorProduct S T)
+        (tensorProductLeftRankEquiv U V (lᵤ, lᵥ),
+          tensorProductRightRankEquiv U V (rᵤ, rᵥ))
+        (finProdFinEquiv (i₁, j₁), finProdFinEquiv (i₂, j₂)) =
+      SourceFactors.sourceU U S (lᵤ, rᵤ) (i₁, i₂) *
+        SourceFactors.sourceU V T (lᵥ, rᵥ) (j₁, j₂) := by
+  simp only [SourceFactors.sourceU, SourceFactors.independentTensorProduct]
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro β _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [tensorProductCutShuffle_symm_apply d D e E (i₁, β) (j₁, γ),
+    tensorProductCutShuffle_symm_apply D d E e (β, i₂) (γ, j₂)]
+  ring
+
+private theorem SourceFactors.sourceV_independentTensorProduct_apply
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
+    (j₁ j₂ : Fin d) (k₁ k₂ : Fin e)
+    (rᵤ : Fin r[U]) (rᵥ : Fin r[V]) (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) :
+    SourceFactors.sourceV (tensorProduct U V)
+        (SourceFactors.independentTensorProduct S T)
+        (finProdFinEquiv (j₁, k₁), finProdFinEquiv (j₂, k₂))
+        (tensorProductRightRankEquiv U V (rᵤ, rᵥ),
+          tensorProductLeftRankEquiv U V (lᵤ, lᵥ)) =
+      SourceFactors.sourceV U S (j₁, j₂) (rᵤ, lᵤ) *
+        SourceFactors.sourceV V T (k₁, k₂) (rᵥ, lᵥ) := by
+  simp only [SourceFactors.sourceV, SourceFactors.independentTensorProduct]
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [tensorProductCutShuffle_symm_apply D d E e (α, j₁) (γ, k₁),
+    tensorProductCutShuffle_symm_apply d D e E (j₂, α) (k₂, γ)]
+  ring
+
+/-- Explicit supplied source factors for the paper's identity family $U_1$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁SourceFactors (d : ℕ) :
+    SourceFactors (shiftExampleU₁ d) (1 : Matrix (Fin 1) (Fin 1) ℂ) :=
+  SourceFactors.independentTensorProduct (identitySourceFactors d)
+    (identitySourceFactors d)
+
+/-- Explicit supplied source factors for the paper's counter-shift family $U_2$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂SourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (shiftExampleU₂ d)
+      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
+  SourceFactors.independentTensorProduct (leftShiftSourceFactors d)
+    (rightShiftSourceFactors d)
+
+/-- Explicit supplied source factors for the paper's reversed counter-shift
+family $U_3$.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
+(lines 2009--2016 and 2028--2034). -/
+noncomputable def shiftExampleU₃SourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (shiftExampleU₃ d)
+      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
+  SourceFactors.independentTensorProduct (rightShiftSourceFactors d)
+    (leftShiftSourceFactors d)
+
+/-- Entry formula for the source $u$ supplied by the bond-one identity
+factors.  The source row is written in the paper order (left, right).
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem sourceU_identitySourceFactors_apply (d : ℕ) (l r i₁ i₂ : Fin d) :
+    SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
+        (identityLeftRankEquiv d l, identityRightRankEquiv d r) (i₁, i₂) =
+      if r = i₁ ∧ l = i₂ then 1 else 0 := by
+  by_cases hr : r = i₁ <;> by_cases hl : l = i₂ <;>
+    simp [SourceFactors.sourceU_apply, identitySourceFactors,
+      Matrix.reindex_apply, Matrix.one_apply, hr, hl, ne_comm]
+
+/-- Entry formula for the source $v$ supplied by the bond-one identity
+factors.  Its source column has the paper order (right, left).
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem sourceV_identitySourceFactors_apply (d : ℕ) (j₁ j₂ r l : Fin d) :
+    SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
+        (j₁, j₂) (identityRightRankEquiv d r, identityLeftRankEquiv d l) =
+      if r = j₁ ∧ l = j₂ then 1 else 0 := by
+  by_cases hr : r = j₁ <;> by_cases hl : l = j₂ <;>
+    simp [SourceFactors.sourceV_apply, identitySourceFactors,
+      Matrix.reindex_apply, Matrix.one_apply, hr, hl]
+  all_goals grind
+
+/-- Entry formula for the source $u$ supplied by the right-shift factors.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
+`eq:uv2_U3` (lines 2009--2034). -/
+theorem sourceU_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
+    (a b i₁ i₂ : Fin d) :
+    SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+        (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) (i₁, i₂) =
+      if a = i₁ ∧ b = i₂ then (Real.sqrt d : ℂ)⁻¹ else 0 := by
+  by_cases ha : a = i₁ <;> by_cases hb : b = i₂ <;>
+    simp [SourceFactors.sourceU_apply, rightShiftSourceFactors,
+      normalizedIdentityColumn, normalizedIdentityVec, Matrix.reindex_apply,
+      Matrix.one_apply, sourceSqrt, ha, hb]
+
+/-- Entry formula for the source $v$ supplied by the right-shift factors.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
+`eq:uv2_U3` (lines 2009--2034). -/
+theorem sourceV_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
+    (j₁ j₂ a b : Fin d) :
+    SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+        (j₁, j₂) (rightShiftRightRankEquiv d (a, b), rightShiftLeftRankEquiv d 0) =
+      if a = j₂ ∧ b = j₁ then (d : ℂ) * (Real.sqrt d : ℂ)⁻¹ else 0 := by
+  by_cases ha : a = j₂ <;> by_cases hb : b = j₁ <;>
+    simp [SourceFactors.sourceV_apply, rightShiftSourceFactors,
+      normalizedIdentityColumn, normalizedIdentityVec, Matrix.reindex_apply,
+      Matrix.one_apply, sourceSqrt, ha, hb, NeZero.ne d,
+      mul_comm, mul_left_comm]
+  all_goals grind
+
+/-- Entry formula for the source $u$ supplied by the left-shift factors.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
+`eq:uv2_U3` (lines 2009--2034). -/
+theorem sourceU_leftShiftSourceFactors_apply (d : ℕ) [NeZero d]
+    (a b i₁ i₂ : Fin d) :
+    SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+        (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0) (i₁, i₂) =
+      if a = i₁ ∧ b = i₂ then (d : ℂ) * (Real.sqrt d : ℂ)⁻¹ else 0 := by
+  by_cases ha : a = i₁ <;> by_cases hb : b = i₂ <;>
+    simp [SourceFactors.sourceU_apply, leftShiftSourceFactors,
+      normalizedIdentityColumn, normalizedIdentityVec, Matrix.reindex_apply,
+      Matrix.one_apply, sourceSqrt, ha, hb, NeZero.ne d, ne_comm,
+      mul_comm, mul_left_comm]
+
+/-- Entry formula for the source $v$ supplied by the left-shift factors.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
+`eq:uv2_U3` (lines 2009--2034). -/
+theorem sourceV_leftShiftSourceFactors_apply (d : ℕ) [NeZero d]
+    (j₁ j₂ a b : Fin d) :
+    SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+        (j₁, j₂) (leftShiftRightRankEquiv d 0, leftShiftLeftRankEquiv d (a, b)) =
+      if a = j₂ ∧ b = j₁ then (Real.sqrt d : ℂ)⁻¹ else 0 := by
+  by_cases ha : a = j₂ <;> by_cases hb : b = j₁ <;>
+    simp [SourceFactors.sourceV_apply, leftShiftSourceFactors,
+      normalizedIdentityColumn, normalizedIdentityVec, Matrix.reindex_apply,
+      Matrix.one_apply, sourceSqrt, ha, hb, NeZero.ne d]
+  all_goals grind
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -43,6 +43,26 @@ private theorem nat_mul_sourceSqrt_inv_mul_inv (d : ℕ) [NeZero d] :
   simpa [mul_comm, mul_left_comm, mul_assoc] using
     sourceSqrt_inv_mul_nat_mul_inv d
 
+/-- The normalization cancellation used when a left-shift source entry is
+multiplied by a right-shift source entry.
+
+Formalization identity used to derive arXiv:1703.09188, equations
+`eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034); the paper
+prints the resulting permutation matrices, not this scalar calculation. -/
+theorem shiftSourceScale_cancel (d : ℕ) [NeZero d] :
+    ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) * (Real.sqrt d : ℂ)⁻¹ = 1 := by
+  simpa [sourceSqrt, mul_assoc] using nat_mul_sourceSqrt_inv_mul_inv d
+
+/-- The reflected normalization cancellation used when a right-shift source
+entry is multiplied by a left-shift source entry.
+
+Formalization identity used to derive arXiv:1703.09188, equations
+`eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034); the paper
+prints the resulting permutation matrices, not this scalar calculation. -/
+theorem shiftSourceScale_cancel_rev (d : ℕ) [NeZero d] :
+    (Real.sqrt d : ℂ)⁻¹ * ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) = 1 := by
+  simpa [sourceSqrt, mul_assoc] using sourceSqrt_inv_mul_nat_mul_inv d
+
 private noncomputable def normalizedIdentityVec (d : ℕ) : Fin d × Fin d → ℂ :=
   (sourceSqrt d)⁻¹ • (1 : Matrix (Fin d) (Fin d) ℂ).vec
 

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -135,40 +135,6 @@ noncomputable def leftShiftLeftRankEquiv (d : ℕ) :
     Fin d × Fin d ≃ Fin ℓ[leftShiftTensor d] :=
   finProdFinEquiv.trans (finCongr (leftRank_leftShiftTensor d).symm)
 
-/-- Remove the unique virtual coordinate from a source-cut row of the
-bond-one identity tensor.
-
-Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
-lines 2009--2016; the paper does not state this intermediate equivalence. -/
-def identitySourceRowEquiv (d : ℕ) : Fin 1 × Fin d ≃ Fin d where
-  toFun x := x.2
-  invFun i := (0, i)
-  left_inv x := by ext <;> simp
-  right_inv _ := rfl
-
-/-- Remove the unique virtual coordinate from a source-cut column of the
-bond-one identity tensor.
-
-Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
-lines 2009--2016; the paper does not state this intermediate equivalence. -/
-def identitySourceColumnEquiv (d : ℕ) : Fin d × Fin 1 ≃ Fin d where
-  toFun x := x.1
-  invFun i := (i, 0)
-  left_inv x := by ext <;> simp
-  right_inv _ := rfl
-
-@[simp] theorem identitySourceRowEquiv_apply (d : ℕ) (x : Fin 1 × Fin d) :
-    identitySourceRowEquiv d x = x.2 := rfl
-
-@[simp] theorem identitySourceRowEquiv_symm_apply (d : ℕ) (i : Fin d) :
-    (identitySourceRowEquiv d).symm i = (0, i) := rfl
-
-@[simp] theorem identitySourceColumnEquiv_apply (d : ℕ) (x : Fin d × Fin 1) :
-    identitySourceColumnEquiv d x = x.1 := rfl
-
-@[simp] theorem identitySourceColumnEquiv_symm_apply (d : ℕ) (i : Fin d) :
-    (identitySourceColumnEquiv d).symm i = (i, 0) := rfl
-
 /-- Both source cuts of the bond-one identity tensor are the identity after
 removing their unique virtual coordinates.
 
@@ -177,8 +143,8 @@ arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
 source-cut formula. -/
 theorem sourceCutM₁_identityMPUTensor (d : ℕ) :
     sourceCutM₁ (identityMPUTensor d) =
-      Matrix.reindex (identitySourceRowEquiv d).symm
-        (identitySourceColumnEquiv d).symm
+      Matrix.reindex (Equiv.uniqueProd (Fin d) (Fin 1)).symm
+        (Equiv.prodUnique (Fin d) (Fin 1)).symm
         (1 : Matrix (Fin d) (Fin d) ℂ) := by
   ext ⟨α, j⟩ ⟨i, β⟩
   have hαβ : α = β := Subsingleton.elim _ _
@@ -187,7 +153,7 @@ theorem sourceCutM₁_identityMPUTensor (d : ℕ) :
       Matrix.one_apply, hij, hαβ]
   · have hji : j ≠ i := Ne.symm hij
     simp [sourceCutM₁, identityMPUTensor, idTensor, Matrix.reindex_apply,
-      Matrix.one_apply, hij, hji, hαβ]
+      hij, hji, hαβ]
 
 /-- The second source cut of the bond-one identity tensor is the same
 reindexed identity as its first source cut.
@@ -197,8 +163,8 @@ arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
 source-cut formula. -/
 theorem sourceCutM₂_identityMPUTensor (d : ℕ) :
     sourceCutM₂ (identityMPUTensor d) =
-      Matrix.reindex (identitySourceRowEquiv d).symm
-        (identitySourceColumnEquiv d).symm
+      Matrix.reindex (Equiv.uniqueProd (Fin d) (Fin 1)).symm
+        (Equiv.prodUnique (Fin d) (Fin 1)).symm
         (1 : Matrix (Fin d) (Fin d) ℂ) := by
   ext ⟨α, i⟩ ⟨j, β⟩
   have hαβ : α = β := Subsingleton.elim _ _
@@ -256,8 +222,8 @@ witness realizes $u_1=v_1=\Id\otimes\Id$ in arXiv:1703.09188, equation
 factor witness itself. -/
 noncomputable def identitySourceFactors (d : ℕ) :
     SourceFactors (identityMPUTensor d) (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
-  let eRow := identitySourceRowEquiv d
-  let eCol := identitySourceColumnEquiv d
+  let eRow := Equiv.uniqueProd (Fin d) (Fin 1)
+  let eCol := Equiv.prodUnique (Fin d) (Fin 1)
   let eR := identityRightRankEquiv d
   let eL := identityLeftRankEquiv d
   let X₁ : Matrix (Fin 1 × Fin d) (Fin r[identityMPUTensor d]) ℂ :=

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -427,7 +427,11 @@ private theorem tensorProductCutShuffle_symm_apply
         (finProdFinEquiv (x.1, y.1), finProdFinEquiv (x.2, y.2)) = (x, y) :=
   (tensorProductCutShuffle a b c f).symm_apply_apply (x, y)
 
-private noncomputable def SourceFactors.independentTensorProduct
+/-- Supplied source factors are multiplicative under the independent tensor
+product when both source weights are identities.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+noncomputable def SourceFactors.independentTensorProduct
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ)) :
@@ -508,7 +512,11 @@ private noncomputable def SourceFactors.independentTensorProduct
   exact ⟨X₁, Y₁, Z₁, X₂, Y₂, Z₂, hcut₁, hcut₂,
     hweighted, hX₂, hY₁Z₁, hY₂Z₂⟩
 
-private theorem SourceFactors.sourceU_independentTensorProduct_apply
+/-- The supplied source $u$ of an independent tensor product is the product
+of the two constituent source entries in the product rank coordinates.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem SourceFactors.sourceU_independentTensorProduct_apply
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
@@ -535,7 +543,11 @@ private theorem SourceFactors.sourceU_independentTensorProduct_apply
     tensorProductCutShuffle_symm_apply D d E e (β, i₂) (γ, j₂)]
   ring
 
-private theorem SourceFactors.sourceV_independentTensorProduct_apply
+/-- The supplied source $v$ of an independent tensor product is the product
+of the two constituent source entries in the product rank coordinates.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem SourceFactors.sourceV_independentTensorProduct_apply
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
@@ -561,34 +573,6 @@ private theorem SourceFactors.sourceV_independentTensorProduct_apply
   rw [tensorProductCutShuffle_symm_apply D d E e (α, j₁) (γ, k₁),
     tensorProductCutShuffle_symm_apply d D e E (j₂, α) (k₂, γ)]
   ring
-
-/-- Explicit supplied source factors for the paper's identity family $U_1$.
-
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
-noncomputable def shiftExampleU₁SourceFactors (d : ℕ) :
-    SourceFactors (shiftExampleU₁ d) (1 : Matrix (Fin 1) (Fin 1) ℂ) :=
-  SourceFactors.independentTensorProduct (identitySourceFactors d)
-    (identitySourceFactors d)
-
-/-- Explicit supplied source factors for the paper's counter-shift family $U_2$.
-
-Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
-noncomputable def shiftExampleU₂SourceFactors (d : ℕ) [NeZero d] :
-    SourceFactors (shiftExampleU₂ d)
-      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
-  SourceFactors.independentTensorProduct (leftShiftSourceFactors d)
-    (rightShiftSourceFactors d)
-
-/-- Explicit supplied source factors for the paper's reversed counter-shift
-family $U_3$.
-
-Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
-(lines 2009--2016 and 2028--2034). -/
-noncomputable def shiftExampleU₃SourceFactors (d : ℕ) [NeZero d] :
-    SourceFactors (shiftExampleU₃ d)
-      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
-  SourceFactors.independentTensorProduct (rightShiftSourceFactors d)
-    (leftShiftSourceFactors d)
 
 /-- Entry formula for the source $u$ supplied by the bond-one identity
 factors.  The source row is written in the paper order (left, right).

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexSqrt
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
-import TNLean.MPS.MPU.SourceFactorsTensorProduct
+import TNLean.MPS.MPU.SourceUV
 
 /-!
 # Supplied source factors for the cyclic-shift examples

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -5,19 +5,20 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexSqrt
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
-import TNLean.MPS.MPU.SourceUV
+import TNLean.MPS.MPU.SourceFactorsTensorProduct
 
 /-!
 # Supplied source factors for the cyclic-shift examples
 
-This module chooses the source factorizations used for the three shift families
-in arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3`
-(lines 2009--2034).  The choices are explicit; none of the statements below
-identifies these factors with the factors chosen by compact singular-value
-decomposition.
+This module constructs explicit formalization witnesses realizing the source
+matrices printed for the three shift families in arXiv:1703.09188, equations
+`eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034).  The paper does
+not print these normalized factors or their intermediate coordinate
+identities.  None of the statements below identifies the supplied witnesses
+with factors chosen by compact singular-value decomposition.
 -/
 
-open scoped Matrix Kronecker BigOperators
+open scoped Matrix BigOperators
 
 namespace MPOTensor
 
@@ -104,28 +105,32 @@ private theorem scaled_conjTranspose_mul_inverse_scaled_column (d : ℕ)
 
 /-- The product coordinates are the right source coordinates of the right shift.
 
-Source: arXiv:1703.09188, lines 2009--2034. -/
+Formalization coordinate for the printed source formulas in arXiv:1703.09188,
+lines 2009--2034; the paper does not state this intermediate equivalence. -/
 noncomputable def rightShiftRightRankEquiv (d : ℕ) :
     Fin d × Fin d ≃ Fin r[rightShiftTensor d] :=
   finProdFinEquiv.trans (finCongr (rightRank_rightShiftTensor d).symm)
 
 /-- The unique coordinate is the left source coordinate of the right shift.
 
-Source: arXiv:1703.09188, lines 2009--2034. -/
+Formalization coordinate for the printed source formulas in arXiv:1703.09188,
+lines 2009--2034; the paper does not state this intermediate equivalence. -/
 noncomputable def rightShiftLeftRankEquiv (d : ℕ) [NeZero d] :
     Fin 1 ≃ Fin ℓ[rightShiftTensor d] :=
   finCongr (leftRank_rightShiftTensor d).symm
 
 /-- The unique coordinate is the right source coordinate of the left shift.
 
-Source: arXiv:1703.09188, lines 2009--2034. -/
+Formalization coordinate for the printed source formulas in arXiv:1703.09188,
+lines 2009--2034; the paper does not state this intermediate equivalence. -/
 noncomputable def leftShiftRightRankEquiv (d : ℕ) [NeZero d] :
     Fin 1 ≃ Fin r[leftShiftTensor d] :=
   finCongr (rightRank_leftShiftTensor d).symm
 
 /-- The product coordinates are the left source coordinates of the left shift.
 
-Source: arXiv:1703.09188, lines 2009--2034. -/
+Formalization coordinate for the printed source formulas in arXiv:1703.09188,
+lines 2009--2034; the paper does not state this intermediate equivalence. -/
 noncomputable def leftShiftLeftRankEquiv (d : ℕ) :
     Fin d × Fin d ≃ Fin ℓ[leftShiftTensor d] :=
   finProdFinEquiv.trans (finCongr (leftRank_leftShiftTensor d).symm)
@@ -133,7 +138,8 @@ noncomputable def leftShiftLeftRankEquiv (d : ℕ) :
 /-- Remove the unique virtual coordinate from a source-cut row of the
 bond-one identity tensor.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
+lines 2009--2016; the paper does not state this intermediate equivalence. -/
 def identitySourceRowEquiv (d : ℕ) : Fin 1 × Fin d ≃ Fin d where
   toFun x := x.2
   invFun i := (0, i)
@@ -143,7 +149,8 @@ def identitySourceRowEquiv (d : ℕ) : Fin 1 × Fin d ≃ Fin d where
 /-- Remove the unique virtual coordinate from a source-cut column of the
 bond-one identity tensor.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
+lines 2009--2016; the paper does not state this intermediate equivalence. -/
 def identitySourceColumnEquiv (d : ℕ) : Fin d × Fin 1 ≃ Fin d where
   toFun x := x.1
   invFun i := (i, 0)
@@ -165,7 +172,9 @@ def identitySourceColumnEquiv (d : ℕ) : Fin d × Fin 1 ≃ Fin d where
 /-- Both source cuts of the bond-one identity tensor are the identity after
 removing their unique virtual coordinates.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization identity used to realize equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+source-cut formula. -/
 theorem sourceCutM₁_identityMPUTensor (d : ℕ) :
     sourceCutM₁ (identityMPUTensor d) =
       Matrix.reindex (identitySourceRowEquiv d).symm
@@ -183,7 +192,9 @@ theorem sourceCutM₁_identityMPUTensor (d : ℕ) :
 /-- The second source cut of the bond-one identity tensor is the same
 reindexed identity as its first source cut.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization identity used to realize equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+source-cut formula. -/
 theorem sourceCutM₂_identityMPUTensor (d : ℕ) :
     sourceCutM₂ (identityMPUTensor d) =
       Matrix.reindex (identitySourceRowEquiv d).symm
@@ -198,7 +209,9 @@ theorem sourceCutM₂_identityMPUTensor (d : ℕ) :
 /-- The right source rank of the bond-one identity tensor is its physical
 dimension.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization rank identity used to realize equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+identity. -/
 theorem rightRank_identityMPUTensor (d : ℕ) :
     r[identityMPUTensor d] = d := by
   rw [rightRank, sourceCutM₁_identityMPUTensor, Matrix.rank_reindex,
@@ -208,7 +221,9 @@ theorem rightRank_identityMPUTensor (d : ℕ) :
 /-- The left source rank of the bond-one identity tensor is its physical
 dimension.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization rank identity used to realize equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+identity. -/
 theorem leftRank_identityMPUTensor (d : ℕ) :
     ℓ[identityMPUTensor d] = d := by
   rw [leftRank, sourceCutM₂_identityMPUTensor, Matrix.rank_reindex,
@@ -218,7 +233,8 @@ theorem leftRank_identityMPUTensor (d : ℕ) :
 /-- Physical coordinates are the right source coordinates of the bond-one
 identity tensor.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
+lines 2009--2016; the paper does not state this intermediate equivalence. -/
 noncomputable def identityRightRankEquiv (d : ℕ) :
     Fin d ≃ Fin r[identityMPUTensor d] :=
   finCongr (rightRank_identityMPUTensor d).symm
@@ -226,16 +242,18 @@ noncomputable def identityRightRankEquiv (d : ℕ) :
 /-- Physical coordinates are the left source coordinates of the bond-one
 identity tensor.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate for equation `eq:SF_u1_u3` in arXiv:1703.09188,
+lines 2009--2016; the paper does not state this intermediate equivalence. -/
 noncomputable def identityLeftRankEquiv (d : ℕ) :
     Fin d ≃ Fin ℓ[identityMPUTensor d] :=
   finCongr (leftRank_identityMPUTensor d).symm
 
 /-- Explicit supplied source factors for the bond-one identity tensor.
 
-Both cuts are transported identity matrices.  This is the building block for
-$u_1=v_1=\Id\otimes\Id$ in arXiv:1703.09188, equation
-`eq:SF_u1_u3` (lines 2009--2016). -/
+Both cuts are transported identity matrices.  This explicit formalization
+witness realizes $u_1=v_1=\Id\otimes\Id$ in arXiv:1703.09188, equation
+`eq:SF_u1_u3` (lines 2009--2016); the paper does not print the normalized
+factor witness itself. -/
 noncomputable def identitySourceFactors (d : ℕ) :
     SourceFactors (identityMPUTensor d) (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
   let eRow := identitySourceRowEquiv d
@@ -296,8 +314,10 @@ noncomputable def identitySourceFactors (d : ℕ) :
 
 The first cut is the identity in the coordinates `rightShiftRightRankEquiv`.
 The second cut uses the normalized vectorization of the identity matrix.  This
-is the elementary right-shift factorization used in arXiv:1703.09188,
-equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+explicit formalization witness realizes the right-shift contribution to the
+printed formulas `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` in
+arXiv:1703.09188, lines 2009--2034; the paper does not print the normalized
+factor witness itself. -/
 noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
     SourceFactors (rightShiftTensor d) (1 : Matrix (Fin d) (Fin d) ℂ) := by
   let eR := rightShiftRightRankEquiv d
@@ -351,8 +371,10 @@ noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
 
 The first cut uses the normalized vectorization of the identity matrix.  The
 second cut is the identity in the coordinates `leftShiftLeftRankEquiv`.  This
-is the elementary left-shift factorization used in arXiv:1703.09188,
-equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+explicit formalization witness realizes the left-shift contribution to the
+printed formulas `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` in
+arXiv:1703.09188, lines 2009--2034; the paper does not print the normalized
+factor witness itself. -/
 noncomputable def leftShiftSourceFactors (d : ℕ) [NeZero d] :
     SourceFactors (leftShiftTensor d) (1 : Matrix (Fin d) (Fin d) ℂ) := by
   let eR := leftShiftRightRankEquiv d
@@ -403,181 +425,12 @@ noncomputable def leftShiftSourceFactors (d : ℕ) [NeZero d] :
   exact ⟨C, R, Z, P, Pᴴ, P, hcut₁, hcut₂, hweighted, hP.1,
     hRZ, hP.1⟩
 
-/-- Product source coordinates, followed by the multiplicative right-rank
-identification for an independent tensor product.
-
-Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
-noncomputable def tensorProductRightRankEquiv
-    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
-    Fin r[U] × Fin r[V] ≃ Fin r[tensorProduct U V] :=
-  finProdFinEquiv.trans (finCongr (rightRank_tensorProduct U V).symm)
-
-/-- Product source coordinates, followed by the multiplicative left-rank
-identification for an independent tensor product.
-
-Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
-noncomputable def tensorProductLeftRankEquiv
-    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
-    Fin ℓ[U] × Fin ℓ[V] ≃ Fin ℓ[tensorProduct U V] :=
-  finProdFinEquiv.trans (finCongr (leftRank_tensorProduct U V).symm)
-
-private theorem tensorProductCutShuffle_symm_apply
-    (a b c f : ℕ) (x : Fin a × Fin b) (y : Fin c × Fin f) :
-    (tensorProductCutShuffle a b c f).symm
-        (finProdFinEquiv (x.1, y.1), finProdFinEquiv (x.2, y.2)) = (x, y) :=
-  (tensorProductCutShuffle a b c f).symm_apply_apply (x, y)
-
-/-- Supplied source factors are multiplicative under the independent tensor
-product when both source weights are identities.
-
-Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
-noncomputable def SourceFactors.independentTensorProduct
-    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
-    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
-    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ)) :
-    SourceFactors (tensorProduct U V)
-      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) := by
-  let eRow := tensorProductCutShuffle D d E e
-  let eCol := tensorProductCutShuffle d D e E
-  let eR := tensorProductRightRankEquiv U V
-  let eL := tensorProductLeftRankEquiv U V
-  let X₁ := Matrix.reindex eRow eR (S.X₁ ⊗ₖ T.X₁)
-  let Y₁ := Matrix.reindex eR eCol (S.Y₁ ⊗ₖ T.Y₁)
-  let Z₁ := Matrix.reindex eCol eR (S.Z₁ ⊗ₖ T.Z₁)
-  let X₂ := Matrix.reindex eRow eL (S.X₂ ⊗ₖ T.X₂)
-  let Y₂ := Matrix.reindex eL eCol (S.Y₂ ⊗ₖ T.Y₂)
-  let Z₂ := Matrix.reindex eCol eL (S.Z₂ ⊗ₖ T.Z₂)
-  have hSX₁ : S.X₁.IsIsometry := by
-    have h := S.X₁_weighted_isometry
-    rw [show sourceWeight (d := d) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 by
-      simp [sourceWeight]] at h
-    simpa [Matrix.IsIsometry] using h
-  have hTX₁ : T.X₁.IsIsometry := by
-    have h := T.X₁_weighted_isometry
-    rw [show sourceWeight (d := e) (1 : Matrix (Fin E) (Fin E) ℂ) = 1 by
-      simp [sourceWeight]] at h
-    simpa [Matrix.IsIsometry] using h
-  have hKX₁ : (S.X₁ ⊗ₖ T.X₁).IsIsometry := by
-    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
-      ← Matrix.mul_kronecker_mul]
-    change (S.X₁ᴴ * S.X₁) ⊗ₖ (T.X₁ᴴ * T.X₁) = 1
-    rw [show S.X₁ᴴ * S.X₁ = 1 by exact hSX₁,
-      show T.X₁ᴴ * T.X₁ = 1 by exact hTX₁]
-    simp
-  have hKX₂ : (S.X₂ ⊗ₖ T.X₂).IsIsometry := by
-    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
-      ← Matrix.mul_kronecker_mul]
-    change (S.X₂ᴴ * S.X₂) ⊗ₖ (T.X₂ᴴ * T.X₂) = 1
-    rw [show S.X₂ᴴ * S.X₂ = 1 by exact S.X₂_isometry,
-      show T.X₂ᴴ * T.X₂ = 1 by exact T.X₂_isometry]
-    simp
-  have hX₁ : X₁.IsIsometry :=
-    Matrix.IsIsometry.reindex _ hKX₁ eRow eR
-  have hX₂ : X₂.IsIsometry :=
-    Matrix.IsIsometry.reindex _ hKX₂ eRow eL
-  have hcut₁ : sourceCutM₁ (tensorProduct U V) = X₁ * Y₁ := by
-    rw [sourceCutM₁_tensorProduct, S.sourceCutM₁_eq, T.sourceCutM₁_eq]
-    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
-        ((S.X₁ * S.Y₁) ⊗ₖ (T.X₁ * T.Y₁)) =
-      Matrix.reindexLinearEquiv ℂ ℂ eRow eR (S.X₁ ⊗ₖ T.X₁) *
-        Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁)
-    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eR eCol,
-      Matrix.mul_kronecker_mul]
-  have hcut₂ : sourceCutM₂ (tensorProduct U V) = X₂ * Y₂ := by
-    rw [sourceCutM₂_tensorProduct, S.sourceCutM₂_eq, T.sourceCutM₂_eq]
-    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
-        ((S.X₂ * S.Y₂) ⊗ₖ (T.X₂ * T.Y₂)) =
-      Matrix.reindexLinearEquiv ℂ ℂ eRow eL (S.X₂ ⊗ₖ T.X₂) *
-        Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂)
-    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eL eCol,
-      Matrix.mul_kronecker_mul]
-  have hweighted : X₁ᴴ * sourceWeight (d := d * e)
-      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) * X₁ = 1 := by
-    rw [show sourceWeight (d := d * e)
-        (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) = 1 by
-      simp [sourceWeight]]
-    simpa [Matrix.IsIsometry] using hX₁
-  have hY₁Z₁ : Y₁ * Z₁ = 1 := by
-    change Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁) *
-      Matrix.reindexLinearEquiv ℂ ℂ eCol eR (S.Z₁ ⊗ₖ T.Z₁) = 1
-    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eR eCol eR,
-      ← Matrix.mul_kronecker_mul, S.Y₁_mul_Z₁, T.Y₁_mul_Z₁]
-    simp
-  have hY₂Z₂ : Y₂ * Z₂ = 1 := by
-    change Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂) *
-      Matrix.reindexLinearEquiv ℂ ℂ eCol eL (S.Z₂ ⊗ₖ T.Z₂) = 1
-    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eL eCol eL,
-      ← Matrix.mul_kronecker_mul, S.Y₂_mul_Z₂, T.Y₂_mul_Z₂]
-    simp
-  exact ⟨X₁, Y₁, Z₁, X₂, Y₂, Z₂, hcut₁, hcut₂,
-    hweighted, hX₂, hY₁Z₁, hY₂Z₂⟩
-
-/-- The supplied source $u$ of an independent tensor product is the product
-of the two constituent source entries in the product rank coordinates.
-
-Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
-theorem SourceFactors.sourceU_independentTensorProduct_apply
-    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
-    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
-    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
-    (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) (rᵤ : Fin r[U]) (rᵥ : Fin r[V])
-    (i₁ i₂ : Fin d) (j₁ j₂ : Fin e) :
-    SourceFactors.sourceU (tensorProduct U V)
-        (SourceFactors.independentTensorProduct S T)
-        (tensorProductLeftRankEquiv U V (lᵤ, lᵥ),
-          tensorProductRightRankEquiv U V (rᵤ, rᵥ))
-        (finProdFinEquiv (i₁, j₁), finProdFinEquiv (i₂, j₂)) =
-      SourceFactors.sourceU U S (lᵤ, rᵤ) (i₁, i₂) *
-        SourceFactors.sourceU V T (lᵥ, rᵥ) (j₁, j₂) := by
-  simp only [SourceFactors.sourceU, SourceFactors.independentTensorProduct]
-  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro β _
-  rw [Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro γ _
-  rw [tensorProductCutShuffle_symm_apply d D e E (i₁, β) (j₁, γ),
-    tensorProductCutShuffle_symm_apply D d E e (β, i₂) (γ, j₂)]
-  ring
-
-/-- The supplied source $v$ of an independent tensor product is the product
-of the two constituent source entries in the product rank coordinates.
-
-Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
-theorem SourceFactors.sourceV_independentTensorProduct_apply
-    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
-    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
-    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
-    (j₁ j₂ : Fin d) (k₁ k₂ : Fin e)
-    (rᵤ : Fin r[U]) (rᵥ : Fin r[V]) (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) :
-    SourceFactors.sourceV (tensorProduct U V)
-        (SourceFactors.independentTensorProduct S T)
-        (finProdFinEquiv (j₁, k₁), finProdFinEquiv (j₂, k₂))
-        (tensorProductRightRankEquiv U V (rᵤ, rᵥ),
-          tensorProductLeftRankEquiv U V (lᵤ, lᵥ)) =
-      SourceFactors.sourceV U S (j₁, j₂) (rᵤ, lᵤ) *
-        SourceFactors.sourceV V T (k₁, k₂) (rᵥ, lᵥ) := by
-  simp only [SourceFactors.sourceV, SourceFactors.independentTensorProduct]
-  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro α _
-  rw [Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro γ _
-  rw [tensorProductCutShuffle_symm_apply D d E e (α, j₁) (γ, k₁),
-    tensorProductCutShuffle_symm_apply d D e E (j₂, α) (k₂, γ)]
-  ring
-
 /-- Entry formula for the source $u$ supplied by the bond-one identity
 factors.  The source row is written in the paper order (left, right).
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate identity used to derive equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+entry formula. -/
 theorem sourceU_identitySourceFactors_apply (d : ℕ) (l r i₁ i₂ : Fin d) :
     SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
         (identityLeftRankEquiv d l, identityRightRankEquiv d r) (i₁, i₂) =
@@ -589,7 +442,9 @@ theorem sourceU_identitySourceFactors_apply (d : ℕ) (l r i₁ i₂ : Fin d) :
 /-- Entry formula for the source $v$ supplied by the bond-one identity
 factors.  Its source column has the paper order (right, left).
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+Formalization coordinate identity used to derive equation `eq:SF_u1_u3` in
+arXiv:1703.09188, lines 2009--2016; the paper does not state this intermediate
+entry formula. -/
 theorem sourceV_identitySourceFactors_apply (d : ℕ) (j₁ j₂ r l : Fin d) :
     SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
         (j₁, j₂) (identityRightRankEquiv d r, identityLeftRankEquiv d l) =
@@ -601,8 +456,9 @@ theorem sourceV_identitySourceFactors_apply (d : ℕ) (j₁ j₂ r l : Fin d) :
 
 /-- Entry formula for the source $u$ supplied by the right-shift factors.
 
-Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
-`eq:uv2_U3` (lines 2009--2034). -/
+Formalization coordinate identity used to derive equations `eq:SF_u1_u3`,
+`eq:uv2_U2`, and `eq:uv2_U3` in arXiv:1703.09188, lines 2009--2034; the paper
+does not state this intermediate entry formula. -/
 theorem sourceU_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
     (a b i₁ i₂ : Fin d) :
     SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
@@ -615,8 +471,9 @@ theorem sourceU_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
 
 /-- Entry formula for the source $v$ supplied by the right-shift factors.
 
-Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
-`eq:uv2_U3` (lines 2009--2034). -/
+Formalization coordinate identity used to derive equations `eq:SF_u1_u3`,
+`eq:uv2_U2`, and `eq:uv2_U3` in arXiv:1703.09188, lines 2009--2034; the paper
+does not state this intermediate entry formula. -/
 theorem sourceV_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
     (j₁ j₂ a b : Fin d) :
     SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
@@ -631,8 +488,9 @@ theorem sourceV_rightShiftSourceFactors_apply (d : ℕ) [NeZero d]
 
 /-- Entry formula for the source $u$ supplied by the left-shift factors.
 
-Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
-`eq:uv2_U3` (lines 2009--2034). -/
+Formalization coordinate identity used to derive equations `eq:SF_u1_u3`,
+`eq:uv2_U2`, and `eq:uv2_U3` in arXiv:1703.09188, lines 2009--2034; the paper
+does not state this intermediate entry formula. -/
 theorem sourceU_leftShiftSourceFactors_apply (d : ℕ) [NeZero d]
     (a b i₁ i₂ : Fin d) :
     SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
@@ -646,8 +504,9 @@ theorem sourceU_leftShiftSourceFactors_apply (d : ℕ) [NeZero d]
 
 /-- Entry formula for the source $v$ supplied by the left-shift factors.
 
-Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
-`eq:uv2_U3` (lines 2009--2034). -/
+Formalization coordinate identity used to derive equations `eq:SF_u1_u3`,
+`eq:uv2_U2`, and `eq:uv2_U3` in arXiv:1703.09188, lines 2009--2034; the paper
+does not state this intermediate entry formula. -/
 theorem sourceV_leftShiftSourceFactors_apply (d : ℕ) [NeZero d]
     (j₁ j₂ a b : Fin d) :
     SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
@@ -291,10 +291,14 @@ noncomputable def shiftExampleU₂SourceURowEquiv (d : ℕ) [NeZero d] :
   Equiv.prodCongr (shiftExampleU₂LeftRankEquiv d)
     (shiftExampleU₂RightRankEquiv d)
 
-/-- Paper coordinates for the source column of $v_2^{(2)}$.  Each active
-rank pair is reversed, exactly as in the reflected source convention.
+/-- Coordinates for the source column of $v_2^{(2)}$.
 
-Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+The outer coordinate has the order $(r,\ell)$ fixed by the diagram defining
+$v$ in arXiv:1703.09188, equation `vdagger` (lines 520--543).  Within each
+primitive-shift rank, `Equiv.prodComm` changes the tensor-product rank order to
+the four-spin order in which equation `eq:uv2_U2` is printed (lines
+2018--2026).  This is an explicit formalization reindexing; the paper states
+the resulting matrix, not this intermediate equivalence. -/
 noncomputable def shiftExampleU₂SourceVColumnEquiv (d : ℕ) [NeZero d] :
     ((Fin d × Fin d) × (Fin d × Fin d)) ≃
       (Fin r[shiftExampleU₂ d] × Fin ℓ[shiftExampleU₂ d]) :=
@@ -312,10 +316,14 @@ noncomputable def shiftExampleU₃SourceURowEquiv (d : ℕ) [NeZero d] :
   Equiv.prodCongr (shiftExampleU₃LeftRankEquiv d)
     (shiftExampleU₃RightRankEquiv d)
 
-/-- Paper coordinates for the source column of $v_3^{(2)}$.  Each active
-rank pair is reversed, exactly as in the reflected source convention.
+/-- Coordinates for the source column of $v_3^{(2)}$.
 
-Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+The outer coordinate has the order $(r,\ell)$ fixed by the diagram defining
+$v$ in arXiv:1703.09188, equation `vdagger` (lines 520--543).  Within each
+primitive-shift rank, `Equiv.prodComm` changes the tensor-product rank order to
+the four-spin order in which equation `eq:uv2_U3` is printed (lines
+2028--2034).  This is an explicit formalization reindexing; the paper states
+the resulting matrix, not this intermediate equivalence. -/
 noncomputable def shiftExampleU₃SourceVColumnEquiv (d : ℕ) [NeZero d] :
     ((Fin d × Fin d) × (Fin d × Fin d)) ≃
       (Fin r[shiftExampleU₃ d] × Fin ℓ[shiftExampleU₃ d]) :=
@@ -324,10 +332,14 @@ noncomputable def shiftExampleU₃SourceVColumnEquiv (d : ℕ) [NeZero d] :
     (Equiv.prodCongr (shiftExampleU₃RightRankEquiv d)
       (shiftExampleU₃LeftRankEquiv d))
 
-/-- Reorder two pairs so that the $u_3$ source coordinates exhibit the single
-swap $\mathbb S$ from `eq:SF_u1_u3`.
+/-- Reorder two pairs so that the $u_3$ source coordinates exhibit one swap.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+After expanding the product ranks in the outer $(\ell,r)$ order fixed by the
+diagram defining $u$ in arXiv:1703.09188, equation `uu` (lines 532--543), this
+map sends $((a,b),(c,e))$ to $((e,b),(c,a))$.  It thereby gives the two
+composite indices in which equation `eq:SF_u1_u3` prints $u_3=\mathbb S$
+(lines 2009--2016).  This shuffle is formalization infrastructure; the paper
+states the final swap, not the intermediate reindexing. -/
 def shiftExampleU₃SourceUSwapShuffle (d : ℕ) :
     ((Fin d × Fin d) × (Fin d × Fin d)) ≃
       ((Fin d × Fin d) × (Fin d × Fin d)) where
@@ -336,10 +348,14 @@ def shiftExampleU₃SourceUSwapShuffle (d : ℕ) :
   left_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
   right_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
 
-/-- Reorder two pairs so that the $v_3$ source coordinates exhibit the single
-swap $\mathbb S$ from `eq:SF_u1_u3`.
+/-- Reorder two pairs so that the $v_3$ source coordinates exhibit one swap.
 
-Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+After expanding the product ranks in the outer $(r,\ell)$ order fixed by the
+diagram defining $v$ in arXiv:1703.09188, equation `vdagger` (lines 520--543),
+this map sends $((a,b),(c,e))$ to $((a,c),(b,e))$.  It thereby gives the two
+composite indices in which equation `eq:SF_u1_u3` prints $v_3=\mathbb S$
+(lines 2009--2016).  This shuffle is formalization infrastructure; the paper
+states the final swap, not the intermediate reindexing. -/
 def shiftExampleU₃SourceVSwapShuffle (d : ℕ) :
     ((Fin d × Fin d) × (Fin d × Fin d)) ≃
       ((Fin d × Fin d) × (Fin d × Fin d)) where

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
+import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import QICLean.Channel.MaximallyEntangled
 
 /-!
@@ -173,7 +174,7 @@ of $U_2$; the right-shift left source has its unique value.
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
 noncomputable def shiftExampleU₂LeftRankEquiv (d : ℕ) [NeZero d] :
     Fin d × Fin d ≃ Fin ℓ[shiftExampleU₂ d] :=
-  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm |>.trans
+  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm.trans
     ((Equiv.prodCongr (leftShiftLeftRankEquiv d)
       (rightShiftLeftRankEquiv d)).trans
         (tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)))
@@ -184,7 +185,7 @@ coordinates of $U_2$; the left-shift right source has its unique value.
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
 noncomputable def shiftExampleU₂RightRankEquiv (d : ℕ) [NeZero d] :
     Fin d × Fin d ≃ Fin r[shiftExampleU₂ d] :=
-  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm |>.trans
+  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm.trans
     ((Equiv.prodCongr (leftShiftRightRankEquiv d)
       (rightShiftRightRankEquiv d)).trans
         (tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)))
@@ -196,7 +197,7 @@ Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
 (lines 2009--2016 and 2028--2034). -/
 noncomputable def shiftExampleU₃LeftRankEquiv (d : ℕ) [NeZero d] :
     Fin d × Fin d ≃ Fin ℓ[shiftExampleU₃ d] :=
-  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm |>.trans
+  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm.trans
     ((Equiv.prodCongr (rightShiftLeftRankEquiv d)
       (leftShiftLeftRankEquiv d)).trans
         (tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)))
@@ -208,7 +209,7 @@ Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
 (lines 2009--2016 and 2028--2034). -/
 noncomputable def shiftExampleU₃RightRankEquiv (d : ℕ) [NeZero d] :
     Fin d × Fin d ≃ Fin r[shiftExampleU₃ d] :=
-  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm |>.trans
+  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm.trans
     ((Equiv.prodCongr (rightShiftRightRankEquiv d)
       (leftShiftRightRankEquiv d)).trans
         (tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)))

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
@@ -406,11 +406,11 @@ private theorem shiftExampleU₂_sourceU_product_apply (d : ℕ) [NeZero d]
       (leftShiftLeftRankEquiv d (a, b)) (rightShiftLeftRankEquiv d 0)
       (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (c, e)) i k j l
 
-/-- Entry formula for the supplied $u_2^{(2)}$ in the paper's source and
-four-spin coordinates.
+/-- Entry formula for the supplied source $u$ of $U_2$ in the four-spin
+coordinates used by the paper's two-site standard form.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
-theorem shiftExampleU₂_sourceU_two_apply (d : ℕ) [NeZero d]
+theorem shiftExampleU₂_sourceU_fourSpin_apply (d : ℕ) [NeZero d]
     (a b c e i j k l : Fin d) :
     SourceFactors.sourceU (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
         (shiftExampleU₂SourceURowEquiv d ((a, b), (c, e)))
@@ -437,11 +437,15 @@ theorem shiftExampleU₂_sourceU_two_apply (d : ℕ) [NeZero d]
         simp [identitySwapIdentityMatrix, ha, hb, hc, he,
           shiftSourceScale_cancel d]
 
-/-- For the supplied factors of $U_2$, the paper's two-site source gate is
-$u_2^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the displayed four-spin order.
+/-- In the four-spin coordinates used by the two-site standard form, the
+supplied source $u$ of $U_2$ is $\Id\otimes\mathbb S\otimes\Id$.
+
+Its occurrence as the central gate $u_2^{(2)}$ in the actual two-site block is
+the content of `shiftExampleU₂_blockTwo_apply_eq_sum_X₁_mul_u₂_two_mul_Y₂`.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
-theorem shiftExampleU₂_sourceU_two_eq_identitySwapIdentity (d : ℕ) [NeZero d] :
+theorem shiftExampleU₂_sourceU_reindex_eq_identitySwapIdentity
+    (d : ℕ) [NeZero d] :
     Matrix.reindex (shiftExampleU₂SourceURowEquiv d).symm
         (shiftTwoSitePhysicalEquiv d).symm
         (SourceFactors.sourceU (shiftExampleU₂ d)
@@ -450,7 +454,7 @@ theorem shiftExampleU₂_sourceU_two_eq_identitySwapIdentity (d : ℕ) [NeZero d
   ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
   simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Equiv.symm_symm] using
-    shiftExampleU₂_sourceU_two_apply d a b c e i j k l
+    shiftExampleU₂_sourceU_fourSpin_apply d a b c e i j k l
 
 private theorem shiftExampleU₂_sourceV_product_apply (d : ℕ) [NeZero d]
     (a b c e i j k l : Fin d) :
@@ -471,11 +475,11 @@ private theorem shiftExampleU₂_sourceV_product_apply (d : ℕ) [NeZero d]
       (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (b, a))
       (leftShiftLeftRankEquiv d (e, c)) (rightShiftLeftRankEquiv d 0)
 
-/-- Entry formula for the supplied $v_2^{(2)}$ in the paper's source and
-four-spin coordinates.
+/-- Entry formula for the supplied source $v$ of $U_2$ in the four-spin
+coordinates used by the paper's reflected two-site standard form.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
-theorem shiftExampleU₂_sourceV_two_apply (d : ℕ) [NeZero d]
+theorem shiftExampleU₂_sourceV_fourSpin_apply (d : ℕ) [NeZero d]
     (i j k l a b c e : Fin d) :
     SourceFactors.sourceV (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
         (shiftTwoSitePhysicalEquiv d ((i, j), (k, l)))
@@ -503,13 +507,16 @@ theorem shiftExampleU₂_sourceV_two_apply (d : ℕ) [NeZero d]
         by_cases hc : i = c <;> by_cases he : k = e <;>
         simp [ha, hb, hc, he, shiftSourceScale_cancel_rev d] <;> aesop
 
-/-- For the supplied factors of $U_2$, the paper's reflected two-site source
-gate is
-$v_2^{(2)}=(\mathbb S\otimes\mathbb S)
-(\Id\otimes\mathbb S\otimes\Id)$ in the displayed four-spin order.
+/-- In the four-spin coordinates used by the reflected two-site standard form,
+the supplied source $v$ of $U_2$ is
+$(\mathbb S\otimes\mathbb S)(\Id\otimes\mathbb S\otimes\Id)$.
+
+Its occurrence as the central gate $v_2^{(2)}$ in the actual two-site block is
+the content of
+`shiftExampleU₂_blockTwo_apply_eq_sum_X₂_mul_v₂_two_reflected_mul_Y₁`.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
-theorem shiftExampleU₂_sourceV_two_eq_swapSwap_mul_identitySwapIdentity
+theorem shiftExampleU₂_sourceV_reindex_eq_swapSwap_mul_identitySwapIdentity
     (d : ℕ) [NeZero d] :
     Matrix.reindex (shiftTwoSitePhysicalEquiv d).symm
         (shiftExampleU₂SourceVColumnEquiv d).symm
@@ -519,7 +526,7 @@ theorem shiftExampleU₂_sourceV_two_eq_swapSwap_mul_identitySwapIdentity
   ext ⟨⟨i, j⟩, ⟨k, l⟩⟩ ⟨⟨a, b⟩, ⟨c, e⟩⟩
   simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Equiv.symm_symm] using
-    shiftExampleU₂_sourceV_two_apply d i j k l a b c e
+    shiftExampleU₂_sourceV_fourSpin_apply d i j k l a b c e
 
 private theorem shiftExampleU₃_sourceU_product_apply (d : ℕ) [NeZero d]
     (a b c e i j k l : Fin d) :
@@ -539,11 +546,11 @@ private theorem shiftExampleU₃_sourceU_product_apply (d : ℕ) [NeZero d]
       (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (a, b))
       (rightShiftRightRankEquiv d (c, e)) (leftShiftRightRankEquiv d 0) i k j l
 
-/-- Entry formula for the supplied $u_3^{(2)}$ in the paper's source and
-four-spin coordinates.
+/-- Entry formula for the supplied source $u$ of $U_3$ in the four-spin
+coordinates used by the paper's two-site standard form.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
-theorem shiftExampleU₃_sourceU_two_apply (d : ℕ) [NeZero d]
+theorem shiftExampleU₃_sourceU_fourSpin_apply (d : ℕ) [NeZero d]
     (a b c e i j k l : Fin d) :
     SourceFactors.sourceU (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
         (shiftExampleU₃SourceURowEquiv d ((a, b), (c, e)))
@@ -570,12 +577,15 @@ theorem shiftExampleU₃_sourceU_two_apply (d : ℕ) [NeZero d]
         by_cases hc : c = i <;> by_cases he : e = k <;>
         simp [ha, hb, hc, he, shiftSourceScale_cancel_rev d]
 
-/-- For the supplied factors of $U_3$, the paper's two-site source gate is
-$u_3^{(2)}=(\Id\otimes\mathbb S\otimes\Id)
-(\mathbb S\otimes\mathbb S)$ in the displayed four-spin order.
+/-- In the four-spin coordinates used by the two-site standard form, the
+supplied source $u$ of $U_3$ is
+$(\Id\otimes\mathbb S\otimes\Id)(\mathbb S\otimes\mathbb S)$.
+
+Its occurrence as the central gate $u_3^{(2)}$ in the actual two-site block is
+the content of `shiftExampleU₃_blockTwo_apply_eq_sum_X₁_mul_u₃_two_mul_Y₂`.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
-theorem shiftExampleU₃_sourceU_two_eq_identitySwapIdentity_mul_swapSwap
+theorem shiftExampleU₃_sourceU_reindex_eq_identitySwapIdentity_mul_swapSwap
     (d : ℕ) [NeZero d] :
     Matrix.reindex (shiftExampleU₃SourceURowEquiv d).symm
         (shiftTwoSitePhysicalEquiv d).symm
@@ -585,7 +595,7 @@ theorem shiftExampleU₃_sourceU_two_eq_identitySwapIdentity_mul_swapSwap
   ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
   simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Equiv.symm_symm] using
-    shiftExampleU₃_sourceU_two_apply d a b c e i j k l
+    shiftExampleU₃_sourceU_fourSpin_apply d a b c e i j k l
 
 private theorem shiftExampleU₃_sourceV_product_apply (d : ℕ) [NeZero d]
     (a b c e i j k l : Fin d) :
@@ -607,11 +617,11 @@ private theorem shiftExampleU₃_sourceV_product_apply (d : ℕ) [NeZero d]
       (rightShiftRightRankEquiv d (b, a)) (leftShiftRightRankEquiv d 0)
       (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (e, c))
 
-/-- Entry formula for the supplied $v_3^{(2)}$ in the paper's source and
-four-spin coordinates.
+/-- Entry formula for the supplied source $v$ of $U_3$ in the four-spin
+coordinates used by the paper's reflected two-site standard form.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
-theorem shiftExampleU₃_sourceV_two_apply (d : ℕ) [NeZero d]
+theorem shiftExampleU₃_sourceV_fourSpin_apply (d : ℕ) [NeZero d]
     (i j k l a b c e : Fin d) :
     SourceFactors.sourceV (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
         (shiftTwoSitePhysicalEquiv d ((i, j), (k, l)))
@@ -640,12 +650,15 @@ theorem shiftExampleU₃_sourceV_two_apply (d : ℕ) [NeZero d]
         simp [identitySwapIdentityMatrix, ha, hb, hc, he,
           shiftSourceScale_cancel d] <;> aesop
 
-/-- For the supplied factors of $U_3$, the paper's reflected two-site source
-gate is $v_3^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the displayed
-four-spin order.
+/-- In the four-spin coordinates used by the reflected two-site standard form,
+the supplied source $v$ of $U_3$ is $\Id\otimes\mathbb S\otimes\Id$.
+
+Its occurrence as the central gate $v_3^{(2)}$ in the actual two-site block is
+the content of
+`shiftExampleU₃_blockTwo_apply_eq_sum_X₂_mul_v₃_two_reflected_mul_Y₁`.
 
 Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
-theorem shiftExampleU₃_sourceV_two_eq_identitySwapIdentity
+theorem shiftExampleU₃_sourceV_reindex_eq_identitySwapIdentity
     (d : ℕ) [NeZero d] :
     Matrix.reindex (shiftTwoSitePhysicalEquiv d).symm
         (shiftExampleU₃SourceVColumnEquiv d).symm
@@ -655,7 +668,7 @@ theorem shiftExampleU₃_sourceV_two_eq_identitySwapIdentity
   ext ⟨⟨i, j⟩, ⟨k, l⟩⟩ ⟨⟨a, b⟩, ⟨c, e⟩⟩
   simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Equiv.symm_symm] using
-    shiftExampleU₃_sourceV_two_apply d i j k l a b c e
+    shiftExampleU₃_sourceV_fourSpin_apply d i j k l a b c e
 
 private theorem shiftExampleU₁_sourceU_product_apply (d : ℕ)
     (a b c e i j k l : Fin d) :

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
@@ -1,0 +1,873 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.ShiftSourceFactors
+import QICLean.Channel.MaximallyEntangled
+
+/-!
+# Supplied source formulas for the cyclic-shift examples
+
+This module evaluates the explicit supplied source factors from
+`ShiftSourceFactors` for the three shift families of arXiv:1703.09188.  The
+coordinate identifications retain the paper's tensor-factor order in equations
+`eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034).
+-/
+
+open scoped Matrix Kronecker BigOperators
+
+namespace MPOTensor
+
+private theorem shiftSourceScale_cancel (d : ℕ) [NeZero d] :
+    ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) * (Real.sqrt d : ℂ)⁻¹ = 1 := by
+  have hsqrt : (Real.sqrt d : ℂ) ^ 2 = (d : ℂ) := by
+    exact Complex.ofReal_sqrt_sq d (by positivity)
+  have hsqrt_ne : (Real.sqrt d : ℂ) ≠ 0 := by
+    exact Complex.ofReal_ne_zero.mpr <|
+      Real.sqrt_ne_zero'.2 (by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d))
+  rw [← hsqrt]
+  field_simp [hsqrt_ne]
+
+private theorem shiftSourceScale_cancel_rev (d : ℕ) [NeZero d] :
+    (Real.sqrt d : ℂ)⁻¹ * ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) = 1 := by
+  simpa [mul_comm, mul_left_comm, mul_assoc] using shiftSourceScale_cancel d
+
+/-- Explicit supplied source factors for the paper's identity family $U_1$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁SourceFactors (d : ℕ) :
+    SourceFactors (shiftExampleU₁ d) (1 : Matrix (Fin 1) (Fin 1) ℂ) :=
+  SourceFactors.independentTensorProduct (identitySourceFactors d)
+    (identitySourceFactors d)
+
+/-- Explicit supplied source factors for the paper's counter-shift family $U_2$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂SourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (shiftExampleU₂ d)
+      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
+  SourceFactors.independentTensorProduct (leftShiftSourceFactors d)
+    (rightShiftSourceFactors d)
+
+/-- Explicit supplied source factors for the paper's reversed counter-shift
+family $U_3$.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
+(lines 2009--2016 and 2028--2034). -/
+noncomputable def shiftExampleU₃SourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (shiftExampleU₃ d)
+      (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
+  SourceFactors.independentTensorProduct (rightShiftSourceFactors d)
+    (leftShiftSourceFactors d)
+
+/-- Decode the two physical sites of a shift-family source matrix into their
+four constituent $d$-dimensional spins, in site order.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and
+`eq:uv2_U3` (lines 2009--2034). -/
+def shiftTwoSitePhysicalEquiv (d : ℕ) :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin (d * d) × Fin (d * d)) :=
+  Equiv.prodCongr finProdFinEquiv finProdFinEquiv
+
+/-- The matrix $\Id\otimes\Id$ on the two composite physical sites.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def identityTensorIdentityMatrix (d : ℕ) :
+    Matrix ((Fin d × Fin d) × (Fin d × Fin d))
+      ((Fin d × Fin d) × (Fin d × Fin d)) ℂ :=
+  (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) ⊗ₖ
+    (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+
+/-- Entry formula for the paper's $\Id\otimes\Id$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+@[simp] theorem identityTensorIdentityMatrix_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    identityTensorIdentityMatrix d ((a, b), (c, e)) ((i, j), (k, l)) =
+      if a = i ∧ b = j ∧ c = k ∧ e = l then 1 else 0 := by
+  by_cases ha : a = i <;> by_cases hb : b = j <;>
+    by_cases hc : c = k <;> by_cases he : e = l <;>
+    simp [identityTensorIdentityMatrix, Matrix.kroneckerMap_apply,
+      Prod.ext_iff, ha, hb, hc, he]
+
+/-- The four-spin matrix $\Id\otimes\mathbb S\otimes\Id$, with the two
+physical sites grouped as `((1, 2), (3, 4))`.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+noncomputable def identitySwapIdentityMatrix (d : ℕ) :
+    Matrix ((Fin d × Fin d) × (Fin d × Fin d))
+      ((Fin d × Fin d) × (Fin d × Fin d)) ℂ :=
+  fun ((a, b), (c, e)) ((i, j), (k, l)) ↦
+    if a = i ∧ b = k ∧ c = j ∧ e = l then 1 else 0
+
+/-- Entry formula for $\Id\otimes\mathbb S\otimes\Id$ in the paper's
+four-spin order.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+@[simp] theorem identitySwapIdentityMatrix_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    identitySwapIdentityMatrix d ((a, b), (c, e)) ((i, j), (k, l)) =
+      if a = i ∧ b = k ∧ c = j ∧ e = l then 1 else 0 := rfl
+
+/-- The four-spin matrix $\mathbb S\otimes\mathbb S$, with the two swaps
+acting on the pairs `(1, 2)` and `(3, 4)`.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+noncomputable def swapTensorSwapMatrix (d : ℕ) :
+    Matrix ((Fin d × Fin d) × (Fin d × Fin d))
+      ((Fin d × Fin d) × (Fin d × Fin d)) ℂ :=
+  Matrix.swapMatrix d ⊗ₖ Matrix.swapMatrix d
+
+/-- Entry formula for $\mathbb S\otimes\mathbb S$ in the paper's four-spin
+order.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+@[simp] theorem swapTensorSwapMatrix_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    swapTensorSwapMatrix d ((a, b), (c, e)) ((i, j), (k, l)) =
+      if a = j ∧ b = i ∧ c = l ∧ e = k then 1 else 0 := by
+  by_cases ha : a = j <;> by_cases hb : b = i <;>
+    by_cases hc : c = l <;> by_cases he : e = k <;>
+    simp [swapTensorSwapMatrix, Matrix.kroneckerMap_apply,
+      Matrix.swapMatrix_apply, ha, hb, hc, he]
+
+/-- Entry formula for
+$(\mathbb S\otimes\mathbb S)(\Id\otimes\mathbb S\otimes\Id)$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2021--2026). -/
+@[simp] theorem swapTensorSwapMatrix_mul_identitySwapIdentityMatrix_apply
+    (d : ℕ) (a b c e i j k l : Fin d) :
+    (swapTensorSwapMatrix d * identitySwapIdentityMatrix d)
+        ((a, b), (c, e)) ((i, j), (k, l)) =
+      if a = k ∧ b = i ∧ c = l ∧ e = j then 1 else 0 := by
+  classical
+  simp only [Matrix.mul_apply, Fintype.sum_prod_type]
+  simp [swapTensorSwapMatrix_apply, identitySwapIdentityMatrix_apply,
+    ite_and, eq_comm]
+
+/-- Entry formula for
+$(\Id\otimes\mathbb S\otimes\Id)(\mathbb S\otimes\mathbb S)$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2030--2034). -/
+@[simp] theorem identitySwapIdentityMatrix_mul_swapTensorSwapMatrix_apply
+    (d : ℕ) (a b c e i j k l : Fin d) :
+    (identitySwapIdentityMatrix d * swapTensorSwapMatrix d)
+        ((a, b), (c, e)) ((i, j), (k, l)) =
+      if a = j ∧ b = l ∧ c = i ∧ e = k then 1 else 0 := by
+  classical
+  simp only [Matrix.mul_apply, Fintype.sum_prod_type]
+  simp [swapTensorSwapMatrix_apply, identitySwapIdentityMatrix_apply,
+    ite_and, eq_comm]
+
+/-- The product coordinates are the left source coordinates of $U_1$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁LeftRankEquiv (d : ℕ) :
+    Fin d × Fin d ≃ Fin ℓ[shiftExampleU₁ d] :=
+  (Equiv.prodCongr (identityLeftRankEquiv d) (identityLeftRankEquiv d)).trans
+    (tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d))
+
+/-- The product coordinates are the right source coordinates of $U_1$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁RightRankEquiv (d : ℕ) :
+    Fin d × Fin d ≃ Fin r[shiftExampleU₁ d] :=
+  (Equiv.prodCongr (identityRightRankEquiv d) (identityRightRankEquiv d)).trans
+    (tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d))
+
+/-- The two nontrivial left-shift coordinates are the left source coordinates
+of $U_2$; the right-shift left source has its unique value.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂LeftRankEquiv (d : ℕ) [NeZero d] :
+    Fin d × Fin d ≃ Fin ℓ[shiftExampleU₂ d] :=
+  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm |>.trans
+    ((Equiv.prodCongr (leftShiftLeftRankEquiv d)
+      (rightShiftLeftRankEquiv d)).trans
+        (tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)))
+
+/-- The two nontrivial right-shift coordinates are the right source
+coordinates of $U_2$; the left-shift right source has its unique value.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂RightRankEquiv (d : ℕ) [NeZero d] :
+    Fin d × Fin d ≃ Fin r[shiftExampleU₂ d] :=
+  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm |>.trans
+    ((Equiv.prodCongr (leftShiftRightRankEquiv d)
+      (rightShiftRightRankEquiv d)).trans
+        (tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)))
+
+/-- The two nontrivial left-shift coordinates are the left source coordinates
+of $U_3$; the right-shift left source has its unique value.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
+(lines 2009--2016 and 2028--2034). -/
+noncomputable def shiftExampleU₃LeftRankEquiv (d : ℕ) [NeZero d] :
+    Fin d × Fin d ≃ Fin ℓ[shiftExampleU₃ d] :=
+  (Equiv.uniqueProd (Fin d × Fin d) (Fin 1)).symm |>.trans
+    ((Equiv.prodCongr (rightShiftLeftRankEquiv d)
+      (leftShiftLeftRankEquiv d)).trans
+        (tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)))
+
+/-- The two nontrivial right-shift coordinates are the right source
+coordinates of $U_3$; the left-shift right source has its unique value.
+
+Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
+(lines 2009--2016 and 2028--2034). -/
+noncomputable def shiftExampleU₃RightRankEquiv (d : ℕ) [NeZero d] :
+    Fin d × Fin d ≃ Fin r[shiftExampleU₃ d] :=
+  (Equiv.prodUnique (Fin d × Fin d) (Fin 1)).symm |>.trans
+    ((Equiv.prodCongr (rightShiftRightRankEquiv d)
+      (leftShiftRightRankEquiv d)).trans
+        (tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)))
+
+@[simp] theorem shiftExampleU₁LeftRankEquiv_apply (d : ℕ) (a b : Fin d) :
+    shiftExampleU₁LeftRankEquiv d (a, b) =
+      tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+        (identityLeftRankEquiv d a, identityLeftRankEquiv d b) := rfl
+
+@[simp] theorem shiftExampleU₁RightRankEquiv_apply (d : ℕ) (a b : Fin d) :
+    shiftExampleU₁RightRankEquiv d (a, b) =
+      tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+        (identityRightRankEquiv d a, identityRightRankEquiv d b) := rfl
+
+@[simp] theorem shiftExampleU₂LeftRankEquiv_apply (d : ℕ) [NeZero d]
+    (a b : Fin d) :
+    shiftExampleU₂LeftRankEquiv d (a, b) =
+      tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+        (leftShiftLeftRankEquiv d (a, b), rightShiftLeftRankEquiv d 0) := rfl
+
+@[simp] theorem shiftExampleU₂RightRankEquiv_apply (d : ℕ) [NeZero d]
+    (a b : Fin d) :
+    shiftExampleU₂RightRankEquiv d (a, b) =
+      tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+        (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) := rfl
+
+@[simp] theorem shiftExampleU₃LeftRankEquiv_apply (d : ℕ) [NeZero d]
+    (a b : Fin d) :
+    shiftExampleU₃LeftRankEquiv d (a, b) =
+      tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+        (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (a, b)) := rfl
+
+@[simp] theorem shiftExampleU₃RightRankEquiv_apply (d : ℕ) [NeZero d]
+    (a b : Fin d) :
+    shiftExampleU₃RightRankEquiv d (a, b) =
+      tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+        (rightShiftRightRankEquiv d (a, b), leftShiftRightRankEquiv d 0) := rfl
+
+/-- Paper coordinates for the source row of $u_1$: the right-source pair is
+followed by the left-source pair.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁SourceURowEquiv (d : ℕ) :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin ℓ[shiftExampleU₁ d] × Fin r[shiftExampleU₁ d]) :=
+  (Equiv.prodComm (Fin d × Fin d) (Fin d × Fin d)).trans
+    (Equiv.prodCongr (shiftExampleU₁LeftRankEquiv d)
+      (shiftExampleU₁RightRankEquiv d))
+
+/-- Paper coordinates for the source column of $v_1$: the right-source pair
+is followed by the left-source pair.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₁SourceVColumnEquiv (d : ℕ) :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin r[shiftExampleU₁ d] × Fin ℓ[shiftExampleU₁ d]) :=
+  Equiv.prodCongr (shiftExampleU₁RightRankEquiv d)
+    (shiftExampleU₁LeftRankEquiv d)
+
+/-- Paper coordinates for the source row of $u_2^{(2)}$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂SourceURowEquiv (d : ℕ) [NeZero d] :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin ℓ[shiftExampleU₂ d] × Fin r[shiftExampleU₂ d]) :=
+  Equiv.prodCongr (shiftExampleU₂LeftRankEquiv d)
+    (shiftExampleU₂RightRankEquiv d)
+
+/-- Paper coordinates for the source column of $v_2^{(2)}$.  Each active
+rank pair is reversed, exactly as in the reflected source convention.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
+noncomputable def shiftExampleU₂SourceVColumnEquiv (d : ℕ) [NeZero d] :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin r[shiftExampleU₂ d] × Fin ℓ[shiftExampleU₂ d]) :=
+  (Equiv.prodCongr (Equiv.prodComm (Fin d) (Fin d))
+      (Equiv.prodComm (Fin d) (Fin d))).trans
+    (Equiv.prodCongr (shiftExampleU₂RightRankEquiv d)
+      (shiftExampleU₂LeftRankEquiv d))
+
+/-- Paper coordinates for the source row of $u_3^{(2)}$.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+noncomputable def shiftExampleU₃SourceURowEquiv (d : ℕ) [NeZero d] :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin ℓ[shiftExampleU₃ d] × Fin r[shiftExampleU₃ d]) :=
+  Equiv.prodCongr (shiftExampleU₃LeftRankEquiv d)
+    (shiftExampleU₃RightRankEquiv d)
+
+/-- Paper coordinates for the source column of $v_3^{(2)}$.  Each active
+rank pair is reversed, exactly as in the reflected source convention.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+noncomputable def shiftExampleU₃SourceVColumnEquiv (d : ℕ) [NeZero d] :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      (Fin r[shiftExampleU₃ d] × Fin ℓ[shiftExampleU₃ d]) :=
+  (Equiv.prodCongr (Equiv.prodComm (Fin d) (Fin d))
+      (Equiv.prodComm (Fin d) (Fin d))).trans
+    (Equiv.prodCongr (shiftExampleU₃RightRankEquiv d)
+      (shiftExampleU₃LeftRankEquiv d))
+
+/-- Reorder two pairs so that the $u_3$ source coordinates exhibit the single
+swap $\mathbb S$ from `eq:SF_u1_u3`.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+def shiftExampleU₃SourceUSwapShuffle (d : ℕ) :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      ((Fin d × Fin d) × (Fin d × Fin d)) where
+  toFun x := ((x.2.2, x.1.2), (x.2.1, x.1.1))
+  invFun x := ((x.2.2, x.1.2), (x.2.1, x.1.1))
+  left_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
+  right_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
+
+/-- Reorder two pairs so that the $v_3$ source coordinates exhibit the single
+swap $\mathbb S$ from `eq:SF_u1_u3`.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+def shiftExampleU₃SourceVSwapShuffle (d : ℕ) :
+    ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      ((Fin d × Fin d) × (Fin d × Fin d)) where
+  toFun x := ((x.1.1, x.2.1), (x.1.2, x.2.2))
+  invFun x := ((x.1.1, x.2.1), (x.1.2, x.2.2))
+  left_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
+  right_inv x := by rcases x with ⟨⟨_, _⟩, ⟨_, _⟩⟩; rfl
+
+/-- Composite-site coordinates for the source row of the paper's $u_3$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₃SwapSourceURowEquiv (d : ℕ) [NeZero d] :
+    (Fin (d * d) × Fin (d * d)) ≃
+      (Fin ℓ[shiftExampleU₃ d] × Fin r[shiftExampleU₃ d]) :=
+  ((Equiv.prodCongr finProdFinEquiv.symm finProdFinEquiv.symm).trans
+    (shiftExampleU₃SourceUSwapShuffle d)).trans
+      (Equiv.prodCongr (shiftExampleU₃LeftRankEquiv d)
+        (shiftExampleU₃RightRankEquiv d))
+
+/-- Composite-site coordinates for the source column of the paper's $v_3$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+noncomputable def shiftExampleU₃SwapSourceVColumnEquiv (d : ℕ) [NeZero d] :
+    (Fin (d * d) × Fin (d * d)) ≃
+      (Fin r[shiftExampleU₃ d] × Fin ℓ[shiftExampleU₃ d]) :=
+  ((Equiv.prodCongr finProdFinEquiv.symm finProdFinEquiv.symm).trans
+    (shiftExampleU₃SourceVSwapShuffle d)).trans
+      (Equiv.prodCongr (shiftExampleU₃RightRankEquiv d)
+        (shiftExampleU₃LeftRankEquiv d))
+
+@[simp] theorem shiftExampleU₃SwapSourceURowEquiv_apply (d : ℕ) [NeZero d]
+    (a b c e : Fin d) :
+    shiftExampleU₃SwapSourceURowEquiv d
+        (finProdFinEquiv (a, b), finProdFinEquiv (c, e)) =
+      (shiftExampleU₃LeftRankEquiv d (e, b),
+        shiftExampleU₃RightRankEquiv d (c, a)) := by
+  simp [shiftExampleU₃SwapSourceURowEquiv,
+    shiftExampleU₃SourceUSwapShuffle]
+
+@[simp] theorem shiftExampleU₃SwapSourceVColumnEquiv_apply (d : ℕ) [NeZero d]
+    (a b c e : Fin d) :
+    shiftExampleU₃SwapSourceVColumnEquiv d
+        (finProdFinEquiv (a, b), finProdFinEquiv (c, e)) =
+      (shiftExampleU₃RightRankEquiv d (a, c),
+        shiftExampleU₃LeftRankEquiv d (b, e)) := by
+  simp [shiftExampleU₃SwapSourceVColumnEquiv,
+    shiftExampleU₃SourceVSwapShuffle]
+
+private theorem shiftExampleU₂_sourceU_product_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        (tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+            (leftShiftLeftRankEquiv d (a, b), rightShiftLeftRankEquiv d 0),
+          tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+            (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (c, e)))
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) =
+      SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+          (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0) (i, k) *
+        SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+          (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, e)) (j, l) := by
+  simpa only [shiftExampleU₂, shiftExampleU₂SourceFactors] using
+    SourceFactors.sourceU_independentTensorProduct_apply
+      (leftShiftSourceFactors d) (rightShiftSourceFactors d)
+      (leftShiftLeftRankEquiv d (a, b)) (rightShiftLeftRankEquiv d 0)
+      (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (c, e)) i k j l
+
+/-- Entry formula for the supplied $u_2^{(2)}$ in the paper's source and
+four-spin coordinates.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
+theorem shiftExampleU₂_sourceU_two_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        (shiftExampleU₂SourceURowEquiv d ((a, b), (c, e)))
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l))) =
+      identitySwapIdentityMatrix d ((a, b), (c, e)) ((i, j), (k, l)) := by
+  rw [show shiftExampleU₂SourceURowEquiv d ((a, b), (c, e)) =
+      (tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+          (leftShiftLeftRankEquiv d (a, b), rightShiftLeftRankEquiv d 0),
+        tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+          (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (c, e))) by rfl,
+    show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl]
+  calc
+    _ = SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+          (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0) (i, k) *
+        SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+          (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, e))
+            (j, l) := shiftExampleU₂_sourceU_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceU_leftShiftSourceFactors_apply,
+        sourceU_rightShiftSourceFactors_apply]
+      by_cases ha : a = i <;> by_cases hb : b = k <;>
+        by_cases hc : c = j <;> by_cases he : e = l <;>
+        simp [identitySwapIdentityMatrix, ha, hb, hc, he,
+          shiftSourceScale_cancel d]
+
+/-- For the supplied factors of $U_2$, the paper's two-site source gate is
+$u_2^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the displayed four-spin order.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
+theorem shiftExampleU₂_sourceU_two_eq_identitySwapIdentity (d : ℕ) [NeZero d] :
+    Matrix.reindex (shiftExampleU₂SourceURowEquiv d).symm
+        (shiftTwoSitePhysicalEquiv d).symm
+        (SourceFactors.sourceU (shiftExampleU₂ d)
+          (shiftExampleU₂SourceFactors d)) =
+      identitySwapIdentityMatrix d := by
+  ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm] using
+    shiftExampleU₂_sourceU_two_apply d a b c e i j k l
+
+private theorem shiftExampleU₂_sourceV_product_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l))
+        (tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+            (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (b, a)),
+          tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+            (leftShiftLeftRankEquiv d (e, c), rightShiftLeftRankEquiv d 0)) =
+      SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+          (i, k) (leftShiftRightRankEquiv d 0, leftShiftLeftRankEquiv d (e, c)) *
+        SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+          (j, l) (rightShiftRightRankEquiv d (b, a),
+            rightShiftLeftRankEquiv d 0) := by
+  simpa only [shiftExampleU₂, shiftExampleU₂SourceFactors] using
+    SourceFactors.sourceV_independentTensorProduct_apply
+      (leftShiftSourceFactors d) (rightShiftSourceFactors d) i k j l
+      (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (b, a))
+      (leftShiftLeftRankEquiv d (e, c)) (rightShiftLeftRankEquiv d 0)
+
+/-- Entry formula for the supplied $v_2^{(2)}$ in the paper's source and
+four-spin coordinates.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
+theorem shiftExampleU₂_sourceV_two_apply (d : ℕ) [NeZero d]
+    (i j k l a b c e : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₂ d) (shiftExampleU₂SourceFactors d)
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l)))
+        (shiftExampleU₂SourceVColumnEquiv d ((a, b), (c, e))) =
+      (swapTensorSwapMatrix d * identitySwapIdentityMatrix d)
+        ((i, j), (k, l)) ((a, b), (c, e)) := by
+  rw [show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl,
+    show shiftExampleU₂SourceVColumnEquiv d ((a, b), (c, e)) =
+      (tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+          (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (b, a)),
+        tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
+          (leftShiftLeftRankEquiv d (e, c), rightShiftLeftRankEquiv d 0)) by rfl]
+  calc
+    _ = SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+          (i, k) (leftShiftRightRankEquiv d 0, leftShiftLeftRankEquiv d (e, c)) *
+        SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+          (j, l) (rightShiftRightRankEquiv d (b, a),
+            rightShiftLeftRankEquiv d 0) :=
+      shiftExampleU₂_sourceV_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceV_leftShiftSourceFactors_apply,
+        sourceV_rightShiftSourceFactors_apply]
+      by_cases ha : j = a <;> by_cases hb : l = b <;>
+        by_cases hc : i = c <;> by_cases he : k = e <;>
+        simp [ha, hb, hc, he, shiftSourceScale_cancel_rev d] <;> aesop
+
+/-- For the supplied factors of $U_2$, the paper's reflected two-site source
+gate is
+$v_2^{(2)}=(\mathbb S\otimes\mathbb S)
+(\Id\otimes\mathbb S\otimes\Id)$ in the displayed four-spin order.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2026). -/
+theorem shiftExampleU₂_sourceV_two_eq_swapSwap_mul_identitySwapIdentity
+    (d : ℕ) [NeZero d] :
+    Matrix.reindex (shiftTwoSitePhysicalEquiv d).symm
+        (shiftExampleU₂SourceVColumnEquiv d).symm
+        (SourceFactors.sourceV (shiftExampleU₂ d)
+          (shiftExampleU₂SourceFactors d)) =
+      swapTensorSwapMatrix d * identitySwapIdentityMatrix d := by
+  ext ⟨⟨i, j⟩, ⟨k, l⟩⟩ ⟨⟨a, b⟩, ⟨c, e⟩⟩
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm] using
+    shiftExampleU₂_sourceV_two_apply d i j k l a b c e
+
+private theorem shiftExampleU₃_sourceU_product_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+            (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (a, b)),
+          tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+            (rightShiftRightRankEquiv d (c, e), leftShiftRightRankEquiv d 0))
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) =
+      SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+          (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, e)) (i, k) *
+        SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+          (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0) (j, l) := by
+  simpa only [shiftExampleU₃, shiftExampleU₃SourceFactors] using
+    SourceFactors.sourceU_independentTensorProduct_apply
+      (rightShiftSourceFactors d) (leftShiftSourceFactors d)
+      (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (a, b))
+      (rightShiftRightRankEquiv d (c, e)) (leftShiftRightRankEquiv d 0) i k j l
+
+/-- Entry formula for the supplied $u_3^{(2)}$ in the paper's source and
+four-spin coordinates.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+theorem shiftExampleU₃_sourceU_two_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (shiftExampleU₃SourceURowEquiv d ((a, b), (c, e)))
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l))) =
+      (identitySwapIdentityMatrix d * swapTensorSwapMatrix d)
+        ((a, b), (c, e)) ((i, j), (k, l)) := by
+  rw [show shiftExampleU₃SourceURowEquiv d ((a, b), (c, e)) =
+      (tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+          (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (a, b)),
+        tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+          (rightShiftRightRankEquiv d (c, e), leftShiftRightRankEquiv d 0)) by rfl,
+    show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl]
+  calc
+    _ = SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+          (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, e)) (i, k) *
+        SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+          (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0)
+            (j, l) := shiftExampleU₃_sourceU_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceU_rightShiftSourceFactors_apply,
+        sourceU_leftShiftSourceFactors_apply]
+      by_cases ha : a = j <;> by_cases hb : b = l <;>
+        by_cases hc : c = i <;> by_cases he : e = k <;>
+        simp [ha, hb, hc, he, shiftSourceScale_cancel_rev d]
+
+/-- For the supplied factors of $U_3$, the paper's two-site source gate is
+$u_3^{(2)}=(\Id\otimes\mathbb S\otimes\Id)
+(\mathbb S\otimes\mathbb S)$ in the displayed four-spin order.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+theorem shiftExampleU₃_sourceU_two_eq_identitySwapIdentity_mul_swapSwap
+    (d : ℕ) [NeZero d] :
+    Matrix.reindex (shiftExampleU₃SourceURowEquiv d).symm
+        (shiftTwoSitePhysicalEquiv d).symm
+        (SourceFactors.sourceU (shiftExampleU₃ d)
+          (shiftExampleU₃SourceFactors d)) =
+      identitySwapIdentityMatrix d * swapTensorSwapMatrix d := by
+  ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm] using
+    shiftExampleU₃_sourceU_two_apply d a b c e i j k l
+
+private theorem shiftExampleU₃_sourceV_product_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l))
+        (tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+            (rightShiftRightRankEquiv d (b, a), leftShiftRightRankEquiv d 0),
+          tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+            (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (e, c))) =
+      SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+          (i, k) (rightShiftRightRankEquiv d (b, a),
+            rightShiftLeftRankEquiv d 0) *
+        SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+          (j, l) (leftShiftRightRankEquiv d 0,
+            leftShiftLeftRankEquiv d (e, c)) := by
+  simpa only [shiftExampleU₃, shiftExampleU₃SourceFactors] using
+    SourceFactors.sourceV_independentTensorProduct_apply
+      (rightShiftSourceFactors d) (leftShiftSourceFactors d) i k j l
+      (rightShiftRightRankEquiv d (b, a)) (leftShiftRightRankEquiv d 0)
+      (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (e, c))
+
+/-- Entry formula for the supplied $v_3^{(2)}$ in the paper's source and
+four-spin coordinates.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+theorem shiftExampleU₃_sourceV_two_apply (d : ℕ) [NeZero d]
+    (i j k l a b c e : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l)))
+        (shiftExampleU₃SourceVColumnEquiv d ((a, b), (c, e))) =
+      identitySwapIdentityMatrix d ((i, j), (k, l)) ((a, b), (c, e)) := by
+  rw [show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl,
+    show shiftExampleU₃SourceVColumnEquiv d ((a, b), (c, e)) =
+      (tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+          (rightShiftRightRankEquiv d (b, a), leftShiftRightRankEquiv d 0),
+        tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
+          (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (e, c))) by rfl]
+  calc
+    _ = SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+          (i, k) (rightShiftRightRankEquiv d (b, a),
+            rightShiftLeftRankEquiv d 0) *
+        SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+          (j, l) (leftShiftRightRankEquiv d 0,
+            leftShiftLeftRankEquiv d (e, c)) :=
+      shiftExampleU₃_sourceV_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceV_rightShiftSourceFactors_apply,
+        sourceV_leftShiftSourceFactors_apply]
+      by_cases ha : i = a <;> by_cases hb : k = b <;>
+        by_cases hc : j = c <;> by_cases he : l = e <;>
+        simp [identitySwapIdentityMatrix, ha, hb, hc, he,
+          shiftSourceScale_cancel d] <;> aesop
+
+/-- For the supplied factors of $U_3$, the paper's reflected two-site source
+gate is $v_3^{(2)}=\Id\otimes\mathbb S\otimes\Id$ in the displayed
+four-spin order.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2028--2034). -/
+theorem shiftExampleU₃_sourceV_two_eq_identitySwapIdentity
+    (d : ℕ) [NeZero d] :
+    Matrix.reindex (shiftTwoSitePhysicalEquiv d).symm
+        (shiftExampleU₃SourceVColumnEquiv d).symm
+        (SourceFactors.sourceV (shiftExampleU₃ d)
+          (shiftExampleU₃SourceFactors d)) =
+      identitySwapIdentityMatrix d := by
+  ext ⟨⟨i, j⟩, ⟨k, l⟩⟩ ⟨⟨a, b⟩, ⟨c, e⟩⟩
+  simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_symm] using
+    shiftExampleU₃_sourceV_two_apply d i j k l a b c e
+
+private theorem shiftExampleU₁_sourceU_product_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₁ d) (shiftExampleU₁SourceFactors d)
+        (tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+            (identityLeftRankEquiv d c, identityLeftRankEquiv d e),
+          tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+            (identityRightRankEquiv d a, identityRightRankEquiv d b))
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) =
+      SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
+          (identityLeftRankEquiv d c, identityRightRankEquiv d a) (i, k) *
+        SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
+          (identityLeftRankEquiv d e, identityRightRankEquiv d b) (j, l) := by
+  simpa only [shiftExampleU₁, shiftExampleU₁SourceFactors] using
+    SourceFactors.sourceU_independentTensorProduct_apply
+      (identitySourceFactors d) (identitySourceFactors d)
+      (identityLeftRankEquiv d c) (identityLeftRankEquiv d e)
+      (identityRightRankEquiv d a) (identityRightRankEquiv d b) i k j l
+
+/-- Entry formula for the supplied $u_1=\Id\otimes\Id$ in the paper's source
+coordinates.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₁_sourceU_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₁ d) (shiftExampleU₁SourceFactors d)
+        (shiftExampleU₁SourceURowEquiv d ((a, b), (c, e)))
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l))) =
+      identityTensorIdentityMatrix d ((a, b), (c, e)) ((i, j), (k, l)) := by
+  rw [show shiftExampleU₁SourceURowEquiv d ((a, b), (c, e)) =
+      (tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+          (identityLeftRankEquiv d c, identityLeftRankEquiv d e),
+        tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+          (identityRightRankEquiv d a, identityRightRankEquiv d b)) by rfl,
+    show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl]
+  calc
+    _ = SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
+          (identityLeftRankEquiv d c, identityRightRankEquiv d a) (i, k) *
+        SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
+          (identityLeftRankEquiv d e, identityRightRankEquiv d b)
+            (j, l) := shiftExampleU₁_sourceU_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceU_identitySourceFactors_apply,
+        sourceU_identitySourceFactors_apply]
+      by_cases ha : a = i <;> by_cases hb : b = j <;>
+        by_cases hc : c = k <;> by_cases he : e = l <;>
+        simp [identityTensorIdentityMatrix_apply, ha, hb, hc, he]
+
+private theorem shiftExampleU₁_sourceV_product_apply (d : ℕ)
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₁ d) (shiftExampleU₁SourceFactors d)
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l))
+        (tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+            (identityRightRankEquiv d a, identityRightRankEquiv d b),
+          tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+            (identityLeftRankEquiv d c, identityLeftRankEquiv d e)) =
+      SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
+          (i, k) (identityRightRankEquiv d a, identityLeftRankEquiv d c) *
+        SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
+          (j, l) (identityRightRankEquiv d b, identityLeftRankEquiv d e) := by
+  simpa only [shiftExampleU₁, shiftExampleU₁SourceFactors] using
+    SourceFactors.sourceV_independentTensorProduct_apply
+      (identitySourceFactors d) (identitySourceFactors d) i k j l
+      (identityRightRankEquiv d a) (identityRightRankEquiv d b)
+      (identityLeftRankEquiv d c) (identityLeftRankEquiv d e)
+
+/-- Entry formula for the supplied $v_1=\Id\otimes\Id$ in the paper's source
+coordinates.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₁_sourceV_apply (d : ℕ)
+    (i j k l a b c e : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₁ d) (shiftExampleU₁SourceFactors d)
+        (shiftTwoSitePhysicalEquiv d ((i, j), (k, l)))
+        (shiftExampleU₁SourceVColumnEquiv d ((a, b), (c, e))) =
+      identityTensorIdentityMatrix d ((i, j), (k, l)) ((a, b), (c, e)) := by
+  rw [show shiftTwoSitePhysicalEquiv d ((i, j), (k, l)) =
+      (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) by rfl,
+    show shiftExampleU₁SourceVColumnEquiv d ((a, b), (c, e)) =
+      (tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+          (identityRightRankEquiv d a, identityRightRankEquiv d b),
+        tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
+          (identityLeftRankEquiv d c, identityLeftRankEquiv d e)) by rfl]
+  calc
+    _ = SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
+          (i, k) (identityRightRankEquiv d a, identityLeftRankEquiv d c) *
+        SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
+          (j, l) (identityRightRankEquiv d b,
+            identityLeftRankEquiv d e) :=
+      shiftExampleU₁_sourceV_product_apply d a b c e i j k l
+    _ = _ := by
+      rw [sourceV_identitySourceFactors_apply,
+        sourceV_identitySourceFactors_apply]
+      by_cases ha : i = a <;> by_cases hb : j = b <;>
+        by_cases hc : k = c <;> by_cases he : l = e <;>
+        simp [identityTensorIdentityMatrix_apply, ha, hb, hc, he] <;> aesop
+
+/-- For the supplied factors of $U_1$, both paper source gates are
+$u_1=v_1=\Id\otimes\Id$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₁_sourceUV_eq_identityTensorIdentity (d : ℕ) :
+    Matrix.reindex (shiftExampleU₁SourceURowEquiv d).symm
+        (shiftTwoSitePhysicalEquiv d).symm
+        (SourceFactors.sourceU (shiftExampleU₁ d)
+          (shiftExampleU₁SourceFactors d)) = identityTensorIdentityMatrix d ∧
+      Matrix.reindex (shiftTwoSitePhysicalEquiv d).symm
+        (shiftExampleU₁SourceVColumnEquiv d).symm
+        (SourceFactors.sourceV (shiftExampleU₁ d)
+          (shiftExampleU₁SourceFactors d)) = identityTensorIdentityMatrix d := by
+  constructor
+  · ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Equiv.symm_symm] using
+      shiftExampleU₁_sourceU_apply d a b c e i j k l
+  · ext ⟨⟨i, j⟩, ⟨k, l⟩⟩ ⟨⟨a, b⟩, ⟨c, e⟩⟩
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Equiv.symm_symm] using
+      shiftExampleU₁_sourceV_apply d i j k l a b c e
+
+/-- Entry formula for the supplied $u_3=\mathbb S$ in the paper's
+composite-site source coordinates.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₃_sourceU_eq_swap_apply (d : ℕ) [NeZero d]
+    (a b c e i j k l : Fin d) :
+    SourceFactors.sourceU (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (shiftExampleU₃SwapSourceURowEquiv d
+          (finProdFinEquiv (a, b), finProdFinEquiv (c, e)))
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) =
+      Matrix.swapMatrix (d * d)
+        (finProdFinEquiv (a, b), finProdFinEquiv (c, e))
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) := by
+  rw [shiftExampleU₃SwapSourceURowEquiv_apply,
+    shiftExampleU₃LeftRankEquiv_apply,
+    shiftExampleU₃RightRankEquiv_apply]
+  calc
+    _ = SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
+          (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, a)) (i, k) *
+        SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
+          (leftShiftLeftRankEquiv d (e, b), leftShiftRightRankEquiv d 0)
+            (j, l) := shiftExampleU₃_sourceU_product_apply d e b c a i j k l
+    _ = _ := by
+      rw [sourceU_rightShiftSourceFactors_apply,
+        sourceU_leftShiftSourceFactors_apply, Matrix.swapMatrix_apply]
+      by_cases ha : a = k <;> by_cases hb : b = l <;>
+        by_cases hc : c = i <;> by_cases he : e = j <;>
+        simp [ha, hb, hc, he, shiftSourceScale_cancel_rev d]
+
+/-- Entry formula for the supplied $v_3=\mathbb S$ in the paper's
+composite-site source coordinates.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₃_sourceV_eq_swap_apply (d : ℕ) [NeZero d]
+    (i j k l a b c e : Fin d) :
+    SourceFactors.sourceV (shiftExampleU₃ d) (shiftExampleU₃SourceFactors d)
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l))
+        (shiftExampleU₃SwapSourceVColumnEquiv d
+          (finProdFinEquiv (a, b), finProdFinEquiv (c, e))) =
+      Matrix.swapMatrix (d * d)
+        (finProdFinEquiv (i, j), finProdFinEquiv (k, l))
+        (finProdFinEquiv (a, b), finProdFinEquiv (c, e)) := by
+  rw [shiftExampleU₃SwapSourceVColumnEquiv_apply,
+    shiftExampleU₃RightRankEquiv_apply,
+    shiftExampleU₃LeftRankEquiv_apply]
+  calc
+    _ = SourceFactors.sourceV (rightShiftTensor d) (rightShiftSourceFactors d)
+          (i, k) (rightShiftRightRankEquiv d (a, c),
+            rightShiftLeftRankEquiv d 0) *
+        SourceFactors.sourceV (leftShiftTensor d) (leftShiftSourceFactors d)
+          (j, l) (leftShiftRightRankEquiv d 0,
+            leftShiftLeftRankEquiv d (b, e)) :=
+      shiftExampleU₃_sourceV_product_apply d c a e b i j k l
+    _ = _ := by
+      rw [sourceV_rightShiftSourceFactors_apply,
+        sourceV_leftShiftSourceFactors_apply, Matrix.swapMatrix_apply]
+      by_cases ha : k = a <;> by_cases hb : l = b <;>
+        by_cases hc : i = c <;> by_cases he : j = e <;>
+        simp [ha, hb, hc, he, shiftSourceScale_cancel d] <;> aesop
+
+/-- For the supplied factors of $U_3$, both unblocked paper source gates are
+$u_3=v_3=\mathbb S$.
+
+Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
+theorem shiftExampleU₃_sourceUV_eq_swap (d : ℕ) [NeZero d] :
+    Matrix.reindex (shiftExampleU₃SwapSourceURowEquiv d).symm
+        (Equiv.refl _)
+        (SourceFactors.sourceU (shiftExampleU₃ d)
+          (shiftExampleU₃SourceFactors d)) = Matrix.swapMatrix (d * d) ∧
+      Matrix.reindex (Equiv.refl _)
+        (shiftExampleU₃SwapSourceVColumnEquiv d).symm
+        (SourceFactors.sourceV (shiftExampleU₃ d)
+          (shiftExampleU₃SourceFactors d)) = Matrix.swapMatrix (d * d) := by
+  constructor
+  · ext row col
+    obtain ⟨⟨⟨a, b⟩, ⟨c, e⟩⟩, rfl⟩ :=
+      (shiftTwoSitePhysicalEquiv d).surjective row
+    obtain ⟨⟨⟨i, j⟩, ⟨k, l⟩⟩, rfl⟩ :=
+      (shiftTwoSitePhysicalEquiv d).surjective col
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Equiv.symm_symm, Equiv.refl_symm, Equiv.refl_apply,
+      shiftTwoSitePhysicalEquiv, Equiv.prodCongr_apply, Prod.map_apply'] using
+      shiftExampleU₃_sourceU_eq_swap_apply d a b c e i j k l
+  · ext row col
+    obtain ⟨⟨⟨i, j⟩, ⟨k, l⟩⟩, rfl⟩ :=
+      (shiftTwoSitePhysicalEquiv d).surjective row
+    obtain ⟨⟨⟨a, b⟩, ⟨c, e⟩⟩, rfl⟩ :=
+      (shiftTwoSitePhysicalEquiv d).surjective col
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Equiv.symm_symm, Equiv.refl_symm, Equiv.refl_apply,
+      shiftTwoSitePhysicalEquiv, Equiv.prodCongr_apply, Prod.map_apply'] using
+      shiftExampleU₃_sourceV_eq_swap_apply d i j k l a b c e
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean
@@ -19,26 +19,12 @@ open scoped Matrix Kronecker BigOperators
 
 namespace MPOTensor
 
-private theorem shiftSourceScale_cancel (d : ℕ) [NeZero d] :
-    ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) * (Real.sqrt d : ℂ)⁻¹ = 1 := by
-  have hsqrt : (Real.sqrt d : ℂ) ^ 2 = (d : ℂ) := by
-    exact Complex.ofReal_sqrt_sq d (by positivity)
-  have hsqrt_ne : (Real.sqrt d : ℂ) ≠ 0 := by
-    exact Complex.ofReal_ne_zero.mpr <|
-      Real.sqrt_ne_zero'.2 (by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d))
-  rw [← hsqrt]
-  field_simp [hsqrt_ne]
-
-private theorem shiftSourceScale_cancel_rev (d : ℕ) [NeZero d] :
-    (Real.sqrt d : ℂ)⁻¹ * ((d : ℂ) * (Real.sqrt d : ℂ)⁻¹) = 1 := by
-  simpa [mul_comm, mul_left_comm, mul_assoc] using shiftSourceScale_cancel d
-
 /-- Explicit supplied source factors for the paper's identity family $U_1$.
 
 Source: arXiv:1703.09188, equation `eq:SF_u1_u3` (lines 2009--2016). -/
 noncomputable def shiftExampleU₁SourceFactors (d : ℕ) :
     SourceFactors (shiftExampleU₁ d) (1 : Matrix (Fin 1) (Fin 1) ℂ) :=
-  SourceFactors.independentTensorProduct (identitySourceFactors d)
+  SourceFactors.independentTensorProductOfIdentityWeight (identitySourceFactors d)
     (identitySourceFactors d)
 
 /-- Explicit supplied source factors for the paper's counter-shift family $U_2$.
@@ -47,7 +33,7 @@ Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2018--2027). -/
 noncomputable def shiftExampleU₂SourceFactors (d : ℕ) [NeZero d] :
     SourceFactors (shiftExampleU₂ d)
       (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
-  SourceFactors.independentTensorProduct (leftShiftSourceFactors d)
+  SourceFactors.independentTensorProductOfIdentityWeight (leftShiftSourceFactors d)
     (rightShiftSourceFactors d)
 
 /-- Explicit supplied source factors for the paper's reversed counter-shift
@@ -58,7 +44,7 @@ Source: arXiv:1703.09188, equations `eq:SF_u1_u3` and `eq:uv2_U3`
 noncomputable def shiftExampleU₃SourceFactors (d : ℕ) [NeZero d] :
     SourceFactors (shiftExampleU₃ d)
       (1 : Matrix (Fin (d * d)) (Fin (d * d)) ℂ) :=
-  SourceFactors.independentTensorProduct (rightShiftSourceFactors d)
+  SourceFactors.independentTensorProductOfIdentityWeight (rightShiftSourceFactors d)
     (leftShiftSourceFactors d)
 
 /-- Decode the two physical sites of a shift-family source matrix into their
@@ -227,34 +213,64 @@ noncomputable def shiftExampleU₃RightRankEquiv (d : ℕ) [NeZero d] :
       (leftShiftRightRankEquiv d)).trans
         (tensorProductRightRankEquiv (rightShiftTensor d) (leftShiftTensor d)))
 
+/-- Evaluation of the left source-rank coordinates of $U_1$.
+
+Formalization coordinate identity for arXiv:1703.09188, equation
+`eq:SF_u1_u3` (lines 2009--2016); the paper states the resulting source
+matrix, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₁LeftRankEquiv_apply (d : ℕ) (a b : Fin d) :
     shiftExampleU₁LeftRankEquiv d (a, b) =
       tensorProductLeftRankEquiv (identityMPUTensor d) (identityMPUTensor d)
         (identityLeftRankEquiv d a, identityLeftRankEquiv d b) := rfl
 
+/-- Evaluation of the right source-rank coordinates of $U_1$.
+
+Formalization coordinate identity for arXiv:1703.09188, equation
+`eq:SF_u1_u3` (lines 2009--2016); the paper states the resulting source
+matrix, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₁RightRankEquiv_apply (d : ℕ) (a b : Fin d) :
     shiftExampleU₁RightRankEquiv d (a, b) =
       tensorProductRightRankEquiv (identityMPUTensor d) (identityMPUTensor d)
         (identityRightRankEquiv d a, identityRightRankEquiv d b) := rfl
 
+/-- Evaluation of the left source-rank coordinates of $U_2$.
+
+Formalization coordinate identity for arXiv:1703.09188, equation `eq:uv2_U2`
+(lines 2018--2027); the paper states the resulting source matrix, not this
+intermediate equivalence. -/
 @[simp] theorem shiftExampleU₂LeftRankEquiv_apply (d : ℕ) [NeZero d]
     (a b : Fin d) :
     shiftExampleU₂LeftRankEquiv d (a, b) =
       tensorProductLeftRankEquiv (leftShiftTensor d) (rightShiftTensor d)
         (leftShiftLeftRankEquiv d (a, b), rightShiftLeftRankEquiv d 0) := rfl
 
+/-- Evaluation of the right source-rank coordinates of $U_2$.
+
+Formalization coordinate identity for arXiv:1703.09188, equation `eq:uv2_U2`
+(lines 2018--2027); the paper states the resulting source matrix, not this
+intermediate equivalence. -/
 @[simp] theorem shiftExampleU₂RightRankEquiv_apply (d : ℕ) [NeZero d]
     (a b : Fin d) :
     shiftExampleU₂RightRankEquiv d (a, b) =
       tensorProductRightRankEquiv (leftShiftTensor d) (rightShiftTensor d)
         (leftShiftRightRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) := rfl
 
+/-- Evaluation of the left source-rank coordinates of $U_3$.
+
+Formalization coordinate identity for arXiv:1703.09188, equations
+`eq:SF_u1_u3` and `eq:uv2_U3` (lines 2009--2016 and 2028--2034); the paper
+states the resulting source matrices, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₃LeftRankEquiv_apply (d : ℕ) [NeZero d]
     (a b : Fin d) :
     shiftExampleU₃LeftRankEquiv d (a, b) =
       tensorProductLeftRankEquiv (rightShiftTensor d) (leftShiftTensor d)
         (rightShiftLeftRankEquiv d 0, leftShiftLeftRankEquiv d (a, b)) := rfl
 
+/-- Evaluation of the right source-rank coordinates of $U_3$.
+
+Formalization coordinate identity for arXiv:1703.09188, equations
+`eq:SF_u1_u3` and `eq:uv2_U3` (lines 2009--2016 and 2028--2034); the paper
+states the resulting source matrices, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₃RightRankEquiv_apply (d : ℕ) [NeZero d]
     (a b : Fin d) :
     shiftExampleU₃RightRankEquiv d (a, b) =
@@ -386,6 +402,12 @@ noncomputable def shiftExampleU₃SwapSourceVColumnEquiv (d : ℕ) [NeZero d] :
       (Equiv.prodCongr (shiftExampleU₃RightRankEquiv d)
         (shiftExampleU₃LeftRankEquiv d))
 
+/-- Evaluation of the composite-site source-row coordinates exhibiting
+$u_3=\mathbb S$.
+
+Formalization coordinate identity for arXiv:1703.09188, equations `uu` and
+`eq:SF_u1_u3` (lines 532--543 and 2009--2016); the paper states the final
+swap, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₃SwapSourceURowEquiv_apply (d : ℕ) [NeZero d]
     (a b c e : Fin d) :
     shiftExampleU₃SwapSourceURowEquiv d
@@ -395,6 +417,12 @@ noncomputable def shiftExampleU₃SwapSourceVColumnEquiv (d : ℕ) [NeZero d] :
   simp [shiftExampleU₃SwapSourceURowEquiv,
     shiftExampleU₃SourceUSwapShuffle]
 
+/-- Evaluation of the composite-site source-column coordinates exhibiting
+$v_3=\mathbb S$.
+
+Formalization coordinate identity for arXiv:1703.09188, equations `vdagger`
+and `eq:SF_u1_u3` (lines 520--543 and 2009--2016); the paper states the final
+swap, not this intermediate equivalence. -/
 @[simp] theorem shiftExampleU₃SwapSourceVColumnEquiv_apply (d : ℕ) [NeZero d]
     (a b c e : Fin d) :
     shiftExampleU₃SwapSourceVColumnEquiv d
@@ -417,7 +445,7 @@ private theorem shiftExampleU₂_sourceU_product_apply (d : ℕ) [NeZero d]
         SourceFactors.sourceU (rightShiftTensor d) (rightShiftSourceFactors d)
           (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (c, e)) (j, l) := by
   simpa only [shiftExampleU₂, shiftExampleU₂SourceFactors] using
-    SourceFactors.sourceU_independentTensorProduct_apply
+    SourceFactors.sourceU_independentTensorProductOfIdentityWeight_apply
       (leftShiftSourceFactors d) (rightShiftSourceFactors d)
       (leftShiftLeftRankEquiv d (a, b)) (rightShiftLeftRankEquiv d 0)
       (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (c, e)) i k j l
@@ -486,7 +514,7 @@ private theorem shiftExampleU₂_sourceV_product_apply (d : ℕ) [NeZero d]
           (j, l) (rightShiftRightRankEquiv d (b, a),
             rightShiftLeftRankEquiv d 0) := by
   simpa only [shiftExampleU₂, shiftExampleU₂SourceFactors] using
-    SourceFactors.sourceV_independentTensorProduct_apply
+    SourceFactors.sourceV_independentTensorProductOfIdentityWeight_apply
       (leftShiftSourceFactors d) (rightShiftSourceFactors d) i k j l
       (leftShiftRightRankEquiv d 0) (rightShiftRightRankEquiv d (b, a))
       (leftShiftLeftRankEquiv d (e, c)) (rightShiftLeftRankEquiv d 0)
@@ -557,7 +585,7 @@ private theorem shiftExampleU₃_sourceU_product_apply (d : ℕ) [NeZero d]
         SourceFactors.sourceU (leftShiftTensor d) (leftShiftSourceFactors d)
           (leftShiftLeftRankEquiv d (a, b), leftShiftRightRankEquiv d 0) (j, l) := by
   simpa only [shiftExampleU₃, shiftExampleU₃SourceFactors] using
-    SourceFactors.sourceU_independentTensorProduct_apply
+    SourceFactors.sourceU_independentTensorProductOfIdentityWeight_apply
       (rightShiftSourceFactors d) (leftShiftSourceFactors d)
       (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (a, b))
       (rightShiftRightRankEquiv d (c, e)) (leftShiftRightRankEquiv d 0) i k j l
@@ -628,7 +656,7 @@ private theorem shiftExampleU₃_sourceV_product_apply (d : ℕ) [NeZero d]
           (j, l) (leftShiftRightRankEquiv d 0,
             leftShiftLeftRankEquiv d (e, c)) := by
   simpa only [shiftExampleU₃, shiftExampleU₃SourceFactors] using
-    SourceFactors.sourceV_independentTensorProduct_apply
+    SourceFactors.sourceV_independentTensorProductOfIdentityWeight_apply
       (rightShiftSourceFactors d) (leftShiftSourceFactors d) i k j l
       (rightShiftRightRankEquiv d (b, a)) (leftShiftRightRankEquiv d 0)
       (rightShiftLeftRankEquiv d 0) (leftShiftLeftRankEquiv d (e, c))
@@ -699,7 +727,7 @@ private theorem shiftExampleU₁_sourceU_product_apply (d : ℕ)
         SourceFactors.sourceU (identityMPUTensor d) (identitySourceFactors d)
           (identityLeftRankEquiv d e, identityRightRankEquiv d b) (j, l) := by
   simpa only [shiftExampleU₁, shiftExampleU₁SourceFactors] using
-    SourceFactors.sourceU_independentTensorProduct_apply
+    SourceFactors.sourceU_independentTensorProductOfIdentityWeight_apply
       (identitySourceFactors d) (identitySourceFactors d)
       (identityLeftRankEquiv d c) (identityLeftRankEquiv d e)
       (identityRightRankEquiv d a) (identityRightRankEquiv d b) i k j l
@@ -747,7 +775,7 @@ private theorem shiftExampleU₁_sourceV_product_apply (d : ℕ)
         SourceFactors.sourceV (identityMPUTensor d) (identitySourceFactors d)
           (j, l) (identityRightRankEquiv d b, identityLeftRankEquiv d e) := by
   simpa only [shiftExampleU₁, shiftExampleU₁SourceFactors] using
-    SourceFactors.sourceV_independentTensorProduct_apply
+    SourceFactors.sourceV_independentTensorProductOfIdentityWeight_apply
       (identitySourceFactors d) (identitySourceFactors d) i k j l
       (identityRightRankEquiv d a) (identityRightRankEquiv d b)
       (identityLeftRankEquiv d c) (identityLeftRankEquiv d e)

--- a/TNLean/MPS/MPU/SourceFactorsTensorProduct.lean
+++ b/TNLean/MPS/MPU/SourceFactorsTensorProduct.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceUV
+import TNLean.MPS.MPU.TensorProduct
+
+/-!
+# Source factors of independent tensor products
+
+This module constructs supplied source factors for an independent tensor
+product from supplied identity-weight factors for its two constituents.  The
+source ranks and the entries of the paper's tensors $u$ and $v$ are
+multiplicative in the corresponding product-rank coordinates.
+
+This is formalization infrastructure for the tensoring clause of Theorem
+`IndexTh` (ii), which arXiv:1703.09188 calls trivial in lines 824--847; the
+paper does not print these explicit supplied factors.
+-/
+
+open scoped Matrix Kronecker BigOperators
+
+namespace MPOTensor
+
+/-- Product source coordinates, followed by the multiplicative right-rank
+identification for an independent tensor product.
+
+Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
+(ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
+noncomputable def tensorProductRightRankEquiv
+    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
+    Fin r[U] × Fin r[V] ≃ Fin r[tensorProduct U V] :=
+  finProdFinEquiv.trans (finCongr (rightRank_tensorProduct U V).symm)
+
+/-- Product source coordinates, followed by the multiplicative left-rank
+identification for an independent tensor product.
+
+Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
+(ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
+noncomputable def tensorProductLeftRankEquiv
+    {d D e E : ℕ} (U : MPOTensor d D) (V : MPOTensor e E) :
+    Fin ℓ[U] × Fin ℓ[V] ≃ Fin ℓ[tensorProduct U V] :=
+  finProdFinEquiv.trans (finCongr (leftRank_tensorProduct U V).symm)
+
+private theorem tensorProductCutShuffle_symm_apply
+    (a b c f : ℕ) (x : Fin a × Fin b) (y : Fin c × Fin f) :
+    (tensorProductCutShuffle a b c f).symm
+        (finProdFinEquiv (x.1, y.1), finProdFinEquiv (x.2, y.2)) = (x, y) :=
+  (tensorProductCutShuffle a b c f).symm_apply_apply (x, y)
+
+/-- Supplied source factors are multiplicative under the independent tensor
+product when both source weights are identities.
+
+Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
+(ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
+noncomputable def SourceFactors.independentTensorProduct
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ)) :
+    SourceFactors (tensorProduct U V)
+      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) := by
+  let eRow := tensorProductCutShuffle D d E e
+  let eCol := tensorProductCutShuffle d D e E
+  let eR := tensorProductRightRankEquiv U V
+  let eL := tensorProductLeftRankEquiv U V
+  let X₁ := Matrix.reindex eRow eR (S.X₁ ⊗ₖ T.X₁)
+  let Y₁ := Matrix.reindex eR eCol (S.Y₁ ⊗ₖ T.Y₁)
+  let Z₁ := Matrix.reindex eCol eR (S.Z₁ ⊗ₖ T.Z₁)
+  let X₂ := Matrix.reindex eRow eL (S.X₂ ⊗ₖ T.X₂)
+  let Y₂ := Matrix.reindex eL eCol (S.Y₂ ⊗ₖ T.Y₂)
+  let Z₂ := Matrix.reindex eCol eL (S.Z₂ ⊗ₖ T.Z₂)
+  have hSX₁ : S.X₁.IsIsometry := by
+    have h := S.X₁_weighted_isometry
+    rw [show sourceWeight (d := d) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 by
+      simp [sourceWeight]] at h
+    simpa [Matrix.IsIsometry] using h
+  have hTX₁ : T.X₁.IsIsometry := by
+    have h := T.X₁_weighted_isometry
+    rw [show sourceWeight (d := e) (1 : Matrix (Fin E) (Fin E) ℂ) = 1 by
+      simp [sourceWeight]] at h
+    simpa [Matrix.IsIsometry] using h
+  have hKX₁ : (S.X₁ ⊗ₖ T.X₁).IsIsometry := by
+    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul]
+    change (S.X₁ᴴ * S.X₁) ⊗ₖ (T.X₁ᴴ * T.X₁) = 1
+    rw [show S.X₁ᴴ * S.X₁ = 1 by exact hSX₁,
+      show T.X₁ᴴ * T.X₁ = 1 by exact hTX₁]
+    simp
+  have hKX₂ : (S.X₂ ⊗ₖ T.X₂).IsIsometry := by
+    rw [Matrix.IsIsometry, Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul]
+    change (S.X₂ᴴ * S.X₂) ⊗ₖ (T.X₂ᴴ * T.X₂) = 1
+    rw [show S.X₂ᴴ * S.X₂ = 1 by exact S.X₂_isometry,
+      show T.X₂ᴴ * T.X₂ = 1 by exact T.X₂_isometry]
+    simp
+  have hX₁ : X₁.IsIsometry :=
+    Matrix.IsIsometry.reindex _ hKX₁ eRow eR
+  have hX₂ : X₂.IsIsometry :=
+    Matrix.IsIsometry.reindex _ hKX₂ eRow eL
+  have hcut₁ : sourceCutM₁ (tensorProduct U V) = X₁ * Y₁ := by
+    rw [sourceCutM₁_tensorProduct, S.sourceCutM₁_eq, T.sourceCutM₁_eq]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
+        ((S.X₁ * S.Y₁) ⊗ₖ (T.X₁ * T.Y₁)) =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow eR (S.X₁ ⊗ₖ T.X₁) *
+        Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eR eCol,
+      Matrix.mul_kronecker_mul]
+  have hcut₂ : sourceCutM₂ (tensorProduct U V) = X₂ * Y₂ := by
+    rw [sourceCutM₂_tensorProduct, S.sourceCutM₂_eq, T.sourceCutM₂_eq]
+    change Matrix.reindexLinearEquiv ℂ ℂ eRow eCol
+        ((S.X₂ * S.Y₂) ⊗ₖ (T.X₂ * T.Y₂)) =
+      Matrix.reindexLinearEquiv ℂ ℂ eRow eL (S.X₂ ⊗ₖ T.X₂) *
+        Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eRow eL eCol,
+      Matrix.mul_kronecker_mul]
+  have hweighted : X₁ᴴ * sourceWeight (d := d * e)
+      (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) * X₁ = 1 := by
+    rw [show sourceWeight (d := d * e)
+        (1 : Matrix (Fin (D * E)) (Fin (D * E)) ℂ) = 1 by
+      simp [sourceWeight]]
+    simpa [Matrix.IsIsometry] using hX₁
+  have hY₁Z₁ : Y₁ * Z₁ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eR eCol (S.Y₁ ⊗ₖ T.Y₁) *
+      Matrix.reindexLinearEquiv ℂ ℂ eCol eR (S.Z₁ ⊗ₖ T.Z₁) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eR eCol eR,
+      ← Matrix.mul_kronecker_mul, S.Y₁_mul_Z₁, T.Y₁_mul_Z₁]
+    simp
+  have hY₂Z₂ : Y₂ * Z₂ = 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eL eCol (S.Y₂ ⊗ₖ T.Y₂) *
+      Matrix.reindexLinearEquiv ℂ ℂ eCol eL (S.Z₂ ⊗ₖ T.Z₂) = 1
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ eL eCol eL,
+      ← Matrix.mul_kronecker_mul, S.Y₂_mul_Z₂, T.Y₂_mul_Z₂]
+    simp
+  exact ⟨X₁, Y₁, Z₁, X₂, Y₂, Z₂, hcut₁, hcut₂,
+    hweighted, hX₂, hY₁Z₁, hY₂Z₂⟩
+
+/-- The supplied source $u$ of an independent tensor product is the product
+of the two constituent source entries in the product rank coordinates.
+
+Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
+(ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
+theorem SourceFactors.sourceU_independentTensorProduct_apply
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
+    (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) (rᵤ : Fin r[U]) (rᵥ : Fin r[V])
+    (i₁ i₂ : Fin d) (j₁ j₂ : Fin e) :
+    SourceFactors.sourceU (tensorProduct U V)
+        (SourceFactors.independentTensorProduct S T)
+        (tensorProductLeftRankEquiv U V (lᵤ, lᵥ),
+          tensorProductRightRankEquiv U V (rᵤ, rᵥ))
+        (finProdFinEquiv (i₁, j₁), finProdFinEquiv (i₂, j₂)) =
+      SourceFactors.sourceU U S (lᵤ, rᵤ) (i₁, i₂) *
+        SourceFactors.sourceU V T (lᵥ, rᵥ) (j₁, j₂) := by
+  simp only [SourceFactors.sourceU, SourceFactors.independentTensorProduct]
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro β _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [tensorProductCutShuffle_symm_apply d D e E (i₁, β) (j₁, γ),
+    tensorProductCutShuffle_symm_apply D d E e (β, i₂) (γ, j₂)]
+  ring
+
+/-- The supplied source $v$ of an independent tensor product is the product
+of the two constituent source entries in the product rank coordinates.
+
+Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
+(ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
+theorem SourceFactors.sourceV_independentTensorProduct_apply
+    {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
+    (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
+    (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
+    (j₁ j₂ : Fin d) (k₁ k₂ : Fin e)
+    (rᵤ : Fin r[U]) (rᵥ : Fin r[V]) (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) :
+    SourceFactors.sourceV (tensorProduct U V)
+        (SourceFactors.independentTensorProduct S T)
+        (finProdFinEquiv (j₁, k₁), finProdFinEquiv (j₂, k₂))
+        (tensorProductRightRankEquiv U V (rᵤ, rᵥ),
+          tensorProductLeftRankEquiv U V (lᵤ, lᵥ)) =
+      SourceFactors.sourceV U S (j₁, j₂) (rᵤ, lᵤ) *
+        SourceFactors.sourceV V T (k₁, k₂) (rᵥ, lᵥ) := by
+  simp only [SourceFactors.sourceV, SourceFactors.independentTensorProduct]
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [tensorProductCutShuffle_symm_apply D d E e (α, j₁) (γ, k₁),
+    tensorProductCutShuffle_symm_apply d D e E (j₂, α) (k₂, γ)]
+  ring
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceFactorsTensorProduct.lean
+++ b/TNLean/MPS/MPU/SourceFactorsTensorProduct.lean
@@ -14,6 +14,11 @@ product from supplied identity-weight factors for its two constituents.  The
 source ranks and the entries of the paper's tensors $u$ and $v$ are
 multiplicative in the corresponding product-rank coordinates.
 
+The identity-weight restriction is explicit in the declaration names below.
+An arbitrary-weight construction would additionally require a source-weight
+shuffle relating the reindexed virtual Kronecker weight to the two constituent
+source weights; that construction is not used for the shift formulas.
+
 This is formalization infrastructure for the tensoring clause of Theorem
 `IndexTh` (ii), which arXiv:1703.09188 calls trivial in lines 824--847; the
 paper does not print these explicit supplied factors.
@@ -54,7 +59,7 @@ product when both source weights are identities.
 
 Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
 (ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
-noncomputable def SourceFactors.independentTensorProduct
+noncomputable def SourceFactors.independentTensorProductOfIdentityWeight
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ)) :
@@ -140,20 +145,21 @@ of the two constituent source entries in the product rank coordinates.
 
 Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
 (ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
-theorem SourceFactors.sourceU_independentTensorProduct_apply
+theorem SourceFactors.sourceU_independentTensorProductOfIdentityWeight_apply
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
     (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) (rᵤ : Fin r[U]) (rᵥ : Fin r[V])
     (i₁ i₂ : Fin d) (j₁ j₂ : Fin e) :
     SourceFactors.sourceU (tensorProduct U V)
-        (SourceFactors.independentTensorProduct S T)
+        (SourceFactors.independentTensorProductOfIdentityWeight S T)
         (tensorProductLeftRankEquiv U V (lᵤ, lᵥ),
           tensorProductRightRankEquiv U V (rᵤ, rᵥ))
         (finProdFinEquiv (i₁, j₁), finProdFinEquiv (i₂, j₂)) =
       SourceFactors.sourceU U S (lᵤ, rᵤ) (i₁, i₂) *
         SourceFactors.sourceU V T (lᵥ, rᵥ) (j₁, j₂) := by
-  simp only [SourceFactors.sourceU, SourceFactors.independentTensorProduct]
+  simp only [SourceFactors.sourceU,
+    SourceFactors.independentTensorProductOfIdentityWeight]
   rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
   simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]
@@ -172,20 +178,21 @@ of the two constituent source entries in the product rank coordinates.
 
 Formalization infrastructure for the tensoring clause of Theorem `IndexTh`
 (ii), which arXiv:1703.09188 calls trivial in lines 824--847. -/
-theorem SourceFactors.sourceV_independentTensorProduct_apply
+theorem SourceFactors.sourceV_independentTensorProductOfIdentityWeight_apply
     {d D e E : ℕ} {U : MPOTensor d D} {V : MPOTensor e E}
     (S : SourceFactors U (1 : Matrix (Fin D) (Fin D) ℂ))
     (T : SourceFactors V (1 : Matrix (Fin E) (Fin E) ℂ))
     (j₁ j₂ : Fin d) (k₁ k₂ : Fin e)
     (rᵤ : Fin r[U]) (rᵥ : Fin r[V]) (lᵤ : Fin ℓ[U]) (lᵥ : Fin ℓ[V]) :
     SourceFactors.sourceV (tensorProduct U V)
-        (SourceFactors.independentTensorProduct S T)
+        (SourceFactors.independentTensorProductOfIdentityWeight S T)
         (finProdFinEquiv (j₁, k₁), finProdFinEquiv (j₂, k₂))
         (tensorProductRightRankEquiv U V (rᵤ, rᵥ),
           tensorProductLeftRankEquiv U V (lᵤ, lᵥ)) =
       SourceFactors.sourceV U S (j₁, j₂) (rᵤ, lᵤ) *
         SourceFactors.sourceV V T (k₁, k₂) (rᵥ, lᵥ) := by
-  simp only [SourceFactors.sourceV, SourceFactors.independentTensorProduct]
+  simp only [SourceFactors.sourceV,
+    SourceFactors.independentTensorProductOfIdentityWeight]
   rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
   simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
     Matrix.kroneckerMap_apply, Equiv.symm_apply_apply]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7635,6 +7635,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         u_3 & =\mathbb S,      & v_3 & =\mathbb S.
     \end{align}
     These are the formulas in \cite[equation~\texttt{eq:SF\_u1\_u3}]{Cirac2017MPU}.
+    The $U_3$ equalities use the source-coordinate presentation of that
+    equation; they are distinct from the blocked four-spin presentation below.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -7646,55 +7648,95 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     swap $\mathbb S$ in both orientations.
 \end{proof}
 
-\begin{theorem}[Two-site supplied source tensors for $U_2$]
+\begin{theorem}[Central gates in the supplied two-site factorizations of $U_2$]
     \label{thm:threeMPU_U2_supplied_source_uv_two}
-    \lean{MPOTensor.shiftExampleU₂_sourceU_two_eq_identitySwapIdentity,
-        MPOTensor.shiftExampleU₂_sourceV_two_eq_swapSwap_mul_identitySwapIdentity}
+    \lean{MPOTensor.shiftExampleU₂_blockTwo_apply_eq_sum_X₁_mul_u₂_two_mul_Y₂,
+        MPOTensor.shiftExampleU₂_blockTwo_apply_eq_sum_X₂_mul_v₂_two_reflected_mul_Y₁}
     \leanok
-    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
-    After blocking two sites and retaining the paper's four-spin order,
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv,
+        thm:mpu_source_u_open_two_site, thm:mpu_source_v_open_two_site}
+    The two open-leg factorizations of the blocked tensor have, as their
+    respective central gates,
     \begin{align}
         u_2^{(2)} & =\Id\otimes\mathbb S\otimes\Id, \\
         v_2^{(2)} & =(\mathbb S\otimes\mathbb S)
             (\Id\otimes\mathbb S\otimes\Id).
     \end{align}
+    Here the two physical sites are decoded into the four-spin order of the
+    paper, and the factors $X_1,Y_2$ and $X_2,Y_1$ remain as the two open
+    boundaries of the respective factorizations.
     This is \cite[equation~\texttt{eq:uv2\_U2}]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:threeMPU_supplied_source_factors,
-        def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
-    Expand the two supplied source contractions in product-rank coordinates.
-    Each normalized identity-vector contraction contributes one Kronecker
-    delta, and the scalar normalizations cancel.  Reindexing the four remaining
-    spin coordinates gives $\Id\otimes\mathbb S\otimes\Id$ for $u_2^{(2)}$.
-    The reflected contraction first exchanges the two pairs and then exchanges
-    the middle spins, giving the displayed ordered product for $v_2^{(2)}$.
+        def:mpu_source_uv, thm:mpu_source_u_open_two_site,
+        thm:mpu_source_v_open_two_site}
+    Write $B_2=\mathcal U_{2,2}$ for the actual two-site block and decode
+    $I=(I_1,I_2)$ and $J=(J_1,J_2)$.  If $\pi$ is the four-spin physical
+    identification and $\iota_u,\iota_v$ are the two source-rank
+    identifications, the asserted open-leg equalities are
+    \begin{align}
+        (B_2)_{I,J;\alpha,\gamma}
+        & =\sum_{r,l}(X_1)_{(\alpha,J_1),r}
+        [\Id\otimes\mathbb S\otimes\Id]_
+            {\iota_u^{-1}(l,r),\pi^{-1}(I_1,I_2)}
+        (Y_2)_{l,(J_2,\gamma)}, \\
+        (B_2)_{I,J;\alpha,\gamma}
+        & =\sum_{l,r}(X_2)_{(\alpha,I_1),l}
+        [(\mathbb S\otimes\mathbb S)
+            (\Id\otimes\mathbb S\otimes\Id)]_
+            {\pi^{-1}(J_2,J_1),\iota_v^{-1}(r,l)}
+        (Y_1)_{r,(I_2,\gamma)}.
+    \end{align}
+    These follow from the two exact open two-site factorizations.  Evaluating
+    the supplied sources in product-rank coordinates reduces their normalized
+    identity-vector contractions to the two displayed matrices.
 \end{proof}
 
-\begin{theorem}[Two-site supplied source tensors for $U_3$]
+\begin{theorem}[Central gates in the supplied two-site factorizations of $U_3$]
     \label{thm:threeMPU_U3_supplied_source_uv_two}
-    \lean{MPOTensor.shiftExampleU₃_sourceU_two_eq_identitySwapIdentity_mul_swapSwap,
-        MPOTensor.shiftExampleU₃_sourceV_two_eq_identitySwapIdentity}
+    \lean{MPOTensor.shiftExampleU₃_blockTwo_apply_eq_sum_X₁_mul_u₃_two_mul_Y₂,
+        MPOTensor.shiftExampleU₃_blockTwo_apply_eq_sum_X₂_mul_v₃_two_reflected_mul_Y₁}
     \leanok
-    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
-    After blocking two sites and retaining the paper's four-spin order,
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv,
+        thm:mpu_source_u_open_two_site, thm:mpu_source_v_open_two_site}
+    The two open-leg factorizations of the blocked tensor have, as their
+    respective central gates,
     \begin{align}
         u_3^{(2)} & =(\Id\otimes\mathbb S\otimes\Id)
             (\mathbb S\otimes\mathbb S), \\
         v_3^{(2)} & =\Id\otimes\mathbb S\otimes\Id.
     \end{align}
+    Again the four-spin order is the one displayed in the paper, and the
+    source factors at the two open boundaries are retained explicitly.
     This is \cite[equation~\texttt{eq:uv2\_U3}]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:threeMPU_supplied_source_factors,
-        def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
-    Reverse the order of the left-shift and right-shift supplied factors in the
-    preceding calculation.  The unreflected contraction therefore exchanges
-    the middle spins before exchanging the two pairs, while the reflected
-    contraction only exchanges the middle spins.  This gives the two displayed
-    matrices in their stated order.
+        def:mpu_source_uv, thm:mpu_source_u_open_two_site,
+        thm:mpu_source_v_open_two_site}
+    With $B_3=\mathcal U_{3,2}$ for the actual two-site block and the
+    corresponding identifications $\pi,\iota_u,\iota_v$, the exact equalities
+    are
+    \begin{align}
+        (B_3)_{I,J;\alpha,\gamma}
+        & =\sum_{r,l}(X_1)_{(\alpha,J_1),r}
+        [(\Id\otimes\mathbb S\otimes\Id)
+            (\mathbb S\otimes\mathbb S)]_
+            {\iota_u^{-1}(l,r),\pi^{-1}(I_1,I_2)}
+        (Y_2)_{l,(J_2,\gamma)}, \\
+        (B_3)_{I,J;\alpha,\gamma}
+        & =\sum_{l,r}(X_2)_{(\alpha,I_1),l}
+        [\Id\otimes\mathbb S\otimes\Id]_
+            {\pi^{-1}(J_2,J_1),\iota_v^{-1}(r,l)}
+        (Y_1)_{r,(I_2,\gamma)}.
+    \end{align}
+    They follow by reversing the order of the left-shift and right-shift
+    supplied factors in the preceding calculation.  The first contraction
+    exchanges the middle spins before exchanging the two pairs, whereas the
+    reflected contraction only exchanges the middle spins.
 \end{proof}
 
 \begin{proposition}[Standard forms of the three shift MPUs]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7602,12 +7602,110 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     unitarity, so all three tensors are matrix product unitaries.
 \end{proof}
 
+\begin{definition}[Supplied source factors for the three shift MPUs]
+    \label{def:threeMPU_supplied_source_factors}
+    \lean{MPOTensor.identitySourceFactors,
+        MPOTensor.rightShiftSourceFactors,
+        MPOTensor.leftShiftSourceFactors,
+        MPOTensor.SourceFactors.independentTensorProduct,
+        MPOTensor.shiftExampleU₁SourceFactors,
+        MPOTensor.shiftExampleU₂SourceFactors,
+        MPOTensor.shiftExampleU₃SourceFactors}
+    \leanok
+    \uses{threeMPU, def:mpu_weighted_source_factors,
+        thm:mpu_shift_source_cuts_ranks}
+    Equip $U_1$ with the tensor product of the two bond-one identity source
+    factorizations.  Equip $U_2$ with the tensor product of the left-shift and
+    right-shift source factorizations, in that order, and equip $U_3$ with the
+    tensor product in the reverse order.  In all three cases the virtual weight
+    is the identity.  These are explicit supplied source-factor witnesses; no
+    identification with an arbitrary compact singular-value decomposition is
+    asserted.
+\end{definition}
+
+\begin{theorem}[One-site supplied source tensors for $U_1$ and $U_3$]
+    \label{thm:threeMPU_supplied_source_uv_one}
+    \lean{MPOTensor.shiftExampleU₁_sourceUV_eq_identityTensorIdentity,
+        MPOTensor.shiftExampleU₃_sourceUV_eq_swap}
+    \leanok
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
+    In the source coordinates of the supplied factorizations,
+    \begin{align}
+        u_1 & =\Id\otimes\Id, & v_1 & =\Id\otimes\Id, \\
+        u_3 & =\mathbb S,      & v_3 & =\mathbb S.
+    \end{align}
+    These are the formulas in \cite[equation~\texttt{eq:SF\_u1\_u3}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:threeMPU_supplied_source_factors,
+        def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
+    For the identity tensor, both source contractions are products of two
+    Kronecker deltas.  For $U_3$, the right-shift and left-shift contractions
+    interchange the two composite indices.  Thus their tensor product is the
+    swap $\mathbb S$ in both orientations.
+\end{proof}
+
+\begin{theorem}[Two-site supplied source tensors for $U_2$]
+    \label{thm:threeMPU_U2_supplied_source_uv_two}
+    \lean{MPOTensor.shiftExampleU₂_sourceU_two_eq_identitySwapIdentity,
+        MPOTensor.shiftExampleU₂_sourceV_two_eq_swapSwap_mul_identitySwapIdentity}
+    \leanok
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
+    After blocking two sites and retaining the paper's four-spin order,
+    \begin{align}
+        u_2^{(2)} & =\Id\otimes\mathbb S\otimes\Id, \\
+        v_2^{(2)} & =(\mathbb S\otimes\mathbb S)
+            (\Id\otimes\mathbb S\otimes\Id).
+    \end{align}
+    This is \cite[equation~\texttt{eq:uv2\_U2}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:threeMPU_supplied_source_factors,
+        def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
+    Expand the two supplied source contractions in product-rank coordinates.
+    Each normalized identity-vector contraction contributes one Kronecker
+    delta, and the scalar normalizations cancel.  Reindexing the four remaining
+    spin coordinates gives $\Id\otimes\mathbb S\otimes\Id$ for $u_2^{(2)}$.
+    The reflected contraction first exchanges the two pairs and then exchanges
+    the middle spins, giving the displayed ordered product for $v_2^{(2)}$.
+\end{proof}
+
+\begin{theorem}[Two-site supplied source tensors for $U_3$]
+    \label{thm:threeMPU_U3_supplied_source_uv_two}
+    \lean{MPOTensor.shiftExampleU₃_sourceU_two_eq_identitySwapIdentity_mul_swapSwap,
+        MPOTensor.shiftExampleU₃_sourceV_two_eq_identitySwapIdentity}
+    \leanok
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
+    After blocking two sites and retaining the paper's four-spin order,
+    \begin{align}
+        u_3^{(2)} & =(\Id\otimes\mathbb S\otimes\Id)
+            (\mathbb S\otimes\mathbb S), \\
+        v_3^{(2)} & =\Id\otimes\mathbb S\otimes\Id.
+    \end{align}
+    This is \cite[equation~\texttt{eq:uv2\_U3}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:threeMPU_supplied_source_factors,
+        def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
+    Reverse the order of the left-shift and right-shift supplied factors in the
+    preceding calculation.  The unreflected contraction therefore exchanges
+    the middle spins before exchanging the two pairs, while the reflected
+    contraction only exchanges the middle spins.  This gives the two displayed
+    matrices in their stated order.
+\end{proof}
+
 \begin{proposition}[Standard forms of the three shift MPUs]
     \label{prop:threeMPU_standard_forms}
     \notready
     \discussion{5715}
-    \uses{threeMPU}
-    Their standard-form unitaries satisfy
+    \uses{threeMPU, thm:threeMPU_supplied_source_uv_one,
+        thm:threeMPU_U2_supplied_source_uv_two,
+        thm:threeMPU_U3_supplied_source_uv_two}
+    For the fixed standard-form source factors, the corresponding unitaries
+    satisfy
     \begin{align}
         u_1                          & =\Id\otimes\Id,                  & v_1 & =\Id\otimes\Id, \\
         u_3                          & =\mathbb S,                      & v_3 & =\mathbb S,     \\
@@ -7618,6 +7716,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         (\mathbb S\otimes\mathbb S), &
         v_3^{(2)}                    & =\Id\otimes\mathbb S\otimes\Id.
     \end{align}
+    The preceding theorems establish these matrices for explicit supplied
+    source-factor witnesses.  It remains to identify that supplied choice with
+    the fixed standard-form choice.
     % Source lines: paper_v2.tex 2002--2042.
 \end{proposition}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7634,7 +7634,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         u_1 & =\Id\otimes\Id, & v_1 & =\Id\otimes\Id, \\
         u_3 & =\mathbb S,      & v_3 & =\mathbb S.
     \end{align}
-    These are the formulas in \cite[equation~\texttt{eq:SF\_u1\_u3}]{Cirac2017MPU}.
+    These are the formulas in \cite[lines~2009--2016]{Cirac2017MPU}.
     The $U_3$ equalities use the source-coordinate presentation of that
     equation; they are distinct from the blocked four-spin presentation below.
 \end{theorem}
@@ -7665,7 +7665,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Here the two physical sites are decoded into the four-spin order of the
     paper, and the factors $X_1,Y_2$ and $X_2,Y_1$ remain as the two open
     boundaries of the respective factorizations.
-    This is \cite[equation~\texttt{eq:uv2\_U2}]{Cirac2017MPU}.
+    This is \cite[lines~2018--2026]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -7710,7 +7710,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Again the four-spin order is the one displayed in the paper, and the
     source factors at the two open boundaries are retained explicitly.
-    This is \cite[equation~\texttt{eq:uv2\_U3}]{Cirac2017MPU}.
+    This is \cite[lines~2028--2034]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7607,7 +7607,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.identitySourceFactors,
         MPOTensor.rightShiftSourceFactors,
         MPOTensor.leftShiftSourceFactors,
-        MPOTensor.SourceFactors.independentTensorProduct,
+        MPOTensor.SourceFactors.independentTensorProductOfIdentityWeight,
         MPOTensor.shiftExampleU₁SourceFactors,
         MPOTensor.shiftExampleU₂SourceFactors,
         MPOTensor.shiftExampleU₃SourceFactors}
@@ -7708,9 +7708,23 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
             {\pi^{-1}(J_2,J_1),\iota_v^{-1}(r,l)}
         (Y_1)_{r,(I_2,\gamma)}.
     \end{align}
-    These follow from the two exact open two-site factorizations.  Evaluating
-    the supplied sources in product-rank coordinates reduces their normalized
-    identity-vector contractions to the two displayed matrices.
+    Write $s=d^{-1/2}$, so that $d\,s^2=1$.  In the product-rank coordinates,
+    the entries of the two central gates are
+    \begin{align}
+        [u_2^{(2)}]_{((a,b),(c,e)),((i,j),(k,l))}
+         & =(d\,s\delta_{a,i}\delta_{b,k})
+            (s\delta_{c,j}\delta_{e,l}) \\
+         & =\delta_{a,i}\delta_{b,k}\delta_{c,j}\delta_{e,l}, \\
+        [v_2^{(2)}]_{((i,j),(k,l)),((a,b),(c,e))}
+         & =(s\delta_{e,k}\delta_{c,i})
+            (d\,s\delta_{b,l}\delta_{a,j}) \\
+         & =\delta_{a,j}\delta_{b,l}\delta_{c,i}\delta_{e,k}.
+    \end{align}
+    These are respectively the entries of
+    $\Id\otimes\mathbb S\otimes\Id$ and
+    $(\mathbb S\otimes\mathbb S)(\Id\otimes\mathbb S\otimes\Id)$;
+    substituting them into the exact open two-site factorizations gives the
+    asserted equalities.
 \end{proof}
 
 \begin{theorem}[Central gates in the supplied two-site factorizations of $U_3$]
@@ -7752,10 +7766,23 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
             {\pi^{-1}(J_2,J_1),\iota_v^{-1}(r,l)}
         (Y_1)_{r,(I_2,\gamma)}.
     \end{align}
-    They follow by reversing the order of the left-shift and right-shift
-    supplied factors in the preceding calculation.  The first contraction
-    exchanges the middle spins before exchanging the two pairs, whereas the
-    reflected contraction only exchanges the middle spins.
+    Again write $s=d^{-1/2}$, so that $d\,s^2=1$.  Reversing the two supplied
+    factors gives the entry identities
+    \begin{align}
+        [u_3^{(2)}]_{((a,b),(c,e)),((i,j),(k,l))}
+         & =(s\delta_{c,i}\delta_{e,k})
+            (d\,s\delta_{a,j}\delta_{b,l}) \\
+         & =\delta_{a,j}\delta_{b,l}\delta_{c,i}\delta_{e,k}, \\
+        [v_3^{(2)}]_{((i,j),(k,l)),((a,b),(c,e))}
+         & =(d\,s\delta_{b,k}\delta_{a,i})
+            (s\delta_{e,l}\delta_{c,j}) \\
+         & =\delta_{a,i}\delta_{b,k}\delta_{c,j}\delta_{e,l}.
+    \end{align}
+    The first is the entry of
+    $(\Id\otimes\mathbb S\otimes\Id)(\mathbb S\otimes\mathbb S)$,
+    and the second is the entry of $\Id\otimes\mathbb S\otimes\Id$.
+    Substitution into the two exact open two-site factorizations proves the
+    claim.
 \end{proof}
 
 \begin{proposition}[Standard forms of the three shift MPUs]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7614,13 +7614,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     \uses{threeMPU, def:mpu_weighted_source_factors,
         thm:mpu_shift_source_cuts_ranks}
-    Equip $U_1$ with the tensor product of the two bond-one identity source
-    factorizations.  Equip $U_2$ with the tensor product of the left-shift and
-    right-shift source factorizations, in that order, and equip $U_3$ with the
-    tensor product in the reverse order.  In all three cases the virtual weight
-    is the identity.  These are explicit supplied source-factor witnesses; no
-    identification with an arbitrary compact singular-value decomposition is
-    asserted.
+    Assume $d>0$. Equip $U_1$ with the tensor product of the two bond-one
+    identity source factorizations.  Equip $U_2$ with the tensor product of the
+    left-shift and right-shift source factorizations, in that order, and equip
+    $U_3$ with the tensor product in the reverse order.  In all three cases the
+    virtual weight is the identity.  These are explicit supplied source-factor
+    witnesses; no identification with an arbitrary compact singular-value
+    decomposition is asserted.
 \end{definition}
 
 \begin{theorem}[One-site supplied source tensors for $U_1$ and $U_3$]
@@ -7629,7 +7629,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.shiftExampleU₃_sourceUV_eq_swap}
     \leanok
     \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
-    In the source coordinates of the supplied factorizations,
+    Assume $d>0$. In the source coordinates of the supplied factorizations,
     \begin{align}
         u_1 & =\Id\otimes\Id, & v_1 & =\Id\otimes\Id, \\
         u_3 & =\mathbb S,      & v_3 & =\mathbb S.
@@ -7655,8 +7655,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv,
         thm:mpu_source_u_open_two_site, thm:mpu_source_v_open_two_site}
-    The two open-leg factorizations of the blocked tensor have, as their
-    respective central gates,
+    Assume $d>0$. The two open-leg factorizations of the blocked tensor have,
+    as their respective central gates,
     \begin{align}
         u_2^{(2)} & =\Id\otimes\mathbb S\otimes\Id, \\
         v_2^{(2)} & =(\mathbb S\otimes\mathbb S)
@@ -7701,8 +7701,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv,
         thm:mpu_source_u_open_two_site, thm:mpu_source_v_open_two_site}
-    The two open-leg factorizations of the blocked tensor have, as their
-    respective central gates,
+    Assume $d>0$. The two open-leg factorizations of the blocked tensor have,
+    as their respective central gates,
     \begin{align}
         u_3^{(2)} & =(\Id\otimes\mathbb S\otimes\Id)
             (\mathbb S\otimes\mathbb S), \\
@@ -7746,8 +7746,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{threeMPU, thm:threeMPU_supplied_source_uv_one,
         thm:threeMPU_U2_supplied_source_uv_two,
         thm:threeMPU_U3_supplied_source_uv_two}
-    For the fixed standard-form source factors, the corresponding unitaries
-    satisfy
+    Assume $d>0$. For the fixed standard-form source factors, the corresponding
+    unitaries satisfy
     \begin{align}
         u_1                          & =\Id\otimes\Id,                  & v_1 & =\Id\otimes\Id, \\
         u_3                          & =\mathbb S,                      & v_3 & =\mathbb S,     \\

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7642,10 +7642,29 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{proof}\leanok
     \uses{def:threeMPU_supplied_source_factors,
         def:mpu_source_uv, thm:mpu_shift_source_cuts_ranks}
-    For the identity tensor, both source contractions are products of two
-    Kronecker deltas.  For $U_3$, the right-shift and left-shift contractions
-    interchange the two composite indices.  Thus their tensor product is the
-    swap $\mathbb S$ in both orientations.
+    Write the source and physical indices as
+    $((a,b),(c,e))$ and $((i,j),(k,l))$, respectively, and set
+    $s=d^{-1/2}$.  The identity factors give
+    \begin{align}
+        [u_1]_{((a,b),(c,e)),((i,j),(k,l))}
+         & =[v_1]_{((i,j),(k,l)),((a,b),(c,e))} \\
+         & =(\delta_{a,i}\delta_{c,k})(\delta_{b,j}\delta_{e,l}) \\
+         & =\delta_{a,i}\delta_{b,j}\delta_{c,k}\delta_{e,l}.
+    \end{align}
+    For $U_3$, the right-shift and left-shift factors instead give
+    \begin{align}
+        [u_3]_{((a,b),(c,e)),((i,j),(k,l))}
+         & =(s\delta_{c,i}\delta_{a,k})
+            (d\,s\delta_{e,j}\delta_{b,l}) \\
+         & =\delta_{a,k}\delta_{b,l}\delta_{c,i}\delta_{e,j}, \\
+        [v_3]_{((i,j),(k,l)),((a,b),(c,e))}
+         & =(d\,s\delta_{a,k}\delta_{c,i})
+            (s\delta_{b,l}\delta_{e,j}) \\
+         & =\delta_{a,k}\delta_{b,l}\delta_{c,i}\delta_{e,j},
+    \end{align}
+    where $d\,s^2=1$.  The first display is the identity matrix, while the
+    second interchanges the two composite indices and is therefore
+    $\mathbb S$ in both orientations.
 \end{proof}
 
 \begin{theorem}[Central gates in the supplied two-site factorizations of $U_2$]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1359,24 +1359,6 @@ current counts and full location lists).
   they encode the source-cut orientations and should not be inferred by a
   searching tactic.
 
-### tensor product of source factors at arbitrary weights — candidate
-- **Pattern:** the tensor product of two supplied source factors is
-  constructed only for identity source weights
-  (`SourceFactors.independentTensorProductOfIdentityWeight`), discharging each
-  weighted-isometry step through the simplification `sourceWeight 1 = 1`.
-- **Seen:** `TNLean/MPS/MPU/SourceFactorsTensorProduct.lean` (definition at
-  line 62 and the two entrywise `..._apply` theorems), from a PR review
-  suggestion, recorded 2026-08-24.
-- **Abstraction (proposed):** a source-weight shuffle
-  `sourceWeight (ρ ⊗ₖ σ) ≅ sourceWeight ρ ⊗ₖ sourceWeight σ` relating the
-  reindexed virtual Kronecker weight to the two constituent source weights,
-  so that an arbitrary-weight `SourceFactors.independentTensorProduct` becomes
-  available and the present identity-weight construction is its `ρ := 1`
-  corollary.
-- **Notes:** recorded only, not implemented; the shift formulas use only
-  identity weights, so no second call site exists yet.  Promotion waits for a
-  consumer with nontrivial source weights.
-
 ### factor pairing under a two-index finite sum — candidate
 - **Pattern:** before collapsing a two-index finite sum, use `simp_rw` with a
   pointwise identity proved by `ring` to pair corresponding scalar factors from

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1279,6 +1279,86 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### supplied source-gate indicator entries — candidate
+- **Pattern:** case-split the two or four physical-index equalities in an
+  explicit source-gate entry, simplify the resulting indicator functions and
+  primitive `sourceU`/`sourceV` entries, and cancel the factors
+  $d(\sqrt d)^{-1}(\sqrt d)^{-1}=1$ before closing the zero and nonzero cases.
+- **Seen:** 10 four-index occurrences in
+  `TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean` (representatively lines
+  76, 121, 479, 550, and 620) and six two-index primitive-entry occurrences in
+  `TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean` (lines 424--501), recorded
+  2026-08-24.
+- **Abstraction (proposed):** scout Mathlib's indicator and `ite` product
+  lemmas first; otherwise extract the common scalar-indicator calculation as
+  a lemma family, or mark its characterizing equalities for terminal `grind`
+  once the stable goal shape is clear.  Prefer either route to a tactic macro.
+- **Notes:** the four-index proofs differ in their paper-coordinate
+  permutations and in which factor carries $d(\sqrt d)^{-1}$, while the
+  primitive proofs have only two equality tests.  Promotion should preserve
+  those visible coordinate choices and remove only the repeated Boolean and
+  normalization calculation.
+
+### Kronecker product of matrix isometries — candidate
+- **Pattern:** prove that $A\otimes B$ is an isometry by expanding
+  `Matrix.IsIsometry`, rewriting `Matrix.conjTranspose_kronecker` and
+  `Matrix.mul_kronecker_mul`, and substituting the two constituent isometry
+  identities.
+- **Seen:** two new occurrences in
+  `TNLean/MPS/MPU/SourceFactorsTensorProduct.lean` (lines 88--101); the
+  private helpers `kronecker_isometry` in
+  `TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean` (lines 75--83) and
+  `kron_isometry` in `TNLean/MPS/MPDO/CPSVExample410Spectrum.lean`
+  (lines 156--161) prove exactly this statement, and hand-rolled instances
+  include `TNLean/MPS/MPDO/BNTRightTripleFusion.lean` (lines 137--144) and
+  `TNLean/MPS/MPDO/BNTLeftTripleFusion.lean` (line 139).  A 2026-08-24 grep
+  finds 47 `Matrix.conjTranspose_kronecker` and 96 `Matrix.mul_kronecker_mul`
+  occurrences across `TNLean/MPS/MPDO/*.lean`, well over the promotion
+  threshold.
+- **Abstraction (proposed):** scout Mathlib and QICLean for a suitably generic
+  `Matrix.IsIsometry.kronecker` theorem; if none exists, add that matrix lemma
+  at the lowest common algebra layer and replace all occurrences together.
+- **Notes:** the current proofs use square complex matrices, but the natural
+  statement is rectangular and should retain only the finite-index and
+  star-semiring hypotheses needed by `Matrix.IsIsometry`.  Do not promote a
+  source-factor-specific wrapper.
+
+### matrix-reindex entry wrappers — candidate
+- **Pattern:** transport an entry formula through `Matrix.reindex` in either
+  direction: use `ext; simpa only [Matrix.reindex_apply, ...]` to package a
+  pointwise formula as a reindexed matrix equality, or apply `congrFun` twice
+  and simplify the inverse equivalences to recover the original entry from
+  that equality.
+- **Seen:** four packaging proofs in
+  `TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean` (lines 491--716) and four
+  recovery proofs in
+  `TNLean/MPS/MPU/Examples/ShiftSourceBlockedFormulas.lean` (lines 23--159),
+  recorded 2026-08-24.
+- **Abstraction (proposed):** a pair of generic matrix lemmas connecting
+  `Matrix.reindex eRow eCol M = N` with the corresponding entry equality at
+  `eRow`/`eCol` coordinates; scout `Matrix.reindex_apply` and extensionality
+  helpers before adding project declarations.
+- **Notes:** this is coordinate transport, not a tensor-network argument.  A
+  promoted lemma should remove only the equivalence bookkeeping and leave the
+  source-specific four-spin order explicit at every call site.
+
+### multiplication of compatibly reindexed matrices — candidate
+- **Pattern:** expose two adjacent `Matrix.reindex` factors as
+  `Matrix.reindexLinearEquiv` applications, apply
+  `Matrix.reindexLinearEquiv_mul`, and simplify a reindexed identity matrix.
+- **Seen:** eight occurrences in
+  `TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean` (lines 272--408), plus
+  four more of the same multiplication step in
+  `TNLean/MPS/MPU/SourceFactorsTensorProduct.lean` (lines 112--137), recorded
+  2026-08-24.
+- **Abstraction (proposed):** a theorem stating directly that
+  `Matrix.reindex e₁ e₂ A * Matrix.reindex e₂ e₃ B` is
+  `Matrix.reindex e₁ e₃ (A * B)`, as a thin entrywise or linear-equivalence
+  wrapper around Mathlib's `Matrix.reindexLinearEquiv_mul`.
+- **Notes:** keep the three equivalences explicit in the theorem statement;
+  they encode the source-cut orientations and should not be inferred by a
+  searching tactic.
+
 ### factor pairing under a two-index finite sum — candidate
 - **Pattern:** before collapsing a two-index finite sum, use `simp_rw` with a
   pointwise identity proved by `ring` to pair corresponding scalar factors from

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1359,6 +1359,24 @@ current counts and full location lists).
   they encode the source-cut orientations and should not be inferred by a
   searching tactic.
 
+### tensor product of source factors at arbitrary weights — candidate
+- **Pattern:** the tensor product of two supplied source factors is
+  constructed only for identity source weights
+  (`SourceFactors.independentTensorProductOfIdentityWeight`), discharging each
+  weighted-isometry step through the simplification `sourceWeight 1 = 1`.
+- **Seen:** `TNLean/MPS/MPU/SourceFactorsTensorProduct.lean` (definition at
+  line 62 and the two entrywise `..._apply` theorems), from a PR review
+  suggestion, recorded 2026-08-24.
+- **Abstraction (proposed):** a source-weight shuffle
+  `sourceWeight (ρ ⊗ₖ σ) ≅ sourceWeight ρ ⊗ₖ sourceWeight σ` relating the
+  reindexed virtual Kronecker weight to the two constituent source weights,
+  so that an arbitrary-weight `SourceFactors.independentTensorProduct` becomes
+  available and the present identity-weight construction is its `ρ := 1`
+  corollary.
+- **Notes:** recorded only, not implemented; the shift formulas use only
+  identity weights, so no second call site exists yet.  Promotion waits for a
+  consumer with nontrivial source weights.
+
 ### factor pairing under a two-index finite sum — candidate
 - **Pattern:** before collapsing a two-index finite sum, use `simp_rw` with a
   pointwise identity proved by `ring` to pair corresponding scalar factors from


### PR DESCRIPTION
### Motivation

- Close the assigned leaf #7027 by formalizing the supplied source-factor calculations for the three shift MPUs in `Papers/1703.09188/paper_v2.tex`, lines 2009–2034, equations `eq:SF_u1_u3`, `eq:uv2_U2`, and `eq:uv2_U3`.
- The source says that for $U_2^{(N)}$ “we must block two sites,” so the formulas carrying the superscript $(2)$ must be tied to the actual two-site block and its open source legs, not merely to a one-site coordinate definition.

### Description

- Construct explicit `SourceFactors` witnesses for the bond-one identity, primitive right shift, and primitive left shift, proving every source-cut, weighted-isometry, isometry, and right-inverse field directly.
- Add a reusable core construction showing that supplied identity-weight source factors tensor independently. Its identity-weight restriction is explicit in the declaration names. The paper calls the tensoring clause of Theorem `IndexTh` (ii) trivial but does not print these normalized factors, so their declarations are documented as formalization infrastructure rather than quoted source identities.
- Use these witnesses for the three families $U_1,U_2,U_3$ and evaluate the paper's supplied source matrices in its factor order:
  - $u_1=v_1=\mathrm{Id}\otimes\mathrm{Id}$;
  - $u_3=v_3=\mathbb S$;
  - $u_2^{(2)}=\mathrm{Id}\otimes\mathbb S\otimes\mathrm{Id}$;
  - $v_2^{(2)}=(\mathbb S\otimes\mathbb S)(\mathrm{Id}\otimes\mathbb S\otimes\mathrm{Id})$;
  - $u_3^{(2)}=(\mathrm{Id}\otimes\mathbb S\otimes\mathrm{Id})(\mathbb S\otimes\mathbb S)$;
  - $v_3^{(2)}=\mathrm{Id}\otimes\mathbb S\otimes\mathrm{Id}$.
- Insert the four blocked formulas into the exact open-leg two-site factorizations, retaining the $X_1,Y_2$ and $X_2,Y_1$ boundaries. Thus every superscript $(2)$ refers to the actual two-site MPU block.
- Add source-cited Chapter 28 entries with the mathematical hypothesis $d>0$, matching Lean's `[NeZero d]`. The source-coordinate presentation $u_3=v_3=\mathbb S$ remains explicitly distinct from the blocked four-spin presentation.
- Display the normalized Kronecker-delta contractions for the $U_1$, $U_2$, and $U_3$ gates, including $d(d^{-1/2})^2=1$, in the paper's row and column order.
- Record the repeated indicator-entry, matrix-reindex, compatible-reindex multiplication, and Kronecker-isometry proof families in the tactic-pattern ledger. Reuse the existing square-root normalization lemmas instead of rederiving them.
- Leave `prop:threeMPU_standard_forms` not ready for the separate fixed-standard-form packaging issue #7028.

The public formulas match the cited equations, including both matrix-product orders. No result identifies the supplied witnesses with `Classical.choice` compact-SVD factors. The changed proof modules contain no `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`, or `Classical.choice`.

An exact type audit found that extending the tensor-product constructor to arbitrary source weights first requires a new source-weight shuffle relating the reindexed virtual Kronecker weight to the Kronecker product of the two constituent source weights. Cirac does not print that transport identity, #7027 does not use it, and the broader tensor-product infrastructure belongs to #7029; this PR therefore keeps the honest identity-weight specialization and does not open an ownerless follow-up.

### Testing

- Exact hot-main cache seeded from `b30623bb651aef65130a7feaab263bddc69106fb`.
- `lake build TNLean.MPS.MPU.SourceFactorsTensorProduct`
- `lake build TNLean.MPS.MPU.Examples.ShiftSourceFactors`
- `lake build TNLean.MPS.MPU.Examples.ShiftSourceFormulas`
- `lake build TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas`
- `lake build TNLean.MPS.MPU.Examples`
- `python3 scripts/generate_import_aggregators.py --check` (36 generated files, 1033 production modules)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- `latexindent -k -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch28_mpu.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex`
- Changed-module proof-integrity scan.
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` reports 6,786 unique Lean references, 6,795/6,795 theorem-like entries, and Chapter 28 at 800/800.
- Genuine `texra-blueprint web` passed with the pinned plugin, without fallback parsing, in a disposable Python 3.11.2 environment containing `texra-blueprint` 0.3.7 (tag commit `0181a0a824f9bdb54e9e20eb9820d37dfa7cd8c3`), `leanblueprint` 0.0.20, and plasTeX 3.1.

The repository's existing Python 3.9.6 user environment cannot install `texra-blueprint` 0.3.7 because that release requires Python 3.10 or newer. Its old pip first created an erroneous `UNKNOWN-0.0.0` artifact; that exact artifact was immediately uninstalled without changing unrelated packages. The disposable Python 3.11 environment above was used instead and removed after validation.

The strict local `leanblueprint checkdecls` invocation reached `lake exe checkdecls` but could not start because this targeted-cache worktree does not contain the aggregate root object `.lake/build/lib/lean/TNLean.olean`. No competing full aggregate build was started merely to create that artifact; hosted CI builds the root before running the strict checker.

### Agent assistance

- OpenAI Codex (GPT-5) produced the Lean definitions and proofs, the reusable tensor-product refactoring, the Blueprint prose, and the local validation under the human author's direction and source review.

---
Closes #7027
