### PR TITLE
feat(QCA): prove support algebra commutation

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -33,5 +33,6 @@ import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset
 import TNLean.QCA.RelativeCommutant
 import TNLean.QCA.SiteIndexedSupportAlgebra
+import TNLean.QCA.SupportAlgebraCommutation
 import TNLean.QCA.Translation
 import TNLean.QCA.TranslationCovariance

--- a/TNLean/QCA/SupportAlgebraCommutation.lean
+++ b/TNLean/QCA/SupportAlgebraCommutation.lean
@@ -18,8 +18,8 @@ source pairs are disjoint, and the support-algebra commutation lemma then applie
 
 **Scope restriction (homogeneous chain):** Gross--Nesme--Vogts--Werner allow the one-site
 matrix size to depend on the site. This file treats the fixed positive size \(d\) of the present
-quasi-local algebra. See
-[the homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
+quasi-local algebra. See the homogeneous-chain scope note in
+`docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex`.
 
 ## References
 
@@ -249,14 +249,9 @@ private lemma transport_evenPairLocalImage_add_one
   apply transport_bipartiteLocalRestrictionRange_left hω
     (rightPair_eq_leftPair_add_one x)
 
-section
-
-set_option maxHeartbeats 800000
-
-/-- The canonical lifts of two consecutive finite images commute in the common six-site
-left--middle--right coordinates.
-
-This is the disjoint-source step in GNVW, arXiv:0910.3675v2, lines 1270--1274. -/
+set_option maxHeartbeats 800000 in
+-- Elaborating the dependent finite-region transports in this disjoint-source step needs more
+-- than the project heartbeat default (GNVW, arXiv:0910.3675v2, lines 1270--1274).
 private theorem evenPairLocalImages_overlappingLifts_commute
     (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
     ∀ ⦃X⦄, X ∈ evenPairLocalImage hω x →
@@ -308,7 +303,6 @@ private theorem evenPairLocalImages_overlappingLifts_commute
   rw [← map_mul, (quasiLocalObservable_commute_of_disjoint
     (disjoint_evenPair_evenPair_add_one x) A₀ B₀).eq, map_mul]
 
-end
 
 /-- Left support algebras respect equality of their left finite region. -/
 private lemma transport_leftSupportAlgebra {d : ℕ} {Λ Γ Δ : Finset ℤ} (h : Λ = Γ)
@@ -353,7 +347,7 @@ private theorem oddSupportAlgebra_commute_consecutiveLeftSupportAlgebra
     (evenPairLocalImages_overlappingLifts_commute hω x) R hR L hL
 
 /-- The two embedded support algebras in the unique overlapping odd--even configuration commute. -/
-theorem embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one
+theorem embeddedOddSupport_commute_embeddedEvenSupport_add_one
     (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
     ∀ X ∈ embeddedOddSupportAlgebra hω x,
       ∀ Y ∈ embeddedEvenSupportAlgebra hω (x + 1), Commute X Y := by
@@ -441,10 +435,7 @@ theorem embeddedSupportAlgebra_supportedIn
       omega
     rw [hrepl, supportRegion_even]
     exact embeddedSupportAlgebra_even_supportedIn hω (y / 2) (hrepl ▸ hR)
-  · have hmod : y % 2 = 1 := by
-      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
-      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
-      omega
+  · have hmod : y % 2 = 1 := by omega
     have hrepl : y = 2 * (y / 2) + 1 := by
       have hdiv := Int.ediv_mul_add_emod y 2
       omega
@@ -471,10 +462,7 @@ theorem supportRegion_disjoint_or_consecutive {y z : ℤ} (hyz : y ≠ z) :
   · have hy' : y = 2 * (y / 2) := by
       have := Int.ediv_mul_add_emod y 2
       omega
-    have hzmod : z % 2 = 1 := by
-      have hnonneg := Int.emod_nonneg z (by norm_num : (2 : ℤ) ≠ 0)
-      have hlt := Int.emod_lt_of_pos z (by norm_num : (0 : ℤ) < 2)
-      omega
+    have hzmod : z % 2 = 1 := by omega
     have hz' : z = 2 * (z / 2) + 1 := by
       have := Int.ediv_mul_add_emod z 2
       omega
@@ -484,10 +472,7 @@ theorem supportRegion_disjoint_or_consecutive {y z : ℤ} (hyz : y ≠ z) :
     · left
       rw [hy', hz', supportRegion_even, supportRegion_odd]
       exact disjoint_leftPair_rightPair_of_ne_add_one h
-  · have hymod : y % 2 = 1 := by
-      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
-      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
-      omega
+  · have hymod : y % 2 = 1 := by omega
     have hy' : y = 2 * (y / 2) + 1 := by
       have := Int.ediv_mul_add_emod y 2
       omega
@@ -500,14 +485,8 @@ theorem supportRegion_disjoint_or_consecutive {y z : ℤ} (hyz : y ≠ z) :
     · left
       rw [hy', hz', supportRegion_odd, supportRegion_even]
       exact disjoint_rightPair_leftPair_of_ne_add_one h
-  · have hymod : y % 2 = 1 := by
-      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
-      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
-      omega
-    have hzmod : z % 2 = 1 := by
-      have hnonneg := Int.emod_nonneg z (by norm_num : (2 : ℤ) ≠ 0)
-      have hlt := Int.emod_lt_of_pos z (by norm_num : (0 : ℤ) < 2)
-      omega
+  · have hymod : y % 2 = 1 := by omega
+    have hzmod : z % 2 = 1 := by omega
     have hy' : y = 2 * (y / 2) + 1 := by
       have := Int.ediv_mul_add_emod y 2
       omega
@@ -535,11 +514,11 @@ theorem embeddedSupportAlgebra_pairwise_commute
   · rcases hover with ⟨x, rfl, rfl⟩
     rw [embeddedSupportAlgebra_odd] at hX
     rw [show 2 * x + 2 = 2 * (x + 1) by ring, embeddedSupportAlgebra_even] at hY
-    exact embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one hω x X hX Y hY
+    exact embeddedOddSupport_commute_embeddedEvenSupport_add_one hω x X hX Y hY
   · rcases hover with ⟨x, rfl, rfl⟩
     rw [show 2 * x + 2 = 2 * (x + 1) by ring, embeddedSupportAlgebra_even] at hX
     rw [embeddedSupportAlgebra_odd] at hY
-    exact (embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one
+    exact (embeddedOddSupport_commute_embeddedEvenSupport_add_one
       hω x Y hY X hX).symm
 
 end PropagatesWithin

--- a/TNLean/QCA/SupportAlgebraCommutation.lean
+++ b/TNLean/QCA/SupportAlgebraCommutation.lean
@@ -1,0 +1,547 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.DisjointSupport
+import TNLean.QCA.OverlappingSupportAlgebra
+import TNLean.QCA.SiteIndexedSupportAlgebra
+
+/-!
+# Commutation of site-indexed QCA support algebras
+
+For a nearest-neighbour automorphism, the support algebras attached to distinct sites commute.
+The only case not already covered by disjoint locality is the common physical pair
+\(P_x=L_{x+1}\). For this pair, the two finite local images are included into the common
+six-site region in canonical left--middle--right coordinates. Their images commute because the
+source pairs are disjoint, and the support-algebra commutation lemma then applies.
+
+**Scope restriction (homogeneous chain):** Gross--Nesme--Vogts--Werner allow the one-site
+matrix size to depend on the site. This file treats the fixed positive size \(d\) of the present
+quasi-local algebra. See
+[the homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
+
+## References
+
+* Gross--Nesme--Vogts--Werner, arXiv:0910.3675v2, Lemma `sppcomm`, lines 1221--1246,
+  and the consecutive/disjoint argument, lines 1270--1274.
+* Schumacher--Werner, quant-ph/0405174, Lemma `sppcomm`, lines 1174--1194.
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1703.09188, Appendix,
+  lines 2313--2329.
+-/
+
+namespace SpinChain
+
+/-! ### Canonical tripartite coordinates -/
+
+/-- Configurations on three pairwise disjoint regions, in left--middle--right order. -/
+def Config.disjointTripleEquiv {d : ℕ} {Λ Γ Δ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ) :
+    Config d ((Λ ∪ Γ) ∪ Δ) ≃ (Config d Λ × Config d Γ) × Config d Δ :=
+  (Config.disjointUnionEquiv hΛΓΔ).trans
+    ((Config.disjointUnionEquiv hΛΓ).prodCongr (Equiv.refl (Config d Δ)))
+
+/-- Local observables on three pairwise disjoint regions, in left--middle--right matrix
+coordinates. -/
+noncomputable def tripartiteLocalAlgebraEquiv {d : ℕ} {Λ Γ Δ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ) :
+    LocalAlgebra d ((Λ ∪ Γ) ∪ Δ) ≃⋆ₐ[ℂ]
+      Matrix ((Config d Λ × Config d Γ) × Config d Δ)
+        ((Config d Λ × Config d Γ) × Config d Δ) ℂ :=
+  (CStarMatrix.reindexₐ ℂ ℂ (Config.disjointTripleEquiv hΛΓ hΛΓΔ)).trans
+    CStarMatrix.ofMatrixStarAlgEquiv.symm
+
+/-- Equality on the complement of the last two regions is equality on the first region. -/
+private lemma Config.restrict_sdiff_union_right_eq_iff {d : ℕ} {Λ Γ Δ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ)
+    (u v : Config d ((Λ ∪ Γ) ∪ Δ)) :
+    restrict (Finset.sdiff_subset : ((Λ ∪ Γ) ∪ Δ) \ (Γ ∪ Δ) ⊆ (Λ ∪ Γ) ∪ Δ) u =
+        restrict Finset.sdiff_subset v ↔
+      restrict (show Λ ⊆ (Λ ∪ Γ) ∪ Δ by simp) u =
+        restrict (show Λ ⊆ (Λ ∪ Γ) ∪ Δ by simp) v := by
+  constructor
+  · intro h
+    funext i
+    have hiΓ : (i : ℤ) ∉ Γ := hΛΓ.notMem_of_mem_left_finset i.2
+    have hiΔ : (i : ℤ) ∉ Δ := hΛΓΔ.notMem_of_mem_left_finset
+      (Finset.mem_union_left Γ i.2)
+    exact congrFun h ⟨i, Finset.mem_sdiff.mpr ⟨by simp [i.2], by simp [hiΓ, hiΔ]⟩⟩
+  · intro h
+    funext i
+    have hiNot : (i : ℤ) ∉ Γ ∪ Δ := (Finset.mem_sdiff.mp i.2).2
+    have hiAB : (i : ℤ) ∈ Λ ∪ Γ :=
+      (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_right
+        (fun hiΔ ↦ hiNot (Finset.mem_union_right Γ hiΔ))
+    have hiΛ : (i : ℤ) ∈ Λ :=
+      (Finset.mem_union.mp hiAB).resolve_right
+        (fun hiΓ ↦ hiNot (Finset.mem_union_left Δ hiΓ))
+    exact congrFun h ⟨i, hiΛ⟩
+
+/-- Restriction of reconstructed tripartite coordinates to the first region recovers the left
+coordinate. -/
+@[simp]
+private lemma Config.restrict_disjointTripleEquiv_symm_left {d : ℕ} {Λ Γ Δ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ)
+    (x : (Config d Λ × Config d Γ) × Config d Δ) :
+    restrict (show Λ ⊆ (Λ ∪ Γ) ∪ Δ by simp)
+        ((disjointTripleEquiv hΛΓ hΛΓΔ).symm x) = x.1.1 := by
+  calc
+    _ = restrict (show Λ ⊆ Λ ∪ Γ by simp)
+        (restrict (show Λ ∪ Γ ⊆ (Λ ∪ Γ) ∪ Δ from
+          fun _ h ↦ Finset.mem_union_left Δ h)
+          ((disjointTripleEquiv hΛΓ hΛΓΔ).symm x)) :=
+      (restrict_trans (show Λ ⊆ Λ ∪ Γ by simp)
+        (show Λ ∪ Γ ⊆ (Λ ∪ Γ) ∪ Δ from
+          fun _ h ↦ Finset.mem_union_left Δ h) _).symm
+    _ = x.1.1 := by simp [disjointTripleEquiv]
+
+/-- Restriction of reconstructed tripartite coordinates to the last two regions recovers the
+middle--right pair. -/
+private lemma Config.restrict_disjointTripleEquiv_symm_right {d : ℕ} {Λ Γ Δ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ)
+    (x : (Config d Λ × Config d Γ) × Config d Δ) :
+    restrict (show Γ ∪ Δ ⊆ (Λ ∪ Γ) ∪ Δ by simp)
+        ((disjointTripleEquiv hΛΓ hΛΓΔ).symm x) =
+      (disjointUnionEquiv
+        (hΛΓΔ.mono Finset.subset_union_right (fun _ h ↦ h))).symm (x.1.2, x.2) := by
+  let hΓΔ : Disjoint Γ Δ :=
+    hΛΓΔ.mono Finset.subset_union_right (fun _ h ↦ h)
+  apply (disjointUnionEquiv hΓΔ).injective
+  apply Prod.ext
+  · simp only [disjointUnionEquiv_apply_fst,
+      restrict_disjointUnionEquiv_symm_left]
+    rw [restrict_trans]
+    change restrict Finset.subset_union_right
+        (restrict Finset.subset_union_left
+          ((disjointTripleEquiv hΛΓ hΛΓΔ).symm x)) = x.1.2
+    simp [disjointTripleEquiv]
+  · simp only [disjointUnionEquiv_apply_snd,
+      restrict_disjointUnionEquiv_symm_right]
+    rw [restrict_trans]
+    simp [disjointTripleEquiv]
+
+/-- In canonical tripartite coordinates, inclusion from the first two regions is the natural
+left overlapping lift. -/
+theorem tripartiteLocalAlgebraEquiv_localInclusion_left {d : ℕ}
+    {Λ Γ Δ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ)
+    (A : LocalAlgebra d (Λ ∪ Γ)) :
+    tripartiteLocalAlgebraEquiv hΛΓ hΛΓΔ
+        (localInclusion (d := d) Finset.subset_union_left A) =
+      Matrix.leftOverlappingLift (bipartiteLocalAlgebraEquiv hΛΓ A) := by
+  ext x y
+  change localInclusion (d := d) Finset.subset_union_left A
+      ((Config.disjointTripleEquiv hΛΓ hΛΓΔ).symm x)
+      ((Config.disjointTripleEquiv hΛΓ hΛΓΔ).symm y) = _
+  rw [localInclusion_apply]
+  simp only [Config.splitEquiv_snd_eq_iff_restrict_right hΛΓΔ]
+  simp [Config.disjointTripleEquiv, Matrix.leftOverlappingLift,
+    bipartiteLocalAlgebraEquiv_apply, Matrix.one_apply]
+
+/-- In canonical tripartite coordinates, inclusion from the last two regions is the natural
+right overlapping lift. -/
+theorem tripartiteLocalAlgebraEquiv_localInclusion_right {d : ℕ}
+    {Λ Γ Δ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) (hΛΓΔ : Disjoint (Λ ∪ Γ) Δ)
+    (A : LocalAlgebra d (Γ ∪ Δ)) :
+    tripartiteLocalAlgebraEquiv hΛΓ hΛΓΔ
+        (localInclusion (d := d) (by intro i hi; simp only [Finset.mem_union] at hi ⊢; aesop) A) =
+      Matrix.rightOverlappingLift (bipartiteLocalAlgebraEquiv
+        (hΛΓΔ.mono Finset.subset_union_right (fun _ h ↦ h)) A) := by
+  ext x y
+  change localInclusion (d := d) _ A
+      ((Config.disjointTripleEquiv hΛΓ hΛΓΔ).symm x)
+      ((Config.disjointTripleEquiv hΛΓ hΛΓΔ).symm y) = _
+  rw [localInclusion_apply]
+  simp only [Config.splitEquiv_snd_eq_iff_restrict_sdiff]
+  simp only [Config.restrict_sdiff_union_right_eq_iff hΛΓ hΛΓΔ]
+  rw [Config.restrict_disjointTripleEquiv_symm_right hΛΓ hΛΓΔ x,
+    Config.restrict_disjointTripleEquiv_symm_right hΛΓ hΛΓΔ y,
+    Config.restrict_disjointTripleEquiv_symm_left hΛΓ hΛΓΔ x,
+    Config.restrict_disjointTripleEquiv_symm_left hΛΓ hΛΓΔ y]
+  simp [Matrix.rightOverlappingLift, bipartiteLocalAlgebraEquiv_apply,
+    Matrix.one_apply]
+
+/-! ### Consecutive finite images -/
+
+/-- The source pairs for consecutive blocks are disjoint. -/
+private lemma disjoint_evenPair_evenPair_add_one (x : ℤ) :
+    Disjoint (evenPair x) (evenPair (x + 1)) := by
+  rw [Finset.disjoint_left]
+  intro i hi hj
+  simp only [evenPair, Finset.mem_insert, Finset.mem_singleton] at hi hj
+  omega
+
+/-- The three target pairs \(L_x,P_x,P_{x+1}\) are pairwise disjoint. -/
+lemma disjoint_leftPair_union_rightPair_rightPair_add_one (x : ℤ) :
+    Disjoint (leftPair x ∪ rightPair x) (rightPair (x + 1)) := by
+  rw [Finset.disjoint_left]
+  intro i hi hj
+  simp only [leftPair, rightPair, Finset.mem_union, Finset.mem_insert,
+    Finset.mem_singleton] at hi hj
+  omega
+
+/-- The common target of the two consecutive finite images is the six-site region displayed by
+GNVW in the consecutive-pair argument. -/
+lemma leftPair_union_rightPair_union_rightPair_add_one (x : ℤ) :
+    (leftPair x ∪ rightPair x) ∪ rightPair (x + 1) =
+      {2 * x - 1, 2 * x, 2 * x + 1, 2 * x + 2, 2 * x + 3, 2 * x + 4} := by
+  ext i
+  simp only [leftPair, rightPair, Finset.mem_union, Finset.mem_insert,
+    Finset.mem_singleton]
+  omega
+
+namespace PropagatesWithin
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+
+/-- The defining finite-restriction equality after transporting along a target-region
+identity. -/
+private lemma quasiLocalObservable_transport_localRestriction
+    {𝓝 Λ T : Finset ℤ} (hω : PropagatesWithin ω 𝓝)
+    (hT : regionSumset Λ 𝓝 = T) (A : LocalAlgebra d Λ) :
+    quasiLocalObservable d T (hT ▸ hω.localRestriction Λ A) =
+      ω (quasiLocalObservable d Λ A) := by
+  subst T
+  exact hω.quasiLocalObservable_localRestriction Λ A
+
+/-- Membership in a finite local image transported along its target-region equality. -/
+private lemma mem_transport_localRestrictionRange_iff
+    {𝓝 Λ T : Finset ℤ} (hω : PropagatesWithin ω 𝓝)
+    (hT : regionSumset Λ 𝓝 = T) (A : LocalAlgebra d T) :
+    A ∈ hT ▸ hω.localRestrictionRange Λ ↔
+      ∃ A₀, A = hT ▸ hω.localRestriction Λ A₀ := by
+  subst T
+  change (∃ A₀, hω.localRestriction Λ A₀ = A) ↔
+    ∃ A₀, A = hω.localRestriction Λ A₀
+  constructor <;> rintro ⟨A₀, hA₀⟩
+  · exact ⟨A₀, hA₀.symm⟩
+  · exact ⟨A₀, hA₀.symm⟩
+
+/-- Bipartite finite-image coordinates respect equality of the left finite region. -/
+private lemma transport_bipartiteLocalRestrictionRange_left
+    {𝓝 Λ Γ Γ' Δ : Finset ℤ} (hω : PropagatesWithin ω 𝓝) (q : Γ = Γ')
+    (hΓΔ : Disjoint Γ Δ) (hΓ'Δ : Disjoint Γ' Δ)
+    (hT : regionSumset Λ 𝓝 = Γ ∪ Δ) (hT' : regionSumset Λ 𝓝 = Γ' ∪ Δ) :
+    q.symm ▸ hω.bipartiteLocalRestrictionRange Λ Γ' Δ hΓ'Δ hT' =
+      hω.bipartiteLocalRestrictionRange Λ Γ Δ hΓΔ hT := by
+  subst Γ'
+  rfl
+
+/-- The finite image of the next source pair, using the canonical equality
+\(L_{x+1}=P_x\) so its left coordinate is literally the common physical pair. -/
+private noncomputable def consecutiveEvenPairLocalImage
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    StarSubalgebra ℂ
+      (Matrix (Config d (rightPair x) × Config d (rightPair (x + 1)))
+        (Config d (rightPair x) × Config d (rightPair (x + 1))) ℂ) :=
+  hω.bipartiteLocalRestrictionRange (evenPair (x + 1)) (rightPair x)
+    (rightPair (x + 1))
+    (by rw [rightPair_eq_leftPair_add_one]; exact disjoint_leftPair_rightPair (x + 1))
+    (by rw [regionSumset_evenPair, ← rightPair_eq_leftPair_add_one x])
+
+/-- Transporting the next block's canonical image along \(P_x=L_{x+1}\) gives the
+consecutively aligned image. -/
+private lemma transport_evenPairLocalImage_add_one
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    (rightPair_eq_leftPair_add_one x).symm ▸ evenPairLocalImage hω (x + 1) =
+      consecutiveEvenPairLocalImage hω x := by
+  unfold evenPairLocalImage consecutiveEvenPairLocalImage
+  apply transport_bipartiteLocalRestrictionRange_left hω
+    (rightPair_eq_leftPair_add_one x)
+
+section
+
+set_option maxHeartbeats 800000
+
+/-- The canonical lifts of two consecutive finite images commute in the common six-site
+left--middle--right coordinates.
+
+This is the disjoint-source step in GNVW, arXiv:0910.3675v2, lines 1270--1274. -/
+private theorem evenPairLocalImages_overlappingLifts_commute
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    ∀ ⦃X⦄, X ∈ evenPairLocalImage hω x →
+      ∀ ⦃Y⦄, Y ∈ consecutiveEvenPairLocalImage hω x →
+        Matrix.leftOverlappingLift X * Matrix.rightOverlappingLift Y =
+          Matrix.rightOverlappingLift Y * Matrix.leftOverlappingLift X := by
+  intro X hX Y hY
+  rw [evenPairLocalImage, bipartiteLocalRestrictionRange,
+    StarSubalgebra.bipartiteReindex, StarSubalgebra.mem_map] at hX
+  rw [consecutiveEvenPairLocalImage, bipartiteLocalRestrictionRange,
+    StarSubalgebra.bipartiteReindex, StarSubalgebra.mem_map] at hY
+  rcases hX with ⟨A, hA, rfl⟩
+  rcases hY with ⟨B, hB, rfl⟩
+  rw [mem_transport_localRestrictionRange_iff hω (regionSumset_evenPair x)] at hA
+  have hNextTarget : regionSumset (evenPair (x + 1)) (Finset.Icc (-1) 1) =
+      rightPair x ∪ rightPair (x + 1) := by
+    rw [regionSumset_evenPair, ← rightPair_eq_leftPair_add_one x]
+  rw [mem_transport_localRestrictionRange_iff hω hNextTarget] at hB
+  rcases hA with ⟨A₀, rfl⟩
+  rcases hB with ⟨B₀, rfl⟩
+  let hLP := disjoint_leftPair_rightPair x
+  let hT := disjoint_leftPair_union_rightPair_rightPair_add_one x
+  let hPR : Disjoint (rightPair x) (rightPair (x + 1)) :=
+    hT.mono Finset.subset_union_right (fun _ h ↦ h)
+  change Matrix.leftOverlappingLift
+      (bipartiteLocalAlgebraEquiv hLP
+        (regionSumset_evenPair x ▸ hω.localRestriction (evenPair x) A₀)) *
+      Matrix.rightOverlappingLift
+        (bipartiteLocalAlgebraEquiv hPR
+          (hNextTarget ▸ hω.localRestriction (evenPair (x + 1)) B₀)) =
+      Matrix.rightOverlappingLift
+          (bipartiteLocalAlgebraEquiv hPR
+            (hNextTarget ▸ hω.localRestriction (evenPair (x + 1)) B₀)) *
+        Matrix.leftOverlappingLift
+          (bipartiteLocalAlgebraEquiv hLP
+            (regionSumset_evenPair x ▸ hω.localRestriction (evenPair x) A₀))
+  have hLeft := tripartiteLocalAlgebraEquiv_localInclusion_left hLP hT
+    (regionSumset_evenPair x ▸ hω.localRestriction (evenPair x) A₀)
+  have hRight := tripartiteLocalAlgebraEquiv_localInclusion_right hLP hT
+    (hNextTarget ▸ hω.localRestriction (evenPair (x + 1)) B₀)
+  rw [← hLeft, ← hRight]
+  rw [← map_mul, ← map_mul]
+  congr 1
+  apply quasiLocalObservable_injective d ((leftPair x ∪ rightPair x) ∪ rightPair (x + 1))
+  rw [map_mul, map_mul, quasiLocalObservable_localInclusion,
+    quasiLocalObservable_localInclusion,
+    quasiLocalObservable_transport_localRestriction hω (regionSumset_evenPair x),
+    quasiLocalObservable_transport_localRestriction hω hNextTarget]
+  rw [← map_mul, (quasiLocalObservable_commute_of_disjoint
+    (disjoint_evenPair_evenPair_add_one x) A₀ B₀).eq, map_mul]
+
+end
+
+/-- Left support algebras respect equality of their left finite region. -/
+private lemma transport_leftSupportAlgebra {d : ℕ} {Λ Γ Δ : Finset ℤ} (h : Λ = Γ)
+    (S : StarSubalgebra ℂ
+      (Matrix (Config d Γ × Config d Δ) (Config d Γ × Config d Δ) ℂ)) :
+    h.symm ▸ Matrix.leftSupportAlgebra S =
+      Matrix.leftSupportAlgebra (h.symm ▸ S) := by
+  subst Γ
+  rfl
+
+/-- Membership in a matrix star-subalgebra transports along equality of the finite region. -/
+private lemma matrix_mem_transport {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ = Γ)
+    (S : StarSubalgebra ℂ (Matrix (Config d Γ) (Config d Γ) ℂ))
+    {A : Matrix (Config d Γ) (Config d Γ) ℂ} (hA : A ∈ S) :
+    h.symm ▸ A ∈ h.symm ▸ S := by
+  subst Γ
+  exact hA
+
+/-- Canonical quasi-local matrix embeddings respect equality of their finite regions. -/
+private lemma matrixToQuasiLocalObservable_transport {d : ℕ} [NeZero d]
+    {Λ Γ : Finset ℤ} (h : Λ = Γ)
+    (A : Matrix (Config d Γ) (Config d Γ) ℂ) :
+    matrixToQuasiLocalObservable d Λ (h.symm ▸ A) =
+      matrixToQuasiLocalObservable d Γ A := by
+  subst Γ
+  rfl
+
+/-- Consecutive support algebras in the load-bearing odd--even order commute on their common
+physical pair.
+
+This applies Schumacher--Werner/GNVW Lemma `sppcomm` in the order
+\(\operatorname{Spp}_{\mathrm R}(S_x),\operatorname{Spp}_{\mathrm L}(S_{x+1})\). -/
+private theorem oddSupportAlgebra_commute_consecutiveLeftSupportAlgebra
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    ∀ R ∈ oddSupportAlgebra hω x,
+      ∀ L ∈ Matrix.leftSupportAlgebra (consecutiveEvenPairLocalImage hω x),
+        Commute R L := by
+  intro R hR L hL
+  rw [commute_iff_eq]
+  exact Matrix.supportAlgebras_commute_of_overlappingLifts_commute
+    (evenPairLocalImage hω x) (consecutiveEvenPairLocalImage hω x)
+    (evenPairLocalImages_overlappingLifts_commute hω x) R hR L hL
+
+/-- The two embedded support algebras in the unique overlapping odd--even configuration commute. -/
+theorem embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (x : ℤ) :
+    ∀ X ∈ embeddedOddSupportAlgebra hω x,
+      ∀ Y ∈ embeddedEvenSupportAlgebra hω (x + 1), Commute X Y := by
+  intro X hX Y hY
+  rw [embeddedOddSupportAlgebra, StarSubalgebra.mem_map] at hX
+  rw [embeddedEvenSupportAlgebra, StarSubalgebra.mem_map] at hY
+  rcases hX with ⟨R, hR, rfl⟩
+  rcases hY with ⟨L, hL, rfl⟩
+  let L' : Matrix (Config d (rightPair x)) (Config d (rightPair x)) ℂ :=
+    (rightPair_eq_leftPair_add_one x).symm ▸ L
+  have hLcast : (rightPair_eq_leftPair_add_one x).symm ▸ L ∈
+      (rightPair_eq_leftPair_add_one x).symm ▸ evenSupportAlgebra hω (x + 1) :=
+    matrix_mem_transport (rightPair_eq_leftPair_add_one x)
+      (evenSupportAlgebra hω (x + 1)) hL
+  rw [evenSupportAlgebra,
+    transport_leftSupportAlgebra (rightPair_eq_leftPair_add_one x)] at hLcast
+  have hL' : L' ∈ Matrix.leftSupportAlgebra (consecutiveEvenPairLocalImage hω x) := by
+    change (rightPair_eq_leftPair_add_one x).symm ▸ L ∈ _
+    rw [← transport_evenPairLocalImage_add_one hω x]
+    exact hLcast
+  have hComm := oddSupportAlgebra_commute_consecutiveLeftSupportAlgebra hω x R hR L' hL'
+  rw [← matrixToQuasiLocalObservable_transport
+    (rightPair_eq_leftPair_add_one x) L]
+  exact hComm.map (matrixToQuasiLocalObservable d (rightPair x))
+
+end PropagatesWithin
+
+/-! ### Physical support regions and pairwise assembly -/
+
+/-- The physical two-site region of the embedded support algebra \(\mathcal R_y\). -/
+def supportRegion (y : ℤ) : Finset ℤ :=
+  if y % 2 = 0 then leftPair (y / 2) else rightPair (y / 2)
+
+@[simp]
+lemma supportRegion_even (x : ℤ) : supportRegion (2 * x) = leftPair x := by
+  simp [supportRegion]
+
+@[simp]
+lemma supportRegion_odd (x : ℤ) : supportRegion (2 * x + 1) = rightPair x := by
+  rw [supportRegion]
+  simp only [Int.mul_add_emod_self_left, Int.one_emod_two, one_ne_zero, ↓reduceIte]
+  congr 1
+  rw [show 2 * x + 1 = 1 + x * 2 by ring, Int.add_mul_ediv_right]
+  all_goals norm_num
+
+private lemma disjoint_leftPair_leftPair_of_ne {x z : ℤ} (h : x ≠ z) :
+    Disjoint (leftPair x) (leftPair z) := by
+  rw [Finset.disjoint_left]
+  intro i hix hiz
+  simp only [leftPair, Finset.mem_insert, Finset.mem_singleton] at hix hiz
+  omega
+
+private lemma disjoint_rightPair_rightPair_of_ne {x z : ℤ} (h : x ≠ z) :
+    Disjoint (rightPair x) (rightPair z) := by
+  rw [Finset.disjoint_left]
+  intro i hix hiz
+  simp only [rightPair, Finset.mem_insert, Finset.mem_singleton] at hix hiz
+  omega
+
+private lemma disjoint_leftPair_rightPair_of_ne_add_one {x z : ℤ} (h : x ≠ z + 1) :
+    Disjoint (leftPair x) (rightPair z) := by
+  rw [Finset.disjoint_left]
+  intro i hix hiz
+  simp only [leftPair, rightPair, Finset.mem_insert, Finset.mem_singleton] at hix hiz
+  omega
+
+private lemma disjoint_rightPair_leftPair_of_ne_add_one {x z : ℤ} (h : z ≠ x + 1) :
+    Disjoint (rightPair x) (leftPair z) := by
+  exact (disjoint_leftPair_rightPair_of_ne_add_one h).symm
+
+namespace PropagatesWithin
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+
+/-- Every element of the site-indexed family is supported in its parity-selected physical
+region. -/
+theorem embeddedSupportAlgebra_supportedIn
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (y : ℤ)
+    {R : QuasiLocalAlgebra d} (hR : R ∈ embeddedSupportAlgebra hω y) :
+    QuasiLocalSupportedIn R (supportRegion y) := by
+  by_cases hy : y % 2 = 0
+  · have hrepl : y = 2 * (y / 2) := by
+      have hdiv := Int.ediv_mul_add_emod y 2
+      omega
+    rw [hrepl, supportRegion_even]
+    exact embeddedSupportAlgebra_even_supportedIn hω (y / 2) (hrepl ▸ hR)
+  · have hmod : y % 2 = 1 := by
+      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
+      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
+      omega
+    have hrepl : y = 2 * (y / 2) + 1 := by
+      have hdiv := Int.ediv_mul_add_emod y 2
+      omega
+    rw [hrepl, supportRegion_odd]
+    exact embeddedSupportAlgebra_odd_supportedIn hω (y / 2) (hrepl ▸ hR)
+
+/-- For distinct indices, physical support regions are disjoint except for the consecutive
+odd--even pair, in either order. -/
+theorem supportRegion_disjoint_or_consecutive {y z : ℤ} (hyz : y ≠ z) :
+    Disjoint (supportRegion y) (supportRegion z) ∨
+      (∃ x, y = 2 * x + 1 ∧ z = 2 * x + 2) ∨
+      ∃ x, z = 2 * x + 1 ∧ y = 2 * x + 2 := by
+  by_cases hy : y % 2 = 0 <;> by_cases hz : z % 2 = 0
+  · have hy' : y = 2 * (y / 2) := by
+      have := Int.ediv_mul_add_emod y 2
+      omega
+    have hz' : z = 2 * (z / 2) := by
+      have := Int.ediv_mul_add_emod z 2
+      omega
+    left
+    rw [hy', hz', supportRegion_even, supportRegion_even]
+    apply disjoint_leftPair_leftPair_of_ne
+    omega
+  · have hy' : y = 2 * (y / 2) := by
+      have := Int.ediv_mul_add_emod y 2
+      omega
+    have hzmod : z % 2 = 1 := by
+      have hnonneg := Int.emod_nonneg z (by norm_num : (2 : ℤ) ≠ 0)
+      have hlt := Int.emod_lt_of_pos z (by norm_num : (0 : ℤ) < 2)
+      omega
+    have hz' : z = 2 * (z / 2) + 1 := by
+      have := Int.ediv_mul_add_emod z 2
+      omega
+    by_cases h : y / 2 = z / 2 + 1
+    · right; right
+      exact ⟨z / 2, hz', by omega⟩
+    · left
+      rw [hy', hz', supportRegion_even, supportRegion_odd]
+      exact disjoint_leftPair_rightPair_of_ne_add_one h
+  · have hymod : y % 2 = 1 := by
+      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
+      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
+      omega
+    have hy' : y = 2 * (y / 2) + 1 := by
+      have := Int.ediv_mul_add_emod y 2
+      omega
+    have hz' : z = 2 * (z / 2) := by
+      have := Int.ediv_mul_add_emod z 2
+      omega
+    by_cases h : z / 2 = y / 2 + 1
+    · right; left
+      exact ⟨y / 2, hy', by omega⟩
+    · left
+      rw [hy', hz', supportRegion_odd, supportRegion_even]
+      exact disjoint_rightPair_leftPair_of_ne_add_one h
+  · have hymod : y % 2 = 1 := by
+      have hnonneg := Int.emod_nonneg y (by norm_num : (2 : ℤ) ≠ 0)
+      have hlt := Int.emod_lt_of_pos y (by norm_num : (0 : ℤ) < 2)
+      omega
+    have hzmod : z % 2 = 1 := by
+      have hnonneg := Int.emod_nonneg z (by norm_num : (2 : ℤ) ≠ 0)
+      have hlt := Int.emod_lt_of_pos z (by norm_num : (0 : ℤ) < 2)
+      omega
+    have hy' : y = 2 * (y / 2) + 1 := by
+      have := Int.ediv_mul_add_emod y 2
+      omega
+    have hz' : z = 2 * (z / 2) + 1 := by
+      have := Int.ediv_mul_add_emod z 2
+      omega
+    left
+    rw [hy', hz', supportRegion_odd, supportRegion_odd]
+    apply disjoint_rightPair_rightPair_of_ne
+    omega
+
+/-- Distinct members of the site-indexed support-algebra family commute elementwise.
+
+This is the homogeneous-chain specialization of the consecutive/disjoint commutation argument
+in GNVW, arXiv:0910.3675v2, lines 1270--1274. -/
+theorem embeddedSupportAlgebra_pairwise_commute
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) :
+    Pairwise fun y z : ℤ ↦
+      ∀ X ∈ embeddedSupportAlgebra hω y,
+        ∀ Y ∈ embeddedSupportAlgebra hω z, Commute X Y := by
+  intro y z hyz X hX Y hY
+  rcases supportRegion_disjoint_or_consecutive hyz with hdisj | hover | hover
+  · exact (embeddedSupportAlgebra_supportedIn hω y hX).commute_of_disjoint
+      (embeddedSupportAlgebra_supportedIn hω z hY) hdisj
+  · rcases hover with ⟨x, rfl, rfl⟩
+    rw [embeddedSupportAlgebra_odd] at hX
+    rw [show 2 * x + 2 = 2 * (x + 1) by ring, embeddedSupportAlgebra_even] at hY
+    exact embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one hω x X hX Y hY
+  · rcases hover with ⟨x, rfl, rfl⟩
+    rw [show 2 * x + 2 = 2 * (x + 1) by ring, embeddedSupportAlgebra_even] at hX
+    rw [embeddedSupportAlgebra_odd] at hY
+    exact (embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one
+      hω x Y hY X hX).symm
+
+end PropagatesWithin
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11904,68 +11904,149 @@ left/right order below agrees with the adjacent-pair convention in
     $\widehat{\mathcal R}_{2x+1}$ in $\mathcal A_{P_x}$.
 \end{proof}
 
-\begin{theorem}[Tripartite coordinates for consecutive pair images]
-    \label{thm:qca_consecutive_pair_tripartite_coordinates}
+\begin{definition}[Tripartite finite-region coordinates]
+    \label{def:qca_tripartite_local_coordinates}
     \lean{SpinChain.Config.disjointTripleEquiv,
-        SpinChain.tripartiteLocalAlgebraEquiv,
-        SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_left,
-        SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_right,
-        SpinChain.disjoint_leftPair_union_rightPair_rightPair_add_one,
+        SpinChain.tripartiteLocalAlgebraEquiv}
+    \leanok
+    \uses{def:qca_bipartite_local_algebra_coordinates}
+    For pairwise disjoint finite regions $\Lambda,\Gamma,\Delta$, successive
+    restriction in left--middle--right order gives
+    \begin{align}
+        \mathcal C_{(\Lambda\cup\Gamma)\cup\Delta}
+         & \cong(\mathcal C_\Lambda\times\mathcal C_\Gamma)
+        \times\mathcal C_\Delta,                                \\
+        \mathcal A_{(\Lambda\cup\Gamma)\cup\Delta}
+         & \cong M_{(\mathcal C_\Lambda\times\mathcal C_\Gamma)
+                \times\mathcal C_\Delta}(\mathbb C).
+    \end{align}
+\end{definition}
+
+\begin{lemma}[Geometry of consecutive pair images]
+    \label{lem:qca_consecutive_pair_geometry}
+    \lean{SpinChain.disjoint_leftPair_union_rightPair_rightPair_add_one,
         SpinChain.leftPair_union_rightPair_union_rightPair_add_one}
     \leanok
-    \uses{lem:qca_nearest_neighbor_pair_geometry, def:qca_bipartite_local_algebra_coordinates,
-        thm:qca_bipartite_local_algebra_inclusions}
-    Let
+    \uses{def:qca_nearest_neighbor_pair_regions}
+    The three regions $L_x,P_x,P_{x+1}$ are pairwise disjoint, and
     \begin{align}
-        T_x&=(L_x\cup P_x)\cup P_{x+1}
-        =\{2x-1,2x,2x+1,2x+2,2x+3,2x+4\}.
+        T_x & =(L_x\cup P_x)\cup P_{x+1}        \\
+            & =\{2x-1,2x,2x+1,2x+2,2x+3,2x+4\}.
     \end{align}
-    The regions $L_x,P_x,P_{x+1}$ are pairwise disjoint, and their ordered
-    configuration coordinates identify
-    \begin{align}
-        \mathcal A_{T_x}
-        &\cong M_{(\mathcal C_{L_x}\times\mathcal C_{P_x})
-          \times\mathcal C_{P_{x+1}}}(\mathbb C).
-    \end{align}
-    In these coordinates, the canonical inclusion from $L_x\cup P_x$ is
-    $X\mapsto X\otimes\mathbf 1$, while the canonical inclusion from
-    $P_x\cup P_{x+1}$ is $Y\mapsto\mathbf 1\otimes Y$, with the displayed
-    left--middle--right factor order.
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute the three pair definitions and compare their six sites.
+\end{proof}
+
+\begin{theorem}[Canonical inclusions in tripartite coordinates]
+    \label{thm:qca_consecutive_pair_tripartite_coordinates}
+    \lean{SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_left,
+        SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_right}
+    \leanok
+    \uses{def:qca_tripartite_local_coordinates,
+        def:qca_local_inclusion}
+    In the coordinates of Definition~\ref{def:qca_tripartite_local_coordinates},
+    the canonical inclusion from $\Lambda\cup\Gamma$ is
+    $X\mapsto X\otimes\mathbf 1$, and the canonical inclusion from
+    $\Gamma\cup\Delta$ is $Y\mapsto\mathbf 1\otimes Y$, with the ordered
+    factors $\Lambda,\Gamma,\Delta$.
 \end{theorem}
 
 \begin{proof}\leanok
-    Split configurations first across $(L_x\cup P_x),P_{x+1}$ and then
-    across $L_x,P_x$.  The two canonical local inclusions become the left
-    and right overlapping lifts after this product reassociation.  The
-    explicit formulas for the three pairs give their disjointness and the
-    six displayed sites.
+    \uses{def:qca_tripartite_local_coordinates,
+        def:qca_bipartite_local_algebra_coordinates,
+        def:qca_local_inclusion}
+    Restrict each reconstructed configuration to the retained region and its
+    complement.  In the first inclusion the complementary coordinates are
+    equal precisely on $\Delta$; in the second they are equal precisely on
+    $\Lambda$.  The two matrix entries are therefore the left and right
+    overlapping lifts, respectively.
+\end{proof}
+
+\begin{theorem}[Commutation across the common physical pair]
+    \label{thm:qca_consecutive_support_algebras_commute}
+    \lean{
+        SpinChain.PropagatesWithin.embeddedOddSupport_commute_embeddedEvenSupport_add_one}
+    \leanok
+    \uses{def:qca_site_indexed_support_algebras}
+    For every $x\in\mathbb Z$, the canonically embedded support algebras
+    $\widehat{\mathcal R}_{2x+1}$ and
+    $\widehat{\mathcal R}_{2x+2}$ commute elementwise.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_consecutive_pair_geometry,
+        thm:qca_consecutive_pair_tripartite_coordinates,
+        thm:qca_finite_region_restriction_embedding,
+        thm:qca_disjoint_quasi_local_commute,
+        thm:qca_overlapping_support_algebras_commute}
+    The source regions $E_x$ and $E_{x+1}$ are disjoint, so their canonical
+    quasi-local observables commute.  Multiplicativity of $\omega$ preserves
+    this equality.  Embed the two finite images into $\mathcal A_{T_x}$ and
+    use the tripartite coordinates above to obtain
+    \begin{align}
+        (X\otimes\mathbf 1)(\mathbf 1\otimes Y)
+         & =(\mathbf 1\otimes Y)(X\otimes\mathbf 1).
+    \end{align}
+    The overlapping-support theorem, in the order
+    $\operatorname{Spp}_{\mathrm R}(S_x)$ followed by
+    $\operatorname{Spp}_{\mathrm L}(S_{x+1})$, gives the claim.
+\end{proof}
+
+\begin{definition}[Physical region of a site-indexed support algebra]
+    \label{def:qca_support_algebra_region}
+    \lean{SpinChain.supportRegion,
+        SpinChain.supportRegion_even,
+        SpinChain.supportRegion_odd}
+    \leanok
+    \uses{def:qca_nearest_neighbor_pair_regions}
+    Define $Q_{2x}=L_x$ and $Q_{2x+1}=P_x$.
+\end{definition}
+
+\begin{theorem}[Unified physical localization]
+    \label{thm:qca_unified_support_algebra_region}
+    \lean{SpinChain.PropagatesWithin.embeddedSupportAlgebra_supportedIn}
+    \leanok
+    \uses{def:qca_support_algebra_region,
+        def:qca_site_indexed_support_algebras}
+    Every element of $\widehat{\mathcal R}_y$ is supported in $Q_y$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_site_indexed_support_regions}
+    Split according to the parity of $y$ and apply the corresponding
+    localization of $\widehat{\mathcal R}_{2x}$ or
+    $\widehat{\mathcal R}_{2x+1}$.
+\end{proof}
+
+\begin{theorem}[Classification of overlapping support regions]
+    \label{thm:qca_support_region_overlap_classification}
+    \lean{SpinChain.PropagatesWithin.supportRegion_disjoint_or_consecutive}
+    \leanok
+    \uses{def:qca_support_algebra_region}
+    If $y\ne z$, then $Q_y$ and $Q_z$ are disjoint unless
+    \begin{align}
+        (y,z) & =(2x+1,2x+2)
+    \end{align}
+    for some $x$, or unless this ordered pair is reversed.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write each index in its even or odd form.  Two regions of equal parity
+    are disjoint.  In the mixed-parity cases, the defining two-site sets
+    intersect exactly for the displayed consecutive odd--even pair.
 \end{proof}
 
 \begin{theorem}[Pairwise commutation of distinct support algebras]
     \label{thm:qca_site_indexed_support_algebras_commute}
-    \lean{SpinChain.supportRegion,
-        SpinChain.supportRegion_even,
-        SpinChain.supportRegion_odd,
-        SpinChain.PropagatesWithin.embeddedSupportAlgebra_supportedIn,
-        SpinChain.PropagatesWithin.supportRegion_disjoint_or_consecutive,
-        SpinChain.PropagatesWithin.embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one,
-        SpinChain.PropagatesWithin.embeddedSupportAlgebra_pairwise_commute}
+    \lean{SpinChain.PropagatesWithin.embeddedSupportAlgebra_pairwise_commute}
     \leanok
-    \uses{def:qca_site_indexed_support_algebras,
-        thm:qca_site_indexed_support_regions,
-        thm:qca_consecutive_pair_tripartite_coordinates,
-        thm:qca_overlapping_support_algebras_commute}
-    Let $Q_{2x}=L_x$ and $Q_{2x+1}=P_x$.  For $y\ne z$, the regions
-    $Q_y,Q_z$ are disjoint except when
+    \uses{def:qca_site_indexed_support_algebras}
+    Distinct members of the canonically embedded family commute elementwise:
     \begin{align}
-        (y,z)&=(2x+1,2x+2)
-    \end{align}
-    for some $x$, or when this ordered pair is reversed.  Consequently,
-    distinct members of the canonically embedded family commute
-    elementwise:
-    \begin{align}
-        [X,Y]&=0,
-        &X\in\widehat{\mathcal R}_y,\quad
+        [X,Y] & =0,
+              & X\in\widehat{\mathcal R}_y,\quad
         Y\in\widehat{\mathcal R}_z,\quad y\ne z.
     \end{align}
     This is the homogeneous fixed-$d$ specialization of the
@@ -11980,16 +12061,14 @@ left/right order below agrees with the adjacent-pair convention in
 \end{theorem}
 
 \begin{proof}\leanok
-    Consecutive source pairs $E_x,E_{x+1}$ are disjoint, so their canonical
-    observables commute.  Multiplicativity of $\omega$ preserves this
-    equality.  Embed both finite images into $\mathcal A_{T_x}$ and use the
-    tripartite coordinates above; the two overlapping lifts commute.
-    Lemma~\ref{thm:qca_overlapping_support_algebras_commute}, in the order
-    $\operatorname{Spp}_{\mathrm R}(S_x)$ followed by
-    $\operatorname{Spp}_{\mathrm L}(S_{x+1})$, gives commutation of
-    $\mathcal R_{2x+1}$ and $\mathcal R_{2x+2}$.  Every remaining ordered
-    pair has disjoint physical supports, so disjoint locality applies; the
-    reversed exceptional pair follows by symmetry.
+    \uses{thm:qca_support_region_overlap_classification,
+        thm:qca_unified_support_algebra_region,
+        thm:qca_consecutive_support_algebras_commute,
+        thm:qca_disjoint_quasi_local_commute}
+    In the exceptional odd--even order apply
+    Theorem~\ref{thm:qca_consecutive_support_algebras_commute}; the reversed
+    order follows by symmetry.  Every remaining ordered pair has disjoint
+    physical supports, so disjoint quasi-locality applies.
 \end{proof}
 
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11928,10 +11928,10 @@ left/right order below agrees with the adjacent-pair convention in
         SpinChain.leftPair_union_rightPair_union_rightPair_add_one}
     \leanok
     \uses{def:qca_nearest_neighbor_pair_regions}
-    The three regions $L_x,P_x,P_{x+1}$ are pairwise disjoint, and
+    Let $T_x=(L_x\cup P_x)\cup P_{x+1}$. The three regions
+    $L_x,P_x,P_{x+1}$ are pairwise disjoint, and
     \begin{align}
-        T_x & =(L_x\cup P_x)\cup P_{x+1}        \\
-            & =\{2x-1,2x,2x+1,2x+2,2x+3,2x+4\}.
+        T_x & =\{2x-1,2x,2x+1,2x+2,2x+3,2x+4\}.
     \end{align}
 \end{lemma}
 
@@ -12034,6 +12034,7 @@ left/right order below agrees with the adjacent-pair convention in
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:qca_support_algebra_region}
     Write each index in its even or odd form.  Two regions of equal parity
     are disjoint.  In the mixed-parity cases, the defining two-site sets
     intersect exactly for the displayed consecutive odd--even pair.
@@ -12054,7 +12055,7 @@ left/right order below agrees with the adjacent-pair convention in
     consecutive/disjoint argument in
     \cite[lines~1270--1274]{Gross2012IndexTheory}, using Lemma
     \texttt{sppcomm} from lines~1221--1246; compare
-    \cite[lines~1174--1194]{Schumacher2004QCA}.  Cirac et al. provide the
+    \cite[lines~1174--1194]{SchumacherWerner2004QCA}.  Cirac et al. provide the
     homogeneous four-site localization at
     \cite[lines~2313--2329]{Cirac2017MPU}, but do not state this commutation
     result.  The site-dependent GNVW statement is not claimed; see

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -12015,7 +12015,8 @@ left/right order below agrees with the adjacent-pair convention in
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:qca_site_indexed_support_regions}
+    \uses{def:qca_support_algebra_region,
+        thm:qca_site_indexed_support_regions}
     Split according to the parity of $y$ and apply the corresponding
     localization of $\widehat{\mathcal R}_{2x}$ or
     $\widehat{\mathcal R}_{2x+1}$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11936,6 +11936,7 @@ left/right order below agrees with the adjacent-pair convention in
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{def:qca_nearest_neighbor_pair_regions}
     Substitute the three pair definitions and compare their six sites.
 \end{proof}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11924,7 +11924,8 @@ left/right order below agrees with the adjacent-pair convention in
 
 \begin{lemma}[Geometry of consecutive pair images]
     \label{lem:qca_consecutive_pair_geometry}
