### PR TITLE
docs: close QICLean migration follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ follow-up, not against the temporary `sorry` count.
 | `MPOTensor.IsSAL.physTraceTransfer_ne_zero` | helper theorem | Deriving nonvanishing of the one-site physical-trace transfer from the positive-length normalization clause in saturation of the area law | `TNLean/MPS/MPDO/SALTraceTransfer.lean` |
 | `Finset.sum_eq_sum_subtype_ne_zero` | helper theorem | Restricting a finite sum to the subtype where a weight is nonzero when the remaining summands vanish | `TNLean/Algebra/FinsetSubtypeSum.lean` |
 | `Complex.ofReal_sqrt_sq` | helper theorem | Squaring the complex coercion of a nonnegative real square root | `TNLean/Algebra/ComplexSqrt.lean` |
-| `Matrix.IsIsometry.kronecker` | helper theorem | Preserving matrix isometries under the Kronecker product | `TNLean/Algebra/MatrixIsometryKronecker.lean` |
+| `Matrix.IsIsometry.kronecker` | helper theorem | Preserving matrix isometries under the Kronecker product | `QICLean/Algebra/MatrixIsometryKronecker.lean` (QICLean dependency) |
 | `Matrix.reindexLinearEquiv_mul` | helper theorem | Multiplying matrices transported along compatible row, middle, and column equivalences; instantiate all three equivalences explicitly | `Mathlib/LinearAlgebra/Matrix/Reindex.lean` |
 | `Matrix.entry_eq_of_heq` | helper theorem | Equating entries of a dependent family of matrices from the index equation and two heterogeneous coordinate identifications | `TNLean/MPS/MPDO/PhysicalSectorFactorization.lean` |
 | `MPSTensor.cyclic_projection_mul_left` | helper theorem | Multiplying out the adjoint transfer map applied to a cyclic-sector projection times an arbitrary matrix, instead of rebuilding the Kadison–Schwarz multiplicative-domain argument | `TNLean/MPS/Periodic/SectorIrreducibility/HLift.lean` |

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -60,7 +60,7 @@ index to the active sector (`sum_prod_traceSq_eq_sum_active`), and the
 cyclic-product expansion of `tr(S^N)` (`trace_pow_eq_sum_cyclic_product`).
 
 The singleton-sector proof is by contradiction, following the source-facing repair
-documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`: the overlap formula and
+documented in <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>: the overlap formula and
 normality (`MPSTensor.IsNormalTensor.selfOverlap_tendsto_one`, the `equalMPS`
 self-overlap limit) give `tr(S^N) → 1`.  Conjugating the primitive `T` by its
 Perron vector (`TNLean/Algebra/PerronFrobenius/PerronVector.lean`) gives a
@@ -573,7 +573,7 @@ normal (in the paper's spectral-radius-one sense), then the active sector set ha
 one element.
 
 The proof is by contradiction from the source-faithful route recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`: the overlap
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>: the overlap
 formula and normality give `tr(S^N) → 1`; positivity bounds `S` entrywise by the Hadamard
 square of the primitive stochastic conjugate `P` of `T`; if there were more than one active
 sector, `P` would be irreducible substochastic on a nontrivial index set, forcing
@@ -699,7 +699,7 @@ on the active sector such that $T_{kh}=a_kb_h$ and $\sum_k a_kb_k=1$.
 The unique active sector, the identity $T^2=T$, and strict positivity of $T^2$ force
 the sole entry of $T$ to equal one, so the constant functions $a=b=1$ suffice.
 
-**Scope restriction (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`):** this is the normal
+**Scope restriction (<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>):** this is the normal
 Case-I active-sector packaging of CPSV16 equations `Apptralktrrk` and `AppPsiPhi`
 (Appendix C.2, lines 1394--1401 and 1484--1499). No Case-II conclusion follows;
 Case II requires its separate coefficient argument. -/
@@ -749,7 +749,7 @@ factors, and `QL` is the complexification of the active-sector trace matrix `T`.
 Thus this identity is the algebraic form of
 `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`, namely `T² = T`.
 
-**Local fix (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`):** this is a project-derived
+**Local fix (<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>):** this is a project-derived
 rectangular form, in project notation, of the factors built from $l_h$ and $r_k$ in
 CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper does not state it as a
 separate displayed theorem. -/

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -121,7 +121,7 @@ Source: arXiv:1703.09188, equations `Erightleft`, `simple1`, and `simple2`,
 lines 397--427.
 
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
-`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρtrace : Matrix.trace ρ = 1)
@@ -193,7 +193,7 @@ representative supplied by
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
-`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.exists_reduced_cfii_forced_block_simple_contractions
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
     (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)

