### PR TITLE
feat(MPS/ParentHamiltonian): prove embedded fixed-window C2

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -68,6 +68,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
+import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -10,6 +10,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
+import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
@@ -54,6 +55,8 @@ The fourteen components are:
   and the projector-defect reduction to an anticommutator estimate;
 * `Martingale.OpenHamiltonian` — the nonwrapping finite-volume Hamiltonian and its
   kernel identification with the open MPS boundary-condition space;
+* `Martingale.EmbeddedC2` — the unique fixed-window suffix interaction and
+  condition C2 with constant one;
 * `Martingale.C3Threshold` — a uniform input-site overlap length satisfying the
   open-chain C3 defect threshold and its anticommutator consequence;
 * `Martingale.BlockedGap` — transport of that threshold to three blocked sites

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -37,7 +37,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The fourteen components are:
+The sixteen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`

--- a/TNLean/MPS/ParentHamiltonian/Martingale/EmbeddedC2.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/EmbeddedC2.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
+
+/-!
+# Embedded fixed-window condition C2
+
+When the suffix length equals the interaction length \(L\), the compatible suffix
+Hamiltonian contains exactly one nonwrapping local parent interaction. Hence it
+is an orthogonal projection and satisfies Nachtergaele's condition C2 with
+constant one.
+
+The statements remain generic in \(L\). Setting \(L = l + 1\) and
+\(m = n + 1\) gives the source interval
+\(\Lambda_{n+1}\setminus\Lambda_{n-l}=[n-l,n+1)\) and
+\(\gamma_{l+1}=1\).
+
+## References
+
+* Nachtergaele, arXiv:cond-mat/9410110, condition C2, lines 1043--1058;
+  Theorem 2.1(i), lines 1119--1130; proof lines 1240--1248.
+-/
+
+open scoped InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A suffix whose length equals the interaction length contains exactly the
+local term starting at \(n-L\). -/
+theorem openSuffixParentHamiltonianES_eq_localTermES (A : MPSTensor d D)
+    {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n) (hnN : n ≤ N) :
+    openSuffixParentHamiltonianES A L L N n =
+      localTermES A L (⟨n - L, by omega⟩ : Fin N) := by
+  have hn : 0 < n := lt_of_lt_of_le hL hLn
+  have hstart : n - L < N := lt_of_lt_of_le (Nat.sub_lt hn hL) hnN
+  let i : NonwrappingStart L N :=
+    ⟨⟨n - L, hstart⟩, by simpa [Nat.sub_add_cancel hLn] using hnN⟩
+  have hfilter :
+      Finset.univ.filter (fun j : NonwrappingStart L N =>
+        n - L ≤ j.1.val ∧ j.1.val + L ≤ n) = {i} := by
+    ext j
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton]
+    constructor
+    · rintro ⟨hjLower, hjUpper⟩
+      apply Subtype.ext
+      apply Fin.ext
+      exact le_antisymm (Nat.le_sub_of_add_le hjUpper) hjLower
+    · intro hji
+      subst j
+      exact ⟨le_rfl, Nat.sub_add_cancel hLn ▸ le_rfl⟩
+  rw [openSuffixParentHamiltonianES, hfilter, Finset.sum_singleton]
+
+/-- The fixed-window suffix Hamiltonian is a symmetric projection. -/
+theorem openSuffixParentHamiltonianES_isSymmetricProjection
+    (A : MPSTensor d D) {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n)
+    (hnN : n ≤ N) :
+    (openSuffixParentHamiltonianES A L L N n).IsSymmetricProjection := by
+  rw [openSuffixParentHamiltonianES_eq_localTermES A hL hLn hnN]
+  exact localTermES_isSymmetricProjection A L _
+
+/-- The fixed-window suffix Hamiltonian is the orthogonal projection onto the
+orthogonal complement of its kernel. -/
+theorem openSuffixParentHamiltonianES_eq_orthogonal_starProjection_ker
+    (A : MPSTensor d D) {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n)
+    (hnN : n ≤ N) :
+    openSuffixParentHamiltonianES A L L N n =
+      (LinearMap.ker (openSuffixParentHamiltonianES A L L N n))ᗮ.starProjection.toLinearMap := by
+  let H := openSuffixParentHamiltonianES A L L N n
+  have hH : H.IsSymmetricProjection :=
+    openSuffixParentHamiltonianES_isSymmetricProjection A hL hLn hnN
+  apply hH.ext (Submodule.isSymmetricProjection_starProjection (LinearMap.ker H)ᗮ)
+  rw [Submodule.range_starProjection]
+  have hrangeOrthogonal : (LinearMap.range H)ᗮ = LinearMap.ker H :=
+    (LinearMap.IsIdempotentElem.isSymmetric_iff_orthogonal_range
+      hH.isIdempotentElem).mp hH.isSymmetric
+  calc
+    LinearMap.range H = (LinearMap.range H)ᗮᗮ :=
+      (Submodule.orthogonal_orthogonal (LinearMap.range H)).symm
+    _ = (LinearMap.ker H)ᗮ := congrArg Submodule.orthogonal hrangeOrthogonal
+
+/-- Literal fixed-window identity \(H=I-G\), where \(G\) is the orthogonal
+projection onto the kernel of \(H\). -/
+theorem openSuffixParentHamiltonianES_eq_id_sub_starProjection_ker
+    (A : MPSTensor d D) {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n)
+    (hnN : n ≤ N) :
+    openSuffixParentHamiltonianES A L L N n =
+      LinearMap.id -
+        (LinearMap.ker (openSuffixParentHamiltonianES A L L N n)).starProjection.toLinearMap := by
+  let H := openSuffixParentHamiltonianES A L L N n
+  calc
+    H = (LinearMap.ker H)ᗮ.starProjection.toLinearMap :=
+      openSuffixParentHamiltonianES_eq_orthogonal_starProjection_ker A hL hLn hnN
+    _ = (1 - (LinearMap.ker H).starProjection).toLinearMap := by
+      rw [Submodule.starProjection_orthogonal']
+    _ = LinearMap.id - (LinearMap.ker H).starProjection.toLinearMap := rfl
+
+/-- Nachtergaele's condition C2 in Loewner order, with \(\gamma_L=1\). -/
+theorem openSuffixParentHamiltonianES_C2 (A : MPSTensor d D)
+    {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n) (hnN : n ≤ N) :
+    LinearMap.id -
+        (LinearMap.ker (openSuffixParentHamiltonianES A L L N n)).starProjection.toLinearMap ≤
+      openSuffixParentHamiltonianES A L L N n := by
+  exact (openSuffixParentHamiltonianES_eq_id_sub_starProjection_ker
+    A hL hLn hnN).symm.le
+
+/-- Quadratic-form version of condition C2 with \(\gamma_L=1\). -/
+theorem openSuffixParentHamiltonianES_C2_quadratic_form (A : MPSTensor d D)
+    {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n) (hnN : n ≤ N)
+    (v : EuclideanSpace ℂ (Cfg d N)) :
+    ((⟪((LinearMap.id : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ]
+          EuclideanSpace ℂ (Cfg d N)) -
+          (LinearMap.ker (openSuffixParentHamiltonianES A L L N n)).starProjection.toLinearMap) v,
+        v⟫_ℂ).re) ≤
+      (⟪openSuffixParentHamiltonianES A L L N n v, v⟫_ℂ).re := by
+  have hvEq := LinearMap.congr_fun
+    (openSuffixParentHamiltonianES_eq_id_sub_starProjection_ker A hL hLn hnN) v
+  exact (congrArg (fun w => (⟪w, v⟫_ℂ).re) hvEq.symm).le
+
+/-- On the orthogonal complement of its kernel, the fixed-window suffix
+Hamiltonian preserves the norm exactly. -/
+theorem openSuffixParentHamiltonianES_norm_eq_of_mem_orthogonal_ker
+    (A : MPSTensor d D) {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n)
+    (hnN : n ≤ N) (v : EuclideanSpace ℂ (Cfg d N))
+    (hv : v ∈ (LinearMap.ker (openSuffixParentHamiltonianES A L L N n))ᗮ) :
+    ‖openSuffixParentHamiltonianES A L L N n v‖ = ‖v‖ := by
+  rw [openSuffixParentHamiltonianES_eq_orthogonal_starProjection_ker A hL hLn hnN]
+  apply Submodule.norm_starProjection_apply
+  exact hv
+
+/-- The fixed-window suffix Hamiltonian has unit gap on the orthogonal
+complement of its kernel. Under \(L=l+1\) and with endpoint \(m=n+1\), this is
+\(\gamma_{l+1}=1\) in Nachtergaele's Theorem 2.1(i). -/
+theorem openSuffixParentHamiltonianES_unit_gap (A : MPSTensor d D)
+    {L N n : ℕ} (hL : 0 < L) (hLn : L ≤ n) (hnN : n ≤ N)
+    (v : EuclideanSpace ℂ (Cfg d N))
+    (hv : v ∈ (LinearMap.ker (openSuffixParentHamiltonianES A L L N n))ᗮ) :
+    (1 : ℝ) * ‖v‖ ≤ ‖openSuffixParentHamiltonianES A L L N n v‖ := by
+  simpa only [one_mul] using
+    (openSuffixParentHamiltonianES_norm_eq_of_mem_orthogonal_ker
+      A hL hLn hnN v hv).symm.le
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1114,6 +1114,106 @@ coercivity.
     Its local windows lie in the nonwrapping interval $[n-l,n)$.
 \end{definition}
 
+% Source anchors: References/cond-mat_9410110/main.tex, condition C2,
+% lines 1043--1058; Theorem 2.1(i), lines 1119--1130; and the one-window
+% argument in the printed proof, lines 1240--1248.
+\begin{theorem}[Embedded fixed-window condition C2]
+    \label{thm:open_suffix_parent_hamiltonian_es_c2}
+    \lean{MPSTensor.openSuffixParentHamiltonianES_eq_localTermES,
+        MPSTensor.openSuffixParentHamiltonianES_isSymmetricProjection,
+        MPSTensor.openSuffixParentHamiltonianES_eq_orthogonal_starProjection_ker,
+        MPSTensor.openSuffixParentHamiltonianES_eq_id_sub_starProjection_ker,
+        MPSTensor.openSuffixParentHamiltonianES_C2,
+        MPSTensor.openSuffixParentHamiltonianES_C2_quadratic_form,
+        MPSTensor.openSuffixParentHamiltonianES_norm_eq_of_mem_orthogonal_ker,
+        MPSTensor.openSuffixParentHamiltonianES_unit_gap}
+    \leanok
+    \uses{def:open_suffix_parent_hamiltonian_es,
+        lem:transported_es_local_projections}
+    Let $L>0$ and $L\leq m\leq N$. The suffix of length $L$ ending at $m$
+    contains one interaction:
+    \begin{align}
+        H^{\mathrm{suffix}}_{N,L;L,m}(A)
+         & =h_{m-L,\mathrm{ES}}(A,L).
+        \label{eq:open_suffix_parent_hamiltonian_unique_term}
+    \end{align}
+    Write $G^{\ker}_{N,L;m}$ for the orthogonal projection onto the kernel of
+    this suffix Hamiltonian. Then
+    \begin{align}
+        H^{\mathrm{suffix}}_{N,L;L,m}(A)
+         &=\operatorname{Proj}_{(\ker H^{\mathrm{suffix}}_{N,L;L,m}(A))^\perp}
+          =I-G^{\ker}_{N,L;m}.
+        \label{eq:open_suffix_parent_hamiltonian_id_sub_kernel}
+    \end{align}
+    Consequently condition C2 holds in Loewner order with $\gamma_L=1$:
+    \begin{align}
+        H^{\mathrm{suffix}}_{N,L;L,m}(A)
+         &\geq I-G^{\ker}_{N,L;m}.
+        \label{eq:open_suffix_parent_hamiltonian_c2}
+    \end{align}
+    Equivalently, for every $v$,
+    \begin{align}
+        \re\left\langle (I-G^{\ker}_{N,L;m})v,v\right\rangle
+         &\leq
+        \re\left\langle H^{\mathrm{suffix}}_{N,L;L,m}(A)v,v\right\rangle.
+        \label{eq:open_suffix_parent_hamiltonian_c2_form}
+    \end{align}
+    If $v\in(\ker H^{\mathrm{suffix}}_{N,L;L,m}(A))^\perp$, then
+    \begin{align}
+        \left\lVert H^{\mathrm{suffix}}_{N,L;L,m}(A)v\right\rVert
+         &=\lVert v\rVert.
+        \label{eq:open_suffix_parent_hamiltonian_norm}
+    \end{align}
+    In particular,
+    \begin{align}
+        \lVert v\rVert
+         &\leq\left\lVert H^{\mathrm{suffix}}_{N,L;L,m}(A)v\right\rVert.
+        \label{eq:open_suffix_parent_hamiltonian_unit_gap}
+    \end{align}
+    In the notation of \cite{Nachtergaele1996Spectral}, set $L=l+1$ and
+    $m=n+1$. The interval is then
+    $\Lambda_{n+1}\setminus\Lambda_{n-l}=[n-l,n+1)$, so
+    \begin{align}
+        d_{l+1}&=1.
+    \end{align}
+    Condition C2 has the constant
+    \begin{align}
+        \gamma_{l+1}&=1.
+    \end{align}
+    The later condition C3 uses the distinct overlap parameter
+    $\varepsilon_l$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:open_suffix_parent_hamiltonian_es,
+        lem:transported_es_local_projections}
+    % Source anchor: References/cond-mat_9410110/main.tex, lines 1240--1248.
+    An admissible start $i$ satisfies
+    \begin{align}
+        m-L&\leq i.
+    \end{align}
+    It also satisfies
+    \begin{align}
+        i+L&\leq m.
+    \end{align}
+    Hence $i=m-L$, which proves
+    Equation~\eqref{eq:open_suffix_parent_hamiltonian_unique_term}. The sole
+    local term is an orthogonal projection. For any orthogonal projection $H$,
+    \begin{align}
+        \operatorname{ran}H&=(\ker H)^\perp.
+    \end{align}
+    Therefore
+    \begin{align}
+        H&=\operatorname{Proj}_{(\ker H)^\perp}
+          =I-\operatorname{Proj}_{\ker H}.
+    \end{align}
+    This gives Equation~\eqref{eq:open_suffix_parent_hamiltonian_id_sub_kernel}.
+    The Loewner and quadratic-form inequalities are equalities. On
+    $(\ker H)^\perp=\operatorname{ran}H$, idempotence gives $Hv=v$, and hence
+    exact norm preservation and the unit lower bound.
+\end{proof}
+
 \begin{theorem}[Finite-overlap condition C1 for the compatible open chain]
     \label{thm:open_parent_hamiltonian_es_c1}
     \lean{MPSTensor.openParentHamiltonianES_C1}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1114,9 +1114,46 @@ coercivity.
     Its local windows lie in the nonwrapping interval $[n-l,n)$.
 \end{definition}
 
+\begin{theorem}[Finite-overlap condition C1 for the compatible open chain]
+    \label{thm:open_parent_hamiltonian_es_c1}
+    \lean{MPSTensor.openParentHamiltonianES_C1}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es,
+        def:open_suffix_parent_hamiltonian_es}
+    If $L\leq l$, then
+    \begin{align}
+        0
+        \leq \sum_{n=l}^{N}H^{\mathrm{suffix}}_{N,L;l,n}(A)
+        \leq (l-L+1)H^{\mathrm{open}}_{N,L}(A).
+        \label{eq:open_parent_hamiltonian_es_c1}
+    \end{align}
+    Thus condition C1 of
+    \cite{Nachtergaele1996Spectral} holds with $d_l=l-L+1$.
+    This is the source value $pl-r+1$ in the present convention $p=1$ and
+    interaction range $r=L$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:transported_es_positive}
+    Fix a starting site $i\in I_{L,N}$. The suffix Hamiltonian indexed by $n$
+    contains its local term exactly when
+    \begin{align}
+        i+L\leq n\leq i+l.
+    \end{align}
+    This interval contains at most $l-L+1$ integers. Reversing the two finite
+    sums therefore writes the left-hand side as
+    \begin{align}
+        \sum_{i\in I_{L,N}}c_i h_{i,\mathrm{ES}}(A,L),
+    \end{align}
+    where $0\leq c_i\leq l-L+1$. Positivity of each local term turns the
+    coefficient bound into the upper operator inequality. Positivity of their
+    sum gives the lower inequality.
+\end{proof}
+
 % Source anchors: References/cond-mat_9410110/main.tex, condition C2,
-% lines 1043--1058; Theorem 2.1(i), lines 1119--1130; and the one-window
-% argument in the printed proof, lines 1240--1248.
+% lines 1043--1058; Theorem 2.1(i), lines 1119--1130; and the use of C2 with
+% gamma_{l+1} in the printed proof, lines 1240--1248.
 \begin{theorem}[Embedded fixed-window condition C2]
     \label{thm:open_suffix_parent_hamiltonian_es_c2}
     \lean{MPSTensor.openSuffixParentHamiltonianES_eq_localTermES,
@@ -1129,6 +1166,7 @@ coercivity.
         MPSTensor.openSuffixParentHamiltonianES_unit_gap}
     \leanok
     \uses{def:open_suffix_parent_hamiltonian_es,
+        thm:open_parent_hamiltonian_es_c1,
         lem:transported_es_local_projections}
     Let $L>0$ and $L\leq m\leq N$. The suffix of length $L$ ending at $m$
     contains one interaction:
@@ -1189,8 +1227,10 @@ coercivity.
 \begin{proof}
     \leanok
     \uses{def:open_suffix_parent_hamiltonian_es,
+        thm:open_parent_hamiltonian_es_c1,
         lem:transported_es_local_projections}
-    % Source anchor: References/cond-mat_9410110/main.tex, lines 1240--1248.
+    % The interval calculation specializes the compatible open-chain sum to
+    % L=l+1. Source lines 1240--1248 then use C2 with gamma_{l+1}.
     An admissible start $i$ satisfies
     \begin{align}
         m-L
@@ -1217,44 +1257,9 @@ coercivity.
     This gives Equation~\eqref{eq:open_suffix_parent_hamiltonian_id_sub_kernel}.
     The Loewner and quadratic-form inequalities are equalities. On
     $(\ker H)^\perp=\operatorname{ran}H$, idempotence gives $Hv=v$, and hence
-    exact norm preservation and the unit lower bound.
-\end{proof}
-
-\begin{theorem}[Finite-overlap condition C1 for the compatible open chain]
-    \label{thm:open_parent_hamiltonian_es_c1}
-    \lean{MPSTensor.openParentHamiltonianES_C1}
-    \leanok
-    \uses{def:open_parent_hamiltonian_es,
-        def:open_suffix_parent_hamiltonian_es}
-    If $L\leq l$, then
-    \begin{align}
-        0
-        \leq \sum_{n=l}^{N}H^{\mathrm{suffix}}_{N,L;l,n}(A)
-        \leq (l-L+1)H^{\mathrm{open}}_{N,L}(A).
-        \label{eq:open_parent_hamiltonian_es_c1}
-    \end{align}
-    Thus condition C1 of
-    \cite{Nachtergaele1996Spectral} holds with $d_l=l-L+1$.
-    This is the source value $pl-r+1$ in the present convention $p=1$ and
-    interaction range $r=L$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{lem:transported_es_positive}
-    Fix a starting site $i\in I_{L,N}$. The suffix Hamiltonian indexed by $n$
-    contains its local term exactly when
-    \begin{align}
-        i+L\leq n\leq i+l.
-    \end{align}
-    This interval contains at most $l-L+1$ integers. Reversing the two finite
-    sums therefore writes the left-hand side as
-    \begin{align}
-        \sum_{i\in I_{L,N}}c_i h_{i,\mathrm{ES}}(A,L),
-    \end{align}
-    where $0\leq c_i\leq l-L+1$. Positivity of each local term turns the
-    coefficient bound into the upper operator inequality. Positivity of their
-    sum gives the lower inequality.
+    exact norm preservation and the unit lower bound. Condition C1 at suffix
+    length $L$ gives $d_L=L-L+1=1$. With $L=l+1$, the two constants are therefore
+    $d_{l+1}=1$ and $\gamma_{l+1}=1$.
 \end{proof}
 
 \begin{theorem}[Zero energy forces every compatible local constraint]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1141,44 +1141,46 @@ coercivity.
     this suffix Hamiltonian. Then
     \begin{align}
         H^{\mathrm{suffix}}_{N,L;L,m}(A)
-         &=\operatorname{Proj}_{(\ker H^{\mathrm{suffix}}_{N,L;L,m}(A))^\perp}
-          =I-G^{\ker}_{N,L;m}.
+         & =\operatorname{Proj}_{(\ker H^{\mathrm{suffix}}_{N,L;L,m}(A))^\perp}
+        =I-G^{\ker}_{N,L;m}.
         \label{eq:open_suffix_parent_hamiltonian_id_sub_kernel}
     \end{align}
     Consequently condition C2 holds in Loewner order with $\gamma_L=1$:
     \begin{align}
         H^{\mathrm{suffix}}_{N,L;L,m}(A)
-         &\geq I-G^{\ker}_{N,L;m}.
+         & \geq I-G^{\ker}_{N,L;m}.
         \label{eq:open_suffix_parent_hamiltonian_c2}
     \end{align}
     Equivalently, for every $v$,
     \begin{align}
         \re\left\langle (I-G^{\ker}_{N,L;m})v,v\right\rangle
-         &\leq
+         & \leq
         \re\left\langle H^{\mathrm{suffix}}_{N,L;L,m}(A)v,v\right\rangle.
         \label{eq:open_suffix_parent_hamiltonian_c2_form}
     \end{align}
     If $v\in(\ker H^{\mathrm{suffix}}_{N,L;L,m}(A))^\perp$, then
     \begin{align}
         \left\lVert H^{\mathrm{suffix}}_{N,L;L,m}(A)v\right\rVert
-         &=\lVert v\rVert.
+         & =\lVert v\rVert.
         \label{eq:open_suffix_parent_hamiltonian_norm}
     \end{align}
     In particular,
     \begin{align}
         \lVert v\rVert
-         &\leq\left\lVert H^{\mathrm{suffix}}_{N,L;L,m}(A)v\right\rVert.
+         & \leq\left\lVert H^{\mathrm{suffix}}_{N,L;L,m}(A)v\right\rVert.
         \label{eq:open_suffix_parent_hamiltonian_unit_gap}
     \end{align}
     In the notation of \cite{Nachtergaele1996Spectral}, set $L=l+1$ and
     $m=n+1$. The interval is then
     $\Lambda_{n+1}\setminus\Lambda_{n-l}=[n-l,n+1)$, so
     \begin{align}
-        d_{l+1}&=1.
+        d_{l+1}
+         & =1.
     \end{align}
     Condition C2 has the constant
     \begin{align}
-        \gamma_{l+1}&=1.
+        \gamma_{l+1}
+         & =1.
     \end{align}
     The later condition C3 uses the distinct overlap parameter
     $\varepsilon_l$.
@@ -1191,22 +1193,26 @@ coercivity.
     % Source anchor: References/cond-mat_9410110/main.tex, lines 1240--1248.
     An admissible start $i$ satisfies
     \begin{align}
-        m-L&\leq i.
+        m-L
+         & \leq i.
     \end{align}
     It also satisfies
     \begin{align}
-        i+L&\leq m.
+        i+L
+         & \leq m.
     \end{align}
     Hence $i=m-L$, which proves
     Equation~\eqref{eq:open_suffix_parent_hamiltonian_unique_term}. The sole
     local term is an orthogonal projection. For any orthogonal projection $H$,
     \begin{align}
-        \operatorname{ran}H&=(\ker H)^\perp.
+        \operatorname{ran}H
+         & =(\ker H)^\perp.
     \end{align}
     Therefore
     \begin{align}
-        H&=\operatorname{Proj}_{(\ker H)^\perp}
-          =I-\operatorname{Proj}_{\ker H}.
+        H
+         & =\operatorname{Proj}_{(\ker H)^\perp}
+        =I-\operatorname{Proj}_{\ker H}.
     \end{align}
     This gives Equation~\eqref{eq:open_suffix_parent_hamiltonian_id_sub_kernel}.
     The Loewner and quadratic-form inequalities are equalities. On

--- a/scripts/check_numbered_lean_files.py
+++ b/scripts/check_numbered_lean_files.py
@@ -68,6 +68,8 @@ SEMANTIC_EXCEPTIONS: dict[str, str] = {
         "ZMod 2 is the mathematical coefficient group used by the example.",
     "TNLean/MPS/MPDO/GroupedFigure8.lean":
         "Figure 8 is the source-paper figure whose grouped construction is formalized.",
+    "TNLean/MPS/ParentHamiltonian/Martingale/EmbeddedC2.lean":
+        "Condition C2 is Nachtergaele's martingale condition formalized by this module.",
     "TNLean/MPS/Periodic/Symmetry/Corollary41.lean":
         "Corollary 4.1 is the source result formalized by this module.",
 }


### PR DESCRIPTION
### Motivation

Nachtergaele condition C2 requires the finite suffix Hamiltonian to dominate the orthogonal complement of its ground space. Issue #7488 asks for the exact fixed-window case used in the source indexing.

### Description

- proves that the embedded suffix with interaction length and suffix length both equal to `L` contains exactly the local projector starting at `m - L`
- identifies this Hamiltonian with the orthogonal projection onto the complement of its kernel and hence with `I - G`
- exports the Loewner and quadratic-form forms of C2, exact norm preservation, and the unit gap `γ_{l+1} = 1`
- records the source indexing `L = l + 1`, `m = n + 1`, and `d_{l+1} = γ_{l+1} = 1`, distinct from the C3 parameter `ε_l`

Source review: Nachtergaele, arXiv:cond-mat/9410110, condition C2 (lines 1043–1058), Theorem 2.1(i) (lines 1119–1130), and proof lines 1240–1248. The result uses no primitivity or injectivity hypothesis.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2 TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- pinned `latexindent` 3.24.7 byte comparison against `blueprint/latexindent.yaml`
- double `lualatex` from a clean auxiliary state with pinned tenkz on `TEXINPUTS`; zero undefined non-citation references
- `python3 scripts/check_numbered_lean_files.py` (0 new violations)
- `git diff --check origin/main...HEAD`
- hosted exact-head root build and Blueprint compilation are in progress

Closes #7488