### PR TITLE
feat(MPDO): descend neighboring trace data through embeddings

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -202,6 +202,7 @@ import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
 import TNLean.MPS.MPDO.PhysicalIsometricEmbedding
+import TNLean.MPS.MPDO.PhysicalIsometricEmbeddingNeighboringTrace
 import TNLean.MPS.MPDO.PhysicalSectorActiveBond
 import TNLean.MPS.MPDO.PhysicalSectorActiveCoordinates
 import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport

--- a/TNLean/MPS/MPDO/PhysicalIsometricEmbeddingNeighboringTrace.lean
+++ b/TNLean/MPS/MPDO/PhysicalIsometricEmbeddingNeighboringTrace.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalIsometricEmbedding
+import TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring
+import TNLean.MPS.MPDO.PhysicalSupportRestrictionComparison
+
+/-!
+# Neighboring-trace factorization under physical isometric embeddings
+
+A normalized rank-one neighboring-trace factorization of an isometrically
+embedded injective MPO tensor descends to the original tensor when the latter
+has full one-site physical support. The proof passes through the active
+physical support and compares two isometric coordinate descriptions of that
+support.
+
+This is a project-derived transport result, not a statement of CPSV16. Its
+role is to test the representativewise conclusion of Theorem 4.9(iv), lines
+864--889, after the physical-support restriction used in Appendix C.2, lines
+1680--1691 and 1733--1770.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d e D : ℕ} {K : MPOTensor d D}
+
+/-- A normalized rank-one neighboring-trace factorization of an isometrically
+embedded injective tensor descends to the original tensor when the latter has
+full one-site physical support.
+
+The proof first restricts an arbitrary factorization of the embedded tensor to
+its active physical support. It then compares those support coordinates with
+the coordinates supplied by the embedding isometry; the latter restriction is
+the original tensor. Thus the neighboring operators, their positivity, the
+factorization \(\operatorname{tr}(\eta_{k,h})=a_kb_h\), and the normalization
+\(\sum_k a_kb_k=1\) are all retained by the existing active-support and
+unitary-coordinate transports.
+
+This is a project-derived transport theorem, not a statement of CPSV16. Its
+role is to test the representativewise conclusion of Theorem 4.9(iv), lines
+864--889, after the physical-support restriction used in Appendix C.2, lines
+1680--1691 and 1733--1770. -/
+theorem exists_neighboringTraceFactorization_of_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (hK : Kraus.IsInjective K.toMPSTensor)
+    (hFull : physicalSupportProj K = 1)
+    (hEmbedded : ∃ F : PhysicalSectorFactorization (changePhysicalBasis V K),
+      Nonempty F.NeighboringTraceFactorization) :
+    ∃ F : PhysicalSectorFactorization K,
+      Nonempty F.NeighboringTraceFactorization := by
+  let M := changePhysicalBasis V K
+  have hM : Kraus.IsInjective M.toMPSTensor := by
+    exact (isInjective_toMPSTensor_changePhysicalBasis_iff V hV K).2 hK
+  have hRestrict : changePhysicalBasis Vᴴ M = K := by
+    change changePhysicalBasis Vᴴ (changePhysicalBasis V K) = K
+    rw [changePhysicalBasis_changePhysicalBasis, hV]
+    ext i j β α
+    simp [changePhysicalBasis, physicalSlice]
+  let explicitRestriction : PhysicalSupportRestrictionData
+      (physicalSupportProj M) M :=
+    { supportDim := d
+      inclusion := V
+      inclusion_isometry := hV
+      inclusion_range := by
+        simpa [M, hFull] using
+          (physicalSupportProj_changePhysicalBasis V hV K).symm
+      restricted_injective := by
+        rw [hRestrict]
+        exact hK
+      reembed := by
+        rw [hRestrict] }
+  obtain ⟨F, ⟨H⟩⟩ := hEmbedded
+  let A := F.activeFactorSupportData
+  let activeRestriction :=
+    F.activePhysicalSupportRestrictionData A hM H.neighboringOperator_pos
+  have hActive :
+      ∃ G : PhysicalSectorFactorization
+          (changePhysicalBasis activeRestriction.inclusionᴴ M),
+        Nonempty G.NeighboringTraceFactorization := by
+    refine ⟨F.activeRestrictedPhysicalSectorFactorization A, ⟨?_⟩⟩
+    exact
+      F.activeRestrictedPhysicalSectorFactorization_neighboringTraceFactorization
+        A hM H
+  have hExplicit :=
+    (activeRestriction.exists_neighboringTraceFactorization_restriction_iff
+      explicitRestriction).mp hActive
+  have hInclusion : explicitRestriction.inclusion = V := rfl
+  rw [hInclusion, hRestrict] at hExplicit
+  exact hExplicit
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -750,6 +750,71 @@
     \end{align}
 \end{proof}
 
