### PR TITLE
feat(MPU): formalize finite-group operator representations

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -237,52 +237,6 @@ Combined with the containment
 This bypasses the blocked-irreducibility gap entirely for the Kraus.IsNormal conclusion.
 -/
 
-/-- The word span at `N + k` contains the word span at `k` when `Kraus.wordSpan A N = ⊤`.
-
-Proof: `Kraus.wordSpan A N * Kraus.wordSpan A k ≤ Kraus.wordSpan A (N + k)`, and
-`1 ∈ Kraus.wordSpan A N = ⊤` gives `M = 1 * M ∈ Kraus.wordSpan A N * Kraus.wordSpan A k`
-for any `M ∈ Kraus.wordSpan A k`. -/
-private theorem wordSpan_le_wordSpan_add_of_wordSpan_eq_top
-    (A : MPSTensor d D) {N : ℕ} (hN : Kraus.wordSpan A N = ⊤) (k : ℕ) :
-    Kraus.wordSpan A k ≤ Kraus.wordSpan A (N + k) := by
-  intro M hM
-  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Kraus.wordSpan A N := by
-    rw [hN]; exact Submodule.mem_top
-  have hprod : (1 : Matrix (Fin D) (Fin D) ℂ) * M ∈ Kraus.wordSpan A N * Kraus.wordSpan A k :=
-    Submodule.mul_mem_mul h1 hM
-  rw [one_mul] at hprod
-  exact Kraus.wordSpan_mul_le A N k hprod
-
-/-- The word span at any positive multiple of `N` is `⊤` when `Kraus.wordSpan A N = ⊤`.
-
-Proof by induction: `Kraus.wordSpan A ((m+1)*N) ⊇ Kraus.wordSpan A (m*N)` via the preceding lemma
-(with `k = m*N`). -/
-private theorem wordSpan_mul_eq_top_of_wordSpan_eq_top
-    (A : MPSTensor d D) {N : ℕ} (hN : Kraus.wordSpan A N = ⊤) (m : ℕ) (hm : 0 < m) :
-    Kraus.wordSpan A (m * N) = ⊤ := by
-  induction m with
-  | zero => exact absurd rfl (Nat.ne_of_gt hm)
-  | succ n ih =>
-    by_cases hn : n = 0
-    · simp [hn, hN]
-    · have hn_pos : 0 < n := Nat.pos_of_ne_zero hn
-      have hprev := ih hn_pos
-      have hle : Kraus.wordSpan A (n * N) ≤ Kraus.wordSpan A ((n + 1) * N) := by
-        calc Kraus.wordSpan A (n * N)
-            ≤ Kraus.wordSpan A (N + n * N) :=
-              wordSpan_le_wordSpan_add_of_wordSpan_eq_top A hN (n * N)
-          _ = Kraus.wordSpan A ((n + 1) * N) := by ring_nf
-      exact eq_top_iff.mpr (hprev ▸ hle)
-
-/-- Fixed-length injectivity persists at positive multiples of the length. -/
-theorem isNBlkInjective_mul_of_isNBlkInjective
-    (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m) (hN : Kraus.IsNBlkInjective A N) :
-    Kraus.IsNBlkInjective A (m * N) := by
-  have hwordN : Kraus.wordSpan A N = ⊤ :=
-    (wordSpan_eq_top_iff_isNBlkInjective A N).mpr hN
-  exact (wordSpan_eq_top_iff_isNBlkInjective A (m * N)).mp
-    (wordSpan_mul_eq_top_of_wordSpan_eq_top A hwordN m hm)
-
 /-- One-site injectivity of a blocked tensor persists after a positive further
 blocking, read back as direct blocking of the original tensor. -/
 theorem blockTensor_isInjective_mul_of_blockTensor_isInjective
@@ -349,7 +303,7 @@ theorem isNormal_blockTensor_of_isNormal
   have hwordN : Kraus.wordSpan A N = ⊤ :=
     (wordSpan_eq_top_iff_isNBlkInjective A N).mpr hNblk
   have hwordNP : Kraus.wordSpan A (P * N) = ⊤ :=
-    wordSpan_mul_eq_top_of_wordSpan_eq_top A hwordN (N := N) (m := P) hP
+    Kraus.wordSpan_top_of_mul A hwordN P hP
   -- Kraus.wordSpan A (N * P) ≤ Kraus.wordSpan (blockTensor A P) N
   have hle : Kraus.wordSpan A (N * P) ≤
       Kraus.wordSpan (blockTensor (d := d) (D := D) A P) N :=

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -81,6 +81,8 @@ lemma isNBlkInjective_iff_blockTensor_isInjective
 theorem isNBlkInjective_mul_of_isNBlkInjective
     (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m) (hN : Kraus.IsNBlkInjective A N) :
     Kraus.IsNBlkInjective A (m * N) := by
+  -- Use word-span factorization here rather than importing the higher-level
+  -- Wielandt theorem `Kraus.wordSpan_top_of_mul` into basic blocking.
   induction m with
   | zero => omega
   | succ m ih =>

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
 import QICLean.Kraus.Blocking
+import QICLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
 
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.EquivFin
@@ -76,6 +77,12 @@ lemma isNBlkInjective_iff_blockTensor_isInjective
     (A : Fin d → Matrix (Fin D) (Fin D) ℂ) (N : ℕ) :
     Kraus.IsNBlkInjective A N ↔ Kraus.IsInjective (blockTensor A N) := by
   exact Kraus.isNBlkInjective_iff_blockTensor_isInjective A N
+
+/-- Fixed-length injectivity persists at positive multiples of the length. -/
+theorem isNBlkInjective_mul_of_isNBlkInjective
+    (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m) (hN : Kraus.IsNBlkInjective A N) :
+    Kraus.IsNBlkInjective A (m * N) := by
+  exact Kraus.wordSpan_top_of_mul A hN m hm
 
 /-- Flatten a word in blocked indices into a word in the original alphabet. -/
 noncomputable abbrev flattenBlockedWord (d L : ℕ) :

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
 import QICLean.Kraus.Blocking
-import QICLean.Kraus.Wielandt.SpanGrowth.VectorToMatrixSpan
 
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.EquivFin
@@ -82,7 +81,25 @@ lemma isNBlkInjective_iff_blockTensor_isInjective
 theorem isNBlkInjective_mul_of_isNBlkInjective
     (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m) (hN : Kraus.IsNBlkInjective A N) :
     Kraus.IsNBlkInjective A (m * N) := by
