### PR TITLE
fix(paper-gaps): apply post-merge citation review

### DIFF
--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -368,7 +368,7 @@ without this stronger one-sided estimate.\footnote{The formal anchors are
     \leanid{MPSTensor.parentHamiltonian_gapped_of_overlap_norm_constant} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}.
     The projection-geometry results are in
-    \path{TNLean/Analysis/ProjectionGeometry.lean}. The declaration names
+    \path{QICLean/Analysis/ProjectionGeometry.lean}. The declaration names
     distinguish the ordered cross-term estimate from the sufficient
     norm-compression estimates. This note reserves ``anticommutator estimate''
     for the source condition and ``norm compression'' for the stronger local

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -92,10 +92,10 @@ difficult inclusion in
 Eq.~\ref{eq:cpgsv21_normal_range_reduction_periodic_ground_space} combines a
 complementary-word argument for $L_0+1<N$ with a full-ring cyclic change of cut
 for $N=L_0+1$.\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:885 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:738 for
 \leanid{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:923 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:776 for
 \leanid{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal
 hypotheses are named \leanid{Kraus.IsNormal A} and
 \leanid{Kraus.IsNBlkInjective A L0}, together with
@@ -113,11 +113,11 @@ available intersection theorem applies to a tensor that is already injective
 at one site. Its proof writes the identity as a linear combination of the
 one-site matrices $A_j$ and iterates the resulting single-letter intersection
 property through contiguous windows.\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:281--284 for
+\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:343 for
 \leanid{MPSTensor.groundSpace_intersection},
-\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:341--364 for
+\path{TNLean/MPS/Chain/OneSidedInverse.lean}:67 for
 \leanid{Kraus.decompositionMap hA 1}, and
-\path{TNLean/MPS/ParentHamiltonian/CyclicWindow.lean}:153--163 for the
+\path{TNLean/MPS/ParentHamiltonian/CyclicWindow.lean}:220--257 for the
 contiguous iteration.}
 For a normal tensor with injectivity length $L_0$, the available inverse acts
 on words of length $L_0$, not on individual letters. This does not contradict
@@ -131,9 +131,9 @@ chain belongs to its full MPS ground space. Cyclic-window monotonicity derives
 this conclusion from the cyclic length-$L$ constraints. This formalizes the
 iterated open-boundary argument without using the single-site intersection
 lemma.\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:266 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:107 for
 \leanid{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:328 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:169 for
 \leanid{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
 \section{The boundary block-window identity}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -252,7 +252,8 @@ pairs.\footnote{Formal theorem:
 \leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}.}
 Because this theorem operates on the unweighted basis direct sum rather than
 the raw weighted repeated-copy tensor,\footnote{Formal declarations:
-\leanid{MPSTensor.directSumTensor P.basis} and \path{P.toTensor}.} and because the
+\leanid{MPSTensor.directSumTensor P.basis} and
+\leanid{MPSTensor.SectorDecomposition.toTensor P}.} and because the
 source equations involve all copy pairs with their respective weight powers,
 unrestricted observable realization for the raw tensor remains separate.
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1716,47 +1716,28 @@ The remaining obligations are the following.
           tensor is the gauge action \(\operatorname{gaugeVertex} B\,X\,v\), so the extraction reads
           as the per-vertex gauge relation
           \(A_v=(c_S/c_R)\cdot\operatorname{gaugeVertex} B\,X\,v\)
-          (\leanid{TNLean.PEPS.component_eq_gaugeVertex_of_twoBlockProportional}), exactly the shape
-          of \path{hPV}. Consequently the torus scalar condition follows directly from the two
-          two-block proportionalities at every vertex with a common ratio
+          (\leanid{TNLean.PEPS.component_eq_gaugeVertex_of_twoBlockProportional}),
+          exactly the per-vertex relation concluded by the torus theorem. Consequently
+          the torus scalar condition follows directly from two-block proportionalities
+          at every vertex with a common ratio
           (\leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}).
 
