### PR TITLE
docs(blueprint): restore algebraic and PEPS chapters

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_peps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_peps.tex
@@ -40,9 +40,9 @@ product states, and the square lattice.
         % Source verdict: exact square-lattice specialization of the first
         % hypothesis in arXiv:1804.04964, paper_normal.tex:1475--1499.
         \tenkzkernel
-        \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
         \begin{tenkz}[rows={wire,wire,wire,wire,wire,wire,wire}, cols=7,
                 west=open, east=open, north=open, south=open]
+            \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} \\
@@ -87,9 +87,9 @@ product states, and the square lattice.
         % arXiv:1804.04964, paper_normal.tex:1405--1429 and 1519--1544.
         $\text{and}\qquad$
         \tenkzkernel
-        \tndeclare{species}{marked-site}{hue=source:blue}
         \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5,
                 west=open, east=open, north=open, south=open]
+            \tndeclare{species}{marked-site}{hue=source:blue}
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} & \tn[skin=dot]{} \\
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
@@ -106,6 +106,7 @@ product states, and the square lattice.
         $\qquad\subset\qquad$
         \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5,
                 west=open, east=open, north=open, south=open]
+            \tndeclare{species}{marked-site}{hue=source:blue}
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} & \tn[skin=dot]{} \\
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
@@ -363,9 +363,9 @@
         % Source verdict: exact discrete translation of arXiv:1804.04964,
         % paper_normal.tex:1475--1499; A1 is red, A2 blue, and A3 the rest.
         \tenkzkernel
-        \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
         \begin{tenkz}[rows={wire,wire,wire,wire,wire,wire,wire}, cols=7,
                 west=open, east=open, north=open, south=open]
+            \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
             \tn[skin=dot]{} \\

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -20,7 +20,7 @@
 \input{chapter/ch21_mpdo_rfp}
 \input{chapter/ch21_mpdo_rfp_algebraic}
 \input{chapter/ch22_periodic_ft}
-% \input{chapter/ch23_algebraic_ft}
-% \input{chapter/ch24_peps_ft}
+\input{chapter/ch23_algebraic_ft}
+\input{chapter/ch24_peps_ft}
 
 \input{appendix/ft_mps_appendices}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -25,6 +25,7 @@
 \maketitle
 \tableofcontents
 \csname input\endcsname{\blueprintcontent} % chktex 27 (macro-based path; use \csname to bypass chktex \input pattern matching)
-\bibliographystyle{alpha}
+% `alpha` emits an invalid label after 26 same-author/year paper-gap entries.
+\bibliographystyle{plain}
 \bibliography{references}
 \end{document}

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -91,31 +91,19 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   parent record by `rfl` with nothing reading the pin; see
   `docs/audits/2026-08-26_canonical_form_retirements.md`.
 
-### S5. Retire the ch23 algebraic-FT route and the redundant TI CycleMPS mirror — net 2,400 lines, risk 6/10
-- **Status**: open (#4565)
-- **What**: `MPS/Chain/{GaugePhase,SameStateBridge}.lean`;
-  `PiAlgebra/{Construction,FundamentalTheoremComplete,TIReduction}.lean`;
-  `PEPS/{CycleMPSOverlapWindow,CycleMPSOverlapInsertion}.lean`; only the
-  ~30-line redundant wrapper in `CycleMPSTranslationInvariant.lean` (NOT
-  its ~150-line gauge-uniqueness theorem — see caution below);
-  `blueprint/src/chapter/ch23_algebraic_ft.tex` (1,776 ln, already dormant).
-- **Why it's excess**: the ch23 route proves a stronger-hypothesis variant
-  gated on the never-instantiated `SameStateBridgeHyp`
-  ([D2](#d2-fundamental-theorem-gauge-extraction-spine-re-instantiated-per-setting-capstone-conditional-on-an-unconstructed-bridge--abstraction-gap-impact-710-effort-710));
-  a translation-invariant closed chain is the constant instance of the
-  site-dependent one, so the TI window/insertion lemmas are second proofs
-  of already-proved content.
-- **Caution (verified)**: `CycleMPSTranslationInvariant.lean`'s
-  `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique` (~150-160
-  ln) is the sole, currently-irreplaceable formalization of the source's
-  uniqueness clause, `\leanok`-cited 3x from `ch24_peps_ft_normal_capstone.tex`
-  — it only looks deletable because its chapter is dormant. It must be
-  **relocated** into `CycleMPSOverlapCapstone.lean`, not deleted.
-- **First PR**: rehome `piTrace_mul_right_eq_zero` into
-  `BiCFDerivation/Core.lean`, then delete the four zero-consumer PiAlgebra
-  files plus `GaugePhase.lean`/`SameStateBridge.lean` (~940 lines, zero
-  blueprint exposure). The CycleMPS collapse and gauge-uniqueness
-  relocation are separate follow-on PRs given the content-loss risk above.
+### S5. Preserve the ch23 algebraic-FT chapter — retirement cancelled
+- **Status**: cancelled (#4565; owner decision on #7220)
+- **Decision**: the Chapter 23 algebraic Fundamental Theorem material is a
+  useful account of András's paper and remains part of the Blueprint. Its
+  chapter router and three section files are restored to the full build; they
+  are not deletion candidates.
+- **History**: earlier Lean-side deduplication and the relocation of
+  `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique` remain in
+  place. Those implementation cleanups do not justify deleting the mathematical
+  chapter. Any future citation migration caused by Lean refactoring must update
+  the retained chapter in place.
+- **Scope**: no further chapter or Lean deletion is authorized by S5. Any
+  future CycleMPS simplification requires a separate, freshly verified issue.
 
 ### S12. Collapse duplicated spectral-split proofs onto `ProjectionSpectralSplit`/corner-compression API — net 520 lines, risk 5/10
 - **Status**: open (#4566)


### PR DESCRIPTION
## Summary

- restore the Chapter 23 algebraic Fundamental Theorem and Chapter 24 PEPS Fundamental Theorem routers to the full Blueprint
- cancel proof-debt ledger item S5: the Chapter 23 account of András\u2019s paper is retained, and no further chapter or Lean deletion is authorized by that item
- keep the focused Chapters 1\u201312 entry point unchanged
- make the newly rendered Chapter 24 tenkz pictures self-contained by moving custom species declarations into each captured picture
- switch the print bibliography from `alpha` to `plain`, because the restored bibliography has more than 26 same-author/year paper-gap entries and BibTeX `alpha` emits an invalid 27th label

## Verification

- five-root reachability scan: 228/228 tracked Blueprint `.tex` files reachable
- `texra-blueprint web` (Chapters 23 and 24 rendered)
- `./scripts/build_blueprint_ch01_12.sh` and PDF text check (Chapters 23 and 24 absent)
- `leanblueprint pdf` (998 pages; Chapters 23 and 24 present)
- Blueprint declaration scanner and sync: 6657/6657
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/test_tenkz_pic.py`
- `git diff --check`

Closes #7220.
Closes #4565.