### PR TITLE
feat(MPS/MPU): identify tensor-product normalized flattening

### DIFF
--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -19,6 +19,7 @@ arbitrary remaining length.
 ## Main definitions
 
 * `finTupleProdEquiv`: splits a tuple of encoded product indices pointwise.
+* `finDoubledProdEquiv`: regroups two encoded product indices by their two factors.
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
 * `finSuccArrowEquiv`: separates the first coordinate from a finite tuple.
@@ -27,6 +28,8 @@ arbitrary remaining length.
 ## Main statements
 
 * `finTupleProdEquiv_apply`: gives the two pointwise component tuples.
+* `finDoubledProdEquiv_apply`: gives the regrouped doubled-product coordinate.
+* `finDoubledProdEquiv_symm_apply`: gives the inverse coordinate regrouping.
 * `finSuccArrowEquiv_apply`: gives the first coordinate and the remaining tuple.
 * `finSuccArrowEquiv_symm_apply`: reconstructs a tuple from its first coordinate and tail.
 * `finAddTwoArrowEquiv_apply`: gives the first two coordinates and the remaining tuple.
@@ -63,6 +66,33 @@ at every coordinate. -/
     finTupleProdEquiv N d e σ =
       (fun n ↦ (σ n).divNat, fun n ↦ (σ n).modNat) := by
   rfl
+
+/-- Regroup two encoded product indices by their factors:
+`((i, k), (j, l)) ↦ ((i, j), (k, l))`.
+
+All four pairs use the standard finite-product encoding `finProdFinEquiv`. -/
+def finDoubledProdEquiv (d e : ℕ) :
+    Fin ((d * e) * (d * e)) ≃ Fin ((d * d) * (e * e)) :=
+  finProdFinEquiv.symm |>.trans <|
+    (Equiv.prodCongr finProdFinEquiv.symm finProdFinEquiv.symm).trans <|
+      (Equiv.prodProdProdComm (Fin d) (Fin e) (Fin d) (Fin e)).trans <|
+        (Equiv.prodCongr finProdFinEquiv finProdFinEquiv).trans finProdFinEquiv
+
+/-- Forward coordinate formula for `finDoubledProdEquiv`. -/
+@[simp] theorem finDoubledProdEquiv_apply {d e : ℕ}
+    (i j : Fin d) (k l : Fin e) :
+    finDoubledProdEquiv d e
+        (finProdFinEquiv (finProdFinEquiv (i, k), finProdFinEquiv (j, l))) =
+      finProdFinEquiv (finProdFinEquiv (i, j), finProdFinEquiv (k, l)) := by
+  simp [finDoubledProdEquiv]
+
+/-- Inverse coordinate formula for `finDoubledProdEquiv`. -/
+@[simp] theorem finDoubledProdEquiv_symm_apply {d e : ℕ}
+    (i j : Fin d) (k l : Fin e) :
+    (finDoubledProdEquiv d e).symm
+        (finProdFinEquiv (finProdFinEquiv (i, j), finProdFinEquiv (k, l))) =
+      finProdFinEquiv (finProdFinEquiv (i, k), finProdFinEquiv (j, l)) := by
+  simp [finDoubledProdEquiv]
 
 /-- The canonical right-associated identification of a three-coordinate
 function with a triple. -/

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -49,6 +49,7 @@ import TNLean.MPS.MPU.StandardForm
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.SuppliedWitnessReblocking
 import TNLean.MPS.MPU.TensorProduct
+import TNLean.MPS.MPU.TensorProductCanonicalForm
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferMultiplicity

--- a/TNLean/MPS/MPU/PhysicalAncilla.lean
+++ b/TNLean/MPS/MPU/PhysicalAncilla.lean
@@ -17,7 +17,6 @@ the virtual bond dimension remains \(D\).
 ## Main definitions
 
 * `MPOTensor.tensorPhysicalId`: attach an identity ancilla at each physical site.
-* `MPOTensor.doubledPhysicalAncillaShuffle`: separate the original and ancilla doubled indices.
 * `MPOTensor.normalizedDiagonalLift`: adjoin the normalized diagonal ancilla alphabet.
 * `MPOTensor.normalizedDiagonalLiftCFIIData`: construct canonical-form-II data for the lift.
 * `MPOTensor.tensorPhysicalIdCFIIData`: construct canonical-form-II data after ancilla attachment.
