### PR TITLE
docs(paper-gaps): repair Lean declaration citations

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -35,6 +35,7 @@ on:
       - 'scripts/fetch_tenkz.py'
       - 'scripts/tenkz_paths.py'
       - 'blueprint/src/**'
+      - 'docs/paper-gaps/**'
       # Trees the paper-gap reference check scans (texra-blueprint
       # paper-gaps check); without these the check never runs
       # on merge pushes that only touch a scanned file.
@@ -45,6 +46,8 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/test_blueprint_lean_sync.py'
+      - 'scripts/paper_gap_leanid_sync.py'
+      - 'scripts/test_paper_gap_leanid_sync.py'
       - 'scripts/badge_utils.py'
       - 'scripts/write_badges.py'
       - 'scripts/generate_badges.py'
@@ -104,6 +107,8 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/test_blueprint_lean_sync.py'
+      - 'scripts/paper_gap_leanid_sync.py'
+      - 'scripts/test_paper_gap_leanid_sync.py'
       - 'scripts/badge_utils.py'
       - 'scripts/write_badges.py'
       - 'scripts/generate_badges.py'
@@ -216,6 +221,8 @@ jobs:
               - 'blueprint/comments/**'
               - 'docs/**/*.md'
               - 'texra-blueprint.toml'
+              - 'scripts/paper_gap_leanid_sync.py'
+              - 'scripts/test_paper_gap_leanid_sync.py'
             workflow:
               - '.github/workflows/**'
               - '.github/dependabot.yml'
@@ -229,6 +236,7 @@ jobs:
         github.event_name != 'pull_request' ||
         needs.changes.outputs.lean == 'true' ||
         needs.changes.outputs.blueprint == 'true' ||
+        needs.changes.outputs.paper_gaps == 'true' ||
         needs.changes.outputs.workflow == 'true'
       )
     runs-on: ubuntu-latest
@@ -324,6 +332,13 @@ jobs:
       - name: Check Blueprint Lean declarations
         timeout-minutes: 10
         run: lake exe checkdecls blueprint/lean_decls
+
+      - name: Generate paper-gap Lean declaration list
+        run: python3 scripts/paper_gap_leanid_sync.py --root . --output "$RUNNER_TEMP/paper_gap_leanid_decls"
+
+      - name: Check paper-gap Lean declarations
+        timeout-minutes: 10
+        run: lake exe checkdecls "$RUNNER_TEMP/paper_gap_leanid_decls"
 
       # A cancelled or failed build can leave partially written `.olean` files.
       # Restore only caches saved after the complete build and style checks pass.
@@ -627,6 +642,9 @@ jobs:
 
       - name: Test Blueprint declaration scanner
         run: python3 scripts/test_blueprint_lean_sync.py
+
+      - name: Test paper-gap Lean declaration scanner
+        run: PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py
 
       - name: Test badge color thresholds
         run: python3 scripts/test_badge_colors.py

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -95,16 +95,16 @@ suffix gives Eq.~\ref{eq:cpgsv17_bicf_block_separation_word_tuple_span}.
 
 These criteria yield the older per-copy trace-separation conclusion in the
 formal development.\footnote{The criteria are
-    \leanid{WordTupleSpanTop}, \leanid{wordEntryFamily}, and
-    \leanid{PropBlockInjective}. The trace-separation assumption is
-    \leanid{HorizontalCFData.biCF}. The constructors from these hypotheses to
-    \leanid{HorizontalCFData} structures are in the modules under
+    \leanid{MPSTensor.WordTupleSpanTop}, \leanid{MPSTensor.wordEntryFamily}, and
+    \leanid{MPSTensor.PropBlockInjective}. The trace-separation assumption is
+    \leanid{MPOTensor.HorizontalCFData.biCF}. The constructors from these hypotheses to
+    \leanid{MPOTensor.HorizontalCFData} structures are in the modules under
     \path{TNLean/MPS/MPDO/BiCFDerivation/}. Relevant implications include
-    \leanid{hasBiCF_of_wordTupleSpanTop},
-    \leanid{hasBiCF_of_wordEntryFamily_linearIndependent},
-    \leanid{hasBiCF_of_propBlockInjective}, and corresponding
-    \leanid{HorizontalCFData} constructors such as
-    \leanid{horizontalCFData_of_propBlockInjective}. The blueprint records
+    \leanid{MPSTensor.hasBiCF_of_wordTupleSpanTop},
+    \leanid{MPSTensor.hasBiCF_of_wordEntryFamily_linearIndependent},
+    \leanid{MPSTensor.hasBiCF_of_propBlockInjective}, and corresponding
+    \leanid{MPOTensor.HorizontalCFData} constructors such as
+    \leanid{MPOTensor.horizontalCFData_of_propBlockInjective}. The blueprint records
     these restricted criteria in its finite-witness remark.}
 They remain valid restricted results. The sharp proposition is now proved
 separately for a representative-indexed BNT sector decomposition, which groups
@@ -137,7 +137,7 @@ counterexample is recorded.
 \section{Consequence for Lemma L}
 
 The same independence restricts the older theorem
-\leanid{blockwise_insert_eq_of_mpv_agree}, which assumes \leanid{biCF} for the
+\leanid{MPOTensor.blockwise_insert_eq_of_mpv_agree}, which assumes \leanid{MPOTensor.HorizontalCFData.biCF} for the
 full family of flattened copies. Lemma~L in Appendix~C.3 of the source instead
 decomposes the canonical-form tensor as
 \begin{align}
@@ -360,7 +360,7 @@ representatives. The representative-grouped Lemma~L gives equality of the
 opposite-corner insertions on every minimal representative. Linearity extends
 this equality to the full weighted direct sum, and gauge conjugation transports
 it to the original matrix product operator tensor. The older per-copy
-\leanid{HorizontalCFData} theorems remain available only as explicitly
+\leanid{MPOTensor.HorizontalCFData} theorems remain available only as explicitly
 restricted auxiliary statements.
 
 \section{The Appendix C.2 sector entropy argument}
@@ -377,7 +377,7 @@ that the one-letter tuples of the minimal normal representatives span
 The inverse tensor used immediately afterward, and hence the one-site
 projections in the proof of Proposition~4.13, depend on this hypothesis
 \cite{Cirac2016MPDO_arXiv}. The formal assumption
-\leanid{WordTupleSpanTop S.basis 1} is therefore the direct algebraic form of
+\leanid{MPSTensor.WordTupleSpanTop S.basis 1} is therefore the direct algebraic form of
 the source's block-injective canonical-form hypothesis.
 
 Starting instead from an unblocked canonical form and removing the one-letter

--- a/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
@@ -52,7 +52,7 @@ sector-coordinate theorem proves the fixed-point identities for
     \label{eq:cpgsv17_mpdo_blocked_rfp_physical_transport_sector_block}
 \end{align}
 \footnote{Formal declaration:
-\leanid{NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS}.}
+\leanid{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS}.}
 Its conclusion is exact in the selected sector coordinates, but it does not
 transport the two channels back to
 $\operatorname{blockTwo}(\mathcal K)$. It is therefore a scope-restricted
@@ -105,7 +105,7 @@ and proves
     \label{eq:cpgsv17_mpdo_blocked_rfp_physical_transport_original_block_rfp}
 \end{align}
 \footnote{Formal declaration:
-\leanid{NeighboringTraceFactorization.blockTwo_isRFPViaTS}.}
+\leanid{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}.}
 This theorem discharges the physical-coordinate transport gap for one supplied
 factorization of the entire tensor. It does not prove the raw implication
 (iv)$\Rightarrow$(v) in Theorem~4.9 of

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -351,7 +351,7 @@ The four-site specialization used by the later argument takes $L=1$. SAL makes
 the normalization scalar nonzero, so every $\widehat R_j$ is nonzero.
 \footnote{The relevant declarations are
 \leanid{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix},
-\leanid{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV}\textsubscript{2},
+\leanid{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂Pos},
 and
 \leanid{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
 
@@ -363,7 +363,7 @@ the four-site Hayashi decomposition. Every active Markov sector then has a
 unique BNT label, and the BNT-labelled sums of Hayashi projections are
 orthogonal, mutually disjoint, and resolve the active Markov support.
 \footnote{The relevant declaration is
-\leanid{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL}.}
+\leanid{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL}.}
 This specialization needs no further closing-matrix hypothesis.
 
 For every physical slice of the $i$-th normal representative,
@@ -396,7 +396,7 @@ relevant declarations are
 \leanid{MPOTensor.sum_bntSectorProjection_mul_physicalSlice_mul_self},
 \leanid{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
 \leanid{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
-\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL}.}
+\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
 
 The literal identity resolution in Equation \emph{Pis} of
 Ref.~\cite{Cirac2016MPDO_arXiv} is recovered in the ambient physical space.
@@ -433,7 +433,7 @@ the active-support resolution and Equation \emph{Pis} of
 Ref.~\cite{Cirac2016MPDO_arXiv}. The construction and its SAL specialization
 are
 \leanid{MPOTensor.completedBntSectorProjection} and
-\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL_of_weight_copy_independent}.
+\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent}.
 
 The source's standing assumptions are recovered by
 \leanid{MPOTensor.exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL}.
@@ -452,7 +452,7 @@ integer $n_s$. ZCL follows by restricting the full transfer equation to the
 $s$-th canonical block and using nonnilpotence to exclude the zero transfer.
 \footnote{The relevant declarations are
 \leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection},
-\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV}\textsubscript{2}\leanid{Pos_isSAL},
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
 and
 \leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
 
@@ -482,7 +482,7 @@ under the biCF hypothesis imposed at the beginning of Case II in the source.
 \footnote{The principal declarations are
 \leanid{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
 \leanid{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
-\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV}\textsubscript{2}\leanid{Pos}.}
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
 This completes the entropy argument at lines 1748--1781 of Appendix C.2 of
 Ref.~\cite{Cirac2016MPDO_arXiv} under its stated biCF hypothesis.
 
@@ -1125,7 +1125,7 @@ row and zero column and cannot be primitive. The primitive matrix in Lemma
 \end{align}
 This is the customary convention when zero-probability terms are omitted from
 a direct-sum state decomposition. The Lean definition
-\leanid{PhysicalSectorFactorization.activeSectorTraceMatrix} restricts the
+\leanid{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix} restricts the
 trace matrix to this subtype while preserving the full physical sector
 equivalence and hence the complete Hilbert space.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -174,12 +174,12 @@ reduction.
 
 The open-chain geometry is independent of the later cyclic specialization.
 Inside the Hilbert space on $\Lambda_{n+1}$, the formal subspaces
-\leanid{openChainLeftGroundSpaceES} and
-\leanid{openChainTailGroundSpaceES} are the ranges of $G_{\Lambda_n}$ and
+\leanid{MPSTensor.openChainLeftGroundSpaceES} and
+\leanid{MPSTensor.openChainTailGroundSpaceES} are the ranges of $G_{\Lambda_n}$ and
 $G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}$. They use the existing last-site
 and fixed-prefix restriction maps. Under $L_0$-block injectivity, with
 $n=K+L_0$ and $l=L_0$, the theorem
-\leanid{openChainLeft_inf_tailGroundSpaceES} proves
+\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES} proves
 \begin{align}
     U\cap V
     &=\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A).
@@ -187,7 +187,7 @@ $n=K+L_0$ and $l=L_0$, the theorem
 \end{align}
 
 The theorem
-\leanid{isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le}
+\leanid{Submodule.isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le}
 turns
 \begin{align}
     \lVert P_UP_V-P_{U\cap V}\rVert
@@ -196,7 +196,7 @@ turns
 \end{align}
 into a Friedrichs bound. Combined with the complementary-projection theorem,
 it gives
-\leanid{re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}.
+\leanid{MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}.
 Its hypothesis is the C3 defect
 \begin{align}
     \lVert
@@ -345,27 +345,27 @@ Thus
 (\ref{eq:cpgsv21_martingale_overlap_ordered_cross_term}). The formal
 development also contains the source anticommutator row-sum argument directly,
 without this stronger one-sided estimate.\footnote{The formal anchors are
-    \leanid{crossTerm_sum_bound_of_anticommutator_rowCol},
-    \leanid{quadraticForm_sum_projections_of_anticommutator_rowCol}, and
-    \leanid{parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds}.
+    \leanid{ProjectionGeometry.crossTerm_sum_bound_of_anticommutator_rowCol},
+    \leanid{ProjectionGeometry.quadraticForm_sum_projections_of_anticommutator_rowCol}, and
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds}.
     The finite-overlap reductions are
-    \leanid{quadraticForm_sum_projections_of_finite_overlap_anticommutator},
-    \leanid{parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator},
+    \leanid{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_anticommutator},
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator},
     and
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}.
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}.
     The final gap statement is
-    \leanid{parentHamiltonian_gapped_of_anticommutator} in
+    \leanid{MPSTensor.parentHamiltonian_gapped_of_anticommutator} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}.
     The cyclic-window compression reductions are
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_ordered_cross_term},
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_ordered_cross_term},
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},
     and
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
     in \path{TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean}.
     The constant-$\eta$ reduction is
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt}
+    \leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt}
     in the same file; the public spectral-gap statement is
-    \leanid{parentHamiltonian_gapped_of_overlap_norm_constant} in
+    \leanid{MPSTensor.parentHamiltonian_gapped_of_overlap_norm_constant} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}.
     The projection-geometry results are in
     \path{TNLean/Analysis/ProjectionGeometry.lean}. The declaration names
@@ -431,7 +431,7 @@ The optimized FNW coefficient and its source constants remain unmatched. This
 comparison is unnecessary for the proved range-two blocked theorem: the exact
 three-site identification gives $7/16$, and cyclic transport covers every
 overlap. The theorem
