### PR TITLE
feat(PEPS): formalize scoped cyclic MPS description

### DIFF
--- a/TNLean/MPS/Chain/VaryingBondOBC.lean
+++ b/TNLean/MPS/Chain/VaryingBondOBC.lean
@@ -115,6 +115,29 @@ theorem coeff_eq_sum_cyclic (A : MPSChainTensor d D N)
   simp only [B, τ, Equiv.symm_apply_apply] at h
   simpa [MPSChainTensor.coeff, MPSChainTensor.eval, List.ofFn_eq_map] using h
 
+/-- Cyclically shifting the tensors in a square closed chain is equivalent,
+at the level of coefficients, to shifting the physical configuration in the
+opposite direction.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1827 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeff_cyclicShift (A : MPSChainTensor d D N) [NeZero N]
+    (σ : Fin N → Fin d) :
+    coeff (cyclicShift A) σ = coeff A (fun v => σ ((finRotate N).symm v)) := by
+  rw [coeff_eq_sum_cyclic, coeff_eq_sum_cyclic]
+  let e : (Fin N → Fin D) ≃ (Fin N → Fin D) :=
+    Equiv.arrowCongr (finRotate N) (Equiv.refl (Fin D))
+  refine Fintype.sum_equiv e _ _ fun g => ?_
+  let F : Fin N → ℂ := fun m =>
+    A m (σ ((finRotate N).symm m)) ((e g) m) ((e g) (m + 1))
+  calc
+    (∏ v : Fin N, (cyclicShift A) v (σ v) (g v) (g (v + 1))) =
+        ∏ v : Fin N, F (finRotate N v) := by
+          apply Finset.prod_congr rfl
+          intro v _
+          simp [F, e, cyclicShift, cyclicSucc, finRotate_apply]
+    _ = ∏ m : Fin N, F m := Equiv.prod_comp (finRotate N) F
+
 end MPSChainTensor
 
 namespace OBCChainTensor

--- a/TNLean/PEPS/CycleMPSConstantDescription.lean
+++ b/TNLean/PEPS/CycleMPSConstantDescription.lean
@@ -157,7 +157,7 @@ theorem Tensor.isInjective_reindexMPSChain
   intro v
   let q := cycleIncidentPairEquiv (D := D) hn v
   let f : Fin D × Fin D → Fin d → ℂ :=
-    (reindexTensor A hDim).component v ∘ q.symm
+    A'.component v ∘ q.symm
   have hLI : LinearIndependent ℂ f := (hA' v).comp q.symm q.symm.injective
   let e : Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] ((Fin D × Fin D) → ℂ) :=
     (LinearEquiv.curry ℂ ℂ (Fin D) (Fin D)).symm
@@ -169,30 +169,6 @@ theorem Tensor.isInjective_reindexMPSChain
   rw [Kraus.IsInjective, ← Submodule.map_eq_top_iff (e := e),
     Submodule.map_span, ← Set.range_comp, hcomp]
   exact span_flip_eq_top_iff_linearIndependent.mpr hLI
-
-/-- Cyclically shifting the tensors in a square closed chain is equivalent,
-at the level of coefficients, to shifting the physical configuration in the
-opposite direction.
-
-Source: arXiv:1804.04964, Applications section, lines 1807--1827 of
-`Papers/1804.04964/paper_normal.tex`. -/
-theorem MPSChainTensor.coeff_cyclicShift
-    {n d D : ℕ} [NeZero n] (A : MPSChainTensor d D n)
-    (sigma : Fin n → Fin d) :
-    coeff (cyclicShift A) sigma = coeff A (fun v => sigma ((finRotate n).symm v)) := by
-  rw [MPSChainTensor.coeff_eq_sum_cyclic, MPSChainTensor.coeff_eq_sum_cyclic]
-  let e : (Fin n → Fin D) ≃ (Fin n → Fin D) :=
-    Equiv.arrowCongr (finRotate n) (Equiv.refl (Fin D))
-  refine Fintype.sum_equiv e _ _ fun g => ?_
-  let F : Fin n → ℂ := fun m =>
-    A m (sigma ((finRotate n).symm m)) ((e g) m) ((e g) (m + 1))
-  calc
-    (∏ v : Fin n, (cyclicShift A) v (sigma v) (g v) (g (v + 1))) =
-        ∏ v : Fin n, F (finRotate n v) := by
-          apply Finset.prod_congr rfl
-          intro v _
-          simp [F, e, cyclicShift, cyclicSucc, finRotate_apply]
-    _ = ∏ m : Fin n, F m := Equiv.prod_comp (finRotate n) F
 
 /-- The common-bond reindexing preserves cyclic-shift invariance of the
 closed-chain state.

--- a/TNLean/PEPS/CycleMPSConstantDescription.lean
+++ b/TNLean/PEPS/CycleMPSConstantDescription.lean
@@ -13,7 +13,8 @@ import Mathlib.LinearAlgebra.Dual.Lemmas
 /-!
 # Translation-invariant description of an injective closed MPS chain
 
-This file delivers the Applications-section corollary of arXiv:1804.04964
+This file delivers the positive-bond, at-least-three-site form of the
+Applications-section corollary of arXiv:1804.04964
 (`Papers/1804.04964/paper_normal.tex`, the corollary at line 1804, proof lines
 1807--1890).  For a cycle-graph tensor with one virtual dimension per bond,
 cyclic-shift invariance first makes all bond dimensions equal.  The dependent
@@ -37,11 +38,23 @@ by `B`, hence is a scalar `λ ≠ 0`.  An `n`-th root `c^n = λ⁻¹`, available
 tensor `B' = c · B`, which is still injective and generates the same closed
 state.
 
