### PR TITLE
fix(ci): close scanner and badge follow-up gaps

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Generate badge JSON
         run: |
+          python3 scripts/test_badge_colors.py
           python3 scripts/generate_badges.py --output-dir badge-output --blueprint-src blueprint/src
           json_count=$(find badge-output -maxdepth 1 -name '*.json' | wc -l)
           if [ "$json_count" -eq 0 ]; then

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -29,7 +29,9 @@ on:
       - 'scripts/build_blueprint_ch01_12.sh'
       - 'scripts/assemble-pages-site.sh'
       - 'scripts/fetch-latest-artifact.sh'
+      - 'scripts/badge_utils.py'
       - 'scripts/write_badges.py'
+      - 'scripts/test_badge_colors.py'
       - 'scripts/tenkz_blueprint_sweep.py'
       - 'scripts/test_tenkz_pic.py'
   workflow_dispatch:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,6 +45,10 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/test_blueprint_lean_sync.py'
+      - 'scripts/badge_utils.py'
+      - 'scripts/write_badges.py'
+      - 'scripts/generate_badges.py'
+      - 'scripts/test_badge_colors.py'
       - 'scripts/test_blueprint_web_render.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/audit_cpsv16_labels.py'
@@ -100,6 +104,10 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/test_blueprint_lean_sync.py'
+      - 'scripts/badge_utils.py'
+      - 'scripts/write_badges.py'
+      - 'scripts/generate_badges.py'
+      - 'scripts/test_badge_colors.py'
       - 'scripts/test_blueprint_web_render.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/audit_cpsv16_labels.py'
@@ -185,6 +193,10 @@ jobs:
               - 'blueprint/.chktexrc'
               - 'blueprint/latexindent.yaml'
               - 'scripts/check_reader_facing_prose.py'
+              - 'scripts/badge_utils.py'
+              - 'scripts/write_badges.py'
+              - 'scripts/generate_badges.py'
+              - 'scripts/test_badge_colors.py'
               - 'scripts/test_blueprint_web_render.py'
               - 'scripts/tenkz_blueprint_sweep.py'
               - 'scripts/test_tenkz_blueprint_sweep.py'
@@ -616,6 +628,9 @@ jobs:
 
       - name: Test Blueprint declaration scanner
         run: python3 scripts/test_blueprint_lean_sync.py
+
+      - name: Test badge color thresholds
+        run: python3 scripts/test_badge_colors.py
 
       - name: Generate lean_decls from blueprint .tex files
         id: lean-decls

--- a/scripts/badge_utils.py
+++ b/scripts/badge_utils.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Shared helpers for badge endpoint generators."""
+
+from __future__ import annotations
+
+
+def count_color(
+    count: int,
+    *,
+    warning_at: int = 1,
+    danger_at: int | None = None,
+) -> str:
+    """Color a nonnegative count using inclusive escalation thresholds."""
+    if count == 0:
+        return "brightgreen"
+    if count < warning_at:
+        return "yellow"
+    if danger_at is not None and count >= danger_at:
+        return "red"
+    return "orange"

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -263,7 +263,10 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
             match = _LEAN_STRUCTURE_FIELD_RE.match(code)
             if not match:
                 continue
-            indent = len(code) - len(code.lstrip())
+            # Comment stripping concatenates the surviving fragments and does
+            # not preserve source columns. Lean layout uses the original line's
+            # leading indentation, including for an inline field doc comment.
+            indent = len(raw) - len(raw.lstrip())
             if field_indent is None:
                 field_indent = indent
             elif indent != field_indent:

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -38,6 +38,8 @@ import tomllib
 from collections import defaultdict
 from pathlib import Path
 
+from badge_utils import count_color
+
 
 SORRY_RE = re.compile(r"\bsorry\b")
 AXIOM_RE = re.compile(
@@ -132,16 +134,6 @@ def count_pattern(files: list[Path], pattern: re.Pattern[str]) -> int:
         source = path.read_text(encoding="utf-8")
         count += len(pattern.findall(strip_lean_comments_and_strings(source)))
     return count
-
-
-def count_color(count: int, *, warn: int, danger: int) -> str:
-    if count == 0:
-        return "brightgreen"
-    if count < warn:
-        return "yellow"
-    if count < danger:
-        return "orange"
-    return "red"
 
 
 def lean_version(repo_root: Path) -> str:
@@ -261,7 +253,9 @@ def main() -> None:
 
     badge_records = {
         "sorries.json": badge(
-            "sorries", str(sorry_count), count_color(sorry_count, warn=10, danger=50)
+            "sorries",
+            str(sorry_count),
+            count_color(sorry_count, warning_at=10, danger_at=50),
         ),
         "axioms.json": badge(
             "axioms", str(axiom_count), "brightgreen" if axiom_count == 0 else "red"
@@ -287,12 +281,12 @@ def main() -> None:
         badge_records["blueprint_no_leanok.json"] = badge(
             r"blueprint: no \leanok",
             str(no_leanok_count),
-            count_color(no_leanok_count, warn=100, danger=300),
+            count_color(no_leanok_count, warning_at=100, danger_at=300),
         )
         badge_records["blueprint_not_ready.json"] = badge(
             "blueprint: not ready",
             str(not_ready_count),
-            count_color(not_ready_count, warn=100, danger=300),
+            count_color(not_ready_count, warning_at=100, danger_at=300),
         )
 
     # --- Write badges ---

--- a/scripts/test_badge_colors.py
+++ b/scripts/test_badge_colors.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Regression tests for shared badge count-color thresholds."""
+
+import generate_badges
+import write_badges
+from badge_utils import count_color
+
+
+def test_generators_share_count_color() -> None:
+    assert generate_badges.count_color is count_color
+    assert write_badges.count_color is count_color
+
+
+def test_count_color_boundaries() -> None:
+    colors = {
+        count: count_color(count, warning_at=100, danger_at=300)
+        for count in (0, 1, 99, 100, 299, 300)
+    }
+    assert colors == {
+        0: "brightgreen",
+        1: "yellow",
+        99: "yellow",
+        100: "orange",
+        299: "orange",
+        300: "red",
+    }
+
+
+if __name__ == "__main__":
+    test_generators_share_count_color()
+    test_count_color_boundaries()
+    print("Badge color tests passed.")