-\leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
+\leanid{Submodule.re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
 shows that a Friedrichs bound $\eta$ for the two ground-space ranges, after
 removing their common intersection, gives
 \begin{align}
@@ -502,19 +502,19 @@ argument. Both norm conditions are conditional formal reductions, not
 achievable source-faithful estimates in the generic overlapping case.
 
 The abstract conversion is
-\leanid{re_inner_anticommutator_ge_neg_of_norm_apply_le}. The cyclic-window
+\leanid{LinearMap.IsSymmetricProjection.re_inner_anticommutator_ge_neg_of_norm_apply_le}. The cyclic-window
 entry points are
-\leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le}
+\leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le}
 and
-\leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt};
+\leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt};
 the public reformulation is
-\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. For the
+\leanid{MPSTensor.parentHamiltonian_gapped_of_overlap_operator_norm_constant}. For the
 blocked range-two theorem, the exact three-site identity and the forward and
 backward transport results replace this conditional route. The theorem
-\leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
+\leanid{Submodule.re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
 uses the intersection identity
 (\ref{eq:cpgsv21_martingale_overlap_common_ground_space}), equivalently
-\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; it does not
+\leanid{MPSTensor.adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; it does not
 require a small bound on $\lVert p_ip_j\rVert$.
 
 \section{Relation to the blueprint}
@@ -536,7 +536,7 @@ and the transport of the $7/16$ adjacent anticommutator estimate to every
 cyclic overlap.
 
 The source-matching entry \path{thm:anticommutator_gap_bound} points to
-\leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}
+\leanid{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}
 in \path{TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean}; its hypothesis
 is (\ref{eq:cpgsv21_martingale_overlap_cyclic_anticommutator_target}). The
 entries \path{thm:overlap_norm_gap_bound} and

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -97,8 +97,8 @@ for $N=L_0+1$.\footnote{Formal locations:
 and
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:923 for
 \leanid{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal
-hypotheses are named \leanid{IsNormal A} and
-\leanid{IsNBlkInjective A L0}, together with
+hypotheses are named \leanid{Kraus.IsNormal A} and
+\leanid{Kraus.IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, \path{L0 + 1 <= N}, and
 \path{L0 < L <= N}.}
 
@@ -116,7 +116,7 @@ property through contiguous windows.\footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:281--284 for
 \leanid{MPSTensor.groundSpace_intersection},
 \path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:341--364 for
-\leanid{decompositionMap hA 1}, and
+\leanid{Kraus.decompositionMap hA 1}, and
 \path{TNLean/MPS/ParentHamiltonian/CyclicWindow.lean}:153--163 for the
 contiguous iteration.}
 For a normal tensor with injectivity length $L_0$, the available inverse acts

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -47,7 +47,7 @@ cross-overlap between basis blocks $j$ and $k$ by
             \overline{\mathtt{mpv}(P.\mathtt{basis}\,k)(\sigma)}.
     \label{eq:bnt-rate_cross_overlap_expansion}
 \end{align}
-This overlap is written \leanid{mpvOverlap} in the
+This overlap is written \leanid{MPSTensor.mpvOverlap} in the
 formalization.\footnote{Declaration \leanid{MPSTensor.mpvOverlap} in
     \doclink{TNLean/MPS/Overlap/Basic}.}
 
@@ -112,11 +112,11 @@ such that, for every $j\ne k$,
 together with the geometric bound
 (\ref{eq:bnt-rate_geometric_cross_overlap_bound}) for every $N$.
 
-The surviving \leanid{SectorBNT} surface does not package such constants. It
-keeps the raw BNT weights in \leanid{SectorDecomposition} and records
+The surviving \path{TNLean/MPS/FundamentalTheorem/SectorBNT} surface does not package such constants. It
+keeps the raw BNT weights in \leanid{MPSTensor.SectorDecomposition} and records
 qualitative consequences in
 \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Api}: the raw power-sum
-coefficient identity \leanid{SectorDecomposition.coeff_eq_sum_weight_pow},
+coefficient identity \leanid{MPSTensor.SectorDecomposition.coeff_eq_sum_weight_pow},
 within-family cross-decay
 \leanid{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}, the
 combined-family linear-independence criterion
@@ -170,7 +170,7 @@ what Ref.~\cite[\S II]{Cirac2016MPDO_arXiv} and
 Definition~4.2 of Ref.~\cite{Cirac2021Matrix} make explicit. Obtaining a
 geometric rate requires a separate finite-dimensional spectral-radius input
 for the mixed transfer operator underlying
-\leanid{mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP}.
+\leanid{MPSTensor.mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP}.
 Moreover, the compatibility inequality
 $\eta_{j,k}|\lambda_j/\lambda_k|<1$ is not implied by the BNT structure. The
 retired projection argument would therefore have needed this condition as an
@@ -178,7 +178,7 @@ additional hypothesis or a separate analytic theorem.
 
 The design memo
 \path{docs/audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} records the
-abandoned spectral-gap proposal. The corrected \leanid{SectorBNT} theorem uses
+abandoned spectral-gap proposal. The corrected \path{TNLean/MPS/FundamentalTheorem/SectorBNT} theorem uses
 coefficient comparison and combined-family linear independence instead. This
 note documents why the rate-quantified projection route must not be revived as
 a purported obligation of the proportional fundamental theorem.

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -261,7 +261,7 @@ but it does not explain why the implementation diverged from the
 memo.\footnote{%
     The introducing commit is \texttt{dd54b79e}, ``Add ScalarPowerSumIdentity,
     BNTConstruction, BNTPermutationThm44.'' Despite the name, the
-    \leanid{ScalarPowerSumIdentity} module added by that commit does not
+    \path{QICLean/Algebra/ScalarPowerSumIdentity.lean} module added by that commit does not
     implement the fixed-length scalar identity planned from the elementary
     power-sum lemma in Ref.~\cite{Cirac2016MPDO_arXiv}. The structure refactor
     that bundled the limit fields is \texttt{9e096a14} (2026-03-22), and the

--- a/docs/paper-gaps/cpsv16_figure11_per_pair_support.tex
+++ b/docs/paper-gaps/cpsv16_figure11_per_pair_support.tex
@@ -162,8 +162,7 @@ principal declarations are
 \leanid{MPOTensor.retainedVerticalProductTensor_eq_sum_pairBlocks},
 \leanid{MPOTensor.RetainedProductSpectralFamily.retained_reconstruction_active},
 and
-\leanid{MPOTensor.RetainedProductSpectralFamily.flat_sameMPV}%
-\textsubscript{2}\leanid{Pos}.}
+\leanid{MPOTensor.RetainedProductSpectralFamily.flat_sameMPV₂Pos}.}
 
 \section{Zero copy pairs}
 

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -103,7 +103,7 @@ Ref.~\cite{Cirac2016MPDO_arXiv} is narrower:
         &= r_A+1.
     \label{eq:cpsv16_fixed_block_cancellation_formal_fixed_block_boundary}
 \end{align}
-The surviving \leanid{SectorBNT} API does not formalize the source sentence as
+The surviving \path{TNLean/MPS/FundamentalTheorem/SectorBNT} API does not formalize the source sentence as
 a standalone fixed-block contradiction. The corrected theorem instead uses a
 restricted coefficient-comparison argument. It separates the $P$-blocks whose
 overlaps with every $Q$-block decay, represents the remaining $P$-blocks by

--- a/docs/paper-gaps/cpsv16_ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/cpsv16_ft_one_copy_scope_restriction.tex
@@ -106,7 +106,7 @@ from finitely many polynomial identities. It does not use a limiting argument.
 \section{The basis-of-representatives restriction}
 
 The surviving formal normal-CF-BNT structure is
-\leanid{IsNormalCanonicalFormBNT}.\footnote{Defined in
+\leanid{MPSTensor.IsNormalCanonicalFormBNT}.\footnote{Defined in
 \path{TNLean/MPS/BNT/Construction.lean}. The earlier non-normal wrapper was
 retired after its downstream consumers were replaced by explicit
 separated-block hypotheses.} This structure no longer requires strict
@@ -116,7 +116,7 @@ Instead of strict modulus separation, its BNT separation field requires
 distinct blocks not to be gauge-phase equivalent.
 
 The remaining restriction is therefore not strict modulus ordering.
-The structure \leanid{IsNormalCanonicalFormBNT} is a
+The structure \leanid{MPSTensor.IsNormalCanonicalFormBNT} is a
 basis-of-representatives surface: its block family already contains one
 selected representative for each gauge-phase class. It does not retain
 multiple copies of one source BNT tensor as separate summands together with
@@ -127,8 +127,8 @@ their individual weights $\mu_{j,q}$, copy gauges, and coefficient
     \label{eq:cpsv16_ft_one_copy_scope_restriction_sector_copy_coefficient}
 \end{align}
 The formalization carries this raw multiplicity data in
-\leanid{SectorDecomposition} and in the SectorBNT comparison theorems, not in
-\leanid{IsNormalCanonicalFormBNT}.
+\leanid{MPSTensor.SectorDecomposition} and in the SectorBNT comparison theorems, not in
+\leanid{MPSTensor.IsNormalCanonicalFormBNT}.
 
 In the one-copy special case, the source decomposition becomes
 \begin{align}
@@ -166,7 +166,7 @@ $N=1,\ldots,\max(x_a,x_b)$ are equal as multisets. This finite algebraic fact
 follows from the Newton--Girard identities: the power sums determine the
 elementary symmetric polynomials, which determine the multiset of roots.
 
-A module named \leanid{ScalarPowerSumIdentity}\footnote{Introduced in commit
+A module named \path{QICLean/Algebra/ScalarPowerSumIdentity.lean}\footnote{Introduced in commit
 \texttt{dd54b79e}.} was added early in the project, but it does not specialize
 to the fixed-length statement in the form required by Step~4 of the source
 proof. The result must therefore be available as a standalone theorem,
@@ -190,10 +190,10 @@ Ref.~\cite{Cirac2016MPDO_arXiv}.
 
 \subsection{Multi-copy sector structure}
 
-The structure \leanid{IsNormalCanonicalFormBNT} permits equal moduli but does
+The structure \leanid{MPSTensor.IsNormalCanonicalFormBNT} permits equal moduli but does
 not store repeated gauge-phase-equivalent copies with their individual
 weights. The general theorem therefore requires the
-\leanid{SectorDecomposition}/SectorBNT multiplicity structure, in which every
+\leanid{MPSTensor.SectorDecomposition}/SectorBNT multiplicity structure, in which every
 sector has an arbitrary finite list of copy weights and gauges. Without this
 data, the general-multiplicity form of Corollary~\texttt{II\_cor2} of
 Ref.~\cite{Cirac2016MPDO_arXiv} and its gauge-assembly step cannot be stated on
@@ -219,28 +219,28 @@ matches the per-block gauges.
 
 The former strict-modulus proportional branch has been deleted. The surviving
 block-matching boundary uses the explicit conclusion
-\leanid{BlockPermutationGaugePhaseConclusion} only when the BNT comparison has
+\leanid{MPSTensor.BlockPermutationGaugePhaseConclusion} only when the BNT comparison has
 already been supplied. Thus no current theorem is presented as deriving the
 source proportional comparison from the discarded coefficient hypotheses.
 
 Neither the old dominant-normalization field nor the old strict-ordering field
-remains in \leanid{IsNormalCanonicalFormBNT}. When a CPSV argument needs a
+remains in \leanid{MPSTensor.IsNormalCanonicalFormBNT}. When a CPSV argument needs a
 unit-modulus witness for a sector, it carries that datum as an explicit
 SectorBNT hypothesis, for example through the corresponding field of
-\leanid{SectorDecomposition}.
+\leanid{MPSTensor.SectorDecomposition}.
 
 \section{Downstream audit status}
 
 The downstream CPSV16 surfaces that consume the restricted normal-CF-BNT
 predicate have been audited against the basis-of-representatives
 boundary.\footnote{The relevant \Lean{} surfaces are
-\leanid{IsNormalCanonicalFormBNT},
-\leanid{IsNormalCanonicalFormBNT.ofSeparatedData},
-\leanid{IsNormalCanonicalFormBNT.cross_overlap_tendsto_zero},
-\leanid{IsNormalCanonicalFormBNT.isBNT},
-\leanid{IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective},
+\leanid{MPSTensor.IsNormalCanonicalFormBNT},
+\leanid{MPSTensor.IsNormalCanonicalFormBNT.ofSeparatedData},
+\leanid{MPSTensor.cross_overlap_tendsto_zero_of_separated_normal_bnt_data},
+\leanid{MPSTensor.IsNormalCanonicalFormBNT.isBNT},
+\leanid{MPSTensor.IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective},
 and
-\leanid{exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT}.}
+\leanid{MPSTensor.exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT}.}
 
 Each public surface assumes or constructs an already selected representative
 family whose weights are ordered non-increasingly by modulus. Equal moduli are
@@ -253,7 +253,7 @@ Wielandt blueprint corollary therefore carry the same
 basis-of-representatives marker.
 
 This marker does not apply to the sector-BNT development based on
-\leanid{IsBNTCanonicalForm}. That predicate is the paper-faithful sector
+\leanid{MPSTensor.IsBNTCanonicalForm}. That predicate is the paper-faithful sector
 surface used for the CPSV16 coefficient and weight-multiplicity arguments,
 where repeated copies inside one sector remain explicit.
 

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -58,7 +58,7 @@ a scalar sequence $c_N$, nonzero cofinally, such that
     \label{eq:nondominant_eventual_proportionality}
 \end{align}
 This condition is formalized as
-\leanid{EventuallyNonzeroProportionalMPV}\textsubscript{2}.
+\leanid{MPSTensor.EventuallyNonzeroProportionalMPV₂}.
 
 The retired one-copy normal-canonical BNT route carried a single weight
 $\mu_k$ per sector with the strict ordering
@@ -69,12 +69,12 @@ $\mu_k$ per sector with the strict ordering
 \end{align}
 Together with the dominant normalization $|\mu_1|=1$, this ordering made every
 sub-dominant block have modulus strictly less than $1$. These fields are not
-part of the current \leanid{IsNormalCanonicalFormBNT} predicate, which allows
+part of the current \leanid{MPSTensor.IsNormalCanonicalFormBNT} predicate, which allows
 equal-modulus blocks. The discussion below concerns the deleted strict-modulus
 variant. Definition~4.2 and lines~1864--1884 of
 Ref.~\cite{Cirac2021Matrix} state the source structure using repeated copies
 and raw weights $\mu_{j,q}$ with sector multiplicities $r_j\geq 1$. The current
-\leanid{SectorDecomposition} surface retains those power-sum coefficients; see
+\leanid{MPSTensor.SectorDecomposition} surface retains those power-sum coefficients; see
 \path{docs/paper-gaps/cpsv16_ft_one_copy_scope_restriction.tex}.
 
 \section{Cited assertion}
@@ -103,7 +103,7 @@ not establish linear independence of the full combined family.
 The historical target was the following statement for arbitrary
 $k_0:\mathrm{Fin}\,r_B$: given the one-copy normal-canonical BNT hypotheses on
 both $\mu^A,A$ and $\mu^B,B$,
-\leanid{EventuallyNonzeroProportionalMPV}\textsubscript{2} between the
+\leanid{MPSTensor.EventuallyNonzeroProportionalMPV₂} between the
 assembled tensors, and the hypothesis
 \begin{align}
     \braket{V^{(N)}(A_j)}{V^{(N)}(B_{k_0})}
@@ -112,8 +112,8 @@ assembled tensors, and the hypothesis
     \label{eq:nondominant_retired_target_decay}
 \end{align}
 derive a contradiction. The old one-copy fixed-block declarations for this
-target have been retired. The corrected \leanid{SectorBNT} proportional
-matching theorem keeps the raw coefficients of \leanid{SectorDecomposition}
+target have been retired. The corrected \path{TNLean/MPS/FundamentalTheorem/SectorBNT} proportional
+matching theorem keeps the raw coefficients of \leanid{MPSTensor.SectorDecomposition}
 visible and uses the API lemmas in
 \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Api}. It does not require a
 separate universally quantified fixed-block projection theorem.
