### PR TITLE
fix(lean): eliminate lake build warnings

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -104,7 +104,7 @@ theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) 
               (X : Matrix (Fin D) (Fin D) ℂ)⁻¹) * Y *
               (((X : Matrix (Fin D) (Fin D) ℂ) * A x *
                 (X : Matrix (Fin D) (Fin D) ℂ)⁻¹)ᴴ) := by
-            simp [Kraus.transferMap_apply, hX]
+            simp [hX]
       _ = ∑ x : Fin d,
             (X : Matrix (Fin D) (Fin D) ℂ) *
               (A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
@@ -123,7 +123,7 @@ theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) 
       _ = similarityMap (D := D)
             ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
             (Kraus.transferMap (d := d) (D := D) A) Y := by
-            simp [similarityMap, Kraus.transferMap_apply, Matrix.conjTranspose_nonsing_inv,
+            simp [similarityMap, Matrix.conjTranspose_nonsing_inv,
               hX_inv_inv, hXstar_inv_inv, Matrix.mul_assoc]
 
 /-- Gauge equivalence transports quasi-idempotence of the transfer map. -/
@@ -222,7 +222,7 @@ theorem exists_tpGauge_of_irreducible_spectralRadius_one
     push Not at hzero
     have hmap : Kraus.transferMap (d := d) (D := D) A = 0 := by
       ext X a b
-      simp [Kraus.transferMap_apply, hzero]
+      simp [hzero]
     have hspectral := hRadius
     rw [hmap] at hspectral
     simp at hspectral
@@ -355,7 +355,7 @@ theorem IsNormalTensor.exists_apply_ne_zero [NeZero D]
   push Not at hzero
   have hmap : Kraus.transferMap (d := d) (D := D) A = 0 := by
     ext X a b
-    simp [Kraus.transferMap_apply, hzero]
+    simp [hzero]
   have hspectral := h.spectral_radius_one
   rw [hmap] at hspectral
   simp at hspectral

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -100,7 +100,7 @@ private theorem cyclic_projection_mem_multiplicativeDomain
         Kraus.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X =
           KadisonSchwarz.krausMap K X := by
     intro X
-    simp [K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+    simp [K, KadisonSchwarz.krausMap]
   intro k
   have hPk_star : (P k)ᴴ = P k := (hPproj k).1.eq
   have hTPk_eq : Kraus.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) = P (k - 1) := by

--- a/TNLean/MPS/Core/PhysicalIndexMixing.lean
+++ b/TNLean/MPS/Core/PhysicalIndexMixing.lean
@@ -51,7 +51,7 @@ theorem isLeftCanonical_kraus_isometry
   change IsLeftCanonical C
   rw [IsLeftCanonical]
   exact kraus_sum_conjTranspose_mul_of_tp C (Kraus.transferMap C)
-    (fun X ↦ by simp [Kraus.transferMap_apply]) hCh.tp
+    (fun X ↦ by simp) hCh.tp
 
 /-- An isometric physical-index mixing of an injective matrix family remains
 injective.

--- a/TNLean/MPS/Core/TPGauge.lean
+++ b/TNLean/MPS/Core/TPGauge.lean
@@ -103,7 +103,7 @@ theorem tpGauge_isTP_of_transferMap_conjTranspose_eigenvector
     rw [← Finset.smul_sum]
     have hsum : ∑ i : Fin d, (A i)ᴴ * ρ * ((A i)ᴴ)ᴴ =
         Kraus.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ρ := by
-      simp [Kraus.transferMap_apply]
+      simp only [Kraus.transferMap_apply]
     rw [hsum, heig, smul_smul, inv_mul_cancel₀, one_smul]
     exact_mod_cast hr.ne'
   exact tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A' ρ hρ hfix

--- a/TNLean/MPS/Core/TransferMatrix.lean
+++ b/TNLean/MPS/Core/TransferMatrix.lean
@@ -28,6 +28,6 @@ theorem transferMatrix_eq (A : MPSTensor d D) :
     transferMatrix (Kraus.transferMap A) =
       ∑ n : Fin d,
         (A n).map (starRingEnd ℂ) ⊗ₖ A n :=
-  transferMatrix_kraus A _ (fun X => by simp [Kraus.transferMap_apply])
+  transferMatrix_kraus A _ (fun X => by simp)
 
 end MPSTensor

--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -213,7 +213,7 @@ theorem ghz_orderParam_fixed :
     Kraus.transferMap ghzTensor (!![(1 : ℂ), 0; 0, -1]) = !![(1 : ℂ), 0; 0, -1] := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Kraus.transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal,
+    simp [ghzTensor, Fin.sum_univ_two, Matrix.diagonal,
       Pi.single_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -43,7 +43,7 @@ private theorem scalarUnitTensor_transferMap :
   ext a b
   fin_cases a
   fin_cases b
-  simp [Kraus.transferMap_apply, scalarUnitTensor]
+  simp [scalarUnitTensor]
 
 /-- The one-dimensional scalar unit tensor is normal.
 

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -71,9 +71,8 @@ private theorem phaseFlipTensor_transferMap_adjoint :
   apply LinearMap.ext
   intro X
   rw [← Kraus.mapLM_conjTranspose_eq_adjoint]
-  simp only [Kraus.mapLM_apply, Kraus.adjointMap, Matrix.conjTranspose_conjTranspose]
-  simp [Kraus.adjointMap, Kraus.transferMap_apply,
-    phaseFlipTensor_conjTranspose]
+  simp only [Kraus.mapLM_apply]
+  simp [phaseFlipTensor_conjTranspose]
 
 private theorem phaseFlipTensor_transferMap_pow_adjoint (n : ℕ) :
     ((Kraus.transferMap phaseFlipTensor) ^ n).adjoint =

--- a/TNLean/MPS/MPDO/BondTwoSingletonBaseModel.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonBaseModel.lean
@@ -167,7 +167,7 @@ private theorem baseSymbolTensor_transferMap (a : Fin 4) :
   ext x y
   fin_cases x
   fin_cases y
-  simp [Kraus.transferMap_apply, baseSymbolTensor]
+  simp [baseSymbolTensor]
 
 /-- Every symbol block in the four-block decomposition is a normal tensor. -/
 theorem baseSymbolTensor_isNormalTensor (a : Fin 4) :

--- a/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
+++ b/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
@@ -136,7 +136,7 @@ private lemma secondBasis_transferMap :
   ext a b
   fin_cases a
   fin_cases b
-  simp [Kraus.transferMap_apply, secondBasisTensor, Matrix.mul_apply]
+  simp [secondBasisTensor, Matrix.mul_apply]
 
 /-- Each of the two displayed bond-one representatives is a normal tensor.
 

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -712,7 +712,7 @@ private lemma scalarPurifier_isTransferIdempotent :
   ext a b
   fin_cases a
   fin_cases b
-  simp [LinearMap.comp_apply, Kraus.transferMap_apply, purificationTensor,
+  simp [LinearMap.comp_apply, purificationTensor,
     scalarPurifier]
 
 private lemma nilpotentGlobalPRFP_isPRFP : IsPRFP nilpotentGlobalPRFP := by

--- a/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
+++ b/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
@@ -422,8 +422,7 @@ private theorem transferMap_A_diagonal (x : Fin 2 → ℂ) :
       Matrix.diagonal (wMat.mulVec x) := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Kraus.transferMap_apply, A, wMat,
-      dotProduct, Fin.sum_univ_four, Fin.sum_univ_two] <;> ring
+    simp [A, wMat, dotProduct, Fin.sum_univ_four, Fin.sum_univ_two] <;> ring
 
 private theorem transferMap_A_pow_single_diag (N : ℕ) (i : Fin 2) :
     (Kraus.transferMap A ^ N) (Matrix.single i i 1) =

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -535,7 +535,7 @@ theorem wMat_eigenvalue_eq_oneLabelChi_entry (k : Fin 2) :
 theorem transferMap_A_one : Kraus.transferMap A 1 = 1 := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Kraus.transferMap_apply, Fin.sum_univ_four, A] <;> norm_num
+    simp [Fin.sum_univ_four, A] <;> norm_num
 
 /-- `φ` scales the traceless diagonal `diag(1, -1)` by `lambda = 7/25`. -/
 theorem transferMap_A_diag_alt :
@@ -543,19 +543,19 @@ theorem transferMap_A_diag_alt :
       (lambda : ℂ) • !![(1 : ℂ), 0; 0, -1] := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Kraus.transferMap_apply, Fin.sum_univ_four, A, lambda] <;> norm_num
