### PR TITLE
docs(MPDO): repoint QICLean paper-gap citations

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -154,10 +154,10 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   only that, for each sector `j`, the coefficient sequence
   `c_N^{(j)} = ∑_q μ_{j,q}^N` is not eventually zero in `N`, not that some
   specific copy `q` of sector `j` has `‖μ_{j,q}‖ = 1`.  See
-  `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` for the closed
-  global-versus-per-sector audit. For the separate interaction between this
+  <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_global_vs_persector_unit_witness.pdf>
+  for the closed global-versus-per-sector audit. For the separate interaction between this
   source convention and the scale fixed by MPDO renormalization, see
-  `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
+  <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>. -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
 

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
@@ -522,7 +522,8 @@ tensor. The raw tensor here has doubled-transfer spectral radius `5 / 16` and
 does not meet that normalization. Its normalized representative loses the
 paper's literal zero-correlation-length identity. Thus this theorem records the
 normalization obstruction but does not refute Lemma C.5 under its complete
-standing hypotheses. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+standing hypotheses. Documented in
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Case I at lines 1374--1381 and Lemma
 `SALZCL` at lines 1473--1499. -/

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -34,7 +34,7 @@ The same tensor also has an explicit one-sector factorization with a positive,
 trace-one neighboring operator.  Thus the selected four-sector factorization is
 nonminimal.  This observation concerns only the displayed tensor and does not
 settle the general absorbed-representative assertion documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 ## Main result
 
@@ -278,7 +278,7 @@ two controls the right Pauli \(Z\).
 **Scope restriction (one explicit tensor):** This construction proves only
 that the selected four-sector inverse-map factorization is nonminimal for this
 tensor.  It does not settle the general factorization assertion documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Derived from the physical-sector identity in arXiv:1606.00608, Appendix C.2,
 equation `AppUkU=rl`, lines 1381--1388. -/
@@ -374,7 +374,7 @@ physical factorization.
 **Scope restriction (one explicit tensor):** This construction proves only
 that the selected four-sector inverse-map factorization is nonminimal for this
 tensor.  It does not settle the general factorization assertion documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Derived from the neighboring-trace identities in arXiv:1606.00608,
 Appendix C.2, lines 1389--1403. -/
@@ -400,7 +400,7 @@ trace factors with normalized product.
 selected four-sector inverse-map factorization is nonminimal for this tensor.
 It neither supplies a coarsening result for arbitrary physical-sector
 factorizations nor settles the general assertion documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Derived from the physical-sector and neighboring-trace identities in
 arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`, lines
@@ -561,7 +561,7 @@ source-selected inverse-map identification is proved separately in
 `inverseMap_provenance_preserves_rectangular_remainder`.
 
 **Scope restriction (non-normal representative):** documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>. -/
 theorem virtual_spanning_does_not_force_rectangular_remainder_zero :
     tensor.IsInjective ∧ tensor.IsSourceZCL ∧
       physTraceTransfer tensor * physTraceTransfer tensor = physTraceTransfer tensor ∧

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningRFP.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningRFP.lean
@@ -253,7 +253,7 @@ satisfy the global unit-weight canonical normalization, while the Lean
 predicate `IsRFPViaTS` records only the two channel equations. Thus this
 theorem is not an instance of Definition 4.1 for the raw representative.
 Documented in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 This is a classification of this explicit tensor, not a proof of the general
 strong-area-law and zero-correlation-length implication in Theorem 4.9.
@@ -273,7 +273,7 @@ coarse-graining and refinement maps twice and passing to blocked coordinates.
 inherits the scope restriction of `tensor_isRFPViaTS`. It proves the two channel
 equations after blocking, but does not supply the canonical-form hypothesis of
 Definition 4.1. Documented in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 This proves the bare channel equations for this witness only; it does not prove
 the universal implication from the hypotheses of Theorem 4.9.
@@ -343,7 +343,7 @@ outer labels `k,h` in the selected four-sector factorization.
 **Scope restriction (selected four-sector factorization):** this excludes
 only the inverse-map-selected four-sector decomposition.  It does not exclude
 mixing or coarsening those labels, nor a different physical-sector
-factorization.  Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+factorization.  Documented in <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Derived from the sector-controlled, twice-iterated maps in
 arXiv:1606.00608, Appendix C.2, lines 1522--1555 and 1821--1825. -/
@@ -371,7 +371,7 @@ labels `k,h` in the selected four-sector factorization.
 **Scope restriction (selected four-sector factorization):** this excludes
 only the inverse-map-selected four-sector decomposition.  It does not exclude
 mixing or coarsening those labels, nor a different physical-sector
-factorization.  Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+factorization.  Documented in <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Derived from the sector-controlled, twice-iterated maps in
 arXiv:1606.00608, Appendix C.2, lines 1522--1555 and 1821--1825. -/
@@ -402,8 +402,8 @@ This does not contradict the pair-preserving obstructions above: the bare
 pair of a chosen nonminimal decomposition.
 
 **Scope restriction (bare predicate and selected decomposition):** documented
-in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex` and
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+in <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf> and
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source comparison: arXiv:1606.00608, Definition 4.1, lines 645--659, and the
 sector-projected construction at Appendix C.2, lines 1810--1825. -/

--- a/TNLean/MPS/MPDO/BNTChannelComposition.lean
+++ b/TNLean/MPS/MPDO/BNTChannelComposition.lean
@@ -716,7 +716,7 @@ source hypotheses, this theorem assumes that the outer support projections
 resolve the physical identity (`hPsum`) and that every absorbed representative
 already has a blocked renormalization channel pair (`hRFP`). These two
 obligations and their elimination plans are recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`: prove projector completeness from
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>: prove projector completeness from
 the source hypotheses and construct the representative channel pairs. -/
 theorem blockTwo_isRFPViaTS_of_commonWeightAbsorbedBNTChannels
     (S : MPSTensor.SectorDecomposition (d * d))

