### PR TITLE
fix(MPS/MPU): prove the literal three-swap permutation

### DIFF
--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -17,5 +17,6 @@ import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
 import TNLean.MPS.MPU.Examples.ShiftSwap
 import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
+import TNLean.MPS.MPU.Examples.ShiftSymmetryPaths
 import TNLean.MPS.MPU.Examples.ShiftTilde
 import TNLean.MPS.MPU.Examples.SwapPath

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -37,58 +37,66 @@ def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
   right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
 
-/-- The crossed swap of species $1$ with the neighboring ancilla in Figure
-`fig:TR-ancilla`. The ancilla entering the first output is shifted by
-`rotateConfig` inverse, while the first species entering the ancilla output is
-shifted by `rotateConfig`. -/
+/-- The crossed swap $S^{1,a}_{n,n+1}$ in Figure `fig:TR-ancilla`.
+Since `rotateConfig N d σ` evaluates to `σ` at the next site, the first output
+receives the next-site ancilla and the ancilla output receives the previous-site
+first species. -/
 def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   toFun σ :=
-    (((rotateConfig N d).symm σ.2, σ.1.2), (rotateConfig N d) σ.1.1)
+    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
   invFun σ :=
-    (((rotateConfig N d).symm σ.2, σ.1.2), (rotateConfig N d) σ.1.1)
+    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
   left_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁), σ₂),
-        (rotateConfig N d) ((rotateConfig N d).symm a))) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
+        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
   right_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁), σ₂),
-        (rotateConfig N d) ((rotateConfig N d).symm a))) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
+        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
 
-/-- The three swap layers shown below the $\tilde U_1$ endpoint in Figure
-`fig:TR-ancilla`: first $S^{2,a}_{n,n}$, then $S^{1,2}_{n,n}$, and finally
-$S^{1,a}_{n,n+1}$. -/
+/-- Coordinate action of the source gate $S^{1,a}_{n,n+1}$ in Figure
+`fig:TR-ancilla`. -/
+@[simp] theorem shiftAncillaSwap₁aNext_apply (N d : ℕ)
+    (σ₁ σ₂ a : Fin N → Fin d) :
+    shiftAncillaSwap₁aNext N d ((σ₁, σ₂), a) =
+      (((rotateConfig N d) a, σ₂), (rotateConfig N d).symm σ₁) := by
+  rfl
+
+/-- The three swap layers shown above the $\tilde U_1$ endpoint in Figure
+`fig:TR-ancilla`, read from the endpoint outwards: first $S^{1,a}_{n,n+1}$,
+then $S^{1,2}_{n,n}$, and finally $S^{2,a}_{n,n}$. -/
 def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
-  ((shiftAncillaSwap₂a N d).trans (shiftAncillaSwap₁₂ N d)).trans
-    (shiftAncillaSwap₁aNext N d)
+  ((shiftAncillaSwap₁aNext N d).trans (shiftAncillaSwap₁₂ N d)).trans
+    (shiftAncillaSwap₂a N d)
 
 /-- The ancilla-enlarged endpoint $\tilde U_2$: the two physical species shift
 in opposite directions and the identity ancilla is fixed. -/
 def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   toFun σ :=
-    ((((rotateConfig N d).symm σ.1.2), (rotateConfig N d) σ.1.1), σ.2)
+    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
   invFun σ :=
-    ((((rotateConfig N d).symm σ.1.2), (rotateConfig N d) σ.1.1), σ.2)
+    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
   left_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁),
-        (rotateConfig N d) ((rotateConfig N d).symm σ₂)), a)) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
+        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
   right_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁),
-        (rotateConfig N d) ((rotateConfig N d).symm σ₂)), a)) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
+        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
 
 /-- Exact coordinate identity behind the three-swap ancilla construction.
 Conjugating the sitewise physical swap by the three displayed swap layers sends
