### PR TITLE
refactor(MPS/Core): centralize blocking and bond reindexing

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -54,8 +54,8 @@ theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
       (blockTensor (d := d) (D := D) B p) := by
   obtain ⟨X, hX⟩ := h
   refine ⟨X, fun i ↦ ?_⟩
-  simpa [MPSTensor.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
-    evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
+  simpa [Kraus.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
+    evalWord_gauge (A := A) (B := B) X hX (Kraus.wordOfBlock d p i)
 
 end GaugeEquiv
 
@@ -132,9 +132,9 @@ theorem blockTensor_toTensorFromBlocks_apply {r : ℕ} {dim : Fin r → ℕ}
       toTensorFromBlocks (d := blockPhysDim d p)
         (fun k ↦ μ k ^ p)
         (fun k ↦ blockTensor (d := d) (D := dim k) (blocks k) p) i := by
-  simp [MPSTensor.blockTensor, toTensorFromBlocks,
+  simp [Kraus.blockTensor, toTensorFromBlocks,
     evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal,
-    length_wordOfBlock]
+    Kraus.length_wordOfBlock]
 
 namespace CPSVCanonicalFormData
 
@@ -161,20 +161,20 @@ noncomputable def blockTensor {A : MPSTensor d D}
   coisometric := data.coisometric
   reconstruct := by
     intro i
-    have hword_ne : wordOfBlock d p i ≠ [] := by
+    have hword_ne : Kraus.wordOfBlock d p i ≠ [] := by
       intro hnil
       have hlen := congrArg List.length hnil
-      simp [length_wordOfBlock, hp.ne'] at hlen
+      simp [Kraus.length_wordOfBlock, hp.ne'] at hlen
     calc
       MPSTensor.blockTensor (d := d) (D := D) A p i =
           data.ambient_coisometryᴴ *
             Kraus.evalWord (toTensorFromBlocks (d := d) data.weights data.blocks)
-              (wordOfBlock d p i) *
+              (Kraus.wordOfBlock d p i) *
             data.ambient_coisometry := by
-            simpa [MPSTensor.blockTensor] using
+            simpa [Kraus.blockTensor] using
               evalWord_eq_coisometry_reconstruction_of_ne_nil
                 data.ambient_coisometry data.coisometric data.reconstruct
-                (wordOfBlock d p i) hword_ne
+                (Kraus.wordOfBlock d p i) hword_ne
       _ = data.ambient_coisometryᴴ *
             toTensorFromBlocks (d := blockPhysDim d p)
               (fun k ↦ data.weights k ^ p)
@@ -207,7 +207,7 @@ noncomputable def blockTensor {A : MPSTensor d D}
     intro k
     obtain ⟨Λ, hΛpos, hΛdiag, hΛfix⟩ := data.blocks_fixed_point k
     exact ⟨Λ, hΛpos, hΛdiag, by
-      change Kraus.transferMap (MPSTensor.blockTensor (data.blocks k) p) Λ = Λ
+      change Kraus.transferMap (Kraus.blockTensor (data.blocks k) p) Λ = Λ
       exact transferMap_blockTensor_fixedPoint (data.blocks k) p Λ hΛfix⟩
 
 end CPSVCanonicalFormIIData

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -111,7 +111,7 @@ theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
   have hConj := hInj.mapStar
   convert hConj using 1
   ext σ β α
-  simp [MPSTensor.blockTensor, MPSTensor.evalWord_mapStar]
+  simp [Kraus.blockTensor, MPSTensor.evalWord_mapStar]
 
 end Kraus
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -337,11 +337,13 @@ private theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
       (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
     wordOfBlock d p i := by
   subst hp_eq
-  simp only [flattenBlockedWord, wordOfBlock, decodeBlock, List.map_ofFn, Function.comp_apply]
+  simp only [Kraus.flattenBlockedWord, Kraus.wordOfBlock, Kraus.decodeBlock,
+    List.map_ofFn, Function.comp_apply]
   rw [List.ofFn_mul']
   apply congrArg List.flatten
   exact congrArg List.ofFn (funext fun j => by
-    simp only [wordOfBlock, decodeBlock, Fin.cast_cast, Function.comp_apply]
+    simp only [Kraus.wordOfBlock, Kraus.decodeBlock, Fin.cast_cast,
+      Function.comp_apply]
     exact congrArg List.ofFn (funext fun t => by
       apply Fin.ext
       simpa [blockPhysDim_eq_pow] using
@@ -428,7 +430,12 @@ private theorem blockTensor_eq_commonReindexedBlock_of_word_eq
     blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k := by
   funext i
   rw [commonReindexedBlock, cast_physDim_apply (F.blockPhysDim_nested_eq k)]
-  simp [Kraus.reindexPhysical, blockTensor, hWord i]
+  change Kraus.evalWord (blocks k) (Kraus.wordOfBlock d F.p i) =
+    Kraus.evalWord (blocks k)
+      (Kraus.wordOfBlock d (F.period k * F.extra k)
+        (iteratedBlockIndex d (F.period k) (F.extra k)
+          (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i)))
+  exact congrArg (Kraus.evalWord (blocks k)) (hWord i)
 
 /-- Direct blocking of one original block is the relabeled common block when the
 canonical identification with the iterated alphabet agrees with consecutive grouping of the

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Core.BlockingTransfer
+import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.Core.CanonicalNormalization
 import TNLean.MPS.Core.CorrelationReduction
 import TNLean.MPS.Core.Correlations

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -38,11 +38,6 @@ noncomputable abbrev blockPhysDim (d L : ℕ) : ℕ :=
 lemma blockPhysDim_eq_pow (d L : ℕ) : blockPhysDim d L = d ^ L := by
   exact Kraus.blockPhysDim_eq_pow d L
 
-/-- Blocking preserves nonzero physical dimensions. -/
-instance instNeZeroBlockPhysDim [NeZero d] : NeZero (blockPhysDim d L) := ⟨by
-  rw [blockPhysDim_eq_pow]
-  exact pow_ne_zero L (NeZero.ne d)⟩
-
 /-- The physical alphabet after blocking one site is equivalent to the original alphabet. -/
 noncomputable abbrev singleBlockEquiv (d : ℕ) : Fin (blockPhysDim d 1) ≃ Fin d :=
   Kraus.singleBlockEquiv d

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -32,8 +32,8 @@ namespace MPSTensor
 variable {d D L : ℕ}
 
 /-- Blocked physical dimension: the number of length-`L` words over an alphabet of size `d`. -/
-noncomputable def blockPhysDim (d L : ℕ) : ℕ :=
-  Fintype.card (Fin L → Fin d)
+noncomputable abbrev blockPhysDim (d L : ℕ) : ℕ :=
+  Kraus.blockPhysDim d L
 
 lemma blockPhysDim_eq_pow (d L : ℕ) : blockPhysDim d L = d ^ L := by
   exact Kraus.blockPhysDim_eq_pow d L
@@ -44,44 +44,43 @@ instance instNeZeroBlockPhysDim [NeZero d] : NeZero (blockPhysDim d L) := ⟨by
   exact pow_ne_zero L (NeZero.ne d)⟩
 
 /-- The physical alphabet after blocking one site is equivalent to the original alphabet. -/
-noncomputable def singleBlockEquiv (d : ℕ) : Fin (blockPhysDim d 1) ≃ Fin d :=
-  ((finCongr (blockPhysDim_eq_pow d 1)).trans finFunctionFinEquiv.symm).trans
-    (Equiv.funUnique (Fin 1) (Fin d))
+noncomputable abbrev singleBlockEquiv (d : ℕ) : Fin (blockPhysDim d 1) ≃ Fin d :=
+  Kraus.singleBlockEquiv d
 
 /-- Decode a blocked physical index into the corresponding length-`L` word. -/
-noncomputable def decodeBlock (d L : ℕ) : Fin (blockPhysDim d L) → (Fin L → Fin d) :=
-  finFunctionFinEquiv.symm ∘ Fin.cast (blockPhysDim_eq_pow d L)
+noncomputable abbrev decodeBlock (d L : ℕ) : Fin (blockPhysDim d L) → (Fin L → Fin d) :=
+  Kraus.decodeBlock d L
 
 /-- Turn a blocked physical index into a list of length `L`. -/
-noncomputable def wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) : List (Fin d) :=
-  List.ofFn (decodeBlock d L i)
+noncomputable abbrev wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) : List (Fin d) :=
+  Kraus.wordOfBlock d L i
 
-@[simp] lemma length_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
+lemma length_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
     (wordOfBlock d L i).length = L := by
   exact Kraus.length_wordOfBlock d L i
 
-@[simp] lemma wordOfBlock_one (d : ℕ) (i : Fin (blockPhysDim d 1)) :
+lemma wordOfBlock_one (d : ℕ) (i : Fin (blockPhysDim d 1)) :
     wordOfBlock d 1 i = [singleBlockEquiv d i] := by
   exact Kraus.wordOfBlock_one d i
 
 /-- The blocked index is equivalent to a word of length `L`. -/
-noncomputable def decodeBlockEquiv (d L : ℕ) :
+noncomputable abbrev decodeBlockEquiv (d L : ℕ) :
     Fin (blockPhysDim d L) ≃ (Fin L → Fin d) :=
-  (finCongr (blockPhysDim_eq_pow d L)).trans finFunctionFinEquiv.symm
+  Kraus.decodeBlockEquiv d L
 
-@[simp] lemma decodeBlockEquiv_apply (d L : ℕ) (I : Fin (blockPhysDim d L)) :
+lemma decodeBlockEquiv_apply (d L : ℕ) (I : Fin (blockPhysDim d L)) :
     decodeBlockEquiv d L I = decodeBlock d L I := rfl
 
-@[simp] lemma decodeBlock_decodeBlockEquiv_symm (d L : ℕ) (w : Fin L → Fin d) :
+lemma decodeBlock_decodeBlockEquiv_symm (d L : ℕ) (w : Fin L → Fin d) :
     decodeBlock d L ((decodeBlockEquiv d L).symm w) = w := by
   exact Kraus.decodeBlock_decodeBlockEquiv_symm d L w
 
 /-- Block a matrix product tensor by grouping `L` physical sites. -/
-noncomputable def blockTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ) :
+noncomputable abbrev blockTensor (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (L : ℕ) :
     Fin (blockPhysDim d L) → Matrix (Fin D) (Fin D) ℂ :=
-  fun i => Kraus.evalWord A (wordOfBlock d L i)
+  Kraus.blockTensor A L
 
-@[simp] lemma blockTensor_one_apply (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
+lemma blockTensor_one_apply (A : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (i : Fin (blockPhysDim d 1)) :
     blockTensor (d := d) (D := D) A 1 i = A (singleBlockEquiv d i) := by
   exact Kraus.blockTensor_one_apply A i
@@ -93,11 +92,11 @@ lemma isNBlkInjective_iff_blockTensor_isInjective
   exact Kraus.isNBlkInjective_iff_blockTensor_isInjective A N
 
 /-- Flatten a word in blocked indices into a word in the original alphabet. -/
-noncomputable def flattenBlockedWord (d L : ℕ) :
-    List (Fin (blockPhysDim d L)) → List (Fin d)
-  | w => (w.map (wordOfBlock d L)).flatten
+noncomputable abbrev flattenBlockedWord (d L : ℕ) :
+    List (Fin (blockPhysDim d L)) → List (Fin d) :=
+  Kraus.flattenBlockedWord d L
 
-@[simp] lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
+lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
   exact Kraus.flattenBlockedWord_nil d L
 
 lemma flattenBlockedWord_cons (d L : ℕ) (i : Fin (blockPhysDim d L))
@@ -105,7 +104,7 @@ lemma flattenBlockedWord_cons (d L : ℕ) (i : Fin (blockPhysDim d L))
     flattenBlockedWord d L (i :: w) = wordOfBlock d L i ++ flattenBlockedWord d L w := by
   exact Kraus.flattenBlockedWord_cons d L i w
 
-@[simp] lemma flattenBlockedWord_one (d : ℕ) (w : List (Fin (blockPhysDim d 1))) :
+lemma flattenBlockedWord_one (d : ℕ) (w : List (Fin (blockPhysDim d 1))) :
     flattenBlockedWord d 1 w = w.map (singleBlockEquiv d) := by
   exact Kraus.flattenBlockedWord_one d w
 
@@ -208,7 +207,8 @@ lemma ofFn_blockedConfigEquiv (d N L : ℕ)
     funext k
     simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, Function.comp]
   rw [hfun, List.ofFn_mul]
-  rw [flattenBlockedWord, List.map_ofFn]
+  change _ = ((List.ofFn σ).map (Kraus.wordOfBlock d L)).flatten
+  rw [List.map_ofFn]
   congr 1
   refine congrArg List.ofFn (funext fun i => ?_)
   have hsymm : ∀ j : Fin L,
@@ -228,8 +228,7 @@ lemma ofFn_blockedConfigEquiv (d N L : ℕ)
     change (i : ℕ) * L + (j : ℕ) = (j : ℕ) + L * (i : ℕ)
     rw [Nat.mul_comm L (i : ℕ), Nat.add_comm]
   simp only [hsymm]
-  change (List.ofFn fun j : Fin L => decodeBlock d L (σ i) j) = (wordOfBlock d L ∘ σ) i
-  simp [wordOfBlock, Function.comp]
+  rfl
 
 private theorem evalWord_pointwise_conjTranspose_reverse (A : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     ∀ w : List (Fin d), (Kraus.evalWord (fun i => (A i)ᴴ) w)ᴴ = Kraus.evalWord A w.reverse := by

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -324,7 +324,7 @@ theorem wordOfBlock_blockIndexOfList (d L : ℕ) (w : List (Fin d))
     (h : w.length = L) :
     wordOfBlock d L (blockIndexOfList d L w h) = w := by
   classical
-  unfold blockIndexOfList wordOfBlock decodeBlock
+  unfold blockIndexOfList
   change List.ofFn (finFunctionFinEquiv.symm
     (finFunctionFinEquiv (fun i : Fin L => w.get (Fin.cast h.symm i)))) = w
   rw [finFunctionFinEquiv.symm_apply_apply]
@@ -389,7 +389,6 @@ theorem wordOfBlock_injective (d L : ℕ) : Function.Injective (wordOfBlock d L)
   intro i j hij
   have hdecode : decodeBlock d L i = decodeBlock d L j :=
     List.ofFn_injective hij
-  unfold decodeBlock at hdecode
   exact ((finCongr (blockPhysDim_eq_pow d L)).trans finFunctionFinEquiv.symm).injective hdecode
 
 /-- Flattening the grouped iterated index recovers the direct blocked word. -/
@@ -401,12 +400,12 @@ theorem flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex (d m n : ℕ)
   classical
   unfold directToIteratedBlockIndex
   rw [wordOfBlock_blockIndexOfList]
-  simp only [flattenBlockedWord, List.map_ofFn]
+  simp only [Kraus.flattenBlockedWord, List.map_ofFn]
   change (List.ofFn (fun j : Fin n =>
     wordOfBlock d m (blockIndexOfList d m (blockWordChunk d m n i j) _))).flatten =
       wordOfBlock d (m * n) i
   simp_rw [wordOfBlock_blockIndexOfList]
-  simpa [blockWordChunk, wordOfBlock] using
+  simpa [blockWordChunk, Kraus.wordOfBlock] using
     (List.ofFn_mul' (m := m) (n := n) (f := decodeBlock d (m * n) i)).symm
 
 /-- Direct blocking is recovered after grouping a direct blocked index and then flattening
@@ -493,7 +492,13 @@ theorem blockTensor_blockTensor_apply {D : ℕ} (A : MPSTensor d D) (m n : ℕ)
     blockTensor (d := blockPhysDim d m) (D := D)
         (blockTensor (d := d) (D := D) A m) n i =
       blockTensor (d := d) (D := D) A (m * n) (iteratedBlockIndex d m n i) := by
-  simp [blockTensor, evalWord_blockTensor, wordOfBlock_iteratedBlockIndex]
+  change Kraus.evalWord (Kraus.blockTensor (d := d) (D := D) A m)
+      (Kraus.wordOfBlock (Kraus.blockPhysDim d m) n i) =
+    Kraus.evalWord A
+      (Kraus.wordOfBlock d (m * n) (iteratedBlockIndex d m n i))
+  rw [Kraus.evalWord_blockTensor]
+  exact congrArg (Kraus.evalWord A)
+    (wordOfBlock_iteratedBlockIndex d m n i).symm
 
 /-- Tensor form of iterated blocking versus direct blocking with physical relabeling. -/
 theorem blockTensor_blockTensor_eq_reindex {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -36,13 +36,13 @@ theorem transferMap_blockTensor_apply
   -- Expand the RHS as a sum over length-`L` words.
   rw [Kraus.transferMap_pow_apply' (A := A) (N := L) X]
   -- Expand the LHS as a sum over blocked physical indices.
-  simp only [Kraus.transferMap_apply, blockTensor, wordOfBlock]
+  simp only [Kraus.transferMap_apply, Kraus.blockTensor, Kraus.wordOfBlock]
   -- Reindex the blocked sum by the equivalence `Fin (blockPhysDim d L) ≃ (Fin L → Fin d)`.
   let e : Fin (blockPhysDim d L) ≃ (Fin L → Fin d) :=
     decodeBlockEquiv d L
   -- After rewriting `decodeBlock` in terms of `e`, `Fintype.sum_equiv` is exactly the desired
   -- reindexing statement.
-  simpa [decodeBlockEquiv_apply, e] using
+  simpa [Kraus.decodeBlockEquiv_apply, e] using
     (Fintype.sum_equiv e
       (f := fun i =>
         Kraus.evalWord A (List.ofFn (e i)) * X * (Kraus.evalWord A (List.ofFn (e i)))ᴴ)

--- a/TNLean/MPS/Core/BondReindex.lean
+++ b/TNLean/MPS/Core/BondReindex.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.TraceReindex
+import TNLean.MPS.Defs
+
+/-!
+# Bond-dimension reindexing of matrix product tensors
+
+This file provides the canonical transport of a matrix product tensor along an
+equality of bond dimensions.  The transport is expressed as an equivalence and
+implemented by reindexing both matrix coordinates along the induced equivalence
+of finite bond-index types.
+
+The accompanying lemmas identify this transport with the former raw type
+cast, describe its values at physical and bond coordinates, and record the
+transport of word evaluation together with the invariance of matrix product
+vectors, `SameMPV₂`, and `GaugePhaseEquiv`.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D D₁ D₂ D₃ : ℕ}
+
+/-- Reindex the bond coordinates of a matrix product tensor along an equality
+of bond dimensions. -/
+def reindex (h : D₁ = D₂) : MPSTensor d D₁ ≃ MPSTensor d D₂ :=
+  Equiv.piCongrRight fun _ : Fin d => Matrix.reindex (finCongr h) (finCongr h)
+
+/-- The bond reindexing along reflexivity is the identity on tensors. -/
+@[simp] theorem reindex_rfl (A : MPSTensor d D) :
+    reindex (rfl : D = D) A = A := by
+  ext i j k
+  rfl
+
+/-- The former type-cast transport agrees with bond-coordinate reindexing. -/
+@[simp] theorem cast_eq_reindex (h : D₁ = D₂) (A : MPSTensor d D₁) :
+    cast (congrArg (MPSTensor d) h) A = reindex h A := by
+  subst h
+  simp
+
+/-- Reindexing a tensor at one physical index reindexes both matrix
+coordinates. -/
+theorem reindex_apply (h : D₁ = D₂) (A : MPSTensor d D₁) (i : Fin d) :
+    reindex h A i =
+      Matrix.reindex (finCongr h) (finCongr h) (A i) := by
+  rfl
+
+/-- At one physical index, bond reindexing agrees with dependent transport of
+the corresponding matrix value. -/
+theorem reindex_apply_eq_cast (h : D₁ = D₂) (A : MPSTensor d D₁) (i : Fin d) :
+    reindex h A i =
+      cast (congrArg (fun n => Matrix (Fin n) (Fin n) ℂ) h) (A i) := by
+  subst h
+  rfl
+
+/-- Reindexing at physical and bond coordinates evaluates the original tensor
+at the inversely reindexed bond coordinates. -/
+@[simp] theorem reindex_apply_apply (h : D₁ = D₂) (A : MPSTensor d D₁)
+    (i : Fin d) (j k : Fin D₂) :
+    reindex h A i j k = A i (finCongr h.symm j) (finCongr h.symm k) := by
+  rfl
+
+/-- Word evaluation commutes with bond-dimension reindexing. -/
+theorem reindex_evalWord (h : D₁ = D₂) (A : MPSTensor d D₁)
+    (w : List (Fin d)) :
+    Kraus.evalWord (reindex h A) w =
+      Matrix.reindex (finCongr h) (finCongr h) (Kraus.evalWord A w) := by
+  subst h
+  simp
+
+/-- Bond-dimension reindexing does not change matrix product vector
+coefficients. -/
+theorem reindex_mpv (h : D₁ = D₂) (A : MPSTensor d D₁)
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (reindex h A) σ = mpv A σ := by
+  unfold mpv coeff
+  rw [reindex_evalWord, Matrix.trace_reindex]
+
+/-- Reindexing the left tensor preserves equality of matrix product vector
+families. -/
+@[simp] theorem sameMPV₂_reindex_left (h : D₁ = D₂)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₃) :
+    SameMPV₂ (reindex h A) B ↔ SameMPV₂ A B := by
+  constructor <;> intro hAB N σ
+  · simpa only [reindex_mpv] using hAB N σ
+  · simpa only [reindex_mpv] using hAB N σ
+
+/-- Reindexing the right tensor preserves equality of matrix product vector
+families. -/
+@[simp] theorem sameMPV₂_reindex_right (h : D₁ = D₂)
+    (A : MPSTensor d D₃) (B : MPSTensor d D₁) :
+    SameMPV₂ A (reindex h B) ↔ SameMPV₂ A B := by
+  constructor <;> intro hAB N σ
+  · simpa only [reindex_mpv] using hAB N σ
+  · simpa only [reindex_mpv] using hAB N σ
+
+/-- Simultaneous bond-dimension reindexing preserves gauge-phase equivalence. -/
+@[simp] theorem gaugePhaseEquiv_reindex (h : D₁ = D₂)
+    (A B : MPSTensor d D₁) :
+    GaugePhaseEquiv (reindex h A) (reindex h B) ↔ GaugePhaseEquiv A B := by
+  subst h
+  simp
+
+end MPSTensor

--- a/TNLean/MPS/Core/BondReindex.lean
+++ b/TNLean/MPS/Core/BondReindex.lean
@@ -20,8 +20,6 @@ transport of word evaluation together with the invariance of matrix product
 vectors, `SameMPV₂`, and `GaugePhaseEquiv`.
 -/
 
-open scoped Matrix
-
 namespace MPSTensor
 
 variable {d D D₁ D₂ D₃ : ℕ}

--- a/TNLean/MPS/Examples/AKLTStringOrder.lean
+++ b/TNLean/MPS/Examples/AKLTStringOrder.lean
@@ -126,12 +126,12 @@ the single-site letters propagates to length-`2` words. -/
 private theorem akltBlocked_transferMap_one : Kraus.transferMap akltBlocked 1 = 1 := by
   classical
   rw [Kraus.transferMap_apply]
-  simp only [Matrix.mul_one, akltBlocked, blockTensor, wordOfBlock]
-  rw [Fintype.sum_equiv (decodeBlockEquiv 3 2)
-    (fun I => Kraus.evalWord akltTensor (List.ofFn (decodeBlock 3 2 I)) *
-      (Kraus.evalWord akltTensor (List.ofFn (decodeBlock 3 2 I)))ᴴ)
+  simp only [Matrix.mul_one, akltBlocked, Kraus.blockTensor, Kraus.wordOfBlock]
+  rw [Fintype.sum_equiv (Kraus.decodeBlockEquiv 3 2)
+    (fun I => Kraus.evalWord akltTensor (List.ofFn (Kraus.decodeBlock 3 2 I)) *
+      (Kraus.evalWord akltTensor (List.ofFn (Kraus.decodeBlock 3 2 I)))ᴴ)
     (fun ρ => Kraus.evalWord akltTensor (List.ofFn ρ) * (Kraus.evalWord akltTensor (List.ofFn ρ))ᴴ)
-    (fun I => by rw [decodeBlockEquiv_apply])]
+    (fun I => by rw [Kraus.decodeBlockEquiv_apply])]
   exact sum_evalWord_mul_conjTranspose_evalWord akltTensor aklt_sum_mul_conjTranspose 2
 
 /-- The maximally mixed boundary state `Λ = (1/2)·1` is a fixed point of the

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -232,13 +232,14 @@ private lemma clusterBlocked_apply (i : Fin 4) :
     clusterBlocked i =
       clusterTensor (decodeBlock 2 2 (Fin.cast cluster_blockPhysDim.symm i) 0) *
         clusterTensor (decodeBlock 2 2 (Fin.cast cluster_blockPhysDim.symm i) 1) := by
-  simp only [clusterBlocked, blockTensor, wordOfBlock]
+  simp only [clusterBlocked, Kraus.blockTensor, Kraus.wordOfBlock]
   simp [List.ofFn_succ, List.ofFn_zero, Kraus.evalWord]
 
 private lemma decodeBlock_cast_val (i : Fin 4) (j : Fin 2) :
     ((decodeBlock 2 2 (Fin.cast cluster_blockPhysDim.symm i)) j : ℕ) =
       i.val / 2 ^ (j : ℕ) % 2 := by
-  unfold decodeBlock
+  change ((Kraus.decodeBlock 2 2 (Fin.cast cluster_blockPhysDim.symm i)) j : ℕ) = _
+  unfold Kraus.decodeBlock
   simp only [Function.comp_apply, finFunctionFinEquiv_symm_apply_val]
   rfl
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -207,11 +207,11 @@ theorem blockTensor_toTensor (P : SectorDecomposition d) (p : ℕ) :
       (fun s ↦ (P.flatWeight s) ^ p)
       (fun s ↦ MPSTensor.blockTensor (P.flatBasis s) p)
   funext i
-  rw [MPSTensor.blockTensor]
-  have h := evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal
-    P.flatWeight P.flatBasis (wordOfBlock d p i)
   change Kraus.evalWord
-      (toTensorFromBlocks (d := d) P.flatWeight P.flatBasis) (wordOfBlock d p i) = _ at h
+      (toTensorFromBlocks (d := d) P.flatWeight P.flatBasis)
+      (Kraus.wordOfBlock d p i) = _
+  have h := evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal
+    P.flatWeight P.flatBasis (Kraus.wordOfBlock d p i)
   rw [h]
   simp only [toTensorFromBlocks, length_wordOfBlock]
   rfl

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
@@ -24,13 +24,6 @@ variable {A B : MPSTensor d D}
 
 namespace CPSVCanonicalFormData
 
-private lemma mpsTensor_cast_apply {n m : ℕ} (h : n = m)
-    (T : MPSTensor d n) (i : Fin d) :
-    (cast (congr_arg (MPSTensor d) h) T) i =
-      cast (congr_arg (fun r => Matrix (Fin r) (Fin r) ℂ) h) (T i) := by
-  subst h
-  rfl
-
 private lemma coisometry_cast_rows {n m : ℕ} (h : n = m)
     (U : Matrix (Fin n) (Fin D) ℂ) (hU : U * Uᴴ = 1) :
     let V := cast (congr_arg (fun r => Matrix (Fin r) (Fin D) ℂ) h) U
@@ -118,7 +111,10 @@ theorem fundamentalTheorem_equal_ambient_canonicalForm
         Subsingleton.elim _ _
       calc
         P' i = cast (congr_arg (fun r => Matrix (Fin r) (Fin r) ℂ) hTotal)
-            (P.toTensor i) := mpsTensor_cast_apply hTotal P.toTensor i
+            (P.toTensor i) := by
+              dsimp [P']
+              rw [cast_eq_reindex hTotal P.toTensor]
+              exact reindex_apply_eq_cast hTotal P.toTensor i
         _ = cast hm (P.toTensor i) := by rw [hp]
     rw [hPi]
     exact hGauge i

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Unitary
 
 /-!
@@ -153,16 +154,6 @@ equation of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` into the literal
 form `ft_sector_bnt_equal_mps_gaugeEquiv_literal`, the equal-MPV corollary
 form (CPSV16 §II.C lines 354–361). -/
 
-/-- Cast of an `MPSTensor` along a bond-dimension equality, evaluated at one
-physical site and two bond indices, equals the underlying tensor evaluated at
-the inversely-cast indices. -/
-private lemma mpsTensor_cast_apply {n m : ℕ} (h : n = m) (A : MPSTensor d n)
-    (i : Fin d) (j₁ j₂ : Fin m) :
-    (cast (congr_arg (MPSTensor d) h) A) i j₁ j₂ =
-      A i (finCongr h.symm j₁) (finCongr h.symm j₂) := by
-  subst h
-  simp [finCongr]
-
 /-- Coordinate identification of `matched_p_basis` with a cast of `P.flatBasis`
 at the matched flat sector. -/
 private lemma matched_p_basis_eq_cast_flatBasis
@@ -231,11 +222,13 @@ private lemma matched_p_basis_apply
             (P := P) (Q := Q) β hDim τ s).symm m)
         (finCongr (SectorDecomposition.flatDim_sectorFlatEquiv
             (P := P) (Q := Q) β hDim τ s).symm m') := by
+  let hFlat :
+      P.flatDim (SectorDecomposition.sectorFlatEquiv
+        (P := P) (Q := Q) β τ s) = Q.flatDim s :=
+    SectorDecomposition.flatDim_sectorFlatEquiv
+      (P := P) (Q := Q) β hDim τ s
   rw [matched_p_basis_eq_cast_flatBasis (P := P) (Q := Q) β hDim τ s,
-      mpsTensor_cast_apply
-        (SectorDecomposition.flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s)
-        (P.flatBasis (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s))
-        i m m']
+      cast_eq_reindex hFlat, reindex_apply_apply hFlat]
 
 /-- `matched_p_weight β τ s = P.flatWeight (sectorFlatEquiv β τ s)`. -/
 private lemma matched_p_weight_eq_flatWeight

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/PreparedReconstruction.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/PreparedReconstruction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
 import TNLean.MPS.SharedInfra.BlockAssembly
 
@@ -31,13 +32,6 @@ private lemma cast_gl_conj_apply {n m : ℕ} (h : n = m)
     ((G : Matrix (Fin m) (Fin m) ℂ) *
       cast (congr_arg (fun t => Matrix (Fin t) (Fin t) ℂ) h) B *
       (↑(G⁻¹) : Matrix (Fin m) (Fin m) ℂ)) x y := by
-  subst h
-  rfl
-
-private lemma mpsTensor_cast_apply_matrix {n m : ℕ} (h : n = m)
-    (B : MPSTensor d n) (i : Fin d) :
-    (cast (congr_arg (MPSTensor d) h) B) i =
-      cast (congr_arg (fun t => Matrix (Fin t) (Fin t) ℂ) h) (B i) := by
   subst h
   rfl
 
@@ -220,8 +214,8 @@ theorem exists_isBNTCanonicalForm_exact_of_tp_primitive_irr_blocks
           (P.flatBasis (P.flatIndexEquiv jqP) i) x y]
         rw [← hCastBasisMatrix]
         dsimp [C]
-        rw [mpsTensor_cast_apply_matrix (d := d) (hEq jq.1 jq.2)
-          (blocks ((mpvPhaseClassData (d := d) blocks).repr jq.1)) i]
+        rw [cast_eq_reindex (hEq jq.1 jq.2),
+          reindex_apply_eq_cast (hEq jq.1 jq.2)]
       have hfin (z : Fin (dim ((mpvPhaseClassData (d := d) blocks).enum jq.1 jq.2))) :
           (finCongr hdLocal).symm.symm z = Fin.cast hdLocal z := by
         apply Fin.ext

--- a/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
@@ -68,20 +68,20 @@ theorem blocked_fusion_of_lengthIndependent
   obtain ⟨n, rfl⟩ : ∃ n, L = n + 1 :=
     ⟨L - 1, (Nat.succ_pred_eq_of_pos hL).symm⟩
   rw [← blockTensor_mulTensor (Fam.tensor α) (Fam.tensor β)]
-  simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+  simp only [blockTensor_apply, Kraus.wordOfBlock, MPOTensor.evalWord_ofFn]
   let F : Fin (n + 1) →
       Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
         (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
     fun l ↦ mulTensor (Fam.tensor α) (Fam.tensor β)
-      (MPSTensor.decodeBlock p (n + 1) I l)
-      (MPSTensor.decodeBlock p (n + 1) J l)
+      (Kraus.decodeBlock p (n + 1) I l)
+      (Kraus.decodeBlock p (n + 1) J l)
   let G : ∀ γ : Λ, Fin (n + 1) →
       Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ :=
     fun γ l ↦ Fam.tensor γ
-      (MPSTensor.decodeBlock p (n + 1) I l)
-      (MPSTensor.decodeBlock p (n + 1) J l)
+      (Kraus.decodeBlock p (n + 1) I l)
+      (Kraus.decodeBlock p (n + 1) J l)
   unfold blockedUnweightedDirectSumLetter
-  simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+  simp only [blockTensor_apply, Kraus.wordOfBlock, MPOTensor.evalWord_ofFn]
   change Fam.fusionIsometry α β * (List.ofFn F).prod *
       (Fam.fusionIsometry α β)ᴴ =
     Matrix.blockDiagonal' fun γ ↦
@@ -98,8 +98,8 @@ theorem blocked_fusion_of_lengthIndependent
       rw [List.ofFn_inj]
       funext l
       exact Fam.fusion α β
-        (MPSTensor.decodeBlock p (n + 1) I l)
-        (MPSTensor.decodeBlock p (n + 1) J l)
+        (Kraus.decodeBlock p (n + 1) I l)
+        (Kraus.decodeBlock p (n + 1) J l)
     _ = Matrix.blockDiagonal' (fun γ ↦
         ((Fam.chi.matrix α β γ) ^ (n + 1)) ⊗ₖ
           (List.ofFn (G γ)).prod) := by
@@ -240,11 +240,11 @@ theorem exists_positive_block_with_injective_fusion
   have hReindexed :=
     (MPSTensor.wordTupleSpanTop_reindexPhysical_equiv
       (blockedDoubledIndexEquiv p L)
-      (fun γ ↦ MPSTensor.blockTensor (Fam.tensor γ).toMPSTensor L) 1).2 hSpan
+      (fun γ ↦ Kraus.blockTensor (Fam.tensor γ).toMPSTensor L) 1).2 hSpan
   have hFamily :
       (fun γ ↦ (blockTensor (Fam.tensor γ) L).toMPSTensor) =
         fun γ ↦ Kraus.reindexPhysical (blockedDoubledIndexEquiv p L)
-          (MPSTensor.blockTensor (Fam.tensor γ).toMPSTensor L) := by
+          (Kraus.blockTensor (Fam.tensor γ).toMPSTensor L) := by
     funext γ
     exact toMPSTensor_blockTensor (Fam.tensor γ)
   have hSpanBlocked : MPSTensor.WordTupleSpanTop

--- a/TNLean/MPS/MPDO/FirstSiteBlocking.lean
+++ b/TNLean/MPS/MPDO/FirstSiteBlocking.lean
@@ -121,11 +121,11 @@ theorem insertedTensor_firstSiteActionOnBlock_blockTensor
   intro j _
   rw [Fintype.sum_eq_single
     (fun k : Fin L => decodeBlock d (L + 1) I k.succ)]
-  · simp [firstSiteActionOnBlock, blockTensor, wordOfBlock, List.ofFn_succ,
-      Kraus.evalWord_cons]
+  · simp [firstSiteActionOnBlock, Kraus.blockTensor, Kraus.wordOfBlock,
+      List.ofFn_succ, Kraus.evalWord_cons]
   · intro w hw
     simp only [Fin.consEquiv_apply, firstSiteActionOnBlock,
-      decodeBlock_decodeBlockEquiv_symm, Fin.cons_zero, Fin.cons_succ]
+      Kraus.decodeBlock_decodeBlockEquiv_symm, Fin.cons_zero, Fin.cons_succ]
     rw [ite_eq_right]
     · simp
     · exact fun h => hw h.symm

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -136,7 +136,7 @@ lemma decodeBlock_blockedDoubledIndexEquiv (d L : ℕ)
         (MPSTensor.decodeBlock d L ij.divNat k,
           MPSTensor.decodeBlock d L ij.modNat k) := by
   simp [blockedDoubledIndexEquiv, Equiv.arrowCongr,
-    MPSTensor.decodeBlockEquiv_apply]
+    Kraus.decodeBlockEquiv_apply]
 
 /-- Physical blocking commutes with passing from an MPO tensor to its
 doubled-index MPS tensor, up to the canonical pairing of the blocked ket and
@@ -147,7 +147,7 @@ theorem toMPSTensor_blockTensor (M : MPOTensor d D) {L : ℕ} :
         (MPSTensor.blockTensor M.toMPSTensor L) := by
   funext ij
   simp [toMPSTensor, blockTensor_apply, Kraus.reindexPhysical,
-    MPSTensor.blockTensor, MPSTensor.wordOfBlock, MPOTensor.evalWord_ofFn,
+    Kraus.blockTensor, Kraus.wordOfBlock, MPOTensor.evalWord_ofFn,
     MPSTensor.evalWord_ofFn_eq_prod, decodeBlock_blockedDoubledIndexEquiv,
     MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
 
@@ -170,12 +170,12 @@ theorem blockTensor_mulTensor {D₁ D₂ : ℕ}
   funext I K
   rw [blockTensor_apply, mulTensor_apply]
   change evalWord (mulTensor M N)
-      (List.ofFn (MPSTensor.decodeBlock d L I))
-      (List.ofFn (MPSTensor.decodeBlock d L K)) = _
+      (List.ofFn (Kraus.decodeBlock d L I))
+      (List.ofFn (Kraus.decodeBlock d L K)) = _
   rw [evalWord_mulTensor]
-  rw [← (MPSTensor.decodeBlockEquiv d L).sum_comp]
-  simp only [MPSTensor.decodeBlockEquiv_apply, blockTensor_apply,
-    MPSTensor.wordOfBlock]
+  rw [← (Kraus.decodeBlockEquiv d L).sum_comp]
+  simp only [Kraus.decodeBlockEquiv_apply, blockTensor_apply,
+    Kraus.wordOfBlock]
 
 private theorem evalWord_blockTensor_ofFn (M : MPOTensor d D) (L : ℕ) {N : ℕ}
     (s t : Fin N → Fin (MPSTensor.blockPhysDim d L)) :
@@ -184,10 +184,10 @@ private theorem evalWord_blockTensor_ofFn (M : MPOTensor d D) (L : ℕ) {N : ℕ
         (MPSTensor.flattenBlockedWord d L (List.ofFn t)) := by
   induction N with
   | zero =>
-      simp [MPSTensor.flattenBlockedWord]
+      simp
   | succ N ih =>
       simp only [List.ofFn_succ, evalWord_cons, blockTensor_apply,
-        MPSTensor.flattenBlockedWord_cons]
+        Kraus.flattenBlockedWord_cons]
       rw [ih]
       rw [evalWord_append M _ _ _ _ (by simp)]
 
@@ -264,8 +264,8 @@ theorem toMPSTensor_blockTwo (M : MPOTensor d D) :
         (MPSTensor.blockTensor M.toMPSTensor 2) := by
   funext ij
   simp [toMPSTensor, blockTwo, Kraus.reindexPhysical,
-    MPSTensor.blockTensor, evalWord, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
-    blockedDoubledIndexEquiv, MPSTensor.wordOfBlock, Equiv.arrowCongr]
+    Kraus.blockTensor, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
+    blockedDoubledIndexEquiv, Kraus.wordOfBlock, Equiv.arrowCongr]
 
 /-- The concrete two-site blocking is the general length-two blocking after
 the canonical relabeling of each physical index.
@@ -275,7 +275,7 @@ theorem blockTwo_eq_blockTensor_reindex (M : MPOTensor d D) :
     blockTwo M = fun i j ↦
       blockTensor M 2 (twoSiteBlockEquiv d i) (twoSiteBlockEquiv d j) := by
   funext i j
-  simp [blockTwo, blockTensor, twoSiteBlockEquiv, MPSTensor.wordOfBlock]
+  simp [blockTwo, blockTensor, twoSiteBlockEquiv, Kraus.wordOfBlock]
 
 /-- Closing a chain of concrete two-site blocks is the same as closing a
 chain of general length-two blocks, after relabeling every physical index.

--- a/TNLean/MPS/MPDO/VerticalProductCornerComparison.lean
+++ b/TNLean/MPS/MPDO/VerticalProductCornerComparison.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.MPDO.VerticalProductSpectralFamily
 
 /-!
@@ -158,13 +159,6 @@ private theorem castDependentTensor_eq
     (A : (i : ι) → MPSTensor e (bondDim i))
     {i j : ι} (h : i = j) :
     cast (congrArg (MPSTensor e) (congrArg bondDim h)) (A i) = A j := by
-  cases h
-  rfl
-
-private theorem castTensor_apply
-    {e m n : ℕ} (h : m = n) (A : MPSTensor e m) (v : Fin e) :
-    (cast (congrArg (MPSTensor e) h) A) v =
-      cast (congrArg (fun k ↦ Matrix (Fin k) (Fin k) ℂ) h) (A v) := by
   cases h
   rfl
 
@@ -402,7 +396,8 @@ private theorem originalCornerInclusion_weighted_intertwining
               (Fin (S.flatDim j)) ℂ))) := by
     intro v
     rw [hVflat v, C.block_eq j v]
-    rw [castTensor_apply (C.dim_eq j) (A₂ (C.label j)) v]
+    rw [MPSTensor.cast_eq_reindex (C.dim_eq j) (A₂ (C.label j)),
+      MPSTensor.reindex_apply_eq_cast (C.dim_eq j) (A₂ (C.label j)) v]
     simp only [c, smul_smul]
   let W₂ := normalizedGroupedSectorMap (C.dim_eq j) Vflat
     (C.gauge j) (omega j)
@@ -553,8 +548,10 @@ private theorem originalCornerTerm_weighted_eq
     have hcast := castBondColumns_corner (A₂ (C.label j) ab) W₂ c
       (congrArg dim₂ hSigma).symm
     have hAcastLetter := congrFun hAcast ab
-    rw [castTensor_apply (congrArg dim₂ hSigma).symm
-      (A₂ (C.label j)) ab] at hAcastLetter
+    rw [MPSTensor.cast_eq_reindex (congrArg dim₂ hSigma.symm)
+      (A₂ (C.label j)),
+      MPSTensor.reindex_apply_eq_cast (congrArg dim₂ hSigma.symm)
+        (A₂ (C.label j)) ab] at hAcastLetter
     rw [hAcastLetter] at hcast
     simpa only [Wsigma] using hcast
   have hGaugeCorner : W₂ * (c • A₂ (C.label j) ab) * W₂ᴴ =
@@ -584,8 +581,9 @@ private theorem originalCornerTerm_weighted_eq
       (S.localInclusion p k) (S.coefficient p k)
       (localDim_eq_flatDim S p k)
     have hblockLetter := congrFun hblock ab
-    rw [castTensor_apply (localDim_eq_flatDim S p k) (S.block p k) ab]
-      at hblockLetter
+    rw [MPSTensor.cast_eq_reindex (localDim_eq_flatDim S p k) (S.block p k),
+      MPSTensor.reindex_apply_eq_cast (localDim_eq_flatDim S p k)
+        (S.block p k) ab] at hblockLetter
     rw [hblockLetter] at hcast
     simpa only [Vflat] using hcast
   have hscalar : a * ((c * t) / a) = c * t := by
@@ -616,7 +614,8 @@ private theorem originalCornerTerm_weighted_eq
             (Fin (S.flatDim j)) ℂ))) * Vflatᴴ := hGaugeCorner
     _ = Vflat * (S.coefficient p k • S.flatBlock j ab) * Vflatᴴ := by
       rw [C.block_eq j ab,
-        castTensor_apply (C.dim_eq j) (A₂ (C.label j)) ab]
+        MPSTensor.cast_eq_reindex (C.dim_eq j) (A₂ (C.label j)),
+        MPSTensor.reindex_apply_eq_cast (C.dim_eq j) (A₂ (C.label j)) ab]
       simp only [c, smul_smul]
     _ = S.localInclusion p k * (S.coefficient p k • S.block p k ab) *
         (S.localInclusion p k)ᴴ := hLocalCorner

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -37,23 +37,23 @@ namespace MPOTensor
 variable {d D : ℕ}
 
 private noncomputable def blockHead (k : ℕ)
-    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) : Fin d :=
-  MPSTensor.decodeBlock d (k + 1) I 0
+    (I : Fin (Kraus.blockPhysDim d (k + 1))) : Fin d :=
+  Kraus.decodeBlock d (k + 1) I 0
 
 private noncomputable def blockTail (k : ℕ)
-    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-    Fin (MPSTensor.blockPhysDim d k) :=
-  (MPSTensor.decodeBlockEquiv d k).symm
-    (fun q : Fin k => MPSTensor.decodeBlock d (k + 1) I q.succ)
+    (I : Fin (Kraus.blockPhysDim d (k + 1))) :
+    Fin (Kraus.blockPhysDim d k) :=
+  (Kraus.decodeBlockEquiv d k).symm
+    (fun q : Fin k => Kraus.decodeBlock d (k + 1) I q.succ)
 
 private lemma wordOfBlock_succ (k : ℕ)
-    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-    MPSTensor.wordOfBlock d (k + 1) I =
-      blockHead k I :: MPSTensor.wordOfBlock d k (blockTail k I) := by
-  simp [MPSTensor.wordOfBlock, blockHead, blockTail, List.ofFn_succ]
+    (I : Fin (Kraus.blockPhysDim d (k + 1))) :
+    Kraus.wordOfBlock d (k + 1) I =
+      blockHead k I :: Kraus.wordOfBlock d k (blockTail k I) := by
+  simp [Kraus.wordOfBlock, blockHead, blockTail, List.ofFn_succ]
 
 private lemma blockTensor_succ_apply (U : MPOTensor d D) (k : ℕ)
-    (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+    (I J : Fin (Kraus.blockPhysDim d (k + 1))) :
     blockTensor U (k + 1) I J =
       U (blockHead k I) (blockHead k J) *
         blockTensor U k (blockTail k I) (blockTail k J) := by
@@ -69,7 +69,7 @@ private lemma sourceCutSVD_factorization_apply
   simpa only [Matrix.mul_apply] using h.symm
 
 private noncomputable def rightSuccLeft (U : MPOTensor d D) (k : ℕ) :
-    Matrix (Fin D × Fin (MPSTensor.blockPhysDim d (k + 1)))
+    Matrix (Fin D × Fin (Kraus.blockPhysDim d (k + 1)))
       (Fin d × Fin r[blockTensor U k]) ℂ :=
   fun (α, J) (i, q) =>
     ∑ γ : Fin D, U i (blockHead k J) α γ *
@@ -77,7 +77,7 @@ private noncomputable def rightSuccLeft (U : MPOTensor d D) (k : ℕ) :
 
 private noncomputable def rightSuccRight (U : MPOTensor d D) (k : ℕ) :
     Matrix (Fin d × Fin r[blockTensor U k])
-      (Fin (MPSTensor.blockPhysDim d (k + 1)) × Fin D) ℂ :=
+      (Fin (Kraus.blockPhysDim d (k + 1)) × Fin D) ℂ :=
   fun (i, q) (I, β) =>
     if i = blockHead k I then
       ((sourceSVD₁ (blockTensor U k)).diagonal *
@@ -125,7 +125,7 @@ private theorem sourceCutM₁_blockTensor_succ_factorization
     simp [hi]
 
 private noncomputable def leftSuccLeft (U : MPOTensor d D) (k : ℕ) :
-    Matrix (Fin D × Fin (MPSTensor.blockPhysDim d (k + 1)))
+    Matrix (Fin D × Fin (Kraus.blockPhysDim d (k + 1)))
       (Fin d × Fin ℓ[blockTensor U k]) ℂ :=
   fun (α, I) (j, q) =>
     ∑ γ : Fin D, U (blockHead k I) j α γ *
@@ -133,7 +133,7 @@ private noncomputable def leftSuccLeft (U : MPOTensor d D) (k : ℕ) :
 
 private noncomputable def leftSuccRight (U : MPOTensor d D) (k : ℕ) :
     Matrix (Fin d × Fin ℓ[blockTensor U k])
-      (Fin (MPSTensor.blockPhysDim d (k + 1)) × Fin D) ℂ :=
+      (Fin (Kraus.blockPhysDim d (k + 1)) × Fin D) ℂ :=
   fun (j, q) (J, β) =>
     if j = blockHead k J then
       ((sourceSVD₂ (blockTensor U k)).diagonal *

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -311,7 +311,7 @@ variable {d D : ℕ}
 private theorem sqrt_blockPhysDim (d p : ℕ) :
     Real.sqrt (MPSTensor.blockPhysDim d p) = Real.sqrt d ^ p := by
   suffices Real.sqrt ((d ^ p : ℕ) : ℝ) = Real.sqrt d ^ p by
-    simpa [MPSTensor.blockPhysDim] using this
+    simpa only [Kraus.blockPhysDim_eq_pow] using this
   induction p with
   | zero => simp
   | succ p ih =>
@@ -333,11 +333,11 @@ theorem normalizedFlattening_blockTensor (U : MPOTensor d D) (p : ℕ) :
   funext ij
   rw [normalizedFlattening, toMPSTensor_blockTensor]
   simp only [Kraus.reindexPhysical]
-  simp only [MPSTensor.blockTensor]
+  simp only [Kraus.blockTensor]
   change _ = Kraus.evalWord
     (fun i => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor i) _
-  rw [Kraus.evalWord_smul, MPSTensor.length_wordOfBlock]
-  have hsqrtC : (Real.sqrt (MPSTensor.blockPhysDim d p) : ℂ) =
+  rw [Kraus.evalWord_smul, Kraus.length_wordOfBlock]
+  have hsqrtC : (Real.sqrt (Kraus.blockPhysDim d p) : ℂ) =
       (Real.sqrt d : ℂ) ^ p := by
     rw [sqrt_blockPhysDim]
     exact Complex.ofReal_pow _ _

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -466,11 +466,11 @@ theorem IsMPUSimple.blockTensor {U : MPOTensor d D} (hU : IsMPUSimple U)
   refine ⟨a, b, ?_, ?_⟩
   · intro I J
     rw [doubleLayerTensor_blockTensor, blockTensor_apply]
-    simp only [MPSTensor.wordOfBlock]
-    rw [evalWord_ofFn]
+    simp only [Kraus.wordOfBlock]
+    rw [MPOTensor.evalWord_ofFn]
     let l := List.ofFn (fun k : Fin L ↦
-      doubleLayerTensor U (MPSTensor.decodeBlock d L I k)
-        (MPSTensor.decodeBlock d L J k))
+      doubleLayerTensor U (Kraus.decodeBlock d L I k)
+        (Kraus.decodeBlock d L J k))
     have hl : l ≠ [] := by simp [l, Nat.ne_of_gt hL]
     have hlP : ∀ A ∈ l, P A := by
       intro A hA
@@ -484,18 +484,18 @@ theorem IsMPUSimple.blockTensor {U : MPOTensor d D} (hU : IsMPUSimple U)
       simp
     · rw [ite_eq_right hIJ]
       have hpoint : ∃ k : Fin L,
-          MPSTensor.decodeBlock d L I k ≠ MPSTensor.decodeBlock d L J k := by
+          Kraus.decodeBlock d L I k ≠ Kraus.decodeBlock d L J k := by
         by_contra h
         apply hIJ
-        exact (MPSTensor.decodeBlockEquiv d L).injective
+        exact (Kraus.decodeBlockEquiv d L).injective
           (funext fun k ↦ not_ne_iff.mp (not_exists.mp h k))
       obtain ⟨k, hk⟩ := hpoint
       apply Finset.prod_eq_zero (Finset.mem_univ k)
       simp [hk]
   · intro I J K M
     rw [doubleLayerTensor_blockTensor, blockTensor_apply, blockTensor_apply]
-    simp only [MPSTensor.wordOfBlock]
-    rw [evalWord_ofFn, evalWord_ofFn]
+    simp only [Kraus.wordOfBlock]
+    rw [MPOTensor.evalWord_ofFn, MPOTensor.evalWord_ofFn]
     apply listProd_mul_eq_listProd_mul_rankOne_mul a b P hpair
     · simp [Nat.ne_of_gt hL]
     · simp [Nat.ne_of_gt hL]
@@ -528,61 +528,61 @@ theorem blockTensor_succ_simple2_of_supplied
           doubleLayerTensor (blockTensor U (k + 1)) K L := by
   classical
   let W := doubleLayerTensor U
-  let suffixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      Fin (MPSTensor.blockPhysDim d k) :=
-    (MPSTensor.decodeBlockEquiv d k).symm
-      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-  let prefixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      Fin (MPSTensor.blockPhysDim d k) :=
-    (MPSTensor.decodeBlockEquiv d k).symm
-      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
-  have hmiddle (I J K L : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+  let suffixIndex (I : Fin (Kraus.blockPhysDim d (k + 1))) :
+      Fin (Kraus.blockPhysDim d k) :=
+    (Kraus.decodeBlockEquiv d k).symm
+      (fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.succ)
+  let prefixIndex (I : Fin (Kraus.blockPhysDim d (k + 1))) :
+      Fin (Kraus.blockPhysDim d k) :=
+    (Kraus.decodeBlockEquiv d k).symm
+      (fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.castSucc)
+  have hmiddle (I J K L : Fin (Kraus.blockPhysDim d (k + 1))) :
       evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.succ)
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) J x.succ) *
         evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) =
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) K x.castSucc)
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) L x.castSucc) =
       evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.succ)
+          (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) J x.succ) *
         Matrix.vecMulVec b a *
           evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) := by
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) K x.castSucc)
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) L x.castSucc) := by
     have h := h₂ (suffixIndex I) (suffixIndex J) (prefixIndex K) (prefixIndex L)
     simpa only [doubleLayerTensor_blockTensor, blockTensor_apply,
-      MPSTensor.wordOfBlock, MPSTensor.decodeBlock_decodeBlockEquiv_symm,
+      Kraus.wordOfBlock, Kraus.decodeBlock_decodeBlockEquiv_symm,
       W, suffixIndex, prefixIndex] using h
-  have hfirst (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
-          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
-        W (MPSTensor.decodeBlock d (k + 1) I 0)
-            (MPSTensor.decodeBlock d (k + 1) J 0) *
+  have hfirst (I J : Fin (Kraus.blockPhysDim d (k + 1))) :
+      evalWord W (List.ofFn (Kraus.decodeBlock d (k + 1) I))
+          (List.ofFn (Kraus.decodeBlock d (k + 1) J)) =
+        W (Kraus.decodeBlock d (k + 1) I 0)
+            (Kraus.decodeBlock d (k + 1) J 0) *
           evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) := by
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.succ)
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) J x.succ) := by
     rw [List.ofFn_succ, List.ofFn_succ, evalWord_cons]
-  have hlast (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
-          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
+  have hlast (I J : Fin (Kraus.blockPhysDim d (k + 1))) :
+      evalWord W (List.ofFn (Kraus.decodeBlock d (k + 1) I))
+          (List.ofFn (Kraus.decodeBlock d (k + 1) J)) =
         evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.castSucc) *
-          W (MPSTensor.decodeBlock d (k + 1) I (Fin.last k))
-            (MPSTensor.decodeBlock d (k + 1) J (Fin.last k)) := by
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) I x.castSucc)
+            (List.ofFn fun x : Fin k ↦ Kraus.decodeBlock d (k + 1) J x.castSucc) *
+          W (Kraus.decodeBlock d (k + 1) I (Fin.last k))
+            (Kraus.decodeBlock d (k + 1) J (Fin.last k)) := by
     rw [List.ofFn_succ', List.ofFn_succ', List.concat_eq_append,
       List.concat_eq_append, evalWord_append W _ _ _ _ (by simp)]
     simp
   intro I J K L
   simp only [doubleLayerTensor_blockTensor, blockTensor_apply,
-    MPSTensor.wordOfBlock]
+    Kraus.wordOfBlock]
   rw [hfirst I J, hlast K L]
   have h := congrArg
-    (fun X ↦ W (MPSTensor.decodeBlock d (k + 1) I 0)
-        (MPSTensor.decodeBlock d (k + 1) J 0) * X *
-      W (MPSTensor.decodeBlock d (k + 1) K (Fin.last k))
-        (MPSTensor.decodeBlock d (k + 1) L (Fin.last k)))
+    (fun X ↦ W (Kraus.decodeBlock d (k + 1) I 0)
+        (Kraus.decodeBlock d (k + 1) J 0) * X *
+      W (Kraus.decodeBlock d (k + 1) K (Fin.last k))
+        (Kraus.decodeBlock d (k + 1) L (Fin.last k)))
     (hmiddle I J K L)
   simpa only [Matrix.mul_assoc] using h
 
@@ -773,15 +773,15 @@ theorem IsMPUSimple.reindexPhysical {d' : ℕ} {U : MPOTensor d D}
 
 private theorem evalWord_blockTensor_ofFn_local
     (U : MPOTensor d D) (L : ℕ) {N : ℕ}
-    (s t : Fin N → Fin (MPSTensor.blockPhysDim d L)) :
+    (s t : Fin N → Fin (Kraus.blockPhysDim d L)) :
     evalWord (MPOTensor.blockTensor U L) (List.ofFn s) (List.ofFn t) =
-      evalWord U (MPSTensor.flattenBlockedWord d L (List.ofFn s))
-        (MPSTensor.flattenBlockedWord d L (List.ofFn t)) := by
+      evalWord U (Kraus.flattenBlockedWord d L (List.ofFn s))
+        (Kraus.flattenBlockedWord d L (List.ofFn t)) := by
   induction N with
-  | zero => simp [MPSTensor.flattenBlockedWord]
+  | zero => simp [Kraus.flattenBlockedWord]
   | succ N ih =>
       simp only [List.ofFn_succ, evalWord_cons, blockTensor_apply,
-        MPSTensor.flattenBlockedWord_cons]
+        Kraus.flattenBlockedWord_cons]
       rw [ih]
       rw [evalWord_append U _ _ _ _ (by simp)]
 
@@ -795,19 +795,30 @@ theorem reindexPhysical_blockTensor_blockTensor
         (MPOTensor.blockTensor (MPOTensor.blockTensor U m) n) =
       MPOTensor.blockTensor U (m * n) := by
   funext i j
-  simp only [reindexPhysical, blockTensor_apply, MPSTensor.wordOfBlock]
+  simp only [reindexPhysical, blockTensor_apply, Kraus.wordOfBlock]
   rw [evalWord_blockTensor_ofFn_local]
   change evalWord U
-      (MPSTensor.flattenBlockedWord d m
-        (MPSTensor.wordOfBlock (MPSTensor.blockPhysDim d m) n
+      (Kraus.flattenBlockedWord d m
+        (Kraus.wordOfBlock (Kraus.blockPhysDim d m) n
           (MPSTensor.directToIteratedBlockIndex d m n i)))
-      (MPSTensor.flattenBlockedWord d m
-        (MPSTensor.wordOfBlock (MPSTensor.blockPhysDim d m) n
+      (Kraus.flattenBlockedWord d m
+        (Kraus.wordOfBlock (Kraus.blockPhysDim d m) n
           (MPSTensor.directToIteratedBlockIndex d m n j))) =
-    evalWord U (MPSTensor.wordOfBlock d (m * n) i)
-      (MPSTensor.wordOfBlock d (m * n) j)
-  rw [MPSTensor.flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex,
-    MPSTensor.flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex]
+    evalWord U (Kraus.wordOfBlock d (m * n) i)
+      (Kraus.wordOfBlock d (m * n) j)
+  have hi :=
+    MPSTensor.flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex d m n i
+  have hj :=
+    MPSTensor.flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex d m n j
+  change Kraus.flattenBlockedWord d m
+      (Kraus.wordOfBlock (Kraus.blockPhysDim d m) n
+        (MPSTensor.directToIteratedBlockIndex d m n i)) =
+    Kraus.wordOfBlock d (m * n) i at hi
+  change Kraus.flattenBlockedWord d m
+      (Kraus.wordOfBlock (Kraus.blockPhysDim d m) n
+        (MPSTensor.directToIteratedBlockIndex d m n j)) =
+    Kraus.wordOfBlock d (m * n) j at hj
+  rw [hi, hj]
 
 /-- For bond dimension greater than one, an MPU has a strictly less than \(D^4\)
 positive direct blocking that is MPU-simple.
@@ -842,8 +853,8 @@ theorem IsMPU.exists_blockTensor_isMPUSimple_of_one_lt
     change normalizedDiagonal (doubleLayerTensor (MPOTensor.blockTensor U J)) = _
     rw [hU.normalizedDiagonal_doubleLayerTensor_blockTensor_eq_vecMulVec hD]
     rfl
-  let : NeZero (MPSTensor.blockPhysDim d J) := ⟨by
-    rw [MPSTensor.blockPhysDim_eq_pow]
+  let : NeZero (Kraus.blockPhysDim d J) := ⟨by
+    rw [Kraus.blockPhysDim_eq_pow]
     exact pow_ne_zero J (NeZero.ne d)⟩
   have hsimpleIterated : IsMPUSimple (MPOTensor.blockTensor V (D * D)) :=
     hVmpu.blockTensor_sq_isMPUSimple_of_normalizedDiagonal_eq_vecMulVec ρ Φ hpair hVE

--- a/TNLean/MPS/MPU/SourceURangeTransport.lean
+++ b/TNLean/MPS/MPU/SourceURangeTransport.lean
@@ -80,15 +80,15 @@ theorem normalizedDiagonal_outputLayer_pow_apply [NeZero d]
   simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
     one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, ite_true,
     blockTensor_apply, Matrix.smul_apply, smul_eq_mul]
-  have hdim : (MPSTensor.blockPhysDim d K : ℂ)⁻¹ = ((d : ℂ)⁻¹) ^ K := by
-    rw [MPSTensor.blockPhysDim_eq_pow, Nat.cast_pow, inv_pow]
+  have hdim : (Kraus.blockPhysDim d K : ℂ)⁻¹ = ((d : ℂ)⁻¹) ^ K := by
+    rw [Kraus.blockPhysDim_eq_pow, Nat.cast_pow, inv_pow]
   rw [hdim]
   congr 1
-  have hsum := (MPSTensor.decodeBlockEquiv d K).sum_comp
+  have hsum := (Kraus.decodeBlockEquiv d K).sum_comp
     (fun τ ↦ evalWord (doubleLayerTensor (physicalAdjointTensor U))
       (List.ofFn τ) (List.ofFn τ))
-  simp only [MPSTensor.decodeBlockEquiv_apply] at hsum
-  simp only [MPSTensor.wordOfBlock]
+  simp only [Kraus.decodeBlockEquiv_apply] at hsum
+  simp only [Kraus.wordOfBlock]
   rw [hsum]
   simp only [Matrix.sum_apply]
   apply Finset.sum_congr rfl

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -37,34 +37,34 @@ It is distinct from the reversal of two blocked letters caused by conjugate
 transposition in the supplied-contraction transport below. -/
 noncomputable def blockWordReverseEquiv (d K : ℕ) :
     Fin (MPSTensor.blockPhysDim d K) ≃ Fin (MPSTensor.blockPhysDim d K) :=
-  (MPSTensor.decodeBlockEquiv d K).trans
+  (Kraus.decodeBlockEquiv d K).trans
     ((Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))).trans
-      (MPSTensor.decodeBlockEquiv d K).symm)
+      (Kraus.decodeBlockEquiv d K).symm)
 
 @[simp] theorem decodeBlock_blockWordReverseEquiv
     (i : Fin (MPSTensor.blockPhysDim d K)) (k : Fin K) :
     MPSTensor.decodeBlock d K (blockWordReverseEquiv d K i) k =
       MPSTensor.decodeBlock d K i (Fin.rev k) := by
-  simp [blockWordReverseEquiv, MPSTensor.decodeBlockEquiv_apply]
+  simp [blockWordReverseEquiv]
 
 @[simp] theorem wordOfBlock_blockWordReverseEquiv
     (i : Fin (MPSTensor.blockPhysDim d K)) :
     MPSTensor.wordOfBlock d K (blockWordReverseEquiv d K i) =
       (MPSTensor.wordOfBlock d K i).reverse := by
-  simp only [MPSTensor.wordOfBlock]
+  simp only [Kraus.wordOfBlock]
   calc
-    List.ofFn (MPSTensor.decodeBlock d K (blockWordReverseEquiv d K i)) =
-        List.ofFn (MPSTensor.decodeBlock d K i ∘ Fin.rev) := by
+    List.ofFn (Kraus.decodeBlock d K (blockWordReverseEquiv d K i)) =
+        List.ofFn (Kraus.decodeBlock d K i ∘ Fin.rev) := by
       congr 1
       funext k
       simp
-    _ = (List.ofFn (MPSTensor.decodeBlock d K i)).reverse :=
-      (List.ofFn_reverse (MPSTensor.decodeBlock d K i)).symm
+    _ = (List.ofFn (Kraus.decodeBlock d K i)).reverse :=
+      (List.ofFn_reverse (Kraus.decodeBlock d K i)).symm
 
 @[simp] theorem blockWordReverseEquiv_involutive
     (i : Fin (MPSTensor.blockPhysDim d K)) :
     blockWordReverseEquiv d K (blockWordReverseEquiv d K i) = i := by
-  apply (MPSTensor.decodeBlockEquiv d K).injective
+  apply (Kraus.decodeBlockEquiv d K).injective
   funext k
   simp
 
@@ -143,8 +143,8 @@ theorem conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec
         (fun x : Fin (D * D) ↦
           (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))
         (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x)) := by
-  let : NeZero (MPSTensor.blockPhysDim d K) := ⟨by
-    rw [MPSTensor.blockPhysDim_eq_pow]
+  let : NeZero (Kraus.blockPhysDim d K) := ⟨by
+    rw [Kraus.blockPhysDim_eq_pow]
     exact pow_ne_zero K (NeZero.ne d)⟩
   rw [← physicalAdjointTensor_blockTensor]
   rw [normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor, hE]
@@ -168,8 +168,8 @@ theorem reflected_transfer_power_eq_vecMulVec_transpose [NeZero d]
         (Kraus.transferMap (physicalAdjointTensor U).normalizedFlattening) ^ J =
       Matrix.vecMulVec ρ.transpose.vec
         (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
-  let : NeZero (MPSTensor.blockPhysDim d J) := ⟨by
-    simpa only [MPSTensor.blockPhysDim_eq_pow] using
+  let : NeZero (Kraus.blockPhysDim d J) := ⟨by
+    simpa only [Kraus.blockPhysDim_eq_pow] using
       pow_ne_zero J (NeZero.ne d)⟩
   rw [← Equiv.apply_eq_iff_eq
     (Matrix.reindex finProdFinEquiv finProdFinEquiv)]

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -78,10 +78,10 @@ Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
 noncomputable def tensorProductBlockEquiv (d e L : ℕ) :
     Fin (MPSTensor.blockPhysDim (d * e) L) ≃
       Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim e L) :=
-  (MPSTensor.decodeBlockEquiv (d * e) L).trans
+  (Kraus.decodeBlockEquiv (d * e) L).trans
     (finTupleProdEquiv L d e) |>.trans
-    (Equiv.prodCongr (MPSTensor.decodeBlockEquiv d L).symm
-      (MPSTensor.decodeBlockEquiv e L).symm) |>.trans
+    (Equiv.prodCongr (Kraus.decodeBlockEquiv d L).symm
+      (Kraus.decodeBlockEquiv e L).symm) |>.trans
     finProdFinEquiv
 
 /-- Decoding the first blocked component gives the pointwise quotient of the
@@ -90,7 +90,7 @@ blocked product letters. -/
     (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
     MPSTensor.decodeBlock d L ((tensorProductBlockEquiv d e L I).divNat) k =
       (MPSTensor.decodeBlock (d * e) L I k).divNat := by
-  simp [tensorProductBlockEquiv, MPSTensor.decodeBlockEquiv_apply]
+  simp [tensorProductBlockEquiv]
 
 /-- Decoding the second blocked component gives the pointwise remainder of the
 blocked product letters. -/
@@ -98,7 +98,7 @@ blocked product letters. -/
     (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
     MPSTensor.decodeBlock e L ((tensorProductBlockEquiv d e L I).modNat) k =
       (MPSTensor.decodeBlock (d * e) L I k).modNat := by
-  simp [tensorProductBlockEquiv, MPSTensor.decodeBlockEquiv_apply]
+  simp [tensorProductBlockEquiv]
 
 private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
     (is js : List (Fin (d * e))) :
@@ -129,7 +129,7 @@ theorem blockTensor_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) (L : �
   funext I J
   simp only [blockTensor_apply, reindexPhysical, tensorProduct]
   rw [evalWord_tensorProduct]
-  simp only [MPSTensor.wordOfBlock, List.map_ofFn]
+  simp only [Kraus.wordOfBlock, List.map_ofFn]
   congr 2
   · apply congrArg₂ (evalWord U)
     · apply congrArg List.ofFn

--- a/TNLean/MPS/MPU/ThreeFormSpan.lean
+++ b/TNLean/MPS/MPU/ThreeFormSpan.lean
@@ -341,8 +341,8 @@ private theorem doubleLayer_entry_eq_diagonal_add_residual
     simp
 
 private theorem diagonal_coeff_prod_eq
-    {N d : ℕ} (I J : Fin (MPSTensor.blockPhysDim d N)) :
-    (∏ k : Fin N, if MPSTensor.decodeBlock d N I k = MPSTensor.decodeBlock d N J k
+    {N d : ℕ} (I J : Fin (Kraus.blockPhysDim d N)) :
+    (∏ k : Fin N, if Kraus.decodeBlock d N I k = Kraus.decodeBlock d N J k
       then (1 : ℂ) else 0) = if I = J then 1 else 0 := by
   classical
   by_cases hIJ : I = J
@@ -350,11 +350,11 @@ private theorem diagonal_coeff_prod_eq
     simp
   · rw [ite_eq_right hIJ]
     have hdiff : ∃ k : Fin N,
-        MPSTensor.decodeBlock d N I k ≠ MPSTensor.decodeBlock d N J k := by
+        Kraus.decodeBlock d N I k ≠ Kraus.decodeBlock d N J k := by
       by_contra h
       push Not at h
       apply hIJ
-      exact (MPSTensor.decodeBlockEquiv d N).injective (funext h)
+      exact (Kraus.decodeBlockEquiv d N).injective (funext h)
     obtain ⟨k, hk⟩ := hdiff
     exact Finset.prod_eq_zero (Finset.mem_univ k) (ite_eq_right hk)
 
@@ -375,8 +375,8 @@ theorem IsMPU.residualSlice_doubleLayerTensor_blockTensor_single_mem_threeFormSu
       threeFormSubmodule (normalizedDiagonal (doubleLayerTensor U)) (residualAlgebra U) := by
   classical
   let E := normalizedDiagonal (doubleLayerTensor U)
-  let σ := MPSTensor.decodeBlock d (D * D) I
-  let τ := MPSTensor.decodeBlock d (D * D) J
+  let σ := Kraus.decodeBlock d (D * D) I
+  let τ := Kraus.decodeBlock d (D * D) J
   let c : Fin (D * D) → ℂ := fun k ↦ if σ k = τ k then 1 else 0
   let S : Fin (D * D) → residualAlgebra U := fun k ↦
     ⟨residualSlice (doubleLayerTensor U) (Matrix.single (τ k) (σ k) 1),
@@ -388,7 +388,7 @@ theorem IsMPU.residualSlice_doubleLayerTensor_blockTensor_single_mem_threeFormSu
     hN (fun l hl hlen ↦ hU.residualAlgebra_list_prod_eq_zero l hl hlen) c S
   have hentry : MPOTensor.blockTensor (doubleLayerTensor U) (D * D) I J =
       (List.ofFn (fun k ↦ c k • E + (S k : Matrix (Fin (D * D)) (Fin (D * D)) ℂ))).prod := by
-    simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+    simp only [blockTensor_apply, Kraus.wordOfBlock, MPOTensor.evalWord_ofFn]
     apply congrArg List.prod
     apply congrArg List.ofFn
     funext k

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -62,7 +62,7 @@ private theorem exists_right_factor_of_letter_compatibility [NeZero D]
       exists_evalWord_factor_of_letter_compatibility (A := A) hCompat (wordOfBlock d L₀ i) hword
     refine ⟨Y, ?_⟩
     intro j
-    simpa [blockTensor] using hY j
+    simpa [Kraus.blockTensor] using hY j
   choose Y hY using hBlockCompat
   let X : Matrix (Fin D) (Fin D) ℂ := ∑ i, c i • Y i
   refine ⟨X, ?_⟩

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -369,7 +369,7 @@ theorem ZGaugeEquiv.blockTensor_gaugeEquiv {m : ℕ} {A B : MPSTensor d D}
     calc
       Kraus.evalWord A (wordOfBlock d m i)
           = Z ^ (wordOfBlock d m i).length * Kraus.evalWord A (wordOfBlock d m i) := by
-              simp [length_wordOfBlock, hpow]
+              simp [hpow]
       _ = Kraus.evalWord (fun j => Z * A j) (wordOfBlock d m i) :=
             (evalWord_leftMul_of_commute hcomm (wordOfBlock d m i)).symm
       _ = (Y : Matrix (Fin D) (Fin D) ℂ) * Kraus.evalWord B (wordOfBlock d m i) *
@@ -380,7 +380,7 @@ theorem ZGaugeEquiv.blockTensor_gaugeEquiv {m : ℕ} {A B : MPSTensor d D}
   have := congrArg (fun M =>
     (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
       (Y : Matrix (Fin D) (Fin D) ℂ))) hWord
-  simpa [blockTensor, Matrix.mul_assoc] using this.symm
+  simpa [Kraus.blockTensor, Matrix.mul_assoc] using this.symm
 
 /-- Full-period blocking turns a `ℤ_m`-gauge equivalence into MPV equality. -/
 theorem ZGaugeEquiv.blockTensor_sameMPV {m : ℕ} {A B : MPSTensor d D}

--- a/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
+++ b/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
@@ -115,7 +115,7 @@ private theorem gaugePhaseEquiv_blockTensor
           ((X : Matrix (Fin D) (Fin D) ℂ) *
             blockTensor (d := d) (D := D) A L i *
             ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
-          simp [hGauge, blockTensor]
+          simp [hGauge, Kraus.blockTensor]
 
 /-- A periodic tensor has nonzero blocked self-overlap limit after blocking by
 its period; the limit is the period itself. This restates

--- a/TNLean/MPS/Periodic/Overlap/SectorMatch/Contraction.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorMatch/Contraction.lean
@@ -228,7 +228,9 @@ lemma sectorTensor_proportional_of_blockedMatch
         subst n
         let i : Fin (blockPhysDim d m) := (decodeBlockEquiv d m).symm σ
         have hword : wordOfBlock d m i = List.ofFn σ := by
-          simp [wordOfBlock, i]
+          change List.ofFn
+              (Kraus.decodeBlock d m ((Kraus.decodeBlockEquiv d m).symm σ)) = List.ofFn σ
+          rw [Kraus.decodeBlock_decodeBlockEquiv_symm]
         rw [← hword,
           cornerProd_eq_blockDiagCorner P A hP_proj hP_shift,
           cornerProd_eq_blockDiagCorner Q B hQ_proj hQ_shift]

--- a/TNLean/MPS/Periodic/Overlap/SectorOverlapTransport.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorOverlapTransport.lean
@@ -127,11 +127,6 @@ private lemma sectorOverlap_eq_physical_sum {m : ℕ} [NeZero D] [NeZero m]
         star ((PB v * Kraus.evalWord B (List.ofFn τ)).trace))]
   refine Finset.sum_congr rfl fun σ _ => ?_
   rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedConfigEquiv]
-  change
-    (PA u * Kraus.evalWord (blockTensor A m) (List.ofFn σ)).trace *
-        star ((PB v * Kraus.evalWord (blockTensor B m) (List.ofFn σ)).trace) =
-      (PA u * Kraus.evalWord A (flattenBlockedWord d m (List.ofFn σ))).trace *
-        star ((PB v * Kraus.evalWord B (flattenBlockedWord d m (List.ofFn σ))).trace)
   rw [← evalWord_blockTensor, ← evalWord_blockTensor]
 
 /-- **One-step transport of the cross sector overlap** (positive lengths,

--- a/TNLean/MPS/Periodic/SectorContraction.lean
+++ b/TNLean/MPS/Periodic/SectorContraction.lean
@@ -84,12 +84,15 @@ theorem ofFn_blockFlattenEquiv (d m L : ℕ) (σ : Fin L → Fin (blockPhysDim d
   have hword :
       wordOfBlock (blockPhysDim d m) L
           ((decodeBlockEquiv (blockPhysDim d m) L).symm σ) = List.ofFn σ := by
-    rw [wordOfBlock, decodeBlock_decodeBlockEquiv_symm]
+    change List.ofFn
+        (Kraus.decodeBlock (Kraus.blockPhysDim d m) L
+          ((Kraus.decodeBlockEquiv (Kraus.blockPhysDim d m) L).symm σ)) = List.ofFn σ
+    rw [Kraus.decodeBlock_decodeBlockEquiv_symm]
   calc List.ofFn (blockFlattenEquiv d m L σ)
       = wordOfBlock d (m * L)
           (iteratedBlockIndex d m L ((decodeBlockEquiv (blockPhysDim d m) L).symm σ)) := by
         simp only [blockFlattenEquiv, Equiv.trans_apply, decodeBlockEquiv_apply,
-          directIteratedBlockEquiv_symm_apply, wordOfBlock]
+          directIteratedBlockEquiv_symm_apply, Kraus.wordOfBlock]
     _ = flattenBlockedWord d m
           (wordOfBlock (blockPhysDim d m) L ((decodeBlockEquiv (blockPhysDim d m) L).symm σ)) :=
         wordOfBlock_iteratedBlockIndex d m L _

--- a/TNLean/MPS/Symmetry/Defs.lean
+++ b/TNLean/MPS/Symmetry/Defs.lean
@@ -151,7 +151,8 @@ lemma twistedTensor_blockTensor_comm
   classical
   funext I
   rw [twistedTensor]
-  simp only [blockKronAction_apply, blockKron, blockTensor, wordOfBlock]
+  simp only [blockKronAction_apply, blockKron, Kraus.blockTensor,
+    Kraus.wordOfBlock]
   have hEval :
       Kraus.evalWord (twistedTensor A U g) (List.ofFn (decodeBlock d L I)) =
         ∑ v : Fin L → Fin d,
@@ -162,7 +163,7 @@ lemma twistedTensor_blockTensor_comm
   -- Reindex the sum over words by the blocked index.
   rw [← (decodeBlockEquiv d L).sum_comp]
   refine Finset.sum_congr rfl (fun J _ => ?_)
-  simp [decodeBlockEquiv_apply]
+  simp [Kraus.decodeBlockEquiv_apply]
 
 /-- On-site symmetry transfers to the blocked tensor under the Kronecker-power
 action: if `A` is on-site symmetric under `U`, then `blockTensor A L` is on-site

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -115,7 +115,8 @@ theorem wordSpan_le_wordSpan_blockTensor (A : MPSTensor d D) (L n : ℕ) :
     set B := blockTensor (d := d) (D := D) A L
     set σ₀_enc := Fin.cast (blockPhysDim_eq_pow d L).symm (finFunctionFinEquiv σ₀)
     have hfirst_eq : Kraus.evalWord A (List.ofFn σ₀) = B σ₀_enc := by
-      simp [B, blockTensor, wordOfBlock, decodeBlock, σ₀_enc, Fin.cast_cast]
+      simp [B, Kraus.blockTensor, Kraus.wordOfBlock, Kraus.decodeBlock,
+        σ₀_enc, Fin.cast_cast]
     have hfirst : Kraus.evalWord A (List.ofFn σ₀) ∈ Kraus.wordSpan B 1 := by
       rw [hfirst_eq]
       apply Submodule.subset_span
@@ -164,7 +165,8 @@ theorem blockTensor_apply_encodeBlock (A : MPSTensor d D) (L : ℕ)
     (blockTensor (d := d) (D := D) A L) (encodeBlock d L σ₀) =
       Kraus.evalWord A (List.ofFn σ₀) := by
   classical
-  simp [blockTensor, wordOfBlock, decodeBlock, encodeBlock, Fin.cast_cast]
+  simp [Kraus.blockTensor, Kraus.wordOfBlock, Kraus.decodeBlock, encodeBlock,
+    Fin.cast_cast]
 
 /-- **Word eigenvector → single-index eigenvector of the blocked tensor.** -/
 theorem blockTensor_single_eigenvector (A : MPSTensor d D)

--- a/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
+++ b/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
@@ -1,0 +1,69 @@
+# Issue #6855: core compatibility thinning audit
+
+This note records a TNLean-local reduction of the duplicate
+`Kraus`/`MPSTensor` and bond-cast interfaces from the August 2026 structural
+debt review.
+
+## Blocking definitions
+
+The following public `MPSTensor` names remain available, but their copied
+definition bodies are replaced by abbreviations of the canonical QICLean
+finite-family definitions:
+
+| TNLean name | Canonical body |
+|---|---|
+| `MPSTensor.blockPhysDim` | `Kraus.blockPhysDim` |
+| `MPSTensor.singleBlockEquiv` | `Kraus.singleBlockEquiv` |
+| `MPSTensor.decodeBlock` | `Kraus.decodeBlock` |
+| `MPSTensor.wordOfBlock` | `Kraus.wordOfBlock` |
+| `MPSTensor.decodeBlockEquiv` | `Kraus.decodeBlockEquiv` |
+| `MPSTensor.blockTensor` | `Kraus.blockTensor` |
+| `MPSTensor.flattenBlockedWord` | `Kraus.flattenBlockedWord` |
+
+The forwarding lemmas retain their TNLean names for compatibility, while only
+the canonical `Kraus` copies carry the simplification attributes. The three
+injectivity-predicate copies named by issue #6855 no longer occur on current
+main: the QICLean extraction removed their former TNLean module and migrated
+live consumers directly to the canonical predicates.
+
+Replacing an opaque wrapper by an abbreviation changes which constant an
+explicit unfolding or restricted simplification step must name. The necessary
+proof repairs therefore name the canonical definitions directly. They are
+confined to the blocking calculations in `Core/Blocking.lean`,
+`Core/BlockingInfrastructure.lean`, and `Core/BlockingTransfer.lean`; the
+canonical-form and example calculations in `CPSVBlocking.lean`, `Conjugation.lean`,
+`CommonBlockedCyclicSectorFamily.lean`,
+`FundamentalTheorem/SectorBNT/Blocking.lean`, `AKLTStringOrder.lean`, and
+`Cluster.lean`; the MPDO and boundary calculations in
+`BlockedBNTFusionIsometries.lean`, `FirstSiteBlocking.lean`,
+`PhysicalBlocking.lean`, and `ExtendRight.lean`; the MPU calculations in
+`BlockingRanks.lean`, `CanonicalForm.lean`, `SimpleBlocking.lean`,
+`SourceURangeTransport.lean`, `SourceUReflectedKernel.lean`,
+`TensorProduct.lean`, and `ThreeFormSpan.lean`; the periodic and symmetry
+calculations in
+`Periodic/Defs.lean`,
+`Periodic/Overlap/NoSectorMatch.lean`,
+`Periodic/Overlap/SectorMatch/Contraction.lean`,
+`Periodic/Overlap/SectorOverlapTransport.lean`,
+`Periodic/SectorContraction.lean`, and `Symmetry/Defs.lean`; and the encoded
+word calculation in `Wielandt/RectangularSpan/Basic.lean`. No mathematical
+statement changes in these consumers.
+
+## Bond reindexing
+
+`MPSTensor.reindex` is now the canonical equivalence for transport along an
+equality of bond dimensions. The module also records its application,
+word-evaluation, MPV, and gauge properties. The cast-to-reindex and application
+lemmas replace four private cast calculations:
+
+| Removed private declaration | Replacement |
+|---|---|
+| `MPSTensor.CPSVCanonicalFormData.mpsTensor_cast_apply` in `CanonicalFormEqualAmbient.lean` | `MPSTensor.cast_eq_reindex` and `MPSTensor.reindex_apply_eq_cast` |
+| `MPSTensor.mpsTensor_cast_apply` in `FundamentalCoord.lean` | `MPSTensor.cast_eq_reindex` and `MPSTensor.reindex_apply_apply` |
+| `MPSTensor.mpsTensor_cast_apply_matrix` in `PreparedReconstruction.lean` | `MPSTensor.cast_eq_reindex` and `MPSTensor.reindex_apply_eq_cast` |
+| `MPOTensor.RetainedProductSpectralFamily.castTensor_apply` in `VerticalProductCornerComparison.lean` | `MPSTensor.cast_eq_reindex` and `MPSTensor.reindex_apply_eq_cast` |
+
+The remaining differently named cast helpers in
+`NormalizedGroupedSectorMaps.lean` and
+`BNTAlgebraTensorClauseDirectSumUnitary.lean` have different dependent
+contexts and are not claimed by this migration.

--- a/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
+++ b/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
@@ -20,6 +20,14 @@ finite-family definitions:
 | `MPSTensor.blockTensor` | `Kraus.blockTensor` |
 | `MPSTensor.flattenBlockedWord` | `Kraus.flattenBlockedWord` |
 
+The public instance `MPSTensor.instNeZeroBlockPhysDim` was also an exact
+duplicate of `Kraus.instNeZeroBlockPhysDim` and has been removed. Since
+`MPSTensor.blockPhysDim` is now an abbreviation of `Kraus.blockPhysDim`, the
+canonical QICLean instance directly supplies every former
+`NeZero (MPSTensor.blockPhysDim d L)` goal.  Thus
+`Kraus.instNeZeroBlockPhysDim` is the named replacement; no second transition
+instance is required.
+
 The forwarding lemmas retain their TNLean names for compatibility, while only
 the canonical `Kraus` copies carry the simplification attributes. The three
 injectivity-predicate copies named by issue #6855 no longer occur on current

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1110,9 +1110,11 @@ abstracted — record why, so it is not re-proposed).
 - **Pattern:** four local calculations in `Martingale/BlockedGap.lean` repeated the same
   three-line construction of `NeZero (blockPhysDim d p)`, and the qualitative blocked-gap
   theorem repeated the anticommutator route already used by the preceding explicit-gap theorem.
-- **Reuse:** `TNLean/MPS/Core/Blocking.lean` now provides the instance
-  `MPSTensor.instNeZeroBlockPhysDim`, replacing exactly those four local calculations in
-  `Martingale/BlockedGap.lean`.
+- **Reuse:** QICLean's `Kraus.instNeZeroBlockPhysDim` provides the instance,
+  replacing exactly those four local calculations in `Martingale/BlockedGap.lean`.
+  The former TNLean instance `MPSTensor.instNeZeroBlockPhysDim` was an exact
+  duplicate and has been retired; `MPSTensor.blockPhysDim` is an abbreviation
+  of `Kraus.blockPhysDim`, so the canonical instance applies directly.
   `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` is now a thin
   corollary of `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth`,
   using `1 / 8` as the positive gap witness.


### PR DESCRIPTION
## Summary

- Makes the seven TNLean blocking definitions transparent abbreviations of the canonical `Kraus` definitions in QICLean.
- Retains the TNLean forwarding names while leaving simplification attributes on the canonical declarations only.
- Retires the exact duplicate public instance `MPSTensor.instNeZeroBlockPhysDim`; `Kraus.instNeZeroBlockPhysDim` is its named canonical replacement and applies directly because `MPSTensor.blockPhysDim` is now an abbreviation.
- Introduces `MPSTensor.reindex` and its coordinate, word-evaluation, matrix-product-vector, and gauge invariance API.
- Replaces four duplicated private bond-cast calculations with the shared reindexing lemmas.
- Records the exact compatibility reduction, the public-instance migration, and the intentionally deferred cast contexts in a focused audit note.

## Scope

This is focused progress on #6855, extracted from preserved integration commit `69e44860603be67aeac5eab8310fad904015324f` and rebased onto current `main`. The additional consumer edits are only the proof-normalization repairs required when the former opaque blocking wrappers become abbreviations. No mathematical statement changes.

This pull request does not include grouped normalization, the separate `SameMPV`/mixed-transfer consolidation, trace-preserving or unital predicates, tactics, CI policy, Archive changes, or unrelated proof rewrites.

## Validation

- linter-bearing `lake build` with every changed Lean module as an explicit target
- `lake build TNLean.MPS.Core.BondReindex` after the final documentation review
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/test_generate_import_aggregators.py` (14 tests)
- `python3 scripts/test_lean_file_policies.py` (16 tests)
- `python3 scripts/check_oversized_lean_files.py`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --ci`
- reverse Blueprint coverage for every changed Lean declaration
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`

The full root-object declaration check is left to CI; the scoped worktree intentionally reuses the shared dependency cache and does not build the umbrella `TNLean.olean`.

Addresses #6855
