### PR TITLE
feat(PEPS): expose open-boundary blocking obstruction

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingMargins.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingMargins.lean
@@ -14,8 +14,11 @@ present open rectangular square-lattice model.
 
 The boundary nonexistence statements below concern this open-rectangle model.
 They do not contradict the every-edge blocking sentence in arXiv:1804.04964.
-The comparison with the paper, the boundary obstruction, and the remaining
-finite-geometry obligations are recorded in
+The final section also gives an abstract region-injectivity countermodel: the
+source rectangular hypotheses and union closure alone do not imply a
+red/blue/complement blocking at a boundary edge. Thus an open-boundary
+extension requires additional tensor-level or boundary injectivity input.
+The comparison with the paper and the boundary obstruction are recorded in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
 mathematical obligations".
 
@@ -439,6 +442,110 @@ theorem not_forall_normalSquareEdgeMarginCover_seven :
   exact not_leftBoundaryRightEdge_marginCover_seven
     ⟨data (squareLatticeRightEdge (width := 7) (height := 7) 0 2
       (by decide) (by decide))⟩
+
+/-! ### Rectangular injectivity does not force an open-boundary blocking -/
+
+/-- An abstract region-injectivity predicate used to test the left boundary
+edge of the open \(7\times7\) rectangle.
+
+A region is declared injective only if containing the left endpoint of the
+chosen boundary edge forces it to contain the right endpoint. This predicate
+is not asserted to arise from a PEPS tensor. It is a countermodel internal to
+the abstract `RegionInjectivityData` interface.
+
+Source comparison: arXiv:1804.04964, Theorem `normal`, lines 1574--1585,
+assumes an injective three-part blocking around every edge; it does not derive
+that hypothesis from rectangular injectivity on an open rectangle. -/
+def leftBoundaryRightEdgeInjectivityCountermodelSeven :
+    RegionInjectivityData (SquareLatticeVertex 7 7) where
+  IsInjective R :=
+    (squareLatticeRightEdge (width := 7) (height := 7) 0 2
+      (by decide) (by decide)).1.1 ∈ R →
+      (squareLatticeRightEdge (width := 7) (height := 7) 0 2
+        (by decide) (by decide)).1.2 ∈ R
+
+/-- The boundary-edge countermodel is closed under unions of injective
+regions, as required by the union lemma of the source.
+
+Source comparison: arXiv:1804.04964, Lemma `injective_union`, lines
+1322--1404. -/
+theorem leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure :
+    RegionInjectivityUnionClosure leftBoundaryRightEdgeInjectivityCountermodelSeven := by
+  constructor
+  intro A B hA hB hLeft
+  rw [Finset.mem_union] at hLeft ⊢
+  exact hLeft.elim (fun h => Or.inl (hA h)) (fun h => Or.inr (hB h))
+
+/-- Every contiguous \(2\times3\) and \(3\times2\) rectangle in the open
+\(7\times7\) lattice is injective for the boundary-edge countermodel.
+
+Indeed, any such rectangle containing the left endpoint at horizontal
+coordinate zero also contains its right neighbor.
+
+Source comparison: arXiv:1804.04964, Theorem 3, lines 1407--1452. -/
+theorem leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular :
+    NormalSquareLatticeRectangleInjectivityHypotheses
+      leftBoundaryRightEdgeInjectivityCountermodelSeven := by
+  constructor
+  · intro R hR
+    obtain ⟨xStart, yStart, _hx, _hy, rfl⟩ := hR
+    intro hLeft
+    rw [mem_squareLatticeContiguousRectangle] at hLeft ⊢
+    simp only [squareLatticeRightEdge] at hLeft ⊢
+    omega
+  · intro R hR
+    obtain ⟨xStart, yStart, _hx, _hy, rfl⟩ := hR
+    intro hLeft
+    rw [mem_squareLatticeContiguousRectangle] at hLeft ⊢
+    simp only [squareLatticeRightEdge] at hLeft ⊢
+    omega
+
+/-- The countermodel admits no red/blue/complement blocking datum at the
+chosen left-boundary edge.
+
+The red block contains the left endpoint. Its countermodel injectivity then
+places the right endpoint in the red block, contradicting its required
+membership in the disjoint blue block.
+
+This is an obstruction only to deriving the open-boundary blocking from the
+abstract rectangular-injectivity and union-closure hypotheses. It does not
+concern the periodic translationally invariant statement of arXiv:1804.04964,
+Theorem 3.
+
+Source comparison: arXiv:1804.04964, Theorem `normal`, lines 1574--1585. -/
+theorem not_leftBoundaryRightEdge_blockingData_countermodelSeven :
+    ¬ Nonempty
+      (NormalEdgeBlockingData leftBoundaryRightEdgeInjectivityCountermodelSeven
+        (squareLatticeGraph 7 7)
+        (squareLatticeRightEdge (width := 7) (height := 7) 0 2
+          (by decide) (by decide))) := by
+  rintro ⟨d⟩
+  have hRightRed := d.red_injective d.left_mem_red
+  exact Finset.disjoint_left.mp d.red_disjoint_blue hRightRed d.right_mem_blue
+
+/-- Rectangular injectivity and union closure alone do not imply an
+open-boundary blocking datum in the abstract region-injectivity interface.
+
+The witness is the left-boundary countermodel on the open \(7\times7\)
+rectangle. Thus a theorem constructing boundary-near
+`NormalEdgeBlockingData` requires additional tensor-level or boundary
+injectivity input; it cannot follow from the two abstract hypotheses used by
+the interior tiling argument alone.
+
+Source comparison: arXiv:1804.04964, Theorem `normal`, lines 1574--1585,
+takes the every-edge injective blocking as a hypothesis. -/
+theorem exists_rectangularInjectivity_not_boundaryBlockingData :
+    ∃ κ : RegionInjectivityData (SquareLatticeVertex 7 7),
+      NormalSquareLatticeRectangleInjectivityHypotheses κ ∧
+        RegionInjectivityUnionClosure κ ∧
+          ¬ Nonempty
+            (NormalEdgeBlockingData κ (squareLatticeGraph 7 7)
+              (squareLatticeRightEdge (width := 7) (height := 7) 0 2
+                (by decide) (by decide))) :=
+  ⟨leftBoundaryRightEdgeInjectivityCountermodelSeven,
+    leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular,
+    leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure,
+    not_leftBoundaryRightEdge_blockingData_countermodelSeven⟩
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
@@ -398,6 +398,57 @@
     \end{tenkzequation}
 \end{definition}
 
