### PR TITLE
feat(algebra): derive rank one from semisimple trace powers

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -32,4 +32,5 @@ import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.RankOneFactorization
 import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleInversion
+import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.UnitaryKronecker

--- a/TNLean/Algebra/SemisimpleTracePowers.lean
+++ b/TNLean/Algebra/SemisimpleTracePowers.lean
@@ -3,10 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Algebra.ShiftedTracePowerSpectrum
 import Mathlib.LinearAlgebra.Eigenspace.Semisimple
-import Mathlib.LinearAlgebra.JordanChevalley
 import Mathlib.LinearAlgebra.Trace
+import QICLean.Algebra.ShiftedTracePowerSpectrum
 
 /-!
 # Semisimple Endomorphisms with Rank-One Trace Powers

--- a/TNLean/Algebra/SemisimpleTracePowers.lean
+++ b/TNLean/Algebra/SemisimpleTracePowers.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.ShiftedTracePowerSpectrum
+import Mathlib.LinearAlgebra.Eigenspace.Semisimple
+import Mathlib.LinearAlgebra.JordanChevalley
+import Mathlib.LinearAlgebra.Trace
+
+/-!
+# Semisimple Endomorphisms with Rank-One Trace Powers
+
+This file isolates the finite-dimensional linear algebra used in the
+Jordan--Chevalley step of arXiv:1706.07329v2, Proposition 20, lines 3839--3866.
+
+A semisimple complex endomorphism has one-dimensional range when a nonzero
+scalar multiple has trace one at every power above one. The proof applies
+QICLean's shifted trace-power characteristic-polynomial theorem to a matrix in
+an arbitrary basis. Semisimplicity identifies the generalized zero-eigenspace
+with the kernel, and root multiplicity together with rank--nullity then gives
+the range dimension.
+
+A commuting nilpotent endomorphism preserves this one-dimensional range. Its
+restriction is a scalar endomorphism, whose nilpotence forces that scalar to
+vanish. Thus the nilpotent and semisimple parts annihilate one another in both
+orders, and sufficiently high powers of their sum are powers of the
+semisimple part alone.
+
+No normality, Hermitianity, positivity, or chosen-basis hypothesis is used.
+
+## Reference
+
+* [Molnar--Ge--Schuch--Cirac 2018] arXiv:1706.07329v2, Proposition 20,
+  lines 3839--3866
+-/
+
+open Polynomial
+
+namespace Module.End
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+
+/-- A semisimple complex endomorphism has one-dimensional range if a nonzero
+scalar multiple has trace one at every power above one.
+
+This is the root-multiplicity step in arXiv:1706.07329v2, Proposition 20,
+lines 3839--3866. The scaling scalar is explicit and required to be nonzero. -/
+theorem finrank_range_eq_one_of_isSemisimple_of_scaled_trace_pow_eq_one
+    (S : Module.End ℂ V) (hS : S.IsSemisimple) (c : ℂ) (hc : c ≠ 0)
+    (htrace : ∀ k : ℕ, 1 < k → LinearMap.trace ℂ V ((c • S) ^ k) = 1) :
+    Module.finrank ℂ S.range = 1 := by
+  classical
+  let g := c • S
+  let b := Module.Free.chooseBasis ℂ V
+  let A := LinearMap.toMatrix b b g
+  have hAtrace : ∀ k : ℕ, 1 < k → Matrix.trace (A ^ k) = 1 := by
+    intro k hk
+    change Matrix.trace ((LinearMap.toMatrix b b g) ^ k) = 1
+    rw [LinearMap.toMatrix_pow, ← LinearMap.trace_eq_matrix_trace ℂ b]
+    exact htrace k hk
+  have hcharA :
+      A.charpoly =
+        X ^ (Fintype.card (Module.Free.ChooseBasisIndex ℂ V) - 1) * (X - 1) :=
+    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt
+      A hAtrace
+  have hdim :
+      Fintype.card (Module.Free.ChooseBasisIndex ℂ V) = Module.finrank ℂ V := by
+    simpa using (Module.finrank_eq_card_basis b).symm
+  have hchar : g.charpoly = X ^ (Module.finrank ℂ V - 1) * (X - 1) := by
+    rw [← LinearMap.charpoly_toMatrix g b, hcharA, hdim]
+  have hgss : g.IsSemisimple := Module.End.IsSemisimple_smul c hS
+  have hker : Module.finrank ℂ (LinearMap.ker g) = Module.finrank ℂ V - 1 := by
+    calc
+      Module.finrank ℂ (LinearMap.ker g) =
+          Module.finrank ℂ (g.maxGenEigenspace 0) := by
+            rw [hgss.isFinitelySemisimple.maxGenEigenspace_eq_eigenspace,
+              Module.End.eigenspace_zero]
+      _ = g.charpoly.rootMultiplicity 0 :=
+        LinearMap.finrank_maxGenEigenspace_eq g 0
+      _ = Module.finrank ℂ V - 1 := by
+        rw [hchar, Polynomial.rootMultiplicity_eq_natTrailingDegree',
+          Polynomial.natTrailingDegree_mul (pow_ne_zero _ Polynomial.X_ne_zero)
+            (by simpa using (Polynomial.X_sub_C_ne_zero (1 : ℂ)))]
+        simp
+  have hdimpos : 0 < Module.finrank ℂ V := by
+    by_contra h
+    have hdimzero : Module.finrank ℂ V = 0 := Nat.eq_zero_of_not_pos h
+    have h := htrace 2 (by omega)
+    rw [show (c • S) ^ 2 = 0 by
+      have hs : Subsingleton V := Module.finrank_zero_iff.mp hdimzero
+      apply LinearMap.ext
+      intro x
+      exact Subsingleton.elim _ _] at h
+    simp at h
+  have hrangeg : Module.finrank ℂ g.range = 1 := by
+    have hnullity := g.finrank_range_add_finrank_ker
+    rw [hker] at hnullity
+    omega
+  have hrange : g.range = S.range := LinearMap.range_smul S c hc
+  rwa [← hrange]
+
+/-- A nilpotent endomorphism commuting with an endomorphism of one-dimensional
+range annihilates it in both orders.
+
+The nilpotent map restricts to the range because of commutation. Every
+endomorphism of that one-dimensional range is scalar, and a nilpotent scalar
+over `ℂ` is zero. -/
+theorem IsNilpotent.mul_eq_zero_and_mul_eq_zero_of_commute_of_finrank_range_eq_one
+    {N : Module.End ℂ V} (hN : IsNilpotent N) (S : Module.End ℂ V)
+    (hcomm : Commute N S) (hrank : Module.finrank ℂ S.range = 1) :
+    N * S = 0 ∧ S * N = 0 := by
+  have hmaps : Set.MapsTo N S.range S.range := by
+    rintro _ ⟨x, rfl⟩
+    refine ⟨N x, ?_⟩
+    rw [← Module.End.mul_apply, ← Module.End.mul_apply, hcomm.eq]
+  let R : Module.End ℂ S.range := N.restrict hmaps
+  have hRnil : IsNilpotent R := Module.End.isNilpotent.restrict hmaps hN
+  obtain ⟨a, ha, -⟩ := LinearMap.existsUnique_eq_smul_id_of_finrank_eq_one hrank R
+  have htr : LinearMap.trace ℂ S.range R = 0 :=
+    IsNilpotent.eq_zero (LinearMap.isNilpotent_trace_of_isNilpotent hRnil)
+  have ha0 : a = 0 := by
+    rw [ha, map_smul, LinearMap.trace_id, hrank, Nat.cast_one] at htr
+    simpa using htr
+  have hRzero : R = 0 := by rw [ha, ha0, zero_smul]
+  have hNS : N * S = 0 := by
+    ext x
+    have hx :=
+      LinearMap.congr_fun hRzero (⟨S x, LinearMap.mem_range_self S x⟩ : S.range)
+    dsimp [R] at hx
+    exact congrArg Subtype.val hx
+  exact ⟨hNS, hcomm.eq ▸ hNS⟩
+
+private lemma add_pow_eq_pow_add_pow_of_mul_eq_zero {R : Type*} [Semiring R]
+    (x y : R) (hxy : x * y = 0) (hyx : y * x = 0) {k : ℕ} (hk : 0 < k) :
+    (x + y) ^ k = x ^ k + y ^ k := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hk)
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, ih (by omega)]
+      simp [add_mul, mul_add, mul_assoc, hxy, hyx, pow_succ]
+
+omit [FiniteDimensional ℂ V] in
+/-- If two endomorphisms annihilate one another and the first is nilpotent,
+then sufficiently high powers of their sum are powers of the second alone. -/
+theorem IsNilpotent.exists_add_pow_eq_right_of_mul_eq_zero
+    {N : Module.End ℂ V} (hN : IsNilpotent N) (S : Module.End ℂ V)
+    (hNS : N * S = 0) (hSN : S * N = 0) :
+    ∃ J : ℕ, 0 < J ∧ ∀ k : ℕ, J ≤ k → (N + S) ^ k = S ^ k := by
+  obtain ⟨j, hj⟩ := hN
+  refine ⟨max 1 j, by omega, ?_⟩
+  intro k hk
+  rw [add_pow_eq_pow_add_pow_of_mul_eq_zero N S hNS hSN (by omega),
+    pow_eq_zero_of_le (le_trans (Nat.le_max_right 1 j) hk) hj, zero_add]
+
+/-- In a Jordan--Chevalley split, shifted scaled trace powers of the semisimple
+part force the nilpotent and semisimple parts to annihilate one another; all
+sufficiently high powers of their sum then equal powers of the semisimple part.
+
+This packages the linear-algebra reduction in arXiv:1706.07329v2,
+Proposition 20, lines 3839--3866. -/
+theorem IsNilpotent.products_eq_zero_and_eventual_add_pow_eq_of_scaled_trace
+    {N : Module.End ℂ V} (hN : IsNilpotent N) (S : Module.End ℂ V)
+    (hcomm : Commute N S) (hS : S.IsSemisimple) (c : ℂ) (hc : c ≠ 0)
+    (htrace : ∀ k : ℕ, 1 < k → LinearMap.trace ℂ V ((c • S) ^ k) = 1) :
+    N * S = 0 ∧ S * N = 0 ∧
+      ∃ J : ℕ, 0 < J ∧ ∀ k : ℕ, J ≤ k → (N + S) ^ k = S ^ k := by
+  have hrank :=
+    finrank_range_eq_one_of_isSemisimple_of_scaled_trace_pow_eq_one S hS c hc htrace
+  obtain ⟨hNS, hSN⟩ :=
+    IsNilpotent.mul_eq_zero_and_mul_eq_zero_of_commute_of_finrank_range_eq_one
+      hN S hcomm hrank
+  exact ⟨hNS, hSN,
+    IsNilpotent.exists_add_pow_eq_right_of_mul_eq_zero hN S hNS hSN⟩
+
+end Module.End

