### PR TITLE
feat(MPS/MPU): construct reduced CFII representatives

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
@@ -58,14 +58,17 @@ private theorem IsNormalTensor.exists_cfiiBlockGaugeData {m : ℕ} [NeZero m]
     isNormalTensor_of_isNormal_leftCanonical B hNormalAlg hLeft
   exact ⟨⟨B, hGauge, hNormal, hLeft, Λ, hΛPos, hΛDiag, hΛFix⟩⟩
 
-/-- Literal CPSV canonical-form data admit a canonical-form-II representative
-in the same ambient bond dimension, related to the original tensor by a
-nonsingular gauge.
+/-- For literal CPSV canonical-form data, there are canonical-form-II witness
+data in the same ambient bond dimension, related to the original tensor by a
+nonsingular gauge. The returned witness records that the total retained block
+dimension is unchanged by the blockwise gauges.
 
 Source: arXiv:1606.00608, Appendix A, lines 1058--1077 and eq. `II_XAX`. -/
-theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
+theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormIIData
     {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
-    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ IsCPSVCanonicalFormII B := by
+    ∃ (B : MPSTensor d D) (dataB : CPSVCanonicalFormIIData B),
+      GaugeEquiv A B ∧
+        ∑ k : Fin dataB.r, dataB.dim k = ∑ k : Fin data.r, data.dim k := by
   classical
   let blockData : (k : Fin data.r) → CFIIBlockGaugeData (data.blocks k) := fun k => by
     letI : NeZero (data.dim k) := NeZero.of_pos (data.dim_pos k)
@@ -129,8 +132,7 @@ theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
       _ = (Uᴴ * Xmat) * C * (Xinv * U) := by simp only [Matrix.mul_assoc]
       _ = (Gmat * Uᴴ) * C * (U * Ginv) := by rw [hGU', hUGinv']
       _ = Gmat * (Uᴴ * C * U) * Ginv := by simp only [Matrix.mul_assoc]
-  refine ⟨B, hGauge, ?_⟩
-  refine ⟨{
+  let dataB : CPSVCanonicalFormIIData B := {
       r := data.r
       dim := data.dim
       dim_pos := data.dim_pos
@@ -143,7 +145,19 @@ theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
       coisometric := data.coisometric
       reconstruct := fun _ => rfl
       blocks_left_canonical := fun k => (blockData k).leftCanonical
-      blocks_fixed_point := fun k => (blockData k).fixedPoint }⟩
+      blocks_fixed_point := fun k => (blockData k).fixedPoint }
+  exact ⟨B, dataB, hGauge, rfl⟩
+
+/-- For literal CPSV canonical-form data, there is a canonical-form-II
+representative in the same ambient bond dimension, related to the original
+tensor by a nonsingular gauge.
+
+Source: arXiv:1606.00608, Appendix A, lines 1058--1077 and eq. `II_XAX`. -/
+theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
+    {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
+    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ IsCPSVCanonicalFormII B := by
+  obtain ⟨B, dataB, hGauge, _⟩ := data.exists_gaugeEquiv_canonicalFormIIData
+  exact ⟨B, hGauge, dataB.isCPSVCanonicalFormII⟩
 
 /-- Every tensor in literal CPSV canonical form is gauge-equivalent, in the
 same ambient bond dimension, to a tensor in literal canonical form II.

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -22,6 +22,7 @@ import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm
 import TNLean.MPS.MPU.PhysicalAncilla
+import TNLean.MPS.MPU.ReducedCanonicalRepresentative
 import TNLean.MPS.MPU.ReducedRepresentative
 import TNLean.MPS.MPU.ReducedToHatTransport
 import TNLean.MPS.MPU.ResidualAlgebra

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -19,10 +19,12 @@ representative is used as an ambient tensor.
 
 **Scope restriction (full-support irreducibility):** This module treats the
 intended reduced canonical representative in the argument for arXiv:1703.09188,
-Proposition `prop:normal-tensor`. The formalization does not construct the reduced
-representative obtained by omitting the ambient zero complement. Consequently the
-MPU normality capstone below assumes full support and does not claim bare
-`IsMPU` implies ambient normality. See
+Proposition `prop:normal-tensor`. The reduced representative obtained by
+omitting the ambient zero complement is constructed by
+`MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii`. The original
+nonminimal tensor need not be normal, so the MPU normality capstone below still
+assumes full support for that named tensor and does not claim bare `IsMPU`
+implies its ambient normality. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
@@ -263,8 +265,10 @@ theorem ambientBlockInclusion_mul_conjTranspose_eq_one
 
 **Scope restriction (unique full-support block):** This is the algebraic
 irreducibility conclusion for the intended reduced representative in
-arXiv:1703.09188, Proposition `prop:normal-tensor`, lines 344--354. The reduction
-that omits the ambient zero complement is not formalized here; see
+arXiv:1703.09188, Proposition `prop:normal-tensor`, lines 344--354. The theorem
+`MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii` constructs the
+reduced representative; this lemma supplies its full-support irreducibility
+step and does not assert irreducibility of the original nonminimal tensor. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
 theorem isIrreducibleTensor_of_r_eq_one_of_fullSupport
     (data : CPSVCanonicalFormData A) (hr : data.r = 1)
@@ -279,8 +283,10 @@ primitivity fields.
 **Scope restriction (supplied spectral data):** The radius and primitivity fields
 are the spectral conclusions of arXiv:1703.09188, Proposition
 `prop:normal-tensor`, lines 349--354. The full-support premise describes the
-intended reduced representative after lines 319--326; the reduction that omits
-the ambient zero complement is not formalized here. See
+intended reduced representative after lines 319--326. That representative is
+constructed by `MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii`; this
+lemma combines its full-support conclusion with supplied spectral data and does
+not make the original nonminimal tensor normal. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
 theorem isNormalTensor_of_r_eq_one_of_fullSupport
     (data : CPSVCanonicalFormData A) (hr : data.r = 1)

--- a/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
+++ b/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.CPSVCanonicalFormII
+import TNLean.MPS.MPU.CanonicalForm
+import TNLean.MPS.Tactic.Basic
+
+/-!
+# Reduced canonical representatives of matrix product unitaries
+
+This file constructs the reduced canonical-form-II representative used before
+the matrix product unitary arguments of Cirac--Perez-Garcia--Schuch--Verstraete.
+The construction removes zero and upper-triangular virtual sectors, normalizes
+the retained irreducible blocks through the shifted transfer traces, and then
+applies the canonical-form-II gauge.
+
+The reduction follows arXiv:1606.00608, lines 195--255 and 1058--1077. Its use
+for matrix product unitaries follows arXiv:1703.09188, lines 257--294, 319--326,
+and 344--356.
+
+**Scope boundary (representative reduction):** The result constructs a new
+tensor of no larger bond dimension with the same positive-length periodic
+operator family. Equality at length zero is neither asserted nor generally
+true. The construction does not transport compact-SVD source spaces or source
+factors from the reduced tensor back to the original auxiliary space. See
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+private theorem mpvOverlap_two_eq_zero_of_bondDim_eq_zero
+    {e E : ℕ} (A : MPSTensor e E) (hE : E = 0) :
+    MPSTensor.mpvOverlap A A 2 = 0 := by
+  subst E
+  simp [MPSTensor.mpvOverlap, MPSTensor.mpv, MPSTensor.coeff, Matrix.trace]
+
+/-- Every matrix product unitary has a positive-dimensional, normal,
+full-support canonical-form-II representative of its normalized flattening.
+The representative has no larger bond dimension and generates the same matrix
+product vectors at every positive length.
+
+The canonical-form convention in arXiv:1703.09188, lines 257--294 and 319--326,
+replaces a tensor by one generating the same matrix product vectors. For a
+matrix product unitary, lines 344--356 then use the shifted transfer traces to
+obtain a normal representative in canonical form II. The dimension-bounded
+irreducible reduction and canonical-form-II gauge are those of
+arXiv:1606.00608, lines 195--255 and 1058--1077. This theorem combines those
+steps; it is not a separately stated theorem of either paper. -/
+theorem IsMPU.exists_reduced_normalizedFlattening_cfii
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU) :
+    ∃ (Dred : ℕ) (_hDred : 0 < Dred) (Ared : MPSTensor (d * d) Dred)
+      (cfii : MPSTensor.CPSVCanonicalFormIIData Ared),
+      Dred ≤ D ∧
+      MPSTensor.SameMPV₂Pos U.normalizedFlattening Ared ∧
+      MPSTensor.IsNormalTensor Ared ∧
+      cfii.toCPSVCanonicalFormData.HasFullSupport := by
+  classical
+  obtain ⟨r, dim, blocks, hIrr, hNonzero, hDim, hSame, hDimLe⟩ :=
+    MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks U.normalizedFlattening
+  let Dred : ℕ := ∑ k : Fin r, dim k
+  let Ared : MPSTensor (d * d) Dred :=
+    MPSTensor.toTensorFromBlocks (fun _ : Fin r => (1 : ℂ)) blocks
+  have hOriginalOverlap :
+      MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening 2 = 1 := by
+    rw [← MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap]
+    exact hU.trace_transferMatrix_normalizedFlattening_pow_eq_one (by omega)
+  have hReducedOverlap : MPSTensor.mpvOverlap Ared Ared 2 = 1 := by
+    calc
+      MPSTensor.mpvOverlap Ared Ared 2 =
+          MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening 2 :=
+        (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
+          (fun {N} hN => hSame N hN) (fun {N} hN => hSame N hN) (by omega)).symm
+      _ = 1 := hOriginalOverlap
+  have hDred : 0 < Dred := by
+    by_contra h
+    have hDredZero : Dred = 0 := Nat.eq_zero_of_not_pos h
+    have hzero := mpvOverlap_two_eq_zero_of_bondDim_eq_zero Ared hDredZero
+    rw [hReducedOverlap] at hzero
+    exact one_ne_zero hzero
+  let _ : NeZero Dred := NeZero.of_pos hDred
+  have hTrace : ∀ N : ℕ, 1 < N →
+      Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) = 1 := by
+    intro N hN
+    calc
+      Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) =
+          MPSTensor.mpvOverlap Ared Ared N :=
+        MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap Ared N
+      _ = MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N :=
+        (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
+          (fun {N} hN => hSame N hN) (fun {N} hN => hSame N hN)
+          (Nat.zero_lt_of_lt hN)).symm
+      _ = Matrix.trace
+          (transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ N) :=
+        (MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap
+          U.normalizedFlattening N).symm
+      _ = 1 := hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+  have hBlocksNormal : ∀ k : Fin r, MPSTensor.IsNormalTensor (blocks k) := by
+    intro k
+    let _ : NeZero (dim k) := NeZero.of_pos (hDim k)
+    obtain ⟨ρ, radius, hρ, hRadius, hEigenvector⟩ :=
+      MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible
+        (blocks k) (hIrr k) (hNonzero k)
+    have hEigenvalue_eq_one : ∀ {μ : ℂ},
+        Module.End.HasEigenvalue (Kraus.transferMap (blocks k)) μ → μ ≠ 0 → μ = 1 := by
+      intro μ hμ hμ0
+      have hAmbient : Module.End.HasEigenvalue (Kraus.transferMap Ared) μ :=
+        MPSTensor.hasEigenvalue_transferMap_of_intertwine Ared (blocks k)
+          (MPSTensor.blockInclusion dim k)
+          (MPSTensor.blockInclusion_conjTranspose_mul_self dim k)
+          (fun i => by
+            simpa [Ared] using
+              MPSTensor.toTensorFromBlocks_mul_blockInclusion
+                (fun _ : Fin r => (1 : ℂ)) blocks k i)
+          hμ
+      have hMatrix : Module.End.HasEigenvalue
+          (transferMatrix (Kraus.transferMap Ared)).toLin' μ :=
+        (transferMatrix_hasEigenvalue_iff (Kraus.transferMap Ared) μ).mp hAmbient
+      have hSpectrum : μ ∈ spectrum ℂ (transferMatrix (Kraus.transferMap Ared)) := by
+        simpa using Module.End.hasEigenvalue_iff_mem_spectrum.mp hMatrix
+      exact Matrix.eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
+        (transferMatrix (Kraus.transferMap Ared)) hTrace hSpectrum hμ0
+    have hρne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ).ne_zero
+    have hRadiusEigenvalue : Module.End.HasEigenvalue
+        (Kraus.transferMap (blocks k)) (radius : ℂ) :=
+      hasEigenvalue_of_eigenvector_eq _ _ ρ hEigenvector hρne
+    have hRadiusComplex : (radius : ℂ) = 1 :=
+      hEigenvalue_eq_one hRadiusEigenvalue (by exact_mod_cast hRadius.ne')
+    have hRadiusOne : radius = 1 := by exact_mod_cast hRadiusComplex
+    have hNormal := MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral
+      (blocks k) (hIrr k) ρ radius hρ hRadius hEigenvector (fun μ hμ hNorm => by
+        have hμ0 : μ ≠ 0 := by
+          intro hzero
+          subst μ
+          simp only [norm_zero] at hNorm
+          linarith
+        rw [hRadiusOne]
+        exact hEigenvalue_eq_one hμ hμ0)
+    simpa [hRadiusOne] using hNormal
+  let data : MPSTensor.CPSVCanonicalFormData Ared :=
+    MPSTensor.CPSVCanonicalFormData.ofBlocks hDim
+      (fun _ : Fin r => (1 : ℂ)) (fun _ => one_ne_zero) blocks hBlocksNormal
+  have hFull : data.HasFullSupport := by
+    rfl
+  obtain ⟨B, dataB, hGauge, hTotalDim⟩ :=
+    data.exists_gaugeEquiv_canonicalFormIIData
+  have hGaugePos : MPSTensor.SameMPV₂Pos Ared B :=
+    MPSTensor.SameMPV₂.toSameMPV₂Pos (fun N σ => hGauge.sameMPV N σ)
+  have hSameB : MPSTensor.SameMPV₂Pos U.normalizedFlattening B :=
+    hSame.trans hGaugePos
+  have hTraceB : ∀ N : ℕ, 1 < N →
+      Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) = 1 := by
+    intro N hN
+    calc
+      Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) =
+          MPSTensor.mpvOverlap B B N :=
+        MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap B N
+      _ = MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N :=
+        (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
+          (fun {N} hN => hSameB N hN) (fun {N} hN => hSameB N hN)
+          (Nat.zero_lt_of_lt hN)).symm
+      _ = Matrix.trace
+          (transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ N) :=
+        (MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap
+          U.normalizedFlattening N).symm
+      _ = 1 := hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+  have hFullB : dataB.toCPSVCanonicalFormData.HasFullSupport := by
+    change (∑ k : Fin dataB.r, dataB.dim k) = Dred
+    exact hTotalDim.trans hFull
+  have hBlockCountB : dataB.r = 1 :=
+    dataB.toCPSVCanonicalFormData.r_eq_one_of_shifted_transfer_trace hTraceB
+  obtain ⟨hRadiusB, hPrimitiveB⟩ :=
+    spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace
+      (Kraus.transferMap B) hTraceB
+  have hBNormal : MPSTensor.IsNormalTensor B :=
+    dataB.toCPSVCanonicalFormData.isNormalTensor_of_r_eq_one_of_fullSupport
+      hBlockCountB hFullB hRadiusB hPrimitiveB
+  exact ⟨Dred, hDred, B, dataB, by simpa [Dred] using hDimLe,
+    hSameB, hBNormal, hFullB⟩
+
+private noncomputable def ofNormalizedFlattening
+    (A : MPSTensor (d * d) D) : MPOTensor d D :=
+  fun i j => (Real.sqrt d : ℂ) • A (finProdFinEquiv (i, j))
+
+private theorem toMPSTensor_ofNormalizedFlattening
+    (A : MPSTensor (d * d) D) :
+    (ofNormalizedFlattening A).toMPSTensor =
+      fun ij => (Real.sqrt d : ℂ) • A ij := by
+  funext ij
+  rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
+    exact (finProdFinEquiv.apply_symm_apply ij).symm]
+  simp [ofNormalizedFlattening, MPOTensor.toMPSTensor]
+
+private theorem normalizedFlattening_ofNormalizedFlattening [NeZero d]
+    (A : MPSTensor (d * d) D) :
+    (ofNormalizedFlattening A).normalizedFlattening = A := by
+  have hd : (0 : ℝ) < d := by
+    exact_mod_cast NeZero.pos d
+  have hsqrt : (Real.sqrt d : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr hd).ne'
+  change (fun ij => ((Real.sqrt d : ℂ)⁻¹) •
+    (ofNormalizedFlattening A).toMPSTensor ij) = A
+  rw [toMPSTensor_ofNormalizedFlattening]
+  funext ij
+  rw [smul_smul, inv_mul_cancel₀ hsqrt, one_smul]
+
+private theorem sqrt_smul_normalizedFlattening [NeZero d]
+    (U : MPOTensor d D) :
+    (fun ij => (Real.sqrt d : ℂ) • U.normalizedFlattening ij) = U.toMPSTensor := by
+  have hd : (0 : ℝ) < d := by
+    exact_mod_cast NeZero.pos d
+  have hsqrt : (Real.sqrt d : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr hd).ne'
+  funext ij
+  simp [MPOTensor.normalizedFlattening, smul_smul, hsqrt]
+
+/-- Every matrix product unitary has a positive-dimensional
+canonical-form-II matrix product unitary representative of no larger bond
+dimension which generates the same periodic operators at every positive
+length.
+
+This is the representative-level form of the replacement used in
+arXiv:1703.09188, lines 257--294 and 319--326, with normality supplied by the
+shifted-transfer argument at lines 344--356. The dimension reduction and CFII
+gauge follow arXiv:1606.00608, lines 195--255 and 1058--1077. This theorem does
+not identify a virtual gauge between the original and reduced bond spaces,
+whose dimensions may differ. -/
+theorem IsMPU.exists_reduced_cfii_representative
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU) :
+    ∃ (Dred : ℕ) (_hDred : 0 < Dred) (Ured : MPOTensor d Dred)
+      (cfii : MPSTensor.CPSVCanonicalFormIIData Ured.normalizedFlattening),
+      Dred ≤ D ∧
+      (∀ N : ℕ, 0 < N → mpo Ured N = mpo U N) ∧
+      Ured.IsMPU ∧
+      cfii.toCPSVCanonicalFormData.HasFullSupport := by
+  obtain ⟨Dred, hDred, Ared, cfii, hDimLe, hSame, _hNormal, hFull⟩ :=
+    hU.exists_reduced_normalizedFlattening_cfii
+  let Ured : MPOTensor d Dred := ofNormalizedFlattening Ared
+  have hFlat : Ured.normalizedFlattening = Ared :=
+    normalizedFlattening_ofNormalizedFlattening Ared
+  have hRaw : MPSTensor.SameMPV₂Pos U.toMPSTensor Ured.toMPSTensor := by
+    mpv_ext
+    rw [← sqrt_smul_normalizedFlattening U,
+      toMPSTensor_ofNormalizedFlattening, MPSTensor.mpv_smul,
+      MPSTensor.mpv_smul, hSame N hN σ]
+  have hMpo : ∀ N : ℕ, 0 < N → mpo Ured N = mpo U N := by
+    intro N hN
+    ext σ τ
+    rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+      ← MPSTensor.mpv_toMPSTensor_pairConfig]
+    exact (hRaw N hN (fun n => finProdFinEquiv (σ n, τ n))).symm
+  have hUred : Ured.IsMPU := by
+    intro N hN
+    rw [hMpo N (Nat.zero_lt_of_lt hN)]
+    exact hU N hN
+  refine ⟨Dred, hDred, Ured, ?_⟩
+  rw [hFlat]
+  exact ⟨cfii, hDimLe, hMpo, hUred, hFull⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -89,6 +89,7 @@
 
 \begin{theorem}[Canonical form admits a canonical-form-II gauge]
     \label{thm:cpsv_cf_to_cfii_gauge}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormIIData}
     \lean{MPSTensor.CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII}
     \lean{MPSTensor.IsCPSVCanonicalForm.exists_gaugeEquiv_canonicalFormII}
     \leanok
