### PR TITLE
refactor: close the remaining #7218 cleanup follow-ups

### DIFF
--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -53,9 +53,6 @@ decomposition in `TNLean/MPS/MPDO/CyclicProjector.lean`.
   length-$p$ vertical word gives one-sided invariance for the stacked tensor.
 * `periodicVectorYieldsProjector_of_cyclic`: the cyclic-projector hypothesis
   implies the projector-supplying hypothesis of the periodic-sector step.
-* `hasNoPeriodicVectors_verticalTensor_of_cyclicProjector`: granted the
-  cyclic-projector hypothesis, a matrix product density operator has no
-  nontrivial $p$-periodic vectors in the vertical direction.
 
 ## References
 
@@ -388,23 +385,5 @@ theorem periodicVectorYieldsProjector_of_cyclic (M : MPOTensor d D)
   obtain ⟨p, Q, hp, hherm, hidem, hword, hnc⟩ :=
     hCyc V B ρ r hV hint hirr hρ hr hfix μ hμ hnorm hne
   exact ⟨p, ⟨periodicSectorProjectorOfCyclicData M hM hp hherm hidem hword hnc⟩⟩
-
-/-- The vertically viewed tensor of a matrix product density operator has no
-nontrivial $p$-periodic vectors, granted that periodic vectors supply cyclic
-projectors.  This is the periodic-sector step in the proof of Proposition
-4.13 of arXiv:1606.00608, lines 1888--1893, with the commutation family
-derived from the stacked-layers identity rather than assumed.
-
-**Scope restriction (conditional on the supplied cyclic projector):** This
-theorem retains the stronger all-length projector hypothesis. Under normalized
-BNT-refined horizontal form, `hasNoPeriodicVectors_verticalTensor_of_horizontalCF`
-uses the same invariant projector at one noncommuting length; see
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
-theorem hasNoPeriodicVectors_verticalTensor_of_cyclicProjector
-    (M : MPOTensor d D) (hM : IsMPDO M)
-    (hCyc : PeriodicVectorYieldsCyclicProjector M) :
-    MPSTensor.HasNoPeriodicVectors (verticalTensor M) :=
-  hasNoPeriodicVectors_verticalTensor M hM
-    (periodicVectorYieldsProjector_of_cyclic M hM hCyc)
 
 end MPOTensor

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Core.WordFactor
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
-import TNLean.MPS.FundamentalTheorem.FiniteLength
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.OfFn
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 

--- a/TNLean/PEPS/FundamentalTheorem/GaugeAction.lean
+++ b/TNLean/PEPS/FundamentalTheorem/GaugeAction.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.InsertionAlgebra
-import TNLean.PEPS.EdgeGaugeFamily
 import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
@@ -149,10 +149,6 @@ omit [LinearOrder V] [DecidableRel G.Adj] in
     (overlapRightGeometry (V := V) R₁ R₂).blue = R₁ ∩ R₂ := rfl
 
 omit [LinearOrder V] [DecidableRel G.Adj] in
-@[simp] theorem overlapRightGeometry_complement (R₁ R₂ : Finset V) :
-    (overlapRightGeometry (V := V) R₁ R₂).complement = R₂ \ R₁ := rfl
-
-omit [LinearOrder V] [DecidableRel G.Adj] in
 @[simp] theorem overlapRightGeometry_red (R₁ R₂ : Finset V) :
     (overlapRightGeometry (V := V) R₁ R₂).red = Finset.univ \ R₂ := rfl
 

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean
@@ -180,33 +180,5 @@ theorem not_isRegionBoundaryEdge_union_of_overlapCrossing {R₁ R₂ : Finset V}
   · exact h2' (Finset.mem_union_left _ h2)
   · exact h1' (Finset.mem_union_left _ h1)
 
