### PR TITLE
feat(MPS/MPU): formalize swap-transformed shift tensors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,7 @@ follow-up, not against the temporary `sorry` count.
 
 | Name | Kind | Use when | Defined in |
 |---|---|---|---|
+| `Equiv.Perm.permMatrix_mem_unitaryGroup` | helper theorem | Showing that a complex permutation matrix is unitary | `TNLean/Algebra/PermutationMatrixUnitary.lean` |
 | `List.ofFn_reverse` | helper theorem | Reversing a `List.ofFn`-indexed finite word by precomposition with `Fin.rev` | `QICLean/Kraus/Word.lean` (QICLean dependency) |
 | `verticalAssembledTensor_apply_copy_same` | helper theorem | Evaluating an assembled vertical tensor at two coordinates in the same retained multiplicity copy | `TNLean/MPS/MPDO/VerticalSectorCoordinates.lean` |
 | `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_of_openBoundary` | helper theorem | Closing block-diagonal boundaries from an open-boundary representation and a simultaneous span across the complementary global cut | `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean` |

--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -26,6 +26,7 @@ import TNLean.Algebra.LSymbolBlockIndependence
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NegMulLog
+import TNLean.Algebra.PermutationMatrixUnitary
 import TNLean.Algebra.PiSigmaEquiv
 import TNLean.Algebra.PiTensorProductPhase
 import TNLean.Algebra.PositiveGeneralizedCocycle

--- a/TNLean/Algebra/PermutationMatrixUnitary.lean
+++ b/TNLean/Algebra/PermutationMatrixUnitary.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Permutation
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Unitarity of permutation matrices
+
+This file records that a complex permutation matrix belongs to the unitary group.
+-/
+
+open scoped Matrix
+
+namespace Equiv.Perm
+
+/-- A complex permutation matrix is unitary. -/
+theorem permMatrix_mem_unitaryGroup {n : Type*} [DecidableEq n] [Fintype n]
+    (σ : Equiv.Perm n) :
+    permMatrix ℂ σ ∈ Matrix.unitaryGroup n ℂ := by
+  rw [Matrix.mem_unitaryGroup_iff, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_permMatrix, ← Matrix.permMatrix_mul]
+  simp
+
+end Equiv.Perm

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.PermutationMatrixUnitary
 import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Unitary
 
@@ -358,21 +359,6 @@ theorem permGL_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
 theorem permGL_inv_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
     (((permGL σ)⁻¹ : GL n ℂ) : Matrix n n ℂ) = Equiv.Perm.permMatrix ℂ σ.symm := rfl
 
-/-- The general linear group element associated with a permutation is unitary. -/
-private theorem permGL_mem_unitaryGroup {n : Type*} [DecidableEq n] [Fintype n]
-    (σ : Equiv.Perm n) :
-    (permGL σ : Matrix n n ℂ) ∈ Matrix.unitaryGroup n ℂ := by
-  rw [Matrix.mem_unitaryGroup_iff, Matrix.star_eq_conjTranspose,
-    permGL_val, Matrix.conjTranspose_permMatrix]
-  change Equiv.Perm.permMatrix ℂ σ * Equiv.Perm.permMatrix ℂ σ.symm = 1
-  have hmul : Equiv.Perm.permMatrix ℂ σ * Equiv.Perm.permMatrix ℂ σ.symm =
-      Equiv.Perm.permMatrix ℂ (σ.symm * σ) :=
-    (Matrix.permMatrix_mul (σ := σ.symm) (τ := σ)).symm
-  rw [hmul]
-  change Equiv.Perm.permMatrix ℂ (σ⁻¹ * σ) = 1
-  rw [inv_mul_cancel]
-  exact Matrix.permMatrix_one
-
 /-- Conjugating a square matrix by a permutation matrix gives a `submatrix` of
 the original by the permutation index map. -/
 lemma permMatrix_conj_eq_submatrix {n : Type*}
@@ -550,8 +536,8 @@ private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal
   have hYunitary :
       (X' * permGL ρ : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) ∈
         Matrix.unitaryGroup (Fin Q.totalDim) ℂ :=
-    (Matrix.unitaryGroup (Fin Q.totalDim) ℂ).mul_mem
-      hX'unitary (permGL_mem_unitaryGroup ρ)
+    (Matrix.unitaryGroup (Fin Q.totalDim) ℂ).mul_mem hX'unitary (by
+      simpa only [permGL_val] using Equiv.Perm.permMatrix_mem_unitaryGroup ρ)
   refine ⟨X' * permGL ρ, hYunitary, ?_⟩
   intro i
   have hsubm := matched_toTensor_eq_submatrix (P := P) (Q := Q) β hDim τ i

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -6,14 +6,16 @@ Authors: TNLean contributors
 import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Channel.SingleKrausPositivity
 import TNLean.Algebra.ListProduct
