### PR TITLE
fix(PEPS): refute two-site cyclic MPS bond uniformity

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -25,6 +25,7 @@ import TNLean.PEPS.CycleMPSInjectivity
 import TNLean.PEPS.CycleMPSOverlapCapstone
 import TNLean.PEPS.CycleMPSTensor
 import TNLean.PEPS.CycleMPSTranslationInvariant
+import TNLean.PEPS.CycleMPSTwoSiteCounterexample
 import TNLean.PEPS.CycleMPSWordTransport
 import TNLean.PEPS.CycleShiftBondUniformity
 import TNLean.PEPS.Defs

--- a/TNLean/PEPS/CycleMPSTwoSiteCounterexample.lean
+++ b/TNLean/PEPS/CycleMPSTwoSiteCounterexample.lean
@@ -57,7 +57,7 @@ def IsRectangularInjective {d Dₗ Dᵣ : ℕ}
 /-- The coefficient equality expressing invariance of a two-site closed MPS
 under the cyclic shift of its two local tensors.
 
-Source: arXiv:1804.04964, lines 1803--1808. -/
+Source: arXiv:1804.04964, lines 1807--1827. -/
 def IsTwoSiteCyclicShiftInvariantState {d D₁ D₂ : ℕ}
     (A₁ : Fin d → Matrix (Fin D₁) (Fin D₂) ℂ)
     (A₂ : Fin d → Matrix (Fin D₂) (Fin D₁) ℂ) : Prop :=

