### PR TITLE
fix: resolve review follow-ups from docs batch

### DIFF
--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -221,7 +221,7 @@ corner-isometry data, the spectral proof is formalized.
 Appendix~A, lines 961--1117, of
 Ref.~\cite{DeLasCuevas2017Irreducible} starts from the blocked identity
 \emph{eq:Nm}, lines 978--984. Applying the translation operator $T^l$ and
-Theorem~2.10 of Ref.~\cite{CiracPerezGarcia2017Matrix} produces, at each
+Theorem~2.10 of Ref.~\cite{Cirac2016MPDO} produces, at each
  offset, a phase
 and a unitary
 \begin{align}
@@ -620,11 +620,11 @@ G.~de las Cuevas, J.~I.~Cirac, N.~Schuch, and D.~P\'erez-Garc\'ia,
 \emph{Irreducible forms of matrix product states: Theory and applications},
 J.~Math.~Phys.\ \textbf{58}, 121901 (2017), arXiv:1708.00029.
 
-\bibitem{CiracPerezGarcia2017Matrix}
+\bibitem{Cirac2016MPDO}
 J.~I.~Cirac, D.~P\'erez-Garc\'ia, N.~Schuch, and F.~Verstraete,
-\emph{Matrix product states and projected entangled pair states: Concepts,
-symmetries, theorems}, Ann.\ Phys.\ \textbf{378}, 100 (2017)
-(``Ci15'' in arXiv:1708.00029).
+\emph{Matrix product density operators: Renormalization fixed points and
+boundary theories}, Ann.\ Phys.\ \textbf{378}, 100--149 (2017),
+arXiv:1606.00608 (``Ci15'' in arXiv:1708.00029).
 
 \bibitem{Wolf2012Quantum}
 M.~M.~Wolf, \emph{Quantum Channels and Operations: Guided Tour}, unpublished

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -229,6 +229,7 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
         if decl.kind != "structure":
             continue
         block_comment_depth = 0
+        field_indent: int | None = None
         for line_no in range(decl.line + 1, decl.end_line + 1):
             raw = lines[line_no - 1]
             code_parts: list[str] = []
@@ -261,6 +262,14 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
             code = "".join(code_parts)
             match = _LEAN_STRUCTURE_FIELD_RE.match(code)
             if not match:
+                continue
+            indent = len(code) - len(code.lstrip())
+            if field_indent is None:
+                field_indent = indent
+            elif indent != field_indent:
+                # Continuations of a field type may contain local binders such
+                # as `letI : NeZero N`; only declarations aligned with the
+                # structure's first field generate projections.
                 continue
             field_name = match.group(1)
             field_decls.append(

--- a/scripts/test_blueprint_lean_sync.py
+++ b/scripts/test_blueprint_lean_sync.py
@@ -38,6 +38,8 @@ end Example
         assert "Example.Witness" in decls
         assert decls["Example.Witness.value"].kind == "field"
         assert decls["Example.Witness.relation"].kind == "field"
+        assert decls["Example.Witness.withLocalBinder"].kind == "field"
+        assert "Example.Witness.letI" not in decls
         assert "Example.Witness.this" not in decls
         assert "Example.Witness.fake" not in decls
         assert "Example.after" in decls

--- a/scripts/test_blueprint_lean_sync.py
+++ b/scripts/test_blueprint_lean_sync.py
@@ -24,6 +24,10 @@ structure Witness where
   -/
   value : Nat
   relation (x : Nat) : x = value
+  withLocalBinder :
+    ∀ (n : Nat),
+      letI : NeZero (n + 1) := ⟨by omega⟩
+      True
 
  theorem after : True := by trivial
 


### PR DESCRIPTION
## Summary

Resolve the two automatic review follow-ups opened after #7208.

- restrict generated structure-field discovery to the indentation of genuine fields, preventing nested `let`/`letI` binders from being accepted as projections
- extend the scanner regression test with a multiline field type containing `letI`, and assert against the concrete current-tree false positive
- correct the Theorem 2.10 source metadata to the 2017 MPDO paper consistently

## Verification

- `python3 scripts/test_blueprint_lean_sync.py`
- concrete `CyclicEdgeWeightForm.product_apply` scanner assertion: real field present, fake `.letI` absent
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (no generated diff)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `texra-blueprint paper-gaps check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`
- affected log has no unresolved citation/reference or missing-character warnings

Closes #7209.
Closes #7210.