@@ -100,8 +101,9 @@
         B^i
          & =G A^iG^{-1}.
     \end{align}
-    Moreover, $B$ is in canonical form II. This is the nonsingular gauge
-    assertion of \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
+    Moreover, $B$ is in canonical form II and the total retained block
+    dimension is unchanged. This is the nonsingular gauge assertion of
+    \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     % Maintainer source anchor: arXiv:1606.00608, lines 1058--1077,
     % especially eq:II_TPLambda and eq:II_XAX at lines 1062--1077.
 \end{theorem}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3459,6 +3459,137 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+\begin{theorem}[Reduced canonical representative of the normalized tensor]
+    \label{thm:mpu_reduced_normalized_flattening_cfii}
+    \lean{MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii}
+    \leanok
+    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii,
+        def:mpu_full_support, def:normal, def:same_mpv2_pos}
+    Let $d,D>0$, let $U$ be an MPU tensor of physical dimension $d$ and
+    bond dimension $D$, and let $\widetilde U=d^{-1/2}U$ be its normalized
+    doubled-index tensor. There are an integer $D_{\mathrm{red}}>0$, a normal
+    tensor $A_{\mathrm{red}}$ of bond dimension $D_{\mathrm{red}}$, and
+    canonical-form-II data for $A_{\mathrm{red}}$ such that, for every
+    integer $N>0$ and every word $\sigma$ of length $N$,
+    \begin{align}
+        D_{\mathrm{red}} & \leq D, \\
+        V^{(N)}(A_{\mathrm{red}})_\sigma
+            & =V^{(N)}(\widetilde U)_\sigma, \\
+        \sum_{k=1}^{r}D_k & =D_{\mathrm{red}}.
+    \end{align}
+    This organizes the dimension-bounded canonical replacement used in
+    \cite[lines~257--294 and 319--326]{Cirac2017MPU}. Its irreducible
+    reduction and canonical-form-II gauge are those of
+    \cite[lines~195--255 and 1058--1077]{Cirac2016MPDO_arXiv}. The shifted
+    transfer argument is the one used in
+    \cite[lines~344--356]{Cirac2017MPU}.
+    % Source role: replacement infrastructure, not a separately named source theorem.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_canonical_form,
+        thm:nonzero_irreducible_block_decomposition,
+        lem:overlap_eq_of_pos_mpv, thm:mpu_transfer_matrix_overlap,
+        thm:mpu_normalized_transfer_trace,
+        thm:mpu_transfer_matrix_eigenvalues,
+        thm:mpu_dependent_block_inclusion_identities,
+        lem:transfer_map_corner_intertwine,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization,
+        thm:mpu_shifted_trace_power_spectrum,
+        thm:mpu_shifted_transfer_trace_single_block,
+        thm:mpu_shifted_transfer_trace_primitive,
+        thm:mpu_unique_full_support_normal,
+        thm:cpsv_cf_to_cfii_gauge, thm:gauge_invariance}
+    Remove the zero irreducible blocks of $\widetilde U$ and write
+    \begin{align}
+        A_0^i & =\bigoplus_{k=1}^{r}B_k^i,
+             & \sum_{k=1}^{r}D_k & \leq D, \\
+        V^{(N)}(A_0)_\sigma
+             & =V^{(N)}(\widetilde U)_\sigma,
+    \end{align}
+    for every $N>0$ and every word $\sigma$ of length $N$.
+    At $N=2$ the common self-overlap is one, so the retained sum is nonempty
+    and $D_0=\sum_kD_k>0$. For every integer $N>1$, overlap invariance gives
+    \begin{align}
+        \tr(E_{A_0}^{\,N})
+          & =\sum_\sigma\left|V^{(N)}(A_0)_\sigma\right|^2
+           =\sum_\sigma\left|V^{(N)}(\widetilde U)_\sigma\right|^2
+           =1.
+        \label{eq:mpu_reduced_trace}
+    \end{align}
+    Let $J_k:\mathbb C^{D_k}\to\mathbb C^{D_0}$ be the inclusion of the
+    $k$th block. Then
+    \begin{align}
+        J_k^\dagger J_k & =\Id,
+            & A_0^iJ_k & =J_kB_k^i, \\
+        \E_{A_0}(J_kXJ_k^\dagger)
+            & =J_k\E_{B_k}(X)J_k^\dagger.
+    \end{align}
+    Thus every nonzero transfer eigenvalue of $B_k$ is a nonzero eigenvalue of
+    $E_{A_0}$ and hence equals one by
+    (\ref{eq:mpu_reduced_trace}). Perron--Frobenius theory supplies
+    $\rho_k>0$ and $s_k>0$ with
+    $\E_{B_k}(\rho_k)=s_k\rho_k$. Therefore $s_k=1$, and every peripheral
+    eigenvalue of $B_k$ is also one. Each $B_k$ is consequently normal.
+
+    The direct sum now has literal canonical-form data with full support.
+    Apply the nonsingular blockwise canonical-form-II gauge. It preserves the
+    block dimensions and all periodic vectors, so the resulting tensor
+    $A_{\mathrm{red}}$ still satisfies
+    \begin{align}
+        \sum_{k=1}^{r}D_k & =D_{\mathrm{red}},
+            & \tr(E_{A_{\mathrm{red}}}^{\,N}) & =1,
+    \end{align}
+    for every integer $N>1$.
+    The shifted traces force $r=1$, spectral radius one, and primitivity.
+    Full support identifies the unique block with the ambient bond space, so
+    $A_{\mathrm{red}}$ is normal.
+\end{proof}
+
+\begin{theorem}[Reduced canonical representative of an MPU]
+    \label{thm:mpu_reduced_cfii_representative}
+    \lean{MPOTensor.IsMPU.exists_reduced_cfii_representative}
+    \leanok
+    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii,
+        def:mpu_full_support}
+    Let $d,D>0$ and let $U$ be an MPU tensor. There are
+    $D_{\mathrm{red}}>0$ and an MPU tensor $U_{\mathrm{red}}$ of bond
+    dimension $D_{\mathrm{red}}$ such that, for every integer $N>0$,
+    \begin{align}
+        D_{\mathrm{red}} & \leq D, \\
+        U_{\mathrm{red}}^{(N)} & =U^{(N)}.
+    \end{align}
+    The normalized doubled-index tensor of $U_{\mathrm{red}}$ has
+    canonical-form-II data whose retained block dimensions sum to
+    $D_{\mathrm{red}}$. No equality is asserted at length zero, and no
+    virtual gauge is asserted between the two potentially unequal-dimensional
+    bond spaces.
+    % Source role: MPU corollary of the canonical-replacement infrastructure.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_reduced_normalized_flattening_cfii,
+        lem:mpv_smul, lem:mpdo_three_first_site_contraction_coefficients}
+    Apply Theorem~\ref{thm:mpu_reduced_normalized_flattening_cfii} and write
+    its representative as $A_{\mathrm{red}}$. Define
+    \begin{align}
+        U_{\mathrm{red}}^{ij}
+            & =\sqrt d\,A_{\mathrm{red}}^{(i,j)}.
+    \end{align}
+    Since $d>0$, normalization recovers $A_{\mathrm{red}}$ exactly. For every
+    $N>0$ and every ket--bra pair $(\sigma,\tau)$, the doubled-index
+    coefficient identity gives
+    \begin{align}
+        (U_{\mathrm{red}}^{(N)})_{\sigma,\tau}
+          & =d^{N/2}V^{(N)}(A_{\mathrm{red}})_{(\sigma,\tau)} \\
+          & =d^{N/2}V^{(N)}(\widetilde U)_{(\sigma,\tau)} \\
+          & =(U^{(N)})_{\sigma,\tau}.
+    \end{align}
+    Hence the periodic operators agree at every positive length. For $N>1$
+    the right side is unitary, so $U_{\mathrm{red}}$ is an MPU.
+\end{proof}
+
 \begin{theorem}[Full support under physical blocking]
     \label{thm:mpu_full_support_blocking}
     \lean{MPSTensor.CPSVCanonicalFormData.hasFullSupport_blockTensor}

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -5,7 +5,7 @@
 \input{command}
 \title{Full Support in MPU Normality and Theorem III.8}
 \author{}
