### PR TITLE
feat(Algebra): project finite-group unitary averages

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -17,6 +17,7 @@ import TNLean.Algebra.EventuallyConstantCycleWeights
 import TNLean.Algebra.FinCyclicInduction
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.FiniteCycleCoboundary
+import TNLean.Algebra.FiniteGroupUnitaryAverage
 import TNLean.Algebra.FinsetSubtypeSum
 import TNLean.Algebra.FixedPointFreeInvolutionSign
 import TNLean.Algebra.GeneralizedCocycle

--- a/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
+++ b/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
@@ -12,7 +12,7 @@ import QICLean.Algebra.OrthogonalProjection
 The normalized average of a finite-group unitary representation is the
 orthogonal projection onto its invariant subspace. This is the matrix-level
 averaging fact used for the local gauge constraints in arXiv:2502.20257,
-lines 459--461 and Eq. `eq:projection`.
+lines 457--461.
 -/
 
 open scoped BigOperators Matrix
@@ -32,19 +32,16 @@ noncomputable def unitaryMatrixRepresentation
 /-- The normalized finite-group average
 $|G|^{-1}\sum_{g \in G}\rho(g)$ of a unitary matrix representation.
 
-This is the local gauge projector of arXiv:2502.20257, lines 459--461. -/
+This is the matrix-level form of the local gauge average in arXiv:2502.20257,
+lines 459--461. -/
 noncomputable def finiteGroupUnitaryAverage
     (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ :=
   (Fintype.card G : ℂ)⁻¹ • ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)
 
 /-- The normalized average of a finite-group unitary matrix representation is
-an orthogonal projection.
-
-This is the single-site projection assertion underlying arXiv:2502.20257,
-lines 459--461 and Eq. `eq:projection`. Idempotence is inherited from the
-standard averaging projection onto representation invariants; self-adjointness
-uses unitarity and reindexes the group sum by inversion. -/
-theorem finiteGroupUnitaryAverage_isOrthogonalProjection
+an orthogonal projection, as asserted for the local gauge operators in
+arXiv:2502.20257, lines 457--461. -/
+theorem isOrthogonalProjection_finiteGroupUnitaryAverage
     (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
     IsOrthogonalProjection (finiteGroupUnitaryAverage ρ) := by
   classical
@@ -65,7 +62,7 @@ theorem finiteGroupUnitaryAverage_isOrthogonalProjection
     simp only [finiteGroupUnitaryAverage, Matrix.conjTranspose_smul,
       Matrix.conjTranspose_sum]
     congr 1
-    · simp
+    · simp only [star_inv₀, star_natCast]
     · calc
         ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)ᴴ =
             ∑ g : G, (ρ g⁻¹ : Matrix (Fin n) (Fin n) ℂ) := by

--- a/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
+++ b/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.RepresentationTheory.Invariants
+import QICLean.Algebra.OrthogonalProjection
+
+/-!
+# Finite-group averages of unitary representations
+
+The normalized average of a finite-group unitary representation is the
+orthogonal projection onto its invariant subspace. This is the matrix-level
+averaging fact used for the local gauge constraints in arXiv:2502.20257,
+lines 459--461 and Eq. `eq:projection`.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean.Algebra
+
+variable {G : Type*} {n : ℕ} [Group G] [Fintype G]
+
+/-- The matrix representation on column vectors associated with a unitary
+matrix representation. -/
+noncomputable def unitaryMatrixRepresentation
+    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
+    Representation ℂ G (Fin n → ℂ) :=
+  Matrix.toLinAlgEquiv'.toMonoidHom.comp
+    ((Matrix.unitaryGroup (Fin n) ℂ).subtype.comp ρ)
+
+/-- The normalized finite-group average
+$|G|^{-1}\sum_{g \in G}\rho(g)$ of a unitary matrix representation.
+
+This is the local gauge projector of arXiv:2502.20257, lines 459--461. -/
+noncomputable def finiteGroupUnitaryAverage
+    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ :=
+  (Fintype.card G : ℂ)⁻¹ • ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)
+
+/-- The normalized average of a finite-group unitary matrix representation is
+an orthogonal projection.
+
+This is the single-site projection assertion underlying arXiv:2502.20257,
+lines 459--461 and Eq. `eq:projection`. Idempotence is inherited from the
+standard averaging projection onto representation invariants; self-adjointness
+uses unitarity and reindexes the group sum by inversion. -/
+theorem finiteGroupUnitaryAverage_isOrthogonalProjection
+    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
+    IsOrthogonalProjection (finiteGroupUnitaryAverage ρ) := by
+  classical
+  let _ : Invertible (Fintype.card G : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  let σ := unitaryMatrixRepresentation ρ
+  have havg :
+      LinearMap.toMatrixAlgEquiv' σ.averageMap = finiteGroupUnitaryAverage ρ := by
+    simp [σ, unitaryMatrixRepresentation, Representation.averageMap,
+      GroupAlgebra.average, finiteGroupUnitaryAverage]
+  apply IsStarProjection.isOrthogonalProjection
+  rw [isStarProjection_iff']
+  constructor
+  · have hidem := (Representation.isProj_averageMap (ρ := σ)).isIdempotentElem.eq
+    rw [← havg]
+    simpa only [map_mul] using congr_arg LinearMap.toMatrixAlgEquiv' hidem
+  · change (finiteGroupUnitaryAverage ρ)ᴴ = finiteGroupUnitaryAverage ρ
+    simp only [finiteGroupUnitaryAverage, Matrix.conjTranspose_smul,
+      Matrix.conjTranspose_sum]
+    congr 1
+    · simp
+    · calc
+        ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)ᴴ =
+            ∑ g : G, (ρ g⁻¹ : Matrix (Fin n) (Fin n) ℂ) := by
+              apply Finset.sum_congr rfl
+              intro g _
+              simp [← Matrix.star_eq_conjTranspose]
+        _ = ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ) := by
+          simpa using Equiv.sum_comp (Equiv.inv G)
+            (fun g : G ↦ (ρ g : Matrix (Fin n) (Fin n) ℂ))
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -7,25 +7,34 @@
     \label{def:mpug_finite_group_unitary_average}
     \lean{TNLean.Algebra.finiteGroupUnitaryAverage}
     \leanok
