### PR TITLE
feat(MPS/MPDO): transport MPO tensors through isometric physical embeddings

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -18,6 +18,7 @@ import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Core.MultiBlockWord
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
+import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge

--- a/TNLean/MPS/Core/PhysicalIndexMixing.lean
+++ b/TNLean/MPS/Core/PhysicalIndexMixing.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.KrausRepresentation
+import QICLean.Kraus.TransferChannel
+import TNLean.MPS.Core.CanonicalNormalization
+
+/-!
+# Physical-index mixing of MPS tensors
+
+This module collects generic facts about replacing a finite family of MPS
+matrices by fixed linear combinations of that family.  Isometric mixing
+preserves the transfer map and left-canonical normalization, while arbitrary
+mixing preserves a common virtual gauge.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Isometric Kraus mixing -/
+
+/-- For a possibly rectangular isometry `W`, the family
+`C τ = ∑ σ, W τ σ • B σ` has the same transfer map as `B`. -/
+theorem transferMap_kraus_isometry
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1) :
+    Kraus.transferMap (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ) = Kraus.transferMap B := by
+  ext X : 1
+  simpa [Kraus.transferMap_apply] using
+    kraus_same_map_of_isometry_combination
+      (K := fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ)
+      (K' := B) W hW (fun _ ↦ rfl) X
+
+/-- A physical-index isometry preserves left-canonicality. -/
+theorem isLeftCanonical_kraus_isometry
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
+    (hB : IsLeftCanonical B) :
+    IsLeftCanonical (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ) := by
+  let C : MPSTensor m D := fun τ ↦ ∑ σ : Fin d, W τ σ • B σ
+  have hCh : IsChannel (Kraus.transferMap C) := by
+    have hEq : Kraus.transferMap C = Kraus.transferMap B := by
+      simpa [C] using transferMap_kraus_isometry B W hW
+    simpa [hEq] using Kraus.isChannel_transferMap B hB
+  change IsLeftCanonical C
+  rw [IsLeftCanonical]
+  exact kraus_sum_conjTranspose_mul_of_tp C (Kraus.transferMap C)
+    (fun X ↦ by simp [Kraus.transferMap_apply]) hCh.tp
+
+/-- An isometric physical-index mixing of an injective matrix family remains
+injective.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this lemma. -/
+theorem isInjective_kraus_isometry
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
+    (hB : Kraus.IsInjective B) :
+    Kraus.IsInjective (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ) := by
+  let C : MPSTensor m D := fun τ ↦ ∑ σ : Fin d, W τ σ • B σ
+  have hrecover (sigma : Fin d) :
+      ∑ tau : Fin m, star (W tau sigma) • C tau = B sigma := by
+    ext i j
+    simp only [C, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    calc
+      ∑ tau : Fin m, star (W tau sigma) * ∑ rho : Fin d, W tau rho * B rho i j =
+          ∑ tau : Fin m, ∑ rho : Fin d,
+            (star (W tau sigma) * W tau rho) * B rho i j := by
+              apply Finset.sum_congr rfl
+              intro tau _
+              rw [Finset.mul_sum]
+              apply Finset.sum_congr rfl
+              intro rho _
+              ring
+      _ = ∑ rho : Fin d, ∑ tau : Fin m,
+          (star (W tau sigma) * W tau rho) * B rho i j := Finset.sum_comm
+      _ = ∑ rho : Fin d,
+          (∑ tau : Fin m, star (W tau sigma) * W tau rho) * B rho i j := by
+            apply Finset.sum_congr rfl
+            intro rho _
+            rw [Finset.sum_mul]
+      _ = B sigma i j := by
+        have hentry (rho : Fin d) :
+            (∑ tau : Fin m, star (W tau sigma) * W tau rho) =
+              if sigma = rho then 1 else 0 := by
+          simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+            Matrix.one_apply] using
+            congrFun (congrFun hW sigma) rho
+        simp_rw [hentry]
+        simp
+  rw [Kraus.IsInjective, eq_top_iff]
+  intro X _
+  have hle : Submodule.span ℂ (Set.range B) ≤
+      Submodule.span ℂ (Set.range C) := by
+    apply Submodule.span_le.mpr
+    rintro _ ⟨sigma, rfl⟩
+    rw [← hrecover sigma]
+    apply Submodule.sum_mem
+    intro tau _
+    exact Submodule.smul_mem _ _
+      (Submodule.subset_span ⟨tau, rfl⟩)
+  apply hle
+  rw [hB]
+  exact Submodule.mem_top
+
+/-- A linearly mixed family can be injective only if the original family is
+injective.  No isometry hypothesis is needed.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this lemma. -/
+theorem isInjective_of_kraus_mixing_isInjective
+    {m : ℕ} (B : MPSTensor d D) (W : Matrix (Fin m) (Fin d) ℂ)
+    (hC : Kraus.IsInjective
+      (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ)) :
+    Kraus.IsInjective B := by
+  let C : MPSTensor m D := fun τ ↦ ∑ σ : Fin d, W τ σ • B σ
+  rw [Kraus.IsInjective, eq_top_iff]
+  intro X _
+  have hle : Submodule.span ℂ (Set.range C) ≤
+      Submodule.span ℂ (Set.range B) := by
+    apply Submodule.span_le.mpr
+    rintro _ ⟨tau, rfl⟩
+    apply Submodule.sum_mem
+    intro sigma _
+    exact Submodule.smul_mem _ _
+      (Submodule.subset_span ⟨sigma, rfl⟩)
+  apply hle
+  rw [show Kraus.IsInjective C from hC]
+  exact Submodule.mem_top
+
+/-- Isometric physical-index mixing preserves and reflects one-site
+injectivity.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this equivalence. -/
+theorem isInjective_kraus_isometry_iff
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1) :
+    Kraus.IsInjective (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ) ↔
+      Kraus.IsInjective B := by
+  constructor
+  · exact isInjective_of_kraus_mixing_isInjective B W
+  · exact isInjective_kraus_isometry B W hW
+
+/-! ### Gauge covariance -/
+
+/-- Applying the same physical-index mixing to two gauge-equivalent tensors
+preserves their virtual gauge.  No isometry hypothesis is needed.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this lemma. -/
+theorem GaugeEquiv.sum_smul
+    {m : ℕ} {A B : MPSTensor d D}
+    (hAB : GaugeEquiv A B) (W : Matrix (Fin m) (Fin d) ℂ) :
+    GaugeEquiv
+      (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • A σ)
+      (fun τ : Fin m ↦ ∑ σ : Fin d, W τ σ • B σ) := by
+  obtain ⟨X, hX⟩ := hAB
+  refine ⟨X, fun τ ↦ ?_⟩
+  simp_rw [hX]
+  rw [Matrix.mul_sum, Matrix.sum_mul]
+  apply Finset.sum_congr rfl
+  intro σ _
+  simp
+
+end MPSTensor

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -221,6 +221,7 @@ import TNLean.MPS.MPDO.PhysicalAdjoint
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
+import TNLean.MPS.MPDO.PhysicalIsometricEmbedding
 import TNLean.MPS.MPDO.PhysicalSectorActiveBond
 import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport
 import TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring

--- a/TNLean/MPS/MPDO/PhysicalIsometricEmbedding.lean
+++ b/TNLean/MPS/MPDO/PhysicalIsometricEmbedding.lean
@@ -1,0 +1,511 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Core.PhysicalIndexMixing
+import TNLean.MPS.MPDO.BNTLayerOrthogonality
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+
+/-!
+# Isometric embeddings of the physical space of an MPO tensor
+
+This module records the elementary coordinate transport obtained by embedding
+the one-site physical space of an MPO tensor isometrically into a larger
+space.  On the doubled MPS index, the isometry is the ket matrix tensored with
+the conjugate of the bra matrix.
+
+These statements are project-derived coordinate lemmas.  They are used when
+placing normal BNT representatives in orthogonal physical sectors; they are
+not statements of arXiv:1606.00608.  The source context is the normal-block
+decomposition in lines 217--246 and the per-sector reduction in lines
+1628--1665 and 1740--1782.
+
+## Main definitions and statements
+
+* `MPOTensor.doubledPhysicalMatrix`: the induced matrix on the doubled
+  physical index.
+* `MPOTensor.doubledPhysicalMatrix_isometry`: a physical isometry induces an
+  isometry on the doubled index.
+* `MPOTensor.toMPSTensor_changePhysicalBasis`: exact identification with
+  isometric Kraus mixing.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, lines
+  217--246, 1628--1665, and 1740--1782 (construction context only)
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d e D : ℕ}
+
+open PhysicalSectorFactorization
+
+/-! ### The doubled physical isometry -/
+
+/-- The matrix induced on the doubled physical index by a physical coordinate
+matrix.  Its ket coefficient is `V i p`, while its bra coefficient is
+`star (V j q)`, in the `finProdFinEquiv` convention of `MPOTensor.toMPSTensor`.
+
+This is a project-derived coordinate definition used in the setting of
+arXiv:1606.00608, lines 217--246 and 1628--1665; the paper does not state this
+definition. -/
+def doubledPhysicalMatrix (V : Matrix (Fin e) (Fin d) ℂ) :
+    Matrix (Fin (e * e)) (Fin (d * d)) ℂ :=
+  fun ij pq ↦
+    V ij.divNat pq.divNat * star (V ij.modNat pq.modNat)
+
+/-- An isometry of the one-site physical space induces an isometry on the
+doubled ket--bra index.
+
+This is project-derived coordinate algebra in the setting of arXiv:1606.00608,
+lines 217--246 and 1628--1665, not a result asserted in the paper. -/
+theorem doubledPhysicalMatrix_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) :
+    (doubledPhysicalMatrix V)ᴴ * doubledPhysicalMatrix V = 1 := by
+  classical
+  ext pq rs
+  obtain ⟨⟨p, q⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin d × Fin d ≃ Fin (d * d)).surjective pq
+  obtain ⟨⟨r, s⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin d × Fin d ≃ Fin (d * d)).surjective rs
+  rw [Matrix.mul_apply, ← Equiv.sum_comp
+    (finProdFinEquiv : Fin e × Fin e ≃ Fin (e * e)), Fintype.sum_prod_type]
+  simp only [Matrix.conjTranspose_apply, doubledPhysicalMatrix,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp_rw [star_mul, star_star]
+  have hterm (i j : Fin e) :
+      (V j q * star (V i p)) * (V i r * star (V j s)) =
+        (star (V i p) * V i r) * (V j q * star (V j s)) := by
+    ring
+  simp_rw [hterm]
+  rw [← Fintype.sum_mul_sum]
+  have hpr := congrFun (congrFun hV p) r
+  have hsq := congrFun (congrFun hV s) q
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at hpr hsq
+  rw [hpr]
+  have hsecond :
+      (∑ j : Fin e, V j q * star (V j s)) =
+        (1 : Matrix (Fin d) (Fin d) ℂ) s q := by
+    simpa only [mul_comm] using hsq
+  rw [hsecond]
+  simp only [Matrix.one_apply, Equiv.apply_eq_iff_eq, Prod.mk.injEq]
+  by_cases h₁ : p = r <;> by_cases h₂ : q = s <;>
+    simp [h₁, h₂, eq_comm]
+
+/-- Changing the physical basis of an MPO tensor is exactly isometric mixing
+of its doubled-index MPS matrices by `doubledPhysicalMatrix`.
+
+This is a project-derived coordinate identity used in the setting of
+arXiv:1606.00608, lines 217--246 and 1628--1665; the paper does not state it. -/
+theorem toMPSTensor_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (K : MPOTensor d D) :
+    (changePhysicalBasis V K).toMPSTensor =
+      fun ij ↦ ∑ pq : Fin (d * d), doubledPhysicalMatrix V ij pq • K.toMPSTensor pq := by
+  funext ij
+  obtain ⟨⟨i, j⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin e × Fin e ≃ Fin (e * e)).surjective ij
+  simp only [toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat]
+  rw [changePhysicalBasis_apply_eq_sum]
+  rw [← Equiv.sum_comp (finProdFinEquiv : Fin d × Fin d ≃ Fin (d * d))]
+  apply Finset.sum_congr rfl
+  rintro ⟨p, q⟩ _
+  simp [doubledPhysicalMatrix]
+
+/-! ### Doubled-index MPS consequences -/
+
+/-- An isometric embedding of the one-site physical space leaves the
+doubled-index MPS transfer map unchanged.
+
+This is a project-derived coordinate identity used in the setting of
+arXiv:1606.00608, lines 217--246 and 1628--1665; the paper does not state it. -/
+theorem transferMap_toMPSTensor_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    Kraus.transferMap (changePhysicalBasis V K).toMPSTensor =
+      Kraus.transferMap K.toMPSTensor := by
+  rw [toMPSTensor_changePhysicalBasis]
+  exact MPSTensor.transferMap_kraus_isometry K.toMPSTensor
+    (doubledPhysicalMatrix V) (doubledPhysicalMatrix_isometry V hV)
+
+/-- Isometric physical embedding preserves and reflects one-site
+injectivity of the doubled-index MPS tensor.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this equivalence. -/
+theorem isInjective_toMPSTensor_changePhysicalBasis_iff
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    Kraus.IsInjective (changePhysicalBasis V K).toMPSTensor ↔
+      Kraus.IsInjective K.toMPSTensor := by
+  rw [toMPSTensor_changePhysicalBasis]
+  exact MPSTensor.isInjective_kraus_isometry_iff K.toMPSTensor
+    (doubledPhysicalMatrix V) (doubledPhysicalMatrix_isometry V hV)
+
+/-- An isometric physical embedding preserves left-canonical normalization
+of the doubled-index MPS tensor.
+
+This is project-derived coordinate algebra used for the normal-block
+construction surrounding arXiv:1606.00608, lines 217--246 and 1628--1665;
+the paper does not state this lemma. -/
+theorem isLeftCanonical_toMPSTensor_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) (hK : MPSTensor.IsLeftCanonical K.toMPSTensor) :
+    MPSTensor.IsLeftCanonical (changePhysicalBasis V K).toMPSTensor := by
+  rw [toMPSTensor_changePhysicalBasis]
+  exact MPSTensor.isLeftCanonical_kraus_isometry K.toMPSTensor
+    (doubledPhysicalMatrix V) (doubledPhysicalMatrix_isometry V hV) hK
+
+/-- Isometric physical embedding preserves and reflects normality of the
+doubled-index MPS tensor.
+
+The proof only transports the transfer map and the equivalence between
+irreducibility of a Kraus family and of its transfer map; it introduces no
+new Perron--Frobenius argument.  This is project-derived coordinate algebra
+used for the normal-block construction surrounding arXiv:1606.00608, lines
+217--246 and 1628--1665, not a theorem asserted in the paper. -/
+theorem isNormalTensor_toMPSTensor_changePhysicalBasis_iff
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    MPSTensor.IsNormalTensor (changePhysicalBasis V K).toMPSTensor ↔
+      MPSTensor.IsNormalTensor K.toMPSTensor := by
+  have hTransfer := transferMap_toMPSTensor_changePhysicalBasis V hV K
+  constructor
+  · intro hC
+    refine ⟨?_, ?_, ?_⟩
+    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap
+      have hIrr := Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+        (changePhysicalBasis V K).toMPSTensor hC.no_invariant_proj
+      rw [hTransfer] at hIrr
+      exact hIrr
+    · rw [← hTransfer]
+      exact hC.spectral_radius_one
+    · rw [← hTransfer]
+      exact hC.primitive_transfer
+  · intro hB
+    refine ⟨?_, ?_, ?_⟩
+    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap
+      have hIrr := Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+        K.toMPSTensor hB.no_invariant_proj
+      rw [hTransfer]
+      exact hIrr
+    · rw [hTransfer]
+      exact hB.spectral_radius_one
+    · rw [hTransfer]
+      exact hB.primitive_transfer
+
+/-- Applying the same physical-coordinate matrix to two MPO tensors
+preserves gauge equivalence of their doubled-index MPS representatives.  No
+isometry hypothesis is needed.
+
+This is project-derived coordinate algebra used in the setting of
+arXiv:1606.00608, lines 217--246 and 1628--1665; the paper does not state it. -/
+theorem gaugeEquiv_toMPSTensor_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) {K L : MPOTensor d D}
+    (hKL : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
+    MPSTensor.GaugeEquiv
+      (changePhysicalBasis V K).toMPSTensor
+      (changePhysicalBasis V L).toMPSTensor := by
+  simp only [toMPSTensor_changePhysicalBasis]
+  exact hKL.sum_smul (doubledPhysicalMatrix V)
+
+/-! ### MPO positivity and saturation consequences -/
+
+/-- Applying an arbitrary physical-coordinate matrix preserves the MPDO
+positivity condition in the forward direction.
+
+No isometry hypothesis is required: every periodic density operator is
+conjugated by the corresponding sitewise physical matrix.  This is a
+project-derived coordinate fact used in the setting of arXiv:1606.00608,
+lines 1628--1665 and 1740--1782; the paper does not state it. -/
+protected theorem IsMPDO.changePhysicalBasis
+    (hK : IsMPDO K) (V : Matrix (Fin e) (Fin d) ℂ) :
+    IsMPDO (changePhysicalBasis V K) := by
+  intro N hN
+  rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+  exact (hK N hN).mul_mul_conjTranspose_same (sitewisePhysicalMatrix V N)
+
+/-- Under an isometric physical embedding, the MPDO condition is equivalent
+before and after the embedding.
+
+This is project-derived coordinate algebra used in the setting of
+arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper does not state
+this equivalence. -/
+theorem isMPDO_changePhysicalBasis_iff
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    IsMPDO (changePhysicalBasis V K) ↔ IsMPDO K := by
+  constructor
+  · exact isMPDO_of_changePhysicalBasis_isMPDO_of_isometry V hV K
+  · intro hK
+    exact hK.changePhysicalBasis V
+
+/-- Saturation of the area law ascends through an isometric physical
+embedding.
+
+The source tensor's positivity, positive-length trace normalization, and the
+equalities of neighboring mutual informations are retained.  This is a
+project-derived coordinate fact used in the setting of arXiv:1606.00608,
+lines 1628--1665 and 1740--1782; the paper does not state it. -/
+protected theorem IsSAL.changePhysicalBasis_of_isometry
+    (hK : IsSAL K) (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) :
+    IsSAL (changePhysicalBasis V K) := by
+  obtain ⟨hMpdo, hTrace, hStep⟩ := hK
+  let hAmbientMpdo : IsMPDO (changePhysicalBasis V K) :=
+    hMpdo.changePhysicalBasis V
+  refine ⟨hAmbientMpdo, ?_, ?_⟩
+  · intro N hN
+    rw [trace_mpo_changePhysicalBasis_of_isometry V hV]
+    exact hTrace N hN
+  · intro N L hL hLN
+    rw [mutualInfoChain_changePhysicalBasis_of_isometry V hV K N L
+        (Nat.le_of_lt (hLN.trans_le (Nat.div_le_self N 2)))
+        (hMpdo N (by omega)),
+      mutualInfoChain_changePhysicalBasis_of_isometry V hV K N (L + 1)
+        (hLN.trans_le (Nat.div_le_self N 2)) (hMpdo N (by omega))]
+    exact hStep N L hL hLN
+
+/-- Under an isometric physical embedding, saturation of the area law is
+equivalent before and after the embedding.
+
+This is project-derived coordinate algebra used in the setting of
+arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper does not state
+this equivalence. -/
+theorem isSAL_changePhysicalBasis_iff
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    IsSAL (changePhysicalBasis V K) ↔ IsSAL K := by
+  constructor
+  · exact isSAL_of_changePhysicalBasis_isSAL_of_isometry V hV K
+  · intro hK
+    exact hK.changePhysicalBasis_of_isometry V hV
+
+/-- An isometric physical embedding leaves the one-site physical-trace
+transfer matrix unchanged.
+
+This is project-derived coordinate algebra used in the zero-correlation
+length setting of arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper
+does not state this identity. -/
+theorem physTraceTransfer_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    physTraceTransfer (changePhysicalBasis V K) = physTraceTransfer K := by
+  ext beta alpha
+  simp only [physTraceTransfer, Matrix.sum_apply]
+  simp_rw [changePhysicalBasis_apply_eq_sum]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  calc
+    ∑ i : Fin e, ∑ pq : Fin d × Fin d,
+        (V i pq.1 * star (V i pq.2)) * K pq.1 pq.2 beta alpha =
+        ∑ pq : Fin d × Fin d,
+          (∑ i : Fin e, V i pq.1 * star (V i pq.2)) *
+            K pq.1 pq.2 beta alpha := by
+              rw [Finset.sum_comm]
+              apply Finset.sum_congr rfl
+              intro pq _
+              rw [Finset.sum_mul]
+    _ = ∑ p : Fin d, K p p beta alpha := by
+      have hentry (p q : Fin d) :
+          (∑ i : Fin e, V i p * star (V i q)) =
+            if p = q then 1 else 0 := by
+        have hpq := congrFun (congrFun hV q) p
+        simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+          Matrix.one_apply, mul_comm, eq_comm] using hpq
+      rw [Fintype.sum_prod_type]
+      simp_rw [hentry]
+      simp
+
+/-! ### Canonical one-site physical support -/
+
+/-- The blockwise copy of `Vᴴ` acting on the physical-column component of
+`physicalSliceColumns`.  It leaves the two virtual column indices fixed.
+
+This is a project-derived coordinate matrix used in the normal-block setting
+of arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper does not state
+this definition. -/
+noncomputable def physicalSliceColumnCoisometry
+    (V : Matrix (Fin e) (Fin d) ℂ) :
+    Matrix (Fin (D * D * d)) (Fin (D * D * e)) ℂ :=
+  fun q r ↦ if q.divNat = r.divNat then star (V r.modNat q.modNat) else 0
+
+/-- If `V` is an isometry, its blockwise action on the stacked physical
+columns is a coisometry.
+
+This is project-derived coordinate algebra used in the normal-block setting
+of arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper does not state
+this lemma. -/
+theorem physicalSliceColumnCoisometry_mul_conjTranspose
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) :
+    physicalSliceColumnCoisometry (D := D) V *
+      (physicalSliceColumnCoisometry (D := D) V)ᴴ = 1 := by
+  classical
+  ext x y
+  obtain ⟨⟨u, p⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin (D * D) × Fin d ≃ Fin (D * D * d)).surjective x
+  obtain ⟨⟨v, q⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin (D * D) × Fin d ≃ Fin (D * D * d)).surjective y
+  rw [Matrix.mul_apply, ← Equiv.sum_comp
+    (finProdFinEquiv : Fin (D * D) × Fin e ≃ Fin (D * D * e)),
+    Fintype.sum_prod_type]
+  simp only [physicalSliceColumnCoisometry, Matrix.conjTranspose_apply,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat,
+    Matrix.one_apply, Equiv.apply_eq_iff_eq, Prod.mk.injEq]
+  have hpq :
+      (∑ i : Fin e, star (V i p) * V i q) = if p = q then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply] using congrFun (congrFun hV p) q
+  by_cases huv : u = v
+  · subst v
+    simpa [hpq]
+  · have hvu : ¬ v = u := fun h ↦ huv h.symm
+    simp [huv, hvu]
+
+/-- The stacked physical columns of a physically embedded MPO tensor are
+obtained by multiplying the original stacked columns by `V` on the left and
+the blockwise copy of `Vᴴ` on the right.
+
+This identity uses the literal `physicalSliceColumns` definition.  It is
+project-derived coordinate algebra used in the normal-block setting of
+arXiv:1606.00608, lines 1628--1665 and 1740--1782; the paper does not state it. -/
+theorem physicalSliceColumns_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (K : MPOTensor d D) :
+    physicalSliceColumns (changePhysicalBasis V K) =
+      V * physicalSliceColumns K * physicalSliceColumnCoisometry (D := D) V := by
+  classical
+  ext i r
+  obtain ⟨⟨u, j⟩, rfl⟩ :=
+    (finProdFinEquiv : Fin (D * D) × Fin e ≃ Fin (D * D * e)).surjective r
+  simp only [physicalSliceColumns, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, changePhysicalBasis]
+  conv_rhs =>
+    rw [Matrix.mul_apply, ← Equiv.sum_comp
+      (finProdFinEquiv : Fin (D * D) × Fin d ≃ Fin (D * D * d)),
+      Fintype.sum_prod_type]
+  simp only [physicalSliceColumnCoisometry,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp [Matrix.mul_apply, physicalSliceColumns, physicalSlice]
+
+/-- The joint column support of `V * Y` is the isometric image of the joint
+column support of `Y`.
+
+This private helper is project-derived finite-dimensional linear algebra for
+the physical-support transport used around arXiv:1606.00608, lines 1628--1665
+and 1740--1782; the paper does not state it. -/
+private theorem supportProj_left_isometry
+    {n m k : ℕ} (V : Matrix (Fin m) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (Y : Matrix (Fin n) (Fin k) ℂ) :
+    (Matrix.posSemidef_self_mul_conjTranspose (V * Y)).supportProj =
+      V * (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj * Vᴴ := by
+  let P := (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj
+  let Z := V * Y
+  let Q := (Matrix.posSemidef_self_mul_conjTranspose Z).supportProj
+  change Q = V * P * Vᴴ
+  have hPY : P * Y = Y := by
+    simpa [P, Matrix.PosSemidef.supportProj] using
+      Matrix.supportProj_mul_conjTranspose_mul_self Y
+  have hQZ : Q * Z = Z := by
+    simpa [Q, Matrix.PosSemidef.supportProj] using
+      Matrix.supportProj_mul_conjTranspose_mul_self Z
+  have hPHerm : P.IsHermitian := by
+    exact (Matrix.posSemidef_self_mul_conjTranspose Y).supportProj_isHermitian
+  have hQHerm : Q.IsHermitian := by
+    exact (Matrix.posSemidef_self_mul_conjTranspose Z).supportProj_isHermitian
+  have hCandidateHerm : (V * P * Vᴴ).IsHermitian :=
+    Matrix.isHermitian_mul_mul_conjTranspose V hPHerm
+  have hCandidateZ : (V * P * Vᴴ) * Z = Z := by
+    simp only [Z, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc Vᴴ V Y, hV, Matrix.one_mul, hPY]
+  obtain ⟨T, hQT⟩ :=
+    (Matrix.posSemidef_self_mul_conjTranspose Z).exists_supportProj_eq_mul
+  change Q = Z * Zᴴ * T at hQT
+  have hCandidateQ : (V * P * Vᴴ) * Q = Q := by
+    calc
+      (V * P * Vᴴ) * Q =
+          (V * P * Vᴴ) * (Z * Zᴴ * T) := by rw [hQT]
+      _ = ((V * P * Vᴴ) * Z) * (Zᴴ * T) := by
+        simp only [Matrix.mul_assoc]
+      _ = Z * (Zᴴ * T) := by rw [hCandidateZ]
+      _ = Q := by rw [hQT]; simp only [Matrix.mul_assoc]
+  obtain ⟨S, hPS⟩ :=
+    (Matrix.posSemidef_self_mul_conjTranspose Y).exists_supportProj_eq_mul
+  change P = Y * Yᴴ * S at hPS
+  have hCandidateFactor : V * P * Vᴴ = Z * (Yᴴ * S * Vᴴ) := by
+    rw [hPS]
+    simp only [Z, Matrix.mul_assoc]
+  have hQCandidate : Q * (V * P * Vᴴ) = V * P * Vᴴ := by
+    rw [hCandidateFactor, ← Matrix.mul_assoc, hQZ]
+  have hQCandidateEqQ : Q * (V * P * Vᴴ) = Q := by
+    have hAdjoint := congrArg Matrix.conjTranspose hCandidateQ
+    simpa only [Matrix.conjTranspose_mul, hQHerm.eq,
+      hCandidateHerm.eq] using hAdjoint
+  exact hQCandidateEqQ.symm.trans hQCandidate
+
+/-- The Gram matrix of the stacked physical columns transforms by isometric
+conjugation under an isometric physical embedding.
+
+The proof uses the literal stacked-column identity and the coisometry on its
+column index.  This is project-derived coordinate algebra used in the
+normal-block setting of arXiv:1606.00608, lines 1628--1665 and 1740--1782;
+the paper does not state it. -/
+theorem physicalSliceColumns_mul_conjTranspose_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    physicalSliceColumns (changePhysicalBasis V K) *
+        (physicalSliceColumns (changePhysicalBasis V K))ᴴ =
+      V * (physicalSliceColumns K * (physicalSliceColumns K)ᴴ) * Vᴴ := by
+  let Z := physicalSliceColumns K
+  let R := physicalSliceColumnCoisometry (D := D) V
+  have hR : R * Rᴴ = 1 :=
+    physicalSliceColumnCoisometry_mul_conjTranspose V hV
+  rw [physicalSliceColumns_changePhysicalBasis]
+  change (V * Z * R) * (V * Z * R)ᴴ = V * (Z * Zᴴ) * Vᴴ
+  calc
+    (V * Z * R) * (V * Z * R)ᴴ =
+        V * Z * (R * Rᴴ) * Zᴴ * Vᴴ := by
+          simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+    _ = V * Z * Zᴴ * Vᴴ := by rw [hR]; simp
+    _ = V * (Z * Zᴴ) * Vᴴ := by simp only [Matrix.mul_assoc]
+
+/-- The canonical support projection of the stacked physical columns is
+transported by isometric conjugation:
+`physicalSupportProj (changePhysicalBasis V K) =
+V * physicalSupportProj K * Vᴴ`.
+
+This uses the repository's literal `physicalSliceColumns` and
+`physicalSupportProj` definitions.  It is a project-derived coordinate fact
+used in the normal-block setting of arXiv:1606.00608, lines 1628--1665 and
+1740--1782; the paper does not state it. -/
+theorem physicalSupportProj_changePhysicalBasis
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (K : MPOTensor d D) :
+    physicalSupportProj (changePhysicalBasis V K) =
+      V * physicalSupportProj K * Vᴴ := by
+  let Z := physicalSliceColumns K
+  let Z' := physicalSliceColumns (changePhysicalBasis V K)
+  have hGram : Z' * Z'ᴴ = (V * Z) * (V * Z)ᴴ := by
+    calc
+      Z' * Z'ᴴ = V * (Z * Zᴴ) * Vᴴ :=
+        physicalSliceColumns_mul_conjTranspose_changePhysicalBasis V hV K
+      _ = (V * Z) * (V * Z)ᴴ := by
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+  have hSupport :=
+    (Matrix.posSemidef_self_mul_conjTranspose Z').supportProj_congr
+      (Matrix.posSemidef_self_mul_conjTranspose (V * Z)) hGram
+  calc
+    physicalSupportProj (changePhysicalBasis V K) =
+        (Matrix.posSemidef_self_mul_conjTranspose (V * Z)).supportProj := by
+          simpa [physicalSupportProj, Z'] using hSupport
+    _ = V * (Matrix.posSemidef_self_mul_conjTranspose Z).supportProj * Vᴴ :=
+      supportProj_left_isometry V hV Z
+    _ = V * physicalSupportProj K * Vᴴ := by
+      simp only [physicalSupportProj, Z]
+
+end MPOTensor

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ListProduct
 import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Periodic.Symmetry.Theorem41Defs
 
 /-!
@@ -24,22 +25,6 @@ namespace MPSTensor
 section Theorem41Forward
 
 variable {d D : ℕ}
-
-/-- **Rectangular Kraus isometry mixing.**
-
-For a (possibly rectangular) isometry `W : Fin m → Fin d` with `Wᴴ · W = 1`,
-the family `C τ := ∑_σ W(τ, σ) · B σ` has the same transfer map
-as `B`. This is an adapter from
-`kraus_same_map_of_isometry_combination` to the `Kraus.transferMap` interface. -/
-theorem transferMap_kraus_isometry
-    {m : ℕ} (B : MPSTensor d D)
-    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1) :
-    Kraus.transferMap (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) = Kraus.transferMap B := by
-  ext X : 1
-  simpa [Kraus.transferMap_apply] using
-    kraus_same_map_of_isometry_combination
-      (K := fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ)
-      (K' := B) W hW (fun _ => rfl) X
 
 /-- Evaluation of the tensor \(C\) defined from \(W\) on a blocked word is a \(W\)-weighted sum
 of evaluations of the original tensor.
@@ -99,22 +84,6 @@ theorem sameMPV₂_sum_smul_ofFn
     _ = mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' • B σ') τ := by
           symm
           exact mpv_sum_smul_ofFn B W N τ
-
-/-- A physical-index isometry preserves left-canonicality. -/
-theorem isLeftCanonical_kraus_isometry
-    {m : ℕ} (B : MPSTensor d D)
-    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
-    (hB : IsLeftCanonical B) :
-    IsLeftCanonical (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) := by
-  let C : MPSTensor m D := fun τ => ∑ σ : Fin d, W τ σ • B σ
-  have hCh : IsChannel (Kraus.transferMap C) := by
-    have hEq : Kraus.transferMap C = Kraus.transferMap B := by
-      simpa [C] using transferMap_kraus_isometry B W hW
-    simpa [hEq] using Kraus.isChannel_transferMap B hB
-  change IsLeftCanonical C
-  rw [IsLeftCanonical]
-  exact kraus_sum_conjTranspose_mul_of_tp C (Kraus.transferMap C)
-    (fun X => by simp [Kraus.transferMap_apply]) hCh.tp
 
 /-- A physical-index isometry preserves periodicity and its period. -/
 theorem isPeriodic_kraus_isometry

--- a/blueprint/src/chapter/ch21_mpdo_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp.tex
@@ -24,6 +24,7 @@ Chapter~\ref{ch:mpdo_rfp_algebraic}.
 \input{chapter/ch21_mpdo_rfp_strong}
 \input{chapter/ch21_mpdo_rfp_foundations}
 \input{chapter/ch21_mpdo_rfp_area_law}
+\input{chapter/ch21_mpdo_rfp_physical_isometric_embeddings}
 \input{chapter/ch21_mpdo_rfp_simple_definition}
 \input{chapter/ch21_mpdo_rfp_local_embedding_coordinates}
 \input{chapter/ch21_mpdo_rfp_gsnnch_definitions}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_physical_isometric_embeddings.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_physical_isometric_embeddings.tex
@@ -1,0 +1,123 @@
+\section{Isometric enlargements of the physical space}
+
+% The results in this section are project-derived coordinate statements.  The
+% cited CPSV16 passages are construction context, not source statements of the
+% invariance theorem below.
+
+\begin{definition}[Doubled physical matrix]
+    \label{def:mpdo_doubled_physical_matrix}
+    \lean{MPOTensor.doubledPhysicalMatrix}
+    \leanok
+    Let $V:\C^d\to\C^e$ be a linear map.  Its action on the doubled
+    ket--bra index is the matrix $W:\C^{d^2}\to\C^{e^2}$ with
+    \begin{align}
+        W_{(i,j),(p,q)}
+         &=V_{i,p}\,\overline{V_{j,q}}.
+        \label{eq:mpdo_doubled_physical_matrix}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Transport under an isometric physical embedding]
+    \label{thm:mpdo_isometric_physical_embedding}
+    \lean{MPSTensor.transferMap_kraus_isometry,
+        MPSTensor.isLeftCanonical_kraus_isometry,
+        MPSTensor.isInjective_kraus_isometry,
+        MPSTensor.isInjective_of_kraus_mixing_isInjective,
+        MPSTensor.isInjective_kraus_isometry_iff,
+        MPSTensor.GaugeEquiv.sum_smul,
+        MPOTensor.doubledPhysicalMatrix_isometry,
+        MPOTensor.toMPSTensor_changePhysicalBasis,
+        MPOTensor.transferMap_toMPSTensor_changePhysicalBasis,
+        MPOTensor.isInjective_toMPSTensor_changePhysicalBasis_iff,
+        MPOTensor.isLeftCanonical_toMPSTensor_changePhysicalBasis,
+        MPOTensor.isNormalTensor_toMPSTensor_changePhysicalBasis_iff,
+        MPOTensor.IsMPDO.changePhysicalBasis,
+        MPOTensor.isMPDO_changePhysicalBasis_iff,
+        MPOTensor.IsSAL.changePhysicalBasis_of_isometry,
+        MPOTensor.isSAL_changePhysicalBasis_iff,
+        MPOTensor.physTraceTransfer_changePhysicalBasis,
+        MPOTensor.gaugeEquiv_toMPSTensor_changePhysicalBasis,
+        MPOTensor.physicalSliceColumnCoisometry,
+        MPOTensor.physicalSliceColumnCoisometry_mul_conjTranspose,
+        MPOTensor.physicalSliceColumns_changePhysicalBasis,
+        MPOTensor.physicalSliceColumns_mul_conjTranspose_changePhysicalBasis,
+        MPOTensor.physicalSupportProj_changePhysicalBasis}
+    \leanok
+    \uses{def:mpdo_doubled_physical_matrix, def:injective,
+        def:left_canonical_tensor, def:nt_cpsv, def:gauge_equiv,
+        def:mpdo, def:is_sal}
+    Let $\mathcal K=\{\mathcal K^{pq}\}_{p,q=0}^{d-1}$ be an MPO tensor and
+    set
+    $\mathcal K_V^{ij}=\sum_{p,q}V_{i,p}\overline{V_{j,q}}\mathcal K^{pq}$.
+    Write $A^{(p,q)}=\mathcal K^{pq}$ and
+    $A_V^{(i,j)}=\mathcal K_V^{ij}$ for the associated doubled-index MPS
+    tensors.  For every $V$, the matrix in
+    (\ref{eq:mpdo_doubled_physical_matrix}) satisfies
+    $A_V^\tau=\sum_\sigma W_{\tau,\sigma}A^\sigma$.
+
+    Suppose now that $V^\dagger V=\Id$. Then
+    \begin{align}
+        W^\dagger W &=\Id,
+        & \E_{A_V} &=\E_A,
+        \label{eq:mpdo_embedding_transfer} \\
+        A_V\text{ is injective}
+          &\Longleftrightarrow A\text{ is injective},
+        & A_V\text{ is normal}
+          &\Longleftrightarrow A\text{ is normal},
+        \notag \\
+        \mathcal K_V\text{ is an MPDO}
+          &\Longleftrightarrow \mathcal K\text{ is an MPDO},
+        & \mathcal K_V\text{ saturates the area law}
+          &\Longleftrightarrow \mathcal K\text{ saturates the area law},
+        \notag \\
+        \mathcal T_{\mathcal K_V} &=\mathcal T_{\mathcal K},
+        & P_{\mathcal K_V} &=V P_{\mathcal K}V^\dagger.
+        \label{eq:mpdo_embedding_trace_support}
+    \end{align}
+    Here $P_{\mathcal K}$ is the orthogonal projection onto the joint column
+    span of the physical slices of $\mathcal K$.  Left-canonical normalization
+    of $A$ implies left-canonical normalization of $A_V$.
+
+    For arbitrary $V$, positivity of every positive-length periodic operator
+    for $\mathcal K$ implies the same positivity for $\mathcal K_V$.
+    Moreover, if two doubled-index tensors are related by one virtual gauge,
+    applying the same $V$ to their physical indices preserves that gauge.
+
+    This theorem is project-derived and is not stated in
+    \cite{Cirac2016MPDO_arXiv}.  Its application is to the normal-block and
+    per-sector constructions in lines~217--246, 1628--1665, and 1740--1782 of
+    that source.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The $(\sigma,\rho)$ entry of $W^\dagger W$ factors into the product of
+    the corresponding ket and bra entries of $V^\dagger V$, which gives the
+    first identity in (\ref{eq:mpdo_embedding_transfer}).  Isometric mixing of
+    a Kraus family therefore gives the second identity.  Conversely, each
+    original matrix is recovered from the mixed family by
+    $A^\sigma=\sum_\tau\overline{W_{\tau,\sigma}}A_V^\tau$; this proves the
+    injectivity equivalence.  The transfer-map identity and the equivalence
+    between irreducibility of a Kraus family and of its transfer map preserve
+    the three clauses of normality without a new spectral argument.
+
+    At length $N$, the periodic operator of $\mathcal K_V$ is
+    $V^{\otimes N}\rho^{(N)}(\mathcal K)(V^{\otimes N})^\dagger$.
+    This proves positivity for arbitrary $V$.  Under the isometry hypothesis,
+    traces and the mutual informations of every contiguous block agree in the
+    two physical spaces, which gives the MPDO and area-law equivalences in
+    (\ref{eq:mpdo_embedding_trace_support}).  Contracting the two physical
+    indices and using $V^\dagger V=\Id$ gives the equality of the matrices
+    $\mathcal T$.
+
+    Finally, let $Z_{\mathcal K}$ stack all columns of all physical slices.
+    Directly from the definition,
+    $Z_{\mathcal K_V}=VZ_{\mathcal K}R$, where $R$ is the blockwise copy of
+    $V^\dagger$ and $RR^\dagger=\Id$.  Hence
+    $Z_{\mathcal K_V}Z_{\mathcal K_V}^\dagger
+      =VZ_{\mathcal K}Z_{\mathcal K}^\dagger V^\dagger$,
+    and taking column-support projections proves the last identity in
+    (\ref{eq:mpdo_embedding_trace_support}).  A common virtual similarity
+    distributes termwise through the physical sums, proving the gauge
+    assertion.
+\end{proof}


### PR DESCRIPTION
## Summary

Implements #7087: the exact doubled-physical-index bridge between `changePhysicalBasis` and `MPSTensor.transferMap_kraus_isometry`, plus the MPO-level isometric transport needed by the counterexample construction in #6775.

**Source-faithfulness boundary.** Every new declaration is a project-derived coordinate lemma; nothing here is a statement of arXiv:1606.00608. The CPSV16 passages (lines 217–246, 1628–1665, 1740–1782) are cited in docstrings and blueprint prose as construction context only, per the issue's instruction.

## New module: `TNLean/MPS/MPDO/PhysicalIsometricEmbedding.lean`

For `K : MPOTensor d D`, `V : Matrix (Fin e) (Fin d) ℂ`, `hV : Vᴴ * V = 1`:

- `doubledPhysicalMatrix`: the induced matrix on the doubled physical index, `W[(i,j),(p,q)] = V[i,p] * star (V[j,q])`, in the repository's `finProdFinEquiv` convention (ket/bra order and bra conjugation verified by extensional equality against `changePhysicalBasis_apply_eq_sum` — no alternative doubling convention introduced).
- `doubledPhysicalMatrix_isometry`: `Wᴴ * W = 1` from `Vᴴ * V = 1`.
- `toMPSTensor_changePhysicalBasis`: literal identity `(changePhysicalBasis V K).toMPSTensor = fun ij ↦ ∑ pq, W ij pq • K.toMPSTensor pq`.
- `transferMap_toMPSTensor_changePhysicalBasis`: transfer-map equality, by direct application of the existing `MPSTensor.transferMap_kraus_isometry`.
- `isInjective_toMPSTensor_changePhysicalBasis_iff`, `isLeftCanonical_toMPSTensor_changePhysicalBasis`, `isNormalTensor_toMPSTensor_changePhysicalBasis_iff`: injectivity, left-canonicality, and normality transport. Normality reuses only the transfer-map equality and the existing irreducible-family/transfer-map equivalence — no new Perron–Frobenius argument.
- `IsMPDO.changePhysicalBasis` (ascent, no isometry needed) and `isMPDO_changePhysicalBasis_iff` (with the existing descent).
- `IsSAL.changePhysicalBasis_of_isometry` (ascent from the existing trace and mutual-information equalities) and `isSAL_changePhysicalBasis_iff` (with the existing descent).
- `physTraceTransfer_changePhysicalBasis`: `physTraceTransfer (changePhysicalBasis V K) = physTraceTransfer K`.
- `physicalSupportProj_changePhysicalBasis`: `physicalSupportProj (changePhysicalBasis V K) = V * physicalSupportProj K * Vᴴ`, proved from the literal stacked-column `physicalSliceColumns` definition via `physicalSliceColumns_changePhysicalBasis` and the blockwise coisometry `physicalSliceColumnCoisometry` — no newly postulated support.
- `gaugeEquiv_toMPSTensor_changePhysicalBasis`: termwise gauge compatibility of doubled-index representatives under the same physical embedding; no second gauge notion.

## Layer refactor (per the issue's import-layer instruction)

The generic Kraus-isometry mixing lemmas `MPSTensor.transferMap_kraus_isometry` and `MPSTensor.isLeftCanonical_kraus_isometry` moved without proof duplication from the layer-5 `MPS/Periodic/Symmetry/Theorem41Forward.lean` into the new lower shared module `TNLean/MPS/Core/PhysicalIndexMixing.lean` (same declaration names; `MPS/MPDO` is layer 3b and cannot import `MPS/Periodic`). That module also hosts the new generic injectivity equivalence `isInjective_kraus_isometry_iff` and `GaugeEquiv.sum_smul`. `Theorem41Forward.lean` keeps its periodicity content and imports the new module.

## Blueprint

New disjoint chapter `blueprint/src/chapter/ch21_mpdo_rfp_physical_isometric_embeddings.tex` (one definition, one combined transport theorem, both `\leanok`; explicit project-derived disclaimer), `\input` from `ch21_mpdo_rfp.tex`. Disjoint from the files owned by #7067, #7063, #7078, and #7056.

## Verification

- `lake build` — full project, 10292 jobs, success.
- `lake exe lint_style --github` — clean.
- `python3 scripts/generate_import_aggregators.py --check` — current (36 generated files, 1032 modules).
- `check_oversized_lean_files.py`, `check_numbered_lean_files.py` — clean.
- `blueprint_lean_sync.py --update-lean-decls` + `lake exe checkdecls blueprint/lean_decls` — in sync, 6800/6800, exit 0.
- `check_reader_facing_prose.py --diff-base origin/main --ci` — clean.
- No `sorry`/`admit`/`axiom`/`native_decide`; merge-tree against current `origin/main` is conflict-free.

Closes #7087