+    simp [Fin.sum_univ_four, A, lambda] <;> norm_num
 
 /-- `φ` annihilates the off-diagonal matrix unit `E₀₁`. -/
 theorem transferMap_A_single01 :
     Kraus.transferMap A (Matrix.single (0 : Fin 2) (1 : Fin 2) (1 : ℂ)) = 0 := by
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [Kraus.transferMap_apply, Fin.sum_univ_four, A]
+  fin_cases i <;> fin_cases j <;> simp [Fin.sum_univ_four, A]
 
 /-- `φ` annihilates the off-diagonal matrix unit `E₁₀`. -/
 theorem transferMap_A_single10 :
     Kraus.transferMap A (Matrix.single (1 : Fin 2) (0 : Fin 2) (1 : ℂ)) = 0 := by
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [Kraus.transferMap_apply, Fin.sum_univ_four, A]
+  fin_cases i <;> fin_cases j <;> simp [Fin.sum_univ_four, A]
 
 /-- **The explicit eigenvalues of `φ` (`Kraus.transferMap A`).** The
 identity is fixed (eigenvalue `1`), the traceless diagonal `diag(1, -1)` is

--- a/TNLean/MPS/MPU/TransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/TransferMultiplicity.lean
@@ -321,7 +321,7 @@ theorem r_eq_one_of_shifted_transfer_trace
     have htransferZero :
         transferMatrix (Kraus.transferMap (0 : MPSTensor d D)) = 0 := by
       ext ⟨a, b⟩ ⟨c, e⟩
-      simp [transferMatrix, Kraus.transferMap_apply]
+      simp [transferMatrix]
     rw [htransferZero] at htwo
     simp at htwo
   let M := transferMatrix (Kraus.transferMap A)

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -373,6 +373,7 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvw
     omega
   · exact hψ
 
+set_option linter.style.longLine false in
 /-- A global change of cut closes the block-diagonal boundary conditions
 under the PGVWC07 source normalization: source unitality together with positive,
 full-rank dual fixed points. No left-canonical identity is assumed on the source
@@ -423,6 +424,7 @@ theorem
     omega
   · exact hψ
 
+set_option linter.style.longLine false in
 /-- Under the PGVWC07 source normalization, the periodic chain space of
 the block sum is the sum of the periodic block spaces, and the open-boundary
 block spaces are independent. This is the unrestricted source-shaped chain-space
@@ -471,6 +473,7 @@ theorem
       groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
         A hr hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀ hUnital (by omega)
 
+set_option linter.style.longLine false in
 /-- The unrestricted PGVWC07 source-shaped periodic chain-space equality.
 
 Source: arXiv:quant-ph/0608197, canonical normalization lines 742--763 and
@@ -501,6 +504,7 @@ theorem
     μ A hμ hr hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀ hUnital
       hRange hNlarge).1
 
+set_option linter.style.longLine false in
 /-- Under the unrestricted PGVWC07 source normalization, blockwise periodic
 uniqueness implies containment of the block-sum parent-Hamiltonian kernel in the
 span of the BNT matrix product vectors.
@@ -541,6 +545,7 @@ theorem
       μ A hμ hr hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀ hUnital
         hRange hNlarge)
 
+set_option linter.style.longLine false in
 /-- The parent-Hamiltonian kernel of the unrestricted PGVWC07 source-shaped block
 sum is exactly the span of its periodic component vectors.
 
@@ -593,6 +598,7 @@ theorem
   · exact bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks
       μ A hμ hN hLN
 
+set_option linter.style.longLine false in
 /-- At the length bound of Perez-Garcia, Verstraete, Wolf, and Cirac, the
 periodic chain space of a normalized BNT block sum is the sum of the periodic
 chain spaces of its blocks, while the open-boundary block spaces are independent.
@@ -694,6 +700,7 @@ theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_c
     (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
       μ A hμ hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge)
 
+set_option linter.style.longLine false in
 /-- At the PGVWC07 source range, the parent-Hamiltonian kernel of the normalized
 BNT block direct sum is exactly the span of the periodic component vectors.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalSourceNormalization.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalSourceNormalization.lean
@@ -18,6 +18,7 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+set_option linter.style.longLine false in
 /-- Under the PGVWC07 source normalization, every block-diagonal periodic vector
 belongs to the sum of the open-boundary block spaces at the sharp source length.
 The positive dual fixed points are used only by the tuple-span/intersection layer;
@@ -62,6 +63,7 @@ theorem
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
+set_option linter.style.longLine false in
 /-- Under the source-shaped PGVWC07 hypotheses, the chain-ground-space
 containment is accompanied by independence of the open-boundary block spaces.
 
@@ -98,6 +100,7 @@ chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1_pgvwc
       groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
         A hr hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀ hUnital (by omega)
 
+set_option linter.style.longLine false in
 /-- Every source-shaped PGVWC07 block-diagonal chain vector has a unique sum
 decomposition into the open-boundary spaces of the blocks.
 
