### PR TITLE
feat(MPS/ParentHamiltonian): formalize open-chain C3 bound

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -199,8 +199,8 @@ in its literal martingale-difference form
   \lVert G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n\rVert
     \leq \varepsilon_l < \frac{1}{\sqrt{l+1}}.
 \]
-The indices are \(n=K+l\) and \(n_l=l\), and the same \(l\) and
-\(\varepsilon_l\) are supplied by
+The indices are \(n=K+l\) and \(n_l=l+1\), so \(0<K\), and the same \(l\)
+and \(\varepsilon_l\) are supplied by
 `exists_openChain_groundProjection_defect_lt_c3_threshold`. This is only the
 exact projector identification following condition C3 in Nachtergaele,
 arXiv:cond-mat/9410110, equation (2.4); no new decay estimate enters. -/
@@ -210,13 +210,13 @@ theorem IsPrimitiveMPS.exists_openChain_martingaleDifference_norm_lt_c3_threshol
     ∃ l : ℕ, ∃ ε : ℝ,
       1 < l ∧ Kraus.IsNBlkInjective A l ∧ 0 ≤ ε ∧
       ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
-      ∀ K : ℕ,
+      ∀ (K : ℕ) (hK : 0 < K),
         ‖openChainTailGroundProjectionES A K (l + 1) ∘L
-            openChainMartingaleDifferenceES A K l‖ ≤ ε := by
+            openChainMartingaleDifferenceES A K l hK‖ ≤ ε := by
   obtain ⟨l, ε, hl, hInj, hε, hε_lt, hDefect⟩ :=
     hP.exists_openChain_groundProjection_defect_lt_c3_threshold hρ
-  refine ⟨l, ε, hl, hInj, hε, hε_lt, fun K ↦ ?_⟩
-  rw [openChainTailGroundProjection_comp_martingaleDifference hInj hl.le]
+  refine ⟨l, ε, hl, hInj, hε, hε_lt, fun K hK ↦ ?_⟩
+  rw [openChainTailGroundProjection_comp_martingaleDifference hK]
   exact hDefect K
 
 /-- The C3 threshold yields the uniform open-chain anticommutator estimate for

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -207,16 +207,15 @@ arXiv:cond-mat/9410110, equation (2.4); no new decay estimate enters. -/
 theorem IsPrimitiveMPS.exists_openChain_martingaleDifference_norm_lt_c3_threshold
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
-    ∃ l : ℕ, ∃ ε : ℝ,
-      1 < l ∧ Kraus.IsNBlkInjective A l ∧ 0 ≤ ε ∧
-      ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+    ∃ l : ℕ, ∃ ε : ℝ, ∃ hl : 1 < l, ∃ hInj : Kraus.IsNBlkInjective A l,
+      0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
       ∀ (K : ℕ) (hK : 0 < K),
         ‖openChainTailGroundProjectionES A K (l + 1) ∘L
-            openChainMartingaleDifferenceES A K l hK‖ ≤ ε := by
+            openChainMartingaleDifferenceES A K l hInj hl.le hK‖ ≤ ε := by
   obtain ⟨l, ε, hl, hInj, hε, hε_lt, hDefect⟩ :=
     hP.exists_openChain_groundProjection_defect_lt_c3_threshold hρ
   refine ⟨l, ε, hl, hInj, hε, hε_lt, fun K hK ↦ ?_⟩
-  rw [openChainTailGroundProjection_comp_martingaleDifference hK]
+  rw [openChainTailGroundProjection_comp_martingaleDifference hInj hl.le hK]
   exact hDefect K
 
 /-- The C3 threshold yields the uniform open-chain anticommutator estimate for

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -23,6 +23,8 @@ blocked-chain filtration step.
   specializes the uniform estimate to three equal original-site blocks.
 * `MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold`
   chooses a block-injective overlap length and one uniform C3 defect coefficient.
+* `MPSTensor.IsPrimitiveMPS.exists_openChain_martingaleDifference_norm_lt_c3_threshold`
+  states the same bound as Nachtergaele's literal C3 operator norm.
 * `MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold`
   gives the corresponding open-chain excitation-projection anticommutator estimate.
 
@@ -190,6 +192,32 @@ theorem IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold
   refine ⟨l, ε, hl, hInj, hε, hε_lt, ?_⟩
   intro K
   exact hDefect K l (by omega) hl_small
