### PR TITLE
doc(conventions): clarify theorem-name components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,10 @@ before working in that area:
   `TNLean/` prefix
 - **Issue titles**: plain mathematical titles, not `type(scope): ...`; use
   `Tracking: <area>` for trackers and keep titles bracket-free
-- **Naming**: Definitions `camelCase`, predicates `IsPrefix`, theorems `snake_case`, files `CamelCase.lean`
+- **Naming**: Definitions use `camelCase`, predicates use `IsPrefix`, and
+  theorem names use underscore-separated components. An embedded definition
+  or predicate keeps its canonical spelling, as in `evalWord_tensorProduct`.
+  Files use `CamelCase.lean`.
 - **Proof integrity blockers**: `sorry`, `admit`, `native_decide`, `unsafeCast`, `axiom`, circular reasoning
 - **Blueprint prose**: Pure mathematics only — no Lean identifiers in text, no software jargon (see banned terms list in blueprint style guide)
 - **Paper references**: Cite theorem numbers in docstrings (e.g., "Wolf Thm 6.3", "arXiv:1606.00608 Appendix A")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,10 @@ before working in that area:
   `Tracking: <area>` for trackers and keep titles bracket-free
 - **Naming**: Definitions use `camelCase`, predicates use `IsPrefix`, and
   theorem names use underscore-separated components. An embedded definition
-  or predicate keeps its canonical spelling, as in `evalWord_tensorProduct`.
+  keeps its `camelCase` spelling, while an embedded predicate is
+  lower-camel-cased (`Is` becomes `is`). Internal word boundaries are never
+  split, as in `evalWord_tensorProduct` and
+  `isNormalTensor_of_isNormal_leftCanonical`.
   Files use `CamelCase.lean`.
 - **Proof integrity blockers**: `sorry`, `admit`, `native_decide`, `unsafeCast`, `axiom`, circular reasoning
 - **Blueprint prose**: Pure mathematics only — no Lean identifiers in text, no software jargon (see banned terms list in blueprint style guide)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -188,10 +188,12 @@ multi-block case.
 Before opening a pull request, skim the conventions below; each links to the
 document that spells it out in full.
 
-**Naming.** Definitions are `camelCase`, predicates are named `IsFoo`,
-theorems and lemmas are `snake_case`, and files are `CamelCase.lean`. The
-full capitalization rules and the symbol-to-name dictionary (how to spell
-`⊗`, `≤`, `⁻¹`, and so on in an identifier) are in the MATHLIB_naming
+**Naming.** Definitions are `camelCase`, predicates are named `IsFoo`, and
+files are `CamelCase.lean`. The component rule for theorem and lemma names,
+including the spelling of embedded definitions and predicates, is summarized
+in the repository [quick reference](../CLAUDE.md#quick-reference-from-the-docs-above).
+The canonical capitalization rules and the symbol-to-name dictionary (how to
+spell `⊗`, `≤`, `⁻¹`, and so on in an identifier) are in the MATHLIB_naming
 reference of the `lean-conventions` skill
 ([texra-ai/texra-lean-skills](https://github.com/texra-ai/texra-lean-skills)).
 


### PR DESCRIPTION
Closes #7149.

## Purpose

Clarify the abbreviated theorem-naming rule in the repository quick reference. The canonical shared convention uses underscore-separated theorem-name components, but an embedded definition or predicate retains its internal word boundaries. The local examples `evalWord_tensorProduct` and `isNormalTensor_of_isNormal_leftCanonical` make the definition and predicate cases explicit.

This prevents the short phrase “theorems snake_case” from being read as an instruction to split identifiers such as `tensorProduct`, `wordSpan`, or `IsNormal` into unrelated words. That ambiguity caused opposing review rounds in #7125.

## Single source of truth

`CLAUDE.md` contains the local quick-reference summary. `AGENTS.md` remains its existing symbolic link to `CLAUDE.md`, and the contributor onboarding guide now links to that summary instead of repeating the ambiguous shorthand. No duplicate instruction file or duplicate naming rule is introduced.

## Follow-up

The automated review and repair prompt templates still contain abbreviated `snake_case` wording without the embedded-identifier qualification. Updating those templates is deliberately outside this focused documentation PR and should be handled as a separate prompt-maintainability change.

## Verification

- `AGENTS.md -> CLAUDE.md` link and byte-identity check
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- onboarding quick-reference link check
- `git diff --check`