-  exact Kraus.wordSpan_top_of_mul A hN m hm
+  induction m with
+  | zero => omega
+  | succ m ih =>
+      by_cases hm0 : m = 0
+      · simpa [hm0] using hN
+      · have hm_pos : 0 < m := Nat.pos_of_ne_zero hm0
+        have hih : Kraus.wordSpan A (m * N) = ⊤ := ih hm_pos
+        rw [Nat.succ_mul]
+        change Kraus.wordSpan A (m * N + N) = ⊤
+        rw [Kraus.wordSpan_add, hih, hN]
+        apply eq_top_iff.mpr
+        intro M _
+        simpa using
+          (Submodule.mul_mem_mul
+            (show M ∈ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
+              Submodule.mem_top)
+            (show (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+                (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
+              Submodule.mem_top))
 
 /-- Flatten a word in blocked indices into a word in the original alphabet. -/
 noncomputable abbrev flattenBlockedWord (d L : ℕ) :

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -18,6 +18,7 @@ import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
 import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.FiniteChainConjugation
+import TNLean.MPS.MPU.GroupRepresentation
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm

--- a/TNLean/MPS/MPU/GroupRepresentation.lean
+++ b/TNLean/MPS/MPU/GroupRepresentation.lean
@@ -83,6 +83,7 @@ namespace GroupFamily
 
 variable {G : Type u} {d : ℕ}
 
+/-- Every bond dimension in a group family is nonzero. -/
 instance (F : GroupFamily G d) (g : G) : NeZero (F.bondDim g) :=
   ⟨Nat.ne_of_gt (F.bondDim_pos g)⟩
 
@@ -99,15 +100,16 @@ structure IsRepresentation [Group G] (F : GroupFamily G d) : Prop where
     mpo (F.tensor g) N * mpo (F.tensor h) N = mpo (F.tensor (g * h)) N
 
 /-- The multiplication law as exact positive-length equality of doubled-index
-matrix product vectors.  The orientation exposes the product tensor on the left
-and the chosen tensor for `g * h` on the right.
+matrix product vectors. The chosen injective tensor for `g * h` is placed first,
+matching the orientation used by the later rectangular reduction interface.
 
 Source: arXiv:2502.20257, lines 1403--1407. -/
 theorem IsRepresentation.sameMPV₂Pos_mulTensor [Group G]
     (F : GroupFamily G d) (hF : F.IsRepresentation) (g h : G) :
     MPSTensor.SameMPV₂Pos
-      (MPOTensor.mulTensor (F.tensor g) (F.tensor h)).toMPSTensor
-      (F.tensor (g * h)).toMPSTensor := by
+      (F.tensor (g * h)).toMPSTensor
+      (MPOTensor.mulTensor (F.tensor g) (F.tensor h)).toMPSTensor := by
+  apply MPSTensor.SameMPV₂Pos.symm
   intro N hN ρ
   let σ : Fin N → Fin d := fun n ↦ (ρ n).divNat
   let τ : Fin N → Fin d := fun n ↦ (ρ n).modNat
@@ -138,19 +140,21 @@ private theorem injective_blockTensor (F : GroupFamily G d) (g : G)
     (F.tensor g).toMPSTensor L).1 (by simpa using hMul)
 
 private theorem operator_one_block [Group G] (F : GroupFamily G d)
-    (hF : F.IsRepresentation) {L : ℕ} (hL : 0 < L) (N : ℕ) (hN : 0 < N) :
+    (hOne : ∀ N, 0 < N → mpo (F.tensor 1) N = 1)
+    {L : ℕ} (hL : 0 < L) (N : ℕ) (hN : 0 < N) :
     mpo ((F.block L).tensor 1) N = 1 := by
   simp only [block]
   rw [mpo_blockTensor_eq_reindex,
-    hF.operator_one (N * L) (Nat.mul_pos hN hL)]
+    hOne (N * L) (Nat.mul_pos hN hL)]
   change (Matrix.reindexLinearEquiv ℂ ℂ
     (MPSTensor.blockedConfigEquiv d N L).symm
     (MPSTensor.blockedConfigEquiv d N L).symm) 1 = 1
   exact Matrix.reindexLinearEquiv_one ℂ ℂ _
 
 private theorem operator_mul_block [Group G] (F : GroupFamily G d)
-    (hF : F.IsRepresentation) {L : ℕ} (hL : 0 < L)
-    (g h : G) (N : ℕ) (hN : 0 < N) :
+    (hMul : ∀ g h N, 0 < N →
+      mpo (F.tensor g) N * mpo (F.tensor h) N = mpo (F.tensor (g * h)) N)
+    {L : ℕ} (hL : 0 < L) (g h : G) (N : ℕ) (hN : 0 < N) :
     mpo ((F.block L).tensor g) N * mpo ((F.block L).tensor h) N =
       mpo ((F.block L).tensor (g * h)) N := by
   simp only [block]
@@ -163,7 +167,7 @@ private theorem operator_mul_block [Group G] (F : GroupFamily G d)
           (mpo (F.tensor h) (N * L)) =
       (Matrix.reindexAlgEquiv ℂ ℂ (MPSTensor.blockedConfigEquiv d N L).symm)
         (mpo (F.tensor (g * h)) (N * L))
-  rw [← map_mul, hF.operator_mul g h (N * L) (Nat.mul_pos hN hL)]
+  rw [← map_mul, hMul g h (N * L) (Nat.mul_pos hN hL)]
 
 /-- Positive physical blocking preserves exact representation laws, unitarity,
 simplicity, and injectivity. -/
@@ -173,8 +177,8 @@ theorem IsRepresentation.block [Group G] (F : GroupFamily G d)
   isMPUPos g := (hF.isMPUPos g).blockTensor L hL
   isSimple g := (hF.isSimple g).blockTensor L hL
   isInjective g := injective_blockTensor F g hL (hF.isInjective g)
-  operator_one N hN := operator_one_block F hF hL N hN
-  operator_mul g h N hN := operator_mul_block F hF hL g h N hN
+  operator_one N hN := operator_one_block F hF.operator_one hL N hN
+  operator_mul g h N hN := operator_mul_block F hF.operator_mul hL g h N hN
 
 /-- An exact positive-length MPU representation before simplicity is imposed. -/
 structure IsRawRepresentation [Group G] (F : GroupFamily G d) : Prop where
@@ -217,31 +221,10 @@ theorem IsRawRepresentation.block_common [Group G] [Fintype G] [NeZero d]
       ((hF.isMPUPos g).isMPU.blockTensor_pow_four_isMPUSimple)
   isInjective g :=
     injective_blockTensor F g F.commonSimpleLength_pos (hF.isInjective g)
