### PR TITLE
feat(MPS/ParentHamiltonian): prove original CPSV range

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -38,6 +38,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.C3CorrectionBounds
 import TNLean.MPS.ParentHamiltonian.CPSVBlockedNearestNeighbor
+import TNLean.MPS.ParentHamiltonian.CPSVOriginalRange
 import TNLean.MPS.ParentHamiltonian.CenteredOverlapFactor
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.CoisometricReconstruction

--- a/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
+++ b/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
@@ -233,7 +233,7 @@ the direct sum of any pure gauges of its distinct representatives. -/
 private theorem CPSVCanonicalFormData.groundSpace_eq_representativeGaugeSum
     {s d : ℕ} {A : MPSTensor s d} (data : CPSVCanonicalFormData A)
     (ref : data.BNTRefinement)
-    {C : (j : Fin data.phaseClasses.g) =>
+    {C : (j : Fin data.phaseClasses.g) →
       MPSTensor s (data.dim (data.representativeIndex j))}
     (hGauge : ∀ j,
       GaugeEquiv (data.blocks (data.representativeIndex j)) (C j))
@@ -262,8 +262,8 @@ private theorem CPSVCanonicalFormData.groundSpace_eq_representativeGaugeSum
       (groundSpace_toTensorFromBlocks_eq_iSup
         (fun _ => 1) C (by simp) L).symm
 
-/-- A normal tensor of bond dimension at most `K` is block injective at
-length `K ^ 4`. -/
+/-- A normal tensor of bond dimension at most \(K\) is block injective at
+length \(K^4\). -/
 private theorem IsNormalTensor.isNBlkInjective_cap_pow_four
     {s n K : ℕ} {A : MPSTensor s n} (hA : IsNormalTensor A)
     (hnK : n ≤ K) : Kraus.IsNBlkInjective A (K ^ 4) := by
@@ -323,7 +323,15 @@ exactly the span of the BNT matrix product vectors.
 
 Source: arXiv:1606.00608, Definition 3.9 and the first sentence of line 527,
 source lines 511--527.  The short-ring completion uses the theorem cited there,
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456. -/
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+
+`HasParentHamiltonianGroundSpaceSpanning` unfolds precisely to Definition
+3.9's spanning clause: the kernel/BNT-span equality for every \(N>L\).  It
+does not include the preceding construction condition \(d^L>D^2\), and hence
+does not by itself assert that the local orthogonal-complement projector is
+nonzero.  That condition is a separate formal boundary, not an additional
+hypothesis of the spanning theorem.  The typeclass `[NeZero D]` records the
+corresponding nonzero bond-dimension boundary. -/
 theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
     {A : MPSTensor d D} [NeZero D] (hA : IsCPSVCanonicalForm A) :
     ∃ g : ℕ, ∃ dim : Fin g → ℕ,

--- a/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
+++ b/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
@@ -1,0 +1,523 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalReduction.TPGauge
+import TNLean.MPS.MPDO.CPSVSharpBlocking
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
+import TNLean.MPS.ParentHamiltonian.BlockDiagonalOneSiteSpan
+import TNLean.MPS.ParentHamiltonian.CoisometricReconstruction
+import TNLean.MPS.SharedInfra.CoisometryGauge
+
+/-!
+# Original-lattice parent-Hamiltonian range for CPSV canonical form
+
+A tensor in the literal canonical form of
+Cirac--Pérez-García--Schuch--Verstraete has an original-lattice parent
+Hamiltonian whose interaction range is at most \(3D^5\).  The ground space on
+every periodic chain longer than that range is spanned by the matrix product
+vectors of a basis of normal tensors.
+
+The proof uses the construction of Pérez-García--Verstraete--Wolf--Cirac,
+Theorem 12.  Its printed global-cut argument proves the kernel identity at a
+range \(R\) when \(N\geq R+L_0\).  We absorb this finite-size window into the
+interaction range by taking
+\[
+  L=3(g-1)(D^4+1)+D^4.
+\]
+For \(N>L\), the theorem applies at
+\(R=3(g-1)(D^4+1)+1\), and antitonicity of the cyclic chain space transports
+the upper inclusion from range \(R\) to range \(L\).  The usual
+frustration-free inclusion supplies the reverse containment.
+
+The predicate `HasParentHamiltonianGroundSpaceSpanning` records only the
+ground-space spanning clause of arXiv:1606.00608, Definition 3.9, lines
+522--524.  The preceding condition \(d^L>D^2\), which makes the local
+orthogonal complement nontrivial, is a separate boundary of that predicate.
+
+## Main result
+
+* `MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning`
+
+## References
+
+* arXiv:1606.00608, Definition 3.9 and line 527, source lines 511--527.
+* arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A spectral-radius-one normal tensor admits the source-unital PGVWC07
+orientation, together with a positive-definite fixed point of the dual
+transfer map, without scalar rescaling.
+
+This is the Perron normalization used in arXiv:quant-ph/0608197, canonical
+normalization lines 742--763 and 816--832, specialized to a normal tensor in
+the sense of arXiv:1606.00608, lines 231--235. -/
+private theorem IsNormalTensor.exists_pgvwc07_unital_dualFixedPoint_gauge
+    {A : MPSTensor d D} (hA : IsNormalTensor A) :
+    ∃ (B : MPSTensor d D) (Λ : Matrix (Fin D) (Fin D) ℂ),
+      GaugeEquiv A B ∧
+      Λ.PosDef ∧
+      (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+      Kraus.transferMap (d := d) (D := D) (fun i => (B i)ᴴ) Λ = Λ := by
+  let : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  have hIrr : Kraus.IsIrreducibleFamily A := hA.no_invariant_proj
+  obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
+    exists_posDef_transferMap_eigenvector_of_irreducible
+      A hIrr hA.exists_apply_ne_zero
+  have hIrrMap : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) A) :=
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily A hIrr
+  have hradius :
+      (spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (Kraus.transferMap (d := d) (D := D) A))).toReal = r :=
+    spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp
+      (Kraus.transferMap (d := d) (D := D) A) (Kraus.transferMap_isCPMap A)
+      hIrrMap ρ r hρ hr hρeig
+  have hradius_one :
+      (spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (Kraus.transferMap (d := d) (D := D) A))).toReal = 1 := by
+    rw [hA.spectral_radius_one]
+    simp
+  have hr_one : r = 1 := hradius.symm.trans hradius_one
+  have hρfix : Kraus.transferMap (d := d) (D := D) A ρ = ρ := by
+    simpa [hr_one] using hρeig
+  let C : MPSTensor d D := Kraus.unitalGauge A ρ
+  have hCUnital : ∑ i : Fin d, C i * (C i)ᴴ = 1 := by
+    simpa [C, Kraus.IsUnital] using
+      Kraus.unitalGauge_isUnital_of_map_fixedPoint A ρ hρ hρfix
+  have hGaugeAC : GaugeEquiv A C := by
+    simpa [C] using gaugeEquiv_unitalGauge A ρ hρ
+  have hCNormal : IsNormalTensor C :=
+    hA.of_gaugeEquiv hGaugeAC.symm
+  obtain ⟨U, Λ, _hSame, hΛ, _hΛdiag, hBUnital, hDualFixed⟩ :=
+    exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor
+      C hCUnital hCNormal.no_invariant_proj (NeZero.pos D)
+  let B : MPSTensor d D := fun i =>
+    (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * C i *
+      (↑U : Matrix (Fin D) (Fin D) ℂ)
+  have hGaugeCB : GaugeEquiv C B := by
+    refine ⟨(unitaryGL U)⁻¹, fun i => ?_⟩
+    simp [B]
+  exact ⟨B, Λ, hGaugeAC.trans hGaugeCB, hΛ, hBUnital, hDualFixed⟩
+
+/-- Blockwise pure gauges preserve a CPSV basis of normal tensors. -/
+private theorem IsCPSVBasisOfNormalTensors.of_family_gaugeEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B C : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩))
+    (hGauge : ∀ j, GaugeEquiv (B j) (C j)) :
+    IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, C j⟩) := by
+  refine ⟨fun j => (hBNT.blocks_normal j).of_gaugeEquiv (hGauge j).symm, ?_, ?_⟩
+  · intro N hN
+    obtain ⟨c, hc⟩ := hBNT.spans_mpv N hN
+    refine ⟨c, fun σ => (hc σ).trans ?_⟩
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [(hGauge j).sameMPV N σ]
+  · obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+    refine ⟨N₀, fun N hN => ?_⟩
+    have hEq :
+        (fun j : Fin g => mpvState (d := d) (B j) N) =
+          fun j : Fin g => mpvState (d := d) (C j) N := by
+      funext j
+      ext σ
+      exact (hGauge j).sameMPV N σ
+    rw [← hEq]
+    exact hLI N hN
+
+/-- Nonzero scalar multiplication does not change a positive-length local MPS
+space. -/
+private theorem groundSpace_smul_eq_of_ne_zero
+    {s n : ℕ} (A : MPSTensor s n) (ζ : ℂ) (hζ : ζ ≠ 0) (L : ℕ) :
+    groundSpace (ζ • A) L = groundSpace A L := by
+  have hMap (X : Matrix (Fin n) (Fin n) ℂ) :
+      groundSpaceMap (ζ • A) L X = groundSpaceMap A L ((ζ ^ L) • X) := by
+    ext σ
+    rw [groundSpaceMap_apply, groundSpaceMap_apply]
+    change Matrix.trace
+        (Kraus.evalWord (fun i => ζ • A i) (List.ofFn σ) * X) = _
+    rw [Kraus.evalWord_smul]
+    simp [Matrix.trace_smul]
+  apply le_antisymm
+  · rintro _ ⟨X, rfl⟩
+    exact ⟨(ζ ^ L) • X, (hMap X).symm⟩
+  · rintro _ ⟨Y, rfl⟩
+    refine ⟨(ζ ^ L)⁻¹ • Y, ?_⟩
+    rw [hMap]
+    congr 1
+    rw [smul_smul, mul_inv_cancel₀ (pow_ne_zero L hζ), one_smul]
+
+/-- Changing only the presentation of the bond dimension does not change the
+local MPS space. -/
+private theorem groundSpace_cast_bond_dim
+    {s D₁ D₂ : ℕ} (h : D₁ = D₂) (A : MPSTensor s D₁) (L : ℕ) :
+    groundSpace (cast (congr_arg (MPSTensor s) h) A) L = groundSpace A L := by
+  subst D₂
+  rfl
+
+/-- The positive-length local MPS space of literal CPSV canonical-form data is
+the sum of the local spaces of its distinct normal representatives.
+
+This is the unblocked form of equation `II_CF1` and the BNT regrouping in
+equations `eq:II_ABasicTensors` and `decBSV`, arXiv:1606.00608, lines
+237--301. -/
+private theorem CPSVCanonicalFormData.groundSpace_eq_iSup_representatives
+    {s d : ℕ} {A : MPSTensor s d} (data : CPSVCanonicalFormData A)
+    (ref : data.BNTRefinement) {L : ℕ} (hL : 0 < L) :
+    groundSpace A L =
+      ⨆ j : Fin data.phaseClasses.g,
+        groundSpace (data.blocks (data.representativeIndex j)) L := by
+  classical
+  have hCopy (k : Fin data.r) :
+      groundSpace (data.blocks k) L =
+        groundSpace (data.blocks (data.representativeIndex (data.classCopy k).1)) L := by
+    have hGauge : GaugeEquiv (ref.regroupedBlocks k) (data.blocks k) :=
+      ⟨ref.listedGauge k, ref.blocksEqListedGaugeConj k⟩
+    have hPhaseNe : ref.copyPhase k ≠ 0 := by
+      intro hk
+      simpa [hk] using ref.copyPhaseNorm k
+    calc
+      groundSpace (data.blocks k) L = groundSpace (ref.regroupedBlocks k) L :=
+        (hGauge.groundSpace_eq L).symm
+      _ = groundSpace
+          (ref.copyPhase k •
+            cast (congr_arg (MPSTensor s) (ref.copyDimEq k))
+              (data.blocks (data.representativeIndex (data.classCopy k).1))) L := by
+        rw [ref.regroupedBlocksEq]
+      _ = groundSpace
+          (cast (congr_arg (MPSTensor s) (ref.copyDimEq k))
+            (data.blocks (data.representativeIndex (data.classCopy k).1))) L :=
+        groundSpace_smul_eq_of_ne_zero _ _ hPhaseNe L
+      _ = groundSpace
+          (data.blocks (data.representativeIndex (data.classCopy k).1)) L :=
+        groundSpace_cast_bond_dim (ref.copyDimEq k) _ L
+  have hCopies :
+      (⨆ k : Fin data.r, groundSpace (data.blocks k) L) =
+        ⨆ j : Fin data.phaseClasses.g,
+          groundSpace (data.blocks (data.representativeIndex j)) L := by
+    apply le_antisymm
+    · refine iSup_le fun k => ?_
+      rw [hCopy k]
+      exact le_iSup (fun j : Fin data.phaseClasses.g =>
+        groundSpace (data.blocks (data.representativeIndex j)) L) (data.classCopy k).1
+    · refine iSup_le fun j => ?_
+      let q : Fin (data.phaseClasses.copies j) :=
+        ⟨0, data.phaseClasses.copies_pos j⟩
+      let k : Fin data.r := data.classCopyEquiv ⟨j, q⟩
+      have hkClass : (data.classCopy k).1 = j := by
+        simpa [k] using congrArg Sigma.fst (data.classCopy_classCopyEquiv j q)
+      have hkRep : k = data.representativeIndex j :=
+        mpvPhaseClassData_enum_zero_eq_repr data.blocks j
+      rw [← hkRep, hCopy k, hkClass]
+      exact le_iSup (fun k : Fin data.r => groundSpace (data.blocks k) L) k
+  calc
+    groundSpace A L =
+        groundSpace (toTensorFromBlocks (d := s) data.weights data.blocks) L :=
+      groundSpace_eq_of_coisometry_reconstruction data.ambient_coisometry
+        data.coisometric data.reconstruct hL
+    _ = ⨆ k : Fin data.r, groundSpace (data.blocks k) L :=
+      groundSpace_toTensorFromBlocks_eq_iSup
+        data.weights data.blocks data.weights_ne_zero L
+    _ = _ := hCopies
+
+/-- The local space of literal CPSV canonical-form data agrees with that of
+the direct sum of any pure gauges of its distinct representatives. -/
+private theorem CPSVCanonicalFormData.groundSpace_eq_representativeGaugeSum
+    {s d : ℕ} {A : MPSTensor s d} (data : CPSVCanonicalFormData A)
+    (ref : data.BNTRefinement)
+    {C : (j : Fin data.phaseClasses.g) =>
+      MPSTensor s (data.dim (data.representativeIndex j))}
+    (hGauge : ∀ j,
+      GaugeEquiv (data.blocks (data.representativeIndex j)) (C j))
+    {L : ℕ} (hL : 0 < L) :
+    groundSpace A L =
+      groundSpace (toTensorFromBlocks (d := s) (fun _ => 1) C) L := by
+  have hSup :
+      (⨆ j : Fin data.phaseClasses.g,
+          groundSpace (data.blocks (data.representativeIndex j)) L) =
+        ⨆ j : Fin data.phaseClasses.g, groundSpace (C j) L := by
+    apply le_antisymm
+    · refine iSup_le fun j => ?_
+      rw [(hGauge j).groundSpace_eq L]
+      exact le_iSup (fun k : Fin data.phaseClasses.g => groundSpace (C k) L) j
+    · refine iSup_le fun j => ?_
+      rw [← (hGauge j).groundSpace_eq L]
+      exact le_iSup (fun k : Fin data.phaseClasses.g =>
+        groundSpace (data.blocks (data.representativeIndex k)) L) j
+  calc
+    groundSpace A L =
+        ⨆ j : Fin data.phaseClasses.g,
+          groundSpace (data.blocks (data.representativeIndex j)) L :=
+      data.groundSpace_eq_iSup_representatives ref hL
+    _ = ⨆ j : Fin data.phaseClasses.g, groundSpace (C j) L := hSup
+    _ = groundSpace (toTensorFromBlocks (d := s) (fun _ => 1) C) L :=
+      (groundSpace_toTensorFromBlocks_eq_iSup
+        (fun _ => 1) C (by simp) L).symm
+
+/-- A normal tensor of bond dimension at most `K` is block injective at
+length `K ^ 4`. -/
+private theorem IsNormalTensor.isNBlkInjective_cap_pow_four
+    {s n K : ℕ} {A : MPSTensor s n} (hA : IsNormalTensor A)
+    (hnK : n ≤ K) : Kraus.IsNBlkInjective A (K ^ 4) := by
+  let : NeZero n := ⟨hA.bondDim_ne_zero⟩
+  obtain ⟨σ, _hσ, _hσfix, hTP, hGauge, hPrim, hIrr⟩ := hA.exists_tpGauge
+  let B := Kraus.tpGauge (d := s) (D := n) A σ
+  have hBNormal : Kraus.IsNormal B :=
+    isNormal_of_tp_primitive_irreducible B hTP hPrim hIrr
+  have hOwn : Kraus.IsNBlkInjective B (n ^ 4) :=
+    isNBlkInjective_pow_four_of_isNormal_leftCanonical B hTP hBNormal
+  have hAOwn : Kraus.IsNBlkInjective A (n ^ 4) :=
+    isNBlkInjective_of_gaugeEquiv hOwn hGauge.symm
+  exact isNBlkInjective_of_le
+    (Nat.pow_pos (Nat.pos_of_ne_zero hA.bondDim_ne_zero)) hAOwn
+    (Nat.pow_le_pow_left hnK 4)
+
+/-- Numerical slack needed to absorb the PGVWC07 short-ring window into the
+interaction range while retaining the CPSV16 bound. -/
+private theorem three_mul_pred_mul_pow_four_add_one_add_pow_four_le_three_mul_pow_five
+    {K : ℕ} (hK : 0 < K) :
+    3 * ((K - 1) * (K ^ 4 + 1)) + K ^ 4 ≤ 3 * K ^ 5 := by
+  have hTail : 3 * (K - 1) ≤ 2 * K ^ 4 := by
+    by_cases hKone : K = 1
+    · simp [hKone]
+    · have hKtwo : 2 ≤ K := by omega
+      have hPow : K ^ 2 ≤ K ^ 4 :=
+        pow_le_pow_right' (a := K) hK (by omega)
+      calc
+        3 * (K - 1) ≤ 3 * K := Nat.mul_le_mul_left 3 (Nat.sub_le K 1)
+        _ ≤ (2 * K) * K := Nat.mul_le_mul_right K (by omega)
+        _ = 2 * K ^ 2 := by ring
+        _ ≤ 2 * K ^ 4 := Nat.mul_le_mul_left 2 hPow
+  calc
+    3 * ((K - 1) * (K ^ 4 + 1)) + K ^ 4 =
+        3 * (K - 1) * K ^ 4 + 3 * (K - 1) + K ^ 4 := by ring
+    _ ≤ 3 * (K - 1) * K ^ 4 + 2 * K ^ 4 + K ^ 4 := by omega
+    _ = 3 * ((K - 1) + 1) * K ^ 4 := by ring
+    _ = 3 * K * K ^ 4 := by rw [Nat.sub_add_cancel (by omega)]
+    _ = 3 * K ^ 5 := by ring
+
+/-- The one-block interaction range also lies below the CPSV16 bound. -/
+private theorem pow_four_add_one_le_three_mul_pow_five
+    {K : ℕ} (hK : 0 < K) : K ^ 4 + 1 ≤ 3 * K ^ 5 := by
+  have hPowPos : 0 < K ^ 4 := Nat.pow_pos hK
+  calc
+    K ^ 4 + 1 ≤ K ^ 4 + K ^ 4 := Nat.add_le_add_left (by omega) _
+    _ = 2 * K ^ 4 := by ring
+    _ ≤ (3 * K) * K ^ 4 := Nat.mul_le_mul_right (K ^ 4) (by omega)
+    _ = 3 * K ^ 5 := by ring
+
+/-- **CPSV16 original-lattice parent-Hamiltonian range bound.**
+
+For a tensor in literal CPSV canonical form, there are a basis of normal
+tensors and a positive interaction range \(L\leq 3D^5\) such that, on every
+original periodic chain of length \(N>L\), the parent-Hamiltonian kernel is
+exactly the span of the BNT matrix product vectors.
+
+Source: arXiv:1606.00608, Definition 3.9 and the first sentence of line 527,
+source lines 511--527.  The short-ring completion uses the theorem cited there,
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456. -/
+theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
+    {A : MPSTensor d D} [NeZero D] (hA : IsCPSVCanonicalForm A) :
+    ∃ g : ℕ, ∃ dim : Fin g → ℕ,
+      ∃ B : (j : Fin g) → MPSTensor d (dim j), ∃ L : ℕ,
+        IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩) ∧
+        0 < L ∧ L ≤ 3 * D ^ 5 ∧
+        HasParentHamiltonianGroundSpaceSpanning A L B := by
+  classical
+  let data := Classical.choice hA
+  let ref := data.bntRefinement
+  let dim : Fin data.phaseClasses.g → ℕ := fun j =>
+    data.dim (data.representativeIndex j)
+  let B : (j : Fin data.phaseClasses.g) → MPSTensor d (dim j) := fun j =>
+    data.blocks (data.representativeIndex j)
+  have hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩) := by
+    simpa [dim, B] using ref.representativesBNT
+  have hDimSum : ∑ j, dim j ≤ D := by
+    simpa [dim] using data.sum_representative_dim_le
+  by_cases hd : d = 0
+  · subst d
+    refine ⟨data.phaseClasses.g, dim, B, 1, hBNT, by omega, ?_, ?_⟩
+    · have hD5 : 0 < D ^ 5 := Nat.pow_pos (NeZero.pos D)
+      omega
+    · intro N hN
+      ext ψ
+      have hψ : ψ = 0 := by
+        funext σ
+        exact Fin.elim0 (σ ⟨0, by omega⟩)
+      subst ψ
+      simp
+  · let : NeZero d := ⟨hd⟩
+    let : ∀ j : Fin data.phaseClasses.g, NeZero (dim j) := fun j =>
+      ⟨(hBNT.blocks_dim_pos j).ne'⟩
+    choose C Λ hGauge hΛ hUnital hDualFixed using fun j =>
+      (hBNT.blocks_normal j).exists_pgvwc07_unital_dualFixedPoint_gauge
+    have hCBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, C j⟩) :=
+      hBNT.of_family_gaugeEquiv hGauge
+    have hDimLe : ∀ j, dim j ≤ D := by
+      intro j
+      exact (Finset.single_le_sum (fun k _ => Nat.zero_le (dim k))
+        (Finset.mem_univ j)).trans hDimSum
+    have hCountLe : data.phaseClasses.g ≤ D := by
+      calc
+        data.phaseClasses.g = ∑ _j : Fin data.phaseClasses.g, 1 := by simp
+        _ ≤ ∑ j : Fin data.phaseClasses.g, dim j :=
+          Finset.sum_le_sum fun j _ => hBNT.blocks_dim_pos j
+        _ ≤ D := hDimSum
+    have hNormal : ∀ j, IsNormalTensor (C j) := hCBNT.blocks_normal
+    have hIrr : HasIrreducibleBlocks (d := d) C :=
+      HasIrreducibleBlocks.ofForall fun j => (hNormal j).no_invariant_proj
+    have hBlocks : BlocksNotGaugePhaseEquiv (d := d) C :=
+      hCBNT.blocks_not_gaugePhaseEquiv
+    have hBlk : ∀ j, Kraus.IsNBlkInjective (C j) (D ^ 4) := fun j =>
+      (hNormal j).isNBlkInjective_cap_pow_four (hDimLe j)
+    by_cases hCountZero : data.phaseClasses.g = 0
+    · have hOne : WordTupleSpanTop C 1 := by
+        letI : IsEmpty (Fin data.phaseClasses.g) := by
+          rw [hCountZero]
+          infer_instance
+        unfold WordTupleSpanTop
+        apply top_unique
+        intro X _
+        have hX : X = 0 := by
+          funext j
+          exact isEmptyElim j
+        rw [hX]
+        exact Submodule.zero_mem _
+      have hDirect :
+          HasParentHamiltonianGroundSpaceSpanning
+            (toTensorFromBlocks (d := d) (fun _ => 1) C) 2 C :=
+        hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_wordTupleSpanTop_one
+          (fun _ => 1) C (by simp) hOne
+      have hLocal :
+          groundSpace A 2 =
+            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) 2 := by
+        simpa [B, dim] using
+          data.groundSpace_eq_representativeGaugeSum ref hGauge (by omega : 0 < 2)
+      have hD5 : 0 < D ^ 5 := Nat.pow_pos (NeZero.pos D)
+      exact ⟨data.phaseClasses.g, dim, C, 2, hCBNT, by omega, by omega,
+        hDirect.of_groundSpace_eq hLocal⟩
+    by_cases hCountOne : data.phaseClasses.g = 1
+    · let L₀ := D ^ 4
+      let L := L₀ + 1
+      let j₀ : Fin data.phaseClasses.g := ⟨0, by omega⟩
+      have hIndex (j : Fin data.phaseClasses.g) : j = j₀ := by
+        apply Fin.ext
+        omega
+      have hGroundSup (M : ℕ) :
+          (⨆ j : Fin data.phaseClasses.g, groundSpace (C j) M) =
+            groundSpace (C j₀) M := by
+        apply le_antisymm
+        · refine iSup_le fun j => ?_
+          rw [hIndex j]
+        · exact le_iSup (fun j : Fin data.phaseClasses.g => groundSpace (C j) M) j₀
+      have hChainSup (M : ℕ) :
+          (⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L M) =
+            chainGroundSpace (C j₀) L M := by
+        apply le_antisymm
+        · refine iSup_le fun j => ?_
+          rw [hIndex j]
+        · exact le_iSup
+            (fun j : Fin data.phaseClasses.g => chainGroundSpace (C j) L M) j₀
+      have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
+      have hDirectLocal :
+          groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
+            ⨆ j : Fin data.phaseClasses.g, groundSpace (C j) L :=
+        groundSpace_toTensorFromBlocks_eq_iSup (fun _ => 1) C (by simp) L
+      have hDirect :
+          HasParentHamiltonianGroundSpaceSpanning
+            (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
+        apply
+          hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain
+            (fun _ => 1) C (by simp)
+        · intro N hN
+          have hLocalSingle :
+              groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
+                groundSpace (C j₀) L :=
+            hDirectLocal.trans (hGroundSup L)
+          calc
+            chainGroundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L N =
+                chainGroundSpace (C j₀) L N :=
+              chainGroundSpace_eq_of_groundSpace_eq hLocalSingle
+            _ = ⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L N := by
+              exact (hChainSup N).symm
+        · intro N hN j
+          exact chainGroundSpace_eq_mpvSubmodule_normal
+            (hNormal j).isNormal (hBlk j) hL₀ (by omega) (by omega) (by omega) (by omega)
+      have hLocal :
+          groundSpace A L =
+            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L := by
+        simpa [B, dim] using
+          data.groundSpace_eq_representativeGaugeSum ref hGauge (by omega : 0 < L)
+      exact ⟨data.phaseClasses.g, dim, C, L, hCBNT, by omega,
+        pow_four_add_one_le_three_mul_pow_five (NeZero.pos D),
+        hDirect.of_groundSpace_eq hLocal⟩
+    · have hCountTwo : 2 ≤ data.phaseClasses.g := by omega
+      let L₀ := D ^ 4
+      let base := (data.phaseClasses.g - 1) *
+        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+      let R := base + 1
+      let L := base + L₀
+      have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
+      have hRleL : R ≤ L := by
+        dsimp [R, L]
+        omega
+      have hDirect :
+          HasParentHamiltonianGroundSpaceSpanning
+            (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
+        rw [hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+          (fun _ => 1) C (by simp)]
+        intro N hN
+        have hNpos : 0 < N := by omega
+        have hLN : L ≤ N := by omega
+        have hRN : R ≤ N := hRleL.trans hLN
+        have hNlarge : R + L₀ ≤ N := by
+          dsimp [R, L]
+          omega
+        have hSmall :=
+          ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_pgvwc07_of_dualFixedPoint
+            (fun _ => 1) C (by simp) hCountTwo hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀
+              hUnital (by simp [R, base]) hNlarge
+        intro ψ hψ
+        rw [← hSmall]
+        rw [ker_parentHamiltonian_eq_chainGroundSpace
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hLN] at hψ
+        rw [ker_parentHamiltonian_eq_chainGroundSpace
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRN]
+        exact chainGroundSpace_le_chainGroundSpace_of_le
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRleL hLN hψ
+      have hPredLe : data.phaseClasses.g - 1 ≤ D - 1 :=
+        Nat.sub_le_sub_right hCountLe 1
+      have hBaseLe : base ≤
+          (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) :=
+        Nat.mul_le_mul_right _ hPredLe
+      have hLBound : L ≤ 3 * D ^ 5 := by
+        calc
+          L ≤ (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + L₀ :=
+            Nat.add_le_add_right hBaseLe L₀
+          _ = 3 * ((D - 1) * (D ^ 4 + 1)) + D ^ 4 := by
+            simp only [L₀]
+            ring
+          _ ≤ 3 * D ^ 5 :=
+            three_mul_pred_mul_pow_four_add_one_add_pow_four_le_three_mul_pow_five
+              (NeZero.pos D)
+      have hLocal :
+          groundSpace A L =
+            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L := by
+        simpa [B, dim] using
+          data.groundSpace_eq_representativeGaugeSum ref hGauge (by
+            dsimp [L, base]
+            omega)
+      exact ⟨data.phaseClasses.g, dim, C, L, hCBNT, by
+          dsimp [L, base]
+          omega,
+        hLBound, hDirect.of_groundSpace_eq hLocal⟩
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
+++ b/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
@@ -82,6 +82,10 @@ private theorem IsNormalTensor.exists_pgvwc07_unital_dualFixedPoint_gauge
       (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
       Kraus.transferMap (d := d) (D := D) (fun i => (B i)ᴴ) Λ = Λ := by
   let : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.linftyOpNormedAddCommGroup
+  let : NormedSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.linftyOpNormedSpace
   have hIrr : Kraus.IsIrreducibleFamily A := hA.no_invariant_proj
   obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
     exists_posDef_transferMap_eigenvector_of_irreducible
@@ -120,7 +124,7 @@ private theorem IsNormalTensor.exists_pgvwc07_unital_dualFixedPoint_gauge
       (↑U : Matrix (Fin D) (Fin D) ℂ)
   have hGaugeCB : GaugeEquiv C B := by
     refine ⟨(unitaryGL U)⁻¹, fun i => ?_⟩
-    simp [B]
+    simp [B, unitaryGL]
   exact ⟨B, Λ, hGaugeAC.trans hGaugeCB, hΛ, hBUnital, hDualFixed⟩
 
 /-- Blockwise pure gauges preserve a CPSV basis of normal tensors. -/
@@ -236,6 +240,7 @@ private theorem CPSVCanonicalFormData.groundSpace_eq_iSup_representatives
             cast (congr_arg (MPSTensor s) (ref.copyDimEq k))
               (data.blocks (data.representativeIndex (data.classCopy k).1))) L := by
         rw [ref.regroupedBlocksEq]
+        rfl
       _ = groundSpace
           (cast (congr_arg (MPSTensor s) (ref.copyDimEq k))
             (data.blocks (data.representativeIndex (data.classCopy k).1))) L :=
@@ -367,7 +372,7 @@ private theorem sq_lt_pow_three_mul_pow_five
     have hStrict : K ^ 2 < 2 * K ^ 2 + 1 := by omega
     exact hStrict.trans_le (Nat.two_mul_sq_add_one_le_two_pow_two_mul K)
   have hBase : 2 ^ (2 * K) ≤ s ^ (2 * K) :=
-    pow_le_pow_left' hs.le (2 * K)
+    Nat.pow_le_pow_left (by omega) (2 * K)
   have hKlePow : K ≤ K ^ 5 := by
     simpa using pow_le_pow_right' (a := K) hK (by omega : 1 ≤ 5)
   have hExp : 2 * K ≤ 3 * K ^ 5 := by omega
@@ -395,9 +400,9 @@ extension of these source arguments.
 3.9's spanning clause: the kernel/BNT-span equality for every \(N>L\).  The
 separate conclusion \(D^2<d^L\) supplies the preceding construction condition
 from source line 515 and therefore makes the local orthogonal-complement
-projector nonzero.  The hypotheses `[NeZero D]` and `1 < d` record the
-positive bond-dimension and nontrivial physical-spin boundaries; Perron-gauge
-and short-ring data are derived internally. -/
+projector nonzero.  The conditions \(D>0\) and \(1<d\) record the positive
+bond-dimension and nontrivial physical-spin boundaries; Perron-gauge and
+short-ring data are derived internally. -/
 theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
     {A : MPSTensor d D} [NeZero D] (hd : 1 < d) (hA : IsCPSVCanonicalForm A) :
     ∃ g : ℕ, ∃ dim : Fin g → ℕ,
@@ -449,7 +454,7 @@ theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
     (hNormal j).isNBlkInjective_cap_pow_four (hDimLe j)
   by_cases hCountZero : data.phaseClasses.g = 0
   · have hOne : WordTupleSpanTop C 1 := by
-      letI : IsEmpty (Fin data.phaseClasses.g) := by
+      let : IsEmpty (Fin data.phaseClasses.g) := by
         rw [hCountZero]
         infer_instance
       unfold WordTupleSpanTop
@@ -564,7 +569,7 @@ theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
       have hSmall :=
         ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_pgvwc07_of_dualFixedPoint
           (fun _ => 1) C (by simp) hCountTwo hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀
-            hUnital (by simp [R, base]) hNlarge
+            hUnital (by simp [R, base, L₀]) hNlarge
       intro ψ hψ
       rw [← hSmall]
       rw [ker_parentHamiltonian_eq_chainGroundSpace

--- a/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
+++ b/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
@@ -13,28 +13,42 @@ import TNLean.MPS.SharedInfra.CoisometryGauge
 /-!
 # Original-lattice parent-Hamiltonian range for CPSV canonical form
 
-A tensor in the literal canonical form of
-Cirac--Pérez-García--Schuch--Verstraete has an original-lattice parent
-Hamiltonian whose interaction range is at most \(3D^5\).  The ground space on
-every periodic chain longer than that range is spanned by the matrix product
-vectors of a basis of normal tensors.
+For a tensor in the literal canonical form of
+Cirac--Pérez-García--Schuch--Verstraete over a nontrivial physical alphabet,
+there is an original-lattice parent Hamiltonian of interaction range at most
+\(3D^5\).  Its local interaction is nonzero, and on every longer periodic
+chain its kernel is spanned by the matrix product vectors of a basis of normal
+tensors.
 
 The proof uses the construction of Pérez-García--Verstraete--Wolf--Cirac,
 Theorem 12.  Its printed global-cut argument proves the kernel identity at a
 range \(R\) when \(N\geq R+L_0\).  We absorb this finite-size window into the
-interaction range by taking
+preliminary interaction range by taking
 \[
-  L=3(g-1)(D^4+1)+D^4.
+  L_{\mathrm{aux}}=3(g-1)(D^4+1)+D^4.
 \]
-For \(N>L\), the theorem applies at
+For \(N>L_{\mathrm{aux}}\), the theorem applies at
 \(R=3(g-1)(D^4+1)+1\), and antitonicity of the cyclic chain space transports
-the upper inclusion from range \(R\) to range \(L\).  The usual
-frustration-free inclusion supplies the reverse containment.
+the upper inclusion from range \(R\) to range \(L_{\mathrm{aux}}\).  The usual
+frustration-free inclusion supplies the reverse containment.  Enlarging once
+more to the uniform range \(L=3D^5\) preserves the equality and gives
+\(D^2<d^L\).  For one BNT representative, the proof uses the normal-tensor
+intersection and closure property reviewed in arXiv:2011.12127, Section IV.C.
+The case of no BNT representatives is a formal boundary extension of these
+source arguments.
 
 The predicate `HasParentHamiltonianGroundSpaceSpanning` records only the
 ground-space spanning clause of arXiv:1606.00608, Definition 3.9, lines
-522--524.  The preceding condition \(d^L>D^2\), which makes the local
-orthogonal complement nontrivial, is a separate boundary of that predicate.
+522--524.  The theorem separately proves the preceding condition
+\(d^L>D^2\), which makes the local orthogonal complement nontrivial, under the
+necessary physical-spin boundary \(1<d\).
+
+**Local fix (physical-dimension boundary):** The parent-Hamiltonian claim in
+arXiv:1606.00608, line 527, leaves implicit the feasibility condition already
+imposed at line 515.  When \(D>0\), the inequality \(D^2<d^L\) is possible for
+some positive \(L\) exactly when \(1<d\).  The main theorem states this
+boundary explicitly and proves the inequality for its witness.  See
+`docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex`.
 
 ## Main result
 
@@ -44,6 +58,7 @@ orthogonal complement nontrivial, is a separate boundary of that predicate.
 
 * arXiv:1606.00608, Definition 3.9 and line 527, source lines 511--527.
 * arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+* arXiv:2011.12127, Section IV.C, source lines 2078--2090.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
@@ -162,6 +177,35 @@ private theorem groundSpace_cast_bond_dim
     groundSpace (cast (congr_arg (MPSTensor s) h) A) L = groundSpace A L := by
   subst D₂
   rfl
+
+/-- Enlarging the interaction range preserves the ground-space spanning
+equation for a block-diagonal tensor with nonzero weights.
+
+This is a derived monotonicity consequence of the parent-Hamiltonian
+construction in arXiv:1606.00608, Definition 3.9, lines 511--525; it is not a
+separate assertion of the paper. -/
+private theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_le
+    {s r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (C : (j : Fin r) → MPSTensor s (dim j))
+    (hμ : ∀ j, μ j ≠ 0) {L L' : ℕ}
+    (hSpan : HasParentHamiltonianGroundSpaceSpanning
+      (toTensorFromBlocks (d := s) μ C) L C)
+    (hLL' : L ≤ L') :
+    HasParentHamiltonianGroundSpaceSpanning
+      (toTensorFromBlocks (d := s) μ C) L' C := by
+  rw [hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+    μ C hμ] at hSpan ⊢
+  intro N hN ψ hψ
+  have hNpos : 0 < N := by omega
+  have hL'N : L' ≤ N := by omega
+  have hLN : L ≤ N := hLL'.trans hL'N
+  apply hSpan N (lt_of_le_of_lt hLL' hN)
+  rw [ker_parentHamiltonian_eq_chainGroundSpace
+    (toTensorFromBlocks (d := s) μ C) hNpos hLN]
+  rw [ker_parentHamiltonian_eq_chainGroundSpace
+    (toTensorFromBlocks (d := s) μ C) hNpos hL'N] at hψ
+  exact chainGroundSpace_le_chainGroundSpace_of_le
+    (toTensorFromBlocks (d := s) μ C) hNpos hLL' hL'N hψ
 
 /-- The positive-length local MPS space of literal CPSV canonical-form data is
 the sum of the local spaces of its distinct normal representatives.
@@ -314,30 +358,52 @@ private theorem pow_four_add_one_le_three_mul_pow_five
     _ ≤ (3 * K) * K ^ 4 := Nat.mul_le_mul_right (K ^ 4) (by omega)
     _ = 3 * K ^ 5 := by ring
 
+/-- A nontrivial physical alphabet has enough words at the uniform CPSV16
+range to leave a nonzero local orthogonal complement. -/
+private theorem sq_lt_pow_three_mul_pow_five
+    {s K : ℕ} (hs : 1 < s) (hK : 0 < K) :
+    K ^ 2 < s ^ (3 * K ^ 5) := by
+  have hBinary : K ^ 2 < 2 ^ (2 * K) := by
+    have hStrict : K ^ 2 < 2 * K ^ 2 + 1 := by omega
+    exact hStrict.trans_le (Nat.two_mul_sq_add_one_le_two_pow_two_mul K)
+  have hBase : 2 ^ (2 * K) ≤ s ^ (2 * K) :=
+    pow_le_pow_left' hs.le (2 * K)
+  have hKlePow : K ≤ K ^ 5 := by
+    simpa using pow_le_pow_right' (a := K) hK (by omega : 1 ≤ 5)
+  have hExp : 2 * K ≤ 3 * K ^ 5 := by omega
+  have hExponent : s ^ (2 * K) ≤ s ^ (3 * K ^ 5) :=
+    pow_le_pow_right' (a := s) (by omega) hExp
+  exact hBinary.trans_le (hBase.trans hExponent)
+
 /-- **CPSV16 original-lattice parent-Hamiltonian range bound.**
 
-For a tensor in literal CPSV canonical form, there are a basis of normal
-tensors and a positive interaction range \(L\leq 3D^5\) such that, on every
-original periodic chain of length \(N>L\), the parent-Hamiltonian kernel is
-exactly the span of the BNT matrix product vectors.
+For a tensor in literal CPSV canonical form over a nontrivial physical
+alphabet, there are a basis of normal tensors and a positive interaction
+range \(L\leq 3D^5\) with \(D^2<d^L\) such that, on every original periodic
+chain of length \(N>L\), the parent-Hamiltonian kernel is exactly the span of
+the BNT matrix product vectors.
 
 Source: arXiv:1606.00608, Definition 3.9 and the first sentence of line 527,
-source lines 511--527.  The short-ring completion uses the theorem cited there,
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+source lines 511--527.  For at least two BNT representatives, the short-ring
+completion uses the theorem cited there, arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1424--1456.  For one representative, it uses the normal-tensor
+intersection and closure property reviewed in arXiv:2011.12127, Section IV.C,
+source lines 2078--2090.  The no-representative case is a formal boundary
+extension of these source arguments.
 
 `HasParentHamiltonianGroundSpaceSpanning` unfolds precisely to Definition
-3.9's spanning clause: the kernel/BNT-span equality for every \(N>L\).  It
-does not include the preceding construction condition \(d^L>D^2\), and hence
-does not by itself assert that the local orthogonal-complement projector is
-nonzero.  That condition is a separate formal boundary, not an additional
-hypothesis of the spanning theorem.  The typeclass `[NeZero D]` records the
-corresponding nonzero bond-dimension boundary. -/
+3.9's spanning clause: the kernel/BNT-span equality for every \(N>L\).  The
+separate conclusion \(D^2<d^L\) supplies the preceding construction condition
+from source line 515 and therefore makes the local orthogonal-complement
+projector nonzero.  The hypotheses `[NeZero D]` and `1 < d` record the
+positive bond-dimension and nontrivial physical-spin boundaries; Perron-gauge
+and short-ring data are derived internally. -/
 theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
-    {A : MPSTensor d D} [NeZero D] (hA : IsCPSVCanonicalForm A) :
+    {A : MPSTensor d D} [NeZero D] (hd : 1 < d) (hA : IsCPSVCanonicalForm A) :
     ∃ g : ℕ, ∃ dim : Fin g → ℕ,
       ∃ B : (j : Fin g) → MPSTensor d (dim j), ∃ L : ℕ,
         IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩) ∧
-        0 < L ∧ L ≤ 3 * D ^ 5 ∧
+        0 < L ∧ D ^ 2 < d ^ L ∧ L ≤ 3 * D ^ 5 ∧
         HasParentHamiltonianGroundSpaceSpanning A L B := by
   classical
   let data := Classical.choice hA
@@ -350,182 +416,187 @@ theorem IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning
     simpa [dim, B] using ref.representativesBNT
   have hDimSum : ∑ j, dim j ≤ D := by
     simpa [dim] using data.sum_representative_dim_le
-  by_cases hd : d = 0
-  · subst d
-    refine ⟨data.phaseClasses.g, dim, B, 1, hBNT, by omega, ?_, ?_⟩
-    · have hD5 : 0 < D ^ 5 := Nat.pow_pos (NeZero.pos D)
-      omega
-    · intro N hN
-      ext ψ
-      have hψ : ψ = 0 := by
-        funext σ
-        exact Fin.elim0 (σ ⟨0, by omega⟩)
-      subst ψ
-      simp
-  · let : NeZero d := ⟨hd⟩
-    let : ∀ j : Fin data.phaseClasses.g, NeZero (dim j) := fun j =>
-      ⟨(hBNT.blocks_dim_pos j).ne'⟩
-    choose C Λ hGauge hΛ hUnital hDualFixed using fun j =>
-      (hBNT.blocks_normal j).exists_pgvwc07_unital_dualFixedPoint_gauge
-    have hCBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, C j⟩) :=
-      hBNT.of_family_gaugeEquiv hGauge
-    have hDimLe : ∀ j, dim j ≤ D := by
-      intro j
-      exact (Finset.single_le_sum (fun k _ => Nat.zero_le (dim k))
-        (Finset.mem_univ j)).trans hDimSum
-    have hCountLe : data.phaseClasses.g ≤ D := by
-      calc
-        data.phaseClasses.g = ∑ _j : Fin data.phaseClasses.g, 1 := by simp
-        _ ≤ ∑ j : Fin data.phaseClasses.g, dim j :=
-          Finset.sum_le_sum fun j _ => hBNT.blocks_dim_pos j
-        _ ≤ D := hDimSum
-    have hNormal : ∀ j, IsNormalTensor (C j) := hCBNT.blocks_normal
-    have hIrr : HasIrreducibleBlocks (d := d) C :=
-      HasIrreducibleBlocks.ofForall fun j => (hNormal j).no_invariant_proj
-    have hBlocks : BlocksNotGaugePhaseEquiv (d := d) C :=
-      hCBNT.blocks_not_gaugePhaseEquiv
-    have hBlk : ∀ j, Kraus.IsNBlkInjective (C j) (D ^ 4) := fun j =>
-      (hNormal j).isNBlkInjective_cap_pow_four (hDimLe j)
-    by_cases hCountZero : data.phaseClasses.g = 0
-    · have hOne : WordTupleSpanTop C 1 := by
-        letI : IsEmpty (Fin data.phaseClasses.g) := by
-          rw [hCountZero]
-          infer_instance
-        unfold WordTupleSpanTop
-        apply top_unique
-        intro X _
-        have hX : X = 0 := by
-          funext j
-          exact isEmptyElim j
-        rw [hX]
-        exact Submodule.zero_mem _
-      have hDirect :
-          HasParentHamiltonianGroundSpaceSpanning
-            (toTensorFromBlocks (d := d) (fun _ => 1) C) 2 C :=
-        hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_wordTupleSpanTop_one
-          (fun _ => 1) C (by simp) hOne
-      have hLocal :
-          groundSpace A 2 =
-            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) 2 := by
-        simpa [B, dim] using
-          data.groundSpace_eq_representativeGaugeSum ref hGauge (by omega : 0 < 2)
+  let Lmax := 3 * D ^ 5
+  have hLmaxPos : 0 < Lmax := by
+    dsimp [Lmax]
+    exact Nat.mul_pos (by omega) (Nat.pow_pos (NeZero.pos D))
+  have hLmaxDim : D ^ 2 < d ^ Lmax := by
+    simpa [Lmax] using
+      sq_lt_pow_three_mul_pow_five hd (NeZero.pos D)
+  let : NeZero d := ⟨by omega⟩
+  let : ∀ j : Fin data.phaseClasses.g, NeZero (dim j) := fun j =>
+    ⟨(hBNT.blocks_dim_pos j).ne'⟩
+  choose C Λ hGauge hΛ hUnital hDualFixed using fun j =>
+    (hBNT.blocks_normal j).exists_pgvwc07_unital_dualFixedPoint_gauge
+  have hCBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, C j⟩) :=
+    hBNT.of_family_gaugeEquiv hGauge
+  have hDimLe : ∀ j, dim j ≤ D := by
+    intro j
+    exact (Finset.single_le_sum (fun k _ => Nat.zero_le (dim k))
+      (Finset.mem_univ j)).trans hDimSum
+  have hCountLe : data.phaseClasses.g ≤ D := by
+    calc
+      data.phaseClasses.g = ∑ _j : Fin data.phaseClasses.g, 1 := by simp
+      _ ≤ ∑ j : Fin data.phaseClasses.g, dim j :=
+        Finset.sum_le_sum fun j _ => hBNT.blocks_dim_pos j
+      _ ≤ D := hDimSum
+  have hNormal : ∀ j, IsNormalTensor (C j) := hCBNT.blocks_normal
+  have hIrr : HasIrreducibleBlocks (d := d) C :=
+    HasIrreducibleBlocks.ofForall fun j => (hNormal j).no_invariant_proj
+  have hBlocks : BlocksNotGaugePhaseEquiv (d := d) C :=
+    hCBNT.blocks_not_gaugePhaseEquiv
+  have hBlk : ∀ j, Kraus.IsNBlkInjective (C j) (D ^ 4) := fun j =>
+    (hNormal j).isNBlkInjective_cap_pow_four (hDimLe j)
+  by_cases hCountZero : data.phaseClasses.g = 0
+  · have hOne : WordTupleSpanTop C 1 := by
+      letI : IsEmpty (Fin data.phaseClasses.g) := by
+        rw [hCountZero]
+        infer_instance
+      unfold WordTupleSpanTop
+      apply top_unique
+      intro X _
+      have hX : X = 0 := by
+        funext j
+        exact isEmptyElim j
+      rw [hX]
+      exact Submodule.zero_mem _
+    have hDirectSmall :
+        HasParentHamiltonianGroundSpaceSpanning
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) 2 C :=
+      hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_wordTupleSpanTop_one
+        (fun _ => 1) C (by simp) hOne
+    have hTwoLe : 2 ≤ Lmax := by
+      dsimp [Lmax]
       have hD5 : 0 < D ^ 5 := Nat.pow_pos (NeZero.pos D)
-      exact ⟨data.phaseClasses.g, dim, C, 2, hCBNT, by omega, by omega,
-        hDirect.of_groundSpace_eq hLocal⟩
-    by_cases hCountOne : data.phaseClasses.g = 1
-    · let L₀ := D ^ 4
-      let L := L₀ + 1
-      let j₀ : Fin data.phaseClasses.g := ⟨0, by omega⟩
-      have hIndex (j : Fin data.phaseClasses.g) : j = j₀ := by
-        apply Fin.ext
-        omega
-      have hGroundSup (M : ℕ) :
-          (⨆ j : Fin data.phaseClasses.g, groundSpace (C j) M) =
-            groundSpace (C j₀) M := by
-        apply le_antisymm
-        · refine iSup_le fun j => ?_
-          rw [hIndex j]
-        · exact le_iSup (fun j : Fin data.phaseClasses.g => groundSpace (C j) M) j₀
-      have hChainSup (M : ℕ) :
-          (⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L M) =
-            chainGroundSpace (C j₀) L M := by
-        apply le_antisymm
-        · refine iSup_le fun j => ?_
-          rw [hIndex j]
-        · exact le_iSup
-            (fun j : Fin data.phaseClasses.g => chainGroundSpace (C j) L M) j₀
-      have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
-      have hDirectLocal :
-          groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
-            ⨆ j : Fin data.phaseClasses.g, groundSpace (C j) L :=
-        groundSpace_toTensorFromBlocks_eq_iSup (fun _ => 1) C (by simp) L
-      have hDirect :
-          HasParentHamiltonianGroundSpaceSpanning
-            (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
-        apply
-          hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain
-            (fun _ => 1) C (by simp)
-        · intro N hN
-          have hLocalSingle :
-              groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
-                groundSpace (C j₀) L :=
-            hDirectLocal.trans (hGroundSup L)
-          calc
-            chainGroundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L N =
-                chainGroundSpace (C j₀) L N :=
-              chainGroundSpace_eq_of_groundSpace_eq hLocalSingle
-            _ = ⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L N := by
-              exact (hChainSup N).symm
-        · intro N hN j
-          exact chainGroundSpace_eq_mpvSubmodule_normal
-            (hNormal j).isNormal (hBlk j) hL₀ (by omega) (by omega) (by omega) (by omega)
-      have hLocal :
-          groundSpace A L =
-            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L := by
-        simpa [B, dim] using
-          data.groundSpace_eq_representativeGaugeSum ref hGauge (by omega : 0 < L)
-      exact ⟨data.phaseClasses.g, dim, C, L, hCBNT, by omega,
-        pow_four_add_one_le_three_mul_pow_five (NeZero.pos D),
-        hDirect.of_groundSpace_eq hLocal⟩
-    · have hCountTwo : 2 ≤ data.phaseClasses.g := by omega
-      let L₀ := D ^ 4
-      let base := (data.phaseClasses.g - 1) *
-        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
-      let R := base + 1
-      let L := base + L₀
-      have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
-      have hRleL : R ≤ L := by
+      omega
+    have hDirect :=
+      hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_le
+        (fun _ => 1) C (by simp) hDirectSmall hTwoLe
+    have hLocal :
+        groundSpace A Lmax =
+          groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) Lmax := by
+      simpa [B, dim] using
+        data.groundSpace_eq_representativeGaugeSum ref hGauge hLmaxPos
+    exact ⟨data.phaseClasses.g, dim, C, Lmax, hCBNT, hLmaxPos, hLmaxDim,
+      le_rfl, hDirect.of_groundSpace_eq hLocal⟩
+  by_cases hCountOne : data.phaseClasses.g = 1
+  · let L₀ := D ^ 4
+    let L := L₀ + 1
+    let j₀ : Fin data.phaseClasses.g := ⟨0, by omega⟩
+    have hIndex (j : Fin data.phaseClasses.g) : j = j₀ := by
+      apply Fin.ext
+      omega
+    have hGroundSup (M : ℕ) :
+        (⨆ j : Fin data.phaseClasses.g, groundSpace (C j) M) =
+          groundSpace (C j₀) M := by
+      apply le_antisymm
+      · refine iSup_le fun j => ?_
+        rw [hIndex j]
+      · exact le_iSup (fun j : Fin data.phaseClasses.g => groundSpace (C j) M) j₀
+    have hChainSup (M : ℕ) :
+        (⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L M) =
+          chainGroundSpace (C j₀) L M := by
+      apply le_antisymm
+      · refine iSup_le fun j => ?_
+        rw [hIndex j]
+      · exact le_iSup
+          (fun j : Fin data.phaseClasses.g => chainGroundSpace (C j) L M) j₀
+    have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
+    have hDirectLocal :
+        groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
+          ⨆ j : Fin data.phaseClasses.g, groundSpace (C j) L :=
+      groundSpace_toTensorFromBlocks_eq_iSup (fun _ => 1) C (by simp) L
+    have hDirect :
+        HasParentHamiltonianGroundSpaceSpanning
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
+      apply
+        hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain
+          (fun _ => 1) C (by simp)
+      · intro N hN
+        have hLocalSingle :
+            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L =
+              groundSpace (C j₀) L :=
+          hDirectLocal.trans (hGroundSup L)
+        calc
+          chainGroundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L N =
+              chainGroundSpace (C j₀) L N :=
+            chainGroundSpace_eq_of_groundSpace_eq hLocalSingle
+          _ = ⨆ j : Fin data.phaseClasses.g, chainGroundSpace (C j) L N := by
+            exact (hChainSup N).symm
+      · intro N hN j
+        exact chainGroundSpace_eq_mpvSubmodule_normal
+          (hNormal j).isNormal (hBlk j) hL₀ (by omega) (by omega) (by omega) (by omega)
+    have hLBound : L ≤ Lmax := by
+      simpa [L, L₀, Lmax] using
+        pow_four_add_one_le_three_mul_pow_five (NeZero.pos D)
+    have hDirectMax :=
+      hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_le
+        (fun _ => 1) C (by simp) hDirect hLBound
+    have hLocal :
+        groundSpace A Lmax =
+          groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) Lmax := by
+      simpa [B, dim] using
+        data.groundSpace_eq_representativeGaugeSum ref hGauge hLmaxPos
+    exact ⟨data.phaseClasses.g, dim, C, Lmax, hCBNT, hLmaxPos, hLmaxDim,
+      le_rfl, hDirectMax.of_groundSpace_eq hLocal⟩
+  · have hCountTwo : 2 ≤ data.phaseClasses.g := by omega
+    let L₀ := D ^ 4
+    let base := (data.phaseClasses.g - 1) *
+      ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+    let R := base + 1
+    let L := base + L₀
+    have hL₀ : 0 < L₀ := Nat.pow_pos (NeZero.pos D)
+    have hRleL : R ≤ L := by
+      dsimp [R, L]
+      omega
+    have hDirect :
+        HasParentHamiltonianGroundSpaceSpanning
+          (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
+      rw [hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+        (fun _ => 1) C (by simp)]
+      intro N hN
+      have hNpos : 0 < N := by omega
+      have hLN : L ≤ N := by omega
+      have hRN : R ≤ N := hRleL.trans hLN
+      have hNlarge : R + L₀ ≤ N := by
         dsimp [R, L]
         omega
-      have hDirect :
-          HasParentHamiltonianGroundSpaceSpanning
-            (toTensorFromBlocks (d := d) (fun _ => 1) C) L C := by
-        rw [hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
-          (fun _ => 1) C (by simp)]
-        intro N hN
-        have hNpos : 0 < N := by omega
-        have hLN : L ≤ N := by omega
-        have hRN : R ≤ N := hRleL.trans hLN
-        have hNlarge : R + L₀ ≤ N := by
-          dsimp [R, L]
-          omega
-        have hSmall :=
-          ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_pgvwc07_of_dualFixedPoint
-            (fun _ => 1) C (by simp) hCountTwo hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀
-              hUnital (by simp [R, base]) hNlarge
-        intro ψ hψ
-        rw [← hSmall]
-        rw [ker_parentHamiltonian_eq_chainGroundSpace
-          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hLN] at hψ
-        rw [ker_parentHamiltonian_eq_chainGroundSpace
-          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRN]
-        exact chainGroundSpace_le_chainGroundSpace_of_le
-          (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRleL hLN hψ
-      have hPredLe : data.phaseClasses.g - 1 ≤ D - 1 :=
-        Nat.sub_le_sub_right hCountLe 1
-      have hBaseLe : base ≤
-          (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) :=
-        Nat.mul_le_mul_right _ hPredLe
-      have hLBound : L ≤ 3 * D ^ 5 := by
-        calc
-          L ≤ (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + L₀ :=
-            Nat.add_le_add_right hBaseLe L₀
-          _ = 3 * ((D - 1) * (D ^ 4 + 1)) + D ^ 4 := by
-            simp only [L₀]
-            ring
-          _ ≤ 3 * D ^ 5 :=
-            three_mul_pred_mul_pow_four_add_one_add_pow_four_le_three_mul_pow_five
-              (NeZero.pos D)
-      have hLocal :
-          groundSpace A L =
-            groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) L := by
-        simpa [B, dim] using
-          data.groundSpace_eq_representativeGaugeSum ref hGauge (by
-            dsimp [L, base]
-            omega)
-      exact ⟨data.phaseClasses.g, dim, C, L, hCBNT, by
-          dsimp [L, base]
-          omega,
-        hLBound, hDirect.of_groundSpace_eq hLocal⟩
+      have hSmall :=
+        ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_pgvwc07_of_dualFixedPoint
+          (fun _ => 1) C (by simp) hCountTwo hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀
+            hUnital (by simp [R, base]) hNlarge
+      intro ψ hψ
+      rw [← hSmall]
+      rw [ker_parentHamiltonian_eq_chainGroundSpace
+        (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hLN] at hψ
+      rw [ker_parentHamiltonian_eq_chainGroundSpace
+        (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRN]
+      exact chainGroundSpace_le_chainGroundSpace_of_le
+        (toTensorFromBlocks (d := d) (fun _ => 1) C) hNpos hRleL hLN hψ
+    have hPredLe : data.phaseClasses.g - 1 ≤ D - 1 :=
+      Nat.sub_le_sub_right hCountLe 1
+    have hBaseLe : base ≤
+        (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) :=
+      Nat.mul_le_mul_right _ hPredLe
+    have hLBound : L ≤ 3 * D ^ 5 := by
+      calc
+        L ≤ (D - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + L₀ :=
+          Nat.add_le_add_right hBaseLe L₀
+        _ = 3 * ((D - 1) * (D ^ 4 + 1)) + D ^ 4 := by
+          simp only [L₀]
+          ring
+        _ ≤ 3 * D ^ 5 :=
+          three_mul_pred_mul_pow_four_add_one_add_pow_four_le_three_mul_pow_five
+            (NeZero.pos D)
+    have hDirectMax :=
+      hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_le
+        (fun _ => 1) C (by simp) hDirect (by simpa [Lmax] using hLBound)
+    have hLocal :
+        groundSpace A Lmax =
+          groundSpace (toTensorFromBlocks (d := d) (fun _ => 1) C) Lmax := by
+      simpa [B, dim] using
+        data.groundSpace_eq_representativeGaugeSum ref hGauge hLmaxPos
+    exact ⟨data.phaseClasses.g, dim, C, Lmax, hCBNT, hLmaxPos, hLmaxDim,
+      le_rfl, hDirectMax.of_groundSpace_eq hLocal⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -217,8 +217,14 @@ construction; they are not attributed to a source theorem.
     Let $A$ be in literal CPSV canonical form with positive ambient bond
     dimension $D$, and suppose that the physical dimension satisfies $1<d$.
     There are a basis of normal tensors $(A_j)_{j=1}^{g}$ and a positive
-    integer $L$ such that $D^2<d^L$ and $L\leq3D^5$, and, for every
-    original periodic chain of length $N>L$,
+    integer $L$ such that
+    \begin{align}
+        D^2<d^L,
+        \qquad
+        L\leq3D^5,
+        \label{eq:cpsv_original_lattice_parent_hamiltonian_dimension_range}
+    \end{align}
+    and, for every original periodic chain of length $N>L$,
     \begin{align}
         \ker H_L^{(N)}(A)
          & =\spn\left\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\right\}.
@@ -248,25 +254,19 @@ construction; they are not attributed to a source theorem.
     Choose one normal representative from each BNT phase class and put each
     representative in a Perron gauge for which
     \begin{align}
-        \sum_a A^j_a A^{j\,\dagger}_a & =\Id.
+        \sum_a A^j_a A^{j\,\dagger}_a          & =\Id,
+                                               &
+        \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j
         \notag
     \end{align}
-    The positive definite matrix $\Lambda_j$ satisfies
-    \begin{align}
-        \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j.
-        \notag
-    \end{align}
-    Their dimensions satisfy
+    with $\Lambda_j$ positive definite. Their dimensions satisfy
     $\sum_jD_j\leq D$, so $g\leq D$, and quantum Wielandt makes every
     representative block-injective at the common length $L_0=D^4$.
 
     Suppose first that $g\geq2$. Put
     \begin{align}
-        R & =3(g-1)(L_0+1)+1.
-        \notag
-    \end{align}
-    Set the auxiliary range to
-    \begin{align}
+        R                & =3(g-1)(L_0+1)+1,
+                         &
         L_{\mathrm{aux}} & =3(g-1)(L_0+1)+L_0.
         \notag
     \end{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -217,14 +217,8 @@ construction; they are not attributed to a source theorem.
     Let $A$ be in literal CPSV canonical form with positive ambient bond
     dimension $D$, and suppose that the physical dimension satisfies $1<d$.
     There are a basis of normal tensors $(A_j)_{j=1}^{g}$ and a positive
-    integer $L$ such that
-    \begin{align}
-        D^2<d^L,
-        \qquad
-        L\leq3D^5,
-        \label{eq:cpsv_original_lattice_parent_hamiltonian_dimension_range}
-    \end{align}
-    and, for every original periodic chain of length $N>L$,
+    integer $L$ such that $D^2<d^L$ and $L\leq3D^5$, and, for every
+    original periodic chain of length $N>L$,
     \begin{align}
         \ker H_L^{(N)}(A)
          & =\spn\left\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\right\}.
@@ -254,19 +248,25 @@ construction; they are not attributed to a source theorem.
     Choose one normal representative from each BNT phase class and put each
     representative in a Perron gauge for which
     \begin{align}
-        \sum_a A^j_a A^{j\,\dagger}_a          & =\Id,
-                                               &
-        \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j
+        \sum_a A^j_a A^{j\,\dagger}_a & =\Id.
         \notag
     \end{align}
-    with $\Lambda_j$ positive definite. Their dimensions satisfy
+    The positive definite matrix $\Lambda_j$ satisfies
+    \begin{align}
+        \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j.
+        \notag
+    \end{align}
+    Their dimensions satisfy
     $\sum_jD_j\leq D$, so $g\leq D$, and quantum Wielandt makes every
     representative block-injective at the common length $L_0=D^4$.
 
     Suppose first that $g\geq2$. Put
     \begin{align}
-        R                & =3(g-1)(L_0+1)+1,
-                         &
+        R & =3(g-1)(L_0+1)+1.
+        \notag
+    \end{align}
+    Set the auxiliary range to
+    \begin{align}
         L_{\mathrm{aux}} & =3(g-1)(L_0+1)+L_0.
         \notag
     \end{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -213,14 +213,7 @@ construction; they are not attributed to a source theorem.
         exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
     \leanok
     \uses{def:cpsv_canonical_form, def:bnt_cpsv,
-        def:parent_hamiltonian_ground_space_spanning,
-        thm:cpsv_canonical_form_bnt_refinement,
-        thm:cpsv_bnt_dimension_bound,
-        thm:gs_eq_bnt_span_source_normalization,
-        lem:cyclic_window_range_antitonicity,
-        lem:bnt_span_le_parent_hamiltonian_kernel,
-        lem:coisometric_reconstruction_local_space,
-        lem:parent_spanning_of_local_space_eq}
+        def:parent_hamiltonian_ground_space_spanning}
     Let $A$ be in literal CPSV canonical form with positive ambient bond
     dimension $D$. There are a basis of normal tensors
     $(A_j)_{j=1}^{g}$ and a positive integer $L\leq3D^5$ such that, for

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -215,21 +215,26 @@ construction; they are not attributed to a source theorem.
     \uses{def:cpsv_canonical_form, def:bnt_cpsv,
         def:parent_hamiltonian_ground_space_spanning}
     Let $A$ be in literal CPSV canonical form with positive ambient bond
-    dimension $D$. There are a basis of normal tensors
-    $(A_j)_{j=1}^{g}$ and a positive integer $L\leq3D^5$ such that, for
-    every original periodic chain of length $N>L$,
+    dimension $D$, and suppose that the physical dimension satisfies $1<d$.
+    There are a basis of normal tensors $(A_j)_{j=1}^{g}$ and a positive
+    integer $L$ such that
+    \begin{align}
+        D^2<d^L,
+        \qquad
+        L\leq3D^5,
+        \label{eq:cpsv_original_lattice_parent_hamiltonian_dimension_range}
+    \end{align}
+    and, for every original periodic chain of length $N>L$,
     \begin{align}
         \ker H_L^{(N)}(A)
          & =\spn\left\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\right\}.
         \label{eq:cpsv_original_lattice_parent_hamiltonian_range}
     \end{align}
-    This is the parent-Hamiltonian spanning clause of
-    \cite[Definition~3.9 and line~527]{Cirac2016MPDO_arXiv}. The spanning
-    condition records precisely the equality above for all $N>L$. It does
-    not include the preceding construction condition $d^L>D^2$, and hence
-    does not by itself assert that the local orthogonal-complement projector
-    is nonzero. That nontriviality condition is a separate boundary, not an
-    additional hypothesis of this theorem.
+    Thus the orthogonal complement of the local MPS space is nonzero, and
+    the corresponding bounded-range interaction is a parent Hamiltonian.
+    This is the construction of
+    \cite[Definition~3.9 and line~527]{Cirac2016MPDO_arXiv}, with its
+    condition $d^L>D^2$ made explicit.
 \end{theorem}
 
 \begin{proof}
@@ -240,7 +245,12 @@ construction; they are not attributed to a source theorem.
         lem:cyclic_window_range_antitonicity,
         lem:bnt_span_le_parent_hamiltonian_kernel,
         lem:coisometric_reconstruction_local_space,
-        lem:parent_spanning_of_local_space_eq}
+        lem:parent_spanning_of_local_space_eq,
+        thm:exact_pow_four_block_injectivity_normal_left_canonical,
+        thm:chain_ground_space_eq_mpv_normal,
+        thm:block_diagonal_one_site_span_parent_spanning,
+        thm:unital_gauge_of_pd_fixed_point,
+        thm:pgvwc07_dual_diag_unital}
     Choose one normal representative from each BNT phase class and put each
     representative in a Perron gauge for which
     \begin{align}
@@ -257,30 +267,42 @@ construction; they are not attributed to a source theorem.
     \begin{align}
         R & =3(g-1)(L_0+1)+1,
         &
-        L & =3(g-1)(L_0+1)+L_0.
+        L_{\mathrm{aux}} & =3(g-1)(L_0+1)+L_0.
         \notag
     \end{align}
-    If $N>L$, then $N\geq R+L_0$. The source-normalized form of
-    \cite[Theorem~12]{PerezGarcia2007Matrix} therefore identifies the
-    range-$R$ parent-Hamiltonian kernel with the BNT span. Since $R\leq L$,
-    cyclic-window antitonicity places the range-$L$ kernel inside the
-    range-$R$ kernel. Every BNT vector satisfies the range-$L$ local
-    constraints, which gives the reverse inclusion. Thus the range-$L$
-    kernel is exactly the BNT span for every $N>L$. Finally,
+    If $N>L_{\mathrm{aux}}$, then $N\geq R+L_0$. The source-normalized
+    form of \cite[Theorem~12]{PerezGarcia2007Matrix} therefore identifies
+    the range-$R$ parent-Hamiltonian kernel with the BNT span. Since
+    $R\leq L_{\mathrm{aux}}$, cyclic-window antitonicity places the
+    range-$L_{\mathrm{aux}}$ kernel inside the range-$R$ kernel. Every BNT
+    vector satisfies the range-$L_{\mathrm{aux}}$ local constraints, which
+    gives the reverse inclusion. Thus the range-$L_{\mathrm{aux}}$ kernel
+    is exactly the BNT span for every $N>L_{\mathrm{aux}}$, and
     \begin{align}
-        L
-        & \leq 3(D-1)(D^4+1)+D^4
+        L_{\mathrm{aux}}
+         & \leq 3(D-1)(D^4+1)+D^4
           \leq 3D^5.
         \notag
     \end{align}
-    Exact coisometric reconstruction identifies the local space of the
-    representative direct sum with $G_L(A)$, so the spanning equation
-    transfers to the original tensor.
+    If $g=1$, the same spanning conclusion holds at
+    $L_{\mathrm{aux}}=D^4+1$ by the normal-tensor intersection and closure
+    property reviewed in \cite[Section~IV.C]{Cirac2021Matrix}. If $g=0$,
+    the one-site block-diagonal spanning result gives it at
+    $L_{\mathrm{aux}}=2$; this is a formal boundary extension of the source
+    argument.
 
-    If $g=1$, take $L=D^4+1$ and apply the single normal-block periodic
-    intersection theorem. If $g=0$, take $L=2$. When the physical alphabet is
-    empty, take $L=1$. These boundary cases satisfy the same bound and the
-    same all-$N>L$ conclusion.
+    In every case enlarge the interaction range to the common value
+    $L=3D^5$. Range antitonicity gives the upper inclusion at $L$, while the
+    usual frustration-free inclusion gives the reverse one, so the
+    all-$N>L$ spanning equation is preserved. Since $D>0$ and $d\geq2$,
+    \begin{align}
+        D^2<2^{2D}\leq d^{2D}\leq d^{3D^5}=d^L.
+        \notag
+    \end{align}
+    Exact coisometric reconstruction identifies the local space of the
+    representative direct sum with $G_L(A)$ and transfers the equality to
+    the original tensor. The chosen range is positive and satisfies
+    $L\leq3D^5$ by equality.
 \end{proof}
 
 \begin{theorem}[Sharp blocking gives a nearest-neighbor parent Hamiltonian]
@@ -304,9 +326,9 @@ construction; they are not attributed to a source theorem.
     Thus the actual blocked tensor has a nearest-neighbor parent Hamiltonian
     on the blocked lattice. This is distinct from
     Theorem~\ref{thm:cpsv_original_lattice_parent_hamiltonian_range}, which
-    supplies an interaction of range at most $3D^5$ on every sufficiently
-    long original chain. The two conclusions and the argument closing the
-    short-ring window are recorded in
+    supplies a nonzero bounded-range interaction and the parent-Hamiltonian
+    spanning identity on every sufficiently long original chain. The two
+    conclusions and the argument closing the short-ring window are recorded in
     \cite{gap:cpsv16_parent_hamiltonian_range_short_ring}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -255,7 +255,7 @@ construction; they are not attributed to a source theorem.
     representative in a Perron gauge for which
     \begin{align}
         \sum_a A^j_a A^{j\,\dagger}_a          & =\Id,
-        &
+                                               &
         \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j
         \notag
     \end{align}
@@ -265,8 +265,8 @@ construction; they are not attributed to a source theorem.
 
     Suppose first that $g\geq2$. Put
     \begin{align}
-        R & =3(g-1)(L_0+1)+1,
-        &
+        R                & =3(g-1)(L_0+1)+1,
+                         &
         L_{\mathrm{aux}} & =3(g-1)(L_0+1)+L_0.
         \notag
     \end{align}
@@ -281,7 +281,7 @@ construction; they are not attributed to a source theorem.
     \begin{align}
         L_{\mathrm{aux}}
          & \leq 3(D-1)(D^4+1)+D^4
-          \leq 3D^5.
+        \leq 3D^5.
         \notag
     \end{align}
     If $g=1$, the same spanning conclusion holds at

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -207,6 +207,89 @@ construction; they are not attributed to a source theorem.
     (\ref{eq:parent_spanning_local_space_kernel_congruence}).
 \end{proof}
 
+\begin{theorem}[Original-lattice parent-Hamiltonian range]
+    \label{thm:cpsv_original_lattice_parent_hamiltonian_range}
+    \lean{MPSTensor.IsCPSVCanonicalForm.%
+        exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv,
+        def:parent_hamiltonian_ground_space_spanning,
+        thm:cpsv_canonical_form_bnt_refinement,
+        thm:cpsv_bnt_dimension_bound,
+        thm:gs_eq_bnt_span_source_normalization,
+        lem:cyclic_window_range_antitonicity,
+        lem:bnt_span_le_parent_hamiltonian_kernel,
+        lem:coisometric_reconstruction_local_space,
+        lem:parent_spanning_of_local_space_eq}
+    Let $A$ be in literal CPSV canonical form with positive ambient bond
+    dimension $D$. There are a basis of normal tensors
+    $(A_j)_{j=1}^{g}$ and a positive integer $L\leq3D^5$ such that, for
+    every original periodic chain of length $N>L$,
+    \begin{align}
+        \ker H_L^{(N)}(A)
+         & =\spn\left\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\right\}.
+        \label{eq:cpsv_original_lattice_parent_hamiltonian_range}
+    \end{align}
+    This is the parent-Hamiltonian spanning clause of
+    \cite[Definition~3.9 and line~527]{Cirac2016MPDO_arXiv}. The spanning
+    condition records precisely the equality above for all $N>L$. It does
+    not include the preceding construction condition $d^L>D^2$, and hence
+    does not by itself assert that the local orthogonal-complement projector
+    is nonzero. That nontriviality condition is a separate boundary, not an
+    additional hypothesis of this theorem.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_canonical_form_bnt_refinement,
+        thm:cpsv_bnt_dimension_bound,
+        thm:gs_eq_bnt_span_source_normalization,
+        lem:cyclic_window_range_antitonicity,
+        lem:bnt_span_le_parent_hamiltonian_kernel,
+        lem:coisometric_reconstruction_local_space,
+        lem:parent_spanning_of_local_space_eq}
+    Choose one normal representative from each BNT phase class and put each
+    representative in a Perron gauge for which
+    \begin{align}
+        \sum_a A^j_a A^{j\,\dagger}_a          & =\Id,
+        &
+        \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j
+        \notag
+    \end{align}
+    with $\Lambda_j$ positive definite. Their dimensions satisfy
+    $\sum_jD_j\leq D$, so $g\leq D$, and quantum Wielandt makes every
+    representative block-injective at the common length $L_0=D^4$.
+
+    Suppose first that $g\geq2$. Put
+    \begin{align}
+        R & =3(g-1)(L_0+1)+1,
+        &
+        L & =3(g-1)(L_0+1)+L_0.
+        \notag
+    \end{align}
+    If $N>L$, then $N\geq R+L_0$. The source-normalized form of
+    \cite[Theorem~12]{PerezGarcia2007Matrix} therefore identifies the
+    range-$R$ parent-Hamiltonian kernel with the BNT span. Since $R\leq L$,
+    cyclic-window antitonicity places the range-$L$ kernel inside the
+    range-$R$ kernel. Every BNT vector satisfies the range-$L$ local
+    constraints, which gives the reverse inclusion. Thus the range-$L$
+    kernel is exactly the BNT span for every $N>L$. Finally,
+    \begin{align}
+        L
+        & \leq 3(D-1)(D^4+1)+D^4
+          \leq 3D^5.
+        \notag
+    \end{align}
+    Exact coisometric reconstruction identifies the local space of the
+    representative direct sum with $G_L(A)$, so the spanning equation
+    transfers to the original tensor.
+
+    If $g=1$, take $L=D^4+1$ and apply the single normal-block periodic
+    intersection theorem. If $g=0$, take $L=2$. When the physical alphabet is
+    empty, take $L=1$. These boundary cases satisfy the same bound and the
+    same all-$N>L$ conclusion.
+\end{proof}
+
 \begin{theorem}[Sharp blocking gives a nearest-neighbor parent Hamiltonian]
     \label{thm:cpsv_blocked_nearest_neighbor_parent_hamiltonian}
     \lean{MPSTensor.IsCPSVCanonicalForm.%
@@ -226,8 +309,11 @@ construction; they are not attributed to a source theorem.
         \label{eq:cpsv_blocked_nearest_neighbor_parent_hamiltonian}
     \end{align}
     Thus the actual blocked tensor has a nearest-neighbor parent Hamiltonian
-    on the blocked lattice. This does not identify an interaction of range
-    at most $3D^5$ on every original lattice; that distinction is recorded in
+    on the blocked lattice. This is distinct from
+    Theorem~\ref{thm:cpsv_original_lattice_parent_hamiltonian_range}, which
+    supplies an interaction of range at most $3D^5$ on every sufficiently
+    long original chain. The two conclusions and the argument closing the
+    short-ring window are recorded in
     \cite{gap:cpsv16_parent_hamiltonian_range_short_ring}.
 \end{theorem}
 

--- a/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
+++ b/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
@@ -14,11 +14,11 @@
 
 \title{Blocking and the Parent-Hamiltonian Range Claim in CPSV16}
 \author{}
-\date{2026-08-30}
+\date{2026-08-31}
 
 \begin{document}
 \maketitle
-\gapnote{scope-restriction}{open}
+\gapnote{scope-restriction}{resolved}
 
 \section{The two lattice statements}
 
@@ -55,7 +55,20 @@ This is the statement proved in the formal development.
 \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_blocked_hasNearestNeighborParentHamiltonian}
 in \doclink{TNLean/MPS/ParentHamiltonian/CPSVBlockedNearestNeighbor}.}
 
