### PR TITLE
feat(MPS/MPU): compute shift source-index values

### DIFF
--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.MPU.Examples
 
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.Examples.ShiftIndex
 import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas

--- a/TNLean/MPS/MPU/Examples/ShiftIndex.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftIndex.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.ShiftSourceFactors
+import TNLean.MPS.MPU.Examples.ShiftSourceRanks
+import TNLean.MPS.MPU.SourceIndexValue
+
+/-!
+# Specified-tensor source-index values of the shift examples
+
+This module computes the source-index value of the specified right-shift,
+left-shift, identity, and three displayed shift-family tensors. These results do
+not assert that the value is independent of a choice of simple blocking.
+
+Source: arXiv:1703.09188, lines 2037--2041.
+-/
+
+namespace MPOTensor
+
+private theorem sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
+    (U : MPOTensor d D) (hr : 0 < r[U]) (hℓ : 0 < ℓ[U])
+    (h : r[U] = ℓ[U]) :
+    sourceIndexValue U hr hℓ = 0 := by
+  simp [sourceIndexValue, h]
+
+/-- The specified right-shift tensor has source-index value $\log_2 d$.
+
+Source: arXiv:1703.09188, lines 2039--2041. This is a value for the displayed
+tensor, not the blocking-independent MPU index. -/
+theorem sourceIndexValue_rightShiftTensor (d : ℕ) [NeZero d]
+    (hr : 0 < r[rightShiftTensor d]) (hℓ : 0 < ℓ[rightShiftTensor d]) :
+    sourceIndexValue (rightShiftTensor d) hr hℓ = Real.logb 2 d := by
+  have hd : (d : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne d
+  rw [sourceIndexValue, rightRank_rightShiftTensor, leftRank_rightShiftTensor,
+    Nat.cast_mul, Real.logb_mul hd hd]
+  norm_num
+  ring
+
+/-- The specified left-shift tensor has source-index value $-\log_2 d$.
+
+Source: arXiv:1703.09188, lines 2039--2041. This is a value for the displayed
+tensor, not the blocking-independent MPU index. -/
+theorem sourceIndexValue_leftShiftTensor (d : ℕ) [NeZero d]
+    (hr : 0 < r[leftShiftTensor d]) (hℓ : 0 < ℓ[leftShiftTensor d]) :
+    sourceIndexValue (leftShiftTensor d) hr hℓ = -Real.logb 2 d := by
+  have hd : (d : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne d
+  rw [sourceIndexValue, rightRank_leftShiftTensor, leftRank_leftShiftTensor,
+    Nat.cast_mul, Real.logb_mul hd hd]
+  norm_num
+  ring
+
+/-- The specified bond-one identity tensor has source-index value zero.
+
+Source: arXiv:1703.09188, lines 2037--2039. -/
+theorem sourceIndexValue_identityMPUTensor (d : ℕ) [NeZero d]
+    (hr : 0 < r[identityMPUTensor d]) (hℓ : 0 < ℓ[identityMPUTensor d]) :
+    sourceIndexValue (identityMPUTensor d) hr hℓ = 0 := by
+  apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
+  rw [rightRank_identityMPUTensor, leftRank_identityMPUTensor]
+
+/-- The specified tensor for the identity family $U_1$ has source-index value zero.
+
+Source: arXiv:1703.09188, lines 2037--2039. -/
+theorem sourceIndexValue_shiftExampleU₁ (d : ℕ) [NeZero d]
+    (hr : 0 < r[shiftExampleU₁ d]) (hℓ : 0 < ℓ[shiftExampleU₁ d]) :
+    sourceIndexValue (shiftExampleU₁ d) hr hℓ = 0 := by
+  apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
+  simp only [shiftExampleU₁, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_identityMPUTensor, leftRank_identityMPUTensor]
+
+/-- The specified tensor for the balanced shift family $U_2$ has source-index value zero.
+
+Source: arXiv:1703.09188, lines 2037--2039. -/
+theorem sourceIndexValue_shiftExampleU₂ (d : ℕ) [NeZero d]
+    (hr : 0 < r[shiftExampleU₂ d]) (hℓ : 0 < ℓ[shiftExampleU₂ d]) :
+    sourceIndexValue (shiftExampleU₂ d) hr hℓ = 0 := by
+  apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
+  simp only [shiftExampleU₂, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_leftShiftTensor, rightRank_rightShiftTensor,
+    leftRank_leftShiftTensor, leftRank_rightShiftTensor, one_mul, mul_one]
+
+/-- The specified tensor for the balanced shift family $U_3$ has source-index value zero.
+
+Source: arXiv:1703.09188, lines 2037--2039. -/
+theorem sourceIndexValue_shiftExampleU₃ (d : ℕ) [NeZero d]
+    (hr : 0 < r[shiftExampleU₃ d]) (hℓ : 0 < ℓ[shiftExampleU₃ d]) :
+    sourceIndexValue (shiftExampleU₃ d) hr hℓ = 0 := by
+  apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
+  simp only [shiftExampleU₃, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_rightShiftTensor, rightRank_leftShiftTensor,
+    leftRank_rightShiftTensor, leftRank_leftShiftTensor, one_mul, mul_one]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftIndex.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftIndex.lean
@@ -31,13 +31,58 @@ private theorem sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
     sourceIndexValue U hr hℓ = 0 := by
   simp only [sourceIndexValue, h, sub_self, mul_zero]
 
+/-- The source ranks of the specified right-shift tensor are positive. -/
+lemma sourceRanks_pos_rightShiftTensor (d : ℕ) [NeZero d] :
+    0 < r[rightShiftTensor d] ∧ 0 < ℓ[rightShiftTensor d] := by
+  rw [rightRank_rightShiftTensor, leftRank_rightShiftTensor]
+  exact ⟨Nat.mul_pos (NeZero.pos d) (NeZero.pos d), Nat.zero_lt_one⟩
+
+/-- The source ranks of the specified left-shift tensor are positive. -/
+lemma sourceRanks_pos_leftShiftTensor (d : ℕ) [NeZero d] :
+    0 < r[leftShiftTensor d] ∧ 0 < ℓ[leftShiftTensor d] := by
+  rw [rightRank_leftShiftTensor, leftRank_leftShiftTensor]
+  exact ⟨Nat.zero_lt_one, Nat.mul_pos (NeZero.pos d) (NeZero.pos d)⟩
+
+/-- The source ranks of the specified bond-one identity tensor are positive. -/
+lemma sourceRanks_pos_identityMPUTensor (d : ℕ) [NeZero d] :
+    0 < r[identityMPUTensor d] ∧ 0 < ℓ[identityMPUTensor d] := by
+  rw [rightRank_identityMPUTensor, leftRank_identityMPUTensor]
+  exact ⟨NeZero.pos d, NeZero.pos d⟩
+
+/-- The source ranks of the specified tensor for $U_1$ are positive. -/
+lemma sourceRanks_pos_shiftExampleU₁ (d : ℕ) [NeZero d] :
+    0 < r[shiftExampleU₁ d] ∧ 0 < ℓ[shiftExampleU₁ d] := by
+  simp only [shiftExampleU₁, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_identityMPUTensor, leftRank_identityMPUTensor]
+  exact ⟨Nat.mul_pos (NeZero.pos d) (NeZero.pos d),
+    Nat.mul_pos (NeZero.pos d) (NeZero.pos d)⟩
+
+/-- The source ranks of the specified tensor for $U_2$ are positive. -/
+lemma sourceRanks_pos_shiftExampleU₂ (d : ℕ) [NeZero d] :
+    0 < r[shiftExampleU₂ d] ∧ 0 < ℓ[shiftExampleU₂ d] := by
+  simp only [shiftExampleU₂, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_leftShiftTensor, rightRank_rightShiftTensor,
+    leftRank_leftShiftTensor, leftRank_rightShiftTensor, one_mul, mul_one]
+  exact ⟨Nat.mul_pos (NeZero.pos d) (NeZero.pos d),
+    Nat.mul_pos (NeZero.pos d) (NeZero.pos d)⟩
+
+/-- The source ranks of the specified tensor for $U_3$ are positive. -/
+lemma sourceRanks_pos_shiftExampleU₃ (d : ℕ) [NeZero d] :
+    0 < r[shiftExampleU₃ d] ∧ 0 < ℓ[shiftExampleU₃ d] := by
+  simp only [shiftExampleU₃, rightRank_tensorProduct, leftRank_tensorProduct,
+    rightRank_rightShiftTensor, rightRank_leftShiftTensor,
+    leftRank_rightShiftTensor, leftRank_leftShiftTensor, one_mul, mul_one]
+  exact ⟨Nat.mul_pos (NeZero.pos d) (NeZero.pos d),
+    Nat.mul_pos (NeZero.pos d) (NeZero.pos d)⟩
+
 /-- The specified right-shift tensor has source-index value $\log_2 d$.
 
 Source: arXiv:1703.09188, lines 2039--2041. This is a value for the displayed
 tensor, not the blocking-independent MPU index. -/
-theorem sourceIndexValue_rightShiftTensor (d : ℕ) [NeZero d]
-    (hr : 0 < r[rightShiftTensor d]) (hℓ : 0 < ℓ[rightShiftTensor d]) :
-    sourceIndexValue (rightShiftTensor d) hr hℓ = Real.logb 2 d := by
+theorem sourceIndexValue_rightShiftTensor (d : ℕ) [NeZero d] :
+    sourceIndexValue (rightShiftTensor d)
+      (sourceRanks_pos_rightShiftTensor d).1 (sourceRanks_pos_rightShiftTensor d).2 =
+        Real.logb 2 d := by
   have hd : (d : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne d
   rw [sourceIndexValue, rightRank_rightShiftTensor, leftRank_rightShiftTensor,
     Nat.cast_mul, Real.logb_mul hd hd]
@@ -48,9 +93,10 @@ theorem sourceIndexValue_rightShiftTensor (d : ℕ) [NeZero d]
 
 Source: arXiv:1703.09188, lines 2039--2041. This is a value for the displayed
 tensor, not the blocking-independent MPU index. -/
-theorem sourceIndexValue_leftShiftTensor (d : ℕ) [NeZero d]
-    (hr : 0 < r[leftShiftTensor d]) (hℓ : 0 < ℓ[leftShiftTensor d]) :
-    sourceIndexValue (leftShiftTensor d) hr hℓ = -Real.logb 2 d := by
+theorem sourceIndexValue_leftShiftTensor (d : ℕ) [NeZero d] :
+    sourceIndexValue (leftShiftTensor d)
+      (sourceRanks_pos_leftShiftTensor d).1 (sourceRanks_pos_leftShiftTensor d).2 =
+        -Real.logb 2 d := by
   have hd : (d : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne d
   rw [sourceIndexValue, rightRank_leftShiftTensor, leftRank_leftShiftTensor,
     Nat.cast_mul, Real.logb_mul hd hd]
@@ -60,18 +106,18 @@ theorem sourceIndexValue_leftShiftTensor (d : ℕ) [NeZero d]
 /-- The specified bond-one identity tensor has source-index value zero.
 
 Source: arXiv:1703.09188, lines 2037--2039. -/
-theorem sourceIndexValue_identityMPUTensor (d : ℕ) [NeZero d]
-    (hr : 0 < r[identityMPUTensor d]) (hℓ : 0 < ℓ[identityMPUTensor d]) :
-    sourceIndexValue (identityMPUTensor d) hr hℓ = 0 := by
+theorem sourceIndexValue_identityMPUTensor (d : ℕ) [NeZero d] :
+    sourceIndexValue (identityMPUTensor d)
+      (sourceRanks_pos_identityMPUTensor d).1 (sourceRanks_pos_identityMPUTensor d).2 = 0 := by
   apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
   rw [rightRank_identityMPUTensor, leftRank_identityMPUTensor]
 
 /-- The specified tensor for the identity family $U_1$ has source-index value zero.
 
 Source: arXiv:1703.09188, lines 2037--2039. -/
-theorem sourceIndexValue_shiftExampleU₁ (d : ℕ) [NeZero d]
-    (hr : 0 < r[shiftExampleU₁ d]) (hℓ : 0 < ℓ[shiftExampleU₁ d]) :
-    sourceIndexValue (shiftExampleU₁ d) hr hℓ = 0 := by
+theorem sourceIndexValue_shiftExampleU₁ (d : ℕ) [NeZero d] :
+    sourceIndexValue (shiftExampleU₁ d)
+      (sourceRanks_pos_shiftExampleU₁ d).1 (sourceRanks_pos_shiftExampleU₁ d).2 = 0 := by
   apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
   simp only [shiftExampleU₁, rightRank_tensorProduct, leftRank_tensorProduct,
     rightRank_identityMPUTensor, leftRank_identityMPUTensor]
@@ -79,9 +125,9 @@ theorem sourceIndexValue_shiftExampleU₁ (d : ℕ) [NeZero d]
 /-- The specified tensor for the balanced shift family $U_2$ has source-index value zero.
 
 Source: arXiv:1703.09188, lines 2037--2039. -/
-theorem sourceIndexValue_shiftExampleU₂ (d : ℕ) [NeZero d]
-    (hr : 0 < r[shiftExampleU₂ d]) (hℓ : 0 < ℓ[shiftExampleU₂ d]) :
-    sourceIndexValue (shiftExampleU₂ d) hr hℓ = 0 := by
+theorem sourceIndexValue_shiftExampleU₂ (d : ℕ) [NeZero d] :
+    sourceIndexValue (shiftExampleU₂ d)
+      (sourceRanks_pos_shiftExampleU₂ d).1 (sourceRanks_pos_shiftExampleU₂ d).2 = 0 := by
   apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
   simp only [shiftExampleU₂, rightRank_tensorProduct, leftRank_tensorProduct,
     rightRank_leftShiftTensor, rightRank_rightShiftTensor,
@@ -90,9 +136,9 @@ theorem sourceIndexValue_shiftExampleU₂ (d : ℕ) [NeZero d]
 /-- The specified tensor for the balanced shift family $U_3$ has source-index value zero.
 
 Source: arXiv:1703.09188, lines 2037--2039. -/
-theorem sourceIndexValue_shiftExampleU₃ (d : ℕ) [NeZero d]
-    (hr : 0 < r[shiftExampleU₃ d]) (hℓ : 0 < ℓ[shiftExampleU₃ d]) :
-    sourceIndexValue (shiftExampleU₃ d) hr hℓ = 0 := by
+theorem sourceIndexValue_shiftExampleU₃ (d : ℕ) [NeZero d] :
+    sourceIndexValue (shiftExampleU₃ d)
+      (sourceRanks_pos_shiftExampleU₃ d).1 (sourceRanks_pos_shiftExampleU₃ d).2 = 0 := by
   apply sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
   simp only [shiftExampleU₃, rightRank_tensorProduct, leftRank_tensorProduct,
     rightRank_rightShiftTensor, rightRank_leftShiftTensor,

--- a/TNLean/MPS/MPU/Examples/ShiftIndex.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftIndex.lean
@@ -11,8 +11,14 @@ import TNLean.MPS.MPU.SourceIndexValue
 # Specified-tensor source-index values of the shift examples
 
 This module computes the source-index value of the specified right-shift,
-left-shift, identity, and three displayed shift-family tensors. These results do
-not assert that the value is independent of a choice of simple blocking.
+left-shift, identity, and three displayed shift-family tensors.
+
+**Scope restriction (specified tensors):** arXiv:1703.09188, lines 2037--2041,
+states values of the public blocking-independent MPU index. The results here
+compute the same formulas only for the displayed tensors and do not prove
+independence of a chosen simple blocking. This restriction and its elimination
+plan are recorded in
+`docs/paper-gaps/mpu_shift_specified_tensor_index_scope.tex`.
 
 Source: arXiv:1703.09188, lines 2037--2041.
 -/
@@ -23,7 +29,7 @@ private theorem sourceIndexValue_eq_zero_of_rightRank_eq_leftRank
     (U : MPOTensor d D) (hr : 0 < r[U]) (hℓ : 0 < ℓ[U])
     (h : r[U] = ℓ[U]) :
     sourceIndexValue U hr hℓ = 0 := by
-  simp [sourceIndexValue, h]
+  simp only [sourceIndexValue, h, sub_self, mul_zero]
 
 /-- The specified right-shift tensor has source-index value $\log_2 d$.
 

--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -10,8 +10,14 @@ import Mathlib.Analysis.SpecialFunctions.Log.Base
 # Source-index value of a specified MPU tensor
 
 This module defines the numerical source-index expression of a specified tensor
-from its positive right and left source-cut ranks. It does not choose a simple
-blocking and therefore does not define the choice-independent index of an MPU.
+from its positive right and left source-cut ranks.
+
+**Scope restriction (specified tensors):** arXiv:1703.09188, Definition IV.1 and
+Proposition IV.2, define the public MPU index by choosing a simple blocking and
+proving independence of that choice. This module proves only specified-tensor
+identities and conditional blocking invariance. The restriction and its
+elimination plan are recorded in
+`docs/paper-gaps/mpu_shift_specified_tensor_index_scope.tex`.
 
 For a tensor with positive right rank $r$ and left rank $\ell$, the value is
 $$

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7962,6 +7962,51 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     unitarity, so all three tensors are matrix product unitaries.
 \end{proof}
 
+\begin{theorem}[Specified-tensor source-index values of the shifts]
+    \label{thm:mpu_shift_specified_source_index_values}
+    \lean{MPOTensor.sourceIndexValue_rightShiftTensor,
+        MPOTensor.sourceIndexValue_leftShiftTensor,
+        MPOTensor.sourceIndexValue_identityMPUTensor,
+        MPOTensor.sourceIndexValue_shiftExampleU₁,
+        MPOTensor.sourceIndexValue_shiftExampleU₂,
+        MPOTensor.sourceIndexValue_shiftExampleU₃}
+    \leanok
+    \uses{def:mpu_specified_source_index_value,
+        thm:mpu_shift_source_cuts_ranks,
+        thm:mpu_tensor_product_source_ranks, threeMPU}
+    Assume $d>0$. For the displayed right- and left-shift tensors $T$ and
+    $T^\sharp$, the specified-tensor values are
+    \begin{align}
+        \operatorname{ind}_{\mathrm{src}}(T) & =\log_2 d.
+    \end{align}
+    Likewise,
+    \begin{align}
+        \operatorname{ind}_{\mathrm{src}}(T^\sharp) & =-\log_2 d.
+    \end{align}
+    The bond-one identity tensor and the three tensors $U_1,U_2,U_3$ satisfy
+    \begin{align}
+        \operatorname{ind}_{\mathrm{src}}(\Id)
+        =\operatorname{ind}_{\mathrm{src}}(U_1)
+        =\operatorname{ind}_{\mathrm{src}}(U_2)
+        =\operatorname{ind}_{\mathrm{src}}(U_3) & =0.
+    \end{align}
+    These are values of the specified tensors; no blocking-independent index is
+    asserted.
+    % Source: paper_v2.tex lines 2037--2041.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_specified_source_index_value,
+        thm:mpu_shift_source_cuts_ranks,
+        thm:mpu_tensor_product_source_ranks, threeMPU}
+    The right shift has source ranks $(d^2,1)$, while the left shift has
+    $(1,d^2)$. Substitution into the source-index expression gives the first
+    two formulas. The identity tensor has equal source ranks $(d,d)$. Source
+    ranks multiply under the independent tensor product, so each of
+    $U_1,U_2,U_3$ has equal right and left rank $d^2$. Their logarithmic
+    differences therefore vanish.
+\end{proof}
+
 \begin{definition}[Supplied source factors for the three shift MPUs]
     \label{def:threeMPU_supplied_source_factors}
     \lean{MPOTensor.identitySourceFactors,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7990,8 +7990,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         =\operatorname{ind}_{\mathrm{src}}(U_2)
         =\operatorname{ind}_{\mathrm{src}}(U_3) & =0.
     \end{align}
-    These are values of the specified tensors; no blocking-independent index is
-    asserted.
+    Here $\operatorname{ind}_{\mathrm{src}}$ is the specified-tensor quantity
+    from Definition~\ref{def:mpu_specified_source_index_value}, evaluated on the
+    displayed unblocked tensors. It is not the public MPU index
+    $\operatorname{ind}$ of Definition~\ref{def:index}, whose definition uses a
+    simple blocking and requires independence of that choice.
+    % **Scope restriction (specified tensors):** the source states the public
+    % blocking-independent MPU index, while this theorem computes only the raw
+    % value of each displayed tensor. Documented in
+    % docs/paper-gaps/mpu_shift_specified_tensor_index_scope.tex; elimination is
+    % tracked by issues #7011 and #5856.
     % Source: paper_v2.tex lines 2037--2041.
 \end{theorem}
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -11,6 +11,13 @@ the current formal boundary.
   and the remaining reduction from a full-rank fixed point to an explicitly
   chosen positive-definite invariant weight.
 
+For the MPU index of arXiv:1703.09188:
+
+- `mpu_shift_specified_tensor_index_scope.tex` records that the computed shift
+  formulas are values of the displayed tensors, while the source states the
+  public blocking-independent MPU index. The remaining public construction is
+  tracked by issues #7011 and #5856.
+
 For the MPU symmetry-defect gauging paper:
 
 - `fbc25_gauss_law_commuting_projector_source_audit.tex` pins the oriented

--- a/docs/paper-gaps/mpu_shift_specified_tensor_index_scope.tex
+++ b/docs/paper-gaps/mpu_shift_specified_tensor_index_scope.tex
@@ -1,0 +1,93 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Specified-Tensor Shift Values and the Public MPU Index}
+\author{}
+\date{2026-08-30}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{Source statement}
+
+For a simple matrix product unitary tensor with positive right and left
+source-cut ranks $r$ and $\ell$, Definition~IV.1 of
+Ref.~\cite{Cirac2017MPU} uses
+\begin{align}
+    \frac12(\log_2 r-\log_2\ell).
+    \label{eq:mpu_shift_specified_tensor_index_scope_expression}
+\end{align}
+Proposition~IV.2 proves that this value is independent of the chosen simple
+blocking. The resulting blocking-independent quantity is the public MPU
+index.
+% Source: paper_v2.tex lines 681--704, labels def:index and
+% index-well-defined.
+
+For the topological-insulator examples, the paper states that the right shift
+$T^{(N)}$ has index $\log_2 d$, its adjoint left shift $T^{(N)\dagger}$ has
+index $-\log_2 d$, and the three displayed families
+\begin{align}
+    U_1^{(N)} &= (\Id\otimes\Id)^{\otimes N}, \\
+    U_2^{(N)} &= T^{(N)\dagger}\otimes T^{(N)}, \\
+    U_3^{(N)} &= T^{(N)}\otimes T^{(N)\dagger}
+\end{align}
+have index zero.
+% Source: paper_v2.tex lines 1980--2001 and 2037--2041, label threeMPU.
+
+\section{Formal boundary}
+
+The definition \leanid{MPOTensor.sourceIndexValue} evaluates
+Eq.~\ref{eq:mpu_shift_specified_tensor_index_scope_expression} for one named
+tensor and supplied positivity proofs. It does not choose a simple blocking or
+prove independence of that choice.
+
+The shift calculations use the exact source-rank pairs
+\begin{align}
+    (r[T],\ell[T])
+        &=(d^2,1), \\
+    (r[T^\dagger],\ell[T^\dagger])
+        &=(1,d^2).
+\end{align}
+The bond-one identity has equal ranks $(d,d)$. Source ranks multiply under the
+independent tensor product, so each specified tensor for $U_1,U_2,U_3$ has
+equal right and left rank $d^2$. Therefore the formal declarations
+\leanid{MPOTensor.sourceIndexValue_rightShiftTensor},
+\leanid{MPOTensor.sourceIndexValue_leftShiftTensor}, and the four corresponding
+zero-value theorems prove the exact formulas for these named tensors.
+
+These calculations verify the numerical expression and its signs. They do not
+yet identify those values with the public blocking-independent MPU index
+asserted by the source.
+
+\section{Elimination plan}
+
+The public index construction is tracked by \ghissue{7011}. It must choose a
+simple blocking and prove that
+Eq.~\ref{eq:mpu_shift_specified_tensor_index_scope_expression} is independent
+of every such choice. Its remaining source-faithful input is the four-way
+source theorem tracked by \ghissue{5856}, which supplies the rank-product
+identity needed by the blocking argument without adding it as a hypothesis.
+
+After that construction, the shift results can be stated for the public index
+by evaluating it at the displayed simple representatives and applying
+blocking independence. Until then, the Lean declarations and their Blueprint
+entry remain explicitly restricted to specified tensors.
+
+\section{Verdict}
+
+The specified-tensor formulas agree exactly with the source-rank calculations,
+including the positive sign for the right shift and the negative sign for the
+left shift. The open gap is only the passage from these named-tensor values to
+the public blocking-independent MPU index of Definition~IV.1 and
+Proposition~IV.2 of Ref.~\cite{Cirac2017MPU}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## What changed
- compute the specified-tensor `sourceIndexValue` for the right and left cyclic shifts
- prove zero values for the bond-one identity tensor and `U₁`, `U₂`, `U₃` from existing source-rank formulas
- add the generated examples aggregator import and synchronized Blueprint theorem/proof entries
- keep the statements explicitly scoped away from the blocking-independent public MPU index

## Validation
- `lake build TNLean.MPS.MPU.Examples.ShiftIndex`
- `lake build TNLean.MPS.MPU.Examples`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- Blueprint `print.tex` compiled twice with no undefined references
- changed Lean file contains no `sorry`, `admit`, or `axiom`
- `git diff --check`

No full local build was run, per the assigned warm-cache/targeted-build scope.

Closes #7465