@@ -108,25 +107,6 @@ theorem IsMPU.tensorPhysicalId {U : MPOTensor d D} (hU : IsMPU U)
 
 
 /-! ## Normalized doubled-index tensor -/
-
-/-- Separate the original and ancilla doubled physical indices by the shuffle
-\(((i,a),(j,b))\mapsto((i,j),(a,b))\).
-
-This is the physical relabeling used to identify the normalized flattening and
-canonical-form-II data after identity-ancilla attachment. -/
-def doubledPhysicalAncillaShuffle (d x : ℕ) :
-    Fin ((d * x) * (d * x)) ≃ Fin ((d * d) * (x * x)) :=
-  finProdFinEquiv.symm |>.trans <|
-    (Equiv.prodCongr finProdFinEquiv.symm finProdFinEquiv.symm).trans <|
-      (Equiv.prodProdProdComm (Fin d) (Fin x) (Fin d) (Fin x)).trans <|
-        (Equiv.prodCongr finProdFinEquiv finProdFinEquiv).trans finProdFinEquiv
-
-/-- Coordinate action of the doubled physical-ancilla shuffle. -/
-@[simp] theorem doubledPhysicalAncillaShuffle_apply (i j : Fin d) (a b : Fin x) :
-    doubledPhysicalAncillaShuffle d x
-        (finProdFinEquiv (finProdFinEquiv (i, a), finProdFinEquiv (j, b))) =
-      finProdFinEquiv (finProdFinEquiv (i, j), finProdFinEquiv (a, b)) := by
-  simp [doubledPhysicalAncillaShuffle]
 
 /-- Lift a doubled-index MPS tensor by a normalized diagonal ancilla alphabet.
 Only letters \((a,a)\) are nonzero, and each is scaled by \(1/\sqrt{x}\).
@@ -252,7 +232,7 @@ lines 336--340. -/
 theorem normalizedFlattening_tensorPhysicalId (U : MPOTensor d D)
     (x : ℕ) (_hx : 0 < x) :
     (tensorPhysicalId U x).normalizedFlattening =
-      Kraus.reindexPhysical (doubledPhysicalAncillaShuffle d x)
+      Kraus.reindexPhysical (finDoubledProdEquiv d x)
         (normalizedDiagonalLift U.normalizedFlattening x) := by
   funext k
   rcases finProdFinEquiv.surjective k with ⟨⟨ia, jb⟩, rfl⟩
@@ -263,7 +243,7 @@ theorem normalizedFlattening_tensorPhysicalId (U : MPOTensor d D)
         ((Real.sqrt (d * x) : ℂ)⁻¹) •
           tensorPhysicalId U x (finProdFinEquiv (i, a)) (finProdFinEquiv (j, b)) by
       simp [normalizedFlattening, MPOTensor.toMPSTensor]]
