### PR TITLE
feat(Algebra): characterize signs for fixed-point-free involutions

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -18,6 +18,7 @@ import TNLean.Algebra.FinCyclicInduction
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FinsetSubtypeSum
+import TNLean.Algebra.FixedPointFreeInvolutionSign
 import TNLean.Algebra.GeneralizedCocycle
 import TNLean.Algebra.GeneralizedCocycleInversion
 import TNLean.Algebra.LSymbol

--- a/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
+++ b/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+import Mathlib.SetTheory.Cardinal.Order
+
+/-!
+# Signs for fixed-point-free involutions
+
+A fixed-point-free involution partitions a set into two-element orbits. A
+classical well-order orients every orbit, which gives opposite signs to its two
+points. Conversely, an equation with product `-1` at a fixed point is
+impossible for a sign valued in `{1, -1}`.
+
+This isolates the sign choice in arXiv:2502.20257,
+Proposition `prop:def_tens_anomalous`, equation `eq:defects_Z2b`, lines
+2979--2981. The results apply to arbitrary types; finiteness of the block set
+is not needed for this choice.
+-/
+
+namespace TNLean.Algebra
+
+/-- A complex unit is a sign when it is either `1` or `-1`. -/
+def IsComplexUnitSign (z : Units ℂ) : Prop :=
+  z = 1 ∨ z = -1
+
+/-- An involution admits an anomalous sign when its points can be labelled by
+complex-unit signs whose values on each orbit multiply to `-1`.
+
+This is the `{±1}`-valued condition on `ξ_g` in arXiv:2502.20257,
+`eq:defects_Z2b`, lines 2979--2981, specialized to an order-two action. -/
+def HasAnomalousInvolutionSign {X : Type*} (f : X → X) : Prop :=
+  ∃ ξ : X → Units ℂ,
+    (∀ x, IsComplexUnitSign (ξ x)) ∧ ∀ x, ξ x * ξ (f x) = -1
+
+section Involution
+
+variable {X : Type*} {f : X → X}
+
+private noncomputable def orientedSign (f : X → X) (x : X) : Units ℂ := by
+  classical
+  exact if WellOrderingRel x (f x) then 1 else -1
+
+private theorem orientedSign_isSign (x : X) :
+    IsComplexUnitSign (orientedSign f x) := by
+  classical
+  simp only [orientedSign, IsComplexUnitSign]
+  split <;> simp
+
+private theorem orientedSign_mul_apply (hf : Function.Involutive f)
+    (hfixed : ∀ x, f x ≠ x) (x : X) :
+    orientedSign f x * orientedSign f (f x) = -1 := by
+  classical
+  rcases trichotomous_of WellOrderingRel x (f x) with hlt | heq | hgt
+  · have hnot : ¬ WellOrderingRel (f x) x := fun h ↦ (asymm hlt h).elim
+    simp [orientedSign, hlt, hf x, hnot]
+  · exact (hfixed x heq.symm).elim
+  · have hnot : ¬ WellOrderingRel x (f x) := fun h ↦ (asymm h hgt).elim
+    simp [orientedSign, hgt, hf x, hnot]
+
+/-- Every fixed-point-free involution admits a `{±1}`-valued function whose
+values at paired points multiply to `-1`.
+
+The proof orients each two-element orbit using a classical well-order. This
+formalizes the sign choice in arXiv:2502.20257, `eq:defects_Z2b`, lines
+2979--2981. -/
+theorem hasAnomalousInvolutionSign_of_fixedPointFree (hf : Function.Involutive f)
+    (hfixed : ∀ x, f x ≠ x) : HasAnomalousInvolutionSign f := by
+  refine ⟨orientedSign f, orientedSign_isSign, ?_⟩
+  exact orientedSign_mul_apply hf hfixed
+
+/-- A fixed point obstructs the anomalous product equation for every genuinely
+`{±1}`-valued complex-unit function. The range hypothesis is essential:
+arbitrary complex units can have square `-1`.
+
+This is the converse to the sign choice used in arXiv:2502.20257,
+`eq:defects_Z2b`, lines 2979--2981. -/
+theorem not_hasAnomalousInvolutionSign_of_fixedPoint {x : X} (hx : f x = x) :
+    ¬ HasAnomalousInvolutionSign f := by
+  rintro ⟨ξ, hsign, hmul⟩
+  rcases hsign x with hone | hneg
+  · simpa [hx, IsComplexUnitSign, hone] using hmul x
+  · simpa [hx, IsComplexUnitSign, hneg] using hmul x
+
+/-- For an involution, anomalous `{±1}` signs exist exactly when there are no
+fixed points. This is the precise sign-valued form of the choice in
+arXiv:2502.20257, `eq:defects_Z2b`, lines 2979--2981. -/
+theorem hasAnomalousInvolutionSign_iff_fixedPointFree (hf : Function.Involutive f) :
+    HasAnomalousInvolutionSign f ↔ ∀ x, f x ≠ x := by
+  constructor
+  · intro hsign x hx
+    exact not_hasAnomalousInvolutionSign_of_fixedPoint hx hsign
+  · exact hasAnomalousInvolutionSign_of_fixedPointFree hf
+
+end Involution
+
+section GroupAction
+
+variable {G X : Type*} [Group G] [MulAction G X]
+
+/-- Acting by an element whose square is the identity defines an involution. -/
+theorem involutive_smul_of_mul_self_eq_one {g : G} (hg : g * g = 1) :
+    Function.Involutive (fun x : X ↦ g • x) := by
+  intro x
+  change g • (g • x) = x
+  rw [← mul_smul, hg, one_smul]
+
+/-- For an order-two group element, an anomalous `{±1}` sign on the block set
+exists exactly when that element fixes no block.
+
+This is the group-action specialization of the function `ξ_g` required in
+arXiv:2502.20257, Proposition `prop:def_tens_anomalous`, equation
+`eq:defects_Z2b`, lines 2979--2981. -/
+theorem hasAnomalousInvolutionSign_smul_iff {g : G} (hg : g * g = 1) :
+    HasAnomalousInvolutionSign (fun x : X ↦ g • x) ↔ ∀ x : X, g • x ≠ x :=
+  hasAnomalousInvolutionSign_iff_fixedPointFree
+    (involutive_smul_of_mul_self_eq_one hg)
+
+end GroupAction
+
+end TNLean.Algebra

