### PR TITLE
docs(MPDO): use area-law saturation terminology

### DIFF
--- a/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.SectorTrace
 /-!
 # Saturated area law for the four-sector classical tensor
 
-This file proves the strong area law for the explicit four-sector tensor in
+This file proves saturation of the area law for the explicit four-sector tensor in
 `ActiveSectorSpanningCounterexample`.  Its finite-chain operators are the
 classical cyclic law determined by the neighboring transition matrix
 \[
@@ -22,7 +22,7 @@ explicit Hayashi quantum-Markov decomposition at every admissible cut.
 
 ## Main result
 
-* `tensor_isSAL`: the four-sector tensor satisfies the strong area law.
+* `tensor_isSAL`: the four-sector tensor satisfies saturation of the area law.
 
 ## Reference
 
@@ -479,7 +479,7 @@ private theorem nonempty_markovDecomposition_tripartite
     rw [Matrix.one_apply_ne htuple]
     simp [hii]
 
-/-- The four-sector classical tensor satisfies the strong area law.  The
+/-- The four-sector classical tensor satisfies saturation of the area law.  The
 proof uses its exact cyclic transition law and the resulting quantum-Markov
 decomposition at every admissible cut; it does not assume that the transition
 matrix has rank one.

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -25,7 +25,7 @@ while
 
 Thus spanning by the full virtual matrix algebra does not, by itself, prove
 the missing vanishing in the proof of Lemma C.5.  The induced classical cyclic
-family satisfies the strong area law mathematically.  The companion
+family satisfies saturation of the area law mathematically.  The companion
 `ActiveSectorInverseMapProvenance` calculation identifies the factorization
 below with one selected by an explicit Hayashi decomposition, normalized tail,
 and inverse map.
@@ -550,7 +550,7 @@ positive semidefinite neighboring operators, an injective tensor with literal
 physical-trace idempotence, and a primitive trace-one active trace matrix, while
 that matrix is non-idempotent and the rectangular remainder is nonzero.
 
-The companion area-law theorem proves the strong area law for this tensor.
+The companion area-law theorem proves saturation of the area law for this tensor.
 Nevertheless, this is a counterexample only to the proposed intermediate
 implication.  Lemma C.5 is proved in Case I under the standing assumption that
 the tensor is an injective normal tensor; the raw tensor here does not have that

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningRFP.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningRFP.lean
@@ -26,7 +26,7 @@ used in this development. The paper's literal zero-correlation-length diagram
 has the same normalization sensitivity and is not the up-to-scalar predicate.
 
 This classification concerns the explicit tensor. It does not prove the
-general implication from the strong area law and zero correlation length to a
+general implication from saturation of the area law and zero correlation length to a
 renormalization fixed point in Theorem 4.9; the printed proof of that implication
 still passes through the normalization-sensitive rank-one step of Lemma C.5.
 
@@ -255,8 +255,8 @@ theorem is not an instance of Definition 4.1 for the raw representative.
 Documented in
 <https://sirui-lu.com/QICLean/paper-gaps/cpsv16_zcl_canonical_form_normalization.pdf>.
 
-This is a classification of this explicit tensor, not a proof of the general
-strong-area-law and zero-correlation-length implication in Theorem 4.9.
+This is a classification of this explicit tensor, not a proof of the general implication
+from saturation of the area law and zero correlation length in Theorem 4.9.
 
 Source: arXiv:1606.00608, Definition 4.1, lines 645--659, and the proposed
 implication in Theorem 4.9 at lines 1810--1825. -/

--- a/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
+++ b/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
@@ -77,7 +77,7 @@ twice-applied channel observation at lines 1821--1825.
 
 **Scope restriction (supplied per-representative factorizations):** the
 neighboring trace factorizations of the absorbed representatives are assumed
-here, while Proposition `prop2to5` derives them from the strong area law and
+here, while Proposition `prop2to5` derives them from saturation of the area law and
 zero correlation length through the printed factorization assertion of
 Proposition `prop2to3`.  That derivation remains open; it is documented in
 <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
@@ -123,7 +123,7 @@ four selected sectors.
 
 **Scope restriction (supplied per-representative factorizations):** the
 single-sector factorizations are assumed here rather than derived from the
-strong area law and zero correlation length; the derivation is documented in
+saturation of the area law and zero correlation length; the derivation is documented in
 <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.BNTProjectorSelection
 
 /-!
-# Separating projectors for a simple tensor satisfying the strong area law
+# Separating projectors for a simple tensor satisfying saturation of the area law
 
 For the four-site quantum-Markov decomposition, the BNT projectors resolve the
 positive-weight Markov support. The remaining zero-weight Markov summands

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -255,7 +255,7 @@ theorem exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
   exact ⟨z, hpos, (F.rephase z).activeSectorTraceMatrix_isPrimitive
     hη.p hpos hspan hnonzero htriangle⟩
 
-/-- Every injective MPO tensor satisfying the strong area law admits a
+/-- Every injective MPO tensor satisfying saturation of the area law admits a
 positive physical-sector factorization whose active trace matrix is primitive.
 
 The accompanying weights are nonnegative and sum to one. Zero-weight sectors

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -268,7 +268,7 @@ theorem exists_positive_inverseMapPhysicalSectorFactorization
     K hK R hρ hη alpha beta hm hM
   exact ⟨F.rephase z, hpos⟩
 
-/-- Every injective MPO tensor satisfying the strong area law admits a
+/-- Every injective MPO tensor satisfying saturation of the area law admits a
 physical-sector factorization with positive semidefinite neighboring
 operators.
 
@@ -293,7 +293,7 @@ theorem exists_positive_physicalSectorFactorization_of_isSAL
     (normalizedFourSiteTail K) (isThreeSiteClosure_reducedBlockState K)
     hη alpha beta hm (Classical.choose hSAL)
 
-/-- Every injective MPO tensor satisfying the strong area law has the
+/-- Every injective MPO tensor satisfying saturation of the area law has the
 positive commuting nearest-neighbor product structure of Proposition C.8.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.MPDO.SALTraceTransfer
 
 The positive normalization furnished by source zero correlation length gives
 the square--cube and positive-power trace relations on the same active,
-positively rephased trace matrix that is primitive under the strong area law.
+positively rephased trace matrix that is primitive under saturation of the area law.
 
 The argument writes the physical-trace transfer as a rectangular product
 indexed only by sectors of nonzero Hayashi weight.  The opposite rectangular
@@ -25,7 +25,7 @@ neighboring operators are positive semidefinite.
   the inverse-map construction has one rephasing for which positivity,
   primitivity, and both normalized relations hold.
 * `exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL`:
-  the corresponding existence statement from the strong area law and source
+  the corresponding existence statement from saturation of the area law and source
   zero correlation length.
 
 ## References
@@ -93,7 +93,7 @@ theorem exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations
       hη.p hinactive hpos hZCL
   exact ⟨z, lam, hlam, hpos, hprim, hrel⟩
 
-/-- Every injective MPO tensor satisfying the strong area law and source zero
+/-- Every injective MPO tensor satisfying saturation of the area law and source zero
 correlation length admits a positive physical-sector factorization whose
 active trace matrix is primitive and whose common positive normalization
 satisfies the square--cube and positive-power trace relations.
@@ -141,7 +141,7 @@ theorem exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL
   exact ⟨F₀.rephase z, hη.p, lam, hlam, hη.hp_nonneg, hη.hp_sum,
     hpos, hprim, hrel⟩
 
-/-- Every injective MPO tensor satisfying the strong area law and literal
+/-- Every injective MPO tensor satisfying saturation of the area law and literal
 idempotence of the physical-trace transfer admits the same positive
 physical-sector factorization and primitive normalized active trace matrix as
 in the source-ZCL theorem.

--- a/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
@@ -7,9 +7,9 @@ import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
 import TNLean.MPS.MPDO.LemmaC5CaseI
 
 /-!
-# The literal normal Case-I coefficient theorem from the strong area law
+# The literal normal Case-I coefficient theorem from saturation of the area law
 
-The strong area law supplies the Hayashi decomposition and its MPDO positivity.
+Saturation of the area law supplies the Hayashi decomposition and its MPDO positivity.
 The inverse-map construction retains one positive rephasing together with the
 active spanning, nonvanishing, recurrence, inactive-sector, and nonemptiness
 witnesses. Literal zero correlation length and normality then give normalized
@@ -80,7 +80,7 @@ theorem exists_rephased_inverseMap_caseI_rank_one_coefficients_witnesses
     K hK (normalizedFourSiteTail K) (isThreeSiteClosure_reducedBlockState K)
       hη alpha beta hm z k h hzero
 
-/-- An injective normal MPO tensor satisfying the strong area law and literal
+/-- An injective normal MPO tensor satisfying saturation of the area law and literal
 zero correlation length admits normalized rank-one coefficients for the active
 inverse-map trace matrix.
 
@@ -194,7 +194,7 @@ coherently rephased inverse-map witness; CPSV16 does not specify this
 inactive-sector convention. See <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
 
 **Scope restriction (normal Case I):** this theorem assumes injectivity, the
-strong area law, literal zero correlation length, and normality. It makes no
+saturation of the area law, literal zero correlation length, and normality. It makes no
 scale-invariant ZCL or Case-II claim. See
 <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> for the precise paper boundary.
 

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -48,7 +48,7 @@ A completely positive coarse-graining map cannot send the former to the latter.
 * `tensor_isSAL`: the tensor saturates the area law (Definition 4.6).
 * `exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS`:
   the tensor simultaneously exhibits CPSV canonical form, MPDO positivity,
-  idempotent physical-trace transfer, strong area law, and absence of
+  idempotent physical-trace transfer, saturation of the area law, and absence of
   fixed-scale renormalization.
 
 ## References
@@ -318,7 +318,7 @@ The nonexistence of fixed-scale channels is not stated by Kato; it follows
 from the one- and two-site closure identities above.  Kato proves that the family has an
 exact renormalization flow in which the tensor changes; arXiv:2410.22696,
 lines 692--706 and 827--838 distinguishes that flow from its fixed points.
-No canonical-form, strong-area-law, or static-converse assertion is made here.
+No assertion about canonical form, saturation of the area law, or a static converse is made here.
 -/
 theorem tensor_not_isRFPViaTS : ¬ IsRFPViaTS tensor := by
   intro hRFP
@@ -552,7 +552,7 @@ theorem tensor_toMPSTensor_isCPSVCanonicalForm :
     (fun _ => by norm_num) katoCFWeights katoCFWeights_ne_zero katoCFBlocks
     katoCFBlocks_normal).isCPSVCanonicalForm
 
