### PR TITLE
feat(Algebra): prove scalar cocycle inversion identities

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -24,3 +24,4 @@ import TNLean.Algebra.PiSigmaEquiv
 import TNLean.Algebra.PiTensorProductPhase
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarThreeCocycle
+import TNLean.Algebra.ScalarThreeCocycleInversion

--- a/TNLean/Algebra/ScalarThreeCocycleInversion.lean
+++ b/TNLean/Algebra/ScalarThreeCocycleInversion.lean
@@ -124,7 +124,8 @@ theorem hat_eq_mul_coboundary_Xi (ω : ScalarThreeCochain G)
   simp only [inv_mul_cancel, mul_one, mul_assoc] at hCocycle_kInvMulHInvMulGInv_g_h_k
   have hCocycle_kInv_hInv_gInv_g_val :
       (↑(ω (k⁻¹ * h⁻¹) g⁻¹ g) : ℂ) =
-        ↑(ω k⁻¹ h⁻¹ g⁻¹) * ↑(ω k⁻¹ (h⁻¹ * g⁻¹) g) * ↑(ω h⁻¹ g⁻¹ g) := by
+        ↑(ω k⁻¹ h⁻¹ g⁻¹) * ↑(ω k⁻¹ (h⁻¹ * g⁻¹) g) *
+          ↑(ω h⁻¹ g⁻¹ g) := by
     simpa only [Units.val_mul] using congrArg Units.val hCocycle_kInv_hInv_gInv_g
   have hCocycle_kInv_hInvMulGInv_g_h_val :
       (↑(ω (k⁻¹ * (h⁻¹ * g⁻¹)) g h) : ℂ) *
@@ -146,7 +147,8 @@ theorem hat_eq_mul_coboundary_Xi (ω : ScalarThreeCochain G)
     ((ω k⁻¹ h⁻¹ g⁻¹ : ℂ) * (ω h⁻¹ g⁻¹ g : ℂ) *
       (ω k⁻¹ (h⁻¹ * g⁻¹) (g * h) : ℂ)) * hCocycle_kInvMulHInvMulGInv_g_h_k_val +
     ((ω k⁻¹ h⁻¹ g⁻¹ : ℂ) * (ω h⁻¹ g⁻¹ g : ℂ) *
-      (ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k : ℂ) * (ω g h k : ℂ)) * hCocycle_kInv_hInvMulGInv_g_h_val -
+      (ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k : ℂ) * (ω g h k : ℂ)) *
+        hCocycle_kInv_hInvMulGInv_g_h_val -
     ((ω g h k : ℂ) * (ω k⁻¹ h⁻¹ h : ℂ) *
       (ω (h⁻¹ * g⁻¹) g h : ℂ) *
       (ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k : ℂ)) * hCocycle_kInv_hInv_gInv_g_val
@@ -223,10 +225,12 @@ theorem Xi_eq_hat_mul_coboundary_sigma (ω : ScalarThreeCochain G)
           ↑(ω (g * h) (h⁻¹ * g⁻¹) (g * h)) = 1 := by
     simpa only [Units.val_mul, Units.val_one] using congrArg Units.val hSigmaGH
   have hA' :
-      (↑(ω h⁻¹ g⁻¹ g) : ℂ) = ↑(ω (h⁻¹ * g⁻¹) g g⁻¹) * ↑(ω g g⁻¹ g) := by
+      (↑(ω h⁻¹ g⁻¹ g) : ℂ) =
+        ↑(ω (h⁻¹ * g⁻¹) g g⁻¹) * ↑(ω g g⁻¹ g) := by
     simpa only [Units.val_mul] using congrArg Units.val hA
   have hP' :
-      (↑(ω h h⁻¹ g⁻¹) : ℂ) = ↑(ω h⁻¹ h (h⁻¹ * g⁻¹)) * ↑(ω h h⁻¹ h) := by
+      (↑(ω h h⁻¹ g⁻¹) : ℂ) =
+        ↑(ω h⁻¹ h (h⁻¹ * g⁻¹)) * ↑(ω h h⁻¹ h) := by
     simpa only [Units.val_mul] using congrArg Units.val hP
   simp only [Xi, ScalarOneCochain.coboundary, sigma, mul_inv_rev, inv_inv]
   apply Units.ext

