### PR TITLE
feat(algebra): trivialize positive generalized cocycles

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -18,12 +18,14 @@ import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FinsetSubtypeSum
 import TNLean.Algebra.GeneralizedCocycle
+import TNLean.Algebra.GeneralizedCocycleInversion
 import TNLean.Algebra.LSymbol
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NegMulLog
 import TNLean.Algebra.PiSigmaEquiv
 import TNLean.Algebra.PiTensorProductPhase
+import TNLean.Algebra.PositiveGeneralizedCocycle
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleInversion

--- a/TNLean/Algebra/GeneralizedCocycleInversion.lean
+++ b/TNLean/Algebra/GeneralizedCocycleInversion.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.GeneralizedCocycle
+
+/-!
+# Inversion of block-dependent generalized cocycles
+
+This file formalizes the hat operation from arXiv:2502.20257, line 5912, for
+block-dependent scalar one- and two-cochains. For a group `G` acting on block
+labels `X`, the operations are
+
+`(hat χ)ˣ_g = χ^{g • x}_{g⁻¹}`
+
+and
+
+`(hat Ω)ˣ_{g,h} = Ω^{gh • x}_{h⁻¹,g⁻¹}`.
+
+Both operations are involutions, preserve pointwise multiplication, and
+commute with the generalized coboundary.
+-/
+
+namespace TNLean.Algebra
+
+variable {G X : Type*} [Group G] [MulAction G X]
+
+namespace ActionTensorGauge
+
+/-- The block-dependent hat operation on scalar one-cochains:
+`(hat χ)ˣ_g = χ^{g • x}_{g⁻¹}`.
+
+This is arXiv:2502.20257, line 5912, specialized to one group index. -/
+def hat (χ : ActionTensorGauge G X) : ActionTensorGauge G X :=
+  fun g x => χ g⁻¹ (g • x)
+
+/-- The hat operation on block-dependent scalar one-cochains is an involution. -/
+@[simp]
+theorem hat_hat (χ : ActionTensorGauge G X) : hat (hat χ) = χ := by
+  funext g x
+  simp [hat]
+
+/-- The hat operation preserves the constant one cochain. -/
+@[simp]
+theorem hat_one : hat (1 : ActionTensorGauge G X) = 1 := by
+  rfl
+
+/-- The hat operation preserves pointwise multiplication. -/
+@[simp]
+theorem hat_mul (χ ψ : ActionTensorGauge G X) : hat (χ * ψ) = hat χ * hat ψ := by
+  rfl
+
+/-- The hat operation preserves pointwise inversion. -/
+@[simp]
+theorem hat_inv (χ : ActionTensorGauge G X) : hat χ⁻¹ = (hat χ)⁻¹ := by
+  rfl
+
+/-- The hat operation preserves pointwise division. -/
+@[simp]
+theorem hat_div (χ ψ : ActionTensorGauge G X) : hat (χ / ψ) = hat χ / hat ψ := by
+  rfl
+
+end ActionTensorGauge
+
+namespace LSymbol
+
+/-- The block-dependent hat operation on scalar two-cochains:
+`(hat Ω)ˣ_{g,h} = Ω^{gh • x}_{h⁻¹,g⁻¹}`.
+
+This is arXiv:2502.20257, line 5912, specialized to two group indices. -/
+def hat (Ω : LSymbol G X) : LSymbol G X :=
+  fun x g h => Ω ((g * h) • x) h⁻¹ g⁻¹
+
+/-- The hat operation on block-dependent scalar two-cochains is an involution. -/
+@[simp]
+theorem hat_hat (Ω : LSymbol G X) : hat (hat Ω) = Ω := by
+  funext x g h
+  simp [hat, mul_smul]
+
+/-- The hat operation preserves the constant one two-cochain. -/
+@[simp]
+theorem hat_one : hat (1 : LSymbol G X) = 1 := by
+  rfl
+
+/-- The hat operation preserves pointwise multiplication. -/
+@[simp]
+theorem hat_mul (Ω Λ : LSymbol G X) : hat (Ω * Λ) = hat Ω * hat Λ := by
+  rfl
+
+/-- The hat operation preserves pointwise inversion. -/
+@[simp]
+theorem hat_inv (Ω : LSymbol G X) : hat Ω⁻¹ = (hat Ω)⁻¹ := by
+  rfl
+
+/-- The hat operation preserves pointwise division. -/
+@[simp]
+theorem hat_div (Ω Λ : LSymbol G X) : hat (Ω / Λ) = hat Ω / hat Λ := by
+  rfl
+
+/-- The block-dependent hat operation commutes with the generalized
+coboundary: `hat (dχ) = d(hat χ)`.
+
+This is the one-to-two-cochain instance of the notation introduced in
+arXiv:2502.20257, lines 5910--5922. -/
+theorem hat_coboundary (χ : ActionTensorGauge G X) :
+    hat (ActionTensorGauge.coboundary χ) =
+      ActionTensorGauge.coboundary (ActionTensorGauge.hat χ) := by
+  funext x g h
+  simp only [hat, ActionTensorGauge.coboundary, ActionTensorGauge.hat]
+  simp [mul_smul, mul_comm]
+
+end LSymbol
+
+end TNLean.Algebra

--- a/TNLean/Algebra/PositiveGeneralizedCocycle.lean
+++ b/TNLean/Algebra/PositiveGeneralizedCocycle.lean
@@ -23,9 +23,10 @@ we first take its pointwise norm and then its positive `|G|`-th root. If also
 The block label is retained throughout. No transitivity or finiteness assumption
 is imposed on the block-label type.
 
