### PR TITLE
feat(Algebra): formalize twisted regular actions

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -39,6 +39,7 @@ import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.SwapMatrix
+import TNLean.Algebra.TwistedRegularRepresentation
 import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryFactorizationComparison
 import TNLean.Algebra.UnitaryKronecker

--- a/TNLean/Algebra/TwistedRegularRepresentation.lean
+++ b/TNLean/Algebra/TwistedRegularRepresentation.lean
@@ -51,18 +51,16 @@ theorem phase_isCocycle {ω : ScalarCocycle G} (hω : ω.IsCocycle) (g h k : G) 
 omit [Group G] in
 /-- Every coefficient of the canonical circle-valued representative has norm
 one. -/
+@[simp]
 lemma norm_phase (ω : ScalarCocycle G) (g h : G) : ‖ω.phase g h‖ = 1 :=
   Circle.norm_coe _
-
-attribute [simp] norm_phase
 
 omit [Group G] in
 /-- Every coefficient of the canonical circle-valued representative is
 nonzero. -/
+@[simp]
 lemma phase_ne_zero (ω : ScalarCocycle G) (g h : G) : ω.phase g h ≠ 0 := by
   exact norm_ne_zero_iff.mp (by simp)
-
-attribute [simp] phase_ne_zero
 
 /-- The cocycle-twisted left regular matrix
 