--- a/TNLean/Algebra/ScalarThreeCocycleInversion.lean
+++ b/TNLean/Algebra/ScalarThreeCocycleInversion.lean
@@ -1,0 +1,246 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Tactic.Group
+import Mathlib.Tactic.LinearCombination
+import TNLean.Algebra.ScalarThreeCocycle
+
+/-!
+# Inversion cochains of a scalar three-cocycle
+
+This file proves the scalar inversion identities in arXiv:2502.20257,
+`eq:introXi` and `lemma:omegaXi` (lines 5967--5979). The proofs name and combine
+the cocycle substitutions listed in the source.
+-/
+
+namespace TNLean.Algebra
+
+variable {G : Type*} [Group G]
+
+/-- A multiplicative scalar one-cochain on a group. -/
+abbrev ScalarOneCochain (G : Type*) := G → Units ℂ
+
+namespace ScalarOneCochain
+
+/-- The multiplicative coboundary of a scalar one-cochain,
+`(dσ)(g,h) = σ(g) σ(h) / σ(gh)`, as in arXiv:2502.20257, line 5916. -/
+def coboundary (σ : ScalarOneCochain G) : ScalarCocycle G :=
+  fun g h => (σ g * σ h) / σ (g * h)
+
+end ScalarOneCochain
+
+namespace ScalarCocycle
+
+/-- The hat operation on scalar two-cochains,
+`hat β(g,h) = β(h⁻¹,g⁻¹)`, obtained from arXiv:2502.20257, line 5912. -/
+def hat (β : ScalarCocycle G) : ScalarCocycle G :=
+  fun g h => β h⁻¹ g⁻¹
+
+/-- Applying the hat operation twice returns the original scalar two-cochain,
+as stated after arXiv:2502.20257, line 5912. -/
+@[simp]
+theorem hat_hat (β : ScalarCocycle G) : hat (hat β) = β := by
+  funext g h
+  simp [hat]
+
+end ScalarCocycle
+
+namespace ScalarThreeCochain
+
+/-- The hat operation on scalar three-cochains,
+`hat ω(g,h,k) = ω(k⁻¹,h⁻¹,g⁻¹)`, obtained from arXiv:2502.20257, line 5912. -/
+def hat (ω : ScalarThreeCochain G) : ScalarThreeCochain G :=
+  fun g h k => ω k⁻¹ h⁻¹ g⁻¹
+
+/-- Applying the hat operation twice returns the original scalar three-cochain,
+as stated after arXiv:2502.20257, line 5912. -/
+@[simp]
+theorem hat_hat (ω : ScalarThreeCochain G) : hat (hat ω) = ω := by
+  funext g h k
+  simp [hat]
+
+/-- The inversion two-cochain
+`Xi(g,h) = ω(h⁻¹,g⁻¹,g) / ω(h⁻¹g⁻¹,g,h)` from arXiv:2502.20257,
+`eq:introXi`. -/
+def Xi (ω : ScalarThreeCochain G) : ScalarCocycle G :=
+  fun g h => ω h⁻¹ g⁻¹ g / ω (h⁻¹ * g⁻¹) g h
+
+/-- The inversion one-cochain `σ(g) = ω(g,g⁻¹,g)` from arXiv:2502.20257,
+`eq:introXi`. -/
+def sigma (ω : ScalarThreeCochain G) : ScalarOneCochain G :=
+  fun g => ω g g⁻¹ g
+
+/-- The second formula for the inversion cochain in arXiv:2502.20257,
+`eq:introXi`:
+`Xi(g,h) = ω(h⁻¹,g⁻¹,gh) / ω(g⁻¹,g,h)`.
+
+This is the cocycle equation at `(h⁻¹,g⁻¹,g,h)`, not a definitional equality. -/
+theorem Xi_eq_second_formula (ω : ScalarThreeCochain G) (hω : IsCocycle ω)
+    (hωn : IsNormalized ω) (g h : G) :
+    Xi ω g h = ω h⁻¹ g⁻¹ (g * h) / ω g⁻¹ g h := by
+  have hCocycle := hω h⁻¹ g⁻¹ g h
+  simp only [inv_mul_cancel, hωn.2.1] at hCocycle
+  have hCocycle' :
+      (↑(ω (h⁻¹ * g⁻¹) g h) : ℂ) * ↑(ω h⁻¹ g⁻¹ (g * h)) =
+        ↑(ω h⁻¹ g⁻¹ g) * 1 * ↑(ω g⁻¹ g h) := by
+    simpa only [Units.val_mul, Units.val_one] using congrArg Units.val hCocycle
+  simp only [Xi]
+  apply Units.ext
+  push_cast
+  field_simp
+  linear_combination -hCocycle'
+
+/-- The inversion scalar satisfies `σ(g⁻¹) = σ(g)⁻¹`.
+
+The proof is the normalized cocycle equation at `(g,g⁻¹,g,g⁻¹)`, the fourth
+substitution listed for arXiv:2502.20257, `lemma:omegaXi`. -/
+theorem sigma_inv (ω : ScalarThreeCochain G) (hω : IsCocycle ω)
+    (hωn : IsNormalized ω) (g : G) :
+    sigma ω g⁻¹ = (sigma ω g)⁻¹ := by
+  have hCocycle := hω g g⁻¹ g g⁻¹
+  simp only [mul_inv_cancel, inv_mul_cancel, hωn.1, hωn.2.1, hωn.2.2] at hCocycle
+  simp only [sigma, inv_inv]
+  rw [eq_inv_iff_mul_eq_one]
+  simpa [mul_comm] using hCocycle.symm
+
+/-- For a normalized scalar three-cocycle,
+`hat ω = ω * dXi`, the first identity of arXiv:2502.20257,
+`lemma:omegaXi`.
+
+The proof combines exactly the source substitutions
+`(k⁻¹,h⁻¹,g⁻¹,g)`, `(k⁻¹,h⁻¹g⁻¹,g,h)`, and
+`(k⁻¹h⁻¹g⁻¹,g,h,k)`. -/
+theorem hat_eq_mul_coboundary_Xi (ω : ScalarThreeCochain G)
+    (hω : IsCocycle ω) (hωn : IsNormalized ω) :
+    hat ω = ω * coboundary (Xi ω) := by
+  funext g h k
+  have hCocycle_kInv_hInv_gInv_g := hω k⁻¹ h⁻¹ g⁻¹ g
+  have hCocycle_kInv_hInvMulGInv_g_h := hω k⁻¹ (h⁻¹ * g⁻¹) g h
+  have hCocycle_kInvMulHInvMulGInv_g_h_k := hω (k⁻¹ * (h⁻¹ * g⁻¹)) g h k
+  simp only [inv_mul_cancel, hωn.2.2, mul_one] at hCocycle_kInv_hInv_gInv_g
+  simp only [inv_mul_cancel, mul_one, mul_assoc] at hCocycle_kInv_hInvMulGInv_g_h
+  simp only [inv_mul_cancel, mul_one, mul_assoc] at hCocycle_kInvMulHInvMulGInv_g_h_k
+  have hCocycle_kInv_hInv_gInv_g_val :
+      (↑(ω (k⁻¹ * h⁻¹) g⁻¹ g) : ℂ) =
+        ↑(ω k⁻¹ h⁻¹ g⁻¹) * ↑(ω k⁻¹ (h⁻¹ * g⁻¹) g) * ↑(ω h⁻¹ g⁻¹ g) := by
+    simpa only [Units.val_mul] using congrArg Units.val hCocycle_kInv_hInv_gInv_g
+  have hCocycle_kInv_hInvMulGInv_g_h_val :
+      (↑(ω (k⁻¹ * (h⁻¹ * g⁻¹)) g h) : ℂ) *
+          ↑(ω k⁻¹ (h⁻¹ * g⁻¹) (g * h)) =
+        ↑(ω k⁻¹ (h⁻¹ * g⁻¹) g) * ↑(ω k⁻¹ h⁻¹ h) *
+          ↑(ω (h⁻¹ * g⁻¹) g h) := by
+    simpa only [Units.val_mul, mul_assoc] using congrArg Units.val hCocycle_kInv_hInvMulGInv_g_h
+  have hCocycle_kInvMulHInvMulGInv_g_h_k_val :
+      (↑(ω (k⁻¹ * h⁻¹) h k) : ℂ) *
+          ↑(ω (k⁻¹ * (h⁻¹ * g⁻¹)) g (h * k)) =
+        ↑(ω (k⁻¹ * (h⁻¹ * g⁻¹)) g h) *
+          ↑(ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k) * ↑(ω g h k) := by
+    simpa only [Units.val_mul, mul_assoc] using congrArg Units.val hCocycle_kInvMulHInvMulGInv_g_h_k
+  simp only [hat, coboundary, Xi, Pi.mul_apply, mul_inv_rev, mul_assoc]
+  apply Units.ext
+  push_cast
+  field_simp
+  linear_combination
+    ((ω k⁻¹ h⁻¹ g⁻¹ : ℂ) * (ω h⁻¹ g⁻¹ g : ℂ) *
+      (ω k⁻¹ (h⁻¹ * g⁻¹) (g * h) : ℂ)) * hCocycle_kInvMulHInvMulGInv_g_h_k_val +
+    ((ω k⁻¹ h⁻¹ g⁻¹ : ℂ) * (ω h⁻¹ g⁻¹ g : ℂ) *
+      (ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k : ℂ) * (ω g h k : ℂ)) * hCocycle_kInv_hInvMulGInv_g_h_val -
+    ((ω g h k : ℂ) * (ω k⁻¹ h⁻¹ h : ℂ) *
+      (ω (h⁻¹ * g⁻¹) g h : ℂ) *
+      (ω (k⁻¹ * (h⁻¹ * g⁻¹)) (g * h) k : ℂ)) * hCocycle_kInv_hInv_gInv_g_val
+
+/-- For a normalized scalar three-cocycle,
+`Xi = hat Xi * dσ`, the second identity of arXiv:2502.20257,
+`lemma:omegaXi`.
+
+After rewriting the hatted `Xi` by `Xi_eq_second_formula`, the proof uses the source
+substitutions `(h⁻¹g⁻¹,g,h,h⁻¹g⁻¹)`, `(h⁻¹,h,h⁻¹,g⁻¹)`, and
+`(h⁻¹,g⁻¹,g,g⁻¹)`. The fourth substitution `(u,u⁻¹,u,u⁻¹)` is used through
+`sigma_inv` at `u = g`, `h`, and `gh`. -/
+theorem Xi_eq_hat_mul_coboundary_sigma (ω : ScalarThreeCochain G)
+    (hω : IsCocycle ω) (hωn : IsNormalized ω) :
+    Xi ω = ScalarCocycle.hat (Xi ω) * ScalarOneCochain.coboundary (sigma ω) := by
+  funext g h
+  simp only [Pi.mul_apply]
+  rw [show ScalarCocycle.hat (Xi ω) g h = Xi ω h⁻¹ g⁻¹ by rfl]
+  nth_rewrite 2 [Xi_eq_second_formula ω hω hωn]
+  have hCocycle_hInvMulGInv_g_h_hInvMulGInv_raw := hω (h⁻¹ * g⁻¹) g h (h⁻¹ * g⁻¹)
+  have hCocycle_hInvMulGInv_g_h_hInvMulGInv :
+      ω h⁻¹ h (h⁻¹ * g⁻¹) * ω (h⁻¹ * g⁻¹) g g⁻¹ =
+        ω (h⁻¹ * g⁻¹) g h * ω (h⁻¹ * g⁻¹) (g * h) (h⁻¹ * g⁻¹) *
+          ω g h (h⁻¹ * g⁻¹) := by
+    convert hCocycle_hInvMulGInv_g_h_hInvMulGInv_raw using 1
+    all_goals group
+  have hCocycle_hInv_h_hInv_gInv :
+      ω h⁻¹ h (h⁻¹ * g⁻¹) = ω h⁻¹ h h⁻¹ * ω h h⁻¹ g⁻¹ := by
+    simpa only [inv_mul_cancel, mul_inv_cancel, hωn.1, hωn.2.1, one_mul, mul_one]
+      using hω h⁻¹ h h⁻¹ g⁻¹
+  have hCocycle_hInv_gInv_g_gInv :
+      ω (h⁻¹ * g⁻¹) g g⁻¹ = ω h⁻¹ g⁻¹ g * ω g⁻¹ g g⁻¹ := by
+    simpa only [inv_mul_cancel, mul_inv_cancel, hωn.2.1, hωn.2.2, mul_one]
+      using hω h⁻¹ g⁻¹ g g⁻¹
+  have hSigmaG : ω g⁻¹ g g⁻¹ * ω g g⁻¹ g = 1 := by
+    have hInv := sigma_inv ω hω hωn g
+    have hOne : sigma ω g⁻¹ * sigma ω g = 1 := by rw [hInv, inv_mul_cancel]
+    simpa only [sigma, inv_inv] using hOne
+  have hSigmaH : ω h⁻¹ h h⁻¹ * ω h h⁻¹ h = 1 := by
+    have hInv := sigma_inv ω hω hωn h
+    have hOne : sigma ω h⁻¹ * sigma ω h = 1 := by rw [hInv, inv_mul_cancel]
+    simpa only [sigma, inv_inv] using hOne
+  have hSigmaGH :
+      ω (h⁻¹ * g⁻¹) (g * h) (h⁻¹ * g⁻¹) *
+          ω (g * h) (h⁻¹ * g⁻¹) (g * h) = 1 := by
+    have hInv := sigma_inv ω hω hωn (g * h)
+    have hOne : sigma ω (g * h)⁻¹ * sigma ω (g * h) = 1 := by
+      rw [hInv, inv_mul_cancel]
+    simpa only [sigma, mul_inv_rev, inv_inv] using hOne
+  have hA :
+      ω h⁻¹ g⁻¹ g = ω (h⁻¹ * g⁻¹) g g⁻¹ * ω g g⁻¹ g := by
+    calc
+      ω h⁻¹ g⁻¹ g = ω h⁻¹ g⁻¹ g * (ω g⁻¹ g g⁻¹ * ω g g⁻¹ g) := by
+        rw [hSigmaG, mul_one]
+      _ = (ω h⁻¹ g⁻¹ g * ω g⁻¹ g g⁻¹) * ω g g⁻¹ g := by
+        rw [mul_assoc]
+      _ = ω (h⁻¹ * g⁻¹) g g⁻¹ * ω g g⁻¹ g := by rw [← hCocycle_hInv_gInv_g_gInv]
+  have hP :
+      ω h h⁻¹ g⁻¹ = ω h⁻¹ h (h⁻¹ * g⁻¹) * ω h h⁻¹ h := by
+    calc
+      ω h h⁻¹ g⁻¹ = (ω h⁻¹ h h⁻¹ * ω h h⁻¹ h) * ω h h⁻¹ g⁻¹ := by
+        rw [hSigmaH, one_mul]
+      _ = (ω h⁻¹ h h⁻¹ * ω h h⁻¹ g⁻¹) * ω h h⁻¹ h := by ac_rfl
+      _ = ω h⁻¹ h (h⁻¹ * g⁻¹) * ω h h⁻¹ h := by rw [← hCocycle_hInv_h_hInv_gInv]
+  have hCocycle_hInvMulGInv_g_h_hInvMulGInv_val :
+      (↑(ω h⁻¹ h (h⁻¹ * g⁻¹)) : ℂ) * ↑(ω (h⁻¹ * g⁻¹) g g⁻¹) =
+        ↑(ω (h⁻¹ * g⁻¹) g h) *
+          ↑(ω (h⁻¹ * g⁻¹) (g * h) (h⁻¹ * g⁻¹)) *
+            ↑(ω g h (h⁻¹ * g⁻¹)) := by
+    simpa only [Units.val_mul, mul_assoc] using
+      congrArg Units.val hCocycle_hInvMulGInv_g_h_hInvMulGInv
+  have hSigmaGH' :
+      (↑(ω (h⁻¹ * g⁻¹) (g * h) (h⁻¹ * g⁻¹)) : ℂ) *
+          ↑(ω (g * h) (h⁻¹ * g⁻¹) (g * h)) = 1 := by
+    simpa only [Units.val_mul, Units.val_one] using congrArg Units.val hSigmaGH
+  have hA' :
+      (↑(ω h⁻¹ g⁻¹ g) : ℂ) = ↑(ω (h⁻¹ * g⁻¹) g g⁻¹) * ↑(ω g g⁻¹ g) := by
+    simpa only [Units.val_mul] using congrArg Units.val hA
+  have hP' :
+      (↑(ω h h⁻¹ g⁻¹) : ℂ) = ↑(ω h⁻¹ h (h⁻¹ * g⁻¹)) * ↑(ω h h⁻¹ h) := by
+    simpa only [Units.val_mul] using congrArg Units.val hP
+  simp only [Xi, ScalarOneCochain.coboundary, sigma, mul_inv_rev, inv_inv]
+  apply Units.ext
+  push_cast
+  field_simp
+  linear_combination
+    ((ω h h⁻¹ g⁻¹ : ℂ) * (ω (g * h) (h⁻¹ * g⁻¹) (g * h) : ℂ)) * hA' +
+    ((ω (h⁻¹ * g⁻¹) g g⁻¹ : ℂ) * (ω g g⁻¹ g : ℂ) *
+      (ω (g * h) (h⁻¹ * g⁻¹) (g * h) : ℂ)) * hP' +
+    ((ω g g⁻¹ g : ℂ) * (ω h h⁻¹ h : ℂ) *
+      (ω (g * h) (h⁻¹ * g⁻¹) (g * h) : ℂ)) * hCocycle_hInvMulGInv_g_h_hInvMulGInv_val +
+    ((ω (h⁻¹ * g⁻¹) g h : ℂ) * (ω g h (h⁻¹ * g⁻¹) : ℂ) *
+      (ω g g⁻¹ g : ℂ) * (ω h h⁻¹ h : ℂ)) * hSigmaGH'
+
+end ScalarThreeCochain
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -220,3 +220,122 @@ they do not construct fusion tensors or an MPU representation.
     A scalar $3$-cochain has trivial gauge class when it is cohomologous to
     the constant cochain $1$.
 \end{definition}