-/-! ### Strong Area Law (SAL)
+/-! ### Saturation of the Area Law (SAL)
 
 The saturation of the area law (arXiv:1606.00608, Definition 4.6, line 811)
 requires the mutual information chain $I_1 = I_2 = \dots$ with

--- a/TNLean/MPS/MPDO/NonCartesianActiveSectorCandidate.lean
+++ b/TNLean/MPS/MPDO/NonCartesianActiveSectorCandidate.lean
@@ -262,7 +262,7 @@ lemma neighboringOperator_pos (k h : Fin 4) :
   change (0 : ℂ) ≤ (traceMatrix k h : ℂ)
   exact_mod_cast (traceMatrix_pos k h).le
 
-/-- The candidate tensor satisfies the strong area law. -/
+/-- The candidate tensor satisfies saturation of the area law. -/
 lemma tensor_isSAL : tensor.IsSAL := by
   let _ : NeZero 2 := ⟨by omega⟩
   exact factorization.isSAL_of_isSourceZCL tensor_isInjective

--- a/TNLean/MPS/MPDO/PhysicalSectorBondPairwise.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondPairwise.lean
@@ -37,8 +37,8 @@ private theorem cyclicForwardSite_one_eq_finRotate {N : ℕ} (i : Fin N) :
 chain of length at least two.
 
 This assembles the adjacent, crossed two-site, and disjoint-support