@@ -153,6 +156,7 @@ chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1_pgvwc
   have hzero := hIndep Finset.univ (fun i => φ' i - φ i) hmem hsum j (Finset.mem_univ j)
   exact sub_eq_zero.mp hzero
 
+set_option linter.style.longLine false in
 /-- Under the source-shaped PGVWC07 hypotheses, a periodic vector of the block
 sum admits one block-diagonal open-boundary matrix. Its block components belong
 to the corresponding open-boundary block spaces.

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
@@ -405,7 +405,7 @@ private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
     simpa [IsLeftCanonical, Kraus.IsTP] using hP.leftCanonical
   have hK_apply : ∀ X : MatrixAlg D, T X = KadisonSchwarz.krausMap K X := by
     intro X
-    simp [T, K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+    simp [T, K, KadisonSchwarz.krausMap]
   have hMulDomain : ∀ k : Fin m, P k ∈ KadisonSchwarz.multiplicativeDomain K := by
     intro k
     have hPk_star : (P k)ᴴ = P k := (hPproj k).1.eq
@@ -831,7 +831,7 @@ private lemma exists_offDiag_eigenvector_of_gaugePhase_same_dim
     calc
       Kraus.transferMap (d := d₀) (D := D) C U =
           ∑ i : Fin d₀, C i * (Vu * Y * Vvᴴ) * (C i)ᴴ := by
-        simp [Kraus.transferMap_apply, U]
+        simp [U]
       _ = ∑ i : Fin d₀, Vu * (Au i * Y * (Av i)ᴴ) * Vvᴴ := by
         refine Finset.sum_congr rfl ?_
         intro i _

--- a/TNLean/MPS/Periodic/SectorIrreducibility/HLift.lean
+++ b/TNLean/MPS/Periodic/SectorIrreducibility/HLift.lean
@@ -500,24 +500,24 @@ theorem sectorFixedPointAlgebraRigidity_of_irreducible_tp
       calc
         KadisonSchwarz.krausMap K (P k * (P k)ᴴ)
             = T (P k * (P k)ᴴ) := by
-              simp [T, K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+              simp [T, K, KadisonSchwarz.krausMap]
         _ = T (P k) := by rw [hPk_star, (hPproj k).2]
         _ = T (P k) * (T (P k))ᴴ := by
               rw [hTPk_proj.1.eq, hTPk_proj.2]
         _ = KadisonSchwarz.krausMap K (P k) * (KadisonSchwarz.krausMap K (P k))ᴴ := by
-              simp [T, K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+              simp [T, K, KadisonSchwarz.krausMap]
     have hLeft :
         KadisonSchwarz.krausMap K ((P k)ᴴ * P k) =
           (KadisonSchwarz.krausMap K (P k))ᴴ * KadisonSchwarz.krausMap K (P k) := by
       calc
         KadisonSchwarz.krausMap K ((P k)ᴴ * P k)
             = T ((P k)ᴴ * P k) := by
-              simp [T, K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+              simp [T, K, KadisonSchwarz.krausMap]
         _ = T (P k) := by rw [hPk_star, (hPproj k).2]
         _ = (T (P k))ᴴ * T (P k) := by
               rw [hTPk_proj.1.eq, hTPk_proj.2]
         _ = (KadisonSchwarz.krausMap K (P k))ᴴ * KadisonSchwarz.krausMap K (P k) := by
-              simp [T, K, Kraus.transferMap_apply, KadisonSchwarz.krausMap]
+              simp [T, K, KadisonSchwarz.krausMap]
     exact ⟨
       (KadisonSchwarz.mem_rightMultiplicativeDomain_iff K hUnital (P k)).2 hRight,
       (KadisonSchwarz.mem_leftMultiplicativeDomain_iff K hUnital (P k)).2 hLeft⟩

--- a/TNLean/MPS/Periodic/SectorIrreducibility/HLiftCore.lean
+++ b/TNLean/MPS/Periodic/SectorIrreducibility/HLiftCore.lean
@@ -81,7 +81,7 @@ theorem hFixUpgrade_of_peripheral
               simpa [T, Kraus.transferMap_apply, Kraus.map, Kraus.adjointMap] using
                 (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := fun i => (A i)ᴴ) ρ X)
       _ = Matrix.trace (E ρ * X) := by
-            simp [E, Kraus.transferMap_apply, Kraus.adjointMap]
+            simp [E, Kraus.adjointMap]
       _ = Matrix.trace (ρ * X) := by rw [hρ_fix]
   have htrace_pow :
       ∀ n : ℕ, ∀ X : MatrixAlg D,

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -302,7 +302,7 @@ theorem rfp_nt_structural_full_sqSum (A : MPSTensor d D) [NeZero D]
     intro Y
     calc
       ∑ i : Fin d, B i * Y * (B i)ᴴ = Kraus.transferMap B Y := by
-        simp [Kraus.transferMap_apply]
+        simp
       _ = fixedPointProj ρ htr Y := by
         rw [hB_proj]
       _ = ∑ p : Fin D × Fin D, K p * Y * (K p)ᴴ := by

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -81,7 +81,8 @@ lemma transferMap_tpGauge_eq_similarityMap
       _ = S * (∑ i : Fin d, A i * (S⁻¹ * X * S⁻¹ * (A i)ᴴ)) * S := by
             simp only [← Matrix.sum_mul, ← Matrix.mul_sum]
       _ = similarityMap (D := D) S⁻¹ (Kraus.transferMap A) X := by
-            simp [similarityMap, S, hS_inv_inv, hS_inv_herm', Matrix.mul_assoc]
+            simp only [Matrix.mul_assoc, similarityMap, hS_inv_inv, hS_inv_herm',
+              Kraus.mapLM_apply, Kraus.map_apply, LinearMap.coe_mk, AddHom.coe_mk, S]
   exact congrFun (congrFun hcalc i) j
 
 /-- Positive-definite TP gauging preserves peripheral-spectrum primitivity. -/
@@ -146,7 +147,8 @@ lemma gaugePhaseEquiv_of_gaugeEquiv_left_right
     _ = ζ • (((Z⁻¹ * Y * X : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
           (((Z⁻¹ * Y * X : GL (Fin D) ℂ)⁻¹ : GL (Fin D) ℂ) :
             Matrix (Fin D) (Fin D) ℂ)) := by
-      simp [Matrix.mul_assoc, mul_inv_rev]
+      simp only [Matrix.coe_units_inv, Matrix.mul_assoc, Units.val_mul, mul_inv_rev,
+        inv_inv]
 
 /-- Gauge equivalence on both sides transports a casted gauge-phase
 equivalence back to the original tensors. -/
@@ -338,9 +340,9 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
       Kraus.mixedTransferMap setup.A' setup.B' (setup.S * V * setup.Sᴴ)
           = ∑ i : Fin d,
               setup.A' i * (setup.S * V * setup.Sᴴ) * (setup.B' i)ᴴ := by
-                  simp [Kraus.mixedTransferMap_apply]
+                  simp only [Kraus.mixedTransferMap_apply]
       _ = ∑ i : Fin d, setup.S * (A i * V * (setup.B i)ᴴ) * setup.Sᴴ := by
-            simp [hTerm]
+            simp only [hTerm]
       _ = setup.S * (∑ i : Fin d, A i * V * (setup.B i)ᴴ) * setup.Sᴴ := by
             simp only [← Matrix.sum_mul, ← Matrix.mul_sum]
       _ = ev • (setup.S * V * setup.Sᴴ) := by
@@ -365,6 +367,43 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
     simpa [hBot] using hMem
   exact hGauge_ne (Submodule.mem_bot ℂ |>.mp this)
 
+/-- Unitary physical mixing can be inverted by conjugating its coefficients. -/
+private lemma unitary_mix_inverse
+    (A : MPSTensor d D)
+    (u : Matrix (Fin d) (Fin d) ℂ)
+    (hu : uᴴ * u = 1)
+    (k : Fin d) :
+    ∑ i : Fin d, (starRingEnd ℂ) (u i k) • (∑ j : Fin d, u i j • A j) = A k := by
+  have hcoeff :
+      ∀ j : Fin d,
+        ∑ i : Fin d, (starRingEnd ℂ) (u i k) * u i j = if k = j then 1 else 0 := by
+    intro j
+    have hentry := congrFun (congrFun hu k) j
+    simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] using hentry
+  calc
+    ∑ i : Fin d, (starRingEnd ℂ) (u i k) • (∑ j : Fin d, u i j • A j)
+        = ∑ i : Fin d, ∑ j : Fin d,
+            ((starRingEnd ℂ) (u i k) * u i j) • A j := by
+              apply Finset.sum_congr rfl
+              intro i _
+              rw [Finset.smul_sum]
+              apply Finset.sum_congr rfl
+              intro j _
+              simp [smul_smul]
+    _ = ∑ j : Fin d, ∑ i : Fin d,
+          ((starRingEnd ℂ) (u i k) * u i j) • A j := by
+            rw [Finset.sum_comm]
+    _ = ∑ j : Fin d,
+          (∑ i : Fin d, (starRingEnd ℂ) (u i k) * u i j) • A j := by
+            apply Finset.sum_congr rfl
+            intro j _
+            rw [Finset.sum_smul]
+    _ = ∑ j : Fin d, (if k = j then (1 : ℂ) else 0) • A j := by
+          apply Finset.sum_congr rfl
+          intro j _
+          rw [hcoeff j]
+    _ = A k := by simp
+
 /-- Inverting a unitary physical action transports a virtual symmetry relation
 for the twisted companion back to the original tensor. -/
 private theorem inverse_physical_action_of_twisted_companion
@@ -382,38 +421,9 @@ private theorem inverse_physical_action_of_twisted_companion
   let B : MPSTensor d D := twistedMixedCompanion A u
   have hsum :
       ∑ j : Fin d, u i j • B j = A i := by
-    have hcoeff :
-        ∀ n' : Fin d,
-          ∑ j : Fin d, u i j * (starRingEnd ℂ) (u n' j) = if i = n' then 1 else 0 := by
-      intro n'
-      have hentry := congrFun (congrFun hu i) n'
-      simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] using hentry
-    calc
-      ∑ j : Fin d, u i j • B j
-          = ∑ j : Fin d, ∑ n' : Fin d, (u i j * (starRingEnd ℂ) (u n' j)) • A n' := by
-              refine Finset.sum_congr rfl ?_
-              intro j _
-              have hBj :
-                  B j = ∑ n' : Fin d, (starRingEnd ℂ) (u n' j) • A n' := by
-                simp [B, twistedMixedCompanion]
-              rw [hBj]
-              simpa [smul_smul, mul_assoc] using
-                (Finset.smul_sum (s := Finset.univ)
-                  (f := fun n' : Fin d => (starRingEnd ℂ) (u n' j) • A n')
-                  (r := u i j))
-      _ = ∑ n' : Fin d, ∑ j : Fin d, (u i j * (starRingEnd ℂ) (u n' j)) • A n' := by
-            rw [Finset.sum_comm]
-      _ = ∑ n' : Fin d, (∑ j : Fin d, u i j * (starRingEnd ℂ) (u n' j)) • A n' := by
-            refine Finset.sum_congr rfl ?_
-            intro n' _
-            simpa using
-              (Finset.sum_smul (s := Finset.univ)
-                (f := fun j : Fin d => u i j * (starRingEnd ℂ) (u n' j))
-                (x := A n')).symm
-      _ = ∑ n' : Fin d, (if i = n' then 1 else 0) • A n' := by
-            simp [hcoeff]
-      _ = A i := by
-            simp
+    simpa only [B, twistedMixedCompanion, Matrix.conjTranspose_apply,
+      starRingEnd_apply, star_star] using
+      unitary_mix_inverse A uᴴ (by simpa using hu) i
   have hsum_virtual : A i = ζ • (U * (∑ j : Fin d, u i j • A j) * Uᴴ) := by
     calc
       A i = ∑ j : Fin d, u i j • B j := hsum.symm
@@ -606,7 +616,8 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
       calc
         X * (a⁻¹ • Uᴴ) = (a • U) * (a⁻¹ • Uᴴ) := by rw [hX_eq]
         _ = (a * a⁻¹) • (U * Uᴴ) := by
-              simpa [Matrix.mul_assoc] using smul_mul_smul_comm a U a⁻¹ Uᴴ
+              simpa only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, mul_comm] using
+                smul_mul_smul_comm a U a⁻¹ Uᴴ
         _ = 1 := by simp [ha_ne0, hU_unitary_left]
     simpa [X, Xin] using hXin'
   refine ⟨Uᴴ, ζ⁻¹, ?_, ?_, ?_, ?_⟩
@@ -701,39 +712,20 @@ theorem boundaryState_invariant_of_virtualUnitary
   have hμ_sq : star μ * μ = 1 := by
     rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
   have huc : uᴴ * u = 1 := mul_eq_one_comm.mp hu
-  have hcoeff :
-      ∀ k j : Fin d,
-        ∑ i : Fin d, (starRingEnd ℂ) (u i k) * u i j = if k = j then 1 else 0 := by
-    intro k j
-    have hentry := congrFun (congrFun huc k) j
-    simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] using hentry
   have hA_from_B :
       ∀ k : Fin d, A k = μ • (V * B k * Vᴴ) := by
     intro k
     calc
-      A k = ∑ j : Fin d, (if k = j then 1 else 0) • A j := by simp
-      _ = ∑ j : Fin d, (∑ i : Fin d, (starRingEnd ℂ) (u i k) * u i j) • A j := by
-            simp [hcoeff]
-      _ = ∑ j : Fin d, ∑ i : Fin d, ((starRingEnd ℂ) (u i k) * u i j) • A j := by
-            apply Finset.sum_congr rfl
-            intro j _
-            rw [← Finset.sum_smul]
-      _ = ∑ i : Fin d, ∑ j : Fin d, ((starRingEnd ℂ) (u i k) * u i j) • A j := by
-            rw [Finset.sum_comm]
-      _ = ∑ i : Fin d, (starRingEnd ℂ) (u i k) • (∑ j : Fin d, u i j • A j) := by
-            apply Finset.sum_congr rfl
-            intro i _
-            rw [Finset.smul_sum]
-            apply Finset.sum_congr rfl
-            intro j _
-            simp [smul_smul]
+      A k = ∑ i : Fin d, (starRingEnd ℂ) (u i k) •
+          (∑ j : Fin d, u i j • A j) := (unitary_mix_inverse A u huc k).symm
       _ = ∑ i : Fin d, (starRingEnd ℂ) (u i k) • (μ • (V * A i * Vᴴ)) := by
             apply Finset.sum_congr rfl
             intro i _
             rw [hC1μ i]
       _ = μ • (V * B k * Vᴴ) := by
-            simp [B, twistedMixedCompanion, smul_smul, mul_assoc,
-              Finset.smul_sum, Finset.mul_sum, Finset.sum_mul, mul_comm]
+            simp only [mul_assoc, smul_smul, mul_comm, twistedMixedCompanion,
+              Finset.mul_sum, Algebra.mul_smul_comm, Finset.sum_mul,
+              Algebra.smul_mul_assoc, Finset.smul_sum, B]
   have hB_eq :
       ∀ X : Matrix (Fin D) (Fin D) ℂ, Kraus.transferMap B X = Kraus.transferMap A X := by
     intro X

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -71,7 +71,7 @@ lemma transferMap_tpGauge_eq_similarityMap
     calc
       Kraus.transferMap (tpGauge (d := d) (D := D) A σ) X
           = ∑ i : Fin d, (S * A i * S⁻¹) * X * (S * A i * S⁻¹)ᴴ := by
-              simp [Kraus.transferMap_apply, tpGauge, Kraus.tpGauge, S]
+              simp [tpGauge, Kraus.tpGauge, S]
       _ = ∑ i : Fin d, S * (A i * (S⁻¹ * X * S⁻¹ * (A i)ᴴ)) * S := by
             refine Finset.sum_congr rfl ?_
             intro x _
@@ -81,8 +81,7 @@ lemma transferMap_tpGauge_eq_similarityMap
       _ = S * (∑ i : Fin d, A i * (S⁻¹ * X * S⁻¹ * (A i)ᴴ)) * S := by
             simp only [← Matrix.sum_mul, ← Matrix.mul_sum]
       _ = similarityMap (D := D) S⁻¹ (Kraus.transferMap A) X := by
-            simp [similarityMap, Kraus.transferMap_apply, S, hS_inv_inv, hS_inv_herm',
-              Matrix.mul_assoc]
+            simp [similarityMap, S, hS_inv_inv, hS_inv_herm', Matrix.mul_assoc]
   exact congrFun (congrFun hcalc i) j
 
 /-- Positive-definite TP gauging preserves peripheral-spectrum primitivity. -/
@@ -216,7 +215,7 @@ noncomputable def twistedTPGaugeSetup [NeZero D]
   have hAadjNorm : ∑ i : Fin d, (((fun i => (A i)ᴴ) i)ᴴ) * ((fun i => (A i)ᴴ) i) = 1 := by
     simpa using
       kraus_sum_mul_conjTranspose_of_unital A (Kraus.transferMap A)
-        (fun X => by simp [Kraus.transferMap_apply]) hNorm
+        (fun X => by simp) hNorm
   have hChAdj : IsChannel (Kraus.transferMap (d := d) (D := D) fun i => (A i)ᴴ) :=
     Kraus.isChannel_mapLM (fun i => (A i)ᴴ) hAadjNorm
   let hσ_exists :=
@@ -671,7 +670,7 @@ theorem twistedTransfer_eigen_of_virtualUnitary
     _ = μ • (V * ∑ i : Fin d, A i * (A i)ᴴ) := by
           simp [Matrix.mul_assoc, Matrix.mul_sum]
     _ = μ • (V * Kraus.transferMap A 1) := by
-          simp [Kraus.transferMap_apply]
+          simp
     _ = μ • V := by
           simp [hNorm]
 
@@ -754,7 +753,7 @@ theorem boundaryState_invariant_of_virtualUnitary
     calc
       Kraus.transferMap (fun i => (A i)ᴴ) ρ
           = ∑ i : Fin d, (A i)ᴴ * ρ * A i := by
-              simp [Kraus.transferMap_apply]
+              simp
       _ = ∑ i : Fin d, V * ((B i)ᴴ * Λ * B i) * Vᴴ := by
             apply Finset.sum_congr rfl
             intro i _
@@ -779,7 +778,7 @@ theorem boundaryState_invariant_of_virtualUnitary
       _ = V * (∑ i : Fin d, (B i)ᴴ * Λ * B i) * Vᴴ := by
             simp only [← Matrix.sum_mul, ← Matrix.mul_sum]
       _ = V * Kraus.transferMap (fun i => (B i)ᴴ) Λ * Vᴴ := by
-            simp [Kraus.transferMap_apply]
+            simp
       _ = ρ := by simp [ρ, hBfix, Matrix.mul_assoc]
   have hρ_tr : Matrix.trace ρ = 1 := by
     have hρ_unf : ρ = V * Λ * Vᴴ := rfl

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -470,7 +470,7 @@ theorem condC2_imp_condC1_of_injective
     calc
       Kraus.transferMap B X
           = V * Kraus.transferMap A (Vᴴ * X * V) * Vᴴ := by
-              simp [B, Kraus.transferMap_apply, Matrix.mul_assoc, Finset.mul_sum, Finset.sum_mul]
+              simp [B, Matrix.mul_assoc, Finset.mul_sum, Finset.sum_mul]
       _ = Kraus.transferMap A X := by
             have hVV : V * (Vᴴ * X * V) * Vᴴ = X := by
               calc

--- a/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
+++ b/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
@@ -54,6 +54,7 @@ arguments.
 \begin{lemma}[Perron gauges preserve primitivity]
     \label{lem:perron_gauge_primitive_iff}
     \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}
+    \lean{MPSTensor.transferMap_tpGauge_eq_similarityMap}
     \leanok
     Let $\sigma$ be positive definite. The transfer map of the Perron gauge
     determined by $\sigma$ is primitive if and only if the original transfer

--- a/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
+++ b/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
@@ -51,10 +51,29 @@ arguments.
     has spectral radius one, and its only eigenvalue is one.
 \end{proof}
 
+\begin{lemma}[Transfer map of a positive Perron gauge]
+    \label{lem:perron_gauge_transfer_similarity}
+    \lean{MPSTensor.transferMap_tpGauge_eq_similarityMap}
+    \leanok
+    \uses{def:transfer_map}
+    Let $\sigma>0$, put $S=\sigma^{1/2}$, and define
+    $B^i=SA^iS^{-1}$. Then
+    \begin{align}
+        \E_B(X)
+         & =S\,\E_A(S^{-1}XS^{-1})S.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute $B^i=SA^iS^{-1}$ in the Kraus sum. Since $S$ and $S^{-1}$
+    are Hermitian, the outer factors combine to $S$ and the inner factors to
+    $S^{-1}XS^{-1}$.
+\end{proof}
+
 \begin{lemma}[Perron gauges preserve primitivity]
     \label{lem:perron_gauge_primitive_iff}
     \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}
