### PR TITLE
feat(MPS/CanonicalForm): preserve tensor-product normality

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -43,3 +43,4 @@ import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
 import TNLean.MPS.CanonicalForm.QuadraticReconstruction
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.CanonicalForm.SectorComparison
+import TNLean.MPS.CanonicalForm.TensorProduct

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Core.TensorProductSpan
+
+/-!
+# Independent tensor products of left-canonical normal blocks
+
+This module packages the algebraic tensor-product argument for the retained
+normal blocks of the canonical-form decomposition.  The product is
+left-canonical by a direct Kronecker calculation, algebraically normal by the
+common homogeneous word-span length, and hence a CPSV normal tensor by the
+established left-canonical bridge.
+
+The result is project infrastructure for the tensoring clause in
+arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845; it is not a
+separately stated theorem of that paper.  The retained-normal-block terminology
+comes from arXiv:1606.00608, equation `II_CF1`, lines 224--245.  The two
+left-canonical identities are explicit project hypotheses, not an additional
+claim attributed to that passage.
+
+## Main statement
+
+* `MPSTensor.IsNormalTensor.tensorProduct` preserves CPSV normality for two
+  left-canonical normal blocks; `MPSTensor.leftCanonical_tensorProduct`
+  supplies the accompanying left-canonical conclusion.
+-/
+
+namespace MPSTensor
+
+variable {d D e E : ℕ}
+
+/-- The independent tensor product of two left-canonical CPSV normal blocks is
+again a CPSV normal tensor.  Its left-canonicality is the conclusion of
+`MPSTensor.leftCanonical_tensorProduct`.
+
+For normal blocks `A` and `B`, algebraic normality follows at the synchronized
+homogeneous word length `N_A N_B`, while the two identities
+\[
+  \sum_i (A^i)^\dagger A^i=\mathbf 1_D,
+  \qquad
+  \sum_k (B^k)^\dagger B^k=\mathbf 1_E
+\]
+give left-canonicality of `A \boxtimes B`.  The theorem then applies
+`MPSTensor.isNormalTensor_of_isNormal_leftCanonical`.
+
+This is infrastructure for arXiv:1703.09188, proof of Theorem `IndexTh` (ii),
+lines 824--845, not a separate result asserted there.  The normal-block and
+left-canonical hypotheses are the project inputs for the retained
+canonical-form blocks described around arXiv:1606.00608, equation `II_CF1`,
+lines 224--245; the passage itself is not cited as asserting left-canonicality.
+-/
+theorem IsNormalTensor.tensorProduct {A : MPSTensor d D} (hA : IsNormalTensor A)
+    {B : MPSTensor e E} (hB : IsNormalTensor B)
+    (hLeftA : IsLeftCanonical A) (hLeftB : IsLeftCanonical B) :
+    IsNormalTensor (tensorProduct A B) := by
+  let _ : NeZero (D * E) :=
+    ⟨Nat.mul_ne_zero hA.bondDim_ne_zero hB.bondDim_ne_zero⟩
+  exact isNormalTensor_of_isNormal_leftCanonical (tensorProduct A B)
+    (isNormal_tensorProduct A B hA.isNormal hB.isNormal)
+    (leftCanonical_tensorProduct A B hLeftA hLeftB)
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -56,10 +56,10 @@ lines 224--245; the passage itself is not cited as asserting left-canonicality.
 theorem IsNormalTensor.tensorProduct {A : MPSTensor d D} (hA : IsNormalTensor A)
     {B : MPSTensor e E} (hB : IsNormalTensor B)
     (hLeftA : IsLeftCanonical A) (hLeftB : IsLeftCanonical B) :
-    IsNormalTensor (tensorProduct A B) := by
+    IsNormalTensor (MPSTensor.tensorProduct A B) := by
   let _ : NeZero (D * E) :=
     ⟨Nat.mul_ne_zero hA.bondDim_ne_zero hB.bondDim_ne_zero⟩
-  exact isNormalTensor_of_isNormal_leftCanonical (tensorProduct A B)
+  exact isNormalTensor_of_isNormal_leftCanonical (MPSTensor.tensorProduct A B)
     (isNormal_tensorProduct A B hA.isNormal hB.isNormal)
     (leftCanonical_tensorProduct A B hLeftA hLeftB)
 

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -18,13 +18,13 @@ established left-canonical bridge.
 The result is project infrastructure for the tensoring clause in
 arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845; it is not a
 separately stated theorem of that paper.  The retained-normal-block terminology
-comes from arXiv:1606.00608, equation `II_CF1`, lines 224--245.  The two
+comes from arXiv:1606.00608, equation `II_CF1`, lines 214--245.  The two
 left-canonical identities are explicit project hypotheses, not an additional
 claim attributed to that passage.
 
 ## Main statement
 
-* `MPSTensor.IsNormalTensor.tensorProduct` preserves CPSV normality for two
+* `MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical` preserves CPSV normality for two
   left-canonical normal blocks; `MPSTensor.leftCanonical_tensorProduct`
   supplies the accompanying left-canonical conclusion.
 -/
@@ -51,9 +51,10 @@ This is infrastructure for arXiv:1703.09188, proof of Theorem `IndexTh` (ii),
 lines 824--845, not a separate result asserted there.  The normal-block and
 left-canonical hypotheses are the project inputs for the retained
 canonical-form blocks described around arXiv:1606.00608, equation `II_CF1`,
-lines 224--245; the passage itself is not cited as asserting left-canonicality.
+lines 214--245; the passage itself is not cited as asserting left-canonicality.
 -/
-theorem IsNormalTensor.tensorProduct {A : MPSTensor d D} (hA : IsNormalTensor A)
+theorem IsNormalTensor.tensorProduct_of_leftCanonical {A : MPSTensor d D}
+    (hA : IsNormalTensor A)
     {B : MPSTensor e E} (hB : IsNormalTensor B)
     (hLeftA : IsLeftCanonical A) (hLeftB : IsLeftCanonical B) :
     IsNormalTensor (MPSTensor.tensorProduct A B) := by

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -24,9 +24,9 @@ claim attributed to that passage.
 
 ## Main statement
 
-* `MPSTensor.IsNormalTensor.tensor_product_of_left_canonical` preserves CPSV
+* `MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical` preserves CPSV
   normality for two left-canonical normal blocks;
-  `MPSTensor.left_canonical_tensor_product`
+  `MPSTensor.leftCanonical_tensorProduct`
   supplies the accompanying left-canonical conclusion.
 
 ## References
@@ -43,7 +43,7 @@ variable {d D e E : ℕ}
 
 /-- The independent tensor product of two left-canonical CPSV normal blocks is
 again a CPSV normal tensor.  Its left-canonicality is the conclusion of
-`MPSTensor.left_canonical_tensor_product`.
+`MPSTensor.leftCanonical_tensorProduct`.
 
 For normal blocks `A` and `B`, algebraic normality follows at the common
 homogeneous word length `N_A N_B`, while the two identities
@@ -61,7 +61,7 @@ left-canonical hypotheses are the project inputs for the retained
 canonical-form blocks described around arXiv:1606.00608, equation `II_CF1`,
 lines 214--245; the passage itself is not cited as asserting left-canonicality.
 -/
-theorem IsNormalTensor.tensor_product_of_left_canonical {A : MPSTensor d D}
+theorem IsNormalTensor.tensorProduct_of_leftCanonical {A : MPSTensor d D}
     (hA : IsNormalTensor A)
     {B : MPSTensor e E} (hB : IsNormalTensor B)
     (hLeftA : IsLeftCanonical A) (hLeftB : IsLeftCanonical B) :