-**Local fix (determinant sign):** The source takes a positive root of the
-determinant cochain but does not account for the sign of the regular
-permutation. We first take the pointwise norm and then the positive root. See
+**Local fix (determinant sign):** The source invokes the positive-root
+bijection without addressing that the determinant primitive can carry the sign
+of the regular permutation. We first take the pointwise norm and then the
+positive root. See
 `docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex`.
 -/
 

--- a/TNLean/Algebra/PositiveGeneralizedCocycle.lean
+++ b/TNLean/Algebra/PositiveGeneralizedCocycle.lean
@@ -22,6 +22,11 @@ we first take its pointwise norm and then its positive `|G|`-th root. If also
 
 The block label is retained throughout. No transitivity or finiteness assumption
 is imposed on the block-label type.
+
+**Local fix (determinant sign):** The source takes a positive root of the
+determinant cochain but does not account for the sign of the regular
+permutation. We first take the pointwise norm and then the positive root. See
+`docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex`.
 -/
 
 namespace TNLean.Algebra
@@ -139,7 +144,7 @@ noncomputable def positivePrimitive [Fintype G] (Ω : LSymbol G X) :
   ActionTensorGauge.positiveRpow (Fintype.card G : ℝ)⁻¹ (determinantCochain Ω)
 
 /-- The determinant/root primitive is positive-valued. -/
-theorem positivePrimitive_isPositiveValued [Fintype G] (Ω : LSymbol G X) :
+theorem isPositiveValued_positivePrimitive [Fintype G] (Ω : LSymbol G X) :
     ActionTensorGauge.IsPositiveValued (positivePrimitive Ω) :=
   ActionTensorGauge.isPositiveValued_positiveRpow _ _
 
@@ -156,7 +161,7 @@ theorem exists_positive_coboundary [Finite G] {Ω : LSymbol G X}
       ActionTensorGauge.IsPositiveValued χ ∧
         Ω = ActionTensorGauge.coboundary χ := by
   let _ := Fintype.ofFinite G
-  refine ⟨positivePrimitive Ω, positivePrimitive_isPositiveValued Ω, ?_⟩
+  refine ⟨positivePrimitive Ω, isPositiveValued_positivePrimitive Ω, ?_⟩
   funext x g h
   let n := Fintype.card G
   have hn : n ≠ 0 := Fintype.card_ne_zero
@@ -188,7 +193,7 @@ theorem exists_positive_coboundary_hat_mul_eq_one [Finite G]
       ActionTensorGauge.IsPositiveValued χ ∧
         Ω = ActionTensorGauge.coboundary χ ∧
           χ * ActionTensorGauge.hat χ = 1 := by
-  obtain ⟨χ₀, hχ₀pos, hχ₀⟩ := exists_positive_coboundary hΩ hpos
+  obtain ⟨χ₀, _, hχ₀⟩ := exists_positive_coboundary hΩ hpos
   let χ : ActionTensorGauge G X :=
     ActionTensorGauge.positiveRpow (2 : ℝ)⁻¹ (χ₀ / ActionTensorGauge.hat χ₀)
   refine ⟨χ, ActionTensorGauge.isPositiveValued_positiveRpow _ _, ?_, ?_⟩