--- a/TNLean/PEPS/CycleMPSTwoSiteCounterexample.lean
+++ b/TNLean/PEPS/CycleMPSTwoSiteCounterexample.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Chain.Defs
+
+/-!
+# The two-site cyclic MPS bond-uniformity claim is false
+
+The Applications-section corollary of arXiv:1804.04964, printed at line 1804
+of `Papers/1804.04964/paper_normal.tex`, omits the standing assumption that the
+chain has at least three sites.  This file gives a nondegenerate two-site
+counterexample to its bond-uniformity conclusion.
+
+Take physical dimension two and virtual dimensions `D₁ = 1`, `D₂ = 2`.
+For the standard basis vectors `e₀,e₁`, let the first tensor consist of the
+rows `eᵢᵀ` and the second tensor of the columns `eᵢ`.  Both local maps from
+the two-dimensional virtual space to the two-dimensional physical space are
+isomorphisms.  Their two-site coefficient is
+
+\[
+  \operatorname{tr}(A_1^i A_2^j)=\delta_{ij}
+    =\operatorname{tr}(A_2^i A_1^j),
+\]
+
+so the state is invariant under the cyclic shift, although `D₁ ≠ D₂`.
+
+This is a genuine positive-dimensional example, not a zero-bond degeneracy.
+It explains why the source's injective MPS Fundamental Theorem is stated for
+at least three sites at lines 688--725 and why the surrounding section declares
+that standing hypothesis at line 145.
+
+## Reference
+
+* Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Applications-section corollary and proof, lines 1803--1890 of the local
+  source.
+-/
+
+open scoped Matrix
+
+namespace TNLean
+namespace PEPS
+namespace CycleMPSTwoSiteCounterexample
+
+/-- A rectangular MPS tensor is injective when its virtual basis vectors give
+a linearly independent family of physical vectors.
+
+This is the two-leg form of the source definition at arXiv:1804.04964,
+lines 196--205. -/
+def IsRectangularInjective {d Dₗ Dᵣ : ℕ}
+    (A : Fin d → Matrix (Fin Dₗ) (Fin Dᵣ) ℂ) : Prop :=
+  LinearIndependent ℂ (fun p : Fin Dₗ × Fin Dᵣ ↦ fun i ↦ A i p.1 p.2)
+
+/-- The coefficient equality expressing invariance of a two-site closed MPS
+under the cyclic shift of its two local tensors.
+
+Source: arXiv:1804.04964, lines 1803--1808. -/
+def IsTwoSiteCyclicShiftInvariantState {d D₁ D₂ : ℕ}
+    (A₁ : Fin d → Matrix (Fin D₁) (Fin D₂) ℂ)
+    (A₂ : Fin d → Matrix (Fin D₂) (Fin D₁) ℂ) : Prop :=
+  ∀ i j, Matrix.trace (A₁ i * A₂ j) = Matrix.trace (A₂ i * A₁ j)
+
+/-- The first tensor: the two standard row vectors in `Mat₁×₂(ℂ)`. -/
+noncomputable def rowTensor (i : Fin 2) : Matrix (Fin 1) (Fin 2) ℂ :=
+  fun _ b ↦ (Pi.single b (1 : ℂ) : Fin 2 → ℂ) i
+
+/-- The second tensor: the two standard column vectors in `Mat₂×₁(ℂ)`. -/
+noncomputable def columnTensor (i : Fin 2) : Matrix (Fin 2) (Fin 1) ℂ :=
+  fun b _ ↦ (Pi.single b (1 : ℂ) : Fin 2 → ℂ) i
+
+/-- The two row tensors form a basis of the two-dimensional physical space. -/
+theorem rowTensor_isRectangularInjective :
+    IsRectangularInjective rowTensor := by
+  have hinj : Function.Injective (fun p : Fin 1 × Fin 2 ↦ p.2) := by
+    intro p q hpq
+    exact Prod.ext (Subsingleton.elim _ _) hpq
+  have h := (Pi.basisFun ℂ (Fin 2)).linearIndependent.comp
+    (fun p : Fin 1 × Fin 2 ↦ p.2) hinj
+  rw [IsRectangularInjective]
+  convert h using 1
+  funext p i
+  simp [rowTensor, Pi.basisFun_apply]
+
+/-- The two column tensors form a basis of the two-dimensional physical space. -/
+theorem columnTensor_isRectangularInjective :
+    IsRectangularInjective columnTensor := by
+  have hinj : Function.Injective (fun p : Fin 2 × Fin 1 ↦ p.1) := by
+    intro p q hpq
+    exact Prod.ext hpq (Subsingleton.elim _ _)
+  have h := (Pi.basisFun ℂ (Fin 2)).linearIndependent.comp
+    (fun p : Fin 2 × Fin 1 ↦ p.1) hinj
+  rw [IsRectangularInjective]
+  convert h using 1
+  funext p i
+  simp [columnTensor, Pi.basisFun_apply]
+
+/-- The row--column contraction is the Kronecker delta. -/
+theorem trace_rowTensor_mul_columnTensor (i j : Fin 2) :
+    Matrix.trace (rowTensor i * columnTensor j) = if i = j then 1 else 0 := by
+  fin_cases i <;> fin_cases j <;>
+    simp [rowTensor, columnTensor, Matrix.trace, Matrix.mul_apply, Pi.single_apply]
+
+/-- The column--row contraction has the same trace, by the same direct
+Kronecker-delta calculation. -/
+theorem trace_columnTensor_mul_rowTensor (i j : Fin 2) :
+    Matrix.trace (columnTensor i * rowTensor j) = if i = j then 1 else 0 := by
+  rw [Matrix.trace_mul_comm, trace_rowTensor_mul_columnTensor]
+  simp only [eq_comm]
+
+/-- The state of the rectangular two-site chain is invariant under its cyclic
+shift. -/
+theorem twoSite_cyclicShiftInvariant :
+    IsTwoSiteCyclicShiftInvariantState rowTensor columnTensor := by
+  intro i j
+  rw [trace_rowTensor_mul_columnTensor, trace_columnTensor_mul_rowTensor]
+
+/-- The literal two-site bond-uniformity specialization of the source
+corollary at arXiv:1804.04964, line 1804. -/
+def TwoSiteBondUniformityStatement : Prop :=
+  ∀ {d D₁ D₂ : ℕ}
+    (A₁ : Fin d → Matrix (Fin D₁) (Fin D₂) ℂ)
+    (A₂ : Fin d → Matrix (Fin D₂) (Fin D₁) ℂ),
+    0 < D₁ →
+    0 < D₂ →
+    IsRectangularInjective A₁ →
+    IsRectangularInjective A₂ →
+    IsTwoSiteCyclicShiftInvariantState A₁ A₂ →
+    D₁ = D₂
+
+/-- **False source result:** The source corollary is false when read literally
+at two sites: the
+positive-dimensional tensors `rowTensor`, `columnTensor` satisfy both local
+injectivity hypotheses and cyclic state invariance, but their adjacent bond
+dimensions are `1` and `2`.
+
+Source: arXiv:1804.04964, Applications-section corollary, lines 1803--1804.
+The false printed statement and its corrected at-least-three-site scope are
+documented in
+`docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex`. -/
+theorem twoSiteBondUniformityStatement_false :
+    ¬ TwoSiteBondUniformityStatement := by
+  intro h
+  have hdim := h rowTensor columnTensor (by omega) (by omega)
+    rowTensor_isRectangularInjective columnTensor_isRectangularInjective
+    twoSite_cyclicShiftInvariant
+  omega
+
+end CycleMPSTwoSiteCounterexample
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -364,6 +364,37 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     then proves equality on all bonds.
 \end{proof}
 
