### PR TITLE
feat(PEPS): prove cross-tensor multiplicativity

### DIFF
--- a/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
+++ b/TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean
@@ -17,9 +17,13 @@ operations give one common family on the genuine `B` window tensors.  The paper 
 two end windows with open boundaries and uses their injectivity to extract one unique virtual
 matrix on the highlighted bond of `B`.
 
-This file formalizes exactly that extraction.  It does not compare the two virtual matrices, prove
-a multiplication law for their assignment, identify the bond dimensions of `A` and `B`, or
-construct a gauge.
+This file formalizes that extraction and the paper's ensuing composition argument.  The canonical
+left end operations satisfy `O₁ᴬ(XY) = O₁ᴬ(X) O₁ᴬ(Y)`.  The canonical right end
+operations satisfy `O₃ᴬ(XY) = O₃ᴬ(Y) O₃ᴬ(X)` in the underlying orientation, equivalently
+ordinary multiplication after passing to `O₃ᵀ`.  Choosing the globally unique matrix on the
+`B`-bond therefore gives a multiplicative cross-tensor assignment.  No external boundary
+configuration is selected in this argument, and no bond-dimension identification or gauge is
+constructed.
 
 **Scope restriction (displayed horizontal staircase, `L, K ≥ 2`):** The result is stated for the
 non-wrapping horizontal staircase coordinates supported by the present boundary-geometry API.
@@ -39,6 +43,138 @@ in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.
 namespace TNLean
 namespace PEPS
 
