### PR TITLE
feat(PEPS): prove cycle bond uniformity

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -26,6 +26,7 @@ import TNLean.PEPS.CycleMPSOverlapCapstone
 import TNLean.PEPS.CycleMPSTensor
 import TNLean.PEPS.CycleMPSTranslationInvariant
 import TNLean.PEPS.CycleMPSWordTransport
+import TNLean.PEPS.CycleShiftBondUniformity
 import TNLean.PEPS.Defs
 import TNLean.PEPS.EdgeGaugeExtraction
 import TNLean.PEPS.EdgeGaugeFamily

--- a/TNLean/PEPS/CycleMPSConstantDescription.lean
+++ b/TNLean/PEPS/CycleMPSConstantDescription.lean
@@ -35,9 +35,11 @@ state.
 **Scope restriction (uniform bond dimension):** the source corollary also
 concludes that all per-bond dimensions of the original site-dependent
 representation are equal; in the uniform `MPSChainTensor d D n` setting that
-clause is built into the type and carries no content.  The per-edge
-bond-dimension form, which makes the equal-dimension conclusion non-vacuous,
-remains the follow-up recorded in
+clause is built into the type and carries no content.  For a cycle-graph tensor
+with one dimension per edge, `bondDim_eq_of_isCycleShiftInvariantState` now
+proves the source's equal-dimension conclusion.  The remaining follow-up is the
+explicit reindexing from those propositionally equal edge spaces to the uniform
+closed-chain representation used by this theorem; it is recorded in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 ## References

