### PR TITLE
doc(MPDO/RFP): complete final source-review corrections

### DIFF
--- a/TNLean/PEPS/SquareLatticeBoundaryMPO.lean
+++ b/TNLean/PEPS/SquareLatticeBoundaryMPO.lean
@@ -6,23 +6,28 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.Defs
 
 /-!
-# Boundary MPO tensor from a square-lattice PEPS tensor
+# Local contraction pattern for a square-lattice PEPS boundary tensor
 
-This module records the local boundary tensor in the boundary-theory construction
-of Cirac--Perez-Garcia--Schuch--Verstraete. A rank-five component function gives
-one physical leg and four virtual legs in left, right, up, down order. The tensor
-in FigureDavid1 is obtained by contracting both the physical leg and the inward
-(down) virtual leg between the ket and bra copies. The remaining up indices are
-the two physical indices of the boundary MPO, while its left and right bond
-indices each group the corresponding ket and bra indices.
+Under the PEPS RFP hypothesis, arXiv:1606.00608, lines 716--724, identifies the
+contraction in FigureDavid1 with the tensor of the boundary theory. This module
+records only that algebraic contraction pattern for an arbitrary rank-five
+component function; without the RFP hypothesis, it is not asserted to be a
+boundary-theory tensor.
+
+The component function has one physical leg and four virtual legs in left,
+right, up, down order. The FigureDavid1 contraction contracts both the physical
+leg and the inward (down) virtual leg between the ket and bra copies. The
+remaining up indices are the two physical indices of the resulting MPO tensor,
+while its left and right bond indices each group the corresponding ket and bra
+indices.
 
 The source diagram does not label the virtual directions. The names `up` and
 `down` are local to each copy: after choosing the matching inward legs, the
 project represents their common contracted coordinate by the fourth (`down`)
 argument in both component functions.
 
-This is an unconditional local contraction only. It is not a selected transfer
-fixed point or a complete boundary theory.
+The contraction is defined unconditionally. It is not a selected transfer fixed
+point or, without the source's RFP hypothesis, a complete boundary theory.
 
 The source diagram does not require the horizontal and vertical virtual spaces
 to have the same dimension. This module therefore allows dimensions `Dh` and
@@ -48,7 +53,7 @@ namespace PEPS
 
 variable {d Dh Dv : ℕ}
 
-/-- The boundary MPO tensor associated with a translationally invariant
+/-- The FigureDavid1 contraction pattern of a translationally invariant
 square-lattice PEPS component function.
 
 The arguments of `A` are the left and right indices in `Fin Dh`, the up and down
@@ -62,7 +67,9 @@ component formula is
 Thus the common physical index `s` and inward virtual index `b` are contracted,
 the MPO physical coordinates are `u` and `u'`, and its bonds are `(l,l')` and
 `(r,r')`. This is the component form of FigureDavid1 in arXiv:1606.00608,
-lines 721--724.
+lines 721--724. The source identifies it with the boundary-theory tensor under
+the PEPS RFP hypothesis introduced at lines 716--720; for arbitrary `A`, this
+definition records only the algebraic contraction pattern.
 
 The source diagram does not label the virtual directions. The names `up` and
 `down` are local to each copy, and choosing the fourth argument of both

--- a/TNLean/PEPS/SquareLatticeBoundaryPositivity.lean
+++ b/TNLean/PEPS/SquareLatticeBoundaryPositivity.lean
@@ -9,14 +9,17 @@ import TNLean.PEPS.SquareLatticeBoundaryMPO
 /-!
 # Positivity of the local square-lattice PEPS boundary tensor
 
-The local tensor in FigureDavid1 of arXiv:1606.00608 is a Gram contraction.
-The contracted PEPS physical and inward virtual indices form its local
-purification ancilla, and the horizontal PEPS virtual space is its purifying
-bond. Consequently the tensor is an LPDO and hence an MPDO.
+Under the PEPS renormalization hypothesis, arXiv:1606.00608, lines 716--724,
+identifies the contraction in FigureDavid1 with the tensor of the boundary
+theory. The same algebraic contraction is a Gram contraction for every
+rank-five tensor: the contracted PEPS physical and inward virtual indices form
+its local purification ancilla, and the horizontal PEPS virtual space is its
+purifying bond. Consequently this contraction is an LPDO and hence an MPDO.
 
