### PR TITLE
feat(MPS/Core): add independent tensor products

### DIFF
--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -18,6 +18,7 @@ arbitrary remaining length.
 
 ## Main definitions
 
+* `finTupleProdEquiv`: splits a tuple of encoded product indices pointwise.
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
 * `finSuccArrowEquiv`: separates the first coordinate from a finite tuple.
@@ -25,6 +26,7 @@ arbitrary remaining length.
 
 ## Main statements
 
+* `finTupleProdEquiv_apply`: gives the two pointwise component tuples.
 * `finSuccArrowEquiv_apply`: gives the first coordinate and the remaining tuple.
 * `finSuccArrowEquiv_symm_apply`: reconstructs a tuple from its first coordinate and tail.
 * `finAddTwoArrowEquiv_apply`: gives the first two coordinates and the remaining tuple.
@@ -39,12 +41,28 @@ arbitrary remaining length.
 The fixed-length product coordinates are right-associated and are constructed
 recursively from Mathlib's `finTwoArrowEquiv` using `Fin.consEquiv`.  The
 variable-length equivalences use `Fin.consEquiv` to separate the prescribed
-initial coordinates from the remaining tuple.
+initial coordinates from the remaining tuple.  Product-valued tuples use
+Mathlib's canonical `finProdFinEquiv` at every coordinate.
 
 ## Tags
 
 finite tuples, equivalence, product coordinates
 -/
+
+/-- Split a finite tuple of canonically encoded product indices into its two
+component tuples. -/
+def finTupleProdEquiv (N d e : ℕ) :
+    (Fin N → Fin (d * e)) ≃ (Fin N → Fin d) × (Fin N → Fin e) :=
+  (Equiv.arrowCongr (Equiv.refl (Fin N)) finProdFinEquiv.symm).trans
+    (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ ↦ Fin d) (fun _ ↦ Fin e))
+
+/-- The product-tuple equivalence takes the quotient and remainder component
+at every coordinate. -/
+@[simp] theorem finTupleProdEquiv_apply (N d e : ℕ)
+    (σ : Fin N → Fin (d * e)) :
+    finTupleProdEquiv N d e σ =
+      (fun n ↦ (σ n).divNat, fun n ↦ (σ n).modNat) := by
+  rfl
 
 /-- The canonical right-associated identification of a three-coordinate
 function with a triple. -/

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -22,6 +22,7 @@ import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
+import TNLean.MPS.Core.TensorProduct
 import TNLean.MPS.Core.TransferMatrix
 import TNLean.MPS.Core.TransferPeripheral
 import TNLean.MPS.Core.WordFactor

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.LinearAlgebra.Matrix.Reindex
+import QICLean.Kraus.Word
+import TNLean.Algebra.FinTupleEquiv
+
+/-!
+# Independent tensor products of matrix product tensors
+
+For matrix product tensors (A=(A^i)_i) and (B=(B^k)_k), their independent
+tensor product has local matrices
+\[
+  (A\boxtimes B)^{(i,k)}=A^i\otimes B^k.
+\]
+Both the physical and virtual product indices use Mathlib's canonical
+`finProdFinEquiv` coordinates.  Word evaluation separates into the two
+pointwise component words.
+
+This construction is infrastructure for the sentence "The case of tensoring
+is trivial" in arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines
+824--845; the paper does not state it as a separate theorem.  The matrix
+product tensor notation agrees with the canonical-form block notation in
+arXiv:1606.00608, equation `II_CF1`, lines 214--245.  No canonical-form or
+normality assertion is made here.
+
+## Main definitions
+
+* `MPSTensor.tensorProduct` is the local Kronecker product in standard finite
+  product coordinates.
+
+## Main statements
+
+* `MPSTensor.tensorProduct_apply` gives its exact matrix entries.
+* `MPSTensor.evalWord_tensorProduct` separates a product-indexed word into its
+  two component word evaluations.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPSTensor
+
+variable {d D e E : ℕ}
+
+/-- The independent tensor product of two matrix product tensors, using
+`finProdFinEquiv` on both physical and virtual indices.
+
+This is infrastructure for the tensoring clause in arXiv:1703.09188, proof of
+Theorem `IndexTh` (ii), lines 824--845, rather than a separately stated result
+of that paper. -/
+def tensorProduct (A : MPSTensor d D) (B : MPSTensor e E) :
+    MPSTensor (d * e) (D * E) :=
+  fun ik ↦ Matrix.reindex finProdFinEquiv finProdFinEquiv
+    (A ik.divNat ⊗ₖ B ik.modNat)
+
+/-- Entry formula for the independent tensor product.
+
+This is the coordinate form of the tensoring infrastructure for
+arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845, not a
+separately stated theorem of the paper. -/
+@[simp] theorem tensorProduct_apply (A : MPSTensor d D) (B : MPSTensor e E)
+    (i : Fin d) (k : Fin e) (α β : Fin D) (γ δ : Fin E) :
+    tensorProduct A B (finProdFinEquiv (i, k))
+        (finProdFinEquiv (α, γ)) (finProdFinEquiv (β, δ)) =
+      A i α β * B k γ δ := by
+  simp only [tensorProduct, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply]
+  simp only [Equiv.symm_apply_apply]
+  change
+    A (finProdFinEquiv.symm (finProdFinEquiv (i, k))).1 α β *
+        B (finProdFinEquiv.symm (finProdFinEquiv (i, k))).2 γ δ =
+      A i α β * B k γ δ
+  rw [Equiv.symm_apply_apply]
+
+/-- Evaluating a word in the independent tensor product is the reindexed
+Kronecker product of the evaluations of its two pointwise component words.
+
+This is the word form of the tensoring construction used in
+arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845; it is
+infrastructure, not a separately stated theorem of the paper. -/
+theorem evalWord_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    (w : List (Fin (d * e))) :
+    Kraus.evalWord (tensorProduct A B) w =
+      Matrix.reindex finProdFinEquiv finProdFinEquiv
+        (Kraus.evalWord A (w.map Fin.divNat) ⊗ₖ
+          Kraus.evalWord B (w.map Fin.modNat)) := by
+  induction w with
+  | nil =>
+      simp [Kraus.evalWord]
+  | cons i w ih =>
+      simp only [Kraus.evalWord_cons, List.map_cons, tensorProduct]
+      rw [ih]
+      rw [← Matrix.coe_reindexRingEquiv ℂ finProdFinEquiv]
+      rw [← map_mul, Matrix.mul_kronecker_mul]
+
+end MPSTensor

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.Reindex
 import QICLean.Kraus.Word
