### PR TITLE
refactor(mps): package prepared BNT block data

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormBridge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormBridge.lean
@@ -168,10 +168,20 @@ theorem exists_isBNTCanonicalForm_exact
     intro k
     exact hGauge k
   obtain ⟨Y, hY⟩ := hDirectGauge
+  let preparedData : PreparedBNTBlocks d :=
+    { r := data.r
+      dim := data.dim
+      weight := data.weights
+      blocks := prepared
+      dim_pos := data.dim_pos
+      leftCanonical := hTP
+      primitive := hPrim
+      irreducible := hIrr
+      weight_ne_zero := data.weights_ne_zero }
   obtain ⟨P, hBNT, hTotal, e, X, hExact⟩ :=
-    exists_isBNTCanonicalForm_exact_of_tp_primitive_irr_blocks
-      data.weights prepared data.dim_pos hTP hPrim hIrr data.weights_ne_zero
-      hNorm.weight_norm_le_one (hNorm.weight_unit_exists hA)
+    preparedData.exists_isBNTCanonicalForm_exact
+      { norm_le_one := hNorm.weight_norm_le_one
+        unit_exists := hNorm.weight_unit_exists hA }
   let Q : Matrix (Fin P.totalDim) (Fin (∑ k, data.dim k)) ℂ :=
     equivalenceCoisometry e
   let W := transportGL e Y

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/PreparedReconstruction.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/PreparedReconstruction.lean
@@ -13,7 +13,9 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 This module strengthens the prepared-block SectorBNT supplier from positive-length
 matrix-product-vector equality to a letterwise reconstruction. It retains the precise
 phase-class scalar, assembles the resulting block gauges, and reindexes the heterogeneous
-block sum by an equivalence of flattened bond coordinates.
+block sum by an equivalence of flattened bond coordinates. The bundled
+`PreparedBNTBlocks.exists_isBNTCanonicalForm_exact` method exposes this reconstruction
+without repeating the prepared family and its invariants.
 -/
 
 open scoped Matrix BigOperators
@@ -250,5 +252,19 @@ theorem exists_isBNTCanonicalForm_exact_of_tp_primitive_irr_blocks
   rw [hX]
   exact toTensorFromBlocks_eq_reindex_of_equiv μ blocks P.flatWeight gaugedFlat
     blockEquiv hBlockDim hBlock i
+
+/-- Normalized prepared blocks have an exact, dimension-preserving BNT reconstruction. -/
+theorem PreparedBNTBlocks.exists_isBNTCanonicalForm_exact
+    (data : PreparedBNTBlocks d) (hNorm : data.IsWeightNormalized) :
+    ∃ P : SectorDecomposition d,
+      IsBNTCanonicalForm P ∧ P.totalDim = ∑ k : Fin data.r, data.dim k ∧
+      ∃ e : Fin P.totalDim ≃ Fin (∑ k : Fin data.r, data.dim k),
+      ∃ X : GL (Fin P.totalDim) ℂ, ∀ i,
+        toTensorFromBlocks (d := d) data.weight data.blocks i =
+          Matrix.reindex e e
+            ((X : Matrix _ _ ℂ) * P.toTensor i * (↑(X⁻¹) : Matrix _ _ ℂ)) :=
+  exists_isBNTCanonicalForm_exact_of_tp_primitive_irr_blocks
+    data.weight data.blocks data.dim_pos data.leftCanonical data.primitive data.irreducible
+      data.weight_ne_zero hNorm.norm_le_one hNorm.unit_exists
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -15,9 +15,10 @@ import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 /-!
 # Prepared-block SectorBNT constructor
 