-These are local positivity results only. They do not select a row-transfer
-fixed point or assert the under-specified boundary renormalization equations
-shown later in FigureDavid2.
+These are stronger algebraic positivity results for the displayed contraction,
+not a formalization of the RFP-dependent identification with the boundary
+theory. They do not select a row-transfer fixed point or assert the
+under-specified boundary renormalization equations shown later in FigureDavid2.
 -/
 
 namespace TNLean
@@ -24,14 +27,17 @@ namespace PEPS
 
 variable {d Dh Dv : ℕ}
 
-/-- The local boundary tensor in FigureDavid1 is a locally purifiable density
-operator. Its ancillary coordinate is the pair consisting of the contracted
-PEPS physical index and the contracted inward virtual index, while its
-purifying bond is the horizontal PEPS virtual space.
+/-- The contraction pattern displayed in FigureDavid1 is a locally purifiable
+density operator for every rank-five tensor. Its ancillary coordinate is the
+pair consisting of the contracted PEPS physical index and the contracted
+inward virtual index, while its purifying bond is the horizontal PEPS virtual
+space.
 
-This is only the local positivity statement implicit in FigureDavid1 of
-arXiv:1606.00608, lines 721--724. It does not select a row-transfer fixed point
-or assert the boundary renormalization equations of FigureDavid2. -/
+ArXiv:1606.00608, lines 716--724, uses the PEPS RFP hypothesis to identify this
+contraction with the boundary-theory tensor. The theorem proves the stronger
+algebraic positivity statement for arbitrary `A`; it does not formalize that
+identification, select a row-transfer fixed point, or assert the boundary
+renormalization equations of FigureDavid2. -/
 theorem localBoundaryMPOTensor_isLPDO
     (A : Fin Dh → Fin Dh → Fin Dv → Fin Dv → Fin d → ℂ) :
     MPOTensor.IsLPDO (localBoundaryMPOTensor A) := by
@@ -48,12 +54,15 @@ theorem localBoundaryMPOTensor_isLPDO
     MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
   rfl
 
-/-- The local boundary tensor in FigureDavid1 generates a positive
-semidefinite matrix product operator on every nonempty chain.
+/-- The contraction pattern displayed in FigureDavid1 generates a positive
+semidefinite matrix product operator on every nonempty chain for every
+rank-five tensor.
 
-This follows from the explicit local purification of FigureDavid1 in
-arXiv:1606.00608, lines 721--724, and is independent of the under-specified
-transfer-fixed-point and channel constructions at lines 725--729. -/
+ArXiv:1606.00608, lines 716--724, invokes the PEPS RFP hypothesis when it
+identifies this contraction with the boundary-theory tensor. The present
+result concerns only the algebraic contraction and follows from its explicit
+local purification; it is independent of the under-specified fixed-point and
+channel constructions at lines 725--729. -/
 theorem localBoundaryMPOTensor_isMPDO
     (A : Fin Dh → Fin Dh → Fin Dv → Fin Dv → Fin d → ℂ) :
     MPOTensor.IsMPDO (localBoundaryMPOTensor A) :=

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -273,11 +273,17 @@ construction; they are not attributed to a source theorem.
     If $N>L_{\mathrm{aux}}$, then $N\geq R+L_0$. The source-normalized
     form of \cite[Theorem~12]{PerezGarcia2007Matrix} therefore identifies
     the range-$R$ parent-Hamiltonian kernel with the BNT span. Since
-    $R\leq L_{\mathrm{aux}}$, cyclic-window antitonicity places the
-    range-$L_{\mathrm{aux}}$ kernel inside the range-$R$ kernel. Every BNT
-    vector satisfies the range-$L_{\mathrm{aux}}$ local constraints, which
-    gives the reverse inclusion. Thus the range-$L_{\mathrm{aux}}$ kernel
-    is exactly the BNT span for every $N>L_{\mathrm{aux}}$, and
+    $R\leq L_{\mathrm{aux}}$, cyclic-window antitonicity and the usual
+    frustration-free inclusion give
+    \begin{align}
+        \ker H_{L_{\mathrm{aux}}}^{(N)}
+         & \subseteq \ker H_R^{(N)}
+        =\spn\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\}
+        \subseteq \ker H_{L_{\mathrm{aux}}}^{(N)}.
+        \notag
+    \end{align}
+    Thus the range-$L_{\mathrm{aux}}$ kernel is exactly the BNT span for
+    every $N>L_{\mathrm{aux}}$, and
     \begin{align}
         L_{\mathrm{aux}}
          & \leq 3(D-1)(D^4+1)+D^4