--- a/TNLean/PEPS/CycleShiftBondUniformity.lean
+++ b/TNLean/PEPS/CycleShiftBondUniformity.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Logic.Equiv.Fin.Rotate
+
+import TNLean.Algebra.FinCyclicInduction
+import TNLean.PEPS.CycleMPSTensor
+import TNLean.PEPS.FundamentalTheorem
+import TNLean.PEPS.IsoTransport
+
+/-!
+# Bond dimensions of a cyclically invariant injective MPS
+
+The Applications-section corollary of arXiv:1804.04964 begins with a
+site-dependent injective MPS `A₁, …, Aₙ` on a closed chain.  Translational
+invariance identifies its state with the state of the one-site cyclic shift
+`A₂, …, Aₙ, A₁`.  The source applies the injective MPS Fundamental Theorem to
+these two descriptions and obtains an invertible matrix on every bond; in
+particular, adjacent bond dimensions agree (lines 1803--1842 of
+`Papers/1804.04964/paper_normal.tex`).
+
+Here a site-dependent chain with possibly different bond dimensions is a
+`Tensor (SimpleGraph.cycleGraph n) d`.  The cyclic successor permutation is a
+graph automorphism (`cycleRotate`), and transport by its inverse places the
+tensor at site `v + 1` at site `v` (`Tensor.cycleShift`).  Vertex injectivity is
+preserved by transport, so the graph-level injective Fundamental Theorem
+applies to a tensor and its cyclic shift.  Equality of its bond-dimension
+functions then gives the source's adjacent-bond equality, and cyclic induction
+gives equality of all bond dimensions on the closed chain.
+
+This file establishes only the bond-dimension clause of the source corollary.
+It does not construct the repeated tensor `B` from lines 1843--1889.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Applications section, corollary and proof lines 1803--1890 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {n d : ℕ} [NeZero n]
+
+/-! ### The one-site rotation of the cycle -/
+
+/-- The cyclic successor permutation `v ↦ v + 1` as an automorphism of the
+cycle graph.
+
+Source: arXiv:1804.04964, Applications section, lines 1815--1827 of
+`Papers/1804.04964/paper_normal.tex`, where the second MPS description is the
+one-site cyclic translate of the first. -/
+def cycleRotate (hn : 3 ≤ n) :
+    SimpleGraph.cycleGraph n ≃g SimpleGraph.cycleGraph n := by
+  exact
+    { toEquiv := finRotate n
+      map_rel_iff' := by
+        intro u v
+        rw [cycleGraph_adj_iff_add_one hn, cycleGraph_adj_iff_add_one hn]
+        simp only [finRotate_apply]
+        constructor
+        · rintro (h | h)
+          · exact Or.inl (add_right_cancel h)
+          · exact Or.inr (add_right_cancel h)
+        · rintro (h | h)
+          · exact Or.inl (congrArg (fun x : Fin n => x + 1) h)
+          · exact Or.inr (congrArg (fun x : Fin n => x + 1) h) }
+
+/-- The one-site cycle rotation sends site `v` to its cyclic successor.
+
+Source: arXiv:1804.04964, Applications section, lines 1815--1827 of
+`Papers/1804.04964/paper_normal.tex`. -/
+@[simp] theorem cycleRotate_apply (hn : 3 ≤ n) (v : Fin n) :
+    cycleRotate hn v = v + 1 := by
+  exact finRotate_apply v
+
+/-- Rotating the cycle carries the bond from `v` to `v + 1` to the next bond,
+from `v + 1` to `v + 2`.
+
+Source: arXiv:1804.04964, Applications section, lines 1828--1842 of
+`Papers/1804.04964/paper_normal.tex`, where the Fundamental Theorem gauges are
+indexed by successive bonds. -/
+theorem Edge.map_cycleRotate_cycleSuccEdge (hn : 3 ≤ n) (v : Fin n) :
+    Edge.map (cycleRotate hn) (cycleSuccEdge hn v) = cycleSuccEdge hn (v + 1) := by
+  symm
+  rw [cycleSuccEdge]
+  apply Edge.ofAdj_eq_of_endpoints
+  have hsource :
+      (((cycleSuccEdge hn v).1.1 = v ∧ (cycleSuccEdge hn v).1.2 = v + 1) ∨
+        ((cycleSuccEdge hn v).1.1 = v + 1 ∧ (cycleSuccEdge hn v).1.2 = v)) := by
+    rw [cycleSuccEdge]
+    exact Edge.ofAdj_endpoints (cycleGraph_adj_succ hn v)
+  have hmap := Edge.map_endpoints (cycleRotate hn) (cycleSuccEdge hn v)
+  rcases hsource with hs | hs <;> rcases hmap with hm | hm
+  · exact Or.inl ⟨by rw [hm.1, hs.1, cycleRotate_apply],
+      by rw [hm.2, hs.2, cycleRotate_apply]⟩
+  · exact Or.inr ⟨by rw [hm.2, hs.1, cycleRotate_apply],
+      by rw [hm.1, hs.2, cycleRotate_apply]⟩
+  · exact Or.inr ⟨by rw [hm.2, hs.2, cycleRotate_apply],
+      by rw [hm.1, hs.1, cycleRotate_apply]⟩
+  · exact Or.inl ⟨by rw [hm.1, hs.2, cycleRotate_apply],
+      by rw [hm.2, hs.1, cycleRotate_apply]⟩
+
+/-! ### Cyclic shift and state invariance -/
+
+/-- The site-dependent tensor family shifted as in the source,
+`A₁, …, Aₙ ↦ A₂, …, Aₙ, A₁`.  Transport is taken along the inverse rotation,
+so the transported tensor at site `v` comes from site `v + 1`.
+
+Source: arXiv:1804.04964, Applications section, lines 1815--1827 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def Tensor.cycleShift (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hn : 3 ≤ n) : Tensor (SimpleGraph.cycleGraph n) d :=
+  A.transport (cycleRotate hn).symm
+
+/-- The state of a site-dependent closed chain is invariant under the one-site
+cyclic shift when it agrees with the state generated by
+`A₂, …, Aₙ, A₁`.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1827 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsCycleShiftInvariantState (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hn : 3 ≤ n) : Prop :=
+  SameState A (A.cycleShift hn)
+
+/-! ### Adjacent and cyclewise bond-dimension equality -/
+
+/-- Applying the injective PEPS Fundamental Theorem to a site-dependent closed
+chain and its one-site cyclic shift gives the source's family of invertible
+bond gauges `Zᵢ`.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1842 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem gaugeEquiv_cycleShift_of_isCycleShiftInvariantState
+    (hn : 3 ≤ n) (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hA : IsVertexInjective A) (hTI : IsCycleShiftInvariantState A hn)
+    (hpos : ∀ e : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim e) :
+    GaugeEquiv A (A.cycleShift hn) := by
+  have hconn : (SimpleGraph.cycleGraph n).Connected :=
+    ⟨SimpleGraph.cycleGraph_preconnected⟩
+  apply fundamentalTheorem_PEPS A (A.cycleShift hn) hA
+      (hA.transport (cycleRotate hn).symm) hTI hpos
+  · intro e
+    exact hpos (Edge.map (cycleRotate hn) e)
+  · exact hconn
+
+/-- Adjacent bonds of a cyclically invariant injective closed-chain MPS have
+the same dimension: if `Dᵢ` is the dimension of the bond from site `i` to
+site `i + 1`, then `Dᵢ = Dᵢ₊₁`.
+
+This is the first conclusion of the Applications-section corollary.  It is
+obtained from the bond-dimension equality in the injective Fundamental Theorem
+applied to `A₁, …, Aₙ` and `A₂, …, Aₙ, A₁`.
+
+Source: arXiv:1804.04964, Applications section, corollary line 1804 and proof
+lines 1807--1842 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_cycleSuccEdge_add_one_eq_of_isCycleShiftInvariantState
+    (hn : 3 ≤ n) (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hA : IsVertexInjective A) (hTI : IsCycleShiftInvariantState A hn)
+    (hpos : ∀ e : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim e)
+    (v : Fin n) :
+    A.bondDim (cycleSuccEdge hn (v + 1)) = A.bondDim (cycleSuccEdge hn v) := by
+  obtain ⟨hDim, _, _⟩ :=
+    gaugeEquiv_cycleShift_of_isCycleShiftInvariantState hn A hA hTI hpos
+  have h := congrFun hDim (cycleSuccEdge hn v)
+  rw [Tensor.cycleShift, Tensor.transport_bondDim] at h
+  have h' : A.bondDim (cycleSuccEdge hn v) =
+      A.bondDim (Edge.map (cycleRotate hn) (cycleSuccEdge hn v)) := by
+    simpa only [RelIso.symm_symm] using h
+  rw [Edge.map_cycleRotate_cycleSuccEdge] at h'
+  exact h'.symm
+
+/-- All bonds of a cyclically invariant injective closed-chain MPS have the
+same dimension.
+
+Source: arXiv:1804.04964, Applications section, corollary line 1804 and proof
+lines 1807--1842 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_eq_of_isCycleShiftInvariantState
+    (hn : 3 ≤ n) (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hA : IsVertexInjective A) (hTI : IsCycleShiftInvariantState A hn)
+    (hpos : ∀ e : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim e)
+    (e f : Edge (SimpleGraph.cycleGraph n)) :
+    A.bondDim e = A.bondDim f := by
+  obtain ⟨u, rfl⟩ := cycleSuccEdge_surjective hn e
+  obtain ⟨v, rfl⟩ := cycleSuccEdge_surjective hn f
+  have hzero (w : Fin n) :
+      A.bondDim (cycleSuccEdge hn w) = A.bondDim (cycleSuccEdge hn 0) :=
+    Fin.cyclic_induction
+      (P := fun i => A.bondDim (cycleSuccEdge hn i) = A.bondDim (cycleSuccEdge hn 0))
+      rfl (fun i hi =>
+        (bondDim_cycleSuccEdge_add_one_eq_of_isCycleShiftInvariantState
+          hn A hA hTI hpos i).trans hi) w
+  exact (hzero u).trans (hzero v).symm
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/IsoTransport.lean
+++ b/TNLean/PEPS/IsoTransport.lean
@@ -127,11 +127,33 @@ def IncidentEdge.toSymm (φ : G ≃g G') (w : W) (ie : IncidentEdge G (φ.symm w
     have h := Edge.map_incident φ ie.2
     rwa [φ.apply_symm_apply] at h⟩
 
+/-- The inverse of `IncidentEdge.toSymm`: carry an edge incident to `w` back
+through `φ.symm`, obtaining an edge incident to `φ.symm w`. -/
+def IncidentEdge.fromSymm (φ : G ≃g G') (w : W) (ie' : IncidentEdge G' w) :
+    IncidentEdge G (φ.symm w) :=
+  ⟨Edge.map φ.symm ie'.1, Edge.map_incident φ.symm ie'.2⟩
+
 omit [Fintype V] [Fintype W] in
 @[simp] theorem IncidentEdge.toSymm_coe (φ : G ≃g G') (w : W)
     (ie : IncidentEdge G (φ.symm w)) :
     (IncidentEdge.toSymm φ w ie).1 = Edge.map φ ie.1 :=
   rfl
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem IncidentEdge.fromSymm_coe (φ : G ≃g G') (w : W)
+    (ie' : IncidentEdge G' w) :
+    (IncidentEdge.fromSymm φ w ie').1 = Edge.map φ.symm ie'.1 :=
+  rfl
+
+omit [Fintype V] [Fintype W] in
+/-- Every edge incident to `w` comes from an edge incident to `φ.symm w`. -/
+theorem IncidentEdge.toSymm_surjective (φ : G ≃g G') (w : W) :
+    Function.Surjective (IncidentEdge.toSymm φ w) := by
+  intro ie'
+  refine ⟨IncidentEdge.fromSymm φ w ie', ?_⟩
+  apply Subtype.ext
+  simp only [IncidentEdge.toSymm_coe, IncidentEdge.fromSymm_coe,
+    Edge.map_map_symm]
 
 /-! ### Transport of a tensor along a graph isomorphism -/
 
@@ -160,6 +182,61 @@ omit [Fintype V] [Fintype W] in
 @[simp] theorem Tensor.transport_bondDim (A : Tensor G d) (φ : G ≃g G') (e' : Edge G') :
     (A.transport φ).bondDim e' = A.bondDim (Edge.map φ.symm e') :=
   rfl
+
+omit [Fintype V] [Fintype W] in
+/-- Pull a virtual configuration incident to `w` back to the incident edges at
+`φ.symm w`.  This is the reindexing appearing in `Tensor.transport`. -/
+noncomputable def localVirtualConfigPullback (A : Tensor G d) (φ : G ≃g G') (w : W)
+    (η' : (ie' : IncidentEdge G' w) → Fin ((A.transport φ).bondDim ie'.1))
+    (ie : IncidentEdge G (φ.symm w)) : Fin (A.bondDim ie.1) :=
+  finCongr
+    (show A.bondDim (Edge.map φ.symm (IncidentEdge.toSymm φ w ie).1) =
+        A.bondDim ie.1 by
+      simp only [IncidentEdge.toSymm_coe, Edge.map_symm_map])
+    (η' (IncidentEdge.toSymm φ w ie))
+
+omit [Fintype V] [Fintype W] in
+/-- Pullback of local virtual configurations through a graph isomorphism is
+injective: every target incident edge has a unique source incident edge. -/
+theorem localVirtualConfigPullback_injective (A : Tensor G d) (φ : G ≃g G') (w : W) :
+    Function.Injective (localVirtualConfigPullback A φ w) := by
+  intro η' ξ' h
+  funext ie'
+  obtain ⟨ie, rfl⟩ := IncidentEdge.toSymm_surjective φ w ie'
+  have hval := congrArg Fin.val (congrFun h ie)
+  change (η' (IncidentEdge.toSymm φ w ie)).val =
+    (ξ' (IncidentEdge.toSymm φ w ie)).val at hval
+  exact Fin.ext hval
+
+omit [Fintype V] [Fintype W] in
+/-- Transporting a tensor reindexes, but does not change, each local family of
+physical vectors. -/
+theorem Tensor.transport_component_localVirtualConfigPullback
+    (A : Tensor G d) (φ : G ≃g G') (w : W)
+    (η' : (ie' : IncidentEdge G' w) → Fin ((A.transport φ).bondDim ie'.1)) :
+    (A.transport φ).component w η' =
+      A.component (φ.symm w) (localVirtualConfigPullback A φ w η') := by
+  rfl
+
+omit [Fintype V] [Fintype W] in
+/-- Vertex injectivity is invariant under transport along a graph isomorphism.
+The local virtual configurations are only reindexed by the induced bijection on
+incident edges.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1842 of
+`Papers/1804.04964/paper_normal.tex`, where the injective MPS is compared with
+its one-site cyclic translate through the injective Fundamental Theorem. -/
+theorem IsVertexInjective.transport {A : Tensor G d} (hA : IsVertexInjective A)
+    (φ : G ≃g G') : IsVertexInjective (A.transport φ) := by
+  intro w
+  have h := (hA (φ.symm w)).comp (localVirtualConfigPullback A φ w)
+    (localVirtualConfigPullback_injective A φ w)
+  have heq : A.component (φ.symm w) ∘ localVirtualConfigPullback A φ w =
+      (A.transport φ).component w := by
+    funext η'
+    exact (Tensor.transport_component_localVirtualConfigPullback A φ w η').symm
+  rw [heq] at h
+  exact h
 
 /-- The virtual configurations of `A.transport φ` correspond to those of `A` by the
 edge action of `φ`: a configuration on the edges of `G'` is the same data as a

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -5,12 +5,13 @@ carrying tensors $A_1, \ldots, A_5$ whose two-site windows are injective.
 The entries above specialize to one repeated tensor; the remaining entries
 of this section formalize the site-dependent setting itself. A closed
 chain carries one tensor per site, windows are arcs of consecutive sites,
-and the closed-chain corollary delivers one gauge per bond. Throughout,
-all sites share one physical dimension $d$ and all bonds one bond
-dimension $D$; the source poses no restriction on the local dimensions of
-the site-dependent tensors, and the uniform-dimension restriction is
-recorded in the route note
-(\cite{gap:peps_normal_ft_section3_route}).
+and the closed-chain corollary delivers one gauge per bond. Most of the
+matrix-chain statements below take one physical dimension $d$ and one bond
+dimension $D$. For the Applications-section cyclic-shift corollary, the
+cycle-graph formulation instead retains one dimension $D_e$ per bond and
+derives their equality from the injective Fundamental Theorem. The remaining
+uniform-dimension restriction on the repeated-tensor construction is recorded
+in the route note (\cite{gap:peps_normal_ft_section3_route}).
 
 \begin{definition}[Arc products and window injectivity of a site-dependent
         chain]%
@@ -315,6 +316,54 @@ recorded in the route note
     $A_1,\ldots,A_{n-1},A_0$.
 \end{definition}
 
+\begin{definition}[Cyclic shift of a cycle-graph tensor]%
+    \label{def:peps_cycle_tensor_cyclic_shift}
+    \lean{TNLean.PEPS.cycleRotate}
+    \lean{TNLean.PEPS.Tensor.cycleShift}
+    \lean{TNLean.PEPS.IsCycleShiftInvariantState}
+    \leanok
+    \uses{def:peps_tensor, def:peps_same_state}
+    On the cycle graph with $n\ge3$ sites, let $r(v)=v+1$ be the one-site
+    rotation. The cyclic shift of a site-dependent tensor family
+    $A_0,\ldots,A_{n-1}$ is the transport along $r^{-1}$, so its tensor at
+    site $v$ is $A_{v+1}$. Thus the shifted family is
+    $A_1,\ldots,A_{n-1},A_0$, exactly as in
+    \cite[lines~1807--1827]{Molnar2018NormalPEPS}. The generated state is
+    cyclic-shift invariant when the original and shifted families generate
+    the same closed-chain state.
+\end{definition}
+
+\begin{corollary}[Bond dimensions of a cyclic-shift-invariant injective MPS]%
+    \label{cor:peps_cycle_shift_bond_uniform}
+    \lean{TNLean.PEPS.gaugeEquiv_cycleShift_of_isCycleShiftInvariantState}
+    \lean{TNLean.PEPS.bondDim_cycleSuccEdge_add_one_eq_of_isCycleShiftInvariantState}
+    \lean{TNLean.PEPS.bondDim_eq_of_isCycleShiftInvariantState}
+    \leanok
+    \uses{def:peps_cycle_tensor_cyclic_shift, thm:fundamentalTheorem_PEPS, def:cycleTensorOfMPS}
+    Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS on
+    $n\ge3$ sites, with one positive dimension $D_e$ for each bond $e$.
+    If its generated state is invariant under the cyclic shift
+    $A_v\mapsto A_{v+1}$, then the injective Fundamental Theorem compares
+    the family with its shift by invertible matrices on the corresponding
+    bonds. Consequently the bond from $v$ to $v+1$ and the bond from
+    $v+1$ to $v+2$ have the same dimension. Iterating around the cycle gives
+    $D_e=D_f$ for every pair of bonds $e,f$.
+
+    This is the ``all bond dimensions are the same'' clause of the
+    Applications-section corollary in
+    \cite[lines~1803--1842]{Molnar2018NormalPEPS}. Positivity excludes empty
+    virtual spaces, the same counterexample-backed correction as in the
+    injective Fundamental Theorem.
+\end{corollary}
+\begin{proof}\leanok
+    Transport along the inverse rotation preserves injectivity and replaces
+    the bond-dimension function $D_e$ by $D_{r(e)}$. Apply the injective
+    Fundamental Theorem to the original and shifted families. Equality of
+    their bond-dimension functions gives $D_e=D_{r(e)}$; rotation sends the
+    successor bond at $v$ to the successor bond at $v+1$. Cyclic induction
+    then proves equality on all bonds.
+\end{proof}
+
 \begin{corollary}[Gauge comparison with the cyclic shift]%
     \label{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_cyclicShift}
@@ -414,6 +463,42 @@ recorded in the route note
     $\lambda\ne0$. Since $\C$ is algebraically closed, there is an
     $n$-th root $c^n=\lambda^{-1}$; the rescaled tensor $cB$ is still
     injective and its constant chain generates the same closed state.
+\end{proof}
+
+\begin{corollary}[Translation-invariant description of an injective closed MPS chain,
+        per-bond form]%
+    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+    \notready
+    \uses{cor:peps_cycle_shift_bond_uniform, cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
+    Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS on
+    $n\ge3$ sites, with positive dimensions $D_e$ on its individual bonds.
+    If the closed-chain state is invariant under the cyclic shift
+    $A_v\mapsto A_{v+1}$, then there are a positive integer $D$ and an
+    injective tensor $B$ of $D\times D$ matrices such that $D_e=D$ for every
+    bond $e$ and
+    \begin{align}
+        \Coeff_A(\sigma)
+         & =
+        \tr\!\left(B^{\sigma_0}\cdots B^{\sigma_{n-1}}\right).
+        \notag
+    \end{align}
+    for every physical configuration $\sigma$.
+
+    This is the full per-bond statement of
+    \cite[lines~1803--1890]{Molnar2018NormalPEPS}. The equality $D_e=D$ is
+    Corollary~\ref{cor:peps_cycle_shift_bond_uniform}; what remains is to
+    transport the now-equal virtual spaces into the uniform closed-chain
+    representation and apply the already proved $L_i,R_i$ telescoping and
+    seam closure.
+\end{corollary}
+\begin{proof}
+    The source first compares the family with its cyclic shift, obtaining
+    adjacent bond isomorphisms and hence one common dimension $D$. After
+    identifying every bond with $\C^D$, its products $L_i$ and $R_i$ express
+    every $A_i$ through $A_0$; the common residual operation is absorbed into
+    one repeated tensor $B$. The bond-uniformity step is complete. The explicit
+    reindexing to the uniform closed-chain representation remains to be
+    supplied.
 \end{proof}
 
 \begin{corollary}[Translation-invariant description of an injective 2D PEPS,

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2508,7 +2508,8 @@ of states nor the root-of-unity conditions enter.
 
 The Applications section contains a different translation-invariance
 corollary (lines 1801--1890 of
-\path{Papers/1804.04964/paper_normal.tex}, Ref.~\cite{Molnar2018NormalPEPS}), tracked by \ghissue{2920}. Its
+\path{Papers/1804.04964/paper_normal.tex}, Ref.~\cite{Molnar2018NormalPEPS}),
+whose full per-bond form is tracked by \ghissue{3371}. Its
 input is a single site-dependent injective MPS whose resulting closed-chain
 state is invariant under the cyclic shift. Its conclusion is not a gauge
 between two given tensor families: the proof applies the non-translation
@@ -2531,21 +2532,30 @@ After telescoping the gauges obtained by comparing the family with its cyclic
 shift, the source chooses $B=A_1Z_1^{-1}$ in
 (\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}).
 
-This corollary is not covered by the two-tensor results above. The already
-formalized statements compare two supplied tensors, or two supplied repeated
-tensors, with the same closed-chain state. They do not start from one
-site-dependent family and a cyclic-shift invariance hypothesis on its state,
-and they do not construct the comparison tensor internally. A uniform
-matrix-tensor version would be faithful to the existence of the repeated
-description, but would make the source's ``all bond dimensions are the same''
-conclusion vacuous: the type already fixes one bond dimension \(D\). The fully
-faithful statement therefore requires a per-bond, rectangular matrix model in
-which the adjacent invertible gauges first imply equality of the bond
-dimensions. Until that vocabulary exists, the intended first theorem is the
-uniform-\(D\) existence statement, carrying this scope restriction explicitly;
-the per-bond-dimension theorem remains a separate follow-up. Under a prior
-uniform bond-dimension hypothesis on the family $A_i$, the initial restricted
-statement is
+The equal-bond-dimension implication in
+(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_equal_bond_dimensions})
+is now formalized without introducing a second rectangular matrix-chain type.
+A site-dependent chain with one dimension per bond is represented by
+\leanid{TNLean.PEPS.Tensor} on the cycle graph. The automorphism
+\leanid{TNLean.PEPS.cycleRotate} is the cyclic successor $v\mapsto v+1$, and
+\leanid{TNLean.PEPS.Tensor.cycleShift} transports along its inverse, so that
+the tensor at site $v$ is $A_{v+1}$, exactly the family displayed at source
+lines 1819--1826. Vertex injectivity is preserved by graph transport
+(\leanid{TNLean.PEPS.IsVertexInjective.transport}). Hence the injective PEPS
+Fundamental Theorem applies to the original tensor and its shifted transport:
+\leanid{TNLean.PEPS.gaugeEquiv_cycleShift_of_isCycleShiftInvariantState}
+delivers the source's bond gauges. Reading its bond-dimension equality through
+the rotation of successor edges gives
+\leanid{TNLean.PEPS.bondDim_cycleSuccEdge_add_one_eq_of_isCycleShiftInvariantState},
+and cyclic induction gives equality on every pair of cycle edges in
+\leanid{TNLean.PEPS.bondDim_eq_of_isCycleShiftInvariantState}. These results
+carry the explicit positivity assumption inherited from the corrected
+injective Fundamental Theorem; it excludes empty virtual spaces.
+
+The repeated-tensor implication in
+(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}) still has
+two complementary pieces rather than one end-to-end theorem. Under a prior
+uniform bond-dimension hypothesis on the family $A_i$, the proved statement is
 \begin{align}
     T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n)
         &\Longrightarrow
@@ -2556,7 +2566,7 @@ statement is
 Thus (\ref{eq:peps_normal_ft_section3_route_uniform_bond_repeated_tensor})
 omits the equal-bond-dimension conclusion in
 (\ref{eq:peps_normal_ft_section3_route_cyclic_shift_equal_bond_dimensions})
-because the formal type assumes it.
+because its matrix-chain type assumes it.
 The blueprint records this restricted target as
 \path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}, now
 formalized as
@@ -2571,12 +2581,18 @@ scalar, but not necessarily the identity, so an \(n\)-th root (available since
 \(\mathbb{C}\) is algebraically closed) is needed to fold the residual phase
 into the repeated tensor.
 
-\emph{Verdict: scope restriction.} The uniform-\(D\) theorem records the
-existence of the repeated injective tensor \(B\), but it cannot express the
-source's equal-bond-dimension conclusion as a theorem with mathematical
-content: the type \path{MPSChainTensor d D n} already fixes one bond dimension.
-The per-bond rectangular version, in which adjacent invertible gauges first
-imply equality of the bond dimensions, remains the follow-up.
+\emph{Verdict: the bond-dimension clause is complete; the end-to-end
+corollary remains a scope restriction.} The missing step is now an explicit
+reindexing theorem. Starting from the proved equality of all cycle-edge
+dimensions, it must identify the two incident virtual indices at every site
+with one common pair $\operatorname{Fin}(D)\times\operatorname{Fin}(D)$,
+convert the cycle-graph tensor into a uniform
+\path{MPSChainTensor d D n}, and preserve vertex injectivity, the closed-state
+coefficients, and cyclic-shift invariance. The existing uniform theorem then
+constructs $B$. The Blueprint records the full source statement separately as
+\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+and keeps it not ready until this reindexing is supplied. No collected gauge
+factorization or alternative proof route is required.
 
 \subsection*{The 2D analogue}
 


### PR DESCRIPTION
## Summary

This draft formalizes the first, bond-dimension part of the translation-invariance corollary in the Applications section of arXiv:1804.04964.

- It defines the one-site rotation of `cycleGraph n` and the corresponding transport of a site-dependent graph tensor.
- It proves that vertex injectivity is preserved by graph transport.
- It applies the landed injective PEPS Fundamental Theorem to a tensor and its cyclic shift, obtaining the source's per-bond gauge comparison.
- It derives equality of adjacent bond dimensions and then equality of all bond dimensions around the cycle.
- It synchronizes the Blueprint and paper-gap note while keeping the full repeated-tensor conclusion separate and explicitly not ready.

## Source correspondence

The implementation follows `Papers/1804.04964/paper_normal.tex` without introducing a heterogeneous matrix-chain type or an alternative gauge route:

- lines 1803–1805 state the corollary and its equal-bond-dimension clause;
- lines 1807–1827 compare `A₁,…,Aₙ` with its cyclic shift `A₂,…,Aₙ,A₁`;
- lines 1828–1842 apply the injective Fundamental Theorem and infer equality of adjacent bond dimensions from the successive invertible bond gauges.

A site-dependent chain with dimensions `D_e` is represented here by `Tensor (cycleGraph n) d`. Transport by the inverse cycle rotation places the tensor at `v + 1` at `v`. The graph-level Fundamental Theorem then gives precisely the bond-dimension equality used by the paper.

The construction of the products `L_i`, `R_i` and the repeated tensor `B` in lines 1843–1890 is not claimed here. Equal natural-number dimensions do not definitionally identify the dependent virtual spaces `Fin (D_e)`. The remaining faithful step is an explicit reindexing to the existing uniform closed-chain representation, preserving vertex injectivity, state coefficients, and cyclic-shift invariance. The source-facing repeated-`B` Blueprint node therefore remains `\notready` and has no Lean tags.

No collected gauge factorization, constant-tensor construction, plaquette data, or new proof route is introduced.

## Verification

At exact head `5f84eadaa70820bc3fe29c4fca0f2fc37fc23d46` on `origin/main` `5f00129664ba2d08a7cefb9fae49f85dd8d86311`:

- `lake build TNLean` — passed (10,434 jobs)
- `python3 scripts/generate_import_aggregators.py --check` — passed (1,059 production modules)
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --changed-files TNLean/PEPS/IsoTransport.lean TNLean/PEPS/CycleShiftBondUniformity.lean TNLean/PEPS/CycleMPSConstantDescription.lean --diff-base origin/main --diff-head HEAD` — passed; only internal transport helpers are intentionally unregistered
- `leanblueprint web` — passed
- `leanblueprint checkdecls` — passed
- `leanblueprint pdf` — passed (1,050 pages)
- `git diff --check origin/main...HEAD` — passed
- proof-integrity token scan of the changed Lean files — clean

Advances #3371
