### PR TITLE
feat(QCA): add finite-region restrictions

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -10,12 +10,14 @@ Authors: TNLean contributors
 
 import TNLean.QCA.AlgebraicBlocking
 import TNLean.QCA.AlgebraicTranslation
+import TNLean.QCA.BipartiteLocalAlgebra
 import TNLean.QCA.BipartiteSupportAlgebra
 import TNLean.QCA.Blocking
 import TNLean.QCA.BlockingQCA
 import TNLean.QCA.BlockingTranslation
 import TNLean.QCA.CompatibleLocalAutomorphism
 import TNLean.QCA.DisjointSupport
+import TNLean.QCA.FiniteLocalRestriction
 import TNLean.QCA.FinitePropagation
 import TNLean.QCA.InversePropagation
 import TNLean.QCA.IsQCA

--- a/TNLean/QCA/BipartiteLocalAlgebra.lean
+++ b/TNLean/QCA/BipartiteLocalAlgebra.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.MatrixKroneckerEmbed
+import TNLean.QCA.LocalAlgebra
+
+/-!
+# Bipartite coordinates for finite-region observable algebras
+
+For disjoint finite regions \(\Lambda\) and \(\Gamma\), restriction to the two regions identifies
+configurations on \(\Lambda\cup\Gamma\) with pairs of configurations. Reindexing rows and columns
+along this identification gives a star-algebra equivalence
+\[
+  \mathcal A_{\Lambda\cup\Gamma}\simeq
+  M_{\operatorname{Config}(\Lambda)\times\operatorname{Config}(\Gamma)}(\mathbb C).
+\]
+The canonical inclusions from the two regions become the left and right Kronecker embeddings in
+this order. This is the finite-dimensional coordinate boundary used before applying matrix support
+algebras; no support algebra is defined here.
+
+## Main definitions
+
+* `SpinChain.Config.disjointUnionEquiv` — configurations on a disjoint union as pairs.
+* `SpinChain.bipartiteLocalAlgebraEquiv` — the associated matrix star-algebra equivalence.
+* `SpinChain.StarSubalgebra.bipartiteReindex` — a local star-subalgebra in the resulting fixed
+  left/right matrix coordinates.
+
+## Main results
+
+* `SpinChain.bipartiteLocalAlgebraEquiv_localInclusion_left` — the left local inclusion is
+  \(A\mapsto A\otimes 1\).
+* `SpinChain.bipartiteLocalAlgebraEquiv_localInclusion_right` — the right local inclusion is
+  \(B\mapsto 1\otimes B\).
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2298.
+* Schumacher--Werner, quant-ph/0405174, lines 270--293 and Definition 1.
+* Gross--Nesme--Vogts--Werner, arXiv:0910.3675v2, lines 1249--1266.
+-/
+
+open scoped Kronecker
+
+namespace SpinChain
+
+namespace Config
+
+/-- The complementary sites of the left region in a disjoint union are the sites of the right
+region.
+
+Source context: this is the site identification underlying GNVW, arXiv:0910.3675v2,
+equation `RR2x`, lines 1249--1266. -/
+private def leftComplementSiteEquiv {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    ↥((Λ ∪ Γ) \ Λ) ≃ ↥Γ where
+  toFun i := ⟨i, (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_left
+    (Finset.mem_sdiff.mp i.2).2⟩
+  invFun i := ⟨i, Finset.mem_sdiff.mpr
+    ⟨Finset.mem_union_right Λ i.2, hΛΓ.notMem_of_mem_right_finset i.2⟩⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Reindexing complementary configurations from the left split by the right-region sites.
+
+Source context: this is the configuration identification underlying GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+private def leftComplementEquiv (d : ℕ) {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    Config d ((Λ ∪ Γ) \ Λ) ≃ Config d Γ :=
+  (leftComplementSiteEquiv hΛΓ).arrowCongr (Equiv.refl (Fin d))
+
+/-- The complementary sites of the right region in a disjoint union are the sites of the left
+region.
+
+Source context: this is the site identification underlying GNVW, arXiv:0910.3675v2,
+equation `RR2x`, lines 1249--1266. -/
+private def rightComplementSiteEquiv {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    ↥((Λ ∪ Γ) \ Γ) ≃ ↥Λ where
+  toFun i := ⟨i, (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_right
+    (Finset.mem_sdiff.mp i.2).2⟩
+  invFun i := ⟨i, Finset.mem_sdiff.mpr
+    ⟨Finset.mem_union_left Γ i.2, hΛΓ.notMem_of_mem_left_finset i.2⟩⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Reindexing complementary configurations from the right split by the left-region sites.
+
+Source context: this is the configuration identification underlying GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+private def rightComplementEquiv (d : ℕ) {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    Config d ((Λ ∪ Γ) \ Γ) ≃ Config d Λ :=
+  (rightComplementSiteEquiv hΛΓ).arrowCongr (Equiv.refl (Fin d))
+
+/-- Reindexing restriction to the left complement agrees with restriction to the right region.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+private lemma leftComplementEquiv_restrict {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x : Config d (Λ ∪ Γ)) :
+    leftComplementEquiv d hΛΓ
+        (restrict (Finset.sdiff_subset : (Λ ∪ Γ) \ Λ ⊆ Λ ∪ Γ) x) =
+      restrict Finset.subset_union_right x := by
+  funext i
+  rfl
+
+/-- Reindexing restriction to the right complement agrees with restriction to the left region.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+private lemma rightComplementEquiv_restrict {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x : Config d (Λ ∪ Γ)) :
+    rightComplementEquiv d hΛΓ
+        (restrict (Finset.sdiff_subset : (Λ ∪ Γ) \ Γ ⊆ Λ ∪ Γ) x) =
+      restrict Finset.subset_union_left x := by
+  funext i
+  rfl
+
+/-- Splitting configurations on a union of disjoint regions into the two restrictions.
+
+The first component is the configuration on `Λ` and the second is the configuration on `Γ`.
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+def disjointUnionEquiv {d : ℕ} {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    Config d (Λ ∪ Γ) ≃ Config d Λ × Config d Γ :=
+  (splitEquiv (d := d) (Finset.subset_union_left : Λ ⊆ Λ ∪ Γ)).trans
+    ((Equiv.refl (Config d Λ)).prodCongr (leftComplementEquiv d hΛΓ))
+
+/-- The first component of the disjoint-union equivalence is restriction to the left region.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+lemma disjointUnionEquiv_apply_fst {d : ℕ} {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ)
+    (x : Config d (Λ ∪ Γ)) :
+    (disjointUnionEquiv hΛΓ x).1 = restrict Finset.subset_union_left x :=
+  rfl
+
+/-- The second component of the disjoint-union equivalence is restriction to the right region.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+lemma disjointUnionEquiv_apply_snd {d : ℕ} {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ)
+    (x : Config d (Λ ∪ Γ)) :
+    (disjointUnionEquiv hΛΓ x).2 = restrict Finset.subset_union_right x := by
+  exact leftComplementEquiv_restrict hΛΓ x
+
+/-- Restricting a reconstructed pair to the left region recovers its first component.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+lemma restrict_disjointUnionEquiv_symm_left {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x : Config d Λ × Config d Γ) :
+    restrict Finset.subset_union_left ((disjointUnionEquiv hΛΓ).symm x) = x.1 :=
+  by simpa only [disjointUnionEquiv_apply_fst] using
+    congrArg Prod.fst ((disjointUnionEquiv hΛΓ).apply_symm_apply x)
+
+/-- Restricting a reconstructed pair to the right region recovers its second component.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+lemma restrict_disjointUnionEquiv_symm_right {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x : Config d Λ × Config d Γ) :
+    restrict Finset.subset_union_right ((disjointUnionEquiv hΛΓ).symm x) = x.2 :=
+  by simpa only [disjointUnionEquiv_apply_snd] using
+    congrArg Prod.snd ((disjointUnionEquiv hΛΓ).apply_symm_apply x)
+
+/-- Equality of the complementary coordinates for the left split is equality after restriction to
+the right region.
+
+Source context: this coordinate identity underlies the left tensor factor in GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266; it is not stated separately there. -/
+lemma splitEquiv_snd_eq_iff_restrict_right {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
+    (splitEquiv Finset.subset_union_left x).2 =
+        (splitEquiv Finset.subset_union_left y).2 ↔
+      restrict Finset.subset_union_right x = restrict Finset.subset_union_right y := by
+  rw [splitEquiv_snd_eq_iff_restrict_sdiff]
+  constructor
+  · intro h
+    simpa only [leftComplementEquiv_restrict] using
+      congrArg (leftComplementEquiv d hΛΓ) h
+  · intro h
+    apply (leftComplementEquiv d hΛΓ).injective
+    simpa only [leftComplementEquiv_restrict] using h
+
+/-- Equality of the complementary coordinates for the right split is equality after restriction
+to the left region.
+
+Source context: this coordinate identity underlies the right tensor factor in GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266; it is not stated separately there. -/
+lemma splitEquiv_snd_eq_iff_restrict_left {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
+    (splitEquiv Finset.subset_union_right x).2 =
+        (splitEquiv Finset.subset_union_right y).2 ↔
+      restrict Finset.subset_union_left x = restrict Finset.subset_union_left y := by
+  rw [splitEquiv_snd_eq_iff_restrict_sdiff]
+  constructor
+  · intro h
+    simpa only [rightComplementEquiv_restrict] using
+      congrArg (rightComplementEquiv d hΛΓ) h
+  · intro h
+    apply (rightComplementEquiv d hΛΓ).injective
+    simpa only [rightComplementEquiv_restrict] using h
+
+end Config
+
+variable {d : ℕ} {Λ Γ : Finset ℤ}
+
+/-- Bipartite matrix coordinates for the observable algebra on a disjoint union.
+
+The left matrix factor corresponds to `Λ` and the right matrix factor corresponds to `Γ`.
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+noncomputable def bipartiteLocalAlgebraEquiv (hΛΓ : Disjoint Λ Γ) :
+    LocalAlgebra d (Λ ∪ Γ) ≃⋆ₐ[ℂ]
+      Matrix (Config d Λ × Config d Γ) (Config d Λ × Config d Γ) ℂ :=
+  (CStarMatrix.reindexₐ ℂ ℂ (Config.disjointUnionEquiv hΛΓ)).trans
+    CStarMatrix.ofMatrixStarAlgEquiv.symm
+
+/-- Evaluation of the bipartite equivalence is simultaneous reindexing by the reconstructed left
+and right configurations.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+@[simp]
+lemma bipartiteLocalAlgebraEquiv_apply (hΛΓ : Disjoint Λ Γ)
+    (A : LocalAlgebra d (Λ ∪ Γ)) (x y : Config d Λ × Config d Γ) :
+    bipartiteLocalAlgebraEquiv hΛΓ A x y =
+      A ((Config.disjointUnionEquiv hΛΓ).symm x)
+        ((Config.disjointUnionEquiv hΛΓ).symm y) :=
+  rfl
+
+/-- In bipartite coordinates, inclusion from the left region is tensoring on the right by the
+identity matrix.
+
+This fixes the tensor-factor orientation used by the support algebra in GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+theorem bipartiteLocalAlgebraEquiv_localInclusion_left (hΛΓ : Disjoint Λ Γ)
+    (A : LocalAlgebra d Λ) :
+    bipartiteLocalAlgebraEquiv hΛΓ
+        (localInclusion (d := d) Finset.subset_union_left A) =
+      Matrix.leftKroneckerEmbed (n := Config d Γ) (CStarMatrix.ofMatrix.symm A) := by
+  ext x y
+  rw [bipartiteLocalAlgebraEquiv_apply, localInclusion_apply]
+  simp only [Config.splitEquiv_snd_eq_iff_restrict_right hΛΓ]
+  simp only [Config.restrict_disjointUnionEquiv_symm_left,
+    Config.restrict_disjointUnionEquiv_symm_right]
+  simp [Matrix.leftKroneckerEmbed_apply, Matrix.kroneckerMap_apply, Matrix.one_apply]
+
+/-- In bipartite coordinates, inclusion from the right region is tensoring on the left by the
+identity matrix.
+
+This fixes the tensor-factor orientation used by the support algebra in GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. -/
+theorem bipartiteLocalAlgebraEquiv_localInclusion_right (hΛΓ : Disjoint Λ Γ)
+    (B : LocalAlgebra d Γ) :
+    bipartiteLocalAlgebraEquiv hΛΓ
+        (localInclusion (d := d) Finset.subset_union_right B) =
+      Matrix.rightKroneckerEmbed (m := Config d Λ) (CStarMatrix.ofMatrix.symm B) := by
+  ext x y
+  rw [bipartiteLocalAlgebraEquiv_apply, localInclusion_apply]
+  simp only [Config.splitEquiv_snd_eq_iff_restrict_left hΛΓ]
+  simp only [Config.restrict_disjointUnionEquiv_symm_left,
+    Config.restrict_disjointUnionEquiv_symm_right]
+  simp [Matrix.rightKroneckerEmbed_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+    mul_comm]
+
+/-- A finite-region star-subalgebra written in the bipartite matrix coordinates of two disjoint
+regions.
+
+The result is a star-subalgebra of the bipartite matrix algebra on which the left and right support
+algebras are defined. No support algebra is formed here.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. This is the canonical
+finite-dimensional coordinate construction determined by that decomposition, not a separately
+stated source definition. -/
+noncomputable def StarSubalgebra.bipartiteReindex (hΛΓ : Disjoint Λ Γ)
+    (S : StarSubalgebra ℂ (LocalAlgebra d (Λ ∪ Γ))) :
+    StarSubalgebra ℂ
+      (Matrix (Config d Λ × Config d Γ) (Config d Λ × Config d Γ) ℂ) :=
+  S.map (bipartiteLocalAlgebraEquiv hΛΓ).toStarAlgHom
+
+end SpinChain

--- a/TNLean/QCA/DisjointSupport.lean
+++ b/TNLean/QCA/DisjointSupport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.QCA.BipartiteLocalAlgebra
 import TNLean.QCA.FinitePropagation
 
 /-!
@@ -31,77 +32,6 @@ named result of the source.
 -/
 
 namespace SpinChain
-
-namespace Config
-
-/-- A configuration on a disjoint union is determined by its restrictions to both regions.
-
-This is elementary finite tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
-lines 2292--2300. -/
-private lemma eq_of_restrict_eq_restrict {d : ℕ} {Λ Γ : Finset ℤ}
-    {x y : Config d (Λ ∪ Γ)}
-    (hΛ : restrict Finset.subset_union_left x = restrict Finset.subset_union_left y)
-    (hΓ : restrict Finset.subset_union_right x = restrict Finset.subset_union_right y) :
-    x = y := by
-  funext i
-  rcases Finset.mem_union.mp i.2 with hiΛ | hiΓ
-  · exact congrFun hΛ ⟨i, hiΛ⟩
-  · exact congrFun hΓ ⟨i, hiΓ⟩
-
-/-- Splitting configurations on a union of disjoint regions into the two restrictions. -/
-private def disjointUnionEquiv {d : ℕ} {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
-    Config d (Λ ∪ Γ) ≃ Config d Λ × Config d Γ where
-  toFun x := (restrict Finset.subset_union_left x, restrict Finset.subset_union_right x)
-  invFun x i := if hiΛ : (i : ℤ) ∈ Λ then x.1 ⟨i, hiΛ⟩ else
-    x.2 ⟨i, (Finset.mem_union.mp i.2).resolve_left hiΛ⟩
-  left_inv x := by
-    apply eq_of_restrict_eq_restrict
-    · funext i
-      simp [restrict]
-    · funext i
-      simp [restrict, hΛΓ.notMem_of_mem_right_finset i.2]
-  right_inv x := by
-    apply Prod.ext
-    · funext i
-      simp [restrict]
-    · funext i
-      simp [restrict, hΛΓ.notMem_of_mem_right_finset i.2]
-
-private lemma splitEquiv_snd_eq_iff_restrict_right {d : ℕ} {Λ Γ : Finset ℤ}
-    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
-    (splitEquiv Finset.subset_union_left x).2 =
-        (splitEquiv Finset.subset_union_left y).2 ↔
-      restrict Finset.subset_union_right x = restrict Finset.subset_union_right y := by
-  constructor
-  · intro h
-    funext i
-    exact congrFun h ⟨i, Finset.mem_sdiff.mpr
-      ⟨Finset.mem_union_right Λ i.2, hΛΓ.notMem_of_mem_right_finset i.2⟩⟩
-  · intro h
-    funext i
-    have hiΓ : (i : ℤ) ∈ Γ :=
-      (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_left
-        (Finset.mem_sdiff.mp i.2).2
-    exact congrFun h ⟨i, hiΓ⟩
-
-private lemma splitEquiv_snd_eq_iff_restrict_left {d : ℕ} {Λ Γ : Finset ℤ}
-    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
-    (splitEquiv Finset.subset_union_right x).2 =
-        (splitEquiv Finset.subset_union_right y).2 ↔
-      restrict Finset.subset_union_left x = restrict Finset.subset_union_left y := by
-  constructor
-  · intro h
-    funext i
-    exact congrFun h ⟨i, Finset.mem_sdiff.mpr
-      ⟨Finset.mem_union_left Γ i.2, hΛΓ.notMem_of_mem_left_finset i.2⟩⟩
-  · intro h
-    funext i
-    have hiΛ : (i : ℤ) ∈ Λ :=
-      (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_right
-        (Finset.mem_sdiff.mp i.2).2
-    exact congrFun h ⟨i, hiΛ⟩
-
-end Config
 
 section Local
 

--- a/TNLean/QCA/FiniteLocalRestriction.lean
+++ b/TNLean/QCA/FiniteLocalRestriction.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.BipartiteLocalAlgebra
+import TNLean.QCA.FinitePropagation
+import TNLean.QCA.TranslationCovariance
+
+/-!
+# Finite-region restrictions of finite-propagation automorphisms
+
+If a quasi-local star-automorphism \(\omega\) propagates within a finite neighborhood
+\(\mathcal N\), the inclusion
+\[
+  \omega(\mathcal A_\Lambda)\subseteq\mathcal A_{\Lambda+\mathcal N}
+\]
+determines a unique injective star-algebra homomorphism
+\[
+  \omega_{\Lambda,\mathcal N}\colon
+  \mathcal A_\Lambda\longrightarrow\mathcal A_{\Lambda+\mathcal N}.
+\]
+These finite-region restrictions commute with enlargement of the source region. For a
+translation-covariant automorphism, their canonical quasi-local images also commute with every
+lattice translation. Their ranges provide the finite-dimensional star-subalgebras to which the
+bipartite coordinates of `TNLean.QCA.BipartiteLocalAlgebra` may subsequently be applied.
+
+No support algebra, matrix-factor theorem, adjacent-block generation theorem, or generalized
+Margolus unitary is constructed here.
+
+## Main definitions
+
+* `SpinChain.PropagatesWithin.localRestriction` — the finite-region restriction of the
+  automorphism.
+* `SpinChain.PropagatesWithin.localRestrictionRange` — its range as a finite-dimensional
+  star-subalgebra.
+* `SpinChain.PropagatesWithin.bipartiteLocalRestrictionRange` — that range in fixed left/right
+  matrix coordinates when the target is a disjoint union.
+
+## Main results
+
+* `SpinChain.PropagatesWithin.quasiLocalObservable_localRestriction` — the defining quasi-local
+  equality.
+* `SpinChain.PropagatesWithin.localRestriction_injective` — injectivity.
+* `SpinChain.PropagatesWithin.localRestriction_localInclusion` — compatibility under enlargement.
+* `SpinChain.PropagatesWithin.localRestriction_translation` — translation naturality in the
+  canonical quasi-local algebra.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2298.
+* Schumacher--Werner, quant-ph/0405174, Definition 1 and Lemma `lem:localrule`.
+-/
+
+namespace SpinChain
+
+namespace PropagatesWithin
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+  {𝓝 : Finset ℤ}
+
+/-- The finite-region restriction of an automorphism with propagation neighborhood
+\(\mathcal N\).
+
+It is the unique map \(\omega_{\Lambda,\mathcal N}\) satisfying
+\[
+  \iota_{\Lambda+\mathcal N}(\omega_{\Lambda,\mathcal N}(A))
+    =\omega(\iota_\Lambda(A)).
+\]
+The construction restricts the codomain of the quasi-local action to the range of the target
+finite-region embedding, then uses the injectivity of that embedding. It therefore makes no
+elementwise choice of local representatives.
+
+Source context: arXiv:1703.09188, Appendix, line 2298; Schumacher--Werner,
+quant-ph/0405174, Definition 1, lines 309--318. This finite-region map is the canonical map
+determined by the cited locality inclusion, not a separately stated definition in either source. -/
+noncomputable def localRestriction (hω : PropagatesWithin ω 𝓝) (Λ : Finset ℤ) :
+    LocalAlgebra d Λ →⋆ₐ[ℂ] LocalAlgebra d (regionSumset Λ 𝓝) := by
+  let j := quasiLocalObservable d (regionSumset Λ 𝓝)
+  let f : LocalAlgebra d Λ →⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+    ω.toStarAlgHom.comp (quasiLocalObservable d Λ)
+  let fRange : LocalAlgebra d Λ →⋆ₐ[ℂ] j.range :=
+    f.codRestrict j.range fun A ↦ by
+      exact (propagatesWithin_iff_range_subset.mp hω Λ) ⟨A, rfl⟩
+  exact (StarAlgEquiv.ofInjective j
+    (quasiLocalObservable_injective d (regionSumset Λ 𝓝))).symm.toStarAlgHom.comp fRange
+
+/-- The defining equality for the finite-region restriction after the canonical quasi-local
+embeddings.
+
+Source context: arXiv:1703.09188, Appendix, line 2298. The displayed equality is the
+finite-dimensional form of the cited inclusion, rather than a separately stated source lemma. -/
+theorem quasiLocalObservable_localRestriction (hω : PropagatesWithin ω 𝓝)
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    quasiLocalObservable d (regionSumset Λ 𝓝) (hω.localRestriction Λ A) =
+      ω (quasiLocalObservable d Λ A) := by
+  let j := quasiLocalObservable d (regionSumset Λ 𝓝)
+  let f : LocalAlgebra d Λ →⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+    ω.toStarAlgHom.comp (quasiLocalObservable d Λ)
+  have hfA : f A ∈ j.range :=
+    (propagatesWithin_iff_range_subset.mp hω Λ) ⟨A, rfl⟩
+  let y : j.range := ⟨f A, hfA⟩
+  let e := StarAlgEquiv.ofInjective j
+    (quasiLocalObservable_injective d (regionSumset Λ 𝓝))
+  change j (e.symm y) = f A
+  exact congrArg Subtype.val (e.apply_symm_apply y)
+
+/-- Every finite-region restriction of a star-automorphism is injective.
+
+Source context: arXiv:1703.09188, Appendix, line 2298 assumes that the global action is an
+automorphism; its injectivity gives the assertion here. Schumacher--Werner, quant-ph/0405174,
+Definition 1, lines 309--318 supplies the corresponding finite local-rule setting. -/
+theorem localRestriction_injective (hω : PropagatesWithin ω 𝓝) (Λ : Finset ℤ) :
+    Function.Injective (hω.localRestriction Λ) := by
+  intro A B hAB
+  apply quasiLocalObservable_injective d Λ
+  apply ω.injective
+  change ω (quasiLocalObservable d Λ A) = ω (quasiLocalObservable d Λ B)
+  rw [← hω.quasiLocalObservable_localRestriction Λ A,
+    ← hω.quasiLocalObservable_localRestriction Λ B, hAB]
+
+/-- Finite-region restrictions commute with canonical inclusions under enlargement of the source
+region.
+
+This is the coherent local-rule property underlying Schumacher--Werner, quant-ph/0405174,
+Lemma `lem:localrule`, lines 331--365; the finite-region enlargement equality is not displayed
+separately there. -/
+theorem localRestriction_localInclusion (hω : PropagatesWithin ω 𝓝)
+    {Λ Γ : Finset ℤ} (hΛΓ : Λ ⊆ Γ) (A : LocalAlgebra d Λ) :
+    hω.localRestriction Γ (localInclusion hΛΓ A) =
+      localInclusion (regionSumset_mono_left 𝓝 hΛΓ) (hω.localRestriction Λ A) := by
+  apply quasiLocalObservable_injective d (regionSumset Γ 𝓝)
+  rw [hω.quasiLocalObservable_localRestriction,
+    quasiLocalObservable_localInclusion,
+    quasiLocalObservable_localInclusion,
+    hω.quasiLocalObservable_localRestriction]
+
+/-- The range of a finite-region restriction as a star-subalgebra of
+\(\mathcal A_{\Lambda+\mathcal N}\).
+
+This is the local image to be written in bipartite coordinates before forming the GNVW support
+algebras. No support algebra is formed here.
+
+Source context: arXiv:1703.09188, Appendix, line 2298; GNVW, arXiv:0910.3675v2,
+equation `RR2x`, lines 1249--1266. This finite-dimensional local image is determined by the cited
+locality inclusion; it is not a separately stated source definition. -/
+noncomputable def localRestrictionRange (hω : PropagatesWithin ω 𝓝) (Λ : Finset ℤ) :
+    StarSubalgebra ℂ (LocalAlgebra d (regionSumset Λ 𝓝)) :=
+  (hω.localRestriction Λ).range
+
+/-- The source local algebra is star-algebra equivalent to the range of its finite-region
+restriction.
+
+This records that the local image in
+\(\mathcal A_{\Lambda+\mathcal N}\) is an isomorphic copy of
+\(\mathcal A_\Lambda\). It is a finite-dimensional consequence of the locality inclusion in
+arXiv:1703.09188, Appendix, line 2298, rather than a separately stated theorem there. -/
+noncomputable def localRestrictionRangeEquiv (hω : PropagatesWithin ω 𝓝)
+    (Λ : Finset ℤ) :
+    LocalAlgebra d Λ ≃⋆ₐ[ℂ] hω.localRestrictionRange Λ :=
+  StarAlgEquiv.ofInjective (hω.localRestriction Λ) (hω.localRestriction_injective Λ)
+
+/-- The finite local image written in fixed left/right matrix coordinates whenever its target
+region is presented as a disjoint union.
+
+The left matrix index is `Config d Γ` and the right matrix index is `Config d Δ`. The result is
+therefore a star-subalgebra of the bipartite matrix algebra on which
+`Matrix.leftSupportAlgebra` and `Matrix.rightSupportAlgebra` are defined; neither support algebra
+is formed here.
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266; the finite local image
+comes from arXiv:1703.09188, Appendix, line 2298. -/
+noncomputable def bipartiteLocalRestrictionRange (hω : PropagatesWithin ω 𝓝)
+    (Λ Γ Δ : Finset ℤ) (hΓΔ : Disjoint Γ Δ)
+    (htarget : regionSumset Λ 𝓝 = Γ ∪ Δ) :
+    StarSubalgebra ℂ
+      (Matrix (Config d Γ × Config d Δ) (Config d Γ × Config d Δ) ℂ) :=
+  StarSubalgebra.bipartiteReindex hΓΔ (htarget ▸ hω.localRestrictionRange Λ)
+
+/-- Translation covariance makes the finite-region restrictions natural under lattice
+translations, expressed after the canonical embeddings of their propositionally equal target
+regions.
+
+For \(a\in\mathbb Z\), the two target regions are equal by
+\((\Lambda+a)+\mathcal N=(\Lambda+\mathcal N)+a\). The displayed equality avoids choosing a
+transport between the corresponding matrix index types.
+
+Source context: arXiv:1703.09188, Appendix, line 2298; Schumacher--Werner,
+quant-ph/0405174, Lemma `lem:localrule`, lines 331--365. This finite-region formula is not stated
+separately in either source. -/
+theorem localRestriction_translation (hω : PropagatesWithin ω 𝓝)
+    (hcov : TranslationCovariant ω) (a : ℤ) (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    quasiLocalObservable d (regionSumset (translateRegion a Λ) 𝓝)
+        (hω.localRestriction (translateRegion a Λ) (localTranslation d a Λ A)) =
+      quasiLocalObservable d (translateRegion a (regionSumset Λ 𝓝))
+        (localTranslation d a (regionSumset Λ 𝓝) (hω.localRestriction Λ A)) := by
+  rw [hω.quasiLocalObservable_localRestriction]
+  rw [← quasiLocalTranslation_quasiLocalObservable,
+    ← quasiLocalTranslation_quasiLocalObservable,
+    hω.quasiLocalObservable_localRestriction]
+  exact (translationCovariant_iff ω).mp hcov a (quasiLocalObservable d Λ A)
+
+end PropagatesWithin
+
+end SpinChain

--- a/TNLean/QCA/LocalAlgebra.lean
+++ b/TNLean/QCA/LocalAlgebra.lean
@@ -115,6 +115,62 @@ def splitEquiv {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ) :
 lemma splitEquiv_apply_fst {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ) (x : Config d Γ) :
     (splitEquiv h x).1 = restrict h x := rfl
 
+/-- Restricting a configuration reconstructed by `splitEquiv` to the retained region recovers
+the first component.
+
+This is the coordinate identity underlying the canonical inclusions in arXiv:1703.09188,
+Appendix, lines 2292--2298. It is not stated separately there. -/
+@[simp]
+lemma restrict_splitEquiv_symm {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (p : Config d Λ × Config d (Γ \ Λ)) :
+    restrict h ((splitEquiv h).symm p) = p.1 :=
+  congrArg Prod.fst ((splitEquiv h).apply_symm_apply p)
+
+/-- Restricting a configuration reconstructed by `splitEquiv` to the complementary region
+recovers the second component.
+
+This is the coordinate identity underlying the canonical inclusions in arXiv:1703.09188,
+Appendix, lines 2292--2298. It is not stated separately there. -/
+@[simp]
+lemma restrict_sdiff_splitEquiv_symm {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (p : Config d Λ × Config d (Γ \ Λ)) :
+    restrict (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) ((splitEquiv h).symm p) = p.2 :=
+  congrArg Prod.snd ((splitEquiv h).apply_symm_apply p)
+
+/-- Two configurations have the same complementary coordinate under `splitEquiv` exactly when
+their restrictions to the complementary region agree.
+
+This is the coordinate identity underlying the canonical inclusions in arXiv:1703.09188,
+Appendix, lines 2292--2298. It is not stated separately there. -/
+lemma splitEquiv_snd_eq_iff_restrict_sdiff {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (x y : Config d Γ) :
+    (splitEquiv h x).2 = (splitEquiv h y).2 ↔
+      restrict (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) x =
+        restrict (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) y := by
+  rfl
+
+/-- Equality of the complementary coordinates for the split retaining `Γ \ Λ` is equality after
+restriction to `Λ`.
+
+This is the coordinate identity underlying the canonical inclusions in arXiv:1703.09188,
+Appendix, lines 2292--2298. It is not stated separately there. -/
+lemma splitEquiv_sdiff_snd_eq_iff_restrict {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (x y : Config d Γ) :
+    (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) x).2 =
+        (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) y).2 ↔
+      restrict h x = restrict h y := by
+  constructor
+  · intro hxy
+    funext i
+    exact congrFun hxy ⟨i, Finset.mem_sdiff.mpr ⟨h i.2, by simp [i.2]⟩⟩
+  · intro hxy
+    funext i
+    have hiΛ : (i : ℤ) ∈ Λ := by
+      by_contra hi
+      exact (Finset.mem_sdiff.mp i.2).2
+        (Finset.mem_sdiff.mpr ⟨(Finset.mem_sdiff.mp i.2).1, hi⟩)
+    exact congrFun hxy ⟨i, hiΛ⟩
+
 end Config
 
 section Inclusion

--- a/TNLean/QCA/RelativeCommutant.lean
+++ b/TNLean/QCA/RelativeCommutant.lean
@@ -29,33 +29,6 @@ open scoped Kronecker
 
 namespace SpinChain
 
-namespace Config
-
-private lemma splitComplement_snd_eq_iff {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
-    (x y : Config d Γ) :
-    (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) x).2 =
-        (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) y).2 ↔
-      restrict h x = restrict h y := by
-  constructor
-  · intro hxy
-    funext i
-    exact congrFun hxy ⟨i, Finset.mem_sdiff.mpr ⟨h i.2, by simp [i.2]⟩⟩
-  · intro hxy
-    funext i
-    have hiΛ : (i : ℤ) ∈ Λ := by
-      by_contra hi
-      exact (Finset.mem_sdiff.mp i.2).2
-        (Finset.mem_sdiff.mpr ⟨(Finset.mem_sdiff.mp i.2).1, hi⟩)
-    exact congrFun hxy ⟨i, hiΛ⟩
-
-private lemma restrict_sdiff_splitEquiv_symm {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
-    (p : Config d Λ × Config d (Γ \ Λ)) :
-    restrict (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) ((splitEquiv h).symm p) = p.2 := by
-  have hp := congrArg Prod.snd ((splitEquiv h).apply_symm_apply p)
-  exact hp
-
-end Config
-
 section Finite
 
 variable {d : ℕ} {Λ Γ : Finset ℤ}
@@ -82,15 +55,17 @@ private lemma reindex_localInclusion_sdiff (h : Λ ⊆ Γ)
   simp only [CStarMatrix.ofMatrix_apply, Matrix.rightKroneckerEmbed_apply,
     Matrix.kroneckerMap_apply, Matrix.one_apply]
   have hp : Config.restrict h ((Config.splitEquiv h).symm p) = p.1 :=
-    congrArg Prod.fst ((Config.splitEquiv h).apply_symm_apply p)
+    Config.restrict_splitEquiv_symm h p
   have hq : Config.restrict h ((Config.splitEquiv h).symm q) = q.1 :=
-    congrArg Prod.fst ((Config.splitEquiv h).apply_symm_apply q)
+    Config.restrict_splitEquiv_symm h q
   have heq :
       (Config.splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ)
           ((Config.splitEquiv h).symm p)).2 =
         (Config.splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ)
           ((Config.splitEquiv h).symm q)).2 ↔ p.1 = q.1 := by
-    rw [Config.splitComplement_snd_eq_iff h, hp, hq]
+    simpa only [Config.restrict_splitEquiv_symm] using
+      (Config.splitEquiv_sdiff_snd_eq_iff_restrict
+        (d := d) h ((Config.splitEquiv h).symm p) ((Config.splitEquiv h).symm q))
   by_cases hpq : p.1 = q.1
   · have hsnd := heq.mpr hpq
     simp [hpq, hsnd]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11700,6 +11700,196 @@ any part of that external structure theorem beyond this change of grouping.
     QCA property.
 \end{proof}
 
+Lines~2292--2298 of \cite{Cirac2017MPU} specify the finite local
+algebras, their canonical inclusions, translation covariance, and the locality
+inclusion
+\begin{align}
+    \omega(\mathcal A_\Lambda)
+    &\subseteq \mathcal A_{\Lambda+\mathcal N}.
+\end{align}
+The following statements record the finite-dimensional maps determined by
+this inclusion.  They are consequences and coordinate formulations of the
+cited locality relation, not separately named theorems of the paper.  The
+left/right order below agrees with the adjacent-pair convention in
+\cite{Gross2012IndexTheory}.
+
+\begin{definition}[Finite-region restriction]
+    \label{def:qca_finite_region_restriction}
+    \lean{SpinChain.PropagatesWithin.localRestriction}
+    \leanok
+    \uses{def:qca_local_algebra,def:qca_local_inclusion,
+        def:qca_region_sumset,def:qca_quasi_local_observable,
+        def:qca_propagates_within}
+    Let $d>0$, let $\omega$ be a star-algebra automorphism of
+    $\mathcal A^{(d)}$, and suppose that $\omega$ propagates within the finite
+    neighborhood $\mathcal N$.  For every finite region $\Lambda$, define
+    the finite-region restriction
+    \begin{align}
+        \omega_{\Lambda,\mathcal N}\colon\mathcal A_\Lambda
+        &\longrightarrow\mathcal A_{\Lambda+\mathcal N}
+    \end{align}
+    to be the unique star-algebra homomorphism satisfying
+    \begin{align}
+        \iota_{\Lambda+\mathcal N}
+          \bigl(\omega_{\Lambda,\mathcal N}(A)\bigr)
+        &=\omega\bigl(\iota_\Lambda(A)\bigr)
+        \qquad(A\in\mathcal A_\Lambda).
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Finite-region restriction is an embedding]
+    \label{thm:qca_finite_region_restriction_embedding}
+    \lean{SpinChain.PropagatesWithin.quasiLocalObservable_localRestriction,
+        SpinChain.PropagatesWithin.localRestriction_injective}
+    \leanok
+    \uses{def:qca_finite_region_restriction}
+    The finite-region restriction is injective, and for every
+    $A\in\mathcal A_\Lambda$ one has
+    \begin{align}
+        \iota_{\Lambda+\mathcal N}
+          \bigl(\omega_{\Lambda,\mathcal N}(A)\bigr)
+        &=\omega\bigl(\iota_\Lambda(A)\bigr).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_finite_region_restriction}
+    The defining equality follows from the locality inclusion and the
+    injectivity of $\iota_{\Lambda+\mathcal N}$.  If two local observables
+    have the same image under $\omega_{\Lambda,\mathcal N}$, their canonical
+    images become equal after applying $\omega$.  Injectivity of $\omega$ and
+    of $\iota_\Lambda$ then gives equality of the two local observables.
+\end{proof}
+
+\begin{theorem}[Enlargement of finite-region restrictions]
+    \label{thm:qca_finite_region_restriction_enlargement}
+    \lean{SpinChain.PropagatesWithin.localRestriction_localInclusion}
+    \leanok
+    \uses{def:qca_finite_region_restriction}
+    If $\Lambda\subseteq\Gamma$, then for every
+    $A\in\mathcal A_\Lambda$,
+    \begin{align}
+        \omega_{\Gamma,\mathcal N}
+          \bigl(\iota_{\Lambda,\Gamma}(A)\bigr)
+        &=\iota_{\Lambda+\mathcal N,\Gamma+\mathcal N}
+          \bigl(\omega_{\Lambda,\mathcal N}(A)\bigr).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_finite_region_restriction_embedding}
+    Apply the canonical inclusion into the quasi-local algebra to both sides.
+    Both expressions become $\omega(\iota_\Lambda(A))$; injectivity of the
+    target inclusion gives the equality.
+\end{proof}
+
+\begin{theorem}[Translation of finite-region restrictions]
+    \label{thm:qca_finite_region_restriction_translation}
+    \lean{SpinChain.PropagatesWithin.localRestriction_translation}
+    \leanok
+    \uses{def:qca_translation_covariant,
+        def:qca_finite_local_translation,
+        def:qca_finite_region_restriction}
+    Suppose in addition that $\omega$ is translation covariant.  For
+    $a\in\mathbb Z$ and $A\in\mathcal A_\Lambda$,
+    \begin{align}
+        \iota_{(\Lambda+a)+\mathcal N}
+          \bigl(\omega_{\Lambda+a,\mathcal N}
+            (\tau_{a,\Lambda}(A))\bigr)
+        &=\iota_{(\Lambda+\mathcal N)+a}
+          \bigl(\tau_{a,\Lambda+\mathcal N}
+            (\omega_{\Lambda,\mathcal N}(A))\bigr).
+    \end{align}
+    Here $(\Lambda+a)+\mathcal N=(\Lambda+\mathcal N)+a$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_finite_region_restriction_embedding,
+        lem:qca_quasi_local_translation_action}
+    The left-hand side is
+    $\omega(\tau_a(\iota_\Lambda(A)))$.  Translation covariance moves
+    $\tau_a$ past $\omega$, and the finite-region translation formula gives
+    the right-hand side.
+\end{proof}
+
+\begin{definition}[Bipartite coordinates for disjoint local algebras]
+    \label{def:qca_bipartite_local_algebra_coordinates}
+    \lean{SpinChain.Config.disjointUnionEquiv,
+        SpinChain.bipartiteLocalAlgebraEquiv}
+    \leanok
+    \uses{def:qca_local_algebra}
+    Let $\Gamma,\Delta\subset\mathbb Z$ be disjoint finite regions.  Writing
+    $\mathcal C_\Gamma$ and $\mathcal C_\Delta$ for their configuration
+    spaces, restriction to the two regions gives
+    \begin{align}
+        \mathcal C_{\Gamma\cup\Delta}
+        &\simeq \mathcal C_\Gamma\times\mathcal C_\Delta,
+    \end{align}
+    with the $\Gamma$-configuration first.  Reindexing matrix rows and
+    columns gives a star-algebra equivalence
+    \begin{align}
+        \beta_{\Gamma,\Delta}\colon
+        \mathcal A_{\Gamma\cup\Delta}
+        &\simeq
+        M_{\mathcal C_\Gamma\times\mathcal C_\Delta}(\mathbb C).
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Canonical inclusions in bipartite coordinates]
+    \label{thm:qca_bipartite_local_algebra_inclusions}
+    \lean{SpinChain.bipartiteLocalAlgebraEquiv_localInclusion_left,
+        SpinChain.bipartiteLocalAlgebraEquiv_localInclusion_right}
+    \leanok
+    \uses{def:qca_bipartite_local_algebra_coordinates,
+        def:qca_local_inclusion}
+    For $A\in\mathcal A_\Gamma$ and $B\in\mathcal A_\Delta$,
+    \begin{align}
+        \beta_{\Gamma,\Delta}(\iota_{\Gamma,\Gamma\cup\Delta}(A))
+        &=A\otimes\mathbf 1,\\
+        \beta_{\Gamma,\Delta}(\iota_{\Delta,\Gamma\cup\Delta}(B))
+        &=\mathbf 1\otimes B.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_bipartite_local_algebra_coordinates}
+    Evaluate both matrices on pairs of configurations.  For the first local
+    inclusion, restriction to $\Gamma$ gives the matrix coefficient of $A$,
+    while equality of the complementary $\Delta$-configurations gives the
+    matrix coefficient of the identity.  This is $A\otimes\mathbf 1$.
+    Interchanging the two regions gives $\mathbf 1\otimes B$.
+\end{proof}
+
+\begin{definition}[Finite local image in bipartite coordinates]
+    \label{def:qca_bipartite_finite_local_image}
+    \lean{SpinChain.PropagatesWithin.localRestrictionRange,
+        SpinChain.PropagatesWithin.localRestrictionRangeEquiv,
+        SpinChain.StarSubalgebra.bipartiteReindex,
+        SpinChain.PropagatesWithin.bipartiteLocalRestrictionRange}
+    \leanok
+    \uses{def:qca_finite_region_restriction,
+        thm:qca_finite_region_restriction_embedding,
+        def:qca_bipartite_local_algebra_coordinates}
+    Define the finite local image by
+    \begin{align}
+        \mathcal R_{\Lambda,\mathcal N}
+        &=\omega_{\Lambda,\mathcal N}(\mathcal A_\Lambda)
+          \subseteq\mathcal A_{\Lambda+\mathcal N}.
+    \end{align}
+    It is a star-subalgebra star-isomorphic to $\mathcal A_\Lambda$.  If
+    $\Lambda+\mathcal N=\Gamma\cup\Delta$ with
+    $\Gamma\cap\Delta=\varnothing$, then
+    \begin{align}
+        \beta_{\Gamma,\Delta}
+          (\mathcal R_{\Lambda,\mathcal N})
+        &\subseteq
+        M_{\mathcal C_\Gamma\times\mathcal C_\Delta}(\mathbb C)
+    \end{align}
+    is the bipartite matrix star-subalgebra to which the left and right
+    support-algebra constructions apply.  No support algebra is defined in
+    this statement.
+\end{definition}
+
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
 local action associated with an MPU by eventual finite-chain conjugation.  In
 lines~2300--2306, eventual constancy is used to obtain a norm-preserving


### PR DESCRIPTION
### Motivation

A propagation bound for a quasi-local automorphism gives, for each finite region \(\Lambda\), a canonical finite-dimensional map
\[
  \mathcal A_\Lambda \longrightarrow \mathcal A_{\Lambda+\mathcal N}.
\]
This is the finite-local boundary needed before the image can be studied with the existing matrix support-algebra API.

The source context is the finite-algebra inclusion and covariance in `Papers/1703.09188/paper_v2.tex`, lines 2292–2298; Schumacher–Werner's local observable algebras and locality inclusion in `Papers/quant-ph_0405174/qca.tex`, lines 270–318; their translated-local-rule compatibility lemma at lines 331–365; and the adjacent-pair support-algebra setting in GNVW, `References/0910.3675v2/QCI12.tex`, lines 1249–1266.

### Description

- Define `PropagatesWithin.localRestriction` by restricting the automorphism's range to the prescribed finite local algebra. Prove its quasi-local defining equality and injectivity.
- Prove compatibility with enlargement through the canonical source and target inclusions, and translation naturality for a translation-covariant automorphism.
- Package the finite image as a star subalgebra and expose the induced star-algebra equivalence onto that range.
- Expose the canonical disjoint-union reindexing in a fixed left/right tensor-factor order. Prove that the two local inclusions become the left and right Kronecker embeddings.
- Reindex a finite-local range into the exact matrix star-subalgebra type accepted by the existing left and right support-algebra constructions.
- Promote the shared coordinate lemmas from `LocalAlgebra.lean` and remove their private duplicates from the disjoint-support and relative-commutant modules.
- Add source-labelled Chapter 28 definitions and lemmas, while stating explicitly that this finite-local infrastructure is not the generalized Margolus theorem or the GNVW factor theorem.

No site-indexed support-algebra family, commutation theorem, factor theorem, index, or Margolus unitary is introduced here.

### Validation

The exact rebased head passed:

- `lake build TNLean.QCA.LocalAlgebra TNLean.QCA.BipartiteLocalAlgebra TNLean.QCA.FiniteLocalRestriction TNLean.QCA.DisjointSupport TNLean.QCA.RelativeCommutant`
- `lake build TNLean.QCA`
- proof-integrity scanning of every changed Lean file
- generated-import tests and completeness checking
- Lean-file policy tests, oversized-file checking, and the numbered-file policy
- `python3 scripts/tactic_pattern_scan.py`
- `texra-blueprint paper-gaps check`
- strict `texra-blueprint web` generation with the pinned plugin
- direct Lean resolution of all thirteen new names emitted in `blueprint/lean_decls`
- `git diff --check`

PR CI supplies the root build and declaration-checking pass without starting a second local umbrella build.

Closes #7112
