### PR TITLE
refactor(Algebra): reuse Mathlib nnnormHom

### DIFF
--- a/TNLean/Algebra/PositiveGeneralizedCocycle.lean
+++ b/TNLean/Algebra/PositiveGeneralizedCocycle.lean
@@ -45,15 +45,9 @@ namespace PositiveUnits
 def embedding : Units NNReal →* Units ℂ :=
   Units.map (Complex.ofRealHom.comp NNReal.toRealHom).toMonoidHom
 
-/-- The complex norm as a multiplicative map into the nonnegative reals. -/
-noncomputable def normMonoidHom : ℂ →* NNReal where
-  toFun z := ⟨‖z‖, norm_nonneg z⟩
-  map_one' := NNReal.eq norm_one
-  map_mul' z w := NNReal.eq (norm_mul z w)
-
 /-- The norm of a complex unit, regarded as a nonnegative-real unit. -/
 noncomputable def norm : Units ℂ →* Units NNReal :=
-  Units.map normMonoidHom
+  Units.map nnnormHom.toMonoidHom
 
 /-- Raising nonnegative-real units to a real power is a multiplicative map. -/
 noncomputable def rpow (r : ℝ) : Units NNReal →* Units NNReal :=

--- a/docs/audits/2026-08-29_positive_units_norm_hom_retirement.md
+++ b/docs/audits/2026-08-29_positive_units_norm_hom_retirement.md
@@ -1,0 +1,12 @@
+# Positive-unit norm homomorphism retirement
+
+This audit records the removal of `PositiveUnits.normMonoidHom` from
+`TNLean/Algebra/PositiveGeneralizedCocycle.lean`. Its sole non-Archive use was
+the adjacent definition `PositiveUnits.norm`, and no blueprint declaration tag
+named it.
+
+The exact replacement is Mathlib's `nnnormHom.toMonoidHom`: both maps send a
+complex number `z` to its nonnegative norm ‖z‖₊ and preserve multiplication.
+`PositiveUnits.norm` now passes that map directly to `Units.map`. No
+compatibility alias is retained, in accordance with
+`docs/project_conventions.md` §Style.


### PR DESCRIPTION
### Motivation

- `PositiveUnits.normMonoidHom` duplicates the norm homomorphism already supplied by Mathlib.
- This follows the modularity review of #7305 and resolves the focused cleanup in #7311.

### Description

- Replace `Units.map PositiveUnits.normMonoidHom` with `Units.map nnnormHom.toMonoidHom` in `PositiveUnits.norm`.
- Remove the dead local declaration after confirming that it had one non-Archive caller and no blueprint tag.
- Record the exact retirement in `docs/audits/2026-08-29_positive_units_norm_hom_retirement.md`. No compatibility alias is provided because the replacement has identical behavior and TNLean does not promise a stable local Lean API.

### Testing

- `lake build TNLean.Algebra.PositiveGeneralizedCocycle`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --ci --changed-files TNLean/Algebra/PositiveGeneralizedCocycle.lean`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Algebra/PositiveGeneralizedCocycle.lean || true`
- `git diff --check`

Closes #7311

### Agent assistance

- OpenAI Codex (GPT-5) was used for repository scouting, the focused Mathlib refactor, audit documentation, and validation.
