### PR TITLE
feat(PEPS): extract cross-tensor staircase end operation

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -118,6 +118,7 @@ import TNLean.PEPS.TorusWindowChain4
 import TNLean.PEPS.TorusWindowChain5
 import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowComplement
+import TNLean.PEPS.TorusWindowCrossTensorEndOperation
 import TNLean.PEPS.TorusWindowExtraction
 import TNLean.PEPS.TorusWindowFamily
 import TNLean.PEPS.TorusWindowFamilyCrossing

--- a/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
+++ b/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
@@ -21,10 +21,12 @@ This file formalizes exactly that extraction.  It does not compare the two virtu
 a multiplication law for their assignment, identify the bond dimensions of `A` and `B`, or
 construct a gauge.
 
-**Scope restriction (displayed horizontal staircase):** The result is stated for the
+**Scope restriction (displayed horizontal staircase, `L, K ≥ 2`):** The result is stated for the
 non-wrapping horizontal staircase coordinates supported by the present boundary-geometry API.
-The rotation/translation assembly needed for the full two-dimensional corollary is recorded in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
+It assumes `L, K ≥ 2`, so the displayed windows straddle the highlighted edge; the paper treats
+`L = K = 2` in its sketch and leaves the cases `L = 1` or `K = 1` unaddressed.  This clarification
+and the rotation/translation assembly needed for the full two-dimensional corollary are recorded
+in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 
 ## References
 

