### PR TITLE
feat(MPS/MPU): normalize composition flattening

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
+import TNLean.MPS.MPU.CompositionFlattening
 import TNLean.MPS.MPU.CompositionRanks
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence

--- a/TNLean/MPS/MPU/CompositionFlattening.lean
+++ b/TNLean/MPS/MPU/CompositionFlattening.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.OperatorProduct
+import TNLean.MPS.MPU.TransferMatrix
+
+/-!
+# Normalized flattening of a composition tensor
+
+This file relates the normalized flattening of the composition tensor to the
+normalized flattenings of its two factors.
+
+## Main results
+
+* `MPOTensor.normalizedFlattening_mulTensor_apply`: the physical contraction
+  formula, with the doubled auxiliary indices in their canonical order.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188], equation
+  `eq:transfer-op`, lines 336--340, and the proof of Theorem `IndexTh`, lines
+  837--841.
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor
+
+variable {d D₁ D₂ : ℕ}
+
+/-- The normalized flattening of the composition tensor is the physical
+contraction of the two normalized flattenings, multiplied by the scalar
+$\sqrt d$.
+The auxiliary pairs are encoded by `finProdFinEquiv` in the same order as in
+`MPOTensor.mulTensor`.
+
+This combines the raw composition tensor in arXiv:1703.09188, proof of Theorem
+`IndexTh`, lines 837--841, with the normalization in equation
+`eq:transfer-op`, lines 336--340; it is not a separately stated result of the
+paper. -/
+lemma normalizedFlattening_mulTensor_apply [NeZero d]
+    (U : MPOTensor d D₁) (V : MPOTensor d D₂) (i k : Fin d) :
+    (mulTensor U V).normalizedFlattening (finProdFinEquiv (i, k)) =
+      (Real.sqrt d : ℂ) •
+        (∑ j : Fin d,
+          U.normalizedFlattening (finProdFinEquiv (i, j)) ⊗ₖ
+            V.normalizedFlattening (finProdFinEquiv (j, k))).submatrix
+              finProdFinEquiv.symm finProdFinEquiv.symm := by
+  classical
+  have hd : (0 : ℝ) < d := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
+  have hsqrt : (Real.sqrt d : ℂ) ≠ 0 := by
+    exact_mod_cast Real.sqrt_ne_zero'.mpr hd
+  ext a b
+  simp only [normalizedFlattening, mulTensor_apply, toMPSTensor,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat,
+    Matrix.smul_apply, Matrix.submatrix_apply, Matrix.sum_apply,
+    Matrix.kroneckerMap_apply, smul_eq_mul]
+  simp only [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  field_simp
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3634,7 +3634,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
             \widetilde U^{ij}\otimes\widetilde V^{jk}.
     \end{align}
     This identity combines the raw composition tensor used in the proof of
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU} with the normalization in
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU} with the normalization in
     \cite[Section~III, equation~(13)]{Cirac2017MPU}; it is not a separately
     stated result of that proof.
 \end{lemma}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3615,6 +3615,37 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \cite[Section~III, equation~(13)]{Cirac2017MPU}.
 \end{definition}
 
+\begin{lemma}[Normalized flattening of a composition tensor]
+    \label{lem:mpu_normalized_flattening_composition}
+    \lean{MPOTensor.normalizedFlattening_mulTensor_apply}
+    \leanok
+    \uses{def:mpu_normalized_flattening, def:mpdo_operator_product}
+    Let $\mathcal U$ and $\mathcal V$ be MPO tensors with the same positive
+    physical dimension $d$, and let
+    \begin{align}
+        W^{ik} & =\sum_{j=0}^{d-1}U^{ij}\otimes V^{jk}
+    \end{align}
+    be their composition tensor. Under the canonical identification of its
+    auxiliary space with $\C^{D_U}\otimes\C^{D_V}$, the normalized
+    flattenings satisfy
+    \begin{align}
+        \widetilde W^{ik}
+         & =\sqrt d\sum_{j=0}^{d-1}
+            \widetilde U^{ij}\otimes\widetilde V^{jk}.
+    \end{align}
+    This identity combines the raw composition tensor used in the proof of
+    \cite[Theorem~IV.3(ii)]{Cirac2017MPU} with the normalization in
+    \cite[Section~III, equation~(13)]{Cirac2017MPU}; it is not a separately
+    stated result of that proof.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpu_normalized_flattening, def:mpdo_operator_product}
+    Substitute $U^{ij}=\sqrt d\,\widetilde U^{ij}$ and
+    $V^{jk}=\sqrt d\,\widetilde V^{jk}$ into the defining contraction for
+    $W^{ik}$, and then multiply the result by $d^{-1/2}$.
+\end{proof}
+
 \begin{theorem}[Normalized flattening under blocking]
     \label{thm:mpu_normalized_flattening_blocking}
     \lean{MPOTensor.normalizedFlattening_blockTensor}


### PR DESCRIPTION
## What changed

- add `MPOTensor.normalizedFlattening_mulTensor_apply`
- state the exact physical contraction with auxiliary indices reindexed by `finProdFinEquiv.symm`
- record the normalization factor `sqrt d` and the two source passages
- index the result in the MPU Blueprint chapter

## Statement integrity

The theorem uses only `[NeZero d]`. It preserves the requested `(i,j)` and `(j,k)` physical index order, applies `finProdFinEquiv.symm` to both auxiliary coordinates, and gives the exact scalar `sqrt d`. The documentation identifies the formula as definitional infrastructure obtained from the cited source definitions, not as a separately stated paper theorem.

## Validation

- `lake build TNLean.MPS.MPU.CompositionFlattening` (3183 jobs)
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- Blueprint source synchronization: 6783/6783 entries
- focused reader-facing prose check
- `chktex` on `blueprint/src/chapter/ch28_mpu.tex`
- `git diff --check`

The strict whole-Blueprint declaration checker was not run locally because the exact warmed cache lacked an unrelated MPDO object file; no broad rebuild was started. Hosted CI will run the complete check.

Closes #7064