+
+/-- A primitive MPS with faithful fixed point satisfies Nachtergaele's condition C3
+in its literal martingale-difference form
+\[
+  \lVert G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n\rVert
+    \leq \varepsilon_l < \frac{1}{\sqrt{l+1}}.
+\]
+The indices are \(n=K+l\) and \(n_l=l\), and the same \(l\) and
+\(\varepsilon_l\) are supplied by
+`exists_openChain_groundProjection_defect_lt_c3_threshold`. This is only the
+exact projector identification following condition C3 in Nachtergaele,
+arXiv:cond-mat/9410110, equation (2.4); no new decay estimate enters. -/
+theorem IsPrimitiveMPS.exists_openChain_martingaleDifference_norm_lt_c3_threshold
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ l : ℕ, ∃ ε : ℝ,
+      1 < l ∧ Kraus.IsNBlkInjective A l ∧ 0 ≤ ε ∧
+      ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      ∀ K : ℕ,
+        ‖openChainTailGroundProjectionES A K (l + 1) ∘L
+            openChainMartingaleDifferenceES A K l‖ ≤ ε := by
+  obtain ⟨l, ε, hl, hInj, hε, hε_lt, hDefect⟩ :=
+    hP.exists_openChain_groundProjection_defect_lt_c3_threshold hρ
+  refine ⟨l, ε, hl, hInj, hε, hε_lt, fun K ↦ ?_⟩
+  rw [openChainTailGroundProjection_comp_martingaleDifference hInj hl.le]
+  exact hDefect K
 
 /-- The C3 threshold yields the uniform open-chain anticommutator estimate for
 the complementary excitation projections. Nachtergaele's identity following condition

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -92,12 +92,15 @@ noncomputable def openChainTailGroundProjectionES (A : MPSTensor d D) (K L : ℕ
 \(E_n=G_{\Lambda_n}-G_{\Lambda_{n+1}}\), represented in the Hilbert space on
 \(\Lambda_{n+1}\).
 
-The indices are \(n=K+l\) and \(n_l=l\). Thus the first term is the projector
-onto the left ground condition on \(\Lambda_n\), extended across the last site,
-and the second is the whole-chain ground projector on \(\Lambda_{n+1}\).
-See arXiv:cond-mat/9410110, equation `(En)` and the identity following
-condition C3 in equation (2.4). -/
-noncomputable def openChainMartingaleDifferenceES (A : MPSTensor d D) (K l : ℕ) :
+The indices are \(n=K+l\) and \(n_l=l+1\), so \(0<K\). Thus the first term is
+the projector onto the left ground condition on \(\Lambda_n\), extended across
+the last site, and the second is the whole-chain ground projector on
+\(\Lambda_{n+1}\). The strict inequality excludes the undersized volume where
+the interaction of length \(l+1\) has no nonwrapping window. See
+arXiv:cond-mat/9410110, equation `(En)` and the identity following condition C3
+in equation (2.4). -/
+noncomputable def openChainMartingaleDifferenceES
+    (A : MPSTensor d D) (K l : ℕ) (_hK : 0 < K) :
     EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
       EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
   openChainLeftGroundProjectionES A (K + l) -
@@ -146,22 +149,21 @@ theorem openChainLeft_inf_tailGroundSpaceES [NeZero D]
       groundSpace_inTailGround A K (L₀ + 1) hv⟩
 
 /-- The whole ground space on \(\Lambda_{n+1}\) lies in the tail ground space
-\(G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}\), where \(n=K+l\) and
-\(n_l=l\). -/
-theorem groundSpaceES_le_openChainTailGroundSpaceES [NeZero D]
-    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
-    (hl : 0 < l) :
+\(G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}\), where \(n=K+l\). -/
+theorem groundSpaceES_le_openChainTailGroundSpaceES
+    {A : MPSTensor d D} {K l : ℕ} :
     groundSpaceES A (K + l + 1) ≤ openChainTailGroundSpaceES A K (l + 1) := by
-  rw [← openChainLeft_inf_tailGroundSpaceES hInj hl]
-  exact inf_le_right
+  intro v hv
+  rw [mem_groundSpaceES_iff] at hv
+  rw [mem_openChainTailGroundSpaceES_iff]
+  exact groundSpace_inTailGround A K (l + 1) hv
 
 /-- Projecting first onto the whole ground space and then onto the tail ground
 space leaves the whole-ground projection unchanged. This is the reverse
 projector composition required in the identity following Nachtergaele's
 condition C3. -/
-theorem openChainTailGroundProjection_comp_groundSpaceProjection [NeZero D]
-    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
-    (hl : 0 < l) :
+theorem openChainTailGroundProjection_comp_groundSpaceProjection
+    {A : MPSTensor d D} {K l : ℕ} :
     openChainTailGroundProjectionES A K (l + 1) ∘L
         (groundSpaceES A (K + l + 1)).starProjection =
       (groundSpaceES A (K + l + 1)).starProjection := by
@@ -171,7 +173,7 @@ theorem openChainTailGroundProjection_comp_groundSpaceProjection [NeZero D]
       ((groundSpaceES A (K + l + 1)).starProjection v) =
     (groundSpaceES A (K + l + 1)).starProjection v
   apply Submodule.starProjection_eq_self_iff.mpr