-**Local fix (cyclic seam scalar):** At source lines 1860--1889, the paper
-sets the closing products `R_{n+1}` and `L_{n+1}` equal to the identity.  The
-closed-chain argument only forces their residual product to be a nonzero
-scalar.  The proof below absorbs an inverse `n`-th root of that scalar into the
-repeated tensor.  This correction is documented in
+**Local fix (cyclic seam scalar):** At source line 1876, the paper sets the
+closing products `R_{n+1}` and `L_{n+1}` equal to the identity.  The
+closed-chain argument only forces the closing loop product to be a nonzero
+scalar.  The proof below absorbs an inverse `n`-th root of that scalar into
+the repeated tensor.  This correction is documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+**Scope restriction (positive bonds and at least three sites):** The final
+theorem below assumes positive virtual dimensions and `3 ≤ n`.  Positivity is
+not intrinsic to the current `Tensor` type, and the source corollary at line
+1804 does not state either hypothesis.  However, the source section explicitly
+works with at least three sites at line 145, and the corollary's proof invokes
+the corresponding Fundamental Theorem at lines 688--725.  Thus `3 ≤ n` records
+the intended source context rather than a missing short-chain extension.  The
+literal two-site statement is false for nondegenerate rectangular bond data,
+so omission of this qualifier from the printed corollary is a source-scope
+defect.  The remaining source-facing gap is recorded in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 The uniform-chain theorem
@@ -431,9 +444,10 @@ theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState
       arcEval_const, Kraus.evalWord_smul, List.length_ofFn, Matrix.trace_smul,
       smul_eq_mul, hc]
 
-/-- **Translation-invariant description of an injective closed MPS chain with
-one dimension per bond** (arXiv:1804.04964, Applications section, corollary
-line 1804 and proof lines 1807--1890).
+/-- **Positive-bond, at-least-three-site translation-invariant description of
+an injective closed MPS chain with one dimension per bond**
+(arXiv:1804.04964, Applications section, corollary line 1804 and proof lines
+1807--1890).
 
 Let a site-dependent injective MPS on the cycle graph have positive virtual
 dimension on every bond, and suppose that its closed-chain state is invariant
@@ -445,7 +459,9 @@ The first step is `bondDim_eq_of_isCycleShiftInvariantState`, corresponding to
 source lines 1807--1842.  The tensor is then explicitly reindexed to the
 uniform chain `Tensor.reindexMPSChain`.  The existing uniform theorem above
 supplies the source's `L_i,R_i` telescoping, seam closure, and repeated tensor
-from lines 1843--1889. -/
+from lines 1843--1889.  The explicit positive-bond and `3 ≤ n` hypotheses are
+the scope restriction documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
 theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond
     {n d : ℕ} [NeZero n] (hn : 3 ≤ n)
     (A : Tensor (SimpleGraph.cycleGraph n) d)

--- a/TNLean/PEPS/CycleMPSConstantDescription.lean
+++ b/TNLean/PEPS/CycleMPSConstantDescription.lean
@@ -3,20 +3,25 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Chain.VaryingBondOBC
 import TNLean.PEPS.CycleMPSChainOverlapCapstone
+import TNLean.PEPS.CycleShiftBondUniformity
 
 import Mathlib.FieldTheory.IsAlgClosed.Basic
+import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
 # Translation-invariant description of an injective closed MPS chain
 
 This file delivers the Applications-section corollary of arXiv:1804.04964
 (`Papers/1804.04964/paper_normal.tex`, the corollary at line 1804, proof lines
-1807--1890) in the uniform physical- and bond-dimension setting: an injective
-site-dependent closed chain whose generated state is invariant under the cyclic
-shift of the local tensors admits a translation-invariant description by a
-single repeated injective tensor `B` of the same bond dimension
-(`exists_constant_injectiveMPS_of_cyclicShiftInvariantState`).
+1807--1890).  For a cycle-graph tensor with one virtual dimension per bond,
+cyclic-shift invariance first makes all bond dimensions equal.  The dependent
+spaces `Fin (D_e)` are then reindexed to one common `Fin D`, producing the
+uniform closed chain to which the already proved `L_i,R_i` telescoping and seam
+closure apply.  The result is a single repeated injective tensor `B` of the
+same bond dimension
+(`exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond`).
 
 The argument follows the source.  Comparing the chain with its cyclic shift
 through the injective MPS Fundamental Theorem
@@ -32,15 +37,18 @@ by `B`, hence is a scalar `λ ≠ 0`.  An `n`-th root `c^n = λ⁻¹`, available
 tensor `B' = c · B`, which is still injective and generates the same closed
 state.
 
-**Scope restriction (uniform bond dimension):** the source corollary also
-concludes that all per-bond dimensions of the original site-dependent
-representation are equal; in the uniform `MPSChainTensor d D n` setting that
-clause is built into the type and carries no content.  For a cycle-graph tensor
-with one dimension per edge, `bondDim_eq_of_isCycleShiftInvariantState` now
-proves the source's equal-dimension conclusion.  The remaining follow-up is the
-explicit reindexing from those propositionally equal edge spaces to the uniform
-closed-chain representation used by this theorem; it is recorded in
+**Local fix (cyclic seam scalar):** At source lines 1860--1889, the paper
+sets the closing products `R_{n+1}` and `L_{n+1}` equal to the identity.  The
+closed-chain argument only forces their residual product to be a nonzero
+scalar.  The proof below absorbs an inverse `n`-th root of that scalar into the
+repeated tensor.  This correction is documented in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+The uniform-chain theorem
+`exists_constant_injectiveMPS_of_cyclicShiftInvariantState` remains the
+source's telescoping calculation.  The graph-to-chain bridge below only makes
+the source's implicit identification of the now-equal virtual spaces explicit;
+it does not introduce a second varying-bond chain model.
 
 ## References
 
@@ -57,6 +65,142 @@ namespace TNLean
 namespace PEPS
 
 open MPSChainTensor
