### PR TITLE
feat(Algebra): prove skew-unitary dimension parity

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -45,6 +45,7 @@ import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.SICPOVMBound
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.ShiftedZeroTraceNilpotent
+import TNLean.Algebra.SkewSymmetricMatrix
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.SpinCover.EulerAngles
 import TNLean.Algebra.TracePairing

--- a/TNLean/Algebra/SkewSymmetricMatrix.lean
+++ b/TNLean/Algebra/SkewSymmetricMatrix.lean
@@ -3,21 +3,20 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Analysis.Complex.Basic
 import Mathlib.LinearAlgebra.UnitaryGroup
 
 /-!
 # Skew-symmetric matrices
 
-This file proves the parity obstruction for nonsingular complex skew-symmetric
-matrices. In particular, a complex skew-symmetric unitary matrix has even
-dimension.
+This file proves the parity obstruction for nonsingular skew-symmetric matrices
+over a commutative ring of characteristic zero without zero divisors. In particular,
+a skew-symmetric unitary matrix over such a star ring has even dimension.
 
 ## Main results
 
-* `Matrix.det_eq_zero_of_transpose_eq_neg_of_odd_card`: a complex skew-symmetric
-  matrix indexed by an odd-cardinality finite type has zero determinant.
-* `Matrix.even_card_of_transpose_eq_neg_of_det_ne_zero`: a nonsingular complex
+* `Matrix.det_eq_zero_of_transpose_eq_neg_of_odd_card`: a skew-symmetric matrix
+  indexed by an odd-cardinality finite type has zero determinant.
+* `Matrix.even_card_of_transpose_eq_neg_of_det_ne_zero`: a nonsingular
   skew-symmetric matrix has even cardinality.
 * `Matrix.UnitaryGroup.even_dimension_of_transpose_eq_neg`: a skew-symmetric
   unitary matrix on `Fin d` has even dimension.
@@ -29,40 +28,45 @@ dimension.
 
 namespace Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n R : Type*} [Fintype n] [DecidableEq n]
+  [CommRing R] [NoZeroDivisors R] [CharZero R]
 
-/-- A complex skew-symmetric matrix indexed by an odd-cardinality finite type has
-zero determinant.
+/-- A skew-symmetric matrix over a commutative ring of characteristic zero without
+zero divisors, indexed by an odd-cardinality finite type, has zero determinant.
 
-This is the determinant argument used in arXiv:1703.09188, Proposition `corconj`,
-lines 1098--1126: $\det A = \det A^{\mathsf T} = \det(-A) = (-1)^{|n|}\det A$. -/
-theorem det_eq_zero_of_transpose_eq_neg_of_odd_card {A : Matrix n n ℂ}
+The identity $\det A = \det A^{\mathsf T} = \det(-A) = (-1)^{|n|}\det A$ proves
+the parity assertion in arXiv:1703.09188, Proposition `corconj`, line 1125. -/
+theorem det_eq_zero_of_transpose_eq_neg_of_odd_card {A : Matrix n n R}
     (hA : Aᵀ = -A) (hodd : Odd (Fintype.card n)) : A.det = 0 := by
   apply CharZero.eq_neg_self_iff.mp
   calc
     A.det = Aᵀ.det := (Matrix.det_transpose A).symm
     _ = (-A).det := congrArg Matrix.det hA
-    _ = (-1 : ℂ) ^ Fintype.card n * A.det := Matrix.det_neg A
+    _ = (-1 : R) ^ Fintype.card n * A.det := Matrix.det_neg A
     _ = -A.det := by rw [hodd.neg_one_pow, neg_one_mul]
 
-/-- A complex skew-symmetric matrix with nonzero determinant is indexed by a finite
-type of even cardinality.
+/-- A skew-symmetric matrix over a commutative ring of characteristic zero without
+zero divisors and with nonzero determinant is indexed by a finite type of even
+cardinality.
 
-This is the nonsingular form of the parity obstruction in arXiv:1703.09188,
-Proposition `corconj`, lines 1098--1126. -/
-theorem even_card_of_transpose_eq_neg_of_det_ne_zero {A : Matrix n n ℂ}
+The determinant argument proves the parity assertion in arXiv:1703.09188,
+Proposition `corconj`, line 1125. -/
+theorem even_card_of_transpose_eq_neg_of_det_ne_zero {A : Matrix n n R}
     (hA : Aᵀ = -A) (hdet : A.det ≠ 0) : Even (Fintype.card n) := by
   rw [← Nat.not_odd_iff_even]
   exact fun hodd ↦ hdet (det_eq_zero_of_transpose_eq_neg_of_odd_card hA hodd)
 
 namespace UnitaryGroup
 
-/-- A complex skew-symmetric unitary matrix has even dimension.
+/-- A skew-symmetric unitary matrix over a commutative star ring of characteristic
+zero without zero divisors has even dimension.
 