+\begin{definition}[Left-boundary injectivity countermodel]%
+    \label{def:peps_leftBoundaryRightEdgeInjectivityCountermodel}
+    \lean{TNLean.PEPS.leftBoundaryRightEdgeInjectivityCountermodelSeven}
+    \lean{TNLean.PEPS.%
+        leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure}
+    \lean{TNLean.PEPS.%
+        leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular}
+    \leanok
+    \uses{def:peps_regionInjectivityData,
+        def:peps_normalRectangleInjectivityHypotheses}
+    In the open $7\times7$ rectangle, let $u=(0,2)$ and $v=(1,2)$ be
+    the endpoints of a left-boundary horizontal edge. Define a region
+    relation by
+    \[
+        \inj_{\partial}(R)\quad\Longleftrightarrow\quad
+        u\in R\Longrightarrow v\in R.
+    \]
+    This relation is closed under unions. It also holds for every contiguous
+    $2\times3$ and $3\times2$ rectangle: a rectangle of either shape that
+    contains $u$ necessarily contains its right neighbor $v$.
+\end{definition}
+
+\begin{lemma}[Rectangular injectivity does not force an open-boundary
+        blocking]%
+    \label{lem:peps_rectangularInjectivity_not_boundaryBlockingData}
+    \lean{TNLean.PEPS.not_leftBoundaryRightEdge_blockingData_countermodelSeven}
+    \lean{TNLean.PEPS.exists_rectangularInjectivity_not_boundaryBlockingData}
+    \leanok
+    \uses{def:peps_leftBoundaryRightEdgeInjectivityCountermodel,
+        def:peps_normalEdgeBlockingHypotheses}
+    There is a union-closed region relation on the open $7\times7$ rectangle
+    that satisfies all contiguous $2\times3$ and $3\times2$ rectangle
+    conditions, but admits no three-partite injective MPS blocking around the
+    edge $u$--$v$. Indeed, the red region must contain $u$, so its injectivity
+    places $v$ in the red region, while the blocking requires $v$ to lie in
+    the disjoint blue region.
+
+    This counterexample for abstract region relations shows only that the
+    rectangular and union hypotheses do not entail a boundary blocking on an
+    open rectangle. It neither gives a PEPS tensor nor concerns the periodic
+    translationally invariant statement of~\cite[Theorem~3]{Molnar2018NormalPEPS}.
+    The later general theorem in the source takes the every-edge three-partite
+    injective MPS blocking as a hypothesis.
+\end{lemma}
+\begin{proof}\leanok
+    Use the relation $\inj_{\partial}$ above. Union closure and the two
+    rectangle conditions follow directly from the horizontal coordinates.
+    Disjointness of the red and blue regions contradicts their forced common
+    vertex $v$.
+\end{proof}
+
 \begin{theorem}[Injectivity supplied by normal edge blocking]%
     \label{thm:peps_normalEdgeBlockingHypotheses_injectiveChain}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.injective_chain}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
