### PR TITLE
ci: prefer fresh paper-gap deployment artifact

### DIFF
--- a/scripts/assemble-pages-site.sh
+++ b/scripts/assemble-pages-site.sh
@@ -3,9 +3,14 @@
 # Usage: assemble-pages-site.sh COMPONENTS_DIR OUT_DIR
 #
 # COMPONENTS_DIR may contain:
-#   site-blueprint/  Jekyll-built homepage, blueprint web + PDFs  (required)
+#   site-blueprint/  Jekyll-built homepage, blueprint web + PDFs,
+#                    paper-gap PDFs                               (required)
 #   site-docs/       doc-gen4 API docs and paper-gap PDFs         (optional)
 #   site-badges/     badge endpoint JSON                          (optional)
+#
+# Paper-gap PDFs come from site-blueprint when present: the blueprint job
+# rebuilds them on every push that touches a note, so its copy is at least
+# as fresh as the weekly docgen's site-docs copy, which remains a fallback.
 set -euo pipefail
 
 COMPONENTS="$1"
@@ -38,8 +43,11 @@ if [ -d "$COMPONENTS/site-docs/docs" ]; then
 else
   echo "::warning::site-docs component missing — deploying without API docs (the next docgen run restores them)"
 fi
-if [ -d "$COMPONENTS/site-docs/paper-gaps" ]; then
-  echo "==> Paper-gap PDFs..."
+if [ -d "$COMPONENTS/site-blueprint/paper-gaps" ]; then
+  echo "==> Paper-gap PDFs (blueprint component)..."
+  cp -r "$COMPONENTS/site-blueprint/paper-gaps" "$OUT/paper-gaps"
+elif [ -d "$COMPONENTS/site-docs/paper-gaps" ]; then
+  echo "==> Paper-gap PDFs (docs component)..."
   cp -r "$COMPONENTS/site-docs/paper-gaps" "$OUT/paper-gaps"
 fi
 


### PR DESCRIPTION
## Summary

- deploy paper-gap PDFs from the merge-triggered `site-blueprint` component when available
- retain the weekly `site-docs` paper-gap artifact as a fallback
- align TNLean's Pages assembly precedence with QICLean

## Cause

PR #7214 successfully rebuilt all paper-gap PDFs and packaged them into `site-blueprint/paper-gaps`. The Pages assembly script nevertheless ignored that directory and copied `site-docs/paper-gaps`, whose PDFs were built on August 23, 2026. Thus the August 26 deployment succeeded while still publishing stale PDFs.

The CI log confirms the fresh outputs differed from the live files. For example:

- `cpsv16_bnt_rate_quantification.pdf`: CI built 4 pages / 212,693 bytes; live site served 3 pages / 211,354 bytes
- `pgvwc07_direct_sum_input.pdf`: CI built 6 pages / 223,341 bytes; live site served 5 pages / 219,236 bytes

## Validation

- `bash -n scripts/assemble-pages-site.sh`
- assembly test with both artifacts present confirms `site-blueprint/paper-gaps` wins
- fallback test confirms `site-docs/paper-gaps` is used when the Blueprint copy is absent
- `git diff --check`