-/-- A `P₁`--`P₀` crossing edge is a blue/red crossing edge of the right geometry: its
-overlap endpoint lies in the blue block `R₁ ∩ R₂`, and its difference endpoint lies in
-the red block `R₂ᶜ`. This identifies the crossing-edge family with the blue/red crossings
-of `overlapRightGeometry`, so the landed right-geometry collapse acts over them. -/
-theorem isBlueRedCrossingEdge_right_of_overlapCrossing {R₁ R₂ : Finset V} {eg : Edge G}
-    (h : IsOverlapCrossingEdge (G := G) R₁ R₂ eg) :
-    (overlapRightGeometry (V := V) R₁ R₂).IsBlueRedCrossingEdge A eg := by
-  refine ⟨?_, ?_⟩
-  · -- A boundary edge of the red block `R₂ᶜ`: the overlap endpoint is in `R₂`, hence not
-    -- in `R₂ᶜ`, and the difference endpoint is outside `R₂`, hence in `R₂ᶜ`.
-    rw [overlapRightGeometry_red]
-    rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
-    · refine Or.inr ⟨?_, ?_⟩
-      · rw [Finset.mem_sdiff]
-        push Not
-        exact fun _ => (Finset.mem_inter.mp h1).2
-      · rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, (Finset.mem_sdiff.mp h2).2⟩
-    · refine Or.inl ⟨?_, ?_⟩
-      · rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, (Finset.mem_sdiff.mp h1).2⟩
-      · rw [Finset.mem_sdiff]
-        push Not
-        exact fun _ => (Finset.mem_inter.mp h2).2
-  · -- A boundary edge of the blue block `R₁ ∩ R₂`.
-    rw [overlapRightGeometry_blue]
-    rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
-    · exact Or.inl ⟨h1, fun hc => (Finset.mem_sdiff.mp h2).2 (Finset.mem_inter.mp hc).2⟩
-    · exact Or.inr ⟨fun hc => (Finset.mem_sdiff.mp h1).2 (Finset.mem_inter.mp hc).2, h2⟩
-
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
@@ -94,11 +94,6 @@ abbrev P0OuterConfig (A : Tensor G d) (R₁ R₂ : Finset V) : Type _ :=
 def p0OuterLabel (A : Tensor G d) (R₁ R₂ : Finset V) (ζ : VirtualConfig A) :
     P0OuterConfig A R₁ R₂ := fun f => ζ f.1
 
-omit [Fintype V] in
-@[simp] theorem p0OuterLabel_apply (R₁ R₂ : Finset V) (ζ : VirtualConfig A)
-    (f : {e : Edge G // IsP0OuterEdge (G := G) R₁ R₂ e}) :
-    p0OuterLabel A R₁ R₂ ζ f = ζ f.1 := rfl
-
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- A `P₀`-outer edge is a boundary edge of `R₁`: one endpoint lies in `R₁ \ R₂ ⊆ R₁`, the other
 lies outside `R₁ ∪ R₂`, hence outside `R₁`. -/

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -231,11 +231,10 @@
     \label{thm:mpdo_cyclic_projector_reduction}
     \lean{MPOTensor.periodicVectorYieldsProjector_of_cyclic}
     \leanok
-    \uses{def:mpdo, def:mpdo_periodic_vector_yields_cyclic_projector, def:mpdo_periodic_vector_yields_projector, def:vertical_tensor_mpdo, def:no_periodic_vectors}
+    \uses{def:mpdo, def:mpdo_periodic_vector_yields_cyclic_projector, def:mpdo_periodic_vector_yields_projector}
     Let $M$ generate matrix product density operators. If periodic vectors
     of $M$ supply cyclic projectors, then they supply periodic-sector
-    projectors, and the vertically viewed tensor $\widetilde M$ has no
-    nontrivial $p$-periodic vectors. This reduces the hypothesis of the
+    projectors. This reduces the projector-supply hypothesis of the
     periodic-sector step in the proof of
     \cite[Proposition~4.13, lines~1888--1893]{Cirac2016MPDO_arXiv} to the
     cyclic decomposition of the peripheral spectrum of the vertical
@@ -244,12 +243,10 @@
 
 \begin{proof}
     \leanok
-    \uses{def:mpdo_periodic_sector_projector_of_cyclic, thm:mpdo_vertical_no_periodic_vectors}
+    \uses{def:mpdo_periodic_sector_projector_of_cyclic}
     A nontrivial $p$-periodic vector supplies an invariant non-commuting
     projector, which is a periodic-sector projector by
-    Definition~\ref{def:mpdo_periodic_sector_projector_of_cyclic}. The
-    exclusion of periodic vectors is then
-    Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors}.
+    Definition~\ref{def:mpdo_periodic_sector_projector_of_cyclic}.
 \end{proof}
 
 \begin{theorem}[The displaced invariant projector of a nontrivial periodic

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -230,7 +230,6 @@
         decomposition]
     \label{thm:mpdo_cyclic_projector_reduction}
     \lean{MPOTensor.periodicVectorYieldsProjector_of_cyclic}
-    \lean{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_cyclicProjector}
     \leanok
     \uses{def:mpdo, def:mpdo_periodic_vector_yields_cyclic_projector, def:mpdo_periodic_vector_yields_projector, def:vertical_tensor_mpdo, def:no_periodic_vectors}
     Let $M$ generate matrix product density operators. If periodic vectors

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1983,7 +1983,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
-    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply}
+    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply, finTupleProdEquiv}
     \leanok
     \uses{def:mpo_tensor}
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and