-\section{The unresolved implication}
+The first statement concerns every sufficiently long chain on the original
+lattice. It asserts that there are BNT representatives $A_1,\ldots,A_g$ and a
+positive integer $L\leq3D^5$ such that
+\begin{align}
+    \ker H_L^{(N)}(A)
+      &=\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
+    \label{eq:cpsv16_parent_hamiltonian_range_original_statement}
+\end{align}
+This statement is also proved in the formal development.
+\footnote{Formal declaration:
+\leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
+in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
+
+\section{Why the blocked theorem alone is insufficient}
 
 A two-site interaction on the blocked lattice acts on $2p$ consecutive sites
 of the original lattice. Consequently,
@@ -70,23 +83,87 @@ chain lengths divisible by $p$ and greater than $2p$. Definition~3.9 instead
 requires the original-lattice ground-space identity for every chain length
 strictly larger than the chosen interaction range. Thus the blocked statement
 alone does not establish
+(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}). In
+particular, transporting the two-site blocked interaction is not the proof of
+the first sentence of line~527.
+
+\section{Resolution on the original lattice}
+
+Choose one normal representative from each BNT phase class and put each
+representative in a Perron gauge such that
 \begin{align}
-    \exists L\leq 3D^5\ \forall n>L,
-    \qquad
-    \ker H_L^{(n)}(A)
-      &=\operatorname{span}\left\{V^{(n)}(A_j):1\leq j\leq g\right\}.
-    \label{eq:cpsv16_parent_hamiltonian_range_original_statement}
+    \sum_a A^j_a A^{j\,\dagger}_a          &=I,
+    &
+    \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a&=\Lambda_j,
+    \label{eq:cpsv16_parent_hamiltonian_range_perron_gauge}
 \end{align}