@@ -207,7 +207,7 @@ fails at $r_A=r_B=2$ with distinct sub-dominant moduli. Path~$\beta$ scope
 adjustment
 (\path{docs/audits/2026-05-13_cpsv16_ft_path_beta_scout.md},
 \ghpr{1664}) shows that the lifted per-block projection on the
-\leanid{SectorDecomposition} surface inherits the same decay mismatch.
+\leanid{MPSTensor.SectorDecomposition} surface inherits the same decay mismatch.
 
 \section{The fixed-block source claim and the formal repair}
 
@@ -256,7 +256,7 @@ unproved theorem required by the current development.
 The source line~1182 fixed-block claim and the current formal repair must be
 kept distinct. The repair uses restricted combined-family linear independence,
 scalar relations for the complementary blocks, and the raw power sums
-$\sum_q\mu_{j,q}^N$ carried by \leanid{SectorDecomposition}. Together with
+$\sum_q\mu_{j,q}^N$ carried by \leanid{MPSTensor.SectorDecomposition}. Together with
 \leanid{MPSTensor.SectorDecomposition.coeff_not_eventually_zero}, this gives
 the active-sector coefficient comparison proved in the current theorem.
 Collapsing a sector to one strictly ordered weight destroys precisely the

--- a/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
+++ b/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
@@ -46,7 +46,7 @@ define equality of projective points.
 \section{Formal reading}
 
 The formal predicate
-\leanid{NonzeroProportionalMPV}\textsubscript{2} requires that, for every
+\leanid{MPSTensor.NonzeroProportionalMPV₂} requires that, for every
 positive length $N\geq 1$, there be a scalar $c_N\neq 0$ such that
 \begin{align}
     V^{(N)}(A)
@@ -106,9 +106,8 @@ projective statement.
 
 One eventual-proportionality hypothesis remains outside the named predicate.
 The overlap-convergence theorem
-\leanid{mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV}%
-\textsubscript{2} in
-\leanid{TNLean/MPS/FundamentalTheorem/Proportional.lean} assumes only that,
+\leanid{MPSTensor.mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂} in
+\path{TNLean/MPS/FundamentalTheorem/Proportional.lean} assumes only that,
 eventually in $N$, some scalar $c_N$ satisfies
 (\ref{eq:cpsv16_nonzero_proportionality_reading_formal_relation}); it does not
 assume $c_N\neq 0$. Its self-overlap convergence hypotheses imply the eventual

--- a/docs/paper-gaps/cpsv16_power_sum_alternative_route.tex
+++ b/docs/paper-gaps/cpsv16_power_sum_alternative_route.tex
@@ -146,7 +146,7 @@ For the two sector-weight families, apply this lemma to
     \label{eq:cpsv16_power_sum_alternative_route_signed_weight_sum}
 \end{align}
 The nonzero-weight hypothesis permits the use of $w_1^M\neq 0$. Every weight
-in \leanid{SectorWeightData} is nonzero, so the exponent-zero power sum counts
+in \leanid{MPSTensor.SectorWeightData} is nonzero, so the exponent-zero power sum counts
 the entries:
 \begin{align}
     \sum_{q=1}^{r_j}\mu_{j,q}^{0}
@@ -168,10 +168,10 @@ The same-cardinality Newton--Girard theorem then recovers the weight multiset.
 This route previously existed as checked \Lean{} code through declarations for
 the copy count, transported positive power sums, and weight-multiset
 equality.\footnote{Formal declarations:
-\leanid{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq};
-\leanid{MPSTensor.SectorWeightData.eventually_coeff_eq_implies_all_pos_eq_after_copies};
+\path{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq};
+\path{MPSTensor.SectorWeightData.eventually_coeff_eq_implies_all_pos_eq_after_copies};
 and
-\leanid{MPSTensor.SectorWeightData.weight_multiset_eq_of_copies_eq_of_coeff_eq}.}
+\path{MPSTensor.SectorWeightData.weight_multiset_eq_of_copies_eq_of_coeff_eq}.}
 Those declarations have been removed because the proportional Fundamental
 Theorem no longer uses this same-cardinality detour. The calculation records
 the removed route for comparison with Ref.~\cite{Cirac2016MPDO_arXiv}; it is

--- a/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
+++ b/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
@@ -123,8 +123,7 @@ $A$ to a minimal invariant subspace forces
 Each rescaled corner is therefore normal. Both steps are formalized without a
 normalization hypothesis.\footnote{Formal declarations:
 \leanid{MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral} and
-\leanid{MPSTensor.exists_normalTensor_blockDecomp_sameMPV}%
-\textsubscript{2}\leanid{Pos_of_hasInvariantProjectorClosure}
+\leanid{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure}
 in \doclink{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral}.}
 
 The cited proposition does not assume a left-canonical identity such as

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -252,7 +252,7 @@ pairs.\footnote{Formal theorem:
 \leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}.}
 Because this theorem operates on the unweighted basis direct sum rather than
 the raw weighted repeated-copy tensor,\footnote{Formal declarations:
-\leanid{directSumTensor P.basis} and \leanid{P.toTensor}.} and because the
+\leanid{MPSTensor.directSumTensor P.basis} and \path{P.toTensor}.} and because the
 source equations involve all copy pairs with their respective weight powers,
 unrestricted observable realization for the raw tensor remains separate.
 

--- a/docs/paper-gaps/cpsv16_sector_relabeling_hypothesis.tex
+++ b/docs/paper-gaps/cpsv16_sector_relabeling_hypothesis.tex
@@ -63,7 +63,7 @@ family. The scalar weights and block-diagonal assembly are unchanged.
 The formalization uses the unconditional identity for the nonzero part of a
 common cyclic-sector family. It does not introduce a relabeling
 hypothesis.\footnote{The family-level declaration is
-\leanid{CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}; the common
+\leanid{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}; the common
 primitive-block theorem applies it directly on both sides. The declarations
 are in
 \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean}

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -38,7 +38,7 @@ Lieb and Ruskai proved this inequality in finite dimensions
 
 The formal development previously asserted
 Eq.~\ref{eq:cpsv16_ssa_from_lieb_route_strong_subadditivity} as the standalone
-axiom \leanid{strong_subadditivity}. It now derives the result as
+axiom \path{strong_subadditivity}. It now derives the result as
 \leanid{strong_subadditivity_general} in
 \doclink{TNLean/Channel/Schwarz/StrongSubadditivityPosDef}. The former axiom has
 been removed from \doclink{TNLean/Entropy/SSAEqualityCharacterization}, and its
@@ -118,7 +118,7 @@ and records its formal implementation.
     logarithm limits on the positive eigenvalues. The condition
     $\ker\sigma\subseteq\ker\rho$ eliminates the diagonal weights associated
     with zero eigenvalues. The formal limit is
-    \leanid{tendsto_re_trace_mul_log_perturb}. This proof uses neither Lieb
+    \leanid{TNLean.Klein.tendsto_re_trace_mul_log_perturb}. This proof uses neither Lieb
     concavity nor operator Jensen.
 
     The full-rank equality case is
@@ -161,18 +161,18 @@ and records its formal implementation.
     Their pointwise limit is therefore convex.
 
     The positive-definite result is
-    \leanid{convexOn_quantumRelativeEntropy} in
+    \leanid{TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy} in
     \doclink{TNLean/Channel/Schwarz/RelativeEntropyConvexity}
     (\path{TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean}).
     The convexity of the approximants is
-    \leanid{convexOn_relativeEntropyApprox}, which consumes
+    \leanid{TNLean.RelativeEntropyConvexity.convexOn_relativeEntropyApprox}, which consumes
     \leanid{lieb_concavity_posDef}, and their convergence is
-    \leanid{tendsto_relativeEntropyApprox}. The double-sum identity
-    \leanid{re_trace_cfc_mul_cfc_eq_double_sum} used in the limit requires no
+    \leanid{TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyApprox}. The double-sum identity
+    \leanid{TNLean.Klein.re_trace_cfc_mul_cfc_eq_double_sum} used in the limit requires no
     Lieb input.
 
     The theorem
-    \leanid{convexOn_quantumRelativeEntropy_support} extends joint convexity to
+    \leanid{TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy_support} extends joint convexity to
     the full domain $\ker\sigma\subseteq\ker\rho$. It regularizes both
     arguments by
     \begin{align}
@@ -183,10 +183,10 @@ and records its formal implementation.
     \end{align}
     applies positive-definite convexity to the four regularized endpoints and
     their mixture, and passes to the limit with
-    \leanid{tendsto_relativeEntropyPerturb}. The domain is convex because the
+    \leanid{TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturb}. The domain is convex because the
     kernel of a positively weighted sum of positive semidefinite matrices is
     the intersection of their kernels; this step is
-    \leanid{mulVec_eq_zero_of_smul_add}. The extension uses no additional Lieb
+    \leanid{TNLean.RelativeEntropyConvexity.mulVec_eq_zero_of_smul_add}. The extension uses no additional Lieb
     input.
 
     \item \emph{Data processing under a partial trace.}
@@ -290,13 +290,13 @@ and records its formal implementation.
         \label{eq:cpsv16_ssa_from_lieb_route_partial_trace_monotonicity}
     \end{align}
     The positive-definite theorem is
-    \leanid{quantumRelativeEntropy_partialTraceRight_le} in
+    \leanid{Matrix.quantumRelativeEntropy_partialTraceRight_le} in
     \doclink{TNLean/Channel/Schwarz/RelativeEntropyDataProcessing}. Transport
     of joint convexity to the product index uses
-    \leanid{quantumRelativeEntropy_submatrix_equiv}.
+    \leanid{Matrix.quantumRelativeEntropy_submatrix_equiv}.
 
     The support-domain theorem is
-    \leanid{quantumRelativeEntropy_partialTraceRight_le_support} in the same
+    \leanid{Matrix.quantumRelativeEntropy_partialTraceRight_le_support} in the same
     file. It regularizes both arguments by
     \begin{align}
         M_\varepsilon
@@ -309,7 +309,7 @@ and records its formal implementation.
     limit. The partial traces are affine regularizations of
     $\tr_C\rho$ and $\tr_C\sigma$ with scaling rate $N_{SC}$ and shift rate
     $d_C$; this identity is
-    \leanid{partialTraceRight_regPerturbAffine}. The support condition passes
+    \leanid{Matrix.partialTraceRight_regPerturbAffine}. The support condition passes
     to the marginals by \leanid{Matrix.partialTraceRight_support}. The
     arbitrary-rate affine limit
     \leanid{TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine}
@@ -487,8 +487,8 @@ The general theorem is \leanid{strong_subadditivity_general} in the same file.
 It applies to every positive semidefinite unit-trace $\rho_{ABC}$. The theorem
 \leanid{Matrix.marginal_support} places the possibly singular reference state
 in the domain of
-\leanid{quantumRelativeEntropy_partialTraceRight_le_support}. The two relative
-entropies are evaluated by \leanid{rel_entropy_eval_support}, which regularizes
+\leanid{Matrix.quantumRelativeEntropy_partialTraceRight_le_support}. The two relative
+entropies are evaluated by \leanid{SSAPosDef.rel_entropy_eval_support}, which regularizes
 the reduced state as
 \begin{align}
     \rho_{R,\varepsilon}
@@ -502,7 +502,7 @@ tensor-logarithm split is unavailable for a singular reference state.
 The stable entropy interface re-exports the inequality from
 \doclink{TNLean/Entropy/StrongSubadditivity}. Its consumers import that theorem
 rather than the former axiom module. Their statements require no change; only
-the justification has changed from the axiom \leanid{strong_subadditivity} to
+the justification has changed from the axiom \path{strong_subadditivity} to
 the theorem \leanid{strong_subadditivity_general}.
 
 \section{Verdict}
@@ -513,12 +513,12 @@ entropy, Klein's inequality, joint convexity from Lieb concavity, data
 processing under a partial trace, and the tripartite instantiation.
 
 The positive-definite joint-convexity theorem
