### PR TITLE
feat(MPS/MPU): formalize source-faithful source-u endpoints

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -43,6 +43,7 @@ import TNLean.MPS.MPU.SourceFactorContraction
 import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import TNLean.MPS.MPU.SourceIndexValue
+import TNLean.MPS.MPU.SourceUCompleteNetwork
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVIsometry
 import TNLean.MPS.MPU.StandardForm

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -34,6 +34,22 @@ private theorem sourceSqrt_ne_zero (d : ℕ) [NeZero d] : sourceSqrt d ≠ 0 := 
 private theorem sourceSqrt_sq (d : ℕ) : sourceSqrt d ^ 2 = (d : ℂ) := by
   exact Complex.ofReal_sqrt_sq d (by positivity)
 
+private theorem sourceSqrt_mul_inv (d : ℕ) [NeZero d] :
+    sourceSqrt d * (sourceSqrt d)⁻¹ = 1 := by
+  exact mul_inv_cancel₀ (sourceSqrt_ne_zero d)
+
+private theorem sourceSqrt_inv_mul (d : ℕ) [NeZero d] :
+    (sourceSqrt d)⁻¹ * sourceSqrt d = 1 := by
+  exact inv_mul_cancel₀ (sourceSqrt_ne_zero d)
+
+private theorem sourceSqrt_mul_nat_inv_mul_sourceSqrt (d : ℕ) [NeZero d] :
+    sourceSqrt d * (d : ℂ)⁻¹ * sourceSqrt d = 1 := by
+  calc
+    sourceSqrt d * (d : ℂ)⁻¹ * sourceSqrt d =
+        sourceSqrt d ^ 2 * (d : ℂ)⁻¹ := by ring
+    _ = (d : ℂ) * (d : ℂ)⁻¹ := by rw [sourceSqrt_sq]
+    _ = 1 := mul_inv_cancel₀ (by exact_mod_cast NeZero.ne d)
+
 private theorem sourceSqrt_inv_mul_nat_mul_inv (d : ℕ) [NeZero d] :
     (sourceSqrt d)⁻¹ * (d : ℂ) * (sourceSqrt d)⁻¹ = 1 := by
   rw [← sourceSqrt_sq]
@@ -374,6 +390,135 @@ noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
         simp
   exact ⟨P, Pᴴ, P, C, R, Z, hcut₁, hcut₂, hweighted, hC,
     hP.1, hRZ⟩