--- a/scripts/test_blueprint_lean_sync.py
+++ b/scripts/test_blueprint_lean_sync.py
@@ -29,6 +29,10 @@ structure Witness where
       letI : NeZero (n + 1) := ⟨by omega⟩
       True
 
+structure InlineDoc where
+  /-- Documentation on the first field. -/ first : Nat
+  second : Nat
+
  theorem after : True := by trivial
 
 end Example
@@ -42,6 +46,8 @@ end Example
         assert "Example.Witness.letI" not in decls
         assert "Example.Witness.this" not in decls
         assert "Example.Witness.fake" not in decls
+        assert decls["Example.InlineDoc.first"].kind == "field"
+        assert decls["Example.InlineDoc.second"].kind == "field"
         assert "Example.after" in decls
 
 

--- a/scripts/write_badges.py
+++ b/scripts/write_badges.py
@@ -16,6 +16,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from badge_utils import count_color
+
 
 ROOT = Path(__file__).resolve().parents[1]
 LEAN_ROOT = ROOT / "TNLean"
@@ -119,16 +121,6 @@ def write_badge(name: str, label: str, message: str, color: str, badge_dir: Path
     badge_dir.mkdir(parents=True, exist_ok=True)
     payload = {"schemaVersion": 1, "label": label, "message": message, "color": color}
     (badge_dir / f"{name}.json").write_text(json.dumps(payload, indent=2) + "\n")
-
-
-def count_color(count: int, *, warning_at: int = 1, danger_at: int | None = None) -> str:
-    if count == 0:
-        return "brightgreen"
-    if count <= warning_at:
-        return "yellow"
-    if danger_at is not None and count >= danger_at:
-        return "red"
-    return "orange"
 
 
 def blueprint_badge_counts() -> tuple[int, int]:


### PR DESCRIPTION
## Summary

- compute structure-field layout indentation from the original Lean source line, so an inline field doc comment cannot shift the scanner baseline
- add the requested inline-doc-comment regression fixture
- consolidate badge count coloring into one shared helper with threshold escalation at `warning_at` and `danger_at`
- exercise the exact warning/danger boundaries through both badge generators in PR and scheduled badge CI
- record that #7215 was already fixed independently by #7221

Closes #7213.
Closes #7169.

## Verification

- `python3 scripts/test_blueprint_lean_sync.py`
- `python3 scripts/test_badge_colors.py`
- `python3 scripts/write_badges.py /tmp/tnlean-badges-write`
- `python3 scripts/generate_badges.py --output-dir /tmp/tnlean-badges-generate --blueprint-src blueprint/src`
- `python3 -m py_compile scripts/*.py`
- `git diff --check`