-  exact groundSpaceES_le_openChainTailGroundSpaceES hInj hl
+  exact groundSpaceES_le_openChainTailGroundSpaceES
     (Submodule.starProjection_apply_mem _ _)
 
 /-- The exact projector identity following Nachtergaele's condition C3:
@@ -180,18 +182,17 @@ G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
  =G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
   -G_{\Lambda_{n+1}}.
 \]
-Here \(n=K+l\) and \(n_l=l\), so every operator acts on the Hilbert space of
-\(\Lambda_{n+1}\). -/
-theorem openChainTailGroundProjection_comp_martingaleDifference [NeZero D]
-    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
-    (hl : 0 < l) :
+Here \(n=K+l\), \(n_l=l+1\), and \(0<K\), so every operator acts on the
+physical open chain in the Hilbert space of \(\Lambda_{n+1}\). -/
+theorem openChainTailGroundProjection_comp_martingaleDifference
+    {A : MPSTensor d D} {K l : ℕ} (hK : 0 < K) :
     openChainTailGroundProjectionES A K (l + 1) ∘L
-        openChainMartingaleDifferenceES A K l =
+        openChainMartingaleDifferenceES A K l hK =
       openChainTailGroundProjectionES A K (l + 1) ∘L
           openChainLeftGroundProjectionES A (K + l) -
         (groundSpaceES A (K + l + 1)).starProjection := by
   rw [openChainMartingaleDifferenceES, ContinuousLinearMap.comp_sub,
-    openChainTailGroundProjection_comp_groundSpaceProjection hInj hl]
+    openChainTailGroundProjection_comp_groundSpaceProjection]
 
 set_option maxHeartbeats 800000 in
 -- The expanded finite-dimensional projector statement requires extra elaboration budget.

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -90,17 +90,16 @@ noncomputable def openChainTailGroundProjectionES (A : MPSTensor d D) (K L : ℕ
 
 /-- Nachtergaele's physical open-chain martingale difference
 \(E_n=G_{\Lambda_n}-G_{\Lambda_{n+1}}\), represented in the Hilbert space on
-\(\Lambda_{n+1}\).
+\(\Lambda_{n+1}\), for the MPS parent interaction of length \(l+1\).
 
-The indices are \(n=K+l\) and \(n_l=l+1\), so \(0<K\). Thus the first term is
-the projector onto the left ground condition on \(\Lambda_n\), extended across
-the last site, and the second is the whole-chain ground projector on
-\(\Lambda_{n+1}\). The strict inequality excludes the undersized volume where
-the interaction of length \(l+1\) has no nonwrapping window. See
+The indices are \(n=K+l\) and \(n_l=l+1\). Block injectivity identifies the MPS
+ground spaces below with the corresponding open-parent Hamiltonian kernels,
+and \(0<K\) excludes the undersized volume with no nonwrapping window. See
 arXiv:cond-mat/9410110, equation `(En)` and the identity following condition C3
 in equation (2.4). -/
-noncomputable def openChainMartingaleDifferenceES
-    (A : MPSTensor d D) (K l : ℕ) (_hK : 0 < K) :
+noncomputable def openChainMartingaleDifferenceES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ) (_hInj : Kraus.IsNBlkInjective A l)
+    (_hl : 0 < l) (_hK : 0 < K) :
     EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
       EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
   openChainLeftGroundProjectionES A (K + l) -
@@ -183,11 +182,15 @@ G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
   -G_{\Lambda_{n+1}}.
 \]
 Here \(n=K+l\), \(n_l=l+1\), and \(0<K\), so every operator acts on the
-physical open chain in the Hilbert space of \(\Lambda_{n+1}\). -/
-theorem openChainTailGroundProjection_comp_martingaleDifference
-    {A : MPSTensor d D} {K l : ℕ} (hK : 0 < K) :
+physical open chain in the Hilbert space of \(\Lambda_{n+1}\). The projector
+composition used in the proof is independent of block injectivity; the latter
+is needed only to identify the MPS spaces in `openChainMartingaleDifferenceES`
+with the physical open-parent ground spaces. -/
+theorem openChainTailGroundProjection_comp_martingaleDifference [NeZero D]
+    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
+    (hl : 0 < l) (hK : 0 < K) :
     openChainTailGroundProjectionES A K (l + 1) ∘L