-          An intermediate construction produced a \emph{single} per-edge family carrying the
-          absorbed equality at every edge. The conjugation-to-absorbed conversion is
-          packaged so the bare-edge
-          absorbed equality at a single edge follows from one coefficient-identity witness, depending
-          only on the gauge at that edge (the open-edge gauge cancellation isolates the boundary
-          edge), so the per-edge absorbing choices are independent
-          (\leanid{TNLean.PEPS.edgeAbsorbed_of_conjIdentity},
-          \leanid{TNLean.PEPS.edgeAbsorbed_of_edgeCoeffIdentityWitness}). Feeding the two
-          orientation-class coefficient-identity witness families to that conversion produces one
-          per-edge gauge family \(X\) --- the orientation-adapted absorbing gauge read off each chosen
-          witness --- for which the bare-edge absorbed equality against \(\operatorname{applyGauge}
-          B\,X\) holds at every torus edge
-          (\path{TNLean.PEPS.exists_edgeAbsorbed_torus_rectangle}). The region-independence step
-          then multiplies this back up to the region absorbed equality, supplying the comparison's
-          \path{hregion} and producing the region-block proportionality \(A_R\propto\widetilde B_R\)
-          at \emph{every} comparison region from the bare-edge equality
-          (\leanid{TNLean.PEPS.regionAbsorbed_of_edgeAbsorbed},
-          \leanid{TNLean.PEPS.twoBlockProportional_of_edgeAbsorbed}); the proportionality scalar is
-          unique once the comparison block is injective
-          (\leanid{TNLean.PEPS.twoBlockScalarProportional_unique}). The torus scalar condition is then
-          assembled from the bare-edge absorbed equality at the two one-site-different comparison
-          regions together with the per-vertex two-block proportionalities of common ratio, as the
-          unconditional torus theorem does
-          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}).
-
-          The proof of the completed unconditional torus Fundamental Theorem replaces
-          that independently chosen family by the translation-covariant family supplied
-          by \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}. The theorem
-          concludes: translation covariance of the absorbing family, expressed by
+          The completed proof obtains a translation-covariant absorbing family directly
+          from \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}. Its
+          bare-edge absorbed equality gives the two comparison-region proportionalities
+          through \leanid{TNLean.PEPS.twoBlockProportional_of_edgeAbsorbed}. Translation
+          covariance then makes the ratio \(c_S/c_R\) common across vertices via
+          \leanid{TNLean.PEPS.component_eq_gaugeVertex_of_cornerProportional}; no
+          uniqueness lemma for the proportionality scalar is used in this argument.
+          The resulting theorem
+          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional})
+          concludes translation covariance of the absorbing family, expressed by
           \leanid{TNLean.PEPS.IsTranslationCovariantGaugeFamily}; the absorbed
           inserted-coefficient equality at every edge; and a single scalar \(\lambda\)
           giving the per-vertex gauge relation with
-          \(\lambda^{\,\mathrm{width}\cdot\mathrm{height}}=1\). The comparison-region
-          injectivity and the common ratio \(c_S/c_R\), whose uniqueness uses
-          \leanid{TNLean.PEPS.twoBlockScalarProportional_unique}, are internal proof
-          ingredients rather than additional theorem conclusions.
+          \(\lambda^{\,\mathrm{width}\cdot\mathrm{height}}=1\). Comparison-region
+          injectivity and the ratio \(c_S/c_R\) are internal proof ingredients rather
+          than additional theorem conclusions.
     \item Distinguish the scalar conclusions in the open and periodic settings.
 
           The open-lattice square theorem chooses absorbing gauges independently on

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1402,74 +1402,29 @@ The remaining obligations are the following.
           gauge files. This is a finite engineering step with no further mathematical
           content: the gauge of a one-edge datum
           (\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_blockingData}) and the
-          single-crossing discharge are already in place. The orientation-uniform
-          reduction (obligation~6) and the boundary geometry (obligation~4) remain the
-          open mathematical pieces above this bridge.
+          single-crossing discharge were already in place. In that now-retired
+          skeleton, the orientation-uniform reduction (obligation~6) and the boundary
+          geometry (obligation~4) were the open mathematical pieces above this bridge.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.
 
-          The carrier of this reduction is now formalized. A square-lattice
-          bond-dimension function is orientation uniform when every horizontal edge
-          has one dimension and every vertical edge has another; given that, a single
-          horizontal matrix and a single vertical matrix determine a gauge family by
-          transport across the bond-dimension equalities, and a gauge family of this
-          shape is called orientation uniform. The absorption step incorporates such
-          an orientation-uniform family into the second tensor, preserving the
-          orientation-uniform bond dimensions and vertex injectivity; the
-          post-absorption edge-insertion equality is taken as the conditional kernel
-          input, in the shape produced unconditionally in the vertex-injective case.\footnote{
-          Formal declarations:
-          \path{TNLean.PEPS.SquareLatticeUniformBondDim},
-          \path{TNLean.PEPS.orientationUniformGauge},
-          \path{TNLean.PEPS.IsOrientationUniformGaugeFamily},
-          \path{TNLean.PEPS.exists_orientationUniformGaugeFamily},
-          \path{TNLean.PEPS.tiAbsorb},
-          \path{TNLean.PEPS.isVertexInjective_tiAbsorb},
-          \path{TNLean.PEPS.tiNormalGaugeAbsorption}, and
-          \path{TNLean.PEPS.exists_postAbsorption_of_vertexInjective}.}
+          A now-retired open-lattice translation-invariant skeleton formalized an
+          orientation-uniform gauge route. That route was removed because the open
+          coordinate lattice carries no translation action from which such covariance
+          can be derived. The current open-lattice construction instead chooses an
+          absorbing gauge independently at each interior edge and asserts no covariance
+          between distinct edges.\footnote{Current declarations:
+          \leanid{TNLean.PEPS.exists_normalSquareInteriorAbsorbedGaugeFamily} and
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional}.
+          The retired orientation-uniform apparatus is recorded in the section
+          ``Removal of the conditional square-lattice skeleton.''}
 