+
+/-- The trace-one canonical-form-II weight for the right shift.
+
+The factor (d^{-1}) is required by the normalization
+\(\operatorname{tr}(\rho)=1\) used in CPSV17 equation `Erightleft`. -/
+noncomputable def rightShiftTraceOneSourceWeight (d : ℕ) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  (d : ℂ)⁻¹ • 1
+
+/-- The right-shift canonical-form-II weight is positive definite.
+
+Source: CPSV17 equation `Erightleft` (lines 269--280). -/
+theorem rightShiftTraceOneSourceWeight_posDef (d : ℕ) [NeZero d] :
+    (rightShiftTraceOneSourceWeight d).PosDef := by
+  unfold rightShiftTraceOneSourceWeight
+  exact Matrix.PosDef.one.smul (by positivity)
+
+/-- The right-shift canonical-form-II weight has trace one.
+
+Source: CPSV17 equation `Erightleft` (lines 269--280). -/
+theorem trace_rightShiftTraceOneSourceWeight (d : ℕ) [NeZero d] :
+    Matrix.trace (rightShiftTraceOneSourceWeight d) = 1 := by
+  rw [rightShiftTraceOneSourceWeight, Matrix.trace_smul, Matrix.trace_one]
+  simp [NeZero.ne d]
+
+/-- Supplied source factors for the right shift with the trace-one
+canonical-form-II weight \(\rho=d^{-1}I\).
+
+Relative to `rightShiftSourceFactors`, the first-cut factors are rescaled as
+\(X_1'=\sqrt d\,X_1\), \(Y_1'=d^{-1/2}Y_1\), and
+\(Z_1'=\sqrt d\,Z_1\).  This preserves both the source-cut factorization and
+the right inverse while changing the weighted normalization to the source
+normalization used in CPSV17 equation `X1X2b`.
+
+Source: CPSV17 equations `Erightleft`, `X1X2b`, and `YZ=1` (lines 269--280
+and 487--506). -/
+noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (rightShiftTensor d) (rightShiftTraceOneSourceWeight d) := by
+  let S := rightShiftSourceFactors d
+  let s := sourceSqrt d
+  let X₁ := s • S.X₁
+  let Y₁ := s⁻¹ • S.Y₁
+  let Z₁ := s • S.Z₁
+  have hcut₁ : sourceCutM₁ (rightShiftTensor d) = X₁ * Y₁ := by
+    calc
+      sourceCutM₁ (rightShiftTensor d) = S.X₁ * S.Y₁ := S.sourceCutM₁_eq
+      _ = X₁ * Y₁ := by
+        simp only [X₁, Y₁, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+        rw [sourceSqrt_mul_inv]
+        simp
+  have hweighted : X₁ᴴ * sourceWeight (d := d)
+      (rightShiftTraceOneSourceWeight d) * X₁ = 1 := by
+    have hS : S.X₁ᴴ * S.X₁ = 1 := by
+      simpa [sourceWeight] using S.X₁_weighted_isometry
+    simp only [X₁, rightShiftTraceOneSourceWeight, sourceWeight,
+      Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+      Matrix.smul_kronecker, Matrix.one_kronecker_one]
+    rw [show star s = s by simp [s, sourceSqrt], hS,
+      sourceSqrt_mul_nat_inv_mul_sourceSqrt]
+    simp
+  have hY₁Z₁ : Y₁ * Z₁ = 1 := by
+    simp only [Y₁, Z₁, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+    rw [sourceSqrt_inv_mul, S.Y₁_mul_Z₁]
+    simp
+  exact
+    { X₁ := X₁
+      Y₁ := Y₁
+      Z₁ := Z₁
+      X₂ := S.X₂
+      Y₂ := S.Y₂
+      Z₂ := S.Z₂
+      sourceCutM₁_eq := hcut₁
+      sourceCutM₂_eq := S.sourceCutM₂_eq
+      X₁_weighted_isometry := hweighted
+      X₂_isometry := S.X₂_isometry
+      Y₁_mul_Z₁ := hY₁Z₁
+      Y₂_mul_Z₂ := S.Y₂_mul_Z₂ }
+
+/-- With the trace-one canonical-form-II weight, the paper gate
+\(u=Y_2\mathbin{-}Y_1\) of the right shift is a literal permutation matrix.
+
+The source coordinate `(a,b)` is sent to the physical coordinate `(b,a)`,
+fixing both the triangle order and the normalization in CPSV17 equation `uu`.
+-/
+theorem sourceU_rightShiftTraceOneSourceFactors_apply (d : ℕ) [NeZero d]
+    (a b i₁ i₂ : Fin d) :
+    SourceFactors.sourceU (rightShiftTensor d)
+        (rightShiftTraceOneSourceFactors d)
+        (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) (i₁, i₂) =
+      if a = i₂ ∧ b = i₁ then 1 else 0 := by
+  by_cases ha : a = i₂ <;> by_cases hb : b = i₁ <;>
+    simp [SourceFactors.sourceU_apply, rightShiftTraceOneSourceFactors,
+      rightShiftSourceFactors, normalizedIdentityColumn, normalizedIdentityVec,
+      Matrix.reindex_apply, Matrix.one_apply, sourceSqrt, ha, hb, NeZero.ne d,
+      shiftSourceScale_cancel, mul_comm, mul_left_comm]
+  all_goals grind
+
+/-- The trace-one right-shift source gate has the expected input-oriented
+Gram matrix.  This is the normalization and orientation regression for the
+complete-network theorem corresponding to CPSV17 equation `uUnitary`.
+-/
+theorem sourceU_rightShiftTraceOneSourceFactors_gram (d : ℕ) [NeZero d]
+    (p q : Fin d × Fin d) :
+    (∑ lr, SourceFactors.sourceU (rightShiftTensor d)
+        (rightShiftTraceOneSourceFactors d) lr q *
+      star (SourceFactors.sourceU (rightShiftTensor d)
+        (rightShiftTraceOneSourceFactors d) lr p)) =
+      if p = q then 1 else 0 := by
+  classical
+  let e := (rightShiftLeftRankEquiv d).prodCongr (rightShiftRightRankEquiv d)
+  rw [← e.sum_comp, Fintype.sum_prod_type]
+  simp only [e, sourceU_rightShiftTraceOneSourceFactors_apply]
+  rcases p with ⟨p₁, p₂⟩
+  rcases q with ⟨q₁, q₂⟩
+  simp only [Prod.mk.injEq]
+  by_cases h₁ : p₁ = q₁ <;> by_cases h₂ : p₂ = q₂ <;> simp [h₁, h₂]
+
+/-- The paper source gate of the right shift is an isometry when its first
+source cut uses the trace-one canonical-form-II weight.
+
+Source: CPSV17 Lemma `lemuisometry` and equation `uUnitary` (lines 545--557).
+-/
+theorem sourceU_rightShiftTraceOneSourceFactors_isIsometry (d : ℕ) [NeZero d] :
+    (SourceFactors.sourceU (rightShiftTensor d)
+      (rightShiftTraceOneSourceFactors d)).IsIsometry := by
+  rw [Matrix.IsIsometry]
+  ext p q
+  simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+    eq_comm] using sourceU_rightShiftTraceOneSourceFactors_gram d p q
 
 /-- Explicit supplied source factors for the left-shift tensor.
 

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -425,14 +425,32 @@ noncomputable def rightShiftPaperSourceFactors (d : ℕ) [NeZero d] :
         simp
   have hweighted : X₁ᴴ * sourceWeight (d := d)
       (shiftPaperWeight d) * X₁ = 1 := by
-    have hS : S.X₁ᴴ * S.X₁ = 1 := by
-      simpa [sourceWeight] using S.X₁_weighted_isometry
-    simp only [X₁, shiftPaperWeight, sourceWeight,
-      Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
-      Matrix.smul_kronecker, Matrix.one_kronecker_one]
-    rw [show star s = s by simp [s, sourceSqrt], Matrix.mul_one, hS,
-      hs_weight]
-    simp
+    have hsstar : star s = s := by simp [s, sourceSqrt]
+    have hweight : sourceWeight (d := d) (shiftPaperWeight d) =
+        (d : ℂ)⁻¹ • sourceWeight (d := d)
+          (1 : Matrix (Fin d) (Fin d) ℂ) := by
+      ext x y
+      by_cases hxy : x = y
+      · subst y
+        simp [sourceWeight, shiftPaperWeight]
+      · by_cases h₁ : x.2 = y.2 <;> by_cases h₂ : x.1 = y.1
+        · have hpair : x = y := Prod.ext h₂ h₁
+          contradiction
+        · simp [sourceWeight, shiftPaperWeight, hxy, h₁, h₂]
+        · simp [sourceWeight, shiftPaperWeight, hxy, h₁]
+        · simp [sourceWeight, shiftPaperWeight, hxy, h₁, h₂]
+    have hscalar : star s * (d : ℂ)⁻¹ * s = 1 := by
+      simpa [hsstar, mul_assoc] using hs_weight
+    calc
+      X₁ᴴ * sourceWeight (d := d) (shiftPaperWeight d) * X₁ =
+          (star s * (d : ℂ)⁻¹ * s) •
+            (S.X₁ᴴ * sourceWeight (d := d)
+              (1 : Matrix (Fin d) (Fin d) ℂ) * S.X₁) := by
+        simp [X₁, hweight, Matrix.conjTranspose_smul, Matrix.smul_mul,
+          Matrix.mul_smul, smul_smul, mul_comm, mul_left_comm]
+      _ = 1 := by
+        rw [hscalar, S.X₁_weighted_isometry]
+        simp
   have hY₁Z₁ : Y₁ * Z₁ = 1 := by
     simp only [Y₁, Z₁, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
     rw [hs_mul_inv, S.Y₁_mul_Z₁]
@@ -452,30 +470,28 @@ noncomputable def rightShiftPaperSourceFactors (d : ℕ) [NeZero d] :
       Y₂_mul_Z₂ := S.Y₂_mul_Z₂ }
 
 /-- With the trace-normalized scalar weight, the paper gate
-\(u=Y_2\mathbin{-}Y_1\) of the right shift is a literal permutation matrix.
+\(u=Y_2\mathbin{-}Y_1\) of the right shift is the identity permutation on
+the two physical letters.
 
-The source coordinate `(a,b)` is sent to the physical coordinate `(b,a)`,
-fixing both the triangle order and the normalization in CPSV17 equation `uu`.
--/
+Source: CPSV17 equations `uu` and `uUnitary` (lines 532--557). -/
 theorem sourceU_rightShiftPaperSourceFactors_apply (d : ℕ) [NeZero d]
     (a b i₁ i₂ : Fin d) :
     SourceFactors.sourceU (rightShiftTensor d)
         (rightShiftPaperSourceFactors d)
         (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) (i₁, i₂) =
-      if a = i₂ ∧ b = i₁ then 1 else 0 := by
+      if a = i₁ ∧ b = i₂ then 1 else 0 := by
   have hscale : (d : ℂ) *
       ((Real.sqrt d : ℂ)⁻¹ * (Real.sqrt d : ℂ)⁻¹) = 1 := by
     simpa only [sourceSqrt] using nat_mul_sourceSqrt_inv_mul_inv d
-  by_cases ha : a = i₂ <;> by_cases hb : b = i₁ <;>
+  by_cases ha : a = i₁ <;> by_cases hb : b = i₂ <;>
     simp [SourceFactors.sourceU_apply, rightShiftPaperSourceFactors,
       rightShiftSourceFactors, normalizedIdentityColumn, normalizedIdentityVec,
       Matrix.reindex_apply, Matrix.one_apply, sourceSqrt, ha, hb,
       hscale, mul_comm, mul_left_comm]
 
-/-- The trace-one right-shift source gate has the expected input-oriented
-Gram matrix.  This is the normalization and orientation regression for the
-complete-network theorem corresponding to CPSV17 equation `uUnitary`.
--/
+/-- The trace-one right-shift source gate has identity Gram matrix.
+This is the normalization and orientation regression for the complete-network
+theorem corresponding to CPSV17 equation `uUnitary`. -/
 theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
     (p q : Fin d × Fin d) :
     (∑ lr, SourceFactors.sourceU (rightShiftTensor d)
@@ -490,7 +506,7 @@ theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
   have happly (x : Fin 1 × (Fin d × Fin d)) (i₁ i₂ : Fin d) :
       SourceFactors.sourceU (rightShiftTensor d)
           (rightShiftPaperSourceFactors d) (e x) (i₁, i₂) =
-        if x.2.1 = i₂ ∧ x.2.2 = i₁ then 1 else 0 := by
+        if x.2.1 = i₁ ∧ x.2.2 = i₂ then 1 else 0 := by
     rcases x with ⟨x₀, ⟨a, b⟩⟩
     have hx₀ : x₀ = 0 := Subsingleton.elim _ _
     subst x₀

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexSqrt
 import Mathlib.LinearAlgebra.Matrix.Reindex
+import TNLean.MPS.MPU.Examples.ShiftPaperSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
 import TNLean.MPS.MPU.SourceUV
 
@@ -391,34 +392,6 @@ noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
   exact ⟨P, Pᴴ, P, C, R, Z, hcut₁, hcut₂, hweighted, hC,
     hP.1, hRZ⟩
 
-/-- The trace-one canonical-form-II weight for the right shift.
-
-The factor (d^{-1}) is required by the normalization
-\(\operatorname{tr}(\rho)=1\) used in CPSV17 equation `Erightleft`. -/
-noncomputable def rightShiftTraceOneSourceWeight (d : ℕ) :
-    Matrix (Fin d) (Fin d) ℂ :=
-  (d : ℂ)⁻¹ • 1
-
-/-- The right-shift canonical-form-II weight is positive definite.
-
-Source: CPSV17 equation `Erightleft` (lines 269--280). -/
-theorem rightShiftTraceOneSourceWeight_posDef (d : ℕ) [NeZero d] :
-    (rightShiftTraceOneSourceWeight d).PosDef := by
-  rw [show rightShiftTraceOneSourceWeight d =
-      (d : ℝ)⁻¹ • (1 : Matrix (Fin d) (Fin d) ℂ) by
-    ext i j
-    simp [rightShiftTraceOneSourceWeight, Matrix.one_apply]]
-  exact Matrix.PosDef.one.smul <| inv_pos.mpr <| by
-    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
-
-/-- The right-shift canonical-form-II weight has trace one.
-
-Source: CPSV17 equation `Erightleft` (lines 269--280). -/
-theorem trace_rightShiftTraceOneSourceWeight (d : ℕ) [NeZero d] :
-    Matrix.trace (rightShiftTraceOneSourceWeight d) = 1 := by
-  rw [rightShiftTraceOneSourceWeight, Matrix.trace_smul, Matrix.trace_one]
-  simp [NeZero.ne d]
-
 /-- Supplied source factors for the right shift with the trace-one
 canonical-form-II weight \(\rho=d^{-1}I\).
 
@@ -430,8 +403,8 @@ normalization used in CPSV17 equation `X1X2b`.
 
 Source: CPSV17 equations `Erightleft`, `X1X2b`, and `YZ=1` (lines 269--280
 and 487--506). -/
-noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
-    SourceFactors (rightShiftTensor d) (rightShiftTraceOneSourceWeight d) := by
+noncomputable def rightShiftPaperSourceFactors (d : ℕ) [NeZero d] :
+    SourceFactors (rightShiftTensor d) (shiftPaperWeight d) := by
   let S := rightShiftSourceFactors d
   let s := sourceSqrt d
   let X₁ := s • S.X₁
@@ -451,10 +424,10 @@ noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
         rw [hs_inv_mul]
         simp
   have hweighted : X₁ᴴ * sourceWeight (d := d)
-      (rightShiftTraceOneSourceWeight d) * X₁ = 1 := by
+      (shiftPaperWeight d) * X₁ = 1 := by
     have hS : S.X₁ᴴ * S.X₁ = 1 := by
       simpa [sourceWeight] using S.X₁_weighted_isometry
-    simp only [X₁, rightShiftTraceOneSourceWeight, sourceWeight,
+    simp only [X₁, shiftPaperWeight, sourceWeight,
       Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
       Matrix.smul_kronecker, Matrix.one_kronecker_one]
     rw [show star s = s by simp [s, sourceSqrt], Matrix.mul_one, hS,
@@ -484,17 +457,17 @@ noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
 The source coordinate `(a,b)` is sent to the physical coordinate `(b,a)`,
 fixing both the triangle order and the normalization in CPSV17 equation `uu`.
 -/
-theorem sourceU_rightShiftTraceOneSourceFactors_apply (d : ℕ) [NeZero d]
+theorem sourceU_rightShiftPaperSourceFactors_apply (d : ℕ) [NeZero d]
     (a b i₁ i₂ : Fin d) :
     SourceFactors.sourceU (rightShiftTensor d)
-        (rightShiftTraceOneSourceFactors d)
+        (rightShiftPaperSourceFactors d)
         (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) (i₁, i₂) =
       if a = i₂ ∧ b = i₁ then 1 else 0 := by
   have hscale : (d : ℂ) *
       ((Real.sqrt d : ℂ)⁻¹ * (Real.sqrt d : ℂ)⁻¹) = 1 := by
     simpa only [sourceSqrt] using nat_mul_sourceSqrt_inv_mul_inv d
   by_cases ha : a = i₂ <;> by_cases hb : b = i₁ <;>
-    simp [SourceFactors.sourceU_apply, rightShiftTraceOneSourceFactors,
+    simp [SourceFactors.sourceU_apply, rightShiftPaperSourceFactors,
       rightShiftSourceFactors, normalizedIdentityColumn, normalizedIdentityVec,
       Matrix.reindex_apply, Matrix.one_apply, sourceSqrt, ha, hb,
       hscale, mul_comm, mul_left_comm]
@@ -503,12 +476,12 @@ theorem sourceU_rightShiftTraceOneSourceFactors_apply (d : ℕ) [NeZero d]
 Gram matrix.  This is the normalization and orientation regression for the
 complete-network theorem corresponding to CPSV17 equation `uUnitary`.
 -/
-theorem sourceU_rightShiftTraceOneSourceFactors_gram (d : ℕ) [NeZero d]
+theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
     (p q : Fin d × Fin d) :
     (∑ lr, SourceFactors.sourceU (rightShiftTensor d)
-        (rightShiftTraceOneSourceFactors d) lr q *
+        (rightShiftPaperSourceFactors d) lr q *
       star (SourceFactors.sourceU (rightShiftTensor d)
-        (rightShiftTraceOneSourceFactors d) lr p)) =
+        (rightShiftPaperSourceFactors d) lr p)) =
       if p = q then 1 else 0 := by
   classical
   let e := (rightShiftLeftRankEquiv d).prodCongr (rightShiftRightRankEquiv d)
@@ -516,12 +489,12 @@ theorem sourceU_rightShiftTraceOneSourceFactors_gram (d : ℕ) [NeZero d]
   rcases q with ⟨q₁, q₂⟩
   have happly (x : Fin 1 × (Fin d × Fin d)) (i₁ i₂ : Fin d) :
       SourceFactors.sourceU (rightShiftTensor d)
-          (rightShiftTraceOneSourceFactors d) (e x) (i₁, i₂) =
+          (rightShiftPaperSourceFactors d) (e x) (i₁, i₂) =
         if x.2.1 = i₂ ∧ x.2.2 = i₁ then 1 else 0 := by
     rcases x with ⟨x₀, ⟨a, b⟩⟩
     have hx₀ : x₀ = 0 := Subsingleton.elim _ _
     subst x₀
-    simpa [e] using sourceU_rightShiftTraceOneSourceFactors_apply
+    simpa [e] using sourceU_rightShiftPaperSourceFactors_apply
       d a b i₁ i₂
   rw [← e.sum_comp]
   simp_rw [happly]
@@ -534,13 +507,13 @@ source cut uses the trace-one canonical-form-II weight.
 
 Source: CPSV17 Lemma `lemuisometry` and equation `uUnitary` (lines 545--557).
 -/
-theorem sourceU_rightShiftTraceOneSourceFactors_isIsometry (d : ℕ) [NeZero d] :
+theorem sourceU_rightShiftPaperSourceFactors_isIsometry (d : ℕ) [NeZero d] :
     (SourceFactors.sourceU (rightShiftTensor d)
-      (rightShiftTraceOneSourceFactors d)).IsIsometry := by
+      (rightShiftPaperSourceFactors d)).IsIsometry := by
   rw [Matrix.IsIsometry]
   ext p q
   simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
-    mul_comm] using sourceU_rightShiftTraceOneSourceFactors_gram d p q
+    mul_comm] using sourceU_rightShiftPaperSourceFactors_gram d p q
 
 /-- Explicit supplied source factors for the left-shift tensor.
 

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -19,7 +19,7 @@ identities.  None of the statements below identifies the supplied witnesses
 with factors chosen by compact singular-value decomposition.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 
 namespace MPOTensor
 
@@ -404,8 +404,12 @@ noncomputable def rightShiftTraceOneSourceWeight (d : ℕ) :
 Source: CPSV17 equation `Erightleft` (lines 269--280). -/
 theorem rightShiftTraceOneSourceWeight_posDef (d : ℕ) [NeZero d] :
     (rightShiftTraceOneSourceWeight d).PosDef := by
-  unfold rightShiftTraceOneSourceWeight
-  exact Matrix.PosDef.one.smul (by positivity)
+  rw [show rightShiftTraceOneSourceWeight d =
+      (d : ℝ)⁻¹ • (1 : Matrix (Fin d) (Fin d) ℂ) by
+    ext i j
+    simp [rightShiftTraceOneSourceWeight, Matrix.one_apply]]
+  exact Matrix.PosDef.one.smul <| inv_pos.mpr <| by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
 
 /-- The right-shift canonical-form-II weight has trace one.
 
@@ -433,12 +437,18 @@ noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
   let X₁ := s • S.X₁
   let Y₁ := s⁻¹ • S.Y₁
   let Z₁ := s • S.Z₁
+  have hs_mul_inv : s * s⁻¹ = 1 := by
+    simpa only [s] using sourceSqrt_mul_inv d
+  have hs_inv_mul : s⁻¹ * s = 1 := by
+    simpa only [s] using sourceSqrt_inv_mul d
+  have hs_weight : s * ((d : ℂ)⁻¹ * s) = 1 := by
+    simpa only [s, mul_assoc] using sourceSqrt_mul_nat_inv_mul_sourceSqrt d
   have hcut₁ : sourceCutM₁ (rightShiftTensor d) = X₁ * Y₁ := by
     calc
       sourceCutM₁ (rightShiftTensor d) = S.X₁ * S.Y₁ := S.sourceCutM₁_eq
       _ = X₁ * Y₁ := by
         simp only [X₁, Y₁, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-        rw [sourceSqrt_mul_inv]
+        rw [hs_inv_mul]
         simp
   have hweighted : X₁ᴴ * sourceWeight (d := d)
       (rightShiftTraceOneSourceWeight d) * X₁ = 1 := by
@@ -447,12 +457,12 @@ noncomputable def rightShiftTraceOneSourceFactors (d : ℕ) [NeZero d] :
     simp only [X₁, rightShiftTraceOneSourceWeight, sourceWeight,
       Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
       Matrix.smul_kronecker, Matrix.one_kronecker_one]
-    rw [show star s = s by simp [s, sourceSqrt], hS,
-      sourceSqrt_mul_nat_inv_mul_sourceSqrt]
+    rw [show star s = s by simp [s, sourceSqrt], Matrix.mul_one, hS,
+      hs_weight]
     simp
   have hY₁Z₁ : Y₁ * Z₁ = 1 := by
     simp only [Y₁, Z₁, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-    rw [sourceSqrt_inv_mul, S.Y₁_mul_Z₁]
+    rw [hs_mul_inv, S.Y₁_mul_Z₁]
     simp
   exact
     { X₁ := X₁
@@ -480,12 +490,14 @@ theorem sourceU_rightShiftTraceOneSourceFactors_apply (d : ℕ) [NeZero d]
         (rightShiftTraceOneSourceFactors d)
         (rightShiftLeftRankEquiv d 0, rightShiftRightRankEquiv d (a, b)) (i₁, i₂) =
       if a = i₂ ∧ b = i₁ then 1 else 0 := by
+  have hscale : (d : ℂ) *
+      ((Real.sqrt d : ℂ)⁻¹ * (Real.sqrt d : ℂ)⁻¹) = 1 := by
+    simpa only [sourceSqrt] using nat_mul_sourceSqrt_inv_mul_inv d
   by_cases ha : a = i₂ <;> by_cases hb : b = i₁ <;>
     simp [SourceFactors.sourceU_apply, rightShiftTraceOneSourceFactors,
       rightShiftSourceFactors, normalizedIdentityColumn, normalizedIdentityVec,
-      Matrix.reindex_apply, Matrix.one_apply, sourceSqrt, ha, hb, NeZero.ne d,
-      shiftSourceScale_cancel, mul_comm, mul_left_comm]
-  all_goals grind
+      Matrix.reindex_apply, Matrix.one_apply, sourceSqrt, ha, hb,
+      hscale, mul_comm, mul_left_comm]
 
 /-- The trace-one right-shift source gate has the expected input-oriented
 Gram matrix.  This is the normalization and orientation regression for the
@@ -500,12 +512,22 @@ theorem sourceU_rightShiftTraceOneSourceFactors_gram (d : ℕ) [NeZero d]
       if p = q then 1 else 0 := by
   classical
   let e := (rightShiftLeftRankEquiv d).prodCongr (rightShiftRightRankEquiv d)
-  rw [← e.sum_comp, Fintype.sum_prod_type]
-  simp only [e, sourceU_rightShiftTraceOneSourceFactors_apply]
   rcases p with ⟨p₁, p₂⟩
   rcases q with ⟨q₁, q₂⟩
-  simp only [Prod.mk.injEq]
-  by_cases h₁ : p₁ = q₁ <;> by_cases h₂ : p₂ = q₂ <;> simp [h₁, h₂]
+  have happly (x : Fin 1 × (Fin d × Fin d)) (i₁ i₂ : Fin d) :
+      SourceFactors.sourceU (rightShiftTensor d)
+          (rightShiftTraceOneSourceFactors d) (e x) (i₁, i₂) =
+        if x.2.1 = i₂ ∧ x.2.2 = i₁ then 1 else 0 := by
+    rcases x with ⟨x₀, ⟨a, b⟩⟩
+    have hx₀ : x₀ = 0 := Subsingleton.elim _ _
+    subst x₀
+    simpa [e] using sourceU_rightShiftTraceOneSourceFactors_apply
+      d a b i₁ i₂
+  rw [← e.sum_comp]
+  simp_rw [happly]
+  simp only [Fintype.sum_prod_type, Prod.mk.injEq]
+  by_cases h₁ : p₁ = q₁ <;> by_cases h₂ : p₂ = q₂ <;>
+    simp [ite_and, h₁, h₂, ne_comm]
 
 /-- The paper source gate of the right shift is an isometry when its first
 source cut uses the trace-one canonical-form-II weight.
@@ -518,7 +540,7 @@ theorem sourceU_rightShiftTraceOneSourceFactors_isIsometry (d : ℕ) [NeZero d] 
   rw [Matrix.IsIsometry]
   ext p q
   simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
-    eq_comm] using sourceU_rightShiftTraceOneSourceFactors_gram d p q
+    mul_comm] using sourceU_rightShiftTraceOneSourceFactors_gram d p q
 
 /-- Explicit supplied source factors for the left-shift tensor.
 

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -392,8 +392,8 @@ noncomputable def rightShiftSourceFactors (d : ℕ) [NeZero d] :
   exact ⟨P, Pᴴ, P, C, R, Z, hcut₁, hcut₂, hweighted, hC,
     hP.1, hRZ⟩
 
-/-- Supplied source factors for the right shift with the trace-one
-canonical-form-II weight \(\rho=d^{-1}I\).
+/-- Supplied source factors for the right shift with the trace-normalized
+scalar weight \(\rho=d^{-1}I\) prescribed by canonical form II.
 
 Relative to `rightShiftSourceFactors`, the first-cut factors are rescaled as
 \(X_1'=\sqrt d\,X_1\), \(Y_1'=d^{-1/2}Y_1\), and
@@ -451,7 +451,7 @@ noncomputable def rightShiftPaperSourceFactors (d : ℕ) [NeZero d] :
       Y₁_mul_Z₁ := hY₁Z₁
       Y₂_mul_Z₂ := S.Y₂_mul_Z₂ }
 
