### PR TITLE
feat(algebra): formalize scalar L-symbol gauge relations

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -17,6 +17,7 @@ import TNLean.Algebra.FinCyclicInduction
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FinsetSubtypeSum
+import TNLean.Algebra.LSymbol
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NegMulLog

--- a/TNLean/Algebra/LSymbol.lean
+++ b/TNLean/Algebra/LSymbol.lean
@@ -68,12 +68,22 @@ theorem IsCompatible.gauge {L : LSymbol G X} {ω : ScalarThreeCochain G}
     (hL : IsCompatible L ω) (β : ScalarCocycle G) (γ : ActionTensorGauge G X) :
     IsCompatible (gauge β γ L) (ScalarThreeCochain.fusionGauge β ω) := by
   intro x g h k
-  simp only [gauge, ScalarThreeCochain.fusionGauge, ScalarThreeCochain.coboundary]
-  rw [hL]
+  simp only [LSymbol.gauge, ScalarThreeCochain.fusionGauge,
+    ScalarThreeCochain.coboundary]
   apply Units.ext
   push_cast
-  simp only [map_mul, map_div, smul_smul]
+  simp only [smul_smul]
+  have hL' := congrArg Units.val (hL x g h k)
+  push_cast at hL'
   field_simp
+  simp only [mul_assoc]
+  calc
+    _ = (γ (g * (h * k)) x : ℂ) *
+        ((L x g (h * k) : ℂ) * (L x h k : ℂ)) := by ring
+    _ = (γ (g * (h * k)) x : ℂ) *
+        ((ω g h k : ℂ) * (L (k • x) g h : ℂ) * (L x (g * h) k : ℂ)) := by
+      rw [hL']
+    _ = _ := by ring
 
 /-- L-symbols are normalized when `Lˣ_{g,1} = Lˣ_{1,g} = 1`. This is the
 standing convention in arXiv:2502.20257, `eq:triv_Ls`. -/
@@ -102,20 +112,20 @@ theorem isNormalized_gauge_iff (β : ScalarCocycle G) (γ : ActionTensorGauge G 
   constructor
   · rintro ⟨hright, hleft⟩
     refine ⟨fun x g => ?_, fun x g => ?_⟩
-    · exact (div_mul_eq_one_iff_eq (γ 1 x)).mp (hright x g)
-    · exact (div_mul_eq_one_iff_eq (γ 1 (g • x))).mp (hleft x g)
+    · simpa only [div_mul_eq_mul_div, div_eq_one] using hright x g
+    · simpa only [div_mul_eq_mul_div, div_eq_one] using hleft x g
   · rintro ⟨hright, hleft⟩
     refine ⟨fun x g => ?_, fun x g => ?_⟩
-    · exact (div_mul_eq_one_iff_eq (γ 1 x)).mpr (hright x g)
-    · exact (div_mul_eq_one_iff_eq (γ 1 (g • x))).mpr (hleft x g)
+    · simpa only [div_mul_eq_mul_div, div_eq_one] using hright x g
+    · simpa only [div_mul_eq_mul_div, div_eq_one] using hleft x g
 
 /-- Normalized fusion and action gauges preserve normalized L-symbols. -/
 theorem IsNormalized.gauge {L : LSymbol G X} (hL : IsNormalized L)
     {β : ScalarCocycle G} (hβ : β.IsNormalized) {γ : ActionTensorGauge G X}
     (hγ : γ.IsNormalized) : IsNormalized (gauge β γ L) := by
   apply (isNormalized_gauge_iff β γ L).2
-  exact ⟨fun x g => by simp [hβ.2, hL.1, hγ],
-    fun x g => by simp [hβ.1, hL.2, hγ]⟩
+  exact ⟨fun x g => by simp [hβ.2, hL.1, hγ x],
+    fun x g => by simp [hβ.1, hL.2, hγ (g • x)]⟩
 
 end LSymbol
 

--- a/TNLean/Algebra/LSymbol.lean
+++ b/TNLean/Algebra/LSymbol.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarThreeCocycle
+
+/-!
+# Scalar L-symbols
+
+This file isolates the scalar L-symbol relations in arXiv:2502.20257,
+equations `eq:Lsymbgauge`, `eq:omega_and_Ls`, and `eq:triv_Ls`. It does not
+assert the existence of action tensors, impose transitivity or finiteness, or
+attach these scalars to a matrix product unitary.
+
+## Main definitions
+
+* `LSymbol`: scalar L-symbols for a group action.
+* `ActionTensorGauge`: scalar gauge choices for action tensors.
+* `LSymbol.IsCompatible`: compatibility with a scalar 3-cochain.
+* `LSymbol.gauge`: the joint fusion-tensor and action-tensor gauge action.
+* `LSymbol.IsNormalized`: triviality when either group argument is the identity.
+-/
+
+namespace TNLean.Algebra
+
+variable {G X : Type*} [Group G] [MulAction G X]
+
+/-- Scalar L-symbols `Lˣ_{g,h}` for a group `G` acting on a type `X`. -/
+abbrev LSymbol (G X : Type*) := X → G → G → Units ℂ
+
+/-- Scalar action-tensor gauges `γ_{g,x}`. -/
+abbrev ActionTensorGauge (G X : Type*) := G → X → Units ℂ
+
+namespace ActionTensorGauge
+
+/-- An action-tensor gauge is normalized when `γ_{1,x} = 1` for every `x`. -/
+def IsNormalized (γ : ActionTensorGauge G X) : Prop :=
+  ∀ x, γ 1 x = 1
+
+end ActionTensorGauge
+
+namespace LSymbol
+
+/-- Compatibility of L-symbols with a scalar 3-cochain:
+
+`Lˣ_{g,hk} Lˣ_{h,k} = ω(g,h,k) L^{k • x}_{g,h} Lˣ_{gh,k}`.
+
+This is arXiv:2502.20257, `eq:omega_and_Ls`. -/
+def IsCompatible (L : LSymbol G X) (ω : ScalarThreeCochain G) : Prop :=
+  ∀ x g h k,
+    L x g (h * k) * L x h k =
+      ω g h k * L (k • x) g h * L x (g * h) k
+
+/-- The joint fusion-tensor and action-tensor scalar gauge action:
+
+`Lˣ_{g,h} ↦ γ_{gh,x} β_{g,h} / (γ_{g,h • x} γ_{h,x}) Lˣ_{g,h}`.
+
+This is arXiv:2502.20257, `eq:Lsymbgauge`. -/
+def gauge (β : ScalarCocycle G) (γ : ActionTensorGauge G X) (L : LSymbol G X) :
+    LSymbol G X :=
+  fun x g h =>
+    ((γ (g * h) x * β g h) / (γ g (h • x) * γ h x)) * L x g h
+
+/-- Joint scalar gauges preserve compatibility, with the 3-cochain changed by
+the corresponding fusion gauge. -/
+theorem IsCompatible.gauge {L : LSymbol G X} {ω : ScalarThreeCochain G}
+    (hL : IsCompatible L ω) (β : ScalarCocycle G) (γ : ActionTensorGauge G X) :
+    IsCompatible (gauge β γ L) (ScalarThreeCochain.fusionGauge β ω) := by
+  intro x g h k
+  simp only [gauge, ScalarThreeCochain.fusionGauge, ScalarThreeCochain.coboundary]
+  rw [hL]
+  apply Units.ext
+  push_cast
+  simp only [map_mul, map_div, smul_smul]
+  field_simp
+
+/-- L-symbols are normalized when `Lˣ_{g,1} = Lˣ_{1,g} = 1`. This is the
+standing convention in arXiv:2502.20257, `eq:triv_Ls`. -/
+def IsNormalized (L : LSymbol G X) : Prop :=
+  (∀ x g, L x g 1 = 1) ∧ (∀ x g, L x 1 g = 1)
+
+/-- The exact right identity-axis formula for a joint scalar gauge. -/
+theorem gauge_apply_right_one (β : ScalarCocycle G) (γ : ActionTensorGauge G X)
+    (L : LSymbol G X) (x : X) (g : G) :
+    gauge β γ L x g 1 = (β g 1 / γ 1 x) * L x g 1 := by
+  simp [gauge, mul_comm]
+
+/-- The exact left identity-axis formula for a joint scalar gauge. -/
+theorem gauge_apply_left_one (β : ScalarCocycle G) (γ : ActionTensorGauge G X)
+    (L : LSymbol G X) (x : X) (g : G) :
+    gauge β γ L x 1 g = (β 1 g / γ 1 (g • x)) * L x 1 g := by
+  simp [gauge, mul_comm]
+
+/-- Exact characterization of when a joint scalar gauge is normalized. -/
+theorem isNormalized_gauge_iff (β : ScalarCocycle G) (γ : ActionTensorGauge G X)
+    (L : LSymbol G X) :
+    IsNormalized (gauge β γ L) ↔
+      (∀ x g, β g 1 * L x g 1 = γ 1 x) ∧
+        (∀ x g, β 1 g * L x 1 g = γ 1 (g • x)) := by
+  simp only [IsNormalized, gauge_apply_right_one, gauge_apply_left_one]
+  constructor
+  · rintro ⟨hright, hleft⟩
+    refine ⟨fun x g => ?_, fun x g => ?_⟩
+    · exact (div_mul_eq_one_iff_eq (γ 1 x)).mp (hright x g)
+    · exact (div_mul_eq_one_iff_eq (γ 1 (g • x))).mp (hleft x g)
+  · rintro ⟨hright, hleft⟩
+    refine ⟨fun x g => ?_, fun x g => ?_⟩
+    · exact (div_mul_eq_one_iff_eq (γ 1 x)).mpr (hright x g)
+    · exact (div_mul_eq_one_iff_eq (γ 1 (g • x))).mpr (hleft x g)
+
+/-- Normalized fusion and action gauges preserve normalized L-symbols. -/
+theorem IsNormalized.gauge {L : LSymbol G X} (hL : IsNormalized L)
+    {β : ScalarCocycle G} (hβ : β.IsNormalized) {γ : ActionTensorGauge G X}
+    (hγ : γ.IsNormalized) : IsNormalized (gauge β γ L) := by
+  apply (isNormalized_gauge_iff β γ L).2
+  exact ⟨fun x g => by simp [hβ.2, hL.1, hγ],
+    fun x g => by simp [hβ.1, hL.2, hγ]⟩
+
+end LSymbol
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -221,6 +221,111 @@ they do not construct fusion tensors or an MPU representation.
     the constant cochain $1$.
 \end{definition}
 
+\begin{definition}[L-symbols and compatibility]
+    \label{def:mpug_l_symbols}
+    \lean{TNLean.Algebra.LSymbol,
+        TNLean.Algebra.LSymbol.IsCompatible}
+    \leanok
+    \uses{def:mpug_scalar_cochains}
+    Let $G$ act on a set $\mathsf X$. An $L$-symbol is a function
+    $L\colon \mathsf X\times G^2\to\C^\times$, written $L^x_{g,h}$.
+    It is compatible with a scalar $3$-cochain $\omega$ when, for every
+    $x\in\mathsf X$ and $g,h,k\in G$,
+    \begin{align}
+        L^x_{g,hk}L^x_{h,k}
+        & =\omega(g,h,k)L^{k x}_{g,h}L^x_{gh,k}.
+        \label{eq:mpug_l_compatibility}
+    \end{align}
+    This is the scalar compatibility relation of
+    \cite{FrancoRubio2025MPUGauging}. No transitivity or finiteness assumption
+    is imposed on the action.
+    % Source anchor: arXiv:2502.20257, eq:omega_and_Ls.
+\end{definition}
+
+\begin{definition}[Joint scalar gauge of L-symbols]
+    \label{def:mpug_l_gauge}
+    \lean{TNLean.Algebra.ActionTensorGauge,
+        TNLean.Algebra.LSymbol.gauge}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_fusion_gauge}
+    An action-tensor scalar gauge is a function
+    $\gamma\colon G\times\mathsf X\to\C^\times$. Together with a
+    fusion-tensor scalar gauge $\beta\colon G^2\to\C^\times$, it changes an
+    $L$-symbol by
+    \begin{align}
+        (\beta,\gamma)\mathbin{\triangleright}L^x_{g,h}
+        & =\frac{\gamma_{gh,x}\beta_{g,h}}
+        {\gamma_{g,hx}\gamma_{h,x}}L^x_{g,h}.
+        \label{eq:mpug_l_gauge}
+    \end{align}
+    This is the joint fusion-tensor and action-tensor gauge freedom in
+    \cite{FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, eq:Lsymbgauge.
+\end{definition}
+
+\begin{definition}[Normalized L-symbols and action-tensor gauges]
+    \label{def:mpug_l_normalized}
+    \lean{TNLean.Algebra.LSymbol.IsNormalized,
+        TNLean.Algebra.ActionTensorGauge.IsNormalized}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_l_gauge}
+    The $L$-symbol is normalized when, for every $x\in\mathsf X$ and $g\in G$,
+    \begin{align}
+        L^x_{g,e} & =1.
+        \label{eq:mpug_l_normalized_right}
+    \end{align}
+    \begin{align}
+        L^x_{e,g} & =1.
+        \label{eq:mpug_l_normalized_left}
+    \end{align}
+    The action-tensor gauge is normalized when $\gamma_{e,x}=1$ for every
+    $x\in\mathsf X$. These conventions match the trivial-identity choices of
+    \cite{FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, eq:triv_Ls.
+\end{definition}
+
+\begin{theorem}[Joint scalar gauges preserve L-symbol compatibility]
+    \label{thm:mpug_l_gauge_preservation}
+    \lean{TNLean.Algebra.LSymbol.IsCompatible.gauge,
+        TNLean.Algebra.LSymbol.gauge_apply_right_one,
+        TNLean.Algebra.LSymbol.gauge_apply_left_one,
+        TNLean.Algebra.LSymbol.isNormalized_gauge_iff,
+        TNLean.Algebra.LSymbol.IsNormalized.gauge}
+    \leanok
+    \uses{def:mpug_fusion_gauge, def:mpug_l_symbols,
+        def:mpug_l_gauge, def:mpug_l_normalized}
+    If $L$ is compatible with $\omega$, then
+    $(\beta,\gamma)\mathbin{\triangleright}L$ is compatible with
+    $\beta\mathbin{\triangleright}\omega$. On the identity axes, the gauge
+    formula is exactly
+    \begin{align}
+        ((\beta,\gamma)\mathbin{\triangleright}L)^x_{g,e}
+        & =\frac{\beta_{g,e}}{\gamma_{e,x}}L^x_{g,e}.
+        \label{eq:mpug_l_gauge_right}
+    \end{align}
+    \begin{align}
+        ((\beta,\gamma)\mathbin{\triangleright}L)^x_{e,g}
+        & =\frac{\beta_{e,g}}{\gamma_{e,gx}}L^x_{e,g}.
+        \label{eq:mpug_l_gauge_left}
+    \end{align}
+    Thus the gauged $L$-symbol is normalized exactly when
+    $\beta_{g,e}L^x_{g,e}=\gamma_{e,x}$ and
+    $\beta_{e,g}L^x_{e,g}=\gamma_{e,gx}$ for all $x$ and $g$. In particular,
+    normalized $\beta$, $\gamma$, and $L$ give a normalized gauged $L$-symbol.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_fusion_gauge, def:mpug_l_symbols, def:mpug_l_gauge}
+    Substitute (\ref{eq:mpug_l_gauge}) into both sides of
+    (\ref{eq:mpug_l_compatibility}). The $L$-factors give the original
+    compatibility relation, while the remaining $\beta$-factors give
+    $d\beta$. The $\gamma$-factors cancel after using
+    $h(kx)=(hk)x$. Setting either group argument equal to $e$ gives
+    (\ref{eq:mpug_l_gauge_right}) and
+    (\ref{eq:mpug_l_gauge_left}), from which the normalization statements
+    follow.
+\end{proof}
+
 \begin{definition}[Inversion cochains]
     \label{def:mpug_inversion_cochains}
     \lean{TNLean.Algebra.ScalarOneCochain,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -10,8 +10,9 @@ nonzero complex numbers. The fusion tensors have the scalar gauge freedom
 \end{align}
 % Source anchor: arXiv:2502.20257, eq:scalar_fus_ten.
 This is the fusion-tensor gauge freedom of~\cite{FrancoRubio2025MPUGauging}.
-The results below formalize only the scalar functions $\beta$ and $\omega$;
-they do not construct fusion tensors or an MPU representation.
+The results below formalize only the scalar functions $\beta$, $\omega$,
+$\gamma$, and $L$; they construct neither fusion tensors nor action tensors nor
+an MPU representation.
 
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
@@ -236,7 +237,8 @@ they do not construct fusion tensors or an MPU representation.
         & =\omega(g,h,k)L^{k x}_{g,h}L^x_{gh,k}.
         \label{eq:mpug_l_compatibility}
     \end{align}
-    This is the scalar compatibility relation of
+    The $L$-symbols were introduced by
+    \cite{GarreRubio2023MPOSym}; this is the scalar compatibility relation of
     \cite{FrancoRubio2025MPUGauging}. No transitivity or finiteness assumption
     is imposed on the action.
     % Source anchor: arXiv:2502.20257, eq:omega_and_Ls.
@@ -315,7 +317,8 @@ they do not construct fusion tensors or an MPU representation.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_fusion_gauge, def:mpug_l_symbols, def:mpug_l_gauge}
+    \uses{def:mpug_fusion_gauge, def:mpug_l_symbols, def:mpug_l_gauge,
+        def:mpug_l_normalized}
     Substitute (\ref{eq:mpug_l_gauge}) into both sides of
     (\ref{eq:mpug_l_compatibility}). The $L$-factors give the original
     compatibility relation, while the remaining $\beta$-factors give

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -477,7 +477,7 @@
   title        = {Classifying Phases Protected by Matrix Product Operator Symmetries Using Matrix Product States},
   journal      = {Quantum},
   volume       = {7},
-  pages        = {927--954},
+  pages        = {927},
   year         = {2023},
   doi          = {10.22331/q-2023-02-21-927},
   eprint       = {2203.12563},

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -472,6 +472,18 @@
   eprinttype   = {arxiv},
 }
 