-          The uniqueness-up-to-scalar step is now formalized. The conjugating
-          matrix realizing a forward per-edge transfer is determined up to a
-          multiplicative constant: if two invertible matrices induce the same
-          conjugation on every bond matrix then their quotient commutes with the
-          whole bond matrix algebra, hence lies in its center, the scalars, so the
-          two differ by a nonzero constant. Reading this through the bond-dimension
-          reindexing gives the same statement for the per-edge transfer map of an
-          edge: two gauges with the same transfer map differ by a constant. This is
-          the source's statement that the horizontal and vertical matrices are unique
-          up to a multiplicative constant, at the level of a single edge.\footnote{
-          Formal declarations:
+          The surviving per-edge uniqueness result is weaker and does not assemble a
+          translation-covariant open-lattice family: two gauges realizing the same
+          transfer map differ by a nonzero scalar.\footnote{Formal declarations:
           \leanid{TNLean.PEPS.gl_conj_unique_scalar} and
           \leanid{TNLean.PEPS.edgeGauge_unique_scalar}.}
-
-          Because each per-edge gauge is fixed only up to a constant, the reduction
-          to one horizontal and one vertical matrix holds only up to a per-edge
-          scalar: a gauge family is orientation uniform up to scalars when each edge
-          gauge is the transported reference matrix rescaled by a nonzero per-edge
-          constant. The assembly across the two orientation classes is formalized:
-          collecting, on each class, the per-edge ``agree with the reference up to a
-          constant'' facts produces one orientation-uniform-up-to-scalar family, with
-          the exact orientation-uniform family as the all-constants-one
-          specialization.\footnote{
-          Formal declarations:
-          \path{TNLean.PEPS.IsOrientationUniformGaugeFamilyModScalar},
-          \path{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_isOrientationUniform},
-          and
-          \path{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_classAgreement}.}
-
-          The per-edge constants are absorbed at the absorption step when they are
-          vertex balanced. A per-edge scalar rescaling whose oriented product around
-          every vertex is one is a balanced edge-scalar reweighting, and such a
-          reweighting leaves the absorbed tensor unchanged. Hence the
-          scalar-carrying orientation-uniform gauge and the underlying exact
-          orientation-uniform gauge incorporate into the same modified second tensor,
-          so the conditional square-lattice theorem may consume an exact
-          orientation-uniform gauge even though the blocking delivers one only up to
-          balanced constants.\footnote{
-          Formal declarations:
-          \path{TNLean.PEPS.gaugeEquivModEdgeScalars_of_matrixScalar} and
-          \path{TNLean.PEPS.absorbEdgeGauges_eq_of_matrixScalar}.}
 
           The periodic lattice on which this transport lives is now formalized,
           together with the covariance of the blocking machinery under it. The
@@ -1506,21 +1461,20 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.isCrossingEdge_torusHorizontalRectangleBlockingDatum},
           and
           \leanid{TNLean.PEPS.isCrossingEdge_torusVerticalRectangleBlockingDatum}.}
-          The per-edge gauge interface applies verbatim on the torus (it is stated
-          over a general finite ordered vertex set), and the orientation-uniform
-          reduction is ported to the torus, so the assembly above a class-agreement
-          input is in place there too.\footnote{
-          Formal declarations:
-          \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus},
-          \path{TNLean.PEPS.torusOrientationUniformGauge},
-          \path{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar},
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement},
-          and
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant}.}
+          The per-edge gauge interface applies verbatim on the torus, since it is
+          stated over a general finite ordered vertex set. The surviving torus
+          assembly does not pass through a lexicographic orientation-uniform-up-to-
+          scalar family. Instead, it transports one reference witness per orientation
+          class and constructs a translation-covariant absorbed gauge family;
+          translations that reverse the stored endpoint order carry the gauge to its
+          transposed inverse.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.IsTranslationCovariantGaugeFamily} and
+          \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}.}
 
           The covariance of the region-inserted coefficient is now established, and
-          with it the determinacy that closes the class-agreement input above the
-          per-edge gauge of obligation~5. The region-inserted coefficient of a tensor
+          with it the transfer-map determinacy used in the transported-witness
+          development above the per-edge gauge of obligation~5. The region-inserted
+          coefficient of a tensor
           transported along a graph isomorphism, over the image region with the
           inserted matrix carried to the image bond and the boundary edge to its image,
           equals the original coefficient over the original region; the boundary
@@ -1543,37 +1497,20 @@ The remaining obligations are the following.
           The non-constructive transfer map of the gauge interface is determined by the
           coefficient identity it satisfies: with the second tensor's region and
           complement injective and positive bond dimensions, two matrix maps realizing
-          the same coefficient identity coincide. Hence the per-edge transfer map at a
-          translate equals the reference transfer map carried across the translation,
-          two independently chosen per-edge gauges realize the same conjugation map, and
-          the per-edge uniqueness up to scalar supplies the constants; gathering the two
-          orientation classes yields the orientation-uniform-up-to-scalar family.
-          \footnote{Formal declarations:
+          the same coefficient identity coincide. This identifies the conjugation maps
+          realized by two matched coefficient identities. In the surviving torus route,
+          the transported reference witnesses are converted directly into the
+          translation-covariant absorbed family rather than being assembled through a
+          lexicographic uniform-up-to-scalar predicate.\footnote{Formal declarations:
           \leanid{TNLean.PEPS.regionInsertedCoeff_transferMap_unique},
-          \path{TNLean.PEPS.regionTransferMap_eq_of_coeffIdentities}, and
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance}.}
-          The algebraic reduction from matched coefficient identities to the conjugation
-          covariance is now in place. The per-edge gauge at a torus edge carries its
-          defining coefficient identity, so the gauge conjugation itself satisfies the
-          identity. Reindexing across a bond-dimension equality commutes with
-          conjugation, identifying the transported reference matrix with the conjugation
-          by the reindexed reference. Two gauges realizing the same coefficient identity
-          by conjugation induce the same conjugation map on every bond matrix, by the
-          transfer-map determinacy. These supply, edge by edge, the conjugation
-          coincidence the orientation-uniform selection consumes.\footnote{Formal
-          declarations: \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
-          \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity_conj},
-          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities}, and
-          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities_target}.}
-          What remains is the geometric production of the two matched coefficient
-          identities at every edge: reading the per-edge gauge off the reference blocking
-          datum transported along each class translation, and matching its region and
-          boundary edge with those of the transported reference identity. The transported
-          blocking datum reads its three blocks from the translation, which may reorder
-          the edge endpoints and so place the reference red region in the blue slot; the
-          orientation-class matching must account for this branch. This construction
-          still depends on the open per-edge gauge of obligation~5 for the transfer maps
-          themselves.
+          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities},
+          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities_target}, and
+          \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}.}
+          The geometric input is the production of two matched coefficient identities
+          at every edge, obtained by transporting the reference blocking datum along
+          each class translation. A translation may reverse the stored endpoint order
+          and place the reference red region in the blue slot; the witness transport
+          accounts for this branch explicitly.
 
           The endpoint-reordering branch is now handled at the level of the gauge-interface
           inputs. The transported datum's complement block is always the image of the