-  operator_one N hN := by
-    simp only [block]
-    rw [mpo_blockTensor_eq_reindex,
-      hF.operator_one (N * F.commonSimpleLength)
-        (Nat.mul_pos hN F.commonSimpleLength_pos)]
-    change (Matrix.reindexLinearEquiv ℂ ℂ
-      (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm
-      (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm) 1 = 1
-    exact Matrix.reindexLinearEquiv_one ℂ ℂ _
-  operator_mul g h N hN := by
-    simp only [block]
-    rw [mpo_blockTensor_eq_reindex, mpo_blockTensor_eq_reindex,
-      mpo_blockTensor_eq_reindex]
-    change
-      (Matrix.reindexAlgEquiv ℂ ℂ
-          (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
-            (mpo (F.tensor g) (N * F.commonSimpleLength)) *
-        (Matrix.reindexAlgEquiv ℂ ℂ
-          (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
-            (mpo (F.tensor h) (N * F.commonSimpleLength)) =
-      (Matrix.reindexAlgEquiv ℂ ℂ
-        (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
-          (mpo (F.tensor (g * h)) (N * F.commonSimpleLength))
-    rw [← map_mul, hF.operator_mul g h (N * F.commonSimpleLength)
-      (Nat.mul_pos hN F.commonSimpleLength_pos)]
+  operator_one N hN :=
+    operator_one_block F hF.operator_one F.commonSimpleLength_pos N hN
+  operator_mul g h N hN :=
+    operator_mul_block F hF.operator_mul F.commonSimpleLength_pos g h N hN
 
 /-- After the explicit common simplicity block, every further positive physical
 blocking remains an exact simple injective MPU representation. -/

--- a/TNLean/MPS/MPU/GroupRepresentation.lean
+++ b/TNLean/MPS/MPU/GroupRepresentation.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SimpleBlocking
+
+/-!
+# Matrix product unitary group representations
+
+This file formalizes the tensor family used in the discussion of matrix product
+unitary group representations in arXiv:2502.20257.  Bond dimensions may depend
+on the group element.  All operator identities and unitarity statements use
+positive chain lengths, matching the paper's convention that the represented
+operators act on nonempty chains.
+
+## Main definitions
+
+* `MPOTensor.IsMPUPos`: unitarity on every positive chain length.
+* `MPOTensor.GroupFamily`: a group-indexed family of positive-bond-dimension MPO tensors.
+* `MPOTensor.GroupFamily.IsRepresentation`: an exact positive-length operator
+  representation whose tensors are simple and injective.
+* `MPOTensor.GroupFamily.block`: simultaneous positive physical blocking.
+
+## Main results
+
+* `MPOTensor.IsMPUPos.isMPU`: the positive-length convention implies the
+  established `IsMPU` predicate.
+* `MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_mulTensor`: the tensor
+  product representing multiplication generates exactly the same positive-length
+  MPV family as the tensor indexed by the product.
+* `MPOTensor.GroupFamily.IsRepresentation.block`: positive blocking preserves
+  the representation, simplicity, and injectivity.
+* `MPOTensor.GroupFamily.IsRawRepresentation.block_common`: for a finite group,
+  one explicit positive block makes every tensor in an injective raw
+  representation simple.
+
+Source: arXiv:2502.20257, Section "MPU group representations", beginning at
+lines 1403--1407.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+universe u
+
+variable {d D : ℕ}
+
+/-- The paper-facing MPU convention: the periodic MPO is unitary on every
+nonempty chain.
+
+Source: arXiv:2502.20257, lines 198--209. -/
+def IsMPUPos (U : MPOTensor d D) : Prop :=
+  ∀ N : ℕ, 0 < N → mpo U N ∈ Matrix.unitaryGroup (Fin N → Fin d) ℂ
+
+namespace IsMPUPos
+
+/-- Positive-length MPU unitarity implies the established all-`N > 1`
+predicate. -/
+theorem isMPU {U : MPOTensor d D} (hU : IsMPUPos U) : IsMPU U :=
+  fun N hN ↦ hU N (by omega)
+
+/-- Positive physical blocking preserves unitarity on every nonempty chain. -/
+theorem blockTensor {U : MPOTensor d D} (hU : IsMPUPos U)
+    (L : ℕ) (hL : 0 < L) : IsMPUPos (MPOTensor.blockTensor U L) := by
+  intro N hN
+  rw [mpo_blockTensor_eq_reindex U L N]
+  apply Matrix.reindex_mem_unitaryGroup
+    (MPSTensor.blockedConfigEquiv d N L).symm (mpo U (N * L))
+  exact hU (N * L) (Nat.mul_pos hN hL)
+
+end IsMPUPos
+
+/-- A group-indexed MPO tensor family with a positive, element-dependent bond
+dimension. -/
+structure GroupFamily (G : Type u) (d : ℕ) where
+  bondDim : G → ℕ
+  bondDim_pos : ∀ g, 0 < bondDim g
+  tensor : (g : G) → MPOTensor d (bondDim g)
+
+namespace GroupFamily
+
+variable {G : Type u} {d : ℕ}
+
+instance (F : GroupFamily G d) (g : G) : NeZero (F.bondDim g) :=
+  ⟨Nat.ne_of_gt (F.bondDim_pos g)⟩
+
+/-- An exact positive-length MPU representation by simple injective tensors.
+The operator identities are literal matrix equalities, with no scalar freedom.
+
+Source: arXiv:2502.20257, lines 1403--1407. -/
+structure IsRepresentation [Group G] (F : GroupFamily G d) : Prop where
+  isMPUPos : ∀ g, IsMPUPos (F.tensor g)
+  isSimple : ∀ g, IsMPUSimple (F.tensor g)
+  isInjective : ∀ g, Kraus.IsInjective (F.tensor g).toMPSTensor
+  operator_one : ∀ N, 0 < N → mpo (F.tensor 1) N = 1
+  operator_mul : ∀ g h N, 0 < N →
+    mpo (F.tensor g) N * mpo (F.tensor h) N = mpo (F.tensor (g * h)) N
+
+/-- The multiplication law as exact positive-length equality of doubled-index
+matrix product vectors.  The orientation exposes the product tensor on the left
+and the chosen tensor for `g * h` on the right.
+
+Source: arXiv:2502.20257, lines 1403--1407. -/
+theorem IsRepresentation.sameMPV₂Pos_mulTensor [Group G]
+    (F : GroupFamily G d) (hF : F.IsRepresentation) (g h : G) :
+    MPSTensor.SameMPV₂Pos
+      (MPOTensor.mulTensor (F.tensor g) (F.tensor h)).toMPSTensor
+      (F.tensor (g * h)).toMPSTensor := by
+  intro N hN ρ
+  let σ : Fin N → Fin d := fun n ↦ (ρ n).divNat
+  let τ : Fin N → Fin d := fun n ↦ (ρ n).modNat
+  have hρ : (fun n ↦ finProdFinEquiv (σ n, τ n)) = ρ := by
+    funext n
+    exact finProdFinEquiv.apply_symm_apply (ρ n)
+  rw [← hρ, MPSTensor.mpv_toMPSTensor_pairConfig,
+    MPSTensor.mpv_toMPSTensor_pairConfig, mpo_mulTensor,
+    hF.operator_mul g h N hN]
+
+/-- Simultaneously block every tensor in a group family by `L` physical sites. -/
+noncomputable def block (F : GroupFamily G d) (L : ℕ) :
+    GroupFamily G (MPSTensor.blockPhysDim d L) where
+  bondDim := F.bondDim
+  bondDim_pos := F.bondDim_pos
+  tensor g := MPOTensor.blockTensor (F.tensor g) L
+
+private theorem injective_blockTensor (F : GroupFamily G d) (g : G)
+    {L : ℕ} (hL : 0 < L) (h : Kraus.IsInjective (F.tensor g).toMPSTensor) :
+    Kraus.IsInjective ((F.block L).tensor g).toMPSTensor := by
+  rw [block, isInjective_toMPSTensor_blockTensor_iff]
+  have hOne : Kraus.IsNBlkInjective (F.tensor g).toMPSTensor 1 :=
+    Kraus.isNBlkInjective_one_of_isInjective h
+  have hMul : Kraus.IsNBlkInjective (F.tensor g).toMPSTensor (L * 1) :=
+    MPSTensor.isNBlkInjective_mul_of_isNBlkInjective
+      (F.tensor g).toMPSTensor hL hOne
+  exact (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective
+    (F.tensor g).toMPSTensor L).1 (by simpa using hMul)
+
+private theorem operator_one_block [Group G] (F : GroupFamily G d)
+    (hF : F.IsRepresentation) {L : ℕ} (hL : 0 < L) (N : ℕ) (hN : 0 < N) :
+    mpo ((F.block L).tensor 1) N = 1 := by
+  simp only [block]
+  rw [mpo_blockTensor_eq_reindex,
+    hF.operator_one (N * L) (Nat.mul_pos hN hL)]
+  change (Matrix.reindexLinearEquiv ℂ ℂ
+    (MPSTensor.blockedConfigEquiv d N L).symm
+    (MPSTensor.blockedConfigEquiv d N L).symm) 1 = 1
+  exact Matrix.reindexLinearEquiv_one ℂ ℂ _
+
+private theorem operator_mul_block [Group G] (F : GroupFamily G d)
+    (hF : F.IsRepresentation) {L : ℕ} (hL : 0 < L)
+    (g h : G) (N : ℕ) (hN : 0 < N) :
+    mpo ((F.block L).tensor g) N * mpo ((F.block L).tensor h) N =
+      mpo ((F.block L).tensor (g * h)) N := by
+  simp only [block]
+  rw [mpo_blockTensor_eq_reindex, mpo_blockTensor_eq_reindex,
+    mpo_blockTensor_eq_reindex]
+  change
+    (Matrix.reindexAlgEquiv ℂ ℂ (MPSTensor.blockedConfigEquiv d N L).symm)
+          (mpo (F.tensor g) (N * L)) *
+        (Matrix.reindexAlgEquiv ℂ ℂ (MPSTensor.blockedConfigEquiv d N L).symm)
+          (mpo (F.tensor h) (N * L)) =
+      (Matrix.reindexAlgEquiv ℂ ℂ (MPSTensor.blockedConfigEquiv d N L).symm)
+        (mpo (F.tensor (g * h)) (N * L))
+  rw [← map_mul, hF.operator_mul g h (N * L) (Nat.mul_pos hN hL)]
+
+/-- Positive physical blocking preserves exact representation laws, unitarity,
+simplicity, and injectivity. -/
+theorem IsRepresentation.block [Group G] (F : GroupFamily G d)
+    (hF : F.IsRepresentation) (L : ℕ) (hL : 0 < L) :
+    (F.block L).IsRepresentation where
+  isMPUPos g := (hF.isMPUPos g).blockTensor L hL
+  isSimple g := (hF.isSimple g).blockTensor L hL
+  isInjective g := injective_blockTensor F g hL (hF.isInjective g)
+  operator_one N hN := operator_one_block F hF hL N hN
+  operator_mul g h N hN := operator_mul_block F hF hL g h N hN
+
+/-- An exact positive-length MPU representation before simplicity is imposed. -/
+structure IsRawRepresentation [Group G] (F : GroupFamily G d) : Prop where
+  isMPUPos : ∀ g, IsMPUPos (F.tensor g)
+  isInjective : ∀ g, Kraus.IsInjective (F.tensor g).toMPSTensor
+  operator_one : ∀ N, 0 < N → mpo (F.tensor 1) N = 1
+  operator_mul : ∀ g h N, 0 < N →
+    mpo (F.tensor g) N * mpo (F.tensor h) N = mpo (F.tensor (g * h)) N
+
+/-- An explicit common blocking length for a finite group-indexed family. -/
+noncomputable def commonSimpleLength [Fintype G] (F : GroupFamily G d) : ℕ :=
+  ∑ g : G, F.bondDim g ^ 4
+
+private theorem bond_pow_le_commonSimpleLength [Fintype G]
+    (F : GroupFamily G d) (g : G) :
+    F.bondDim g ^ 4 ≤ F.commonSimpleLength := by
+  classical
+  simpa only [commonSimpleLength] using
+    (Finset.single_le_sum (s := Finset.univ)
+      (f := fun x : G ↦ F.bondDim x ^ 4)
+      (fun _ _ ↦ Nat.zero_le _) (Finset.mem_univ g))
+
+/-- The explicit common simplicity length is positive for a finite group. -/
+theorem commonSimpleLength_pos [Group G] [Fintype G] (F : GroupFamily G d) :
+    0 < F.commonSimpleLength := by
+  classical
+  apply Finset.sum_pos'
+  · exact fun _ _ ↦ Nat.zero_le _
+  · exact ⟨1, Finset.mem_univ _, pow_pos (F.bondDim_pos 1) 4⟩
+
+/-- For a finite group, blocking an injective raw representation at the explicit
+positive length `∑ g, (bondDim g)^4` makes every representing tensor simple. -/
+theorem IsRawRepresentation.block_common [Group G] [Fintype G] [NeZero d]
+    (F : GroupFamily G d) (hF : F.IsRawRepresentation) :
+    (F.block F.commonSimpleLength).IsRepresentation where
+  isMPUPos g := (hF.isMPUPos g).blockTensor _ F.commonSimpleLength_pos
+  isSimple g :=
+    (hF.isMPUPos g).isMPU.blockTensor_isMPUSimple_of_le
+      (pow_pos (F.bondDim_pos g) 4) (F.bond_pow_le_commonSimpleLength g)
+      ((hF.isMPUPos g).isMPU.blockTensor_pow_four_isMPUSimple)
+  isInjective g :=
+    injective_blockTensor F g F.commonSimpleLength_pos (hF.isInjective g)
+  operator_one N hN := by
+    simp only [block]
+    rw [mpo_blockTensor_eq_reindex,
+      hF.operator_one (N * F.commonSimpleLength)
+        (Nat.mul_pos hN F.commonSimpleLength_pos)]
+    change (Matrix.reindexLinearEquiv ℂ ℂ
+      (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm
+      (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm) 1 = 1
+    exact Matrix.reindexLinearEquiv_one ℂ ℂ _
+  operator_mul g h N hN := by
+    simp only [block]
+    rw [mpo_blockTensor_eq_reindex, mpo_blockTensor_eq_reindex,
+      mpo_blockTensor_eq_reindex]
+    change
+      (Matrix.reindexAlgEquiv ℂ ℂ
+          (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
+            (mpo (F.tensor g) (N * F.commonSimpleLength)) *
+        (Matrix.reindexAlgEquiv ℂ ℂ
+          (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
+            (mpo (F.tensor h) (N * F.commonSimpleLength)) =
+      (Matrix.reindexAlgEquiv ℂ ℂ
+        (MPSTensor.blockedConfigEquiv d N F.commonSimpleLength).symm)
+          (mpo (F.tensor (g * h)) (N * F.commonSimpleLength))
+    rw [← map_mul, hF.operator_mul g h (N * F.commonSimpleLength)
+      (Nat.mul_pos hN F.commonSimpleLength_pos)]
+
+/-- After the explicit common simplicity block, every further positive physical
+blocking remains an exact simple injective MPU representation. -/
+theorem IsRawRepresentation.block_common_then_block
+    [Group G] [Fintype G] [NeZero d]
+    (F : GroupFamily G d) (hF : F.IsRawRepresentation)
+    (L : ℕ) (hL : 0 < L) :
+    ((F.block F.commonSimpleLength).block L).IsRepresentation :=
+  (hF.block_common F).block (F.block F.commonSimpleLength) L hL
+
+end GroupFamily
+
+end MPOTensor

--- a/TNLean/MPS/MPU/GroupRepresentation.lean
+++ b/TNLean/MPS/MPU/GroupRepresentation.lean
@@ -90,7 +90,10 @@ instance (F : GroupFamily G d) (g : G) : NeZero (F.bondDim g) :=
 /-- An exact positive-length MPU representation by simple injective tensors.
 The operator identities are literal matrix equalities, with no scalar freedom.
 
-Source: arXiv:2502.20257, lines 1403--1407. -/
+The multiplication law comes from arXiv:2502.20257, lines 1403--1407. The
+identity law is a standard consequence retained explicitly in this bounded
+positive-length interface; it is compatible with the stronger bond-one identity
+tensor convention at lines 1933--1937. -/
 structure IsRepresentation [Group G] (F : GroupFamily G d) : Prop where
   isMPUPos : ∀ g, IsMPUPos (F.tensor g)
   isSimple : ∀ g, IsMPUSimple (F.tensor g)

--- a/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
+++ b/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
@@ -38,8 +38,13 @@ Theorem~\ref{thm:tp_primitive_irred_block_injective}.
 
 \begin{proof}
     \leanok
-    Split every word of length $m+n$ after its first $m$ letters. Conversely,
-    concatenate a word of length $m$ with one of length $n$.
+    For words $w_1,w_2$ of lengths $m,n$, concatenation satisfies
+    \begin{align}
+        A^{w_1w_2} & =A^{w_1}A^{w_2}.
+        \notag
+    \end{align}
+    Split each word of length $m+n$ after its first $m$ letters for one
+    inclusion, and concatenate words of lengths $m$ and $n$ for the other.
 \end{proof}
 
 \begin{lemma}[Zero-length word span]

--- a/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
+++ b/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
@@ -33,17 +33,13 @@ Theorem~\ref{thm:tp_primitive_irred_block_injective}.
     \lean{Kraus.wordSpan_add}
     \leanok
     \uses{def:word_span}
-    For all $m,n\geq 0$,
-    \[
-        S_{m+n}(A)=S_m(A)S_n(A).
-    \]
+    For all $m,n\geq 0$, one has $S_{m+n}(A)=S_m(A)S_n(A)$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:word_span_mul}
-    Split every word of length $m+n$ after its first $m$ letters. The reverse
-    inclusion is Lemma~\ref{lem:word_span_mul}.
+    Split every word of length $m+n$ after its first $m$ letters. Conversely,
+    concatenate a word of length $m$ with one of length $n$.
 \end{proof}
 
 \begin{lemma}[Zero-length word span]

--- a/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
+++ b/blueprint/src/appendix/ft_mps/ch08_wielandt.tex
@@ -28,6 +28,24 @@ Theorem~\ref{thm:tp_primitive_irred_block_injective}.
     $|w_1w_2|=m+n$.
 \end{proof}
 
+\begin{theorem}[Exact factorization of word spans]
+    \label{thm:word_span_add_exact}
+    \lean{Kraus.wordSpan_add}
+    \leanok
+    \uses{def:word_span}
+    For all $m,n\geq 0$,
+    \[
+        S_{m+n}(A)=S_m(A)S_n(A).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:word_span_mul}
+    Split every word of length $m+n$ after its first $m$ letters. The reverse
+    inclusion is Lemma~\ref{lem:word_span_mul}.
+\end{proof}
+
 \begin{lemma}[Zero-length word span]
     \label{lem:wordspan_zero_ne_top}
     \lean{Kraus.wordSpan_zero_ne_top_of_two_le}

--- a/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
+++ b/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
@@ -163,19 +163,19 @@ construction is in Section~\ref{sec:app_wielandt_blocking_support}.
     $S_{L+k}(A)=\MN{D}$.
 \end{proof}
 
-\begin{lemma}[Exact block injectivity at positive multiples]
-    \label{lem:exact_block_injectivity_positive_multiple}
+\begin{theorem}[Exact block injectivity at positive multiples]
+    \label{thm:exact_block_injectivity_positive_multiple}
     \lean{MPSTensor.isNBlkInjective_mul_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective}
     If $A$ is $N$-block injective and $m>0$, then $A$ is
     $(mN)$-block injective.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:l_blk_injective}
-    Induct on $m$. Concatenation gives
+    \uses{def:l_blk_injective, thm:word_span_add_exact}
+    Induct on $m$. Theorem~\ref{thm:word_span_add_exact} gives
     $S_{mN+N}(A)=S_{mN}(A)S_N(A)$, and the product of the full matrix
     algebra with itself is again the full matrix algebra.
 \end{proof}
@@ -186,14 +186,14 @@ construction is in Section~\ref{sec:app_wielandt_blocking_support}.
         exists_common_isNBlkInjective_of_isNormal_leftCanonical}
     \leanok
     \uses{def:l_blk_injective, def:normal, thm:bounded_injective_blocking_normal_left_canonical,
-        lem:exact_block_injectivity_positive_multiple}
+        thm:exact_block_injectivity_positive_multiple}
     Let $(A_j)_{j=1}^g$ be a finite family of positive-bond-dimension,
     left-canonical normal tensors. There is a positive integer $L$ such that
     every $A_j$ is $L$-block injective.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:exact_block_injectivity_positive_multiple}
+    \uses{thm:exact_block_injectivity_positive_multiple}
     Apply
     Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical} to each
     block. The product of the finitely many positive lengths is a common

--- a/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
+++ b/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
@@ -163,18 +163,37 @@ construction is in Section~\ref{sec:app_wielandt_blocking_support}.
     $S_{L+k}(A)=\MN{D}$.
 \end{proof}
 
+\begin{lemma}[Exact block injectivity at positive multiples]
+    \label{lem:exact_block_injectivity_positive_multiple}
+    \lean{MPSTensor.isNBlkInjective_mul_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective}
+    If $A$ is $N$-block injective and $m>0$, then $A$ is
+    $(mN)$-block injective.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:l_blk_injective}
+    Induct on $m$. Concatenation gives
+    $S_{mN+N}(A)=S_{mN}(A)S_N(A)$, and the product of the full matrix
+    algebra with itself is again the full matrix algebra.
+\end{proof}
+
 \begin{theorem}[Common exact block-injectivity length]
     \label{thm:common_exact_block_injectivity_normal_left_canonical}
     \lean{MPSTensor.%
         exists_common_isNBlkInjective_of_isNormal_leftCanonical}
     \leanok
-    \uses{def:l_blk_injective, def:normal, thm:bounded_injective_blocking_normal_left_canonical}
+    \uses{def:l_blk_injective, def:normal, thm:bounded_injective_blocking_normal_left_canonical,
+        lem:exact_block_injectivity_positive_multiple}
     Let $(A_j)_{j=1}^g$ be a finite family of positive-bond-dimension,
     left-canonical normal tensors. There is a positive integer $L$ such that
     every $A_j$ is $L$-block injective.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:exact_block_injectivity_positive_multiple}
     Apply
     Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical} to each
     block. The product of the finitely many positive lengths is a common

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4,7 +4,7 @@
 \section{Finite-group representations by matrix product unitaries}
 \label{sec:mpug_group_representations}
 
-Let $G$ be a finite group, let $d>0$, and let
+Let $G$ be a group, let $d\in\N$, and let
 $D\colon G\to\N_{>0}$ assign a virtual bond dimension to each group element.
 For every $g\in G$, let $\mathcal U_g$ be an MPO tensor with physical input and
 output dimension $d$ and virtual bond dimension $D_g$. Write $U_g^{(N)}$ for
@@ -12,39 +12,57 @@ the periodic operator obtained by closing a chain of $N$ copies of
 $\mathcal U_g$. Throughout this section the chain length is positive:
 $N\geq1$. In particular, no identity at length zero is asserted.
 
-\begin{definition}[Positive-chain matrix product unitary]
+\begin{definition}[Matrix product unitarity on nonempty chains]
     \label{def:mpug_positive_mpu}
     \lean{MPOTensor.IsMPUPos}
     \leanok
     \uses{def:mpu}
-    An MPO tensor $\mathcal U$ is a positive-chain matrix product unitary when
-    $U^{(N)}$ is unitary for every $N\geq1$.
+    An MPO tensor $\mathcal U$ is a matrix product unitary on nonempty chains
+    when $U^{(N)}$ is unitary for every $N\geq1$. This is the system-size
+    convention in \cite[line~207]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
-\begin{theorem}[Comparison with the length-two MPU convention]
+\begin{theorem}[Comparison with the $N>1$ MPU convention]
     \label{thm:mpug_positive_mpu_to_mpu}
     \lean{MPOTensor.IsMPUPos.isMPU}
     \leanok
     \uses{def:mpug_positive_mpu, def:mpu}
-    Every positive-chain matrix product unitary is a matrix product unitary in
-    the sense of Definition~\ref{def:mpu}.
+    Every matrix product unitary on nonempty chains is a matrix product unitary
+    in the sense of Definition~\ref{def:mpu}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_positive_mpu, def:mpu}
-    The positive-chain condition applies in particular to every $N>1$.
+    The nonempty-chain condition applies in particular to every $N>1$.
 \end{proof}
 
-\begin{definition}[Finite-group representation by simple injective MPUs]
+\begin{lemma}[Physical blocking preserves nonempty-chain unitarity]
+    \label{lem:mpug_positive_mpu_blocking}
+    \lean{MPOTensor.IsMPUPos.blockTensor}
+    \leanok
+    \uses{def:mpug_positive_mpu, def:mpdo_physical_blocking}
+    If $\mathcal U$ is a matrix product unitary on nonempty chains and $L>0$,
+    then $\mathcal U^{[L]}$ is also a matrix product unitary on nonempty chains.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_reindex_unitary, thm:mpdo_closed_chain_physical_blocking}
+    At chain length $N\geq1$, the blocked periodic operator is $U^{(NL)}$ up to
+    the canonical reindexing of configurations. Since $N,L>0$, the length $NL$
+    is positive. Thus $U^{(NL)}$ is unitary, and simultaneous reindexing
+    preserves unitarity.
+\end{proof}
+
+\begin{definition}[Group representation by simple injective MPUs]
     \label{def:mpug_group_representation}
     \lean{MPOTensor.GroupFamily,
         MPOTensor.GroupFamily.IsRepresentation}
     \leanok
     \uses{def:injective, def:mpu_simple, def:mpug_positive_mpu}
-    A finite-group representation by simple injective MPUs consists of the
+    A group representation by simple injective MPUs consists of the
     dependent-bond family $\{\mathcal U_g\}_{g\in G}$ above such that every
-    $\mathcal U_g$ is injective and simple, every $\mathcal U_g$ is a
-    positive-chain matrix product unitary, and
+    $\mathcal U_g$ is injective and simple, every $\mathcal U_g$ is a matrix
+    product unitary on nonempty chains, and
     \begin{align}
         U_e^{(N)}          & =\Id,
         \label{eq:mpug_rep_identity}       \\
@@ -73,7 +91,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
         \label{eq:mpug_product_tensor_positive_chain}
     \end{align}
     Thus the product tensor and the selected tensor $\mathcal U_{gh}$ generate
-    the same positive-length periodic operators, although their virtual bond
+    the same nonempty-chain periodic operators, although their virtual bond
     dimensions may differ.
 \end{theorem}
 
@@ -107,8 +125,8 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     \leanok
     \uses{def:mpug_common_blocking}
     Let $L>0$. The commonly blocked family
-    $\{\mathcal U_g^{[L]}\}_{g\in G}$ is again a finite-group representation by
-    simple injective MPUs. Under the canonical identification of blocked
+    $\{\mathcal U_g^{[L]}\}_{g\in G}$ is again a group representation by simple
+    injective MPUs. Under the canonical identification of blocked
     configurations with words of length $NL$,
     \begin{align}
         O_N(\mathcal U_g^{[L]})
@@ -130,58 +148,82 @@ $N\geq1$. In particular, no identity at length zero is asserted.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:blocking_preserves_injectivity, lem:mpu_blocking,
+    \uses{lem:mpug_positive_mpu_blocking,
+        thm:mpdo_blocking_doubled_index,
         thm:mpu_bounded_simple_blocking,
         thm:mpdo_closed_chain_physical_blocking,
         thm:mpdo_blocking_product}
-    Physical blocking preserves injectivity, simplicity, and unitarity. The
-    blocked periodic operator is the original operator at length $NL$, up to
-    the canonical simultaneous reindexing. Since $N,L>0$, the length $NL$ is
-    positive, so (\ref{eq:mpug_rep_identity}) and
+    Physical blocking preserves nonempty-chain unitarity, injectivity, and
+    simplicity. The blocked periodic operator is the original operator at
+    length $NL$, up to the canonical simultaneous reindexing. Since $N,L>0$,
+    the length $NL$ is positive, so (\ref{eq:mpug_rep_identity}) and
     (\ref{eq:mpug_rep_multiplication}) apply. Simultaneous reindexing preserves
-    identities and products, which gives
-    (\ref{eq:mpug_blocked_identity}) and
+    identities and products, which gives (\ref{eq:mpug_blocked_identity}) and
     (\ref{eq:mpug_blocked_multiplication}). Expanding one blocked letter gives
     (\ref{eq:mpug_block_product_tensor}).
 \end{proof}
 
-\begin{theorem}[A finite MPU family has a common simple blocking]
-    \label{thm:mpug_finite_common_simple_blocking}
-    \lean{MPOTensor.GroupFamily.IsRawRepresentation,
-        MPOTensor.GroupFamily.commonSimpleLength,
-        MPOTensor.GroupFamily.commonSimpleLength_pos,
-        MPOTensor.GroupFamily.IsRawRepresentation.block_common,
-        MPOTensor.GroupFamily.IsRawRepresentation.block_common_then_block}
+Assume from now until the end of this section that $G$ is finite and $d>0$.
+
+\begin{definition}[Raw MPU representation]
+    \label{def:mpug_raw_group_representation}
+    \lean{MPOTensor.GroupFamily.IsRawRepresentation}
     \leanok
-    \uses{def:mpug_positive_mpu, def:injective, def:mpu_simple,
-        def:mpdo_physical_blocking}
-    Suppose that $\{\mathcal U_g\}_{g\in G}$ is a dependent-bond family of
-    injective positive-chain matrix product unitaries satisfying
-    (\ref{eq:mpug_rep_identity}) and
-    (\ref{eq:mpug_rep_multiplication}). Define
+    \uses{def:injective, def:mpug_positive_mpu}
+    A raw MPU representation is a dependent-bond family
+    $\{\mathcal U_g\}_{g\in G}$ of injective matrix product unitaries on
+    nonempty chains satisfying (\ref{eq:mpug_rep_identity}) and
+    (\ref{eq:mpug_rep_multiplication}) for all $g,h\in G$ and all $N\geq1$.
+    No simplicity hypothesis is imposed.
+\end{definition}
+
+\begin{definition}[Common simplicity length]
+    \label{def:mpug_common_simple_length}
+    \lean{MPOTensor.GroupFamily.commonSimpleLength}
+    \leanok
+    \uses{def:mpug_raw_group_representation}
+    For a finite dependent-bond family, define
     \begin{align}
         L_* & =\sum_{g\in G}D_g^4.
         \label{eq:mpug_common_simple_length}
     \end{align}
-    Then $L_*>0$, and every $\mathcal U_g^{[L_*]}$ is simple. For every $K>0$,
-    each further block $(\mathcal U_g^{[L_*]})^{[K]}$ is simple. Consequently
-    the blocked family at length $L_*$ satisfies
+\end{definition}
+
+\begin{theorem}[A finite MPU family has a common simple blocking]
+    \label{thm:mpug_finite_common_simple_blocking}
+    \lean{MPOTensor.GroupFamily.commonSimpleLength_pos,
+        MPOTensor.GroupFamily.IsRawRepresentation.block_common,
+        MPOTensor.GroupFamily.IsRawRepresentation.block_common_then_block}
+    \leanok
+    \uses{def:mpug_raw_group_representation,
+        def:mpug_common_simple_length, def:mpu_simple,
+        def:mpdo_physical_blocking}
+    Let $\{\mathcal U_g\}_{g\in G}$ be a raw MPU representation. Then $L_*>0$,
+    and every $\mathcal U_g^{[L_*]}$ is simple. For every $K>0$, each further
+    block $(\mathcal U_g^{[L_*]})^{[K]}$ is simple. Consequently the blocked
+    family at length $L_*$ satisfies
     Definition~\ref{def:mpug_group_representation}, and every further common
     positive blocking does as well.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_positive_mpu_to_mpu,
+    \uses{lem:mpug_positive_mpu_blocking,
+        thm:mpug_positive_mpu_to_mpu,
         thm:mpu_common_pow_four_simple_blocking,
         thm:mpu_all_later_simple_blockings,
+        thm:mpdo_blocking_doubled_index,
+        thm:mpdo_closed_chain_physical_blocking,
         thm:mpug_common_blocking_representation}
     Positivity of the bond dimensions gives $L_*>0$. For each $g$, the direct
     block of length $D_g^4$ is simple, and $D_g^4\leq L_*$ by
     (\ref{eq:mpug_common_simple_length}). Simplicity holds at every later direct
-    blocking, hence at the common length $L_*$. It is preserved under every
-    further positive iterated blocking.
-    Theorem~\ref{thm:mpug_common_blocking_representation} supplies the common
-    operator laws.
+    blocking, hence at the common length $L_*$. Nonempty-chain unitarity and
+    injectivity are preserved by physical blocking. Reindexing the closed chain
+    at length $NL_*$ carries the identity and multiplication laws of the raw
+    representation to the blocked family. The length-$L_*$ family is therefore
+    a group representation by simple injective MPUs. Applying
+    Theorem~\ref{thm:mpug_common_blocking_representation} to this established
+    representation proves the assertion for every further positive blocking.
 \end{proof}
 
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1,5 +1,191 @@
-\chapter{Scalar Three-Cocycles and Fusion-Tensor Gauge Freedom}%
+\chapter{Finite-Group MPU Representations and Scalar Gauge Data}%
 \label{ch:mpu_gauging}
+
+\section{Finite-group representations by matrix product unitaries}
+\label{sec:mpug_group_representations}
+
+Let $G$ be a finite group, let $d>0$, and let
+$D\colon G\to\N_{>0}$ assign a virtual bond dimension to each group element.
+For every $g\in G$, let $\mathcal U_g$ be an MPO tensor with physical input and
+output dimension $d$ and virtual bond dimension $D_g$. Write $U_g^{(N)}$ for
+the periodic operator obtained by closing a chain of $N$ copies of
+$\mathcal U_g$. Throughout this section the chain length is positive:
+$N\geq1$. In particular, no identity at length zero is asserted.
+
+\begin{definition}[Positive-chain matrix product unitary]
+    \label{def:mpug_positive_mpu}
+    \lean{MPOTensor.IsMPUPos}
+    \leanok
+    \uses{def:mpu}
+    An MPO tensor $\mathcal U$ is a positive-chain matrix product unitary when
+    $U^{(N)}$ is unitary for every $N\geq1$.
+\end{definition}
+
+\begin{theorem}[Comparison with the length-two MPU convention]
+    \label{thm:mpug_positive_mpu_to_mpu}
+    \lean{MPOTensor.IsMPUPos.isMPU}
+    \leanok
+    \uses{def:mpug_positive_mpu, def:mpu}
+    Every positive-chain matrix product unitary is a matrix product unitary in
+    the sense of Definition~\ref{def:mpu}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_positive_mpu, def:mpu}
+    The positive-chain condition applies in particular to every $N>1$.
+\end{proof}
+
+\begin{definition}[Finite-group representation by simple injective MPUs]
+    \label{def:mpug_group_representation}
+    \lean{MPOTensor.GroupFamily,
+        MPOTensor.GroupFamily.IsRepresentation}
+    \leanok
+    \uses{def:injective, def:mpu_simple, def:mpug_positive_mpu}
+    A finite-group representation by simple injective MPUs consists of the
+    dependent-bond family $\{\mathcal U_g\}_{g\in G}$ above such that every
+    $\mathcal U_g$ is injective and simple, every $\mathcal U_g$ is a
+    positive-chain matrix product unitary, and
+    \begin{align}
+        U_e^{(N)}          & =\Id,
+        \label{eq:mpug_rep_identity}       \\
+        U_g^{(N)}U_h^{(N)} & =U_{gh}^{(N)}
+        \label{eq:mpug_rep_multiplication}
+    \end{align}
+    for all $g,h\in G$ and all $N\geq1$.
+    This is the representation-level input in
+    \cite[Subsection ``MPU group representations'']{FrancoRubio2025MPUGauging}.
+    The dimensions $D_gD_h$ and $D_{gh}$ need not agree, so
+    (\ref{eq:mpug_rep_multiplication}) is an identity of periodic operators,
+    not an equality of local tensors.
+\end{definition}
+
+\begin{theorem}[Product-tensor operator identity]
+    \label{thm:mpug_product_tensor_operator}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_mulTensor}
+    \leanok
+    \uses{def:mpug_group_representation, def:mpdo_operator_product}
+    Let $\mathcal U_g\mathbin{\cdot}\mathcal U_h$ denote the product MPO tensor,
+    whose virtual bond dimension is $D_gD_h$. For every $N\geq1$,
+    \begin{align}
+        O_N(\mathcal U_g\mathbin{\cdot}\mathcal U_h)
+         & =U_g^{(N)}U_h^{(N)}
+        =U_{gh}^{(N)}.
+        \label{eq:mpug_product_tensor_positive_chain}
+    \end{align}
+    Thus the product tensor and the selected tensor $\mathcal U_{gh}$ generate
+    the same positive-length periodic operators, although their virtual bond
+    dimensions may differ.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_group_representation, thm:mpdo_operator_product_mpo}
+    The first equality in
+    (\ref{eq:mpug_product_tensor_positive_chain}) is multiplicativity of the
+    periodic operator under the product-tensor contraction. The second is
+    (\ref{eq:mpug_rep_multiplication}).
+\end{proof}
+
+\begin{definition}[Common positive physical blocking]
+    \label{def:mpug_common_blocking}
+    \lean{MPOTensor.GroupFamily.block}
+    \leanok
+    \uses{def:mpug_group_representation, def:mpdo_physical_blocking}
+    For a positive integer $L$, the common length-$L$ physical blocking is the
+    family
+    \begin{align}
+        \widetilde{\mathcal U}_g & =\mathcal U_g^{[L]}.
+        \label{eq:mpug_common_blocked_family}
+    \end{align}
+    Each blocked tensor has physical dimension $d^L$ and the same virtual bond
+    dimension $D_g$ as $\mathcal U_g$. The physical alphabet is replaced
+    simultaneously for every group element by words of length $L$.
+\end{definition}
+
+\begin{theorem}[Common blocking preserves the representation laws]
+    \label{thm:mpug_common_blocking_representation}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.block}
+    \leanok
+    \uses{def:mpug_common_blocking}
+    Let $L>0$. The commonly blocked family
+    $\{\mathcal U_g^{[L]}\}_{g\in G}$ is again a finite-group representation by
+    simple injective MPUs. Under the canonical identification of blocked
+    configurations with words of length $NL$,
+    \begin{align}
+        O_N(\mathcal U_g^{[L]})
+         & \cong U_g^{(NL)},
+        \label{eq:mpug_blocked_operator} \\
+        O_N(\mathcal U_e^{[L]})
+         & =\Id,
+        \label{eq:mpug_blocked_identity} \\
+        O_N(\mathcal U_g^{[L]})O_N(\mathcal U_h^{[L]})
+         & =O_N(\mathcal U_{gh}^{[L]})
+        \label{eq:mpug_blocked_multiplication}
+    \end{align}
+    for every $N\geq1$. Moreover,
+    \begin{align}
+        (\mathcal U_g\mathbin{\cdot}\mathcal U_h)^{[L]}
+         & =\mathcal U_g^{[L]}\mathbin{\cdot}\mathcal U_h^{[L]}.
+        \label{eq:mpug_block_product_tensor}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:blocking_preserves_injectivity, lem:mpu_blocking,
+        thm:mpu_bounded_simple_blocking,
+        thm:mpdo_closed_chain_physical_blocking,
+        thm:mpdo_blocking_product}
+    Physical blocking preserves injectivity, simplicity, and unitarity. The
+    blocked periodic operator is the original operator at length $NL$, up to
+    the canonical simultaneous reindexing. Since $N,L>0$, the length $NL$ is
+    positive, so (\ref{eq:mpug_rep_identity}) and
+    (\ref{eq:mpug_rep_multiplication}) apply. Simultaneous reindexing preserves
+    identities and products, which gives
+    (\ref{eq:mpug_blocked_identity}) and
+    (\ref{eq:mpug_blocked_multiplication}). Expanding one blocked letter gives
+    (\ref{eq:mpug_block_product_tensor}).
+\end{proof}
+
+\begin{theorem}[A finite MPU family has a common simple blocking]
+    \label{thm:mpug_finite_common_simple_blocking}
+    \lean{MPOTensor.GroupFamily.IsRawRepresentation,
+        MPOTensor.GroupFamily.commonSimpleLength,
+        MPOTensor.GroupFamily.commonSimpleLength_pos,
+        MPOTensor.GroupFamily.IsRawRepresentation.block_common,
+        MPOTensor.GroupFamily.IsRawRepresentation.block_common_then_block}
+    \leanok
+    \uses{def:mpug_positive_mpu, def:injective, def:mpu_simple,
+        def:mpdo_physical_blocking}
+    Suppose that $\{\mathcal U_g\}_{g\in G}$ is a dependent-bond family of
+    injective positive-chain matrix product unitaries satisfying
+    (\ref{eq:mpug_rep_identity}) and
+    (\ref{eq:mpug_rep_multiplication}). Define
+    \begin{align}
+        L_* & =\sum_{g\in G}D_g^4.
+        \label{eq:mpug_common_simple_length}
+    \end{align}
+    Then $L_*>0$, and every $\mathcal U_g^{[L_*]}$ is simple. For every $K>0$,
+    each further block $(\mathcal U_g^{[L_*]})^{[K]}$ is simple. Consequently
+    the blocked family at length $L_*$ satisfies
+    Definition~\ref{def:mpug_group_representation}, and every further common
+    positive blocking does as well.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_positive_mpu_to_mpu,
+        thm:mpu_common_pow_four_simple_blocking,
+        thm:mpu_all_later_simple_blockings,
+        thm:mpug_common_blocking_representation}
+    Positivity of the bond dimensions gives $L_*>0$. For each $g$, the direct
+    block of length $D_g^4$ is simple, and $D_g^4\leq L_*$ by
+    (\ref{eq:mpug_common_simple_length}). Simplicity holds at every later direct
+    blocking, hence at the common length $L_*$. It is preserved under every
+    further positive iterated blocking.
+    Theorem~\ref{thm:mpug_common_blocking_representation} supplies the common
+    operator laws.
+\end{proof}
+
+\section{Scalar three-cocycles and fusion-tensor gauge freedom}
+\label{sec:mpug_scalar_gauge}
 
 Let $G$ be a group and write $\C^\times$ for the multiplicative group of
 nonzero complex numbers. The fusion tensors have the scalar gauge freedom