--- a/TNLean/Algebra/PositiveGeneralizedCocycle.lean
+++ b/TNLean/Algebra/PositiveGeneralizedCocycle.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import TNLean.Algebra.GeneralizedCocycleInversion
+
+/-!
+# Positive generalized cocycles
+
+This file proves arXiv:2502.20257, `cor:positive_trivial`, lines 5950--5960.
+A positive complex unit means an element of the embedded subgroup
+`Units NNReal → Units ℂ`, rather than a complex number with positive real part.
+
+For a positive generalized cocycle `Ω`, finite-group power trivialization gives
+`Ω ^ |G| = dχ₀`. The determinant cochain `χ₀` can contain permutation signs, so
+we first take its pointwise norm and then its positive `|G|`-th root. If also
+`Ω * hat Ω = 1`, the source's refined witness is
+
+`χ = sqrt (χ₀ / hat χ₀)`.
+
+The block label is retained throughout. No transitivity or finiteness assumption
+is imposed on the block-label type.
+-/
+
+namespace TNLean.Algebra
+
+variable {G X : Type*} [Group G] [MulAction G X]
+
+namespace PositiveUnits
+
+/-- The multiplicative embedding of nonnegative-real units into complex units. -/
+def embedding : Units NNReal →* Units ℂ :=
+  Units.map (Complex.ofRealHom.comp NNReal.toRealHom).toMonoidHom
+
+/-- The complex norm as a multiplicative map into the nonnegative reals. -/
+noncomputable def normMonoidHom : ℂ →* NNReal where
+  toFun z := ⟨‖z‖, norm_nonneg z⟩
+  map_one' := NNReal.eq norm_one
+  map_mul' z w := NNReal.eq (norm_mul z w)
+
+/-- The norm of a complex unit, regarded as a nonnegative-real unit. -/
+noncomputable def norm : Units ℂ →* Units NNReal :=
+  Units.map normMonoidHom
+
+/-- Raising nonnegative-real units to a real power is a multiplicative map. -/
+noncomputable def rpow (r : ℝ) : Units NNReal →* Units NNReal :=
+  Units.map (NNReal.rpowMonoidHom r)
+
+/-- The canonical positive real power of a complex unit: take its norm, apply
+`NNReal.rpow`, and embed the result back into the complex units. -/
+noncomputable def positiveRpow (r : ℝ) : Units ℂ →* Units ℂ :=
+  embedding.comp ((rpow r).comp norm)
+
+/-- A complex unit is strictly positive when it belongs to the image of the
+unit group of the nonnegative reals. Since a unit of `ℝ≥0` is nonzero, this is
+exactly membership in the embedded subgroup `ℝ_{>0} ⊆ ℂˣ`. -/
+def IsPositive (z : Units ℂ) : Prop :=
+  z ∈ Set.range embedding
+
+/-- Taking the norm is a left inverse to the positive-unit embedding. -/
+@[simp]
+theorem norm_embedding (r : Units NNReal) : norm (embedding r) = r := by
+  apply Units.ext
+  apply NNReal.eq
+  change ‖((r : NNReal) : ℂ)‖ = (r : NNReal)
+  exact Complex.norm_of_nonneg r.val.property
+
+/-- A canonical positive real power is positive-valued. -/
+theorem isPositive_positiveRpow (r : ℝ) (z : Units ℂ) : IsPositive (positiveRpow r z) := by
+  exact ⟨rpow r (norm z), rfl⟩
+
+/-- Positive real powers recover the usual `NNReal.rpow` on embedded positive
+units. -/
+@[simp]
+theorem positiveRpow_embedding (s : ℝ) (r : Units NNReal) :
+    positiveRpow s (embedding r) = embedding (rpow s r) := by
+  simp [positiveRpow]
+
+/-- The positive `n`-th root raised to the `n`-th power recovers a positive
+complex unit. -/
+theorem positiveRpow_inv_natCast_pow {z : Units ℂ} (hz : IsPositive z)
+    {n : ℕ} (hn : n ≠ 0) : positiveRpow (n : ℝ)⁻¹ z ^ n = z := by
+  obtain ⟨r, rfl⟩ := hz
+  rw [positiveRpow_embedding, ← map_pow]
+  apply congrArg embedding
+  apply Units.ext
+  simpa [rpow, Units.coe_map] using NNReal.rpow_inv_natCast_pow (r : NNReal) hn
+
+end PositiveUnits
+
+namespace ActionTensorGauge
+
+/-- A block-dependent scalar one-cochain is positive-valued when every value
+lies in the embedded subgroup `ℝ_{>0} ⊆ ℂˣ`. -/
+def IsPositiveValued (χ : ActionTensorGauge G X) : Prop :=
+  ∀ g x, PositiveUnits.IsPositive (χ g x)
+
+/-- Apply the canonical positive real-power homomorphism pointwise to a
+block-dependent one-cochain. -/
+noncomputable def positiveRpow (r : ℝ) (χ : ActionTensorGauge G X) :
+    ActionTensorGauge G X :=
+  fun g x => PositiveUnits.positiveRpow r (χ g x)
+
+omit [Group G] [MulAction G X] in
+/-- Pointwise positive real powers are positive-valued. -/
+theorem isPositiveValued_positiveRpow (r : ℝ) (χ : ActionTensorGauge G X) :
+    IsPositiveValued (positiveRpow r χ) :=
+  fun g x => PositiveUnits.isPositive_positiveRpow r (χ g x)
+
+/-- Generalized coboundaries preserve pointwise division. -/
+theorem coboundary_div (χ ψ : ActionTensorGauge G X) :
+    coboundary (χ / ψ) = coboundary χ / coboundary ψ := by
+  funext x g h
+  simp only [coboundary, Pi.div_apply, div_eq_mul_inv, mul_inv_rev, inv_inv]
+  simp [mul_comm, mul_left_comm, mul_assoc]
+
+/-- Pointwise positive real powers commute with the generalized coboundary. -/
+theorem coboundary_positiveRpow (r : ℝ) (χ : ActionTensorGauge G X) :
+    coboundary (positiveRpow r χ) =
+      fun x g h => PositiveUnits.positiveRpow r (coboundary χ x g h) := by
+  funext x g h
+  simp [coboundary, positiveRpow]
+
+end ActionTensorGauge
+
+namespace LSymbol
+
+/-- A block-dependent scalar two-cochain is positive-valued when every value
+lies in the embedded subgroup `ℝ_{>0} ⊆ ℂˣ`. -/
+def IsPositiveValued (Ω : LSymbol G X) : Prop :=
+  ∀ x g h, PositiveUnits.IsPositive (Ω x g h)
+
+/-- The positive primitive obtained from the determinant cochain: take the
+pointwise norm and then the positive `|G|`-th root. -/
+noncomputable def positivePrimitive [Fintype G] (Ω : LSymbol G X) :
+    ActionTensorGauge G X :=
+  ActionTensorGauge.positiveRpow (Fintype.card G : ℝ)⁻¹ (determinantCochain Ω)
+
+/-- The determinant/root primitive is positive-valued. -/
+theorem positivePrimitive_isPositiveValued [Fintype G] (Ω : LSymbol G X) :
+    ActionTensorGauge.IsPositiveValued (positivePrimitive Ω) :=
+  ActionTensorGauge.isPositiveValued_positiveRpow _ _
+
+/-- Every positive generalized scalar cocycle of a finite group is a
+block-dependent coboundary with a positive primitive.
+
+The proof follows arXiv:2502.20257, `cor:positive_trivial`, lines 5950--5956.
+Unlike the abbreviated notation in the source, the witness retains its block
+label. The determinant supplied by finite-group power trivialization is first
+replaced pointwise by its norm because permutation signs need not be positive. -/
+theorem exists_positive_coboundary [Finite G] {Ω : LSymbol G X}
+    (hΩ : IsGeneralizedCocycle Ω) (hpos : IsPositiveValued Ω) :
+    ∃ χ : ActionTensorGauge G X,
+      ActionTensorGauge.IsPositiveValued χ ∧
+        Ω = ActionTensorGauge.coboundary χ := by
+  let _ := Fintype.ofFinite G
+  refine ⟨positivePrimitive Ω, positivePrimitive_isPositiveValued Ω, ?_⟩
+  funext x g h
+  let n := Fintype.card G
+  have hn : n ≠ 0 := Fintype.card_ne_zero
+  have hpow := pow_card_eq_coboundary_apply hΩ x g h
+  calc
+    Ω x g h = PositiveUnits.positiveRpow (n : ℝ)⁻¹ (Ω x g h) ^ n :=
+      (PositiveUnits.positiveRpow_inv_natCast_pow (hpos x g h) hn).symm
+    _ = PositiveUnits.positiveRpow (n : ℝ)⁻¹ (Ω x g h ^ n) := by
+      rw [map_pow]
+    _ = PositiveUnits.positiveRpow (n : ℝ)⁻¹
+        (ActionTensorGauge.coboundary (determinantCochain Ω) x g h) := by
+      rw [hpow]
+    _ = ActionTensorGauge.coboundary (positivePrimitive Ω) x g h := by
+      have hcob := congrFun (congrFun (congrFun
+        (ActionTensorGauge.coboundary_positiveRpow (n : ℝ)⁻¹
+          (determinantCochain Ω)) x) g) h
+      simpa [positivePrimitive, n] using hcob.symm
+
+/-- Under `Ω * hat Ω = 1`, the positive primitive can be chosen to satisfy
+`χ * hat χ = 1` as well.
+
+Starting from a positive primitive `χ₀`, this is exactly the source choice
+`χ = sqrt (χ₀ / hat χ₀)` from arXiv:2502.20257,
+`cor:positive_trivial`, lines 5955--5959. -/
+theorem exists_positive_coboundary_hat_mul_eq_one [Finite G]
+    {Ω : LSymbol G X} (hΩ : IsGeneralizedCocycle Ω)
+    (hpos : IsPositiveValued Ω) (hhat : Ω * hat Ω = 1) :
+    ∃ χ : ActionTensorGauge G X,
+      ActionTensorGauge.IsPositiveValued χ ∧
+        Ω = ActionTensorGauge.coboundary χ ∧
+          χ * ActionTensorGauge.hat χ = 1 := by
+  obtain ⟨χ₀, hχ₀pos, hχ₀⟩ := exists_positive_coboundary hΩ hpos
+  let χ : ActionTensorGauge G X :=
+    ActionTensorGauge.positiveRpow (2 : ℝ)⁻¹ (χ₀ / ActionTensorGauge.hat χ₀)
+  refine ⟨χ, ActionTensorGauge.isPositiveValued_positiveRpow _ _, ?_, ?_⟩
+  · rw [ActionTensorGauge.coboundary_positiveRpow,
+      ActionTensorGauge.coboundary_div, ← hat_coboundary, ← hχ₀]
+    funext x g h
+    have hhatApply : Ω x g h * hat Ω x g h = 1 := by
+      simpa only [Pi.mul_apply, Pi.one_apply] using
+        congrFun (congrFun (congrFun hhat x) g) h
+    have hquot : Ω x g h / hat Ω x g h = Ω x g h ^ 2 := by
+      rw [div_eq_mul_inv, inv_eq_of_mul_eq_one_left hhatApply, pow_two]
+    change Ω x g h = PositiveUnits.positiveRpow (2 : ℝ)⁻¹
+      (Ω x g h / hat Ω x g h)
+    rw [hquot]
+    rw [map_pow]
+    exact (PositiveUnits.positiveRpow_inv_natCast_pow (hpos x g h) (by decide)).symm
+  · funext g x
+    change χ g x * ActionTensorGauge.hat χ g x = 1
+    dsimp only [χ, ActionTensorGauge.hat, ActionTensorGauge.positiveRpow, Pi.div_apply]
+    simp only [inv_inv, inv_smul_smul]
+    rw [← map_mul]
+    simp
+
+end LSymbol
+
+end TNLean.Algebra

