### PR TITLE
feat(Algebra): compare unitary Kronecker factorizations

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -35,3 +35,4 @@ import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.UnitaryKronecker
+import TNLean.Algebra.UnitaryKroneckerComparison

--- a/TNLean/Algebra/UnitaryKroneckerComparison.lean
+++ b/TNLean/Algebra/UnitaryKroneckerComparison.lean
@@ -64,10 +64,10 @@ theorem factorization_comparison_of_one_sided_inverses
 variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
   [Nonempty m] [Nonempty n]
 
-/-- Two comparison matrices whose Kronecker product is unitary determine
-unitary gauges with reciprocal positive scalars.  If the returned scalar is
-`δ`, the source-oriented scalars are `δ⁻¹` for the first factor and `δ` for the
-second, so their product is one.
+/-- Two comparison matrices whose Kronecker product `K₁ ⊗ₖ K₂` is unitary
+determine unitary gauges with reciprocal positive scalars.  If the returned
+scalar is `δ`, the source-oriented scalars are `δ⁻¹` for the first factor and
+`δ` for the second, so their product is one.
 
 The unitary matrices in the conclusion are the inverses, equivalently the
 adjoints, of the unitary factors of the comparison matrices.  This is the
@@ -78,7 +78,7 @@ theorem exists_reciprocal_unitary_gauges_of_comparison
     {X₁ Xt₁ : Matrix α₁ m ℂ} {Y₁ Yt₁ : Matrix m β₁ ℂ}
     {X₂ Xt₂ : Matrix α₂ n ℂ} {Y₂ Yt₂ : Matrix n β₂ ℂ}
     {K₁ : Matrix m m ℂ} {K₂ : Matrix n n ℂ}
-    (hK : K₂ ⊗ₖ K₁ ∈ Matrix.unitaryGroup (n × m) ℂ)
+    (hK : K₁ ⊗ₖ K₂ ∈ Matrix.unitaryGroup (m × n) ℂ)
     (hX₁ : X₁ = Xt₁ * K₁) (hY₁ : Yt₁ = K₁ * Y₁)
     (hX₂ : X₂ = Xt₂ * K₂) (hY₂ : Yt₂ = K₂ * Y₂) :
     ∃ (δ : ℝ) (_ : 0 < δ) (W₁ : Matrix.unitaryGroup m ℂ)
@@ -89,11 +89,9 @@ theorem exists_reciprocal_unitary_gauges_of_comparison
       Yt₂ = (δ : ℂ)⁻¹ • (star (W₂ : Matrix n n ℂ) * Y₂) ∧
       (δ : ℂ)⁻¹ * (δ : ℂ) = 1 := by
   classical
-  obtain ⟨r, hr, U₂, U₁, hK₂, hK₁⟩ :=
+  obtain ⟨δ, hδ, U₁, U₂, hK₁, hK₂⟩ :=
     exists_pos_real_smul_unitary_factors_of_kronecker_mem_unitaryGroup hK
-  let δ : ℝ := r⁻¹
-  have hrℂ : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
-  have hδ : 0 < δ := inv_pos.mpr hr
+  have hδℂ : (δ : ℂ) ≠ 0 := by exact_mod_cast hδ.ne'
   let W₁ : Matrix.unitaryGroup m ℂ := U₁⁻¹
   let W₂ : Matrix.unitaryGroup n ℂ := U₂⁻¹
   have hU₁W₁ : (U₁ : Matrix m m ℂ) * (W₁ : Matrix m m ℂ) = 1 := by
@@ -110,18 +108,13 @@ theorem exists_reciprocal_unitary_gauges_of_comparison
   · rw [hX₁, hK₁, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc, hU₁W₁,
       Matrix.mul_one]
     ext i j
-    simp [δ, smul_apply, hrℂ]
+    simp [smul_apply, hδℂ]
   · rw [hY₁, hK₁, Matrix.smul_mul, hstarW₁]
-    ext i j
-    simp [δ, smul_apply]
   · rw [hX₂, hK₂, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc, hU₂W₂,
       Matrix.mul_one]
     ext i j
-    simp [δ, smul_apply, hrℂ]
+    simp [smul_apply, hδℂ]
   · rw [hY₂, hK₂, Matrix.smul_mul, hstarW₂]
