### PR TITLE
docs: resolve post-cleanup follow-up issues

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -43,6 +43,7 @@ on:
       - 'blueprint/.chktexrc'
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
+      - 'scripts/test_blueprint_lean_sync.py'
       - 'scripts/test_blueprint_web_render.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/audit_cpsv16_labels.py'
@@ -95,6 +96,7 @@ on:
       - 'blueprint/.chktexrc'
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
+      - 'scripts/test_blueprint_lean_sync.py'
       - 'scripts/test_blueprint_web_render.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/audit_cpsv16_labels.py'
@@ -594,6 +596,9 @@ jobs:
       - name: Test generated blueprint pages
         if: env.TEX_CHANGED == 'true'
         run: python3 scripts/test_blueprint_web_render.py --web-root blueprint/web
+
+      - name: Test Blueprint declaration scanner
+        run: python3 scripts/test_blueprint_lean_sync.py
 
       - name: Generate lean_decls from blueprint .tex files
         id: lean-decls

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -13,6 +13,17 @@ This module connects Appendix B structural extraction data to the generic
 parent-Hamiltonian interfaces. It contains the RFP-specific conditional bridge
 theorems, while `TNLean.MPS.ParentHamiltonian.Commuting` remains independent of
 the RFP layer.
+
+## Main statements
+
+* `rfp_implies_nncph_of_appendixBExtraction`
+* `rfp_implies_nncph_ground_state_of_appendixBExtraction`
+* `rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning`
+
+## References
+
+The statements implement the conditional Appendix B route for Theorem 3.10(i)⇒(iii)
+of Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608.
 -/
 
 open scoped Matrix BigOperators

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -513,7 +513,7 @@ single family.
 
 \begin{lemma}[Unit-modulus weight witness from the canonical-form normalization]%
     \label{lem:sector_bnt_weight_unit_exists}
-    \lean{MPSTensor.IsBNTCanonicalForm}
+    \lean{MPSTensor.IsBNTCanonicalForm.weight_unit_exists}
     \leanok
     \uses{def:sector_bnt_cf}
     Under the BNT canonical form, the

--- a/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
@@ -248,19 +248,10 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 \subsection{Converse: gauge equivalence implies same MPV}%
 \label{subsec:converse_gauge_mpv}
 
-\begin{lemma}[Gauge equivalence of direct sums implies same MPV]\label{lem:gauge_equiv_implies_same_mpv}
-    \lean{MPSTensor.GaugeEquiv.sameMPV}\leanok
-    \uses{def:block_diagonal_tensor, def:gauge_equiv, def:same_mpv}
-    If the weighted block-diagonal tensors $\bigoplus_k \mu_k A_k$ and
-    $\bigoplus_k \mu_k B_k$ are gauge equivalent, then they generate the
-    same MPV family.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:gauge_equiv}
-    Gauge equivalence preserves all traces of word evaluations, hence all
-    MPV coefficients.
-\end{proof}
+The general gauge-invariance theorem, Theorem~\ref{thm:gauge_invariance},
+already states that gauge-equivalent tensors generate the same MPV family.
+Applying it to the two weighted block-diagonal tensors gives the direct-sum
+specialization needed here; no additional formal declaration is required.
 
 \subsection{Canonical-form tensor as a weighted direct sum}%
 \label{subsec:canonical_form_block_sum}

--- a/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -93,8 +93,9 @@ After the wrappers and Appendix B structural data above, the missing internal th
 - `TNLean/MPS/RFP/AppendixBStructuralData.lean` now records this output as
   `AppendixBStructuralData` and names the remaining chain-space extraction as
   `AppendixBProductPairExtraction`.
-- `Commuting.lean` exposes both the final wrapper `ProductPairBridge.isNNCPH` and the conditional
-  theorem `rfp_implies_nncph_of_appendixBExtraction`.
+- `TNLean/MPS/ParentHamiltonian/Commuting.lean` exposes the final wrapper
+  `ProductPairBridge.isNNCPH`, while `TNLean/MPS/RFP/CommutingBridge.lean` exposes the
+  RFP-specific conditional theorem `rfp_implies_nncph_of_appendixBExtraction`.
 
 ### What is still missing
 