+
+/-! ### Reindexing equal cycle bonds to one matrix chain -/
+
+/-- Reindex a cycle-graph tensor whose bond dimensions are all equal to `D`
+as a site-dependent chain of `D × D` matrices.  The row index is read from
+the bond entering the site and the column index from the bond leaving it.
+
+This is the explicit dependent-index identification used after the
+equal-bond-dimension step in arXiv:1804.04964, Applications section, proof
+lines 1843--1890 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def Tensor.reindexMPSChain
+    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n)
+    (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hDim : (fun _ : Edge (SimpleGraph.cycleGraph n) => D) = A.bondDim) :
+    MPSChainTensor d D n :=
+  let A' := reindexTensor A hDim
+  fun v i a b =>
+    A'.component v ((cycleIncidentPairEquiv (D := D) hn v).symm (a, b)) i
+
+/-- Reindexing all cycle bonds to one common `Fin D` preserves every
+closed-chain coefficient.
+
+Source: arXiv:1804.04964, Applications section, lines 1843--1889 of
+`Papers/1804.04964/paper_normal.tex`, where the equal virtual spaces are read
+as square matrices before the `L_i,R_i` telescoping. -/
+theorem Tensor.stateCoeff_reindexMPSChain
+    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n)
+    (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hDim : (fun _ : Edge (SimpleGraph.cycleGraph n) => D) = A.bondDim)
+    (sigma : Fin n → Fin d) :
+    stateCoeff A sigma = MPSChainTensor.coeff (A.reindexMPSChain hn hDim) sigma := by
+  rw [← stateCoeff_reindexTensor A hDim sigma,
+    MPSChainTensor.coeff_eq_sum_cyclic]
+  unfold stateCoeff
+  refine (Fintype.sum_equiv
+    (Equiv.arrowCongr (cycleEdgeEquiv hn).symm (Equiv.refl (Fin D)))
+    (fun eta : VirtualConfig (reindexTensor A hDim) =>
+      ∏ v : Fin n, (reindexTensor A hDim).component v (fun ie => eta ie.1) (sigma v))
+    (fun g : Fin n → Fin D =>
+      ∏ v : Fin n, (A.reindexMPSChain hn hDim) v (sigma v) (g (v - 1)) (g v))
+    (fun eta => Finset.prod_congr rfl fun v _ => by
+      have hedge (w : Fin n) :
+          ((Equiv.arrowCongr (cycleEdgeEquiv hn).symm (Equiv.refl (Fin D))) eta) w =
+            eta (cycleSuccEdge hn w) := rfl
+      rw [hedge (v - 1), hedge v]
+      change (reindexTensor A hDim).component v (fun ie => eta ie.1) (sigma v) =
+        (reindexTensor A hDim).component v
+          ((cycleIncidentPairEquiv (D := D) hn v).symm
+            (eta (cycleSuccEdge hn (v - 1)), eta (cycleSuccEdge hn v))) (sigma v)
+      congr 1
+      exact ((cycleIncidentPairEquiv (D := D) hn v).symm_apply_apply
+        (fun ie => eta ie.1)).symm)).trans
+    (Fintype.sum_equiv
+      (Equiv.arrowCongr (Equiv.subRight (1 : Fin n)).symm (Equiv.refl (Fin D)))
+      (fun g : Fin n → Fin D =>
+        ∏ v : Fin n, (A.reindexMPSChain hn hDim) v (sigma v) (g (v - 1)) (g v))
+      (fun g : Fin n → Fin D =>
+        ∏ v : Fin n, (A.reindexMPSChain hn hDim) v (sigma v) (g v) (g (v + 1)))
+      (fun g => Finset.prod_congr rfl fun v _ => by
+        simp only [Equiv.arrowCongr_apply, Equiv.symm_symm, Equiv.coe_refl,
+          Function.comp_apply, Equiv.subRight_apply, id_eq]
+        rw [add_sub_cancel_right]))
+
+/-- Reindexing all cycle bonds to one common `Fin D` carries vertex
+injectivity to sitewise matrix injectivity.
+
+Source: arXiv:1804.04964, Applications section, lines 1843--1890 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem Tensor.isInjective_reindexMPSChain
+    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n)
+    (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hDim : (fun _ : Edge (SimpleGraph.cycleGraph n) => D) = A.bondDim)
+    (hA : IsVertexInjective A) :
+    MPSChainTensor.IsInjective (A.reindexMPSChain hn hDim) := by
+  let A' := reindexTensor A hDim
+  have hA' : IsVertexInjective A' := isVertexInjective_reindexTensor A hDim hA
+  intro v
+  let q := cycleIncidentPairEquiv (D := D) hn v
+  let f : Fin D × Fin D → Fin d → ℂ :=
+    (reindexTensor A hDim).component v ∘ q.symm
+  have hLI : LinearIndependent ℂ f := (hA' v).comp q.symm q.symm.injective
+  let e : Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] ((Fin D × Fin D) → ℂ) :=
+    (LinearEquiv.curry ℂ ℂ (Fin D) (Fin D)).symm
+  have hcomp :
+      (⇑(e : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin D × Fin D) → ℂ))) ∘
+        (A.reindexMPSChain hn hDim v) = flip f := by
+    funext i p
+    rfl
+  rw [Kraus.IsInjective, ← Submodule.map_eq_top_iff (e := e),
+    Submodule.map_span, ← Set.range_comp, hcomp]
+  exact span_flip_eq_top_iff_linearIndependent.mpr hLI
+
+/-- Cyclically shifting the tensors in a square closed chain is equivalent,
+at the level of coefficients, to shifting the physical configuration in the
+opposite direction.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1827 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem MPSChainTensor.coeff_cyclicShift
+    {n d D : ℕ} [NeZero n] (A : MPSChainTensor d D n)
+    (sigma : Fin n → Fin d) :
+    coeff (cyclicShift A) sigma = coeff A (fun v => sigma ((finRotate n).symm v)) := by
+  rw [MPSChainTensor.coeff_eq_sum_cyclic, MPSChainTensor.coeff_eq_sum_cyclic]
+  let e : (Fin n → Fin D) ≃ (Fin n → Fin D) :=
+    Equiv.arrowCongr (finRotate n) (Equiv.refl (Fin D))
+  refine Fintype.sum_equiv e _ _ fun g => ?_
+  let F : Fin n → ℂ := fun m =>
+    A m (sigma ((finRotate n).symm m)) ((e g) m) ((e g) (m + 1))
+  calc
+    (∏ v : Fin n, (cyclicShift A) v (sigma v) (g v) (g (v + 1))) =
+        ∏ v : Fin n, F (finRotate n v) := by
+          apply Finset.prod_congr rfl
+          intro v _
+          simp [F, e, cyclicShift, cyclicSucc, finRotate_apply]
+    _ = ∏ m : Fin n, F m := Equiv.prod_comp (finRotate n) F
+
+/-- The common-bond reindexing preserves cyclic-shift invariance of the
+closed-chain state.
+
+Source: arXiv:1804.04964, Applications section, lines 1807--1890 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem Tensor.isCyclicShiftInvariantState_reindexMPSChain
+    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n)
+    (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hDim : (fun _ : Edge (SimpleGraph.cycleGraph n) => D) = A.bondDim)
+    (hTI : IsCycleShiftInvariantState A hn) :
+    MPSChainTensor.IsCyclicShiftInvariantState (A.reindexMPSChain hn hDim) := by
+  intro sigma
+  rw [MPSChainTensor.coeff_cyclicShift,
+    ← A.stateCoeff_reindexMPSChain hn hDim sigma,
+    ← A.stateCoeff_reindexMPSChain hn hDim (fun v => sigma ((finRotate n).symm v))]
+  have h := hTI sigma
+  rw [Tensor.cycleShift, stateCoeff_transport] at h
+  have hrotate (v : Fin n) :
+      (cycleRotate hn).symm v = (finRotate n).symm v := rfl
+  simpa only [hrotate] using h
 
 /-- The running product `Z_{m-1} ⋯ Z_0` of the first `m` cyclic-shift gauges.
 This is the uniform-bond-dimension form of the products denoted `L_i`, `R_i` in