--- a/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
+++ b/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.NormalSquareInjectivity
+import TNLean.PEPS.TorusWindowChain6
+import TNLean.PEPS.TorusWindowPeeling.EndPhysicalOperation
+import TNLean.PEPS.TorusWindowVirtualOperationFamily
+
+/-!
+# The cross-tensor end operation on a staircase edge
+
+Fix a virtual matrix `X` for a tensor `A`, and realize it by the physical operations on the
+staircase windows.  If a tensor `B` generates the same closed state, those same physical
+operations give one common family on the genuine `B` window tensors.  The paper next compares the
+two end windows with open boundaries and uses their injectivity to extract one unique virtual
+matrix on the highlighted bond of `B`.
+
+This file formalizes exactly that extraction.  It does not compare the two virtual matrices, prove
+a multiplication law for their assignment, identify the bond dimensions of `A` and `B`, or
+construct a gauge.
+
+**Scope restriction (displayed horizontal staircase):** The result is stated for the
+non-wrapping horizontal staircase coordinates supported by the present boundary-geometry API.
+The rotation/translation assembly needed for the full two-dimensional corollary is recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Lemma 5 at lines 2045--2252 and the
+  two-dimensional open-boundary and end-window comparison at lines 2368--2444 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+-/
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {d L K : ℕ}
+
+private noncomputable def regionPhysicalOperationCongr
+    {R S : Finset (TorusVertex width height)} (h : R = S)
+    (O : Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d) R → ℂ)) :
+    Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d) S → ℂ) := by
+  subst S
+  exact O
+
+private noncomputable def regionInsertCongr
+    (B : Tensor (torusGraph width height) d)
+    {R S : Finset (TorusVertex width height)} (h : R = S)
+    (C : RegionInsert (G := torusGraph width height) (d := d) B R) :
+    RegionInsert (G := torusGraph width height) (d := d) B S := by
+  subst S
+  exact C
+
+private theorem regionInsertOfPhysicalOp_congr
+    (B : Tensor (torusGraph width height) d)
+    {R S : Finset (TorusVertex width height)} (h : R = S)
+    (O : Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d) R → ℂ)) :
+    regionInsertCongr B h (regionInsertOfPhysicalOp (G := torusGraph width height) B R O) =
+      regionInsertOfPhysicalOp (G := torusGraph width height) B S
+        (regionPhysicalOperationCongr h O) := by
+  subst S
+  rfl
+
+private theorem extendInsert_congr_region
+    (B : Tensor (torusGraph width height) d)
+    {R S P : Finset (TorusVertex width height)} (h : R = S)
+    (hRP : R ⊆ P) (hSP : S ⊆ P)
+    (C : RegionInsert (G := torusGraph width height) (d := d) B R) :
+    extendInsert (G := torusGraph width height) hRP C =
+      extendInsert (G := torusGraph width height) hSP (regionInsertCongr B h C) := by
+  subst S
+  rfl
+
+/-- The paper's left end operation `O₁` for the staircase family of `A`.
+
+The last staircase window is the left end window, whose right boundary contains the highlighted
+edge.  The canonical physical realization of `X` on that window is therefore the operation named
+`O₁` in Lemma 5.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2045--2129 and the staircase windows at lines
+2320--2415 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def staircaseO1PhysicalOp (A : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (horizontalStaircaseLeftWindow
+          ((a : ZMod width), (b : ZMod height)) L K) → ℂ) :=
+  regionPhysicalOperationCongr
+    (staircaseWindow_last ((a : ZMod width), (b : ZMod height)) hL hK)
+    (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X (L + K - 1))
+
+/-- The paper's right end operation `O₃` for the staircase family of `A`.
+
+The first staircase window is the right end window, whose left boundary contains the highlighted
+edge.  Its canonical physical realization is the underlying operation `O₃`; the extracted
+relation is read in the paper's `O₃ᵀ` orientation.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2045--2129 and the staircase windows at lines
+2320--2415 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def staircaseO3PhysicalOp (A : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (horizontalStaircaseRightWindow
+          ((a : ZMod width), (b : ZMod height)) L K) → ℂ) :=
+  regionPhysicalOperationCongr
+    (staircaseWindow_zero ((a : ZMod width), (b : ZMod height)) L K)
+    (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X 0)
+
+/-- **The virtual operation on `B` extracted from the staircase operations of `A`.**
+
+Let `A` and `B` be translation-invariant tensors with the same closed state and with every cyclic
+`L × K` window injective.  Apply the canonical physical operations `Oⱼᴬ(X)` to the genuine
+window tensors of `B`.  Their common transformed state gives, by the paper's consecutive-window
+and corner-completion argument, an equality of the two open end-window inserts.  Injectivity of
+those two genuine `B` windows then extracts a unique matrix `Y` on the highlighted bond of
+`B` such that the left operation `O₁ᴬ(X)` realizes `Y`, while the right operation `O₃ᴬ(X)`
+realizes `Y` in the paper's transposed `O₃ᵀ` orientation.
+
+No equality between the bond dimensions of `A` and `B` is assumed or concluded.  This theorem
+does not compare `X` and `Y`, nor does it assert that the assignment `X ↦ Y` is multiplicative.
+
+Source: arXiv:1804.04964, the common open-boundary family at lines 2368--2415, the end-window
+comparison at lines 2415--2444, and the two-end extraction of Lemma 5 at lines 2213--2252 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameState
+    (A B : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hATI : IsTorusTranslationInvariant A) (hBTI : IsTorusTranslationInvariant B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hposB : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    let s : TorusVertex width height := ((a : ZMod width), (b : ZMod height))
+    let Wleft := horizontalStaircaseLeftWindow s L K
+    let Wright := horizontalStaircaseRightWindow s L K
+    let Eleft := horizontalStaircaseLeftWindowBoundaryConfigEquiv B
+      (by omega) (by omega) ha0 haw hbh
+    let Eright := horizontalStaircaseRightWindowBoundaryConfigEquiv B
+      (by omega) (by omega) ha0 haw hbh
+    ∃! Y : Matrix
+        (Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K)))
+        (Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K))) ℂ,
+      (∀ etaLeft : HorizontalStaircaseLeftExternalBoundaryConfig B (L := L) (K := K) s,
+        IsO1VirtualOperation
+          (fun k : Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K)) ↦
+            regionBlockedWeight (G := torusGraph width height) B Wleft
+              (Eleft.symm (k, etaLeft)))
+          (staircaseO1PhysicalOp A hA (by omega) (by omega) haw (by omega) X) Y) ∧
+      ∀ etaRight : HorizontalStaircaseRightExternalBoundaryConfig B (L := L) (K := K) s,
+        IsO3TransposeVirtualOperation
+          (fun k : Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K)) ↦
+            regionBlockedWeight (G := torusGraph width height) B Wright
+              (Eright.symm (k, etaRight)))
+          (staircaseO3PhysicalOp A hA (by omega) (by omega) haw (by omega) X) Y := by
+  classical
+  dsimp only
+  let s : TorusVertex width height := ((a : ZMod width), (b : ZMod height))
+  let O₁ := staircaseO1PhysicalOp A hA (by omega) (by omega) haw (by omega) X
+  let O₃ := staircaseO3PhysicalOp A hA (by omega) (by omega) haw (by omega) X
+  let C : ∀ j, RegionInsert (G := torusGraph width height) (d := d) B
+      (staircaseWindow s L K j) :=
+    fun j ↦ regionInsertOfPhysicalOp (G := torusGraph width height) B
+      (staircaseWindow s L K j)
+      (staircaseVirtualOperationPhysicalOp (B := A) hA
+        (by omega) (by omega) haw (by omega) X j)
+  let common := deformedRegionStateAssembled (G := torusGraph width height) B
+    (staircaseWindow s L K 0) (C 0)
+  have hagree : ∀ j, j < L + K →
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (staircaseWindow s L K j) (C j) = common := by
+    intro j _
+    exact deformedRegionStateAssembled_staircasePhysicalOp_sameState
+      (L := L) (K := K) (a := a) (b := b) (j := j) (j' := 0)
+      hA hATI hBTI hAB hposA (by omega) (by omega) haw (by omega) X
+  have hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B) :=
+    regionInjectivityUnionClosure_of_overlap B hposB
+  have hend := staircasePair_insert_eq_open hB hUB hposB hL hK hxw hyh s C common hagree
+  have hleftInjective : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseLeftWindow s L K) := by
+    have hi := hB.horizontalStaircaseLeftWindow_injective s
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hrightInjective : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseRightWindow s L K) := by
+    have hi := hB.horizontalStaircaseRightWindow_injective s
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hLpos : 0 < L := by omega
+  have hKpos : 0 < K := by omega
+  have hlast := staircaseWindow_last s hLpos hKpos
+  have hzero := staircaseWindow_zero s L K
+  have hCleft :
+      regionInsertCongr B hlast (C (L + K - 1)) =
+        regionInsertOfPhysicalOp (G := torusGraph width height) B
+          (horizontalStaircaseLeftWindow s L K) O₁ := by
+    simpa only [C, O₁, s, staircaseO1PhysicalOp] using
+      regionInsertOfPhysicalOp_congr B hlast
+        (staircaseVirtualOperationPhysicalOp (B := A) hA hLpos hKpos haw (by omega) X
+          (L + K - 1))
+  have hCright :
+      regionInsertCongr B hzero (C 0) =
+        regionInsertOfPhysicalOp (G := torusGraph width height) B
+          (horizontalStaircaseRightWindow s L K) O₃ := by
+    simpa only [C, O₃, s, staircaseO3PhysicalOp] using
+      regionInsertOfPhysicalOp_congr B hzero
+        (staircaseVirtualOperationPhysicalOp (B := A) hA hLpos hKpos haw (by omega) X 0)
+  have heq :
+      extendInsert (G := torusGraph width height)
+          (horizontalStaircaseLeftWindow_subset_endPair s)
+          (fun μ ↦ O₁ (regionBlockedWeight (G := torusGraph width height) B
+            (horizontalStaircaseLeftWindow s L K) μ)) =
+        extendInsert (G := torusGraph width height)
+          (horizontalStaircaseRightWindow_subset_endPair s)
+          (fun μ ↦ O₃ (regionBlockedWeight (G := torusGraph width height) B
+            (horizontalStaircaseRightWindow s L K) μ)) := by
+    calc
+      _ = extendInsert (G := torusGraph width height)
+          (horizontalStaircaseLeftWindow_subset_endPair s)
+          (regionInsertCongr B hlast (C (L + K - 1))) := by
+            exact congrArg
+              (extendInsert (G := torusGraph width height)
+                (horizontalStaircaseLeftWindow_subset_endPair s)) hCleft.symm
+      _ = extendInsert (G := torusGraph width height)
+          (staircaseWindow_last_subset_endPair hLpos hKpos s) (C (L + K - 1)) :=
+            (extendInsert_congr_region B hlast
+              (staircaseWindow_last_subset_endPair hLpos hKpos s)
+              (horizontalStaircaseLeftWindow_subset_endPair s) (C (L + K - 1))).symm
+      _ = extendInsert (G := torusGraph width height)
+          (staircaseWindow_zero_subset_endPair s L K) (C 0) := hend.symm
+      _ = extendInsert (G := torusGraph width height)
+          (horizontalStaircaseRightWindow_subset_endPair s)
+          (regionInsertCongr B hzero (C 0)) :=
+            extendInsert_congr_region B hzero
+              (staircaseWindow_zero_subset_endPair s L K)
+              (horizontalStaircaseRightWindow_subset_endPair s) (C 0)
+      _ = _ := by
+        exact congrArg
+          (extendInsert (G := torusGraph width height)
+            (horizontalStaircaseRightWindow_subset_endPair s)) hCright
+  simpa only [s, O₁, O₃] using
+    existsUnique_virtualOperation_of_horizontalStaircaseEndPhysicalOperations
+      B hBTI (by omega) (by omega) ha0 haw hbh hposB hleftInjective hrightInjective O₁ O₃ heq
+
+end Torus
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -355,7 +355,7 @@ correspondence in the proof sketch of the two-dimensional corollary
     \uses{thm:peps_staircase_virtual_operation_physical_realization}
     For $X\in\MN{D_A(e)}$, define $O_3^A(X)=O_0^A(X)$ after identifying
     the first staircase window with the right end window.
