### PR TITLE
fix(MPS/MPDO): certify Proposition C.15 witness simplicity

### DIFF
--- a/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
+++ b/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
@@ -86,7 +86,7 @@ counterexample excludes every asserted two-to-three channel under the complete
 standing hypotheses and therefore refutes the unrestricted conclusion of
 `prop2to5`. See
 <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> and
-<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
+<https://sirui-lu.com/TNLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817; the closing proof at lines 1821--1825; and the weight
@@ -136,7 +136,7 @@ construction; the separate trace-norm counterexample excludes every asserted
 two-to-three channel under the complete standing hypotheses and refutes the
 unrestricted source conclusion. See
 <https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> and
-<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
+<https://sirui-lu.com/TNLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817, and lines 1389--1403. -/

--- a/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
+++ b/TNLean/MPS/MPDO/BNTFactorizationChannels.lean
@@ -81,10 +81,12 @@ here. The printed route to Proposition `prop2to5` obtains them from saturation
 of the area law and zero correlation length through Proposition `prop2to3`,
 but that representativewise assertion is false under the complete standing
 hypotheses. Thus this theorem proves the conditional channel construction but
-does not prove Proposition `prop2to5`. The counterexample does not exclude
-different channel maps, so the bare conclusion of `prop2to5` is neither proved
-nor refuted. See
-<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
+does not prove Proposition `prop2to5`. Independently, the trace-norm
+counterexample excludes every asserted two-to-three channel under the complete
+standing hypotheses and therefore refutes the unrestricted conclusion of
+`prop2to5`. See
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> and
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817; the closing proof at lines 1821--1825; and the weight
@@ -129,10 +131,12 @@ four selected sectors.
 single-sector factorizations are assumed here. They do not follow in general
 from saturation of the area law and zero correlation length, because the
 printed representative-factorization assertion is false under the complete
-standing hypotheses. This theorem proves the conditional channel construction
-but does not decide whether different channels establish the bare source
-conclusion. See
-<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf>.
+standing hypotheses. This theorem proves only the conditional channel
+construction; the separate trace-norm counterexample excludes every asserted
+two-to-three channel under the complete standing hypotheses and refutes the
+unrestricted source conclusion. See
+<https://sirui-lu.com/QICLean/paper-gaps/cpgsv17_pf_rank_one.pdf> and
+<https://sirui-lu.com/QICLean/paper-gaps/cpsv16_prop_c15_blocking_channel_false.pdf>.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `prop2to5`, lines
 1810--1817, and lines 1389--1403. -/

--- a/TNLean/MPS/MPDO/CPSVBlockingChannelAmbientCounterexample.lean
+++ b/TNLean/MPS/MPDO/CPSVBlockingChannelAmbientCounterexample.lean
@@ -134,6 +134,7 @@ theorem printed_propositionC15_and_theorem49_ii_to_v_are_false :
         (∀ N, 0 < N → 0 < Matrix.trace (mpo K N)) ∧
         IsSAL K ∧
         IsSimpleCanonicalForm K ∧
+        IsSimple K ∧
         MPSTensor.IsBNTCanonicalForm S ∧
         MPSTensor.WordTupleSpanTop S.basis 1 ∧
         (∀ j, MPSTensor.IsNormalTensor (S.basis j)) ∧

--- a/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientCounterexample.lean
+++ b/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientCounterexample.lean
@@ -739,6 +739,19 @@ theorem ambient_isSimpleCanonicalForm
   simp only [hGlobal, Units.val_one, inv_one, one_mul, mul_one]
   exact (cast_eq _ _).symm
 
+/-- The ambient tensor is simple in the sense of CPSV16, Definition 4.7.
+This follows from its displayed normalized simple canonical form; the
+conclusion forgets the global unit-weight normalization at line 246.
+
+Source: CPSV16, Definition 4.7, lines 815--822, under the standing Appendix
+C.2 hypothesis at line 1628. -/
+theorem ambient_isSimple
+    (mu : ℂ) (B : MPSTensor (5 * 5) 2) (hmu : mu ≠ 0)
+    (hGauge : MPSTensor.GaugeEquiv embeddedObstruction.toMPSTensor (mu • B))
+    (hBNT : MPSTensor.IsBNTCanonicalForm (sectors mu B hmu)) :
+    IsSimple (ambient mu B hmu) :=
+  (ambient_isSimpleCanonicalForm mu B hmu hGauge hBNT).isSimple
+
 /-- Every positive-length ambient periodic operator has strictly positive
 normalization.  This is the normalization clause used in the Appendix C.2
 standing MPDO and SAL hypotheses.
@@ -853,7 +866,7 @@ theorem exists_ambient_simpleBiCF_neighboringTraceObstruction :
     fun N hN ↦ trace_mpo_ambient_pos mu B hmu hGauge hN,
     ambient_isSAL mu B hmu hGauge,
     ambient_isSimpleCanonicalForm mu B hmu hGauge hBNT,