@@ -292,9 +298,17 @@ construction; they are not attributed to a source theorem.
     argument.
 
     In every case enlarge the interaction range to the common value
-    $L=3D^5$. Range antitonicity gives the upper inclusion at $L$, while the
-    usual frustration-free inclusion gives the reverse one, so the
-    all-$N>L$ spanning equation is preserved. Since $D>0$ and $d\geq2$,
+    $L=3D^5$. For every $N>L$, range antitonicity and the
+    frustration-free inclusion give the second kernel sandwich
+    \begin{align}
+        \ker H_L^{(N)}
+         & \subseteq \ker H_{L_{\mathrm{aux}}}^{(N)}
+        =\spn\{\ket{V^{(N)}(A_j)}:1\leq j\leq g\}
+        \subseteq \ker H_L^{(N)}.
+        \notag
+    \end{align}
+    Hence the all-$N>L$ spanning equation is preserved. Since $D>0$ and
+    $d\geq2$,
     \begin{align}
         D^2<2^{2D}\leq d^{2D}\leq d^{3D^5}=d^L.
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_peps_boundary.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_peps_boundary.tex
@@ -19,11 +19,13 @@ makes sense with separate horizontal and vertical dimensions.
     dimension $D_{\mathrm v}$ and bond dimension $D_{\mathrm h}^2$.
 
     The unlabelled diagram at source lines~721--724 of
-    \cite{Cirac2016MPDO_arXiv} depicts this local ket-bra boundary tensor. The
-    source does not label the virtual directions. Directional names are local
-    to each copy. After choosing matching inward legs in the ket and bra copies,
-    we denote their common contracted coordinate by $b$ in both component
-    functions.
+    \cite{Cirac2016MPDO_arXiv} depicts this local ket--bra contraction. Under
+    the PEPS renormalization hypothesis at lines~716--724, the source identifies
+    it with the boundary-theory tensor. For arbitrary $A$, the definition
+    records only the algebraic contraction pattern. The source does not label
+    the virtual directions. Directional names are local to each copy. After
+    choosing matching inward legs in the ket and bra copies, we denote their
+    common contracted coordinate by $b$ in both component functions.
 \end{definition}
 
 \begin{theorem}[Component formula for the local boundary tensor]
@@ -67,9 +69,12 @@ makes sense with separate horizontal and vertical dimensions.
          & = A^s_{l,r,u,b}.
         \notag
     \end{align}
-    Thus the local contraction in FigureDavid1 of
-    \cite[lines~721--724]{Cirac2016MPDO_arXiv} has an LPDO presentation
-    without any transfer-fixed-point or renormalization-channel hypothesis.
+    Under the PEPS renormalization hypothesis at source lines~716--724,
+    \cite{Cirac2016MPDO_arXiv} identifies this contraction with the tensor of
+    the boundary theory. The displayed Gram factorization proves the stronger
+    algebraic statement that the same contraction pattern is an LPDO for every
+    rank-five tensor $A$; this positivity assertion itself requires no transfer
+    fixed point or renormalization channel.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -421,8 +421,18 @@
     relabels the displayed sector decomposition into a BNT presentation of the
     blocked tensor. Normality and eventual linear independence are preserved
     by this relabeling, and the global block gauge gives equality of all
-    positive-length closed matrix-product coefficients. Finally, reindexing
-    the diagonal physical-trace sum by the same bijection leaves each
-    representative's transfer matrix unchanged. The assumed non-nilpotency
-    certificates therefore prove simplicity.
+    positive-length closed matrix-product coefficients. Write $e_1$ for the
+    one-site physical bijection, $\widehat e=e_1\times e_1$ for its induced
+    bijection of ket--bra pairs, and $\widehat e^{\,*}A_j$ for the corresponding
+    relabeling of the $j$-th representative. Since
+    $\widehat e(i,i)=(e_1(i),e_1(i))$, reindexing the diagonal sum gives
+    \begin{align}
+        \mathcal T_{\widehat e^{\,*}A_j}
+         & =\sum_i(\widehat e^{\,*}A_j)^{ii}
+        =\sum_iA_j^{e_1(i),e_1(i)}
+        =\sum_kA_j^{kk}
+        =\mathcal T_{A_j}.
+        \notag
+    \end{align}
+    The assumed non-nilpotency certificates therefore prove simplicity.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -786,16 +786,16 @@
     required rank-one normalization with unit coefficient families.
 \end{proof}
 