-calculations. It uses no positivity, strong-area-law, zero-correlation-length,
-or injectivity hypothesis beyond the given physical-sector factorization.
+calculations. It uses no hypothesis of positivity, saturation of the area law, zero correlation
+length, or injectivity beyond the given physical-sector factorization.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
 1571--1593. -/

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -255,8 +255,8 @@ periodic chain of length two.
 
 In sector coordinates `(k,h)`, the translate beginning at site zero acts on
 $R_k \otimes L_h$, while the translate beginning at site one acts on
-$R_h \otimes L_k$.  No positivity, strong-area-law, zero-correlation-length,
-or injectivity hypothesis is used.
+$R_h \otimes L_k$.  No hypothesis of positivity, saturation of the area law, zero correlation
+length, or injectivity is used.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source proves
 commutativity of translated bonds but does not discuss this crossed two-site

--- a/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 # Normal representative for the SAL-selected commuting-bond product
 
 The positive physical-sector factorization of an injective tensor satisfying
-the strong area law selects a particular commuting bond. The tensor itself
+saturation of the area law selects a particular commuting bond. The tensor itself
 represents the products of this bond exactly, with scalar one. If its
 doubled-index tensor is normal, it is therefore already a normal representative
 of the selected product family.

--- a/TNLean/MPS/MPDO/SALPhysicalSectorCyclicPositivity.lean
+++ b/TNLean/MPS/MPDO/SALPhysicalSectorCyclicPositivity.lean
@@ -8,10 +8,10 @@ import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.SectorEtaPositivity
 
 /-!
