### PR TITLE
feat(parent-hamiltonian): cancel outside martingale window

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -72,6 +72,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
+import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.MixedGram

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
+import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
@@ -35,13 +36,15 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The thirteen components are:
+The fourteen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
   (quadratic form implies norm bound);
 * `Martingale.DifferenceProjections` — Nachtergaele's mutually orthogonal
   martingale differences, telescoping resolution, and norm-square decomposition;
+* `Martingale.ProjectionCancellation` — outside-window cancellation and the
+  finite interval reduction between equations \(Enpsi\) and \(Enpsi2\);
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.AdjacentLocalTerms` — individual three-site kernels and the

--- a/TNLean/MPS/ParentHamiltonian/Martingale/ProjectionCancellation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/ProjectionCancellation.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
+
+/-!
+# Outside-window cancellation for martingale differences
+
+This file formalizes the commutation reduction between equations \(Enpsi\) and
+\(Enpsi2\) in the proof of Nachtergaele's Theorem 2.1(i),
+arXiv:cond-mat/9410110, lines 1206--1220. For the local ground projection
+\(Q_n=G_{n,l}\), the source assumes that \(E_m\) commutes with \(Q_n\) when
+\(m<n-l\) or \(n<m\). Mutual orthogonality of the martingale differences then
+gives
+\[
+  E_mQ_nE_n=Q_nE_mE_n=0.
+\]
+Consequently, the complete resolution sum over \(0\leq m<N\) reduces to the
+active interval \(n-l\leq m\leq n\).
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace FrustrationFree.NestedGroundProjections
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- Outside the interval \([n-l,n]\), source commutation with the local ground
+projection \(Q_n\) and martingale-difference orthogonality imply
+\(E_mQ_nE_n=0\).
+
+This is the cancellation in Nachtergaele, arXiv:cond-mat/9410110, lines
+1210--1215. -/
+theorem martingaleDifference_comp_localProjection_comp_eq_zero
+    (G : NestedGroundProjections (E := E)) (Q : E →ₗ[ℂ] E) {m n l : ℕ}
+    (hout : m < n - l ∨ n < m)
+    (hcomm : (G.martingaleDifference m).comp Q =
+      Q.comp (G.martingaleDifference m)) :
+    (G.martingaleDifference m).comp
+      (Q.comp (G.martingaleDifference n)) = 0 := by
+  have hmn : m ≠ n := by omega
+  calc
+    (G.martingaleDifference m).comp
+        (Q.comp (G.martingaleDifference n)) =
+      ((G.martingaleDifference m).comp Q).comp
+        (G.martingaleDifference n) := by
+          rw [LinearMap.comp_assoc]
+    _ = (Q.comp (G.martingaleDifference m)).comp
+        (G.martingaleDifference n) := by rw [hcomm]
+    _ = Q.comp ((G.martingaleDifference m).comp
+        (G.martingaleDifference n)) := by rw [LinearMap.comp_assoc]
+    _ = 0 := by
+      rw [G.martingaleDifference_comp_eq_zero hmn, LinearMap.comp_zero]
+
+/-- The full martingale-resolution sum in \(Enpsi\) reduces to the active
+indices \(m\in[n-l,n]\).
+
+The hypothesis is exactly the source commutation condition outside that
+interval. The bound \(n<N\) ensures that every active index occurs in the
+original sum \(0\leq m<N\). This is the finite-sum reduction used in
+Nachtergaele's equation \(Enpsi2\), arXiv:cond-mat/9410110, lines 1206--1220. -/
+theorem sum_martingaleDifference_localProjection_eq_sum_Icc
+    (G : NestedGroundProjections (E := E)) (Q : E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp Q =
+        Q.comp (G.martingaleDifference m)) (v : E) :
+    ∑ m ∈ Finset.range N,
+        G.martingaleDifference m (Q (G.martingaleDifference n v)) =
+      ∑ m ∈ Finset.Icc (n - l) n,
+        G.martingaleDifference m (Q (G.martingaleDifference n v)) := by
+  symm
+  apply Finset.sum_subset
+  · intro m hm
+    exact Finset.mem_range.mpr (lt_of_le_of_lt (Finset.mem_Icc.mp hm).2 hn)
+  · intro m _ hm
+    have hout : m < n - l ∨ n < m := by
+      rw [Finset.mem_Icc] at hm
+      omega
+    change ((G.martingaleDifference m).comp
+      (Q.comp (G.martingaleDifference n))) v = 0
+    rw [martingaleDifference_comp_localProjection_comp_eq_zero G Q hout
+      (hcomm m hout)]
+    rfl
+
+/-- Inner-product form of the active-window reduction from \(Enpsi\) to
+\(Enpsi2\):
+\[
+ \left\langle v,\sum_{m=0}^{N-1}E_mQ_nE_nv\right\rangle
+ =\left\langle\sum_{m=n-l}^{n}E_mv,Q_nE_nv\right\rangle.
+\]
+
+This uses only the outside-window commutation hypothesis and symmetry of the
+martingale differences, exactly as in Nachtergaele,
+arXiv:cond-mat/9410110, lines 1206--1220. -/
+theorem inner_sum_martingaleDifference_localProjection_eq_inner_sum_Icc
+    (G : NestedGroundProjections (E := E)) (Q : E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp Q =
+        Q.comp (G.martingaleDifference m)) (v : E) :
+    inner ℂ v (∑ m ∈ Finset.range N,
+        G.martingaleDifference m (Q (G.martingaleDifference n v))) =
+      inner ℂ (∑ m ∈ Finset.Icc (n - l) n,
+        G.martingaleDifference m v) (Q (G.martingaleDifference n v)) := by
+  rw [G.sum_martingaleDifference_localProjection_eq_sum_Icc Q N n l hn hcomm v]
+  simp_rw [inner_sum, sum_inner]
+  apply Finset.sum_congr rfl
+  intro m _
+  exact (G.martingaleDifference_isSymmetricProjection m).isSymmetric
+    v (Q (G.martingaleDifference n v)) |>.symm
+
+end FrustrationFree.NestedGroundProjections

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -129,6 +129,53 @@
     $v=\sum_{n=0}^{N-1}E_nv$ into the Pythagorean identity.
 \end{proof}
 
+% Source: References/cond-mat_9410110/main.tex:1206--1220,
+% Theorem 2.1(i), equations Enpsi and Enpsi2.
+
+\begin{theorem}[Outside-window martingale cancellation]%
+    \label{thm:outside-window-martingale-cancellation}
+    \lean{FrustrationFree.NestedGroundProjections.martingaleDifference_comp_localProjection_comp_eq_zero}
+    \lean{FrustrationFree.NestedGroundProjections.inner_sum_martingaleDifference_localProjection_eq_inner_sum_Icc}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    Let $Q_n$ be a local ground projection and suppose that
+    \begin{align}
+        E_mQ_n & =Q_nE_m
+               &         & \text{whenever }m<n-l\text{ or }n<m.
+    \end{align}
+    Then every index outside $[n-l,n]$ cancels:
+    \begin{align}
+        E_mQ_nE_n & =0
+                  &    & \text{whenever }m<n-l\text{ or }n<m.
+    \end{align}
+    If $n<N$, the complete resolution term therefore reduces to
+    \begin{align}
+        \left\langle v,
+        \sum_{m=0}^{N-1}E_mQ_nE_nv\right\rangle
+         & =\left\langle
+        \sum_{m=n-l}^{n}E_mv,Q_nE_nv\right\rangle.
+    \end{align}
+    This is the reduction from \textup{Enpsi} to the first line of
+    \textup{Enpsi2} in \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:orthogonal-martingale-difference-resolution}
+    For an outside index, commutation and orthogonality give
+    \begin{align}
+        E_mQ_nE_n & =Q_nE_mE_n=0,
+    \end{align}
+    since either inequality implies $m\ne n$.  Hence only
+    $n-l\leq m\leq n$ remains in the finite sum.  Finally, symmetry of each
+    $E_m$ gives
+    \begin{align}
+        \langle v,E_mQ_nE_nv\rangle
+         & =\langle E_mv,Q_nE_nv\rangle,
+    \end{align}
+    and summing over the active interval proves the displayed identity.
+\end{proof}
+
 \subsection{Spectator-indexed boundary maps}\label{subsec:spectator_boundary_maps}
 
 The tail and left boundary maps embed virtual-space data into a common


### PR DESCRIPTION
## Summary

Stacked on the martingale-difference branch from PR #7515. This preserves the issue #7487 projection-cancellation checkpoint and should be reviewed after its base PR.

## Verification

- git diff check passed for the branch range