-\leanid{convexOn_quantumRelativeEntropy} is extended to the support domain by
-\leanid{convexOn_quantumRelativeEntropy_support}. Unitary invariance,
+\leanid{TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy} is extended to the support domain by
+\leanid{TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy_support}. Unitary invariance,
 ancilla-additivity, the finite Heisenberg--Weyl twirl, and its ancilla lift give
-\leanid{quantumRelativeEntropy_partialTraceRight_le}; regularization gives
-\leanid{quantumRelativeEntropy_partialTraceRight_le_support}. The marginal
-support lemma and \leanid{rel_entropy_eval_support} then establish
+\leanid{Matrix.quantumRelativeEntropy_partialTraceRight_le}; regularization gives
+\leanid{Matrix.quantumRelativeEntropy_partialTraceRight_le_support}. The marginal
+support lemma and \leanid{SSAPosDef.rel_entropy_eval_support} then establish
 \leanid{strong_subadditivity_general} for every positive semidefinite
 unit-trace state.
 

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -20,7 +20,7 @@
 \textbf{Historical proof archaeology, not an active gap.}
 This note records the mismatch between a retired strict-modulus specialization
 and the repeated-copy BNT decomposition in CPSV16. The current
-\leanid{SectorDecomposition} and \leanid{IsBNTCanonicalForm} surfaces retain the
+\leanid{MPSTensor.SectorDecomposition} and \leanid{MPSTensor.IsBNTCanonicalForm} surfaces retain the
 raw copy weights, and
 \leanid{MPSTensor.fundamentalTheorem_proportional_canonicalForm} proves the
 corrected proportional theorem on BNT families with nonzero copy weights. No
@@ -98,14 +98,14 @@ imposed three hypotheses stronger than the source decomposition:
 \section{The surviving formal surface}
 
 The surviving surface separates the source decomposition into two pieces.
-\leanid{SectorDecomposition} stores the basis blocks, their copy
+\leanid{MPSTensor.SectorDecomposition} stores the basis blocks, their copy
 multiplicities, and the raw weights $\mu_{j,q}$ through the coefficient
 \begin{align}
     P.\mathtt{coeff}\,N\,j
         &=\sum_q(P.\mathtt{weight}\,j\,q)^N.
     \label{eq:two-layer_sector_power_sum_coefficient}
 \end{align}
-The predicate \leanid{IsBNTCanonicalForm} records the BNT hypotheses used by
+The predicate \leanid{MPSTensor.IsBNTCanonicalForm} records the BNT hypotheses used by
 the fundamental-theorem route: irreducibility, left canonical normalization,
 gauge-phase distinctness of equal-dimensional basis blocks, eventual linear
 independence of the basis MPVs, bounded weights, and the existence of at least
@@ -119,12 +119,12 @@ hypothesis rather than hidden in the canonical-form predicate.
 
 \section{Historical scope restriction and its resolution}
 
-The representative-family predicate \leanid{IsNormalCanonicalFormBNT} covers
+The representative-family predicate \leanid{MPSTensor.IsNormalCanonicalFormBNT} covers
 one chosen block per gauge-phase class and therefore does not itself store the
 repeated-copy data $r_j>1$. The earlier route tried to bridge this restriction
 through a strict-modulus adapter. That adapter was retired.
 
-The current \leanid{SectorDecomposition} surface directly permits
+The current \leanid{MPSTensor.SectorDecomposition} surface directly permits
 $P.\mathtt{copies}(j)>1$, and the SectorBNT comparison recovers repeated weights
 from the power sums
 \begin{align}
@@ -139,10 +139,10 @@ proportional fundamental theorem. Its history is documented in
 
 The relevant surviving formal declarations are:
 \begin{itemize}
-    \item \leanid{SectorDecomposition}: the raw two-layer sector surface
+    \item \leanid{MPSTensor.SectorDecomposition}: the raw two-layer sector surface
     (\doclink{TNLean/MPS/SharedInfra/SectorDecomposition}).
 
-    \item \leanid{IsBNTCanonicalForm}: the BNT canonical-form predicate
+    \item \leanid{MPSTensor.IsBNTCanonicalForm}: the BNT canonical-form predicate
     (\doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Basic}).
 
     \item

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -102,8 +102,8 @@ The formal declarations for these corners are
 \begin{center}
 \scriptsize
 \mbox{\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.}}\\
-\mbox{\leanid{exists_oneSite_raw_sector_corner},}\qquad
-\mbox{\leanid{exists_blockTwo_gauge_sector_corner}.}
+\mbox{\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.exists_oneSite_raw_sector_corner},}\qquad
+\mbox{\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.exists_blockTwo_gauge_sector_corner}.}
 \end{center}
 
 \section{The common unblocked reflected tail}
@@ -144,9 +144,7 @@ Thus, for every positive tail length and all open indices and tail words,
 The mixed-prefix identity is formalized by
 \begin{center}
 \scriptsize
-\mbox{\leanid{MPOTensor.IsMPDO.}}\\
-\mbox{\leanid{markedChainCoefficient_blockTwoPrefix_}}\\
-\mbox{\leanid{gramDressing_eq_reflectedAdjoint}.}
+\mbox{\leanid{MPOTensor.IsMPDO.markedChainCoefficient_blockTwoPrefix_gramDressing_eq_reflectedAdjoint}.}
 \end{center}
 Its essential feature is that the two-site prefix is followed by the original
 one-site tensor, not by the blocked tensor.
@@ -390,10 +388,9 @@ canonical form, and MPDO positivity from which both physical corners arise.
 The relevant formal declarations are
 \begin{center}
 \scriptsize
-\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.}}\\
-\mbox{\leanid{sameMPV}\ensuremath{{}_{2}}\leanid{Pos_does_not_force_positive_}}\\
-\mbox{\leanid{isometric_realization},}\qquad
-\mbox{\leanid{gramDressing_gauge_ne_one}.}
+\mbox{\path{MPSTensor.PositiveMinimalRealizationCounterexample}}\\
+\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.sameMPV₂Pos_does_not_force_positive_isometric_realization},}\qquad
+\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.gramDressing_gauge_ne_one}.}
 \end{center}
 
 The same distinction explains the negative result for the per-block linear
@@ -407,8 +404,8 @@ require this positivity. The corresponding formal declarations are
 \scriptsize
 \mbox{\leanid{Matrix.exists_unitary_conj_of_positive_algEquiv_matrix},}\\
 \mbox{\leanid{MPSTensor.exists_unitary_conj_of_positive_perBlockLinearExtension},}\\
-\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.}}\\
-\mbox{\leanid{perBlockLinearExtension_not_positive}.}
+\mbox{\path{MPSTensor.PositiveMinimalRealizationCounterexample}}\\
+\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.perBlockLinearExtension_not_positive}.}
 \end{center}
 
 \subsection{Terminal positivity and the bond-two test}
@@ -443,11 +440,11 @@ for a metric boundary is superseded by the mixed-prefix comparison. The
 formal tests are
 \begin{center}
 \scriptsize
-\mbox{\leanid{MPOTensor.BondTwoSingletonBaseModel.}}\\
-\mbox{\leanid{gaugeGram_eq_pos_smul_one_of_gaugeDeformedBaseMPO_isMPDO},}\\
-\mbox{\leanid{gaugeDeformedBaseMPO_gauge_not_isMPDO},}\\
-\mbox{\leanid{gaugeDeformedBaseMPOBNTAlgebraTensorClause},}\qquad
-\mbox{\leanid{gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm}.}
+\mbox{\path{MPOTensor.BondTwoSingletonBaseModel}}\\
+\mbox{\leanid{MPOTensor.BondTwoSingletonBaseModel.gaugeGram_eq_pos_smul_one_of_gaugeDeformedBaseMPO_isMPDO},}\\
+\mbox{\leanid{MPOTensor.BondTwoSingletonBaseModel.gaugeDeformedBaseMPO_gauge_not_isMPDO},}\\
+\mbox{\leanid{MPOTensor.BondTwoSingletonBaseModel.gaugeDeformedBaseMPOBNTAlgebraTensorClause},}\qquad
+\mbox{\leanid{MPOTensor.BondTwoSingletonBaseModel.gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm}.}
 \end{center}
 
 \section{Verdict}

--- a/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
@@ -106,7 +106,7 @@ development, this coupling produced transport lemmas used only to move the
 empty-word instance of
 Eq.~\ref{eq:cpsv16_zero_tail_length_zero_decomposition_all_length_identity}
 through those operations.\footnote{%
-  These were the \leanid{zeroTail_*} lemmas in
+  These were the \path{zeroTail_*} lemmas in
   \path{TNLean/MPS/CanonicalForm/SectorComparison/}; they are removed in
   PRs \ghpr{2156} and \ghpr{2167} once the comparison is stated at positive
   length.}
@@ -141,7 +141,7 @@ blocks, the downstream argument needs only
 \end{align}
 No physical theorem therefore needs an empty-word coefficient or a scalar
 recording the dimension of the discarded bond space. Formally, positive-length
-equality is \leanid{SameMPV₂Pos}; the canonical-form reduction carries
+equality is \leanid{MPSTensor.SameMPV₂Pos}; the canonical-form reduction carries
 Eq.~\ref{eq:cpsv16_zero_tail_length_zero_decomposition_positive_length_comparison}
 and the bound in
 Eq.~\ref{eq:cpsv16_zero_tail_length_zero_decomposition_dimension_bound}.
@@ -149,7 +149,7 @@ Eq.~\ref{eq:cpsv16_zero_tail_length_zero_decomposition_dimension_bound}.
 \section{Formal status}
 
 The declaration
-\leanid{exists_tp_primitive_blockDecomp_after_blocking}, corresponding to
+\leanid{MPSTensor.exists_tp_primitive_blockDecomp_after_blocking}, corresponding to
 blueprint item \path{thm:tp_primitive_blockdecomp} in
 \path{blueprint/src/chapter/ch09_canonical.tex}, now has the source-faithful
 shape. Its matrix-product-vector clause is the positive-length comparison in
@@ -158,9 +158,9 @@ and its dimension clause is
 Eq.~\ref{eq:cpsv16_zero_tail_length_zero_decomposition_dimension_bound}.
 
 The intermediate declarations carrying \texttt{zeroTailDim} and the former
-support lemma \leanid{zeroTail_toTensorFromBlocks_blockPower} have been
+support lemma \path{zeroTail_toTensorFromBlocks_blockPower} have been
 removed. The subsequent common-sector theorems now assume
-\leanid{SameMPV₂Pos} directly; their proofs no longer convert an all-length
+\leanid{MPSTensor.SameMPV₂Pos} directly; their proofs no longer convert an all-length
 hypothesis back to positive length. The former bridge from positive-length
 equality plus equal bond dimensions to an all-length statement has also been
 removed from the public comparison surface. The empty-word coefficient lemma

--- a/docs/paper-gaps/cpsv17_transfer_trace_power.tex
+++ b/docs/paper-gaps/cpsv17_transfer_trace_power.tex
@@ -33,7 +33,7 @@ $T:M_D(\mathbb C)\to M_D(\mathbb C)$ defined by
            \widetilde U^a X(\widetilde U^a)^\dagger.
     \label{eq:cpsv17_transfer_trace_power_transfer_map}
 \end{align}
-This is \leanid{MPSTensor.transferMap} applied to
+This is \leanid{Kraus.transferMap} applied to
 \leanid{MPOTensor.normalizedFlattening}.
 
 Let $F_{k\ell}$ denote the matrix units in $M_D(\mathbb C)$, and let

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -22,14 +22,14 @@ This note compares the formal proof of the periodic overlap dichotomy with the
 Appendix~A argument of Ref.~\cite{DeLasCuevas2017Irreducible}. It identifies
 the equivalent proof routes used in the formal development and the statements
 that remain restricted relative to the source.\footnote{Formal files:
-\leanid{TNLean/MPS/Periodic/Overlap/}. Local source:
-\leanid{Papers/1708.00029/main.tex}. Paper-level umbrella:
+\path{TNLean/MPS/Periodic/Overlap/}. Local source:
+\path{Papers/1708.00029/main.tex}. Paper-level umbrella:
 \href{https://github.com/LionSR/TNLean/issues/619}{issue \#619};
 proposition-level subtracking:
 \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}. The Case-3
 contraction and phase construction was tracked by
 \href{https://github.com/LionSR/TNLean/issues/873}{issue \#873} and is now
-formalized by \leanid{sectorTensor_proportional_of_blockedMatch}.}
+formalized by \leanid{MPSTensor.sectorTensor_proportional_of_blockedMatch}.}
 
 The source proposition is ``equal-or-orthogonal-generalized''.\footnote{The
 statement appears at lines 589--609 and its proof appears at lines 903--1118
@@ -42,8 +42,7 @@ mathematically equivalent to the source route.
 
 The formal periodic-overlap argument states its matrix-product-vector
 equalities for $N\geq 1$. In particular,
-\leanid{peripheralProportionalCase_periodicFT_of_sameMPV}%
-\textsubscript{2}\leanid{Pos} assumes equality
+\leanid{MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV₂Pos} assumes equality
 at every positive length. This assumption suffices because the overlap
 argument is asymptotic and uses only a tail of positive lengths. The empty word
 contains only a bond-dimension trace and does not enter theorem
@@ -110,8 +109,8 @@ equal-or-orthogonal dichotomy gives
 This spectral argument replaces the least-common-multiple blocking and
 translation argument of the source and is complete.\footnote{Formal
 declaration:
-\leanid{periodicOverlap_tendsto_zero_of_ne_period} in
-\leanid{DifferentPeriod.lean}.}
+\leanid{MPSTensor.periodicOverlap_tendsto_zero_of_ne_period} in
+\path{DifferentPeriod.lean}.}
 
 \section{Sector non-repetition from the blocked fixed-point structure}
 