-\date{2026-08-12}
+\date{2026-08-24}
 \begin{document}
 \maketitle
 \gapnote{scope-restriction}{open}
@@ -31,7 +31,13 @@ coisometric embedding of the retained direct sum into a larger ambient bond
 space.  This choice is useful for exact reconstruction.  The proof of the
 proposition is correct for the intended reduced representative in which the
 ambient zero complement has been omitted, but the source does not state this
-reduction as a separate step and the formalization does not yet construct it.
+reduction as a separate theorem.  The formalization now constructs such a
+representative in
+\leanid{MPOTensor.IsMPU.exists_reduced_cfii_representative}.  It has positive
+bond dimension $D_{\mathrm{red}}\leq D$, has full-support
+canonical-form-II data, and generates the same periodic operators at every
+positive length.  It is a new representative; the theorem does not make the
+original ambient tensor normal.
 
 This distinction is necessary.  Starting with any MPU representative, adjoin a
 zero virtual direct summand.  Every periodic contraction is unchanged, hence
@@ -52,6 +58,14 @@ other retained block exists.  The ambient coisometry is square and hence
 unitary; block assembly and unitary conjugation transport irreducibility from
 the normal block to the ambient tensor.
 
+The normalized-flattening form of the construction is
+\leanid{MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii}.  Starting
+from the nonzero irreducible reduction, it transfers the shifted trace
+identities to the retained direct sum.  Every transfer eigenvalue of a retained
+block embeds into the ambient transfer spectrum.  Its positive Perron value
+and every peripheral value therefore equal one, so the retained blocks are
+normal.  The canonical-form-II gauge preserves their total bond dimension.
+
 \section{The source factors and Theorem III.8}
 Let $\mathcal U$ be an MPU tensor with physical dimension $d$ and bond
 dimension $D$, and let $E$ be the transfer matrix of the normalized tensor
