### PR TITLE
refactor(MPS): simplify MPDO and RFP leaves

### DIFF
--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -150,9 +150,6 @@ def formAt (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
     CommutingFormData d N :=
   data.bondData.toCommutingFormData (N := N) hN
 
-@[simp] theorem formAt_bond (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
-    (data.formAt N hN).bond = data.bondData.bond := rfl
-
 /-- The chain-level commuting-form witness obtained from `EtaLocalStructureData`
 realizes the MPO operator at that chain length. -/
 theorem formAt_realizes (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -335,25 +335,14 @@ private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ)
       norm_num [Complex.ofReal_sqrt_sq 2 (by norm_num : (0 : ℝ) ≤ 2)]
     _ = (1 / 2 : ℂ) := by norm_num
 
-private noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
 private noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
 private noncomputable def katoCFWeights : Fin 2 → ℂ :=
-  fun k => match k with | 0 => block0Weight | 1 => block1Weight
+  fun k => match k with | 0 => blockLetterAmplitude | 1 => block1Weight
 
 private lemma katoCFWeights_ne_zero (k : Fin 2) : katoCFWeights k ≠ 0 := by
   have hs : (Real.sqrt 2 : ℂ) ≠ 0 := by
     exact_mod_cast (Real.sqrt_pos.mpr (show (0 : ℝ) < 2 by norm_num)).ne'
-  fin_cases k <;> simp [katoCFWeights, block0Weight, block1Weight, hs]
-
-private lemma block0Weight_times_amplitude :
-    block0Weight * blockLetterAmplitude = (1 / 2 : ℂ) := by
-  calc
-    block0Weight * blockLetterAmplitude =
-        ((1 : ℂ) / Real.sqrt 2) * ((1 : ℂ) / Real.sqrt 2) := rfl
-    _ = 1 / ((Real.sqrt 2 : ℂ) ^ 2) := by ring
-    _ = 1 / (2 : ℂ) := by
-      norm_num [Complex.ofReal_sqrt_sq 2 (by norm_num : (0 : ℝ) ≤ 2)]
-    _ = (1 / 2 : ℂ) := by norm_num
+  fin_cases k <;> simp [katoCFWeights, blockLetterAmplitude, block1Weight, hs]
 
 private lemma block1Weight_times_amplitude :
     block1Weight * blockLetterAmplitude = (1 / 4 : ℂ) := by
@@ -488,12 +477,12 @@ private theorem toMPSTensor_eq_toTensorFromBlocks :
       rcases hp_val with rfl | rfl
       · fin_cases x
         · simp [tensor, siteSign, Fin.divNat, Fin.modNat,
-            katoCFBlock0, block0Weight_times_amplitude]
+            katoCFBlock0, ← pow_two, blockLetterAmplitude_sq]
         · simp [tensor, siteSign, Fin.divNat, Fin.modNat,
             katoCFBlock1, block1Weight_times_amplitude]
       · fin_cases x
         · simp [tensor, siteSign, Fin.divNat, Fin.modNat,
-            katoCFBlock0, block0Weight_times_amplitude]
+            katoCFBlock0, ← pow_two, blockLetterAmplitude_sq]
         · simp [tensor, siteSign, Fin.divNat, Fin.modNat,
             katoCFBlock1, block1Weight_times_amplitude]
     · -- p.divNat ≠ p.modNat means p is 1 or 2; tensor = 0 and blocks = 0

--- a/TNLean/MPS/MPDO/PhysicalSupportBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportBondCommutativity.lean
@@ -194,12 +194,5 @@ noncomputable def liftedTranslationInvariantBondData
       neighboring_comm := fun _ ↦ F.liftedBond_zero_one_comm data hN }
     simpa [G, GSNNCHData.bondAt] using G.bondAt_comm (0 : Fin 1) i j
 
-/-- The local bond of the lifted translation-invariant data is the isometric
-conjugate of the restricted bond. -/
-@[simp] theorem liftedTranslationInvariantBondData_bond
-    (F : PhysicalSupportRestrictionData P K)
-    (data : TranslationInvariantBondData F.supportDim) :
-    (F.liftedTranslationInvariantBondData data).bond =
-      F.liftedBond data.bond := rfl
 
 end MPOTensor.PhysicalSupportRestrictionData

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -554,14 +554,6 @@ noncomputable def liftedEtaLocalStructureData
       (sitewisePhysicalMatrix F.inclusion N)).map_smul]
     rw [F.singleKrausMap_bondProduct_eq_liftedBondProduct data.bondData hN]
 