@@ -1582,10 +1519,10 @@ The remaining obligations are the following.
           remaining two covers the host region of the red block and is injective under
           union closure. So both injectivity inputs the per-edge gauge consumes are
           available on both branches, with no case split, and the region-inserted
-          coefficient is endpoint-symmetric. What is left is to route the orientation-class
-          matching through the image of the reference red region rather than the
-          possibly-swapped red slot, which the region-polymorphic coefficient covariance
-          already supplies.\footnote{Formal declarations:
+          coefficient is endpoint-symmetric. The orientation-class matching is routed
+          through the image of the reference red region rather than the possibly swapped
+          red slot, using the region-polymorphic coefficient covariance.\footnote{
+          Formal declarations:
           \leanid{TNLean.PEPS.transportBlockingDataAlong_complement},
           \leanid{TNLean.PEPS.regionBlockedTensorInjective_transportBlockingDataAlong_red},
           and
@@ -1613,56 +1550,20 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.isCrossingEdge_torusHorizontalEdge}, and
           \leanid{TNLean.PEPS.isCrossingEdge_torusVerticalEdge}.}
 
-          Feeding this faithful datum to the per-edge gauge engine yields, at the reference
-          edge, the per-edge conjugation gauge realizing the region-insertion coefficient
-          identity, with the second tensor's red and host injectivities supplied by its own
-          rectangle hypotheses and union closure. The conjugation-covariance input the
-          orientation-uniform selection consumes is packaged as a per-edge coefficient-identity
-          witness — a region with single boundary edge $e$, the second tensor's
-          region and host injectivity, and the two coefficient identities the per-edge gauge
-          and the transported reference gauge realize. Each witness yields the conjugation
-          coincidence by the transfer-map determinacy, and gathering the two orientation
-          classes assembles the orientation-uniform-up-to-scalar family. The reference edge
-          inhabits this witness interface directly.
-
-          The translation production is now carried out. The reference coefficient identity,
-          realized by conjugation with the reference gauge, transports along each class
-          translation to the same identity at every edge of the class, realized by conjugation
-          with the reference gauge carried across the bond-dimension reindexing. The translated
-          region is the image of the reference region; the second tensor's image region and its
-          host are injective there by transport of the reference injectivities, since the
-          second tensor is fixed by the translation; and an arbitrary region or complement
-          configuration on the image region is the transport of a unique configuration on the
-          reference region. Composing the two reindexings of the transported gauge collapses to
-          the single transported orientation matrix the selection expects, so the per-edge
-          witness against that matrix holds at every edge. Gathering the horizontal and vertical
-          witness families through the orientation-uniform selection produces, from the source's
-          rectangle hypotheses on a translation-invariant pair, the
-          orientation-uniform-up-to-scalar family unconditionally: the per-edge gauge family is
-          the single reference matrix per class transported to every edge, the source's
-          ``$X$ and $Y$, the same matrix on all horizontal (vertical) edges'', with the per-edge
-          scalars all one.\footnote{Formal declarations:
+          Feeding this faithful datum to the per-edge gauge engine yields a reference
+          conjugation gauge and its region-insertion coefficient identity. The surviving
+          witness interface records the region, its single boundary edge, the required
+          injectivity, and the matched coefficient identities. Witness transport supplies
+          the horizontal and vertical families, while transfer-map determinacy identifies
+          the transported conjugations. The final constructor assembles these data directly
+          into the translation-covariant absorbed gauge family, including the
+          transpose-inverse branch when endpoint order reverses.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
           \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity_conj},
           \leanid{TNLean.PEPS.edgeCoeffIdentityWitness_translate},
