### PR TITLE
refactor(imports): trim redundant MPDO and RFP imports

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -3,10 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Algebra.Algebra.Bilinear
-import Mathlib.Analysis.Matrix.Order
-import Mathlib.LinearAlgebra.Basis.VectorSpace
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import QICLean.Channel.FixedPoint.Algebra
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.MPDO.FusionIsometries

--- a/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Algebra.FinSum
 import TNLean.MPS.MPDO.TopologicalProjectors
 
 /-!

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Algebra.MatrixIsometryEntries
 import TNLean.MPS.RFP.StructuralForm
 
 /-!


### PR DESCRIPTION
### Motivation

- Remove six direct imports shown by issue #7416 to be redundant after the current MPDO and RFP import graph was audited.
- Keep each module dependent on its direct mathematical owners rather than duplicating transitive implementation dependencies.

### Description

- Removed four redundant Mathlib imports from `TNLean/MPS/MPDO/AlgebraStructure.lean`.
- Removed the redundant direct `QICLean.Algebra.FinSum` import from `TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean`.
- Removed the redundant direct `QICLean.Algebra.MatrixIsometryEntries` import from `TNLean/MPS/RFP/StructuralFull.lean`.
- No declaration, theorem statement, proof, Blueprint entry, or computed value changes.
- Assisted by OpenAI Codex (GPT-5): the agent performed the import audit and prepared the change; the maintainer reviewed the complete diff and remains accountable for it.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.AlgebraStructure TNLean.MPS.MPDO.TopologicalProjectorRecursion TNLean.MPS.RFP.StructuralFull` (passed; 9,095 jobs).
- Hosted PR CI supplies the current full root build, generated-import check, module-policy check, and Blueprint validation.
- The diff contains exactly the six import-line deletions specified by #7416.

---
Closes #7416