--- a/TNLean/Algebra/TwistedRegularRepresentation.lean
+++ b/TNLean/Algebra/TwistedRegularRepresentation.lean
@@ -1,0 +1,312 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.UnitaryGroup
+import TNLean.Algebra.CircleCohomology
+
+/-!
+# Cocycle-twisted regular representations
+
+This file formalizes the left and right regular actions in
+arXiv:2502.20257, equations following `eq:localsyms` and the onsite
+specialization at lines 3758--3766.  For a scalar cocycle `ω`, we use its
+canonical circle-valued representative `ω.circlePhase` and the paper's inverse
+conventions
+
+`Lᵠ_g |h⟩ = ϕ(g,h)⁻¹ |gh⟩`,
+
+`Rᵠ_g |h⟩ = ϕ(h,g⁻¹)⁻¹ |hg⁻¹⟩`.
+
+The extra identity used to rewrite the onsite Gauss coefficient assumes
+`ϕ(g⁻¹,g) = 1` explicitly.  It is not inferred from cocyclicity.
+-/
+
+noncomputable section
+
+namespace TNLean.Algebra
+
+variable {G : Type*} [Group G]
+
+namespace ScalarCocycle
+
+/-- The complex coefficient of the canonical circle-valued representative of
+`ω`. -/
+abbrev phase (ω : ScalarCocycle G) (g h : G) : ℂ :=
+  (ω.circlePhase g h : ℂ)
+
+/-- The circle phase of a scalar cocycle satisfies the complex-valued cocycle
+equation. -/
+theorem phase_isCocycle {ω : ScalarCocycle G} (hω : ω.IsCocycle) (g h k : G) :
+    ω.phase g h * ω.phase (g * h) k =
+      ω.phase g (h * k) * ω.phase h k := by
+  have hc := ω.circlePhase_isMulCocycle₂ hω g h k
+  change ω.circlePhase (g * h) k * ω.circlePhase g h =
+    ω.circlePhase h k * ω.circlePhase g (h * k) at hc
+  have hcℂ := congrArg (fun z : Circle ↦ z.1) hc
+  change (ω.circlePhase (g * h) k : ℂ) * (ω.circlePhase g h : ℂ) =
+    (ω.circlePhase h k : ℂ) * (ω.circlePhase g (h * k) : ℂ) at hcℂ
+  simpa only [mul_comm] using hcℂ
+
+omit [Group G] in
+/-- Every coefficient of the canonical circle-valued representative has norm
+one. -/
+lemma norm_phase (ω : ScalarCocycle G) (g h : G) : ‖ω.phase g h‖ = 1 :=
+  Circle.norm_coe _
+
+attribute [simp] norm_phase
+
+omit [Group G] in
+/-- Every coefficient of the canonical circle-valued representative is
+nonzero. -/
+lemma phase_ne_zero (ω : ScalarCocycle G) (g h : G) : ω.phase g h ≠ 0 := by
+  exact norm_ne_zero_iff.mp (by simp)
+
+attribute [simp] phase_ne_zero
+
+/-- The cocycle-twisted left regular matrix
+
+`Lᵠ_g = ∑_h ϕ(g,h)⁻¹ |gh⟩⟨h|`
+
+from arXiv:2502.20257, equations following `eq:localsyms`. -/
+def twistedLeftRegular (ω : ScalarCocycle G) (g : G) : Matrix G G ℂ := by
+  classical
+  exact fun i h ↦ if i = g * h then (ω.phase g h)⁻¹ else 0
+
+/-- The cocycle-twisted right regular matrix
+
+`Rᵠ_g = ∑_h ϕ(h,g⁻¹)⁻¹ |hg⁻¹⟩⟨h|`
+
+from arXiv:2502.20257, equations following `eq:localsyms`. -/
+def twistedRightRegular (ω : ScalarCocycle G) (g : G) : Matrix G G ℂ := by
+  classical
+  exact fun i h ↦ if i = h * g⁻¹ then (ω.phase h g⁻¹)⁻¹ else 0
+
+@[simp]
+theorem twistedLeftRegular_apply_of_eq (ω : ScalarCocycle G) (g i h : G)
+    (hi : i = g * h) :
+    twistedLeftRegular ω g i h = (ω.phase g h)⁻¹ := by
+  classical
+  simp [twistedLeftRegular, hi]
+
+@[simp]
+theorem twistedLeftRegular_apply_of_ne (ω : ScalarCocycle G) (g i h : G)
+    (hi : i ≠ g * h) : twistedLeftRegular ω g i h = 0 := by
+  classical
+  simp [twistedLeftRegular, hi]
+
+@[simp]
+theorem twistedRightRegular_apply_of_eq (ω : ScalarCocycle G) (g i h : G)
+    (hi : i = h * g⁻¹) :
+    twistedRightRegular ω g i h = (ω.phase h g⁻¹)⁻¹ := by
+  classical
+  simp [twistedRightRegular, hi]
+
+@[simp]
+theorem twistedRightRegular_apply_of_ne (ω : ScalarCocycle G) (g i h : G)
+    (hi : i ≠ h * g⁻¹) : twistedRightRegular ω g i h = 0 := by
+  classical
+  simp [twistedRightRegular, hi]
+
+/-- The left regular matrix acts on coefficient functions by the paper's
+formula `Lᵠ_g |h⟩ = ϕ(g,h)⁻¹ |gh⟩`. -/
+theorem twistedLeftRegular_mulVec_apply [Fintype G]
+    (ω : ScalarCocycle G) (g h : G) (v : G → ℂ) :
+    (twistedLeftRegular ω g).mulVec v (g * h) = (ω.phase g h)⁻¹ * v h := by
+  classical
+  rw [Matrix.mulVec, dotProduct, Fintype.sum_eq_single h]
+  · rw [twistedLeftRegular_apply_of_eq ω g (g * h) h rfl]
+  · intro j hj
+    rw [twistedLeftRegular_apply_of_ne]
+    · simp
+    · intro heq
+      exact hj (mul_left_cancel heq.symm)
+
+/-- The right regular matrix acts on coefficient functions by the paper's
+formula `Rᵠ_g |h⟩ = ϕ(h,g⁻¹)⁻¹ |hg⁻¹⟩`. -/
+theorem twistedRightRegular_mulVec_apply [Fintype G]
+    (ω : ScalarCocycle G) (g h : G) (v : G → ℂ) :
+    (twistedRightRegular ω g).mulVec v (h * g⁻¹) =
+      (ω.phase h g⁻¹)⁻¹ * v h := by
+  classical
+  rw [Matrix.mulVec, dotProduct, Fintype.sum_eq_single h]
+  · rw [twistedRightRegular_apply_of_eq ω g (h * g⁻¹) h rfl]
+  · intro j hj
+    rw [twistedRightRegular_apply_of_ne]
+    · simp
+    · intro heq
+      exact hj (mul_right_cancel heq.symm)
+
+/-- The twisted left regular matrices obey the projective multiplication law
+`Lᵠ_g Lᵠ_h = ϕ(g,h)⁻¹ Lᵠ_{gh}`. -/
+theorem twistedLeftRegular_mul [Fintype G] {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (g h : G) :
+    twistedLeftRegular ω g * twistedLeftRegular ω h =
+      (ω.phase g h)⁻¹ • twistedLeftRegular ω (g * h) := by
+  classical
+  ext i k
+  rw [Matrix.mul_apply, Fintype.sum_eq_single (h * k)]
+  · rw [twistedLeftRegular_apply_of_eq ω h (h * k) k rfl]
+    change twistedLeftRegular ω g i (h * k) * (ω.phase h k)⁻¹ =
+      (ω.phase g h)⁻¹ * twistedLeftRegular ω (g * h) i k
+    by_cases hi : i = g * (h * k)
+    · rw [twistedLeftRegular_apply_of_eq ω g i (h * k) hi,
+        twistedLeftRegular_apply_of_eq ω (g * h) i k (by simpa only [mul_assoc] using hi)]
+      rw [← mul_inv_rev, ← mul_inv_rev]
+      congr 1
+      simpa only [mul_comm] using (phase_isCocycle hω g h k).symm
+    · rw [twistedLeftRegular_apply_of_ne ω g i (h * k) hi,
+        twistedLeftRegular_apply_of_ne ω (g * h) i k
+          (by simpa only [mul_assoc] using hi)]
+      simp
+  · intro j hj
+    rw [twistedLeftRegular_apply_of_ne ω h j k hj]
+    simp
+
+/-- The twisted right regular matrices obey the projective multiplication law
+`Rᵠ_g Rᵠ_h = ϕ(h⁻¹,g⁻¹)⁻¹ Rᵠ_{gh}`. -/
+theorem twistedRightRegular_mul [Fintype G] {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (g h : G) :
+    twistedRightRegular ω g * twistedRightRegular ω h =
+      (ω.phase h⁻¹ g⁻¹)⁻¹ • twistedRightRegular ω (g * h) := by
+  classical
+  ext i k
+  rw [Matrix.mul_apply, Fintype.sum_eq_single (k * h⁻¹)]
+  · rw [twistedRightRegular_apply_of_eq ω h (k * h⁻¹) k rfl]
+    change twistedRightRegular ω g i (k * h⁻¹) * (ω.phase k h⁻¹)⁻¹ =
+      (ω.phase h⁻¹ g⁻¹)⁻¹ * twistedRightRegular ω (g * h) i k
+    by_cases hi : i = (k * h⁻¹) * g⁻¹
+    · rw [twistedRightRegular_apply_of_eq ω g i (k * h⁻¹) hi,
+        twistedRightRegular_apply_of_eq ω (g * h) i k
+          (by simpa only [mul_inv_rev, mul_assoc] using hi)]
+      rw [mul_comm (ω.phase (k * h⁻¹) g⁻¹)⁻¹, ← mul_inv_rev, ← mul_inv_rev]
+      congr 1
+      simpa only [mul_inv_rev, mul_comm] using phase_isCocycle hω k h⁻¹ g⁻¹
+    · rw [twistedRightRegular_apply_of_ne ω g i (k * h⁻¹) hi,
+        twistedRightRegular_apply_of_ne ω (g * h) i k
+          (by simpa only [mul_inv_rev, mul_assoc] using hi)]
+      simp
+  · intro j hj
+    rw [twistedRightRegular_apply_of_ne ω h j k hj]
+    simp
+
+/-- The cocycle-twisted left and right regular matrices commute. -/
+theorem twistedLeftRegular_commute [Fintype G] {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (g h : G) :
+    twistedLeftRegular ω g * twistedRightRegular ω h =
+      twistedRightRegular ω h * twistedLeftRegular ω g := by
+  classical
+  ext i k
+  rw [Matrix.mul_apply, Fintype.sum_eq_single (k * h⁻¹),
+    Matrix.mul_apply, Fintype.sum_eq_single (g * k)]
+  · rw [twistedRightRegular_apply_of_eq ω h (k * h⁻¹) k rfl,
+      twistedLeftRegular_apply_of_eq ω g (g * k) k rfl]
+    by_cases hi : i = g * (k * h⁻¹)
+    · rw [twistedLeftRegular_apply_of_eq ω g i (k * h⁻¹) hi,
+        twistedRightRegular_apply_of_eq ω h i (g * k)
+          (by simpa only [mul_assoc] using hi)]
+      rw [← mul_inv_rev, ← mul_inv_rev]
+      congr 1
+      simpa only [mul_comm] using (phase_isCocycle hω g k h⁻¹).symm
+    · rw [twistedLeftRegular_apply_of_ne ω g i (k * h⁻¹) hi,
+        twistedRightRegular_apply_of_ne ω h i (g * k)
+          (by simpa only [mul_assoc] using hi)]
+      simp
+  · intro j hj
+    rw [twistedLeftRegular_apply_of_ne ω g j k hj]
+    simp
+  · intro j hj
+    rw [twistedRightRegular_apply_of_ne ω h j k hj]
+    simp
+
+/-- The cocycle-twisted left regular matrix is unitary.  The unit-modulus
+hypothesis is honest because the coefficients are taken from
+`ScalarCocycle.circlePhase`. -/
+theorem twistedLeftRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
+    (ω : ScalarCocycle G) (g : G) :
+    twistedLeftRegular ω g ∈ Matrix.unitaryGroup G ℂ := by
+  classical
+  rw [Matrix.mem_unitaryGroup_iff']
+  ext i j
+  rw [Matrix.mul_apply, Fintype.sum_eq_single (g * i)]
+  · by_cases hij : i = j
+    · subst j
+      simp only [Matrix.one_apply_eq]
+      rw [Matrix.star_apply, twistedLeftRegular_apply_of_eq ω g (g * i) i rfl,
+        star_inv₀, ← mul_inv_rev]
+      rw [show ω.phase g i * star (ω.phase g i) = 1 by
+        calc
+          ω.phase g i * star (ω.phase g i) = Complex.normSq (ω.phase g i) :=
+            Complex.mul_conj _
+          _ = 1 := by
+            norm_cast
+            exact Circle.normSq_coe _]
+      simp
+    · simp [twistedLeftRegular, hij]
+  · intro k hk
+    simp [twistedLeftRegular, hk]
+
+/-- The cocycle-twisted right regular matrix is unitary.  The unit-modulus
+hypothesis is honest because the coefficients are taken from
+`ScalarCocycle.circlePhase`. -/
+theorem twistedRightRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
+    (ω : ScalarCocycle G) (g : G) :
+    twistedRightRegular ω g ∈ Matrix.unitaryGroup G ℂ := by
+  classical
+  rw [Matrix.mem_unitaryGroup_iff']
+  ext i j
+  rw [Matrix.mul_apply, Fintype.sum_eq_single (i * g⁻¹)]
+  · by_cases hij : i = j
+    · subst j
+      simp only [Matrix.one_apply_eq]
+      rw [Matrix.star_apply, twistedRightRegular_apply_of_eq ω g (i * g⁻¹) i rfl,
+        star_inv₀, ← mul_inv_rev]
+      rw [show ω.phase i g⁻¹ * star (ω.phase i g⁻¹) = 1 by
+        calc
+          ω.phase i g⁻¹ * star (ω.phase i g⁻¹) = Complex.normSq (ω.phase i g⁻¹) :=
+            Complex.mul_conj _
+          _ = 1 := by
+            norm_cast
+            exact Circle.normSq_coe _]
+      simp
+    · simp [twistedRightRegular, hij]
+  · intro k hk
+    simp [twistedRightRegular, hk]
+
+/-- The coefficient identity used in the onsite Gauss operator,
+
+`ϕ(ag⁻¹,gb) / ϕ(a,b) = 1 / (ϕ(a,g⁻¹) ϕ(g,b))`.
+
+Besides cocyclicity, this explicitly assumes the paper's normalization
+`ϕ(t⁻¹,t) = 1`.  In particular, the normalization is not claimed as a
+consequence of an arbitrary cocycle.  This is arXiv:2502.20257, lines
+3763--3766. -/
+theorem onsiteGauss_phase_div {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (hInv : ∀ t : G, ω.phase t⁻¹ t = 1)
+    (a g b : G) :
+    ω.phase (a * g⁻¹) (g * b) / ω.phase a b =
+      1 / (ω.phase a g⁻¹ * ω.phase g b) := by
+  have hOne : ω.phase 1 b = 1 := by
+    have hc := phase_isCocycle hω 1 1 b
+    have := hInv 1
+    simp only [inv_one] at this
+    rw [this] at hc
+    simpa using hc.symm
+  have h₁ := phase_isCocycle hω a g⁻¹ (g * b)
+  have h₂ := phase_isCocycle hω g⁻¹ g b
+  simp only [inv_mul_cancel_left] at h₁
+  simp only [inv_mul_cancel] at h₂
+  rw [hInv g, hOne] at h₂
+  have h₂' : ω.phase g⁻¹ (g * b) * ω.phase g b = 1 := by simpa using h₂.symm
+  field_simp
+  calc
+    ω.phase (a * g⁻¹) (g * b) * ω.phase a g⁻¹ * ω.phase g b
+        = (ω.phase a g⁻¹ * ω.phase (a * g⁻¹) (g * b)) * ω.phase g b := by
+            ring
+    _ = (ω.phase a b * ω.phase g⁻¹ (g * b)) * ω.phase g b := by rw [h₁]
+    _ = ω.phase a b := by rw [mul_assoc, h₂']; simp
+
+end ScalarCocycle
+
+end TNLean.Algebra

--- a/TNLean/Algebra/TwistedRegularRepresentation.lean
+++ b/TNLean/Algebra/TwistedRegularRepresentation.lean
@@ -10,10 +10,9 @@ import TNLean.Algebra.CircleCohomology
 # Cocycle-twisted regular representations
 
 This file formalizes the left and right regular actions in
-arXiv:2502.20257, equations following `eq:localsyms` and the onsite
-specialization at lines 3758--3766.  For a scalar cocycle `ω`, we use its
-canonical circle-valued representative `ω.circlePhase` and the paper's inverse
-conventions
+arXiv:2502.20257, lines 412--418, and the onsite specialization at lines
+3758--3766. For a scalar cocycle `ω`, we use its canonical circle-valued
+representative `ω.circlePhase` and the paper's inverse conventions
 
 `Lᵠ_g |h⟩ = ϕ(g,h)⁻¹ |gh⟩`,
 
@@ -69,7 +68,7 @@ attribute [simp] phase_ne_zero
 
 `Lᵠ_g = ∑_h ϕ(g,h)⁻¹ |gh⟩⟨h|`
 
-from arXiv:2502.20257, equations following `eq:localsyms`. -/
+from arXiv:2502.20257, lines 412--415. -/
 def twistedLeftRegular (ω : ScalarCocycle G) (g : G) : Matrix G G ℂ := by
   classical
   exact fun i h ↦ if i = g * h then (ω.phase g h)⁻¹ else 0
@@ -78,7 +77,7 @@ def twistedLeftRegular (ω : ScalarCocycle G) (g : G) : Matrix G G ℂ := by
 
 `Rᵠ_g = ∑_h ϕ(h,g⁻¹)⁻¹ |hg⁻¹⟩⟨h|`
 
-from arXiv:2502.20257, equations following `eq:localsyms`. -/
+from arXiv:2502.20257, lines 416--418. -/
 def twistedRightRegular (ω : ScalarCocycle G) (g : G) : Matrix G G ℂ := by
   classical
   exact fun i h ↦ if i = h * g⁻¹ then (ω.phase h g⁻¹)⁻¹ else 0
@@ -109,8 +108,8 @@ theorem twistedRightRegular_apply_of_ne (ω : ScalarCocycle G) (g i h : G)
   classical
   simp [twistedRightRegular, hi]
 
-/-- The left regular matrix acts on coefficient functions by the paper's
-formula `Lᵠ_g |h⟩ = ϕ(g,h)⁻¹ |gh⟩`. -/
+/-- The left regular matrix acts on coefficient functions by
+`(Lᵠ_g v)(gh) = ϕ(g,h)⁻¹ v(h)`. -/
 theorem twistedLeftRegular_mulVec_apply [Fintype G]
     (ω : ScalarCocycle G) (g h : G) (v : G → ℂ) :
     (twistedLeftRegular ω g).mulVec v (g * h) = (ω.phase g h)⁻¹ * v h := by
@@ -123,8 +122,8 @@ theorem twistedLeftRegular_mulVec_apply [Fintype G]
     · intro heq
       exact hj (mul_left_cancel heq.symm)
 
-/-- The right regular matrix acts on coefficient functions by the paper's
-formula `Rᵠ_g |h⟩ = ϕ(h,g⁻¹)⁻¹ |hg⁻¹⟩`. -/
+/-- The right regular matrix acts on coefficient functions by
+`(Rᵠ_g v)(hg⁻¹) = ϕ(h,g⁻¹)⁻¹ v(h)`. -/
 theorem twistedRightRegular_mulVec_apply [Fintype G]
     (ω : ScalarCocycle G) (g h : G) (v : G → ℂ) :
     (twistedRightRegular ω g).mulVec v (h * g⁻¹) =
@@ -220,9 +219,8 @@ theorem twistedLeftRegular_commute [Fintype G] {ω : ScalarCocycle G}
     rw [twistedRightRegular_apply_of_ne ω h j k hj]
     simp
 
-/-- The cocycle-twisted left regular matrix is unitary.  The unit-modulus
-hypothesis is honest because the coefficients are taken from
-`ScalarCocycle.circlePhase`. -/
+/-- The cocycle-twisted left regular matrix is unitary because its phase
+coefficients have norm one. -/
 theorem twistedLeftRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
     (ω : ScalarCocycle G) (g : G) :
     twistedLeftRegular ω g ∈ Matrix.unitaryGroup G ℂ := by
@@ -247,9 +245,8 @@ theorem twistedLeftRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
   · intro k hk
     simp [twistedLeftRegular, hk]
 
-/-- The cocycle-twisted right regular matrix is unitary.  The unit-modulus
-hypothesis is honest because the coefficients are taken from
-`ScalarCocycle.circlePhase`. -/
+/-- The cocycle-twisted right regular matrix is unitary because its phase
+coefficients have norm one. -/
 theorem twistedRightRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
     (ω : ScalarCocycle G) (g : G) :
     twistedRightRegular ω g ∈ Matrix.unitaryGroup G ℂ := by
@@ -278,10 +275,10 @@ theorem twistedRightRegular_mem_unitaryGroup [Fintype G] [DecidableEq G]
 
 `ϕ(ag⁻¹,gb) / ϕ(a,b) = 1 / (ϕ(a,g⁻¹) ϕ(g,b))`.
 
-Besides cocyclicity, this explicitly assumes the paper's normalization
-`ϕ(t⁻¹,t) = 1`.  In particular, the normalization is not claimed as a
-consequence of an arbitrary cocycle.  This is arXiv:2502.20257, lines
-3763--3766. -/
+Besides cocyclicity, this explicitly assumes `ϕ(t⁻¹,t) = 1`, the normalization
+corresponding to the scalar convention `S_{t⁻¹} = S_t⁻¹` at line 238. The
+normalization is not claimed as a consequence of an arbitrary cocycle. The
+coefficient rewrite is arXiv:2502.20257, lines 3763--3766. -/
 theorem onsiteGauss_phase_div {ω : ScalarCocycle G}
     (hω : ω.IsCocycle) (hInv : ∀ t : G, ω.phase t⁻¹ t = 1)
     (a g b : G) :

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1394,6 +1394,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         (R_g^\phi v)(hg^{-1})
          & =\phi(h,g^{-1})^{-1}v(h).
     \end{align}
+    % Source anchor: arXiv:2502.20257, lines 412--418.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1417,11 +1418,13 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
          & =\phi(h^{-1},g^{-1})^{-1}R_{gh}^\phi.
         \label{eq:mpug_twisted_regular_multiplication}
     \end{align}
+    % Source anchor: arXiv:2502.20257, lines 406--418; the laws follow from
+    % the displayed twisted regular matrices and the cocycle equation.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_twisted_regular_action,
-        thm:mpug_circle_complex_units_h2}
+        lem:mpug_circle_phase_cocycle}
     Apply both sides to a basis vector.  The two scalar identities are the
     cocycle equation at $(g,h,k)$ and $(k,h^{-1},g^{-1})$, respectively.
 \end{proof}
@@ -1431,18 +1434,20 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_commute}
     \leanok
     \uses{thm:mpug_twisted_regular_action,
-        thm:mpug_circle_complex_units_h2}
+        lem:mpug_circle_phase_cocycle}
     If $\omega$ is a cocycle, then
     \begin{align}
         L_g^\phi R_h^\phi
          & =R_h^\phi L_g^\phi.
         \label{eq:mpug_twisted_regular_commutation}
     \end{align}
+    % Source anchor: arXiv:2502.20257, lines 406--418; commutation is the
+    % compatibility of the two gauge-leg actions in the local representation.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_twisted_regular_action,
-        thm:mpug_circle_complex_units_h2}
+        lem:mpug_circle_phase_cocycle}
     Apply both sides to a basis vector and use the cocycle equation at
     $(g,k,h^{-1})$.
 \end{proof}
@@ -1469,7 +1474,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \label{thm:mpug_onsite_gauss_phase}
     \lean{TNLean.Algebra.ScalarCocycle.onsiteGauss_phase_div}
     \leanok
-    \uses{def:mpug_twisted_regular_matrices, def:is_cocycle}
+    \uses{def:mpug_twisted_regular_matrices,
+        lem:mpug_circle_phase_cocycle}
     Suppose that $\omega$ is a cocycle and impose the additional normalization
     \begin{align}
         \phi(t^{-1},t) & =1
@@ -1487,7 +1493,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_twisted_regular_multiplication}
+    \uses{lem:mpug_circle_phase_cocycle}
     Use the cocycle equation first at $(a,g^{-1},gb)$ and then at
     $(g^{-1},g,b)$.  The normalization at $t=e$ also gives
     $\phi(e,b)=1$.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1335,6 +1335,122 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     inverse induced by $q$ proves injectivity.
 \end{proof}
 