-    Equation~\eqref{eq:peps_staircase_o3_cross_tensor_relation} has the
+    The relation (\ref{eq:peps_staircase_o3_cross_tensor_relation}) has the
     paper's transposed $O_3^{\mathsf T}$ orientation; no transpose is chosen
     on the abstract physical endomorphism space.
 \end{definition}
@@ -391,7 +391,7 @@ correspondence in the proof sketch of the two-dimensional corollary
          & =\sum_jY_{kj}T_{B,W_{\mathrm R}}(j,\eta_{\mathrm R}).
         \label{eq:peps_staircase_o3_cross_tensor_relation}
     \end{align}
-    Thus Equation~\eqref{eq:peps_staircase_o3_cross_tensor_relation} has the
+    Thus the relation (\ref{eq:peps_staircase_o3_cross_tensor_relation}) has the
     paper's $O_3^{\mathsf T}$ orientation.
     No equality between $D_A(e)$ and $D_B(e)$ is assumed or concluded, and
     this statement contains no multiplication or gauge assertion.

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -338,6 +338,77 @@ correspondence in the proof sketch of the two-dimensional corollary
     cancelled.
 \end{proof}
 
+\begin{definition}[The left staircase end operation $O_1^A(X)$]%
+    \label{def:peps_staircase_O1_physical_operation}
+    \lean{TNLean.PEPS.staircaseO1PhysicalOp}
+    \leanok
+    \uses{thm:peps_staircase_virtual_operation_physical_realization}
+    For $X\in\MN{D_A(e)}$, define
+    $O_1^A(X)=O_{L+K-1}^A(X)$ after identifying the last staircase
+    window with the left end window.
+\end{definition}
+
+\begin{definition}[The underlying right staircase end operation $O_3^A(X)$]%
+    \label{def:peps_staircase_O3_physical_operation}
+    \lean{TNLean.PEPS.staircaseO3PhysicalOp}
+    \leanok
+    \uses{thm:peps_staircase_virtual_operation_physical_realization}
+    For $X\in\MN{D_A(e)}$, define $O_3^A(X)=O_0^A(X)$ after identifying
+    the first staircase window with the right end window. The second virtual
+    relation below has the paper's transposed $O_3^{\mathsf T}$ orientation;
+    no transpose is chosen on the abstract physical endomorphism space.
+\end{definition}
+
+\begin{theorem}[Cross-tensor virtual operation on the staircase edge]%
+    \label{thm:peps_cross_tensor_virtual_operation_of_staircase}
+    \lean{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameState}
+    \leanok
+    \uses{def:peps_staircase_O1_physical_operation,
+        def:peps_staircase_O3_physical_operation}
+    Let $L,K\geq2$, and choose the displayed non-wrapping horizontal
+    staircase coordinates $(a,b)$ with
+    \begin{align}
+        1    & \leq a,
+             & a+2L                 & \leq \mathrm{width},
+             & b+2K-1               & \leq \mathrm{height},
+        \notag                                              \\
+        2L+1 & \leq \mathrm{width},
+             & 2K+1                 & \leq \mathrm{height}.
+        \notag
+    \end{align}
+    Suppose that $A$ and $B$ are translation invariant, generate the same
+    closed state, every cyclic $L\times K$ window of either tensor is
+    injective, and every bond dimension of either tensor is positive. For
+    $X\in\MN{D_A(e)}$, there is a unique $Y\in\MN{D_B(e)}$ such that, for
+    every external boundary configuration $\eta_{\mathrm L}$ and
+    $\eta_{\mathrm R}$,
+    \begin{align}
+        O_1^A(X)\bigl(T_{B,W_{\mathrm L}}(k,\eta_{\mathrm L})\bigr)
+         & =\sum_jY_{jk}T_{B,W_{\mathrm L}}(j,\eta_{\mathrm L}),
+        \notag                                                   \\
+        O_3^A(X)\bigl(T_{B,W_{\mathrm R}}(k,\eta_{\mathrm R})\bigr)
+         & =\sum_jY_{kj}T_{B,W_{\mathrm R}}(j,\eta_{\mathrm R}).
+        \notag
+    \end{align}
+    Thus the second relation has the paper's $O_3^{\mathsf T}$ orientation.
+    No equality between $D_A(e)$ and $D_B(e)$ is assumed or concluded, and
+    this statement contains no multiplication or gauge assertion.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:peps_staircase_physical_operation_same_state,
+        thm:peps_staircase_pair_insert_eq_open,
+        thm:peps_existsUnique_virtualOperation_of_horizontal_staircase_end_pair,
+        thm:peps_regionInjectivityUnionClosure_of_overlap}
+    The transferred physical inserts form one common $B$-state. The
+    overlapping-union lemma supplies the union closure needed to compare
+    consecutive staircase windows, and corner completion gives equality of
+    the two end inserts with open boundary. At the two ends these inserts are
+    precisely the actions of $O_3^A(X)$ and $O_1^A(X)$ on the genuine
+    $B$-window tensors. Injectivity of those two windows and the two-end
+    comparison give the displayed relations and the uniqueness of $Y$.
+\end{proof}
+
 \begin{theorem}[End-window identity for one virtual operation]%
     \label{thm:peps_end_window_identity_staircase_virtual_operation}
     \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -354,9 +354,10 @@ correspondence in the proof sketch of the two-dimensional corollary
     \leanok
     \uses{thm:peps_staircase_virtual_operation_physical_realization}
     For $X\in\MN{D_A(e)}$, define $O_3^A(X)=O_0^A(X)$ after identifying
