### PR TITLE
feat(MPS/Core): prove boundary-dressed reduction uniqueness

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -26,6 +26,7 @@ import TNLean.MPS.Core.ReductionCrossMatrix
 import TNLean.MPS.Core.ReductionExistence
 import TNLean.MPS.Core.ReductionResidual
 import TNLean.MPS.Core.ReductionResidual.Basic
+import TNLean.MPS.Core.ReductionUniqueness
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.TensorProduct

--- a/TNLean/MPS/Core/ReductionUniqueness.lean
+++ b/TNLean/MPS/Core/ReductionUniqueness.lean
@@ -24,6 +24,18 @@ namespace MPSTensor
 
 variable {d D_A D_B : ℕ}
 
+private theorem mul_single_mul_apply {D : ℕ}
+    (P Q : Matrix (Fin D) (Fin D) ℂ) (i j a b : Fin D) :
+    (P * Matrix.single j a (1 : ℂ) * Q) i b = P i j * Q a b := by
+  rw [Matrix.mul_apply, Finset.sum_eq_single a]
+  · rw [Matrix.mul_single_apply_same]
+    simp
+  · intro k _ hka
+    rw [Matrix.mul_single_apply_of_ne (c := (1 : ℂ)) (i := j) (j := a)
+      (a := i) (b := k) hka]
+    simp
+  · simp
+
 private theorem exists_evalWord_ne_zero_of_isNBlkInjective
     {A : MPSTensor d D_A} {L : ℕ} (hD : D_A ≠ 0)
     (hA : Kraus.IsNBlkInjective A L) :
@@ -146,31 +158,9 @@ private theorem exists_cross_scalar
       (Matrix.single j a (1 : ℂ))) i) b
   let X := V * Kraus.evalWord B u * W'
   let Y := V * Kraus.evalWord B q * W'
-  have hleftEntry :
-      (X * Matrix.single j a (1 : ℂ) * Kraus.evalWord A q) i b =
-        X i j * Kraus.evalWord A q a b := by
-    rw [Matrix.mul_apply, Finset.sum_eq_single a]
-    · rw [Matrix.mul_single_apply_same]
-      simp
-    · intro k _ hka
-      rw [Matrix.mul_single_apply_of_ne (c := (1 : ℂ)) (i := j) (j := a)
-        (a := i) (b := k) hka]
-      simp
-    · simp
-  have hrightEntry :
-      (Kraus.evalWord A u * Matrix.single j a (1 : ℂ) * Y) i b =
-        Kraus.evalWord A u i j * Y a b := by
-    rw [Matrix.mul_apply, Finset.sum_eq_single a]
-    · rw [Matrix.mul_single_apply_same]
-      simp
-    · intro k _ hka
-      rw [Matrix.mul_single_apply_of_ne (c := (1 : ℂ)) (i := j) (j := a)
-        (a := i) (b := k) hka]
-      simp
-    · simp
   change (X * Matrix.single j a (1 : ℂ) * Kraus.evalWord A q) i b =
     (Kraus.evalWord A u * Matrix.single j a (1 : ℂ) * Y) i b at hsingle
-  rw [hleftEntry, hrightEntry] at hsingle
+  simp only [mul_single_mul_apply] at hsingle
   change X i j = z * Kraus.evalWord A u i j
   have hden : Kraus.evalWord A q a b ≠ 0 := by simpa [q] using hab
   dsimp [z]