-    (ambient_isSimpleCanonicalForm mu B hmu hGauge hBNT).isSimple,
+    ambient_isSimple mu B hmu hGauge hBNT,
     hBNT, sectors_wordTupleSpanTop_one mu B hmu hBInj hBSupport,
     sectors_basis_isNormalTensor mu B hmu hBNormal,
     ambient_toMPSTensor_eq_sectors_toTensor mu B hmu,

--- a/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientCounterexample.lean
+++ b/TNLean/MPS/MPDO/NeighboringTraceObstructionAmbientCounterexample.lean
@@ -11,6 +11,7 @@ import TNLean.MPS.MPDO.NeighboringTraceObstructionAmbientBlocks
 import TNLean.MPS.MPDO.PhysicalIsometricEmbeddingNeighboringTrace
 import TNLean.MPS.MPDO.PhysicalSectorGaugeTransport
 import TNLean.MPS.MPDO.SALTraceTransfer
+import TNLean.MPS.MPDO.Simple
 
 /-!
 # An ambient neighboring-trace obstruction in simple biCF form
@@ -817,6 +818,7 @@ theorem exists_ambient_simpleBiCF_neighboringTraceObstruction :
       (∀ N, 0 < N → 0 < Matrix.trace (mpo K N)) ∧
       IsSAL K ∧
       IsSimpleCanonicalForm K ∧
+      IsSimple K ∧
       MPSTensor.IsBNTCanonicalForm S ∧
       MPSTensor.WordTupleSpanTop S.basis 1 ∧
       (∀ j, MPSTensor.IsNormalTensor (S.basis j)) ∧
@@ -851,6 +853,7 @@ theorem exists_ambient_simpleBiCF_neighboringTraceObstruction :
     fun N hN ↦ trace_mpo_ambient_pos mu B hmu hGauge hN,
     ambient_isSAL mu B hmu hGauge,
     ambient_isSimpleCanonicalForm mu B hmu hGauge hBNT,
+    (ambient_isSimpleCanonicalForm mu B hmu hGauge hBNT).isSimple,
     hBNT, sectors_wordTupleSpanTop_one mu B hmu hBInj hBSupport,
     sectors_basis_isNormalTensor mu B hmu hBNormal,
     ambient_toMPSTensor_eq_sectors_toTensor mu B hmu,
@@ -894,6 +897,7 @@ theorem printed_theorem49_ii_to_iv_is_false :
         (∀ N, 0 < N → 0 < Matrix.trace (mpo K N)) ∧
         IsSAL K ∧
         IsSimpleCanonicalForm K ∧
+        IsSimple K ∧
         MPSTensor.IsBNTCanonicalForm S ∧
         MPSTensor.WordTupleSpanTop S.basis 1 ∧
         (∀ j, MPSTensor.IsNormalTensor (S.basis j)) ∧

--- a/TNLean/MPS/MPDO/Simple.lean
+++ b/TNLean/MPS/MPDO/Simple.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.BNTRefinement
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.MPDO.SimpleTensor
 
 /-!
@@ -21,6 +22,8 @@ a defining clause.
 ## Main results
 
 * `MPOTensor.IsSimple`: Definition 4.7 read over the canonical blocks.
+* `MPOTensor.IsSimpleCanonicalForm.isSimple`: the fixed-representative canonical
+  package implies source-facing simplicity.
 * `MPOTensor.IsSimple.exists_mpo_ne_zero`: simplicity supplies a nonzero closed
   MPO at some positive chain length.
 
@@ -98,6 +101,83 @@ def IsSimple (M : MPOTensor d D) : Prop :=
             (blockTensor M L).toMPSTensor P ∧
           ∀ j, ¬ IsNilpotent
             (doubledPhysTraceTransfer (MPSTensor.blockPhysDim d L) (P.basis j))
