### PR TITLE
feat(mpu): prove shift swap matrix unitarity

### DIFF
--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -13,3 +13,4 @@ import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
+import TNLean.MPS.MPU.Examples.ShiftSwapMatrices

--- a/TNLean/MPS/MPU/Examples/ShiftSwapMatrices.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSwapMatrices.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import QICLean.Algebra.MatrixIsometryKronecker
+import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 
 /-!
 # Unitarity of the shift-example swap matrices
@@ -47,8 +47,8 @@ Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
 (lines 2018--2034). -/
 theorem identitySwapIdentityMatrix_isUnitaryBetween (d : ℕ) :
     (identitySwapIdentityMatrix d).IsUnitaryBetween := by
-  let hOne := one_isUnitaryBetween d
-  let hSwap := swapMatrix_isUnitaryBetween d
+  have hOne := one_isUnitaryBetween d
+  have hSwap := swapMatrix_isUnitaryBetween d
   have hFirst :
       ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ Matrix.swapMatrix d).IsIsometry :=
     Matrix.IsIsometry.kronecker _ _ hOne.1 hSwap.1
@@ -72,9 +72,9 @@ Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
 (lines 2018--2034). -/
 theorem swapTensorSwapMatrix_isUnitaryBetween (d : ℕ) :
     (swapTensorSwapMatrix d).IsUnitaryBetween := by
+  have hSwap := swapMatrix_isUnitaryBetween d
   have hIso : (swapTensorSwapMatrix d).IsIsometry :=
-    Matrix.IsIsometry.kronecker _ _
-      (swapMatrix_isUnitaryBetween d).1 (swapMatrix_isUnitaryBetween d).1
+    Matrix.IsIsometry.kronecker _ _ hSwap.1 hSwap.1
   exact hIso.isUnitaryBetween_of_card_eq _ rfl
 
 /-- The displayed matrix

