### PR TITLE
feat(MPS/MPU): prove local U2-U3 species swap

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -18,6 +18,13 @@ import TNLean.MPS.MPU.DaggerInverseGauge
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
+import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
+import TNLean.MPS.MPU.Examples.ShiftSourceFactors
+import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
+import TNLean.MPS.MPU.Examples.ShiftSourceRanks
+import TNLean.MPS.MPU.Examples.ShiftSwap
+import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
 import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.FiniteChainConjugation
 import TNLean.MPS.MPU.GroupRepresentation

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -18,13 +18,6 @@ import TNLean.MPS.MPU.DaggerInverseGauge
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
-import TNLean.MPS.MPU.Examples.Shift
-import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
-import TNLean.MPS.MPU.Examples.ShiftSourceFactors
-import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
-import TNLean.MPS.MPU.Examples.ShiftSourceRanks
-import TNLean.MPS.MPU.Examples.ShiftSwap
-import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
 import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.FiniteChainConjugation
 import TNLean.MPS.MPU.GroupRepresentation

--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -13,8 +13,5 @@ import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
-<<<<<<< HEAD
-import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
-=======
 import TNLean.MPS.MPU.Examples.ShiftSwap
->>>>>>> 5f3e51353 (feat(MPS/MPU): prove local U2-U3 species swap)
+import TNLean.MPS.MPU.Examples.ShiftSwapMatrices

--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -13,4 +13,8 @@ import TNLean.MPS.MPU.Examples.ShiftSourceBlockedFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
+<<<<<<< HEAD
 import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
+=======
+import TNLean.MPS.MPU.Examples.ShiftSwap
+>>>>>>> 5f3e51353 (feat(MPS/MPU): prove local U2-U3 species swap)

