### PR TITLE
ci: rebuild paper-gap PDFs during blueprint deploy

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -51,6 +51,11 @@ jobs:
 
       - name: Install system dependencies
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1
+        with:
+          # texlive-fonts-extra supplies dsfont, which paper-gap notes load;
+          # keep this cache separate from the extra-package-free web cache.
+          cache-suffix: web-v2
+          extra-packages: texlive-fonts-extra
 
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1
@@ -72,6 +77,12 @@ jobs:
 
       - name: Build blueprint bibliography
         run: texra-blueprint bbl
+
+      # The bibliography links every paper-gap note to its published PDF. Build
+      # those PDFs in the same merge-triggered workflow that publishes the links
+      # instead of reusing the last Full documentation artifact.
+      - name: Build paper-gap PDFs
+        run: texra-blueprint --root . paper-gaps build
 
       - name: Build blueprint
         run: |
@@ -117,6 +128,7 @@ jobs:
           cp -r blueprint/web site-blueprint/blueprint
           cp blueprint/print/print.pdf site-blueprint/blueprint.pdf
           cp blueprint/print/print12.pdf site-blueprint/blueprint-ch01-12.pdf
+          texra-blueprint --root . paper-gaps site site-blueprint/paper-gaps
           python3 scripts/write_badges.py site-badges
 
       # Runs in Docker and produces root-owned output; keep it after the


### PR DESCRIPTION
## Summary

- install `texlive-fonts-extra` in the Blueprint deployment job so paper-gap notes using `dsfont` compile
- rebuild all paper-gap PDFs in the merge-triggered Blueprint workflow
- package the freshly built paper-gap site into the GitHub Pages artifact

## Motivation

The proof-gap documentation sweep merged in #7204 and the subsequent Pages workflow succeeded, but the deployed paper-gap PDFs were stale artifacts from August 23, 2026. QICLean already rebuilds and packages paper-gap PDFs in its Blueprint deployment workflow. This change gives TNLean the same behavior, so a successful Pages deployment contains PDFs produced from the deployed commit.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- local paper-gap build and site assembly completed successfully
- the change is limited to `.github/workflows/blueprint.yml`