-        openChainMartingaleDifferenceES A K l hK =
+        openChainMartingaleDifferenceES A K l hInj hl hK =
       openChainTailGroundProjectionES A K (l + 1) ∘L
           openChainLeftGroundProjectionES A (K + l) -
         (groundSpaceES A (K + l + 1)).starProjection := by

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -49,6 +49,13 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+private theorem groundSpaceES_hasOrthogonalProjection_openChain
+    (A : MPSTensor d D) (N : ℕ) : (groundSpaceES A N).HasOrthogonalProjection := by
+  let : CompleteSpace (groundSpaceES A N) := FiniteDimensional.complete ℂ _
+  exact Submodule.HasOrthogonalProjection.ofCompleteSpace _
+
+attribute [local instance] groundSpaceES_hasOrthogonalProjection_openChain
+
 /-- The open-chain left-window ground subspace on \(L + 1\) sites.
 
 Membership says that every restriction obtained by fixing the final site lies
@@ -80,6 +87,21 @@ noncomputable def openChainLeftGroundProjectionES (A : MPSTensor d D) (L : ℕ) 
 noncomputable def openChainTailGroundProjectionES (A : MPSTensor d D) (K L : ℕ) :
     EuclideanSpace ℂ (Cfg d (K + L)) →L[ℂ] EuclideanSpace ℂ (Cfg d (K + L)) :=
   (openChainTailGroundSpaceES A K L).starProjection
+
+/-- Nachtergaele's physical open-chain martingale difference
+\(E_n=G_{\Lambda_n}-G_{\Lambda_{n+1}}\), represented in the Hilbert space on
+\(\Lambda_{n+1}\).
+
+The indices are \(n=K+l\) and \(n_l=l\). Thus the first term is the projector
+onto the left ground condition on \(\Lambda_n\), extended across the last site,
+and the second is the whole-chain ground projector on \(\Lambda_{n+1}\).
+See arXiv:cond-mat/9410110, equation `(En)` and the identity following
+condition C3 in equation (2.4). -/
+noncomputable def openChainMartingaleDifferenceES (A : MPSTensor d D) (K l : ℕ) :
+    EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
+      EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
+  openChainLeftGroundProjectionES A (K + l) -
+    (groundSpaceES A (K + l + 1)).starProjection
 
 /-- Membership in the left-window Hilbert subspace is exactly
 `InLeftGround` after transport by the canonical `WithLp` equivalence. -/
@@ -122,6 +144,54 @@ theorem openChainLeft_inf_tailGroundSpaceES [NeZero D]
   · intro hv
     exact ⟨groundSpace_inLeftGround A (K + L₀) hv,
       groundSpace_inTailGround A K (L₀ + 1) hv⟩
+
+/-- The whole ground space on \(\Lambda_{n+1}\) lies in the tail ground space
+\(G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}\), where \(n=K+l\) and
+\(n_l=l\). -/
+theorem groundSpaceES_le_openChainTailGroundSpaceES [NeZero D]
+    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
+    (hl : 0 < l) :
+    groundSpaceES A (K + l + 1) ≤ openChainTailGroundSpaceES A K (l + 1) := by
+  rw [← openChainLeft_inf_tailGroundSpaceES hInj hl]
+  exact inf_le_right
+
+/-- Projecting first onto the whole ground space and then onto the tail ground
+space leaves the whole-ground projection unchanged. This is the reverse
+projector composition required in the identity following Nachtergaele's
+condition C3. -/
+theorem openChainTailGroundProjection_comp_groundSpaceProjection [NeZero D]
+    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
+    (hl : 0 < l) :
+    openChainTailGroundProjectionES A K (l + 1) ∘L
+        (groundSpaceES A (K + l + 1)).starProjection =
+      (groundSpaceES A (K + l + 1)).starProjection := by
+  apply ContinuousLinearMap.ext
+  intro v
+  change (openChainTailGroundSpaceES A K (l + 1)).starProjection
+      ((groundSpaceES A (K + l + 1)).starProjection v) =
+    (groundSpaceES A (K + l + 1)).starProjection v
+  apply Submodule.starProjection_eq_self_iff.mpr
+  exact groundSpaceES_le_openChainTailGroundSpaceES hInj hl
+    (Submodule.starProjection_apply_mem _ _)
+
+/-- The exact projector identity following Nachtergaele's condition C3:
+\[
+G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
+ =G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+  -G_{\Lambda_{n+1}}.
+\]
+Here \(n=K+l\) and \(n_l=l\), so every operator acts on the Hilbert space of
+\(\Lambda_{n+1}\). -/
+theorem openChainTailGroundProjection_comp_martingaleDifference [NeZero D]
+    {A : MPSTensor d D} {K l : ℕ} (hInj : Kraus.IsNBlkInjective A l)
+    (hl : 0 < l) :
+    openChainTailGroundProjectionES A K (l + 1) ∘L
+        openChainMartingaleDifferenceES A K l =
+      openChainTailGroundProjectionES A K (l + 1) ∘L
+          openChainLeftGroundProjectionES A (K + l) -
+        (groundSpaceES A (K + l + 1)).starProjection := by
+  rw [openChainMartingaleDifferenceES, ContinuousLinearMap.comp_sub,
+    openChainTailGroundProjection_comp_groundSpaceProjection hInj hl]
 
 set_option maxHeartbeats 800000 in
 -- The expanded finite-dimensional projector statement requires extra elaboration budget.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1352,13 +1352,14 @@ coercivity.
 \end{proof}
 
 % Source: References/cond-mat_9410110/main.tex, equation En, lines 1060--1073.
