### PR TITLE
feat(QCA): assemble commuting star-subalgebra products

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.CommutingProjectionProduct
+import TNLean.Algebra.CommutingStarSubalgebraProduct
 import TNLean.Algebra.ComplexSqrt
 import TNLean.Algebra.DirectedWalkCoboundary
 import TNLean.Algebra.EventuallyConstantCycleWeights

--- a/TNLean/Algebra/CommutingStarSubalgebraProduct.lean
+++ b/TNLean/Algebra/CommutingStarSubalgebraProduct.lean
@@ -41,11 +41,14 @@ simplicity. Consequently, the join is itself a full matrix algebra of the produc
 
 * B. Schumacher and R. F. Werner, *Reversible quantum cellular automata*,
   quant-ph/0405174, Proposition `Cscom`, lines 2119--2138.
-* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one dimensional quantum walks
+* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one-dimensional quantum walks
   and cellular automata*, arXiv:0910.3675v2, lines 1270--1314.
 
-The full-matrix theorem below is only the unital single-block specialization of `Cscom`. It does
-not assert the direct-sum multiplicity theorem or that the join fills the ambient algebra.
+**Scope restriction (full matrix, single block):** The full-matrix theorem below is only the
+unital single-block specialization of `Cscom`. It does not assert the direct-sum block-pair theorem,
+the multiplicity equation, or that the join fills the ambient algebra. This restriction and its
+elimination plan are documented in
+`docs/paper-gaps/gnvw12_cscom_single_block_scope.tex`.
 -/
 
 open scoped TensorProduct

