### PR TITLE
feat(MPS/MPDO): transport neighboring trace presentations

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -272,6 +272,7 @@ import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 import TNLean.MPS.MPDO.PhysicalSupportProductTransport
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
+import TNLean.MPS.MPDO.PhysicalSupportRestrictionComparison
 import TNLean.MPS.MPDO.PhysicalSupportSALTransport
 import TNLean.MPS.MPDO.PositiveLinearExtensionCounterexample
 import TNLean.MPS.MPDO.PositiveMinimalRealizationCounterexample

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Algebra.FinSum
+import QICLean.Algebra.MatrixUnitaryBetween
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 
 /-!
@@ -306,6 +307,28 @@ theorem exists_neighboringTraceFactorization_changePhysicalBasis_iff
   · rintro ⟨F, ⟨H⟩⟩
     exact ⟨F.ofChangePhysicalBasis V hV,
       ⟨H.ofChangePhysicalBasis V hV⟩⟩
+
+/-- Existence of neighboring trace data is invariant under a rectangular
+matrix that is unitary between its finite physical coordinate spaces.
+
+Finite-dimensional unitarity forces the two coordinate dimensions to agree,
+so this proposition reduces to the square coordinate transport above.  It
+retains the $\eta_{k,h}$, $a_k$, and $b_h$ data from arXiv:1606.00608,
+Theorem 4.9(iv) and Appendix C.2, lines 1381--1450, literally.  The rectangular
+equivalence is project-derived and is not stated in that source. -/
+theorem exists_neighboringTraceFactorization_changePhysicalBasis_iff_of_isUnitaryBetween
+    {e : ℕ} (V : Matrix (Fin e) (Fin d) ℂ)
+    (hV : V.IsUnitaryBetween) :
+    (∃ F : PhysicalSectorFactorization K,
+        Nonempty F.NeighboringTraceFactorization) ↔
+      ∃ F : PhysicalSectorFactorization (changePhysicalBasis V K),
+        Nonempty F.NeighboringTraceFactorization := by
+  have hed : e = d := by
+    apply le_antisymm
+    · simpa using Matrix.IsCoisometry.card_le V hV.2
+    · simpa using Matrix.IsIsometry.card_le V hV.1
+  subst e
+  exact exists_neighboringTraceFactorization_changePhysicalBasis_iff V hV.1
 
 theorem sectorCoordinateTensor_eq_changePhysicalBasis
     (F : PhysicalSectorFactorization K) :

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -117,10 +117,8 @@ noncomputable def NeighboringTraceFactorization.ofGaugeEquiv
     (H : NeighboringTraceFactorization F)
     (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
     NeighboringTraceFactorization (F.ofGaugeEquiv hGauge) where
-  neighboringOperator_pos := by
-    intro k h
-    rw [F.ofGaugeEquiv_neighboringOperator hGauge k h]
-    exact H.neighboringOperator_pos k h
+  neighboringOperator_pos :=
+    F.ofGaugeEquiv_neighboringOperator_posSemidef hGauge H.neighboringOperator_pos
   a := H.a
   b := H.b
   trace_neighboringOperator := by

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorVirtualTransport
 
 /-!
@@ -102,5 +103,50 @@ theorem ofGaugeEquiv_neighboringOperator_posSemidef
   intro k h
   rw [F.ofGaugeEquiv_neighboringOperator hGauge k h]
   exact hpos k h
+
+/-- Transport neighboring trace data through an invertible virtual gauge.
+
+The neighboring operators $\eta_{k,h}$ and the real coefficient families
+$a_k,b_h$ are retained literally, so their positivity, trace factorization,
+and normalization clauses are the supplied clauses themselves.  The data are
+those of arXiv:1606.00608, Theorem 4.9(iv) and Appendix C.2, lines 864--889 and
+1381--1450.  Their virtual-gauge transport is project-derived and is not
+stated in that source. -/
+noncomputable def NeighboringTraceFactorization.ofGaugeEquiv
+    {F : PhysicalSectorFactorization K}
+    (H : NeighboringTraceFactorization F)
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
+    NeighboringTraceFactorization (F.ofGaugeEquiv hGauge) where
+  neighboringOperator_pos := by
+    intro k h
+    rw [F.ofGaugeEquiv_neighboringOperator hGauge k h]
+    exact H.neighboringOperator_pos k h
+  a := H.a
+  b := H.b
+  trace_neighboringOperator := by
+    intro k h
+    rw [F.ofGaugeEquiv_neighboringOperator hGauge k h]
+    exact H.trace_neighboringOperator k h
+  sum_mul := H.sum_mul
+
+/-- Existence of neighboring trace data is invariant under an invertible
+virtual gauge.
+
+This equivalence retains $\eta_{k,h}$, $a_k$, and $b_h$ literally.  It is a
+project-derived consequence of the gauge similarity in arXiv:1606.00608,
+Section 2.3, lines 187--195, applied to the data of Theorem 4.9(iv) and
+Appendix C.2, lines 864--889 and 1381--1450; the source does not state this
+equivalence. -/
+theorem exists_neighboringTraceFactorization_iff_of_gaugeEquiv
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
+    (∃ F : PhysicalSectorFactorization K,
+        Nonempty F.NeighboringTraceFactorization) ↔
+      ∃ F : PhysicalSectorFactorization L,
+        Nonempty F.NeighboringTraceFactorization := by
+  constructor
+  · rintro ⟨F, ⟨H⟩⟩
+    exact ⟨F.ofGaugeEquiv hGauge, ⟨H.ofGaugeEquiv hGauge⟩⟩
+  · rintro ⟨F, ⟨H⟩⟩
+    exact ⟨F.ofGaugeEquiv hGauge.symm, ⟨H.ofGaugeEquiv hGauge.symm⟩⟩
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSupportRestrictionComparison.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportRestrictionComparison.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.PhysicalSupportRestriction
+
+/-!
+# Comparison of physical-support restriction coordinates
+
+Two isometric coordinate realizations of the range of the same physical
+projection differ by a matrix that is unitary between their finite coordinate
+spaces.  This module records the resulting exact comparison of the restricted
+MPO tensors and of neighboring trace factorizations.
+
+These statements are project-derived coordinate facts, not results stated in
+arXiv:1606.00608.  Their source context is the range restriction surrounding
+equations `PjKiPj` and `generateMPDO` in Appendix C.2, lines 1680--1691 and
+1733--1770.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace MPOTensor.PhysicalSupportRestrictionData
+
+variable {d D : ℕ} {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+
+open PhysicalSectorFactorization
+
+/-- The coordinate matrix from the support coordinates selected by `G` to
+those selected by `F`.
+
+This is a project-derived comparison of two range restrictions in the setting
+of arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines
+1680--1691 and 1733--1770; the paper does not define this matrix. -/
+noncomputable def supportCoordinateChange
+    (F G : PhysicalSupportRestrictionData P K) :
+    Matrix (Fin F.supportDim) (Fin G.supportDim) ℂ :=
+  F.inclusionᴴ * G.inclusion
+
+/-- The coordinate change between two isometric realizations of the same
+physical support is unitary between their coordinate spaces.
+
+This is project-derived finite-dimensional coordinate algebra in the setting
+of arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines
+1680--1691 and 1733--1770; it is not a theorem stated in the paper. -/
+theorem supportCoordinateChange_isUnitaryBetween
+    (F G : PhysicalSupportRestrictionData P K) :
+    (F.supportCoordinateChange G).IsUnitaryBetween := by
+  constructor
+  · change
+      (F.inclusionᴴ * G.inclusion)ᴴ *
+          (F.inclusionᴴ * G.inclusion) = 1
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    calc
+      (G.inclusionᴴ * F.inclusion) *
+            (F.inclusionᴴ * G.inclusion) =
+          G.inclusionᴴ * (F.inclusion * F.inclusionᴴ) * G.inclusion := by
+            simp only [Matrix.mul_assoc]
+      _ = G.inclusionᴴ * P * G.inclusion := by rw [F.inclusion_range]
+      _ = G.inclusionᴴ * (G.inclusion * G.inclusionᴴ) * G.inclusion := by
+        rw [G.inclusion_range]
+      _ = (G.inclusionᴴ * G.inclusion) *
+          (G.inclusionᴴ * G.inclusion) := by
+            simp only [Matrix.mul_assoc]
+      _ = 1 := by simp only [G.inclusion_isometry, Matrix.one_mul]
+  · change
+      (F.inclusionᴴ * G.inclusion) *
+          (F.inclusionᴴ * G.inclusion)ᴴ = 1
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    calc
+      (F.inclusionᴴ * G.inclusion) *
+            (G.inclusionᴴ * F.inclusion) =
+          F.inclusionᴴ * (G.inclusion * G.inclusionᴴ) * F.inclusion := by
+            simp only [Matrix.mul_assoc]
+      _ = F.inclusionᴴ * P * F.inclusion := by rw [G.inclusion_range]
+      _ = F.inclusionᴴ * (F.inclusion * F.inclusionᴴ) * F.inclusion := by
+        rw [F.inclusion_range]
+      _ = (F.inclusionᴴ * F.inclusion) *
+          (F.inclusionᴴ * F.inclusion) := by
+            simp only [Matrix.mul_assoc]
+      _ = 1 := by simp only [F.inclusion_isometry, Matrix.one_mul]
+
+/-- Changing from one set of support coordinates to another gives exactly the
+restriction defined by the target coordinates.
+
+This is a project-derived coordinate identity used with the support
+restriction in arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1680--1691 and 1733--1770; the source does not state it. -/
+theorem changePhysicalBasis_supportCoordinateChange
+    (F G : PhysicalSupportRestrictionData P K) :
+    changePhysicalBasis (F.supportCoordinateChange G)
+        (changePhysicalBasis G.inclusionᴴ K) =
+      changePhysicalBasis F.inclusionᴴ K := by
+  rw [changePhysicalBasis_changePhysicalBasis]
+  congr 1
+  calc
+    (F.inclusionᴴ * G.inclusion) * G.inclusionᴴ =
+        F.inclusionᴴ * (G.inclusion * G.inclusionᴴ) := by
+          rw [Matrix.mul_assoc]
+    _ = F.inclusionᴴ * P := by rw [G.inclusion_range]
+    _ = F.inclusionᴴ * (F.inclusion * F.inclusionᴴ) := by
+      rw [F.inclusion_range]
+    _ = F.inclusionᴴ := by
+      rw [← Matrix.mul_assoc, F.inclusion_isometry, Matrix.one_mul]
+
+/-- Existence of neighboring trace data for a restriction is independent of
+the chosen isometric coordinates on a fixed physical support.
+
+This equivalence is project-derived.  It compares presentations of the support
+restriction used around arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1680--1691 and 1733--1770; it is not stated in that
+source. -/
+theorem exists_neighboringTraceFactorization_restriction_iff
+    (F G : PhysicalSupportRestrictionData P K) :
+    (∃ H : PhysicalSectorFactorization
+        (changePhysicalBasis F.inclusionᴴ K),
+        Nonempty H.NeighboringTraceFactorization) ↔
+      ∃ H : PhysicalSectorFactorization
+        (changePhysicalBasis G.inclusionᴴ K),
+        Nonempty H.NeighboringTraceFactorization := by
+  have hTransport :=
+    exists_neighboringTraceFactorization_changePhysicalBasis_iff_of_isUnitaryBetween
+        (K := changePhysicalBasis G.inclusionᴴ K)
+        (F.supportCoordinateChange G)
+        (F.supportCoordinateChange_isUnitaryBetween G)
+  rw [F.changePhysicalBasis_supportCoordinateChange G] at hTransport
+  exact hTransport.symm
+
+end MPOTensor.PhysicalSupportRestrictionData

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -982,8 +982,7 @@
         MPOTensor.PhysicalSupportRestrictionData.exists_neighboringTraceFactorization_restriction_iff}
     \leanok
     \uses{def:gauge_equiv, def:mpdo_neighboring_trace_factorization,
-        def:mpdo_physical_support_restriction,
-        thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
+        def:mpdo_physical_support_restriction}
     Suppose that two MPO tensors of the same physical and virtual dimensions
     differ by an invertible virtual gauge.  One admits a physical-sector
     factorization with neighboring data $\eta_{k,h}$, $a_k$, and $b_h$ if and
@@ -1023,7 +1022,17 @@
     \leanok
     \uses{thm:mpdo_physical_sector_factorization_gauge,
         thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
-    Under the virtual gauge, every neighboring operator is unchanged.
+    For the virtual gauge $L^i=XK^iX^{-1}$, write
+    $\eta^K_{k,h}(M)$ for the neighboring contraction with $M$ inserted
+    between the transported virtual factors.  Their composition is
+    $X^{-1}X$, and hence
+    \begin{align}
+        \eta^L_{k,h}
+        &=\eta^K_{k,h}(X^{-1}X)
+         =\eta^K_{k,h}(\Id)
+         =\eta^K_{k,h}.
+        \notag
+    \end{align}
     The families $a_k$ and $b_h$ are retained literally, together with their
     positivity, trace, and normalization identities.  The reverse implication
     uses the inverse gauge.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -922,7 +922,7 @@
 
 % This coordinate-invariance theorem is project-derived.  It transports the
 % data in CPSV16 Theorem 4.9(iv), but is not a theorem stated in that source.
-\begin{theorem}[Unitary physical-coordinate invariance of neighboring trace factorizations]
+\begin{theorem}[Unitary-between physical-coordinate invariance of neighboring trace factorizations]
     \label{thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
     \lean{MPOTensor.PhysicalSectorFactorization.ofChangePhysicalBasis,
         MPOTensor.PhysicalSectorFactorization.toChangePhysicalBasis,
@@ -930,11 +930,13 @@
         MPOTensor.PhysicalSectorFactorization.toChangePhysicalBasis_neighboringOperator,
         MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.ofChangePhysicalBasis,
         MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.toChangePhysicalBasis,
-        MPOTensor.PhysicalSectorFactorization.exists_neighboringTraceFactorization_changePhysicalBasis_iff}
+        MPOTensor.PhysicalSectorFactorization.exists_neighboringTraceFactorization_changePhysicalBasis_iff,
+        MPOTensor.PhysicalSectorFactorization.exists_neighboringTraceFactorization_changePhysicalBasis_iff_of_isUnitaryBetween}
     \leanok
     \uses{def:mpdo_physical_sector_factorization, def:mpdo_neighboring_trace_factorization}
-    Let $V$ be a square physical-space matrix with $V^\dagger V=\Id$, and
-    define ${\cal K}^V_{\beta,\alpha}
+    Let $V:\C^d\to\C^e$ satisfy
+    $V^\dagger V=\Id_d$ and $VV^\dagger=\Id_e$, and define
+    ${\cal K}^V_{\beta,\alpha}
     =V{\cal K}_{\beta,\alpha}V^\dagger$.  Then ${\cal K}$ admits a
     physical-sector factorization with
     \begin{align}
@@ -955,7 +957,8 @@
 
 \begin{proof}
     \leanok
-    Since $V$ is square, $VV^\dagger=\Id$.  If the physical isometry for
+    The two one-sided unitary identities give $d\leq e$ and $e\leq d$,
+    respectively, so $d=e$.  If the physical isometry for
     ${\cal K}$ is $U$, use $UV^\dagger$ for ${\cal K}^V$; then
     $(UV^\dagger){\cal K}^V_{\beta,\alpha}(UV^\dagger)^\dagger
     =U{\cal K}_{\beta,\alpha}U^\dagger$.  Conversely, if the isometry for
@@ -964,6 +967,90 @@
     $\eta_{k,h}=\sum_\gamma(r_k)_\gamma\otimes(l_h)_\gamma$ is unchanged.
     The positivity, trace, and normalization identities therefore remain the
     same identities.
+\end{proof}
+
+% These presentation-independence statements are project-derived.  CPSV16
+% supplies the transported data and the source settings for gauge and support
+% restriction, but does not state either equivalence below.
+\begin{theorem}[Gauge and support-coordinate independence of neighboring trace factorizations]
+    \label{thm:mpdo_neighboring_trace_factorization_presentation_invariant}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.ofGaugeEquiv,
+        MPOTensor.PhysicalSectorFactorization.exists_neighboringTraceFactorization_iff_of_gaugeEquiv,
+        MPOTensor.PhysicalSupportRestrictionData.supportCoordinateChange,
+        MPOTensor.PhysicalSupportRestrictionData.supportCoordinateChange_isUnitaryBetween,
+        MPOTensor.PhysicalSupportRestrictionData.changePhysicalBasis_supportCoordinateChange,
+        MPOTensor.PhysicalSupportRestrictionData.exists_neighboringTraceFactorization_restriction_iff}
+    \leanok
+    \uses{def:gauge_equiv, def:mpdo_neighboring_trace_factorization,
+        def:mpdo_physical_support_restriction,
+        thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
+    Suppose that two MPO tensors of the same physical and virtual dimensions
+    differ by an invertible virtual gauge.  One admits a physical-sector
+    factorization with neighboring data $\eta_{k,h}$, $a_k$, and $b_h$ if and
+    only if the other does.  The same neighboring operators and the same
+    numbers $a_k,b_h$ may be used on both sides.
+
+    Let $V_F:\C^{d_F}\to\C^d$ and
+    $V_G:\C^{d_G}\to\C^d$ be two isometric inclusions with the same range
+    projection $P$:
+    \begin{align}
+        V_F^\dagger V_F &=\Id_{d_F},
+        & V_G^\dagger V_G &=\Id_{d_G},
+        \notag \\
+        V_FV_F^\dagger &=P,
+        & V_GV_G^\dagger &=P.
+        \label{eq:mpdo_support_coordinate_ranges}
+    \end{align}
+    Set $Q=V_F^\dagger V_G$.  Then
+    \begin{align}
+        Q^\dagger Q &=\Id_{d_G},
+        & QQ^\dagger &=\Id_{d_F},
+        \notag \\
+        Q\bigl(V_G^\dagger {\cal K}V_G\bigr)Q^\dagger
+          &=V_F^\dagger {\cal K}V_F.
+        \label{eq:mpdo_support_coordinate_tensor}
+    \end{align}
+    Consequently, the restrictions of ${\cal K}$ along $V_F$ and $V_G$
+    admit neighboring trace factorizations simultaneously.
+
+    Both equivalences are project-derived and are not stated in
+    \cite{Cirac2016MPDO_arXiv}.  The gauge transformation is the one discussed
+    in Section~2.3, lines~187--195; the support-restriction setting is that of
+    Appendix~C.2, lines~1680--1691 and 1733--1770.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_physical_sector_factorization_gauge,
+        thm:mpdo_neighboring_trace_factorization_physical_basis_invariant}
+    Under the virtual gauge, every neighboring operator is unchanged.
+    The families $a_k$ and $b_h$ are retained literally, together with their
+    positivity, trace, and normalization identities.  The reverse implication
+    uses the inverse gauge.
+
+    For the support coordinates,
+    (\ref{eq:mpdo_support_coordinate_ranges}) gives
+    \begin{align}
+        Q^\dagger Q
+          &=V_G^\dagger(V_FV_F^\dagger)V_G
+           =V_G^\dagger PV_G
+           =\Id_{d_G},
+        \notag \\
+        QQ^\dagger
+          &=V_F^\dagger(V_GV_G^\dagger)V_F
+           =V_F^\dagger PV_F
+           =\Id_{d_F},
+        \notag \\
+        QV_G^\dagger
+          &=V_F^\dagger(V_GV_G^\dagger)
+           =V_F^\dagger P
+           =V_F^\dagger.
+        \notag
+    \end{align}
+    The last identity gives
+    (\ref{eq:mpdo_support_coordinate_tensor}) by composition of physical
+    coordinate changes.  The unitary-between invariance above, with the
+    resulting equivalence reversed, proves the claim.
 \end{proof}
 
 \begin{theorem}[Trace of the three-site neighboring operator]


### PR DESCRIPTION
## Summary

- extend physical-coordinate invariance from square unitaries to rectangular matrices that are unitary between their finite coordinate spaces
- transport neighboring trace factorizations through an invertible virtual gauge while retaining the neighboring operators and coefficient families literally
- compare any two isometric coordinate realizations of the same physical support and prove the resulting restriction-independence equivalence
- connect every public declaration to the project-derived Chapter 21 Blueprint entry

## Mathematical provenance

The transported data are those surrounding CPSV16 Theorem 4.9(iv) and Appendix C.2. The rectangular coordinate equivalence, virtual-gauge transport, and equal-support comparison are finite-dimensional consequences required by TNLean; they are not presented as theorems stated in CPSV16. No saturation, normality, simplicity, injectivity, or nonvanishing assumption is added.

Closes #7078.

## Review corrections

- keep the physical-basis invariance theorem only in the proof-level Blueprint dependencies
- display the virtual cancellation in the convention used by the construction: $\eta^L_{k,h}=\eta^K_{k,h}(X^{-1}X)=\eta^K_{k,h}(\mathrm{Id})=\eta^K_{k,h}$
- reuse the existing positivity-transport lemma in the gauge-transport structure

## Validation

- focused build of the three changed modules: 9,199 jobs
- current-main aggregate build: 10,314 jobs
- import-aggregator check and 14 generator tests
- 16 Lean file-policy tests and oversized-file guard
- Blueprint source synchronization: 6,839 of 6,839 theorem-like entries synchronized; every changed declaration is referenced
- compiled declaration checking, paper-gap reference resolution for 98 slugs, and complete Blueprint web rendering
- reader-facing prose, tactic-pattern, ChkTeX, proof-integrity, and `git diff --check` scans
- `#print axioms` for all five public theorems: only `propext`, `Classical.choice`, and `Quot.sound`

## Rebase provenance

The original mathematical commit `38ff77478` was rebased from `48bedcd22` onto current main `ad9a3f1049` as `50dad60fc`. `git range-diff` reports an exact match and both commits have stable patch ID `75eb15b0994daed336403280ff0df21a3b929a14`. The second commit contains only the three reviewed corrections above.

For preservation provenance, the original four-file local state remains on remote branch `snapshot/issue-7078-local-20260825` at `aebdbd5f0`; the old reviewed head is retained as `archive/pr-7145-head-38ff774`.