+\begin{definition}[Cocycle-twisted regular matrices]
+    \label{def:mpug_twisted_regular_matrices}
+    \lean{TNLean.Algebra.ScalarCocycle.phase,
+        TNLean.Algebra.ScalarCocycle.twistedLeftRegular,
+        TNLean.Algebra.ScalarCocycle.twistedRightRegular}
+    \leanok
+    \uses{def:scalar_cocycle, thm:mpug_circle_complex_units_h2}
+    Let $G$ be finite and let $\omega$ be a $\C^\times$-valued scalar
+    cochain.  Write
+    \begin{align}
+        \phi(g,h) & =\frac{\omega(g,h)}{|\omega(g,h)|}\in U(1).
+    \end{align}
+    On the standard basis of $\C^G$, define
+    \begin{align}
+        L_g^\phi
+         & =\sum_{h\in G}\phi(g,h)^{-1}|gh\rangle\langle h|,
+        &
+        R_g^\phi
+         & =\sum_{h\in G}\phi(h,g^{-1})^{-1}|hg^{-1}\rangle\langle h|.
+        \label{eq:mpug_twisted_regular_matrices}
+    \end{align}
+    These are the leg and inverse conventions used after
+    \cite[Eq.~\texttt{eq:localsyms}]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Action of the twisted regular matrices]
+    \label{thm:mpug_twisted_regular_action}
+    \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_mulVec_apply,
+        TNLean.Algebra.ScalarCocycle.twistedRightRegular_mulVec_apply}
+    \leanok
+    \uses{def:mpug_twisted_regular_matrices}
+    For $v\in\C^G$ and $g,h\in G$,
+    \begin{align}
+        (L_g^\phi v)(gh)
+         & =\phi(g,h)^{-1}v(h),
+        &
+        (R_g^\phi v)(hg^{-1})
+         & =\phi(h,g^{-1})^{-1}v(h).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_twisted_regular_matrices}
+    In each matrix-vector product, exactly one summand is nonzero: the column
+    indexed by $h$.
+\end{proof}
+
+\begin{theorem}[Multiplication and commutation of twisted regular matrices]
+    \label{thm:mpug_twisted_regular_multiplication}
+    \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_mul,
+        TNLean.Algebra.ScalarCocycle.twistedRightRegular_mul,
+        TNLean.Algebra.ScalarCocycle.twistedLeftRegular_commute}
+    \leanok
+    \uses{def:mpug_twisted_regular_matrices, def:is_cocycle}
+    If $\omega$ is a cocycle, then its circle phase $\phi$ is a cocycle and
+    \begin{align}
+        L_g^\phi L_h^\phi
+         & =\phi(g,h)^{-1}L_{gh}^\phi, \\
+        R_g^\phi R_h^\phi
+         & =\phi(h^{-1},g^{-1})^{-1}R_{gh}^\phi, \\
+        L_g^\phi R_h^\phi
+         & =R_h^\phi L_g^\phi.
+        \label{eq:mpug_twisted_regular_multiplication}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_twisted_regular_action}
+    Apply both sides to a basis vector.  The scalar equalities are respectively
+    the cocycle equation at $(g,h,k)$, $(k,h^{-1},g^{-1})$, and
+    $(g,k,h^{-1})$.
+\end{proof}
+
+\begin{theorem}[Unitarity of twisted regular matrices]
+    \label{thm:mpug_twisted_regular_unitary}
+    \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_mem_unitaryGroup,
+        TNLean.Algebra.ScalarCocycle.twistedRightRegular_mem_unitaryGroup}
+    \leanok
+    \uses{def:mpug_twisted_regular_matrices}
+    The matrices $L_g^\phi$ and $R_g^\phi$ are unitary for every $g\in G$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_twisted_regular_matrices}
+    Each matrix is a permutation matrix whose nonzero entries have modulus
+    one.  Distinct columns therefore have disjoint support, while every column
+    has squared norm one.
+\end{proof}
+
+\begin{theorem}[Onsite Gauss coefficient identity]
+    \label{thm:mpug_onsite_gauss_phase}
+    \lean{TNLean.Algebra.ScalarCocycle.onsiteGauss_phase_div}
+    \leanok
+    \uses{def:mpug_twisted_regular_matrices, def:is_cocycle}
+    Suppose that $\omega$ is a cocycle and, as an additional normalization,
+    \begin{align}
+        \phi(t^{-1},t) & =1
+    \end{align}
+    for every $t\in G$.  Then
+    \begin{align}
+        \frac{\phi(ag^{-1},gb)}{\phi(a,b)}
+         & =\frac{1}{\phi(a,g^{-1})\phi(g,b)}.
+        \label{eq:mpug_onsite_gauss_phase}
+    \end{align}
+    This is the scalar rewrite in
+    \cite[lines~3763--3766]{FrancoRubio2025MPUGauging}.  The displayed
+    normalization is an assumption, not a consequence of cocyclicity.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_twisted_regular_multiplication}
+    Use the cocycle equation first at $(a,g^{-1},gb)$ and then at
+    $(g^{-1},g,b)$.  The normalization at $t=e$ also gives
+    $\phi(e,b)=1$.
+\end{proof}
+
 \begin{definition}[Block scalar and block independence]
     \label{def:mpug_block_independence_factor}
     \lean{TNLean.Algebra.LSymbol.ell,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1342,7 +1342,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.ScalarCocycle.twistedRightRegular}
     \leanok
     \uses{def:scalar_cocycle, thm:mpug_circle_complex_units_h2}
