### PR TITLE
feat(QCA): prove scalar center of quasi-local algebra

### DIFF
--- a/TNLean/QCA/QuasiLocalCommutant.lean
+++ b/TNLean/QCA/QuasiLocalCommutant.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.ComplementaryWeylTwirl
+import Mathlib.Algebra.Central.Basic
 import TNLean.QCA.DisjointSupport
 
 /-!
@@ -12,6 +13,8 @@ import TNLean.QCA.DisjointSupport
 A quasi-local observable belongs to the algebra of a finite region exactly when it commutes with
 all observables supported in finite regions disjoint from it. The reverse implication uses finite
 Weyl averaging on the complementary tensor factor and closedness of the finite-region image.
+At the empty region, this characterization implies that every central observable is a unique
+complex scalar multiple of the identity.
 
 This is UHF-algebra infrastructure used by the QCA development. It is not a theorem stated in the
 MPU paper or by Schumacher--Werner.
@@ -243,5 +246,86 @@ theorem quasiLocalSupportedIn_iff_commute_disjoint {d : ℕ} [NeZero d]
     exact hdist.trans_lt (by
       rw [quasiLocalObservable_localInclusion d hΓΔ A]
       exact hxz)
+
+/-- If a quasi-local observable on a homogeneous spin chain commutes with every embedded
+finite-region observable, then it is a unique complex scalar multiple of the identity.
+
+This supplies the scalar-center fact invoked in GNVW, arXiv:0910.3675v2, lines 1276--1282
+(specifically line 1279), for the homogeneous quasi-local algebra of arXiv:1703.09188,
+lines 2292--2298. Schumacher--Werner, quant-ph/0405174, lines 263--285, give the corresponding
+homogeneous norm-completed construction. The scalar-center conclusion is not stated separately in
+these sources. -/
+theorem existsUnique_eq_smul_one_of_commute_quasiLocalObservable {d : ℕ} [NeZero d]
+    (z : QuasiLocalAlgebra d)
+    (hz : ∀ (Γ : Finset ℤ) (A : LocalAlgebra d Γ),
+      Commute z (quasiLocalObservable d Γ A)) :
+    ∃! c : ℂ, z = c • 1 := by
+  have hz_empty : QuasiLocalSupportedIn z ∅ := by
+    rw [quasiLocalSupportedIn_iff_commute_disjoint]
+    intro Γ _ y hy
+    obtain ⟨A, rfl⟩ := hy
+    exact hz Γ A
+  obtain ⟨A, hA⟩ := QuasiLocalSupportedIn.iff_exists.mp hz_empty
+  let _ : Unique (Config d ∅) := by
+    change Unique ((↥(∅ : Finset ℤ)) → Fin d)
+    infer_instance
+  let _ : Fintype (Config d ∅) := Unique.fintype
+  let e : ℂ ≃⋆ₐ[ℂ] LocalAlgebra d ∅ := CStarMatrix.toOneByOne (Config d ∅) ℂ ℂ
+  let c := e.symm A
+  have hAc : A = c • (1 : LocalAlgebra d ∅) := by
+    calc
+      A = e (e.symm A) := (e.apply_symm_apply A).symm
+      _ = e (c • (1 : ℂ)) := by simp [c]
+      _ = c • (1 : LocalAlgebra d ∅) := by rw [map_smul, map_one]
+  let _ : Fintype (Config d ∅) := instFintypeConfig d ∅
+  refine ⟨c, ?_, ?_⟩
+  · rw [← hA, hAc, map_smul, map_one]
+  · intro c' hc'
+    have hlocal : c' • (1 : LocalAlgebra d ∅) = c • 1 := by
+      apply quasiLocalObservable_injective d ∅
+      simp only [map_smul, map_one]
+      rw [← hc', ← hA, hAc, map_smul, map_one]
+    have hentry := congrFun (congrFun hlocal default) default
+    simpa using hentry
+
+/-- Every central observable of the homogeneous quasi-local spin-chain algebra is a unique complex
+scalar multiple of the identity.
+
+This is the homogeneous scalar-center fact invoked at GNVW, arXiv:0910.3675v2,
+lines 1276--1282 (specifically line 1279). GNVW cites the fact as known; it is not stated in the
+homogeneous QCA appendix of arXiv:1703.09188, lines 2292--2298. -/
+theorem existsUnique_eq_smul_one_of_commute {d : ℕ} [NeZero d]
+    (z : QuasiLocalAlgebra d) (hz : ∀ a, Commute z a) :
+    ∃! c : ℂ, z = c • 1 := by
+  exact existsUnique_eq_smul_one_of_commute_quasiLocalObservable z fun Γ A ↦
+    hz (quasiLocalObservable d Γ A)
+
+/-- The homogeneous quasi-local spin-chain algebra is central over ℂ in Mathlib's sense.
+
+This is the canonical `Algebra.IsCentral` formulation of the scalar-center fact invoked at GNVW,
+arXiv:0910.3675v2, line 1279, for the homogeneous norm completion defined in arXiv:1703.09188,
+lines 2292--2298. It does not assert the site-dependent GNVW statement. -/
+instance instIsCentralQuasiLocalAlgebra (d : ℕ) [NeZero d] :
+    Algebra.IsCentral ℂ (QuasiLocalAlgebra d) where
+  out := by
+    intro z hz
+    rw [Algebra.mem_bot]
+    have hcomm : ∀ a, Commute z a := by
+      intro a
+      rw [commute_iff_eq]
+      exact (Subalgebra.mem_center_iff.mp hz a).symm
+    obtain ⟨c, hc, _⟩ := existsUnique_eq_smul_one_of_commute z hcomm
+    refine ⟨c, ?_⟩
+    simpa only [Algebra.algebraMap_eq_smul_one] using hc.symm
+
+/-- The center of the homogeneous quasi-local spin-chain algebra is its scalar subalgebra.
+
+This is the center-subalgebra formulation of the scalar-center fact invoked at GNVW,
+arXiv:0910.3675v2, line 1279, for the homogeneous norm completion defined in arXiv:1703.09188,
+lines 2292--2298. It does not assert the site-dependent GNVW statement. -/
+@[simp]
+theorem quasiLocalAlgebra_center_eq_bot (d : ℕ) [NeZero d] :
+    Subalgebra.center ℂ (QuasiLocalAlgebra d) = ⊥ :=
+  Algebra.IsCentral.center_eq_bot ℂ (QuasiLocalAlgebra d)
 
 end SpinChain

--- a/TNLean/QCA/QuasiLocalCommutant.lean
+++ b/TNLean/QCA/QuasiLocalCommutant.lean
@@ -266,18 +266,18 @@ theorem existsUnique_eq_smul_one_of_commute_quasiLocalObservable {d : ℕ} [NeZe
     obtain ⟨A, rfl⟩ := hy
     exact hz Γ A
   obtain ⟨A, hA⟩ := QuasiLocalSupportedIn.iff_exists.mp hz_empty
-  let _ : Unique (Config d ∅) := by
-    change Unique ((↥(∅ : Finset ℤ)) → Fin d)
-    infer_instance
-  let _ : Fintype (Config d ∅) := Unique.fintype
-  let e : ℂ ≃⋆ₐ[ℂ] LocalAlgebra d ∅ := CStarMatrix.toOneByOne (Config d ∅) ℂ ℂ
-  let c := e.symm A
-  have hAc : A = c • (1 : LocalAlgebra d ∅) := by
+  obtain ⟨c, hAc⟩ : ∃ c : ℂ, A = c • (1 : LocalAlgebra d ∅) := by
+    let _ : Unique (Config d ∅) := by
+      change Unique ((↥(∅ : Finset ℤ)) → Fin d)
+      infer_instance
+    let _ : Fintype (Config d ∅) := Unique.fintype
+    let e : ℂ ≃⋆ₐ[ℂ] LocalAlgebra d ∅ := CStarMatrix.toOneByOne (Config d ∅) ℂ ℂ
+    let c := e.symm A
+    refine ⟨c, ?_⟩
     calc
       A = e (e.symm A) := (e.apply_symm_apply A).symm
       _ = e (c • (1 : ℂ)) := by simp [c]
       _ = c • (1 : LocalAlgebra d ∅) := by rw [map_smul, map_one]
-  let _ : Fintype (Config d ∅) := instFintypeConfig d ∅
   refine ⟨c, ?_, ?_⟩
   · rw [← hA, hAc, map_smul, map_one]
   · intro c' hc'
@@ -285,7 +285,8 @@ theorem existsUnique_eq_smul_one_of_commute_quasiLocalObservable {d : ℕ} [NeZe
       apply quasiLocalObservable_injective d ∅
       simp only [map_smul, map_one]
       rw [← hc', ← hA, hAc, map_smul, map_one]
-    have hentry := congrFun (congrFun hlocal default) default
+    let i : Config d ∅ := Classical.choice (instNonemptyConfig d ∅)
+    have hentry := congrFun (congrFun hlocal i) i
     simpa using hentry
 
 /-- Every central observable of the homogeneous quasi-local spin-chain algebra is a unique complex

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10277,6 +10277,58 @@ support by commutation with observables on the complementary tensor factor.
     hence has closed range, and therefore $x\in\mathcal A_\Lambda$.
 \end{proof}
 
+The following theorem gives the scalar center of the homogeneous UHF algebra.  GNVW
+invoke this conclusion for the quasi-local algebra at
+\cite[lines~1276--1282]{Gross2012IndexTheory}, specifically line~1279, but do
+not prove it there.  The homogeneous construction in
+\cite[lines~2292--2298]{Cirac2017MPU} likewise defines the norm completion
+without stating this conclusion separately.  Schumacher--Werner give the
+corresponding homogeneous norm-completed construction in
+\cite[lines~263--285]{SchumacherWerner2004QCA}, again without a separate
+scalar-center theorem.
+
+\begin{theorem}[Scalar center of the homogeneous quasi-local algebra]
+    \label{thm:qca_quasi_local_center_scalar}
+    \lean{SpinChain.existsUnique_eq_smul_one_of_commute_quasiLocalObservable,
+        SpinChain.existsUnique_eq_smul_one_of_commute,
+        SpinChain.instIsCentralQuasiLocalAlgebra,
+        SpinChain.quasiLocalAlgebra_center_eq_bot}
+    \leanok
+    \uses{def:qca_quasi_local_algebra, def:qca_quasi_local_observable}
+    Let $d>0$ and let $z\in\mathcal A$.  If
+    \begin{align}
+        \forall\Gamma\subset\mathbb Z\text{ finite},\quad
+        \forall A\in\mathcal A_\Gamma,\qquad
+        z j_\Gamma(A)&=j_\Gamma(A)z,
+    \end{align}
+    then there is a unique $c\in\mathbb C$ such that
+    \begin{align}
+        z&=c\mathbf 1.
+    \end{align}
+    Consequently,
+    \begin{align}
+        \{z\in\mathcal A\mid za=az\text{ for every }a\in\mathcal A\}
+        &=\mathbb C\mathbf 1.
+    \end{align}
+    This statement concerns the fixed on-site dimension $d$; it does not assert
+    the site-dependent extension used in GNVW.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_quasi_local_supported_iff_commute_disjoint,
+        lem:qca_quasi_local_observable}
+    Apply Theorem~\ref{thm:qca_quasi_local_supported_iff_commute_disjoint}
+    with $\Lambda=\varnothing$.  The commutation hypothesis gives
+    $z\in j_\varnothing(\mathcal A_\varnothing)$.  The empty tensor product is
+    the one-dimensional algebra
+    $\mathcal A_\varnothing\cong\mathbb C$, so every element of its image has
+    the form $c\mathbf 1$.  The one-by-one equivalence makes this coefficient
+    unique in $\mathcal A_\varnothing$, and injectivity of $j_\varnothing$
+    transports that uniqueness to $\mathcal A$.  A central element satisfies
+    the finite-region commutation hypothesis, which gives the displayed
+    description of the center.
+\end{proof}
+
 The appendix requires that ``there exists a finite subset
 $\mathcal N\subset\mathbb Z$'' such that, for every finite
 $\Lambda\subset\mathbb Z$,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -10316,17 +10316,38 @@ scalar-center theorem.
 
 \begin{proof}\leanok
     \uses{thm:qca_quasi_local_supported_iff_commute_disjoint,
-        lem:qca_quasi_local_observable}
+        def:qca_quasi_local_supported_in, lem:qca_quasi_local_observable}
     Apply Theorem~\ref{thm:qca_quasi_local_supported_iff_commute_disjoint}
     with $\Lambda=\varnothing$.  The commutation hypothesis gives
-    $z\in j_\varnothing(\mathcal A_\varnothing)$.  The empty tensor product is
-    the one-dimensional algebra
-    $\mathcal A_\varnothing\cong\mathbb C$, so every element of its image has
-    the form $c\mathbf 1$.  The one-by-one equivalence makes this coefficient
-    unique in $\mathcal A_\varnothing$, and injectivity of $j_\varnothing$
-    transports that uniqueness to $\mathcal A$.  A central element satisfies
-    the finite-region commutation hypothesis, which gives the displayed
-    description of the center.
+    $z\in j_\varnothing(\mathcal A_\varnothing)$, so there is an
+    $A\in\mathcal A_\varnothing$ with $z=j_\varnothing(A)$.  Let
+    $e\colon\mathbb C\xrightarrow{\ \sim\ }\mathcal A_\varnothing$ be the
+    canonical isomorphism and write $A=e(c)$.  If also
+    $z=j_\varnothing(e(c'))$, then injectivity of $j_\varnothing$ and of $e$
+    give
+    \begin{align}
+        j_\varnothing(e(c))=j_\varnothing(e(c'))
+        &\Longrightarrow e(c)=e(c')
+        \Longrightarrow c=c'.
+    \end{align}
+    Thus $c$ is the unique scalar for which $z=c\mathbf 1$.
+
+    Write $Z(\mathcal A)$ for the center.  Since every
+    $j_\Gamma(B)$ belongs to $\mathcal A$, the two inclusions are
+    \begin{align}
+        z\in Z(\mathcal A)
+        &\Longrightarrow
+        \bigl(\forall \Gamma\subset\mathbb Z\text{ finite},\
+        \forall B\in\mathcal A_\Gamma,\
+        z j_\Gamma(B)=j_\Gamma(B)z\bigr)
+        \Longrightarrow z\in\mathbb C\mathbf 1,\\
+        z=c\mathbf 1\quad(c\in\mathbb C)
+        &\Longrightarrow
+        \bigl(\forall a\in\mathcal A,\
+        (c\mathbf 1)a=a(c\mathbf 1)\bigr)
+        \Longrightarrow z\in Z(\mathcal A).
+    \end{align}
+    Hence $Z(\mathcal A)=\mathbb C\mathbf 1$.
 \end{proof}
 
 The appendix requires that ``there exists a finite subset


### PR DESCRIPTION
## Summary

- prove that commutation with every embedded finite-region observable forces a homogeneous quasi-local observable into the empty-region algebra
- identify that algebra with `ℂ` and obtain the unique scalar coefficient
- publish the corresponding `Algebra.IsCentral` instance and derive the center identity from the canonical Mathlib theorem
- add a Chapter 28 Blueprint statement that records the homogeneous scope and precise source context

## Mathematical scope

The result supplies the scalar-center fact invoked in GNVW, arXiv:0910.3675v2, lines 1276–1282, for the homogeneous quasi-local algebra. It does not assert the site-dependent extension used by the full GNVW theorem.

Closes #7117.

## Validation

- `lake build TNLean.QCA.QuasiLocalCommutant` (3,068 cached jobs)
- exact one-commit range-diff after rebase onto current main
- import-aggregator check and 14 generator tests
- 16 Lean file-policy tests and oversized-file guard
- reader-facing prose, proof-integrity, tactic-pattern, ChkTeX, and `git diff --check` scans
- Blueprint source synchronization: 6,825 of 6,825 theorem-like entries synchronized; every changed declaration is referenced

The full Blueprint declaration check remains an exact-head CI gate after the complete library build.