-\begin{definition}[Sitewise recovery from a physical isometry]
+\begin{definition}[Sitewise support completion of an adjoint map]
     \label{def:mpdo_sitewise_physical_recovery}
     \lean{MPOTensor.sitewisePhysicalRecovery}
     \leanok
     \uses{def:mpdo_sitewise_physical_matrix,
         thm:matrix_support_completion_cptp}
-    Let $d>0$, let $V:\C^d\to\C^e$ be an isometry, put
+    Let $d>0$, let $V:\C^d\to\C^e$ be a linear map, put
     $W_N=V^{\otimes N}$ and $P_N=W_NW_N^\dagger$, and let
     $\tau_N=d^{-N}I\in\MN{d^N}$ be the uniform faithful density matrix. The
-    sitewise recovery map is
+    sitewise support-completion map is
     \begin{align}
         \mathcal R_N(Y)
          & =W_N^\dagger YW_N
@@ -811,8 +811,9 @@
     \lean{MPOTensor.sitewisePhysicalRecovery_physCloseN}
     \leanok
     \uses{def:mpdo_sitewise_physical_recovery}
-    The map $\mathcal R_N:\MN{e^N}\to\MN{d^N}$ is trace-preserving and
-    completely positive. It is a left inverse to the physical embedding:
+    If $V$ is an isometry, then
+    $\mathcal R_N:\MN{e^N}\to\MN{d^N}$ is trace-preserving and completely
+    positive. It is a left inverse to the physical embedding:
     \begin{align}
         \mathcal R_N(W_NZW_N^\dagger) & =Z.
         \label{eq:mpdo_sitewise_physical_recovery_inverse}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -786,6 +786,61 @@
     required rank-one normalization with unit coefficient families.
 \end{proof}
 
+\begin{definition}[Sitewise recovery from a physical isometry]
+    \label{def:mpdo_sitewise_physical_recovery}
+    \lean{MPOTensor.sitewisePhysicalRecovery}
+    \leanok
+    \uses{def:mpdo_sitewise_physical_matrix,
+        thm:matrix_support_completion_cptp}
+    Let $d>0$, let $V:\C^d\to\C^e$ be an isometry, put
+    $W_N=V^{\otimes N}$ and $P_N=W_NW_N^\dagger$, and let
+    $\tau_N=d^{-N}I\in\MN{d^N}$ be the uniform faithful density matrix. The
+    sitewise recovery map is
+    \begin{align}
+        \mathcal R_N(Y)
+         & =W_N^\dagger YW_N
+        +\tr\bigl((I-P_N)Y(I-P_N)\bigr)\tau_N.
+        \label{eq:mpdo_sitewise_physical_recovery}
+    \end{align}
+\end{definition}
+
+\begin{lemma}[The sitewise recovery is a channel]
+    \label{lem:mpdo_sitewise_physical_recovery}
+    \lean{MPOTensor.sitewisePhysicalRecovery_isKrausCPTP}
+    \lean{MPOTensor.sitewisePhysicalRecovery_apply_singleKrausMap}
+    \lean{MPOTensor.sitewisePhysicalRecovery_physCloseN}
+    \leanok
+    \uses{def:mpdo_sitewise_physical_recovery}
+    The map $\mathcal R_N:\MN{e^N}\to\MN{d^N}$ is trace-preserving and
+    completely positive. It is a left inverse to the physical embedding:
+    \begin{align}
+        \mathcal R_N(W_NZW_N^\dagger) & =Z.
+        \label{eq:mpdo_sitewise_physical_recovery_inverse}
+    \end{align}
+    In particular, if $\widetilde A$ is obtained from an MPO tensor $A$ by the
+    one-site physical isometry $V$, then
+    \begin{align}
+        \mathcal R_N\bigl(\mathcal K_N^{\widetilde A}(X)\bigr)
+         & =\mathcal K_N^A(X)
+        \notag
+    \end{align}
+    for every virtual boundary $X$. This is a general conditional transport
+    construction: it applies after an isometric physical embedding has been
+    supplied. It neither constructs nor implies the refinement channel asserted
+    in Proposition~C.15.
+\end{lemma}
+
+\begin{proof}\leanok
+    Since $W_N^\dagger W_N=I$, the first term of
+    (\ref{eq:mpdo_sitewise_physical_recovery}) has trace
+    $\tr(P_NY)$. The second is completely positive and has trace
+    $\tr((I-P_N)Y)$. Their sum is therefore a channel. On matrices supported by
+    $P_N$, the second term vanishes and conjugation by $W_N^\dagger$ proves
+    (\ref{eq:mpdo_sitewise_physical_recovery_inverse}). The closure identity
+    follows because a sitewise physical change sends every $N$-site closure to
+    $W_N\mathcal K_N^A(X)W_N^\dagger$.
+\end{proof}
+
 % **False source result:** CPSV16 Proposition C.15 asserts the two blocking
 % channels under the complete Case-II standing hypotheses.  The trace-norm
 % witness below refutes the refinement direction itself; it is not merely a
