### PR TITLE
feat(MPS/Core): prove corrected proportional reductions

### DIFF
--- a/TNLean/MPS/Core/Reduction.lean
+++ b/TNLean/MPS/Core/Reduction.lean
@@ -49,6 +49,23 @@ theorem evalWord (h : IsReduction B A V W) (w : List (Fin d)) :
 theorem evalWord_nil (h : IsReduction B A V W) :
     V * Kraus.evalWord B [] * W = Kraus.evalWord A [] := h.2 []
 
+/-- Scaling both tensors by the same scalar preserves a rectangular reduction. -/
+theorem smul (h : IsReduction B A V W) (c : ℂ) :
+    IsReduction (fun i => c • B i) (fun i => c • A i) V W := by
+  refine ⟨h.mul_eq_one, fun w => ?_⟩
+  simp only [Kraus.evalWord_smul, Matrix.mul_smul, Matrix.smul_mul, h.evalWord]
+
+/-- A reduction whose target is scaled by `c` intertwines an unscaled source
+word with `c` to the word length times the corresponding unscaled target word.
+
+This is the explicit corrected relation in MGSC18, Proposition 20,
+`eq:mgsc18_reduction_proportionality_corrected_word_relation`; see
+`docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`, lines 96--120. -/
+theorem evalWord_smul_target {c : ℂ}
+    (h : IsReduction B (fun i => c • A i) V W) (w : List (Fin d)) :
+    V * Kraus.evalWord B w * W = (c ^ w.length) • Kraus.evalWord A w := by
+  simpa only [Kraus.evalWord_smul] using h.evalWord w
+
 /-- A rectangular reduction cannot increase the bond dimension: the target
 bond dimension is at most the source bond dimension. -/
 theorem bondDim_le (h : IsReduction B A V W) : D₁ ≤ D₂ :=

--- a/TNLean/MPS/Core/ReductionExistence.lean
+++ b/TNLean/MPS/Core/ReductionExistence.lean
@@ -3,20 +3,21 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.LinearAlgebra.JordanChevalley
 import TNLean.Algebra.RankOneFactorization
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Core.Reduction
 import TNLean.MPS.Core.ReductionCrossMatrix
-import Mathlib.LinearAlgebra.JordanChevalley
 
 /-!
-# Equality-case rectangular reductions
+# Equality-case and corrected proportional rectangular reductions
 
-This file proves the equality specialization of Proposition 20 of
-Molnár--Ge--Schuch--Cirac.  The target tensor is first made injective by a
-positive physical blocking.  Its coefficient-dual inverse and the source
-tensor define the mixed-bond cross matrix on `Fin D_B × Fin D_A`.
+This file proves the equality specialization and corrected nonzero proportional
+version of Proposition 20 of Molnár--Ge--Schuch--Cirac.  In the equality proof,
+the target tensor is first made injective by a positive physical blocking.  Its
+coefficient-dual inverse and the source tensor define the mixed-bond cross
+matrix on `Fin D_B × Fin D_A`.
 Jordan--Chevalley decomposition separates this cross endomorphism into
 commuting nilpotent and semisimple parts.  The source trace-power identities
 force the semisimple part to have rank one; its rectangular factorization is
@@ -30,11 +31,11 @@ trace-preserving normalization enters the argument.
 Source: arXiv:1706.07329v2, Proposition 20, `cornerproblem.tex` lines
 3815--3938.
 
-**Scope restriction (equality-only local fix):** The results assume
-`SameMPV₂Pos`, and hence prove the `λ = 1` specialization of the proportional
-premise printed in Proposition 20.  The unscaled conclusion is false for
-unrestricted `λ ≠ 1`; see
-`docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`.
+**Local fix (proportionality scalar):** The equality-case core assumes
+`SameMPV₂Pos`, while the corrected nonzero proportional theorems retain the
+factor `λ ^ |w|` by reducing to that core after rescaling the arbitrary source.
+The unscaled conclusion printed in Proposition 20 is false for unrestricted
+`λ ≠ 1`; see `docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`.
 -/
 
 open scoped Matrix BigOperators
