### PR TITLE
feat(MPS/Chain): formalize alternating networks

### DIFF
--- a/TNLean/MPS/Chain.lean
+++ b/TNLean/MPS/Chain.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.Chain
 
 import TNLean.MPS.Chain.AlgebraIsomorphism
+import TNLean.MPS.Chain.AlternatingNetwork
 import TNLean.MPS.Chain.BlockedChainFT
 import TNLean.MPS.Chain.CyclicBlockAverage
 import TNLean.MPS.Chain.Defs

--- a/TNLean/MPS/Chain/AlternatingNetwork.lean
+++ b/TNLean/MPS/Chain/AlternatingNetwork.lean
@@ -45,6 +45,8 @@ are recorded in
 
 open scoped BigOperators TensorProduct
 
+open Module
+
 namespace MPSTensor
 
 /-- The connected open chain \(A_1B_1A_2B_2\cdots A_nB_n\).
@@ -72,12 +74,13 @@ noncomputable def openAlternatingNetwork
 
 private theorem piTensorProduct_eq_of_forall_matrix_entry_prod_eq
     {n : ℕ} {row col : Fin n → Type*}
-    [∀ i : Fin n, Fintype (row i)] [∀ i : Fin n, Fintype (col i)]
+    [∀ i : Fin n, Finite (row i)] [∀ i : Fin n, Finite (col i)]
     (B B' : (i : Fin n) → Matrix (row i) (col i) ℂ)
     (h : ∀ (r : (i : Fin n) → row i) (c : (i : Fin n) → col i),
       (∏ i : Fin n, B i (r i) (c i)) = ∏ i : Fin n, B' i (r i) (c i)) :
     (⨂ₜ[ℂ] i : Fin n, B i) = ⨂ₜ[ℂ] i : Fin n, B' i := by
   classical
+  let _ : ∀ i : Fin n, Fintype (row i) := fun i ↦ Fintype.ofFinite _
   let b : (i : Fin n) →
       Basis (row i × col i) ℂ (Matrix (row i) (col i) ℂ) :=
     fun i ↦ Matrix.stdBasis ℂ (row i) (col i)
@@ -134,14 +137,14 @@ private theorem matrixUnit_prod_eq_zero_of_path_ne
     (q y : (i : Fin n) → Fin (D i.castSucc))
     (hxlast : x (Fin.last n) = z (Fin.last n)) (hx : x ≠ z) :
     (∏ i : Fin n,
-      Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i)) = 0 := by
+      Matrix.single (z i.castSucc) (q i) (1 : ℂ) (x i.castSucc) (y i)) = 0 := by
   classical
   have hcast : ∃ i : Fin n, x i.castSucc ≠ z i.castSucc := by
     by_contra h
     apply hx
     funext j
     exact Fin.lastCases hxlast
-      (fun i ↦ not_ne.mp (not_exists.mp h i)) j
+      (fun i ↦ not_not.mp (not_exists.mp h i)) j
   obtain ⟨i, hi⟩ := hcast
   apply Finset.prod_eq_zero (Finset.mem_univ i)
   exact Matrix.single_apply_of_row_ne hi.symm _ _ _
@@ -151,13 +154,13 @@ private theorem matrixUnit_prod_eq_zero_of_middle_ne
     (z x : (j : Fin (n + 1)) → Fin (D j))
     (q y : (i : Fin n) → Fin (D i.castSucc)) (hy : y ≠ q) :
     (∏ i : Fin n,
-      Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i)) = 0 := by
+      Matrix.single (z i.castSucc) (q i) (1 : ℂ) (x i.castSucc) (y i)) = 0 := by
   classical
   have hmiddle : ∃ i : Fin n, y i ≠ q i := by
     by_contra h
     apply hy
     funext i
-    exact not_ne.mp (not_exists.mp h i)
+    exact not_not.mp (not_exists.mp h i)
   obtain ⟨i, hi⟩ := hmiddle
   apply Finset.prod_eq_zero (Finset.mem_univ i)
   exact Matrix.single_apply_of_col_ne _ _ hi.symm _
@@ -191,14 +194,14 @@ theorem inverseContraction_openAlternatingNetwork
               ∏ i : Fin n, B i (τ i, y i) (x i.succ)
           else 0 := by
       simp only [openAlternatingNetwork, Finset.mul_sum]
-      rw [Fintype.sum_comm]
+      rw [Finset.sum_comm]
       apply Finset.sum_congr rfl
       intro x _
-      rw [Fintype.sum_comm]
+      rw [Finset.sum_comm]
       apply Finset.sum_congr rfl
       intro y _
       by_cases hxy : x 0 = z 0 ∧ x (Fin.last n) = z (Fin.last n)
-      · simp only [hxy, if_true]
+      · simp only [ite_eq_left hxy]
         simp_rw [Finset.prod_mul_distrib, ← mul_assoc]
         rw [← Finset.sum_mul, inverseCoefficient_sum A hA z x q y]
       · simp [hxy]
@@ -207,13 +210,16 @@ theorem inverseContraction_openAlternatingNetwork
       · rw [Fintype.sum_eq_single q]
         · simp
         · intro y hy
-          simp [matrixUnit_prod_eq_zero_of_middle_ne z z q y hy]
+          rw [ite_eq_left ⟨rfl, rfl⟩]
+          exact mul_eq_zero_of_left
+            (matrixUnit_prod_eq_zero_of_middle_ne z z q y hy) _
       · intro x hx
         by_cases hboundary : x 0 = z 0 ∧ x (Fin.last n) = z (Fin.last n)
-        · simp only [hboundary, if_true]
-          apply Finset.sum_eq_zero
+        · apply Finset.sum_eq_zero
           intro y _
-          rw [matrixUnit_prod_eq_zero_of_path_ne z x q y hboundary.2 hx, zero_mul]
+          rw [ite_eq_left hboundary]
+          exact mul_eq_zero_of_left
+            (matrixUnit_prod_eq_zero_of_path_ne z x q y hboundary.2 hx) _
         · simp [hboundary]
 
 private theorem exists_matrix_entry_ne_zero
@@ -252,7 +258,7 @@ theorem exists_scalars_of_openAlternatingNetwork_eq
     refine ⟨fun i ↦ Fin.elim0 i, by simp, ?_⟩
     intro i
     exact Fin.elim0 i
-  haveI : NeZero n := ⟨hn⟩
+  have : NeZero n := ⟨hn⟩
   have hentries :
       ∀ (r : (i : Fin n) → p i × Fin (D i.castSucc))
         (c : (i : Fin n) → Fin (D i.succ)),

