### PR TITLE
fix(tenkz): keep prelude species outside the hue cycle

### DIFF
--- a/docs/tenkz/FIXTURE-RETIREMENT.md
+++ b/docs/tenkz/FIXTURE-RETIREMENT.md
@@ -233,13 +233,13 @@ policy-answer value `r_atom_physical_answer.tex` does not spell.
 
 **Discharged.** The glyph half blocked this fixture: `__tenkz_kernel_atom_skin:nN` defaulted every atom's skin to `dot`, so `\tn[void=open]{}` drew a site indistinguishable from a real one (recorded as issue #5609). PR #5616 defaults a void's skin to `none` — a hole draws nothing, no glyph and no label, unless the author declares a skin — and shipped `tests/tenkz/kernel/regression/r_void_open.tex` pinning the open hole's bridging bonds, its preserved physical index, the boundary contrast against the sealed variant, and the atom-scope `physical=updown` answer.
 
-### G2 — mark slot words and mark names (write before deletion)
+### G2 — region words and mark names (write before deletion)
 
-The kernel mark slot alphabet is `{selected, secondary, complement, collar,
-neutral}` (`tenkz-kernel.code.tex` line 1222), and marks accept `name=` (line
-1227). Surviving suites exercise only `selected` (13 uses) and `secondary`
-(`r_region_complement.tex`). The words `complement`, `collar`, and `neutral`
-and the mark `name=` key are exercised solely by five legacy lattice fixtures
+The former kernel mark slot alphabet was `{selected, secondary, complement,
+collar, neutral}`, and marks also accepted `name=`. Before the
+slot-for-species exchange, surviving suites exercised only `selected` and
+`secondary`; the words `complement`, `collar`, and `neutral` and the mark
+`name=` key were exercised solely by five legacy lattice fixtures
 (`lattice_test`, `notch`, `feat`, `t2_gs2d_lasso`, `t2_tcdual`).
 
 **Replacement:** `tests/tenkz/kernel/regression/r_region_words.tex`. One
@@ -248,7 +248,8 @@ grid with three enclosures carrying `species=complement`, `species=collar`,
 its own semantic ink and the named mark is accepted and recorded. The
 deferred slot-for-species exchange (`LANGUAGE-1.0.md` §14.5) has executed:
 `slot=` is retired, the fixture pins the `species=` respelling, and the
-region words stand as prelude species.
+region words stand as prelude species. `n_mark_slot_key.tex` separately pins
+the retired `slot=` key's unknown-key refusal.
 
 **Closed.** The fixture (born `r_region_slot_words.tex`, renamed with the
 exchange) hooks `\__tenkz_kernel_r_mark_enclosure:n` to capture the

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -4059,3 +4059,11 @@ mark-name pin follows the renamed fixture.
 | flag:lonely-type:size-table | departed: its sole carrier was the inert sizes= setup key; permanent |
 | flag:consumers:key:kernel-setup:theme | retired: stored an identifier, read by nothing; the house palette binds at load and cited palettes enter through species hue declarations; permanent |
 | flag:consumers:key:kernel-wire:weight | retired: zero authored consumers; it changed no ink, endpoint type owns stroke, and multiplicity belongs to the mathematical label; permanent |
+
+### 2026-08-25 — correction to the slot-retirement verdict summary
+
+The preceding session's summary should be read as its verdict table states:
+the mark's `slot=` consumer row is tombstoned permanently, while the
+`semantic-slot` lonely type dies with that key. The meters and all other
+verdicts are unchanged. This correction is appended because shrink sessions
+are immutable.

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2839,6 +2839,19 @@ do
     exit 1
   }
 done
