### PR TITLE
feat(Algebra): prove SWAP Kronecker trace identity

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -48,4 +48,5 @@ import TNLean.Algebra.ShiftedZeroTraceNilpotent
 import TNLean.Algebra.SkewSymmetricMatrix
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.SpinCover.EulerAngles
+import TNLean.Algebra.SwapTrace
 import TNLean.Algebra.TracePairing

--- a/TNLean/Algebra/SwapTrace.lean
+++ b/TNLean/Algebra/SwapTrace.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.MaximallyEntangled
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Trace contraction with the swap matrix
+
+This file proves the trace identity used to contract a swap operator against a
+Kronecker product.
+
+## Main results
+
+* `Matrix.trace_swapMatrix_mul_kronecker`: the swap contraction equals the trace of the
+  product of the two factors.
+* `Matrix.trace_swapMatrix_mul_kronecker_conjTranspose_of_mem_unitaryGroup`: the
+  contraction of a unitary with its conjugate transpose equals its dimension.
+
+## References
+
+* [J. I. Cirac et al., *Matrix product unitaries: structure, symmetries, and topological
+  invariants*, arXiv:1703.09188, lines 1608--1610][Cirac2017MPU]
+-/
+
+open scoped Matrix Kronecker
+open Matrix Finset BigOperators
+
+namespace Matrix
+
+variable {n : ℕ}
+
+/-- Contracting the swap matrix with a Kronecker product gives the trace of the product,
+with the factor order used in arXiv:1703.09188, lines 1608--1610. -/
+theorem trace_swapMatrix_mul_kronecker
+    (A B : Matrix (Fin n) (Fin n) ℂ) :
+    (swapMatrix n * (A ⊗ₖ B)).trace = (A * B).trace := by
+  classical
+  have hinner (i j k : Fin n) :
+      (∑ l : Fin n, (if i = l ∧ j = k then 1 else 0) * (A k i * B l j)) =
+        if j = k then A k i * B i j else 0 := by
+    by_cases hjk : j = k
+    · subst k
+      simp
+    · simp [hjk]
+  have hmiddle (i j : Fin n) :
+      (∑ k : Fin n, if j = k then A k i * B i j else 0) = A j i * B i j := by
+    rw [Finset.sum_eq_single j]
+    · simp
+    · intro k _ hkj
+      simp [Ne.symm hkj]
+    · simp
+  have hsum :
+      (∑ i : Fin n, ∑ j : Fin n, ∑ k : Fin n, ∑ l : Fin n,
+        (if i = l ∧ j = k then 1 else 0) * (A k i * B l j)) =
+      ∑ i : Fin n, ∑ j : Fin n, A i j * B j i := by
+    calc
+      _ = ∑ i : Fin n, ∑ j : Fin n, ∑ k : Fin n,
+          if j = k then A k i * B i j else 0 := by
+        apply Finset.sum_congr rfl
+        intro i _
+        apply Finset.sum_congr rfl
+        intro j _
+        apply Finset.sum_congr rfl
+        intro k _
+        exact hinner i j k
+      _ = ∑ i : Fin n, ∑ j : Fin n, A j i * B i j := by
+        apply Finset.sum_congr rfl
+        intro i _
+        apply Finset.sum_congr rfl
+        intro j _
+        exact hmiddle i j
+      _ = ∑ i : Fin n, ∑ j : Fin n, A i j * B j i := by
+        rw [Finset.sum_comm]
+  simpa only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Fintype.sum_prod_type,
+    swapMatrix_apply, Matrix.kroneckerMap_apply] using hsum
+
+/-- For a unitary matrix, contracting the swap matrix with the Kronecker product of the
+matrix and its conjugate transpose gives the matrix dimension. -/
+theorem trace_swapMatrix_mul_kronecker_conjTranspose_of_mem_unitaryGroup
+    (A : Matrix (Fin n) (Fin n) ℂ) (hA : A ∈ unitaryGroup (Fin n) ℂ) :
+    (swapMatrix n * (A ⊗ₖ Aᴴ)).trace = (n : ℂ) := by
+  rw [trace_swapMatrix_mul_kronecker]
+  have hunit : A * Aᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using mem_unitaryGroup_iff.mp hA
+  rw [hunit, Matrix.trace_one, Fintype.card_fin]
+
+end Matrix

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7006,11 +7006,41 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     the original endpoints.
 \end{proof}
 
+\begin{lemma}[SWAP trace contraction]
+    \label{lem:matrix_trace_swap_kronecker}
+    \lean{Matrix.trace_swapMatrix_mul_kronecker,
+        Matrix.trace_swapMatrix_mul_kronecker_conjTranspose_of_mem_unitaryGroup}
+    \leanok
+    For matrices $A,B\in\mathbb C^{n\times n}$ and the exchange matrix $\mathbb S$ on
+    $\mathbb C^n\otimes\mathbb C^n$,
+    \begin{align}
+        \tr\!\left[\mathbb S(A\otimes B)\right] & =\tr(AB).
+    \end{align}
+    In particular, if $U$ is unitary, then
+    \begin{align}
+        \tr\!\left[\mathbb S(U\otimes U^\dagger)\right] & =n.
+    \end{align}
+    % Source identity: paper_v2.tex lines 1608--1610.
+\end{lemma}
+
+\begin{proof}\leanok
+    In product coordinates, the exchange matrix has entries
+    $\mathbb S_{(i,j),(k,l)}=\delta_{i,l}\delta_{j,k}$. Therefore
+    \begin{align}
+        \tr\!\left[\mathbb S(A\otimes B)\right]
+         & =\sum_{i,j}A_{j,i}B_{i,j}
+          =\sum_{i,j}A_{i,j}B_{j,i}
+          =\tr(AB).
+    \end{align}
+    Taking $A=U$ and $B=U^\dagger$ gives
+    $\tr(UU^\dagger)=\tr(\Id)=n$.
+\end{proof}
+
 \begin{lemma}[Trace formula for the time-reversal sign]
     \label{eq:sigma-from-trace}
     \notready
     \discussion{5714}
-    \uses{PropChiral}
+    \uses{PropChiral, lem:matrix_trace_swap_kronecker}
     For a time-reversal-invariant MPU in standard form, the sign $\sigma$ is
     \begin{align}
         \sigma & =\frac1{d^2}\tr\!\left[\mathbb S_{12,34}


### PR DESCRIPTION
Closes #7076.

## Summary
- New module `TNLean/Algebra/SwapTrace.lean` proving the trace of SWAP times a Kronecker product: `tr(SWAP · (A ⊗ B)) = tr(A · B)` (`tr_swap_mul_kronecker`-style statement for square matrices).
- Blueprint coverage in ch28_mpu.tex.

## Verification
- No sorry/axiom/native_decide (grep-checked).