### PR TITLE
doc(blueprint): correct MPU Index Theorem citations

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -154,7 +154,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     with the input index of $\mathcal V$ gives a matrix product unitary tensor
     whose periodic operator is $U^{(N)}V^{(N)}$, in that order.  This is the
     concatenation tensor $\mathcal W$ in the proof of
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1888,7 +1888,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \uses{def:mpu, def:mpu_independent_tensor_product}
     The independent tensor product of two matrix product unitary tensors is a
     matrix product unitary tensor. This is the tensoring operation in the proof
-    of \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    of \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1980,7 +1980,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
          & =\ell(\mathcal U)\ell(\mathcal V).
     \end{align}
     This is the rank-multiplication ingredient for the tensoring case in the
-    proof of \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    proof of \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -4978,7 +4978,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\operatorname{ind}(\mathcal U)+\operatorname{ind}(\mathcal V).
     \end{align}
     This is the unrestricted tensor-product statement in
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 824--833.
 \end{lemma}
 
@@ -5000,7 +5000,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\operatorname{ind}(\mathcal U)+\operatorname{ind}(\mathcal V).
     \end{align}
     This is the common-block reduced-source version of
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 824--833.
 \end{lemma}
 
@@ -5090,7 +5090,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\operatorname{ind}(\mathcal U)+\operatorname{ind}(\mathcal U').
     \end{align}
     This is the unrestricted composition statement in
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 833--845.
 \end{lemma}
 
@@ -5121,7 +5121,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\operatorname{ind}(\mathcal U)+\operatorname{ind}(\mathcal U').
     \end{align}
     This is the six-block reduced-source version of
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 833--845.
 \end{lemma}
 
@@ -5268,8 +5268,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     is witnessed by such a path. They are admissibly equivalent if the blocked,
     ancilla-enlarged endpoints in Definition~\ref{def:equivalent-tensors} are
     joined by an admissible strict-equivalence path. The source arguments
-    motivating these additional path hypotheses are Proposition~IV.2,
-    Theorem~IV.3 and its following corollary, and the lemma following the
+    motivating these additional path hypotheses are Proposition~IV.5,
+    Theorem~IV.6, Corollary~IV.7, and the lemma following the
     symmetry-equivalence definitions in \cite{Cirac2017MPU}; the datum itself is
     introduced here and has no source-labelled counterpart.
     % Source lines: paper_v2.tex 733--910 and 1366--1380.
@@ -6255,7 +6255,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
               equivalent.
     \end{enumerate}
     This is the unrestricted statement of
-    \cite[Theorem~IV.3]{Cirac2017MPU}.
+    \cite[Theorem~IV.6]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 824--865.
 \end{theorem}
 
@@ -6290,7 +6290,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
               tensors with the same index are admissibly equivalent whenever the
               standard-form interpolation is supplied with an admissible path datum.
     \end{enumerate}
-    These are the conclusions of \cite[Theorem~IV.3]{Cirac2017MPU}, restricted
+    These are the conclusions of \cite[Theorem~IV.6]{Cirac2017MPU}, restricted
     to the explicit admissibility hypotheses above.
     % Source lines: paper_v2.tex 824--865.
 \end{theorem}
@@ -6322,7 +6322,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     paths of unitaries $u(p)$ and $v(p)$ such that the MPU
     $U^{(2k_0N)}(p)$ has standard form given by $u(p)$ and $v(p)$ for every
     $p\in[0,1]$. This is the reduced-source version of
-    \cite[Corollary following Theorem~IV.3]{Cirac2017MPU}.
+    \cite[Corollary~IV.7]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 867--910.
 \end{corollary}
 


### PR DESCRIPTION
### Motivation

- Chapter 28 inherited eleven citations identifying the MPU Index Theorem as Theorem IV.3. In `Papers/1703.09188/paper_v2.tex`, Section IV instead numbers the continuity proposition as IV.5, the theorem labelled `IndexTh` as IV.6, and its following standard-form corollary as IV.7.
- The source statement at lines 824--832 includes the clause “The index is additive by tensoring and composition” as item (ii). The corresponding Chapter 28 citations should therefore name Theorem IV.6(ii).

### Description

- Correct the seven inherited tensor-product and composition references to Theorem IV.6(ii).
- Correct the path-source paragraph to Proposition IV.5, Theorem IV.6, and Corollary IV.7.
- Correct the two full Index-Theorem references to Theorem IV.6 and the standard-form reference to Corollary IV.7.
- Preserve the genuine Proposition IV.2 citations and make no Lean declaration or proof change.
- Agent assistance: OpenAI Codex performed the source comparison, narrow edit, and validation under maintainer supervision.

### Testing

- `git diff --check`
- `rg -n 'Theorem~IV\.3' blueprint/src/chapter/ch28_mpu.tex` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch28_mpu.tex`
- `texra-blueprint paper-gaps check`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex`
- `latexindent -k -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch28_mpu.tex`
- `python3 scripts/blueprint_bibtex.py`
- `texra-blueprint web` with the pinned v0.3.7 plugin; generated citations display IV.5, IV.6, IV.6(ii), and IV.7 with no renderer errors
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls` was invoked after seeding dependency artifacts from the hot-main cache. The cache policy correctly omitted TNLean build artifacts because the hot cache was at a different revision, so the local command could not resolve `TNLean`; no aggregate rebuild was started. Exact-head pull-request CI supplies the authoritative declaration check.

---
Closes #7081