@@ -216,5 +217,69 @@ theorem exists_isReduction_of_isNormal_of_sameMPV₂Pos [NeZero D_A]
   obtain ⟨p, hp, hAp⟩ := hA
   apply exists_isReduction_of_blockTensor_isInjective_of_sameMPV₂Pos A B hSame p hp
   exact (isNBlkInjective_iff_blockTensor_isInjective A p).mp hAp
+
+/-- Rescaling a proportionally equal source by the inverse scalar gives exact
+positive-length MPV equality. -/
+private theorem sameMPV₂Pos_inv_smul_of_mpv_eq_pow_mul
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B) (c : ℂ) (hc : c ≠ 0)
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B σ = c ^ N * mpv A σ) :
+    SameMPV₂Pos (fun i => c⁻¹ • B i) A := by
+  intro N hN σ
+  calc
+    mpv (fun i => c⁻¹ • B i) σ = c⁻¹ ^ N * mpv B σ := by
+      simp only [mpv, coeff, Kraus.evalWord_smul, List.length_ofFn,
+        Matrix.trace_smul, smul_eq_mul]
+    _ = c⁻¹ ^ N * (c ^ N * mpv A σ) := by rw [hmpv N hN σ]
+    _ = mpv A σ := by rw [← mul_assoc, ← mul_pow]; simp [hc]
+
+/-- An injective target and a source whose positive-length MPVs are `c ^ N`
+times the target MPVs admit a reduction to the target scaled by nonzero `c`.
+Only the arbitrary source is first rescaled by `c⁻¹`; the equality-case theorem
+is then applied before both sides are scaled back by `c`.
+
+This is the injective-target form of the corrected MGSC18 Proposition 20
+relation `eq:mgsc18_reduction_proportionality_corrected_word_relation`, derived
+from `cornerproblem.tex` lines 3124--3133 and 3815--3938.  The correction is
+recorded in `docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`,
+lines 96--120. -/
+theorem exists_isReduction_smul_of_isInjective_of_mpv_eq_pow_mul [NeZero D_A]
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B) (c : ℂ)
+    (hA : Kraus.IsInjective A) (hc : c ≠ 0)
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B σ = c ^ N * mpv A σ) :
+    ∃ (V : Matrix (Fin D_A) (Fin D_B) ℂ)
+      (W : Matrix (Fin D_B) (Fin D_A) ℂ),
+        IsReduction B (fun i => c • A i) V W := by
+  have hSame := sameMPV₂Pos_inv_smul_of_mpv_eq_pow_mul A B c hc hmpv
+  obtain ⟨V, W, hReduction⟩ :=
+    exists_isReduction_of_isInjective_of_sameMPV₂Pos
+      A (fun i => c⁻¹ • B i) hA hSame
+  refine ⟨V, W, ?_⟩
+  simpa [smul_smul, hc] using hReduction.smul c
+
+/-- A normal target and a source whose positive-length MPVs are `c ^ N` times
+the target MPVs admit a reduction to the target scaled by nonzero `c`.
+Consequently, `IsReduction.evalWord_smul_target` gives exactly
+`V * evalWord B w * W = (c ^ w.length) • evalWord A w`.
+
+This is the corrected nonzero-scalar form of MGSC18 Proposition 20,
+`eq:mgsc18_reduction_proportionality_corrected_word_relation`; see
+`cornerproblem.tex` lines 3124--3133 and 3815--3938 and
+`docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex`, lines 96--120. -/
+theorem exists_isReduction_smul_of_isNormal_of_mpv_eq_pow_mul [NeZero D_A]
+    (A : MPSTensor d D_A) (B : MPSTensor d D_B) (c : ℂ)
+    (hA : Kraus.IsNormal A) (hc : c ≠ 0)
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B σ = c ^ N * mpv A σ) :
+    ∃ (V : Matrix (Fin D_A) (Fin D_B) ℂ)
+      (W : Matrix (Fin D_B) (Fin D_A) ℂ),
+        IsReduction B (fun i => c • A i) V W := by
+  have hSame := sameMPV₂Pos_inv_smul_of_mpv_eq_pow_mul A B c hc hmpv
+  obtain ⟨V, W, hReduction⟩ :=
+    exists_isReduction_of_isNormal_of_sameMPV₂Pos
+      A (fun i => c⁻¹ • B i) hA hSame
+  refine ⟨V, W, ?_⟩
+  simpa [smul_smul, hc] using hReduction.smul c
 
 end MPSTensor

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -953,6 +953,78 @@ $A^{-1}A=\Id$. This is the identity used in
     scale.
 \end{proof}
 