--- a/docs/audits/2026-08-26_issue7190_pass_through_inventory.md
+++ b/docs/audits/2026-08-26_issue7190_pass_through_inventory.md
@@ -1,0 +1,21 @@
+# PR #7190 pass-through retirement inventory
+
+Date: 2026-08-26
+
+PR #7190 removed four public declarations that merely forwarded to an existing theorem,
+projected a structure field, or preserved a deprecated exact alias. All live non-`Archive`
+consumers and Blueprint references were migrated before deletion.
+
+| Removed declaration | Canonical replacement |
+|---|---|
+| `MPSTensor.gaugeEquiv_toTensorFromBlocks_implies_sameMPV` | `MPSTensor.GaugeEquiv.sameMPV` |
+| `MPSTensor.IsBNTCanonicalForm.weight_unit_exists_of_struct` | `MPSTensor.IsBNTCanonicalForm.weight_unit_exists` |
+| `MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero` | `MPSTensor.SectorDecomposition.coeff_not_eventually_zero`, now owned by `TNLean.MPS.SharedInfra.SectorDecomposition` |
+| `SectorBNT.Examples.singletonDecomp` | `MPSTensor.singleSectorDecomposition` |
+
+The private helper `cyclic_projection_nonzero_of_sum_one` was also removed after its proof was
+written directly at the sole use site. As a private declaration it is not a public compatibility
+endpoint.
+
+This inventory supplies the audit trail required by `docs/project_conventions.md` for retiring
+public pass-through declarations without transition aliases.

--- a/docs/audits/2026-08-26_mixed_map_no_alias_exception.md
+++ b/docs/audits/2026-08-26_mixed_map_no_alias_exception.md
@@ -1,0 +1,42 @@
+# Mixed-map compatibility aliases: intentional retirement
+
+Date: 2026-08-26
+
+## Decision
+
+PR #7192 migrated TNLean from the retired `mixedTransferMap` and `mixedTransferMap₂` vocabulary to
+the canonical QICLean API `Kraus.mixedMapLM`. No deprecated aliases are provided for the renamed
+TNLean declarations listed below.
+
+This is a deliberate architectural exception to the usual mathematical-language rename rule in
+`docs/CONTRIBUTING.md`. The change was not an isolated spelling improvement: QICLean PR #504
+deleted the entire `QICLean.Spectral.MixedTransfer` compatibility module, and TNLean PR #7192
+removed its final downstream theorem ecosystem. Reintroducing the old declaration names would
+recreate the compatibility surface that the ownership migration intentionally retired.
+
+`Kraus.mixedMapLM` is now the sole generic mixed-map API. Tensor-network statements may retain
+mixed-transfer terminology in prose, but declaration names should identify the canonical map they
+use. The exact MPS-domain abbreviation `Kraus.transferMap` remains a separate, explicitly retained
+exception and does not justify rebuilding the deleted mixed-map aliases.
+
+## Rename inventory
+
+| Retired declaration name | Canonical declaration name |
+|---|---|
+| `MPSTensor.mixedTransferMap₂_rotatePhysical` | `MPSTensor.mixedMapLM_rotatePhysical` |
+| `MPSTensor.mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul` | `MPSTensor.mixedMapLM_comp_self_eq_smul_of_transferMap_comp_self_eq_smul` |
+| `MPSTensor.mixedTransferMap₂_isIdempotentElem_of_isTransferIdempotent_directSum` | `MPSTensor.mixedMapLM_isIdempotentElem_of_isTransferIdempotent_directSum` |
+| `MPSTensor.blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂` | `MPSTensor.blockTransferSum_idempotent_of_pairwise_mixedMapLM` |
+| `MPSTensor.isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem` | `MPSTensor.isTransferIdempotent_directSumTensor_iff_pairwise_mixedMapLM_isIdempotentElem` |
+| `MPSTensor.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne` | `MPSTensor.normalizedMinimalLoopTensor_mixedMapLM_eq_zero_of_ne` |
+| `MPSTensor.mixedTransferMap₂_conj_apply` | `MPSTensor.mixedMapLM_conj_apply` |
+| `MPSTensor.mixedTransferMap₂_eq_zero_of_conj` | `MPSTensor.mixedMapLM_eq_zero_of_conj` |
+| `MPSTensor.mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv` | `MPSTensor.mixedMapLM_eq_zero_of_gaugePhaseEquiv` |
+| `MPSTensor.mixedTransferMap₂_cast_eq_zero_iff` | `MPSTensor.mixedMapLM_cast_eq_zero_iff` |
+| `MPSTensor.residual_isometry_entry_of_mixedTransferMap₂_eq_zero` | `MPSTensor.residual_isometry_entry_of_mixedMapLM_eq_zero` |
+| `MPSTensor.trace_mixedTransferMap_pow_eq_mpvOverlap` | `MPSTensor.trace_mixedMapLM_pow_eq_mpvOverlap` |
+| `MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap` | `MPSTensor.trace_transferMatrix_mixedMapLM_pow_eq_mpvOverlap` |
+| `MPSTensor.trace_mixedTransferMap₂_pow_eq_mpvOverlap` | `MPSTensor.trace_mixedMapLM_rect_pow_eq_mpvOverlap` |
+
+The post-migration cleanup report is
+`docs/audits/2026-08-26_post_migration_spaghetti_cleanup.md`.