--- a/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
+++ b/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
@@ -80,7 +80,7 @@ neighboring trace factorizations of the absorbed representatives are assumed
 here, while Proposition `prop2to5` derives them from the strong area law and
 zero correlation length through the printed factorization assertion of
 Proposition `prop2to3`.  That derivation remains open; it is documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817; the closing proof at lines 1821--1825; and the weight
@@ -124,7 +124,7 @@ four selected sectors.
 **Scope restriction (supplied per-representative factorizations):** the
 single-sector factorizations are assumed here rather than derived from the
 strong area law and zero correlation length; the derivation is documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817, and lines 1389--1403. -/

--- a/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
@@ -82,7 +82,7 @@ the absorbed BNT representative, but not spectral normality. Coefficient absorpt
 transfer spectral radius by the squared modulus of the coefficient, and the global canonical-form
 normalization does not make every coefficient unit modulus. Thus the normal Case-I theorem cannot
 yet be applied sectorwise. The remaining boundary is recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1745--1782. -/
 theorem commonWeightAbsorbedBasisMPOTensor_physTraceTransfer_sq_of_literal_ZCL

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -400,7 +400,7 @@ It does not assert `MPSTensor.IsNormalTensor`: coefficient absorption rescales t
 spectral radius by the squared coefficient modulus, while the global canonical-form normalization
 does not force every coefficient to have modulus one. The normal Case-I structural theorem
 therefore remains unavailable sectorwise. This boundary is recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1745--1782. -/
 theorem commonWeightAbsorbedBasisMPOTensor_caseII_properties_of_literal_ZCL

--- a/TNLean/MPS/MPDO/BondOnePhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/BondOnePhysicalSectorFactorization.lean
@@ -48,7 +48,7 @@ tensor.
 **Scope restriction (virtual bond dimension one):** This is a boundary
 specialization of the physical-sector assertion in CPSV16 Theorem 4.9.  It
 does not establish the unrestricted all-sector statement documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
 1381--1388, and equation `etarl`, lines 1441--1450. -/
@@ -151,7 +151,7 @@ factorization $1=1\cdot1$.
 **Scope restriction (virtual bond dimension one):** This is a conditional
 boundary specialization of CPSV16 Theorem 4.9 and Appendix C.2.  It does not
 prove the unrestricted absorbed-BNT representative assertion documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Theorem 4.9 and Appendix C.2, lines 1381--1403,
 1441--1450, and 1647--1782. -/
@@ -178,7 +178,7 @@ physical-sector conclusion at virtual bond dimension one.
 **Scope restriction (virtual bond dimension one):** This theorem is a
 conditional boundary specialization of CPSV16 Theorem 4.9.  The unrestricted
 all-sector assertion is documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Theorem 4.9 and Appendix C.2, lines 1381--1403,
 1441--1450, and 1647--1782. -/

--- a/TNLean/MPS/MPDO/CPSVExample412Literal.lean
+++ b/TNLean/MPS/MPDO/CPSVExample412Literal.lean
@@ -31,7 +31,8 @@ satisfies the project's scale-invariant `IsSourceZCL` relation with scale $2$,
 but it fails the paper's literal ZCL equation and is not an RFP via
 trace-preserving physical maps. The separate likely normalized representative
 $(1/2)\,M$ is discussed in
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex` and is not treated here.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>
+and is not treated here.
 
 ## References
 
@@ -327,7 +328,7 @@ $(I+\sigma_z)^2=2(I+\sigma_z)$.
 **Local fix (normalization):** Definition 4.2 of the source requires literal
 idempotence, whereas the tensor printed in Example 4.12 satisfies only this
 scale-two relation. See
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, line 937. -/
 theorem physTraceTransfer_M_sq :
@@ -345,7 +346,7 @@ relation with the explicit positive scale $\lambda=2$.
 therefore broader than the literal idempotence in CPSV16 Definition 4.2. This
 theorem records the corrected scale-two relation for the printed tensor, not
 the paper's literal ZCL assertion. See
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, line 937. -/
 theorem M_isSourceZCL : IsSourceZCL M := by
@@ -360,7 +361,7 @@ normalization mismatch hidden by the source's statement that the same printed
 representative is an RFP.
 
 **Local fix (normalization):** see
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, lines 937--938. -/
 theorem physTraceTransfer_M_not_idempotent :
@@ -375,7 +376,7 @@ trace-preserving physical maps, since that condition forces literal transfer
 idempotence.
 
 **Local fix (normalization):** the likely $(1/2)\,M$ representative is separate;
-see `docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+see <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, lines 937--938. -/
 theorem M_not_isRFPViaTS : ¬ IsRFPViaTS M := by

--- a/TNLean/MPS/MPDO/CPSVExample412NormalizedRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVExample412NormalizedRFP.lean
@@ -22,11 +22,11 @@ trace-preserving completely positive map equations of CPSV16 Definition 4.1.
 The horizontal normal-block weights of `\widehat M` have modulus `1 / √2`, not
 one. Thus the theorem here concerns the bare channel predicate `IsRFPViaTS`; it
 does not assert the line-246 global unit-weight convention. This scale tension