@@ -86,7 +230,8 @@ theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState
     {n d D : ℕ} [NeZero n] (hn : 3 ≤ n) (hD : 0 < D)
     (A : MPSChainTensor d D n)
     (hA : IsInjective A) (hTI : IsCyclicShiftInvariantState A) :
-    ∃ B : MPSTensor d D, Kraus.IsInjective B ∧ SameState A (fun _ : Fin n => B) := by
+    ∃ B : MPSTensor d D, Kraus.IsInjective B ∧
+      MPSChainTensor.SameState A (fun _ : Fin n => B) := by
   have hn0 : 0 < n := by omega
   have : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
   -- The cyclic-shift comparison: one invertible gauge per bond.
@@ -285,6 +430,54 @@ theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState
     rw [hcoeffA σ, coeff_eq_trace_arcEval (fun _ : Fin n => fun i => c • B i) σ,
       arcEval_const, Kraus.evalWord_smul, List.length_ofFn, Matrix.trace_smul,
       smul_eq_mul, hc]
+
+/-- **Translation-invariant description of an injective closed MPS chain with
+one dimension per bond** (arXiv:1804.04964, Applications section, corollary
+line 1804 and proof lines 1807--1890).
+
+Let a site-dependent injective MPS on the cycle graph have positive virtual
+dimension on every bond, and suppose that its closed-chain state is invariant
+under the cyclic shift `Aᵥ ↦ Aᵥ₊₁`.  Then all bond dimensions equal one
+positive integer `D`, and the state is generated by one repeated injective
+`D × D` matrix tensor `B`.
+
+The first step is `bondDim_eq_of_isCycleShiftInvariantState`, corresponding to
+source lines 1807--1842.  The tensor is then explicitly reindexed to the
+uniform chain `Tensor.reindexMPSChain`.  The existing uniform theorem above
+supplies the source's `L_i,R_i` telescoping, seam closure, and repeated tensor
+from lines 1843--1889. -/
+theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond
+    {n d : ℕ} [NeZero n] (hn : 3 ≤ n)
+    (A : Tensor (SimpleGraph.cycleGraph n) d)
+    (hA : IsVertexInjective A) (hTI : IsCycleShiftInvariantState A hn)
+    (hpos : ∀ e : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim e) :
+    ∃ D : ℕ, 0 < D ∧ (∀ e, A.bondDim e = D) ∧
+      ∃ B : MPSTensor d D, Kraus.IsInjective B ∧
+        ∀ sigma : Fin n → Fin d, stateCoeff A sigma = MPSTensor.mpv B sigma := by
+  let e₀ := cycleSuccEdge hn (0 : Fin n)
+  let D := A.bondDim e₀
+  have hD : 0 < D := hpos e₀
+  have hDim : ∀ e : Edge (SimpleGraph.cycleGraph n), A.bondDim e = D := fun e =>
+    bondDim_eq_of_isCycleShiftInvariantState hn A hA hTI hpos e e₀
+  have hDim' : (fun _ : Edge (SimpleGraph.cycleGraph n) => D) = A.bondDim := by
+    funext e
+    exact (hDim e).symm
+  let C := A.reindexMPSChain hn hDim'
+  have hCInjective : MPSChainTensor.IsInjective C :=
+    A.isInjective_reindexMPSChain hn hDim' hA
+  have hCShift : MPSChainTensor.IsCyclicShiftInvariantState C :=
+    A.isCyclicShiftInvariantState_reindexMPSChain hn hDim' hTI
+  obtain ⟨B, hBInjective, hBC⟩ :=
+    exists_constant_injectiveMPS_of_cyclicShiftInvariantState hn hD C hCInjective hCShift
+  refine ⟨D, hD, hDim, B, hBInjective, ?_⟩
+  intro sigma
+  calc
+    stateCoeff A sigma = MPSChainTensor.coeff C sigma :=
+      A.stateCoeff_reindexMPSChain hn hDim' sigma
+    _ = MPSChainTensor.coeff (fun _ : Fin n => B) sigma := hBC sigma
+    _ = MPSTensor.mpv B sigma := by
+      rw [MPSChainTensor.coeff_eq_trace_arcEval, MPSChainTensor.arcEval_const,
+        MPSTensor.mpv_eq, MPSTensor.coeff_eq]
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -498,12 +498,29 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
 \end{corollary}
 \begin{proof}\leanok
     By Corollary~\ref{cor:peps_cycle_shift_bond_uniform}, every bond has the