+
+\begin{definition}[Inversion cochains]
+    \label{def:mpug_inversion_cochains}
+    \lean{TNLean.Algebra.ScalarOneCochain,
+        TNLean.Algebra.ScalarOneCochain.coboundary,
+        TNLean.Algebra.ScalarCocycle.hat,
+        TNLean.Algebra.ScalarThreeCochain.hat,
+        TNLean.Algebra.ScalarThreeCochain.Xi,
+        TNLean.Algebra.ScalarThreeCochain.sigma}
+    \leanok
+    \uses{def:mpug_scalar_cochains}
+    For scalar cochains with one, two, and three arguments, set
+    \begin{equation}
+        (d\sigma)(g,h)=\frac{\sigma(g)\sigma(h)}{\sigma(gh)}.
+        \label{eq:mpug_one_coboundary}
+    \end{equation}
+    The hat reverses the arguments and replaces each group element by its
+    inverse:
+    \begin{equation}
+        \widehat\beta(g,h)=\beta(h^{-1},g^{-1}).
+        \label{eq:mpug_two_hat}
+    \end{equation}
+    \begin{equation}
+        \widehat\omega(g,h,k)=\omega(k^{-1},h^{-1},g^{-1}).
+        \label{eq:mpug_three_hat}
+    \end{equation}
+    Define the inversion cochains by
+    \begin{equation}
+        \Xi(g,h)=
+        \frac{\omega(h^{-1},g^{-1},g)}
+             {\omega(h^{-1}g^{-1},g,h)}.
+        \label{eq:mpug_intro_Xi}
+    \end{equation}
+    \begin{equation}
+        \sigma(g)=\omega(g,g^{-1},g).
+        \label{eq:mpug_intro_sigma}
+    \end{equation}
+    % Source anchors: arXiv:2502.20257, lines 5910--5916 and eq:introXi.
+\end{definition}
+
+\begin{theorem}[Two inversion-cochain formulas]
+    \label{thm:mpug_inversion_cochain_formulas}
+    \lean{TNLean.Algebra.ScalarCocycle.hat_hat,
+        TNLean.Algebra.ScalarThreeCochain.hat_hat,
+        TNLean.Algebra.ScalarThreeCochain.Xi_eq_second_formula,
+        TNLean.Algebra.ScalarThreeCochain.sigma_inv}
+    \leanok
+    \uses{def:mpug_three_cocycle, def:mpug_inversion_cochains}
+    Let $\omega$ be a normalized scalar $3$-cocycle. The hat operation is an
+    involution, and
+    \begin{equation}
+        \Xi(g,h)=
+        \frac{\omega(h^{-1},g^{-1},g)}
+             {\omega(h^{-1}g^{-1},g,h)}
+        =
+        \frac{\omega(h^{-1},g^{-1},gh)}
+             {\omega(g^{-1},g,h)}.
+        \label{eq:mpug_Xi_two_formulas}
+    \end{equation}
+    Moreover,
+    \begin{equation}
+        \sigma(g^{-1})=\sigma(g)^{-1}.
+        \label{eq:mpug_sigma_inverse}
+    \end{equation}
+    No finiteness assumption on $G$ is needed.
+    % Source anchor: arXiv:2502.20257, eq:introXi and lemma:omegaXi.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_three_cocycle, def:mpug_inversion_cochains}
+    Apply the cocycle identity to $(h^{-1},g^{-1},g,h)$ and use normalization;
+    this gives the second quotient in
+    (\ref{eq:mpug_Xi_two_formulas}). Applying it to
+    $(g,g^{-1},g,g^{-1})$ gives
+    $1=\sigma(g)\sigma(g^{-1})$, hence
+    (\ref{eq:mpug_sigma_inverse}). Reversing and inverting the arguments twice
+    proves the involution statements.
+\end{proof}
+
+\begin{theorem}[Inversion identities for a normalized three-cocycle]
+    \label{thm:mpug_omega_Xi}
+    \lean{TNLean.Algebra.ScalarThreeCochain.hat_eq_mul_coboundary_Xi,
+        TNLean.Algebra.ScalarThreeCochain.Xi_eq_hat_mul_coboundary_sigma}
+    \leanok
+    \uses{def:mpug_fusion_gauge, def:mpug_inversion_cochains,
+        thm:mpug_inversion_cochain_formulas}
+    Let $\omega$ be a normalized scalar $3$-cocycle. Then
+    \begin{equation}
+        \widehat\omega=\omega\,d\Xi.
+        \label{eq:mpug_hat_omega}
+    \end{equation}
+    The inversion two-cochain also satisfies
+    \begin{equation}
+        \Xi=\widehat\Xi\,d\sigma.
+        \label{eq:mpug_Xi_hat_sigma}
+    \end{equation}
+    % Source anchor: arXiv:2502.20257, lemma:omegaXi, lines 5967--5979.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_three_cocycle, thm:mpug_inversion_cochain_formulas}
+    For (\ref{eq:mpug_hat_omega}), multiply the cocycle identities at
+    \begin{equation}
+        (k^{-1},h^{-1},g^{-1},g),\quad
+        (k^{-1},h^{-1}g^{-1},g,h),\quad
+        (k^{-1}h^{-1}g^{-1},g,h,k),
+    \end{equation}
+    and cancel the normalized factors. For (\ref{eq:mpug_Xi_hat_sigma}), use
+    the second expression in (\ref{eq:mpug_Xi_two_formulas}) for
+    $\widehat\Xi$, then combine the identities at
+    \begin{equation}
+        (h^{-1}g^{-1},g,h,h^{-1}g^{-1}),\quad
+        (h^{-1},h,h^{-1},g^{-1}),\quad
+        (h^{-1},g^{-1},g,g^{-1}),\quad
+        (g,g^{-1},g,g^{-1}).
+    \end{equation}
+    The last identity at $g$, $h$, and $gh$ supplies
+    (\ref{eq:mpug_sigma_inverse}) in the three required places.
+\end{proof}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -231,32 +231,34 @@ they do not construct fusion tensors or an MPU representation.
         TNLean.Algebra.ScalarThreeCochain.sigma}
     \leanok
     \uses{def:mpug_scalar_cochains}