--- a/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
+++ b/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
@@ -30,7 +30,8 @@ def IsComplexUnitSign (z : Units ℂ) : Prop :=
 complex-unit signs whose values on each orbit multiply to `-1`.
 
 This is the `{±1}`-valued condition on `ξ_g` in arXiv:2502.20257,
-`eq:defects_Z2b`, lines 2979--2981, specialized to an order-two action. -/
+`eq:defects_Z2b`, lines 2979--2981, specialized to an action by an element whose square
+is the identity. -/
 def HasAnomalousInvolutionSign {X : Type*} (f : X → X) : Prop :=
   ∃ ξ : X → Units ℂ,
     (∀ x, IsComplexUnitSign (ξ x)) ∧ ∀ x, ξ x * ξ (f x) = -1

--- a/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
+++ b/TNLean/Algebra/FixedPointFreeInvolutionSign.lean
@@ -107,8 +107,8 @@ theorem involutive_smul_of_mul_self_eq_one {g : G} (hg : g * g = 1) :
   change g • (g • x) = x
   rw [← mul_smul, hg, one_smul]
 
-/-- For an order-two group element, an anomalous `{±1}` sign on the block set
-exists exactly when that element fixes no block.
+/-- For a group element whose square is the identity, an anomalous `{±1}` sign on the
+block set exists exactly when that element fixes no block.
 
 This is the group-action specialization of the function `ξ_g` required in
 arXiv:2502.20257, Proposition `prop:def_tens_anomalous`, equation

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2098,7 +2098,7 @@ the scalar data and their gauge classes.
     $\C^\times$ are $1$ and $-1$.
 \end{proof}
 