--- a/TNLean/Algebra/CommutingStarSubalgebraProduct.lean
+++ b/TNLean/Algebra/CommutingStarSubalgebraProduct.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.Star.TensorProduct
+import Mathlib.Algebra.Star.Subalgebra
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.LinearAlgebra.Matrix.Reindex
+import Mathlib.LinearAlgebra.TensorProduct.Submodule
+import Mathlib.RingTheory.MatrixAlgebra
+import Mathlib.RingTheory.SimpleRing.Congr
+import Mathlib.RingTheory.SimpleRing.Matrix
+import QICLean.Algebra.SkolemNoetherUnitary
+
+/-!
+# Products of commuting star-subalgebras
+
+Two unital star-subalgebras of a common algebra which commute elementwise define a star-algebra
+homomorphism from their tensor product by multiplication. Its range is their algebraic join, and
+its underlying complex vector space is the span of products of elements from the two factors.
+
+When both factors are full matrix algebras of positive sizes, this homomorphism is injective by
+simplicity. Consequently, the join is itself a full matrix algebra of the product size.
+
+## Main definitions
+
+* `StarSubalgebra.commutingMulMap` maps a pure tensor to the product of its two factors.
+* `StarSubalgebra.commutingSupEquivMatrix` presents the join of two commuting full matrix factors.
+
+## Main results
+
+* `StarSubalgebra.commutingMulMap_range` identifies the range with the algebraic join.
+* `StarSubalgebra.sup_toSubmodule_eq_mul` identifies the join with the linear span of products.
+* `StarSubalgebra.commutingMulMap_injective_of_equiv_matrix` derives injectivity from full-matrix
+  presentations of the two factors.
+* `StarSubalgebra.finrank_sup_of_equiv_matrix` computes the complex dimension of the join.
+
+## References
+
+* B. Schumacher and R. F. Werner, *Reversible quantum cellular automata*,
+  quant-ph/0405174, Proposition `Cscom`, lines 2119--2138.
+* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one dimensional quantum walks
+  and cellular automata*, arXiv:0910.3675v2, lines 1270--1314.
+
+The full-matrix theorem below is only the unital single-block specialization of `Cscom`. It does
+not assert the direct-sum multiplicity theorem or that the join fills the ambient algebra.
+-/
+
+open scoped TensorProduct
+
+namespace StarSubalgebra
+
+variable {C : Type*} [Ring C] [Algebra ℂ C] [StarRing C] [StarModule ℂ C]
+
+/-- Multiplication from the tensor product of two elementwise commuting unital star-subalgebras
+into their common ambient algebra. -/
+noncomputable def commutingMulMap [Nontrivial C] (A B : StarSubalgebra ℂ C)
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : C) (b : C)) :
+    A ⊗[ℂ] B →⋆ₐ[ℂ] C where
+  toAlgHom := Algebra.TensorProduct.lift A.subtype.toAlgHom B.subtype.toAlgHom
+    (fun a b ↦ hAB a b)
+  map_star' x := by
+    change
+      Algebra.TensorProduct.lift A.subtype.toAlgHom B.subtype.toAlgHom
+          (fun a b ↦ hAB a b) (star x) =
+        star (Algebra.TensorProduct.lift A.subtype.toAlgHom B.subtype.toAlgHom
+          (fun a b ↦ hAB a b) x)
+    induction x with
+    | zero => simp
+    | tmul a b =>
+        change ((star a : A) : C) * ((star b : B) : C) =
+          star ((a : C) * (b : C))
+        rw [star_mul]
+        exact (hAB (star a) (star b)).eq
+    | add x y hx hy => simp only [star_add, map_add, hx, hy]
+
+/-- The commuting multiplication map sends a pure tensor to the ambient product. -/
+@[simp]
+theorem commutingMulMap_tmul (A B : StarSubalgebra ℂ C)
+    [Nontrivial C]
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : C) (b : C)) (a : A) (b : B) :
+    commutingMulMap A B hAB (a ⊗ₜ[ℂ] b) = (a : C) * (b : C) :=
+  rfl
+
+/-- The underlying linear map of commuting multiplication is the standard product map on the
+underlying submodules. -/
+theorem commutingMulMap_toLinearMap (A B : StarSubalgebra ℂ C)
+    [Nontrivial C]
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : C) (b : C)) :
+    (commutingMulMap A B hAB).toLinearMap =
+      Submodule.mulMap A.toSubmodule B.toSubmodule := by
+  apply TensorProduct.ext'
+  intro a b
+  rfl
+
+/-- The range of multiplication from two commuting unital star-subalgebras is their algebraic
+join. -/
+theorem commutingMulMap_range (A B : StarSubalgebra ℂ C)
+    [Nontrivial C]
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : C) (b : C)) :
+    StarAlgHom.range (commutingMulMap A B hAB) = A ⊔ B := by
+  apply le_antisymm
+  · rintro _ ⟨x, rfl⟩
+    induction x with
+    | zero => rw [map_zero]; exact (A ⊔ B).zero_mem
+    | tmul a b =>
+        change (a : C) * (b : C) ∈ A ⊔ B
+        exact (A ⊔ B).mul_mem ((show A ≤ A ⊔ B from le_sup_left) a.2)
+          ((show B ≤ A ⊔ B from le_sup_right) b.2)
+    | add x y hx hy => rw [map_add]; exact (A ⊔ B).add_mem hx hy
+  · refine sup_le ?_ ?_
+    · intro x hx
+      exact ⟨(⟨x, hx⟩ : A) ⊗ₜ[ℂ] (1 : B), by simp⟩
+    · intro x hx
+      exact ⟨(1 : A) ⊗ₜ[ℂ] (⟨x, hx⟩ : B), by simp⟩
+
+/-- The underlying complex vector space of the join of two commuting unital star-subalgebras is
+the span of products of elements from the two factors. -/
+theorem sup_toSubmodule_eq_mul (A B : StarSubalgebra ℂ C)
+    [Nontrivial C]
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : C) (b : C)) :
+    (A ⊔ B).toSubmodule = A.toSubmodule * B.toSubmodule := by
+  rw [← commutingMulMap_range A B hAB]
+  change LinearMap.range (commutingMulMap A B hAB).toLinearMap = _
+  rw [commutingMulMap_toLinearMap, Submodule.mulMap_range]
+
+private noncomputable def tensorProductStarAlgEquiv
+    {A B D E : Type*}
+    [Ring A] [Algebra ℂ A] [StarRing A] [StarModule ℂ A]
+    [Ring B] [Algebra ℂ B] [StarRing B] [StarModule ℂ B]
+    [Ring D] [Algebra ℂ D] [StarRing D] [StarModule ℂ D]
+    [Ring E] [Algebra ℂ E] [StarRing E] [StarModule ℂ E]
+    (eA : A ≃⋆ₐ[ℂ] D) (eB : B ≃⋆ₐ[ℂ] E) :
+    A ⊗[ℂ] B ≃⋆ₐ[ℂ] D ⊗[ℂ] E :=
+  StarAlgEquiv.ofAlgEquiv
+    (Algebra.TensorProduct.congr eA.toAlgEquiv eB.toAlgEquiv) fun x ↦ by
+      induction x with
+      | zero => simp
+      | tmul a b =>
+          simp only [TensorProduct.star_tmul, Algebra.TensorProduct.congr_apply,
+            Algebra.TensorProduct.map_tmul]
+          change eA (star a) ⊗ₜ[ℂ] eB (star b) = star (eA a) ⊗ₜ[ℂ] star (eB b)
+          rw [map_star eA a, map_star eB b]
+      | add x y hx hy => simp only [star_add, map_add, hx, hy]
+
+private noncomputable def tensorProductFullMatrixStarAlgEquiv
+    {A B : Type*}
+    [Ring A] [Algebra ℂ A] [StarRing A] [StarModule ℂ A]
+    [Ring B] [Algebra ℂ B] [StarRing B] [StarModule ℂ B]
+    {p q : ℕ} (eA : A ≃⋆ₐ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (eB : B ≃⋆ₐ[ℂ] Matrix (Fin q) (Fin q) ℂ) :
+    A ⊗[ℂ] B ≃⋆ₐ[ℂ] Matrix (Fin (p * q)) (Fin (p * q)) ℂ :=
+  (tensorProductStarAlgEquiv eA eB).trans <|
+    (Matrix.kroneckerStarAlgEquiv (Fin p) (Fin q) ℂ).trans <|
+      Matrix.matrixReindexStarAlgEquiv finProdFinEquiv
+
+section FullMatrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+variable (A B : StarSubalgebra ℂ (Matrix n n ℂ))
+variable {p q : ℕ} [NeZero p] [NeZero q]
+
+/-- For two commuting full matrix factors in a nonzero ambient matrix algebra, multiplication from
+their tensor product is injective. This is the unital single-block specialization of
+Schumacher--Werner Proposition `Cscom`, quant-ph/0405174, lines 2119--2138, used in GNVW at
+arXiv:0910.3675v2, lines 1270--1308. -/
+theorem commutingMulMap_injective_of_equiv_matrix
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : Matrix n n ℂ) (b : Matrix n n ℂ))
+    (eA : A ≃⋆ₐ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (eB : B ≃⋆ₐ[ℂ] Matrix (Fin q) (Fin q) ℂ) :
+    Function.Injective (commutingMulMap A B hAB) := by
+  let hSimple : IsSimpleRing (A ⊗[ℂ] B) :=
+    IsSimpleRing.of_ringEquiv
+      (tensorProductFullMatrixStarAlgEquiv eA eB).symm.toRingEquiv inferInstance
+  exact @RingHom.injective _ _ _ hSimple _ _ (commutingMulMap A B hAB).toRingHom
+
+/-- The join of two commuting full matrix factors of sizes `p` and `q` is a full matrix algebra of
+size `p * q`. This is the unital single-block specialization of Schumacher--Werner Proposition
+`Cscom`, quant-ph/0405174, lines 2119--2138. It does not assert that the join is the whole ambient
+matrix algebra. -/
+noncomputable def commutingSupEquivMatrix
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : Matrix n n ℂ) (b : Matrix n n ℂ))
+    (eA : A ≃⋆ₐ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (eB : B ≃⋆ₐ[ℂ] Matrix (Fin q) (Fin q) ℂ) :
+    ↥(A ⊔ B) ≃⋆ₐ[ℂ] Matrix (Fin (p * q)) (Fin (p * q)) ℂ := by
+  let eJoin : A ⊗[ℂ] B ≃⋆ₐ[ℂ] ↥(A ⊔ B) := by
+    rw [← commutingMulMap_range A B hAB]
+    exact StarAlgEquiv.ofInjective (commutingMulMap A B hAB)
+      (commutingMulMap_injective_of_equiv_matrix A B hAB eA eB)
+  exact eJoin.symm.trans (tensorProductFullMatrixStarAlgEquiv eA eB)
+
+/-- The full-matrix presentation of the join of two commuting full matrix factors exists. -/
+theorem nonempty_equiv_sup_matrix
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : Matrix n n ℂ) (b : Matrix n n ℂ))
+    (eA : A ≃⋆ₐ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (eB : B ≃⋆ₐ[ℂ] Matrix (Fin q) (Fin q) ℂ) :
+    Nonempty (↥(A ⊔ B) ≃⋆ₐ[ℂ] Matrix (Fin (p * q)) (Fin (p * q)) ℂ) :=
+  ⟨commutingSupEquivMatrix A B hAB eA eB⟩
+
+/-- The complex dimension of the join of commuting full matrix factors of sizes `p` and `q` is
+`(p * q) * (p * q)`. -/
+theorem finrank_sup_of_equiv_matrix
+    (hAB : ∀ a : A, ∀ b : B, Commute (a : Matrix n n ℂ) (b : Matrix n n ℂ))
+    (eA : A ≃⋆ₐ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (eB : B ≃⋆ₐ[ℂ] Matrix (Fin q) (Fin q) ℂ) :
+    Module.finrank ℂ ↥(A ⊔ B) = (p * q) * (p * q) := by
+  calc
+    Module.finrank ℂ ↥(A ⊔ B) =
+        Module.finrank ℂ (Matrix (Fin (p * q)) (Fin (p * q)) ℂ) :=
+      (commutingSupEquivMatrix A B hAB eA eB).toAlgEquiv.toLinearEquiv.finrank_eq
+    _ = (p * q) * (p * q) := by simp [Module.finrank_matrix]
+
+end FullMatrix
+
+end StarSubalgebra

--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -15,6 +15,7 @@ import TNLean.QCA.BipartiteSupportAlgebra
 import TNLean.QCA.Blocking
 import TNLean.QCA.BlockingQCA
 import TNLean.QCA.BlockingTranslation
+import TNLean.QCA.CommutingStarSubalgebraKronecker
 import TNLean.QCA.CompatibleLocalAutomorphism
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FiniteLocalRestriction

--- a/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
+++ b/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
@@ -97,7 +97,7 @@ theorem leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule
       subst X
       simp
   | inr hm =>
-      letI : Nonempty m := hm
+      let _ : Nonempty m := hm
       cases isEmpty_or_nonempty n with
       | inl _ =>
           apply Submodule.ext
@@ -106,7 +106,7 @@ theorem leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule
           subst X
           simp
       | inr hn =>
-          letI : Nonempty n := hn
+          let _ : Nonempty n := hn
           rw [StarSubalgebra.sup_toSubmodule_eq_mul _ _ (left_right_kronecker_commute S T)]
           exact left_right_kronecker_mul_toSubmodule S T
 

--- a/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
+++ b/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CommutingStarSubalgebraProduct
+import TNLean.QCA.BipartiteSupportAlgebra
+
+/-!
+# Canonical coordinates for products of commuting matrix factors
+
+The canonical embeddings of two matrix star-subalgebras into a bipartite matrix algebra commute.
+The underlying complex vector space of their algebraic join is the Kronecker-product span of the
+two original subspaces.
+
+This coordinate statement is distinct from the abstract full-matrix presentation of a pair of
+commuting factors: an arbitrary common ambient matrix algebra has no distinguished bipartite
+coordinates.
+
+## Main result
+
+* `Matrix.leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule` identifies the canonical join
+  with `Matrix.kroneckerSubmodule`.
+
+## References
+
+* B. Schumacher and R. F. Werner, *Reversible quantum cellular automata*,
+  quant-ph/0405174, Proposition `Cscom`, lines 2119--2138.
+* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one dimensional quantum walks
+  and cellular automata*, arXiv:0910.3675v2, lines 1270--1308.
+-/
+
+open scoped Kronecker
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+
+private theorem leftKroneckerEmbed_mul_rightKroneckerEmbed
+    (A : Matrix m m ℂ) (B : Matrix n n ℂ) :
+    leftKroneckerEmbed (n := n) A * rightKroneckerEmbed (m := m) B = A ⊗ₖ B := by
+  rw [leftKroneckerEmbed_apply, rightKroneckerEmbed_apply, ← mul_kronecker_mul,
+    mul_one, one_mul]
+
+private theorem rightKroneckerEmbed_mul_leftKroneckerEmbed
+    (A : Matrix m m ℂ) (B : Matrix n n ℂ) :
+    rightKroneckerEmbed (m := m) B * leftKroneckerEmbed (n := n) A = A ⊗ₖ B := by
+  rw [leftKroneckerEmbed_apply, rightKroneckerEmbed_apply, ← mul_kronecker_mul,
+    one_mul, mul_one]
+
+private theorem left_right_kronecker_commute
+    (S : StarSubalgebra ℂ (Matrix m m ℂ)) (T : StarSubalgebra ℂ (Matrix n n ℂ)) :
+    ∀ a : S.map (leftKroneckerEmbed (n := n)),
+      ∀ b : T.map (rightKroneckerEmbed (m := m)),
+        Commute (a : Matrix (m × n) (m × n) ℂ) (b : Matrix (m × n) (m × n) ℂ) := by
+  intro a b
+  obtain ⟨A, _, hA⟩ := StarSubalgebra.mem_map.mp a.2
+  obtain ⟨B, _, hB⟩ := StarSubalgebra.mem_map.mp b.2
+  change (a : Matrix (m × n) (m × n) ℂ) * b = b * a
+  rw [← hA, ← hB, leftKroneckerEmbed_mul_rightKroneckerEmbed,
+    rightKroneckerEmbed_mul_leftKroneckerEmbed]
+
+private theorem left_right_kronecker_mul_toSubmodule
+    (S : StarSubalgebra ℂ (Matrix m m ℂ)) (T : StarSubalgebra ℂ (Matrix n n ℂ)) :
+    (S.map (leftKroneckerEmbed (n := n))).toSubmodule *
+        (T.map (rightKroneckerEmbed (m := m))).toSubmodule =
+      kroneckerSubmodule S.toSubmodule T.toSubmodule := by
+  apply le_antisymm
+  · rw [Submodule.mul_le]
+    intro X hX Y hY
+    obtain ⟨A, hA, hAX⟩ := StarSubalgebra.mem_map.mp hX
+    obtain ⟨B, hB, hBY⟩ := StarSubalgebra.mem_map.mp hY
+    rw [← hAX, ← hBY, leftKroneckerEmbed_mul_rightKroneckerEmbed]
+    exact Submodule.apply_mem_map₂ Matrix.kroneckerBilinear hA hB
+  · rw [kroneckerSubmodule, Submodule.map₂_le]
+    intro A hA B hB
+    change A ⊗ₖ B ∈
+      (S.map (leftKroneckerEmbed (n := n))).toSubmodule *
+        (T.map (rightKroneckerEmbed (m := m))).toSubmodule
+    rw [← leftKroneckerEmbed_mul_rightKroneckerEmbed]
+    exact Submodule.mul_mem_mul (StarSubalgebra.mem_map.mpr ⟨A, hA, rfl⟩)
+      (StarSubalgebra.mem_map.mpr ⟨B, hB, rfl⟩)
+
+/-- In canonical bipartite coordinates, the join of the left and right embedded factors has
+underlying vector space equal to the Kronecker-product span. This is the coordinate identity used
+for the commuting support algebras in GNVW, arXiv:0910.3675v2, lines 1270--1308. -/
+theorem leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule
+    (S : StarSubalgebra ℂ (Matrix m m ℂ)) (T : StarSubalgebra ℂ (Matrix n n ℂ)) :
+    (S.map (leftKroneckerEmbed (n := n)) ⊔
+        T.map (rightKroneckerEmbed (m := m))).toSubmodule =
+      kroneckerSubmodule S.toSubmodule T.toSubmodule := by
+  cases isEmpty_or_nonempty m with
+  | inl _ =>
+      apply Submodule.ext
+      intro X
+      have hX : X = 0 := Subsingleton.elim _ _
+      subst X
+      simp
+  | inr hm =>
+      letI : Nonempty m := hm
+      cases isEmpty_or_nonempty n with
+      | inl _ =>
+          apply Submodule.ext
+          intro X
+          have hX : X = 0 := Subsingleton.elim _ _
+          subst X
+          simp
+      | inr hn =>
+          letI : Nonempty n := hn
+          rw [StarSubalgebra.sup_toSubmodule_eq_mul _ _ (left_right_kronecker_commute S T)]
+          exact left_right_kronecker_mul_toSubmodule S T
+
+end Matrix

--- a/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
+++ b/TNLean/QCA/CommutingStarSubalgebraKronecker.lean
@@ -26,7 +26,7 @@ coordinates.
 
 * B. Schumacher and R. F. Werner, *Reversible quantum cellular automata*,
   quant-ph/0405174, Proposition `Cscom`, lines 2119--2138.
-* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one dimensional quantum walks
+* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one-dimensional quantum walks
   and cellular automata*, arXiv:0910.3675v2, lines 1270--1308.
 -/
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9840,7 +9840,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     \begin{align}
         \mu_{\mathcal A,\mathcal B}
         \colon \mathcal A\otimes_{\mathbb C}\mathcal B
-         & \longrightarrow \mathcal C, &
+         & \longrightarrow \mathcal C, \notag \\
         \mu_{\mathcal A,\mathcal B}(a\otimes b)
          & =ab.
     \end{align}
@@ -9890,13 +9890,13 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     Suppose that $\mathcal C=M_I(\mathbb C)$ for a finite nonempty set
     $I$, that $p,q>0$, and that
     \begin{align}
-        \mathcal A & \cong M_p(\mathbb C), &
+        \mathcal A & \cong M_p(\mathbb C), \notag \\
         \mathcal B & \cong M_q(\mathbb C)
     \end{align}
     as star-algebras.  Then $\mu_{\mathcal A,\mathcal B}$ is injective and
     \begin{align}
         \mathcal A\vee\mathcal B
-         & \cong M_{pq}(\mathbb C), &
+         & \cong M_{pq}(\mathbb C), \notag \\
         \dim_{\mathbb C}(\mathcal A\vee\mathcal B)
          & =(pq)^2.
         \label{eq:qca_commuting_full_matrix_product}
@@ -9935,13 +9935,8 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     $\mathcal S\subseteq M_I(\mathbb C)$ and
     $\mathcal T\subseteq M_J(\mathbb C)$ be unital star-subalgebras.  In
     the canonical bipartite coordinates, the underlying complex vector
-    space of the join of
-    \begin{align}
-        \mathcal S\otimes\mathbf 1_J
-        \quad\text{and}\quad
-        \mathbf 1_I\otimes\mathcal T
-    \end{align}
-    is exactly
+    space of the join of $\mathcal S\otimes\mathbf 1_J$ and
+    $\mathbf 1_I\otimes\mathcal T$ is exactly
     \begin{align}
         \mathcal S\boxtimes\mathcal T
          & =\operatorname{span}_{\mathbb C}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9839,10 +9839,10 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     Multiplication defines a unital star-algebra homomorphism
     \begin{align}
         \mu_{\mathcal A,\mathcal B}
-          \colon \mathcal A\otimes_{\mathbb C}\mathcal B
-          & \longrightarrow \mathcal C, &
+        \colon \mathcal A\otimes_{\mathbb C}\mathcal B
+         & \longrightarrow \mathcal C, &
         \mu_{\mathcal A,\mathcal B}(a\otimes b)
-          & =ab.
+         & =ab.
     \end{align}
 \end{definition}
 
@@ -9856,8 +9856,8 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     $\mathcal A\vee\mathcal B$.  Its underlying complex vector space is
     \begin{align}
         \mathcal A\mathcal B
-          & =\operatorname{span}_{\mathbb C}
-          \{ab\mid a\in\mathcal A,\ b\in\mathcal B\}.
+         & =\operatorname{span}_{\mathbb C}
+        \{ab\mid a\in\mathcal A,\ b\in\mathcal B\}.
         \label{eq:qca_commuting_factor_product_span}
     \end{align}
     Thus every element of the join is a finite complex-linear sum of
@@ -9870,7 +9870,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     $b^*\in\mathcal B$ commute,
     \begin{align}
         \mu_{\mathcal A,\mathcal B}\bigl((a\otimes b)^*\bigr)
-          & =a^*b^*=b^*a^*=(ab)^*.
+         & =a^*b^*=b^*a^*=(ab)^*.
     \end{align}
     The image contains both factors because $a=a\mathbf 1$ and
     $b=\mathbf 1b$.  Conversely, every pure tensor maps to an element of
@@ -9896,9 +9896,9 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     as star-algebras.  Then $\mu_{\mathcal A,\mathcal B}$ is injective and
     \begin{align}
         \mathcal A\vee\mathcal B
-          & \cong M_{pq}(\mathbb C), &
+         & \cong M_{pq}(\mathbb C), &
         \dim_{\mathbb C}(\mathcal A\vee\mathcal B)
-          & =(pq)^2.
+         & =(pq)^2.
         \label{eq:qca_commuting_full_matrix_product}
     \end{align}
     This is the unital single-block specialization of Schumacher--Werner
@@ -9916,7 +9916,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     The source of the multiplication homomorphism is
     \begin{align}
         M_p(\mathbb C)\otimes_{\mathbb C}M_q(\mathbb C)
-          & \cong M_{pq}(\mathbb C).
+         & \cong M_{pq}(\mathbb C).
     \end{align}
     This is a simple ring.  The kernel of a unital homomorphism from a
     simple ring to a nonzero ring is not the whole ring, and is therefore
@@ -9944,8 +9944,8 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     is exactly
     \begin{align}
         \mathcal S\boxtimes\mathcal T
-          & =\operatorname{span}_{\mathbb C}
-          \{S\otimes T\mid S\in\mathcal S,\ T\in\mathcal T\}.
+         & =\operatorname{span}_{\mathbb C}
+        \{S\otimes T\mid S\in\mathcal S,\ T\in\mathcal T\}.
         \label{eq:qca_commuting_factor_kronecker_coordinates}
     \end{align}
 \end{theorem}
@@ -9955,7 +9955,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     The two canonical factors commute, and their products satisfy
     \begin{align}
         (S\otimes\mathbf 1_J)(\mathbf 1_I\otimes T)
-          & =S\otimes T.
+         & =S\otimes T.
     \end{align}
     Equation~(\ref{eq:qca_commuting_factor_product_span}) therefore becomes
     exactly

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9825,6 +9825,143 @@ circuit, MPU standard form, or index comparison is asserted here.
     (\ref{eq:qca_overlapping_support_conclusion}).
 \end{proof}
 
+\subsection{Products of commuting matrix factors}
+
+Let $\mathcal C$ be a nonzero complex star-algebra and let
+$\mathcal A,\mathcal B\subseteq\mathcal C$ be unital star-subalgebras such
+that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
+
+\begin{definition}[Multiplication of commuting factors]
+    \label{def:qca_commuting_factor_multiplication}
+    \lean{StarSubalgebra.commutingMulMap,
+        StarSubalgebra.commutingMulMap_tmul}
+    \leanok
+    Multiplication defines a unital star-algebra homomorphism
+    \begin{align}
+        \mu_{\mathcal A,\mathcal B}
+          \colon \mathcal A\otimes_{\mathbb C}\mathcal B
+          & \longrightarrow \mathcal C, &
+        \mu_{\mathcal A,\mathcal B}(a\otimes b)
+          & =ab.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Algebraic product of commuting factors]
+    \label{thm:qca_commuting_factor_product}
+    \lean{StarSubalgebra.commutingMulMap_range,
+        StarSubalgebra.sup_toSubmodule_eq_mul}
+    \leanok
+    \uses{def:qca_commuting_factor_multiplication}
+    The image of $\mu_{\mathcal A,\mathcal B}$ is the algebraic join
+    $\mathcal A\vee\mathcal B$.  Its underlying complex vector space is
+    \begin{align}
+        \mathcal A\mathcal B
+          & =\operatorname{span}_{\mathbb C}
+          \{ab\mid a\in\mathcal A,\ b\in\mathcal B\}.
+        \label{eq:qca_commuting_factor_product_span}
+    \end{align}
+    Thus every element of the join is a finite complex-linear sum of
+    products $ab$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_commuting_factor_multiplication}
+    The involution reverses products.  Since $a^*\in\mathcal A$ and
+    $b^*\in\mathcal B$ commute,
+    \begin{align}
+        \mu_{\mathcal A,\mathcal B}\bigl((a\otimes b)^*\bigr)
+          & =a^*b^*=b^*a^*=(ab)^*.
+    \end{align}
+    The image contains both factors because $a=a\mathbf 1$ and
+    $b=\mathbf 1b$.  Conversely, every pure tensor maps to an element of
+    the join, and linearity gives the reverse inclusion.  The description
+    of the underlying vector space is the range formula for the linear
+    multiplication map.
+\end{proof}
+
+\begin{theorem}[Product of two full matrix factors]
+    \label{thm:qca_commuting_full_matrix_product}
+    \lean{StarSubalgebra.commutingMulMap_injective_of_equiv_matrix,
+        StarSubalgebra.commutingSupEquivMatrix,
+        StarSubalgebra.nonempty_equiv_sup_matrix,
+        StarSubalgebra.finrank_sup_of_equiv_matrix}
+    \leanok
+    \uses{thm:qca_commuting_factor_product}
+    Suppose that $\mathcal C=M_I(\mathbb C)$ for a finite nonempty set
+    $I$, that $p,q>0$, and that
+    \begin{align}
+        \mathcal A & \cong M_p(\mathbb C), &
+        \mathcal B & \cong M_q(\mathbb C)
+    \end{align}
+    as star-algebras.  Then $\mu_{\mathcal A,\mathcal B}$ is injective and
+    \begin{align}
+        \mathcal A\vee\mathcal B
+          & \cong M_{pq}(\mathbb C), &
+        \dim_{\mathbb C}(\mathcal A\vee\mathcal B)
+          & =(pq)^2.
+        \label{eq:qca_commuting_full_matrix_product}
+    \end{align}
+    This is the unital single-block specialization of Schumacher--Werner
+    Proposition~\texttt{Cscom}
+    \cite[lines~2119--2138]{SchumacherWerner2004QCA}, used for the adjacent
+    support algebras in
+    \cite[lines~1270--1308]{Gross2012IndexTheory}.  It does not assert the
+    direct-sum multiplicity statement of Proposition~\texttt{Cscom}, nor
+    that the displayed matrix algebra fills the ambient algebra.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:qca_commuting_factor_multiplication,
+        thm:qca_commuting_factor_product}
+    The source of the multiplication homomorphism is
+    \begin{align}
+        M_p(\mathbb C)\otimes_{\mathbb C}M_q(\mathbb C)
+          & \cong M_{pq}(\mathbb C).
+    \end{align}
+    This is a simple ring.  The kernel of a unital homomorphism from a
+    simple ring to a nonzero ring is not the whole ring, and is therefore
+    zero.  Hence multiplication is injective.  Its image is the join by
+    Theorem~\ref{thm:qca_commuting_factor_product}; the matrix presentation
+    and dimension formula in
+    Equation~(\ref{eq:qca_commuting_full_matrix_product}) follow.
+\end{proof}
+
+\begin{theorem}[Canonical Kronecker coordinates]
+    \label{thm:qca_commuting_factor_kronecker_coordinates}
+    \lean{Matrix.leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule}
+    \leanok
+    \uses{thm:qca_commuting_factor_product, def:qca_kronecker_submodule}
+    Let $I,J$ be finite sets, and let
+    $\mathcal S\subseteq M_I(\mathbb C)$ and
+    $\mathcal T\subseteq M_J(\mathbb C)$ be unital star-subalgebras.  In
+    the canonical bipartite coordinates, the underlying complex vector
+    space of the join of
+    \begin{align}
+        \mathcal S\otimes\mathbf 1_J
+        \quad\text{and}\quad
+        \mathbf 1_I\otimes\mathcal T
+    \end{align}
+    is exactly
+    \begin{align}
+        \mathcal S\boxtimes\mathcal T
+          & =\operatorname{span}_{\mathbb C}
+          \{S\otimes T\mid S\in\mathcal S,\ T\in\mathcal T\}.
+        \label{eq:qca_commuting_factor_kronecker_coordinates}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:qca_commuting_factor_product}
+    The two canonical factors commute, and their products satisfy
+    \begin{align}
+        (S\otimes\mathbf 1_J)(\mathbf 1_I\otimes T)
+          & =S\otimes T.
+    \end{align}
+    Equation~(\ref{eq:qca_commuting_factor_product_span}) therefore becomes
+    exactly
+    (\ref{eq:qca_commuting_factor_kronecker_coordinates}).
+\end{proof}
+
 \begin{definition}[Translation of a finite region]
     \label{def:qca_translate_region}
     \lean{SpinChain.translateRegion,SpinChain.mem_translateRegion,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9886,7 +9886,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
         StarSubalgebra.nonempty_equiv_sup_matrix,
         StarSubalgebra.finrank_sup_of_equiv_matrix}
     \leanok