+    These conventions and inversion cochains follow
+    \cite[lines~5910--5916 and 5967--5973]{FrancoRubio2025MPUGauging}.
     For scalar cochains with one, two, and three arguments, set
-    \begin{equation}
-        (d\sigma)(g,h)=\frac{\sigma(g)\sigma(h)}{\sigma(gh)}.
+    \begin{align}
+        (d\sigma)(g,h) & =\frac{\sigma(g)\sigma(h)}{\sigma(gh)}.
         \label{eq:mpug_one_coboundary}
-    \end{equation}
+    \end{align}
     The hat reverses the arguments and replaces each group element by its
     inverse:
-    \begin{equation}
-        \widehat\beta(g,h)=\beta(h^{-1},g^{-1}).
+    \begin{align}
+        \widehat\beta(g,h) & =\beta(h^{-1},g^{-1}).
         \label{eq:mpug_two_hat}
-    \end{equation}
-    \begin{equation}
-        \widehat\omega(g,h,k)=\omega(k^{-1},h^{-1},g^{-1}).
+    \end{align}
+    \begin{align}
+        \widehat\omega(g,h,k) & =\omega(k^{-1},h^{-1},g^{-1}).
         \label{eq:mpug_three_hat}
-    \end{equation}
+    \end{align}
     Define the inversion cochains by
