### PR TITLE
ci(blueprint): enforce pinned latexindent gate

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -562,11 +562,9 @@ jobs:
           find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 \
             | xargs -0 -r chktex -q -l blueprint/.chktexrc
 
-      # Phase 1 of LionSR/TNLean#6878 pins latexindent 3.24.7 and formats the
-      # current tree, but keeps this check advisory while the real
-      # pull_request-triggered job is exercised repeatedly. Remove
-      # continue-on-error after those runs establish that the pinned check is
-      # deterministic.
+      # Phase 1 of LionSR/TNLean#6878 pinned latexindent 3.24.7 and formatted
+      # the current tree. Keep this second real pull-request run advisory;
+      # after it passes, remove continue-on-error to enforce the pinned check.
       - name: Check LaTeX formatting (latexindent)
         if: env.TEX_CHANGED == 'true'
         continue-on-error: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -562,12 +562,10 @@ jobs:
           find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 \
             | xargs -0 -r chktex -q -l blueprint/.chktexrc
 
-      # Phase 1 of LionSR/TNLean#6878 pinned latexindent 3.24.7 and formatted
-      # the current tree. Keep this second real pull-request run advisory;
-      # after it passes, remove continue-on-error to enforce the pinned check.
+      # LionSR/TNLean#6878 pins latexindent 3.24.7 after repeated successful
+      # real pull-request runs, so formatting regressions fail this job.
       - name: Check LaTeX formatting (latexindent)
         if: env.TEX_CHANGED == 'true'
-        continue-on-error: true
         timeout-minutes: 5
         run: |
           set -e

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -562,17 +562,27 @@ jobs:
           find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 \
             | xargs -0 -r chktex -q -l blueprint/.chktexrc
 
-      # LionSR/TNLean#6878 pins latexindent 3.24.7 after repeated successful
-      # real pull-request runs, so formatting regressions fail this job.
+      # latexindent's -k mode remains nondeterministic on GitHub runners even
+      # at the pinned version (LionSR/TNLean#6878). Format temporary copies and
+      # compare bytes instead; -w mode is stable and leaves sources untouched.
       - name: Check LaTeX formatting (latexindent)
         if: env.TEX_CHANGED == 'true'
         timeout-minutes: 5
         run: |
           set -e
           scripts/latexindent --version
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           status=0
+          index=0
           while IFS= read -r f; do
-            if ! scripts/latexindent -k -s -l blueprint/latexindent.yaml "$f" > /dev/null; then
+            candidate_dir="$tmpdir/$index"
+            index=$((index + 1))
+            mkdir "$candidate_dir"
+            candidate="$candidate_dir/$(basename "$f")"
+            cp -- "$f" "$candidate"
+            scripts/latexindent -w -s -l blueprint/latexindent.yaml "$candidate" > /dev/null
+            if ! cmp -s -- "$f" "$candidate"; then
               echo "::warning file=$f::not formatted to blueprint/latexindent.yaml; run 'scripts/latexindent -l blueprint/latexindent.yaml -w -s \"$f\"' locally to fix"
               status=1
             fi

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -234,7 +234,7 @@ an MPU representation.
     $x\in\mathsf X$ and $g,h,k\in G$,
     \begin{align}
         L^x_{g,hk}L^x_{h,k}
-        & =\omega(g,h,k)L^{k x}_{g,h}L^x_{gh,k}.
+         & =\omega(g,h,k)L^{k x}_{g,h}L^x_{gh,k}.
         \label{eq:mpug_l_compatibility}
     \end{align}
     The $L$-symbols were introduced by
@@ -256,7 +256,7 @@ an MPU representation.
     $L$-symbol by
     \begin{align}
         (\beta,\gamma)\mathbin{\triangleright}L^x_{g,h}
-        & =\frac{\gamma_{gh,x}\beta_{g,h}}
+         & =\frac{\gamma_{gh,x}\beta_{g,h}}
         {\gamma_{g,hx}\gamma_{h,x}}L^x_{g,h}.
         \label{eq:mpug_l_gauge}
     \end{align}
@@ -302,12 +302,12 @@ an MPU representation.
     formula is exactly
     \begin{align}
         ((\beta,\gamma)\mathbin{\triangleright}L)^x_{g,e}
-        & =\frac{\beta_{g,e}}{\gamma_{e,x}}L^x_{g,e}.
+         & =\frac{\beta_{g,e}}{\gamma_{e,x}}L^x_{g,e}.
         \label{eq:mpug_l_gauge_right}
     \end{align}
     \begin{align}
         ((\beta,\gamma)\mathbin{\triangleright}L)^x_{e,g}
-        & =\frac{\beta_{e,g}}{\gamma_{e,gx}}L^x_{e,g}.
+         & =\frac{\beta_{e,g}}{\gamma_{e,gx}}L^x_{e,g}.
         \label{eq:mpug_l_gauge_left}
     \end{align}
     Thus the gauged $L$-symbol is normalized exactly when


### PR DESCRIPTION
Closes #6878.

Phase 1 (#7293) checksum-pinned latexindent 3.24.7 and formatted the then-current Blueprint tree. A second real pull-request run passed, but the first enforced run reproduced `-k` nondeterminism on `ch29_mpu_gauging.tex`, proving that pinning alone was insufficient.

This PR now makes the gate deterministic by formatting a temporary copy of each source with stable `-w` mode and comparing bytes, leaving the working tree untouched. It also formats four equation lines added concurrently by #7292 after the phase-1 branch point. `continue-on-error` remains removed, so formatting regressions fail CI.

Local verification checked all 229 non-package Blueprint TeX files successfully with the temporary-copy algorithm, parsed the workflow YAML, and passed `git diff --check`. No mathematical content changes are included; the TeX diff is whitespace-only.