### PR TITLE
feat(parent-hamiltonian): prove moving-window count

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -67,6 +67,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -10,6 +10,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
@@ -33,7 +34,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The twelve components are:
+The thirteen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
@@ -55,6 +56,8 @@ The twelve components are:
   and quadratic-form domination by the original range-\(2p\) Hamiltonian;
 * `Martingale.BlockedOriginalGap` — transfer of the gap constant \(1/8\) to
   original-site periodic chains of length divisible by the block length;
+* `Martingale.MovingWindowCount` — reversal and counting of the finite moving-window
+  sums in Nachtergaele's martingale estimate;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Real.Basic
+
+/-!
+# Moving-window double counting
+
+This module records the finite-sum estimate used when Nachtergaele sums the
+per-index martingale inequality. Each coefficient belongs to at most \(l+1\)
+of the active windows.
+-/
+
+open scoped BigOperators
+
+namespace FrustrationFree
+
+/--
+For nonnegative coefficients \(a_m\), summing the windows
+\([n-l,n]\) over \(n\in[l,N)\) counts each coefficient at most \(l+1\) times.
+Thus
+\[
+  \sum_{n=l}^{N-1}\sum_{m=n-l}^{n}a_m
+  \le (l+1)\sum_{m=0}^{N-1}a_m.
+\]
+
+The proof follows the summation after equation \(\mathrm{Enpsi2}\) in Theorem 2.1(i)
+of Nachtergaele, arXiv:cond-mat/9410110, lines 1220–1255. Write
+\(m=n-l+k\) with \(0\le k\le l\), reverse the sums over \(n\) and \(k\),
+and for fixed \(k\) inject the shifted indices into \([0,N)\). No relation
+between \(l\) and \(N\) is required, so the empty outer sum when \(l\ge N\)
+is included.
+-/
+theorem movingWindow_sum_le (a : ℕ → ℝ) (l N : ℕ) (ha : ∀ m, 0 ≤ a m) :
+    ∑ n ∈ Finset.Ico l N, ∑ m ∈ Finset.Icc (n - l) n, a m ≤
+      (l + 1) * ∑ m ∈ Finset.range N, a m := by
+  have hwindow (n : ℕ) (hn : l ≤ n) :
+      ∑ m ∈ Finset.Icc (n - l) n, a m =
+        ∑ k ∈ Finset.range (l + 1), a (n - l + k) := by
+    rw [show Finset.Icc (n - l) n = Finset.Ico (n - l) (n + 1) by
+      ext m
+      simp only [Finset.mem_Icc, Finset.mem_Ico, Nat.lt_succ_iff]]
+    rw [Finset.sum_Ico_eq_sum_range]
+    rw [show n + 1 - (n - l) = l + 1 by omega]
+  calc
+    ∑ n ∈ Finset.Ico l N, ∑ m ∈ Finset.Icc (n - l) n, a m =
+        ∑ n ∈ Finset.Ico l N, ∑ k ∈ Finset.range (l + 1), a (n - l + k) := by
+          refine Finset.sum_congr rfl fun n hn ↦ ?_
+          exact hwindow n (Finset.mem_Ico.mp hn).1
+    _ = ∑ k ∈ Finset.range (l + 1), ∑ n ∈ Finset.Ico l N, a (n - l + k) :=
+      Finset.sum_comm
+    _ ≤ ∑ k ∈ Finset.range (l + 1), ∑ m ∈ Finset.range N, a m := by
+      refine Finset.sum_le_sum fun k hk ↦ ?_
+      have hklt : k < l + 1 := Finset.mem_range.mp hk
+      let g : ℕ → ℕ := fun n ↦ n - l + k
+      have hg_inj : Set.InjOn g (Finset.Ico l N) := by
+        intro n hn n' hn' hEq
+        simp only [g] at hEq
+        have hn_ge : l ≤ n := (Finset.mem_Ico.mp hn).1
+        have hn'_ge : l ≤ n' := (Finset.mem_Ico.mp hn').1
+        omega
+      have hg_sub : Finset.image g (Finset.Ico l N) ⊆ Finset.range N := by
+        intro m hm
+        rcases Finset.mem_image.mp hm with ⟨n, hn, rfl⟩
+        simp only [Finset.mem_range, g]
+        have hn_bounds := Finset.mem_Ico.mp hn
+        omega
+      calc
+        ∑ n ∈ Finset.Ico l N, a (n - l + k) =
+            ∑ m ∈ Finset.image g (Finset.Ico l N), a m := by
+              symm
+              exact Finset.sum_image hg_inj
+        _ ≤ ∑ m ∈ Finset.range N, a m :=
+          Finset.sum_le_sum_of_subset_of_nonneg hg_sub fun m _ _ ↦ ha m
+    _ = (l + 1) * ∑ m ∈ Finset.range N, a m := by simp
+
+end FrustrationFree

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -676,6 +676,33 @@ norm estimate is derived here.
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
+\begin{theorem}[Moving-window double counting]
+    \label{thm:moving_window_sum_le}
+    \lean{FrustrationFree.movingWindow_sum_le}
+    \leanok
+    Let $(a_m)_{m\geq0}$ be a nonnegative real sequence. For all $l,N\in\N$,
+    \begin{align}
+        \sum_{n=l}^{N-1}\sum_{m=n-l}^{n}a_m
+         & \leq (l+1)\sum_{m=0}^{N-1}a_m.
+        \label{eq:moving_window_sum_le}
+    \end{align}
+    When $l\geq N$, the sum on the left is empty.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $m=n-l+k$, where $0\leq k\leq l$, and reverse the order of
+    summation. For each fixed $k$, the map $n\mapsto n-l+k$ is injective on
+    $\{l,\ldots,N-1\}$ and has image in $\{0,\ldots,N-1\}$. Nonnegativity
+    therefore bounds the corresponding inner sum by
+    $\sum_{m=0}^{N-1}a_m$. Summing over the $l+1$ values of $k$ proves
+    (\ref{eq:moving_window_sum_le}). This is the counting step in the proof of
+    Nachtergaele's Theorem~2.1(i), between Equation~(Enpsi2) and the following
+    summed estimate: for $a_m=\lVert E_m\psi\rVert^2$, each term occurs in at
+    most $l+1$ consecutive windows
+    \cite[Proof of Theorem~2.1(i)]{Nachtergaele1996Spectral}.
+\end{proof}
+
 \begin{theorem}[Martingale criterion for a finite family of projections]
     \label{thm:martingale_criterion}
     \lean{MPSTensor.spectralGap_of_martingale_anticommutator_rowCol_of_finiteDimensional}


### PR DESCRIPTION
## Summary

- formalize the nonnegative moving-window double-counting inequality used in Nachtergaele Theorem 2.1(i)
- retain the exact active range $n\in[l,N)$ and coefficient $l+1$
- prove the bound by reindexing and reversing finite sums, not by cyclic row/column machinery
- expose the helper through the martingale and parent-Hamiltonian aggregators

## Source

- `References/cond-mat_9410110/main.tex`, proof of Theorem 2.1(i), from `Enpsi2` to `Enpsi3`, lines 1220-1255

## Verification

- targeted build of the new module and martingale aggregator, 8972 jobs
- generated import aggregators current
- oversized-file, proof-integrity, cyclic-route guard, and whitespace checks pass

Closes #7486
Related to #7478