-$((σ_1,σ_2),a)$ to $((R^{-1}σ_2,Rσ_1),a)$, where $R$ is the cyclic rotation.
+$((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/
@@ -96,7 +104,7 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
     (σ₁ σ₂ a : Fin N → Fin d) :
     (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
         (shiftAncillaThreeSwap N d).symm) ((σ₁, σ₂), a) =
-      ((((rotateConfig N d).symm σ₂), (rotateConfig N d) σ₁), a) := by
+      ((((rotateConfig N d) σ₂), (rotateConfig N d).symm σ₁), a) := by
   have rotate_symm_comp (σ : Fin N → Fin d) :
       (rotateConfig N d).symm (σ ∘ finRotate N) = σ := by
     change (rotateConfig N d).symm ((rotateConfig N d) σ) = σ

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -11,15 +11,16 @@ import TNLean.MPS.MPDO.AreaLaw
 
 The proof of arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
 (lines 2217--2229), conjugates the swap endpoint by three layers of swaps after
-adjoining one identity ancilla of dimension $d$. With the finite-chain shift
-convention used here, the literal labels in Figure `fig:TR-ancilla` produce the
-$\tilde U_3$ coordinate endpoint, not $\tilde U_2$.
+adjoining one identity ancilla of dimension $d$. The literal labels in Figure
+`fig:TR-ancilla` produce the coordinate map
+$((σ_1,σ_2),a)\mapsto((Rσ_2,R^{-1}σ_1),a)$.
 
-**Local fix.** Reversing the crossed species--ancilla swap gives the intended
-$\tilde U_2$ endpoint. The printed-orientation error and correction are recorded
-in `docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex`. This module keeps
-the literal labels and records only their finite permutation identity. It does
-not construct a path or an action on the full enlarged operator algebra.
+**Local fix.** The relation between this map and the paper's named MPU endpoints,
+together with the reversed crossed swap, is recorded in
+`docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex`. This module proves only
+the finite permutation identity. It does not identify the permutation matrix
+with an ancilla-enlarged MPO, construct a path, or define an action on the full
+enlarged operator algebra.
 -/
 
 namespace MPOTensor
@@ -71,9 +72,8 @@ def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   ((shiftAncillaSwap₁aNext N d).trans (shiftAncillaSwap₁₂ N d)).trans
     (shiftAncillaSwap₂a N d)
 
-/-- The ancilla-enlarged $\tilde U_3$ endpoint produced by the literal figure
-labels: the two physical species shift in opposite directions and the identity
-ancilla is fixed. -/
+/-- The counter-shift permutation produced by the literal figure labels: the
+two physical species shift in opposite directions and the ancilla is fixed. -/
 def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   Function.Involutive.toPerm
     (fun σ =>
@@ -88,9 +88,8 @@ def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :
 /-- Exact coordinate identity for the three literal swap labels in Figure
 `fig:TR-ancilla`. Conjugating the sitewise physical swap sends
 $((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
-Under the finite-chain conventions of `mpo_shiftExampleU₂` and
-`mpo_shiftExampleU₃`, this is the $\tilde U_3$ endpoint rather than the
-$\tilde U_2$ endpoint named in the figure.
+The relation between this coordinate permutation and the named MPU endpoints
+requires a separate reindexing theorem and is not asserted here.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/
@@ -106,9 +105,9 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
   simp [shiftAncillaThreeSwap, shiftAncillaSwap₂a, shiftAncillaSwap₁₂,
     shiftAncillaSwap₁aNext, Function.Involutive.toPerm, rotate_symm_comp]
 
-/-- The three-swap conjugation is exactly the ancilla-enlarged $\tilde U_3$
-counter-shift permutation produced by the literal labels in Figure
-`fig:TR-ancilla`, without path or symmetry-action packaging.
+/-- The three-swap conjugation is exactly the counter-shift permutation
+produced by the literal labels in Figure `fig:TR-ancilla`, without MPU,
+path, or symmetry-action packaging.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -13,9 +13,13 @@ The proof of arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
 (lines 2217--2229), conjugates the swap endpoint by three layers of swaps after
 adjoining one identity ancilla of dimension $d$. With the finite-chain shift
 convention used here, the literal labels in Figure `fig:TR-ancilla` produce the
-$\tilde U_3$ coordinate endpoint, not $\tilde U_2$. This module records only
-that finite permutation identity. It does not construct a path or an action on
-the full enlarged operator algebra.
+$\tilde U_3$ coordinate endpoint, not $\tilde U_2$.
+
+**Local fix.** Reversing the crossed species--ancilla swap gives the intended
+$\tilde U_2$ endpoint. The printed-orientation error and correction are recorded
+in `docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex`. This module keeps
+the literal labels and records only their finite permutation identity. It does
+not construct a path or an action on the full enlarged operator algebra.
 -/
 
 namespace MPOTensor
@@ -26,40 +30,31 @@ abbrev ShiftAncillaConfig (N d : ℕ) :=
   ((Fin N → Fin d) × (Fin N → Fin d)) × (Fin N → Fin d)
 
 /-- The sitewise swap of the first and second physical species. -/
-def shiftAncillaSwap₁₂ (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
-  toFun σ := ((σ.1.2, σ.1.1), σ.2)
-  invFun σ := ((σ.1.2, σ.1.1), σ.2)
-  left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
-  right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+def shiftAncillaSwap₁₂ (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
+  Function.Involutive.toPerm (fun σ => ((σ.1.2, σ.1.1), σ.2)) (by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    rfl)
 
 /-- The sitewise swap of the second physical species with the ancilla. -/
-def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
-  toFun σ := ((σ.1.1, σ.2), σ.1.2)
-  invFun σ := ((σ.1.1, σ.2), σ.1.2)
-  left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
-  right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
+  Function.Involutive.toPerm (fun σ => ((σ.1.1, σ.2), σ.1.2)) (by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    rfl)
 
 /-- The crossed swap $S^{1,a}_{n,n+1}$ in Figure `fig:TR-ancilla`.
 Since `rotateConfig N d σ` evaluates to `σ` at the next site, the first output
 receives the next-site ancilla and the ancilla output receives the previous-site
 first species. -/
-def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
-  toFun σ :=
-    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
-  invFun σ :=
-    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
-  left_inv := by
-    rintro ⟨⟨σ₁, σ₂⟩, a⟩
-    change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
-        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
-    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
-  right_inv := by
-    rintro ⟨⟨σ₁, σ₂⟩, a⟩
-    change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
-        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
-    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
+  Function.Involutive.toPerm
+    (fun σ =>
+      (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1))
+    (by
+      rintro ⟨⟨σ₁, σ₂⟩, a⟩
+      change
+        ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
+          (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
+      simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply])
 
 /-- Coordinate action of the source gate $S^{1,a}_{n,n+1}$ in Figure
 `fig:TR-ancilla`. -/
@@ -79,23 +74,16 @@ def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
 /-- The ancilla-enlarged $\tilde U_3$ endpoint produced by the literal figure
 labels: the two physical species shift in opposite directions and the identity
 ancilla is fixed. -/
-def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
-  toFun σ :=
-    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
-  invFun σ :=
-    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
-  left_inv := by
-    rintro ⟨⟨σ₁, σ₂⟩, a⟩
-    change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
-        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
-    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
-  right_inv := by
-    rintro ⟨⟨σ₁, σ₂⟩, a⟩
-    change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
-        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
-    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
+  Function.Involutive.toPerm
+    (fun σ =>
+      ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2))
+    (by
+      rintro ⟨⟨σ₁, σ₂⟩, a⟩
+      change
+        ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
+          (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
+      simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply])
 
 /-- Exact coordinate identity for the three literal swap labels in Figure
 `fig:TR-ancilla`. Conjugating the sitewise physical swap sends
@@ -116,7 +104,7 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
     change (rotateConfig N d).symm ((rotateConfig N d) σ) = σ
     exact (rotateConfig N d).symm_apply_apply σ
   simp [shiftAncillaThreeSwap, shiftAncillaSwap₂a, shiftAncillaSwap₁₂,
-    shiftAncillaSwap₁aNext, rotate_symm_comp]
+    shiftAncillaSwap₁aNext, Function.Involutive.toPerm, rotate_symm_comp]
 
 /-- The three-swap conjugation is exactly the ancilla-enlarged $\tilde U_3$
 counter-shift permutation produced by the literal labels in Figure

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.Examples.Shift
+import Mathlib.LinearAlgebra.Matrix.Permutation
+import TNLean.MPS.MPDO.AreaLaw
 
 /-!
 # The finite three-swap endpoint for the counter-shift MPU

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.MPU.Examples.Shift
 # The finite three-swap endpoint for the counter-shift MPU
 
 The proof of arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
-(lines 2203--2230), conjugates the swap endpoint by three layers of swaps after
+(lines 2217--2229), conjugates the swap endpoint by three layers of swaps after
 adjoining one identity ancilla of dimension $d$. This module records only the
 resulting finite permutation identity. It does not construct a path or an
 action on the full enlarged operator algebra.
@@ -89,7 +89,7 @@ Conjugating the sitewise physical swap by the three displayed swap layers sends
 $((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
-`fig:TR-ancilla` (lines 2203--2230). -/
+`fig:TR-ancilla` (lines 2217--2229). -/
 @[simp] theorem shiftAncillaThreeSwap_conj_swap₁₂_apply (N d : ℕ)
     (σ₁ σ₂ a : Fin N → Fin d) :
     (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
@@ -107,7 +107,7 @@ permutation. This is the finite endpoint equality from Figure
 `fig:TR-ancilla`, without path or symmetry-action packaging.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
-`fig:TR-ancilla` (lines 2203--2230). -/
+`fig:TR-ancilla` (lines 2217--2229). -/
 theorem shiftAncillaThreeSwap_conj_swap₁₂ (N d : ℕ) :
     ((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
         (shiftAncillaThreeSwap N d).symm =
@@ -123,5 +123,22 @@ theorem permMatrix_shiftAncillaThreeSwap_endpoint (N d : ℕ) :
           (shiftAncillaThreeSwap N d).symm) =
       Equiv.Perm.permMatrix ℂ (shiftAncillaCounterShift N d) := by
   rw [shiftAncillaThreeSwap_conj_swap₁₂]
+
+/-- Matrix-conjugation form of the finite endpoint identity.
+
+Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
+`fig:TR-ancilla` (lines 2217--2229). -/
+theorem permMatrix_shiftAncillaThreeSwap_conj_swap₁₂ (N d : ℕ) :
+    Equiv.Perm.permMatrix ℂ (shiftAncillaThreeSwap N d) *
+          Equiv.Perm.permMatrix ℂ (shiftAncillaSwap₁₂ N d) *
+        Equiv.Perm.permMatrix ℂ (shiftAncillaThreeSwap N d).symm =
+      Equiv.Perm.permMatrix ℂ (shiftAncillaCounterShift N d) := by
+  rw [← Matrix.permMatrix_mul, ← Matrix.permMatrix_mul]
+  change
+    Equiv.Perm.permMatrix ℂ
+        (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
+          (shiftAncillaThreeSwap N d).symm) =
+      Equiv.Perm.permMatrix ℂ (shiftAncillaCounterShift N d)
+  exact permMatrix_shiftAncillaThreeSwap_endpoint N d
 
 end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -30,13 +30,19 @@ ancilla on a periodic chain of length $N$. -/
 abbrev ShiftAncillaConfig (N d : ℕ) :=
   ((Fin N → Fin d) × (Fin N → Fin d)) × (Fin N → Fin d)
 
-/-- The sitewise swap of the first and second physical species. -/
+/-- The sitewise swap of the first and second physical species.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 def shiftAncillaSwap₁₂ (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   Function.Involutive.toPerm (fun σ => ((σ.1.2, σ.1.1), σ.2)) (by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     rfl)
 
-/-- The sitewise swap of the second physical species with the ancilla. -/
+/-- The sitewise swap of the second physical species with the ancilla.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   Function.Involutive.toPerm (fun σ => ((σ.1.1, σ.2), σ.1.2)) (by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
@@ -45,7 +51,10 @@ def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
 /-- The crossed swap $S^{1,a}_{n,n+1}$ in Figure `fig:TR-ancilla`.
 Since `rotateConfig N d σ` evaluates to `σ` at the next site, the first output
 receives the next-site ancilla and the ancilla output receives the previous-site
-first species. -/
+first species.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   Function.Involutive.toPerm
     (fun σ =>
@@ -58,7 +67,10 @@ def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :
       simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply])
 
 /-- Coordinate action of the source gate $S^{1,a}_{n,n+1}$ in Figure
-`fig:TR-ancilla`. -/
+`fig:TR-ancilla`.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 @[simp] theorem shiftAncillaSwap₁aNext_apply (N d : ℕ)
     (σ₁ σ₂ a : Fin N → Fin d) :
     shiftAncillaSwap₁aNext N d ((σ₁, σ₂), a) =
@@ -67,7 +79,10 @@ def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :
 
 /-- The three swap layers shown above the $\tilde U_1$ endpoint in Figure
 `fig:TR-ancilla`, read from the endpoint outwards: first $S^{1,a}_{n,n+1}$,
-then $S^{1,2}_{n,n}$, and finally $S^{2,a}_{n,n}$. -/
+then $S^{1,2}_{n,n}$, and finally $S^{2,a}_{n,n}$.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   ((shiftAncillaSwap₁aNext N d).trans (shiftAncillaSwap₁₂ N d)).trans
     (shiftAncillaSwap₂a N d)

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -37,25 +37,26 @@ def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
   right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
 
-/-- The crossed swap of species $1$ at site $n$ with the ancilla at site $n+1$.
-The first output is shifted by `rotateConfig`; the returned first species is
-shifted oppositely into the ancilla coordinate. -/
+/-- The crossed swap of species $1$ with the neighboring ancilla in Figure
+`fig:TR-ancilla`. The ancilla entering the first output is shifted by
+`rotateConfig` inverse, while the first species entering the ancilla output is
+shifted by `rotateConfig`. -/
 def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   toFun σ :=
-    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
+    (((rotateConfig N d).symm σ.2, σ.1.2), (rotateConfig N d) σ.1.1)
   invFun σ :=
-    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
+    (((rotateConfig N d).symm σ.2, σ.1.2), (rotateConfig N d) σ.1.1)
   left_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
-        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁), σ₂),
+        (rotateConfig N d) ((rotateConfig N d).symm a))) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
   right_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
-        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁), σ₂),
+        (rotateConfig N d) ((rotateConfig N d).symm a))) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
 
 /-- The three swap layers shown below the $\tilde U_1$ endpoint in Figure
@@ -69,25 +70,25 @@ def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
 in opposite directions and the identity ancilla is fixed. -/
 def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   toFun σ :=
-    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
+    ((((rotateConfig N d).symm σ.1.2), (rotateConfig N d) σ.1.1), σ.2)
   invFun σ :=
-    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
+    ((((rotateConfig N d).symm σ.1.2), (rotateConfig N d) σ.1.1), σ.2)
   left_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
-        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁),
+        (rotateConfig N d) ((rotateConfig N d).symm σ₂)), a)) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
   right_inv := by
     rintro ⟨⟨σ₁, σ₂⟩, a⟩
     change
