### PR TITLE
feat(Algebra): compare Circle and complex-unit H²

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Algebra
 
+import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.CommutingProjectionProduct
 import TNLean.Algebra.ComplexSqrt

--- a/TNLean/Algebra/CircleCohomology.lean
+++ b/TNLean/Algebra/CircleCohomology.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.RepresentationTheory.Homological.GroupCohomology.Functoriality
+import QICLean.Algebra.ComplexPhasePositivity
+import TNLean.Algebra.CocycleCohomology
+import TNLean.Algebra.PositiveGeneralizedCocycle
+
+/-!
+# Circle and complex-unit coefficients in degree-two group cohomology
+
+For a finite group with trivial coefficient action, inclusion of unit-modulus
+complex numbers into the nonzero complex numbers induces an equivalence
+
+`H²(G, Circle) ≃ H²(G, Units ℂ)`.
+
+The proof is algebraic.  The unit phase of a nonzero complex number is a
+retraction of `Circle.toUnits`, so the induced map is injective for every
+group.  For a finite group, the positive norm part of a complex-valued
+cocycle is a coboundary by the positive generalized-cocycle theorem.  Dividing
+by this coboundary gives a unit-modulus representative.
+
+This differs from the explanation in arXiv:2502.20257, line 1931 and its
+footnote.  There the coefficient spaces are treated as topological abelian
+groups and compared in sheaf cohomology over a CW complex.  Here `G` is a
+finite discrete group, the cohomology is algebraic group cohomology, and the
+comparison is proved directly from cocycles.  See
+`docs/paper-gaps/fbc25_circle_complex_units_cohomology.tex`.
+-/
+
+noncomputable section
+
+open CategoryTheory
+
+namespace TNLean.Algebra
+
+variable {G : Type*} [Group G]
+
+set_option warn.classDefReducibility false in
+/-- The trivial action of `G` on the circle group. -/
+def Circle.trivialMulDistribMulAction : MulDistribMulAction G Circle where
+  smul _ z := z
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+  smul_one _ := rfl
+  smul_mul _ _ _ := rfl
+
+/-- The representation of `G` on the circle group with trivial action. -/
+abbrev circleH2Representation (G : Type*) [Group G] : Rep ℤ G :=
+  @Rep.ofMulDistribMulAction G Circle _ _
+    (Circle.trivialMulDistribMulAction (G := G))
+
+/-- Taking the unit phase retracts the inclusion of the circle into the
+nonzero complex numbers. -/
+@[simp]
+theorem Complex.unitsPhase_toUnits (z : Circle) :
+    Complex.unitsPhase (Circle.toUnits z) = z := by
+  apply Circle.ext
+  change (z : ℂ) / ‖(z : ℂ)‖ = (z : ℂ)
+  rw [Circle.norm_coe]
+  change (z : ℂ) / (1 : ℂ) = (z : ℂ)
+  exact div_one _
+
+/-- Polar decomposition of a nonzero complex number, expressed in the unit
+group: the quotient by its unit phase is its positive norm. -/
+theorem Complex.div_toUnits_unitsPhase (z : Units ℂ) :
+    z / Circle.toUnits (Complex.unitsPhase z) =
+      PositiveUnits.embedding (PositiveUnits.norm z) := by
+  apply Units.ext
+  change (z : ℂ) / ((z : ℂ) / ‖(z : ℂ)‖) = ((‖(z : ℂ)‖ : ℝ) : ℂ)
+  field_simp
+
+/-! ### Cocycle representatives -/
+
+/-- The pointwise unit phase of a complex-unit-valued scalar two-cochain. -/
+noncomputable def ScalarCocycle.circlePhase (ω : ScalarCocycle G) :
+    G → G → Circle :=
+  fun g h ↦ Complex.unitsPhase (ω g h)
+
+/-- Include the pointwise unit phase of a scalar two-cochain back into
+`ℂˣ`. -/
+noncomputable def ScalarCocycle.circlePhaseInclusion (ω : ScalarCocycle G) :
+    ScalarCocycle G :=
+  fun g h ↦ Circle.toUnits (ω.circlePhase g h)
+
+/-- The positive radial part left after dividing a scalar two-cochain by its
+pointwise unit phase, regarded as an L-symbol over one block. -/
+noncomputable def ScalarCocycle.positiveResidual (ω : ScalarCocycle G) :
+    LSymbol G PUnit.{1} :=
+  fun _ g h ↦ ω g h / ω.circlePhaseInclusion g h
+
+/-- Taking pointwise unit phase preserves the scalar cocycle equation. -/
+theorem ScalarCocycle.circlePhase_isMulCocycle₂ {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) :
+    @groupCohomology.IsMulCocycle₂ G Circle _ _
+      (Circle.trivialMulDistribMulAction (G := G)).toSMul
+      (Function.uncurry ω.circlePhase) := by
+  intro g h k
+  change Complex.unitsPhase (ω (g * h) k) * Complex.unitsPhase (ω g h) =
+    Complex.unitsPhase (ω h k) * Complex.unitsPhase (ω g (h * k))
+  simpa only [map_mul, mul_comm] using congrArg Complex.unitsPhase (hω g h k)
+
+/-- The radial residual of a scalar cocycle is a generalized cocycle on the
+one-point block space. -/
+theorem ScalarCocycle.positiveResidual_isGeneralizedCocycle
+    {ω : ScalarCocycle G} (hω : ω.IsCocycle) :
+    LSymbol.IsGeneralizedCocycle ω.positiveResidual := by
+  intro x g h k
+  change ω.positiveResidual x g (h * k) * ω.positiveResidual x h k =
+    1 * ω.positiveResidual (k • x) g h * ω.positiveResidual x (g * h) k
+  simp only [one_mul, positiveResidual, circlePhaseInclusion, circlePhase,
+    div_mul_div_comm]
+  congr 1
+  · exact (hω g h k).symm
+  · simpa only [map_mul] using (congrArg
+      (fun z : Units ℂ ↦ Circle.toUnits (Complex.unitsPhase z)) (hω g h k)).symm
+
+omit [Group G] in
+/-- The radial residual of any scalar two-cochain takes values in the positive
+subgroup of `ℂˣ`. -/
+theorem ScalarCocycle.positiveResidual_isPositiveValued (ω : ScalarCocycle G) :
+    LSymbol.IsPositiveValued ω.positiveResidual := by
+  intro x g h
+  exact ⟨PositiveUnits.norm (ω g h), (Complex.div_toUnits_unitsPhase (ω g h)).symm⟩
+
+/-- For a finite group, the radial residual of a scalar cocycle is a
+coboundary.  This is the one-block specialization of the positive generalized
+cocycle trivialization. -/
+theorem ScalarCocycle.positiveResidual_isCoboundary [Finite G]
+    {ω : ScalarCocycle G} (hω : ω.IsCocycle) :
+    ScalarCocycle.IsCoboundary
+      (fun g h ↦ ω.positiveResidual PUnit.unit g h) := by
+  obtain ⟨χ, _, hχ⟩ := LSymbol.exists_positive_coboundary
+    (positiveResidual_isGeneralizedCocycle hω)
+    (positiveResidual_isPositiveValued ω)
+  refine ⟨fun g ↦ χ g PUnit.unit, fun g h ↦ ?_⟩
+  have hχApply := congrFun (congrFun (congrFun hχ PUnit.unit) g) h
+  simpa [ActionTensorGauge.coboundary, div_eq_mul_inv] using hχApply
+
+/-- Every `ℂˣ`-valued scalar cocycle of a finite group is cohomologous to the
+inclusion of its pointwise `U(1)` phase.
+
+This is the finite-discrete algebraic comparison used for
+arXiv:2502.20257, line 1931.  It does not use the sheaf-cohomology argument in
+the source footnote. -/
+theorem ScalarCocycle.cohomologousTo_circlePhaseInclusion [Finite G]
+    {ω : ScalarCocycle G} (hω : ω.IsCocycle) :
+    ω.CohomologousTo ω.circlePhaseInclusion := by
+  rw [ScalarCocycle.cohomologousTo_iff_isCoboundary_div]
+  change ScalarCocycle.IsCoboundary
+    (fun g h ↦ ω g h / ω.circlePhaseInclusion g h)
+  exact positiveResidual_isCoboundary hω
+
+/-- Inclusion of circle coefficients as a morphism of trivial
+representations. -/
+def circleToComplexUnitsRepHom (G : Type*) [Group G] :
+    circleH2Representation G ⟶ scalarH2Representation G := by
+  apply Rep.ofHom
+  refine ⟨Circle.toUnits.toAdditive.toIntLinearMap, ?_⟩
+  intro g
+  rfl
+
+/-- Unit phase as a morphism of trivial representations. -/
+def complexUnitsPhaseRepHom (G : Type*) [Group G] :
+    scalarH2Representation G ⟶ circleH2Representation G := by
+  apply Rep.ofHom
+  refine ⟨Complex.unitsPhase.toAdditive.toIntLinearMap, ?_⟩
+  intro g
+  rfl
+
+/-- Unit phase is a left inverse to inclusion at the representation level. -/
+theorem circleToComplexUnitsRepHom_comp_complexUnitsPhaseRepHom (G : Type*) [Group G] :
+    circleToComplexUnitsRepHom G ≫ complexUnitsPhaseRepHom G =
+      𝟙 (circleH2Representation G) := by
+  ext z
+  exact Complex.unitsPhase_toUnits z
+
+/-! ### Canonical degree-two cohomology -/
+
+/-- The Mathlib circle-valued cocycle obtained by taking the pointwise phase
+of a complex-unit-valued cocycle. -/
+noncomputable def ScalarCocycle.circlePhaseMathlibCocycle {G : Type} [Group G]
+    (ω : groupCohomology.cocycles₂ (scalarH2Representation G)) :
+    groupCohomology.cocycles₂ (circleH2Representation G) :=
+  groupCohomology.mapCocycles₂ (MonoidHom.id G)
+    (complexUnitsPhaseRepHom G) ω
+
+/-- Mapping the phase representative back to complex units gives the
+pointwise phase inclusion of the original curried representative. -/
+theorem ScalarCocycle.ofMathlibCocycle_map_circlePhaseMathlibCocycle
+    {G : Type} [Group G]
+    (ω : groupCohomology.cocycles₂ (scalarH2Representation G)) :
+    (ScalarCocycle.ofMathlibCocycle
+      (groupCohomology.mapCocycles₂ (MonoidHom.id G)
+        (circleToComplexUnitsRepHom G)
+        (ScalarCocycle.circlePhaseMathlibCocycle ω))).1 =
+      (ScalarCocycle.ofMathlibCocycle ω).1.circlePhaseInclusion := by
+  rfl
+
+/-- For a finite group, the included pointwise-phase representative and the
+original complex-unit-valued representative determine the same canonical
+degree-two cohomology class. -/
+theorem ScalarCocycle.H2π_map_circlePhaseMathlibCocycle
+    {G : Type} [Group G] [Finite G]
+    (ω : groupCohomology.cocycles₂ (scalarH2Representation G)) :
+    groupCohomology.H2π (scalarH2Representation G)
+        (groupCohomology.mapCocycles₂ (MonoidHom.id G)
+          (circleToComplexUnitsRepHom G)
+          (ScalarCocycle.circlePhaseMathlibCocycle ω)) =
+      groupCohomology.H2π (scalarH2Representation G) ω := by
+  let ωphase := groupCohomology.mapCocycles₂ (MonoidHom.id G)
+    (circleToComplexUnitsRepHom G)
+    (ScalarCocycle.circlePhaseMathlibCocycle ω)
+  have hcoh :
+      (ScalarCocycle.ofMathlibCocycle ωphase).1.CohomologousTo
+        (ScalarCocycle.ofMathlibCocycle ω).1 := by
+    rw [ofMathlibCocycle_map_circlePhaseMathlibCocycle]
+    exact (ScalarCocycle.cohomologousTo_circlePhaseInclusion
+      (ScalarCocycle.ofMathlibCocycle ω).2).symm
+  exact (ScalarCocycle.cohomologousTo_iff_H2π_eq
+    (ScalarCocycle.ofMathlibCocycle ωphase)
+    (ScalarCocycle.ofMathlibCocycle ω)).mp hcoh
+
+/-- The coefficient-inclusion map
+`H²(G, U(1)) → H²(G, ℂˣ)`. -/
+noncomputable def circleH2ToComplexUnitsH2 (G : Type) [Group G] :
+    groupCohomology.H2 (circleH2Representation G) ⟶
+      groupCohomology.H2 (scalarH2Representation G) :=
+  groupCohomology.map (MonoidHom.id G) (circleToComplexUnitsRepHom G) 2
+
+/-- The coefficient phase map
+`H²(G, ℂˣ) → H²(G, U(1))`. -/
+noncomputable def complexUnitsH2ToCircleH2 (G : Type) [Group G] :
+    groupCohomology.H2 (scalarH2Representation G) ⟶
+      groupCohomology.H2 (circleH2Representation G) :=
+  groupCohomology.map (MonoidHom.id G) (complexUnitsPhaseRepHom G) 2
+
+/-- Taking coefficient phase after coefficient inclusion is the identity on
+`H²(G, U(1))`.  No finiteness hypothesis on `G` is needed. -/
+theorem complexUnitsH2ToCircleH2_leftInverse (G : Type) [Group G] :
+    Function.LeftInverse (complexUnitsH2ToCircleH2 G)
+      (circleH2ToComplexUnitsH2 G) := by
+  intro x
+  change (groupCohomology.map (MonoidHom.id G)
+      (circleToComplexUnitsRepHom G) 2 ≫
+    groupCohomology.map (MonoidHom.id G)
+      (complexUnitsPhaseRepHom G) 2) x = x
+  rw [← groupCohomology.map_id_comp,
+    circleToComplexUnitsRepHom_comp_complexUnitsPhaseRepHom]
+  rw [groupCohomology.map_id]
+  rfl
+
+/-- Coefficient inclusion is injective on degree-two group cohomology for any
+group. -/
+theorem circleH2ToComplexUnitsH2_injective (G : Type) [Group G] :
+    Function.Injective (circleH2ToComplexUnitsH2 G) :=
+  (complexUnitsH2ToCircleH2_leftInverse G).injective
+
+/-- For a finite group, every `ℂˣ`-valued degree-two cohomology class has the
+included pointwise-phase cocycle as a `U(1)`-valued representative. -/
+theorem circleH2ToComplexUnitsH2_surjective (G : Type) [Group G] [Finite G] :
+    Function.Surjective (circleH2ToComplexUnitsH2 G) := by
+  intro x
+  refine groupCohomology.H2_induction_on
+    (C := fun y ↦ ∃ z, circleH2ToComplexUnitsH2 G z = y) x ?_
+  intro ω
+  refine ⟨groupCohomology.H2π (circleH2Representation G)
+    (ScalarCocycle.circlePhaseMathlibCocycle ω), ?_⟩
+  change groupCohomology.map (MonoidHom.id G)
+      (circleToComplexUnitsRepHom G) 2
+        (groupCohomology.H2π (circleH2Representation G)
+          (ScalarCocycle.circlePhaseMathlibCocycle ω)) =
+    groupCohomology.H2π (scalarH2Representation G) ω
+  rw [groupCohomology.H2π_comp_map_apply]
+  exact ScalarCocycle.H2π_map_circlePhaseMathlibCocycle ω
+
+/-- For a finite group with trivial coefficient action, inclusion of the
+circle into the nonzero complex numbers induces the algebraic comparison
+
+`H²(G, U(1)) ≃ H²(G, ℂˣ)`.
+
+This proves the finite-discrete algebraic comparison asserted in
+arXiv:2502.20257, line 1931.  The source footnote instead discusses sheaf
+cohomology with topological coefficient groups; see
+`docs/paper-gaps/fbc25_circle_complex_units_cohomology.tex`.
+
+Mathlib's low-degree interface places the acting group and coefficient ring in
+the same universe, so this canonical comparison is stated for `G : Type`. -/
+noncomputable def circleH2EquivComplexUnitsH2 (G : Type) [Group G] [Finite G] :
+    groupCohomology.H2 (circleH2Representation G) ≃ₗ[ℤ]
+      groupCohomology.H2 (scalarH2Representation G) :=
+  LinearEquiv.ofBijective (circleH2ToComplexUnitsH2 G).hom
+    ⟨circleH2ToComplexUnitsH2_injective G,
+      circleH2ToComplexUnitsH2_surjective G⟩
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch12_symmetry_spt.tex
+++ b/blueprint/src/chapter/ch12_symmetry_spt.tex
@@ -31,11 +31,13 @@ in~\cite{Schuch2011Phases}.
 
 \begin{remark}[Scalar and character conventions]
     \label{rem:spt_scalar_character_conventions}