@@ -10,9 +196,10 @@ nonzero complex numbers. The fusion tensors have the scalar gauge freedom
 \end{align}
 % Source anchor: arXiv:2502.20257, eq:scalar_fus_ten.
 This is the fusion-tensor gauge freedom of~\cite{FrancoRubio2025MPUGauging}.
-The results below formalize only the scalar functions $\beta$, $\omega$,
-$\gamma$, and $L$; they construct neither fusion tensors nor action tensors nor
-an MPU representation.
+The results in this section formalize only the scalar functions $\beta$,
+$\omega$, $\gamma$, and $L$; they construct neither fusion tensors nor action
+tensors. The representation-level data were specified in
+Definition~\ref{def:mpug_group_representation}.
 
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -140,7 +140,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
          & =O_N(\mathcal U_{gh}^{[L]})
         \label{eq:mpug_blocked_multiplication}
     \end{align}
-    for every $N\geq1$. Moreover,
+    for every $N\geq1$. Physical blocking also commutes with tensor products:
     \begin{align}
         (\mathcal U_g\mathbin{\cdot}\mathcal U_h)^{[L]}
          & =\mathcal U_g^{[L]}\mathbin{\cdot}\mathcal U_h^{[L]}.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -16,7 +16,6 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     \label{def:mpug_positive_mpu}
     \lean{MPOTensor.IsMPUPos}
     \leanok