--- a/TNLean/MPS/MPU/Examples/ShiftSwap.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSwap.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.Shift
+import QICLean.Channel.MaximallyEntangled
+
+/-!
+# Physical-species swap for the shift examples
+
+The local form of the observation in arXiv:1703.09188, lines 1999--2001 and
+2238--2245, that exchanging the two spins at every site swaps the shift examples
+$U_2$ and $U_3$.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+private theorem swapMatrix_mul_mul_swapMatrix_apply
+    (d : ℕ) (M : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (α₁ α₂ β₁ β₂ : Fin d) :
+    (Matrix.swapMatrix d * M * Matrix.swapMatrix d) (α₁, α₂) (β₁, β₂) =
+      M (α₂, α₁) (β₂, β₁) := by
+  have swap_mul_apply (γ₁ γ₂ : Fin d) :
+      (Matrix.swapMatrix d * M) (α₁, α₂) (γ₁, γ₂) = M (α₂, α₁) (γ₁, γ₂) := by
+    rw [Matrix.mul_apply]
+    simp only [Fintype.sum_prod_type, Matrix.swapMatrix_apply]
+    rw [Finset.sum_eq_single α₂]
+    · rw [Finset.sum_eq_single α₁]
+      · simp
+      · intro x _ hx
+        simp [Ne.symm hx]
+      · simp
+    · intro x _ hx
+      apply Finset.sum_eq_zero
+      intro y _
+      simp [Ne.symm hx]
+    · simp
+  rw [Matrix.mul_apply]
+  simp only [Fintype.sum_prod_type, Matrix.swapMatrix_apply, swap_mul_apply]
+  rw [Finset.sum_eq_single β₂]
+  · rw [Finset.sum_eq_single β₁]
+    · simp
+    · intro x _ hx
+      simp [hx]
+    · simp
+  · intro x _ hx
+    apply Finset.sum_eq_zero
+    intro y _
+    simp [hx]
+  · simp
+
+/-- Swapping the two physical species exchanges the local tensors $U_2$ and
+$U_3$, up to the corresponding swap of their two virtual factors.
+
+The physical bra and ket coordinates are ordered as `(i₁, i₂)` and `(j₁, j₂)`.
+After their exchange, the $U_3$ entry at `(i₂, i₁)` and `(j₂, j₁)` is the
+$U_2$ virtual matrix conjugated by the SWAP operator. This is the local tensor
+identity underlying arXiv:1703.09188, lines 1999--2001 and 2238--2245. -/
+theorem shiftExampleU₃_physicalSwap_eq_swapMatrix_mul_shiftExampleU₂_mul_swapMatrix
+    (d : ℕ) (i₁ i₂ j₁ j₂ : Fin d) :
+    Matrix.reindex finProdFinEquiv.symm finProdFinEquiv.symm
+        (shiftExampleU₃ d (finProdFinEquiv (i₂, i₁)) (finProdFinEquiv (j₂, j₁))) =
+      Matrix.swapMatrix d *
+        Matrix.reindex finProdFinEquiv.symm finProdFinEquiv.symm
+          (shiftExampleU₂ d (finProdFinEquiv (i₁, i₂)) (finProdFinEquiv (j₁, j₂))) *
+        Matrix.swapMatrix d := by
+  ext ⟨α₁, α₂⟩ ⟨β₁, β₂⟩
+  rw [swapMatrix_mul_mul_swapMatrix_apply]
+  simp only [Matrix.reindex_apply]
+  simp [shiftExampleU₂, shiftExampleU₃, mul_comm]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSwap.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSwap.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.Examples.Shift
 import QICLean.Channel.MaximallyEntangled
+import TNLean.MPS.MPU.Examples.Shift
 
 /-!
 # Physical-species swap for the shift examples
 
-The local form of the observation in arXiv:1703.09188, lines 1999--2001 and
-2238--2245, that exchanging the two spins at every site swaps the shift examples
+A local refinement of the finite-chain observations in arXiv:1703.09188,
+lines 1999--2001 and 2240--2245: exchanging the two spins at every site swaps
 $U_2$ and $U_3$.
 -/
 
@@ -24,7 +24,8 @@ private theorem swapMatrix_mul_mul_swapMatrix_apply
     (Matrix.swapMatrix d * M * Matrix.swapMatrix d) (α₁, α₂) (β₁, β₂) =
       M (α₂, α₁) (β₂, β₁) := by
   have swap_mul_apply (γ₁ γ₂ : Fin d) :
-      (Matrix.swapMatrix d * M) (α₁, α₂) (γ₁, γ₂) = M (α₂, α₁) (γ₁, γ₂) := by
+      (Matrix.swapMatrix d * M) (α₁, α₂) (γ₁, γ₂) =
+        M (α₂, α₁) (γ₁, γ₂) := by
     rw [Matrix.mul_apply]
     simp only [Fintype.sum_prod_type, Matrix.swapMatrix_apply]
     rw [Finset.sum_eq_single α₂]
@@ -55,10 +56,11 @@ private theorem swapMatrix_mul_mul_swapMatrix_apply
 /-- Swapping the two physical species exchanges the local tensors $U_2$ and
 $U_3$, up to the corresponding swap of their two virtual factors.
 
-The physical bra and ket coordinates are ordered as `(i₁, i₂)` and `(j₁, j₂)`.
-After their exchange, the $U_3$ entry at `(i₂, i₁)` and `(j₂, j₁)` is the
-$U_2$ virtual matrix conjugated by the SWAP operator. This is the local tensor
-identity underlying arXiv:1703.09188, lines 1999--2001 and 2238--2245. -/
+The physical output and input coordinates are ordered as `(i₁, i₂)` and
+`(j₁, j₂)`. After their exchange, the $U_3$ entry at `(i₂, i₁)` and
+`(j₂, j₁)` is the $U_2$ virtual matrix conjugated by the SWAP operator. This
+locally refines the finite-chain statements in arXiv:1703.09188, lines
+1999--2001 and 2240--2245. -/
 theorem shiftExampleU₃_physicalSwap_eq_swapMatrix_mul_shiftExampleU₂_mul_swapMatrix
     (d : ℕ) (i₁ i₂ j₁ j₂ : Fin d) :
     Matrix.reindex finProdFinEquiv.symm finProdFinEquiv.symm

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7944,12 +7944,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     two virtual factors, defined by
     \begin{align}
         \mathbb S\lvert\alpha_1,\alpha_2\rangle
-          & =\lvert\alpha_2,\alpha_1\rangle.
+         & =\lvert\alpha_2,\alpha_1\rangle.
     \end{align}
     Then
     \begin{align}
         [U_3]^{(i_2,i_1),(j_2,j_1)}
-          & =\mathbb S[U_2]^{(i_1,i_2),(j_1,j_2)}\mathbb S.
+         & =\mathbb S[U_2]^{(i_1,i_2),(j_1,j_2)}\mathbb S.
     \end{align}
     Thus exchanging the two physical species exchanges the local tensors
     $U_2$ and $U_3$, with the same exchange on their virtual factors.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7933,6 +7933,35 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1988--1995.
 \end{definition}
 
+\begin{theorem}[Local physical-species swap for the shift MPUs]
+    \label{thm:threeMPU_local_physical_swap}
+    \lean{MPOTensor.shiftExampleU₃_physicalSwap_eq_swapMatrix_mul_shiftExampleU₂_mul_swapMatrix}
+    \leanok
+    \uses{threeMPU}
+    Write $[U_a]^{(i_1,i_2),(j_1,j_2)}$ for the virtual matrix of the
+    one-site tensor $U_a$ with physical bra coordinate $(i_1,i_2)$ and ket
+    coordinate $(j_1,j_2)$. If $\mathbb S(\alpha_1,\alpha_2)
+        =(\alpha_2,\alpha_1)$ is the SWAP matrix on the two virtual factors,
+    then
+    \begin{align}
+        [U_3]^{(i_2,i_1),(j_2,j_1)}
+          =\mathbb S[U_2]^{(i_1,i_2),(j_1,j_2)}\mathbb S.
+    \end{align}
+    Thus exchanging the two physical species exchanges the local tensors
+    $U_2$ and $U_3$, with the same exchange on their virtual factors.
+    % Source lines: paper_v2.tex 1999--2001 and 2238--2245.
+\end{theorem}
+
+\begin{proof}\leanok
+    In virtual coordinates $(\alpha_1,\alpha_2)$ and
+    $(\beta_1,\beta_2)$, multiplication by $\mathbb S$ on both sides selects
+    the entry with row $(\alpha_2,\alpha_1)$ and column
+    $(\beta_2,\beta_1)$. The left-hand side is therefore the right-shift
+    entry for the second physical species times the left-shift entry for the
+    first. The corresponding $U_2$ entry contains the same two scalar factors
+    in the opposite order, so the equality follows from commutativity.
+\end{proof}
+
 \begin{theorem}[Finite-chain formulas for the three shift MPUs]
     \label{thm:threeMPU_chain_formulas}
     \lean{MPOTensor.mpo_identityMPUTensor}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7962,11 +7962,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     In virtual coordinates $(\alpha_1,\alpha_2)$ and
     $(\beta_1,\beta_2)$, multiplication by $\mathbb S$ on both sides selects
     the entry with row $(\alpha_2,\alpha_1)$ and column
-    $(\beta_2,\beta_1)$. The left-hand side is therefore the right-shift
-    entry for the first physical coordinate $(i_2,j_2)$ times the left-shift
-    entry for the second coordinate $(i_1,j_1)$. The corresponding $U_2$
-    entry contains the same two scalar factors in the opposite order, so the
-    equality follows from commutativity.
+    $(\beta_2,\beta_1)$. Consequently,
+    \begin{align}
+        [U_3]^{(i_2,i_1),(j_2,j_1)}_{(\alpha_1,\alpha_2),(\beta_1,\beta_2)}
+         & =T^{i_2j_2}_{\alpha_1\beta_1}
+        (T^\dagger)^{i_1j_1}_{\alpha_2\beta_2}                                   \\
+         & =(T^\dagger)^{i_1j_1}_{\alpha_2\beta_2}
+        T^{i_2j_2}_{\alpha_1\beta_1}                                             \\
+         & =[U_2]^{(i_1,i_2),(j_1,j_2)}_{(\alpha_2,\alpha_1),(\beta_2,\beta_1)}.
+    \end{align}
+    This is exactly the entrywise form of conjugation by $\mathbb S$.
 \end{proof}
 
 \begin{theorem}[Finite-chain formulas for the three shift MPUs]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7937,29 +7937,36 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:threeMPU_local_physical_swap}
     \lean{MPOTensor.shiftExampleU₃_physicalSwap_eq_swapMatrix_mul_shiftExampleU₂_mul_swapMatrix}
     \leanok
