### PR TITLE
feat(Algebra): bridge scalar H² to Mathlib

### DIFF
--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -3,13 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.RepresentationTheory.Homological.GroupCohomology.LowDegree
 import TNLean.Algebra.ProjectiveRepresentation
 
 /-!
 # Coboundary equivalence and cohomology for scalar 2-cocycles
 
-This file defines coboundary equivalence of multiplicative `U(1)`-valued 2-cocycles
-and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
+This file defines coboundary equivalence of multiplicative `ℂˣ`-valued 2-cocycles
+and establishes the `H²(G, ℂˣ)` cohomology class as a well-defined quotient.
 
 ## Main definitions
 
@@ -18,7 +19,9 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
 * `ScalarCocycle.CohomologousTo` : two cocycles are cohomologous if their ratio
   is a coboundary
 * `ScalarCocycle.IsCocycle` : the multiplicative 2-cocycle condition
-* `H2` : the second cohomology quotient `H²(G, U(1))` over genuine cocycles
+* `H2` : the second cohomology quotient `H²(G, ℂˣ)` over genuine cocycles
+* `scalarH2Representation` : the trivial representation used for Mathlib's
+  low-degree group cohomology
 * `ProjectiveRepresentation.cocycle` : the cocycle attached to a projective
   representation
 * `ProjectivelyEquivalent` : two projective representations are projectively
@@ -30,6 +33,9 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
   relation
 * `ScalarCocycle.isCoboundary_iff_cohomologousTo_one` : a cocycle is a coboundary
   iff it is cohomologous to the trivial cocycle
+* `ScalarCocycle.isCocycle_iff_isMulCocycle₂` : agreement with Mathlib's
+  multiplicative 2-cocycle condition
+* `h2EquivGroupCohomology` : equivalence with Mathlib's degree-two group cohomology
 * `projRep_equiv_iff_cohomologous` : projective equivalence iff cocycles are
   cohomologous
 
@@ -39,6 +45,8 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
   arXiv:0802.0447
 * Chen, Gu, Wen, *Classification of gapped symmetric phases in one-dimensional
   spin systems*, Phys. Rev. B 83, 035107 (2011)
+* Franco-Rubio, Bochniak, Cirac, *Symmetry defects and gauging for quantum states
+  with matrix product unitary symmetries*, arXiv:2502.20257, lines 1927--1931
 -/
 
 namespace TNLean.Algebra
@@ -134,7 +142,7 @@ instance ScalarCocycle.IsCocycle.instSetoid :
     fun h => ScalarCocycle.CohomologousTo.symm h,
     fun h₁₂ h₂₃ => ScalarCocycle.CohomologousTo.trans h₁₂ h₂₃⟩
 
-/-- The second cohomology quotient `H²(G, U(1))` modelled by scalar 2-cocycles. -/
+/-- The second cohomology quotient `H²(G, ℂˣ)` modelled by scalar 2-cocycles. -/
 def H2 (G : Type*) [Group G] :=
   Quotient (ScalarCocycle.IsCocycle.instSetoid (G := G))
 
@@ -164,13 +172,216 @@ lemma ScalarCocycle.isCoboundary_iff_cohomologousTo_one (ω : ScalarCocycle G) :
   · rintro ⟨φ, hφ⟩
     exact ⟨φ, fun g h => by rw [hφ g h]; simp [mul_one]⟩
 