+
+/-- A simple canonical-form tensor is simple in the source-facing sense of
+Definition 4.7.
+
+Take blocking length $L=1$ and relabel the displayed BNT by the canonical
+identification between the one-site blocked ket-bra alphabet and the original
+doubled alphabet. The global block gauge preserves every closed
+matrix-product coefficient, while this relabeling preserves normality and the
+physical-trace transfer of each representative. Hence the displayed
+nonnilpotency certificates give the required BNT presentation after blocking.
+
+The implication forgets the line-246 unit-weight normalization built into
+`IsSimpleCanonicalForm`; that normalization is not part of `IsSimple`.
+
+Source: arXiv:1606.00608, canonical form at lines 217--246 and Definition 4.7
+at lines 815--822. -/
+theorem IsSimpleCanonicalForm.isSimple {M : MPOTensor d D}
+    (hM : IsSimpleCanonicalForm M) : IsSimple M := by
+  obtain ⟨hMPDO, S, hCF, hNonNil, hTotal, X, hEq⟩ := hM
+  subst D
+  let e : Fin (MPSTensor.blockPhysDim d 1 * MPSTensor.blockPhysDim d 1) ≃ Fin (d * d) :=
+    finProdFinEquiv.symm |>.trans
+      (Equiv.prodCongr (MPSTensor.singleBlockEquiv d) (MPSTensor.singleBlockEquiv d)) |>.trans
+        finProdFinEquiv
+  let P : MPSTensor.SectorDecomposition
+      (MPSTensor.blockPhysDim d 1 * MPSTensor.blockPhysDim d 1) := {
+    basisCount := S.basisCount
+    basisDim := S.basisDim
+    basis := fun j ↦ Kraus.reindexPhysical e (S.basis j)
+    sectors := S.sectors }
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
+    refine ⟨MPSTensor.globalGaugeOfBlocks X, ?_⟩
+    intro i
+    simpa using hEq i
+  have hSame : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
+    MPSTensor.SameMPV₂.toSameMPV₂Pos (fun N σ => (hGauge.sameMPV N σ).symm)
+  have hBlock : (blockTensor M 1).toMPSTensor =
+      Kraus.reindexPhysical e M.toMPSTensor := by
+    funext ij
+    change
+      M (MPSTensor.singleBlockEquiv d ij.divNat)
+          (MPSTensor.singleBlockEquiv d ij.modNat) * 1 =
+        M (e ij).divNat (e ij).modNat
+    simp [e]
+  refine ⟨hMPDO, 1, Nat.one_pos, P, ?_, ?_⟩
+  · refine ⟨?_, ?_, ?_, ?_⟩
+    · obtain ⟨j, _q, _hj⟩ := hCF.weight_unit_exists
+      exact Fin.pos_iff_nonempty.mpr ⟨j⟩
+    · intro N hN σ
+      rw [hBlock]
+      change MPSTensor.mpv (Kraus.reindexPhysical e M.toMPSTensor) σ =
+        MPSTensor.mpv (Kraus.reindexPhysical e S.toTensor) σ
+      simp only [MPSTensor.mpv_reindexPhysical]
+      exact hSame N hN (fun n => e (σ n))
+    · let _ : ∀ j : Fin S.basisCount, NeZero (S.basisDim j) :=
+        fun j => ⟨(hCF.basis_dim_pos j).ne'⟩
+      intro j
+      exact (MPSTensor.isNormalTensor_of_isNormal_leftCanonical (S.basis j)
+        (hCF.basis_isNormal j) (hCF.basis_left_canonical j)).reindexPhysical e
+    · obtain ⟨N₀, hLI⟩ := hCF.bnt_data
+      refine ⟨N₀, fun N hN ↦ ?_⟩
+      exact MPSTensor.linearIndependent_mpvState_reindexPhysical_equiv e S.basis (hLI N hN)
+  · intro j
+    change ¬ IsNilpotent (doubledPhysTraceTransfer (MPSTensor.blockPhysDim d 1)
+      (Kraus.reindexPhysical e (S.basis j)))
+    have hTransfer :
+        doubledPhysTraceTransfer (MPSTensor.blockPhysDim d 1)
+            (Kraus.reindexPhysical e (S.basis j)) =
+          doubledPhysTraceTransfer d (S.basis j) := by
+      rw [doubledPhysTraceTransfer, doubledPhysTraceTransfer]
+      change (∑ i : Fin (MPSTensor.blockPhysDim d 1),
+          S.basis j (e (finProdFinEquiv (i, i)))) =
+        ∑ i : Fin d, S.basis j (finProdFinEquiv (i, i))
+      simpa [e] using (MPSTensor.singleBlockEquiv d).sum_comp
+        (fun i : Fin d => S.basis j (finProdFinEquiv (i, i)))
+    rw [hTransfer]
+    exact hNonNil j
 
 /-- Simplicity supplies a nonzero closed MPO at some positive length.
 

--- a/TNLean/MPS/MPDO/Simple.lean
+++ b/TNLean/MPS/MPDO/Simple.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.BNTRefinement
-import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.MPDO.SimpleTensor
 
 /-!
@@ -125,12 +125,7 @@ theorem IsSimpleCanonicalForm.isSimple {M : MPOTensor d D}
     finProdFinEquiv.symm |>.trans
       (Equiv.prodCongr (MPSTensor.singleBlockEquiv d) (MPSTensor.singleBlockEquiv d)) |>.trans
         finProdFinEquiv
-  let P : MPSTensor.SectorDecomposition
-      (MPSTensor.blockPhysDim d 1 * MPSTensor.blockPhysDim d 1) := {
-    basisCount := S.basisCount
-    basisDim := S.basisDim
-    basis := fun j ↦ Kraus.reindexPhysical e (S.basis j)
-    sectors := S.sectors }
+  let P := S.reindexPhysical e
   have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
     refine ⟨MPSTensor.globalGaugeOfBlocks X, ?_⟩
     intro i
@@ -146,7 +141,9 @@ theorem IsSimpleCanonicalForm.isSimple {M : MPOTensor d D}
         M (e ij).divNat (e ij).modNat
     simp [e]
   refine ⟨hMPDO, 1, Nat.one_pos, P, ?_, ?_⟩