--- a/TNLean/MPS/Chain/AlternatingNetwork.lean
+++ b/TNLean/MPS/Chain/AlternatingNetwork.lean
@@ -1,0 +1,307 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.PiTensorProductPhase
+import TNLean.MPS.Chain.OneSidedInverse
+
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Data.Matrix.Basis
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+
+/-!
+# Alternating open tensor networks
+
+This file proves the nondegenerate form of the alternating-network proportionality
+argument in arXiv:2502.20257, Lemma `lemma:1`, lines 2296--2395.  The network is kept
+open at its two horizontal ends.  Contracting the physical leg of each injective tensor
+against a one-sided inverse separates the tensors in the intervening positions.
+
+## Main definitions
+
+* `MPSTensor.openAlternatingNetwork` is the connected open chain
+  \(A_1B_1A_2B_2\cdots A_nB_n\).
+
+## Main results
+
+* `MPSTensor.inverseContraction_openAlternatingNetwork` implements contraction
+  by the paper's one-sided inverses of all \(A_i\).
+* `MPSTensor.exists_scalars_of_openAlternatingNetwork_eq` is the corrected form of
+  arXiv:2502.20257, Lemma `lemma:1`, under nonvanishing of every \(B_i\).
+
+**Local fix (nonzero intervening tensors):** the printed lemma omits nonvanishing,
+and a zero factor makes its conclusion false.  Both uses at lines 2567 and 3157
+have nonzero intervening tensors.  The convention and the zero-factor degeneration
+are recorded in
+`docs/paper-gaps/fbc25_alternating_network_nondegeneracy.tex`.
+
+## References
+
+* [arXiv:2502.20257](https://arxiv.org/abs/2502.20257) -- Adrián Franco Rubio,
+  Arkadiusz Bochniak, and J. Ignacio Cirac, *Symmetry defects and gauging for quantum
+  states with matrix product unitary symmetries*
+-/
+
+open scoped BigOperators TensorProduct
+
+namespace MPSTensor
+
+/-- The connected open chain \(A_1B_1A_2B_2\cdots A_nB_n\).
+
+The functions `d` and `D` give the sitewise physical dimensions and the dimensions
+of the \(n+1\) horizontal bonds.  At site \(i\), the injective tensor \(A_i\) has square
+bond dimension \(D_i\), while \(B_i\) has left and right bond dimensions \(D_i\) and
+\(D_{i+1}\).  Its remaining open leg has index type `p i` and is grouped with its
+left bond index.
+
+Source: arXiv:2502.20257, equation `eq:lemma_equality`, lines 2296--2361. -/
+noncomputable def openAlternatingNetwork
+    {n : ℕ} {d : Fin n → ℕ} (D : Fin (n + 1) → ℕ) (p : Fin n → Type*)
+    [∀ i : Fin n, Fintype (p i)]
+    (A : (i : Fin n) → MPSTensor (d i) (D i.castSucc))
+    (B : (i : Fin n) → Matrix (p i × Fin (D i.castSucc)) (Fin (D i.succ)) ℂ)
+    (σ : (i : Fin n) → Fin (d i)) (τ : (i : Fin n) → p i) :
+    Matrix (Fin (D 0)) (Fin (D (Fin.last n))) ℂ := fun a b ↦
+  ∑ x : (j : Fin (n + 1)) → Fin (D j),
+    ∑ y : (i : Fin n) → Fin (D i.castSucc),
+      if x 0 = a ∧ x (Fin.last n) = b then
+        ∏ i : Fin n,
+          A i (σ i) (x i.castSucc) (y i) * B i (τ i, y i) (x i.succ)
+      else 0
+
+private theorem piTensorProduct_eq_of_forall_matrix_entry_prod_eq
+    {n : ℕ} {row col : Fin n → Type*}
+    [∀ i : Fin n, Fintype (row i)] [∀ i : Fin n, Fintype (col i)]
+    (B B' : (i : Fin n) → Matrix (row i) (col i) ℂ)
+    (h : ∀ (r : (i : Fin n) → row i) (c : (i : Fin n) → col i),
+      (∏ i : Fin n, B i (r i) (c i)) = ∏ i : Fin n, B' i (r i) (c i)) :
+    (⨂ₜ[ℂ] i : Fin n, B i) = ⨂ₜ[ℂ] i : Fin n, B' i := by
+  classical
+  let b : (i : Fin n) →
+      Basis (row i × col i) ℂ (Matrix (row i) (col i) ℂ) :=
+    fun i ↦ Matrix.stdBasis ℂ (row i) (col i)
+  apply (Basis.piTensorProduct b).repr.injective
+  ext q
+  simpa [b, Matrix.stdBasis] using h (fun i ↦ (q i).1) (fun i ↦ (q i).2)
+
+private theorem decompositionMap_matrixUnit_entry
+    {d D : ℕ} {A : MPSTensor d D} (hA : Kraus.IsInjective A)
+    (a b x y : Fin D) :
+    (∑ s : Fin d,
+      Kraus.decompositionMap hA (Matrix.single a b 1) s * A s x y) =
+      Matrix.single a b 1 x y := by
+  calc
+    _ = (∑ s : Fin d,
+        Kraus.decompositionMap hA (Matrix.single a b 1) s • A s) x y := by
+      simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    _ = _ := by
+      rw [Kraus.decompositionMap_sum]
+
+private theorem inverseCoefficient_sum
+    {n : ℕ} {d : Fin n → ℕ} {D : Fin (n + 1) → ℕ}
+    (A : (i : Fin n) → MPSTensor (d i) (D i.castSucc))
+    (hA : ∀ i : Fin n, Kraus.IsInjective (A i))
+    (z x : (j : Fin (n + 1)) → Fin (D j))
+    (q y : (i : Fin n) → Fin (D i.castSucc)) :
+    (∑ σ : (i : Fin n) → Fin (d i),
+      (∏ i : Fin n,
+        Kraus.decompositionMap (hA i)
+          (Matrix.single (z i.castSucc) (q i) 1) (σ i)) *
+        ∏ i : Fin n, A i (σ i) (x i.castSucc) (y i)) =
+      ∏ i : Fin n,
+        Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i) := by
+  classical
+  calc
+    _ = ∏ i : Fin n, ∑ s : Fin (d i),
+        Kraus.decompositionMap (hA i)
+          (Matrix.single (z i.castSucc) (q i) 1) s *
+          A i s (x i.castSucc) (y i) := by
+      simpa only [Finset.prod_mul_distrib] using
+        (Fintype.prod_sum (fun i s ↦
+          Kraus.decompositionMap (hA i)
+            (Matrix.single (z i.castSucc) (q i) 1) s *
+            A i s (x i.castSucc) (y i))).symm
+    _ = _ := by
+      apply Finset.prod_congr rfl
+      intro i _
+      exact decompositionMap_matrixUnit_entry (hA i)
+        (z i.castSucc) (q i) (x i.castSucc) (y i)
+
+private theorem matrixUnit_prod_eq_zero_of_path_ne
+    {n : ℕ} {D : Fin (n + 1) → ℕ}
+    (z x : (j : Fin (n + 1)) → Fin (D j))
+    (q y : (i : Fin n) → Fin (D i.castSucc))
+    (hxlast : x (Fin.last n) = z (Fin.last n)) (hx : x ≠ z) :
+    (∏ i : Fin n,
+      Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i)) = 0 := by
+  classical
+  have hcast : ∃ i : Fin n, x i.castSucc ≠ z i.castSucc := by
+    by_contra h
+    apply hx
+    funext j
+    exact Fin.lastCases hxlast
+      (fun i ↦ not_ne.mp (not_exists.mp h i)) j
+  obtain ⟨i, hi⟩ := hcast
+  apply Finset.prod_eq_zero (Finset.mem_univ i)
+  exact Matrix.single_apply_of_row_ne hi.symm _ _ _
+
+private theorem matrixUnit_prod_eq_zero_of_middle_ne
+    {n : ℕ} {D : Fin (n + 1) → ℕ}
+    (z x : (j : Fin (n + 1)) → Fin (D j))
+    (q y : (i : Fin n) → Fin (D i.castSucc)) (hy : y ≠ q) :
+    (∏ i : Fin n,
+      Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i)) = 0 := by
+  classical
+  have hmiddle : ∃ i : Fin n, y i ≠ q i := by
+    by_contra h
+    apply hy
+    funext i
+    exact not_ne.mp (not_exists.mp h i)
+  obtain ⟨i, hi⟩ := hmiddle
+  apply Finset.prod_eq_zero (Finset.mem_univ i)
+  exact Matrix.single_apply_of_col_ne _ _ hi.symm _
+
+/-- Contracting every injective tensor against inverse coefficients for matrix
+units separates all intervening tensors in the connected open chain.
+
+This is the inverse-tensor contraction in arXiv:2502.20257, Lemma `lemma:1`,
+lines 2365--2392. -/
+theorem inverseContraction_openAlternatingNetwork
+    {n : ℕ} {d : Fin n → ℕ} (D : Fin (n + 1) → ℕ) (p : Fin n → Type*)
+    [∀ i : Fin n, Fintype (p i)]
+    (A : (i : Fin n) → MPSTensor (d i) (D i.castSucc))
+    (B : (i : Fin n) → Matrix (p i × Fin (D i.castSucc)) (Fin (D i.succ)) ℂ)
+    (hA : ∀ i : Fin n, Kraus.IsInjective (A i))
+    (z : (j : Fin (n + 1)) → Fin (D j))
+    (q : (i : Fin n) → Fin (D i.castSucc)) (τ : (i : Fin n) → p i) :
+    (∑ σ : (i : Fin n) → Fin (d i),
+      (∏ i : Fin n,
+        Kraus.decompositionMap (hA i)
+          (Matrix.single (z i.castSucc) (q i) 1) (σ i)) *
+        openAlternatingNetwork D p A B σ τ (z 0) (z (Fin.last n))) =
+      ∏ i : Fin n, B i (τ i, q i) (z i.succ) := by
+  classical
+  calc
+    _ = ∑ x : (j : Fin (n + 1)) → Fin (D j),
+        ∑ y : (i : Fin n) → Fin (D i.castSucc),
+          if x 0 = z 0 ∧ x (Fin.last n) = z (Fin.last n) then
+            (∏ i : Fin n,
+              Matrix.single (z i.castSucc) (q i) 1 (x i.castSucc) (y i)) *
+              ∏ i : Fin n, B i (τ i, y i) (x i.succ)
+          else 0 := by
+      simp only [openAlternatingNetwork, Finset.mul_sum]
+      rw [Fintype.sum_comm]
+      apply Finset.sum_congr rfl
+      intro x _
+      rw [Fintype.sum_comm]
+      apply Finset.sum_congr rfl
+      intro y _
+      by_cases hxy : x 0 = z 0 ∧ x (Fin.last n) = z (Fin.last n)
+      · simp only [hxy, if_true]
+        simp_rw [Finset.prod_mul_distrib, ← mul_assoc]
+        rw [← Finset.sum_mul, inverseCoefficient_sum A hA z x q y]
+      · simp [hxy]
+    _ = _ := by
+      rw [Fintype.sum_eq_single z]
+      · rw [Fintype.sum_eq_single q]
+        · simp
+        · intro y hy
+          simp [matrixUnit_prod_eq_zero_of_middle_ne z z q y hy]
+      · intro x hx
+        by_cases hboundary : x 0 = z 0 ∧ x (Fin.last n) = z (Fin.last n)
+        · simp only [hboundary, if_true]
+          apply Finset.sum_eq_zero
+          intro y _
+          rw [matrixUnit_prod_eq_zero_of_path_ne z x q y hboundary.2 hx, zero_mul]
+        · simp [hboundary]
+
+private theorem exists_matrix_entry_ne_zero
+    {r c : Type*} (M : Matrix r c ℂ) (hM : M ≠ 0) :
+    ∃ a b, M a b ≠ 0 := by
+  classical
+  by_contra h
+  apply hM
+  ext a b
+  by_contra hab
+  exact h ⟨a, b, hab⟩
+
+/-- The nondegenerate corrected form of the alternating-network proportionality
+lemma: equality of the connected open chains forces the intervening tensors to
+be proportional, with product-one proportionality scalars.
+
+Source: arXiv:2502.20257, Lemma `lemma:1` and equation `eq:lemma_equality`,
+lines 2296--2395.  Nonvanishing is justified at the two uses on lines 2567 and
+3157. -/
+theorem exists_scalars_of_openAlternatingNetwork_eq
+    {n : ℕ} {d : Fin n → ℕ} (D : Fin (n + 1) → ℕ) (p : Fin n → Type*)
+    [∀ i : Fin n, Fintype (p i)]
+    (A : (i : Fin n) → MPSTensor (d i) (D i.castSucc))
+    (B B' : (i : Fin n) →
+      Matrix (p i × Fin (D i.castSucc)) (Fin (D i.succ)) ℂ)
+    (hA : ∀ i : Fin n, Kraus.IsInjective (A i))
+    (hB : ∀ i : Fin n, B i ≠ 0)
+    (hnetwork : ∀ (σ : (i : Fin n) → Fin (d i)) (τ : (i : Fin n) → p i),
+      openAlternatingNetwork D p A B σ τ =
+        openAlternatingNetwork D p A B' σ τ) :
+    ∃ β : Fin n → ℂ,
+      (∏ i : Fin n, β i = 1) ∧ ∀ i : Fin n, B i = β i • B' i := by
+  classical
+  by_cases hn : n = 0
+  · subst n
+    refine ⟨fun i ↦ Fin.elim0 i, by simp, ?_⟩
+    intro i
+    exact Fin.elim0 i
+  haveI : NeZero n := ⟨hn⟩
+  have hentries :
+      ∀ (r : (i : Fin n) → p i × Fin (D i.castSucc))
+        (c : (i : Fin n) → Fin (D i.succ)),
+        (∏ i : Fin n, B i (r i) (c i)) =
+          ∏ i : Fin n, B' i (r i) (c i) := by
+    intro r c
+    let z : (j : Fin (n + 1)) → Fin (D j) :=
+      Fin.cases (r 0).2 (fun i ↦ c i)
+    let q : (i : Fin n) → Fin (D i.castSucc) := fun i ↦ (r i).2
+    let τ : (i : Fin n) → p i := fun i ↦ (r i).1
+    calc
+      ∏ i : Fin n, B i (r i) (c i) =
+          ∏ i : Fin n, B i (τ i, q i) (z i.succ) := by
+            simp [z, q, τ]
+      _ = ∑ σ : (i : Fin n) → Fin (d i),
+          (∏ i : Fin n,
+            Kraus.decompositionMap (hA i)
+              (Matrix.single (z i.castSucc) (q i) 1) (σ i)) *
+            openAlternatingNetwork D p A B σ τ (z 0) (z (Fin.last n)) :=
+        (inverseContraction_openAlternatingNetwork D p A B hA z q τ).symm
+      _ = ∑ σ : (i : Fin n) → Fin (d i),
+          (∏ i : Fin n,
+            Kraus.decompositionMap (hA i)
+              (Matrix.single (z i.castSucc) (q i) 1) (σ i)) *
+            openAlternatingNetwork D p A B' σ τ (z 0) (z (Fin.last n)) := by
+        apply Finset.sum_congr rfl
+        intro σ _
+        rw [hnetwork σ τ]
+      _ = ∏ i : Fin n, B' i (τ i, q i) (z i.succ) :=
+        inverseContraction_openAlternatingNetwork D p A B' hA z q τ
+      _ = ∏ i : Fin n, B' i (r i) (c i) := by
+        simp [z, q, τ]
+  have htensor :
+      (⨂ₜ[ℂ] i : Fin n, B i) = ⨂ₜ[ℂ] i : Fin n, B' i :=
+    piTensorProduct_eq_of_forall_matrix_entry_prod_eq B B' hentries
+  choose r c hrc using fun i ↦ exists_matrix_entry_ne_zero (B i) (hB i)
+  obtain ⟨κ, hκprod, hκ⟩ :=
+    TNLean.Algebra.PiTensorProductPhase.exists_kappa_of_piTensorProduct_eq_smul
+      (fun i (_ : Fin 1) ↦ B' i) (fun i (_ : Fin 1) ↦ B i)
+      1 one_ne_zero (fun _ ↦ 0) r c (fun i ↦ by simpa using hrc i)
+      (fun _ ↦ by simpa using htensor.symm)
+  have hκprod_ne : (∏ i : Fin n, κ i) ≠ 0 := by
+    rw [hκprod]
+    exact one_ne_zero
+  have hκ_ne (i : Fin n) : κ i ≠ 0 :=
+    (Finset.prod_ne_zero_iff.mp hκprod_ne) i (Finset.mem_univ i)
+  refine ⟨fun i ↦ (κ i)⁻¹, ?_, ?_⟩
+  · rw [Finset.prod_inv_distrib, hκprod, inv_one]
+  · intro i
+    rw [hκ i 0, ← mul_smul, inv_mul_cancel₀ (hκ_ne i), one_smul]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -638,6 +638,132 @@ These three matrix identities supply the final algebraic steps in
 Theorem~\ref{thm:mpug_dagger_inverse_scalar} after the representation-level
 gauges and scalar relation have been constructed.
 
+\section{A nondegenerate alternating-network comparison}
+\label{sec:mpug_alternating_network}
+
+\begin{definition}[Connected open alternating network]
+    \label{def:mpug_open_alternating_network}
+    \lean{MPSTensor.openAlternatingNetwork}
+    \leanok
+    Let $n\geq 0$, and let $D_1,\ldots,D_{n+1}$ be horizontal bond dimensions.  At each
+    $1\leq i\leq n$, let $A_i$ have square bond dimension $D_i$, and let
+    $B_i$ have left and right bond dimensions $D_i$ and $D_{i+1}$.  For fixed
+    physical indices $\sigma=(\sigma_i)_i$ and $\tau=(\tau_i)_i$, define the
+    connected network with its horizontal ends open by
+    \begin{align}
+        \mathcal N_{A,B}(\sigma,\tau)_{a,b}
+            &:=\sum_{\substack{x_1,\ldots,x_{n+1}\\
+                    x_1=a,\,x_{n+1}=b}}
+                \ \sum_{y_1,\ldots,y_n}
+                \prod_{i=1}^{n}
+                (A_i^{\sigma_i})_{x_i,y_i}
+                (B_i^{\tau_i})_{y_i,x_{i+1}}.
+        \notag
+    \end{align}
+    The indices $y_i$ join $A_i$ to $B_i$, while $x_{i+1}$ joins $B_i$ to
+    $A_{i+1}$ when $i<n$; $x_1$ and $x_{n+1}$ are the two open end indices.
+    This is the coordinate form of the connected open diagram in
+    \cite[lines~2299--2361, equation~\texttt{eq:lemma\_equality}]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{lemma}[One-sided-inverse contraction of an alternating network]
+    \label{lem:mpug_inverse_contraction_open_alternating_network}
+    \lean{MPSTensor.inverseContraction_openAlternatingNetwork}
+    \leanok
+    \uses{def:injective, def:decomposition_map,
+        def:mpug_open_alternating_network}
+    Suppose that every $A_i$ is injective.  For the matrix unit $E_{z_i,q_i}$,
+    let $c_i^{\sigma_i}(z_i,q_i)$ be its coefficients under a one-sided
+    inverse of $A_i$, so that
+    \begin{align}
+        \sum_{\sigma_i}c_i^{\sigma_i}(z_i,q_i)A_i^{\sigma_i}
+            &=E_{z_i,q_i}.
+        \notag
+    \end{align}
+    Then, for every horizontal path $z=(z_i)_{i=1}^{n+1}$, every intermediate
+    path $q=(q_i)_{i=1}^{n}$, and every $\tau$, one has
+    \begin{align}
+        \sum_{\sigma_1,\ldots,\sigma_n}
+            \left(\prod_{i=1}^{n}c_i^{\sigma_i}(z_i,q_i)\right)
+            \mathcal N_{A,B}(\sigma,\tau)_{z_1,z_{n+1}}
+            &=\prod_{i=1}^{n}(B_i^{\tau_i})_{q_i,z_{i+1}}.
+        \notag
+    \end{align}
+    This is the simultaneous inverse-tensor contraction in
+    \cite[lines~2365--2392]{FrancoRubio2025MPUGauging}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the connected network and interchange the finite sums.  At site
+    $i$, the sum over $\sigma_i$ is the $(x_i,y_i)$ entry of
+    $E_{z_i,q_i}$.  Its two Kronecker deltas force $x_i=z_i$ and $y_i=q_i$.
+    Thus every internal sum collapses, leaving precisely the displayed product
+    of entries of the $B_i$.
+\end{proof}
+
+\begin{theorem}[Nondegenerate corrected alternating-network proportionality]
+    \label{thm:mpug_alternating_network_nondegenerate}
+    \lean{MPSTensor.exists_scalars_of_openAlternatingNetwork_eq}
+    \leanok
+    \uses{def:injective, def:decomposition_map,
+        def:mpug_open_alternating_network,
+        lem:mpug_inverse_contraction_open_alternating_network,
+        thm:periodic_product_tensor_phase_extraction}
+    Let $n\geq 0$, and let $D_1,\ldots,D_{n+1}$ be horizontal bond dimensions.
+    For each $1\leq i\leq n$, let $A_i$ be an injective MPS tensor with square
+    bond dimension $D_i$, and let $B_i,B'_i$ be tensors whose left and right
+    horizontal bond dimensions are $D_i$ and $D_{i+1}$.  Suppose that every
+    $B_i$ is nonzero and that the connected open networks agree:
+    \begin{align}
+        A_1B_1A_2B_2\cdots A_nB_n
+            &=A_1B'_1A_2B'_2\cdots A_nB'_n.
+        \label{eq:mpug_alternating_network_equality}
+    \end{align}
+    Here the equality retains the two horizontal end legs and all physical
+    legs.  Then there are scalars $\beta_i\in\C$ such that
+    \begin{align}
+        B_i&=\beta_iB'_i,
+        \label{eq:mpug_alternating_network_proportionality}\\
+        \prod_{i=1}^{n}\beta_i&=1.
+        \label{eq:mpug_alternating_network_scalar_product}
+    \end{align}
+
+    This is the nondegenerate corrected form of Lemma~\texttt{lemma:1} in
+    \cite[lines~2296--2395]{FrancoRubio2025MPUGauging}.  The printed wording
+    omits nonvanishing.  The paper's truncated symmetry $U^L_g$ is unitary at
+    line~2099;
+    lines~2444--2466 identify the side used at line~2567 with
+    $(U^L_{g^{-1}})^\dagger$, while lines~3033--3053 identify the side used at
+    line~3157 with $\sigma_g(U^L_{g^{-1}})^\dagger$ for
+    $\sigma_g\in\{1,-1\}$.  Both displayed networks are therefore nonzero.  A
+    vanishing intervening factor would make its entire network zero, so taking
+    the factors on these sides as the $B_i$ supplies $B_i\ne 0$ at both
+    applications.  The zero-factor degeneration and this local correction are
+    recorded in
+    \cite{gap:fbc25_alternating_network_nondegeneracy}.  The unrestricted
+    printed statement is not asserted here.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Lemma~\ref{lem:mpug_inverse_contraction_open_alternating_network} to
+    both sides of (\ref{eq:mpug_alternating_network_equality}), choosing the
+    matrix units to prescribe arbitrary entries of all $B_i$.  The resulting
+    connected horizontal contractions retain precisely those entries.  Since
+    the entries were arbitrary, this gives the pure-tensor identity
+    \begin{align}
+        \bigotimes_{i=1}^{n}B_i
+            &=\bigotimes_{i=1}^{n}B'_i.
+        \label{eq:mpug_alternating_network_pure_tensor_equality}
+    \end{align}
+    Apply Theorem~\ref{thm:periodic_product_tensor_phase_extraction} to
+    (\ref{eq:mpug_alternating_network_pure_tensor_equality}), with global
+    scalar $1$ and the nonzero reference entries of the $B_i$.  It
+    gives the factorwise proportionalities and
+    (\ref{eq:mpug_alternating_network_scalar_product}); reversing the
+    resulting nonzero scalars gives the orientation
+    (\ref{eq:mpug_alternating_network_proportionality}).
+\end{proof}
+
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
 \label{sec:mpug_scalar_gauge}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -652,12 +652,12 @@ gauges and scalar relation have been constructed.
     connected network with its horizontal ends open by
     \begin{align}
         \mathcal N_{A,B}(\sigma,\tau)_{a,b}
-            &:=\sum_{\substack{x_1,\ldots,x_{n+1}\\
-                    x_1=a,\,x_{n+1}=b}}
-                \ \sum_{y_1,\ldots,y_n}
-                \prod_{i=1}^{n}
-                (A_i^{\sigma_i})_{x_i,y_i}
-                (B_i^{\tau_i})_{y_i,x_{i+1}}.
+         & :=\sum_{\substack{x_1,\ldots,x_{n+1} \\
+                x_1=a,\,x_{n+1}=b}}
+        \ \sum_{y_1,\ldots,y_n}
+        \prod_{i=1}^{n}
+        (A_i^{\sigma_i})_{x_i,y_i}
+        (B_i^{\tau_i})_{y_i,x_{i+1}}.
         \notag
     \end{align}
     The indices $y_i$ join $A_i$ to $B_i$, while $x_{i+1}$ joins $B_i$ to
@@ -677,16 +677,16 @@ gauges and scalar relation have been constructed.
     inverse of $A_i$, so that
     \begin{align}
         \sum_{\sigma_i}c_i^{\sigma_i}(z_i,q_i)A_i^{\sigma_i}
-            &=E_{z_i,q_i}.
+         & =E_{z_i,q_i}.
         \notag
     \end{align}
     Then, for every horizontal path $z=(z_i)_{i=1}^{n+1}$, every intermediate
     path $q=(q_i)_{i=1}^{n}$, and every $\tau$, one has
     \begin{align}
         \sum_{\sigma_1,\ldots,\sigma_n}
-            \left(\prod_{i=1}^{n}c_i^{\sigma_i}(z_i,q_i)\right)
-            \mathcal N_{A,B}(\sigma,\tau)_{z_1,z_{n+1}}
-            &=\prod_{i=1}^{n}(B_i^{\tau_i})_{q_i,z_{i+1}}.
+        \left(\prod_{i=1}^{n}c_i^{\sigma_i}(z_i,q_i)\right)
+        \mathcal N_{A,B}(\sigma,\tau)_{z_1,z_{n+1}}
+         & =\prod_{i=1}^{n}(B_i^{\tau_i})_{q_i,z_{i+1}}.
         \notag
     \end{align}
     This is the simultaneous inverse-tensor contraction in
@@ -716,15 +716,15 @@ gauges and scalar relation have been constructed.
     $B_i$ is nonzero and that the connected open networks agree:
     \begin{align}
         A_1B_1A_2B_2\cdots A_nB_n
-            &=A_1B'_1A_2B'_2\cdots A_nB'_n.
+         & =A_1B'_1A_2B'_2\cdots A_nB'_n.
         \label{eq:mpug_alternating_network_equality}
     \end{align}
     Here the equality retains the two horizontal end legs and all physical
     legs.  Then there are scalars $\beta_i\in\C$ such that
     \begin{align}
-        B_i&=\beta_iB'_i,
-        \label{eq:mpug_alternating_network_proportionality}\\
-        \prod_{i=1}^{n}\beta_i&=1.
+        B_i                    & =\beta_iB'_i,
+        \label{eq:mpug_alternating_network_proportionality} \\
+        \prod_{i=1}^{n}\beta_i & =1.
         \label{eq:mpug_alternating_network_scalar_product}
     \end{align}
 
@@ -752,7 +752,7 @@ gauges and scalar relation have been constructed.
     the entries were arbitrary, this gives the pure-tensor identity
     \begin{align}
         \bigotimes_{i=1}^{n}B_i
-            &=\bigotimes_{i=1}^{n}B'_i.
+         & =\bigotimes_{i=1}^{n}B'_i.
         \label{eq:mpug_alternating_network_pure_tensor_equality}
     \end{align}
     Apply Theorem~\ref{thm:periodic_product_tensor_phase_extraction} to

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -663,7 +663,7 @@ gauges and scalar relation have been constructed.
     The indices $y_i$ join $A_i$ to $B_i$, while $x_{i+1}$ joins $B_i$ to
     $A_{i+1}$ when $i<n$; $x_1$ and $x_{n+1}$ are the two open end indices.
     This is the coordinate form of the connected open diagram in
-    \cite[lines~2299--2361, equation~\texttt{eq:lemma\_equality}]{FrancoRubio2025MPUGauging}.
+    \cite[lines~2299--2361]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
 \begin{lemma}[One-sided-inverse contraction of an alternating network]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -645,23 +645,23 @@ gauges and scalar relation have been constructed.
     \label{def:mpug_open_alternating_network}
     \lean{MPSTensor.openAlternatingNetwork}
     \leanok
-    Let $n\geq 0$, and let $D_1,\ldots,D_{n+1}$ be horizontal bond dimensions.  At each
-    $1\leq i\leq n$, let $A_i$ have square bond dimension $D_i$, and let
-    $B_i$ have left and right bond dimensions $D_i$ and $D_{i+1}$.  For fixed
+    Let $n\geq 0$, and let $D_0,\ldots,D_n$ be horizontal bond dimensions.  At each
+    $0\leq i<n$, let $A_i$ have square bond dimension $D_i$, and let $B_i$ have
+    left and right bond dimensions $D_i$ and $D_{i+1}$.  For fixed
     physical indices $\sigma=(\sigma_i)_i$ and $\tau=(\tau_i)_i$, define the
     connected network with its horizontal ends open by
     \begin{align}
         \mathcal N_{A,B}(\sigma,\tau)_{a,b}
-         & :=\sum_{\substack{x_1,\ldots,x_{n+1} \\
-                x_1=a,\,x_{n+1}=b}}
-        \ \sum_{y_1,\ldots,y_n}
-        \prod_{i=1}^{n}
+         & :=\sum_{\substack{x_0,\ldots,x_n \\
+                x_0=a,\,x_n=b}}
+        \ \sum_{y_0,\ldots,y_{n-1}}
+        \prod_{i=0}^{n-1}
         (A_i^{\sigma_i})_{x_i,y_i}
         (B_i^{\tau_i})_{y_i,x_{i+1}}.
         \notag
     \end{align}
     The indices $y_i$ join $A_i$ to $B_i$, while $x_{i+1}$ joins $B_i$ to
-    $A_{i+1}$ when $i<n$; $x_1$ and $x_{n+1}$ are the two open end indices.
+    $A_{i+1}$ when $i+1<n$; $x_0$ and $x_n$ are the two open end indices.
     This is the coordinate form of the connected open diagram in
     \cite[lines~2299--2361]{FrancoRubio2025MPUGauging}.
 \end{definition}
@@ -680,13 +680,13 @@ gauges and scalar relation have been constructed.
          & =E_{z_i,q_i}.
         \notag
     \end{align}
-    Then, for every horizontal path $z=(z_i)_{i=1}^{n+1}$, every intermediate
-    path $q=(q_i)_{i=1}^{n}$, and every $\tau$, one has
+    Then, for every horizontal path $z=(z_i)_{i=0}^{n}$, every intermediate
+    path $q=(q_i)_{i=0}^{n-1}$, and every $\tau$, one has
     \begin{align}
-        \sum_{\sigma_1,\ldots,\sigma_n}
-        \left(\prod_{i=1}^{n}c_i^{\sigma_i}(z_i,q_i)\right)
-        \mathcal N_{A,B}(\sigma,\tau)_{z_1,z_{n+1}}
-         & =\prod_{i=1}^{n}(B_i^{\tau_i})_{q_i,z_{i+1}}.
+        \sum_{\sigma_0,\ldots,\sigma_{n-1}}
+        \left(\prod_{i=0}^{n-1}c_i^{\sigma_i}(z_i,q_i)\right)
+        \mathcal N_{A,B}(\sigma,\tau)_{z_0,z_n}
+         & =\prod_{i=0}^{n-1}(B_i^{\tau_i})_{q_i,z_{i+1}}.
         \notag
     \end{align}
     This is the simultaneous inverse-tensor contraction in
@@ -706,22 +706,22 @@ gauges and scalar relation have been constructed.
     \lean{MPSTensor.exists_scalars_of_openAlternatingNetwork_eq}
     \leanok
     \uses{def:injective, def:mpug_open_alternating_network}
-    Let $n\geq 0$, and let $D_1,\ldots,D_{n+1}$ be horizontal bond dimensions.
-    For each $1\leq i\leq n$, let $A_i$ be an injective MPS tensor with square
-    bond dimension $D_i$, and let $B_i,B'_i$ be tensors whose left and right
+    Let $n\geq 0$, and let $D_0,\ldots,D_n$ be horizontal bond dimensions.
+    For each $0\leq i<n$, let $A_i$ be an injective MPS tensor with square bond
+    dimension $D_i$, and let $B_i,B'_i$ be tensors whose left and right
     horizontal bond dimensions are $D_i$ and $D_{i+1}$.  Suppose that every
     $B_i$ is nonzero and that the connected open networks agree:
     \begin{align}
-        A_1B_1A_2B_2\cdots A_nB_n
-         & =A_1B'_1A_2B'_2\cdots A_nB'_n.
+        A_0B_0A_1B_1\cdots A_{n-1}B_{n-1}
+         & =A_0B'_0A_1B'_1\cdots A_{n-1}B'_{n-1}.
         \label{eq:mpug_alternating_network_equality}
     \end{align}
     Here the equality retains the two horizontal end legs and all physical
-    legs.  Then there are scalars $\beta_i\in\C$ such that
+    legs.  Then there are scalars $\beta_i\in\C$, for $0\leq i<n$, such that
     \begin{align}
-        B_i                    & =\beta_iB'_i,
+        B_i                      & =\beta_iB'_i,
         \label{eq:mpug_alternating_network_proportionality} \\
-        \prod_{i=1}^{n}\beta_i & =1.
+        \prod_{i=0}^{n-1}\beta_i & =1.
         \label{eq:mpug_alternating_network_scalar_product}
     \end{align}
 
@@ -750,8 +750,8 @@ gauges and scalar relation have been constructed.
     connected horizontal contractions retain precisely those entries.  Since
     the entries were arbitrary, this gives the pure-tensor identity
     \begin{align}
-        \bigotimes_{i=1}^{n}B_i
-         & =\bigotimes_{i=1}^{n}B'_i.
+        \bigotimes_{i=0}^{n-1}B_i
+         & =\bigotimes_{i=0}^{n-1}B'_i.
         \label{eq:mpug_alternating_network_pure_tensor_equality}
     \end{align}
     Apply Theorem~\ref{thm:periodic_product_tensor_phase_extraction} to

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -705,10 +705,7 @@ gauges and scalar relation have been constructed.
     \label{thm:mpug_alternating_network_nondegenerate}
     \lean{MPSTensor.exists_scalars_of_openAlternatingNetwork_eq}
     \leanok
-    \uses{def:injective, def:decomposition_map,
-        def:mpug_open_alternating_network,
-        lem:mpug_inverse_contraction_open_alternating_network,
-        thm:periodic_product_tensor_phase_extraction}
+    \uses{def:injective, def:mpug_open_alternating_network}
     Let $n\geq 0$, and let $D_1,\ldots,D_{n+1}$ be horizontal bond dimensions.
     For each $1\leq i\leq n$, let $A_i$ be an injective MPS tensor with square
     bond dimension $D_i$, and let $B_i,B'_i$ be tensors whose left and right
@@ -738,13 +735,15 @@ gauges and scalar relation have been constructed.
     $\sigma_g\in\{1,-1\}$.  Both displayed networks are therefore nonzero.  A
     vanishing intervening factor would make its entire network zero, so taking
     the factors on these sides as the $B_i$ supplies $B_i\ne 0$ at both
-    applications.  The zero-factor degeneration and this local correction are
-    recorded in
+    applications.  This local nondegeneracy convention is recorded in
     \cite{gap:fbc25_alternating_network_nondegeneracy}.  The unrestricted
     printed statement is not asserted here.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:decomposition_map,
+        lem:mpug_inverse_contraction_open_alternating_network,
+        thm:periodic_product_tensor_phase_extraction}
     Apply Lemma~\ref{lem:mpug_inverse_contraction_open_alternating_network} to
     both sides of (\ref{eq:mpug_alternating_network_equality}), choosing the
     matrix units to prescribe arbitrary entries of all $B_i$.  The resulting

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -966,6 +966,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf}},
 }
 