+\begin{theorem}[Two-site obstruction to cyclic MPS bond uniformity]%
+    \label{thm:peps_cycle_two_site_bond_uniformity_counterexample}
+    \lean{TNLean.PEPS.CycleMPSTwoSiteCounterexample.twoSiteBondUniformityStatement_false}
+    \leanok
+    The bond-uniformity implication is false for two sites. More precisely,
+    there are injective tensors
+    \begin{align}
+        A_1^i&\in\operatorname{Mat}_{1\times2}(\mathbb C),
+        &A_2^i&\in\operatorname{Mat}_{2\times1}(\mathbb C)
+        \qquad (i=0,1).
+        \label{eq:peps_cycle_two_site_rectangular_tensors}
+    \end{align}
+    whose closed-chain coefficients are invariant under the cyclic shift,
+    but whose positive virtual dimensions are unequal. Consequently the condition
+    $n\ge3$ in Corollary~\ref{cor:peps_cycle_shift_bond_uniform} cannot be
+    removed. This corrects the unqualified printed corollary in
+    \cite[lines~1801--1804]{Molnar2018NormalPEPS}; see
+    \cite{gap:peps_cyclic_mps_two_site_bond_uniformity}.
+\end{theorem}
+\begin{proof}\leanok
+    Let $e_0,e_1$ be the standard basis of $\mathbb C^2$ and take
+    $A_1^i=e_i^{\mathsf T}$ and $A_2^i=e_i$. Each local tensor map sends a
+    virtual basis to $e_0,e_1$, hence is injective. Moreover
+    \begin{align}
+        \tr(A_1^iA_2^j)=\delta_{ij}=\tr(A_2^iA_1^j).
+        \label{eq:peps_cycle_two_site_shift_invariance}
+    \end{align}
+    so the state is cyclically invariant, whereas the adjacent dimensions
+    are $1$ and $2$.
+\end{proof}
+
 \begin{corollary}[Gauge comparison with the cyclic shift]%
     \label{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_cyclicShift}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -7,11 +7,14 @@ of this section formalize the site-dependent setting itself. A closed
 chain carries one tensor per site, windows are arcs of consecutive sites,
 and the closed-chain corollary delivers one gauge per bond. Most of the
 matrix-chain statements below take one physical dimension $d$ and one bond
-dimension $D$. For the Applications-section cyclic-shift corollary, the
-cycle-graph formulation instead retains one dimension $D_e$ per bond and
-derives their equality from the injective Fundamental Theorem. The remaining
-uniform-dimension restriction on the repeated-tensor construction is recorded
-in the route note (\cite{gap:peps_normal_ft_section3_route}).
+dimension $D$. For the Applications-section translational-invariance
+corollary, the cycle-graph formulation instead retains one dimension $D_e$ per
+bond, derives their equality from the injective Fundamental Theorem, and then
+identifies the virtual spaces to construct the repeated tensor in the source's
+standing regime of at least three sites. The literal two-site reading of the
+printed corollary is false; this is recorded by
+Theorem~\ref{thm:peps_cycle_two_site_bond_uniformity_counterexample} and
+\cite{gap:peps_cyclic_mps_two_site_bond_uniformity}.
 
 \begin{definition}[Arc products and window injectivity of a site-dependent
         chain]%
@@ -368,11 +371,12 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     \label{thm:peps_cycle_two_site_bond_uniformity_counterexample}
     \lean{TNLean.PEPS.CycleMPSTwoSiteCounterexample.twoSiteBondUniformityStatement_false}
     \leanok
+    \discussion{3371}
     The bond-uniformity implication is false for two sites. More precisely,
     there are injective tensors
     \begin{align}
