### PR TITLE
refactor(MPS/ParentHamiltonian): narrow BlockStrip imports

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Core.WordFactor
-import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.OfFn
 
@@ -123,7 +123,7 @@ theorem exists_right_factor_of_block_word_compatibility
           obtain ⟨Yτ, hYτ⟩ := hCompat (Fin.cons i τ)
           refine ⟨Yτ, ?_⟩
           intro σ
-          simpa [Zi, evalWord_ofFn_cons, Matrix.mul_assoc] using hYτ σ
+          simpa [Zi, List.ofFn_cons, Kraus.evalWord, Matrix.mul_assoc] using hYτ σ
         obtain ⟨Xi, hXi⟩ := ih hCompatZi
         exact ⟨Xi, hXi⟩
       exact exists_right_factor_of_block_letter_compatibility hInj hL₀ hCompat1

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -9,6 +9,7 @@ import QICLean.Analysis.InjectiveRangeProjector
 import QICLean.Kraus.MapIterate
 import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import QICLean.Kraus.MixedMap
 import QICLean.Kraus.Transfer
 

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -7,9 +7,9 @@ import QICLean.Algebra.FrobeniusHilbert
 import QICLean.Algebra.RectangularChoi
 import QICLean.Analysis.InjectiveRangeProjector
 import QICLean.Kraus.MapIterate
-import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import QICLean.Kraus.MixedMap
 import QICLean.Kraus.Transfer
 


### PR DESCRIPTION
### Motivation

- `BlockStrip.lean` reached the word-span theorem through the much broader `IntersectionProperty` module, although its direct owner is `CumulativeSpan`.
- Issue #7414 identifies this as an import-cone and re-export-hygiene correction; no mathematical statement or Blueprint entry should change.

### Description

- Replaced the `IntersectionProperty` import in `BlockStrip.lean` by the direct `CumulativeSpan` import.
- Rewrote the sole use of `evalWord_ofFn_cons` directly with `List.ofFn_cons` and the defining equation of `Kraus.evalWord`.
- Replaced the unused `BlockStrip` import in `GroundSpaceGram.lean` by the two direct owners it uses: `IntersectionProperty` for `groundSpaceMap_injective_of_isNBlkInjective` and `CumulativeSpan` for `isNBlkInjective_of_le`.
- Public declarations, namespaces, computed values, and Blueprint tags are unchanged.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.ParentHamiltonian.BlockStrip TNLean.MPS.ParentHamiltonian.GroundSpaceGram` — passed on exact head `88c962857`, 3,038 jobs.
- `scripts/lake_build_locked.sh TNLean.MPS.ParentHamiltonian.BlockStrip TNLean.MPS.ParentHamiltonian.GroundSpaceGram TNLean.MPS.ParentHamiltonian.WrappingWindowLastSiteFactorization TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing` — passed on exact head `88c962857`, 9,072 jobs.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed on exact head, 6,926/6,926 entries synchronized.
- `python3 scripts/generate_import_aggregators.py --check` — passed on exact head.
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main` — passed on exact head.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passed on exact head.
- `git diff --check origin/main` — passed on exact head.
- Exact-head pull-request CI is running.

---
Closes #7414

### Agent assistance

- Codex (GPT-5) audited the direct declaration owners, made the import-only change, ran the stated validation, and prepared this pull request. The repository owner remains responsible for the change.