--- a/TNLean/Algebra/PositiveGeneralizedCocycle.lean
+++ b/TNLean/Algebra/PositiveGeneralizedCocycle.lean
@@ -23,6 +23,11 @@ we first take its pointwise norm and then its positive `|G|`-th root. If also
 The block label is retained throughout. No transitivity or finiteness assumption
 is imposed on the block-label type.
 
+**Local fix (block index):** The source writes `χ_g` in the corollary, while
+its preceding determinant construction gives `χ_g^x`. The block label is
+necessary in general. See
+`docs/paper-gaps/fbc25_positive_generalized_cocycle_block_index.tex`.
+
 **Local fix (determinant sign):** The source invokes the positive-root
 bijection without addressing that the determinant primitive can carry the sign
 of the regular permutation. We first take the pointwise norm and then the

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -540,7 +540,7 @@ an MPU representation.
     \lean{TNLean.Algebra.PositiveUnits.positiveRpow,
         TNLean.Algebra.ActionTensorGauge.positiveRpow,
         TNLean.Algebra.LSymbol.positivePrimitive,
-        TNLean.Algebra.LSymbol.positivePrimitive_isPositiveValued,
+        TNLean.Algebra.LSymbol.isPositiveValued_positivePrimitive,
         TNLean.Algebra.LSymbol.exists_positive_coboundary}
     \leanok
     \uses{def:mpug_generalized_cocycle,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -558,8 +558,12 @@ an MPU representation.
     \end{align}
     for all $x\in\mathsf X$ and $g,h\in G$.
     This is the first assertion of
-    \cite[Corollary~\texttt{cor:positive\_trivial}]
-    {FrancoRubio2025MPUGauging}.
+    \cite[Corollary at lines~5950--5960]{FrancoRubio2025MPUGauging}.
+    The source writes $\chi_g$ here, whereas the
+    preceding determinant lemma constructs $\chi^x_g$; the block label $x$ is
+    therefore retained.
+    % Local correction:
+    % docs/paper-gaps/fbc25_positive_generalized_cocycle_block_index.tex.
     % Source anchor: arXiv:2502.20257, cor:positive_trivial, lines 5950--5956.
 \end{theorem}
 
@@ -617,8 +621,7 @@ an MPU representation.
         \label{eq:mpug_positive_hat_witness_identity}
     \end{align}
     This is the second assertion of
-    \cite[Corollary~\texttt{cor:positive\_trivial}]
-    {FrancoRubio2025MPUGauging}.
+    \cite[Corollary at lines~5950--5960]{FrancoRubio2025MPUGauging}.
     % Source anchor: arXiv:2502.20257, cor:positive_trivial, lines 5955--5960.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -370,13 +370,13 @@ an MPU representation.
     multiplicative embedding. A block-dependent scalar $1$-cochain $\chi$ is
     positive when
     \begin{align}
-        \chi^x_g &\in\iota(\mathbb R_{>0})
+        \chi^x_g & \in\iota(\mathbb R_{>0})
         \label{eq:mpug_positive_one_cochain}
     \end{align}
     for every $x\in\mathsf X$ and $g\in G$. A block-dependent scalar
     $2$-cochain $\Omega$ is positive when
     \begin{align}
-        \Omega^x_{g,h} &\in\iota(\mathbb R_{>0})
+        \Omega^x_{g,h} & \in\iota(\mathbb R_{>0})
         \label{eq:mpug_positive_two_cochain}
     \end{align}
     for every $x\in\mathsf X$ and $g,h\in G$. Thus positivity means
@@ -552,8 +552,8 @@ an MPU representation.
     \begin{align}
         \Omega^x_{g,h}
          & =(d\chi_0)^x_{g,h}
-          =\frac{\chi^{\,h x}_{0,g}\chi^x_{0,h}}
-          {\chi^x_{0,gh}}
+        =\frac{\chi^{\,h x}_{0,g}\chi^x_{0,h}}
+        {\chi^x_{0,gh}}
         \label{eq:mpug_positive_coboundary}
     \end{align}
     for all $x\in\mathsf X$ and $g,h\in G$.
@@ -633,9 +633,9 @@ an MPU representation.
     \begin{align}
         \chi^x_g
          & =\sqrt{\frac{\chi^x_{0,g}}
-         {\widehat\chi^{\,x}_{0,g}}}
-          =\sqrt{\frac{\chi^x_{0,g}}
-          {\chi^{\,g x}_{0,g^{-1}}}}.
+            {\widehat\chi^{\,x}_{0,g}}}
+        =\sqrt{\frac{\chi^x_{0,g}}
+            {\chi^{\,g x}_{0,g^{-1}}}}.
         \label{eq:mpug_positive_hat_witness}
     \end{align}
     All values are positive, so the positive square roots are unambiguous.
