### PR TITLE
feat(MPS/MPU): transport stabilized symmetries

### DIFF
--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -12,12 +12,19 @@ import TNLean.MPS.MPU.PhysicalAncilla
 
 This file formalizes strict equivalence and equivalence after attaching physical
 identity ancillas and then blocking, following arXiv:1703.09188, lines 706--724.
-It also formalizes strict equivalence under symmetry from lines 1340--1354.
+It also formalizes strict and stabilized equivalence under symmetry from
+lines 1340--1366.
 
 The virtual bond dimension is fixed along every path. The source does not specify
 a stabilization that compares tensors of different virtual bond dimensions, so
 no such relation is introduced here. Strict paths remain inside the MPU locus;
 only the canonical-form condition from the paper is omitted along the path.
+
+The symmetry used after adjoining an identity ancilla is supplied as part of a
+coherent dimension-indexed family. This avoids extending an action arbitrarily
+from operators of the form \(X\otimes I\) to the full enlarged operator algebra.
+Blocking, by contrast, canonically conjugates the action along the finite-chain
+configuration equivalence.
 
 ## Main definitions
 
@@ -25,25 +32,29 @@ only the canonical-form condition from the paper is omitted along the path.
 * `MPOTensor.Equivalent`: strict equivalence after positive identity-ancilla
   attachment and a common positive blocking length.
 * `MPOTensor.FiniteChainOperatorSymmetry`: an operator action at specified chain lengths.
+* `MPOTensor.FiniteChainOperatorSymmetryFamily`: coherent actions across physical dimensions.
 * `MPOTensor.StrictlyEquivalentUnderSymmetry`: strict equivalence through invariant MPUs.
+* `MPOTensor.EquivalentUnderSymmetry`: stabilized equivalence through invariant MPUs.
 -/
+
+open scoped Matrix Kronecker
 
 namespace MPOTensor
 
-variable {da db D : ℕ}
+variable {d da db D : ℕ}
 
-/-- A finite-chain operator symmetry consists of an action on every finite-chain
-operator space and a set of chain lengths on which that action is imposed.
+/-- A finite-chain operator symmetry at physical dimension \(d\) consists of an
+action on every length-\(N\) operator space and a set of chain lengths on which
+that action is imposed.
 
-The action is defined for every physical dimension, but no continuity, linearity,
-or compatibility between different chain lengths is assumed at this abstract
-level.
+No continuity, linearity, or compatibility between different chain lengths is
+assumed at this abstract level.
 
 Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
 lines 1345--1354. -/
-structure FiniteChainOperatorSymmetry where
+structure FiniteChainOperatorSymmetry (d : ℕ) where
   applicable : Set ℕ
-  action : {d N : ℕ} →
+  action : {N : ℕ} →
     Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ →
       Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ
 
@@ -57,9 +68,111 @@ the original operator. See `docs/paper-gaps/mpu_canonical_form_full_support.tex`
 
 Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
 lines 1345--1354. -/
-def IsInvariantUnderSymmetry (S : FiniteChainOperatorSymmetry)
-    (W : MPOTensor da D) : Prop :=
+def IsInvariantUnderSymmetry (S : FiniteChainOperatorSymmetry d)
+    (W : MPOTensor d D) : Prop :=
   ∀ ⦃N : ℕ⦄, N ∈ S.applicable → S.action (mpo W N) = mpo W N