--- a/TNLean/MPS/MPU/Examples/ShiftSwapMatrices.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSwapMatrices.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
+import QICLean.Algebra.MatrixIsometryKronecker
+
+/-!
+# Unitarity of the shift-example swap matrices
+
+This module proves unitarity of the four-spin matrices displayed in
+arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3` (lines 2018--2034).
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor
+
+private def fourSpinAssocEquiv (d : ℕ) :
+    ((Fin d × (Fin d × Fin d)) × Fin d) ≃
+      ((Fin d × Fin d) × (Fin d × Fin d)) where
+  toFun x := ((x.1.1, x.1.2.1), (x.1.2.2, x.2))
+  invFun x := ((x.1.1, (x.1.2, x.2.1)), x.2.2)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+private noncomputable def identitySwapIdentityKronecker (d : ℕ) :
+    Matrix ((Fin d × (Fin d × Fin d)) × Fin d)
+      ((Fin d × (Fin d × Fin d)) × Fin d) ℂ :=
+  ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ Matrix.swapMatrix d) ⊗ₖ
+    (1 : Matrix (Fin d) (Fin d) ℂ)
+
+private theorem one_isUnitaryBetween (d : ℕ) :
+    (1 : Matrix (Fin d) (Fin d) ℂ).IsUnitaryBetween :=
+  ⟨by simp [Matrix.IsIsometry], by simp [Matrix.IsCoisometry]⟩
+
+private theorem swapMatrix_isUnitaryBetween (d : ℕ) :
+    (Matrix.swapMatrix d).IsUnitaryBetween := by
+  constructor <;>
+    simp [Matrix.IsIsometry, Matrix.IsCoisometry,
+      Matrix.swapMatrix_conjTranspose, Matrix.swapMatrix_mul_self]
+
+/-- The displayed matrix $\Id\otimes\mathbb S\otimes\Id$ is unitary.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+theorem identitySwapIdentityMatrix_isUnitaryBetween (d : ℕ) :
+    (identitySwapIdentityMatrix d).IsUnitaryBetween := by
+  let hOne := one_isUnitaryBetween d
+  let hSwap := swapMatrix_isUnitaryBetween d
+  have hFirst :
+      ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ Matrix.swapMatrix d).IsIsometry :=
+    Matrix.IsIsometry.kronecker _ _ hOne.1 hSwap.1
+  have hRawIso : (identitySwapIdentityKronecker d).IsIsometry :=
+    Matrix.IsIsometry.kronecker _ _ hFirst hOne.1
+  have hRaw : (identitySwapIdentityKronecker d).IsUnitaryBetween :=
+    hRawIso.isUnitaryBetween_of_card_eq _ rfl
+  have hReindexed := Matrix.IsUnitaryBetween.reindex _ hRaw
+    (fourSpinAssocEquiv d) (fourSpinAssocEquiv d)
+  convert hReindexed using 1
+  ext ⟨⟨a, b⟩, ⟨c, e⟩⟩ ⟨⟨i, j⟩, ⟨k, l⟩⟩
+  by_cases ha : a = i <;> by_cases hb : b = k <;>
+    by_cases hc : c = j <;> by_cases he : e = l <;>
+    simp [identitySwapIdentityMatrix, identitySwapIdentityKronecker,
+      fourSpinAssocEquiv, Matrix.reindex_apply, Matrix.kroneckerMap_apply,
+      Matrix.swapMatrix_apply, ha, hb, hc, he]
+
+/-- The displayed matrix $\mathbb S\otimes\mathbb S$ is unitary.
+
+Source: arXiv:1703.09188, equations `eq:uv2_U2` and `eq:uv2_U3`
+(lines 2018--2034). -/
+theorem swapTensorSwapMatrix_isUnitaryBetween (d : ℕ) :
+    (swapTensorSwapMatrix d).IsUnitaryBetween := by
+  have hIso : (swapTensorSwapMatrix d).IsIsometry :=
+    Matrix.IsIsometry.kronecker _ _
+      (swapMatrix_isUnitaryBetween d).1 (swapMatrix_isUnitaryBetween d).1
+  exact hIso.isUnitaryBetween_of_card_eq _ rfl
+
+/-- The displayed matrix
+$(\mathbb S\otimes\mathbb S)(\Id\otimes\mathbb S\otimes\Id)$ is unitary.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U2` (lines 2021--2026). -/
+theorem swapTensorSwapMatrix_mul_identitySwapIdentityMatrix_isUnitaryBetween
+    (d : ℕ) :
+    (swapTensorSwapMatrix d * identitySwapIdentityMatrix d).IsUnitaryBetween :=
+  Matrix.IsUnitaryBetween.mul _ _ (swapTensorSwapMatrix_isUnitaryBetween d)
+    (identitySwapIdentityMatrix_isUnitaryBetween d)
+
+/-- The displayed matrix
+$(\Id\otimes\mathbb S\otimes\Id)(\mathbb S\otimes\mathbb S)$ is unitary.
+
+Source: arXiv:1703.09188, equation `eq:uv2_U3` (lines 2030--2034). -/
+theorem identitySwapIdentityMatrix_mul_swapTensorSwapMatrix_isUnitaryBetween
+    (d : ℕ) :
+    (identitySwapIdentityMatrix d * swapTensorSwapMatrix d).IsUnitaryBetween :=
+  Matrix.IsUnitaryBetween.mul _ _ (identitySwapIdentityMatrix_isUnitaryBetween d)
+    (swapTensorSwapMatrix_isUnitaryBetween d)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7999,6 +7999,36 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     decomposition is asserted.
 \end{definition}
 
+\begin{theorem}[Unitarity of the four-spin shift matrices]
+    \label{thm:threeMPU_four_spin_matrix_unitarity}
+    \lean{MPOTensor.identitySwapIdentityMatrix_isUnitaryBetween,
+        MPOTensor.swapTensorSwapMatrix_isUnitaryBetween,
+        MPOTensor.swapTensorSwapMatrix_mul_identitySwapIdentityMatrix_isUnitaryBetween,
+        MPOTensor.identitySwapIdentityMatrix_mul_swapTensorSwapMatrix_isUnitaryBetween}
+    \leanok
+    \uses{def:threeMPU_supplied_source_factors}
+    Let $\mathbb S$ exchange two $d$-dimensional spins. The four matrices
+    displayed in the blocked forms of $U_2$ and $U_3$ are unitary:
+    \[
+    \begin{gathered}
+        \Id\otimes\mathbb S\otimes\Id, \quad
+        \mathbb S\otimes\mathbb S, \\
+        (\mathbb S\otimes\mathbb S)
+            (\Id\otimes\mathbb S\otimes\Id), \quad
+        (\Id\otimes\mathbb S\otimes\Id)
+            (\mathbb S\otimes\mathbb S).
+    \end{gathered}
+    \]
+    % Source lines: paper_v2.tex 2018--2034.
+\end{theorem}
+
+\begin{proof}\leanok
+    The swap satisfies $\mathbb S^\dagger=\mathbb S$ and
+    $\mathbb S^2=\Id$. Kronecker products preserve isometries, and a square
+    isometry is unitary. Thus both factors are unitary. Closure of the unitary
+    matrices under multiplication gives the two ordered products.
+\end{proof}
+
 \begin{theorem}[One-site supplied mixed kernels for $U_1$ and $U_3$]
     \label{thm:threeMPU_supplied_mixed_kernels_one}
     \lean{MPOTensor.shiftExampleU₁SourceY₁X₂RowEquiv,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8006,19 +8006,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.swapTensorSwapMatrix_mul_identitySwapIdentityMatrix_isUnitaryBetween,
         MPOTensor.identitySwapIdentityMatrix_mul_swapTensorSwapMatrix_isUnitaryBetween}
     \leanok
