### PR TITLE
refactor(qiclean): consume canonical mapLM APIs

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -91,11 +91,11 @@ theorem exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor
     exact hIrrAdj
   -- A positive definite fixed point for `Kraus.transferMap A`, hence for `Kraus.adjointMap K`.
   have hCh : IsChannel (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isChannel_transferMap (d := d) (D := D) A (by unfold Kraus.IsTP; convert hTP)
+    Kraus.isChannel_mapLM (d := d) (D := D) A (by unfold Kraus.IsTP; convert hTP)
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     hCh.exists_posSemidef_fixedPoint (E := Kraus.transferMap (d := d) (D := D) A) hDpos
   have hIrrAmap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily (d := d) (D := D) A hIrrT
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily (d := d) (D := D) A hIrrT
   have hρ_pd : ρ.PosDef :=
     Kraus.posSemidef_fixedPoint_isPosDef_of_irreducible (A := A) (d := d) (D := D)
       hIrrAmap ρ hρ_psd hρ_ne hρ_fix

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -170,13 +170,13 @@ theorem of_gaugeEquiv {A B : MPSTensor d D} (hB : IsNormalTensor B)
   obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
   refine ⟨?_, ?_, ?_⟩
   · have hIrrB : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) B) :=
-      Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily B hB.no_invariant_proj
+      Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily B hB.no_invariant_proj
     have hIrrA : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) := by
       have hIrrSim : IsIrreducibleMap
           (similarityMap (D := D) C (Kraus.transferMap (d := d) (D := D) A)) := by
         simpa [hMap] using hIrrB
       exact (isIrreducibleMap_similarity_iff (D := D) hC).1 hIrrSim
