### PR TITLE
feat(MPU): add continuous unitary factor-swap path

### DIFF
--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -14,3 +14,4 @@ import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
 import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
+import TNLean.MPS.MPU.Examples.SwapPath

--- a/TNLean/MPS/MPU/Examples/SwapPath.lean
+++ b/TNLean/MPS/MPU/Examples/SwapPath.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.MaximallyEntangled
+import Mathlib.Algebra.Star.StarProjection
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.LinearAlgebra.UnitaryGroup
+import Mathlib.Topology.Instances.Matrix
+
+/-!
+# A continuous unitary path to the factor swap
+
+The path used in arXiv:1703.09188, Proposition `prop:U2-U3-trivial-tr-transpose`,
+lines 2143--2155, and Proposition `prop:U1-U2-equiv-ancillatrick`, lines
+2226--2235.
+
+The factor swap acts by `Matrix.swapMatrix d`. We decompose the tensor-square
+space into its symmetric and antisymmetric subspaces and rotate only the
+antisymmetric subspace by the phase `exp (π x I)`.
+-/
+
+open scoped ComplexConjugate Matrix
+
+namespace Matrix
+
+variable (d : ℕ)
+
+/-- The orthogonal projection onto the symmetric subspace of the tensor square. -/
+noncomputable def swapSymmetricProjection :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  (2 : ℂ)⁻¹ • (1 + swapMatrix d)
+
+/-- The orthogonal projection onto the antisymmetric subspace of the tensor square. -/
+noncomputable def swapAntisymmetricProjection :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  1 - swapSymmetricProjection d
+
+/-- The symmetric-subspace projection is self-adjoint and idempotent. -/
+theorem isStarProjection_swapSymmetricProjection :
+    IsStarProjection (swapSymmetricProjection d) := by
+  rw [isStarProjection_iff']
+  constructor
+  · unfold swapSymmetricProjection
+    rw [Matrix.smul_mul, Matrix.mul_smul, add_mul, one_mul, mul_add, mul_one,
+      swapMatrix_mul_self]
+    module
+  · change (swapSymmetricProjection d)ᴴ = swapSymmetricProjection d
+    simp [swapSymmetricProjection, swapMatrix_conjTranspose]
+
+/-- The antisymmetric-subspace projection is self-adjoint and idempotent. -/
+theorem isStarProjection_swapAntisymmetricProjection :
+    IsStarProjection (swapAntisymmetricProjection d) := by
+  exact (isStarProjection_swapSymmetricProjection d).one_sub
+
+/-- The unit complex phase used on the antisymmetric subspace. -/
+noncomputable def swapPhase (x : ℝ) : ℂ :=
+  Complex.exp ((Real.pi * x : ℝ) * Complex.I)
+
+/-- The swap phase times its complex conjugate is one. -/
+@[simp] theorem swapPhase_mul_star (x : ℝ) :
+    swapPhase x * star (swapPhase x) = 1 := by
+  change Complex.exp ((Real.pi * x : ℝ) * Complex.I) *
+    conj (Complex.exp ((Real.pi * x : ℝ) * Complex.I)) = 1
+  rw [Complex.mul_conj, Complex.normSq_eq_norm_sq,
+    Complex.norm_exp_ofReal_mul_I]
+  norm_num
+
+/-- The explicit path from the identity to the factor swap.
+
+It acts as the identity on the symmetric subspace and by `exp (π x I)` on the
+antisymmetric subspace. Source: arXiv:1703.09188, lines 2148--2151 and
+2229--2234. -/
+noncomputable def swapPath (x : ℝ) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  swapSymmetricProjection d + swapPhase x • swapAntisymmetricProjection d
+
+/-- Applying a unit-modulus phase to the complement of a star projection is unitary. -/
+private theorem projection_add_phase_complement_mem_unitaryGroup
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (p : Matrix n n ℂ) (hp : IsStarProjection p) (c : ℂ)
+    (hc : c * star c = 1) :
+    p + c • (1 - p) ∈ unitaryGroup n ℂ := by
+  rw [mem_unitaryGroup_iff]
+  have hq := hp.one_sub
+  have hpH : pᴴ = p := by
+    rw [← Matrix.star_eq_conjTranspose, hp.isSelfAdjoint.star_eq]
+  have hqH : (1 - p)ᴴ = 1 - p := by
+    rw [← Matrix.star_eq_conjTranspose, hq.isSelfAdjoint.star_eq]
+  rw [Matrix.star_eq_conjTranspose, conjTranspose_add, conjTranspose_smul,
+    hpH, hqH]
+  rw [mul_add, add_mul, hp.isIdempotentElem.eq,
+    Matrix.smul_mul, hp.one_sub_mul_self, smul_zero,
+    Matrix.mul_smul, add_mul, hp.mul_one_sub_self,
+    Matrix.smul_mul, hq.isIdempotentElem.eq, zero_add,
+    smul_smul, mul_comm (star c) c, hc, one_smul]
+  simp
+
+/-- Every matrix on the swap path is unitary. -/
+theorem swapPath_mem_unitaryGroup (x : ℝ) :
+    swapPath d x ∈ unitaryGroup (Fin d × Fin d) ℂ := by
+  exact projection_add_phase_complement_mem_unitaryGroup
+    (swapSymmetricProjection d) (isStarProjection_swapSymmetricProjection d)
+    (swapPhase x) (swapPhase_mul_star x)
+
+/-- The path starts at the identity matrix. -/
+@[simp] theorem swapPath_zero : swapPath d 0 = 1 := by
+  simp [swapPath, swapPhase, swapAntisymmetricProjection]
+
+/-- The path ends at the factor-swap matrix. -/
+@[simp] theorem swapPath_one : swapPath d 1 = swapMatrix d := by
+  rw [swapPath, swapPhase, show (Real.pi * (1 : ℝ) : ℝ) = Real.pi by ring,
+    Complex.exp_pi_mul_I]
+  simp only [neg_smul, one_smul, swapAntisymmetricProjection,
+    swapSymmetricProjection]
+  module
+
+/-- The explicit matrix-valued swap path is continuous. -/
+theorem continuous_swapPath : Continuous (swapPath d) := by
+  apply continuous_const.add
+  exact (Complex.continuous_exp.comp
+    ((Complex.continuous_ofReal.comp (continuous_const.mul continuous_id)).mul
+      continuous_const)).smul continuous_const
+
+/-- There is a continuous unitary path from the identity to the factor swap.
+
+This is the operator $\mathbb S(x)$ chosen in arXiv:1703.09188, Proposition
+`prop:U2-U3-trivial-tr-transpose`, lines 2148--2151, and reused in Proposition
+`prop:U1-U2-equiv-ancillatrick`, lines 2229--2234. -/
+theorem exists_continuous_unitary_swapPath :
+    ∃ S : ℝ → Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ,
+      Continuous S ∧ S 0 = 1 ∧ S 1 = swapMatrix d ∧
+        ∀ x : ℝ, S x ∈ unitaryGroup (Fin d × Fin d) ℂ := by
+  exact ⟨swapPath d, continuous_swapPath d, swapPath_zero d,
+    swapPath_one d, swapPath_mem_unitaryGroup d⟩
+
+end Matrix

--- a/TNLean/MPS/MPU/Examples/SwapPath.lean
+++ b/TNLean/MPS/MPU/Examples/SwapPath.lean
@@ -3,22 +3,24 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Channel.MaximallyEntangled
 import Mathlib.Algebra.Star.StarProjection
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.Topology.Instances.Matrix
+import QICLean.Channel.MaximallyEntangled
 
 /-!
 # A continuous unitary path to the factor swap
 
-The path used in arXiv:1703.09188, Proposition `prop:U2-U3-trivial-tr-transpose`,
+arXiv:1703.09188 requires a continuous unitary interpolation from the identity
+matrix to the factor swap in Proposition `prop:U2-U3-trivial-tr-transpose`,
 lines 2143--2155, and Proposition `prop:U1-U2-equiv-ancillatrick`, lines
 2226--2235.
 
-The factor swap acts by `Matrix.swapMatrix d`. We decompose the tensor-square
-space into its symmetric and antisymmetric subspaces and rotate only the
-antisymmetric subspace by the phase `exp (π x I)`.
+The factor swap acts by `Matrix.swapMatrix d`. We give a concrete interpolation
+by decomposing the tensor-square space into its symmetric and antisymmetric
+subspaces and rotating only the antisymmetric subspace by the phase
+`exp (π x I)`.
 -/
 
 open scoped ComplexConjugate Matrix
@@ -59,7 +61,7 @@ noncomputable def swapPhase (x : ℝ) : ℂ :=
   Complex.exp ((Real.pi * x : ℝ) * Complex.I)
 
 /-- The swap phase times its complex conjugate is one. -/
-@[simp] theorem swapPhase_mul_star (x : ℝ) :
+theorem swapPhase_mul_star (x : ℝ) :
     swapPhase x * star (swapPhase x) = 1 := by
   change Complex.exp ((Real.pi * x : ℝ) * Complex.I) *
     conj (Complex.exp ((Real.pi * x : ℝ) * Complex.I)) = 1
@@ -67,11 +69,11 @@ noncomputable def swapPhase (x : ℝ) : ℂ :=
     Complex.norm_exp_ofReal_mul_I]
   norm_num
 