-  · refine ⟨?_, ?_, ?_, ?_⟩
+  · have hCF' :=
+      MPSTensor.SectorDecomposition.IsBNTCanonicalForm.reindexPhysical hCF e
+    refine ⟨?_, ?_, ?_, hCF'.bnt_data⟩
     · obtain ⟨j, _q, _hj⟩ := hCF.weight_unit_exists
       exact Fin.pos_iff_nonempty.mpr ⟨j⟩
     · intro N hN σ
@@ -155,14 +152,11 @@ theorem IsSimpleCanonicalForm.isSimple {M : MPOTensor d D}
         MPSTensor.mpv (Kraus.reindexPhysical e S.toTensor) σ
       simp only [MPSTensor.mpv_reindexPhysical]
       exact hSame N hN (fun n => e (σ n))
-    · let _ : ∀ j : Fin S.basisCount, NeZero (S.basisDim j) :=
-        fun j => ⟨(hCF.basis_dim_pos j).ne'⟩
+    · let _ : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+        fun j => ⟨(hCF'.basis_dim_pos j).ne'⟩
       intro j
-      exact (MPSTensor.isNormalTensor_of_isNormal_leftCanonical (S.basis j)
-        (hCF.basis_isNormal j) (hCF.basis_left_canonical j)).reindexPhysical e
-    · obtain ⟨N₀, hLI⟩ := hCF.bnt_data
-      refine ⟨N₀, fun N hN ↦ ?_⟩
-      exact MPSTensor.linearIndependent_mpvState_reindexPhysical_equiv e S.basis (hLI N hN)
+      exact MPSTensor.isNormalTensor_of_isNormal_leftCanonical (P.basis j)
+        (hCF'.basis_isNormal j) (hCF'.basis_left_canonical j)
   · intro j
     change ¬ IsNilpotent (doubledPhysTraceTransfer (MPSTensor.blockPhysDim d 1)
       (Kraus.reindexPhysical e (S.basis j)))

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -457,7 +457,7 @@ single family.
     \lean{MPSTensor.SectorDecomposition.reindexPhysical,
         MPSTensor.SectorDecomposition.IsBNTCanonicalForm.reindexPhysical}
     \leanok
-    \uses{def:sector_bnt_cf, thm:cpsv_physical_reindexing}
+    \uses{def:sector_bnt_cf}
     Let $P$ be a BNT canonical form and let $e$ be a bijection of its physical
     alphabet with another finite alphabet. Relabel every basis tensor of $P$
     by $e$, leaving the representative and copy labels, bond dimensions, and

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -452,6 +452,28 @@ single family.
     not derivable from the per-block normality hypotheses alone.
 \end{definition}
 
+\begin{theorem}[Physical relabeling preserves BNT canonical form]
+    \label{thm:sector_bnt_cf_reindex_physical}
+    \lean{MPSTensor.SectorDecomposition.reindexPhysical,
+        MPSTensor.SectorDecomposition.IsBNTCanonicalForm.reindexPhysical}
+    \leanok
+    \uses{def:sector_bnt_cf, thm:cpsv_physical_reindexing}
+    Let $P$ be a BNT canonical form and let $e$ be a bijection of its physical
+    alphabet with another finite alphabet. Relabel every basis tensor of $P$
+    by $e$, leaving the representative and copy labels, bond dimensions, and
+    weights unchanged. The resulting sector decomposition is again a BNT
+    canonical form.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_physical_reindexing}
+    Physical relabeling preserves irreducibility, left-canonical
+    normalization, normalized self-overlaps, eventual linear independence,
+    and gauge-phase separation of the representatives. Since the weights and
+    all sector data are unchanged, the canonical-form normalization is also
+    preserved.
+\end{proof}
+
 \begin{definition}[Single-sector decomposition]
     \label{def:single_sector_decomposition}
     \lean{MPSTensor.singleSectorDecomposition}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -412,7 +412,8 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:global_gauge_of_blocks, thm:gauge_invariance,
+    \uses{def:mpdo_doubled_phys_trace_transfer,
+        def:global_gauge_of_blocks, thm:gauge_invariance,
         thm:is_normal_tensor_of_is_normal_left_canonical,
         thm:sector_bnt_cf_reindex_physical}
     Take the blocking length to be one. The canonical bijection between the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -414,7 +414,7 @@
 \begin{proof}\leanok
     \uses{def:global_gauge_of_blocks, thm:gauge_invariance,
         thm:is_normal_tensor_of_is_normal_left_canonical,
-        thm:cpsv_physical_reindexing}
+        thm:sector_bnt_cf_reindex_physical}
     Take the blocking length to be one. The canonical bijection between the
     one-site blocked ket--bra alphabet and the original doubled alphabet
     relabels the displayed sector decomposition into a BNT presentation of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -400,3 +400,25 @@
     block-diagonal gauge---give a horizontal canonical form. Positivity and
     non-nilpotency are not needed for this conclusion.
 \end{proof}