-    exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hIrrA
+    exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hIrrA
   · have hsr := hB.spectral_radius_one
     rw [hMap] at hsr
     rw [spectralRadius_similarityMap_eq (D := D) C hC
@@ -227,7 +227,7 @@ theorem exists_tpGauge_of_irreducible_spectralRadius_one
     rw [hmap] at hspectral
     simp at hspectral
   have hIrrMap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr
   obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
     exists_posDef_transferMap_eigenvector_of_irreducible A hIrr hA
   have hradius :
@@ -331,7 +331,7 @@ theorem isNormalTensor_of_isNormal_leftCanonical [NeZero D]
     isNormal_implies_stronglyIrreducible A hLeft hNormal
   obtain ⟨ρ, hρ, hρfix⟩ := hStrong.posDef_fixedPoint
   have hIrr : Kraus.IsIrreducibleFamily A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hStrong.isIrreducibleMap
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hStrong.isIrreducibleMap
   have huniq : ∀ μ : ℂ, Module.End.HasEigenvalue (Kraus.transferMap A) μ →
       ‖μ‖ = (1 : ℝ) → μ = (1 : ℂ) := by
     intro μ hμ hμnorm

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -6,7 +6,8 @@ Authors: TNLean contributors
 import QICLean.Algebra.DependentBlockDiagonal
 import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
 import TNLean.MPS.CanonicalForm.Definitions
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.Irreducible.FormII
 import QICLean.Channel.Irreducible.PerronFrobenius
@@ -264,7 +265,7 @@ theorem exists_posDef_transferMap_eigenvector_of_irreducible {n : ℕ} [NeZero n
   obtain ⟨ρ, r, hρ, hr, hEig⟩ :=
     exists_posDef_eigenvector_of_irreducible_cp (Kraus.transferMap (d := d) (D := n) B)
       (Kraus.transferMap_isCPMap B)
-      (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily B hIrr) hne
+      (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily B hIrr) hne
   exact ⟨ρ, r, hρ, hr, hEig⟩
 
 /-- **Spectral normalization of an irreducible block** (arXiv:1606.00608,
@@ -314,7 +315,7 @@ theorem isNormalTensor_invSqrt_smul_of_unique_peripheral {n : ℕ} [NeZero n]
         (Kraus.transferMap (d := d) (D := n)
           (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i))
         (Kraus.transferMap_isCPMap _)
-        (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily _ hIrrScaled)
+        (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily _ hIrrScaled)
         ρ 1 hρ (by norm_num) (by simpa using hfix))
   · refine isPrimitive_of_unique_norm_one _ ρ hfix hρ_ne ?_
     intro μ hμ hμnorm

--- a/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
@@ -55,7 +55,7 @@ with the PSD fixed point `ρ` of the original transfer map:
    and `N^{Pk} σ' = σ'` (from `E^P σ' = σ'`), but `N^n → 0`, we get `σ' = 0`.
 4. Apply `isIrreducibleMap_of_channel_posDef_fixedPoint_unique` →
    `IsIrreducibleMap (Kraus.transferMap (blockTensor A P))`
-5. Apply `Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap` →
+5. Apply `Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM` →
    `Kraus.IsIrreducibleFamily (blockTensor A P)`
 -/
 
@@ -88,7 +88,7 @@ theorem isIrreducibleTensor_blockTensor_of_tp_primitive_irr [NeZero D]
     leftCanonical_blockTensor A P hTP
   -- Step 3: Blocked transfer map is a channel.
   have hCh : IsChannel (Kraus.transferMap (d := blockPhysDim d P) (D := D) (blockTensor A P)) :=
-    Kraus.isChannel_transferMap (blockTensor A P) hTP_blocked
+    Kraus.isChannel_mapLM (blockTensor A P) hTP_blocked
   -- Step 4: ρ is fixed by the blocked transfer map.
   have hρ_fix_blocked :
       Kraus.transferMap (d := blockPhysDim d P) (D := D) (blockTensor A P) ρ = ρ :=
@@ -136,7 +136,7 @@ theorem isIrreducibleTensor_blockTensor_of_tp_primitive_irr [NeZero D]
       -- E^{Pk} = Pρ + N^{Pk} (from pow_eq_fixedPointProj_add_compl_pow).
       have hdecomp : (E ^ (P * k)) σ' = Pρ σ' + (N ^ (P * k)) σ' := by
         have h := pow_eq_fixedPointProj_add_compl_pow E hPrimMPS.trace_ne_zero
-          (Kraus.isChannel_transferMap _ hPrimMPS.norm).tp hPrimMPS.fixedPoint_is_fixed hPk_pos
+          (Kraus.isChannel_mapLM _ hPrimMPS.norm).tp hPrimMPS.fixedPoint_is_fixed hPk_pos
         have happ := congrArg (fun T => T σ') h
         simpa [Pρ_def, N_def, LinearMap.add_apply] using happ
       -- E^{Pk} σ' = σ' (from hEPk_σ').
@@ -199,7 +199,7 @@ theorem isIrreducibleTensor_blockTensor_of_tp_primitive_irr [NeZero D]
       (Kraus.transferMap (d := blockPhysDim d P) (D := D) (blockTensor A P))
       hCh ρ hPD hρ_fix_blocked huniq
   -- Step 7: IsIrreducibleMap → Kraus.IsIrreducibleFamily.
-  exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap (blockTensor A P) hIrrMap
+  exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM (blockTensor A P) hIrrMap
 
 /-- **Extra blocking after period removal.**
 

--- a/TNLean/MPS/Core/PhysicalIndexMixing.lean
+++ b/TNLean/MPS/Core/PhysicalIndexMixing.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Channel.KrausMap
 import QICLean.Channel.KrausRepresentation
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Core.CanonicalNormalization
 
 /-!
@@ -46,7 +47,7 @@ theorem isLeftCanonical_kraus_isometry
   have hCh : IsChannel (Kraus.transferMap C) := by
     have hEq : Kraus.transferMap C = Kraus.transferMap B := by
       simpa [C] using transferMap_kraus_isometry B W hW
-    simpa [hEq] using Kraus.isChannel_transferMap B hB
+    simpa [hEq] using Kraus.isChannel_mapLM B hB
   change IsLeftCanonical C
   rw [IsLeftCanonical]
   exact kraus_sum_conjTranspose_mul_of_tp C (Kraus.transferMap C)

--- a/TNLean/MPS/FundamentalTheorem/UnitaryGauge.lean
+++ b/TNLean/MPS/FundamentalTheorem/UnitaryGauge.lean
@@ -103,7 +103,7 @@ theorem gaugePhase_scalar_norm_eq_one_of_leftCanonical_irreducible
   obtain ⟨τ, hτ_psd, hτ_ne, hτ_fix⟩ :=
     Kraus.exists_posSemidef_fixedPoint B hB_left (NeZero.pos D)
   have hB_irrMap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) B) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily B hB_irr
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily B hB_irr
   have hB_cp : IsCPMap (Kraus.transferMap (d := d) (D := D) B) := Kraus.transferMap_isCPMap B
   have hEB_eq : ∀ Y, Kraus.transferMap (d := d) (D := D) B Y =
       (ζ * starRingEnd ℂ ζ) •

--- a/TNLean/MPS/Irreducible/Adjoint.lean
+++ b/TNLean/MPS/Irreducible/Adjoint.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Irreducible.FormII
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import QICLean.Channel.Irreducible.AdjointFamily
 import QICLean.Channel.Schwarz.KadisonSchwarz
 
@@ -57,7 +58,7 @@ theorem exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleT
       Kraus.isIrreducibleMap_mapLM_conjTranspose A
         (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr)
   have hIrrAdj : Kraus.IsIrreducibleFamily (d := d) (D := D) Aadj :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap Aadj hIrrAdjMap
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM Aadj hIrrAdjMap
   obtain ⟨U, Λ, hΛ_pd, hΛ_diag, hTP_conj, hΛ_fix⟩ :=
     exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
       (d := d) (D := D) Aadj hTPadj hIrrAdj hD

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -6,7 +6,9 @@ Authors: TNLean contributors
 import TNLean.MPS.CanonicalForm.Reduction
 import QICLean.Algebra.MatrixAux
 import QICLean.Channel.FixedPoint.SupportInvariance
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import QICLean.QPF.Assembly
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 
@@ -139,13 +141,13 @@ theorem exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
           (fun i => (↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) Λ = Λ := by
   -- Step 1: The transfer map is a channel (from TP hypothesis).
   have hCh : IsChannel (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isChannel_transferMap A (by unfold Kraus.IsTP; convert hTP)
+    Kraus.isChannel_mapLM A (by unfold Kraus.IsTP; convert hTP)
   -- Step 2: Get a PSD fixed point ρ ≠ 0 from the channel.
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     hCh.exists_posSemidef_fixedPoint (E := Kraus.transferMap (d := d) (D := D) A) hD
   -- Step 3: Convert irreducibility: tensor → CP map.
   have hIrrCP : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr
   -- Step 4: Upgrade PSD to PD via quantum Perron–Frobenius.
   have hρ_pd : ρ.PosDef :=
     Kraus.posSemidef_fixedPoint_isPosDef_of_irreducible A hIrrCP ρ hρ_psd hρ_ne hρ_fix

--- a/TNLean/MPS/Irreducible/PerronGauge.lean
+++ b/TNLean/MPS/Irreducible/PerronGauge.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.PerronFrobenius.Existence
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.FormII
@@ -61,8 +62,7 @@ theorem exists_posDef_adjoint_eigenvector
       Kraus.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = (r : ℂ) • σ := by
   obtain ⟨σ, r, hσ_pd, hr_pos, hσ_eig⟩ :=
     Kraus.exists_posDef_adjoint_eigenvector (K := A)
-      (Kraus.isIrreducibleMap_mapLM_of_transferMap _
-        (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr)) hA
+      (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr) hA
   refine ⟨σ, r, hσ_pd, hr_pos, ?_⟩
   exact hσ_eig
 
@@ -132,7 +132,7 @@ theorem exists_unital_data_of_irreducible
       Kraus.isIrreducibleMap_mapLM_conjTranspose A
         (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr)
   have hIrrAdj : Kraus.IsIrreducibleFamily (d := d) (D := D) Aadj :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap Aadj hIrrAdjMap
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM Aadj hIrrAdjMap
   have hAadj : ∃ i, Aadj i ≠ 0 := by
     rcases hA with ⟨i, hi⟩
     refine ⟨i, ?_⟩

--- a/TNLean/MPS/Irreducible/ScalarFixedPoint.lean
+++ b/TNLean/MPS/Irreducible/ScalarFixedPoint.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Irreducible.FormII
 import QICLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary
 
@@ -55,7 +56,7 @@ theorem fixed_eq_scalar_of_isIrreducibleTensor_unital
     simpa [Kraus.transferMap_apply, Matrix.mul_one, KadisonSchwarz.IsUnitalKraus]
       using hUnital
   have hIrrMap : IsIrreducibleMap (Kraus.mapLM A) := by
-        exact Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr
+        exact Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr
   have hfix_map : Kraus.mapLM A X = X := by exact hfix
   exact Kraus.fixed_eq_scalar_of_irreducible_unital A hUnitalKraus hIrrMap X hfix_map
 

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -125,7 +125,7 @@ theorem spectralUnitalGauge_schwarz_setup [NeZero D]
     exact h
   have hIrrMap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D)
       (spectralUnitalGauge B rad ρ)) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily _ hIrrK
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily _ hIrrK
   refine ⟨hUnital, hIrrK, hIrrMap, ?_⟩
   -- The adjoint of a unital family is trace-preserving; its transfer map is a
   -- channel and has a positive semidefinite fixed point, which irreducibility
@@ -134,7 +134,7 @@ theorem spectralUnitalGauge_schwarz_setup [NeZero D]
   have hTPadj : ∑ v : Fin d, ((K v)ᴴ)ᴴ * (K v)ᴴ = 1 := by
     simpa [Matrix.conjTranspose_conjTranspose] using hUnital
   have hCh : IsChannel (Kraus.transferMap (d := d) (D := D) (fun v => (K v)ᴴ)) :=
-    Kraus.isChannel_transferMap (fun v => (K v)ᴴ) hTPadj
+    Kraus.isChannel_mapLM (fun v => (K v)ᴴ) hTPadj
   obtain ⟨σ, hσ_psd, hσ_ne, hσ_fix⟩ :=
     hCh.exists_posSemidef_fixedPoint
       (E := Kraus.transferMap (d := d) (D := D) (fun v => (K v)ᴴ)) (NeZero.pos D)

--- a/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
+++ b/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
@@ -326,7 +326,7 @@ theorem exists_normalTensor_scalar_representation :
       (spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
         (Kraus.transferMap A.toMPSTensor)
         (Kraus.transferMap_isCPMap A.toMPSTensor)
-        (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+        (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily
           A.toMPSTensor hAIrr)
         rho 1 hrho (by norm_num) (by simpa using hfix))
   obtain ⟨sigma, hsigma, hsigmaFix, hLeft, hGauge, hGaugeIrr⟩ :=

--- a/TNLean/MPS/MPDO/PhysicalIsometricEmbedding.lean
+++ b/TNLean/MPS/MPDO/PhysicalIsometricEmbedding.lean
@@ -181,9 +181,11 @@ theorem isNormalTensor_toMPSTensor_changePhysicalBasis_iff
   constructor
   · intro hC
     refine ⟨?_, ?_, ?_⟩
-    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap
-      have hIrr := Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM
+      have hIrr := Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily
         (changePhysicalBasis V K).toMPSTensor hC.no_invariant_proj
+      change IsIrreducibleMap
+        (Kraus.transferMap (changePhysicalBasis V K).toMPSTensor) at hIrr
       rw [hTransfer] at hIrr
       exact hIrr
     · rw [← hTransfer]
@@ -192,9 +194,12 @@ theorem isNormalTensor_toMPSTensor_changePhysicalBasis_iff
       exact hC.primitive_transfer
   · intro hB
     refine ⟨?_, ?_, ?_⟩
-    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap
-      have hIrr := Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+    · apply Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM
+      have hIrr := Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily
         K.toMPSTensor hB.no_invariant_proj
+      change IsIrreducibleMap (Kraus.transferMap K.toMPSTensor) at hIrr
+      change IsIrreducibleMap
+        (Kraus.transferMap (changePhysicalBasis V K).toMPSTensor)
       rw [hTransfer]
       exact hIrr
     · rw [hTransfer]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -276,7 +276,7 @@ theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_d
     HasIrreducibleBlocks.ofForall fun j =>
       isIrreducibleTensor_tpGauge_of_isIrreducibleMap
         (A j) (Λ j) (hΛ j)
-        (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily (A j) (hIrr.block_irreducible j))
+        (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily (A j) (hIrr.block_irreducible j))
   have hPreparedLeft : IsLeftCanonicalBlockFamily (d := d) prepared :=
     IsLeftCanonicalBlockFamily.ofForall fun j =>
       tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint

--- a/TNLean/MPS/Periodic/SectorIrreducibility/HLift.lean
+++ b/TNLean/MPS/Periodic/SectorIrreducibility/HLift.lean
@@ -272,7 +272,7 @@ theorem hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity
     Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
       ((Kraus.isIrreducibleMap_mapLM_conjTranspose_iff A).mp hIrrAdj)
   have hIrr : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrrTensor
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrrTensor
   intro k Q hQproj hQP hPQ hQcorner
   have hQfix : (T ^ m) Q = Q := by
     simpa [T] using

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -95,10 +95,10 @@ theorem isPeriodic_kraus_isometry
   have hEq : Kraus.transferMap C = Kraus.transferMap B := by
     simpa [C] using transferMap_kraus_isometry B W hW
   have hIrrMapB : IsIrreducibleMap (Kraus.transferMap B) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily B hB.irreducible
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily B hB.irreducible
   have hIrrMapC : IsIrreducibleMap (Kraus.transferMap C) := by
     simpa [hEq] using hIrrMapB
-  refine ⟨Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap C hIrrMapC,
+  refine ⟨Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM C hIrrMapC,
     isLeftCanonical_kraus_isometry B W hW hB.leftCanonical,
     hB.period_pos, ?_⟩
   simpa [C, hEq] using hB.peripheral_eq
@@ -275,7 +275,7 @@ transfer map `E_A` is a CPTP channel) *and* the channel-level matching
 
 The proof combines the channel-level blocking identity `E_{A^{[p]}} = (E_A)^p`
 (`MPSTensor.transferMap_blockTensor`) with the left-canonical channel property
-`Kraus.isChannel_transferMap`. The bridging from the direct coefficient-level
+`Kraus.isChannel_mapLM`. The bridging from the direct coefficient-level
 `IsPRefinable B p` hypothesis to this witness is handled in
 `thm_4_1_p_refinement_forward` below. -/
 theorem thm_4_1_p_refinement_forward_witness
@@ -284,7 +284,7 @@ theorem thm_4_1_p_refinement_forward_witness
     (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hTransferEq : Kraus.transferMap B = Kraus.transferMap (blockTensor A p)) :
     IsPDivisibleChannel (Kraus.transferMap B) p :=
-  ⟨Kraus.transferMap A, Kraus.isChannel_transferMap A hA_norm, by
+  ⟨Kraus.transferMap A, Kraus.isChannel_mapLM A hA_norm, by
     rw [hTransferEq, transferMap_blockTensor]⟩
 
 /-- **Blocked \(Z\)-gauge extraction for the periodic equal-case step.**

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -144,7 +144,7 @@ theorem rfp_nt_cfii_diagonal_fixedPoint [NeZero D]
   have hIrrMap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
     Kraus.injective_implies_irreducibleCP A hInj
   have hIrrTensor : Kraus.IsIrreducibleFamily (d := d) (D := D) A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hIrrMap
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hIrrMap
   have hD : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   exact exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
     (d := d) (D := D) A hLeft hIrrTensor hD

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -271,9 +271,9 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
   let : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
   let E := Kraus.transferMap (P.basis j)
   have hCh : IsChannel E :=
-    Kraus.isChannel_transferMap (P.basis j) (hCF.basis_left_canonical j)
+    Kraus.isChannel_mapLM (P.basis j) (hCF.basis_left_canonical j)
   have hIrr : IsIrreducibleMap E :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily
       (P.basis j) (hCF.basis_irreducible j)
   let ρ := Channel.stationaryState E hCh hIrr (hCF.basis_dim_pos j)
   have hρ := Channel.stationaryState_spec hCh hIrr (hCF.basis_dim_pos j)
@@ -473,9 +473,9 @@ theorem exists_basis_physicalObservables_expectation_eq_trace_mul_transferMap_po
   let : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
   let E := Kraus.transferMap (P.basis j)
   have hCh : IsChannel E :=
-    Kraus.isChannel_transferMap (P.basis j) (hCF.basis_left_canonical j)
+    Kraus.isChannel_mapLM (P.basis j) (hCF.basis_left_canonical j)
   have hIrr : IsIrreducibleMap E :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily
       (P.basis j) (hCF.basis_irreducible j)
   let ρ := Channel.stationaryState E hCh hIrr (hCF.basis_dim_pos j)
   have hρ := Channel.stationaryState_spec hCh hIrr (hCF.basis_dim_pos j)

--- a/TNLean/MPS/SharedInfra/KrausAdjointSetup.lean
+++ b/TNLean/MPS/SharedInfra/KrausAdjointSetup.lean
@@ -48,11 +48,11 @@ theorem conjTranspose_kraus_setup
     Kraus.isIrreducibleMap_mapLM_conjTranspose A
       (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr)
   have hCh : IsChannel (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isChannel_transferMap (d := d) (D := D) A (by unfold Kraus.IsTP; convert hTP)
+    Kraus.isChannel_mapLM (d := d) (D := D) A (by unfold Kraus.IsTP; convert hTP)
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
     hCh.exists_posSemidef_fixedPoint (E := Kraus.transferMap (d := d) (D := D) A) hDpos
   have hIrrAmap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily (d := d) (D := D) A hIrr
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily (d := d) (D := D) A hIrr
   have hρ_pd : ρ.PosDef :=
     Kraus.posSemidef_fixedPoint_isPosDef_of_irreducible (A := A) (d := d) (D := D)
       hIrrAmap ρ hρ_psd hρ_ne hρ_fix

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -120,7 +120,7 @@ lemma isIrreducibleTensor_tpGauge_of_isIrreducibleMap [NeZero D]
   have hIrr' : IsIrreducibleMap
       (Kraus.transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) := by
     simpa [hEq] using hIrrSim
-  exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap _ hIrr'
+  exact Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM _ hIrr'
 
 /-- Gauge equivalence on the left and right transports a gauge-phase
 equivalence back to the original tensors. -/
@@ -209,7 +209,7 @@ noncomputable def twistedTPGaugeSetup [NeZero D]
   have hIrrB : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) B) := by
     simpa [hEqBA] using hIrrA
   have hIrrTensor : Kraus.IsIrreducibleFamily (d := d) (D := D) A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hIrrA
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hIrrA
   have hIrrAdj : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) fun i => (A i)ᴴ) :=
     Kraus.isIrreducibleMap_mapLM_conjTranspose A
       (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrrTensor)
