### PR TITLE
feat(MPS/MPU): identify source ranks from zero index

### DIFF
--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -42,6 +42,8 @@ of the chosen simple blocking, is not asserted here.
   under a supplied rank-product equality.
 * `MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div`: the left-rank formula
   under a supplied rank-product equality.
+* `MPOTensor.sourceRanks_eq_physDim_of_sourceIndexValue_eq_zero`: vanishing of the
+  source-index value forces both source ranks to equal the physical dimension.
 -/
 
 namespace MPOTensor
@@ -193,5 +195,31 @@ theorem sourceIndexValue_eq_neg_logb_leftRank_div (U : MPOTensor d D)
   rw [Real.logb_mul hrReal hℓReal, Real.logb_mul hdReal hdReal] at hlog
   rw [sourceIndexValue, Real.logb_div hℓReal hdReal]
   linarith
+
+/-- If the positive source ranks satisfy $r[U]\ell[U]=d^2$ and the specified
+source-index value vanishes, then both source ranks equal the physical dimension:
+$$
+r[U]=d, \qquad \ell[U]=d.
+$$
+
+This is the final arithmetic implication in arXiv:2502.20257, line 1547. The
+rank-product identity and vanishing of the source-index value are explicit
+hypotheses; no finite-order or blocking-independent index statement is asserted. -/
+theorem sourceRanks_eq_physDim_of_sourceIndexValue_eq_zero
+    (U : MPOTensor d D) (hr : 0 < r[U]) (hℓ : 0 < ℓ[U]) (hd : 0 < d)
+    (hprod : r[U] * ℓ[U] = d ^ 2) (hindex : sourceIndexValue U hr hℓ = 0) :
+    r[U] = d ∧ ℓ[U] = d := by
+  have hlog : Real.logb 2 ((r[U] : ℝ) / d) = 0 := by
+    rw [← sourceIndexValue_eq_logb_rightRank_div U hr hℓ hd hprod]
+    exact hindex
+  have hrReal : 0 < (r[U] : ℝ) := by exact_mod_cast hr
+  have hdReal : 0 < (d : ℝ) := by exact_mod_cast hd
+  have hratio := Real.eq_one_of_pos_of_logb_eq_zero (by norm_num : (1 : ℝ) < 2)
+    (div_pos hrReal hdReal) hlog
+  have hrEq : r[U] = d := by
+    exact_mod_cast eq_of_div_eq_one hratio
+  refine ⟨hrEq, ?_⟩
+  rw [hrEq, pow_two] at hprod
+  exact Nat.mul_left_cancel hd hprod
 
 end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -237,6 +237,38 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
     representation proves the assertion for every further positive blocking.
 \end{proof}
 
+\begin{theorem}[Zero specified source-index value determines the source ranks]
+    \label{thm:mpug_zero_specified_source_index_ranks}
+    \lean{MPOTensor.sourceRanks_eq_physDim_of_sourceIndexValue_eq_zero}
+    \leanok
+    \uses{def:mpu_specified_source_index_value,
+        def:mpu_right_rank, def:mpu_left_rank}
+    Let $\mathcal U$ be a specified MPO tensor of positive physical dimension
+    $d$, with positive right and left source-cut ranks $r$ and $\ell$. If
+    \begin{align}
+        r\ell & =d^2
+    \end{align}
+    and $\operatorname{ind}_{\mathrm{src}}(\mathcal U)=0$, then
+    \begin{align}
+        r    & =d, \\
+        \ell & =d.
+    \end{align}
+    This is the arithmetic conclusion in
+    \cite[line~1547]{FrancoRubio2025MPUGauging}, under the displayed
+    hypotheses.
+    % Scope: this entry does not assert finite-order vanishing, the rank-product
+    % theorem, blocking independence, or the public MPU index.
+    % Source anchor: Papers/2502.20257/main.tex, line 1547.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_specified_source_index_identities}
+    The source-index identity gives
+    $0=\log_2(r/d)$. Since $r/d>0$, this implies $r/d=1$, hence $r=d$.
+    Substitution into $r\ell=d^2$ and cancellation of the positive factor $d$
+    give $\ell=d$.
+\end{proof}
+
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
 \label{sec:mpug_scalar_gauge}
 


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex`, line 1547, uses vanishing index and the source-rank product to conclude that both source ranks equal the physical dimension.
- Parent issue #7318 still awaits the structural finite-order and rank-product inputs, but this arithmetic endpoint is independent.

### Description

- Prove `MPOTensor.sourceRanks_eq_physDim_of_sourceIndexValue_eq_zero` in `SourceIndexValue.lean`.
- From positivity, `r[U] * ℓ[U] = d ^ 2`, and `sourceIndexValue U hr hℓ = 0`, derive `r[U] = d ∧ ℓ[U] = d` using the existing logarithmic source-index formula and natural-number cancellation.
- Add a Chapter 29 Blueprint theorem that states only this specified-index endpoint. It does not assert finite-order vanishing, blocking independence, the source-rank product, or the public MPU index.

### Testing

- `lake build TNLean.MPS.MPU.SourceIndexValue`
- `lake build` (10,391 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- strict Blueprint synchronization check, 6,918/6,918 entries synchronized
- double LuaLaTeX build of `blueprint/src/print.tex`, zero undefined cross-references
- `python3 scripts/check_numbered_lean_files.py --root .`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the changed Lean file

---
Closes #7437
Advances #7318

### Agent assistance

- TeXRA Lean, Lean simplification, and LeanBlueprint agents using GPT-5.6 produced and reviewed the proof and Blueprint entry. The human maintainer scoped the theorem, checked the mathematical boundary, and ran the final validation.