-    \uses{def:is_same_spt_phase, def:h2_cx}
-    These factor systems take values in $\C^\times$.  For unitary bond
-    representations one may choose unit-modulus representatives and obtain the
-    physical classification label in $H^2(G,\mathrm U(1))$; this normalization
-    is not an equality $\C^\times=\mathrm U(1)$.  Moreover,
+    \uses{def:is_same_spt_phase, def:h2_cx,
+        thm:mpug_circle_complex_units_h2}
+    These factor systems take values in $\C^\times$.  For finite $G$,
+    Theorem~\ref{thm:mpug_circle_complex_units_h2} gives unit-modulus
+    representatives and identifies their classes with
+    $H^2(G,\mathrm U(1))$; this comparison is not an equality
+    $\C^\times=\mathrm U(1)$.  Moreover,
     Definition~\ref{def:is_same_spt_phase} requires exact tensor equations.
     A physical state symmetry may instead act on an MPS vector by a
     one-dimensional character $\chi(g)$, producing a scalar factor in the

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -461,7 +461,7 @@ an MPU representation.
     \begin{align}
         u(g,h)
          & =\frac{\omega(g,h)}{|\omega(g,h)|}\in U(1),
-        &
+         &
         r(g,h)
          & =\frac{\omega(g,h)}{u(g,h)}=|\omega(g,h)|.
         \label{eq:mpug_circle_phase_residual}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -435,6 +435,63 @@ an MPU representation.
     % Rep.ofMulDistribMulAction with the explicit trivial action.
 \end{definition}
 