-/-- The lifted eta-local structure has the isometrically included restricted
-bond as its local bond. -/
-@[simp] theorem liftedEtaLocalStructureData_bond
-    (F : PhysicalSupportRestrictionData P K)
-    (data : EtaLocalStructureData
-      (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)) :
-    (F.liftedEtaLocalStructureData data).bondData.bond =
-      F.liftedBond data.bondData.bond := rfl
 
 /-- A positive physical-sector factorization on the restricted physical space
 gives a positive commuting bond for the ambient tensor supported on the tensor

--- a/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
+++ b/TNLean/MPS/MPDO/RescalingStableExplicitVerticalBNT.lean
@@ -529,24 +529,5 @@ noncomputable def R_oneLabelBNTAlgebraTensorClause : BNTAlgebraTensorClause R wh
   coeffs := oneLabelCoeffs
   algebraClause := R_oneLabelAlgebraClause
 
-/-- The explicit BNT algebra tensor clause for `R` has one label. -/
-@[simp] theorem R_oneLabelBNTAlgebraTensorClause_labelCount :
-    R_oneLabelBNTAlgebraTensorClause.labelCount = 1 := rfl
-
-/-- The tensor in the unique BNT label is the normalized vertical component. -/
-@[simp] theorem R_oneLabelBNTAlgebraTensorClause_tensor (α : Fin 1) :
-    R_oneLabelBNTAlgebraTensorClause.tensor α = verticalComponent := rfl
-
-/-- The unique vertical multiplicity weight is `25/32`. -/
-@[simp] theorem R_oneLabelBNTAlgebraTensorClause_weight (α : Fin 1) (q : Fin 1) :
-    R_oneLabelBNTAlgebraTensorClause.weight α q = 25 / 32 := rfl
-
-/-- The explicit clause uses the coefficient family `oneLabelCoeffs`. -/
-@[simp] theorem R_oneLabelBNTAlgebraTensorClause_coeffs :
-    R_oneLabelBNTAlgebraTensorClause.coeffs = oneLabelCoeffs := rfl
-
-/-- The positive trace-power family in the explicit clause is `oneLabelChi`. -/
-@[simp] theorem R_oneLabelBNTAlgebraTensorClause_chi :
-    R_oneLabelBNTAlgebraTensorClause.algebraClause.positiveChi.chi = oneLabelChi := rfl
 
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/RFP/AppendixBSupportProjectionCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBSupportProjectionCommutation.lean
@@ -435,31 +435,6 @@ theorem AppendixBStructuralData.twoSiteBasicSupportProjection_commute_lifts
   rw [← hStruct.transportedTwoSiteBondProjection_eq_support]
   exact hStruct.transportedTwoSiteBondProjection_commute_lifts
 
-/-- Commutation of the two lifted basic-support projectors implies the
-overlapping two-site commutation condition for their complementary Appendix B
-parent interactions.
-
-Source: arXiv:1606.00608, parent construction, lines 511--524, equations
-(3.17)--(3.18), lines 564--578, and Definition D.2, lines 2205--2218. -/
-theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_support_commute
-    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
-    (hcomm :
-      leftPairLift hStruct.twoSiteBasicSupportProjection *
-          rightPairLift hStruct.twoSiteBasicSupportProjection =
-        rightPairLift hStruct.twoSiteBasicSupportProjection *
-          leftPairLift hStruct.twoSiteBasicSupportProjection) :
-    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
-      hStruct.appendixBQXBOnCoeffSpace := by
-  let hSupport : HasOverlappingTwoSiteCommutation (d := d)
-      hStruct.twoSiteBasicSupportProjection hStruct.twoSiteBasicSupportProjection :=
-    { left_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
-      right_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
-      commute_lifts := hcomm }
-  have hComplement := hSupport.complement
-  simpa [hStruct.twoSiteBasicSupportProjection_eq_complement,
-    AppendixBStructuralData.appendixBQAXOnCoeffSpace,
-    AppendixBStructuralData.appendixBQXBOnCoeffSpace] using hComplement
-
 /-- The two overlapping Appendix B parent interactions commute on three sites.
 
 Source: arXiv:1606.00608, parent-space construction, lines 511--524,
@@ -468,9 +443,16 @@ equations (3.16)--(3.18), lines 543--578, and Definition D.2, lines
 theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