--- a/docs/audits/2026-08-26_post_migration_spaghetti_cleanup.md
+++ b/docs/audits/2026-08-26_post_migration_spaghetti_cleanup.md
@@ -51,6 +51,11 @@ canonical reindex API. TNLean PR #7203 retired the stale documentation-only
 `Wielandt.WolfChapter6TNIndex` module, whose prose still pointed to pre-migration `TNLean.Channel`
 and `TNLean.QPF` ownership paths.
 
+The declaration-by-declaration pass-through inventory is recorded in
+`2026-08-26_issue7190_pass_through_inventory.md`. The intentional decision not to recreate the
+retired `mixedTransferMap` alias ecosystem is recorded in
+`2026-08-26_mixed_map_no_alias_exception.md`.
+
 ### Dependency direction
 
 TNLean PR #7191 repaired three lower-layer ownership inversions while preserving declaration names

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -273,7 +273,7 @@ nonzero $k$-blocks. It therefore defines a unique label $j_k$ and projections
 \begin{align}
     P_s
         &=
-        \sum_{\substack{k:p_k\neq 0j_k=s}}Q_k,
+        \sum_{\substack{k:p_k\neq 0\\j_k=s}}Q_k,
     \label{eq:cpgsv17_mpdo_sal_zcl_eta_local_structure_bnt_projection}\\
     \sum_s P_s
         &=
@@ -351,7 +351,7 @@ The four-site specialization used by the later argument takes $L=1$. SAL makes
 the normalization scalar nonzero, so every $\widehat R_j$ is nonzero.
 \footnote{The relevant declarations are
 \leanid{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix},
-\leanid{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂},
+\leanid{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV}\textsubscript{2},
 and
 \leanid{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
 
@@ -363,7 +363,7 @@ the four-site Hayashi decomposition. Every active Markov sector then has a
 unique BNT label, and the BNT-labelled sums of Hayashi projections are
 orthogonal, mutually disjoint, and resolve the active Markov support.
 \footnote{The relevant declaration is
-\leanid{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL}.}
+\leanid{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL}.}
 This specialization needs no further closing-matrix hypothesis.
 
 For every physical slice of the $i$-th normal representative,
@@ -396,7 +396,7 @@ relevant declarations are
 \leanid{MPOTensor.sum_bntSectorProjection_mul_physicalSlice_mul_self},
 \leanid{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
 \leanid{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
-\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
+\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL}.}
 
 The literal identity resolution in Equation \emph{Pis} of
 Ref.~\cite{Cirac2016MPDO_arXiv} is recovered in the ambient physical space.
@@ -433,7 +433,7 @@ the active-support resolution and Equation \emph{Pis} of
 Ref.~\cite{Cirac2016MPDO_arXiv}. The construction and its SAL specialization
 are
 \leanid{MPOTensor.completedBntSectorProjection} and
-\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent}.
+\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL_of_weight_copy_independent}.
 
 The source's standing assumptions are recovered by
 \leanid{MPOTensor.exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL}.