+\begin{theorem}[Circle and nonzero-complex coefficients in degree two]
+    \label{thm:mpug_circle_complex_units_h2}
+    \lean{TNLean.Algebra.Complex.div_toUnits_unitsPhase,
+        TNLean.Algebra.ScalarCocycle.circlePhase_isMulCocycle₂,
+        TNLean.Algebra.ScalarCocycle.positiveResidual_isCoboundary,
+        TNLean.Algebra.ScalarCocycle.cohomologousTo_circlePhaseInclusion,
+        TNLean.Algebra.ScalarCocycle.circlePhaseMathlibCocycle,
+        TNLean.Algebra.ScalarCocycle.H2π_map_circlePhaseMathlibCocycle,
+        TNLean.Algebra.circleH2ToComplexUnitsH2_injective,
+        TNLean.Algebra.circleH2ToComplexUnitsH2_surjective,
+        TNLean.Algebra.circleH2EquivComplexUnitsH2}
+    \leanok
+    \uses{def:mpug_h2_group_cohomology_comparison,
+        thm:mpug_positive_generalized_cocycle}
+    Let $G$ be finite, and give $U(1)$ and $\C^\times$ the trivial
+    $G$-actions.  Inclusion of the unit circle induces an equivalence
+    \begin{align}
+        H^2(G,U(1))
+         & \simeq H^2(G,\C^\times).
+        \label{eq:mpug_circle_complex_units_h2}
+    \end{align}
+    More concretely, for a $\C^\times$-valued cocycle $\omega$, define its
+    pointwise phase and radial residual by
+    \begin{align}
+        u(g,h)
+         & =\frac{\omega(g,h)}{|\omega(g,h)|}\in U(1),
+        &
+        r(g,h)
+         & =\frac{\omega(g,h)}{u(g,h)}=|\omega(g,h)|.
+        \label{eq:mpug_circle_phase_residual}
+    \end{align}
+    Then $u$ is a cocycle, $r$ is a positive coboundary, and hence $\omega$
+    is cohomologous to the inclusion of $u$.  The inclusion map is injective
+    for every group because pointwise phase is its left inverse; finiteness is
+    used only to prove surjectivity.
+
+    This is an algebraic group-cohomology statement for a finite discrete
+    group.  The footnote at
+    \cite[line~1931]{FrancoRubio2025MPUGauging} instead invokes a comparison
+    of sheaf cohomology with topological coefficient groups; the distinction
+    and the direct finite-group proof are recorded in
+    \cite{gap:fbc25_circle_complex_units_cohomology}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_positive_generalized_cocycle}
+    The phase map $q(z)=z/|z|$ is multiplicative and satisfies
+    $q(u)=u$ for $u\in U(1)$, so it preserves the cocycle equation and
+    retracts inclusion.  The polar identity in
+    (\ref{eq:mpug_circle_phase_residual}) identifies the residual $r$ with a
+    positive cocycle.  Apply
+    Theorem~\ref{thm:mpug_positive_generalized_cocycle} to the one-point block
+    space to write $r=d\chi$.  Therefore $\omega\sim u$, which proves
+    surjectivity of coefficient inclusion on degree-two classes.  Its left
+    inverse induced by $q$ proves injectivity.
+\end{proof}
+
 \begin{definition}[Block scalar and block independence]
     \label{def:mpug_block_independence_factor}
     \lean{TNLean.Algebra.LSymbol.ell,

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -895,6 +895,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_block_independence_reciprocal_errors.pdf}},
 }
 
