### PR TITLE
fix(build): serialize Lake commands with lockf

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -25,6 +25,7 @@ on:
       - 'scripts/test_lean_file_policies.py'
       - 'scripts/lake_build_hotspots.py'
       - 'scripts/test_lake_build_hotspots.py'
+      - 'scripts/lake_build_locked.sh'
       - 'scripts/seed_lake_build.sh'
       - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
@@ -93,6 +94,7 @@ on:
       - 'scripts/test_lean_file_policies.py'
       - 'scripts/lake_build_hotspots.py'
       - 'scripts/test_lake_build_hotspots.py'
+      - 'scripts/lake_build_locked.sh'
       - 'scripts/seed_lake_build.sh'
       - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
@@ -186,6 +188,7 @@ jobs:
               - 'scripts/test_lean_file_policies.py'
               - 'scripts/lake_build_hotspots.py'
               - 'scripts/test_lake_build_hotspots.py'
+              - 'scripts/lake_build_locked.sh'
               - 'scripts/seed_lake_build.sh'
               - 'scripts/test_seed_lake_build.sh'
               - 'docs/ci-automation.md'
@@ -409,6 +412,7 @@ jobs:
 
       - name: Check local cache-seeding shell syntax
         run: |
+          bash -n scripts/lake_build_locked.sh
           bash -n scripts/seed_lake_build.sh
           bash -n scripts/test_seed_lake_build.sh
 

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -22,8 +22,9 @@ regular, non-symlinked source `.lake`, `.lake/build`, and `.lake/packages`
 directories, and an absent target `.lake`. Git dependency checkouts must be
 clean and at the revisions recorded in `lake-manifest.json`; nested Lake build
 directories must not be symlinks; and Mathlib's prebuilt `Mathlib.olean` must
-already be present. If it is missing, run `lake exe cache get` in the source
-worktree before seeding. The seed command also runs `lake exe cache get` itself
+already be present. If it is missing, run
+`scripts/lake_build_locked.sh -- lake exe cache get` in the source worktree
+before seeding. The seed command also runs `lake exe cache get` itself
 to verify that the prebuilt artifacts match the current manifest revision.
 macOS `/bin/cp -c` creates independent writable files and fails instead of
 falling back to a full copy when APFS cloning is unavailable. The absolute path
@@ -38,23 +39,52 @@ validated dependency packages, including prebuilt Mathlib artifacts, and
 leaves the target without `.lake/build`. This prevents Lean from loading stale
 TNLean `.olean` files whose declarations no longer match the target source.
 
-At an identical commit, run the desired `lake build` or `lake env lean`
-command and Lake will reuse the full build. After a cross-commit seed, run
-`lake build` first so TNLean is rebuilt against the seeded dependencies. For a
-targeted check that applies the package `leanOptions`, including the Mathlib
-standard linter set, run `lake build TNLean.Path.To.File`. Linter diagnostics
+At an identical commit, run the desired command through the build wrapper and
+Lake will reuse the full build. After a cross-commit seed, run
+`scripts/lake_build_locked.sh` first so TNLean is rebuilt against the seeded
+dependencies. For a targeted check that applies the package `leanOptions`,
+including the Mathlib standard linter set, run
+`scripts/lake_build_locked.sh TNLean.Path.To.File`. Linter diagnostics
 appear only when Lake re-elaborates the module; an unchanged, already-built
 module produces no new diagnostics. A bare
 `lake env lean TNLean/Path/To/File.lean` remains useful for fast elaboration,
 but it does not apply those package options and is not a linter-bearing local
 verification.
 
+## Serialize local builds
+
+The seed command and the build wrapper use the standard macOS `lockf` utility
+with one lock file in Git's common directory. This serializes cooperating
+commands across TNLean worktrees without sharing writable package checkouts:
+
+```bash
+scripts/lake_build_locked.sh
+scripts/lake_build_locked.sh TNLean.Path.To.File
+scripts/lake_build_locked.sh -- lake build -q --log-level=info
+```
+
+Without `--`, the wrapper fetches the pinned prebuilt cache before building.
+The `--` form runs exactly the supplied command. Direct `lake` commands bypass
+the lock, so use the wrapper for local TNLean builds while another worktree may
+be warming or seeding its cache.
+
+To refresh the canonical cache and seed an issue worktree, use regular,
+self-contained package directories throughout:
+
+```bash
+git -C worktrees/hot-main fetch
+git -C worktrees/hot-main reset --hard origin/main
+(cd worktrees/hot-main && scripts/lake_build_locked.sh)
+scripts/seed_lake_build.sh worktrees/issue-N worktrees/hot-main --dry-run
+scripts/seed_lake_build.sh worktrees/issue-N worktrees/hot-main
+```
+
 ## Sort build timings
 
 Save a build log and list every job taking at least 25 seconds:
 
 ```bash
-lake build 2>&1 | tee /tmp/tnlean-build.log
+scripts/lake_build_locked.sh -- lake build 2>&1 | tee /tmp/tnlean-build.log
 python3 scripts/lake_build_hotspots.py /tmp/tnlean-build.log
 ```
 