-import TNLean.Algebra.FinTupleEquiv
 
 /-!
 # Independent tensor products of matrix product tensors

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.MatrixRankKronecker
 import QICLean.Algebra.TraceReindex
 import TNLean.MPS.MPU.Basic
@@ -68,8 +69,7 @@ def tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
 /-- Split a product-valued physical configuration site by site. -/
 def tensorProductConfigEquiv (N d e : ℕ) :
     (Fin N → Fin (d * e)) ≃ (Fin N → Fin d) × (Fin N → Fin e) :=
-  (Equiv.arrowCongr (Equiv.refl (Fin N)) finProdFinEquiv.symm).trans
-    (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ ↦ Fin d) (fun _ ↦ Fin e))
+  finTupleProdEquiv N d e
 
 /-- Split every letter of a blocked product alphabet and re-encode the two
 component words as a pair of blocked letters.
@@ -79,8 +79,7 @@ noncomputable def tensorProductBlockEquiv (d e L : ℕ) :
     Fin (MPSTensor.blockPhysDim (d * e) L) ≃
       Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim e L) :=
   (MPSTensor.decodeBlockEquiv (d * e) L).trans
-    ((Equiv.arrowCongr (Equiv.refl (Fin L)) finProdFinEquiv.symm).trans
-      (Equiv.arrowProdEquivProdArrow (Fin L) (fun _ ↦ Fin d) (fun _ ↦ Fin e))) |>.trans
+    (finTupleProdEquiv L d e) |>.trans
     (Equiv.prodCongr (MPSTensor.decodeBlockEquiv d L).symm
       (MPSTensor.decodeBlockEquiv e L).symm) |>.trans
     finProdFinEquiv