@@ -644,15 +644,15 @@ an MPU representation.
     \begin{align}
         d\chi
          & =\sqrt{\frac{d\chi_0}{d\widehat\chi_0}}
-          =\sqrt{\frac{\Omega}{\widehat\Omega}}
-          =\sqrt{\Omega^2}
-          =\Omega.
+        =\sqrt{\frac{\Omega}{\widehat\Omega}}
+        =\sqrt{\Omega^2}
+        =\Omega.
     \end{align}
     Moreover,
     \begin{align}
         \widehat\chi
          & =\sqrt{\frac{\widehat\chi_0}{\chi_0}}
-          =\chi^{-1},
+        =\chi^{-1},
     \end{align}
     which proves
     (\ref{eq:mpug_positive_hat_witness_identity}).

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -358,6 +358,86 @@ an MPU representation.
     % Source anchor: arXiv:2502.20257, lines 5914--5921 and lemma:G_cocycle.
 \end{definition}
 
+\begin{definition}[Positive block-dependent cochains]
+    \label{def:mpug_positive_generalized_cochains}
+    \lean{TNLean.Algebra.PositiveUnits.embedding,
+        TNLean.Algebra.PositiveUnits.IsPositive,
+        TNLean.Algebra.ActionTensorGauge.IsPositiveValued,
+        TNLean.Algebra.LSymbol.IsPositiveValued}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_l_gauge}
+    Let $\iota\colon\mathbb R_{>0}\to\C^\times$ be the natural
+    multiplicative embedding. A block-dependent scalar $1$-cochain $\chi$ is
+    positive when
+    \begin{align}
+        \chi^x_g &\in\iota(\mathbb R_{>0})
+        \label{eq:mpug_positive_one_cochain}
+    \end{align}
+    for every $x\in\mathsf X$ and $g\in G$. A block-dependent scalar
+    $2$-cochain $\Omega$ is positive when
+    \begin{align}
+        \Omega^x_{g,h} &\in\iota(\mathbb R_{>0})
+        \label{eq:mpug_positive_two_cochain}
+    \end{align}
+    for every $x\in\mathsf X$ and $g,h\in G$. Thus positivity means
+    membership in the embedded subgroup of strictly positive real numbers,
+    not positivity of the real part.
+\end{definition}
+
+\begin{definition}[Hat operation on block-dependent cochains]
+    \label{def:mpug_generalized_hat}
+    \lean{TNLean.Algebra.ActionTensorGauge.hat,
+        TNLean.Algebra.LSymbol.hat}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_l_gauge}
+    For block-dependent scalar cochains, define
+    \begin{align}
+        \widehat\chi^{\,x}_g
+         & =\chi^{\,g x}_{g^{-1}},
+        \label{eq:mpug_generalized_hat_one}
+    \end{align}
+    and
+    \begin{align}
+        \widehat\Omega^{\,x}_{g,h}
+         & =\Omega^{\,(gh)x}_{h^{-1},g^{-1}}.
+        \label{eq:mpug_generalized_hat_two}
+    \end{align}
+    These are the one-index and two-index cases of the hat operation in
+    \cite[line~5912]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Hat involution and generalized coboundaries]
+    \label{thm:mpug_generalized_hat_coboundary}
+    \lean{TNLean.Algebra.ActionTensorGauge.hat_hat,
+        TNLean.Algebra.LSymbol.hat_hat,
+        TNLean.Algebra.LSymbol.hat_coboundary}
+    \leanok
+    \uses{def:mpug_generalized_cocycle, def:mpug_generalized_hat}
+    The block-dependent hat operation is an involution:
+    \begin{align}
+        \widehat{\widehat\chi} & =\chi,
+        \label{eq:mpug_generalized_hat_hat_one}
+    \end{align}
+    and
+    \begin{align}
+        \widehat{\widehat\Omega} & =\Omega.
+        \label{eq:mpug_generalized_hat_hat_two}
+    \end{align}
+    It commutes with the generalized coboundary:
+    \begin{align}
+        \widehat{d\chi} & =d\widehat\chi.
+        \label{eq:mpug_generalized_hat_coboundary}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_generalized_cocycle, def:mpug_generalized_hat}
+    Apply the group action law and cancel each group element with its inverse.
+    Expanding both sides of
+    (\ref{eq:mpug_generalized_hat_coboundary}) gives the same three cochain
+    values, with their scalar factors reordered in $\C^\times$.
+\end{proof}
+
 \begin{definition}[Regular-action matrices]
     \label{def:mpug_generalized_regular_matrices}
     \lean{TNLean.Algebra.LSymbol.regularMatrix}