-    \lean{MPSTensor.transferMap_tpGauge_eq_similarityMap}
     \leanok
     Let $\sigma$ be positive definite. The transfer map of the Perron gauge
     determined by $\sigma$ is primitive if and only if the original transfer
@@ -62,6 +81,7 @@ arguments.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:perron_gauge_transfer_similarity}
     The two transfer maps are similar through the invertible congruence
     $X\mapsto\sigma^{-1/2}X\sigma^{-1/2}$. Similar linear maps have the same
     spectrum, so the condition that $1$ is the only eigenvalue on the unit

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -58,6 +58,25 @@
 \end{proof}
 
 
+\begin{theorem}[Transfer matrix of an MPS transfer map]
+    \label{thm:mps_transfer_matrix_kraus_sum}
+    \lean{MPSTensor.transferMatrix_eq}
+    \leanok
+    \uses{def:transfer_map}
+    For an MPS tensor $A=\{A^i\}_{i=0}^{d-1}$, the matrix representing
+    $\E_A$ under vectorization is
+    \begin{align}
+        K_A & =\sum_{i=0}^{d-1}\overline{A^i}\otimes A^i.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the standard vectorization identity
+    $\operatorname{vec}(AXB)=(B^{\mathsf T}\otimes A)\operatorname{vec}(X)$
+    to each summand $A^iX(A^i)^\dagger$ and sum over the physical index.
+\end{proof}
+
 \begin{lemma}[Trace adjointness of a transfer map]
     \label{lem:trace_mul_transfer_map_adjoint}
     \lean{Kraus.trace_mul_transferMap_adjoint}