-    Let $G$ be finite and let $\omega$ be a $\C^\times$-valued scalar
+    Let $G$ be a group and let $\omega$ be a $\C^\times$-valued scalar
     cochain.  Write
     \begin{align}
         \phi(g,h) & =\frac{\omega(g,h)}{|\omega(g,h)|}\in U(1).
@@ -1386,7 +1386,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.ScalarCocycle.twistedRightRegular_mulVec_apply}
     \leanok
     \uses{def:mpug_twisted_regular_matrices}
-    For $v\in\C^G$ and $g,h\in G$,
+    If $G$ is finite, then for $v\in\C^G$ and $g,h\in G$,
     \begin{align}
         (L_g^\phi v)(gh)
          & =\phi(g,h)^{-1}v(h),
@@ -1410,7 +1410,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \uses{def:mpug_twisted_regular_matrices,
         lem:mpug_circle_phase_cocycle}
-    If $\omega$ is a cocycle, then
+    If $G$ is finite and $\omega$ is a cocycle, then
     \begin{align}
         L_g^\phi L_h^\phi
          & =\phi(g,h)^{-1}L_{gh}^\phi,           \\
@@ -1423,9 +1423,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_twisted_regular_action,
-        lem:mpug_circle_phase_cocycle}
-    Apply both sides to a basis vector.  The two scalar identities are the
+    \uses{lem:mpug_circle_phase_cocycle}
+    Expand the matrix products entrywise.  The two scalar identities are the
     cocycle equation at $(g,h,k)$ and $(k,h^{-1},g^{-1})$, respectively.
 \end{proof}
 