-  rw [show Kraus.reindexPhysical (doubledPhysicalAncillaShuffle d x)
+  rw [show Kraus.reindexPhysical (finDoubledProdEquiv d x)
       (normalizedDiagonalLift U.normalizedFlattening x)
       (finProdFinEquiv (finProdFinEquiv (i, a), finProdFinEquiv (j, b))) =
         normalizedDiagonalLift U.normalizedFlattening x
@@ -366,7 +346,7 @@ noncomputable def tensorPhysicalIdCFIIData (U : MPOTensor d D)
     MPSTensor.CPSVCanonicalFormIIData (tensorPhysicalId U x).normalizedFlattening :=
   (normalizedFlattening_tensorPhysicalId U x hx).symm ▸
     (normalizedDiagonalLiftCFIIData data x hx).reindexPhysical
-      (doubledPhysicalAncillaShuffle d x)
+      (finDoubledProdEquiv d x)
 
 /-- Full support is preserved by physical identity-ancilla attachment.
 
@@ -381,10 +361,10 @@ theorem hasFullSupport_tensorPhysicalIdCFIIData (U : MPOTensor d D)
   let lifted := normalizedDiagonalLiftCFIIData data x hx
   have hlift : lifted.toCPSVCanonicalFormData.HasFullSupport :=
     hasFullSupport_normalizedDiagonalLiftCFIIData data hfull x hx
-  let shuffled := lifted.reindexPhysical (doubledPhysicalAncillaShuffle d x)
+  let shuffled := lifted.reindexPhysical (finDoubledProdEquiv d x)
   have hshuffle : shuffled.toCPSVCanonicalFormData.HasFullSupport :=
     MPSTensor.CPSVCanonicalFormData.hasFullSupport_reindexPhysical
-      lifted.toCPSVCanonicalFormData hlift (doubledPhysicalAncillaShuffle d x)
+      lifted.toCPSVCanonicalFormData hlift (finDoubledProdEquiv d x)
   exact hasFullSupport_castCFIIData
     (normalizedFlattening_tensorPhysicalId U x hx) shuffled hshuffle
 

--- a/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
+++ b/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.Core.TensorProduct
+import TNLean.MPS.MPU.TensorProduct
+import TNLean.MPS.MPU.TransferMatrix
+
+/-!
+# Normalized flattening of an independent tensor product
+
+This file identifies the normalized doubled-index MPS tensor of an independent
+MPO tensor product with the independent tensor product of the two normalized
+flattenings.  The physical coordinate is regrouped in the canonical
+product-coordinate order
+`((i, k), (j, l)) ↦ ((i, j), (k, l))`.
+
+## Main statement
+
+* `MPOTensor.normalizedFlattening_tensorProduct`: normalized flattening commutes
+  with independent tensor products after the doubled-product coordinate change.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188], equation
+  `eq:transfer-op`, lines 336--340, and the proof of Theorem `IndexTh` (ii),
+  lines 824--845.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor
+
+variable {d D e E : ℕ}
+
+/-- Normalized flattening commutes with independent tensor products after the
+doubled physical coordinate change
+`((i, k), (j, l)) ↦ ((i, j), (k, l))`.
+
+The scalar equality is
+`(sqrt (d * e))⁻¹ = (sqrt d)⁻¹ * (sqrt e)⁻¹`; it holds without nonzero-dimension
+hypotheses because inverses in `ℂ` are totalized.
+This identity makes explicit the normalized-flattening compatibility
+corresponding to the tensoring clause in arXiv:1703.09188, proof of Theorem
+`IndexTh` (ii), lines 824--845; the paper does not state it separately. -/
+theorem normalizedFlattening_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    (tensorProduct U V).normalizedFlattening =
+      Kraus.reindexPhysical (finDoubledProdEquiv d e)
+        (MPSTensor.tensorProduct U.normalizedFlattening V.normalizedFlattening) := by
+  have hsqrt :
+      (Real.sqrt ((d * e : ℕ) : ℝ) : ℂ) =
+        (Real.sqrt d : ℂ) * (Real.sqrt e : ℂ) := by
+    rw [Nat.cast_mul, Real.sqrt_mul (by positivity), Complex.ofReal_mul]
+  funext q
+  rcases finProdFinEquiv.surjective q with ⟨⟨ik, jl⟩, rfl⟩
+  rcases finProdFinEquiv.surjective ik with ⟨⟨i, k⟩, rfl⟩
+  rcases finProdFinEquiv.surjective jl with ⟨⟨j, l⟩, rfl⟩
+  ext αγ βδ
+  rcases finProdFinEquiv.surjective αγ with ⟨⟨α, γ⟩, rfl⟩
+  rcases finProdFinEquiv.surjective βδ with ⟨⟨β, δ⟩, rfl⟩
+  simp only [normalizedFlattening, Kraus.reindexPhysical,
+    finDoubledProdEquiv_apply, MPSTensor.tensorProduct_apply,
+    MPOTensor.tensorProduct_apply, toMPSTensor,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat,
+    Matrix.smul_apply, smul_eq_mul]
+  rw [hsqrt, mul_inv]
+  ring
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3925,6 +3925,82 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \cite[Section~III, equation~(13)]{Cirac2017MPU}.
 \end{definition}
 
+\begin{definition}[Doubled product-coordinate equivalence]
+    \label{def:mpu_doubled_product_coordinate_equiv}
+    \lean{finDoubledProdEquiv, finDoubledProdEquiv_apply,
+        finDoubledProdEquiv_symm_apply}
+    \leanok
+    Write
+    $\pi_{m,n}:\Fin m\times\Fin n\to\Fin{mn}$ for the standard product
+    coordinate bijection.  For natural numbers $d,e$, the canonical doubled
+    product-coordinate equivalence
+    $s_{d,e}:\Fin{(de)^2}\to\Fin{d^2e^2}$ and its inverse satisfy
+    \begin{align}
+        s_{d,e}\!\left(\pi_{de,de}
+        \bigl(\pi_{d,e}(i,k),\pi_{d,e}(j,\ell)\bigr)\right)
+         & =\pi_{d^2,e^2}
+        \bigl(\pi_{d,d}(i,j),\pi_{e,e}(k,\ell)\bigr), \notag \\
+        s_{d,e}^{-1}\!\left(\pi_{d^2,e^2}
+        \bigl(\pi_{d,d}(i,j),\pi_{e,e}(k,\ell)\bigr)\right)
+         & =\pi_{de,de}
+        \bigl(\pi_{d,e}(i,k),\pi_{d,e}(j,\ell)\bigr).
+        \label{eq:mpu_tensor_flattening_shuffle}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Normalized flattening of an independent tensor product]
+    \label{thm:mpu_normalized_flattening_tensor_product}
+    \lean{MPOTensor.normalizedFlattening_tensorProduct}
+    \leanok
+    \uses{def:mpu_doubled_product_coordinate_equiv,
+        def:mpu_normalized_flattening,
+        def:mpu_independent_tensor_product,
+        def:mps_independent_tensor_product}
+    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and
+    auxiliary dimensions $D,E$, respectively.  With the coordinate
+    equivalence $s_{d,e}$ of
+    Definition~\ref{def:mpu_doubled_product_coordinate_equiv}, normalized
+    flattening obeys
+    \begin{align}
+        \widetilde{\mathcal U\boxtimes\mathcal V}
+         & =s_{d,e}^{*}
+        \bigl(\widetilde{\mathcal U}\boxtimes
+        \widetilde{\mathcal V}\bigr), \notag            \\
+        \left(\widetilde{\mathcal U\boxtimes\mathcal V}\right)^{
+                \pi_{d,e}(i,k),\pi_{d,e}(j,\ell)}_{
+                \pi_{D,E}(\alpha,\gamma),\pi_{D,E}(\beta,\delta)}
+         & =\widetilde{\mathcal U}^{i,j}_{\alpha,\beta}
+        \widetilde{\mathcal V}^{k,\ell}_{\gamma,\delta}.
+        \label{eq:mpu_tensor_normalized_flattening}
+    \end{align}
+    For positive physical dimensions this uses the normalization of
+    \cite[Section~III, equation~(13)]{Cirac2017MPU}.  With the totalized
+    inverse convention $0^{-1}=0$, the algebraic identity also holds when
+    $d=0$ or $e=0$.  This identity makes explicit the normalized-flattening
+    compatibility corresponding to the tensoring clause in
+    \cite[Theorem~IV.6(ii), lines~824--845]{Cirac2017MPU}; the paper does not
+    state it separately.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_doubled_product_coordinate_equiv,
+        def:mpu_normalized_flattening,
+        def:mpu_independent_tensor_product,
+        def:mps_independent_tensor_product}
+    Apply the two product-coordinate entry formulas after the regrouping in
+    (\ref{eq:mpu_tensor_flattening_shuffle}).  The scalar normalizations agree
+    because
+    \begin{align}
+        \bigl(\sqrt{de}\bigr)^{-1}
+         & =\bigl(\sqrt d\sqrt e\bigr)^{-1}
+        =\bigl(\sqrt d\bigr)^{-1}\bigl(\sqrt e\bigr)^{-1}.
+    \end{align}
+    Multiplying this identity by
+    $\mathcal U^{i,j}_{\alpha,\beta}
+        \mathcal V^{k,\ell}_{\gamma,\delta}$ gives
+    (\ref{eq:mpu_tensor_normalized_flattening}).
+\end{proof}
+
 \begin{lemma}[Normalized flattening of a composition tensor]
     \label{lem:mpu_normalized_flattening_composition}
     \lean{MPOTensor.normalizedFlattening_mulTensor_apply}