-/-- The explicit path from the identity to the factor swap.
+/-- A concrete path from the identity to the factor swap.
 
 It acts as the identity on the symmetric subspace and by `exp (π x I)` on the
-antisymmetric subspace. Source: arXiv:1703.09188, lines 2148--2151 and
-2229--2234. -/
+antisymmetric subspace. This realizes the interpolation required in
+arXiv:1703.09188, lines 2148--2151 and 2229--2234. -/
 noncomputable def swapPath (x : ℝ) :
     Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
   swapSymmetricProjection d + swapPhase x • swapAntisymmetricProjection d
@@ -95,7 +97,7 @@ private theorem projection_add_phase_complement_mem_unitaryGroup
     Matrix.mul_smul, add_mul, hp.mul_one_sub_self,
     Matrix.smul_mul, hq.isIdempotentElem.eq, zero_add,
     smul_smul, mul_comm (star c) c, hc, one_smul]
-  simp
+  module
 
 /-- Every matrix on the swap path is unitary. -/
 theorem swapPath_mem_unitaryGroup (x : ℝ) :
@@ -125,9 +127,9 @@ theorem continuous_swapPath : Continuous (swapPath d) := by
 
 /-- There is a continuous unitary path from the identity to the factor swap.
 
-This is the operator $\mathbb S(x)$ chosen in arXiv:1703.09188, Proposition
-`prop:U2-U3-trivial-tr-transpose`, lines 2148--2151, and reused in Proposition
-`prop:U1-U2-equiv-ancillatrick`, lines 2229--2234. -/
+This supplies the operator $\mathbb S(x)$ required in arXiv:1703.09188,
+Proposition `prop:U2-U3-trivial-tr-transpose`, lines 2148--2151, and reused in
+Proposition `prop:U1-U2-equiv-ancillatrick`, lines 2229--2234. -/
 theorem exists_continuous_unitary_swapPath :
     ∃ S : ℝ → Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ,
       Continuous S ∧ S 0 = 1 ∧ S 1 = swapMatrix d ∧

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8361,7 +8361,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Continuous unitary path to the factor swap]
     \label{lem:mpu-continuous-unitary-swap-path}