@@ -1433,22 +1432,21 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \label{thm:mpug_twisted_regular_commutation}
     \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_commute}
     \leanok
-    \uses{thm:mpug_twisted_regular_action,
-        lem:mpug_circle_phase_cocycle}
-    If $\omega$ is a cocycle, then
+    \uses{def:mpug_twisted_regular_matrices}
+    If $G$ is finite and $\omega$ is a cocycle, then
     \begin{align}
         L_g^\phi R_h^\phi
          & =R_h^\phi L_g^\phi.
         \label{eq:mpug_twisted_regular_commutation}
     \end{align}
-    % Source anchor: arXiv:2502.20257, lines 406--418; commutation is the
-    % compatibility of the two gauge-leg actions in the local representation.
+    % Source anchor: arXiv:2502.20257, lines 406--418 and 457; the latter
+    % explicitly attributes commuting local symmetries to commutativity of the
+    % left and right group actions.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_twisted_regular_action,
-        lem:mpug_circle_phase_cocycle}
-    Apply both sides to a basis vector and use the cocycle equation at
+    \uses{lem:mpug_circle_phase_cocycle}
+    Expand both matrix products entrywise and use the cocycle equation at
     $(g,k,h^{-1})$.
 \end{proof}
 
@@ -1458,7 +1456,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.ScalarCocycle.twistedRightRegular_mem_unitaryGroup}
     \leanok
     \uses{def:mpug_twisted_regular_matrices}