-          \path{TNLean.PEPS.edgeCoeffIdentityWitness_translateUniform},
           \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_horizontalFamily},
           \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_verticalFamily}, and
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}.}
-
-          One strengthening remains. The family produced above takes the per-edge gauge to be the
-          transported reference matrix itself, so the witness's two coefficient identities are the
-          same single identity and the per-edge scalars are all one. The source's stronger claim is
-          that \emph{any} per-edge gauge independently produced by the edge-blocking engine at each
-          edge agrees with the transported reference up to a scalar. Reading that independent engine
-          gauge over the image of the reference region requires a blocking datum at the translated
-          edge whose red block is the image of the reference red block; but the lexicographic edge
-          convention reorders the endpoints under a wraparound translation, so the transported
-          datum's red block is the image of the reference \emph{blue} block on that branch, and the
-          reference coefficient identity — tied to the reference red region — does not transport to
-          it. Closing the independent-gauge strengthening therefore needs a branch-free reference
-          identity (one stated over the reference region's host orientation as well), which the
-          present reference engine does not supply. The unconditional family above does not depend
-          on this strengthening.
+          \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}.}
 
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective
@@ -1734,34 +1635,20 @@ The remaining obligations are the following.
           which is what the region comparison \leanid{TNLean.PEPS.regionComplement_comparison}
           consumes.
 
-          On the torus the per-edge coefficient identity is produced at a single boundary edge of
-          each \emph{red blocking region} of the orientation-uniform family
-          (\leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}). The
-          per-vertex relation \(A_v=\lambda\cdot\operatorname{gaugeVertex} B\,X\,v\) that the
-          torus Fundamental Theorem
-          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}) takes as the hypothesis
-          \path{hPV} still needs two pieces above the region-independence just recorded. First, the
-          absorbing matrix \leanid{TNLean.PEPS.absorbedBoundaryGauge} is the orientation-adapted
-          transpose of each \emph{per-edge} engine gauge \(Z_e\), so the absorbed equality holds
-          against a per-edge absorbing family rather than against the single
-          orientation-uniform \(X=\operatorname{torusOrientationUniformGauge}\) that
-          \path{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}
-          returns and that \path{hPV} is stated against; reconciling the per-edge absorbing family
-          with that orientation-uniform \(X\) (the transpose/orientation bookkeeping across the two
-          orientation classes) is the first open piece. Second, feeding the absorbed equality to
-          \leanid{TNLean.PEPS.regionComplement_comparison} at the source comparison regions \(R\)
-          and \(S\) (which differ in one site, both blocked-tensor injective with injective
-          complements) gives \(A_R\propto\widetilde B_R\) and \(A_S\propto\widetilde B_S\);
-          quotienting the two region proportionalities to isolate the single differing vertex is
-          the second open piece. The block-granularity one-site quotient that performs this
-          isolation without single-vertex injectivity --- the region analogue of
-          \leanid{TNLean.PEPS.perVertexScalar}, whose present form rests on
-          \leanid{TNLean.PEPS.one_vertex_complement_comparison} and edge-level vertex injectivity
-          --- needs a factorization of the blocked-region weight of \(\operatorname{withSite} v\)
-          through the blocked-region weight of \(\operatorname{withoutSite} v\) and the single
-          vertex tensor at \(v\) (the one-vertex analogue of
-          \leanid{TNLean.PEPS.regionBlockedWeight_eq_localTensorMap}).
+          On the torus, the transported witness families and the covariant absorbed
+          constructor supply one gauge family with the absorbed coefficient identity at
+          every edge. Feeding this equality to
+          \leanid{TNLean.PEPS.regionComplement_comparison} at the one-site-different
+          comparison regions \(R\) and \(S\) gives
+          \(A_R\propto\widetilde B_R\) and \(A_S\propto\widetilde B_S\). The landed
+          block-granularity quotient described next isolates the differing vertex without
+          assuming single-site injectivity; the subsequent scalar extraction turns these
+          proportionalities into the per-vertex relation concluded by
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}. The
+          comparison uses the factorization of the blocked-region weight of
+          \(\operatorname{withSite} v\) through the weight of
+          \(\operatorname{withoutSite} v\) and the tensor at \(v\), the block analogue of
+          \leanid{TNLean.PEPS.regionBlockedWeight_eq_localTensorMap}.
 
           The foundational layer of this quotient is now landed. Writing the differing regions as
           \(S=\operatorname{insert} v\,R\) with \(v\notin R\), the vertex product over the sites of
@@ -1834,8 +1721,9 @@ The remaining obligations are the following.
           two-block proportionalities at every vertex with a common ratio
           (\leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}).
 
-          The production of a \emph{single} per-edge family carrying the absorbed equality at every
-          edge is now landed. The conjugation-to-absorbed conversion is packaged so the bare-edge
+          An intermediate construction produced a \emph{single} per-edge family carrying the
+          absorbed equality at every edge. The conjugation-to-absorbed conversion is
+          packaged so the bare-edge
           absorbed equality at a single edge follows from one coefficient-identity witness, depending
           only on the gauge at that edge (the open-edge gauge cancellation isolates the boundary
           edge), so the per-edge absorbing choices are independent
@@ -1858,48 +1746,31 @@ The remaining obligations are the following.
           unconditional torus theorem does
           (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}).
 