-    \uses{threeMPU}
+    \uses{threeMPU, def:mpu_shift_tensors, def:mpu_independent_tensor_product}
     Write $[U_a]^{(i_1,i_2),(j_1,j_2)}$ for the virtual matrix of the
-    one-site tensor $U_a$ with physical bra coordinate $(i_1,i_2)$ and ket
-    coordinate $(j_1,j_2)$. If $\mathbb S(\alpha_1,\alpha_2)
-        =(\alpha_2,\alpha_1)$ is the SWAP matrix on the two virtual factors,
-    then
+    one-site tensor $U_a$ with physical output coordinate $(i_1,i_2)$ and
+    input coordinate $(j_1,j_2)$. Let $\mathbb S$ be the SWAP matrix on the
+    two virtual factors, defined by
+    \begin{align}
+        \mathbb S\lvert\alpha_1,\alpha_2\rangle
+          & =\lvert\alpha_2,\alpha_1\rangle.
+    \end{align}
+    Then
     \begin{align}
         [U_3]^{(i_2,i_1),(j_2,j_1)}
-          =\mathbb S[U_2]^{(i_1,i_2),(j_1,j_2)}\mathbb S.
+          & =\mathbb S[U_2]^{(i_1,i_2),(j_1,j_2)}\mathbb S.
     \end{align}
     Thus exchanging the two physical species exchanges the local tensors
     $U_2$ and $U_3$, with the same exchange on their virtual factors.
