### PR TITLE
fix(Algebra): restore block-triangular API

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Algebra
 
+import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.BurnsideTheorem
 import TNLean.Algebra.CocycleCohomology

--- a/TNLean/Algebra/BlockTriangularTrace.lean
+++ b/TNLean/Algebra/BlockTriangularTrace.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+import TNLean.MPS.Core.MultiBlock
+
+import Mathlib.Data.Matrix.Block
+import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Block-triangular trace invariance for MPS tensors
+
+This file proves that strict upper-right blocks do not affect word traces of
+block upper-triangular tensors. It defines block-sum and reindexing maps and
+proves `sameMPV_upperFin_diagFin`, reducing an
+upper-triangular tensor to its block-diagonal part.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+section BlockTriangular
+
+variable {d n m : ℕ}
+
+/-- A `2×2` block upper-triangular tensor on `Fin n ⊕ Fin m` indices. -/
+noncomputable def upperSum
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    Fin d → Matrix (Fin n ⊕ Fin m) (Fin n ⊕ Fin m) ℂ :=
+  fun i => Matrix.fromBlocks (A11 i) (A12 i) 0 (A22 i)
+
+/-- The block-diagonal part of a `2×2` block tensor on `Fin n ⊕ Fin m` indices. -/
+noncomputable def diagSum
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    Fin d → Matrix (Fin n ⊕ Fin m) (Fin n ⊕ Fin m) ℂ :=
+  fun i => Matrix.fromBlocks (A11 i) 0 0 (A22 i)
+
+/-- Reindex `upperSum` from `Fin n ⊕ Fin m` to `Fin (n+m)`, producing an `MPSTensor d (n+m)`. -/
+noncomputable def upperFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    MPSTensor d (n + m) :=
+  fun i =>
+    Matrix.reindex (finSumFinEquiv (m := n) (n := m)) (finSumFinEquiv (m := n) (n := m))
+      (upperSum (d := d) (n := n) (m := m) A11 A12 A22 i)
+
+/-- Reindex `diagSum` from `Fin n ⊕ Fin m` to `Fin (n+m)`, producing an `MPSTensor d (n+m)`. -/
+noncomputable def diagFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    MPSTensor d (n + m) :=
+  fun i =>
+    Matrix.reindex (finSumFinEquiv (m := n) (n := m)) (finSumFinEquiv (m := n) (n := m))
+      (diagSum (d := d) (n := n) (m := m) A11 A22 i)
+
+
+/-- Trace of a block upper-triangular `2×2` matrix is the sum of the traces of its diagonal blocks.
+
+The strict upper-right block does not contribute to the trace. -/
+lemma trace_fromBlocks_upper (X : Matrix (Fin n) (Fin n) ℂ)
+    (Y : Matrix (Fin n) (Fin m) ℂ) (Z : Matrix (Fin m) (Fin m) ℂ) :
+    Matrix.trace (Matrix.fromBlocks X Y 0 Z) = Matrix.trace X + Matrix.trace Z := by
+  classical
+  -- Expand `trace` as a sum over the diagonal and split the `Sum` index.
+  simp [Matrix.trace, Fintype.sum_sum_type]
+
+
+/-- For any word `w`, evaluating `upperSum` gives an upper-triangular block matrix.
+
+The (inessential) upper-right block is carried by an auxiliary recursion `UR`. -/
+lemma evalWord_upperSum_is_fromBlocks
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    ∀ w : List (Fin d),
+      ∃ UR : Matrix (Fin n) (Fin m) ℂ,
+        _root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w =
+          Matrix.fromBlocks (_root_.evalWord A11 w) UR 0 (_root_.evalWord A22 w) := by
+  classical
+  intro w
+  induction w with
+  | nil =>
+      refine ⟨0, ?_⟩
+      simp [_root_.evalWord]
+  | cons i w ih =>
+      rcases ih with ⟨URw, hURw⟩
+      -- Multiply two block-upper-triangular matrices; the lower-left block stays `0`.
+      refine ⟨A11 i * URw + A12 i * _root_.evalWord A22 w, ?_⟩
+      simp [upperSum, _root_.evalWord, hURw, Matrix.fromBlocks_multiply]
+
+
+/-- Word evaluation of `diagSum` stays block diagonal. -/
+lemma evalWord_diagSum_is_fromBlocks
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    ∀ w : List (Fin d),
+      _root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w =
+        Matrix.fromBlocks (_root_.evalWord A11 w) 0 0 (_root_.evalWord A22 w) := by
+  classical
+  intro w
+  induction w with
+  | nil =>
+      simp [_root_.evalWord]
+  | cons i w ih =>
+      simp [diagSum, _root_.evalWord, ih, Matrix.fromBlocks_multiply]
+
+
+/-- The strict upper-right blocks of an upper-triangular tensor do not affect word traces. -/
+lemma trace_evalWord_upperSum_eq_trace_evalWord_diagSum
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    ∀ w : List (Fin d),
+      Matrix.trace (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
+        = Matrix.trace (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
+  classical
+  intro w
+  rcases evalWord_upperSum_is_fromBlocks (d := d) (n := n) (m := m) A11 A12 A22 w with
+    ⟨UR, hUR⟩
+  have hDiag := evalWord_diagSum_is_fromBlocks (d := d) (n := n) (m := m) A11 A22 w
+  -- Now take traces; the upper-right block is irrelevant.
+  simp [hUR, hDiag, trace_fromBlocks_upper]
+
+
+/-- Deleting the strict upper-right blocks of a block upper-triangular tensor does not change MPVs
+(after reindexing from `Fin n ⊕ Fin m` to `Fin (n+m)`). -/
+lemma mpv_upperFin_eq_mpv_diagFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ)
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (upperFin (d := d) (n := n) (m := m) A11 A12 A22) σ =
+      mpv (diagFin (d := d) (n := n) (m := m) A11 A22) σ := by
+  classical
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv (m := n) (n := m)
+  set w : List (Fin d) := List.ofFn σ with hw
+  -- Expand the MPV coefficients.
+  simp only [MPSTensor.mpv, MPSTensor.coeff, hw.symm]
+  -- Commute `Kraus.evalWord` with reindexing, then drop the reindexing inside `trace`.
+  have hUpperEval :
+      Kraus.evalWord (upperFin (d := d) (n := n) (m := m) A11 A12 A22) w =
+        Matrix.reindex e e
+          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w) := by
+    change Kraus.evalWord
+        (fun i => Matrix.reindex e e
+          (upperSum (d := d) (n := n) (m := m) A11 A12 A22 i)) w =
+        Matrix.reindex e e
+          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
+    exact
+      (MPSTensor.evalWord_reindex (d := d) (D := n + m) (e := e)
+        (A := upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
+  have hDiagEval :
+      Kraus.evalWord (diagFin (d := d) (n := n) (m := m) A11 A22) w =
+        Matrix.reindex e e
+          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
+    change Kraus.evalWord
+        (fun i => Matrix.reindex e e
+          (diagSum (d := d) (n := n) (m := m) A11 A22 i)) w =
+        Matrix.reindex e e
+          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)
+    exact
+      (MPSTensor.evalWord_reindex (d := d) (D := n + m) (e := e)
+        (A := diagSum (d := d) (n := n) (m := m) A11 A22) w)
+  -- Reduce to the Sum-index trace identity.
+  --
+  -- `trace (reindex e e M) = trace M`, so the reindexing from `Fin n ⊕ Fin m` to `Fin (n+m)`
+  -- does not affect the coefficient.
+  calc
+    Matrix.trace (Kraus.evalWord (upperFin (d := d) (n := n) (m := m) A11 A12 A22) w)
+        = Matrix.trace (Matrix.reindex e e
+            (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)) := by
+          simp [hUpperEval]
+    _ = Matrix.trace
+          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w) := by
+          simpa using (Matrix.trace_reindex e
+            (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w))
+    _ = Matrix.trace
+          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
+          simpa using
+            trace_evalWord_upperSum_eq_trace_evalWord_diagSum
+              (d := d) (n := n) (m := m) A11 A12 A22 w
+    _ = Matrix.trace (Matrix.reindex e e
+          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)) := by
+          simpa using (Matrix.trace_reindex e
+            (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)).symm
+    _ = Matrix.trace (Kraus.evalWord (diagFin (d := d) (n := n) (m := m) A11 A22) w) := by
+          simp [hDiagEval]
+
+
+/-- Final `SameMPV` statement: upper-triangular off-diagonal blocks are irrelevant for MPVs. -/
+theorem sameMPV_upperFin_diagFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    SameMPV (upperFin (d := d) (n := n) (m := m) A11 A12 A22)
+      (diagFin (d := d) (n := n) (m := m) A11 A22) := by
+  intro N σ
+  simpa using
+    mpv_upperFin_eq_mpv_diagFin (d := d) (n := n) (m := m) A11 A12 A22 (N := N) σ
+
+end BlockTriangular
+
+end MPSTensor