@@ -452,7 +452,7 @@ integer $n_s$. ZCL follows by restricting the full transfer equation to the
 $s$-th canonical block and using nonnilpotence to exclude the zero transfer.
 \footnote{The relevant declarations are
 \leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection},
-\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL},
 and
 \leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
 
@@ -482,7 +482,7 @@ under the biCF hypothesis imposed at the beginning of Case II in the source.
 \footnote{The principal declarations are
 \leanid{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
 \leanid{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
-\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV}\textsubscript{2}\leanid{Pos}.}
 This completes the entropy argument at lines 1748--1781 of Appendix C.2 of
 Ref.~\cite{Cirac2016MPDO_arXiv} under its stated biCF hypothesis.
 

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -123,7 +123,7 @@ combined-family linear-independence criterion
 \leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li}, and the
 modulus-free non-vanishing coefficient statement
 \leanid{MPSTensor.SectorDecomposition.coeff_not_eventually_zero} from
-\doclink{TNLean/MPS/FundamentalTheorem/SectorWeightComparison}. None of these
+\doclink{TNLean/MPS/SharedInfra/SectorDecomposition}. None of these
 declarations supplies the constants in
 (\ref{eq:bnt-rate_nonnegative_prefactor})--%
 (\ref{eq:bnt-rate_weight_compatibility}).

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -74,7 +74,7 @@ case into two steps. First, asymptotically unit-modulus overlap forces the
 spectral radius of the mixed transfer matrix to be at least one.\footnote{The
 formal theorem is
 \leanid{MPSTensor.mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one}
-in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}. It formalizes a
+in \path{TNLean/MPS/SharedInfra/GaugePhase.lean}. It formalizes a
 step in the proof of Lemma~\texttt{equalMPS}
 \cite[lines~1093--1117]{Cirac2016MPDO_arXiv}.}
 This statement is the contrapositive of the formalized decay theorem for mixed
@@ -84,12 +84,12 @@ Second, the modulus-one spectral theorem applies the Cauchy--Schwarz equality
 argument with the positive fixed point and obtains gauge-phase
 equivalence.\footnote{The formal theorem is
 \leanid{MPSTensor.modulus_one_eigenvalue_implies_gauge_of_irreducible_TP}
-in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.}
+in \path{TNLean/Spectral/TransferOperatorGapNT.lean}.}
 Combining these steps gives the same-dimensional gauge-phase theorem with the
 source overlap hypothesis and without an MPV proportionality
 hypothesis.\footnote{The formal theorem is
 \leanid{MPSTensor.gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}
-in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.}
+in \path{TNLean/MPS/SharedInfra/GaugePhase.lean}.}
 
 This same-dimensional theorem modifies the normal-tensor hypotheses in a
 controlled way. In the source, a normal tensor has no nontrivial invariant
@@ -130,7 +130,7 @@ The decay theorem is
 in \path{TNLean/Spectral/TransferOperatorGapNT.lean}. Its contrapositive is
 recorded as
 \leanid{MPSTensor.dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP}
-in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}. These results use
+in \path{TNLean/MPS/SharedInfra/GaugePhase.lean}. These results use
 only positive-length asymptotic overlaps and do not depend on the empty-word
 coefficient.
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -926,6 +926,13 @@ agreement of the selected completed local channel on the supported marginal.
   \emph{Quantum Information: An Introduction},
   Springer, 2006; Theorem 5.24.
 
+\bibitem{Cirac2021Matrix}
+  J.~I.~Cirac, D.~P\'erez-Garc\'ia, N.~Schuch, and F.~Verstraete,
+  \emph{Matrix product states and projected entangled pair states: Concepts,
+  symmetries, theorems},
+  Reviews of Modern Physics \textbf{93} (2021), 045003,
+  arXiv:2011.12127.
+
 \end{thebibliography}
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -151,7 +151,7 @@ The relevant surviving formal declarations are:
     \leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li}
     in \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Api}, together with
     \leanid{MPSTensor.SectorDecomposition.coeff_not_eventually_zero} in
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorWeightComparison}.
+    \doclink{TNLean/MPS/SharedInfra/SectorDecomposition}.
 
     \item
     \leanid{MPSTensor.fundamentalTheorem_proportional_canonicalForm}: the

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -42,7 +42,8 @@ mathematically equivalent to the source route.
 
 The formal periodic-overlap argument states its matrix-product-vector
 equalities for $N\geq 1$. In particular,
