### PR TITLE
docs(audit): correct block-trace replacement routes

### DIFF
--- a/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
+++ b/docs/audits/2026-08-23_issue6861_dead_module_deletion.md
@@ -34,12 +34,12 @@ removal was:
 | Removed coordinate declaration | Surviving replacement |
 |---|---|
 | `MPSTensor.upperSum` | None; construct the block matrix directly when coordinates are required. |
-| `MPSTensor.diagSum` | `Kraus.diagPart` for the coordinate-free diagonal compression. |
+| `MPSTensor.diagSum` | None; construct the block matrix directly when coordinates are required. |
 | `MPSTensor.upperFin` | None; reindex a tensor directly when coordinates are required. |
 | `MPSTensor.diagFin` | `Kraus.diagPart` after choosing the orthogonal projection. |
 | `MPSTensor.trace_fromBlocks_upper` | `Matrix.trace_eq_trace_diag_of_proj`. |
-| `MPSTensor.evalWord_upperSum_is_fromBlocks` | `Kraus.lowerZero_evalWord` and `Kraus.evalWord_diagPart_eq`; no individual block-coordinate wrapper remains. |
-| `MPSTensor.evalWord_diagSum_is_fromBlocks` | `Kraus.evalWord_diagPart_eq`; no individual block-coordinate wrapper remains. |
+| `MPSTensor.evalWord_upperSum_is_fromBlocks` | `Kraus.lowerZero_evalWord`, `Kraus.evalWord_diagPart_eq`, and the diagonal inclusion intertwiners via `Kraus.evalWord_intertwine`; no individual block-coordinate wrapper remains. |
+| `MPSTensor.evalWord_diagSum_is_fromBlocks` | The diagonal inclusion intertwiners via `Kraus.evalWord_intertwine`; no individual block-coordinate wrapper remains. |
 | `MPSTensor.trace_evalWord_upperSum_eq_trace_evalWord_diagSum` | `Kraus.trace_evalWord_diagPart_eq`. |
 | `MPSTensor.mpv_upperFin_eq_mpv_diagFin` | Pointwise use of `MPSTensor.sameMPV_diagPart_of_lowerZero`. |
 | `MPSTensor.sameMPV_upperFin_diagFin` | `MPSTensor.sameMPV_diagPart_of_lowerZero`. |


### PR DESCRIPTION
## Summary

Correct the permanent retirement audit after #7269:

- record that `MPSTensor.diagSum` has no surviving coordinate constructor replacement
- attribute `evalWord_diagSum_is_fromBlocks` to the diagonal inclusion intertwiners through `Kraus.evalWord_intertwine`
- include that intertwiner route in the transitive account of `evalWord_upperSum_is_fromBlocks`

The corrections were checked directly against the deleted proof at the pre-#7269 base. No Lean declarations or Blueprint sources change.

## Verification

- inspected `evalWord_diagSumAux` and `evalWord_upperSumAux` at commit `17106f8a`
- `git diff --check`

Closes #7271.