### PR TITLE
fix(Spectral): bridge gauged intertwining to MPS equivalence

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -47,6 +47,22 @@ theorem gaugePhaseEquiv_of_krausGaugePhaseEquiv
   change B i = μ⁻¹ • (Xinv * A i * X)
   rw [hstep, smul_smul, inv_mul_cancel₀ hμ_ne0, one_smul]
 
+/-- Intertwining after invertible gauges yields gauge-phase equivalence of the original tensors. -/
+theorem gaugePhaseEquiv_of_gauged_intertwining
+    (A B : MPSTensor d D)
+    (SA SB X' : Matrix (Fin D) (Fin D) ℂ) (μ : ℂ)
+    (hSA_det : SA.det ≠ 0) (hSB_det : SB.det ≠ 0)
+    (hX'_u : IsUnit X'.det) (hμ : ‖μ‖ = 1)
+    (hInter :
+      ∀ i : Fin d, Kraus.gaugeTensor SA A i * X' = μ • X' * Kraus.gaugeTensor SB B i) :
+    GaugePhaseEquiv A B := by
+  rcases eq_or_ne D 0 with rfl | hD
+  · exact ⟨1, 1, one_ne_zero, fun i => by ext a; exact a.elim0⟩
+  let _ : NeZero D := ⟨hD⟩
+  exact gaugePhaseEquiv_of_krausGaugePhaseEquiv <|
+    Kraus.gaugePhaseEquiv_of_gauged_intertwining
+      A B SA SB X' μ hSA_det hSB_det hX'_u hμ hInter
+
 /-- If the mixed transfer spectral radius of two irreducible left-canonical tensors is at least
 `1`, then the tensors are gauge-phase equivalent. -/
 theorem modulus_one_eigenvalue_implies_gauge_of_irreducible_TP

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -165,7 +165,7 @@ dimension once they are invertible.
 
 \begin{lemma}[Intertwining yields gauge-phase equivalence]%
     \label{thm:gauged_intertwining_gauge_phase}
-    \lean{Kraus.gaugePhaseEquiv_of_gauged_intertwining}
+    \lean{MPSTensor.gaugePhaseEquiv_of_gauged_intertwining}
     \leanok
     \uses{def:gauge_phase_equiv}
     Let $A$ and $B$ be tensors of the same bond dimension. Suppose invertible


### PR DESCRIPTION
Closes #6954.

- adds a public `MPSTensor.gaugePhaseEquiv_of_gauged_intertwining` wrapper
- composes the QICLean gauged-intertwining theorem with TNLean's existing relation-shape bridge
- handles the zero bond-dimension case directly, so the Blueprint statement does not gain an unstated `NeZero D` assumption
- retags the Blueprint lemma to the exact local `MPSTensor.GaugePhaseEquiv` conclusion

Verification:
- targeted `lake env lean TNLean/Spectral/TransferOperatorGapNT.lean`
- targeted `lake exe checkdecls` for the new declaration
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci` (6,669 unique tags synchronized; affected chapter 8/8)
- proof-integrity scan
- `git diff --check`

A full cached checkdecls run was stale only for 33 intervening ScalarThreeCocycleInversion declarations; it did not miss the new declaration. No broad rebuild was run.