### PR TITLE
ci(blueprint): pin latexindent and restore formatting gate

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -562,28 +562,22 @@ jobs:
           find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 \
             | xargs -0 -r chktex -q -l blueprint/.chktexrc
 
-      # continue-on-error: the runner's latexindent 3.23.6 (TeX Live 2023,
-      # texlive-extra-utils on ubuntu-latest) is intermittently
-      # nondeterministic in `-k` check mode on
-      # blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex (a ragged
-      # 4-column \begin{align} block at lines 482-484): the file is
-      # correctly formatted -- 32/32 isolated and full-tree stress-mode
-      # invocations pass, and -w -s is a no-op on it -- yet the real
-      # pull_request-triggered check step has failed on it 3/3 times
-      # (LionSR/TNLean#6874, then twice more on main after the merge).
-      # Re-enforce once the flake is root-caused (candidates: pin an exact
-      # latexindent release rather than tracking apt's texlive-extra-utils,
-      # or restructure the align block to a uniform column count).
+      # Phase 1 of LionSR/TNLean#6878 pins latexindent 3.24.7 and formats the
+      # current tree, but keeps this check advisory while the real
+      # pull_request-triggered job is exercised repeatedly. Remove
+      # continue-on-error after those runs establish that the pinned check is
+      # deterministic.
       - name: Check LaTeX formatting (latexindent)
         if: env.TEX_CHANGED == 'true'
         continue-on-error: true
         timeout-minutes: 5
         run: |
           set -e
+          scripts/latexindent --version
           status=0
           while IFS= read -r f; do
-            if ! latexindent -k -s -l blueprint/latexindent.yaml "$f" > /dev/null; then
-              echo "::warning file=$f::not formatted to blueprint/latexindent.yaml; run 'latexindent -l blueprint/latexindent.yaml -w -s \"$f\"' locally to fix"
+            if ! scripts/latexindent -k -s -l blueprint/latexindent.yaml "$f" > /dev/null; then
+              echo "::warning file=$f::not formatted to blueprint/latexindent.yaml; run 'scripts/latexindent -l blueprint/latexindent.yaml -w -s \"$f\"' locally to fix"
               status=1
             fi
           done < <(find blueprint/src -name '*.tex' -not -path '*/Packages/*')

--- a/blueprint/latexindent.yaml
+++ b/blueprint/latexindent.yaml
@@ -1,8 +1,8 @@
 # latexindent policy for blueprint sources.
 #
-# The existing blueprint files use four-space indentation. The workflow points
-# latexindent at this file explicitly; the check remains advisory until a
-# separate mechanical reformat PR applies this policy to blueprint/src.
+# Blueprint files use four-space indentation. The workflow applies this policy
+# with the pinned scripts/latexindent wrapper; the check remains temporarily
+# advisory while the pinned pull-request job is tested for repeatability.
 
 defaultIndent: "    "
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation_marginal_supports.tex
@@ -268,7 +268,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \begin{align}
         E^A_{ak}PE^A_{ka}(\Id-P)E^B_{bl}PE^B_{lb}
          & =E^A_{ak}
-        [PE^A_{ka}(\Id-P)E^B_{bl}P]
+            [PE^A_{ka}(\Id-P)E^B_{bl}P]
         E^B_{lb} =0,
         \notag
     \end{align}
@@ -290,7 +290,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \begin{align}
         E^B_{bl}PE^B_{lb}(\Id-P)E^A_{ak}PE^A_{ka}
          & =E^B_{bl}