-        A_1^i&\in\operatorname{Mat}_{1\times2}(\mathbb C),
-        &A_2^i&\in\operatorname{Mat}_{2\times1}(\mathbb C)
+        A_1^i & \in\operatorname{Mat}_{1\times2}(\mathbb C),
+              & A_2^i                                        & \in\operatorname{Mat}_{2\times1}(\mathbb C)
         \qquad (i=0,1).
         \label{eq:peps_cycle_two_site_rectangular_tensors}
     \end{align}
@@ -380,7 +384,7 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     but whose positive virtual dimensions are unequal. Consequently the condition
     $n\ge3$ in Corollary~\ref{cor:peps_cycle_shift_bond_uniform} cannot be
     removed. This corrects the unqualified printed corollary in
-    \cite[lines~1801--1804]{Molnar2018NormalPEPS}; see
+    \cite[lines~1803--1805]{Molnar2018NormalPEPS}; see
     \cite{gap:peps_cyclic_mps_two_site_bond_uniformity}.
 \end{theorem}
 \begin{proof}\leanok
@@ -506,13 +510,15 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     \lean{TNLean.PEPS.Tensor.isCyclicShiftInvariantState_reindexMPSChain}
     \lean{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
     \leanok
+    \discussion{3371}
     \uses{cor:peps_cycle_shift_bond_uniform, cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
     Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS on
     $n\ge3$ sites, with positive dimensions $D_e$ on its individual bonds.
-    If the closed-chain state is invariant under the cyclic shift
-    $A_v\mapsto A_{v+1}$, then there are a positive integer $D$ and an
-    injective tensor $B$ of $D\times D$ matrices such that $D_e=D$ for every
-    bond $e$ and
+    If the closed-chain state is translationally invariant, in the finite
+    closed-chain sense that it is invariant under the cyclic shift
+    $A_v\mapsto A_{v+1}$ of \cite[lines~1807--1827]{Molnar2018NormalPEPS},
+    then there are a positive integer $D$ and an injective tensor $B$ of
+    $D\times D$ matrices such that $D_e=D$ for every bond $e$ and
     \begin{align}
         \Coeff_A(\sigma)
          & =
@@ -521,11 +527,17 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     \end{align}
     for every physical configuration $\sigma$.
 
-    This is the positive-bond, at-least-three-site form corresponding to
+    This completes the positive-bond, at-least-three-site form of the
+    translational-invariance corollary and its proof in
     \cite[lines~1803--1890]{Molnar2018NormalPEPS}. The equality $D_e=D$ is
     Corollary~\ref{cor:peps_cycle_shift_bond_uniform}. Identifying each
     virtual space with $\C^D$ gives a uniform closed-chain representation,
-    to which the already proved $L_i,R_i$ telescoping and seam closure apply.
+    to which the source's $L_i,R_i$ telescoping and repeated-tensor
+    construction apply. The source section places its injective Fundamental
+    Theorem in the regime of at least three sites; the omitted two-site case
+    is false by
+    Theorem~\ref{thm:peps_cycle_two_site_bond_uniformity_counterexample}, as
+    recorded in \cite{gap:peps_cyclic_mps_two_site_bond_uniformity}.
 \end{corollary}
 \begin{proof}\leanok
     By Corollary~\ref{cor:peps_cycle_shift_bond_uniform}, every bond has the
@@ -559,45 +571,11 @@ in the route note (\cite{gap:peps_normal_ft_section3_route}).
     the required repeated injective tensor $B$.
 \end{proof}
 
-\begin{corollary}[Translation-invariant description of an injective closed MPS chain,
-        source statement]%
-    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-    \notready
-    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}
-    Let $A_0,\ldots,A_{n-1}$ be a site-dependent injective closed MPS, with
-    dimension $D_e$ on each individual bond. If the closed-chain state is
-    invariant under the cyclic shift $A_v\mapsto A_{v+1}$, then all bond
-    dimensions are equal to one dimension $D$, and there is an injective
-    tensor $B$ of $D\times D$ matrices such that
-    \begin{align}
-        \Coeff_A(\sigma)
-         & =
-        \tr\!\left(B^{\sigma_0}\cdots B^{\sigma_{n-1}}\right)
-        \notag
-    \end{align}
-    for every physical configuration $\sigma$.
-
-    This is the corollary stated in
-    \cite[lines~1803--1890]{Molnar2018NormalPEPS}, without adding the positive
-    bond-dimension or $n\ge3$ hypotheses that do not appear in its statement.
-\end{corollary}
-\begin{proof}
-    For positive bond dimensions in the intended $n\ge3$ source context, this
-    is the preceding corollary. The source states at line~145 that its
-    injective MPS Fundamental Theorem concerns at least three sites and invokes
-    precisely that theorem here. Thus omission of $n\ge3$ from the displayed
-    corollary is a source-scope defect: the literal two-site statement is false
-    for nondegenerate rectangular bond dimensions. It is not a short-chain
-    extension left to this proof. The positive-dimension condition must be
-    built into the domain of bond dimensions or removed mathematically before
-    the printed statement can be marked complete.
-\end{proof}
-
 \begin{corollary}[Translation-invariant description of an injective 2D PEPS,
         uniform bond dimension]%
     \label{cor:exists_constant_injectivePEPS_of_translationInvariantState}
     \notready
-    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState, thm:fundamentalTheorem_PEPS, def:peps_torus_translation_invariant, def:peps_torus_uniform_bond_dim, thm:peps_stateCoeff_translationInvariant}
+    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos, thm:fundamentalTheorem_PEPS, def:peps_torus_translation_invariant, def:peps_torus_uniform_bond_dim, thm:peps_stateCoeff_translationInvariant}
     Let $A$ be an injective PEPS on the discrete torus with orientation-uniform
     bond dimensions, horizontal dimension $D_h$ and vertical dimension $D_v$,
     and positive bond dimensions. If the generated state is invariant under all

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1079,6 +1079,16 @@
   note         = {Preprint},
 }
 