-    \lean{Matrix.exists_continuous_unitary_swapPath}
+    \lean{Matrix.swapSymmetricProjection,
+        Matrix.swapAntisymmetricProjection,
+        Matrix.swapPath,
+        Matrix.exists_continuous_unitary_swapPath}
     \leanok
     Let $\mathbb S$ denote the swap operator on
     $\mathbb C^d\otimes\mathbb C^d$. There is a continuous map
@@ -8369,7 +8372,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \bigl(S(0),S(1)\bigr) & = \bigl(\Id,\mathbb S\bigr).
     \end{align}
-    It is given explicitly by
+    One concrete choice is
     \begin{align}
         S(x) & = P_{\mathrm{sym}} + e^{\mathrm{i}\pi x}P_{\mathrm{anti}},
     \end{align}
@@ -8478,7 +8481,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     After adding one ancilla of dimension $d$ per site,
     $\widetilde U_1^{(N)}$ and $\widetilde U_2^{(N)}$ are strictly equivalent
     under both time reversal and transposition.
-    % Source lines: paper_v2.tex 2203--2230.
+    % Source lines: paper_v2.tex 2203--2235.
 \end{proposition}
 
 \begin{proposition}[Admissible ancilla equivalence of $U_1$ and $U_2$]
@@ -8507,7 +8510,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     tensors is asserted, because the equal ancilla dimensions used here need not
     satisfy the coprimality condition in
     Definition~\ref{def:mpu_admissible_symmetry_equivalence}.
-    % Source lines: paper_v2.tex 2203--2230.
+    % Source lines: paper_v2.tex 2203--2235.
 \end{proposition}
 
 \section{Finite-region observable algebras}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8400,15 +8400,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Hence the two projections satisfy
     \begin{align}
         \bigl(P_{\mathrm{sym}}^2,P_{\mathrm{anti}}^2\bigr)
