### PR TITLE
feat(Algebra): derive signs from unitary entrywise conjugation

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -34,5 +34,6 @@ import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
+import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryKronecker
 import TNLean.Algebra.UnitaryKroneckerComparison

--- a/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
+++ b/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Scalar relations from entrywise conjugates of unitary matrices
+
+This file proves the generic unitary-matrix algebra used for the virtual-gauge signs in
+FBC25, equations `eq:defT` and `eq:intro_sigma` (arXiv:2502.20257, lines 1557--1564).
+The operation on the second matrix is entrywise complex conjugation
+`Matrix.map (starRingEnd ℂ)`, not conjugate transpose.
+
+These results are conditional on the scalar-matrix relations. They do not construct the
+virtual gauges or prove those relations for an MPU representation.
+
+## Main results
+
+- `Matrix.scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one`: the scalar multiplying the
+  identity in a product of unitaries has unit modulus.
+- `Matrix.paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one`: scalars from the two
+  oppositely ordered relations are reciprocal.
+- `Matrix.scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one`: the scalar in the
+  self relation is a sign.
+-/
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- If the product of a unitary matrix and the entrywise conjugate of another unitary
+matrix is scalar, then the scalar has unit modulus. This is the scalar phase step in
+FBC25, equation `eq:intro_sigma` (arXiv:2502.20257, lines 1559--1562). -/
+theorem scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one
+    (T S : Matrix.unitaryGroup n ℂ) (σ : ℂ)
+    (hσ : (T : Matrix n n ℂ) * (S : Matrix n n ℂ).map (starRingEnd ℂ) = σ • 1) :
+    σ * starRingEnd ℂ σ = 1 := by
+  let i : n := Classical.choice inferInstance
+  have hmem : (σ • 1 : Matrix n n ℂ) ∈ Matrix.unitaryGroup n ℂ := by
+    rw [← hσ]
+    exact (Matrix.unitaryGroup n ℂ).mul_mem T.property
+      (Matrix.map_star_mem_unitaryGroup_iff.mpr S.property)
+  have hunit := Matrix.mem_unitaryGroup_iff.mp hmem
+  have hii := congrFun (congrFun hunit i) i
+  simpa [Matrix.mul_apply, Matrix.one_apply] using hii
+
+/-- For two unitary matrices, scalars in the two relations obtained by exchanging the
+matrices and entrywise conjugating the second factor are reciprocal. This is the identity
+`σ_g σ_{g⁻¹} = 1` following FBC25, equation `eq:intro_sigma`
+(arXiv:2502.20257, lines 1559--1563). -/
+theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
+    (T S : Matrix.unitaryGroup n ℂ) (σ τ : ℂ)
+    (hσ : (T : Matrix n n ℂ) * (S : Matrix n n ℂ).map (starRingEnd ℂ) = σ • 1)
+    (hτ : (S : Matrix n n ℂ) * (T : Matrix n n ℂ).map (starRingEnd ℂ) = τ • 1) :
+    σ * τ = 1 := by
+  let Sstar := Matrix.UnitaryGroup.map_star S
+  have hcomm : (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) = σ • 1 := by
+    calc
+      (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) =
+          (1 : Matrix n n ℂ) * ((Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by simp
+      _ = (((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) * (T : Matrix n n ℂ)) *
+          ((Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by simp
+      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) *
+          (((T : Matrix n n ℂ) * (Sstar : Matrix n n ℂ)) * (T : Matrix n n ℂ)) := by
+            simp only [mul_assoc]
+      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) *
+          ((σ • 1 : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by
+            rw [show (T : Matrix n n ℂ) * (Sstar : Matrix n n ℂ) = σ • 1 by
+              simpa [Sstar] using hσ]
+      _ = σ • 1 := by simp
+  have hτstar : (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) = starRingEnd ℂ τ • 1 := by
+    have h := congrArg (fun M : Matrix n n ℂ ↦ M.map (starRingEnd ℂ)) hτ
+    rw [Matrix.map_mul] at h
+    ext i j
+    have hij := congrFun (congrFun h i) j
+    by_cases hij' : i = j <;>
+      simpa [Sstar, Matrix.mul_apply, Matrix.map_apply, Matrix.one_apply, Function.comp_apply, hij']
+        using hij
+  have hστ : σ = starRingEnd ℂ τ := by
+    let i : n := Classical.choice inferInstance
+    have h := congrFun (congrFun (hcomm.symm.trans hτstar) i) i
+    simpa using h
+  have hτunit := scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one S T τ hτ
+  rw [hστ, mul_comm]
+  exact hτunit
+
+/-- In the self relation, the scalar multiplying the identity is `1` or `-1`. This is the
+involution conclusion after FBC25, equation `eq:intro_sigma`
+(arXiv:2502.20257, lines 1563--1564). -/
+theorem scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one
+    (T : Matrix.unitaryGroup n ℂ) (σ : ℂ)
+    (hσ : (T : Matrix n n ℂ) * (T : Matrix n n ℂ).map (starRingEnd ℂ) = σ • 1) :
+    σ = 1 ∨ σ = -1 := by
+  apply sq_eq_one_iff.mp
+  rw [pow_two]
+  exact paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one T T σ σ hσ hσ
+
+end Matrix

--- a/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
+++ b/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
@@ -10,7 +10,7 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 # Scalar relations from entrywise conjugates of unitary matrices
 
 This file proves the generic unitary-matrix algebra used for the virtual-gauge signs in
-FBC25, equations `eq:defT` and `eq:intro_sigma` (arXiv:2502.20257, lines 1557--1564).
+FBC25, equations `eq:defT` and `eq:intro_sigma` (arXiv:2502.20257, lines 1557--1567).
 The operation on the second matrix is entrywise complex conjugation
 `Matrix.map (starRingEnd ℂ)`, not conjugate transpose.
 
@@ -60,16 +60,11 @@ theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
   have hcomm : (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) = σ • 1 := by
     calc
       (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) =
-          (1 : Matrix n n ℂ) * ((Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by simp
-      _ = (((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) * (T : Matrix n n ℂ)) *
-          ((Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by simp
-      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) *
-          (((T : Matrix n n ℂ) * (Sstar : Matrix n n ℂ)) * (T : Matrix n n ℂ)) := by
-            simp only [mul_assoc]
-      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) *
-          ((σ • 1 : Matrix n n ℂ) * (T : Matrix n n ℂ)) := by
-            rw [show (T : Matrix n n ℂ) * (Sstar : Matrix n n ℂ) = σ • 1 by
-              simpa [Sstar] using hσ]
+          ((((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) * T) * Sstar) * T := by simp
+      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) * (T * Sstar) * T := by
+        simp only [mul_assoc]
+      _ = ((T⁻¹ : Matrix.unitaryGroup n ℂ) : Matrix n n ℂ) * (σ • 1) * T := by
+        rw [show (T : Matrix n n ℂ) * Sstar = σ • 1 by simpa [Sstar] using hσ]
       _ = σ • 1 := by simp
   have hτstar : (Sstar : Matrix n n ℂ) * (T : Matrix n n ℂ) = starRingEnd ℂ τ • 1 := by
     have h := congrArg (fun M : Matrix n n ℂ ↦ M.map (starRingEnd ℂ)) hτ
@@ -89,7 +84,7 @@ theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
 
 /-- In the self relation, the scalar multiplying the identity is `1` or `-1`. This is the
 involution conclusion after FBC25, equation `eq:intro_sigma`
-(arXiv:2502.20257, lines 1563--1564). -/
+(arXiv:2502.20257, lines 1563--1567). -/
 theorem scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one
     (T : Matrix.unitaryGroup n ℂ) (σ : ℂ)
     (hσ : (T : Matrix n n ℂ) * (T : Matrix n n ℂ).map (starRingEnd ℂ) = σ • 1) :

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -151,8 +151,8 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     \label{thm:mpug_physical_adjoint_inverse_mpv}
     \lean{MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_physicalAdjointTensor_inv}
     \leanok
-    \uses{def:mpug_group_representation, def:mpo_to_mps,
-        def:same_mpv2_pos}
+    \uses{def:mpug_group_representation, def:mpdo_physical_adjoint,
+        def:mpo_to_mps, def:same_mpv2_pos}
     View $\mathcal U_g^\sharp$ and $\mathcal U_{g^{-1}}$ as MPS tensors by
     pairing their two physical indices. They generate the same matrix product
     vectors at every positive length:

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -341,6 +341,103 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
     give $\ell=d$.
 \end{proof}
 
+For a complex matrix $A$, write
+$A^*=(\overline{A_{ij}})_{i,j}$ for its entrywise complex conjugate. This is
+not the Hermitian adjoint $A^\dagger=(A^*)^{\mathsf T}$.
+
+\begin{theorem}[Scalar phase from a unitary relation]
+    \label{thm:mpug_unitary_entrywise_scalar_phase}
+    \lean{Matrix.scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one}
+    \leanok
+    Let $I$ be a nonempty finite set, let $T,S\in\operatorname{Mat}_I(\C)$ be
+    unitary, and let $\sigma\in\C$. If
+    \begin{align}
+        TS^* & =\sigma\mathbf 1,
+        \label{eq:mpug_unitary_entrywise_scalar_relation}
+    \end{align}
+    then
+    \begin{align}
+        \sigma\overline\sigma & =1.
+        \label{eq:mpug_unitary_entrywise_scalar_phase}
+    \end{align}
+    This is the scalar phase conclusion following
+    \cite[lines~1557--1562]{FrancoRubio2025MPUGauging} once the matrix relation
+    has been supplied.
+\end{theorem}
+
+\begin{proof}\leanok
+    The matrix $S^*$ is unitary, so $TS^*=\sigma\mathbf 1$ is unitary. Hence
+    \begin{align}
+        (\sigma\mathbf 1)(\sigma\mathbf 1)^\dagger
+         & =\sigma\overline\sigma\,\mathbf 1=\mathbf 1.
+    \end{align}
+    Evaluating a diagonal entry gives
+    (\ref{eq:mpug_unitary_entrywise_scalar_phase}).
+\end{proof}
+
+\begin{theorem}[Reciprocal scalars in the paired relations]
+    \label{thm:mpug_unitary_entrywise_paired_scalars}
+    \lean{Matrix.paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one}
+    \leanok
+    Let $I$ be a nonempty finite set, let $T,S\in\operatorname{Mat}_I(\C)$ be
+    unitary, and let $\sigma,\tau\in\C$. If
+    \begin{align}
+        TS^* & =\sigma\mathbf 1, \\
+        ST^* & =\tau\mathbf 1,
+        \label{eq:mpug_unitary_entrywise_paired_relations}
+    \end{align}
+    then
+    \begin{align}
+        \sigma\tau & =1.
+        \label{eq:mpug_unitary_entrywise_paired_scalars}
+    \end{align}
+    This is the conditional matrix-algebra content of
+    $\sigma_g\sigma_{g^{-1}}=1$ in
+    \cite[lines~1559--1563]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_unitary_entrywise_scalar_phase}
+    Multiplying the first relation by $T^{-1}$ on the left and by $T$ on the
+    right gives $S^*T=\sigma\mathbf 1$. Entrywise conjugation of the second
+    relation gives $S^*T=\overline\tau\,\mathbf 1$. A diagonal entry therefore
+    gives $\sigma=\overline\tau$. Applying
+    Theorem~\ref{thm:mpug_unitary_entrywise_scalar_phase} to the second relation
+    yields $\tau\overline\tau=1$, and hence $\sigma\tau=1$.
+\end{proof}
+
+\begin{theorem}[Sign dichotomy in the self relation]
+    \label{thm:mpug_unitary_entrywise_self_sign}
+    \lean{Matrix.scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one}
+    \leanok
+    Let $I$ be a nonempty finite set, let $T\in\operatorname{Mat}_I(\C)$ be
+    unitary, and let $\sigma\in\C$. If
+    \begin{align}
+        TT^* & =\sigma\mathbf 1,
+        \label{eq:mpug_unitary_entrywise_self_relation}
+    \end{align}
+    then
+    \begin{align}
+        \sigma & \in\{1,-1\}.
+        \label{eq:mpug_unitary_entrywise_self_sign}
+    \end{align}
+    This is the involution conclusion in
+    \cite[lines~1563--1567]{FrancoRubio2025MPUGauging}, conditional on the
+    self relation.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_unitary_entrywise_paired_scalars}
+    Apply Theorem~\ref{thm:mpug_unitary_entrywise_paired_scalars} with $S=T$
+    and $\tau=\sigma$. Then $\sigma^2=1$, so
+    $\sigma=1$ or $\sigma=-1$.
+\end{proof}
+
+These three results assume the unitary matrices and their scalar relations.
+They do not construct the representation-level matrices $T_g$ or scalars
+$\sigma_g$, nor do they prove $T_gT_{g^{-1}}^*=\sigma_g\mathbf 1$ for an MPU
+representation. The dagger--inverse construction therefore remains separate.
+
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
 \label{sec:mpug_scalar_gauge}
 


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex`, lines 1557-1567, derives the phase, inverse, and involution properties of `σ_g` from unitary virtual-gauge relations involving entrywise complex conjugation.
- Parent issue #7323 still needs the representation-level construction of `T_g` and `σ_g`, but the conditional unitary-matrix algebra is independent.

### Description

- Add `Matrix.scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one`: a scalar identity relation between unitary matrices implies `σ * conjugate σ = 1`.
- Add `Matrix.paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one`: paired relations imply `σ * τ = 1`.
- Add `Matrix.scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one`: the self relation implies `σ = 1 ∨ σ = -1`.
- Use the source operation exactly as entrywise `.map (starRingEnd ℂ)`, not conjugate transpose.
- Export the semantic algebra module and add synchronized Chapter 29 statements with the conditional boundary explicit.
- Record `def:mpdo_physical_adjoint` as a statement dependency of the positive-length MPV consequence introduced by #7441.

### Testing

- `lake build TNLean.Algebra.UnitaryEntrywiseConjugation`
- `lake build TNLean.Algebra`
- `lake build` (10,392 jobs)
- `lake build lint_style`
- Blueprint declaration synchronization, 6,925 theorem-like entries synchronized and Chapter 29 at 164/164
- project and upstream Blueprint declaration checks
- double Blueprint PDF build, zero undefined references
- pinned `latexindent` formatting and idempotence check
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_numbered_lean_files.py --root .`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the new Lean module

---
Closes #7442
Advances #7323

### Agent assistance

- TeXRA Lean, Lean simplification, Lean search, and LeanBlueprint agents using GPT-5.6 researched, produced, and reviewed the proofs and Blueprint entries. The human maintainer selected and assigned the slice, checked the entrywise-conjugation convention and source boundary, and ran the final policy checks.

