### PR TITLE
refactor(MPS/MPDO): split LPDO definitions

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -174,6 +174,7 @@ import TNLean.MPS.MPDO.InverseMapLemmaC5CaseI
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.IsometricAdjacentBondTransport
 import TNLean.MPS.MPDO.KatoDeformedRFPObstruction
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.LemmaC5CaseI
 import TNLean.MPS.MPDO.LengthDependentRFPExample
 import TNLean.MPS.MPDO.LengthIndependentCoefficients

--- a/TNLean/MPS/MPDO/CPSVExample410Operator.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410Operator.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexSqrt
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.LocalPurificationRFP
 
 /-!

--- a/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
@@ -8,6 +8,7 @@ import QICLean.Channel.SingleKrausPositivity
 import QICLean.Algebra.MatrixIsometryKronecker
 import TNLean.MPS.MPDO.CPSVExample410CorrelatedFlip
 import TNLean.MPS.MPDO.CPSVExample410Operator
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.SourceZCLMarginal
 
 /-!

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.ZCL
 

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -7,24 +7,18 @@ import QICLean.Kraus.Word
 import TNLean.MPS.Defs
 import QICLean.Kraus.Transfer
 import Mathlib.LinearAlgebra.Matrix.PosDef
-import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
-# MPO, MPDO, and LPDO — basic definitions
+# MPO and MPDO — basic definitions
 
 This file introduces the core tensor types and predicates for mixed-state
-tensor networks, following arXiv:1606.00608 Section 4 (Cirac–Pérez-García–Schuch–
+tensor networks, following arXiv:1606.00608 Sections 4.1–4.2 (Cirac–Pérez-García–Schuch–
 Verstraete):
 
 * **MPO** (Matrix Product Operator): a 4-index tensor `MPOTensor d D` with
   physical ket/bra indices and virtual left/right indices.
 * **MPDO** (Matrix Product Density Operator): an MPO whose operator family
   `mpo M N` is positive semidefinite for every nonempty chain.
-* **LPDO** (Locally Purifiable Density Operator): an MPO that admits a
-  local purification tensor with Kronecker structure,
-  `M^{ij} = (∑_k A^{(i,k)} ⊗ₖ conj(A^{(j,k)})).submatrix ↑e ↑e`,
-  for an identification `e : Fin D ≃ Fin D' × Fin D'` of the bond index.
-
 ## Main definitions
 
 * `MPOTensor d D`: the type of 4-index tensors (ket, bra, left-virtual,
@@ -42,7 +36,6 @@ Verstraete):
 * `MPOTensor.adjointTensor`: the adjoint tensor `(M†)^{ij} = (M^{ji})†`, which
   generates the adjoint operator family up to spatial reflection.
 * `MPOTensor.IsMPDO`: global positivity predicate.
-* `MPOTensor.IsLPDO`: local purification predicate.
 * `MPOTensor.toMPSTensor`: view an MPO tensor as an MPS tensor with doubled
   physical index `Fin (d * d)`.
 * `MPOTensor.physicalSlice`: the physical matrix at fixed virtual indices.
@@ -56,12 +49,12 @@ Verstraete):
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.1–4.3
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Sections 4.1–4.2
 * [VGRC04] Verstraete, Garcia-Ripoll, Cirac, PRL 93, 207204 (2004)
 * [ZV04] Zwolak, Vidal, PRL 93, 207205 (2004)
 -/
 
-open scoped Matrix ComplexOrder BigOperators Kronecker
+open scoped Matrix ComplexOrder BigOperators
 open Matrix Finset
 
 /-- A **Matrix Product Operator** tensor:
@@ -399,114 +392,5 @@ theorem IsMPDO.adjointTensor {M : MPOTensor d D} (hM : IsMPDO M) :
     rfl
   rw [href]
   exact (hM N hN).submatrix _