-For an element $g$ of order two, the source condition
+For an element $g$ whose square is the identity, the source condition
 $\xi_g(x)\xi_{g^{-1}}(g\mathbin{\cdot}x)=-1$ reduces to
 $\xi_g(x)\xi_g(g\mathbin{\cdot}x)=-1$ because $g^{-1}=g$.
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2098,6 +2098,57 @@ the scalar data and their gauge classes.
     $\C^\times$ are $1$ and $-1$.
 \end{proof}
 
+\begin{definition}[Anomalous sign for an involution]
+    \label{def:mpug_anomalous_involution_sign}
+    \lean{TNLean.Algebra.IsComplexUnitSign,
+        TNLean.Algebra.HasAnomalousInvolutionSign}
+    \leanok
+    Let $f\colon\mathsf X\to\mathsf X$. An anomalous sign for $f$ is a
+    function $\xi\colon\mathsf X\to\C^\times$ such that
+    \begin{align}
+        \xi(x) & \in\{1,-1\},
+        \label{eq:mpug_anomalous_sign_range}
+    \end{align}
+    and
+    \begin{align}
+        \xi(x)\xi(f(x)) & =-1
+        \label{eq:mpug_anomalous_sign_pairing}
+    \end{align}
+    for every $x\in\mathsf X$.
+    % Source anchor: arXiv:2502.20257, prop:def_tens_anomalous,
+    % eq:defects_Z2b, lines 2979--2981.
+\end{definition}
+
+\begin{theorem}[Anomalous signs and fixed points]
+    \label{thm:mpug_anomalous_involution_sign_iff}
+    \lean{TNLean.Algebra.hasAnomalousInvolutionSign_of_fixedPointFree,
+        TNLean.Algebra.not_hasAnomalousInvolutionSign_of_fixedPoint,
+        TNLean.Algebra.hasAnomalousInvolutionSign_iff_fixedPointFree,
+        TNLean.Algebra.involutive_smul_of_mul_self_eq_one,
+        TNLean.Algebra.hasAnomalousInvolutionSign_smul_iff}
+    \leanok
+    \uses{def:mpug_anomalous_involution_sign}
+    Let $f\colon\mathsf X\to\mathsf X$ be an involution. An anomalous sign
+    exists if and only if $f$ has no fixed point. In particular, if a group
+    element $g$ satisfies $g^2=e$, then the action $x\mapsto gx$ admits such a
+    sign if and only if $gx\neq x$ for every $x\in\mathsf X$.
+    This isolates the choice of $\xi_g$ in
+    \cite[Proposition~\texttt{prop:def\_tens\_anomalous},
+    lines~2979--2981]{FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, prop:def_tens_anomalous,
+    % eq:defects_Z2b, lines 2979--2981.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_anomalous_involution_sign}
+    Choose a well-order on $\mathsf X$. In each two-element orbit
+    $\{x,f(x)\}$, assign $1$ to the smaller element and $-1$ to the larger.
+    Involutivity exchanges the two elements, so their signs multiply to
+    $-1$. Conversely, at a fixed point the product is the square of either
+    $1$ or $-1$, hence equals $1$ rather than $-1$. The group-action statement
+    follows from $g(gx)=g^2x=x$.
+\end{proof}
+
 \begin{theorem}[Nontrivial scalar gauge class for $\Z_2$]
     \label{thm:mpug_z2_nontrivial_scalar_class}
     \lean{TNLean.Algebra.ScalarThreeCochain.not_isTrivialGaugeClass_iff_sigma_generator_eq_neg_one}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2098,6 +2098,10 @@ the scalar data and their gauge classes.
     $\C^\times$ are $1$ and $-1$.
 \end{proof}
 