-    dimension $D$ of a fixed reference bond. Reindex each bond configuration
-    along these equalities and, at every site, read the entering and leaving
-    indices as the row and column of a $D\times D$ matrix. Reindexing the
-    finite contraction preserves every state coefficient; the corresponding
-    reindexing of the two incident virtual indices preserves injectivity.
-    Moreover, cyclically shifting the matrix chain amounts to precomposing the
+    dimension $D$ of a fixed reference bond. Write $e_v$ for the bond from
+    $v$ to $v+1$, transport every bond index to $\{0,\ldots,D-1\}$, and let
+    \begin{align}
+        \iota_v(\xi)&=\bigl(\xi(e_{v-1}),\xi(e_v)\bigr),
+        & C_v^i(a,b)&=A_v^{\prime\,i}\!\left(\iota_v^{-1}(a,b)\right),
+        \notag
+    \end{align}
+    where $A'_v$ is the transported local tensor. If $g(v)=\eta(e_v)$, the
+    two corresponding changes of finite summation variables give
+    \begin{align}
+        \Coeff_A(\sigma)
+        &=\sum_{\eta}\prod_{v=0}^{n-1}
+          A_v^{\prime\,\sigma_v}\!\left(\eta|_v\right)
+          \notag\\
+        &=\sum_{g:\{0,\ldots,n-1\}\to\{0,\ldots,D-1\}}
+          \prod_{v=0}^{n-1}
+          C_v^{\sigma_v}\!\left(g(v-1),g(v)\right)
+         =\Coeff_C(\sigma).
+        \notag
+    \end{align}
+    Each $\iota_v$ is a bijection, so the same coordinate change preserves
+    injectivity of every local tensor. Cyclically shifting the matrix chain
+    amounts to precomposing the
     physical configuration by the inverse cyclic rotation, so cyclic-shift
     invariance is preserved. Apply
     Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -501,21 +501,21 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     dimension $D$ of a fixed reference bond. Write $e_v$ for the bond from
     $v$ to $v+1$, transport every bond index to $\{0,\ldots,D-1\}$, and let
     \begin{align}
-        \iota_v(\xi)&=\bigl(\xi(e_{v-1}),\xi(e_v)\bigr),
-        & C_v^i(a,b)&=A_v^{\prime\,i}\!\left(\iota_v^{-1}(a,b)\right),
+        \iota_v(\xi) & =\bigl(\xi(e_{v-1}),\xi(e_v)\bigr),
+                     & C_v^i(a,b)                          & =A_v^{\prime\,i}\!\left(\iota_v^{-1}(a,b)\right),
         \notag
     \end{align}
     where $A'_v$ is the transported local tensor. If $g(v)=\eta(e_v)$, the
     two corresponding changes of finite summation variables give
     \begin{align}
         \Coeff_A(\sigma)
-        &=\sum_{\eta}\prod_{v=0}^{n-1}
-          A_v^{\prime\,\sigma_v}\!\left(\eta|_v\right)
-          \notag\\
-        &=\sum_{g:\{0,\ldots,n-1\}\to\{0,\ldots,D-1\}}
-          \prod_{v=0}^{n-1}
-          C_v^{\sigma_v}\!\left(g(v-1),g(v)\right)
-         =\Coeff_C(\sigma).
+         & =\sum_{\eta}\prod_{v=0}^{n-1}
+        A_v^{\prime\,\sigma_v}\!\left(\eta|_v\right)
+        \notag                                           \\
+         & =\sum_{g:\{0,\ldots,n-1\}\to\{0,\ldots,D-1\}}
+        \prod_{v=0}^{n-1}
+        C_v^{\sigma_v}\!\left(g(v-1),g(v)\right)
+        =\Coeff_C(\sigma).
         \notag
     \end{align}
     Each $\iota_v$ is a bijection, so the same coordinate change preserves

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -471,7 +471,7 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     \lean{TNLean.PEPS.Tensor.reindexMPSChain}
     \lean{TNLean.PEPS.Tensor.stateCoeff_reindexMPSChain}
     \lean{TNLean.PEPS.Tensor.isInjective_reindexMPSChain}