-    the first staircase window with the right end window. The second virtual
-    relation below has the paper's transposed $O_3^{\mathsf T}$ orientation;
-    no transpose is chosen on the abstract physical endomorphism space.
+    the first staircase window with the right end window.
+    Equation~\eqref{eq:peps_staircase_o3_cross_tensor_relation} has the
+    paper's transposed $O_3^{\mathsf T}$ orientation; no transpose is chosen
+    on the abstract physical endomorphism space.
 \end{definition}
 
 \begin{theorem}[Cross-tensor virtual operation on the staircase edge]%
@@ -385,12 +386,13 @@ correspondence in the proof sketch of the two-dimensional corollary
     \begin{align}
         O_1^A(X)\bigl(T_{B,W_{\mathrm L}}(k,\eta_{\mathrm L})\bigr)
          & =\sum_jY_{jk}T_{B,W_{\mathrm L}}(j,\eta_{\mathrm L}),
-        \notag                                                   \\
+        \label{eq:peps_staircase_o1_cross_tensor_relation}       \\
         O_3^A(X)\bigl(T_{B,W_{\mathrm R}}(k,\eta_{\mathrm R})\bigr)
          & =\sum_jY_{kj}T_{B,W_{\mathrm R}}(j,\eta_{\mathrm R}).