-        [PE^B_{lb}(\Id-P)E^A_{ak}P]
+            [PE^B_{lb}(\Id-P)E^A_{ak}P]
         E^A_{ka} =0,
         \notag
     \end{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3027,11 +3027,11 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     For every overlapping pair, the symmetric anticommutator reduction turns
     the operator-product norm bound into
     \begin{align}
-        &\re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
-         +\re\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle \\
-        &\qquad\ge -\eta\bigl(
-          \re\langle h_{i,\mathrm{ES}}v,v\rangle
-         +\re\langle h_{j,\mathrm{ES}}v,v\rangle\bigr).
+         & \re\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        +\re\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle   \\
+         & \qquad\ge -\eta\bigl(
+        \re\langle h_{i,\mathrm{ES}}v,v\rangle
+        +\re\langle h_{j,\mathrm{ES}}v,v\rangle\bigr).
     \end{align}
     The assumption $\eta m<1$ makes $\gamma=1-\eta m$ positive, and the
     cyclic-window row-sum bounds then give the stated norm lower bound.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
@@ -180,12 +180,12 @@
         \end{tenkz}
     \end{center}
     \caption{Blockwise equality from agreement on the MPV family. Top: the
-    hypothesis $Y_1V^{(N)}(A)=Z_1V^{(N)}(A)$ for every positive chain length
-    $N\geq1$, with the operator inserted on the physical leg of the first
-    site. Bottom: the
-    conclusion that the two insertions agree on every block $A_k$ of the
-    canonical form. These are the two displays of Lemma~L,
-    \cite[Appendix~C.3, lines~1835--1846]{Cirac2016MPDO_arXiv}.}
+        hypothesis $Y_1V^{(N)}(A)=Z_1V^{(N)}(A)$ for every positive chain length
+        $N\geq1$, with the operator inserted on the physical leg of the first
+        site. Bottom: the
+        conclusion that the two insertions agree on every block $A_k$ of the
+        canonical form. These are the two displays of Lemma~L,
+        \cite[Appendix~C.3, lines~1835--1846]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_first_site_insertion_agreement}
 \end{figure}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -748,16 +748,16 @@
         \end{tenkz}
     \end{center}
     \caption{Equality of the Gram conjugations for two copies of the same
-    vertical normal tensor:
-    $(X_{\alpha,k}^{\dagger}X_{\alpha,k})M_\alpha
-        (X_{\alpha,k}^{\dagger}X_{\alpha,k})^{-1}
-        =(X_{\alpha,0}^{\dagger}X_{\alpha,0})M_\alpha
-        (X_{\alpha,0}^{\dagger}X_{\alpha,0})^{-1}$.
-    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives this
-    equality from self-adjointness of the corresponding sector compressions
-    and horizontal marked separation. Normality is used only in the
-    subsequent proportionality argument. This is
-    \cite[Proposition~4.13, lines~1915--1921]{Cirac2016MPDO_arXiv}.}
+        vertical normal tensor:
+        $(X_{\alpha,k}^{\dagger}X_{\alpha,k})M_\alpha
+            (X_{\alpha,k}^{\dagger}X_{\alpha,k})^{-1}
+            =(X_{\alpha,0}^{\dagger}X_{\alpha,0})M_\alpha
+            (X_{\alpha,0}^{\dagger}X_{\alpha,0})^{-1}$.
+        Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives this
+        equality from self-adjointness of the corresponding sector compressions
+        and horizontal marked separation. Normality is used only in the
+        subsequent proportionality argument. This is
+        \cite[Proposition~4.13, lines~1915--1921]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_vertical_gauge_gram_comparison}
 \end{figure}
 

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -203,8 +203,8 @@ Diagrammatically,
         \rho^{(N)}(M^\dagger)_{\sigma,\tau}
          & =
         \overline{
-        \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
-        \sigma\circ\mathrm{rev}}
+            \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
+                    \sigma\circ\mathrm{rev}}
         },
         \label{eq:mpdo_coeff_adjoint_reflection}
     \end{align}
@@ -214,7 +214,7 @@ Diagrammatically,
         \rho^{(N)}(M^\dagger)_{\sigma,\tau}
          & =
         \rho^{(N)}(M)_{\sigma\circ\mathrm{rev},
-        \tau\circ\mathrm{rev}},
+                \tau\circ\mathrm{rev}},
         \label{eq:mpdo_adjoint_mpdo}
     \end{align}
     and the adjoint tensor is again an MPDO.