-\begin{definition}[Physical open-chain martingale difference]
+\begin{definition}[Block-injective MPS realization of the open-chain martingale difference]
     \label{def:open_chain_martingale_difference_es}
     \lean{MPSTensor.openChainMartingaleDifferenceES}
     \leanok
-    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
-    Fix $K,l\in\N$ with $K>0$, set $n=K+l$ and $n_l=l+1$, and work in the
-    Hilbert space on $\Lambda_{n+1}$.  The physical open-chain martingale difference is
+    \uses{def:open_chain_ground_subspaces_es, thm:open_parent_hamiltonian_kernel_ground_space}
+    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block-injective.  Fix
+    $K>0$, set $n=K+l$ and $n_l=l+1$, and work in the Hilbert space on
+    $\Lambda_{n+1}$.  The physical open-chain martingale difference is
     \begin{align}
         E_n
          & :=G_{\Lambda_n}-G_{\Lambda_{n+1}} \\
@@ -1367,10 +1368,11 @@ coercivity.
         \label{eq:open_chain_martingale_difference_es}
     \end{align}
     The first projector imposes the ground condition on the left $n$ sites
-    while acting on all $n+1$ sites.  Hence both terms in the difference have
-    the same ambient Hilbert space.  The condition $K>0$ excludes the
-    undersized volume, where an interaction of length $l+1$ has no
-    nonwrapping window and its physical ground projector is the identity.
+    while acting on all $n+1$ sites.  Block injectivity identifies these MPS
+    spaces with the corresponding open-parent Hamiltonian kernels.  The
+    condition $K>0$ excludes the undersized volume, where an interaction of
+    length $l+1$ has no nonwrapping window and its physical ground projector is
+    the identity.
 \end{definition}
 
 \begin{lemma}[Whole ground space lies in the C3 tail space]
@@ -1419,13 +1421,14 @@ coercivity.
 
 % Source: References/cond-mat_9410110/main.tex, condition C3, lines 1083--1094;
 % identity following C3, lines 1178--1188.
-\begin{theorem}[Exact C3 martingale-difference identity]
+\begin{theorem}[Block-injective MPS instance of the exact C3 identity]
     \label{thm:exact_c3_martingale_difference_identity}
     \lean{MPSTensor.openChainTailGroundProjection_comp_martingaleDifference}
     \leanok
     \uses{def:open_chain_martingale_difference_es, lem:reverse_c3_projector_composition}
-    Fix $K,l\in\N$ with $K>0$.  With $n=K+l$ and $n_l=l+1$,
-    Nachtergaele's identity following condition C3 is
+    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block-injective.  Fix $K>0$.
+    With $n=K+l$ and $n_l=l+1$, the MPS parent chain satisfies Nachtergaele's
+    identity following condition C3:
     \begin{align}
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
          & =G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1357,8 +1357,8 @@ coercivity.
     \lean{MPSTensor.openChainMartingaleDifferenceES}
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
-    Fix $K,l\in\N$, set $n=K+l$ and $n_l=l$, and work in the Hilbert space
-    on $\Lambda_{n+1}$.  The physical open-chain martingale difference is
+    Fix $K,l\in\N$ with $K>0$, set $n=K+l$ and $n_l=l+1$, and work in the
+    Hilbert space on $\Lambda_{n+1}$.  The physical open-chain martingale difference is
     \begin{align}
         E_n
          & :=G_{\Lambda_n}-G_{\Lambda_{n+1}} \\
@@ -1368,16 +1368,17 @@ coercivity.
     \end{align}
     The first projector imposes the ground condition on the left $n$ sites
     while acting on all $n+1$ sites.  Hence both terms in the difference have
-    the same ambient Hilbert space.
+    the same ambient Hilbert space.  The condition $K>0$ excludes the
+    undersized volume, where an interaction of length $l+1$ has no
+    nonwrapping window and its physical ground projector is the identity.
 \end{definition}
 
 \begin{lemma}[Whole ground space lies in the C3 tail space]
     \label{lem:whole_ground_space_le_c3_tail_space}
     \lean{MPSTensor.groundSpaceES_le_openChainTailGroundSpaceES}
     \leanok