+\begin{lemma}[Scalar covariance of rectangular reductions]
+    \label{lem:mps_reduction_scalar_covariance}
+    \lean{MPSTensor.IsReduction.smul,
+        MPSTensor.IsReduction.evalWord_smul_target}
+    \leanok
+    \uses{def:mps_rectangular_reduction}
+    If $V,W$ form a reduction from $B$ to $A$, then they also form a reduction
+    from $cB$ to $cA$ for every $c\in\C$.  If instead they form a reduction
+    from $B$ to $cA$, then
+    \begin{align}
+        VW & =1_{D_A},
+           & VB^wW     & =c^{|w|}A^w
+        \qquad\text{for every word }w.
+        \label{eq:mps_reduction_scalar_covariance}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_smul}
+    Scaling both tensors multiplies each length-$|w|$ word by the same factor
+    $c^{|w|}$, so the reduction identities are preserved.  For a reduction to
+    $cA$, expand $(cA)^w=c^{|w|}A^w$ in the defining word identity.  The
+    retraction $VW=1_{D_A}$ is unchanged.
+\end{proof}
+
+\begin{theorem}[Nonzero proportional existence of rectangular reductions]
+    \label{thm:mps_proportional_reduction_exists}
+    \lean{MPSTensor.exists_isReduction_smul_of_isInjective_of_mpv_eq_pow_mul,
+        MPSTensor.exists_isReduction_smul_of_isNormal_of_mpv_eq_pow_mul}
+    \leanok
+    \uses{def:mpv, def:injective, def:normal,
+        def:mps_rectangular_reduction}
+    Let $A$ and $B$ have the same physical alphabet and positive target bond
+    dimension $D_A>0$.  Let $c\in\C$ be nonzero, and suppose that
+    \begin{align}
+        V^{(N)}(B)_\sigma
+         & =c^N V^{(N)}(A)_\sigma
+        \qquad\text{for every }N>0\text{ and every configuration }\sigma.
+        \label{eq:mps_proportional_reduction_hypothesis}
+    \end{align}
+    If $A$ is injective, then there exist
+    $V\in\C^{D_A\times D_B}$ and $W\in\C^{D_B\times D_A}$ such that
+    \begin{align}
+        VW & =1_{D_A},
+           & VB^wW     & =c^{|w|}A^w
+        \qquad\text{for every word }w.
+        \label{eq:mps_proportional_reduction_word_relation}
+    \end{align}
+    The same conclusion holds when $A$ is normal.
+
+    This is the corrected nonzero-scalar form of
+    \cite[Proposition~20]{Molnar2018SemiInjective}.  The unscaled conclusion
+    printed there is false for unrestricted $c\ne1$, and the case $c=0$ does
+    not admit this rescaling argument
+    \cite{gap:mgsc18_reduction_proportionality_scalar}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_smul, thm:mps_equality_reduction_exists,
+        lem:mps_reduction_scalar_covariance}
+    Set $\widetilde B=c^{-1}B$.  Expand its word evaluations with
+    Lemma~\ref{lem:eval_word_smul}, take the trace, and use
+    Eq.~\ref{eq:mps_proportional_reduction_hypothesis}.  The positive-length MPV
+    families of $\widetilde B$ and $A$ are equal.  Apply
+    Theorem~\ref{thm:mps_equality_reduction_exists} to obtain a reduction from
+    $\widetilde B$ to $A$.  Scale both tensors by $c$ to obtain a reduction
+    from $B$ to $cA$, and then apply
+    Lemma~\ref{lem:mps_reduction_scalar_covariance} to get
+    Eq.~\ref{eq:mps_proportional_reduction_word_relation}.
+\end{proof}
 
 \begin{lemma}[Nonempty products in a generated subsemigroup]
     \label{lem:subsemigroup_closure_nonempty_product}