+% This descent statement is project-derived. It combines the canonical active
+% restriction with the coordinate comparison for a fixed physical support; it
+% is not asserted in CPSV16.
+\begin{theorem}[Neighboring-trace factorization descends through a full-support
+        physical embedding]
+    \label{thm:mpdo_neighboring_trace_factorization_isometric_embedding_descent}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+        exists_neighboringTraceFactorization_of_changePhysicalBasis_of_isometry}
+    \leanok
+    \uses{def:injective, def:mpdo_physical_sector_factorization,
+        def:mpdo_neighboring_trace_factorization,
+        thm:mpdo_isometric_physical_embedding}
+    Let $\mathcal K$ be injective, and suppose that the joint column support
+    of its physical slices is the whole one-site space,
+    $\Pi_{\mathcal K}=\Id_d$. Let $V:\C^d\to\C^e$ be an isometry and put
+    \begin{align}
+        \mathcal K_V^{ij}
+         & =\sum_{p,q}V_{i,p}\overline{V_{j,q}}\mathcal K^{pq}.
+        \notag
+    \end{align}
+    If $\mathcal K_V$ admits a physical-sector factorization whose neighboring
+    operators satisfy
+    \begin{align}
+        \eta_{k,h}      & \geq 0,
+        \notag                     \\
+        \tr(\eta_{k,h}) & =a_kb_h,
+        \notag                     \\
+        \sum_k a_kb_k   & =1,
+        \notag
+    \end{align}
+    then $\mathcal K$ admits such a factorization as well.
+
+    This implication is project-derived and is not stated in
+    \cite{Cirac2016MPDO_arXiv}. It transports the neighboring data of
+    Theorem~4.9(iv), lines~864--889, through the physical-support restriction
+    used in Appendix~C.2, lines~1680--1691 and 1733--1770.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_isometric_physical_embedding,
+        thm:mpdo_active_physical_sector_neighboring_positivity,
+        thm:mpdo_neighboring_trace_factorization_presentation_invariant}
+    The isometric embedding theorem gives
+    \begin{align}
+        \Pi_{\mathcal K_V}
+         & =V\Pi_{\mathcal K}V^*=VV^*.
+        \notag
+    \end{align}
+    It also preserves injectivity. Restrict the assumed factorization to its
+    canonical active physical support. The preceding theorem preserves
+    positivity, the identities $\tr(\eta_{k,h})=a_kb_h$, and the normalized
+    sum $\sum_k a_kb_k=1$ on that restriction. Its isometric inclusion $W$
+    satisfies $WW^*=\Pi_{\mathcal K_V}=VV^*$.
+
+    The support-coordinate comparison therefore carries the factorization
+    from $W^*\mathcal K_VW$ to $V^*\mathcal K_VV$. Finally,
+    \begin{align}
+        V^*\mathcal K_VV
+         & =(V^*V)\mathcal K(V^*V)=\mathcal K,
+        \notag
+    \end{align}
+    which proves the assertion.
+\end{proof}
+
 % This theorem supplies the orthogonal-support step used in the completed
 % proof of CPSV16 Proposition `prop3to4`. The final proof does not derive or
 % assume common-copy-weight independence.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -760,8 +760,7 @@
         exists_neighboringTraceFactorization_of_changePhysicalBasis_of_isometry}
     \leanok
     \uses{def:injective, def:mpdo_physical_sector_factorization,
-        def:mpdo_neighboring_trace_factorization,
-        thm:mpdo_isometric_physical_embedding}
+        def:mpdo_neighboring_trace_factorization}
     Let $\mathcal K$ be injective, and suppose that the joint column support
     of its physical slices is the whole one-site space,
     $\Pi_{\mathcal K}=\Id_d$. Let $V:\C^d\to\C^e$ be an isometry and put
@@ -770,8 +769,9 @@
          & =\sum_{p,q}V_{i,p}\overline{V_{j,q}}\mathcal K^{pq}.
         \notag
     \end{align}
-    If $\mathcal K_V$ admits a physical-sector factorization whose neighboring
-    operators satisfy
+    If $\mathcal K_V$ admits a physical-sector factorization for which there
+    exist families $(a_k)_k$ and $(b_h)_h$ of real numbers such that the
+    neighboring operators satisfy
     \begin{align}
         \eta_{k,h}      & \geq 0,
         \notag                     \\
@@ -791,6 +791,7 @@
 \begin{proof}
     \leanok
     \uses{thm:mpdo_isometric_physical_embedding,
+        thm:mpdo_active_physical_sector_restriction,
         thm:mpdo_active_physical_sector_neighboring_positivity,
         thm:mpdo_neighboring_trace_factorization_presentation_invariant}
     The isometric embedding theorem gives


### PR DESCRIPTION
### Motivation

- Issue #6775 requires the obstruction to normalized neighboring-trace factorization to survive an isometric inclusion into the ambient physical space.
- The source data are those in `Papers/1606.00608/MPDO-22-12-17-2.tex`, Theorem 4.9(iv), lines 864–889: each BNT element has positive neighboring operators with `tr(η_{k,h}) = a_k b_h` and `∑_k a_k b_k = 1`. Appendix C.2 restricts representatives to physical-support ranges at lines 1680–1691 and 1733–1770.
- The descent implication is a project-derived coordinate theorem, not a result claimed by CPSV16. It supplies one separately reviewable bridge for the source-faithful counterexample route.

### Description

- Add a focused theorem showing that a normalized neighboring-trace factorization of an isometrically embedded injective MPO tensor descends to the original tensor when its one-site physical support is full.
- Restrict the assumed factorization to its canonical active physical support, preserve positivity and the normalized rank-one trace identities there, compare that support realization with the embedding isometry, and identify the latter restriction with the original tensor.
- Add the focused module to the generated MPDO aggregate import.
- Add a project-derived Blueprint theorem and proof recording the exact transport chain and its role relative to Theorem 4.9(iv) and Appendix C.2.

### Testing

- `lake env lean TNLean/MPS/MPDO/PhysicalIsometricEmbeddingNeighboringTrace.lean`
- `lake build TNLean.MPS.MPDO.PhysicalIsometricEmbeddingNeighboringTrace`
- `lake build TNLean.MPS.MPDO TNLean.MPS TNLean` (import-only aggregate refresh for declaration checking)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base HEAD^`
- `python3 scripts/tactic_pattern_scan.py --top 10 --show-locations 4`
- Forbidden-token scan found no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new module.
- Axiom inspection reports only `propext`, `Classical.choice`, and `Quot.sound`.

---
Advances #7338 and #6775.