-        \notag
+        \label{eq:peps_staircase_o3_cross_tensor_relation}
     \end{align}
-    Thus the second relation has the paper's $O_3^{\mathsf T}$ orientation.
+    Thus Equation~\eqref{eq:peps_staircase_o3_cross_tensor_relation} has the
+    paper's $O_3^{\mathsf T}$ orientation.
     No equality between $D_A(e)$ and $D_B(e)$ is assumed or concluded, and
     this statement contains no multiplication or gauge assertion.
 \end{theorem}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -381,7 +381,7 @@ correspondence in the proof sketch of the two-dimensional corollary
     injective, and every bond dimension of either tensor is positive. For
     $X\in\MN{D_A(e)}$, there is a unique $Y\in\MN{D_B(e)}$ such that, for
     every external boundary configuration $\eta_{\mathrm L}$ and
-    $\eta_{\mathrm R}$,
+    $\eta_{\mathrm R}$, and every reference-edge index $k$,
     \begin{align}
         O_1^A(X)\bigl(T_{B,W_{\mathrm L}}(k,\eta_{\mathrm L})\bigr)
          & =\sum_jY_{jk}T_{B,W_{\mathrm L}}(j,\eta_{\mathrm L}),

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -118,9 +118,10 @@ configuration~$\mu$.  The partial-state identity now also proves that the
 same operators $O_j^A(X)$, applied to the genuine $B$-blocks of a tensor with
 the same closed state, produce one common $B$-state.  The same-tensor two-end
 extraction and the $O_1P_1$ and underlying $P_3O_3$ composition laws are
-complete.  What remains is to apply the two-end extraction to the cross-tensor
-common family, organize the resulting matrix assignments, prove their
-multiplicativity from these laws, and assemble the back half of the argument.
+complete.  Applying that extraction to the cross-tensor common family now
+gives the unique bond matrix pointwise.  What remains is to organize the
+resulting matrix assignments, prove their multiplicativity from these laws,
+obtain the coefficient transfer, and assemble the back half of the argument.
 
 Ref.~\cite{Molnar2018NormalPEPS} supplies this converse by the reduction ``we only need to prove a
 statement similar to Lemma~5''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321}.}

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -184,7 +184,8 @@ a sketch.  The consecutive-window comparison, corner completion, forward
 open-boundary physical realization, and two-end recovery of the unique matrix
 $X$ are now formalized, as are the uniqueness and direct composition laws for
 Lemma~5's $O_1$ and $O_3^{\mathsf T}$ end-factor relations.  What remains is
