### PR TITLE
feat(MPS/Core): build reduction cross matrix

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -22,6 +22,7 @@ import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.ProjectionTriangularTrace
 import TNLean.MPS.Core.Reduction
+import TNLean.MPS.Core.ReductionCrossMatrix
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.TensorProduct

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import TNLean.Algebra.ListProduct
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.MPS.Core.Blocking
-import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.Core.TracePairing
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
@@ -51,7 +50,9 @@ noncomputable def coefficientDualInverse (A : MPSTensor d D_A)
 \[
   \sum_i A^i_{xy} C^i_{a'a}=\delta_{x,a}\delta_{y,a'}.
 \]
-The reversed pair `(a',a)` is the upper-leg convention in the source diagram. -/
+The reversed pair `(a',a)` is the upper-leg convention in the source diagram.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3817--3823. -/
 theorem coefficientDualInverse_sum_entry (A : MPSTensor d D_A)
     (hA : Kraus.IsInjective A) (x y a a' : Fin D_A) :
     ∑ i : Fin d, A i x y * coefficientDualInverse A hA i a' a =
@@ -73,14 +74,18 @@ theorem coefficientDualInverse_sum_entry (A : MPSTensor d D_A)
 
 /-- The source reduction cross matrix
 `K = ∑ i, B i ⊗ (C i)ᵀ`, on the genuinely mixed bond index
-`Fin D_B × Fin D_A`. -/
+`Fin D_B × Fin D_A`.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3824--3838. -/
 noncomputable def reductionCrossMatrix (B : MPSTensor d D_B)
     (C : MPSTensor d D_A) :
     Matrix (Fin D_B × Fin D_A) (Fin D_B × Fin D_A) ℂ :=
   ∑ i : Fin d, B i ⊗ₖ (C i)ᵀ
 
 /-- Exact entry formula for the reduction cross matrix.  In particular, the
-upper inverse-tensor entry is `C i a' a`, not a conjugated entry. -/
+upper inverse-tensor entry is `C i a' a`, not a conjugated entry.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3824--3838. -/
 @[simp] theorem reductionCrossMatrix_apply (B : MPSTensor d D_B)
     (C : MPSTensor d D_A) (b b' : Fin D_B) (a a' : Fin D_A) :
     reductionCrossMatrix B C (b, a) (b', a') =
@@ -115,7 +120,9 @@ private theorem sum_family_pow_eq_sum_listProd
 
 /-- Power expansion of the mixed-bond cross matrix.  The theorem freezes the
 source orientation explicitly: the lower `B` word is in site order while the
-upper `C` word is reversed before taking its ordinary transpose. -/
+upper `C` word is reversed before taking its ordinary transpose.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3839--3865. -/
 theorem reductionCrossMatrix_pow_eq_sum (B : MPSTensor d D_B)
     (C : MPSTensor d D_A) (n : ℕ) :
     reductionCrossMatrix B C ^ n =
@@ -129,7 +136,9 @@ theorem reductionCrossMatrix_pow_eq_sum (B : MPSTensor d D_B)
     listProd_kronecker_transpose B C (List.ofFn σ)
 
 /-- Entrywise power formula, with the source's reversed upper-leg order
-visible in the statement. -/
+visible in the statement.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3839--3865. -/
 theorem reductionCrossMatrix_pow_apply (B : MPSTensor d D_B)
     (C : MPSTensor d D_A) (n : ℕ)
     (b b' : Fin D_B) (a a' : Fin D_A) :
@@ -154,7 +163,9 @@ private theorem diagonalBondVector_dotProduct (D : ℕ) :
   simp [diagonalBondVector]
 
 /-- Pairing an injective tensor with its coefficient dual gives the rank-one
-matrix supported on equal lower/upper bond indices. -/
+matrix supported on equal lower/upper bond indices.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3817--3838. -/
 theorem reductionCrossMatrix_coefficientDualInverse
     (A : MPSTensor d D_A) (hA : Kraus.IsInjective A) :
     reductionCrossMatrix A (coefficientDualInverse A hA) =

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -305,7 +305,10 @@ theorem reductionOpenBoundaryMatrixContraction_eq_cross_sum
   intro σ _
   ring
 
-/-- Exact target evaluation with an arbitrary lower tail matrix. -/
+/-- Exact target evaluation with an arbitrary lower tail matrix.
+
+Source: arXiv:1706.07329v2, proof of Proposition 20,
+`cornerproblem.tex` lines 3866--3887. -/
 theorem reductionOpenBoundaryMatrixContraction_self
     (A : MPSTensor d D_A) (hA : Kraus.IsInjective A)
     (n : ℕ) (hn : 0 < n) (X : Matrix (Fin D_A) (Fin D_A) ℂ)
@@ -318,7 +321,10 @@ theorem reductionOpenBoundaryMatrixContraction_self
   simp [reductionCrossMatrix_coefficientDualInverse,
     Matrix.vecMulVec_apply, diagonalBondVector]
 
-/-- Exact same-alphabet target evaluation of the open-boundary contraction. -/
+/-- Exact same-alphabet target evaluation of the open-boundary contraction.
+
+Source: arXiv:1706.07329v2, proof of Proposition 20,
+`cornerproblem.tex` lines 3866--3887. -/
 theorem reductionOpenBoundaryContraction_self
     (A : MPSTensor d D_A) (hA : Kraus.IsInjective A)
     (n : ℕ) (hn : 0 < n) (w : List (Fin d)) (a' a : Fin D_A) :

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -253,7 +253,13 @@ private theorem trace_mul_eq_sum_entries {D : ℕ}
   rw [Matrix.trace]
   simp only [Matrix.diag, Matrix.mul_apply]
 
-private theorem reductionOpenBoundaryMatrixContraction_eq_cross_sum
+/-- The open-boundary matrix contraction is the pairing of the boundary matrix
+`X` with the corresponding entries of the cross-matrix power.  This is the
+exact cross-sum expansion used before the rank-one reduction in the source's
+open padded contraction.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3866--3887. -/
+theorem reductionOpenBoundaryMatrixContraction_eq_cross_sum
     (B : MPSTensor d D_B) (C : MPSTensor d D_A)
     (n : ℕ) (X : Matrix (Fin D_B) (Fin D_B) ℂ) (a' a : Fin D_A) :
     reductionOpenBoundaryMatrixContraction B C n X a' a =

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -26,6 +26,12 @@ load-bearing.  No conjugate transpose or same-bond Fundamental Theorem is used.
 
 Source: arXiv:1706.07329v2, proof of Proposition 20,
 `cornerproblem.tex` lines 3815--3866 and 3866--3936.
+
+**Scope restriction (equality-only local fix):** The trace-power and source
+open-boundary results below assume `SameMPV₂Pos`, so they treat the `λ = 1`
+specialization of the proportional premise printed in Proposition 20.  The
+unscaled conclusion is false for unrestricted `λ ≠ 1`; see
+`docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`.
 -/
 
 open scoped Matrix Kronecker BigOperators
@@ -39,7 +45,7 @@ Its upper virtual indices are ordered so that
 `coefficientDualInverse A hA i a' a` is the coefficient of `A i` in the
 chosen expansion of the matrix unit `|a⟩⟨a'|`.
 
-Source: the left inverse `Ã⁻¹` in arXiv:1706.07329v2,
+Source: the left inverse \(\widetilde A^{-1}\) in arXiv:1706.07329v2,
 `cornerproblem.tex` lines 3817--3823. -/
 noncomputable def coefficientDualInverse (A : MPSTensor d D_A)
     (hA : Kraus.IsInjective A) : MPSTensor d D_A :=

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -247,7 +247,10 @@ noncomputable def reductionOpenBoundaryMatrixContraction
     Matrix.trace (Kraus.evalWord B (List.ofFn σ) * X) *
       Kraus.evalWord C (List.ofFn σ).reverse a' a
 
-/-- The same-alphabet specialization whose lower tail is the word `B^w`. -/
+/-- The same-alphabet specialization whose lower tail is the word `B^w`.
+
+Source: arXiv:1706.07329v2, proof of Proposition 20,
+`cornerproblem.tex` lines 3866--3887. -/
 noncomputable def reductionOpenBoundaryContraction
     (B : MPSTensor d D_B) (C : MPSTensor d D_A)
     (n : ℕ) (w : List (Fin d)) (a' a : Fin D_A) : ℂ :=

--- a/TNLean/MPS/Core/ReductionCrossMatrix.lean
+++ b/TNLean/MPS/Core/ReductionCrossMatrix.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ListProduct
+import TNLean.MPS.Chain.OneSidedInverse
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Core.TracePairing
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+
+/-!
+# The mixed-bond cross matrix in the MPS reduction proof
+
+This file formalizes the algebra before the Jordan--Chevalley step in the proof
+of Proposition 20 of Molnár--Ge--Schuch--Cirac.  For an injective blocked target
+`A`, its coefficient-dual inverse `C` is chosen from `Kraus.decompositionMap`.
+For a blocked source `B`, the paper's matrix is literally
+
+\[
+  K=\sum_i B^i\otimes(C^i)^T.
+\]
+
+The ordinary transpose and the reversal of the `C` word in powers of `K` are
+load-bearing.  No conjugate transpose or same-bond Fundamental Theorem is used.
+
+Source: arXiv:1706.07329v2, proof of Proposition 20,
+`cornerproblem.tex` lines 3815--3866 and 3866--3936.
+-/
+
+open scoped Matrix Kronecker BigOperators
+
+namespace MPSTensor
+
+variable {d D_A D_B : ℕ}
+
+/-- The coefficient-dual inverse tensor of an injective target tensor.
+Its upper virtual indices are ordered so that
+`coefficientDualInverse A hA i a' a` is the coefficient of `A i` in the
+chosen expansion of the matrix unit `|a⟩⟨a'|`.
+
+Source: the left inverse `Ã⁻¹` in arXiv:1706.07329v2,
+`cornerproblem.tex` lines 3817--3823. -/
+noncomputable def coefficientDualInverse (A : MPSTensor d D_A)
+    (hA : Kraus.IsInjective A) : MPSTensor d D_A :=
+  fun i a' a =>
+    Kraus.decompositionMap (A := A) hA (Matrix.single a a' (1 : ℂ)) i
+
+/-- Exact matrix-unit coefficient identity for the chosen dual inverse:
+\[
+  \sum_i A^i_{xy} C^i_{a'a}=\delta_{x,a}\delta_{y,a'}.
+\]
+The reversed pair `(a',a)` is the upper-leg convention in the source diagram. -/
+theorem coefficientDualInverse_sum_entry (A : MPSTensor d D_A)
+    (hA : Kraus.IsInjective A) (x y a a' : Fin D_A) :
+    ∑ i : Fin d, A i x y * coefficientDualInverse A hA i a' a =
+      (if x = a then 1 else 0) * (if y = a' then 1 else 0) := by
+  calc
+    ∑ i : Fin d, A i x y * coefficientDualInverse A hA i a' a =
+        ∑ i : Fin d, coefficientDualInverse A hA i a' a * A i x y := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [mul_comm]
+    _ = (∑ i : Fin d,
+          Kraus.decompositionMap (A := A) hA (Matrix.single a a' (1 : ℂ)) i • A i) x y := by
+      simp only [coefficientDualInverse, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    _ = Matrix.single a a' (1 : ℂ) x y := by
+      rw [Kraus.decompositionMap_sum]
+    _ = (if x = a then 1 else 0) * (if y = a' then 1 else 0) := by
+      simp only [Matrix.single_apply]
+      split_ifs <;> simp_all
+
+/-- The source reduction cross matrix
+`K = ∑ i, B i ⊗ (C i)ᵀ`, on the genuinely mixed bond index
+`Fin D_B × Fin D_A`. -/
+noncomputable def reductionCrossMatrix (B : MPSTensor d D_B)
+    (C : MPSTensor d D_A) :
+    Matrix (Fin D_B × Fin D_A) (Fin D_B × Fin D_A) ℂ :=
+  ∑ i : Fin d, B i ⊗ₖ (C i)ᵀ
+
+/-- Exact entry formula for the reduction cross matrix.  In particular, the
+upper inverse-tensor entry is `C i a' a`, not a conjugated entry. -/
+@[simp] theorem reductionCrossMatrix_apply (B : MPSTensor d D_B)
+    (C : MPSTensor d D_A) (b b' : Fin D_B) (a a' : Fin D_A) :
+    reductionCrossMatrix B C (b, a) (b', a') =
+      ∑ i : Fin d, B i b b' * C i a' a := by
+  simp only [reductionCrossMatrix, Matrix.sum_apply,
+    Matrix.kroneckerMap_apply, Matrix.transpose_apply]
+
+private theorem listProd_kronecker_transpose
+    (B : MPSTensor d D_B) (C : MPSTensor d D_A) (w : List (Fin d)) :
+    (w.map fun i => B i ⊗ₖ (C i)ᵀ).prod =
+      Kraus.evalWord B w ⊗ₖ (Kraus.evalWord C w.reverse)ᵀ := by
+  have hprod :
+      (w.map fun i => B i ⊗ₖ (C i)ᵀ).prod =
+        Kraus.evalWord B w ⊗ₖ Kraus.evalWord (fun i => (C i)ᵀ) w := by
+    induction w with
+    | nil => simp [Kraus.evalWord]
+    | cons i w ih =>
+        simp only [List.map_cons, List.prod_cons, Kraus.evalWord_cons, ih]
+        exact (Matrix.mul_kronecker_mul (B i) (Kraus.evalWord B w)
+          (C i)ᵀ (Kraus.evalWord (fun j => (C j)ᵀ) w)).symm
+  rw [hprod]
+  congr 1
+  simpa using (Kraus.evalWord_transpose C w.reverse).symm
+
+private theorem sum_family_pow_eq_sum_listProd
+    {m : Type*} [Fintype m] [DecidableEq m]
+    (F : Fin d → Matrix m m ℂ) (n : ℕ) :
+    (∑ i : Fin d, F i) ^ n =
+      ∑ σ : Fin n → Fin d, (List.ofFn fun k => F (σ k)).prod := by
+  rw [← List.prod_replicate, ← List.ofFn_const]
+  exact List.prod_ofFn_sum (fun _ : Fin n => F)
+
+/-- Power expansion of the mixed-bond cross matrix.  The theorem freezes the
+source orientation explicitly: the lower `B` word is in site order while the
+upper `C` word is reversed before taking its ordinary transpose. -/
+theorem reductionCrossMatrix_pow_eq_sum (B : MPSTensor d D_B)
+    (C : MPSTensor d D_A) (n : ℕ) :
+    reductionCrossMatrix B C ^ n =
+      ∑ σ : Fin n → Fin d,
+        Kraus.evalWord B (List.ofFn σ) ⊗ₖ
+          (Kraus.evalWord C (List.ofFn σ).reverse)ᵀ := by
+  rw [reductionCrossMatrix, sum_family_pow_eq_sum_listProd]
+  apply Finset.sum_congr rfl
+  intro σ _
+  simpa only [List.map_ofFn, Function.comp_def] using
+    listProd_kronecker_transpose B C (List.ofFn σ)
+
+/-- Entrywise power formula, with the source's reversed upper-leg order
+visible in the statement. -/
+theorem reductionCrossMatrix_pow_apply (B : MPSTensor d D_B)
+    (C : MPSTensor d D_A) (n : ℕ)
+    (b b' : Fin D_B) (a a' : Fin D_A) :
+    (reductionCrossMatrix B C ^ n) (b, a) (b', a') =
+      ∑ σ : Fin n → Fin d,
+        Kraus.evalWord B (List.ofFn σ) b b' *
+          Kraus.evalWord C (List.ofFn σ).reverse a' a := by
+  have h := congrArg
+    (fun M : Matrix (Fin D_B × Fin D_A) (Fin D_B × Fin D_A) ℂ =>
+      M (b, a) (b', a'))
+    (reductionCrossMatrix_pow_eq_sum B C n)
+  simpa only [Matrix.sum_apply, Matrix.kroneckerMap_apply,
+    Matrix.transpose_apply] using h
+
+private def diagonalBondVector (D : ℕ) : Fin D × Fin D → ℂ :=
+  fun p => if p.1 = p.2 then 1 else 0
+
+private theorem diagonalBondVector_dotProduct (D : ℕ) :
+    diagonalBondVector D ⬝ᵥ diagonalBondVector D = (D : ℂ) := by
+  classical
+  rw [dotProduct, Fintype.sum_prod_type]
+  simp [diagonalBondVector]
+
+/-- Pairing an injective tensor with its coefficient dual gives the rank-one
+matrix supported on equal lower/upper bond indices. -/
+theorem reductionCrossMatrix_coefficientDualInverse
+    (A : MPSTensor d D_A) (hA : Kraus.IsInjective A) :
+    reductionCrossMatrix A (coefficientDualInverse A hA) =
+      Matrix.vecMulVec (diagonalBondVector D_A) (diagonalBondVector D_A) := by
+  ext p q
+  rcases p with ⟨x, a⟩
+  rcases q with ⟨y, a'⟩
+  rw [reductionCrossMatrix_apply, coefficientDualInverse_sum_entry]
+  simp [Matrix.vecMulVec_apply, diagonalBondVector]
+
+private theorem coefficientDualCross_pow
+    (A : MPSTensor d D_A) (hA : Kraus.IsInjective A)
+    (n : ℕ) (hn : 0 < n) :
+    reductionCrossMatrix A (coefficientDualInverse A hA) ^ n =
+      ((D_A : ℂ) ^ (n - 1)) •
+        reductionCrossMatrix A (coefficientDualInverse A hA) := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn)
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, ih (Nat.zero_lt_succ k), Matrix.smul_mul,
+        reductionCrossMatrix_coefficientDualInverse,
+        Matrix.vecMulVec_mul_vecMulVec, diagonalBondVector_dotProduct]
+      ext p q
+      simp only [Matrix.smul_apply, Matrix.vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
+      rw [Nat.succ_sub (Nat.zero_lt_succ k), pow_succ]
+      ring
+
+/-- Under positive-length MPV equality, the trace of every positive power of
+the source cross matrix is exactly `(D_A : ℂ)^n`.
+
+This is the algebraic form of the closed diagram at
+`cornerproblem.tex` lines 3839--3865. -/
+theorem trace_reductionCrossMatrix_pow_of_sameMPV₂Pos
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B)
+    (hA : Kraus.IsInjective A) (hSame : SameMPV₂Pos B A)
+    (n : ℕ) (hn : 0 < n) :
+    Matrix.trace (reductionCrossMatrix B (coefficientDualInverse A hA) ^ n) =
+      (D_A : ℂ) ^ n := by
+  rw [reductionCrossMatrix_pow_eq_sum, Matrix.trace_sum]
+  simp_rw [Matrix.trace_kronecker, Matrix.trace_transpose]
+  have hword (σ : Fin n → Fin d) :
+      Matrix.trace (Kraus.evalWord B (List.ofFn σ)) =
+        Matrix.trace (Kraus.evalWord A (List.ofFn σ)) := by
+    exact hSame.trace_evalWord (List.ofFn σ) (by
+      intro hnil
+      exact (Nat.ne_of_gt hn) (List.ofFn_eq_nil_iff.mp hnil))
+  simp_rw [hword]
+  change (∑ σ : Fin n → Fin d,
+      Matrix.trace (Kraus.evalWord A (List.ofFn σ)) *
+        Matrix.trace
+          (Kraus.evalWord (coefficientDualInverse A hA) (List.ofFn σ).reverse)) = _
+  calc
+    _ = Matrix.trace
+        (reductionCrossMatrix A (coefficientDualInverse A hA) ^ n) := by
+      rw [reductionCrossMatrix_pow_eq_sum, Matrix.trace_sum]
+      simp only [Matrix.trace_kronecker, Matrix.trace_transpose]
+    _ = _ := by
+      rw [coefficientDualCross_pow A hA n hn, Matrix.trace_smul,
+        reductionCrossMatrix_coefficientDualInverse,
+        Matrix.trace_vecMulVec, diagonalBondVector_dotProduct]
+      change (D_A : ℂ) ^ (n - 1) * (D_A : ℂ) = (D_A : ℂ) ^ n
+      rw [← pow_succ,
+        Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.mpr (Nat.ne_of_gt hn))]
+
+/-- The source open-boundary contraction with an arbitrary lower tail matrix.
+This form permits the inverse sites to be blocked while the tail remains an
+unblocked word, as in `cornerproblem.tex` lines 3866--3887. -/
+noncomputable def reductionOpenBoundaryMatrixContraction
+    (B : MPSTensor d D_B) (C : MPSTensor d D_A)
+    (n : ℕ) (X : Matrix (Fin D_B) (Fin D_B) ℂ) (a' a : Fin D_A) : ℂ :=
+  ∑ σ : Fin n → Fin d,
+    Matrix.trace (Kraus.evalWord B (List.ofFn σ) * X) *
+      Kraus.evalWord C (List.ofFn σ).reverse a' a
+
+/-- The same-alphabet specialization whose lower tail is the word `B^w`. -/
+noncomputable def reductionOpenBoundaryContraction
+    (B : MPSTensor d D_B) (C : MPSTensor d D_A)
+    (n : ℕ) (w : List (Fin d)) (a' a : Fin D_A) : ℂ :=
+  reductionOpenBoundaryMatrixContraction B C n (Kraus.evalWord B w) a' a
+
+private theorem trace_mul_eq_sum_entries {D : ℕ}
+    (M X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (M * X) = ∑ x : Fin D, ∑ y : Fin D, M x y * X y x := by
+  rw [Matrix.trace]
+  simp only [Matrix.diag, Matrix.mul_apply]
+
+private theorem reductionOpenBoundaryMatrixContraction_eq_cross_sum
+    (B : MPSTensor d D_B) (C : MPSTensor d D_A)
+    (n : ℕ) (X : Matrix (Fin D_B) (Fin D_B) ℂ) (a' a : Fin D_A) :
+    reductionOpenBoundaryMatrixContraction B C n X a' a =
+      ∑ x : Fin D_B, ∑ y : Fin D_B,
+        (reductionCrossMatrix B C ^ n) (x, a) (y, a') * X y x := by
+  classical
+  simp only [reductionOpenBoundaryMatrixContraction]
+  simp_rw [trace_mul_eq_sum_entries]
+  simp_rw [reductionCrossMatrix_pow_apply]
+  have hleft (σ : Fin n → Fin d) :
+      (∑ x : Fin D_B, ∑ y : Fin D_B,
+          Kraus.evalWord B (List.ofFn σ) x y * X y x) *
+          Kraus.evalWord C (List.ofFn σ).reverse a' a =
+        ∑ x : Fin D_B, ∑ y : Fin D_B,
+          (Kraus.evalWord B (List.ofFn σ) x y * X y x) *
+            Kraus.evalWord C (List.ofFn σ).reverse a' a := by
+    rw [Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro x _
+    rw [Finset.sum_mul]
+  have hright (x y : Fin D_B) :
+      (∑ σ : Fin n → Fin d,
+          Kraus.evalWord B (List.ofFn σ) x y *
+            Kraus.evalWord C (List.ofFn σ).reverse a' a) * X y x =
+        ∑ σ : Fin n → Fin d,
+          (Kraus.evalWord B (List.ofFn σ) x y *
+            Kraus.evalWord C (List.ofFn σ).reverse a' a) * X y x := by
+    rw [Finset.sum_mul]
+  simp_rw [hleft, hright]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro y _
+  apply Finset.sum_congr rfl
+  intro σ _
+  ring
+
+/-- Exact target evaluation with an arbitrary lower tail matrix. -/
+theorem reductionOpenBoundaryMatrixContraction_self
+    (A : MPSTensor d D_A) (hA : Kraus.IsInjective A)
+    (n : ℕ) (hn : 0 < n) (X : Matrix (Fin D_A) (Fin D_A) ℂ)
+    (a' a : Fin D_A) :
+    reductionOpenBoundaryMatrixContraction
+        A (coefficientDualInverse A hA) n X a' a =
+      (D_A : ℂ) ^ (n - 1) * X a' a := by
+  rw [reductionOpenBoundaryMatrixContraction_eq_cross_sum,
+    coefficientDualCross_pow A hA n hn]
+  simp [reductionCrossMatrix_coefficientDualInverse,
+    Matrix.vecMulVec_apply, diagonalBondVector]
+
+/-- Exact same-alphabet target evaluation of the open-boundary contraction. -/
+theorem reductionOpenBoundaryContraction_self
+    (A : MPSTensor d D_A) (hA : Kraus.IsInjective A)
+    (n : ℕ) (hn : 0 < n) (w : List (Fin d)) (a' a : Fin D_A) :
+    reductionOpenBoundaryContraction A (coefficientDualInverse A hA) n w a' a =
+      (D_A : ℂ) ^ (n - 1) * Kraus.evalWord A w a' a := by
+  exact reductionOpenBoundaryMatrixContraction_self A hA n hn
+    (Kraus.evalWord A w) a' a
+
+/-- Source open-boundary formula used immediately after the closed trace-power
+calculation in Proposition 20.  Positive-length MPV equality replaces each
+closed `B` word followed by the tail by the corresponding `A` word; the
+coefficient dual then opens the target tail with the source's reversed upper
+leg order.
+
+Source: arXiv:1706.07329v2, `cornerproblem.tex` lines 3866--3887; compare the
+rank-one rewrite and final reduction equation at lines 3907--3938. -/
+theorem reductionOpenBoundaryContraction_of_sameMPV₂Pos
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B)
+    (hA : Kraus.IsInjective A) (hSame : SameMPV₂Pos B A)
+    (n : ℕ) (hn : 0 < n) (w : List (Fin d)) (a' a : Fin D_A) :
+    reductionOpenBoundaryContraction B (coefficientDualInverse A hA) n w a' a =
+      (D_A : ℂ) ^ (n - 1) * Kraus.evalWord A w a' a := by
+  have hterm (σ : Fin n → Fin d) :
+      Matrix.trace
+          (Kraus.evalWord B (List.ofFn σ) * Kraus.evalWord B w) =
+        Matrix.trace
+          (Kraus.evalWord A (List.ofFn σ) * Kraus.evalWord A w) := by
+    rw [← Kraus.evalWord_append, ← Kraus.evalWord_append]
+    exact hSame.trace_evalWord (List.ofFn σ ++ w) (by
+      intro hnil
+      have hleft : List.ofFn σ = [] := (List.append_eq_nil_iff.mp hnil).1
+      exact (Nat.ne_of_gt hn) (List.ofFn_eq_nil_iff.mp hleft))
+  unfold reductionOpenBoundaryContraction reductionOpenBoundaryMatrixContraction
+  simp_rw [hterm]
+  exact reductionOpenBoundaryContraction_self A hA n hn w a' a
+
+/-- The literal padded source contraction: the `n` inverse sites use the
+`p`-blocked tensors, while the lower open tail is an arbitrary unblocked word.
+The reversed upper dual word is unchanged.  This is the mixed blocked/unblocked
+formula drawn in `cornerproblem.tex` lines 3866--3887. -/
+theorem reductionOpenBoundaryMatrixContraction_blockTensor_of_sameMPV₂Pos
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B)
+    (hSame : SameMPV₂Pos B A) (p : ℕ) (hp : 0 < p)
+    (hA : Kraus.IsInjective (blockTensor (d := d) (D := D_A) A p))
+    (n : ℕ) (hn : 0 < n) (w : List (Fin d)) (a' a : Fin D_A) :
+    reductionOpenBoundaryMatrixContraction
+        (blockTensor (d := d) (D := D_B) B p)
+        (coefficientDualInverse (blockTensor (d := d) (D := D_A) A p) hA)
+        n (Kraus.evalWord B w) a' a =
+      (D_A : ℂ) ^ (n - 1) * Kraus.evalWord A w a' a := by
+  have hflat (σ : Fin n → Fin (blockPhysDim d p)) :
+      flattenBlockedWord d p (List.ofFn σ) ≠ [] := by
+    apply List.ne_nil_of_length_pos
+    rw [length_flattenBlockedWord]
+    simp only [List.length_ofFn]
+    exact Nat.mul_pos hn hp
+  have hterm (σ : Fin n → Fin (blockPhysDim d p)) :
+      Matrix.trace
+          (Kraus.evalWord (blockTensor (d := d) (D := D_B) B p) (List.ofFn σ) *
+            Kraus.evalWord B w) =
+        Matrix.trace
+          (Kraus.evalWord (blockTensor (d := d) (D := D_A) A p) (List.ofFn σ) *
+            Kraus.evalWord A w) := by
+    rw [evalWord_blockTensor, evalWord_blockTensor,
+      ← Kraus.evalWord_append, ← Kraus.evalWord_append]
+    exact hSame.trace_evalWord (flattenBlockedWord d p (List.ofFn σ) ++ w) (by
+      intro hnil
+      exact hflat σ (List.append_eq_nil_iff.mp hnil).1)
+  unfold reductionOpenBoundaryMatrixContraction
+  simp_rw [hterm]
+  exact reductionOpenBoundaryMatrixContraction_self
+    (blockTensor (d := d) (D := D_A) A p) hA n hn (Kraus.evalWord A w) a' a
+
+end MPSTensor

--- a/TNLean/MPS/Core/TracePairing.lean
+++ b/TNLean/MPS/Core/TracePairing.lean
@@ -18,6 +18,7 @@ trace pairing on square matrices.
   two-sided products through a nonzero matrix span the full matrix algebra
 * `MPSTensor.traceMulRightPi` — the linear map `M ↦ (i ↦ trace (M * A i))`
 * `MPSTensor.SameMPV.trace_evalWord` — `SameMPV` implies trace agreement on all words
+* `MPSTensor.SameMPV₂Pos.trace_evalWord` — positive-length, mixed-bond trace transport
 * `MPSTensor.sameMPV_trace_word2` — auxiliary length-2 specialisation
   used in linear-extension proofs
 * `MPSTensor.traceMulRightPi_ker_eq_bot` — injectivity of `traceMulRightPi`
@@ -116,6 +117,14 @@ lemma SameMPV.trace_evalWord {A B : MPSTensor d D} (h : SameMPV A B) (w : List (
     Matrix.trace (Kraus.evalWord A w) = Matrix.trace (Kraus.evalWord B w) := by
   -- Use the `SameMPV` equality on the configuration `σ := w.get`.
   simpa [mpv, coeff, List.ofFn_get] using h w.length w.get
+
+/-- Positive-length MPV equality transports the trace of every nonempty word,
+even when the two tensors have different bond dimensions. -/
+lemma SameMPV₂Pos.trace_evalWord {D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (h : SameMPV₂Pos A B) (w : List (Fin d)) (hw : w ≠ []) :
+    Matrix.trace (Kraus.evalWord A w) = Matrix.trace (Kraus.evalWord B w) := by
+  simpa [mpv, coeff, List.ofFn_get] using h w.length (List.length_pos_of_ne_nil hw) w.get
 
 /-- The linear map `M ↦ (i ↦ trace (M * A i))`. -/
 noncomputable def traceMulRightPi (A : MPSTensor d D) :

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -611,13 +611,14 @@ boundary conditions (PBC).
     $C^i_{a'a}$ is the coefficient of $\widetilde A^i$ in the chosen
     expansion of the matrix unit $\lvert a\rangle\!\langle a'\rvert$.
     For a tensor $\widetilde B$ of bond dimension $D_B$, define the
-    mixed-bond matrix on
-    $\C^{D_B}\otimes\C^{D_A}$ by
-    \[
-        K(\widetilde B,C)=\sum_i \widetilde B^i\otimes(C^i)^T.
-    \]
+    mixed-bond matrix on $\C^{D_B}\otimes\C^{D_A}$ by
+    \begin{align}
+        K(\widetilde B,C)
+         & =\sum_i \widetilde B^i\otimes(C^i)^T.
+        \notag
+    \end{align}
     The superscript $T$ is the ordinary transpose, not the conjugate
-    transpose.  This is exactly the matrix drawn in
+    transpose.  This is the matrix drawn in
     \cite[proof of Proposition~20]{Molnar2018SemiInjective},
     \texttt{cornerproblem.tex} lines 3817--3838.
 \end{definition}
@@ -632,17 +633,19 @@ boundary conditions (PBC).
     \leanok
     \uses{def:mps_reduction_cross_matrix}
     The coefficient dual obeys the exact matrix-unit identity
-    \[
+    \begin{align}
         \sum_i \widetilde A^i_{xy}C^i_{a'a}
-        =\delta_{x,a}\delta_{y,a'}.
-    \]
+         & =\delta_{x,a}\delta_{y,a'}.
+        \notag
+    \end{align}
     Consequently,
-    \[
+    \begin{align}
         (K(\widetilde B,C)^n)_{(b,a),(b',a')}
-        =\sum_{i_1,\ldots,i_n}
+         & =\sum_{i_1,\ldots,i_n}
         (\widetilde B^{i_1}\cdots\widetilde B^{i_n})_{bb'}
         (C^{i_n}\cdots C^{i_1})_{a'a}.
-    \]
+        \notag
+    \end{align}
     In particular, pairing $\widetilde A$ with its own dual gives the
     rank-one matrix whose entry is
     $\delta_{x,a}\delta_{y,a'}$.  The reversed order
@@ -678,34 +681,67 @@ boundary conditions (PBC).
     \uses{def:same_mpv2_pos, def:injective,
         def:mps_reduction_cross_matrix, thm:same_mpv2_pos_block_tensor}
     Suppose $\widetilde A$ and $\widetilde B$ have equal positive-length
-    MPV coefficients and $\widetilde A$ is injective.  Positive blocking
-    preserves this equality, and equality transports the trace of every
-    nonempty word.  For every $n>0$,
-    \[
-        \tr K(\widetilde B,C)^n=D_A^n.
-    \]
-    More generally, let $\widetilde A$ and $\widetilde B$ be the tensors
-    obtained by blocking $p>0$ original sites.  For every unblocked lower tail
-    word $w$ and upper boundary indices $(a',a)$,
-    \[
-        \sum_{i_1,\ldots,i_n}
-        \tr\!\left(
-        \widetilde B^{i_1}\cdots\widetilde B^{i_n} B^w
-        \right)
-        (C^{i_n}\cdots C^{i_1})_{a'a}
-        =D_A^{n-1}(A^w)_{a'a}.
-    \]
-    These are respectively the closed contraction at
-    \texttt{cornerproblem.tex} lines 3839--3865 and the open padded
-    contraction at lines 3866--3887.  The subsequent rank-one rewrite and
-    comparison leading to
-    $VB^{i_1}\cdots B^{i_m}W=A^{i_1}\cdots A^{i_m}$ occur at lines
-    3888--3938 and are deliberately not asserted here.
+    MPV coefficients and $\widetilde A$ is injective.  This equality hypothesis
+    is the $\lambda=1$ specialization of the proportional premise printed in
+    Proposition~20; the unrestricted unscaled conclusion is false
+    \cite{gap:mgsc18_reduction_proportionality_scalar}.  Equality transports
+    the trace of every nonempty word.  For every $n>0$,
+    \begin{align}
+        \tr K(\widetilde B,C)^n
+         & =D_A^n.
+        \notag
+    \end{align}
+
+    For arbitrary tensors $B_0,C_0$, every $n\geq0$, and every boundary matrix
+    $X$, define
+    \begin{align}
+        \mathcal O_n(B_0,C_0;X)_{a'a}
+         & =\sum_{i_1,\ldots,i_n}
+        \tr\!\left(B_0^{i_1}\cdots B_0^{i_n}X\right)
+        (C_0^{i_n}\cdots C_0^{i_1})_{a'a}.
+        \notag
+    \end{align}
+    If $B_0$ has bond dimension $D_B$ and $C_0$ has bond dimension $D_A$,
+    its exact cross-sum expansion is
+    \begin{align}
+        \mathcal O_n(B_0,C_0;X)_{a'a}
+         & =\sum_{x,y}K(B_0,C_0)^n_{(x,a),(y,a')}X_{yx}.
+        \notag
+    \end{align}
+    For $n>0$, if $B_0=\widetilde A$, $C_0=C$, and
+    $X\in\C^{D_A\times D_A}$, then
+    \begin{align}
+        \mathcal O_n(\widetilde A,C;X)_{a'a}
+         & =D_A^{n-1}X_{a'a}.
+        \notag
+    \end{align}
+    The same-alphabet open-boundary contraction is the specialization
+    $X=B_0^w$.  Thus $X=\widetilde A^w$ gives the target self-evaluation, while
+    equality of the positive-length MPV coefficients gives
+    \begin{align}
+        \mathcal O_n(\widetilde B,C;\widetilde B^w)_{a'a}
+         & =D_A^{n-1}(\widetilde A^w)_{a'a}.
+        \notag
+    \end{align}
+
+    Positive blocking preserves MPV equality.  If $\widetilde A$ and
+    $\widetilde B$ are obtained by blocking $p>0$ original sites, then for
+    every unblocked lower tail word $w$,
+    \begin{align}
+        \mathcal O_n(\widetilde B,C;B^w)_{a'a}
+         & =D_A^{n-1}(A^w)_{a'a}.
+        \notag
+    \end{align}
+    The trace-power identity is the closed contraction at
+    \texttt{cornerproblem.tex} lines 3839--3865, and the open-boundary identity
+    is the padded contraction at lines 3866--3887.  The source next uses a
+    rank-one rewrite and comparison to derive
+    $VB^{i_1}\cdots B^{i_m}W=A^{i_1}\cdots A^{i_m}$ at lines 3888--3938.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:mps_reduction_cross_matrix_power, lem:mpv_block}
+    \uses{lem:mps_reduction_cross_matrix_power, lem:eval_word_block}
     Expand $K^n$ by Lemma~\ref{lem:mps_reduction_cross_matrix_power} and use
     the trace formula for a Kronecker product.  Positive-length MPV equality
     replaces the trace of each nonempty $\widetilde B$ word by the
@@ -713,17 +749,16 @@ boundary conditions (PBC).
     identifies the resulting cross matrix with its rank-one target
     specialization, whose $n$th trace is $D_A^n$.
 
-    For the open contraction, expanding the lower trace into matrix entries
-    gives the exact cross sum
-    \[
-        \sum_{x,y}
-        K(\widetilde B,C)^n_{(x,a),(y,a')}X_{yx}.
-    \]
-    After positive blocking, MPV equality applies to the concatenation of the
-    nonempty blocked word and the unblocked tail.  Replacing this closed
-    $\widetilde B$ word by the corresponding $\widetilde A$ word reduces to
-    the same rank-one target calculation and yields
-    $D_A^{n-1}(A^w)_{a'a}$.
+    Expanding the lower trace into matrix entries gives the cross-sum formula
+    for arbitrary $X$.  For the target tensor, the rank-one form of
+    $K(\widetilde A,C)$ evaluates this sum as $D_A^{n-1}X_{a'a}$.
+    Specializing $X$ to a word evaluation gives the self-evaluation formula.
+
+    For blocked tensors, Lemma~\ref{lem:eval_word_block} identifies each
+    blocked word with the evaluation of its flattened word.  Since $n,p>0$,
+    this flattened word is nonempty.  Append the unblocked tail $w$, apply
+    positive-length MPV equality to the resulting original-site word, and use
+    the target self-evaluation with $X=A^w$.
 \end{proof}
 
 The inverse-tensor characterization of injectivity says that $A$ is

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -360,6 +360,98 @@ boundary conditions (PBC).
     instance reads $V1_{D_B}W=1_{D_A}$.
 \end{proof}
 
+\begin{definition}[Coefficient-dual inverse and reduction cross matrix]
+    \label{def:mps_reduction_cross_matrix}
+    \lean{MPSTensor.coefficientDualInverse,
+        MPSTensor.reductionCrossMatrix}
+    \leanok
+    \uses{def:same_mpv2_pos}
+    Let $\widetilde A=(\widetilde A^i)_i$ be injective, with bond dimension
+    $D_A$, and choose the coefficient dual $C=(C^i)_i$ from a right inverse
+    to the linear-combination map of $\widetilde A$.  Thus
+    $C^i_{a'a}$ is the coefficient of $\widetilde A^i$ in the chosen
+    expansion of the matrix unit $\lvert a\rangle\!\langle a'\rvert$.
+    For a tensor $\widetilde B$ of bond dimension $D_B$, define the
+    mixed-bond matrix on
+    $\C^{D_B}\otimes\C^{D_A}$ by
+    \[
+        K(\widetilde B,C)=\sum_i \widetilde B^i\otimes(C^i)^T.
+    \]
+    The superscript $T$ is the ordinary transpose, not the conjugate
+    transpose.  This is exactly the matrix drawn in
+    \cite[proof of Proposition~20]{Molnar2018SemiInjective},
+    \texttt{cornerproblem.tex} lines 3817--3838.
+\end{definition}
+
+\begin{lemma}[Coefficient dual and reversed-word power formulas]
+    \label{lem:mps_reduction_cross_matrix_power}
+    \lean{MPSTensor.coefficientDualInverse_sum_entry,
+        MPSTensor.reductionCrossMatrix_apply,
+        MPSTensor.reductionCrossMatrix_pow_eq_sum,
+        MPSTensor.reductionCrossMatrix_pow_apply,
+        MPSTensor.reductionCrossMatrix_coefficientDualInverse}
+    \leanok
+    \uses{def:mps_reduction_cross_matrix}
+    The coefficient dual obeys the exact matrix-unit identity
+    \[
+        \sum_i \widetilde A^i_{xy}C^i_{a'a}
+          =\delta_{x,a}\delta_{y,a'}.
+    \]
+    Consequently,
+    \[
+      (K(\widetilde B,C)^n)_{(b,a),(b',a')}
+       =\sum_{i_1,\ldots,i_n}
+          (\widetilde B^{i_1}\cdots\widetilde B^{i_n})_{bb'}
+          (C^{i_n}\cdots C^{i_1})_{a'a}.
+    \]
+    In particular, pairing $\widetilde A$ with its own dual gives the
+    rank-one matrix whose entry is
+    $\delta_{x,a}\delta_{y,a'}$.  The reversed order
+    $C^{i_n}\cdots C^{i_1}$ is forced by the transpose and records the
+    upper-leg orientation in
+    \texttt{cornerproblem.tex} lines 3817--3865.
+\end{lemma}
+
+\begin{theorem}[Cross trace powers and source open-boundary contraction]
+    \label{thm:mps_reduction_cross_trace_open}
+    \lean{MPSTensor.SameMPV₂Pos.trace_evalWord,
+        MPSTensor.sameMPV₂Pos_blockTensor,
+        MPSTensor.trace_reductionCrossMatrix_pow_of_sameMPV₂Pos,
+        MPSTensor.reductionOpenBoundaryMatrixContraction,
+        MPSTensor.reductionOpenBoundaryContraction,
+        MPSTensor.reductionOpenBoundaryMatrixContraction_self,
+        MPSTensor.reductionOpenBoundaryContraction_self,
+        MPSTensor.reductionOpenBoundaryContraction_of_sameMPV₂Pos,
+        MPSTensor.reductionOpenBoundaryMatrixContraction_blockTensor_of_sameMPV₂Pos}
+    \leanok
+    \uses{def:same_mpv2_pos, def:mps_reduction_cross_matrix,
+        lem:mps_reduction_cross_matrix_power}
+    Suppose $\widetilde A$ and $\widetilde B$ have equal positive-length
+    MPV coefficients and $\widetilde A$ is injective.  Positive blocking
+    preserves this equality, and equality transports the trace of every
+    nonempty word.  For every $n>0$,
+    \[
+        \tr K(\widetilde B,C)^n=D_A^n.
+    \]
+    More generally, let $\widetilde A$ and $\widetilde B$ be the tensors
+    obtained by blocking $p>0$ original sites.  For every unblocked lower tail
+    word $w$ and upper boundary indices $(a',a)$,
+    \[
+      \sum_{i_1,\ldots,i_n}
+        \tr\!\left(
+          \widetilde B^{i_1}\cdots\widetilde B^{i_n} B^w
+        \right)
+        (C^{i_n}\cdots C^{i_1})_{a'a}
+      =D_A^{n-1}(A^w)_{a'a}.
+    \]
+    These are respectively the closed contraction at
+    \texttt{cornerproblem.tex} lines 3839--3865 and the open padded
+    contraction at lines 3866--3887.  The subsequent rank-one rewrite and
+    comparison leading to
+    $VB^{i_1}\cdots B^{i_m}W=A^{i_1}\cdots A^{i_m}$ occur at lines
+    3888--3938 and are deliberately not asserted here.
+\end{theorem}
+
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
     specialization of Definition~\ref{def:same_mpv2}.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -360,8 +360,6 @@ boundary conditions (PBC).
     instance reads $V1_{D_B}W=1_{D_A}$.
 \end{proof}
 
-
-
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
     specialization of Definition~\ref{def:same_mpv2}.
@@ -668,7 +666,6 @@ boundary conditions (PBC).
 \begin{theorem}[Cross trace powers and source open-boundary contraction]
     \label{thm:mps_reduction_cross_trace_open}
     \lean{MPSTensor.SameMPV₂Pos.trace_evalWord,
-        MPSTensor.sameMPV₂Pos_blockTensor,
         MPSTensor.trace_reductionCrossMatrix_pow_of_sameMPV₂Pos,
         MPSTensor.reductionOpenBoundaryMatrixContraction,
         MPSTensor.reductionOpenBoundaryContraction,
@@ -678,7 +675,7 @@ boundary conditions (PBC).
         MPSTensor.reductionOpenBoundaryMatrixContraction_blockTensor_of_sameMPV₂Pos}
     \leanok
     \uses{def:same_mpv2_pos, def:injective,
-        def:mps_reduction_cross_matrix}
+        def:mps_reduction_cross_matrix, thm:same_mpv2_pos_block_tensor}
     Suppose $\widetilde A$ and $\widetilde B$ have equal positive-length
     MPV coefficients and $\widetilde A$ is injective.  Positive blocking
     preserves this equality, and equality transports the trace of every

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -360,97 +360,7 @@ boundary conditions (PBC).
     instance reads $V1_{D_B}W=1_{D_A}$.
 \end{proof}
 
-\begin{definition}[Coefficient-dual inverse and reduction cross matrix]
-    \label{def:mps_reduction_cross_matrix}
-    \lean{MPSTensor.coefficientDualInverse,
-        MPSTensor.reductionCrossMatrix}
-    \leanok
-    \uses{def:same_mpv2_pos}
-    Let $\widetilde A=(\widetilde A^i)_i$ be injective, with bond dimension
-    $D_A$, and choose the coefficient dual $C=(C^i)_i$ from a right inverse
-    to the linear-combination map of $\widetilde A$.  Thus
-    $C^i_{a'a}$ is the coefficient of $\widetilde A^i$ in the chosen
-    expansion of the matrix unit $\lvert a\rangle\!\langle a'\rvert$.
-    For a tensor $\widetilde B$ of bond dimension $D_B$, define the
-    mixed-bond matrix on
-    $\C^{D_B}\otimes\C^{D_A}$ by
-    \[
-        K(\widetilde B,C)=\sum_i \widetilde B^i\otimes(C^i)^T.
-    \]
-    The superscript $T$ is the ordinary transpose, not the conjugate
-    transpose.  This is exactly the matrix drawn in
-    \cite[proof of Proposition~20]{Molnar2018SemiInjective},
-    \texttt{cornerproblem.tex} lines 3817--3838.
-\end{definition}
 
-\begin{lemma}[Coefficient dual and reversed-word power formulas]
-    \label{lem:mps_reduction_cross_matrix_power}
-    \lean{MPSTensor.coefficientDualInverse_sum_entry,
-        MPSTensor.reductionCrossMatrix_apply,
-        MPSTensor.reductionCrossMatrix_pow_eq_sum,
-        MPSTensor.reductionCrossMatrix_pow_apply,
-        MPSTensor.reductionCrossMatrix_coefficientDualInverse}
-    \leanok
-    \uses{def:mps_reduction_cross_matrix}
-    The coefficient dual obeys the exact matrix-unit identity
-    \[
-        \sum_i \widetilde A^i_{xy}C^i_{a'a}
-          =\delta_{x,a}\delta_{y,a'}.
-    \]
-    Consequently,
-    \[
-      (K(\widetilde B,C)^n)_{(b,a),(b',a')}
-       =\sum_{i_1,\ldots,i_n}
-          (\widetilde B^{i_1}\cdots\widetilde B^{i_n})_{bb'}
-          (C^{i_n}\cdots C^{i_1})_{a'a}.
-    \]
-    In particular, pairing $\widetilde A$ with its own dual gives the
-    rank-one matrix whose entry is
-    $\delta_{x,a}\delta_{y,a'}$.  The reversed order
-    $C^{i_n}\cdots C^{i_1}$ is forced by the transpose and records the
-    upper-leg orientation in
-    \texttt{cornerproblem.tex} lines 3817--3865.
-\end{lemma}
-
-\begin{theorem}[Cross trace powers and source open-boundary contraction]
-    \label{thm:mps_reduction_cross_trace_open}
-    \lean{MPSTensor.SameMPV₂Pos.trace_evalWord,
-        MPSTensor.sameMPV₂Pos_blockTensor,
-        MPSTensor.trace_reductionCrossMatrix_pow_of_sameMPV₂Pos,
-        MPSTensor.reductionOpenBoundaryMatrixContraction,
-        MPSTensor.reductionOpenBoundaryContraction,
-        MPSTensor.reductionOpenBoundaryMatrixContraction_self,
-        MPSTensor.reductionOpenBoundaryContraction_self,
-        MPSTensor.reductionOpenBoundaryContraction_of_sameMPV₂Pos,
-        MPSTensor.reductionOpenBoundaryMatrixContraction_blockTensor_of_sameMPV₂Pos}
-    \leanok
-    \uses{def:same_mpv2_pos, def:mps_reduction_cross_matrix,
-        lem:mps_reduction_cross_matrix_power}
-    Suppose $\widetilde A$ and $\widetilde B$ have equal positive-length
-    MPV coefficients and $\widetilde A$ is injective.  Positive blocking
-    preserves this equality, and equality transports the trace of every
-    nonempty word.  For every $n>0$,
-    \[
-        \tr K(\widetilde B,C)^n=D_A^n.
-    \]
-    More generally, let $\widetilde A$ and $\widetilde B$ be the tensors
-    obtained by blocking $p>0$ original sites.  For every unblocked lower tail
-    word $w$ and upper boundary indices $(a',a)$,
-    \[
-      \sum_{i_1,\ldots,i_n}
-        \tr\!\left(
-          \widetilde B^{i_1}\cdots\widetilde B^{i_n} B^w
-        \right)
-        (C^{i_n}\cdots C^{i_1})_{a'a}
-      =D_A^{n-1}(A^w)_{a'a}.
-    \]
-    These are respectively the closed contraction at
-    \texttt{cornerproblem.tex} lines 3839--3865 and the open padded
-    contraction at lines 3866--3887.  The subsequent rank-one rewrite and
-    comparison leading to
-    $VB^{i_1}\cdots B^{i_m}W=A^{i_1}\cdots A^{i_m}$ occur at lines
-    3888--3938 and are deliberately not asserted here.
-\end{theorem}
 
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
@@ -690,6 +600,128 @@ boundary conditions (PBC).
     full matrix algebra:
     $\spn_{\C}\{A^i : i = 0,\ldots,d{-}1\} = \MN{D}$.
 \end{definition}
+
+\begin{definition}[Coefficient-dual inverse and reduction cross matrix]
+    \label{def:mps_reduction_cross_matrix}
+    \lean{MPSTensor.coefficientDualInverse,
+        MPSTensor.reductionCrossMatrix}
+    \leanok
+    \uses{def:mps_tensor, def:injective}
+    Let $\widetilde A=(\widetilde A^i)_i$ be injective, with bond dimension
+    $D_A$, and choose the coefficient dual $C=(C^i)_i$ from a right inverse
+    to the linear-combination map of $\widetilde A$.  Thus
+    $C^i_{a'a}$ is the coefficient of $\widetilde A^i$ in the chosen
+    expansion of the matrix unit $\lvert a\rangle\!\langle a'\rvert$.
+    For a tensor $\widetilde B$ of bond dimension $D_B$, define the
+    mixed-bond matrix on
+    $\C^{D_B}\otimes\C^{D_A}$ by
+    \[
+        K(\widetilde B,C)=\sum_i \widetilde B^i\otimes(C^i)^T.
+    \]
+    The superscript $T$ is the ordinary transpose, not the conjugate
+    transpose.  This is exactly the matrix drawn in
+    \cite[proof of Proposition~20]{Molnar2018SemiInjective},
+    \texttt{cornerproblem.tex} lines 3817--3838.
+\end{definition}
+
+\begin{lemma}[Coefficient dual and reversed-word power formulas]
+    \label{lem:mps_reduction_cross_matrix_power}
+    \lean{MPSTensor.coefficientDualInverse_sum_entry,
+        MPSTensor.reductionCrossMatrix_apply,
+        MPSTensor.reductionCrossMatrix_pow_eq_sum,
+        MPSTensor.reductionCrossMatrix_pow_apply,
+        MPSTensor.reductionCrossMatrix_coefficientDualInverse}
+    \leanok
+    \uses{def:mps_reduction_cross_matrix}
+    The coefficient dual obeys the exact matrix-unit identity
+    \[
+        \sum_i \widetilde A^i_{xy}C^i_{a'a}
+        =\delta_{x,a}\delta_{y,a'}.
+    \]
+    Consequently,
+    \[
+        (K(\widetilde B,C)^n)_{(b,a),(b',a')}
+        =\sum_{i_1,\ldots,i_n}
+        (\widetilde B^{i_1}\cdots\widetilde B^{i_n})_{bb'}
+        (C^{i_n}\cdots C^{i_1})_{a'a}.
+    \]
+    In particular, pairing $\widetilde A$ with its own dual gives the
+    rank-one matrix whose entry is
+    $\delta_{x,a}\delta_{y,a'}$.  The reversed order
+    $C^{i_n}\cdots C^{i_1}$ is forced by the transpose and records the
+    upper-leg orientation in
+    \texttt{cornerproblem.tex} lines 3817--3865.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:mps_reduction_cross_matrix}
+    The coefficient identity follows by applying the chosen right inverse to a
+    matrix unit.  Expanding the power of the finite sum defining $K$,
+    multiplicativity of the Kronecker product collects the lower factors in
+    site order.  Transposing the upper product reverses its factors, which gives
+    the displayed entry formula.  Specializing the lower tensor to
+    $\widetilde A$ and applying the coefficient identity gives the stated
+    rank-one matrix.
+\end{proof}
+
+\begin{theorem}[Cross trace powers and source open-boundary contraction]
+    \label{thm:mps_reduction_cross_trace_open}
+    \lean{MPSTensor.SameMPV₂Pos.trace_evalWord,
+        MPSTensor.sameMPV₂Pos_blockTensor,
+        MPSTensor.trace_reductionCrossMatrix_pow_of_sameMPV₂Pos,
+        MPSTensor.reductionOpenBoundaryMatrixContraction,
+        MPSTensor.reductionOpenBoundaryContraction,
+        MPSTensor.reductionOpenBoundaryMatrixContraction_self,
+        MPSTensor.reductionOpenBoundaryContraction_self,
+        MPSTensor.reductionOpenBoundaryContraction_of_sameMPV₂Pos,
+        MPSTensor.reductionOpenBoundaryMatrixContraction_blockTensor_of_sameMPV₂Pos}
+    \leanok
+    \uses{def:same_mpv2_pos, def:injective,
+        def:mps_reduction_cross_matrix}
+    Suppose $\widetilde A$ and $\widetilde B$ have equal positive-length
+    MPV coefficients and $\widetilde A$ is injective.  Positive blocking
+    preserves this equality, and equality transports the trace of every
+    nonempty word.  For every $n>0$,
+    \[
+        \tr K(\widetilde B,C)^n=D_A^n.
+    \]
+    More generally, let $\widetilde A$ and $\widetilde B$ be the tensors
+    obtained by blocking $p>0$ original sites.  For every unblocked lower tail
+    word $w$ and upper boundary indices $(a',a)$,
+    \[
+        \sum_{i_1,\ldots,i_n}
+        \tr\!\left(
+        \widetilde B^{i_1}\cdots\widetilde B^{i_n} B^w
+        \right)
+        (C^{i_n}\cdots C^{i_1})_{a'a}
+        =D_A^{n-1}(A^w)_{a'a}.
+    \]
+    These are respectively the closed contraction at
+    \texttt{cornerproblem.tex} lines 3839--3865 and the open padded
+    contraction at lines 3866--3887.  The subsequent rank-one rewrite and
+    comparison leading to
+    $VB^{i_1}\cdots B^{i_m}W=A^{i_1}\cdots A^{i_m}$ occur at lines
+    3888--3938 and are deliberately not asserted here.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mps_reduction_cross_matrix_power, lem:mpv_block}
+    Expand $K^n$ by Lemma~\ref{lem:mps_reduction_cross_matrix_power} and use
+    the trace formula for a Kronecker product.  Positive-length MPV equality
+    replaces the trace of each nonempty $\widetilde B$ word by the
+    corresponding $\widetilde A$ trace.  The coefficient-dual identity then
+    identifies the resulting cross matrix with its rank-one target
+    specialization, whose $n$th trace is $D_A^n$.
+
+    For the open contraction, expand the lower trace into matrix entries and
+    identify the inverse-site sum with an entry of $K^n$.  After positive
+    blocking, MPV equality applies to the concatenation of the nonempty blocked
+    word and the unblocked tail.  Replacing this closed $\widetilde B$ word by
+    the corresponding $\widetilde A$ word reduces to the same rank-one target
+    calculation and yields $D_A^{n-1}(A^w)_{a'a}$.
+\end{proof}
 
 The inverse-tensor characterization of injectivity says that $A$ is
 injective exactly when there is a tensor $A^{-1}$ such that

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -669,6 +669,7 @@ boundary conditions (PBC).
         MPSTensor.trace_reductionCrossMatrix_pow_of_sameMPV₂Pos,
         MPSTensor.reductionOpenBoundaryMatrixContraction,
         MPSTensor.reductionOpenBoundaryContraction,
+        MPSTensor.reductionOpenBoundaryMatrixContraction_eq_cross_sum,
         MPSTensor.reductionOpenBoundaryMatrixContraction_self,
         MPSTensor.reductionOpenBoundaryContraction_self,
         MPSTensor.reductionOpenBoundaryContraction_of_sameMPV₂Pos,
@@ -712,12 +713,17 @@ boundary conditions (PBC).
     identifies the resulting cross matrix with its rank-one target
     specialization, whose $n$th trace is $D_A^n$.
 
-    For the open contraction, expand the lower trace into matrix entries and
-    identify the inverse-site sum with an entry of $K^n$.  After positive
-    blocking, MPV equality applies to the concatenation of the nonempty blocked
-    word and the unblocked tail.  Replacing this closed $\widetilde B$ word by
-    the corresponding $\widetilde A$ word reduces to the same rank-one target
-    calculation and yields $D_A^{n-1}(A^w)_{a'a}$.
+    For the open contraction, expanding the lower trace into matrix entries
+    gives the exact cross sum
+    \[
+        \sum_{x,y}
+        K(\widetilde B,C)^n_{(x,a),(y,a')}X_{yx}.
+    \]
+    After positive blocking, MPV equality applies to the concatenation of the
+    nonempty blocked word and the unblocked tail.  Replacing this closed
+    $\widetilde B$ word by the corresponding $\widetilde A$ word reduces to
+    the same rank-one target calculation and yields
+    $D_A^{n-1}(A^w)_{a'a}$.
 \end{proof}
 
 The inverse-tensor characterization of injectivity says that $A$ is

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -724,9 +724,10 @@ boundary conditions (PBC).
         \notag
     \end{align}
 
-    Positive blocking preserves MPV equality.  If $\widetilde A$ and
-    $\widetilde B$ are obtained by blocking $p>0$ original sites, then for
-    every unblocked lower tail word $w$,
+    For the padded blocked contraction, suppose additionally that the original
+    tensors $A$ and $B$ have equal positive-length MPV coefficients.  If
+    $\widetilde A$ and $\widetilde B$ are obtained by blocking $p>0$ original
+    sites, then for every unblocked lower tail word $w$,
     \begin{align}
         \mathcal O_n(\widetilde B,C;B^w)_{a'a}
          & =D_A^{n-1}(A^w)_{a'a}.
@@ -745,9 +746,10 @@ boundary conditions (PBC).
     Expand $K^n$ by Lemma~\ref{lem:mps_reduction_cross_matrix_power} and use
     the trace formula for a Kronecker product.  Positive-length MPV equality
     replaces the trace of each nonempty $\widetilde B$ word by the
-    corresponding $\widetilde A$ trace.  The coefficient-dual identity then
-    identifies the resulting cross matrix with its rank-one target
-    specialization, whose $n$th trace is $D_A^n$.
+    corresponding $\widetilde A$ trace.  The resulting scalar sum is therefore
+    the trace of the target cross matrix power.  The coefficient-dual identity
+    gives that target cross matrix its rank-one form, whose $n$th trace is
+    $D_A^n$.
 
     Expanding the lower trace into matrix entries gives the cross-sum formula
     for arbitrary $X$.  For the target tensor, the rank-one form of

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -970,6 +970,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_support_algebra_star_closure.pdf}},
 }
 
+@techreport{gap:mgsc18_reduction_proportionality_scalar,
+  author      = {The {TNLean} contributors},
+  title       = {The Proportionality Scalar in the {MPS} Reduction Theorem},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {mgsc18\_reduction\_proportionality\_scalar},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/mgsc18_reduction_proportionality_scalar.pdf}},
+}
+
 @techreport{gap:mgsc18_residual_expansion_empty_word_error,
   author      = {The {TNLean} contributors},
   title       = {The Empty-Word Summation Error in the {MPS} Residual Expansion},


### PR DESCRIPTION
Closes #7426

## Summary
- construct the coefficient-dual inverse from the injective decomposition map
- define the literal-transpose mixed-bond cross matrix on `D_B × D_A`
- prove exact entry, reversed-word power, positive trace-power, and open-boundary contraction formulas
- add the reusable positive-length trace-word transport and full Chapter 2 coverage

## Dependency
This PR is stacked on #7429 (`agent/issue-7425-reduction-interface`) and should merge only after that interface PR. It does not claim the final equality-case reduction existence theorem.

## Verification
- targeted cached elaboration and linter-bearing builds
- generated imports and Chapter 2 Blueprint synchronization/reverse coverage
- exact-head independent source/orientation review approved `325c71facd8a706c2a3d6abe7b34ab670ef3bfd1`
- no broad build was run