-    \uses{def:mpu}
     An MPO tensor $\mathcal U$ is a matrix product unitary on nonempty chains
     when $U^{(N)}$ is unitary for every $N\geq1$. This is the system-size
     convention in \cite[line~207]{FrancoRubio2025MPUGauging}.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -46,10 +46,12 @@ $N\geq1$. In particular, no identity at length zero is asserted.
 
 \begin{proof}\leanok
     \uses{thm:mpu_reindex_unitary, thm:mpdo_closed_chain_physical_blocking}
-    At chain length $N\geq1$, the blocked periodic operator is $U^{(NL)}$ up to
-    the canonical reindexing of configurations. Since $N,L>0$, the length $NL$
-    is positive. Thus $U^{(NL)}$ is unitary, and simultaneous reindexing
-    preserves unitarity.
+    At chain length $N\geq1$, the canonical reindexing of configurations gives
+    \begin{align}
+        O_N(\mathcal U^{[L]}) & \cong U^{(NL)}.
+    \end{align}
+    Since $N,L>0$, the length $NL$ is positive. Thus $U^{(NL)}$ is unitary,
+    and simultaneous reindexing preserves unitarity.
 \end{proof}
 
 \begin{definition}[Group representation by simple injective MPUs]
@@ -170,7 +172,8 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
     \label{def:mpug_raw_group_representation}
     \lean{MPOTensor.GroupFamily.IsRawRepresentation}
     \leanok