-\leanid{peripheralProportionalCase_periodicFT_of_sameMPV₂Pos} assumes equality
+\leanid{peripheralProportionalCase_periodicFT_of_sameMPV}%
+\textsubscript{2}\leanid{Pos} assumes equality
 at every positive length. This assumption suffices because the overlap
 argument is asymptotic and uses only a tail of positive lengths. The empty word
 contains only a bond-dimension trace and does not enter theorem
@@ -220,7 +221,8 @@ corner-isometry data, the spectral proof is formalized.
 Appendix~A, lines 961--1117, of
 Ref.~\cite{DeLasCuevas2017Irreducible} starts from the blocked identity
 \emph{eq:Nm}, lines 978--984. Applying the translation operator $T^l$ and
-Theorem~2.10 of Ref.~\cite{Cirac2021Matrix} produces, at each offset, a phase
+Theorem~2.10 of Ref.~\cite{CiracPerezGarcia2017Matrix} produces, at each
+ offset, a phase
 and a unitary
 \begin{align}
     U_{\widetilde v+l}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -175,7 +175,7 @@ The formal development contains the following components.
 
 \begin{enumerate}
     \item
-          \leanid{MPSTensor.spectralUnitalGauge_isUnital_of_transferMap_eigenvector}
+          \leanid{Kraus.spectralUnitalGauge_isUnital_of_map_eigenvector}
           formalizes the spectral-radius normalization in lines~765--769 of
           Theorem~\texttt{Th:TIcanonical} in
           Ref.~\cite{PerezGarcia2007MPSReps}. Given a positive-definite
@@ -191,7 +191,7 @@ The formal development contains the following components.
           \end{align}
 
     \item
-          \leanid{MPSTensor.unitalGauge_isUnital_of_transferMap_fixedPoint}
+          \leanid{Kraus.unitalGauge_isUnital_of_map_fixedPoint}
           formalizes the full-rank fixed-point gauge in lines~767--769. For a
           positive-definite fixed point $\rho$, it sets
           \begin{align}

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -149,7 +149,7 @@ example, the prose may say that the formal theorem is the same-dimensional
 gauge-phase component of a source lemma, while a footnote identifies the
 declaration.\footnote{Formal declaration:
     \leanid{MPSTensor.gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}
-    in \doclink{TNLean/MPS/FundamentalTheorem/Proportional}.}
+    in \doclink{TNLean/MPS/SharedInfra/GaugePhase}.}
 Do not put formal identifiers in displayed equations merely as traceability
 data.
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -46,6 +46,14 @@ _LEAN_DECL_KEYWORD_ONLY_RE = re.compile(
     r"(?:(?:noncomputable|protected|private)\s+)*"
     r"(def|theorem|lemma|abbrev|instance|class|structure|inductive|axiom|opaque|alias)\s*$"
 )
+# Structure fields are declarations too: Lean generates a projection named
+# `StructureName.fieldName` for each field.  Blueprint entries may legitimately
+# cite that projection rather than the bundling structure.
+_LEAN_STRUCTURE_FIELD_RE = re.compile(
+    r"^\s+((?!where\b|extends\b|deriving\b)[\w']+)"
+    r"(?:\s*\([^)]*\))*\s*:\s*"
+)
+
 _TRACKED_REVERSE_DECL_KINDS = {"def", "theorem", "lemma"}
 _DIFF_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
@@ -212,7 +220,61 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
         if idx + 1 < len(decls):
             decl.end_line = decls[idx + 1].line - 1
 
