### PR TITLE
fix(ci): align badge endpoints and action-update gates

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -29,8 +29,8 @@ on:
       - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
-      - '.github/workflows/pr-ci.yml'
-      - '.github/workflows/docgen.yml'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
       - 'tenkz.toml'
       - 'scripts/fetch_tenkz.py'
       - 'scripts/tenkz_paths.py'
@@ -93,8 +93,8 @@ on:
       - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
-      - '.github/workflows/pr-ci.yml'
-      - '.github/workflows/docgen.yml'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
       - 'tenkz.toml'
       - 'scripts/fetch_tenkz.py'
       - 'scripts/tenkz_paths.py'
@@ -217,9 +217,8 @@ jobs:
               - 'docs/**/*.md'
               - 'texra-blueprint.toml'
             workflow:
-              - '.github/workflows/pr-ci.yml'
-              - '.github/workflows/docgen.yml'
-              - '.github/workflows/blueprint.yml'
+              - '.github/workflows/**'
+              - '.github/dependabot.yml'
 
   build:
     needs: changes

--- a/scripts/badge_utils.py
+++ b/scripts/badge_utils.py
@@ -18,3 +18,13 @@ def count_color(
     if danger_at is not None and count >= danger_at:
         return "red"
     return "orange"
+
+
+def sorries_color(count: int) -> str:
+    """Color the shared sorries endpoint."""
+    return count_color(count, warning_at=10, danger_at=50)
+
+
+def axioms_color(count: int) -> str:
+    """Color the shared axioms endpoint."""
+    return "brightgreen" if count == 0 else "red"

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -38,7 +38,7 @@ import tomllib
 from collections import defaultdict
 from pathlib import Path
 
-from badge_utils import count_color
+from badge_utils import axioms_color, count_color, sorries_color
 
 
 SORRY_RE = re.compile(r"\bsorry\b")
@@ -229,6 +229,11 @@ def _blueprint_badge_counts(
 # ---------------------------------------------------------------------------
 
 
+def badge_count_colors(sorries: int, axioms: int) -> dict[str, str]:
+    """Return colors for the count badges emitted by this generator."""
+    return {"sorries": sorries_color(sorries), "axioms": axioms_color(axioms)}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", type=Path, default=Path("badges"))
@@ -250,16 +255,15 @@ def main() -> None:
 
     sorry_count = count_pattern(lean_files, SORRY_RE)
     axiom_count = count_pattern(lean_files, AXIOM_RE)
+    colors = badge_count_colors(sorry_count, axiom_count)
 
     badge_records = {
         "sorries.json": badge(
             "sorries",
             str(sorry_count),
-            count_color(sorry_count, warning_at=10, danger_at=50),
+            colors["sorries"],
         ),
-        "axioms.json": badge(
-            "axioms", str(axiom_count), "brightgreen" if axiom_count == 0 else "red"
-        ),
+        "axioms.json": badge("axioms", str(axiom_count), colors["axioms"]),
         "lean.json": badge("Lean", lean_version(repo_root), "blue"),
         "mathlib.json": badge("Mathlib", mathlib_version(repo_root), "blue"),
     }

--- a/scripts/test_badge_colors.py
+++ b/scripts/test_badge_colors.py
@@ -3,12 +3,16 @@
 
 import generate_badges
 import write_badges
-from badge_utils import count_color
+from badge_utils import axioms_color, count_color, sorries_color
 
 
 def test_generators_share_count_color() -> None:
     assert generate_badges.count_color is count_color
     assert write_badges.count_color is count_color
+    assert generate_badges.sorries_color is sorries_color
+    assert write_badges.sorries_color is sorries_color
+    assert generate_badges.axioms_color is axioms_color
+    assert write_badges.axioms_color is axioms_color
 
 
 def test_count_color_boundaries() -> None:
@@ -26,7 +30,20 @@ def test_count_color_boundaries() -> None:
     }
 
 
+def test_endpoint_color_agreement() -> None:
+    for count, expected in ((10, "orange"), (50, "red")):
+        generated = generate_badges.badge_count_colors(count, 0)["sorries"]
+        written = write_badges.badge_count_colors(count, 0)["sorries"]
+        assert generated == written == expected
+
+    for count, expected in ((0, "brightgreen"), (1, "red")):
+        generated = generate_badges.badge_count_colors(0, count)["axioms"]
+        written = write_badges.badge_count_colors(0, count)["axioms"]
+        assert generated == written == expected
+
+
 if __name__ == "__main__":
     test_generators_share_count_color()
     test_count_color_boundaries()
+    test_endpoint_color_agreement()
     print("Badge color tests passed.")

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -11,6 +11,8 @@ import json
 import re
 import socketserver
 import threading
+import time
+import urllib.request
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -167,6 +169,30 @@ class _GeneratedStructureParser(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self.in_paragraph:
             self.paragraph_parts.append(data)
+
+
+def _mathjax_bundle(root: Path) -> tuple[str, bytes]:
+    """Fetch once so Chromium does not depend on a cross-origin CDN request."""
+    script_sources: set[str] = set()
+    script_pattern = re.compile(r'<script\b[^>]*\bsrc=["\']([^"\']+)["\']', re.I)
+    for filename in PAGES:
+        source = (root / filename).read_text(encoding="utf-8")
+        script_sources.update(
+            src for src in script_pattern.findall(source)
+            if re.search(r"mathjax|tex-(?:chtml|mml|svg)", src, re.I)
+        )
+    assert len(script_sources) == 1, script_sources
+    url = script_sources.pop()
+    request = urllib.request.Request(url, headers={"User-Agent": "TNLean-CI/1"})
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return url, response.read()
+        except OSError:
+            if attempt == 2:
+                raise
+            time.sleep(2 ** attempt)
+    raise AssertionError("unreachable")
 
 
 def _assert_generated_blocks(root: Path) -> None:
@@ -345,11 +371,18 @@ def main() -> int:
         args.screenshot_dir.mkdir(parents=True, exist_ok=True)
     _assert_generated_blocks(root)
 
+    mathjax_url, mathjax_bundle = _mathjax_bundle(root)
     collected: list[dict[str, object]] = []
     mobile: list[dict[str, object]] = []
     with serve(root) as base_url, sync_playwright() as playwright:
         browser = playwright.chromium.launch()
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.route(
+            mathjax_url,
+            lambda route: route.fulfill(
+                body=mathjax_bundle, content_type="application/javascript"
+            ),
+        )
         for filename in PAGES:
             # The MPDO-RFP page is large; do not wait for every unrelated asset.
             # The fixture pictures have their own readiness check below.

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -397,11 +397,10 @@ def main() -> int:
                 " && window.MathJax.startup.promise",
                 timeout=300_000,
             )
-            # Wait out the typesetting pass as well; otherwise the evaluate
-            # inherits playwright's default 30s budget, the same loaded-runner
-            # flake one step later.
-            page.evaluate(
-                "() => window.MathJax.startup.promise",
+            # Wait out the typesetting pass under the same explicit budget, so
+            # a failure distinguishes slow typesetting from bundle installation.
+            page.wait_for_function(
+                "async () => { await window.MathJax.startup.promise; return true; }",
                 timeout=300_000,
             )
             equations = page.locator(".tenkz-equation")

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -388,13 +388,22 @@ def main() -> int:
             # The fixture pictures have their own readiness check below.
             page.goto(f"{base_url}/{filename}", wait_until="domcontentloaded")
             # Settle MathJax before measuring selectable operators between the
-            # pictures. The bundle is asynchronous even after DOMContentLoaded.
+            # pictures. The bundle is served from the local route above, but
+            # typesetting the large MPDO pages still takes minutes on loaded
+            # runners, so budget generously: a page whose MathJax never starts
+            # still fails, just later.
             page.wait_for_function(
                 "() => window.MathJax && window.MathJax.startup"
                 " && window.MathJax.startup.promise",
-                timeout=120_000,
+                timeout=300_000,
             )
-            page.evaluate("() => window.MathJax.startup.promise")
+            # Wait out the typesetting pass as well; otherwise the evaluate
+            # inherits playwright's default 30s budget, the same loaded-runner
+            # flake one step later.
+            page.evaluate(
+                "() => window.MathJax.startup.promise",
+                timeout=300_000,
+            )
             equations = page.locator(".tenkz-equation")
             # Ignore unrelated chapter pictures: only these fixtures contribute
             # to the row geometry checked below.

--- a/scripts/write_badges.py
+++ b/scripts/write_badges.py
@@ -16,7 +16,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from badge_utils import count_color
+from badge_utils import axioms_color, count_color, sorries_color
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -152,12 +152,18 @@ def blueprint_badge_counts() -> tuple[int, int]:
     return no_leanok, not_ready
 
 
+def badge_count_colors(sorries: int, axioms: int) -> dict[str, str]:
+    """Return colors for the count badges emitted by this generator."""
+    return {"sorries": sorries_color(sorries), "axioms": axioms_color(axioms)}
+
+
 def main() -> None:
     badge_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "home_page" / "badges"
     sorries = count_token("sorry")
     axioms = count_token("axiom")
-    write_badge("sorries", "sorries", str(sorries), count_color(sorries, warning_at=10), badge_dir)
-    write_badge("axioms", "axioms", str(axioms), count_color(axioms, warning_at=0), badge_dir)
+    colors = badge_count_colors(sorries, axioms)
+    write_badge("sorries", "sorries", str(sorries), colors["sorries"], badge_dir)
+    write_badge("axioms", "axioms", str(axioms), colors["axioms"], badge_dir)
     write_badge("lean", "Lean", lean_version(), "blue", badge_dir)
     write_badge("mathlib", "Mathlib", mathlib_version(), "blue", badge_dir)
     no_leanok, not_ready = blueprint_badge_counts()


### PR DESCRIPTION
## Summary

- centralize the sorries and axioms color profiles used by both badge generators
- compare each generator's endpoint-color path at the sorries 10/50 and axioms 0/1 boundaries
- route changes to every managed workflow, plus Dependabot configuration, through the PR CI workflow and its build gate

## Verification

- `python3 -m pytest -q scripts/test_badge_colors.py`
- generated `sorries.json` and `axioms.json` with both scripts and compared their colors
- parsed `.github/workflows/pr-ci.yml` with PyYAML
- `python3 -m compileall -q scripts/badge_utils.py scripts/write_badges.py scripts/generate_badges.py scripts/test_badge_colors.py`
- `git diff --check origin/main...HEAD`

Closes #7243.
Closes #7235.