-    \uses{thm:open_chain_left_tail_ground_intersection}
-    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block injective.  For
-    $n=K+l$ and $n_l=l$,
+    \uses{lem:ground_space_in_tail_ground}
+    For every $K,l\in\N$, set $n=K+l$.  Then
     \begin{align}
         \mathcal G_{n+1}^{\mathrm{ES}}(A)
          & \subseteq \mathcal V_{K,l+1}(A).
@@ -1387,13 +1388,10 @@ coercivity.
 
 \begin{proof}
     \leanok
-    \uses{thm:open_chain_left_tail_ground_intersection}
-    The open-chain intersection theorem gives
-    \begin{align}
-        \mathcal U_{K+l}(A)\cap\mathcal V_{K,l+1}(A)
-         & =\mathcal G_{K+l+1}^{\mathrm{ES}}(A).
-    \end{align}
-    The intersection is contained in its second factor.
+    \uses{lem:ground_space_in_tail_ground}
+    Every fixed-prefix suffix restriction of a whole-chain ground-space vector
+    is a ground-space vector on the suffix.  This is exactly membership in
+    $\mathcal V_{K,l+1}(A)$.
 \end{proof}
 
 \begin{lemma}[Reverse C3 projector composition]
@@ -1401,8 +1399,7 @@ coercivity.
     \lean{MPSTensor.openChainTailGroundProjection_comp_groundSpaceProjection}
     \leanok
     \uses{lem:whole_ground_space_le_c3_tail_space}
-    Under the same hypotheses, the tail projector fixes the whole-ground
-    projector:
+    For every $K,l\in\N$, the tail projector fixes the whole-ground projector:
     \begin{align}
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_{n+1}}
          & =G_{\Lambda_{n+1}}.
@@ -1427,8 +1424,8 @@ coercivity.
     \lean{MPSTensor.openChainTailGroundProjection_comp_martingaleDifference}
     \leanok
     \uses{def:open_chain_martingale_difference_es, lem:reverse_c3_projector_composition}
-    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block injective.  With
-    $n=K+l$ and $n_l=l$, Nachtergaele's identity following condition C3 is
+    Fix $K,l\in\N$ with $K>0$.  With $n=K+l$ and $n_l=l+1$,
+    Nachtergaele's identity following condition C3 is
     \begin{align}
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
          & =G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
@@ -2746,7 +2743,7 @@ coercivity.
     Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
     positive-definite fixed point.  There are $l>1$ and
     $\varepsilon_l\geq0$, with $A$ $l$-block injective, such that for every
-    $K\in\N$, after setting $n=K+l$ and $n_l=l$,
+    $K>0$, after setting $n=K+l$ and $n_l=l+1$,
     \begin{align}
         \left\lVert
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
@@ -2775,7 +2772,7 @@ coercivity.
         \right\rVert
          & \leq\varepsilon_l
     \end{align}
-    for every $K$.  Rewrite its norm by
+    for every $K>0$.  Rewrite its norm by
     Theorem~\ref{thm:exact_c3_martingale_difference_identity}; the existing
     strict threshold on $\varepsilon_l$ is unchanged.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1351,6 +1351,102 @@ coercivity.
     other, so antisymmetry gives the equality.
 \end{proof}
 