-            & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
+         & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
     \end{align}
     \begin{align}
         \bigl(P_{\mathrm{sym}}P_{\mathrm{anti}},
-            P_{\mathrm{anti}}P_{\mathrm{sym}}\bigr) & = (0,0),
+        P_{\mathrm{anti}}P_{\mathrm{sym}}\bigr) & = (0,0),
     \end{align}
     \begin{align}
         \bigl(P_{\mathrm{sym}}^\dagger,P_{\mathrm{anti}}^\dagger\bigr)
-            & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
+         & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
     \end{align}
     and
     \begin{align}
@@ -8417,7 +8417,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Since $\lvert e^{\mathrm{i}\pi x}\rvert=1$, these identities imply
     \begin{align}
         S(x)S(x)^\dagger
-            & = P_{\mathrm{sym}}+P_{\mathrm{anti}}=\Id.
+         & = P_{\mathrm{sym}}+P_{\mathrm{anti}}=\Id.
     \end{align}
     Continuity follows from continuity of the exponential, while $e^0=1$ and
     $e^{\mathrm{i}\pi}=-1$ give the endpoint identities.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8359,8 +8359,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2110--2134.
 \end{proposition}
 
-\begin{lemma}[Continuous unitary path to the factor swap]
-    \label{lem:mpu-continuous-unitary-swap-path}
+\begin{theorem}[Continuous unitary path to the factor swap]
+    \label{thm:mpu-continuous-unitary-swap-path}
     \lean{Matrix.swapSymmetricProjection,
         Matrix.swapAntisymmetricProjection,
         Matrix.swapPath,
@@ -8368,7 +8368,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     Let $\mathbb S$ denote the swap operator on
     $\mathbb C^d\otimes\mathbb C^d$. There is a continuous map
-    $S\colon\mathbb R\to U(d^2)$ such that
+    $S\colon\mathbb R\to \mathrm{U}(d^2)$ such that
     \begin{align}
         \bigl(S(0),S(1)\bigr) & = \bigl(\Id,\mathbb S\bigr).
     \end{align}
@@ -8385,22 +8385,49 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         P_{\mathrm{anti}} & = \frac{\Id-\mathbb S}{2}.
     \end{align}
     % Source lines: paper_v2.tex 2148--2151 and 2229--2234.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    Since $\mathbb S$ is a self-adjoint involution, the two displayed
-    operators are complementary orthogonal projections. The phase
-    $e^{\mathrm{i}\pi x}$ has modulus one, so $S(x)$ is unitary for every
-    $x$. Continuity follows from continuity of the exponential, while
-    $e^0=1$ and $e^{\mathrm{i}\pi}=-1$ give the endpoint identities.
+    The swap is a self-adjoint involution:
+    \begin{align}
+        \mathbb S^2 & = \Id,
+    \end{align}
+    and
+    \begin{align}
+        \mathbb S^\dagger & = \mathbb S.
+    \end{align}
+    Hence the two projections satisfy
+    \begin{align}
+        \bigl(P_{\mathrm{sym}}^2,P_{\mathrm{anti}}^2\bigr)
+            & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
+    \end{align}
+    \begin{align}
+        \bigl(P_{\mathrm{sym}}P_{\mathrm{anti}},
+            P_{\mathrm{anti}}P_{\mathrm{sym}}\bigr) & = (0,0),
+    \end{align}
+    \begin{align}
+        \bigl(P_{\mathrm{sym}}^\dagger,P_{\mathrm{anti}}^\dagger\bigr)
+            & = \bigl(P_{\mathrm{sym}},P_{\mathrm{anti}}\bigr),
+    \end{align}
+    and
+    \begin{align}
+        P_{\mathrm{sym}}+P_{\mathrm{anti}} & = \Id.
+    \end{align}
+    Since $\lvert e^{\mathrm{i}\pi x}\rvert=1$, these identities imply
+    \begin{align}
+        S(x)S(x)^\dagger
+            & = P_{\mathrm{sym}}+P_{\mathrm{anti}}=\Id.
+    \end{align}
+    Continuity follows from continuity of the exponential, while $e^0=1$ and
+    $e^{\mathrm{i}\pi}=-1$ give the endpoint identities.
 \end{proof}
 
 \begin{proposition}[Time-reversal and transposition phases of $U_2$ and $U_3$]
     \label{prop:U2-U3-trivial-tr-transpose}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lemma:sym-trafo-swap, lem:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2, lemma:sym-trafo-swap, thm:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
     The MPUs $\widetilde U_2^{(N)}$ and $\widetilde U_3^{(N)}$ are in the same
     phase under both time reversal and transposition.
     % Source lines: paper_v2.tex 2136--2155.
@@ -8477,7 +8504,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:U1-U2-equiv-ancillatrick}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lemma:sym-trafo-swap, lem:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2, lemma:sym-trafo-swap, thm:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
     After adding one ancilla of dimension $d$ per site,
     $\widetilde U_1^{(N)}$ and $\widetilde U_2^{(N)}$ are strictly equivalent
     under both time reversal and transposition.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8359,11 +8359,45 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 2110--2134.
 \end{proposition}
 
