### PR TITLE
fix(tenkz): name pre-record diagnostic scopes

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2146,8 +2146,7 @@ if ( cd "$WORK" &&
        timeout 120 xelatex -interaction=nonstopmode \
        "$KERNEL/negative/$context_recovery.tex" \
        >"$WORK/$context_recovery.recovery.transcript" 2>&1 ); then
-  echo "FAIL: $context_recovery recovery compile reported no errors" >&2
-  exit 1
+  :
 fi
 context_recovery_log="$WORK/$context_recovery.recovery.transcript"
 [ "$(grep -Fc '[TKZ-LANG-UNKNOWN-KEY]' "$context_recovery_log")" -eq 2 ] || {

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2099,18 +2099,70 @@ grep -Fq '[TKZ-KERNEL-SKIN]' "$WORK/n_unknown_skin.transcript" || {
   exit 1
 }
 
-metrics_negative="$KERNEL/negative/n_picture_metrics.tex"
+# These validators run before a picture, setup act, or declaration has a
+# model record.  Their final clause names that truthful scope, never an empty
+# or stale newest-record id.  One case pins each distinct reader.
+for context_negative in \
+  n_picture_metrics:TKZ-LANG-CHOICE:picture \
+  n_picture_side_word:TKZ-LANG-CHOICE:picture \
+  n_picture_unknown_key:TKZ-LANG-UNKNOWN-KEY:picture \
+  n_picture_sugar_flag_word:TKZ-LANG-CHOICE:picture \
+  n_picture_align_word:TKZ-LANG-CHOICE:picture \
+  n_equation_align_word:TKZ-LANG-CHOICE:equation \
+  n_setup_sizes_key:TKZ-LANG-UNKNOWN-KEY:setup \
+  n_declare_unknown_key:TKZ-LANG-UNKNOWN-KEY:declaration
+do
+  context_name=${context_negative%%:*}
+  context_rest=${context_negative#*:}
+  context_code=${context_rest%%:*}
+  context_scope=${context_negative##*:}
+  context_source="$KERNEL/negative/$context_name.tex"
+  if ( cd "$WORK" &&
+       TEXINPUTS="$REPO/tex/tenkz//:" \
+         timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
+         "$context_source" >"$WORK/$context_name.transcript" 2>&1 ); then
+    echo "FAIL: $context_name was accepted" >&2
+    exit 1
+  fi
+  grep -Fq "[$context_code]" "$WORK/$context_name.transcript" || {
+    echo "FAIL: $context_name lacked $context_code" >&2
+    exit 1
+  }
+  grep -Fq "(record $context_scope)" "$WORK/$context_name.transcript" || {
+    echo "FAIL: $context_name lacked its $context_scope context" >&2
+    exit 1
+  }
+  if grep -Fq '(record )' "$WORK/$context_name.transcript"; then
+    echo "FAIL: $context_name carried an empty record clause" >&2
+    exit 1
+  fi
+done
+
+# Recover past a picture-option error and ask a body key to fail as well.
+# The context wrapper must have restored the ordinary record diagnostic.
+context_recovery=n_picture_unknown_key
 if ( cd "$WORK" &&
      TEXINPUTS="$REPO/tex/tenkz//:" \
-       timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
-       "$metrics_negative" >"$WORK/n_picture_metrics.transcript" 2>&1 ); then
-  echo "FAIL: a word outside the metric-profile alphabet was accepted" >&2
+       timeout 120 xelatex -interaction=nonstopmode \
+       "$KERNEL/negative/$context_recovery.tex" \
+       >"$WORK/$context_recovery.recovery.transcript" 2>&1 ); then
+  echo "FAIL: $context_recovery recovery compile reported no errors" >&2
   exit 1
 fi
-grep -Fq '[TKZ-LANG-CHOICE]' "$WORK/n_picture_metrics.transcript" || {
-  echo "FAIL: unknown metric profile lacked TKZ-LANG-CHOICE" >&2
+context_recovery_log="$WORK/$context_recovery.recovery.transcript"
+[ "$(grep -Fc '[TKZ-LANG-UNKNOWN-KEY]' "$context_recovery_log")" -eq 2 ] || {
+  echo "FAIL: $context_recovery did not reach both refusals" >&2
   exit 1
 }
+grep -Fq '(record picture)' "$context_recovery_log" &&
+  grep -Eq 'atom-[0-9]+\)\.' "$context_recovery_log" || {
+  echo "FAIL: $context_recovery did not restore the atom-record context" >&2
+  exit 1
+}
+if grep -Fq '(record )' "$context_recovery_log"; then
+  echo "FAIL: $context_recovery recovery carried an empty record clause" >&2
+  exit 1
+fi
 
 # A key that would be silently inert at group scope is a key the author has
 # misplaced: the class belongs to the picture, the audit to the equation, and
@@ -2675,14 +2727,12 @@ for contract_negative in \
   n_mark_inset_key \
   n_atom_nudge_key \
   n_mark_nudge_key \
-  n_setup_sizes_key \
   n_setup_theme_key \
   n_wire_weight_key \
   n_wire_restyle_transform \
   n_wire_restyle_nested \
   n_leg_restyle_transform \
   n_picture_cols_word \
-  n_picture_align_word \
   n_malformed_via \
   n_malformed_cross \
   n_malformed_mark_target \
@@ -2768,8 +2818,6 @@ do
     expected='[TKZ-LANG-UNKNOWN-KEY]'
   [ "$contract_negative" = n_mark_nudge_key ] &&
     expected='[TKZ-LANG-UNKNOWN-KEY]'
-  [ "$contract_negative" = n_setup_sizes_key ] &&
-    expected='[TKZ-LANG-UNKNOWN-KEY]'
   [ "$contract_negative" = n_setup_theme_key ] &&
     expected='[TKZ-LANG-UNKNOWN-KEY]'
   [ "$contract_negative" = n_wire_weight_key ] &&
@@ -2782,8 +2830,6 @@ do
     expected='[TKZ-WIRE-RESTYLE-TRANSFORM]'
   [ "$contract_negative" = n_picture_cols_word ] &&
     expected='[TKZ-PIC-POSITIVE-INTEGER]'
-  [ "$contract_negative" = n_picture_align_word ] &&
-    expected='[TKZ-LANG-CHOICE]'
   [ "$contract_negative" = n_signature_carrier_port ] &&
     expected='[TKZ-EQ-SIGNATURE]'
   grep -Fq "$expected" "$WORK/$contract_negative.transcript" || {

--- a/tests/tenkz/kernel/negative/n_declare_unknown_key.tex
+++ b/tests/tenkz/kernel/negative/n_declare_unknown_key.tex
@@ -1,0 +1,8 @@
+% Negative regression: an unknown descriptor key is refused while a
+% declaration is being parsed, before any model record exists.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\tndeclare{skin}{test-skin}{bogus=value}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_equation_align_word.tex
+++ b/tests/tenkz/kernel/negative/n_equation_align_word.tex
@@ -1,0 +1,12 @@
+% Negative regression: equation options are parsed before any panel record,
+% so an invalid alignment word names the equation rather than a stale record.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkzeq}[align=bogus]
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]\tn{A}\end{tenkz}
+  =
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]\tn{B}\end{tenkz}
+\end{tenkzeq}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_picture_side_word.tex
+++ b/tests/tenkz/kernel/negative/n_picture_side_word.tex
@@ -1,0 +1,10 @@
+% Negative regression: a picture-side policy takes one word of its closed
+% alphabet, and its refusal names the picture being parsed.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, bonds=none, west=bogus]
+  \tn{A}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_picture_sugar_flag_word.tex
+++ b/tests/tenkz/kernel/negative/n_picture_sugar_flag_word.tex
@@ -1,0 +1,10 @@
+% Negative regression: a picture sugar flag takes true or false, and its
+% alphabet refusal names the picture being parsed.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[sandwich=maybe, cols=1, bonds=none]
+  \tn{A}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_picture_unknown_key.tex
+++ b/tests/tenkz/kernel/negative/n_picture_unknown_key.tex
@@ -1,0 +1,11 @@
+% Negative regression: an unknown picture option is refused before the
+% picture record exists; if compilation recovers, the later atom refusal
+% must name its own record rather than retaining the picture context.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, bonds=none, theme=house]
+  \tn[up=1pt]{A}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -423,6 +423,8 @@
 % list passes through this door, which braces each address before l3keys
 % reads it.  Members go first: the pair pattern must not consume their prefix.
 \tl_new:N \l__tenkz_kernel_opts_tl