@@ -453,6 +533,126 @@ an MPU representation.
     (\ref{eq:mpug_generalized_regular_multiplication}) and using
     $\det(cX)=c^{|G|}\det X$ gives
     (\ref{eq:mpug_generalized_power_coboundary}).
+\end{proof}
+
+\begin{theorem}[Positive generalized cocycles are coboundaries]
+    \label{thm:mpug_positive_generalized_cocycle}
+    \lean{TNLean.Algebra.PositiveUnits.positiveRpow,
+        TNLean.Algebra.ActionTensorGauge.positiveRpow,
+        TNLean.Algebra.LSymbol.positivePrimitive,
+        TNLean.Algebra.LSymbol.positivePrimitive_isPositiveValued,
+        TNLean.Algebra.LSymbol.exists_positive_coboundary}
+    \leanok
+    \uses{def:mpug_generalized_cocycle,
+        def:mpug_positive_generalized_cochains,
+        thm:mpug_generalized_cocycle_power}
+    Let $G$ be finite and let $G$ act on a set $\mathsf X$. If $\Omega$ is a
+    positive generalized $2$-cocycle, then there is a positive
+    block-dependent scalar $1$-cochain $\chi_0$ such that
+    \begin{align}
+        \Omega^x_{g,h}
+         & =(d\chi_0)^x_{g,h}
+          =\frac{\chi^{\,h x}_{0,g}\chi^x_{0,h}}
+          {\chi^x_{0,gh}}
+        \label{eq:mpug_positive_coboundary}
+    \end{align}
+    for all $x\in\mathsf X$ and $g,h\in G$.
+    This is the first assertion of
+    \cite[Corollary~\texttt{cor:positive\_trivial}]
+    {FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, cor:positive_trivial, lines 5950--5956.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_positive_generalized_cochains,
+        thm:mpug_generalized_cocycle_power}
+    Write $\delta^x_g=\det X^x_g$ for the determinant cochain from
+    Theorem~\ref{thm:mpug_generalized_cocycle_power}, and set
+    \begin{align}
+        \chi^x_{0,g}
+         & =\lvert\delta^x_g\rvert^{1/\lvert G\rvert}.
+        \label{eq:mpug_positive_determinant_root}
+    \end{align}
+    The regular-action permutation can contribute a sign to $\delta^x_g$.
+    Its norm is therefore taken before the positive $\lvert G\rvert$-th root.
+    Taking norms in $\Omega^{\lvert G\rvert}=d\delta$ gives
+    \begin{align}
+        \Omega^{\lvert G\rvert} & =d\lvert\delta\rvert.
+    \end{align}
+    Positive real powers are multiplicative, and the
+    $\lvert G\rvert$-th power is injective on $\mathbb R_{>0}$. Hence
+    $d\chi_0=\Omega$.
+    % Consolidated clarification:
+    % docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex.
+\end{proof}
+
+\begin{theorem}[Hat-compatible positive primitive]
+    \label{thm:mpug_positive_generalized_cocycle_hat}
+    \lean{TNLean.Algebra.ActionTensorGauge.coboundary_div,
+        TNLean.Algebra.ActionTensorGauge.coboundary_positiveRpow,
+        TNLean.Algebra.LSymbol.exists_positive_coboundary_hat_mul_eq_one}
+    \leanok
+    \uses{def:mpug_generalized_hat,
+        def:mpug_positive_generalized_cochains,
+        thm:mpug_generalized_hat_coboundary,
+        thm:mpug_positive_generalized_cocycle}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpug_positive_generalized_cocycle}, suppose additionally
+    that
+    \begin{align}
+        \Omega^x_{g,h}\widehat\Omega^{\,x}_{g,h}
+         & =1
+        \label{eq:mpug_positive_hat_hypothesis}
+    \end{align}
+    for every $x\in\mathsf X$ and $g,h\in G$. Then the positive cochain can
+    be chosen so that
+    \begin{align}
+        \Omega & =d\chi,
+        \label{eq:mpug_positive_hat_coboundary}
+    \end{align}
+    and
+    \begin{align}
+        \chi^x_g\widehat\chi^{\,x}_g
+         & =1.
+        \label{eq:mpug_positive_hat_witness_identity}
+    \end{align}
+    This is the second assertion of
+    \cite[Corollary~\texttt{cor:positive\_trivial}]
+    {FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, cor:positive_trivial, lines 5955--5960.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_generalized_hat_coboundary,
+        thm:mpug_positive_generalized_cocycle}
+    Let $\chi_0$ satisfy $d\chi_0=\Omega$ as in
+    Theorem~\ref{thm:mpug_positive_generalized_cocycle}. Define
+    \begin{align}
+        \chi^x_g
+         & =\sqrt{\frac{\chi^x_{0,g}}
+         {\widehat\chi^{\,x}_{0,g}}}
+          =\sqrt{\frac{\chi^x_{0,g}}
+          {\chi^{\,g x}_{0,g^{-1}}}}.
+        \label{eq:mpug_positive_hat_witness}
+    \end{align}
+    All values are positive, so the positive square roots are unambiguous.
+    Using $\widehat{d\chi_0}=d\widehat\chi_0$ and
+    $\Omega\widehat\Omega=1$ gives
+    \begin{align}
+        d\chi
+         & =\sqrt{\frac{d\chi_0}{d\widehat\chi_0}}
+          =\sqrt{\frac{\Omega}{\widehat\Omega}}
+          =\sqrt{\Omega^2}
+          =\Omega.
+    \end{align}
+    Moreover,
+    \begin{align}
+        \widehat\chi
+         & =\sqrt{\frac{\widehat\chi_0}{\chi_0}}
+          =\chi^{-1},
+    \end{align}
+    which proves
+    (\ref{eq:mpug_positive_hat_witness_identity}).
 \end{proof}
 
 \begin{definition}[Inversion cochains]