@@ -823,32 +878,43 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpdo_neighboring_trace_obstruction_ambient_properties}
-    For the four-letter rank-one tensor underlying the ambient construction,
-    choose the virtual boundary displayed in the paper-gap note. The resulting
-    physical closures are real diagonal Hermitian matrices, and direct finite
-    summation gives
+    \uses{lem:mpdo_sitewise_physical_recovery,
+        thm:mpdo_neighboring_trace_obstruction_ambient_properties}
+    Let $A$ be the four-letter rank-one tensor underlying the ambient
+    construction, and choose the virtual boundary $X$ displayed in the
+    paper-gap note \cite{gap:cpsv16_prop_c15_blocking_channel_false}. The
+    resulting physical closures are real diagonal Hermitian matrices, and
+    direct finite summation gives
     \begin{align}
-        \lVert\mathcal K_2(X)\rVert_1
+        \lVert\mathcal K_2^A(X)\rVert_1
          & =\frac{337}{250},
-         & \lVert\mathcal K_3(X)\rVert_1
-         & =\lVert\mathcal K_4(X)\rVert_1=\frac{27}{20}.
+         & \lVert\mathcal K_3^A(X)\rVert_1
+         & =\lVert\mathcal K_4^A(X)\rVert_1=\frac{27}{20}.
         \notag
     \end{align}
     A trace-preserving positive map contracts the trace norm on Hermitian
     matrices, but the latter value exceeds the former by $1/500$. Hence the
     two-to-three and two-to-four refinement maps do not exist for this tensor.
 
-    Embed its four physical letters isometrically into the first four letters
-    of the ambient tensor. Conjugation by the sitewise adjoint, completed on
-    the orthogonal complement by preparing a faithful state, gives a
-    trace-preserving completely positive recovery. On the virtual side, one
-    boundary supported on the obstruction block isolates the embedded closure
-    for every chain length; the terminal block contributes zero. Therefore a
-    refinement map for the ambient tensor would descend to one of the two
-    forbidden maps above. Finally, the refinement map of an RFP structure for
-    $K^{[2]}$, transported from blocked coordinates, would give the forbidden
-    two-to-four map for $K$.
+    Let $V$ embed its four physical letters into the first four letters of the
+    ambient tensor, let $\widetilde A$ be the resulting embedded tensor, and let
+    $Y_X$ be the ambient virtual boundary supported on its obstruction block.
+    Moving the virtual gauge to the boundary, discarding the zero terminal
+    block, and applying the physical embedding give, for every $N$,
+    \begin{align}
+        \mathcal K_N^K(Y_X)
+         & =\mathcal K_N^{\widetilde A}(X),
+         &
+        \mathcal K_N^{\widetilde A}(X)
+         & =V^{\otimes N}\mathcal K_N^A(X)(V^{\otimes N})^\dagger.
+        \notag
+    \end{align}
+    Lemma~\ref{lem:mpdo_sitewise_physical_recovery} supplies a
+    trace-preserving completely positive left inverse to the second equality.
+    Therefore a refinement map for the ambient tensor would descend to one of
+    the two forbidden maps above. Finally, the refinement map of an RFP
+    structure for $K^{[2]}$, transported from blocked coordinates, would give
+    the forbidden two-to-four map for $K$.
 \end{proof}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -2710,7 +2710,7 @@ This is the calculation in
 
     The representatives have simultaneous one-letter span
     \begin{align}
-        \operatorname{span}\{(A_0^i,A_1^i):1\leq i\leq25\}
+        \operatorname{span}\{(A_0^i,A_1^i):0\leq i<25\}
         =M_2(\mathbb C)\times\mathbb C.
         \notag
     \end{align}