+% Source: References/cond-mat_9410110/main.tex, equation En, lines 1060--1073.
+\begin{definition}[Physical open-chain martingale difference]
+    \label{def:open_chain_martingale_difference_es}
+    \lean{MPSTensor.openChainMartingaleDifferenceES}
+    \leanok
+    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
+    Fix $K,l\in\N$, set $n=K+l$ and $n_l=l$, and work in the Hilbert space
+    on $\Lambda_{n+1}$.  The physical open-chain martingale difference is
+    \begin{align}
+        E_n
+         &:=G_{\Lambda_n}-G_{\Lambda_{n+1}} \\
+         &=P_{\mathcal U_{K+l}(A)}
+           -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}.
+        \label{eq:open_chain_martingale_difference_es}
+    \end{align}
+    The first projector imposes the ground condition on the left $n$ sites
+    while acting on all $n+1$ sites.  Hence both terms in the difference have
+    the same ambient Hilbert space.
+\end{definition}
+
+\begin{lemma}[Whole ground space lies in the C3 tail space]
+    \label{lem:whole_ground_space_le_c3_tail_space}
+    \lean{MPSTensor.groundSpaceES_le_openChainTailGroundSpaceES}
+    \leanok
+    \uses{thm:open_chain_left_tail_ground_intersection}
+    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block injective.  For
+    $n=K+l$ and $n_l=l$,
+    \begin{align}
+        \mathcal G_{n+1}^{\mathrm{ES}}(A)
+         &\subseteq \mathcal V_{K,l+1}(A).
+        \label{eq:whole_ground_space_le_c3_tail_space}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_chain_left_tail_ground_intersection}
+    The open-chain intersection theorem gives
+    \begin{align}
+        \mathcal U_{K+l}(A)\cap\mathcal V_{K,l+1}(A)
+         &=\mathcal G_{K+l+1}^{\mathrm{ES}}(A).
+    \end{align}
+    The intersection is contained in its second factor.
+\end{proof}
+
+\begin{lemma}[Reverse C3 projector composition]
+    \label{lem:reverse_c3_projector_composition}
+    \lean{MPSTensor.openChainTailGroundProjection_comp_groundSpaceProjection}
+    \leanok
+    \uses{lem:whole_ground_space_le_c3_tail_space}
+    Under the same hypotheses, the tail projector fixes the whole-ground
+    projector:
+    \begin{align}
+        G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_{n+1}}
+         &=G_{\Lambda_{n+1}}.
+        \label{eq:reverse_c3_projector_composition}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:whole_ground_space_le_c3_tail_space}
+    The inner projection has range in
+    $\mathcal G_{n+1}^{\mathrm{ES}}(A)$, which lies in the tail ground space by
+    Lemma~\ref{lem:whole_ground_space_le_c3_tail_space}.  Orthogonal projection
+    onto that tail space therefore leaves every vector in the inner range
+    unchanged.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C3, lines 1083--1094;
+% identity following C3, lines 1178--1188.
+\begin{theorem}[Exact C3 martingale-difference identity]
+    \label{thm:exact_c3_martingale_difference_identity}
+    \lean{MPSTensor.openChainTailGroundProjection_comp_martingaleDifference}
+    \leanok
+    \uses{def:open_chain_martingale_difference_es, lem:reverse_c3_projector_composition}
+    Assume $D\geq1$, $l>0$, and that $A$ is $l$-block injective.  With
+    $n=K+l$ and $n_l=l$, Nachtergaele's identity following condition C3 is
+    \begin{align}
+        G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
+         &=G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+           -G_{\Lambda_{n+1}}.
+        \label{eq:exact_c3_martingale_difference_identity}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:open_chain_martingale_difference_es, lem:reverse_c3_projector_composition}
+    Distribute the tail projector over
+    $E_n=G_{\Lambda_n}-G_{\Lambda_{n+1}}$.  The second product is
+    $G_{\Lambda_{n+1}}$ by
+    Lemma~\ref{lem:reverse_c3_projector_composition}, which gives the displayed
+    identity.
+\end{proof}
+
 \begin{theorem}[Nachtergaele open-chain projector defect]
     \label{thm:nachtergaele_open_chain_projector_defect}
     \lean{MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}
@@ -2639,6 +2735,49 @@ coercivity.
     gives the uniform defect bound with
     $\varepsilon_l=(1-cr^l)^{-1}Cr^l$.  The open-chain projector-defect theorem
     gives the anticommutator statement.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C3, lines 1083--1094.
+\begin{theorem}[Literal open-chain martingale condition C3]
+    \label{thm:literal_open_chain_martingale_c3}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_openChain_martingaleDifference_norm_lt_c3_threshold}
+    \leanok
+    \uses{thm:nachtergaele_c3_blocked_length, thm:exact_c3_martingale_difference_identity}
+    Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
+    positive-definite fixed point.  There are $l>1$ and
+    $\varepsilon_l\geq0$, with $A$ $l$-block injective, such that for every
+    $K\in\N$, after setting $n=K+l$ and $n_l=l$,
+    \begin{align}
+        \left\lVert
+        G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
+        \right\rVert
+         &\leq\varepsilon_l.
+        \label{eq:literal_open_chain_martingale_c3}
+    \end{align}
+    The coefficient satisfies
+    \begin{align}
+        \varepsilon_l
+         &<\frac{1}{\sqrt{l+1}}.
+        \label{eq:literal_open_chain_martingale_c3_threshold}
+    \end{align}
+    The length $l$ and coefficient $\varepsilon_l$ are exactly those chosen
+    by Theorem~\ref{thm:nachtergaele_c3_blocked_length}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:nachtergaele_c3_blocked_length, thm:exact_c3_martingale_difference_identity}
+    The uniform threshold theorem gives
+    \begin{align}
+        \left\lVert
+        G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+        -G_{\Lambda_{n+1}}
+        \right\rVert
+         &\leq\varepsilon_l
+    \end{align}
+    for every $K$.  Rewrite its norm by
+    Theorem~\ref{thm:exact_c3_martingale_difference_identity}; the existing
+    strict threshold on $\varepsilon_l$ is unchanged.
 \end{proof}
 
 \begin{lemma}[Blocked three-site projector and adjacent-pair transport]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1361,9 +1361,9 @@ coercivity.
     on $\Lambda_{n+1}$.  The physical open-chain martingale difference is
     \begin{align}
         E_n