+where $\Lambda_j$ is positive definite. The representative dimensions obey
+$\sum_jD_j\leq D$, hence $g\leq D$. Quantum Wielandt gives the common
+block-injectivity length
+\begin{align}
+    L_0&=D^4.
+    \label{eq:cpsv16_parent_hamiltonian_range_wielandt_length}
+\end{align}
+
+For $g\geq2$, the proof of
+\cite[Theorem~12]{PerezGarcia2007Matrix} gives the BNT kernel equality at
+range
+\begin{align}
+    R&=3(g-1)(L_0+1)+1
+    \label{eq:cpsv16_parent_hamiltonian_range_pgvwc_range}
+\end{align}
+whenever $N\geq R+L_0$. Define instead
+\begin{align}
+    L&=3(g-1)(L_0+1)+L_0=R+L_0-1.
+    \label{eq:cpsv16_parent_hamiltonian_range_absorbed}
+\end{align}
+Then $N>L$ implies $N\geq R+L_0$. Since $R\leq L$, antitonicity of the
+cyclic local-constraint spaces and the usual frustration-free inclusion give
+the sandwich
+\begin{align}
+    \ker H_L^{(N)}
+      \subseteq \ker H_R^{(N)}
+      =\operatorname{span}\{V^{(N)}(A_j):1\leq j\leq g\}
+      \subseteq \ker H_L^{(N)}.
+    \label{eq:cpsv16_parent_hamiltonian_range_sandwich}
+\end{align}
+The exact coisometric reconstruction of literal CPSV canonical form preserves
+the positive-length local space, so this equality transfers from the direct
+sum of representatives to $A$. Finally,
+\begin{align}
+    L
+      &\leq3(D-1)(D^4+1)+D^4
+       \leq3D^5.
+    \label{eq:cpsv16_parent_hamiltonian_range_bound}
+\end{align}
+For one representative, one may take $L=D^4+1$; for no representatives, one
+may take $L=2$. If the physical alphabet is empty, take $L=1$. These cases
+satisfy the same bound and remove every short-ring exception.
+
+\section{The nontrivial-local-term boundary}
+
+The formal predicate used in
+(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) is precisely
+the spanning clause of Definition~3.9: it quantifies the kernel equality over
+all $N>L$. It does not contain the preceding construction assumption
+$d^L>D^2$ from lines~511--515. Consequently, the formal theorem does not by
+itself assert that the orthogonal-complement projector $P_L^\perp$ is nonzero.
+This is a separate boundary of the construction, not an additional hypothesis
+of the spanning theorem. The positive ambient bond-dimension hypothesis
+$D>0$ is the legitimate boundary needed for the $3D^5$ estimate.
 
 \section{Conclusion}
 
 The blocked-lattice assertion
 (\ref{eq:cpsv16_parent_hamiltonian_range_blocked_statement}) is valid and is
 formalized with the sharp bound $p\leq3D^5$. The original-lattice assertion