+@techreport{gap:peps_cyclic_mps_two_site_bond_uniformity,
+  author      = {The {TNLean} contributors},
+  title       = {A Two-Site Counterexample to Cyclic {MPS} Bond Uniformity},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {peps\_cyclic\_mps\_two\_site\_bond\_uniformity},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.pdf}},
+}
+
 @techreport{gap:peps_normal_ft_section3_route,
   author      = {The {TNLean} contributors},
   title       = {Normal {PEPS} Fundamental Theorem: Section 3 Route},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -94,6 +94,16 @@ obligation. The unreferenced strict-modulus removal record was deleted because
 its useful content is already preserved in the non-dominant projection and
 two-layer refinement notes.
 
+For the translation-invariant MPS application of the normal-PEPS Fundamental
+Theorem:
+
+- `peps_cyclic_mps_two_site_bond_uniformity.tex` is the resolved false-source
+  record for the unqualified cyclic-shift corollary of arXiv:1804.04964. The
+  standard row and column tensors with virtual dimensions (1) and (2) are
+  locally injective and generate the cyclically invariant coefficient
+  δᵢⱼ, but their bond dimensions are unequal. The corrected theorem retains
+  the source section's standing assumption of at least three sites.
+
 For MPDO renormalization fixed points:
 
 - `cpsv16_peps_boundary_rfp_specification.tex` records the source-faithful

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -102,7 +102,8 @@ Theorem:
   standard row and column tensors with virtual dimensions (1) and (2) are
   locally injective and generate the cyclically invariant coefficient
   δᵢⱼ, but their bond dimensions are unequal. The corrected theorem retains
-  the source section's standing assumption of at least three sites.
+  the source section's standing assumption of at least three sites and is
+  complete for positive bond dimensions.
 
 For MPDO renormalization fixed points:
 

--- a/docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex
+++ b/docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex
@@ -1,0 +1,114 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command}
+
+\title{A Two-Site Counterexample to Cyclic MPS Bond Uniformity}
+\author{}
+\date{2026-08-31}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{resolved}
+
+\section{The printed corollary}
+
+The Applications section of Ref.~\cite{Molnar2018NormalPEPS} considers a
+closed matrix product state whose local matrices have sizes
+$D_k\times D_{k+1}$.  Its translation-invariance corollary asserts that
+cyclic invariance of the state and injectivity of the local tensors imply
+equality of all virtual dimensions and the existence of one repeated tensor.
+Thus its bond-dimension conclusion is
+\begin{align}
+    D_1=D_2=\cdots=D_n.
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_printed_conclusion}
+\end{align}
+The corollary itself does not state a lower bound on $n$.\footnote{Local source:
+\path{Papers/1804.04964/paper_normal.tex:1801--1804}.}
+
+The surrounding MPS section of Ref.~\cite{Molnar2018NormalPEPS} says that its
+Fundamental Theorem concerns chains with at least three sites, and the theorem
+invoked in the corollary is stated under that condition.\footnote{Local source:
+\path{Papers/1804.04964/paper_normal.tex:145} and
+\path{Papers/1804.04964/paper_normal.tex:688--725}.}  The omission in the
+corollary is therefore consequential rather than a harmless simplification:
+the literal two-site specialization is false.
+
+\section{A positive-dimensional two-site example}
+
+Let the physical space be $\mathbb C^2$, with standard basis $e_0,e_1$, and
+take
+\begin{align}
+    D_1&=1,
+    &D_2&=2,
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_dimensions}\\
+    A_1^i&=e_i^{\mathsf T}\in\operatorname{Mat}_{1\times2}(\mathbb C),
+    &A_2^i&=e_i\in\operatorname{Mat}_{2\times1}(\mathbb C)
+    \qquad (i=0,1).
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_tensors}
+\end{align}
+The first local tensor sends the two virtual basis vectors of
+$\mathbb C^1\otimes\mathbb C^2$ to $e_0,e_1$; the second does the same from
+$\mathbb C^2\otimes\mathbb C^1$.  Both local tensor maps are therefore
+isomorphisms, in particular injective.
+
+For physical indices $i,j\in\{0,1\}$, the coefficient before and after the
+cyclic shift is
+\begin{align}
+    \tr(A_1^iA_2^j)
+        &=e_i^{\mathsf T}e_j
+         =\delta_{ij},
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_original_coefficient}\\
+    \tr(A_2^iA_1^j)
+        &=\tr(e_i e_j^{\mathsf T})
+         =\delta_{ij}.
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_shifted_coefficient}
+\end{align}
+Equations~(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_original_coefficient})
+and~(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_shifted_coefficient})
+show that the two-site state is cyclically invariant.  Every virtual space is
+nonzero and both local tensors are injective, while
+(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_dimensions}) contradicts
+(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_printed_conclusion}).
+
+The construction and the negation of the literal two-site statement have
+kernel-checked proofs.\footnote{Formal declaration:
+\leanid{TNLean.PEPS.CycleMPSTwoSiteCounterexample.twoSiteBondUniformityStatement_false}
+in \doclink{TNLean/PEPS/CycleMPSTwoSiteCounterexample}.}
+
+\section{Corrected scope}
+
+The source proof compares the site-dependent chain with its cyclic shift by
+the injective MPS Fundamental Theorem and then telescopes the resulting bond
+isomorphisms.  That argument is available in the source's stated regime
+$n\geq3$ and does not apply to the example above.  The source-faithful
+correction is therefore to retain the standing three-site hypothesis:
+\begin{align}
+    n\geq3
+    \quad\Longrightarrow\quad
+    D_1=D_2=\cdots=D_n,
+    \label{eq:peps_cyclic_mps_two_site_bond_uniformity_corrected_scope}
+\end{align}
+together with the positive-dimensional convention for the virtual spaces.
+This is precisely the regime in which the graph-theoretic cycle has one edge
+for each bond and the cited Fundamental Theorem comparison is valid.
+
+\section{Verdict}
+
+The translation-invariance corollary of Ref.~\cite{Molnar2018NormalPEPS} is
+false as printed if it is read at two sites.  The example
+(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_tensors}) satisfies the
+nondegenerate source hypotheses and has a cyclically invariant state, but its
+two virtual dimensions are unequal.  The corrected statement is the
+at-least-three-site result
+(\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_corrected_scope}), in
+accordance with the standing scope and the Fundamental Theorem used by the
+source proof.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex
+++ b/docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex
@@ -18,16 +18,19 @@
 
 The Applications section of Ref.~\cite{Molnar2018NormalPEPS} considers a
 closed matrix product state whose local matrices have sizes
