### PR TITLE
refactor(mps): derive block triangular trace from projections

### DIFF
--- a/TNLean/MPS/Core/BlockTriangularTrace.lean
+++ b/TNLean/MPS/Core/BlockTriangularTrace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Defs
+import TNLean.MPS.Core.ProjectionTriangularTrace
 import TNLean.MPS.Core.MultiBlock
 
 import Mathlib.Data.Matrix.Block
@@ -12,16 +12,10 @@ import Mathlib.Logic.Equiv.Fin.Basic
 /-!
 # Block-triangular trace invariance for MPS tensors
 
-This file proves that strict upper-right blocks do not affect word traces of
-block upper-triangular tensors. It defines block-sum and reindexing maps and
-proves `sameMPV_upperFin_diagFin`, reducing an
-upper-triangular tensor to its block-diagonal part.
-
-The coordinate-free strict generalization is
-`MPSTensor.sameMPV_diagPart_of_lowerZero` in
-`TNLean.MPS.Core.ProjectionTriangularTrace`. The declarations here retain the
-two-block coordinate presentation as a compatibility interface; they should be
-derived from that projection formulation before deprecation.
+This file specializes the coordinate-free projection-triangular API to the decomposition
+`Fin n ⊕ Fin m`, transported to `Fin (n + m)` by `finSumFinEquiv`. The public coordinate
+constructions and statements are retained as a compatibility interface, while their proofs
+are obtained from the projection formulation.
 -/
 
 open scoped Matrix BigOperators
@@ -67,6 +61,257 @@ noncomputable def diagFin
       (diagSum (d := d) (n := n) (m := m) A11 A22 i)
 
 