-      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
-        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
+      ((((rotateConfig N d).symm ((rotateConfig N d) σ₁),
+        (rotateConfig N d) ((rotateConfig N d).symm σ₂)), a)) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
 
 /-- Exact coordinate identity behind the three-swap ancilla construction.
 Conjugating the sitewise physical swap by the three displayed swap layers sends
-$((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
+$((σ_1,σ_2),a)$ to $((R^{-1}σ_2,Rσ_1),a)$, where $R$ is the cyclic rotation.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/
@@ -95,11 +96,11 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
     (σ₁ σ₂ a : Fin N → Fin d) :
     (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
         (shiftAncillaThreeSwap N d).symm) ((σ₁, σ₂), a) =
-      ((((rotateConfig N d) σ₂), (rotateConfig N d).symm σ₁), a) := by
+      ((((rotateConfig N d).symm σ₂), (rotateConfig N d) σ₁), a) := by
   have rotate_symm_comp (σ : Fin N → Fin d) :
-      (rotateConfig N d).symm σ ∘ finRotate N = σ := by
-    change (rotateConfig N d) ((rotateConfig N d).symm σ) = σ
-    exact (rotateConfig N d).apply_symm_apply σ
+      (rotateConfig N d).symm (σ ∘ finRotate N) = σ := by
+    change (rotateConfig N d).symm ((rotateConfig N d) σ) = σ
+    exact (rotateConfig N d).symm_apply_apply σ
   simp [shiftAncillaThreeSwap, shiftAncillaSwap₂a, shiftAncillaSwap₁₂,
     shiftAncillaSwap₁aNext, rotate_symm_comp]
 

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -88,7 +88,10 @@ def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
     (shiftAncillaSwap₂a N d)
 
 /-- The counter-shift permutation produced by the literal figure labels: the
-two physical species shift in opposite directions and the ancilla is fixed. -/
+two physical species shift in opposite directions and the ancilla is fixed.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   Function.Involutive.toPerm
     (fun σ =>
@@ -134,7 +137,10 @@ theorem shiftAncillaThreeSwap_conj_swap₁₂ (N d : ℕ) :
   rintro ⟨⟨σ₁, σ₂⟩, a⟩
   exact shiftAncillaThreeSwap_conj_swap₁₂_apply N d σ₁ σ₂ a
 
-/-- Permutation-matrix form of the exact finite three-swap endpoint identity. -/
+/-- Permutation-matrix form of the exact finite three-swap endpoint identity.
+
+Source: arXiv:1703.09188, Figure `fig:TR-ancilla` and Proposition
+`prop:U1-U2-equiv-ancillatrick` (lines 2217--2229). -/
 theorem permMatrix_shiftAncillaThreeSwap_endpoint (N d : ℕ) :
     Equiv.Perm.permMatrix ℂ
         (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -26,7 +26,10 @@ enlarged operator algebra.
 namespace MPOTensor
 
 /-- Configurations of two physical species and one $d$-dimensional identity
-ancilla on a periodic chain of length $N$. -/
+ancilla on a periodic chain of length $N$.
+
+Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
+(lines 2210--2215) and Figure `fig:TR-ancilla` (lines 2217--2229). -/
 abbrev ShiftAncillaConfig (N d : ℕ) :=
   ((Fin N → Fin d) × (Fin N → Fin d)) × (Fin N → Fin d)
 

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -127,8 +127,9 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
     shiftAncillaSwap₁aNext, Function.Involutive.toPerm, rotate_symm_comp]
 
 /-- The three-swap conjugation is exactly the counter-shift permutation
-produced by the literal labels in Figure `fig:TR-ancilla`, without MPU,
-path, or symmetry-action packaging.
+produced by the literal labels in Figure `fig:TR-ancilla`, without asserting an
+identification with an MPU, a continuous path, or a symmetry action on the
+operator algebra.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.Shift
+
+/-!
+# The finite three-swap endpoint for the counter-shift MPU
+
+The proof of arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
+(lines 2203--2230), conjugates the swap endpoint by three layers of swaps after
+adjoining one identity ancilla of dimension $d$. This module records only the
+resulting finite permutation identity. It does not construct a path or an
+action on the full enlarged operator algebra.
+-/
+
+namespace MPOTensor
+
+/-- Configurations of two physical species and one $d$-dimensional identity
+ancilla on a periodic chain of length $N$. -/
+abbrev ShiftAncillaConfig (N d : ℕ) :=
+  ((Fin N → Fin d) × (Fin N → Fin d)) × (Fin N → Fin d)
+
+/-- The sitewise swap of the first and second physical species. -/
+def shiftAncillaSwap₁₂ (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
+  toFun σ := ((σ.1.2, σ.1.1), σ.2)
+  invFun σ := ((σ.1.2, σ.1.1), σ.2)
+  left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+  right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+
+/-- The sitewise swap of the second physical species with the ancilla. -/
+def shiftAncillaSwap₂a (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
+  toFun σ := ((σ.1.1, σ.2), σ.1.2)
+  invFun σ := ((σ.1.1, σ.2), σ.1.2)
+  left_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+  right_inv := by rintro ⟨⟨σ₁, σ₂⟩, a⟩; rfl
+
+/-- The crossed swap of species $1$ at site $n$ with the ancilla at site $n+1$.
+The first output is shifted by `rotateConfig`; the returned first species is
+shifted oppositely into the ancilla coordinate. -/
+def shiftAncillaSwap₁aNext (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
+  toFun σ :=
+    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
+  invFun σ :=
+    (((rotateConfig N d) σ.2, σ.1.2), (rotateConfig N d).symm σ.1.1)
+  left_inv := by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    change
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
+        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
+    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+  right_inv := by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    change
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁), σ₂),
+        (rotateConfig N d).symm ((rotateConfig N d) a))) = ((σ₁, σ₂), a)
+    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+
+/-- The three swap layers shown below the $\tilde U_1$ endpoint in Figure
+`fig:TR-ancilla`: first $S^{2,a}_{n,n}$, then $S^{1,2}_{n,n}$, and finally
+$S^{1,a}_{n,n+1}$. -/
+def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
+  ((shiftAncillaSwap₂a N d).trans (shiftAncillaSwap₁₂ N d)).trans
+    (shiftAncillaSwap₁aNext N d)
+
+/-- The ancilla-enlarged endpoint $\tilde U_2$: the two physical species shift
+in opposite directions and the identity ancilla is fixed. -/
+def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
+  toFun σ :=
+    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
+  invFun σ :=
+    ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
+  left_inv := by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    change
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
+        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
+    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+  right_inv := by
+    rintro ⟨⟨σ₁, σ₂⟩, a⟩
+    change
+      ((((rotateConfig N d) ((rotateConfig N d).symm σ₁),
+        (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
+    simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
+
+/-- Exact coordinate identity behind the three-swap ancilla construction.
+Conjugating the sitewise physical swap by the three displayed swap layers sends
+$((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
+
+Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
+`fig:TR-ancilla` (lines 2203--2230). -/
+@[simp] theorem shiftAncillaThreeSwap_conj_swap₁₂_apply (N d : ℕ)
+    (σ₁ σ₂ a : Fin N → Fin d) :
+    (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
+        (shiftAncillaThreeSwap N d).symm) ((σ₁, σ₂), a) =
+      ((((rotateConfig N d) σ₂), (rotateConfig N d).symm σ₁), a) := by
+  have rotate_symm_comp (σ : Fin N → Fin d) :
+      (rotateConfig N d).symm σ ∘ finRotate N = σ := by
+    change (rotateConfig N d) ((rotateConfig N d).symm σ) = σ
+    exact (rotateConfig N d).apply_symm_apply σ
+  simp [shiftAncillaThreeSwap, shiftAncillaSwap₂a, shiftAncillaSwap₁₂,
+    shiftAncillaSwap₁aNext, rotate_symm_comp]
+
+/-- The three-swap conjugation is exactly the ancilla-enlarged counter-shift
+permutation. This is the finite endpoint equality from Figure
+`fig:TR-ancilla`, without path or symmetry-action packaging.
+
+Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
+`fig:TR-ancilla` (lines 2203--2230). -/
+theorem shiftAncillaThreeSwap_conj_swap₁₂ (N d : ℕ) :
+    ((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
+        (shiftAncillaThreeSwap N d).symm =
+      shiftAncillaCounterShift N d := by
+  apply Equiv.ext
+  rintro ⟨⟨σ₁, σ₂⟩, a⟩
+  exact shiftAncillaThreeSwap_conj_swap₁₂_apply N d σ₁ σ₂ a
+
+/-- Permutation-matrix form of the exact finite three-swap endpoint identity. -/
+theorem permMatrix_shiftAncillaThreeSwap_endpoint (N d : ℕ) :
+    Equiv.Perm.permMatrix ℂ
+        (((shiftAncillaThreeSwap N d).trans (shiftAncillaSwap₁₂ N d)).trans
+          (shiftAncillaThreeSwap N d).symm) =
+      Equiv.Perm.permMatrix ℂ (shiftAncillaCounterShift N d) := by
+  rw [shiftAncillaThreeSwap_conj_swap₁₂]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSymmetryPaths.lean
@@ -7,13 +7,15 @@ import Mathlib.LinearAlgebra.Matrix.Permutation
 import TNLean.MPS.MPDO.AreaLaw
 
 /-!
-# The finite three-swap endpoint for the counter-shift MPU
+# The finite endpoint of the literal three-swap circuit
 
 The proof of arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick`
 (lines 2217--2229), conjugates the swap endpoint by three layers of swaps after
-adjoining one identity ancilla of dimension $d$. This module records only the
-resulting finite permutation identity. It does not construct a path or an
-action on the full enlarged operator algebra.
+adjoining one identity ancilla of dimension $d$. With the finite-chain shift
+convention used here, the literal labels in Figure `fig:TR-ancilla` produce the
+$\tilde U_3$ coordinate endpoint, not $\tilde U_2$. This module records only
+that finite permutation identity. It does not construct a path or an action on
+the full enlarged operator algebra.
 -/
 
 namespace MPOTensor
@@ -74,8 +76,9 @@ def shiftAncillaThreeSwap (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) :=
   ((shiftAncillaSwap₁aNext N d).trans (shiftAncillaSwap₁₂ N d)).trans
     (shiftAncillaSwap₂a N d)
 
-/-- The ancilla-enlarged endpoint $\tilde U_2$: the two physical species shift
-in opposite directions and the identity ancilla is fixed. -/
+/-- The ancilla-enlarged $\tilde U_3$ endpoint produced by the literal figure
+labels: the two physical species shift in opposite directions and the identity
+ancilla is fixed. -/
 def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) where
   toFun σ :=
     ((((rotateConfig N d) σ.1.2), (rotateConfig N d).symm σ.1.1), σ.2)
@@ -94,9 +97,12 @@ def shiftAncillaCounterShift (N d : ℕ) : Equiv.Perm (ShiftAncillaConfig N d) w
         (rotateConfig N d).symm ((rotateConfig N d) σ₂)), a)) = ((σ₁, σ₂), a)
     simp only [Equiv.apply_symm_apply, Equiv.symm_apply_apply]
 
-/-- Exact coordinate identity behind the three-swap ancilla construction.
-Conjugating the sitewise physical swap by the three displayed swap layers sends
+/-- Exact coordinate identity for the three literal swap labels in Figure
+`fig:TR-ancilla`. Conjugating the sitewise physical swap sends
 $((σ_1,σ_2),a)$ to $((Rσ_2,R^{-1}σ_1),a)$, where $R$ is the cyclic rotation.
+Under the finite-chain conventions of `mpo_shiftExampleU₂` and
+`mpo_shiftExampleU₃`, this is the $\tilde U_3$ endpoint rather than the
+$\tilde U_2$ endpoint named in the figure.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
 `fig:TR-ancilla` (lines 2217--2229). -/
@@ -112,8 +118,8 @@ Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure
   simp [shiftAncillaThreeSwap, shiftAncillaSwap₂a, shiftAncillaSwap₁₂,
     shiftAncillaSwap₁aNext, rotate_symm_comp]
 
-/-- The three-swap conjugation is exactly the ancilla-enlarged counter-shift
-permutation. This is the finite endpoint equality from Figure
+/-- The three-swap conjugation is exactly the ancilla-enlarged $\tilde U_3$
+counter-shift permutation produced by the literal labels in Figure
 `fig:TR-ancilla`, without path or symmetry-action packaging.
 
 Source: arXiv:1703.09188, Proposition `prop:U1-U2-equiv-ancillatrick` and Figure

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8727,56 +8727,119 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2158--2200.
 \end{proposition}
 
-\begin{lemma}[Literal three-swap permutation identity]
-    \label{lem:mpu_shift_ancilla_three_swap_endpoint}
-    \lean{MPOTensor.shiftAncillaSwap₁₂,
-        MPOTensor.shiftAncillaSwap₂a,
-        MPOTensor.shiftAncillaSwap₁aNext,
-        MPOTensor.shiftAncillaSwap₁aNext_apply,
-        MPOTensor.shiftAncillaThreeSwap,
-        MPOTensor.shiftAncillaCounterShift,
+\begin{definition}[Two-species ancilla configurations]
+    \label{def:mpu_shift_ancilla_config}
+    \lean{MPOTensor.ShiftAncillaConfig}
+    \leanok
+    \discussion{7470}
+    For a periodic chain of length $N$, the configuration space consists of
+    triples $((\sigma_1,\sigma_2),a)$ of two physical configurations and one
+    $d$-dimensional ancilla configuration.
+\end{definition}
+
+\begin{definition}[Sitewise physical swap]
+    \label{def:mpu_shift_ancilla_swap_12}
+    \lean{MPOTensor.shiftAncillaSwap₁₂}
+    \leanok
+    \discussion{7470}
+    \uses{def:mpu_shift_ancilla_config}
+    The sitewise physical swap is
+    \begin{align}
+        S^{1,2}((\sigma_1,\sigma_2),a)
+         & =((\sigma_2,\sigma_1),a).
+    \end{align}
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{definition}
+
+\begin{definition}[Sitewise second-species--ancilla swap]
+    \label{def:mpu_shift_ancilla_swap_2a}
+    \lean{MPOTensor.shiftAncillaSwap₂a}
+    \leanok
+    \discussion{7470}
+    \uses{def:mpu_shift_ancilla_config}
+    The sitewise swap of the second species with the ancilla is
+    \begin{align}
+        S^{2,a}((\sigma_1,\sigma_2),a)
+         & =((\sigma_1,a),\sigma_2).
+    \end{align}
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{definition}
+
+\begin{definition}[Crossed first-species--ancilla swap]
+    \label{def:mpu_shift_ancilla_swap_1a_next}
+    \lean{MPOTensor.shiftAncillaSwap₁aNext,
+        MPOTensor.shiftAncillaSwap₁aNext_apply}
+    \leanok
+    \discussion{7470}
+    \uses{def:mpu_shift_ancilla_config, def:mpo_rotate_config}
+    Let $R$ cyclically rotate configurations on the chain. The crossed swap is
+    \begin{align}
+        S^{1,a}_{+}((\sigma_1,\sigma_2),a)
+         & =((Ra,\sigma_2),R^{-1}\sigma_1).
+    \end{align}
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{definition}
+
+\begin{definition}[Literal three-swap circuit]
+    \label{def:mpu_shift_ancilla_three_swap}
+    \lean{MPOTensor.shiftAncillaThreeSwap}
+    \leanok
+    \discussion{7470}
+    \uses{def:mpu_shift_ancilla_swap_12,
+        def:mpu_shift_ancilla_swap_2a,
+        def:mpu_shift_ancilla_swap_1a_next}
+    Let $C$ be the permutation obtained by applying $S^{1,a}_{+}$ first, then
+    $S^{1,2}$, and finally $S^{2,a}$.
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{definition}
+
+\begin{definition}[Counter-shift permutation]
+    \label{def:mpu_shift_ancilla_counter_shift}
+    \lean{MPOTensor.shiftAncillaCounterShift}
+    \leanok
+    \discussion{7470}
+    \uses{def:mpu_shift_ancilla_config, def:mpo_rotate_config}
+    Define
+    \begin{align}
+        K((\sigma_1,\sigma_2),a)
+         & =((R\sigma_2,R^{-1}\sigma_1),a).
+    \end{align}
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{definition}
+
+\begin{theorem}[Literal three-swap permutation identity]
+    \label{thm:mpu_shift_ancilla_three_swap_endpoint}
+    \lean{MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂,
         MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂_apply,
-        MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂,
         MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint,
         MPOTensor.permMatrix_shiftAncillaThreeSwap_conj_swap₁₂}
     \leanok
     \discussion{7470}
-    \uses{threeMPU2}
-    Let $R$ cyclically rotate configurations on a periodic chain of length $N$.
-    On triples $((\sigma_1,\sigma_2),a)$ of two physical configurations and one
-    $d$-dimensional ancilla configuration, let $C$ apply the swaps above
-    $\widetilde U_1$ from the endpoint outwards: $S^{1,a}_{n,n+1}$,
-    $S^{1,2}_{n,n}$, and $S^{2,a}_{n,n}$. Then
+    \uses{def:mpu_shift_ancilla_swap_12,
+        def:mpu_shift_ancilla_three_swap,
+        def:mpu_shift_ancilla_counter_shift}
+    The literal three-swap circuit satisfies
+    \begin{align}
+        C^{-1}S^{1,2}C & =K.
+    \end{align}
+    Writing $P_f$ for the permutation matrix of $f$, one also has
+    \begin{align}
+        P_C P_{S^{1,2}} P_{C^{-1}} & =P_K.
+    \end{align}
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_shift_ancilla_swap_12,
+        def:mpu_shift_ancilla_three_swap,
+        def:mpu_shift_ancilla_counter_shift}
+    Evaluating the three swaps gives
     \begin{align}
         C^{-1}S^{1,2}C((\sigma_1,\sigma_2),a)
          & =((R\sigma_2,R^{-1}\sigma_1),a).
     \end{align}
-    Let $K((\sigma_1,\sigma_2),a)=((R\sigma_2,R^{-1}\sigma_1),a)$.
-    Writing $P_f$ for the permutation matrix of $f$, the matrix endpoint is
-    \begin{align}
-        P_C P_{S^{1,2}} P_{C^{-1}}
-         & =P_K.
-    \end{align}
-    At the coordinate level, $K$ is the configuration map of
-    $\widetilde U_3$, whereas $\widetilde U_2$ has configuration map
-    $((\sigma_1,\sigma_2),a)\mapsto
-        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal source labels do not
-    produce the claimed $\widetilde U_2$ endpoint on a nondegenerate periodic
-    chain. This finite permutation identity does not identify $P_K$ with an
-    ancilla-enlarged MPU. It also asserts neither a continuous path nor a
-    symmetry action on the full ancilla-enlarged operator algebra.
-    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
-\end{lemma}
-
-\begin{proof}\leanok
-    Each of the three swap layers is an involution. Evaluating them successively
-    before and after $S^{1,2}$ gives
-    \begin{align}
-        ((\sigma_1,\sigma_2),a)
-         & \longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
-    \end{align}
-    Extensionality proves the permutation equality, and applying the
-    permutation-matrix construction proves its matrix form.
+    Extensionality gives the permutation equality. The permutation-matrix
+    identity follows by functoriality.
 \end{proof}
 
 \begin{proposition}[Ancilla equivalence of $U_1$ and $U_2$]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8727,6 +8727,39 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2158--2200.
 \end{proposition}
 
+\begin{lemma}[Finite three-swap ancilla endpoint]
+    \label{lem:mpu_shift_ancilla_three_swap_endpoint}
+    \lean{MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂_apply,
+        MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂,
+        MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint}
+    \leanok
+    \uses{threeMPU2}
+    Let $R$ cyclically rotate configurations on a periodic chain of length $N$.
+    On triples $((\sigma_1,\sigma_2),a)$ of two physical configurations and one
+    $d$-dimensional ancilla configuration, let $C$ apply, in order, the swaps
+    $S^{2,a}_{n,n}$, $S^{1,2}_{n,n}$, and $S^{1,a}_{n,n+1}$ from the
+    source figure. Then
+    \begin{align}
+        C^{-1}S^{1,2}C((\sigma_1,\sigma_2),a)
+            &=((R\sigma_2,R^{-1}\sigma_1),a).
+    \end{align}
+    Hence the corresponding permutation matrices are equal. This is only the
+    finite endpoint identity; it asserts neither a continuous path nor a
+    symmetry action on the full ancilla-enlarged operator algebra.
+    % Source lines: paper_v2.tex 2203--2230.
+\end{lemma}
+
+\begin{proof}\leanok
+    Each of the three swap layers is an involution. Evaluating them successively
+    before and after $S^{1,2}$ gives
+    \begin{align}
+        ((\sigma_1,\sigma_2),a)
+        &\longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
+    \end{align}
+    Extensionality proves the permutation equality, and applying the
+    permutation-matrix construction proves its matrix form.
+\end{proof}
+
 \begin{proposition}[Ancilla equivalence of $U_1$ and $U_2$]
     \label{prop:U1-U2-equiv-ancillatrick}
     \notready

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8757,7 +8757,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         P_C P_{S^{1,2}} P_{C^{-1}}
          & =P_K.
     \end{align}
-    This finite permutation identity does not identify $P_K$ with an
+    At the coordinate level, $K$ is the configuration map of
+    $\widetilde U_3$, whereas $\widetilde U_2$ has configuration map
+    $((\sigma_1,\sigma_2),a)\mapsto
+        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal source labels do not
+    produce the claimed $\widetilde U_2$ endpoint on a nondegenerate periodic
+    chain. This finite permutation identity does not identify $P_K$ with an
     ancilla-enlarged MPU. It also asserts neither a continuous path nor a
     symmetry action on the full ancilla-enlarged operator algebra.
     % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8815,7 +8815,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.permMatrix_shiftAncillaThreeSwap_conj_swap₁₂}
     \leanok
     \discussion{7470}
-    \uses{def:mpu_shift_ancilla_swap_12,
+    \uses{threeMPU2,
+        def:mpu_shift_ancilla_swap_12,
         def:mpu_shift_ancilla_three_swap,
         def:mpu_shift_ancilla_counter_shift}
     The literal three-swap circuit satisfies
@@ -8826,6 +8827,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         P_C P_{S^{1,2}} P_{C^{-1}} & =P_K.
     \end{align}
+    At the coordinate level, $K$ is the configuration map of
+    $\widetilde U_3$, whereas $\widetilde U_2$ has configuration map
+    $((\sigma_1,\sigma_2),a)\mapsto
+        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal source labels do not
+    produce the claimed $\widetilde U_2$ endpoint on a nondegenerate periodic
+    chain. The theorem does not identify $P_K$ with an ancilla-enlarged MPU and
+    asserts neither a continuous path nor a symmetry action on the enlarged
+    operator algebra.
     % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8729,10 +8729,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Finite three-swap ancilla endpoint]
     \label{lem:mpu_shift_ancilla_three_swap_endpoint}
-    \lean{MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂_apply,
+    \lean{MPOTensor.shiftAncillaSwap₁₂,
+        MPOTensor.shiftAncillaSwap₂a,
+        MPOTensor.shiftAncillaSwap₁aNext,
+        MPOTensor.shiftAncillaThreeSwap,
+        MPOTensor.shiftAncillaCounterShift,
+        MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂_apply,
         MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂,
-        MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint}
+        MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint,
+        MPOTensor.permMatrix_shiftAncillaThreeSwap_conj_swap₁₂}
     \leanok
+    \discussion{7470}
     \uses{threeMPU2}
     Let $R$ cyclically rotate configurations on a periodic chain of length $N$.
     On triples $((\sigma_1,\sigma_2),a)$ of two physical configurations and one
@@ -8741,12 +8748,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     source figure. Then
     \begin{align}
         C^{-1}S^{1,2}C((\sigma_1,\sigma_2),a)
-            &=((R\sigma_2,R^{-1}\sigma_1),a).
+         & =((R\sigma_2,R^{-1}\sigma_1),a).
     \end{align}
-    Hence the corresponding permutation matrices are equal. This is only the
-    finite endpoint identity; it asserts neither a continuous path nor a
-    symmetry action on the full ancilla-enlarged operator algebra.
-    % Source lines: paper_v2.tex 2203--2230.
+    Let $K((\sigma_1,\sigma_2),a)=((R\sigma_2,R^{-1}\sigma_1),a)$.
+    Writing $P_f$ for the permutation matrix of $f$, the matrix endpoint is
+    \begin{align}
+        P_C P_{S^{1,2}} P_{C^{-1}}
+         & =P_K.
+    \end{align}
+    This is only the finite endpoint identity; it asserts neither a continuous
+    path nor a symmetry action on the full ancilla-enlarged operator algebra.
+    % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -8754,7 +8766,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     before and after $S^{1,2}$ gives
     \begin{align}
         ((\sigma_1,\sigma_2),a)
-        &\longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
+         & \longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
     \end{align}
     Extensionality proves the permutation equality, and applying the
     permutation-matrix construction proves its matrix form.
@@ -8764,7 +8776,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:U1-U2-equiv-ancillatrick}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lemma:sym-trafo-swap, thm:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2, lem:mpu_shift_ancilla_three_swap_endpoint, lemma:sym-trafo-swap, thm:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
     After adding one ancilla of dimension $d$ per site,
     $\widetilde U_1^{(N)}$ and $\widetilde U_2^{(N)}$ are strictly equivalent
     under both time reversal and transposition.
@@ -8779,7 +8791,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % ancilla-enlarged tensors carry source data and the comparison path is
     % admissible. No preservation under adjoining ancillas is asserted.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{threeMPU2, lem:mpu_admissible_swap_symmetry_equivalence, def:mpu_admissible_strict_symmetry_equivalence, def:mpu_admissible_symmetry_equivalence, def:mpu_reduced_full_support_source_datum, def:mpu_admissible_equivalence_datum}
+    \uses{threeMPU2, lem:mpu_shift_ancilla_three_swap_endpoint, lem:mpu_admissible_swap_symmetry_equivalence, def:mpu_admissible_strict_symmetry_equivalence, def:mpu_admissible_symmetry_equivalence, def:mpu_reduced_full_support_source_datum, def:mpu_admissible_equivalence_datum}
     After adding one ancilla of dimension $d$ per site and performing the source
     blocking, denote the actual enlarged blocked endpoints by
     $\widehat{\mathcal U}_1$ and $\widehat{\mathcal U}_2$. For either time

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8732,6 +8732,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.shiftAncillaSwap₁₂,
         MPOTensor.shiftAncillaSwap₂a,
         MPOTensor.shiftAncillaSwap₁aNext,
+        MPOTensor.shiftAncillaSwap₁aNext_apply,
         MPOTensor.shiftAncillaThreeSwap,
         MPOTensor.shiftAncillaCounterShift,
         MPOTensor.shiftAncillaThreeSwap_conj_swap₁₂_apply,
@@ -8743,14 +8744,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{threeMPU2}
     Let $R$ cyclically rotate configurations on a periodic chain of length $N$.
     On triples $((\sigma_1,\sigma_2),a)$ of two physical configurations and one
-    $d$-dimensional ancilla configuration, let $C$ apply, in order, the swaps
-    $S^{2,a}_{n,n}$, $S^{1,2}_{n,n}$, and $S^{1,a}_{n,n+1}$ from the
-    source figure. Then
+    $d$-dimensional ancilla configuration, let $C$ apply the swaps above
+    $\widetilde U_1$ from the endpoint outwards: $S^{1,a}_{n,n+1}$,
+    $S^{1,2}_{n,n}$, and $S^{2,a}_{n,n}$. Then
     \begin{align}
         C^{-1}S^{1,2}C((\sigma_1,\sigma_2),a)
-         & =((R^{-1}\sigma_2,R\sigma_1),a).
+         & =((R\sigma_2,R^{-1}\sigma_1),a).
     \end{align}
-    Let $K((\sigma_1,\sigma_2),a)=((R^{-1}\sigma_2,R\sigma_1),a)$.
+    Let $K((\sigma_1,\sigma_2),a)=((R\sigma_2,R^{-1}\sigma_1),a)$.
     Writing $P_f$ for the permutation matrix of $f$, the matrix endpoint is
     \begin{align}
         P_C P_{S^{1,2}} P_{C^{-1}}
@@ -8766,7 +8767,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     before and after $S^{1,2}$ gives
     \begin{align}
         ((\sigma_1,\sigma_2),a)
-         & \longmapsto ((R^{-1}\sigma_2,R\sigma_1),a).
+         & \longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
     \end{align}
     Extensionality proves the permutation equality, and applying the
     permutation-matrix construction proves its matrix form.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8727,7 +8727,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2158--2200.
 \end{proposition}
 
-\begin{lemma}[Finite three-swap ancilla endpoint]
+\begin{lemma}[Literal three-swap coordinate endpoint]
     \label{lem:mpu_shift_ancilla_three_swap_endpoint}
     \lean{MPOTensor.shiftAncillaSwap₁₂,
         MPOTensor.shiftAncillaSwap₂a,
@@ -8757,8 +8757,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         P_C P_{S^{1,2}} P_{C^{-1}}
          & =P_K.
     \end{align}
-    This is only the finite endpoint identity; it asserts neither a continuous
-    path nor a symmetry action on the full ancilla-enlarged operator algebra.
+    With the shift convention in the finite-chain formulas, $K$ is the
+    configuration permutation for $\widetilde U_3$, whereas the permutation for
+    $\widetilde U_2$ is
+    $((\sigma_1,\sigma_2),a)\mapsto
+        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal labels in
+    Figure~\ref{fig:TR-ancilla} do not prove the stated
+    $\widetilde U_1$--$\widetilde U_2$ endpoint in these conventions. This
+    finite identity asserts neither a continuous path nor a symmetry action on
+    the full ancilla-enlarged operator algebra.
     % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
 \end{lemma}
 
@@ -8777,7 +8784,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:U1-U2-equiv-ancillatrick}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lem:mpu_shift_ancilla_three_swap_endpoint, lemma:sym-trafo-swap, thm:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2,
+        lemma:sym-trafo-swap,
+        thm:mpu-continuous-unitary-swap-path,
+        def:strictly-equivalent-symmetry}
     After adding one ancilla of dimension $d$ per site,
     $\widetilde U_1^{(N)}$ and $\widetilde U_2^{(N)}$ are strictly equivalent
     under both time reversal and transposition.
@@ -8792,7 +8802,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % ancilla-enlarged tensors carry source data and the comparison path is
     % admissible. No preservation under adjoining ancillas is asserted.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{threeMPU2, lem:mpu_shift_ancilla_three_swap_endpoint, lem:mpu_admissible_swap_symmetry_equivalence, def:mpu_admissible_strict_symmetry_equivalence, def:mpu_admissible_symmetry_equivalence, def:mpu_reduced_full_support_source_datum, def:mpu_admissible_equivalence_datum}
+    \uses{threeMPU2,
+        lem:mpu_admissible_swap_symmetry_equivalence,
+        def:mpu_admissible_strict_symmetry_equivalence,
+        def:mpu_admissible_symmetry_equivalence,
+        def:mpu_reduced_full_support_source_datum,
+        def:mpu_admissible_equivalence_datum}
     After adding one ancilla of dimension $d$ per site and performing the source
     blocking, denote the actual enlarged blocked endpoints by
     $\widehat{\mathcal U}_1$ and $\widehat{\mathcal U}_2$. For either time

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8748,9 +8748,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     source figure. Then
     \begin{align}
         C^{-1}S^{1,2}C((\sigma_1,\sigma_2),a)
-         & =((R\sigma_2,R^{-1}\sigma_1),a).
+         & =((R^{-1}\sigma_2,R\sigma_1),a).
     \end{align}
-    Let $K((\sigma_1,\sigma_2),a)=((R\sigma_2,R^{-1}\sigma_1),a)$.
+    Let $K((\sigma_1,\sigma_2),a)=((R^{-1}\sigma_2,R\sigma_1),a)$.
     Writing $P_f$ for the permutation matrix of $f$, the matrix endpoint is
     \begin{align}
         P_C P_{S^{1,2}} P_{C^{-1}}
@@ -8766,7 +8766,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     before and after $S^{1,2}$ gives
     \begin{align}
         ((\sigma_1,\sigma_2),a)
-         & \longmapsto ((R\sigma_2,R^{-1}\sigma_1),a).
+         & \longmapsto ((R^{-1}\sigma_2,R\sigma_1),a).
     \end{align}
     Extensionality proves the permutation equality, and applying the
     permutation-matrix construction proves its matrix form.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8727,7 +8727,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2158--2200.
 \end{proposition}
 
-\begin{lemma}[Literal three-swap coordinate endpoint]
+\begin{lemma}[Literal three-swap permutation identity]
     \label{lem:mpu_shift_ancilla_three_swap_endpoint}
     \lean{MPOTensor.shiftAncillaSwap₁₂,
         MPOTensor.shiftAncillaSwap₂a,
@@ -8757,15 +8757,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         P_C P_{S^{1,2}} P_{C^{-1}}
          & =P_K.
     \end{align}
-    With the shift convention in the finite-chain formulas, $K$ is the
-    configuration permutation for $\widetilde U_3$, whereas the permutation for
-    $\widetilde U_2$ is
-    $((\sigma_1,\sigma_2),a)\mapsto
-        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal labels in the source
-    figure do not prove the stated
-    $\widetilde U_1$--$\widetilde U_2$ endpoint in these conventions. This
-    finite identity asserts neither a continuous path nor a symmetry action on
-    the full ancilla-enlarged operator algebra.
+    This finite permutation identity does not identify $P_K$ with an
+    ancilla-enlarged MPU. It also asserts neither a continuous path nor a
+    symmetry action on the full ancilla-enlarged operator algebra.
     % Source: paper_v2.tex 2217--2229 and Figure fig:TR-ancilla.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8761,8 +8761,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     configuration permutation for $\widetilde U_3$, whereas the permutation for
     $\widetilde U_2$ is
     $((\sigma_1,\sigma_2),a)\mapsto
-        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal labels in
-    Figure~\ref{fig:TR-ancilla} do not prove the stated
+        ((R^{-1}\sigma_2,R\sigma_1),a)$. Thus the literal labels in the source
+    figure do not prove the stated
     $\widetilde U_1$--$\widetilde U_2$ endpoint in these conventions. This
     finite identity asserts neither a continuous path nor a symmetry action on
     the full ancilla-enlarged operator algebra.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -17,6 +17,10 @@ For the MPU index of arXiv:1703.09188:
   formulas are values of the displayed tensors, while the source states the
   public blocking-independent MPU index. The remaining public construction is
   tracked by issues #7011 and #5856.
+- `mpu_ancilla_three_swap_orientation.tex` records that the literal crossed
+  swap labels in Figure `fig:TR-ancilla` produce the $\widetilde U_3$ endpoint,
+  not the claimed $\widetilde U_2$ endpoint, and that reversing those crossed
+  swaps gives the intended local correction.
 
 For the MPU symmetry-defect gauging paper:
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -18,9 +18,9 @@ For the MPU index of arXiv:1703.09188:
   public blocking-independent MPU index. The remaining public construction is
   tracked by issues #7011 and #5856.
 - `mpu_ancilla_three_swap_orientation.tex` records that the literal crossed
-  swap labels in Figure `fig:TR-ancilla` produce the $\widetilde U_3$ endpoint,
-  not the claimed $\widetilde U_2$ endpoint, and that reversing those crossed
-  swaps gives the intended local correction.
+  swap labels in Figure `fig:TR-ancilla` agree with $\widetilde U_3$ and differ
+  from the claimed $\widetilde U_2$ endpoint when $N\geq3$ and $d\geq2$, and
+  that reversing those crossed swaps gives the intended local correction.
 
 For the MPU symmetry-defect gauging paper:
 

--- a/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
+++ b/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
@@ -78,10 +78,12 @@ the two swap-transformed shifts act by
 Comparison of (\ref{eq:mpu_ancilla_orientation_literal_endpoint}) with
 (\ref{eq:mpu_ancilla_orientation_tilde_u2})--
 (\ref{eq:mpu_ancilla_orientation_tilde_u3}) shows that the literal circuit
-labels produce $\widetilde U_3$, not $\widetilde U_2$. This is a genuine
-nondegenerate distinction: for $N\geq3$ and $d\geq2$, one may choose a
-configuration whose values at the preceding and following sites differ, so
-$R\sigma\neq R^{-1}\sigma$.
+labels always agree with $\widetilde U_3$. For $N\geq3$ and $d\geq2$, they do
+not in general agree with $\widetilde U_2$: one may choose a configuration
+whose values at the preceding and following sites differ, so
+$R\sigma\neq R^{-1}\sigma$. By contrast, $R=R^{-1}$ when $N\leq2$, and the
+configuration space has at most one element when $d\leq1$. The two endpoint
+permutations therefore coincide in these degenerate cases.
 
 \section{Local correction and formal record}
 
@@ -106,9 +108,10 @@ of the crossed labels is a local correction of the diagram; it does not alter
 the proposition's intended endpoint.
 
 The formal coordinate calculation keeps the literal printed labels and proves
-(\ref{eq:mpu_ancilla_orientation_literal_endpoint}). It therefore records the
-result as the $\widetilde U_3$ endpoint and does not use it as a dependency of
-the $\widetilde U_1$--$\widetilde U_2$ path proposition.
+(\ref{eq:mpu_ancilla_orientation_literal_endpoint}). It asserts only this
+permutation identity and does not identify its permutation matrix with either
+ancilla-enlarged MPO or use it as a dependency of the
+$\widetilde U_1$--$\widetilde U_2$ path proposition.
 \footnote{Formal declarations:
     \leanid{MPOTensor.shiftAncillaCounterShift} and
     \leanid{MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint} in
@@ -116,9 +119,10 @@ the $\widetilde U_1$--$\widetilde U_2$ path proposition.
 
 \section{Verdict}
 
-The three swap labels in Figure~\texttt{fig:TR-ancilla} produce
-$\widetilde U_3$ under the shift convention stated in the same paper. The
-figure's claimed $\widetilde U_2$ endpoint is false as printed on
+The three swap labels in Figure~\texttt{fig:TR-ancilla} agree with
+$\widetilde U_3$ under the shift convention stated in the same paper. They
+also agree with $\widetilde U_2$ in the degenerate cases $N\leq2$ or $d\leq1$,
+but the figure's claimed $\widetilde U_2$ endpoint is false as printed on
 nondegenerate periodic chains. Reversing the orientation of the crossed
 species--ancilla swaps gives the intended endpoint, so the discrepancy has a
 resolved local correction.

--- a/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
+++ b/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
@@ -8,7 +8,7 @@
 
 \title{Orientation of the Three-Swap Ancilla Circuit}
 \author{}
-\date{2026-08-31}
+\date{2026-08-30}
 
 \begin{document}
 \maketitle
@@ -65,7 +65,7 @@ Consequently, conjugating the physical swap gives
 The paper defines $T$ by
 $T\lvert n_1,\ldots,n_N\rangle
     =\lvert n_N,n_1,\ldots,n_{N-1}\rangle$. Thus $T$ sends a ket configuration
-$	au$ to $R^{-1}\tau$, and $T^\dagger$ sends it to $R\tau$. It follows that
+$\tau$ to $R^{-1}\tau$, and $T^\dagger$ sends it to $R\tau$. It follows that
 the two swap-transformed shifts act by
 \begin{align}
     \widetilde U_2(x,y,a)

--- a/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
+++ b/docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex
@@ -1,0 +1,129 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Orientation of the Three-Swap Ancilla Circuit}
+\author{}
+\date{2026-08-31}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The printed circuit}
+
+Proposition \texttt{prop:U1-U2-equiv-ancillatrick} of
+Ref.~\cite{Cirac2017MPU} claims that, after adjoining one identity ancilla per
+site, conjugating $\widetilde U_1$ by the three swap layers in
+Figure~\texttt{fig:TR-ancilla} gives $\widetilde U_2$. The layers above
+$\widetilde U_1$, read from the endpoint outwards, are labelled
+$S^{1,a}_{n,n+1}$, $S^{1,2}_{n,n}$, and $S^{2,a}_{n,n}$.
+
+Let $R$ denote cyclic rotation of configurations, with
+$(R\sigma)(n)=\sigma(n+1)$. On triples $(x,y,a)$ of the first species, second
+species, and ancilla configurations, the three literal swap labels act as
+\begin{align}
+    A(x,y,a)
+     & =(Ra,y,R^{-1}x),
+    \label{eq:mpu_ancilla_orientation_crossed_swap}  \\
+    B(x,y,a)
+     & =(y,x,a),
+    \label{eq:mpu_ancilla_orientation_physical_swap} \\
+    D(x,y,a)
+     & =(x,a,y).
+    \label{eq:mpu_ancilla_orientation_ancilla_swap}
+\end{align}
+Here $A$ is the global product of the swaps between species $1$ at site $n$
+and the ancilla at site $n+1$. The first output therefore receives the
+next-site ancilla, while the ancilla output receives the previous-site first
+species.
+
+\section{The orientation mismatch}
+
+Let $C=D\circ B\circ A$ be the stack above $\widetilde U_1$. Direct
+substitution into (\ref{eq:mpu_ancilla_orientation_crossed_swap})--
+(\ref{eq:mpu_ancilla_orientation_ancilla_swap}) gives
+\begin{align}
+    C(x,y,a)
+     & =(y,R^{-1}x,Ra),
+    \label{eq:mpu_ancilla_orientation_stack} \\
+    C^{-1}(x,y,a)
+     & =(Ry,x,R^{-1}a).
+    \label{eq:mpu_ancilla_orientation_stack_inverse}
+\end{align}
+Consequently, conjugating the physical swap gives
+\begin{align}
+    C^{-1}BC(x,y,a)
+     & =(Ry,R^{-1}x,a).
+    \label{eq:mpu_ancilla_orientation_literal_endpoint}
+\end{align}
+
+The paper defines $T$ by
+$T\lvert n_1,\ldots,n_N\rangle
+    =\lvert n_N,n_1,\ldots,n_{N-1}\rangle$. Thus $T$ sends a ket configuration
+$	au$ to $R^{-1}\tau$, and $T^\dagger$ sends it to $R\tau$. It follows that
+the two swap-transformed shifts act by
+\begin{align}
+    \widetilde U_2(x,y,a)
+     & =(R^{-1}y,Rx,a),
+    \label{eq:mpu_ancilla_orientation_tilde_u2} \\
+    \widetilde U_3(x,y,a)
+     & =(Ry,R^{-1}x,a).
+    \label{eq:mpu_ancilla_orientation_tilde_u3}
+\end{align}
+Comparison of (\ref{eq:mpu_ancilla_orientation_literal_endpoint}) with
+(\ref{eq:mpu_ancilla_orientation_tilde_u2})--
+(\ref{eq:mpu_ancilla_orientation_tilde_u3}) shows that the literal circuit
+labels produce $\widetilde U_3$, not $\widetilde U_2$. This is a genuine
+nondegenerate distinction: for $N\geq3$ and $d\geq2$, one may choose a
+configuration whose values at the preceding and following sites differ, so
+$R\sigma\neq R^{-1}\sigma$.
+
+\section{Local correction and formal record}
+
+Reversing the crossed swap replaces $A$ by
+\begin{align}
+    A_{\mathrm{rev}}(x,y,a)
+     & =(R^{-1}a,y,Rx).
+    \label{eq:mpu_ancilla_orientation_reversed_crossed_swap}
+\end{align}
+This is the swap between species $1$ at site $n+1$ and the ancilla at site
+$n$, rather than the literal $S^{1,a}_{n,n+1}$ label. Using
+$A_{\mathrm{rev}}$ in the same three-layer stack changes
+(\ref{eq:mpu_ancilla_orientation_literal_endpoint}) to
+\begin{align}
+    (x,y,a)
+     & \longmapsto(R^{-1}y,Rx,a),
+    \label{eq:mpu_ancilla_orientation_corrected_endpoint}
+\end{align}
+which is the $\widetilde U_2$ endpoint in
+(\ref{eq:mpu_ancilla_orientation_tilde_u2}). Thus reversing the orientation
+of the crossed labels is a local correction of the diagram; it does not alter
+the proposition's intended endpoint.
+
+The formal coordinate calculation keeps the literal printed labels and proves
+(\ref{eq:mpu_ancilla_orientation_literal_endpoint}). It therefore records the
+result as the $\widetilde U_3$ endpoint and does not use it as a dependency of
+the $\widetilde U_1$--$\widetilde U_2$ path proposition.
+\footnote{Formal declarations:
+    \leanid{MPOTensor.shiftAncillaCounterShift} and
+    \leanid{MPOTensor.permMatrix_shiftAncillaThreeSwap_endpoint} in
+    \doclink{TNLean/MPS/MPU/Examples/ShiftSymmetryPaths}.}
+
+\section{Verdict}
+
+The three swap labels in Figure~\texttt{fig:TR-ancilla} produce
+$\widetilde U_3$ under the shift convention stated in the same paper. The
+figure's claimed $\widetilde U_2$ endpoint is false as printed on
+nondegenerate periodic chains. Reversing the orientation of the crossed
+species--ancilla swaps gives the intended endpoint, so the discrepancy has a
+resolved local correction.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## What changed
- define the three finite swap layers literally labeled in arXiv:1703.09188, Figure `fig:TR-ancilla`, on two physical configurations and one identity-ancilla configuration
- prove that their conjugation sends the sitewise swap to the exact coordinate permutation $((\sigma_1,\sigma_2),a) \mapsto ((R\sigma_2,R^{-1}\sigma_1),a)$
- prove both the permutation equality and its permutation-matrix conjugation form
- refactor the four self-inverse maps through `Function.Involutive.toPerm`
- record the source-orientation audit and reversed-crossed-swap correction in `docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex`
- remove the invalid dependency from the two $\widetilde U_1$--$\widetilde U_2$ propositions

The formal theorem is deliberately limited to permutations on `ShiftAncillaConfig`. It does not identify the resulting permutation matrix with an ancilla-enlarged MPO, prove either named MPU endpoint, construct a continuous path, or extend a symmetry action to the full enlarged operator algebra. Those MPU propositions remain `\notready`.

## Validation
- `lake build TNLean.MPS.MPU.Examples.ShiftSymmetryPaths` (3063 jobs)
- `lake build TNLean.MPS.MPU.Examples` (9234 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7111/7111)
- `python3 scripts/paper_gap_leanid_sync.py --root .`
- standalone clean compilation of `docs/paper-gaps/mpu_ancilla_three_swap_orientation.tex`
- pinned `latexindent` byte comparisons for both changed TeX files
- no `sorry`, `axiom`, or `admit` in the new module
- `git diff --check`

Refs #7470

