### PR TITLE
feat(MPS/Core): define rectangular reductions

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.Core.MultiBlockWord
 import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.ProjectionTriangularTrace
+import TNLean.MPS.Core.Reduction
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.TensorProduct

--- a/TNLean/MPS/Core/Reduction.lean
+++ b/TNLean/MPS/Core/Reduction.lean
@@ -14,8 +14,6 @@ Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Proposition 20, is separate from
 the definition below.
 -/
 
-open scoped Matrix
-
 namespace MPSTensor
 
 variable {d D₁ D₂ : ℕ}
@@ -46,8 +44,7 @@ theorem mul_eq_one (h : IsReduction B A V W) : V * W = 1 := h.1
 theorem evalWord (h : IsReduction B A V W) (w : List (Fin d)) :
     V * Kraus.evalWord B w * W = Kraus.evalWord A w := h.2 w
 
-/-- The empty-word intertwining equation is the rectangular retraction
-identity. -/
+/-- The empty-word instance of the intertwining equation. -/
 theorem evalWord_nil (h : IsReduction B A V W) :
     V * Kraus.evalWord B [] * W = Kraus.evalWord A [] := h.2 []
 

--- a/TNLean/MPS/Core/Reduction.lean
+++ b/TNLean/MPS/Core/Reduction.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+
+/-!
+# Rectangular reductions of matrix product state tensors
+
+This file introduces the source-facing notion of a reduction between MPS
+tensors of possibly different bond dimensions.  The existence theorem of
+Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Proposition 20, is separate from
+the definition below.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D₁ D₂ : ℕ}
+
+/-- A rectangular reduction from `B` to `A` consists of matrices `V,W` with
+$VW=1$ which intertwine every virtual word:
+$V B^{\mathbf a} W=A^{\mathbf a}$.  The word clause includes the empty word.
+
+Source: Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Definition following
+Proposition 20, `cornerproblem.tex` lines 3137--3139; the equations are stated
+at lines 3129--3132, and the empty-word equation is made explicit at lines
+3934--3938. -/
+def IsReduction (B : MPSTensor d D₂) (A : MPSTensor d D₁)
+    (V : Matrix (Fin D₁) (Fin D₂) ℂ) (W : Matrix (Fin D₂) (Fin D₁) ℂ) : Prop :=
+  V * W = 1 ∧
+    ∀ w : List (Fin d), V * Kraus.evalWord B w * W = Kraus.evalWord A w
+
+namespace IsReduction
+
+variable {B : MPSTensor d D₂} {A : MPSTensor d D₁}
+  {V : Matrix (Fin D₁) (Fin D₂) ℂ} {W : Matrix (Fin D₂) (Fin D₁) ℂ}
+
+/-- The two rectangular matrices in a reduction have product one on the target
+bond space. -/
+theorem mul_eq_one (h : IsReduction B A V W) : V * W = 1 := h.1
+
+/-- A reduction intertwines every word, including the empty word. -/
+theorem evalWord (h : IsReduction B A V W) (w : List (Fin d)) :
+    V * Kraus.evalWord B w * W = Kraus.evalWord A w := h.2 w
+
+/-- The empty-word intertwining equation is the rectangular retraction
+identity. -/
+theorem evalWord_nil (h : IsReduction B A V W) :
+    V * Kraus.evalWord B [] * W = Kraus.evalWord A [] := h.2 []
+
+/-- It is enough to state the all-word intertwining equation: its empty-word
+case recovers $VW=1$. -/
+theorem iff_forall_evalWord :
+    IsReduction B A V W ↔
+      ∀ w : List (Fin d), V * Kraus.evalWord B w * W = Kraus.evalWord A w := by
+  constructor
+  · exact fun h => h.2
+  · intro h
+    refine ⟨?_, h⟩
+    simpa using h []
+
+end IsReduction
+
+end MPSTensor

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -325,19 +325,36 @@ boundary conditions (PBC).
     \leanok
     Let $A$ and $B$ have the same physical alphabet and respective bond
     dimensions $D_A$ and $D_B$.  A reduction from $B$ to $A$ is a pair
-    \begin{align}
-        V&\in\mathbb C^{D_A\times D_B}, &
-        W&\in\mathbb C^{D_B\times D_A}
-    \end{align}
-    such that
+    $V\in\mathbb C^{D_A\times D_B}$ and
+    $W\in\mathbb C^{D_B\times D_A}$ such that
     \begin{align}
         VW&=1_{D_A}, &
         VB^{\mathbf a}W&=A^{\mathbf a}
+        \label{eq:mps_rectangular_reduction}
     \end{align}
     for every word $\mathbf a$, including the empty word.
     This is the reduction of
     \cite[Proposition~20 and the following definition]{Molnar2018SemiInjective}.
 \end{definition}