@@ -241,20 +241,20 @@ Diagrammatically,
         \bigr)
         =
         \overline{
-        \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
-        \sigma\circ\mathrm{rev}}
+            \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
+                    \sigma\circ\mathrm{rev}}
         }.
         \notag
     \end{align}
     For an MPDO, $\rho^{(N)}(M)$ is Hermitian, so
     \begin{align}
         \overline{
-        \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
-        \sigma\circ\mathrm{rev}}
+            \rho^{(N)}(M)_{\tau\circ\mathrm{rev},
+                    \sigma\circ\mathrm{rev}}
         }
          & =
         \rho^{(N)}(M)_{\sigma\circ\mathrm{rev},
-        \tau\circ\mathrm{rev}};
+                \tau\circ\mathrm{rev}};
         \notag
     \end{align}
     positive semidefiniteness is preserved under the simultaneous relabeling

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -853,8 +853,8 @@ The corresponding generic result is proved in the companion quantum-channel volu
         S_L^{(N)}(A)
          & =
         \sum_{\lambda\in
-        \operatorname{roots}\chi_{c\,(R_{N-L}R_{N-L}^\dagger)
-        (L_L^\dagger L_L)}}
+            \operatorname{roots}\chi_{c\,(R_{N-L}R_{N-L}^\dagger)
+                (L_L^\dagger L_L)}}
         -\re(\lambda)\log\re(\lambda).
         \notag
     \end{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -447,7 +447,7 @@ physical indices, as in
     orthogonally controlled preparation of these density matrices. Thus
     \begin{align}
         [\mathcal P(Z)]_{\langle\alpha,(i,q)\rangle,
-            \langle\beta,(j,s)\rangle}
+                \langle\beta,(j,s)\rangle}
          & =
         \begin{cases}
             Z_{\langle\alpha,i\rangle,\langle\alpha,j\rangle}
@@ -463,7 +463,7 @@ physical indices, as in
     satisfies
     \begin{align}
         [\widehat R_\mu(Z)]_{\langle\alpha,(q,i)\rangle,
-            \langle\beta,(s,j)\rangle}
+                \langle\beta,(s,j)\rangle}
          & =
         \begin{cases}
             \rho_\alpha(q,s)
@@ -484,7 +484,7 @@ physical indices, as in
     the full-matrix extension satisfies
     \begin{align}
         [\widehat{\widetilde R}(Y)]_{\langle\alpha,i\rangle,
-            \langle\beta,j\rangle}
+                \langle\beta,j\rangle}
          & =
         \begin{cases}
             \sum_{q=0}^{r_\alpha-1}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_bond_products.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_bond_products.tex
@@ -270,7 +270,7 @@
         (\eta_{q,h})_{(r,\ell),(r',\ell')}
          & =
         B'_{(q,r,\ell_q^0;h,r_h^0,\ell),
-        (q,r',\ell_q^0;h,r_h^0,\ell')}.
+                (q,r',\ell_q^0;h,r_h^0,\ell')}.
         \notag
     \end{align}
     Thus $\eta_{q,h}$ is a principal compression of the positive operator

--- a/blueprint/src/chapter/ch21_mpdo_rfp_physical_isometric_embeddings.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_physical_isometric_embeddings.tex
@@ -57,17 +57,17 @@
     \begin{align}
         W^\dagger W               & =\Id,
                                   & \E_{A_V}                                                      & =\E_A,
-        \label{eq:mpdo_embedding_transfer}                                                                                      \\
+        \label{eq:mpdo_embedding_transfer}                                                                                        \\
         A_V\text{ is injective}
                                   & \Longleftrightarrow A\text{ is injective},
                                   & A_V\text{ is normal}
                                   & \Longleftrightarrow A\text{ is normal},