+
+\begin{theorem}[Normalized simple canonical forms are simple]
+    \label{thm:mpdo_simple_cf_is_simple}
+    \lean{MPOTensor.IsSimpleCanonicalForm.isSimple}
+    \leanok
+    \uses{def:mpdo_simple_cf_tensor, def:mpdo_simple_tensor}
+    Every tensor satisfying normalized simplicity in the chosen blocked
+    canonical-form setting is simple in the sense of
+    Definition~\ref{def:mpdo_simple_tensor}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Take the blocking length to be one. The canonical bijection between the
+    one-site blocked ket--bra alphabet and the original doubled alphabet
+    relabels the displayed sector decomposition into a BNT presentation of the
+    blocked tensor. Normality and eventual linear independence are preserved
+    by this relabeling, and the global block gauge gives equality of all
+    positive-length closed matrix-product coefficients. Finally, reindexing
+    the diagonal physical-trace sum by the same bijection leaves each
+    representative's transfer matrix unchanged. The assumed non-nilpotency
+    certificates therefore prove simplicity.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -412,6 +412,9 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:global_gauge_of_blocks, thm:gauge_invariance,
+        thm:is_normal_tensor_of_is_normal_left_canonical,
+        thm:cpsv_physical_reindexing}
     Take the blocking length to be one. The canonical bijection between the
     one-site blocked ket--bra alphabet and the original doubled alphabet
     relabels the displayed sector decomposition into a BNT presentation of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -803,11 +803,11 @@
         def:mpdo_two_site_blocking,
         thm:mpdo_neighboring_trace_obstruction_ambient_properties}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three
-    which generates matrix product density operators and is simple and in
-    block-injective canonical form. Its two normal representatives occur once
-    with coefficients $\mu$ and $1$, where $0<|\mu|<1$, so the paper's global
-    normalization convention holds. The tensor saturates the area law and has
-    literal zero correlation length,
+    which generates matrix product density operators, is simple in the sense
+    of Definition~4.7, and is in biCF. Its two normal representatives occur
+    once with coefficients $\mu$ and $1$, where $0<|\mu|<1$, so the paper's
+    global normalization convention holds. The tensor saturates the area law
+    and has literal zero correlation length,
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -797,8 +797,9 @@
         printed_propositionC15_and_theorem49_ii_to_v_are_false}
     \leanok
     \discussion{7479}
-    \uses{def:mpdo_simple_cf_tensor, def:sector_bnt_cf, def:is_sal,
-        def:mpo_physical_trace_transfer, def:is_rfp_via_ts,
+    \uses{def:mpdo_simple_cf_tensor, def:mpdo_simple_tensor,
+        def:sector_bnt_cf, def:is_sal, def:mpo_physical_trace_transfer,
+        def:is_rfp_via_ts,
         def:mpdo_two_site_blocking,
         thm:mpdo_neighboring_trace_obstruction_ambient_properties}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -803,11 +803,11 @@
         def:mpdo_two_site_blocking,
         thm:mpdo_neighboring_trace_obstruction_ambient_properties}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three
-    which generates matrix product density operators, is simple in the sense
-    of Definition~4.7, and is in biCF. Its two normal representatives occur
-    once with coefficients $\mu$ and $1$, where $0<|\mu|<1$, so the paper's
-    global normalization convention holds. The tensor saturates the area law
-    and has literal zero correlation length,
+    which generates matrix product density operators, has normalized simple
+    canonical form, is simple in the sense of Definition~4.7, and is in biCF.
+    Its two normal representatives occur once with coefficients $\mu$ and $1$,
+    where $0<|\mu|<1$, so the paper's global normalization convention holds.
+    The tensor saturates the area law and has literal zero correlation length,
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2676,8 +2676,8 @@ This is the calculation in
     \lean{MPOTensor.NeighboringTraceObstructionAmbientCounterexample.%
         exists_ambient_simpleBiCF_neighboringTraceObstruction}
     \leanok
-    \uses{def:mpdo_simple_cf_tensor, def:sector_bnt_cf, def:is_sal,
-        def:mpo_physical_trace_transfer}
+    \uses{def:mpdo_simple_cf_tensor, def:mpdo_simple_tensor,
+        def:sector_bnt_cf, def:is_sal, def:mpo_physical_trace_transfer}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three
     with a two-representative horizontal canonical presentation. The
     representatives $A_0,A_1$ are normal and left-canonical, have bond
@@ -2712,6 +2712,7 @@ This is the calculation in
 
 \begin{proof}\leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_prepared_two_block_bnt,
+        thm:mpdo_simple_cf_is_simple,
         thm:mpdo_local_orthogonal_sum_sal,
         lem:mpdo_sal_phys_trace_transfer_nonzero,
         thm:mpdo_source_zcl_strict_positive_length_normalization}
