### PR TITLE
feat(Algebra): prove generalized coboundaries square to one

### DIFF
--- a/TNLean/Algebra/GeneralizedCocycle.lean
+++ b/TNLean/Algebra/GeneralizedCocycle.lean
@@ -9,10 +9,12 @@ import TNLean.Algebra.LSymbol
 /-!
 # Finite-group generalized cocycles
 
-This file proves the finite-group power-trivialization lemma from
-arXiv:2502.20257, `lemma:G_cocycle`, lines 5931--5948. For generalized
-2-cocycles `Ωˣ_{g,h}` attached to an action of a finite group `G` on block
-labels `X`, it constructs the regular-action matrices
+This file formalizes the block-dependent coboundaries from arXiv:2502.20257,
+lines 5914--5922, and proves that two successive coboundaries are trivial. It
+also proves the finite-group power-trivialization lemma `lemma:G_cocycle`,
+lines 5931--5948. For generalized 2-cocycles `Ωˣ_{g,h}` attached to an action
+of a finite group `G` on block labels `X`, it constructs the regular-action
+matrices
 
 `Xˣ_g |k⟩ = Ω^{k⁻¹ • x}_{g,k} |gk⟩`
 
@@ -32,12 +34,18 @@ gives `det X^{h • x}_g det Xˣ_h`. See
 ## Main definitions
 
 * `ActionTensorGauge.coboundary`: the generalized coboundary `dχ`.
+* `LSymbol.coboundary`: the corrected two-index generalized coboundary `df`.
+* `GeneralizedThreeCochain.coboundary`: the generalized coboundary of a
+  block-dependent scalar three-cochain.
 * `LSymbol.IsGeneralizedCocycle`: the equation `dΩ = 1`.
 * `LSymbol.regularMatrix`: the regular-action matrix `Xˣ_g`.
 * `LSymbol.determinantCochain`: the cochain `χˣ_g = det Xˣ_g`.
 
 ## Main results
 
+* `ActionTensorGauge.isGeneralizedCocycle_coboundary`: `dχ` is a generalized
+  2-cocycle.
+* `GeneralizedThreeCochain.coboundary_coboundary`: `d(df) = 1`.
 * `LSymbol.regularMatrix_mul`: `X^{h • x}_g Xˣ_h = Ωˣ_{g,h} Xˣ_{gh}`.
 * `LSymbol.pow_card_eq_coboundary`: `Ω ^ |G| = dχ`.
 -/
@@ -45,6 +53,12 @@ gives `det X^{h • x}_g det Xˣ_h`. See
 namespace TNLean.Algebra
 
 variable {G X : Type*} [Group G] [MulAction G X]
+
+/-- Block-dependent scalar three-cochains `fˣ_{g,h,k}` for an action of `G` on `X`. -/
+abbrev GeneralizedThreeCochain (G X : Type*) := X → G → G → G → Units ℂ
+
+/-- Block-dependent scalar four-cochains `fˣ_{g,h,k,l}` for an action of `G` on `X`. -/
+abbrev GeneralizedFourCochain (G X : Type*) := X → G → G → G → G → Units ℂ
 
 namespace ActionTensorGauge
 
@@ -60,6 +74,16 @@ end ActionTensorGauge
 
 namespace LSymbol
 
+/-- The generalized coboundary of a block-dependent scalar two-cochain:
+
+`(df)ˣ_{g,h,k} = fˣ_{g,hk} fˣ_{h,k} / (f^{k • x}_{g,h} fˣ_{gh,k})`.
+
+This is the locally corrected formula from arXiv:2502.20257, lines 5918--5921.
+The source prints the block label `x` in the final group-index position; see
+`docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex`. -/
+def coboundary (f : LSymbol G X) : GeneralizedThreeCochain G X :=
+  fun x g h k => (f x g (h * k) * f x h k) / (f (k • x) g h * f x (g * h) k)
+
 /-- A generalized scalar 2-cocycle is an L-symbol compatible with the constant
 scalar 3-cochain one. Equivalently,
 
@@ -68,6 +92,55 @@ scalar 3-cochain one. Equivalently,
 This is the equation `dΩ = 1` in arXiv:2502.20257, `lemma:G_cocycle`. -/
 def IsGeneralizedCocycle (Ω : LSymbol G X) : Prop :=
   IsCompatible Ω (fun _ _ _ => 1)