-(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) requires an
-additional argument controlling the interaction range and the short periodic
-rings. Until such an argument is supplied, the two assertions must remain
-distinct.
+(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) is now proved by
+absorbing the finite-size window of the source theorem into the interaction
+range and then applying the cyclic-range sandwich. The two assertions remain
+mathematically distinct even though both are complete: one concerns a
+nearest-neighbour interaction for the actual blocked tensor, while the other
+concerns a bounded-range interaction on every sufficiently long original
+periodic chain.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
+++ b/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
@@ -31,9 +31,9 @@ dimension of $A_j$,
     1\leq p\leq 3D^5,
     \qquad
     \operatorname{span}\left\{
-    \bigl((A_1^{[p]})^i,\ldots,(A_g^{[p]})^i\bigr):i
+        \bigl((A_1^{[p]})^i,\ldots,(A_g^{[p]})^i\bigr):i
     \right\}
-     & =\bigoplus_{j=1}^{g}M_{D_j}(\mathbb C).
+      &=\bigoplus_{j=1}^{g}M_{D_j}(\mathbb C).
     \label{eq:cpsv16_parent_hamiltonian_range_block_span}
 \end{align}
 The discussion following Definition~3.9 then states both that $A$ has a
@@ -45,30 +45,30 @@ The second statement has a direct meaning on the blocked lattice. For every
 blocked-chain length $N>2$, it asserts
 \begin{align}
     \ker H_2^{(N)}\!\left(A^{[p]}\right)
