### PR TITLE
doc(PEPS): distinguish periodic and open edge blocking

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_blocking_and_fundamental.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_blocking_and_fundamental.tex
@@ -126,7 +126,9 @@
     $T$, together with their translated variants, give an edge-centred
     blocking into red, blue, and complementary injective regions. These are
     the regions on which the three-site injective-chain insertion argument is
-    applied:
+    applied. Here the translations are those of the periodic square lattice;
+    the cited proof does not give separate boundary blockings for an open
+    rectangle:
     \begin{tenkzequation}
         % Formula verdict: A1=(4-6,2-3), A2=(3-4,4-6), and A3 is their
         % complement in the 7-by-7 frame; blocking contracts each region to
@@ -211,9 +213,9 @@
     The torus form of this absorption, with the gauge family carried onto
     every edge by the translations from one matrix per orientation class, is
     part of Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional}.
-    The present open-lattice entry awaits a translation-invariance predicate
-    on the open lattice, which would make the per-edge gauges of the edge
-    blocking one horizontal and one vertical matrix.
+    This is the geometry used in the source. An analogous assertion for an
+    open rectangle would require additional boundary data and is not an
+    unproved case of the cited theorem.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal square-lattice PEPS]%
@@ -228,15 +230,14 @@
     $\lambda^{nm}=1$. This is
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
     Theorem~\ref{thm:fundamentalTheorem_normalSquarePEPS_unconditional} proves
-    an interior-window form of this statement from the source hypotheses alone,
+    a related interior-window theorem on an open rectangle,
     without translation invariance and with per-vertex scalars in place of the
     single $\lambda$; the gauge-equivalence conclusion on a general connected
     graph, from region injectivity alone, is
-    Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}. The present
-    source-exact entry awaits a translation-invariance predicate on the open
-    lattice, which would make the per-edge gauges one horizontal and one
-    vertical matrix and the per-vertex scalars a single $\lambda$ with
-    $\lambda^{nm}=1$.
+    Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}. The periodic
+    statement of the source is formalized in
+    Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional}. Extending
+    the open-rectangle theorem to its boundary is a separate question.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal square-lattice PEPS,

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_rectangular_injectivity.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_rectangular_injectivity.tex
@@ -278,9 +278,12 @@
 
     \emph{Scope restriction (interior edge).} The removed blocks must sit in the
     interior. The fixed origin window has its corner forced and so has no
-    rectangular cover; the source object is the full-lattice complement $A_3$,
-    which has room only at an interior edge. The source comparison is recorded
-    in \cite{gap:peps_normal_ft_section3_route}.
+    rectangular cover; the corresponding object for the open rectangle is the
+    full-lattice complement $A_3$, which has room only at an interior edge.
+    This is an open-boundary extension of the source geometry. In
+    \cite[Theorem~3]{Molnar2018NormalPEPS}, translations on the periodic lattice
+    carry a reference blocking to every edge; see
+    \cite{gap:peps_normal_ft_section3_route}.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
@@ -307,9 +310,11 @@
 
     \emph{Scope restriction (interior edge).} The construction supplies data
     only at edges with interior margins. Edges near the lattice boundary of the
-    open rectangular model lack such margins; on a translation-invariant lattice
-    every edge is interior. The source comparison is recorded in
-    \cite{gap:peps_normal_ft_section3_route}.
+    open rectangular model lack such margins. Covering those edges is a further
+    open-boundary problem, not an omitted case of
+    \cite[Theorem~3]{Molnar2018NormalPEPS}; the cited theorem uses translations
+    on the periodic lattice, where the reference blocking reaches every edge.
+    See \cite{gap:peps_normal_ft_section3_route}.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok

--- a/docs/audits/2026-08-04_issue_status_audit.md
+++ b/docs/audits/2026-08-04_issue_status_audit.md
@@ -5,7 +5,19 @@
 fundamental theorem. That is false: the datum reached no such consumer, and
 the module defining it has since been deleted. See
 `2026-08-26_peps_torus_singleton_blocking_deletion.md`, section "Correction to