@@ -218,7 +218,7 @@ noncomputable def twistedTPGaugeSetup [NeZero D]
       kraus_sum_mul_conjTranspose_of_unital A (Kraus.transferMap A)
         (fun X => by simp [Kraus.transferMap_apply]) hNorm
   have hChAdj : IsChannel (Kraus.transferMap (d := d) (D := D) fun i => (A i)ᴴ) :=
-    Kraus.isChannel_transferMap (fun i => (A i)ᴴ) hAadjNorm
+    Kraus.isChannel_mapLM (fun i => (A i)ᴴ) hAadjNorm
   let hσ_exists :=
     IsChannel.exists_unique_density_fixedPoint_of_irreducible
       (E := Kraus.transferMap (d := d) (D := D) fun i => (A i)ᴴ) hChAdj hIrrAdj (NeZero.pos D)
@@ -790,7 +790,7 @@ theorem boundaryState_invariant_of_virtualUnitary
   have hIrrA : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
     Kraus.injective_implies_irreducibleCP A hA
   have hIrrTensor : Kraus.IsIrreducibleFamily (d := d) (D := D) A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hIrrA
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hIrrA
   have hIrrAdj :
       IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) fun i => (A i)ᴴ) :=
     Kraus.isIrreducibleMap_mapLM_conjTranspose A