--- a/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
+++ b/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
@@ -1,18 +1,18 @@
-# Issue 6861: dead-module deletion audit
+# Issue 6861: compatibility retirement audit
 
-This note records the first TNLean-local orphan-module deletion from the
-August 2026 mass-deletion review. The audit was repeated at the branch point
-from `main`: none of the names below has a non-`Archive` Lean consumer, and no
-Blueprint `\lean{...}` tag names one of them.
+This note records the compatibility decision for two TNLean-local modules from
+the August 2026 mass-deletion review. The audit was repeated at the branch
+point from `main`: none of the names below has a non-`Archive` Lean consumer,
+and no Blueprint `\lean{...}` tag names one of them.
 
 Repository-wide prose search finds only dated inventory snapshots in
 `docs/audits/`. These records describe earlier tree states; they neither
 prescribe an import nor present either module as a current public interface.
 
-## `TNLean/Algebra/BlockTriangularTrace.lean`
+## Retained: `TNLean/Algebra/BlockTriangularTrace.lean`
 
-The whole module was reachable only through the generated `TNLean.Algebra`
-aggregator. The following declarations are removed without replacements:
+The whole module is reachable only through the generated `TNLean.Algebra`
+aggregator. It contains the following substantive public declarations:
 
 - `MPSTensor.upperSum`;
 - `MPSTensor.diagSum`;