-    The matrices $L_g^\phi$ and $R_g^\phi$ are unitary for every $g\in G$.
+    If $G$ is finite, the matrices $L_g^\phi$ and $R_g^\phi$ are unitary for
+    every $g\in G$.
     % Source anchor: arXiv:2502.20257, lines 406--418, where these matrices
     % form the two gauge legs of the local unitary representation.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1351,14 +1351,34 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         L_g^\phi
          & =\sum_{h\in G}\phi(g,h)^{-1}|gh\rangle\langle h|,
-        &
+         &
         R_g^\phi
          & =\sum_{h\in G}\phi(h,g^{-1})^{-1}|hg^{-1}\rangle\langle h|.
         \label{eq:mpug_twisted_regular_matrices}
     \end{align}
-    These are the leg and inverse conventions used after
-    \cite[Eq.~\texttt{eq:localsyms}]{FrancoRubio2025MPUGauging}.
+    The source uses a $U(1)$-valued cocycle $\Omega$; taking $\Omega=\phi$
+    gives exactly the leg and inverse conventions in
+    \cite[lines~412--418]{FrancoRubio2025MPUGauging}.
 \end{definition}
+
+\begin{lemma}[Cocycle equation for the circle phase]
+    \label{lem:mpug_circle_phase_cocycle}
+    \lean{TNLean.Algebra.ScalarCocycle.phase_isCocycle}
+    \leanok
+    \uses{def:is_cocycle, thm:mpug_circle_complex_units_h2}
+    If $\omega$ is a cocycle, then its circle phase satisfies
+    \begin{align}
+        \phi(g,h)\phi(gh,k)
+         & =\phi(g,hk)\phi(h,k)
+    \end{align}
+    for all $g,h,k\in G$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_circle_complex_units_h2}
+    The pointwise phase map $z\mapsto z/|z|$ is multiplicative, so it preserves
+    the cocycle equation.
+\end{proof}
 
 \begin{theorem}[Action of the twisted regular matrices]
     \label{thm:mpug_twisted_regular_action}