-This is the parity obstruction stated at arXiv:1703.09188, Proposition `corconj`,
-line 1125: the skew-symmetric case can occur only in even dimensions. -/
-theorem even_dimension_of_transpose_eq_neg {d : ℕ} (U : Matrix.unitaryGroup (Fin d) ℂ)
-    (hU : (U : Matrix (Fin d) (Fin d) ℂ)ᵀ = -U) : Even d := by
+The determinant argument proves the parity assertion in arXiv:1703.09188,
+Proposition `corconj`, line 1125: the skew-symmetric case can occur only in even
+dimensions. -/
+theorem even_dimension_of_transpose_eq_neg {d : ℕ} [StarRing R]
+    (U : Matrix.unitaryGroup (Fin d) R)
+    (hU : (U : Matrix (Fin d) (Fin d) R)ᵀ = -U) : Even d := by
   simpa using even_card_of_transpose_eq_neg_of_det_ne_zero hU
     (Matrix.UnitaryGroup.det_isUnit U).ne_zero
 

--- a/TNLean/Algebra/SkewSymmetricMatrix.lean
+++ b/TNLean/Algebra/SkewSymmetricMatrix.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Skew-symmetric matrices
+
+This file proves the parity obstruction for nonsingular complex skew-symmetric
+matrices. In particular, a complex skew-symmetric unitary matrix has even
+dimension.
+
+## Main results
+
+* `Matrix.det_eq_zero_of_transpose_eq_neg_of_odd_card`: a complex skew-symmetric
+  matrix indexed by an odd-cardinality finite type has zero determinant.
+* `Matrix.even_card_of_transpose_eq_neg_of_det_ne_zero`: a nonsingular complex
+  skew-symmetric matrix has even cardinality.
+* `Matrix.UnitaryGroup.even_dimension_of_transpose_eq_neg`: a skew-symmetric
+  unitary matrix on `Fin d` has even dimension.
+
+## References
+
+* arXiv:1703.09188, Proposition `corconj`, lines 1098--1126, especially line 1125.
+-/
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A complex skew-symmetric matrix indexed by an odd-cardinality finite type has
+zero determinant.
+
+This is the determinant argument used in arXiv:1703.09188, Proposition `corconj`,
+lines 1098--1126: $\det A = \det A^{\mathsf T} = \det(-A) = (-1)^{|n|}\det A$. -/
+theorem det_eq_zero_of_transpose_eq_neg_of_odd_card {A : Matrix n n ℂ}
+    (hA : Aᵀ = -A) (hodd : Odd (Fintype.card n)) : A.det = 0 := by
+  apply CharZero.eq_neg_self_iff.mp
+  calc
+    A.det = Aᵀ.det := (Matrix.det_transpose A).symm
+    _ = (-A).det := congrArg Matrix.det hA
+    _ = (-1 : ℂ) ^ Fintype.card n * A.det := Matrix.det_neg A
+    _ = -A.det := by rw [hodd.neg_one_pow, neg_one_mul]
+
+/-- A complex skew-symmetric matrix with nonzero determinant is indexed by a finite
+type of even cardinality.
+
+This is the nonsingular form of the parity obstruction in arXiv:1703.09188,
+Proposition `corconj`, lines 1098--1126. -/
+theorem even_card_of_transpose_eq_neg_of_det_ne_zero {A : Matrix n n ℂ}
+    (hA : Aᵀ = -A) (hdet : A.det ≠ 0) : Even (Fintype.card n) := by
+  rw [← Nat.not_odd_iff_even]
+  exact fun hodd ↦ hdet (det_eq_zero_of_transpose_eq_neg_of_odd_card hA hodd)
+
+namespace UnitaryGroup
+
+/-- A complex skew-symmetric unitary matrix has even dimension.
+
+This is the parity obstruction stated at arXiv:1703.09188, Proposition `corconj`,
+line 1125: the skew-symmetric case can occur only in even dimensions. -/
+theorem even_dimension_of_transpose_eq_neg {d : ℕ} (U : Matrix.unitaryGroup (Fin d) ℂ)
+    (hU : (U : Matrix (Fin d) (Fin d) ℂ)ᵀ = -U) : Even d := by
+  simpa using even_card_of_transpose_eq_neg_of_det_ne_zero hU
+    (Matrix.UnitaryGroup.det_isUnit U).ne_zero
+
+end UnitaryGroup
+
+end Matrix

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6352,11 +6352,65 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1041--1084.
 \end{lemma}
 