-    ext i j
-    simp [δ, smul_apply]
-  · change (((r⁻¹ : ℝ) : ℂ)⁻¹ * ((r⁻¹ : ℝ) : ℂ)) = 1
-    exact inv_mul_cancel₀ (by exact_mod_cast (inv_ne_zero hr.ne'))
+  · exact inv_mul_cancel₀ hδℂ
 
 end Matrix

--- a/TNLean/Algebra/UnitaryKroneckerComparison.lean
+++ b/TNLean/Algebra/UnitaryKroneckerComparison.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.UnitaryKronecker
+
+/-!
+# Comparison of matrix factorizations with unitary Kronecker gauges
+
+This file isolates the matrix-algebraic core of the uniqueness argument for
+three-legged decompositions of a matrix product unitary.  A chosen left inverse
+and right inverse identify the comparison matrix between two factorizations.
+When two such comparison matrices have unitary Kronecker product, their
+reciprocal positive rescalings give the unitary gauges in the orientation of
+the original decompositions.
+
+## Main results
+
+- `Matrix.factorization_comparison_of_one_sided_inverses`: compares two equal
+  rectangular matrix factorizations using chosen one-sided inverses.
+- `Matrix.exists_reciprocal_unitary_gauges_of_comparison`: converts two
+  comparison matrices with unitary Kronecker product into reciprocal unitary
+  gauges.
+-/
+
+open scoped Kronecker
+
+namespace Matrix
+
+/-- Suppose `X * Y` and `Xt * Yt` are the same matrix, `Lt` is a left inverse
+of `Xt`, and `R` is a right inverse of `Y`.  Then `Lt * X` is the comparison
+matrix between the two factorizations.
+
+This is the one-sided-inverse step in FBC25, Lemma `lem:deco`
+(arXiv:2502.20257, lines 1052--1066). -/
+theorem factorization_comparison_of_one_sided_inverses
+    {α β γ 𝕜 : Type*} [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq β] [Semiring 𝕜]
+    {X Xt : Matrix α β 𝕜} {Y Yt : Matrix β γ 𝕜}
+    {Lt : Matrix β α 𝕜} {R : Matrix γ β 𝕜}
+    (hfac : X * Y = Xt * Yt) (hleft : Lt * Xt = 1) (hright : Y * R = 1) :
+    Lt * X = Yt * R ∧ X = Xt * (Lt * X) ∧ Yt = (Lt * X) * Y := by
+  have hK : Lt * X = Yt * R := by
+    calc
+      Lt * X = (Lt * X) * (Y * R) := by rw [hright, Matrix.mul_one]
+      _ = Lt * (X * Y) * R := by simp only [Matrix.mul_assoc]
+      _ = Lt * (Xt * Yt) * R := by rw [hfac]
+      _ = (Lt * Xt) * Yt * R := by simp only [Matrix.mul_assoc]
+      _ = Yt * R := by rw [hleft, Matrix.one_mul]
+  refine ⟨hK, ?_, ?_⟩
+  · calc
+      X = X * (Y * R) := by rw [hright, Matrix.mul_one]
+      _ = (X * Y) * R := by simp only [Matrix.mul_assoc]
+      _ = (Xt * Yt) * R := by rw [hfac]
+      _ = Xt * (Yt * R) := by simp only [Matrix.mul_assoc]
+      _ = Xt * (Lt * X) := by rw [hK]
+  · calc
+      Yt = (Lt * Xt) * Yt := by rw [hleft, Matrix.one_mul]
+      _ = Lt * (Xt * Yt) := by simp only [Matrix.mul_assoc]
+      _ = Lt * (X * Y) := by rw [hfac]
+      _ = (Lt * X) * Y := by simp only [Matrix.mul_assoc]
+
+variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
+  [Nonempty m] [Nonempty n]
+
+/-- Two comparison matrices whose Kronecker product is unitary determine
+unitary gauges with reciprocal positive scalars.  If the returned scalar is
+`δ`, the source-oriented scalars are `δ⁻¹` for the first factor and `δ` for the
+second, so their product is one.
+
+The unitary matrices in the conclusion are the inverses, equivalently the
+adjoints, of the unitary factors of the comparison matrices.  This is the
+reciprocal-unitary-gauge step in FBC25, Lemma `lem:deco`
+(arXiv:2502.20257, lines 1052--1066). -/
+theorem exists_reciprocal_unitary_gauges_of_comparison
+    {α₁ β₁ α₂ β₂ : Type*}
+    {X₁ Xt₁ : Matrix α₁ m ℂ} {Y₁ Yt₁ : Matrix m β₁ ℂ}
+    {X₂ Xt₂ : Matrix α₂ n ℂ} {Y₂ Yt₂ : Matrix n β₂ ℂ}
+    {K₁ : Matrix m m ℂ} {K₂ : Matrix n n ℂ}
+    (hK : K₂ ⊗ₖ K₁ ∈ Matrix.unitaryGroup (n × m) ℂ)
+    (hX₁ : X₁ = Xt₁ * K₁) (hY₁ : Yt₁ = K₁ * Y₁)
+    (hX₂ : X₂ = Xt₂ * K₂) (hY₂ : Yt₂ = K₂ * Y₂) :
+    ∃ (δ : ℝ) (_ : 0 < δ) (W₁ : Matrix.unitaryGroup m ℂ)
+      (W₂ : Matrix.unitaryGroup n ℂ),
+      Xt₁ = (δ : ℂ)⁻¹ • (X₁ * (W₁ : Matrix m m ℂ)) ∧
+      Yt₁ = (δ : ℂ) • (star (W₁ : Matrix m m ℂ) * Y₁) ∧
+      Xt₂ = (δ : ℂ) • (X₂ * (W₂ : Matrix n n ℂ)) ∧
+      Yt₂ = (δ : ℂ)⁻¹ • (star (W₂ : Matrix n n ℂ) * Y₂) ∧
+      (δ : ℂ)⁻¹ * (δ : ℂ) = 1 := by
+  classical
+  obtain ⟨r, hr, U₂, U₁, hK₂, hK₁⟩ :=
+    exists_pos_real_smul_unitary_factors_of_kronecker_mem_unitaryGroup hK
+  let δ : ℝ := r⁻¹
+  have hrℂ : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
+  have hδ : 0 < δ := inv_pos.mpr hr
+  let W₁ : Matrix.unitaryGroup m ℂ := U₁⁻¹
+  let W₂ : Matrix.unitaryGroup n ℂ := U₂⁻¹
+  have hU₁W₁ : (U₁ : Matrix m m ℂ) * (W₁ : Matrix m m ℂ) = 1 := by
+    change (U₁ : Matrix m m ℂ) * star (U₁ : Matrix m m ℂ) = 1
+    exact U₁.2.2
+  have hU₂W₂ : (U₂ : Matrix n n ℂ) * (W₂ : Matrix n n ℂ) = 1 := by
+    change (U₂ : Matrix n n ℂ) * star (U₂ : Matrix n n ℂ) = 1
+    exact U₂.2.2
+  have hstarW₁ : star (W₁ : Matrix m m ℂ) = (U₁ : Matrix m m ℂ) := by
+    simp [W₁]
+  have hstarW₂ : star (W₂ : Matrix n n ℂ) = (U₂ : Matrix n n ℂ) := by
+    simp [W₂]
+  refine ⟨δ, hδ, W₁, W₂, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [hX₁, hK₁, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc, hU₁W₁,
+      Matrix.mul_one]
+    ext i j
+    simp [δ, smul_apply, hrℂ]
+  · rw [hY₁, hK₁, Matrix.smul_mul, hstarW₁]
+    ext i j
+    simp [δ, smul_apply]
+  · rw [hX₂, hK₂, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc, hU₂W₂,
+      Matrix.mul_one]
+    ext i j
+    simp [δ, smul_apply, hrℂ]
+  · rw [hY₂, hK₂, Matrix.smul_mul, hstarW₂]
+    ext i j
+    simp [δ, smul_apply]
+  · change (((r⁻¹ : ℝ) : ℂ)⁻¹ * ((r⁻¹ : ℝ) : ℂ)) = 1
+    exact inv_mul_cancel₀ (by exact_mod_cast (inv_ne_zero hr.ne'))
+
+end Matrix

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -281,11 +281,10 @@ nonzero complex numbers. The fusion tensors have the scalar gauge freedom
 \end{align}
 % Source anchor: arXiv:2502.20257, eq:scalar_fus_ten.
 This is the fusion-tensor gauge freedom of~\cite{FrancoRubio2025MPUGauging}.
-Apart from the preliminary matrix-factor result below, the results in this
-section formalize only the scalar functions $\beta$, $\omega$, $\gamma$, and
-$L$; they construct neither fusion tensors nor action tensors. The
-representation-level data were specified in
-Definition~\ref{def:mpug_group_representation}.
+Apart from the matrix results below, the results in this section formalize
+only the scalar functions $\beta$, $\omega$, $\gamma$, and $L$; they construct
+neither fusion tensors nor action tensors. The representation-level data were
+specified in Definition~\ref{def:mpug_group_representation}.
 
 \begin{theorem}[Scalar factors of an identity Kronecker product]
     \label{thm:mpug_kronecker_identity_factors}
@@ -345,6 +344,90 @@ Definition~\ref{def:mpug_group_representation}.
     are $W_1$ and $W_2$ in
     (\ref{eq:mpug_unitary_kronecker_factors}).
 \end{proof}
+
+\begin{theorem}[Comparison of factorizations from one-sided inverses]
+    \label{thm:mpug_factorization_comparison}
+    \lean{Matrix.factorization_comparison_of_one_sided_inverses}
+    \leanok
+    Let $A,B,C$ be finite index sets and let $\mathbb S$ be a semiring. Suppose
+    that
+    \begin{align}
+        X,\widetilde X&\in\operatorname{Mat}_{A\times B}(\mathbb S), &
+        Y,\widetilde Y&\in\operatorname{Mat}_{B\times C}(\mathbb S),
+    \end{align}
+    and $XY=\widetilde X\widetilde Y$. If
+    $L\in\operatorname{Mat}_{B\times A}(\mathbb S)$ and
+    $R\in\operatorname{Mat}_{C\times B}(\mathbb S)$ satisfy
+    $L\widetilde X=\mathbf 1$ and $YR=\mathbf 1$, then the comparison matrix
+    $K=LX$ obeys
+    \begin{align}
+        K&=\widetilde YR, & X&=\widetilde XK, & \widetilde Y&=KY.
+        \label{eq:mpug_factorization_comparison}
+    \end{align}
+    % Source anchor: arXiv:2502.20257, Lemma lem:deco, lines 1061--1065.
+    These are the one-sided-inverse identities used in the proof of
+    \cite[Lemma at lines~1052--1066]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Associativity and the two inverse identities give
+    \begin{align}
+        LX
+        &=(LX)(YR)
+         =L(XY)R
+         =L(\widetilde X\widetilde Y)R
+         =\widetilde YR.
+    \end{align}
+    Multiplying $XY=\widetilde X\widetilde Y$ on the right by $R$ gives
+    $X=\widetilde XK$. Multiplying it on the left by $L$ gives
+    $\widetilde Y=KY$.
+\end{proof}
+
+\begin{theorem}[Reciprocal unitary gauges from a Kronecker comparison]
+    \label{thm:mpug_reciprocal_unitary_gauges}
+    \lean{Matrix.exists_reciprocal_unitary_gauges_of_comparison}
+    \leanok
+    \uses{thm:mpug_unitary_kronecker_factors}
+    For $i=1,2$, suppose that two compatible matrix factorizations are related
+    by square comparison matrices $K_i$ through
+    \begin{align}
+        X_i&=\widetilde X_iK_i, & \widetilde Y_i&=K_iY_i.
+        \label{eq:mpug_comparison_matrices}
+    \end{align}
+    If $K_2\otimes K_1$ is unitary, then there are a positive real number
+    $\delta$ and unitary matrices $W_1,W_2$ such that
+    \begin{align}
+        \widetilde X_1&=\delta^{-1}X_1W_1, &
+        \widetilde Y_1&=\delta W_1^\dagger Y_1, \\
+        \widetilde X_2&=\delta X_2W_2, &
+        \widetilde Y_2&=\delta^{-1}W_2^\dagger Y_2.
+        \label{eq:mpug_reciprocal_unitary_gauges}
+    \end{align}
+    Thus the positive scalar factors in the orientation of
+    \cite[Lemma at lines~1052--1066]{FrancoRubio2025MPUGauging} are
+    $\delta_1=\delta^{-1}$ and $\delta_2=\delta$, and hence
+    $\delta_1\delta_2=1$.
+    % Source anchor: arXiv:2502.20257, Lemma lem:deco, lines 1052--1066.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_unitary_kronecker_factors}
+    Apply Theorem~\ref{thm:mpug_unitary_kronecker_factors} to
+    $K_2\otimes K_1$. It gives $r>0$ and unitary matrices $U_2,U_1$ with
+    $K_2=rU_2$ and $K_1=r^{-1}U_1$. Set $\delta=r^{-1}$ and
+    $W_i=U_i^\dagger$. Substitution into
+    (\ref{eq:mpug_comparison_matrices}) gives
+    (\ref{eq:mpug_reciprocal_unitary_gauges}); positivity of $\delta$ gives
+    $\delta^{-1}\delta=1$.
+\end{proof}
+
+The full decomposition theorem also requires the comparison matrices obtained
+from the MPU source-gate identities to have unitary Kronecker product. Once
+this tensor-specific statement is established,
+Theorems~\ref{thm:mpug_factorization_comparison} and
+\ref{thm:mpug_reciprocal_unitary_gauges} yield the claimed gauges.
+% Formalization boundary: the MPU-specific source-gate transport and the final
+% lem:deco wrapper remain outside this slice and depend on issue #7313.
 
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -393,7 +393,7 @@ specified in Definition~\ref{def:mpug_group_representation}.
         X_i & =\widetilde X_iK_i, & \widetilde Y_i & =K_iY_i.
         \label{eq:mpug_comparison_matrices}
     \end{align}
-    If $K_2\otimes K_1$ is unitary, then there are a positive real number
+    If $K_1\otimes K_2$ is unitary, then there are a positive real number
     $\delta$ and unitary matrices $W_1,W_2$ such that
     \begin{align}
         \widetilde X_1 & =\delta^{-1}X_1W_1,          &
@@ -412,8 +412,8 @@ specified in Definition~\ref{def:mpug_group_representation}.
 \begin{proof}\leanok
     \uses{thm:mpug_unitary_kronecker_factors}
     Apply Theorem~\ref{thm:mpug_unitary_kronecker_factors} to
-    $K_2\otimes K_1$. It gives $r>0$ and unitary matrices $U_2,U_1$ with
-    $K_2=rU_2$ and $K_1=r^{-1}U_1$. Set $\delta=r^{-1}$ and
+    $K_1\otimes K_2$. It gives $\delta>0$ and unitary matrices $U_1,U_2$ with
+    $K_1=\delta U_1$ and $K_2=\delta^{-1}U_2$. Set
     $W_i=U_i^\dagger$. Substitution into
     (\ref{eq:mpug_comparison_matrices}) gives
     (\ref{eq:mpug_reciprocal_unitary_gauges}); positivity of $\delta$ gives

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -387,7 +387,6 @@ specified in Definition~\ref{def:mpug_group_representation}.
     \label{thm:mpug_reciprocal_unitary_gauges}
     \lean{Matrix.exists_reciprocal_unitary_gauges_of_comparison}
     \leanok
-    \uses{thm:mpug_unitary_kronecker_factors}
     For $i=1,2$, suppose that two compatible matrix factorizations are related
     by square comparison matrices $K_i$ through
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -352,8 +352,8 @@ specified in Definition~\ref{def:mpug_group_representation}.
     Let $A,B,C$ be finite index sets and let $\mathbb S$ be a semiring. Suppose
     that
     \begin{align}
-        X,\widetilde X&\in\operatorname{Mat}_{A\times B}(\mathbb S), &
-        Y,\widetilde Y&\in\operatorname{Mat}_{B\times C}(\mathbb S),
+        X,\widetilde X & \in\operatorname{Mat}_{A\times B}(\mathbb S), &
+        Y,\widetilde Y & \in\operatorname{Mat}_{B\times C}(\mathbb S),
     \end{align}
     and $XY=\widetilde X\widetilde Y$. If
     $L\in\operatorname{Mat}_{B\times A}(\mathbb S)$ and
@@ -361,7 +361,7 @@ specified in Definition~\ref{def:mpug_group_representation}.
     $L\widetilde X=\mathbf 1$ and $YR=\mathbf 1$, then the comparison matrix
     $K=LX$ obeys
     \begin{align}
-        K&=\widetilde YR, & X&=\widetilde XK, & \widetilde Y&=KY.
+        K & =\widetilde YR, & X & =\widetilde XK, & \widetilde Y & =KY.
         \label{eq:mpug_factorization_comparison}
     \end{align}
     % Source anchor: arXiv:2502.20257, Lemma lem:deco, lines 1061--1065.
@@ -373,10 +373,10 @@ specified in Definition~\ref{def:mpug_group_representation}.
     Associativity and the two inverse identities give
     \begin{align}
         LX
-        &=(LX)(YR)
-         =L(XY)R
-         =L(\widetilde X\widetilde Y)R
-         =\widetilde YR.
+         & =(LX)(YR)
+        =L(XY)R
+        =L(\widetilde X\widetilde Y)R
+        =\widetilde YR.
     \end{align}
     Multiplying $XY=\widetilde X\widetilde Y$ on the right by $R$ gives
     $X=\widetilde XK$. Multiplying it on the left by $L$ gives
@@ -391,16 +391,16 @@ specified in Definition~\ref{def:mpug_group_representation}.
     For $i=1,2$, suppose that two compatible matrix factorizations are related
     by square comparison matrices $K_i$ through
     \begin{align}
-        X_i&=\widetilde X_iK_i, & \widetilde Y_i&=K_iY_i.
+        X_i & =\widetilde X_iK_i, & \widetilde Y_i & =K_iY_i.
         \label{eq:mpug_comparison_matrices}
     \end{align}
     If $K_2\otimes K_1$ is unitary, then there are a positive real number
     $\delta$ and unitary matrices $W_1,W_2$ such that
     \begin{align}
-        \widetilde X_1&=\delta^{-1}X_1W_1, &
-        \widetilde Y_1&=\delta W_1^\dagger Y_1, \\
-        \widetilde X_2&=\delta X_2W_2, &
-        \widetilde Y_2&=\delta^{-1}W_2^\dagger Y_2.
+        \widetilde X_1 & =\delta^{-1}X_1W_1,          &
+        \widetilde Y_1 & =\delta W_1^\dagger Y_1,       \\
+        \widetilde X_2 & =\delta X_2W_2,              &
+        \widetilde Y_2 & =\delta^{-1}W_2^\dagger Y_2.
         \label{eq:mpug_reciprocal_unitary_gauges}
     \end{align}
     Thus the positive scalar factors in the orientation of


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex`, lines 1052-1066, compares two simple MPU source decompositions using one-sided inverses and reciprocal unitary gauges.
- Parent issue #7315 still awaits the MPU source-decomposition and source-gate interfaces from #7313, but the generic matrix-algebraic core is independent.

### Description

- Add `Matrix.factorization_comparison_of_one_sided_inverses`. From equal rectangular factorizations and chosen one-sided inverses, it constructs the comparison matrix and proves the three required factor identities.
- Add `Matrix.exists_reciprocal_unitary_gauges_of_comparison`. It reuses the existing unitary Kronecker factor theorem to obtain source-oriented unitary gauges with positive scalar factors `δ⁻¹` and `δ` whose product is one.
- Export the new semantic algebra module through `TNLean.Algebra`.
- Add synchronized Chapter 29 Blueprint statements and proof sketches. The Blueprint explicitly leaves the MPU source-gate transport and final `lem:deco` wrapper outside this slice.

### Testing

- `lake build TNLean.Algebra.UnitaryKroneckerComparison`
- `lake build TNLean.Algebra`
- `lake build` (10,392 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- strict Blueprint synchronization check, 6,919/6,919 entries synchronized
- double LuaLaTeX build of `blueprint/src/print.tex`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_numbered_lean_files.py --root .`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the new Lean module

---
Closes #7436
Advances #7315

### Agent assistance

- TeXRA Lean, Lean simplification, and LeanBlueprint agents using GPT-5.6 produced and reviewed the proofs and Blueprint entries. The human maintainer scoped the source boundary, checked the mathematical orientation, and ran the final validation.