-    \uses{def:injective, def:mpug_positive_mpu}
+    \uses{def:injective, def:mpug_positive_mpu,
+        def:mpug_group_representation}
     A raw MPU representation is a dependent-bond family
     $\{\mathcal U_g\}_{g\in G}$ of injective matrix product unitaries on
     nonempty chains satisfying (\ref{eq:mpug_rep_identity}) and
@@ -197,8 +200,8 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
         MPOTensor.GroupFamily.IsRawRepresentation.block_common_then_block}
     \leanok
     \uses{def:mpug_raw_group_representation,
-        def:mpug_common_simple_length, def:mpu_simple,
-        def:mpdo_physical_blocking}
+        def:mpug_common_simple_length, def:mpug_group_representation,
+        def:mpu_simple, def:mpdo_physical_blocking}
     Let $\{\mathcal U_g\}_{g\in G}$ be a raw MPU representation. Then $L_*>0$,
     and every $\mathcal U_g^{[L_*]}$ is simple. For every $K>0$, each further
     block $(\mathcal U_g^{[L_*]})^{[K]}$ is simple. Consequently the blocked

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -35,14 +35,14 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     The nonempty-chain condition applies in particular to every $N>1$.
 \end{proof}
 
-\begin{lemma}[Physical blocking preserves nonempty-chain unitarity]
-    \label{lem:mpug_positive_mpu_blocking}
+\begin{theorem}[Physical blocking preserves nonempty-chain unitarity]
+    \label{thm:mpug_positive_mpu_blocking}
     \lean{MPOTensor.IsMPUPos.blockTensor}
     \leanok
     \uses{def:mpug_positive_mpu, def:mpdo_physical_blocking}
     If $\mathcal U$ is a matrix product unitary on nonempty chains and $L>0$,
     then $\mathcal U^{[L]}$ is also a matrix product unitary on nonempty chains.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_reindex_unitary, thm:mpdo_closed_chain_physical_blocking}