+
+\begin{lemma}[Basic rectangular reduction identities]
+    \label{lem:mps_rectangular_reduction_identities}
+    \lean{MPSTensor.IsReduction.mul_eq_one,
+        MPSTensor.IsReduction.evalWord,
+        MPSTensor.IsReduction.evalWord_nil,
+        MPSTensor.IsReduction.iff_forall_evalWord}
+    \leanok
+    \uses{def:mps_rectangular_reduction}
+    A rectangular reduction satisfies both identities in
+    Eq.~\eqref{eq:mps_rectangular_reduction}.  Conversely, the all-word
+    identity alone implies $VW=1_{D_A}$ by taking the empty word.
+\end{lemma}
+
+\begin{proof}
+    The forward statements are the two defining clauses.  For the converse,
+    $A^{\varnothing}=1_{D_A}$ and $B^{\varnothing}=1_{D_B}$, so the empty-word
+    instance reads $V1_{D_B}W=1_{D_A}$.
+\end{proof}
 
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -323,6 +323,7 @@ boundary conditions (PBC).
     \label{def:mps_rectangular_reduction}
     \lean{MPSTensor.IsReduction}
     \leanok
+    \uses{def:mps_tensor, def:eval_word}
     Let $A$ and $B$ have the same physical alphabet and respective bond
     dimensions $D_A$ and $D_B$.  A reduction from $B$ to $A$ is a pair
     $V\in\mathbb C^{D_A\times D_B}$ and
@@ -351,6 +352,7 @@ boundary conditions (PBC).
 \end{lemma}
 
 \begin{proof}
+    \leanok
     The forward statements are the two defining clauses.  For the converse,
     $A^{\varnothing}=1_{D_A}$ and $B^{\varnothing}=1_{D_B}$, so the empty-word
     instance reads $V1_{D_B}W=1_{D_A}$.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -319,6 +319,26 @@ boundary conditions (PBC).
     $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N > 0$.
 \end{definition}
 
+\begin{definition}[Rectangular MPS reduction]
+    \label{def:mps_rectangular_reduction}
+    \lean{MPSTensor.IsReduction}
+    \leanok
+    Let $A$ and $B$ have the same physical alphabet and respective bond
+    dimensions $D_A$ and $D_B$.  A reduction from $B$ to $A$ is a pair
+    \begin{align}
+        V&\in\mathbb C^{D_A\times D_B}, &
+        W&\in\mathbb C^{D_B\times D_A}
+    \end{align}
+    such that
+    \begin{align}
+        VW&=1_{D_A}, &
+        VB^{\mathbf a}W&=A^{\mathbf a}
+    \end{align}
+    for every word $\mathbf a$, including the empty word.
+    This is the reduction of
+    \cite[Proposition~20 and the following definition]{Molnar2018SemiInjective}.
+\end{definition}
+
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
     specialization of Definition~\ref{def:same_mpv2}.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -329,8 +329,8 @@ boundary conditions (PBC).
     $V\in\mathbb C^{D_A\times D_B}$ and
     $W\in\mathbb C^{D_B\times D_A}$ such that
     \begin{align}
-        VW&=1_{D_A}, &
-        VB^{\mathbf a}W&=A^{\mathbf a}
+        VW              & =1_{D_A},      &
+        VB^{\mathbf a}W & =A^{\mathbf a}
         \label{eq:mps_rectangular_reduction}
     \end{align}
     for every word $\mathbf a$, including the empty word.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -326,12 +326,13 @@ boundary conditions (PBC).
     \uses{def:mps_tensor, def:eval_word}
     Let $A$ and $B$ have the same physical alphabet and respective bond
     dimensions $D_A$ and $D_B$.  A reduction from $B$ to $A$ is a pair
-    $V\in\mathbb C^{D_A\times D_B}$ and
-    $W\in\mathbb C^{D_B\times D_A}$ such that
+    $V\in\C^{D_A\times D_B}$ and
+    $W\in\C^{D_B\times D_A}$ such that
     \begin{align}
-        VW              & =1_{D_A},      &
-        VB^{\mathbf a}W & =A^{\mathbf a}
-        \label{eq:mps_rectangular_reduction}
+        VW              & =1_{D_A},
+        \label{eq:mps_rectangular_reduction_retraction} \\
+        VB^{\mathbf a}W & =A^{\mathbf a}.
+        \label{eq:mps_rectangular_reduction_word}
     \end{align}
     for every word $\mathbf a$, including the empty word.
     This is the reduction of
@@ -346,9 +347,10 @@ boundary conditions (PBC).
         MPSTensor.IsReduction.iff_forall_evalWord}
     \leanok
     \uses{def:mps_rectangular_reduction}
