### PR TITLE
feat(QCA): add site-indexed support algebras

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -32,6 +32,7 @@ import TNLean.QCA.QuasiLocalCommutant
 import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset
 import TNLean.QCA.RelativeCommutant
+import TNLean.QCA.SiteIndexedSupportAlgebra
 import TNLean.QCA.Translation
 import TNLean.QCA.TranslationCovariance
 import TNLean.QCA.TwoSidedPropagation

--- a/TNLean/QCA/SiteIndexedSupportAlgebra.lean
+++ b/TNLean/QCA/SiteIndexedSupportAlgebra.lean
@@ -1,0 +1,320 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.BipartiteSupportAlgebra
+import TNLean.QCA.FiniteLocalRestriction
+
+/-!
+# Site-indexed support algebras of a nearest-neighbour QCA
+
+For
+\[
+  E_x=\{2x,2x+1\},\qquad
+  L_x=\{2x-1,2x\},\qquad
+  P_x=\{2x+1,2x+2\},
+\]
+nearest-neighbour propagation places the image of the observable algebra on \(E_x\) in the
+observable algebra on \(L_x\cup P_x\). The canonical bipartite coordinates put \(L_x\) first and
+\(P_x\) second. The left and right support algebras of this image are therefore, in the notation
+of Gross--Nesme--Vogts--Werner,
+\[
+  \mathcal R_{2x}=\operatorname{Spp}_{\mathrm L}(S_x),\qquad
+  \mathcal R_{2x+1}=\operatorname{Spp}_{\mathrm R}(S_x).
+\]
+They are embedded into the quasi-local algebra as one family indexed by \(\mathbb Z\).
+
+**Scope restriction (homogeneous chain):** Gross--Nesme--Vogts--Werner allow the one-site
+matrix size to depend on the site. This file treats the fixed positive size \(d\) of the present
+quasi-local algebra. The unrestricted construction requires a site-dependent spin-chain
+observable algebra. See
+[the homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
+
+No translation covariance, commutation theorem, matrix-factor classification, adjacent-block
+generation equality, or index is proved here.
+
+## Main definitions
+
+* `SpinChain.evenPair`, `SpinChain.leftPair`, and `SpinChain.rightPair` are \(E_x,L_x,P_x\).
+* `SpinChain.matrixToQuasiLocalObservable` is the canonical star-algebra homomorphism from
+  ordinary finite-region matrices to quasi-local observables.
+* `SpinChain.PropagatesWithin.evenPairLocalImage` is \(S_x\) in the ordered
+  \(L_x\times P_x\) coordinates.
+* `SpinChain.PropagatesWithin.evenSupportAlgebra` and
+  `SpinChain.PropagatesWithin.oddSupportAlgebra` are
+  \(\mathcal R_{2x}\) and \(\mathcal R_{2x+1}\).
+* `SpinChain.PropagatesWithin.embeddedSupportAlgebra` is the unified quasi-local family
+  \((\mathcal R_y)_{y\in\mathbb Z}\).
+
+## Main results
+
+* `SpinChain.regionSumset_evenPair` identifies the four-site target as \(L_x\cup P_x\).
+* `SpinChain.rightPair_eq_leftPair_add_one` identifies \(P_x=L_{x+1}\).
+* `SpinChain.matrixToQuasiLocalObservable_supportedIn` records the finite-region support of this
+  canonical homomorphism.
+* `SpinChain.PropagatesWithin.evenPairLocalImage_le_support_kroneckerSubmodule` is the
+  site-specific two-sided support containment.
+* `SpinChain.PropagatesWithin.embeddedSupportAlgebra_even_supportedIn` and
+  `SpinChain.PropagatesWithin.embeddedSupportAlgebra_odd_supportedIn` place the two parity
+  families in their physical two-site regions.
+
+## References
+
+* Gross--Nesme--Vogts--Werner, arXiv:0910.3675v2, equation `RR2x`, lines 1251--1278.
+* Schumacher--Werner, quant-ph/0405174, Section 4.3, lines 1137--1194.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2329.
+-/
+
+namespace SpinChain
+
+/-! ### Adjacent two-site regions -/
+
+/-- The even source pair \(E_x=\{2x,2x+1\}\).
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266; Cirac et al.,
+arXiv:1703.09188, Appendix, lines 2313--2318. -/
+def evenPair (x : ℤ) : Finset ℤ :=
+  {2 * x, 2 * x + 1}
+
+/-- The left target pair \(L_x=\{2x-1,2x\}\).
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266. -/
+def leftPair (x : ℤ) : Finset ℤ :=
+  {2 * x - 1, 2 * x}
+
+/-- The right target pair \(P_x=\{2x+1,2x+2\}\).
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266. -/
+def rightPair (x : ℤ) : Finset ℤ :=
+  {2 * x + 1, 2 * x + 2}
+
+/-- The nearest-neighbour enlargement of \(E_x\) is the ordered union \(L_x\cup P_x\).
+
+Source context: GNVW, arXiv:0910.3675v2, lines 1251--1258; Cirac et al.,
+arXiv:1703.09188, Appendix, lines 2313--2318. -/
+lemma regionSumset_evenPair (x : ℤ) :
+    regionSumset (evenPair x) (Finset.Icc (-1) 1) = leftPair x ∪ rightPair x := by
+  ext y
+  simp only [mem_regionSumset, evenPair, leftPair, rightPair, Finset.mem_insert,
+    Finset.mem_singleton, Finset.mem_union, Finset.mem_Icc]
+  constructor
+  · rintro ⟨j, hj, a, ha, rfl⟩
+    rcases hj with rfl | rfl <;> omega
+  · rintro ((rfl | rfl) | rfl | rfl)
+    · exact ⟨2 * x, Or.inl rfl, -1, by omega⟩
+    · exact ⟨2 * x, Or.inl rfl, 0, by omega⟩
+    · exact ⟨2 * x, Or.inl rfl, 1, by omega⟩
+    · exact ⟨2 * x + 1, Or.inr rfl, 1, by omega⟩
+
+/-- The two target pairs \(L_x\) and \(P_x\) are disjoint.
+
+Source context: GNVW, arXiv:0910.3675v2, lines 1251--1258. -/
+lemma disjoint_leftPair_rightPair (x : ℤ) : Disjoint (leftPair x) (rightPair x) := by
+  rw [Finset.disjoint_left]
+  intro a haL haR
+  simp only [leftPair, rightPair, Finset.mem_insert, Finset.mem_singleton] at haL haR
+  omega
+
+/-- The right target pair of \(E_x\) is the left target pair of \(E_{x+1}\):
+\(P_x=L_{x+1}\).
+
+Source context: this is the common two-site region in the consecutive-pair argument of GNVW,
+arXiv:0910.3675v2, lines 1270--1278. -/
+lemma rightPair_eq_leftPair_add_one (x : ℤ) : rightPair x = leftPair (x + 1) := by
+  ext y
+  simp only [rightPair, leftPair, Finset.mem_insert, Finset.mem_singleton]
+  omega
+
+/-! ### Canonical matrix observables -/
+
+/-- The canonical star-algebra homomorphism from ordinary matrices in finite-region coordinates
+to the quasi-local algebra.
+
+It first identifies a matrix with the corresponding element of the finite local C*-algebra and
+then applies the canonical quasi-local inclusion. Under this identification, it is the
+finite-region inclusion used by Cirac et al., arXiv:1703.09188, lines 2292--2298. It also realizes
+the finite-cell inclusions surrounding GNVW equation `RR2x`, arXiv:0910.3675v2,
+lines 1251--1274; neither source names the composition separately. -/
+noncomputable def matrixToQuasiLocalObservable (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    Matrix (Config d Λ) (Config d Λ) ℂ →⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  (quasiLocalObservable d Λ).comp CStarMatrix.ofMatrixStarAlgEquiv.toStarAlgHom
+
+/-- A matrix embedded by `matrixToQuasiLocalObservable` is supported in its defining finite
+region.
+
+This is the support property of the canonical finite-region inclusion used by Cirac et al.,
+arXiv:1703.09188, lines 2292--2298; it is not a separately stated source theorem. -/
+theorem matrixToQuasiLocalObservable_supportedIn (d : ℕ) [NeZero d] (Λ : Finset ℤ)
+    (a : Matrix (Config d Λ) (Config d Λ) ℂ) :
+    QuasiLocalSupportedIn (matrixToQuasiLocalObservable d Λ a) Λ := by
+  change QuasiLocalSupportedIn
+    (quasiLocalObservable d Λ (CStarMatrix.ofMatrixStarAlgEquiv a)) Λ
+  exact QuasiLocalSupportedIn.quasiLocalObservable _
+
+/-! ### Finite support algebras -/
+
+namespace PropagatesWithin
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+
+/-- The finite image \(S_x=\omega(\mathcal A_{E_x})\) in the canonical ordered
+\(L_x\times P_x\) matrix coordinates.
+
+The first matrix coordinate is `Config d (leftPair x)` and the second is
+`Config d (rightPair x)`.
+
+This is the fixed-\(d\) specialization of the site-dependent local image in GNVW,
+arXiv:0910.3675v2, lines 1251--1266, under the homogeneous-chain scope stated in the module
+docstring. Cirac et al. use the homogeneous image at arXiv:1703.09188, lines 2313--2318.
+See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def evenPairLocalImage
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ
+      (Matrix (Config d (leftPair x) × Config d (rightPair x))
+        (Config d (leftPair x) × Config d (rightPair x)) ℂ) :=
+  hω.bipartiteLocalRestrictionRange (evenPair x) (leftPair x) (rightPair x)
+    (disjoint_leftPair_rightPair x) (regionSumset_evenPair x)
+
+/-- The even support algebra
+\(\mathcal R_{2x}=\operatorname{Spp}_{\mathrm L}(S_x)\) on \(L_x\).
+
+This is the fixed-\(d\) instance of GNVW equation `RR2x`, arXiv:0910.3675v2,
+lines 1261--1266, under the homogeneous-chain scope stated in the module docstring. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def evenSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ (Matrix (Config d (leftPair x)) (Config d (leftPair x)) ℂ) :=
+  Matrix.leftSupportAlgebra (evenPairLocalImage hω x)
+
+/-- The odd support algebra
+\(\mathcal R_{2x+1}=\operatorname{Spp}_{\mathrm R}(S_x)\) on \(P_x\).
+
+This is the fixed-\(d\) instance of GNVW equation `RR2x`, arXiv:0910.3675v2,
+lines 1261--1266, under the homogeneous-chain scope stated in the module docstring. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def oddSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ (Matrix (Config d (rightPair x)) (Config d (rightPair x)) ℂ) :=
+  Matrix.rightSupportAlgebra (evenPairLocalImage hω x)
+
+/-- The site-specific two-sided support containment
+\[
+  S_x\subseteq
+  \operatorname{Spp}_{\mathrm L}(S_x)\boxtimes
+  \operatorname{Spp}_{\mathrm R}(S_x).
+\]
+
+This is obtained from the general full-matrix support containment after inserting the canonical
+\(L_x\times P_x\) coordinates.
+
+This is the fixed-\(d\) instance of GNVW equation `a2Supp`, arXiv:0910.3675v2,
+lines 1211--1219, used for the adjacent pair at lines 1276--1278. Cirac et al.,
+arXiv:1703.09188, lines 2322--2328, state only the weaker containment in the left support
+algebra tensored with the unrestricted right physical factor. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+theorem evenPairLocalImage_le_support_kroneckerSubmodule
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    (evenPairLocalImage hω x).toSubmodule ≤
+      Matrix.kroneckerSubmodule (evenSupportAlgebra hω x).toSubmodule
+        (oddSupportAlgebra hω x).toSubmodule := by
+  simpa only [evenSupportAlgebra, oddSupportAlgebra] using
+    Matrix.le_support_kroneckerSubmodule (evenPairLocalImage hω x)
+
+/-! ### Canonical quasi-local embeddings -/
+
+/-- The canonical quasi-local copy of \(\mathcal R_{2x}\subseteq\mathcal A_{L_x}\).
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1261--1278; the canonical
+finite-region embedding is the homogeneous quasi-local inclusion in Cirac et al.,
+arXiv:1703.09188, lines 2292--2298. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def embeddedEvenSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ (QuasiLocalAlgebra d) :=
+  (evenSupportAlgebra hω x).map (matrixToQuasiLocalObservable d (leftPair x))
+
+/-- The canonical quasi-local copy of \(\mathcal R_{2x+1}\subseteq\mathcal A_{P_x}\).
+
+Source context: GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1261--1278; the canonical
+finite-region embedding is the homogeneous quasi-local inclusion in Cirac et al.,
+arXiv:1703.09188, lines 2292--2298. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def embeddedOddSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ (QuasiLocalAlgebra d) :=
+  (oddSupportAlgebra hω x).map (matrixToQuasiLocalObservable d (rightPair x))
+
+/-- The unified embedded support-algebra family \((\mathcal R_y)_{y\in\mathbb Z}\).
+
+Even indices select the left support of \(S_x\), and odd indices select its right support.
+
+This family is the fixed-\(d\) specialization of GNVW equation `RR2x`, arXiv:0910.3675v2,
+lines 1261--1266, under the homogeneous-chain scope stated in the module docstring. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+noncomputable def embeddedSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (y : ℤ) :
+    StarSubalgebra ℂ (QuasiLocalAlgebra d) :=
+  if y % 2 = 0 then embeddedEvenSupportAlgebra hω (y / 2)
+  else embeddedOddSupportAlgebra hω (y / 2)
+
+/-- At an even index, the unified family is the embedded left support algebra.
+
+This is the even parity formula in the fixed-\(d\) specialization of GNVW equation `RR2x`,
+arXiv:0910.3675v2, lines 1261--1266. See the homogeneous-chain scope statement in the module
+docstring. -/
+@[simp]
+theorem embeddedSupportAlgebra_even
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    embeddedSupportAlgebra hω (2 * x) = embeddedEvenSupportAlgebra hω x := by
+  rw [embeddedSupportAlgebra]
+  simp
+
+/-- At an odd index, the unified family is the embedded right support algebra.
+
+This is the odd parity formula in the fixed-\(d\) specialization of GNVW equation `RR2x`,
+arXiv:0910.3675v2, lines 1261--1266. See the homogeneous-chain scope statement in the module
+docstring. -/
+@[simp]
+theorem embeddedSupportAlgebra_odd
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    embeddedSupportAlgebra hω (2 * x + 1) = embeddedOddSupportAlgebra hω x := by
+  rw [embeddedSupportAlgebra]
+  simp only [Int.mul_add_emod_self_left, Int.one_emod_two, one_ne_zero, ↓reduceIte]
+  congr 1
+  rw [show 2 * x + 1 = 1 + x * 2 by ring, Int.add_mul_ediv_right]
+  all_goals norm_num
+
+/-- Every element of the unified family at an even index is supported in \(L_x\).
+
+This is the physical localization accompanying the even algebra in GNVW equation `RR2x`,
+arXiv:0910.3675v2, lines 1261--1274. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+theorem embeddedSupportAlgebra_even_supportedIn
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ)
+    {r : QuasiLocalAlgebra d} (hr : r ∈ embeddedSupportAlgebra hω (2 * x)) :
+    QuasiLocalSupportedIn r (leftPair x) := by
+  rw [embeddedSupportAlgebra_even] at hr
+  rw [embeddedEvenSupportAlgebra, StarSubalgebra.mem_map] at hr
+  rcases hr with ⟨a, _ha, rfl⟩
+  exact matrixToQuasiLocalObservable_supportedIn d (leftPair x) a
+
+/-- Every element of the unified family at an odd index is supported in \(P_x\).
+
+This is the physical localization accompanying the odd algebra in GNVW equation `RR2x`,
+arXiv:0910.3675v2, lines 1261--1274. See the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf). -/
+theorem embeddedSupportAlgebra_odd_supportedIn
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ)
+    {r : QuasiLocalAlgebra d} (hr : r ∈ embeddedSupportAlgebra hω (2 * x + 1)) :
+    QuasiLocalSupportedIn r (rightPair x) := by
+  rw [embeddedSupportAlgebra_odd] at hr
+  rw [embeddedOddSupportAlgebra, StarSubalgebra.mem_map] at hr
+  rcases hr with ⟨a, _ha, rfl⟩
+  exact matrixToQuasiLocalObservable_supportedIn d (rightPair x) a
+
+end PropagatesWithin
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -12061,6 +12061,7 @@ left/right order below agrees with the adjacent-pair convention in
         SpinChain.PropagatesWithin.embeddedSupportAlgebra_odd}
     \leanok
     \uses{def:qca_bipartite_finite_local_image,
+        def:qca_quasi_local_observable,
         def:qca_left_support_algebra,def:qca_right_support_algebra,
         def:qca_nearest_neighbor_pair_regions,
         lem:qca_nearest_neighbor_pair_geometry}