@@ -69,7 +69,7 @@ theorem IsNormalTensor.tensor_product_of_left_canonical {A : MPSTensor d D}
   let _ : NeZero (D * E) :=
     ⟨Nat.mul_ne_zero hA.bondDim_ne_zero hB.bondDim_ne_zero⟩
   exact isNormalTensor_of_isNormal_leftCanonical (MPSTensor.tensorProduct A B)
-    (is_normal_tensor_product A B hA.isNormal hB.isNormal)
-    (left_canonical_tensor_product A B hLeftA hLeftB)
+    (isNormal_tensorProduct A B hA.isNormal hB.isNormal)
+    (leftCanonical_tensorProduct A B hLeftA hLeftB)
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -37,7 +37,7 @@ variable {d D e E : ℕ}
 again a CPSV normal tensor.  Its left-canonicality is the conclusion of
 `MPSTensor.leftCanonical_tensorProduct`.
 
-For normal blocks `A` and `B`, algebraic normality follows at the synchronized
+For normal blocks `A` and `B`, algebraic normality follows at the common
 homogeneous word length `N_A N_B`, while the two identities
 \[
   \sum_i (A^i)^\dagger A^i=\mathbf 1_D,

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -24,9 +24,17 @@ claim attributed to that passage.
 
 ## Main statement
 
-* `MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical` preserves CPSV normality for two
-  left-canonical normal blocks; `MPSTensor.leftCanonical_tensorProduct`
+* `MPSTensor.IsNormalTensor.tensor_product_of_left_canonical` preserves CPSV
+  normality for two left-canonical normal blocks;
+  `MPSTensor.left_canonical_tensor_product`
   supplies the accompanying left-canonical conclusion.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Unitaries:
+  Structure, Symmetries, and Topological Invariants*, arXiv:1703.09188.
+* Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608.
 -/
 
 namespace MPSTensor
@@ -35,7 +43,7 @@ variable {d D e E : ℕ}
 
 /-- The independent tensor product of two left-canonical CPSV normal blocks is
 again a CPSV normal tensor.  Its left-canonicality is the conclusion of
-`MPSTensor.leftCanonical_tensorProduct`.
+`MPSTensor.left_canonical_tensor_product`.
 
 For normal blocks `A` and `B`, algebraic normality follows at the common
 homogeneous word length `N_A N_B`, while the two identities
@@ -53,7 +61,7 @@ left-canonical hypotheses are the project inputs for the retained
 canonical-form blocks described around arXiv:1606.00608, equation `II_CF1`,
 lines 214--245; the passage itself is not cited as asserting left-canonicality.
 -/
-theorem IsNormalTensor.tensorProduct_of_leftCanonical {A : MPSTensor d D}
+theorem IsNormalTensor.tensor_product_of_left_canonical {A : MPSTensor d D}
     (hA : IsNormalTensor A)
     {B : MPSTensor e E} (hB : IsNormalTensor B)
     (hLeftA : IsLeftCanonical A) (hLeftB : IsLeftCanonical B) :
@@ -61,7 +69,7 @@ theorem IsNormalTensor.tensorProduct_of_leftCanonical {A : MPSTensor d D}
   let _ : NeZero (D * E) :=
     ⟨Nat.mul_ne_zero hA.bondDim_ne_zero hB.bondDim_ne_zero⟩
   exact isNormalTensor_of_isNormal_leftCanonical (MPSTensor.tensorProduct A B)
-    (isNormal_tensorProduct A B hA.isNormal hB.isNormal)
-    (leftCanonical_tensorProduct A B hLeftA hLeftB)
+    (is_normal_tensor_product A B hA.isNormal hB.isNormal)
+    (left_canonical_tensor_product A B hLeftA hLeftB)
 
 end MPSTensor

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -23,6 +23,7 @@ import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.TensorProduct
+import TNLean.MPS.Core.TensorProductSpan
 import TNLean.MPS.Core.TransferMatrix
 import TNLean.MPS.Core.TransferPeripheral
 import TNLean.MPS.Core.WordFactor

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -115,7 +115,7 @@ then the Kronecker multiplication and adjoint identities give
 This is project infrastructure for the tensoring clause in arXiv:1703.09188,
 proof of Theorem `IndexTh` (ii), lines 824--845, not a result stated separately
 in that paper.  The retained-normal-block context is
-arXiv:1606.00608, equation `II_CF1`, lines 224--245; the two left-canonical
+arXiv:1606.00608, equation `II_CF1`, lines 214--245; the two left-canonical
 identities are explicit project hypotheses, not an assertion attributed to
 that passage. -/
 theorem leftCanonical_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -37,7 +37,7 @@ normality assertion is made here.
 * `MPSTensor.tensorProduct_apply` gives its exact matrix entries.
 * `MPSTensor.evalWord_tensorProduct` separates a product-indexed word into its
   two component word evaluations.
-* `MPSTensor.left_canonical_tensor_product` proves left-canonicality directly
+* `MPSTensor.leftCanonical_tensorProduct` proves left-canonicality directly
   from the two constituent normalization identities.
 -/
 
@@ -118,7 +118,7 @@ in that paper.  The retained-normal-block context is
 arXiv:1606.00608, equation `II_CF1`, lines 214--245; the two left-canonical
 identities are explicit project hypotheses, not an assertion attributed to
 that passage. -/
-theorem left_canonical_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
+theorem leftCanonical_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     (hA : IsLeftCanonical A) (hB : IsLeftCanonical B) :
     IsLeftCanonical (tensorProduct A B) := by
   classical

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -37,7 +37,7 @@ normality assertion is made here.
 * `MPSTensor.tensorProduct_apply` gives its exact matrix entries.
 * `MPSTensor.evalWord_tensorProduct` separates a product-indexed word into its
   two component word evaluations.
-* `MPSTensor.leftCanonical_tensorProduct` proves left-canonicality directly
+* `MPSTensor.left_canonical_tensor_product` proves left-canonicality directly
   from the two constituent normalization identities.
 -/
 
@@ -118,7 +118,7 @@ in that paper.  The retained-normal-block context is
 arXiv:1606.00608, equation `II_CF1`, lines 214--245; the two left-canonical
 identities are explicit project hypotheses, not an assertion attributed to
 that passage. -/
-theorem leftCanonical_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+theorem left_canonical_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
     (hA : IsLeftCanonical A) (hB : IsLeftCanonical B) :
     IsLeftCanonical (tensorProduct A B) := by
   classical

--- a/TNLean/MPS/Core/TensorProduct.lean
+++ b/TNLean/MPS/Core/TensorProduct.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.Reindex
 import QICLean.Kraus.Word
+import TNLean.MPS.Core.CanonicalNormalization
 
 /-!
 # Independent tensor products of matrix product tensors
@@ -36,6 +37,8 @@ normality assertion is made here.
 * `MPSTensor.tensorProduct_apply` gives its exact matrix entries.
 * `MPSTensor.evalWord_tensorProduct` separates a product-indexed word into its
   two component word evaluations.
+* `MPSTensor.leftCanonical_tensorProduct` proves left-canonicality directly
+  from the two constituent normalization identities.
 -/
 
 open scoped Matrix Kronecker
@@ -94,5 +97,71 @@ theorem evalWord_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
       rw [ih]
       rw [← Matrix.coe_reindexRingEquiv ℂ finProdFinEquiv]
       rw [← map_mul, Matrix.mul_kronecker_mul]
+
+/-- Independent tensor products preserve left-canonical normalization.
+
+If `A` and `B` satisfy
+\[
+  \sum_i (A^i)^\dagger A^i=\mathbf 1_D,
+  \qquad
+  \sum_k (B^k)^\dagger B^k=\mathbf 1_E,
+\]
+then the Kronecker multiplication and adjoint identities give
+\[
+  \sum_{i,k} ((A^i\otimes B^k)^\dagger)(A^i\otimes B^k)
+  =\mathbf 1_D\otimes\mathbf 1_E=\mathbf 1_{DE}.
+\]
+
+This is project infrastructure for the tensoring clause in arXiv:1703.09188,
+proof of Theorem `IndexTh` (ii), lines 824--845, not a result stated separately
+in that paper.  The retained-normal-block context is
+arXiv:1606.00608, equation `II_CF1`, lines 224--245; the two left-canonical
+identities are explicit project hypotheses, not an assertion attributed to
+that passage. -/
+theorem leftCanonical_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    (hA : IsLeftCanonical A) (hB : IsLeftCanonical B) :
+    IsLeftCanonical (tensorProduct A B) := by
+  classical
+  unfold IsLeftCanonical
+  unfold IsLeftCanonical at hA hB
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  have hterm (i : Fin d) (k : Fin e) :
+      (tensorProduct A B (finProdFinEquiv (i, k)))ᴴ *
+          tensorProduct A B (finProdFinEquiv (i, k)) =
+        Matrix.reindex finProdFinEquiv finProdFinEquiv
+          (((A i)ᴴ * A i) ⊗ₖ ((B k)ᴴ * B k)) := by
+    have hi : (finProdFinEquiv (i, k) : Fin (d * e)).divNat = i :=
+      congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, k))
+    have hk : (finProdFinEquiv (i, k) : Fin (d * e)).modNat = k :=
+      congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, k))
+    simp only [tensorProduct, hi, hk]
+    rw [Matrix.conjTranspose_reindex]
+    change Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+          ((A i ⊗ₖ B k)ᴴ) *
+        Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+          (A i ⊗ₖ B k) =
+      Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+        (((A i)ᴴ * A i) ⊗ₖ ((B k)ᴴ * B k))
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ finProdFinEquiv finProdFinEquiv
+      finProdFinEquiv, Matrix.conjTranspose_kronecker, Matrix.mul_kronecker_mul]
+  simp_rw [hterm]
+  change ∑ i : Fin d, ∑ k : Fin e,
+      Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+        (((A i)ᴴ * A i) ⊗ₖ ((B k)ᴴ * B k)) = 1
+  apply (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv).symm.injective
+  simp only [map_sum, LinearEquiv.symm_apply_apply]
+  rw [Matrix.symm_reindexLinearEquiv, Matrix.reindexLinearEquiv_one]
+  have hsum :
+      (∑ i : Fin d, ∑ k : Fin e, ((A i)ᴴ * A i) ⊗ₖ ((B k)ᴴ * B k)) =
+        (∑ i : Fin d, (A i)ᴴ * A i) ⊗ₖ (∑ k : Fin e, (B k)ᴴ * B k) := by
+    symm
+    change Matrix.kroneckerBilinear (R := ℂ) (α := ℂ)
+      (∑ i : Fin d, (A i)ᴴ * A i) (∑ k : Fin e, (B k)ᴴ * B k) = _
+    rw [map_sum]
+    simp_rw [map_sum]
+    rw [Finset.sum_comm]
+    simp only [LinearMap.sum_apply]
+    rfl
+  rw [hsum, hA, hB, Matrix.one_kronecker_one]
 
 end MPSTensor

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.RingTheory.MatrixAlgebra
 import QICLean.Kraus.Injectivity
 import QICLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Algebra.FinTupleEquiv

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -22,7 +22,7 @@ This is project infrastructure for the sentence "The case of tensoring is
 trivial" in arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845;
 the paper does not state a separate normality theorem here.  The tensors to
 which this infrastructure is applied are the retained normal blocks of
