### PR TITLE
doc(PEPS): delimit the boundary fixed-point specification

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_peps_boundary.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_peps_boundary.tex
@@ -106,9 +106,17 @@ makes sense with separate horizontal and vertical dimensions.
     right boundary operator invariant under the corresponding transfer action.
     The transfer-operator diagram at source lines~709--712 of
     \cite{Cirac2016MPDO_arXiv} depicts the operator from which the fixed point is
-    selected; it does not depict the fixed point itself. An algebraic definition
-    must specify the transfer space, orientation, and the choice of left and
-    right fixed points.
+    selected; it does not depict the fixed point itself. On a finite cylinder,
+    \cite[Section~II.2, Equations~(10)--(13)]{Cirac2011Entanglement} defines the
+    positive boundary operators $\sigma_L,\sigma_R$ and the support isometry
+    $U$, with
+    $\rho_\ell=U\sqrt{\sigma_L^T}\sigma_R\sqrt{\sigma_L^T}U^\dagger$.
+    For a long cylinder, \cite[Equation~(1) and the following paragraph]
+    {Schuch2013Topological} identifies $\sigma_L,\sigma_R$ with eigenvectors for
+    the largest eigenvalue of the transfer operator and notes that topological
+    degeneracy can make the fixed point non-unique. These constructions specify
+    the boundary operators in their respective cylinder settings, but not their
+    algebraic passage to the local boundary tensor and channels below.
 \end{definition}
 
 \begin{definition}[Algebraic PEPS renormalization fixed-point relation]
@@ -171,9 +179,11 @@ makes sense with separate horizontal and vertical dimensions.
         def:peps_boundary_coarse_graining, def:peps_boundary_refinement,
         def:is_rfp_via_ts}
     The source diagrams do not specify the domain and codomain of the physical
-    isometry, the virtual-space identifications, the choice and normalization of
-    the transfer fixed points, or the inserted factor in the refinement map.
-    Consequently, complete positivity, trace preservation, and the identities
+    isometry, the virtual-space identifications, the passage from the
+    finite-cylinder operators $\sigma_L,\sigma_R$ to the displayed local tensor,
+    a fixed-point selection in the degenerate case, or the inserted factor in
+    the refinement map. Consequently, complete positivity, trace preservation,
+    and the identities
     $\mathcal S[M_2(X)]=M_1(X)$ and
     $\mathcal T[M_1(X)]=M_2(X)$ cannot yet be checked algebraically. This
     missing specification is recorded in

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -264,6 +264,32 @@
   note         = {Preprint; published version: Ann.\ Phys.\ \textbf{378} (2017) 100--149},
 }
 
