### PR TITLE
feat(parent-hamiltonian): add martingale-difference resolution

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -66,6 +66,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
+import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
+import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
@@ -39,6 +40,8 @@ The thirteen components are:
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
   (quadratic form implies norm bound);
+* `Martingale.DifferenceProjections` — Nachtergaele's mutually orthogonal
+  martingale differences, telescoping resolution, and norm-square decomposition;
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.AdjacentLocalTerms` — individual three-site kernels and the

--- a/TNLean/MPS/ParentHamiltonian/Martingale/DifferenceProjections.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/DifferenceProjections.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Subspace
+import Mathlib.Analysis.InnerProductSpace.Symmetric
+
+/-!
+# Martingale differences of nested ground-space projections
+
+This file formalizes the projection resolution used in Nachtergaele's
+martingale method (cond-mat/9410110, equation (En) and the proof of Theorem
+2.1(i)). For a decreasing family of orthogonal ground-space projections
+\(G_n\), its martingale differences are
+
+\[
+E_n = G_n-G_{n+1}.
+\]
+
+Each \(E_n\) is an orthogonal projection, distinct differences are mutually
+orthogonal, and their finite sums telescope. With the source endpoint
+conventions \(G_0=\mathrm{id}\) and \(G_{N+1}=0\), the complete sum is the
+identity. If \(v\perp\operatorname{range}(G_N)\), the truncated resolution
+reconstructs \(v\) and gives the Pythagorean decomposition
+
+\[
+v=\sum_{n=0}^{N-1}E_nv,
+\qquad
+\lVert v\rVert^2=\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
+\]
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace FrustrationFree
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- A decreasing family of orthogonal projections, abstracting the nested
+finite-volume ground-space projections \(G_{\Lambda_n}\). -/
+structure NestedGroundProjections where
+  /-- The ground-space projection at level \(n\). -/
+  projection : ℕ → E →ₗ[ℂ] E
+  /-- Each ground-space operator is an orthogonal projection. -/
+  isSymmetricProjection : ∀ n, (projection n).IsSymmetricProjection
+  /-- Ground-space ranges decrease as the volume grows. -/
+  antitone_range : Antitone fun n ↦ LinearMap.range (projection n)
+
+namespace NestedGroundProjections
+
+variable (G : NestedGroundProjections (E := E))
+
+/-- Nachtergaele's martingale difference \(E_n=G_n-G_{n+1}\). -/
+def martingaleDifference (n : ℕ) : E →ₗ[ℂ] E :=
+  G.projection n - G.projection (n + 1)
+
+private theorem projection_comp_eq_of_le {m n : ℕ} (hmn : m ≤ n) :
+    (G.projection m).comp (G.projection n) = G.projection n :=
+  (LinearMap.IsIdempotentElem.comp_eq_right_iff
+    (G.isSymmetricProjection m).isIdempotentElem (G.projection n)).mpr
+      (G.antitone_range hmn)
+
+private theorem projection_comp_eq_of_ge {m n : ℕ} (hmn : m ≤ n) :
+    (G.projection n).comp (G.projection m) = G.projection n := by
+  ext x
+  apply ext_inner_left ℂ
+  intro y
+  calc
+    ⟪y, G.projection n (G.projection m x)⟫_ℂ =
+        ⟪G.projection n y, G.projection m x⟫_ℂ :=
+      ((G.isSymmetricProjection n).isSymmetric y (G.projection m x)).symm
+    _ = ⟪G.projection m (G.projection n y), x⟫_ℂ :=
+      ((G.isSymmetricProjection m).isSymmetric (G.projection n y) x).symm
+    _ = ⟪G.projection n y, x⟫_ℂ := by
+      rw [← LinearMap.comp_apply, G.projection_comp_eq_of_le hmn]
+    _ = ⟪y, G.projection n x⟫_ℂ :=
+      (G.isSymmetricProjection n).isSymmetric y x
+
+/-- A difference of two consecutive nested ground-space projections is itself
+an orthogonal projection. -/
+theorem martingaleDifference_isSymmetricProjection (n : ℕ) :
+    (G.martingaleDifference n).IsSymmetricProjection :=
+  (G.isSymmetricProjection (n + 1)).sub_of_range_le_range
+    (G.isSymmetricProjection n) (G.antitone_range (Nat.le_succ n))
+
+/-- Distinct martingale differences have zero product. This is the
+\(E_nE_m=0\) part of equation (En). -/
+theorem martingaleDifference_comp_eq_zero {m n : ℕ} (hmn : m ≠ n) :
+    (G.martingaleDifference m).comp (G.martingaleDifference n) = 0 := by
+  rcases lt_or_gt_of_ne hmn with hmn | hnm
+  · simp only [martingaleDifference, LinearMap.sub_comp, LinearMap.comp_sub]
+    rw [G.projection_comp_eq_of_le hmn.le,
+      G.projection_comp_eq_of_le (hmn.le.trans (Nat.le_succ n)),
+      G.projection_comp_eq_of_le hmn,
+      G.projection_comp_eq_of_le (Nat.succ_le_succ hmn.le)]
+    simp
+  · simp only [martingaleDifference, LinearMap.sub_comp, LinearMap.comp_sub]
+    rw [G.projection_comp_eq_of_ge hnm.le,
+      G.projection_comp_eq_of_ge hnm,
+      G.projection_comp_eq_of_ge (hnm.le.trans (Nat.le_succ m)),
+      G.projection_comp_eq_of_ge (Nat.succ_le_succ hnm.le)]
+    simp
+
+/-- The complete product rule
+\(E_nE_m=\delta_{n,m}E_n\) for martingale differences. -/
+theorem martingaleDifference_comp (m n : ℕ) :
+    (G.martingaleDifference m).comp (G.martingaleDifference n) =
+      if m = n then G.martingaleDifference m else 0 := by
+  split_ifs with hmn
+  · subst n
+    simpa [Module.End.mul_eq_comp] using
+      (G.martingaleDifference_isSymmetricProjection m).isIdempotentElem.eq
+  · exact G.martingaleDifference_comp_eq_zero hmn
+
+/-- Images under distinct martingale differences are orthogonal. -/
+theorem inner_martingaleDifference_eq_zero {m n : ℕ} (hmn : m ≠ n) (x y : E) :
+    ⟪G.martingaleDifference m x, G.martingaleDifference n y⟫_ℂ = 0 := by
+  rw [(G.martingaleDifference_isSymmetricProjection m).isSymmetric]
+  change ⟪x, ((G.martingaleDifference m).comp (G.martingaleDifference n)) y⟫_ℂ = 0
+  rw [G.martingaleDifference_comp_eq_zero hmn]
+  simp
+
+/-- The finite martingale-difference sum telescopes with both endpoints shown
+explicitly. -/
+theorem sum_martingaleDifference (N : ℕ) :
+    ∑ n ∈ Finset.range N, G.martingaleDifference n =
+      G.projection 0 - G.projection N := by
+  simpa [martingaleDifference] using Finset.sum_range_sub' G.projection N
+
+/-- Under the source conventions \(G_0=\mathrm{id}\) and \(G_{N+1}=0\),
+the martingale differences \(E_0,\ldots,E_N\) sum to the identity. -/
+theorem sum_martingaleDifference_eq_id (N : ℕ)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hfinal : G.projection (N + 1) = 0) :
+    ∑ n ∈ Finset.range (N + 1), G.martingaleDifference n = LinearMap.id := by
+  rw [G.sum_martingaleDifference, hzero, hfinal, sub_zero]
+
+/-- The squared norm of a finite martingale-difference sum is the sum of the
+squared norms of its terms. -/
+theorem norm_sq_sum_martingaleDifference (N : ℕ) (v : E) :
+    ‖∑ n ∈ Finset.range N, G.martingaleDifference n v‖ ^ 2 =
+      ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 := by
+  let V : (n : ℕ) →
+      LinearMap.range (G.martingaleDifference n) →ₗᵢ[ℂ] E :=
+    fun n ↦ (LinearMap.range (G.martingaleDifference n)).subtypeₗᵢ
+  have hV : OrthogonalFamily ℂ
+      (fun n : ℕ ↦ LinearMap.range (G.martingaleDifference n)) V := by
+    intro m n hmn x y
+    obtain ⟨x', hx⟩ := x.property
+    obtain ⟨y', hy⟩ := y.property
+    change ⟪(x : E), (y : E)⟫_ℂ = 0
+    rw [← hx, ← hy]
+    exact G.inner_martingaleDifference_eq_zero hmn x' y'
+  simpa [V] using hV.norm_sum
+    (fun n ↦ ⟨G.martingaleDifference n v, ⟨v, rfl⟩⟩) (Finset.range N)
+
+/-- A vector orthogonal to the final ground space is reconstructed by the
+truncated martingale-difference sum. This is `resolutionpsi` in the proof of
+Nachtergaele's Theorem 2.1(i). -/
+theorem sum_martingaleDifference_apply_of_mem_orthogonal (N : ℕ) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ) :
+    ∑ n ∈ Finset.range N, G.martingaleDifference n v = v := by
+  rw [(G.isSymmetricProjection N).isSymmetric.orthogonal_range] at hv
+  have hvzero : G.projection N v = 0 := LinearMap.mem_ker.mp hv
+  calc
+    ∑ n ∈ Finset.range N, G.martingaleDifference n v =
+        (∑ n ∈ Finset.range N, G.martingaleDifference n) v := by simp
+    _ = (G.projection 0 - G.projection N) v := by rw [G.sum_martingaleDifference]
+    _ = v := by simp [hzero, hvzero]
+
+/-- The Pythagorean norm-square decomposition `resolutionnormpsi` in the proof
+of Nachtergaele's Theorem 2.1(i). -/
+theorem norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal (N : ℕ) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ) :
+    ‖v‖ ^ 2 = ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 := by
+  calc
+    ‖v‖ ^ 2 = ‖∑ n ∈ Finset.range N, G.martingaleDifference n v‖ ^ 2 := by
+      rw [G.sum_martingaleDifference_apply_of_mem_orthogonal N v hzero hv]
+    _ = ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 :=
+      G.norm_sq_sum_martingaleDifference N v
+
+end NestedGroundProjections
+
+end FrustrationFree

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1,3 +1,134 @@
+\subsection{Nested ground projections and martingale differences}%
+\label{subsec:nested-ground-projection-differences}
+
+% Source: References/cond-mat_9410110/main.tex:1060--1073, equation En.
+% Source: References/cond-mat_9410110/main.tex:1195--1205,
+% Theorem 2.1(i), equations resolutionpsi and resolutionnormpsi.
+
+\begin{definition}[Nested ground projections and their martingale differences]%
+    \label{def:nested-ground-projection-differences}
+    \lean{FrustrationFree.NestedGroundProjections}
+    \lean{FrustrationFree.NestedGroundProjections.martingaleDifference}
+    \leanok
+    Let $\mathcal H$ be a complex Hilbert space.  A \emph{nested ground-projection
+    family} is a sequence $(G_n)_{n\geq0}$ of orthogonal projections such that
+    \begin{align}
+        m\leq n
+        \quad&\Longrightarrow\quad
+        \operatorname{ran}(G_n)\subseteq\operatorname{ran}(G_m).
+    \end{align}
+    Its $n$th martingale difference is
+    \begin{align}
+        E_n&=G_n-G_{n+1}.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Orthogonal martingale-difference resolution]%
+    \label{thm:orthogonal-martingale-difference-resolution}
+    \lean{FrustrationFree.NestedGroundProjections.martingaleDifference_isSymmetricProjection}
+    \lean{FrustrationFree.NestedGroundProjections.martingaleDifference_comp}
+    \lean{FrustrationFree.NestedGroundProjections.sum_martingaleDifference_eq_id}
+    \leanok
+    \uses{def:nested-ground-projection-differences}
+    Each $E_n$ is an orthogonal projection, and
+    \begin{align}
+        E_mE_n&=\delta_{m,n}E_m.
+    \end{align}
+    With Nachtergaele's endpoint conventions
+    $G_0=\mathbf 1$ and $G_{N+1}=0$, the differences form a complete family:
+    \begin{align}
+        \sum_{n=0}^{N}E_n&=\mathbf 1.
+    \end{align}
+    These are the assertions following the display labelled $E_n$ in
+    \cite{Nachtergaele1996Spectral}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:nested-ground-projection-differences}
+    If $m\leq n$, nestedness and orthogonality give
+    $G_mG_n=G_nG_m=G_n$.  Consequently,
+    \begin{align}
+        E_n^2
+        &=(G_n-G_{n+1})^2
+          =G_n-G_{n+1}=E_n,\\
+        E_mE_n&=0\qquad(m\ne n).
+    \end{align}
+    Self-adjointness follows from
+    $E_n^\dagger=G_n^\dagger-G_{n+1}^\dagger=E_n$.
+    The complete sum telescopes with both endpoints visible:
+    \begin{align}
+        \sum_{n=0}^{N}E_n
+        &=\sum_{n=0}^{N}(G_n-G_{n+1})
+          =G_0-G_{N+1}=\mathbf 1.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Truncated martingale-difference reconstruction]%
+    \label{thm:truncated-martingale-difference-reconstruction}
+    \lean{FrustrationFree.NestedGroundProjections.sum_martingaleDifference_apply_of_mem_orthogonal}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    Suppose $G_0=\mathbf 1$.  For every $v\perp\operatorname{ran}(G_N)$,
+    \begin{align}
+        v&=\sum_{n=0}^{N-1}E_nv.
+    \end{align}
+    This is the identity \textup{resolutionpsi} in the proof of
+    \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    Since $G_N$ is the orthogonal projection onto its range,
+    $v\perp\operatorname{ran}(G_N)$ implies $G_Nv=0$.  Hence
+    \begin{align}
+        \sum_{n=0}^{N-1}E_nv
+        &=(G_0-G_N)v=v.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Pythagorean identity for martingale differences]%
+    \label{thm:martingale-difference-pythagorean-identity}
+    \lean{FrustrationFree.NestedGroundProjections.norm_sq_sum_martingaleDifference}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    For every $v\in\mathcal H$ and $N\in\N$,
+    \begin{align}
+        \left\lVert\sum_{n=0}^{N-1}E_nv\right\rVert^2
+        &=\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    The summands are pairwise orthogonal because
+    $\langle E_mv,E_nv\rangle=\langle v,E_mE_nv\rangle=0$ for $m\ne n$.
+    The identity follows by the finite Pythagorean theorem.
+\end{proof}
+
+\begin{theorem}[Norm-square decomposition on the final orthogonal complement]%
+    \label{thm:martingale-difference-final-complement-norm-decomposition}
+    \lean{FrustrationFree.NestedGroundProjections.norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal}
+    \leanok
+    \uses{thm:truncated-martingale-difference-reconstruction, thm:martingale-difference-pythagorean-identity}
+    Suppose $G_0=\mathbf 1$.  For every $v\perp\operatorname{ran}(G_N)$,
+    \begin{align}
+        \lVert v\rVert^2
+        &=\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
+    \end{align}
+    This is the identity \textup{resolutionnormpsi} in the proof of
+    \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:truncated-martingale-difference-reconstruction, thm:martingale-difference-pythagorean-identity}
+    Substitute the truncated reconstruction
+    $v=\sum_{n=0}^{N-1}E_nv$ into the Pythagorean identity.
+\end{proof}
+
 \subsection{Spectator-indexed boundary maps}\label{subsec:spectator_boundary_maps}
 
 The tail and left boundary maps embed virtual-space data into a common

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -11,15 +11,15 @@
     \lean{FrustrationFree.NestedGroundProjections.martingaleDifference}
     \leanok
     Let $\mathcal H$ be a complex Hilbert space.  A \emph{nested ground-projection
-    family} is a sequence $(G_n)_{n\geq0}$ of orthogonal projections such that
+        family} is a sequence $(G_n)_{n\geq0}$ of orthogonal projections such that
     \begin{align}
         m\leq n
-        \quad&\Longrightarrow\quad
+        \quad & \Longrightarrow\quad
         \operatorname{ran}(G_n)\subseteq\operatorname{ran}(G_m).
     \end{align}
     Its $n$th martingale difference is
     \begin{align}
-        E_n&=G_n-G_{n+1}.
+        E_n & =G_n-G_{n+1}.
     \end{align}
 \end{definition}
 
@@ -32,12 +32,12 @@
     \uses{def:nested-ground-projection-differences}
     Each $E_n$ is an orthogonal projection, and
     \begin{align}
-        E_mE_n&=\delta_{m,n}E_m.
+        E_mE_n & =\delta_{m,n}E_m.
     \end{align}
     With Nachtergaele's endpoint conventions
     $G_0=\mathbf 1$ and $G_{N+1}=0$, the differences form a complete family:
     \begin{align}
-        \sum_{n=0}^{N}E_n&=\mathbf 1.
+        \sum_{n=0}^{N}E_n & =\mathbf 1.
     \end{align}
     These are the assertions following the display labelled $E_n$ in
     \cite{Nachtergaele1996Spectral}.
@@ -50,17 +50,17 @@
     $G_mG_n=G_nG_m=G_n$.  Consequently,
     \begin{align}
         E_n^2
-        &=(G_n-G_{n+1})^2
-          =G_n-G_{n+1}=E_n,\\
-        E_mE_n&=0\qquad(m\ne n).
+               & =(G_n-G_{n+1})^2
+        =G_n-G_{n+1}=E_n,          \\
+        E_mE_n & =0\qquad(m\ne n).
     \end{align}
     Self-adjointness follows from
     $E_n^\dagger=G_n^\dagger-G_{n+1}^\dagger=E_n$.
     The complete sum telescopes with both endpoints visible:
     \begin{align}
         \sum_{n=0}^{N}E_n
-        &=\sum_{n=0}^{N}(G_n-G_{n+1})
-          =G_0-G_{N+1}=\mathbf 1.
+         & =\sum_{n=0}^{N}(G_n-G_{n+1})
+        =G_0-G_{N+1}=\mathbf 1.
     \end{align}
 \end{proof}
 
@@ -71,7 +71,7 @@
     \uses{thm:orthogonal-martingale-difference-resolution}
     Suppose $G_0=\mathbf 1$.  For every $v\perp\operatorname{ran}(G_N)$,
     \begin{align}
-        v&=\sum_{n=0}^{N-1}E_nv.
+        v & =\sum_{n=0}^{N-1}E_nv.
     \end{align}
     This is the identity \textup{resolutionpsi} in the proof of
     \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}.
@@ -84,7 +84,7 @@
     $v\perp\operatorname{ran}(G_N)$ implies $G_Nv=0$.  Hence
     \begin{align}
         \sum_{n=0}^{N-1}E_nv
-        &=(G_0-G_N)v=v.
+         & =(G_0-G_N)v=v.
     \end{align}
 \end{proof}
 
@@ -96,7 +96,7 @@
     For every $v\in\mathcal H$ and $N\in\N$,
     \begin{align}
         \left\lVert\sum_{n=0}^{N-1}E_nv\right\rVert^2
-        &=\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
+         & =\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
     \end{align}
 \end{theorem}
 
@@ -116,7 +116,7 @@
     Suppose $G_0=\mathbf 1$.  For every $v\perp\operatorname{ran}(G_N)$,
     \begin{align}
         \lVert v\rVert^2
-        &=\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
+         & =\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
     \end{align}
     This is the identity \textup{resolutionnormpsi} in the proof of
     \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}.


### PR DESCRIPTION
## Summary

- define decreasing families of orthogonal ground-space projections and Nachtergaele's martingale differences $E_n=G_n-G_{n+1}$
- prove that each $E_n$ is an orthogonal projection and that $E_mE_n=\delta_{m,n}E_m$
- prove the telescoping identity, truncated vector reconstruction, and Pythagorean norm-square resolution used in Theorem 2.1(i)
- add formula-driven Chapter 13 coverage and expose the module through the martingale and parent-Hamiltonian aggregators

## Source

- `References/cond-mat_9410110/main.tex`, equation `En`, lines 1060-1073
- the proof of Theorem 2.1(i), `resolutionpsi` and `resolutionnormpsi`, lines 1195-1205

The proof uses the printed nested-filtration route. It does not use the cyclic anticommutator machinery.

## Verification

- exact-base targeted build of `TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections`
- prior full martingale and parent-Hamiltonian aggregator builds on the verified checkpoint
- generated import aggregators current
- Blueprint source synchronization recognizes all new entries
- proof-integrity and whitespace checks pass

Closes #7475
Related to #6411 and #7478