--- a/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
+++ b/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
@@ -500,14 +500,21 @@ Section~\ref{sec:app_canonical_cyclic_sectors}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:adjoint_corner_fixed_of_preserved}
-    Irreducibility passes to the adjoint transfer map. The cyclic relation
-    sends each $P_k$ to an orthogonal projection. Equality in the
-    Kadison--Schwarz inequality therefore places every $P_k$ in the
-    multiplicative domain of $\E_{A^\dagger}$. The resulting left and right
-    multiplicativity identities, together with
-    Theorem~\ref{thm:adjoint_corner_fixed_of_preserved}, give the displayed
-    product formula for fixed elements supported on one sector.
+    \uses{thm:irreducible_unital_scalar_fixed_point}
+    Irreducibility passes to the adjoint transfer map. The cyclic relation and
+    equality in the Kadison--Schwarz inequality place every $P_k$ in its
+    multiplicative domain. If $X\in P_k\MN{D}P_k$ is fixed by
+    $(\E_{A^\dagger})^m$, then its orbit sum
+    \begin{align}
+        R_X & =\sum_{\ell=0}^{m-1}(\E_{A^\dagger})^\ell(X)
+        \notag
+    \end{align}
+    is fixed by $\E_{A^\dagger}$. By
+    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point}, $R_X=c\Id$.
+    Orthogonality of the cyclic sectors and the multiplicative-domain
+    identities give $X=P_kR_XP_k=cP_k$. Similarly, $Y=c'P_k$. Since
+    $\E_{A^\dagger}(P_k)=P_{k-1}$, both sides of the required identity equal
+    $cc'P_{k-1}$.
 \end{proof}
 
 \begin{lemma}[Sector irreducibility for the adjoint blocked map]%