-$D_k\times D_{k+1}$.  Its translation-invariance corollary asserts that
-cyclic invariance of the state and injectivity of the local tensors imply
-equality of all virtual dimensions and the existence of one repeated tensor.
+$D_k\times D_{k+1}$.  Its translational-invariance corollary asserts that
+translational invariance of the state and injectivity of the local tensors
+imply equality of all virtual dimensions and the existence of one repeated
+tensor.  For this finite closed chain, the source writes translational
+invariance as equality with the one-site cyclic shift.
 Thus its bond-dimension conclusion is
 \begin{align}
     D_1=D_2=\cdots=D_n.
     \label{eq:peps_cyclic_mps_two_site_bond_uniformity_printed_conclusion}
 \end{align}
 The corollary itself does not state a lower bound on $n$.\footnote{Local source:
-\path{Papers/1804.04964/paper_normal.tex:1801--1804}.}
+\path{Papers/1804.04964/paper_normal.tex:1803--1805}; the cyclic-shift equality
+is displayed at lines 1807--1827.}
 
 The surrounding MPS section of Ref.~\cite{Molnar2018NormalPEPS} says that its
 Fundamental Theorem concerns chains with at least three sites, and the theorem
@@ -82,10 +85,11 @@ in \doclink{TNLean/PEPS/CycleMPSTwoSiteCounterexample}.}
 \section{Corrected scope}
 
 The source proof compares the site-dependent chain with its cyclic shift by
