### PR TITLE
refactor(Wielandt): retire residual span-growth pass-throughs

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.BurnsideTheorem
 import TNLean.MPS.CanonicalForm.Reduction
-import TNLean.Wielandt.SpanGrowth.CumulativeSpan
+import QICLean.Kraus.Wielandt.SpanGrowth.CumulativeSpan
 
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 import Mathlib.RingTheory.Noetherian.Defs
@@ -140,14 +140,14 @@ theorem mem_cumulativeSpan_of_mem_algSpan (A : MPSTensor d D)
   | algebraMap r =>
     refine ⟨0, ?_⟩
     rw [Algebra.algebraMap_eq_smul_one]
-    exact (Kraus.cumulativeSpan A 0).smul_mem r (one_mem_cumulativeSpan A 0)
+    exact (Kraus.cumulativeSpan A 0).smul_mem r (Kraus.one_mem_cumulativeSpan A 0)
   | add x y _ _ ihx ihy =>
     rcases ihx with ⟨Nx, hNx⟩
     rcases ihy with ⟨Ny, hNy⟩
     refine ⟨max Nx Ny, ?_⟩
     exact (Kraus.cumulativeSpan A (max Nx Ny)).add_mem
-      ((cumulativeSpan_mono' A (le_max_left Nx Ny)) hNx)
-      ((cumulativeSpan_mono' A (le_max_right Nx Ny)) hNy)
+      ((Kraus.cumulativeSpan_mono' A (le_max_left Nx Ny)) hNx)
+      ((Kraus.cumulativeSpan_mono' A (le_max_right Nx Ny)) hNy)
   | mul x y _ _ ihx ihy =>
     rcases ihx with ⟨Nx, hNx⟩
     rcases ihy with ⟨Ny, hNy⟩
@@ -170,7 +170,7 @@ lemma exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
     isNoetherian_of_isNoetherianRing_of_finite ℂ _
   -- Construct the monotone chain as an order homomorphism
   let f : ℕ →o Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
-    ⟨Kraus.cumulativeSpan A, fun _ _ h => cumulativeSpan_mono' A h⟩
+    ⟨Kraus.cumulativeSpan A, fun _ _ h => Kraus.cumulativeSpan_mono' A h⟩
   -- Noetherian ⟹ the ascending chain stabilizes
   obtain ⟨N₀, hstab⟩ := (monotone_stabilizes_iff_noetherian.mpr ‹_›) f
   -- Show the stable value is ⊤.
@@ -178,7 +178,7 @@ lemma exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
   intro x _
   rcases hx x with ⟨M, hM⟩
   rcases le_total M N₀ with hMN | hNM
-  · exact (cumulativeSpan_mono' A hMN) hM
+  · exact (Kraus.cumulativeSpan_mono' A hMN) hM
   · have heq : Kraus.cumulativeSpan A M = Kraus.cumulativeSpan A N₀ := (hstab M hNM).symm
     simpa [heq] using hM
 

--- a/TNLean/Wielandt/Inequality/Bounds.lean
+++ b/TNLean/Wielandt/Inequality/Bounds.lean
@@ -409,7 +409,7 @@ theorem iIndex_le_general_of_isPrimitivePaper [NeZero D]
       have hInvTop := wordSpan_eq_top_of_isNormal_of_isUnit B i₀ hInv hNB
       -- Use permanence to extend to level D² (since D²-krausRank B+1 ≤ D²)
       have hD2top : Kraus.wordSpan B (D ^ 2) = ⊤ := by
-        apply wordSpan_eq_top_of_ge_of_isUnit B i₀ hInv hInvTop
+        apply Kraus.wordSpan_eq_top_of_ge_of_isUnit B i₀ hInv hInvTop
         have hkB : krausRank B ≤ D ^ 2 := by
           simpa [krausRank] using Kraus.wordSpan_finrank_le B 1
         -- krausRank B ≥ 1 since B i₀ is a unit (hence nonzero) in Kraus.wordSpan B 1

--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -22,18 +22,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Word spans -/
-
-/-- Cumulative word spans are monotone in their length bound. -/
-theorem cumulativeSpan_mono' (A : MPSTensor d D) {n m : ℕ} (h : n ≤ m) :
-    Kraus.cumulativeSpan A n ≤ Kraus.cumulativeSpan A m :=
-  Kraus.cumulativeSpan_mono' A h
-
-/-- The identity matrix belongs to every cumulative word span. -/
-theorem one_mem_cumulativeSpan (A : MPSTensor d D) (n : ℕ) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Kraus.cumulativeSpan A n :=
-  Kraus.one_mem_cumulativeSpan A n
-
 /-! ### Injectivity and normality -/
 
 /-- Block injectivity at a positive length propagates to the next length. -/

--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -39,14 +39,6 @@ theorem krausRank_oneStepAugment (A : MPSTensor d D)
   unfold krausRank
   rw [Kraus.wordSpan_oneStepAugment_eq A hX 1]
 
-/-- If one word span is full and a tensor entry is invertible, every later
-word span is full. -/
-theorem wordSpan_eq_top_of_ge_of_isUnit (A : MPSTensor d D)
-    (i₀ : Fin d) (hU : IsUnit (A i₀)) {N : ℕ}
-    (hN : Kraus.wordSpan A N = ⊤) {m : ℕ} (hm : N ≤ m) :
-    Kraus.wordSpan A m = ⊤ :=
-  Kraus.wordSpan_eq_top_of_ge_of_isUnit A i₀ hU hN hm
-
 private theorem hasEventuallyFullWordSpan_of_isNormal_of_isUnit
     (A : MPSTensor d D) (i₀ : Fin d) (hU : IsUnit (A i₀))
     (hN : Kraus.IsNormal A) : Kraus.HasEventuallyFullWordSpan A := by

--- a/docs/audits/2026-08-25_issue6861_wielandt_pass_through.md
+++ b/docs/audits/2026-08-25_issue6861_wielandt_pass_through.md
@@ -1,0 +1,18 @@
+# Issue #6861: Wielandt pass-through audit at current main
+
+Audited at TNLean `0f80092e302558e7be7076bcd2c321b6b180eef0`, with QICLean v0.2.1 at
+`df9ded03a81d2c02ce1962331777a7a1a87c57b4`.
+
+The project pass-through exception applies: each declaration is a literal
+forward, every non-Archive consumer is migrated, and no Blueprint tag names it.
+
+| Removed declaration | Single source of truth | Migrated consumer |
+|---|---|---|
+| `MPSTensor.cumulativeSpan_mono'` | `Kraus.cumulativeSpan_mono'` | `BurnsideMatrix` |
+| `MPSTensor.one_mem_cumulativeSpan` | `Kraus.one_mem_cumulativeSpan` | `BurnsideMatrix` |
+| `MPSTensor.wordSpan_eq_top_of_ge_of_isUnit` | `Kraus.wordSpan_eq_top_of_ge_of_isUnit` | `Bounds` |
+
+At the audited head, repository-wide search found only the declarations and five
+`BurnsideMatrix` call sites plus one `Bounds` call site; no Archive or docs use.
+The two defining modules remain because their other results are MPS-specific;
+only these duplicate statements are retired in favor of the QICLean owners.


### PR DESCRIPTION
## Summary

This removes three residual TNLean statements that repeat the corresponding QICLean Kraus theorems verbatim:

- `MPSTensor.cumulativeSpan_mono'` in favor of `Kraus.cumulativeSpan_mono'`
- `MPSTensor.one_mem_cumulativeSpan` in favor of `Kraus.one_mem_cumulativeSpan`
- `MPSTensor.wordSpan_eq_top_of_ge_of_isUnit` in favor of `Kraus.wordSpan_eq_top_of_ge_of_isUnit`

Five uses in `BurnsideMatrix` and one use in `Bounds` now call the QICLean owners directly. The two Wielandt modules retain their substantive MPS-specific results.

## Scope and audit

This is a narrow, independently repeated audit of three residual pass-throughs; it does not reopen or claim to complete the broader alias campaign. At current main `0f80092e302558e7be7076bcd2c321b6b180eef0`, repository-wide search found no other non-Archive consumer and no Blueprint or documentation citation. The project pass-through exception therefore permits direct retirement without deprecated aliases. The focused audit is recorded in `docs/audits/2026-08-25_issue6861_wielandt_pass_through.md`.

The four-file source patch has stable patch identifier `a6903dc61146974c3d669765685f9982428f9ccb`, equal to the independently extracted Wielandt slice from snapshot `e3094a8` and integration `69e448606`. Rebasing from `38bf4fbff` to current main gave an equal range-diff.

## Validation

- `lake build TNLean.Algebra.BurnsideMatrix TNLean.Wielandt.Inequality.Bounds TNLean.Wielandt.SpanGrowth.CumulativeSpan TNLean.Wielandt.SpanGrowth.InvertibleWordSpan` (8895/8895)
- `lake build TNLean` (10314/10314)
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint declaration synchronization and changed-declaration coverage
- generated-import checks and 14 import-generator tests
- Lean file-policy tests, numbered-file and size checks
- forbidden-token, tactic-pattern, reader-facing prose, style, and diff checks

Part of #6861.