@@ -185,8 +184,8 @@ off-diagonal. Since $U\neq 0$, this is a contradiction.
 The formal statement proves the same non-repetition result: distinct cyclic
 sectors with $P_uP_v=0$ are not gauge-phase equivalent.\footnote{Formal
 declaration:
-\leanid{not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces} in
-\leanid{SelfOverlap.lean}.} The proof follows the spectral route above. From a
+\path{MPSTensor.not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces} in
+\path{SelfOverlap.lean}.} The proof follows the spectral route above. From a
 gauge-phase equivalence between two compressed sectors, it constructs a
 nonzero off-diagonal eigenvector of $\mathcal E_A^m$ using the sector
 corner-letter identity and rectangular support isometries for the compressed
@@ -194,9 +193,9 @@ corners. The existing off-diagonal vanishing lemma then gives the
 contradiction. The scalar normalization uses the same Perron--Frobenius
 eigenvalue-uniqueness input as the different-period proof.\footnote{Formal
 declarations:
-\leanid{exists_offDiag_eigenvector_of_gaugePhase_cast_left},
-\leanid{offDiag_eigenvector_eq_zero_of_isPeriodic}, and
-\leanid{period_eq_of_gaugePhaseEquiv_of_isPeriodic}.}
+\leanid{MPSTensor.exists_offDiag_eigenvector_of_gaugePhase_cast_left},
+\leanid{MPSTensor.offDiag_eigenvector_eq_zero_of_isPeriodic}, and
+\path{MPSTensor.period_eq_of_gaugePhaseEquiv_of_isPeriodic}.}
 
 \paragraph{Signature correction.}
 
@@ -209,9 +208,9 @@ gauge-phase-equivalent distinct sectors. The spectral proof requires $A$ to
 be a periodic irreducible block, because periodicity supplies irreducibility,
 the prescribed peripheral spectrum, and primitive sectors.
 
-The hypothesis \leanid{hP : IsPeriodic m A} was therefore added to the lemma
+The hypothesis \path{hP : IsPeriodic m A} was therefore added to the lemma
 signature. It is supplied at the unique call site
-\leanid{sectorBlocks_not_gaugePhaseEquiv_of_ne}. With this hypothesis and the
+\path{MPSTensor.sectorBlocks_not_gaugePhaseEquiv_of_ne}. With this hypothesis and the
 corner-isometry data, the spectral proof is formalized.
 
 \section{Sector matching: propagation and phase construction}
@@ -284,14 +283,14 @@ The sector phases then telescope into the global phase and unitary
 The formal development follows the same two stages: the $T^l$ and
 Theorem~2.10 propagation staircase, followed by the $\Omega_u$ contraction and
 the $\kappa/\theta/\phi$ phase construction.\footnote{Formal declarations:
-\leanid{sectorMatch_propagation} in
-\leanid{SectorMatch/Propagation.lean},
-\leanid{sectorTensor_proportional_of_blockedMatch} in
-\leanid{SectorMatch/Contraction.lean}, and
-\leanid{periodicOverlap_gaugeEquiv_of_sector_match} in
-\leanid{SectorMatch/Consequences.lean}.} The top-level theorem invokes these
+\leanid{MPSTensor.sectorMatch_propagation} in
+\path{SectorMatch/Propagation.lean},
+\leanid{MPSTensor.sectorTensor_proportional_of_blockedMatch} in
+\path{SectorMatch/Contraction.lean}, and
+\leanid{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match} in
+\path{SectorMatch/Consequences.lean}.} The top-level theorem invokes these
 component lemmas. The contraction leaf
-\leanid{sectorTensor_proportional_of_blockedMatch}, the global unitary gauge,
+\leanid{MPSTensor.sectorTensor_proportional_of_blockedMatch}, the global unitary gauge,
 and the repeated-blocks theorem are proved.
 
 The docstrings now cite the source equation identifiers and line ranges rather
@@ -303,10 +302,10 @@ $\kappa/\theta/\phi$ construction is essential.
 
 The formal single-site off-diagonal decomposition follows from the cyclic
 adjoint-shift relation.\footnote{Formal declarations:
-\leanid{offDiag_shift_of_adjoint_cyclic_shift},
-\leanid{eq_sum_offDiag_of_adjoint_cyclic_shift},
-\leanid{IsCyclicSectorDecomp.offDiag_shift}, and
-\leanid{IsCyclicSectorDecomp.eq_sum_offDiag}.} With the repository's inverse
+\leanid{MPSTensor.offDiag_shift_of_adjoint_cyclic_shift},
+\leanid{MPSTensor.eq_sum_offDiag_of_adjoint_cyclic_shift},
+\leanid{MPSTensor.IsCyclicSectorDecomp.offDiag_shift}, and
+\leanid{MPSTensor.IsCyclicSectorDecomp.eq_sum_offDiag}.} With the repository's inverse
 cyclic indexing convention, it gives
 \begin{align}
     P_{u+1}A^i
@@ -329,9 +328,9 @@ Ref.~\cite{DeLasCuevas2017Irreducible}. The later source equation
 The cyclic-sector construction also records a letter-level corner identity
 and a rectangular support isometry for each corner.\footnote{Formal
 declarations:
-\leanid{exists_cyclic_sector_decomp_with_letter_and_isometry_after_blocking_of_isPeriodic}
+\leanid{MPSTensor.exists_cyclic_sector_decomp_with_letter_and_isometry_after_blocking_of_isPeriodic}
 and
-\leanid{exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic}.}
+\leanid{MPSTensor.exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic}.}
 If $\varphi_u$ is the compression isomorphism from the compressed sector
 algebra onto $P_uM_DP_u$, then
 \begin{align}
@@ -354,7 +353,7 @@ Define the sector overlap by
 \end{align}
 The one-site sector-overlap translation is also formalized.\footnote{Formal
 declaration:
-\leanid{sectorOverlap_succ_eq_of_cyclicSectorDecomp}.} For every $N>0$, it
+\leanid{MPSTensor.sectorOverlap_succ_eq_of_cyclicSectorDecomp}.} For every $N>0$, it
 proves
 \begin{align}
     O_{A_{u+1},B_{v+1}}(N)
@@ -389,18 +388,18 @@ The formal contraction and gauge construction has two parts.
 \end{itemize}
 These steps discharge the contraction obligation for the repeated-blocks
 theorem.\footnote{Formal declaration:
-\leanid{sectorTensor_proportional_of_blockedMatch} in
-\leanid{SectorMatch/Contraction.lean}.} Tensor-product scalar extraction and
+\leanid{MPSTensor.sectorTensor_proportional_of_blockedMatch} in
+\path{SectorMatch/Contraction.lean}.} Tensor-product scalar extraction and
 product-one normalization are isolated in
-\leanid{PiTensorProductPhase.exists_kappa_of_piTensorProduct_eq_smul} and
-\leanid{PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul}.
+\leanid{TNLean.Algebra.PiTensorProductPhase.exists_kappa_of_piTensorProduct_eq_smul} and
+\leanid{TNLean.Algebra.PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul}.
 The finite-cycle phase choice is isolated in
-\leanid{exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one}.
+\leanid{TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one}.
 The one-step transport theorem follows from the single-site overlap theorem,
 the overlap-to-gauge theorem, and sector primitivity.\footnote{Formal
 declarations:
-\leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport} and
-\leanid{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}.}
+\path{MPSTensor.sectorGaugePhaseEquiv_succ_of_cyclicTransport} and
+\leanid{MPSTensor.gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}.}
 
 \subsection{Corner-letter building blocks}
 
@@ -428,7 +427,7 @@ projector is absorbed by idempotency, so this law requires neither injectivity
 nor normality. These are the $A_u^i$ and $F_u$ objects used in the cyclic
 contraction. The formal right-inverse contraction to source equation
 \emph{eq:resultprop} and the global unitary assembly are completed in
-\leanid{sectorTensor_proportional_of_blockedMatch}.
+\leanid{MPSTensor.sectorTensor_proportional_of_blockedMatch}.
 
 \section{Scope restriction: independence without spanning}
 
@@ -444,12 +443,12 @@ source phrase ``basis of periodic vectors'' at line 611.
 
 The formal theorem states only eventual linear independence.\footnote{Formal
 declaration:
-\leanid{periodicBasis_eventuallyLinearlyIndependent} in
-\leanid{Dichotomy.lean}. The corresponding blueprint entry is in
+\leanid{MPSTensor.periodicBasis_eventuallyLinearlyIndependent} in
+\path{Dichotomy.lean}. The corresponding blueprint entry is in
 \path{blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex}.}
 It encodes the basis assumptions directly as the pairwise non-repetition
-hypothesis \leanid{hNonrep} and the common-period divisibility hypothesis
-\leanid{hDiv}. It neither derives them from a basis of periodic tensors nor
+hypothesis \path{hNonrep} and the common-period divisibility hypothesis
+\path{hDiv}. It neither derives them from a basis of periodic tensors nor
 uses the almost-orthonormal-implies-independent Lemma~\emph{Lem1t}. Restoring
 the spanning clause and routing the proof through \emph{Lem1t} was classified
 under \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}. The
@@ -587,8 +586,8 @@ hypothesis to the original spectral-radius-one blocks. This completes the
 overlap-hypothesis step tracked by
 \href{https://github.com/LionSR/TNLean/issues/5342}{issue \#5342}.
 
-The declarations \leanid{fundamentalTheorem_periodic_proportional} and
-\leanid{fundamentalTheorem_periodic_proportional_of_isPeriodic} start after
+The declarations \leanid{MPSTensor.fundamentalTheorem_periodic_proportional} and
+\leanid{MPSTensor.fundamentalTheorem_periodic_proportional_of_isPeriodic} start after
 this step. They assume the periodic-overlap hypothesis, or its non-decaying
 partner fields, and prove finite block matching. Together with the spectrally
 periodic multiplicity theorem, they yield block matching for literal

--- a/docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex
+++ b/docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex
@@ -166,7 +166,7 @@ PEPS. A PEPS on a disconnected graph is a product of independent states and
 lies outside the local blocking argument used there. The faithful correction
 adds connectivity to \leanid{TNLean.PEPS.gaugeConsistency} and
 \leanid{TNLean.PEPS.fundamentalTheorem_PEPS}, for example through
-\leanid{G.Connected}, or through \leanid{G.Preconnected} together with
+\leanid{SimpleGraph.Connected}, or through \leanid{SimpleGraph.Preconnected} together with
 nonemptiness of $V$.
 
 Under connectivity, state equality and state nonvanishing give

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -223,7 +223,7 @@ but differ on that positive-dimensional bond by no scalar. Both families
 satisfy the relevant hypotheses vacuously, while the balanced edge-scalar
 conclusion fails. The nonzero-bond convention is precisely the normal-PEPS
 assumption used in the existence direction, where it appears as
-\leanid{hposA} in \leanid{TNLean.PEPS.fundamentalTheorem_PEPS}. The uniqueness
+\path{hposA} in \leanid{TNLean.PEPS.fundamentalTheorem_PEPS}. The uniqueness
 clause requires the same convention.
 
 \section{Verdict}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -398,7 +398,7 @@ can hold vacuously while physical-to-virtual recovery and the gauge conclusion
 fail. The theorem-level counterexample is
 \leanid{TNLean.PEPS.FundamentalTheoremCounterexample.fundamentalTheoremPEPSStatement_false};
 the intermediate recovery failure is
-\leanid{TNLean.PEPS.PhysicalToVirtualCounterexample}; and the edge-middle
+\leanid{TNLean.PEPS.PhysicalToVirtualCounterexample.physical_to_virtual_insertion_statement_false}; and the edge-middle
 obstruction is
 \leanid{TNLean.PEPS.not_edgeMiddleTensorInjective_of_isEmpty}. Thus the
 positive-bond assumptions formalize the source's nonzero virtual bond spaces
@@ -794,7 +794,7 @@ refutes the conclusion when this hypothesis is dropped. Connectivity is an
 explicit correction to the literal source statement and is documented in
 \path{docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex}. The
 counterexample
-\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample} refutes the
+\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample.gaugeConsistencyStatement_false} refutes the
 gauge-consistency conclusion without connectivity.
 
 % Use the shared bibliography when it is available. The fallback keeps this

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -203,7 +203,7 @@ injective tensors.''} instantiated at the $L \times K$ blocking; it is not a
 second, stronger hypothesis. The faithful Lean hypothesis bundle is
 \leanid{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses}
 (\path{TNLean/PEPS/TorusWindowComplement.lean}), a single field
-\leanid{arcWindow_injective}: every cyclic $L \times K$ window is injective in
+\leanid{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses.arcWindow_injective}: every cyclic $L \times K$ window is injective in
 the sense of \leanid{TNLean.PEPS.RegionBlockedTensorInjective}. This neither
 exceeds nor falls short of the source's hypothesis.
 
@@ -257,7 +257,7 @@ $O_j(X)$ and proves $O_j(X)T_{B,W_j}(\mu)=C_j(X)(\mu)$ before complementary
 contraction; all these inserts also have common closed state
 $P_B(W_0)E_B(e,\cdot,X)$.  The outstanding input is instead the cross-tensor
 coefficient transfer between $A$ and $B$ and its multiplicativity
-\leanid{hmul}, the two-dimensional counterpart of Lemma~5's algebra
+\path{hmul}, the two-dimensional counterpart of Lemma~5's algebra
 homomorphisms.  Existing single-window and coarse-three-site attempts do not
 derive that input at the minimal size; a source-faithful extraction must use
 the actual overlapping-window comparison rather than assume a matrix span.
@@ -507,14 +507,14 @@ The faithful step is therefore the shared-block cancellation that yields
 needs only injectivity of the completed rectangle $Q$ (an $L \times K$
 window, injective by hypothesis) and never asserts injectivity of
 $\mathrm{univ} \setminus S$. The Lean stripping is the open-boundary
