### PR TITLE
feat(parent-hamiltonian): prove open-chain C1 bound

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -167,10 +167,12 @@ theorem openParentHamiltonianES_C1 (A : MPSTensor d D) {L l N : ℕ}
       ∑ n ∈ Finset.Icc l N, openSuffixParentHamiltonianES A L l N n =
         ∑ i : NonwrappingStart L N,
           ((windows i).card : ℂ) • localTermES A L i.1 := by
-    rw [openSuffixParentHamiltonianES]
-    rw [Finset.sum_comm' (fun n i => by
-      simp only [Finset.mem_Icc, Finset.mem_filter, Finset.mem_univ, true_and, windows]
-      tauto)]
+    simp_rw [openSuffixParentHamiltonianES]
+    rw [Finset.sum_comm'
+      (s := Finset.Icc l N)
+      (t := fun n => Finset.univ.filter fun i : NonwrappingStart L N =>
+        n - l ≤ i.1.val ∧ i.1.val + L ≤ n)
+      (t' := Finset.univ) (s' := windows) (fun n i => by simp [windows])]
     apply Finset.sum_congr rfl
     intro i _
     simp only [windows, Finset.sum_const, Nat.cast_smul_eq_nsmul]
@@ -182,9 +184,10 @@ theorem openParentHamiltonianES_C1 (A : MPSTensor d D) {L l N : ℕ}
   · rw [hsum, openParentHamiltonianES, Finset.smul_sum]
     apply Finset.sum_le_sum
     intro i _
-    rw [LinearMap.le_def, ← sub_smul]
-    apply (localTermES_isPositive A L i.1).smul_of_nonneg
-    exact_mod_cast hwindows_card i
+    simp only [Nat.cast_smul_eq_nsmul]
+    apply nsmul_le_nsmul_left
+    · exact (LinearMap.nonneg_iff_isPositive _).mpr (localTermES_isPositive A L i.1)
+    · exact hwindows_card i
 
 /-- If the open-chain Hamiltonian annihilates a vector, then every individual
 nonwrapping local term annihilates it.

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -115,11 +115,11 @@ theorem openParentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
   rw [openParentHamiltonianES]
   exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
 
-/-- The parent Hamiltonian on the last `l` sites of the prefix of length `n`,
-embedded in an `N`-site open chain.
+/-- The parent Hamiltonian on the last \(l\) sites of the prefix of length \(n\),
+embedded in an \(N\)-site open chain.
 
-Its summands have starts `i` satisfying `n - l ≤ i` and `i + L ≤ n`. Thus their
-length-`L` windows lie in the nonwrapping interval `[n - l, n)`. This is
+Its summands have starts \(i\) satisfying \(n-l≤i\) and \(i+L≤n\). Thus their
+length-\(L\) windows lie in the nonwrapping interval \([n-l,n)\). This is
 \(H_{\Lambda_n\setminus\Lambda_{n-l}}\) for \(\Lambda_n=[0,n)\) in
 Nachtergaele, arXiv:cond-mat/9410110, condition C1 (lines 1030--1041). -/
 noncomputable def openSuffixParentHamiltonianES (A : MPSTensor d D)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -176,8 +176,9 @@ theorem openParentHamiltonianES_C1 (A : MPSTensor d D) {L l N : ℕ}
     simp only [windows, Finset.sum_const, Nat.cast_smul_eq_nsmul]
   constructor
   · rw [LinearMap.nonneg_iff_isPositive]
-    exact LinearMap.isPositive_sum _ fun n _ =>
-      LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
+    refine LinearMap.isPositive_sum _ fun n _ => ?_
+    rw [openSuffixParentHamiltonianES]
+    exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
   · rw [hsum, openParentHamiltonianES, Finset.smul_sum]
     apply Finset.sum_le_sum
     intro i _

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -115,6 +115,76 @@ theorem openParentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
   rw [openParentHamiltonianES]
   exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
 