-    \uses{def:threeMPU_supplied_source_factors}
-    Let $\mathbb S$ exchange two $d$-dimensional spins. The four matrices
-    displayed in the blocked forms of $U_2$ and $U_3$ are unitary:
-    \[
-    \begin{gathered}
-        \Id\otimes\mathbb S\otimes\Id, \quad
-        \mathbb S\otimes\mathbb S, \\
-        (\mathbb S\otimes\mathbb S)
-            (\Id\otimes\mathbb S\otimes\Id), \quad
-        (\Id\otimes\mathbb S\otimes\Id)
+    Let $\mathbb S$ exchange two $d$-dimensional spins. The two swap factors
+    appearing in the blocked forms of $U_2$ and $U_3$, and both ordered
+    products, are unitary:
+    \begin{align}
+        &\Id\otimes\mathbb S\otimes\Id, \\
+        &\mathbb S\otimes\mathbb S, \\
+        &(\mathbb S\otimes\mathbb S)
+            (\Id\otimes\mathbb S\otimes\Id), \\
+        &(\Id\otimes\mathbb S\otimes\Id)
             (\mathbb S\otimes\mathbb S).
-    \end{gathered}
-    \]
+    \end{align}
     % Source lines: paper_v2.tex 2018--2034.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8010,12 +8010,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     appearing in the blocked forms of $U_2$ and $U_3$, and both ordered
     products, are unitary:
     \begin{align}
-        &\Id\otimes\mathbb S\otimes\Id, \\
-        &\mathbb S\otimes\mathbb S, \\
-        &(\mathbb S\otimes\mathbb S)
-            (\Id\otimes\mathbb S\otimes\Id), \\
-        &(\Id\otimes\mathbb S\otimes\Id)
-            (\mathbb S\otimes\mathbb S).
+        \Id\otimes\mathbb S\otimes\Id,\quad
+        \mathbb S\otimes\mathbb S,\quad
+        (\mathbb S\otimes\mathbb S)(\Id\otimes\mathbb S\otimes\Id),\quad
+        (\Id\otimes\mathbb S\otimes\Id)(\mathbb S\otimes\mathbb S).
     \end{align}
     % Source lines: paper_v2.tex 2018--2034.
 \end{theorem}


### PR DESCRIPTION
## What changed
- prove `IsUnitaryBetween` for the displayed $\mathrm{Id}\otimes\mathbb S\otimes\mathrm{Id}$ and $\mathbb S\otimes\mathbb S$ matrices
- derive unitarity of both ordered products from closure under matrix multiplication
- anchor all four statements to arXiv:1703.09188 equations `eq:uv2_U2` and `eq:uv2_U3`
- add the generated example aggregator import and synchronized Blueprint theorem/proof coverage

## Proof
The swap is self-adjoint and involutive. Kronecker products preserve isometries, and the resulting square isometries are unitary. The two products are then unitary by closure under multiplication.

## Validation
- `lake build TNLean.MPS.MPU.Examples.ShiftSwapMatrices`
- `lake build TNLean.MPS.MPU.Examples`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- no `sorry`, `admit`, or `axiom` in `ShiftSwapMatrices.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Blueprint `print.tex` compiled twice with no undefined-reference warning
- `git diff --check`

Full Lean build is left to hosted CI, as requested.

Closes #7464