--- a/docs/paper-gaps/fbc25_positive_generalized_cocycle_block_index.tex
+++ b/docs/paper-gaps/fbc25_positive_generalized_cocycle_block_index.tex
@@ -1,0 +1,81 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Block Index in the Positive Generalized-Cocycle Corollary}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{Source context}
+
+The finite-group determinant lemma in
+Ref.~\cite[lines~5931--5947]{FrancoRubio2025MPUGauging} starts with a
+block-dependent generalized cocycle $\Omega^x_{g,h}$ and constructs a
+block-dependent cochain $\chi^x_g=\det X^x_g$. The following corollary instead
+writes that there exists $\chi_g>0$ with $\Omega=d\chi$.
+
+The omitted superscript is shorthand, not a restriction to a block-independent
+cochain. The later displays at lines~6023--6029 similarly suppress block
+indices while applying the same generalized-cocycle result to
+block-dependent quantities.
+
+\section{A two-block counterexample}
+
+Let $G=C_2=\{e,s\}$ act trivially on the two-element block set
+$\mathsf X=\{a,b\}$. Define a positive block-dependent $1$-cochain $\rho$ by
+\begin{align}
+    \rho^a_e=\rho^b_e&=1,
+    &\rho^a_s&=1,
+    &\rho^b_s&=2.
+    \label{eq:fbc25_positive_block_index_cochain}
+\end{align}
+Set $\Omega=d\rho$. Since the action is trivial and $s^2=e$,
+\begin{align}
+    \Omega^a_{s,s}
+        &=\frac{\rho^a_s\rho^a_s}{\rho^a_e}=1,
+    &
+    \Omega^b_{s,s}
+        &=\frac{\rho^b_s\rho^b_s}{\rho^b_e}=4.
+    \label{eq:fbc25_positive_block_index_values}
+\end{align}
+Thus $\Omega$ is a positive generalized $2$-cocycle and a generalized
+coboundary. If a primitive $\chi_g$ were independent of the block, then
+$(d\chi)^x_{s,s}$ would also be independent of $x$, contradicting
+Eq.~\ref{eq:fbc25_positive_block_index_values}.
+
+\section{Corrected statement}
+
+The primitive in the corollary must retain its block label:
+\begin{align}
+    \Omega^x_{g,h}
+        &=(d\chi)^x_{g,h}
+          =\frac{\chi^{h x}_g\chi^x_h}{\chi^x_{gh}}.
+    \label{eq:fbc25_positive_block_index_corrected}
+\end{align}
+This agrees with the determinant construction immediately preceding the
+corollary and leaves all other hypotheses and conclusions unchanged.
+
+\section{Formal treatment}
+
+The formal theorem quantifies over a block-dependent cochain and proves
+Eq.~\ref{eq:fbc25_positive_block_index_corrected}.\footnote{Formal
+declarations: \leanid{TNLean.Algebra.ActionTensorGauge.coboundary} and
+\leanid{TNLean.Algebra.LSymbol.exists\_positive\_coboundary} in
+\doclink{TNLean/Algebra/PositiveGeneralizedCocycle}.}
+
+\textbf{Verdict: resolved local correction.}
+The surrounding determinant construction and the explicit two-block example
+show that the block superscript on $\chi$ is necessary.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex
+++ b/docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex
@@ -12,7 +12,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{clarification}{resolved}
+\gapnote{local-correction}{resolved}
 
 \section{Source argument}
 