-    A rectangular reduction satisfies both identities in
-    (\ref{eq:mps_rectangular_reduction}).  Conversely, the all-word identity
-    alone implies $VW=1_{D_A}$ by taking the empty word.
+    A rectangular reduction satisfies the retraction identity
+    (\ref{eq:mps_rectangular_reduction_retraction}) and the word identity
+    (\ref{eq:mps_rectangular_reduction_word}).  Conversely, the all-word
+    identity alone implies $VW=1_{D_A}$ by taking the empty word.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -338,8 +338,8 @@ boundary conditions (PBC).
     \cite[Proposition~20 and the following definition]{Molnar2018SemiInjective}.
 \end{definition}
 
-\begin{lemma}[Basic rectangular reduction identities]
-    \label{lem:mps_rectangular_reduction_identities}
+\begin{theorem}[Basic rectangular reduction identities]
+    \label{thm:mps_rectangular_reduction_identities}
     \lean{MPSTensor.IsReduction.mul_eq_one,
         MPSTensor.IsReduction.evalWord,
         MPSTensor.IsReduction.evalWord_nil,
@@ -347,9 +347,9 @@ boundary conditions (PBC).
     \leanok
     \uses{def:mps_rectangular_reduction}
     A rectangular reduction satisfies both identities in
-    Eq.~\eqref{eq:mps_rectangular_reduction}.  Conversely, the all-word
-    identity alone implies $VW=1_{D_A}$ by taking the empty word.
-\end{lemma}
+    (\ref{eq:mps_rectangular_reduction}).  Conversely, the all-word identity
+    alone implies $VW=1_{D_A}$ by taking the empty word.
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -487,7 +487,8 @@
 @article{Molnar2018SemiInjective,
   author       = {Moln{\'a}r, Andr{\'a}s and Ge, Yimin and Schuch, Norbert and
                   Cirac, J. Ignacio},
-  title        = {A generalization of the injectivity condition for projected entangled pair states},
+  title        = {A generalization of the injectivity condition for projected
+                  entangled pair states},
   journal      = {Journal of Mathematical Physics},
   volume       = {59},
   number       = {2},

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -484,6 +484,20 @@
   eprinttype   = {arxiv},
 }
 
+@article{Molnar2018SemiInjective,
+  author       = {Moln{\'a}r, Andr{\'a}s and Ge, Yimin and Schuch, Norbert and
+                  Cirac, J. Ignacio},
+  title        = {A generalization of the injectivity condition for projected entangled pair states},
+  journal      = {Journal of Mathematical Physics},
+  volume       = {59},
+  number       = {2},
+  pages        = {021902},
+  year         = {2018},
+  doi          = {10.1063/1.5007017},
+  eprint       = {1706.07329},
+  eprinttype   = {arxiv},
+}
+
 @article{Molnar2018NormalPEPS,
   author       = {Moln{\'a}r, Andr{\'a}s and Garre-Rubio, Jos{\'e} and
                   P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and

--- a/docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex
+++ b/docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex
@@ -131,11 +131,14 @@ length: this is the case $\lambda=1$.  The fusion equations used there are
 therefore unaffected by the defect in the proportional version of
 Proposition~20.
 
-The formal development should state the reusable reduction theorem first for
-equal positive-length matrix product state families.  A later proportional
-version may be derived by the rescaling above, with the power
-$\lambda^m$ retained explicitly.  The equality-case implementation and its
-selected-reduction residual algebra are tracked by
+The formal predicate \leanid{MPSTensor.IsReduction} records the rectangular
+pair, the retraction $VW=1$, and the word equation including the empty word.
+The reusable existence theorem must first be proved for equal positive-length
+matrix product state families.  A later proportional version may be derived
+by the rescaling above, with the power $\lambda^m$ retained explicitly.  The
+equality-case existence proof is tracked by
+\href{https://github.com/LionSR/TNLean/issues/7393}{TNLean issue 7393}; its
+selected-reduction residual algebra is tracked under
 \href{https://github.com/LionSR/TNLean/issues/7322}{TNLean issue 7322}.
 
 \section{Verdict}


### PR DESCRIPTION
## Summary

- define the source-facing rectangular reduction relation for MPS tensors with different bond dimensions
- expose the retraction, all-word, empty-word, and redundancy lemmas
- add Chapter 2 coverage, the Molnár et al. bibliography entry, and synchronize the proportionality gap note

## Source and scope

This is the definition/interface leaf from Molnár--Ge--Schuch--Cirac Proposition 20 and the following reduction definition (`cornerproblem.tex:3124-3139`, empty-word equation at `3934-3938`). It does **not** claim the equality-case existence theorem; that remains #7393, blocked by the source cross-matrix and linear-algebra leaves #7426-#7428.

## Verification

- `lake env lean TNLean/MPS/Core/Reduction.lean`
- Blueprint source sync and changed-declaration reverse coverage
- generated import validation
- proof-integrity and diff checks
- independent exact-head approval at `e2c3e3daa9a821f102672f1fc2434ad3914a4b08` (execution `4fc1cae58e7a`)

Closes #7425.