### PR TITLE
docs(blueprint): align bibliography styles

### DIFF
--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -649,7 +649,7 @@
 
 % -------------------------------------------------------------------------
 %  Paper-gap notes (cite as \cite{gap:<slug>}; the note field carries the
-%  published PDF of the note as a \url link, because the alpha bibliography
+%  published PDF of the note as a \url link, because the plain bibliography
 %  style omits the url field for techreport entries in the PDF build. The
 %  link points to this repository's site for local notes and to the owning
 %  repository's site for cross-repository citations).

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -31,6 +31,6 @@
 \begin{document}
 \maketitle
 \input{content}
-\bibliographystyle{alpha}
+\bibliographystyle{plain}
 \bibliography{references}
 \end{document}


### PR DESCRIPTION
## Summary

- switch the Blueprint web entry point from `alpha` to `plain`, matching the print build and avoiding the invalid 27th same-author/year label if the web bibliography is ever processed by BibTeX
- update the paper-gap bibliography comment to name the active `plain` style while preserving the reason URLs live in each `note` field

## Verification

- `texra-blueprint bbl`
- `python3 scripts/fetch_tenkz.py`
- `texra-blueprint web`
- `git diff --check`

Closes #7275.