+For an element $g$ of order two, the source condition
+$\xi_g(x)\xi_{g^{-1}}(g\mathbin{\cdot}x)=-1$ reduces to
+$\xi_g(x)\xi_g(g\mathbin{\cdot}x)=-1$ because $g^{-1}=g$.
+
 \begin{definition}[Anomalous sign for an involution]
     \label{def:mpug_anomalous_involution_sign}
     \lean{TNLean.Algebra.IsComplexUnitSign,
@@ -2129,12 +2133,12 @@ the scalar data and their gauge classes.
     \leanok
     \uses{def:mpug_anomalous_involution_sign}
     Let $f\colon\mathsf X\to\mathsf X$ be an involution. An anomalous sign
-    exists if and only if $f$ has no fixed point. In particular, if a group
-    element $g$ satisfies $g^2=e$, then the action $x\mapsto gx$ admits such a
-    sign if and only if $gx\neq x$ for every $x\in\mathsf X$.
-    This isolates the choice of $\xi_g$ in
-    \cite[Proposition~\texttt{prop:def\_tens\_anomalous},
-    lines~2979--2981]{FrancoRubio2025MPUGauging}.
+    exists if and only if $f$ has no fixed point. In particular, let a group
+    act on $\mathsf X$ from the left, and suppose that $g^2=e$. The action
+    $x\mapsto g\mathbin{\cdot}x$ admits an anomalous sign if and only if
+    $g\mathbin{\cdot}x\neq x$ for every $x\in\mathsf X$.
+    This is the sign condition used for anomalous defect tensors in
+    \cite[lines~2979--2981]{FrancoRubio2025MPUGauging}.
     % Source anchor: arXiv:2502.20257, prop:def_tens_anomalous,
     % eq:defects_Z2b, lines 2979--2981.
 \end{theorem}
@@ -2145,8 +2149,8 @@ the scalar data and their gauge classes.
     $\{x,f(x)\}$, assign $1$ to the smaller element and $-1$ to the larger.
     Involutivity exchanges the two elements, so their signs multiply to
     $-1$. Conversely, at a fixed point the product is the square of either
-    $1$ or $-1$, hence equals $1$ rather than $-1$. The group-action statement
-    follows from $g(gx)=g^2x=x$.
+    $1$ or $-1$, hence equals $1$ rather than $-1$. For the action statement,
+    $g\mathbin{\cdot}(g\mathbin{\cdot}x)=(g^2)\mathbin{\cdot}x=x$.
 \end{proof}
 
 \begin{theorem}[Nontrivial scalar gauge class for $\Z_2$]


### PR DESCRIPTION
## What changed
- define genuinely `{±1}`-valued complex-unit signs and the anomalous pairing condition
- construct opposite signs for every fixed-point-free involution by orienting its two-cycles with a classical well-order
- prove the fixed-point obstruction and the exact equivalence with fixed-point-freeness
- specialize the API to an element whose square is the identity acting on a block set
- add the generated Algebra import and Blueprint coverage for arXiv:2502.20257, `prop:def_tens_anomalous` / `eq:defects_Z2b`, lines 2979–2981

The converse explicitly requires `{±1}`-valued signs. It does not make the false claim for arbitrary complex units, where a square root of `-1` exists.

## Validation
- `lake build TNLean.Algebra.FixedPointFreeInvolutionSign`
- `lake build TNLean.Algebra TNLean.Algebra.FixedPointFreeInvolutionSign` (3485 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- isolated double `lualatex` compilation of `ch29_mpu_gauging.tex`
- proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `#print axioms` on all five public theorems: only standard `propext`, `Classical.choice`, and `Quot.sound` dependencies
- `git diff --check`

No full local build was run, as requested for this parallel issue lane; hosted CI supplies the repository-wide build.

Closes #7461

