### PR TITLE
ci(pages): clear remaining Node 20 warning

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./scripts/assemble-pages-site.sh components _site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 


### PR DESCRIPTION
## What changed

- update `actions/upload-pages-artifact` from v3 to v5
- remove the remaining Node 20 deprecation annotation from the Pages deployment job

`upload-pages-artifact@v5` delegates to `actions/upload-artifact@v7`, whose action runtime targets Node 24. The inputs used here are unchanged.

## Validation

- parsed `.github/workflows/deploy-pages.yml` as YAML
- `git diff --check`

Follow-up to #7171, whose exact post-merge Blueprint run `32884514545` exposed this nested action warning.