+@article{Cirac2011Entanglement,
+  author       = {Cirac, J. I. and Poilblanc, D. and Schuch, N. and Verstraete, F.},
+  title        = {Entanglement Spectrum and Boundary Theories with Projected Entangled-Pair States},
+  journal      = {Phys. Rev. B},
+  volume       = {83},
+  number       = {24},
+  pages        = {245134},
+  year         = {2011},
+  doi          = {10.1103/PhysRevB.83.245134},
+  eprint       = {1103.3427},
+  eprinttype   = {arxiv},
+}
+
+@article{Schuch2013Topological,
+  author       = {Schuch, N. and Poilblanc, D. and Cirac, J. I. and P{\'e}rez-Garc{\'i}a, D.},
+  title        = {Topological Order in {PEPS}: Transfer Operator and Boundary Hamiltonians},
+  journal      = {Phys. Rev. Lett.},
+  volume       = {111},
+  number       = {9},
+  pages        = {090501},
+  year         = {2013},
+  doi          = {10.1103/PhysRevLett.111.090501},
+  eprint       = {1210.5601},
+  eprinttype   = {arxiv},
+}
+
 @unpublished{Kato2024Exact,
   author       = {Kato, Kohtaro},
   title        = {Exact Renormalization Group Flow for Matrix Product Density Operators},

--- a/docs/paper-gaps/cpsv16_peps_boundary_rfp_specification.tex
+++ b/docs/paper-gaps/cpsv16_peps_boundary_rfp_specification.tex
@@ -10,7 +10,7 @@
 
 \title{The Missing Algebraic Specification of the PEPS Boundary-RFP Diagrams}
 \author{}
-\date{2026-08-30}
+\date{2026-08-31}
 
 \begin{document}
 \maketitle
@@ -44,6 +44,48 @@ and $\mathcal T$, in the reverse direction, such that
 for every virtual operator $X$. The existence and channel properties of these
 maps are conclusions of the PEPS renormalization relation, not additional
 hypotheses.
+
+\section{Boundary data supplied by the cited constructions}
+
+The boundary construction cited by the source is algebraic at the level of a
+finite cylinder. For a cylinder of circumference $N_{\mathrm v}$ and bond
+dimension $D$, the virtual boundary space has dimension $D^{N_{\mathrm v}}$.
+After blocking the left and right parts of the cylinder,
+Ref.~\cite[Equation~(10)]
+{Cirac2011Entanglement} defines the positive operators
+\begin{align}
+    \sigma_L
+      &= \sum_{I_a}|\widehat L^{I_a})(\widehat L^{I_a}|,
+    &
+    \sigma_R
+      &= \sum_{I_b}|\widehat R^{I_b})(\widehat R^{I_b}|.
+    \label{eq:cpsv16_peps_boundary_rfp_specification_sigma_lr}
+\end{align}
+Equations~(11)--(13) of the same reference choose an orthonormal basis of the
+range of $\sigma_L$, define the corresponding support isometry $U$, and obtain
+\begin{align}
+    \rho_\ell
+      &= U\sqrt{\sigma_L^T}\,\sigma_R\sqrt{\sigma_L^T}\,U^\dagger.
+    \label{eq:cpsv16_peps_boundary_rfp_specification_boundary_density}
+\end{align}
+Thus these equations specify the finite-cylinder transfer space, its two
+positive boundary operators, and their relation to the reduced density
+operator.
+
+For a long cylinder, Ref.~\cite[Equation~(1) and the following paragraph]
+{Schuch2013Topological} writes the boundary state as
+\begin{align}
+    \sigma
+      &\mathrel{\propto}
+      \sqrt{\sigma_L^*}\,\sigma_R\sqrt{\sigma_L^*},
+    \label{eq:cpsv16_peps_boundary_rfp_specification_long_cylinder}
+\end{align}
+and identifies $\sigma_L$ and $\sigma_R$ with eigenvectors of the transfer
+operator for its largest eigenvalue. The same passage emphasizes that symmetry
+and topological order can make this fixed point non-unique. These results
+specify the transfer operators and boundary density operators. They do not
+define the PEPS blocking isometry in Figure~\cpsvref{PEPS-RFP} or the two maps
+in the final renormalization diagram.
 
 \section{The local boundary tensor}
 
@@ -86,9 +128,13 @@ at every nonzero length, again without a fixed-point or channel hypothesis.
 The source passage does not give an algebraic form of the PEPS blocking
 relation. In particular, it does not specify the domain and codomain of the
 physical isometry or the identifications between the external virtual spaces
-before and after blocking. It also does not specify the spaces, orientation,
-choice, or normalization of the left and right transfer fixed points used to
-form the boundary state.
+before and after blocking. The cited boundary constructions do specify
+Eqs.~\eqref{eq:cpsv16_peps_boundary_rfp_specification_sigma_lr}--
+\eqref{eq:cpsv16_peps_boundary_rfp_specification_long_cylinder}, but they do
+not select a normalized pair independently of cylinder boundary conditions
+when the leading transfer eigenspace is degenerate. Nor do they identify such
+a selection algebraically with the local tensor $E_A$ in
+Eq.~\eqref{eq:cpsv16_peps_boundary_rfp_specification_local_tensor}.
 
 The refinement part of the final diagram inserts an unlabelled local factor.
 Its space and normalization are not stated. The coarse-graining and refinement
@@ -108,11 +154,15 @@ would not formalize the implication asserted by the paper.
 
 The source-faithful local contraction
 \eqref{eq:cpsv16_peps_boundary_rfp_specification_local_tensor} is complete.
-The implication from the PEPS renormalization diagram to the boundary MPO
-renormalization equations remains an open statement-level problem. A faithful
-completion must first choose an algebraic PEPS blocking relation and boundary
-fixed-point construction that determine the two channels, and must then derive
-their channel properties and
+The transfer operators and finite-cylinder boundary density are specified by
+Eqs.~\eqref{eq:cpsv16_peps_boundary_rfp_specification_sigma_lr}--
+\eqref{eq:cpsv16_peps_boundary_rfp_specification_long_cylinder}, but their
+passage to the local tensor used by the renormalization diagram is not. The
+implication from the PEPS renormalization diagram to the boundary MPO
+renormalization equations therefore remains an open statement-level problem.
+A faithful completion must first give an algebraic PEPS blocking relation and
+a boundary fixed-point construction that determine the two channels, and must
+then derive their channel properties and
 Eqs.~\eqref{eq:cpsv16_peps_boundary_rfp_specification_coarse_graining}--
 \eqref{eq:cpsv16_peps_boundary_rfp_specification_refinement}. No additional
 complete-positivity, trace-preservation, fixed-point normalization, or

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -54,6 +54,32 @@
   note         = {arXiv:2405.00439v2},
 }
 
+@article{Cirac2011Entanglement,
+  author       = {Cirac, J. Ignacio and Poilblanc, Didier and Schuch, Norbert and Verstraete, Frank},
+  title        = {Entanglement Spectrum and Boundary Theories with Projected Entangled-Pair States},
+  journal      = {Physical Review B},
+  volume       = {83},
+  number       = {24},
+  pages        = {245134},
+  year         = {2011},
+  doi          = {10.1103/PhysRevB.83.245134},
+  eprint       = {1103.3427},
+  eprinttype   = {arxiv},
+}
+
+@article{Schuch2013Topological,
+  author       = {Schuch, Norbert and Poilblanc, Didier and Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David},
+  title        = {Topological Order in {PEPS}: Transfer Operator and Boundary Hamiltonians},
+  journal      = {Physical Review Letters},
+  volume       = {111},
+  number       = {9},
+  pages        = {090501},
+  year         = {2013},
+  doi          = {10.1103/PhysRevLett.111.090501},
+  eprint       = {1210.5601},
+  eprinttype   = {arxiv},
+}
+
 @article{Seifnashri2024LSM,
   author       = {Seifnashri, Sahand},
   title        = {Lieb-Schultz-Mattis anomalies as obstructions to gauging (non-on-site) symmetries},


### PR DESCRIPTION
### Motivation

- CPSV16, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 694--729, passes from the PEPS transfer operator to the graphical RFP assertion and says that the last diagram “gives the desired $T$ and $S$” of Definition 4.1.
- The two boundary-theory papers cited at lines 713--714 contain precise finite- and long-cylinder boundary-state formulas, but they do not determine the blocking isometry or the two full-algebra channels appearing in the CPSV16 diagrams.
- The Blueprint and paper-gap note should record this exact boundary before any Lean statement is proposed.

### Description

- Cite Cirac--Poilblanc--Schuch--Verstraete, arXiv:1103.3427, Section II.2, Equations (10)--(13), including
  $\rho_\ell=U\sqrt{\sigma_L^T}\sigma_R\sqrt{\sigma_L^T}U^\dagger$.
- Cite Schuch--Poilblanc--Cirac--Pérez-García, arXiv:1210.5601, Equation (1), including
  $\sigma\propto\sqrt{\sigma_L^*}\sigma_R\sqrt{\sigma_L^*}$ and the possible non-uniqueness of the leading transfer fixed point.
- Distinguish these boundary operators from the data not supplied by CPSV16 Figures David0 and David2: the domain and codomain of the physical blocking isometry, external virtual identifications, the passage to the local boundary tensor, a choice in a degenerate fixed-point space, and the inserted refinement factor.
- Keep the source-facing RFP implication `\notready`, with no Lean declaration or `\leanok` tag. No Lean source is changed.

### Testing

- `./scripts/generate_paper_aux.sh 1606.00608`
- Standalone `latexmk` build and three-page render of `docs/paper-gaps/cpsv16_peps_boundary_rfp_specification.tex`
- `python3 scripts/audit_cpsv16_labels.py`
- `python3 scripts/test_audit_cpsv16_labels.py`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/paper_gap_leanid_sync.py --root .`
- `python3 scripts/fetch_tenkz.py`
- `lake exe cache get`
- `lake build`
- `leanblueprint pdf` on the same documentation patch over base `a97887f8e`; the final rebase to `76425afa` changed only disjoint files
- `leanblueprint web`
- `leanblueprint checkdecls`

---
Addresses #7371