-shared-corner cancellation \leanid{staircasePair_insert_eq_open}: it cancels
+shared-corner cancellation \leanid{TNLean.PEPS.staircasePair_insert_eq_open}: it cancels
 the shared injective completed rectangle $Q$ from
 (\ref{eq:peps_normal_ft_2d_overlap_patch_end_window_comparison}) and never
 inverts $\mathrm{univ} \setminus S$. An earlier closed-torus stripping
 discharged Step~3 with the full-complement engine
-\leanid{deformedRegionStateAssembled_insert_eq_of_complementInjective} and so
-carried \leanid{RegionBlockedTensorInjective}~$B\;(\mathrm{univ} \setminus
-\text{\leanid{horizontalStaircaseEndPair}}\;s\,L\,K)$ as an explicit
+\leanid{TNLean.PEPS.deformedRegionStateAssembled_insert_eq_of_complementInjective} and so
+carried \leanid{TNLean.PEPS.RegionBlockedTensorInjective}~$B\;(\mathrm{univ} \setminus
+\text{\leanid{TNLean.PEPS.horizontalStaircaseEndPair}}\;s\,L\,K)$ as an explicit
 hypothesis not derivable at the minimal size; it has been removed in favour of
 the shared-injective-block cancellation engine for $Q$, which inverts the
 common completed-corner block rather than the whole complement.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -496,7 +496,7 @@ The remaining obligations are the following.
           with the crossing-edge family taken to be the $P_1$--$P_0$ edges and the
           produced block taken to be $B$. After the collapse, the right
           geometry's blue-side factorization
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.regionInteriorBondProd_smul_threeBlockBlueWeight_eq}
+          \leanid{TNLean.PEPS.regionInteriorBondProd_smul_threeBlockBlueWeight_eq}
           reads the rebuilt coupling as a combination of $B$ blocked weights, the
           left inverse for $B$ forces the reconstructed host residual coefficients
           to vanish, and host-boundary surjectivity
@@ -1219,7 +1219,7 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both directions). Both are now
           landed; the per-edge gauge is delivered through the coherent-frame interface
           \leanid{TNLean.PEPS.exists_regionEdgeGauge_of_coherentFrames}, which discharges the
-          three hypotheses \leanid{hbondAB}, \leanid{hbondBA}, and \leanid{hmul} of the
+          three hypotheses \path{hbondAB}, \path{hbondBA}, and \path{hmul} of the
           abstract \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}
           from the two coherent frames and the single-crossing hypothesis, returning the same
           gauge conclusion. The final assembly is recorded below.
@@ -1420,14 +1420,14 @@ The remaining obligations are the following.
           post-absorption edge-insertion equality is taken as the conditional kernel
           input, in the shape produced unconditionally in the vertex-injective case.\footnote{
           Formal declarations:
-          \leanid{TNLean.PEPS.SquareLatticeUniformBondDim},
-          \leanid{TNLean.PEPS.orientationUniformGauge},
-          \leanid{TNLean.PEPS.IsOrientationUniformGaugeFamily},
-          \leanid{TNLean.PEPS.exists_orientationUniformGaugeFamily},
-          \leanid{TNLean.PEPS.tiAbsorb},
-          \leanid{TNLean.PEPS.isVertexInjective_tiAbsorb},
-          \leanid{TNLean.PEPS.tiNormalGaugeAbsorption}, and
-          \leanid{TNLean.PEPS.exists_postAbsorption_of_vertexInjective}.}
+          \path{TNLean.PEPS.SquareLatticeUniformBondDim},
+          \path{TNLean.PEPS.orientationUniformGauge},
+          \path{TNLean.PEPS.IsOrientationUniformGaugeFamily},
+          \path{TNLean.PEPS.exists_orientationUniformGaugeFamily},
+          \path{TNLean.PEPS.tiAbsorb},
+          \path{TNLean.PEPS.isVertexInjective_tiAbsorb},
+          \path{TNLean.PEPS.tiNormalGaugeAbsorption}, and
+          \path{TNLean.PEPS.exists_postAbsorption_of_vertexInjective}.}
 
           The uniqueness-up-to-scalar step is now formalized. The conjugating
           matrix realizing a forward per-edge transfer is determined up to a
@@ -1453,10 +1453,10 @@ The remaining obligations are the following.
           the exact orientation-uniform family as the all-constants-one
           specialization.\footnote{
           Formal declarations:
-          \leanid{TNLean.PEPS.IsOrientationUniformGaugeFamilyModScalar},
-          \leanid{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_isOrientationUniform},
+          \path{TNLean.PEPS.IsOrientationUniformGaugeFamilyModScalar},
+          \path{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_isOrientationUniform},
           and
-          \leanid{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_classAgreement}.}
+          \path{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_classAgreement}.}
 
           The per-edge constants are absorbed at the absorption step when they are
           vertex balanced. A per-edge scalar rescaling whose oriented product around
@@ -1468,8 +1468,8 @@ The remaining obligations are the following.
           orientation-uniform gauge even though the blocking delivers one only up to
           balanced constants.\footnote{
           Formal declarations:
-          \leanid{TNLean.PEPS.gaugeEquivModEdgeScalars_of_matrixScalar} and
-          \leanid{TNLean.PEPS.absorbEdgeGauges_eq_of_matrixScalar}.}
+          \path{TNLean.PEPS.gaugeEquivModEdgeScalars_of_matrixScalar} and
+          \path{TNLean.PEPS.absorbEdgeGauges_eq_of_matrixScalar}.}
 
           The periodic lattice on which this transport lives is now formalized,
           together with the covariance of the blocking machinery under it. The
@@ -1512,11 +1512,11 @@ The remaining obligations are the following.
           input is in place there too.\footnote{
           Formal declarations:
           \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus},
-          \leanid{TNLean.PEPS.torusOrientationUniformGauge},
-          \leanid{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar},
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement},
+          \path{TNLean.PEPS.torusOrientationUniformGauge},
+          \path{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar},
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement},
           and
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant}.}
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant}.}
 
           The covariance of the region-inserted coefficient is now established, and
           with it the determinacy that closes the class-agreement input above the
@@ -1550,8 +1550,8 @@ The remaining obligations are the following.
           orientation classes yields the orientation-uniform-up-to-scalar family.
           \footnote{Formal declarations:
           \leanid{TNLean.PEPS.regionInsertedCoeff_transferMap_unique},
-          \leanid{TNLean.PEPS.regionTransferMap_eq_of_coeffIdentities}, and
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance}.}
+          \path{TNLean.PEPS.regionTransferMap_eq_of_coeffIdentities}, and
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance}.}
           The algebraic reduction from matched coefficient identities to the conjugation
           covariance is now in place. The per-edge gauge at a torus edge carries its
           defining coefficient identity, so the gauge conjugation itself satisfies the
@@ -1644,10 +1644,10 @@ The remaining obligations are the following.
           scalars all one.\footnote{Formal declarations:
           \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity_conj},
           \leanid{TNLean.PEPS.edgeCoeffIdentityWitness_translate},
-          \leanid{TNLean.PEPS.edgeCoeffIdentityWitness_translateUniform},
+          \path{TNLean.PEPS.edgeCoeffIdentityWitness_translateUniform},
           \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_horizontalFamily},
           \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_verticalFamily}, and
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}.}
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}.}
 
           One strengthening remains. The family produced above takes the per-edge gauge to be the
           transported reference matrix itself, so the witness's two coefficient identities are the
@@ -1737,16 +1737,16 @@ The remaining obligations are the following.
           On the torus the per-edge coefficient identity is produced at a single boundary edge of
           each \emph{red blocking region} of the orientation-uniform family
           (\leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}). The
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}). The
           per-vertex relation \(A_v=\lambda\cdot\operatorname{gaugeVertex} B\,X\,v\) that the
           torus Fundamental Theorem
-          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS}) takes as the hypothesis
+          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}) takes as the hypothesis
           \path{hPV} still needs two pieces above the region-independence just recorded. First, the
           absorbing matrix \leanid{TNLean.PEPS.absorbedBoundaryGauge} is the orientation-adapted
           transpose of each \emph{per-edge} engine gauge \(Z_e\), so the absorbed equality holds
           against a per-edge absorbing family rather than against the single
           orientation-uniform \(X=\operatorname{torusOrientationUniformGauge}\) that
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}
+          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}
           returns and that \path{hPV} is stated against; reconciling the per-edge absorbing family
           with that orientation-uniform \(X\) (the transpose/orientation bookkeeping across the two
           orientation classes) is the first open piece. Second, feeding the absorbed equality to
@@ -1845,7 +1845,7 @@ The remaining obligations are the following.
           per-edge gauge family \(X\) --- the orientation-adapted absorbing gauge read off each chosen
           witness --- for which the bare-edge absorbed equality against \(\operatorname{applyGauge}
           B\,X\) holds at every torus edge
-          (\leanid{TNLean.PEPS.exists_edgeAbsorbed_torus_rectangle}). The region-independence step
+          (\path{TNLean.PEPS.exists_edgeAbsorbed_torus_rectangle}). The region-independence step
           then multiplies this back up to the region absorbed equality, supplying the comparison's
           \path{hregion} and producing the region-block proportionality \(A_R\propto\widetilde B_R\)
           at \emph{every} comparison region from the bare-edge equality
@@ -1862,7 +1862,7 @@ The remaining obligations are the following.
           Fundamental Theorem, are three pieces, all consuming the landed \(X\) above. First, the
           \emph{orientation-uniformity} of that absorbing family --- that it is one horizontal matrix
           and one vertical matrix up to per-edge scalars, the shape the Fundamental Theorem's gauge
-          conclusion \leanid{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar} asserts. The
+          conclusion \path{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar} asserts. The
           absorbing matrix \leanid{TNLean.PEPS.absorbedBoundaryGauge} is \(Z^{\mathsf T}\) or
           \(Z^{-1}\) according to whether the boundary edge's left endpoint lies in the red blocking
           region, and the engine gauge \(Z_e\) is the transported reference; both are
@@ -1895,11 +1895,11 @@ The remaining obligations are the following.
           skeletons remain conditional on the open per-edge gauge of
           obligation~5.\footnote{
           Formal declarations:
-          \leanid{TNLean.PEPS.card_squareLatticeVertex},
-          \leanid{TNLean.PEPS.lambda_pow_card_eq_one},
-          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS},
-          \leanid{TNLean.PEPS.tiNormalGaugeAbsorptionData_of_modScalar}, and
-          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_of_modScalarGauge}.}
+          \path{TNLean.PEPS.card_squareLatticeVertex},
+          \leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one},
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional},
+          \path{TNLean.PEPS.tiNormalGaugeAbsorptionData_of_modScalar}, and
+          \path{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_of_modScalarGauge}.}
 \end{enumerate}
 
 \section{Source-to-formalization ledger}

--- a/docs/paper-gaps/pgvwc07_direct_sum_input.tex
+++ b/docs/paper-gaps/pgvwc07_direct_sum_input.tex
@@ -268,8 +268,8 @@ which is exactly the source length in
 The downstream consumers of the direct-sum input are threefold. The
 exact-length span of a direct-sum block family and its two-block trace-dual
 form are expressed as predicates used throughout the pair route.\footnote{%
-\leanid{WordTupleSpanTop}, \leanid{PairWordTupleSpanTop},
-\leanid{PairTraceSeparatingAt}.}
+\leanid{MPSTensor.WordTupleSpanTop}, \leanid{MPSTensor.PairWordTupleSpanTop},
+\leanid{MPSTensor.PairTraceSeparatingAt}.}
 Theorems in the period-window module turn a positive homogeneous window of the
 pair-span predicate into homogeneous trace separation.\footnote{%
 \path{TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean}.}

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -68,10 +68,10 @@ representations that already have the same block structure. Their hypotheses
 include blockwise normalization, injective or irreducible blocks, a common
 block index set, a common block-dimension function, and strict ordering of
 weight moduli.\footnote{The formal declarations are
-\leanid{MPSTensor.per_block_sameMPV_of_canonical_form},
-\leanid{MPSTensor.per_block_sameMPV_of_normal_canonical_form},
-\leanid{MPSTensor.fundamentalTheorem_canonicalForm}, and
-\leanid{MPSTensor.fundamentalTheorem_canonicalForm_explicit}.}
+\leanid{MPSTensor.fundamentalTheorem_multiBlock_blocks},
+\leanid{MPSTensor.fundamentalTheorem_multiBlock_global},
+\leanid{MPSTensor.fundamentalTheorem_canonicalForm_sameStructure}, and
+\leanid{MPSTensor.fundamentalTheorem_multiBlock_explicit}.}
 
 These assumptions are useful in local MPS arguments, but they are not the
 source hypotheses. In particular, the source theorem does not assume that the

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -180,7 +180,7 @@ formal identifier or source-file link does not replace either step.
 All notes in this directory must load
 \path{docs/paper-gaps/command.tex}. Shared notation belongs there. In
 particular, use the shared commands \verb|\tr| and \verb|\leanid| to produce
-$\tr(X)$ and \leanid{someDeclaration}; do not redefine them in an individual
+$\tr(X)$ and \path{someDeclaration}; do not redefine them in an individual
 note. This rule keeps the documents visually consistent and prevents
 contradictory local conventions.
 

--- a/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
+++ b/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
@@ -58,7 +58,7 @@ $A^i=\sigma^i$ given by the Pauli matrices. For each
 $R\in\mathrm{SO}(3)$, applying $R$ to the physical index gives a tensor gauge
 equivalent to $A$. The gauge is an $\mathrm{SU}(2)$ preimage $U$ of $R$ under
 the adjoint double cover.\footnote{Formal declaration:
-\leanid{aklt\_isOnSiteSymmetric\_SO3} in
+\leanid{MPSTensor.aklt_isOnSiteSymmetric_SO3} in
 \doclink{TNLean/MPS/Examples/AKLTRotation}.}
 
 The substantive group-theoretic input is the surjectivity of the adjoint map