@@ -91,8 +90,7 @@ blocked product letters. -/
     (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
     MPSTensor.decodeBlock d L ((tensorProductBlockEquiv d e L I).divNat) k =
       (MPSTensor.decodeBlock (d * e) L I k).divNat := by
-  simp [tensorProductBlockEquiv, Equiv.arrowCongr,
-    MPSTensor.decodeBlockEquiv_apply]
+  simp [tensorProductBlockEquiv, MPSTensor.decodeBlockEquiv_apply]
 
 /-- Decoding the second blocked component gives the pointwise remainder of the
 blocked product letters. -/
@@ -100,8 +98,7 @@ blocked product letters. -/
     (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
     MPSTensor.decodeBlock e L ((tensorProductBlockEquiv d e L I).modNat) k =
       (MPSTensor.decodeBlock (d * e) L I k).modNat := by
-  simp [tensorProductBlockEquiv, Equiv.arrowCongr,
-    MPSTensor.decodeBlockEquiv_apply]
+  simp [tensorProductBlockEquiv, MPSTensor.decodeBlockEquiv_apply]
 
 private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
     (is js : List (Fin (d * e))) :
@@ -161,7 +158,7 @@ theorem mpo_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) (N : ℕ) :
   simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.kroneckerMap_apply,
     mpo_apply, mpoMatrixEntry]
   rw [evalWord_tensorProduct, Matrix.trace_reindex, Matrix.trace_kronecker]
-  simp [tensorProductConfigEquiv, Equiv.arrowCongr, Function.comp_def]
+  simp [tensorProductConfigEquiv, Function.comp_def]
 
 /-- Independent tensor products of matrix product unitaries are matrix product
 unitaries.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1803,6 +1803,81 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     fact to the two source-cut identities.
 \end{proof}
 
+\begin{definition}[Independent tensor product of matrix product tensors]
+    \label{def:mps_independent_tensor_product}
+    \lean{finTupleProdEquiv, MPSTensor.tensorProduct,
+        MPSTensor.tensorProduct_apply}
+    \leanok
+    \uses{def:mps_tensor}
+    Let $A=(A^i)_{i\in\Fin d}$ and $B=(B^k)_{k\in\Fin e}$ have
+    auxiliary dimensions $D$ and $E$, respectively.  Write
+    \begin{align}
+        \pi_{m,n}:\Fin m\times\Fin n & \longrightarrow\Fin{mn}
+    \end{align}
+    for the standard finite-product coordinate bijection.  Their independent
+    tensor product $A\boxtimes B$ has physical dimension $de$, auxiliary
+    dimension $DE$, and local matrices determined by
+    \begin{align}
+        (A\boxtimes B)^{\pi_{d,e}(i,k)}_{
+            \pi_{D,E}(\alpha,\gamma),\pi_{D,E}(\beta,\delta)}
+         & =A^i_{\alpha,\beta}B^k_{\gamma,\delta}.
+        \label{eq:mps_independent_tensor_product_entries}
+    \end{align}
+    For every $N$, the same coordinates give the pointwise splitting
+    \begin{align}
+        (\Fin N\to\Fin{de})
+                  & \simeq(\Fin N\to\Fin d)\times(\Fin N\to\Fin e), \\
+        \sigma    & \longmapsto(\sigma_d,\sigma_e),
+                  &
+        \sigma(n) & =\pi_{d,e}(\sigma_d(n),\sigma_e(n)).
+        \label{eq:mps_tensor_product_tuple_split}
+    \end{align}
+    This is infrastructure for the tensoring clause in the proof of the MPU
+    Index Theorem~IV.6(ii)
+    \cite[lines~824--845]{Cirac2017MPU}, not a separately stated theorem of
+    that paper.  The notation $A=(A^i)_i$ agrees with the canonical-form block
+    notation around equation~\textup{II\_CF1} in
+    \cite[lines~214--245]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Word evaluation of an independent tensor product]
+    \label{thm:mps_eval_word_independent_tensor_product}
+    \lean{MPSTensor.evalWord_tensorProduct}
+    \leanok
+    \uses{def:mps_independent_tensor_product}
+    If
+    \begin{align}
+        w   & =\bigl(\pi_{d,e}(i_1,k_1),\ldots,
+        \pi_{d,e}(i_L,k_L)\bigr),               \\
+        w_d & =(i_1,\ldots,i_L),
+            &
+        w_e & =(k_1,\ldots,k_L),
+    \end{align}
+    then
+    \begin{align}
+        \operatorname{eval}_{A\boxtimes B}(w)
+         & =\operatorname{reind}_{\pi_{D,E}}
+        \left(\operatorname{eval}_A(w_d)\otimes
+        \operatorname{eval}_B(w_e)\right).
+        \label{eq:mps_eval_word_independent_tensor_product}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mps_independent_tensor_product}
+    Induct on the length of $w$.  For the empty word, use
+    $\mathbf 1_D\otimes\mathbf 1_E=\mathbf 1_{DE}$ and invariance of the
+    identity under the coordinate bijection.  For a leading letter
+    $\pi_{d,e}(i,k)$, equation
+    (\ref{eq:mps_independent_tensor_product_entries}) and the induction
+    hypothesis reduce the claim to
+    \begin{align}
+        (A^i\otimes B^k)(X\otimes Y)
+         & =(A^iX)\otimes(B^kY),
+    \end{align}
+    after transporting multiplication through the same coordinate bijection.
+\end{proof}
+
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
     \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1836,15 +1836,14 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Index Theorem~IV.6(ii)
     \cite[lines~824--845]{Cirac2017MPU}, not a separately stated theorem of
     that paper.  The notation $A=(A^i)_i$ agrees with the canonical-form block
