### PR TITLE
docs(review): apply post-merge follow-ups from #7218

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2950,9 +2950,10 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 \begin{proof}
     \leanok
     The finite-overlap martingale reduction applies with the cyclic overlap
-    relation: at most $2(L-1)$ off-diagonal neighbours per row, non-overlapping
-    pairs handled by disjoint-window positivity, and the anticommutator
-    inequality retained as an explicit hypothesis.
+    relation: at most $2(L-1)$ off-diagonal neighbours per row; for
+    non-overlapping pairs the disjoint-window estimate
+    $\re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle\ge 0$ holds;
+    and the anticommutator inequality is retained as an explicit hypothesis.
 \end{proof}
 
 \begin{theorem}[Gap bound from a strict cyclic compression constant]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3024,8 +3024,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    For every overlapping pair, applying the directional compression bound
-    in both orientations and adding gives
+    For every overlapping pair, the symmetric anticommutator reduction turns
+    the operator-product norm bound into
     \begin{align}
         &\re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
          +\re\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle \\

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3024,11 +3024,16 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    The symmetric anticommutator reduction turns the displayed
-    operator-product hypothesis into the row-summable anticommutator estimate
-    with coefficient $\eta$; the cyclic-window martingale reduction with
-    $\gamma=1-\eta m$ then gives $0<1-\eta m$ together with the stated norm
-    lower bound.
+    For every overlapping pair, the operator-product bound gives
+    \begin{align}
+        &\re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+         +\re\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle \\
+        &\qquad\ge -\eta\bigl(
+          \re\langle h_{i,\mathrm{ES}}v,v\rangle
+         +\re\langle h_{j,\mathrm{ES}}v,v\rangle\bigr).
+    \end{align}
+    The cyclic-window row-sum bounds with $\gamma=1-\eta m$ then give
+    $0<1-\eta m$ together with the stated norm lower bound.
 \end{proof}
 
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3024,7 +3024,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    For every overlapping pair, the operator-product bound gives
+    For every overlapping pair, applying the directional compression bound
+    in both orientations and adding gives
     \begin{align}
         &\re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
          +\re\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle \\
@@ -3032,8 +3033,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
           \re\langle h_{i,\mathrm{ES}}v,v\rangle
          +\re\langle h_{j,\mathrm{ES}}v,v\rangle\bigr).
     \end{align}
-    The cyclic-window row-sum bounds with $\gamma=1-\eta m$ then give
-    $0<1-\eta m$ together with the stated norm lower bound.
+    The assumption $\eta m<1$ makes $\gamma=1-\eta m$ positive, and the
+    cyclic-window row-sum bounds then give the stated norm lower bound.
 \end{proof}
 
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1538,7 +1538,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.sourceCutM₁Fin_apply,
         MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank}
     \leanok
-    \uses{def:mpo_tensor}
+    \uses{def:mpo_tensor, def:mps_independent_tensor_product}
     The matrix $M_1$ is obtained by combining the left auxiliary index with the
     lower physical index, and the upper physical index with the right auxiliary
     index. Thus
@@ -1983,7 +1983,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
-    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply, finTupleProdEquiv}
+    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply}
     \leanok
     \uses{def:mpo_tensor}
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1983,7 +1983,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
-    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply}
+    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply, finTupleProdEquiv}
     \leanok
     \uses{def:mpo_tensor}
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and

--- a/docs/audits/2026-08-27_mpdo_shared_sign_and_generic_helpers.md
+++ b/docs/audits/2026-08-27_mpdo_shared_sign_and_generic_helpers.md
@@ -1,11 +1,12 @@
 # MPDO shared sign calculus and generic private helpers (2026-08-27)
 
 Three cleanups in `TNLean/MPS/MPDO`. The private helper removals follow the
-direct-removal policy of `docs/project_conventions.md` §Style. Every non-`Archive` use is migrated, and the two blueprint `\lean{}`
-tags affected are redirected in the same change. Under TNLean's explicit
-no-public-API-compatibility policy, the four old qualified sign-definition names
-are deleted directly rather than retained as deprecated aliases. No private removed name needs an alias, and no removed name
-encoded misleading terminology.
+direct-removal policy in `docs/project_conventions.md`. Every non-`Archive` use
+is migrated, and the two blueprint `\lean{}` tags affected are redirected in
+the same change. Under TNLean's explicit no-public-API-compatibility policy, the
+four old qualified sign-definition names are deleted directly rather than
+retained as deprecated aliases. No private removed name needs an alias, and no
+removed name encoded misleading terminology.
 
 ## 1. Generic helpers replaced by their owned equivalents
 

