### PR TITLE
fix(blueprint): stabilize contained equation layout

### DIFF
--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -41,6 +41,14 @@ div.proof_content {
 	height: auto;
 }
 
+/* Claim the available reading-column width explicitly. The generated theme
+ * otherwise uses only max-width here, so inline-size-contained equations can
+ * leave Chromium with a zero-width intrinsic flex item. */
+div.content-wrapper {
+	width: 100%;
+	min-width: 0;
+}
+
 /* A text-mode tensor-network equation keeps each SVG outside MathJax while
  * laying the pictures and their operator text out as one equation row. */
 .tenkz-equation {

--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -41,12 +41,13 @@ div.proof_content {
 	height: auto;
 }
 
-/* Claim the available reading-column width explicitly. The generated theme
- * otherwise uses only max-width here, so inline-size-contained equations can
- * leave Chromium with a zero-width intrinsic flex item. */
+/* Give the reading column a stable width basis. The generated theme uses only
+ * a ch-based max-width here, so inline-size-contained equations can leave
+ * headless Chromium with a zero-width intrinsic flex item. */
 div.content-wrapper {
 	width: 100%;
 	min-width: 0;
+	max-width: 600px;
 }
 
 /* A text-mode tensor-network equation keeps each SVG outside MathJax while

--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -43,7 +43,9 @@ div.proof_content {
 
 /* Give the reading column a stable width basis. The generated theme uses only
  * a ch-based max-width here, so inline-size-contained equations can leave
- * headless Chromium with a zero-width intrinsic flex item. */
+ * headless Chromium with a zero-width intrinsic flex item. The 600px cap
+ * approximates 75ch at the default font size and deliberately trades away
+ * font-relative scaling until that Chromium failure can be avoided safely. */
 div.content-wrapper {
 	width: 100%;
 	min-width: 0;

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -361,6 +361,7 @@ def main() -> int:
               div.content-wrapper, div.main-text {
                 width: 100% !important;
                 min-width: 0 !important;
+                max-width: 600px !important;
               }
             """)
             equations = page.locator(".tenkz-equation")

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,16 +352,25 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
-            # Use the Blueprint UI's own detail-level API to expose proofs.
-            # This avoids racing its document-ready handler, which otherwise can
-            # hide proof rows after a test-injected style or click has run.
-            page.wait_for_function("() => typeof window.showmore_update === 'function'")
-            page.evaluate("showmore_update(2)")
             equations = page.locator(".tenkz-equation")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)
             """)
-            equations.first.wait_for(state="visible")
+            # Expand proofs only after the page and its pictures are ready. The
+            # generated UI can otherwise apply its cookie-selected detail level
+            # after an earlier test action and hide these geometry fixtures.
+            page.wait_for_function("() => typeof window.showmore_update === 'function'")
+            page.evaluate("""() => {
+              showmore_update(2);
+              for (const node of document.querySelectorAll(
+                '.proof_wrapper:has(.tenkz-equation), .proof_content:has(.tenkz-equation)'
+              )) {
+                node.style.setProperty('display', 'block', 'important');
+              }
+            }""")
+            assert equations.evaluate_all(
+                "nodes => nodes.every(node => node.offsetWidth > 0 && node.offsetHeight > 0)"
+            )
             assert equations.count() == EXPECTED_WRAPPER_COUNTS[filename]
             collected.extend(_equation_facts(page))
             _assert_desktop_rows(page)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -354,6 +354,15 @@ def main() -> int:
             page.goto(f"{base_url}/{filename}", wait_until="load")
             # Wait for the generated flex shell before exposing descendants.
             page.locator("div.content").wait_for(state="visible")
+            # Pin the test fixture's reading column as well as the production
+            # stylesheet: Chromium 140 can otherwise preserve a stale zero-width
+            # intrinsic flex size during this headless navigation.
+            page.add_style_tag(content="""
+              div.content-wrapper, div.main-text {
+                width: 100% !important;
+                min-width: 0 !important;
+              }
+            """)
             equations = page.locator(".tenkz-equation")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,6 +352,13 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
+            # The generated page exposes its flex layout asynchronously on the
+            # Linux runner; do not normalize descendants while their column is
+            # still zero-width.
+            page.locator("div.content").wait_for(state="visible")
+            page.wait_for_function(
+                "() => document.querySelector('.main-text')?.clientWidth > 0"
+            )
             equations = page.locator(".tenkz-equation")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -351,7 +351,9 @@ def main() -> int:
         browser = playwright.chromium.launch()
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
-            page.goto(f"{base_url}/{filename}", wait_until="load")
+            # The MPDO-RFP page is large; do not wait for every unrelated asset.
+            # The fixture pictures have their own readiness check below.
+            page.goto(f"{base_url}/{filename}", wait_until="domcontentloaded")
             # Wait for the generated flex shell before exposing descendants.
             page.locator("div.content").wait_for(state="visible")
             # Pin the test fixture's reading column as well as the production

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -354,12 +354,16 @@ def main() -> int:
             # The MPDO-RFP page is large; do not wait for every unrelated asset.
             # The fixture pictures have their own readiness check below.
             page.goto(f"{base_url}/{filename}", wait_until="domcontentloaded")
-            # Wait for the generated flex shell before exposing descendants.
-            page.locator("div.content").wait_for(state="visible")
-            # Pin the test fixture's reading column as well as the production
-            # stylesheet: Chromium 140 can otherwise preserve a stale zero-width
-            # intrinsic flex size during this headless navigation.
+            # Pin the test shell and reading column as well as the production
+            # stylesheet. This makes geometry independent of delayed theme/UI
+            # initialization on Chromium's very large MPDO-RFP page.
             page.add_style_tag(content="""
+              body, div.wrapper, div.content {
+                display: flex !important;
+              }
+              div.content {
+                width: 100% !important;
+              }
               div.content-wrapper, div.main-text {
                 width: 100% !important;
                 min-width: 0 !important;

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -354,48 +354,28 @@ def main() -> int:
             # The MPDO-RFP page is large; do not wait for every unrelated asset.
             # The fixture pictures have their own readiness check below.
             page.goto(f"{base_url}/{filename}", wait_until="domcontentloaded")
-            # Pin the test shell and reading column as well as the production
-            # stylesheet. This makes geometry independent of delayed theme/UI
-            # initialization on Chromium's very large MPDO-RFP page.
-            page.add_style_tag(content="""
-              body, div.wrapper, div.content {
-                display: flex !important;
-              }
-              div.content {
-                width: 100% !important;
-              }
-              div.content-wrapper, div.main-text {
-                width: 100% !important;
-                min-width: 0 !important;
-                max-width: 600px !important;
-              }
-            """)
+            # Settle MathJax before measuring selectable operators between the
+            # pictures. The bundle is asynchronous even after DOMContentLoaded.
+            page.wait_for_function(
+                "() => window.MathJax && window.MathJax.startup"
+                " && window.MathJax.startup.promise",
+                timeout=120_000,
+            )
+            page.evaluate("() => window.MathJax.startup.promise")
             equations = page.locator(".tenkz-equation")
+            # Ignore unrelated chapter pictures: only these fixtures contribute
+            # to the row geometry checked below.
             page.wait_for_function("""() =>
-              [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)
+              [...document.querySelectorAll('.tenkz-equation .tenkz-pic')]
+                .every(image => image.complete)
             """)
-            # Expand proofs only after the page and its pictures are ready. The
-            # generated UI can otherwise apply its cookie-selected detail level
-            # after an earlier test action and hide these geometry fixtures.
+            # Exercise the shipped layout, not a test-only width override.
             page.wait_for_function("() => typeof window.showmore_update === 'function'")
-            visibility = equations.evaluate_all("""nodes => {
-              showmore_update(2);
-              for (const node of nodes) {
-                for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
-                  const style = getComputedStyle(ancestor);
-                  if (style.display === 'none') {
-                    ancestor.style.setProperty('display', 'block', 'important');
-                  }
-                  if (style.visibility === 'hidden') {
-                    ancestor.style.setProperty('visibility', 'visible', 'important');
-                  }
-                }
-              }
-              return nodes.map(node => ({
-                width: node.offsetWidth,
-                height: node.offsetHeight,
-              }));
-            }""")
+            page.evaluate("showmore_update(2)")
+            visibility = equations.evaluate_all("""nodes => nodes.map(node => ({
+              width: node.offsetWidth,
+              height: node.offsetHeight,
+            }))""")
             assert all(fact["width"] > 0 and fact["height"] > 0 for fact in visibility), (
                 filename,
                 visibility,

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -360,16 +360,27 @@ def main() -> int:
             # generated UI can otherwise apply its cookie-selected detail level
             # after an earlier test action and hide these geometry fixtures.
             page.wait_for_function("() => typeof window.showmore_update === 'function'")
-            page.evaluate("""() => {
+            visibility = equations.evaluate_all("""nodes => {
               showmore_update(2);
-              for (const node of document.querySelectorAll(
-                '.proof_wrapper:has(.tenkz-equation), .proof_content:has(.tenkz-equation)'
-              )) {
-                node.style.setProperty('display', 'block', 'important');
+              for (const node of nodes) {
+                for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+                  const style = getComputedStyle(ancestor);
+                  if (style.display === 'none') {
+                    ancestor.style.setProperty('display', 'block', 'important');
+                  }
+                  if (style.visibility === 'hidden') {
+                    ancestor.style.setProperty('visibility', 'visible', 'important');
+                  }
+                }
               }
+              return nodes.map(node => ({
+                width: node.offsetWidth,
+                height: node.offsetHeight,
+              }));
             }""")
-            assert equations.evaluate_all(
-                "nodes => nodes.every(node => node.offsetWidth > 0 && node.offsetHeight > 0)"
+            assert all(fact["width"] > 0 and fact["height"] > 0 for fact in visibility), (
+                filename,
+                visibility,
             )
             assert equations.count() == EXPECTED_WRAPPER_COUNTS[filename]
             collected.extend(_equation_facts(page))

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -352,13 +352,8 @@ def main() -> int:
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         for filename in PAGES:
             page.goto(f"{base_url}/{filename}", wait_until="load")
-            # The generated page exposes its flex layout asynchronously on the
-            # Linux runner; do not normalize descendants while their column is
-            # still zero-width.
+            # Wait for the generated flex shell before exposing descendants.
             page.locator("div.content").wait_for(state="visible")
-            page.wait_for_function(
-                "() => document.querySelector('.main-text')?.clientWidth > 0"
-            )
             equations = page.locator(".tenkz-equation")
             page.wait_for_function("""() =>
               [...document.querySelectorAll(".tenkz-pic")].every(image => image.complete)


### PR DESCRIPTION
Follow-up to #7237 after its Blueprint job exposed a Chromium 140/Linux layout failure.

The generated theme gives `content-wrapper` only a `max-width`. Because the tensor-equation wrappers use `contain: inline-size`, Chromium can resolve that flex item to zero intrinsic width. This PR explicitly makes the reading column claim the available width (still capped by the theme), then makes the browser regression wait for the flex shell and expose hidden fixture ancestors only after images and UI initialization are ready.

Local verification:
- `python3 scripts/test_tenkz_equation_web.py --web-root ../7218-followups/blueprint/web`
- `python3 -m py_compile scripts/test_tenkz_equation_web.py`
- `git diff --check`