### PR TITLE
fix(tenkz): align absolute-path scan with TeX grouping

### DIFF
--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -523,11 +523,15 @@ ABSOLUTE_LOAD = re.compile(
     # the specifiers that pass their braced text through as the name are
     # read against a literal path: v and c name a variable or a command
     # whose value is the real argument, so a literal there is a name,
-    # not a path.  N passes its braced text through unexpanded, and a
-    # doubled brace group reaches the file test as the inner group.
+    # not a path.  The n form, its o/x/e/f expansion variants, and
+    # file_input:n take one braced literal; a second group stays in the
+    # file name.  A generated N wrapper consumes one group before it
+    # forwards to the n base, so only a doubled group delivers the full path.
     r"|\\(?:file_input:n"
-    r"|file_if_exist(?:_p:[Nnoxef]|:[Nnoxef](?:TF|T|F)))"
-    rf"\s*\{{\s*\{{?\s*\"?{ABSOLUTE_PATH_HEAD}"
+    r"|file_if_exist(?:_p:[noxef]|:[noxef](?:TF|T|F)))"
+    rf"\s*\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
+    r"|\\file_if_exist(?:_p:N|:N(?:TF|T|F))"
+    rf"\s*\{{\s*\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\open(?:in|out)\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
     r"|\\(?:ior_open|iow_open|file_get|file_get_full_name"

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -1281,6 +1281,9 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\file_if_exist:nF {/Users/somebody/data} {}",
                      r"\file_if_exist:oTF {/Users/somebody/data} {} {}",
                      r"\file_if_exist_p:n {/Users/somebody/data}",
+                     # A generated N wrapper consumes one brace group before
+                     # the n base, so a doubled group delivers the literal path.
+                     r"\file_if_exist:NTF {{/Users/somebody/data}} {} {}",
                      '\\font\\tenkzfont="/Users/somebody/foo.otf"',
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
@@ -1302,7 +1305,14 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                          # An indirect specifier names a variable whose
                          # value is the real argument: a literal there is
                          # a name, not a path.
-                         "\\file_if_exist:vTF {/Users/somebody/data} {} {}\n"):
+                         "\\file_if_exist:vTF {/Users/somebody/data} {} {}\n",
+                         # One group is removed by the generated N wrapper,
+                         # leaving the n base to read only the first path token.
+                         "\\file_if_exist:NTF {/Users/somebody/data} {} {}\n",
+                         # A direct n argument retains the inner group as part
+                         # of the name, rather than stripping a second layer.
+                         "\\file_if_exist:nTF {{/Users/somebody/data}} {} {}\n",
+                         "\\file_input:n {{/Users/somebody/data}}\n"):
             (tree / "tenkz.sty").write_text(innocent, encoding="utf-8")
             relative = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
             assert not relative.failures, (innocent, relative.failures)


### PR DESCRIPTION
### Motivation

- The arXiv absolute-path check gave the same optional second brace to `file_input:n` and every direct existence-conditional spelling. Issue LionSR/tenkz#218 records that these forms do not have the same TeX argument boundary.
- A compiled XeLaTeX probe against an existing absolute file established the boundary before the matcher was changed: a generated `N` wrapper needs two groups to deliver the complete path to the `n` base, while `n`, `o`, `x`, `e`, `f`, and `file_input:n` accept one group and retain a second group in the file name.

### Description

- Split the direct expl3 absolute-load expression into a one-group arm for `file_input:n` and the `n`/`o`/`x`/`e`/`f` existence forms, and a two-group arm for the generated `N` form.
- Add four contract rows: doubled-group `N` remains a finding; single-group `N`, doubled-group `n`, and doubled-group `file_input:n` are innocents.
- Keep the change within the static CTAN/arXiv checker and its contract test. No tenkz parser, registry, census, manual, catalogue, golden baseline, rendering code, or Lean source changes.

The `N` probe explicitly generated the conditional with `\prg_generate_conditional_variant:Nnn \file_if_exist:n {N} {p,T,F,TF}`. With a single braced path, instrumentation showed that the wrapper forwarded only the first `/` token to the `n` base and left both intended branch groups in the input. With a doubled group, it forwarded the complete absolute path and selected only the true branch. Direct doubled-group `n` returned false for the existing file, and doubled-group `file_input:n` reported a name whose leading brace was retained.

### Testing

- Test-first targeted run: the four new rows made the old matcher fail on the three innocents while preserving the doubled-group `N` finding.
- `python3 scripts/test_tenkz_ctan.py` — all 57 contract tests passed, including deterministic archive, clean-install, and eight offline cases.
- `python3 scripts/tenkz_ctan.py check --require-smoke`
- `python3 tests/tenkz/release-harness/selftest.py`; `supervisor.py check-inventory`; `run-all`; `check-readiness`; `pins`
- Corpus evidence: provenance, dimension inventory, render replacement, equation audit, Blueprint sweep, manual extraction, 56 displayed manual examples, and 12 reference examples.
- `scripts/tenkz_kernel_probes.sh` — 164 regressions, 11 sugar equivalences, 14 exact streams, and the pixel ledger passed.
- `TENKZ_CORPUS_JOBS=4 scripts/tenkz_corpus.sh`; `TENKZ_CORPUS_JOBS=4 scripts/tenkz_golden.sh --check`; `scripts/tenkz_string_probes.sh`
- `python3 -m py_compile scripts/tenkz_ctan.py scripts/test_tenkz_ctan.py`; `git diff --check`; reader-facing prose check.

### Agent assistance

OpenAI Codex (GPT-5) performed the compiled audit, prepared the two-file patch, and ran the listed validation. The maintainer remains accountable for the change.

---
Closes LionSR/tenkz#218