@@ -60,6 +74,12 @@ without loss of generality that this normalized tensor is in canonical form II
 \cite[discussion following Proposition~III.1]{Cirac2017MPU}. Choose such data
 with full support.
 % Source lines: paper_v2.tex 350--356.
+The cited representative theorem justifies this replacement at the level
+of the positive-length periodic operator family.  It does not identify the
+compact-SVD source cuts or selected source factors of the new tensor with those
+of the original auxiliary presentation.  Consequently, results whose
+statements retain the source cuts of a named tensor still require source data
+for that same tensor, or a separate comparison theorem.
 Let $\mathcal A_1$ be its unique block, let $V$ be the inclusion
 of that block into the ambient bond space, and let $\Lambda$ be the block's
 diagonal positive right fixed point normalized to have trace one. Set
@@ -404,8 +424,11 @@ rather than only at its endpoints. The resulting non-strict conclusion compares 
 $\sigma^{(2)}$ of the two supplied witness endpoints
 $\mathcal W_{\mathrm{anc}}(0)$ and $\mathcal W_{\mathrm{anc}}(1)$. It does not
 compare $\sigma^{(2)}$ of the original MPU tensors. Promoting this witness-level
-equality to an original-tensor invariant requires preservation under adjoining
-identity ancillas, which remains open in issue~\#6138. All later time-reversal
+equality to an original-tensor invariant requires preservation of the selected
+source data under adjoining identity ancillas. The closed issue~\#6138 proves
+CFII and full-support preservation but does not identify the selected
+compact-SVD factors; that remaining boundary is tracked by issue~\#6136. All
+later time-reversal
 descendants and examples repeat the required endpoint and comparison data after
 blocking or adjoining ancillas. The swap transformation and its two dependent
 strict-phase statements require the actual source-constructed interpolation to
