### PR TITLE
feat(algebra): prove swap matrix unitarity

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -34,6 +34,7 @@ import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
+import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryKronecker
 import TNLean.Algebra.UnitaryKroneckerComparison

--- a/TNLean/Algebra/SwapMatrix.lean
+++ b/TNLean/Algebra/SwapMatrix.lean
@@ -25,13 +25,11 @@ namespace Matrix
 With columns as source coordinates and rows as target coordinates, `swapMatrix d` sends the
 source coordinate `(i, j)` to the target coordinate `(j, i)`. This is the exchange matrix
 used in the shift-MPU source factors of arXiv:1703.09188, equations `eq:SF_u1_u3`,
-`eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+`eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034), and as the endpoint of the
+unitary interpolation at lines 2148--2150. -/
 theorem swapMatrix_isUnitaryBetween (d : ℕ) :
     (swapMatrix d).IsUnitaryBetween := by
-  constructor
-  · rw [IsIsometry, swapMatrix_conjTranspose]
-    exact swapMatrix_mul_self
-  · rw [IsCoisometry, swapMatrix_conjTranspose]
-    exact swapMatrix_mul_self
+  rw [IsUnitaryBetween, IsIsometry, IsCoisometry, swapMatrix_conjTranspose]
+  exact ⟨swapMatrix_mul_self, swapMatrix_mul_self⟩
 
 end Matrix

--- a/TNLean/Algebra/SwapMatrix.lean
+++ b/TNLean/Algebra/SwapMatrix.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.MatrixUnitaryBetween
+import QICLean.Channel.MaximallyEntangled
+
+/-!
+# Unitarity of the tensor-factor swap matrix
+
+This file packages the self-adjoint involution property of QICLean's tensor-factor
+swap matrix as unitarity between its product-coordinate spaces.
+
+## Main result
+
+* `Matrix.swapMatrix_isUnitaryBetween`: the tensor-factor swap matrix is unitary between
+  its source and target product-coordinate orders.
+-/
+
+namespace Matrix
+
+/-- The tensor-factor swap matrix is unitary between its product-coordinate spaces.
+
+With columns as source coordinates and rows as target coordinates, `swapMatrix d` sends the
+source coordinate `(i, j)` to the target coordinate `(j, i)`. This is the exchange matrix
+used in the shift-MPU source factors of arXiv:1703.09188, equations `eq:SF_u1_u3`,
+`eq:uv2_U2`, and `eq:uv2_U3` (lines 2009--2034). -/
+theorem swapMatrix_isUnitaryBetween (d : ℕ) :
+    (swapMatrix d).IsUnitaryBetween := by
+  constructor
+  · rw [IsIsometry, swapMatrix_conjTranspose]
+    exact swapMatrix_mul_self
+  · rw [IsCoisometry, swapMatrix_conjTranspose]
+    exact swapMatrix_mul_self
+
+end Matrix

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7916,28 +7916,31 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     calculation.
 \end{proof}
 
-\begin{theorem}[Unitarity of the factor exchange]
+\begin{theorem}[Unitarity of the swap operator]
     \label{thm:mpu_swap_matrix_unitary}
     \lean{Matrix.swapMatrix_isUnitaryBetween}
     \leanok
-    Let $\mathbb S$ be the exchange matrix from
-    \cite[Section~VII]{Cirac2017MPU}, with source coordinates $(k,l)$ and target
-    coordinates $(i,j)$:
+    Let $d\in\N$. On $\C^d\otimes\C^d$, let $\mathbb S$ be the swap operator
+    used in \cite[Section~VII]{Cirac2017MPU}, defined on the standard basis by
+    $\mathbb S(e_k\otimes e_\ell)=e_\ell\otimes e_k$. With columns indexed by
+    source coordinates $(k,\ell)$ and rows indexed by target coordinates
+    $(i,j)$, its entries are
     \begin{align}
-        \mathbb S_{(i,j),(k,l)} & =\delta_{i,l}\delta_{j,k}.
+        \mathbb S_{(i,j),(k,\ell)} & =\delta_{i,\ell}\delta_{j,k}.
     \end{align}
     Then $\mathbb S$ is unitary between the two product-coordinate orders:
     \begin{align}
         \mathbb S^\dagger\mathbb S & =\Id, \\
         \mathbb S\mathbb S^\dagger & =\Id.
     \end{align}
-    % Source use: paper_v2.tex lines 2009--2034, equations eq:SF_u1_u3,
+    % Operator characterization: paper_v2.tex lines 1316--1320.
+    % Section VII uses: lines 1999--2034, equations eq:SF_u1_u3,
     % eq:uv2_U2, and eq:uv2_U3; the unitary interpolation has endpoint
     % S at lines 2148--2150.
 \end{theorem}
 
 \begin{proof}\leanok
-    The exchange matrix is self-adjoint and involutive, so
+    The swap operator is self-adjoint and involutive, so
     $\mathbb S^\dagger=\mathbb S$ and $\mathbb S^2=\Id$. Substitution gives
     both identities.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7916,6 +7916,31 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     calculation.
 \end{proof}
 
+\begin{theorem}[Unitarity of the factor exchange]
+    \label{thm:mpu_swap_matrix_unitary}
+    \lean{Matrix.swapMatrix_isUnitaryBetween}
+    \leanok
+    Let $\mathbb S$ be the exchange matrix from
+    \cite[Section~VII]{Cirac2017MPU}, with source coordinates $(k,l)$ and target
+    coordinates $(i,j)$:
+    \begin{align}
+        \mathbb S_{(i,j),(k,l)} & =\delta_{i,l}\delta_{j,k}.
+    \end{align}
+    Then $\mathbb S$ is unitary between the two product-coordinate orders:
+    \begin{align}
+        \mathbb S^\dagger\mathbb S & =\Id, \\
+        \mathbb S\mathbb S^\dagger & =\Id.
+    \end{align}
+    % Source use: paper_v2.tex lines 2009--2034, equations eq:SF_u1_u3,
+    % eq:uv2_U2, and eq:uv2_U3.
+\end{theorem}
+
+\begin{proof}\leanok
+    The exchange matrix is self-adjoint and involutive, so
+    $\mathbb S^\dagger=\mathbb S$ and $\mathbb S^2=\Id$. Substitution gives
+    both identities.
+\end{proof}
+
 \begin{definition}[Three topological-insulator shift MPUs]
     \label{threeMPU}
     \lean{MPOTensor.identityMPUTensor}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7932,7 +7932,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \mathbb S\mathbb S^\dagger & =\Id.
     \end{align}
     % Source use: paper_v2.tex lines 2009--2034, equations eq:SF_u1_u3,
-    % eq:uv2_U2, and eq:uv2_U3.
+    % eq:uv2_U2, and eq:uv2_U3; the unitary interpolation has endpoint
+    % S at lines 2148--2150.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## What changed
- prove `Matrix.swapMatrix_isUnitaryBetween` from QICLean’s existing self-adjointness and involution identities
- document the source-to-target product-coordinate orientation
- export the theorem through `TNLean.Algebra`
- add source-facing coverage for the exchange matrices in arXiv:1703.09188, Section VII

## Validation
- `lake build TNLean.Algebra.SwapMatrix TNLean.Algebra` (3488 jobs)
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (7018/7018 entries)
- proof-integrity scan of `TNLean/Algebra/SwapMatrix.lean`
- Lean diagnostics: no errors, warnings, or hints
- `git diff --check`

No full local build was run, per the issue-slice constraint.

Closes #7463