### PR TITLE
cleanup: remove eight zero-reference declarations

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean
+++ b/TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean
@@ -63,20 +63,6 @@ def retainedMultiplicityWeightEntry (H : BNTFusionTensorClause M)
   let px := verticalCopyCoordinateEquiv H.bondDim H.multiplicity u
   H.weight px.1.1 px.1.2
 
-/-- In retained copy coordinates, the one-site entry is the corresponding
-diagonal entry of the multiplicity matrix.
-
-Source: CPSV16, local source lines 999–1002. -/
-@[simp]
-theorem retainedMultiplicityWeightEntry_verticalCopyCoordinateEquiv_symm
-    (H : BNTFusionTensorClause M) (p : H.VerticalCopy)
-    (x : Fin (H.bondDim p.1)) :
-    H.retainedMultiplicityWeightEntry
-        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨p, x⟩) =
-      H.weight p.1 p.2 := by
-  unfold retainedMultiplicityWeightEntry
-  rw [Equiv.apply_symm_apply]
-
 /-- Every retained one-site multiplicity weight is strictly positive.
 
 Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/

--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -44,12 +44,8 @@ the nonzero tensor `B`, merging them into one constant.
 
 The graph-level presentation of the same corollary is still reachable from
 here: the per-edge matrices of the cycle-graph gauge equivalence convert to