+    \discussion{7458}
     Let $G$ be a finite group and let $\rho\colon G\to\mathrm U(n)$ be a
     unitary representation. Define
     \begin{align}
         P_\rho & = \frac{1}{|G|}\sum_{g\in G}\rho(g).
     \end{align}
-    This is the local gauge average in
+    For a fixed lattice site $j$, the specialization
+    $\rho(g)=\mathcal G_g^j$ gives the local Gauss-law average $P_j$ in
     \cite[lines~459--461]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
 \begin{theorem}[Finite-group unitary average is an orthogonal projection]
     \label{thm:mpug_finite_group_unitary_average_projection}
-    \lean{TNLean.Algebra.finiteGroupUnitaryAverage_isOrthogonalProjection}
+    \lean{TNLean.Algebra.isOrthogonalProjection_finiteGroupUnitaryAverage}
     \leanok
+    \discussion{7458}
     \uses{def:mpug_finite_group_unitary_average}
     For every finite-dimensional unitary representation $\rho$ of a finite
-    group, $P_\rho$ is an orthogonal projection.
+    group,
+    \begin{align}
+        P_\rho^\dagger & =P_\rho, \\
+        P_\rho^2 & =P_\rho.
+    \end{align}
+    Hence $P_\rho$ is an orthogonal projection.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpug_finite_group_unitary_average}
     The standard averaging operator on a representation is the projection onto
     its invariant subspace, so $P_\rho^2=P_\rho$. Unitarity gives
     $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes $G$,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -35,12 +35,16 @@
 
 \begin{proof}\leanok
     \uses{def:mpug_finite_group_unitary_average}
-    Regard each matrix $\rho(g)$ as the corresponding linear map. The
-    finite-group representation-averaging theorem states that its normalized
-    average is idempotent. Transporting that identity back to matrices gives
+    Regard each matrix $\rho(g)$ as the corresponding linear map and let
+    $e_G=|G|^{-1}\sum_{g\in G}g$ be the normalized group-algebra average. The
+    finite-group representation-averaging theorem used here is the projection
+    identity whose concrete group-algebra calculation is
     \begin{align}
-        P_\rho^2 & =P_\rho.
+        h e_G & =e_G \quad (h\in G),                  &
+        e_G^2 & =\frac{1}{|G|}\sum_{h\in G}h e_G=e_G.
     \end{align}
+    Applying the linear representation and transporting back to matrices gives
+    $P_\rho^2=P_\rho$.
     Unitarity gives $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes
     $G$,
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1,6 +1,42 @@
 \chapter{Finite-Group MPU Representations and Scalar Gauge Data}%
 \label{ch:mpu_gauging}
 