-        \notag                                                                                                                  \\
+        \notag                                                                                                                    \\
         \mathcal K_V\text{ is an MPDO}
                                   & \Longleftrightarrow \mathcal K\text{ is an MPDO},
                                   & \mathcal K_V\text{ saturates the area law}
                                   & \Longleftrightarrow \mathcal K\text{ saturates the area law},
-        \notag                                                                                                                  \\
+        \notag                                                                                                                    \\
         \mathcal T_{\mathcal K_V} & =\mathcal T_{\mathcal K},
                                   & \Pi_{\mathcal K_V}                                            & =V \Pi_{\mathcal K}V^\dagger.
         \label{eq:mpdo_embedding_trace_support}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
@@ -352,10 +352,10 @@ This is the contraction in
         \notag
     \end{align}
     \caption{Closing the horizontal indices of the factorized sector tensors
-    pairs each right factor with the left factor at the next site. The cycle
-    therefore becomes the product of the neighboring operators
-    $\eta_{k_n,k_{n+1}}$; compare
-    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.}
+        pairs each right factor with the left factor at the next site. The cycle
+        therefore becomes the product of the neighboring operators
+        $\eta_{k_n,k_{n+1}}$; compare
+        \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_cyclic_eta_contraction}
 \end{figure}
 
@@ -461,7 +461,7 @@ This is the contraction in
     Then
     \begin{align}
         \bigl[\reindex_{\Phi_N}
-        (M_N(\widetilde{\cal K}))\bigr]_{(k,x),(k,y)}
+            (M_N(\widetilde{\cal K}))\bigr]_{(k,x),(k,y)}
          & =\tr(M_0M_1\cdots M_{N-1}) \notag    \\
          & =\prod_{n=0}^{N-1}\eta_{k_n,k_{n+1}}
         ((x_n^R,x_{n+1}^L),(y_n^R,y_{n+1}^L))

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex
@@ -289,10 +289,10 @@ This is the single-block identity in
         \end{tenkz}
     \end{tenkzequation}
     \caption{Applying $\mathcal K^{-1}$ at the first and third sites collapses
-    the three-site contraction to
-    $\mathcal K^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
-    $p_2=(i_2,j_2)$ is the doubled physical index; compare
-    \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.}
+        the three-site contraction to
+        $\mathcal K^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
+        $p_2=(i_2,j_2)$ is the doubled physical index; compare
+        \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_inverse_map_three_site_contraction}
 \end{figure}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -158,7 +158,7 @@ strong subadditivity for a normalized three-site reduced state.
          & \quad=
         \begin{cases}
             {(R_s)}_{\beta_3,\alpha_1}