-the cross-tensor transfer and the back-half assembly.  The failed
+the cross-tensor coefficient transfer, its multiplicativity, and the
+back-half assembly.  The failed
 single-window span above is an invented auxiliary route, not a statement made
 or required by the paper.
 
@@ -253,18 +254,24 @@ with the same closed state without identifying the two virtual boundary
 spaces
 (\path{TNLean/PEPS/RegionBlock/PhysicalOperation.lean},
 \path{TNLean/PEPS/RegionBlock/InteriorBondInsertion.lean}, and
-\path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}). Every
+\path{TNLean/PEPS/TorusWindowVirtualOperationFamily.lean}); and the
+pointwise cross-tensor end extraction
+\leanid{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp\_sameState},
+which recovers the unique $B$-bond matrix with the source's $O_1$ and
+$O_3^{\mathsf T}$ orientations
+(\path{TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean}). Every
 inverted region is a union of one-orientation $L \times K$ window translates,
 host-decomposable at $n \geq 2L+1$, $m \geq 2K+1$. The development is
 minimal-size-ready through the single-tensor virtual-operation family and the
-unique end-pair extraction
-\leanid{TNLean.PEPS.existsUnique_virtualOperation_of_horizontalStaircaseEndPair}.
+unique end-pair and pointwise cross-tensor extraction.
 The direct $O_1\mapsto X$ and $O_3^{\mathsf T}\mapsto X$ composition laws are
-also complete.  The remaining gates are the cross-tensor transfer and the
-back-half assembly that re-anchors the torus Theorem~3 layers to the
-$(L+1) \times (K+1)$ comparison pair.
+also complete.  The remaining gates are to organize the two pointwise
+cross-tensor assignments, prove the forward assignment multiplicative,
+obtain the coefficient transfer, and complete the back-half assembly that
+re-anchors the torus Theorem~3 layers to the $(L+1) \times (K+1)$
+comparison pair.
 
-\paragraph{3. The remaining cross-tensor extraction.}
+\paragraph{3. The pointwise cross-tensor extraction.}
 The same-tensor operation family is no longer missing.  For a fixed matrix
 $X$ on $e$, the first window carries $X^{\mathsf T}$, the windows
 $W_1,\ldots,W_{L-1}$ carry the interior-bond insert of $X$, and the remaining
@@ -276,14 +283,16 @@ $P_B(W_0)E_B(e,\cdot,X)$.  The relations
 \leanid{TNLean.PEPS.IsO3TransposeVirtualOperation} are single-valued on the
 genuine end families, and their multiplication theorems give exactly the two
 composition orders printed in Lemma~5.  The new common-state theorem applies
-the operators $O_j^A(X)$ to the genuine $B$-blocks.  It remains to apply the
-end extraction to this family in both directions and prove that the forward
-matrix assignment respects products; these are the
-\path{htransferAB}/\path{htransferBA}/\path{hmul} data consumed downstream.
-Existing single-window and coarse-three-site
-attempts do not derive that cross-tensor input at the minimal size; a
-source-faithful extraction must use the actual overlapping-window comparison
-rather than assume a matrix span.
+the operators $O_j^A(X)$ to the genuine $B$-blocks.  Feeding this family
+through the open end-pair equality and the two-end comparison now gives the
+unique $B$-bond matrix in
+\leanid{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp\_sameState}.
+Swapping the two tensors gives the reverse pointwise statement.  What
+remains is to organize these unique matrices into the forward and reverse
+coefficient transfers and prove that the forward assignment respects
+products; these are the \path{htransferAB}/\path{htransferBA}/\path{hmul}
+data consumed downstream.  This route uses the actual overlapping-window
+comparison and assumes no single-window matrix span.
 
 \paragraph{4. Auxiliary closing routes ruled out at the minimal size.}
 The following findings rule out particular substitutes for the paper's
@@ -345,14 +354,17 @@ a single-window square-matrix span.  The forward correspondence, its
 open-boundary physical operators, its transpose convention, and the unique
 end-pair operation now follow this description literally.  So do the direct
 composition laws for Lemma~5's $O_1$ and $O_3^{\mathsf T}$ orientations.  The
-remaining formal work is the cross-tensor transfer and the back-half assembly.
+pointwise cross-tensor end extraction is also complete.  The remaining formal
+work is the cross-tensor coefficient transfer, its multiplicativity, and the
+back-half assembly.
 
 \paragraph{6. Status.}
 The corollary remains \emph{unformalized}: no blueprint entry claims it, it
 carries the \texttt{notready} marker, and no \texttt{leanok} marks it.  The