+import TNLean.MPS.MPDO.FirstSite
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 
 /-!
 # Sitewise physical matrices on periodic MPOs
 
-A one-site matrix `V` acts on a chain by its sitewise tensor power.  Acting on
-both physical legs of a periodic MPO is the same as changing the physical
-basis of every local MPO matrix before closing the virtual trace.
+A one-site matrix `V` acts on a chain by its sitewise tensor power. Acting on
+the ket leg at every site left-multiplies the closed MPO by this tensor power.
+Acting on both physical legs is the same as changing the physical basis of
+every local MPO matrix before closing the virtual trace.
 
 This is finite-dimensional tensor-product algebra.  The construction is used
 below with the BNT physical-sector projections of arXiv:1606.00608,
@@ -53,6 +55,43 @@ noncomputable def sitewisePhysicalMatrix
     (V : Matrix (Fin e) (Fin d) ℂ) (N : ℕ) :
     Matrix (Fin N → Fin e) (Fin N → Fin d) ℂ :=
   fun s t ↦ ∏ n : Fin N, V (s n) (t n)
+
+private theorem trace_mul_evalWord_ketLeftMul_ofFn
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
+    Matrix.trace (X * evalWord (M.ketLeftMul P) (List.ofFn σ) (List.ofFn τ)) =
+      ∑ ρ : Fin N → Fin d, (∏ n : Fin N, P (σ n) (ρ n)) *
+        Matrix.trace (X * evalWord M (List.ofFn ρ) (List.ofFn τ)) := by
+  induction N generalizing X with
+  | zero => simp
+  | succ n ih =>
+      simp only [List.ofFn_succ, evalWord_cons, ketLeftMul]
+      rw [← Matrix.mul_assoc, Matrix.mul_sum, Finset.sum_mul, Matrix.trace_sum]
+      simp_rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+      have reindex : ∀ F : (Fin (n + 1) → Fin d) → ℂ,
+          ∑ ρ, F ρ = ∑ k : Fin d, ∑ ρ' : Fin n → Fin d, F (Fin.cons k ρ') :=
+        fun F => by
+          rw [← Fintype.sum_prod_type']
+          exact ((Fin.consEquiv fun _ : Fin (n + 1) ↦ Fin d).sum_comp F).symm
+      rw [reindex]
+      simp only [Fin.cons_zero, Fin.cons_succ, Fin.prod_univ_succ]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [ih, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro ρ _
+      rw [Matrix.mul_assoc]
+      ring
+
+/-- Applying a matrix to the ket leg at every site left-multiplies the closed
+MPO by its sitewise tensor power. -/
+theorem mpo_ketLeftMul (M : MPOTensor d D)
+    (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
+    mpo (M.ketLeftMul P) N = sitewisePhysicalMatrix P N * mpo M N := by
+  ext σ τ
+  simp only [Matrix.mul_apply, mpo_apply, mpoMatrixEntry, sitewisePhysicalMatrix]
+  simpa only [Matrix.one_mul] using
+    trace_mul_evalWord_ketLeftMul_ofFn M P (1 : Matrix (Fin D) (Fin D) ℂ) σ τ
 
 /-- Sitewise tensor powers preserve rectangular matrix multiplication. -/
 theorem sitewisePhysicalMatrix_mul

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.MPU.Examples
 import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.FiniteChainConjugation
 import TNLean.MPS.MPU.GroupRepresentation
+import TNLean.MPS.MPU.KetLeftMul
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.MixedKernelBoundary

--- a/TNLean/MPS/MPU/Examples.lean
+++ b/TNLean/MPS/MPU/Examples.lean
@@ -15,4 +15,5 @@ import TNLean.MPS.MPU.Examples.ShiftSourceFactors
 import TNLean.MPS.MPU.Examples.ShiftSourceFormulas
 import TNLean.MPS.MPU.Examples.ShiftSourceRanks
 import TNLean.MPS.MPU.Examples.ShiftSwapMatrices
+import TNLean.MPS.MPU.Examples.ShiftTilde
 import TNLean.MPS.MPU.Examples.SwapPath

--- a/TNLean/MPS/MPU/Examples/Shift.lean
+++ b/TNLean/MPS/MPU/Examples/Shift.lean
@@ -3,11 +3,12 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.LinearAlgebra.Matrix.Permutation
+import TNLean.Algebra.PermutationMatrixUnitary
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPU.SourceFactorContraction
 import TNLean.MPS.MPU.TensorProduct
-import TNLean.MPS.MPDO.StackedLayers
-import TNLean.MPS.MPDO.AreaLaw
-import Mathlib.LinearAlgebra.Matrix.Permutation
 
 /-!
 # Shift matrix product unitaries
@@ -108,10 +109,7 @@ theorem rightShiftTensor_isMPU (d : ℕ) : IsMPU (rightShiftTensor d) := by
   intro N hN
   let : NeZero N := ⟨Nat.ne_of_gt (lt_trans Nat.zero_lt_one hN)⟩
   rw [mpo_rightShiftTensor]
-  rw [Matrix.mem_unitaryGroup_iff]
-  simp only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_permMatrix]
-  rw [← Matrix.permMatrix_mul]
-  simp
+  exact Equiv.Perm.permMatrix_mem_unitaryGroup (rotateConfig N d)
 
 /-- The adjoint tensor generates the left shift. -/
 def leftShiftTensor (d : ℕ) : MPOTensor d d :=

--- a/TNLean/MPS/MPU/Examples/ShiftTilde.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftTilde.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.Examples.Shift
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+import TNLean.MPS.MPU.Examples.Shift
 
 /-!
 # Swap-transformed shift matrix product unitaries
@@ -97,18 +97,18 @@ theorem shiftPhysicalSwap_mem_unitaryGroup (d : ℕ) :
   rw [← Matrix.permMatrix_mul]
   simp
 
-/-- The paper's transformed tensor $\widetilde{\mathcal U}_1=\mathcal U_1\mathbb S$,
-implemented by the exact local physical left action. -/
+/-- The transformed tensor generating
+$\widetilde U_1^{(N)} = \mathbb S^{\otimes N} U_1^{(N)}$. -/
 noncomputable def shiftExampleTildeU₁ (d : ℕ) : MPOTensor (d * d) 1 :=
   (shiftExampleU₁ d).ketLeftMul (shiftPhysicalSwap d)
 
-/-- The paper's transformed tensor $\widetilde{\mathcal U}_2=\mathcal U_2\mathbb S$,
-implemented by the exact local physical left action. -/
+/-- The transformed tensor generating
+$\widetilde U_2^{(N)} = \mathbb S^{\otimes N} U_2^{(N)}$. -/
 noncomputable def shiftExampleTildeU₂ (d : ℕ) : MPOTensor (d * d) (d * d) :=
   (shiftExampleU₂ d).ketLeftMul (shiftPhysicalSwap d)
 
-/-- The paper's transformed tensor $\widetilde{\mathcal U}_3=\mathcal U_3\mathbb S$,
-implemented by the exact local physical left action. -/
+/-- The transformed tensor generating
+$\widetilde U_3^{(N)} = \mathbb S^{\otimes N} U_3^{(N)}$. -/
 noncomputable def shiftExampleTildeU₃ (d : ℕ) : MPOTensor (d * d) (d * d) :=
   (shiftExampleU₃ d).ketLeftMul (shiftPhysicalSwap d)
 

--- a/TNLean/MPS/MPU/Examples/ShiftTilde.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftTilde.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.PermutationMatrixUnitary
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPU.KetLeftMul
 
 /-!
 # Swap-transformed shift matrix product unitaries
@@ -17,63 +19,9 @@ proves their exact finite-chain formulas, and proves that they remain MPUs.
 No symmetry-phase classification is asserted here.
 -/
 
-open scoped Matrix BigOperators Kronecker
+open scoped Matrix Kronecker
 
 namespace MPOTensor
-
-variable {d D : ℕ}
-
-private theorem trace_mul_evalWord_ketLeftMul_ofFn
-    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
-    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
-    Matrix.trace (X * evalWord (M.ketLeftMul P) (List.ofFn σ) (List.ofFn τ)) =
-      ∑ ρ : Fin N → Fin d, (∏ n : Fin N, P (σ n) (ρ n)) *
-        Matrix.trace (X * evalWord M (List.ofFn ρ) (List.ofFn τ)) := by
-  induction N generalizing X with
-  | zero => simp
-  | succ n ih =>
-      simp only [List.ofFn_succ, evalWord_cons, ketLeftMul]
-      rw [← Matrix.mul_assoc, Matrix.mul_sum, Finset.sum_mul, Matrix.trace_sum]
-      simp_rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
-      have reindex : ∀ F : (Fin (n + 1) → Fin d) → ℂ,
-          ∑ ρ, F ρ = ∑ k : Fin d, ∑ ρ' : Fin n → Fin d, F (Fin.cons k ρ') :=
-        fun F => by
-          rw [← Fintype.sum_prod_type']
-          exact ((Fin.consEquiv fun _ : Fin (n + 1) ↦ Fin d).sum_comp F).symm
-      rw [reindex]
-      simp only [Fin.cons_zero, Fin.cons_succ, Fin.prod_univ_succ]
-      apply Finset.sum_congr rfl
-      intro k _
-      rw [ih, Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro ρ _
-      rw [Matrix.mul_assoc]
-      ring
-
-/-- Applying a matrix to the ket leg at every site left-multiplies the closed
-MPO by its sitewise tensor power. -/
-theorem mpo_ketLeftMul (M : MPOTensor d D)
-    (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
-    mpo (M.ketLeftMul P) N = sitewisePhysicalMatrix P N * mpo M N := by
-  ext σ τ
-  simp only [Matrix.mul_apply, mpo_apply, mpoMatrixEntry, sitewisePhysicalMatrix]
-  simpa only [Matrix.one_mul] using
-    trace_mul_evalWord_ketLeftMul_ofFn M P (1 : Matrix (Fin D) (Fin D) ℂ) σ τ
-
-/-- Left multiplication by a one-site unitary preserves the MPU property. -/
-theorem IsMPU.ketLeftMul {M : MPOTensor d D} (hM : IsMPU M)
-    {P : Matrix (Fin d) (Fin d) ℂ}
-    (hP : P ∈ Matrix.unitaryGroup (Fin d) ℂ) :
-    IsMPU (M.ketLeftMul P) := by
-  intro N hN
-  rw [mpo_ketLeftMul]
-  apply (Matrix.unitaryGroup (Fin N → Fin d) ℂ).mul_mem
-  · rw [Matrix.mem_unitaryGroup_iff']
-    rw [Matrix.star_eq_conjTranspose,
-      sitewisePhysicalMatrix_isometry P]
-    rw [Matrix.mem_unitaryGroup_iff'] at hP
-    simpa only [Matrix.star_eq_conjTranspose] using hP
-  · exact hM.mpo_mem_unitaryGroup hN
 
 /-- The local physical swap on the two $d$-dimensional spins, in the flattened
 `Fin (d * d)` coordinates used by `MPOTensor`. -/
@@ -90,12 +38,8 @@ noncomputable def shiftPhysicalSwap (d : ℕ) :
 
 /-- The local physical swap is unitary. -/
 theorem shiftPhysicalSwap_mem_unitaryGroup (d : ℕ) :
-    shiftPhysicalSwap d ∈ Matrix.unitaryGroup (Fin (d * d)) ℂ := by
-  rw [Matrix.mem_unitaryGroup_iff]
-  simp only [shiftPhysicalSwap, Matrix.star_eq_conjTranspose,
-    Matrix.conjTranspose_permMatrix]
-  rw [← Matrix.permMatrix_mul]
-  simp
+    shiftPhysicalSwap d ∈ Matrix.unitaryGroup (Fin (d * d)) ℂ :=
+  Equiv.Perm.permMatrix_mem_unitaryGroup (bondPairSwapEquiv d)
 
 /-- The transformed tensor generating
 $\widetilde U_1^{(N)} = \mathbb S^{\otimes N} U_1^{(N)}$. -/

--- a/TNLean/MPS/MPU/Examples/ShiftTilde.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftTilde.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Examples.Shift
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+
+/-!
+# Swap-transformed shift matrix product unitaries
+
+The swap transformation in arXiv:1703.09188, equations `threeMPU2`
+(lines 2046--2062), multiplies every local physical operator on the left by
+the swap of the two spins. This file defines the three transformed tensors,
+proves their exact finite-chain formulas, and proves that they remain MPUs.
+
+No symmetry-phase classification is asserted here.
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+private theorem trace_mul_evalWord_ketLeftMul_ofFn
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
+    Matrix.trace (X * evalWord (M.ketLeftMul P) (List.ofFn σ) (List.ofFn τ)) =
+      ∑ ρ : Fin N → Fin d, (∏ n : Fin N, P (σ n) (ρ n)) *
+        Matrix.trace (X * evalWord M (List.ofFn ρ) (List.ofFn τ)) := by
+  induction N generalizing X with
+  | zero => simp
+  | succ n ih =>
+      simp only [List.ofFn_succ, evalWord_cons, ketLeftMul]
+      rw [← Matrix.mul_assoc, Matrix.mul_sum, Finset.sum_mul, Matrix.trace_sum]
+      simp_rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+      have reindex : ∀ F : (Fin (n + 1) → Fin d) → ℂ,
+          ∑ ρ, F ρ = ∑ k : Fin d, ∑ ρ' : Fin n → Fin d, F (Fin.cons k ρ') :=
+        fun F => by
+          rw [← Fintype.sum_prod_type']
+          exact ((Fin.consEquiv fun _ : Fin (n + 1) ↦ Fin d).sum_comp F).symm
+      rw [reindex]
+      simp only [Fin.cons_zero, Fin.cons_succ, Fin.prod_univ_succ]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [ih, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro ρ _
+      rw [Matrix.mul_assoc]
+      ring
+
+/-- Applying a matrix to the ket leg at every site left-multiplies the closed
+MPO by its sitewise tensor power. -/
+theorem mpo_ketLeftMul (M : MPOTensor d D)
+    (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
+    mpo (M.ketLeftMul P) N = sitewisePhysicalMatrix P N * mpo M N := by
+  ext σ τ
+  simp only [Matrix.mul_apply, mpo_apply, mpoMatrixEntry, sitewisePhysicalMatrix]
+  simpa only [Matrix.one_mul] using
+    trace_mul_evalWord_ketLeftMul_ofFn M P (1 : Matrix (Fin D) (Fin D) ℂ) σ τ
+
+/-- Left multiplication by a one-site unitary preserves the MPU property. -/
+theorem IsMPU.ketLeftMul {M : MPOTensor d D} (hM : IsMPU M)
+    {P : Matrix (Fin d) (Fin d) ℂ}
+    (hP : P ∈ Matrix.unitaryGroup (Fin d) ℂ) :
+    IsMPU (M.ketLeftMul P) := by
+  intro N hN
+  rw [mpo_ketLeftMul]
+  apply (Matrix.unitaryGroup (Fin N → Fin d) ℂ).mul_mem
+  · rw [Matrix.mem_unitaryGroup_iff']
+    rw [Matrix.star_eq_conjTranspose,
+      sitewisePhysicalMatrix_isometry P]
+    rw [Matrix.mem_unitaryGroup_iff'] at hP
+    simpa only [Matrix.star_eq_conjTranspose] using hP
+  · exact hM.mpo_mem_unitaryGroup hN
+
+/-- The local physical swap on the two $d$-dimensional spins, in the flattened
+`Fin (d * d)` coordinates used by `MPOTensor`. -/
+noncomputable def shiftPhysicalSwap (d : ℕ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  Equiv.Perm.permMatrix ℂ (bondPairSwapEquiv d)
+
+/-- The flattened local matrix exchanges the two spin coordinates. -/
+@[simp] theorem shiftPhysicalSwap_apply (d : ℕ) (i j k l : Fin d) :
+    shiftPhysicalSwap d (finProdFinEquiv (i, j)) (finProdFinEquiv (k, l)) =
+      if i = l ∧ j = k then 1 else 0 := by
+  simp [shiftPhysicalSwap, Equiv.Perm.permMatrix, PEquiv.toMatrix,
+    bondPairSwapEquiv_apply, bondPairSwap_finProdFinEquiv, and_comm]
+
+/-- The local physical swap is unitary. -/
+theorem shiftPhysicalSwap_mem_unitaryGroup (d : ℕ) :
+    shiftPhysicalSwap d ∈ Matrix.unitaryGroup (Fin (d * d)) ℂ := by
+  rw [Matrix.mem_unitaryGroup_iff]
+  simp only [shiftPhysicalSwap, Matrix.star_eq_conjTranspose,
+    Matrix.conjTranspose_permMatrix]
+  rw [← Matrix.permMatrix_mul]
+  simp
+
+/-- The paper's transformed tensor $\widetilde{\mathcal U}_1=\mathcal U_1\mathbb S$,
+implemented by the exact local physical left action. -/
+noncomputable def shiftExampleTildeU₁ (d : ℕ) : MPOTensor (d * d) 1 :=
+  (shiftExampleU₁ d).ketLeftMul (shiftPhysicalSwap d)
+
+/-- The paper's transformed tensor $\widetilde{\mathcal U}_2=\mathcal U_2\mathbb S$,
+implemented by the exact local physical left action. -/
+noncomputable def shiftExampleTildeU₂ (d : ℕ) : MPOTensor (d * d) (d * d) :=
+  (shiftExampleU₂ d).ketLeftMul (shiftPhysicalSwap d)
+
+/-- The paper's transformed tensor $\widetilde{\mathcal U}_3=\mathcal U_3\mathbb S$,
+implemented by the exact local physical left action. -/
+noncomputable def shiftExampleTildeU₃ (d : ℕ) : MPOTensor (d * d) (d * d) :=
+  (shiftExampleU₃ d).ketLeftMul (shiftPhysicalSwap d)
+
+/-- Exact all-chain formula for $\widetilde U_1^{(N)}=\mathbb S^{\otimes N}$. -/
+theorem mpo_shiftExampleTildeU₁ (d N : ℕ) :
+    mpo (shiftExampleTildeU₁ d) N = sitewisePhysicalMatrix (shiftPhysicalSwap d) N := by
+  rw [shiftExampleTildeU₁, mpo_ketLeftMul, mpo_shiftExampleU₁, Matrix.mul_one]
+
+/-- Exact all-chain formula for
+$\widetilde U_2^{(N)}=\mathbb S^{\otimes N}(T^{(N)\dagger}\otimes T^{(N)})$. -/
+theorem mpo_shiftExampleTildeU₂ (d N : ℕ) [NeZero N] :
+    mpo (shiftExampleTildeU₂ d) N =
+      sitewisePhysicalMatrix (shiftPhysicalSwap d) N *
+        Matrix.reindex (finTupleProdEquiv N d d).symm
+          (finTupleProdEquiv N d d).symm
+          ((Equiv.Perm.permMatrix ℂ (rotateConfig N d))ᴴ ⊗ₖ
+            Equiv.Perm.permMatrix ℂ (rotateConfig N d)) := by
+  rw [shiftExampleTildeU₂, mpo_ketLeftMul, mpo_shiftExampleU₂]
+
+/-- Exact all-chain formula for
+$\widetilde U_3^{(N)}=\mathbb S^{\otimes N}(T^{(N)}\otimes T^{(N)\dagger})$. -/
+theorem mpo_shiftExampleTildeU₃ (d N : ℕ) [NeZero N] :
+    mpo (shiftExampleTildeU₃ d) N =
+      sitewisePhysicalMatrix (shiftPhysicalSwap d) N *
+        Matrix.reindex (finTupleProdEquiv N d d).symm
+          (finTupleProdEquiv N d d).symm
+          (Equiv.Perm.permMatrix ℂ (rotateConfig N d) ⊗ₖ
+            (Equiv.Perm.permMatrix ℂ (rotateConfig N d))ᴴ) := by
+  rw [shiftExampleTildeU₃, mpo_ketLeftMul, mpo_shiftExampleU₃]
+
+/-- $\widetilde U_1$ is an MPU. -/
+theorem shiftExampleTildeU₁_isMPU (d : ℕ) : IsMPU (shiftExampleTildeU₁ d) :=
+  (shiftExampleU₁_isMPU d).ketLeftMul (shiftPhysicalSwap_mem_unitaryGroup d)
+
+/-- $\widetilde U_2$ is an MPU. -/
+theorem shiftExampleTildeU₂_isMPU (d : ℕ) : IsMPU (shiftExampleTildeU₂ d) :=
+  (shiftExampleU₂_isMPU d).ketLeftMul (shiftPhysicalSwap_mem_unitaryGroup d)
+
+/-- $\widetilde U_3$ is an MPU. -/
+theorem shiftExampleTildeU₃_isMPU (d : ℕ) : IsMPU (shiftExampleTildeU₃ d) :=
+  (shiftExampleU₃_isMPU d).ketLeftMul (shiftPhysicalSwap_mem_unitaryGroup d)
+
+end MPOTensor

--- a/TNLean/MPS/MPU/KetLeftMul.lean
+++ b/TNLean/MPS/MPU/KetLeftMul.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+import TNLean.MPS.MPU.Basic
+
+/-!
+# Matrix product unitaries under physical left actions
+
+A unitary acting on the ket leg of every local MPO matrix preserves the matrix product unitary
+property.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Left multiplication by a one-site unitary preserves the MPU property. -/
+theorem IsMPU.ketLeftMul {M : MPOTensor d D} (hM : IsMPU M)
+    {P : Matrix (Fin d) (Fin d) ℂ}
+    (hP : P ∈ Matrix.unitaryGroup (Fin d) ℂ) :
+    IsMPU (M.ketLeftMul P) := by
+  intro N hN
+  rw [mpo_ketLeftMul]
+  apply (Matrix.unitaryGroup (Fin N → Fin d) ℂ).mul_mem
+  · rw [Matrix.mem_unitaryGroup_iff']
+    rw [Matrix.star_eq_conjTranspose, sitewisePhysicalMatrix_isometry P]
+    rw [Matrix.mem_unitaryGroup_iff'] at hP
+    simpa only [Matrix.star_eq_conjTranspose] using hP
+  · exact hM.mpo_mem_unitaryGroup hN
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8330,10 +8330,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.shiftExampleTildeU₂}
     \lean{MPOTensor.shiftExampleTildeU₃}
     \leanok
-    \uses{threeMPU}
-    Let $\mathbb S$ exchange the two $d$-dimensional spins at one site.  The
-    transformed local tensors are obtained by applying $\mathbb S$ to the
-    output physical index of each of the three shift tensors.
+    \uses{threeMPU, def:mpu_physical_pair_swap}
+    Let $\mathbb S$ exchange the two $d$-dimensional spins at one site, with
+    matrix entries
+    \begin{align}
+        \mathbb S_{(p,q),(r,s)}=\delta_{p,s}\delta_{q,r}.
+    \end{align}
+    With the row index as the output physical index and the column index as the
+    input physical index, define
+    \begin{align}
+        \widetilde{\mathcal U}_a^{\,IJ}
+        =\sum_K\mathbb S_{IK}\mathcal U_a^{\,KJ},
+        \qquad a\in\{1,2,3\}.
+    \end{align}
+    Thus the swap acts on the output leg, and the corresponding closed operator
+    is left-multiplied by $\mathbb S^{\otimes N}$.
     % Source lines: paper_v2.tex 2045--2062.
 \end{definition}
 
@@ -8349,7 +8360,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.shiftExampleTildeU₂_isMPU}
     \lean{MPOTensor.shiftExampleTildeU₃_isMPU}
     \leanok
-    \uses{threeMPU, threeMPU2, thm:threeMPU_chain_formulas, def:mpu}
+    \uses{threeMPU2, thm:threeMPU_chain_formulas,
+        def:mpdo_sitewise_physical_matrix, def:mpu}
     On every nonempty chain,
     \begin{align}
         \widetilde U_1^{(N)} & =\mathbb S^{\otimes N}, \\
@@ -8363,7 +8375,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{threeMPU2, thm:threeMPU_chain_formulas, def:mpu}
+    \uses{threeMPU2, thm:threeMPU_chain_formulas,
+        def:mpdo_sitewise_physical_matrix, def:mpu}
     Applying a one-site matrix to every output physical index left-multiplies
     the closed operator by its sitewise tensor power.  The swap is a
     permutation matrix and hence unitary.  The formulas now follow from the
@@ -8374,7 +8387,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:threeMPU2_remaining_formulas}
     \notready
     \discussion{5715}
-    \uses{threeMPU2}
+    \uses{threeMPU2, thm:threeMPU2_chain_formulas, def:mpu_source_uv}
     The third transformed family also satisfies
     \begin{equation}
         \widetilde U_3^{(N)}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8377,22 +8377,35 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{proof}\leanok
     \uses{threeMPU2, thm:threeMPU_chain_formulas,
         def:mpdo_sitewise_physical_matrix, def:mpu}
-    Applying a one-site matrix to every output physical index left-multiplies
-    the closed operator by its sitewise tensor power.  The swap is a
-    permutation matrix and hence unitary.  The formulas now follow from the
-    three shift formulas, and the product of two unitary operators is unitary.
+    Acting by a one-site matrix $P$ on every output physical index gives
+    \begin{align}
+        \operatorname{MPO}_N(P\mathcal M)
+        =P^{\otimes N}\operatorname{MPO}_N(\mathcal M).
+    \end{align}
+    Substituting $P=\mathbb S$ and the three shift formulas gives the stated
+    identities. The swap is a permutation matrix and hence unitary. If
+    $\mathcal M$ is an MPU, then
+    \begin{align}
+        \bigl(P^{\otimes N}\operatorname{MPO}_N(\mathcal M)\bigr)^\dagger
+        \bigl(P^{\otimes N}\operatorname{MPO}_N(\mathcal M)\bigr)
+         & =\operatorname{MPO}_N(\mathcal M)^\dagger
+        (P^{\otimes N})^\dagger P^{\otimes N}
+        \operatorname{MPO}_N(\mathcal M)             \\
+         & =\Id.
+    \end{align}
+    Thus the sitewise left action preserves the MPU property.
 \end{proof}
 
-\begin{proposition}[Remaining swap-transformation identities]
-    \label{prop:threeMPU2_remaining_formulas}
+\begin{theorem}[Remaining swap-transformation identities]
+    \label{thm:threeMPU2_remaining_formulas}
     \notready
     \discussion{5715}
     \uses{threeMPU2, thm:threeMPU2_chain_formulas, def:mpu_source_uv}
     The third transformed family also satisfies
-    \begin{equation}
+    \begin{align}
         \widetilde U_3^{(N)}
         =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}.
-    \end{equation}
+    \end{align}
     The first two standard forms are
     \begin{align}
         \widetilde u_1 & =\mathbb S,     &
@@ -8401,7 +8414,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \widetilde v_2 & =\mathbb S.
     \end{align}
     % Source lines: paper_v2.tex 2059--2099.
-\end{proposition}
+\end{theorem}
 
 \begin{lemma}[Transformation with swaps and symmetry equivalence]
     \label{lemma:sym-trafo-swap}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8324,18 +8324,62 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Transformation with swaps]
     \label{threeMPU2}
-    \notready
-    \discussion{5715}
+    \lean{MPOTensor.shiftPhysicalSwap}
+    \lean{MPOTensor.shiftPhysicalSwap_apply}
+    \lean{MPOTensor.shiftExampleTildeU₁}
+    \lean{MPOTensor.shiftExampleTildeU₂}
+    \lean{MPOTensor.shiftExampleTildeU₃}
+    \leanok
     \uses{threeMPU}
-    Define
+    Let $\mathbb S$ exchange the two $d$-dimensional spins at one site.  The
+    transformed local tensors are obtained by applying $\mathbb S$ to the
+    output physical index of each of the three shift tensors.
+    % Source lines: paper_v2.tex 2045--2062.
+\end{definition}
+
+\begin{theorem}[Finite-chain formulas for the swap-transformed shifts]
+    \label{thm:threeMPU2_chain_formulas}
+    \lean{MPOTensor.mpo_ketLeftMul}
+    \lean{MPOTensor.IsMPU.ketLeftMul}
+    \lean{MPOTensor.shiftPhysicalSwap_mem_unitaryGroup}
+    \lean{MPOTensor.mpo_shiftExampleTildeU₁}
+    \lean{MPOTensor.mpo_shiftExampleTildeU₂}
+    \lean{MPOTensor.mpo_shiftExampleTildeU₃}
+    \lean{MPOTensor.shiftExampleTildeU₁_isMPU}
+    \lean{MPOTensor.shiftExampleTildeU₂_isMPU}
+    \lean{MPOTensor.shiftExampleTildeU₃_isMPU}
+    \leanok
+    \uses{threeMPU, threeMPU2, thm:threeMPU_chain_formulas, def:mpu}
+    On every nonempty chain,
     \begin{align}
         \widetilde U_1^{(N)} & =\mathbb S^{\otimes N}, \\
         \widetilde U_2^{(N)} & =\mathbb S^{\otimes N}
         (T^{(N)\dagger}\otimes T^{(N)}),               \\
         \widetilde U_3^{(N)} & =\mathbb S^{\otimes N}
-        (T^{(N)}\otimes T^{(N)\dagger})
-        =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}.
+        (T^{(N)}\otimes T^{(N)\dagger}).
     \end{align}
+    Each transformed tensor is a matrix product unitary.
+    % Source lines: paper_v2.tex 2052--2062.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{threeMPU2, thm:threeMPU_chain_formulas, def:mpu}
+    Applying a one-site matrix to every output physical index left-multiplies
+    the closed operator by its sitewise tensor power.  The swap is a
+    permutation matrix and hence unitary.  The formulas now follow from the
+    three shift formulas, and the product of two unitary operators is unitary.
+\end{proof}
+
+\begin{proposition}[Remaining swap-transformation identities]
+    \label{prop:threeMPU2_remaining_formulas}
+    \notready
+    \discussion{5715}
+    \uses{threeMPU2}
+    The third transformed family also satisfies
+    \begin{equation}
+        \widetilde U_3^{(N)}
+        =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}.
+    \end{equation}
     The first two standard forms are
     \begin{align}
         \widetilde u_1 & =\mathbb S,     &
@@ -8343,8 +8387,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \widetilde u_2 & =\Id\otimes\Id, &
         \widetilde v_2 & =\mathbb S.
     \end{align}
-    % Source lines: paper_v2.tex 2045--2099.
-\end{definition}
+    % Source lines: paper_v2.tex 2059--2099.
+\end{proposition}
 
 \begin{lemma}[Transformation with swaps and symmetry equivalence]
     \label{lemma:sym-trafo-swap}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,22 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### permutation-matrix unitarity — promoted
+- **Pattern:** unfold unitary-group membership, rewrite the conjugate transpose
+  of a permutation matrix as the inverse permutation matrix, and reduce their
+  product to the identity permutation.
+- **Seen:** three occurrences before promotion (2026-08-30):
+  `TNLean/MPS/MPU/Examples/Shift.lean` (`rightShiftTensor_isMPU`),
+  `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean`
+  (`permGL_mem_unitaryGroup`), and
+  `TNLean/MPS/MPU/Examples/ShiftTilde.lean`
+  (`shiftPhysicalSwap_mem_unitaryGroup`).
+- **Abstraction:** `Equiv.Perm.permMatrix_mem_unitaryGroup` in
+  `TNLean/Algebra/PermutationMatrixUnitary.lean`.
+- **Notes:** all three call sites now use the common theorem; the
+  fundamental-theorem consumer simplifies the coercion of `permGL` to its
+  underlying permutation matrix.
+
 ### non-injectivity from an annihilating linear functional — promoted
 - **Pattern:** exhibit a matrix outside the span of a finite Kraus family by
   running `Submodule.span_induction` over an entrywise linear condition


### PR DESCRIPTION
## What changed
- define the flattened local physical swap and the three source-faithful swap-transformed shift tensors
- prove the sitewise physical-left-action MPO formula, unitary closure, all three finite-chain formulas, and `IsMPU` instances
- export the module and synchronize the Chapter 28 Blueprint while leaving the unproved conjugacy and standard-form claims explicitly not ready

## Validation
- `lake build TNLean.MPS.MPU.Examples.ShiftTilde`
- `lake build TNLean.MPS.MPU.Examples`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration reverse Blueprint coverage: no misses
- `cd blueprint && leanblueprint checkdecls`
- Blueprint LaTeX formatting idempotence
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new module
- `git diff --check`

No full local build was run, as requested.

Closes #7467