+\begin{lemma}[Continuous unitary path to the factor swap]
+    \label{lem:mpu-continuous-unitary-swap-path}
+    \lean{Matrix.exists_continuous_unitary_swapPath}
+    \leanok
+    Let $\mathbb S$ denote the swap operator on
+    $\mathbb C^d\otimes\mathbb C^d$. There is a continuous map
+    $S\colon\mathbb R\to U(d^2)$ such that
+    \begin{align}
+        \bigl(S(0),S(1)\bigr) & = \bigl(\Id,\mathbb S\bigr).
+    \end{align}
+    It is given explicitly by
+    \begin{align}
+        S(x) & = P_{\mathrm{sym}} + e^{\mathrm{i}\pi x}P_{\mathrm{anti}},
+    \end{align}
+    where
+    \begin{align}
+        P_{\mathrm{sym}} & = \frac{\Id+\mathbb S}{2},
+    \end{align}
+    and
+    \begin{align}
+        P_{\mathrm{anti}} & = \frac{\Id-\mathbb S}{2}.
+    \end{align}
+    % Source lines: paper_v2.tex 2148--2151 and 2229--2234.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Since $\mathbb S$ is a self-adjoint involution, the two displayed
+    operators are complementary orthogonal projections. The phase
+    $e^{\mathrm{i}\pi x}$ has modulus one, so $S(x)$ is unitary for every
+    $x$. Continuity follows from continuity of the exponential, while
+    $e^0=1$ and $e^{\mathrm{i}\pi}=-1$ give the endpoint identities.
+\end{proof}
+
 \begin{proposition}[Time-reversal and transposition phases of $U_2$ and $U_3$]
     \label{prop:U2-U3-trivial-tr-transpose}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lemma:sym-trafo-swap, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2, lemma:sym-trafo-swap, lem:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
     The MPUs $\widetilde U_2^{(N)}$ and $\widetilde U_3^{(N)}$ are in the same
     phase under both time reversal and transposition.
     % Source lines: paper_v2.tex 2136--2155.
@@ -8440,7 +8474,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:U1-U2-equiv-ancillatrick}
     \notready
     \discussion{5715}
-    \uses{threeMPU2, lemma:sym-trafo-swap, def:strictly-equivalent-symmetry}
+    \uses{threeMPU2, lemma:sym-trafo-swap, lem:mpu-continuous-unitary-swap-path, def:strictly-equivalent-symmetry}
     After adding one ancilla of dimension $d$ per site,
     $\widetilde U_1^{(N)}$ and $\widetilde U_2^{(N)}$ are strictly equivalent
     under both time reversal and transposition.


### PR DESCRIPTION
## What changed

- define the symmetric and antisymmetric factor-swap projections from QICLean's `Matrix.swapMatrix`
- construct the explicit path
  `swapPath d x = P_sym + exp (π x I) • P_anti`
- prove both projections are self-adjoint idempotents, every path value belongs to `Matrix.unitaryGroup`, continuity on `ℝ`, and the exact identities at `0` and `1`
- package the source statement as `Matrix.exists_continuous_unitary_swapPath`
- add the generated MPU examples import and a source-faithful Blueprint node used by the two swap-interpolation propositions

The construction follows arXiv:1703.09188, lines 2148–2151 and 2229–2234, and does not use general unitary-group connectedness.

## Validation

- `lake build TNLean.MPS.MPU.Examples.SwapPath TNLean.MPS.MPU.Examples` (9101 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7018/7018 entries, in sync)
- `cd blueprint && leanblueprint checkdecls`
- no `sorry`, `axiom`, or `admit` in `SwapPath.lean`
- `#print axioms Matrix.exists_continuous_unitary_swapPath`: only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check HEAD^ HEAD`

A full local build was intentionally not run; hosted CI provides that gate.

Closes #7469