+
+/-- Attach an identity ancilla of dimension \(x\) to a finite-chain operator.
+
+This is the canonical embedding \(X\mapsto X\otimes I\), written in the
+sitewise product coordinates used by `tensorPhysicalId`.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1364. -/
+def tensorPhysicalIdOperator {d N : ℕ}
+    (X : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (x : ℕ) :
+    Matrix (Fin N → Fin (d * x)) (Fin N → Fin (d * x)) ℂ :=
+  Matrix.reindex (finTupleProdEquiv N d x).symm
+    (finTupleProdEquiv N d x).symm
+    (X ⊗ₖ (1 : Matrix (Fin N → Fin x) (Fin N → Fin x) ℂ))
+
+/-- A physical-dimension-indexed family of finite-chain symmetries whose actions
+commute with adjoining the canonical identity ancilla.
+
+The applicable lengths are common to every physical dimension. The semiconjugacy
+law specifies the enlarged-dimension action on the image of \(X\mapsto X\otimes I\),
+while the action on the rest of the enlarged operator algebra remains supplied
+data rather than an arbitrary extension.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1364. -/
+structure FiniteChainOperatorSymmetryFamily where
+  applicable : Set ℕ
+  action : {d N : ℕ} →
+    Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ →
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ
+  tensorPhysicalId_semiconj : ∀ (d x N : ℕ),
+    Function.Semiconj (fun X ↦ tensorPhysicalIdOperator X x)
+      (@action d N) (@action (d * x) N)
+
+/-- The component of a coherent symmetry family at physical dimension \(d\). -/
+def FiniteChainOperatorSymmetryFamily.at
+    (S : FiniteChainOperatorSymmetryFamily) (d : ℕ) :
+    FiniteChainOperatorSymmetry d where
+  applicable := S.applicable
+  action := S.action
+
+/-- Canonically transport a symmetry through blocking \(k\) consecutive sites.
+Its applicable blocked lengths are exactly those \(N\) for which the original
+length \(Nk\) is applicable.
+
+Source: arXiv:1703.09188, line 1366. -/
+noncomputable def FiniteChainOperatorSymmetry.block
+    (S : FiniteChainOperatorSymmetry d) (k : ℕ) :
+    FiniteChainOperatorSymmetry (MPSTensor.blockPhysDim d k) where
+  applicable := {N | N * k ∈ S.applicable}
+  action := fun {N} X ↦
+    let e := MPSTensor.blockedConfigEquiv d N k
+    Matrix.reindex e.symm e.symm (S.action (Matrix.reindex e e X))
+
+/-- The blocked action is conjugation along the canonical blocked-configuration
+equivalence.
+
+Source: arXiv:1703.09188, line 1366. -/
+theorem FiniteChainOperatorSymmetry.block_action
+    (S : FiniteChainOperatorSymmetry d) (k N : ℕ)
+    (X : Matrix (Fin N → Fin (MPSTensor.blockPhysDim d k))
+      (Fin N → Fin (MPSTensor.blockPhysDim d k)) ℂ) :
+    (S.block k).action X =
+      Matrix.reindex (MPSTensor.blockedConfigEquiv d N k).symm
+        (MPSTensor.blockedConfigEquiv d N k).symm
+        (S.action (Matrix.reindex (MPSTensor.blockedConfigEquiv d N k)
+          (MPSTensor.blockedConfigEquiv d N k) X)) := rfl
+
+/-- Invariance transports through the canonical identity-ancilla embedding for
+a coherent family of symmetries.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1364. -/
+theorem IsInvariantUnderSymmetry.tensorPhysicalId
+    (S : FiniteChainOperatorSymmetryFamily) {U : MPOTensor d D}
+    (hU : IsInvariantUnderSymmetry (S.at d) U) (x : ℕ) :
+    IsInvariantUnderSymmetry (S.at (d * x)) (tensorPhysicalId U x) := by
+  intro N hN
+  rw [mpo_tensorPhysicalId]
+  change S.action (tensorPhysicalIdOperator (mpo U N) x) =
+    tensorPhysicalIdOperator (mpo U N) x
+  calc
+    S.action (tensorPhysicalIdOperator (mpo U N) x) =
+        tensorPhysicalIdOperator (S.action (mpo U N)) x :=
+      (S.tensorPhysicalId_semiconj d x N (mpo U N)).symm
+    _ = tensorPhysicalIdOperator (mpo U N) x := congrArg (fun X ↦
+      tensorPhysicalIdOperator X x) (hU hN)
+
+/-- Invariance transports through blocking, with the blocked action and its
+applicable lengths pulled back along \(N\mapsto Nk\).
+
+Source: arXiv:1703.09188, line 1366. -/
+theorem IsInvariantUnderSymmetry.blockTensor
+    {S : FiniteChainOperatorSymmetry d} {U : MPOTensor d D}
+    (hU : IsInvariantUnderSymmetry S U) (k : ℕ) :
+    IsInvariantUnderSymmetry (S.block k) (blockTensor U k) := by
+  intro N hN
+  rw [mpo_blockTensor_eq_reindex]
+  simp only [FiniteChainOperatorSymmetry.block_action]
+  let e := MPSTensor.blockedConfigEquiv d N k
+  have hreindex : Matrix.reindex e e
+      (Matrix.reindex e.symm e.symm (mpo U (N * k))) = mpo U (N * k) := by
+    ext σ τ
+    simp [Matrix.reindex_apply]
+  rw [hreindex, hU hN]
 
 /-- Two fixed-bond MPU tensors in canonical form are strictly equivalent when,
 after explicitly identifying their physical dimensions, they are joined by a
@@ -99,7 +212,7 @@ definition only compares tensors in one fixed ambient bond dimension. See
 
 Source: arXiv:1703.09188, Definition `def:strictly-equivalent-symmetry`,
 lines 1345--1354. -/
-def StrictlyEquivalentUnderSymmetry (S : FiniteChainOperatorSymmetry)
+def StrictlyEquivalentUnderSymmetry (S : FiniteChainOperatorSymmetry db)
     (U : MPOTensor da D) (V : MPOTensor db D) (hphys : da = db) : Prop :=
   MPSTensor.IsMPUCanonicalForm U.toMPSTensor ∧
     MPSTensor.IsMPUCanonicalForm V.toMPSTensor ∧
@@ -112,7 +225,7 @@ ordinary strict equivalence.
 Source: arXiv:1703.09188, Definitions `def:strictly-equivalent-tensors` and
 `def:strictly-equivalent-symmetry`, lines 708--714 and 1345--1354. -/
 theorem StrictlyEquivalentUnderSymmetry.toStrictlyEquivalent
-    {S : FiniteChainOperatorSymmetry} {U : MPOTensor da D} {V : MPOTensor db D}
+    {S : FiniteChainOperatorSymmetry db} {U : MPOTensor da D} {V : MPOTensor db D}
     {hphys : da = db} (h : StrictlyEquivalentUnderSymmetry S U V hphys) :
     StrictlyEquivalent U V hphys :=
   ⟨h.1, h.2.1, h.2.2.mono fun _ hW ↦ hW.1⟩
@@ -146,5 +259,45 @@ def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
             (blockTensor (tensorPhysicalId U pa) k)
             (blockTensor (tensorPhysicalId V pb) k)
             (blockedAncillaPhysicalDim_eq k hphys)
+
+/-- Two fixed-bond MPU tensors are equivalent under a coherent symmetry family
+when, after adjoining positive coprime identity ancillas and then applying a
+common positive blocking length, they are strictly equivalent under the
+canonically blocked enlarged-dimension symmetry.
+
+The order is ancilla attachment followed by blocking. The component at the full
+enlarged physical dimension is supplied by the coherent family; it is not an
+extension chosen from the original-dimension action. The blocked applicable
+lengths are exactly \(\{N\mid Nk\in A\}\).
+
+**Scope restriction (arXiv:1703.09188, lines 1356--1366):** the bond dimension
+\(D\) is fixed. The standard-form path criterion belongs to a separate result.
+See `docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1366. -/
+def EquivalentUnderSymmetry (S : FiniteChainOperatorSymmetryFamily)
+    (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
+  IsMPU U ∧ IsMPU V ∧
+    ∃ k pa pb : ℕ,
+      0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
+        ∃ hphys : pa * da = pb * db,
+          StrictlyEquivalentUnderSymmetry
+            ((S.at (db * pb)).block k)
+            (blockTensor (tensorPhysicalId U pa) k)
+            (blockTensor (tensorPhysicalId V pb) k)
+            (blockedAncillaPhysicalDim_eq k hphys)
+
+/-- Forgetting the symmetry from stabilized symmetry-preserving equivalence gives
+ordinary stabilized equivalence.
+
+Source: arXiv:1703.09188, Definitions `def:equivalent-tensors` and
+`def:equivalent-symmetry`, lines 716--724 and 1356--1366. -/
+theorem EquivalentUnderSymmetry.toEquivalent
+    {S : FiniteChainOperatorSymmetryFamily}
+    {U : MPOTensor da D} {V : MPOTensor db D}
+    (h : EquivalentUnderSymmetry S U V) : Equivalent U V := by
+  rcases h with ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys, hstrict⟩
+  exact ⟨hU, hV, k, pa, pb, hk, hpa, hpb, hcoprime, hphys,
+    hstrict.toStrictlyEquivalent⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.MPU.PhysicalAncilla
 
 This file formalizes strict equivalence and equivalence after attaching physical
 identity ancillas and then blocking, following arXiv:1703.09188, lines 706--724.
-It also formalizes strict and stabilized equivalence under symmetry from
-lines 1340--1366.
+It also formalizes strict equivalence under symmetry and the fixed-bond,
+coherent-family variant of stabilized equivalence from lines 1340--1366.
 
 The virtual bond dimension is fixed along every path. The source does not specify
 a stabilization that compares tensors of different virtual bond dimensions, so

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -270,9 +270,13 @@ enlarged physical dimension is supplied by the coherent family; it is not an
 extension chosen from the original-dimension action. The blocked applicable
 lengths are exactly \(\{N\mid Nk\in A\}\).
 
-**Scope restriction (arXiv:1703.09188, lines 1356--1366):** the bond dimension
-\(D\) is fixed. The standard-form path criterion belongs to a separate result.
-See `docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
+**Scope restriction (arXiv:1703.09188, lines 1356--1366):** the virtual bond
+dimension \(D\) is fixed. In addition, the symmetry is supplied as a family
+indexed by physical dimension that semiconjugates every canonical
+identity-ancilla embedding. The standard-form path criterion belongs to a
+separate result. See
+`docs/paper-gaps/mpu_equivalence_fixed_bond.tex` and
+`docs/paper-gaps/mpu_symmetry_ancilla_transport.tex`.
 
 Source: arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1366. -/
 def EquivalentUnderSymmetry (S : FiniteChainOperatorSymmetryFamily)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6914,9 +6914,22 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}\leanok