-         &:=G_{\Lambda_n}-G_{\Lambda_{n+1}} \\
-         &=P_{\mathcal U_{K+l}(A)}
-           -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}.
+         & :=G_{\Lambda_n}-G_{\Lambda_{n+1}} \\
+         & =P_{\mathcal U_{K+l}(A)}
+        -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}.
         \label{eq:open_chain_martingale_difference_es}
     \end{align}
     The first projector imposes the ground condition on the left $n$ sites
@@ -1380,7 +1380,7 @@ coercivity.
     $n=K+l$ and $n_l=l$,
     \begin{align}
         \mathcal G_{n+1}^{\mathrm{ES}}(A)
-         &\subseteq \mathcal V_{K,l+1}(A).
+         & \subseteq \mathcal V_{K,l+1}(A).
         \label{eq:whole_ground_space_le_c3_tail_space}
     \end{align}
 \end{lemma}
@@ -1391,7 +1391,7 @@ coercivity.
     The open-chain intersection theorem gives
     \begin{align}
         \mathcal U_{K+l}(A)\cap\mathcal V_{K,l+1}(A)
-         &=\mathcal G_{K+l+1}^{\mathrm{ES}}(A).
+         & =\mathcal G_{K+l+1}^{\mathrm{ES}}(A).
     \end{align}
     The intersection is contained in its second factor.
 \end{proof}
@@ -1405,7 +1405,7 @@ coercivity.
     projector:
     \begin{align}
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_{n+1}}
-         &=G_{\Lambda_{n+1}}.
+         & =G_{\Lambda_{n+1}}.
         \label{eq:reverse_c3_projector_composition}
     \end{align}
 \end{lemma}
@@ -1431,8 +1431,8 @@ coercivity.
     $n=K+l$ and $n_l=l$, Nachtergaele's identity following condition C3 is
     \begin{align}
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
-         &=G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
-           -G_{\Lambda_{n+1}}.
+         & =G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+        -G_{\Lambda_{n+1}}.
         \label{eq:exact_c3_martingale_difference_identity}
     \end{align}
 \end{theorem}
@@ -2751,13 +2751,13 @@ coercivity.
         \left\lVert
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
         \right\rVert
-         &\leq\varepsilon_l.
+         & \leq\varepsilon_l.
         \label{eq:literal_open_chain_martingale_c3}
     \end{align}
     The coefficient satisfies
     \begin{align}
         \varepsilon_l
-         &<\frac{1}{\sqrt{l+1}}.
+         & <\frac{1}{\sqrt{l+1}}.
         \label{eq:literal_open_chain_martingale_c3_threshold}
     \end{align}
     The length $l$ and coefficient $\varepsilon_l$ are exactly those chosen
@@ -2773,7 +2773,7 @@ coercivity.
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
         -G_{\Lambda_{n+1}}
         \right\rVert
-         &\leq\varepsilon_l
+         & \leq\varepsilon_l
     \end{align}
     for every $K$.  Rewrite its norm by
     Theorem~\ref{thm:exact_c3_martingale_difference_identity}; the existing


### PR DESCRIPTION
## What changed

- defines the open-chain martingale difference in the block-injective MPS setting, with the hypotheses needed to identify both MPS spaces with kernels of the physical open parent Hamiltonians
- proves the whole-ground-space inclusion and reverse projector composition without block-injectivity assumptions
- proves the exact C3 martingale-difference identity and the literal C3 norm bound using the existing projector-defect estimate, with the same `l` and `ε_l`
- synchronizes the Blueprint with explicitly scope-restricted “block-injective MPS realization/instance” nodes

## Source faithfulness

Source: Nachtergaele, condition C3 and the identity immediately following it (`References/cond-mat_9410110/main.tex`, lines 1083–1094 and 1178–1188).

The physical martingale-difference definition requires `[NeZero D]`, `Kraus.IsNBlkInjective A l`, `0 < l`, and `0 < K`. These hypotheses identify the two displayed MPS projectors with the corresponding open-parent-Hamiltonian kernel projectors and exclude the undersized left window. The assumption-free algebraic inclusion and reverse composition remain separate. The Blueprint does not present this MPS realization as the unrestricted source definition.

## Validation

- focused builds of `TNLean.MPS.ParentHamiltonian.Martingale.OpenChain` and `TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold`
- full `lake build TNLean` before the current additive rebase
- Blueprint synchronization and strict declaration checks (7134/7134 before the current additive rebase)
- pinned `latexindent`, cross-reference, proof-token, and `git diff --check` checks
- the current-head patch has the same stable patch id as the source-reviewed pre-rebase head; hosted exact-head Lean and Blueprint jobs are running

Closes #7477