-    \uses{thm:qca_commuting_factor_product}
+    \uses{def:qca_commuting_factor_multiplication}
     Suppose that $\mathcal C=M_I(\mathbb C)$ for a finite nonempty set
     $I$, that $p,q>0$, and that
     \begin{align}
@@ -9901,13 +9901,16 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
          & =(pq)^2.
         \label{eq:qca_commuting_full_matrix_product}
     \end{align}
+    \textbf{Scope restriction (full matrix, single block):}
     This is the unital single-block specialization of Schumacher--Werner
     Proposition~\texttt{Cscom}
     \cite[lines~2119--2138]{SchumacherWerner2004QCA}, used for the adjacent
     support algebras in
     \cite[lines~1270--1308]{Gross2012IndexTheory}.  It does not assert the
-    direct-sum multiplicity statement of Proposition~\texttt{Cscom}, nor
-    that the displayed matrix algebra fills the ambient algebra.
+    direct-sum block-pair theorem or the multiplicity equation of
+    Proposition~\texttt{Cscom}, nor that the displayed matrix algebra fills
+    the ambient algebra.  The omitted statement and its elimination plan are
+    recorded in \cite{gap:gnvw12_cscom_single_block_scope}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -9930,7 +9933,7 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
     \label{thm:qca_commuting_factor_kronecker_coordinates}
     \lean{Matrix.leftKroneckerEmbed_sup_rightKroneckerEmbed_toSubmodule}
     \leanok