+\begin{lemma}[Odd-dimensional skew-symmetric determinant]
+    \label{lem:mpu_skew_symmetric_det_zero}
+    \lean{Matrix.det_eq_zero_of_transpose_eq_neg_of_odd_card}
+    \leanok
+    Let $I$ be a finite set of odd cardinality and let
+    $A\in\operatorname{Mat}_I(\mathbb C)$ satisfy $A^T=-A$. Then
+    \begin{align}
+        \det A & =0.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Transpose invariance, skew symmetry, and the determinant of a negated
+    matrix give
+    \begin{align}
+        \det A
+         & =\det(A^T)
+          =\det(-A)
+          =(-1)^{|I|}\det A
+          =-\det A.
+    \end{align}
+    Since the complex numbers have characteristic zero, $\det A=0$.
+\end{proof}
+
+\begin{lemma}[Parity of a nonsingular skew-symmetric matrix]
+    \label{lem:mpu_skew_symmetric_even_card}
+    \lean{Matrix.even_card_of_transpose_eq_neg_of_det_ne_zero}
+    \leanok
+    Let $I$ be finite and let $A\in\operatorname{Mat}_I(\mathbb C)$ satisfy
+    $A^T=-A$ and $\det A\ne0$. Then $|I|$ is even.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_skew_symmetric_det_zero}
+    If $|I|$ were odd, Lemma~\ref{lem:mpu_skew_symmetric_det_zero} would give
+    $\det A=0$. Hence $|I|$ is not odd and is therefore even.
+\end{proof}
+
+\begin{theorem}[Even dimension of a skew-symmetric unitary]
+    \label{thm:mpu_skew_unitary_even_dimension}
+    \lean{Matrix.UnitaryGroup.even_dimension_of_transpose_eq_neg}
+    \leanok
+    Let $U\in\operatorname{Mat}_d(\mathbb C)$ be unitary and satisfy
+    $U^T=-U$. Then $d$ is even. This is the parity obstruction in
+    \cite[Proposition~V.2, Case~II]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 1098--1126, especially line 1125.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_skew_symmetric_even_card}
+    The determinant of a unitary matrix is a unit, so it is nonzero. Apply
+    Lemma~\ref{lem:mpu_skew_symmetric_even_card} to $U$.
+\end{proof}
+
 \begin{proposition}[Orthogonal and symplectic standard forms]
     \label{corconj}
     \notready
     \discussion{5713}
-    \uses{prop1conj, lemma:conjclass-normalform-continuous, FundamentalMPU}
+    \uses{prop1conj, lemma:conjclass-normalform-continuous, FundamentalMPU, thm:mpu_skew_unitary_even_dimension}
     Let an MPU in standard form be invariant under complex conjugation. Its
     standard-form unitaries can be chosen in exactly one of the following two
     cases. In Case I,


### PR DESCRIPTION
### Motivation

- Proposition `corconj` in arXiv:1703.09188 states that its skew-symmetric case can occur only when the left and right dimensions are even.
- Issue #7058 isolates the determinant obstruction used for that sentence, independently of MPU standard form and source-factor machinery.

### Description

- Add `Matrix.det_eq_zero_of_transpose_eq_neg_of_odd_card`: over a commutative characteristic-zero ring without zero divisors, an odd-cardinality skew-symmetric matrix has zero determinant.
- Add `Matrix.even_card_of_transpose_eq_neg_of_det_ne_zero`: nonzero determinant therefore forces even index cardinality.
- Add `Matrix.UnitaryGroup.even_dimension_of_transpose_eq_neg`: a skew-symmetric unitary matrix indexed by `Fin d` has even dimension.
- Register the module in the generated Algebra import surface.
- Add three source-cited Chapter 28 entries and make the still-unformalized `corconj` proposition depend on the parity leaf.

### Statement integrity

- For complex matrices, the generic determinant theorem specializes exactly to the source argument
  `det A = det Aᵀ = det (-A) = (-1)^n det A`.
- The unitary specialization derives determinant nonvanishing from Mathlib's unitary-group API. It adds no hypothesis beyond unitarity and `Uᵀ = -U`.
- This PR proves only the parity leaf. It does not claim the full orthogonal/symplectic standard-form proposition, whose Blueprint entry remains `\notready` under #5713.
- The declarations do not import or mention MPU standard form, source factors, the public index, blocking, or continuity.

### Testing

- Existing warm-cache full `lake build` completed on the rebased branch before the final ring-generalization follow-up.
- `git diff --check origin/main...HEAD`
- Proof-integrity scan of `TNLean/Algebra/SkewSymmetricMatrix.lean` found no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- The exact-head focused rerun was not duplicated while other branch workers were running Lean builds. Hosted CI remains the exact-head build and Blueprint declaration-resolution gate.

---

Closes #7058.
Contributes to #5713.

### Agent assistance

Codex audited the existing proof branch, source correspondence, Mathlib coverage, supersession, and publication state. LionSR remains accountable for review and merge.