-same-tensor family, unique end-pair extraction, and direct end-composition
-laws are complete; the remaining work is the cross-tensor transfer and the
-back-half assembly tracked separately.
+same-tensor family, pointwise cross-tensor end extraction, and direct
+end-composition laws are complete; the remaining work is the bidirectional
+coefficient transfer, its multiplicativity, and the back-half assembly tracked
+separately.
 
 \section{The filled-in derivation}
 
@@ -648,10 +660,11 @@ window block on the compatible fibre and vanishes off it, and
 the unique matrix $X$.  Specializing the end inserts to the physical actions
 $O_1$ and $O_3$ gives the source's two factor relations, whose direct
 composition laws are now formalized.  The same-state partial-state identity
-also supplies the cross-tensor common family for these physical operations.
-The residual is to extract and organize the resulting matrix assignment, use
-the end-composition laws to prove its multiplicativity, and complete the
-back-half assembly.
+also supplies the cross-tensor common family for these physical operations,
+and the end-pair theorem now extracts its unique bond matrix.  The residual
+is to organize the two pointwise assignments, use the end-composition laws
+to prove multiplicativity, obtain the coefficient transfer, and complete
+the back-half assembly.
 
 \subsection{Step 5: the rest of the proof}
 
@@ -783,9 +796,9 @@ end-pair-operation layers of the derivation above are complete, including the
 direct composition laws in the two source orientations. The remaining source
 steps following
 \path{Papers/1804.04964/paper_normal.tex:2368--2444} of
-Ref.~\cite{Molnar2018NormalPEPS} are the cross-tensor transfer and the
-back-half assembly.  The layer list below records the campaign around these
-steps:
+Ref.~\cite{Molnar2018NormalPEPS} are the cross-tensor coefficient transfer,
+its multiplicativity, and the back-half assembly.  The layer list below
+records the campaign around these steps:
 
 \begin{enumerate}
     \item \emph{Window geometry} (no tensors): the one-orientation
@@ -807,7 +820,8 @@ steps:
           last physical operations after adjoining the genuine corner tensors,
           invert the resulting regions, and recover the unique virtual operation
           $X$, with the $O_1\mapsto X$ and $O_3^{\mathsf T}\mapsto X$ uniqueness and
-          direct composition laws (complete).
+          direct composition laws, including the pointwise cross-tensor end
+          extraction (complete).
     \item \emph{The per-edge witness}: the landed insertion-correspondence and
           Skolem--Noether interface at one reference edge per orientation; the
           remaining cross-tensor transfer must supply the coefficient identity this
@@ -1169,8 +1183,9 @@ contraction and unique-operation extraction are in
 \path{TNLean/PEPS/TorusWindowPeeling/EndOperation.lean}.
 
 The Step~4 end relations and their direct composition laws are complete.  The
-remaining work is to use them in the cross-tensor assembly and then complete
-the back half of the proof.
+remaining work is to organize the pointwise operations into the cross-tensor
+coefficient transfer, prove its multiplicativity, and then complete the back
+half of the proof.
 
 \subsection{The back-half geometry supports a window witness region}
 
@@ -1338,19 +1353,24 @@ $\text{\path{deformedRegionStateAssembled\_staircasePhysicalOp\_sameState}}$.
 This statement uses neither an identification of the two virtual boundary
 spaces nor a multiplicativity hypothesis.
 
-The local residual is now the cross-tensor matrix assignment and its
-multiplicativity.  One must feed this common family through
-$\text{\path{staircasePair\_insert\_eq\_open}}$ and the landed unique end
-extraction in both directions, then use the end-composition laws to prove that
-the forward assignment respects products.  The region-level recovery
+The pointwise cross-tensor matrix extraction is now
+$\text{\path{existsUnique\_crossTensorVirtualOperation\_of\_staircasePhysicalOp\_sameState}}$.
+It feeds the common family through
+$\text{\path{staircasePair\_insert\_eq\_open}}$ and the genuine two-end
+injectivity argument, giving the unique $B$-matrix with the paper's $O_1$ and
+$O_3^{\mathsf T}$ orientations; swapping $A$ and $B$ gives the reverse
+pointwise extraction.  The local residual is to organize these unique
+matrices into the two coefficient transfers and use the end-composition laws
+to prove that the forward assignment respects products.  The region-level recovery
 $\text{\path{regionInsertionTransfer\_of\_realizes}}$ derives all three transfer fields ---
 $\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and $\text{\path{hmul}}$ --- from one region
 physical-to-virtual realization $\text{\path{RegionTransferRealizes}}$ in each direction, with
