### PR TITLE
refactor(MPS): centralize SameMPV and equal-dimension transfer proofs

### DIFF
--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -74,18 +74,19 @@ theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
 def GaugeEquiv (A B : MPSTensor d D) : Prop :=
   ∃ X : GL (Fin D) ℂ, ∀ i : Fin d, B i = X * A i * X⁻¹
 
-/-- Two tensors generate the same MPV family if they produce the same coefficient for every
-system size `N` and every basis configuration `σ : Fin N → Fin d`. -/
-def SameMPV (A B : MPSTensor d D) : Prop :=
-  ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ
-
 /-- MPV equality for possibly different bond dimensions.
 
-This is the version of `SameMPV` for different bond dimensions, used later
-when comparing block decompositions whose summands need not live in the same
-matrix algebra. -/
+This is used when comparing block decompositions whose summands need not live
+in the same matrix algebra. -/
 def SameMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ
+
+/-- Two tensors of the same bond dimension generate the same MPV family if they produce the
+same coefficient for every system size `N` and every basis configuration `σ : Fin N → Fin d`.
+
+This is the same-bond-dimension specialization of `SameMPV₂`. -/
+abbrev SameMPV (A B : MPSTensor d D) : Prop :=
+  SameMPV₂ A B
 
 /-- Positive-length MPV equality for possibly different bond dimensions.
 

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -225,8 +225,7 @@ theorem mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one
     -- `Kraus.mixedTransferMap` and `Kraus.mixedTransferMap₂` agree on `D × D` matrices.
     have hagree :
         Kraus.mixedTransferMap (d := d) (D := D) A B =
-          Kraus.mixedTransferMap₂ (d := d) (D₁ := D) (D₂ := D) A B :=
-      (Kraus.mixedTransferMap₂_same_dim A B).symm
+          Kraus.mixedTransferMap₂ (d := d) (D₁ := D) (D₂ := D) A B := rfl
     rw [← hagree]; exact hsq
   have hzero :
       Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -483,8 +483,6 @@ private lemma mixedTransferSpectralRadius₂_lt_one_of_dim_eq
     Kraus.mixedTransferSpectralRadius₂ A B < 1 := by
   subst hD
   simp only [cast_eq] at hgpe
-  rw [Kraus.mixedTransferSpectralRadius₂_eq, Kraus.mixedTransferMap₂_same_dim,
-    ← Kraus.mixedTransferSpectralRadius_eq]
   exact spectralRadius_mixedTransfer_lt_one_of_irreducible_TP A B hA_irr hB_irr
     hA_left hB_left hgpe
 

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -114,9 +114,8 @@ theorem mpvOverlap_tendsto_zero_of_irreducible_TP [NeZero D]
     (hAB : ¬ GaugePhaseEquiv A B) :
     Filter.Tendsto (fun N => mpvOverlap A B N) Filter.atTop (nhds 0) :=
   mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one (A := A) (B := B) <|
-    by simpa only [Kraus.mixedTransferMap₂_same_dim, Kraus.mixedTransferSpectralRadius] using
-      spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
-        A B hA_irr hB_irr hA_left hB_left hAB
+    spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
+      A B hA_irr hB_irr hA_left hB_left hAB
 
 /-- Rectangular strict transfer-operator gap for irreducible left-canonical blocks of different
 bond sizes. -/

--- a/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
+++ b/docs/audits/2026-08-23_issue6855_core_compatibility_thinning.md
@@ -75,3 +75,20 @@ The remaining differently named cast helpers in
 `NormalizedGroupedSectorMaps.lean` and
 `BNTAlgebraTensorClauseDirectSumUnitary.lean` have different dependent
 contexts and are not claimed by this migration.
+
+## MPV and mixed transfer (re-audited 2026-08-25)
+
+At TNLean `c626a7a51377368b886fe919d93e5e61e7fd2c9a`, with QICLean at
+`df9ded03a81d2c02ce1962331777a7a1a87c57b4`, `MPSTensor.SameMPV` and
+`MPSTensor.SameMPV₂` have identical propositions when the two bond dimensions
+agree. The public name `SameMPV` therefore remains as the equal-dimension
+abbreviation of `SameMPV₂`; `SameMPV₂Pos` remains distinct because it omits the
+chain-length-zero condition. The Archive use and the Blueprint declarations
+naming `SameMPV` and its namespace remain unchanged.
+
+The three TNLean uses of `Kraus.mixedTransferMap₂_same_dim`, in
+`MPS/FundamentalTheorem/Proportional.lean`, `MPS/RFP/BNTOrthogonality.lean`,
+and `Spectral/TransferOperatorGapNT.lean`, are replaced by definitional
+equality. QICLean retains the bridge because its mixed-transfer iteration,
+self-transfer, and normalized spectral-radius results still use it; removing
+that upstream interface is outside this TNLean-local migration.


### PR DESCRIPTION
### Motivation

- `MPSTensor.SameMPV` and the equal-bond-dimension specialization of `SameMPV₂` state the same coefficient equality for every chain length, including zero.
- Three TNLean proofs still crossed the square-to-rectangular mixed-transfer bridge even though the maps are definitionally equal at equal bond dimension.
- This is the TNLean-local part of item 7 in the structural proof-debt audit; QICLean still has internal consumers of its bridge.

### Description

- Retain `MPSTensor.SameMPV` as the public equal-bond-dimension abbreviation of `SameMPV₂`.
- Replace all three TNLean uses of `Kraus.mixedTransferMap₂_same_dim` by the underlying definitional equality.
- Append a focused current-head liveness audit recording the preserved Archive and Blueprint names and the QICLean consumers which require the upstream bridge to remain.

No theorem statement, hypothesis, or mathematical conclusion changes. In particular, `SameMPV` still includes the chain-length-zero equation, while `SameMPV₂Pos` remains the distinct positive-length relation. The public `SameMPV` name and its namespace are preserved.

Changing `SameMPV` from a definition to an abbreviation intentionally makes it reducible. The full build confirms that existing named and dot-notation APIs continue to elaborate with this transparency.

This does not retire the QICLean bridge. The two unrelated `show`-to-`change` style edits from the earlier snapshot were also deliberately excluded.

### Testing

- `lake build TNLean.MPS.Defs TNLean.MPS.FundamentalTheorem.Proportional TNLean.MPS.RFP.BNTOrthogonality TNLean.Spectral.TransferOperatorGapNT TNLean.Archive.BlockSepCounterexample`
- `lake build TNLean` (10,314 jobs)
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --warn-missing-blueprint --changed-files ... --diff-base origin/main --diff-head HEAD`
- `lake exe checkdecls blueprint/lean_decls`
- proof-integrity, import-aggregator, policy, tactic-pattern, reader-facing-prose, and diff checks
- verified zero remaining TNLean uses of `Kraus.mixedTransferMap₂_same_dim`

Part of #6855.
