### PR TITLE
feat(PEPS): transfer staircase physical-operation states

### DIFF
--- a/TNLean/PEPS/RegionBlock/PhysicalOperation.lean
+++ b/TNLean/PEPS/RegionBlock/PhysicalOperation.lean
@@ -19,6 +19,12 @@ highlighted bond is a physical operation on an injective window.  Unlike equalit
 window against its complement, the theorem below is an open-boundary identity for every boundary
 configuration.
 
+In the other direction, any physical operation defines an insert by applying it to every genuine
+open-boundary block.  Closing this insert against the complement is the operation applied to the
+partial state, up to the region's interior-bond multiplicity.  Since partial states depend only on
+the closed state, this gives the direct `SameState` transfer used in the common-state comparison of
+the two-dimensional converse.
+
 ## References
 
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair
@@ -68,6 +74,67 @@ theorem physicalOpOfRegionInsert_realizes (A : Tensor G d) (R : Finset V)
   rw [physicalOpOfRegionInsert, LinearMap.comp_apply,
     regionBlockedLeftInverse_regionBlockedWeight,
     Fintype.linearCombination_apply_single, one_smul]
+
+/-- The region insert obtained by applying a physical operation to every genuine
+open-boundary block of the region.
+
+Source: arXiv:1804.04964, the four physical operations on the staircase windows at lines
+2320--2415 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionInsertOfPhysicalOp (A : Tensor G d) (R : Finset V)
+    (O : Module.End ℂ (RegionPhysicalConfig (V := V) (d := d) R → ℂ)) :
+    RegionInsert (G := G) (d := d) A R :=
+  fun μ => O (regionBlockedWeight (G := G) A R μ)
+
+/-- Applying a physical operation to every genuine open-boundary block and then closing the
+region against its complement is the same as applying that operation to the corresponding
+partial state, with the interior-bond multiplicity of the region.
+
+This is the coefficient form of the common-state comparison for the four physical operations in
+the two-dimensional proof: the operation is applied before the window is contracted with the
+rest of the network.
+
+Source: arXiv:1804.04964, the four physical operations and their common closed state at lines
+2368--2415 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem deformedRegionState_regionInsertOfPhysicalOp (A : Tensor G d) (R : Finset V)
+    (O : Module.End ℂ (RegionPhysicalConfig (V := V) (d := d) R → ℂ))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    deformedRegionState (G := G) A R (regionInsertOfPhysicalOp (G := G) A R O) σ τ =
+      O ((regionInteriorBondProd (G := G) A R : ℂ) •
+        regionPartialState (G := G) A R τ) σ := by
+  classical
+  unfold deformedRegionState regionInsertOfPhysicalOp
+  rw [regionInteriorBondProd_smul_regionPartialState (G := G) A R τ]
+  simp only [map_sum, map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+  exact Finset.sum_congr rfl fun μ _ => mul_comm _ _
+
+/-- The same physical operation, applied to the genuine blocks of two tensors with the same
+closed state, produces deformed states equal after cross-multiplication by the two interior-bond
+products.
+
+No identification of the two virtual boundary spaces is used: the two boundary sums are first
+read as the same partial state, and the only tensor-dependent factors left are the two
+interior-bond multiplicities.  This is the source-faithful bridge from `SameState` to the common
+physical-operation states compared in the two-dimensional converse.
+
+Source: arXiv:1804.04964, the common-state comparison at lines 2368--2415 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem deformedRegionState_regionInsertOfPhysicalOp_sameState (A B : Tensor G d)
+    (hAB : SameState A B) (R : Finset V)
+    (O : Module.End ℂ (RegionPhysicalConfig (V := V) (d := d) R → ℂ))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (regionInteriorBondProd (G := G) B R : ℂ) •
+        deformedRegionState (G := G) A R
+          (regionInsertOfPhysicalOp (G := G) A R O) σ τ =
+      (regionInteriorBondProd (G := G) A R : ℂ) •
+        deformedRegionState (G := G) B R
+          (regionInsertOfPhysicalOp (G := G) B R O) σ τ := by
+  rw [deformedRegionState_regionInsertOfPhysicalOp,
+    deformedRegionState_regionInsertOfPhysicalOp,
+    regionPartialState_sameState hAB R τ]
+  simp only [map_smul, Pi.smul_apply, smul_eq_mul]
+  ring
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
+++ b/TNLean/PEPS/TorusWindowVirtualOperationFamily.lean
@@ -31,6 +31,12 @@ explicit physical operator `Oⱼ(X)` whose action on every open-boundary genuine
 and the last-window coefficient with `X`.  This transpose agrees with the ordered-endpoint
 convention of Lemma 5, where the right-end physical operation occurs in the map from `O₃ᵀ` to `X`.
 
+If a second tensor has the same closed state, the same physical operators `Oⱼ(X)` may be applied
+to its genuine window blocks even though its virtual boundary spaces need not agree with those of
+the first tensor.  The partial-state identity transfers the common-state property across the two
+tensors after the honest interior-bond factors are accounted for.  Thus the physical operations
+give the common family required by the converse before any multiplication law is considered.
+
 The construction follows the paper's actual operation: it keeps the distinguished bond `e`
 fixed and adjoins genuine tensors to a window.  No auxiliary matrix-span or different-bond
 transport is introduced.
@@ -245,6 +251,101 @@ theorem deformedRegionStateAssembled_staircaseVirtualOperationInsert {a b j : �
       rw [deformedRegionStateAssembled_interiorBondInserted_eq_smul_edgeInsertedCoeff
         (hpos := hpos)]
       rw [regionInteriorBondProd_staircaseWindow_eq hTI _ L K j 0]
+
+/-- The physical operations `Oⱼ(X)` constructed from one tensor `A`, when applied to the
+corresponding genuine staircase-window blocks of a tensor `B` with the same closed state, all
+produce one common deformed state of `B`.
+
+For each window, `deformedRegionState_regionInsertOfPhysicalOp_sameState` transfers the closed
+action of `Oⱼ(X)` from `A` to `B`, without identifying their virtual boundary spaces.  On `A`, the
+operation realizes the insert family `Cⱼ(X)`, whose deformed states agree.  Translation invariance
+identifies the interior-bond products for the windows of each tensor, and positivity of the bond
+dimensions of `A` cancels its one common nonzero factor.
+
+This is exactly the common-state premise for comparing consecutive physical operations in the
+two-dimensional converse.  It assumes neither a multiplication law for the operations nor an
+auxiliary single-vertex or coarse-block injectivity condition.
+
+The source family has indices `0 ≤ k < L + K`.  The truncated offsets in `staircaseWindow`
+stabilize at the last window for `L + K - 1 ≤ k`, so the statement below holds for arbitrary
+natural indices; this is stabilization, not a cyclic convention.  No equality between the
+edge-dependent bond dimensions of `A` and `B` is assumed.
+
+Source: arXiv:1804.04964, the virtual-to-physical staircase construction at lines 2320--2368 and
+the common-state comparison of the four physical operations at lines 2368--2415 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem deformedRegionStateAssembled_staircasePhysicalOp_sameState
+    {A B : Tensor (torusGraph width height) d} {a b j j' : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hATI : IsTorusTranslationInvariant A) (hBTI : IsTorusTranslationInvariant B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    deformedRegionStateAssembled (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+        (regionInsertOfPhysicalOp (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+          (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X j)) =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j')
+        (regionInsertOfPhysicalOp (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j')
+          (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X j')) := by
+  classical
+  funext cfg
+  have hrealizes (k : ℕ) :
+      regionInsertOfPhysicalOp (G := torusGraph width height) A
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+          (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X k) =
+        staircaseVirtualOperationInsert (B := A) hL hK haw hyh X k := by
+    funext μ
+    exact staircaseVirtualOperationPhysicalOp_realizes hA hL hK haw hyh X k μ
+  have hcross (k : ℕ) :
+      (regionInteriorBondProd (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k) : ℂ) •
+        deformedRegionStateAssembled (G := torusGraph width height) A
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+          (regionInsertOfPhysicalOp (G := torusGraph width height) A
+            (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+            (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X k)) cfg =
+      (regionInteriorBondProd (G := torusGraph width height) A
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k) : ℂ) •
+        deformedRegionStateAssembled (G := torusGraph width height) B
+          (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+          (regionInsertOfPhysicalOp (G := torusGraph width height) B
+            (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+            (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X k)) cfg := by
+    exact deformedRegionState_regionInsertOfPhysicalOp_sameState
+      (G := torusGraph width height) A B hAB
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K k)
+      (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X k)
+      (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+      (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+  have hcross_j := hcross j
+  have hcross_j' := hcross j'
+  rw [hrealizes j,
+    deformedRegionStateAssembled_staircaseVirtualOperationInsert hATI hposA hL hK haw hyh X cfg,
+    regionInteriorBondProd_staircaseWindow_eq (A := B) hBTI _ L K j 0,
+    regionInteriorBondProd_staircaseWindow_eq (A := A) hATI _ L K j 0] at hcross_j
+  rw [hrealizes j',
+    deformedRegionStateAssembled_staircaseVirtualOperationInsert hATI hposA hL hK haw hyh X cfg,
+    regionInteriorBondProd_staircaseWindow_eq (A := B) hBTI _ L K j' 0,
+    regionInteriorBondProd_staircaseWindow_eq (A := A) hATI _ L K j' 0] at hcross_j'
+  simp only [nsmul_eq_mul, smul_eq_mul] at hcross_j hcross_j'
+  have hpA :
+      (regionInteriorBondProd (G := torusGraph width height) A
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0) : ℂ) ≠ 0 := by
+    have hpos : 0 < regionInteriorBondProd (G := torusGraph width height) A
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0) :=
+      Finset.prod_pos (fun e _ => hposA e)
+    exact_mod_cast hpos.ne'
+  exact mul_left_cancel₀ hpA (hcross_j.symm.trans hcross_j')
 
 /-- The coefficient on the first window with `Xᵀ` inserted equals the coefficient on the last
 window with `X` inserted.

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -40,6 +40,66 @@ correspondence in the proof sketch of the two-dimensional corollary
     vector to $C(\mu)$.
 \end{proof}
 
+\begin{definition}[Region insert of a physical operator]%
+    \label{def:peps_region_insert_of_physical_operator}
+    \lean{TNLean.PEPS.regionInsertOfPhysicalOp}
+    \leanok
+    Let $O$ be a physical operator on the physical space of a region $R$.
+    Its action on the genuine open-boundary blocks defines the insert
+    \begin{align}
+        C^O_{A,R}(\mu) & =O\bigl(T_{A,R}(\mu)\bigr).
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Closed state of a physical operator]%
+    \label{thm:peps_closed_state_of_physical_operator}
+    \lean{TNLean.PEPS.deformedRegionState_regionInsertOfPhysicalOp}
+    \leanok
+    \uses{def:peps_region_insert_of_physical_operator}
+    For a complement physical configuration $\tau$, define the partial state
+    $\psi^\tau_{A,R}$ by
+    $\psi^\tau_{A,R}(\sigma)=\Psi_A(\sigma\cup\tau)$. Then
+    \begin{align}
+        \Psi_{A,R,C^O_{A,R}}(\sigma,\tau)
+         & =\bigl[O\bigl(P_A(R)\psi^\tau_{A,R}\bigr)\bigr](\sigma).
+        \label{eq:peps_physical_op_partial_state}
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    Splitting the closed contraction across $R$ gives
+    \begin{align}
+        P_A(R)\psi^\tau_{A,R}
+         & =\sum_{\mu}
+        T_{A,V\setminus R}(\bar\mu)(\tau)\,T_{A,R}(\mu).
+        \notag
+    \end{align}
+    Applying $O$ and evaluating at $\sigma$ proves
+    (\ref{eq:peps_physical_op_partial_state}).
+\end{proof}
+
+\begin{theorem}[Physical operator transferred between equal closed states]%
+    \label{thm:peps_physical_operator_same_state_transfer}
+    \lean{TNLean.PEPS.deformedRegionState_regionInsertOfPhysicalOp_sameState}
+    \leanok
+    \uses{thm:peps_closed_state_of_physical_operator}
+    If $A$ and $B$ generate the same closed state, then
+    \begin{align}
+        P_B(R)\Psi_{A,R,C^O_{A,R}}(\sigma,\tau)
+         & =P_A(R)\Psi_{B,R,C^O_{B,R}}(\sigma,\tau).
+        \label{eq:peps_physical_op_same_state}
+    \end{align}
+    The two virtual boundary spaces need not be identified.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Equality of the closed states gives
+    $\psi^\tau_{A,R}=\psi^\tau_{B,R}$. Apply
+    (\ref{eq:peps_physical_op_partial_state}) to both tensors and
+    cross-multiply the two interior-bond products.
+\end{proof}
+
 \begin{definition}[Interior-bond region insert]%
     \label{def:peps_interior_bond_inserted_region_insert}
     \lean{TNLean.PEPS.interiorBondInsertedRegionInsert}
@@ -173,6 +233,55 @@ correspondence in the proof sketch of the two-dimensional corollary
     boundary orientation fixes $X$.  Each case gives
     $P_B(W_j)E_B(e,\omega,X)$.  Translation invariance identifies
     $P_B(W_j)$ with $P_B(W_0)$.
+\end{proof}
+
+\begin{theorem}[Common staircase state transferred between tensors]%
+    \label{thm:peps_staircase_physical_operation_same_state}
+    \lean{TNLean.PEPS.deformedRegionStateAssembled_staircasePhysicalOp_sameState}
+    \leanok
+    \uses{thm:peps_physical_operator_same_state_transfer,
+        thm:peps_staircase_virtual_operation_physical_realization,
+        thm:peps_staircase_virtual_operation_common_state,
+        thm:peps_regionInteriorBondProd_staircaseWindow_eq}
+    Let $L,K>0$, and choose staircase coordinates $(a,b)$ with
+    $a+2L\leq\mathrm{width}$ and $2K\leq\mathrm{height}$. Let $A$ and $B$
+    be translation invariant tensors with the same physical dimension and the
+    same closed state. Suppose every cyclic $L\times K$ window of $A$ is
+    injective and $D_A(g)>0$ for every edge $g$. For
+    $X\in\MN{D_A(e)}$, let $O_j^A(X)$ be the physical operators obtained from
+    the staircase insert family of $A$, and define inserts on the windows of
+    $B$ by
+    \begin{align}
+        C_j^{A\to B}(X)(\mu)
+         & =O_j^A(X)\bigl(T_{B,W_j}(\mu)\bigr).
+        \notag
+    \end{align}
+    Then, for all $j,j'\in\mathbb{N}$,
+    \begin{align}
+        \Psi^{\mathrm{as}}_{B,W_j,C_j^{A\to B}(X)}
+         & =\Psi^{\mathrm{as}}_{B,W_{j'},C_{j'}^{A\to B}(X)}.
+        \notag
+    \end{align}
+    The source family has $0\leq j<L+K$. In the definition used here the
+    truncated offsets stabilize at $W_{L+K-1}$ for $j\geq L+K-1$; the indices
+    are not read modulo $L+K$. No equality between the edge-dependent bond
+    dimensions of $A$ and $B$, and no positivity assumption on those of $B$,
+    is required.
+\end{theorem}
+\begin{proof}
+    \leanok
+    For each $j$, (\ref{eq:peps_physical_op_same_state}) and the
+    open-boundary realization of $O_j^A(X)$ give
+    \begin{align}
+        P_B(W_j)\Psi^{\mathrm{as}}_{A,W_j,C_j^A(X)}
+         & =P_A(W_j)\Psi^{\mathrm{as}}_{B,W_j,C_j^{A\to B}(X)}.
+        \notag
+    \end{align}
+    The staircase family of $A$ has one common deformed state. Translation
+    invariance gives $P_A(W_j)=P_A(W_0)$ and
+    $P_B(W_j)=P_B(W_0)$. Hence the right-hand side is independent of $j$.
+    Positivity of the bond dimensions makes $P_A(W_0)$ nonzero, so it may be
+    cancelled.
 \end{proof}
 
 \begin{theorem}[End-window identity for one virtual operation]%

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -4,6 +4,58 @@ The construction below formalizes the forward virtual/physical-operation
 correspondence in the proof sketch of the two-dimensional corollary
 \cite[corollary after Lemma~5, lines~2297--2444]{Molnar2018NormalPEPS}.
 
+\begin{definition}[Partial state across a region cut]%
+    \label{def:peps_region_partial_state}
+    \lean{TNLean.PEPS.regionPartialState}
+    \leanok
+    For a region $R$ and a physical configuration $\tau$ on its complement,
+    define the partial state $\psi^\tau_{A,R}$ on the physical space of $R$
+    by
+    \begin{align}
+        \psi^\tau_{A,R}(\sigma)
+         & =\Psi_A(\sigma\cup\tau).
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Partial states of equal closed states]%
+    \label{thm:peps_region_partial_state_same_state}
+    \lean{TNLean.PEPS.regionPartialState_sameState}
+    \leanok
+    \uses{def:peps_region_partial_state}
+    If $A$ and $B$ generate the same closed state, then, for every region
+    $R$ and every complement configuration $\tau$,
+    $\psi^\tau_{A,R}=\psi^\tau_{B,R}$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Evaluate both functions at a physical configuration $\sigma$ on $R$ and
+    apply the equality of the two closed-state coefficients at
+    $\sigma\cup\tau$.
+\end{proof}
+
+\begin{theorem}[Blocked-tensor expansion of a partial state]%
+    \label{thm:peps_region_partial_state_blocked_expansion}
+    \lean{TNLean.PEPS.regionInteriorBondProd_smul_regionPartialState}
+    \leanok
+    \uses{def:peps_region_partial_state,
+        def:peps_regionComplementBoundaryConfig}
+    Let $P_A(R)$ be the product of the dimensions of the bonds internal to
+    $R$. For every complement configuration $\tau$,
+    \begin{align}
+        P_A(R)\psi^\tau_{A,R}
+         & =\sum_{\mu\in\partial R}
+        T_{A,V\setminus R}(\bar\mu)(\tau)T_{A,R}(\mu).
+        \label{eq:peps_partial_state_blocked_expansion}
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    Split the closed contraction across $R$. The virtual labels on the two
+    sides agree through the complement-boundary identification, while each
+    bond internal to $R$ contributes its dimension.
+\end{proof}
+
 \begin{definition}[Physical operator of a region insert]%
     \label{def:peps_physical_operator_of_region_insert}
     \lean{TNLean.PEPS.physicalOpOfRegionInsert}
@@ -56,10 +108,10 @@ correspondence in the proof sketch of the two-dimensional corollary
     \label{thm:peps_closed_state_of_physical_operator}
     \lean{TNLean.PEPS.deformedRegionState_regionInsertOfPhysicalOp}
     \leanok
-    \uses{def:peps_region_insert_of_physical_operator}
-    For a complement physical configuration $\tau$, define the partial state
-    $\psi^\tau_{A,R}$ by
-    $\psi^\tau_{A,R}(\sigma)=\Psi_A(\sigma\cup\tau)$. Then
+    \uses{def:peps_region_insert_of_physical_operator,
+        thm:peps_region_partial_state_blocked_expansion}
+    For a complement physical configuration $\tau$, let
+    $\psi^\tau_{A,R}$ be the partial state across the cut. Then
     \begin{align}
         \Psi_{A,R,C^O_{A,R}}(\sigma,\tau)
          & =\bigl[O\bigl(P_A(R)\psi^\tau_{A,R}\bigr)\bigr](\sigma).
@@ -68,14 +120,8 @@ correspondence in the proof sketch of the two-dimensional corollary
 \end{theorem}
 \begin{proof}
     \leanok
-    Splitting the closed contraction across $R$ gives
-    \begin{align}
-        P_A(R)\psi^\tau_{A,R}
-         & =\sum_{\mu}
-        T_{A,V\setminus R}(\bar\mu)(\tau)\,T_{A,R}(\mu).
-        \notag
-    \end{align}
-    Applying $O$ and evaluating at $\sigma$ proves
+    Apply $O$ to~(\ref{eq:peps_partial_state_blocked_expansion}) and evaluate
+    at $\sigma$. This proves
     (\ref{eq:peps_physical_op_partial_state}).
 \end{proof}
 
@@ -83,7 +129,8 @@ correspondence in the proof sketch of the two-dimensional corollary
     \label{thm:peps_physical_operator_same_state_transfer}
     \lean{TNLean.PEPS.deformedRegionState_regionInsertOfPhysicalOp_sameState}
     \leanok
-    \uses{thm:peps_closed_state_of_physical_operator}
+    \uses{thm:peps_closed_state_of_physical_operator,
+        thm:peps_region_partial_state_same_state}
     If $A$ and $B$ generate the same closed state, then
     \begin{align}
         P_B(R)\Psi_{A,R,C^O_{A,R}}(\sigma,\tau)

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -13,7 +13,7 @@ correspondence in the proof sketch of the two-dimensional corollary
     by
     \begin{align}
         \psi^\tau_{A,R}(\sigma)
-         & =\Psi_A(\sigma\cup\tau).
+         & =c_A(\omega_{R,\sigma,\tau}).
         \notag
     \end{align}
 \end{definition}
@@ -31,7 +31,7 @@ correspondence in the proof sketch of the two-dimensional corollary
     \leanok
     Evaluate both functions at a physical configuration $\sigma$ on $R$ and
     apply the equality of the two closed-state coefficients at
-    $\sigma\cup\tau$.
+    $\omega_{R,\sigma,\tau}$.
 \end{proof}
 
 \begin{theorem}[Blocked-tensor expansion of a partial state]%
@@ -51,9 +51,16 @@ correspondence in the proof sketch of the two-dimensional corollary
 \end{theorem}
 \begin{proof}
     \leanok
-    Split the closed contraction across $R$. The virtual labels on the two
-    sides agree through the complement-boundary identification, while each
-    bond internal to $R$ contributes its dimension.
+    Split the closed contraction across $R$. If $\mu$ and $\nu$ are boundary
+    labels on $R$, the complement-boundary identification satisfies
+    \begin{align}
+        \bar\mu=\bar\nu
+         & \quad\Longleftrightarrow\quad \mu=\nu.
+        \notag
+    \end{align}
+    Hence the double boundary sum collapses to its diagonal, which gives the
+    sum in~(\ref{eq:peps_partial_state_blocked_expansion}); each bond internal
+    to $R$ contributes its dimension to the factor $P_A(R)$.
 \end{proof}
 
 \begin{definition}[Physical operator of a region insert]%

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -116,9 +116,10 @@ every staircase window --- is now complete: the open-boundary identity
 $O_j(X)T_{B,W_j}(\mu)=C_j(X)(\mu)$ is proved for every virtual boundary
 configuration~$\mu$.  The partial-state identity now also proves that the
 same operators $O_j^A(X)$, applied to the genuine $B$-blocks of a tensor with
-the same closed state, produce one common $B$-state.  The two-end extraction
-and the $O_1P_1$ and underlying $P_3O_3$ composition laws are complete.  What
-remains is to extract the cross-tensor matrix assignments, prove their
+the same closed state, produce one common $B$-state.  The same-tensor two-end
+extraction and the $O_1P_1$ and underlying $P_3O_3$ composition laws are
+complete.  What remains is to apply the two-end extraction to the cross-tensor
+common family, organize the resulting matrix assignments, prove their
 multiplicativity from these laws, and assemble the back half of the argument.
 
 Ref.~\cite{Molnar2018NormalPEPS} supplies this converse by the reduction ``we only need to prove a

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -114,13 +114,12 @@ the two directions of this correspondence.  The forward direction ---
 realizing a fixed virtual operation $X$ by a physical operator $O_j(X)$ on
 every staircase window --- is now complete: the open-boundary identity
 $O_j(X)T_{B,W_j}(\mu)=C_j(X)(\mu)$ is proved for every virtual boundary
-configuration~$\mu$.  The two-end comparison that recovers the unique matrix
-$X$ is also complete.  The end-factor relations are now proved unique and
-closed under composition in the source's two orientations: $O_1P_1$ realizes
-$XY$, while the underlying product $P_3O_3$ realizes $XY$ in the
-$O_3^{\mathsf T}$ orientation.  What remains is to use these relations to
-construct the cross-tensor transfer and assemble the back half of the
-argument.
+configuration~$\mu$.  The partial-state identity now also proves that the
+same operators $O_j^A(X)$, applied to the genuine $B$-blocks of a tensor with
+the same closed state, produce one common $B$-state.  The two-end extraction
+and the $O_1P_1$ and underlying $P_3O_3$ composition laws are complete.  What
+remains is to extract the cross-tensor matrix assignments, prove their
+multiplicativity from these laws, and assemble the back half of the argument.
 
 Ref.~\cite{Molnar2018NormalPEPS} supplies this converse by the reduction ``we only need to prove a
 statement similar to Lemma~5''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321}.}
@@ -246,7 +245,13 @@ open-boundary physical operators
 \leanid{TNLean.PEPS.staircaseVirtualOperationPhysicalOp\_realizes}), and its
 end-window coefficient identity
 \leanid{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}
-(\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean} and
+as well as the cross-tensor common-state identity
+\leanid{TNLean.PEPS.deformedRegionStateAssembled_staircasePhysicalOp\_sameState},
+which applies the same physical operators to the genuine blocks of a tensor
+with the same closed state without identifying the two virtual boundary
+spaces
+(\path{TNLean/PEPS/RegionBlock/PhysicalOperation.lean},
+\path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean}, and
 \path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}). Every
 inverted region is a union of one-orientation $L \times K$ window translates,
 host-decomposable at $n \geq 2L+1$, $m \geq 2K+1$. The development is
@@ -269,10 +274,12 @@ $P_B(W_0)E_B(e,\cdot,X)$.  The relations
 \leanid{TNLean.PEPS.IsO1VirtualOperation} and
 \leanid{TNLean.PEPS.IsO3TransposeVirtualOperation} are single-valued on the
 genuine end families, and their multiplication theorems give exactly the two
-composition orders printed in Lemma~5.  The outstanding input is the
-cross-tensor coefficient transfer between $A$ and $B$, including its
-multiplicativity field \path{hmul}.  The back-half assembly follows only after
-this transfer is available.  Existing single-window and coarse-three-site
+composition orders printed in Lemma~5.  The new common-state theorem applies
+the operators $O_j^A(X)$ to the genuine $B$-blocks.  It remains to apply the
+end extraction to this family in both directions and prove that the forward
+matrix assignment respects products; these are the
+\path{htransferAB}/\path{htransferBA}/\path{hmul} data consumed downstream.
+Existing single-window and coarse-three-site
 attempts do not derive that cross-tensor input at the minimal size; a
 source-faithful extraction must use the actual overlapping-window comparison
 rather than assume a matrix span.
@@ -390,6 +397,15 @@ and the remaining windows carry the boundary insert of $X$.  Translation
 invariance identifies the non-boundary bond products, so all these inserts
 produce the common state $P_A(W_0)E_A(e,\cdot,X)$.  This is formalized in
 \path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}.