-the injective MPS Fundamental Theorem and then telescopes the resulting bond
-isomorphisms.  That argument is available in the source's stated regime
-$n\geq3$ and does not apply to the example above.  The source-faithful
-correction is therefore to retain the standing three-site hypothesis:
+the injective MPS Fundamental Theorem, writes every $A_i$ in terms of $A_1$
+and the matrices $L_i,R_i$, and then telescopes these matrices to construct a
+repeated tensor $B$.  That argument is available in the source's stated regime
+$n\geq3$ and does not apply to the example above.  The corrected statement
+therefore retains the standing three-site hypothesis:
 \begin{align}
     n\geq3
     \quad\Longrightarrow\quad
@@ -96,9 +100,15 @@ together with the positive-dimensional convention for the virtual spaces.
 This is precisely the regime in which the graph-theoretic cycle has one edge
 for each bond and the cited Fundamental Theorem comparison is valid.
 
+The complete corrected conclusion, including equality of all bond dimensions
+and the repeated injective tensor $B$, is formalized by
+\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}.
+It is recorded as complete in the Blueprint node
+\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}.
+
 \section{Verdict}
 
-The translation-invariance corollary of Ref.~\cite{Molnar2018NormalPEPS} is
+The translational-invariance corollary of Ref.~\cite{Molnar2018NormalPEPS} is
 false as printed if it is read at two sites.  The example
 (\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_tensors}) satisfies the
 nondegenerate source hypotheses and has a cyclically invariant state, but its
@@ -106,7 +116,8 @@ two virtual dimensions are unequal.  The corrected statement is the
 at-least-three-site result
 (\ref{eq:peps_cyclic_mps_two_site_bond_uniformity_corrected_scope}), in
 accordance with the standing scope and the Fundamental Theorem used by the
-source proof.
+source proof.  The impossible unqualified reading is therefore a resolved
+false-source statement, not a separate open proof obligation.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2506,7 +2506,7 @@ of states nor the root-of-unity conditions enter.
 
 \section*{The Applications translation-invariant description corollary}
 
-The Applications section contains a different translation-invariance
+The Applications section contains a different translational-invariance
 corollary (lines 1801--1890 of
 \path{Papers/1804.04964/paper_normal.tex}, Ref.~\cite{Molnar2018NormalPEPS}),
 whose full per-bond form is tracked by \ghissue{3371}. Its
@@ -2599,26 +2599,31 @@ the positive-bond, at-least-three-site form of
 Blueprint records this proved restriction as
 \path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos}.
 