+@techreport{gap:fbc25_alternating_network_nondegeneracy,
+  author      = {The {TNLean} contributors},
+  title       = {Nondegeneracy in the Alternating-Network Proportionality Lemma},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_alternating\_network\_nondegeneracy},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_alternating_network_nondegeneracy.pdf}},
+}
+
 @techreport{gap:fbc25_block_independence_reciprocal_errors,
   author      = {The {TNLean} contributors},
   title       = {Reciprocal Factors in the Block-Independence Argument},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -30,6 +30,12 @@ For the MPU symmetry-defect gauging paper:
   distinction between a trivial anomaly class and a pointwise trivial gauge,
   and the stable finite-periodic-chain support boundary. It is a prerequisite
   audit, not a formalization of Proposition `prop:comm_proj`.
+- `fbc25_alternating_network_nondegeneracy.tex` records the zero-factor
+  counterexample to the unrestricted alternating-network proportionality
+  lemma and the corrected one-sided nonvanishing hypothesis. Both applications
+  in the source satisfy this hypothesis because their displayed boundary
+  networks are nonzero scalar multiples of adjoints of truncated unitaries.
+  The local correction is resolved by the formal nondegenerate theorem.
 
 For GNVW support algebras, the source corrections and the remaining scope
 restriction are recorded separately.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -30,12 +30,12 @@ For the MPU symmetry-defect gauging paper:
   distinction between a trivial anomaly class and a pointwise trivial gauge,
   and the stable finite-periodic-chain support boundary. It is a prerequisite
   audit, not a formalization of Proposition `prop:comm_proj`.
-- `fbc25_alternating_network_nondegeneracy.tex` records the zero-factor
-  counterexample to the unrestricted alternating-network proportionality
-  lemma and the corrected one-sided nonvanishing hypothesis. Both applications
-  in the source satisfy this hypothesis because their displayed boundary
-  networks are nonzero scalar multiples of adjoints of truncated unitaries.
-  The local correction is resolved by the formal nondegenerate theorem.
+- `fbc25_alternating_network_nondegeneracy.tex` records the one-sided
+  nonvanishing convention for the alternating-network proportionality lemma.
+  Both applications in the source satisfy this convention because their
+  displayed boundary networks are nonzero scalar multiples of adjoints of
+  truncated unitaries. The local correction is resolved by the formal
+  nondegenerate theorem.
 
 For GNVW support algebras, the source corrections and the remaining scope
 restriction are recorded separately.

--- a/docs/paper-gaps/fbc25_alternating_network_nondegeneracy.tex
+++ b/docs/paper-gaps/fbc25_alternating_network_nondegeneracy.tex
@@ -1,0 +1,100 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Nondegeneracy in the Alternating-Network Proportionality Lemma}
+\author{}
+\date{2026-08-30}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+\section{The printed statement}
+
+Lemma~\texttt{lemma:1} of
+Ref.~\cite[lines~2296--2395]{FrancoRubio2025MPUGauging} considers a connected
+open chain
+\begin{align}
+    A_1B_1A_2B_2\cdots A_nB_n
+        &=A_1B'_1A_2B'_2\cdots A_nB'_n,
+    \label{eq:fbc25_alternating_network_nondegeneracy_source_equality}
+\end{align}
+where every $A_i$ is injective.  It concludes that there are scalars
+$\beta_i$ such that
+\begin{align}
+    B_i&=\beta_iB'_i,
+    \label{eq:fbc25_alternating_network_nondegeneracy_source_proportionality}\\
+    \prod_{i=1}^n\beta_i&=1.
+    \label{eq:fbc25_alternating_network_nondegeneracy_source_product}
+\end{align}
+The statement does not exclude a zero factor.  For $n=2$, take
+$B_1=B'_1=0$ and choose $B_2,B'_2$ which are not proportional.  Then
+(\ref{eq:fbc25_alternating_network_nondegeneracy_source_equality}) holds,
+but
+(\ref{eq:fbc25_alternating_network_nondegeneracy_source_proportionality})
+does not.  This is the degenerate zero-factor reading of the printed lemma.
+
+\section{Nondegenerate correction}
+
+The corrected statement assumes
+\begin{align}
+    B_i&\ne0\qquad (1\leq i\leq n).
+    \label{eq:fbc25_alternating_network_nondegeneracy_nonzero_factors}
+\end{align}
+Contracting the physical leg of each $A_i$ against an inverse tensor, exactly
+as in the source proof, separates the intervening tensors and gives
+\begin{align}
+    \bigotimes_{i=1}^n B_i
+        &=\bigotimes_{i=1}^n B'_i.
+    \label{eq:fbc25_alternating_network_nondegeneracy_pure_tensor_equality}
+\end{align}
+Condition
+(\ref{eq:fbc25_alternating_network_nondegeneracy_nonzero_factors}) makes the
+left-hand side of
+(\ref{eq:fbc25_alternating_network_nondegeneracy_pure_tensor_equality})
+nonzero.  Proportionality of the factors of two equal nonzero pure tensors
+then gives
+(\ref{eq:fbc25_alternating_network_nondegeneracy_source_proportionality})--%
+(\ref{eq:fbc25_alternating_network_nondegeneracy_source_product}).  A
+one-sided nonvanishing assumption is sufficient: the pure-tensor equality
+forces every $B'_i$ to be nonzero as well.
+
+The two uses in Ref.~\cite{FrancoRubio2025MPUGauging} already lie in this
+nondegenerate regime.  The truncated symmetry $U^L_g$ is unitary by the
+statement at line~2099.  For the application at line~2567, lines~2444--2466
+identify one side of the top boundary network with
+$(U^L_{g^{-1}})^\dagger$.  This network is nonzero; hence none of its
+constituent intervening factors can vanish.  One may take these factors as the
+single-sided family $B_i$ in
+(\ref{eq:fbc25_alternating_network_nondegeneracy_nonzero_factors}).  For the
+application at line~3157, lines~3033--3053 identify the corresponding network
+with $\sigma_g(U^L_{g^{-1}})^\dagger$, where
+$\sigma_g\in\{1,-1\}$.  It is again nonzero for the same reason.  Neither use
+requires a stronger invertibility assumption on every $B_i$.
+
+\section{Formal treatment}
+
+The formal theorem models the connected open chain with its horizontal ends
+uncontracted.  Matrix units supplied to the one-sided inverses of the
+injective $A_i$ retain both virtual indices, so their contraction proves
+(\ref{eq:fbc25_alternating_network_nondegeneracy_pure_tensor_equality}) rather
+than merely an equality of matrix products.  The final factorwise conclusion
+uses the existing pure-tensor proportionality theorem.\footnote{Formal
+declaration:
+\leanid{MPSTensor.exists\_scalars\_of\_openAlternatingNetwork\_eq} in
+\doclink{TNLean/MPS/Chain/AlternatingNetwork}.}
+
+\textbf{Verdict: resolved local fix.}
+The zero-factor degeneration is excluded by the intended nondegenerate
+convention, which is present at both applications in the article.  The
+unrestricted printed wording is not used as a formal theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/fbc25_alternating_network_nondegeneracy.tex
+++ b/docs/paper-gaps/fbc25_alternating_network_nondegeneracy.tex
@@ -14,7 +14,7 @@
 \maketitle
 \gapnote{local-correction}{resolved}
 
