### PR TITLE
doc(PEPS): add Lemma 5 Blueprint dependency

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus_single_bond_peeling.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_single_bond_peeling.tex
@@ -438,7 +438,9 @@
     \lean{TNLean.PEPS.existsUnique_virtualOperation_of_horizontalStaircaseEndPair}
     \lean{TNLean.PEPS.existsUnique_virtualOperation_of_horizontalStaircaseEndPhysicalOperations}
     \leanok
-    \uses{thm:peps_existsUnique_virtualOperation_of_endPair, thm:peps_horizontal_staircase_end_pair_single_bond_contraction}
+    \uses{def:peps_end_operations_realizing_virtual_matrix,
+        thm:peps_existsUnique_virtualOperation_of_endPair,
+        thm:peps_horizontal_staircase_end_pair_single_bond_contraction}
     Suppose the tensor is translation invariant, all bond dimensions are
     positive, and the two genuine highlighted end-window blocked tensors are
     injective.  If arbitrary inserts $C_{\mathrm L}$ and $C_{\mathrm R}$ on


### PR DESCRIPTION
### Motivation

PR #7484 added the source-facing end-operation specialization to the horizontal staircase end-pair theorem. That specialization uses the predicates defining when O₁ and O₃ᵀ realize a virtual matrix, but the theorem node did not record the defining Blueprint node as a dependency.

### Description

Add def:peps_end_operations_realizing_virtual_matrix to the uses list of thm:peps_existsUnique_virtualOperation_of_horizontal_staircase_end_pair. This is only a dependency-graph correction; the mathematical statement, Lean declarations, and proof remain unchanged.

### Testing

- git diff --check
- reader-facing prose check
- Blueprint to Lean source synchronization: all 7,129 entries resolve
- Blueprint synchronization, paper-gap identifier, and badge-color tests
- complete leanblueprint web build with the pinned texra-blueprint v0.3.8 plugin
- hosted exact-head root build, Blueprint compilation, declaration checks, and compilation-time check passed

Closes #7530