-          What remains for an unconditional \path{hPV}, and hence for an unconditional torus
-          Fundamental Theorem, are three pieces, all consuming the landed \(X\) above. First, the
-          \emph{orientation-uniformity} of that absorbing family --- that it is one horizontal matrix
-          and one vertical matrix up to per-edge scalars, the shape the Fundamental Theorem's gauge
-          conclusion \path{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar} asserts. The
-          absorbing matrix \leanid{TNLean.PEPS.absorbedBoundaryGauge} is \(Z^{\mathsf T}\) or
-          \(Z^{-1}\) according to whether the boundary edge's left endpoint lies in the red blocking
-          region, and the engine gauge \(Z_e\) is the transported reference; both are
-          orientation-determined, but the endpoint-membership branch varies across the translates of
-          a class with wraparound, which is the transpose/orientation bookkeeping that remains.
-          Second, the blocked-tensor injectivity of the comparison regions of the reindexed
-          \(\operatorname{applyGauge} B\,X\) (the gauge-absorbed analogue of the rectangle injectivity
-          of \(B\)), and of \(A\)'s one-site-different comparison regions and their complements.
-          Third, the translation-invariant common ratio \(c_S/c_R\) of the
-          (now uniquely-named, \leanid{TNLean.PEPS.twoBlockScalarProportional_unique}) proportionality
-          scalars across the vertices. The scalar extraction itself is no longer on the critical
-          path.
-    \item Prove the scalar condition $\lambda^{nm}=1$ for the square-lattice
-          theorem, and state separately the scalar freedom in the non-translation
-          invariant normal theorem.
+          The proof of the completed unconditional torus Fundamental Theorem replaces
+          that independently chosen family by the translation-covariant family supplied
+          by \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily}. The theorem
+          concludes: translation covariance of the absorbing family, expressed by
+          \leanid{TNLean.PEPS.IsTranslationCovariantGaugeFamily}; the absorbed
+          inserted-coefficient equality at every edge; and a single scalar \(\lambda\)
+          giving the per-vertex gauge relation with
+          \(\lambda^{\,\mathrm{width}\cdot\mathrm{height}}=1\). The comparison-region
+          injectivity and the common ratio \(c_S/c_R\), whose uniqueness uses
+          \leanid{TNLean.PEPS.twoBlockScalarProportional_unique}, are internal proof
+          ingredients rather than additional theorem conclusions.
+    \item Distinguish the scalar conclusions in the open and periodic settings.
 
-          The square-lattice scalar condition is formalized: when all per-vertex
-          scalars equal a single $\lambda$, their product over the
-          $\text{width}\times\text{height}$ lattice is $\lambda$ raised to the site
-          count, which the injective theorem forces to be one, giving
-          $\lambda^{\,\text{width}\cdot\text{height}}=1$. The square-lattice theorem
-          skeleton records the top-down assembly: from the orientation-uniform gauge
-          absorption datum and the per-vertex single-scalar relation (the region
-          comparison output) the scalar condition follows. A second entry to the same
-          assembly consumes the gauge in the shape the edge blocking actually
-          delivers: an orientation-uniform gauge fixed only up to vertex-balanced
-          per-edge constants, which absorb identically, so the exact
-          orientation-uniform reference carries the post-absorption equality and the
-          per-vertex relation against it yields the same scalar condition. Both
-          skeletons remain conditional on the open per-edge gauge of
-          obligation~5.\footnote{
-          Formal declarations:
-          \path{TNLean.PEPS.card_squareLatticeVertex},
-          \leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one},
+          The open-lattice square theorem chooses absorbing gauges independently on
+          interior edges and concludes a per-vertex scalar relation on the interior
+          comparison window; it asserts neither one global scalar nor a power-one
+          condition. The periodic torus theorem instead concludes a single scalar
+          \(\lambda\) for every vertex and
+          \(\lambda^{\,\mathrm{width}\cdot\mathrm{height}}=1\). The general-graph
+          normal theorem states gauge equivalence under its blocking, single-crossing,
+          same-state, positivity, and connectivity hypotheses without adding the torus
+          scalar constraint.\footnote{Formal declarations:
           \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional},
-          \path{TNLean.PEPS.tiNormalGaugeAbsorptionData_of_modScalar}, and
-          \path{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_of_modScalarGauge}.}
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}, and
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalPEPS}.}
 \end{enumerate}
 
 \section{Source-to-formalization ledger}
@@ -2415,11 +2286,15 @@ The conditional square-lattice skeleton recorded earlier in this note has been
 removed. Its assembly assumed single-site injectivity of $A$
 (\path{IsVertexInjective}), the hypothesis the normal theorem exists to avoid: its
 scalar condition rested on the vertex-injective product identity rather than the
-region-injective one (\path{prod_perVertexScalar_eq_one_of_regionInjective}), and
-the interior-window open-lattice theorem
-(\path{fundamentalTheorem_normalSquarePEPS_unconditional}) and the general-graph
-gauge-equivalence theorem (\path{fundamentalTheorem_normalPEPS}) now cover the
-square-lattice content from region injectivity alone. Gone are: the conditional
+region-injective one (\path{prod_perVertexScalar_eq_one_of_regionInjective}). The
+interior-window open-lattice theorem
+\leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional} and the
+general-graph gauge-equivalence theorem
+\leanid{TNLean.PEPS.fundamentalTheorem_normalPEPS} now cover the corresponding
+square-lattice content without single-site injectivity: the former uses the stated
+rectangle-injectivity, matched-bond, same-state, and positivity hypotheses, while
+the latter uses the paired blocking, single-crossing, same-state, positivity, and
+connectivity hypotheses. Gone are: the conditional
 statements themselves (\path{fundamentalTheorem_normalSquarePEPS},
 \path{fundamentalTheorem_normalSquarePEPS_of_modScalarGauge},
 \path{lambda_pow_card_eq_one}, \path{card_squareLatticeVertex}); the

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -64,19 +64,21 @@ intertwiner has the usual permutation-and-phase interpretation
 
 The checked Chapter~9 block-separation lemmas do not formalize
 Theorem~\texttt{thm-uniq} of Ref.~\cite{PerezGarcia2007MPSReps}. They compare