+
+end LSymbol
+
+namespace ActionTensorGauge
+
+/-- The generalized coboundary of a block-dependent scalar one-cochain is a
+generalized scalar two-cocycle.
+
+This is the one-index instance of `d(df) = 1` in arXiv:2502.20257, line 5922. -/
+theorem isGeneralizedCocycle_coboundary (χ : ActionTensorGauge G X) :
+    LSymbol.IsGeneralizedCocycle (coboundary χ) := by
+  intro x g h k
+  simp only [coboundary, mul_smul, one_mul, mul_assoc]
+  apply Units.ext
+  push_cast
+  field_simp
+
+end ActionTensorGauge
+
+namespace GeneralizedThreeCochain
+
+/-- The generalized coboundary of a block-dependent scalar three-cochain:
+
+`(dω)ˣ_{g,h,k,l} = ω^{l • x}_{g,h,k} ωˣ_{g,hk,l} ωˣ_{h,k,l} /
+  (ωˣ_{gh,k,l} ωˣ_{g,h,kl})`.
+
+This spells out the three-to-four-cochain instance needed to state the identity
+`d(df) = 1` in arXiv:2502.20257, line 5922. -/
+def coboundary (ω : GeneralizedThreeCochain G X) : GeneralizedFourCochain G X :=
+  fun x g h k l =>
+    (ω (l • x) g h k * ω x g (h * k) l * ω x h k l) /
+      (ω x (g * h) k l * ω x g h (k * l))
+
+/-- Two successive block-dependent scalar coboundaries are trivial:
+`d(df) = 1`.
+
+This is arXiv:2502.20257, line 5922, using the corrected two-index coboundary
+recorded in `docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex`. -/
+theorem coboundary_coboundary (f : LSymbol G X) :
+    coboundary (LSymbol.coboundary f) = 1 := by
+  funext x g h k l
+  simp only [coboundary, LSymbol.coboundary, Pi.one_apply, mul_smul, mul_assoc]
+  apply Units.ext
+  push_cast
+  field_simp
+
+end GeneralizedThreeCochain
+
+namespace LSymbol
 
 /-- The regular-action matrix from arXiv:2502.20257, `lemma:G_cocycle`:
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -633,7 +633,11 @@ show that the tensor gauge freedoms induce the joint scalar gauge
 
 \begin{definition}[Generalized coboundary and cocycle]
     \label{def:mpug_generalized_cocycle}
-    \lean{TNLean.Algebra.ActionTensorGauge.coboundary,
+    \lean{TNLean.Algebra.GeneralizedThreeCochain,
+        TNLean.Algebra.GeneralizedFourCochain,
+        TNLean.Algebra.ActionTensorGauge.coboundary,
+        TNLean.Algebra.LSymbol.coboundary,
+        TNLean.Algebra.GeneralizedThreeCochain.coboundary,
         TNLean.Algebra.LSymbol.IsGeneralizedCocycle}
     \leanok
     \uses{def:mpug_l_symbols, def:mpug_l_gauge}
@@ -644,6 +648,27 @@ show that the tensor gauge freedoms induce the joint scalar gauge
          & =\frac{\chi^{h x}_g\chi^x_h}{\chi^x_{gh}}.
         \label{eq:mpug_generalized_coboundary}
     \end{align}
+    For a block-dependent scalar $2$-cochain
+    $f\colon\mathsf X\times G^2\to\C^\times$, set
+    \begin{align}
+        (df)^x_{g,h,k}
+         &=\frac{f^x_{g,hk}f^x_{h,k}}
+             {f^{k x}_{g,h}f^x_{gh,k}}.
+        \label{eq:mpug_generalized_two_coboundary}
+    \end{align}
+    The final group index in the denominator is $k$; this local correction
+    of the printed formula is recorded in
+    \cite{gap:fbc25_two_cochain_coboundary_index_typo}. For a block-dependent
+    scalar $3$-cochain
+    $\omega\colon\mathsf X\times G^3\to\C^\times$, the corresponding next
+    coboundary is
+    \begin{align}
+        (d\omega)^x_{g,h,k,l}
+         &=\frac{\omega^{l x}_{g,h,k}\omega^x_{g,hk,l}
+                  \omega^x_{h,k,l}}
+                 {\omega^x_{gh,k,l}\omega^x_{g,h,kl}}.
+        \label{eq:mpug_generalized_three_coboundary}
+    \end{align}
     A function $\Omega\colon\mathsf X\times G^2\to\C^\times$ is a
     generalized $2$-cocycle when
     \begin{align}
@@ -651,14 +676,42 @@ show that the tensor gauge freedoms induce the joint scalar gauge
          & =\Omega^{k x}_{g,h}\Omega^x_{gh,k}.
         \label{eq:mpug_generalized_cocycle}
     \end{align}
-    These are the block-dependent coboundary and the equation $d\Omega=1$ in
-    \cite[lines~5914--5921 and Lemma~\texttt{lemma:G\_cocycle}]
-    {FrancoRubio2025MPUGauging}. No transitivity or finiteness assumption
-    is imposed on $\mathsf X$.
+    The source gives the first two coboundaries and the equation $d\Omega=1$
+    in \cite[lines~5914--5922 and Lemma~\texttt{lemma:G\_cocycle}]
+    {FrancoRubio2025MPUGauging}. Equation
+    \eqref{eq:mpug_generalized_three_coboundary} spells out the
+    three-to-four-cochain instance needed to read its assertion $d(df)=1$.
+    No transitivity or finiteness assumption is imposed on $\mathsf X$.
 
     % Local fix: docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex.
-    % Source anchor: arXiv:2502.20257, lines 5914--5921 and lemma:G_cocycle.
+    % Source anchor: arXiv:2502.20257, lines 5914--5922 and lemma:G_cocycle.
 \end{definition}
+
+\begin{theorem}[Generalized coboundaries square to one]
+    \label{thm:mpug_generalized_coboundary_squared}
+    \lean{TNLean.Algebra.ActionTensorGauge.isGeneralizedCocycle_coboundary,
+        TNLean.Algebra.GeneralizedThreeCochain.coboundary_coboundary}
+    \leanok
+    \uses{def:mpug_generalized_cocycle}
+    The generalized coboundary of every block-dependent scalar $1$-cochain
+    is a generalized $2$-cocycle. For every block-dependent scalar
+    $2$-cochain $f$,
+    \begin{align}
+        d(df)&=1.
+        \label{eq:mpug_generalized_coboundary_squared}
+    \end{align}
+    This is the identity stated in
+    \cite[line~5922]{FrancoRubio2025MPUGauging}, with the index correction in
+    \cite{gap:fbc25_two_cochain_coboundary_index_typo}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_generalized_cocycle}
+    Substitute the coboundary formulas. The action law
+    $k(lx)=(kl)x$ and associativity identify the shifted block labels and
+    group products. Every value of the original cochain then occurs once in
+    the numerator and once in the denominator, so all factors cancel.
+\end{proof}
 
 \begin{definition}[Positive block-dependent cochains]
     \label{def:mpug_positive_generalized_cochains}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -652,8 +652,8 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     $f\colon\mathsf X\times G^2\to\C^\times$, set
     \begin{align}
         (df)^x_{g,h,k}