@@ -1370,7 +1390,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         (L_g^\phi v)(gh)
          & =\phi(g,h)^{-1}v(h),
-        &
+         &
         (R_g^\phi v)(hg^{-1})
          & =\phi(h,g^{-1})^{-1}v(h).
     \end{align}
@@ -1382,29 +1402,48 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     indexed by $h$.
 \end{proof}
 
-\begin{theorem}[Multiplication and commutation of twisted regular matrices]
+\begin{theorem}[Multiplication laws for twisted regular matrices]
     \label{thm:mpug_twisted_regular_multiplication}
     \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_mul,
-        TNLean.Algebra.ScalarCocycle.twistedRightRegular_mul,
-        TNLean.Algebra.ScalarCocycle.twistedLeftRegular_commute}
+        TNLean.Algebra.ScalarCocycle.twistedRightRegular_mul}
     \leanok
-    \uses{def:mpug_twisted_regular_matrices, def:is_cocycle}
-    If $\omega$ is a cocycle, then its circle phase $\phi$ is a cocycle and
+    \uses{def:mpug_twisted_regular_matrices,
+        lem:mpug_circle_phase_cocycle}
+    If $\omega$ is a cocycle, then
     \begin{align}
         L_g^\phi L_h^\phi
-         & =\phi(g,h)^{-1}L_{gh}^\phi, \\
+         & =\phi(g,h)^{-1}L_{gh}^\phi,           \\
         R_g^\phi R_h^\phi