--- a/TNLean/Spectral/CrossCorrelation.lean
+++ b/TNLean/Spectral/CrossCorrelation.lean
@@ -60,10 +60,8 @@ theorem cross_correlation_tendsto_zero
     fun h => hAB (gaugePhaseEquiv_of_krausGaugePhaseEquiv h)
   simpa [Kraus.mixedTransferMap] using
     Kraus.cross_correlation_tendsto_zero A B
-      (Kraus.isIrreducibleMap_mapLM_of_transferMap A
-        (Kraus.injective_implies_irreducibleCP A hA))
-      (Kraus.isIrreducibleMap_mapLM_of_transferMap B
-        (Kraus.injective_implies_irreducibleCP B hB))
+      (Kraus.injective_implies_irreducibleCP A hA)
+      (Kraus.injective_implies_irreducibleCP B hB)
       hA_norm hB_norm hK X
 
 

--- a/TNLean/Spectral/PeripheralToTransferMapGap.lean
+++ b/TNLean/Spectral/PeripheralToTransferMapGap.lean
@@ -5,7 +5,9 @@ Authors: TNLean contributors
 -/
 import QICLean.Channel.Semigroup.Primitivity.Helpers
 import QICLean.Kraus.CPPrimitive
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.InvariantProjection
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Structure.PrimitiveFixedPoint
 import TNLean.Spectral.TransferOperatorGap
 