-    return decls
+    # The declaration regex above finds the structure itself, but not the
+    # projection declarations generated for its fields.  Scan only the source
+    # span of each structure and ignore block/line comments so documentation
+    # prose cannot be mistaken for a field.
+    field_decls: list[LeanDecl] = []
+    for decl in decls:
+        if decl.kind != "structure":
+            continue
+        block_comment_depth = 0
+        for line_no in range(decl.line + 1, decl.end_line + 1):
+            raw = lines[line_no - 1]
+            code_parts: list[str] = []
+            cursor = 0
+            while cursor < len(raw):
+                if block_comment_depth:
+                    nested = raw.find("/-", cursor)
+                    end = raw.find("-/", cursor)
+                    if nested >= 0 and (end < 0 or nested < end):
+                        block_comment_depth += 1
+                        cursor = nested + 2
+                    elif end >= 0:
+                        block_comment_depth -= 1
+                        cursor = end + 2
+                    else:
+                        cursor = len(raw)
+                    continue
+                block = raw.find("/-", cursor)
+                line_comment = raw.find("--", cursor)
+                stops = [x for x in (block, line_comment) if x >= 0]
+                stop = min(stops) if stops else len(raw)
+                code_parts.append(raw[cursor:stop])
+                if stop == line_comment:
+                    cursor = len(raw)
+                elif stop == block:
+                    block_comment_depth = 1
+                    cursor = stop + 2
+                else:
+                    cursor = len(raw)
+            code = "".join(code_parts)
+            match = _LEAN_STRUCTURE_FIELD_RE.match(code)
+            if not match:
+                continue
+            field_name = match.group(1)
+            field_decls.append(
+                LeanDecl(
+                    file=rel,
+                    line=line_no,
+                    fqn=f"{decl.fqn}.{field_name}",
+                    kind="field",
+                    short_name=field_name,
+                    end_line=line_no,
+                )
+            )
+
+    return decls + field_decls
 
 
 def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:

--- a/scripts/test_blueprint_lean_sync.py
+++ b/scripts/test_blueprint_lean_sync.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Unit tests for Blueprint Lean-declaration source scanning."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from blueprint_lean_sync import collect_file_lean_decls
+
+
+def test_structure_fields_are_declarations() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        lean_root = root / "TNLean"
+        lean_root.mkdir()
+        source = lean_root / "Example.lean"
+        source.write_text(
+            """namespace Example
+
+structure Witness where
+  /-- A colon in prose: this is not a field. -/
+  /- An outer comment
+    /- with a nested comment -/
+    fake : Nat
+  -/
+  value : Nat
+  relation (x : Nat) : x = value
+
+ theorem after : True := by trivial
+
+end Example
+"""
+        )
+        decls = {decl.fqn: decl for decl in collect_file_lean_decls(source, lean_root)}
+        assert "Example.Witness" in decls
+        assert decls["Example.Witness.value"].kind == "field"
+        assert decls["Example.Witness.relation"].kind == "field"
+        assert "Example.Witness.this" not in decls
+        assert "Example.Witness.fake" not in decls
+        assert "Example.after" in decls
+
+
+if __name__ == "__main__":
+    test_structure_fields_are_declarations()
+    print("Blueprint declaration scanner tests passed.")


### PR DESCRIPTION
## Summary

Resolve the automatically opened follow-ups from the post-migration cleanup and proof-gap documentation audit in one batch.

- repair stale declaration/module references, bibliography attribution, and malformed LaTeX
- point the BNT weight Blueprint entry at the generated structure-field projection and remove the duplicate gauge-invariance entry
- teach the Blueprint declaration scanner about structure-field projections, with a regression test
- add the #7190 pass-through retirement inventory and document the intentional no-alias mixed-map architecture
- refresh the RFP commuting-bridge module header and relocation audit links

## Verification

- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `lake build`
- `texra-blueprint --root . paper-gaps build`
- affected proof-gap logs have no unresolved citation/reference or missing-character warnings
- `texra-blueprint paper-gaps check`
- `texra-blueprint bbl`
- pinned `texra-blueprint` web build contains no `ERROR:` lines
- `python3 scripts/test_blueprint_lean_sync.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (no generated diff)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

Closes #7188.
Closes #7193.
Closes #7194.
Closes #7195.
Closes #7200.
Closes #7201.
Closes #7205.
Closes #7206.
Closes #7207.