--- a/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
+++ b/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
@@ -450,11 +450,69 @@ families are placed over a common blocked alphabet. The compression and
 common-alphabet identities are proved in
 Section~\ref{sec:app_canonical_cyclic_sectors}.
 
+\begin{theorem}[Fixed-point upgrade on an invariant corner]%
+    \label{thm:adjoint_corner_fixed_of_preserved}
+    \lean{MPSTensor.hFixUpgrade_of_peripheral}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A$ have positive bond dimension, suppose that $\E_A$ is irreducible,
+    and assume $\sum_i(A^i)^\dagger A^i=\Id$. Let $Q$ be an orthogonal
+    projection. If $(\E_{A^\dagger})^m$ preserves the corner
+    $Q\MN{D}Q$, then
+    \begin{align}
+        (\E_{A^\dagger})^m(Q) & =Q.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose a positive-definite fixed point $\rho$ of $\E_A$. The weighted
+    trace $X\mapsto\tr(\rho X)$ is invariant under $\E_{A^\dagger}$ and its
+    powers. Corner preservation gives
+    \begin{align}
+        Q-(\E_{A^\dagger})^m(Q)
+         & =Q(\E_{A^\dagger})^m(\Id-Q)Q\ge0.
+        \notag
+    \end{align}
+    The invariant weighted trace of this positive semidefinite difference is
+    zero. Since $\rho>0$, the difference vanishes.
+\end{proof}
+
+\begin{theorem}[Fixed-point algebra rigidity on cyclic sectors]%
+    \label{thm:sector_fixed_point_algebra_rigidity}
+    \lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}
+    \leanok
+    \uses{def:irreducible_tensor, def:transfer_map}
+    Let $A$ be an irreducible MPS tensor with positive bond dimension and
+    $\sum_i(A^i)^\dagger A^i=\Id$. Let $(P_k)_{k\in\Z/m\Z}$ be orthogonal
+    projections such that
+    \begin{align}
+        \sum_kP_k & =\Id,
+                  & \E_{A^\dagger}(P_{k+1}) & =P_k.
+        \notag
+    \end{align}
+    If $X,Y\in P_k\MN{D}P_k$ are fixed by $(\E_{A^\dagger})^m$, then
+    \begin{align}
+        \E_{A^\dagger}(XY)
+         & =\E_{A^\dagger}(X)\E_{A^\dagger}(Y).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:adjoint_corner_fixed_of_preserved}
+    Irreducibility passes to the adjoint transfer map. The cyclic relation
+    sends each $P_k$ to an orthogonal projection. Equality in the
+    Kadison--Schwarz inequality therefore places every $P_k$ in the
+    multiplicative domain of $\E_{A^\dagger}$. The resulting left and right
+    multiplicativity identities, together with
+    Theorem~\ref{thm:adjoint_corner_fixed_of_preserved}, give the displayed
+    product formula for fixed elements supported on one sector.
+\end{proof}
+
 \begin{lemma}[Sector irreducibility for the adjoint blocked map]%
     \label{thm:sector_irred_unconditional}
     \lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps}
-    \lean{MPSTensor.hFixUpgrade_of_peripheral}
-    \lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}
     \leanok
     \uses{def:irreducible_tensor}
     Let $A$ be a left-canonical irreducible MPS tensor with $D>0$, let $m$ be the

--- a/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
+++ b/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
@@ -501,9 +501,26 @@ Section~\ref{sec:app_canonical_cyclic_sectors}.
 
 \begin{proof}\leanok
     \uses{thm:irreducible_unital_scalar_fixed_point}
-    Irreducibility passes to the adjoint transfer map. The cyclic relation and
-    equality in the Kadison--Schwarz inequality place every $P_k$ in its
-    multiplicative domain. If $X\in P_k\MN{D}P_k$ is fixed by
+    Irreducibility passes to the adjoint transfer map. The cyclic relation
+    gives equality in both Kadison--Schwarz inequalities:
+    \begin{align}
+        \E_{A^\dagger}(P_k^\dagger P_k)
+         & =\E_{A^\dagger}(P_k)^\dagger\E_{A^\dagger}(P_k),
+        \notag                                              \\
+        \E_{A^\dagger}(P_kP_k^\dagger)
+         & =\E_{A^\dagger}(P_k)\E_{A^\dagger}(P_k)^\dagger.
+        \notag
+    \end{align}
+    Hence every $P_k$ lies in the multiplicative domain, so for every $Z$,
+    \begin{align}
+        \E_{A^\dagger}(P_kZ)
+         & =\E_{A^\dagger}(P_k)\E_{A^\dagger}(Z),
+        \notag                                    \\
+        \E_{A^\dagger}(ZP_k)
+         & =\E_{A^\dagger}(Z)\E_{A^\dagger}(P_k).
+        \notag
+    \end{align}
+    If $X\in P_k\MN{D}P_k$ is fixed by
     $(\E_{A^\dagger})^m$, then its orbit sum
     \begin{align}
         R_X & =\sum_{\ell=0}^{m-1}(\E_{A^\dagger})^\ell(X)

--- a/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
+++ b/blueprint/src/chapter/ch09_canonical_ft_reduction.tex
@@ -452,7 +452,10 @@ Section~\ref{sec:app_canonical_cyclic_sectors}.
 
 \begin{lemma}[Sector irreducibility for the adjoint blocked map]%
     \label{thm:sector_irred_unconditional}
-    \lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps}\leanok
+    \lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps}
+    \lean{MPSTensor.hFixUpgrade_of_peripheral}
+    \lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}
+    \leanok
     \uses{def:irreducible_tensor}
     Let $A$ be a left-canonical irreducible MPS tensor with $D>0$, let $m$ be the
     period of its cyclic-sector decomposition, and let $(P_u)_{u=1}^m$ be the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -382,7 +382,6 @@
 \begin{theorem}[A global change of cut gives periodic single-block states]
     \label{thm:block_diagonal_boundary_periodic_components_from_global_cut}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
-    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_source_length, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut, lem:block_diagonal_boundary_component_right_boundary_matrices}
     With the hypotheses and notation of
@@ -458,6 +457,60 @@
         1454--1456]{PerezGarcia2007Matrix}.
 \end{proof}
 
