### PR TITLE
refactor(MPS/MPDO): deduplicate bond-one counterexample factors

### DIFF
--- a/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
+++ b/TNLean/MPS/MPDO/CaseIIAbsorptionCounterexample.lean
@@ -4,14 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Channel.SupportCompletion
-import TNLean.MPS.CanonicalForm.Definitions
-import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.SimpleTensor
-import TNLean.MPS.MPDO.ZCL
-import TNLean.MPS.MPDO.Theorem49RepeatedCopyCounterexample
-import TNLean.MPS.SharedInfra.WordTupleGauge
-import TNLean.MPS.SharedInfra.Scaling
 
 /-!
 # Coefficient absorption need not preserve CPSV normality

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPDO.BondOnePhysicalSectorFactorization
 import TNLean.MPS.MPDO.LPDO
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.ZCL
@@ -105,55 +106,13 @@ noncomputable def factorization : PhysicalSectorFactorization tensor where
       rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
       simp [tensor, hkh]
 
-/-- The two physical basis vectors as one sector with a two-dimensional left
-factor and a one-dimensional right factor.
-
-Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1; arXiv:1606.00608,
-Appendix C.2, lines 1603--1605. -/
-noncomputable def oneSectorEquiv :
-    Fin 2 ≃ Sigma fun _k : Fin 1 => Fin 2 × Fin 1 where
-  toFun i := ⟨0, (i, 0)⟩
-  invFun q := q.2.1
-  left_inv _ := rfl
-  right_inv := by
-    rintro ⟨k, i, j⟩
-    have hk : k = 0 := Subsingleton.elim _ _
-    have hj : j = 0 := Subsingleton.elim _ _
-    subst k
-    subst j
-    rfl
-
 /-- A one-sector factorization of the product tensor, with the sector weight
 placed entirely in its two-dimensional left factor.
 
 Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1; arXiv:1606.00608,
 Appendix C.2, lines 1603--1605. -/
-noncomputable def oneSectorFactorization : PhysicalSectorFactorization tensor where
-  sectorCount := 1
-  leftDim := fun _ => 2
-  rightDim := fun _ => 1
-  leftDim_pos := fun _ => by omega
-  rightDim_pos := fun _ => by omega
-  sectorEquiv := oneSectorEquiv
-  physicalIsometry := 1
-  physicalIsometry_isometry := by simp
-  leftTensor := fun _ _ => Matrix.diagonal sectorWeight
-  rightTensor := fun _ _ => 1
-  factorization := by
-    intro beta alpha
-    ext q r
-    obtain ⟨k, x, y⟩ := q
-    obtain ⟨h, u, v⟩ := r
-    fin_cases k
-    fin_cases h
-    fin_cases y
-    fin_cases v
-    fin_cases beta
-    fin_cases alpha
-    simp [Matrix.reindex_apply, oneSectorEquiv, physicalSlice, tensor,
-      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply, Matrix.diagonal_apply]
-    by_cases hxu : x = u
-    all_goals simp [hxu]
+noncomputable abbrev oneSectorFactorization : PhysicalSectorFactorization tensor :=
+  BondOnePhysicalSectorFactorization.factorization tensor
 
 /-- The real trace matrix of the neighboring operators considered in
 arXiv:1606.00608, Appendix C.2, line 1613. -/
@@ -181,20 +140,8 @@ lemma oneSector_neighboringOperator_eq
     Fin.default_eq_zero, Fin.isValue, Finset.sum_singleton]
   fin_cases x₁
   fin_cases y₁
-  simp only [oneSectorFactorization, Matrix.one_apply]
-  by_cases hxy : x₂ = y₂
-  · subst y₂
-    rw [ite_eq_left True.intro, one_mul]
-    exact ((Matrix.diagonal_apply sectorWeight x₂ x₂).trans (ite_eq_left rfl)).trans
-      ((Matrix.diagonal_apply (fun x : Fin 1 × Fin 2 => sectorWeight x.2)
-        (⟨0, x₂⟩ : Fin 1 × Fin 2) ⟨0, x₂⟩).trans (ite_eq_left rfl)).symm
-  · rw [ite_eq_left True.intro, one_mul]
-    have hpair : (⟨0, x₂⟩ : Fin 1 × Fin 2) ≠ ⟨0, y₂⟩ := by
-      intro hp
-      exact hxy (congrArg Prod.snd hp)
-    exact ((Matrix.diagonal_apply sectorWeight x₂ y₂).trans (ite_eq_right hxy)).trans
-      ((Matrix.diagonal_apply (fun x : Fin 1 × Fin 2 => sectorWeight x.2)
-        (⟨0, x₂⟩ : Fin 1 × Fin 2) ⟨0, y₂⟩).trans (ite_eq_right hpair)).symm
+  simp [oneSectorFactorization, physicalSlice, tensor, Matrix.diagonal_apply]
+  split <;> simp_all
 
 /-- Every neighboring operator in the one-sector factorization is positive
 semidefinite.