+/-! ### Comparison with Mathlib's low-degree group cohomology
+
+The coefficient group in `Papers/2502.20257/main.tex:1927--1931` is
+`Units ℂ`, or `ℂˣ`, with the trivial group action.  The declarations below
+identify the concrete, curried quotient above with Mathlib's degree-two group
+cohomology without introducing another quotient.
+
+Mathlib's low-degree comparison theorems currently place the coefficient ring and
+the acting group in the same universe.  Consequently, the comparison is stated
+for `G : Type`, while the concrete definition `H2` remains universe-polymorphic.
+-/
+
+set_option warn.classDefReducibility false in
+/-- The trivial action of `G` on the scalar coefficient group `ℂˣ`.
+
+This action is supplied explicitly to each low-degree group-cohomology
+construction rather than selected implicitly. -/
+def ScalarCocycle.trivialMulDistribMulAction : MulDistribMulAction G (Units ℂ) where
+  smul _ z := z
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+  smul_one _ := rfl
+  smul_mul _ _ _ := rfl
+
+/-- The representation of `G` on `ℂˣ` with trivial action, used to form
+Mathlib's degree-two scalar group cohomology. -/
+abbrev scalarH2Representation (G : Type*) [Group G] : Rep ℤ G :=
+  @Rep.ofMulDistribMulAction G (Units ℂ) _ _
+    (ScalarCocycle.trivialMulDistribMulAction (G := G))
+
+/-- TNLean's curried scalar 2-cocycle equation is Mathlib's uncurried
+multiplicative 2-cocycle equation for the trivial action on `ℂˣ`.
+
+This fixes the equation orientation in the comparison used for
+arXiv:2502.20257, lines 1927--1931. -/
+theorem ScalarCocycle.isCocycle_iff_isMulCocycle₂ (ω : ScalarCocycle G) :
+    letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+    ω.IsCocycle ↔ groupCohomology.IsMulCocycle₂ (Function.uncurry ω) := by
+  constructor
+  · intro h g k j
+    change ω (g * k) j * ω g k = ω k j * ω g (k * j)
+    simpa only [mul_comm] using h g k j
+  · intro h g k j
+    have h' := h g k j
+    change ω (g * k) j * ω g k = ω k j * ω g (k * j) at h'
+    simpa only [mul_comm] using h'
+
+/-- TNLean's scalar coboundary equation is Mathlib's multiplicative
+2-coboundary equation for the trivial action on `ℂˣ`. -/
+theorem ScalarCocycle.isCoboundary_iff_isMulCoboundary₂ (ω : ScalarCocycle G) :
+    letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+    ω.IsCoboundary ↔ groupCohomology.IsMulCoboundary₂ (Function.uncurry ω) := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_⟩
+    intro g h
+    change φ h / φ (g * h) * φ g = ω g h
+    rw [hφ g h]
+    simp only [div_eq_mul_inv, mul_assoc, mul_comm]
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_⟩
+    intro g h
+    have h' := hφ g h
+    change φ h / φ (g * h) * φ g = ω g h at h'
+    rw [← h']
+    simp only [div_eq_mul_inv, mul_assoc, mul_comm]
+
+/-- Two scalar cocycles are cohomologous precisely when their pointwise ratio
+is a coboundary. -/
+theorem ScalarCocycle.cohomologousTo_iff_isCoboundary_div
+    (ω₁ ω₂ : ScalarCocycle G) :
+    ω₁.CohomologousTo ω₂ ↔ (ω₁ / ω₂).IsCoboundary := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_⟩
+    intro g h
+    change ω₁ g h / ω₂ g h = φ g * φ h * (φ (g * h))⁻¹
+    rw [hφ g h]
+    simp [div_eq_mul_inv, mul_assoc]
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_⟩
+    intro g h
+    have h' := hφ g h
+    change ω₁ g h / ω₂ g h = φ g * φ h * (φ (g * h))⁻¹ at h'
+    calc
+      ω₁ g h = (ω₁ g h / ω₂ g h) * ω₂ g h := by simp
+      _ = φ g * φ h * (φ (g * h))⁻¹ * ω₂ g h := by rw [h']
+
+/-- A curried TNLean cocycle representative, regarded as a Mathlib 2-cocycle
+representative for the trivial action on `ℂˣ`. -/
+def ScalarCocycle.toMathlibCocycle {G : Type} [Group G]
+    (ω : {ω : ScalarCocycle G // ω.IsCocycle}) :
+    groupCohomology.cocycles₂ (scalarH2Representation G) := by
+  letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+  apply groupCohomology.cocyclesOfIsMulCocycle₂
+  exact (ScalarCocycle.isCocycle_iff_isMulCocycle₂ ω).mp ω.property
+
+/-- A Mathlib 2-cocycle representative for the trivial action on `ℂˣ`,
+regarded as a curried TNLean cocycle representative. -/
+def ScalarCocycle.ofMathlibCocycle {G : Type} [Group G]
+    (ω : groupCohomology.cocycles₂ (scalarH2Representation G)) :
+    {ω : ScalarCocycle G // ω.IsCocycle} := by
+  letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+  refine ⟨fun g h ↦ (ω (g, h)).toMul, ?_⟩
+  apply (ScalarCocycle.isCocycle_iff_isMulCocycle₂ _).mpr
+  have h := groupCohomology.isMulCocycle₂_of_mem_cocycles₂ (G := G) (M := Units ℂ)
+    (fun p ↦ ω p) ω.property
+  exact h
+
+/-- Curried TNLean cocycle representatives are equivalent to Mathlib's
+uncurried cocycle representatives for the trivial action on `ℂˣ`. -/
+def ScalarCocycle.representativesEquivMathlib (G : Type) [Group G] :
+    {ω : ScalarCocycle G // ω.IsCocycle} ≃
+      groupCohomology.cocycles₂ (scalarH2Representation G) where
+  toFun := ScalarCocycle.toMathlibCocycle
+  invFun := ScalarCocycle.ofMathlibCocycle
+  left_inv ω := by
+    ext g h
+    rfl
+  right_inv ω := by
+    apply Subtype.ext
+    funext p
+    rcases p with ⟨g, h⟩
+    rfl
+
+set_option linter.style.haveILetI false in
+/-- A scalar cochain is a TNLean coboundary precisely when the corresponding
+additive cochain belongs to Mathlib's submodule of 2-coboundaries. -/
+theorem ScalarCocycle.isCoboundary_iff_mem_mathlibCoboundaries
+    {G : Type} [Group G] (ω : ScalarCocycle G) :
+    ω.IsCoboundary ↔
+      (fun p : G × G ↦ Additive.ofMul (ω p.1 p.2)) ∈
+        groupCohomology.coboundaries₂ (scalarH2Representation G) := by
+  letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+  constructor
+  · intro h
+    exact (groupCohomology.coboundariesOfIsMulCoboundary₂
+      ((ScalarCocycle.isCoboundary_iff_isMulCoboundary₂ ω).mp h)).property
+  · intro h
+    apply (ScalarCocycle.isCoboundary_iff_isMulCoboundary₂ ω).mpr
+    have h' := groupCohomology.isMulCoboundary₂_of_mem_coboundaries₂
+      (G := G) (M := Units ℂ) (Function.uncurry ω) h
+    change groupCohomology.IsMulCoboundary₂ (Function.uncurry ω) at h'
+    exact h'
+
+/-- Two TNLean cocycle representatives determine the same Mathlib cohomology
+class precisely when they are cohomologous. -/
+theorem ScalarCocycle.cohomologousTo_iff_H2π_eq {G : Type} [Group G]
+    (ω₁ ω₂ : {ω : ScalarCocycle G // ω.IsCocycle}) :
+    ω₁.1.CohomologousTo ω₂.1 ↔
+      groupCohomology.H2π (scalarH2Representation G)
+          (ScalarCocycle.toMathlibCocycle ω₁) =
+        groupCohomology.H2π (scalarH2Representation G)
+          (ScalarCocycle.toMathlibCocycle ω₂) := by
+  rw [groupCohomology.H2π_eq_iff]
+  rw [ScalarCocycle.cohomologousTo_iff_isCoboundary_div]
+  rw [ScalarCocycle.isCoboundary_iff_mem_mathlibCoboundaries]
+  rfl
+
+/-- The canonical map from TNLean's concrete quotient of scalar cocycles to
+Mathlib's degree-two group cohomology for the trivial action on `ℂˣ`. -/
+noncomputable def h2ToGroupCohomology (G : Type) [Group G] :
+    H2 G → groupCohomology.H2 (scalarH2Representation G) :=
+  Quotient.lift
+    (fun ω ↦ groupCohomology.H2π (scalarH2Representation G)
+      (ScalarCocycle.toMathlibCocycle ω))
+    fun ω₁ ω₂ h ↦ (ScalarCocycle.cohomologousTo_iff_H2π_eq ω₁ ω₂).mp h
+
+/-- The canonical comparison map is injective. -/
+theorem h2ToGroupCohomology_injective (G : Type) [Group G] :
+    Function.Injective (h2ToGroupCohomology G) := by
+  intro x y h
+  induction x using Quotient.inductionOn with
+  | _ ω₁ =>
+    induction y using Quotient.inductionOn with
+    | _ ω₂ =>
+      apply Quotient.sound
+      exact (ScalarCocycle.cohomologousTo_iff_H2π_eq ω₁ ω₂).mpr h
+
+/-- The canonical comparison map is surjective. -/
+theorem h2ToGroupCohomology_surjective (G : Type) [Group G] :
+    Function.Surjective (h2ToGroupCohomology G) := by
+  intro x
+  refine groupCohomology.H2_induction_on
+    (C := fun y ↦ ∃ z, h2ToGroupCohomology G z = y) x ?_
+  intro ω
+  refine ⟨Quotient.mk _ (ScalarCocycle.ofMathlibCocycle ω), ?_⟩
+  change groupCohomology.H2π (scalarH2Representation G)
+      ((ScalarCocycle.representativesEquivMathlib G)
+        ((ScalarCocycle.representativesEquivMathlib G).symm ω)) =
+    groupCohomology.H2π (scalarH2Representation G) ω
+  rw [Equiv.apply_symm_apply]
+
+/-- TNLean's concrete quotient `H2 G` is equivalent to Mathlib's degree-two
+group cohomology for the trivial action on `ℂˣ`.
+
+This is the cohomology group `H²(G, ℂˣ)` used in arXiv:2502.20257,
+lines 1927--1931. -/
+noncomputable def h2EquivGroupCohomology (G : Type) [Group G] :
+    H2 G ≃ groupCohomology.H2 (scalarH2Representation G) :=
+  Equiv.ofBijective (h2ToGroupCohomology G)
+    ⟨h2ToGroupCohomology_injective G, h2ToGroupCohomology_surjective G⟩
+
 /-! ### Commutator phase and non-triviality of a cohomology class
 
 For a pair of commuting group elements `g`, `h`, the *commutator phase*
-`ω(g,h) · ω(h,g)⁻¹` of a `U(1)`-valued 2-cocycle is invariant under the
+`ω(g,h) · ω(h,g)⁻¹` of an `ℂˣ`-valued 2-cocycle is invariant under the
 coboundary action and so descends to the cohomology class.  When the phase
 differs from `1` the class is non-trivial.  This is the standard discrete
-invariant detecting the non-trivial element of `H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+invariant detecting the non-trivial element of `H²(Z₂ × Z₂, ℂˣ) = Z₂`. -/
 
 /-- The commutator phase `ω(g,h) · ω(h,g)⁻¹` of a scalar 2-cocycle. -/
 def ScalarCocycle.commPhase (ω : ScalarCocycle G) (g h : G) : Units ℂ :=

--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -297,7 +297,6 @@ def ScalarCocycle.representativesEquivMathlib (G : Type) [Group G] :
     rcases p with ⟨g, h⟩
     rfl
 
-set_option linter.style.haveILetI false in
 /-- A scalar cochain is a TNLean coboundary precisely when the corresponding
 additive cochain belongs to Mathlib's submodule of 2-coboundaries. -/
 theorem ScalarCocycle.isCoboundary_iff_mem_mathlibCoboundaries
@@ -305,7 +304,7 @@ theorem ScalarCocycle.isCoboundary_iff_mem_mathlibCoboundaries
     ω.IsCoboundary ↔
       (fun p : G × G ↦ Additive.ofMul (ω p.1 p.2)) ∈
         groupCohomology.coboundaries₂ (scalarH2Representation G) := by
-  letI := ScalarCocycle.trivialMulDistribMulAction (G := G)
+  let _ := ScalarCocycle.trivialMulDistribMulAction (G := G)
   constructor
   · intro h
     exact (groupCohomology.coboundariesOfIsMulCoboundary₂

--- a/TNLean/Algebra/ProjectiveRepresentation.lean
+++ b/TNLean/Algebra/ProjectiveRepresentation.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 /-!
-# Projective representations and concrete `U(1)`-valued 2-cocycles
+# Projective representations and concrete `ℂˣ`-valued 2-cocycles
 
 This file introduces a concrete notion of projective representation for matrix-valued
 virtual symmetries:

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -492,7 +492,7 @@ theorem aklt_isUnitary_Z2Z2 (g : Multiplicative (ZMod 2 × ZMod 2)) :
     (by rw [akltPhysP1_conjTranspose, akltPhysP1_sq])
     (by rw [akltPhysP2_conjTranspose, akltPhysP2_sq]) g
 
-/-! ### The AKLT factor system is the non-trivial class of `H²(Z₂ × Z₂, U(1))`
+/-! ### The AKLT factor system is the non-trivial class of `H²(Z₂ × Z₂, ℂˣ)`
 
 The anticommuting virtual gauges `iσy` and `σz` assemble into an explicit
 projective representation of `Z₂ × Z₂` on the bond space.  Its factor system
@@ -500,7 +500,7 @@ projective representation of `Z₂ × Z₂` on the bond space.  Its factor syste
 nonzero and the two components of `g` differ, the cocycle `(-1)^{(g₁+g₂) h₁}`;
 the extra diagonal term over the cluster case reflects `(iσy)² = -I`.  Its
 commutator phase on the two generators is `-1`, so the commutator-phase test
-shows its class is the non-trivial element of `H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+shows its class is the non-trivial element of `H²(Z₂ × Z₂, ℂˣ) = Z₂`. -/
 
 open TNLean.Algebra in
 /-- The AKLT factor system on `Z₂ × Z₂`: `ω(g, h) = (-1)^{(g₁ + g₂) h₁}`, the
@@ -547,7 +547,7 @@ def akltProjRep : ProjectiveRepresentation (D := 2) akltOmega where
 open TNLean.Algebra in
 /-- `akltOmega` is a genuine `2`-cocycle: it is the factor system of the
 projective representation `akltProjRep`, so its class lives in
-`H²(Z₂ × Z₂, U(1))`. -/
+`H²(Z₂ × Z₂, ℂˣ)`. -/
 lemma akltOmega_isCocycle : ScalarCocycle.IsCocycle akltOmega :=
   ScalarCocycle.isCocycle_of_projRep akltProjRep (by norm_num)
 
@@ -562,7 +562,7 @@ lemma aklt_commPhase_eq_neg_one :
 
 open TNLean.Algebra in
 /-- The AKLT factor system represents the non-trivial element of
-`H²(Z₂ × Z₂, U(1)) = Z₂`: the AKLT state is a non-trivial SPT phase. -/
+`H²(Z₂ × Z₂, ℂˣ) = Z₂`: the AKLT state is a non-trivial SPT phase. -/
 theorem aklt_isNontrivialSPT : ScalarCocycle.IsNontrivialClass akltOmega := by
   refine ScalarCocycle.isNontrivialClass_of_commPhase_ne_one
     (g := Multiplicative.ofAdd (1, 0)) (h := Multiplicative.ofAdd (0, 1)) ?_ ?_

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -447,7 +447,7 @@ theorem cluster_isOnSiteSymmetric_Z2Z2 :
   · exact cluster_gaugeEquiv_X2.sameMPV
   · exact cluster_gaugeEquiv_X1X2.sameMPV
 
-/-! ### The cluster factor system is the non-trivial class of `H²(Z₂ × Z₂, U(1))`
+/-! ### The cluster factor system is the non-trivial class of `H²(Z₂ × Z₂, ℂˣ)`
 
 The anticommuting virtual gauges `σz` and `σx` assemble into an explicit
 projective representation of `Z₂ × Z₂` on the bond space.  Its factor system
@@ -455,7 +455,7 @@ projective representation of `Z₂ × Z₂` on the bond space.  Its factor syste
 and the first component of `h` are both nonzero, the standard commutator cocycle
 `(-1)^{g₂ h₁}`.  Its commutator phase on the two generators is `-1`, so by
 `isNontrivialClass_of_commPhase_ne_one` its class is the non-trivial element of
-`H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+`H²(Z₂ × Z₂, ℂˣ) = Z₂`. -/
 
 open TNLean.Algebra in
 /-- The cluster factor system on `Z₂ × Z₂`: `ω(g, h) = (-1)^{g₂ h₁}`, the value
@@ -500,7 +500,7 @@ def clusterProjRep : ProjectiveRepresentation (D := 2) clusterOmega where
 open TNLean.Algebra in
 /-- `clusterOmega` is a genuine `2`-cocycle: it is the factor system of the
 projective representation `clusterProjRep`, so its class lives in
-`H²(Z₂ × Z₂, U(1))`. -/
+`H²(Z₂ × Z₂, ℂˣ)`. -/
 lemma clusterOmega_isCocycle : ScalarCocycle.IsCocycle clusterOmega :=
   ScalarCocycle.isCocycle_of_projRep clusterProjRep (by norm_num)
 
@@ -515,7 +515,7 @@ lemma cluster_commPhase_eq_neg_one :
 
 open TNLean.Algebra in
 /-- The cluster factor system represents the non-trivial element of
-`H²(Z₂ × Z₂, U(1)) = Z₂`: the cluster state is a non-trivial SPT phase. -/
+`H²(Z₂ × Z₂, ℂˣ) = Z₂`: the cluster state is a non-trivial SPT phase. -/
 theorem cluster_isNontrivialSPT : ScalarCocycle.IsNontrivialClass clusterOmega := by
   refine ScalarCocycle.isNontrivialClass_of_commPhase_ne_one
     (g := Multiplicative.ofAdd (1, 0)) (h := Multiplicative.ofAdd (0, 1)) ?_ ?_

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -353,6 +353,88 @@ an MPU representation.
     follow.
 \end{proof}
 
+\begin{theorem}[Cocycles and coboundaries for trivial coefficients]
+    \label{thm:mpug_h2_trivial_coefficients}
+    \lean{TNLean.Algebra.ScalarCocycle.isCocycle_iff_isMulCocycle₂,
+        TNLean.Algebra.ScalarCocycle.isCoboundary_iff_isMulCoboundary₂,
+        TNLean.Algebra.ScalarCocycle.cohomologousTo_iff_isCoboundary_div,
+        TNLean.Algebra.ScalarCocycle.isCoboundary_iff_mem_mathlibCoboundaries,
+        TNLean.Algebra.ScalarCocycle.cohomologousTo_iff_H2π_eq}
+    \leanok
+    \uses{def:is_coboundary, def:cohomologous_to, def:is_cocycle}
+    Let $G$ act trivially on $\C^\times$, and let
+    $f(g,h)=\omega(g,h)$. The multiplicative cocycle equation
+    \begin{align}
+        f(gh,k)f(g,h)
+         & =f(h,k)f(g,hk)
+        \label{eq:mpug_h2_cocycle_comparison}
+    \end{align}
+    is equivalent to Definition~\ref{def:is_cocycle}. Likewise, the
+    multiplicative coboundary equation
+    \begin{align}
+        \frac{\varphi(h)}{\varphi(gh)}\varphi(g)
+         & =f(g,h)
+        \label{eq:mpug_h2_coboundary_comparison}
+    \end{align}
+    is equivalent to Definition~\ref{def:is_coboundary}.
+
+    If $\pi$ denotes the canonical map from multiplicative $2$-cocycles to
+    degree-two group cohomology, then for any two cocycles $\omega_1$ and
+    $\omega_2$,
+    \begin{align}
+        \omega_1\sim\omega_2
+         & \quad\Longleftrightarrow\quad
+        \pi(\omega_1)=\pi(\omega_2).
+        \label{eq:mpug_h2_class_comparison}
+    \end{align}
+    % Source anchor: arXiv:2502.20257, lines 1927--1931.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:is_coboundary, def:cohomologous_to, def:is_cocycle}
+    Since $\C^\times$ is commutative,
+    (\ref{eq:mpug_h2_cocycle_comparison}) is obtained from the cocycle
+    equation by interchanging the two factors on each side, and
+    (\ref{eq:mpug_h2_coboundary_comparison}) is obtained from
+    $\varphi(g)\varphi(h)\varphi(gh)^{-1}$ by reordering its factors.
+    Moreover, $\omega_1\sim\omega_2$ holds exactly when
+    $\omega_1\omega_2^{-1}$ is a coboundary. In additive notation this ratio
+    is the difference of the corresponding cochains, so the quotient
+    criterion for $\pi$ gives
+    (\ref{eq:mpug_h2_class_comparison}).
+\end{proof}
+
+\begin{definition}[Comparison with low-degree group cohomology]
+    \label{def:mpug_h2_group_cohomology_comparison}
+    \lean{TNLean.Algebra.h2EquivGroupCohomology,
+        TNLean.Algebra.ScalarCocycle.trivialMulDistribMulAction,
+        TNLean.Algebra.scalarH2Representation,
+        TNLean.Algebra.ScalarCocycle.toMathlibCocycle,
+        TNLean.Algebra.ScalarCocycle.ofMathlibCocycle,
+        TNLean.Algebra.ScalarCocycle.representativesEquivMathlib,
+        TNLean.Algebra.h2ToGroupCohomology,
+        TNLean.Algebra.h2ToGroupCohomology_injective,
+        TNLean.Algebra.h2ToGroupCohomology_surjective}
+    \leanok
+    \uses{def:h2_cx, thm:mpug_h2_trivial_coefficients}
+    Give $\C^\times$ the trivial $G$-action. Currying and uncurrying identify
+    the cocycle representatives in Definition~\ref{def:h2_cx} with the
+    multiplicative representatives in the inhomogeneous cochain complex.
+    By (\ref{eq:mpug_h2_class_comparison}), this correspondence induces a
+    canonical equivalence
+    \begin{align}
+        Z^2(G,\C^\times)/{\sim}
+         & \simeq H^2\bigl(G,\C^\times_{\mathrm{triv}}\bigr).
+        \label{eq:mpug_h2_equivalence}
+    \end{align}
+    The left-hand side is the quotient already defined in
+    Definition~\ref{def:h2_cx}; no additional quotient is introduced.
+    This is the $H^2(H,\C^\times)$ appearing in the pair $(H,\psi)$ in
+    \cite[lines~1927--1931]{FrancoRubio2025MPUGauging}.
+    % Reuse boundary: the right-hand side is Mathlib's low-degree H2 for
+    % Rep.ofMulDistribMulAction with the explicit trivial action.
+\end{definition}
+
 \begin{definition}[Block scalar and block independence]
     \label{def:mpug_block_independence_factor}
     \lean{TNLean.Algebra.LSymbol.ell,


### PR DESCRIPTION
### Motivation

The MPU classification uses a pair $(H, \psi)$ with $\psi \in H^2(H, \mathbb{C}^{\times})$ in `Papers/2502.20257/main.tex:1927–1931`. TNLean already had a concrete quotient of scalar cocycles, while Mathlib already had low-degree group cohomology. Their precise relationship was not recorded, leaving later MPU work liable to duplicate quotient machinery or silently change cocycle conventions.

### Description

- Gives `Units ℂ` the explicit trivial group action used by the comparison. This remains a plain named definition and is installed locally at each converter or proof site; it is not a global typeclass instance.
- Proves the curried/uncurried cocycle and coboundary equations agree, including the exact quotient criterion relating `ScalarCocycle.CohomologousTo` to equality under Mathlib's `H2π`.
- Identifies the representative spaces and constructs a canonical equivalence from the existing TNLean `H2` quotient to Mathlib's degree-two group cohomology. No third quotient is introduced.
- Adds the corresponding Chapter 29 blueprint statements and declaration tags, anchored to the paper's $H^2(H, \mathbb{C}^{\times})$ terminology.
- Corrects nearby AKLT, cluster-state, and projective-representation prose from $U(1)$ to the coefficient group actually used by their Lean declarations, $\mathbb{C}^{\times}$.

There were no existing consumers of the `H2` quotient to refactor: current downstream arguments use `ScalarCocycle.CohomologousTo` directly. The comparison is stated for `G : Type` because Mathlib's present low-degree construction places the acting group and coefficient ring in the same universe; TNLean's concrete `H2` remains universe-polymorphic. The separate comparison between $\mathbb{C}^{\times}$- and $U(1)$-valued cohomology is deliberately excluded and remains tracked in #7364.

Closes #7337.

### Testing

- `lake build TNLean.Algebra.CocycleCohomology TNLean.MPS.Symmetry.CocycleCoboundary TNLean.MPS.Symmetry.StringOrder TNLean.MPS.Periodic.ProjectiveRep TNLean.MPS.Examples.AKLT TNLean.MPS.Examples.Cluster`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/tactic_pattern_scan.py`
- Proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` in every changed Lean file
- `git diff --check`

### Agent assistance

OpenAI Codex (GPT-5) scouted Mathlib's low-degree group-cohomology definitions and the existing TNLean cohomology consumers, implemented and proved the bridge, aligned the coefficient terminology, added the blueprint synchronization entries, and ran the targeted validation.