+awk '
+  { transcript = transcript " " $0 }
+  END {
+    exit(transcript !~ /\(record[[:space:]]+(\(tenkz\)[[:space:]]+)?mark-[0-9]+\)\./)
+  }
+' "$WORK/n_mark_slot_key.transcript" || {
+  echo "FAIL: the retired mark slot rejection dropped its mark-record context" >&2
+  exit 1
+}
+if grep -Fq '(record )' "$WORK/n_mark_slot_key.transcript"; then
+  echo "FAIL: the retired mark slot rejection carried an empty record clause" >&2
+  exit 1
+fi
 grep -Eq '\(node addr-[0-9]+\)' "$WORK/n_noncell_leg.transcript" || {
   echo "FAIL: the non-cell leg rejection dropped its node context" >&2
   exit 1

--- a/tests/tenkz/kernel/negative/n_mark_slot_key.tex
+++ b/tests/tenkz/kernel/negative/n_mark_slot_key.tex
@@ -1,5 +1,5 @@
 % Negative: the retired mark `slot=` semantic-tint key has no parser path;
-% species= carries the region word.
+% species= carries the region word, and the refusal names its mark record.
 \documentclass{standalone}
 \usepackage{tenkz}
 \begin{document}

--- a/tests/tenkz/kernel/regression/r_region_words.tex
+++ b/tests/tenkz/kernel/regression/r_region_words.tex
@@ -9,6 +9,14 @@
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
 \seq_new:N \g__tenkz_test_slot_hue_seq
+\tl_new:N \g__tenkz_test_shared_species_hue_tl
+\cs_new_eq:NN \__tenkz_test_species_one_hued:nn \tenkz_species_one_hued:nn
+\cs_set_protected:Npn \tenkz_species_one_hued:nn #1#2
+  {
+    \__tenkz_test_species_one_hued:nn {#1} {#2}
+    \str_if_eq:nnT {#1} {selected}
+      { \tl_gset:Nn \g__tenkz_test_shared_species_hue_tl {#2} }
+  }
 \cs_new_eq:NN \__tenkz_test_slot_enclosure:n \__tenkz_kernel_r_mark_enclosure:n
 \cs_set_protected:Npn \__tenkz_kernel_r_mark_enclosure:n #1
   {
@@ -16,10 +24,63 @@
     \seq_gput_right:Ne \g__tenkz_test_slot_hue_seq
       { \tl_use:N \l__tenkz_kernel_r_hue_tl }
   }
+% Exercise the mark text resolver without adding ink or audit records to the
+% fixture.  The temporary record is discarded before the drawn picture.
+\cs_new_protected:Npn \__tenkz_test_region_mark_ink:nnN #1#2#3
+  {
+    \__tenkz_model_reset:
+    \__tenkz_model_record_mark:n { form = #1 , species = #2 }
+    \__tenkz_kernel_r_mark_text_ink:nN {mark-1} #3
+  }
+\cs_new_protected:Npn \__tenkz_test_first_undeclared_hue:nN #1#2
+  {
+    \__tenkz_kernel_r_species_prepare:
+    \__tenkz_kernel_r_species_hue:nN {#1} #2
+  }
 \ExplSyntaxOff
 \makeatother
 \begin{document}
 \tenkzkernel
+\ExplSyntaxOn
+\__tenkz_test_first_undeclared_hue:nN {before-prelude} \l_tmpa_tl
+\str_if_eq:VnF \l_tmpa_tl {tenkzMarked}
+  { \errmessage{the~first~undeclared~species~did~not~take~cycle~slot~one} }
+\ExplSyntaxOff
+% A hue-less redeclaration preserves the prelude hue in both the shared tree
+% styles and the kernel renderer without consuming a house-cycle slot.  It
+% remains a compatibility region word: a label-form mark is coloured, while
+% contour-bearing labels stay plain.
+\tndeclare{species}{selected}{}
+\ExplSyntaxOn
+\str_if_eq:VnF \g__tenkz_test_shared_species_hue_tl {tenkzAction}
+  { \errmessage{a~hue-less~prelude~redeclaration~changed~the~shared~hue} }
+\__tenkz_kernel_r_species_hue:nN {selected} \l_tmpa_tl
+\str_if_eq:VnF \l_tmpa_tl {tenkzAction}
+  { \errmessage{a~hue-less~prelude~redeclaration~changed~the~kernel~hue} }
+\__tenkz_test_first_undeclared_hue:nN {after-prelude} \l_tmpa_tl
+\str_if_eq:VnF \l_tmpa_tl {tenkzMarked}
+  { \errmessage{a~prelude~redeclaration~consumed~a~house-cycle~slot} }
+\__tenkz_test_region_mark_ink:nnN {label} {selected} \l_tmpa_tl
+\tl_if_in:VnF \l_tmpa_tl {tenkzAction}
+  { \errmessage{a~region~word~did~not~colour~a~label-form~mark} }
+\__tenkz_test_region_mark_ink:nnN {enclosure} {selected} \l_tmpa_tl
+\tl_if_empty:NF \l_tmpa_tl
+  { \errmessage{a~hue-less~region~redeclaration~coloured~an~enclosure~label} }
+\__tenkz_test_region_mark_ink:nnN {bracket} {selected} \l_tmpa_tl
+\tl_if_empty:NF \l_tmpa_tl
+  { \errmessage{a~hue-less~region~redeclaration~coloured~a~bracket~label} }
+\ExplSyntaxOff
+% An explicit hue is an intentional species declaration, rather than the
+% retired slot compatibility spelling, and therefore colours every form.
+\tndeclare{species}{selected}{hue=source:green}
+\ExplSyntaxOn
+\str_if_eq:VnF \g__tenkz_test_shared_species_hue_tl {green}
+  { \errmessage{an~explicit~prelude~hue~did~not~reach~the~shared~styles} }
+\__tenkz_test_region_mark_ink:nnN {enclosure} {selected} \l_tmpa_tl
+\tl_if_in:VnF \l_tmpa_tl {green}
+  { \errmessage{an~explicit~region~hue~did~not~colour~the~enclosure~label} }
+\__tenkz_model_reset:
+\ExplSyntaxOff
 \begin{tenkz}[rows={wire,wire,wire}, cols=3, west=open, east=open]
   \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} \\
   \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} \\

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2699,9 +2699,9 @@
   }
 % The prelude species and their fixed hues, one authority for the hue
 % resolver and the declaration door: the four semantic roles and the five
-% region words the retired slot= key left to species=.  A prelude word
-% keeps its hue however a document redeclares it, which is the standing
-% redeclaration contract; only names outside this table ride the cycle.
+% region words the retired slot= key left to species=.  A hue-less prelude
+% redeclaration keeps its fixed hue; an explicit hue remains authoritative.
+% Only hue-less names outside this table ride the cycle.
 \clist_const:Nn \c__tenkz_kernel_region_words_clist
   { selected , secondary , complement , collar , neutral }
 \int_new:N \g__tenkz_kernel_species_cycle_int
@@ -2721,6 +2721,25 @@
       }
       { \tl_clear:N #2 }
   }
+% Read the one optional hue field from a species descriptor.  Declaration,
+% rendering, and the mark compatibility rule all use this parser, so they
+% cannot disagree about whether a document supplied an explicit hue.
+\cs_new_protected:Npn \__tenkz_kernel_species_descriptor_hue:nN #1#2
+  {
+    \tl_clear:N #2
+    \regex_extract_once:nnNT
+      {
+        (?: \A | , ) \s* hue \s* = \s*
+        (?: \{ \s* )? (?: source: )?
+        ([^,{}\s]+) (?: \s* \} )?
+      }
+      {#1}
+      \l__tenkz_kernel_r_hue_match_seq
+      {
+        \tl_set:Ne #2
+          { \seq_item:Nn \l__tenkz_kernel_r_hue_match_seq {2} }
+      }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_declare_species:nn #1#2
   {
     \__tenkz_kernel_declare_table:Nnn
@@ -2729,34 +2748,21 @@
     % `species <name> ...' style family (tenkz-core) that \tntree draws
     % from, so a declared species is usable on every record class.  A
     % declared hue is authoritative there exactly as it is for kernel
-    % records (\__tenkz_kernel_r_species_hue:nN); only hue-less
+    % records (\__tenkz_kernel_r_species_hue:nN); only non-prelude hue-less
     % declarations take the house cycle.
-    \regex_extract_once:nnNTF
+    \__tenkz_kernel_species_descriptor_hue:nN {#2}
+      \l__tenkz_kernel_scratch_tl
+    \tl_if_empty:NTF \l__tenkz_kernel_scratch_tl
       {
-        (?: \A | , ) \s* hue \s* = \s*
-        (?: \{ \s* )? (?: source: )?
-        ([^,{}\s]+) (?: \s* \} )?
-      }
-      {#2}
-      \l__tenkz_kernel_r_hue_match_seq
-      {
-        \tl_set:Ne \l__tenkz_kernel_scratch_tl
-          { \seq_item:Nn \l__tenkz_kernel_r_hue_match_seq {2} }
-        \exp_args:NnV \tenkz_species_one_hued:nn {#1}
+        \__tenkz_kernel_prelude_hue:nN {#1}
           \l__tenkz_kernel_scratch_tl
-      }
-      {
-        \tenkz_species_one:n {#1}
-        % Hue-less declarations receive a document-scope cycle slot now, in
-        % declaration order.  Reordering first uses in later pictures
-        % therefore cannot change the identity's ink.
-        \prop_if_in:NnF \g__tenkz_kernel_species_hue_prop {#1}
+        \tl_if_empty:NTF \l__tenkz_kernel_scratch_tl
           {
-            % A prelude word keeps its fixed hue across redeclarations;
-            % the cycle counts only the names it has actually served, so
-            % seeding a prelude word never shifts another name's slot.
-            \__tenkz_kernel_prelude_hue:nN {#1} \l_tmpa_tl
-            \tl_if_empty:NT \l_tmpa_tl
+            \tenkz_species_one:n {#1}
+            % Hue-less declarations receive a document-scope cycle slot now,
+            % in declaration order.  Reordering first uses in later pictures
+            % therefore cannot change the identity's ink.
+            \prop_if_in:NnF \g__tenkz_kernel_species_hue_prop {#1}
               {
                 \int_set:Nn \l_tmpa_int
                   {
@@ -2771,9 +2777,24 @@
                       { \l_tmpa_int }
                   }
                 \int_gincr:N \g__tenkz_kernel_species_cycle_int
+                \prop_gput:NnV
+                  \g__tenkz_kernel_species_hue_prop {#1} \l_tmpa_tl
               }
-            \prop_gput:NnV \g__tenkz_kernel_species_hue_prop {#1} \l_tmpa_tl
           }
+          {
+            % Prelude declarations use their fixed hue in the shared tree
+            % styles as well as in kernel records.  They do not consume a
+            % house-cycle slot.
+            \exp_args:NnV \tenkz_species_one_hued:nn {#1}
+              \l__tenkz_kernel_scratch_tl
+            \prop_gput:NnV
+              \g__tenkz_kernel_species_hue_prop {#1}
+              \l__tenkz_kernel_scratch_tl
+          }
+      }
+      {
+        \exp_args:NnV \tenkz_species_one_hued:nn {#1}
+          \l__tenkz_kernel_scratch_tl
       }
   }
 \cs_new_protected:Npn \__tenkz_kernel_declare_table:Nnn #1#2#3
@@ -5372,6 +5393,7 @@
 \seq_new:N  \l__tenkz_kernel_r_after_atom_seq % physical traces need glyph borders
 \int_new:N  \l__tenkz_kernel_r_rows_int
 \int_new:N  \l__tenkz_kernel_r_cols_int
+\int_new:N  \l__tenkz_kernel_r_species_cycle_int
 \tl_new:N   \l__tenkz_kernel_r_tl
 \tl_new:N   \l__tenkz_kernel_r_b_tl
 \tl_new:N   \l__tenkz_kernel_r_c_tl
@@ -5390,6 +5412,7 @@
 \tl_new:N   \l__tenkz_kernel_r_hue_tl
 \tl_new:N   \l__tenkz_kernel_r_species_tl
 \tl_new:N   \l__tenkz_kernel_r_species_descriptor_tl
+\tl_new:N   \l__tenkz_kernel_r_species_declared_hue_tl
 \tl_new:N   \l__tenkz_kernel_r_mark_side_tl
 \bool_new:N \l__tenkz_kernel_r_mark_side_default_bool
 \bool_new:N \l__tenkz_kernel_r_mark_text_bool
@@ -15598,7 +15621,7 @@
     \quark_if_no_value:NT #2 { \tl_set:Nn #2 {#1} }
   }
 
-% Cache one undeclared or hue-less species in the house cycle.
+% Cache one undeclared non-prelude species in the picture-local house cycle.
 \cs_new_protected:Npn \__tenkz_kernel_r_cycle_hue:nN #1#2
   {
     \prop_get:NnNF \l__tenkz_kernel_r_species_prop {#1} #2
@@ -15608,18 +15631,20 @@
             \clist_item:Nn \c__tenkz_speccycle_clist
               {
                 \int_mod:nn
-                  { \prop_count:N \l__tenkz_kernel_r_species_prop }
+                  { \l__tenkz_kernel_r_species_cycle_int }
                   { \clist_count:N \c__tenkz_speccycle_clist }
                 + 1
               }
           }
         \prop_put:NnV \l__tenkz_kernel_r_species_prop {#1} #2
+        \int_incr:N \l__tenkz_kernel_r_species_cycle_int
       }
   }
 
-% Species -> hue.  An explicit hue is authoritative.  Hue-less declarations
-% and other named species take the house cycle in model-record order; the
-% undeclared prelude roles retain their fixed semantic hues.
+% Species -> hue.  An explicit hue is authoritative.  Hue-less non-prelude
+% declarations reserve document-scope cycle slots, and other non-prelude
+% names take the next picture-local slots in model-record order.  Prelude
+% names retain their fixed semantic hues unless explicitly overridden.
 \cs_new_protected:Npn \__tenkz_kernel_r_hue:nN #1#2
   {
     \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_species_tl
@@ -15630,27 +15655,19 @@
           \l__tenkz_kernel_r_species_tl #2
       }
   }
-% Resolve a species name for every ink consumer.  Declared hues win, hue-less
-% names share the house cycle, and the undeclared prelude roles keep their
-% semantic colors; wires and skin pairings therefore cannot color one species
-% through different lookup paths.
+% Resolve a species name for every ink consumer.  Declared hues win,
+% non-prelude names share the house cycle, and prelude names keep their fixed
+% semantic colors unless explicitly overridden; wires and skin pairings
+% therefore cannot color one species through different lookup paths.
 \cs_new_protected:Npn \__tenkz_kernel_r_species_hue:nN #1#2
   {
     \prop_get:NnNTF \g__tenkz_kernel_species_prop
       {#1} \l__tenkz_kernel_r_species_descriptor_tl
       {
-        \exp_args:NnV \regex_extract_once:nnNTF
-          {
-            (?: \A | , ) \s* hue \s* = \s*
-            (?: \{ \s* )? (?: source: )?
-            ([^,{}\s]+) (?: \s* \} )?
-          }
+        \exp_args:NV \__tenkz_kernel_species_descriptor_hue:nN
           \l__tenkz_kernel_r_species_descriptor_tl
-          \l__tenkz_kernel_r_hue_match_seq
-          {
-            \tl_set:Ne #2
-              { \seq_item:Nn \l__tenkz_kernel_r_hue_match_seq {2} }
-          }
+          #2
+        \tl_if_empty:NT #2
           {
             \prop_get:NnNTF \g__tenkz_kernel_species_hue_prop {#1} #2
               { }
@@ -20049,8 +20066,16 @@
         \clist_if_in:NVT \c__tenkz_kernel_region_words_clist
           \l__tenkz_kernel_r_species_tl
           {
-            \prop_if_in:NVF \g__tenkz_kernel_species_prop
+            \tl_clear:N \l__tenkz_kernel_r_species_declared_hue_tl
+            \prop_get:NVNT \g__tenkz_kernel_species_prop
               \l__tenkz_kernel_r_species_tl
+              \l__tenkz_kernel_r_species_descriptor_tl
+              {
+                \exp_args:NV \__tenkz_kernel_species_descriptor_hue:nN
+                  \l__tenkz_kernel_r_species_descriptor_tl
+                  \l__tenkz_kernel_r_species_declared_hue_tl
+              }
+            \tl_if_empty:NT \l__tenkz_kernel_r_species_declared_hue_tl
               {
                 \__tenkz_model_get:nnN {#1} {form}
                   \l__tenkz_kernel_r_mark_form_tl
@@ -20960,11 +20985,23 @@
 \cs_new:Npn \__tenkz_kernel_r_axis:
   { \l__tenkz_kernel_r_axis_tl }
 
+\cs_new_protected:Npn \__tenkz_kernel_r_species_prepare:
+  {
+    \prop_clear:N \l__tenkz_kernel_r_species_prop
+    % Document-scope hue-less non-prelude declarations reserve their cycle
+    % slots before any picture-local undeclared name is assigned.  Prelude
+    % entries share the hue cache but not the independent cycle count.
+    \int_set_eq:NN
+      \l__tenkz_kernel_r_species_cycle_int
+      \g__tenkz_kernel_species_cycle_int
+    \prop_map_inline:Nn \g__tenkz_kernel_species_hue_prop
+      { \prop_put:Nnn \l__tenkz_kernel_r_species_prop {##1} {##2} }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_render_prepare:
   {
     \prop_clear:N \l__tenkz_kernel_r_placed_prop
     \prop_clear:N \l__tenkz_kernel_r_legdrawn_prop
-    \prop_clear:N \l__tenkz_kernel_r_species_prop
+    \__tenkz_kernel_r_species_prepare:
     \prop_clear:N \l__tenkz_kernel_r_sid_record_prop
     \prop_clear:N \l__tenkz_kernel_r_index_style_prop
     \prop_clear:N \l__tenkz_kernel_r_index_sid_prop
@@ -20975,12 +21012,6 @@
     \seq_clear:N \l__tenkz_kernel_r_skin_routes_seq
     \seq_clear:N \l__tenkz_kernel_r_after_atom_seq
     \seq_clear:N \l__tenkz_kernel_ow_run_stack_seq
-    % Document-scope hue-less declarations reserve their cycle slots before
-    % any picture-local undeclared name is assigned.  An unused declaration
-    % therefore cannot collide with an undeclared identity used earlier in
-    % this picture.
-    \prop_map_inline:Nn \g__tenkz_kernel_species_hue_prop
-      { \prop_put:Nnn \l__tenkz_kernel_r_species_prop {##1} {##2} }
     % Resolve cycle assignment once in declaration order, before renderer
     % staging separates wires from atoms.
     \seq_map_inline:Nn \l__tenkz_model_record_seq


### PR DESCRIPTION
Follow-up to #7151.

PR #7151 merged at `7069c3d6de689d9cdb9f9392dee39e0467872f50` while a `CHANGES_REQUESTED` review remained in its history and before the locally discovered semantic follow-up had completed its gates. This corrective PR contains every hunk that was still missing from that merge.

## Correction

- Give picture rendering an independent species-cycle counter seeded only by ordinary document-scope declarations. A hue-less prelude redeclaration therefore keeps its fixed hue without advancing the next undeclared species.
- Use one descriptor-hue reader for declaration, rendering, and mark-label compatibility.
- Preserve the intended distinction among coloured label-form marks, plain enclosure and bracket labels for compatibility region words, and explicit hue overrides.
- Extend `r_region_words.tex` with no-output assertions for the first undeclared cycle slot before and after a prelude redeclaration, shared-tree hue, renderer hue, all three mark forms, and explicit override.
- Require the retired `slot=` diagnostic to name its actual `mark-N` record, including XeTeX continuation wrapping.
- Correct the active fixture-retirement prose and append the verdict-summary correction to the immutable shrink ledger.

## Exact accounting

The merged #7151 tree and the fully rebased pre-merge integration tree are identical: `3d2250c781e252047350a41d2f7128603ef8b6a9`. The correction was first published as `75acd152291f2d299bf1b88b66b58c14edc3f7f8`, then rebased onto #7153 at base `cea0ec27da7c7a3eed52df3c4685ac312122d4de`. The current exact head is `2ee98a062c5355043508914345ca7ee80505073d`.

The rebase has an identity range-diff, preserves stable patch ID `4c069a96dcc99ab381d885fa85a60b78b461f820`, and changes the same six paths. #7153 touches the shared kernel file only in distant leg-reach hunks. The reviewed pre-rebase head remains preserved at `snapshot/pr-7155-pre-rebase-75acd`. This PR does not reopen the retired parser row or change the census.

## Validation

The complete local gate set passed on the patch-identical pre-rebase head:

- standalone `r_region_words.tex` XeLaTeX compile;
- full kernel probes: 164 regressions, 11 sugar event/pixel equivalences, 14 exact record streams, and byte-identical kernel pixels;
- all 130 RMP targets, exact dimensions, and the benchmark book;
- 9 corpus compiles/audits, 9 golden streams, and 28 string event/pixel artifacts;
- 56 displayed manual examples and 12 reference examples;
- CTAN 57-test suite, deterministic archive, clean installation, smoke, and 8 offline cases;
- release harness, exact-OID compatibility policy, language/tree, shrink append-only/census, Demolition Guard, and disposition gates;
- Blueprint source lint, shared parsers, picture pipeline, equation/overlap/torus/routing/tree tests, paper-gap references, and Blueprint–Lean synchronization (6809/6809).

On exact current head `2ee98a062c5355043508914345ca7ee80505073d`, the full kernel probe again passes all 164 regressions, 11 sugar event/pixel equivalences, 14 exact record streams, and the pixel ledger. Current-head CI supplies the fully provisioned Blueprint web build and the remaining integration gates. The PR was merged only after those checks and exact-head reviews were terminal green.