-is documented in `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+is documented in <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>.
 
 **Local fix (normalization):** The source prints the unscaled tensor, whose
 physical-trace transfer is not idempotent. See
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 ## Main results
 
@@ -54,7 +54,7 @@ namespace MPOTensor.CPSVExample412NormalizedRFP
 Example 4.12.
 
 **Local fix (normalization):** The source omits the factor `1 / 2`; see
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, lines 932--938. -/
 def Mhat : MPOTensor 2 2 :=
@@ -73,7 +73,7 @@ theorem mpo_Mhat (N : ℕ) :
 of the tensor printed in CPSV16 Example 4.12.
 
 **Local fix (normalization):** The equality uses the omitted tensor factor
-`1 / 2`; see `docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+`1 / 2`; see <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, lines 933--938. -/
 theorem mpo_Mhat_eq_normalizedMPO_M (N : ℕ) (hN : 0 < N) :
@@ -85,7 +85,7 @@ theorem mpo_Mhat_eq_normalizedMPO_M (N : ℕ) (hN : 0 < N) :
 /-- The positive-length periodic MPO of `Mhat` has trace one.
 
 **Local fix (normalization):** The printed tensor instead has trace `2 ^ N`;
-see `docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+see <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Example 4.12, lines 933--938. -/
 theorem trace_mpo_Mhat (N : ℕ) (hN : 0 < N) :
@@ -251,7 +251,7 @@ private lemma physClose2_Mhat_of_ne (X : Matrix (Fin 2) (Fin 2) ℂ)
 
 **Local fix (normalization):** This equation holds for `Mhat = (1 / 2) • M`,
 not for the tensor printed without the scalar. See
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, equations `eq:Smap` and
 `RFPMixedTS`, lines 645--660, and Example 4.12, lines 932--939. -/
@@ -291,7 +291,7 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 2) (Fin 2) ℂ) :
 
 **Local fix (normalization):** This equation holds for `Mhat = (1 / 2) • M`,
 not for the tensor printed without the scalar. See
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, equations `eq:Tmap` and
 `RFPMixedTS`, lines 650--660, and Example 4.12, lines 932--939. -/
@@ -325,12 +325,12 @@ two trace-preserving completely positive map equations of Definition 4.1.
 **Local fix (normalization):** The source prints the unscaled tensor, for which
 the channel equations are impossible. This theorem concerns
 `Mhat = (1 / 2) • M`; see
-`docs/paper-gaps/cpsv16_example_4_12_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_example_4_12_normalization.pdf>.
 
 **Scope restriction (canonical weight):** `IsRFPViaTS` isolates the two channel
 equations. This theorem does not assert the line-246 unit-weight horizontal
 canonical convention; see
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>.
 
 Source comparison: CPSV16, arXiv:1606.00608, Definition 4.1, lines 638--660,
 and Example 4.12, lines 932--939. -/

--- a/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
+++ b/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
@@ -549,7 +549,7 @@ the ambient doubled-index tensor.
 **Scope restriction (normalized fixed representative):** this is the
 project's fixed-representative predicate, which includes the global
 unit-weight convention of arXiv:1606.00608, line 246. See
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>.
 Source: arXiv:1606.00608, canonical form at lines 224--246, simplicity at
 lines 815--822, and the Case-II standing hypothesis at line 1628. -/
 theorem ambient_isSimpleCanonicalForm : IsSimpleCanonicalForm ambient := by
@@ -918,7 +918,7 @@ refute the conclusion of Proposition `prop2to3` or Theorem 4.9.
 **Scope restriction (normalized fixed representative):** simplicity is the
 project's fixed-representative predicate, including the line-246 unit-weight
 convention. See
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>.
 Source: arXiv:1606.00608, canonical normalization at lines 224--246,
 Definition 4.1 at lines 638--660, and the simple Case-II argument at lines
 1628--1665 and 1740--1782. -/

--- a/TNLean/MPS/MPDO/DiagonalCutRank.lean
+++ b/TNLean/MPS/MPDO/DiagonalCutRank.lean
@@ -97,7 +97,7 @@ periodic MPO cut is at most $D^2$.
 
 This is the virtual-pair factorization used in the classical-diagonal analysis
 of Proposition 4.5 of arXiv:1606.00608; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalCutMatrix_rank_le (M : MPOTensor d D) (L R : ℕ) :
     (diagonalCutMatrix M L R).rank ≤ D * D := by
   classical

--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -44,7 +44,7 @@ and positive semidefiniteness at every positive chain length.
 * arXiv:1606.00608, Proposition 4.5, lines 792--806, and its proof at
   lines 1316--1320.
 * Riazanov--Vyalyi, arXiv:1704.06507, Theorem 4.1.
-* `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`, section
+* <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>, section
   "Diagonal matrix product operators".
 -/
 
@@ -60,7 +60,7 @@ operator has no off-diagonal matrix entries.
 
 This is the fixed-length diagonal restriction used here to study the bound
 invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines 1316--1320;
-see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+see <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 def IsDiagonalAt (M : MPOTensor d D) (N : ℕ) : Prop :=
   (mpo M N).IsDiag
 
@@ -69,7 +69,7 @@ positive chain length.
 
 This is the global diagonal restriction used here to study the bound invoked
 in the proof of arXiv:1606.00608, Proposition 4.5, lines 1316--1320; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 def IsDiagonal (M : MPOTensor d D) : Prop :=
   ∀ N : ℕ, 0 < N → M.IsDiagonalAt N
 
@@ -78,7 +78,8 @@ def IsDiagonal (M : MPOTensor d D) : Prop :=
 For a positive finite-chain operator these coefficients are real and
 nonnegative.  This matrix belongs to the fixed-length diagonal restriction of
 the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
-1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+1316--1320; see
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 noncomputable def diagonalCutRealMatrix (M : MPOTensor d D) (L R : ℕ) :
     Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
   (diagonalCutMatrix M L R).map Complex.re
