### PR TITLE
feat(MPS/MPU): identify physical adjoints with group inverses

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.CompositionFlattening
 import TNLean.MPS.MPU.CompositionRanks
+import TNLean.MPS.MPU.DaggerInverse
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples

--- a/TNLean/MPS/MPU/DaggerInverse.lean
+++ b/TNLean/MPS/MPU/DaggerInverse.lean
@@ -49,16 +49,8 @@ theorem IsRepresentation.mpo_physicalAdjointTensor_eq_inv [Group G]
       MPOTensor.mpo (F.tensor g) N * star (MPOTensor.mpo (F.tensor g) N) = 1 :=
     Matrix.mem_unitaryGroup_iff.mp (hF.isMPUPos g N hN)
   have hInvEqStar :
-      MPOTensor.mpo (F.tensor g⁻¹) N = star (MPOTensor.mpo (F.tensor g) N) := by
-    calc
-      MPOTensor.mpo (F.tensor g⁻¹) N =
-          MPOTensor.mpo (F.tensor g⁻¹) N * 1 := (mul_one _).symm
-      _ = MPOTensor.mpo (F.tensor g⁻¹) N *
-          (MPOTensor.mpo (F.tensor g) N * star (MPOTensor.mpo (F.tensor g) N)) := by
-            rw [hUnit]
-      _ = (MPOTensor.mpo (F.tensor g⁻¹) N * MPOTensor.mpo (F.tensor g) N) *
-          star (MPOTensor.mpo (F.tensor g) N) := by rw [mul_assoc]
-      _ = star (MPOTensor.mpo (F.tensor g) N) := by rw [hInvMul, one_mul]
+      MPOTensor.mpo (F.tensor g⁻¹) N = star (MPOTensor.mpo (F.tensor g) N) :=
+    left_inv_eq_right_inv hInvMul hUnit
   ext σ τ
   rw [MPOTensor.mpo_physicalAdjointTensor]
   exact (congrFun (congrFun hInvEqStar σ) τ).symm

--- a/TNLean/MPS/MPU/DaggerInverse.lean
+++ b/TNLean/MPS/MPU/DaggerInverse.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.GroupRepresentation
+import TNLean.MPS.MPDO.PhysicalAdjoint
+
+/-!
+# Physical adjoints and inverses in MPU representations
+
+This file identifies the physical adjoint of a represented MPU tensor with the
+tensor representing the inverse group element at the periodic-operator and
+positive-length matrix product vector levels.
+
+## Main results
+
+* `MPOTensor.GroupFamily.IsRepresentation.mpo_physicalAdjointTensor_eq_inv`:
+  the physical adjoint for `g` generates the operator represented by `g⁻¹`.
+* `MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv`:
+  the corresponding underlying MPS tensors generate the same positive-length
+  matrix product vectors.
+
+Source: arXiv:2502.20257, line 1552.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.GroupFamily
+
+universe u
+
+variable {G : Type u} {d : ℕ}
+
+/-- The physical adjoint of the tensor representing `g` generates the operator
+represented by `g⁻¹` on every nonempty chain.
+
+This is the operator-level assertion preceding the virtual-gauge construction
+in arXiv:2502.20257, line 1552. -/
+theorem IsRepresentation.mpo_physicalAdjointTensor_eq_inv [Group G]
+    (F : MPOTensor.GroupFamily G d) (hF : F.IsRepresentation)
+    (g : G) (N : ℕ) (hN : 0 < N) :
+    MPOTensor.mpo (MPOTensor.physicalAdjointTensor (F.tensor g)) N =
+      MPOTensor.mpo (F.tensor g⁻¹) N := by
+  have hInvMul :
+      MPOTensor.mpo (F.tensor g⁻¹) N * MPOTensor.mpo (F.tensor g) N = 1 := by
+    rw [hF.operator_mul g⁻¹ g N hN, inv_mul_cancel, hF.operator_one N hN]
+  have hUnit :
+      MPOTensor.mpo (F.tensor g) N * star (MPOTensor.mpo (F.tensor g) N) = 1 :=
+    Matrix.mem_unitaryGroup_iff.mp (hF.isMPUPos g N hN)
+  have hInvEqStar :
+      MPOTensor.mpo (F.tensor g⁻¹) N = star (MPOTensor.mpo (F.tensor g) N) := by
+    calc
+      MPOTensor.mpo (F.tensor g⁻¹) N =
+          MPOTensor.mpo (F.tensor g⁻¹) N * 1 := (mul_one _).symm
+      _ = MPOTensor.mpo (F.tensor g⁻¹) N *
+          (MPOTensor.mpo (F.tensor g) N * star (MPOTensor.mpo (F.tensor g) N)) := by
+            rw [hUnit]
+      _ = (MPOTensor.mpo (F.tensor g⁻¹) N * MPOTensor.mpo (F.tensor g) N) *
+          star (MPOTensor.mpo (F.tensor g) N) := by rw [mul_assoc]
+      _ = star (MPOTensor.mpo (F.tensor g) N) := by rw [hInvMul, one_mul]
+  ext σ τ
+  rw [MPOTensor.mpo_physicalAdjointTensor]
+  exact (congrFun (congrFun hInvEqStar σ) τ).symm
+
+/-- The physical-adjoint tensor for `g` and the tensor for `g⁻¹` generate the
+same matrix product vectors at every positive length.
+
+Source: arXiv:2502.20257, line 1552. -/
+theorem IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv [Group G]
+    (F : MPOTensor.GroupFamily G d) (hF : F.IsRepresentation) (g : G) :
+    MPSTensor.SameMPV₂Pos
+      (MPOTensor.physicalAdjointTensor (F.tensor g)).toMPSTensor
+      (F.tensor g⁻¹).toMPSTensor := by
+  intro N hN ρ
+  let σ : Fin N → Fin d := fun n ↦ (ρ n).divNat
+  let τ : Fin N → Fin d := fun n ↦ (ρ n).modNat
+  have hρ : (fun n ↦ finProdFinEquiv (σ n, τ n)) = ρ := by
+    funext n
+    exact finProdFinEquiv.apply_symm_apply (ρ n)
+  rw [← hρ, MPSTensor.mpv_toMPSTensor_pairConfig,
+    MPSTensor.mpv_toMPSTensor_pairConfig,
+    hF.mpo_physicalAdjointTensor_eq_inv F g N hN]
+
+end MPOTensor.GroupFamily

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -119,7 +119,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     $\mathcal U_g$ generates the operator representing $g^{-1}$:
     \begin{align}
         O_N(\mathcal U_g^\sharp)