+\begin{theorem}[Doubly normalized global-cut boundary closing]
+    \label{thm:block_diagonal_boundary_periodic_components_doubly_normalized}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_doubly_normalized, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut}
+    Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
+    be irreducible blocks with positive bond dimensions, pairwise inequivalent
+    up to gauge and phase, and injective at a common
+    length $L_0>0$. Assume normalized self-overlap and the two normalization
+    identities
+    \begin{align}
+        \sum_a(A^j_a)^\dagger A^j_a & =\Id,
+        \notag                              \\
+        \sum_aA^j_a(A^j_a)^\dagger  & =\Id.
+        \notag
+    \end{align}
+    Let every $\mu_j$ be nonzero, and suppose
+    \begin{align}
+        L & \ge3(g-1)(L_0+1)+1,
+        \notag                  \\
+        N & \ge L+L_0.
+        \notag
+    \end{align}
+    If $\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)$, then there are
+    matrices $X_j$ such that, for every $j$,
+    \begin{align}
+        \psi
+         & =\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+        \notag                                                        \\
+        \Gamma_N^{A_j}(\mu_j^NX_j)
+         & \in\mathcal G_{N,L}(A_j).
+        \notag
+    \end{align}
+    This theorem is restricted to the case in which the positive dual fixed
+    matrices of the source normalization are all the identity, with normalized
+    self-overlap imposed separately.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_doubly_normalized, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut}
+    Obtain block-diagonal boundary matrices at the chosen cut. Move the cut
+    past the final $L_0$ sites and compare the two boundary representations.
+    The doubly normalized simultaneous product-span theorem separates the
+    blocks and gives
+    \begin{align}
+        (\mu_j^NX_j)A^j_\alpha
+         & =A^j_\alpha(\mu_j^NY_j).
+        \notag
+    \end{align}
+    for every word $\alpha$ of length $L_0$. Injectivity identifies the two
+    boundary matrices and permits the cut to move across every local interval,
+    proving the periodic single-block constraints.
+\end{proof}
+
 \begin{theorem}[Periodic block decomposition from a global cut]
     \label{thm:block_diagonal_chain_space_global_cut}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
@@ -500,7 +553,6 @@
 \begin{theorem}[Periodic block decomposition and block-space independence]
     \label{thm:block_diagonal_chain_space_global_cut_independent}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
-    \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut, lem:block_diagonal_boundary_representation_inclusion, lem:block_diagonal_boundary_closing_equality, thm:pgvwc_block_space_independence_source_length}
     Under the same hypotheses,
@@ -537,10 +589,46 @@
     sum.
 \end{proof}
 
+\begin{theorem}[Unique decomposition into open-boundary block spaces]
+    \label{thm:block_diagonal_chain_unique_decomposition_source_length}
+    \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length}
+    Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
+    be irreducible blocks with positive bond dimensions, pairwise inequivalent
+    up to gauge and phase, and injective at a common
+    length $L_0>0$. Assume the source normalization
+    \begin{align}
+        \sum_aA^j_a(A^j_a)^\dagger          & =\Id,
+        \notag                                            \\
+        \sum_a(A^j_a)^\dagger\Lambda_jA^j_a & =\Lambda_j,
+        \notag                                            \\
+        \Lambda_j                           & >0.
+        \notag
+    \end{align}
+    Let every $\mu_j$ be nonzero. If $0<L\le N$ and
+    $L\ge3(g-1)(L_0+1)+1$, then every
+    $\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)$ has a unique decomposition
+    \begin{align}
+        \psi   & =\sum_j\phi_j,
+        \notag                  \\
+        \phi_j & \in G_N(A_j)
+        \quad\text{for every }j.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length}
+    The source-length open-boundary theorem places $\psi$ in
+    $\sum_jG_N(A_j)$ and proves that the spaces $G_N(A_j)$ form an internal
+    sum. Existence follows from membership in the sum, and internality makes
+    the components unique.
+\end{proof}
+
 \begin{corollary}[Kernel containment from the global cut]
     \label{cor:block_diagonal_kernel_global_cut}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
-    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     Under the same hypotheses, suppose additionally that every periodic
@@ -560,6 +648,39 @@
     The parent-Hamiltonian kernel is the periodic chain space. Apply the
     preceding block decomposition and then the assumed single-block
     containments.
+\end{proof}
+
+\begin{theorem}[Doubly normalized kernel containment from a global cut]
+    \label{thm:block_diagonal_kernel_global_cut_doubly_normalized}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
+    \leanok
+    \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    Under the hypotheses of
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_doubly_normalized},
+    suppose in addition that, for every $j$,
+    \begin{align}
+        \mathcal G_{N,L}(A_j)
+         & \subseteq\spn\{\ket{V^{(N)}(A_j)}\}.
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+        \ker H_L^{(N)}\!\left(\bigoplus_j\mu_jA_j\right)
+         & \subseteq
+        \spn\{\ket{V^{(N)}(A_j)}:1\le j\le g\}.
+        \notag
+    \end{align}
+    This theorem is restricted to the doubly normalized case in which every
+    positive dual fixed matrix is the identity and normalized self-overlap is
+    assumed.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    The global-cut decomposition identifies the periodic chain space of the
+    block sum with the sum of the single-block chain spaces. Apply the assumed
+    containment to each summand, and use the identification of the
+    parent-Hamiltonian kernel with the periodic chain space.
 \end{proof}
 
 \begin{lemma}[Matrix identities give periodic single-block states]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -382,6 +382,7 @@
 \begin{theorem}[A global change of cut gives periodic single-block states]
     \label{thm:block_diagonal_boundary_periodic_components_from_global_cut}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_source_length, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut, lem:block_diagonal_boundary_component_right_boundary_matrices}
     With the hypotheses and notation of
@@ -499,6 +500,7 @@
 \begin{theorem}[Periodic block decomposition and block-space independence]
     \label{thm:block_diagonal_chain_space_global_cut_independent}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
+    \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut, lem:block_diagonal_boundary_representation_inclusion, lem:block_diagonal_boundary_closing_equality, thm:pgvwc_block_space_independence_source_length}
     Under the same hypotheses,
@@ -538,6 +540,7 @@
 \begin{corollary}[Kernel containment from the global cut]
     \label{cor:block_diagonal_kernel_global_cut}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07_of_dualFixedPoint}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     Under the same hypotheses, suppose additionally that every periodic

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -589,6 +589,44 @@
     sum.
 \end{proof}
 
+\begin{theorem}[Doubly normalized periodic block decomposition]
+    \label{thm:block_diagonal_chain_space_global_cut_doubly_normalized}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07}
+    \leanok
+    Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
+    be irreducible blocks with positive bond dimensions, pairwise inequivalent
+    up to gauge and phase, and injective at a common length $L_0>0$. Assume
+    normalized self-overlap and the two normalization identities
+    \begin{align}
+        \sum_a(A^j_a)^\dagger A^j_a & =\Id,
+        \notag                              \\
+        \sum_aA^j_a(A^j_a)^\dagger  & =\Id.
+        \notag
+    \end{align}
+    Let every $\mu_j$ be nonzero, and suppose
+    \begin{align}
+        L & \ge3(g-1)(L_0+1)+1,
+        \notag                  \\
+        N & \ge L+L_0.
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+         & =
+        \sum_j\mathcal G_{N,L}(A_j).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:block_diagonal_chain_space_global_cut}
+    Apply Theorem~\ref{thm:block_diagonal_chain_space_global_cut} with
+    $\Lambda_j=\Id$. The first normalization identity gives
+    $\sum_a(A^j_a)^\dagger\Lambda_jA^j_a=\Lambda_j$, so all hypotheses of that
+    theorem hold.
+\end{proof}
+
 \begin{theorem}[Unique decomposition into open-boundary block spaces]
     \label{thm:block_diagonal_chain_unique_decomposition_source_length}
     \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint}