-    \lean{TNLean.PEPS.MPSChainTensor.coeff_cyclicShift}
+    \lean{MPSChainTensor.coeff_cyclicShift}
     \lean{TNLean.PEPS.Tensor.isCyclicShiftInvariantState_reindexMPSChain}
     \lean{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
     \leanok

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -519,10 +519,10 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
         \notag
     \end{align}
     Each $\iota_v$ is a bijection, so the same coordinate change preserves
-    injectivity of every local tensor. Cyclically shifting the matrix chain
-    amounts to precomposing the
-    physical configuration by the inverse cyclic rotation, so cyclic-shift
-    invariance is preserved. Apply
+    injectivity of every local tensor. If $r(v)=v+1$ is the cyclic rotation,
+    then
+    $\Coeff_{\mathrm{shift}(C)}(\sigma)=\Coeff_C(\sigma\circ r^{-1})$;
+    hence cyclic-shift invariance is preserved. Apply
     Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
     to this uniform chain. Its $L_i,R_i$ telescoping and seam closure produce
     the required repeated injective tensor $B$.

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -468,7 +468,13 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
 \begin{corollary}[Translation-invariant description of an injective closed MPS chain,
         per-bond form]%
     \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-    \notready
+    \lean{TNLean.PEPS.Tensor.reindexMPSChain}
+    \lean{TNLean.PEPS.Tensor.stateCoeff_reindexMPSChain}
+    \lean{TNLean.PEPS.Tensor.isInjective_reindexMPSChain}
+    \lean{TNLean.PEPS.MPSChainTensor.coeff_cyclicShift}
+    \lean{TNLean.PEPS.Tensor.isCyclicShiftInvariantState_reindexMPSChain}
+    \lean{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+    \leanok
     \uses{cor:peps_cycle_shift_bond_uniform, cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
     Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS on
     $n\ge3$ sites, with positive dimensions $D_e$ on its individual bonds.
@@ -486,19 +492,23 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
 
     This is the full per-bond statement of
     \cite[lines~1803--1890]{Molnar2018NormalPEPS}. The equality $D_e=D$ is
-    Corollary~\ref{cor:peps_cycle_shift_bond_uniform}; what remains is to
-    transport the now-equal virtual spaces into the uniform closed-chain
-    representation and apply the already proved $L_i,R_i$ telescoping and
-    seam closure.
+    Corollary~\ref{cor:peps_cycle_shift_bond_uniform}. Identifying each
+    virtual space with $\C^D$ gives a uniform closed-chain representation,
+    to which the already proved $L_i,R_i$ telescoping and seam closure apply.
 \end{corollary}
-\begin{proof}
-    The source first compares the family with its cyclic shift, obtaining
-    adjacent bond isomorphisms and hence one common dimension $D$. After
-    identifying every bond with $\C^D$, its products $L_i$ and $R_i$ express
-    every $A_i$ through $A_0$; the common residual operation is absorbed into
-    one repeated tensor $B$. The bond-uniformity step is complete. The explicit
-    reindexing to the uniform closed-chain representation remains to be
-    supplied.
+\begin{proof}\leanok
+    By Corollary~\ref{cor:peps_cycle_shift_bond_uniform}, every bond has the
+    dimension $D$ of a fixed reference bond. Reindex each bond configuration
+    along these equalities and, at every site, read the entering and leaving
+    indices as the row and column of a $D\times D$ matrix. Reindexing the
+    finite contraction preserves every state coefficient; the corresponding
+    reindexing of the two incident virtual indices preserves injectivity.
+    Moreover, cyclically shifting the matrix chain amounts to precomposing the
+    physical configuration by the inverse cyclic rotation, so cyclic-shift
+    invariance is preserved. Apply
+    Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
+    to this uniform chain. Its $L_i,R_i$ telescoping and seam closure produce
+    the required repeated injective tensor $B$.
 \end{proof}
 
 \begin{corollary}[Translation-invariant description of an injective 2D PEPS,

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -349,8 +349,8 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     $v+1$ to $v+2$ have the same dimension. Iterating around the cycle gives
     $D_e=D_f$ for every pair of bonds $e,f$.
 
-    This is the ``all bond dimensions are the same'' clause of the
-    Applications-section corollary in
+    This is the positive-bond, at-least-three-site form of the ``all bond
+    dimensions are the same'' clause of the Applications-section corollary in
     \cite[lines~1803--1842]{Molnar2018NormalPEPS}. Positivity excludes empty
     virtual spaces, the same counterexample-backed correction as in the
     injective Fundamental Theorem.
@@ -466,8 +466,8 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
 \end{proof}
 
 \begin{corollary}[Translation-invariant description of an injective closed MPS chain,
-        per-bond form]%
-    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+        positive-bond form on at least three sites]%
+    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}
     \lean{TNLean.PEPS.Tensor.reindexMPSChain}
     \lean{TNLean.PEPS.Tensor.stateCoeff_reindexMPSChain}
     \lean{TNLean.PEPS.Tensor.isInjective_reindexMPSChain}
@@ -490,7 +490,7 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     \end{align}
     for every physical configuration $\sigma$.
 
-    This is the full per-bond statement of
+    This is the positive-bond, at-least-three-site form corresponding to
     \cite[lines~1803--1890]{Molnar2018NormalPEPS}. The equality $D_e=D$ is
     Corollary~\ref{cor:peps_cycle_shift_bond_uniform}. Identifying each
     virtual space with $\C^D$ gives a uniform closed-chain representation,
@@ -509,6 +509,40 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
     to this uniform chain. Its $L_i,R_i$ telescoping and seam closure produce
     the required repeated injective tensor $B$.
+\end{proof}
+
+\begin{corollary}[Translation-invariant description of an injective closed MPS chain,
+        source statement]%
+    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+    \notready
+    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}
+    Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS, with
+    dimension $D_e$ on each individual bond. If the closed-chain state is
+    invariant under the cyclic shift $A_v\mapsto A_{v+1}$, then all bond
+    dimensions are equal to one dimension $D$, and there is an injective
+    tensor $B$ of $D\times D$ matrices such that
+    \begin{align}
+        \Coeff_A(\sigma)
+         & =
+        \tr\!\left(B^{\sigma_0}\cdots B^{\sigma_{n-1}}\right)
+        \notag
+    \end{align}
+    for every physical configuration $\sigma$.
+
+    This is the corollary stated in
+    \cite[lines~1803--1890]{Molnar2018NormalPEPS}, without adding the positive
+    bond-dimension or $n\ge3$ hypotheses that do not appear in its statement.
+\end{corollary}
+\begin{proof}
+    For positive bond dimensions in the intended $n\ge3$ source context, this
+    is the preceding corollary. The source states at line~145 that its
+    injective MPS Fundamental Theorem concerns at least three sites and invokes
+    precisely that theorem here. Thus omission of $n\ge3$ from the displayed
+    corollary is a source-scope defect: the literal two-site statement is false
+    for nondegenerate rectangular bond dimensions. It is not a short-chain
+    extension left to this proof. The positive-dimension condition must be
+    built into the domain of bond dimensions or removed mathematically before
+    the printed statement can be marked complete.
 \end{proof}
 
 \begin{corollary}[Translation-invariant description of an injective 2D PEPS,

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2550,12 +2550,15 @@ the rotation of successor edges gives
 and cyclic induction gives equality on every pair of cycle edges in
 \leanid{TNLean.PEPS.bondDim_eq_of_isCycleShiftInvariantState}. These results
 carry the explicit positivity assumption inherited from the corrected
-injective Fundamental Theorem; it excludes empty virtual spaces.
+injective Fundamental Theorem; it excludes empty virtual spaces. They also
+assume at least three sites, the hypothesis of the injective MPS Fundamental
+Theorem at source lines 688--725 that the proof invokes at line 1828.
 
 The repeated-tensor implication in
 (\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}) is now
-formalized end to end. Its gauge calculation is first proved for a family
-$A_i$ with one common bond dimension:
+formalized end to end for positive bond dimensions on at least three sites.
+Its gauge calculation is first proved for a family $A_i$ with one common bond
+dimension:
 \begin{align}
     T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n)
         &\Longrightarrow