--- a/docs/paper-gaps/cpsv16_peps_boundary_rfp_specification.tex
+++ b/docs/paper-gaps/cpsv16_peps_boundary_rfp_specification.tex
@@ -89,8 +89,11 @@ in the final renormalization diagram.
 
 \section{The local boundary tensor}
 
-The local boundary tensor in the diagram at source lines~721--724 has two
-ket--bra contractions. Let $d$ be the PEPS physical dimension, and let
+Under the PEPS renormalization hypothesis introduced at source
+lines~716--720, the paper identifies the diagram at lines~721--724 with the
+tensor of the boundary theory. Independently of that identification, the same
+diagram defines an algebraic ket--bra contraction for every rank-five tensor.
+Let $d$ be the PEPS physical dimension, and let
 $D_{\mathrm h}$ and $D_{\mathrm v}$ be its horizontal and vertical virtual
 dimensions. Write $A^s_{l,r,u,b}$ for a PEPS tensor with
 $0\leq s<d$, $0\leq l,r<D_{\mathrm h}$, and
@@ -111,14 +114,18 @@ directions, and directional names are local to each copy. After choosing
 matching inward legs in the ket and bra copies, we denote their common
 contracted coordinate by $b$ in both component functions.
 
-This local formula is formalized without a fixed-point or channel
-hypothesis.
+The formal definition records this algebraic contraction for an arbitrary
+tensor. It does not formalize the source's RFP-dependent identification of the
+contraction with a boundary-theory tensor.
 \footnote{Formal declaration:
     \leanid{TNLean.PEPS.localBoundaryMPOTensor}.}
 Moreover, grouping the contracted pair $(s,b)$ into one ancillary coordinate
 gives a local purification with purifying bond dimension $D_{\mathrm h}$.
-Thus $E_A$ is an LPDO and generates positive semidefinite periodic operators
-at every nonzero length, again without a fixed-point or channel hypothesis.
+Thus the contraction $E_A$ is an LPDO and generates positive semidefinite
+periodic operators at every nonzero length for every $A$. This is a stronger
+algebraic positivity statement than the source needs: the paper invokes RFP to
+identify $E_A$ with the boundary theory, whereas positivity of the displayed
+Gram contraction itself needs neither a fixed point nor a channel.
 \footnote{Formal declarations:
     \leanid{TNLean.PEPS.localBoundaryMPOTensor_isLPDO} and
     \leanid{TNLean.PEPS.localBoundaryMPOTensor_isMPDO}.}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1462,6 +1462,24 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### one-site blocking by canonical physical reindexing — candidate
+- **Pattern:** identify the doubled physical alphabet after one-site blocking
+  with the original doubled alphabet, prove that blocking is the resulting
+  physical relabeling, and reindex the diagonal physical-trace sum to preserve
+  each representative's transfer matrix.
+- **Seen:** 2 occurrences: the general implication
+  `MPOTensor.IsSimpleCanonicalForm.isSimple` in
+  `TNLean/MPS/MPDO/Simple.lean` and the four-letter specialization
+  `MPOTensor.RescalingStableLengthDependentRFP.R_isSimple` in
+  `TNLean/MPS/MPDO/RescalingStableSimple.lean` (post-merge review of PR #7533,
+  2026-08-31).
+- **Abstraction (proposed):** if a third occurrence appears, extract the
+  dimension-parametric one-site doubled equivalence together with lemmas for
+  the blocked-tensor relabeling and invariance of the doubled physical-trace
+  transfer. Specialize the existing proofs to those lemmas.
+- **Notes:** below the rule-of-three promotion threshold. Do not add a one-use
+  wrapper or duplicate predicate surface merely to merge these two proofs.
+
 ### supplied mixed-kernel indicator entries — candidate
 - **Pattern:** case-split the two or four physical-index equalities in an
   explicit mixed-kernel entry, simplify the resulting indicator functions and


### PR DESCRIPTION
### Motivation