--- a/TNLean/MPS/MPU/ResidualAlgebra.lean
+++ b/TNLean/MPS/MPU/ResidualAlgebra.lean
@@ -17,7 +17,7 @@ algebra, hence every element is nilpotent.  Finally, the finite-dimensional
 nil-matrix theorem shows that every product of exactly `D²` residual matrices vanishes.
 
 The source claims a strict intermediate bound.  We use the corrected exact
-length `D²`; see `docs/paper-gaps/mpu_nil_matrix_bound.tex`.
+length `D²`; see <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>.
 -/
 
 open scoped Matrix
@@ -168,7 +168,7 @@ theorem IsMPU.isNilpotent_of_mem_residualAlgebra
 
 **Local fix (arXiv:1703.09188, Proposition III.3, lines 410--415):** the source's
 unsupported strict intermediate bound is replaced by the exact ambient-dimension
-length `D²`; see `docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+length `D²`; see <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.residualAlgebra_list_prod_eq_zero
     [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
     (l : List (Matrix (Fin (D * D)) (Fin (D * D)) ℂ))
@@ -182,7 +182,7 @@ theorem IsMPU.residualAlgebra_list_prod_eq_zero
 
 **Local fix (arXiv:1703.09188, equation `Sprime=0`, lines 410--415):** the
 corrected length is `D²`, rather than a strict bound below it; see
-`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.prod_residualSlice_doubleLayerTensor_eq_zero
     [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
     (X : Fin (D * D) → Matrix (Fin d) (Fin d) ℂ) :

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -170,7 +170,7 @@ exact length \(D^2\).
 Source: arXiv:1703.09188, Proposition III.3(ii), lines 405--427.
 
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\), replacing the
-unsupported strict intermediate bound; see `docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+unsupported strict intermediate bound; see <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.blockTensor_sq_simple_contractions_of_normalizedDiagonal_eq_vecMulVec
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
     (ρ Φ : Fin (D * D) → ℂ) (hpair : Φ ⬝ᵥ ρ = 1)
@@ -246,7 +246,7 @@ MPU-simple after the corrected second blocking of exact length \(D^2\).
 Source: arXiv:1703.09188, Proposition III.3(ii), lines 405--427.
 
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\), replacing the
-unsupported strict intermediate bound; see `docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+unsupported strict intermediate bound; see <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.blockTensor_sq_isMPUSimple_of_normalizedDiagonal_eq_vecMulVec
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
     (ρ Φ : Fin (D * D) → ℂ) (hpair : Φ ⬝ᵥ ρ = 1)
@@ -728,7 +728,7 @@ Source: arXiv:1703.09188, Proposition III.3(ii), lines 397--427.
 
 **Local fix (nil-matrix length):** the first exponent satisfies \(J \leq D^2 - 1\)
 and the second length is exactly \(D^2\), still giving \(JD^2 < D^4\); see