-    notation around equation~\textup{II\_CF1} in
-    \cite[lines~214--245]{Cirac2016MPDO_arXiv}.
+    notation in \cite[Section~2.3, lines~214--245]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[Word evaluation of an independent tensor product]
     \label{thm:mps_eval_word_independent_tensor_product}
     \lean{MPSTensor.evalWord_tensorProduct}
     \leanok
-    \uses{def:mps_independent_tensor_product}
+    \uses{def:mps_independent_tensor_product, def:eval_word}
     If $w$ has length $n$ and
     \begin{align}
         w   & =\bigl(\pi_{d,e}(i_1,k_1),\ldots,
@@ -1863,7 +1862,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mps_independent_tensor_product}
+    \uses{def:mps_independent_tensor_product, def:eval_word}
     Induct on the length of $w$.  For the empty word, use
     $\mathbf 1_D\otimes\mathbf 1_E=\mathbf 1_{DE}$ and invariance of the
     identity under the coordinate bijection.  For a leading letter

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1805,8 +1805,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Independent tensor product of matrix product tensors]
     \label{def:mps_independent_tensor_product}
-    \lean{finTupleProdEquiv, MPSTensor.tensorProduct,
-        MPSTensor.tensorProduct_apply}
+    \lean{finTupleProdEquiv, finTupleProdEquiv_apply,
+        MPSTensor.tensorProduct, MPSTensor.tensorProduct_apply}
     \leanok
     \uses{def:mps_tensor}
     Let $A=(A^i)_{i\in\Fin d}$ and $B=(B^k)_{k\in\Fin e}$ have
@@ -1864,7 +1864,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{def:mps_independent_tensor_product, def:eval_word}
     Induct on the length of $w$.  For the empty word, use
-    $\mathbf 1_D\otimes\mathbf 1_E=\mathbf 1_{DE}$ and invariance of the
+    $\Id_D\otimes\Id_E=\Id_{DE}$ and invariance of the
     identity under the coordinate bijection.  For a leading letter
     $\pi_{d,e}(i,k)$, equation
     (\ref{eq:mps_independent_tensor_product_entries}) and the induction

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1845,20 +1845,19 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPSTensor.evalWord_tensorProduct}
     \leanok
     \uses{def:mps_independent_tensor_product}