--- a/TNLean/MPS/Core/ReductionUniqueness.lean
+++ b/TNLean/MPS/Core/ReductionUniqueness.lean
@@ -1,0 +1,367 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.Core.ReductionResidual
+
+/-!
+# Boundary-dressed uniqueness of rectangular reductions
+
+This file proves that two reductions from the same tensor to the same normal
+target agree up to a nonzero scalar after sufficiently long words.  The
+conclusion remains boundary-dressed: it does not cancel the source words to
+assert equalities between the rectangular boundary matrices themselves.
+
+Source: Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Theorem 22,
+`cornerproblem.tex` lines 3156--3162 and proof at lines 4007--4035.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D_A D_B : ℕ}
+
+private theorem exists_evalWord_ne_zero_of_isNBlkInjective
+    {A : MPSTensor d D_A} {L : ℕ} (hD : D_A ≠ 0)
+    (hA : Kraus.IsNBlkInjective A L) :
+    ∃ σ : Fin L → Fin d, Kraus.evalWord A (List.ofFn σ) ≠ 0 := by
+  classical
+  by_contra h
+  push Not at h
+  have hbot : Kraus.wordSpan A L = ⊥ := by
+    rw [Kraus.wordSpan]
+    apply le_antisymm
+    · rw [Submodule.span_le]
+      rintro X ⟨σ, rfl⟩
+      change Kraus.evalWord A (List.ofFn σ) ∈ (⊥ : Submodule ℂ _)
+      simp [h σ]
+    · exact bot_le
+  unfold Kraus.IsNBlkInjective at hA
+  rw [hbot] at hA
+  let a : Fin D_A := ⟨0, Nat.pos_of_ne_zero hD⟩
+  have hone : (1 : Matrix (Fin D_A) (Fin D_A) ℂ) ∈
+      (⊥ : Submodule ℂ (Matrix (Fin D_A) (Fin D_A) ℂ)) := by
+    rw [hA]
+    exact Submodule.mem_top
+  have honeZero : (1 : Matrix (Fin D_A) (Fin D_A) ℂ) = 0 := hone
+  have := congrFun (congrFun honeZero a) a
+  simp at this
+
+private theorem cross_mul_evalWord_mul_cross
+    {B : MPSTensor d D_B} {A : MPSTensor d D_A}
+    {V : Matrix (Fin D_A) (Fin D_B) ℂ} {W : Matrix (Fin D_B) (Fin D_A) ℂ}
+    {V' : Matrix (Fin D_A) (Fin D_B) ℂ} {W' : Matrix (Fin D_B) (Fin D_A) ℂ}
+    (h : IsReduction B A V W) (h' : IsReduction B A V' W') {N : ℕ}
+    (hBound : IsReductionResidualNilpotencyBound B A V W N)
+    (hBound' : IsReductionResidualNilpotencyBound B A V' W' N)
+    (p c q : List (Fin d)) (hc : c ≠ [])
+    (hp : N ≤ p.length + 1) (hq : N ≤ q.length + 1) :
+    (V * Kraus.evalWord B p * W') * Kraus.evalWord A c * Kraus.evalWord A q =
+      Kraus.evalWord A p * Kraus.evalWord A c *
+        (V * Kraus.evalWord B q * W') := by
+  have hext' :=
+    h'.evalWord_mul_reduced_exterior_eq_evalWord_append hBound' p c q hc hp hq
+  have hext := h.evalWord_mul_reduced_exterior_eq_evalWord_append hBound p c q hc hp hq
+  have hleft :
+      (V * Kraus.evalWord B p * W') * Kraus.evalWord A c * Kraus.evalWord A q =
+        V * Kraus.evalWord B (p ++ c ++ q) * W' := by
+    calc
+      _ = V * (Kraus.evalWord B p * W' * Kraus.evalWord A c * V' *
+          Kraus.evalWord B q) * W' := by
+        rw [← h'.evalWord q]
+        simp only [Matrix.mul_assoc]
+      _ = _ := congrArg (fun X ↦ V * X * W') hext'
+  have hright :
+      Kraus.evalWord A p * Kraus.evalWord A c *
+          (V * Kraus.evalWord B q * W') =
+        V * Kraus.evalWord B (p ++ c ++ q) * W' := by
+    calc
+      _ = V * (Kraus.evalWord B p * W * Kraus.evalWord A c * V *
+          Kraus.evalWord B q) * W' := by
+        rw [← h.evalWord p]
+        simp only [Matrix.mul_assoc]
+      _ = _ := congrArg (fun X ↦ V * X * W') hext
+  exact hleft.trans hright.symm
+
+private theorem cross_mul_matrix_mul_cross
+    {B : MPSTensor d D_B} {A : MPSTensor d D_A}
+    {V : Matrix (Fin D_A) (Fin D_B) ℂ} {W : Matrix (Fin D_B) (Fin D_A) ℂ}
+    {V' : Matrix (Fin D_A) (Fin D_B) ℂ} {W' : Matrix (Fin D_B) (Fin D_A) ℂ}
+    (h : IsReduction B A V W) (h' : IsReduction B A V' W') {N L : ℕ}
+    (hBound : IsReductionResidualNilpotencyBound B A V W N)
+    (hBound' : IsReductionResidualNilpotencyBound B A V' W' N)
+    (hLpos : 0 < L) (hA : Kraus.IsNBlkInjective A L)
+    (p q : List (Fin d)) (hp : N ≤ p.length + 1) (hq : N ≤ q.length + 1)
+    (M : Matrix (Fin D_A) (Fin D_A) ℂ) :
+    (V * Kraus.evalWord B p * W') * M * Kraus.evalWord A q =
+      Kraus.evalWord A p * M * (V * Kraus.evalWord B q * W') := by
+  have hmem : M ∈ Kraus.wordSpan A L := by rw [hA]; exact Submodule.mem_top
+  rw [Kraus.wordSpan] at hmem
+  induction hmem using Submodule.span_induction with
+  | mem M hM =>
+      obtain ⟨σ, rfl⟩ := hM
+      exact cross_mul_evalWord_mul_cross h h' hBound hBound' p (List.ofFn σ) q
+        (by simpa using hLpos.ne') hp hq
+  | zero => simp
+  | add X Y _ _ hX hY => simp only [Matrix.mul_add, Matrix.add_mul, hX, hY]
+  | smul c X _ hX =>
+      simp only [Matrix.mul_smul, Matrix.smul_mul, hX]
+
+private theorem exists_cross_scalar
+    {B : MPSTensor d D_B} {A : MPSTensor d D_A}
+    {V : Matrix (Fin D_A) (Fin D_B) ℂ} {W : Matrix (Fin D_B) (Fin D_A) ℂ}
+    {V' : Matrix (Fin D_A) (Fin D_B) ℂ} {W' : Matrix (Fin D_B) (Fin D_A) ℂ}
+    (hD : D_A ≠ 0) (hNormal : Kraus.IsNormal A)
+    (h : IsReduction B A V W) (h' : IsReduction B A V' W') {N : ℕ}
+    (hBound : IsReductionResidualNilpotencyBound B A V W N)
+    (hBound' : IsReductionResidualNilpotencyBound B A V' W' N) :
+    ∃ z : ℂ, ∀ u : List (Fin d), N ≤ u.length + 1 →
+      V * Kraus.evalWord B u * W' = z • Kraus.evalWord A u := by
+  classical
+  obtain ⟨L, hLpos, hL⟩ := hNormal
+  let m := N + 1
+  have hm : 0 < m := by simp [m]
+  have hK := isNBlkInjective_mul_of_isNBlkInjective A hm hL
+  obtain ⟨σ, hσ⟩ := exists_evalWord_ne_zero_of_isNBlkInjective hD hK
+  have hab : ∃ a b, Kraus.evalWord A (List.ofFn σ) a b ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    apply hσ
+    ext a b
+    exact hall a b
+  obtain ⟨a, b, hab⟩ := hab
+  let q := List.ofFn σ
+  have hq : N ≤ q.length + 1 := by
+    simp only [q, List.length_ofFn]
+    dsimp [m]
+    nlinarith
+  let z := (V * Kraus.evalWord B q * W') a b / Kraus.evalWord A q a b
+  refine ⟨z, fun u hu ↦ ?_⟩
+  ext i j
+  have hsingle := congrFun (congrFun
+    (cross_mul_matrix_mul_cross h h' hBound hBound' hLpos hL u q hu hq
+      (Matrix.single j a (1 : ℂ))) i) b
+  let X := V * Kraus.evalWord B u * W'
+  let Y := V * Kraus.evalWord B q * W'
+  have hleftEntry :
+      (X * Matrix.single j a (1 : ℂ) * Kraus.evalWord A q) i b =
+        X i j * Kraus.evalWord A q a b := by
+    rw [Matrix.mul_apply, Finset.sum_eq_single a]
+    · rw [Matrix.mul_single_apply_same]
+      simp
+    · intro k _ hka
+      rw [Matrix.mul_single_apply_of_ne (c := (1 : ℂ)) (i := j) (j := a)
+        (a := i) (b := k) hka]
+      simp
+    · simp
+  have hrightEntry :
+      (Kraus.evalWord A u * Matrix.single j a (1 : ℂ) * Y) i b =
+        Kraus.evalWord A u i j * Y a b := by
+    rw [Matrix.mul_apply, Finset.sum_eq_single a]
+    · rw [Matrix.mul_single_apply_same]
+      simp
+    · intro k _ hka
+      rw [Matrix.mul_single_apply_of_ne (c := (1 : ℂ)) (i := j) (j := a)
+        (a := i) (b := k) hka]
+      simp
+    · simp
+  change (X * Matrix.single j a (1 : ℂ) * Kraus.evalWord A q) i b =
+    (Kraus.evalWord A u * Matrix.single j a (1 : ℂ) * Y) i b at hsingle
+  rw [hleftEntry, hrightEntry] at hsingle
+  change X i j = z * Kraus.evalWord A u i j
+  have hden : Kraus.evalWord A q a b ≠ 0 := by simpa [q] using hab
+  dsimp [z]
+  change X i j = (Y a b / Kraus.evalWord A q a b) * Kraus.evalWord A u i j
+  rw [div_mul_eq_mul_div]
+  apply (eq_div_iff hden).2
+  simpa only [mul_comm] using hsingle
+
+namespace IsReduction
+
+variable {B : MPSTensor d D_B} {A : MPSTensor d D_A}
+  {V : Matrix (Fin D_A) (Fin D_B) ℂ} {W : Matrix (Fin D_B) (Fin D_A) ℂ}
+  {V' : Matrix (Fin D_A) (Fin D_B) ℂ} {W' : Matrix (Fin D_B) (Fin D_A) ℂ}
+
+/-- Two reductions to the same normal tensor are uniquely proportional after
+words longer than twice a common residual nilpotency bound.  Both conclusions
+retain the source word next to the rectangular boundary, as in MGSC18
+Theorem 22; no bare equality between boundary matrices is asserted.
+
+Source: Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Theorem 22,
+`cornerproblem.tex` lines 3156--3162 and 4007--4035. -/
+theorem exists_boundary_dressed_proportional
+    (h : IsReduction B A V W) (h' : IsReduction B A V' W')
+    (hNormal : Kraus.IsNormal A) {N₀ : ℕ}
+    (hBound : IsReductionResidualNilpotencyBound B A V W N₀)
+    (hBound' : IsReductionResidualNilpotencyBound B A V' W' N₀) :
+    ∃ z : ℂ, z ≠ 0 ∧ ∀ w : List (Fin d), 2 * N₀ < w.length →
+      V * Kraus.evalWord B w = z • (V' * Kraus.evalWord B w) ∧
+        Kraus.evalWord B w * W = z⁻¹ • (Kraus.evalWord B w * W') := by
+  classical
+  by_cases hD : D_A = 0
+  · subst D_A
+    refine ⟨1, one_ne_zero, fun w _ ↦ ?_⟩
+    constructor
+    · ext i
+      exact Fin.elim0 i
+    · ext i j
+      exact Fin.elim0 j
+  obtain ⟨z, hz⟩ := exists_cross_scalar hD hNormal h h' hBound hBound'
+  obtain ⟨μ, hμ⟩ := exists_cross_scalar hD hNormal h' h hBound' hBound
+  have hzμ : z * μ = 1 := by
+    obtain ⟨L, hLpos, hL⟩ := hNormal
+    let m := N₀ + 1
+    have hm : 0 < m := by simp [m]
+    have htotal := isNBlkInjective_mul_of_isNBlkInjective A
+      (show 0 < 2 * m + 1 by omega) hL
+    obtain ⟨σ, hσ⟩ := exists_evalWord_ne_zero_of_isNBlkInjective hD htotal
+    let word := List.ofFn σ
+    let p := word.take (m * L)
+    let r := word.drop (m * L)
+    let c := r.take L
+    let q := r.drop L
+    have hsplit : p ++ c ++ q = word := by
+      simp only [p, c, q, r, List.take_append_drop, List.append_assoc]
+    have htotalLen : (2 * m + 1) * L = m * L + (m + 1) * L := by ring
+    have hpLen : p.length = m * L := by
+      simp [p, word, List.length_take, htotalLen]
+    have hrLen : r.length = (m + 1) * L := by
+      simp [r, word, List.length_drop, htotalLen]
+    have hcLen : c.length = L := by simp [c, hrLen, hLpos]
+    have hqLen : q.length = m * L := by simp [q, hrLen, Nat.add_mul]
+    have hp : N₀ ≤ p.length + 1 := by rw [hpLen]; dsimp [m]; nlinarith
+    have hq : N₀ ≤ q.length + 1 := by rw [hqLen]; dsimp [m]; nlinarith
+    have hc : c ≠ [] := by
+      intro hc0
+      rw [hc0] at hcLen
+      simp at hcLen
+      omega
+    have hext := h'.evalWord_mul_reduced_exterior_eq_evalWord_append
+      hBound' p c q hc hp hq
+    have hpCross : V * Kraus.evalWord B p * W' = z • Kraus.evalWord A p := hz p hp
+    have hqCross : V' * Kraus.evalWord B q * W = μ • Kraus.evalWord A q := hμ q hq
+    have hword : Kraus.evalWord A (p ++ c ++ q) ≠ 0 := by
+      simpa [hsplit, word] using hσ
+    have hscalar : (z * μ) • Kraus.evalWord A (p ++ c ++ q) =
+        Kraus.evalWord A (p ++ c ++ q) := by
+      calc
+        _ = (z • Kraus.evalWord A p) * Kraus.evalWord A c *
+              (μ • Kraus.evalWord A q) := by
+            simp only [Kraus.evalWord_append, Matrix.smul_mul, Matrix.mul_smul,
+              smul_smul, Matrix.mul_assoc]
+            rw [mul_comm μ z]
+        _ = (V * Kraus.evalWord B p * W') * Kraus.evalWord A c *
+              (V' * Kraus.evalWord B q * W) := by rw [hpCross, hqCross]
+        _ = V * (Kraus.evalWord B p * W' * Kraus.evalWord A c * V' *
+              Kraus.evalWord B q) * W := by simp only [Matrix.mul_assoc]
+        _ = V * Kraus.evalWord B (p ++ c ++ q) * W :=
+          congrArg (fun X ↦ V * X * W) hext
+        _ = _ := h.evalWord (p ++ c ++ q)
+    by_contra hne
+    apply hword
+    have : (z * μ - 1) • Kraus.evalWord A (p ++ c ++ q) = 0 := by
+      rw [sub_smul, one_smul, hscalar, sub_self]
+    exact (smul_eq_zero.mp this).resolve_left (sub_ne_zero.mpr hne)
+  have hzne : z ≠ 0 := by
+    intro hzero
+    simp [hzero] at hzμ
+  refine ⟨z, hzne, fun w hw ↦ ?_⟩
+  let p := w.take N₀
+  let r := w.drop N₀
+  let c := r.take (r.length - N₀)
+  let q := r.drop (r.length - N₀)
+  have hpLen : p.length = N₀ := by simp [p, List.length_take]; omega
+  have hrLen : r.length = w.length - N₀ := by simp [r, List.length_drop]
+  have hcLen : c.length = w.length - 2 * N₀ := by
+    simp [c, hrLen, List.length_take]
+    omega
+  have hqLen : q.length = N₀ := by
+    simp [q, hrLen]
+    omega
+  have hsplit : p ++ c ++ q = w := by
+    simp only [p, r, c, q, List.take_append_drop, List.append_assoc]
+  have hc : c ≠ [] := by
+    intro hc0
+    rw [hc0] at hcLen
+    simp at hcLen
+    omega
+  have hp : N₀ ≤ p.length + 1 := by omega
+  have hq : N₀ ≤ q.length + 1 := by omega
+  have hext := h'.evalWord_mul_reduced_exterior_eq_evalWord_append
+    hBound' p c q hc hp hq
+  have hext' := h.evalWord_mul_reduced_exterior_eq_evalWord_append
+    hBound p c q hc hp hq
+  constructor
+  · have hpCross : V * Kraus.evalWord B p * W' =
+        z • Kraus.evalWord A p := hz p hp
+    have hleft : V * Kraus.evalWord B w =
+        z • (Kraus.evalWord A p * Kraus.evalWord A c * V' *
+          Kraus.evalWord B q) := by
+      calc
+        _ = V * (Kraus.evalWord B p * W' * Kraus.evalWord A c * V' *
+              Kraus.evalWord B q) := by rw [← hsplit, ← hext]
+        _ = (V * Kraus.evalWord B p * W') * Kraus.evalWord A c * V' *
+              Kraus.evalWord B q := by simp only [Matrix.mul_assoc]
+        _ = _ := by rw [hpCross]; simp only [Matrix.smul_mul, Matrix.mul_assoc]
+    have hright : V' * Kraus.evalWord B w =
+        Kraus.evalWord A p * Kraus.evalWord A c * V' * Kraus.evalWord B q := by
+      calc
+        _ = V' * (Kraus.evalWord B p * W' * Kraus.evalWord A c * V' *
+              Kraus.evalWord B q) := by rw [← hsplit, ← hext]
+        _ = _ := by
+          rw [← h'.evalWord p]
+          simp only [Matrix.mul_assoc]
+    rw [hleft, hright]
+  · have hqCross : V * Kraus.evalWord B q * W' =
+        z • Kraus.evalWord A q := hz q hq
+    have hforward : Kraus.evalWord B w * W' =
+        z • (Kraus.evalWord B w * W) := by
+      calc
+        _ = (Kraus.evalWord B p * W * Kraus.evalWord A c * V *
+              Kraus.evalWord B q) * W' := by rw [← hsplit, ← hext']
+        _ = Kraus.evalWord B p * W * Kraus.evalWord A c *
+              (V * Kraus.evalWord B q * W') := by simp only [Matrix.mul_assoc]
+        _ = z • (Kraus.evalWord B p * W * Kraus.evalWord A c *
+              Kraus.evalWord A q) := by rw [hqCross]; simp only [Matrix.mul_smul]
+        _ = z • ((Kraus.evalWord B p * W * Kraus.evalWord A c * V *
+              Kraus.evalWord B q) * W) := by
+          congr 1
+          rw [← h.evalWord q]
+          simp only [Matrix.mul_assoc]
+        _ = _ := by rw [hext', hsplit]
+    calc
+      Kraus.evalWord B w * W = z⁻¹ • (z • (Kraus.evalWord B w * W)) := by
+        rw [smul_smul, inv_mul_cancel₀ hzne, one_smul]
+      _ = z⁻¹ • (Kraus.evalWord B w * W') := by rw [hforward]
+
+/-- Source-form boundary-dressed uniqueness, phrased using the least residual
+nilpotency lengths of the two selected reductions.  Positive-length MPV
+equality ensures that each least length is an actual bound; the two supplied
+inequalities then promote those bounds to the common threshold `N₀`.
+
+Source: Molnár--Ge--Schuch--Cirac, arXiv:1706.07329v2, Theorem 22,
+`cornerproblem.tex` lines 3156--3162 and 4007--4035. -/
+theorem exists_boundary_dressed_proportional_of_nilpotencyLength_le
+    (h : IsReduction B A V W) (h' : IsReduction B A V' W')
+    (hNormal : Kraus.IsNormal A) (hSame : SameMPV₂Pos B A) {N₀ : ℕ}
+    (hLength : reductionResidualNilpotencyLength B A V W ≤ N₀)
+    (hLength' : reductionResidualNilpotencyLength B A V' W' ≤ N₀) :
+    ∃ z : ℂ, z ≠ 0 ∧ ∀ w : List (Fin d), 2 * N₀ < w.length →
+      V * Kraus.evalWord B w = z • (V' * Kraus.evalWord B w) ∧
+        Kraus.evalWord B w * W = z⁻¹ • (Kraus.evalWord B w * W') := by
+  have hBound : IsReductionResidualNilpotencyBound B A V W N₀ := by
+    intro w hw
+    exact evalWord_reductionResidual_eq_zero_of_bound_le_length
+      (h.reductionResidualNilpotencyLength_isBound hSame) w (by simpa [hw] using hLength)
+  have hBound' : IsReductionResidualNilpotencyBound B A V' W' N₀ := by
+    intro w hw
+    exact evalWord_reductionResidual_eq_zero_of_bound_le_length
+      (h'.reductionResidualNilpotencyLength_isBound hSame) w (by simpa [hw] using hLength')
+  exact h.exists_boundary_dressed_proportional h' hNormal hBound hBound'
+
+end IsReduction
+
+end MPSTensor

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -1595,7 +1595,8 @@ $A^{-1}A=\Id$. This is the identity used in
     \uses{thm:mps_rectangular_reduction_identities,
         thm:mps_reduction_residual_dimension_bound,
         thm:mps_reduction_residual_bound_consequences,
-        thm:mps_reduction_exterior_buffer, def:l_blk_injective}
+        thm:mps_reduction_exterior_buffer, def:l_blk_injective,
+        thm:exact_block_injectivity_positive_multiple}
     If the target bond dimension is zero, both dressed identities hold
     entrywise for $\lambda=1$ because the relevant target row or column index is
     empty.  Hence assume that the target bond dimension is positive.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -1555,16 +1555,12 @@ $A^{-1}A=\Id$. This is the identity used in
     \discussion{7395}
     \uses{def:same_mpv2_pos, def:mps_rectangular_reduction,
         def:mps_reduction_residual_nilpotency_length, def:normal}
-    Let $A$ be normal, let $B$ have the same positive-length closed-chain
-    coefficients as $A$, and let $(V,W)$ and
-    $(\widetilde V,\widetilde W)$ be two reductions from $B$ to $A$.  Suppose
-    that, for some $N_0\in\mathbb N$,
-    \begin{align}
-        \ell(B,A;V,W) & \leq N_0,
-          & \ell(B,A;\widetilde V,\widetilde W) & \leq N_0.
-        \label{eq:mps_reduction_boundary_dressed_bounds}
-    \end{align}
-    Then there exists a single scalar $\lambda\in\C$ with $\lambda\ne0$ such
+    Let $A$ be normal, let $B$ have the same physical alphabet, and let
+    $(V,W)$ and $(\widetilde V,\widetilde W)$ be two reductions from $B$ to
+    $A$.  Suppose that $N_0\in\mathbb N$ is a residual-word nilpotency bound
+    for both reductions: every word of length $N_0$ in either residual tensor
+    vanishes.  Then there exists a single scalar $\lambda\in\C$ with
+    $\lambda\ne0$ such
     that, for every word $\mathbf a$ satisfying
     \begin{align}
         |\mathbf a| & > 2N_0,
@@ -1579,9 +1575,10 @@ $A^{-1}A=\Id$. This is the identity used in
          & =\lambda^{-1}B^{\mathbf a}\widetilde W.
         \label{eq:mps_reduction_boundary_dressed_right}
     \end{align}
-    More generally, the same conclusion holds when $N_0$ is directly assumed
-    to be a residual-word nilpotency bound for both reductions; that bound-form
-    statement requires no equality of closed-chain coefficients.
+    If $A$ and $B$ have the same positive-length closed-chain coefficients and
+    the two least residual nilpotency lengths are at most $N_0$, then $N_0$ is
+    such a common bound and the same conclusion follows.  The direct-bound
+    statement itself requires no equality of closed-chain coefficients.
 
     These are boundary-dressed identities: they do not assert the bare matrix
     equalities $V=\lambda\widetilde V$ or
@@ -1602,11 +1599,6 @@ $A^{-1}A=\Id$. This is the identity used in
     If the target bond dimension is zero, both dressed identities hold
     entrywise for $\lambda=1$ because the relevant target row or column index is
     empty.  Hence assume that the target bond dimension is positive.
-
-    First replace the two least-length inequalities by common residual-word
-    bounds at $N_0$: the least lengths are actual bounds under the
-    positive-length closed-chain equality, and prefix factorization propagates
-    vanishing to every larger length.
 
     Choose $L>0$ such that $A$ is $L$-block injective.  For exterior words
     $\mathbf p,\mathbf q$ satisfying the $N_0$ buffer inequalities, compare the
@@ -1638,6 +1630,11 @@ $A^{-1}A=\Id$. This is the identity used in
     $B^{\mathbf a}\widetilde W=\lambda B^{\mathbf a}W$ on the right.
     Multiplication by $\lambda^{-1}$ yields
     (\ref{eq:mps_reduction_boundary_dressed_right}).
+
+    For the least-length corollary, positive-length closed-chain equality makes
+    each least residual nilpotency length an actual bound.  Prefix
+    factorization propagates vanishing from that least length to $N_0$, so the
+    direct-bound theorem applies.
 \end{proof}
 
 \begin{lemma}[Gauge invariance of block injectivity]

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -1547,6 +1547,91 @@ $A^{-1}A=\Id$. This is the identity used in
     (\ref{eq:mps_reduction_exterior_buffer}).
 \end{proof}
 
+\begin{theorem}[Boundary-dressed uniqueness of rectangular reductions]
+    \label{thm:mps_reduction_boundary_dressed_uniqueness}
+    \lean{MPSTensor.IsReduction.exists_boundary_dressed_proportional,
+        MPSTensor.IsReduction.exists_boundary_dressed_proportional_of_nilpotencyLength_le}
+    \leanok
+    \discussion{7395}
+    \uses{def:same_mpv2_pos, def:mps_rectangular_reduction,
+        def:mps_reduction_residual_nilpotency_length, def:normal}
+    Let $A$ be normal, let $B$ have the same positive-length closed-chain
+    coefficients as $A$, and let $(V,W)$ and
+    $(\widetilde V,\widetilde W)$ be two reductions from $B$ to $A$.  Suppose
+    that, for some $N_0\in\mathbb N$,
+    \begin{align}
+        \ell(B,A;V,W) & \leq N_0,
+          & \ell(B,A;\widetilde V,\widetilde W) & \leq N_0.
+        \label{eq:mps_reduction_boundary_dressed_bounds}
+    \end{align}
+    Then there exists a single scalar $\lambda\in\C$ with $\lambda\ne0$ such
+    that, for every word $\mathbf a$ satisfying
+    \begin{align}
+        |\mathbf a| & > 2N_0,
+        \label{eq:mps_reduction_boundary_dressed_length}
+    \end{align}
+    one has
+    \begin{align}
+        VB^{\mathbf a}
+         & =\lambda\,\widetilde V B^{\mathbf a},
+        \label{eq:mps_reduction_boundary_dressed_left}\\
+        B^{\mathbf a}W
+         & =\lambda^{-1}B^{\mathbf a}\widetilde W.
+        \label{eq:mps_reduction_boundary_dressed_right}
+    \end{align}
+    These are boundary-dressed identities: they do not assert the bare matrix
+    equalities $V=\lambda\widetilde V$ or
+    $W=\lambda^{-1}\widetilde W$.
+
+    This is Theorem~22 of \cite{Molnar2018SemiInjective}, stated in
+    \texttt{cornerproblem.tex} lines 3156--3162 and proved at lines 4007--4035.
+    We retain the printed strict inequality $|\mathbf a|>2N_0$; the non-strict
+    endpoint appearing later in the source proof is not claimed here.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mps_rectangular_reduction_identities,
+        thm:mps_reduction_residual_dimension_bound,
+        thm:mps_reduction_residual_bound_consequences,
+        thm:mps_reduction_exterior_buffer, def:l_blk_injective}
+    First replace the two least-length inequalities by common residual-word
+    bounds at $N_0$: the least lengths are actual bounds under the
+    positive-length closed-chain equality, and prefix factorization propagates
+    vanishing to every larger length.
+
+    Choose $L>0$ such that $A$ is $L$-block injective.  For exterior words
+    $\mathbf p,\mathbf q$ satisfying the $N_0$ buffer inequalities, compare the
+    two exterior-buffer expansions of the mixed contraction
+    $VB^{\mathbf p}\widetilde W$.  Inserting a nonempty central $A$-word gives
+    \begin{align}
+        (VB^{\mathbf p}\widetilde W)A^{\mathbf c}A^{\mathbf q}
+         =A^{\mathbf p}A^{\mathbf c}(VB^{\mathbf q}\widetilde W).
+        \notag
+    \end{align}
+    Since the length-$L$ words span the full target matrix algebra, linearity
+    replaces $A^{\mathbf c}$ by an arbitrary matrix.  Insert matrix units and
+    choose a nonzero target word at a positive multiple of $L$.  Entrywise
+    cancellation then yields one scalar $\lambda$ with
+    $VB^{\mathbf p}\widetilde W=\lambda A^{\mathbf p}$ for every sufficiently
+    buffered $\mathbf p$.  Reversing the two reductions gives a scalar $\mu$
+    for the opposite mixed boundary.
+
+    Choose a longer nonzero target word, split it into two buffered exterior
+    pieces and a nonempty injective central block, and apply the exterior-buffer
+    identity once more.  The two mixed-boundary formulas give
+    $(\lambda\mu)A^{\mathbf a}=A^{\mathbf a}$; nonvanishing of the chosen word
+    implies $\lambda\mu=1$, so in particular $\lambda\ne0$.
+
+    Finally, if $|\mathbf a|>2N_0$, split $\mathbf a$ into exterior words of
+    length $N_0$ and a nonempty center.  Substitution of the two mixed-boundary
+    formulas into the corresponding exterior-buffer identities gives
+    (\ref{eq:mps_reduction_boundary_dressed_left}) and first gives
+    $B^{\mathbf a}\widetilde W=\lambda B^{\mathbf a}W$ on the right.
+    Multiplication by $\lambda^{-1}$ yields
+    (\ref{eq:mps_reduction_boundary_dressed_right}).
+\end{proof}
+
 \begin{lemma}[Gauge invariance of block injectivity]
     \label{lem:gauge_invariance_block_injective}
     \lean{MPSTensor.isNBlkInjective_of_gaugeEquiv}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -1579,6 +1579,10 @@ $A^{-1}A=\Id$. This is the identity used in
          & =\lambda^{-1}B^{\mathbf a}\widetilde W.
         \label{eq:mps_reduction_boundary_dressed_right}
     \end{align}
+    More generally, the same conclusion holds when $N_0$ is directly assumed
+    to be a residual-word nilpotency bound for both reductions; that bound-form
+    statement requires no equality of closed-chain coefficients.
+
     These are boundary-dressed identities: they do not assert the bare matrix
     equalities $V=\lambda\widetilde V$ or
     $W=\lambda^{-1}\widetilde W$.
@@ -1595,6 +1599,10 @@ $A^{-1}A=\Id$. This is the identity used in
         thm:mps_reduction_residual_dimension_bound,
         thm:mps_reduction_residual_bound_consequences,
         thm:mps_reduction_exterior_buffer, def:l_blk_injective}
+    If the target bond dimension is zero, both dressed identities hold
+    entrywise for $\lambda=1$ because the relevant target row or column index is
+    empty.  Hence assume that the target bond dimension is positive.
+
     First replace the two least-length inequalities by common residual-word
     bounds at $N_0$: the least lengths are actual bounds under the
     positive-length closed-chain equality, and prefix factorization propagates

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -1570,7 +1570,7 @@ $A^{-1}A=\Id$. This is the identity used in
     \begin{align}
         VB^{\mathbf a}
          & =\lambda\,\widetilde V B^{\mathbf a},
-        \label{eq:mps_reduction_boundary_dressed_left}\\
+        \label{eq:mps_reduction_boundary_dressed_left} \\
         B^{\mathbf a}W
          & =\lambda^{-1}B^{\mathbf a}\widetilde W.
         \label{eq:mps_reduction_boundary_dressed_right}
@@ -1606,7 +1606,7 @@ $A^{-1}A=\Id$. This is the identity used in
     $VB^{\mathbf p}\widetilde W$.  Inserting a nonempty central $A$-word gives
     \begin{align}
         (VB^{\mathbf p}\widetilde W)A^{\mathbf c}A^{\mathbf q}
-         =A^{\mathbf p}A^{\mathbf c}(VB^{\mathbf q}\widetilde W).
+        =A^{\mathbf p}A^{\mathbf c}(VB^{\mathbf q}\widetilde W).
         \notag
     \end{align}
     Since the length-$L$ words span the full target matrix algebra, linearity


### PR DESCRIPTION
Closes #7395

## Summary
- prove MGSC18 Theorem 22 for two rectangular reductions with a common residual bound
- add the source-form corollary using least residual nilpotency lengths and positive-length MPV equality
- preserve the strict `2 * N₀ < |w|` condition and boundary-dressed conclusions only
- add the Chapter 2 Blueprint theorem and generated Core aggregate import
- factor the repeated matrix-unit insertion calculation through one private `mul_single_mul_apply` lemma
- record the exact-block injectivity dependency used at positive multiples of the injectivity length

## Source
- MGSC18, arXiv:1706.07329v2, Theorem 22 (`cornerproblem.tex` lines 3156–3162)
- proof at `cornerproblem.tex` lines 4007–4035

## Verification
- `scripts/lake_build_locked.sh TNLean.MPS.Core.ReductionUniqueness` (3,068 jobs; linter-bearing)
- `scripts/lake_build_locked.sh TNLean` (10,433 jobs; exact-head aggregate build)
- `lake exe checkdecls blueprint/lean_decls` (7,142 declarations)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7,166/7,166)
- changed-declaration reverse Blueprint coverage for `TNLean/MPS/Core/ReductionUniqueness.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex` and pinned `latexindent` checks for `blueprint/src/chapter/ch02_mps.tex`
- tactic-pattern, proof-integrity, and `git diff --check` scans