--- a/docs/audits/2026-08-27_mpdo_shared_sign_and_generic_helpers.md
+++ b/docs/audits/2026-08-27_mpdo_shared_sign_and_generic_helpers.md
@@ -1,8 +1,7 @@
 # MPDO shared sign calculus and generic private helpers (2026-08-27)
 
-Three cleanups in `TNLean/MPS/MPDO`. The private helper removals use the
-repository-local pass-through exception of `docs/project_conventions.md`
-§Style. Every non-`Archive` use is migrated, and the two blueprint `\lean{}`
+Three cleanups in `TNLean/MPS/MPDO`. The private helper removals follow the
+direct-removal policy of `docs/project_conventions.md` §Style. Every non-`Archive` use is migrated, and the two blueprint `\lean{}`
 tags affected are redirected in the same change. Under TNLean's explicit
 no-public-API-compatibility policy, the four old qualified sign-definition names
 are deleted directly rather than retained as deprecated aliases. No private removed name needs an alias, and no removed name

--- a/docs/audits/2026-08-27_mpu_shift_source_prod_comm_shadow_removal.md
+++ b/docs/audits/2026-08-27_mpu_shift_source_prod_comm_shadow_removal.md
@@ -1,7 +1,7 @@
 # MPU shift-source four-way product shadow and single-use restatements
 
-This audit records the repository-local pass-through exception of
-`docs/project_conventions.md` §Style for one public reindexing equivalence that
+This audit applies the direct-removal policy of
+`docs/project_conventions.md` §Style to one public reindexing equivalence that
 duplicated a Mathlib equivalence, together with four `private` entry-formula
 restatements that were inlined into their sole consumers. All five removals are
 in `TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean`.