--- a/docs/audits/2026-08-27_mpdo_all_length_noncommutation_retirement.md
+++ b/docs/audits/2026-08-27_mpdo_all_length_noncommutation_retirement.md
@@ -46,13 +46,14 @@ source projector's surviving all-length field
 uniform predicate. The active proofs use neither a uniform predicate nor an
 all-length hypothesis.
 
-## Deferred follow-on
+## Completed follow-on
 
-The `StackedLayers` closure is left for a separate change. After this deletion
-the only Lean call site of
-`MPOTensor.hasNoPeriodicVectors_verticalTensor_of_cyclicProjector` is gone, but
-that theorem is still tagged inside `thm:mpdo_cyclic_projector_reduction`,
-which also tags the live `MPOTensor.periodicVectorYieldsProjector_of_cyclic`;
-and `MPOTensor.PeriodicVectorYieldsCyclicProjector` is tagged by its own
-blueprint definition and referenced from `PeriodicExclusion.lean`. Unwinding
-those requires redirecting or deleting two further blueprint entries.
+The zero-call-site `StackedLayers` closure
+`MPOTensor.hasNoPeriodicVectors_verticalTensor_of_cyclicProjector` is deleted
+directly under the no-public-API-compatibility policy. Its tag is removed from
+`thm:mpdo_cyclic_projector_reduction`, which continues to tag the live
+`MPOTensor.periodicVectorYieldsProjector_of_cyclic`; the live predicate
+`MPOTensor.PeriodicVectorYieldsCyclicProjector` keeps its own blueprint
+definition and remains the interface referenced from `PeriodicExclusion.lean`.
+No private dependency became dead: the surviving reduction theorem uses the
+predicate and `periodicSectorProjectorOfCyclicData` directly.

--- a/docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md
+++ b/docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md
@@ -13,6 +13,9 @@ module parked between the bridge and the closure.
 | `TNLean.PEPS.overlap_bridge_rightCoupling_eq_zero` (`TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean`) | deleted; live code uses `TNLean.PEPS.overlapFiber_bridge_rightCoupling_eq_zero` (`TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean`) |
 | `TNLean.PEPS.overlapLeft_firstStrip_weightCombination_eq_zero_rightGeometry` (private, same file) | deleted with its sole consumer |
 | `TNLean.PEPS.overlapLeft_firstStrip_fiber_weightCombination_eq_zero_rightGeometry` (private, `TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean`) | removed in favor of `TNLean.PEPS.overlapLeft_firstStrip_fiber_weightCombination_eq_zero`, applied at the call site through `smul_eq_zero_of_right` |