-    At a blocked length $N$, identify the blocked operator with $U^{(Nk)}$.
-    The two inverse configuration reindexings cancel, and invariance follows
-    because $Nk\in A$.
+    Let $R_{d,N,k}$ be the canonical identification from blocked length-$N$
+    configurations to unblocked length-$Nk$ configurations. For $N\in A_k$,
+    one has $Nk\in A$ and
+    \begin{align}
+        \mathcal S_{k,N}\bigl[U_k^{(N)}\bigr]
+         & = R_{d,N,k}^{-1}\!\left(
+        \mathcal S_{d,Nk}\!\left[
+                R_{d,N,k}\bigl(U_k^{(N)}\bigr)
+        \right]\right)                               \\
+         & = R_{d,N,k}^{-1}\!\left(
+        \mathcal S_{d,Nk}\bigl[U^{(Nk)}\bigr]\right) \\
+         & = R_{d,N,k}^{-1}\bigl(U^{(Nk)}\bigr)      \\
+         & = U_k^{(N)}.
+    \end{align}
+    The second and final equalities are the inverse reindexing identities, and
+    the third is invariance of $U^{(Nk)}$ because $Nk\in A$.
 \end{proof}
 
 \begin{definition}[Strict equivalence under a symmetry]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6855,13 +6855,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     an ancilla dimension $x$, let
     \begin{align}
         \iota_x(X)