--- a/docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex
+++ b/docs/paper-gaps/mgsc18_reduction_proportionality_scalar.tex
@@ -8,11 +8,11 @@
 
 \title{The Proportionality Scalar in the MPS Reduction Theorem}
 \author{}
-\date{2026-08-29}
+\date{2026-08-30}
 
 \begin{document}
 \maketitle
-\gapnote{false-source}{open}
+\gapnote{false-source}{resolved}
 
 \section{The printed statement}
 
@@ -133,13 +133,18 @@ Proposition~20.
 
 The formal predicate \leanid{MPSTensor.IsReduction} records the rectangular
 pair, the retraction $VW=1$, and the word equation including the empty word.
-The reusable existence theorem must first be proved for equal positive-length
-matrix product state families.  A later proportional version may be derived
-by the rescaling above, with the power $\lambda^m$ retained explicitly.  The
-equality-case existence proof is tracked by
-\href{https://github.com/LionSR/TNLean/issues/7393}{TNLean issue 7393}; its
-selected-reduction residual algebra is tracked under
-\href{https://github.com/LionSR/TNLean/issues/7322}{TNLean issue 7322}.
+Scalar covariance is proved by \leanid{MPSTensor.IsReduction.smul}, and
+\leanid{MPSTensor.IsReduction.evalWord_smul_target} gives the corrected formula
+$VB^wW=\lambda^{|w|}A^w$ for a reduction from $B$ to $\lambda A$.  For
+$\lambda\ne0$, the injective-target and normal-target existence results are
+\leanid{MPSTensor.exists_isReduction_smul_of_isInjective_of_mpv_eq_pow_mul}
+and
+\leanid{MPSTensor.exists_isReduction_smul_of_isNormal_of_mpv_eq_pow_mul}.
+They rescale the arbitrary source to $\lambda^{-1}B$, apply the equality-case
+existence theorem, and scale back.  The corresponding Blueprint entries are
+\path{lem:mps_reduction_scalar_covariance} and
+\path{thm:mps_proportional_reduction_exists} in
+\path{blueprint/src/chapter/ch02_mps.tex}.
 
 \section{Verdict}
 


### PR DESCRIPTION
## Summary

- add scalar covariance for rectangular MPS reductions and expose the exact word-length power relation
- derive injective- and normal-target nonzero proportional reduction existence from the merged equality case by rescaling only the arbitrary source
- resolve the MGSC18 Proposition 20 proportionality-scalar gap note while preserving the false unscaled statement and the `c = 0` exclusion
- add formula-driven Chapter 2 coverage

## Source-faithful route

For `c ≠ 0` and

```lean
mpv B σ = c ^ N * mpv A σ,
```

rescale the arbitrary source to `c⁻¹ • B`, apply the equality-case theorem, and scale both sides back. The resulting reduction is from `B` to `c • A`, so

```lean
V * Kraus.evalWord B w * W =
  (c ^ w.length) • Kraus.evalWord A w.
```

No same-bond Fundamental Theorem, BNT decomposition, canonical/TP normalization, equal-bond assumption, or residual machinery is used.

## Validation

Hot-main protocol only; no broad `lake build` was run.

- `lake env lean TNLean/MPS/Core/Reduction.lean`
- `lake env lean TNLean/MPS/Core/ReductionExistence.lean`
- Blueprint synchronization and reverse coverage
- Blueprint declaration-scanner regression tests
- paper-gap Lean-id regression tests
- `git diff --check`
- exact-head Lean/style approval: `b3bcaad44333`
- exact-head Blueprint/source-traceability approval: `b9d9bd315eee`

Closes #7376