@@ -654,7 +692,7 @@
     \label{thm:block_diagonal_kernel_global_cut_doubly_normalized}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    \uses{thm:block_diagonal_chain_space_global_cut_doubly_normalized, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     Under the hypotheses of
     Theorem~\ref{thm:block_diagonal_boundary_periodic_components_doubly_normalized},
     suppose in addition that, for every $j$,
@@ -676,9 +714,10 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:block_diagonal_chain_space_global_cut, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
-    The global-cut decomposition identifies the periodic chain space of the
-    block sum with the sum of the single-block chain spaces. Apply the assumed
+    \uses{thm:block_diagonal_chain_space_global_cut_doubly_normalized, lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut_doubly_normalized}
+    identifies the periodic chain space of the block sum with the sum of the
+    single-block chain spaces. Apply the assumed
     containment to each summand, and use the identification of the
     parent-Hamiltonian kernel with the periodic chain space.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -423,11 +423,27 @@ direct.
     after gauging.
 \end{proof}
 
+\begin{lemma}[Gauge-phase equivalence is invariant under gauge replacement]
+    \label{lem:gauge_phase_equiv_transport_same_dimension}
+    \lean{MPSTensor.gaugePhaseEquiv_of_gaugeEquiv_left_right}
+    \leanok
+    \uses{def:gauge_equiv, def:gauge_phase_equiv}
+    Let $A,A',B,B'$ have the same bond dimension. If $A$ is gauge equivalent
+    to $A'$, $A'$ is gauge-phase equivalent to $B'$, and $B$ is gauge
+    equivalent to $B'$, then $A$ is gauge-phase equivalent to $B$.
+\end{lemma}
+
+\begin{proof}\leanok
+    If $X,Y,Z$ are the left gauge, gauge-phase intertwiner, and right gauge,
+    respectively, then $Z^{-1}YX$ is the required intertwiner from $A$ to $B$;
+    it carries the same unit-modulus phase as $Y$.
+\end{proof}
+
 \begin{lemma}[Gauge-phase equivalence transports across two gauges]
     \label{lem:gauge_phase_equiv_transport_left_right}
     \lean{MPSTensor.gaugePhaseEquiv_of_gaugeEquiv_left_right_cast}
     \leanok
-    \uses{def:gauge_equiv, def:gauge_phase_equiv}
+    \uses{lem:gauge_phase_equiv_transport_same_dimension, def:gauge_equiv, def:gauge_phase_equiv}
     Gauge equivalent replacements on both sides preserve gauge-phase
     equivalence, including after identifying equal bond dimensions.
 \end{lemma}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -838,6 +838,10 @@
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         wMat_eigenvalue_eq_oneLabelChi_entry}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_eigen}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_one}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_diag_alt}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single01}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single10}
     \leanok
     \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
     The two diagonal entries of $\chi$ are eigenvalues of the local

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -832,16 +832,82 @@
     the nonnegative scalar $(25/32)^N$.
 \end{proof}
 
+\begin{theorem}[Unitality of the explicit per-site transfer map]%
+    \label{thm:mpdo_rescaling_transfer_unital}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_one}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    For the explicit four-letter tensor $A$, its per-site transfer map
+    $\varphi(Y)=\sum_aA^aY(A^a)^\dagger$ satisfies
+    \begin{align}
+        \varphi(\Id) & =\Id.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Evaluate the four matrix entries of $\varphi(\Id)$ from the displayed
+    matrices $A^a$. The diagonal entries are one and the off-diagonal entries
+    vanish.
+\end{proof}
+
+\begin{theorem}[Traceless diagonal eigenvector of the explicit transfer map]%
+    \label{thm:mpdo_rescaling_transfer_diag_alt}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_diag_alt}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    For $Z=\operatorname{diag}(1,-1)$, the same transfer map satisfies
+    \begin{align}
+        \varphi(Z) & =\frac{7}{25}Z.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Evaluate $\sum_aA^aZ(A^a)^\dagger$ entrywise. Its off-diagonal entries
+    vanish, while its diagonal entries are $7/25$ and $-7/25$.
+\end{proof}
+
+\begin{theorem}[Annihilation of the first off-diagonal matrix unit]%
+    \label{thm:mpdo_rescaling_transfer_single_zero_one}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single01}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    For the matrix unit $E_{01}$, the same transfer map satisfies
+    \begin{align}
+        \varphi(E_{01}) & =0.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitution of the four matrices $A^a$ shows that every entry of
+    $\sum_aA^aE_{01}(A^a)^\dagger$ is zero.
+\end{proof}
+
+\begin{theorem}[Annihilation of the second off-diagonal matrix unit]%
+    \label{thm:mpdo_rescaling_transfer_single_one_zero}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single10}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    For the matrix unit $E_{10}$, the same transfer map satisfies
+    \begin{align}
+        \varphi(E_{10}) & =0.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitution of the four matrices $A^a$ shows that every entry of
+    $\sum_aA^aE_{10}(A^a)^\dagger$ is zero.
+\end{proof}
+
 \begin{theorem}[Spectral identification of the local factor and the
         per-site transfer map]%
     \label{thm:mpdo_bnt_label_rescaling_stable_spectral}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         wMat_eigenvalue_eq_oneLabelChi_entry}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_eigen}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_one}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_diag_alt}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single01}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.transferMap_A_single10}
     \leanok
     \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
     The two diagonal entries of $\chi$ are eigenvalues of the local
@@ -856,6 +922,7 @@
     % eigenvalues as the diagonal entries of its chi matrix.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{thm:mpdo_rescaling_transfer_unital, thm:mpdo_rescaling_transfer_diag_alt, thm:mpdo_rescaling_transfer_single_zero_one, thm:mpdo_rescaling_transfer_single_one_zero}
     The uniform and alternating vectors are eigenvectors of the explicit
     $2\times2$ matrix $W$,
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -722,6 +722,7 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
 \begin{theorem}[Fixed local purification: pure RFP iff normalized physical-trace idempotence]
     \label{thm:purification_tensor_rfp_iff_physical_trace_idempotent}
     \lean{MPOTensor.purificationTensor_isTransferIdempotent_iff_physTraceTransfer_sq}
+    \lean{MPSTensor.transferMatrix_eq}
     \leanok
     \uses{def:mpdo_purification_tensor, def:mpo_physical_trace_transfer, def:mps_transfer_idempotence}
     Suppose that $M$ is the ancillary contraction of a fixed spin--ancilla

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -722,7 +722,6 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
 \begin{theorem}[Fixed local purification: pure RFP iff normalized physical-trace idempotence]
     \label{thm:purification_tensor_rfp_iff_physical_trace_idempotent}
     \lean{MPOTensor.purificationTensor_isTransferIdempotent_iff_physTraceTransfer_sq}
-    \lean{MPSTensor.transferMatrix_eq}
     \leanok
     \uses{def:mpdo_purification_tensor, def:mpo_physical_trace_transfer, def:mps_transfer_idempotence}
     Suppose that $M$ is the ancillary contraction of a fixed spin--ancilla


### PR DESCRIPTION
## What changed

- remove every unused simp argument exposed by the current full build
- add 11 declaration-scoped long-line linter exceptions covering 13 unavoidable warning headers caused by exported BNT theorem identifiers
- streamline `StringOrderAux` elaboration to keep the changed module below the hosted compilation-time warning threshold
- add dedicated Blueprint entries for every changed public declaration that previously lacked coverage
- preserve all public declaration names and theorem statements

## Validation

- targeted builds for every changed Lean module
- `lake build` (10,385 jobs; 0 warning headers)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- hosted-compatible Blueprint formatting checks
- `git diff --check`