@@ -12148,7 +12149,8 @@ left/right order below agrees with the adjacent-pair convention in
         SpinChain.PropagatesWithin.embeddedSupportAlgebra_even_supportedIn,
         SpinChain.PropagatesWithin.embeddedSupportAlgebra_odd_supportedIn}
     \leanok
-    \uses{def:qca_site_indexed_support_algebras}
+    \uses{def:qca_site_indexed_support_algebras,
+        def:qca_quasi_local_supported_in}
     If $\widehat{\mathcal R}_y$ denotes the canonical quasi-local copy of
     $\mathcal R_y$, then for every $x\in\mathbb Z$,
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -12002,6 +12002,174 @@ left/right order below agrees with the adjacent-pair convention in
     this statement.
 \end{definition}
 
+\begin{definition}[Nearest-neighbour pair regions]
+    \label{def:qca_nearest_neighbor_pair_regions}
+    \lean{SpinChain.evenPair,SpinChain.leftPair,SpinChain.rightPair}
+    \leanok
+    For $x\in\mathbb Z$, set
+    \begin{align}
+        E_x&=\{2x,2x+1\},&
+        L_x&=\{2x-1,2x\},&
+        P_x&=\{2x+1,2x+2\}.
+        \label{eq:qca_pair_regions}
+    \end{align}
+    The order $L_x,P_x$ is the left--right factor order in equation
+    \texttt{RR2x} of
+    \cite[lines~1251--1266]{Gross2012IndexTheory}.  The same four-site
+    localization occurs in
+    \cite[lines~2313--2318]{Cirac2017MPU}.
+\end{definition}
+
+\begin{lemma}[Geometry of the nearest-neighbour pair image]
+    \label{lem:qca_nearest_neighbor_pair_geometry}
+    \lean{SpinChain.regionSumset_evenPair,
+        SpinChain.disjoint_leftPair_rightPair,
+        SpinChain.rightPair_eq_leftPair_add_one}
+    \leanok
+    \uses{def:qca_nearest_neighbor_pair_regions}
+    For the neighbourhood $\mathcal N=\{-1,0,1\}$,
+    \begin{align}
+        E_x+\mathcal N&=L_x\cup P_x,&
+        L_x\cap P_x&=\varnothing,&
+        P_x&=L_{x+1}.
+        \label{eq:qca_pair_geometry}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute (\ref{eq:qca_pair_regions}).  Adding $-1,0,1$ to the two
+    points of $E_x$ gives
+    \begin{align}
+        E_x+\{-1,0,1\}
+        &=\{2x-1,2x,2x+1,2x+2\}=L_x\cup P_x.
+    \end{align}
+    The largest point of $L_x$ is $2x$, while the smallest point of $P_x$
+    is $2x+1$, so the two sets are disjoint.  Finally,
+    $L_{x+1}=\{2x+1,2x+2\}=P_x$.
+\end{proof}
+
+\begin{definition}[Site-indexed support algebras]
+    \label{def:qca_site_indexed_support_algebras}
+    \lean{SpinChain.matrixToQuasiLocalObservable,
+        SpinChain.PropagatesWithin.evenPairLocalImage,
+        SpinChain.PropagatesWithin.evenSupportAlgebra,
+        SpinChain.PropagatesWithin.oddSupportAlgebra,
+        SpinChain.PropagatesWithin.embeddedEvenSupportAlgebra,
+        SpinChain.PropagatesWithin.embeddedOddSupportAlgebra,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_even,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_odd}
+    \leanok
+    \uses{def:qca_bipartite_finite_local_image,
+        def:qca_left_support_algebra,def:qca_right_support_algebra,
+        def:qca_nearest_neighbor_pair_regions,
+        lem:qca_nearest_neighbor_pair_geometry}
+    Let $\omega$ be a star-algebra automorphism of the homogeneous
+    quasi-local algebra which propagates within $\{-1,0,1\}$.  Write the
+    finite image of $\mathcal A_{E_x}$ in the ordered $L_x\times P_x$
+    coordinates as
+    \begin{align}
+        S_x
+        &=\beta_{L_x,P_x}\bigl(\omega(\mathcal A_{E_x})\bigr)
+          \subseteq
+          M_{\mathcal C_{L_x}\times\mathcal C_{P_x}}(\mathbb C).
+        \label{eq:qca_site_image}
+    \end{align}
+    Define
+    \begin{align}
+        \mathcal R_{2x}
+          &=\operatorname{Spp}_{\mathrm L}(S_x)
+            \subseteq M_{\mathcal C_{L_x}}(\mathbb C),\\
+        \mathcal R_{2x+1}
+          &=\operatorname{Spp}_{\mathrm R}(S_x)
+            \subseteq M_{\mathcal C_{P_x}}(\mathbb C).
+        \label{eq:qca_RR2x}
+    \end{align}
+    After the canonical finite-region embeddings, these form one family of
+    star-subalgebras of the quasi-local algebra.  Here the matrix embedding is
+    the composition
+    \begin{align}
+        M_{\mathcal C_\Lambda}(\mathbb C)
+        \cong \mathcal A_\Lambda
+        \longrightarrow \mathcal A.
+    \end{align}
+    Under this identification, the canonical local inclusion in
+    \cite[lines~2292--2298]{Cirac2017MPU} is exactly the displayed
+    composition.
+    Formula (\ref{eq:qca_RR2x}) is equation \texttt{RR2x} in
+    \cite[lines~1261--1266]{Gross2012IndexTheory}.  Cirac et al. use the
+    homogeneous even factor in
+    \cite[lines~2322--2328]{Cirac2017MPU}; the odd factor and unified family
+    are supplied by the GNVW construction.
+
+    \textbf{Scope restriction (homogeneous chain):}
+    GNVW allow the cell size $d(y)$ to depend on $y$, whereas the present
+    definition fixes one positive size $d$.  The site-dependent statement is
+    not claimed here; see
+    \cite{gap:gnvw12_site_dependent_adjacent_generation_scope}.
+\end{definition}
+
+\begin{theorem}[Adjacent-pair support containment]
+    \label{thm:qca_adjacent_pair_support_containment}
+    \lean{SpinChain.PropagatesWithin.evenPairLocalImage_le_support_kroneckerSubmodule}
+    \leanok
+    \uses{def:qca_site_indexed_support_algebras,
+        thm:qca_two_sided_support_containment}
+    For every $x\in\mathbb Z$, the finite image satisfies
+    \begin{align}
+        S_x
+        &\subseteq
+        \mathcal R_{2x}\boxtimes\mathcal R_{2x+1}
+        \subseteq
+        M_{\mathcal C_{L_x}\times\mathcal C_{P_x}}(\mathbb C).
+        \label{eq:qca_adjacent_pair_containment}
+    \end{align}
+    This is the homogeneous, full-matrix instance used in the two-sided
+    containment at
+    \cite[lines~1276--1278]{Gross2012IndexTheory}; see
+    \cite{gap:gnvw12_site_dependent_adjacent_generation_scope}.
+    Cirac et al. state only the weaker inclusion in the left support algebra
+    tensored with the unrestricted right physical factor at
+    \cite[lines~2322--2328]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_two_sided_support_containment}
+    Apply Theorem~\ref{thm:qca_two_sided_support_containment} to $S_x$ in
+    the ordered coordinates of (\ref{eq:qca_site_image}).  Its left support
+    is $\mathcal R_{2x}$ and its right support is
+    $\mathcal R_{2x+1}$ by (\ref{eq:qca_RR2x}), which gives
+    (\ref{eq:qca_adjacent_pair_containment}).
+\end{proof}
+
+\begin{theorem}[Physical support of the site-indexed support algebras]
+    \label{thm:qca_site_indexed_support_regions}
+    \lean{SpinChain.matrixToQuasiLocalObservable_supportedIn,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_even_supportedIn,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_odd_supportedIn}
+    \leanok
+    \uses{def:qca_site_indexed_support_algebras}
+    If $\widehat{\mathcal R}_y$ denotes the canonical quasi-local copy of
+    $\mathcal R_y$, then for every $x\in\mathbb Z$,
+    \begin{align}
+        \widehat{\mathcal R}_{2x}&\subseteq\mathcal A_{L_x},&
+        \widehat{\mathcal R}_{2x+1}&\subseteq\mathcal A_{P_x}.
+    \end{align}
+    More generally, the canonical image of any matrix on a finite region
+    $\Lambda$ is supported in $\Lambda$.
+    This is the homogeneous specialization of the localization accompanying
+    equation \texttt{RR2x} in
+    \cite[lines~1261--1274]{Gross2012IndexTheory}; see
+    \cite{gap:gnvw12_site_dependent_adjacent_generation_scope}.
+\end{theorem}
+
+\begin{proof}\leanok
+    An element of $\widehat{\mathcal R}_{2x}$ is the canonical image of a
+    matrix in $\mathcal R_{2x}\subseteq\mathcal A_{L_x}$ and is therefore
+    supported in $L_x$.  The same argument places
+    $\widehat{\mathcal R}_{2x+1}$ in $\mathcal A_{P_x}$.
+\end{proof}
+
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
 local action associated with an MPU by eventual finite-chain conjugation.  In
 lines~2300--2306, eventual constancy is used to obtain a norm-preserving

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -875,6 +875,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_support_algebra_outer_factor_basis.pdf}},
 }
 