-\emph{Verdict: the explicit reindexing and repeated-tensor construction are
-complete under the positive-bond and at-least-three-site restrictions; the
-unrestricted source entry remains not ready.} The Blueprint entry
-\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-records the printed corollary separately and carries no Lean declaration. The
-positive-bond hypothesis is currently external because
-\leanid{TNLean.PEPS.Tensor} stores bond dimensions in $\mathbb{N}$ and admits
-empty virtual spaces; it must be made intrinsic to the source-facing domain or
-eliminated before the printed statement can be marked complete. The source
-corollary also omits a system-size hypothesis, although its proof invokes the
-at-least-three-particle Fundamental Theorem. The source section explicitly
-sets this scope at line~145. Thus $n\ge3$ is the intended source context, and
-its omission from the displayed corollary is a source-scope defect. Indeed,
-the literal two-site statement is false for nondegenerate rectangular bond
-dimensions; it is not a short-chain extension left to the present argument.
-The proved restricted theorem follows the source route:
-equality of the bond dimensions, explicit identification of the equal virtual
-spaces, and the already formalized $L_i,R_i$ telescoping and seam closure. It
-introduces neither a collected gauge factorization nor an alternative proof
-route.
+\emph{Verdict: the corrected positive-bond, at-least-three-site theorem is
+complete.} It follows the proof at source lines 1807--1890: equality of the
+bond dimensions, explicit identification of the equal virtual spaces, and the
+$L_i,R_i$ telescoping and repeated-tensor construction. It introduces neither
+a collected gauge factorization nor an alternative proof route. The Blueprint
+therefore records the completed theorem only at
+\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos};
+it does not retain a separate unqualified node marked not ready.
+
+The source section places the injective MPS Fundamental Theorem in the regime
+of at least three sites at line~145, and the theorem invoked at line~1828 has
+this hypothesis at lines 688--725. The displayed corollary at lines 1803--1805
+omits the restriction. Its literal two-site reading is false even for positive
+virtual dimensions: with $D_1=1$, $D_2=2$,
+$A_1^i=e_i^{\mathsf T}$, and $A_2^i=e_i$, both local tensor maps are injective
+and
+\begin{align}
+    \tr(A_1^iA_2^j)=\delta_{ij}=\tr(A_2^iA_1^j),
+\end{align}
+but $D_1\ne D_2$. The kernel-checked negation is
+\leanid{TNLean.PEPS.CycleMPSTwoSiteCounterexample.twoSiteBondUniformityStatement_false},
+and the false-source disposition is recorded in
+\doclink{docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity}. Positive
+virtual dimensions are the intended nonempty-space convention; the genuine
+source defect is the omitted at-least-three-site scope.
 
 \subsection*{The 2D analogue}
 


### PR DESCRIPTION
### Motivation

- The Applications corollary in `Papers/1804.04964/paper_normal.tex`, lines
  1803--1805, says without a length qualifier that a translationally invariant
  injective MPS has equal bond dimensions and a description by one repeated
  injective tensor.
- Its proof at lines 1807--1890 invokes the injective MPS Fundamental Theorem,
  whose scope is at least three sites both in the section introduction at line
  145 and in the theorem at lines 688--725. The omitted two-site reading is
  false even when both virtual dimensions are positive.

### Description

- Add the explicit two-site witness
  $D_1=1$, $D_2=2$, $A_1^i=e_i^{\mathsf T}$, and $A_2^i=e_i$. Both maps from
  the virtual indices to the physical index are injective, while
  $\operatorname{tr}(A_1^iA_2^j)=\delta_{ij}
  =\operatorname{tr}(A_2^iA_1^j)$, so the state is invariant under the cyclic
  shift although $D_1\ne D_2$.
- Prove the positivity-qualified universal two-site bond-uniformity statement
  false in
  `TNLean.PEPS.CycleMPSTwoSiteCounterexample.twoSiteBondUniformityStatement_false`.
  The headline theorem and all witness lemmas have only Lean's standard
  logical axioms.
- Retain the completed positive-bond theorem on at least three sites,
  `TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond`,
  which follows the source route merged in #7551: bond-dimension equality,
  explicit identification of the equal virtual spaces, and the printed
  $L_i,R_i$ telescoping and repeated-tensor construction.
- Replace the impossible unrestricted Blueprint `\notready` node by a proved
  counterexample node, while keeping the corrected positive, $n\geq3$ node
  complete. Record the source defect in
  `docs/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.tex` and update the
  Section 3 route note and paper-gap index accordingly.

No alternative proof route is introduced: the corrected theorem continues to
match `paper_normal.tex` lines 1807--1890, and this change records precisely why
the printed unqualified two-site statement cannot be formalized.

### Testing

- `lake build TNLean.PEPS.CycleMPSTwoSiteCounterexample TNLean.PEPS`
- kernel `#print axioms` audit of both injectivity witnesses, cyclic-shift
  invariance, and the headline negation
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `texra-blueprint paper-gaps check`
- `texra-blueprint --root . paper-gaps build`
- reader-facing prose, `chktex`, and pinned `latexindent` checks

---
Closes #3371

### Agent assistance

- OpenAI Codex audited the paper statement and proof, constructed and checked
  the Lean counterexample, and synchronized the Blueprint and paper-gap
  documentation. The mathematical witness and every generated change were
  independently checked against the cited source ranges.