@@ -401,13 +401,8 @@
 \begin{definition}[Left-boundary injectivity countermodel]%
     \label{def:peps_leftBoundaryRightEdgeInjectivityCountermodel}
     \lean{TNLean.PEPS.leftBoundaryRightEdgeInjectivityCountermodelSeven}
-    \lean{TNLean.PEPS.%
-        leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure}
-    \lean{TNLean.PEPS.%
-        leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular}
     \leanok
-    \uses{def:peps_regionInjectivityData,
-        def:peps_normalRectangleInjectivityHypotheses}
+    \uses{def:peps_regionInjectivityData}
     In the open $7\times7$ rectangle, let $u=(0,2)$ and $v=(1,2)$ be
     the endpoints of a left-boundary horizontal edge. Define a region
     relation by
@@ -415,25 +410,65 @@
         \inj_{\partial}(R)\quad\Longleftrightarrow\quad
         u\in R\Longrightarrow v\in R.
     \]
-    This relation is closed under unions. It also holds for every contiguous
-    $2\times3$ and $3\times2$ rectangle: a rectangle of either shape that
-    contains $u$ necessarily contains its right neighbor $v$.
 \end{definition}
 
-\begin{lemma}[Rectangular injectivity does not force an open-boundary
-        blocking]%
-    \label{lem:peps_rectangularInjectivity_not_boundaryBlockingData}
+\begin{theorem}[Union closure of the boundary countermodel]%
+    \label{thm:peps_leftBoundaryRightEdgeInjectivityCountermodel_unionClosure}
+    \lean{TNLean.PEPS.%
+        leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure}
+    \leanok
+    \uses{def:peps_leftBoundaryRightEdgeInjectivityCountermodel}
+    The relation $\inj_{\partial}$ is closed under unions.
+\end{theorem}
+\begin{proof}\leanok
+    If $u\in A\cup B$, then $u$ belongs to one of the two regions. The
+    defining implication for that region places $v$ in the same region, hence
+    in $A\cup B$.
+\end{proof}
+
+\begin{theorem}[Rectangular conditions for the boundary countermodel]%
+    \label{thm:peps_leftBoundaryRightEdgeInjectivityCountermodel_rectangular}
+    \lean{TNLean.PEPS.%
+        leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular}
+    \leanok
+    \uses{def:peps_leftBoundaryRightEdgeInjectivityCountermodel,
+        def:peps_normalRectangleInjectivityHypotheses}
+    Every contiguous $2\times3$ and $3\times2$ rectangle satisfies
+    $\inj_{\partial}$. Indeed, a rectangle of either shape that contains $u$
+    necessarily contains its right neighbor $v$.
+\end{theorem}
+\begin{proof}\leanok
+    This follows directly from the horizontal coordinates of the two
+    endpoints.
+\end{proof}
+
+\begin{theorem}[No boundary blocking for the countermodel]%
+    \label{thm:peps_leftBoundaryRightEdge_not_boundaryBlockingData}
     \lean{TNLean.PEPS.not_leftBoundaryRightEdge_blockingData_countermodelSeven}