-representations that already have the same block structure. Their hypotheses
-include blockwise normalization, injective or irreducible blocks, a common
-block index set, a common block-dimension function, and strict ordering of
-weight moduli.\footnote{The formal declarations are
+block families that already share a block index set and block-dimension
+function. Their substantive hypotheses are blockwise injectivity of the first
+family and equality of the corresponding MPV families; the global and
+canonical-form variants retain the same block correspondence and use a common,
+otherwise arbitrary, weight function. They assume neither blockwise
+normalization nor strict ordering of weight moduli.\footnote{The formal declarations are
 \leanid{MPSTensor.fundamentalTheorem_multiBlock_blocks},
 \leanid{MPSTensor.fundamentalTheorem_multiBlock_global},
 \leanid{MPSTensor.fundamentalTheorem_canonicalForm_sameStructure}, and
 \leanid{MPSTensor.fundamentalTheorem_multiBlock_explicit}.}
 
-These assumptions are useful in local MPS arguments, but they are not the
-source hypotheses. In particular, the source theorem does not assume that the
-representations have a common prepared block decomposition, nor does it assume
-the Chapter~9 strict-modulus separation result. Its proof instead uses
+These same-structure assumptions are useful in local MPS arguments, but they
+are not the source hypotheses. In particular, the source theorem does not
+assume that the representations have a common prepared block decomposition.
+Its proof instead uses
 uniqueness of the OBC canonical representation and the Horn--Johnson
 matrix-lemma route described after Theorem~\texttt{thm-uniq} in
 Ref.~\cite{PerezGarcia2007MPSReps}.
@@ -97,9 +99,11 @@ provide one unitary $U$ satisfying
 (\ref{eq:pgvwc07_ti_uniqueness_scope_unitary_intertwiner}) for every physical
 index.
 
-The current Chapter~9 block-separation lemmas may support such a proof only
-after their stronger same-structure and strict-modulus hypotheses have been
-derived within the argument. They cannot replace the source theorem.
+The current same-structure lemmas may support such a proof only after the
+source argument has produced a common block correspondence and established,
+block by block, equality of the corresponding matrix product vector families.
+They do not themselves derive that correspondence from finite-ring state
+equality and therefore cannot replace the source theorem.
 
 \section{Tracked consequences}
 

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -180,7 +180,7 @@ formal identifier or source-file link does not replace either step.
 All notes in this directory must load
 \path{docs/paper-gaps/command.tex}. Shared notation belongs there. In
 particular, use the shared commands \verb|\tr| and \verb|\leanid| to produce
-$\tr(X)$ and \path{someDeclaration}; do not redefine them in an individual
+$\tr(X)$ and \leanid{someDeclaration}; do not redefine them in an individual
 note. This rule keeps the documents visually consistent and prevents
 contradictory local conventions.
 

--- a/docs/paper-gaps/template.tex
+++ b/docs/paper-gaps/template.tex
@@ -102,7 +102,7 @@ hypotheses; it does not derive $\mathcal K$ from the original assumptions.
 If the formal development proves (\ref{eq:model_corrected_statement}), state
 that fact in prose and identify the exact formal declaration in a
 footnote.\footnote{Model formal declaration:
-    \path{modelCorrected} in \doclink{TNLean/Path/To/File}.}
+    \leanid{modelCorrected} in \doclink{TNLean/Path/To/File}.}
 The formal declaration is evidence for the corrected mathematical statement; it
 does not replace its mathematical explanation.
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -88,7 +88,8 @@ _TEX_PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
 _TEX_PROOF_END_RE = re.compile(r"\\end\{proof\}")
 
 
-def _is_escaped_tex_char(text: str, index: int) -> bool:
+def is_escaped_tex_char(text: str, index: int) -> bool:
+    """Return whether the character at ``index`` is escaped in TeX source."""
     backslashes = 0
     cursor = index - 1
     while cursor >= 0 and text[cursor] == "\\":
@@ -101,7 +102,7 @@ def _strip_tex_comments(payload: str) -> str:
     parts: list[str] = []
     index = 0
     while index < len(payload):
-        if payload[index] == "%" and not _is_escaped_tex_char(payload, index):
+        if payload[index] == "%" and not is_escaped_tex_char(payload, index):
             newline = payload.find("\n", index)
             if newline < 0:
                 break
@@ -127,7 +128,7 @@ def split_tex_lean_decls(payload: str) -> list[str]:
     start = 0
     depth = 0
     for index, char in enumerate(payload):
-        if _is_escaped_tex_char(payload, index):
+        if is_escaped_tex_char(payload, index):
             continue
         if char in "([{":
             depth += 1

--- a/scripts/paper_gap_leanid_sync.py
+++ b/scripts/paper_gap_leanid_sync.py
@@ -16,11 +16,16 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from blueprint_lean_sync import split_tex_lean_decls
+from blueprint_lean_sync import is_escaped_tex_char, split_tex_lean_decls
 
 
 _MACRO_NAME = "leanid"
 _HEAD_STRIP_CHARS = "`$.,;:()[]{}"
