### PR TITLE
feat(algebra): add unitary factorization comparisons

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -35,5 +35,6 @@ import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.UnitaryEntrywiseConjugation
+import TNLean.Algebra.UnitaryFactorizationComparison
 import TNLean.Algebra.UnitaryKronecker
 import TNLean.Algebra.UnitaryKroneckerComparison

--- a/TNLean/Algebra/UnitaryFactorizationComparison.lean
+++ b/TNLean/Algebra/UnitaryFactorizationComparison.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Comparison of unitary factorizations
+
+Given a family of unitary operators indexed by pairs, this file compares two
+members by multiplying the first by the inverse of the second.  The orientation
+is
+
+`unitaryFactorizationComparison R a b c d = (R c d)⁻¹ * R a b`.
+
+For unitary matrices, the inverse is the adjoint.  Thus this is precisely the
+operator $\lambda_{a,b}^{c,d} = (\lambda^R_{c,d})^\dagger\lambda^R_{a,b}$ in
+the corollary following FBC25, Proposition `prop:3`
+(arXiv:2502.20257, lines 2782--2821).
+
+The algebra does not use equalities between products of the indices.  Such
+equalities only determine which factorizations are compared in applications.
+-/
+
+namespace Matrix
+
+variable {ι n 𝕜 : Type*} [Fintype n] [DecidableEq n] [CommRing 𝕜] [StarRing 𝕜]
+
+/-- The comparison of the unitary operators indexed by `(a, b)` and `(c, d)`,
+with the reference pair `(c, d)` on the left.
+
+This is the orientation
+$\lambda_{a,b}^{c,d} = (\lambda^R_{c,d})^\dagger\lambda^R_{a,b}$ from the
+corollary following FBC25, Proposition `prop:3`
+(arXiv:2502.20257, lines 2782--2821). -/
+def unitaryFactorizationComparison
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d : ι) :
+    Matrix.unitaryGroup n 𝕜 :=
+  (R c d)⁻¹ * R a b
+
+/-- The matrix underlying a unitary factorization comparison is the adjoint of
+the reference operator multiplied by the source operator. -/
+theorem unitaryFactorizationComparison_coe
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d : ι) :
+    (unitaryFactorizationComparison R a b c d : Matrix n n 𝕜) =
+      star (R c d : Matrix n n 𝕜) * (R a b : Matrix n n 𝕜) :=
+  rfl
+
+/-- Comparing a unitary factorization with itself gives the identity. -/
+@[simp]
+theorem unitaryFactorizationComparison_self
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b : ι) :
+    unitaryFactorizationComparison R a b a b = 1 := by
+  simp [unitaryFactorizationComparison]
+
+/-- Unitary factorization comparisons compose through an intermediate pair in
+the source orientation.  This is the composition law in the corollary
+following FBC25, Proposition `prop:3`
+(arXiv:2502.20257, lines 2782--2821). -/
+theorem unitaryFactorizationComparison_trans
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d f g : ι) :
+    unitaryFactorizationComparison R a b f g =
+      unitaryFactorizationComparison R c d f g *
+        unitaryFactorizationComparison R a b c d := by
+  simp [unitaryFactorizationComparison, mul_assoc]
+
+/-- If the reference operator is the identity, comparison against it recovers
+the source operator. -/
+@[simp]
+theorem unitaryFactorizationComparison_of_reference_eq_one
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d : ι)
+    (href : R c d = 1) :
+    unitaryFactorizationComparison R a b c d = R a b := by
+  simp [unitaryFactorizationComparison, href]
+
+/-- If the identity-prefixed operators are normalized to one, comparison with
+`(1, g * h)` recovers the right-fusion operator indexed by `(g, h)`.
+
+This is $\lambda^R_{g,h} = \lambda_{g,h}^{e,gh}$ in the corollary following
+FBC25, Proposition `prop:3` (arXiv:2502.20257, lines 2782--2821). -/
+@[simp]
+theorem unitaryFactorizationComparison_right_reference
+    {G : Type*} [Group G] (R : G → G → Matrix.unitaryGroup n 𝕜)
+    (hR : ∀ x, R 1 x = 1) (g h : G) :
+    unitaryFactorizationComparison R g h 1 (g * h) = R g h := by
+  exact unitaryFactorizationComparison_of_reference_eq_one R g h 1 (g * h) (hR (g * h))
+
+end Matrix

--- a/TNLean/Algebra/UnitaryFactorizationComparison.lean
+++ b/TNLean/Algebra/UnitaryFactorizationComparison.lean
@@ -52,7 +52,7 @@ theorem unitaryFactorizationComparison_coe
 theorem unitaryFactorizationComparison_self
     (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b : ι) :
     unitaryFactorizationComparison R a b a b = 1 := by