-          & = R_{d,x,N}\bigl(X\otimes I_{x^N}\bigr)R_{d,x,N}^{-1},
+         & = R_{d,x,N}\bigl(X\otimes I_{x^N}\bigr)R_{d,x,N}^{-1},
     \end{align}
     where $R_{d,x,N}$ is the canonical sitewise identification of the
     $d$-dimensional and $x$-dimensional configurations. Coherence means
     \begin{align}
         \iota_x\bigl(\mathcal S_{d,N}(X)\bigr)
-          & = \mathcal S_{dx,N}\bigl(\iota_x(X)\bigr).
+         & = \mathcal S_{dx,N}\bigl(\iota_x(X)\bigr).
     \end{align}
     Thus the action on the full enlarged operator algebra is supplied data; it
     is not obtained by extending its values on operators $X\otimes I$.
@@ -6883,8 +6883,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Semiconjugacy and invariance of $U^{(N)}$ give
     \begin{align}
         \mathcal S_{dx,N}\bigl(\iota_x(U^{(N)})\bigr)
-          & = \iota_x\bigl(\mathcal S_{d,N}(U^{(N)})\bigr)
-           = \iota_x(U^{(N)}).
+         & = \iota_x\bigl(\mathcal S_{d,N}(U^{(N)})\bigr)
+        = \iota_x(U^{(N)}).
     \end{align}
 \end{proof}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6995,11 +6995,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
     $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a
     positive blocking length $k$ and coprime positive ancilla dimensions
-    $p_a,p_b$ with
-    \begin{align}
-        p_ad_a & =p_bd_b
-    \end{align}
-    such that $(\mathcal U^{(p_a)})_k$ and
+    $p_a,p_b$ with $p_ad_a=p_bd_b$ such that $(\mathcal U^{(p_a)})_k$ and
     $(\mathcal V^{(p_b)})_k$ are strictly equivalent under $\mathcal S$.
     % Source lines: paper_v2.tex 1356--1366.
 \end{definition}
@@ -7019,11 +7015,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     have physical dimensions $d_a$ and $d_b$. They are coherently equivalent
     under a dimension-indexed symmetry family $\mathcal S$ if they are MPUs and
     there are a positive blocking length $k$ and coprime positive ancilla
-    dimensions $p_a,p_b$ with
-    \begin{align}
-        p_ad_a & =p_bd_b
-    \end{align}
-    such that $(\mathcal U^{(p_a)})_k$ and
+    dimensions $p_a,p_b$ with $p_ad_a=p_bd_b$ such that
+    $(\mathcal U^{(p_a)})_k$ and
     $(\mathcal V^{(p_b)})_k$ are strictly equivalent under the $k$-site
     blocking of the supplied enlarged-dimension symmetry. The family obeys the
     identity-ancilla semiconjugacy law, and its applicable blocked lengths are

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6977,7 +6977,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{definition}[Equivalence under a symmetry]
     \label{def:equivalent-symmetry}
     \notready
-    \discussion{6017}
+    \discussion{7422}
     \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors}
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
     $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6868,15 +6868,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1356--1364.
 \end{definition}
 
-\begin{lemma}[Identity-ancilla transport of symmetry invariance]
-    \label{lem:mpu_symmetry_identity_ancilla_invariant}
+\begin{theorem}[Identity-ancilla transport of symmetry invariance]
+    \label{thm:mpu_symmetry_identity_ancilla_invariant}
     \lean{MPOTensor.IsInvariantUnderSymmetry.tensorPhysicalId}
     \leanok
     \uses{def:mpu_coherent_symmetry_family, def:equivalent-tensors}
     If $\mathcal U$ is invariant under the $d$-dimensional component of a
     coherent symmetry family, then $\mathcal U^{(x)}$ is invariant under its
     $dx$-dimensional component.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     The finite-chain operator of $\mathcal U^{(x)}$ is $\iota_x(U^{(N)})$.
@@ -6904,14 +6904,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source line: paper_v2.tex 1366.
 \end{definition}
 
-\begin{lemma}[Blocking transport of symmetry invariance]
-    \label{lem:mpu_symmetry_blocking_invariant}
+\begin{theorem}[Blocking transport of symmetry invariance]
+    \label{thm:mpu_symmetry_blocking_invariant}
     \lean{MPOTensor.IsInvariantUnderSymmetry.blockTensor}
     \leanok
     \uses{def:mpu_blocked_finite_chain_symmetry, thm:mpdo_closed_chain_physical_blocking}
     If $\mathcal U$ is invariant under $\mathcal S$, then its $k$-site blocking
     is invariant under the blocked symmetry.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Let $R_{d,N,k}$ be the canonical identification from blocked length-$N$