-arXiv:1606.00608, equation `II_CF1`, lines 224--245.
+arXiv:1606.00608, equation `II_CF1`, lines 214--245.
 
 ## Main statements
 
@@ -57,7 +57,7 @@ This is infrastructure for arXiv:1703.09188, proof of Theorem `IndexTh` (ii),
 lines 824--845, rather than a separately stated theorem of that paper.  Its
 homogeneous-word route supplies the project's algebraic-normality input for
 the retained blocks described around arXiv:1606.00608, equation `II_CF1`,
-lines 224--245. -/
+lines 214--245. -/
 theorem wordSpan_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     (N : ℕ) :
     Kraus.wordSpan (tensorProduct A B) N =

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.RingTheory.MatrixAlgebra
+import QICLean.Kraus.Injectivity
+import QICLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
+import TNLean.MPS.Core.TensorProduct
+
+/-!
+# Homogeneous word spans of independent tensor products
+
+The length-`N` words of an independent tensor product are exactly the
+reindexed Kronecker products of a length-`N` word in each constituent tensor.
+Consequently, simultaneous full homogeneous word spans imply a full word span
+for the product tensor.  Two eventual full-span witnesses are synchronized at
+the common positive length `N_A * N_B`.
+
+This is project infrastructure for the sentence "The case of tensoring is
+trivial" in arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845;
+the paper does not state a separate normality theorem here.  The tensors to
+which this infrastructure is applied are the retained normal blocks of
+arXiv:1606.00608, equation `II_CF1`, lines 224--245.
+
+## Main statements
+
+* `MPSTensor.wordSpan_tensorProduct` identifies the product word span with the
+  image of the paired constituent spans.
+* `MPSTensor.isNBlkInjective_tensorProduct` preserves full homogeneous word
+  spans at a common length.
+* `MPSTensor.isNormal_tensorProduct` preserves algebraic normality by using
+  the common length `N_A * N_B`.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPSTensor
+
+variable {d D e E : ℕ}
+
+/-- The homogeneous word span of an independent tensor product is the image
+of the two constituent homogeneous word spans under the canonical tensor-product
+and matrix-reindexing equivalences.
+
+Writing `S_N(A)` for the span of the length-`N` words of `A`, the statement is
+\[
+  S_N(A\boxtimes B)
+  =\operatorname{reind}_{\pi_{D,E}}
+    \left(\kappa\bigl(S_N(A)\otimes S_N(B)\bigr)\right),
+\]
+where `κ` is Mathlib's matrix Kronecker linear equivalence and
+`π_{D,E}` is the standard finite-product coordinate bijection.
+
+This is infrastructure for arXiv:1703.09188, proof of Theorem `IndexTh` (ii),
+lines 824--845, rather than a separately stated theorem of that paper.  Its
+homogeneous-word route supplies the project's algebraic-normality input for
+the retained blocks described around arXiv:1606.00608, equation `II_CF1`,
+lines 224--245. -/
+theorem wordSpan_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    (N : ℕ) :
+    Kraus.wordSpan (tensorProduct A B) N =
+      Submodule.map
+        (((kroneckerLinearEquiv (Fin D) (Fin D) (Fin E) (Fin E) ℂ).trans
+          (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv)).toLinearMap)
+        (Submodule.map₂
+          (TensorProduct.mk ℂ
+            (Matrix (Fin D) (Fin D) ℂ)
+            (Matrix (Fin E) (Fin E) ℂ))
+          (Kraus.wordSpan A N) (Kraus.wordSpan B N)) := by
+  unfold Kraus.wordSpan
+  rw [Submodule.map_map₂, Submodule.map₂_span_span]
+  congr 1
+  ext X
+  constructor
+  · rintro ⟨σ, rfl⟩
+    refine ⟨Kraus.evalWord A (List.ofFn (fun n ↦ (σ n).divNat)), ?_,
+      Kraus.evalWord B (List.ofFn (fun n ↦ (σ n).modNat)), ?_, ?_⟩
+    · exact ⟨fun n ↦ (σ n).divNat, rfl⟩
+    · exact ⟨fun n ↦ (σ n).modNat, rfl⟩
+    · change _ = Kraus.evalWord (tensorProduct A B) (List.ofFn σ)
+      rw [evalWord_tensorProduct]
+      simp only [List.map_ofFn, Function.comp_def]
+      rfl
+  · rintro ⟨_, ⟨σA, rfl⟩, _, ⟨σB, rfl⟩, rfl⟩
+    refine ⟨(finTupleProdEquiv N d e).symm (σA, σB), ?_⟩
+    change Kraus.evalWord (tensorProduct A B)
+      (List.ofFn ((finTupleProdEquiv N d e).symm (σA, σB))) = _
+    rw [evalWord_tensorProduct]
+    have hsplit := (finTupleProdEquiv N d e).apply_symm_apply (σA, σB)
+    rw [finTupleProdEquiv_apply] at hsplit
+    have hσA := congrArg Prod.fst hsplit
+    change (fun n ↦ ((finTupleProdEquiv N d e).symm (σA, σB) n).divNat) = σA at hσA
+    have hσB := congrArg Prod.snd hsplit
+    change (fun n ↦ ((finTupleProdEquiv N d e).symm (σA, σB) n).modNat) = σB at hσB
+    simp only [List.map_ofFn, Function.comp_def, hσA, hσB]
+    rfl
+
+/-- Full homogeneous word spans at the same length are preserved by an
+independent tensor product.
+
+Surjectivity of the composite of `kroneckerLinearEquiv` and
+`Matrix.reindexLinearEquiv` sends the full tensor product of the two matrix
+spaces onto the full product matrix algebra.  This is the fixed-length step
+in the algebraic proof associated with arXiv:1703.09188, Theorem `IndexTh`
+(ii), lines 824--845. -/
+theorem isNBlkInjective_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    {N : ℕ} (hA : Kraus.IsNBlkInjective A N)
+    (hB : Kraus.IsNBlkInjective B N) :
+    Kraus.IsNBlkInjective (tensorProduct A B) N := by
+  rw [Kraus.IsNBlkInjective, wordSpan_tensorProduct]
+  change Kraus.wordSpan A N = ⊤ at hA
+  change Kraus.wordSpan B N = ⊤ at hB
+  rw [hA, hB, TensorProduct.map₂_mk_top_top_eq_top]
+  rw [Submodule.map_top]
+  exact LinearMap.range_eq_top.mpr
+    ((kroneckerLinearEquiv (Fin D) (Fin D) (Fin E) (Fin E) ℂ).trans
+      (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv)).surjective
+
+/-- Algebraic normality is preserved by independent tensor products.
+
+If `S_{N_A}(A)` and `S_{N_B}(B)` are full at positive lengths `N_A` and
+`N_B`, then `Kraus.wordSpan_top_of_mul` gives
+\[
+  S_{N_A N_B}(A)=\operatorname{Mat}_D(\mathbb C),\qquad
+  S_{N_A N_B}(B)=\operatorname{Mat}_E(\mathbb C).
+\]
+The paired-span theorem at this common length gives a full product matrix
+algebra.  This is project infrastructure for arXiv:1703.09188, proof of
+Theorem `IndexTh` (ii), lines 824--845, not a separate paper theorem. -/
+theorem isNormal_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    (hA : Kraus.IsNormal A) (hB : Kraus.IsNormal B) :
+    Kraus.IsNormal (tensorProduct A B) := by
+  rcases hA with ⟨NA, hNA, hA⟩
+  rcases hB with ⟨NB, hNB, hB⟩
+  refine ⟨NA * NB, Nat.mul_pos hNA hNB, ?_⟩
+  have hAcommon : Kraus.IsNBlkInjective A (NA * NB) := by
+    change Kraus.wordSpan A (NA * NB) = ⊤
+    have h := Kraus.wordSpan_top_of_mul A hA NB
+      (Nat.one_le_iff_ne_zero.mpr hNB.ne')
+    simpa [Nat.mul_comm] using h
+  have hBcommon : Kraus.IsNBlkInjective B (NA * NB) := by
+    change Kraus.wordSpan B (NA * NB) = ⊤
+    exact Kraus.wordSpan_top_of_mul B hB NA
+      (Nat.one_le_iff_ne_zero.mpr hNA.ne')
+  exact isNBlkInjective_tensorProduct A B hAcommon hBcommon
+
+end MPSTensor

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -15,8 +15,8 @@ import TNLean.MPS.Core.TensorProduct
 The length-`N` words of an independent tensor product are exactly the
 reindexed Kronecker products of a length-`N` word in each constituent tensor.
 Consequently, simultaneous full homogeneous word spans imply a full word span
-for the product tensor.  Two eventual full-span witnesses are synchronized at
-the common positive length `N_A * N_B`.
+for the product tensor.  Two eventual full-span witnesses meet at the common
+positive length `N_A * N_B`.
 
 This is project infrastructure for the sentence "The case of tensoring is
 trivial" in arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845;

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -26,11 +26,11 @@ arXiv:1606.00608, equation `II_CF1`, lines 214--245.
 
 ## Main statements
 
-* `MPSTensor.word_span_tensor_product` identifies the product word span with the
+* `MPSTensor.wordSpan_tensorProduct` identifies the product word span with the
   image of the paired constituent spans.
-* `MPSTensor.is_n_blk_injective_tensor_product` preserves full homogeneous word
+* `MPSTensor.isNBlkInjective_tensorProduct` preserves full homogeneous word
   spans at a common length.
-* `MPSTensor.is_normal_tensor_product` preserves algebraic normality by using
+* `MPSTensor.isNormal_tensorProduct` preserves algebraic normality by using
   the common length `N_A * N_B`.
 
 ## References
@@ -65,7 +65,7 @@ lines 824--845, rather than a separately stated theorem of that paper.  Its
 homogeneous-word route supplies the project's algebraic-normality input for
 the retained blocks described around arXiv:1606.00608, equation `II_CF1`,
 lines 214--245. -/
-theorem word_span_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
+theorem wordSpan_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     (N : ℕ) :
     Kraus.wordSpan (tensorProduct A B) N =
       Submodule.map
@@ -112,11 +112,11 @@ Surjectivity of the composite of `kroneckerLinearEquiv` and
 spaces onto the full product matrix algebra.  This is the fixed-length step
 in the algebraic proof associated with arXiv:1703.09188, Theorem `IndexTh`
 (ii), lines 824--845. -/
-theorem is_n_blk_injective_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
+theorem isNBlkInjective_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     {N : ℕ} (hA : Kraus.IsNBlkInjective A N)
     (hB : Kraus.IsNBlkInjective B N) :
     Kraus.IsNBlkInjective (tensorProduct A B) N := by
-  rw [Kraus.IsNBlkInjective, word_span_tensor_product]
+  rw [Kraus.IsNBlkInjective, wordSpan_tensorProduct]
   change Kraus.wordSpan A N = ⊤ at hA
   change Kraus.wordSpan B N = ⊤ at hB
   rw [hA, hB, TensorProduct.map₂_mk_top_top_eq_top]
@@ -136,7 +136,7 @@ If `S_{N_A}(A)` and `S_{N_B}(B)` are full at positive lengths `N_A` and
 The paired-span theorem at this common length gives a full product matrix
 algebra.  This is project infrastructure for arXiv:1703.09188, proof of
 Theorem `IndexTh` (ii), lines 824--845, not a separate paper theorem. -/
-theorem is_normal_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
+theorem isNormal_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     (hA : Kraus.IsNormal A) (hB : Kraus.IsNormal B) :
     Kraus.IsNormal (tensorProduct A B) := by
   rcases hA with ⟨NA, hNA, hA⟩
@@ -151,6 +151,6 @@ theorem is_normal_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
     change Kraus.wordSpan B (NA * NB) = ⊤
     exact Kraus.wordSpan_top_of_mul B hB NA
       (Nat.one_le_iff_ne_zero.mpr hNA.ne')
-  exact is_n_blk_injective_tensor_product A B hAcommon hBcommon
+  exact isNBlkInjective_tensorProduct A B hAcommon hBcommon
 
 end MPSTensor

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.RingTheory.MatrixAlgebra
 import QICLean.Kraus.Injectivity
 import QICLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.Core.TensorProduct
 
 /-!

--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -26,12 +26,19 @@ arXiv:1606.00608, equation `II_CF1`, lines 214--245.
 
 ## Main statements
 
-* `MPSTensor.wordSpan_tensorProduct` identifies the product word span with the
+* `MPSTensor.word_span_tensor_product` identifies the product word span with the
   image of the paired constituent spans.
-* `MPSTensor.isNBlkInjective_tensorProduct` preserves full homogeneous word
+* `MPSTensor.is_n_blk_injective_tensor_product` preserves full homogeneous word
   spans at a common length.
-* `MPSTensor.isNormal_tensorProduct` preserves algebraic normality by using
+* `MPSTensor.is_normal_tensor_product` preserves algebraic normality by using
   the common length `N_A * N_B`.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Unitaries:
+  Structure, Symmetries, and Topological Invariants*, arXiv:1703.09188.
+* Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608.
 -/
 
 open scoped Matrix Kronecker
@@ -58,7 +65,7 @@ lines 824--845, rather than a separately stated theorem of that paper.  Its
 homogeneous-word route supplies the project's algebraic-normality input for
 the retained blocks described around arXiv:1606.00608, equation `II_CF1`,
 lines 214--245. -/
-theorem wordSpan_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+theorem word_span_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
     (N : ℕ) :
     Kraus.wordSpan (tensorProduct A B) N =
       Submodule.map
@@ -105,11 +112,11 @@ Surjectivity of the composite of `kroneckerLinearEquiv` and
 spaces onto the full product matrix algebra.  This is the fixed-length step
 in the algebraic proof associated with arXiv:1703.09188, Theorem `IndexTh`
 (ii), lines 824--845. -/
-theorem isNBlkInjective_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+theorem is_n_blk_injective_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
     {N : ℕ} (hA : Kraus.IsNBlkInjective A N)
     (hB : Kraus.IsNBlkInjective B N) :
     Kraus.IsNBlkInjective (tensorProduct A B) N := by
-  rw [Kraus.IsNBlkInjective, wordSpan_tensorProduct]
+  rw [Kraus.IsNBlkInjective, word_span_tensor_product]
   change Kraus.wordSpan A N = ⊤ at hA
   change Kraus.wordSpan B N = ⊤ at hB
   rw [hA, hB, TensorProduct.map₂_mk_top_top_eq_top]
@@ -129,7 +136,7 @@ If `S_{N_A}(A)` and `S_{N_B}(B)` are full at positive lengths `N_A` and
 The paired-span theorem at this common length gives a full product matrix
 algebra.  This is project infrastructure for arXiv:1703.09188, proof of
 Theorem `IndexTh` (ii), lines 824--845, not a separate paper theorem. -/
-theorem isNormal_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+theorem is_normal_tensor_product (A : MPSTensor d D) (B : MPSTensor e E)
     (hA : Kraus.IsNormal A) (hB : Kraus.IsNormal B) :
     Kraus.IsNormal (tensorProduct A B) := by
   rcases hA with ⟨NA, hNA, hA⟩
@@ -144,6 +151,6 @@ theorem isNormal_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
     change Kraus.wordSpan B (NA * NB) = ⊤
     exact Kraus.wordSpan_top_of_mul B hB NA
       (Nat.one_le_iff_ne_zero.mpr hNA.ne')
-  exact isNBlkInjective_tensorProduct A B hAcommon hBcommon
+  exact is_n_blk_injective_tensor_product A B hAcommon hBcommon
 
 end MPSTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1878,9 +1878,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Homogeneous word spans of an independent tensor product]
     \label{thm:mps_word_span_tensor_product}
-    \lean{MPSTensor.word_span_tensor_product,
-        MPSTensor.is_n_blk_injective_tensor_product,
-        MPSTensor.is_normal_tensor_product}
+    \lean{MPSTensor.wordSpan_tensorProduct,
+        MPSTensor.isNBlkInjective_tensorProduct,
+        MPSTensor.isNormal_tensorProduct}
     \leanok
     \uses{def:mps_independent_tensor_product, def:word_span, def:normal}
     Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$.  The pointwise splitting of
@@ -1928,8 +1928,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Left-canonical normal blocks under independent tensor products]
     \label{thm:mps_normal_block_tensor_product}
-    \lean{MPSTensor.left_canonical_tensor_product,
-        MPSTensor.IsNormalTensor.tensor_product_of_left_canonical}
+    \lean{MPSTensor.leftCanonical_tensorProduct,
+        MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical}
     \leanok
     \uses{def:mps_independent_tensor_product, def:left_canonical_tensor,
         def:nt_cpsv}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1882,7 +1882,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPSTensor.isNBlkInjective_tensorProduct,
         MPSTensor.isNormal_tensorProduct}
     \leanok
-    \uses{def:mps_independent_tensor_product, def:word_span}
+    \uses{def:mps_independent_tensor_product, def:word_span, def:normal}
     Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$ and define
     \begin{align}
         \Phi_{D,E}(X\otimes Y)
@@ -1908,7 +1908,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mps_eval_word_independent_tensor_product, def:word_span}
+    \uses{thm:mps_eval_word_independent_tensor_product, def:word_span,
+        def:normal}
     For every product word $w$, let $(u,v)$ be its pointwise component words.
     The bijection between $w$ and $(u,v)$ and
     Theorem~\ref{thm:mps_eval_word_independent_tensor_product} give

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1809,7 +1809,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPSTensor.tensorProduct, MPSTensor.tensorProduct_apply}
     \leanok
     \uses{def:mps_tensor}