-     & =\operatorname{span}\left\{
-    V^{(N)}\!\left(A_j^{[p]}\right):1\leq j\leq g
-    \right\}.
+      &=\operatorname{span}\left\{
+          V^{(N)}\!\left(A_j^{[p]}\right):1\leq j\leq g
+        \right\}.
     \label{eq:cpsv16_parent_hamiltonian_range_blocked_statement}
 \end{align}
 This is the statement proved in the formal development.
 \footnote{Formal declaration:
-    \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_blocked_hasNearestNeighborParentHamiltonian}
-    in \doclink{TNLean/MPS/ParentHamiltonian/CPSVBlockedNearestNeighbor}.}
+\leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_blocked_hasNearestNeighborParentHamiltonian}
+in \doclink{TNLean/MPS/ParentHamiltonian/CPSVBlockedNearestNeighbor}.}
 
 The first statement concerns every sufficiently long chain on the original
 lattice. It asserts that there are BNT representatives $A_1,\ldots,A_g$ and a
 positive integer $L\leq3D^5$ such that
 \begin{align}
     \ker H_L^{(N)}(A)
-     & =\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
+      &=\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
     \label{eq:cpsv16_parent_hamiltonian_range_original_statement}
 \end{align}
 For $1<d$, the formal development proves this all-chain spanning clause
 simultaneously with $D^2<d^L$. Thus it also verifies that the local
 orthogonal-complement interaction is nonzero.
 \footnote{Formal declaration:
-    \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
-    in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
+\leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
+in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
 
 \section{Why the blocked theorem alone is insufficient}
 
@@ -76,7 +76,7 @@ A two-site interaction on the blocked lattice acts on $2p$ consecutive sites
 of the original lattice. Consequently,
 \begin{align}
     \text{nearest-neighbour range for }A^{[p]}
-     & \Longrightarrow \text{range }2p\text{ for the induced interaction on }A,
+      &\Longrightarrow \text{range }2p\text{ for the induced interaction on }A,
     \label{eq:cpsv16_parent_hamiltonian_range_naive_transport}
 \end{align}
 not range $p$. Moreover, the quantifier $N>2$ in
@@ -94,16 +94,16 @@ the first sentence of line~527.
 Choose one normal representative from each BNT phase class and put each
 representative in a Perron gauge such that
 \begin{align}
-    \sum_a A^j_a A^{j\,\dagger}_a          & =I,
-                                           &
-    \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j,
+    \sum_a A^j_a A^{j\,\dagger}_a          &=I,
+    &
+    \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a&=\Lambda_j,
     \label{eq:cpsv16_parent_hamiltonian_range_perron_gauge}
 \end{align}
 where $\Lambda_j$ is positive definite. The representative dimensions obey
 $\sum_jD_j\leq D$, hence $g\leq D$. Quantum Wielandt gives the common
 block-injectivity length
 \begin{align}
-    L_0 & =D^4.
+    L_0&=D^4.
     \label{eq:cpsv16_parent_hamiltonian_range_wielandt_length}
 \end{align}
 
@@ -111,12 +111,12 @@ For $g\geq2$, the proof of
 \cite[Theorem~12]{PerezGarcia2007Matrix} gives the BNT kernel equality at
 range
 \begin{align}
-    R & =3(g-1)(L_0+1)+1
+    R&=3(g-1)(L_0+1)+1
     \label{eq:cpsv16_parent_hamiltonian_range_pgvwc_range}
 \end{align}
 whenever $N\geq R+L_0$. Define instead
 \begin{align}
-    L & =3(g-1)(L_0+1)+L_0=R+L_0-1.
+    L&=3(g-1)(L_0+1)+L_0=R+L_0-1.
     \label{eq:cpsv16_parent_hamiltonian_range_absorbed}
 \end{align}
 Then $N>L$ implies $N\geq R+L_0$. Since $R\leq L$, antitonicity of the
@@ -124,9 +124,9 @@ cyclic local-constraint spaces and the usual frustration-free inclusion give
 the sandwich
 \begin{align}
     \ker H_L^{(N)}
-    \subseteq \ker H_R^{(N)}
-    =\operatorname{span}\{V^{(N)}(A_j):1\leq j\leq g\}
-    \subseteq \ker H_L^{(N)}.
+      \subseteq \ker H_R^{(N)}
+      =\operatorname{span}\{V^{(N)}(A_j):1\leq j\leq g\}
+      \subseteq \ker H_L^{(N)}.
     \label{eq:cpsv16_parent_hamiltonian_range_sandwich}
 \end{align}
 The exact coisometric reconstruction of literal CPSV canonical form preserves
@@ -134,8 +134,8 @@ the positive-length local space, so this equality transfers from the direct
 sum of representatives to $A$. Finally,
 \begin{align}
     L
-     & \leq3(D-1)(D^4+1)+D^4
-    \leq3D^5.
+      &\leq3(D-1)(D^4+1)+D^4
+       \leq3D^5.
     \label{eq:cpsv16_parent_hamiltonian_range_bound}
 \end{align}
 For one representative, one may take $L_{\mathrm{aux}}=D^4+1$. The
@@ -148,7 +148,7 @@ CPSV16 or PGVWC07.
 To obtain one witness that also satisfies the nontriviality condition, enlarge
 each auxiliary range to
 \begin{align}
-    L & =3D^5.
+    L&=3D^5.
     \label{eq:cpsv16_parent_hamiltonian_range_uniform}
 \end{align}
 Cyclic-range antitonicity preserves the upper inclusion at the enlarged

--- a/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
+++ b/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
@@ -12,13 +12,13 @@
 \providecommand{\gapnote}[2]{%
     \par\noindent\textbf{Verdict:} #1 (#2).\par}
 
-\title{Blocking and the Parent-Hamiltonian Range Claim in CPSV16}
+\title{Blocking and the Parent-Hamiltonian Range in CPSV16}
 \author{}
 \date{2026-08-31}
 
 \begin{document}
 \maketitle
-\gapnote{scope-restriction}{resolved}
+\gapnote{original-lattice parent-Hamiltonian construction}{resolved for $1<d$}
 
 \section{The two lattice statements}
 
@@ -63,7 +63,9 @@ positive integer $L\leq3D^5$ such that
       &=\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
     \label{eq:cpsv16_parent_hamiltonian_range_original_statement}
 \end{align}
-This statement is also proved in the formal development.
+For $1<d$, the formal development proves this all-chain spanning clause
+simultaneously with $D^2<d^L$. Thus it also verifies that the local
+orthogonal-complement interaction is nonzero.
 \footnote{Formal declaration:
 \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
 in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
@@ -136,31 +138,53 @@ sum of representatives to $A$. Finally,
        \leq3D^5.
     \label{eq:cpsv16_parent_hamiltonian_range_bound}
 \end{align}
-For one representative, one may take $L=D^4+1$; for no representatives, one
-may take $L=2$. If the physical alphabet is empty, take $L=1$. These cases
-satisfy the same bound and remove every short-ring exception.
+For one representative, one may take $L_{\mathrm{aux}}=D^4+1$. The
+required periodic intersection and closure property for a normal tensor is
+the result reviewed in \cite[Section~IV.C]{Cirac2021Matrix}. If there are no
+representatives, one may take $L_{\mathrm{aux}}=2$; this is a formal boundary
+extension of the source argument, not an additional claim extracted from
+CPSV16 or PGVWC07.
 
-\section{The nontrivial-local-term boundary}
+To obtain one witness that also satisfies the nontriviality condition, enlarge
+each auxiliary range to
+\begin{align}
+    L&=3D^5.
+    \label{eq:cpsv16_parent_hamiltonian_range_uniform}
+\end{align}
+Cyclic-range antitonicity preserves the upper inclusion at the enlarged
+range, and the usual frustration-free inclusion supplies the reverse one.
+Therefore the spanning equality still holds for every $N>L$. If $D>0$ and
+$1<d$, then
+\begin{align}
+    D^2<2^{2D}\leq d^{2D}\leq d^{3D^5}=d^L.
+    \label{eq:cpsv16_parent_hamiltonian_range_nontriviality}
+\end{align}
+The same witness now satisfies $0<L$, $D^2<d^L$, and $L\leq3D^5$.
 
-The formal predicate used in
-(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) is precisely
-the spanning clause of Definition~3.9: it quantifies the kernel equality over
-all $N>L$. It does not contain the preceding construction assumption
-$d^L>D^2$ from lines~511--515. Consequently, the formal theorem does not by
-itself assert that the orthogonal-complement projector $P_L^\perp$ is nonzero.
-This is a separate boundary of the construction, not an additional hypothesis
-of the spanning theorem. The positive ambient bond-dimension hypothesis
-$D>0$ is the legitimate boundary needed for the $3D^5$ estimate.
+\section{The physical-dimension boundary}
+
+The source first imposes $d^L>D^2$ and then defines the local interaction as
+the orthogonal complement of the local MPS space. For $D>0$, this condition is
+possible for some positive $L$ exactly when $1<d$: if $d\leq1$, then
+$d^L\leq1\leq D^2$, whereas the estimate
+(\ref{eq:cpsv16_parent_hamiltonian_range_nontriviality}) proves sufficiency
+when $1<d$. The source-faithful formal theorem therefore states this exact
+feasibility boundary explicitly and includes $D^2<d^L$ in its existential
+conclusion. This is a boundary of the construction, not an extra premise used
+to prove the ground-space equality. Positive ambient bond dimension is
+likewise explicit through $D>0$.
 
 \section{Conclusion}
 
 The blocked-lattice assertion
-(\ref{eq:cpsv16_parent_hamiltonian_range_blocked_statement}) is valid and is
-formalized with the sharp bound $p\leq3D^5$. The original-lattice assertion
-(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) is now proved by
-absorbing the finite-size window of the source theorem into the interaction
-range and then applying the cyclic-range sandwich. The two assertions remain
-mathematically distinct even though both are complete: one concerns a
+(\ref{eq:cpsv16_parent_hamiltonian_range_blocked_statement}) is formalized
+with the sharp bound $p\leq3D^5$. For $1<d$, the original-lattice assertion
+(\ref{eq:cpsv16_parent_hamiltonian_range_original_statement}) is now proved
+with $0<L$, $D^2<d^L$, and $L\leq3D^5$. The proof absorbs the finite-size
+window of the source theorem into an auxiliary interaction range, applies the
+cyclic-range sandwich, and enlarges uniformly to $L=3D^5$. This resolves the
+full source construction under its necessary nontrivial physical boundary.
+The blocked and original-lattice assertions remain distinct: one concerns a
 nearest-neighbour interaction for the actual blocked tensor, while the other
 concerns a bounded-range interaction on every sufficiently long original
 periodic chain.

--- a/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
+++ b/docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex
@@ -18,7 +18,7 @@
 
 \begin{document}
 \maketitle
-\gapnote{original-lattice parent-Hamiltonian construction}{resolved for $1<d$}
+\gapnote{local-correction}{resolved}
 
 \section{The two lattice statements}
 
@@ -31,9 +31,9 @@ dimension of $A_j$,
     1\leq p\leq 3D^5,
     \qquad
     \operatorname{span}\left\{
-        \bigl((A_1^{[p]})^i,\ldots,(A_g^{[p]})^i\bigr):i
+    \bigl((A_1^{[p]})^i,\ldots,(A_g^{[p]})^i\bigr):i
     \right\}
-      &=\bigoplus_{j=1}^{g}M_{D_j}(\mathbb C).
+     & =\bigoplus_{j=1}^{g}M_{D_j}(\mathbb C).
     \label{eq:cpsv16_parent_hamiltonian_range_block_span}
 \end{align}
 The discussion following Definition~3.9 then states both that $A$ has a
@@ -45,30 +45,30 @@ The second statement has a direct meaning on the blocked lattice. For every
 blocked-chain length $N>2$, it asserts
 \begin{align}
     \ker H_2^{(N)}\!\left(A^{[p]}\right)
-      &=\operatorname{span}\left\{
-          V^{(N)}\!\left(A_j^{[p]}\right):1\leq j\leq g
-        \right\}.
+     & =\operatorname{span}\left\{
+    V^{(N)}\!\left(A_j^{[p]}\right):1\leq j\leq g
+    \right\}.
     \label{eq:cpsv16_parent_hamiltonian_range_blocked_statement}
 \end{align}
 This is the statement proved in the formal development.
 \footnote{Formal declaration:
-\leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_blocked_hasNearestNeighborParentHamiltonian}
-in \doclink{TNLean/MPS/ParentHamiltonian/CPSVBlockedNearestNeighbor}.}
+    \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_blocked_hasNearestNeighborParentHamiltonian}
+    in \doclink{TNLean/MPS/ParentHamiltonian/CPSVBlockedNearestNeighbor}.}
 
 The first statement concerns every sufficiently long chain on the original
 lattice. It asserts that there are BNT representatives $A_1,\ldots,A_g$ and a
 positive integer $L\leq3D^5$ such that
 \begin{align}
     \ker H_L^{(N)}(A)