-Given a finite family of **already prepared** TP / primitive / irreducible
-blocks with nonzero weights satisfying the CPSV16 §II.C line-246 normalization
-(`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
+The `PreparedBNTBlocks` structure packages a finite family of **already prepared**
+TP / primitive / irreducible blocks and their nonzero weights. Its nested
+`IsWeightNormalized` proposition records the CPSV16 §II.C line-246 normalization
+(`|μ_k| ≤ 1` and at least one `|μ_k| = 1`). The bundled supplier methods produce a
 `SectorDecomposition` `P` together with a proof that
 
 * `P.toTensor` has the same MPV at every positive length as the original
@@ -354,6 +355,39 @@ theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
 
 /-! ### Prepared-block SectorBNT constructor -/
 
+/-- A finite family of positive-dimensional, left-canonical, primitive, irreducible blocks
+with nonzero weights, ready for phase-class collapse into BNT sectors. -/
+structure PreparedBNTBlocks (d : ℕ) where
+  /-- Number of prepared blocks. -/
+  r : ℕ
+  /-- Bond dimension of each prepared block. -/
+  dim : Fin r → ℕ
+  /-- Scalar weight of each prepared block. -/
+  weight : Fin r → ℂ
+  /-- Prepared tensor blocks. -/
+  blocks : (k : Fin r) → MPSTensor d (dim k)
+  /-- Every prepared block has positive bond dimension. -/
+  dim_pos : ∀ k, 0 < dim k
+  /-- Every prepared block is left-canonical. -/
+  leftCanonical : ∀ k, IsLeftCanonical (blocks k)
+  /-- Every prepared block has primitive transfer map. -/
+  primitive : ∀ k, _root_.IsPrimitive (Kraus.transferMap (blocks k))
+  /-- Every prepared block is an irreducible Kraus family. -/
+  irreducible : ∀ k, Kraus.IsIrreducibleFamily (blocks k)
+  /-- Every prepared-block weight is nonzero. -/
+  weight_ne_zero : ∀ k, weight k ≠ 0
+
+namespace PreparedBNTBlocks
+
+/-- CPSV16 §II.C normalization of the weights of prepared blocks. -/
+structure IsWeightNormalized (data : PreparedBNTBlocks d) : Prop where
+  /-- Every prepared-block weight has norm at most one. -/
+  norm_le_one : ∀ k, ‖data.weight k‖ ≤ 1
+  /-- Some prepared-block weight has unit norm. -/
+  unit_exists : ∃ k, ‖data.weight k‖ = 1
+
+end PreparedBNTBlocks
+
 /--
 **Prepared-block SectorBNT constructor.**
 
@@ -488,6 +522,27 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
   exact isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
     μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
 
+/-- The phase-class collapse of normalized prepared blocks is in BNT canonical form. -/
+theorem PreparedBNTBlocks.isBNTCanonicalForm_collapsed
+    (data : PreparedBNTBlocks d) (hNorm : data.IsWeightNormalized) :
+    IsBNTCanonicalForm
+      (collapsedBntSectorDecomp (d := d) data.weight data.blocks data.weight_ne_zero) :=
+  isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
+    data.weight data.blocks data.dim_pos data.leftCanonical data.primitive data.irreducible
+      data.weight_ne_zero hNorm.norm_le_one hNorm.unit_exists
+
+/-- Normalized prepared blocks determine a BNT sector decomposition with the same
+positive-length matrix product vectors. -/
+theorem PreparedBNTBlocks.exists_isBNTCanonicalForm
+    (data : PreparedBNTBlocks d) (hNorm : data.IsWeightNormalized) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂Pos P.toTensor
+        (toTensorFromBlocks (d := d) (μ := data.weight) data.blocks) ∧
+      IsBNTCanonicalForm P :=
+  exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
+    data.weight data.blocks data.dim_pos data.leftCanonical data.primitive data.irreducible
+      data.weight_ne_zero hNorm.norm_le_one hNorm.unit_exists
+
 /-- Prepared TP, primitive, irreducible blocks determine a dimension-preserving BNT
 canonical-form sector decomposition.
 
@@ -513,6 +568,17 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim
       μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
   · exact collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
       μ blocks hDim hTP hPrim hIrr hμne
+
+/-- Normalized prepared blocks determine a dimension-preserving BNT sector decomposition. -/
+theorem PreparedBNTBlocks.exists_isBNTCanonicalForm_and_totalDim
+    (data : PreparedBNTBlocks d) (hNorm : data.IsWeightNormalized) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂Pos P.toTensor
+        (toTensorFromBlocks (d := d) (μ := data.weight) data.blocks) ∧
+      IsBNTCanonicalForm P ∧ P.totalDim = ∑ k : Fin data.r, data.dim k :=
+  exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim
+    data.weight data.blocks data.dim_pos data.leftCanonical data.primitive data.irreducible
+      data.weight_ne_zero hNorm.norm_le_one hNorm.unit_exists
 
 /-! ### Arbitrary-input prepared-block supplier
 


### PR DESCRIPTION
## Summary
- add `PreparedBNTBlocks` and its weight-normalization predicate to package repeated dependent supplier data
- expose bundled adapters for collapsed, existential, dimension-preserving, and exact BNT reconstruction
- migrate the canonical-form bridge consumer to one prepared-data record

All existing public theorem statements remain byte-for-byte unchanged. The long coordinate proof and arbitrary-input/injectivity path are intentionally untouched.

## Verification
- narrow and downstream SectorBNT builds
- full `lake build` (10,388 jobs)
- Blueprint sync/declaration checks after temporary regeneration of the already-stale stacked-base declaration index
- generated imports, module policies, proof-integrity/style checks
- `git diff --check`

Stacked on #7191 to isolate the three-file packaging diff. Unrelated untracked `docs/tenkz/` remains untouched.