-    \begin{equation}
-        \Xi(g,h)=
+    \begin{align}
+        \Xi(g,h) & =
         \frac{\omega(h^{-1},g^{-1},g)}
-             {\omega(h^{-1}g^{-1},g,h)}.
+        {\omega(h^{-1}g^{-1},g,h)}.
         \label{eq:mpug_intro_Xi}
-    \end{equation}
-    \begin{equation}
-        \sigma(g)=\omega(g,g^{-1},g).
+    \end{align}
+    \begin{align}
+        \sigma(g) & =\omega(g,g^{-1},g).
         \label{eq:mpug_intro_sigma}
-    \end{equation}
+    \end{align}
     % Source anchors: arXiv:2502.20257, lines 5910--5916 and eq:introXi.
 \end{definition}
 
@@ -268,22 +270,24 @@ they do not construct fusion tensors or an MPU representation.
         TNLean.Algebra.ScalarThreeCochain.sigma_inv}
     \leanok
     \uses{def:mpug_three_cocycle, def:mpug_inversion_cochains}
+    These formulas are part of the cocycle calculation in
+    \cite[lines~5967--5979]{FrancoRubio2025MPUGauging}.
     Let $\omega$ be a normalized scalar $3$-cocycle. The hat operation is an
     involution, and
-    \begin{equation}
-        \Xi(g,h)=
+    \begin{align}
+        \Xi(g,h) & =
         \frac{\omega(h^{-1},g^{-1},g)}
