### PR TITLE
feat(MPS/MPU): prove represented-operator finite order

### DIFF
--- a/TNLean/MPS/MPU/GroupRepresentation.lean
+++ b/TNLean/MPS/MPU/GroupRepresentation.lean
@@ -102,6 +102,34 @@ structure IsRepresentation [Group G] (F : GroupFamily G d) : Prop where
   operator_mul : ∀ g h N, 0 < N →
     mpo (F.tensor g) N * mpo (F.tensor h) N = mpo (F.tensor (g * h)) N
 
+/-- The represented operator preserves natural powers on every nonempty chain.
+
+Source: arXiv:2502.20257, line 1547. -/
+theorem IsRepresentation.operator_pow [Group G]
+    (F : GroupFamily G d) (hF : F.IsRepresentation) (g : G)
+    (n N : ℕ) (hN : 0 < N) :
+    mpo (F.tensor g) N ^ n = mpo (F.tensor (g ^ n)) N := by
+  induction n with
+  | zero => rw [pow_zero, pow_zero, hF.operator_one N hN]
+  | succ n ih =>
+      calc
+        mpo (F.tensor g) N ^ (n + 1) =
+            mpo (F.tensor g) N ^ n * mpo (F.tensor g) N := pow_succ _ _
+        _ = mpo (F.tensor (g ^ n)) N * mpo (F.tensor g) N := by rw [ih]
+        _ = mpo (F.tensor (g ^ n * g)) N := hF.operator_mul (g ^ n) g N hN
+        _ = mpo (F.tensor (g ^ (n + 1))) N := by rw [pow_succ]
+
+/-- The operator representing an element of a finite group has finite order on
+any nonempty chain.
+
+Source: arXiv:2502.20257, line 1547. -/
+theorem IsRepresentation.operator_pow_orderOf_eq_one [Group G] [Finite G]
+    (F : GroupFamily G d) (hF : F.IsRepresentation) (g : G)
+    (N : ℕ) (hN : 0 < N) :
+    mpo (F.tensor g) N ^ orderOf g = 1 := by
+  rw [hF.operator_pow F g (orderOf g) N hN, pow_orderOf_eq_one,
+    hF.operator_one N hN]
+
 /-- The multiplication law as exact positive-length equality of doubled-index
 matrix product vectors. The chosen injective tensor for `g * h` is placed first,
 matching the orientation used by the later rectangular reduction interface.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -84,6 +84,62 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     not an equality of local tensors.
 \end{definition}
 
+\begin{theorem}[Powers of represented operators]
+    \label{thm:mpug_operator_power}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.operator_pow}
+    \leanok
+    \discussion{7445}
+    \uses{def:mpug_group_representation}
+    For every $g\in G$, every $n\in\N$, and every $N\geq1$,
+    \begin{align}
+        \bigl(U_g^{(N)}\bigr)^n & =U_{g^n}^{(N)}.
+        \label{eq:mpug_operator_power}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_group_representation}
+    Induct on $n$. For $n=0$, the identity law gives
+    $U_e^{(N)}=\Id$. For the induction step, multiply the induction hypothesis
+    by $U_g^{(N)}$ and apply the representation multiplication law:
+    \begin{align}
+        \bigl(U_g^{(N)}\bigr)^{n+1}
+         & =U_{g^n}^{(N)}U_g^{(N)}
+        =U_{g^{n+1}}^{(N)}.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Finite order of represented operators]
+    \label{thm:mpug_operator_finite_order}
+    \lean{MPOTensor.GroupFamily.IsRepresentation.operator_pow_orderOf_eq_one}
+    \leanok
+    \discussion{7445}
+    \uses{def:mpug_group_representation}
+    Suppose that $G$ is finite. For every $g\in G$ and every $N\geq1$, the
+    represented operator has finite order dividing the order of $g$:
+    \begin{align}
+        \bigl(U_g^{(N)}\bigr)^{\operatorname{ord}(g)} & =\Id.
+        \label{eq:mpug_operator_finite_order}
+    \end{align}
+    This is the finite-order assertion in
+    \cite[line~1547]{FrancoRubio2025MPUGauging}.
+    % Source anchor: Papers/2502.20257/main.tex, line 1547.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_group_representation, thm:mpug_operator_power}
+    Apply (\ref{eq:mpug_operator_power}) with $n=\operatorname{ord}(g)$.
+    The finite-order identity $g^{\operatorname{ord}(g)}=e$ and the
+    representation identity law then give
+    $\bigl(U_g^{(N)}\bigr)^{\operatorname{ord}(g)}=U_e^{(N)}=\Id$.
+\end{proof}
+
+These theorems establish only finite order of the periodic operators. They do
+not prove vanishing of the public topological index, the source-rank product
+$r\ell=d^2$, or the final equalities $r=\ell=d$.
+% Tracking boundary: issue #7318 remains open for public-index vanishing, the
+% rank-product input, and the final rank equality.
+
 \begin{theorem}[Product-tensor operator identity]
     \label{thm:mpug_product_tensor_operator}
     \lean{MPOTensor.GroupFamily.IsRepresentation.sameMPV₂Pos_mulTensor}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -119,7 +119,6 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     represented operator has finite order dividing the order of $g$:
     \begin{align}
         \bigl(U_g^{(N)}\bigr)^{\operatorname{ord}(g)} & =\Id.