-    If
+    If $w$ has length $n$ and
     \begin{align}
         w   & =\bigl(\pi_{d,e}(i_1,k_1),\ldots,
-        \pi_{d,e}(i_L,k_L)\bigr),               \\
-        w_d & =(i_1,\ldots,i_L),
+        \pi_{d,e}(i_n,k_n)\bigr),               \\
+        w_d & =(i_1,\ldots,i_n),
             &
-        w_e & =(k_1,\ldots,k_L),
+        w_e & =(k_1,\ldots,k_n),
     \end{align}
     then
     \begin{align}
-        \operatorname{eval}_{A\boxtimes B}(w)
+        (A\boxtimes B)^w
          & =\operatorname{reind}_{\pi_{D,E}}
-        \left(\operatorname{eval}_A(w_d)\otimes
-        \operatorname{eval}_B(w_e)\right).
+        \left(A^{w_d}\otimes B^{w_e}\right).
         \label{eq:mps_eval_word_independent_tensor_product}
     \end{align}
 \end{theorem}


### PR DESCRIPTION
### Motivation

- Provide the neutral MPS tensor-product operation and word API required by the tensoring clause of the MPU Index Theorem.
- Source: `Papers/1703.09188/paper_v2.tex`, Theorem `IndexTh` (ii), lines 824--845, especially the sentence “The case of tensoring is trivial” at line 837.
- The construction follows the matrix-product tensor notation around `II_CF1` in `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 214--245. It is reusable infrastructure for `IndexTh` (ii), not a separately stated theorem of either paper.

### Description

- Add the neutral equivalence `finTupleProdEquiv`, which splits a tuple of `Fin (d * e)` indices pointwise through the existing `finProdFinEquiv` coordinates.
- Define `MPSTensor.tensorProduct` by the local Kronecker product, together with its exact entry formula and the fixed-word identity `MPSTensor.evalWord_tensorProduct` using `w.map Fin.divNat` and `w.map Fin.modNat`.
- Make the existing MPU configuration and blocking coordinates reuse the neutral tuple split; no source-cut, rank, selected-factor, CFII, or normality result is repeated.
- Add a formula-driven Chapter 28 definition and word-evaluation entry, with source language explicitly distinguishing this infrastructure from a paper theorem.

### Testing

Before the serial rebase, the identical logical implementation patch passed these targeted linter-bearing builds:

- `lake build TNLean.Algebra.FinTupleEquiv TNLean.MPS.Core.TensorProduct`
- `lake build TNLean.MPS.MPU.TensorProduct`
- a final `lake build TNLean.MPS.Core.TensorProduct`, with the target `.olean` verified

The branch was subsequently rebased conflict-free from `ec06c3317eda041002a9683a16586cc621c564cf` onto exact main `2650db66ae599df917f8bfcdc1ee4ec6055de4a8`. The rebase range-diff marked both then-existing commits equal; their stable patch IDs remained `bbacd8bc642c27fe66eed063be14e55ca002c1f4` for the implementation and `55a35d5feeb7917fc8420d94c68e977bfd1e5216` for the notation repair.

At current exact head `f4440b84a39709b13566799e2d41850853a80dd0`, the consolidated final review repair adds `finTupleProdEquiv_apply` to the Blueprint declaration list, uses the established `\Id` notation in the empty-word proof, and removes the unused `TNLean.Algebra.FinTupleEquiv` import from the Core tensor-product module. The Lean proof bodies and mathematical formulas are unchanged.

Proportionate local checks after that repair passed: direct elaboration of `TNLean/MPS/Core/TensorProduct.lean` against an already-present Mathlib/QICLean dependency cache, reader-facing prose, Chapter 28 tenkz lint, `chktex`, edited-region `latexindent`, and `git diff --check`. The target worktree `.lake` remained absent; the direct elaboration was not a package linter build.

Exact-head PR CI run `32755110224` passed the full Lean build, changed-module timing gate, Lean and text policies, Blueprint compilation, declaration checking and source synchronization, and the remaining repository policy jobs. This exact-head CI is authoritative for package linter and Blueprint evidence.

Closes #7083