@@ -7032,15 +7032,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1356--1366, under the stated restrictions.
 \end{definition}
 
-\begin{lemma}[Forgetting symmetry from coherent stabilized equivalence]
-    \label{lem:mpu_symmetry_equivalence_forget}
+\begin{theorem}[Forgetting symmetry from coherent stabilized equivalence]
+    \label{thm:mpu_symmetry_equivalence_forget}
     \lean{MPOTensor.EquivalentUnderSymmetry.toEquivalent}
     \leanok
     \uses{def:mpu_coherent_family_equivalent_symmetry, def:equivalent-tensors,
         lem:mpu_strict_symmetry_equivalence_forget}
     Fixed-bond equivalence under a coherent symmetry family implies ordinary
     equivalence after the same ancillas and blocking.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Retain the MPU hypotheses, positive coprime ancilla dimensions, common

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6976,35 +6976,57 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Equivalence under a symmetry]
     \label{def:equivalent-symmetry}
-    \lean{MPOTensor.EquivalentUnderSymmetry}
-    \leanok
-    \discussion{7015}
-    \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors,
-        def:mpu_coherent_symmetry_family, def:mpu_blocked_finite_chain_symmetry}
-    Fix a virtual bond dimension $D$, and let $\mathcal U$ and $\mathcal V$
-    have physical dimensions $d_a$ and $d_b$. They are equivalent under a
-    coherent symmetry family $\mathcal S$ if they are MPUs and there are a
+    \notready
+    \discussion{6017}
+    \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors}
+    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
+    $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a
     positive blocking length $k$ and coprime positive ancilla dimensions
     $p_a,p_b$ with
     \begin{align}
         p_ad_a & =p_bd_b
     \end{align}
     such that $(\mathcal U^{(p_a)})_k$ and
-    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under the $k$-site
-    blocking of the supplied enlarged-dimension symmetry. Its applicable
-    finite blocked chains are precisely the lengths $N$ for which $Nk\in A$.
-    The ancillas are attached before the common blocking.
+    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under $\mathcal S$.
     % Source lines: paper_v2.tex 1356--1366.
 \end{definition}
 
-\begin{lemma}[Forgetting symmetry from stabilized equivalence]
+\begin{definition}[Fixed-bond coherent-family equivalence under a symmetry]
+    \label{def:mpu_coherent_family_equivalent_symmetry}
+    \lean{MPOTensor.EquivalentUnderSymmetry}
+    \leanok
+    \discussion{7015}
+    \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors,
+        def:mpu_coherent_symmetry_family, def:mpu_blocked_finite_chain_symmetry}
+    % **Scope restriction (fixed bond and coherent family):** the symmetry is
+    % supplied at every physical dimension and semiconjugates the canonical
+    % identity-ancilla embeddings. Documented in
+    % docs/paper-gaps/mpu_symmetry_ancilla_transport.tex.
+    Fix a virtual bond dimension $D$, and let $\mathcal U$ and $\mathcal V$
+    have physical dimensions $d_a$ and $d_b$. They are coherently equivalent
+    under a dimension-indexed symmetry family $\mathcal S$ if they are MPUs and
+    there are a positive blocking length $k$ and coprime positive ancilla
+    dimensions $p_a,p_b$ with
+    \begin{align}
+        p_ad_a & =p_bd_b
+    \end{align}
+    such that $(\mathcal U^{(p_a)})_k$ and
+    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under the $k$-site
+    blocking of the supplied enlarged-dimension symmetry. The family obeys the
+    identity-ancilla semiconjugacy law, and its applicable blocked lengths are
+    precisely the lengths $N$ for which $Nk\in A$. The ancillas are attached
+    before the common blocking.
+    % Source lines: paper_v2.tex 1356--1366, under the stated restrictions.
+\end{definition}
+
+\begin{lemma}[Forgetting symmetry from coherent stabilized equivalence]
     \label{lem:mpu_symmetry_equivalence_forget}
     \lean{MPOTensor.EquivalentUnderSymmetry.toEquivalent}
     \leanok
-    \uses{def:equivalent-symmetry, def:equivalent-tensors,
+    \uses{def:mpu_coherent_family_equivalent_symmetry, def:equivalent-tensors,
         lem:mpu_strict_symmetry_equivalence_forget}
-    Equivalence under a coherent symmetry family implies ordinary equivalence
-    after the same ancillas and blocking.
+    Fixed-bond equivalence under a coherent symmetry family implies ordinary
+    equivalence after the same ancillas and blocking.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6827,22 +6827,97 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.FiniteChainOperatorSymmetry,
         MPOTensor.IsInvariantUnderSymmetry}
     \leanok