-    \lean{TNLean.PEPS.exists_rectangularInjectivity_not_boundaryBlockingData}
     \leanok
     \uses{def:peps_leftBoundaryRightEdgeInjectivityCountermodel,
         def:peps_normalEdgeBlockingHypotheses}
+    The relation $\inj_{\partial}$ admits no three-partite injective MPS
+    blocking around the edge $u$--$v$.
+\end{theorem}
+\begin{proof}\leanok
+    The red region must contain $u$, so its injectivity places $v$ in the red
+    region. The blocking requires $v$ to lie in the disjoint blue region,
+    which is impossible.
+\end{proof}
+
+\begin{theorem}[Rectangular injectivity does not force an open-boundary
+        blocking]%
+    \label{thm:peps_rectangularInjectivity_not_boundaryBlockingData}
+    \lean{TNLean.PEPS.exists_rectangularInjectivity_not_boundaryBlockingData}
+    \leanok
+    \uses{thm:peps_leftBoundaryRightEdgeInjectivityCountermodel_unionClosure,
+        thm:peps_leftBoundaryRightEdgeInjectivityCountermodel_rectangular,
+        thm:peps_leftBoundaryRightEdge_not_boundaryBlockingData}
     There is a union-closed region relation on the open $7\times7$ rectangle
     that satisfies all contiguous $2\times3$ and $3\times2$ rectangle
     conditions, but admits no three-partite injective MPS blocking around the
-    edge $u$--$v$. Indeed, the red region must contain $u$, so its injectivity
-    places $v$ in the red region, while the blocking requires $v$ to lie in
-    the disjoint blue region.
+    edge $u$--$v$.
 
     This counterexample for abstract region relations shows only that the
     rectangular and union hypotheses do not entail a boundary blocking on an
@@ -441,12 +476,9 @@
     translationally invariant statement of~\cite[Theorem~3]{Molnar2018NormalPEPS}.
     The later general theorem in the source takes the every-edge three-partite
     injective MPS blocking as a hypothesis.
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
-    Use the relation $\inj_{\partial}$ above. Union closure and the two
-    rectangle conditions follow directly from the horizontal coordinates.
-    Disjointness of the red and blue regions contradicts their forced common
-    vertex $v$.
+    Use the relation $\inj_{\partial}$ and the three preceding theorems.
 \end{proof}
 
 \begin{theorem}[Injectivity supplied by normal edge blocking]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -319,6 +319,34 @@ rectangles. It is not an omitted case of Theorem~\path{3}: the source uses the
 periodic translation action, and the corresponding every-edge construction is
 the torus construction described below.
 
+The abstract region-injectivity hypotheses also show why the open-boundary
+extension cannot be obtained from rectangular injectivity and union closure
+alone. On the open $7\times7$ rectangle, fix the left-boundary horizontal edge
+$u=(0,2)$, $v=(1,2)$ and define
+\[
+    \operatorname{inj}_{\partial}(R)
+    \quad\Longleftrightarrow\quad
+    u\in R\Longrightarrow v\in R.
+\]
+This relation is closed under unions, and every contiguous $2\times3$ and
+$3\times2$ rectangle satisfies it: any such rectangle containing $u$ also
+contains $v$. A red/blue/complement blocking around $u$--$v$ is nevertheless
+impossible, because injectivity of the red region and $u\in R_{\mathrm{red}}$
+force $v\in R_{\mathrm{red}}$, while the blocking requires
+$v\in R_{\mathrm{blue}}$ and disjointness of the red and blue regions.
+Thus the abstract hypotheses used by the interior tiling do not imply
+open-boundary blocking data; any such extension needs additional tensor-level
+or boundary injectivity input. This countermodel of the abstract region
+relation is not claimed to arise from a PEPS tensor and does not concern the
+periodic Theorem~\path{3}.
+\footnote{Formal declarations:
+    \leanid{TNLean.PEPS.leftBoundaryRightEdgeInjectivityCountermodelSeven},
+    \leanid{TNLean.PEPS.leftBoundaryRightEdgeInjectivityCountermodelSeven_unionClosure},
+    \leanid{TNLean.PEPS.leftBoundaryRightEdgeInjectivityCountermodelSeven_rectangular},
+    \leanid{TNLean.PEPS.not_leftBoundaryRightEdge_blockingData_countermodelSeven},
+    and
+    \leanid{TNLean.PEPS.exists_rectangularInjectivity_not_boundaryBlockingData}.}
+
 Verdict: this note records an open gap with a scope restriction. The earlier
 vocabulary gap for contiguous rectangular blocks is closed. The earlier
 coordinate rectangular-injectivity structure is also present, and the
