### PR TITLE
docs(paper-gaps): check live PEPS citations

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2265,9 +2265,10 @@ reading.
 
 The conditional square-lattice skeleton recorded earlier in this note has been
 removed. Its assembly assumed single-site injectivity of $A$
-(\path{IsVertexInjective}), the hypothesis the normal theorem exists to avoid: its
+(\leanid{TNLean.PEPS.IsVertexInjective}), the hypothesis the normal theorem exists to avoid: its
 scalar condition rested on the vertex-injective product identity rather than the
-region-injective one (\path{prod_perVertexScalar_eq_one_of_regionInjective}). The
+region-injective one
+(\leanid{TNLean.PEPS.prod_perVertexScalar_eq_one_of_regionInjective}). The
 interior-window open-lattice theorem
 \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional} and the
 general-graph gauge-equivalence theorem
@@ -2545,7 +2546,7 @@ column and close under the periodic boundary condition. This route is the
 expected one, not a proof the source carries out.
 
 The load-bearing dependency, the injective PEPS Fundamental Theorem
-(\path{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
+(\leanid{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
 \path{thm:fundamentalTheorem_PEPS}), is formalized. The one-dimensional
 repeated-tensor construction discussed above is also formalized as
 \leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.


### PR DESCRIPTION
## Summary

Convert the three remaining live PEPS declaration references identified by #7270 from the file-path macro to fully qualified, scanner-checked `\leanid` citations:

- `TNLean.PEPS.IsVertexInjective`
- `TNLean.PEPS.prod_perVertexScalar_eq_one_of_regionInjective`
- `TNLean.PEPS.fundamentalTheorem_PEPS`

The adjacent `\path{thm:fundamentalTheorem_PEPS}` remains a Blueprint label rather than a Lean declaration. Removal-ledger references to declarations that no longer exist also remain `\path` citations.

## Verification

- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `texra-blueprint paper-gaps check`
- `python3 scripts/paper_gap_leanid_sync.py --check` (2145 citations, 1733 unique heads; declaration check passed)
- `git diff --check`

Closes #7270.