-             {\omega(h^{-1}g^{-1},g,h)}
+        {\omega(h^{-1}g^{-1},g,h)}
         =
         \frac{\omega(h^{-1},g^{-1},gh)}
-             {\omega(g^{-1},g,h)}.
+        {\omega(g^{-1},g,h)}.
         \label{eq:mpug_Xi_two_formulas}
-    \end{equation}
+    \end{align}
     Moreover,
-    \begin{equation}
-        \sigma(g^{-1})=\sigma(g)^{-1}.
+    \begin{align}
+        \sigma(g^{-1}) & =\sigma(g)^{-1}.
         \label{eq:mpug_sigma_inverse}
-    \end{equation}
+    \end{align}
     No finiteness assumption on $G$ is needed.
     % Source anchor: arXiv:2502.20257, eq:introXi and lemma:omegaXi.
 \end{theorem}
@@ -306,36 +310,38 @@ they do not construct fusion tensors or an MPU representation.
     \leanok
     \uses{def:mpug_fusion_gauge, def:mpug_inversion_cochains,
         thm:mpug_inversion_cochain_formulas}
+    These inversion identities and their cocycle substitutions are given in
+    \cite[lines~5967--5979]{FrancoRubio2025MPUGauging}.
     Let $\omega$ be a normalized scalar $3$-cocycle. Then