-         & =U_{g^{-1}}^{(N)}=\bigl(U_g^{(N)}\bigr)^\dagger.
+         & =U_{g^{-1}}^{(N)}.
         \label{eq:mpug_physical_adjoint_inverse}
     \end{align}
     This is the first assertion in
@@ -151,7 +151,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     \label{thm:mpug_physical_adjoint_inverse_mpv}
     \lean{MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv}
     \leanok
-    \uses{thm:mpug_physical_adjoint_inverse, def:mpo_to_mps,
+    \uses{def:mpug_group_representation, def:mpo_to_mps,
         def:same_mpv2_pos}
     View $\mathcal U_g^\sharp$ and $\mathcal U_{g^{-1}}$ as MPS tensors by
     pairing their two physical indices. They generate the same matrix product

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -110,6 +110,78 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     (\ref{eq:mpug_rep_multiplication}).
 \end{proof}
 
+\begin{theorem}[The physical adjoint represents the inverse]
+    \label{thm:mpug_physical_adjoint_inverse}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.mpo_physicalAdjointTensor_eq_inv}
+    \leanok
+    \uses{def:mpug_group_representation, def:mpdo_physical_adjoint}
+    For every $g\in G$ and every $N\geq1$, the physical adjoint of
+    $\mathcal U_g$ generates the operator representing $g^{-1}$:
+    \begin{align}
+        O_N(\mathcal U_g^\sharp)
+         & =U_{g^{-1}}^{(N)}=\bigl(U_g^{(N)}\bigr)^\dagger.
+        \label{eq:mpug_physical_adjoint_inverse}
+    \end{align}
+    This is the first assertion in
+    \cite[line~1552]{FrancoRubio2025MPUGauging}. It requires no finiteness
+    assumption on $G$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_group_representation, def:mpdo_physical_adjoint}
+    The representation law and unitarity give
+    \begin{align}
+        U_{g^{-1}}^{(N)}U_g^{(N)}              & =U_e^{(N)}=\Id, \\
+        U_g^{(N)}\bigl(U_g^{(N)}\bigr)^\dagger & =\Id.
+    \end{align}
+    Hence
+    \begin{align}
+        U_{g^{-1}}^{(N)}
+         & =U_{g^{-1}}^{(N)}
+        \bigl(U_g^{(N)}\bigl(U_g^{(N)}\bigr)^\dagger\bigr)
+        =\bigl(U_{g^{-1}}^{(N)}U_g^{(N)}\bigr)
+        \bigl(U_g^{(N)}\bigr)^\dagger
+        =\bigl(U_g^{(N)}\bigr)^\dagger.
+    \end{align}
+    Closing the physical-adjoint tensor gives the conjugate transpose, which
+    proves (\ref{eq:mpug_physical_adjoint_inverse}).
+\end{proof}
+
+\begin{theorem}[Positive-length matrix product vector consequence]
+    \label{thm:mpug_physical_adjoint_inverse_mpv}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv}
+    \leanok
+    \uses{thm:mpug_physical_adjoint_inverse, def:mpo_to_mps,
+        def:same_mpv2_pos}
+    View $\mathcal U_g^\sharp$ and $\mathcal U_{g^{-1}}$ as MPS tensors by
+    pairing their two physical indices. They generate the same matrix product
+    vectors at every positive length:
+    \begin{align}
+        \mc{V}^+\bigl((\mathcal U_g^\sharp)^{\mathrm{MPS}}\bigr)
+         & =\mc{V}^+\bigl(\mathcal U_{g^{-1}}^{\mathrm{MPS}}\bigr).
+        \label{eq:mpug_physical_adjoint_inverse_mpv}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_physical_adjoint_inverse,
+        lem:mpdo_three_first_site_contraction_coefficients}
+    For a doubled physical configuration $\rho$, decode each site as a pair of
+    ket and bra indices $(\sigma_n,\tau_n)$. The corresponding matrix product
+    vector coefficient is the $(\sigma,\tau)$ matrix entry of the periodic
+    operator. Equality
+    (\ref{eq:mpug_physical_adjoint_inverse}) therefore gives equality of every
+    coefficient in (\ref{eq:mpug_physical_adjoint_inverse_mpv}).
+\end{proof}
+
+These results concern only periodic operators and positive-length matrix
+product vectors. They do not construct the virtual gauges $T_g$, analyze the
+entrywise conjugate $T_{g^{-1}}^*$, or define the representation-level signs
+$\sigma_g$. The remaining dagger--inverse gauge assertions in
+\cite[lines~1553--1567]{FrancoRubio2025MPUGauging} are outside the present
+scope. Here $T_{g^{-1}}^*$ denotes entrywise complex conjugation, not the
+physical adjoint or conjugate transpose.
+
 \begin{definition}[Common positive physical blocking]
     \label{def:mpug_common_blocking}
     \lean{MPOTensor.GroupFamily.block}


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex`, line 1552, first identifies the physical adjoint of the operator represented by `g` with the operator represented by `g⁻¹`.
- Parent issue #7323 still needs coherent canonical representatives and virtual-gauge uniqueness to construct `T_g` and the representation-level signs `σ_g`, but this operator bridge is independent.

### Description

- Add `MPOTensor.GroupFamily.IsRepresentation.mpo_physicalAdjointTensor_eq_inv`. For every positive chain length, the physical-adjoint tensor for `g` generates the same MPO as the tensor for `g⁻¹`.
- Add `MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv`, the corresponding positive-length MPV equality after pairing physical indices.
- Export the semantic `DaggerInverse` module through `TNLean.MPS.MPU`.
- Add synchronized Chapter 29 Blueprint statements and proof sketches. The scope paragraph keeps the later entrywise conjugation `T_{g⁻¹}*`, virtual gauges, and signs outside this PR.

### Testing

- `lake build TNLean.MPS.MPU.DaggerInverse TNLean.MPS.MPU`
- `lake build` (10,392 jobs)
- `lake build lint_style`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- project and upstream Blueprint declaration checks
- strict Blueprint synchronization, Chapter 29 at 158/158 formalized
- double LuaLaTeX build of `blueprint/src/print.tex`, zero undefined cross-references
- pinned `latexindent` formatting and idempotence check
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_numbered_lean_files.py --root .`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the new Lean module

---
Closes #7440
Advances #7323

### Agent assistance

- TeXRA Lean, Lean simplification, Lean search, and LeanBlueprint agents using GPT-5.6 researched, produced, and reviewed the proofs and Blueprint entries. The human maintainer selected and assigned the slice, checked the operator and conjugation conventions, and ran the final validation.