@@ -2728,7 +2729,8 @@ This is the calculation in
     sectors to $K$. The physical-trace transfer is block diagonal. Its two
     diagonal blocks are idempotent, hence so is the ambient transfer. The
     exact weighted direct sum and nonnilpotency of both representatives give
-    the asserted simple canonical presentation. SAL makes the physical-trace
+    the asserted simple canonical presentation, which is simple by
+    Theorem~\ref{thm:mpdo_simple_cf_is_simple}. SAL makes the physical-trace
     transfer nonzero; together with literal idempotence this gives source zero
     correlation length, hence every nonempty periodic trace is nonzero. The
     MPDO positivity condition then upgrades each such trace to strict
@@ -2780,7 +2782,7 @@ This is the calculation in
     \leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_ambient_properties,
         thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization,
-        def:mpdo_physical_sector_factorization,
+        def:mpdo_simple_tensor, def:mpdo_physical_sector_factorization,
         def:mpdo_neighboring_trace_factorization}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three
     with two normal left-canonical representatives $A_0,A_1$ whose one-site
@@ -2789,9 +2791,9 @@ This is the calculation in
     obstruction is virtually gauge equivalent to $\mu A_0$. Each
     representative occurs once, with coefficients $\mu$ and $1$, where
     $0<|\mu|<1$; hence every coefficient has modulus at most one and the second
-    has modulus one. The tensor has simple canonical form, generates positive
-    semidefinite periodic operators with strictly positive trace at every
-    positive length, satisfies
+    has modulus one. The tensor has simple canonical form and is simple. It
+    generates positive semidefinite periodic operators with strictly positive
+    trace at every positive length, satisfies
     saturation of the area law, and obeys
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
@@ -2814,10 +2816,13 @@ This is the calculation in
 
 \begin{proof}\leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_ambient_properties,
-        thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization}
+        thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization,
+        thm:mpdo_simple_cf_is_simple}
     Choose the tensor and its two representatives from
     Theorem~\ref{thm:mpdo_neighboring_trace_obstruction_ambient_properties}.
-    The first representative satisfies the gauge relation required by
+    Its normalized simple canonical form gives literal simplicity by
+    Theorem~\ref{thm:mpdo_simple_cf_is_simple}. The first representative
+    satisfies the gauge relation required by
     Theorem~\ref{thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization},
     which excludes every normalized rank-one neighboring-trace factorization
     of its absorbed tensor. All remaining hypotheses are the properties listed

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2695,9 +2695,10 @@ This is the calculation in
     \end{align}
     Thus the presentation is in biCF. The tensor $K$ is the exact weighted
     direct sum $\mu A_0\oplus A_1$ with the identity global virtual gauge. It
-    is simple, generates positive semidefinite periodic operators with
-    strictly positive trace at every positive length, saturates the area law,
-    and has literal zero correlation length,
+    is simple in the sense of Definition~4.7. It generates positive
+    semidefinite periodic operators with strictly positive trace at every
+    positive length, saturates the area law, and has literal zero correlation
+    length,
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.
         \notag
@@ -2772,8 +2773,8 @@ This is the calculation in
 \end{proof}
 
 % **False source result:** Proposition C.12 is contradicted under the complete
-% simultaneous-one-letter-span, simple-canonical, MPDO, SAL, literal-ZCL, and
-% line-246 normalization hypotheses. Documented in
+% simultaneous-one-letter-span, simple, normalized-simple-canonical, MPDO,
+% SAL, literal-ZCL, and line-246 normalization hypotheses. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[The printed absorbed-representative structure assertion is false]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
@@ -2791,9 +2792,9 @@ This is the calculation in
     obstruction is virtually gauge equivalent to $\mu A_0$. Each
     representative occurs once, with coefficients $\mu$ and $1$, where
     $0<|\mu|<1$; hence every coefficient has modulus at most one and the second
-    has modulus one. The tensor has simple canonical form and is simple. It
-    generates positive semidefinite periodic operators with strictly positive
-    trace at every positive length, satisfies
+    has modulus one. The tensor is simple in the sense of Definition~4.7 and
+    is in biCF. It generates positive semidefinite periodic operators with
+    strictly positive trace at every positive length, satisfies
     saturation of the area law, and obeys
     \begin{align}
         \mathcal T_K^2 & =\mathcal T_K.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2817,13 +2817,10 @@ This is the calculation in
 
 \begin{proof}\leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_ambient_properties,
-        thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization,
-        thm:mpdo_simple_cf_is_simple}
+        thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization}
     Choose the tensor and its two representatives from
     Theorem~\ref{thm:mpdo_neighboring_trace_obstruction_ambient_properties}.
-    Its normalized simple canonical form gives literal simplicity by
-    Theorem~\ref{thm:mpdo_simple_cf_is_simple}. The first representative
-    satisfies the gauge relation required by
+    The first representative satisfies the gauge relation required by
     Theorem~\ref{thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization},
     which excludes every normalized rank-one neighboring-trace factorization
     of its absorbed tensor. All remaining hypotheses are the properties listed

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2668,6 +2668,27 @@ This is the calculation in
     representatives.
 \end{proof}
 
