### PR TITLE
refactor(MPS/MPDO): deduplicate word evaluation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -36,6 +36,15 @@ namespace MPSTensor
 /-- The one-letter bond-dimension-one tensor whose sole matrix is `1`. -/
 def scalarUnitTensor : MPSTensor 1 1 := fun _ => 1
 
+/-- Every word of the scalar unit tensor evaluates to the identity matrix. -/
+@[simp] theorem scalarUnitTensor_evalWord (w : List (Fin 1)) :
+    Kraus.evalWord scalarUnitTensor w = 1 := by
+  induction w with
+  | nil => rfl
+  | cons i w ih =>
+      rw [Kraus.evalWord_cons, ih]
+      simp [scalarUnitTensor]
+
 private theorem scalarUnitTensor_transferMap :
     Kraus.transferMap scalarUnitTensor = LinearMap.id := by
   apply LinearMap.ext

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
@@ -186,6 +186,10 @@ private def lastFrom (i : Fin 4) : List (Fin 4) → Fin 4
   | [] => i
   | j :: w => lastFrom j w
 
+private lemma tensor_apply_eq_zero_of_ne {i j : Fin 4} (hij : i ≠ j) :
+    tensor i j = 0 := by
+  simp [tensor, hij]
+
 private lemma evalWord_same_eq (i : Fin 4) (w : List (Fin 4)) :
     evalWord tensor (i :: w) (i :: w) =
       (pathWeight (i :: w) : ℂ) • crossSectorMatrix i (lastFrom i w) := by
@@ -214,31 +218,6 @@ private lemma trace_evalWord_same (i : Fin 4) (w : List (Fin 4)) :
   rw [evalWord_same_eq, Matrix.trace_smul, trace_crossSectorMatrix]
   simp [cycleWeight]
 
-private lemma evalWord_eq_zero_of_ne :
-    ∀ (u v : List (Fin 4)), u.length = v.length → u ≠ v →
-      evalWord tensor u v = 0 := by
-  intro u
-  induction u with
-  | nil =>
-      intro v hlen
-      have hv : v = [] := List.eq_nil_of_length_eq_zero hlen.symm
-      subst v
-      simp
-  | cons i u ih =>
-      intro v hlen hne
-      cases v with
-      | nil => simp at hlen
-      | cons j v =>
-          have hlen' : u.length = v.length := by simpa using hlen
-          by_cases hij : i = j
-          · subst j
-            rw [evalWord_cons, tensor, ite_eq_left rfl]
-            have huv : u ≠ v := by
-              intro huv
-              exact hne (huv ▸ rfl)
-            rw [ih v hlen' huv, Matrix.mul_zero]
-          · rw [evalWord_cons, tensor, ite_eq_right hij, Matrix.zero_mul]
-
 private lemma trace_evalWord_same_mul_loop (i : Fin 4) (w : List (Fin 4)) :
     Matrix.trace
         (evalWord tensor (i :: w) (i :: w) * physTraceTransfer tensor) =
@@ -266,9 +245,8 @@ private lemma mpo_tensor_eq_diagonal (N : ℕ) (hN : 0 < N) :
     rw [List.ofFn_succ]
     exact trace_evalWord_same _ _
   · rw [Matrix.diagonal_apply_ne _ hst, mpo_apply, mpoMatrixEntry,
-      evalWord_eq_zero_of_ne (List.ofFn sigma) (List.ofFn tau) (by simp)]
-    · simp
-    · exact fun h => hst (List.ofFn_injective h)
+      evalWord_ofFn_eq_zero_of_ne tensor (fun _ _ => tensor_apply_eq_zero_of_ne) hst]
+    simp
 
 private lemma tensor_isMPDO : IsMPDO tensor := by
   intro N hN
@@ -319,9 +297,8 @@ private lemma reducedBlockState_pred_eq_diagonal
     rw [List.ofFn_succ]
     exact trace_evalWord_same_mul_loop _ _
   · rw [Matrix.diagonal_apply_ne _ huv,
-      evalWord_eq_zero_of_ne (List.ofFn u) (List.ofFn v) (by simp)]
-    · simp
-    · exact fun h => huv (List.ofFn_injective h)
+      evalWord_ofFn_eq_zero_of_ne tensor (fun _ _ => tensor_apply_eq_zero_of_ne) huv]
+    simp
 
 private noncomputable def oneSiteEquiv : Fin 4 ≃ Fin (4 ^ 1) :=
   (Equiv.funUnique (Fin 1) (Fin 4)).symm.trans finFunctionFinEquiv

--- a/TNLean/MPS/MPDO/CPSVExample412Literal.lean
+++ b/TNLean/MPS/MPDO/CPSVExample412Literal.lean
@@ -79,13 +79,6 @@ private lemma prod_M_diagonal :
       fin_cases a <;> fin_cases b <;>
         simp [configurationSign, Fin.prod_univ_succ, siteSign, sigmaZ]
 