--- a/scripts/lake_build_locked.sh
+++ b/scripts/lake_build_locked.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run a Lake build under the repository's standard macOS file lock.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/lake_build_locked.sh [LAKE_BUILD_ARGS...]
+  scripts/lake_build_locked.sh -- COMMAND [ARGS...]
+
+Without --, fetch the pinned prebuilt cache and run `lake build`. With --, run
+the given command under the same repository lock.
+EOF
+}
+
+canonical_dir() {
+  (CDPATH='' cd -- "$1" && pwd -P)
+}
+
+worktree_root() {
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null
+}
+
+if test "${1:-}" = "-h" || test "${1:-}" = "--help"; then
+  usage
+  exit 0
+fi
+
+test "$(/usr/bin/uname -s)" = "Darwin" || {
+  echo "lake-build-locked: requires macOS lockf" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(canonical_dir "$(dirname "${BASH_SOURCE[0]}")")"
+REPO_ROOT="$(worktree_root "$SCRIPT_DIR")" || {
+  echo "lake-build-locked: script is not inside a Git worktree" >&2
+  exit 1
+}
+CURRENT_ROOT="$(worktree_root "$PWD")" || {
+  echo "lake-build-locked: current directory is not inside a Git worktree" >&2
+  exit 1
+}
+test "$(canonical_dir "$REPO_ROOT")" = "$(canonical_dir "$CURRENT_ROOT")" || {
+  echo "lake-build-locked: run this wrapper from its TNLean worktree" >&2
+  exit 1
+}
+
+if test "${TNLEAN_LAKE_LOCK_HELD:-}" != "1"; then
+  COMMON_DIR="$(canonical_dir "$(
+    git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir
+  )")"
+  # Keep the locked file description in the final Lake process and its children.
+  exec 9<>"$COMMON_DIR/tnlean-lake-cache.lock"
+  /usr/bin/lockf 9
+  export TNLEAN_LAKE_LOCK_HELD=1
+fi
+
+if test "${1:-}" = "--"; then
+  shift
+  test "$#" -gt 0 || {
+    echo "lake-build-locked: missing command after --" >&2
+    exit 2
+  }
+  exec "$@"
+fi
+
+lake exe cache get
+test -f "$REPO_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" || {
+  echo "lake-build-locked: prebuilt Mathlib artifact is unavailable" >&2
+  exit 1
+}
+exec lake build "$@"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -140,6 +140,13 @@ RESERVATION_DIR=""
 RESERVATION_INODE=""
 DRY_RUN="false"
 
+if test "${TNLEAN_LAKE_LOCK_HELD:-}" != "1"; then
+  # Keep the locked file description through cache fetch and APFS cloning.
+  exec 9<>"$REPO_COMMON_DIR/tnlean-lake-cache.lock"
+  /usr/bin/lockf 9
+  export TNLEAN_LAKE_LOCK_HELD=1
+fi
+
 test "$#" -ge 1 || {
   usage
   exit 2

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -15,6 +15,7 @@ TARGET="$TEST_ROOT/target"
 MISMATCH_TARGET="$TEST_ROOT/mismatch-target"
 mkdir -p "$REPO/scripts"
 cp "$SCRIPT_SOURCE/seed_lake_build.sh" "$REPO/scripts/seed_lake_build.sh"
+cp "$SCRIPT_SOURCE/lake_build_locked.sh" "$REPO/scripts/lake_build_locked.sh"
 printf 'leanprover/lean4:v4.34.0-rc1\n' >"$REPO/lean-toolchain"
 printf '{}\n' >"$REPO/lake-manifest.json"
 printf 'name = "LakeSeedTest"\n' >"$REPO/lakefile.toml"
@@ -55,15 +56,75 @@ EOF
 chmod +x "$TEST_ROOT/bin/cp"
 cat >"$TEST_ROOT/bin/lake" <<'EOF'
 #!/usr/bin/env bash
-if test "$*" != "exe cache get"; then
-  echo "unexpected lake arguments: $*" >&2
-  exit 2
-fi
-printf 'called\n' >>"$LAKE_CALL_LOG"
+case "$*" in
+  "exe cache get"|build*)
+    printf '%s\n' "$*" >>"$LAKE_CALL_LOG"
+    ;;
+  *)
+    echo "unexpected lake arguments: $*" >&2
+    exit 2
+    ;;
+esac
 EOF
 chmod +x "$TEST_ROOT/bin/lake"
 export LAKE_CALL_LOG="$TEST_ROOT/lake-calls.log"
 PATH="$TEST_ROOT/bin:$PATH"