-         &=\frac{f^x_{g,hk}f^x_{h,k}}
-             {f^{k x}_{g,h}f^x_{gh,k}}.
+         & =\frac{f^x_{g,hk}f^x_{h,k}}
+        {f^{k x}_{g,h}f^x_{gh,k}}.
         \label{eq:mpug_generalized_two_coboundary}
     \end{align}
     The final group index in the denominator is $k$; this local correction
@@ -664,9 +664,9 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     coboundary is
     \begin{align}
         (d\omega)^x_{g,h,k,l}
-         &=\frac{\omega^{l x}_{g,h,k}\omega^x_{g,hk,l}
-                  \omega^x_{h,k,l}}
-                 {\omega^x_{gh,k,l}\omega^x_{g,h,kl}}.
+         & =\frac{\omega^{l x}_{g,h,k}\omega^x_{g,hk,l}
+            \omega^x_{h,k,l}}
+        {\omega^x_{gh,k,l}\omega^x_{g,h,kl}}.
         \label{eq:mpug_generalized_three_coboundary}
     \end{align}
     A function $\Omega\colon\mathsf X\times G^2\to\C^\times$ is a
@@ -697,7 +697,7 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     is a generalized $2$-cocycle. For every block-dependent scalar
     $2$-cochain $f$,
     \begin{align}
-        d(df)&=1.
+        d(df) & =1.
         \label{eq:mpug_generalized_coboundary_squared}
     \end{align}
     This is the identity stated in

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -885,6 +885,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_block_independence_reciprocal_errors.pdf}},
 }
 
+@techreport{gap:fbc25_two_cochain_coboundary_index_typo,
+  author      = {The {TNLean} contributors},
+  title       = {The Final Index in the Block-Dependent Two-Cochain Coboundary},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_two\_cochain\_coboundary\_index\_typo},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_two_cochain_coboundary_index_typo.pdf}},
+}
+
 @techreport{gap:gnvw12_support_algebra_full_matrix_scope,
   author      = {The {TNLean} contributors},
   title       = {Full-Matrix Scope for the {GNVW} Support-Algebra Formalization},

--- a/docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex
+++ b/docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex
@@ -37,9 +37,11 @@ The final group index must be $k$:
         {f^{kx}_{g,h}f^x_{gh,k}}.
     \label{eq:fbc25_two_cochain_coboundary_corrected}
 \end{align}
-This is the unique correction with the declared argument types. It also gives
-the generalized cocycle equation $d\Omega=1$ used in
-Lemma~\texttt{lemma:G\_cocycle}.
+Typing rules out the printed block label $x$, but does not by itself
+distinguish among the group elements $g$, $h$, and $k$.  The standard
+generalized coboundary cancellation $d(df)=1$ determines the final index as
+$k$; this is also the identity used in the ensuing generalized-cocycle
+argument of Lemma~\texttt{lemma:G\_cocycle}.
 
 \section{Formal treatment}
 
@@ -51,8 +53,9 @@ declarations: \leanid{TNLean.Algebra.LSymbol.coboundary} and
 \doclink{TNLean/Algebra/GeneralizedCocycle}.}
 
 \textbf{Verdict: resolved local fix.}