@@ -73,12 +73,12 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     for all $g,h\in G$ and all $N\geq1$.
     The multiplicative law is the representation-level input
     in~\cite[Subsection ``MPU group representations'']
-        {FrancoRubio2025MPUGauging}.
+    {FrancoRubio2025MPUGauging}.
     The identity law is its standard consequence and is recorded explicitly for
     positive lengths. It is also compatible with the later, stronger convention
     that $\mathcal U_e=\Id$ has bond dimension one
     in~\cite[Subsection ``Assumptions for the rest of the paper'']
-        {FrancoRubio2025MPUGauging}.
+    {FrancoRubio2025MPUGauging}.
     The dimensions $D_gD_h$ and $D_{gh}$ need not agree, so
     (\ref{eq:mpug_rep_multiplication}) is an identity of periodic operators,
     not an equality of local tensors.
@@ -157,7 +157,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_positive_mpu_blocking,
+    \uses{thm:mpug_positive_mpu_blocking,
         thm:mpdo_blocking_doubled_index,
         thm:mpu_bounded_simple_blocking,
         thm:mpdo_closed_chain_physical_blocking,
@@ -218,7 +218,7 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_positive_mpu_blocking,
+    \uses{thm:mpug_positive_mpu_blocking,
         thm:mpug_positive_mpu_to_mpu,
         thm:mpu_common_pow_four_simple_blocking,
         thm:mpu_all_later_simple_blockings,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -163,8 +163,9 @@ $N\geq1$. In particular, no identity at length zero is asserted.
         thm:mpdo_closed_chain_physical_blocking,
         thm:mpdo_blocking_product}
     Physical blocking preserves nonempty-chain unitarity, injectivity, and
-    simplicity. The blocked periodic operator is the original operator at
-    length $NL$, up to the canonical simultaneous reindexing. Since $N,L>0$,
+    simplicity. By (\ref{eq:mpug_blocked_operator}), the blocked periodic operator is
+    the original operator at length $NL$ up to the canonical simultaneous reindexing.
+    Since $N,L>0$,
     the length $NL$ is positive, so (\ref{eq:mpug_rep_identity}) and
     (\ref{eq:mpug_rep_multiplication}) apply. Simultaneous reindexing preserves
     identities and products, which gives (\ref{eq:mpug_blocked_identity}) and

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -121,7 +121,9 @@ $N\geq1$. In particular, no identity at length zero is asserted.
 
 \begin{theorem}[Common blocking preserves the representation laws]
     \label{thm:mpug_common_blocking_representation}
-    \lean{MPOTensor.GroupFamily.IsRepresentation.block}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.block,
+        MPOTensor.mpo_blockTensor_eq_reindex,
+        MPOTensor.blockTensor_mulTensor}
     \leanok
     \uses{def:mpug_common_blocking}
     Let $L>0$. The commonly blocked family

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -71,8 +71,14 @@ $N\geq1$. In particular, no identity at length zero is asserted.
         \label{eq:mpug_rep_multiplication}
     \end{align}
     for all $g,h\in G$ and all $N\geq1$.