-an earlier audit". The rest of this note stands as a dated snapshot.
+an earlier audit".
+
+**Further correction 2026-08-31.** The #2606 row below treated boundary edges
+of the open rectangular graph as a missing case of arXiv:1804.04964,
+Theorem 3. The source instead uses periodic translationally invariant geometry:
+all graph edges are contracted (`paper_normal.tex:961--979`), the square-lattice
+specialization excludes loops and double edges by requiring both lengths to be
+at least three (`paper_normal.tex:1207--1212`), and translation carries one
+blocking to every horizontal and vertical edge (`paper_normal.tex:1449--1500`).
+The source theorem is realized by
+`fundamentalTheorem_normalTorusPEPS_unconditional`. Boundary coverage for the
+open rectangle is a possible project extension, not a paper obligation. Apart
+from these two corrections, this note stands as a dated snapshot.
 
 Scope: all 145 open GitHub issues. Method: per-issue dossiers (body +
 stale-citation findings from `scripts/audit_stale_issues.py` against current
@@ -229,7 +241,7 @@ CLOSED by audit (14): #631, #2318, #2470, #2616, #3965, #4065, #5086, #5422,
 | #2320 | tracker, updated | |
 | #2449 | PARTIAL | |
 | #2450 | PARTIAL | |
-| #2606 | ACTIVE | |
+| #2606 | SOURCE-SUPERSEDED; optional open-boundary extension | Theorem 3 is periodic and is covered by `fundamentalTheorem_normalTorusPEPS_unconditional`; the source does not provide boundary blockings for the open rectangular graph. |
 | #2660 | PARTIAL, cross-linked with #4872 | defs landed PR #2978 |
 | #2661 | tracker, up-to-date | |
 | #2691 | ACTIVE | |

--- a/docs/audits/2026-08-04_issue_status_audit.md
+++ b/docs/audits/2026-08-04_issue_status_audit.md
@@ -13,7 +13,7 @@ Theorem 3. The source instead uses periodic translationally invariant geometry:
 all graph edges are contracted (`paper_normal.tex:961--979`), the square-lattice
 specialization excludes loops and double edges by requiring both lengths to be
 at least three (`paper_normal.tex:1207--1212`), and translation carries one
-blocking to every horizontal and vertical edge (`paper_normal.tex:1449--1500`).
+blocking to every horizontal and vertical edge (`paper_normal.tex:1449--1498`).
 The source theorem is realized by
 `fundamentalTheorem_normalTorusPEPS_unconditional`. Boundary coverage for the
 open rectangle is a possible project extension, not a paper obligation. Apart

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -63,6 +63,20 @@ $S$ regions gives $A\propto \widetilde B$.
 \footnote{The proof of Theorem \path{3} is
     \path{Papers/1804.04964/paper_normal.tex:1449--1572}, Ref.~\cite{Molnar2018NormalPEPS}.}
 
+Here ``every edge'' belongs to the periodic translationally invariant
+square lattice, not to a finite open rectangle with geometrically distinct
+boundary sites. The source first defines a PEPS by contracting all edges of
+its defining graph, and its $N\times M$ square-lattice specialization requires
+$N,M\geq3$ in order to avoid loops and double edges. In the proof of
+Theorem~\path{3}, one blocking is carried to all horizontal and vertical edges
+by translations. These are precisely the periodic features represented by
+the discrete torus. The cited passage supplies no separate blocking at the
+boundary of an open rectangle.
+\footnote{See
+    \path{Papers/1804.04964/paper_normal.tex:961--979},
+    \path{Papers/1804.04964/paper_normal.tex:1207--1212}, and
+    \path{Papers/1804.04964/paper_normal.tex:1449--1500}.}
+
 The general theorem \path{normal} of Ref.~\cite{Molnar2018NormalPEPS}
 removes the square-lattice specialization.
 It assumes precisely the blockings needed above: every edge can be blocked into
@@ -299,10 +313,11 @@ enough left and right margin; a coordinate upward edge must have enough bottom
 and top margin. Hence the cover-free interior construction supplies data only on
 the interior edges of the open $7\times7$ graph; the earlier translated-window
 and oriented margin-and-cover criteria have the same interior restriction.
-Explicit boundary obstructions are recorded on all four sides. The remaining
-every-edge construction must therefore include the boundary geometry: the
-interior $A_3$ injectivity removes the local and rotated $T$-cover obligation for
-interior edges, leaving the boundary edges of the open rectangular model.
+Explicit boundary obstructions are recorded on all four sides. Extending this
+construction to the boundary edges would be an additional theorem about open
+rectangles. It is not an omitted case of Theorem~\path{3}: the source uses the
+periodic translation action, and the corresponding every-edge construction is
+the torus construction described below.
 
 Verdict: this note records an open gap with a scope restriction. The earlier
 vocabulary gap for contiguous rectangular blocks is closed. The earlier
@@ -324,12 +339,12 @@ since the source object is $A_3$ and the local window is a fixed small frame
 whose corner is forced. The every-edge blocking construction is cover-free at
 interior edges and assembles the normal edge-blocking hypotheses there. The
 tensor-level union theorem is proved for positive bond dimensions, including the
-overlapping case (the overlap re-insertion). The remaining open gap is the
-boundary geometry of the open rectangular model: edges near the lattice
-boundary lack interior margins, so the cover-free construction does not yet
-reach them; on a translation-invariant lattice every edge is interior and the
-construction is complete. Injectivity of $R$ and $S$ is already derived from
-union closure and rectangular injectivity.
+overlapping case (the overlap re-insertion). Edges near the boundary of the open
+rectangular model still lie outside this construction, but this is the scope of
+a possible open-boundary strengthening rather than a gap in the cited theorem.
+For the periodic translationally invariant lattice, every edge is obtained from
+a reference edge by translation and the construction is complete. Injectivity
+of $R$ and $S$ is already derived from union closure and rectangular injectivity.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -612,10 +627,12 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.verticalSquareLatticeEdge_blockingDatum_interior},
           \leanid{TNLean.PEPS.NormalSquareInteriorEdgeDatum}, and
           \leanid{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_interiorData}.}