+\begin{lemma}[The ambient neighboring-trace obstruction is simple]
+    \label{lem:mpdo_neighboring_trace_obstruction_ambient_simple}
+    \lean{MPOTensor.NeighboringTraceObstructionAmbientCounterexample.%
+        ambient_isSimple}
+    \leanok
+    \uses{def:mpdo_simple_tensor, def:sector_bnt_cf}
+    Let $\mu\ne0$ and let $B$ be a five-letter tensor such that the embedded
+    obstruction is virtually gauge equivalent to $\mu B$. If the associated
+    obstruction--terminal sector decomposition is in normalized BNT canonical
+    form, then its ambient weighted direct sum is simple in the sense of
+    Definition~4.7.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_simple_cf_is_simple}
+    The displayed block-diagonal gauge and the nonnilpotent physical-trace
+    transfers of the two representatives give a normalized simple canonical
+    form. Theorem~\ref{thm:mpdo_simple_cf_is_simple} then gives simplicity in
+    the sense of Definition~4.7.
+\end{proof}
+
 % The displayed conjunction matches the hypotheses used in CPSV16
 % Appendix C.2, lines 1628--1782. The simultaneous one-letter span and the
 % local orthogonal-sum entropy calculation are proved directly in TNLean.
@@ -2695,7 +2716,8 @@ This is the calculation in
     \end{align}
     Thus the presentation is in biCF. The tensor $K$ is the exact weighted
     direct sum $\mu A_0\oplus A_1$ with the identity global virtual gauge. It
-    is simple in the sense of Definition~4.7. It generates positive
+    has normalized simple canonical form and is simple in the sense of
+    Definition~4.7. It generates positive
     semidefinite periodic operators with strictly positive trace at every
     positive length, saturates the area law, and has literal zero correlation
     length,
@@ -2713,7 +2735,7 @@ This is the calculation in
 
 \begin{proof}\leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_prepared_two_block_bnt,
-        thm:mpdo_simple_cf_is_simple,
+        lem:mpdo_neighboring_trace_obstruction_ambient_simple,
         thm:mpdo_local_orthogonal_sum_sal,
         lem:mpdo_sal_phys_trace_transfer_nonzero,
         thm:mpdo_source_zcl_strict_positive_length_normalization}
@@ -2730,8 +2752,9 @@ This is the calculation in
     sectors to $K$. The physical-trace transfer is block diagonal. Its two
     diagonal blocks are idempotent, hence so is the ambient transfer. The
     exact weighted direct sum and nonnilpotency of both representatives give
-    the asserted simple canonical presentation, which is simple by
-    Theorem~\ref{thm:mpdo_simple_cf_is_simple}. SAL makes the physical-trace
+    the asserted normalized simple canonical presentation.
+    Lemma~\ref{lem:mpdo_neighboring_trace_obstruction_ambient_simple} gives
+    simplicity in the sense of Definition~4.7. SAL makes the physical-trace
     transfer nonzero; together with literal idempotence this gives source zero
     correlation length, hence every nonempty periodic trace is nonzero. The
     MPDO positivity condition then upgrades each such trace to strict
@@ -2783,7 +2806,8 @@ This is the calculation in
     \leanok
     \uses{thm:mpdo_neighboring_trace_obstruction_ambient_properties,
         thm:mpdo_neighboring_trace_obstruction_absorbed_no_factorization,
-        def:mpdo_simple_tensor, def:mpdo_physical_sector_factorization,
+        def:mpdo_simple_cf_tensor, def:mpdo_simple_tensor,
+        def:mpdo_physical_sector_factorization,
         def:mpdo_neighboring_trace_factorization}
     There is a five-letter MPO tensor $K$ of virtual bond dimension three
     with two normal left-canonical representatives $A_0,A_1$ whose one-site
@@ -2792,8 +2816,9 @@ This is the calculation in
     obstruction is virtually gauge equivalent to $\mu A_0$. Each
     representative occurs once, with coefficients $\mu$ and $1$, where
     $0<|\mu|<1$; hence every coefficient has modulus at most one and the second
