### PR TITLE
refactor: remove residual linter suppressions

### DIFF
--- a/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
@@ -150,15 +150,6 @@ private lemma bellEmbedding_isometry : bellEmbeddingᴴ * bellEmbedding = 1 := b
       Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)] <;>
     norm_num
 
-set_option linter.unusedFintypeInType false in
-private lemma reindex_isometry {a b a' b' : Type*} [Fintype a] [Fintype b]
-    [Fintype a'] [Fintype b'] [DecidableEq b] [DecidableEq b']
-    (A : Matrix a b ℂ) (ha : a ≃ a') (hb : b ≃ b') (hA : Aᴴ * A = 1) :
-    (Matrix.reindex ha hb A)ᴴ * Matrix.reindex ha hb A = 1 := by
-  rw [Matrix.conjTranspose_reindex]
-  change Aᴴ.submatrix hb.symm ha.symm * A.submatrix ha.symm hb.symm = 1
-  rw [Matrix.submatrix_mul_equiv, hA, Matrix.submatrix_one_equiv]
-
 private lemma rawFour_isometry : rawFourᴴ * rawFour = 1 := by
   apply Matrix.IsIsometry.kronecker bellEmbedding _ bellEmbedding_isometry
   apply Matrix.IsIsometry.kronecker bellEmbedding _ bellEmbedding_isometry
@@ -166,7 +157,7 @@ private lemma rawFour_isometry : rawFourᴴ * rawFour = 1 := by
     bellEmbedding_isometry
 
 private theorem VFour_isometry : VFourᴴ * VFour = 1 :=
-  reindex_isometry rawFour rowFourEquiv (Equiv.refl _) rawFour_isometry
+  Matrix.IsIsometry.reindex rawFour rawFour_isometry rowFourEquiv (Equiv.refl _)
 
 private theorem amplitude (κ : Fin 4 → Fin 2) (σ : Fin 4 → Fin 4) :
     Matrix.trace ((List.ofFn fun l => purifier (σ l) (κ l)).prod) =
@@ -430,7 +421,7 @@ private lemma VThree_apply (σ : Fin 3 → Fin 4) (x : Bool × Bool × Bool × B
   rfl
 
 private lemma VThree_isometry : VThreeᴴ * VThree = 1 := by
-  apply reindex_isometry rawThree rowThreeEquiv (Equiv.refl _)
+  apply Matrix.IsIsometry.reindex rawThree _ rowThreeEquiv (Equiv.refl _)
   apply Matrix.IsIsometry.kronecker bitEmbedding _ bitEmbedding_isometry
   apply Matrix.IsIsometry.kronecker bellEmbedding _ bellEmbedding_isometry
   exact Matrix.IsIsometry.kronecker bellEmbedding bitEmbedding bellEmbedding_isometry
@@ -459,7 +450,7 @@ private lemma VTwo_apply (σ : Fin 2 → Fin 4) (x : Bool × Bool × Bool) :
   rfl
 
 private lemma VTwo_isometry : VTwoᴴ * VTwo = 1 := by
-  apply reindex_isometry rawTwo rowTwoEquiv (Equiv.refl _)
+  apply Matrix.IsIsometry.reindex rawTwo _ rowTwoEquiv (Equiv.refl _)
   apply Matrix.IsIsometry.kronecker bitEmbedding _ bitEmbedding_isometry
   exact Matrix.IsIsometry.kronecker bellEmbedding bitEmbedding bellEmbedding_isometry
     bitEmbedding_isometry
@@ -482,7 +473,7 @@ private lemma VOne_apply (σ : Fin 1 → Fin 4) (x : Bool × Bool) :
   rfl
 
 private lemma VOne_isometry : VOneᴴ * VOne = 1 := by
-  apply reindex_isometry rawOne rowOneEquiv (Equiv.refl _)
+  apply Matrix.IsIsometry.reindex rawOne _ rowOneEquiv (Equiv.refl _)
   exact Matrix.IsIsometry.kronecker bitEmbedding bitEmbedding bitEmbedding_isometry
     bitEmbedding_isometry
 

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -40,7 +40,7 @@ private theorem threeFormSubmodule_eq_span_generatorSet
     residualMulProjectorSubmodule, residualMulProjectorMulResidualSubmodule,
     threeFormGeneratorSet, Submodule.span_union]
 
-set_option linter.unusedDecidableInType false in
+omit [DecidableEq n] in
 private theorem threeForm_generator_mul_eq_mul_projector_mul
     (E : Matrix n n ℂ) (A : NonUnitalSubalgebra ℂ (Matrix n n ℂ))
     (hE : E * E = E) (hEAE : ∀ a : A, E * (a : Matrix n n ℂ) * E = 0)
@@ -124,7 +124,7 @@ theorem mul_eq_mul_projector_mul_of_mem_threeFormSubmodule
   | add x z _ _ hx hz => simp [Matrix.add_mul, hx, hz]
   | smul c x _ hx => simp [hx]
 
-set_option linter.unusedDecidableInType false in
+omit [DecidableEq n] in
 private theorem trace_mul_projector_eq_zero_generator
     (E : Matrix n n ℂ) (A : NonUnitalSubalgebra ℂ (Matrix n n ℂ))
     (hE : E * E = E) (hEAE : ∀ a : A, E * (a : Matrix n n ℂ) * E = 0)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -829,16 +829,14 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     HasUniqueGroundState (chainGroundSpace A (2 * L₀) N) := by
   exact parentHamiltonian_unique_gs hA hL₀ (by omega) hN
 
-set_option linter.unusedVariables false in
 /-- Unique ground state for normal tensors at range \(L₀+1\) on every ring
 with \(L₀+1\le N\): \(\dim \mathcal G_{N,L₀+1}(A)=1\). This is
 arXiv:2011.12127, Section IV.C, lines 2086--2094.
 
 The normality hypothesis is redundant because positive-length block injectivity already
 implies normality; it is retained in this specialization. -/
-@[nolint unusedArguments]
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
-    {L₀ : ℕ} (hA : Kraus.IsNormal A) (hInj : Kraus.IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {L₀ : ℕ} (_hA : Kraus.IsNormal A) (hInj : Kraus.IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :
     HasUniqueGroundState (chainGroundSpace A (L₀ + 1) N) := by
   exact parentHamiltonian_unique_gs hInj hL₀ (by omega) hN


### PR DESCRIPTION
Closes #4037.

- generalizes two private SimpleBlocking helpers with `omit [DecidableEq n]` instead of disabling declaration linters
- deletes a duplicate private reindexing-isometry helper in favor of QICLean's existing `Matrix.IsIsometry.reindex`
- retains the sourced normal-tensor specialization while marking its deliberately redundant normality binder with the standard underscore convention
- removes all five remaining TNLean linter-suppression annotations

No public mathematical proposition changes, and no new compatibility aliases or suppressions are added.

Verification:
- targeted `lake env lean` on all three touched files
- targeted package-option builds with declaration linters enabled
- `lake exe lint_style`
- repo-wide linter-suppression scan (zero remaining under `TNLean/`)
- proof-integrity scan
- `git diff --check`