-          The remaining task is the boundary geometry of the open rectangular
-          model, where some edges lack interior margins; on a translation-invariant
-          (periodic) lattice every edge is interior and the construction is
-          complete.
+          Boundary edges of the open rectangular model lack these margins. A
+          construction there would be a separate open-boundary strengthening:
+          the source does not derive it from the $2\times3$ and $3\times2$
+          hypotheses. On the periodic translationally invariant lattice of
+          Theorem~\path{3}, translations carry the reference construction to
+          every edge, and the torus construction below is complete.
     \item Reuse the injective-chain insertion route after this blocking:
           \ghissue{1367}, \ghissue{1368}, \ghissue{1363}, \ghissue{1364},
           \ghissue{1361}, and \ghissue{1360}. The formal material for this route
@@ -2222,10 +2239,11 @@ multilinear in the site tensors, so the relation $A_v = \lambda\cdot(\text{gauge
 action of }B)_v$ with $\lambda^{nm}=1$ already implies the bare-edge absorbed
 equality at every edge (\path{edgeAbsorbed_of_perVertex}).
 
-What remains against the source statement of Theorem~3: the source's square-lattice
-region form of the theorem is covered separately by the conditional square-lattice
-statement recorded earlier in this note. The torus sizes match the source: the
-theorem and its uniqueness clauses hold for $n,m\geq 7$ (see the next section).
+There is no residual boundary-edge obligation in the source statement of
+Theorem~3. Its periodic square-lattice form and its uniqueness clauses hold for
+$n,m\geq 7$ (see the next section). The open-rectangle interior theorem is a
+separate extension and makes no claim at geometrically distinguished boundary
+edges.
 
 \section*{The torus sizes: from $n,m\geq 9$ to the source's $n,m\geq 7$}
 
@@ -2292,10 +2310,13 @@ feeders (\path{tiAbsorb}, \path{TINormalGaugeAbsorptionData},
 \path{absorbEdgeGauges_eq_of_matrixScalar}, and
 \path{TNLean/PEPS/NormalSquareTIAbsorption.lean}). The vertex-injective product identity
 \path{prod_perVertexScalar_eq_one} itself remains: it serves the injective theorem
-(Theorem~2), where single-site injectivity is the source hypothesis. A
-source-exact translationally invariant square-lattice statement awaits a
-translation-invariance predicate on the open lattice, as the earlier sections
-record.
+(Theorem~2), where single-site injectivity is the source hypothesis. No
+translation-invariance predicate on the open rectangle is required for the
+source theorem: its translationally invariant geometry is the discrete torus,
+and that theorem is
+\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}. Extending
+the open-rectangle theorem to its boundary vertices would be additional
+mathematics, not completion of Theorem~\path{3}.
 
 \section*{The closed-chain MPS corollary}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -75,7 +75,7 @@ boundary of an open rectangle.
 \footnote{See
     \path{Papers/1804.04964/paper_normal.tex:961--979},
     \path{Papers/1804.04964/paper_normal.tex:1207--1212}, and
-    \path{Papers/1804.04964/paper_normal.tex:1449--1500}.}
+    \path{Papers/1804.04964/paper_normal.tex:1449--1498}.}
 
 The general theorem \path{normal} of Ref.~\cite{Molnar2018NormalPEPS}
 removes the square-lattice specialization.