+
+If $A$ and $B$ generate the same closed state, apply these same physical
+operators $O_j^A(X)$ to the genuine $B$-blocks.  The partial states of $A$ and
+$B$ coincide.  Closing a physical operation against either complement is the
+operation applied to this partial state, multiplied by the corresponding
+interior-bond product.  Translation invariance makes these products uniform
+over the staircase, so the resulting $B$-deformations again have one common
+state.  This cross-tensor common-state identity is
+\leanid{TNLean.PEPS.deformedRegionStateAssembled_staircasePhysicalOp\_sameState}.
 
 The two-dimensional analogue of Lemma~5 also has a converse. Suppose each
 window $W_j$ carries a deformed tensor $C_j$ (an arbitrary tensor with
@@ -621,18 +637,8 @@ $\prod_{\text{external legs}} \mathrm{bondDim} = \mathrm{bondDim}\,e$, false in
 general. So \path{exists_bondOperator_of_intertwine_span} cannot be fed from
 per-window blocks.
 
-The faithful two-dimensional extraction is the single-crossing
-algebra-isomorphism route the torus Theorem~3 development already uses
-(\path{exists_regionEdgeGauge_of_blockingData} of
-\path{TNLean/PEPS/CoherentFrameInstance2.lean}): the region-inserted
-coefficient \path{regionInsertedCoeff} inserts a matrix on the single boundary
-edge $e$ and contracts the red block against the host, and Skolem--Noether
-(\path{edgeGaugeFromInsertionAlgebraIsomorphism}) turns the resulting algebra
-isomorphism into conjugation by an invertible edge matrix $Z$. The Theorem~3
-engine inverts the \emph{host} $\mathrm{univ} \setminus \mathrm{red}$ (its
-hypothesis \path{hCB}), which the corollary's minimal size does not provide; the
-overlapping-window replacement plays the second end window $W_{L+K-1}$ in the
-host's role, inverting only the two injective windows.  The required
+The faithful two-dimensional extraction instead compares the two genuine end
+windows simultaneously, as in Lemma~5.  The required
 $\text{\path{extendInsert}}\,(W_0 \subseteq S)$-to-single-bond-$e$ peeling is now
 landed: the end-window boundary equivalences separate the index on $e$ from
 the open external legs, the normalized blue coupling is the genuine opposite
@@ -640,8 +646,11 @@ window block on the compatible fibre and vanishes off it, and
 \path{existsUnique_virtualOperation_of_horizontalStaircaseEndPair} extracts
 the unique matrix $X$.  Specializing the end inserts to the physical actions
 $O_1$ and $O_3$ gives the source's two factor relations, whose direct
-composition laws are now formalized.  The residual is their use in the
-cross-tensor transfer and the back-half assembly.
+composition laws are now formalized.  The same-state partial-state identity
+also supplies the cross-tensor common family for these physical operations.
+The residual is to extract and organize the resulting matrix assignment, use
+the end-composition laws to prove its multiplicativity, and complete the
+back-half assembly.
 
 \subsection{Step 5: the rest of the proof}
 
@@ -1321,10 +1330,18 @@ non-boundary-bond factor supplied by translation invariance.  The construction a
 end-window identity are
 $\text{\path{staircaseVirtualOperationInsert}}$ and
 $\text{\path{regionInsertedCoeff\_endWindows\_eq\_staircaseVirtualOperation}}$.
+The partial-state contraction identity now transfers the same physical
+operators to the genuine $B$-blocks: the resulting inserts have one common
+$B$-state by
+$\text{\path{deformedRegionStateAssembled\_staircasePhysicalOp\_sameState}}$.
+This statement uses neither an identification of the two virtual boundary
+spaces nor a multiplicativity hypothesis.
 
-The local residual is the cross-tensor multiplicative transfer: one must
-identify the physical end operations across the two tensor families and feed
-the landed end-composition laws into the transfer.  The region-level recovery
+The local residual is now the cross-tensor matrix assignment and its
+multiplicativity.  One must feed this common family through
+$\text{\path{staircasePair\_insert\_eq\_open}}$ and the landed unique end
+extraction in both directions, then use the end-composition laws to prove that
+the forward assignment respects products.  The region-level recovery
 $\text{\path{regionInsertionTransfer\_of\_realizes}}$ derives all three transfer fields ---
 $\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and $\text{\path{hmul}}$ --- from one region
 physical-to-virtual realization $\text{\path{RegionTransferRealizes}}$ in each direction, with
@@ -1332,11 +1349,11 @@ no further hypothesis; so the window route's residual collapses to producing tha
 realization on the window from the staircase, in place of the edge-middle injectivity
 ($\mathrm{univ}\setminus\{u,v\}$ injective) the rectangle route uses, which fails at the
 minimal size --- the same obstruction, at the edge, that $\mathrm{univ}\setminus S$
-exhibits at the end pair.  A coefficient transfer alone does not yield
-$\text{\path{hmul}}$: the missing bridge is the cross-tensor identification
-that lets the already-proved $O_1$ and $O_3^{\mathsf T}$ composition laws act
-on that transfer.  After this transfer is available, the back-half assembly
-remains.
+exhibits at the end pair.  The common-state theorem alone does not yield
+$\text{\path{hmul}}$: the missing bridge is the comparison of the canonical
+physical operations under composition, in the order $O_1P_1$ on the left and
+the underlying order $P_3O_3$ for the $O_3^{\mathsf T}$ orientation on the
+right.  After this transfer is available, the back-half assembly remains.
 
 \section{The multiplicativity route: compose the two end relations, not a
   single-window span or a coarse frame}
@@ -1425,14 +1442,12 @@ relations instead make multiplicativity a direct calculation: compose the two
 left physical operations, compose the underlying right operations in reverse
 order, and use uniqueness of $X$.  No third block or larger frame enters.
 
-The overlapping-window realization sketched in Ref.~\cite{Molnar2018NormalPEPS} keeps the same virtual operation
-$M$ on $e$ while representing it on every staircase window.  That common-state family
-is now built below.  It closes the single-operation part of this discussion but not the
-cross-tensor homomorphism: the remaining task is to compare the two tensor families and
-show that the resulting coefficient transfer respects products, following Lemma~5's
-now-formalized composition of the $O_1$ and $O_3^{\mathsf T}$ end relations
-rather than a single-window span or an assumed coarse frame.  The back-half
-assembly follows only after this transfer is supplied.
+The overlapping-window realization sketched in Ref.~\cite{Molnar2018NormalPEPS} keeps the same
+virtual operation $M$ on $e$ while representing it on every staircase window.
+That common-state family, including its transfer across equal closed states,
+is now built below.  The remaining cross-tensor homomorphism must be obtained
+from Lemma~5's composition of the $O_1$ and $O_3^{\mathsf T}$ end relations,
+not from a single-window span or an assumed coarse frame.
 
 \subsection{The foundation that lands}
 
@@ -1454,7 +1469,7 @@ work is the cross-tensor identification that feeds the direct end-composition
 laws into the coefficient transfer; the back-half assembly is the subsequent
 step.
 
-\subsection{The common-state family is complete}
+\subsection{The same-tensor and cross-tensor common-state families are complete}
 
 The earlier analysis incorrectly claimed that the intermediate staircase windows contain
 neither endpoint of the reference edge and therefore require transport across different
@@ -1487,15 +1502,27 @@ $\mathrm{edgeInsertedCoeff}(e,M)$.  Translation
 invariance makes that product uniform over the staircase, proving one common deformed
 state for all $L+K$ inserts.
 
+For tensors $A$ and $B$ with the same closed state, the identity
+\leanid{TNLean.PEPS.deformedRegionState_regionInsertOfPhysicalOp\_sameState}
+compares the closed action of one physical operator on their genuine region
+blocks after cross-multiplication by the two interior-bond products.  Applied
+to $O_j^A(M)$, the translation-invariant products are independent of $j$ and
+the positive $A$-factor cancels.  Thus
+\leanid{TNLean.PEPS.deformedRegionStateAssembled_staircasePhysicalOp\_sameState}
+proves that these same physical operators applied to the $B$-blocks also have
+one common state.  No virtual-boundary identification or product law is used.
+
 Consequently
 \leanid{TNLean.PEPS.regionInsertedCoeff\_endWindows\_eq\_staircaseVirtualOperation}
 supplies the source-faithful single-tensor identity between the first-window insertion of
-$M^{\mathsf T}$ and the last-window insertion of $M$.  This closes the common-state-family
-residual.  This end-window coefficient identity follows directly from the two region-to-edge
-identities and translation invariance; it needs neither complement inversion nor a peeling
-hypothesis.  It does not by itself construct the cross-tensor transfer from $A$ to $B$ or
-prove that transfer multiplicative; that cross-tensor feed is the remaining
-Lemma~5-style step, after which the back-half assembly remains.
+$M^{\mathsf T}$ and the last-window insertion of $M$.  This end-window
+coefficient identity follows directly from the two region-to-edge identities
+and translation invariance; it needs neither complement inversion nor a
+peeling hypothesis.  Together with the partial-state argument above, this
+closes both common-state-family residuals.  It does not yet extract the
+cross-tensor matrix assignment or prove that assignment multiplicative;
+those are the remaining Lemma~5-style steps, after which the back-half
+assembly remains.
 
 \section{Normality and discarded stronger routes}
 


### PR DESCRIPTION
## Motivation

In the proof sketch of the two-dimensional corollary of arXiv:1804.04964, one virtual matrix \(X\) is first realized by physical operators on the overlapping staircase windows. The converse then starts from physical operators that produce one common transformed PEPS before the two end windows are compared. The existing development supplied the single-tensor staircase family and the Lemma 5 end-operation composition laws, but not the direct transfer of that common-state premise between two tensors generating the same closed state.

This PR lands only that pre-extraction cross-state premise.

## Description

- define the region insert obtained by applying a physical operator to every genuine open-boundary blocked tensor;
- prove that closing this insert against a complement applies the physical operator to the corresponding partial state, with the honest interior-bond factor;
- prove the cross-multiplied comparison for two tensors with the same closed state, without identifying their virtual boundary spaces;
- specialize this identity to the canonical operators \(O_j^A(X)\): when applied to the genuine staircase-window blocks of \(B\), they produce one common assembled deformed state of \(B\);
- synchronize the Blueprint and the normal-PEPS overlap gap note, including separate Blueprint nodes for the partial state, its blocked-tensor expansion, and its invariance under equality of closed states.

## Mathematical scope

The staircase theorem assumes the printed window injectivity for \(A\), translation invariance of \(A\) and \(B\), equality of their closed states, positive bond dimensions for \(A\), and the stated size inequalities. It assumes no injectivity or positivity for \(B\), no equality of the edge-dependent bond dimensions of \(A\) and \(B\), and no identification of their virtual boundary spaces.

The conclusion is stated for all \(j,j'\in\mathbb N\). This is not a modular convention: the truncated staircase offsets stabilize at the last source window once \(j\geq L+K-1\).

This PR does **not** feed the common family through the two-end extraction, construct the cross-tensor matrix assignment, prove its multiplicativity, or assemble the final gauge. In particular it introduces no `hmul` hypothesis, compatible-pair package, coherent coarse frame, single-vertex injectivity, or per-window square-matrix span. Those remaining steps keep #5456 and #2738 open.

## Source fidelity

The source is `Papers/1804.04964/paper_normal.tex` lines 2320--2415. The new staircase theorem formalizes the common transformed-state premise immediately before the end-window comparison at lines 2415--2444. The later multiplication argument remains the paper's \(O_1P_1\) order on the left and underlying \(P_3O_3\) order for the \(O_3^{\mathsf T}\) orientation; this PR does not claim that step.

## Validation

- exact pushed head: `9fbc702e4403099a8d10e01fb9aa8133d483ae9c`;
- exact-head linter-bearing focused build: **1992/1992 jobs succeeded**;
- the Lean sources are unchanged from the preceding **10432/10432** full-root result;
- Blueprint synchronization and changed-declaration reverse coverage passed: **7157/7157 entries**;
- root `checkdecls` and paper-gap declaration checking passed;
- configured `latexindent`, `chktex`, reader-facing prose, forbidden-token, and diff checks passed;
- exact-head hosted checks and source-faithfulness reviews are pending.

Advances #5456.

Tracks #2738.