--- a/docs/audits/2026-08-29_doubled_product_shuffle_consolidation.md
+++ b/docs/audits/2026-08-29_doubled_product_shuffle_consolidation.md
@@ -1,0 +1,35 @@
+# Doubled-product shuffle consolidation
+
+## Declaration mapping
+
+| Removed declaration | Replacement |
+|---|---|
+| `MPOTensor.doubledPhysicalAncillaShuffle` | `finDoubledProdEquiv` |
+| `MPOTensor.doubledPhysicalAncillaShuffle_apply` | `finDoubledProdEquiv_apply` |
+
+The inverse-coordinate formula is now recorded by
+`finDoubledProdEquiv_symm_apply`.  The three replacement declarations live in
+`TNLean/Algebra/FinTupleEquiv.lean`, where they describe the source-neutral
+equivalence
+`((i, k), (j, l)) ↦ ((i, j), (k, l))`.
+
+## Consumer migration
+
+The existing non-Archive consumers were
+`MPOTensor.normalizedFlattening_tensorPhysicalId`,
+`MPOTensor.tensorPhysicalIdCFIIData`, and
+`MPOTensor.hasFullSupport_tensorPhysicalIdCFIIData`.  They now use
+`finDoubledProdEquiv` directly.  The general tensor-product identity
+`MPOTensor.normalizedFlattening_tensorProduct` uses the same equivalence.
+A repository-wide search found no other non-Archive consumer of either removed
+name.
+
+## Blueprint and compatibility status
+
+The old declarations had zero Blueprint tags, so no old tag remains to be
+migrated.  The neutral equivalence and its two coordinate lemmas are attached
+to the doubled product-coordinate definition in Chapter 28.
+
+No compatibility alias is retained.  TNLean does not promise a stable external
+Lean API, and retaining the ancilla-specific name would preserve a second
+public name for a source-neutral coordinate equivalence.