@@ -41,7 +43,7 @@ theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero
     (htrX : Matrix.trace X = 0) :
     X = 0 :=
   fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible_channel
-    (Kraus.isChannel_transferMap A hNorm) (Kraus.injective_implies_irreducibleCP A hInj)
+    (Kraus.isChannel_mapLM A hNorm) (Kraus.injective_implies_irreducibleCP A hInj)
     X hXfix htrX
 
 /-- For the transfer map of an irreducible normalized tensor, any fixed point with trace
@@ -56,8 +58,8 @@ theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible
     (htrX : Matrix.trace X = 0) :
     X = 0 :=
   fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible_channel
-    (Kraus.isChannel_transferMap A hNorm)
-    (Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr) X hXfix htrX
+    (Kraus.isChannel_mapLM A hNorm)
+    (Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr) X hXfix htrX
 
 /-- Peripheral primitivity of the transfer map of an irreducible normalized tensor implies
 a complementary transfer-map gap for `E - P`, where `P` projects onto a fixed point. -/
@@ -75,9 +77,9 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
               ((Kraus.transferMap (d := d) (D := D) A) - fixedPointProj (D := D) ρ htr))
             < 1 := by
   let E := Kraus.transferMap (d := d) (D := D) A
-  have hCh : IsChannel E := Kraus.isChannel_transferMap A hNorm
+  have hCh : IsChannel E := Kraus.isChannel_mapLM A hNorm
   have hIrrMap : IsIrreducibleMap E :=