-      &=\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
+     & =\operatorname{span}\left\{V^{(N)}(A_j):1\leq j\leq g\right\}.
     \label{eq:cpsv16_parent_hamiltonian_range_original_statement}
 \end{align}
 For $1<d$, the formal development proves this all-chain spanning clause
 simultaneously with $D^2<d^L$. Thus it also verifies that the local
 orthogonal-complement interaction is nonzero.
 \footnote{Formal declaration:
-\leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
-in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
+    \leanid{MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning}
+    in \doclink{TNLean/MPS/ParentHamiltonian/CPSVOriginalRange}.}
 
 \section{Why the blocked theorem alone is insufficient}
 
@@ -76,7 +76,7 @@ A two-site interaction on the blocked lattice acts on $2p$ consecutive sites
 of the original lattice. Consequently,
 \begin{align}
     \text{nearest-neighbour range for }A^{[p]}
-      &\Longrightarrow \text{range }2p\text{ for the induced interaction on }A,
+     & \Longrightarrow \text{range }2p\text{ for the induced interaction on }A,
     \label{eq:cpsv16_parent_hamiltonian_range_naive_transport}
 \end{align}
 not range $p$. Moreover, the quantifier $N>2$ in
@@ -94,16 +94,16 @@ the first sentence of line~527.
 Choose one normal representative from each BNT phase class and put each
 representative in a Perron gauge such that
 \begin{align}