-/-- With the trace-one canonical-form-II weight, the paper gate
+/-- With the trace-normalized scalar weight, the paper gate
 \(u=Y_2\mathbin{-}Y_1\) of the right shift is a literal permutation matrix.
 
 The source coordinate `(a,b)` is sent to the physical coordinate `(b,a)`,
@@ -503,7 +503,7 @@ theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
     simp [ite_and, h₁, h₂, ne_comm]
 
 /-- The paper source gate of the right shift is an isometry when its first
-source cut uses the trace-one canonical-form-II weight.
+source cut uses the trace-normalized scalar weight.
 
 Source: CPSV17 Lemma `lemuisometry` and equation `uUnitary` (lines 545--557).
 -/

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -42,6 +42,38 @@ private lemma sum_rotate_four {A B C P R : Type*}
     (fun _ ↦ rfl)
   simpa only [Fintype.sum_prod_type] using h
 
+private lemma sum_rotate_three {A B C R : Type*}
+    [Fintype A] [Fintype B] [Fintype C] [AddCommMonoid R]
+    (f : A → B → C → R) :
+    (∑ a, ∑ b, ∑ c, f a b c) =
+      ∑ c, ∑ b, ∑ a, f a b c := by
+  let e : ((A × B) × C) ≃ ((C × B) × A) :=
+    { toFun := fun x ↦ ((x.2, x.1.2), x.1.1)
+      invFun := fun x ↦ ((x.2, x.1.2), x.1.1)
+      left_inv := by rintro ⟨⟨a, b⟩, c⟩; rfl
+      right_inv := by rintro ⟨⟨c, b⟩, a⟩; rfl }
+  have h := Fintype.sum_equiv e
+    (fun x ↦ f x.1.1 x.1.2 x.2)
+    (fun x ↦ f x.2 x.1.2 x.1.1)
+    (fun _ ↦ rfl)
+  simpa only [Fintype.sum_prod_type] using h
+
+private lemma sum_rotate_four_last_first {A B C P R : Type*}
+    [Fintype A] [Fintype B] [Fintype C] [Fintype P] [AddCommMonoid R]
+    (f : A → B → C → P → R) :
+    (∑ a, ∑ b, ∑ c, ∑ p, f a b c p) =
+      ∑ p, ∑ c, ∑ a, ∑ b, f a b c p := by
+  let e : (((A × B) × C) × P) ≃ (((P × C) × A) × B) :=
+    { toFun := fun x ↦ (((x.2, x.1.2), x.1.1.1), x.1.1.2)
+      invFun := fun x ↦ (((x.1.2, x.2), x.1.1.2), x.1.1.1)
+      left_inv := by rintro ⟨⟨⟨a, b⟩, c⟩, p⟩; rfl
+      right_inv := by rintro ⟨⟨⟨p, c⟩, a⟩, b⟩; rfl }
+  have h := Fintype.sum_equiv e
+    (fun x ↦ f x.1.1.1 x.1.1.2 x.1.2 x.2)
+    (fun x ↦ f x.1.2 x.2 x.1.1.2 x.1.1.1)
+    (fun _ ↦ rfl)
+  simpa only [Fintype.sum_prod_type] using h
+
 namespace SourceFactors
 
 /-- The tensor product \(Y_1\otimes Y_2\) for supplied source factors, in the