-    \lean{SpinChain.disjoint_leftPair_union_rightPair_rightPair_add_one,
+    \lean{SpinChain.disjoint_leftPair_rightPair,
+        SpinChain.disjoint_leftPair_union_rightPair_rightPair_add_one,
         SpinChain.leftPair_union_rightPair_union_rightPair_add_one}
     \leanok
     \uses{def:qca_nearest_neighbor_pair_regions}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -11904,6 +11904,94 @@ left/right order below agrees with the adjacent-pair convention in
     $\widehat{\mathcal R}_{2x+1}$ in $\mathcal A_{P_x}$.
 \end{proof}
 
+\begin{theorem}[Tripartite coordinates for consecutive pair images]
+    \label{thm:qca_consecutive_pair_tripartite_coordinates}
+    \lean{SpinChain.Config.disjointTripleEquiv,
+        SpinChain.tripartiteLocalAlgebraEquiv,
+        SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_left,
+        SpinChain.tripartiteLocalAlgebraEquiv_localInclusion_right,
+        SpinChain.disjoint_leftPair_union_rightPair_rightPair_add_one,
+        SpinChain.leftPair_union_rightPair_union_rightPair_add_one}
+    \leanok
+    \uses{lem:qca_nearest_neighbor_pair_geometry, def:qca_bipartite_local_algebra_coordinates,
+        thm:qca_bipartite_local_algebra_inclusions}
+    Let
+    \begin{align}
+        T_x&=(L_x\cup P_x)\cup P_{x+1}
+        =\{2x-1,2x,2x+1,2x+2,2x+3,2x+4\}.
+    \end{align}
+    The regions $L_x,P_x,P_{x+1}$ are pairwise disjoint, and their ordered
+    configuration coordinates identify
+    \begin{align}
+        \mathcal A_{T_x}
+        &\cong M_{(\mathcal C_{L_x}\times\mathcal C_{P_x})
+          \times\mathcal C_{P_{x+1}}}(\mathbb C).
+    \end{align}
+    In these coordinates, the canonical inclusion from $L_x\cup P_x$ is
+    $X\mapsto X\otimes\mathbf 1$, while the canonical inclusion from
+    $P_x\cup P_{x+1}$ is $Y\mapsto\mathbf 1\otimes Y$, with the displayed
+    left--middle--right factor order.
+\end{theorem}
+
+\begin{proof}\leanok
+    Split configurations first across $(L_x\cup P_x),P_{x+1}$ and then
+    across $L_x,P_x$.  The two canonical local inclusions become the left
+    and right overlapping lifts after this product reassociation.  The
+    explicit formulas for the three pairs give their disjointness and the
+    six displayed sites.
+\end{proof}
+
+\begin{theorem}[Pairwise commutation of distinct support algebras]
+    \label{thm:qca_site_indexed_support_algebras_commute}
+    \lean{SpinChain.supportRegion,
+        SpinChain.supportRegion_even,
+        SpinChain.supportRegion_odd,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_supportedIn,
+        SpinChain.PropagatesWithin.supportRegion_disjoint_or_consecutive,
+        SpinChain.PropagatesWithin.embeddedOddSupportAlgebra_commute_embeddedEvenSupportAlgebra_add_one,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_pairwise_commute}
+    \leanok
+    \uses{def:qca_site_indexed_support_algebras,
+        thm:qca_site_indexed_support_regions,
+        thm:qca_consecutive_pair_tripartite_coordinates,
+        thm:qca_overlapping_support_algebras_commute}
+    Let $Q_{2x}=L_x$ and $Q_{2x+1}=P_x$.  For $y\ne z$, the regions
+    $Q_y,Q_z$ are disjoint except when
+    \begin{align}
+        (y,z)&=(2x+1,2x+2)
+    \end{align}
+    for some $x$, or when this ordered pair is reversed.  Consequently,
+    distinct members of the canonically embedded family commute
+    elementwise:
+    \begin{align}
+        [X,Y]&=0,
+        &X\in\widehat{\mathcal R}_y,\quad
+        Y\in\widehat{\mathcal R}_z,\quad y\ne z.
+    \end{align}
+    This is the homogeneous fixed-$d$ specialization of the
+    consecutive/disjoint argument in
+    \cite[lines~1270--1274]{Gross2012IndexTheory}, using Lemma
+    \texttt{sppcomm} from lines~1221--1246; compare
+    \cite[lines~1174--1194]{Schumacher2004QCA}.  Cirac et al. provide the
+    homogeneous four-site localization at
+    \cite[lines~2313--2329]{Cirac2017MPU}, but do not state this commutation
+    result.  The site-dependent GNVW statement is not claimed; see
+    \cite{gap:gnvw12_site_dependent_adjacent_generation_scope}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Consecutive source pairs $E_x,E_{x+1}$ are disjoint, so their canonical
+    observables commute.  Multiplicativity of $\omega$ preserves this
+    equality.  Embed both finite images into $\mathcal A_{T_x}$ and use the
+    tripartite coordinates above; the two overlapping lifts commute.
+    Lemma~\ref{thm:qca_overlapping_support_algebras_commute}, in the order
+    $\operatorname{Spp}_{\mathrm R}(S_x)$ followed by
+    $\operatorname{Spp}_{\mathrm L}(S_{x+1})$, gives commutation of
+    $\mathcal R_{2x+1}$ and $\mathcal R_{2x+2}$.  Every remaining ordered
+    pair has disjoint physical supports, so disjoint locality applies; the
+    reversed exceptional pair follows by symmetry.
+\end{proof}
+
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
 local action associated with an MPU by eventual finite-chain conjugation.  In
 lines~2300--2306, eventual constancy is used to obtain a norm-preserving

--- a/docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex
+++ b/docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex
@@ -139,23 +139,31 @@ their Appendix fixes $\mathcal A_y\cong M_d(\mathbb C)$ and constructs the
 even support algebra at lines 2320--2329
 \cite{Cirac2017MPU}.
 
-The theorems currently proved for the fixed-$d$ spin chain establish only the
+The theorems currently proved for the fixed-$d$ spin chain establish the
 homogeneous forms of
 (\ref{eq:gnvw12_site_dependent_adjacent_generation_scope_locality}) and
 (\ref{eq:gnvw12_site_dependent_adjacent_generation_scope_left_support})--%
 (\ref{eq:gnvw12_site_dependent_adjacent_generation_scope_right_support}),
-together with two-sided support containment.\footnote{Formal declarations:
+together with two-sided support containment. They also prove that the
+canonically embedded support algebras at distinct site indices commute
+pairwise. This is the homogeneous specialization of the consecutive/disjoint
+commutation argument at lines 1270--1274 of
+Ref.~\cite{Gross2012IndexTheory}; it does not use translation covariance.%
+\footnote{Formal declarations:
 \leanid{SpinChain.PropagatesWithin.evenPairLocalImage},
 \leanid{SpinChain.PropagatesWithin.evenSupportAlgebra},
 \leanid{SpinChain.PropagatesWithin.oddSupportAlgebra}, and
 \leanid{SpinChain.PropagatesWithin.evenPairLocalImage_le_support_kroneckerSubmodule}
-in \doclink{TNLean/QCA/SiteIndexedSupportAlgebra}.}
-They do not include the adjacent-generation equalities, matrix-factor
-presentations, the identities
+in \doclink{TNLean/QCA/SiteIndexedSupportAlgebra}, and
+\leanid{SpinChain.PropagatesWithin.embeddedSupportAlgebra_pairwise_commute}
+in \doclink{TNLean/QCA/SupportAlgebraCommutation}.}
+The fixed-$d$ development does not classify the support algebras as full
+matrix factors, prove the adjacent-generation equalities or their dimension
+consequences
 (\ref{eq:gnvw12_site_dependent_adjacent_generation_scope_homogeneous_even})--%
 (\ref{eq:gnvw12_site_dependent_adjacent_generation_scope_homogeneous_ratio}),
-or the index. Any future fixed-$d$ formulation of those results remains
-restricted to homogeneous chains.
+or construct the GNVW index. Extending the construction and the commutation
+theorem to site-dependent cell sizes also remains outside the present scope.
 
 This restriction differs from the full-matrix-factor restriction recorded in
 \path{docs/paper-gaps/gnvw12_support_algebra_full_matrix_scope.tex}. That note


### PR DESCRIPTION
## Summary

- add canonical tripartite finite-region coordinates for the ordered factors $L_x,P_x,P_{x+1}$ and identify the two local inclusions with the existing overlapping lifts
- derive consecutive-image commutation from disjoint source locality and multiplicativity of the supplied star-automorphism, then apply the existing support-algebra commutation theorem in right-support/left-support order
- classify the parity-sensitive physical support regions and prove carrier-level pairwise commutation of `embeddedSupportAlgebra` at distinct sites
- add formula-driven Chapter 28 coverage and the generated QCA aggregate import

The core theorem assumes only `[NeZero d]`, a star-automorphism, and `PropagatesWithin ω (Finset.Icc (-1) 1)`; it uses neither translation covariance nor `IsQCA`.

Closes #7116.

## Sources

- GNVW, arXiv:0910.3675v2, Lemma `sppcomm`, lines 1221--1246, and lines 1270--1274
- Schumacher--Werner, quant-ph/0405174, Lemma `sppcomm`, lines 1174--1194
- Cirac et al., arXiv:1703.09188, Appendix, lines 2313--2329

## Checks

- `lake env lean TNLean/QCA/SupportAlgebraCommutation.lean`
- focused `.olean` generation followed by `lake env lean TNLean/QCA.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --changed-files TNLean/QCA/SupportAlgebraCommutation.lean --diff-base origin/main` (Chapter 28: 828/828; reverse coverage clean)
- proof-integrity scan for `sorry|admit|axiom|native_decide|unsafeCast`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`

`leanblueprint checkdecls` reaches the project checker but is currently blocked by a pre-existing environment collision: `Matrix.trace_pow_mul_comm` is loaded both from `QICLean.Algebra.PerronFrobenius.RankOne` and `TNLean.Algebra.MatrixCyclicTracePower`. The source-level Blueprint synchronization and declaration coverage checks pass.