+section RegionPhysicalOperation
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+private noncomputable def regionBoundaryConfigSplitAt
+    (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    RegionBoundaryConfig (G := G) A R ≃
+      Fin (A.bondDim f.1) ×
+        ((g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) →
+          Fin (A.bondDim g.1.1)) :=
+  Equiv.piSplitAt f (fun g ↦ Fin (A.bondDim g.1))
+
+omit [Fintype V] in
+private theorem sameAwayFromBond_iff_splitAt_snd_eq
+    (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (mu nu : RegionBoundaryConfig (G := G) A R) :
+    SameAwayFromBond f mu nu ↔
+      (regionBoundaryConfigSplitAt (G := G) A R f mu).2 =
+        (regionBoundaryConfigSplitAt (G := G) A R f nu).2 := by
+  constructor
+  · intro h
+    funext g
+    exact h g.1 g.2
+  · intro h g hg
+    exact congrFun h ⟨g, hg⟩
+
+private theorem bondInsertedRegionInsert_splitAt
+    (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (j : Fin (A.bondDim f.1))
+    (eta : (g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) →
+      Fin (A.bondDim g.1.1)) :
+    let E := regionBoundaryConfigSplitAt (G := G) A R f
+    bondInsertedRegionInsert (G := G) A R f M (E.symm (j, eta)) =
+      ∑ i : Fin (A.bondDim f.1), M i j •
+        regionBlockedWeight (G := G) A R (E.symm (i, eta)) := by
+  classical
+  dsimp only
+  let E := regionBoundaryConfigSplitAt (G := G) A R f
+  funext sigma
+  rw [bondInsertedRegionInsert]
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+  rw [← Equiv.sum_comp E.symm, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun i _ ↦ ?_)
+  rw [Finset.sum_eq_single eta]
+  · have hsame : SameAwayFromBond f (E.symm (i, eta)) (E.symm (j, eta)) := by
+      rw [sameAwayFromBond_iff_splitAt_snd_eq A R f]
+      simp only [E, Equiv.apply_symm_apply]
+    have hif : (E.symm (i, eta)) f = i := by
+      simp [E, regionBoundaryConfigSplitAt, Equiv.piSplitAt_symm_apply]
+    have hjf : (E.symm (j, eta)) f = j := by
+      simp [E, regionBoundaryConfigSplitAt, Equiv.piSplitAt_symm_apply]
+    rw [ite_eq_left hsame, hif, hjf]
+  · intro eta' _ heta'
+    have hnot : ¬ SameAwayFromBond f (E.symm (i, eta')) (E.symm (j, eta)) := by
+      intro hsame
+      apply heta'
+      rw [sameAwayFromBond_iff_splitAt_snd_eq A R f] at hsame
+      simpa only [E, Equiv.apply_symm_apply] using hsame
+    rw [ite_eq_right hnot, zero_mul]
+  · intro heta
+    exact absurd (Finset.mem_univ eta) heta
+
+private theorem physicalOpOfRegionInsert_mul_of_apply
+    (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (C D E : RegionInsert (G := G) (d := d) A R)
+    (h : ∀ mu, physicalOpOfRegionInsert (G := G) A R hR C (D mu) = E mu) :
+    physicalOpOfRegionInsert (G := G) A R hR C *
+        physicalOpOfRegionInsert (G := G) A R hR D =
+      physicalOpOfRegionInsert (G := G) A R hR E := by
+  classical
+  apply LinearMap.ext
+  intro v
+  rw [Module.End.mul_apply]
+  change physicalOpOfRegionInsert (G := G) A R hR C
+      ((Fintype.linearCombination ℂ D)
+        (regionBlockedLeftInverse (G := G) A R hR v)) =
+    (Fintype.linearCombination ℂ E)
+      (regionBlockedLeftInverse (G := G) A R hR v)
+  simp only [Fintype.linearCombination_apply, map_sum, map_smul]
+  refine Finset.sum_congr rfl (fun mu _ ↦ ?_)
+  rw [h mu]
+
+private theorem physicalOpOfBondInsertedRegionInsert_isO1
+    (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (eta : (g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) →
+      Fin (A.bondDim g.1.1)) :
+    let E := regionBoundaryConfigSplitAt (G := G) A R f
+    IsO1VirtualOperation
+      (fun i : Fin (A.bondDim f.1) ↦
+        regionBlockedWeight (G := G) A R (E.symm (i, eta)))
+      (physicalOpOfRegionInsert (G := G) A R hR
+        (bondInsertedRegionInsert (G := G) A R f M)) M := by
+  dsimp only
+  intro j
+  rw [physicalOpOfRegionInsert_realizes, bondInsertedRegionInsert_splitAt]
+
+private theorem physicalOpOfBondInsertedRegionInsert_mul
+    (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    physicalOpOfRegionInsert (G := G) A R hR
+        (bondInsertedRegionInsert (G := G) A R f (M * N)) =
+      physicalOpOfRegionInsert (G := G) A R hR
+          (bondInsertedRegionInsert (G := G) A R f M) *
+        physicalOpOfRegionInsert (G := G) A R hR
+          (bondInsertedRegionInsert (G := G) A R f N) := by
+  classical
+  symm
+  apply physicalOpOfRegionInsert_mul_of_apply A R hR
+  intro nu
+  rw [← physicalOpOfRegionInsert_realizes A R hR
+      (bondInsertedRegionInsert (G := G) A R f N) nu,
+    ← physicalOpOfRegionInsert_realizes A R hR
+      (bondInsertedRegionInsert (G := G) A R f (M * N)) nu]
+  let E := regionBoundaryConfigSplitAt (G := G) A R f
+  rw [← E.symm_apply_apply nu, ← Module.End.mul_apply]
+  rw [(physicalOpOfBondInsertedRegionInsert_isO1 A R hR f M (E nu).2).mul
+      (physicalOpOfBondInsertedRegionInsert_isO1 A R hR f N (E nu).2) (E nu).1,
+    physicalOpOfBondInsertedRegionInsert_isO1 A R hR f (M * N) (E nu).2 (E nu).1]
+
+end RegionPhysicalOperation
+
 section Torus
 
 variable {width height : ℕ} [NeZero width] [NeZero height]
@@ -53,6 +189,16 @@ private noncomputable def regionPhysicalOperationCongr
       (RegionPhysicalConfig (V := TorusVertex width height) (d := d) S → ℂ) := by
   subst S
   exact O
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+private theorem regionPhysicalOperationCongr_mul
+    {R S : Finset (TorusVertex width height)} (h : R = S)
+    (O P : Module.End ℂ
+      (RegionPhysicalConfig (V := TorusVertex width height) (d := d) R → ℂ)) :
+    regionPhysicalOperationCongr h (O * P) =
+      regionPhysicalOperationCongr h O * regionPhysicalOperationCongr h P := by
+  subst S
+  rfl
 
 private noncomputable def regionInsertCongr
     (B : Tensor (torusGraph width height) d)
@@ -132,6 +278,73 @@ noncomputable def staircaseO3PhysicalOp (A : Tensor (torusGraph width height) d)
   regionPhysicalOperationCongr
     (staircaseWindow_zero ((a : ZMod width), (b : ZMod height)) L K)
     (staircaseVirtualOperationPhysicalOp (B := A) hA hL hK haw hyh X 0)
+
+/-- The canonical left staircase operations preserve multiplication in the paper's ordinary
+`O₁` order:
+\[
+  O₁ᴬ(XY)=O₁ᴬ(X)O₁ᴬ(Y).
+\]
+
+The proof uses the chosen left inverse only through its defining identity on the genuine blocked
+window.  It therefore requires no spanning of the ambient physical space and no auxiliary
+injectivity hypothesis.
+
+Source: arXiv:1804.04964, the statement `X \mapsto O_1` at line 2044 and the phrase "by
+composition" in Lemma 5 at line 2252 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseO1PhysicalOp_mul (A : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X Y : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    staircaseO1PhysicalOp A hA hL hK haw hyh (X * Y) =
+      staircaseO1PhysicalOp A hA hL hK haw hyh X *
+        staircaseO1PhysicalOp A hA hL hK haw hyh Y := by
+  unfold staircaseO1PhysicalOp
+  rw [← regionPhysicalOperationCongr_mul]
+  apply congrArg (regionPhysicalOperationCongr
+    (staircaseWindow_last ((a : ZMod width), (b : ZMod height)) hL hK))
+  unfold staircaseVirtualOperationPhysicalOp
+  rw [staircaseVirtualOperationInsert_last, staircaseVirtualOperationInsert_last,
+    staircaseVirtualOperationInsert_last]
+  apply physicalOpOfBondInsertedRegionInsert_mul
+
+/-- The underlying canonical right staircase operations preserve multiplication in the reversed
+`O₃` order:
+\[
+  O₃ᴬ(XY)=O₃ᴬ(Y)O₃ᴬ(X).
+\]
+Equivalently, after reading the relation in the paper's transposed orientation,
+`X \mapsto (O₃ᴬ(X))ᵀ` preserves multiplication in the ordinary order.  The reversal comes
+exactly from `(XY)ᵀ=YᵀXᵀ`; no transpose is chosen on the abstract physical endomorphism
+space.
+
+Source: arXiv:1804.04964, the statement `X \mapsto O_3^T` at line 2044, the assignments
+`O_3^T \mapsto X` and `O_3 \mapsto X^T` at lines 2129 and 2252, and the phrase "by composition"
+at line 2252 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseO3PhysicalOp_mul (A : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hL : 0 < L) (hK : 0 < K) (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (X Y : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    staircaseO3PhysicalOp A hA hL hK haw hyh (X * Y) =
+      staircaseO3PhysicalOp A hA hL hK haw hyh Y *
+        staircaseO3PhysicalOp A hA hL hK haw hyh X := by
+  unfold staircaseO3PhysicalOp
+  rw [← regionPhysicalOperationCongr_mul]
+  apply congrArg (regionPhysicalOperationCongr
+    (staircaseWindow_zero ((a : ZMod width), (b : ZMod height)) L K))
+  unfold staircaseVirtualOperationPhysicalOp
+  rw [staircaseVirtualOperationInsert_zero, staircaseVirtualOperationInsert_zero,
+    staircaseVirtualOperationInsert_zero, Matrix.transpose_mul]
+  apply physicalOpOfBondInsertedRegionInsert_mul
 
 /-- **The virtual operation on `B` extracted from the staircase operations of `A`.**
 
@@ -276,6 +489,163 @@ theorem existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameStat
   simpa only [s, O₁, O₃] using
     existsUnique_virtualOperation_of_horizontalStaircaseEndPhysicalOperations
       B hBTI (by omega) (by omega) ha0 haw hbh hposB hleftInjective hrightInjective O₁ O₃ heq
+
+/-- The canonical cross-tensor matrix assignment on the highlighted staircase edge.
+
+For `X` on the `A`-bond, this is the unique matrix on the `B`-bond simultaneously determined by
+the `O₁ᴬ(X)` relation at every left external boundary configuration and the `O₃ᴬ(X)` relation,
+read in the paper's `O₃ᵀ` orientation, at every right external boundary configuration.  The
+definition chooses the witness of the globally quantified uniqueness theorem; it does not choose
+an external boundary configuration.
+
+Source: arXiv:1804.04964, the cross-tensor assignment `X \mapsto Y` at lines 563--582,
+the uniquely defined assignments `O_1 \mapsto X` and `O_3^T \mapsto X` in Lemma 5 at lines
+2129 and 2252, and the two-dimensional staircase comparison at lines 2320--2444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def staircaseCrossTensorVirtualOperation
+    (A B : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hATI : IsTorusTranslationInvariant A) (hBTI : IsTorusTranslationInvariant B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hposB : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ :=
+  Classical.choose
+    (existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameState
+      A B hA hB hATI hBTI hAB hposA hposB hL hK ha0 haw hbh hxw hyh X).exists
+
+/-- The canonical cross-tensor matrix satisfies both end relations for every external boundary
+configuration.
+
+The left relation is the source assignment `O₁ ↦ X`; the right relation is the source
+assignment `O₃ᵀ ↦ X`, equivalently `O₃ ↦ Xᵀ`.
+
+Source: arXiv:1804.04964, Lemma 5 at lines 2213--2252 and the two-dimensional end-window
+comparison at lines 2415--2444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseCrossTensorVirtualOperation_spec
+    (A B : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hATI : IsTorusTranslationInvariant A) (hBTI : IsTorusTranslationInvariant B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hposB : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (X : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    let s : TorusVertex width height := ((a : ZMod width), (b : ZMod height))
+    let Wleft := horizontalStaircaseLeftWindow s L K
+    let Wright := horizontalStaircaseRightWindow s L K
+    let Eleft := horizontalStaircaseLeftWindowBoundaryConfigEquiv B
+      (by omega) (by omega) ha0 haw hbh
+    let Eright := horizontalStaircaseRightWindowBoundaryConfigEquiv B
+      (by omega) (by omega) ha0 haw hbh
+    (∀ etaLeft : HorizontalStaircaseLeftExternalBoundaryConfig B (L := L) (K := K) s,
+        IsO1VirtualOperation
+          (fun k : Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K)) ↦
+            regionBlockedWeight (G := torusGraph width height) B Wleft
+              (Eleft.symm (k, etaLeft)))
+          (staircaseO1PhysicalOp A hA (by omega) (by omega) haw (by omega) X)
+          (staircaseCrossTensorVirtualOperation A B hA hB hATI hBTI hAB hposA hposB
+            hL hK ha0 haw hbh hxw hyh X)) ∧
+      ∀ etaRight : HorizontalStaircaseRightExternalBoundaryConfig B (L := L) (K := K) s,
+        IsO3TransposeVirtualOperation
+          (fun k : Fin (B.bondDim (horizontalStaircaseReferenceEdge s L K)) ↦
+            regionBlockedWeight (G := torusGraph width height) B Wright
+              (Eright.symm (k, etaRight)))
+          (staircaseO3PhysicalOp A hA (by omega) (by omega) haw (by omega) X)
+          (staircaseCrossTensorVirtualOperation A B hA hB hATI hBTI hAB hposA hposB
+            hL hK ha0 haw hbh hxw hyh X) := by
+  simpa only [staircaseCrossTensorVirtualOperation] using
+    Classical.choose_spec
+      (existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameState
+        A B hA hB hATI hBTI hAB hposA hposB hL hK ha0 haw hbh hxw hyh X).exists
+
+/-- The canonical cross-tensor matrix assignment preserves multiplication:
+\[
+  Y_{A\to B}(X_1X_2)=Y_{A\to B}(X_1)Y_{A\to B}(X_2).
+\]
+
+Here `Y_{A\to B}(X)` only disambiguates the paper's input matrix `X` and uniquely recovered
+output matrix `Y`; the source calls the assignment `X \mapsto Y`.
+
+Both end relations remain globally quantified throughout the proof.  On the left,
+`O₁ᴬ(XY)=O₁ᴬ(X)O₁ᴬ(Y)` and `IsO1VirtualOperation.mul` give the product in ordinary
+order.  On the right, the underlying operations satisfy
+`O₃ᴬ(XY)=O₃ᴬ(Y)O₃ᴬ(X)`; `IsO3TransposeVirtualOperation.mul` reads this as ordinary
+multiplication in the `O₃ᵀ` orientation.  The globally unique `B`-bond matrix then gives the
+displayed equality.
+
+This theorem records the multiplicative part of the source's algebra-homomorphism assertion.
+Additivity, scalar compatibility, and the unit law are not packaged here.
+
+Source: arXiv:1804.04964, the cross-tensor algebra-homomorphism statement `X \mapsto Y` at
+line 582, the end-operation statements in Lemma 5 at lines 2129 and 2252, and the
+two-dimensional reduction to Lemma 5 at lines 2320--2444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem staircaseCrossTensorVirtualOperation_mul
+    (A B : Tensor (torusGraph width height) d) {a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hATI : IsTorusTranslationInvariant A) (hBTI : IsTorusTranslationInvariant B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hposB : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (X Y : Matrix
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ) :
+    staircaseCrossTensorVirtualOperation A B hA hB hATI hBTI hAB hposA hposB
+        hL hK ha0 haw hbh hxw hyh (X * Y) =
+      staircaseCrossTensorVirtualOperation A B hA hB hATI hBTI hAB hposA hposB
+          hL hK ha0 haw hbh hxw hyh X *
+        staircaseCrossTensorVirtualOperation A B hA hB hATI hBTI hAB hposA hposB
+          hL hK ha0 haw hbh hxw hyh Y := by
+  have hspecXY := staircaseCrossTensorVirtualOperation_spec A B hA hB hATI hBTI hAB
+    hposA hposB hL hK ha0 haw hbh hxw hyh (X * Y)
+  have hspecX := staircaseCrossTensorVirtualOperation_spec A B hA hB hATI hBTI hAB
+    hposA hposB hL hK ha0 haw hbh hxw hyh X
+  have hspecY := staircaseCrossTensorVirtualOperation_spec A B hA hB hATI hBTI hAB
+    hposA hposB hL hK ha0 haw hbh hxw hyh Y
+  have hex := existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp_sameState
+    A B hA hB hATI hBTI hAB hposA hposB hL hK ha0 haw hbh hxw hyh (X * Y)
+  dsimp only at hspecXY hspecX hspecY hex
+  apply hex.unique hspecXY
+  constructor
+  · intro etaLeft
+    simpa only [staircaseO1PhysicalOp_mul] using
+      (hspecX.1 etaLeft).mul (hspecY.1 etaLeft)
+  · intro etaRight
+    simpa only [staircaseO3PhysicalOp_mul] using
+      (hspecX.2 etaRight).mul (hspecY.2 etaRight)
 
 end Torus
 

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -417,9 +417,11 @@ correspondence in the proof sketch of the two-dimensional corollary
     \lean{TNLean.PEPS.staircaseO3PhysicalOp_mul}
     \leanok
     \uses{def:peps_staircase_O1_physical_operation,
-        def:peps_staircase_O3_physical_operation,
-        thm:peps_lemma5_end_operation_multiplication}
-    For matrices $X,Y\in\MN{D_A(e)}$, the canonical end operations satisfy
+        def:peps_staircase_O3_physical_operation}
+    Let $L,K>0$, and choose staircase coordinates $(a,b)$ with
+    $a+2L\leq\mathrm{width}$ and $2K\leq\mathrm{height}$. Suppose every
+    cyclic $L\times K$ window of $A$ is injective. For matrices
+    $X,Y\in\MN{D_A(e)}$, the canonical end operations satisfy
     \begin{align}
         O_1^A(XY) & =O_1^A(X)O_1^A(Y),
         \notag                         \\
@@ -431,6 +433,7 @@ correspondence in the proof sketch of the two-dimensional corollary
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:peps_lemma5_end_operation_multiplication}
     Split the virtual boundary of either end window into the reference-edge
     coordinate and the remaining external coordinates.  On every fixed
     external fibre, the boundary insertion is ordinary matrix action.  The
@@ -467,10 +470,10 @@ correspondence in the proof sketch of the two-dimensional corollary
     \label{thm:peps_staircase_cross_tensor_virtual_operation_multiplication}
     \lean{TNLean.PEPS.staircaseCrossTensorVirtualOperation_mul}
     \leanok
-    \uses{def:peps_staircase_cross_tensor_virtual_operation,
-        thm:peps_staircase_end_physical_operation_multiplication,
-        thm:peps_lemma5_end_operation_multiplication}
-    For all $X_1,X_2\in\MN{D_A(e)}$,
+    \uses{def:peps_staircase_cross_tensor_virtual_operation}
+    Under the hypotheses of
+    Theorem~\ref{thm:peps_cross_tensor_virtual_operation_of_staircase}, for all
+    $X_1,X_2\in\MN{D_A(e)}$,
     \begin{align}
         Y_{A\to B}(X_1X_2)
          & =Y_{A\to B}(X_1)Y_{A\to B}(X_2).
@@ -479,6 +482,8 @@ correspondence in the proof sketch of the two-dimensional corollary
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:peps_staircase_end_physical_operation_multiplication,
+        thm:peps_lemma5_end_operation_multiplication}
     For every left external boundary configuration, compose the two $O_1$
     relations in ordinary order.  For every right external boundary
     configuration, compose the underlying $O_3$ relations in reverse order,

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -448,8 +448,8 @@ correspondence in the proof sketch of the two-dimensional corollary
     \leanok
     \uses{thm:peps_cross_tensor_virtual_operation_of_staircase}
     Under the hypotheses of
-    Theorem~\ref{thm:peps_cross_tensor_virtual_operation_of_staircase}, define
-    In the paper's notation the input and uniquely recovered matrices are
+    Theorem~\ref{thm:peps_cross_tensor_virtual_operation_of_staircase}, in the
+    paper's notation the input and uniquely recovered matrices are
     called $X$ and $Y$.  Writing $Y_{A\to B}(X)$ only to distinguish the two
     tensor families, define
     \begin{align}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -411,6 +411,84 @@ correspondence in the proof sketch of the two-dimensional corollary
     comparison give the displayed relations and the uniqueness of $Y$.
 \end{proof}
 
+\begin{theorem}[Composition of the canonical staircase end operations]%
+    \label{thm:peps_staircase_end_physical_operation_multiplication}
+    \lean{TNLean.PEPS.staircaseO1PhysicalOp_mul}
+    \lean{TNLean.PEPS.staircaseO3PhysicalOp_mul}
+    \leanok
+    \uses{def:peps_staircase_O1_physical_operation,
+        def:peps_staircase_O3_physical_operation,
+        thm:peps_lemma5_end_operation_multiplication}
+    For matrices $X,Y\in\MN{D_A(e)}$, the canonical end operations satisfy
+    \begin{align}
+        O_1^A(XY) & =O_1^A(X)O_1^A(Y),
+        \notag                         \\
+        O_3^A(XY) & =O_3^A(Y)O_3^A(X).
+        \notag
+    \end{align}
+    Thus the right relation preserves multiplication in ordinary order after
+    passing to the orientation $(O_3^A)^{\mathsf T}$ used in Lemma~5.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Split the virtual boundary of either end window into the reference-edge
+    coordinate and the remaining external coordinates.  On every fixed
+    external fibre, the boundary insertion is ordinary matrix action.  The
+    chosen left inverse of the injective blocked tensor is a left inverse on
+    the whole boundary-coordinate space, so composition gives matrix
+    multiplication.  The first window carries $X^{\mathsf T}$; hence
+    $(XY)^{\mathsf T}=Y^{\mathsf T}X^{\mathsf T}$ reverses the order of the
+    underlying right operations.
+\end{proof}
+
+\begin{definition}[Canonical cross-tensor matrix assignment]%
+    \label{def:peps_staircase_cross_tensor_virtual_operation}
+    \lean{TNLean.PEPS.staircaseCrossTensorVirtualOperation}
+    \lean{TNLean.PEPS.staircaseCrossTensorVirtualOperation_spec}
+    \leanok
+    \uses{thm:peps_cross_tensor_virtual_operation_of_staircase}
+    Under the hypotheses of
+    Theorem~\ref{thm:peps_cross_tensor_virtual_operation_of_staircase}, define
+    In the paper's notation the input and uniquely recovered matrices are
+    called $X$ and $Y$.  Writing $Y_{A\to B}(X)$ only to distinguish the two
+    tensor families, define
+    \begin{align}
+        Y_{A\to B}(X) & \in\MN{D_B(e)}
+        \notag
+    \end{align}
+    to be the unique matrix satisfying
+    (\ref{eq:peps_staircase_o1_cross_tensor_relation}) and
+    (\ref{eq:peps_staircase_o3_cross_tensor_relation}) for every left and
+    right external boundary configuration.  This definition makes no choice
+    of an external boundary configuration.
+\end{definition}
+
+\begin{theorem}[Multiplicativity of the cross-tensor assignment]%
+    \label{thm:peps_staircase_cross_tensor_virtual_operation_multiplication}
+    \lean{TNLean.PEPS.staircaseCrossTensorVirtualOperation_mul}
+    \leanok
+    \uses{def:peps_staircase_cross_tensor_virtual_operation,
+        thm:peps_staircase_end_physical_operation_multiplication,
+        thm:peps_lemma5_end_operation_multiplication}
+    For all $X_1,X_2\in\MN{D_A(e)}$,
+    \begin{align}
+        Y_{A\to B}(X_1X_2)
+         & =Y_{A\to B}(X_1)Y_{A\to B}(X_2).
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    For every left external boundary configuration, compose the two $O_1$
+    relations in ordinary order.  For every right external boundary
+    configuration, compose the underlying $O_3$ relations in reverse order,
+    which is ordinary multiplication in the $O_3^{\mathsf T}$ orientation.
+    The preceding theorem identifies these composites with the canonical
+    operations for $XY$.  Both end relations therefore realize
+    $Y_{A\to B}(X_1)Y_{A\to B}(X_2)$, and global uniqueness identifies this
+    product with $Y_{A\to B}(X_1X_2)$.
+\end{proof}
+
 \begin{theorem}[End-window identity for one virtual operation]%
     \label{thm:peps_end_window_identity_staircase_virtual_operation}
     \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_staircaseVirtualOperation}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -436,11 +436,17 @@ correspondence in the proof sketch of the two-dimensional corollary
     \uses{lem:peps_staircase_virtual_operation_end_inserts,
         thm:peps_lemma5_end_operation_multiplication}
     Split the virtual boundary of either end window into the reference-edge
-    coordinate and the remaining external coordinates.  On every fixed
-    external fibre, the boundary insertion is ordinary matrix action.  The
-    chosen left inverse of the injective blocked tensor is a left inverse on
-    the whole boundary-coordinate space, so composition gives matrix
-    multiplication.  The first window carries $X^{\mathsf T}$; hence
+    coordinate and the remaining external coordinates.  Let $E$ be this
+    splitting map, and write $C_M$ for insertion of $M$ on the reference edge.
+    On every fixed external fibre,
+    \begin{align}
+        C_M\bigl(E^{-1}(j,\eta)\bigr)
+         & =\sum_i M_{ij}\,T_{A,W}\bigl(E^{-1}(i,\eta)\bigr).
+        \notag
+    \end{align}
+    The chosen left inverse of the injective blocked tensor is a left inverse
+    on the whole boundary-coordinate space, so this identity gives
+    $O_W(M)O_W(N)=O_W(MN)$.  The first window carries $X^{\mathsf T}$; hence
     $(XY)^{\mathsf T}=Y^{\mathsf T}X^{\mathsf T}$ reverses the order of the
     underlying right operations.
 \end{proof}
@@ -485,14 +491,28 @@ correspondence in the proof sketch of the two-dimensional corollary
     \leanok
     \uses{thm:peps_staircase_end_physical_operation_multiplication,
         thm:peps_lemma5_end_operation_multiplication}
-    For every left external boundary configuration, compose the two $O_1$
-    relations in ordinary order.  For every right external boundary
-    configuration, compose the underlying $O_3$ relations in reverse order,
-    which is ordinary multiplication in the $O_3^{\mathsf T}$ orientation.
-    The preceding theorem identifies these composites with the canonical
-    operations for $XY$.  Both end relations therefore realize
-    $Y_{A\to B}(X_1)Y_{A\to B}(X_2)$, and global uniqueness identifies this
-    product with $Y_{A\to B}(X_1X_2)$.
+    Set $Y_r=Y_{A\to B}(X_r)$ for $r=1,2$.  For every left external
+    boundary configuration, the two $O_1$ relations compose in ordinary order:
+    \begin{align}
+        O_1^A(X_1)\Bigl(O_1^A(X_2)
+        \bigl(T_{B,W_{\mathrm L}}(k,\eta_{\mathrm L})\bigr)\Bigr)
+         & =\sum_i (Y_1Y_2)_{ik}\,
+        T_{B,W_{\mathrm L}}(i,\eta_{\mathrm L}).
+        \notag
+    \end{align}
+    For every right external boundary configuration, the underlying $O_3$
+    operations compose in reverse order:
+    \begin{align}
+        O_3^A(X_2)\Bigl(O_3^A(X_1)
+        \bigl(T_{B,W_{\mathrm R}}(k,\eta_{\mathrm R})\bigr)\Bigr)
+         & =\sum_j (Y_1Y_2)_{kj}\,
+        T_{B,W_{\mathrm R}}(j,\eta_{\mathrm R}).
+        \notag
+    \end{align}
+    This is ordinary multiplication in the $O_3^{\mathsf T}$ orientation.  The
+    preceding theorem identifies the left sides with the canonical operations
+    for $X_1X_2$.  Both end relations therefore realize $Y_1Y_2$, and global
+    uniqueness identifies this product with $Y_{A\to B}(X_1X_2)$.
 \end{proof}
 
 \begin{theorem}[End-window identity for one virtual operation]%

--- a/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_virtual_operation_family.tex
@@ -433,7 +433,8 @@ correspondence in the proof sketch of the two-dimensional corollary
 \end{theorem}
 \begin{proof}
     \leanok
-    \uses{thm:peps_lemma5_end_operation_multiplication}
+    \uses{lem:peps_staircase_virtual_operation_end_inserts,
+        thm:peps_lemma5_end_operation_multiplication}
     Split the virtual boundary of either end window into the reference-edge
     coordinate and the remaining external coordinates.  On every fixed
     external fibre, the boundary insertion is ordinary matrix action.  The

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -118,10 +118,14 @@ configuration~$\mu$.  The partial-state identity now also proves that the
 same operators $O_j^A(X)$, applied to the genuine $B$-blocks of a tensor with
 the same closed state, produce one common $B$-state.  The same-tensor two-end
 extraction and the $O_1P_1$ and underlying $P_3O_3$ composition laws are
-complete.  Applying that extraction to the cross-tensor common family now
-gives the unique bond matrix pointwise.  What remains is to organize the
-resulting matrix assignments, prove their multiplicativity from these laws,
-obtain the coefficient transfer, and assemble the back half of the argument.
+complete.  Applying that extraction to the cross-tensor common family gives
+the globally unique bond matrix, now organized as
+\leanid{TNLean.PEPS.staircaseCrossTensorVirtualOperation}.  The canonical end
+operations compose in the two source orders, and global uniqueness proves
+\leanid{TNLean.PEPS.staircaseCrossTensorVirtualOperation\_mul}.  This is the
+multiplicative part of the source's algebra-homomorphism assertion.  The
+additive, scalar, and unit laws for the full algebra-homomorphism package, the
+two coefficient-transfer identities, and the back-half assembly remain.
 
 Ref.~\cite{Molnar2018NormalPEPS} supplies this converse by the reduction ``we only need to prove a
 statement similar to Lemma~5''\footnote{\path{Papers/1804.04964/paper_normal.tex:2321}.}
@@ -184,9 +188,11 @@ simultaneously.
 a sketch.  The consecutive-window comparison, corner completion, forward
 open-boundary physical realization, and two-end recovery of the unique matrix
 $X$ are now formalized, as are the uniqueness and direct composition laws for
-Lemma~5's $O_1$ and $O_3^{\mathsf T}$ end-factor relations.  What remains is
-the cross-tensor coefficient transfer, its multiplicativity, and the
-back-half assembly.  The failed
+Lemma~5's $O_1$ and $O_3^{\mathsf T}$ end-factor relations.  The globally
+quantified cross-tensor matrix assignment and its multiplicativity are also
+formalized.  This does not yet package either map as an algebra homomorphism:
+the additive, scalar, and unit laws remain, together with the bidirectional
+cross-tensor coefficient transfer and the back-half assembly.  The failed
 single-window span above is an invented auxiliary route, not a statement made
 or required by the paper.
 
@@ -263,12 +269,12 @@ $O_3^{\mathsf T}$ orientations
 (\path{TNLean/PEPS/TorusWindowCrossTensorEndOperation.lean}). Every
 inverted region is a union of one-orientation $L \times K$ window translates,
 host-decomposable at $n \geq 2L+1$, $m \geq 2K+1$. The development is
-minimal-size-ready through the single-tensor virtual-operation family and the
-unique end-pair and pointwise cross-tensor extraction.
+minimal-size-ready through the single-tensor virtual-operation family, the
+unique end-pair extraction, and the multiplicative cross-tensor assignment.
 The direct $O_1\mapsto X$ and $O_3^{\mathsf T}\mapsto X$ composition laws are
-also complete.  The remaining gates are to organize the two pointwise
-cross-tensor assignments, prove the forward assignment multiplicative,
-obtain the coefficient transfer, and complete the back-half assembly that
+also complete.  The remaining gates are the additive, scalar, and unit laws
+for the full algebra-homomorphism statement, the two coefficient-transfer
+identities, and the back-half assembly that
 re-anchors the torus Theorem~3 layers to the $(L+1) \times (K+1)$
 comparison pair.
 
@@ -288,11 +294,15 @@ the operators $O_j^A(X)$ to the genuine $B$-blocks.  Feeding this family
 through the open end-pair equality and the two-end comparison now gives the
 unique $B$-bond matrix in
 \leanid{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp\_sameState}.
-Swapping the two tensors gives the reverse pointwise statement.  What
-remains is to organize these unique matrices into the forward and reverse
-coefficient transfers and prove that the forward assignment respects
-products; these are the \path{htransferAB}/\path{htransferBA}/\path{hmul}
-data consumed downstream.  This route uses the actual overlapping-window
+Swapping the two tensors gives the reverse pointwise statement.  The forward
+matrix is organized as
+\leanid{TNLean.PEPS.staircaseCrossTensorVirtualOperation}, and
+\leanid{TNLean.PEPS.staircaseCrossTensorVirtualOperation\_mul} proves that it
+respects products directly from the two end relations.  What remains is to
+identify these matrices with the forward and reverse region-inserted
+coefficients; these are the \path{htransferAB}/\path{htransferBA} data consumed
+downstream.  The multiplication field \path{hmul} is then supplied by the
+landed theorem.  This route uses the actual overlapping-window
 comparison and assumes no single-window matrix span.
 
 \paragraph{4. Auxiliary closing routes ruled out at the minimal size.}
@@ -355,17 +365,19 @@ a single-window square-matrix span.  The forward correspondence, its
 open-boundary physical operators, its transpose convention, and the unique
 end-pair operation now follow this description literally.  So do the direct
 composition laws for Lemma~5's $O_1$ and $O_3^{\mathsf T}$ orientations.  The
-pointwise cross-tensor end extraction is also complete.  The remaining formal
-work is the cross-tensor coefficient transfer, its multiplicativity, and the
-back-half assembly.
+globally quantified cross-tensor assignment and its multiplicativity are also
+complete.  The remaining formal work is to prove and package the additive,
+scalar, and unit laws, establish the bidirectional cross-tensor coefficient
+transfer, and complete the back-half assembly.
 
 \paragraph{6. Status.}
 The corollary remains \emph{unformalized}: no blueprint entry claims it, it
 carries the \texttt{notready} marker, and no \texttt{leanok} marks it.  The
-same-tensor family, pointwise cross-tensor end extraction, and direct
-end-composition laws are complete; the remaining work is the bidirectional
-coefficient transfer, its multiplicativity, and the back-half assembly tracked
-separately.
+same-tensor family, global cross-tensor assignment, and its direct
+end-composition proof of multiplicativity are complete.  The additive,
+scalar, and unit laws needed for the two full algebra-homomorphism statements,
+the bidirectional coefficient transfer, and the back-half assembly remain
+tracked separately.
 
 \section{The filled-in derivation}
 
@@ -662,10 +674,11 @@ the unique matrix $X$.  Specializing the end inserts to the physical actions
 $O_1$ and $O_3$ gives the source's two factor relations, whose direct
 composition laws are now formalized.  The same-state partial-state identity
 also supplies the cross-tensor common family for these physical operations,
-and the end-pair theorem now extracts its unique bond matrix.  The residual
-is to organize the two pointwise assignments, use the end-composition laws
-to prove multiplicativity, obtain the coefficient transfer, and complete
-the back-half assembly.
+and the end-pair theorem now extracts its unique bond matrix.  The globally
+quantified assignment and its multiplicativity by the two end-composition laws
+are now formalized.  The residual is to prove the additive, scalar, and unit
+laws needed for the full algebra-homomorphism statement, obtain the two
+coefficient-transfer identities, and complete the back-half assembly.
 
 \subsection{Step 5: the rest of the proof}
 
@@ -792,13 +805,15 @@ unions, all of which decompose at $(2L+1)\times(2K+1)$.
 
 \section{Formalization plan}
 
-The geometry, state-equality, forward fixed-edge-operation, and unique
-end-pair-operation layers of the derivation above are complete, including the
-direct composition laws in the two source orientations. The remaining source
+The geometry, state-equality, forward fixed-edge-operation, unique
+end-pair-operation, and multiplicative cross-tensor-assignment layers of the
+derivation above are complete, including the direct composition laws in the
+two source orientations. The remaining source
 steps following
 \path{Papers/1804.04964/paper_normal.tex:2368--2444} of
-Ref.~\cite{Molnar2018NormalPEPS} are the cross-tensor coefficient transfer,
-its multiplicativity, and the back-half assembly.  The layer list below
+Ref.~\cite{Molnar2018NormalPEPS} are the additive, scalar, and unit laws for
+the full algebra-homomorphism package, the bidirectional cross-tensor
+coefficient transfer, and the back-half assembly.  The layer list below
 records the campaign around these steps:
 
 \begin{enumerate}
@@ -821,8 +836,10 @@ records the campaign around these steps:
           last physical operations after adjoining the genuine corner tensors,
           invert the resulting regions, and recover the unique virtual operation
           $X$, with the $O_1\mapsto X$ and $O_3^{\mathsf T}\mapsto X$ uniqueness and
-          direct composition laws, including the pointwise cross-tensor end
-          extraction (complete).
+          direct composition laws, including the globally quantified
+          cross-tensor assignment and its multiplicativity (complete); the
+          additive, scalar, and unit laws needed to package the source's full
+          algebra homomorphisms remain.
     \item \emph{The per-edge witness}: the landed insertion-correspondence and
           Skolem--Noether interface at one reference edge per orientation; the
           remaining cross-tensor transfer must supply the coefficient identity this
@@ -1183,10 +1200,11 @@ The boundary-label and normalized-coupling arguments are in
 contraction and unique-operation extraction are in
 \path{TNLean/PEPS/TorusWindowPeeling/EndOperation.lean}.
 
-The Step~4 end relations and their direct composition laws are complete.  The
-remaining work is to organize the pointwise operations into the cross-tensor
-coefficient transfer, prove its multiplicativity, and then complete the back
-half of the proof.
+The Step~4 end relations, their direct composition laws, and the resulting
+multiplicative cross-tensor assignment are complete.  The remaining work is to
+prove the additive, scalar, and unit laws for the full algebra-homomorphism
+package, prove the two coefficient-transfer identities, and then complete the
+back half of the proof.
 
 \subsection{The back-half geometry supports a window witness region}
 
@@ -1335,10 +1353,12 @@ conjugation field assumed.
 
 The remaining input at this stage is therefore the staircase
 \emph{coefficient transfer} on the window: for each inserted matrix $M$ on
-$A$'s edge $e$ a matching matrix $N$ on $B$ with
-equal window coefficient
-($\text{\path{htransferAB}}$), its reverse ($\text{\path{htransferBA}}$), and the multiplicativity of
-the chosen forward transfer ($\text{\path{hmul}}$).  The same-tensor family that feeds the
+$A$'s edge $e$ a matching matrix $N$ on $B$ with equal window coefficient
+($\text{\path{htransferAB}}$), and its reverse ($\text{\path{htransferBA}}$).
+The canonical forward matrix assignment is already multiplicative by
+\leanid{TNLean.PEPS.staircaseCrossTensorVirtualOperation\_mul}, so this theorem
+supplies $\text{\path{hmul}}$ once the coefficient identities identify the
+transfer with that assignment.  The same-tensor family that feeds the
 single-bond peeling is now complete.  The first window carries the boundary insert of
 $M^{\mathsf T}$, the windows $W_1,\ldots,W_{L-1}$ carry the interior-bond insert of $M$,
 and the remaining windows carry the boundary insert of $M$.  Their common state is the
@@ -1360,9 +1380,10 @@ It feeds the common family through
 $\text{\path{staircasePair\_insert\_eq\_open}}$ and the genuine two-end
 injectivity argument, giving the unique $B$-matrix with the paper's $O_1$ and
 $O_3^{\mathsf T}$ orientations; swapping $A$ and $B$ gives the reverse
-pointwise extraction.  The local residual is to organize these unique
-matrices into the two coefficient transfers and use the end-composition laws
-to prove that the forward assignment respects products.  The region-level recovery
+pointwise extraction.  These matrices are now organized by
+$\text{\path{staircaseCrossTensorVirtualOperation}}$, and the end-composition
+laws prove that the forward assignment respects products.  The local residual
+is to establish the two coefficient identities.  The region-level recovery
 $\text{\path{regionInsertionTransfer\_of\_realizes}}$ derives all three transfer fields ---
 $\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and $\text{\path{hmul}}$ --- from one region
 physical-to-virtual realization $\text{\path{RegionTransferRealizes}}$ in each direction, with
@@ -1371,11 +1392,13 @@ realization on the window from the pointwise staircase extraction, in place of
 the edge-middle injectivity
 ($\mathrm{univ}\setminus\{u,v\}$ injective) the rectangle route uses, which fails at the
 minimal size --- the same obstruction, at the edge, that $\mathrm{univ}\setminus S$
-exhibits at the end pair.  The pointwise existence theorem alone does not yield
-$\text{\path{hmul}}$: the missing bridge is the comparison of the canonical
-physical operations under composition, in the order $O_1P_1$ on the left and
-the underlying order $P_3O_3$ for the $O_3^{\mathsf T}$ orientation on the
-right.  After this transfer is available, the back-half assembly remains.
+exhibits at the end pair.  The comparison of the canonical physical operations
+under composition is now
+$\text{\path{staircaseO1PhysicalOp\_mul}}$ and
+$\text{\path{staircaseO3PhysicalOp\_mul}}$, in the order $O_1P_1$ on the left
+and the underlying order $P_3O_3$ for the $O_3^{\mathsf T}$ orientation on the
+right.  After the coefficient transfer is available, the back-half assembly
+remains.
 
 \section{The multiplicativity route: compose the two end relations, not a
   single-window span or a coarse frame}
@@ -1384,8 +1407,8 @@ This section separates three statements that had previously been conflated:
 the unavailable single-window square-matrix span, an auxiliary coarse-frame
 theorem whose hypotheses fail at the minimal size, and the source's direct
 composition of the two end-factor relations.  The last of these is now
-formalized.  Its use in the cross-tensor transfer field
-$\text{\path{hmul}}$ remains the local open step.
+formalized and gives the cross-tensor multiplication field
+$\text{\path{hmul}}$ without either auxiliary route.
 
 \subsection{The single-window span does not exist, and is not the mechanism}
 
@@ -1467,9 +1490,9 @@ order, and use uniqueness of $X$.  No third block or larger frame enters.
 The overlapping-window realization sketched in Ref.~\cite{Molnar2018NormalPEPS} keeps the same
 virtual operation $M$ on $e$ while representing it on every staircase window.
 That common-state family, including its transfer across equal closed states,
-is now built below.  The remaining cross-tensor homomorphism must be obtained
-from Lemma~5's composition of the $O_1$ and $O_3^{\mathsf T}$ end relations,
-not from a single-window span or an assumed coarse frame.
+is now built below.  The cross-tensor multiplication law is obtained from
+Lemma~5's composition of the $O_1$ and $O_3^{\mathsf T}$ end relations, not
+from a single-window span or an assumed coarse frame.
 
 \subsection{The foundation that lands}
 
@@ -1544,9 +1567,10 @@ peeling hypothesis.  Together with the partial-state argument above, this
 closes both common-state-family residuals.  The subsequent end-pair comparison
 now extracts the unique cross-tensor matrix pointwise in
 \leanid{TNLean.PEPS.existsUnique_crossTensorVirtualOperation_of_staircasePhysicalOp\_sameState}.
-Packaging the forward and reverse coefficient transfers and proving the
-forward assignment multiplicative are the remaining Lemma~5-style steps,
-after which the back-half assembly remains.
+The canonical forward assignment and its multiplicativity are now packaged.
+Proving its additive, scalar, and unit laws and the forward and reverse
+coefficient identities are the remaining Lemma~5-style steps, after which the
+back-half assembly remains.
 
 \section{Normality and discarded stronger routes}
 
@@ -1606,9 +1630,10 @@ region of a coherent frame.\footnote{Formal geometry:
 These observations rule out two auxiliary shortcuts; they do not challenge
 the paper's fixed-edge comparison.  The comparison through adjoining the
 corner regions and recovering the unique cross-tensor virtual operation is now
-landed.  The two source orientations and their direct multiplication laws are
-also landed.  The remaining source work is to organize the bidirectional
-coefficient transfer, prove its multiplicativity, and complete the back-half
+landed.  The two source orientations, their canonical physical-operation laws,
+and the resulting cross-tensor multiplicativity are also landed.  The remaining
+source work is to prove the additive, scalar, and unit laws, prove the
+bidirectional coefficient-transfer identities, and complete the back-half
 assembly.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -1407,8 +1407,11 @@ This section separates three statements that had previously been conflated:
 the unavailable single-window square-matrix span, an auxiliary coarse-frame
 theorem whose hypotheses fail at the minimal size, and the source's direct
 composition of the two end-factor relations.  The last of these is now
-formalized and gives the cross-tensor multiplication field
-$\text{\path{hmul}}$ without either auxiliary route.
+formalized for the canonical cross-tensor assignment.  It supplies the product
+law needed for $\text{\path{hmul}}$ once the still-open coefficient identities
+identify $\text{\path{coeffTransferMap}}$ with that assignment.  The field
+$\text{\path{hmul}}$ remains open until this identification is proved; neither
+auxiliary route is needed for the product law itself.
 
 \subsection{The single-window span does not exist, and is not the mechanism}
 


### PR DESCRIPTION
### Partial source-faithful checkpoint

This pull request advances #5456 without closing it. It formalizes only the multiplicative part of the printed cross-tensor assignment in arXiv:1804.04964. It does not close #5456 or #2738.

### Motivation

Lemma 5 and the two-dimensional staircase argument recover a matrix on the second tensor family from the physical end operations and then say that the assignment is multiplicative “by composition.” The formalization should follow that printed route directly, with the paper's matrices `X`, `Y` and operations `O₁`, `O₃ᵀ`, rather than introducing a single-window span, a coarse frame, vertex injectivity, or a chosen external boundary configuration.

### Description

- Proves the canonical physical composition laws
  `O₁ᴬ(X₁X₂) = O₁ᴬ(X₁) O₁ᴬ(X₂)` and
  `O₃ᴬ(X₁X₂) = O₃ᴬ(X₂) O₃ᴬ(X₁)`, equivalently ordinary multiplication in the paper's `O₃ᵀ` orientation.
- Packages the globally unique recovered matrix `Y` for each input matrix `X`; both end relations remain quantified over every external boundary configuration.
- Uses `IsO1VirtualOperation.mul`, `IsO3TransposeVirtualOperation.mul`, and global uniqueness to prove
  `Y_{A→B}(X₁X₂) = Y_{A→B}(X₁) Y_{A→B}(X₂)`.
- Derives physical composition from the genuine region-boundary insertion and the defining left-inverse identity. No physical-space spanning or additional injectivity hypothesis is introduced.
- Synchronizes the Chapter 24 Blueprint and `docs/paper-gaps/peps_normal_ft_2d_overlap.tex` with the landed checkpoint and its precise residual.

The source anchors are `Papers/1804.04964/paper_normal.tex`, especially lines 563–582 for `X ↦ Y`, Lemma 5 at lines 2044–2252 for `O₁` and `O₃ᵀ`, and the two-dimensional sketch at lines 2320–2444.

This checkpoint does **not** yet prove or package additivity, scalar compatibility, or the unit law; it does not establish the bidirectional coefficient-transfer identities, bond equality, the algebra isomorphism, or the gauge conclusion. Those remain explicit in #5456 and the paper-gap note.

### Testing

- Pre-rebase full linter-bearing build: `scripts/lake_build_locked.sh TNLean` — 10,436 jobs passed.
- Post-rebase focused linter-bearing build: `scripts/lake_build_locked.sh TNLean.PEPS.TorusWindowCrossTensorEndOperation TNLean.PEPS` — 3,287 jobs passed.
- Post-rebase declaration refresh: `scripts/lake_build_locked.sh TNLean.MPS.ParentHamiltonian` — 9,180 jobs passed.
- `lake exe lint_style`
- Blueprint/Lean synchronization and `lake exe checkdecls blueprint/lean_decls`
- Paper-gap `\leanid` declaration check
- Reader-facing prose and forbidden-proof-token guards
- Changed Blueprint ChkTeX and pinned latexindent checks
- `python3 scripts/tactic_pattern_scan.py` — no new pattern from the changed module
- `git diff --check`

Advances #5456. Related to #2738.