-    Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily A hIrr
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ := hCh.exists_posSemidef_fixedPoint (E := E) hDpos
   obtain ⟨htr, hgap⟩ :=
@@ -116,7 +118,7 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive
               ((Kraus.transferMap (d := d) (D := D) A) - fixedPointProj (D := D) ρ htr))
             < 1 := by
   have hIrr : Kraus.IsIrreducibleFamily A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
       (Kraus.injective_implies_irreducibleCP A hInj)
   exact spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
     (A := A) hIrr hNorm hPrim
@@ -131,7 +133,7 @@ theorem hasPrimitiveFixedPoint_of_peripheralPrimitive
     (hPrim : _root_.IsPrimitive (Kraus.transferMap (d := d) (D := D) A)) :
     MPSTensor.HasPrimitiveFixedPoint A := by
   have hIrr : Kraus.IsIrreducibleFamily A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
       (Kraus.injective_implies_irreducibleCP A hInj)
   exact hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible
     (A := A) hIrr hNorm hPrim

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -98,7 +98,7 @@ theorem exponential_convergence_of_primitive [NeZero D]
       (isPrimitivePaper_of_hasEventuallyFullKrausRank A
         ((MPSTensor.hasEventuallyFullKrausRank_iff_isNormal A).2 hA.isNormal))
   have hCh : IsChannel E := by
-    simpa only [E] using Kraus.isChannel_transferMap A hNorm
+    simpa only [E] using Kraus.isChannel_mapLM A hNorm
   have hIrr : IsIrreducibleMap E := by
     simpa only [E] using Kraus.injective_implies_irreducibleCP A hA
   have hρ_ne : ρ ≠ 0 := by