--- a/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientBlocks.lean
+++ b/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientBlocks.lean
@@ -473,17 +473,6 @@ coefficient `mu` and terminal-block coefficient exactly one. -/
         · exact hmu
         · exact one_ne_zero }
 
-/-- The decomposition has exactly two basis sectors. -/
-theorem obstructionTerminalDecomposition_basisCount
-    (mu : ℂ) (B : MPSTensor (5 * 5) 2) (hmu : mu ≠ 0) :
-    (obstructionTerminalDecomposition mu B hmu).basisCount = 2 := rfl
-
-/-- Each basis sector occurs exactly once. -/
-theorem obstructionTerminalDecomposition_copies
-    (mu : ℂ) (B : MPSTensor (5 * 5) 2) (hmu : mu ≠ 0)
-    (j : Fin (obstructionTerminalDecomposition mu B hmu).basisCount) :
-    (obstructionTerminalDecomposition mu B hmu).copies j = 1 := rfl
-
 /-- The two basis bond dimensions are exactly two and one. -/
 theorem obstructionTerminalDecomposition_basisDim
     (mu : ℂ) (B : MPSTensor (5 * 5) 2) (hmu : mu ≠ 0) :
@@ -500,15 +489,6 @@ theorem obstructionTerminalDecomposition_basis
     (obstructionTerminalDecomposition mu B hmu).basis 0 = B ∧
       (obstructionTerminalDecomposition mu B hmu).basis (Fin.succ 0) =
         terminalBlock.toMPSTensor := by
-  constructor
-  · rfl
-  · rfl
-
-/-- The two canonical-form coefficients are literally `(mu, 1)`. -/
-theorem obstructionTerminalDecomposition_weight
-    (mu : ℂ) (B : MPSTensor (5 * 5) 2) (hmu : mu ≠ 0) :
-    (obstructionTerminalDecomposition mu B hmu).weight 0 0 = mu ∧
-      (obstructionTerminalDecomposition mu B hmu).weight (Fin.succ 0) 0 = 1 := by
   constructor
   · rfl
   · rfl
@@ -651,15 +631,11 @@ theorem exists_obstruction_terminal_twoBlock_BNT_witness :
       physicalSupportProj (verticalBNTMPO B) + physicalSupportProj terminalBlock = 1 := by
     rw [hObstructionSupport, terminalBlock_physicalSupportProj]
     exact obstructionPhysicalSupport_add_terminalPhysicalSupport
-  have hBasisCount := obstructionTerminalDecomposition_basisCount mu B hmu
-  have hCopiesZero := obstructionTerminalDecomposition_copies mu B hmu 0
-  have hCopiesOne := obstructionTerminalDecomposition_copies mu B hmu (Fin.succ 0)
   obtain ⟨hDimZero, hDimOne⟩ := obstructionTerminalDecomposition_basisDim mu B hmu
   obtain ⟨hBasisZero, hBasisOne⟩ := obstructionTerminalDecomposition_basis mu B hmu
-  obtain ⟨hWeightZero, hWeightOne⟩ := obstructionTerminalDecomposition_weight mu B hmu
   refine ⟨mu, B, hmu, hmuNorm, hBInj, hBLeft, hBNormal, hGauge, ?_⟩
-  refine ⟨hBasisCount, hCopiesZero, hCopiesOne, hDimZero, hDimOne,
-    hBasisZero, hBasisOne, hWeightZero, hWeightOne, hObstructionSupport,
+  refine ⟨rfl, rfl, rfl, hDimZero, hDimOne,
+    hBasisZero, hBasisOne, rfl, rfl, hObstructionSupport,
     terminalBlock_physicalSupportProj, hObstructionTerminal,
     hTerminalObstruction, hSupportSum, ?_⟩
   exact obstructionTerminalDecomposition_isBNTCanonicalForm

