### PR TITLE
refactor(MPS): use bilinear span closure for word tuples

### DIFF
--- a/TNLean/MPS/SharedInfra/WordTupleGauge.lean
+++ b/TNLean/MPS/SharedInfra/WordTupleGauge.lean
@@ -69,69 +69,16 @@ theorem pointwise_mul_mem_span_wordTuple_add
     (fun k : Fin r => M k * N k) ∈
       Submodule.span ℂ (Set.range (wordTuple A (L + S))) := by
   classical
-  let spanLS : Submodule ℂ ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) :=
-    Submodule.span ℂ (Set.range (wordTuple A (L + S)))
-  have hleft_gen : ∀ u : Fin L → Fin d,
-      (fun k : Fin r => wordTuple A L u k * N k) ∈ spanLS := by
-    intro u
-    induction hN using Submodule.span_induction with
-    | mem N hNmem =>
-        rcases hNmem with ⟨v, rfl⟩
-        have hEq : (fun k : Fin r => wordTuple A L u k * wordTuple A S v k) =
-            wordTuple A (L + S) (Fin.append u v) := by
-          funext k
-          simp [wordTuple, List.ofFn_fin_append, Kraus.evalWord_append]
-        rw [hEq]
-        exact Submodule.subset_span ⟨Fin.append u v, rfl⟩
-    | zero =>
-        have hzero : (fun k : Fin r =>
-            wordTuple A L u k *
-              (0 : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) k) = 0 := by
-          funext k
-          simp
-        rw [hzero]
-        exact Submodule.zero_mem _
-    | add N₁ N₂ _ _ hN₁ hN₂ =>
-        have hEq : (fun k : Fin r => wordTuple A L u k * (N₁ + N₂) k) =
-            (fun k : Fin r => wordTuple A L u k * N₁ k) +
-              (fun k : Fin r => wordTuple A L u k * N₂ k) := by
-          funext k
-          simp [Matrix.mul_add]
-        rw [hEq]
-        exact Submodule.add_mem _ hN₁ hN₂
-    | smul a N _ hN =>
-        have hEq : (fun k : Fin r => wordTuple A L u k * (a • N) k) =
-            a • (fun k : Fin r => wordTuple A L u k * N k) := by
-          funext k
-          simp
-        rw [hEq]
-        exact Submodule.smul_mem _ a hN
-  induction hM using Submodule.span_induction with
-  | mem M hMmem =>
-      rcases hMmem with ⟨u, rfl⟩
-      exact hleft_gen u
-  | zero =>
-      have hzero : (fun k : Fin r =>
-          (0 : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) k * N k) = 0 := by
-        funext k
-        simp
-      rw [hzero]
-      exact Submodule.zero_mem _
-  | add M₁ M₂ _ _ hM₁ hM₂ =>
-      have hEq : (fun k : Fin r => (M₁ + M₂) k * N k) =
-          (fun k : Fin r => M₁ k * N k) +
-            (fun k : Fin r => M₂ k * N k) := by
-        funext k
-        simp [Matrix.add_mul]
-      rw [hEq]
-      exact Submodule.add_mem _ hM₁ hM₂
-  | smul a M _ hM =>
-      have hEq : (fun k : Fin r => (a • M) k * N k) =
-          a • (fun k : Fin r => M k * N k) := by
-        funext k
-        simp
-      rw [hEq]
-      exact Submodule.smul_mem _ a hM
+  apply LinearMap.BilinMap.apply_apply_mem_of_mem_span
+      (B := LinearMap.mul ℂ _)
+      (s := Set.range (wordTuple A L)) (t := Set.range (wordTuple A S))
+  · rintro _ ⟨u, rfl⟩ _ ⟨v, rfl⟩
+    apply Submodule.subset_span
+    refine ⟨Fin.append u v, ?_⟩
+    funext k
+    simp [wordTuple, List.ofFn_fin_append, Kraus.evalWord_append]
+  · exact hM
+  · exact hN
 
 /-- Homogeneous identity padding preserves the full word-tuple span.
 


### PR DESCRIPTION
## What changed

- replace the two nested `Submodule.span_induction` proofs in `pointwise_mul_mem_span_wordTuple_add` with Mathlib's `LinearMap.BilinMap.apply_apply_mem_of_mem_span`
- retain only the generator calculation `wordTuple L u * wordTuple S v = wordTuple (L + S) (Fin.append u v)`
- remove 53 net lines from a high-fanout shared module without changing imports or declarations

## Measurement

Controlled forced re-elaboration at exact base `74e0686d6`, using one regular self-contained package cache and three sequential runs per version:

```text
before module: 3.2s, 3.2s, 3.1s   mean 3.17s
 after module: 3.0s, 3.0s, 3.1s   mean 3.03s
before wall:   4.89s, 4.97s, 4.77s mean 4.88s
 after wall:   4.63s, 4.67s, 4.74s mean 4.68s
```

This is about a 4% reduction in both reported module time and targeted-build wall time. Logs are in `/tmp/tnlean-wordtuple-forced-benchmark-20260829-182703` on the measurement machine.

## Statement-integrity audit

- `MPSTensor.pointwise_mul_mem_span_wordTuple_add` has the same binders, hypotheses, and conclusion as `origin/main`
- no declaration name, theorem statement, import, Blueprint entry, source-paper record, or paper-gap note changed
- no new `sorry`, `axiom`, or `unsafe`
- the only changed source file is `TNLean/MPS/SharedInfra/WordTupleGauge.lean`

## Validation

```bash
lake build TNLean.MPS.SharedInfra.WordTupleGauge
lake build
git diff --check origin/main...HEAD
git grep -n -E '\b(sorry|axiom|unsafe)\b' HEAD -- TNLean/MPS/SharedInfra/WordTupleGauge.lean
```

The targeted build passed at 2717 jobs. The full build passed at 10379 jobs in 6m42s after rebuilding the high-fanout downstream cone.

Closes #7392