@@ -422,46 +445,41 @@ the coprimality condition in the blueprint definition of equivalence when
 $d>1$.
 
 For bond dimension one, the normalized transfer matrix supplies the source
-pair directly. For bond dimension greater than one, no current result
-constructs reduced full-support source data for every simple block or proves
-their preservation under blocking, adjoining ancillas, tensor products,
-composition, conjugation, adjoint, transposition, or continuous variation, or
-identifies the source data of a tensor with those of a reduced representative.
-Consequently the admissible Chapter~28 statements are restricted to the
-explicitly supplied tensors, comparison tensors, and chosen paths. The
-parallel source-labelled statements retain the hypotheses of the paper and
-remain unformalized. No restricted statement is presented under a source
-label.
+pair directly. For arbitrary positive bond dimension, the reduced
+representative theorem now supplies a full-support canonical-form-II tensor
+with the same positive-length periodic operators. It does not identify the
+source data of the original tensor with those of that representative. Nor does
+it prove preservation of such data under tensor products, composition,
+conjugation, adjoint, transposition, or continuous variation. Consequently the
+admissible Chapter~28 statements remain restricted to the explicitly supplied
+tensors, comparison tensors, and chosen paths. The parallel source-labelled
+statements retain the hypotheses of the paper and remain unformalized. No
+restricted statement is presented under a source label.
 
 \section{Elimination plan}
