### PR TITLE
doc(MPS/MPDO): correct purification-RFP gap prose

### DIFF
--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -137,11 +137,11 @@ For MPDO renormalization fixed points:
   from injectivity and choosing positive representatives coherently across
   the sector graph remain open.
 - `cpsv16_purification_rfp_definition.tex` records the distinction between
-  the printed positive-length global PRFP predicate and the corrected local
-  purification condition. A nonzero MPDO with a trace-invisible nilpotent bond
-  sector formally refutes the printed global implication to literal
-  physical-trace idempotence. The stronger scale-invariant counterexample is
-  retained separately, while the local-purification equivalences remain
+  the printed global PRFP predicate, formalized here at positive chain lengths,
+  and the corrected local purification condition. A nonzero MPDO with a
+  trace-invisible nilpotent bond sector formally refutes the printed global
+  implication to literal physical-trace idempotence. The stronger scale-invariant
+  counterexample is retained separately, while the local-purification equivalences remain
   restricted results.
 - `cpsv16_pure_zcl_local_orthogonality_scope.tex` records that the current
   pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The

--- a/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
+++ b/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
@@ -79,7 +79,7 @@ condition from the global nilpotent-sector obstruction discussed below.
 \section{Global formalization and its obstruction}
 
 A literal formalization of the printed purification RFP definition states the
-positive-length global purification equation \path{eq:MPDO-Puri-1} and require
+positive-length global purification equation \path{eq:MPDO-Puri-1} and requires
 the purifying spin--ancilla tensor to be a pure-state RFP. The trace over the
 ancillary index, discussed after Definition \path{def:Puri-RFP}, is a separate
 one-site tpCPM; it is not the two-map mixed-state RFP condition

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -276,7 +276,7 @@ linked exactly by
 its simple-canonical existential form supplied by
 \leanid{MPOTensor.IsSimpleCanonicalForm.exists_weight_copy_independent_of_isPhysicalTraceIdempotent}.
 Both are derived directly from the literal weighted-block equation. The older
-	exttt{IsSourceZCL} declarations remain separate scale-invariant
+\texttt{IsSourceZCL} declarations remain separate scale-invariant
 generalizations and are no longer used as the source nodes. After that
 normalization, the Proposition~C.7 channel pairs must still be combined, using
 the mutually orthogonal outer physical supports, into a single pair of


### PR DESCRIPTION
## Summary

- repair the malformed `\texttt{IsSourceZCL}` command in the ZCL normalization gap note
- distinguish the printed global PRFP definition from TNLean’s positive-chain-length formalization boundary in the paper-gap index
- correct the corresponding grammatical error in the purification-RFP gap note

## Source faithfulness

CPSV16 Definition 4.3 and Theorem 4.4 state the global purification-RFP condition in `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 758–784. The explicit restriction to positive chain lengths belongs to TNLean’s finite-chain formalization, where it avoids imposing an empty-chain bond-dimension normalization absent from the source. This change makes that distinction explicit and changes no mathematical statement, gap status, Lean declaration, or Blueprint readiness tag.

## Verification

- `texra-blueprint paper-gaps check`
- focused `latexmk` builds of `cpsv16_purification_rfp_definition.tex` and `cpsv16_zcl_canonical_form_normalization.tex` with the repository-local `command.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

Closes #7071
Addresses #232