-    A finite-chain operator symmetry $\mathcal S$ specifies a set $A$ of
-    applicable chain lengths and, for every physical dimension $d$ and length
-    $N$, a map
+    At physical dimension $d$, a finite-chain operator symmetry $\mathcal S$
+    specifies a set $A$ of applicable chain lengths and, for every length $N$,
+    a map
     \begin{align}
         \mathcal S_{d,N}\colon
         \operatorname{Mat}_{d^N}(\mathbb C)
          & \longrightarrow \operatorname{Mat}_{d^N}(\mathbb C).
     \end{align}
-    We suppress the subscripts on $\mathcal S_{d,N}$ when $d$ and $N$ are
-    understood. An MPO tensor $\mathcal W$ is invariant under $\mathcal S$ if
+    An MPO tensor $\mathcal W$ is invariant under $\mathcal S$ if
     \begin{align}
         \mathcal S_{d,N}[W^{(N)}] & =W^{(N)}
     \end{align}
     for every $N\in A$.
     % Source lines: paper_v2.tex 1345--1354.
 \end{definition}
+
+\begin{definition}[Coherent symmetry family under identity ancillas]
+    \label{def:mpu_coherent_symmetry_family}
+    \lean{MPOTensor.tensorPhysicalIdOperator,
+        MPOTensor.FiniteChainOperatorSymmetryFamily,
+        MPOTensor.FiniteChainOperatorSymmetryFamily.at}
+    \leanok
+    \uses{def:mpu_finite_chain_operator_symmetry, def:equivalent-tensors}
+    A coherent symmetry family supplies an action $\mathcal S_{d,N}$ for every
+    physical dimension $d$, with one common set $A$ of applicable lengths. For
+    an ancilla dimension $x$, let
+    \begin{align}
+        \iota_x(X)
+          & = R_{d,x,N}\bigl(X\otimes I_{x^N}\bigr)R_{d,x,N}^{-1},
+    \end{align}
+    where $R_{d,x,N}$ is the canonical sitewise identification of the
+    $d$-dimensional and $x$-dimensional configurations. Coherence means
+    \begin{align}
+        \iota_x\bigl(\mathcal S_{d,N}(X)\bigr)
+          & = \mathcal S_{dx,N}\bigl(\iota_x(X)\bigr).
+    \end{align}
+    Thus the action on the full enlarged operator algebra is supplied data; it
+    is not obtained by extending its values on operators $X\otimes I$.
+    % Source lines: paper_v2.tex 1356--1364.
+\end{definition}
+
+\begin{lemma}[Identity-ancilla transport of symmetry invariance]
+    \label{lem:mpu_symmetry_identity_ancilla_invariant}
+    \lean{MPOTensor.IsInvariantUnderSymmetry.tensorPhysicalId}
+    \leanok
+    \uses{def:mpu_coherent_symmetry_family, def:equivalent-tensors}
+    If $\mathcal U$ is invariant under the $d$-dimensional component of a
+    coherent symmetry family, then $\mathcal U^{(x)}$ is invariant under its
+    $dx$-dimensional component.
+\end{lemma}
+
+\begin{proof}\leanok
+    The finite-chain operator of $\mathcal U^{(x)}$ is $\iota_x(U^{(N)})$.
+    Semiconjugacy and invariance of $U^{(N)}$ give
+    \begin{align}
+        \mathcal S_{dx,N}\bigl(\iota_x(U^{(N)})\bigr)
+          & = \iota_x\bigl(\mathcal S_{d,N}(U^{(N)})\bigr)
+           = \iota_x(U^{(N)}).
+    \end{align}
+\end{proof}
+
+\begin{definition}[Blocked finite-chain symmetry]
+    \label{def:mpu_blocked_finite_chain_symmetry}
+    \lean{MPOTensor.FiniteChainOperatorSymmetry.block,
+        MPOTensor.FiniteChainOperatorSymmetry.block_action}
+    \leanok
+    \uses{def:mpu_finite_chain_operator_symmetry, lem:eval_word_block}
+    For a blocking length $k$, the blocked symmetry has applicable lengths
+    \begin{align}
+        A_k & = \{N\mid Nk\in A\}.
+    \end{align}
+    Its action is obtained by conjugating $\mathcal S_{d,Nk}$ along the
+    canonical identification
+    $(\mathbb C^{d^k})^{\otimes N}\cong(\mathbb C^d)^{\otimes Nk}$.
+    % Source line: paper_v2.tex 1366.
+\end{definition}
+
+\begin{lemma}[Blocking transport of symmetry invariance]
+    \label{lem:mpu_symmetry_blocking_invariant}
+    \lean{MPOTensor.IsInvariantUnderSymmetry.blockTensor}
+    \leanok
+    \uses{def:mpu_blocked_finite_chain_symmetry, thm:mpdo_closed_chain_physical_blocking}
+    If $\mathcal U$ is invariant under $\mathcal S$, then its $k$-site blocking
+    is invariant under the blocked symmetry.
+\end{lemma}
+
+\begin{proof}\leanok
+    At a blocked length $N$, identify the blocked operator with $U^{(Nk)}$.
+    The two inverse configuration reindexings cancel, and invariance follows
+    because $Nk\in A$.
+\end{proof}
 
 \begin{definition}[Strict equivalence under a symmetry]
     \label{def:strictly-equivalent-symmetry}