-            [U_B\kappa^{(s)}_{\beta_1,\alpha_3}U_B^\dagger]_
+                [U_B\kappa^{(s)}_{\beta_1,\alpha_3}U_B^\dagger]_
             {(k,l,r),(k',l',r')}, & s=t,    \\
             0,                    & s\ne t.
         \end{cases}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -707,10 +707,10 @@
     as the scalar
     \begin{align}
         \sum_{a,b,c}X_{b,a}
-        [(l_k)_a]_{\lambda_k,\lambda'_k}
-        [(r_k)_c]_{\rho_k,\rho'_k}
-        [(l_h)_c]_{\lambda_h,\lambda'_h}
-        [(r_h)_b]_{\rho_h,\rho'_h}.
+            [(l_k)_a]_{\lambda_k,\lambda'_k}
+            [(r_k)_c]_{\rho_k,\rho'_k}
+            [(l_h)_c]_{\lambda_h,\lambda'_h}
+            [(r_h)_b]_{\rho_h,\rho'_h}.
         \notag
     \end{align}
     Commuting scalar factors and collecting the sums over $(a,b)$ and $c$
@@ -809,12 +809,12 @@
     primed counterpart, the left-hand side is the scalar
     \begin{align}
         \sum_{a,b,c,e}X_{b,a}
-        [(l_k)_a]_{\lambda_k,\lambda'_k}
-        [(r_k)_c]_{\rho_k,\rho'_k}
-        [(l_l)_c]_{\lambda_l,\lambda'_l}
-        [(r_l)_e]_{\rho_l,\rho'_l}
-        [(l_h)_e]_{\lambda_h,\lambda'_h}
-        [(r_h)_b]_{\rho_h,\rho'_h}.
+            [(l_k)_a]_{\lambda_k,\lambda'_k}
+            [(r_k)_c]_{\rho_k,\rho'_k}
+            [(l_l)_c]_{\lambda_l,\lambda'_l}
+            [(r_l)_e]_{\rho_l,\rho'_l}
+            [(l_h)_e]_{\lambda_h,\lambda'_h}
+            [(r_h)_b]_{\rho_h,\rho'_h}.
         \notag
     \end{align}
     Reordering the four finite sums separates the $(a,b)$ boundary

--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -29,8 +29,8 @@ $\prod_{e\ni v}c_{v,e}=1$.
             species=operator, label pos=e,
             ports={90:virtual, 270:virtual}]{c_{v,e_k}}
         \tn[at=1 se of balanceVertex, name=balanceLast, skin=ring,
-        species=operator, label pos=e,
-        ports={135:virtual, 315:virtual}]{c_{v,e_{\deg(v)}}}
+            species=operator, label pos=e,
+            ports={135:virtual, 315:virtual}]{c_{v,e_{\deg(v)}}}
         \tnwire{balanceVertex.225}{balanceFirst.45}
         \tnwire{balanceVertex.270}{balanceTypical.90}
         \tnwire{balanceVertex.315}{balanceLast.135}

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
@@ -540,8 +540,8 @@
         C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
          & =
         \sum_{\substack{\mu,\nu \\
-        \mu|_{\mathcal B\setminus\{b\}}
-        =\nu|_{\mathcal B\setminus\{b\}}}}
+                \mu|_{\mathcal B\setminus\{b\}}
+                =\nu|_{\mathcal B\setminus\{b\}}}}
         X_{\mu_b,\nu_b}
         A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2).
         \notag

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_insertions.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_insertions.tex
@@ -64,8 +64,8 @@
         C_A(R,f,M;\sigma,\tau)
          & =
         \sum_{\substack{\mu,\nu \\
-        \mu|_{\partial R\setminus\{f\}}
-        =\nu|_{\partial R\setminus\{f\}}}}
+                \mu|_{\partial R\setminus\{f\}}
+                =\nu|_{\partial R\setminus\{f\}}}}
         M_{\mu_f,\nu_f}
         T_{A,R}^{\mu}(\sigma)
         T_{A,V\setminus R}^{\nu^c}(\tau).
@@ -108,8 +108,8 @@
         (I_{A,R,f,M})_{\nu,\sigma}
          & =
         \sum_{\substack{\mu\in\partial R \\
-        \mu|_{\partial R\setminus\{f\}}
-        =\nu|_{\partial R\setminus\{f\}}}}
+                \mu|_{\partial R\setminus\{f\}}
+                =\nu|_{\partial R\setminus\{f\}}}}
         M_{\mu_f,\nu_f}\,T_{A,R}^{\mu}(\sigma).
         \notag
     \end{align}
@@ -148,8 +148,8 @@
          & =
         \sum_{\nu\in\partial R}
         \left(\sum_{\substack{\mu\in\partial R \\
-        \mu|_{\partial R\setminus\{f\}}
-        =\nu|_{\partial R\setminus\{f\}}}}
+                \mu|_{\partial R\setminus\{f\}}
+                =\nu|_{\partial R\setminus\{f\}}}}
         M_{\mu_f,\nu_f}\,T_{A,R}^{\mu}(\sigma)\right)
         T_{A,V\setminus R}^{\nu^c}(\tau)
         =C_A(R,f,M;\sigma,\tau).

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_maps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_maps.tex
@@ -231,10 +231,10 @@
         K_X(\mu,\nu)
          & =
         \mathbf 1_{
-        \mu|_{\partial R\setminus\{f\}}
-        =
-        \nu|_{\partial R\setminus\{f\}}
-        }\,Y_{\mu_f,\nu_f},
+                \mu|_{\partial R\setminus\{f\}}
+                =
+                \nu|_{\partial R\setminus\{f\}}
+            }\,Y_{\mu_f,\nu_f},
         \label{eq:peps_transfer_coeff_form}
     \end{align}
     then $C_A(R,f,X;\sigma,\tau)=C_B(R,f,Y;\sigma,\tau)$.
@@ -266,10 +266,10 @@
         K_X(\mu,\nu)
          & =
         \mathbf 1_{
-        \mu|_{\partial R\setminus\{f\}}
-        =
-        \nu|_{\partial R\setminus\{f\}}
-        }\,Y_{\mu_f,\nu_f}.
+                \mu|_{\partial R\setminus\{f\}}
+                =
+                \nu|_{\partial R\setminus\{f\}}
+            }\,Y_{\mu_f,\nu_f}.
         \notag
     \end{align}
 \end{theorem}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_bond_local.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_bond_local.tex
@@ -41,7 +41,7 @@
         K_M(\mu,\nu)
          & =
         \mathbf 1_{\mu|_{\partial W_{\mathrm L}\setminus\{e\}}
-        =\nu|_{\partial W_{\mathrm L}\setminus\{e\}}}
+                =\nu|_{\partial W_{\mathrm L}\setminus\{e\}}}
         N_{\mu_e,\nu_e}. \notag
     \end{align}
     Substituting this form and summing over the matching residual boundary
@@ -82,7 +82,7 @@
         K_N(\mu,\nu)
          & =
         \mathbf 1_{\mu|_{\partial W_{\mathrm L}\setminus\{e\}}
-        =\nu|_{\partial W_{\mathrm L}\setminus\{e\}}}
+                =\nu|_{\partial W_{\mathrm L}\setminus\{e\}}}
         M_{\mu_e,\nu_e}. \notag
     \end{align}
     Substitution gives

--- a/blueprint/src/chapter/ch24_peps_ft_torus_corner_cancellation.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_corner_cancellation.tex
@@ -170,15 +170,15 @@
     interior bonds of $T$ times the single merged sum:
     \begin{align}
         \sum_{\substack{
-        \zeta_2|_{\partial(V\setminus K_1)}=c_1,
+                \zeta_2|_{\partial(V\setminus K_1)}=c_1,
         \zeta_1|_{\partial H_2}=c_2 \\
-        \zeta_1|_{\partial T}=\zeta_2|_{\partial T}}}
+                \zeta_1|_{\partial T}=\zeta_2|_{\partial T}}}
         F_1(\zeta_2)F_2(\zeta_1)
          & =
         P_T
         \sum_{\substack{
-        \eta|_{\partial(V\setminus K_1)}=c_1,
-        \eta|_{\partial H_2}=c_2}}
+                \eta|_{\partial(V\setminus K_1)}=c_1,
+                \eta|_{\partial H_2}=c_2}}
         F_1(\eta)F_2(\eta).
         \notag
     \end{align}

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -374,10 +374,10 @@ ambient bond space.
         \end{tenkz}
     \end{center}
     \caption{The square-root form of a normal renormalization fixed point:
-    $\rho=\diag(\lambda_\alpha)$ and
-    $A^i=X\sqrt\rho\,U^iX^{-1}$. The pair-index isometry is the one in
-    lines~1281--1283, and the square root follows from the reference tensor
-    at line~1300 \cite[Appendix~B]{Cirac2016MPDO_arXiv}.}
+        $\rho=\diag(\lambda_\alpha)$ and
+        $A^i=X\sqrt\rho\,U^iX^{-1}$. The pair-index isometry is the one in
+        lines~1281--1283, and the square root follows from the reference tensor
+        at line~1300 \cite[Appendix~B]{Cirac2016MPDO_arXiv}.}
     \label{fig:rfp_isometry_canonical_form}
 \end{figure}
 % The source expression carries a bare $\Lambda$; the square root is the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2977,8 +2977,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         U^{(K+2)}_{(q,\tau),\eta}
         \overline{U^{(K+2)}_{(p,\tau),\eta}}
         =\tr\!\left[
-        W_{\mathrm{out}}^{q_1p_1}
-        W_{\mathrm{out}}^{q_2p_2}E_{\mathrm{out}}^K\right].
+            W_{\mathrm{out}}^{q_1p_1}
+            W_{\mathrm{out}}^{q_2p_2}E_{\mathrm{out}}^K\right].
     \end{align}
     The retained letters occur in $(q,p)$ order, so $q$ is unstarred and
     $p$ is starred; their doubled bonds are in $(\text{ket},\text{bra})$
@@ -7195,7 +7195,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     For a time-reversal-invariant MPU in standard form, the sign $\sigma$ is
     \begin{align}
         \sigma & =\frac1{d^2}\tr\!\left[\mathbb S_{12,34}
-        v_{23}u_{12}u_{34}v_{23}\right],
+            v_{23}u_{12}u_{34}v_{23}\right],
     \end{align}
     where $\mathbb S_{12,34}$ exchanges the pairs of sites $12$ and $34$.
     % Source lines: paper_v2.tex 1588--1611.