@@ -143,7 +143,7 @@ theorem exponential_convergence_of_primitive [NeZero D]
   · have hn1 : 1 ≤ n := Nat.succ_le_of_lt (Nat.pos_of_ne_zero hn)
     have hpowEq :=
       pow_eq_fixedPointProj_add_compl_pow (D := D) (E := E) (ρ := ρ) htrρ
-        (Kraus.isChannel_transferMap A hNorm).tp hρ_fix hn1
+        (Kraus.isChannel_mapLM A hNorm).tp hρ_fix hn1
     calc
       ‖((E^[n]) X) - P X‖ = ‖(E ^ n) X - P X‖ := by simp [E, Module.End.pow_apply]
       _ = ‖(P + N ^ n) X - P X‖ := by rw [hpowEq]
@@ -243,7 +243,7 @@ theorem correlation_length_bound [NeZero D]
   · have hn1 : 1 ≤ n := Nat.succ_le_of_lt (Nat.pos_of_ne_zero hn)
     have hpowEq :=
       pow_eq_fixedPointProj_add_compl_pow (D := D) (E := E) (ρ := ρ) htrρ
-        (Kraus.isChannel_transferMap A hNorm).tp hρ_fix hn1
+        (Kraus.isChannel_mapLM A hNorm).tp hρ_fix hn1
     calc
       ‖((E^[n]) X)‖ = ‖(E ^ n) X‖ := by simp [E, Module.End.pow_apply]
       _ = ‖(P + N ^ n) X‖ := by rw [hpowEq]

--- a/TNLean/Spectral/TransferOperatorGapInjective.lean
+++ b/TNLean/Spectral/TransferOperatorGapInjective.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import TNLean.Spectral.TransferOperatorGapNT
 import QICLean.Kraus.InvariantProjection
 import QICLean.Kraus.CPPrimitive
-import QICLean.Kraus.TransferChannel
 
 /-!
 # Injective transfer-gap corollaries
@@ -26,7 +25,7 @@ variable {d D D₁ D₂ : ℕ}
 private lemma irreducibleTensor_of_injective
     (A : MPSTensor d D) (hA : Kraus.IsInjective A) :
     Kraus.IsIrreducibleFamily A :=
-  Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A
+  Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
     (Kraus.injective_implies_irreducibleCP A hA)
 
 /-- **Eigenvalue rigidity** for normalized injective tensors. -/

--- a/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.InvariantProjection
 import TNLean.Wielandt.Primitivity.PrimitiveBridge
 
 /-!
@@ -44,7 +44,7 @@ theorem isIrreducibleTensor_of_isPrimitiveMPS_of_posDef
     (hPrim : IsPrimitiveMPS A ρ)
     (hPD : ρ.PosDef) :
     Kraus.IsIrreducibleFamily A :=
-  Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A
+  Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A
     (isIrreducibleMap_of_isPrimitiveMPS_of_posDef hPrim hPD)
 
 end MPSTensor

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -66,7 +66,7 @@ theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ ∧ ρ.PosDef := by
   obtain ⟨_, _, _, hPrim, hIrrMap⟩ := hSI
   have hIrrT : Kraus.IsIrreducibleFamily A :=
-    Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap A hIrrMap
+    Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM A hIrrMap
   obtain ⟨ρ', hPrimMPS⟩ :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrrT hNorm hPrim
   have hρ'PD : ρ'.PosDef :=

--- a/blueprint/qiclean_split_residual.json
+++ b/blueprint/qiclean_split_residual.json
@@ -1022,7 +1022,7 @@
       "title": "Transfer map is a channel",
       "label": "thm:transfer_channel",
       "shared_lean_declarations": [
-        "Kraus.isChannel_transferMap"
+        "Kraus.isChannel_mapLM"
       ],
       "disposition": "retained TN-facing interface",
       "justification": "The statement packages the MPS transfer map as a channel."

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -141,7 +141,7 @@ through its own period agrees with the directly $p$-blocked block.
     \lean{Kraus.HasComplementaryFixedPointGap.posDef_of_isIrreducibleFamily}
     \lean{MPSTensor.transferMap_blockTensor}
     \lean{MPSTensor.transferMap_blockTensor_fixedPoint}
-    \lean{Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap}
+    \lean{Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM}
     \leanok
     \uses{def:blocked_tensor, def:irreducible_tensor, def:primitive_mps, thm:left_canonical_blocking, thm:channel_posdef_fixed_point_unique_irreducible, thm:transfer_channel}
     Let $A$ be left-canonical, tensor-irreducible, and have primitive transfer

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -116,7 +116,7 @@
 \end{proof}
 
 \begin{theorem}[Transfer map is a channel]\label{thm:transfer_channel}