--- a/TNLean/MPS/MPDO/Theorem49RepeatedCopyCounterexample.lean
+++ b/TNLean/MPS/MPDO/Theorem49RepeatedCopyCounterexample.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.MPDO.BondOnePhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.RFPViaTS
@@ -231,55 +232,14 @@ theorem scalarBNT_layer_orthogonal :
   intro x y hxy
   exact absurd (Subsingleton.elim x y) hxy
 
-/-- The one-dimensional physical space as one sector with one-dimensional
-left and right factors.
-
-Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
-1381--1388. -/
-noncomputable def scalarSectorEquiv :
-    Fin 1 ≃ Sigma fun _k : Fin 1 ↦ Fin 1 × Fin 1 where
-  toFun _ := ⟨0, (0, 0)⟩
-  invFun _ := 0
-  left_inv i := Subsingleton.elim _ _
-  right_inv := by
-    rintro ⟨k, x, y⟩
-    fin_cases k
-    fin_cases x
-    fin_cases y
-    rfl
-
 /-- The scalar BNT representative has the one-sector physical
 factorization asserted in condition (iv).
 
 Source: arXiv:1606.00608, Theorem 4.9(iv), lines 869--889, and Appendix C.2,
 equation `AppUkU=rl`, lines 1381--1388. -/
-noncomputable def scalarFactorization :
-    PhysicalSectorFactorization scalarBNT where
-  sectorCount := 1
-  leftDim := fun _ ↦ 1
-  rightDim := fun _ ↦ 1
-  leftDim_pos := fun _ ↦ by omega
-  rightDim_pos := fun _ ↦ by omega
-  sectorEquiv := scalarSectorEquiv
-  physicalIsometry := 1
-  physicalIsometry_isometry := by simp
-  leftTensor := fun _ _ ↦ 1
-  rightTensor := fun _ _ ↦ 1
-  factorization := by
-    intro beta alpha
-    ext q r
-    obtain ⟨k, x, y⟩ := q
-    obtain ⟨h, u, v⟩ := r
-    fin_cases k
-    fin_cases h
-    fin_cases x
-    fin_cases y
-    fin_cases u
-    fin_cases v
-    fin_cases beta
-    fin_cases alpha
-    simp [Matrix.reindex_apply, scalarSectorEquiv, physicalSlice, scalarBNT,
-      Matrix.blockDiagonal'_apply_eq]
+noncomputable abbrev scalarFactorization :
+    PhysicalSectorFactorization scalarBNT :=
+  BondOnePhysicalSectorFactorization.factorization scalarBNT
 
 /-- The sole neighboring operator of `scalarFactorization` is the identity
 density matrix.
@@ -297,7 +257,7 @@ theorem scalarFactorization_neighboringOperator (k h) :
   fin_cases yR
   fin_cases yL
   simp [PhysicalSectorFactorization.neighboringOperator_apply,
-    scalarFactorization]
+    scalarFactorization, physicalSlice, scalarBNT]
 
 /-- The scalar factorization has positive neighboring operators and the
 rank-one trace factorization required in condition (iv).

--- a/docs/audits/2026-08-30_bond_one_counterexample_factorization_deduplication.md
+++ b/docs/audits/2026-08-30_bond_one_counterexample_factorization_deduplication.md
@@ -1,0 +1,48 @@
+# Bond-one counterexample factorization deduplication
+
+## Scope
+
+This audit concerns the one-sector physical factorizations used by two MPDO
+counterexamples associated with CPSV16 Appendix C.2. It changes no mathematical
+statement, neighboring operator, trace calculation, or public capstone.
+
+## Removed declarations and replacements
+
+Five declarations had no repository consumer beyond the displayed local
+constructions and are removed:
+
+- `MPOTensor.CaseIIAbsorptionCounterexample.scalarSectorEquiv` is the
+  one-dimensional instance of
+  `MPOTensor.BondOnePhysicalSectorFactorization.sectorEquiv`.
+- `MPOTensor.CommutingBondTraceMatrixObstruction.oneSectorEquiv` is the
+  two-dimensional instance of the same generic sector equivalence.
+- `MPOTensor.NeighboringTraceObstructionAmbientBlocks.obstructionTerminalDecomposition_basisCount`,
+  `..._copies`, and `..._weight` merely exposed fields of the reducible
+  decomposition by reflexivity. Their sole consumer now supplies those
+  definitional witnesses directly. The substantive `_basisDim` and `_basis`
+  lemmas remain.
+
+The public names `scalarFactorization` and `oneSectorFactorization` remain as
+thin specializations of
+`MPOTensor.BondOnePhysicalSectorFactorization.factorization`. Thus downstream
+statements retain their exact types while using the common bond-one
+construction.
+
+A repository-wide search over Lean, Blueprint, documentation, scripts, papers,
+and notes found no other consumer or Blueprint citation of the removed names.
+
+## Import cleanup
+
+`CaseIIAbsorptionCounterexample.lean` no longer imports the six modules named in
+issue #7412. Its remaining three direct imports supply the declarations used by
+the file. No generated import aggregator changes.
+
+## Source and validation
+
+The one-sector terminology and notation follow
+`Papers/1606.00608/MPDO-22-12-17-2.tex:1381--1403,1441--1450`, in particular
+the physical direct-sum factorization and the neighboring operators
+$\eta_{k,h}$. Targeted linter-bearing builds cover all four changed Lean
+modules; the root build, generated-import check, Blueprint synchronization and
+declaration checks, forbidden-token check, and `git diff --check` form the
+final validation set.