@@ -10717,10 +10717,10 @@ $\omega^{-1}$.
         \mathbf 1_{\{\widetilde x|_{\Gamma\setminus\Lambda}
         =\widetilde y|_{\Gamma\setminus\Lambda}\}},         \\
         \bigl[\iota_{\widehat\Lambda_L,\widehat\Gamma_L}
-        (\mathcal B_{L,\Lambda}(A))\bigr]_{x,y}
+            (\mathcal B_{L,\Lambda}(A))\bigr]_{x,y}
          & =A_{\widetilde x|_\Lambda,\widetilde y|_\Lambda}
         \mathbf 1_{\{x|_{\widehat\Gamma_L\setminus\widehat\Lambda_L}
-        =y|_{\widehat\Gamma_L\setminus\widehat\Lambda_L}\}}.
+                =y|_{\widehat\Gamma_L\setminus\widehat\Lambda_L}\}}.
     \end{align}
     Restriction commutes with block encoding, and decoding identifies
     $\Gamma\setminus\Lambda$ with the original sites in

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -61,7 +61,7 @@ they do not construct fusion tensors or an MPU representation.
     \begin{align}
         (d\beta)(g,h,k)
          & =\frac{\beta(g,hk)\beta(h,k)}
-            {\beta(g,h)\beta(gh,k)},
+        {\beta(g,h)\beta(gh,k)},
         \label{eq:mpug_coboundary}        \\
         (\beta\mathbin{\triangleright}\omega)(g,h,k)
          & =(d\beta)(g,h,k)\omega(g,h,k).