-private lemma prod_M_off_diagonal {N : ℕ} {σ τ : Fin N → Fin 2}
-    (hστ : σ ≠ τ) :
-    (List.ofFn fun k => M (σ k) (τ k)).prod = 0 := by
-  obtain ⟨k, hk⟩ := Function.ne_iff.mp hστ
-  apply List.prod_eq_zero
-  exact List.mem_ofFn.mpr ⟨k, by simp [M, hk]⟩
-
 /-- The exact entrywise version of
 $\rho^{(N)}(M)=I^{\otimes N}+\sigma_z^{\otimes N}$.
 
@@ -99,7 +92,7 @@ theorem rho_eq_diagonal (N : ℕ) :
       prod_M_diagonal, Matrix.trace_diagonal]
     simp [Fin.sum_univ_two]
   · rw [Matrix.diagonal_apply_ne _ hστ, mpo_apply, mpoMatrixEntry,
-      evalWord_ofFn, prod_M_off_diagonal hστ, Matrix.trace_zero]
+      evalWord_ofFn_eq_zero_of_ne M (by simp [M]) hστ, Matrix.trace_zero]
 
 /-- Formula-driven form of the source identity using the public finite
 Kronecker product: for every positive $N$,

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -157,6 +157,17 @@ lemma evalWord_ofFn (M : MPOTensor d D) {N : ℕ} (σ τ : Fin N → Fin d) :
       congr 1
       exact ih (σ ∘ Fin.succ) (τ ∘ Fin.succ)
 
+/-- If every off-diagonal physical entry of an MPO tensor vanishes, then its
+evaluation on two distinct physical configurations is zero. -/
+theorem evalWord_ofFn_eq_zero_of_ne (M : MPOTensor d D)
+    (hM : ∀ i j, i ≠ j → M i j = 0) {N : ℕ} {σ τ : Fin N → Fin d}
+    (hστ : σ ≠ τ) :
+    evalWord M (List.ofFn σ) (List.ofFn τ) = 0 := by
+  rw [evalWord_ofFn]
+  obtain ⟨k, hk⟩ := Function.ne_iff.mp hστ
+  apply List.prod_eq_zero
+  exact List.mem_ofFn.mpr ⟨k, hM (σ k) (τ k) hk⟩
+
 /-- Evaluating the doubled-index MPS view on paired physical letters is the
 same as evaluating the ket and bra words separately. -/
 theorem evalWord_toMPSTensor_ofFn (M : MPOTensor d D) (N : ℕ)

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -118,13 +118,6 @@ private lemma prod_tensor_diagonal :
       fin_cases a <;> fin_cases b <;>
         simp [configurationSign, Fin.prod_univ_succ, pow_succ] <;> ring
 
-private lemma prod_tensor_off_diagonal {N : ℕ} {σ τ : Fin N → Fin 2}
-    (hστ : σ ≠ τ) :
-    (List.ofFn fun k => tensor (σ k) (τ k)).prod = 0 := by
-  obtain ⟨k, hk⟩ := Function.ne_iff.mp hστ
-  apply List.prod_eq_zero
-  exact List.mem_ofFn.mpr ⟨k, by simp [tensor, hk]⟩
-
 /-- The exact closed MPO at every length is diagonal.  Its entry at a physical
 configuration $\sigma$ is
 $2^{-N}+4^{-N}\prod_k z_{\sigma_k}$, where $z_0=1$ and $z_1=-1$.
@@ -143,7 +136,7 @@ theorem mpo_tensor_eq_diagonal (N : ℕ) :
       prod_tensor_diagonal, Matrix.trace_diagonal]
     simp [Fin.sum_univ_two]
   · rw [Matrix.diagonal_apply_ne _ hστ, mpo_apply, mpoMatrixEntry,
-      evalWord_ofFn, prod_tensor_off_diagonal hστ, Matrix.trace_zero]
+      evalWord_ofFn_eq_zero_of_ne tensor (by simp [tensor]) hστ, Matrix.trace_zero]
 
 /-- Kato's $p=1/2$ tensor generates a positive semidefinite operator at every
 positive chain length.

--- a/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientBlocks.lean
+++ b/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientBlocks.lean
@@ -90,11 +90,6 @@ theorem embeddedObstruction_physicalSupportProj :
     physicalInclusion physicalInclusion_isometry, tensor_physicalSupportProj_eq_one]
   simp [obstructionPhysicalSupport]
 