-  simp [unitaryFactorizationComparison]
+  simp only [unitaryFactorizationComparison, inv_mul_cancel]
 
 /-- Unitary factorization comparisons compose through an intermediate pair in
 the source orientation.  This is the composition law in the corollary
@@ -63,27 +63,26 @@ theorem unitaryFactorizationComparison_trans
     unitaryFactorizationComparison R a b f g =
       unitaryFactorizationComparison R c d f g *
         unitaryFactorizationComparison R a b c d := by
-  simp [unitaryFactorizationComparison, mul_assoc]
+  simp only [unitaryFactorizationComparison, mul_assoc, mul_inv_cancel_left]
 
 /-- If the reference operator is the identity, comparison against it recovers
 the source operator. -/
-@[simp]
 theorem unitaryFactorizationComparison_of_reference_eq_one
     (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d : ι)
     (href : R c d = 1) :
     unitaryFactorizationComparison R a b c d = R a b := by
-  simp [unitaryFactorizationComparison, href]
+  simp only [unitaryFactorizationComparison, href, inv_one, one_mul]
 
-/-- If the identity-prefixed operators are normalized to one, comparison with
-`(1, g * h)` recovers the right-fusion operator indexed by `(g, h)`.
+/-- If the identity-prefixed operators are normalized to one, the right-fusion operator
+indexed by `(g, h)` equals its comparison with `(1, g * h)`.
 
 This is $\lambda^R_{g,h} = \lambda_{g,h}^{e,gh}$ in the corollary following
 FBC25, Proposition `prop:3` (arXiv:2502.20257, lines 2782--2821). -/
-@[simp]
 theorem unitaryFactorizationComparison_right_reference
     {G : Type*} [Group G] (R : G → G → Matrix.unitaryGroup n 𝕜)
     (hR : ∀ x, R 1 x = 1) (g h : G) :
-    unitaryFactorizationComparison R g h 1 (g * h) = R g h := by
-  exact unitaryFactorizationComparison_of_reference_eq_one R g h 1 (g * h) (hR (g * h))
+    R g h = unitaryFactorizationComparison R g h 1 (g * h) := by
+  exact
+    (unitaryFactorizationComparison_of_reference_eq_one R g h 1 (g * h) (hR (g * h))).symm
 
 end Matrix

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -752,7 +752,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         \lambda_{a,b}^{c,d}
          & =(R_{c,d})^{-1}R_{a,b}
-         =R_{c,d}^\dagger R_{a,b}.
+        =R_{c,d}^\dagger R_{a,b}.
         \label{eq:mpug_unitary_factorization_comparison}
     \end{align}
     % Source anchor: arXiv:2502.20257, Corollary after Proposition 3,
@@ -773,9 +773,9 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_unitary_factorization_comparison}
     For all indices $a,b,c,d,f,g\in I$,
     \begin{align}
-        \lambda_{a,b}^{a,b} & =\mathbf 1, \\
+        \lambda_{a,b}^{a,b} & =\mathbf 1,                              \\
         \lambda_{a,b}^{f,g}
-         & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
+                            & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
         \label{eq:mpug_unitary_factorization_comparison_laws}
     \end{align}
     If $R_{c,d}=\mathbf 1$, then

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -743,19 +743,22 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{definition}[Unitary factorization comparison]
     \label{def:mpug_unitary_factorization_comparison}
-    \lean{Matrix.unitaryFactorizationComparison}
+    \lean{Matrix.unitaryFactorizationComparison,
+        Matrix.unitaryFactorizationComparison_coe}
     \leanok
-    Let $I$ be a set and let $R_{a,b}$ be a family of unitary matrices indexed
-    by $(a,b)\in I^2$. The comparison from $(a,b)$ to the reference pair
-    $(c,d)$ is
+    Let $I$ be a set and let $R_{a,b}$ be a family of unitary matrices of a
+    fixed size, indexed by $(a,b)\in I^2$. The unitary comparison from $(a,b)$
+    to the reference pair $(c,d)$ is
     \begin{align}
         \lambda_{a,b}^{c,d}
          & =(R_{c,d})^{-1}R_{a,b}
          =R_{c,d}^\dagger R_{a,b}.
         \label{eq:mpug_unitary_factorization_comparison}
     \end{align}
-    This is the orientation in the corollary following Proposition~3 of
-    \cite[lines~2782--2821]{FrancoRubio2025MPUGauging}. In that corollary,
+    % Source anchor: arXiv:2502.20257, Corollary after Proposition 3,
+    % lines 2782--2821, especially the defining formula at line 2820.
+    This is the orientation in the corollary after Proposition~3
+    of~\cite[lines~2782--2821]{FrancoRubio2025MPUGauging}. In that corollary,
     $I=G$ and comparisons are used when $ab=cd$; this equality selects the
     factorizations and is not needed in the unitary calculation.
 \end{definition}