+\section{Finite-group unitary averages}
+
+\begin{definition}[Finite-group unitary average]
+    \label{def:mpug_finite_group_unitary_average}
+    \lean{TNLean.Algebra.finiteGroupUnitaryAverage}
+    \leanok
+    Let $G$ be a finite group and let $\rho\colon G\to\mathrm U(n)$ be a
+    unitary representation. Define
+    \begin{align}
+        P_\rho & = \frac{1}{|G|}\sum_{g\in G}\rho(g).
+    \end{align}
+    This is the local gauge average in
+    \cite[lines~459--461]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Finite-group unitary average is an orthogonal projection]
+    \label{thm:mpug_finite_group_unitary_average_projection}
+    \lean{TNLean.Algebra.finiteGroupUnitaryAverage_isOrthogonalProjection}
+    \leanok
+    \uses{def:mpug_finite_group_unitary_average}
+    For every finite-dimensional unitary representation $\rho$ of a finite
+    group, $P_\rho$ is an orthogonal projection.
+\end{theorem}
+
+\begin{proof}\leanok
+    The standard averaging operator on a representation is the projection onto
+    its invariant subspace, so $P_\rho^2=P_\rho$. Unitarity gives
+    $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes $G$,
+    \begin{align}
+        P_\rho^\dagger
+         & = \frac{1}{|G|}\sum_{g\in G}\rho(g)^\dagger
+          = \frac{1}{|G|}\sum_{g\in G}\rho(g^{-1})
+          = P_\rho.
+    \end{align}
+\end{proof}
+
 \section{Finite-group representations by matrix product unitaries}
 \label{sec:mpug_group_representations}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -28,7 +28,7 @@
     group,
     \begin{align}
         P_\rho^\dagger & =P_\rho, \\
-        P_\rho^2 & =P_\rho.
+        P_\rho^2       & =P_\rho.
     \end{align}
     Hence $P_\rho$ is an orthogonal projection.
 \end{theorem}
@@ -41,8 +41,8 @@
     \begin{align}
         P_\rho^\dagger
          & = \frac{1}{|G|}\sum_{g\in G}\rho(g)^\dagger
-          = \frac{1}{|G|}\sum_{g\in G}\rho(g^{-1})
-          = P_\rho.
+        = \frac{1}{|G|}\sum_{g\in G}\rho(g^{-1})
+        = P_\rho.
     \end{align}
 \end{proof}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -35,9 +35,22 @@
 
 \begin{proof}\leanok
     \uses{def:mpug_finite_group_unitary_average}
-    The standard averaging operator on a representation is the projection onto
-    its invariant subspace, so $P_\rho^2=P_\rho$. Unitarity gives
-    $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes $G$,
+    Left multiplication by any $h\in G$ permutes the group, and hence
+    \begin{align}
+        \rho(h)P_\rho
+         & =\frac{1}{|G|}\sum_{g\in G}\rho(hg)
+        =P_\rho.
+    \end{align}
+    Averaging this identity over $h$ gives
+    \begin{align}
+        P_\rho^2
+         & =\frac{1}{|G|}\sum_{h\in G}\rho(h)P_\rho
+        =\frac{1}{|G|}\sum_{h\in G}P_\rho
+        =P_\rho.
+    \end{align}
+    This is the standard averaging projection onto the invariant subspace.
+    Unitarity gives $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes
+    $G$,
     \begin{align}
         P_\rho^\dagger
          & = \frac{1}{|G|}\sum_{g\in G}\rho(g)^\dagger

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -35,20 +35,12 @@
 
 \begin{proof}\leanok
     \uses{def:mpug_finite_group_unitary_average}
-    Left multiplication by any $h\in G$ permutes the group, and hence
+    Regard each matrix $\rho(g)$ as the corresponding linear map. The
+    finite-group representation-averaging theorem states that its normalized
+    average is idempotent. Transporting that identity back to matrices gives
     \begin{align}
-        \rho(h)P_\rho
-         & =\frac{1}{|G|}\sum_{g\in G}\rho(hg)
-        =P_\rho.
+        P_\rho^2 & =P_\rho.
     \end{align}
-    Averaging this identity over $h$ gives
-    \begin{align}
-        P_\rho^2
-         & =\frac{1}{|G|}\sum_{h\in G}\rho(h)P_\rho
-        =\frac{1}{|G|}\sum_{h\in G}P_\rho
-        =P_\rho.
-    \end{align}
-    This is the standard averaging projection onto the invariant subspace.
     Unitarity gives $\rho(g)^\dagger=\rho(g^{-1})$. Since inversion permutes
     $G$,
     \begin{align}


### PR DESCRIPTION
### Motivation
- Formalize the finite-group averaging step used for local gauge constraints in arXiv:2502.20257.
- Source: `Papers/2502.20257/main.tex`, lines 459--461: `P_j \equiv |G|^{-1} \sum_{g\in G} \mathcal G_g^j`, described there as the projection onto the gauge-invariant subspace.
- Reuse Mathlib's invariant-subspace averaging projector rather than duplicating finite-group invariant theory.

### Description
- Define the linear representation associated with a unitary matrix representation and its normalized matrix average.
- Prove that the average is an `IsOrthogonalProjection`: idempotence comes from `Representation.isProj_averageMap`, while self-adjointness follows from unitarity and reindexing the sum by group inversion.
- Add the generated `TNLean.Algebra` import and synchronized entries in the finite-group MPU gauging blueprint chapter.

### Testing
- `lake build TNLean.Algebra.FiniteGroupUnitaryAverage TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n '\b(sorry|axiom|admit|native_decide|unsafeCast)\b' TNLean/Algebra/FiniteGroupUnitaryAverage.lean` (no matches)
- `git diff --check`

---
Closes #7458