+@article{GarreRubio2023MPOSym,
+  author       = {Garre-Rubio, Jos{\'e} and Lootens, Laurens and Moln{\'a}r, Andr{\'a}s},
+  title        = {Classifying Phases Protected by Matrix Product Operator Symmetries Using Matrix Product States},
+  journal      = {Quantum},
+  volume       = {7},
+  pages        = {927--954},
+  year         = {2023},
+  doi          = {10.22331/q-2023-02-21-927},
+  eprint       = {2203.12563},
+  eprinttype   = {arxiv},
+}
+
 @article{Molnar2018NormalPEPS,
   author       = {Moln{\'a}r, Andr{\'a}s and Garre-Rubio, Jos{\'e} and
                   P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and


### PR DESCRIPTION
## What changed

- add $\mathbb C^\times$-valued `LSymbol` and `ActionTensorGauge` data for a group action
- formalize the paper's exact compatibility relation
  \[
  L^x_{g,hk}L^x_{h,k}=\omega(g,h,k)L^{kx}_{g,h}L^x_{gh,k}
  \]
- formalize the joint fusion/action-tensor gauge
  \[
  (L^{\beta,\gamma})^x_{g,h}
  =\frac{\gamma_{gh,x}\beta_{g,h}}{\gamma_{g,hx}\gamma_{h,x}}L^x_{g,h}
  \]
- prove compatibility is preserved with the existing orientation $\omega\mapsto d\beta\,\omega$
- formalize $L$-symbol and action-gauge normalization, exact identity-axis formulas, and normalization preservation
- add source-faithful Chapter 29 entries and the original Garre-Rubio--Lootens--Molnár reference

This is a scalar supplied-data layer. It does not construct fusion tensors or action tensors, define an MPU-level anomaly, or require finiteness or transitivity.

## Source

- `Papers/2502.20257/main.tex`
- `eq:defL`, `eq:Lsymbgauge`, `eq:omega_and_Ls`, `eq:triv_Ls`

## Validation

- `lake build` (10369 jobs)
- `lake build TNLean.Algebra.LSymbol TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check` (36 generated files, 997 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (6701/6701 entries)
- double LuaLaTeX compile with the project tenkz dependency, 0 undefined cross-references
- `git diff --check origin/main...HEAD`
- no `sorry` or `axiom` in `TNLean/Algebra/LSymbol.lean`

Independent Lean, source-faithfulness, and blueprint reviews approved the final branch.

Closes #7264
