### PR TITLE
doc(Algebra): clarify block-triangular replacement path

### DIFF
--- a/TNLean/Algebra/BlockTriangularTrace.lean
+++ b/TNLean/Algebra/BlockTriangularTrace.lean
@@ -16,6 +16,12 @@ This file proves that strict upper-right blocks do not affect word traces of
 block upper-triangular tensors. It defines block-sum and reindexing maps and
 proves `sameMPV_upperFin_diagFin`, reducing an
 upper-triangular tensor to its block-diagonal part.
+
+The coordinate-free strict generalization is
+`MPSTensor.sameMPV_diagPart_of_lowerZero` in
+`TNLean.Algebra.ProjectionTriangularTrace`. The declarations here retain the
+two-block coordinate presentation as a compatibility interface; they should be
+derived from that projection formulation before deprecation.
 -/
 
 open scoped Matrix BigOperators

--- a/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
+++ b/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
@@ -25,11 +25,21 @@ aggregator. It contains the following substantive public declarations:
 - `MPSTensor.mpv_upperFin_eq_mpv_diagFin`;
 - `MPSTensor.sameMPV_upperFin_diagFin`.
 
-These declarations have no named replacements. They therefore do not satisfy
-the immediate-removal exception in `docs/project_conventions.md`, which is
-limited to exact pass-through declarations, bundled fields, and proof-step
-names replaced at their use sites. The module and its aggregator import remain
-available until a valid compatibility transition is specified.
+These declarations are not literal pass-throughs, but their mathematical
+content is the two-block coordinate specialization of the projection-based API
+in `TNLean/Algebra/ProjectionTriangularTrace.lean`. In particular,
+`MPSTensor.sameMPV_diagPart_of_lowerZero` is the coordinate-free strict
+generalization of `MPSTensor.sameMPV_upperFin_diagFin`, with the remaining
+projection lemmas supplying the corresponding word-evaluation and trace
+statements.
+
+Issue #7135 tracks the missing compatibility transition: the ten coordinate
+names are to be rederived as thin specializations of the projection API before
+deprecation is considered. Until then they do not satisfy the
+immediate-removal exception in `docs/project_conventions.md`, which is limited
+to exact pass-through declarations, bundled fields, and proof-step names
+replaced at their use sites. The module and its aggregator import therefore
+remain available.
 
 ## Retired: `TNLean/Wielandt/RankOne/MatrixFittingRange.lean`
 


### PR DESCRIPTION
### Motivation

The retrospective review of #7133 correctly observed that the compatibility audit described the coordinate block-triangular declarations as having no named replacements. `TNLean.Algebra.ProjectionTriangularTrace` already provides a strict, coordinate-free generalization, although the ten coordinate declarations are not yet literal pass-throughs and therefore are not eligible for immediate removal.

### Description

- Corrects the audit to identify the projection-triangular API as the mathematical replacement route.
- Explains why the coordinate API remains available until a valid compatibility transition is complete.
- Adds the same relationship to the `BlockTriangularTrace` module documentation.
- Links #7135, which narrowly tracks rederiving the ten coordinate declarations as thin specializations before any deprecation is considered.

### Testing

- `lake build TNLean.Algebra.BlockTriangularTrace TNLean.Algebra.ProjectionTriangularTrace TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root .`
- changed-declaration Blueprint coverage check

Follow-up to #7133. Related to #6861 and #7135.