### PR TITLE
feat(Algebra): formalize scalar L-symbol block independence

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -20,6 +20,7 @@ import TNLean.Algebra.FinsetSubtypeSum
 import TNLean.Algebra.GeneralizedCocycle
 import TNLean.Algebra.GeneralizedCocycleInversion
 import TNLean.Algebra.LSymbol
+import TNLean.Algebra.LSymbolBlockIndependence
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NegMulLog

--- a/TNLean/Algebra/LSymbolBlockIndependence.lean
+++ b/TNLean/Algebra/LSymbolBlockIndependence.lean
@@ -8,17 +8,22 @@ import TNLean.Algebra.LSymbol
 /-!
 # Block independence for scalar L-symbols
 
-This file formalizes arXiv:2502.20257, Proposition `prop:technical01`
-(lines 6965–7027), by explicit scalar gauges. No finiteness, transitivity,
-or cocyclicity assumption is used.
+This file formalizes the scalar L-symbol core of arXiv:2502.20257,
+Proposition `prop:technical01` (lines 6965–7027), by explicit scalar gauges.
+It starts from a supplied compatible L-symbol. It does not construct the
+L-symbol from an MPS–MPU pair or identify tensor gauges with scalar gauges.
+That tensor-facing bridge is required for the full source proposition. No
+finiteness, transitivity, or cocyclicity assumption is used in the scalar
+argument.
 
 The proof first factors a block-independent compatible L-symbol as
 `Lˣ_{g,h} = A(g,h) q(x)`. Compatibility then shows that
 `q(g • x) / q(x)` is a character. The resulting forward gauge multiplier is
 exactly `L`, so the pointwise inverse gauges trivialize it.
 
-**Local fixes (source algebra):** The proof follows the paper-gap notes in
-issue #7268 for `prop:technical01`: line 6990 needs `γ_h` in the second denominator factor;
+**Local fixes (source algebra):** See
+`docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex`. In
+`prop:technical01`, line 6990 needs `γ_h` in the second denominator factor;
 line 6996 requires division by `ell_{g,h;h}`; line 7016 therefore contains its
 reciprocal; and the displayed factor is a forward gauge multiplier, whose
 inverse gauges trivialize `L`.
@@ -30,15 +35,19 @@ inverse gauges trivialize `L`.
   the three raw conditions.
 * `LSymbol.HasTrivialGauge`, `HasBlockConstantGauge`,
   `HasTrivialEllGauge`, and `IsBlockIndependent`: the four gauge-existential
-  formulations in `prop:technical01`.
+  formulations underlying the scalar core of `prop:technical01`.
 
 ## Main results
 
 * `LSymbol.factorization_of_isBlockIndependentEll`: corrected factorization.
 * `LSymbol.relativeCharacter_mul`: the relative block scalar is a character.
-* `LSymbol.exists_gauge_eq_one_of_isBlockIndependentEll`: explicit inverse
+* `LSymbol.gauge_inv_eq_one_of_isBlockIndependentEll`: explicit inverse
   gauges trivialize a block-independent compatible L-symbol.
-* `LSymbol.hasTrivialGauge_iff_*`: the four conditions are equivalent.
+* `LSymbol.hasTrivialGauge_iff_*`: the four scalar conditions are
+  equivalent for a supplied compatible L-symbol.
+
+These results do not establish the tensor-facing fourth condition of the source
+for an MPS–MPU pair.
 -/
 
 namespace TNLean.Algebra
@@ -54,19 +63,20 @@ def ell (L : LSymbol G X) (x : X) (a b g : G) : Units ℂ :=
   L x (a * g) (g⁻¹ * b) / L x a b
 
 /-- The raw block-independence condition for `ell`, before choosing a gauge.
-This is the condition preceding arXiv:2502.20257, `prop:technical01`. -/
+This is the scalar condition preceding arXiv:2502.20257,
+`prop:technical01`. -/
 def IsBlockIndependentEll (L : LSymbol G X) : Prop :=
   ∀ x y a b g, ell L x a b g = ell L y a b g
 
 /-- L-symbols are block-constant when they do not depend on the block label.
-This is the raw condition in item 2 of arXiv:2502.20257,
-`prop:technical01`. -/
+This is the raw scalar condition underlying item 2 of
+arXiv:2502.20257, `prop:technical01`. -/
 def IsBlockConstant (L : LSymbol G X) : Prop :=
   ∀ x y g h, L x g h = L y g h
 
 /-- The raw condition that every scalar factor `ellˣ_{a,b;g}` is one.
-This is item 3 of arXiv:2502.20257, `prop:technical01`, before choosing a
-gauge. -/
+This is the raw scalar condition underlying item 3 of
+arXiv:2502.20257, `prop:technical01`, before choosing a gauge. -/
 def IsTrivialEll (L : LSymbol G X) : Prop :=
   ∀ x a b g, ell L x a b g = 1
 
@@ -74,25 +84,29 @@ def IsTrivialEll (L : LSymbol G X) : Prop :=
 def IsTrivial (L : LSymbol G X) : Prop :=
   ∀ x g h, L x g h = 1
 
-/-- Item 1 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
-trivializes every L-symbol. -/
+/-- The scalar L-symbol formulation underlying item 1 of
+arXiv:2502.20257, `prop:technical01`: some joint scalar gauge trivializes the
+supplied L-symbol. -/
 def HasTrivialGauge (L : LSymbol G X) : Prop :=
   ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X, IsTrivial (gauge β γ L)
 
-/-- Item 2 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
-makes the L-symbols block-constant. -/
+/-- The scalar L-symbol formulation underlying item 2 of
+arXiv:2502.20257, `prop:technical01`: some joint scalar gauge makes the supplied
+L-symbol block-constant. -/
 def HasBlockConstantGauge (L : LSymbol G X) : Prop :=
   ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
     IsBlockConstant (gauge β γ L)
 
-/-- Item 3 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
-makes every `ell` equal to one. -/
+/-- The scalar L-symbol formulation underlying item 3 of
+arXiv:2502.20257, `prop:technical01`: some joint scalar gauge makes every `ell`
+equal to one. -/
 def HasTrivialEllGauge (L : LSymbol G X) : Prop :=
   ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
     IsTrivialEll (gauge β γ L)
 
-/-- Item 4 of arXiv:2502.20257, `prop:technical01`: the block-independence
-condition holds after some joint scalar gauge. -/
+/-- Scalar block independence after a joint scalar gauge. This is the
+L-symbol condition used by the source proof of item 4 in arXiv:2502.20257,
+`prop:technical01`; it is not the tensor-facing predicate on an MPS–MPU pair. -/
 def IsBlockIndependent (L : LSymbol G X) : Prop :=
   ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
     IsBlockIndependentEll (gauge β γ L)
@@ -299,33 +313,35 @@ theorem hasTrivialGauge_of_isBlockIndependentEll [Nonempty X]
   exact congrFun (congrFun (congrFun
     (gauge_inv_eq_one_of_isBlockIndependentEll hCompat hBI x₀) x) g) h
 
-/-- Item 1 implies item 2 of arXiv:2502.20257, `prop:technical01`. -/
+/-- At the scalar L-symbol level, triviality implies block constancy. -/
 theorem HasTrivialGauge.hasBlockConstantGauge {L : LSymbol G X}
     (hL : HasTrivialGauge L) : HasBlockConstantGauge L := by
   obtain ⟨β, γ, h⟩ := hL
   exact ⟨β, γ, h.isBlockConstant⟩
 
-/-- Item 1 implies item 3 of arXiv:2502.20257, `prop:technical01`. -/
+/-- At the scalar L-symbol level, triviality implies trivial `ell`. -/
 theorem HasTrivialGauge.hasTrivialEllGauge {L : LSymbol G X}
     (hL : HasTrivialGauge L) : HasTrivialEllGauge L := by
   obtain ⟨β, γ, h⟩ := hL
   exact ⟨β, γ, h.isTrivialEll⟩
 
-/-- Item 2 implies item 4 of arXiv:2502.20257, `prop:technical01`. -/
+/-- At the scalar L-symbol level, block constancy implies block
+independence. -/
 theorem HasBlockConstantGauge.isBlockIndependent {L : LSymbol G X}
     (hL : HasBlockConstantGauge L) : IsBlockIndependent L := by
   obtain ⟨β, γ, h⟩ := hL
   exact ⟨β, γ, h.isBlockIndependentEll⟩
 