-The native source-data scope tracker is issue~\#6136. Its four implementation
-branches separate the logically distinct transport problems. Issue~\#6137
-constructs a reduced full-support representative and transports the source
-objects back to the tensor used in the theorem. Together with the independent
-complete-network issues~\#5982 and~\#6071, this is required before the
-admissible source-isometry and simple-tensor equivalence nodes can be merged
-into \texttt{lemuisometry} and \texttt{ThmFund1}. The admissible standard form
-can then be merged into \texttt{SF}.
+The native source-data scope tracker is issue~\#6136. The
+dimension-bounded full-support representative is constructed by issue~\#7065
+and the two theorems recorded above. This closes representative existence but
+does not transport selected compact-SVD factors across unequal bond spaces.
+The admissible source-unitary and standard-form construction is tracked by
+issue~\#7012, while issue~\#7127 owns the later unrestricted standard-form
+representative. The independent complete-network issues~\#5982 and~\#6071
+remain necessary for the source-$u$ and source-$v$ conclusions.
 
-Issue~\#6138 proves source-data preservation under physical blocking and
-adjoining identity ancillas. It removes the extra hypotheses from the
-admissible index definition, its well-definedness theorem, the blocked local
-symmetry statements, the sign-parity results, and the ancilla-dependent
-examples. Issue~\#6139 treats tensor products, composition, and conjugate,
-adjoint, transposed, and other transformed comparison tensors. It removes the
-extra endpoint and comparison-tensor assumptions from the admissible local
-symmetry and example nodes. Issue~\#6140 constructs continuous source data
-along strict-equivalence paths and their four fixed symmetry-transformed
-comparison paths. It removes the path hypotheses from the admissible
-continuity, symmetry-equivalence, phase-classification, swap, and
-MPS-comparison nodes.
+Issue~\#6139 treats tensor products, composition, and conjugate, adjoint,
+transposed, and other transformed comparison tensors. It removes the extra
+endpoint and comparison-tensor assumptions from the admissible local symmetry
+and example nodes. Issue~\#6140 constructs continuous source data along
+strict-equivalence paths and their four fixed symmetry-transformed comparison
+paths. It removes the path hypotheses from the admissible continuity,
+symmetry-equivalence, phase-classification, swap, and MPS-comparison nodes.
 
 The twenty-nine source/scoped pairs in the continuity and symmetry subtree are
 merged only after the relevant branches above are closed. Until then, every
 source label remains an unrestricted unformalized statement, while every
 reduced-source or path-dependent statement remains under its