@@ -88,7 +89,7 @@ noncomputable def diagonalCutRealMatrix (M : MPOTensor d D) (L R : ℕ) :
 This is the normalization constant for the fixed-length diagonal restriction
 of arXiv:1606.00608, Proposition 4.5.  The source normalization convention is
 at lines 792--793; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 noncomputable def diagonalCutMass (M : MPOTensor d D) (L R : ℕ) : ℝ :=
   ∑ x, ∑ y, diagonalCutRealMatrix M L R x y
 
@@ -97,7 +98,7 @@ noncomputable def diagonalCutMass (M : MPOTensor d D) (L R : ℕ) : ℝ :=
 This is the joint distribution $\widehat P=Z^{-1}P$ for the fixed-length
 diagonal restriction of arXiv:1606.00608, Proposition 4.5.  The source
 normalization convention is at lines 792--793; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 noncomputable def normalizedDiagonalCutDistribution (M : MPOTensor d D) (L R : ℕ) :
     Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
   (diagonalCutMass M L R)⁻¹ • diagonalCutRealMatrix M L R
@@ -107,7 +108,8 @@ the finite-chain MPO operator.
 
 This is the coefficient identity used for the fixed-length diagonal restriction
 of the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
-1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+1316--1320; see
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalCutMatrix_apply_eq_mpo (M : MPOTensor d D) (L R : ℕ)
     (x : Fin L → Fin d) (y : Fin R → Fin d) :
     diagonalCutMatrix M L R x y =
@@ -119,7 +121,8 @@ extension of its real part.
 
 This is the real-coefficient step for the fixed-length diagonal restriction of
 the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
-1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+1316--1320; see
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalCutRealMatrix_map_ofReal_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
     (hpos : (mpo M (L + R)).PosSemidef) :
     (diagonalCutRealMatrix M L R).map Complex.ofReal = diagonalCutMatrix M L R := by
@@ -133,7 +136,8 @@ nonnegative.
 
 This is the positivity step for the fixed-length diagonal restriction of the
 bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
-1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+1316--1320; see
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalCutRealMatrix_nonneg_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
     (hpos : (mpo M (L + R)).PosSemidef) (x : Fin L → Fin d) (y : Fin R → Fin d) :
     0 ≤ diagonalCutRealMatrix M L R x y := by
@@ -145,7 +149,7 @@ finite-chain trace.
 
 This identifies the local normalization constant with the trace in the
 normalization convention of arXiv:1606.00608, lines 792--793; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalCutMass_eq_trace_re (M : MPOTensor d D) (L R : ℕ) :
     diagonalCutMass M L R = (mpo M (L + R)).trace.re := by
   classical
@@ -184,7 +188,7 @@ diagonal cut coefficients a joint probability distribution.
 This is the normalization step for the fixed-length diagonal restriction of
 arXiv:1606.00608, Proposition 4.5.  The source normalization convention is at
 lines 792--793; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem normalizedDiagonalCutDistribution_isJointDistribution (M : MPOTensor d D)
     (L R : ℕ) (hpos : (mpo M (L + R)).PosSemidef)
     (hmass : 0 < diagonalCutMass M L R) :
@@ -218,7 +222,8 @@ for unrestricted quantum mutual information.
 **Scope restriction (diagonal finite-chain operator):** Proposition 4.5 concerns
 arbitrary MPDOs, whereas this theorem treats the classical diagonal subcase at
 one chain length.  The distinction and the unrestricted quantum question are
-documented in `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+documented in
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalFiniteChain_classicalMutualInformation_le_two_log [NeZero D]
     (M : MPOTensor d D) (L R : ℕ) (_hdiag : M.IsDiagonalAt (L + R))
     (hpos : (mpo M (L + R)).PosSemidef) (hmass : 0 < diagonalCutMass M L R) :
@@ -247,7 +252,7 @@ Theorem 4.1 (arXiv:1704.06507).
 **Scope restriction (globally diagonal MPDO):** Proposition 4.5 concerns
 arbitrary MPDOs, whereas this theorem treats globally diagonal tensors.  The
 unrestricted quantum question is documented in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem diagonalMPDO_classicalMutualInformation_le_two_log [NeZero D]
     (M : MPOTensor d D) (hdiag : M.IsDiagonal) (hmpdo : M.IsMPDO)
     (L R : ℕ) (hN : 0 < L + R) (htrace : 0 < (mpo M (L + R)).trace.re) :

--- a/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
@@ -19,7 +19,7 @@ factorization on every ambient Hayashi sector.
 **Scope restriction (normal Case I):** this module proves only the normal
 Case-I conclusion. It does not replace literal zero correlation length by a
 scale-invariant condition and does not pass to Case II. See
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Case I, Lemmas C.4--C.5 and the
 corollary, lines 1374--1505.
@@ -91,7 +91,7 @@ positivity used there is the one contained in `IsSAL K`.
 **Scope restriction (active Hayashi/Case I):** this is the normal Case-I
 active-sector conclusion of CPSV16 Appendix C.2. It does not assert the
 coefficient-rescaled Case-II result. See
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Case I, Lemmas C.4--C.5 and the
 corollary, lines 1374--1505. -/
@@ -121,7 +121,7 @@ ambient sectors and $\sum_k a_kb_k=1$.
 
 **Scope restriction (normal Case I):** this theorem assumes literal zero
 correlation length and normality. It makes no Case-II or scale-invariant ZCL
-claim. See `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+claim. See <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Case I, Lemmas C.4--C.5 and the
 corollary, lines 1374--1505. -/
@@ -191,12 +191,12 @@ the left and right factor tensors, and the exact physical-slice factorization.
 
 **Local fix (inactive sectors):** the zero-weight extension belongs to the
 coherently rephased inverse-map witness; CPSV16 does not specify this