-/-- Item 3 implies item 4 of arXiv:2502.20257, `prop:technical01`. -/
+/-- At the scalar L-symbol level, trivial `ell` implies block
+independence. -/
 theorem HasTrivialEllGauge.isBlockIndependent {L : LSymbol G X}
     (hL : HasTrivialEllGauge L) : IsBlockIndependent L := by
   obtain ⟨β, γ, h⟩ := hL
   exact ⟨β, γ, h.isBlockIndependentEll⟩
 
-/-- Item 4 implies item 1 of arXiv:2502.20257, `prop:technical01`.
-Compatibility is transported through the witnessing gauge and the two gauges
-are then composed. -/
+/-- For a supplied compatible L-symbol, scalar block independence implies
+scalar gauge triviality. Compatibility is transported through the witnessing
+gauge and the two gauges are then composed. -/
 theorem IsBlockIndependent.hasTrivialGauge [Nonempty X]
     {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
     (hL : IsBlockIndependent L) : HasTrivialGauge L := by
@@ -336,8 +352,8 @@ theorem IsBlockIndependent.hasTrivialGauge [Nonempty X]
   rw [← gauge_comp]
   exact hTriv
 
-/-- Capstone equivalence of items 1 and 2 in arXiv:2502.20257,
-`prop:technical01`. -/
+/-- Scalar-core equivalence underlying items 1 and 2 of
+arXiv:2502.20257, `prop:technical01`. -/
 theorem hasTrivialGauge_iff_hasBlockConstantGauge [Nonempty X]
     {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
     HasTrivialGauge L ↔ HasBlockConstantGauge L := by
@@ -345,8 +361,8 @@ theorem hasTrivialGauge_iff_hasBlockConstantGauge [Nonempty X]
   · exact HasTrivialGauge.hasBlockConstantGauge
   · exact fun h ↦ (h.isBlockIndependent).hasTrivialGauge hCompat
 
-/-- Capstone equivalence of items 1 and 3 in arXiv:2502.20257,
-`prop:technical01`. -/
+/-- Scalar-core equivalence underlying items 1 and 3 of
+arXiv:2502.20257, `prop:technical01`. -/
 theorem hasTrivialGauge_iff_hasTrivialEllGauge [Nonempty X]
     {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
     HasTrivialGauge L ↔ HasTrivialEllGauge L := by
@@ -354,8 +370,9 @@ theorem hasTrivialGauge_iff_hasTrivialEllGauge [Nonempty X]
   · exact HasTrivialGauge.hasTrivialEllGauge
   · exact fun h ↦ (h.isBlockIndependent).hasTrivialGauge hCompat
 
-/-- Capstone equivalence of items 1 and 4 in arXiv:2502.20257,
-`prop:technical01`. -/
+/-- Scalar-core equivalence between gauge triviality and block-independent
+`ell` for a supplied compatible L-symbol. The tensor-facing item 4 of
+arXiv:2502.20257, `prop:technical01` requires an additional bridge. -/
 theorem hasTrivialGauge_iff_isBlockIndependent [Nonempty X]
     {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
     HasTrivialGauge L ↔ IsBlockIndependent L := by

--- a/TNLean/Algebra/LSymbolBlockIndependence.lean
+++ b/TNLean/Algebra/LSymbolBlockIndependence.lean
@@ -1,0 +1,368 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.LSymbol
+
+/-!
+# Block independence for scalar L-symbols
+
+This file formalizes arXiv:2502.20257, Proposition `prop:technical01`
+(lines 6965–7027), by explicit scalar gauges. No finiteness, transitivity,
+or cocyclicity assumption is used.
+
+The proof first factors a block-independent compatible L-symbol as
+`Lˣ_{g,h} = A(g,h) q(x)`. Compatibility then shows that
+`q(g • x) / q(x)` is a character. The resulting forward gauge multiplier is
+exactly `L`, so the pointwise inverse gauges trivialize it.
+
+**Local fixes (source algebra):** The proof follows the paper-gap notes in
+issue #7268 for `prop:technical01`: line 6990 needs `γ_h` in the second denominator factor;
+line 6996 requires division by `ell_{g,h;h}`; line 7016 therefore contains its
+reciprocal; and the displayed factor is a forward gauge multiplier, whose
+inverse gauges trivialize `L`.
+
+## Main definitions
+
+* `LSymbol.ell`: the scalar factor `ellˣ_{a,b;g}`.
+* `LSymbol.IsBlockIndependentEll`, `IsBlockConstant`, and `IsTrivialEll`:
+  the three raw conditions.
+* `LSymbol.HasTrivialGauge`, `HasBlockConstantGauge`,
+  `HasTrivialEllGauge`, and `IsBlockIndependent`: the four gauge-existential
+  formulations in `prop:technical01`.
+
+## Main results
+
+* `LSymbol.factorization_of_isBlockIndependentEll`: corrected factorization.
+* `LSymbol.relativeCharacter_mul`: the relative block scalar is a character.
+* `LSymbol.exists_gauge_eq_one_of_isBlockIndependentEll`: explicit inverse
+  gauges trivialize a block-independent compatible L-symbol.
+* `LSymbol.hasTrivialGauge_iff_*`: the four conditions are equivalent.
+-/
+
+namespace TNLean.Algebra
+
+variable {G X : Type*} [Group G] [MulAction G X]
+
+namespace LSymbol
+
+/-- The scalar factor
+`ellˣ_{a,b;g} = Lˣ_{ag,g⁻¹b} / Lˣ_{a,b}` from arXiv:2502.20257,
+Appendix `app:block_indep`. -/
+def ell (L : LSymbol G X) (x : X) (a b g : G) : Units ℂ :=
+  L x (a * g) (g⁻¹ * b) / L x a b
+
+/-- The raw block-independence condition for `ell`, before choosing a gauge.
+This is the condition preceding arXiv:2502.20257, `prop:technical01`. -/
+def IsBlockIndependentEll (L : LSymbol G X) : Prop :=
+  ∀ x y a b g, ell L x a b g = ell L y a b g
+
+/-- L-symbols are block-constant when they do not depend on the block label.
+This is the raw condition in item 2 of arXiv:2502.20257,
+`prop:technical01`. -/
+def IsBlockConstant (L : LSymbol G X) : Prop :=
+  ∀ x y g h, L x g h = L y g h
+
+/-- The raw condition that every scalar factor `ellˣ_{a,b;g}` is one.
+This is item 3 of arXiv:2502.20257, `prop:technical01`, before choosing a
+gauge. -/
+def IsTrivialEll (L : LSymbol G X) : Prop :=
+  ∀ x a b g, ell L x a b g = 1
+
+/-- The raw condition that all L-symbols are one. -/
+def IsTrivial (L : LSymbol G X) : Prop :=
+  ∀ x g h, L x g h = 1
+
+/-- Item 1 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
+trivializes every L-symbol. -/
+def HasTrivialGauge (L : LSymbol G X) : Prop :=
+  ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X, IsTrivial (gauge β γ L)
+
+/-- Item 2 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
+makes the L-symbols block-constant. -/
+def HasBlockConstantGauge (L : LSymbol G X) : Prop :=
+  ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
+    IsBlockConstant (gauge β γ L)
+
+/-- Item 3 of arXiv:2502.20257, `prop:technical01`: some joint scalar gauge
+makes every `ell` equal to one. -/
+def HasTrivialEllGauge (L : LSymbol G X) : Prop :=
+  ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
+    IsTrivialEll (gauge β γ L)
+
+/-- Item 4 of arXiv:2502.20257, `prop:technical01`: the block-independence
+condition holds after some joint scalar gauge. -/
+def IsBlockIndependent (L : LSymbol G X) : Prop :=
+  ∃ β : ScalarCocycle G, ∃ γ : ActionTensorGauge G X,
+    IsBlockIndependentEll (gauge β γ L)
+
+/-- The identity fusion and action gauges leave an L-symbol unchanged. -/
+@[simp]
+theorem gauge_one (L : LSymbol G X) :
+    gauge (fun _ _ ↦ 1) (fun _ _ ↦ 1) L = L := by
+  funext x g h
+  simp [gauge]
+
+/-- Successive joint scalar gauges multiply both cochains pointwise. -/
+theorem gauge_comp (β₁ β₂ : ScalarCocycle G)
+    (γ₁ γ₂ : ActionTensorGauge G X) (L : LSymbol G X) :
+    gauge β₂ γ₂ (gauge β₁ γ₁ L) = gauge (β₁ * β₂) (γ₁ * γ₂) L := by
+  funext x g h
+  simp only [gauge, Pi.mul_apply]
+  (apply Units.ext; push_cast; field_simp)
+
+omit [MulAction G X] in
+/-- Block-constant L-symbols have block-independent `ell`. -/
+theorem IsBlockConstant.isBlockIndependentEll {L : LSymbol G X}
+    (hL : IsBlockConstant L) : IsBlockIndependentEll L := by
+  intro x y a b g
+  simp only [ell]
+  rw [hL x y, hL x y]
+
+omit [MulAction G X] in
+/-- Trivial `ell` is block-independent. -/
+theorem IsTrivialEll.isBlockIndependentEll {L : LSymbol G X}
+    (hL : IsTrivialEll L) : IsBlockIndependentEll L := by
+  intro x y a b g
+  rw [hL x, hL y]
+
+omit [Group G] [MulAction G X] in
+/-- Trivial L-symbols are block-constant. -/
+theorem IsTrivial.isBlockConstant {L : LSymbol G X}
+    (hL : IsTrivial L) : IsBlockConstant L := by
+  intro x y g h
+  rw [hL x, hL y]
+
+omit [MulAction G X] in
+/-- Trivial L-symbols have trivial `ell`. -/
+theorem IsTrivial.isTrivialEll {L : LSymbol G X}
+    (hL : IsTrivial L) : IsTrivialEll L := by
+  intro x a b g
+  rw [ell, hL x, hL x]
+  simp
+
+/-- Compatibility at `(g,1,1)` gives
+`Lˣ_{g,1} = Lˣ_{1,1} / ω(g,1,1)`.
+This is arXiv:2502.20257, `eq:aux1`. -/
+theorem IsCompatible.apply_right_one {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hL : IsCompatible L ω) (x : X) (g : G) :
+    L x g 1 = L x 1 1 / ω g 1 1 := by
+  have h := hL x g 1 1
+  simp only [mul_one, one_smul] at h
+  calc
+    L x g 1 = (ω g 1 1 * L x g 1 * L x g 1) /
+        (ω g 1 1 * L x g 1) := by simp [div_eq_mul_inv]
+    _ = (L x g 1 * L x 1 1) / (ω g 1 1 * L x g 1) := by rw [← h]
+    _ = L x 1 1 / ω g 1 1 := by
+      (apply Units.ext; push_cast; field_simp)
+
+/-- Compatibility at `(1,1,g)` gives
+`Lˣ_{1,g} = ω(1,1,g) L^{g • x}_{1,1}`.
+This is arXiv:2502.20257, `eq:aux2`. -/
+theorem IsCompatible.apply_left_one {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hL : IsCompatible L ω) (x : X) (g : G) :
+    L x 1 g = ω 1 1 g * L (g • x) 1 1 := by
+  have h := hL x 1 1 g
+  simp only [one_mul] at h
+  apply (mul_right_cancel (b := L x 1 g))
+  simpa [mul_assoc] using h
+
+/-- The block-independent scalar factor, evaluated at a chosen base block. -/
+def blockFactor (L : LSymbol G X) (ω : ScalarThreeCochain G) (x₀ : X)
+    (g h : G) : Units ℂ :=
+  (ω (g * h) 1 1 * ell L x₀ g h h)⁻¹
+
+/-- Corrected factorization of a compatible block-independent L-symbol:
+`Lˣ_{g,h} = A(g,h) Lˣ_{1,1}`, where
+`A(g,h) = (ω(gh,1,1) ell^{x₀}_{g,h;h})⁻¹`.
+
+This is arXiv:2502.20257, `eq:Lfact`, with the division by `ell` required by
+its definition. -/
+theorem factorization_of_isBlockIndependentEll {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) (x₀ x : X) (g h : G) :
+    L x g h = blockFactor L ω x₀ g h * L x 1 1 := by
+  have hRight := hCompat.apply_right_one x (g * h)
+  calc
+    L x g h = L x (g * h) 1 / ell L x g h h := by
+      simp only [ell, inv_mul_cancel]
+      simp [div_eq_mul_inv, mul_comm, mul_left_comm]
+    _ = L x (g * h) 1 / ell L x₀ g h h := by rw [hBI x x₀]
+    _ = blockFactor L ω x₀ g h * L x 1 1 := by
+      rw [hRight]
+      simp only [blockFactor]
+      simp [div_eq_mul_inv, mul_assoc, mul_comm]
+
+/-- The relative scalar appearing in arXiv:2502.20257, `eq:defrho`.
+With the corrected factorization it is
+`ρ(g) = (ell^{x₀}_{1,g;g} ω(g,1,1) ω(1,1,g))⁻¹`. -/
+def relativeCharacter (L : LSymbol G X) (ω : ScalarThreeCochain G) (x₀ : X)
+    (g : G) : Units ℂ :=
+  (ell L x₀ 1 g g * ω g 1 1 * ω 1 1 g)⁻¹
+
+/-- The relative block scalar transports `Lˣ_{1,1}` along the action:
+`L^{g • x}_{1,1} = ρ(g) Lˣ_{1,1}`.
+
+This is arXiv:2502.20257, `eq:defrho`, with the reciprocal `ell` forced by the
+corrected `eq:Lfact`. -/
+theorem relativeCharacter_mul_base {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) (x₀ x : X) (g : G) :
+    L (g • x) 1 1 = relativeCharacter L ω x₀ g * L x 1 1 := by
+  have hFactor := factorization_of_isBlockIndependentEll hCompat hBI x₀ x 1 g
+  have hLeft := hCompat.apply_left_one x g
+  rw [hLeft] at hFactor
+  calc
+    L (g • x) 1 1 =
+        (blockFactor L ω x₀ 1 g * L x 1 1) / ω 1 1 g := by
+      rw [← hFactor]
+      simp [div_eq_mul_inv, mul_assoc, mul_comm]
+    _ = relativeCharacter L ω x₀ g * L x 1 1 := by
+      simp only [blockFactor, relativeCharacter, one_mul]
+      (apply Units.ext; push_cast; field_simp)
+
+/-- The relative scalar is multiplicative, hence a one-dimensional character.
+No transitivity or finiteness of the action is needed. -/
+theorem relativeCharacter_mul {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) (x₀ : X) (g h : G) :
+    relativeCharacter L ω x₀ (g * h) =
+      relativeCharacter L ω x₀ g * relativeCharacter L ω x₀ h := by
+  have hgh := relativeCharacter_mul_base hCompat hBI x₀ x₀ (g * h)
+  have hh := relativeCharacter_mul_base hCompat hBI x₀ x₀ h
+  have hg := relativeCharacter_mul_base hCompat hBI x₀ (h • x₀) g
+  have hEq : relativeCharacter L ω x₀ (g * h) * L x₀ 1 1 =
+      relativeCharacter L ω x₀ g *
+        (relativeCharacter L ω x₀ h * L x₀ 1 1) := by
+    calc
+      _ = L ((g * h) • x₀) 1 1 := hgh.symm
+      _ = L (g • h • x₀) 1 1 := by rw [mul_smul]
+      _ = relativeCharacter L ω x₀ g * L (h • x₀) 1 1 := hg
+      _ = _ := by rw [hh]
+  apply (mul_right_cancel (b := L x₀ 1 1))
+  simpa only [mul_assoc] using hEq
+
+/-- The forward fusion cochain whose joint gauge multiplier equals `L`. -/
+def factorFusionGauge (L : LSymbol G X) (ω : ScalarThreeCochain G) (x₀ : X) :
+    ScalarCocycle G :=
+  fun g h ↦ blockFactor L ω x₀ g h / relativeCharacter L ω x₀ h
+
+/-- The forward action cochain whose joint gauge multiplier equals `L`. -/
+def factorActionGauge (L : LSymbol G X) : ActionTensorGauge G X :=
+  fun g x ↦ (L (g • x) 1 1)⁻¹
+
+/-- The corrected factorization is exactly a forward joint gauge multiplier:
+applying the factor gauges to the trivial L-symbol produces `L`.
+
+The inverse gauges, not these forward gauges, therefore trivialize `L`. -/
+theorem gauge_one_eq_of_isBlockIndependentEll {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) (x₀ : X) :
+    gauge (factorFusionGauge L ω x₀) (factorActionGauge L)
+      (fun _ _ _ ↦ 1) = L := by
+  funext x g h
+  simp only [gauge, factorFusionGauge, factorActionGauge, mul_one]
+  rw [factorization_of_isBlockIndependentEll hCompat hBI x₀ x]
+  rw [relativeCharacter_mul_base hCompat hBI x₀ x h]
+  simp only [mul_smul]
+  (apply Units.ext; push_cast; field_simp)
+
+/-- Direct trivializing gauges for a block-independent compatible L-symbol.
+They are the pointwise inverses of the forward factor gauges. -/
+theorem gauge_inv_eq_one_of_isBlockIndependentEll {L : LSymbol G X}
+    {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) (x₀ : X) :
+    gauge (factorFusionGauge L ω x₀)⁻¹ (factorActionGauge L)⁻¹ L =
+      (fun _ _ _ ↦ 1) := by
+  calc
+    gauge (factorFusionGauge L ω x₀)⁻¹ (factorActionGauge L)⁻¹ L =
+        gauge (factorFusionGauge L ω x₀)⁻¹ (factorActionGauge L)⁻¹
+          (gauge (factorFusionGauge L ω x₀) (factorActionGauge L)
+            (fun _ _ _ ↦ 1)) := by
+      rw [gauge_one_eq_of_isBlockIndependentEll hCompat hBI x₀]
+    _ = gauge (factorFusionGauge L ω x₀ * (factorFusionGauge L ω x₀)⁻¹)
+        (factorActionGauge L * (factorActionGauge L)⁻¹)
+        (fun _ _ _ ↦ 1) := gauge_comp _ _ _ _ _
+    _ = (fun _ _ _ ↦ 1) := by
+      funext x g h
+      simp [gauge]
+
+/-- A compatible block-independent L-symbol admits a trivializing gauge.
+The only set-theoretic assumption is that a base block exists. -/
+theorem hasTrivialGauge_of_isBlockIndependentEll [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hBI : IsBlockIndependentEll L) : HasTrivialGauge L := by
+  let x₀ : X := Classical.choice ‹Nonempty X›
+  refine ⟨(factorFusionGauge L ω x₀)⁻¹, (factorActionGauge L)⁻¹, ?_⟩
+  intro x g h
+  exact congrFun (congrFun (congrFun
+    (gauge_inv_eq_one_of_isBlockIndependentEll hCompat hBI x₀) x) g) h
+
+/-- Item 1 implies item 2 of arXiv:2502.20257, `prop:technical01`. -/
+theorem HasTrivialGauge.hasBlockConstantGauge {L : LSymbol G X}
+    (hL : HasTrivialGauge L) : HasBlockConstantGauge L := by
+  obtain ⟨β, γ, h⟩ := hL
+  exact ⟨β, γ, h.isBlockConstant⟩
+
+/-- Item 1 implies item 3 of arXiv:2502.20257, `prop:technical01`. -/
+theorem HasTrivialGauge.hasTrivialEllGauge {L : LSymbol G X}
+    (hL : HasTrivialGauge L) : HasTrivialEllGauge L := by
+  obtain ⟨β, γ, h⟩ := hL
+  exact ⟨β, γ, h.isTrivialEll⟩
+
+/-- Item 2 implies item 4 of arXiv:2502.20257, `prop:technical01`. -/
+theorem HasBlockConstantGauge.isBlockIndependent {L : LSymbol G X}
+    (hL : HasBlockConstantGauge L) : IsBlockIndependent L := by
+  obtain ⟨β, γ, h⟩ := hL
+  exact ⟨β, γ, h.isBlockIndependentEll⟩
+
+/-- Item 3 implies item 4 of arXiv:2502.20257, `prop:technical01`. -/
+theorem HasTrivialEllGauge.isBlockIndependent {L : LSymbol G X}
+    (hL : HasTrivialEllGauge L) : IsBlockIndependent L := by
+  obtain ⟨β, γ, h⟩ := hL
+  exact ⟨β, γ, h.isBlockIndependentEll⟩
+
+/-- Item 4 implies item 1 of arXiv:2502.20257, `prop:technical01`.
+Compatibility is transported through the witnessing gauge and the two gauges
+are then composed. -/
+theorem IsBlockIndependent.hasTrivialGauge [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω)
+    (hL : IsBlockIndependent L) : HasTrivialGauge L := by
+  obtain ⟨β, γ, hBI⟩ := hL
+  obtain ⟨δ, ε, hTriv⟩ :=
+    hasTrivialGauge_of_isBlockIndependentEll (hCompat.gauge β γ) hBI
+  refine ⟨β * δ, γ * ε, ?_⟩
+  rw [← gauge_comp]
+  exact hTriv
+
+/-- Capstone equivalence of items 1 and 2 in arXiv:2502.20257,
+`prop:technical01`. -/
+theorem hasTrivialGauge_iff_hasBlockConstantGauge [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
+    HasTrivialGauge L ↔ HasBlockConstantGauge L := by
+  constructor
+  · exact HasTrivialGauge.hasBlockConstantGauge
+  · exact fun h ↦ (h.isBlockIndependent).hasTrivialGauge hCompat
+
+/-- Capstone equivalence of items 1 and 3 in arXiv:2502.20257,
+`prop:technical01`. -/
+theorem hasTrivialGauge_iff_hasTrivialEllGauge [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
+    HasTrivialGauge L ↔ HasTrivialEllGauge L := by
+  constructor
+  · exact HasTrivialGauge.hasTrivialEllGauge
+  · exact fun h ↦ (h.isBlockIndependent).hasTrivialGauge hCompat
+
+/-- Capstone equivalence of items 1 and 4 in arXiv:2502.20257,
+`prop:technical01`. -/
+theorem hasTrivialGauge_iff_isBlockIndependent [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
+    HasTrivialGauge L ↔ IsBlockIndependent L := by
+  constructor
+  · exact fun h ↦ h.hasBlockConstantGauge.isBlockIndependent
+  · exact IsBlockIndependent.hasTrivialGauge hCompat
+
+end LSymbol
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -329,6 +329,268 @@ an MPU representation.
     follow.
 \end{proof}
 
+\begin{definition}[Block scalar and block independence]
+    \label{def:mpug_block_independence_factor}
+    \lean{TNLean.Algebra.LSymbol.ell,
+        TNLean.Algebra.LSymbol.IsBlockIndependentEll}
+    \leanok
+    \uses{def:mpug_l_symbols}
+    For an $L$-symbol, define
+    \begin{align}
+        \ell^x_{a,b;r}
+         & =\frac{L^x_{ar,r^{-1}b}}{L^x_{a,b}}.
+        \label{eq:mpug_block_scalar}
+    \end{align}
+    The scalar $\ell$ is block-independent when
+    \begin{align}
+        \ell^x_{a,b;r}
+         & =\ell^y_{a,b;r}
+        \label{eq:mpug_block_independence}
+    \end{align}
+    for all $a,b,r\in G$ and $x,y\in\mathsf X$.
+    % Source anchor: arXiv:2502.20257, app:block_indep, lines 6965--6974.
+\end{definition}
+
+\begin{definition}[Four scalar gauge formulations]
+    \label{def:mpug_block_independence_gauge_forms}
+    \lean{TNLean.Algebra.LSymbol.HasTrivialGauge,
+        TNLean.Algebra.LSymbol.HasBlockConstantGauge,
+        TNLean.Algebra.LSymbol.HasTrivialEllGauge,
+        TNLean.Algebra.LSymbol.IsBlockIndependent}
+    \leanok
+    \uses{def:mpug_l_gauge, def:mpug_block_independence_factor}
+    These are the four scalar $L$-symbol properties used in the proof of the
+    source proposition. Write
+    $L'=(\beta,\gamma)\mathbin{\triangleright}L$ for a joint scalar gauge of a
+    supplied $L$-symbol. The four properties are, respectively, the existence
+    of $\beta$ and $\gamma$ such that
+    \begin{align}
+        (L')^x_{g,h} & =1
+        &&\text{for all $x,g,h$},
+        \label{eq:mpug_block_form_trivial}\\
+        (L')^x_{a,b} & =(L')^y_{a,b}
+        &&\text{for all $x,y,a,b$},
+        \label{eq:mpug_block_form_constant}\\
+        \ell[L']^x_{a,b;r} & =1
+        &&\text{for all $x,a,b,r$},
+        \label{eq:mpug_block_form_trivial_ell}\\
+        \ell[L']^x_{a,b;r} & =\ell[L']^y_{a,b;r}
+        &&\text{for all $x,y,a,b,r$}.
+        \label{eq:mpug_block_form_independent_ell}
+    \end{align}
+    % Source anchor: arXiv:2502.20257, prop:technical01, lines 6975--6989.
+\end{definition}
+
+\begin{theorem}[Corrected block factorization]
+    \label{thm:mpug_block_factorization}
+    \lean{TNLean.Algebra.LSymbol.blockFactor,
+        TNLean.Algebra.LSymbol.factorization_of_isBlockIndependentEll}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_block_independence_factor}
+    Suppose that $L$ is compatible with $\omega$ and that $\ell$ is
+    block-independent. Fix $x_0\in\mathsf X$ and set
+    \begin{align}
+        A(g,h)
+         & =\bigl(\omega(gh,e,e)\ell^{x_0}_{g,h;h}\bigr)^{-1}.
+        \label{eq:mpug_block_factor}
+    \end{align}
+    Then, for every $x\in\mathsf X$ and $g,h\in G$,
+    \begin{align}
+        L^x_{g,h}
+         & =A(g,h)L^x_{e,e}.
+        \label{eq:mpug_corrected_block_factorization}
+    \end{align}
+    % Local correction:
+    % docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex.
+    % Source anchor: arXiv:2502.20257, eq:Lfact, lines 6994--7002.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_block_independence_factor}
+    Definition~\ref{def:mpug_block_independence_factor} gives
+    \begin{align}
+        L^x_{g,h}
+         & =\frac{L^x_{gh,e}}{\ell^x_{g,h;h}}.
+        \label{eq:mpug_block_factorization_first}
+    \end{align}
+    Block independence replaces $x$ by $x_0$ in the denominator.
+    Compatibility at $(gh,e,e)$ gives
+    $L^x_{gh,e}=L^x_{e,e}/\omega(gh,e,e)$, which proves
+    (\ref{eq:mpug_corrected_block_factorization}).
+\end{proof}
+
+\begin{theorem}[Relative block character]
+    \label{thm:mpug_relative_block_character}
+    \lean{TNLean.Algebra.LSymbol.relativeCharacter,
+        TNLean.Algebra.LSymbol.relativeCharacter_mul_base,
+        TNLean.Algebra.LSymbol.relativeCharacter_mul}
+    \leanok
+    \uses{thm:mpug_block_factorization}
+    Under the hypotheses of Theorem~\ref{thm:mpug_block_factorization}, define
+    \begin{align}
+        \rho(g)
+         & =\bigl(\ell^{x_0}_{e,g;g}\omega(g,e,e)
+            \omega(e,e,g)\bigr)^{-1}.
+        \label{eq:mpug_relative_block_character}
+    \end{align}
+    Then
+    \begin{align}
+        L^{g x}_{e,e}
+         & =\rho(g)L^x_{e,e},
+        \label{eq:mpug_relative_block_transport}\\
+        \rho(gh)
+         & =\rho(g)\rho(h).
+        \label{eq:mpug_relative_block_multiplicative}
+    \end{align}
+    Thus $\rho\colon G\to\C^\times$ is a one-dimensional character. No
+    transitivity or finiteness assumption on the action is required.
+    % Local correction:
+    % docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex.
+    % Source anchor: arXiv:2502.20257, eq:defrho, lines 7003--7018.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_block_factorization}
+    Compatibility at $(e,e,g)$ gives
+    $L^x_{e,g}=\omega(e,e,g)L^{g x}_{e,e}$. Compare this with
+    (\ref{eq:mpug_corrected_block_factorization}) at $(e,g)$ to obtain
+    (\ref{eq:mpug_relative_block_transport}). Applying that identity first
+    to $h$ and then to $g$, and comparing with its application to $gh$, proves
+    (\ref{eq:mpug_relative_block_multiplicative}) by cancellation.
+\end{proof}
+
+\begin{theorem}[Explicit inverse gauge]
+    \label{thm:mpug_block_independence_inverse_gauge}
+    \lean{TNLean.Algebra.LSymbol.factorFusionGauge,
+        TNLean.Algebra.LSymbol.factorActionGauge,
+        TNLean.Algebra.LSymbol.gauge_one_eq_of_isBlockIndependentEll,
+        TNLean.Algebra.LSymbol.gauge_inv_eq_one_of_isBlockIndependentEll,
+        TNLean.Algebra.LSymbol.hasTrivialGauge_of_isBlockIndependentEll}
+    \leanok
+    \uses{def:mpug_l_gauge, thm:mpug_block_factorization,
+        thm:mpug_relative_block_character}
+    With $A$ and $\rho$ as above, define the forward gauges by
+    \begin{align}
+        \beta^+_{g,h}
+         & =\frac{A(g,h)}{\rho(h)},
+        \label{eq:mpug_forward_fusion_gauge}\\
+        \gamma^{+,x}_g
+         & =\bigl(L^{g x}_{e,e}\bigr)^{-1}.
+        \label{eq:mpug_forward_action_gauge}
+    \end{align}
+    Their joint gauge multiplier equals $L$:
+    \begin{align}
+        (\beta^+,\gamma^+)\mathbin{\triangleright}1
+         & =L.
+        \label{eq:mpug_forward_gauge_multiplier}
+    \end{align}
+    Consequently the pointwise inverse gauges trivialize $L$:
+    \begin{align}
+        ((\beta^+)^{-1},(\gamma^+)^{-1})
+            \mathbin{\triangleright}L
+         & =1.
+        \label{eq:mpug_inverse_gauge_trivialization}
+    \end{align}
+    If $\mathsf X$ is nonempty, a choice of $x_0$ therefore gives a
+    trivializing joint scalar gauge for every compatible block-independent
+    $L$-symbol.
+    % Local correction:
+    % docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex.
+    % Source anchor: arXiv:2502.20257, eq:Lgauge and lines 7019--7027.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_block_factorization,
+        thm:mpug_relative_block_character}
+    Substitute (\ref{eq:mpug_forward_fusion_gauge}) and
+    (\ref{eq:mpug_forward_action_gauge}) into
+    (\ref{eq:mpug_l_gauge}). Equation
+    (\ref{eq:mpug_relative_block_transport}) reduces the multiplier to
+    $A(g,h)L^x_{e,e}$, which equals $L^x_{g,h}$ by
+    (\ref{eq:mpug_corrected_block_factorization}). Joint gauges compose by
+    pointwise multiplication, so the inverse gauges give
+    (\ref{eq:mpug_inverse_gauge_trivialization}).
+\end{proof}
+
+\begin{theorem}[Trivial and block-constant gauges]
+    \label{thm:mpug_trivial_iff_block_constant}
+    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasBlockConstantGauge}
+    \leanok
+    \uses{def:mpug_block_independence_gauge_forms,
+        thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
+    and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
+    $L$ if and only if a joint scalar gauge makes $L^x_{g,h}$ independent of
+    $x$.
+    % Source anchor: arXiv:2502.20257, prop:technical01, items 1 and 2.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    A trivial $L$-symbol is block-constant. Conversely, a block-constant
+    representative has block-independent $\ell$. Apply
+    Theorem~\ref{thm:mpug_block_independence_inverse_gauge} to that
+    representative and compose the two joint gauges.
+\end{proof}
+
+\begin{theorem}[Trivial gauges and trivial block scalars]
+    \label{thm:mpug_trivial_iff_trivial_ell}
+    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasTrivialEllGauge}
+    \leanok
+    \uses{def:mpug_block_independence_gauge_forms,
+        thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
+    and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
+    $L$ if and only if a joint scalar gauge makes every
+    $\ell^x_{a,b;r}$ equal to $1$.
+    % Source anchor: arXiv:2502.20257, prop:technical01, items 1 and 3.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    A trivial $L$-symbol has $\ell=1$. Conversely, the identity $\ell=1$
+    implies block independence. Apply
+    Theorem~\ref{thm:mpug_block_independence_inverse_gauge} and compose the
+    gauges.
+\end{proof}
+
+\begin{theorem}[Scalar gauge triviality and block independence]
+    \label{thm:mpug_trivial_iff_block_independent}
+    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_isBlockIndependent}
+    \leanok
+    \uses{def:mpug_block_independence_gauge_forms,
+        thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
+    and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
+    $L$ if and only if a joint scalar gauge makes $\ell^x_{a,b;r}$ independent
+    of $x$.
+    % Source anchor: arXiv:2502.20257, prop:technical01, items 1 and 4.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_l_gauge_preservation,
+        thm:mpug_block_independence_inverse_gauge}
+    Gauge triviality implies block constancy and hence block independence.
+    For the converse, apply
+    Theorem~\ref{thm:mpug_block_independence_inverse_gauge} to the
+    block-independent representative and compose its trivializing gauge with
+    the original gauge.
+\end{proof}
+
+The source's fourth condition is a statement about an MPS--MPU pair. The
+results above begin instead with a supplied compatible scalar $L$-symbol and
+prove the algebraic equivalence among its four scalar gauge properties. A
+separate tensor-level statement must construct the associated $L$-symbol and
+show that the tensor gauge freedoms induce the joint scalar gauge
+(\ref{eq:mpug_l_gauge}).
+% Scope boundary: the tensor-facing bridge for arXiv:2502.20257,
+% prop:technical01 is not contained in the scalar L-symbol declarations.
+
 \begin{definition}[Generalized coboundary and cocycle]
     \label{def:mpug_generalized_cocycle}
     \lean{TNLean.Algebra.ActionTensorGauge.coboundary,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -277,7 +277,7 @@ an MPU representation.
         (\delta,\varepsilon)\mathbin{\triangleright}
         \bigl((\beta,\gamma)\mathbin{\triangleright}L\bigr)
          & = (\beta\delta,\gamma\varepsilon)
-            \mathbin{\triangleright}L.
+        \mathbin{\triangleright}L.
         \label{eq:mpug_l_gauge_composition}
     \end{align}
 \end{theorem}
@@ -392,17 +392,17 @@ an MPU representation.
     supplied $L$-symbol. The four properties are, respectively, the existence
     of $\beta$ and $\gamma$ such that
     \begin{align}
-        (L')^x_{g,h} & =1
-        &&\text{for all $x,g,h$},
-        \label{eq:mpug_block_form_trivial}\\
-        (L')^x_{a,b} & =(L')^y_{a,b}
-        &&\text{for all $x,y,a,b$},
-        \label{eq:mpug_block_form_constant}\\
+        (L')^x_{g,h}       & =1
+                           &                     & \text{for all $x,g,h$},
+        \label{eq:mpug_block_form_trivial}                                     \\
+        (L')^x_{a,b}       & =(L')^y_{a,b}
+                           &                     & \text{for all $x,y,a,b$},
+        \label{eq:mpug_block_form_constant}                                    \\
         \ell[L']^x_{a,b;r} & =1
-        &&\text{for all $x,a,b,r$},
-        \label{eq:mpug_block_form_trivial_ell}\\
+                           &                     & \text{for all $x,a,b,r$},
+        \label{eq:mpug_block_form_trivial_ell}                                 \\
         \ell[L']^x_{a,b;r} & =\ell[L']^y_{a,b;r}
-        &&\text{for all $x,y,a,b,r$}.
+                           &                     & \text{for all $x,y,a,b,r$}.
         \label{eq:mpug_block_form_independent_ell}
     \end{align}
     % Source anchor: arXiv:2502.20257, prop:technical01, lines 6975--6989.
@@ -459,14 +459,14 @@ an MPU representation.
     \begin{align}
         \rho(g)
          & =\bigl(\ell^{x_0}_{e,g;g}\omega(g,e,e)
-            \omega(e,e,g)\bigr)^{-1}.
+        \omega(e,e,g)\bigr)^{-1}.
         \label{eq:mpug_relative_block_character}
     \end{align}
     Then
     \begin{align}
         L^{g x}_{e,e}
          & =\rho(g)L^x_{e,e},
-        \label{eq:mpug_relative_block_transport}\\
+        \label{eq:mpug_relative_block_transport} \\
         \rho(gh)
          & =\rho(g)\rho(h).
         \label{eq:mpug_relative_block_multiplicative}
@@ -502,7 +502,7 @@ an MPU representation.
     \begin{align}
         \beta^+_{g,h}
          & =\frac{A(g,h)}{\rho(h)},
-        \label{eq:mpug_forward_fusion_gauge}\\
+        \label{eq:mpug_forward_fusion_gauge} \\
         \gamma^{+,x}_g
          & =\bigl(L^{g x}_{e,e}\bigr)^{-1}.
         \label{eq:mpug_forward_action_gauge}
@@ -516,7 +516,7 @@ an MPU representation.
     Consequently the pointwise inverse gauges trivialize $L$:
     \begin{align}
         ((\beta^+)^{-1},(\gamma^+)^{-1})
-            \mathbin{\triangleright}L
+        \mathbin{\triangleright}L
          & =1.
         \label{eq:mpug_inverse_gauge_trivialization}
     \end{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -428,6 +428,8 @@ an MPU representation.
          & =A(g,h)L^x_{e,e}.
         \label{eq:mpug_corrected_block_factorization}
     \end{align}
+    The reciprocal factor in this identity is recorded in
+    \cite{gap:fbc25_block_independence_reciprocal_errors}.
     % Local correction:
     % docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex.
     % Source anchor: arXiv:2502.20257, eq:Lfact, lines 6994--7002.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -265,6 +265,30 @@ an MPU representation.
     % Source anchor: arXiv:2502.20257, eq:Lsymbgauge.
 \end{definition}
 
+\begin{theorem}[Identity and composition of joint scalar gauges]
+    \label{thm:mpug_l_gauge_composition}
+    \lean{TNLean.Algebra.LSymbol.gauge_one,
+        TNLean.Algebra.LSymbol.gauge_comp}
+    \leanok
+    \uses{def:mpug_l_gauge}
+    The constant fusion and action gauges leave every $L$-symbol unchanged.
+    Successive joint gauges compose by pointwise multiplication:
+    \begin{align}
+        (\delta,\varepsilon)\mathbin{\triangleright}
+        \bigl((\beta,\gamma)\mathbin{\triangleright}L\bigr)
+         & = (\beta\delta,\gamma\varepsilon)
+            \mathbin{\triangleright}L.
+        \label{eq:mpug_l_gauge_composition}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_l_gauge}
+    Substitute (\ref{eq:mpug_l_gauge}) twice and cancel the intermediate
+    factors. The identity case follows by taking all four cochains equal to
+    $1$.
+\end{proof}
+
 \begin{definition}[Normalized L-symbols and action-tensor gauges]
     \label{def:mpug_l_normalized}
     \lean{TNLean.Algebra.LSymbol.IsNormalized,
@@ -353,7 +377,10 @@ an MPU representation.
 
 \begin{definition}[Four scalar gauge formulations]
     \label{def:mpug_block_independence_gauge_forms}
-    \lean{TNLean.Algebra.LSymbol.HasTrivialGauge,
+    \lean{TNLean.Algebra.LSymbol.IsBlockConstant,
+        TNLean.Algebra.LSymbol.IsTrivialEll,
+        TNLean.Algebra.LSymbol.IsTrivial,
+        TNLean.Algebra.LSymbol.HasTrivialGauge,
         TNLean.Algebra.LSymbol.HasBlockConstantGauge,
         TNLean.Algebra.LSymbol.HasTrivialEllGauge,
         TNLean.Algebra.LSymbol.IsBlockIndependent}
@@ -383,7 +410,8 @@ an MPU representation.
 
 \begin{theorem}[Corrected block factorization]
     \label{thm:mpug_block_factorization}
-    \lean{TNLean.Algebra.LSymbol.blockFactor,
+    \lean{TNLean.Algebra.LSymbol.IsCompatible.apply_right_one,
+        TNLean.Algebra.LSymbol.blockFactor,
         TNLean.Algebra.LSymbol.factorization_of_isBlockIndependentEll}
     \leanok
     \uses{def:mpug_l_symbols, def:mpug_block_independence_factor}
@@ -421,7 +449,8 @@ an MPU representation.
 
 \begin{theorem}[Relative block character]
     \label{thm:mpug_relative_block_character}
-    \lean{TNLean.Algebra.LSymbol.relativeCharacter,
+    \lean{TNLean.Algebra.LSymbol.IsCompatible.apply_left_one,
+        TNLean.Algebra.LSymbol.relativeCharacter,
         TNLean.Algebra.LSymbol.relativeCharacter_mul_base,
         TNLean.Algebra.LSymbol.relativeCharacter_mul}
     \leanok
@@ -467,8 +496,8 @@ an MPU representation.
         TNLean.Algebra.LSymbol.gauge_inv_eq_one_of_isBlockIndependentEll,
         TNLean.Algebra.LSymbol.hasTrivialGauge_of_isBlockIndependentEll}
     \leanok
-    \uses{def:mpug_l_gauge, thm:mpug_block_factorization,
-        thm:mpug_relative_block_character}
+    \uses{def:mpug_l_gauge, thm:mpug_l_gauge_composition,
+        thm:mpug_block_factorization, thm:mpug_relative_block_character}
     With $A$ and $\rho$ as above, define the forward gauges by
     \begin{align}
         \beta^+_{g,h}
@@ -500,7 +529,7 @@ an MPU representation.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_block_factorization,
+    \uses{thm:mpug_l_gauge_composition, thm:mpug_block_factorization,
         thm:mpug_relative_block_character}
     Substitute (\ref{eq:mpug_forward_fusion_gauge}) and
     (\ref{eq:mpug_forward_action_gauge}) into
@@ -514,10 +543,14 @@ an MPU representation.
 
 \begin{theorem}[Trivial and block-constant gauges]
     \label{thm:mpug_trivial_iff_block_constant}
-    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasBlockConstantGauge}
+    \lean{TNLean.Algebra.LSymbol.IsTrivial.isBlockConstant,
+        TNLean.Algebra.LSymbol.IsBlockConstant.isBlockIndependentEll,
+        TNLean.Algebra.LSymbol.HasTrivialGauge.hasBlockConstantGauge,
+        TNLean.Algebra.LSymbol.HasBlockConstantGauge.isBlockIndependent,
+        TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasBlockConstantGauge}
     \leanok
     \uses{def:mpug_block_independence_gauge_forms,
-        thm:mpug_l_gauge_preservation,
+        thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
     and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
@@ -527,7 +560,7 @@ an MPU representation.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_l_gauge_preservation,
+    \uses{thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     A trivial $L$-symbol is block-constant. Conversely, a block-constant
     representative has block-independent $\ell$. Apply
@@ -537,10 +570,14 @@ an MPU representation.
 
 \begin{theorem}[Trivial gauges and trivial block scalars]
     \label{thm:mpug_trivial_iff_trivial_ell}
-    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasTrivialEllGauge}
+    \lean{TNLean.Algebra.LSymbol.IsTrivial.isTrivialEll,
+        TNLean.Algebra.LSymbol.IsTrivialEll.isBlockIndependentEll,
+        TNLean.Algebra.LSymbol.HasTrivialGauge.hasTrivialEllGauge,
+        TNLean.Algebra.LSymbol.HasTrivialEllGauge.isBlockIndependent,
+        TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasTrivialEllGauge}
     \leanok
     \uses{def:mpug_block_independence_gauge_forms,
-        thm:mpug_l_gauge_preservation,
+        thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
     and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
@@ -550,7 +587,7 @@ an MPU representation.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_l_gauge_preservation,
+    \uses{thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     A trivial $L$-symbol has $\ell=1$. Conversely, the identity $\ell=1$
     implies block independence. Apply
@@ -560,10 +597,11 @@ an MPU representation.
 
 \begin{theorem}[Scalar gauge triviality and block independence]
     \label{thm:mpug_trivial_iff_block_independent}
-    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_isBlockIndependent}
+    \lean{TNLean.Algebra.LSymbol.IsBlockIndependent.hasTrivialGauge,
+        TNLean.Algebra.LSymbol.hasTrivialGauge_iff_isBlockIndependent}
     \leanok
     \uses{def:mpug_block_independence_gauge_forms,
-        thm:mpug_l_gauge_preservation,
+        thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
     and suppose that $\mathsf X$ is nonempty. A joint scalar gauge trivializes
@@ -573,7 +611,7 @@ an MPU representation.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_l_gauge_preservation,
+    \uses{thm:mpug_l_gauge_composition, thm:mpug_l_gauge_preservation,
         thm:mpug_block_independence_inverse_gauge}
     Gauge triviality implies block constancy and hence block independence.
     For the converse, apply

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -875,6 +875,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf}},
 }
 
+@techreport{gap:fbc25_block_independence_reciprocal_errors,
+  author      = {The {TNLean} contributors},
+  title       = {Reciprocal Factors in the Block-Independence Argument},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_block\_independence\_reciprocal\_errors},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_block_independence_reciprocal_errors.pdf}},
+}
+
 @techreport{gap:gnvw12_support_algebra_full_matrix_scope,
   author      = {The {TNLean} contributors},
   title       = {Full-Matrix Scope for the {GNVW} Support-Algebra Formalization},

--- a/docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex
+++ b/docs/paper-gaps/fbc25_block_independence_reciprocal_errors.tex
@@ -1,0 +1,193 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Reciprocal Factors in the Block-Independence Argument}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The gauge multiplier}
+
+Let $G$ act on a set $\mathsf X$, and let
+$L\colon\mathsf X\times G^2\to\mathbb C^\times$ be an $L$-symbol. A fusion
+scalar $\beta_{g,h}$ and an action scalar $\gamma^x_g$ act by multiplication
+with
+\begin{align}
+    M^x_{g,h}(\beta,\gamma)
+        &=\frac{\gamma^x_{gh}\beta_{g,h}}
+        {\gamma^{h x}_g\gamma^x_h}.
+    \label{eq:fbc25_bi_joint_gauge_multiplier}
+\end{align}
+At line~6990, Ref.~\cite{FrancoRubio2025MPUGauging} instead repeats
+$\gamma_g$ in the second denominator factor. The second factor must be
+$\gamma_h^x$, as in
+(\ref{eq:fbc25_bi_joint_gauge_multiplier}); its group index is the second
+argument of $L^x_{g,h}$.
+
+\section{Factorization and the relative character}
+
+The source defines
+\begin{align}
+    \ell^x_{a,b;r}
+        &=\frac{L^x_{ar,r^{-1}b}}{L^x_{a,b}}.
+    \label{eq:fbc25_bi_ell_definition}
+\end{align}
+Taking $a=g$, $b=h$, and $r=h$ in
+(\ref{eq:fbc25_bi_ell_definition}) gives
+\begin{align}
+    \ell^x_{g,h;h}
+        &=\frac{L^x_{gh,e}}{L^x_{g,h}},
+    \label{eq:fbc25_bi_ell_specialization}\\
+    L^x_{g,h}
+        &=\frac{L^x_{gh,e}}{\ell^x_{g,h;h}}.
+    \label{eq:fbc25_bi_ell_solved}
+\end{align}
+Thus line~6996 of Ref.~\cite{FrancoRubio2025MPUGauging} must divide by
+$\ell^x_{g,h;h}$ rather than multiply by it. Compatibility at
+$(gh,e,e)$ gives
+\begin{align}
+    L^x_{gh,e}
+        &=\frac{L^x_{e,e}}{\omega(gh,e,e)},
+    \label{eq:fbc25_bi_right_identity}\\
+    L^x_{g,h}
+        &=\frac{L^x_{e,e}}
+        {\omega(gh,e,e)\ell^x_{g,h;h}}.
+    \label{eq:fbc25_bi_corrected_factorization}
+\end{align}
+Under block independence, $\ell^x_{g,h;h}$ may be evaluated at any fixed
+$x_0\in\mathsf X$. Hence the corrected block factor is
+\begin{align}
+    A(g,h)
+        &=(\omega(gh,e,e)\ell^{x_0}_{g,h;h})^{-1},
+    \label{eq:fbc25_bi_block_factor}\\
+    L^x_{g,h}
+        &=A(g,h)L^x_{e,e}.
+    \label{eq:fbc25_bi_factorized_lsymbol}
+\end{align}
+These identities are formalized directly from the definition of $\ell$ and
+compatibility.\footnote{Formal declarations:
+\leanid{TNLean.Algebra.LSymbol.ell},
+\leanid{TNLean.Algebra.LSymbol.blockFactor}, and
+\leanid{TNLean.Algebra.LSymbol.factorization_of_isBlockIndependentEll} in
+\doclink{TNLean/Algebra/LSymbolBlockIndependence}.}
+
+Compatibility at $(e,e,g)$ also gives
+\begin{align}
+    L^x_{e,g}
+        &=\omega(e,e,g)L^{g x}_{e,e}.
+    \label{eq:fbc25_bi_left_identity}
+\end{align}
+Combining (\ref{eq:fbc25_bi_corrected_factorization}) at $(e,g)$ with
+(\ref{eq:fbc25_bi_left_identity}) yields
+\begin{align}
+    L^{g x}_{e,e}
+        &=\rho(g)L^x_{e,e},
+    \label{eq:fbc25_bi_relative_transport}\\
+    \rho(g)
+        &=\bigl(\ell^{x_0}_{e,g;g}\omega(g,e,e)
+            \omega(e,e,g)\bigr)^{-1}.
+    \label{eq:fbc25_bi_corrected_relative_character}
+\end{align}
+The factor $\ell^{x_0}_{e,g;g}$ at line~7016 of
+Ref.~\cite{FrancoRubio2025MPUGauging} must therefore occur reciprocally.
+Applying (\ref{eq:fbc25_bi_relative_transport}) successively to $h$ and $g$
+shows that
+\begin{align}
+    \rho(gh)
+        &=\rho(g)\rho(h).
+    \label{eq:fbc25_bi_character_multiplicativity}
+\end{align}
+No transitivity or finiteness assumption on the action is needed.\footnote{Formal
+declarations: \leanid{TNLean.Algebra.LSymbol.relativeCharacter},
+\leanid{TNLean.Algebra.LSymbol.relativeCharacter_mul_base}, and
+\leanid{TNLean.Algebra.LSymbol.relativeCharacter_mul} in
+\doclink{TNLean/Algebra/LSymbolBlockIndependence}.}
+
+\section{Forward and inverse gauges}
+
+Define
+\begin{align}
+    \beta^+_{g,h}
+        &=\frac{A(g,h)}{\rho(h)},
+    \label{eq:fbc25_bi_forward_fusion_gauge}\\
+    \gamma^{+,x}_g
+        &=(L^{g x}_{e,e})^{-1}.
+    \label{eq:fbc25_bi_forward_action_gauge}
+\end{align}
+Using (\ref{eq:fbc25_bi_relative_transport}), their multiplier is
+\begin{align}
+    M^x_{g,h}(\beta^+,\gamma^+)
+        &=\frac{A(g,h)}{\rho(h)}
+          \frac{(L^{ghx}_{e,e})^{-1}}
+          {(L^{ghx}_{e,e})^{-1}(L^{hx}_{e,e})^{-1}}
+    \label{eq:fbc25_bi_forward_multiplier_first}\\
+        &=A(g,h)L^x_{e,e}
+    \label{eq:fbc25_bi_forward_multiplier_second}\\
+        &=L^x_{g,h}.
+    \label{eq:fbc25_bi_forward_multiplier_lsymbol}
+\end{align}
+Consequently, $(\beta^+,\gamma^+)$ sends the trivial $L$-symbol to $L$:
+\begin{align}
+    (\beta^+,\gamma^+)\mathbin{\triangleright}1
+        &=L.
+    \label{eq:fbc25_bi_forward_gauge_produces_lsymbol}
+\end{align}
+The displayed factor in the source is therefore a forward gauge multiplier,
+not a multiplier that trivializes $L$. The pointwise inverse gauges give the
+required conclusion:
+\begin{align}
+    ((\beta^+)^{-1},(\gamma^+)^{-1})
+        \mathbin{\triangleright}L
+        &=1.
+    \label{eq:fbc25_bi_inverse_gauge_trivializes_lsymbol}
+\end{align}
+For a supplied compatible scalar $L$-symbol, this proves the implication from
+block independence to gauge triviality and, together with the immediate
+converse implications, the four-way scalar equivalence used in the proof of
+Proposition~\texttt{prop:technical01} of
+Ref.~\cite{FrancoRubio2025MPUGauging}.\footnote{Formal declarations:
+\leanid{TNLean.Algebra.LSymbol.factorFusionGauge},
+\leanid{TNLean.Algebra.LSymbol.factorActionGauge},
+\leanid{TNLean.Algebra.LSymbol.gauge_one_eq_of_isBlockIndependentEll},
+\leanid{TNLean.Algebra.LSymbol.gauge_inv_eq_one_of_isBlockIndependentEll}, and
+\leanid{TNLean.Algebra.LSymbol.hasTrivialGauge_of_isBlockIndependentEll} in
+\doclink{TNLean/Algebra/LSymbolBlockIndependence}. The capstone equivalences
+are \leanid{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasBlockConstantGauge},
+\leanid{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_hasTrivialEllGauge}, and
+\leanid{TNLean.Algebra.LSymbol.hasTrivialGauge_iff_isBlockIndependent}.}
+
+\section{Scope of the formal result}
+
+The formal declarations start with a supplied compatible scalar $L$-symbol and
+prove the algebraic equivalence among its four scalar gauge properties. The
+fourth condition of Proposition~\texttt{prop:technical01} in
+Ref.~\cite{FrancoRubio2025MPUGauging} is instead stated for an MPS--MPU pair.
+A tensor-facing result must still construct the associated $L$-symbol and prove
+that the MPS and MPU tensor gauges induce the scalar multiplier
+(\ref{eq:fbc25_bi_joint_gauge_multiplier}). The scalar calculation does not
+supply that bridge and therefore does not by itself establish the full source
+proposition.
+
+\section{Conclusion}
+
+The four local corrections form one reciprocal chain. The denominator of the
+joint gauge multiplier uses $\gamma_h^x$; the definition of $\ell$ forces
+division by $\ell^x_{g,h;h}$ in the factorization; the relative character
+consequently contains the reciprocal of $\ell^{x_0}_{e,g;g}$; and the resulting
+factor is a forward gauge multiplier whose inverse trivializes the supplied
+$L$-symbol. These reciprocal corrections are resolved. The tensor-facing bridge
+required for the full statement of Proposition~\texttt{prop:technical01}
+remains outside the scalar result.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- Formalize the scalar L-symbol core of the block-independence equivalences in `Papers/2502.20257/main.tex`, lines 3597–3601 and 6965–7027, Proposition `prop:technical01`.
- Keep the scalar result separate from the tensor-facing bridge for an MPS–MPU pair, which remains open in #7268.

### Description

- Define the scalar factor $\ell^x_{a,b;g}$ and the four scalar gauge formulations underlying the block-independence proposition.
- Prove the corrected factorization $L^x_{g,h}=A(g,h)L^x_{e,e}$ and the multiplicative relative character.
- Construct the forward scalar gauge multiplier and use its pointwise inverse to trivialize $L$.
- Prove the three capstone equivalences among trivial, block-constant, trivial-$\ell$, and block-independent scalar gauges.
- Add Chapter 29 coverage and a consolidated paper-gap note for the linked reciprocal and gauge-index corrections.

### Testing

- `lake build` (10,373 jobs)
- `lake build TNLean.Algebra.LSymbolBlockIndependence`
- `lake build TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Blueprint compiled twice with no undefined references
- Paper-gap note compiled with resolved citations and references
- Exact module Blueprint reverse coverage: 35/35 declarations
- Independent Lean, source, and Blueprint reviews approved

Closes #7307.
Advances #7268.

### Agent assistance

- OpenAI Codex (GPT-5) was used for source and library reconnaissance, Lean proof construction, Blueprint and paper-gap alignment, review-thread repair, and validation.
