### PR TITLE
feat(MPS/ParentHamiltonian): prove Nachtergaele analytic bounds

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -63,6 +63,7 @@ import TNLean.MPS.ParentHamiltonian.LocalSupport
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
+import TNLean.MPS.ParentHamiltonian.Martingale.AnalyticBounds
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
+import TNLean.MPS.ParentHamiltonian.Martingale.AnalyticBounds
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
@@ -36,11 +37,13 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The fourteen components are:
+The sixteen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
   (quadratic form implies norm bound);
+* `Martingale.AnalyticBounds` — the weighted inner-product and C3
+  projection-composition inequalities from Nachtergaele's summation;
 * `Martingale.DifferenceProjections` — Nachtergaele's mutually orthogonal
   martingale differences, telescoping resolution, and norm-square decomposition;
 * `Martingale.ProjectionCancellation` — outside-window cancellation and the

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AnalyticBounds.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AnalyticBounds.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Symmetric
+
+/-!
+# Analytic bounds for Nachtergaele's martingale summation
+
+This file records the two elementary estimates used in the proof of
+Nachtergaele's Theorem 2.1(i) (cond-mat/9410110, lines 1195--1259). The first is
+the real-part form of the weighted estimate applied twice in display `Enpsi2`.
+The second turns C3 into its pointwise norm-square form. These are the analytic
+inputs to the source's choices
+\(c_1 = 1 - \epsilon_l\sqrt{l+1}\) and
+\(c_2 = \epsilon_l/\sqrt{l+1}\), which yield the exact factor
+\(\frac{\gamma_{l+1}}{d_{l+1}}(1-\epsilon_l\sqrt{l+1})^2\).
+-/
+
+open scoped InnerProductSpace
+
+namespace FrustrationFree
+
+variable {E F : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [NormedAddCommGroup F] [InnerProductSpace ℂ F]
+
+/-- The real-part form of the weighted inner-product estimate used twice in
+Nachtergaele's display `Enpsi2` (cond-mat/9410110, lines 1223--1239). -/
+theorem re_inner_le_weighted_norm_sq (x y : E) {c : ℝ} (hc : 0 < c) :
+    (⟪x, y⟫_ℂ).re ≤ (1 / (2 * c)) * ‖x‖ ^ 2 + (c / 2) * ‖y‖ ^ 2 := by
+  calc
+    (⟪x, y⟫_ℂ).re ≤ ‖x‖ * ‖y‖ := re_inner_le_norm (𝕜 := ℂ) x y
+    _ = (1 / 2 : ℝ) * (2 * ‖y‖ * ‖x‖) := by ring
+    _ ≤ (1 / 2 : ℝ) * (c * ‖y‖ ^ 2 + c⁻¹ * ‖x‖ ^ 2) := by
+      exact mul_le_mul_of_nonneg_left (two_mul_le_add_mul_sq hc) (by positivity)
+    _ = (1 / (2 * c)) * ‖x‖ ^ 2 + (c / 2) * ‖y‖ ^ 2 := by
+      field_simp [hc.ne']
+      ring
+
+/-- If `P` is an orthogonal projection and the literal composition `Q.comp P`
+has operator norm at most `ε`, then its value on the range of `P` has the C3
+norm-square bound used in cond-mat/9410110, lines 1240--1249, from condition C3
+at lines 1083--1094. No strict positivity of `ε` is required; the operator-norm
+hypothesis already implies its nonnegativity. -/
+theorem norm_sq_apply_projection_le_of_norm_comp_le
+    (Q : E →L[ℂ] F) (P : E →L[ℂ] E)
+    (hP : P.toLinearMap.IsSymmetricProjection) {ε : ℝ}
+    (hQP : ‖Q.comp P‖ ≤ ε) (v : E) :
+    ‖Q (P v)‖ ^ 2 ≤ ε ^ 2 * ‖P v‖ ^ 2 := by
+  have hPP : P (P v) = P v := by
+    have h := congrArg (fun T : E →ₗ[ℂ] E ↦ T v) hP.isIdempotentElem.eq
+    simpa [Module.End.mul_apply] using h
+  have hnorm : ‖Q (P v)‖ ≤ ε * ‖P v‖ := by
+    calc
+      ‖Q (P v)‖ = ‖(Q.comp P) (P v)‖ := by simp [hPP]
+      _ ≤ ‖Q.comp P‖ * ‖P v‖ := ContinuousLinearMap.le_opNorm _ _
+      _ ≤ ε * ‖P v‖ := mul_le_mul_of_nonneg_right hQP (norm_nonneg _)
+  simpa [mul_pow] using pow_le_pow_left₀ (norm_nonneg (Q (P v))) hnorm 2
+
+end FrustrationFree

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AnalyticBounds.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AnalyticBounds.lean
@@ -23,7 +23,7 @@ open scoped InnerProductSpace
 namespace FrustrationFree
 
 variable {E F : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
-  [NormedAddCommGroup F] [InnerProductSpace ℂ F]
+  [NormedAddCommGroup F] [NormedSpace ℂ F]
 
 /-- The real-part form of the weighted inner-product estimate used twice in
 Nachtergaele's display `Enpsi2` (cond-mat/9410110, lines 1223--1239). -/
@@ -38,10 +38,10 @@ theorem re_inner_le_weighted_norm_sq (x y : E) {c : ℝ} (hc : 0 < c) :
       field_simp [hc.ne']
       ring
 
-/-- If `P` is an orthogonal projection and the literal composition `Q.comp P`
-has operator norm at most `ε`, then its value on the range of `P` has the C3
+/-- If \(P\) is an orthogonal projection and the literal composition \(QP\)
+has operator norm at most \(\varepsilon\), then its value on the range of \(P\) has the C3
 norm-square bound used in cond-mat/9410110, lines 1240--1249, from condition C3
-at lines 1083--1094. No strict positivity of `ε` is required; the operator-norm
+at lines 1083--1094. No strict positivity of \(\varepsilon\) is required; the operator-norm
 hypothesis already implies its nonnegativity. -/
 theorem norm_sq_apply_projection_le_of_norm_comp_le
     (Q : E →L[ℂ] F) (P : E →L[ℂ] E)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -858,7 +858,7 @@ norm estimate is derived here.
     \label{lem:nachtergaele_weighted_inner_product}
     \lean{FrustrationFree.re_inner_le_weighted_norm_sq}
     \leanok
-    Let $x$ and $y$ belong to a complex Hilbert space. For every $c>0$,
+    Let $x$ and $y$ belong to a complex inner-product space. For every $c>0$,
     \begin{align}
         \re\langle x,y\rangle
          & \leq \frac{1}{2c}\lVert x\rVert^2
@@ -878,7 +878,7 @@ norm estimate is derived here.
     \label{lem:nachtergaele_c3_projection_composition}
     \lean{FrustrationFree.norm_sq_apply_projection_le_of_norm_comp_le}
     \leanok
-    Let $P$ be an orthogonal projection on a complex Hilbert space, and let
+    Let $P$ be an orthogonal projection on a complex inner-product space, and let
     $Q$ be a bounded linear operator from that space to another. If
     \begin{align}
         \lVert QP\rVert & \leq \epsilon,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -854,6 +854,51 @@ norm estimate is derived here.
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
+\begin{lemma}[Weighted inner-product estimate]
+    \label{lem:nachtergaele_weighted_inner_product}
+    \lean{FrustrationFree.re_inner_le_weighted_norm_sq}
+    \leanok
+    Let $x$ and $y$ belong to a complex Hilbert space. For every $c>0$,
+    \begin{align}
+        \re\langle x,y\rangle
+         & \leq \frac{1}{2c}\lVert x\rVert^2
+        +\frac{c}{2}\lVert y\rVert^2.
+        \label{eq:nachtergaele_weighted_inner_product}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Cauchy--Schwarz bounds the left-hand side by
+    $\lVert x\rVert\lVert y\rVert$. Apply the weighted arithmetic--geometric
+    mean inequality to $\lVert y\rVert$ and $\lVert x\rVert$.
+\end{proof}
+
+\begin{lemma}[C3 projection-composition estimate]
+    \label{lem:nachtergaele_c3_projection_composition}
+    \lean{FrustrationFree.norm_sq_apply_projection_le_of_norm_comp_le}
+    \leanok
+    Let $P$ be an orthogonal projection on a complex Hilbert space, and let
+    $Q$ be a bounded linear operator from that space to another. If
+    \begin{align}
+        \lVert QP\rVert & \leq \epsilon,
+    \end{align}
+    then, for every $v$,
+    \begin{align}
+        \lVert QPv\rVert^2
+         & \leq \epsilon^2\lVert Pv\rVert^2.
+        \label{eq:nachtergaele_c3_projection_composition}
+    \end{align}
+    This includes $\epsilon=0$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Idempotency gives $QPv=QP(Pv)$. Apply the operator-norm estimate for
+    $QP$ to $Pv$ and square the resulting nonnegative inequality. The
+    hypothesis itself implies $\epsilon\geq0$.
+\end{proof}
+
 \begin{theorem}[Moving-window double counting]
     \label{thm:moving_window_sum_le}
     \lean{FrustrationFree.movingWindow_sum_le}


### PR DESCRIPTION
### Motivation

Nachtergaele’s martingale argument uses two elementary analytic estimates that were not yet available on the source-facing parent-Hamiltonian path. Issue #7485 needs these estimates with the constants and projection order appearing in the paper.

### Description

- adds the weighted real-part estimate used twice in the display `Enpsi2`
- derives the pointwise C3 norm-square estimate from the literal projection composition bound
- records both source-backed helpers in Chapter 13 and the parent-Hamiltonian import surface
- preserves the source choices `c₁ = 1 - εₗ sqrt(l+1)` and `c₂ = εₗ / sqrt(l+1)`, hence the exact factor `(γₗ₊₁ / dₗ₊₁) (1 - εₗ sqrt(l+1))²`

Source: `References/cond-mat_9410110/main.tex`, lines 1083-1094 and 1195-1259.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.AnalyticBounds TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian` (9177 jobs)
- `python3 scripts/generate_import_aggregators.py --check` (37 generated files, 1055 production modules)
- `python3 scripts/lean_import_syntax.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- pinned `latexindent` byte comparison and ChkTeX on the changed Chapter 13 file
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- global Blueprint duplicate-label scan and exact status/dependency-tag preservation check
- `git diff --check origin/main`
- hosted exact-head root build and Blueprint compilation passed

Advances #7485.