### PR TITLE
refactor(MPS/MPDO): simplify LPDO proof surface

### DIFF
--- a/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
+++ b/TNLean/MPS/MPDO/CPSVExample410Spectrum.lean
@@ -287,21 +287,15 @@ private theorem mpo_four_eq_purification :
       Matrix.vecMulVec
         (fun σ => Matrix.trace ((List.ofFn fun l => purifier (σ l) (κ l)).prod))
         (star (fun σ => Matrix.trace ((List.ofFn fun l => purifier (σ l) (κ l)).prod))) := by
+  rw [mpo_eq_purificationDensity (M := M) purifier pairEquiv
+    (fun _ _ => rfl) 4]
   ext σ τ
-  simp only [mpo_apply, mpoMatrixEntry, MPOTensor.evalWord_ofFn]
-  have hM : ∀ i j : Fin 4, M i j = (∑ k : Fin 2,
-      purifier i k ⊗ₖ (purifier j k).map (starRingEnd ℂ)).submatrix
-        (↑pairEquiv) (↑pairEquiv) := fun _ _ => rfl
-  rw [MPOTensor.lpdo_prod_decomp purifier pairEquiv hM σ τ]
-  have trace_sub : ∀ (X : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ),
-      Matrix.trace (X.submatrix (↑pairEquiv) (↑pairEquiv)) = Matrix.trace X := by
-    intro X
-    simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
-    exact pairEquiv.sum_comp (fun p => X p p)
-  rw [trace_sub, Matrix.trace_sum]
-  simp_rw [Matrix.trace_kronecker]
-  simp_rw [← AddMonoidHom.map_trace (starRingEnd ℂ)]
-  simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Pi.star_apply, starRingEnd_apply]
+  simp only [purificationDensity, Matrix.of_apply, Matrix.sum_apply,
+    Matrix.vecMulVec_apply, Pi.star_apply]
+  simp_rw [MPSTensor.mpv_eq, MPSTensor.coeff_eq,
+    MPSTensor.evalWord_ofFn_eq_prod]
+  simp only [purificationTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat]
 
 
 private theorem mpo_four_eq_bellDiagonal :

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -344,13 +344,6 @@ lemma tensor_isSourceZCL : tensor.IsSourceZCL := by
     exact one_ne_zero
   · rw [physTraceTransfer_tensor, one_mul]
 
-/-- The unique bond index as a pair of unique purification indices. -/
-noncomputable def singletonPairEquiv : Fin 1 ≃ Fin 1 × Fin 1 where
-  toFun _ := (0, 0)
-  invFun _ := 0
-  left_inv _ := Subsingleton.elim _ _
-  right_inv _ := Subsingleton.elim _ _
-
 /-- A local purification of the product tensor. -/
 noncomputable def purification (i : Fin 2) (_k : Fin 1) :
     Matrix (Fin 1) (Fin 1) ℂ :=
@@ -358,13 +351,13 @@ noncomputable def purification (i : Fin 2) (_k : Fin 1) :
 
 /-- The product tensor is locally purifiable. -/
 lemma tensor_isLPDO : tensor.IsLPDO := by
-  refine ⟨1, 1, purification, singletonPairEquiv, ?_⟩
+  refine ⟨1, 1, purification, (finProdFinEquiv (m := 1) (n := 1)).symm, ?_⟩
   intro i j
   ext a b
   fin_cases a
   fin_cases b
   fin_cases i <;> fin_cases j <;>