-# Positive cyclic sector products from the strong area law
+# Positive cyclic sector products from saturation of the area law
 
 This file combines the raw physical-sector factorization obtained from an
-injective tensor satisfying the strong area law with positivity of the
+injective tensor satisfying saturation of the area law with positivity of the
 finite-chain operators. Every complete cyclic product of neighboring
 contractions is positive semidefinite because it is a diagonal sector
 compression of a physically conjugated finite-chain operator.

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -244,7 +244,7 @@ abbrev EtaStructure
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
   Entropy.QuantumMarkovDecomposition ρ_ABC
 
-/-- **Lemma C.2, local entropy form**: strong area law implies the local
+/-- **Lemma C.2, local entropy form**: saturation of the area law implies the local
 `η`-structure.
 
 We formalize the SAL input at the exact local point where the paper invokes it:
@@ -259,7 +259,7 @@ theorem sal_implies_eta_structure
     Nonempty (EtaStructure ρ_ABC) :=
   Entropy.exists_quantumMarkovDecomposition_of_ssaEquality ρ_ABC hρ_dm hSAL
 
-/-- **Lemma Lsigma3.** If `K` satisfies the strong area law, then the first-three-site
+/-- **Lemma Lsigma3.** If `K` satisfies saturation of the area law, then the first-three-site
 marginal of every periodic chain of length at least four admits a quantum Markov
 decomposition on the middle site.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -378,8 +378,8 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
     along the flow and the source explicitly states that this example is not a
     fixed point. The fixed-tensor-channel obstruction follows directly from
     the one- and two-site closure identities; it is not asserted as a theorem
-    in that source. No canonical-form or strong-area-law conclusion is part of
-    this statement. Theorem~\ref{thm:kato_deformed_mpdo_cf_sal_capstone}
+    in that source. No conclusion about canonical form or saturation of the area law
+    is part of this statement. Theorem~\ref{thm:kato_deformed_mpdo_cf_sal_capstone}
     establishes both conclusions for the same tensor.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -1,7 +1,7 @@
 \subsection{Markov decomposition and inverse-map sector factorization}
 
 For the simple MPDO case in Appendix~C.2 of \cite{Cirac2016MPDO_arXiv},
-the strong-area-law hypothesis is used locally through the equality case of
+the hypothesis of saturation of the area law is used locally through the equality case of
 strong subadditivity for a normalized three-site reduced state.
 
 \begin{definition}[Local $\eta$-structure for a three-site reduced state]
@@ -494,7 +494,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.exists_etaStructure_reducedBlockState_three_of_isSAL}
     \leanok
     \uses{def:is_sal, def:mpdo_eta_structure}
-    Let $K$ satisfy the strong area law and let $N\geq4$. If
+    Let $K$ satisfy saturation of the area law and let $N\geq4$. If
     $\sigma_3^{(N)}(K)$ is obtained from the normalized $N$-site periodic state
     by tracing out all but its first three sites, then
     $\sigma_3^{(N)}(K)$ admits a quantum Markov decomposition on its middle
@@ -539,7 +539,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL}
     \leanok
     \uses{def:is_sal, def:mpdo_eta_structure}
-    Let $K$ satisfy the strong area law. If $\sigma_3^{(4)}(K)$ is obtained
+    Let $K$ satisfy saturation of the area law. If $\sigma_3^{(4)}(K)$ is obtained
     from its normalized four-site periodic state by tracing out the fourth
     site, then $\sigma_3^{(4)}(K)$ admits a quantum Markov decomposition on its
     middle site.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -1318,13 +1318,13 @@
     $\sum_{k\in I_*}a_kb_k=1$.
 \end{proof}
 