@@ -6901,16 +6976,43 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Equivalence under a symmetry]
     \label{def:equivalent-symmetry}
-    \notready
-    \discussion{6017}
-    \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors}
-    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
-    $d_b$. They are equivalent under a symmetry $\mathcal S$ if there are a
+    \lean{MPOTensor.EquivalentUnderSymmetry}
+    \leanok
+    \discussion{7015}
+    \uses{def:strictly-equivalent-symmetry, def:equivalent-tensors,
+        def:mpu_coherent_symmetry_family, def:mpu_blocked_finite_chain_symmetry}
+    Fix a virtual bond dimension $D$, and let $\mathcal U$ and $\mathcal V$
+    have physical dimensions $d_a$ and $d_b$. They are equivalent under a
+    coherent symmetry family $\mathcal S$ if they are MPUs and there are a
     positive blocking length $k$ and coprime positive ancilla dimensions
-    $p_a,p_b$ with $p_ad_a=p_bd_b$ such that $(\mathcal U^{(p_a)})_k$ and
-    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under $\mathcal S$.
-    % Source lines: paper_v2.tex 1356--1364.
+    $p_a,p_b$ with
+    \begin{align}
+        p_ad_a & =p_bd_b
+    \end{align}
+    such that $(\mathcal U^{(p_a)})_k$ and
+    $(\mathcal V^{(p_b)})_k$ are strictly equivalent under the $k$-site
+    blocking of the supplied enlarged-dimension symmetry. Its applicable
+    finite blocked chains are precisely the lengths $N$ for which $Nk\in A$.
+    The ancillas are attached before the common blocking.
+    % Source lines: paper_v2.tex 1356--1366.
 \end{definition}
+
+\begin{lemma}[Forgetting symmetry from stabilized equivalence]
+    \label{lem:mpu_symmetry_equivalence_forget}
+    \lean{MPOTensor.EquivalentUnderSymmetry.toEquivalent}
+    \leanok
+    \uses{def:equivalent-symmetry, def:equivalent-tensors,
+        lem:mpu_strict_symmetry_equivalence_forget}
+    Equivalence under a coherent symmetry family implies ordinary equivalence
+    after the same ancillas and blocking.
+\end{lemma}
+
+\begin{proof}\leanok
+    Retain the MPU hypotheses, positive coprime ancilla dimensions, common
+    positive blocking length, and physical-dimension equality from the
+    symmetry-preserving witness. Forgetting invariance from its final strict
+    path gives the required ordinary stabilized equivalence.
+\end{proof}
 
 \begin{definition}[Admissible equivalence under a symmetry]
     \label{def:mpu_admissible_symmetry_equivalence}

--- a/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
+++ b/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
@@ -25,9 +25,10 @@ For an ancilla dimension $x$, the canonical map on a length-$N$ chain is
 \begin{align}
     \iota_x(X) & = R(X\otimes I_{x^N})R^{-1}.
 \end{align}
-When $x>1$, this is an embedding into the enlarged operator algebra, not an
-equivalence onto it. Consequently, an action specified at dimension $d$ can
-constrain the enlarged action on $\iota_x(X)$ but cannot determine its values
+When $d>0$, $N>0$, and $x>1$, this is an embedding into the enlarged operator
+algebra, not an equivalence onto it. Consequently, in this setting an action at
+dimension $d$ can constrain the enlarged action on $\iota_x(X)$ but cannot
+determine its values
 on arbitrary operators at dimension $dx$. A strict-equivalence path can leave
 the image of $\iota_x$, so an action defined only on that image is insufficient.
 

--- a/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
+++ b/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
@@ -21,24 +21,41 @@ an identity ancilla.
 
 \section{Missing transport}
 
-For an ancilla dimension $x$, the canonical map on a length-$N$ chain is
+Let $d>0$ be the original physical dimension, let $N>0$ be the chain length,
+and let $x>1$ be an ancilla dimension. The canonical sitewise rearrangement is
 \begin{align}
-    \iota_x(X) & = R(X\otimes I_{x^N})R^{-1}.
+    R_{d,x,N}\colon
+    (\mathbb C^d)^{\otimes N}\otimes(\mathbb C^x)^{\otimes N}
+     & \longrightarrow (\mathbb C^{dx})^{\otimes N}.
+    \label{eq:mpu_symmetry_ancilla_transport_sitewise_rearrangement}
 \end{align}