+# Intentional placeholders used to document the macro in policy/template prose.
+_EXAMPLE_PLACEHOLDER_HEADS = {
+    "policy.tex": {"someDeclaration"},
+    "template.tex": {"modelCorrected"},
+}
 
 
 @dataclass(frozen=True)
@@ -30,15 +35,6 @@ class LeanIdRef:
     column: int
     payload: str
     head: str
-
-
-def _is_escaped(text: str, index: int) -> bool:
-    backslashes = 0
-    cursor = index - 1
-    while cursor >= 0 and text[cursor] == "\\":
-        backslashes += 1
-        cursor -= 1
-    return backslashes % 2 == 1
 
 
 def _line_col(text: str, index: int) -> tuple[int, int]:
@@ -64,7 +60,7 @@ def iter_tex_macro_payloads(text: str, macro_name: str = _MACRO_NAME) -> list[tu
     index = 0
     while index < len(text):
         char = text[index]
-        if char == "%" and not _is_escaped(text, index):
+        if char == "%" and not is_escaped_tex_char(text, index):
             index = _skip_tex_comment(text, index)
             continue
         if not text.startswith(marker, index):
@@ -87,14 +83,14 @@ def iter_tex_macro_payloads(text: str, macro_name: str = _MACRO_NAME) -> list[tu
         depth = 1
         payload_parts: list[str] = []
         while cursor < len(text) and depth > 0:
-            if text[cursor] == "%" and not _is_escaped(text, cursor):
+            if text[cursor] == "%" and not is_escaped_tex_char(text, cursor):
                 comment_end = _skip_tex_comment(text, cursor)
                 payload_parts.append(text[cursor:comment_end])
                 cursor = comment_end
                 continue
-            if text[cursor] == "{" and not _is_escaped(text, cursor):
+            if text[cursor] == "{" and not is_escaped_tex_char(text, cursor):
                 depth += 1
-            elif text[cursor] == "}" and not _is_escaped(text, cursor):
+            elif text[cursor] == "}" and not is_escaped_tex_char(text, cursor):
                 depth -= 1
                 if depth == 0:
                     break
@@ -144,6 +140,8 @@ def collect_paper_gap_leanid_refs(paper_gaps_dir: Path, root: Path) -> list[Lean
             for payload_item in split_tex_lean_decls(payload):
                 head = lean_decl_head(payload_item)
                 if head is None:
+                    continue
+                if head in _EXAMPLE_PLACEHOLDER_HEADS.get(tex_file.name, set()):
                     continue
                 refs.append(
                     LeanIdRef(

--- a/scripts/test_paper_gap_leanid_sync.py
+++ b/scripts/test_paper_gap_leanid_sync.py
@@ -11,12 +11,12 @@ from paper_gap_leanid_sync import (
 )
 
 
-def _heads(source: str) -> list[str]:
+def _heads(source: str, filename: str = "example.tex") -> list[str]:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
         paper_gaps = root / "docs" / "paper-gaps"
         paper_gaps.mkdir(parents=True)
-        (paper_gaps / "example.tex").write_text(source)
+        (paper_gaps / filename).write_text(source)
         return [ref.head for ref in collect_paper_gap_leanid_refs(paper_gaps, root)]
 
 
@@ -98,6 +98,15 @@ def test_empty_and_malformed_payloads_are_ignored() -> None:
     ) == []
 
 
+def test_intentional_policy_placeholders_are_scoped_to_their_files() -> None:
+    assert _heads(r"\leanid{modelCorrected}", "template.tex") == []
+    assert _heads(r"\leanid{someDeclaration}", "policy.tex") == []
+    assert _heads(r"\leanid{modelCorrected, someDeclaration}") == [
+        "modelCorrected",
+        "someDeclaration",
+    ]
+
+
 if __name__ == "__main__":
     test_comma_lists_percent_continuations_and_applied_arguments()
     test_comments_and_nonmatching_macros_do_not_create_references()
@@ -106,4 +115,5 @@ if __name__ == "__main__":
     test_source_locations_point_to_macro_start()
     test_duplicates_are_preserved_in_refs_and_deduplicated_in_output()
     test_empty_and_malformed_payloads_are_ignored()
+    test_intentional_policy_placeholders_are_scoped_to_their_files()
     print("Paper-gap leanid sync tests passed.")


### PR DESCRIPTION
## Summary
- share TeX escape detection between the Blueprint and paper-gap scanners instead of maintaining duplicate implementations
- restore the `\leanid` examples in `policy.tex` and `template.tex`, with an explicit two-name placeholder exemption covered by tests
- correct stale source locations and the QICLean projection-geometry path
- align the PEPS route note with the surviving translation-covariant gauge construction and actual theorem conclusions
- correct the stated hypotheses of the PGVWC07 same-structure lemmas and restore a live `SectorDecomposition.toTensor` citation

This applies the actionable post-merge review on #7253. It does not change Lean declarations or proofs.

## Verification
- `python3 scripts/test_blueprint_lean_sync.py`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- generated 2,147 paper-gap citations / 1,737 unique heads and passed `lake exe checkdecls`
- `texra-blueprint paper-gaps check`
- reader-facing prose check
- no newly added lines over 100 columns
- `git diff --check`

Follow-up to #7253