-\begin{theorem}[Strong-area-law form of the normalized Case-I coefficients]
+\begin{theorem}[Saturation-of-the-area-law form of the normalized Case-I coefficients]
     \label{thm:mpdo_casei_rank_one_coefficients_of_is_sal}
     \lean{MPOTensor.exists_activeSectorTraceMatrix_rank_one_coefficients_of_isSAL_of_literal_ZCL}
     \leanok
     \uses{def:mpdo, def:injective, def:is_sal, def:mpo_physical_trace_transfer, def:nt_cpsv}
     Let ${\cal K}$ be an injective MPO tensor. Suppose
-    that ${\cal K}$ satisfies the strong area law, that its physical-trace
+    that ${\cal K}$ satisfies saturation of the area law, that its physical-trace
     transfer is literally idempotent,
     \begin{align}
         \mathcal T_{\cal K}^2 & =\mathcal T_{\cal K},
@@ -1401,7 +1401,7 @@
     \lean{MPOTensor.exists_rephased_inverseMap_caseI_rank_one_coefficients_witnesses}
     \leanok
     \uses{def:mpdo, def:injective, def:is_sal, def:mpo_physical_trace_transfer, def:nt_cpsv}
-    Let ${\cal K}$ be an injective MPO tensor satisfying the strong area law.
+    Let ${\cal K}$ be an injective MPO tensor satisfying saturation of the area law.
     Suppose that its physical-trace transfer is literally idempotent and that
     its underlying tensor is normal. Then one can choose a single coherently
     rephased, zero-weight-reparameterized inverse-map factorization with
@@ -1433,7 +1433,7 @@
 \begin{proof}
     \leanok
     \uses{thm:cpsv_normal_bond_dim_pos, def:mpdo_normalized_four_site_tail, def:mpdo_zero_weight_reparameterized_inverse_map_factorization, thm:mpdo_four_site_sal_eta_structure, thm:mpdo_normalized_four_site_tail_entry_ne_zero, thm:mpdo_three_site_closure_reduced, thm:mpdo_inverse_map_active_sector_witnesses, thm:mpdo_casei_rank_one_coefficients, thm:mpdo_rephased_zero_weight_incident_vanish}
-    Normality makes the bond dimension positive. The strong area law supplies
+    Normality makes the bond dimension positive. Saturation of the area law supplies
     the four-site Hayashi decomposition, while the normalized four-site tail
     gives nonzero outer indices and the required three-site closure. Choose the
     coherently rephased zero-weight-reparameterized inverse-map factorization.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -723,7 +723,7 @@
 \end{proof}
 
 % This theorem assumes the per-representative trace factorizations rather
-% than deriving them from the strong area law and zero correlation length;
+% than deriving them from saturation of the area law and zero correlation length;
 % the derivation is the still-open printed factorization assertion. See
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[Blocking channels from representative trace factorizations]
@@ -755,7 +755,7 @@
     every representative carries a single-sector factorization whose sole
     neighboring operator is positive semidefinite of unit trace, since the
     coefficient families may then be taken identically one. The
-    factorizations are assumed here; deriving them from the strong area law
+    factorizations are assumed here; deriving them from saturation of the area law
     and zero correlation length is the remaining step of the source
     implication and stays open in
     Theorem~\ref{thm:mpdo_sal_zcl_blocking_channels}.
@@ -785,7 +785,7 @@
     \uses{def:mpdo_simple_cf_tensor, def:sector_bnt_cf, def:is_sal, def:mpo_physical_trace_transfer, def:is_rfp_via_ts, def:mpdo_two_site_blocking}
     Let $K$ be a simple tensor in block-injective canonical form (biCF),
     equipped with a basis-of-normal-tensors decomposition and satisfying the
-    strong area law and literal zero correlation length,
+    saturation of the area law and literal zero correlation length,
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
         \notag
@@ -811,7 +811,7 @@
     complete composition down to the blocked channel pair for $M$ is
     Theorem~\ref{thm:mpdo_absorbed_factorization_blocking_channels}. The
     remaining step is therefore the existence of these per-representative