@@ -340,15 +368,19 @@ whose corner is forced. The every-edge blocking construction is cover-free at
 interior edges and assembles the normal edge-blocking hypotheses there. The
 tensor-level union theorem is proved for positive bond dimensions, including the
 overlapping case (the overlap re-insertion). Edges near the boundary of the open
-rectangular model still lie outside this construction, but this is the scope of
-a possible open-boundary strengthening rather than a gap in the cited theorem.
+rectangular model still lie outside this construction. The countermodel above
+shows that rectangular injectivity and union closure do not supply the missing
+blocking under the abstract region-injectivity assumptions, so a possible
+open-boundary strengthening requires additional hypotheses. This is not a gap
+in the cited theorem.
 For the periodic translationally invariant lattice, every edge is obtained from
 a reference edge by translation and the construction is complete. Injectivity
 of $R$ and $S$ is already derived from union closure and rectangular injectivity.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
-\ghissue{1252}.
+\ghissue{1252}. The separate open-rectangle boundary extension and its
+abstract obstruction are tracked by \ghissue{7531}.
 
 \section{Remaining mathematical obligations}
 


### PR DESCRIPTION
## Motivation

Issue #7531 asks whether the rectangular-injectivity hypotheses used in arXiv:1804.04964, Theorem 3, together with union closure, can supply the three-partite injective MPS blocking required near the boundary of the finite open rectangle.

The general theorem `thm:normal` (`Papers/1804.04964/paper_normal.tex:1574-1585`) takes an every-edge three-partite injective MPS blocking as a hypothesis. It does not derive that hypothesis from rectangular injectivity.

## What changed

- defines an abstract region-injectivity relation on the open \(7\times7\) rectangle by
  \[
  \operatorname{inj}_{\partial}(R) \iff (u\in R \Rightarrow v\in R),
  \]
  for the left-boundary internal edge \(u=(0,2)\), \(v=(1,2)\)
- proves that this relation is closed under unions and holds for every contiguous \(2\times3\) and \(3\times2\) rectangle
- proves that it admits no red/blue/complement `NormalEdgeBlockingData` at \(u\)--\(v\): red injectivity forces \(v\) into red, while the blocking requires \(v\) in the disjoint blue region
- records the obstruction in the Blueprint and in `docs/paper-gaps/peps_normal_ft_section3_route.tex`
- gives each source-facing Lean declaration its own Blueprint environment: the countermodel, union closure, rectangle theorem, impossibility theorem, and existential capstone are distinct entries

## Mathematical scope

This is a countermodel to an implication in the abstract `RegionInjectivityData` interface. It is **not** asserted to arise from a PEPS tensor, and it is not a counterexample to the periodic translationally invariant Theorem 3. It shows that an open-rectangle extension needs additional tensor-level or boundary-injectivity input; rectangular injectivity and abstract union closure alone are insufficient.

The terminology and logical direction follow the source: “three partite injective MPS around every edge” is a hypothesis of `thm:normal`, not an output of the rectangular argument.

## Validation

- `lake build TNLean.PEPS.NormalEdgeBlockingMargins`: 1144/1144 green at `d813a55b`, whose Lean sources are identical to exact head `57dfcf239`
- exact-head Blueprint/Lean synchronization: 7144/7144
- generated import aggregators current: 37 files, 1056 production modules
- reader-facing prose, forbidden-token, ChkTeX, pinned `latexindent`, tactic-pattern, Blueprint scanner, and `git diff --check` checks green
- exact-head hosted Lean and Blueprint checks are running

Closes #7531