-    Let $A=(A^i)_{i\in\Fin d}$ and $B=(B^k)_{k\in\Fin e}$ have
+    Let $A=\{A^i\}_{i\in\Fin d}$ and $B=\{B^k\}_{k\in\Fin e}$ have
     auxiliary dimensions $D$ and $E$, respectively.  Write
     \begin{align}
         \pi_{m,n}:\Fin m\times\Fin n & \longrightarrow\Fin{mn}
@@ -1835,7 +1835,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     This is infrastructure for the tensoring clause in the proof of the MPU
     Index Theorem~IV.6(ii)
     \cite[lines~824--845]{Cirac2017MPU}, not a separately stated theorem of
-    that paper.  The notation $A=(A^i)_i$ agrees with the canonical-form block
+    that paper.  The notation $A=\{A^i\}_i$ agrees with the canonical-form block
     notation in \cite[Section~2.3, lines~214--245]{Cirac2016MPDO_arXiv}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1878,9 +1878,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Homogeneous word spans of an independent tensor product]
     \label{thm:mps_word_span_tensor_product}
-    \lean{MPSTensor.wordSpan_tensorProduct,
-        MPSTensor.isNBlkInjective_tensorProduct,
-        MPSTensor.isNormal_tensorProduct}
+    \lean{MPSTensor.word_span_tensor_product,
+        MPSTensor.is_n_blk_injective_tensor_product,
+        MPSTensor.is_normal_tensor_product}
     \leanok
     \uses{def:mps_independent_tensor_product, def:word_span, def:normal}
     Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$.  The pointwise splitting of