--- a/docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md
+++ b/docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md
@@ -99,5 +99,6 @@ the same document are untouched.
 
 Ledger entry S7 (issue #4567) plans further deletions in this chain and cites a
 line range inside the deleted waypoint that no longer existed at the audited
-head. That entry's remaining targets — `UnionInjectivityOverlap4.lean` and the
-dead spans in files 1, 2, 3, and 6 — are unaffected by this slice.
+head. `UnionInjectivityOverlap4.lean` was already absent before this PR. That
+entry's remaining targets are only the dead spans in files 1, 2, 3, and 6;
+they are unaffected by this slice.

--- a/docs/audits/2026-08-27_unused_import_lines.md
+++ b/docs/audits/2026-08-27_unused_import_lines.md
@@ -38,7 +38,7 @@ were proved live only by importers several modules downstream.
 
 ## Removed
 
-### `TNLean.Algebra.TracePairing`
+### `TNLean.MPS.Core.TracePairing`
 
 | File | Line removed |
 |---|---|
@@ -47,8 +47,9 @@ were proved live only by importers several modules downstream.
 | `TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean` | `import TNLean.Algebra.TracePairing` |
 | `TNLean/MPS/MPDO/RFPViaTS.lean` | `import TNLean.Algebra.TracePairing` |
 
-`TNLean/Algebra.lean` keeps `TNLean.Algebra.TracePairing` root-reachable, and
-`TNLean/MPS/FundamentalTheorem/FiniteLength.lean`,
+The module was subsequently moved from `TNLean/Algebra/TracePairing.lean` to
+`TNLean/MPS/Core/TracePairing.lean`; `TNLean/MPS/Core.lean` now keeps it
+root-reachable. `TNLean/MPS/FundamentalTheorem/FiniteLength.lean`,
 `TNLean/MPS/Structure/LinearExtension.lean` and
 `TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean` are genuine users of its
 declarations.
@@ -115,9 +116,9 @@ sweep does not re-propose them.
 
 | File | Import retained | Identifier that forced it | Consumer |
 |---|---|---|---|
-| `TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean` | `TNLean.Algebra.TracePairing` | `ker_bot_of_range_le` | `TNLean/PEPS/CycleMPSWordTransport.lean:122` |
-| `TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean` | `TNLean.Algebra.TracePairing` | `Matrix.trace_mul_right_eq_zero_iff` | same file, line 160 |
-| `TNLean/MPS/Core/MultiBlock.lean` | `QICLean.Algebra.TraceReindex` | `Matrix.trace_reindex` | `TNLean/Algebra/BlockTriangularTrace.lean`, `TNLean/MPS/SharedInfra/BlockAssembly.lean` |
+| `TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean` | `TNLean.MPS.Core.TracePairing` | `ker_bot_of_range_le` | `TNLean/PEPS/CycleMPSWordTransport.lean:122` |
+| `TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean` | `TNLean.MPS.Core.TracePairing` | `Matrix.trace_mul_right_eq_zero_iff` | same file, line 160 |
+| `TNLean/MPS/Core/MultiBlock.lean` | `QICLean.Algebra.TraceReindex` | `Matrix.trace_reindex` | `TNLean/MPS/Core/BlockTriangularTrace.lean`, `TNLean/MPS/SharedInfra/BlockAssembly.lean` |
 | `TNLean/Algebra/CommutingProjectionProduct.lean` | `QICLean.Algebra.PiProductTrace` | `Matrix.trace_piProduct` | `TNLean/MPS/RFP/BeigiSectorGraph.lean:457` |
 | `TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean` | `TNLean.MPS.FundamentalTheorem.SectorWeightComparison` | `Matrix.charpoly_eq_of_forall_trace_pow_eq` | `TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean:60` |
 | `TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean` | `QICLean.Algebra.ScalarPowerSumIdentity` | `Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card` | `TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean:150`, `TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean:129` |

--- a/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
+++ b/docs/paper-gaps/mpu_reduced_representative_supplied_fixed_pair.tex
@@ -149,7 +149,7 @@ data and additionally assume that $X$, $Z$, and $Y$ are invertible.
 
 Finally, the matrix-level theorem
 \leanid{Matrix.exists_units_supportInvExtension_reducedProjection_rightFactor}
-assumes only $L,R\succeq0$. It supplies invertible ambient support-inverse
+from the QICLean companion library assumes only $L,R\succeq0$. It supplies invertible ambient support-inverse
 extensions $X$ and $Z$, together with an invertible right factor $Y$ satisfying
 Eq.~\ref{eq:mpu_reduced_representative_supplied_fixed_pair_reduced_right_factor};
 it does not assume a fixed-point identity, trace normalization, or support

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -135,8 +135,9 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
 
 ### S7. Delete the confirmed-dead half of the UnionInjectivityOverlap chain — net 750 lines, risk 4/10
 - **Status**: open (#4567)
-- **What**: `PEPS/RegionBlock/UnionInjectivityOverlap4.lean` (238 ln, 100%
-  dead) plus scattered dead spans in files 1/2/3/6 (~123 ln).
+- **What**: scattered dead spans in files 1/2/3/6 (~123 ln).
+  `PEPS/RegionBlock/UnionInjectivityOverlap4.lean` (238 ln, formerly 100%
+  dead) had already been removed before this audit.
   **Correction**: the original candidate
   wrongly proposed also collapsing files 1-2 (`overlapLeftGeometry`/
   `overlapRightGeometry`) — those are live, called directly by the
@@ -144,14 +145,15 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   `overlapHostGeometry` sub-chain in file 5 (211 ln) is already gone, and
   file 5 itself was dissolved into `RegionBlock/Basic.lean` and
   `RegionBlock/UnionInjectivityGeneral.lean`
-  (`docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md`),
-  so the entry's remaining target is file 4 plus the scattered spans.
+  (`docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md`).
+  File 4 was already absent before this PR, so the entry's remaining target is
+  only the scattered spans in files 1, 2, 3, and 6.
 - **Why it's excess**: the project's own paper-gap note
   (`docs/paper-gaps/peps_normal_ft_section3_route.tex`) documents this
   exact sub-route as an abandoned dead end that forced a switch to the
   surviving P0-outer parametrization.
-- **First PR**: delete `UnionInjectivityOverlap4.lean` in full. Net -238
-  lines, zero consumers, zero proof changes to the live capstone.
+- **First PR**: delete the confirmed-dead spans in files 1, 2, 3, and 6,
+  without changing the live capstone.
 
 ### S8. Derive injective-tensor Perron-Frobenius as a corollary of the irreducible-CP-map theory — completed
 - **Status**: closed 2026-07-23 (#4568; #4594 and #4628)


### PR DESCRIPTION
## Summary

Applies the documentation corrections raised by the final reviews of #7218 after that PR had already merged:

- corrects the stale `UnionInjectivityOverlap4` ledger/audit status;
- updates `TracePairing` paths after its move to `TNLean/MPS/Core`;
- identifies the QICLean provenance of the reduced-projection theorem;
- updates audit wording to the current direct-removal policy;
- displays the two martingale inequalities requested by the Blueprint prose review;
- attaches `finTupleProdEquiv` to the independent MPU tensor-product definition.

## Verification

- `check_reader_facing_prose.py --diff-base origin/main --ci`: pass.
- Blueprint sync reports no issue for either newly changed tag/passage; the clean worktree lacks the QICLean checkout, so the full scan reports pre-existing unresolved dependency declarations and is left to CI.

Follow-up to #7218.