-    \begin{equation}
-        \widehat\omega=\omega\,d\Xi.
+    \begin{align}
+        \widehat\omega & =\omega\,d\Xi.
         \label{eq:mpug_hat_omega}
-    \end{equation}
+    \end{align}
     The inversion two-cochain also satisfies
-    \begin{equation}
-        \Xi=\widehat\Xi\,d\sigma.
+    \begin{align}
+        \Xi & =\widehat\Xi\,d\sigma.
         \label{eq:mpug_Xi_hat_sigma}
-    \end{equation}
+    \end{align}
     % Source anchor: arXiv:2502.20257, lemma:omegaXi, lines 5967--5979.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_three_cocycle, thm:mpug_inversion_cochain_formulas}
     For (\ref{eq:mpug_hat_omega}), multiply the cocycle identities at
-    \begin{equation}
-        (k^{-1},h^{-1},g^{-1},g),\quad
+    \begin{align}
+         & (k^{-1},h^{-1},g^{-1},g),\quad
         (k^{-1},h^{-1}g^{-1},g,h),\quad
         (k^{-1}h^{-1}g^{-1},g,h,k),
-    \end{equation}
+    \end{align}
     and cancel the normalized factors. For (\ref{eq:mpug_Xi_hat_sigma}), use
     the second expression in (\ref{eq:mpug_Xi_two_formulas}) for
     $\widehat\Xi$, then combine the identities at