@@ -80,7 +80,7 @@ Every rotation has a preimage:
 The proof uses an explicit $ZXZ$ Euler-angle construction. Each coordinate
 rotation is the image of an explicit $\mathrm{SU}(2)$ generator, and every
 rotation factors into coordinate rotations.\footnote{Formal declaration:
-\leanid{spinHalfCover\_surjective\_onto\_SO3}.}
+\leanid{SpinCover.spinHalfCover_surjective_onto_SO3}.}
 
 The physical spin-$1$ representation is the defining action of
 $\mathrm{SO}(3)$ on the three Cartesian components. The map
@@ -120,7 +120,7 @@ identifies as the smallest subgroup of $\mathrm{SO}(3)$ with a nontrivial
 $2$-cocycle, is formalized separately on the $\ket{m}$-basis AKLT tensor
 \cite{Cirac2021Matrix}. Its two gauges are $i\sigma_y$ and $\sigma_z$, and
 they anticommute.\footnote{Formal declaration:
-\leanid{aklt\_isOnSiteSymmetric\_Z2Z2} in
+\leanid{MPSTensor.aklt_isOnSiteSymmetric_Z2Z2} in
 \doclink{TNLean/MPS/Examples/AKLT}.} Explicitly,
 \begin{align}
     (i\sigma_y)\sigma_z

--- a/docs/paper-gaps/rmp_common_blocking_span_equality.tex
+++ b/docs/paper-gaps/rmp_common_blocking_span_equality.tex
@@ -113,13 +113,13 @@ form \cite[lines~1891--1900]{Cirac2021Matrix}.
 \section{The formal argument}
 
 The canonical-form reduction uses the positive-length relation
-\leanid{SameMPV₂Pos}, which matches the source definition in
+\leanid{MPSTensor.SameMPV₂Pos}, which matches the source definition in
 (\ref{eq:rmp_common_blocking_span_equality_mpv_definition}). All-zero blocks
 contribute nothing at positive length and are discarded. The structural
 direct-sum identity directly bounds the total bond dimension of the retained
 blocks, without using an empty-word comparison.\footnote{See
-\leanid{exists_irreducible_blockDecomp_nonzeroBlocks} and
-\leanid{exists_tp_gauge_from_arbitrary}.}
+\leanid{MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks} and
+\leanid{MPSTensor.exists_tp_gauge_from_arbitrary}.}
 
 The common blocking step must also be explicit. For one block family, the source
 instruction to ``block by the least common multiple of the periods'' is

--- a/docs/paper-gaps/rmp_conditional_after_blocking_ft_statement.tex
+++ b/docs/paper-gaps/rmp_conditional_after_blocking_ft_statement.tex
@@ -188,7 +188,7 @@ bookkeeping, and coordinate transports for the final common-sector families.
 
 The zero-tail condition arises from the distinction between positive-length and
 empty-word conventions. The source defines matrix product vectors only at
-positive lengths. The formal relation \leanid{SameMPV}\textsubscript{2} also
+positive lengths. The formal relation \leanid{MPSTensor.SameMPV₂} also
 includes the empty word. A zero block with bond dimension $D_0$ contributes
 zero at every positive length but contributes $D_0$ at length zero. The formal
 proof must therefore record the zero-tail dimension and either identify the two