-    factorizations under the strong area law and zero correlation length.
+    factorizations under saturation of the area law and zero correlation length.
 \end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -42,7 +42,7 @@
     \leanok
     \uses{def:is_sal, def:mpo_source_zcl, thm:mpdo_all_cut_markov_implies_sal, thm:mpdo_inverse_map_nonzero_rectangular_remainder}
     There is an injective matrix product density operator tensor satisfying
-    the strong area law and source zero correlation length whose
+    saturation of the area law and source zero correlation length whose
     source-selected inverse-map factorization has positive semidefinite
     neighboring operators and a primitive trace-one active trace matrix $T$,
     but for which there are no families $a,b$ satisfying
@@ -64,7 +64,7 @@
         \rho^{L}_{A,k}\otimes\rho^{R}_{k,C}. \notag
     \end{align}
     Thus the reduced state has a four-sector quantum-Markov decomposition and
-    the tensor satisfies the strong area law. Its physical-trace
+    the tensor satisfies saturation of the area law. Its physical-trace
     transfer is the idempotent matrix $LQ$, so it has source zero correlation
     length. The explicit Hayashi decomposition and inverse map recover the
     displayed tensors $L,Q$. The active trace matrix is primitive and has
@@ -336,7 +336,7 @@
     \leanok
     \uses{def:mpdo, def:injective, def:is_sal, def:mpo_physical_trace_transfer, def:nt_cpsv, def:mpdo_physical_sector_factorization}
     Let $\mathcal K$ be an injective normal matrix product density operator
-    tensor satisfying the strong area law and literal zero correlation length,
+    tensor satisfying saturation of the area law and literal zero correlation length,
     \begin{align}
         \mathcal T_{\mathcal K}^2 & =\mathcal T_{\mathcal K}.
         \notag
@@ -1194,7 +1194,7 @@ This is the calculation in
         \operatorname{tr}\rho^{(N)}(K) & =2>0.                    \label{eq:caseii-ambient-trace}
     \end{align}
     Hence $K$ generates positive semidefinite operators. It satisfies the
-    strong area law and the literal zero-correlation-length equation
+    saturation of the area law and the literal zero-correlation-length equation
     \begin{align}
         \mathcal T_K & =I_2,
                      & \mathcal T_K^2 & =\mathcal T_K.                           \label{eq:caseii-ambient-zcl}
@@ -1245,7 +1245,7 @@ This is the calculation in
     \end{align}
     These are the channel equations of Definition~4.1
     \cite[lines~638--660]{Cirac2016MPDO_arXiv}; with
-    \eqref{eq:caseii-ambient-trace}, they imply the strong area law. Summing
+    \eqref{eq:caseii-ambient-trace}, they imply saturation of the area law. Summing
     the diagonal slices gives \eqref{eq:caseii-ambient-zcl}, the literal
     diagram of Definition~4.2
     \cite[lines~735--739]{Cirac2016MPDO_arXiv}.
@@ -2543,7 +2543,7 @@ This is the calculation in
     \leanok
     \uses{def:is_sal, def:mpo_physical_trace_idempotence, lem:mpdo_sal_phys_trace_transfer_nonzero, def:mpdo_physical_sector_factorization, def:mpdo_neighboring_trace_factorization}
     Let $K$ be an MPO tensor of virtual bond dimension one. If $K$ satisfies
-    the strong area law and literal zero correlation length, then there is a
+    saturation of the area law and literal zero correlation length, then there is a
     physical-sector factorization of $K$ whose neighboring operator is
     positive semidefinite and whose trace has the normalized rank-one form
     \begin{align}
@@ -2719,7 +2719,7 @@ This is the calculation in
 
     At every positive length, the ambient periodic operator is the sum of the
     two positive sector operators. Their complementary supports give the local
-    orthogonal-sum entropy identity, so the strong area law passes from the
+    orthogonal-sum entropy identity, so saturation of the area law passes from the
     sectors to $K$. The physical-trace transfer is block diagonal. Its two
     diagonal blocks are idempotent, hence so is the ambient transfer. The
     exact weighted direct sum and nonnilpotency of both representatives give
@@ -2785,7 +2785,7 @@ This is the calculation in
     has modulus one. The tensor has simple canonical form, generates positive
     semidefinite periodic operators with strictly positive trace at every
     positive length, satisfies
-    the strong area law, and obeys
+    saturation of the area law, and obeys
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
         \notag