-\texttt{mpu\_admissible} label. Closing issues~\#6137--\#6140 does not replace
-the independent proof obligations in issues~\#5982 and~\#6071.
+\texttt{mpu\_admissible} label. Representative existence does not replace the
+independent proof obligations in issues~\#5982 and~\#6071.
 
 \section{Verdict}
 \textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,
@@ -472,29 +490,31 @@ hypothesis of the normal-tensor proposition, and it does not follow from
 literal canonical-form membership alone.
 
 Consequently, a source-faithful formalization must construct this reduced
-representative and transport the source constructions, or explicitly assume
-chosen canonical-form-II data with full support. The formalization uses
-the latter option when $D>1$ and the direct one-dimensional stabilization when
-$D=1$. It does not yet construct the representative reduction in the
-higher-dimensional case. The original source labels therefore remain
-unrestricted and unformalized; the distinctly named admissible nodes record
-the current reduced full-support route.
+representative and, where a theorem retains named source cuts, separately
+justify the corresponding source constructions. The representative reduction
+is now formalized for every positive bond dimension, with equality of the
+periodic operator family at positive lengths. The admissible source statements
+still take full-support data for the same named tensor because no potentially
+unequal-dimensional source-factor identification is claimed. The original source
+labels therefore remain unrestricted and unformalized; the distinctly named
+admissible nodes record the current same-tensor source-data route.
 