--- a/TNLean/Algebra/SemisimpleTracePowers.lean
+++ b/TNLean/Algebra/SemisimpleTracePowers.lean
@@ -40,6 +40,30 @@ namespace Module.End
 
 variable {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
 
+omit [FiniteDimensional ℂ V] in
+/-- A commuting nilpotent summand does not change trace powers.
+
+The commuting binomial expansion has one term without the nilpotent summand.
+Every other term is nilpotent and therefore has zero trace. This is the trace
+reduction used in arXiv:1706.07329v2, Proposition 20, line 3865. -/
+theorem IsNilpotent.trace_add_pow_eq_trace_pow_of_commute
+    {N : Module.End ℂ V} (hN : IsNilpotent N) (S : Module.End ℂ V)
+    (hcomm : Commute N S) (k : ℕ) :
+    LinearMap.trace ℂ V ((N + S) ^ k) = LinearMap.trace ℂ V (S ^ k) := by
+  rw [hcomm.add_pow k, map_sum]
+  rw [Finset.sum_eq_single 0]
+  · simp
+  · intro m _ hm
+    obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hm
+    apply IsNilpotent.eq_zero
+    apply LinearMap.isNilpotent_trace_of_isNilpotent
+    rw [pow_succ']
+    simp only [mul_assoc]
+    apply Commute.isNilpotent_mul_right _ hN
+    exact ((Commute.refl N).pow_right n).mul_right
+      ((hcomm.pow_right (k - (n + 1))).mul_right (Nat.commute_cast N (k.choose (n + 1))))
+  · simp
+
 /-- A semisimple complex endomorphism has one-dimensional range if a nonzero
 scalar multiple has trace one at every power above one.
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1425,7 +1425,8 @@ nonzero spectrum as a set.
 
 \begin{theorem}[Semisimple rank-one Jordan--Chevalley reduction]
     \label{thm:mpu_semisimple_scaled_trace_rank_one}
-    \lean{Module.End.finrank_range_eq_one_of_isSemisimple_of_scaled_trace_pow_eq_one,
+    \lean{Module.End.IsNilpotent.trace_add_pow_eq_trace_pow_of_commute,
+        Module.End.finrank_range_eq_one_of_isSemisimple_of_scaled_trace_pow_eq_one,
         Module.End.IsNilpotent.mul_eq_zero_and_mul_eq_zero_of_commute_of_finrank_range_eq_one,
         Module.End.IsNilpotent.exists_add_pow_eq_right_of_mul_eq_zero,
         Module.End.IsNilpotent.products_eq_zero_and_eventual_add_pow_eq_of_scaled_trace}
@@ -1439,9 +1440,11 @@ nonzero spectrum as a set.
     \begin{align}
         \dim\operatorname{range}(S) & =1.
     \end{align}
-    If $N$ is nilpotent and commutes with $S$, then
+    If $N$ is nilpotent and commutes with $S$, then, for every positive integer
+    $k$,
     \begin{align}
-        NS & =SN=0.
+        \tr\bigl((N+S)^k\bigr) & =\tr(S^k), \\
+        NS                     & =SN=0.
     \end{align}
     Moreover, there is an integer $J>0$ such that, for every $k\geq J$,
     \begin{align}
@@ -1467,6 +1470,16 @@ nonzero spectrum as a set.
     \end{align}
     Rank--nullity and $c\ne0$ therefore give
     $\dim\operatorname{range}(S)=1$.
+
+    For $k>0$, commutation gives the binomial expansion
+    \begin{align}
+        (N+S)^k & =\sum_{m=0}^k \binom{k}{m}N^mS^{k-m}.
+    \end{align}
+    If $m>0$, write $N^m=N N^{m-1}$. The first factor commutes with the
+    remaining factors, so nilpotence of $N$ makes the entire summand
+    nilpotent and its trace vanishes. Only the term $m=0$ remains, giving
+    $\tr((N+S)^k)=\tr(S^k)$. This is the trace reduction used in
+    arXiv:1706.07329v2, Proposition~20, line 3865.
 
     Commutation makes $\operatorname{range}(S)$ invariant under $N$. The
     restriction of $N$ to this one-dimensional space is both nilpotent and a

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1423,6 +1423,62 @@ nonzero spectrum as a set.
     \end{align}
 \end{proof}
 
+\begin{theorem}[Semisimple rank-one Jordan--Chevalley reduction]
+    \label{thm:mpu_semisimple_scaled_trace_rank_one}
+    \lean{Module.End.finrank_range_eq_one_of_isSemisimple_of_scaled_trace_pow_eq_one,
+        Module.End.IsNilpotent.mul_eq_zero_and_mul_eq_zero_of_commute_of_finrank_range_eq_one,
+        Module.End.IsNilpotent.exists_add_pow_eq_right_of_mul_eq_zero,
+        Module.End.IsNilpotent.products_eq_zero_and_eventual_add_pow_eq_of_scaled_trace}
+    \leanok
+    Let $V$ be a finite-dimensional complex vector space and let $S$ be a
+    semisimple endomorphism of $V$. Suppose that $c\in\mathbb C$ is nonzero and
+    \begin{align}
+        \tr\bigl((cS)^k\bigr) & =1
+    \end{align}
+    for every integer $k>1$. Then
+    \begin{align}
+        \dim\operatorname{range}(S) & =1.
+    \end{align}
+    If $N$ is nilpotent and commutes with $S$, then
+    \begin{align}
+        NS & =SN=0.
+    \end{align}
+    Moreover, there is an integer $J>0$ such that, for every $k\geq J$,
+    \begin{align}
+        (N+S)^k & =S^k.
+    \end{align}
+    This is the generic Jordan--Chevalley step in arXiv:1706.07329v2,
+    Proposition~20, lines 3839--3866.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_shifted_trace_power_charpoly}
+    Choose an arbitrary basis of $V$ and represent $cS$ by a matrix $A$.
+    The shifted trace-power theorem gives
+    \begin{align}
+        \chi_A(X) & =X^{\dim V-1}(X-1).
+    \end{align}
+    Since $cS$ is semisimple, its generalized zero-eigenspace is its ordinary
+    zero-eigenspace, namely its kernel. The dimension of the generalized
+    zero-eigenspace is the root multiplicity of zero in the characteristic
+    polynomial, so
+    \begin{align}
+        \dim\ker(cS) & =\dim V-1.
+    \end{align}
+    Rank--nullity and $c\ne0$ therefore give
+    $\dim\operatorname{range}(S)=1$.
+
+    Commutation makes $\operatorname{range}(S)$ invariant under $N$. The
+    restriction of $N$ to this one-dimensional space is both nilpotent and a
+    scalar endomorphism, hence zero. Therefore $NS=0$, and commutation also
+    gives $SN=0$. For every positive $k$, induction using these two identities
+    yields
+    \begin{align}
+        (N+S)^k & =N^k+S^k.
+    \end{align}
+    Taking $J$ at least the nilpotency index of $N$ removes the first summand.
+\end{proof}
+
 \begin{theorem}[Vanishing positive trace powers determine the characteristic polynomial]
     \label{thm:mpu_zero_trace_power_charpoly}
     \lean{Matrix.charpoly_eq_X_pow_card_of_forall_trace_pow_eq_zero}


### PR DESCRIPTION
Closes #7427

## Summary
- derive one-dimensional range for semisimple endomorphisms from nonzero-scaled trace powers
- prove commuting nilpotent parts annihilate a rank-one semisimple part
- identify all sufficiently high powers of the Jordan--Chevalley sum with the semisimple powers
- document the exact source-faithful linear-algebra step in Chapter 28

## Verification
- targeted cached module build and direct Lean elaboration
- generated-import and Blueprint synchronization checks (Chapter 28: 885/885)
- exact-head independent review approved `9280cddfd699211e01304b99dc1d0046b5485ced`
- no broad build was run

The standalone global Blueprint declaration check remains blocked on the same pre-existing duplicate `Matrix.trace_pow_mul_comm` collision present on `main`; changed declarations synchronize cleanly.