--- a/docs/audits/2026-04-23_issue782_commuting_form_blocker.md
+++ b/docs/audits/2026-04-23_issue782_commuting_form_blocker.md
@@ -19,7 +19,7 @@ So the **downstream API** needed for Theorem 4.9 is now present.
 ## Honest remaining blocker
 
 The missing theorem is the **upstream entropy / local-structure bridge** that
-should produce `HasCommutingForm` from the strong-area-law hypotheses.
+should produce `HasCommutingForm` from hypotheses asserting saturation of the area law.
 
 The paper route is:
 
@@ -39,7 +39,7 @@ block decomposition to the explicit two-site commuting factor.
 
 With the new file in place, the mathematically precise remaining theorem is:
 
-> For a simple MPDO tensor satisfying the Appendix C.2 strong-area-law
+> For a simple MPDO tensor satisfying the Appendix C.2 saturation-of-the-area-law
 > hypotheses, prove `MPOTensor.HasCommutingForm`.
 
 Equivalently, once the local `η`-structure is defined, the immediate next Lean

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -19,7 +19,7 @@ Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
 \section{Source statement}
 
 Appendix C.2 of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete proves that a
-simple matrix product density operator (MPDO) satisfying the strong area law
+simple matrix product density operator (MPDO) satisfying saturation of the area law
 (SAL) has the commuting nearest-neighbor product form
 \begin{align}
     \sigma^{(N)}(\mathcal K)


### PR DESCRIPTION
## What changed

- Replace all 55 audited reader-facing uses of “strong area law” or “strong-area-law” with CPSV16's terminology, “saturation of the area law,” across 16 MPDO Lean modules, five Chapter 21 Blueprint files, one audit, and one paper-gap note.
- Preserve `IsSAL`, SAL-prefixed declarations and modules, formulas, theorem statements, filenames, and every use of “strong subadditivity.”
- Leave Archive unchanged.

## Statement-integrity audit

Primary source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, especially Definition `def:area-law`, lines 809-813, and the earlier SAL discussion at lines 593-604.

Classification: terminology drift only.

- No Lean identifier, declaration statement, hypothesis, conclusion, formula, proof body, namespace, module, or filename changes.
- No compatibility aliases or replacement abstractions are added.
- The entropy inequality “strong subadditivity” remains distinct and unchanged.
- No mathematical gap status or source-label disposition changes.
- All 55 replacements were reviewed in context rather than made by an undifferentiated replacement of “strong.”

## Validation

Exact head: `bb799b37225fe8c8b9d5bbb34baa9978d1aca8da`

```bash
./scripts/lake_build_locked.sh \
  TNLean.MPS.MPDO.ActiveSectorSpanningAreaLaw \
  TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample \
  TNLean.MPS.MPDO.ActiveSectorSpanningRFP \
  TNLean.MPS.MPDO.BNTFactorizationChannels \
  TNLean.MPS.MPDO.BNTSeparatingProjectors \
  TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity \
  TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence \
  TNLean.MPS.MPDO.InverseMapActiveSectorZCL \
  TNLean.MPS.MPDO.InverseMapLemmaC5CaseI \
  TNLean.MPS.MPDO.KatoDeformedRFPObstruction \
  TNLean.MPS.MPDO.NonCartesianActiveSectorCandidate \
  TNLean.MPS.MPDO.PhysicalSectorBondPairwise \
  TNLean.MPS.MPDO.PhysicalSectorBondTwoSite \
  TNLean.MPS.MPDO.PhysicalSectorNormalProductRepresentative \
  TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity \
  TNLean.MPS.MPDO.SimpleLocalStructure
python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
(cd blueprint && leanblueprint checkdecls)
(cd blueprint && leanblueprint pdf)
rg -ni 'strong[ -]area[ -]law' TNLean/MPS/MPDO blueprint/src/chapter/ch21_* docs/paper-gaps docs/audits
git diff --check origin/main...HEAD
```

Results:

- all 16 changed Lean modules passed, 9,345 jobs;
- Blueprint compiled twice without undefined cross-references;
- all 6,800 Blueprint entries resolve;
- all 12 affected rendered pages were inspected;
- scoped terminology census is zero outside Archive;
- prose and diff checks passed;
- generated PDF and log artifacts are absent from the commit.

Closes #7387.