-\section{The printed statement}
+\section{Local nondegeneracy convention}
 
 Lemma~\texttt{lemma:1} of
 Ref.~\cite[lines~2296--2395]{FrancoRubio2025MPUGauging} considers a connected
@@ -32,12 +32,9 @@ $\beta_i$ such that
     \prod_{i=1}^n\beta_i&=1.
     \label{eq:fbc25_alternating_network_nondegeneracy_source_product}
 \end{align}
-The statement does not exclude a zero factor.  For $n=2$, take
-$B_1=B'_1=0$ and choose $B_2,B'_2$ which are not proportional.  Then
-(\ref{eq:fbc25_alternating_network_nondegeneracy_source_equality}) holds,
-but
-(\ref{eq:fbc25_alternating_network_nondegeneracy_source_proportionality})
-does not.  This is the degenerate zero-factor reading of the printed lemma.
+The formal treatment adopts the intended nondegenerate convention that every
+intervening tensor $B_i$ is nonzero.  This convention is present at both
+applications of the lemma in the article.
 
 \section{Nondegenerate correction}
 
@@ -90,9 +87,8 @@ declaration:
 \doclink{TNLean/MPS/Chain/AlternatingNetwork}.}
 
 \textbf{Verdict: resolved local fix.}
-The zero-factor degeneration is excluded by the intended nondegenerate
-convention, which is present at both applications in the article.  The
-unrestricted printed wording is not used as a formal theorem.
+The intended nondegeneracy convention is present at both applications in the
+article.  The unrestricted printed wording is not used as a formal theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- define open alternating tensor networks and their contraction by one-sided inverses of the injective $A_i$
- prove the corrected nondegenerate proportionality theorem: equality of the two alternating networks and $B_i\ne0$ imply $B_i=\beta_iB_i'$ with $\prod_i\beta_i=1$
- keep the hypothesis at the weakest source-usable strength: only the unprimed family is assumed nonzero
- document why both applications in FBC25 satisfy nondegeneracy and index the paper-gap correction

The unrestricted printed lemma is false when an intervening factor vanishes; this PR formalizes the source-faithful theorem used by the later unitary boundary networks.

## Validation

- branch rebased onto current main
- targeted build: 2726/2726
- full cached build before final unrelated-main rebase: 10460/10460
- Blueprint synchronization after rebase: 7339/7339
- generated import aggregators and strict declaration checks
- paper-gap declaration/reference checks
- style, proof integrity, module-size, and reader-facing prose checks
- double LuaLaTeX with zero undefined cross-references

Closes #7326
