### PR TITLE
fix(blueprint): restore font-relative reading width

### DIFF
--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -41,15 +41,13 @@ div.proof_content {
 	height: auto;
 }
 
-/* Give the reading column a stable width basis. The generated theme uses only
- * a ch-based max-width here, so inline-size-contained equations can leave
- * headless Chromium with a zero-width intrinsic flex item. The 600px cap
- * approximates 75ch at the default font size and deliberately trades away
- * font-relative scaling until that Chromium failure can be avoided safely. */
+/* Give the reading column a stable, font-relative width basis. Using em rather
+ * than the generated theme's ch cap avoids Chromium's zero-width intrinsic flex
+ * item for inline-size-contained equations while preserving text-zoom scaling. */
 div.content-wrapper {
 	width: 100%;
 	min-width: 0;
-	max-width: 600px;
+	max-width: 37.5em;
 }
 
 /* A text-mode tensor-network equation keeps each SVG outside MathJax while

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -356,6 +356,24 @@ def _assert_mobile_scroll(page: Page) -> list[dict[str, object]]:
     return facts
 
 
+def _assert_font_relative_reading_width(page: Page) -> None:
+    widths = page.evaluate(
+        """() => {
+          const root = document.documentElement;
+          const wrapper = document.querySelector('div.content-wrapper');
+          const originalSize = root.style.fontSize;
+          root.style.fontSize = '16px';
+          const defaultWidth = parseFloat(getComputedStyle(wrapper).maxWidth);
+          root.style.fontSize = '32px';
+          const enlargedWidth = parseFloat(getComputedStyle(wrapper).maxWidth);
+          root.style.fontSize = originalSize;
+          return {defaultWidth, enlargedWidth};
+        }"""
+    )
+    ratio = widths["enlargedWidth"] / widths["defaultWidth"]
+    assert 1.95 <= ratio <= 2.05, widths
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--web-root", type=Path, default=Path("blueprint/web"))
@@ -387,6 +405,7 @@ def main() -> int:
             # The MPDO-RFP page is large; do not wait for every unrelated asset.
             # The fixture pictures have their own readiness check below.
             page.goto(f"{base_url}/{filename}", wait_until="domcontentloaded")
+            _assert_font_relative_reading_width(page)
             # Settle MathJax before measuring selectable operators between the
             # pictures. The bundle is served from the local route above, but
             # typesetting the large MPDO pages still takes minutes on loaded


### PR DESCRIPTION
## Summary

- replace the fixed `600px` reading-column cap with `37.5em`, preserving the same default-size measure while scaling with enlarged text
- retain the stable explicit width basis that avoids Chromium's zero-width intrinsic flex item for contained equations
- extend the real-browser equation layout regression to verify that doubling the root font size doubles the computed reading-width cap

Closes #7240.

## Verification

- `python3 -m py_compile scripts/test_tenkz_equation_web.py`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/fetch_tenkz.py`
- `texra-blueprint bbl`
- `cd blueprint && texra-blueprint web`
- `python3 scripts/test_tenkz_equation_web.py --web-root blueprint/web`
- `python3 scripts/generate_import_aggregators.py --check`
- `texra-blueprint paper-gaps check`
- `git diff --check`