-         & =\phi(h^{-1},g^{-1})^{-1}R_{gh}^\phi, \\
-        L_g^\phi R_h^\phi
-         & =R_h^\phi L_g^\phi.
+         & =\phi(h^{-1},g^{-1})^{-1}R_{gh}^\phi.
         \label{eq:mpug_twisted_regular_multiplication}
     \end{align}
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_twisted_regular_action}
-    Apply both sides to a basis vector.  The scalar equalities are respectively
-    the cocycle equation at $(g,h,k)$, $(k,h^{-1},g^{-1})$, and
+    \uses{thm:mpug_twisted_regular_action,
+        thm:mpug_circle_complex_units_h2}
+    Apply both sides to a basis vector.  The two scalar identities are the
+    cocycle equation at $(g,h,k)$ and $(k,h^{-1},g^{-1})$, respectively.
+\end{proof}
+
+\begin{theorem}[Commutation of twisted left and right actions]
+    \label{thm:mpug_twisted_regular_commutation}
+    \lean{TNLean.Algebra.ScalarCocycle.twistedLeftRegular_commute}
+    \leanok
+    \uses{thm:mpug_twisted_regular_action,
+        thm:mpug_circle_complex_units_h2}
+    If $\omega$ is a cocycle, then
+    \begin{align}
+        L_g^\phi R_h^\phi
+         & =R_h^\phi L_g^\phi.
+        \label{eq:mpug_twisted_regular_commutation}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_twisted_regular_action,
+        thm:mpug_circle_complex_units_h2}
+    Apply both sides to a basis vector and use the cocycle equation at
     $(g,k,h^{-1})$.
 \end{proof}
 
@@ -1415,6 +1454,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \uses{def:mpug_twisted_regular_matrices}
     The matrices $L_g^\phi$ and $R_g^\phi$ are unitary for every $g\in G$.
+    % Source anchor: arXiv:2502.20257, lines 406--418, where these matrices
+    % form the two gauge legs of the local unitary representation.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1429,7 +1470,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \lean{TNLean.Algebra.ScalarCocycle.onsiteGauss_phase_div}
     \leanok
     \uses{def:mpug_twisted_regular_matrices, def:is_cocycle}
-    Suppose that $\omega$ is a cocycle and, as an additional normalization,
+    Suppose that $\omega$ is a cocycle and impose the additional normalization
     \begin{align}
         \phi(t^{-1},t) & =1
     \end{align}
@@ -1439,9 +1480,10 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
          & =\frac{1}{\phi(a,g^{-1})\phi(g,b)}.
         \label{eq:mpug_onsite_gauss_phase}
     \end{align}
-    This is the scalar rewrite in
-    \cite[lines~3763--3766]{FrancoRubio2025MPUGauging}.  The displayed
-    normalization is an assumption, not a consequence of cocyclicity.
+    The scalar convention $S_{t^{-1}}=S_t^{-1}$ appears in
+    \cite[line~238]{FrancoRubio2025MPUGauging}, and the coefficient rewrite is
+    at lines 3763--3766. The displayed normalization remains an explicit
+    assumption here; it is not a consequence of cocyclicity.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## What changed
- define the cocycle-twisted left and right regular matrices with the leg and inverse conventions of arXiv:2502.20257
- prove their basis-action formulas, projective multiplication laws, mutual commutation, and unitarity using `ScalarCocycle.circlePhase`
- prove the onsite Gauss coefficient rewrite with `φ(t⁻¹,t) = 1` as an explicit hypothesis
- add the generated Algebra import and synchronized Blueprint statements and proofs

## Validation
- `lake build TNLean.Algebra.TwistedRegularRepresentation` (3134 jobs)
- `lake build TNLean.Algebra` (3485 jobs)
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7028/7028 entries in sync)
- forbidden-placeholder scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`: none

The standalone `leanblueprint checkdecls` command exceeded the 10-minute local limit. The CI-style source scanner resolves every new declaration; hosted CI remains the full gate. A local full build was intentionally not started because other full jobs were already running.

Closes #7459