-      hStruct.appendixBQXBOnCoeffSpace :=
-  hStruct.hasOverlappingTwoSiteCommutation_of_support_commute
-    hStruct.twoSiteBasicSupportProjection_commute_lifts
+      hStruct.appendixBQXBOnCoeffSpace := by
+  let hSupport : HasOverlappingTwoSiteCommutation (d := d)
+      hStruct.twoSiteBasicSupportProjection hStruct.twoSiteBasicSupportProjection :=
+    { left_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
+      right_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
+      commute_lifts := hStruct.twoSiteBasicSupportProjection_commute_lifts }
+  have hComplement := hSupport.complement
+  simpa [hStruct.twoSiteBasicSupportProjection_eq_complement,
+    AppendixBStructuralData.appendixBQAXOnCoeffSpace,
+    AppendixBStructuralData.appendixBQXBOnCoeffSpace] using hComplement
 
 
 end MPSTensor

--- a/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
+++ b/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Commuting
-import Mathlib.LinearAlgebra.Dimension.Constructions
 
 /-!
 # Eventual dimension of nearest-neighbor parent ground spaces

--- a/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
+++ b/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Algebra.MatrixIsometryEntries
 import TNLean.MPS.RFP.BeigiLoopSchmidtSupport
 
 /-!

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Channel.KrausFreedom
 import QICLean.Kraus.Transfer
 import TNLean.MPS.Defs