@@ -65,7 +65,7 @@ or conclusion of the corollary.\footnote{Formal declarations:
 \leanid{TNLean.Algebra.LSymbol.exists\_positive\_coboundary} in
 \doclink{TNLean/Algebra/PositiveGeneralizedCocycle}.}
 
-\textbf{Verdict: resolved clarification.}
+\textbf{Verdict: resolved local correction.}
 The norm removes the possible permutation sign while preserving the
 coboundary identity required by the positive-root argument.
 

--- a/docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex
+++ b/docs/paper-gaps/fbc25_positive_generalized_cocycle_determinant_sign.tex
@@ -1,0 +1,75 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Positive Primitive in the Generalized-Cocycle Corollary}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{clarification}{resolved}
+
+\section{Source argument}
+
+Let $G$ be finite and let the positive generalized $2$-cocycle $\Omega$ take
+values in the embedded subgroup $\mathbb R_{>0}\subset\mathbb C^\times$.
+The proof of
+\cite[Corollary~\texttt{cor:positive\_trivial}, lines~5950--5960]
+{FrancoRubio2025MPUGauging} invokes the preceding identity
+\begin{align}
+    \Omega^{|G|} &= d\delta,
+    \qquad
+    \delta^x_g=\det X^x_g,
+    \label{eq:fbc25_positive_generalized_power}
+\end{align}
+and then takes a positive $|G|$-th root.
+
+The determinant cochain $\delta$ need not itself be positive. Indeed, the
+regular-action matrix factors as a permutation matrix times a diagonal matrix,
+and the permutation determinant can equal $-1$. Thus a positive root of
+$\delta^x_g$ is not defined in general.
+
+\section{Positive primitive}
+
+Take the pointwise complex norm before taking the root:
+\begin{align}
+    \chi^x_{0,g}
+        &=\lvert\delta^x_g\rvert^{1/|G|}
+          =\lvert\det X^x_g\rvert^{1/|G|}.
+    \label{eq:fbc25_positive_generalized_primitive}
+\end{align}
+Since $\delta^x_g\ne0$, every value of $\chi_0$ lies in
+$\mathbb R_{>0}\subset\mathbb C^\times$. Multiplicativity of the complex norm
+and positivity of $\Omega$ turn
+Eq.~\ref{eq:fbc25_positive_generalized_power} into
+\begin{align}
+    \Omega^{|G|} &= d\lvert\delta\rvert.
+    \label{eq:fbc25_positive_generalized_norm_power}
+\end{align}
+Positive real powers are multiplicative, so
+$(d\chi_0)^{|G|}=\Omega^{|G|}$. Injectivity of the $|G|$-th power on
+$\mathbb R_{>0}$ gives $d\chi_0=\Omega$.
+
+\section{Formal treatment}
+
+The formal construction takes the pointwise norm of the determinant cochain
+and then its positive $|G|$-th root. The block label $x$ is retained in
+Eq.~\ref{eq:fbc25_positive_generalized_primitive}. This changes no hypothesis
+or conclusion of the corollary.\footnote{Formal declarations:
+\leanid{TNLean.Algebra.LSymbol.positivePrimitive} and
+\leanid{TNLean.Algebra.LSymbol.exists\_positive\_coboundary} in
+\doclink{TNLean/Algebra/PositiveGeneralizedCocycle}.}
+
+\textbf{Verdict: resolved clarification.}
+The norm removes the possible permutation sign while preserving the
+coboundary identity required by the positive-root argument.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## What changed

- define the paper's block-dependent hat operations on scalar one- and two-cochains and prove involution and coboundary compatibility
- model positive complex units as the embedded unit group of nonnegative reals
- construct the positive primitive
  \[
  \chi_g^x=\lvert\det X_g^x\rvert^{1/\lvert G\rvert}
  \]
  from the finite-group determinant identity
- prove the hat-compatible choice
  \[
  \chi=\sqrt{\chi_0/\widehat{\chi_0}}
  \]
  when \(\Omega\widehat\Omega=1\)
- add Chapter 29 coverage and record the determinant-sign correction

The block label is retained throughout. No transitivity or finiteness assumption is imposed on the block-label set.

## Validation

- `lake build` (10372 jobs)
- `lake build TNLean.Algebra.PositiveGeneralizedCocycle TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check`
- blueprint sync and `leanblueprint checkdecls` (6703/6703 declarations; Chapter 29 70/70)
- double LuaLaTeX blueprint compile with zero undefined references
- `git diff --check`
- no `sorry`, `admit`, new `axiom`, `native_decide`, or `unsafeCast` in the new modules

Closes #7266