+
+LOCK_FILE="$REPO/.git/tnlean-lake-cache.lock"
+LOCK_READY="$TEST_ROOT/lock-ready"
+LOCK_CONTINUE="$TEST_ROOT/lock-continue"
+COMMAND_CONTINUE="$TEST_ROOT/command-continue"
+LOCKED_COMMAND_RAN="$TEST_ROOT/locked-command-ran"
+SECOND_COMMAND_RAN="$TEST_ROOT/second-command-ran"
+# shellcheck disable=SC2016
+/usr/bin/lockf -k "$LOCK_FILE" /bin/sh -c \
+  'printf ready >"$1"; while test ! -e "$2"; do sleep 0.1; done' \
+  sh "$LOCK_READY" "$LOCK_CONTINUE" &
+LOCK_HOLDER_PID="$!"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  test -e "$LOCK_READY" && break
+  sleep 0.1
+done
+test -e "$LOCK_READY"
+(
+  cd "$REPO"
+  # shellcheck disable=SC2016
+  scripts/lake_build_locked.sh -- /bin/sh -c \
+    'test -e /dev/fd/9; printf ran >"$1"; while test ! -e "$2"; do sleep 0.1; done' \
+    sh "$LOCKED_COMMAND_RAN" "$COMMAND_CONTINUE"
+) &
+LOCKED_COMMAND_PID="$!"
+sleep 0.2
+test ! -e "$LOCKED_COMMAND_RAN"
+printf continue >"$LOCK_CONTINUE"
+wait "$LOCK_HOLDER_PID"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  test -e "$LOCKED_COMMAND_RAN" && break
+  sleep 0.1
+done
+test "$(cat "$LOCKED_COMMAND_RAN")" = "ran"
+(
+  cd "$REPO"
+  # shellcheck disable=SC2016
+  scripts/lake_build_locked.sh -- /bin/sh -c \
+    'printf second >"$1"' sh "$SECOND_COMMAND_RAN"
+) &
+SECOND_COMMAND_PID="$!"
+sleep 0.2
+test ! -e "$SECOND_COMMAND_RAN"
+printf continue >"$COMMAND_CONTINUE"
+wait "$LOCKED_COMMAND_PID"
+wait "$SECOND_COMMAND_PID"
+test "$(cat "$SECOND_COMMAND_RAN")" = "second"
+test -f "$LOCK_FILE"
+(
+  cd "$REPO"
+  scripts/lake_build_locked.sh Example.Target
+)
+test "$(sed -n '1p' "$LAKE_CALL_LOG")" = "exe cache get"
+test "$(sed -n '2p' "$LAKE_CALL_LOG")" = "build Example.Target"
+test "$(wc -l <"$LAKE_CALL_LOG" | tr -d ' ')" -eq 2
+find "$LAKE_CALL_LOG" -delete
 
 mv "$REPO/.lake" "$REPO/.lake.real"
 ln -s .lake.real "$REPO/.lake"


### PR DESCRIPTION
## What changed

- serialize cooperating cache seeding and local Lake builds with the standard macOS `/usr/bin/lockf` utility
- keep the locked file descriptor in the final command and its descendants, so the lock follows the actual cache-mutating process without a custom lock state machine
- add `scripts/lake_build_locked.sh`; its default path fetches the pinned prebuilt cache, verifies `Mathlib.olean`, and runs `lake build`
- keep the existing self-contained package, manifest revision, APFS clone, and atomic target-publication checks in `seed_lake_build.sh`
- test contention, inherited lock lifetime, and cache-fetch-before-build ordering
- document the exact `hot-main` refresh and issue-worktree seed sequence
- include the wrapper in CI path filters and shell syntax checks

Direct raw `lake` commands bypass this cooperative lock. Whole-tree mutation fingerprinting from the discarded implementation is intentionally not retained after maintainer feedback that the earlier design was overengineered.

## Statement-integrity audit

No Lean source file, declaration, theorem statement, proof, import, Blueprint entry, or paper-gap record changed. The diff is limited to five build-tooling files.

## Validation

```bash
bash -n scripts/lake_build_locked.sh scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh
shellcheck scripts/lake_build_locked.sh scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh
python3 scripts/test_lake_build_hotspots.py
scripts/test_seed_lake_build.sh
git diff --check origin/main...HEAD
```

All commands pass at `a83caad88`; the integration suite reports `Lake build seed integration test passed`. An independent exact-head review also reproduced the fd-held lock and SIGKILL behavior and approved the simplified implementation.

Advances #7386
Tracks #4866