+/-- The parent Hamiltonian on the last `l` sites of the prefix of length `n`,
+embedded in an `N`-site open chain.
+
+Its summands have starts `i` satisfying `n - l ≤ i` and `i + L ≤ n`. Thus their
+length-`L` windows lie in the nonwrapping interval `[n - l, n)`. This is
+\(H_{\Lambda_n\setminus\Lambda_{n-l}}\) for \(\Lambda_n=[0,n)\) in
+Nachtergaele, arXiv:cond-mat/9410110, condition C1 (lines 1030--1041). -/
+noncomputable def openSuffixParentHamiltonianES (A : MPSTensor d D)
+    (L l N n : ℕ) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  ∑ i ∈ Finset.univ.filter fun i : NonwrappingStart L N =>
+    n - l ≤ i.1.val ∧ i.1.val + L ≤ n,
+    localTermES A L i.1
+
+/-- Nachtergaele's condition C1 for the compatible nonwrapping open parent
+Hamiltonian.
+
+For the prefixes \(\Lambda_n=[0,n)\), each range-\(L\) local term belongs to at
+most \(l-L+1\) of the suffix intervals
+\(\Lambda_n\setminus\Lambda_{n-l}\), \(l≤n≤N\). Therefore
+\[
+0\leq\sum_{n=l}^N H_{\Lambda_n\setminus\Lambda_{n-l}}
+  \leq (l-L+1)H_{\Lambda_N}.
+\]
+The source gives \(d_l=pl-r+1\) for \(\Lambda_n=[1,pn]\). The indexing of
+`openParentHamiltonianES` has \(p=1\) and \(r=L\), so its actual counting
+constant is \(d_l=l-L+1\).
+
+This is condition C1 in Nachtergaele, arXiv:cond-mat/9410110, lines 1030--1041. -/
+theorem openParentHamiltonianES_C1 (A : MPSTensor d D) {L l N : ℕ}
+    (hLl : L ≤ l) :
+    0 ≤ ∑ n ∈ Finset.Icc l N, openSuffixParentHamiltonianES A L l N n ∧
+      ∑ n ∈ Finset.Icc l N, openSuffixParentHamiltonianES A L l N n ≤
+        ((l - L + 1 : ℕ) : ℂ) • openParentHamiltonianES A L N := by
+  let windows := fun i : NonwrappingStart L N =>
+    (Finset.Icc l N).filter fun n => n - l ≤ i.1.val ∧ i.1.val + L ≤ n
+  have hwindows_card (i : NonwrappingStart L N) :
+      (windows i).card ≤ l - L + 1 := by
+    calc
+      (windows i).card ≤ (Finset.Icc (i.1.val + L) (i.1.val + l)).card := by
+        apply Finset.card_le_card
+        intro n hn
+        simp only [windows, Finset.mem_filter, Finset.mem_Icc] at hn
+        simp only [Finset.mem_Icc]
+        omega
+      _ = l - L + 1 := by
+        rw [Nat.card_Icc]
+        omega
+  have hsum :
+      ∑ n ∈ Finset.Icc l N, openSuffixParentHamiltonianES A L l N n =
+        ∑ i : NonwrappingStart L N,
+          ((windows i).card : ℂ) • localTermES A L i.1 := by
+    rw [openSuffixParentHamiltonianES]
+    rw [Finset.sum_comm' (fun n i => by
+      simp only [Finset.mem_Icc, Finset.mem_filter, Finset.mem_univ, true_and, windows]
+      tauto)]
+    apply Finset.sum_congr rfl
+    intro i _
+    simp only [windows, Finset.sum_const, Nat.cast_smul_eq_nsmul]
+  constructor
+  · rw [LinearMap.nonneg_iff_isPositive]
+    exact LinearMap.isPositive_sum _ fun n _ =>
+      LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
+  · rw [hsum, openParentHamiltonianES, Finset.smul_sum]
+    apply Finset.sum_le_sum
+    intro i _
+    rw [LinearMap.le_def, ← sub_smul]
+    apply (localTermES_isPositive A L i.1).smul_of_nonneg
+    exact_mod_cast hwindows_card i
+
 /-- If the open-chain Hamiltonian annihilates a vector, then every individual
 nonwrapping local term annihilates it.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1056,7 +1056,7 @@ coercivity.
     \lean{MPSTensor.openSuffixParentHamiltonianES}
     \leanok
     \uses{def:open_parent_hamiltonian_es}
-    For $l,n,N\in\N$, the Hamiltonian on the last $l$ sites of the prefix
+    For $L,l,n,N\in\N$, the Hamiltonian on the last $l$ sites of the prefix
     $[0,n)$, regarded as an operator on the $N$-site chain, is
     \begin{align}
         H^{\mathrm{suffix}}_{N,L;l,n}(A)
@@ -1072,8 +1072,7 @@ coercivity.
     \lean{MPSTensor.openParentHamiltonianES_C1}
     \leanok
     \uses{def:open_parent_hamiltonian_es,
-        def:open_suffix_parent_hamiltonian_es,
-        lem:open_parent_hamiltonian_es_positive}
+        def:open_suffix_parent_hamiltonian_es}
     If $L\leq l$, then
     \begin{align}
         0

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1050,6 +1050,60 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     positive. Positivity is preserved by finite sums.
 \end{proof}
 