-/-- One-site injectivity is preserved by the literal physical inclusion. -/
-theorem embeddedObstruction_isInjective : embeddedObstruction.IsInjective := by
-  exact (isInjective_toMPSTensor_changePhysicalBasis_iff
-    physicalInclusion physicalInclusion_isometry tensor).2 tensor_isInjective
-
 /-- The embedded obstruction remains an MPDO tensor. -/
 theorem embeddedObstruction_isMPDO : embeddedObstruction.IsMPDO := by
   exact (isMPDO_changePhysicalBasis_iff
@@ -261,14 +256,6 @@ private noncomputable def terminalSource : MPOTensor 1 1 :=
   fin_cases b
   simp [terminalSource, doubledTensor, MPSTensor.scalarUnitTensor]
 
-private lemma scalarUnitTensor_evalWord {N : ℕ} (σ : Fin N → Fin 1) :
-    Kraus.evalWord MPSTensor.scalarUnitTensor (List.ofFn σ) = 1 := by
-  induction N with
-  | zero => simp
-  | succ N ih =>
-      rw [List.ofFn_succ, Kraus.evalWord_cons, ih]
-      simp [MPSTensor.scalarUnitTensor]
-
 private theorem scalarUnitTensor_transferMap_eq_id :
     Kraus.transferMap MPSTensor.scalarUnitTensor = LinearMap.id := by
   apply LinearMap.ext
@@ -347,7 +334,7 @@ private theorem scalarUnitTensor_pureState_trace_ne_zero (N : ℕ) :
   have hMpv : ∀ σ : Fin N → Fin 1,
       MPSTensor.mpv MPSTensor.scalarUnitTensor σ = 1 := by
     intro σ
-    simp [MPSTensor.mpv, scalarUnitTensor_evalWord, Matrix.trace]
+    simp [MPSTensor.mpv, MPSTensor.scalarUnitTensor_evalWord, Matrix.trace]
   have hPure : MPSTensor.pureState MPSTensor.scalarUnitTensor N = 1 := by
     ext σ τ
     obtain rfl : τ = σ := Subsingleton.elim τ σ
@@ -396,12 +383,6 @@ theorem terminalBlock_physTraceTransfer_eq_one :
   rw [terminalBlock, physTraceTransfer_changePhysicalBasis
     terminalPhysicalInclusion terminalPhysicalInclusion_isometry terminalSource]
   exact terminalSource_physTraceTransfer_eq_one
-
-/-- The terminal block has literal physical-trace idempotence. -/
-theorem terminalBlock_physTraceTransfer_idempotent :
-    physTraceTransfer terminalBlock * physTraceTransfer terminalBlock =
-      physTraceTransfer terminalBlock := by
-  rw [terminalBlock_physTraceTransfer_eq_one, one_mul]
 
 private theorem terminalSource_physicalSupportProj :
     physicalSupportProj terminalSource = 1 := by

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -373,15 +373,10 @@ lemma retainedBlock_isInjective : Kraus.IsInjective retainedBlock := by
   refine R_toMPSTensor_isInjective.smul (inv_ne_zero ?_)
   exact_mod_cast weight_ne
 
-/-- Algebraic normality (eventual block injectivity) follows from `1`-block
-injectivity. -/
-lemma retainedBlock_isNormal : Kraus.IsNormal retainedBlock :=
-  retainedBlock_isInjective.isNormal
-
 /-- **`retainedBlock` is a CPSV normal tensor.** -/
 lemma retainedBlock_isNormalTensor : MPSTensor.IsNormalTensor retainedBlock :=
   MPSTensor.isNormalTensor_of_isNormal_isTransferIdempotent retainedBlock
-    retainedBlock_isNormal retainedBlock_isTransferIdempotent
+    retainedBlock_isInjective.isNormal retainedBlock_isTransferIdempotent
 
 /-! ### Packaging the literal CPSV canonical form -/
 

--- a/TNLean/MPS/RFP/BNTWeightCounterexample.lean
+++ b/TNLean/MPS/RFP/BNTWeightCounterexample.lean
@@ -47,14 +47,6 @@ theorem halvedWeightTensor_eq_halvedDecomp_toTensor :
     halvedWeightTensor =
       (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor := rfl
 
-private lemma scalarUnitTensor_evalWord (w : List (Fin 1)) :
-    Kraus.evalWord scalarUnitTensor w = 1 := by
-  induction w with
-  | nil => rfl
-  | cons i w ih =>
-      rw [Kraus.evalWord_cons, ih]
-      simp [scalarUnitTensor]
-
 private lemma scalarUnitTensor_mpv {N : ℕ} (σ : Fin N → Fin 1) :
     mpv scalarUnitTensor σ = 1 := by
   simp [mpv, scalarUnitTensor_evalWord, Matrix.trace]

--- a/docs/audits/2026-08-30_mpdo_word_evaluation_cleanup_retirements.md
+++ b/docs/audits/2026-08-30_mpdo_word_evaluation_cleanup_retirements.md
@@ -1,0 +1,34 @@
+# MPDO word-evaluation cleanup retirements
+
+This audit records the removal of three zero-consumer public lemmas in PR
+#7456 under the repository-local retirement rule of
+`docs/project_conventions.md` §Style.  Each lemma was either a one-step
+consequence of a surviving result or a pass-through used once at its point of
+definition.
+
+| Removed declaration | Replacement |
+|---|---|
+| `MPOTensor.RescalingStableLengthDependentRFP.retainedBlock_isNormal` | `MPOTensor.RescalingStableLengthDependentRFP.retainedBlock_isInjective.isNormal`, used directly in `retainedBlock_isNormalTensor` |
+| `MPOTensor.NeighboringTraceObstructionAmbientBlocks.embeddedObstruction_isInjective` | `MPOTensor.isInjective_toMPSTensor_changePhysicalBasis_iff physicalInclusion physicalInclusion_isometry tensor`, applied directly to `tensor_isInjective` if this fact is needed |
+| `MPOTensor.NeighboringTraceObstructionAmbientBlocks.terminalBlock_physTraceTransfer_idempotent` | `terminalBlock_physTraceTransfer_eq_one`, followed by `one_mul` if idempotence is needed |
+
+## Clearance
+
+Exact-name searches found no non-`Archive` Lean consumer and no Blueprint
+`\lean{...}` tag for any of the three removed names.  The only use of
+`retainedBlock_isNormal` was the immediately following construction of the
+CPSV normal tensor; that call now uses
+`retainedBlock_isInjective.isNormal` directly.  The other two lemmas had no
+consumer.
+
+The replacements preserve the same mathematics.  Physical-basis injectivity
+transport is the theorem from which `embeddedObstruction_isInjective` was
+proved verbatim.  The equality
+`terminalBlock_physTraceTransfer_eq_one` is strictly stronger than
+idempotence.  No compatibility alias is retained, since TNLean does not
+promise a stable public Lean interface and all retirement conditions are
+satisfied.
+
+The exact PR head was checked by a root `lake build`, so importers were tested
+after the declarations were removed.  The linter-bearing changed-module
+builds, Blueprint synchronization, and both declaration checks also passed.


### PR DESCRIPTION
### Motivation

Issue #7409 isolates repeated word-evaluation proofs and several zero-consumer declarations in the CPSV16 MPDO/RFP development. These are implementation duplicates and dead leaves; no paper-facing statement is changed.

### Description

- Add `MPOTensor.evalWord_ofFn_eq_zero_of_ne`: an MPO tensor with vanishing off-diagonal physical entries evaluates to zero on two distinct finite configurations.
- Replace the three separate word-vanishing proofs in the literal CPSV example, Kato deformation, and active-sector area-law example by that theorem.
- Add the general list-level theorem `MPSTensor.scalarUnitTensor_evalWord` beside `scalarUnitTensor`, and replace both private copies.
- Remove the unused `embeddedObstruction_isInjective` and `terminalBlock_physTraceTransfer_idempotent` leaves. The former is recoverable from physical-basis injectivity transport; the latter is weaker than `terminalBlock_physTraceTransfer_eq_one`.
- Fold the one-use `retainedBlock_isNormal` pass-through into `retainedBlock_isNormalTensor`.
- Preserve every source-facing theorem signature and every Blueprint tag. The eight Lean files contain 32 additions and 81 deletions, a net reduction of 49 lines.

Repository-wide searches on the final tree find no consumer of any removed declaration. The new shared lemmas retain the exact physical-index and scalar-unit meanings used by their former copies.

### Validation

- `scripts/lake_build_locked.sh` — 10,395/10,395 jobs on the exact post-#7412 base
- linter-bearing builds of every changed module and its requested reverse dependents
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 6,940/6,940 theorem-like entries
- `lake exe checkdecls blueprint/lean_decls`
- `(cd blueprint && leanblueprint checkdecls)`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check origin/main...HEAD`

Closes #7409.
Tracks #4564 and #7338 without closing either parent issue.

### Agent assistance

Codex inspected the existing proofs and consumers, performed the refactor, and ran the listed validation. The human maintainer selected the issue and remains responsible for the mathematical and repository decisions.


### Retirement audit

The three public retirements and their exact replacements are recorded in `docs/audits/2026-08-30_mpdo_word_evaluation_cleanup_retirements.md`: `retainedBlock_isNormal` is replaced by `retainedBlock_isInjective.isNormal`; `embeddedObstruction_isInjective` by the existing physical-basis injectivity equivalence applied to `tensor_isInjective`; and `terminalBlock_physTraceTransfer_idempotent` by `terminalBlock_physTraceTransfer_eq_one` followed by `one_mul`.