@@ -25,11 +25,13 @@ aggregator. The following declarations are removed without replacements:
 - `MPSTensor.mpv_upperFin_eq_mpv_diagFin`;
 - `MPSTensor.sameMPV_upperFin_diagFin`.
 
-These declarations formed one abandoned upper-triangular reduction route. No
-retained theorem depends on the route, so introducing a replacement wrapper
-would preserve the dead layer rather than preserve a public mathematical API.
+These declarations have no named replacements. They therefore do not satisfy
+the immediate-removal exception in `docs/project_conventions.md`, which is
+limited to exact pass-through declarations, bundled fields, and proof-step
+names replaced at their use sites. The module and its aggregator import remain
+available until a valid compatibility transition is specified.
 
-## `TNLean/Wielandt/RankOne/MatrixFittingRange.lean`
+## Retired: `TNLean/Wielandt/RankOne/MatrixFittingRange.lean`
 
 This module contained only deprecated aliases of QICLean-owned declarations.
 Each removed compatibility name and its surviving replacement are:
@@ -57,4 +59,5 @@ Each removed compatibility name and its surviving replacement are:
 | `MPSTensor.WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow` | `Matrix.eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow` |
 
 The generated `TNLean.Algebra` and `TNLean.Wielandt.RankOne` aggregators were
-regenerated after both files were removed.
+regenerated. The former continues to import `BlockTriangularTrace`; the latter
+no longer imports `MatrixFittingRange`.


### PR DESCRIPTION
### Motivation

PR #7130 removed `TNLean/Algebra/BlockTriangularTrace.lean` as an unused module. That module contains ten substantive public declarations with no named replacements. Under `docs/project_conventions.md`, immediate removal without a compatibility transition is limited to exact pass-through declarations, bundled fields, and proof-step names replaced at their use sites. The block-triangular API does not satisfy that exception.

### Description

- Restores `TNLean/Algebra/BlockTriangularTrace.lean` byte-for-byte from the parent of #7130.
- Regenerates `TNLean.Algebra`, restoring its import of the module.
- Corrects the #6861 audit to distinguish the retained substantive API from the valid retirement of `MatrixFittingRange.lean` and its nineteen deprecated aliases.

This correction leaves the fitting-range alias retirement from #7130 intact. The broad #6861 tracker remains open for its other independent cleanup candidates.

### Testing

- `lake build TNLean.Algebra.BlockTriangularTrace TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root .`
- `PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`
- Verified that the restored file has the exact pre-deletion Git blob `81fdd84fc1335b09604609d66d6093b7d1217f5b`.

Corrects #7130.
Addresses #6861.