### PR DESCRIPTION
### Motivation

Issue #2606 treats boundary-edge blocking on the open rectangular square lattice as a missing case of arXiv:1804.04964, Theorem 3. The paper instead proves the translationally invariant statement on periodic square-lattice geometry. Its translation action carries one reference blocking to every horizontal and vertical edge; it does not supply an additional construction at geometrically distinguished open boundary edges.

The source-faithful periodic theorem is already represented by `TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional`. The existing open-rectangle interior theorem remains useful as a project-derived extension, but its boundary is not an unfinished obligation of Theorem 3.

### Description

The source audit uses the following passages.

- `Papers/1804.04964/paper_normal.tex:961--979` defines PEPS by contracting all graph edges.
- Lines `1207--1212` require both square-lattice lengths to be at least three to avoid self-loops and double edges.
- Lines `1449--1498` state the normal translationally invariant two-dimensional theorem and use translation invariance to identify the gauges on all horizontal and vertical edges.
- Lines `1574--1585` give the arbitrary-graph theorem only under the assumption that suitable injective blockings already exist around every edge. They do not derive open-boundary blockings from rectangular injectivity.
- The current open-lattice declarations retain explicit interior-margin hypotheses, whereas the torus theorem gives the every-edge, translation-covariant conclusion.

Accordingly, this change:

- corrects the paper-gap note to distinguish the source's periodic geometry from the optional open-boundary strengthening;
- synchronizes the two normal-square Blueprint chapters with that distinction;
- corrects the dated issue audit and classifies #2606 as source-superseded, with an optional project-extension problem kept separate; and
- preserves all existing open-rectangle theorems and makes no Lean statement or proof changes.

After review, #2606 should be treated as source-superseded rather than as an unfinished subissue of the Theorem 3 route. If open-rectangle boundary coverage is desired independently, a separate project-extension issue should first ask whether rectangular injectivity implies `NormalEdgeBlockingData` at every boundary-near internal edge. Such an issue should cite lines `1574--1585` as a conditional theorem and should not claim to complete Theorem 3.

This pull request does not edit or close the issue.

### Testing

- `lake build`
- `leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `texra-blueprint --root . paper-gaps check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/test_blueprint_lean_sync.py`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/test_badge_colors.py`
- focused `chktex` and the pinned `latexindent` on both changed Blueprint chapters
- `python3 .deps/tenkz/scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex' 'docs/slides/*.tex'`
- `python3 scripts/test_tenkz_peps_torus.py`
- `python3 scripts/test_tenkz_index_routing.py`
- `python3 scripts/test_tenkz_blueprint_sweep.py`
- hosted Blueprint web generation, equation-layout checks, and generated-page rendering

Refs #2606
