### PR TITLE
ci(readme): add blueprint leanok coverage badges

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate badge JSON
         run: |
-          python3 scripts/generate_badges.py --output-dir badge-output
+          python3 scripts/generate_badges.py --output-dir badge-output --blueprint-src blueprint/src
           json_count=$(find badge-output -maxdepth 1 -name '*.json' | wc -l)
           if [ "$json_count" -eq 0 ]; then
             echo "::error::No badge JSON generated — refusing to publish empty badges"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 ![axioms](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/axioms.json)
 ![Lean](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/lean.json)
 ![Mathlib](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/mathlib.json)
+![blueprint: no \leanok](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/blueprint_no_leanok.json)
+![blueprint: not ready](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/blueprint_not_ready.json)
 
 <p align="center">
   <a href="https://sirui-lu.com/TNLean/blueprint/">Blueprint</a> ·

--- a/home_page/badges/blueprint_no_leanok.json
+++ b/home_page/badges/blueprint_no_leanok.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "label": "axioms",
+  "label": "blueprint: no \\leanok",
   "message": "0",
   "color": "brightgreen"
 }

--- a/home_page/badges/blueprint_not_ready.json
+++ b/home_page/badges/blueprint_not_ready.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "blueprint: not ready",
+  "message": "132",
+  "color": "orange"
+}

--- a/home_page/badges/lean.json
+++ b/home_page/badges/lean.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Lean",
-  "message": "v4.29.0",
+  "message": "v4.34.0-rc1",
   "color": "blue"
 }

--- a/home_page/badges/mathlib.json
+++ b/home_page/badges/mathlib.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Mathlib",
-  "message": "v4.29.0",
+  "message": "v4.34.0-rc1",
   "color": "blue"
 }

--- a/home_page/badges/sorries.json
+++ b/home_page/badges/sorries.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "sorries",
-  "message": "20",
-  "color": "orange"
+  "message": "0",
+  "color": "brightgreen"
 }

--- a/scripts/write_badges.py
+++ b/scripts/write_badges.py
@@ -13,11 +13,18 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 LEAN_ROOT = ROOT / "TNLean"
+BLUEPRINT_SRC = ROOT / "blueprint" / "src"
+
+_PROOF_BEARING_ENV_TYPES: frozenset[str] = frozenset(
+    {"theorem", "lemma", "proposition", "corollary"}
+)
+_SKIP_ENV_TYPES: frozenset[str] = frozenset({"remark", "example"})
 
 
 def strip_lean_comments_and_strings(text: str) -> str:
@@ -114,12 +121,43 @@ def write_badge(name: str, label: str, message: str, color: str, badge_dir: Path
     (badge_dir / f"{name}.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 
-def count_color(count: int, *, warning_at: int = 1) -> str:
+def count_color(count: int, *, warning_at: int = 1, danger_at: int | None = None) -> str:
     if count == 0:
         return "brightgreen"
     if count <= warning_at:
         return "yellow"
+    if danger_at is not None and count >= danger_at:
+        return "red"
     return "orange"
+
+
+def blueprint_badge_counts() -> tuple[int, int]:
+    """Return (no_leanok_count, not_ready_count) for unique blueprint declarations."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from blueprint_lean_sync import collect_blueprint_entries
+
+    entries = collect_blueprint_entries(BLUEPRINT_SRC)
+    decl_entries: dict[str, list] = defaultdict(list)
+    for entry in entries:
+        decl_entries[entry.lean_decl].append(entry)
+
+    no_leanok = 0
+    not_ready = 0
+    for elist in decl_entries.values():
+        has_stmt = any(e.has_leanok for e in elist)
+        has_proof = any(e.proof_has_leanok for e in elist)
+        env_types = {e.env_type for e in elist}
+        if not has_stmt and not has_proof:
+            no_leanok += 1
+        if env_types <= _SKIP_ENV_TYPES:
+            continue
+        is_proof_bearing = bool(env_types & _PROOF_BEARING_ENV_TYPES)
+        if is_proof_bearing:
+            if not (has_stmt and has_proof):
+                not_ready += 1
+        elif not has_stmt:
+            not_ready += 1
+    return no_leanok, not_ready
 
 
 def main() -> None:
@@ -130,6 +168,21 @@ def main() -> None:
     write_badge("axioms", "axioms", str(axioms), count_color(axioms, warning_at=0), badge_dir)
     write_badge("lean", "Lean", lean_version(), "blue", badge_dir)
     write_badge("mathlib", "Mathlib", mathlib_version(), "blue", badge_dir)
+    no_leanok, not_ready = blueprint_badge_counts()
+    write_badge(
+        "blueprint_no_leanok",
+        r"blueprint: no \leanok",
+        str(no_leanok),
+        count_color(no_leanok, warning_at=100, danger_at=300),
+        badge_dir,
+    )
+    write_badge(
+        "blueprint_not_ready",
+        "blueprint: not ready",
+        str(not_ready),
+        count_color(not_ready, warning_at=100, danger_at=300),
+        badge_dir,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add the MIPStarRE blueprint-readiness badges: `blueprint: no \leanok` and `blueprint: not ready`.
- Pass `--blueprint-src` to the weekly badge job, and emit the same JSON from `write_badges.py` so blueprint/docgen deploys serve them.

## Test plan
- [ ] `python3 scripts/write_badges.py home_page/badges` writes the two new JSON files.
- [ ] After merge and Pages deploy, both badges render on the GitHub README.