@@ -2591,12 +2594,27 @@ lemmas \leanid{TNLean.PEPS.Tensor.stateCoeff_reindexMPSChain},
 that this identification preserves the closed-state coefficients,
 injectivity, and cyclic-shift invariance. Applying the uniform theorem gives
 \leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond},
-the full implication
-(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}).
+the positive-bond, at-least-three-site form of
+(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}). The
+Blueprint records this proved restriction as
+\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}.
 
-\emph{Verdict: complete.} The Blueprint entry
+\emph{Verdict: the explicit reindexing and repeated-tensor construction are
+complete under the positive-bond and at-least-three-site restrictions; the
+unrestricted source entry remains not ready.} The Blueprint entry
 \path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-now records the full source statement. The proof follows the source route:
+records the printed corollary separately and carries no Lean declaration. The
+positive-bond hypothesis is currently external because
+\leanid{TNLean.PEPS.Tensor} stores bond dimensions in $\mathbb{N}$ and admits
+empty virtual spaces; it must be made intrinsic to the source-facing domain or
+eliminated before the printed statement can be marked complete. The source
+corollary also omits a system-size hypothesis, although its proof invokes the
+at-least-three-particle Fundamental Theorem. The source section explicitly
+sets this scope at line~145. Thus $n\ge3$ is the intended source context, and
+its omission from the displayed corollary is a source-scope defect. Indeed,
+the literal two-site statement is false for nondegenerate rectangular bond
+dimensions; it is not a short-chain extension left to the present argument.
+The proved restricted theorem follows the source route:
 equality of the bond dimensions, explicit identification of the equal virtual
 spaces, and the already formalized $L_i,R_i$ telescoping and seam closure. It
 introduces neither a collected gauge factorization nor an alternative proof
@@ -2626,7 +2644,8 @@ The load-bearing dependency, the injective PEPS Fundamental Theorem
 (\leanid{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
 \path{thm:fundamentalTheorem_PEPS}), is formalized. The one-dimensional
 repeated-tensor construction discussed above is also formalized as
-\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}.
+\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
+under the positive-bond and at-least-three-site restrictions just stated.
 The remaining work is the PEPS-specific two-directional closure: the horizontal
 and vertical gauge telescopings must be compatible around plaquettes and
 periodic seams, and their residual virtual operations must be absorbed into one

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2553,9 +2553,9 @@ carry the explicit positivity assumption inherited from the corrected
 injective Fundamental Theorem; it excludes empty virtual spaces.
 
 The repeated-tensor implication in
-(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}) still has
-two complementary pieces rather than one end-to-end theorem. Under a prior
-uniform bond-dimension hypothesis on the family $A_i$, the proved statement is
+(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}) is now
+formalized end to end. Its gauge calculation is first proved for a family
+$A_i$ with one common bond dimension:
 \begin{align}
     T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n)
         &\Longrightarrow
@@ -2563,11 +2563,9 @@ uniform bond-dimension hypothesis on the family $A_i$, the proved statement is
         \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B).
     \label{eq:peps_normal_ft_section3_route_uniform_bond_repeated_tensor}
 \end{align}
-Thus (\ref{eq:peps_normal_ft_section3_route_uniform_bond_repeated_tensor})
-omits the equal-bond-dimension conclusion in
-(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_equal_bond_dimensions})
-because its matrix-chain type assumes it.
-The blueprint records this restricted target as
+The matrix-chain type in
+(\ref{eq:peps_normal_ft_section3_route_uniform_bond_repeated_tensor}) assumes
+the equal bond dimension. The Blueprint records this uniform calculation as
 \path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}, now
 formalized as
 \leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
@@ -2581,18 +2579,28 @@ scalar, but not necessarily the identity, so an \(n\)-th root (available since
 \(\mathbb{C}\) is algebraically closed) is needed to fold the residual phase
 into the repeated tensor.
 
-\emph{Verdict: the bond-dimension clause is complete; the end-to-end
-corollary remains a scope restriction.} The missing step is now an explicit
-reindexing theorem. Starting from the proved equality of all cycle-edge
-dimensions, it must identify the two incident virtual indices at every site
-with one common pair $\operatorname{Fin}(D)\times\operatorname{Fin}(D)$,
-convert the cycle-graph tensor into a uniform
-\path{MPSChainTensor d D n}, and preserve vertex injectivity, the closed-state
-coefficients, and cyclic-shift invariance. The existing uniform theorem then
-constructs $B$. The Blueprint records the full source statement separately as
+The bridge from the per-bond cycle tensor to this uniform calculation is
+\leanid{TNLean.PEPS.Tensor.reindexMPSChain}. With $D$ the dimension of one
+reference bond,
+\leanid{TNLean.PEPS.bondDim_eq_of_isCycleShiftInvariantState} identifies every
+bond dimension with $D$, and \leanid{TNLean.PEPS.reindexTensor} transports the
+dependent spaces $\operatorname{Fin}(D_e)$ to $\operatorname{Fin}(D)$. The
+lemmas \leanid{TNLean.PEPS.Tensor.stateCoeff_reindexMPSChain},
+\leanid{TNLean.PEPS.Tensor.isInjective_reindexMPSChain}, and
+\leanid{TNLean.PEPS.Tensor.isCyclicShiftInvariantState_reindexMPSChain} show
+that this identification preserves the closed-state coefficients,
+injectivity, and cyclic-shift invariance. Applying the uniform theorem gives
+\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond},
+the full implication
+(\ref{eq:peps_normal_ft_section3_route_cyclic_shift_repeated_tensor}).
+
+\emph{Verdict: complete.} The Blueprint entry
 \path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-and keeps it not ready until this reindexing is supplied. No collected gauge
-factorization or alternative proof route is required.
+now records the full source statement. The proof follows the source route:
+equality of the bond dimensions, explicit identification of the equal virtual
+spaces, and the already formalized $L_i,R_i$ telescoping and seam closure. It
+introduces neither a collected gauge factorization nor an alternative proof
+route.
 
 \subsection*{The 2D analogue}
 