-        \label{eq:mpug_operator_finite_order}
     \end{align}
     This is the finite-order assertion in
     \cite[line~1547]{FrancoRubio2025MPUGauging}.
@@ -134,11 +133,9 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     $\bigl(U_g^{(N)}\bigr)^{\operatorname{ord}(g)}=U_e^{(N)}=\Id$.
 \end{proof}
 
-These theorems establish only finite order of the periodic operators. They do
-not prove vanishing of the public topological index, the source-rank product
-$r\ell=d^2$, or the final equalities $r=\ell=d$.
-% Tracking boundary: issue #7318 remains open for public-index vanishing, the
-% rank-product input, and the final rank equality.
+% Tracking boundary: these entries cover only finite order of the periodic
+% operators. Issue #7318 remains open for public-index vanishing, the
+% rank-product input r l = d^2, and the final rank equality r = l = d.
 
 \begin{theorem}[Product-tensor operator identity]
     \label{thm:mpug_product_tensor_operator}


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex`, line 1547, uses finiteness of the group to conclude that every represented positive-length operator has finite order.
- Merged child #7437 supplies the later zero-index arithmetic endpoint, but #7318 still lacked this representation-theoretic power bridge.

### Description

- Add `MPOTensor.GroupFamily.IsRepresentation.operator_pow`, proving
  `(U_g^(N))^n = U_(g^n)^(N)` for every positive chain length by induction from the representation identity and multiplication laws.
- Add `MPOTensor.GroupFamily.IsRepresentation.operator_pow_orderOf_eq_one`, using Mathlib's `pow_orderOf_eq_one` to obtain `(U_g^(N))^(orderOf g) = 1` for finite groups.
- Add synchronized Chapter 29 Blueprint statements and source-faithful proof sketches.
- Keep public-index vanishing, the structural rank product, and the final source-rank equality outside this slice.

### Testing

- Lean diagnostics on `TNLean/MPS/MPU/GroupRepresentation.lean`
- `lake build TNLean.MPS.MPU.GroupRepresentation` (9,033 jobs)
- `lake build` (10,394 jobs, after rebasing onto current main)
- Blueprint declaration synchronization and declaration-resolution checks
- reader-facing prose and whitespace checks
- proof-integrity scan of the Lean delta
- Full local Blueprint PDF recompilation exceeded the command cap; hosted Blueprint CI remains the compile gate.

---
Closes #7445
Advances #7318

### Agent assistance

- TeXRA Lean, Lean simplification, Lean search, and LeanBlueprint agents using GPT-5.6 researched, produced, corrected, and reviewed the proofs and Blueprint entries. The human maintainer selected and assigned the slice, resolved the concurrent-commit race, and checked the final scope and validation.

