### PR TITLE
docs(QCA): use mathematical support marker wording

### DIFF
--- a/TNLean/QCA/BipartiteSupportAlgebra.lean
+++ b/TNLean/QCA/BipartiteSupportAlgebra.lean
@@ -20,7 +20,7 @@ Schumacher--Werner/GNVW index construction.
 **Local fix (star-closed input):** The printed statement of GNVW Lemma 7 says only
 "subalgebra". Coefficient generation, one-sided and two-sided containment, and leastness remain
 valid for arbitrary algebra input, although every support-algebra declaration in this module uses
-the uniform `A : StarSubalgebra` interface. The commutant characterizations actually fail without
+the uniform `A : StarSubalgebra` input. The commutant characterizations actually fail without
 involution closure; `StarSubalgebra` is the necessary correction for those clauses.
 Schumacher--Werner,
 quant-ph/0405174, lines 1161--1171, instead derives adjoint closure of the support algebra


### PR DESCRIPTION
## Description

- Replace the software term “interface” by the mathematical term “input” in the consolidated GNVW support-algebra module marker.
- Preserve every declaration, theorem statement, proof, source anchor, paper-gap note, and Blueprint entry merged in #7086.
- Address the late exact-head #7086 review thread: https://github.com/LionSR/TNLean/pull/7086#discussion_r3839909951.

Codex produced the implementation and review repairs; LionSR reviewed the result and is accountable for it.

## Testing

- `lake build TNLean.QCA.BipartiteSupportAlgebra`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `git diff --check`

Closes #7098.