@@ -2618,7 +2626,7 @@ The load-bearing dependency, the injective PEPS Fundamental Theorem
 (\leanid{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
 \path{thm:fundamentalTheorem_PEPS}), is formalized. The one-dimensional
 repeated-tensor construction discussed above is also formalized as
-\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
+\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}.
 The remaining work is the PEPS-specific two-directional closure: the horizontal
 and vertical gauge telescopings must be compatible around plaquettes and
 periodic seams, and their residual virtual operations must be absorbed into one

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1462,6 +1462,28 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### cycle-edge virtual-configuration sum reindexing — candidate
+- **Pattern:** identify assignments on the edges of a cycle with assignments
+  indexed by its sites using `cycleEdgeEquiv`, then, when a cyclic product is
+  required, rotate the site-indexed assignment by one step so that the two
+  incident virtual indices become `g v` and `g (v + 1)`.
+- **Seen:** the site-to-edge reindexing occurs in
+  `Tensor.stateCoeff_reindexMPSChain` in
+  `TNLean/PEPS/CycleMPSConstantDescription.lean`,
+  `stateCoeff_cycleTensorOfMPS` in `TNLean/PEPS/CycleMPSTensor.lean`, and the
+  blocked-region calculation in `TNLean/PEPS/CycleMPSInjectivity.lean`
+  (2026-08-31). The subsequent one-step rotation occurs in the first two of
+  these proofs.
+- **Abstraction (proposed):** if a third proof needs the full two-stage
+  reindexing, extract a cycle-graph sum lemma parameterized by the local
+  factor. Keep the factor-specific incident-edge and blocked-arc identities
+  at their call sites.
+- **Notes:** `Fintype.sum_equiv` already owns the common first stage; its three
+  remaining congruence obligations have different mathematical content. The
+  exact two-stage proof occurs twice, so it remains below the promotion
+  threshold rather than introducing a wrapper around the existing finite-sum
+  equivalence.
+
 ### one-site blocking by canonical physical reindexing — candidate
 - **Pattern:** identify the doubled physical alphabet after one-site blocking
   with the original doubled alphabet, prove that blocking is the resulting


### PR DESCRIPTION
### Motivation

- The Applications corollary in `Papers/1804.04964/paper_normal.tex`, lines 1803--1890, prints the conclusion that all bond dimensions are equal and that the state has a translation-invariant injective MPS description.
- Its proof invokes the injective MPS Fundamental Theorem at line 1828. That theorem, and the surrounding source context at line 145, explicitly concern chains with at least three sites.
- The current `Tensor` type also admits zero-dimensional bonds, so the Lean theorem carries a separate positive-bond hypothesis. These two restrictions must remain visible under the repository faithfulness rule.

### Description

- Define `Tensor.reindexMPSChain` by applying the existing `reindexTensor` transport to the equalities `D_e = D`, and read the incoming and outgoing cycle bonds through `cycleIncidentPairEquiv` as the two indices of a `D × D` matrix.
- Prove that this explicit reindexing preserves every closed-state coefficient, vertex injectivity, and cyclic-shift invariance. The coefficient proof reindexes only the two finite contractions already present; the injectivity proof uses `span_flip_eq_top_iff_linearIndependent`; the shift proof uses `MPSChainTensor.coeff_cyclicShift`.
- Apply the existing uniform-chain theorem `exists_constant_injectiveMPS_of_cyclicShiftInvariantState`. The resulting per-bond theorem, under positive bond dimensions and `3 ≤ n`, concludes both `∀ e, A.bondDim e = D` and existence of one repeated injective tensor `B` with the same state.
- Keep the proved Blueprint entry explicitly scoped and ready as `cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos`. Record the unrestricted printed corollary separately, under the original source-facing label, as `\notready` with no Lean declaration.
- Update `docs/paper-gaps/peps_normal_ft_section3_route.tex` to the exact partial verdict. The omitted `n ≥ 3` qualifier is a source-scope defect: the literal two-site conclusion is false for nondegenerate rectangular bond data, not a short-chain case promised by this proof. A kernel-checked counterexample is being handled separately.
- Retain one consolidated `**Local fix (cyclic seam scalar):**` marker. Source line 1876 sets the closing products equal to the identity, whereas the closed-chain argument gives `P_n = λI`; choosing `c^n = λ⁻¹` and replacing `B₀` by `cB₀` closes the seam.
- Display the incident-index bijections, transported matrices, and equality between the original edge contraction and the cyclic matrix-chain sum in the Blueprint proof.

### Paper dictionary

The paper has
`A_{i+1} = Z_i⁻¹ A_i Z_{i+1}`, `L_i = Z_1⋯Z_{i-1}`, and `R_i = Z_2⋯Z_i`.
With zero-based indices, Lean uses `Ẑ_k = Z_{k+1}⁻¹` and
`P_m = Ẑ_{m-1}⋯Ẑ_0 = L_{m+1}⁻¹`. Its tentative tensor is
`B₀ = A_0 Ẑ_0 = A_1 Z_1⁻¹`, exactly the tensor printed at lines 1876--1889, and
`A_m = P_m B₀ P_{m+1}⁻¹ = L_{m+1}⁻¹ A_1 R_{m+1}`.

### Testing

- `scripts/lake_build_locked.sh TNLean.PEPS.CycleMPSConstantDescription`
- `scripts/lake_build_locked.sh TNLean` (10,437 jobs on exact rebased head `864886812`)
- `scripts/lake_build_locked.sh -- lake exe lint_style --github`
- `scripts/lake_build_locked.sh -- lake exe checkdecls blueprint/lean_decls`
- `scripts/lake_build_locked.sh -- python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `python3 scripts/test_blueprint_lean_sync.py`
- `PYTHONPATH=scripts python3 scripts/test_paper_gap_leanid_sync.py`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web` with the pinned `texra-blueprint` v0.3.8 plugin and pinned `tenkz` checkout
- `scripts/latexindent -l blueprint/latexindent.yaml -w -s blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex` (byte-idempotent)
- reader-facing prose, import-aggregator, proof-integrity, and whitespace checks

Addresses #3371
