### PR TITLE
doc(MPU): audit action-tensor source boundary

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -537,7 +537,9 @@ jobs:
 
       - name: Generate paper source labels
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'
-        run: ./scripts/generate_paper_aux.sh 1606.00608
+        run: |
+          ./scripts/generate_paper_aux.sh 1606.00608
+          ./scripts/generate_paper_aux.sh 2502.20257
 
       - name: Check paper-gap references resolve
         if: env.TEX_CHANGED == 'true' || env.PAPER_GAPS_CHANGED == 'true'

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -935,6 +935,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_support_algebra_star_closure.pdf}},
 }
 
+@techreport{gap:mgsc18_residual_expansion_empty_word_error,
+  author      = {The {TNLean} contributors},
+  title       = {The Empty-Word Summation Error in the {MPS} Residual Expansion},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {mgsc18\_residual\_expansion\_empty\_word\_error},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/mgsc18_residual_expansion_empty_word_error.pdf}},
+}
+
 @article{Gross2012IndexTheory,
   author       = {Gross, David and Nesme, Vincent and Vogts, H{\'e}ctor and
                   Werner, Reinhard F.},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -234,6 +234,12 @@ For the non-periodic MPS Fundamental Theorem background:
   scalar $\lambda\ne1$; the equality specialization used for MPU fusion is
   unaffected, while a nonzero general scalar contributes
   $\lambda^{\lvert\mathbf a\rvert}$ to the reduced word.
+- `mgsc18_residual_expansion_empty_word_error.tex` is the open false-source
+  record for the first equality in Lemma `B_expand`.  The printed weak range
+  inserts empty central words and omits the pure residual word; a
+  three-dimensional reduction with residual $E_{23}$ is a counterexample.
+  The corrected formula separates the pure residual term and sums only over
+  nonempty central words.
 - [cpsv16_bnt_uniqueness_zero_coefficient.tex](https://sirui-lu.com/QICLean/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.pdf) records the nonzero-coefficient
   convention: every coefficient of a CPSV16 canonical form is nonzero, as the
   line-246 normalization presupposes. Under this convention Proposition 2.7,
@@ -327,6 +333,8 @@ For the MPU action on injective MPS blocks in arXiv:2502.20257:
 - `fbc25_mpu_action_stabilizer_source_audit.tex` separates the
   positive-length MPS reduction route to action tensors from the stronger
   arbitrary-boundary MPO-algebra route, records the nilpotency and tailwise
-  scalar-uniqueness hypotheses, fixes the left-action and scalar-gauge
-  conventions, and explains the stabilizer/coset and
+  scalar-uniqueness hypotheses, corrects the empty-word summation in the
+  printed residual expansion, fixes the left-action and scalar-gauge
+  conventions (including the swapped-order prose typo preceding Equation
+  (20)), and explains the stabilizer/coset and
   $H^2(H,\mathbb C^\times)$-torsor meanings of the notation $(H,\psi)$.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -321,3 +321,12 @@ note.
   load-bearing κ/θ/φ phase assembly (Case 3). It also records the scope
   restriction of `periodicBasis_eventuallyLinearlyIndependent` (independence
   half only, no spanning clause).
+
+For the MPU action on injective MPS blocks in arXiv:2502.20257:
+
+- `fbc25_mpu_action_stabilizer_source_audit.tex` separates the
+  positive-length MPS reduction route to action tensors from the stronger
+  arbitrary-boundary MPO-algebra route, records the nilpotency and tailwise
+  scalar-uniqueness hypotheses, fixes the left-action and scalar-gauge
+  conventions, and explains the stabilizer/coset and
+  $H^2(H,\mathbb C^\times)$-torsor meanings of the notation $(H,\psi)$.

--- a/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
+++ b/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
@@ -1,0 +1,479 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{graphicx}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Source Boundary for MPU Action Tensors and Stabilizer Data}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{open-gap}{open}
+
+\section{Scope and conclusion}
+
+The source coordinates in this note are pinned to
+\path{Papers/2502.20257/main.tex}, the official
+arXiv:1706.07329v2 file \path{cornerproblem.tex}, the official
+arXiv:2203.12563v3 file \path{REsubmission.tex}, and the official
+arXiv:2405.00439v2 file \path{MPU-DW.tex}.  Thus every source-line range below
+is reproducible against a specified source version rather than a reformatted
+PDF.
+
+The discussion of an MPU action on MPSs in
+Ref.~\cite[lines~1782--1931]{FrancoRubio2025MPUGauging} uses two logically
+different results.  The existence and scalar uniqueness of the action tensors
+come from the MPS reduction theorem of
+Ref.~\cite{Molnar2018SemiInjective}.  The description of scalar
+$L$-symbols by stabilizer data comes from Sections~3 and~4.1 of
+Ref.~\cite{GarreRubio2023MPOSym}.  The second paper also proves an existence
+theorem for action tensors, but under an arbitrary-boundary invariance
+hypothesis that is stronger than the periodic-boundary hypothesis in the
+first paper and in Ref.~\cite{FrancoRubio2025MPUGauging}.
+
+Thus there are two valid existence routes, but they cannot be interchanged.
+For the simple-MPU setting of Ref.~\cite{FrancoRubio2025MPUGauging}, the
+source-faithful route is the positive-length MPS reduction theorem, followed
+by its nilpotency and scalar-uniqueness results.  Appendix~A of
+Ref.~\cite{GarreRubio2023MPOSym} applies only after arbitrary-boundary
+invariance has been supplied.  Once action and fusion tensors exist, the
+scalar analysis of Section~4.1 of that paper applies independently of which
+existence route produced them.
+
+This distinction is the present open formal boundary.  The scalar
+$L$-symbol relations are already formalized, whereas the tensor-valued
+reduction and action data are not.
+
+\section{The reduction route to action tensors}
+
+Let $A_x$ be an injective MPS tensor for every $x$ in a set $\mathsf X$, and
+let $B_{g,x}$ denote the MPS tensor obtained by stacking the MPU tensor
+$\mathcal U_g$ on $A_x$ and vectorizing the physical legs.  The periodic
+symmetry assumption is equality of the positive-length MPS vectors:
+\begin{align}
+    \mathcal V_N(B_{g,x})
+        &=\mathcal V_N(A_{g\mathbin{\cdot}x}),
+        &&N\geq 1.
+    \label{eq:fbc25_action_audit_positive_length_symmetry}
+\end{align}
+Here the dot denotes the left action fixed below.  The target tensor
+$A_{g\mathbin{\cdot}x}$ is injective and therefore normal.
+
+Proposition~20 of Ref.~\cite[source lines~3124--3133, with proof at
+lines~3815--3939]{Molnar2018SemiInjective} applies to a normal target tensor
+$A$ and an arbitrary tensor $B$ which generates the same MPS family, allowing
+an exponential scalar $\lambda^N$.  In the exact symmetry relation
+(\ref{eq:fbc25_action_audit_positive_length_symmetry}), that scalar is one.
+The proposition supplies matrices $V_{g,x}$ and $W_{g,x}$ such that
+\begin{align}
+    V_{g,x}W_{g,x}
+        &=\mathbf 1,
+    \label{eq:fbc25_action_audit_reduction_retraction}\\
+    V_{g,x}B_{g,x}^{i_1}\cdots B_{g,x}^{i_n}W_{g,x}
+        &=A_{g\mathbin{\cdot}x}^{i_1}\cdots
+          A_{g\mathbin{\cdot}x}^{i_n},
+        &&n\geq 1.
+    \label{eq:fbc25_action_audit_reduction_words}
+\end{align}
+The proof obtains
+(\ref{eq:fbc25_action_audit_reduction_retraction}) by taking the empty
+interior word in the local reduction identity; it does not require equality
+of the two length-zero periodic MPS coefficients.
+
+The two matrices in
+(\ref{eq:fbc25_action_audit_reduction_words}) are the source of the action
+tensors $A^{\Gamma}_{g,x}$ and
+$A^{\text{\reflectbox{$\Gamma$}}}_{g,x}$ in the target paper, after matching
+the left and right virtual-leg orientations in its diagrams.  Proposition~21
+and Definition~8 of Ref.~\cite[source lines~3142--3152, with proof at
+lines~3943--3986]{Molnar2018SemiInjective} introduce the residual matrices
+\begin{align}
+    R_{g,x}^{i}
+        &=B_{g,x}^{i}
+          -W_{g,x}A_{g\mathbin{\cdot}x}^{i}V_{g,x}
+    \label{eq:fbc25_action_audit_residual_definition}
+\end{align}
+and prove that their generated algebra is nilpotent.  The nilpotency length
+$\ell_{g,x}$ is the least length after which every residual word vanishes:
+\begin{align}
+    R_{g,x}^{i_1}\cdots R_{g,x}^{i_n}
+        &=0,
+        &&n\geq \ell_{g,x}.
+    \label{eq:fbc25_action_audit_residual_nilpotency}
+\end{align}
+Expanding $B_{g,x}$ using
+(\ref{eq:fbc25_action_audit_residual_definition}) and applying
+(\ref{eq:fbc25_action_audit_residual_nilpotency}) gives the exterior and
+interior action identities used in the target paper.  This is why its
+Equation~\texttt{eq:action\_exterior} requires exterior tails of length
+$m\geq\ell$, whereas Equation~\texttt{eq:action\_interior} permits an
+interior length $n\geq0$
+\cite[lines~1787--1870]{FrancoRubio2025MPUGauging}.
+
+Theorem~22 of Ref.~\cite[source lines~3154--3162, with proof at
+lines~3990--4035]{Molnar2018SemiInjective} gives the precise uniqueness
+statement.  If $(V,W)$ and $(\widetilde V,\widetilde W)$ are two reductions
+whose nilpotency lengths are at most $N_0$, then there is
+$c\in\mathbb C^\times$ such that, for every word of length $n>2N_0$,
+\begin{align}
+    VB^{i_1}\cdots B^{i_n}
+        &=c\,\widetilde V B^{i_1}\cdots B^{i_n},
+    \label{eq:fbc25_action_audit_reduction_left_uniqueness}\\
+    B^{i_1}\cdots B^{i_n}W
+        &=c^{-1}B^{i_1}\cdots B^{i_n}\widetilde W.
+    \label{eq:fbc25_action_audit_reduction_right_uniqueness}
+\end{align}
+This is tailwise scalar uniqueness.  It is not the unconditional assertion
+$V=c\widetilde V$ and $W=c^{-1}\widetilde W$ as bare matrices.
+
+Theorem~1 of Ref.~\cite[source lines~358--377]{GarreRubioSchuch2024DomainWall}
+restates the nilpotency-one case in the form used for MPU products and MPU
+actions.  Its hypotheses give
+\begin{align}
+    VB^i\widehat V
+        &=A^i,
+    \label{eq:fbc25_action_audit_domain_wall_reduction}\\
+    B^i\widehat V A^j V B^k
+        &=B^iB^jB^k,
+    \label{eq:fbc25_action_audit_domain_wall_exterior}\\
+    V\widehat V
+        &=\mathbf 1.
+    \label{eq:fbc25_action_audit_domain_wall_retraction}
+\end{align}
+The statement is explicitly described there as informal: its footnote assumes
+that the off-diagonal residual has nilpotency length one and says that this is
+achieved by blocking.  Likewise, the target paper first permits
+$m\geq\ell$ and then assumes that all nilpotency lengths have been reduced to
+one by blocking
+\cite[lines~1870--1874]{FrancoRubio2025MPUGauging}.  Consequently a formal
+action-tensor theorem must either retain $\ell$ in its identities or prove the
+blocking step before using the one-site identities.  Simplicity of the MPU is
+not, by itself, a cited proof that an unblocked stacked tensor has
+$\ell=1$.
+
+The relevant global equality in the formal library is positive-length equality
+for possibly different bond dimensions.  Full equality at length zero would
+compare the traces of two identity matrices and therefore force equality of
+the bond dimensions, although the stacked tensor $B_{g,x}$ and the reduced
+tensor $A_{g\mathbin{\cdot}x}$ need not have equal bond dimensions.  Thus the
+correct formal input is
+\leanid{MPSTensor.SameMPV}\textsubscript{2}\leanid{Pos}, not
+\leanid{MPSTensor.SameMPV}\textsubscript{2}.
+
+\section{The arbitrary-boundary route is different}
+
+Section~2 of Ref.~\cite[source lines~302--331]{GarreRubio2023MPOSym} defines
+an MPS arbitrary-boundary subspace by allowing every virtual boundary matrix
+$X$, and an MPO algebra by allowing every MPO boundary matrix $C$.  Its
+closedness condition requires one boundary matrix, independent of the system
+size, to represent each product of arbitrary-boundary MPOs.  Section~3 then
+defines symmetry by the stronger condition that for every $C$ and $X$ there
+is a boundary matrix $Y(C,X)$, again independent of $N$, such that
+\begin{align}
+    O^N_{T,C}\,\lvert\psi^N_{A,X}\rangle
+        &=\lvert\psi^N_{A,Y(C,X)}\rangle,
+        &&\text{for every }C,X,N.
+    \label{eq:fbc25_action_audit_arbitrary_boundary_invariance}
+\end{align}
+This is Equation~\texttt{eq:compatible} of that source
+\cite[source lines~429--460]{GarreRubio2023MPOSym}.  Its Appendix~A starts
+from the size-independent linear boundary map, takes a minimal-rank
+decomposition, and uses the one-site and two-site identities plus block
+injectivity to obtain fusion tensors and their orthogonality
+\cite[source lines~2305--2454]{GarreRubio2023MPOSym}.  The final sentence
+applies the same construction to
+(\ref{eq:fbc25_action_audit_arbitrary_boundary_invariance}) to obtain action
+tensors and their orthogonality
+\cite[source line~2455]{GarreRubio2023MPOSym}.
+
+By contrast, the simple-MPU hypothesis gives the periodic relation
+(\ref{eq:fbc25_action_audit_positive_length_symmetry}) for the distinguished
+closed boundaries.  It does not quantify over $C$ and $X$, and it does not
+supply the boundary map used in Appendix~A.  The mismatch is structural, not
+merely a missing lemma.  Ref.~\cite[source lines~1211--1216]{GarreRubio2023MPOSym}
+proves that an injective group MPO satisfying $U_gU_h=U_{gh}$ and
+$U_e=\mathbf 1$ must be on-site, with trivial $3$-cocycle, if its fusion
+tensors also satisfy the arbitrary-boundary closedness condition.  Hence an
+anomalous injective MPU representation with $U_e=\mathbf 1$ cannot satisfy
+that condition.
+
+There is a second difference.  In the arbitrary-boundary group algebra of
+Ref.~\cite[source lines~638--683]{GarreRubio2023MPOSym}, the neutral operator
+$O_e$ is generally a projector onto a relevant periodic-boundary subspace,
+not the identity on the full Hilbert space, and the operators need not be
+unitary.  The target paper instead uses simple injective MPUs, each unitary on
+the full periodic chain, with $\mathcal U_e=\mathbf 1$.  The reduction theorem
+of the preceding section is designed for this latter situation.
+
+\section{Left-action and scalar conventions}
+
+The target paper uses a left action: $g\mathbin{\cdot}x$ is the block obtained
+by applying $g$ to $x$, and $gh\mathbin{\cdot}x$ means that $h$ acts first and
+then $g$.  Its transitivity assumption is that for every $x,y\in\mathsf X$
+there is $g\in G$ with $y=g\mathbin{\cdot}x$
+\cite[lines~1782--1785]{FrancoRubio2025MPUGauging}.  With this convention,
+the scalar compatibility equation is
+\begin{align}
+    L^x_{g,hk}L^x_{h,k}
+        &=\omega(g,h,k)L^{k\mathbin{\cdot}x}_{g,h}L^x_{gh,k}.
+    \label{eq:fbc25_action_audit_l_compatibility}
+\end{align}
+The shifted block is $k\mathbin{\cdot}x$, not
+$g\mathbin{\cdot}x$ or $h\mathbin{\cdot}x$, because the comparison begins
+with the rightmost action.  Equation
+(\ref{eq:fbc25_action_audit_l_compatibility}) is
+Equation~\texttt{eq:omega\_and\_Ls} of the target paper
+\cite[lines~1920--1924]{FrancoRubio2025MPUGauging} and agrees with the group
+specialization in Ref.~\cite[source lines~683--719]{GarreRubio2023MPOSym}.
+
+The target paper scales its reflected-$\Gamma$ action tensor by
+$\gamma_{g,x}$ and its $\Gamma$ action tensor by $\gamma_{g,x}^{-1}$:
+\begin{align}
+    A^{\text{\reflectbox{$\Gamma$}}}_{g,x}
+        &\longmapsto
+          \gamma_{g,x}A^{\text{\reflectbox{$\Gamma$}}}_{g,x},
+    &
+    A^{\Gamma}_{g,x}
+        &\longmapsto
+          \gamma_{g,x}^{-1}A^{\Gamma}_{g,x}.
+    \label{eq:fbc25_action_audit_action_tensor_gauge}
+\end{align}
+Together with its fusion-tensor convention this gives
+\begin{align}
+    L^x_{g,h}
+        &\longmapsto
+          \frac{\gamma_{gh,x}\,\beta_{g,h}}
+               {\gamma_{g,h\mathbin{\cdot}x}\,\gamma_{h,x}}
+          L^x_{g,h}.
+    \label{eq:fbc25_action_audit_target_l_gauge}
+\end{align}
+These are Equations~\texttt{eq:scalar\_act\_ten} and
+\texttt{eq:Lsymbgauge} of Ref.~\cite[lines~1870--1919]{FrancoRubio2025MPUGauging}.
+Equation~\texttt{gdgroup} of Ref.~\cite[source lines~720--726]{GarreRubio2023MPOSym}
+prints the reciprocal factor.  The two formulas use inverse names for both
+scalar gauges: replacing the 2023 parameters by
+$\gamma^{-1}$ and $\beta^{-1}$ gives
+(\ref{eq:fbc25_action_audit_target_l_gauge}).  The compatibility equation is
+unchanged.  The formal library follows the target convention, so a proof may
+not import the 2023 gauge formula without this inversion.
+
+\section{Stabilizer data and the meaning of
+  \texorpdfstring{$(H,\psi)$}{(H, psi)}}
+
+Assume now that $G$ is finite, $\mathsf X$ is nonempty, and the left action is
+transitive.  After choosing $x_0\in\mathsf X$, the subgroup in Section~4.1 of
+Ref.~\cite[source lines~731--749]{GarreRubio2023MPOSym} is precisely the
+stabilizer
+\begin{align}
+    H=\operatorname{Stab}_G(x_0)
+        &=\{h\in G\mid h\mathbin{\cdot}x_0=x_0\}.
+    \label{eq:fbc25_action_audit_stabilizer}
+\end{align}
+It is not an additional ``largest'' subgroup and it need not be normal.
+Transitivity gives an equivariant bijection of sets
+\begin{align}
+    G/H&\longrightarrow\mathsf X,
+    &gH&\longmapsto g\mathbin{\cdot}x_0,
+    \label{eq:fbc25_action_audit_coset_equivalence}\\
+    \lvert\mathsf X\rvert
+        &=\lvert G/H\rvert.
+    \label{eq:fbc25_action_audit_coset_cardinality}
+\end{align}
+Here $G/H$ is the left-coset set.  It is not a quotient group unless $H$ is
+normal.  Replacing $x_0$ by $g\mathbin{\cdot}x_0$ replaces $H$ by the
+conjugate subgroup $gHg^{-1}$, so the basepoint-free datum is a conjugacy
+class of stabilizer data, not a distinguished subgroup.
+
+Restricting
+(\ref{eq:fbc25_action_audit_l_compatibility}) to $H$ shows that
+$\omega|_H$ is cohomologically trivial.  In the convention printed in
+Ref.~\cite[source lines~740--749]{GarreRubio2023MPOSym}, one chooses a
+$2$-cochain $\beta$ satisfying
+\begin{align}
+    \omega(h_1,h_2,h_3)
+    \frac{\beta_{h_1,h_2}\,\beta_{h_1h_2,h_3}}
+         {\beta_{h_2,h_3}\,\beta_{h_1,h_2h_3}}
+        &=1,
+        &&h_1,h_2,h_3\in H,
+    \label{eq:fbc25_action_audit_restricted_trivialization}
+\end{align}
+and then defines the representative
+\begin{align}
+    \psi_{x_0}(h_1,h_2)
+        &=\frac{L^{x_0}_{h_1,h_2}}{\beta_{h_1,h_2}}.
+    \label{eq:fbc25_action_audit_psi_representative}
+\end{align}
+In that chosen trivializing gauge, $\psi_{x_0}$ is a $2$-cocycle.  Changing
+the action-tensor gauge changes it by a $2$-coboundary, so the invariant is its
+class $[\psi_{x_0}]\in H^2(H,\mathbb C^\times)$.  Before choosing a
+trivializer for $\omega|_H$, the corresponding object is a trivializing
+$2$-cochain rather than a canonically based element of $H^2$.
+
+Equation~(20) of Ref.~\cite{GarreRubio2023MPOSym} makes the
+representative-level choices explicit; it is at lines~752--759 of the
+official v3 source.  Choose a representative
+$k_\alpha\in G$ for every coset and define $h_2,h_1\in H$ by
+$g_2k_\alpha=k_\beta h_2$ and
+$g_1k_\beta=k_\gamma h_1$.  The source gives
+\begin{align}
+    L^\alpha_{g_1,g_2}
+        &=\frac{
+          \omega(g_1g_2k_\alpha,h_2^{-1},h_1^{-1})\,
+          \psi(h_1,h_2)}{
+          \omega(g_1,g_2k_\alpha,h_2^{-1})\,
+          \omega(g_1,g_2,k_\alpha)}.
+    \label{eq:fbc25_action_audit_l_reconstruction}
+\end{align}
+Thus Equation~(20) constructs a chosen scalar $L$-symbol representative from
+a chosen representative of $\omega$, a chosen trivialization and cocycle
+representative, a basepoint, and coset representatives.  It is not a canonical
+formula on cohomology classes, and it does not construct action tensors or an
+MPU realization.
+
+For fixed $(G,\omega,H)$, Ref.~\cite[source line~761]{GarreRubio2023MPOSym}
+states that gauge classes of solutions form a torsor for
+$H^2(H,\mathbb C^\times)$.  A choice of trivialization identifies that torsor
+with the group, but in general there is no canonical solution corresponding
+to the identity cohomology class.  Accordingly, the notation $(H,\psi)$ has
+three levels which should not be conflated:
+\begin{enumerate}
+    \item in Equation~(20), $H$ and $\psi$ are chosen representatives, together
+          with the unprinted auxiliary gauge choices just listed;
+    \item for scalar classification, the invariant is stabilizer data up to
+          basepoint conjugacy and a gauge class represented by $\psi$;
+    \item for phases, the invariant is the resulting equivalence class of
+          $L$-symbols, under the hypotheses of the phase theorem.
+\end{enumerate}
+The phase theorem itself concerns periodic Hamiltonians with exact MPS ground
+spaces, equivalent $F$-symbols, and the restricted symmetric gapped paths
+specified in that paper
+\cite[source lines~1219--1272, especially the main result at line~1231]
+{GarreRubio2023MPOSym}.  It is not a classification of arbitrary Hamiltonian
+phases, raw cocycle representatives, action tensors, or MPU tensor data.
+Conversely, the scalar construction
+(\ref{eq:fbc25_action_audit_l_reconstruction}) proves existence of an
+$L$-symbol solution for admissible chosen data, but not existence of tensor
+data realizing every such solution in the simple-MPU setting.
+
+\section{Present formal boundary}
+
+The existing library separates the following layers.
+
+\begin{itemize}
+    \item QICLean defines \leanid{Kraus.IsInjective},
+          \leanid{Kraus.IsNBlkInjective}, and \leanid{Kraus.IsNormal} for one
+          matrix family.  The second predicate says that the length-$N$ words
+          of one tensor span its full matrix algebra.  It is not the paper's
+          direct-sum block-injective condition
+          \begin{align}
+              A^i&=\bigoplus_{x\in\mathsf X}A_x^i,
+              &\operatorname{span}\{A_x^i\}_i
+                  &=\operatorname{Mat}_{D_x}(\mathbb C)
+                  \quad\text{for every }x.
+              \label{eq:fbc25_action_audit_block_injective_distinction}
+          \end{align}
+          The direct-sum assembly is available through
+          \leanid{MPSTensor.toTensorFromBlocks} and the richer
+          \leanid{MPSTensor.SectorDecomposition} infrastructure, but no
+          existing predicate attaches a transitive group action and an MPU
+          action to that family.
+
+    \item TNLean defines \leanid{MPOTensor.IsMPU} by unitarity for every
+          system size $N>1$, following the 2017 MPU convention, and defines
+          \leanid{MPOTensor.IsMPUSimple} by the two local simple-tensor
+          contractions.  It also has the product tensor
+          \leanid{MPOTensor.mulTensor} and the doubled-index view
+          \leanid{MPOTensor.toMPSTensor}.  It has no group-indexed MPU
+          representation object and no tensor for the stacked action of an
+          MPU on an MPS.  Those notions must precede the reduction theorem;
+          they should not be inferred from the scalar $L$-symbol API.
+
+    \item \leanid{MPSTensor.SameMPV}\textsubscript{2}\leanid{Pos}
+          expresses the global
+          equality in
+          (\ref{eq:fbc25_action_audit_positive_length_symmetry}) across
+          different bond dimensions.  The missing result is the
+          Moln\'ar--Ge--Schuch--Cirac reduction package:
+          (\ref{eq:fbc25_action_audit_reduction_retraction})--
+          (\ref{eq:fbc25_action_audit_residual_nilpotency}), its transport
+          under blocking, and the tailwise uniqueness
+          (\ref{eq:fbc25_action_audit_reduction_left_uniqueness})--
+          (\ref{eq:fbc25_action_audit_reduction_right_uniqueness}).
+
+    \item Mathlib's \leanid{MulAction},
+          \leanid{MulAction.IsPretransitive},
+          \leanid{MulAction.stabilizer}, and
+          \leanid{MulAction.orbitEquivQuotientStabilizer} provide the correct
+          action, transitivity, stabilizer, and coset-set language for
+          (\ref{eq:fbc25_action_audit_stabilizer})--
+          (\ref{eq:fbc25_action_audit_coset_equivalence}).  Transitivity is
+          represented by pretransitivity together with nonemptiness.  No
+          normality hypothesis on $H$ should be introduced.
+
+    \item TNLean's \leanid{TNLean.Algebra.LSymbol} is the scalar function
+          $\mathsf X\to G\to G\to\mathbb C^\times$.
+          \leanid{TNLean.Algebra.LSymbol.IsCompatible} is exactly
+          (\ref{eq:fbc25_action_audit_l_compatibility}), and
+          \leanid{TNLean.Algebra.LSymbol.gauge} is exactly
+          (\ref{eq:fbc25_action_audit_target_l_gauge}).  The name
+          \leanid{TNLean.Algebra.ActionTensorGauge} denotes only the scalar
+          cochain $\gamma_{g,x}$; it is not tensor data.  These declarations
+          deliberately assert neither existence of action tensors nor their
+          attachment to an MPU.
+
+    \item \leanid{TNLean.Algebra.H2} is the quotient of genuine
+          $\mathbb C^\times$-valued $2$-cocycles by coboundary equivalence.
+          Its coefficient type is \leanid{Units}\,$\mathbb C$; despite prose in
+          some module comments using $U(1)$, the implemented coefficient
+          group matches the $\mathbb C^\times$ notation of the cited papers.
+          No present theorem packages the restriction to a stabilizer, a
+          chosen trivializer of $\omega|_H$, the torsor of solutions, or the
+          representative reconstruction
+          (\ref{eq:fbc25_action_audit_l_reconstruction}).
+
+    \item The on-site, single-block specialization is already represented by
+          \leanid{MPSTensor.IsOnSiteSymmetric} and
+          \leanid{MPSTensor.virtual_rep_of_symmetric_injective}.  It should be
+          reused when $H=G$ and the anomaly is trivial, but it is not a
+          substitute for an anomalous MPU acting on several injective blocks.
+          Likewise, the MPDO structure named
+          \leanid{MPOTensor.BNTFusionTensorClause} concerns the CPSV16
+          renormalization-fixed-point fusion clause and is not the group-MPU
+          fusion tensor of the present sources.
+\end{itemize}
+
+The tensor-valued reduction package, rather than a new cohomology interface,
+is therefore the next mathematical prerequisite.  Until it exists, the
+formal scalar $L$-symbol results must not be described as proving the
+existence or classification of MPU action tensors.
+
+\section{Verdict}
+
+The cited action-tensor claim is supported by
+Ref.~\cite{Molnar2018SemiInjective}, provided that one retains the normal
+target, positive-length periodic equality, residual nilpotency, and finite
+blocking used by that theorem.  Its scalar uniqueness is the tailwise
+statement
+(\ref{eq:fbc25_action_audit_reduction_left_uniqueness})--
+(\ref{eq:fbc25_action_audit_reduction_right_uniqueness}).  The
+arbitrary-boundary theorem of Ref.~\cite{GarreRubio2023MPOSym} is not an
+alternative proof under the simple-MPU hypotheses.
+
+The stabilizer classification is a classification of gauge classes of scalar
+$L$-symbol solutions, and under the separate phase hypotheses it classifies
+the corresponding exact-MPS symmetric phases.  The notation $(H,\psi)$ does
+not by itself denote tensor data, and the solution set is naturally an
+$H^2(H,\mathbb C^\times)$-torsor.  The formal gap remains open exactly at the
+reduction-to-action-tensor layer; no new tensor data or cohomology interface is
+introduced in this note.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
+++ b/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
@@ -132,8 +132,8 @@ $\ell_{g,x}$ is the least length after which every residual word vanishes:
     \label{eq:fbc25_action_audit_residual_nilpotency}
 \end{align}
 Nilpotency alone does not remove the mixed terms in an expansion of $B$.
-The additional input is the residual-word expansion lemma of Appendix~B and
-its preceding sandwiched-residual lemma
+The additional input is the intended residual-word expansion of Appendix~B
+and its preceding sandwiched-residual lemma
 \cite[source lines~3946--3970 and 3993--4005]{Molnar2018SemiInjective}.
 Suppress $g,x$ temporarily, write an empty product as the identity, and let
 $\mathbf i=(i_1,\ldots,i_n)$.  The sandwiched residual words obey
@@ -143,15 +143,32 @@ $\mathbf i=(i_1,\ldots,i_n)$.  The sandwiched residual words obey
         &&r>0.
     \label{eq:fbc25_action_audit_sandwiched_residual_vanishes}
 \end{align}
-Consequently the full mixed-term expansion and its two boundary contractions
-are
+
+The first equality printed in Lemma~\texttt{B\_expand}, at source
+lines~3993--4005, is false as printed and admits the following local
+correction.  Its weak inequality
+$0\leq r\leq s\leq n$ includes terms with an empty $A$-word and omits the
+pure residual word.  At $n=1$ the printed right-hand side is
+$WVR^i+WA^iV+R^iWV$, rather than $R^i+WA^iV$.  A nondegenerate reduction
+counterexample and the correction are recorded in the dedicated false-source
+note \cite{gap:mgsc18_residual_expansion_empty_word_error}.
+
+Expanding $B^i=R^i+WA^iV$ and using
+(\ref{eq:fbc25_action_audit_sandwiched_residual_vanishes}) shows that the
+correct full expansion is
 \begin{align}
     B^{i_1}\cdots B^{i_n}
-        &=\sum_{0\leq r\leq s\leq n}
+        &=R^{i_1}\cdots R^{i_n}
+          +\sum_{0\leq r<s\leq n}
           R^{i_1}\cdots R^{i_r}
           W A^{i_{r+1}}\cdots A^{i_s}V
-          R^{i_{s+1}}\cdots R^{i_n},
-    \label{eq:fbc25_action_audit_full_residual_expansion}\\
+          R^{i_{s+1}}\cdots R^{i_n}.
+    \label{eq:fbc25_action_audit_full_residual_expansion}
+\end{align}
+Here the strict inequality $r<s$ says that the central $A$-word is nonempty.
+Contracting this corrected identity and using residual nilpotency gives the
+other two equalities printed in Lemma~\texttt{B\_expand}:
+\begin{align}
     V B^{i_1}\cdots B^{i_n}
         &=\sum_{\max(0,n-\ell)\leq s\leq n}
           A^{i_1}\cdots A^{i_s}V
@@ -163,12 +180,21 @@ are
           A^{i_{r+1}}\cdots A^{i_n}.
     \label{eq:fbc25_action_audit_right_residual_expansion}
 \end{align}
-The terms with a residual prefix or suffix of length at least $\ell$ vanish.
-Thus, if $\mathbf p$ and $\mathbf q$ both have length $m\geq\ell$, every
-surviving term in the full expansion of
-$B^{\mathbf p\mathbf c\mathbf q}$ has its central $A$-word crossing all of
-$\mathbf c$.  The last two equations factor precisely those surviving terms,
-and give
+For $n<\ell$, the endpoints $s=0$ and $r=n$ in these contracted sums are the
+pure residual terms $VR^{\mathbf i}$ and $R^{\mathbf i}W$.  For
+$n\geq\ell$, the displayed endpoints with residual length exactly $\ell$
+are zero by the source definition of nilpotency length.  They are retained to
+match the printed bounds; the strictly surviving ranges are
+$n-\ell<s\leq n$ and $0\leq r<\ell$.
+
+Now let $\mathbf p$ and $\mathbf q$ both have length $m\geq\ell$.  The pure
+residual term in the corrected full expansion of
+$B^{\mathbf p\mathbf c\mathbf q}$ vanishes.  A central $A$-word which starts
+after $\mathbf p$ leaves a residual prefix of length at least $\ell$, and one
+which ends before $\mathbf q$ leaves a residual suffix of length at least
+$\ell$.  Hence every surviving central $A$-word crosses all of $\mathbf c$.
+The two contracted equations enumerate precisely these surviving terms and
+give
 \begin{align}
     B^{\mathbf p}W A^{\mathbf c}V B^{\mathbf q}
         &=B^{\mathbf p\mathbf c\mathbf q},
@@ -396,7 +422,11 @@ $2$-cochain rather than a canonically based element of $H^2$.
 
 Equation~(20) of Ref.~\cite{GarreRubio2023MPOSym} makes the
 representative-level choices explicit; it is at lines~752--759 of the
-official v3 source.  Choose a representative
+official v3 source.  The prose at line~754 announces a solution for
+$L^\alpha_{g_2,g_1}$, whereas the displayed equation at lines~755--758 is for
+$L^\alpha_{g_1,g_2}$ and first resolves the $g_2$ action, then the $g_1$
+action.  The prose has the swapped-order typo; the display fixes the convention
+recorded here.  Choose a representative
 $k_\alpha\in G$ for every coset and define $h_2,h_1\in H$ by
 $g_2k_\alpha=k_\beta h_2$ and
 $g_1k_\beta=k_\gamma h_1$.  The source gives
@@ -456,8 +486,8 @@ The existing library separates the following layers.
           \leanid{MPSTensor.primitivePaper\_iff\_hasEventuallyFullKrausRank}
           assumes left-canonical normalization.  Thus an exact named formal
           predicate for source primitivity already exists, while any passage
-          from it to word-span normality must retain the normalization used by
-          the available bridge.
+          from it to word-span normality must retain its left-canonical
+          normalization hypothesis.
 
           QICLean also defines \leanid{Kraus.IsInjective} and
           \leanid{Kraus.IsNBlkInjective} for one matrix family.  The latter
@@ -551,7 +581,10 @@ existence or classification of MPU action tensors.
 The cited action-tensor claim is supported by
 Ref.~\cite{Molnar2018SemiInjective}, provided that one retains the normal
 target, positive-length periodic equality, residual nilpotency, and finite
-blocking used by that theorem.  Its scalar uniqueness is the tailwise
+blocking used by that theorem.  Its printed full residual expansion requires
+the pure-residual and nonempty-middle correction in
+(\ref{eq:fbc25_action_audit_full_residual_expansion}).  Its scalar uniqueness
+is the tailwise
 statement
 (\ref{eq:fbc25_action_audit_reduction_left_uniqueness})--
 (\ref{eq:fbc25_action_audit_reduction_right_uniqueness}).  The

--- a/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
+++ b/docs/paper-gaps/fbc25_mpu_action_stabilizer_source_audit.tex
@@ -7,6 +7,7 @@
 \setlength{\emergencystretch}{2em}
 
 \input{command}
+\importpaperaux{fbc25-}{2502.20257/main-tnlean}
 
 \title{Source Boundary for MPU Action Tensors and Stabilizer Data}
 \author{}
@@ -18,13 +19,29 @@
 
 \section{Scope and conclusion}
 
-The source coordinates in this note are pinned to
-\path{Papers/2502.20257/main.tex}, the official
-arXiv:1706.07329v2 file \path{cornerproblem.tex}, the official
-arXiv:2203.12563v3 file \path{REsubmission.tex}, and the official
-arXiv:2405.00439v2 file \path{MPU-DW.tex}.  Thus every source-line range below
-is reproducible against a specified source version rather than a reformatted
-PDF.
+The target-paper coordinates in this note are pinned to
+\path{Papers/2502.20257/main.tex}.  The three external source archives are not
+duplicated in this repository.  They are pinned by exact version, stable
+retrieval link, internal filename, and archive digest as follows.
+\begin{itemize}
+    \item The
+          \href{https://arxiv.org/e-print/1706.07329v2}
+          {arXiv:1706.07329v2 source archive} contains
+          \path{cornerproblem.tex}; its SHA-256 digest is
+          \nolinkurl{045a2a94589c6d4f82946bc9a1b4322ebd5109882355356191f462b3d362b23e}.
+    \item The
+          \href{https://arxiv.org/e-print/2203.12563v3}
+          {arXiv:2203.12563v3 source archive} contains
+          \path{REsubmission.tex}; its SHA-256 digest is
+          \nolinkurl{53f0eb58d275d4bd801c9f38dc87e0928344745148860c97ba2e03fad4bd9b8c}.
+    \item The
+          \href{https://arxiv.org/e-print/2405.00439v2}
+          {arXiv:2405.00439v2 source archive} contains
+          \path{MPU-DW.tex}; its SHA-256 digest is
+          \nolinkurl{166ce15a174167772f53d53b7ed15438fdf799717e053b128f612a264d3f8bb4}.
+\end{itemize}
+Every external line range below is therefore reproducible against the named
+source file rather than a reformatted PDF.
 
 The discussion of an MPU action on MPSs in
 Ref.~\cite[lines~1782--1931]{FrancoRubio2025MPUGauging} uses two logically
@@ -67,10 +84,17 @@ $A_{g\mathbin{\cdot}x}$ is injective and therefore normal.
 
 Proposition~20 of Ref.~\cite[source lines~3124--3133, with proof at
 lines~3815--3939]{Molnar2018SemiInjective} applies to a normal target tensor
-$A$ and an arbitrary tensor $B$ which generates the same MPS family, allowing
-an exponential scalar $\lambda^N$.  In the exact symmetry relation
-(\ref{eq:fbc25_action_audit_positive_length_symmetry}), that scalar is one.
-The proposition supplies matrices $V_{g,x}$ and $W_{g,x}$ such that
+$A$ and an arbitrary tensor $B$.  Its printed hypothesis allows an exponential
+scalar $\lambda^N$, but its unscaled conclusion is false when $\lambda\ne1$.
+The source proof establishes the equality specialization; the corrected
+nonzero-$\lambda$ conclusion retains the factor $\lambda^n$ on words of
+length $n$.  This source defect and its scalar counterexamples are recorded in
+the
+\href{https://sirui-lu.com/TNLean/paper-gaps/mgsc18_reduction_proportionality_scalar.pdf}
+{dedicated paper-gap note}.  In the exact symmetry relation
+(\ref{eq:fbc25_action_audit_positive_length_symmetry}), $\lambda=1$, so the
+application here is unaffected.  The equality specialization supplies
+matrices $V_{g,x}$ and $W_{g,x}$ such that
 \begin{align}
     V_{g,x}W_{g,x}
         &=\mathbf 1,
@@ -107,14 +131,66 @@ $\ell_{g,x}$ is the least length after which every residual word vanishes:
         &&n\geq \ell_{g,x}.
     \label{eq:fbc25_action_audit_residual_nilpotency}
 \end{align}
-Expanding $B_{g,x}$ using
-(\ref{eq:fbc25_action_audit_residual_definition}) and applying
-(\ref{eq:fbc25_action_audit_residual_nilpotency}) gives the exterior and
-interior action identities used in the target paper.  This is why its
-Equation~\texttt{eq:action\_exterior} requires exterior tails of length
-$m\geq\ell$, whereas Equation~\texttt{eq:action\_interior} permits an
-interior length $n\geq0$
-\cite[lines~1787--1870]{FrancoRubio2025MPUGauging}.
+Nilpotency alone does not remove the mixed terms in an expansion of $B$.
+The additional input is the residual-word expansion lemma of Appendix~B and
+its preceding sandwiched-residual lemma
+\cite[source lines~3946--3970 and 3993--4005]{Molnar2018SemiInjective}.
+Suppress $g,x$ temporarily, write an empty product as the identity, and let
+$\mathbf i=(i_1,\ldots,i_n)$.  The sandwiched residual words obey
+\begin{align}
+    V R^{i_1}\cdots R^{i_r}W
+        &=0,
+        &&r>0.
+    \label{eq:fbc25_action_audit_sandwiched_residual_vanishes}
+\end{align}
+Consequently the full mixed-term expansion and its two boundary contractions
+are
+\begin{align}
+    B^{i_1}\cdots B^{i_n}
+        &=\sum_{0\leq r\leq s\leq n}
+          R^{i_1}\cdots R^{i_r}
+          W A^{i_{r+1}}\cdots A^{i_s}V
+          R^{i_{s+1}}\cdots R^{i_n},
+    \label{eq:fbc25_action_audit_full_residual_expansion}\\
+    V B^{i_1}\cdots B^{i_n}
+        &=\sum_{\max(0,n-\ell)\leq s\leq n}
+          A^{i_1}\cdots A^{i_s}V
+          R^{i_{s+1}}\cdots R^{i_n},
+    \label{eq:fbc25_action_audit_left_residual_expansion}\\
+    B^{i_1}\cdots B^{i_n}W
+        &=\sum_{0\leq r\leq\min(\ell,n)}
+          R^{i_1}\cdots R^{i_r}W
+          A^{i_{r+1}}\cdots A^{i_n}.
+    \label{eq:fbc25_action_audit_right_residual_expansion}
+\end{align}
+The terms with a residual prefix or suffix of length at least $\ell$ vanish.
+Thus, if $\mathbf p$ and $\mathbf q$ both have length $m\geq\ell$, every
+surviving term in the full expansion of
+$B^{\mathbf p\mathbf c\mathbf q}$ has its central $A$-word crossing all of
+$\mathbf c$.  The last two equations factor precisely those surviving terms,
+and give
+\begin{align}
+    B^{\mathbf p}W A^{\mathbf c}V B^{\mathbf q}
+        &=B^{\mathbf p\mathbf c\mathbf q},
+        &&|\mathbf p|=|\mathbf q|=m\geq\ell.
+    \label{eq:fbc25_action_audit_exterior_from_residual_expansion}
+\end{align}
+This is the algebraic content of the exterior action identity
+\papereqref{fbc25}{eq:action_exterior}; the interior identity
+\papereqref{fbc25}{eq:action_interior} is the reduction relation
+(\ref{eq:fbc25_action_audit_reduction_words}) and permits an interior length
+$n\geq0$ \cite[lines~1787--1870]{FrancoRubio2025MPUGauging}.
+
+Neither one-sided identity $VB^{\mathbf i}=A^{\mathbf i}V$ nor
+$B^{\mathbf i}W=WA^{\mathbf i}$ follows.  For example,
+$A^1=1$, $W=(1,0)^{\mathsf T}$, $V=(1,0)$, and
+$B^1=\left(\begin{smallmatrix}1&1\\0&0\end{smallmatrix}\right)$ satisfy the
+retraction and all-word reduction relations, while
+$R^1=\left(\begin{smallmatrix}0&1\\0&0\end{smallmatrix}\right)$ has
+$(R^1)^2=0$ but $V(B^1)^n=(1,1)\ne V$ for every $n>0$.  The full mixed-term
+expansions, rather than residual nilpotency by itself, are therefore
+load-bearing for
+(\ref{eq:fbc25_action_audit_exterior_from_residual_expansion}).
 
 Theorem~22 of Ref.~\cite[source lines~3154--3162, with proof at
 lines~3990--4035]{Molnar2018SemiInjective} gives the precise uniqueness
@@ -163,8 +239,8 @@ compare the traces of two identity matrices and therefore force equality of
 the bond dimensions, although the stacked tensor $B_{g,x}$ and the reduced
 tensor $A_{g\mathbin{\cdot}x}$ need not have equal bond dimensions.  Thus the
 correct formal input is
-\leanid{MPSTensor.SameMPV}\textsubscript{2}\leanid{Pos}, not
-\leanid{MPSTensor.SameMPV}\textsubscript{2}.
+\leanid{MPSTensor.SameMPV₂Pos}, not
+\leanid{MPSTensor.SameMPV₂}.
 
 \section{The arbitrary-boundary route is different}
 
@@ -181,7 +257,7 @@ is a boundary matrix $Y(C,X)$, again independent of $N$, such that
         &&\text{for every }C,X,N.
     \label{eq:fbc25_action_audit_arbitrary_boundary_invariance}
 \end{align}
-This is Equation~\texttt{eq:compatible} of that source
+This is Equation~(7) of that source
 \cite[source lines~429--460]{GarreRubio2023MPOSym}.  Its Appendix~A starts
 from the size-independent linear boundary map, takes a minimal-rank
 decomposition, and uses the one-site and two-site identities plus block
@@ -192,11 +268,13 @@ applies the same construction to
 tensors and their orthogonality
 \cite[source line~2455]{GarreRubio2023MPOSym}.
 
-By contrast, the simple-MPU hypothesis gives the periodic relation
+By contrast, the simple-MPU hypothesis together with the independent periodic
+symmetry assumption gives
 (\ref{eq:fbc25_action_audit_positive_length_symmetry}) for the distinguished
-closed boundaries.  It does not quantify over $C$ and $X$, and it does not
-supply the boundary map used in Appendix~A.  The mismatch is structural, not
-merely a missing lemma.  Ref.~\cite[source lines~1211--1216]{GarreRubio2023MPOSym}
+closed boundaries.  Simplicity alone does not assert this equality.  These
+hypotheses do not quantify over $C$ and $X$, and they do not supply the
+boundary map used in Appendix~A.  The mismatch is structural, not merely a
+missing lemma.  Ref.~\cite[source lines~1211--1216]{GarreRubio2023MPOSym}
 proves that an injective group MPO satisfying $U_gU_h=U_{gh}$ and
 $U_e=\mathbf 1$ must be on-site, with trivial $3$-cocycle, if its fusion
 tensors also satisfy the arbitrary-boundary closedness condition.  Hence an
@@ -228,7 +306,7 @@ The shifted block is $k\mathbin{\cdot}x$, not
 $g\mathbin{\cdot}x$ or $h\mathbin{\cdot}x$, because the comparison begins
 with the rightmost action.  Equation
 (\ref{eq:fbc25_action_audit_l_compatibility}) is
-Equation~\texttt{eq:omega\_and\_Ls} of the target paper
+Equation~\papereqref{fbc25}{eq:omega_and_Ls} of the target paper
 \cite[lines~1920--1924]{FrancoRubio2025MPUGauging} and agrees with the group
 specialization in Ref.~\cite[source lines~683--719]{GarreRubio2023MPOSym}.
 
@@ -253,9 +331,10 @@ Together with its fusion-tensor convention this gives
           L^x_{g,h}.
     \label{eq:fbc25_action_audit_target_l_gauge}
 \end{align}
-These are Equations~\texttt{eq:scalar\_act\_ten} and
-\texttt{eq:Lsymbgauge} of Ref.~\cite[lines~1870--1919]{FrancoRubio2025MPUGauging}.
-Equation~\texttt{gdgroup} of Ref.~\cite[source lines~720--726]{GarreRubio2023MPOSym}
+These are Equations~\papereqref{fbc25}{eq:scalar_act_ten} and
+\papereqref{fbc25}{eq:Lsymbgauge} of
+Ref.~\cite[lines~1870--1919]{FrancoRubio2025MPUGauging}.
+Equation~(19) of Ref.~\cite[source lines~720--726]{GarreRubio2023MPOSym}
 prints the reciprocal factor.  The two formulas use inverse names for both
 scalar gauges: replacing the 2023 parameters by
 $\gamma^{-1}$ and $\beta^{-1}$ gives
@@ -366,11 +445,25 @@ data realizing every such solution in the simple-MPU setting.
 The existing library separates the following layers.
 
 \begin{itemize}
-    \item QICLean defines \leanid{Kraus.IsInjective},
-          \leanid{Kraus.IsNBlkInjective}, and \leanid{Kraus.IsNormal} for one
-          matrix family.  The second predicate says that the length-$N$ words
-          of one tensor span its full matrix algebra.  It is not the paper's
-          direct-sum block-injective condition
+    \item TNLean defines
+          \leanid{MPSTensor.IsPrimitivePaper}, the unnormalized uniform
+          vector-spreading formulation of paper primitivity, and
+          \leanid{MPSTensor.HasEventuallyFullKrausRank}.  The latter is
+          equivalent to QICLean's \leanid{Kraus.IsNormal} by
+          \leanid{MPSTensor.hasEventuallyFullKrausRank\_iff\_isNormal}.
+          The reverse bridge from \leanid{MPSTensor.IsPrimitivePaper} to the
+          word-span predicate in
+          \leanid{MPSTensor.primitivePaper\_iff\_hasEventuallyFullKrausRank}
+          assumes left-canonical normalization.  Thus an exact named formal
+          predicate for source primitivity already exists, while any passage
+          from it to word-span normality must retain the normalization used by
+          the available bridge.
+
+          QICLean also defines \leanid{Kraus.IsInjective} and
+          \leanid{Kraus.IsNBlkInjective} for one matrix family.  The latter
+          says that the length-$N$ words of one tensor span its full matrix
+          algebra.  None of these predicates is the paper's direct-sum
+          block-injective condition
           \begin{align}
               A^i&=\bigoplus_{x\in\mathsf X}A_x^i,
               &\operatorname{span}\{A_x^i\}_i
@@ -394,7 +487,7 @@ The existing library separates the following layers.
           MPU on an MPS.  Those notions must precede the reduction theorem;
           they should not be inferred from the scalar $L$-symbol API.
 
-    \item \leanid{MPSTensor.SameMPV}\textsubscript{2}\leanid{Pos}
+    \item \leanid{MPSTensor.SameMPV₂Pos}
           expresses the global
           equality in
           (\ref{eq:fbc25_action_audit_positive_length_symmetry}) across

--- a/docs/paper-gaps/mgsc18_residual_expansion_empty_word_error.tex
+++ b/docs/paper-gaps/mgsc18_residual_expansion_empty_word_error.tex
@@ -1,0 +1,176 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Empty-Word Summation Error in the MPS Residual Expansion}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{open}
+
+\section{The printed expansion}
+
+Let $A=(A^i)_i$ be a normal matrix product state tensor, let
+$B=(B^i)_i$ be another tensor with the same physical alphabet, and let
+$V,W$ be a reduction from $B$ to $A$.  Thus
+\begin{align}
+    VW
+        &=\mathbf 1,
+    \label{eq:mgsc18_residual_expansion_retraction}\\
+    VB^{i_1}\cdots B^{i_n}W
+        &=A^{i_1}\cdots A^{i_n}
+        \qquad (n\geq1).
+    \label{eq:mgsc18_residual_expansion_reduction_words}
+\end{align}
+Define the residual matrices and their nilpotency length $\ell$ by
+\begin{align}
+    R^i
+        &=B^i-WA^iV,
+    \label{eq:mgsc18_residual_expansion_residual_definition}\\
+    R^{i_1}\cdots R^{i_n}
+        &=0
+        \qquad (n\geq\ell).
+    \label{eq:mgsc18_residual_expansion_nilpotency}
+\end{align}
+The lemma immediately preceding Lemma~\texttt{B\_expand} proves
+\begin{align}
+    VR^{i_1}\cdots R^{i_m}W
+        &=0
+        \qquad (m>0).
+    \label{eq:mgsc18_residual_expansion_sandwiched_word}
+\end{align}
+
+The first equality of Lemma~\texttt{B\_expand} in
+Ref.~\cite{Molnar2018SemiInjective} then prints
+\begin{align}
+    B^{i_1}\cdots B^{i_n}
+        &=\sum_{0\leq r\leq s\leq n}
+          R^{i_1}\cdots R^{i_r}
+          W A^{i_{r+1}}\cdots A^{i_s}V
+          R^{i_{s+1}}\cdots R^{i_n}.
+    \label{eq:mgsc18_residual_expansion_printed_sum}
+\end{align}
+The source coordinates are
+\path{cornerproblem.tex:3993--4005} in the official
+\href{https://arxiv.org/e-print/1706.07329v2}{arXiv:1706.07329v2 source
+archive}.  The archive has SHA-256 digest
+\nolinkurl{045a2a94589c6d4f82946bc9a1b4322ebd5109882355356191f462b3d362b23e}.
+
+With the ordinary convention that an empty matrix product is the identity,
+the summands with $r=s$ in
+(\ref{eq:mgsc18_residual_expansion_printed_sum}) contain $WV$.  The sum also
+has no pure residual term.  In particular, at $n=1$ its right-hand side is
+$WVR^i+WA^iV+R^iWV$, rather than $R^i+WA^iV$.
+
+\section{A nondegenerate counterexample}
+
+Take one physical letter, a one-dimensional normal tensor $A$, and a
+three-dimensional tensor $B$.  Set
+\begin{align}
+    A^1
+        &=1,
+        \qquad W=(1,0,0)^{\mathsf T},
+        \qquad V=(1,0,0),
+    \label{eq:mgsc18_residual_expansion_example_target_and_reduction}\\
+    R^1
+        &=\begin{pmatrix}
+             0&0&0\\
+             0&0&1\\
+             0&0&0
+          \end{pmatrix},
+    &B^1
+        &=WV+R^1.
+    \label{eq:mgsc18_residual_expansion_example_tensors}
+\end{align}
+These data satisfy
+\begin{align}
+    VW
+        &=1,
+    \label{eq:mgsc18_residual_expansion_example_retraction}\\
+    V(B^1)^nW
+        &=1=(A^1)^n
+        \qquad (n\geq0),
+    \label{eq:mgsc18_residual_expansion_example_word_reduction}\\
+    (R^1)^2
+        &=0,
+    &V(R^1)^mW
+        &=0
+        \qquad (m>0).
+    \label{eq:mgsc18_residual_expansion_example_residual_properties}
+\end{align}
+Thus all hypotheses used for
+(\ref{eq:mgsc18_residual_expansion_printed_sum}) hold, with a nonzero
+nilpotent residual.  Nevertheless, its $n=1$ right-hand side is
+\begin{align}
+    WVR^1+WA^1V+R^1WV
+        &=WV,
+    \label{eq:mgsc18_residual_expansion_example_printed_value}\\
+    B^1
+        &=WV+R^1\ne WV.
+    \label{eq:mgsc18_residual_expansion_example_contradiction}
+\end{align}
+Hence the printed equality is false on data satisfying the intended reduction
+and nilpotency conditions; the discrepancy is not a degenerate reading of a
+definition.
+
+\section{The corrected expansion}
+
+Expand each factor as $B^i=R^i+WA^iV$.  If two selected $WA^iV$ factors are
+separated by a nonempty residual word, then
+(\ref{eq:mgsc18_residual_expansion_sandwiched_word}) makes that term zero.
+The surviving terms are therefore the pure residual word and the terms with
+one nonempty consecutive $A$-word.  The corrected all-length identity is
+\begin{align}
+    B^{i_1}\cdots B^{i_n}
+        &=R^{i_1}\cdots R^{i_n}
+          +\sum_{0\leq r<s\leq n}
+          R^{i_1}\cdots R^{i_r}
+          W A^{i_{r+1}}\cdots A^{i_s}V
+          R^{i_{s+1}}\cdots R^{i_n}.
+    \label{eq:mgsc18_residual_expansion_corrected_sum}
+\end{align}
+The strict inequality $r<s$ is essential: it says that the central $A$-word
+is nonempty.
+
+The two contracted equalities printed after
+(\ref{eq:mgsc18_residual_expansion_printed_sum}) remain valid.  In the present
+notation they are
+\begin{align}
+    VB^{i_1}\cdots B^{i_n}
+        &=\sum_{\max(0,n-\ell)\leq s\leq n}
+          A^{i_1}\cdots A^{i_s}V
+          R^{i_{s+1}}\cdots R^{i_n},
+    \label{eq:mgsc18_residual_expansion_left_contraction}\\
+    B^{i_1}\cdots B^{i_n}W
+        &=\sum_{0\leq r\leq\min(\ell,n)}
+          R^{i_1}\cdots R^{i_r}W
+          A^{i_{r+1}}\cdots A^{i_n}.
+    \label{eq:mgsc18_residual_expansion_right_contraction}
+\end{align}
+For $n<\ell$, the terms with $s=0$ and $r=n$ are the contracted pure
+residual word.  For $n\geq\ell$, the displayed endpoints with residual length
+exactly $\ell$ vanish by
+(\ref{eq:mgsc18_residual_expansion_nilpotency}); retaining them is harmless.
+
+\section{Verdict}
+
+The first equality in Lemma~\texttt{B\_expand} is false as printed because its
+weak summation range mishandles the empty central word.  The source proof route
+gives the pure-residual and strict-range formula
+(\ref{eq:mgsc18_residual_expansion_corrected_sum}).  The two contracted
+equalities remain correct with their zero endpoints understood as above.
+
+The eventual formal residual-expansion theorem is tracked by
+\href{https://github.com/LionSR/TNLean/issues/7322}{TNLean issue 7322}; no
+parallel tensor or cohomology interface is introduced here.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -22,6 +22,28 @@
   note         = {Source coordinates in this repository use arXiv:1706.07329v2},
 }
 
+@article{GarreRubio2023MPOSym,
+  author       = {Garre-Rubio, Jos{\'e} and Lootens, Laurens and Moln{\'a}r, Andr{\'a}s},
+  title        = {Classifying Phases Protected by Matrix Product Operator Symmetries Using Matrix Product States},
+  journal      = {Quantum},
+  volume       = {7},
+  pages        = {927},
+  year         = {2023},
+  doi          = {10.22331/q-2023-02-21-927},
+  eprint       = {2203.12563},
+  eprinttype   = {arxiv},
+  note         = {Source coordinates in this repository use arXiv:2203.12563v3},
+}
+
+@unpublished{GarreRubioSchuch2024DomainWall,
+  author       = {Garre-Rubio, Jos{\'e} and Schuch, Norbert},
+  title        = {Fractional Domain Wall Statistics in Spin Chains with Anomalous Symmetries},
+  year         = {2024},
+  eprint       = {2405.00439},
+  eprinttype   = {arxiv},
+  note         = {arXiv:2405.00439v2},
+}
+
 @unpublished{Cirac2016MPDO_arXiv,
   author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and Verstraete, Frank},
   title        = {Matrix Product Density Operators: Renormalization Fixed Points and Boundary Theories},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -22,6 +22,16 @@
   note         = {Source coordinates in this repository use arXiv:1706.07329v2},
 }
 
+@techreport{gap:mgsc18_residual_expansion_empty_word_error,
+  author      = {The {TNLean} contributors},
+  title       = {The Empty-Word Summation Error in the {MPS} Residual Expansion},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {mgsc18\_residual\_expansion\_empty\_word\_error},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/mgsc18_residual_expansion_empty_word_error.pdf}},
+}
+
 @article{GarreRubio2023MPOSym,
   author       = {Garre-Rubio, Jos{\'e} and Lootens, Laurens and Moln{\'a}r, Andr{\'a}s},
   title        = {Classifying Phases Protected by Matrix Product Operator Symmetries Using Matrix Product States},

--- a/scripts/generate_paper_aux.sh
+++ b/scripts/generate_paper_aux.sh
@@ -68,15 +68,18 @@ for tex in "${tex_files[@]}"; do
   if command -v latexmk >/dev/null 2>&1; then
     (
       cd "$target_dir"
-      latexmk -pdf -interaction=nonstopmode -halt-on-error \
+      TEXINPUTS=".:${TEXINPUTS:-}" \
+        latexmk -pdf -interaction=nonstopmode -halt-on-error \
         -outdir="$output_dir" "$tex"
     )
   elif command -v pdflatex >/dev/null 2>&1; then
     (
       cd "$target_dir"
-      pdflatex -interaction=nonstopmode -halt-on-error \
+      TEXINPUTS=".:${TEXINPUTS:-}" \
+        pdflatex -interaction=nonstopmode -halt-on-error \
         -output-directory="$output_dir" "$tex"
-      pdflatex -interaction=nonstopmode -halt-on-error \
+      TEXINPUTS=".:${TEXINPUTS:-}" \
+        pdflatex -interaction=nonstopmode -halt-on-error \
         -output-directory="$output_dir" "$tex"
     )
   else


### PR DESCRIPTION
### Motivation

`Papers/2502.20257/main.tex:1782--1931` invokes external results for action-tensor existence, uniqueness, and stabilizer classification. The exact hypotheses, proof routes, and conventions were not recorded durably in the repository. Issue #7328 requires this source boundary before the implementation children of #7295 proceed.

### Description

- Adds an open action-tensor source audit pinned to the official source archives:
  - arXiv:1706.07329v2, `cornerproblem.tex`, SHA-256 `045a2a94589c6d4f82946bc9a1b4322ebd5109882355356191f462b3d362b23e`;
  - arXiv:2203.12563v3, `REsubmission.tex`, SHA-256 `53f0eb58d275d4bd801c9f38dc87e0928344745148860c97ba2e03fad4bd9b8c`;
  - arXiv:2405.00439v2, `MPU-DW.tex`, SHA-256 `166ce15a174167772f53d53b7ed15438fdf799717e053b128f612a264d3f8bb4`.
- Separates the source-faithful positive-length MPS reduction route from the stronger arbitrary-boundary MPO-algebra route. The simple-MPU hypothesis is used together with the independent periodic-symmetry assumption; simplicity alone is not treated as the state equality.
- Records the exact residual-word, boundary-contraction, blocking, and tailwise scalar-uniqueness hypotheses. The exterior action identity is derived from the corrected mixed-term expansion rather than from residual nilpotency alone.
- Adds `mgsc18_residual_expansion_empty_word_error.tex`, an open `false-source` note for the first equality of MGSC18 Lemma `B_expand`. The printed weak range omits the pure residual word and inserts empty central words; the note gives a nondegenerate three-dimensional counterexample and the corrected `R^word + Σ_{0 ≤ r < s ≤ n}` formula. Issue #7322 now names this correction and remains the sole owner of its eventual Lean theorem.
- Uses the λ = 1 specialization of MGSC18 Proposition 20 and cites the separate proportionality-scalar correction. The formal map includes `MPSTensor.IsPrimitivePaper`, its normalized bridge to eventual full Kraus rank, and `Kraus.IsNormal`.
- Fixes the left-action and scalar-gauge conventions and records the representative, gauge-class, torsor, and phase meanings of `(H, ψ)`. It also records that the prose before arXiv:2203.12563v3 Equation (20) swaps `L^α_{g₂,g₁}`, while the displayed equation and the action order use `L^α_{g₁,g₂}`.
- Imports the generated arXiv:2502.20257 labels and replaces raw target-source labels by rendered equation references. PR CI now generates both CPSV16 and FBC25 paper labels, and the helper puts the paper directory first in `TEXINPUTS`.
- Maps the source objects to current TNLean, QICLean, and Mathlib declarations without defining tensor data or a new cohomology interface.

Closes #7328.
Native parent: #7295.

### Testing

- `TEXINPUTS='/Users/siruilu/Local/TEX:' ./scripts/generate_paper_aux.sh 1606.00608`
- `TEXINPUTS='/Users/siruilu/Local/TEX:' ./scripts/generate_paper_aux.sh 2502.20257`
  - generated 178 unique CPSV16 labels and 139 unique FBC25 labels;
  - the FBC25 recorder uses `./Commands.tex`, not the ambient file;
  - target references resolve to Equations (59), (60), (61), (63), and (64).
- `texra-blueprint paper-gaps check`
- `texra-blueprint paper-gaps build`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
  - checked 2,181 citations with 1,763 unique declaration heads.
- `python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `bash -n scripts/generate_paper_aux.sh`
- `git diff --check origin/main...HEAD`
- Focused `latexmk` builds for both source notes: 10 and 3 pages, with no unresolved references, `??`, or overfull boxes. The corrected expansion, Equation (20) convention, formal-boundary section, verdict, and the complete false-source note were visually inspected.

### Agent assistance

OpenAI Codex (GPT-5) audited the official arXiv source bundles and the current TNLean, QICLean, and Mathlib interfaces; derived and checked the corrected residual expansion; and drafted and validated the source-audit and false-source documentation.