-
-/-! ### LPDO: local purification -/
-
-/-- An MPO tensor `M` is an **LPDO** (Locally Purifiable Density Operator) if
-there exist a Kraus dimension `dK`, an inner bond dimension `D'`, a purifying
-family `A^{(i,k)} ∈ M_{D'}(ℂ)` for `i ∈ Fin d`, `k ∈ Fin dK`, and a bond-space
-identification `e : Fin D ≃ Fin D' × Fin D'` such that
-
-  `M^{ij} = (∑_{k} A^{(i,k)} ⊗ₖ (A^{(j,k)})^*).submatrix ↑e ↑e`
-
-for all `i, j`, where `(·)^*` is entrywise complex conjugation and `⊗ₖ` is the
-Kronecker product. See arXiv:1606.00608, Section 4.3. -/
-def IsLPDO (M : MPOTensor d D) : Prop :=
-  ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
-    (e : Fin D ≃ Fin D' × Fin D'),
-    ∀ i j : Fin d, M i j = (∑ k : Fin dK,
-      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e
-
-/-- The list product of LPDO tensor entries decomposes via Kronecker products
-of the purifying tensor. This is the key technical lemma for `IsLPDO.isMPDO` and
-for the purification identity `mpo_eq_purificationDensity`: the product of
-Kronecker sums expands as a Kronecker sum of products, using the mixed-product
-property `(A ⊗ B)(C ⊗ D) = (AC) ⊗ (BD)`. -/
-lemma lpdo_prod_decomp {dK D' : ℕ}
-    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
-    (e : Fin D ≃ Fin D' × Fin D')
-    {M : MPOTensor d D}
-    (hM : ∀ i j : Fin d, M i j = (∑ k : Fin dK,
-      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e)
-    {N : ℕ} (σ τ : Fin N → Fin d) :
-    (List.ofFn fun l => M (σ l) (τ l)).prod =
-      (∑ κ : Fin N → Fin dK,
-        (List.ofFn fun l => A (σ l) (κ l)).prod ⊗ₖ
-        ((List.ofFn fun l => A (τ l) (κ l)).prod).map
-          (starRingEnd ℂ)).submatrix ↑e ↑e := by
-  induction N with
-  | zero =>
-    simp only [List.ofFn_zero, List.prod_nil, Fintype.sum_unique]
-    have h1 : (1 : Matrix (Fin D') (Fin D') ℂ).map ⇑(starRingEnd ℂ) = 1 :=
-      (starRingEnd ℂ).mapMatrix.map_one
-    rw [h1, Matrix.kroneckerMap_one_one (· * ·) (fun _ => zero_mul _)
-      (fun _ => mul_zero _) (one_mul 1), Matrix.submatrix_one_equiv]
-  | succ n ih =>
-    simp only [List.ofFn_succ, List.prod_cons]
-    rw [hM (σ 0) (τ 0)]
-    have ih_step := ih (σ ∘ Fin.succ) (τ ∘ Fin.succ)
-    simp only [Function.comp_def] at ih_step
-    rw [ih_step, Matrix.submatrix_mul_equiv _ _ (↑e) e (↑e)]
-    -- Strip the submatrix to work at the (Fin D' × Fin D') level
-    congr 1
-    -- Expand LHS product of sums
-    rw [Finset.sum_mul]
-    simp_rw [Finset.mul_sum]
-    -- Apply mixed product property
-    simp_rw [← Matrix.mul_kronecker_mul]
-    -- Combine the conjugated matrices: map star (A) * map star (B) = map star (A * B)
-    have map_star_mul : ∀ (P Q : Matrix (Fin D') (Fin D') ℂ),
-        P.map ⇑(starRingEnd ℂ) * Q.map ⇑(starRingEnd ℂ) =
-        (P * Q).map ⇑(starRingEnd ℂ) :=
-      fun P Q => ((starRingEnd ℂ).mapMatrix.map_mul P Q).symm
-    simp_rw [map_star_mul]
-    -- Reindex RHS: ∑ κ : Fin(n+1) → Fin dK = ∑ k, ∑ κ'
-    have reindex : ∀ (F : (Fin (n + 1) → Fin dK) →
-        Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
-      ∑ κ, F κ = ∑ k : Fin dK, ∑ κ' : Fin n → Fin dK,
-        F (Fin.cons k κ') := fun F => by
-          rw [← Fintype.sum_prod_type']
-          exact ((Fin.consEquiv (fun _ : Fin (n + 1) => Fin dK)).sum_comp F).symm
-    symm
-    rw [reindex]
-    simp only [Fin.cons_zero, Fin.cons_succ]
-
-/-- **LPDO implies MPDO**: every LPDO tensor generates positive semidefinite
-density operators on all nonempty chains.
-
-The proof uses the Kronecker product structure: the N-site density matrix
-decomposes as `ρ^{(N)} = ∑_κ |ψ_κ⟩⟨ψ_κ|` where each `ψ_κ` is an MPS
-vector built from the purifying tensor, giving a manifestly PSD sum of
-rank-1 positive semidefinite matrices.
-
-See arXiv:1606.00608, Section 4.3. -/
-theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
-  obtain ⟨dK, D', A, e, hM⟩ := h
-  intro N _hN
-  -- Define the MPS coefficient vectors from the purifying tensor
-  set ψ : (Fin N → Fin dK) → (Fin N → Fin d) → ℂ :=
-    fun κ σ => Matrix.trace ((List.ofFn fun l => A (σ l) (κ l)).prod) with hψ
-  -- Show mpo M N = ∑ κ, |ψ_κ⟩⟨ψ_κ|, then conclude PSD
-  suffices hmpo : mpo M N = ∑ κ : Fin N → Fin dK,
-      Matrix.vecMulVec (ψ κ) (star (ψ κ)) by
-    rw [hmpo]
-    exact Matrix.posSemidef_sum _ fun κ _ => Matrix.posSemidef_vecMulVec_self_star _
-  -- Prove the matrix equality entry-by-entry
-  ext σ τ
-  simp only [mpo_apply, mpoMatrixEntry, hψ, evalWord_ofFn]
-  -- Apply the Kronecker product decomposition
-  rw [lpdo_prod_decomp A e hM σ τ]
-  -- trace of submatrix = trace (via equiv reindexing)
-  have trace_sub : ∀ (X : Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
-      Matrix.trace (X.submatrix (↑e) (↑e)) = Matrix.trace X := by
-    intro X; simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
-    exact e.sum_comp (fun p => X p p)
-  rw [trace_sub, Matrix.trace_sum]
-  simp_rw [Matrix.trace_kronecker]
-  -- trace of entrywise conjugate = conjugate of trace: trace(A.map star) = star(trace A)
-  simp_rw [← AddMonoidHom.map_trace (starRingEnd ℂ)]
-  -- Evaluate the entries of the finite sum of rank-one matrices.
-  simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Pi.star_apply, starRingEnd_apply]
-
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/LPDO.lean
+++ b/TNLean/MPS/MPDO/LPDO.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import TNLean.MPS.MPDO.Defs
+
+/-!
+# Locally purifiable density operators
+
+This file defines locally purifiable density operators and proves that every
+local purification generates positive semidefinite operators on nonempty
+chains. The local purification is the Kronecker-product presentation from
+arXiv:1606.00608, Section 4.3.
+
+## Main definitions
+
+* `MPOTensor.IsLPDO`: an MPO tensor admitting a local purification tensor.
+
+## Main results
+
+* `MPOTensor.lpdo_prod_decomp`: products of LPDO entries decompose as sums of
+  Kronecker products of purifying-tensor products.
+* `MPOTensor.IsLPDO.isMPDO`: every LPDO is an MPDO.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.3
+-/
+
+open scoped Matrix ComplexOrder BigOperators Kronecker
+open Matrix Finset
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-! ### LPDO: local purification -/
+
+/-- An MPO tensor `M` is an **LPDO** (Locally Purifiable Density Operator) if
+there exist a Kraus dimension `dK`, an inner bond dimension `D'`, a purifying
+family `A^{(i,k)} ∈ M_{D'}(ℂ)` for `i ∈ Fin d`, `k ∈ Fin dK`, and a bond-space
+identification `e : Fin D ≃ Fin D' × Fin D'` such that
+
+  `M^{ij} = (∑_{k} A^{(i,k)} ⊗ₖ (A^{(j,k)})^*).submatrix ↑e ↑e`
+
+for all `i, j`, where `(·)^*` is entrywise complex conjugation and `⊗ₖ` is the
+Kronecker product. See arXiv:1606.00608, Section 4.3. -/
+def IsLPDO (M : MPOTensor d D) : Prop :=
+  ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D'),
+    ∀ i j : Fin d, M i j = (∑ k : Fin dK,
+      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e
+
+/-- The list product of LPDO tensor entries decomposes via Kronecker products
+of the purifying tensor. This is the key technical lemma for `IsLPDO.isMPDO` and
+for the purification identity `mpo_eq_purificationDensity`: the product of
+Kronecker sums expands as a Kronecker sum of products, using the mixed-product
+property `(A ⊗ B)(C ⊗ D) = (AC) ⊗ (BD)`. -/
+lemma lpdo_prod_decomp {dK D' : ℕ}
+    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D')
+    {M : MPOTensor d D}
+    (hM : ∀ i j : Fin d, M i j = (∑ k : Fin dK,
+      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e)
+    {N : ℕ} (σ τ : Fin N → Fin d) :
+    (List.ofFn fun l => M (σ l) (τ l)).prod =
+      (∑ κ : Fin N → Fin dK,
+        (List.ofFn fun l => A (σ l) (κ l)).prod ⊗ₖ
+        ((List.ofFn fun l => A (τ l) (κ l)).prod).map
+          (starRingEnd ℂ)).submatrix ↑e ↑e := by
+  induction N with
+  | zero =>
+    simp only [List.ofFn_zero, List.prod_nil, Fintype.sum_unique]
+    have h1 : (1 : Matrix (Fin D') (Fin D') ℂ).map ⇑(starRingEnd ℂ) = 1 :=
+      (starRingEnd ℂ).mapMatrix.map_one
+    rw [h1, Matrix.kroneckerMap_one_one (· * ·) (fun _ => zero_mul _)
+      (fun _ => mul_zero _) (one_mul 1), Matrix.submatrix_one_equiv]
+  | succ n ih =>
+    simp only [List.ofFn_succ, List.prod_cons]
+    rw [hM (σ 0) (τ 0)]
+    have ih_step := ih (σ ∘ Fin.succ) (τ ∘ Fin.succ)
+    simp only [Function.comp_def] at ih_step
+    rw [ih_step, Matrix.submatrix_mul_equiv _ _ (↑e) e (↑e)]
+    -- Strip the submatrix to work at the (Fin D' × Fin D') level
+    congr 1
+    -- Expand LHS product of sums
+    rw [Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    -- Apply mixed product property
+    simp_rw [← Matrix.mul_kronecker_mul]
+    -- Combine the conjugated matrices: map star (A) * map star (B) = map star (A * B)
+    have map_star_mul : ∀ (P Q : Matrix (Fin D') (Fin D') ℂ),
+        P.map ⇑(starRingEnd ℂ) * Q.map ⇑(starRingEnd ℂ) =
+        (P * Q).map ⇑(starRingEnd ℂ) :=
+      fun P Q => ((starRingEnd ℂ).mapMatrix.map_mul P Q).symm
+    simp_rw [map_star_mul]
+    -- Reindex RHS: ∑ κ : Fin(n+1) → Fin dK = ∑ k, ∑ κ'
+    have reindex : ∀ (F : (Fin (n + 1) → Fin dK) →
+        Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
+      ∑ κ, F κ = ∑ k : Fin dK, ∑ κ' : Fin n → Fin dK,
+        F (Fin.cons k κ') := fun F => by
+          rw [← Fintype.sum_prod_type']
+          exact ((Fin.consEquiv (fun _ : Fin (n + 1) => Fin dK)).sum_comp F).symm
+    symm
+    rw [reindex]
+    simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- **LPDO implies MPDO**: every LPDO tensor generates positive semidefinite
+density operators on all nonempty chains.
+
+The proof uses the Kronecker product structure: the N-site density matrix
+decomposes as `ρ^{(N)} = ∑_κ |ψ_κ⟩⟨ψ_κ|` where each `ψ_κ` is an MPS
+vector built from the purifying tensor, giving a manifestly PSD sum of
+rank-1 positive semidefinite matrices.
+
+See arXiv:1606.00608, Section 4.3. -/
+theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
+  obtain ⟨dK, D', A, e, hM⟩ := h
+  intro N _hN
+  -- Define the MPS coefficient vectors from the purifying tensor
+  set ψ : (Fin N → Fin dK) → (Fin N → Fin d) → ℂ :=
+    fun κ σ => Matrix.trace ((List.ofFn fun l => A (σ l) (κ l)).prod) with hψ
+  -- Show mpo M N = ∑ κ, |ψ_κ⟩⟨ψ_κ|, then conclude PSD
+  suffices hmpo : mpo M N = ∑ κ : Fin N → Fin dK,
+      Matrix.vecMulVec (ψ κ) (star (ψ κ)) by
+    rw [hmpo]
+    exact Matrix.posSemidef_sum _ fun κ _ => Matrix.posSemidef_vecMulVec_self_star _
+  -- Prove the matrix equality entry-by-entry
+  ext σ τ
+  simp only [mpo_apply, mpoMatrixEntry, hψ, evalWord_ofFn]
+  -- Apply the Kronecker product decomposition
+  rw [lpdo_prod_decomp A e hM σ τ]
+  -- trace of submatrix = trace (via equiv reindexing)
+  have trace_sub : ∀ (X : Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
+      Matrix.trace (X.submatrix (↑e) (↑e)) = Matrix.trace X := by
+    intro X; simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
+    exact e.sum_comp (fun p => X p p)
+  rw [trace_sub, Matrix.trace_sum]
+  simp_rw [Matrix.trace_kronecker]
+  -- trace of entrywise conjugate = conjugate of trace: trace(A.map star) = star(trace A)
+  simp_rw [← AddMonoidHom.map_trace (starRingEnd ℂ)]
+  -- Evaluate the entries of the finite sum of rank-one matrices.
+  simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Pi.star_apply, starRingEnd_apply]
+
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Entropy.MutualInformationDataProcessing
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.PureAreaLaw

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Core.TransferMatrix
 import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.ZCL
 

--- a/TNLean/MPS/MPU/VirtualSandwich.lean
+++ b/TNLean/MPS/MPU/VirtualSandwich.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.LinearAlgebra.Matrix.Kronecker
 import TNLean.MPS.MPU.SourceCuts
 import Mathlib.Topology.Instances.Matrix
 


### PR DESCRIPTION
## What changed

- Move `MPOTensor.IsLPDO`, `MPOTensor.lpdo_prod_decomp`, and `MPOTensor.IsLPDO.isMPDO` byte-for-byte from `TNLean/MPS/MPDO/Defs.lean` into the new leaf module `TNLean/MPS/MPDO/LPDO.lean`.
- Remove the Kronecker import from core MPDO definitions and add direct imports only to the five LPDO consumers.
- Give `TNLean/MPS/MPU/VirtualSandwich.lean` its own direct Kronecker import.
- Regenerate the MPDO import aggregator.

`Defs.olean` shrinks from 651,456 B to 465,992 B, a 28.5% reduction. `Defs.ilean` shrinks from 43,866 B to 32,823 B, a 25.2% reduction. Forced wall-clock runs were noisy, so this PR claims structural cone and artifact reduction, not a stable timing speedup.

## Statement-integrity audit

This is an import-boundary refactor only.

- The three moved declaration statements and proof bodies are byte-identical.
- Fully qualified declaration names are unchanged.
- No CPSV16 statement, hypothesis, conclusion, proof route, Blueprint node, or paper-gap disposition changes.
- No compatibility aliases or replacement abstractions are added.
- No `sorry`, `admit`, `axiom`, `unsafe`, `unsafeCast`, or `native_decide` is introduced.
- All five production consumers import the new owner directly.

Classification: build/import-cone optimization. There is no source discrepancy.

## Validation

Exact head: `c8bd0946bb51c25a244b97698c37f62564f4e498`

```bash
./scripts/lake_build_locked.sh \
  TNLean.MPS.MPDO.Defs \
  TNLean.MPS.MPDO.LPDO \
  TNLean.MPS.MPDO.CPSVExample410Operator \
  TNLean.MPS.MPDO.CPSVExample410Spectrum \
  TNLean.MPS.MPDO.CommutingBondTraceMatrixObstruction \
  TNLean.MPS.MPDO.LocalPurificationAreaLaw \
  TNLean.MPS.MPDO.LocalPurificationRFP \
  TNLean.MPS.MPU.VirtualSandwich
python3 scripts/generate_import_aggregators.py --check
python3 scripts/blueprint_lean_sync.py --root . --ci
git diff --check origin/main...HEAD
```

Results:

- targeted locked build passed, 3,493 jobs;
- 36 generated aggregators cover 1,008 production modules;
- all 6,800 Blueprint theorem-like entries resolve;
- diff check passed.

Closes #7403.