-    \uses{thm:qca_commuting_factor_product, def:qca_kronecker_submodule}
+    \uses{def:qca_kronecker_submodule}
     Let $I,J$ be finite sets, and let
     $\mathcal S\subseteq M_I(\mathbb C)$ and
     $\mathcal T\subseteq M_J(\mathbb C)$ be unital star-subalgebras.  In
@@ -9947,7 +9950,9 @@ that $ab=ba$ for every $a\in\mathcal A$ and $b\in\mathcal B$.
 
 \begin{proof}\leanok
     \uses{thm:qca_commuting_factor_product}
-    The two canonical factors commute, and their products satisfy
+    If $I$ or $J$ is empty, the ambient matrix space is zero, so both
+    subspaces in the claimed equality are zero.  Assume that both sets are
+    nonempty.  The two canonical factors commute, and their products satisfy
     \begin{align}
         (S\otimes\mathbf 1_J)(\mathbf 1_I\otimes T)
          & =S\otimes T.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -996,6 +996,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_two_cochain_coboundary_index_typo.pdf}},
 }
 
+@techreport{gap:gnvw12_cscom_single_block_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Single-Block Scope for the Schumacher--Werner Commuting-Algebra Proposition},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {gnvw12\_cscom\_single\_block\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_cscom_single_block_scope.pdf}},
+}
+
 @techreport{gap:gnvw12_support_algebra_full_matrix_scope,
   author      = {The {TNLean} contributors},
   title       = {Full-Matrix Scope for the {GNVW} Support-Algebra Formalization},

--- a/docs/paper-gaps/gnvw12_cscom_single_block_scope.tex
+++ b/docs/paper-gaps/gnvw12_cscom_single_block_scope.tex
@@ -1,0 +1,133 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Single-Block Scope for the Schumacher--Werner Commuting-Algebra Proposition}
+\author{}
+\date{2026-09-01}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source proposition}
+
+Let $\mathcal H$ be a finite-dimensional complex Hilbert space. Suppose that
+$\mathcal A$ and $\mathcal B$ are commuting finite-dimensional subalgebras of
+$\mathcal B(\mathcal H)$ with decompositions
+\begin{align}
+    \mathcal A
+     & \cong\bigoplus_{\mu}M_{n(\mu)}(\mathbb C),
+    \label{eq:gnvw12_cscom_single_block_scope_left_decomposition} \\
+    \mathcal B
+     & \cong\bigoplus_{\nu}M_{m(\nu)}(\mathbb C).
+    \label{eq:gnvw12_cscom_single_block_scope_right_decomposition}
+\end{align}
+Proposition~\texttt{Cscom} of Schumacher and Werner states that the product
+algebra $\mathcal A\mathcal B$ decomposes into the block-pair products. The
+representation on $\mathcal H$ assigns a nonnegative integer multiplicity
+$r_{\mu\nu}$ to each pair and satisfies
+\begin{align}
+    \sum_{\mu,\nu}r_{\mu\nu}n(\mu)m(\nu)
+     & =\dim\mathcal H.
+    \label{eq:gnvw12_cscom_single_block_scope_multiplicity}
+\end{align}
+This is Proposition~\texttt{Cscom} and Equation~\texttt{multip} at lines
+2119--2138 of Ref.~\cite{SchumacherWerner2004QCA}. For a fixed pair of
+blocks, multiplication gives a representation
+\begin{align}
+    M_{n(\mu)}(\mathbb C)\otimes M_{m(\nu)}(\mathbb C)
+     & \longrightarrow\mathcal B(\mathcal H),
+    \label{eq:gnvw12_cscom_single_block_scope_block_representation} \\
+    A_{\mu}\otimes B_{\nu}
+     & \longmapsto A_{\mu}B_{\nu}.
+    \label{eq:gnvw12_cscom_single_block_scope_block_multiplication}
+\end{align}
+The source allows this block-pair representation to vanish because a block
+identity need not equal the identity on $\mathcal H$
+\cite{SchumacherWerner2004QCA}.
+
+\section{The formal specialization}
+
+The formal result takes one unital block in each factor. Let $I$ be a finite
+nonempty set, let
+$\mathcal A,\mathcal B\subseteq M_I(\mathbb C)$ be unital star-subalgebras,
+and assume
+\begin{align}
+    \mathcal A
+     & \cong M_p(\mathbb C),
+    \label{eq:gnvw12_cscom_single_block_scope_left_matrix} \\
+    \mathcal B
+     & \cong M_q(\mathbb C),
+    \label{eq:gnvw12_cscom_single_block_scope_right_matrix}
+\end{align}
+where $p,q>0$. Since the two subalgebras share the ambient identity, their
+multiplication representation is unital and therefore nonzero. Simplicity of
+$M_{pq}(\mathbb C)$ makes it injective. Consequently,
+\begin{align}
+    \mathcal A\vee\mathcal B
+     & \cong M_{pq}(\mathbb C),
+    \label{eq:gnvw12_cscom_single_block_scope_join} \\
+    \dim_{\mathbb C}(\mathcal A\vee\mathcal B)
+     & =(pq)^2.
+    \label{eq:gnvw12_cscom_single_block_scope_join_dimension}
+\end{align}
+The formal declarations establish
+(\ref{eq:gnvw12_cscom_single_block_scope_join}) and
+(\ref{eq:gnvw12_cscom_single_block_scope_join_dimension}).\footnote{Formal
+    declarations:
+    \leanid{StarSubalgebra.commutingMulMap_injective_of_equiv_matrix},
+    \leanid{StarSubalgebra.commutingSupEquivMatrix}, and
+    \leanid{StarSubalgebra.finrank_sup_of_equiv_matrix} in
+    \doclink{TNLean/Algebra/CommutingStarSubalgebraProduct}.}
+
+This specialization does not formalize the direct sums in
+(\ref{eq:gnvw12_cscom_single_block_scope_left_decomposition}) and
+(\ref{eq:gnvw12_cscom_single_block_scope_right_decomposition}), the possibility
+of zero block-pair representations, or the multiplicity identity
+(\ref{eq:gnvw12_cscom_single_block_scope_multiplicity}). Even in the
+single-block case, it does not prove the corresponding ambient representation
+multiplicity $r$ or the equation
+\begin{align}
+    r p q
+     & =|I|.
+    \label{eq:gnvw12_cscom_single_block_scope_single_multiplicity}
+\end{align}
+Thus the matrix size $pq$ describes the product algebra, not necessarily the
+whole ambient matrix algebra.
+
+\section{Why the specialization is useful}
+
+In the adjacent-support-algebra argument, the immediate use of
+Proposition~\texttt{Cscom} is that two commuting full matrix factors span a
+copy of $M_{pq}(\mathbb C)$; see lines 1270--1308 of
+Ref.~\cite{Gross2012IndexTheory}. Showing that this copy fills the adjacent
+physical algebra is a separate surjectivity argument. The specialization
+(\ref{eq:gnvw12_cscom_single_block_scope_join}) supplies the first statement
+without claiming the second.
+
+\section{Elimination plan}
+
+Removing the restriction requires a finite direct-sum form of the
+multiplication representation. For every pair $(\mu,\nu)$, restrict
+multiplication to
+$M_{n(\mu)}(\mathbb C)\otimes M_{m(\nu)}(\mathbb C)$, distinguish the zero and
+nonzero representations, and identify each nonzero image with
+$M_{n(\mu)m(\nu)}(\mathbb C)$. Decompose $\mathcal H$ into the corresponding
+isotypic representation spaces. Their multiplicities then give
+$r_{\mu\nu}$, and summing their dimensions proves
+(\ref{eq:gnvw12_cscom_single_block_scope_multiplicity}).
+
+Until that construction is formalized, source-labelled statements must mark
+the full-matrix, single-block restriction and must not claim the multiplicity
+equation.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## What changed

- construct the multiplication star-algebra homomorphism from the tensor product of two commuting matrix star-subalgebras
- identify its range with the generated join and derive injectivity from simplicity
- package the resulting star-algebra equivalence, finite-dimensional rank formulas, and Kronecker-coordinate model
- synchronize the generic product layer in Chapter 28 without claiming the downstream QCA support-algebra assembly

This generic theorem is independent of the still-open support-algebra presentation and relative-commutant prerequisites.

## Validation

- branch rebased onto current main
- targeted builds for both new modules
- full cached build: 10461 jobs, green before final unrelated-main rebase
- current-head targeted rebuild after rebase: 2421/2421
- import aggregators: 37 files, 1082 production modules
- Blueprint synchronization after rebase: 7345/7345
- strict declaration checks and double LuaLaTeX with zero undefined references
- style, proof-integrity, and `git diff --check`

Closes #7120
Advances #7038
