### PR TITLE
refactor(qiclean): retire transfer compatibility consumers

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -6,7 +6,8 @@ Authors: TNLean contributors
 import QICLean.Algebra.ComplexPhasePositivity
 import QICLean.Channel.Irreducible.SpectralRadius
 import TNLean.MPS.CanonicalForm.Definitions
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Irreducible.PerronGauge
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
@@ -249,7 +250,7 @@ theorem exists_tpGauge_of_irreducible_spectralRadius_one
   have htrace : Matrix.trace (σ * Kraus.transferMap (d := d) (D := D) A ρ) =
       Matrix.trace
         (Kraus.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ * ρ) :=
-    Kraus.trace_mul_transferMap_adjoint A rfl σ ρ
+    Kraus.trace_mul_mapLM_adjoint A rfl σ ρ
   have htr_ne : Matrix.trace (σ * ρ) ≠ 0 := by
     intro htr
     exact (Matrix.PosDef.isUnit hρ).ne_zero

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Core.Blocking
 import QICLean.Kraus.Transfer
+import QICLean.Kraus.MapIterate
 import QICLean.Spectral.MixedTransfer
 
 import Mathlib.LinearAlgebra.Eigenspace.Basic
@@ -34,7 +35,7 @@ theorem transferMap_blockTensor_apply
       ((Kraus.transferMap (d := d) (D := D) A) ^ L) X := by
   classical
   -- Expand the RHS as a sum over length-`L` words.