@@ -1913,9 +1913,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
          & =\operatorname{reind}_{\pi_{D,E}}(A^u\otimes B^v),
     \end{align}
     which proves~(\ref{eq:mpu_tensor_word_span}) after taking linear spans.
-    Pure tensors span $\MN{D}\otimes\MN{E}$, and simultaneous reindexing
-    along $\pi_{D,E}$ is an isomorphism onto $\MN{DE}$; this proves the
-    fixed-length consequence.  If
+    Pure tensors span $\MN{D}\otimes\MN{E}$.  The Kronecker linear
+    equivalence, followed by simultaneous reindexing along $\pi_{D,E}$, is an
+    isomorphism onto $\MN{DE}$; this proves the fixed-length consequence.  If
     $S_{N_A}(A)=\MN{D}$ and $S_{N_B}(B)=\MN{E}$ for positive $N_A,N_B$, then
     persistence at positive multiples gives
     \begin{align}
@@ -1928,8 +1928,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Left-canonical normal blocks under independent tensor products]
     \label{thm:mps_normal_block_tensor_product}
-    \lean{MPSTensor.leftCanonical_tensorProduct,
-        MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical}
+    \lean{MPSTensor.left_canonical_tensor_product,
+        MPSTensor.IsNormalTensor.tensor_product_of_left_canonical}
     \leanok
     \uses{def:mps_independent_tensor_product, def:left_canonical_tensor,
         def:nt_cpsv}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1883,16 +1883,11 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPSTensor.isNormal_tensorProduct}
     \leanok
     \uses{def:mps_independent_tensor_product, def:word_span, def:normal}