-The source's declared argument types and subsequent generalized cocycle
-identity determine the final index as $k$.
+The source's declared argument types rule out the printed block label $x$.
+The coboundary cancellation $d(df)=1$, together with its subsequent
+generalized-cocycle use, determines the final group index as $k$.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex
+++ b/docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex
@@ -43,10 +43,11 @@ Lemma~\texttt{lemma:G\_cocycle}.
 
 \section{Formal treatment}
 
-The formal generalized cocycle equation uses
-Eq.~\ref{eq:fbc25_two_cochain_coboundary_corrected}. No hypothesis or
-conclusion is changed.\footnote{Formal declaration:
-\leanid{TNLean.Algebra.LSymbol.IsGeneralizedCocycle} in
+The formal two-cochain coboundary uses
+Eq.~\ref{eq:fbc25_two_cochain_coboundary_corrected}, and its next coboundary
+is proved to be one. No hypothesis or conclusion is changed.\footnote{Formal
+declarations: \leanid{TNLean.Algebra.LSymbol.coboundary} and
+\leanid{TNLean.Algebra.GeneralizedThreeCochain.coboundary_coboundary} in
 \doclink{TNLean/Algebra/GeneralizedCocycle}.}
 
 \textbf{Verdict: resolved local fix.}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1977,6 +1977,20 @@ spectral split → block extraction → MPV calculation → strict bounds
 
 ## Rejected
 
+### scalar-unit equality by coercion and field cancellation — rejected
+- **Pattern:** reduce an equality in `Units ℂ` to an equality in `ℂ` with
+  `apply Units.ext; push_cast`, then cancel the nonzero scalar denominators
+  with `field_simp`.
+- **Seen:** seven occurrences across
+  `TNLean/Algebra/CocycleCohomology.lean`,
+  `TNLean/Algebra/ScalarThreeCocycle.lean`,
+  `TNLean/Algebra/ScalarThreeCocycleInversion.lean`, and
+  `TNLean/Algebra/GeneralizedCocycle.lean` in the 2026-08-29 scan.
+- **Reason:** `Units.ext` is already the semantic abstraction. The remaining
+  two tactics expose the standard passage to the ambient field and a
+  goal-specific cancellation; a macro would merely hide three idiomatic lines
+  without sharing any mathematical conclusion or simplifying hypotheses.
+
 ### matrix_entry_cases — rejected
 - **Pattern:** matrix extensionality followed by a diagonal/off-diagonal split:
   `ext i j; by_cases hij : i = j; · subst hij`.


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex:5914--5922` defines the block-dependent coboundaries of one- and two-cochains and states that the latter "in fact satisfies `d(df)=1`"; issue #7306 tracks these missing scalar statements.
- The printed two-cochain formula ends with the block label `x` in a group-index position. The resolved note `docs/paper-gaps/fbc25_two_cochain_coboundary_index_typo.tex` identifies the forced correction to `k`.

### Description

- Introduce block-dependent scalar three- and four-cochains, the corrected `LSymbol.coboundary`, and the three-to-four coboundary needed to state the source identity.
- Prove `ActionTensorGauge.isGeneralizedCocycle_coboundary` and `GeneralizedThreeCochain.coboundary_coboundary` under exactly a group action, using the action law, associativity, and cancellation in complex units.
- Extend Chapter 29 with the paper formulas and `leanok` theorem, and update the correction note and its published bibliography entry.
- Record the repeated complex-unit cancellation proof pattern as deliberately direct: `Units.ext` is already its semantic abstraction.

### Testing

- `lake build TNLean.Algebra.GeneralizedCocycle TNLean.Algebra.GeneralizedCocycleInversion TNLean.Algebra.PositiveGeneralizedCocycle TNLean.Algebra`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --warn-missing-blueprint --changed-files TNLean/Algebra/GeneralizedCocycle.lean --diff-base origin/main`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint pdf`
- standalone `latexmk -pdf` build of `fbc25_two_cochain_coboundary_index_typo.tex`
- proof-integrity scan of `TNLean/Algebra/GeneralizedCocycle.lean` for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` returned no matches

---
Closes #7306

### Agent assistance

- OpenAI Codex (GPT-5) was used for source and library reconnaissance, Lean proof construction, documentation alignment, and validation.