-    \lean{Kraus.isChannel_transferMap}
+    \lean{Kraus.isChannel_mapLM}
     \leanok
     \uses{def:transfer_map}
     If $\sum_i(A^i)^\dagger A^i=\Id$, then the transfer map

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -264,7 +264,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{theorem}[Irreducibility of the transfer map of an irreducible tensor]%
     \label{thm:transfer_map_irreducible_of_tensor}
-    \lean{Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily}
+    \lean{Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily}
     \leanok
     \uses{def:irreducible_tensor, def:transfer_map}
     If an MPS tensor $A$ is irreducible, then its transfer map $\E_A$ is

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -392,7 +392,7 @@ direct.
 
 \begin{theorem}[Tensor irreducibility implies transfer-map irreducibility]
     \label{thm:irreducible_tensor_to_transfer_map}
-    \lean{Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily}
+    \lean{Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily}
     \leanok
     \uses{def:irreducible_tensor}
     If an MPS tensor is irreducible, then its transfer map has no nontrivial

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -255,10 +255,10 @@ abstracted — record why, so it is not re-proposed).
   theorems.
 - **Seen:** the five transfer-map compatibility declarations in
   `TNLean/Channel/Peripheral/{ClosureFixedPoint,CyclicGroup}.lean` (2026-08-09).
-- **Abstraction:** `Kraus.isIrreducibleMap_mapLM_of_transferMap` in
-  `QICLean/MPS/Core/TransferChannel.lean` (QICLean dependency).
-- **Notes:** the generic theorems use `Kraus.mapLM`; each transfer-map statement
-  applies this conversion once before invoking its generic counterpart.
+- **Abstraction:** no conversion theorem is needed: `Kraus.transferMap` and
+  `Kraus.mapLM` are definitionally equal.
+- **Notes:** generic theorems use `Kraus.mapLM`; transfer-map hypotheses are
+  passed directly to them without an equality rewrite or compatibility wrapper.
 
 ### Transfer-map spectral arguments in Kraus-map notation — promoted
 - **Pattern:** prove eigenvector, fixed-point, and channel-power statements for
@@ -306,12 +306,10 @@ abstracted — record why, so it is not re-proposed).
   (2026-08-09).
 - **Abstraction:** `Kraus.trace_mul_transferMap_adjoint` in
   `QICLean/Channel/Irreducible/KrausSetup.lean` (QICLean dependency).
-- **Notes:** Channel callers use the theorem on the existing Kraus-setup import
-  boundary, while `MPS.Core.TransferChannel` provides the root-level transfer-map
-  compatibility statement without importing irreducibility theory. The declaration
-  `Kraus.isChannel_transferMap` retains its name and statement but now requires the
-  MPS compatibility import instead of `Channel.FixedPoint.MaximalSupport`; this
-  intentional import-level change removes the former Channel-to-MPS dependency.
+- **Notes:** transfer-map callers use the canonical `Kraus.isChannel_mapLM`
+  theorem from `QICLean/Channel/KrausMap.lean` directly, relying on the
+  definitional equality with `Kraus.transferMap`. The transfer-specific
+  trace-adjoint compatibility theorem remains available for its distinct result.
 
 ### matrix-family irreducibility in transfer-map notation — promoted
 - **Pattern:** convert between irreducibility of a finite matrix family and
@@ -322,12 +320,12 @@ abstracted — record why, so it is not re-proposed).
   `Wielandt/Primitivity/{PrimitiveBridge,ToNormal}.lean` before promotion
   (2026-08-20).
 - **Abstraction:**
-  `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily` and
-  `Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap` in
-  `QICLean/Kraus/TransferChannel.lean` (QICLean dependency).
-- **Notes:** QICLean owns the equivalence directly in transfer-map notation.
-  Downstream callers no longer repeat an equality conversion or import
-  `MPS.Irreducible.FormII` solely for this equivalence.
+  `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily` and
+  `Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM` in
+  `QICLean/Kraus/InvariantProjection.lean` (QICLean dependency).
+- **Notes:** QICLean owns the equivalence canonically in `mapLM` notation.
+  Transfer-map callers use it directly by definitional equality, without an
+  equality conversion or compatibility wrapper.
 
 ### pure gauge to heterogeneous repeated blocks — promoted
 - **Pattern:** convert `GaugeEquiv A B` to `HetRepeatedBlocks A B` by passing


### PR DESCRIPTION
## Summary
- replace every remaining use of the five retired TransferChannel compatibility wrappers with canonical `mapLM` owners
- simplify nested irreducibility conversions definitionally
- update Blueprint references, metadata, imports, and tactic prose
- retain substantive transfer-notation theorems and the six peripheral-to-gap declarations for the next owner migration

## Dependency
Stacked on TNLean #7179. It will be restacked onto `main` after #7179 merges.

## Validation
- zero references to the five retired identifiers
- all 26 focused modules compile
- full `lake build`: 10,385 jobs
- generated import tests/freshness
- Blueprint declaration and 6,717/6,717 synchronization checks
- reader-facing prose, proof-token, protected-declaration, pin, and diff scans