-    % Source lines: paper_v2.tex 1999--2001 and 2238--2245.
+    % Local refinement of the finite-chain statements at paper_v2.tex
+    % 1999--2001 and 2240--2245.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{threeMPU, def:mpu_shift_tensors, def:mpu_independent_tensor_product}
     In virtual coordinates $(\alpha_1,\alpha_2)$ and
     $(\beta_1,\beta_2)$, multiplication by $\mathbb S$ on both sides selects
     the entry with row $(\alpha_2,\alpha_1)$ and column
     $(\beta_2,\beta_1)$. The left-hand side is therefore the right-shift
-    entry for the second physical species times the left-shift entry for the
-    first. The corresponding $U_2$ entry contains the same two scalar factors
-    in the opposite order, so the equality follows from commutativity.
+    entry for the first physical coordinate $(i_2,j_2)$ times the left-shift
+    entry for the second coordinate $(i_1,j_1)$. The corresponding $U_2$
+    entry contains the same two scalar factors in the opposite order, so the
+    equality follows from commutativity.
 \end{proof}
 
 \begin{theorem}[Finite-chain formulas for the three shift MPUs]


### PR DESCRIPTION
## What changed

- add the source-facing one-site identity exchanging the physical species of `shiftExampleU₂ d` and `shiftExampleU₃ d`
- expose every physical and virtual pair through `finProdFinEquiv`, with the swapped physical order `(i₂, i₁)`, `(j₂, j₁)` explicit
- evaluate virtual conjugation using QICLean's `Matrix.swapMatrix_apply`
- add the generated examples aggregator import and synchronized Blueprint theorem/proof coverage

The result is local: it proves
\[
[U_3]^{(i_2,i_1),(j_2,j_1)} = \mathbb S [U_2]^{(i_1,i_2),(j_1,j_2)} \mathbb S,
\]
as a local refinement of the finite-chain statements in `Papers/1703.09188/paper_v2.tex` lines 1999--2001 and 2240--2245. It does not claim a new finite-chain conjugation theorem.

## Validation

- `python3 scripts/generate_import_aggregators.py --root . --check`
- `lake build TNLean.MPS.MPU.Examples.ShiftSwap` (9090/9090)
- `lake build TNLean.MPS.MPU.Examples` (9101/9101)
- no `sorry`, `admit`, or `axiom` in the new module
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (7018/7018 theorem-like entries, 100%)

Full build is left to hosted CI as requested.

Closes #7466