-no further hypothesis; so the window route's residual collapses to producing that
-realization on the window from the staircase, in place of the edge-middle injectivity
+no further hypothesis; so the window route's residual is to produce that
+realization on the window from the pointwise staircase extraction, in place of
+the edge-middle injectivity
 ($\mathrm{univ}\setminus\{u,v\}$ injective) the rectangle route uses, which fails at the
 minimal size --- the same obstruction, at the edge, that $\mathrm{univ}\setminus S$
-exhibits at the end pair.  The common-state theorem alone does not yield
+exhibits at the end pair.  The pointwise existence theorem alone does not yield
 $\text{\path{hmul}}$: the missing bridge is the comparison of the canonical
 physical operations under composition, in the order $O_1P_1$ on the left and
 the underlying order $P_3O_3$ for the $O_3^{\mathsf T}$ orientation on the
@@ -1520,10 +1540,12 @@ $M^{\mathsf T}$ and the last-window insertion of $M$.  This end-window
 coefficient identity follows directly from the two region-to-edge identities
 and translation invariance; it needs neither complement inversion nor a
 peeling hypothesis.  Together with the partial-state argument above, this
-closes both common-state-family residuals.  It does not yet extract the
-cross-tensor matrix assignment or prove that assignment multiplicative;
-those are the remaining Lemma~5-style steps, after which the back-half
-assembly remains.
+closes both common-state-family residuals.  The subsequent end-pair comparison
+now extracts the unique cross-tensor matrix pointwise in
+\leanid{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp\_sameState}.
+Packaging the forward and reverse coefficient transfers and proving the
+forward assignment multiplicative are the remaining Lemma~5-style steps,
+after which the back-half assembly remains.
 
 \section{Normality and discarded stronger routes}
 
@@ -1582,10 +1604,11 @@ region of a coherent frame.\footnote{Formal geometry:
 
 These observations rule out two auxiliary shortcuts; they do not challenge
 the paper's fixed-edge comparison.  The comparison through adjoining the
-corner regions and recovering the unique virtual operation $X$ is now landed.
-The two source orientations and their direct multiplication laws are also
-landed.  The remaining source work is to use them for the cross-tensor
-transfer and complete the back-half assembly.
+corner regions and recovering the unique cross-tensor virtual operation is now
+landed.  The two source orientations and their direct multiplication laws are
+also landed.  The remaining source work is to organize the bidirectional
+coefficient transfer, prove its multiplicativity, and complete the back-half
+assembly.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

The two-dimensional converse in arXiv:1804.04964 compares the same physical staircase operations on tensors $A$ and $B$, then uses the genuine end windows to extract one virtual operation on the highlighted bond of $B$. This is the step at `paper_normal.tex` lines 2368--2444, with the $O_1$ and $O_3^{\mathsf T}$ orientations inherited from Lemma 5 at lines 2045--2252.

### Description

- Define the paper-named left and right end operations `staircaseO1PhysicalOp` and `staircaseO3PhysicalOp` for the already constructed staircase family.
- Transport the common transformed state from $A$ to the genuine $B$-window inserts using the landed cross-tensor staircase comparison.
- Apply the existing two-end open-boundary extraction to obtain one unique $B$-side matrix $Y$.
- Prove the exact source-oriented coefficient identities
  $$
  O_1(T_k)=\sum_j Y_{jk}T_j,
  \qquad
  O_3(T_k)=\sum_j Y_{kj}T_j,
  $$
  so the latter is precisely the paper's $O_3^{\mathsf T}$ convention.
- Synchronize the dedicated Blueprint entry and the Section 3 paper-gap account.

### Scope and remaining work

This pull request treats the displayed non-wrapping horizontal staircase with $L,K\ge 2$ and positive bond dimensions. It does not assume equality of the $A$- and $B$-bond dimensions, and it does not prove multiplicativity, invertibility, or a gauge. The remaining part of #5456 is to package the forward and reverse assignments, prove their source-order algebra laws by composition, transfer the coefficients, and complete the back-half gauge assembly. The source-labelled two-dimensional corollary therefore remains unfinished.

### Verification

- focused module build: 2004/2004 jobs
- `lake build TNLean.PEPS`: 3285/3285 jobs
- `lake build TNLean`: 10434/10434 jobs
- Blueprint declaration synchronization and reverse declaration coverage
- `leanblueprint checkdecls`
- paper-gap Lean-identifier and registry checks
- import, prose, forbidden-token, formatting, and proof-integrity checks
- independent exact-head comparison with `paper_normal.tex` lines 2045--2252 and 2320--2444

Addresses #5456
Tracks #2738