+\tl_new:N \l__tenkz_kernel_diagnostic_context_tl
+\seq_new:N \l__tenkz_kernel_diagnostic_context_seq
 \cs_new_protected:Npn \__tenkz_kernel_keys:nn #1#2
   {
     \tl_set:Nn \l__tenkz_kernel_opts_tl {#2}
@@ -441,6 +443,24 @@
       { \cB\{ \( \1 , \2 \) \cE\} }
       \l__tenkz_kernel_opts_tl
     \keys_set:nV {#1} \l__tenkz_kernel_opts_tl
+  }
+% Picture, equation, setup, and declaration options are read before they own
+% a model record.  Such a parse pushes the scope it can truthfully name;
+% body and group parses leave the stack empty and name their minted record.
+% A recoverable diagnostic returns through \keys_set:nV, so the pop also
+% restores an enclosing context after a refusal.
+\cs_new:Npn \__tenkz_kernel_diagnostic_context:
+  {
+    \seq_if_empty:NTF \l__tenkz_kernel_diagnostic_context_seq
+      { \tl_use:N \l__tenkz_model_last_tl }
+      { \seq_item:Nn \l__tenkz_kernel_diagnostic_context_seq {1} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_context_keys:nnn #1#2#3
+  {
+    \seq_push:Nn \l__tenkz_kernel_diagnostic_context_seq {#1}
+    \__tenkz_kernel_keys:nn {#2} {#3}
+    \seq_pop:NN \l__tenkz_kernel_diagnostic_context_seq
+      \l__tenkz_kernel_diagnostic_context_tl
   }
 
 % The package event writer, reachable whatever the catcode of @ is at load.
@@ -941,7 +961,7 @@
         #2 / unknown .code:n =
           {
             \msg_error:nneeee {tenkz}{kernel-choice} {#2} {##1} {#3}
-              { \tl_use:N \l__tenkz_model_last_tl }
+              { \__tenkz_kernel_diagnostic_context: }
           }
       }
   }
@@ -1025,7 +1045,7 @@
           {
             \msg_error:nneeee {tenkz}{kernel-choice} {#1} {#2}
               { open|none|trace|cup|cup={m} }
-              { \tl_use:N \l__tenkz_model_last_tl }
+              { \__tenkz_kernel_diagnostic_context: }
           }
       }
   }
@@ -1070,7 +1090,7 @@
           {
             \msg_error:nneeee {tenkz}{kernel-choice}
               {align} {#1} {midline|<row~number>}
-              { \tl_use:N \l__tenkz_model_last_tl }
+              { \__tenkz_kernel_diagnostic_context: }
           }
       }
   }
@@ -1102,7 +1122,7 @@
           {
             \msg_error:nneee {tenkz}{kernel-unknown-key}
               { \l_keys_key_str } {#2}
-              { \tl_use:N \l__tenkz_model_last_tl }
+              { \__tenkz_kernel_diagnostic_context: }
           }
       }
   }
@@ -1375,8 +1395,7 @@
       }
       {
         \msg_error:nneeee {tenkz}{kernel-choice}
-          {#1} {#2} {true|false}
-          { \tl_use:N \l__tenkz_model_last_tl }
+          {#1} {#2} {true|false} { \__tenkz_kernel_diagnostic_context: }
       }
   }
 % picture-scope sugar: each expansion is the sugar ledger's row, verbatim.
@@ -2655,7 +2674,8 @@
 \cs_new_protected:Npn \__tenkz_kernel_tnset:n #1
   {
     \prop_clear:N \l__tenkz_kernel_stage_prop
-    \__tenkz_kernel_keys:nn { tenkz-kernel-setup } {#1}
+    \__tenkz_kernel_context_keys:nnn
+      {setup} { tenkz-kernel-setup } {#1}
     \__tenkz_kernel_policy_merge:NN
       \l__tenkz_kernel_stage_prop \g__tenkz_kernel_setup_prop
     \prop_clear:N \l__tenkz_kernel_stage_prop
@@ -2731,14 +2751,16 @@
   {
     % the declaration keys validate the descriptor; the table keeps it raw
     \prop_clear:N \l__tenkz_kernel_stage_prop
-    \__tenkz_kernel_keys:nn { tenkz-kernel-declare } {#3}
+    \__tenkz_kernel_context_keys:nnn
+      {declaration} { tenkz-kernel-declare } {#3}
     \prop_clear:N \l__tenkz_kernel_stage_prop
     \prop_gput:Nnn #1 {#2} {#3}
   }
 \cs_new_protected:Npn \__tenkz_kernel_declare_atom:nn #1#2
   {
     \prop_clear:N \l__tenkz_kernel_stage_prop
-    \__tenkz_kernel_keys:nn { tenkz-kernel-declare-atom } {#2}
+    \__tenkz_kernel_context_keys:nnn
+      {declaration} { tenkz-kernel-declare-atom } {#2}
     \prop_clear:N \l__tenkz_kernel_stage_prop
     \tl_set:Ne \l__tenkz_kernel_scratch_tl { \tl_to_str:n {#1} }
     \str_if_eq:eeT
@@ -21356,7 +21378,8 @@
     \int_zero:N \l__tenkz_kernel_node_int
     \int_zero:N \l__tenkz_kernel_basis_count_int
     \bool_set_false:N \l__tenkz_kernel_group_keys_bool
-    \__tenkz_kernel_keys:nn { tenkz-kernel-picture } {#1}
+    \__tenkz_kernel_context_keys:nnn
+      {picture} { tenkz-kernel-picture } {#1}
     % check= belongs to the equation wrapper.  A valid tenkzeq consumes it
     % before any panel begins, so seeing it here always means picture scope.
     \prop_get:NnN
@@ -21662,7 +21685,8 @@
     \seq_clear:N \l__tenkz_kernel_check_reason_seq
     \prop_clear:N \l__tenkz_kernel_eq_policy_prop
     \prop_clear:N \l__tenkz_kernel_stage_prop
-    \__tenkz_kernel_keys:nn { tenkz-kernel-picture } {#1}
+    \__tenkz_kernel_context_keys:nnn
+      {equation} { tenkz-kernel-picture } {#1}
     % check={signature, off={k: reason}}: the specification is a key list and
     % is read as one.  A reason is prose an author writes
     % about the mathematics, and prose carries commas and braces and words

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -423,7 +423,6 @@
 % list passes through this door, which braces each address before l3keys
 % reads it.  Members go first: the pair pattern must not consume their prefix.
 \tl_new:N \l__tenkz_kernel_opts_tl
-\tl_new:N \l__tenkz_kernel_diagnostic_context_tl
 \seq_new:N \l__tenkz_kernel_diagnostic_context_seq
 \cs_new_protected:Npn \__tenkz_kernel_keys:nn #1#2
   {
@@ -460,7 +459,7 @@
     \seq_push:Nn \l__tenkz_kernel_diagnostic_context_seq {#1}
     \__tenkz_kernel_keys:nn {#2} {#3}
     \seq_pop:NN \l__tenkz_kernel_diagnostic_context_seq
-      \l__tenkz_kernel_diagnostic_context_tl
+      \l__tenkz_kernel_scratch_tl
   }
 
 % The package event writer, reachable whatever the catcode of @ is at load.


### PR DESCRIPTION
### Motivation

Shared alphabet validators took their final diagnostic clause from the newest model record. Picture, equation, setup, and declaration options are parsed before such a record exists, so malformed options could report an empty or stale `(record ...)` clause. This violates the diagnostic doctrine established in LionSR/tenkz#209: a refusal should state only information known at the point of refusal.

Closes LionSR/tenkz#215.

### Description

- Add one short-lived diagnostic-context stack around the existing key reader for pre-record picture, equation, setup, and declaration parsing.
- Make the existing choice, side-policy, alignment, unknown-key, and picture-sugar-flag validators read that truthful context. Their parser interfaces and registries are unchanged.
- Restore the enclosing context after both successful and recoverable refused parses. Body and group diagnostics continue to name their actual minted record; a recovery regression proves that a later atom refusal reports `atom-1`, not the preceding picture scope.
- Add one focused negative fixture for each distinct helper family not already represented, including the same-cause picture `align=`, equation `align=`, side-policy, malformed-sugar, and unknown-key paths.

The affected files are `tex/tenkz/tenkz-kernel.code.tex`, `scripts/tenkz_kernel_probes.sh`, and five focused fixtures under `tests/tenkz/kernel/negative/`.

### Manual and contract audit

An explicit repository search found no complete affected `TKZ-LANG-CHOICE` or `TKZ-LANG-UNKNOWN-KEY` quotation in the manual or catalogue and no pre-existing `(record )` expectation. Existing registry-sweep snippets quote only unchanged diagnostic prefixes. The only `(record )` occurrences after this change are the two new negative assertions that forbid it. The catalogue diagnostic blocks concern tombstone and strict-mode refusals and are unaffected, so no manual quotation changes are required.

This change does not add a language feature or parser row: all existing helper signatures, key registries, and language records are unchanged. `tenkz_language.py check` remains at 114 records; the shrink gate remains at 78 stable records and 53 flags; the compatibility policy reports zero evidence entries. Consequently no census baseline or contract documentation changes are required.

### Testing

- Full kernel probe suite: 164 regressions, 11 sugar expansions, 14 streams, and pixel checks exact.
- Focused halt-on-error probes for picture metrics, side policy, unknown key, malformed sugar flag, alignment, equation alignment, setup, and declaration; recovery compile reaches both picture and atom refusals with truthful contexts.
- Manual doctest: 56 displayed examples and 12 reference examples exact; extraction and reference coverage pass.
- Language check: 114 records; shrink gate: 78 records and 53 flags stable.
- Corpus compile/audit: 9 cases; golden events, string probes, and corpus render baseline exact.
- Kernel/equation audits, TeX-case and tnlog units, compatibility policy, demolition/disposition, release-readiness, CTAN smoke/unit, prose, and `git diff --check` pass.

No rendered output or public language behavior changes apart from the corrected refusal context.