### PR TITLE
doc(blueprint): cite reciprocal block-independence corrections

### DIFF
--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -464,6 +464,8 @@ an MPU representation.
         \omega(e,e,g)\bigr)^{-1}.
         \label{eq:mpug_relative_block_character}
     \end{align}
+    The reciprocal factor $(\ell^{x_0}_{e,g;g})^{-1}$ corrects the
+    corresponding printed factor \cite{gap:fbc25_block_independence_reciprocal_errors}.
     Then
     \begin{align}
         L^{g x}_{e,e}
@@ -522,6 +524,9 @@ an MPU representation.
          & =1.
         \label{eq:mpug_inverse_gauge_trivialization}
     \end{align}
+    The distinction between the forward multiplier and its pointwise inverse
+    corrects the orientation of the displayed source calculation
+    \cite{gap:fbc25_block_independence_reciprocal_errors}.
     If $\mathsf X$ is nonempty, a choice of $x_0$ therefore gives a
     trivializing joint scalar gauge for every compatible block-independent
     $L$-symbol.


### PR DESCRIPTION
### Motivation

- The block-independence argument corrects three reciprocal factors from arXiv:2502.20257, but the generated blueprint previously exposed the paper-gap citation only at the block-factorization theorem.
- The two remaining corrections occur in `Papers/2502.20257/main.tex:7003-7027`, at `eq:defrho` and `eq:Lgauge`: the relative character contains the reciprocal block scalar, and the inverse of the displayed forward gauge trivializes the $L$-symbol.

### Description

- Add a rendered citation to `gap:fbc25_block_independence_reciprocal_errors` at `thm:mpug_relative_block_character`, immediately after the corrected reciprocal factor.
- Add the same rendered citation at `thm:mpug_block_independence_inverse_gauge`, where the forward multiplier and its trivializing inverse are distinguished.
- Preserve the existing source-anchor and local-correction comments. No theorem statement, proof, Lean declaration, or bibliography entry changes.
- Repair #7262's “Review and maintenance debt” list so that it explicitly names native child #7369.

### Testing

- `scripts/latexindent -l blueprint/latexindent.yaml -w -s blueprint/src/chapter/ch29_mpu_gauging.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch29_mpu_gauging.tex`
- `texra-blueprint paper-gaps check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint bbl`
- `texra-blueprint web`
- Inspected `blueprint/web/ch-mpu_gauging.html`: all three corrected theorems render citation [23], and each link resolves to the bibliography entry for `fbc25_block_independence_reciprocal_errors.pdf`.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` reports 6,767/6,767 theorem-like entries in sync. The kernel `checkdecls` pass is left to CI because the shared hot cache lacks an unrelated `TNLean.Algebra.CocycleCohomology.olean`; this PR changes no `\lean{}` tags.

---

Closes #7369

### Agent assistance

- OpenAI Codex (GPT-5) traced the two corrections against the paper source and the existing gap note, made the minimal Chapter 29 prose change, repaired the tracker metadata, and ran the focused blueprint validation described above.