-per-bond gauges through the stored-edge orientation — away from the seam the
-gauge of the bond entering site `v` is the transpose of the edge matrix,
-while on the seam edge, stored with its endpoints in the opposite order, it
-is the inverse (`cycleGaugeOfEdgeGauge`, inverted by
-`edgeGaugeOfCycleGauge`) — and the per-vertex component identity of the
-graph-level gauge equivalence is equivalent to the matrix identity
+per-bond gauges through `cycleGaugeOfEdgeGauge`, and the per-vertex component
+identity of the graph-level gauge equivalence is equivalent to the matrix identity
 `B = Z_v⁻¹ A Z_{v+1}` (`cycleGauge_component_iff_matrix`).
 
 The matrix-level hypotheses match the source corollary: `0 < L` (implicit in
@@ -338,14 +334,6 @@ theorem cycleGauge_component_iff_matrix (hn : 3 ≤ n) (A B : MPSTensor d D)
   rw [cycleGauge_component_iff hn A B X v]
   refine forall_congr' fun i => ?_
   rw [cycleLeftGauge_eq hn A X v, cycleRightGauge_transpose_eq hn A X v]
-
-/-- The per-edge gauge family of a per-bond gauge family, inverting
-`cycleGaugeOfEdgeGauge`: the edge from a site to its cyclic successor carries
-the transpose of the gauge of that bond, except the seam edge — stored with
-its endpoints in the opposite cyclic order — which carries the inverse. -/
-noncomputable def edgeGaugeOfCycleGauge (Z : Fin n → GL (Fin D) ℂ)
-    (e : Edge (SimpleGraph.cycleGraph n)) : GL (Fin D) ℂ :=
-  if e.1.1 + 1 = e.1.2 then glTranspose (Z e.1.2) else (Z e.1.1)⁻¹
 
 end GaugeConversion
 

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -232,20 +232,6 @@ theorem of_peripheral_primitive
       (A := A k) (MPSTensor.irreducibleTensor_of_injective (A k) (hInj k))
       (hLeft k) (hPrim k)
 
-/-- The canonical-form conditions imply blockwise injectivity data. -/
-theorem toHasInjectiveBlocks (hCF : IsCanonicalForm μ A) : HasInjectiveBlocks (d := d) A :=
-  HasInjectiveBlocks.ofForall hCF.block_injective
-
-/-- The canonical-form conditions imply left-canonical block-family normalization. -/
-theorem toIsLeftCanonicalBlockFamily (hCF : IsCanonicalForm μ A) :
-    IsLeftCanonicalBlockFamily (d := d) A :=
-  IsLeftCanonicalBlockFamily.ofForall hCF.leftCanonical
-
-/-- The canonical-form conditions imply self-overlap normalization data. -/
-theorem toHasNormalizedSelfOverlap (hCF : IsCanonicalForm μ A) :
-    HasNormalizedSelfOverlap (d := d) A :=
-  HasNormalizedSelfOverlap.ofForall hCF.overlap_tendsto_one
-
 end IsCanonicalForm
 
 /-! ### Normal canonical form conditions -/
@@ -296,11 +282,6 @@ theorem toIsLeftCanonicalBlockFamily (hNCF : IsNormalCanonicalForm μ A) :
     IsLeftCanonicalBlockFamily (d := d) A :=
   IsLeftCanonicalBlockFamily.ofForall hNCF.leftCanonical
 
-/-- The normal-canonical-form conditions imply blockwise peripheral primitivity data. -/
-theorem toHasPrimitiveBlocks (hNCF : IsNormalCanonicalForm μ A) :
-    HasPrimitiveBlocks (d := d) A :=
-  HasPrimitiveBlocks.ofForall hNCF.block_primitive
-
 /-- The additive split conditions imply `IsNormalCanonicalForm` with non-strict ordering. -/
 theorem ofSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
@@ -331,13 +312,6 @@ theorem overlap_tendsto_one
       (hIrr := hNCF.block_irreducible k)
       (hNorm := hNCF.leftCanonical k)
       (hPrim := hNCF.block_primitive k)
-
-/-- Project normal-canonical-form data to the overlap-normalization interface used by the
-existing separated FT statements. -/
-theorem toHasNormalizedSelfOverlap
-    (hNCF : IsNormalCanonicalForm μ A) :
-    HasNormalizedSelfOverlap (d := d) A :=
-  HasNormalizedSelfOverlap.ofForall hNCF.overlap_tendsto_one
 
 end IsNormalCanonicalForm
 

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -59,17 +59,6 @@ structure HasInjectiveBlocks {r : ℕ} {dim : Fin r → ℕ}
   /-- Each block is algebraically injective (`span (range (A k)) = ⊤`). -/
   block_injective : ∀ k, Kraus.IsInjective (A k)
 
-namespace HasInjectiveBlocks
-
-variable {r : ℕ} {dim : Fin r → ℕ}
-variable {A : (k : Fin r) → MPSTensor d (dim k)}
-
-/-- Build `HasInjectiveBlocks` from pointwise injectivity. -/
-theorem ofForall (hA : ∀ k, Kraus.IsInjective (A k)) : HasInjectiveBlocks (d := d) A where
-  block_injective := hA
-
-end HasInjectiveBlocks
-
 /-- Each block in the family is irreducible in the invariant-projection sense. -/
 structure HasIrreducibleBlocks {r : ℕ} {dim : Fin r → ℕ}
     (A : (k : Fin r) → MPSTensor d (dim k)) : Prop where

--- a/docs/audits/2026-08-30_thirty_area_simplification_survey.md
+++ b/docs/audits/2026-08-30_thirty_area_simplification_survey.md
@@ -10,8 +10,8 @@ issues, the glossary and paper-gap records, and the newest relevant dated
 audits.
 
 The three passes found three bounded deletion batches and one stale ledger
-status. The batches remove seven declarations and 52 net Lean lines. Five
-forwarding theorems in `PiAlgebra` account for 26 lines, while one deferred
+status. The batches remove eight declarations and 63 net Lean lines. Six
+zero-reference declarations in `PiAlgebra` account for 37 lines, while one deferred
 inverse gauge construction in `PEPS` accounts for 12 net lines after its module description
 is shortened, and one attribute-carrying MPDO projection accounts for 14 lines.
 No new proof-debt issue is needed: all three batches are further
@@ -23,8 +23,9 @@ Five forwarding theorems in
 `TNLean/PiAlgebra/CanonicalFormSepAux.lean` had no production Lean consumer
 and no Blueprint tag:
 
-- `MPSTensor.IsCanonicalForm.toHasInjectiveBlocks` (line 236), whose direct
-  replacement is `HasInjectiveBlocks.ofForall hCF.block_injective`;
+- `MPSTensor.IsCanonicalForm.toHasInjectiveBlocks` (line 236); no production
+  proof requires this conversion, and pointwise injectivity is already the
+  `block_injective` field of the canonical-form hypothesis;
 - `MPSTensor.IsCanonicalForm.toIsLeftCanonicalBlockFamily` (line 240), whose
   direct replacement is
   `IsLeftCanonicalBlockFamily.ofForall hCF.leftCanonical`;
@@ -44,9 +45,14 @@ fields. The similarly named normal-form
 projections to irreducibility and left-canonical data remain live through
 `TNLean/MPS/BNT/Construction.lean` and are not candidates.
 
+Deleting `MPSTensor.IsCanonicalForm.toHasInjectiveBlocks` removed the sole
+consumer of `HasInjectiveBlocks.ofForall`. That constructor had no Blueprint
+tag and no independent mathematical role, so it is deleted in the same batch
+rather than retained as an orphaned interface.
+
 This batch is an instance of the existing zero-reference debt S2 and issue
-#4564, not a new debt. Its implementation deletes exactly 26 Lean lines and
-rewrites six glossary lines in place, so the glossary migration is line-neutral.
+#4564, not a new debt. Its implementation deletes exactly 37 Lean lines and
+rewrites the glossary in place.
 
 ## Second-pass evidence for S2 and issue #4564
 

--- a/docs/audits/2026-08-30_thirty_area_simplification_survey.md
+++ b/docs/audits/2026-08-30_thirty_area_simplification_survey.md
@@ -1,0 +1,205 @@
+# Three-pass, ninety-area simplification survey
+
+This note records three successive repository-wide applications of the
+`find-simplification` audit on 2026-08-30. The non-Archive development was
+first divided into thirty broad areas and then into thirty narrower areas for
+an independent second pass. A third pass divided the development into thirty
+cross-repository structural slices. Each area was checked against the current
+Blueprint declaration set, the open proof-debt ledger, open and closed cleanup
+issues, the glossary and paper-gap records, and the newest relevant dated
+audits.
+
+The three passes found three bounded deletion batches and one stale ledger
+status. The batches remove seven declarations and 52 net Lean lines. Five
+forwarding theorems in `PiAlgebra` account for 26 lines, while one deferred
+inverse gauge construction in `PEPS` accounts for 12 net lines after its module description
+is shortened, and one attribute-carrying MPDO projection accounts for 14 lines.
+No new proof-debt issue is needed: all three batches are further
+evidence for S2 and issue #4564.
+
+## New evidence for S2 and issue #4564
+
+Five forwarding theorems in
+`TNLean/PiAlgebra/CanonicalFormSepAux.lean` had no production Lean consumer
+and no Blueprint tag:
+
+- `MPSTensor.IsCanonicalForm.toHasInjectiveBlocks` (line 236), whose direct
+  replacement is `HasInjectiveBlocks.ofForall hCF.block_injective`;
+- `MPSTensor.IsCanonicalForm.toIsLeftCanonicalBlockFamily` (line 240), whose
+  direct replacement is
+  `IsLeftCanonicalBlockFamily.ofForall hCF.leftCanonical`;
+- `MPSTensor.IsCanonicalForm.toHasNormalizedSelfOverlap` (line 245), whose
+  direct replacement is
+  `HasNormalizedSelfOverlap.ofForall hCF.overlap_tendsto_one`;
+- `MPSTensor.IsNormalCanonicalForm.toHasPrimitiveBlocks` (line 300), whose
+  direct replacement is `HasPrimitiveBlocks.ofForall hNCF.block_primitive`;
+- `MPSTensor.IsNormalCanonicalForm.toHasNormalizedSelfOverlap` (line 337),
+  whose direct replacement is
+  `HasNormalizedSelfOverlap.ofForall hNCF.overlap_tendsto_one`.
+
+The first four names occurred in the sanctioned-bridge lists in
+`docs/glossary.md`; these were documentation references rather than Lean
+consumers and have been replaced by the direct constructors or structure
+fields. The similarly named normal-form
+projections to irreducibility and left-canonical data remain live through
+`TNLean/MPS/BNT/Construction.lean` and are not candidates.
+
+This batch is an instance of the existing zero-reference debt S2 and issue
+#4564, not a new debt. Its implementation deletes exactly 26 Lean lines and
+rewrites six glossary lines in place, so the glossary migration is line-neutral.
+
+## Second-pass evidence for S2 and issue #4564
+
+The narrower second pass independently reconfirmed the five `PiAlgebra`
+forwarders and found one further zero-reference declaration:
+`TNLean.PEPS.edgeGaugeOfCycleGauge` in
+`TNLean/PEPS/CycleMPSFundamentalTheorem.lean`. This construction had already
+been isolated for a follow-up in
+`docs/audits/2026-08-26_peps_normal_cycle_zero_reference_deletion.md` after its
+round-trip theorem was removed. A fresh search found no production Lean
+consumer, Blueprint tag, or paper-gap citation. The deletion removes its
+seven-line declaration. Shortening the module description deletes seven more
+lines and adds two replacement lines, for 12 net Lean lines in this file.
+
+The surviving direction `cycleGaugeOfEdgeGauge` remains load-bearing: it
+appears in `cycleGauge_component_iff_matrix` and in the graph-to-matrix
+presentation described by the module. Thus this batch removes only the unused
+inverse construction, not the cycle-gauge conversion used by the Fundamental
+Theorem.
+
+## Third-pass evidence for S2 and issue #4564
+
+The third pass found one attribute-carrying declaration whose name had no
+production consumer and whose simplification attribute did not fire in the
+linter-bearing module build:
+`MPOTensor.BNTFusionTensorClause.retainedMultiplicityWeightEntry_verticalCopyCoordinateEquiv_symm`
+in
+`TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean`. It was a projection
+wrapper over the corresponding retained-multiplicity coordinate formula and
+had no Blueprint tag. Deleting it removes exactly 14 Lean lines, as measured by
+`git diff --numstat` for the file.
+
+The linter-bearing verification
+`lake build TNLean.MPS.MPDO.TopologicalMultiplicityEnergy` passed after the
+deletion. Thus the build, rather than name counting alone, confirms that the
+`@[simp]` declaration was not used implicitly within the checked module. This
+batch is recorded under S2 rather than as a new issue.
+
+## Ledger correction
+
+Ledger item S12 was still marked open although commit `f3ae05159` (#7218)
+already consolidated both named spectral-split developments. The strict
+two-block decomposition now uses the shared private theorem
+`exists_twoBlock_decomp_of_lowerZero_aux`, and cyclic-sector compression now
+uses the support-isometry route. Follow-ups #7224 and #7237 completed the
+review. The ledger status is therefore corrected to burned down.
+
+## First-pass area disposition
+
+The thirty areas were:
+
+1. Algebra;
+2. MPS definitions and top-level files;
+3. MPS Core;
+4. MPS Chain;
+5. MPS Overlap;
+6. MPS Examples;
+7. MPS SharedInfra and Tactic;
+8. MPS Irreducible;
+9. MPS Symmetry;
+10. MPS Periodic;
+11. MPS FundamentalTheorem;
+12. MPS CanonicalForm root;
+13. CanonicalForm CyclicSectors;
+14. CanonicalForm NormalReduction;
+15. CanonicalForm SectorComparison;
+16. MPS BNT;
+17. MPS Structure;
+18. MPS MPU;
+19. ParentHamiltonian root;
+20. ParentHamiltonian Martingale;
+21. MPDO root, alphabetic range A--L;
+22. MPDO root, alphabetic range M--Z;
+23. MPDO BiCFDerivation;
+24. MPDO GSNNCHFourCycleMarkov;
+25. MPS RFP;
+26. PEPS root and EdgeMiddlePhysical;
+27. PEPS FundamentalTheorem and TwoInjectiveComparison;
+28. PEPS RegionBlock and TorusWindowPeeling;
+29. PEPS VertexComplement and the remaining PEPS subareas; and
+30. PiAlgebra, QCA, Spectral, and Wielandt.
+
+Apart from the five PiAlgebra forwarders, no new candidate survived. Apparent
+candidates were rejected because they were Blueprint-cited, had production
+consumers, stated substantive source mathematics, belonged to advertised
+counterexample modules, or were already owned by S2, S3, S5, D5, D7, or the
+dated simplification campaigns of 2026-08-26 through 2026-08-30. In
+particular, the left/right MPU families remain distinct source cuts, the
+ParentHamiltonian and periodic low-reference statements remain load-bearing,
+and the heavily swept MPDO/RFP and PEPS areas yielded no unrecorded deletion.
+
+## Second-pass area disposition
+
+The second pass divided the same development into thirty narrower slices,
+emphasizing private helper closures, import ownership, definition and field
+surfaces, suffix ladders, staged routes, mirrored examples, and Mathlib or
+QICLean shadows. It covered Algebra; the MPS Core, Chain, Overlap,
+Fundamental-Theorem, Canonical-Form, BNT, Structure, Irreducible, Periodic, MPU,
+Parent-Hamiltonian, MPDO, and RFP layers; PEPS; QCA; PiAlgebra; Spectral; and
+Wielandt.
+
+Apart from `edgeGaugeOfCycleGauge` and the independently reconfirmed PiAlgebra
+batch, no candidate survived. In particular, the second pass found that the
+remaining private helpers lie in live proof closures, the remaining
+SectorBNT suffixes encode source-facing hypotheses or paper-gap boundaries,
+the MPU left/right statements are distinct source cuts, the RFP
+counterexample closures advertise the witnesses they construct, and the
+surviving Spectral and Wielandt statements are either upstream-owned already
+or have production consumers. These dispositions agree with the focused
+cleanup records from 2026-08-26 through 2026-08-30 and with the open and closed
+cleanup-issue inventory.
+
+## Third-pass area disposition
+
+Areas 61--80 revisited the largest remaining MPDO and PEPS proof surfaces,
+including carrier projections, coordinate transports, counterexample modules,
+private helper closures, import ownership, and attribute-carrying declarations.
+The only surviving candidate was the MPDO projection wrapper recorded above.
+The other apparent leaves were Blueprint-exposed, belonged to advertised
+counterexamples, were used through structure fields or simplification
+attributes, or had already been settled by the focused cleanup campaign of
+2026-08-26 through 2026-08-30.
+
+Areas 81--90 covered, respectively: exact Algebra/Spectral/Wielandt upstream
+shadows; the MPS Core/Chain/Overlap closure; Fundamental-Theorem,
+Canonical-Form, and BNT projection wrappers and suffix ladders; private clones
+in Structure/Irreducible/Periodic; MPU example and private duplication;
+Parent-Hamiltonian unused fields and private clones; RFP/QCA zero-reference
+closures and imports; remaining PiAlgebra forwards and imports; duplicate
+fully qualified names and cross-file private redeclarations; and a
+repository-wide attribute-carrying and unused-import batch.
+
+No further candidate survived areas 81--90. Exact upstream shadows and private
+clones had already been consolidated by the 2026-08-27 audits; live proof
+closures accounted for the remaining private helpers; source-facing suffixes
+were protected by their Blueprint or paper-gap role; the MPU left/right
+families remained distinct source cuts; and the import candidates had already
+been proved live by downstream consumers in the root-build import audit. The
+fully-qualified-name census found no genuine collision. A larger pool of
+name-level zero-reference `@[simp]` declarations remains suitable only for
+future build-checked S2 batches: a read-only name search cannot decide whether
+their attributes fire inside unnamed simplification calls.
+
+## Repository census and limitations
+
+The census at the time of the survey was 307,948 Lean lines, 913 duplicated
+ten-line windows, 38 numbered-sequel files containing 17,396 lines, nine files
+in the 900--1000-line warning band, 1,940 degenerate-case sites, and one
+`sorry`. The Blueprint exposure census contained 6,917 unique direct Lean
+references.
+
+The surveys were discovery passes. The three deletion batches were
+subsequently implemented in the same working tree, together with the glossary
+migration; no issue was opened. The linter-bearing MPDO target build passed.
+The combined change still requires the root build and the ordinary repository
+checks prescribed by the project before it is merged.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -414,9 +414,10 @@ model different levels of data and different sources.
   stronger separated form used after blocking. Compare arXiv:2011.12127,
   `Papers/2011.12127/TN-Review-main.tex:1831-1836`.
 - **Sanctioned bridges:** `MPSTensor.IsCanonicalForm.of_peripheral_primitive`
-  constructs the form; its fields feed `HasInjectiveBlocks.ofForall`,
-  `IsLeftCanonicalBlockFamily.ofForall`, and
-  `HasNormalizedSelfOverlap.ofForall` directly.
+  constructs the form. Its `block_injective` field supplies pointwise
+  injectivity directly; its remaining fields feed
+  `IsLeftCanonicalBlockFamily.ofForall` and
+  `HasNormalizedSelfOverlap.ofForall`.
 - **Caveat:** this is not the paper's bare direct-sum CF predicate: it assumes
   one-site injectivity, left-canonical normalization, positive dimensions, and
   normalized self-overlap. The already-separated family also does not retain

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -413,10 +413,10 @@ model different levels of data and different sources.
   injectivity, normalization, positivity, and overlap hypotheses implement the
   stronger separated form used after blocking. Compare arXiv:2011.12127,
   `Papers/2011.12127/TN-Review-main.tex:1831-1836`.
-- **Sanctioned bridges:** `MPSTensor.IsCanonicalForm.of_peripheral_primitive`,
-  `MPSTensor.IsCanonicalForm.toHasInjectiveBlocks`,
-  `MPSTensor.IsCanonicalForm.toIsLeftCanonicalBlockFamily`, and
-  `MPSTensor.IsCanonicalForm.toHasNormalizedSelfOverlap`.
+- **Sanctioned bridges:** `MPSTensor.IsCanonicalForm.of_peripheral_primitive`
+  constructs the form; its fields feed `HasInjectiveBlocks.ofForall`,
+  `IsLeftCanonicalBlockFamily.ofForall`, and
+  `HasNormalizedSelfOverlap.ofForall` directly.
 - **Caveat:** this is not the paper's bare direct-sum CF predicate: it assumes
   one-site injectivity, left-canonical normalization, positive dimensions, and
   normalized self-overlap. The already-separated family also does not retain
@@ -436,8 +436,8 @@ model different levels of data and different sources.
 - **Sanctioned bridges:**
   `MPSTensor.IsNormalCanonicalForm.toHasIrreducibleBlocks`,
   `MPSTensor.IsNormalCanonicalForm.toIsLeftCanonicalBlockFamily`,
-  `MPSTensor.IsNormalCanonicalForm.toHasPrimitiveBlocks`, and
-  `MPSTensor.IsNormalCanonicalForm.ofSeparatedData`.
+  `MPSTensor.IsNormalCanonicalForm.ofSeparatedData`, and the direct constructor
+  `HasPrimitiveBlocks.ofForall` applied to the `block_primitive` field.
 - **Caveat:** this does not encode the source's modulus-bound and unit-witness
   normalization for copy weights. No public theorem identifies this predicate
   with `MPSTensor.IsCanonicalForm`; the block hypotheses differ. The positive

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -91,22 +91,22 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   parent record by `rfl` with nothing reading the pin; see
   `docs/audits/2026-08-26_canonical_form_retirements.md`.
 - **Evidence update (2026-08-30)**: three successive thirty-area surveys found
-  seven unused declarations with no production Lean consumer or Blueprint tag.
-  Five canonical-form forwarding theorems in
-  `PiAlgebra/CanonicalFormSepAux.lean` were deleted in favour of their direct
-  structure-field constructors, with their glossary listings migrated
-  (−26 Lean lines). The second pass also discharged the deferred
+  eight unused declarations with no production Lean consumer or Blueprint tag.
+  Five canonical-form forwarding theorems and the constructor orphaned by
+  their removal in `PiAlgebra/CanonicalFormSepAux.lean` were deleted, with
+  their glossary listings migrated (−37 Lean lines). The second pass also
+  discharged the deferred
   `PEPS.edgeGaugeOfCycleGauge` construction from
   `PEPS/CycleMPSFundamentalTheorem.lean`; its round-trip theorem had already
   been removed, and the inverse construction had no remaining consumer
   (−12 net Lean lines including the shorter module description). The two
-  batches remove 38 net Lean lines. The third pass removed the
+  batches remove 49 net Lean lines. The third pass removed the
   attribute-carrying projection wrapper
   `MPOTensor.BNTFusionTensorClause.retainedMultiplicityWeightEntry_verticalCopyCoordinateEquiv_symm`
   from `MPS/MPDO/TopologicalMultiplicityEnergy.lean` (−14 Lean lines). Its
   linter-bearing target build passed, confirming that its `@[simp]` attribute
   was not used implicitly within the module. The three batches therefore
-  remove 52 net Lean lines. See
+  remove 63 net Lean lines. See
   `docs/audits/2026-08-30_thirty_area_simplification_survey.md`.
 
 ### S5. Preserve the ch23 algebraic-FT chapter — retirement cancelled

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -90,6 +90,24 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   the regrouped carrier already states, and the third pinned a field to the
   parent record by `rfl` with nothing reading the pin; see
   `docs/audits/2026-08-26_canonical_form_retirements.md`.
+- **Evidence update (2026-08-30)**: three successive thirty-area surveys found
+  seven unused declarations with no production Lean consumer or Blueprint tag.
+  Five canonical-form forwarding theorems in
+  `PiAlgebra/CanonicalFormSepAux.lean` were deleted in favour of their direct
+  structure-field constructors, with their glossary listings migrated
+  (−26 Lean lines). The second pass also discharged the deferred
+  `PEPS.edgeGaugeOfCycleGauge` construction from
+  `PEPS/CycleMPSFundamentalTheorem.lean`; its round-trip theorem had already
+  been removed, and the inverse construction had no remaining consumer
+  (−12 net Lean lines including the shorter module description). The two
+  batches remove 38 net Lean lines. The third pass removed the
+  attribute-carrying projection wrapper
+  `MPOTensor.BNTFusionTensorClause.retainedMultiplicityWeightEntry_verticalCopyCoordinateEquiv_symm`
+  from `MPS/MPDO/TopologicalMultiplicityEnergy.lean` (−14 Lean lines). Its
+  linter-bearing target build passed, confirming that its `@[simp]` attribute
+  was not used implicitly within the module. The three batches therefore
+  remove 52 net Lean lines. See
+  `docs/audits/2026-08-30_thirty_area_simplification_survey.md`.
 
 ### S5. Preserve the ch23 algebraic-FT chapter — retirement cancelled
 - **Status**: cancelled (#4565; owner decision on #7220)
@@ -106,7 +124,7 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
   future CycleMPS simplification requires a separate, freshly verified issue.
 
 ### S12. Collapse duplicated spectral-split proofs onto `ProjectionSpectralSplit`/corner-compression API — net 520 lines, risk 5/10
-- **Status**: open (#4566)
+- **Status**: burned down (#7218, follow-ups #7224 and #7237)
 - **What**: `MPS/Structure/InvariantSubspaceDecomp.lean`'s strict-case
   theorem re-proves its base theorem's 129-line body near-verbatim
   (728 → ~380 ln after fix); `MPS/CanonicalForm/CyclicSectors/Compression.lean`
@@ -120,6 +138,13 @@ live mathematics. Tracked under [#4529](https://github.com/LionSR/TNLean/issues/
 - **First PR**: `InvariantSubspaceDecomp.lean` alone — extract the shared
   spectral-split body, derive both public theorems as corollaries. Net
   ~-300 to -350 lines, proof-only.
+- **Outcome (2026-08-27)**: commit `f3ae05159` factors the two-block
+  decomposition through the shared private theorem
+  `exists_twoBlock_decomp_of_lowerZero_aux` and reduces
+  `MPS/CanonicalForm/CyclicSectors/Compression.lean` to the support-isometry
+  route. Follow-ups #7224 and #7237 close the remaining review items. The
+  present files are approximately 399 and 160 lines, respectively, rather
+  than the 728- and 433-line versions measured by the original audit.
 
 ### S7. Delete the confirmed-dead half of the UnionInjectivityOverlap chain — completed
 - **Status**: burned down (#4567, #4625, follow-up #7232)


### PR DESCRIPTION
## What changed

- remove five unused canonical-form forwarding theorems and the block-injectivity constructor orphaned by their deletion
- remove the unused inverse cycle-gauge construction and retained-multiplicity simp wrapper
- record the three-pass simplification survey and synchronize the glossary and proof-debt ledger

## Validation

- `git diff --check`
- repository-wide reference scan for all eight deleted declarations
- `lake build TNLean.MPS.MPDO.TopologicalMultiplicityEnergy TNLean.PEPS.CycleMPSFundamentalTheorem TNLean.PiAlgebra.CanonicalFormSepAux` (9443 jobs)

Advances #4564