-    Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$ and define
-    \begin{align}
-        \Phi_{D,E}(X\otimes Y)
-         & =\operatorname{reind}_{\pi_{D,E}}(X\otimes Y).
-        \label{eq:mpu_tensor_span_map}
-    \end{align}
-    Then the pointwise splitting of length-$N$ words gives
+    Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$.  The pointwise splitting of
+    length-$N$ words gives
     \begin{align}
         S_N(A\boxtimes B)
-         & =\spn_{\C}\{\Phi_{D,E}(A^u\otimes B^v):
+         & =\spn_{\C}\{\operatorname{reind}_{\pi_{D,E}}(A^u\otimes B^v):
         |u|=|v|=N\}.
         \label{eq:mpu_tensor_word_span}
     \end{align}
@@ -1904,7 +1899,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     the proof of the MPU Index Theorem~IV.6(ii)
     \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
     It applies to the retained blocks in the canonical-form decomposition
-    \cite[Section~2.3, lines~224--245]{Cirac2016MPDO_arXiv}.
+    \cite[Section~2.3, lines~214--245]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1915,13 +1910,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Theorem~\ref{thm:mps_eval_word_independent_tensor_product} give
     \begin{align}
         (A\boxtimes B)^w
-         & =\Phi_{D,E}(A^u\otimes B^v),
+         & =\operatorname{reind}_{\pi_{D,E}}(A^u\otimes B^v),
     \end{align}
     which proves~(\ref{eq:mpu_tensor_word_span}) after taking linear spans.
-    Pure tensors span
-    $\MN{D}\otimes\MN{E}$, and the map in
-    (\ref{eq:mpu_tensor_span_map}) is an isomorphism onto $\MN{DE}$; this proves
-    the fixed-length consequence.  If
+    Pure tensors span $\MN{D}\otimes\MN{E}$, and simultaneous reindexing
+    along $\pi_{D,E}$ is an isomorphism onto $\MN{DE}$; this proves the
+    fixed-length consequence.  If
     $S_{N_A}(A)=\MN{D}$ and $S_{N_B}(B)=\MN{E}$ for positive $N_A,N_B$, then
     persistence at positive multiples gives
     \begin{align}
@@ -1935,7 +1929,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{theorem}[Left-canonical normal blocks under independent tensor products]
     \label{thm:mps_normal_block_tensor_product}
     \lean{MPSTensor.leftCanonical_tensorProduct,
-        MPSTensor.IsNormalTensor.tensorProduct}
+        MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical}
     \leanok
     \uses{def:mps_independent_tensor_product, def:left_canonical_tensor,
         def:nt_cpsv}
@@ -1958,7 +1952,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
     The retained-normal-block terminology is that of the canonical-form
     decomposition in
-    \cite[Section~2.3, lines~224--245]{Cirac2016MPDO_arXiv}; the two
+    \cite[Section~2.3, lines~214--245]{Cirac2016MPDO_arXiv}; the two
     left-canonical identities are explicit infrastructure hypotheses, not an
     additional assertion attributed to that passage.
 \end{theorem}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1876,6 +1876,113 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     after transporting multiplication through the same coordinate bijection.
 \end{proof}
 