- Post-merge review of the CPSV16 MPO/RFP closure campaign found eleven valid exposition and dependency-visibility corrections in PRs #7405, #7516, #7524, #7526, and #7533; issue #7542 records their source-backed classification.
- In `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 716--724 first assume the PEPS RFP equation and only then identify FigureDavid1 with the boundary-theory tensor. The existing Lean theorem proves the distinct, stronger algebraic fact that the displayed contraction is locally purifiable for arbitrary tensor data.
- The Blueprint proofs also omitted the kernel sandwiches, ambient-isolation and physical-embedding identities, and doubled-index reindexing equation that carry the checked Lean proof paths.

### Description

- Qualify the FigureDavid1 definition, theorem, and paper-gap prose throughout: the source's boundary-theory identification is RFP-dependent, while `localBoundaryMPOTensor` and its Gram/LPDO positivity are unconditional algebraic constructions.
- Display both parent-Hamiltonian kernel sandwiches, the Proposition C.15 counterexample's ambient-isolation and physical-embedding equations, and the physical-trace transfer equality under the induced ket--bra reindexing.
- Add a Blueprint definition and lemma for the existing sitewise physical recovery. The definition assumes only `d > 0` and permits arbitrary `V`, matching the Lean construction; the lemma imposes that `V` is an isometry, matching the channel, left-inverse, and closure theorems. The exact support-completion formula is displayed, and the recovery is marked as a conditional transport helper which neither constructs nor implies Proposition C.15’s false refinement channel.
- Correct the `Fin 25` span to the zero-based range `0 <= i < 25` and record the two occurrences of one-site physical reindexing as a proof-pattern candidate below the rule-of-three threshold.

### Statement-integrity audit

- **Paper assumptions versus Lean assumptions:** no Lean declaration signature changes. CPSV16’s FigureDavid1 boundary-theory identification uses the PEPS RFP hypothesis at lines 716--724; Lean’s arbitrary-tensor contraction and positivity results are now explicitly presented as a project-general algebraic statement, not as that source implication. The recovery definition assumes only `d > 0` and arbitrary `V`, matching `[NeZero d]`; the channel, left-inverse, and closure lemma separately assumes that `V` is an isometry, matching the three linked theorems.
- **Paper conclusion versus Lean conclusion:** no conclusion is weakened or strengthened. The Blueprint now separates the source's conditional identification from unconditional Gram positivity, and it records the exact already-proved recovery, kernel, closure, and transfer identities used in the corresponding arguments.
- **Relevant definitions:** `TNLean.PEPS.localBoundaryMPOTensor`, `MPOTensor.sitewisePhysicalRecovery`, the finite-range parent-Hamiltonian kernels, and `MPOTensor.doubledPhysTraceTransfer`.
- **Proof status:** all linked Lean proofs remain complete. This change introduces no `sorry`, `axiom`, proof term, or new mathematical hypothesis.
- **Faithfulness verdict:** faithful after correction. The remaining PEPS bulk-to-boundary RFP implication is still explicitly retained as the source-level question #7371; the general recovery remains a conditional helper rather than Proposition C.15.
- **Tracking:** closes concrete native child #7542 under continuation tracker #7480. The final campaign tracker #7338 remains open until these corrections are merged and all affected review threads are formally resolved.

### Testing

- `scripts/lake_build_locked.sh TNLean.PEPS.SquareLatticeBoundaryPositivity`
- `lake env lean TNLean/PEPS/SquareLatticeBoundaryMPO.lean`
- `lake env lean TNLean/PEPS/SquareLatticeBoundaryPositivity.lean`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/SquareLatticeBoundaryMPO.lean TNLean/PEPS/SquareLatticeBoundaryPositivity.lean || true`
- `python3 scripts/test_audit_cpsv16_labels.py && python3 scripts/audit_cpsv16_labels.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/test_blueprint_lean_sync.py`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7,177 of 7,177 entries in sync on the final base)
- `python3 scripts/fetch_tenkz.py` followed by the tenkz lint, picture-pipeline, PEPS-geometry, and coefficient-routing checks
- `chktex` and the pinned `latexindent` byte comparison
- `./scripts/generate_paper_aux.sh 1606.00608`
- `./scripts/generate_paper_aux.sh 2502.20257`
- `texra-blueprint paper-gaps check`
- `git diff origin/main...HEAD --check`

The local kernel-level `checkdecls` invocation stopped before declaration checking because the focused fresh-worktree cache lacked the root `TNLean.olean`; the required CI build and declaration-check jobs remain the authoritative gate.

---
Closes #7542

### Agent assistance

- OpenAI Codex (GPT-5) compared the source, Blueprint, gap notes, and Lean declarations; prepared the documentation-only corrections; ran the validations above; and maintained issue/review tracking. An independent Codex subagent reviewed the exact diff hash and found no statement-integrity blocker.