+\begin{definition}[Compatible suffix Hamiltonian]
+    \label{def:open_suffix_parent_hamiltonian_es}
+    \lean{MPSTensor.openSuffixParentHamiltonianES}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es}
+    For $l,n,N\in\N$, the Hamiltonian on the last $l$ sites of the prefix
+    $[0,n)$, regarded as an operator on the $N$-site chain, is
+    \begin{align}
+        H^{\mathrm{suffix}}_{N,L;l,n}(A)
+         & =\sum_{\substack{i\in I_{L,N}\\ n-l\leq i,\ i+L\leq n}}
+            h_{i,\mathrm{ES}}(A,L).
+        \label{eq:open_suffix_parent_hamiltonian_es}
+    \end{align}
+    Its local windows lie in the nonwrapping interval $[n-l,n)$.
+\end{definition}
+
+\begin{theorem}[Finite-overlap condition C1 for the compatible open chain]
+    \label{thm:open_parent_hamiltonian_es_c1}
+    \lean{MPSTensor.openParentHamiltonianES_C1}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es,
+        def:open_suffix_parent_hamiltonian_es,
+        lem:open_parent_hamiltonian_es_positive}
+    If $L\leq l$, then
+    \begin{align}
+        0
+        \leq \sum_{n=l}^{N}H^{\mathrm{suffix}}_{N,L;l,n}(A)
+        \leq (l-L+1)H^{\mathrm{open}}_{N,L}(A).
+        \label{eq:open_parent_hamiltonian_es_c1}
+    \end{align}
+    Thus condition C1 of
+    \cite{Nachtergaele1996Spectral} holds with $d_l=l-L+1$.
+    This is the source value $pl-r+1$ in the present convention $p=1$ and
+    interaction range $r=L$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:transported_es_positive}
+    Fix a starting site $i\in I_{L,N}$. The suffix Hamiltonian indexed by $n$
+    contains its local term exactly when
+    \begin{align}
+        i+L\leq n\leq i+l.
+    \end{align}
+    This interval contains at most $l-L+1$ integers. Reversing the two finite
+    sums therefore writes the left-hand side as
+    \begin{align}
+        \sum_{i\in I_{L,N}}c_i h_{i,\mathrm{ES}}(A,L),
+    \end{align}
+    where $0\leq c_i\leq l-L+1$. Each local term is positive, so comparison of
+    these coefficients gives the
+    upper bound. Their sum is positive as well, which gives the lower bound.
+\end{proof}
+
 \begin{theorem}[Zero energy forces every compatible local constraint]
     \label{thm:open_parent_hamiltonian_zero_local_terms}
     \lean{MPSTensor.localTermES_eq_zero_of_openParentHamiltonianES_eq_zero}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1059,8 +1059,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     $[0,n)$, regarded as an operator on the $N$-site chain, is
     \begin{align}
         H^{\mathrm{suffix}}_{N,L;l,n}(A)
-         & =\sum_{\substack{i\in I_{L,N}\\ n-l\leq i,\ i+L\leq n}}
-            h_{i,\mathrm{ES}}(A,L).
+         & =\sum_{\substack{i\in I_{L,N} \\ n-l\leq i,\ i+L\leq n}}
+        h_{i,\mathrm{ES}}(A,L).
         \label{eq:open_suffix_parent_hamiltonian_es}
     \end{align}
     Its local windows lie in the nonwrapping interval $[n-l,n)$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -927,8 +927,9 @@ of ground-state projectors, and a uniform gap. Theorem~2.1(i) of the same
 source obtains a gap from its three stated hypotheses. Every compatible
 Hamiltonian below is positive because it is a sum of orthogonal projections.
 In addition to the compatible Hamiltonian and its zero-energy space, the
-statements below verify only the unit norm lower bound at the full-window volume
-$N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
+statements below verify condition C1 and the unit norm lower bound at the
+full-window volume $N=L$. They give no gap estimate for $N>L$ and no periodic
+coercivity.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1099,9 +1099,9 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \begin{align}
         \sum_{i\in I_{L,N}}c_i h_{i,\mathrm{ES}}(A,L),
     \end{align}
-    where $0\leq c_i\leq l-L+1$. Each local term is positive, so comparison of
-    these coefficients gives the
-    upper bound. Their sum is positive as well, which gives the lower bound.
+    where $0\leq c_i\leq l-L+1$. Positivity of each local term turns the
+    coefficient bound into the upper operator inequality. Positivity of their
+    sum gives the lower inequality.
 \end{proof}
 
 \begin{theorem}[Zero energy forces every compatible local constraint]


### PR DESCRIPTION
## What changed

- define the compatible suffix Hamiltonian on the nonwrapping interval $[n-l,n)$ inside an $N$-site open chain
- prove Nachtergaele condition C1 in Loewner order by exchanging the finite sums and counting at most $l-L+1$ occurrences of each range-$L$ local term
- identify the Lean counting constant with the source value $pl-r+1$ at $p=1$ and $r=L$
- add source-faithful Chapter 13 coverage while preserving the moving-window and martingale-difference entries

## Source correspondence

- Nachtergaele, arXiv:cond-mat/9410110, condition C1, source lines 1030-1041
- compatible open Hamiltonian, equation (3.12), source lines 1547-1565

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian` (3057/3057)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7073/7073)
- global Blueprint duplicate-label scan and exact C1 tag-count scan
- proof-integrity scan and `git diff --check`

Closes #7476.
Related to #6411 and #7488.