+\begin{theorem}[Homogeneous word spans of an independent tensor product]
+    \label{thm:mps_word_span_tensor_product}
+    \lean{MPSTensor.wordSpan_tensorProduct,
+        MPSTensor.isNBlkInjective_tensorProduct,
+        MPSTensor.isNormal_tensorProduct}
+    \leanok
+    \uses{def:mps_independent_tensor_product, def:word_span}
+    Let $S_N(A)=\spn_{\C}\{A^w:|w|=N\}$ and define
+    \begin{align}
+        \Phi_{D,E}(X\otimes Y)
+         & =\operatorname{reind}_{\pi_{D,E}}(X\otimes Y).
+        \label{eq:mpu_tensor_span_map}
+    \end{align}
+    Then the pointwise splitting of length-$N$ words gives
+    \begin{align}
+        S_N(A\boxtimes B)
+         & =\spn_{\C}\{\Phi_{D,E}(A^u\otimes B^v):
+             |u|=|v|=N\}.
+        \label{eq:mpu_tensor_word_span}
+    \end{align}
+    In particular, if $S_N(A)=\MN{D}$ and $S_N(B)=\MN{E}$, then
+    $S_N(A\boxtimes B)=\MN{DE}$.  If $A$ and $B$ are algebraically normal,
+    then $A\boxtimes B$ is algebraically normal.
+
+    This is the homogeneous-word infrastructure for the tensoring sentence in
+    the proof of the MPU Index Theorem~IV.6(ii)
+    \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
+    It applies to the retained blocks around equation~\textup{II\_CF1} in
+    \cite[lines~224--245]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mps_eval_word_independent_tensor_product, def:word_span}
+    For every product word $w$, let $(u,v)$ be its pointwise component words.
+    The bijection between $w$ and $(u,v)$ and
+    Theorem~\ref{thm:mps_eval_word_independent_tensor_product} give
+    \begin{align}
+        (A\boxtimes B)^w
+         & =\Phi_{D,E}(A^u\otimes B^v),
+    \end{align}
+    which proves~(\ref{eq:mpu_tensor_word_span}) after taking linear spans.
+    Pure tensors span
+    $\MN{D}\otimes\MN{E}$, and the map in
+    (\ref{eq:mpu_tensor_span_map}) is an isomorphism onto $\MN{DE}$; this proves
+    the fixed-length consequence.  If
+    $S_{N_A}(A)=\MN{D}$ and $S_{N_B}(B)=\MN{E}$ for positive $N_A,N_B$, then
+    persistence at positive multiples gives
+    \begin{align}
+        S_{N_A N_B}(A)&=\MN{D}, &
+        S_{N_A N_B}(B)&=\MN{E}.
+    \end{align}
+    Applying the fixed-length consequence at $N_A N_B$ proves algebraic
+    normality of $A\boxtimes B$.
+\end{proof}
+
+\begin{theorem}[Left-canonical normal blocks under independent tensor products]
+    \label{thm:mps_normal_block_tensor_product}
+    \lean{MPSTensor.leftCanonical_tensorProduct,
+        MPSTensor.IsNormalTensor.tensorProduct}
+    \leanok
+    \uses{def:mps_independent_tensor_product, def:left_canonical_tensor,
+        def:nt_cpsv}
+    Let $A$ and $B$ be CPSV normal tensors, and suppose that
+    \begin{align}
+        \sum_i(A^i)^\dagger A^i&=\Id_D, &
+        \sum_k(B^k)^\dagger B^k&=\Id_E.
+        \label{eq:mpu_tensor_left_canonical_inputs}
+    \end{align}
+    Then $A\boxtimes B$ is a CPSV normal tensor and is left-canonical:
+    \begin{align}
+        \sum_{i,k}
+        \bigl((A^i\otimes B^k)^\dagger\bigr)(A^i\otimes B^k)
+         & =\Id_{DE}.
+        \label{eq:mpu_tensor_left_canonical_output}
+    \end{align}
+
+    This is the retained-normal-block infrastructure for the tensoring
+    sentence in the proof of the MPU Index Theorem~IV.6(ii)
+    \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
+    The retained-normal-block terminology is that around
+    equation~\textup{II\_CF1} in
+    \cite[lines~224--245]{Cirac2016MPDO_arXiv}; the two left-canonical
+    identities are explicit infrastructure hypotheses, not an additional
+    assertion attributed to that passage.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mps_word_span_tensor_product,
+        thm:cpsv_normal_eventually_injective,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    The adjoint and multiplication laws for Kronecker products give
+    \begin{align}
+        \sum_{i,k}
+        \bigl((A^i\otimes B^k)^\dagger\bigr)(A^i\otimes B^k)
+         & =\left(\sum_i(A^i)^\dagger A^i\right)
+             \otimes
+             \left(\sum_k(B^k)^\dagger B^k\right) \\
+         & =\Id_D\otimes\Id_E=\Id_{DE},
+    \end{align}
+    proving~(\ref{eq:mpu_tensor_left_canonical_output}).  Spectral normality
+    gives positive lengths $N_A,N_B$ at which the two homogeneous word spans
+    are full.  Theorem~\ref{thm:mps_word_span_tensor_product} therefore makes
+    $A\boxtimes B$ algebraically normal at the common length $N_A N_B$.
+    The algebraically normal, left-canonical tensor is CPSV normal by
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical}.
+\end{proof}
+
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
     \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1893,7 +1893,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \begin{align}
         S_N(A\boxtimes B)
          & =\spn_{\C}\{\Phi_{D,E}(A^u\otimes B^v):
-             |u|=|v|=N\}.
+        |u|=|v|=N\}.
         \label{eq:mpu_tensor_word_span}
     \end{align}
     In particular, if $S_N(A)=\MN{D}$ and $S_N(B)=\MN{E}$, then
@@ -1903,8 +1903,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     This is the homogeneous-word infrastructure for the tensoring sentence in
     the proof of the MPU Index Theorem~IV.6(ii)
     \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
-    It applies to the retained blocks around equation~\textup{II\_CF1} in
-    \cite[lines~224--245]{Cirac2016MPDO_arXiv}.
+    It applies to the retained blocks in the canonical-form decomposition
+    \cite[Section~2.3, lines~224--245]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1924,8 +1924,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     $S_{N_A}(A)=\MN{D}$ and $S_{N_B}(B)=\MN{E}$ for positive $N_A,N_B$, then
     persistence at positive multiples gives
     \begin{align}
-        S_{N_A N_B}(A)&=\MN{D}, &
-        S_{N_A N_B}(B)&=\MN{E}.
+        S_{N_A N_B}(A) & =\MN{D}, &
+        S_{N_A N_B}(B) & =\MN{E}.
     \end{align}
     Applying the fixed-length consequence at $N_A N_B$ proves algebraic
     normality of $A\boxtimes B$.
@@ -1940,8 +1940,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         def:nt_cpsv}
     Let $A$ and $B$ be CPSV normal tensors, and suppose that
     \begin{align}
-        \sum_i(A^i)^\dagger A^i&=\Id_D, &
-        \sum_k(B^k)^\dagger B^k&=\Id_E.
+        \sum_i(A^i)^\dagger A^i & =\Id_D, &
+        \sum_k(B^k)^\dagger B^k & =\Id_E.
         \label{eq:mpu_tensor_left_canonical_inputs}
     \end{align}
     Then $A\boxtimes B$ is a CPSV normal tensor and is left-canonical:
@@ -1955,11 +1955,11 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     This is the retained-normal-block infrastructure for the tensoring
     sentence in the proof of the MPU Index Theorem~IV.6(ii)
     \cite[lines~824--845]{Cirac2017MPU}, not a separate theorem stated there.
-    The retained-normal-block terminology is that around
-    equation~\textup{II\_CF1} in
-    \cite[lines~224--245]{Cirac2016MPDO_arXiv}; the two left-canonical
-    identities are explicit infrastructure hypotheses, not an additional
-    assertion attributed to that passage.
+    The retained-normal-block terminology is that of the canonical-form
+    decomposition in
+    \cite[Section~2.3, lines~224--245]{Cirac2016MPDO_arXiv}; the two
+    left-canonical identities are explicit infrastructure hypotheses, not an
+    additional assertion attributed to that passage.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1971,8 +1971,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         \sum_{i,k}
         \bigl((A^i\otimes B^k)^\dagger\bigr)(A^i\otimes B^k)
          & =\left(\sum_i(A^i)^\dagger A^i\right)
-             \otimes
-             \left(\sum_k(B^k)^\dagger B^k\right) \\
+        \otimes
+        \left(\sum_k(B^k)^\dagger B^k\right)     \\
          & =\Id_D\otimes\Id_E=\Id_{DE},
     \end{align}
     proving~(\ref{eq:mpu_tensor_left_canonical_output}).  Spectral normality

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1942,7 +1942,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Then $A\boxtimes B$ is a CPSV normal tensor and is left-canonical:
     \begin{align}
         \sum_{i,k}
-        \bigl((A^i\otimes B^k)^\dagger\bigr)(A^i\otimes B^k)
+        \left((A\boxtimes B)^{\pi_{d,e}(i,k)}\right)^\dagger
+        (A\boxtimes B)^{\pi_{d,e}(i,k)}
          & =\Id_{DE}.
         \label{eq:mpu_tensor_left_canonical_output}
     \end{align}
@@ -1961,14 +1962,23 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \uses{thm:mps_word_span_tensor_product,
         thm:cpsv_normal_eventually_injective,
         thm:is_normal_tensor_of_is_normal_left_canonical}
-    The adjoint and multiplication laws for Kronecker products give
+    The adjoint and multiplication laws for Kronecker products, together
+    with the fact that simultaneous reindexing preserves adjoints, products,
+    and finite sums, give
     \begin{align}