--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -235,7 +235,7 @@ MPS vector.\footnote{See
 The normal-MPS range-reduction theorem still depends on the periodic-boundary
 comparison. This is the remaining formal gap in the general unique-ground-state
 statement.\footnote{Formal declaration:
-\leanid{wrapped_mirror_witness_agree_of_chainGroundSpace}. See
+\leanid{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}. See
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:822--846 and
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:856--894.}
 

--- a/docs/paper-gaps/rmp_nonperiodic_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/rmp_nonperiodic_bnt_comparison_inputs.tex
@@ -495,7 +495,7 @@ The source comparison gives the following formal requirements.
 \section{Current formal anchors}
 
 The one-copy normal-canonical BNT surface is represented by
-\leanid{IsNormalCanonicalFormBNT}, together with explicit separated-block
+\leanid{MPSTensor.IsNormalCanonicalFormBNT}, together with explicit separated-block
 hypotheses used by the BNT comparison lemmas.\footnote{%
 \path{TNLean/MPS/BNT/Construction.lean}.}
 This already-grouped formulation is restricted: it suppresses the repeated-copy
@@ -619,13 +619,13 @@ the block-diagonal expansion contains the length-dependent coefficients
 \end{align}
 and nonzero weights alone do not imply nonzero full-sequence limits. A faithful
 proof must formalize the relevant power-sum and phase comparison before
-constructing the \leanid{BlockPermutationGaugePhaseConclusion} data and
+constructing the \leanid{MPSTensor.BlockPermutationGaugePhaseConclusion} data and
 applying the BNT sector-data comparison.
 
 Zero-tail equality and common-sector relabelling are primarily formal
 bookkeeping. The source uses positive lengths and treats zero blocks as unused
 bond dimension \cite{Cirac2016MPDO_arXiv}. The $N=0$ convention in
-\leanid{SameMPV}\textsubscript{2} forces an explicit zero-tail identity, and the
+\leanid{MPSTensor.SameMPV₂} forces an explicit zero-tail identity, and the
 common-sector construction must track casts between grouped and flat blocked
 words. These are not additional paper hypotheses, but the final after-blocking
 theorem must transport the identities through the same reblocking coordinates

--- a/docs/paper-gaps/rmp_w_state_ti_bound.tex
+++ b/docs/paper-gaps/rmp_w_state_ti_bound.tex
@@ -102,7 +102,7 @@ finite-size identity. A formal proof would require the following developments.
     explicit $D^2$ scaling and the refinement needed for
     (\ref{eq:rmp_w_state_ti_bound_asymptotic_lower_bound}). These estimates go
     beyond the qualitative primitivity and span-growth results currently
-    available in the \leanid{Wielandt} development.
+    available in the \path{TNLean/Wielandt} development.
 
     \item Combine these results with the rank and dimension argument specific
     to the single-excitation symmetric state to derive

--- a/docs/paper-gaps/spwc10_wielandt_one_step_subspace.tex
+++ b/docs/paper-gaps/spwc10_wielandt_one_step_subspace.tex
@@ -108,7 +108,7 @@ By (\ref{eq:spwc10_wielandt_one_step_subspace_source_kraus_count}) and
 $\operatorname{kr}(A)$ is the invariant form of the source parameter $d$.
 Replacing $d$ by $\operatorname{kr}(A)$ therefore does not change the
 bound.\footnote{The formal definitions are
-    \leanid{MPSTensor.wordSpan} in
+    \leanid{Kraus.wordSpan} in
     \path{TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean:57--64} and
     \leanid{MPSTensor.krausRank} in
     \path{TNLean/Wielandt/Primitivity/Definitions.lean:84--90}. The local
@@ -184,7 +184,7 @@ spaces $S_n(A)$ cannot stagnate for too many successive lengths.
 The formal proof adjoins the chosen matrix $X\in S_1(A)$ as a redundant
 generator. It then proves that the exact word spans and the Kraus rank remain
 unchanged. The relevant declarations are
-\leanid{MPSTensor.wordSpan_oneStepAugment_eq} and
+\leanid{Kraus.wordSpan_oneStepAugment_eq} and
 \leanid{MPSTensor.krausRank_oneStepAugment}, both in
 \path{TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean}. This construction
 reduces the source hypothesis to the single-generator argument without
@@ -202,7 +202,7 @@ The theorem
 \leanid{MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef}\footnote{See
     \path{TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean}.}
 derives normality from a chosen fixed point $\rho$, the local complementary
-transfer-map gap predicate \leanid{IsPrimitiveMPS}, and the additional
+transfer-map gap predicate \leanid{MPSTensor.IsPrimitiveMPS}, and the additional
 hypothesis $\rho>0$.
 
 This theorem formalizes one route for Proposition~3(c)$\Rightarrow$(b) of
@@ -261,7 +261,7 @@ than the full quantum Wielandt theorem. The final theorem in
 $i(A)$ defined by the exact-length spaces in
 (\ref{eq:spwc10_wielandt_one_step_subspace_i_index}).\footnote{The
     cumulative-span theorem is
-    \leanid{MPSTensor.cumulativeSpan_eq_top} in
+    \leanid{Kraus.cumulativeSpan_eq_top} in
     \path{TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean:164--197}; the
     exact-length theorem is the general result identified above. The blueprint
     distinguishes these statements in

--- a/docs/paper-gaps/template.tex
+++ b/docs/paper-gaps/template.tex
@@ -102,7 +102,7 @@ hypotheses; it does not derive $\mathcal K$ from the original assumptions.
 If the formal development proves (\ref{eq:model_corrected_statement}), state
 that fact in prose and identify the exact formal declaration in a
 footnote.\footnote{Model formal declaration:
-    \leanid{modelCorrected} in \doclink{TNLean/Path/To/File}.}
+    \path{modelCorrected} in \doclink{TNLean/Path/To/File}.}
 The formal declaration is evidence for the corrected mathematical statement; it
 does not replace its mathematical explanation.
 

--- a/docs/paper-gaps/tnlean_algebraic_ft_same_state_combined_mpv_gap.tex
+++ b/docs/paper-gaps/tnlean_algebraic_ft_same_state_combined_mpv_gap.tex
@@ -83,7 +83,7 @@ does not imply equality of the combined-tensor MPV families.
 Consequently, the former abstract same-state reduction assertion has no valid
 construction, even when injectivity of the second chain is added.%
 \footnote{Former formal declaration:
-    \leanid{MPSChainTensor.SameStateBridgeHyp}, previously in
+    \path{MPSChainTensor.SameStateBridgeHyp}, previously in
     \path{TNLean/MPS/Chain/SameStateBridge.lean}.}
 In particular, this assertion is not the blocking argument in
 Theorem~\textup{thm:inj\_MPS}, lines~688--725, of

--- a/docs/paper-gaps/tnlean_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/tnlean_bnt_ft_theorem_surface.tex
@@ -221,7 +221,7 @@ The formal route has three distinct layers:
           canonical-form supplier establishes the required
           unit-modulus-copy normalization.
     \item The declaration
-          \leanid{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
+          \path{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
           is an auxiliary rectangular comparison theorem. Given a sector-basis
           matching, linear independence, and equality of the total MPV
           families, it proves equality of the corresponding sector-weight
@@ -263,7 +263,7 @@ to be obtained from the source argument in
 Ref.~\cite{Cirac2016MPDO_arXiv}.
 
 \paragraph{Data structures and transport lemmas.}
-Objects such as \leanid{SectorBasisOverlapSpanHypotheses} store formal
+Objects such as \path{SectorBasisOverlapSpanHypotheses} store formal
 comparison data. They are not paper theorems. Declarations that convert one
 such structure into another are auxiliary unless they directly state one of
 the mathematical claims in Refs.~\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}.
@@ -284,7 +284,7 @@ The following declarations are auxiliary and should not be read as independent
 paper-level theorems.
 \begin{itemize}
     \item The explicit-coefficient equal-MPV declaration
-          \leanid{fundamentalTheorem_equalMPV_of_explicit_coefficients} is
+          \path{fundamentalTheorem_equalMPV_of_explicit_coefficients} is
           lemma-level. It assumes coefficient arrays and their nonzero limits,
           so it is not the full equal-MPV corollary in
           Refs.~\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}.
@@ -318,16 +318,16 @@ paper-level theorems.
           \end{align}
           See lines~217--219 of Ref.~\cite{Cirac2016MPDO_arXiv}.
     \item The declaration
-          \leanid{power_sum_eq_implies_multiset_eq} is a lemma-level
+          \leanid{Matrix.sum_pow_eq_implies_multiset_eq} is a lemma-level
           restatement of the elementary Newton--Girard input used in the
           equal-MPV proof. The former declaration
-          \leanid{perBlock_sameMPV_of_equalMPV_CFBNT}, which extracted
+          \path{perBlock_sameMPV_of_equalMPV_CFBNT}, which extracted
           blockwise equality from the common-block equal-MPV lemma, has also
           been removed from the active Lean tree. These names identify the
           retired one-copy route and should not be counted as additional
           source-level Fundamental Theorems.
     \item The implication
-          \leanid{sameMPV₂_implies_proportionalMPV₂} converts equal MPV
+          \leanid{MPSTensor.SameMPV₂Pos.toNonzeroProportionalMPV₂} converts equal MPV
           families into proportional MPV families with proportionality
           constant $1$. It is lemma-level because it is a logical conversion
           between hypotheses, not a separate theorem from
@@ -335,8 +335,8 @@ paper-level theorems.
           the identifier is the Unicode subscript used in the Lean declaration
           name.
     \item The BNT sector-weight recovery declarations
-          \leanid{weight_multiset_eq_of_sameMPV_bnt} and
-          \leanid{exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt}
+          \leanid{MPSTensor.matched_sector_weight_multiset_eq} and
+          \leanid{MPSTensor.matched_sector_weight_equiv}
           are lemma-level. They formalize the coefficient identity
           \begin{align}
               c_{S,j}^{(N)}
@@ -348,9 +348,9 @@ paper-level theorems.
           They do not add BNT theorems beyond the basis-normal-tensor
           comparison in Ref.~\cite{Cirac2016MPDO_arXiv}.
     \item The phase-matched sector-comparison adapters
-          \leanid{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch}
+          \path{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch}
           and
-          \leanid{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis}
+          \path{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis}
           are lemma-level. Their legacy names describe rectangular comparison
           adapters that transport the same coefficient and multiset formulas
           across a supplied phase or matched-basis identification. The

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -88,18 +88,65 @@ _TEX_PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
 _TEX_PROOF_END_RE = re.compile(r"\\end\{proof\}")
 
 
-def _split_lean_decls(payload: str) -> list[str]:
-    """Split the contents of a ``\\lean{...}`` tag into declaration names.
+def _is_escaped_tex_char(text: str, index: int) -> bool:
+    backslashes = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 1
+
+
+def _strip_tex_comments(payload: str) -> str:
+    parts: list[str] = []
+    index = 0
+    while index < len(payload):
+        if payload[index] == "%" and not _is_escaped_tex_char(payload, index):
+            newline = payload.find("\n", index)
+            if newline < 0:
+                break
+            index = newline + 1
+            while index < len(payload) and payload[index].isspace():
+                index += 1
+            continue
+        parts.append(payload[index])
+        index += 1
+    return "".join(parts)
+
+
+def split_tex_lean_decls(payload: str) -> list[str]:
+    """Split the contents of a TeX Lean-declaration tag into declaration names.
 
     Blueprint tags are often wrapped across several TeX source lines for
     readability.  Normalising whitespace here keeps the sync checker aligned
     with ``leanblueprint web``, whose generated ``lean_decls`` file includes
     declarations from both one-line and multi-line tags.
     """
-    payload = re.sub(r"%[^\n]*\n\s*", "", payload)
-    payload = re.sub(r"%[^\n]*$", "", payload)
-    normalised = re.sub(r"\s+", " ", payload)
-    return [decl.strip() for decl in normalised.split(",") if decl.strip()]
+    payload = _strip_tex_comments(payload)
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    for index, char in enumerate(payload):
+        if _is_escaped_tex_char(payload, index):
+            continue
+        if char in "([{":
+            depth += 1
+        elif char in ")]}" and depth > 0:
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(payload[start:index])
+            start = index + 1
+    parts.append(payload[start:])
+    return [
+        normalised
+        for part in parts
+        if (normalised := re.sub(r"\s+", " ", part).strip())
+    ]
+
+
+def _split_lean_decls(payload: str) -> list[str]:
+    """Backward-compatible wrapper for blueprint ``\\lean{...}`` payloads."""
+    return split_tex_lean_decls(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/paper_gap_leanid_sync.py
+++ b/scripts/paper_gap_leanid_sync.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+r"""Check ``docs/paper-gaps`` ``\leanid{...}`` references.
+
+The paper-gap notes use ``\leanid`` for prose-level Lean declaration citations.
+This script extracts the declaration head from each payload, writes the unique
+heads to a checkdecls-compatible file, and can invoke ``lake exe checkdecls`` so
+existence is checked by Lean's compiled environment rather than by source regexes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from blueprint_lean_sync import split_tex_lean_decls
+
+
+_MACRO_NAME = "leanid"
+_HEAD_STRIP_CHARS = "`$.,;:()[]{}"
+
+
+@dataclass(frozen=True)
+class LeanIdRef:
+    file: str
+    line: int
+    column: int
+    payload: str
+    head: str
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    backslashes = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 1
+
+
+def _line_col(text: str, index: int) -> tuple[int, int]:
+    line = text.count("\n", 0, index) + 1
+    line_start = text.rfind("\n", 0, index) + 1
+    return line, index - line_start + 1
+
+
+def _skip_tex_comment(text: str, index: int) -> int:
+    newline = text.find("\n", index)
+    return len(text) if newline < 0 else newline + 1
+
+
+def iter_tex_macro_payloads(text: str, macro_name: str = _MACRO_NAME) -> list[tuple[int, int, str]]:
+    r"""Return ``(offset, line, payload)`` triples for ``\macro_name{...}``.
+
+    The scanner ignores TeX comments outside macros and tracks braces in the
+    payload.  Braces in comments inside the payload are ignored, which matches
+    the percent-continuation style used in long ``\leanid`` names.
+    """
+    marker = "\\" + macro_name
+    payloads: list[tuple[int, int, str]] = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "%" and not _is_escaped(text, index):
+            index = _skip_tex_comment(text, index)
+            continue
+        if not text.startswith(marker, index):
+            index += 1
+            continue
+
+        after = index + len(marker)
+        if after < len(text) and text[after].isalpha():
+            index += 1
+            continue
+        cursor = after
+        while cursor < len(text) and text[cursor].isspace():
+            cursor += 1
+        if cursor >= len(text) or text[cursor] != "{":
+            index += 1
+            continue
+
+        start = cursor + 1
+        cursor = start
+        depth = 1
+        payload_parts: list[str] = []
+        while cursor < len(text) and depth > 0:
+            if text[cursor] == "%" and not _is_escaped(text, cursor):
+                comment_end = _skip_tex_comment(text, cursor)
+                payload_parts.append(text[cursor:comment_end])
+                cursor = comment_end
+                continue
+            if text[cursor] == "{" and not _is_escaped(text, cursor):
+                depth += 1
+            elif text[cursor] == "}" and not _is_escaped(text, cursor):
+                depth -= 1
+                if depth == 0:
+                    break
+            payload_parts.append(text[cursor])
+            cursor += 1
+
+        if depth == 0:
+            line, _ = _line_col(text, index)
+            payloads.append((index, line, "".join(payload_parts)))
+            index = cursor + 1
+        else:
+            index = start
+    return payloads
+
+
+def _normalise_tex_identifier_text(text: str) -> str:
+    text = text.replace(r"\_", "_")
+    text = text.replace(r"\.", ".")
+    text = text.replace(r"\-", "-")
+    text = text.replace("~", " ")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_lean_name_char(char: str) -> bool:
+    return char == "." or char == "_" or char == "'" or char.isalnum() or ord(char) >= 0x80
+
+
+def lean_decl_head(payload_item: str) -> str | None:
+    """Return the Lean declaration head cited by one normalized payload item."""
+    item = _normalise_tex_identifier_text(payload_item).strip(_HEAD_STRIP_CHARS)
+    if not item:
+        return None
+    cursor = 0
+    while cursor < len(item) and _is_lean_name_char(item[cursor]):
+        cursor += 1
+    head = item[:cursor].strip(".")
+    return head or None
+
+
+def collect_paper_gap_leanid_refs(paper_gaps_dir: Path, root: Path) -> list[LeanIdRef]:
+    refs: list[LeanIdRef] = []
+    for tex_file in sorted(paper_gaps_dir.glob("*.tex")):
+        text = tex_file.read_text(errors="replace")
+        rel = str(tex_file.relative_to(root))
+        for offset, line, payload in iter_tex_macro_payloads(text):
+            _, column = _line_col(text, offset)
+            for payload_item in split_tex_lean_decls(payload):
+                head = lean_decl_head(payload_item)
+                if head is None:
+                    continue
+                refs.append(
+                    LeanIdRef(
+                        file=rel,
+                        line=line,
+                        column=column,
+                        payload=payload_item,
+                        head=head,
+                    )
+                )
+    return refs
+
+
+def write_decl_list(refs: list[LeanIdRef], path: Path) -> None:
+    heads = sorted({ref.head for ref in refs})
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(heads) + ("\n" if heads else ""))
+
+
+def print_summary(refs: list[LeanIdRef]) -> None:
+    heads = sorted({ref.head for ref in refs})
+    print(
+        f"Found {len(refs)} \\leanid citation(s) with "
+        f"{len(heads)} unique declaration head(s)."
+    )
+
+
+def run_checkdecls(root: Path, decls_file: Path) -> int:
+    print(f"Checking paper-gap Lean declarations from {decls_file}")
+    return subprocess.run(
+        ["lake", "exe", "checkdecls", str(decls_file)],
+        cwd=root,
+        check=False,
+    ).returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract and check docs/paper-gaps \\leanid declaration heads."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write a checkdecls-compatible declaration list to this path.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run `lake exe checkdecls` on the generated declaration list.",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    paper_gaps_dir = root / "docs" / "paper-gaps"
+    if not paper_gaps_dir.is_dir():
+        raise FileNotFoundError(f"Paper-gap directory not found: {paper_gaps_dir}")
+
+    refs = collect_paper_gap_leanid_refs(paper_gaps_dir, root)
+    print_summary(refs)
+
+    output = args.output
+    if output is None:
+        output = root / "build" / "paper_gap_leanid_decls"
+    if not output.is_absolute():
+        output = root / output
+    write_decl_list(refs, output)
+    print(f"Wrote {len({ref.head for ref in refs})} declaration head(s) to {output}")
+
+    if args.check:
+        sys.exit(run_checkdecls(root, output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_blueprint_lean_sync.py
+++ b/scripts/test_blueprint_lean_sync.py
@@ -4,7 +4,16 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from blueprint_lean_sync import collect_file_lean_decls
+from blueprint_lean_sync import collect_file_lean_decls, split_tex_lean_decls
+
+
+def test_split_tex_lean_decls_handles_continuations_and_top_level_commas() -> None:
+    assert split_tex_lean_decls(
+        r"""
+Foo.%
+  bar (x, y), Baz.qux [a, b], Quux.{u}
+"""
+    ) == ["Foo.bar (x, y)", "Baz.qux [a, b]", "Quux.{u}"]
 
 
 def test_structure_fields_are_declarations() -> None:
@@ -52,5 +61,6 @@ end Example
 
 
 if __name__ == "__main__":
+    test_split_tex_lean_decls_handles_continuations_and_top_level_commas()
     test_structure_fields_are_declarations()
     print("Blueprint declaration scanner tests passed.")

--- a/scripts/test_paper_gap_leanid_sync.py
+++ b/scripts/test_paper_gap_leanid_sync.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for paper-gap ``\\leanid`` declaration extraction."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from paper_gap_leanid_sync import (
+    collect_paper_gap_leanid_refs,
+    lean_decl_head,
+    write_decl_list,
+)
+
+
+def _heads(source: str) -> list[str]:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        paper_gaps = root / "docs" / "paper-gaps"
+        paper_gaps.mkdir(parents=True)
+        (paper_gaps / "example.tex").write_text(source)
+        return [ref.head for ref in collect_paper_gap_leanid_refs(paper_gaps, root)]
+
+
+def _refs(source: str):
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        paper_gaps = root / "docs" / "paper-gaps"
+        paper_gaps.mkdir(parents=True)
+        (paper_gaps / "example.tex").write_text(source)
+        return collect_paper_gap_leanid_refs(paper_gaps, root)
+
+
+def test_comma_lists_percent_continuations_and_applied_arguments() -> None:
+    assert _heads(
+        r"""
+\leanid{MPOTensor.%
+  transportedVerticalSectorT_isKrausDirectSumMap,
+  WordTupleSpanTop S.basis 1, MPSTensor.majumdarGhosh\_left\_canonical}
+"""
+    ) == [
+        "MPOTensor.transportedVerticalSectorT_isKrausDirectSumMap",
+        "WordTupleSpanTop",
+        "MPSTensor.majumdarGhosh_left_canonical",
+    ]
+
+
+def test_comments_and_nonmatching_macros_do_not_create_references() -> None:
+    assert _heads(
+        r"""
+% \leanid{Ghost.Name}
+\leanidentifier{Also.Ghost}
+\leanid
+\leanid { Real.Name }
+"""
+    ) == ["Real.Name"]
+
+
+def test_head_stops_before_local_type_or_arguments() -> None:
+    assert lean_decl_head("hP : IsPeriodic m A") == "hP"
+    assert lean_decl_head("Matrix.exists_unitary_conj x y") == "Matrix.exists_unitary_conj"
+    assert lean_decl_head("TNLean.PEPS.regionBoundaryLabel_R₂_eq_of_union_sdiff)") == (
+        "TNLean.PEPS.regionBoundaryLabel_R₂_eq_of_union_sdiff"
+    )
+
+
+def test_nested_application_commas_do_not_create_extra_heads() -> None:
+    assert _heads(
+        r"""
+\leanid{Outer.head (alpha, beta), Inner.head [gamma, delta],
+  Wrapped.head {x, y}}
+"""
+    ) == ["Outer.head", "Inner.head", "Wrapped.head"]
+
+
+def test_source_locations_point_to_macro_start() -> None:
+    refs = _refs("\n  prose\n    \\leanid{Located.Name}\n")
+    assert len(refs) == 1
+    assert refs[0].file == "docs/paper-gaps/example.tex"
+    assert refs[0].line == 3
+    assert refs[0].column == 5
+
+
+def test_duplicates_are_preserved_in_refs_and_deduplicated_in_output() -> None:
+    refs = _refs(r"\leanid{Dup.Name, Dup.Name}")
+    assert [ref.head for ref in refs] == ["Dup.Name", "Dup.Name"]
+    with TemporaryDirectory() as tmp:
+        output = Path(tmp) / "decls"
+        write_decl_list(refs, output)
+        assert output.read_text() == "Dup.Name\n"
+
+
+def test_empty_and_malformed_payloads_are_ignored() -> None:
+    assert _heads(
+        r"""
+\leanid{}
+\leanid{  , , }
+\leanid{Unclosed.Name
+"""
+    ) == []
+
+
+if __name__ == "__main__":
+    test_comma_lists_percent_continuations_and_applied_arguments()
+    test_comments_and_nonmatching_macros_do_not_create_references()
+    test_head_stops_before_local_type_or_arguments()
+    test_nested_application_commas_do_not_create_extra_heads()
+    test_source_locations_point_to_macro_start()
+    test_duplicates_are_preserved_in_refs_and_deduplicated_in_output()
+    test_empty_and_malformed_payloads_are_ignored()
+    print("Paper-gap leanid sync tests passed.")


### PR DESCRIPTION
## Summary
- repair or qualify stale `\leanid{}` references across the paper-gap notes, and demote retired/private/module/local names to ordinary prose or `\path{}`
- add a paper-gap declaration extractor that understands applied declarations, TeX continuations, and top-level comma lists
- run the generated declaration list through `lake exe checkdecls` in PR CI so stale citations cannot regrow
- share the TeX payload splitter with the existing Blueprint sync checker and cover both scanners with focused tests

The new authoritative check resolves all 2,141 remaining citations (1,735 unique declaration heads). No compatibility aliases are introduced.

## Verification
- `lake exe checkdecls /tmp/tnlean-paper-gap-leanid-decls`
- `python3 scripts/test_blueprint_lean_sync.py`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `texra-blueprint paper-gaps check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Python syntax compilation and workflow YAML parse
- `git diff --check`

Closes #7219