--- a/docs/audits/2026-08-31_mpdo_rfp_simplification_followup.md
+++ b/docs/audits/2026-08-31_mpdo_rfp_simplification_followup.md
@@ -1,0 +1,96 @@
+# MPDO/RFP simplification follow-up
+
+This audit applies `.claude/skills/find-simplification/SKILL.md` to the 365 Lean
+files under `TNLean/MPS/MPDO/` and the 46 Lean files under `TNLean/MPS/RFP/`.
+The survey started at `27b321fff450db6341cdcfb135ab1d89ee6a2ba5`; the
+validated batch is rebased onto `3abe545abb173a4df58370f216d37ec8f82f6753`.
+It follows the August 27 MPDO/RFP campaign and the August 30 word-evaluation cleanup. Issue #7553 tracks the
+bounded deletion batch under proof-debt tracker #4529. The source paper,
+Blueprint statements, and paper-gap classifications are unchanged.
+
+## Validated removals
+
+The deletion test removes the following declarations. Exact-name and
+receiver-style searches found no remaining non-`Archive` Lean consumer, direct
+Blueprint tag, or surviving documentation reference unless a consumer is named
+below.
+
+| Removed declaration | Survivor or replacement | Net reduction |
+|---|---|---:|
+| `MPOTensor.EtaLocalStructureData.formAt_bond` | The projection reduces by `rfl` from `EtaLocalStructureData.formAt`. | 3 lines |
+| `MPOTensor.PhysicalSupportRestrictionData.liftedTranslationInvariantBondData_bond` | The projection reduces by `rfl` from `liftedTranslationInvariantBondData`. | 7 lines |
+| `MPOTensor.PhysicalSupportRestrictionData.liftedEtaLocalStructureData_bond` | The projection reduces by `rfl` from `liftedEtaLocalStructureData`. | 8 lines |
+| `MPOTensor.RescalingStableLengthDependentRFP.R_oneLabelBNTAlgebraTensorClause_labelCount` | The field reduces definitionally from `R_oneLabelBNTAlgebraTensorClause`. | 3 lines |
+| `MPOTensor.RescalingStableLengthDependentRFP.R_oneLabelBNTAlgebraTensorClause_tensor` | The field reduces definitionally from `R_oneLabelBNTAlgebraTensorClause`. | 3 lines |
+| `MPOTensor.RescalingStableLengthDependentRFP.R_oneLabelBNTAlgebraTensorClause_weight` | The field reduces definitionally from `R_oneLabelBNTAlgebraTensorClause`. | 3 lines |
+| `MPOTensor.RescalingStableLengthDependentRFP.R_oneLabelBNTAlgebraTensorClause_coeffs` | The field reduces definitionally from `R_oneLabelBNTAlgebraTensorClause`. | 3 lines |
+| `MPOTensor.RescalingStableLengthDependentRFP.R_oneLabelBNTAlgebraTensorClause_chi` | The field reduces definitionally from `R_oneLabelBNTAlgebraTensorClause`. | 3 lines |
+| `MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_support_commute` | Its sole consumer, `AppendixBStructuralData.hasOverlappingTwoSiteCommutation`, now performs the complement construction directly. | 18 net lines |
+
+The one-label parent construction remains Blueprint-tagged and is consumed by
+`RescalingStableLengthDependentRFPCapstone.lean`. That capstone already closes
+its coefficient-family obligation by definitional equality and does not name
+any removed projection theorem. The Appendix B capstone and its supporting
+commutator remain Blueprint-tagged and unchanged in statement.
+
+## Private duplicate
+
+`TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean` defined both
+`block0Weight` and `blockLetterAmplitude` as the same complex number,
+`1 / Real.sqrt 2`, and proved the same square calculation twice. The deletion
+test uses `blockLetterAmplitude` as the zero-block weight, removes
+`block0Weight` and `block0Weight_times_amplitude`, and reuses
+`blockLetterAmplitude_sq` at the two local simplification sites. Both removed
+names were private. The change is a net reduction of 11 lines.
+
+## Import edges
+
+Three direct imports elaborate redundantly against the present dependency
+graph and are removed:
+
+- `Mathlib.LinearAlgebra.Dimension.Constructions` from
+  `TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean`;
+- `QICLean.Algebra.MatrixIsometryEntries` from
+  `TNLean/MPS/RFP/BeigiLoopInjectivity.lean`;
+- `QICLean.Algebra.MatrixIsometryEntries` from `TNLean/MPS/RFP/Defs.lean`.
+
+These removals change no declaration or Blueprint reference. Their net
+reduction is 3 lines.
+
+The complete proposed source change is 80 deleted and 11 added lines, for a net
+reduction of 69 lines.
+
+## Retained declarations
+
+The same root-build deletion test covered two additional zero-name-reference
+`@[simp]` lemmas, but this audit retains them:
+
+- `MPOTensor.AlgebraStructureData.toBlockedCoefficients_reconstructFromBlockedCoefficients`
+  is one direction of the natural equivalence API, paired with
+  `reconstructFromBlockedCoefficients_toBlockedCoefficients`. Its independent
+  statement is useful even without a current repository consumer.
+- `MPOTensor.CommutingFormData.bondAt_apply` is the public evaluation theorem
+  for a translated bond. It exposes the defining window condition rather than
+  merely projecting a constructor field.
+
+The following settled surfaces are also retained:
+
+- source-facing or Blueprint-tagged RFP theorems, including
+  `rfp_nt_structural_of_leftCanonical`, `rfp_nt_structural_full`, and the
+  printed BNT spectral-pair obstruction;
+- unexpired deprecations, including `blockTransferSum_blockTransferSum`;
+- the Appendix B coordinate simp lemmas used by bare `simp` in finite-coordinate
+  proofs;
+- QICLean-owned channel and matrix APIs;
+- all material associated with issue #7371, whose remaining PEPS-to-RFP claim
+  lacks source specifications rather than library infrastructure.
+
+## Verification
+
+The candidate names were checked against non-`Archive` Lean sources, the
+multiline-aware Blueprint declaration parser, reader-facing documentation,
+Git history, and open and closed cleanup issues. The deletion batch passes the
+changed-module builds and a root `lake build` with 10,437 jobs. Thus the root
+importers were elaborated after all attribute-carrying declarations were
+removed. The audit does not alter any source-facing statement or close any
+paper-level question.


### PR DESCRIPTION
## What changed

- remove eight unused definitional projection simp lemmas from the MPDO commuting-form, physical-support, and explicit one-label BNT surfaces
- collapse the private duplicate `block0Weight` calculation into `blockLetterAmplitude_sq`
- inline the untagged Appendix B support-complement forwarding theorem into its sole capstone consumer
- remove three redundant direct RFP imports
- record the consumer, Blueprint, history, risk, replacement, and retention audit

The Lean source delta is 80 deletions and 11 additions, for a net reduction of 69 lines. The Blueprint-tagged one-label clause, Appendix B capstone, source-facing statements, QICLean boundary, unexpired deprecations, and issue #7371 remain unchanged.

## Validation

- `lake build` at rebased head: 10,437 jobs passed
- changed-module builds passed
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: 7,208/7,208 entries formalized; declarations in sync
- `python3 scripts/check_forbidden_lean_tokens.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Closes #7553