-When $d>0$, $N>0$, and $x>1$, this is an embedding into the enlarged operator
-algebra, not an equivalence onto it. Consequently, in this setting an action at
-dimension $d$ can constrain the enlarged action on $\iota_x(X)$ but cannot
-determine its values
+It induces the operator embedding
+\begin{align}
+    \iota_x(X)
+     & = R_{d,x,N}(X\otimes I_{x^N})R_{d,x,N}^{-1}.
+    \label{eq:mpu_symmetry_ancilla_transport_operator_embedding}
+\end{align}
+Under these nondegeneracy assumptions, the map in
+(\ref{eq:mpu_symmetry_ancilla_transport_operator_embedding}) is not onto the
+enlarged operator algebra. Consequently, an action at dimension $d$ can
+constrain the enlarged action on $\iota_x(X)$ but cannot determine its values
 on arbitrary operators at dimension $dx$. A strict-equivalence path can leave
 the image of $\iota_x$, so an action defined only on that image is insufficient.
 
-The formalized restricted definition therefore takes actions at every physical
-dimension as supplied data and assumes
+The formalized restricted construction therefore takes actions at every
+physical dimension as supplied data and assumes
 \begin{align}
     \iota_x(\mathcal S_{d,N}(X))
      & = \mathcal S_{dx,N}(\iota_x(X)).
+    \label{eq:mpu_symmetry_ancilla_transport_semiconjugacy}
 \end{align}
-It also fixes one ambient virtual bond dimension along the path.
+The symmetry family supplies the condition in
+(\ref{eq:mpu_symmetry_ancilla_transport_semiconjugacy}), while the stabilized
+equivalence also fixes one ambient virtual bond dimension along the path.\footnote{Formal declarations:
+    \leanid{MPOTensor.FiniteChainOperatorSymmetryFamily} supplies the
+    dimension-indexed actions and semiconjugacy law;
+    \leanid{MPOTensor.EquivalentUnderSymmetry} defines the fixed-bond
+    coherent-family equivalence.}
 
 \section{Verdict}
 

--- a/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
+++ b/docs/paper-gaps/mpu_symmetry_ancilla_transport.tex
@@ -1,0 +1,52 @@
+\documentclass{article}
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\input{command}
+\title{Identity-Ancilla Transport of MPU Symmetries}
+\author{}
+\date{2026-08-29}
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{Source definition}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define two MPU tensors to be
+equivalent under a symmetry when identity ancillas and a common blocking make
+them strictly equivalent under that symmetry
+\cite[lines~1356--1366]{Cirac2017MPU}. The definition does not state how an
+action on the original physical dimension determines an action after adjoining
+an identity ancilla.
+
+\section{Missing transport}
+
+For an ancilla dimension $x$, the canonical map on a length-$N$ chain is
+\begin{align}
+    \iota_x(X) & = R(X\otimes I_{x^N})R^{-1}.
+\end{align}
+When $x>1$, this is an embedding into the enlarged operator algebra, not an
+equivalence onto it. Consequently, an action specified at dimension $d$ can
+constrain the enlarged action on $\iota_x(X)$ but cannot determine its values
+on arbitrary operators at dimension $dx$. A strict-equivalence path can leave
+the image of $\iota_x$, so an action defined only on that image is insufficient.
+
+The formalized restricted definition therefore takes actions at every physical
+dimension as supplied data and assumes
+\begin{align}
+    \iota_x(\mathcal S_{d,N}(X))
+     & = \mathcal S_{dx,N}(\iota_x(X)).
+\end{align}
+It also fixes one ambient virtual bond dimension along the path.
+
+\section{Verdict}
+
+\textbf{Verdict: scope restriction.} The coherent-family definition is a
+well-defined strengthened variant, not the unrestricted source definition.
+The source-level definition remains unformalized until the intended actions on
+the full enlarged operator algebras are specified without adding the
+semiconjugacy hypothesis to the cited statement.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+\end{document}


### PR DESCRIPTION
## Summary

- index finite-chain operator symmetries by physical dimension and add a coherent family across dimensions
- define the canonical identity-ancilla operator embedding and require its `Function.Semiconj` compatibility, without extending an action arbitrarily outside the image
- transport symmetry actions and invariance canonically through physical blocking, with applicable lengths exactly `{N | N * k ∈ A}`
- define fixed-bond stabilized `EquivalentUnderSymmetry` in the source's ancilla-then-block order and prove its forgetful theorem to `Equivalent`
- synchronize the Chapter 28 definitions, transport lemmas, and proof dependencies

Closes #7015.

## Source faithfulness

This follows arXiv:1703.09188, Definition `def:equivalent-symmetry`, lines 1356--1366. The enlarged-dimension symmetry is supplied as part of a coherent family and only constrained on `X ⊗ I` by semiconjugacy. Blocking is canonical along `MPSTensor.blockedConfigEquiv`. No arbitrary extension, partial action, or standard-form path criterion is introduced.

## Checks

- `lake env lean TNLean/MPS/MPU/Equivalence.lean`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPU/Equivalence.lean`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/tactic_pattern_scan.py --root TNLean/MPS/MPU --top 10`
- `git diff --check`

`leanblueprint checkdecls` is currently blocked in this seeded worktree by the pre-existing duplicate environment declaration `Matrix.trace_pow_mul_comm` while importing QICLean and TNLean; source-level Blueprint synchronization and reverse coverage both pass (Chapter 28: 824/824).