-inactive-sector convention. See `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+inactive-sector convention. See <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 **Scope restriction (normal Case I):** this theorem assumes injectivity, the
 strong area law, literal zero correlation length, and normality. It makes no
 scale-invariant ZCL or Case-II claim. See
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex` for the precise paper boundary.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> for the precise paper boundary.
 
 Source: arXiv:1606.00608, Appendix C.2, the corollary after Lemma C.5, lines
 1503--1506. -/

--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -279,7 +279,7 @@ using the local purification of arXiv:1606.00608, Section 4.3.
 the purifying bond dimension. It is not the unrestricted finite-chain estimate
 in the MPO bond dimension asserted for every positive MPDO in arXiv:1606.00608,
 Proposition 4.5; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
     {M : MPOTensor d D} (hLPDO : IsLPDO M)
     (N L K : ℕ) (h : N = L + K) :
@@ -307,7 +307,7 @@ using the local purification of arXiv:1606.00608, Section 4.3.
 the purifying bond dimension. It is not the unrestricted finite-chain estimate
 in the MPO bond dimension asserted for every positive MPDO in arXiv:1606.00608,
 Proposition 4.5; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
     {M : MPOTensor d D} (hLPDO : IsLPDO M) :
     ∃ (dK D' : ℕ)
@@ -339,7 +339,7 @@ arXiv:1606.00608, Appendix C, line 1319.
 For a locally purified tensor it must be derived by tracing the ancillary
 physical indices on the two blocks. An arbitrary positive MPO need not possess
 such a purification; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem mutualInfoChain_le_of_bipartitioned_channel_image
     (M : MPOTensor d D) (A : MPSTensor dP D') (N L : ℕ) (hL : L ≤ N)
     (S : Matrix (Fin (dP ^ L)) (Fin (dP ^ L)) ℂ →ₗ[ℂ]
@@ -391,7 +391,7 @@ purification equation `eq:MPDO-Puri-1` of arXiv:1606.00608 (line 751).
 representation; it does not assert that an arbitrary positive matrix product
 operator has a local purification. The bound is in the purifying bond dimension
 `D'`, not the MPO bond dimension `D`; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem mutualInfoChain_le_of_lpdoWitness
     {dK D' : ℕ} (M : MPOTensor d D)
     (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
@@ -424,7 +424,7 @@ equation (4) of arXiv:0704.3906.
 dimension and remains restricted to LPDOs. It is not the unrestricted bound in
 the MPO bond dimension asserted for arbitrary MPDOs in Proposition 4.5 of
 arXiv:1606.00608; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem IsLPDO.exists_mutualInfoChain_le_purifyingBond
     {M : MPOTensor d D} (hLPDO : IsLPDO M)
     (N L : ℕ) (hN : 0 < N) (hL : L ≤ N)

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -157,7 +157,7 @@ diagonal purification at `d = d_K = 2`, `D = D' = 1`, `A = [1/√2, 0, 0, 1/√2
 its purifying tensor is a pure-state renormalization fixed point, yet the ancilla
 trace contraction halves the leading eigenvalue, so the induced transfer map is
 `½ • id` and idempotence fails. See
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>. -/
 
 /-- Scalar amplitudes of the diagonal purifying tensor: `1/√2` on the diagonal. -/
 noncomputable def witnessAmplitude (i k : Fin 2) : ℂ := if i = k then (Real.sqrt 2)⁻¹ else 0
@@ -242,7 +242,7 @@ length.** There is an MPO tensor satisfying `IsLocalPurificationRFP` whose
 literal transfer-map idempotence `E_M ∘ E_M = E_M` fails, because the
 purification's trace contraction drops the leading eigenvalue below `1`. This is
 the canonical-form deviation documented in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>. -/
 theorem exists_isLocalPurificationRFP_not_isZCL :
     ∃ M : MPOTensor 2 1, IsLocalPurificationRFP M ∧ ¬ IsZCL M := by
   refine ⟨witnessM, ⟨2, 1, witnessA, (finProdFinEquiv (m := 1) (n := 1)).symm, fun _ _ => rfl,
@@ -274,8 +274,8 @@ purification tensor, which is the counterexample above to literal doubled-index
 idempotence, has physical-trace transfer equal to the identity. This transfer is
 nonzero and idempotent, hence the tensor has source zero correlation length. The
 example is recorded in
-docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex: the physical-trace
-transfer correctly classifies the maximally mixed product state as having zero
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>:
+the physical-trace transfer correctly classifies the maximally mixed product state as having zero
 correlation length, whereas the doubled-index condition wrongly excludes it. -/
 theorem isSourceZCL_witnessM : IsSourceZCL witnessM :=
   isSourceZCL_of_physTraceTransfer_sq witnessM

--- a/TNLean/MPS/MPDO/MutualInfoAreaLaw.lean
+++ b/TNLean/MPS/MPDO/MutualInfoAreaLaw.lean
@@ -103,7 +103,7 @@ of normalizing by the finite-chain trace.
 **Local fix (finite-chain bound):** The local-purification argument cited in
 the Appendix does not apply to every positive MPO. The proof instead uses the
 periodic-cut operator-Schmidt estimate; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
 theorem IsMPDO.mutualInfoChain_le_four_log_bondDim
     {M : MPOTensor d D} (hM : IsMPDO M) (N L : ℕ) (hN : 0 < N)
     (hL : L ≤ N) (htr : (mpo M N).trace ≠ 0) :

--- a/TNLean/MPS/MPDO/NeighboringTraceObstruction.lean
+++ b/TNLean/MPS/MPDO/NeighboringTraceObstruction.lean
@@ -48,7 +48,7 @@ on each absorbed representative.
   Theorem 4.9, lines 862--892; Appendix C.2, equation `Tkn` and the
   normalization step, lines 1473--1498; the ambient normalization at lines
   1755--1759.
-* `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, the unit-closure-trace
+* <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>, the unit-closure-trace
   necessary condition.
 -/
 

--- a/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
+++ b/TNLean/MPS/MPDO/NonCartesianActiveSectorCounterexample.lean
@@ -350,8 +350,9 @@ neighboring trace factorization.
 This theorem does not package the ambient simple-biCF canonical reconstruction
 or the global unit-weight convention assumed in arXiv:1606.00608, lines
 217--246 and 1626--1665. It therefore does not refute the source-context
-implication `(ii) ⇒ (iv)`. See `docs/paper-gaps/cpgsv17_pf_rank_one.tex` and
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
+implication `(ii) ⇒ (iv)`. See
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> and
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>. -/
 theorem full_lowLevel_counterexample :
     ∃ (K A : MPOTensor 4 2) (mu : ℂ),
       mu ≠ 0 ∧ ‖mu‖ < 1 ∧ K = mu • A ∧ A.toMPSTensor.IsNormalTensor ∧

--- a/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
@@ -24,7 +24,7 @@ this data separately for every outer BNT element. This file assumes one
 `NeighboringTraceFactorization`; it neither assembles the resulting channel
 pairs along the outer physical supports nor proves the full implication to
 Theorem 4.9(v). Documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 **Local fix (cyclic implication labels):** The concluding proof at source
 lines 1822--1824 assigns the wrong conditions to Propositions `prop2to3`,
@@ -215,7 +215,7 @@ transport the two channels through the two- and four-site physical unitaries.
 `NeighboringTraceFactorization`. Theorem 4.9(iv) supplies such a factorization
 separately for every outer BNT element; their projector-controlled channel
 assembly is not proved here. Documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Definition 4.1, lines 645--659; Proposition C.7,
 lines 1510--1563; and the twice-applied channel observation at Appendix C.2,

--- a/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
@@ -180,7 +180,7 @@ the channels for one `PhysicalSectorFactorization` and its neighboring trace
 data. Theorem 4.9(iv) supplies such data separately for each outer BNT element;
 assembling the resulting channels by the mutually orthogonal outer physical
 supports is proved in `TNLean/MPS/MPDO/BNTFactorizationChannels.lean`.
-Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+Documented in <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Definition 4.1, lines 645--659; Proposition C.7,
 lines 1510--1563; and the twice-applied channel observation at lines

--- a/TNLean/MPS/MPDO/Purity.lean
+++ b/TNLean/MPS/MPDO/Purity.lean
@@ -31,7 +31,7 @@ entry formula `MPSTensor.mpv_toMPSTensor_pairConfig`.
 stated in trace form and in the Frobenius-norm vocabulary of
 `TNLean.Algebra.MatrixAux`.  Following the convention of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`), the
+(<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>), the
 unnormalized quantity `Matrix.trace (mpo K N * (mpo K N)ᴴ)` is called the
 *raw squared Hilbert--Schmidt norm* of the MPO family; it is not a
 normalized-state purity, which would require the trace normalization that has
@@ -52,7 +52,7 @@ not been established here.
 
 These identities are project infrastructure preparing the Lemma C.5 route of
 the eta-local structure paper-gap note
-(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
+(<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines
 1473--1499; Case-I assumptions at lines 1374--1381; cyclic direct-sum form at
 lines 1580--1593).  They are not statements from CPSV16, and no Lemma C.5
@@ -95,7 +95,7 @@ summands along `pairCfgEquiv`.
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
+(<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1473--1499); it is not
 a claim from CPSV16.  Before trace normalization is established, the right
 side is the raw squared Hilbert--Schmidt norm of the MPO family, not a
@@ -132,7 +132,7 @@ MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
+(<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1473--1499); it is not
 a claim from CPSV16. -/
 theorem mpvOverlap_toMPSTensor_self_eq_trace_sq (K : MPOTensor d D) (hK : IsMPDO K)
@@ -147,7 +147,7 @@ Hilbert--Schmidt norm in the vocabulary of `TNLean.Algebra.MatrixAux`.
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`); it
+(<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>); it
 is not a claim from CPSV16. -/
 theorem mpvOverlap_toMPSTensor_self_re_eq_frobenius_norm_sq (K : MPOTensor d D) (N : ℕ) :
     (MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N).re = ‖mpo K N‖ ^ 2 := by

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -93,7 +93,7 @@ trace preservation of the map from one site to
 two sites identifies the traces of the one-site and two-site physical closures
 for every virtual boundary matrix. For its interaction with the line-246
 unit-weight convention on a fixed tensor representative, see
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>. -/
 theorem physTraceTransfer_sq_of_isRFPViaTS (M : MPOTensor d D) (h : IsRFPViaTS M) :
     physTraceTransfer M * physTraceTransfer M = physTraceTransfer M := by
   obtain ⟨_, T, _, hT, _, hT_close⟩ := h
@@ -118,13 +118,13 @@ project's broader scale-invariant physical-trace relation.
 **Scope restriction (scale-invariant corollary):** CPSV16 Definition 4.2 is the
 literal identity proved by `physTraceTransfer_sq_of_isRFPViaTS`. This theorem
 records the resulting, broader `IsSourceZCL` relation for later uses. See
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 **Scope restriction (nonzero transfer):** The source assumes that the tensor is
 in canonical form and generates normalized density operators. The bare
 predicate `IsRFPViaTS` does not include these standing hypotheses, so the
 nonzero transfer is stated explicitly. This restriction is documented in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 Source: arXiv:1606.00608, lines 1333--1340. -/
 theorem isSourceZCL_of_isRFPViaTS (M : MPOTensor d D) (h : IsRFPViaTS M)

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -460,7 +460,7 @@ nonzero trace.
 **Scope restriction (scale-invariant corollary):** the source-facing ZCL
 conclusion is the literal identity `physTraceTransfer_sq_of_isRFPViaTS`. This
 theorem packages the broader `IsSourceZCL` consequence with SAL for later uses. See
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 Nonzero positive-length traces are the normalization condition implicit in the
 source's density-operator language.  The one-site instance, together with the

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
@@ -42,7 +42,7 @@ does not assert presentation independence.
 that every canonical weight has modulus at most one and at least one has
 modulus one; that normalization is not part of this statement. The resulting
 fixed-representative scale tension is recorded in
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>. -/
 theorem exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R :
     ∃ (M : MPOTensor 4 4) (H : BNTAlgebraTensorClause M),
       MPSTensor.IsCPSVCanonicalForm M.toMPSTensor ∧

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -156,7 +156,7 @@ square--cube and trace-power identities from source zero correlation length.
 The remaining problem is to exclude the nilpotent generalized zero-eigenspace
 of the concrete trace matrix without an additional hypothesis absent from
 Lemma C.5. It is recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 ## References
 
@@ -542,7 +542,7 @@ not use primitivity once `trace T = 1` and constant trace powers are known.
 semidefiniteness is absent from arXiv:1606.00608, Appendix C.2, Lemma
 `SALZCL` (Lemma C.5), lines 1484--1499. The primitivity hypothesis is retained
 for comparison with the source but is unused by this corrected argument.
-Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+Documented in <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>. -/
 theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (T : Matrix (Fin n) (Fin n) ℝ)
     (_hPrimitive : Matrix.IsPrimitive T)
@@ -622,7 +622,8 @@ the zero-correlation-length identity: $T^2=T$.
 arXiv:1606.00608, lines 1484--1499 neither assumes nor derives
 linear independence of the sector tensors; see the marker on
 `Matrix.mul_self_eq_self_of_pairing_idempotent` and
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.  The hypothesis
+`hl` is discharged
 by `SectorPairingData.linearIndependent_l` once each sector tensor lies in the
 corresponding member of an independent family of subspaces. -/
 theorem mul_self_eq_self (data : SectorPairingData T V)
@@ -636,7 +637,7 @@ closed sector tensors $|l_k)$ or the functionals $(r_k|$: pairing the
 identity with $(r_j|$ and $|l_i)$ gives this matrix identity directly.
 
 Source: arXiv:1606.00608, lines 1494--1497. This is the pairing computation
-of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3 ("What the operator-valued
+of <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>, §3 ("What the operator-valued
 ZCL identity implies"). -/
 theorem pairing_sq_eq_pairing_cube (data : SectorPairingData T V) : T ^ 2 = T ^ 3 :=
   Matrix.pow_two_eq_pow_three_of_pairing_idempotent data.pairing data.pairing_operator_idempotent
@@ -673,7 +674,7 @@ indices, but the closed tensors $|l_k)$ at lines 1473--1477 live in a common
 bond space after the physical sector legs are contracted. Whether the
 inverse-map construction supplies such supports, or proves independence by
 another argument, remains open; documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>. -/
 theorem linearIndependent_l (data : SectorPairingData T V)
     (support : Fin n → Submodule ℝ V)
     (hmem : ∀ k, data.l k ∈ support k)
@@ -699,7 +700,8 @@ the closed sector tensors nonzero.
 
 **Scope restriction (linear independence):** the source lemma neither assumes
 nor derives linear independence of the sector tensors; documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.  The hypothesis
+`hl` is discharged
 by `SectorPairingData.linearIndependent_l` when each sector tensor lies in the
 corresponding member of an independent family of subspaces. -/
 theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
@@ -724,7 +726,7 @@ an independent family of subspaces containing the respective sector tensors.
 
 **Scope restriction (independent subspaces):** the subspace family carrying the
 closed sector tensors is not displayed in arXiv:1606.00608; documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>. -/
 theorem sal_zcl_implies_rank_one_T_of_sector_supports
     {V : Type*} [AddCommGroup V] [Module ℝ V]
     (T : Matrix (Fin n) (Fin n) ℝ)

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -184,7 +184,7 @@ Thus this predicate is evaluated on the displayed tensor `M`, not modulo a
 nonzero scalar rescaling. The mathematical nilpotency clause is scale invariant,
 but the unit-weight normalization included in the canonical-form witness need
 not be compatible with the scale fixed by Definition 4.1. See
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>. -/
 def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧
     ∃ S : MPSTensor.SectorDecomposition (d * d),
@@ -317,7 +317,7 @@ canonical-form gauge and then reads the diagonal block indexed by `(j, q)`.
 **Scope restriction (literal-ZCL inheritance):** This is only the literal-ZCL inheritance
 part of Case II. It neither gives spectral normality of the absorbed tensor nor completes
 `prop2to3`. The remaining Case-II boundary is recorded in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1745--1782. -/
 theorem weighted_basis_physTraceTransfer_sq_of_literal_ZCL

--- a/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
+++ b/TNLean/MPS/MPDO/VerticalTransportCoefficientCovariance.lean
@@ -39,7 +39,7 @@ normalization of their representatives, and the algebra isomorphism identifies
 the ambient operator algebras at each positive length.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equations
 `eq:vertical-coefficient-explicit-transport` and
 `eq:vertical-coefficient-covariance`. -/
 structure ExplicitVerticalTransport
@@ -63,7 +63,7 @@ structure ExplicitVerticalTransport
 /-- The coefficient family obtained by explicit vertical transport.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equation
 `eq:vertical-coefficient-covariance`. -/
 def verticalTransportCoefficients
     (c : BNTLabelCoefficientFamily Λ) (e : Λ' ≃ Λ) (s : Λ' → ℂ) :
@@ -78,7 +78,7 @@ variable [Fintype Λ] [Fintype Λ']
 scale-covariant coefficient family.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equations
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equations
 `eq:vertical-coefficient-explicit-transport` and
 `eq:vertical-coefficient-covariance`. -/
 theorem ExplicitVerticalTransport.hasSameLengthProductForm_verticalTransport
@@ -119,7 +119,7 @@ theorem ExplicitVerticalTransport.hasSameLengthProductForm_verticalTransport
 forces the scale-covariant comparison law for the structure coefficients.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equation
 `eq:vertical-coefficient-covariance`. -/
 theorem ExplicitVerticalTransport.coeff_eq_verticalTransport_of_linearIndependentAt
     {op : BNTLabelOperatorFamily Λ O} {op' : BNTLabelOperatorFamily Λ' O'}
@@ -138,7 +138,7 @@ theorem ExplicitVerticalTransport.coeff_eq_verticalTransport_of_linearIndependen
 vertical transport preserves its structure coefficient exactly.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equation
 `eq:vertical-coefficient-covariance`. -/
 theorem ExplicitVerticalTransport.coeff_eq_of_scale_mul_eq_of_linearIndependentAt
     {op : BNTLabelOperatorFamily Λ O} {op' : BNTLabelOperatorFamily Λ' O'}
@@ -162,7 +162,7 @@ variable {d D d' D' : ℕ} {M : MPOTensor d D} {M' : MPOTensor d' D'}
 the scale-covariant comparison law for their structure coefficients.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equation
 `eq:vertical-coefficient-covariance`. -/
 theorem coeff_eq_of_explicitVerticalTransport
     (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')
@@ -180,7 +180,7 @@ explicit vertical transport preserves a tensor-attached structure coefficient
 exactly.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1997--2008; see also
-`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`, equation
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.pdf>, equation
 `eq:vertical-coefficient-covariance`. -/
 theorem coeff_eq_of_explicitVerticalTransport_of_scale_mul_eq
     (H : BNTAlgebraTensorClause M) (H' : BNTAlgebraTensorClause M')

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -55,7 +55,7 @@ the leading eigenvalue from `1` to `½`. The predicate
 `IsPhysicalTraceIdempotent` records the paper's literal fixed-tensor diagram.
 The separate predicate `IsSourceZCL` uses the same physical-trace object but
 allows a positive scalar, giving a broader scale-invariant relation. Recorded
-in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+in <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 See arXiv:1606.00608, lines 735–739 (and the canonical-form characterization at
 line 1248), and arXiv:2011.12127, Section II.E.2, lines 937–939. -/
@@ -73,7 +73,8 @@ theorem isZCL_iff_toMPSTensor_isTransferIdempotent (M : MPOTensor d D) :
 single bond matrix obtained by closing the ket and bra physical legs of one
 tensor. This is the transfer object of the source zero-correlation-length
 condition (arXiv:1606.00608, Definition 4.2, lines 735–739), as identified in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. It is distinct
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
+It is distinct
 from the doubled-index completely positive map `transferMap`, which sums
 `∑_{i,j} M^{ij} X (M^{ij})ᴴ` over both physical legs; the physical-trace transfer
 instead contracts the two legs of a single tensor. -/
@@ -110,7 +111,7 @@ arXiv:1606.00608, Definition 4.2, lines 735--739, is the literal `λ = 1`
 identity for a fixed tensor. This development's predicate is a broader,
 scale-invariant repair at the level of the generated state family; it must not
 be substituted unchanged into fixed-tensor implications such as Theorem 4.9.
-Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Documented in <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
 The relation uses the paper's physical-trace transfer object `𝒯_M`, unlike
 `MPOTensor.IsZCL`, which records idempotence of the doubled-index map
@@ -127,7 +128,7 @@ The required nonzero physical-trace transfer cannot be represented on an empty
 bond space.
 
 Scope: the up-to-scalar interpretation documented in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>. -/
 theorem IsSourceZCL.bondDim_ne_zero {M : MPOTensor d D} (h : IsSourceZCL M) :
     D ≠ 0 := by
   intro hD


### PR DESCRIPTION
## What changed
- replace all 102 Lean docstring/comment citations to six TNLean compatibility stubs with their canonical QICLean paper-gap PDFs
- retain the local compatibility stubs for historical links
- use the repository Markdown-autolink convention and reflow only the touched citation lines

## Statement-integrity audit
- **Paper assumptions vs. Lean assumptions:** unchanged; no declaration or hypothesis changed.
- **Paper conclusion vs. Lean conclusion:** unchanged; the cited scope restrictions and counterexamples keep their existing mathematical verdicts.
- **Relevant definitions:** `IsBNTCanonicalForm`, `IsSourceZCL`, `IsPhysicalTraceIdempotent`, the neighboring-trace factorization interfaces, and the Example 4.12 predicates are citation consumers only in this diff.
- **Proof status:** unchanged; no proof term, `sorry`, or axiom changed.
- **Faithfulness verdict:** citation-link drift repaired. Load-bearing source-restriction markers now lead directly to the canonical QICLean notes rather than local pointer stubs.
- **Issues addressed:** closes #7244.

## Validation
- regenerated the citation inventory from current files
- zero remaining `docs/paper-gaps/<slug>.tex` references under `TNLean/**/*.lean` for all six migrated slugs
- verified every changed file differs only by the six requested citation substitutions and citation-line reflow
- no newly added lines over 100 characters
- `git diff --check`

No Lean target build was run because the diff changes comments only.