-    \sum_a A^j_a A^{j\,\dagger}_a          &=I,
-    &
-    \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a&=\Lambda_j,
+    \sum_a A^j_a A^{j\,\dagger}_a          & =I,
+                                           &
+    \sum_a A^{j\,\dagger}_a\Lambda_j A^j_a & =\Lambda_j,
     \label{eq:cpsv16_parent_hamiltonian_range_perron_gauge}
 \end{align}
 where $\Lambda_j$ is positive definite. The representative dimensions obey
 $\sum_jD_j\leq D$, hence $g\leq D$. Quantum Wielandt gives the common
 block-injectivity length
 \begin{align}
-    L_0&=D^4.
+    L_0 & =D^4.
     \label{eq:cpsv16_parent_hamiltonian_range_wielandt_length}
 \end{align}
 
@@ -111,12 +111,12 @@ For $g\geq2$, the proof of
 \cite[Theorem~12]{PerezGarcia2007Matrix} gives the BNT kernel equality at
 range
 \begin{align}
-    R&=3(g-1)(L_0+1)+1
+    R & =3(g-1)(L_0+1)+1
     \label{eq:cpsv16_parent_hamiltonian_range_pgvwc_range}
 \end{align}
 whenever $N\geq R+L_0$. Define instead
 \begin{align}