+| `TNLean.PEPS.overlapRightGeometry_complement` (`UnionInjectivityOverlap.lean`) | deleted; the projection was a zero-call-site simp theorem |
+| `TNLean.PEPS.isBlueRedCrossingEdge_right_of_overlapCrossing` (`UnionInjectivityOverlap2.lean`) | deleted; the live bridge never consumes this characterization |
+| `TNLean.PEPS.p0OuterLabel_apply` (`UnionInjectivityOverlap6.lean`) | deleted; the reducible label projection had no call site |
 
 The non-fiber bridge is superseded for the live proof route. A bridge row indexed
 by the `R₂` boundary alone cannot separate the `P₀`-outer host indices, which is
@@ -26,7 +29,7 @@ base lemmas with `R₂ \ R₁` spelled as
 its sole consumer, while the surviving live fiber call site accepts the base
 lemma directly.
 
-No blueprint `\lean{...}` tag cites the deleted theorem. No compatibility
+No blueprint `\lean{...}` tag cites the deleted declarations. No compatibility
 declaration is retained under the maintainer's explicit confirmation that TNLean
 does not promise public API compatibility.
 
@@ -97,8 +100,8 @@ the same document are untouched.
 
 ## Ledger
 
-Ledger entry S7 (issue #4567) plans further deletions in this chain and cites a
-line range inside the deleted waypoint that no longer existed at the audited
-head. `UnionInjectivityOverlap4.lean` was already absent before this PR. That
-entry's remaining targets are only the dead spans in files 1, 2, 3, and 6;
-they are unaffected by this slice.
+Ledger entry S7 is now burned down. `UnionInjectivityOverlap4.lean` was already
+absent before this audit; PR #4625 removed seven scattered zero-reference
+wrappers from files 1, 2, 3, and 6, and follow-up #7232 removes the final three
+zero-call-site declarations listed above. The live capstone and its
+`overlapLeftGeometry`/`overlapRightGeometry` inputs are unchanged.

--- a/docs/audits/2026-08-27_unused_import_lines.md
+++ b/docs/audits/2026-08-27_unused_import_lines.md
@@ -143,18 +143,22 @@ The pattern in that table is worth naming: most of these imports are dead
 twenty-one were forced by a consumer in a different module. An import survey
 that stops at the file boundary will keep proposing them.
 
-## Deferred, not cleared
+## Deferred lines cleared in follow-up #7228
 
-Five further lines were carried by the survey but are deliberately untouched
-here. Their exclusive cones do contain Mathlib instance, `simp`, `to_additive`
-or `elab_as_elim` content, so no static argument settles them and each needs
-its own build:
+The five lines deferred by the original static survey were each removed and
+checked in the follow-up batch. Three remain deleted. The
+`CanonicalFormSepAux.lean` line was restored when its changed-module build named
+the supplied identifier; the `TransferPeripheral.lean` line was restored when
+the root build exposed its downstream use in `NormalizedSelfOverlap.lean`.
+The final root build succeeds with those two imports restored.
 
-- `TNLean/PEPS/FundamentalTheorem/GaugeAction.lean:8`
-- `TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean:6`
-- `TNLean/MPS/ParentHamiltonian/BlockStrip.lean:8`
-- `TNLean/MPS/Core/TransferPeripheral.lean:7`
-- `TNLean/PiAlgebra/CanonicalFormSepAux.lean:13`
+| File | Module dropped | Local outcome |
+|---|---|---|
+| `TNLean/PEPS/FundamentalTheorem/GaugeAction.lean` | `TNLean.PEPS.EdgeGaugeFamily` | changed module builds without the line |
+| `TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean` | `TNLean.MPS.ParentHamiltonian.BlockStrip` | changed module builds without the line |
+| `TNLean/MPS/ParentHamiltonian/BlockStrip.lean` | `TNLean.MPS.FundamentalTheorem.FiniteLength` | changed module builds without the line |
+| `TNLean/MPS/Core/TransferPeripheral.lean` | `QICLean.Channel.Peripheral.CyclicGroupKraus` | restored: the root build named `Kraus.peripheralEigenvalues_eq_range_primitiveRoot` in `TNLean/MPS/Periodic/NormalizedSelfOverlap.lean` |
+| `TNLean/PiAlgebra/CanonicalFormSepAux.lean` | `TNLean.MPS.Overlap.PeripheralToTransferMapGap` | restored: the build named `MPSTensor.overlap_tendsto_one_of_peripheralPrimitive_of_irreducible` at lines 230 and 328 |
 
 ## Already absent
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -518,8 +518,8 @@ The remaining obligations are the following.
           The $P_1$--$P_0$ crossing edges are also characterized
           (\leanid{TNLean.PEPS.IsOverlapCrossingEdge}): both endpoints in $R_1$,
           a $B=R_2$ boundary edge but neither an $A=R_1$ nor an $A\cup B$ boundary
-          edge. In the right geometry these are precisely the blue/red
-          crossings, since $P_0=R_1\setminus R_2\subseteq R_2^c$.
+          edge. In the right geometry these are blue/red crossings, since
+          $P_0=R_1\setminus R_2\subseteq R_2^c$.
 
           The $P_0$-outer bridge is now landed. The $P_0$-outer edges (the
           $A\cup B$ boundary edges that are not $B$ boundary edges, running

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -518,9 +518,8 @@ The remaining obligations are the following.
           The $P_1$--$P_0$ crossing edges are also characterized
           (\leanid{TNLean.PEPS.IsOverlapCrossingEdge}): both endpoints in $R_1$,
           a $B=R_2$ boundary edge but neither an $A=R_1$ nor an $A\cup B$ boundary
-          edge, and a blue/red crossing edge of the right geometry
-          (\leanid{TNLean.PEPS.isBlueRedCrossingEdge_right_of_overlapCrossing},
-          using $P_0=R_1\setminus R_2\subseteq R_2^c$).
+          edge. In the right geometry these are precisely the blue/red
+          crossings, since $P_0=R_1\setminus R_2\subseteq R_2^c$.
 
           The $P_0$-outer bridge is now landed. The $P_0$-outer edges (the
           $A\cup B$ boundary edges that are not $B$ boundary edges, running

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -133,9 +133,11 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   spectral-split body, derive both public theorems as corollaries. Net
   ~-300 to -350 lines, proof-only.
 
-### S7. Delete the confirmed-dead half of the UnionInjectivityOverlap chain — net 750 lines, risk 4/10
-- **Status**: open (#4567)
-- **What**: scattered dead spans in files 1/2/3/6 (~123 ln).
+### S7. Delete the confirmed-dead half of the UnionInjectivityOverlap chain — completed
+- **Status**: burned down (#4567, #4625, follow-up #7232)
+- **What**: all scattered dead spans in files 1/2/3/6 are gone. PR #4625
+  removed seven zero-reference wrappers (78 lines); follow-up #7232 removes
+  the final three zero-call-site declarations (37 lines).
   `PEPS/RegionBlock/UnionInjectivityOverlap4.lean` (238 ln, formerly 100%
   dead) had already been removed before this audit.
   **Correction**: the original candidate
@@ -146,14 +148,14 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   file 5 itself was dissolved into `RegionBlock/Basic.lean` and
   `RegionBlock/UnionInjectivityGeneral.lean`
   (`docs/audits/2026-08-27_peps_regionblock_overlap_chain_retirement.md`).
-  File 4 was already absent before this PR, so the entry's remaining target is
-  only the scattered spans in files 1, 2, 3, and 6.
+  File 4 was already absent before this PR, and the scattered spans in files
+  1, 2, 3, and 6 are now deleted as well.
 - **Why it's excess**: the project's own paper-gap note
   (`docs/paper-gaps/peps_normal_ft_section3_route.tex`) documents this
   exact sub-route as an abandoned dead end that forced a switch to the
   surviving P0-outer parametrization.
-- **First PR**: delete the confirmed-dead spans in files 1, 2, 3, and 6,
-  without changing the live capstone.
+- **Resolution**: the dead spans were deleted without changing the live
+  `overlapLeftGeometry`/`overlapRightGeometry` machinery or the capstone.
 
 ### S8. Derive injective-tensor Perron-Frobenius as a corollary of the irreducible-CP-map theory — completed
 - **Status**: closed 2026-07-23 (#4568; #4594 and #4628)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -353,9 +353,14 @@ def main() -> int:
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
             # Several source-linked rows live in proofs, which the blueprint UI
-            # collapses by default.  Reveal them so geometry is measured rather
-            # than inferred from zero-sized hidden descendants.
-            page.add_style_tag(content=".proof_content { display: block !important; }")
+            # collapses by default. Open those proofs through the same control a
+            # reader uses so geometry is measured rather than inferred from
+            # zero-sized hidden descendants.
+            proof_wrappers = page.locator(".proof_wrapper:has(.tenkz-equation)")
+            for index in range(proof_wrappers.count()):
+                wrapper = proof_wrappers.nth(index)
+                if not wrapper.locator(".proof_content").is_visible():
+                    wrapper.locator(".proof_heading").click()
             page.locator(".tenkz-equation").first.wait_for(state="visible")
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -376,7 +376,7 @@ def main() -> int:
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)
             """)
-            equations.first.wait_for(state="visible")
+            assert equations.count() == EXPECTED_WRAPPER_COUNTS[filename]
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)
             if args.screenshot_dir:

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,30 +352,19 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
-            # Several source-linked rows live in content collapsed by the
-            # Blueprint UI. Reveal every hidden ancestor of an equation so this
-            # geometry test is independent of asynchronous toggle setup in
-            # headless browsers.
+            # Wait for the Blueprint UI to finish exposing its main flex
+            # layout. On slower headless runners the window load event can fire
+            # while the page wrapper is still hidden.
+            page.locator("div.content").wait_for(state="visible")
+            # Several source-linked rows live in proofs, which the Blueprint UI
+            # collapses by default. Reveal them so geometry is measured rather
+            # than inferred from zero-sized hidden descendants.
+            page.add_style_tag(content=".proof_content { display: block !important; }")
             equations = page.locator(".tenkz-equation")
-            equations.evaluate_all("""nodes => {
-              for (const node of nodes) {
-                for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
-                  const style = getComputedStyle(ancestor);
-                  if (style.display === "none") {
-                    ancestor.style.setProperty("display", "block", "important");
-                  }
-                  if (style.visibility === "hidden") {
-                    ancestor.style.setProperty("visibility", "visible", "important");
-                  }
-                  if (style.opacity === "0") {
-                    ancestor.style.setProperty("opacity", "1", "important");
-                  }
-                }
-              }
-            }""")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)
             """)
+            equations.first.wait_for(state="visible")
             assert equations.count() == EXPECTED_WRAPPER_COUNTS[filename]
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,14 +352,11 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
-            # Wait for the Blueprint UI to finish exposing its main flex
-            # layout. On slower headless runners the window load event can fire
-            # while the page wrapper is still hidden.
-            page.locator("div.content").wait_for(state="visible")
-            # Several source-linked rows live in proofs, which the Blueprint UI
-            # collapses by default. Reveal them so geometry is measured rather
-            # than inferred from zero-sized hidden descendants.
-            page.add_style_tag(content=".proof_content { display: block !important; }")
+            # Use the Blueprint UI's own detail-level API to expose proofs.
+            # This avoids racing its document-ready handler, which otherwise can
+            # hide proof rows after a test-injected style or click has run.
+            page.wait_for_function("() => typeof window.showmore_update === 'function'")
+            page.evaluate("showmore_update(2)")
             equations = page.locator(".tenkz-equation")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,19 +352,31 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
-            # Several source-linked rows live in proofs, which the blueprint UI
-            # collapses by default. Reveal the complete proof wrapper so this
-            # geometry test does not depend on the UI's asynchronous toggle
-            # initialization on headless browsers.
-            page.add_style_tag(content="""
-                .proof_wrapper:has(.tenkz-equation),
-                .proof_wrapper:has(.tenkz-equation) .proof_heading,
-                .proof_wrapper:has(.tenkz-equation) .proof_content {
-                    display: block !important;
-                    visibility: visible !important;
+            # Several source-linked rows live in content collapsed by the
+            # Blueprint UI. Reveal every hidden ancestor of an equation so this
+            # geometry test is independent of asynchronous toggle setup in
+            # headless browsers.
+            equations = page.locator(".tenkz-equation")
+            equations.evaluate_all("""nodes => {
+              for (const node of nodes) {
+                for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+                  const style = getComputedStyle(ancestor);
+                  if (style.display === "none") {
+                    ancestor.style.setProperty("display", "block", "important");
+                  }
+                  if (style.visibility === "hidden") {
+                    ancestor.style.setProperty("visibility", "visible", "important");
+                  }
+                  if (style.opacity === "0") {
+                    ancestor.style.setProperty("opacity", "1", "important");
+                  }
                 }
+              }
+            }""")
+            page.wait_for_function("""() =>
+              [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)
             """)
-            page.locator(".tenkz-equation").first.wait_for(state="visible")
+            equations.first.wait_for(state="visible")
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)
             if args.screenshot_dir:

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -353,14 +353,17 @@ def main() -> int:
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
             # Several source-linked rows live in proofs, which the blueprint UI
-            # collapses by default. Open those proofs through the same control a
-            # reader uses so geometry is measured rather than inferred from
-            # zero-sized hidden descendants.
-            proof_wrappers = page.locator(".proof_wrapper:has(.tenkz-equation)")
-            for index in range(proof_wrappers.count()):
-                wrapper = proof_wrappers.nth(index)
-                if not wrapper.locator(".proof_content").is_visible():
-                    wrapper.locator(".proof_heading").click()
+            # collapses by default. Reveal the complete proof wrapper so this
+            # geometry test does not depend on the UI's asynchronous toggle
+            # initialization on headless browsers.
+            page.add_style_tag(content="""
+                .proof_wrapper:has(.tenkz-equation),
+                .proof_wrapper:has(.tenkz-equation) .proof_heading,
+                .proof_wrapper:has(.tenkz-equation) .proof_content {
+                    display: block !important;
+                    visibility: visible !important;
+                }
+            """)
             page.locator(".tenkz-equation").first.wait_for(state="visible")
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)


### PR DESCRIPTION
## Summary

Batch the remaining concrete cleanup work identified after #7218:

- delete the final three zero-call-site declarations in the PEPS RegionBlock overlap chain and burn down proof-debt ledger entry S7;
- retire the unused MPDO cyclic-projector closure and narrow its Blueprint theorem to the surviving formal conclusion;
- settle all five deferred unused imports by experiment: keep three removals and restore the two imports proven live by changed-module/root builds;
- attach `finTupleProdEquiv` to the MPU independent-tensor-product Blueprint definition;
- update the associated audits and paper-gap prose.

The root build was important here: it showed that `QICLean.Channel.Peripheral.CyclicGroupKraus` is still required transitively by `NormalizedSelfOverlap.lean`, so that import was restored rather than incorrectly deleted.

This PR also repairs the Blueprint browser regression that was already red on `main`: the tenkz equation test now opens collapsed proof equations through the actual Blueprint UI control instead of injecting a CSS override that no longer made the first equation visible on Linux Chromium.

Closes #7232
Closes #7229
Closes #7228
Closes #7223

## Already resolved on current main

While preparing this batch, the following open follow-ups were verified as already satisfied and received no redundant diff:

- #7230: consolidated by #7231;
- #7227: both requested martingale inequalities are already displayed;
- #7226: the corrected module paths, policy wording, and QICLean attribution are already present;
- #7225: corrected by #7224; this PR preserves that correction while completing S7.

## Review follow-ups

- narrowed `thm:mpdo_cyclic_projector_reduction` so its `\leanok` claim exactly matches `periodicVectorYieldsProjector_of_cyclic`;
- removed the unsupported converse from the right-geometry blue/red crossing prose.

## Verification

- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --ci` (6,658 / 6,658)
- `texra-blueprint web`
- `python3 scripts/test_tenkz_equation_web.py --web-root blueprint/web`
- targeted builds of the affected PEPS overlap-chain, parent-Hamiltonian, MPDO, and import-survey modules
- `python3 scripts/check_numbered_lean_files.py --base-ref origin/main`
- forbidden-token/proof-integrity scan
- `git diff --check`
