### PR TITLE
docs(blueprint): correct block-diagonal dependency edges

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -436,7 +436,65 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \end{align}
 \end{proof}
 
-The lemma gives $\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)$. This is not enough for
+\begin{theorem}[Doubly normalized block-diagonal boundary conditions at the source length]
+    \label{thm:bnt_block_diagonal_open_boundary_matrices_source_length_doubly_normalized}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}
+    \leanok
+    Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
+    be irreducible blocks with positive bond dimensions, pairwise inequivalent
+    up to gauge and phase, and injective at the common length $L_0>0$. Assume
+    normalized self-overlap and
+    \begin{align}
+        \sum_a(A^j_a)^\dagger A^j_a & =\Id,
+        \notag                              \\
+        \sum_aA^j_a(A^j_a)^\dagger  & =\Id.
+        \notag
+    \end{align}
+    Let every weight $\mu_j$ be nonzero. If $0<L\le N$ and
+    $L\ge3(g-1)(L_0+1)+1$, then
+    \begin{align}
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+         & \subseteq\bigoplus_jG_N(A_j).
+        \notag
+    \end{align}
+    In particular, every vector $\psi$ in the left-hand side admits matrices
+    $X_j$ such that
+    \begin{align}
+        \psi
+         & =\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+        \notag                                                        \\
+        \Gamma_N^{A_j}(\mu_j^NX_j)
+         & \in G_N(A_j)
+        \notag
+    \end{align}
+    for every $j$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc_direct_sum_intersection_doubly_normalized, thm:pgvwc_block_space_independence_doubly_normalized, lem:block_diagonal_boundary_of_open_boundary_sum}
+    Put $S_M=\sum_jG_M(A_j)$. For every $M$ with $L\le M<N$,
+    Theorem~\ref{thm:pgvwc_direct_sum_intersection_doubly_normalized} gives
+    \begin{align}
+        \left(\bigcap_b\Res_{-,b}^{-1}S_M\right)
+        \cap
+        \left(\bigcap_a\Res_{a,-}^{-1}S_M\right)
+         & =S_{M+1}.
+        \notag
+    \end{align}
+    Induction through the cyclic local constraints therefore yields
+    \begin{align}
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+         & \subseteq S_N.
+        \notag
+    \end{align}
+    At the stated length, the block-space independence theorem makes this sum
+    internal. Lemma~\ref{lem:block_diagonal_boundary_of_open_boundary_sum}
+    then supplies the matrices $X_j$.
+\end{proof}
+
+The theorem gives $\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)$. This is not enough for
 periodic-boundary membership when a cyclic window crosses the chosen cut. The
 boundary-cut comparison of
 Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -461,7 +461,6 @@
     \label{thm:block_diagonal_boundary_periodic_components_doubly_normalized}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_doubly_normalized, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut}
     Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
     be irreducible blocks with positive bond dimensions, pairwise inequivalent
     up to gauge and phase, and injective at a common
@@ -496,7 +495,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length, thm:pgvwc_product_span_doubly_normalized, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut}
+    \uses{thm:bnt_block_diagonal_open_boundary_matrices_source_length_doubly_normalized, thm:pgvwc_product_span_doubly_normalized, lem:parent_cyclic_translate_preserves_chain_space, lem:block_boundary_intertwiner_from_global_cut}
     Obtain block-diagonal boundary matrices at the chosen cut. Move the cut
     past the final $L_0$ sites and compare the two boundary representations.
     The doubly normalized simultaneous product-span theorem separates the
@@ -589,6 +588,30 @@
     sum.
 \end{proof}
 
+\begin{theorem}[Doubly normalized periodic block decomposition and independence]
+    \label{thm:block_diagonal_chain_space_global_cut_independent_doubly_normalized}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07}
+    \leanok
+    \uses{thm:block_diagonal_boundary_periodic_components_doubly_normalized}
+    Under the hypotheses of
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_doubly_normalized},
+    \begin{align}
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+         & =
+        \sum_j\mathcal G_{N,L}(A_j),
+        \notag
+    \end{align}
+    and the open-boundary spaces $G_N(A_j)$ form an internal sum.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:block_diagonal_chain_space_global_cut_independent}
+    Apply
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut_independent}
+    with $\Lambda_j=\Id$. Left canonicity gives the required dual fixed-point
+    identity, while the remaining hypotheses are unchanged.
+\end{proof}
+
 \begin{theorem}[Doubly normalized periodic block decomposition]
     \label{thm:block_diagonal_chain_space_global_cut_doubly_normalized}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07}
@@ -620,18 +643,15 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:block_diagonal_chain_space_global_cut}
-    Apply Theorem~\ref{thm:block_diagonal_chain_space_global_cut} with
-    $\Lambda_j=\Id$. The first normalization identity gives
-    $\sum_a(A^j_a)^\dagger\Lambda_jA^j_a=\Lambda_j$, so all hypotheses of that
-    theorem hold.
+    \uses{thm:block_diagonal_chain_space_global_cut_independent_doubly_normalized}
+    This is the equality component of
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut_independent_doubly_normalized}.
 \end{proof}
 
 \begin{theorem}[Unique decomposition into open-boundary block spaces]
     \label{thm:block_diagonal_chain_unique_decomposition_source_length}
     \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length}
     Let $g\ge2$, assume the physical alphabet is nonempty, and let $A_j$
     be irreducible blocks with positive bond dimensions, pairwise inequivalent
     up to gauge and phase, and injective at a common


### PR DESCRIPTION
## What changed

- remove proof-only dependencies from two theorem statements added in #7184
- add exact Blueprint entries for the doubly normalized open-boundary and combined chain-space declarations
- point specialized proofs at the declarations their Lean implementations actually call

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- hosted `latexindent` 3.23.6 checks on both modified files
- double `lualatex` compilation (new references resolved; repository baseline undefined references remain without the precompiled bibliography)
- `git diff --check`

Follow-up to #7184.