-    L&=3(g-1)(L_0+1)+L_0=R+L_0-1.
+    L & =3(g-1)(L_0+1)+L_0=R+L_0-1.
     \label{eq:cpsv16_parent_hamiltonian_range_absorbed}
 \end{align}
 Then $N>L$ implies $N\geq R+L_0$. Since $R\leq L$, antitonicity of the
@@ -124,9 +124,9 @@ cyclic local-constraint spaces and the usual frustration-free inclusion give
 the sandwich
 \begin{align}
     \ker H_L^{(N)}
-      \subseteq \ker H_R^{(N)}
-      =\operatorname{span}\{V^{(N)}(A_j):1\leq j\leq g\}
-      \subseteq \ker H_L^{(N)}.
+    \subseteq \ker H_R^{(N)}
+    =\operatorname{span}\{V^{(N)}(A_j):1\leq j\leq g\}
+    \subseteq \ker H_L^{(N)}.
     \label{eq:cpsv16_parent_hamiltonian_range_sandwich}
 \end{align}
 The exact coisometric reconstruction of literal CPSV canonical form preserves
@@ -134,8 +134,8 @@ the positive-length local space, so this equality transfers from the direct
 sum of representatives to $A$. Finally,
 \begin{align}
     L
-      &\leq3(D-1)(D^4+1)+D^4
-       \leq3D^5.
+     & \leq3(D-1)(D^4+1)+D^4
+    \leq3D^5.
     \label{eq:cpsv16_parent_hamiltonian_range_bound}
 \end{align}
 For one representative, one may take $L_{\mathrm{aux}}=D^4+1$. The
@@ -148,7 +148,7 @@ CPSV16 or PGVWC07.
 To obtain one witness that also satisfies the nontriviality condition, enlarge
 each auxiliary range to
 \begin{align}
-    L&=3D^5.
+    L & =3D^5.
     \label{eq:cpsv16_parent_hamiltonian_range_uniform}
 \end{align}
 Cyclic-range antitonicity preserves the upper inclusion at the enlarged

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2016,6 +2016,22 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/Channel/Determinant/HeisenbergDual.lean:103`; a follow-up sweep can retire this
   candidate once those are also converted to `norm_star`.
 
+### ground-space invariance under nonzero tensor rescaling — candidate
+- **Pattern:** identify the local MPS spaces of `ζ • A` and `A` for `ζ ≠ 0`
+  by rewriting `groundSpaceMap (ζ • A) L X` as
+  `groundSpaceMap A L ((ζ ^ L) • X)`, then use multiplication by
+  `ζ ^ L` and its inverse for the two range inclusions.
+- **Seen:** two nearly identical private lemmas:
+  `groundSpace_smul_eq` in
+  `TNLean/MPS/ParentHamiltonian/CoisometricReconstruction.lean` and
+  `groundSpace_smul_eq_of_ne_zero` in
+  `TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean` (2026-08-31).
+- **Abstraction (proposed):** if a third consumer appears, promote one public
+  theorem beside the ground-space definitions and replace both private proofs.
+- **Notes:** the two current callers concern different reconstruction arguments,
+  and the earlier theorem is private, so neither can reuse the other without an
+  API change. This remains below the rule-of-three promotion threshold.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
### Motivation

Proves the original-lattice parent-Hamiltonian range asserted after CPSV16 Definition 3.9. The theorem returns both parts of the source construction: a nonzero local interaction, witnessed by `D^2 < d^L`, and the exact BNT ground-space spanning equation for every original periodic ring with `N > L`.

The proof follows Pérez-García--Verstraete--Wolf--Cirac Theorem 12, absorbs its finite-size window into an auxiliary range, and then enlarges uniformly to `L = 3D^5`. It does not infer the original-lattice claim by transporting the distinct blocked nearest-neighbor Hamiltonian proved in #7451.

### Description

#### Statement-integrity audit

##### Paper assumptions versus Lean assumptions

- **Paper:** `A` is in canonical form with positive ambient bond dimension `D`; lines 511–515 require a block length for which `d^L > D^2` before Definition 3.9 names the resulting construction a parent Hamiltonian.
- **Lean:** `hA : IsCPSVCanonicalForm A`, `[NeZero D]`, and `hd : 1 < d`.
- **Boundary verdict:** `[NeZero D]` is the positive bond-dimension boundary. Under `D > 0`, `1 < d` is the exact feasibility boundary for the source condition: if `d ≤ 1`, then `d^L ≤ 1 ≤ D^2` for every positive `L`, while the proof establishes the inequality at `L = 3D^5` whenever `1 < d`.
- The omission of this degenerate physical-spin boundary in line 527 is recorded once as a **Local fix** in the module docstring and in `docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex`.
- No Perron-gauge, dual-fixed-point, block-count, global-cut, or short-ring assumption appears in the theorem. Those data are derived internally.

##### Paper conclusion versus Lean conclusion

CPSV16 lines 511–527 and Definition 3.9 require an original-lattice interaction range satisfying the displayed weak bound `L ≤ 3D^5`, a nontrivial local orthogonal complement, and the BNT spanning equation for every `N > L`.

Lean proves the existence of a genuine CPSV basis of normal tensors `(B_j)_{j=1}^g` and a range `L` such that:

- `0 < L`;
- `D^2 < d^L`, hence the local orthogonal-complement interaction is nonzero;
- `L ≤ 3D^5`;
- for every `N > L`, `ker H_L^(N)(A)` is exactly the span of the periodic BNT vectors `V^(N)(B_j)`.

The conclusion concerns the unblocked tensor `A` and includes every short ring allowed by Definition 3.9. It is neither restricted to multiples of a blocking length nor weakened to the spanning clause alone.

##### Relevant definitions

- `MPSTensor.IsCPSVCanonicalForm`
- `MPSTensor.IsCPSVBasisOfNormalTensors`
- `MPSTensor.HasParentHamiltonianGroundSpaceSpanning`
- `MPSTensor.groundSpace`, `MPSTensor.chainGroundSpace`, and `MPSTensor.parentHamiltonian`
- `MPSTensor.bntMPSVectorSpan`

`HasParentHamiltonianGroundSpaceSpanning` itself unfolds only to Definition 3.9's all-`N>L` kernel/spanning equation. The separate returned conjunct `D^2 < d^L` supplies the preceding source condition that makes the local projector nonzero.

##### Proof status and route

The theorem
`MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning`
is proved without `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`.

Choose one normal representative from each CPSV phase class and put it in the source-unital Perron gauge with a positive dual fixed point. Let `L₀ = D^4`.

- For `g ≥ 2`, set

  ```text
  R    = 3(g-1)(L₀+1)+1,
  Laux = 3(g-1)(L₀+1)+L₀.
  ```

  Then `N > Laux` implies the PGVWC07 global-cut condition `N ≥ R + L₀`. The range-`R` kernel is the BNT span; cyclic-window antitonicity gives the range-`Laux` upper inclusion, and the standard frustration-free BNT inclusion gives the reverse inclusion.

- For `g = 1`, the normal-tensor intersection theorem supplies the equality at `Laux = D^4 + 1`.
- For `g = 0`, the empty direct-sum one-letter parent theorem supplies it at `Laux = 2`.

A shared mathematical monotonicity lemma enlarges each branch to `L = 3D^5` without changing the BNT ground space. Exact coisometric reconstruction transfers the local-space equality to `A`. Finally,

```text
D^2 < 2^(2D) ≤ d^(2D) ≤ d^(3D^5)
```

proves the nontriviality conjunct.

The proof-heavy workflow was followed: `docs/tactic_patterns.md` was consulted, the scanner was run, and the noticed two-occurrence scalar ground-space rescaling pattern was recorded as a candidate below the rule-of-three promotion threshold. The repeated range-enlargement argument across the three block-count cases was factored into one private mathematical lemma.

##### Faithfulness verdict

**Faithful with one documented local boundary clarification.** The theorem proves the full original-lattice construction of lines 511–527 for the exact feasible physical range `1 < d`. It closes the earlier proof-path drift: the blocked theorem alone did not imply the original-lattice result, while the PGVWC07 short-ring sandwich does. `[NeZero D]` and `1 < d` are boundary conditions; no load-bearing proof hypothesis has been added.

##### Issues and tracking

- Closes #7490, a native child of tracking issue #7338.
- Keeps the blocked-lattice result #7400/#7451 mathematically distinct.
- The parent trackers will be synchronized only after the final reviewed head reaches `main`.

#### Source anchors

- `Papers/1606.00608/MPDO-22-12-17-2.tex:511-527`: construction, Definition 3.9, and the `L ≤ 3D^5` assertion.
- `Papers/quant-ph_0608197/MPSarchive.tex:1424-1456`: PGVWC07 Theorem 12 kernel equality and global-cut window.
- arXiv:2011.12127, Section IV.C, lines 2078–2090: the one-normal-block intersection and closure property.

#### Files

- `TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean`
- `TNLean/MPS/ParentHamiltonian.lean`
- `blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex`
- `docs/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.tex`
- `docs/tactic_patterns.md`

### Testing

#### Validation at final head `6a11152b4354239347ce439668720bbb23b04d40`

Passed on the exact committed tree. Its file tree is byte-identical to the reviewed head `a003ea07d31deb66e712ff2f89742de4b013ac05`. External commit `10ce2396504f519c17d7783a66a1236e39708ab4` introduced an unreviewed Blueprint expository rewrite; final commit `6a11152b4354239347ce439668720bbb23b04d40` reverted it in full, leaving an empty cumulative content diff:

- `git diff --check 365eebee57e262243959927f3c648c63c96f20a7...HEAD` (exit 0);
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 365eebee57e262243959927f3c648c63c96f20a7 --ci` (exit 0; the complete committed PR diff was checked against the exact PR base);
- `python3 scripts/test_lean_file_policies.py` (16/16, exit 0);
- `python3 scripts/test_generate_import_aggregators.py` (14/14, exit 0);
- `python3 scripts/tactic_pattern_scan.py` (exit 0; no new promotion candidate beyond the recorded two-occurrence entry);
- forbidden-proof-token scan of the changed Lean module (no matches);
- `lake env lean /tmp/TNLean7490Axiom.lean` with `#print axioms MPSTensor.IsCPSVCanonicalForm.exists_bnt_hasParentHamiltonianGroundSpaceSpanning` (exit 0): `[propext, Classical.choice, Quot.sound]` only.

The linter-bearing command

```text
lake build TNLean.MPS.ParentHamiltonian.CPSVOriginalRange
```

succeeded on the identical working-tree content immediately before the final commit. A redundant forced local replay was cancelled when another process entered the same output path and is not counted as validation; exact-head hosted CI is the authoritative final linter-bearing gate.

Exact-head review:

- Claude review at `a003ea07d31deb66e712ff2f89742de4b013ac05` completed clean in run 33349554576 (comment 5472826682);
- final Claude review at exact `6a11152b4354239347ce439668720bbb23b04d40` completed clean in run 33350785844 (comment 5472973441), confirming the identical tree and no remaining mathematical or Blueprint blocker;
- independent mathematical review confirmed that the source, theorem, proof, Blueprint, and gap note are faithful, and independently verified that `a003ea07...6a11152b` has identical tree `b3c6210a444099221294925ad2277e4153804c14`.

Hosted exact-head results:

- PR CI run 33350720329 completed successfully at `6a11152b4354239347ce439668720bbb23b04d40`;
- full Lean build, changed-time check, style lint, Blueprint declarations, and paper-gap declarations passed in job 99363469827;
- Blueprint source, prose, chktex, pinned latexindent, web generation, generated pages, and synchronization checks passed in job 99363469878.

An exact-head Codex review is unavailable because both final-code-head requests returned the account usage-limit response (comments 5472717428 and 5472742719). The source and Lean proof at `f901c5d85cf4c801413f7ab91eb5eb9a940ef6ea` received clean Claude and independent mathematical reviews; the cumulative file-tree delta from `f901c5d8` through final `6a11152b` consists only of the canonical paper-gap status marker and four pinned-formatter whitespace replacements; both deltas are covered by independent review.

All final gates completed at the exact reviewed head, which merged as `09f69780fd1a103b912e5f16b093eacc2c6f07f0`.

---
Closes #7490.