### PR DESCRIPTION
### Motivation

- Issue #7412 identifies duplicated one-sector physical factorizations, three definitional ambient-block accessors, and six unused direct import edges in the CPSV16 MPDO counterexample development.
- The source scope is `Papers/1606.00608/MPDO-22-12-17-2.tex:1381--1403,1441--1450`, especially equations `AppUkU=rl`, `Apptralktrrk`, and `etarl`: the neighboring operators are denoted `η_{k,h}`, and “the η's can be chosen positive semidefinite.” This refactor preserves those mathematical statements and their terminology.

### Description

- Replace the repeated `scalarFactorization` and `oneSectorFactorization` structure literals by thin specializations of `MPOTensor.BondOnePhysicalSectorFactorization.factorization`. Their public types, neighboring-operator statements, trace factorizations, and counterexample capstones are unchanged.
- Remove the now-dead local equivalences `MPOTensor.CaseIIAbsorptionCounterexample.scalarSectorEquiv` and `MPOTensor.CommutingBondTraceMatrixObstruction.oneSectorEquiv`; both are concrete instances of `MPOTensor.BondOnePhysicalSectorFactorization.sectorEquiv`.
- Remove only `obstructionTerminalDecomposition_basisCount`, `_copies`, and `_weight` from `NeighboringTraceObstructionAmbientBlocks.lean`, supplying their definitional witnesses directly at the sole consumer. The substantive `_basisDim` and `_basis` lemmas remain, and the two declarations owned by #7409 are untouched.
- Remove the six unused direct imports named in #7412 from `CaseIIAbsorptionCounterexample.lean`. Generated import aggregators remain unchanged.
- Record every removed public declaration, its replacement, the consumer search, and the source boundary in `docs/audits/2026-08-30_bond_one_counterexample_factorization_deduplication.md`. No Blueprint-linked declaration is deleted or retagged.
- The four Lean files contain 12 additions and 135 deletions, for a net reduction of 123 tracked Lean lines. Including the required 48-line audit note, the complete pull request is net 75 lines.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.Theorem49RepeatedCopyCounterexample TNLean.MPS.MPDO.CommutingBondTraceMatrixObstruction TNLean.MPS.MPDO.NeighboringTraceObstructionAmbientBlocks TNLean.MPS.MPDO.CaseIIAbsorptionCounterexample` (9,339 jobs)
- `scripts/lake_build_locked.sh` (10,394 jobs)
- `scripts/lake_build_locked.sh lint_style` (147 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `python3 scripts/test_audit_cpsv16_labels.py`
- `python3 scripts/audit_cpsv16_labels.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (6,926/6,926 theorem-like entries)
- `lake exe checkdecls blueprint/lean_decls`
- `(cd blueprint && leanblueprint checkdecls)`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- repository-wide searches for all five removed declaration names and all six removed direct imports
- `git diff --check origin/main...HEAD`

---
Closes #7412

### Agent assistance

- Codex using GPT-5.6 inspected the CPSV16 source, implemented and reviewed the Lean and audit changes, and ran the listed validation. The human maintainer selected and assigned issue #7412, checks the source interpretation, and remains accountable for the change.