@@ -51,12 +83,12 @@ Source: CPSV17 equations `uu` and `uUnitary` (lines 532--557). -/
 private noncomputable def sourceYTensor {ρ : Matrix (Fin D) (Fin D) ℂ}
     (S : SourceFactors U ρ) :
     Matrix (Fin r[U] × Fin ℓ[U])
-      ((Fin d × Fin D) × (Fin d × Fin D)) ℂ :=
+      ((Fin D × Fin d) × (Fin d × Fin D)) ℂ :=
   S.Y₁ ⊗ₖ S.Y₂
 
 @[simp] private theorem sourceYTensor_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
     (S : SourceFactors U ρ) (r : Fin r[U]) (l : Fin ℓ[U])
-    (x₁ x₂ : Fin d × Fin D) :
+    (x₁ : Fin D × Fin d) (x₂ : Fin d × Fin D) :
     sourceYTensor U S (r, l) (x₁, x₂) = S.Y₁ r x₁ * S.Y₂ l x₂ := rfl
 
 /-- The paper gate \(u=Y_2\mathbin{-}Y_1\) is the diagonal virtual
@@ -68,7 +100,7 @@ private theorem sourceU_eq_diagonal_sourceYTensor
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
     sourceU U S (l, r) (i₁, i₂) =
-      ∑ β : Fin D, sourceYTensor U S (r, l) ((i₂, β), (i₁, β)) := by
+      ∑ β : Fin D, sourceYTensor U S (r, l) ((β, i₂), (i₁, β)) := by
   apply Finset.sum_congr rfl
   intro β _
   simp only [sourceYTensor_apply]
@@ -77,9 +109,9 @@ private theorem sourceU_eq_diagonal_sourceYTensor
 private theorem Y₁_gram_eq_weighted_sourceCutM₁_gram
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (p q : Fin d) (a b : Fin D) :
-    (∑ r : Fin r[U], star (S.Y₁ r (p, a)) * S.Y₁ r (q, b)) =
-      ∑ α : Fin D, ∑ α' : Fin D, ∑ j : Fin d,
-        star (U p j α a) * ρ α α' * U q j α' b := by
+    (∑ r : Fin r[U], star (S.Y₁ r (a, p)) * S.Y₁ r (b, q)) =
+      ∑ β : Fin D, ∑ β' : Fin D, ∑ i : Fin d,
+        star (U i p a β) * ρ β β' * U i q b β' := by
   have hgram : S.Y₁ᴴ * S.Y₁ =
       (sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
     calc
@@ -91,15 +123,23 @@ private theorem Y₁_gram_eq_weighted_sourceCutM₁_gram
           (S.X₁ * S.Y₁) := by
         simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
       _ = _ := by rw [← S.sourceCutM₁_eq]
-  have hentry := congrArg (fun M ↦ M (p, a) (q, b)) hgram
+  have hentry := congrArg (fun M ↦ M (a, p) (b, q)) hgram
   simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceWeight,
-    Matrix.kronecker_apply, Matrix.one_apply, mul_ite, mul_one, mul_zero,
-    Finset.sum_ite_eq', Finset.mem_univ, ite_true, sourceCutM₁_apply,
-    Fintype.sum_prod_type] at hentry
-  simp_rw [Finset.sum_mul] at hentry
-  conv_rhs at hentry => arg 2; ext j; rw [Finset.sum_comm]
-  rw [Finset.sum_comm] at hentry
-  exact hentry
+    Matrix.kronecker_apply, sourceCutM₁_apply, Fintype.sum_prod_type] at hentry
+  conv_rhs at hentry =>
+    simp [Matrix.one_apply]
+    arg 2
+    ext i
+    arg 2
+    ext β'
+    rw [Finset.sum_mul]
+  calc
+    (∑ r : Fin r[U], star (S.Y₁ r (a, p)) * S.Y₁ r (b, q)) =
+        ∑ i : Fin d, ∑ β' : Fin D, ∑ β : Fin D,
+          star (U i p a β) * ρ β β' * U i q b β' := hentry
+    _ = ∑ β : Fin D, ∑ β' : Fin D, ∑ i : Fin d,
+          star (U i p a β) * ρ β β' * U i q b β' := by
+      rw [sum_rotate_three]
 
 private theorem Y₂_gram_eq_rotated_sourceCutM₂_gram
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
@@ -129,17 +169,17 @@ private theorem sourceYTensor_gram_eq_four_u_weighted
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (p q : Fin d × Fin d) (a b : Fin D × Fin D) :
     (∑ t : Fin r[U] × Fin ℓ[U],
-      star (sourceYTensor U S t ((p.1, a.1), (p.2, a.2))) *
-        sourceYTensor U S t ((q.1, b.1), (q.2, b.2))) =
-      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D,
+      star (sourceYTensor U S t ((a.1, p.1), (p.2, a.2))) *
+        sourceYTensor U S t ((b.1, q.1), (q.2, b.2))) =
+      ∑ β : Fin D, ∑ β' : Fin D, ∑ γ : Fin D,
       ∑ j₁ : Fin d, ∑ j₂ : Fin d,