@@ -112,7 +112,7 @@ they do not construct fusion tensors or an MPU representation.
     \uses{def:mpug_three_cocycle, def:mpug_fusion_gauge}
     Expanding the two sides gives the same product after cancellation:
     \begin{align}
-         & (d\beta)(gh,k,l)(d\beta)(g,h,kl)     \\
+         & (d\beta)(gh,k,l)(d\beta)(g,h,kl) \\
          & \quad =
         \frac{\beta(k,l)\beta(h,kl)\beta(g,hkl)}
         {\beta(ghk,l)\beta(gh,k)\beta(g,h)} \\

--- a/scripts/latexindent
+++ b/scripts/latexindent
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly LATEXINDENT_VERSION="3.24.7"
+readonly LATEXINDENT_TAG="V${LATEXINDENT_VERSION}"
+readonly RELEASE_BASE="https://github.com/cmhughes/latexindent.pl/releases/download/${LATEXINDENT_TAG}"
+
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64)
+    readonly ASSET="latexindent-macos"
+    readonly EXPECTED_SHA256="c2092c1e0da5a06e7cc09c24253ebbfa69a2b277f71339c8fee494c5396d5f80"
+    ;;
+  Linux:x86_64)
+    readonly ASSET="latexindent-linux"
+    readonly EXPECTED_SHA256="14a3f56807f9bdfa8b7b654bbfd054a59be79ddb959b57b691edcf39b2dc65e5"
+    ;;
+  Linux:aarch64 | Linux:arm64)
+    readonly ASSET="latexindent-linux-arm64"
+    readonly EXPECTED_SHA256="ebb30b9aacfa32fdc5938332956a7cbd080c63769723713cc9c42ed480640657"
+    ;;
+  *)
+    echo "error: latexindent ${LATEXINDENT_VERSION} is not pinned for $(uname -s) $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256() {
+    sha256sum "$1" | awk '{print $1}'
+  }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256() {
+    shasum -a 256 "$1" | awk '{print $1}'
+  }
+else
+  echo "error: sha256sum or shasum is required to verify latexindent" >&2
+  exit 1
+fi
+
+readonly CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/tnlean/latexindent/${LATEXINDENT_VERSION}"
+readonly BINARY="${CACHE_ROOT}/${ASSET}"
+
+verify_checksum() {
+  local actual
+  actual="$(sha256 "$1")"
+  if [[ "$actual" != "$EXPECTED_SHA256" ]]; then
+    echo "error: checksum mismatch for $1" >&2
+    echo "expected: ${EXPECTED_SHA256}" >&2
+    echo "actual:   ${actual}" >&2
+    return 1
+  fi
+}
+
+if [[ -e "$BINARY" ]]; then
+  verify_checksum "$BINARY"
+else
+  command -v curl >/dev/null 2>&1 || {
+    echo "error: curl is required to download latexindent ${LATEXINDENT_VERSION}" >&2
+    exit 1
+  }
+  mkdir -p "$CACHE_ROOT"
+  temporary="$(mktemp "${CACHE_ROOT}/.${ASSET}.XXXXXX")"
+  trap 'rm -f "$temporary"' EXIT
+  curl --fail --location --retry 3 --silent --show-error \
+    "${RELEASE_BASE}/${ASSET}" --output "$temporary"
+  verify_checksum "$temporary"
+  chmod 0755 "$temporary"
+  mv "$temporary" "$BINARY"
+  trap - EXIT
+fi
+
+reported_version="$($BINARY --version 2>&1 | awk 'NR == 1 {print $1}')"
+reported_version="${reported_version%,}"
+if [[ "$reported_version" != "$LATEXINDENT_VERSION" ]]; then
+  echo "error: expected latexindent ${LATEXINDENT_VERSION}, got ${reported_version}" >&2
+  exit 1
+fi
+
+exec "$BINARY" "$@"


### PR DESCRIPTION
Progresses #6878.

Phase 1:
- adds a checksum-verified wrapper pinned to upstream latexindent 3.24.7 on supported macOS/Linux architectures
- routes the PR formatting check and remediation message through the pinned wrapper
- formats the 22 files reported by 3.24.7 to a one-pass fixed point (95 whitespace-only line replacements)
- keeps the step advisory temporarily while the real pull-request job is rerun repeatedly

After repeated real-workflow passes, a follow-up commit on this PR will remove `continue-on-error: true` and close #6878.

Local verification:
- clean-cache download, checksum, version, corruption, unsupported-platform, and mismatch tests
- 10/10 repeated checks over all 229 non-package Blueprint TeX files
- one-pass fixed point
- whitespace-only TeX diff
- no Chapter 23 changes
- shell syntax and shellcheck
- workflow syntax
- `git diff --check`