### PR TITLE
doc(conventions): consolidated markers stay self-contained

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,14 @@ readings: one `**Scope restriction**` or `**Local fix**` marker per
 declaration; a per-declaration marker is justified only when that
 declaration's restriction differs from the module's.
 
+Consolidation is per module, and the surviving marker stays
+self-contained: it states the deviation and cites the paper-gap note by
+path, so the module remains auditable on its own. A sentence naming
+another Lean module is not a marker. A consolidated marker must also
+claim no more than it covers: when only some declarations of a module
+carry the restriction, name them or leave the marker on them, rather
+than asserting it of the whole module.
+
 Every item on that list multiplies downstream statements and hypothesis
 lists and makes further proof writing harder. When an audit finds such a
 reading, the repair is to delete the scaffolding, not to document it.


### PR DESCRIPTION
## Summary

Follow-up to #7054. The marker rule ("one marker per restriction and module") admitted a reading under which consolidation replaces per-module markers with a sentence naming another Lean module, and under which a module-wide marker is asserted of declarations that do not carry the restriction. Both readings appeared in practice.

Two constraints added:

- Consolidation is per module, and the surviving marker stays self-contained: it states the deviation and cites the paper-gap note by path, so the module remains auditable on its own. A sentence naming another Lean module is not a marker.
- A consolidated marker claims no more than it covers: when only some declarations carry the restriction, name them or leave the marker on them.

Documentation only.

https://claude.ai/code/session_01NNSeUBNN4hcqXFFnf6221E