-        star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1 *
-          (star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+        star (U j₁ p.1 a.1 β) * ρ β β' * U j₁ q.1 b.1 β' *
+          (star (U j₂ p.2 γ a.2) * U j₂ q.2 γ b.2) := by
   rw [Fintype.sum_prod_type]
   simp only [sourceYTensor_apply, star_mul]
   calc
-    _ = (∑ r : Fin r[U], star (S.Y₁ r (p.1, a.1)) *
-          S.Y₁ r (q.1, b.1)) *
+    _ = (∑ r : Fin r[U], star (S.Y₁ r (a.1, p.1)) *
+          S.Y₁ r (b.1, q.1)) *
         (∑ l : Fin ℓ[U], star (S.Y₂ l (p.2, a.2)) *
           S.Y₂ l (q.2, b.2)) := by
       simp_rw [Finset.sum_mul_sum]
@@ -148,15 +188,15 @@ private theorem sourceYTensor_gram_eq_four_u_weighted
       apply Finset.sum_congr rfl
       intro l _
       ring
-    _ = (∑ α : Fin D, ∑ α' : Fin D, ∑ j₁ : Fin d,
-          star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1) *
-        (∑ β : Fin D, ∑ j₂ : Fin d,
-          star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+    _ = (∑ β : Fin D, ∑ β' : Fin D, ∑ j₁ : Fin d,
+          star (U j₁ p.1 a.1 β) * ρ β β' * U j₁ q.1 b.1 β') *
+        (∑ γ : Fin D, ∑ j₂ : Fin d,
+          star (U j₂ p.2 γ a.2) * U j₂ q.2 γ b.2) := by
       rw [Y₁_gram_eq_weighted_sourceCutM₁_gram,
         Y₂_gram_eq_rotated_sourceCutM₂_gram]
     _ = _ := by
       simp_rw [Finset.sum_mul, Finset.mul_sum]
-      conv_lhs => arg 2; ext α; arg 2; ext α'; rw [Finset.sum_comm]
+      conv_lhs => arg 2; ext β; arg 2; ext β'; rw [Finset.sum_comm]
 
 /-- The Gram matrix of the corrected paper gate \(u=Y_2\mathbin{-}Y_1\) is
 the literal staggered reflected--direct four-\(\mathcal U\) network.  The pair
@@ -172,47 +212,54 @@ theorem sourceU_gram_eq_staggered_four_u
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (p q : Fin d × Fin d) :
     (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
-      ∑ β : Fin D, ∑ β' : Fin D, ∑ α : Fin D, ∑ α' : Fin D,
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D, ∑ β' : Fin D,
       ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
-        star (U p.2 j₁ α β) * ρ α α' * U q.2 j₁ α' β' *
-          (star (U j₂ p.1 γ β) * U j₂ q.1 γ β') := by
+        star (U j₁ p.2 α β) * ρ β β' * U j₁ q.2 α' β' *
+          (star (U j₂ p.1 γ α) * U j₂ q.1 γ α') := by
   classical
   rcases p with ⟨p₁, p₂⟩
   rcases q with ⟨q₁, q₂⟩
   rw [Fintype.sum_prod_type]
   simp_rw [sourceU_eq_diagonal_sourceYTensor, star_sum]
   simp_rw [Finset.sum_mul_sum]
-  let f := fun (l : Fin ℓ[U]) (r : Fin r[U]) (β β' : Fin D) ↦
-    sourceYTensor U S (r, l) ((q₂, β), (q₁, β)) *
-      star (sourceYTensor U S (r, l) ((p₂, β'), (p₁, β')))
-  change (∑ l, ∑ r, ∑ β, ∑ β', f l r β β') = _
+  let f := fun (l : Fin ℓ[U]) (r : Fin r[U]) (α' α : Fin D) ↦
+    sourceYTensor U S (r, l) ((α', q₂), (q₁, α')) *
+      star (sourceYTensor U S (r, l) ((α, p₂), (p₁, α)))
+  change (∑ l, ∑ r, ∑ α', ∑ α, f l r α' α) = _
   calc
-    _ = ∑ β, ∑ β', ∑ r, ∑ l,
-        star (sourceYTensor U S (r, l) ((p₂, β'), (p₁, β'))) *
-          sourceYTensor U S (r, l) ((q₂, β), (q₁, β)) := by
-      rw [sum_rotate_four]
+    _ = ∑ α, ∑ α', ∑ l, ∑ r,
+        star (sourceYTensor U S (r, l) ((α, p₂), (p₁, α))) *
+          sourceYTensor U S (r, l) ((α', q₂), (q₁, α')) := by
+      rw [sum_rotate_four_last_first]
       apply Finset.sum_congr rfl
-      intro β _
+      intro α _
       apply Finset.sum_congr rfl
-      intro β' _
-      apply Finset.sum_congr rfl
-      intro r _
+      intro α' _
       apply Finset.sum_congr rfl
       intro l _
+      apply Finset.sum_congr rfl
+      intro r _
       simp only [f]
       ring
-    _ = ∑ β, ∑ β', ∑ α, ∑ α', ∑ γ, ∑ j₁, ∑ j₂,
-        star (U p₂ j₁ α β') * ρ α α' * U q₂ j₁ α' β *
-          (star (U j₂ p₁ γ β') * U j₂ q₁ γ β) := by
+    _ = ∑ α, ∑ α', ∑ r, ∑ l,
+        star (sourceYTensor U S (r, l) ((α, p₂), (p₁, α))) *
+          sourceYTensor U S (r, l) ((α', q₂), (q₁, α')) := by
       apply Finset.sum_congr rfl
-      intro β _
+      intro α _
       apply Finset.sum_congr rfl
-      intro β' _
-      rw [← sourceYTensor_gram_eq_four_u_weighted U S
-        (p₂, p₁) (q₂, q₁) (β', β') (β, β),
-        Fintype.sum_prod_type]
-    _ = _ := by
+      intro α' _
       rw [Finset.sum_comm]
+    _ = ∑ α, ∑ α', ∑ β, ∑ β', ∑ γ, ∑ j₁, ∑ j₂,
+        star (U j₁ p₂ α β) * ρ β β' * U j₁ q₂ α' β' *
+          (star (U j₂ p₁ γ α) * U j₂ q₁ γ α') := by
+      apply Finset.sum_congr rfl
+      intro α _
+      apply Finset.sum_congr rfl
+      intro α' _
+      rw [← sourceYTensor_gram_eq_four_u_weighted U S
+        (p₂, p₁) (q₂, q₁) (α, α) (α', α'),
+        Fintype.sum_prod_type]
+    _ = _ := rfl
 
 end SourceFactors
 

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -48,13 +48,13 @@ namespace SourceFactors
 paper's dotted/solid source-bond order `(r,l)`.
 
 Source: CPSV17 equations `uu` and `uUnitary` (lines 532--557). -/
-noncomputable def sourceYTensor {ρ : Matrix (Fin D) (Fin D) ℂ}
+private noncomputable def sourceYTensor {ρ : Matrix (Fin D) (Fin D) ℂ}
     (S : SourceFactors U ρ) :
     Matrix (Fin r[U] × Fin ℓ[U])
       ((Fin d × Fin D) × (Fin d × Fin D)) ℂ :=
   S.Y₁ ⊗ₖ S.Y₂
 
-@[simp] theorem sourceYTensor_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+@[simp] private theorem sourceYTensor_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
     (S : SourceFactors U ρ) (r : Fin r[U]) (l : Fin ℓ[U])
     (x₁ x₂ : Fin d × Fin D) :
     sourceYTensor U S (r, l) (x₁, x₂) = S.Y₁ r x₁ * S.Y₂ l x₂ := rfl
@@ -64,7 +64,7 @@ contraction of `sourceYTensor`, with the physical and source-bond orders
 displayed explicitly.
 
 Source: CPSV17 equation `uu` and Figure `II_umatrix.png` (lines 532--543). -/
-theorem sourceU_eq_diagonal_sourceYTensor
+private theorem sourceU_eq_diagonal_sourceYTensor
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
     sourceU U S (l, r) (i₁, i₂) =
@@ -125,7 +125,7 @@ four local tensor entries.  The first cut retains the source weight, and the
 second cut uses only the column-isometry normalization of \(X_2\).
 
 Source: CPSV17 equations `X1X2b` and `uUnitary` (lines 487--557). -/
-theorem sourceYTensor_gram_eq_four_u_weighted
+private theorem sourceYTensor_gram_eq_four_u_weighted
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (p q : Fin d × Fin d) (a b : Fin D × Fin D) :
     (∑ t : Fin r[U] × Fin ℓ[U],

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -71,7 +71,7 @@ theorem sourceU_eq_diagonal_sourceYTensor
       ∑ β : Fin D, sourceYTensor U S (r, l) ((i₂, β), (i₁, β)) := by
   apply Finset.sum_congr rfl
   intro β _
-  simp only [sourceU_apply, sourceYTensor_apply]
+  simp only [sourceYTensor_apply]
   ring
 
 private theorem Y₁_gram_eq_weighted_sourceCutM₁_gram
@@ -116,8 +116,8 @@ private theorem Y₂_gram_eq_rotated_sourceCutM₂_gram
         simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
       _ = _ := by rw [← S.sourceCutM₂_eq]
   have hentry := congrArg (fun M ↦ M (p, a) (q, b)) hgram
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceCutM₂_apply]
-    at hentry
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    Fintype.sum_prod_type, sourceCutM₂_apply] at hentry
   exact hentry
 
 /-- Complete expansion of the supplied \(Y_1\otimes Y_2\) Gram entry into
@@ -177,17 +177,19 @@ theorem sourceU_gram_eq_staggered_four_u
         star (U p.2 j₁ α β) * ρ α α' * U q.2 j₁ α' β' *
           (star (U j₂ p.1 γ β) * U j₂ q.1 γ β') := by
   classical
+  rcases p with ⟨p₁, p₂⟩
+  rcases q with ⟨q₁, q₂⟩
   rw [Fintype.sum_prod_type]
   simp_rw [sourceU_eq_diagonal_sourceYTensor, star_sum]
   simp_rw [Finset.sum_mul_sum]
   let f := fun (l : Fin ℓ[U]) (r : Fin r[U]) (β β' : Fin D) ↦
-    sourceYTensor U S (r, l) ((q.2, β), (q.1, β)) *
-      star (sourceYTensor U S (r, l) ((p.2, β'), (p.1, β')))
+    sourceYTensor U S (r, l) ((q₂, β), (q₁, β)) *
+      star (sourceYTensor U S (r, l) ((p₂, β'), (p₁, β')))
   change (∑ l, ∑ r, ∑ β, ∑ β', f l r β β') = _
   calc
     _ = ∑ β, ∑ β', ∑ r, ∑ l,
-        star (sourceYTensor U S (r, l) ((p.2, β'), (p.1, β'))) *
-          sourceYTensor U S (r, l) ((q.2, β), (q.1, β)) := by
+        star (sourceYTensor U S (r, l) ((p₂, β'), (p₁, β'))) *
+          sourceYTensor U S (r, l) ((q₂, β), (q₁, β)) := by
       rw [sum_rotate_four]
       apply Finset.sum_congr rfl
       intro β _
@@ -200,14 +202,15 @@ theorem sourceU_gram_eq_staggered_four_u
       simp only [f]
       ring
     _ = ∑ β, ∑ β', ∑ α, ∑ α', ∑ γ, ∑ j₁, ∑ j₂,
-        star (U p.2 j₁ α β') * ρ α α' * U q.2 j₁ α' β *
-          (star (U j₂ p.1 γ β') * U j₂ q.1 γ β) := by
+        star (U p₂ j₁ α β') * ρ α α' * U q₂ j₁ α' β *
+          (star (U j₂ p₁ γ β') * U j₂ q₁ γ β) := by
       apply Finset.sum_congr rfl
       intro β _
       apply Finset.sum_congr rfl
       intro β' _
-      simpa using sourceYTensor_gram_eq_four_u_weighted U S
-        (p.2, p.1) (q.2, q.1) (β', β') (β, β)
+      rw [← sourceYTensor_gram_eq_four_u_weighted U S
+        (p₂, p₁) (q₂, q₁) (β', β') (β, β),
+        Fintype.sum_prod_type]
     _ = _ := by
       rw [Finset.sum_comm]
 

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -1,0 +1,262 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.SourceVIsometry
+
+/-!
+# The complete network for the paper source gate u
+
+This file follows the contraction in CPSV17 Lemma `lemuisometry`.  The source
+gate is the staggered contraction \(u=Y_2\mathbin{-}Y_1\).  Its Gram matrix is
+first expanded into the literal reflected--direct four-tensor network in
+Figure `II_uUnitary.png`; the retained physical legs are not included in the
+simple interior block.
+
+Source: arXiv:1703.09188, equations `X1X2b`, `uu`, and `uUnitary`, and Lemma
+`lemuisometry` (lines 487--557).
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+private lemma sum_rotate_four {A B C P R : Type*}
+    [Fintype A] [Fintype B] [Fintype C] [Fintype P] [AddCommMonoid R]
+    (f : A → B → C → P → R) :
+    (∑ a, ∑ b, ∑ c, ∑ p, f a b c p) =
+      ∑ c, ∑ p, ∑ b, ∑ a, f a b c p := by
+  let e : (((A × B) × C) × P) ≃ (((C × P) × B) × A) :=
+    { toFun := fun x ↦ (((x.1.2, x.2), x.1.1.2), x.1.1.1)
+      invFun := fun x ↦ (((x.2, x.1.2), x.1.1.1), x.1.1.2)
+      left_inv := by rintro ⟨⟨⟨a, b⟩, c⟩, p⟩; rfl
+      right_inv := by rintro ⟨⟨⟨c, p⟩, b⟩, a⟩; rfl }
+  have h := Fintype.sum_equiv e
+    (fun x ↦ f x.1.1.1 x.1.1.2 x.1.2 x.2)
+    (fun x ↦ f x.2 x.1.2 x.1.1.1 x.1.1.2)
+    (fun _ ↦ rfl)
+  simpa only [Fintype.sum_prod_type] using h
+
+namespace SourceFactors
+
+/-- The tensor product \(Y_1\otimes Y_2\) for supplied source factors, in the
+paper's dotted/solid source-bond order `(r,l)`.
+
+Source: CPSV17 equations `uu` and `uUnitary` (lines 532--557). -/
+noncomputable def sourceYTensor {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) :
+    Matrix (Fin r[U] × Fin ℓ[U])
+      ((Fin d × Fin D) × (Fin d × Fin D)) ℂ :=
+  S.Y₁ ⊗ₖ S.Y₂
+
+@[simp] theorem sourceYTensor_apply {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (S : SourceFactors U ρ) (r : Fin r[U]) (l : Fin ℓ[U])
+    (x₁ x₂ : Fin d × Fin D) :
+    sourceYTensor U S (r, l) (x₁, x₂) = S.Y₁ r x₁ * S.Y₂ l x₂ := rfl
+
+/-- The paper gate \(u=Y_2\mathbin{-}Y_1\) is the diagonal virtual
+contraction of `sourceYTensor`, with the physical and source-bond orders
+displayed explicitly.
+
+Source: CPSV17 equation `uu` and Figure `II_umatrix.png` (lines 532--543). -/
+theorem sourceU_eq_diagonal_sourceYTensor
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
+    sourceU U S (l, r) (i₁, i₂) =
+      ∑ β : Fin D, sourceYTensor U S (r, l) ((i₂, β), (i₁, β)) := by
+  apply Finset.sum_congr rfl
+  intro β _
+  simp only [sourceU_apply, sourceYTensor_apply]
+  ring
+
+private theorem Y₁_gram_eq_weighted_sourceCutM₁_gram
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (p q : Fin d) (a b : Fin D) :
+    (∑ r : Fin r[U], star (S.Y₁ r (p, a)) * S.Y₁ r (q, b)) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ j : Fin d,
+        star (U p j α a) * ρ α α' * U q j α' b := by
+  have hgram : S.Y₁ᴴ * S.Y₁ =
+      (sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
+    calc
+      S.Y₁ᴴ * S.Y₁ =
+          S.Y₁ᴴ * (S.X₁ᴴ * sourceWeight (d := d) ρ * S.X₁) * S.Y₁ := by
+        rw [S.X₁_weighted_isometry]
+        simp
+      _ = (S.X₁ * S.Y₁)ᴴ * sourceWeight (d := d) ρ *
+          (S.X₁ * S.Y₁) := by
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      _ = _ := by rw [← S.sourceCutM₁_eq]
+  have hentry := congrArg (fun M ↦ M (p, a) (q, b)) hgram
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceWeight,
+    Matrix.kronecker_apply, Matrix.one_apply, mul_ite, mul_one, mul_zero,
+    Finset.sum_ite_eq', Finset.mem_univ, ite_true, sourceCutM₁_apply,
+    Fintype.sum_prod_type] at hentry
+  simp_rw [Finset.sum_mul] at hentry
+  conv_rhs at hentry => arg 2; ext j; rw [Finset.sum_comm]
+  rw [Finset.sum_comm] at hentry
+  exact hentry
+
+private theorem Y₂_gram_eq_rotated_sourceCutM₂_gram
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (p q : Fin d) (a b : Fin D) :
+    (∑ l : Fin ℓ[U], star (S.Y₂ l (p, a)) * S.Y₂ l (q, b)) =
+      ∑ β : Fin D, ∑ j : Fin d,
+        star (U j p β a) * U j q β b := by
+  have hgram : S.Y₂ᴴ * S.Y₂ = (sourceCutM₂ U)ᴴ * sourceCutM₂ U := by
+    calc
+      S.Y₂ᴴ * S.Y₂ = S.Y₂ᴴ * (S.X₂ᴴ * S.X₂) * S.Y₂ := by
+        rw [show S.X₂ᴴ * S.X₂ = 1 by exact S.X₂_isometry]
+        simp
+      _ = (S.X₂ * S.Y₂)ᴴ * (S.X₂ * S.Y₂) := by
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      _ = _ := by rw [← S.sourceCutM₂_eq]
+  have hentry := congrArg (fun M ↦ M (p, a) (q, b)) hgram
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceCutM₂_apply]
+    at hentry
+  exact hentry
+
+/-- Complete expansion of the supplied \(Y_1\otimes Y_2\) Gram entry into
+four local tensor entries.  The first cut retains the source weight, and the
+second cut uses only the column-isometry normalization of \(X_2\).
+
+Source: CPSV17 equations `X1X2b` and `uUnitary` (lines 487--557). -/
+theorem sourceYTensor_gram_eq_four_u_weighted
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (p q : Fin d × Fin d) (a b : Fin D × Fin D) :
+    (∑ t : Fin r[U] × Fin ℓ[U],
+      star (sourceYTensor U S t ((p.1, a.1), (p.2, a.2))) *
+        sourceYTensor U S t ((q.1, b.1), (q.2, b.2))) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D,
+      ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1 *
+          (star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+  rw [Fintype.sum_prod_type]
+  simp only [sourceYTensor_apply, star_mul]
+  calc
+    _ = (∑ r : Fin r[U], star (S.Y₁ r (p.1, a.1)) *
+          S.Y₁ r (q.1, b.1)) *
+        (∑ l : Fin ℓ[U], star (S.Y₂ l (p.2, a.2)) *
+          S.Y₂ l (q.2, b.2)) := by
+      simp_rw [Finset.sum_mul_sum]
+      apply Finset.sum_congr rfl
+      intro r _
+      apply Finset.sum_congr rfl
+      intro l _
+      ring
+    _ = (∑ α : Fin D, ∑ α' : Fin D, ∑ j₁ : Fin d,
+          star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1) *
+        (∑ β : Fin D, ∑ j₂ : Fin d,
+          star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+      rw [Y₁_gram_eq_weighted_sourceCutM₁_gram,
+        Y₂_gram_eq_rotated_sourceCutM₂_gram]
+    _ = _ := by
+      simp_rw [Finset.sum_mul, Finset.mul_sum]
+      conv_lhs => arg 2; ext α; arg 2; ext α'; rw [Finset.sum_comm]
+
+/-- The Gram matrix of the corrected paper gate \(u=Y_2\mathbin{-}Y_1\) is
+the literal staggered reflected--direct four-\(\mathcal U\) network.  The pair
+`p` is starred and `q` is unstarred.
+
+The first retained physical coordinate belongs to the direct input layer;
+the second belongs to the reflected output layer.  No mixed \(Y_1\)--\(X_2\)
+kernel or ambient source-factor coisometry is used.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem sourceU_gram_eq_staggered_four_u
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      ∑ β : Fin D, ∑ β' : Fin D, ∑ α : Fin D, ∑ α' : Fin D,
+      ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U p.2 j₁ α β) * ρ α α' * U q.2 j₁ α' β' *
+          (star (U j₂ p.1 γ β) * U j₂ q.1 γ β') := by
+  classical
+  rw [Fintype.sum_prod_type]
+  simp_rw [sourceU_eq_diagonal_sourceYTensor, star_sum]
+  simp_rw [Finset.sum_mul_sum]
+  let f := fun (l : Fin ℓ[U]) (r : Fin r[U]) (β β' : Fin D) ↦
+    sourceYTensor U S (r, l) ((q.2, β), (q.1, β)) *
+      star (sourceYTensor U S (r, l) ((p.2, β'), (p.1, β')))
+  change (∑ l, ∑ r, ∑ β, ∑ β', f l r β β') = _
+  calc
+    _ = ∑ β, ∑ β', ∑ r, ∑ l,
+        star (sourceYTensor U S (r, l) ((p.2, β'), (p.1, β'))) *
+          sourceYTensor U S (r, l) ((q.2, β), (q.1, β)) := by
+      rw [sum_rotate_four]
+      apply Finset.sum_congr rfl
+      intro β _
+      apply Finset.sum_congr rfl
+      intro β' _
+      apply Finset.sum_congr rfl
+      intro r _
+      apply Finset.sum_congr rfl
+      intro l _
+      simp only [f]
+      ring
+    _ = ∑ β, ∑ β', ∑ α, ∑ α', ∑ γ, ∑ j₁, ∑ j₂,
+        star (U p.2 j₁ α β') * ρ α α' * U q.2 j₁ α' β *
+          (star (U j₂ p.1 γ β') * U j₂ q.1 γ β) := by
+      apply Finset.sum_congr rfl
+      intro β _
+      apply Finset.sum_congr rfl
+      intro β' _
+      simpa using sourceYTensor_gram_eq_four_u_weighted U S
+        (p.2, p.1) (q.2, q.1) (β', β') (β, β)
+    _ = _ := by
+      rw [Finset.sum_comm]
+
+end SourceFactors
+
+/-- The normalized input-tail contraction is the closed direct double-layer
+network with two retained input letters followed by the (K)-site interior.
+The retained pair `p` is starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem normalized_mpo_input_tail_eq_closed_doubleLayer_trace
+    [NeZero d] (U : MPOTensor d D) (K : ℕ) (p q : Fin d × Fin d) :
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  classical
+  let W := doubleLayerTensor U
+  have hη (σ τ : Fin (K + 2) → Fin d) :
+      (∑ η : Fin (K + 2) → Fin d,
+        star (mpo U (K + 2) η σ) * mpo U (K + 2) η τ) =
+        mpo W (K + 2) σ τ := by
+    have h := congrArg (fun M ↦ M σ τ) (mpo_doubleLayerTensor U (K + 2))
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at h
+    exact h.symm
+  simp_rw [hη]
+  have hword (τ : Fin K → Fin d) :
+      mpo W (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))
+          ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
+        Matrix.trace (W p.1 q.1 * W p.2 q.2 *
+          evalWord W (List.ofFn τ) (List.ofFn τ)) := by
+    rw [mpo_apply, mpoMatrixEntry]
+    simp only [finAddTwoArrowEquiv_symm_apply, List.ofFn_succ, evalWord_cons,
+      Fin.cons_zero, Fin.cons_succ]
+    rw [← Matrix.mul_assoc]
+  simp_rw [hword]
+  change ((d : ℂ)⁻¹) ^ K *
+      ∑ τ : Fin K → Fin d,
+        Matrix.trace (W p.1 q.1 * W p.2 q.2 *
+          evalWord W (List.ofFn τ) (List.ofFn τ)) =
+    Matrix.trace (W p.1 q.1 * W p.2 q.2 * normalizedDiagonal W ^ K)
+  rw [normalizedDiagonal_pow_eq_sum_evalWord W K]
+  simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul,
+    Matrix.mul_sum, Matrix.trace_sum]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3067,10 +3067,27 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{thm:mpu_closed_double_layer, thm:mpu_normalized_diagonal_word_expansion}
-    Close the common output word as the periodic MPO of the double layer.
-    Splitting off the two retained input sites leaves a common diagonal word
-    of length $K$. Expanding the normalized diagonal power as the normalized
-    sum of these words and using linearity of the trace gives the result.
+    Closing the common output word gives the double-layer identity
+    \begin{align}
+        \sum_\eta
+        \overline{U^{(K+2)}_{\eta,\sigma}}
+        U^{(K+2)}_{\eta,\sigma'}
+         & =W^{(K+2)}_{\sigma,\sigma'}.
+    \end{align}
+    Set $\sigma=(p,\tau)$ and $\sigma'=(q,\tau)$. Splitting off the two
+    retained sites rewrites the right-hand side as
+    \begin{align}
+        \tr\!\left[
+        W^{p_1q_1}W^{p_2q_2}
+        W^{\tau_1\tau_1}\cdots W^{\tau_K\tau_K}\right].
+    \end{align}
+    Finally,
+    \begin{align}
+        E^K
+         & =d^{-K}\sum_\tau
+        W^{\tau_1\tau_1}\cdots W^{\tau_K\tau_K}.
+    \end{align}
+    Substitute this expansion and use linearity of the trace.
 \end{proof}
 
 \begin{theorem}[Second-cut metric factorization]
@@ -4929,13 +4946,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $q=(q_1,q_2)$, one has
     \begin{align}
         \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
-        ={} & \sum_{\beta,\beta',\alpha,\alpha',\gamma,j_1,j_2}
-        \overline{\mathcal U^{p_2}_{j_1,\alpha,\beta}}
-        \rho_{\alpha,\alpha'}
-        \mathcal U^{q_2}_{j_1,\alpha',\beta'} \notag            \\
+        ={} & \sum_{\alpha,\alpha',\beta,\beta',\gamma,j_1,j_2}
+        \overline{\mathcal U^{j_1}_{p_2,\alpha,\beta}}
+        \rho_{\beta,\beta'}
+        \mathcal U^{j_1}_{q_2,\alpha',\beta'} \notag            \\
             & \qquad\qquad\cdot
-        \overline{\mathcal U^{j_2}_{p_1,\gamma,\beta}}
-        \mathcal U^{j_2}_{q_1,\gamma,\beta'}.
+        \overline{\mathcal U^{j_2}_{p_1,\gamma,\alpha}}
+        \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
     \end{align}
     The $p$ entries are starred and the $q$ entries are unstarred. This is
     precisely the staggered reflected--direct four-tensor expression obtained
@@ -4945,10 +4962,28 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}\leanok
     \uses{def:mpu_source_uv, thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
-    Expand the two copies of $u$ using their common virtual indices. The
-    $Y_1$ Gram contraction is the first source cut with the weight $\rho$,
-    and the rotated $Y_2$ Gram contraction is the second source cut. Expanding
-    both source matrices and reordering the finite sums gives the formula.
+    Since the first cut has rows $(i,\beta)$ and columns $(\alpha,j)$,
+    its weighted normalization gives
+    \begin{align}
+        \sum_r\overline{(Y_1)_{r,(\alpha,p_2)}}
+        (Y_1)_{r,(\alpha',q_2)}
+         & =\sum_{\beta,\beta',j_1}
+        \overline{\mathcal U^{j_1}_{p_2,\alpha,\beta}}
+        \rho_{\beta,\beta'}
+        \mathcal U^{j_1}_{q_2,\alpha',\beta'}.
+    \end{align}
+    The unweighted normalization of the second cut gives
+    \begin{align}
+        \sum_l\overline{(Y_2)_{l,(p_1,\alpha)}}
+        (Y_2)_{l,(q_1,\alpha')}
+         & =\sum_{\gamma,j_2}
+        \overline{\mathcal U^{j_2}_{p_1,\gamma,\alpha}}
+        \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
+    \end{align}
+    Expand both copies of
+    $u_{(l,r),(i_1,i_2)}=\sum_\alpha
+    (Y_2)_{l,(i_1,\alpha)}(Y_1)_{r,(\alpha,i_2)}$ and substitute these two
+    Gram identities. Reordering the finite sums yields the stated formula.
 \end{proof}
 
 \begin{theorem}[Complete source-$u$ network contraction]
@@ -8405,7 +8440,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     factors of the right shift,
     \begin{align}
         u_{(0,(a,b)),(i_1,i_2)}
-         & =\delta_{a,i_2}\delta_{b,i_1}.
+         & =\delta_{a,i_1}\delta_{b,i_2}.
     \end{align}
     Hence
     \begin{align}
@@ -8420,10 +8455,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}\leanok
     \uses{def:mpu_right_shift_paper_source_factors, def:mpu_source_uv}
-    Substitute the right-shift entries into $u=Y_2\mathbin{-}Y_1$. The two
-    virtual sums impose $a=i_2$ and $b=i_1$, while the two factors of
-    $d^{-1/2}$ cancel the remaining factor $d$. The resulting permutation
-    matrix has identity Gram matrix.
+    For the identity-weight factors, direct substitution in
+    $u=Y_2\mathbin{-}Y_1$ gives
+    \begin{align}
+        u^{(0)}_{(0,(a,b)),(i_1,i_2)}
+         & =d^{1/2}\delta_{a,i_1}\delta_{b,i_2}.
+    \end{align}
+    The trace-normalized first cut replaces $Y_1$ by $d^{-1/2}Y_1$ and leaves
+    $Y_2$ unchanged. Therefore
+    \begin{align}
+        u_{(0,(a,b)),(i_1,i_2)}
+         & =d^{-1/2}u^{(0)}_{(0,(a,b)),(i_1,i_2)}
+          =\delta_{a,i_1}\delta_{b,i_2}.
+    \end{align}
+    Summing the product of two such entries over $(a,b)$ gives
+    $\delta_{p,q}$, which is the entrywise identity $u^\dagger u=\Id$.
 \end{proof}
 
 \begin{theorem}[Local physical-species swap for the shift MPUs]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3050,7 +3050,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_normalized_input_tail_closed_trace}
     \lean{MPOTensor.normalized_mpo_input_tail_eq_closed_doubleLayer_trace}
     \leanok
-    \uses{def:mpo_family, def:mpu_double_layer, thm:mpu_normalized_diagonal_word_expansion}
+    \uses{def:mpo_family, def:mpu_double_layer}
     Assume $d>0$. For any MPO tensor $\mathcal U$, tail length $K$, and
     $p,q\in\Fin d\times\Fin d$, let $W$ be its double layer and let
     $E=d^{-1}\sum_i W^{ii}$ be the normalized physical diagonal. Then
@@ -4923,7 +4923,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_source_u_staggered_gram}
     \lean{MPOTensor.SourceFactors.sourceU_gram_eq_staggered_four_u}
     \leanok
-    \uses{def:mpu_source_uv, thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
+    \uses{def:mpu_source_uv, def:mpu_weighted_source_factors}
     Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
     the weight $\rho$. For retained physical pairs $p=(p_1,p_2)$ and
     $q=(q_1,q_2)$, one has
@@ -4955,8 +4955,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_source_u_complete_network}
     \notready
     \discussion{5982}
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family,
-        thm:mpu_source_u_staggered_gram, thm:mpu_normalized_input_tail_closed_trace}
+    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family}
     % Revalidation boundary: docs/paper-gaps/mpu_source_cut_orientation.tex.
     Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
     dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3078,8 +3078,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     retained sites rewrites the right-hand side as
     \begin{align}
         \tr\!\left[
-        W^{p_1q_1}W^{p_2q_2}
-        W^{\tau_1\tau_1}\cdots W^{\tau_K\tau_K}\right].
+            W^{p_1q_1}W^{p_2q_2}
+            W^{\tau_1\tau_1}\cdots W^{\tau_K\tau_K}\right].
     \end{align}
     Finally,
     \begin{align}
@@ -4982,7 +4982,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Expand both copies of
     $u_{(l,r),(i_1,i_2)}=\sum_\alpha
-    (Y_2)_{l,(i_1,\alpha)}(Y_1)_{r,(\alpha,i_2)}$ and substitute these two
+        (Y_2)_{l,(i_1,\alpha)}(Y_1)_{r,(\alpha,i_2)}$ and substitute these two
     Gram identities. Reordering the finite sums yields the stated formula.
 \end{proof}
 
@@ -8466,7 +8466,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         u_{(0,(a,b)),(i_1,i_2)}
          & =d^{-1/2}u^{(0)}_{(0,(a,b)),(i_1,i_2)}
-          =\delta_{a,i_1}\delta_{b,i_2}.
+        =\delta_{a,i_1}\delta_{b,i_2}.
     \end{align}
     Summing the product of two such entries over $(a,b)$ gives
     $\delta_{p,q}$, which is the entrywise identity $u^\dagger u=\Id$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3046,6 +3046,33 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     trace gives the displayed closed trace.
 \end{proof}
 
+\begin{theorem}[Closed double-layer trace for the normalized input tail]
+    \label{thm:mpu_normalized_input_tail_closed_trace}
+    \lean{MPOTensor.normalized_mpo_input_tail_eq_closed_doubleLayer_trace}
+    \leanok
+    \uses{def:mpo_family, def:mpu_double_layer, thm:mpu_normalized_diagonal_word_expansion}
+    Assume $d>0$. For any MPO tensor $\mathcal U$, tail length $K$, and
+    $p,q\in\Fin d\times\Fin d$, let $W$ be its double layer and let
+    $E=d^{-1}\sum_i W^{ii}$ be the normalized physical diagonal. Then
+    \begin{align}
+        d^{-K}\sum_{\tau,\eta}
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}
+        =\tr\!\left[W^{p_1q_1}W^{p_2q_2}E^K\right].
+    \end{align}
+    Thus $p$ labels the starred input and $q$ the unstarred input. This is
+    the closed input-tail expression occurring on the right-hand side of
+    \cite[equation~\texttt{uUnitary} and lines~550--556]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_closed_double_layer, thm:mpu_normalized_diagonal_word_expansion}
+    Close the common output word as the periodic MPO of the double layer.
+    Splitting off the two retained input sites leaves a common diagonal word
+    of length $K$. Expanding the normalized diagonal power as the normalized
+    sum of these words and using linearity of the trace gives the result.
+\end{proof}
+
 \begin{theorem}[Second-cut metric factorization]
     \label{thm:mpu_second_cut_metric}
     \lean{MPOTensor.sourceX₂_mul_conjTranspose_eq_sourceCutM₂_mul_secondCutMetric}
@@ -4892,11 +4919,44 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 269--280 and 397--405.
 \end{definition}
 
+\begin{theorem}[Staggered Gram expansion of the source tensor $u$]
+    \label{thm:mpu_source_u_staggered_gram}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_staggered_four_u}
+    \leanok
+    \uses{def:mpu_source_uv, thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
+    Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
+    the weight $\rho$. For retained physical pairs $p=(p_1,p_2)$ and
+    $q=(q_1,q_2)$, one has
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+        ={} & \sum_{\beta,\beta',\alpha,\alpha',\gamma,j_1,j_2}
+        \overline{\mathcal U^{p_2}_{j_1,\alpha,\beta}}
+        \rho_{\alpha,\alpha'}
+        \mathcal U^{q_2}_{j_1,\alpha',\beta'} \notag            \\
+            & \qquad\qquad\cdot
+        \overline{\mathcal U^{j_2}_{p_1,\gamma,\beta}}
+        \mathcal U^{j_2}_{q_1,\gamma,\beta'}.
+    \end{align}
+    The $p$ entries are starred and the $q$ entries are unstarred. This is
+    precisely the staggered reflected--direct four-tensor expression obtained
+    from $u=Y_2\mathbin{-}Y_1$ and the two identities in
+    \cite[equations~\texttt{X1X2b} and~\texttt{uUnitary}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_source_uv, thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
+    Expand the two copies of $u$ using their common virtual indices. The
+    $Y_1$ Gram contraction is the first source cut with the weight $\rho$,
+    and the rotated $Y_2$ Gram contraction is the second source cut. Expanding
+    both source matrices and reordering the finite sums gives the formula.
+\end{proof}
+
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
     \notready
     \discussion{5982}
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family}
+    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family,
+        thm:mpu_source_u_staggered_gram, thm:mpu_normalized_input_tail_closed_trace}
     % Revalidation boundary: docs/paper-gaps/mpu_source_cut_orientation.tex.
     Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
     dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
@@ -4911,8 +4971,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
          & =d^{-K}\sum_{\tau,\eta}
-        U^{(K+2)}_{(q,\tau),\eta}
-        \overline{U^{(K+2)}_{(p,\tau),\eta}}.
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}.
     \end{align}
     Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
     output words of length $K+2$. This is the supplied-fixed-pair form of the
@@ -4921,6 +4981,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
+    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_normalized_input_tail_closed_trace}
     Expand both external paper gates using
     $u=Y_2\mathbin{-}Y_1$, retaining the two $Y_2$--$Y_1$ triangles and their
     common virtual indices in the staggered order of
@@ -4929,10 +4990,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     to insert $E^J=\lvert\rho)(\Phi\rvert$ into that exact network and contract
     it directly to the displayed normalized $(K+2)$-site MPU sum.
 
-    This staggered $Y_2$--$Y_1$ network identity is not yet formalized. The
-    checked $Y_1$--$X_2$ mixed-kernel Gram, range-projection, reflected-transfer,
-    and terminal-boundary lemmas concern a different network and do not supply
-    any step of this proof.
+    The staggered four-tensor expansion and the normalized input-tail trace are
+    formalized separately. The missing step is their equality after inserting
+    the fixed pair into the exact retained-interior network of
+    Figure~\texttt{II\_uUnitary.png}. The checked $Y_1$--$X_2$ mixed-kernel
+    Gram, range-projection, reflected-transfer, and terminal-boundary lemmas
+    concern a different network and do not supply that contraction.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]
@@ -5022,14 +5085,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}
-    \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_output_tail_coisometry}
-    Set $K=JD^2$. The complete-network identity and output-first MPU unitarity
+    \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_input_tail_isometry}
+    Set $K=JD^2$. The complete-network identity and input-first MPU unitarity
     give, for all retained physical pairs $p,q$,
     \begin{align}
         (u^\dagger u)_{p,q}
          & =d^{-K}\sum_{\tau,\eta}
-        U^{(K+2)}_{(q,\tau),\eta}
-        \overline{U^{(K+2)}_{(p,\tau),\eta}} \\
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}  \\
          & =\delta_{p,q}.
     \end{align}
     Hence $u^\dagger u=\Id$.
@@ -8299,6 +8362,69 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \tr(\rho_d) & =d^{-1}\tr(\Id_d)=d^{-1}d=1.
     \end{align}
     Replacing $d$ by $d^2$ proves the product-space statements.
+\end{proof}
+
+\begin{definition}[Trace-normalized source factors for the right shift]
+    \label{def:mpu_right_shift_paper_source_factors}
+    \lean{MPOTensor.rightShiftPaperSourceFactors}
+    \leanok
+    \uses{def:mpu_shift_trace_weight, def:threeMPU_supplied_source_factors}
+    Assume $d>0$, and let $T$ be the right-shift tensor. Starting from the
+    displayed source factors for $T$ with identity weight, rescale the first
+    cut by
+    \begin{align}
+        X_1' & =\sqrt d\,X_1,
+             & Y_1'           & =d^{-1/2}Y_1,
+             & Z_1'           & =\sqrt d\,Z_1,
+    \end{align}
+    and leave $X_2,Y_2,Z_2$ unchanged. Then these are supplied source factors
+    for the trace-normalized scalar weight $\rho_d=d^{-1}\Id_d$ prescribed by
+    CFII. In particular,
+    \begin{align}
+        M_i & =X_i'Y_i',
+            & (X_1')^\dagger(\Id_d\otimes\rho_d)X_1' & =\Id,
+            & (X_2')^\dagger X_2'                    & =\Id,
+            & Y_i'Z_i'                               & =\Id.
+    \end{align}
+    This is the normalization of
+    \cite[equations~\texttt{Erightleft}, \texttt{X1X2b}, and
+        \texttt{YZ=1}]{Cirac2017MPU} for the right shift. This definition
+    concerns the source-factor metric; it does not assert a transfer
+    fixed-point equation.
+\end{definition}
+
+\begin{theorem}[The paper source tensor $u$ for the right shift]
+    \label{thm:mpu_right_shift_paper_source_u}
+    \lean{MPOTensor.sourceU_rightShiftPaperSourceFactors_apply,
+        MPOTensor.sourceU_rightShiftPaperSourceFactors_gram,
+        MPOTensor.sourceU_rightShiftPaperSourceFactors_isIsometry}
+    \leanok
+    \uses{def:mpu_right_shift_paper_source_factors, def:mpu_source_uv,
+        thm:mpu_shift_source_cuts_ranks}
+    Assume $d>0$. Identify the unique left source coordinate with $0$ and the
+    right source coordinate with $(a,b)$. For the trace-normalized source
+    factors of the right shift,
+    \begin{align}
+        u_{(0,(a,b)),(i_1,i_2)}
+         & =\delta_{a,i_2}\delta_{b,i_1}.
+    \end{align}
+    Hence
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\delta_{p,q},
+         & u^\dagger u    & =\Id.
+    \end{align}
+    This fixes the order and normalization of the two triangles in
+    \cite[equations~\texttt{uu} and~\texttt{uUnitary}]{Cirac2017MPU} for this
+    basic MPU.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_right_shift_paper_source_factors, def:mpu_source_uv}
+    Substitute the right-shift entries into $u=Y_2\mathbin{-}Y_1$. The two
+    virtual sums impose $a=i_2$ and $b=i_1$, while the two factors of
+    $d^{-1/2}$ cancel the remaining factor $d$. The resulting permutation
+    matrix has identity Gram matrix.
 \end{proof}
 
 \begin{theorem}[Local physical-species swap for the shift MPUs]

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -177,11 +177,13 @@ used to construct the factors and the operators $u$ and $v$.
 The explicit reduced-CFII and full-support hypotheses resolve the
 ambient-positivity question tracked by \ghissue{5855}. They do not prove the
 two complete network identities required for Theorem~III.8 of
-Ref.~\cite{Cirac2017MPU}. The source-$u$ range-insertion equality remains
-tracked by \ghissue{5982} and comes from Lemma~III.7 of
-Ref.~\cite{Cirac2017MPU}. The complete source-$v$ equivalence remains tracked
-by \ghissue{6071} and occurs in the proof of Theorem~III.8 of
-Ref.~\cite{Cirac2017MPU}.
+Ref.~\cite{Cirac2017MPU}. For the source tensor $u$, the staggered
+reflected--direct Gram expansion and the normalized input-tail trace are
+formalized separately. Their equality after inserting the simple $K$-site
+interior of Figure~\texttt{II\_uUnitary.png} remains tracked by
+\ghissue{5982} and comes from Lemma~III.7 of Ref.~\cite{Cirac2017MPU}. The
+complete source-$v$ equivalence remains tracked by \ghissue{6071} and occurs
+in the proof of Theorem~III.8 of Ref.~\cite{Cirac2017MPU}.
 % Source lines: paper_v2.tex 545--557 and 577--600.
 % Source equation labels: uUnitary and vUnitary.
 


### PR DESCRIPTION
## Summary

- rederive the CPSV17 source gate $u=Y_2\mathbin{-}Y_1$ after the merged first-source-cut correction in #7563;
- prove its staggered Gram expansion with $M_1$ rows $(i,\beta)$, source weight $I_d\otimes\rho$, and $\rho_{\beta,\beta'}$ on the right-virtual indices;
- identify the normalized input-tail contraction with the closed direct double-layer trace in the paper's $U^\dagger U$ orientation;
- give trace-normalized right-shift source factors and prove that the resulting source gate is the identity permutation, not the former transposed swap;
- synchronize Chapter 28 with formula-driven proofs while leaving the retained-interior contraction explicitly open.

## Source and scope

The source is CPSV17, `Papers/1703.09188/paper_v2.tex`, equations `X1X2b`, `uu`, and `uUnitary`, and Lemma `lemuisometry`, lines 479--557. The corrected derivation uses the exact leg order established by #7563:

- `sourceCutM₁` has row $(i,\beta)$ and column $(\alpha,j)$;
- `sourceWeight ρ = I_d ⊗ ρ`;
- `sourceU` contracts `Y₂ l (i₁,β)` with `Y₁ r (β,i₂)`;
- the right-shift specialization is $u_{(0,(a,b)),(i_1,i_2)}=\delta_{a,i_1}\delta_{b,i_2}$.

This remains a source-faithful partial checkpoint for #5982. It proves the staggered Gram and normalized input-tail endpoints. The missing equality inserts $E^J=|\rho)(\Phi|$ into the exact retained-interior network of Figure `II_uUnitary.png`. Therefore `thm:mpu_source_u_complete_network` remains `\notready`, and this PR advances but does not close #5982.

The right-shift construction asserts the trace-normalized source-factor metric. It does not claim a separate transfer fixed-point equation.

## Verification

- rebased onto `origin/main` `e7c3750b00cad53c3ebf62ae426a09fbeaf3a3fa`;
- rebase range-diff: all nine commits patch-identical to the repaired pre-FNW branch;
- full `lake build`: 10,472 jobs;
- generated import aggregators current: 37 aggregators covering 1,092 production modules;
- Blueprint--Lean synchronization: 7,431/7,431 entries;
- `leanblueprint checkdecls`;
- two direct LuaLaTeX passes, with no undefined cross-references;
- `git diff --check`;
- repaired Lean files contain no `sorry`, `admit`, `axiom`, `unsafeCast`, or `native_decide`.

Advances #5982; does not close it.
