### PR TITLE
style(Algebra): scope SwapTrace notation opens

### DIFF
--- a/TNLean/Algebra/SwapTrace.lean
+++ b/TNLean/Algebra/SwapTrace.lean
@@ -25,8 +25,7 @@ Kronecker product.
   invariants*, arXiv:1703.09188, lines 1608--1610][Cirac2017MPU]
 -/
 
-open scoped Matrix Kronecker
-open Matrix Finset BigOperators
+open scoped Matrix Kronecker BigOperators
 
 namespace Matrix
 


### PR DESCRIPTION
### Motivation

- A delayed exact-head review of PR #7091 found that `TNLean/Algebra/SwapTrace.lean` opened `Matrix`, `Finset`, and `BigOperators` as ordinary namespaces although the file is already inside `namespace Matrix`, qualifies every `Finset` declaration, and needs only the scoped big-operator notation.
- The correction is the narrow style and import-hygiene follow-up recorded in #7097 and discussion `r3839894326` on PR #7091.

### Description

- Replace the two namespace-opening lines by `open scoped Matrix Kronecker BigOperators`.
- Preserve both SWAP trace theorem statements, proofs, source citations, imports, and Blueprint entries exactly.
- Agent assistance: OpenAI Codex performed the one-line correction and targeted validation under maintainer supervision.

### Testing

- `lake build TNLean.Algebra.SwapTrace` (1932/1932, 7.1 seconds)
- `rg -n 'sorry|axiom|admit|native_decide|unsafeCast' TNLean/Algebra/SwapTrace.lean` (no matches)
- `python3 scripts/tactic_pattern_scan.py` (no pattern introduced or altered by this prose-level namespace change)
- `git diff --check`
- The exact-main worktree was seeded from hot-main for the target build; its reproducible `.lake` clone was removed immediately after validation.

---
Closes #7097