### PR DESCRIPTION
### Motivation

- `Papers/1703.09188/paper_v2.tex`, lines 336--340, equation `eq:transfer-op`, defines the transfer matrix of the normalized tensor `(1 / √d) 𝒰`.
- The proof of the Index Theorem, part (ii), at lines 824--845 says only: “The case of tensoring is trivial.” This change supplies the exact normalized-flattening calculation as TNLean infrastructure; it does not present that calculation as a separately stated theorem of the paper.
- Issue #7084 asks for the canonical doubled physical shuffle and normalization formula needed by the tensor-product branch of tracking issue #7029.

### Description

- Add the source-neutral finite-coordinate equivalence `finDoubledProdEquiv` with the exact forward and inverse formulas
  `((i, k), (j, l)) ↦ ((i, j), (k, l))`.
- Prove `MPOTensor.normalizedFlattening_tensorProduct` by reusing `MPOTensor.tensorProduct` and `MPSTensor.tensorProduct`. The proof displays `√(d e) = √d √e`, adds no positivity or `NeZero` hypotheses, and remains valid for zero dimensions under totalized inversion.
- Replace the duplicate ancilla-specific shuffle in `PhysicalAncilla.lean` by the common equivalence. No compatibility alias is retained: the old name specialized a source-neutral coordinate equivalence and TNLean does not promise a stable public Lean API. The migration is recorded in `docs/audits/2026-08-29_doubled_product_shuffle_consolidation.md`.
- Add formula-driven Chapter 28 Blueprint entries for the coordinate equivalence and normalized-flattening compatibility, explicitly labelled as project infrastructure supporting `IndexTh` (ii), not as a separate source theorem.
- Register the new MPU module in the generated import aggregator.

### Testing

- `scripts/lake_build_locked.sh TNLean.Algebra.FinTupleEquiv TNLean.MPS.MPU.PhysicalAncilla TNLean.MPS.MPU.TensorProductCanonicalForm TNLean.MPS.MPU`
- `scripts/lake_build_locked.sh -- lake exe lint_style --github`
- Kernel `#print axioms` checks for both coordinate formulas and `MPOTensor.normalizedFlattening_tensorProduct` (only `propext`, `Classical.choice`, and `Quot.sound`).
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/test_generate_import_aggregators.py`
- `python3 scripts/test_blueprint_lean_sync.py`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `scripts/latexindent -l blueprint/latexindent.yaml -w -s blueprint/src/chapter/ch28_mpu.tex`
- `python3 scripts/test_paper_gap_leanid_sync.py`
- `texra-blueprint paper-gaps check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- The repository-wide build and root-import declaration check are delegated to the hosted Lean and Blueprint jobs; the exact-head focused linter-bearing build above is green.

---
Closes #7084.
Advances #7029.

### Agent assistance

- OpenAI Codex (GPT-5) assisted with the source comparison, Lean proof, coordinate-equivalence consolidation, Blueprint entry, and validation. The maintainer reviewed the mathematical content and remains accountable for the change.