+@techreport{gap:fbc25_circle_complex_units_cohomology,
+  author      = {The {TNLean} contributors},
+  title       = {Circle and Nonzero-Complex Coefficients in Degree-Two Cohomology},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_circle\_complex\_units\_cohomology},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_circle_complex_units_cohomology.pdf}},
+}
+
 @techreport{gap:fbc25_two_cochain_coboundary_index_typo,
   author      = {The {TNLean} contributors},
   title       = {The Final Index in the Block-Dependent Two-Cochain Coboundary},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -348,6 +348,10 @@ note.
 
 For the MPU action on injective MPS blocks in arXiv:2502.20257:
 
+- `fbc25_circle_complex_units_cohomology.tex` distinguishes the source
+  footnote's sheaf-cohomology comparison from the algebraic group cohomology
+  of a finite discrete group and records the direct phase-and-radial proof of
+  $H^2(G,U(1)) \cong H^2(G,\mathbb C^\times)$ in the latter setting.
 - `fbc25_mpu_action_stabilizer_source_audit.tex` separates the
   positive-length MPS reduction route to action tensors from the stronger
   arbitrary-boundary MPO-algebra route, records the nilpotency and tailwise

--- a/docs/paper-gaps/fbc25_circle_complex_units_cohomology.tex
+++ b/docs/paper-gaps/fbc25_circle_complex_units_cohomology.tex
@@ -1,0 +1,93 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Circle and Nonzero-Complex Coefficients in Degree-Two Cohomology}
+\author{}
+\date{2026-08-29}
+
+\begin{document}
+\maketitle
+\gapnote{clarification}{resolved}
+
+\section{Source context}
+
+For a finite on-site symmetry group $G$, Ref.~\cite[lines~1927--1931]{FrancoRubio2025MPUGauging}
+labels the fully unbroken phases by $H^2(G,\mathbb C^\times)$, or equivalently
+by $H^2(G,U(1))$.  Its footnote regards the two coefficient groups as
+topological abelian groups and invokes an induced comparison in sheaf
+cohomology over a CW complex.
+
+The formal development instead uses algebraic group cohomology.  It regards
+$G$ as finite and discrete and computes cohomology from inhomogeneous cochains
+with trivial coefficient action.  The sheaf-cohomology sentence does not
+directly identify these algebraic cochain complexes.
+
+\section{Finite-discrete comparison}
+
+Let $i:U(1)\longrightarrow\mathbb C^\times$ be inclusion and let
+$q:\mathbb C^\times\longrightarrow U(1)$ be the phase homomorphism
+$q(z)=z/|z|$.  Then
+\begin{align}
+    q\circ i
+        & =\operatorname{id}_{U(1)},
+    &
+    \frac{z}{i(q(z))}
+        & =|z|\in\mathbb R_{>0}.
+    \label{eq:fbc25_circle_polar_retraction}
+\end{align}
+Consequently, if $\omega$ is a $\mathbb C^\times$-valued $2$-cocycle, then
+$q\circ\omega$ is a $U(1)$-valued $2$-cocycle and its radial residual is
+\begin{align}
+    \frac{\omega(g,h)}{i(q(\omega(g,h)))}
+        & =|\omega(g,h)|.
+    \label{eq:fbc25_circle_radial_residual}
+\end{align}
+The right-hand side of
+(\ref{eq:fbc25_circle_radial_residual}) is a positive generalized cocycle on
+the one-point block space.  The finite-group positive-cocycle theorem gives a
+positive $1$-cochain $\chi$ such that
+\begin{align}
+    |\omega(g,h)|
+        & =\frac{\chi(g)\chi(h)}{\chi(gh)}.
+    \label{eq:fbc25_circle_positive_coboundary}
+\end{align}
+Thus $\omega$ and $i\circ q\circ\omega$ are cohomologous.  Every
+$\mathbb C^\times$-valued class therefore has a unit-modulus representative.
+
+Equation~(\ref{eq:fbc25_circle_polar_retraction}) also shows, without assuming
+that $G$ is finite, that the map induced by $i$ is injective: the map induced
+by $q$ is its left inverse.  Combining this injectivity with the finite-group
+surjectivity above gives
+\begin{align}
+    H^2(G,U(1))
+        & \cong H^2(G,\mathbb C^\times)
+        \qquad (G\text{ finite}),
+    \label{eq:fbc25_circle_h2_equivalence}
+\end{align}
+for algebraic group cohomology with trivial coefficient actions.
+
+\section{Formal treatment}
+
+The formal proof implements the phase map, the polar identity, the positive
+one-block trivialization, and the induced maps on the canonical degree-two
+group cohomology object.
+\footnote{Formal declarations:
+\leanid{TNLean.Algebra.ScalarCocycle.cohomologousTo\_circlePhaseInclusion}
+and \leanid{TNLean.Algebra.circleH2EquivComplexUnitsH2} in
+\doclink{TNLean/Algebra/CircleCohomology}.}
+
+\textbf{Verdict: resolved clarification.}
+The source's finite-group equivalence is available for the algebraic
+cohomology used in the classification, but it is established here by a direct
+polar-decomposition argument rather than by identifying it with the sheaf
+cohomology comparison in the footnote.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- add a focused `CircleCohomology` comparison module using Mathlib's canonical degree-two group cohomology;
- prove the exact polar identity for `Circle.toUnits` and QICLean's `Complex.unitsPhase`, then use the existing positive generalized-cocycle trivialization on a one-point block space;
- obtain a circle-valued representative for every complex-unit-valued cocycle of a finite group, while proving coefficient-inclusion injectivity for arbitrary groups;
- package the finite-group result as a linear equivalence
  \(H^2(G,U(1)) \simeq H^2(G,\mathbb C^\times)\), without introducing another quotient or a global action instance;