-Within Theorem~III.8 itself, the two remaining proof gaps are the complete
+Within Theorem~III.8 itself, the remaining proof gaps include the complete
 source-$u$ contraction tracked by issue~\#5982 and the complete source-$v$
 equivalence tracked by issue~\#6071. Separately, the downstream standard-form,
 index, continuity, and symmetry results lack existence or preservation theorems
-for reduced source data under representative reduction, blocking, adjoining
-ancillas, tensor products, composition, transformed comparison tensors, and
-continuous paths. Chapter~28 treats all of these as explicit admissibility
-hypotheses rather than consequences of the MPU predicate.
+for reduced source data under products, transformed comparison tensors, and
+continuous paths. Chapter~28 treats these as explicit admissibility hypotheses
+rather than consequences of the MPU predicate.
 The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_r_eq_one_of_fullSupport}.
 The spectral-radius and primitivity conclusions are derived from the shifted
 normalized transfer traces and combined with full support in
 \leanid{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}.
-Bare \leanid{MPOTensor.IsMPU} is deliberately not used to infer ambient
-normality or an ambient positive definite fixed point.
+Bare \leanid{MPOTensor.IsMPU} is deliberately not used to infer normality or
+an ambient positive definite fixed point for the original, possibly
+nonminimal, representative. It instead supplies the reduced representative in
+\leanid{MPOTensor.IsMPU.exists_reduced_cfii_representative}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

An arbitrary MPU presentation may contain invariant triangular data that is invisible to every positive-length closed chain. The canonical-form construction in `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 195–225, removes this redundancy, while `Papers/quant-ph_0608197/MPSarchive.tex`, lines 742–763, states that the resulting bond dimension is at most the original one. For an MPU, `Papers/1703.09188/paper_v2.tex`, lines 344–356, then identifies the normalized tensor as normal and permits a CFII representative.

Issue #7065 asks for this reduction as an actual smaller positive-dimensional tensor, rather than a gauge relation between unequal ambient dimensions.

### Description

- Add a reduced direct-sum representative built from the nonzero irreducible blocks of the normalized flattening.
- Prove that the reduced bond dimension is positive and at most the original bond dimension.
- Use the MPU trace identities and transfer-spectrum inclusions to prove normality, a single retained block, and primitive peripheral spectrum.
- Gauge the reduced tensor to literal CPSV canonical form II while preserving its retained dimension, then inverse-normalize it to an MPO tensor.
- Prove equality of the generated MPOs for every positive chain length, transfer the MPU property, and expose a full-support CFII witness.
- Record the construction and its source-faithfulness boundary in the blueprint and the existing MPU paper-gap note.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.MPU.ReducedCanonicalRepresentative TNLean.MPS.MPU`
- `lake build TNLean`
- `texra-blueprint web`
- `lake exe checkdecls blueprint/lean_decls`
- `texra-blueprint paper-gaps check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py --root . --import-only-aggregator TNLean.lean`
- `python3 scripts/check_numbered_lean_files.py --root . --base-ref origin/main`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan for `sorry`, `admit`, `native_decide`, `unsafeCast`, and `axiom`

Closes #7065