-  rw [Kraus.transferMap_pow_apply' (A := A) (N := L) X]
+  rw [Kraus.mapLM_pow_apply (K := A) (N := L) X]
   -- Expand the LHS as a sum over blocked physical indices.
   simp only [Kraus.transferMap_apply, Kraus.blockTensor, Kraus.wordOfBlock]
   -- Reindex the blocked sum by the equivalence `Fin (blockPhysDim d L) ≃ (Fin L → Fin d)`.

--- a/TNLean/MPS/Core/TransferPeripheral.lean
+++ b/TNLean/MPS/Core/TransferPeripheral.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import QICLean.Channel.Peripheral.ClosureFixedPointKraus
 import QICLean.Channel.Peripheral.CyclicGroupKraus
 import QICLean.Channel.Peripheral.CyclicDecomposition.LetterShift
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.Transfer
 
 /-!
 # Transfer-map forms of the peripheral fixed-point and cyclic-group results

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PureAreaLaw
 import QICLean.Spectral.MixedTransfer
+import QICLean.Kraus.MapIterate
 import TNLean.MPS.RFP.Defs
 
 /-!
@@ -41,7 +42,7 @@ L-fold transfer map evaluated on the matrix unit e_{b₂,a₂}. -/
 theorem schmidtLeft_gram_apply (A : MPSTensor d D) (L : ℕ) (a b : Fin D × Fin D) :
     ((schmidtLeft A L)ᴴ * schmidtLeft A L) a b
       = ((Kraus.transferMap A ^ L) (Matrix.single b.2 a.2 1)) b.1 a.1 := by
-  rw [Matrix.mul_apply, Kraus.transferMap_pow_apply', Matrix.sum_apply]
+  rw [Matrix.mul_apply, Kraus.mapLM_pow_apply, Matrix.sum_apply]
   refine Finset.sum_congr rfl (fun σ _ => ?_)
   simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, schmidtLeft, Matrix.of_apply,
     Matrix.single_apply, RCLike.star_def, mul_ite, mul_one, mul_zero, ite_and, ite_mul,
@@ -73,7 +74,7 @@ noncomputable def schmidtRight (A : MPSTensor d D) (M : ℕ) :
 theorem schmidtRight_gram_apply (A : MPSTensor d D) (M : ℕ) (p q : Fin D × Fin D) :
     (schmidtRight A M * (schmidtRight A M)ᴴ) p q
       = ((Kraus.transferMap A ^ M) (Matrix.single p.1 q.1 1)) p.2 q.2 := by
-  rw [Matrix.mul_apply, Kraus.transferMap_pow_apply', Matrix.sum_apply]
+  rw [Matrix.mul_apply, Kraus.mapLM_pow_apply, Matrix.sum_apply]
   refine Finset.sum_congr rfl (fun σ _ => ?_)
   simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, schmidtRight, Matrix.of_apply,
     Matrix.single_apply, RCLike.star_def, mul_ite, mul_one, mul_zero, ite_and, ite_mul,

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -5,7 +5,8 @@ Authors: TNLean contributors
 -/
 import QICLean.Algebra.MatrixStabilization
 import QICLean.Algebra.MatrixPosDefTransport
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.TransferMatrix
 
@@ -228,7 +229,7 @@ theorem IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii
       (transferMatrix (Kraus.transferMap U.normalizedFlattening)) =
         (1 : Matrix (Fin D) (Fin D) ℂ).vec :=
     vecMul_vec_one_transferMatrix_eq_of_trace_preserving _
-      (fun X => Kraus.trace_transferMap U.normalizedFlattening X hAleft)
+      (fun X => Kraus.isTracePreservingMap_mapLM_of_isTP U.normalizedFlattening hAleft X)
   have hright : transferMatrix (Kraus.transferMap U.normalizedFlattening) *ᵥ ρ.vec =
       ρ.vec := by
     rw [transferMatrix_mulVec_eq, hρfix]

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -5,7 +5,8 @@ Authors: TNLean contributors
 -/
 import QICLean.Algebra.OperatorNormFrobenius
 import QICLean.Analysis.SpectralRadiusPowerDecay
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.Structure.PrimitiveFixedPoint
 
@@ -132,7 +133,7 @@ theorem IsPrimitiveMPS.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
       ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
   have hTP : IsTracePreservingMap (Kraus.transferMap A) := by
     intro X
-    exact Kraus.trace_transferMap A X hP.norm
+    exact Kraus.isTracePreservingMap_mapLM_of_isTP A hP.norm X
   exact MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
     A ρ htr hTP hP.fixedPoint_is_fixed hP.complementary_transfer_map_gap
 
@@ -153,7 +154,7 @@ theorem IsPrimitiveMPS.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
       ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
   have hTP : IsTracePreservingMap (Kraus.transferMap A) := by
     intro X
-    exact Kraus.trace_transferMap A X hP.norm
+    exact Kraus.isTracePreservingMap_mapLM_of_isTP A hP.norm X
   exact MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
     A ρ htr hTP hP.fixedPoint_is_fixed hP.complementary_transfer_map_gap
 

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import QICLean.Algebra.FrobeniusHilbert
 import QICLean.Algebra.RectangularChoi
 import QICLean.Analysis.InjectiveRangeProjector
+import QICLean.Kraus.MapIterate
 import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.Defs
 import QICLean.Spectral.MixedTransfer
@@ -156,7 +157,7 @@ theorem inner_single_groundSpaceGram_single_eq_rectangularChoi
     (WithLp.toLp 2 (groundSpaceMap A L (Matrix.single a b 1)))
     (WithLp.toLp 2 (groundSpaceMap A L (Matrix.single c e 1))) = _
   rw [EuclideanSpace.inner_toLp_toLp, Matrix.rectangularChoi_apply,
-    Kraus.transferMap_pow_apply']
+    Kraus.mapLM_pow_apply]
   have hmul (W : Matrix (Fin D) (Fin D) ℂ) :
       ((W * Matrix.single c a 1 * Wᴴ : Matrix (Fin D) (Fin D) ℂ) e b) =
         W e c * star (W b a) := by

--- a/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
+++ b/TNLean/MPS/ParentHamiltonian/HalfChainSchmidt.lean
@@ -7,7 +7,8 @@ import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
 import QICLean.Algebra.OperatorNormFrobenius
 import QICLean.Analysis.SpectralRadiusPowerDecay
 import QICLean.Channel.Primitive
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.MapIterate
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Overlap.Basic
 
 /-!
@@ -187,7 +188,7 @@ theorem halfChainGram_apply_eq_transferMap_pow (A : MPSTensor d D) (L : ℕ)
       _ = W e c * star (W b a) := by
         rw [Matrix.mul_apply]
         simp [Matrix.single_apply]
-  rw [halfChainGram, Matrix.mul_apply, Kraus.transferMap_pow_apply' A L, Matrix.sum_apply]
+  rw [halfChainGram, Matrix.mul_apply, Kraus.mapLM_pow_apply A L, Matrix.sum_apply]
   refine Finset.sum_congr rfl fun σ _ => ?_
   rw [hmul (Kraus.evalWord A (List.ofFn σ)) p.2 p.1 q.2 q.1]
   simp [mul_comm]

--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.MapIterate
+import QICLean.Kraus.Transfer
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 
@@ -46,7 +48,7 @@ theorem tailVirtualMapES_adjoint_comp_self_apply (A : MPSTensor d D) (K : ℕ)
   have hsum : (∑ u : Cfg d K, Kraus.evalWord A (List.ofFn u) * (Kraus.evalWord A (List.ofFn u))ᴴ) =
       ((Kraus.transferMap (d := d) (D := D) A) ^ K) 1 := by
     symm
-    simpa only [Matrix.mul_one] using Kraus.transferMap_pow_apply' A K 1
+    simpa only [Matrix.mul_one] using Kraus.mapLM_pow_apply A K 1
   simpa only [Matrix.mul_assoc, Matrix.mul_sum] using
     congrArg (fun M => Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) (X * M)) hsum
 
@@ -142,7 +144,7 @@ theorem IsPrimitiveMPS.tailVirtualMapES_norm_four_pow_uniform
   let T := (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N
   have hTP : IsTracePreservingMap E := by
     intro X
-    exact Kraus.trace_transferMap A X hP.norm
+    exact Kraus.isTracePreservingMap_mapLM_of_isTP A hP.norm X
   have hgap : spectralRadius ℂ T < 1 := by
     dsimp only [T, N, E, P]
     convert hP.complementary_transfer_map_gap using 1

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import QICLean.Algebra.ComplexPhasePositivity
 import QICLean.Algebra.FinSum
 import TNLean.MPS.Core.MultiBlock
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.Transfer
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.SharedInfra.Scaling

--- a/TNLean/MPS/RFP/BNTWeightCounterexample.lean
+++ b/TNLean/MPS/RFP/BNTWeightCounterexample.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
+import QICLean.Kraus.MapIterate
 import TNLean.MPS.RFP.ZeroCorrelationLength
 
 /-!
@@ -84,7 +85,7 @@ private theorem physicalObservableTransfer_one
   intro X
   change physicalObservableTransfer A L O X =
     O (0 : Fin L → Fin 1) (0 : Fin L → Fin 1) • ((Kraus.transferMap A) ^ L) X
-  rw [Kraus.transferMap_pow_apply']
+  rw [Kraus.mapLM_pow_apply]
   simp only [physicalObservableTransfer, Finset.univ_unique, Pi.default_def,
     Fin.default_eq_zero, Fin.isValue, Finset.sum_singleton, List.ofFn_const]
   rw [Matrix.mul_assoc]

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.Primitive
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.MPVOverlapTrace
 
@@ -72,7 +73,7 @@ theorem mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one
   -- First derive `trace((Kraus.transferMap A)^N) → 1`.
   have hTP : IsTracePreservingMap (Kraus.transferMap (d := d) (D := D) A) := by
     intro X
-    exact Kraus.trace_transferMap A X hNorm
+    exact Kraus.isTracePreservingMap_mapLM_of_isTP A hNorm X
   have htrρ : Matrix.trace ρ ≠ 0 := by
     intro htr0
     exact hρ_ne ((Matrix.PosSemidef.trace_eq_zero_iff hρ_psd).1 htr0)

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import QICLean.Kraus.MixedMap.Gap
 import QICLean.Kraus.InvariantProjection
-import QICLean.Kraus.TransferChannel
 import QICLean.Spectral.GaugeConstruction
 import TNLean.Spectral.MPVOverlapDecayRect
 import QICLean.Spectral.TransferOperatorGapNormalized

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import QICLean.Kraus.Wielandt.Primitivity.VectorSpreadPositivity
 import QICLean.Kraus.InvariantProjection
-import QICLean.Kraus.TransferChannel
 import TNLean.Wielandt.Primitivity.Definitions
 
 /-!

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -5,7 +5,8 @@ Authors: TNLean contributors
 -/
 import QICLean.Algebra.EigenspaceMap
 import QICLean.Kraus.Wielandt.Primitivity.VectorSpreadToPrimitive
-import QICLean.Kraus.TransferChannel
+import QICLean.Channel.KrausMap
+import QICLean.Kraus.Transfer
 import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
 
 /-!

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Kraus.MapIterate
-import QICLean.Kraus.TransferChannel
+import QICLean.Kraus.Transfer
 import TNLean.MPS.Structure.PrimitiveFixedPoint
 
 /-!
@@ -74,7 +74,7 @@ theorem exists_nonzero_evalWord_of_isPrimitiveMPS [NeZero D]
   push Not at hall
   have hzero : ∀ σ : Fin n → Fin d, Kraus.evalWord A (List.ofFn σ) = 0 := hall
   have hsum : ((Kraus.transferMap (d := d) (D := D) A) ^ n) ρ = 0 := by
-    rw [Kraus.transferMap_pow_apply']
+    rw [Kraus.mapLM_pow_apply]
     refine Finset.sum_eq_zero ?_
     intro σ _
     rw [hzero σ, Matrix.zero_mul, Matrix.zero_mul]

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.WolfTheorem68
-import QICLean.Kraus.TransferChannel
 import TNLean.Wielandt.Primitivity.PrimitiveBridge
 
 /-!

--- a/blueprint/qiclean_split_residual.json
+++ b/blueprint/qiclean_split_residual.json
@@ -1000,7 +1000,7 @@
       "title": "Trace adjointness of a transfer map",
       "label": "lem:trace_mul_transfer_map_adjoint",
       "shared_lean_declarations": [
-        "Kraus.trace_mul_transferMap_adjoint"
+        "Kraus.trace_mul_mapLM_adjoint"
       ],
       "disposition": "retained TN-facing interface",
       "justification": "The statement is trace adjointness in MPS transfer-map notation."
@@ -1011,7 +1011,7 @@
       "title": "Left-canonical transfer maps preserve trace",
       "label": "lem:trace_transfer_map_left_canonical",
       "shared_lean_declarations": [
-        "Kraus.trace_transferMap"
+        "Kraus.isTracePreservingMap_mapLM_of_isTP"
       ],
       "disposition": "retained TN-facing interface",
       "justification": "The statement is trace preservation for a left-canonical MPS tensor."

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -79,7 +79,7 @@
 
 \begin{lemma}[Trace adjointness of a transfer map]
     \label{lem:trace_mul_transfer_map_adjoint}
-    \lean{Kraus.trace_mul_transferMap_adjoint}
+    \lean{Kraus.trace_mul_mapLM_adjoint}
     \leanok
     \uses{def:transfer_map}
     The trace-adjoint identity of
@@ -112,7 +112,7 @@
 
 \begin{lemma}[Left-canonical transfer maps preserve trace]
     \label{lem:trace_transfer_map_left_canonical}
-    \lean{Kraus.trace_transferMap}
+    \lean{Kraus.isTracePreservingMap_mapLM_of_isTP}
     \leanok
     \uses{def:transfer_map, def:left_canonical_tensor}
     If $A$ is left canonical, then, for every bond matrix $X$,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -304,12 +304,10 @@ abstracted — record why, so it is not re-proposed).
 - **Seen:** three occurrences across `Channel/Irreducible/FromSpectral.lean`,
   `PerronFrobenius.lean`, and `SpectralRadius.lean` before promotion
   (2026-08-09).
-- **Abstraction:** `Kraus.trace_mul_transferMap_adjoint` in
-  `QICLean/Channel/Irreducible/KrausSetup.lean` (QICLean dependency).
-- **Notes:** transfer-map callers use the canonical `Kraus.isChannel_mapLM`
-  theorem from `QICLean/Channel/KrausMap.lean` directly, relying on the
-  definitional equality with `Kraus.transferMap`. The transfer-specific
-  trace-adjoint compatibility theorem remains available for its distinct result.
+- **Abstraction:** `Kraus.trace_mul_mapLM_adjoint` in
+  `QICLean/Channel/KrausMap.lean` (QICLean dependency).
+- **Notes:** transfer-map callers use this canonical finite-Kraus theorem directly,
+  relying on the definitional equality of `Kraus.mapLM` and `Kraus.transferMap`.
 
 ### matrix-family irreducibility in transfer-map notation — promoted
 - **Pattern:** convert between irreducibility of a finite matrix family and


### PR DESCRIPTION
## Summary
- replace the three `QICLean.Kraus.TransferChannel` compatibility declarations with canonical `mapLM` APIs
- remove every TNLean import of the compatibility module
- add direct `KrausMap`, `MapIterate`, and `Transfer` imports at actual consumers
- retarget Blueprint and tactic-pattern references to canonical declarations

## Verification
- all 17 changed Lean modules
- full `lake build` (10,388 jobs)
- Blueprint sync and declaration resolution
- generated import freshness
- style and forbidden-token checks
- no remaining Lean imports or declaration uses of `TransferChannel`