-`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPU.exists_blockTensor_isMPUSimple_of_one_lt
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D) :
     ∃ k : ℕ, 0 < k ∧ k < D ^ 4 ∧ IsMPUSimple (MPOTensor.blockTensor U k) := by

--- a/docs/audits/2026-08-27_issue7177_kraus_pass_through.md
+++ b/docs/audits/2026-08-27_issue7177_kraus_pass_through.md
@@ -1,0 +1,39 @@
+# Issue #7177: Kraus pass-through migration inventory
+
+Audited at TNLean `a07808833b84eab82fbdba6e47c3e0f826443821`, with QICLean pinned at
+`a8347e6f9f97f331c51ec911ca27b8fc8d46a783`.
+
+PR #7177 removed the following TNLean pass-through declarations after migrating
+their non-Archive consumers and Blueprint tags to the existing generic owners.
+This table supplies the per-declaration inventory required by the repository's
+pass-through exception.
+
+| Removed declaration | Replacement |
+|---|---|
+| `MPSTensor.transferMap_conjTranspose_eq_adjoint` | `Kraus.mapLM_conjTranspose_eq_adjoint` |
+| `MPSTensor.transferMap_adjoint_eq_adjointMapLM` | `Kraus.adjointMapLM_apply` via `Kraus.mapLM_conjTranspose_eq_adjoint` |
+| `MPSTensor.transferMap_adjoint_apply_eq_adjointMap` | `Kraus.adjointMapLM_apply` via `Kraus.mapLM_conjTranspose_eq_adjoint` |
+| `MPSTensor.lowerZero_implies_invariance` | `Kraus.lowerZero_implies_invariance` |
+| `MPSTensor.isUnit_peripheral_eigenvector` | `Kraus.isUnit_peripheral_eigenvector` |
+| `MPSTensor.peripheralEigenvalues_pow_mem_of_irreducible_unital_of_adjoint_fixedPoint` | `Kraus.peripheralEigenvalues_pow_mem_of_irreducible_unital_of_adjoint_fixedPoint` |
+| `MPSTensor.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint` | `Kraus.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint` |
+| `MPSTensor.peripheralEigenvalues_mul_mem_of_irreducible_unital_of_adjoint_fixedPoint` | `Kraus.peripheralEigenvalues_mul_mem_of_irreducible_unital_of_adjoint_fixedPoint` |
+| `MPSTensor.peripheralEigenvalues_eq_range_primitiveRoot` | `Kraus.peripheralEigenvalues_eq_range_primitiveRoot` |
+| `MPSTensor.isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor` | `Kraus.isIrreducibleMap_mapLM_conjTranspose` after `Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily` |
+| `MPSTensor.isIrreducibleTensor_of_isIrreducibleMap_conjTranspose` | `Kraus.isIrreducibleFamily_of_isIrreducibleMap_mapLM` after `Kraus.isIrreducibleMap_mapLM_conjTranspose_iff` |
+| `MPSTensor.lowerZero_of_posSemidef_fixedPoint` | `Kraus.lowerZero_of_posSemidef_fixedPoint` |
+| `MPSTensor.invariance_implies_lowerZero` | `Kraus.invariance_implies_lowerZero` |
+| `MPSTensor.isIrreducibleCP_transferMap_of_isIrreducibleTensor` | `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily` |
+| `MPSTensor.isIrreducibleTensor_of_isIrreducibleMap` | `Kraus.isIrreducibleFamily_of_isIrreducibleMap_transferMap` |
+| `MPSTensor.self_correlation_persists` | `Kraus.self_correlation_persists` |
+| `MPSTensor.transferMap_conjTranspose` | `Kraus.map_conjTranspose` |
+| `MPSTensor.transferMap_pow_smul_eigenvector` | `Module.End.pow_apply_of_mem_eigenspace` (Mathlib) |
+| `MPSTensor.trace_eigenvector_eq_zero` | `Kraus.trace_eigenvector_eq_zero` |
+| `MPSTensor.posSemidef_pow_fixedPoint_unique_of_isPrimitivePaper` | `Kraus.posSemidef_pow_fixedPoint_unique` |
+| `MPSTensor.transferMap_pow_apply_eq_sum` | `Kraus.transferMap_pow_apply'` |
+| `MPSTensor.IsPrimitiveMPS.transferMap_isChannel` | `Kraus.isChannel_transferMap _ hP.norm` at the former use site |
+| `MPSTensor.isIrreducibleMap_of_isIrreducibleTensor` | `Kraus.isIrreducibleMap_transferMap_of_isIrreducibleFamily` |
+
+The three deprecated cyclic-projector compatibility aliases removed in the same
+PR were already marked for retirement and are outside this pass-through
+inventory.

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -11,7 +11,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{clarification}{resolved}
+\gapnote{false-source}{open}
 
 QICLean is now the canonical owner of this paper-gap note. The complete note is
 available at


### PR DESCRIPTION
## Summary

- add the per-declaration TNLean-to-QICLean/Mathlib migration inventory omitted from #7177
- repoint the remaining Kronecker-isometry proof-automation ledger entry to its QICLean owner
- replace load-bearing Lean docstring references to local compatibility stubs with clickable canonical QICLean paper-gap URLs
- restore the `cpgsv17_pf_rank_one` compatibility pointer's open false-source verdict

The three Matrix reindex ledger rows named in #7174 were subsequently retired by #7233 when their project helpers were replaced with Mathlib's `Matrix.reindexLinearEquiv_mul`; this PR updates the one stale row that remains on current main.

## Verification

- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `texra-blueprint paper-gaps check`
- `git diff --check origin/main...HEAD`

Closes #7180.
Closes #7174.
Closes #7173.
Closes #7172.