- add the source-faithful Blueprint theorem and the indexed paper-gap note, and retain the source's \(U(1)\) terminology in the Chapter 12 classification theorem.

## Mathematical route and source distinction

For a complex unit `z`, the proof establishes

\[
  z / \operatorname{toUnits}(\operatorname{unitsPhase}(z))
    = \operatorname{embedding}(\operatorname{norm}(z)).
\]

Thus the residual of a complex-unit-valued two-cocycle after dividing by its pointwise phase is a positive generalized cocycle on the one-point block space. For finite `G`, the existing positive-cocycle theorem makes this residual a coboundary, giving the required circle-valued representative. In the other direction, phase retracts coefficient inclusion, so injectivity needs no finiteness hypothesis. Finiteness appears only in the residual trivialization and hence in surjectivity and the final equivalence.

This is an algebraic group-cohomology argument for a finite discrete group. It does not identify the formal cochain complex with the sheaf-cohomology comparison invoked in the footnote of `Papers/2502.20257/main.tex:1931`. That distinction and the direct proof are recorded in `docs/paper-gaps/fbc25_circle_complex_units_cohomology.tex` and cited by the Blueprint.

## Verification

- `lake build TNLean.Algebra.CircleCohomology`
- `lake build TNLean.Algebra TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `texra-blueprint --root . paper-gaps check`
- hostile-environment standalone note build with `TEXINPUTS`, `BIBINPUTS`, and `BSTINPUTS` unset; both rendered pages were inspected and the log has no overflow, warning, or error
- proof-integrity scan, generated-import check, tactic-pattern scan, and `git diff --check`

The exact-head axiom audit reports `[propext, Classical.choice, Quot.sound]` for each of:

- `TNLean.Algebra.circleH2EquivComplexUnitsH2`;
- `TNLean.Algebra.ScalarCocycle.cohomologousTo_circlePhaseInclusion`;
- `TNLean.Algebra.ScalarCocycle.H2π_map_circlePhaseMathlibCocycle`.

Closes #7364.