-    has modulus one. The tensor is simple in the sense of Definition~4.7 and
-    is in biCF. It generates positive semidefinite periodic operators with
+    has modulus one. The tensor has normalized simple canonical form, is
+    simple in the sense of Definition~4.7, and is in biCF. It generates
+    positive semidefinite periodic operators with
     strictly positive trace at every positive length, satisfies
     saturation of the area law, and obeys
     \begin{align}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -510,10 +510,12 @@ model different levels of data and different sources.
   `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
 - `MPOTensor.IsSimpleCanonicalForm` in `TNLean/MPS/MPDO/SimpleTensor.lean` is
   the normalized fixed-representative predicate of Appendix C.2: it adds the
-  MPDO and nonnilpotent-sector conditions to horizontal canonical form, and its
-  sanctioned one-way bridge is
-  `MPOTensor.IsSimpleCanonicalForm.isHorizontalCF`. It is not a quotient by
-  nonzero scalar rescaling; see
+  MPDO and nonnilpotent-sector conditions to horizontal canonical form. Its
+  sanctioned one-way bridges are
+  `MPOTensor.IsSimpleCanonicalForm.isHorizontalCF` and
+  `MPOTensor.IsSimpleCanonicalForm.isSimple`; the latter forgets the line-246
+  normalization and supplies the one-site BNT presentation required by
+  Definition 4.7. It is not a quotient by nonzero scalar rescaling; see
   `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
 - `MPOTensor.IsSimple` in `TNLean/MPS/MPDO/Simple.lean` is the sole
   simplicity predicate: Definition 4.7 of arXiv:1606.00608 at lines 815--822


### PR DESCRIPTION
## What changed

- prove `MPOTensor.IsSimpleCanonicalForm.isSimple` with the permitted one-site blocking and the canonical ket--bra relabeling
- record the construction property `ambient_isSimple` and include literal `IsSimple K` in the shared ambient supplier and both printed counterexample capstones
- reuse `MPSTensor.SectorDecomposition.reindexPhysical` rather than duplicating that construction
- correct the two obsolete Proposition C.15 status docstrings in `BNTFactorizationChannels`
- register the BNT physical-reindexing construction used by the proof and synchronize the Blueprint nodes and glossary with the source-facing simplicity certificate

## Statement-integrity audit

- **Paper assumptions vs. Lean assumptions.** CPSV16 Appendix C.2 assumes that the displayed tensor generates MPDOs, is simple in Definition 4.7, is in biCF, satisfies SAL and literal ZCL, and obeys the canonical normalization convention. The Lean counterexample now proves `IsSimple K` as a property of its constructed witness. The virtual gauge and BNT presentation are proved construction data inside the existential supplier, not added assumptions. `IsSimpleCanonicalForm K` remains only as an additional proved normalized-canonical-form property.
- **Paper conclusion vs. Lean conclusion.** Proposition C.15 asserts two trace-preserving completely positive maps, including a two-to-three-site refinement map. The linked Lean capstone proves that no such two-to-three-site map exists for the witness, universally over virtual boundaries; this suffices to refute the printed proposition. The two-to-four-site obstruction and failure of `IsRFPViaTS (blockTwo K)` remain separate consequences and are not identified with Proposition C.15.
- **Relevant definitions.** `MPOTensor.IsSimple` formalizes CPSV16 Definition 4.7 (lines 815--822). `MPOTensor.IsSimpleCanonicalForm` additionally fixes a normalized representative carrying the line-246 unit-weight convention. `IsSAL`, literal physical-trace idempotence, `IsKrausCPTP`, and `IsRFPViaTS` retain their existing meanings.
- **Proof status.** The canonical-form implication uses blocking length one, transports the BNT presentation through the existing physical-reindexing construction, and proves invariance of the diagonal physical-trace contraction. The witness lemma and all three capstones are kernel checked. No `sorry`, axiom declaration, `native_decide`, or unsafe cast is introduced.
- **Faithfulness verdict.** Faithful false-source certification. This pull request supplies the missing source-facing witness property after #7526 refuted Proposition C.15 as printed; it does not prove Proposition C.15 and does not assume a supplied factorization or selected representative.
- **Tracking.** Resolves the remaining concrete tasks in #7479 under MPO/RFP tracker #7338: literal simplicity in the shared supplier and both capstones, obsolete conditional-helper docstrings, Blueprint dependency/linkage, and glossary guidance.

## Validation

- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.Simple TNLean.MPS.MPDO.BNTFactorizationChannels TNLean.MPS.MPDO.NeighboringTraceObstructionAmbientCounterexample TNLean.MPS.MPDO.CPSVBlockingChannelAmbientCounterexample` (green, 9345/9345 jobs)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` (green; 37 generated files, 1057 production modules)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main` (green)
- changed-file `sorry` / `axiom` / `native_decide` / `unsafeCast` scan (green)
- `#print axioms` for the canonical-form implication, ambient witness property, shared supplier, and both capstones (green; only `propext`, `Classical.choice`, and `Quot.sound`)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` and `python3 scripts/blueprint_lean_sync.py --root . --ci` (green; 7,164/7,164 entries)
- `lake exe checkdecls blueprint/lean_decls` (green in the hosted exact-head build job)
- hosted exact-head [PR CI run 33361888401](https://github.com/LionSR/TNLean/actions/runs/33361888401) (green: full Lean build, changed-file timing guard, module policies, and Blueprint validation)
- pinned `leanblueprint web` with tenkz `2210cfd15c166c8410e80420a9f7c7478010f997` (green; plasTeX 3.1)
- `git diff --check origin/main...HEAD` (green)

Closes #7479