-    This is the representation-level input in
-    \cite[Subsection ``MPU group representations'']{FrancoRubio2025MPUGauging}.
+    The multiplicative law is the representation-level input
+    in~\cite[Subsection ``MPU group representations'']
+        {FrancoRubio2025MPUGauging}.
+    The identity law is its standard consequence and is recorded explicitly for
+    positive lengths. It is also compatible with the later, stronger convention
+    that $\mathcal U_e=\Id$ has bond dimension one
+    in~\cite[Subsection ``Assumptions for the rest of the paper'']
+        {FrancoRubio2025MPUGauging}.
     The dimensions $D_gD_h$ and $D_{gh}$ need not agree, so
     (\ref{eq:mpug_rep_multiplication}) is an identity of periodic operators,
     not an equality of local tensors.


### PR DESCRIPTION
### Motivation

- Formalize the representation-level input of `Papers/2502.20257/main.tex:1403--1405`, where the nonempty-chain operators satisfy $U_e^{(N)}=1$ and $U_g^{(N)}U_h^{(N)}=U_{gh}^{(N)}$.
- Keep the multiplication law at operator and generated-MPV level, since the product tensor has bond dimension $D_gD_h$ while the chosen tensor for $gh$ has bond dimension $D_{gh}$.

### Description

- Add `MPOTensor.IsMPUPos`, group-indexed tensor families with element-dependent positive bond dimensions, and exact positive-length raw and simple injective representation predicates.
- Prove that the selected injective tensor for $gh$ and the product tensor for $(g,h)$ generate the same positive-length MPV family, oriented for the later rectangular reduction theorem.
- Prove preservation of unitarity, representation laws, simplicity, and injectivity under every positive common physical block.
- For finite groups, define the explicit common length $L_*=\sum_g D_g^4$, prove $L_*>0$, obtain simultaneous simplicity there, and prove persistence under further positive blocking.
- Move positive-multiple block injectivity to the basic MPS blocking layer and reuse it from the existing normality-chain argument without adding a Wielandt backend import.
- Add mathematical Blueprint statements for the positive-length representation, product-family equality, blocking laws, and common finite-family block.

### Testing

- `lake build TNLean.MPS.MPU.GroupRepresentation TNLean.MPS.MPU`
- `lake build` (10380 jobs)
- `python3 scripts/test_blueprint_lean_sync.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- Pinned `latexindent` byte comparison and `chktex` on `blueprint/src/chapter/ch29_mpu_gauging.tex`
- Two `lualatex` passes on `blueprint/src/print.tex` with the pinned tenkz package, with no undefined references
- `git diff --check origin/main...HEAD`
- No `sorry`, `axiom`, or `unsafe` in the changed Lean files

---
Closes #7381

### Agent assistance

- TeXRA Lean, Lean Search, Lean Blueprint, and Lean Simplifier agents using GPT-5.6 assisted with implementation, Mathlib and source scouting, Blueprint drafting, and independent review. The orchestration and final verification were performed in the issue worktree.