-        \sum_{i,k}
-        \bigl((A^i\otimes B^k)^\dagger\bigr)(A^i\otimes B^k)
-         & =\left(\sum_i(A^i)^\dagger A^i\right)
-        \otimes
-        \left(\sum_k(B^k)^\dagger B^k\right)     \\
-         & =\Id_D\otimes\Id_E=\Id_{DE},
+        &\sum_{i,k}
+        \left((A\boxtimes B)^{\pi_{d,e}(i,k)}\right)^\dagger
+        (A\boxtimes B)^{\pi_{d,e}(i,k)} \\
+        &\quad=\operatorname{reind}_{\pi_{D,E}}
+        \left(\sum_{i,k}
+        (A^i\otimes B^k)^\dagger(A^i\otimes B^k)\right) \\
+        &\quad=\operatorname{reind}_{\pi_{D,E}}
+        \left(
+        \left(\sum_i(A^i)^\dagger A^i\right)\otimes
+        \left(\sum_k(B^k)^\dagger B^k\right)
+        \right) \\
+        &\quad=\operatorname{reind}_{\pi_{D,E}}
+        (\Id_D\otimes\Id_E)=\Id_{DE},
     \end{align}
     proving~(\ref{eq:mpu_tensor_left_canonical_output}).  Spectral normality
     gives positive lengths $N_A,N_B$ at which the two homogeneous word spans


### PR DESCRIPTION
### Motivation

- Supply the algebraic normal-block tensor-product step used later in the tensoring clause of the MPU Index Theorem.
- Source: `Papers/1703.09188/paper_v2.tex`, proof of Theorem `IndexTh` (ii), lines 824--845, especially “The case of tensoring is trivial” at line 837.
- The retained normal blocks are those of the canonical-form decomposition in `Papers/1606.00608/MPDO-22-12-17-2.tex`, Section 2.3, lines 214--245. This result is project infrastructure for `IndexTh` (ii), not a separately stated theorem of either paper. The two left-canonical identities are explicit project hypotheses, not claims attributed to that source passage.

### Description

- Identify the homogeneous word span of `MPSTensor.tensorProduct A B` with the reindexed image of the paired constituent word spans, using `Submodule.map₂_span_span`, `kroneckerLinearEquiv`, `Matrix.reindexLinearEquiv`, the neutral tuple split from #7123, and `evalWord_tensorProduct`.
- Preserve full homogeneous word spans at a common length and prove algebraic normality by meeting the two witnesses at the positive length `N_A * N_B` through `Kraus.wordSpan_top_of_mul`.
- Prove left-canonicality directly from the two constituent identities using the Kronecker multiplication and adjoint formulas.
- Deduce `MPSTensor.IsNormalTensor` for the product from algebraic normality and left-canonicality.
- Add formula-driven Chapter 28 entries for the span identity, common-length normality argument, left-canonical calculation, and CPSV wrapper.
- The change introduces no QCA support-algebra dependency, spectral-radius multiplicativity result, CFII direct-sum assembly, or second named span object.

### Rebase and source audit

The single logical implementation was originally commit `8ee9349d01b0cddb002afd6a14bcc0c3f5a032ab` over the then-local #7083 parent `de1242f2d17041eee6d4a94fae4aaa548c08b454`. After #7123 merged, it was rebased onto exact main `bef39e35998e8c8851f58787be39d24454b5f677` as `e190d5a215a7e8b64694e68a7eee26fd6deadd9b`.

The range-diff differs only in import context: the rebase preserved #7123's reviewed removal of the unused `TNLean.Algebra.FinTupleEquiv` import from the lower `TensorProduct` module while retaining this change's `TNLean.MPS.Core.CanonicalNormalization` import. Accordingly, the stable patch ID changed from `4c84954d4e73b2d12fe56b4b492378f456dbc2a2` to `0384acb11200680eb1236ae404d088ac6c354f88`; the mathematical additions and proof route are unchanged.

A separate audit commit, `300bd793523ea6cb608999ddaf687ef8694fbd6e`, resolves the two reader-facing source references to “canonical-form decomposition” and Section 2.3, lines 214--245. Its remaining four whitespace hunks are exactly the changes required by `latexindent` in the new Blueprint region.

### Testing

Before the serial release and cache removal, the logical implementation was checked against the then-present local cache. After rebasing and after the source-wording repair, these cache-independent checks passed:

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch28_mpu.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex`
- edited-region `latexindent` verification, with no remaining hunk in the new Chapter 28 block
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity token scan of the three changed Lean modules
- oversized-file and numbered-module guards
- declaration/tag/source-anchor audit and `git diff --check`

The first published-head PR CI run, `32761010363`, passed the Blueprint compilation and policy jobs. Its Lean build compiled `TNLean.MPS.Core.TensorProduct` and then exposed one rebase-context omission in `TNLean.MPS.Core.TensorProductSpan`: that module directly used `finTupleProdEquiv` without directly importing `TNLean.Algebra.FinTupleEquiv`, after #7123 had correctly removed the formerly transitive import from the lower module. Commit `bc5be411c3017a5b8ca4bc49b74669c7f23be62b` adds only that direct import.

The second published-head PR CI run, `32763090476`, again passed the Blueprint and policy jobs and compiled both new Core modules. It then exposed a same-name elaboration ambiguity inside the theorem `MPSTensor.IsNormalTensor.tensor_product_of_left_canonical`: the unqualified constructor name in its proof resolved recursively to the theorem being defined. Commit `b511d6c3bdffe9dff53fa946e082a3730d1e042a` qualifies both the theorem conclusion and the proof argument as `MPSTensor.tensorProduct A B`; no mathematical statement or proof route changes. Post-repair `git diff --check`, import-aggregator verification, and the proof-integrity scan pass.

The release worktree has no `.lake`, and no dependency cache was recreated or local exact-head Lake build claimed after the rebase. Local `blueprint_lean_sync.py --ci` is not authoritative here because the cache-free worktree has no QICLean checkout and the generated local declaration index is stale; restarted exact-head PR CI is authoritative for compilation, linters, `checkdecls`, and Blueprint/source synchronization.

Closes #7082


### Review resolution (`428dba0db`)

- Removes the ad hoc `Φ_{D,E}` notation and writes the established simultaneous-reindexing map directly.
- Reconciles the retained-block source range to lines 214--245 throughout the changed Lean and Blueprint prose.
- Renames the CPSV wrapper to `MPSTensor.IsNormalTensor.tensor_product_of_left_canonical`, making its two load-bearing left-canonical hypotheses visible in the public name.
- Re-runs reader-facing prose, tenkz, ChkTeX, generated-import, file-policy, tactic-pattern, proof-integrity, and diff checks successfully. Exact-head CI remains authoritative for Lean compilation and `checkdecls`.


### Exact-head review resolution (84cb950f1)

- Uses collection braces for both matrix families in the definition and its source comparison.
- Publishes all five new theorems with fully snake-case names and updates every proof call, module index, and Blueprint declaration tag.
- States the full-span argument through the Kronecker linear equivalence followed by simultaneous finite-index reindexing, matching the Lean composite.
- Adds explicit References sections to both new modules.
- Passes the exact targeted build of TNLean.MPS.CanonicalForm.TensorProduct (8,973/8,973 jobs), import aggregation, Lean file policies, proof-integrity, reader-facing prose, tactic-pattern, ChkTeX, and diff checks. Exact-head CI supplies the full Blueprint declaration check.