+private noncomputable def sumProj (n m : ℕ) :
+    Matrix (Fin n ⊕ Fin m) (Fin n ⊕ Fin m) ℂ :=
+  Matrix.fromBlocks 1 0 0 0
+
+private noncomputable def coordProj (n m : ℕ) :
+    Matrix (Fin (n + m)) (Fin (n + m)) ℂ :=
+  Matrix.reindex (finSumFinEquiv (m := n) (n := m)) (finSumFinEquiv (m := n) (n := m))
+    (sumProj n m)
+
+private lemma sumProj_isHermitian : (sumProj n m).IsHermitian := by
+  exact Matrix.IsHermitian.fromBlocks (by simp) (by simp) (by simp)
+
+private lemma sumProj_isIdempotent : sumProj n m * sumProj n m = sumProj n m := by
+  simp [sumProj, Matrix.fromBlocks_multiply]
+
+private lemma coordProj_isOrthogonalProjection :
+    IsOrthogonalProjection (coordProj n m) := by
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  constructor
+  · exact sumProj_isHermitian.reindex e
+  · change (Matrix.reindexRingEquiv ℂ e) (sumProj n m) *
+        (Matrix.reindexRingEquiv ℂ e) (sumProj n m) =
+      (Matrix.reindexRingEquiv ℂ e) (sumProj n m)
+    rw [← map_mul, sumProj_isIdempotent]
+
+private lemma one_sub_sumProj :
+    1 - sumProj n m =
+      Matrix.fromBlocks (0 : Matrix (Fin n) (Fin n) ℂ) 0 0 (1 : Matrix (Fin m) (Fin m) ℂ) := by
+  classical
+  rw [← Matrix.fromBlocks_one]
+  ext i j
+  rcases i with i | i <;> rcases j with j | j <;> simp [sumProj, Matrix.one_apply]
+
+private lemma lowerZero_upperBlocks
+    (X : Matrix (Fin n) (Fin n) ℂ) (Y : Matrix (Fin n) (Fin m) ℂ)
+    (Z : Matrix (Fin m) (Fin m) ℂ) :
+    (1 - sumProj n m) * Matrix.fromBlocks X Y 0 Z * sumProj n m = 0 := by
+  rw [one_sub_sumProj]
+  simp [sumProj, Matrix.fromBlocks_multiply]
+
+private lemma diagPart_upperBlocks
+    (X : Matrix (Fin n) (Fin n) ℂ) (Y : Matrix (Fin n) (Fin m) ℂ)
+    (Z : Matrix (Fin m) (Fin m) ℂ) :
+    sumProj n m * Matrix.fromBlocks X Y 0 Z * sumProj n m +
+      (1 - sumProj n m) * Matrix.fromBlocks X Y 0 Z * (1 - sumProj n m) =
+      Matrix.fromBlocks X 0 0 Z := by
+  rw [one_sub_sumProj]
+  simp only [sumProj, Matrix.fromBlocks_multiply]
+  ext i j
+  rcases i with i | i <;> rcases j with j | j <;> simp
+
+private lemma lowerZero_upperFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    ∀ i, (1 - coordProj n m) * upperFin A11 A12 A22 i * coordProj n m = 0 := by
+  intro i
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  change (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+      (Matrix.reindexRingEquiv ℂ e) (Matrix.fromBlocks (A11 i) (A12 i) 0 (A22 i)) *
+      (Matrix.reindexRingEquiv ℂ e) (sumProj n m) = 0
+  simpa only [map_sub, map_one, map_mul, map_zero] using
+    congrArg (Matrix.reindexRingEquiv ℂ e)
+      (lowerZero_upperBlocks (A11 i) (A12 i) (A22 i))
+
+private lemma diagPart_upperFin
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
+    Kraus.diagPart (upperFin A11 A12 A22) (coordProj n m) = diagFin A11 A22 := by
+  funext i
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  change (Matrix.reindexRingEquiv ℂ e) (sumProj n m) *
+        (Matrix.reindexRingEquiv ℂ e) (Matrix.fromBlocks (A11 i) (A12 i) 0 (A22 i)) *
+        (Matrix.reindexRingEquiv ℂ e) (sumProj n m) +
+      (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+        (Matrix.reindexRingEquiv ℂ e) (Matrix.fromBlocks (A11 i) (A12 i) 0 (A22 i)) *
+        (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) =
+      (Matrix.reindexRingEquiv ℂ e) (Matrix.fromBlocks (A11 i) 0 0 (A22 i))
+  simpa only [map_sub, map_one, map_mul, map_add] using
+    congrArg (Matrix.reindexRingEquiv ℂ e)
+      (diagPart_upperBlocks (A11 i) (A12 i) (A22 i))
+
+private def inlMatrix (n m : ℕ) : Matrix (Fin n ⊕ Fin m) (Fin n) ℂ
+  | Sum.inl i, j => (1 : Matrix (Fin n) (Fin n) ℂ) i j
+  | Sum.inr _, _ => 0
+
+private def inrMatrix (n m : ℕ) : Matrix (Fin n ⊕ Fin m) (Fin m) ℂ
+  | Sum.inl _, _ => 0
+  | Sum.inr i, j => (1 : Matrix (Fin m) (Fin m) ℂ) i j
+
+private lemma evalWord_intertwine_reindex
+    {ι : Type*} [Fintype ι] [DecidableEq ι] {D r : ℕ} (e : ι ≃ Fin D)
+    (K : Fin d → Matrix ι ι ℂ) (L : Fin d → Matrix (Fin r) (Fin r) ℂ)
+    (V : Matrix ι (Fin r) ℂ) (hInt : ∀ i, K i * V = V * L i) (w : List (Fin d)) :
+    _root_.evalWord K w * V = V * _root_.evalWord L w := by
+  let K' : MPSTensor d D := fun i => Matrix.reindex e e (K i)
+  let V' := Matrix.reindex e (Equiv.refl _) V
+  have hInt' : ∀ i, K' i * V' = V' * L i := by
+    intro i
+    change Matrix.reindex e e (K i) * Matrix.reindex e (Equiv.refl _) V =
+      Matrix.reindex e (Equiv.refl _) V * L i
+    rw [show Matrix.reindex e e (K i) * Matrix.reindex e (Equiv.refl _) V =
+      Matrix.reindex e (Equiv.refl _) (K i * V) from
+        Matrix.reindexLinearEquiv_mul ℂ ℂ e e (Equiv.refl _) _ _]
+    rw [show Matrix.reindex e (Equiv.refl _) V * L i =
+      Matrix.reindex e (Equiv.refl _) (V * L i) from
+        Matrix.reindexLinearEquiv_mul ℂ ℂ e (Equiv.refl _) (Equiv.refl _) _ _]
+    exact congrArg (Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _)) (hInt i)
+  have h := Kraus.evalWord_intertwine K' L V' hInt' w
+  have hReindex : Kraus.evalWord K' w = Matrix.reindex e e (_root_.evalWord K w) :=
+    MPSTensor.evalWord_reindex e K w
+  apply (Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _)).injective
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e e (Equiv.refl _)]
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e (Equiv.refl _) (Equiv.refl _)]
+  change Matrix.reindex e e (_root_.evalWord K w) * V' = V' * _root_.evalWord L w
+  rw [← hReindex]
+  simpa only [MPSTensor.evalWord_aux_eq] using h
+
+private lemma diagSum_mul_inl
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (i : Fin d) :
+    diagSum A11 A22 i * inlMatrix n m = inlMatrix n m * A11 i := by
+  classical
+  ext x j
+  rcases x with x | x <;> simp [diagSum, Matrix.mul_apply, inlMatrix, Matrix.one_apply]
+
+private lemma diagSum_mul_inr
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (i : Fin d) :
+    diagSum A11 A22 i * inrMatrix n m = inrMatrix n m * A22 i := by
+  classical
+  ext x j
+  rcases x with x | x <;> simp [diagSum, Matrix.mul_apply, inrMatrix, Matrix.one_apply]
+
+private lemma evalWord_diagSumAux
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (w : List (Fin d)) :
+    _root_.evalWord (diagSum A11 A22) w =
+      Matrix.fromBlocks (_root_.evalWord A11 w) 0 0 (_root_.evalWord A22 w) := by
+  classical
+  have h₁ := evalWord_intertwine_reindex finSumFinEquiv (diagSum A11 A22) A11
+    (inlMatrix n m) (diagSum_mul_inl A11 A22) w
+  have h₂ := evalWord_intertwine_reindex finSumFinEquiv (diagSum A11 A22) A22
+    (inrMatrix n m) (diagSum_mul_inr A11 A22) w
+  ext x y
+  rcases y with y | y
+  · have h := congrArg (fun M => M x y) h₁
+    rcases x with x | x <;>
+      simpa [Matrix.mul_apply, Fintype.sum_sum_type, inlMatrix, Matrix.one_apply] using h
+  · have h := congrArg (fun M => M x y) h₂
+    rcases x with x | x <;>
+      simpa [Matrix.mul_apply, Fintype.sum_sum_type, inrMatrix, Matrix.one_apply] using h
+
+private lemma sumProj_compressions (M : Matrix (Fin n ⊕ Fin m) (Fin n ⊕ Fin m) ℂ) :
+    sumProj n m * M * sumProj n m + (1 - sumProj n m) * M * (1 - sumProj n m) =
+      Matrix.fromBlocks (Matrix.toBlocks₁₁ M) 0 0 (Matrix.toBlocks₂₂ M) := by
+  rw [← Matrix.fromBlocks_toBlocks M, one_sub_sumProj]
+  simp only [sumProj, Matrix.fromBlocks_multiply]
+  ext i j
+  rcases i with i | i <;> rcases j with j | j <;> simp
+
+private lemma sumProj_lowerCompression (M : Matrix (Fin n ⊕ Fin m) (Fin n ⊕ Fin m) ℂ) :
+    (1 - sumProj n m) * M * sumProj n m =
+      Matrix.fromBlocks 0 0 (Matrix.toBlocks₂₁ M) 0 := by
+  rw [← Matrix.fromBlocks_toBlocks M, one_sub_sumProj]
+  simp only [sumProj, Matrix.fromBlocks_multiply]
+  ext i j
+  rcases i with i | i <;> rcases j with j | j <;> simp
+
+private lemma lowerZero_evalWord_upperSum
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (w : List (Fin d)) :
+    (1 - sumProj n m) * _root_.evalWord (upperSum A11 A12 A22) w * sumProj n m = 0 := by
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  have h := Kraus.lowerZero_evalWord (upperFin A11 A12 A22) (coordProj n m)
+    coordProj_isOrthogonalProjection (lowerZero_upperFin A11 A12 A22) w
+  have hEval := MPSTensor.evalWord_reindex e (upperSum A11 A12 A22) w
+  change (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+      Kraus.evalWord (fun i => Matrix.reindex e e (upperSum A11 A12 A22 i)) w *
+      (Matrix.reindexRingEquiv ℂ e) (sumProj n m) = 0 at h
+  rw [hEval] at h
+  change (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+      (Matrix.reindexRingEquiv ℂ e) (_root_.evalWord (upperSum A11 A12 A22) w) *
+      (Matrix.reindexRingEquiv ℂ e) (sumProj n m) = 0 at h
+  apply (Matrix.reindexRingEquiv ℂ e).injective
+  simpa only [map_sub, map_one, map_mul, map_zero] using h
+
+private lemma evalWord_diagPart_upperSum
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (w : List (Fin d)) :
+    _root_.evalWord (diagSum A11 A22) w =
+      sumProj n m * _root_.evalWord (upperSum A11 A12 A22) w * sumProj n m +
+        (1 - sumProj n m) * _root_.evalWord (upperSum A11 A12 A22) w *
+          (1 - sumProj n m) := by
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  have h := Kraus.evalWord_diagPart_eq (upperFin A11 A12 A22) (coordProj n m)
+    coordProj_isOrthogonalProjection (lowerZero_upperFin A11 A12 A22) w
+  rw [diagPart_upperFin] at h
+  have hUpper := MPSTensor.evalWord_reindex e (upperSum A11 A12 A22) w
+  have hDiag := MPSTensor.evalWord_reindex e
+    (diagSum A11 A22) w
+  change Kraus.evalWord (fun i => Matrix.reindex e e (diagSum A11 A22 i)) w =
+    (Matrix.reindexRingEquiv ℂ e) (sumProj n m) *
+        Kraus.evalWord (fun i => Matrix.reindex e e (upperSum A11 A12 A22 i)) w *
+        (Matrix.reindexRingEquiv ℂ e) (sumProj n m) +
+      (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+        Kraus.evalWord (fun i => Matrix.reindex e e (upperSum A11 A12 A22 i)) w *
+        (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) at h
+  rw [hUpper, hDiag] at h
+  change (Matrix.reindexRingEquiv ℂ e)
+      (_root_.evalWord (diagSum A11 A22) w) =
+    (Matrix.reindexRingEquiv ℂ e) (sumProj n m) *
+        (Matrix.reindexRingEquiv ℂ e) (_root_.evalWord (upperSum A11 A12 A22) w) *
+        (Matrix.reindexRingEquiv ℂ e) (sumProj n m) +
+      (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+        (Matrix.reindexRingEquiv ℂ e) (_root_.evalWord (upperSum A11 A12 A22) w) *
+        (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) at h
+  apply (Matrix.reindexRingEquiv ℂ e).injective
+  simpa only [map_sub, map_one, map_mul, map_add] using h
+
+private lemma evalWord_upperSumAux
+    (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
+    (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)
+    (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) (w : List (Fin d)) :
+    ∃ UR : Matrix (Fin n) (Fin m) ℂ,
+      _root_.evalWord (upperSum A11 A12 A22) w =
+        Matrix.fromBlocks (_root_.evalWord A11 w) UR 0 (_root_.evalWord A22 w) := by
+  let M := _root_.evalWord (upperSum A11 A12 A22) w
+  have hLower := lowerZero_evalWord_upperSum A11 A12 A22 w
+  rw [sumProj_lowerCompression] at hLower
+  have h21 : Matrix.toBlocks₂₁ M = 0 := by
+    have h := congrArg Matrix.toBlocks₂₁ hLower
+    change Matrix.toBlocks₂₁ M = (0 : Matrix (Fin m) (Fin n) ℂ) at h
+    exact h
+  have hDiag := evalWord_diagPart_upperSum A11 A12 A22 w
+  rw [evalWord_diagSumAux A11 A22 w, sumProj_compressions] at hDiag
+  have h11 : Matrix.toBlocks₁₁ M = _root_.evalWord A11 w := by
+    simpa using congrArg Matrix.toBlocks₁₁ hDiag.symm
+  have h22 : Matrix.toBlocks₂₂ M = _root_.evalWord A22 w := by
+    simpa using congrArg Matrix.toBlocks₂₂ hDiag.symm
+  refine ⟨Matrix.toBlocks₁₂ M, ?_⟩
+  calc
+    M = Matrix.fromBlocks (Matrix.toBlocks₁₁ M) (Matrix.toBlocks₁₂ M)
+        (Matrix.toBlocks₂₁ M) (Matrix.toBlocks₂₂ M) := (Matrix.fromBlocks_toBlocks M).symm
+    _ = Matrix.fromBlocks (_root_.evalWord A11 w) (Matrix.toBlocks₁₂ M) 0
+        (_root_.evalWord A22 w) := by rw [h11, h21, h22]
+
+
 /-- Trace of a block upper-triangular `2×2` matrix is the sum of the traces of its diagonal blocks.
 
 The strict upper-right block does not contribute to the trace. -/
@@ -74,9 +319,37 @@ lemma trace_fromBlocks_upper (X : Matrix (Fin n) (Fin n) ℂ)
     (Y : Matrix (Fin n) (Fin m) ℂ) (Z : Matrix (Fin m) (Fin m) ℂ) :
     Matrix.trace (Matrix.fromBlocks X Y 0 Z) = Matrix.trace X + Matrix.trace Z := by
   classical
-  -- Expand `trace` as a sum over the diagonal and split the `Sum` index.
-  simp [Matrix.trace, Fintype.sum_sum_type]
-
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  let M := Matrix.fromBlocks X Y 0 Z
+  have h := Matrix.trace_eq_trace_diag_of_proj (coordProj n m)
+    coordProj_isOrthogonalProjection (Matrix.reindex e e M)
+  change Matrix.trace ((Matrix.reindexRingEquiv ℂ e) M) =
+      Matrix.trace ((Matrix.reindexRingEquiv ℂ e) (sumProj n m) *
+        (Matrix.reindexRingEquiv ℂ e) M * (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) +
+      Matrix.trace ((1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m)) *
+        (Matrix.reindexRingEquiv ℂ e) M *
+          (1 - (Matrix.reindexRingEquiv ℂ e) (sumProj n m))) at h
+  have hTransport : Matrix.trace ((Matrix.reindexRingEquiv ℂ e) M) =
+      Matrix.trace ((Matrix.reindexRingEquiv ℂ e) (sumProj n m * M * sumProj n m)) +
+        Matrix.trace ((Matrix.reindexRingEquiv ℂ e)
+          ((1 - sumProj n m) * M * (1 - sumProj n m))) := by
+    simpa only [map_mul, map_sub, map_one] using h
+  change Matrix.trace (Matrix.reindex e e M) =
+      Matrix.trace (Matrix.reindex e e (sumProj n m * M * sumProj n m)) +
+        Matrix.trace (Matrix.reindex e e ((1 - sumProj n m) * M * (1 - sumProj n m)))
+    at hTransport
+  have h' : Matrix.trace M =
+      Matrix.trace (sumProj n m * M * sumProj n m) +
+        Matrix.trace ((1 - sumProj n m) * M * (1 - sumProj n m)) := by
+    simpa only [Matrix.trace_reindex] using hTransport
+  calc
+    Matrix.trace M =
+        Matrix.trace (sumProj n m * M * sumProj n m) +
+          Matrix.trace ((1 - sumProj n m) * M * (1 - sumProj n m)) := h'
+    _ = Matrix.trace (Matrix.fromBlocks X 0 0 Z) := by
+      rw [← Matrix.trace_add, diagPart_upperBlocks]
+    _ = Matrix.trace X + Matrix.trace Z := by
+      simp [Matrix.trace, Fintype.sum_sum_type]
 
 /-- For any word `w`, evaluating `upperSum` gives an upper-triangular block matrix.
 
@@ -88,19 +361,8 @@ lemma evalWord_upperSum_is_fromBlocks
     ∀ w : List (Fin d),
       ∃ UR : Matrix (Fin n) (Fin m) ℂ,
         _root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w =
-          Matrix.fromBlocks (_root_.evalWord A11 w) UR 0 (_root_.evalWord A22 w) := by
-  classical
-  intro w
-  induction w with
-  | nil =>
-      refine ⟨0, ?_⟩
-      simp [_root_.evalWord]
-  | cons i w ih =>
-      rcases ih with ⟨URw, hURw⟩
-      -- Multiply two block-upper-triangular matrices; the lower-left block stays `0`.
-      refine ⟨A11 i * URw + A12 i * _root_.evalWord A22 w, ?_⟩
-      simp [upperSum, _root_.evalWord, hURw, Matrix.fromBlocks_multiply]
-
+          Matrix.fromBlocks (_root_.evalWord A11 w) UR 0 (_root_.evalWord A22 w) :=
+  evalWord_upperSumAux A11 A12 A22
 
 /-- Word evaluation of `diagSum` stays block diagonal. -/
 lemma evalWord_diagSum_is_fromBlocks
@@ -108,15 +370,8 @@ lemma evalWord_diagSum_is_fromBlocks
     (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
     ∀ w : List (Fin d),
       _root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w =
-        Matrix.fromBlocks (_root_.evalWord A11 w) 0 0 (_root_.evalWord A22 w) := by
-  classical
-  intro w
-  induction w with
-  | nil =>
-      simp [_root_.evalWord]
-  | cons i w ih =>
-      simp [diagSum, _root_.evalWord, ih, Matrix.fromBlocks_multiply]
-
+        Matrix.fromBlocks (_root_.evalWord A11 w) 0 0 (_root_.evalWord A22 w) :=
+  evalWord_diagSumAux A11 A22
 
 /-- The strict upper-right blocks of an upper-triangular tensor do not affect word traces. -/
 lemma trace_evalWord_upperSum_eq_trace_evalWord_diagSum
@@ -126,14 +381,18 @@ lemma trace_evalWord_upperSum_eq_trace_evalWord_diagSum
     ∀ w : List (Fin d),
       Matrix.trace (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
         = Matrix.trace (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
-  classical
   intro w
-  rcases evalWord_upperSum_is_fromBlocks (d := d) (n := n) (m := m) A11 A12 A22 w with
-    ⟨UR, hUR⟩
-  have hDiag := evalWord_diagSum_is_fromBlocks (d := d) (n := n) (m := m) A11 A22 w
-  -- Now take traces; the upper-right block is irrelevant.
-  simp [hUR, hDiag, trace_fromBlocks_upper]
-
+  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv
+  have h := Kraus.trace_evalWord_diagPart_eq (upperFin A11 A12 A22) (coordProj n m)
+    coordProj_isOrthogonalProjection (lowerZero_upperFin A11 A12 A22) w
+  rw [diagPart_upperFin] at h
+  have hUpper := MPSTensor.evalWord_reindex e (upperSum A11 A12 A22) w
+  have hDiag := MPSTensor.evalWord_reindex e (diagSum A11 A22) w
+  change Matrix.trace (Kraus.evalWord
+      (fun i => Matrix.reindex e e (upperSum A11 A12 A22 i)) w) =
+    Matrix.trace (Kraus.evalWord (fun i => Matrix.reindex e e (diagSum A11 A22 i)) w) at h
+  rw [hUpper, hDiag, Matrix.trace_reindex, Matrix.trace_reindex] at h
+  exact h
 
 /-- Deleting the strict upper-right blocks of a block upper-triangular tensor does not change MPVs
 (after reindexing from `Fin n ⊕ Fin m` to `Fin (n+m)`). -/
@@ -144,61 +403,10 @@ lemma mpv_upperFin_eq_mpv_diagFin
     {N : ℕ} (σ : Fin N → Fin d) :
     mpv (upperFin (d := d) (n := n) (m := m) A11 A12 A22) σ =
       mpv (diagFin (d := d) (n := n) (m := m) A11 A22) σ := by
-  classical
-  let e : (Fin n ⊕ Fin m) ≃ Fin (n + m) := finSumFinEquiv (m := n) (n := m)
-  set w : List (Fin d) := List.ofFn σ with hw
-  -- Expand the MPV coefficients.
-  simp only [MPSTensor.mpv, MPSTensor.coeff, hw.symm]
-  -- Commute `Kraus.evalWord` with reindexing, then drop the reindexing inside `trace`.
-  have hUpperEval :
-      Kraus.evalWord (upperFin (d := d) (n := n) (m := m) A11 A12 A22) w =
-        Matrix.reindex e e
-          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w) := by
-    change Kraus.evalWord
-        (fun i => Matrix.reindex e e
-          (upperSum (d := d) (n := n) (m := m) A11 A12 A22 i)) w =
-        Matrix.reindex e e
-          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
-    exact
-      (MPSTensor.evalWord_reindex (d := d) (D := n + m) (e := e)
-        (A := upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)
-  have hDiagEval :
-      Kraus.evalWord (diagFin (d := d) (n := n) (m := m) A11 A22) w =
-        Matrix.reindex e e
-          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
-    change Kraus.evalWord
-        (fun i => Matrix.reindex e e
-          (diagSum (d := d) (n := n) (m := m) A11 A22 i)) w =
-        Matrix.reindex e e
-          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)
-    exact
-      (MPSTensor.evalWord_reindex (d := d) (D := n + m) (e := e)
-        (A := diagSum (d := d) (n := n) (m := m) A11 A22) w)
-  -- Reduce to the Sum-index trace identity.
-  --
-  -- `trace (reindex e e M) = trace M`, so the reindexing from `Fin n ⊕ Fin m` to `Fin (n+m)`
-  -- does not affect the coefficient.
-  calc
-    Matrix.trace (Kraus.evalWord (upperFin (d := d) (n := n) (m := m) A11 A12 A22) w)
-        = Matrix.trace (Matrix.reindex e e
-            (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w)) := by
-          simp [hUpperEval]
-    _ = Matrix.trace
-          (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w) := by
-          simpa using (Matrix.trace_reindex e
-            (_root_.evalWord (upperSum (d := d) (n := n) (m := m) A11 A12 A22) w))
-    _ = Matrix.trace
-          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w) := by
-          simpa using
-            trace_evalWord_upperSum_eq_trace_evalWord_diagSum
-              (d := d) (n := n) (m := m) A11 A12 A22 w
-    _ = Matrix.trace (Matrix.reindex e e
-          (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)) := by
-          simpa using (Matrix.trace_reindex e
-            (_root_.evalWord (diagSum (d := d) (n := n) (m := m) A11 A22) w)).symm
-    _ = Matrix.trace (Kraus.evalWord (diagFin (d := d) (n := n) (m := m) A11 A22) w) := by
-          simp [hDiagEval]
-
+  have h := sameMPV_diagPart_of_lowerZero (upperFin A11 A12 A22) (coordProj n m)
+    coordProj_isOrthogonalProjection (lowerZero_upperFin A11 A12 A22)
+  rw [diagPart_upperFin] at h
+  exact h N σ
 
 /-- Final `SameMPV` statement: upper-triangular off-diagonal blocks are irrelevant for MPVs. -/
 theorem sameMPV_upperFin_diagFin
@@ -207,9 +415,9 @@ theorem sameMPV_upperFin_diagFin
     (A22 : Fin d → Matrix (Fin m) (Fin m) ℂ) :
     SameMPV (upperFin (d := d) (n := n) (m := m) A11 A12 A22)
       (diagFin (d := d) (n := n) (m := m) A11 A22) := by
-  intro N σ
-  simpa using
-    mpv_upperFin_eq_mpv_diagFin (d := d) (n := n) (m := m) A11 A12 A22 (N := N) σ
+  rw [← diagPart_upperFin A11 A12 A22]
+  exact sameMPV_diagPart_of_lowerZero (upperFin A11 A12 A22) (coordProj n m)
+    coordProj_isOrthogonalProjection (lowerZero_upperFin A11 A12 A22)
 
 end BlockTriangular
 

--- a/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
+++ b/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
@@ -9,10 +9,10 @@ Repository-wide prose search finds only dated inventory snapshots in
 `docs/audits/`. These records describe earlier tree states; they neither
 prescribe an import nor present either module as a current public interface.
 
-## Retained: `TNLean/Algebra/BlockTriangularTrace.lean`
+## Retained: `TNLean/MPS/Core/BlockTriangularTrace.lean`
 
-The whole module is reachable only through the generated `TNLean.Algebra`
-aggregator. It contains the following substantive public declarations:
+The module is reachable through the generated `TNLean.MPS.Core` aggregator. It
+contains the following substantive public declarations:
 
 - `MPSTensor.upperSum`;
 - `MPSTensor.diagSum`;
@@ -25,21 +25,27 @@ aggregator. It contains the following substantive public declarations:
 - `MPSTensor.mpv_upperFin_eq_mpv_diagFin`;
 - `MPSTensor.sameMPV_upperFin_diagFin`.
 
-These declarations are not literal pass-throughs, but their mathematical
-content is the two-block coordinate specialization of the projection-based API
-in `TNLean/Algebra/ProjectionTriangularTrace.lean`. In particular,
-`MPSTensor.sameMPV_diagPart_of_lowerZero` is the coordinate-free strict
-generalization of `MPSTensor.sameMPV_upperFin_diagFin`, with the remaining
-projection lemmas supplying the corresponding word-evaluation and trace
-statements.
+Issue #7135 completed the compatibility transition. The implementation now
+uses the orthogonal projection obtained by reindexing
+`Matrix.fromBlocks 1 0 0 0` along `finSumFinEquiv`; its complement is
+`Matrix.fromBlocks 0 0 0 1`. The exact replacement relation is:
 
-Issue #7135 tracks the missing compatibility transition: the ten coordinate
-names are to be rederived as thin specializations of the projection API before
-deprecation is considered. Until then they do not satisfy the
-immediate-removal exception in `docs/project_conventions.md`, which is limited
-to exact pass-through declarations, bundled fields, and proof-step names
-replaced at their use sites. The module and its aggregator import therefore
-remain available.
+| Retained coordinate declaration | Projection-based implementation |
+|---|---|
+| `MPSTensor.upperSum` | Definition `fun i ↦ Matrix.fromBlocks (A11 i) (A12 i) 0 (A22 i)` |
+| `MPSTensor.diagSum` | Definition `fun i ↦ Matrix.fromBlocks (A11 i) 0 0 (A22 i)` |
+| `MPSTensor.upperFin` | `upperSum` reindexed along `finSumFinEquiv` |
+| `MPSTensor.diagFin` | The same reindexing of `diagSum`; the bridge proves it is `Kraus.diagPart upperFin coordProj` |
+| `MPSTensor.trace_fromBlocks_upper` | `Matrix.trace_eq_trace_diag_of_proj` plus the two block-compression identities |
+| `MPSTensor.evalWord_upperSum_is_fromBlocks` | `Kraus.lowerZero_evalWord` and `Kraus.evalWord_diagPart_eq`, transported through `finSumFinEquiv` |
+| `MPSTensor.evalWord_diagSum_is_fromBlocks` | The two diagonal inclusion intertwiners, via `Kraus.evalWord_intertwine` |
+| `MPSTensor.trace_evalWord_upperSum_eq_trace_evalWord_diagSum` | `Kraus.trace_evalWord_diagPart_eq` plus the `diagPart_upperFin` and trace-reindex bridges |
+| `MPSTensor.mpv_upperFin_eq_mpv_diagFin` | Pointwise specialization of `MPSTensor.sameMPV_diagPart_of_lowerZero` through `diagPart_upperFin` |
+| `MPSTensor.sameMPV_upperFin_diagFin` | Direct specialization of `MPSTensor.sameMPV_diagPart_of_lowerZero` through `diagPart_upperFin` |
+
+Thus no independent word induction remains in the coordinate module, and the
+coordinate names are compatibility wrappers around the projection argument.
+They remain available; deletion and deprecation are outside #7135.
 
 ## Retired: `TNLean/Wielandt/RankOne/MatrixFittingRange.lean`
 


### PR DESCRIPTION
## Summary

- construct the `finSumFinEquiv` first-summand orthogonal projection and the block/reindex bridge identities for the retained coordinate API
- preserve all ten public block-coordinate declarations and their statements while deriving their results from the coordinate-free projection API
- replace the independent `evalWord` inductions with `lowerZero_evalWord`, `evalWord_diagPart_eq`, `trace_evalWord_diagPart_eq`, `sameMPV_diagPart_of_lowerZero`, and diagonal inclusion intertwiners
- update the issue #6861 deletion audit with the exact ten-declaration replacement relation and current module paths

The explicit inclusion intertwiners are retained only to recover the two exposed diagonal word blocks exactly; the projection API by itself identifies their combined diagonal compression. Deletion and deprecation remain out of scope.

Closes #7135.

## Verification

- `lake env lean TNLean/MPS/Core/ProjectionTriangularTrace.lean`
- `lake env lean TNLean/MPS/Core/BlockTriangularTrace.lean`
- `lake build TNLean.MPS.Core.BlockTriangularTrace`
- `lake build TNLean.MPS.Core`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py`
- `python3 scripts/check_numbered_lean_files.py --base-ref origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- confirmed all ten public signatures are unchanged from `origin/main`
- confirmed no independent `induction` or forbidden proof-integrity token remains in the changed Lean file
- `git diff --check`