-    norm_num [tensor, purification, singletonPairEquiv, sectorWeight,
+    norm_num [tensor, purification, finProdFinEquiv, sectorWeight,
       Matrix.kroneckerMap_apply]
 
 /-- The product tensor generates positive semidefinite operators on every

--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -38,8 +38,6 @@ from the cited argument and is false without further hypotheses.
 * `MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`:
   an explicit local purification gives the normalized block-channel image
   across every cut.
-* `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
-  an LPDO admits purifying data realizing this block-channel identity.
 * `MPOTensor.IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
   one choice of purifying data realizes the identity across every cut.
 * `MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image`: a matrix product
@@ -267,35 +265,6 @@ theorem bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
       congr 1
   refine Finset.sum_congr rfl (fun κ _ ↦ ?_)
   rw [hjoin i x κ, hjoin j y κ]
-
-/-- An LPDO admits a local-purification representation for which the normalized
-finite-chain operator across a prescribed cut is obtained from the purifying
-operator by the ancillary trace on each block.
-
-This is the existential form of the finite-chain channel identity in the
-mixed-PEPS purification argument preceding equation (4) of arXiv:0704.3906,
-using the local purification of arXiv:1606.00608, Section 4.3.
-
-**Scope restriction:** the conclusion remains restricted to LPDOs and exposes
-the purifying bond dimension. It is not the unrestricted finite-chain estimate
-in the MPO bond dimension asserted for every positive MPDO in arXiv:1606.00608,
-Proposition 4.5; see
-<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_mpdo_mutual_information_bound.pdf>. -/
-theorem IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
-    {M : MPOTensor d D} (hLPDO : IsLPDO M)
-    (N L K : ℕ) (h : N = L + K) :
-    ∃ (dK D' : ℕ)
-      (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ),
-      bipartitionedNormalizedMPO M N L K h =
-        Matrix.tensorMapBoth
-          (blockAncillaryTraceMap d dK L)
-          (blockAncillaryTraceMap d dK K)
-          (bipartitionedNormalizedMPO
-            (doubledTensor (purificationTensor A)) N L K h) := by
-  obtain ⟨dK, D', A, e, hcoeff⟩ := hLPDO
-  exact ⟨dK, D', A,
-    bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
-      M A e hcoeff N L K h⟩
 
 /-- An LPDO admits a single local-purification representation whose normalized
 finite-chain operator is obtained by ancillary traces across every cut.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -773,31 +773,6 @@ The corresponding generic result is proved in the companion quantum-channel volu
     normalized identity across $L\mid K$.
 \end{proof}
 
-\begin{theorem}[LPDOs admit a block-channel representation]
-    \label{thm:lpdo_exists_block_channel_image}
-    \lean{MPOTensor.IsLPDO.%
-        exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace}
-    \leanok
-    \uses{def:lpdo, thm:lpdo_block_channel_image}
-    Let $M$ be an LPDO. For every decomposition $N=L+K$, there exist an
-    ancillary dimension $d_K$, a purifying bond dimension $D'$, and a
-    local-purification family $A$. Let $\widetilde A$ be its associated
-    purifying MPS tensor. Then
-    \begin{align}
-        \sigma^{(N)}_{L:K}(M)
-         & =\left(\Tr_{\mathrm{anc},L}\otimes
-        \Tr_{\mathrm{anc},K}\right)
-        \left(\left(\pi_{\widetilde A}^{(N)}\right)_{L:K}\right).
-        \notag
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:lpdo, thm:lpdo_block_channel_image}
-    Choose a local-purification representation of $M$ and apply
-    Theorem~\ref{thm:lpdo_block_channel_image} to its purifying tensor.
-\end{proof}
-
 \begin{theorem}[LPDOs admit a cut-uniform block-channel representation]
     \label{thm:lpdo_exists_cut_uniform_block_channel_image}
     \lean{MPOTensor.IsLPDO.%

--- a/docs/audits/2026-08-30_lpdo_proof_surface_simplification.md
+++ b/docs/audits/2026-08-30_lpdo_proof_surface_simplification.md
@@ -1,0 +1,49 @@
+# LPDO proof-surface simplification
+
+## Scope
+
+This audit concerns the locally purifiable density-operator material associated
+with CPSV16 Section 4.3 and the corrected fixed-parameter realization of
+CPSV16 Example 4.10. It changes no mathematical statement from the paper, and
+no surviving public Lean statement changes.
+
+## Removed declarations and replacements
+
+Two declarations had no remaining repository consumer and are removed:
+
+- `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`
+  is strictly subsumed by
+  `MPOTensor.IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`.
+  The surviving theorem chooses one local purification and proves the same
+  ancillary-trace identity simultaneously for every decomposition $N=L+K$.
+- `MPOTensor.CommutingBondTraceMatrixObstruction.singletonPairEquiv` is the
+  singleton instance of Mathlib's canonical finite-product equivalence and is
+  replaced at both call sites by
+  `(finProdFinEquiv (m := 1) (n := 1)).symm`.
+
+A repository-wide search over Lean, Blueprint, documentation, scripts, papers,
+and notes found no further occurrence of either removed name. The Blueprint
+node `thm:lpdo_exists_block_channel_image`, which cited only the weaker first
+theorem and had no consumer, is removed. The cut-uniform node remains the sole
+Blueprint statement of the LPDO block-channel representation.
+
+## Four-site purification calculation
+
+The private four-site identity in `CPSVExample410Spectrum.lean` now uses
+`MPOTensor.mpo_eq_purificationDensity`, the general propagation of a local
+purification to every finite chain, rather than repeating the Kronecker-product
+and trace expansion. Its statement and the ensuing Bell-diagonal and spectral
+theorems are unchanged. The coefficient equality for the displayed
+`purifier` and `pairEquiv` is definitional. The existential proposition
+`CPSVExample410Operator.M_isLPDO` cannot recover those particular witnesses
+definitionally, so no additional coefficient lemma or public API is introduced.
+
+## Source and validation
+
+The terminology and notation follow
+`Papers/1606.00608/MPDO-22-12-17-2.tex:777--786,897--905`.
+Targeted builds cover the three changed Lean modules and the direct
+`CPSVExample410Entropy` consumer. The root build, generated-import check,
+Blueprint synchronization and declaration checks, CPSV16 label audit,
+reader-facing prose check, forbidden-token check, and `git diff --check` form
+the final validation set.


### PR DESCRIPTION
### Motivation

- Issue #7408 identifies three redundant parts of the locally purifiable density-operator development: a cut-specific corollary subsumed by the cut-uniform theorem, a one-off singleton equivalence already supplied by Mathlib, and a repeated four-site purification expansion.
- The source scope is CPSV16, `Papers/1606.00608/MPDO-22-12-17-2.tex:777--786,897--905`. The latter passage describes the four-spin construction as a “state with ZCL but no SAL”; this refactor changes neither that corrected Example 4.10 realization nor any surviving mathematical statement.

### Description

- Rewrite the private theorem `mpo_four_eq_purification` through the generic finite-chain identity `MPOTensor.mpo_eq_purificationDensity`, retaining only the short calculation that expands `purificationDensity` into the coefficient formula used by the Bell-diagonal argument.
- Keep the coefficient witness for the displayed `purifier` and `pairEquiv` as `fun _ _ => rfl`. The theorem `CPSVExample410Operator.M_isLPDO` has existential type: eliminating this opaque proof produces some purifying dimensions, tensor, and bond equivalence, not witnesses definitionally equal to these displayed terms. Consequently it cannot provide the required coefficient equality for those particular arguments. A new public coefficient lemma would enlarge the API merely to replace this definitional witness.
- Delete `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace` and its orphan Blueprint node `thm:lpdo_exists_block_channel_image`. The retained theorem `MPOTensor.IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace` chooses one purification and proves the same identity simultaneously across every cut.
- Delete `MPOTensor.CommutingBondTraceMatrixObstruction.singletonPairEquiv` and use Mathlib's canonical `(finProdFinEquiv (m := 1) (n := 1)).symm` at both former call sites.
- Record the two removed declarations, their replacements, the consumer search, and the source boundary in `docs/audits/2026-08-30_lpdo_proof_surface_simplification.md`. All surviving public Lean statements remain unchanged.
- The Lean and Blueprint simplification is 10 additions and 79 deletions (net -69 lines). Including the required 49-line deletion audit, the complete pull request is net -20 lines.

### Testing

- `lake build TNLean.MPS.MPDO.LocalPurificationAreaLaw TNLean.MPS.MPDO.CPSVExample410Spectrum TNLean.MPS.MPDO.CommutingBondTraceMatrixObstruction TNLean.MPS.MPDO.CPSVExample410Entropy`
- `lake build` (10,393 jobs)
- `lake build lint_style` (147 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `python3 scripts/test_audit_cpsv16_labels.py`
- `python3 scripts/audit_cpsv16_labels.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (6,921/6,921 theorem-like entries; Chapter 21 at 79/79)
- `lake exe checkdecls blueprint/lean_decls`
- `(cd blueprint && leanblueprint checkdecls)`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- repository-wide searches for both removed declaration names and `thm:lpdo_exists_block_channel_image`
- `git diff --check origin/main...HEAD`

---
Closes #7408

### Agent assistance

- Codex using GPT-5.6 inspected the CPSV16 source, produced and reviewed the Lean, Blueprint, and audit changes, and ran the listed validation. The human maintainer selected and assigned issue #7408, checks the source interpretation, and remains accountable for the change.