+@techreport{gap:gnvw12_site_dependent_adjacent_generation_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Homogeneous-Chain Scope for the {GNVW} Support Algebras, Adjacent Generation, and Index},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {gnvw12\_site\_dependent\_adjacent\_generation\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf}},
+}
+
 @techreport{gap:gnvw12_support_algebra_star_closure,
   author      = {The {TNLean} contributors},
   title       = {Star-Closure Correction for the {GNVW} Support-Algebra Lemma},

--- a/docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex
+++ b/docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex
@@ -1,0 +1,144 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Homogeneous-Chain Scope for the GNVW Support Algebras,
+Adjacent Generation, and Index}
+\author{}
+\date{2026-08-24}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The site-dependent GNVW construction}
+
+Gross--Nesme--Vogts--Werner consider a chain whose cell algebra at
+$y\in\mathbb Z$ is
+\begin{align}
+    \mathcal A_y&=M_{d(y)}(\mathbb C),
+\end{align}
+where the positive matrix size $d(y)$ may depend on $y$
+\cite[Section~7.2]{Gross2012IndexTheory}.  For a nearest-neighbour
+automorphism $\alpha$, set
+\begin{align}
+    E_x&=\{2x,2x+1\},&
+    L_x&=\{2x-1,2x\},&
+    P_x&=\{2x+1,2x+2\}.
+\end{align}
+The locality inclusion is
+\begin{align}
+    \alpha(\mathcal A_{E_x})
+    &\subseteq
+      \mathcal A_{L_x}\otimes\mathcal A_{P_x}.
+    \label{eq:site_scope_locality}
+\end{align}
+In the factor order displayed in (\ref{eq:site_scope_locality}), equation
+\texttt{RR2x} defines
+\begin{align}
+    \mathcal R_{2x}
+      &=\operatorname{Spp}_{\mathrm L}
+        \bigl(\alpha(\mathcal A_{E_x})\bigr)
+        \subseteq\mathcal A_{L_x},\\
+    \mathcal R_{2x+1}
+      &=\operatorname{Spp}_{\mathrm R}
+        \bigl(\alpha(\mathcal A_{E_x})\bigr)
+        \subseteq\mathcal A_{P_x}.
+    \label{eq:site_scope_supports}
+\end{align}
+These formulas occur at lines 1251--1266 of the arXiv v2 source.  The
+site-dependent cell structure and causal-automorphism hypotheses occur at
+lines 557--600.  Translation covariance is not used in
+(\ref{eq:site_scope_locality}) or (\ref{eq:site_scope_supports}).
+
+\section{Adjacent generation and dimensions}
+
+Let $r(y)>0$ be the matrix size for which
+$\mathcal R_y\cong M_{r(y)}(\mathbb C)$.  The adjacent-generation argument
+gives the two ordered product identities
+\begin{align}
+    d(2x)d(2x+1)
+      &=r(2x)r(2x+1),                                      \label{eq:site_scope_even}\\
+    r(2x+1)r(2x+2)
+      &=d(2x+1)d(2x+2).                                    \label{eq:site_scope_odd}
+\end{align}
+The first is the matrix-size consequence of equation \texttt{AARReven} at
+lines 1276--1287; the second is the consequence of equation
+\texttt{AARRodd} at lines 1306--1315
+\cite{Gross2012IndexTheory}.  Consequently,
+\begin{align}
+    \frac{r(2x)}{d(2x)}
+      &=\frac{d(2x+1)}{r(2x+1)}
+       =\frac{r(2x+2)}{d(2x+2)}.
+    \label{eq:site_scope_ratio}
+\end{align}
+Equation (\ref{eq:site_scope_ratio}) is the site-independent multiplicative
+index relation.  It is labelled \texttt{dimtransfer} at lines 1317--1329.
+
+\section{The homogeneous specialization}
+
+The present spin-chain algebra fixes one positive on-site matrix size $d$.
+Thus
+\begin{align}
+    d(y)&=d
+\end{align}
+for every $y$, and (\ref{eq:site_scope_even})--(\ref{eq:site_scope_ratio})
+specialize to
+\begin{align}
+    d^2&=r(2x)r(2x+1),\\
+    r(2x+1)r(2x+2)&=d^2,\\
+    \frac{r(2x)}{d}
+      &=\frac{d}{r(2x+1)}
+       =\frac{r(2x+2)}{d}.
+    \label{eq:site_scope_homogeneous}
+\end{align}
+This is the setting used by Cirac--P\'erez-Garc\'ia--Schuch--Verstraete:
+their Appendix fixes $\mathcal A_y\cong M_d(\mathbb C)$ and forms the even
+support algebra in lines 2320--2329 \cite{Cirac2017MPU}.
+
+The statements presently proved for the fixed-$d$ spin chain establish only
+the homogeneous versions of (\ref{eq:site_scope_locality}) and
+(\ref{eq:site_scope_supports}), together with their two-sided support
+containment.\footnote{Formal declarations:
+\leanid{SpinChain.PropagatesWithin.evenPairLocalImage},
+\leanid{SpinChain.PropagatesWithin.evenSupportAlgebra},
+\leanid{SpinChain.PropagatesWithin.oddSupportAlgebra}, and
+\leanid{SpinChain.PropagatesWithin.evenPairLocalImage_le_support_kroneckerSubmodule}
+in \doclink{TNLean/QCA/SiteIndexedSupportAlgebra}.}
+The adjacent-generation equalities, matrix-factor presentations,
+identities in (\ref{eq:site_scope_homogeneous}), and index are not part of
+these statements; any fixed-$d$ formulation of those later results remains
+subject to the same homogeneous-chain restriction.
+
+This restriction is distinct from the full-matrix-factor restriction in
+\path{docs/paper-gaps/gnvw12_support_algebra_full_matrix_scope.tex}.  That note
+compares full complex matrix factors with arbitrary finite-dimensional
+$C^*$-algebras.  The present note compares a fixed matrix size along the chain
+with the site-dependent full matrix sizes of GNVW.
+
+\section{Elimination plan}
+
+Removing the restriction requires a site-dependent algebraic local observable
+system with cell algebras $M_{d(y)}(\mathbb C)$, canonical inclusions for
+arbitrary finite regions, and its norm completion.  The finite-region
+restriction of a causal automorphism must then be written in the ordered
+$L_x\times P_x$ coordinates of (\ref{eq:site_scope_locality}).  The same
+coefficient definitions give (\ref{eq:site_scope_supports}); the support
+commutation, scalar-center, and adjacent-generation arguments then yield
+(\ref{eq:site_scope_even}) and (\ref{eq:site_scope_odd}) without imposing
+constancy of $d(y)$.  Finally, (\ref{eq:site_scope_ratio}) defines the
+site-independent GNVW index.  The fixed-$d$ theorems should thereafter be
+derived by specializing the dimension function to the constant value $d$.
+
+Until such a site-dependent observable algebra is available, statements
+corresponding to these steps are necessarily restricted to the homogeneous
+chain.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- define the adjacent regions `E_x`, `L_x`, and `P_x`, with their exact union, disjointness, and overlap identities
- form the finite image of the even pair in the ordered `L_x × P_x` coordinates supplied by #7138
- define the left and right matrix support algebras and expose one parity-indexed family in the quasi-local algebra
- prove the site-specific two-sided support containment by reusing the generic support theorem
- record the homogeneous-chain restriction in a dedicated paper-gap note and in the Chapter 28 Blueprint

## Integration

The prerequisite #7138 is merged. This branch is now based on current `main`; `git range-diff` confirms that its single five-file commit is exactly patch-equivalent to the reviewed stacked commit.

## Mathematical scope

The construction is the fixed-on-site-dimension specialization of the support algebras surrounding GNVW equation `RR2x`. It does not assert the site-dependent GNVW construction, translation covariance, adjacent-block generation, or the QCA index.

Closes #7114.

## Validation

- `lake build TNLean.QCA.SiteIndexedSupportAlgebra` (3,060 cached jobs)
- import-aggregator check and 14 generator tests
- 16 Lean file-policy tests and oversized-file guard
- Blueprint source synchronization: 6,840 of 6,840 theorem-like entries synchronized; every changed declaration is referenced
- paper-gap reference resolution: 98 referenced slugs resolved
- reader-facing prose, proof-integrity, tactic-pattern, ChkTeX, and `git diff --check` scans

The full Blueprint declaration check remains an exact-head CI gate after the complete library build.
