### PR TITLE
feat(parent-hamiltonian): build fixed-ambient martingale filtration

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -70,6 +70,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
+import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -12,6 +12,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
+import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
@@ -38,7 +39,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The sixteen components are:
+The seventeen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
@@ -49,6 +50,8 @@ The sixteen components are:
   martingale differences, telescoping resolution, and norm-square decomposition;
 * `Martingale.ProjectionCancellation` — outside-window cancellation and the
   finite interval reduction between equations \(Enpsi\) and \(Enpsi2\);
+* `Martingale.FixedAmbient` — fixed-volume prefix and interval ground projections,
+  physical outside-window commutation, and the resulting interval reduction;
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.AdjacentLocalTerms` — individual three-site kernels and the

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -39,7 +39,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The seventeen components are:
+The eighteen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -11,11 +11,11 @@ import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 # Fixed-ambient open-chain ground projections
 
 This file realizes the projections in Nachtergaele's martingale argument on one
-fixed `N`-site Hilbert space.  The prefix Hamiltonian at level `n` contains the
-nonwrapping local interactions whose support lies in `[0, n)`.  Its kernel
+fixed \(N\)-site Hilbert space. The prefix Hamiltonian at level \(n\) contains the
+nonwrapping local interactions whose support lies in \([0,n)\). Its kernel
 projection is therefore a decreasing family on
 `EuclideanSpace ℂ (Cfg d N)`, rather than a family whose ambient type changes
-with `n`.
+with \(n\).
 
 For the local interval \([n-l,n+1)\), the ground projection is the kernel
 projection of the sum over starts \(n-l\leq i\) and \(i+L\leq n+1\). We prove the
@@ -38,10 +38,10 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 /-- Kernel projections of commuting symmetric operators commute.
 
-The point is not merely that the operators commute.  Commutation makes
-`ker S` invariant under `T`; symmetry makes its orthogonal complement invariant
-as well.  Hence the orthogonal projection onto `ker S` commutes with `T`, and
-the same invariant-subspace argument applied to `ker T` gives commutation of
+The point is not merely that the operators commute. Commutation makes
+\(\ker S\) invariant under \(T\); symmetry makes its orthogonal complement invariant
+as well. Hence the orthogonal projection onto \(\ker S\) commutes with \(T\), and
+the same invariant-subspace argument applied to \(\ker T\) gives commutation of
 the two kernel projections. -/
 theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
     (_hS : S.IsSymmetric) (hT : T.IsSymmetric)
@@ -116,8 +116,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- A nonwrapping interaction start whose length-`L` support lies in the prefix
-`[0, n)` of a fixed `N`-site chain. -/
+/-- A nonwrapping interaction start whose length-\(L\) support lies in the prefix
+\([0,n)\) of a fixed \(N\)-site chain. -/
 abbrev OpenPrefixStart (L N n : ℕ) :=
   {i : NonwrappingStart L N // i.1.val + L ≤ n}
 
@@ -140,20 +140,20 @@ theorem cyclicWindowsDisjoint_of_nonwrapping_ordered {N L : ℕ} {i j : Fin N}
     simpa only [Fin.val_mk, Nat.mod_eq_of_lt hjrN] using congrArg Fin.val hkjEq
   omega
 
-/-- The parent Hamiltonian of the prefix `[0, n)`, acting on the fixed ambient
-space of an `N`-site open chain. -/
+/-- The parent Hamiltonian of the prefix \([0,n)\), acting on the fixed ambient
+space of an \(N\)-site open chain. -/
 noncomputable def openPrefixParentHamiltonianES (A : MPSTensor d D)
     (L N n : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   ∑ i : OpenPrefixStart L N n, localTermES A L i.1.1
 
-/-- The fixed-ambient ground projection of the prefix `[0, n)`. -/
+/-- The fixed-ambient ground projection of the prefix \([0,n)\). -/
 noncomputable def openPrefixGroundProjectionES (A : MPSTensor d D)
     (L N n : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   (LinearMap.ker (openPrefixParentHamiltonianES A L N n)).starProjection.toLinearMap
 
-/-- The fixed-ambient local ground projection on `[n-l, n+1)`.
+/-- The fixed-ambient local ground projection on \([n-l,n+1)\).
 
 Its Hamiltonian sums exactly the starts satisfying \(n-l\leq i\) and
 \(i+L\leq n+1\). -/
@@ -188,7 +188,7 @@ theorem ker_openPrefixParentHamiltonianES_antitone (A : MPSTensor d D)
     ⟨i.1, i.2.trans hmn⟩
 
 /-- The prefix kernel projections form Nachtergaele's decreasing ground-space
-filtration on the single ambient `N`-site Hilbert space. -/
+filtration on the single ambient \(N\)-site Hilbert space. -/
 noncomputable def fixedAmbientNestedGroundProjectionsES (A : MPSTensor d D)
     (L N : ℕ) :
     FrustrationFree.NestedGroundProjections
@@ -261,8 +261,8 @@ theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_l
   exact openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES A hLN
     (by omega)
 
-/-- Once a prefix extends past `n`, its ground space is contained in the local
-ground space on `[n-l, n+1)`. -/
+/-- Once a prefix extends past \(n\), its ground space is contained in the local
+ground space on \([n-l,n+1)\). -/
 theorem ker_openPrefixParentHamiltonianES_le_ker_openSuffixParentHamiltonianES
     (A : MPSTensor d D) {L l N m n : ℕ} (hnm : n < m) :
     LinearMap.ker (openPrefixParentHamiltonianES A L N m) ≤
@@ -289,10 +289,10 @@ theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_l
       A hnm)
 
 /-- The physical fixed-ambient martingale difference commutes with the local
-ground projection outside the active interval `[n-l, n]`.
+ground projection outside the active interval \([n-l,n]\).
 
-For `m < n-l`, both prefix projections in `E_m=G_m-G_{m+1}` are supported to
-the left of `[n-l,n+1)`.  For `n < m`, both prefix kernels are contained in the
+For \(m<n-l\), both prefix projections in \(E_m=G_m-G_{m+1}\) are supported to
+the left of \([n-l,n+1)\). For \(n<m\), both prefix kernels are contained in the
 local interval kernel. -/
 theorem fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES
     (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
@@ -313,12 +313,12 @@ theorem fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES
       openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_lt
         A (by omega)]
 
-/-- Physical fixed-ambient form of the `Icc` cancellation identity in
+/-- Physical fixed-ambient form of the closed-interval cancellation identity in
 Nachtergaele's proof of Theorem 2.1(i).
 
-Here `G_m` is the kernel projection of the prefix Hamiltonian on `[0,m)`,
-`E_m=G_m-G_{m+1}`, and `Q_n` is the kernel projection of the local Hamiltonian
-on `[n-l,n+1)`. -/
+Here \(G_m\) is the kernel projection of the prefix Hamiltonian on \([0,m)\),
+\(E_m=G_m-G_{m+1}\), and \(Q_n\) is the kernel projection of the local Hamiltonian
+on \([n-l,n+1)\). -/
 theorem inner_sum_fixedAmbient_martingaleDifference_openIntervalGroundProjectionES_eq_Icc
     (A : MPSTensor d D) {L N n l : ℕ} (hLN : L ≤ N) (hn : n < N)
     (v : EuclideanSpace ℂ (Cfg d N)) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -1,0 +1,247 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Semisimple
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
+import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
+
+/-!
+# Fixed-ambient open-chain ground projections
+
+This file realizes the projections in Nachtergaele's martingale argument on one
+fixed `N`-site Hilbert space.  The prefix Hamiltonian at level `n` contains the
+nonwrapping local interactions whose support lies in `[0, n)`.  Its kernel
+projection is therefore a decreasing family on
+`EuclideanSpace ℂ (Cfg d N)`, rather than a family whose ambient type changes
+with `n`.
+
+For the local interval `[n-l, n+1)`, the ground projection is the kernel
+projection of `openSuffixParentHamiltonianES A L (l+1) N (n+1)`.  We prove the
+outside-window commutation used between equations `Enpsi` and `Enpsi2` in the
+proof of Theorem 2.1(i).
+
+## References
+
+* Nachtergaele, arXiv:cond-mat/9410110, equation (En), lines 1060--1073.
+* Nachtergaele, arXiv:cond-mat/9410110, Theorem 2.1(i), lines 1195--1220.
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace LinearMap
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- Kernel projections of commuting symmetric operators commute.
+
+The point is not merely that the operators commute.  Commutation makes
+`ker S` invariant under `T`; symmetry makes its orthogonal complement invariant
+as well.  Hence the orthogonal projection onto `ker S` commutes with `T`, and
+the same invariant-subspace argument applied to `ker T` gives commutation of
+the two kernel projections. -/
+theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
+    (_hS : S.IsSymmetric) (hT : T.IsSymmetric)
+    (hcomm : S.comp T = T.comp S) :
+    (LinearMap.ker S).starProjection.toLinearMap.comp
+        (LinearMap.ker T).starProjection.toLinearMap =
+      (LinearMap.ker T).starProjection.toLinearMap.comp
+        (LinearMap.ker S).starProjection.toLinearMap := by
+  let PS := (LinearMap.ker S).starProjection.toLinearMap
+  let PT := (LinearMap.ker T).starProjection.toLinearMap
+  have hkerS : LinearMap.ker S ∈ Module.End.invtSubmodule T := by
+    rw [Module.End.mem_invtSubmodule_iff_forall_mem_of_mem]
+    intro x hx
+    rw [LinearMap.mem_ker] at hx ⊢
+    simpa [hx] using congrArg (fun f : E →ₗ[ℂ] E => f x) hcomm
+  have hkerSperp : (LinearMap.ker S)ᗮ ∈ Module.End.invtSubmodule T :=
+    hT.orthogonalComplement_mem_invtSubmodule hkerS
+  have hPST : Commute PS T := by
+    apply (LinearMap.IsIdempotentElem.commute_iff
+      (Submodule.isSymmetricProjection_starProjection
+        (LinearMap.ker S)).isIdempotentElem).mpr
+    simpa only [PS, Submodule.range_starProjection, Submodule.ker_starProjection] using
+      And.intro hkerS hkerSperp
+  have hkerT : LinearMap.ker T ∈ Module.End.invtSubmodule PS := by
+    rw [Module.End.mem_invtSubmodule_iff_forall_mem_of_mem]
+    intro x hx
+    rw [LinearMap.mem_ker] at hx ⊢
+    simpa [hx] using congrArg (fun f : E →ₗ[ℂ] E => f x) hPST.eq.symm
+  have hkerTperp : (LinearMap.ker T)ᗮ ∈ Module.End.invtSubmodule PS :=
+    (Submodule.isSymmetricProjection_starProjection (LinearMap.ker S)).isSymmetric
+      |>.orthogonalComplement_mem_invtSubmodule hkerT
+  have hPTPS : Commute PT PS := by
+    apply (LinearMap.IsIdempotentElem.commute_iff
+      (Submodule.isSymmetricProjection_starProjection
+        (LinearMap.ker T)).isIdempotentElem).mpr
+    simpa only [PT, Submodule.range_starProjection, Submodule.ker_starProjection] using
+      And.intro hkerT hkerTperp
+  simpa only [PS, PT, Module.End.mul_eq_comp] using hPTPS.eq.symm
+
+/-- Orthogonal projections onto nested submodules commute. -/
+theorem Submodule.starProjection_commute_of_le {U V : Submodule ℂ E}
+    (hUV : U ≤ V) :
+    U.starProjection.toLinearMap.comp V.starProjection.toLinearMap =
+      V.starProjection.toLinearMap.comp U.starProjection.toLinearMap := by
+  have hleft : U.starProjection.toLinearMap.comp V.starProjection.toLinearMap =
+      U.starProjection.toLinearMap := by
+    apply LinearMap.ext
+    intro x
+    change U.starProjection (V.starProjection x) = U.starProjection x
+    exact congrArg (fun f : E →L[ℂ] E => f x)
+      (Submodule.starProjection_comp_starProjection_of_le hUV)
+  have hright : V.starProjection.toLinearMap.comp U.starProjection.toLinearMap =
+      U.starProjection.toLinearMap := by
+    ext x
+    apply ext_inner_left ℂ
+    intro y
+    calc
+      ⟪y, V.starProjection (U.starProjection x)⟫_ℂ =
+          ⟪V.starProjection y, U.starProjection x⟫_ℂ :=
+        (V.starProjection_isSymmetric y (U.starProjection x)).symm
+      _ = ⟪U.starProjection (V.starProjection y), x⟫_ℂ :=
+        (U.starProjection_isSymmetric (V.starProjection y) x).symm
+      _ = ⟪U.starProjection y, x⟫_ℂ := by
+        rw [← ContinuousLinearMap.comp_apply,
+          Submodule.starProjection_comp_starProjection_of_le hUV]
+      _ = ⟪y, U.starProjection x⟫_ℂ := U.starProjection_isSymmetric y x
+  exact hleft.trans hright.symm
+
+end LinearMap
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A nonwrapping interaction start whose length-`L` support lies in the prefix
+`[0, n)` of a fixed `N`-site chain. -/
+abbrev OpenPrefixStart (L N n : ℕ) :=
+  {i : NonwrappingStart L N // i.1.val + L ≤ n}
+
+/-- Ordered nonwrapping windows are cyclically site-disjoint. -/
+theorem cyclicWindowsDisjoint_of_nonwrapping_ordered {N L : ℕ} {i j : Fin N}
+    (hj : j.val + L ≤ N) (hij : i.val + L ≤ j.val) :
+    CyclicWindowsDisjoint L i j := by
+  intro k hki hkj
+  let ri := (k.val + N - i.val) % N
+  let rj := (k.val + N - j.val) % N
+  have hkiEq := eq_cyclic_site_of_offset_eq (Fin.pos i)
+    (i := i) (k := k) (r := ri) rfl
+  have hkjEq := eq_cyclic_site_of_offset_eq (Fin.pos j)
+    (i := j) (k := k) (r := rj) rfl
+  have hirN : i.val + ri < N := by omega
+  have hjrN : j.val + rj < N := by omega
+  have hkri : k.val = i.val + ri := by
+    simpa only [Fin.val_mk, Nat.mod_eq_of_lt hirN] using congrArg Fin.val hkiEq
+  have hkrj : k.val = j.val + rj := by
+    simpa only [Fin.val_mk, Nat.mod_eq_of_lt hjrN] using congrArg Fin.val hkjEq
+  omega
+
+/-- The parent Hamiltonian of the prefix `[0, n)`, acting on the fixed ambient
+space of an `N`-site open chain. -/
+noncomputable def openPrefixParentHamiltonianES (A : MPSTensor d D)
+    (L N n : ℕ) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  ∑ i : OpenPrefixStart L N n, localTermES A L i.1.1
+
+/-- The fixed-ambient ground projection of the prefix `[0, n)`. -/
+noncomputable def openPrefixGroundProjectionES (A : MPSTensor d D)
+    (L N n : ℕ) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  (LinearMap.ker (openPrefixParentHamiltonianES A L N n)).starProjection.toLinearMap
+
+/-- The fixed-ambient local ground projection on `[n-l, n+1)`.
+
+Its Hamiltonian is
+`openSuffixParentHamiltonianES A L (l+1) N (n+1)`, whose starts satisfy
+`n-l ≤ i` and `i+L ≤ n+1`. -/
+noncomputable def openIntervalGroundProjectionES (A : MPSTensor d D)
+    (L l N n : ℕ) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  (LinearMap.ker
+    (openSuffixParentHamiltonianES A L (l + 1) N (n + 1))).starProjection.toLinearMap
+
+/-- If a fixed-ambient prefix Hamiltonian annihilates a vector, every local
+interaction contained in that prefix annihilates it. -/
+theorem localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero
+    (A : MPSTensor d D) (L N n : ℕ) {v : EuclideanSpace ℂ (Cfg d N)}
+    (hv : openPrefixParentHamiltonianES A L N n v = 0)
+    (i : OpenPrefixStart L N n) :
+    localTermES A L i.1.1 v = 0 := by
+  rw [openPrefixParentHamiltonianES] at hv
+  exact ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero
+    (fun i : OpenPrefixStart L N n => localTermES A L i.1.1)
+    (fun i => localTermES_isSymmetricProjection A L i.1.1) hv i
+
+/-- Prefix kernels decrease when the prefix grows. -/
+theorem ker_openPrefixParentHamiltonianES_antitone (A : MPSTensor d D)
+    (L N : ℕ) :
+    Antitone fun n => LinearMap.ker (openPrefixParentHamiltonianES A L N n) := by
+  intro m n hmn v hv
+  rw [LinearMap.mem_ker] at hv ⊢
+  rw [openPrefixParentHamiltonianES, LinearMap.sum_apply]
+  apply Finset.sum_eq_zero
+  intro i _
+  exact localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero A L N n hv
+    ⟨i.1, i.2.trans hmn⟩
+
+/-- The prefix kernel projections form Nachtergaele's decreasing ground-space
+filtration on the single ambient `N`-site Hilbert space. -/
+noncomputable def fixedAmbientNestedGroundProjectionsES (A : MPSTensor d D)
+    (L N : ℕ) :
+    FrustrationFree.NestedGroundProjections
+      (E := EuclideanSpace ℂ (Cfg d N)) where
+  projection := openPrefixGroundProjectionES A L N
+  isSymmetricProjection n := by
+    exact Submodule.isSymmetricProjection_starProjection _
+  antitone_range := by
+    intro m n hmn
+    simpa only [openPrefixGroundProjectionES, Submodule.range_starProjection] using
+      ker_openPrefixParentHamiltonianES_antitone A L N hmn
+
+/-- The fixed-ambient prefix Hamiltonian is positive. -/
+theorem openPrefixParentHamiltonianES_isPositive (A : MPSTensor d D)
+    (L N n : ℕ) : (openPrefixParentHamiltonianES A L N n).IsPositive := by
+  rw [openPrefixParentHamiltonianES]
+  exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1.1
+
+/-- A fixed-ambient suffix-interval Hamiltonian is positive. -/
+theorem openSuffixParentHamiltonianES_isPositive (A : MPSTensor d D)
+    (L l N n : ℕ) : (openSuffixParentHamiltonianES A L l N n).IsPositive := by
+  rw [openSuffixParentHamiltonianES]
+  exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i.1
+
+/-- A prefix Hamiltonian ending before a suffix interval starts commutes with
+that interval Hamiltonian.  The proof expands both finite sums and uses
+site-disjoint commutation for every pair of local interactions. -/
+theorem openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES
+    (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
+    (hsep : m < n - l) :
+    (openPrefixParentHamiltonianES A L N m).comp
+        (openSuffixParentHamiltonianES A L l N n) =
+      (openSuffixParentHamiltonianES A L l N n).comp
+        (openPrefixParentHamiltonianES A L N m) := by
+  apply LinearMap.ext
+  intro v
+  simp only [openPrefixParentHamiltonianES, openSuffixParentHamiltonianES,
+    LinearMap.comp_apply, LinearMap.sum_apply]
+  simp_rw [map_sum]
+  rw [Finset.sum_comm'
+    (s := Finset.univ)
+    (t := fun _ => Finset.univ.filter fun i : NonwrappingStart L N =>
+      n - l ≤ i.1.val ∧ i.1.val + L ≤ n)
+    (t' := Finset.univ.filter fun i : NonwrappingStart L N =>
+      n - l ≤ i.1.val ∧ i.1.val + L ≤ n)
+    (s' := fun _ => Finset.univ)
+    (fun _ _ => by simp)]
+  apply Finset.sum_congr rfl
+  intro j hj
+  rw [Finset.mem_filter] at hj
+  apply Finset.sum_congr rfl
+  intro i _
+  exact localTermES_commute_of_cyclic_windows_disjoint A hLN
+    (cyclicWindowsDisjoint_of_nonwrapping_ordered j.2 (by omega)) v
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -25,7 +25,8 @@ proof of Theorem 2.1(i).
 ## References
 
 * Nachtergaele, arXiv:cond-mat/9410110, equation (En), lines 1060--1073.
-* Nachtergaele, arXiv:cond-mat/9410110, Theorem 2.1(i), lines 1195--1220.
+* Nachtergaele, arXiv:cond-mat/9410110, Theorem 2.1(i), equations \(Enpsi\)
+  and \(Enpsi2\), lines 1206--1220.
 -/
 
 open scoped BigOperators InnerProductSpace

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -19,7 +19,7 @@ with \(n\).
 
 For the local interval \([n-l,n+1)\), the ground projection is the kernel
 projection of the sum over starts \(n-l\leq i\) and \(i+L\leq n+1\). We prove the
-outside-window commutation used between equations `Enpsi` and `Enpsi2` in the
+outside-window commutation used between equations \(Enpsi\) and \(Enpsi2\) in the
 proof of Theorem 2.1(i).
 
 ## References
@@ -36,15 +36,16 @@ namespace LinearMap
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
   [FiniteDimensional ℂ E]
 
-/-- Kernel projections of commuting symmetric operators commute.
+/-- The kernel projection of a linear map commutes with the kernel projection
+of a commuting symmetric operator.
 
 The point is not merely that the operators commute. Commutation makes
-\(\ker S\) invariant under \(T\); symmetry makes its orthogonal complement invariant
-as well. Hence the orthogonal projection onto \(\ker S\) commutes with \(T\), and
-the same invariant-subspace argument applied to \(\ker T\) gives commutation of
-the two kernel projections. -/
+\(\ker S\) invariant under \(T\); symmetry of \(T\) makes its orthogonal complement
+invariant as well. Hence the orthogonal projection onto \(\ker S\) commutes with
+\(T\), and the same invariant-subspace argument applied to \(\ker T\) gives
+commutation of the two kernel projections. -/
 theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
-    (_hS : S.IsSymmetric) (hT : T.IsSymmetric)
+    (hT : T.IsSymmetric)
     (hcomm : S.comp T = T.comp S) :
     (LinearMap.ker S).starProjection.toLinearMap.comp
         (LinearMap.ker T).starProjection.toLinearMap =
@@ -258,7 +259,6 @@ theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_l
       (openIntervalGroundProjectionES A L l N n).comp
         (openPrefixGroundProjectionES A L N m) := by
   apply LinearMap.IsSymmetric.kernelProjection_commute_of_commute
-    (openPrefixParentHamiltonianES_isPositive A L N m).isSymmetric
     (openSuffixParentHamiltonianES_isPositive A L (l + 1) N (n + 1)).isSymmetric
   exact openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES A hLN
     (by omega)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -13,9 +13,8 @@ import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 This file realizes the projections in Nachtergaele's martingale argument on one
 fixed \(N\)-site Hilbert space. The prefix Hamiltonian at level \(n\) contains the
 nonwrapping local interactions whose support lies in \([0,n)\). Its kernel
-projection is therefore a decreasing family on
-`EuclideanSpace ℂ (Cfg d N)`, rather than a family whose ambient type changes
-with \(n\).
+projection is therefore a decreasing family on this fixed ambient Hilbert
+space, rather than a family whose ambient type changes with \(n\).
 
 For the local interval \([n-l,n+1)\), the ground projection is the kernel
 projection of the sum over starts \(n-l\leq i\) and \(i+L\leq n+1\). We prove the
@@ -249,9 +248,8 @@ theorem openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES
     (cyclicWindowsDisjoint_of_nonwrapping_ordered j.2 (by omega)) v
 
 /-- Prefix and local-interval ground projections commute when their supporting
-Hamiltonians are disjoint.  The passage from Hamiltonian commutation to kernel-
-projection commutation uses the invariant-subspace theorem
-`LinearMap.IsSymmetric.kernelProjection_commute_of_commute`. -/
+Hamiltonians are disjoint.  Hamiltonian commutation makes both kernels and their
+orthogonal complements invariant, which yields projection commutation. -/
 theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_le
     (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
     (hsep : m ≤ n - l) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -17,8 +17,8 @@ projection is therefore a decreasing family on
 `EuclideanSpace ℂ (Cfg d N)`, rather than a family whose ambient type changes
 with `n`.
 
-For the local interval `[n-l, n+1)`, the ground projection is the kernel
-projection of `openSuffixParentHamiltonianES A L (l+1) N (n+1)`.  We prove the
+For the local interval \([n-l,n+1)\), the ground projection is the kernel
+projection of the sum over starts \(n-l\leq i\) and \(i+L\leq n+1\). We prove the
 outside-window commutation used between equations `Enpsi` and `Enpsi2` in the
 proof of Theorem 2.1(i).
 
@@ -29,6 +29,7 @@ proof of Theorem 2.1(i).
 -/
 
 open scoped BigOperators InnerProductSpace
+open FrustrationFree.NestedGroundProjections
 
 namespace LinearMap
 
@@ -81,7 +82,7 @@ theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
   simpa only [PS, PT, Module.End.mul_eq_comp] using hPTPS.eq.symm
 
 /-- Orthogonal projections onto nested submodules commute. -/
-theorem Submodule.starProjection_commute_of_le {U V : Submodule ℂ E}
+theorem _root_.Submodule.starProjection_commute_of_le {U V : Submodule ℂ E}
     (hUV : U ≤ V) :
     U.starProjection.toLinearMap.comp V.starProjection.toLinearMap =
       V.starProjection.toLinearMap.comp U.starProjection.toLinearMap := by
@@ -154,9 +155,8 @@ noncomputable def openPrefixGroundProjectionES (A : MPSTensor d D)
 
 /-- The fixed-ambient local ground projection on `[n-l, n+1)`.
 
-Its Hamiltonian is
-`openSuffixParentHamiltonianES A L (l+1) N (n+1)`, whose starts satisfy
-`n-l ≤ i` and `i+L ≤ n+1`. -/
+Its Hamiltonian sums exactly the starts satisfying \(n-l\leq i\) and
+\(i+L\leq n+1\). -/
 noncomputable def openIntervalGroundProjectionES (A : MPSTensor d D)
     (L l N n : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
@@ -218,7 +218,7 @@ that interval Hamiltonian.  The proof expands both finite sums and uses
 site-disjoint commutation for every pair of local interactions. -/
 theorem openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES
     (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
-    (hsep : m < n - l) :
+    (hsep : m ≤ n - l) :
     (openPrefixParentHamiltonianES A L N m).comp
         (openSuffixParentHamiltonianES A L l N n) =
       (openSuffixParentHamiltonianES A L l N n).comp
@@ -243,5 +243,98 @@ theorem openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES
   intro i _
   exact localTermES_commute_of_cyclic_windows_disjoint A hLN
     (cyclicWindowsDisjoint_of_nonwrapping_ordered j.2 (by omega)) v
+
+/-- Prefix and local-interval ground projections commute when their supporting
+Hamiltonians are disjoint.  The passage from Hamiltonian commutation to kernel-
+projection commutation uses the invariant-subspace theorem
+`LinearMap.IsSymmetric.kernelProjection_commute_of_commute`. -/
+theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_le
+    (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
+    (hsep : m ≤ n - l) :
+    (openPrefixGroundProjectionES A L N m).comp
+        (openIntervalGroundProjectionES A L l N n) =
+      (openIntervalGroundProjectionES A L l N n).comp
+        (openPrefixGroundProjectionES A L N m) := by
+  apply LinearMap.IsSymmetric.kernelProjection_commute_of_commute
+    (openPrefixParentHamiltonianES_isPositive A L N m).isSymmetric
+    (openSuffixParentHamiltonianES_isPositive A L (l + 1) N (n + 1)).isSymmetric
+  exact openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES A hLN
+    (by omega)
+
+/-- Once a prefix extends past `n`, its ground space is contained in the local
+ground space on `[n-l, n+1)`. -/
+theorem ker_openPrefixParentHamiltonianES_le_ker_openSuffixParentHamiltonianES
+    (A : MPSTensor d D) {L l N m n : ℕ} (hnm : n < m) :
+    LinearMap.ker (openPrefixParentHamiltonianES A L N m) ≤
+      LinearMap.ker (openSuffixParentHamiltonianES A L (l + 1) N (n + 1)) := by
+  intro v hv
+  rw [LinearMap.mem_ker] at hv ⊢
+  rw [openSuffixParentHamiltonianES, LinearMap.sum_apply]
+  apply Finset.sum_eq_zero
+  intro i hi
+  rw [Finset.mem_filter] at hi
+  exact localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero A L N m hv
+    ⟨i, by omega⟩
+
+/-- Prefix and local-interval ground projections commute when the local ground
+space contains the prefix ground space. -/
+theorem openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_lt
+    (A : MPSTensor d D) {L l N m n : ℕ} (hnm : n < m) :
+    (openPrefixGroundProjectionES A L N m).comp
+        (openIntervalGroundProjectionES A L l N n) =
+      (openIntervalGroundProjectionES A L l N n).comp
+        (openPrefixGroundProjectionES A L N m) := by
+  exact Submodule.starProjection_commute_of_le
+    (ker_openPrefixParentHamiltonianES_le_ker_openSuffixParentHamiltonianES
+      A hnm)
+
+/-- The physical fixed-ambient martingale difference commutes with the local
+ground projection outside the active interval `[n-l, n]`.
+
+For `m < n-l`, both prefix projections in `E_m=G_m-G_{m+1}` are supported to
+the left of `[n-l,n+1)`.  For `n < m`, both prefix kernels are contained in the
+local interval kernel. -/
+theorem fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES
+    (A : MPSTensor d D) {L l N m n : ℕ} (hLN : L ≤ N)
+    (hout : m < n - l ∨ n < m) :
+    ((fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference m).comp
+        (openIntervalGroundProjectionES A L l N n) =
+      (openIntervalGroundProjectionES A L l N n).comp
+        ((fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference m) := by
+  simp only [FrustrationFree.NestedGroundProjections.martingaleDifference,
+    fixedAmbientNestedGroundProjectionsES, LinearMap.sub_comp, LinearMap.comp_sub]
+  rcases hout with hleft | hright
+  · rw [openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_le
+        A hLN (by omega),
+      openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_le
+        A hLN (by omega)]
+  · rw [openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_lt
+        A hright,
+      openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_lt
+        A (by omega)]
+
+/-- Physical fixed-ambient form of the `Icc` cancellation identity in
+Nachtergaele's proof of Theorem 2.1(i).
+
+Here `G_m` is the kernel projection of the prefix Hamiltonian on `[0,m)`,
+`E_m=G_m-G_{m+1}`, and `Q_n` is the kernel projection of the local Hamiltonian
+on `[n-l,n+1)`. -/
+theorem inner_sum_fixedAmbient_martingaleDifference_openIntervalGroundProjectionES_eq_Icc
+    (A : MPSTensor d D) {L N n l : ℕ} (hLN : L ≤ N) (hn : n < N)
+    (v : EuclideanSpace ℂ (Cfg d N)) :
+    inner ℂ v (∑ m ∈ Finset.range N,
+        (fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference m
+          (openIntervalGroundProjectionES A L l N n
+            ((fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference n v))) =
+      inner ℂ (∑ m ∈ Finset.Icc (n - l) n,
+        (fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference m v)
+        (openIntervalGroundProjectionES A L l N n
+          ((fixedAmbientNestedGroundProjectionsES A L N).martingaleDifference n v)) := by
+  apply inner_sum_martingaleDifference_localProjection_eq_inner_sum_Icc
+    (fixedAmbientNestedGroundProjectionsES A L N)
+    (openIntervalGroundProjectionES A L l N n) N n l hn
+  intro m hout
+  exact fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES
+    A hLN hout
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -81,8 +81,12 @@ theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
       And.intro hkerT hkerTperp
   simpa only [PS, PT, Module.End.mul_eq_comp] using hPTPS.eq.symm
 
+end LinearMap
+
 /-- Orthogonal projections onto nested submodules commute. -/
-theorem _root_.Submodule.starProjection_commute_of_le {U V : Submodule ℂ E}
+theorem Submodule.starProjection_commute_of_le {E : Type*}
+    [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
+    {U V : Submodule ℂ E}
     (hUV : U ≤ V) :
     U.starProjection.toLinearMap.comp V.starProjection.toLinearMap =
       V.starProjection.toLinearMap.comp U.starProjection.toLinearMap := by
@@ -109,8 +113,6 @@ theorem _root_.Submodule.starProjection_commute_of_le {U V : Submodule ℂ E}
           Submodule.starProjection_comp_starProjection_of_le hUV]
       _ = ⟪y, U.starProjection x⟫_ℂ := U.starProjection_isSymmetric y x
   exact hleft.trans hright.symm
-
-end LinearMap
 
 namespace MPSTensor
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FixedAmbient.lean
@@ -39,11 +39,10 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 /-- The kernel projection of a linear map commutes with the kernel projection
 of a commuting symmetric operator.
 
-The point is not merely that the operators commute. Commutation makes
-\(\ker S\) invariant under \(T\); symmetry of \(T\) makes its orthogonal complement
-invariant as well. Hence the orthogonal projection onto \(\ker S\) commutes with
-\(T\), and the same invariant-subspace argument applied to \(\ker T\) gives
-commutation of the two kernel projections. -/
+Commutation makes \(\ker S\) invariant under \(T\); symmetry of \(T\) makes its
+orthogonal complement invariant as well. Hence the orthogonal projection onto
+\(\ker S\) commutes with \(T\), and the same invariant-subspace argument applied
+to \(\ker T\) gives commutation of the two kernel projections. -/
 theorem IsSymmetric.kernelProjection_commute_of_commute {S T : E →ₗ[ℂ] E}
     (hT : T.IsSymmetric)
     (hcomm : S.comp T = T.comp S) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -184,14 +184,8 @@
     \label{def:fixed-volume-prefix-ground-projections}
     \lean{MPSTensor.openPrefixParentHamiltonianES,
         MPSTensor.openPrefixGroundProjectionES,
-        MPSTensor.openIntervalGroundProjectionES,
-        MPSTensor.localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero,
-        MPSTensor.ker_openPrefixParentHamiltonianES_antitone,
-        MPSTensor.openPrefixParentHamiltonianES_isPositive,
-        MPSTensor.openSuffixParentHamiltonianES_isPositive,
-        MPSTensor.fixedAmbientNestedGroundProjectionsES}
+        MPSTensor.openIntervalGroundProjectionES}
     \leanok
-    \uses{def:nested-ground-projection-differences}
     Fix an $N$-site Hilbert space and let $h_i$ denote the nonwrapping
     interaction of length $L$ starting at $i$.  For every $m\geq0$, set
     \begin{align}
@@ -204,9 +198,16 @@
         Q_n & =P_{\ker H_{[n-l,n+1)}},
             & H_{[n-l,n+1)}            & =\sum_{n-l\leq i,\ i+L\leq n+1}h_i.
     \end{align}
-    Each $h_i$ is an orthogonal projection and is therefore positive.  Thus
-    both Hamiltonians are sums of positive projections, and hence are positive
-    and symmetric:
+\end{definition}
+
+\begin{lemma}[Positivity of the fixed-volume Hamiltonians]%
+    \label{lem:fixed-volume-hamiltonians-positive}
+    \lean{MPSTensor.openPrefixParentHamiltonianES_isPositive,
+        MPSTensor.openSuffixParentHamiltonianES_isPositive}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        lem:transported_es_positive}
+    The prefix and interval Hamiltonians are positive and symmetric:
     \begin{align}
         H_m^{(N)}
          & =\sum_{i+L\leq m}h_i\geq0,
@@ -217,12 +218,50 @@
          & H_{[n-l,n+1)}^\dagger
          & =H_{[n-l,n+1)}.
     \end{align}
-    Since enlarging the prefix adds positive local interactions,
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        lem:transported_es_positive}
+    Each $h_i$ is an orthogonal projection and is therefore positive.  Finite
+    sums of positive operators are positive, and every positive operator is
+    symmetric.
+\end{proof}
+
+\begin{theorem}[Nested fixed-volume prefix ground projections]%
+    \label{thm:fixed-volume-prefix-ground-projections-nested}
+    \lean{MPSTensor.localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero,
+        MPSTensor.ker_openPrefixParentHamiltonianES_antitone,
+        MPSTensor.fixedAmbientNestedGroundProjectionsES}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        def:nested-ground-projection-differences,
+        lem:fixed-volume-hamiltonians-positive}
+    If $m\leq n$, then
     \begin{align}
-        \ker H_{m+1}^{(N)} & \subseteq\ker H_m^{(N)},
+        \ker H_n^{(N)} & \subseteq\ker H_m^{(N)},
+                       & \operatorname{ran}G_n^{(N)}
+                       & \subseteq\operatorname{ran}G_m^{(N)}.
     \end{align}
-    so $(G_m^{(N)})_{m\geq0}$ is a nested ground-projection family.
-\end{definition}
+    Hence $(G_m^{(N)})_{m\geq0}$ is a nested ground-projection family.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        lem:fixed-volume-hamiltonians-positive}
+    If $H_n^{(N)}v=0$, then orthogonality of the local projections gives
+    \begin{align}
+        0=\langle v,H_n^{(N)}v\rangle
+         & =\sum_{i+L\leq n}\lVert h_iv\rVert^2.
+    \end{align}
+    Every summand is nonnegative, so $h_iv=0$ whenever $i+L\leq n$.
+    When $m\leq n$, every summand of $H_m^{(N)}$ occurs in $H_n^{(N)}$,
+    and hence $H_m^{(N)}v=0$.  This proves the kernel inclusion, and the
+    range inclusion follows from
+    $\operatorname{ran}G_m^{(N)}=\ker H_m^{(N)}$.
+\end{proof}
 
 \begin{theorem}[Physical outside-window commutation and cancellation]%
     \label{thm:physical-outside-window-martingale-cancellation}
@@ -237,6 +276,8 @@
         MPSTensor.inner_sum_fixedAmbient_martingaleDifference_openIntervalGroundProjectionES_eq_Icc}
     \leanok
     \uses{def:fixed-volume-prefix-ground-projections,
+        lem:fixed-volume-hamiltonians-positive,
+        thm:fixed-volume-prefix-ground-projections-nested,
         thm:outside-window-martingale-cancellation}
     Assume $L\leq N$ and let $E_m=G_m^{(N)}-G_{m+1}^{(N)}$.  Then
     \begin{align}
@@ -254,6 +295,8 @@
 \begin{proof}
     \leanok
     \uses{def:fixed-volume-prefix-ground-projections,
+        lem:fixed-volume-hamiltonians-positive,
+        thm:fixed-volume-prefix-ground-projections-nested,
         thm:outside-window-martingale-cancellation}
     If $m<n-l$, the supports of every summand of $H_m^{(N)}$ and every
     summand of $H_{[n-l,n+1)}$ are disjoint.  Their local interactions commute,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -186,6 +186,7 @@
         MPSTensor.openPrefixGroundProjectionES,
         MPSTensor.openIntervalGroundProjectionES}
     \leanok
+    \uses{rem:euclidean_local_projector_ingredients}
     Fix an $N$-site Hilbert space and let $h_i$ denote the nonwrapping
     interaction of length $L$ starting at $i$.  For every $m\geq0$, set
     \begin{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -191,6 +191,7 @@
         MPSTensor.openSuffixParentHamiltonianES_isPositive,
         MPSTensor.fixedAmbientNestedGroundProjectionsES}
     \leanok
+    \uses{def:nested-ground-projection-differences}
     Fix an $N$-site Hilbert space and let $h_i$ denote the nonwrapping
     interaction of length $L$ starting at $i$.  For every $m\geq0$, set
     \begin{align}
@@ -237,7 +238,7 @@
     \leanok
     \uses{def:fixed-volume-prefix-ground-projections,
         thm:outside-window-martingale-cancellation}
-    Let $E_m=G_m^{(N)}-G_{m+1}^{(N)}$.  Then
+    Assume $L\leq N$ and let $E_m=G_m^{(N)}-G_{m+1}^{(N)}$.  Then
     \begin{align}
         E_mQ_n & =Q_nE_m
                &         & \text{if }m<n-l\text{ or }n<m.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -176,6 +176,84 @@
     and summing over the active interval proves the displayed identity.
 \end{proof}
 
+% Source: References/cond-mat_9410110/main.tex:1060--1073, equation En.
+% Source: References/cond-mat_9410110/main.tex:1206--1220,
+% Theorem 2.1(i), equations Enpsi and Enpsi2.
+
+\begin{definition}[Fixed-volume prefix and interval ground projections]%
+    \label{def:fixed-volume-prefix-ground-projections}
+    \lean{MPSTensor.openPrefixParentHamiltonianES,
+        MPSTensor.openPrefixGroundProjectionES,
+        MPSTensor.openIntervalGroundProjectionES,
+        MPSTensor.fixedAmbientNestedGroundProjectionsES}
+    \leanok
+    Fix an $N$-site Hilbert space and let $h_i$ denote the nonwrapping
+    interaction of length $L$ starting at $i$.  For every $m\geq0$, set
+    \begin{align}
+        H_m^{(N)} & =\sum_{i+L\leq m}h_i,
+                  & G_m^{(N)}             & =P_{\ker H_m^{(N)}}.
+    \end{align}
+    All operators act on the same $N$-site space.  The local interval ground
+    projection in the proof of Theorem~2.1(i) is
+    \begin{align}
+        Q_n & =P_{\ker H_{[n-l,n+1)}},
+            & H_{[n-l,n+1)}            & =\sum_{n-l\leq i,\ i+L\leq n+1}h_i.
+    \end{align}
+    Since enlarging the prefix adds positive local interactions,
+    \begin{align}
+        \ker H_{m+1}^{(N)} & \subseteq\ker H_m^{(N)},
+    \end{align}
+    so $(G_m^{(N)})_{m\geq0}$ is a nested ground-projection family.
+\end{definition}
+
+\begin{theorem}[Physical outside-window commutation and cancellation]%
+    \label{thm:physical-outside-window-martingale-cancellation}
+    \lean{LinearMap.IsSymmetric.kernelProjection_commute_of_commute,
+        MPSTensor.fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES,
+        MPSTensor.inner_sum_fixedAmbient_martingaleDifference_openIntervalGroundProjectionES_eq_Icc}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        thm:outside-window-martingale-cancellation}
+    Let $E_m=G_m^{(N)}-G_{m+1}^{(N)}$.  Then
+    \begin{align}
+        E_mQ_n & =Q_nE_m
+               &         & \text{if }m<n-l\text{ or }n<m.
+    \end{align}
+    Consequently, for $n<N$ and every vector $v$,
+    \begin{align}
+        \left\langle v,
+        \sum_{m=0}^{N-1}E_mQ_nE_nv\right\rangle
+         & =\left\langle\sum_{m=n-l}^{n}E_mv,Q_nE_nv\right\rangle.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fixed-volume-prefix-ground-projections,
+        thm:outside-window-martingale-cancellation}
+    If $m<n-l$, the supports of every summand of $H_m^{(N)}$ and every
+    summand of $H_{[n-l,n+1)}$ are disjoint.  Their local interactions commute,
+    hence the two symmetric Hamiltonians commute.  If symmetric operators $S$
+    and $T$ commute, then $\ker S$ and $(\ker S)^\perp$ are invariant under
+    $T$.  Thus $P_{\ker S}$ commutes with $T$; applying the same argument to
+    $\ker T$ shows
+    \begin{align}
+        P_{\ker S}P_{\ker T} & =P_{\ker T}P_{\ker S}.
+    \end{align}
+    This proves the first range of indices for both $G_m^{(N)}$ and
+    $G_{m+1}^{(N)}$.
+
+    If $n<m$, every local interaction in $H_{[n-l,n+1)}$ also occurs in
+    $H_m^{(N)}$.  Therefore
+    \begin{align}
+        \ker H_m^{(N)} & \subseteq\ker H_{[n-l,n+1)},
+    \end{align}
+    and the corresponding nested orthogonal projections commute.  Subtracting
+    the two prefix identities gives $E_mQ_n=Q_nE_m$ in both index ranges.  The
+    abstract outside-window cancellation theorem now restricts the full sum to
+    $m\in[n-l,n]$.
+\end{proof}
+
 \subsection{Spectator-indexed boundary maps}\label{subsec:spectator_boundary_maps}
 
 The tail and left boundary maps embed virtual-space data into a common

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -236,8 +236,7 @@
         MPSTensor.fixedAmbientNestedGroundProjectionsES}
     \leanok
     \uses{def:fixed-volume-prefix-ground-projections,
-        def:nested-ground-projection-differences,
-        lem:fixed-volume-hamiltonians-positive}
+        def:nested-ground-projection-differences}
     If $m\leq n$, then
     \begin{align}
         \ker H_n^{(N)} & \subseteq\ker H_m^{(N)},

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -203,6 +203,19 @@
         Q_n & =P_{\ker H_{[n-l,n+1)}},
             & H_{[n-l,n+1)}            & =\sum_{n-l\leq i,\ i+L\leq n+1}h_i.
     \end{align}
+    Each $h_i$ is an orthogonal projection and is therefore positive.  Thus
+    both Hamiltonians are sums of positive projections, and hence are positive
+    and symmetric:
+    \begin{align}
+        H_m^{(N)}
+         & =\sum_{i+L\leq m}h_i\geq0,
+         & \bigl(H_m^{(N)}\bigr)^\dagger
+         & =H_m^{(N)},                              \\
+        H_{[n-l,n+1)}
+         & =\sum_{n-l\leq i,\ i+L\leq n+1}h_i\geq0,
+         & H_{[n-l,n+1)}^\dagger
+         & =H_{[n-l,n+1)}.
+    \end{align}
     Since enlarging the prefix adds positive local interactions,
     \begin{align}
         \ker H_{m+1}^{(N)} & \subseteq\ker H_m^{(N)},
@@ -243,10 +256,12 @@
         thm:outside-window-martingale-cancellation}
     If $m<n-l$, the supports of every summand of $H_m^{(N)}$ and every
     summand of $H_{[n-l,n+1)}$ are disjoint.  Their local interactions commute,
-    hence the two symmetric Hamiltonians commute.  If symmetric operators $S$
-    and $T$ commute, then $\ker S$ and $(\ker S)^\perp$ are invariant under
-    $T$.  Thus $P_{\ker S}$ commutes with $T$; applying the same argument to
-    $\ker T$ shows
+    hence the two symmetric Hamiltonians commute.  More generally, suppose
+    that $T$ is symmetric and that an arbitrary linear operator $S$ commutes
+    with $T$.  Then $\ker S$ is invariant under $T$, and symmetry of $T$ makes
+    $(\ker S)^\perp$ invariant as well.  Thus $P_{\ker S}$ commutes with $T$.
+    Since $P_{\ker S}$ is symmetric, applying the same argument to $\ker T$
+    shows
     \begin{align}
         P_{\ker S}P_{\ker T} & =P_{\ker T}P_{\ker S}.
     \end{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -185,6 +185,10 @@
     \lean{MPSTensor.openPrefixParentHamiltonianES,
         MPSTensor.openPrefixGroundProjectionES,
         MPSTensor.openIntervalGroundProjectionES,
+        MPSTensor.localTermES_eq_zero_of_openPrefixParentHamiltonianES_eq_zero,
+        MPSTensor.ker_openPrefixParentHamiltonianES_antitone,
+        MPSTensor.openPrefixParentHamiltonianES_isPositive,
+        MPSTensor.openSuffixParentHamiltonianES_isPositive,
         MPSTensor.fixedAmbientNestedGroundProjectionsES}
     \leanok
     Fix an $N$-site Hilbert space and let $h_i$ denote the nonwrapping
@@ -209,6 +213,12 @@
 \begin{theorem}[Physical outside-window commutation and cancellation]%
     \label{thm:physical-outside-window-martingale-cancellation}
     \lean{LinearMap.IsSymmetric.kernelProjection_commute_of_commute,
+        Submodule.starProjection_commute_of_le,
+        MPSTensor.cyclicWindowsDisjoint_of_nonwrapping_ordered,
+        MPSTensor.openPrefixParentHamiltonianES_commute_openSuffixParentHamiltonianES,
+        MPSTensor.openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_le,
+        MPSTensor.ker_openPrefixParentHamiltonianES_le_ker_openSuffixParentHamiltonianES,
+        MPSTensor.openPrefixGroundProjectionES_commute_openIntervalGroundProjectionES_of_lt,
         MPSTensor.fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES,
         MPSTensor.inner_sum_fixedAmbient_martingaleDifference_openIntervalGroundProjectionES_eq_Icc}
     \leanok


### PR DESCRIPTION
## What changed

- define fixed-final-volume prefix Hamiltonians and their decreasing kernel projections
- define the local interval ground projection on $[n-l,n+1)$
- prove kernel projections commute from commuting symmetric Hamiltonians
- prove $E_mQ_n=Q_nE_m$ for $m<n-l$ or $n<m$
- instantiate the closed-interval martingale cancellation identity
- add formula-driven Chapter 13 coverage

The construction follows `References/cond-mat_9410110/main.tex`, equation `En` at lines 1060-1073 and the proof of Theorem 2.1(i) at lines 1195-1220. It uses one fixed ambient space throughout and does not use periodic coercivity.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient` (3082 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- pinned LaTeX formatting, reader-facing prose, proof-integrity, and diff checks
- exact-head source/API review found no blocking or important findings

Closes #7534