-    \begin{equation}
-        (h^{-1}g^{-1},g,h,h^{-1}g^{-1}),\quad
+    \begin{align}
+         & (h^{-1}g^{-1},g,h,h^{-1}g^{-1}),\quad
         (h^{-1},h,h^{-1},g^{-1}),\quad
         (h^{-1},g^{-1},g,g^{-1}),\quad
         (g,g^{-1},g,g^{-1}).
-    \end{equation}
+    \end{align}
     The last identity at $g$, $h$, and $gh$ supplies
     (\ref{eq:mpug_sigma_inverse}) in the three required places.
 \end{proof}


### PR DESCRIPTION
### Motivation

- Formalize `eq:introXi` and `lemma:omegaXi` from `Papers/2502.20257/main.tex:5912,5967--5979` on top of the scalar three-cocycle API merged in #7277.
- Preserve the paper's explicit cocycle-substitution proof instead of replacing it with an abstract cohomology argument.

### Description

- Add scalar one-cochains and their multiplicative coboundary.
- Add the paper's reversal-and-inversion hat operations on scalar two- and three-cochains.
- Define $\Xi$ and $\sigma$, and prove the second displayed formula for $\Xi$ from the cocycle equation.
- Prove $\sigma(g^{-1})=\sigma(g)^{-1}$ without asserting the stronger unsupported symmetry $\sigma(g)=\sigma(g^{-1})$.
- Prove
  \[
  \widehat\omega=\omega\,d\Xi,
  \qquad
  \Xi=\widehat\Xi\,d\sigma
  \]
  using exactly the substitutions listed in the source.
- Add formula-driven Chapter 29 Blueprint coverage with direct dependencies.

### Testing

- `lake build TNLean.Algebra.ScalarThreeCocycleInversion TNLean.Algebra`
- `lake build`
- import-aggregator, forbidden-token, and diff-scoped reader-facing prose checks
- Blueprint forward sync, reverse coverage, and `leanblueprint checkdecls`
- two-pass Blueprint render with no undefined cross-references
- exact Lean line-length check and `git diff --check origin/main...HEAD`

---
Closes #7267

### Agent assistance

- TeXRA Lean agents using `gpt56` researched the exact source substitutions, implemented the Lean proofs and Blueprint entries, and performed independent Lean-style and Blueprint reviews. The branch incorporates the only review finding, four line-wrap fixes.