@@ -776,12 +779,14 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \label{eq:mpug_unitary_factorization_comparison_laws}
     \end{align}
     If $R_{c,d}=\mathbf 1$, then
-    $\lambda_{a,b}^{c,d}=R_{a,b}$. In particular, for a group $G$, the
+    $\lambda_{a,b}^{c,d}=R_{a,b}$. In particular, if $I=G$ is a group, the
     normalization $R_{e,x}=\mathbf 1$ gives
     \begin{align}
-        \lambda_{g,h}^{e,gh} & =R_{g,h}.
+        R_{g,h} & =\lambda_{g,h}^{e,gh}.
         \label{eq:mpug_unitary_factorization_right_reference}
     \end{align}
+    % Source anchor: arXiv:2502.20257, Corollary after Proposition 3,
+    % line 2817 (right reference and composition).
     The last identity is the right-reference specialization
     $\lambda^R_{g,h}=\lambda_{g,h}^{e,gh}$ in the cited corollary.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -741,6 +741,63 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 % Formalization boundary: the MPU-specific source-gate transport and the final
 % lem:deco wrapper remain outside this slice and depend on issue #7313.
 
+\begin{definition}[Unitary factorization comparison]
+    \label{def:mpug_unitary_factorization_comparison}
+    \lean{Matrix.unitaryFactorizationComparison}
+    \leanok
+    Let $I$ be a set and let $R_{a,b}$ be a family of unitary matrices indexed
+    by $(a,b)\in I^2$. The comparison from $(a,b)$ to the reference pair
+    $(c,d)$ is
+    \begin{align}
+        \lambda_{a,b}^{c,d}
+         & =(R_{c,d})^{-1}R_{a,b}
+         =R_{c,d}^\dagger R_{a,b}.
+        \label{eq:mpug_unitary_factorization_comparison}
+    \end{align}
+    This is the orientation in the corollary following Proposition~3 of
+    \cite[lines~2782--2821]{FrancoRubio2025MPUGauging}. In that corollary,
+    $I=G$ and comparisons are used when $ab=cd$; this equality selects the
+    factorizations and is not needed in the unitary calculation.
+\end{definition}
+
+\begin{theorem}[Identity, composition, and right-reference laws]
+    \label{thm:mpug_unitary_factorization_comparison_laws}
+    \lean{Matrix.unitaryFactorizationComparison_self,
+        Matrix.unitaryFactorizationComparison_trans,
+        Matrix.unitaryFactorizationComparison_of_reference_eq_one,
+        Matrix.unitaryFactorizationComparison_right_reference}
+    \leanok
+    \uses{def:mpug_unitary_factorization_comparison}
+    For all indices $a,b,c,d,f,g\in I$,
+    \begin{align}
+        \lambda_{a,b}^{a,b} & =\mathbf 1, \\
+        \lambda_{a,b}^{f,g}
+         & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
+        \label{eq:mpug_unitary_factorization_comparison_laws}
+    \end{align}
+    If $R_{c,d}=\mathbf 1$, then
+    $\lambda_{a,b}^{c,d}=R_{a,b}$. In particular, for a group $G$, the
+    normalization $R_{e,x}=\mathbf 1$ gives
+    \begin{align}
+        \lambda_{g,h}^{e,gh} & =R_{g,h}.
+        \label{eq:mpug_unitary_factorization_right_reference}
+    \end{align}
+    The last identity is the right-reference specialization
+    $\lambda^R_{g,h}=\lambda_{g,h}^{e,gh}$ in the cited corollary.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_unitary_factorization_comparison}
+    The identity and right-reference formulas follow from
+    $R_{a,b}^{-1}R_{a,b}=\mathbf 1$ and
+    $\mathbf 1^{-1}R_{a,b}=R_{a,b}$. For composition, insert the identity at
+    the intermediate pair:
+    \begin{align}
+        (R_{f,g})^{-1}R_{a,b}
+         & =(R_{f,g})^{-1}R_{c,d}(R_{c,d})^{-1}R_{a,b}.
+    \end{align}
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,


### PR DESCRIPTION
## What changed
- define the generic comparison
  `unitaryFactorizationComparison R a b c d = (R c d)⁻¹ * R a b`
  in `Matrix.unitaryGroup`
- prove self-comparison, transitivity, identity-reference recovery, and the paper's right-reference specialization
- keep product equalities out of the algebraic hypotheses, since they only select comparable factorizations
- add the generated Algebra import and source-faithful Blueprint coverage for FBC25, lines 2782-2821

## Validation
- `lake build TNLean.Algebra.UnitaryFactorizationComparison TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (7022/7022 entries synchronized)
- forbidden-proof scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `#print axioms` on all four proof declarations, with only standard Lean foundational axioms reported
- `git diff --check`

A full local build was intentionally not run for this isolated algebra slice.

Closes #7460
