### PR TITLE
feat(PEPS): prove state-level torus bond uniformity

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -109,6 +109,7 @@ import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleRegion
 import TNLean.PEPS.TorusRowColumnReductionObstruction
+import TNLean.PEPS.TorusStateTranslationInvariant
 import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusWindowBondLocal

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -19,6 +19,12 @@ This root-only capstone records the full statement of the PEPS Fundamental
 Theorem (arXiv:1804.04964, Section 3, Theorem 2), with the forward
 bond-dimension obligation and converse gaps documented in the paper-gap notes
 cited below. The separate root-only audit is tracked by issue #1512.
+
+**Local fix (positive virtual spaces):** The paper's virtual bond spaces have
+positive dimension, whereas `Tensor.bondDim` can take the value zero.  Results
+using the three-site insertion comparison therefore state positivity
+explicitly.  The convention and the zero-dimensional obstruction are
+documented in `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
 -/
 
 open scoped BigOperators Matrix
@@ -586,6 +592,31 @@ theorem bondDim_eq_of_matrixAlgEquiv {m n : ℕ}
   simp only [Fintype.card_fin, Module.finrank_self, mul_one] at hfr
   exact Nat.mul_self_inj.mp hfr
 
+/-- Vertex-injective PEPS tensors with the same state and positive virtual
+spaces have the same bond dimension on every edge.
+
+This is the bond-dimension consequence of the virtual-operation algebra
+isomorphism in the proof of the injective PEPS Fundamental Theorem and does not
+require the graph to be connected.  At each edge, the edge-blocked three-site
+comparison gives an algebra equivalence between the two full matrix algebras on
+that bond; equality of their dimensions forces equality of the matrix sizes.
+
+Source: arXiv:1804.04964, the virtual-operation algebra isomorphism at lines
+279--282 and 571--582, and Theorem 2 at lines 1207--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_eq_of_isVertexInjective_sameState (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
+    A.bondDim = B.bondDim := by
+  funext e
+  exact bondDim_eq_of_matrixAlgEquiv
+    (edgeTransferAlgEquiv A B e
+      (hA.edgeBlockedThreeSiteInjective hposA e)
+      (hB.edgeBlockedThreeSiteInjective hposB e)
+      hAB hposA hposB)
+
 /-- **Fundamental Theorem for injective PEPS** (arXiv:1804.04964, Theorem 2).
 
 For PEPS tensors on a finite simple graph, if `A` and `B` are vertex-injective
@@ -629,18 +660,7 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
     (hposB : ∀ e : Edge G, 0 < B.bondDim e)
     (hconn : G.Connected) :
     GaugeEquiv A B := by
-  -- Bond-dimension equality follows edgewise from the edge-blocked insertion
-  -- algebra isomorphism: blocking around an edge gives two injective three-site
-  -- chains generating the same state, and the matched matrix insertions on that
-  -- bond form an algebra equivalence between the two full bond matrix algebras.
-  -- Such an equivalence forces equal matrix sizes.
-  have hDim : A.bondDim = B.bondDim := by
-    funext e
-    exact bondDim_eq_of_matrixAlgEquiv
-      (edgeTransferAlgEquiv A B e
-        (hA.edgeBlockedThreeSiteInjective hposA e)
-        (hB.edgeBlockedThreeSiteInjective hposB e)
-        hAB hposA hposB)
+  have hDim := bondDim_eq_of_isVertexInjective_sameState A B hA hB hAB hposA hposB
   -- With matching bond dimensions, gauge consistency supplies the global gauges.
   exact fundamentalTheorem_PEPS_of_bondDim A B hA hB hAB hDim hposA hconn
 

--- a/TNLean/PEPS/TorusStateTranslationInvariant.lean
+++ b/TNLean/PEPS/TorusStateTranslationInvariant.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.FundamentalTheorem
+import TNLean.PEPS.TorusTranslationInvariant
+
+/-!
+# Translation-invariant torus states have orientation-uniform bond dimensions
+
+The Applications section of arXiv:1804.04964 considers a possibly site-dependent
+injective PEPS whose represented state, rather than its tensor family, is
+translation invariant.  Its two-dimensional corollary first concludes that all
+horizontal bond dimensions agree and all vertical bond dimensions agree.
+
+This file proves exactly that first conclusion.  Translation invariance of the
+state identifies the tensor with each translated transport at the level of state
+coefficients.  Vertex injectivity is preserved by transport, so the
+virtual-operation algebra isomorphism from the proof of the injective PEPS
+Fundamental Theorem forces equality of the corresponding bond dimensions.
+Transitivity of torus translations on each orientation class then gives one
+horizontal and one vertical dimension.
+
+No site-independent tensor is constructed here.  The source states that second
+conclusion without a two-dimensional proof; its unresolved status is recorded
+in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+**Local fix (positive virtual spaces):** The paper's virtual bond spaces have
+positive dimension, whereas `Tensor.bondDim` can take the value zero.  The
+bond-uniformity theorems below therefore state positivity explicitly.  This
+convention and the zero-dimensional obstruction are documented in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+
+## Reference
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Applications section, lines 1801 and 1891--1894 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- A torus PEPS represents a translation-invariant state when every state
+coefficient is unchanged after precomposition of the physical configuration
+with a torus translation.
+
+This is weaker than `IsTorusTranslationInvariant A`: the local tensor family
+may depend on the site even though its contracted state is translation
+invariant.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsTorusTranslationInvariantState
+    (A : Tensor (torusGraph width height) d) : Prop :=
+  ∀ (a : ZMod width) (b : ZMod height)
+    (σ : TorusVertex width height → Fin d),
+    stateCoeff A (fun v ↦ σ (translate a b v)) = stateCoeff A σ
+
+/-- A translation-invariant torus tensor represents a translation-invariant
+state.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem IsTorusTranslationInvariant.isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) :
+    IsTorusTranslationInvariantState A :=
+  fun a b σ ↦ stateCoeff_translationInvariant hA a b σ
+
+/-- State translation invariance identifies a tensor with its transported
+translate at the level of all state coefficients.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem sameState_transport_of_isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariantState A)
+    (a : ZMod width) (b : ZMod height) :
+    SameState A (A.transport (translate a b)) := by
+  intro σ
+  rw [stateCoeff_transport]
+  exact (hA a b σ).symm
+
+/-- For an injective PEPS with positive virtual spaces, translation invariance
+of the represented state forces the bond dimension at every translated edge
+to equal the original bond dimension.
+
+The proof uses only the virtual-operation algebra isomorphism from the proof of
+the injective PEPS Fundamental Theorem.  It does not require a choice of gauge
+or a connectivity argument.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_translateEdge_of_isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hInj : IsVertexInjective A)
+    (hTI : IsTorusTranslationInvariantState A)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (a : ZMod width) (b : ZMod height)
+    (e : Edge (torusGraph width height)) :
+    A.bondDim (translateEdge a b e) = A.bondDim e := by
+  let φ := translate a b
+  have hInjTransport : IsVertexInjective (A.transport φ) :=
+    hInj.transport φ
+  have hposTransport :
+      ∀ f : Edge (torusGraph width height), 0 < (A.transport φ).bondDim f := by
+    intro f
+    simpa only [Tensor.transport_bondDim] using hpos (Edge.map φ.symm f)
+  have hDim : A.bondDim = (A.transport φ).bondDim :=
+    bondDim_eq_of_isVertexInjective_sameState A (A.transport φ)
+      hInj hInjTransport
+      (sameState_transport_of_isTorusTranslationInvariantState hTI a b)
+      hpos hposTransport
+  rw [translateEdge_eq_map]
+  have h := congrFun hDim (Edge.map φ e)
+  simpa only [Tensor.transport_bondDim, Edge.map_symm_map] using h
+
+/-- The horizontal bond dimension of an injective translation-invariant state
+is independent of the left endpoint of the edge.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusRightEdge_const_of_isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hInj : IsVertexInjective A)
+    (hTI : IsTorusTranslationInvariantState A)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (p p' : TorusVertex width height) :
+    A.bondDim (torusRightEdge p') = A.bondDim (torusRightEdge p) :=
+  bondDim_torusRightEdge_const_of_translate A.bondDim
+    (bondDim_translateEdge_of_isTorusTranslationInvariantState hInj hTI hpos)
+    p p'
+
+/-- The vertical bond dimension of an injective translation-invariant state is
+independent of the lower endpoint of the edge.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusUpEdge_const_of_isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hInj : IsVertexInjective A)
+    (hTI : IsTorusTranslationInvariantState A)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (p p' : TorusVertex width height) :
+    A.bondDim (torusUpEdge p') = A.bondDim (torusUpEdge p) :=
+  bondDim_torusUpEdge_const_of_translate A.bondDim
+    (bondDim_translateEdge_of_isTorusTranslationInvariantState hInj hTI hpos)
+    p p'
+
+/-- **An injective PEPS representing a translation-invariant state has
+orientation-uniform bond dimensions.**
+
+All horizontal bond dimensions equal the dimension at the reference right
+edge, and all vertical bond dimensions equal the dimension at the reference up
+edge.  This is the first conclusion of the two-dimensional
+Applications-section corollary.
+
+Source: arXiv:1804.04964, Applications section, lines 1801 and 1891--1894 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusUniformBondDim_of_isTorusTranslationInvariantState
+    {A : Tensor (torusGraph width height) d}
+    (hInj : IsVertexInjective A)
+    (hTI : IsTorusTranslationInvariantState A)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e) :
+    TorusUniformBondDim A.bondDim
+      (A.bondDim (torusRightEdge 0)) (A.bondDim (torusUpEdge 0)) :=
+  torusUniformBondDim_of_translate A.bondDim
+    (bondDim_translateEdge_of_isTorusTranslationInvariantState hInj hTI hpos)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusTranslationInvariant.lean
+++ b/TNLean/PEPS/TorusTranslationInvariant.lean
@@ -205,18 +205,63 @@ theorem translateEdge_torusUpEdge (a : ZMod width) (b : ZMod height)
   · exact Or.inr ⟨by rw [o1]; apply Prod.ext <;> simp [translate_apply]; ring,
       by rw [o2]; apply Prod.ext <;> simp [translate_apply]⟩
 
-/-- A translation-invariant tensor has the same bond dimension on every horizontal
-edge: the bond dimension of any right edge is independent of its left endpoint.
+/-- A bond-dimension function invariant under torus translations is constant
+on the horizontal edges.
+
+This is the geometric transitivity argument shared by tensor-level and
+state-level translation invariance.
+
+Source: arXiv:1804.04964, the horizontal bond-dimension conclusion at lines
+1891--1894 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusRightEdge_const_of_translate
+    (bondDim : Edge (torusGraph width height) → ℕ)
+    (htranslate : ∀ (a : ZMod width) (b : ZMod height) e,
+      bondDim (translateEdge a b e) = bondDim e)
+    (p p' : TorusVertex width height) :
+    bondDim (torusRightEdge p') = bondDim (torusRightEdge p) := by
+  have key :
+      translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusRightEdge p) =
+        torusRightEdge p' := by
+    rw [translateEdge_torusRightEdge]
+    congr 1
+    apply Prod.ext <;> simp
+  rw [← key]
+  exact htranslate _ _ (torusRightEdge p)
+
+/-- A bond-dimension function invariant under torus translations is constant
+on the vertical edges.
+
+This is the geometric transitivity argument shared by tensor-level and
+state-level translation invariance.
+
+Source: arXiv:1804.04964, the vertical bond-dimension conclusion at lines
+1891--1894 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusUpEdge_const_of_translate
+    (bondDim : Edge (torusGraph width height) → ℕ)
+    (htranslate : ∀ (a : ZMod width) (b : ZMod height) e,
+      bondDim (translateEdge a b e) = bondDim e)
+    (p p' : TorusVertex width height) :
+    bondDim (torusUpEdge p') = bondDim (torusUpEdge p) := by
+  have key :
+      translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusUpEdge p) =
+        torusUpEdge p' := by
+    rw [translateEdge_torusUpEdge]
+    congr 1
+    apply Prod.ext <;> simp
+  rw [← key]
+  exact htranslate _ _ (torusUpEdge p)
+
+/-- A translation-invariant tensor has the same bond dimension on every
+horizontal edge: the bond dimension of any right edge is independent of its
+left endpoint.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem bondDim_torusRightEdge_const {A : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (p p' : TorusVertex width height) :
-    A.bondDim (torusRightEdge p') = A.bondDim (torusRightEdge p) := by
-  have key : translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusRightEdge p) = torusRightEdge p' := by
-    rw [translateEdge_torusRightEdge]; congr 1; apply Prod.ext <;> simp
-  rw [← key]
-  exact bondDim_translateEdge_of_translationInvariant hA _ _ (torusRightEdge p)
+    A.bondDim (torusRightEdge p') = A.bondDim (torusRightEdge p) :=
+  bondDim_torusRightEdge_const_of_translate A.bondDim
+    (bondDim_translateEdge_of_translationInvariant hA) p p'
 
 /-- A translation-invariant tensor has the same bond dimension on every vertical
 edge: the bond dimension of any up edge is independent of its lower endpoint.
@@ -225,11 +270,9 @@ Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem bondDim_torusUpEdge_const {A : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (p p' : TorusVertex width height) :
-    A.bondDim (torusUpEdge p') = A.bondDim (torusUpEdge p) := by
-  have key : translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusUpEdge p) = torusUpEdge p' := by
-    rw [translateEdge_torusUpEdge]; congr 1; apply Prod.ext <;> simp
-  rw [← key]
-  exact bondDim_translateEdge_of_translationInvariant hA _ _ (torusUpEdge p)
+    A.bondDim (torusUpEdge p') = A.bondDim (torusUpEdge p) :=
+  bondDim_torusUpEdge_const_of_translate A.bondDim
+    (bondDim_translateEdge_of_translationInvariant hA) p p'
 
 /-! ### Constant bond dimension on each orientation class
 
@@ -249,6 +292,23 @@ def TorusUniformBondDim (bondDim : Edge (torusGraph width height) → ℕ) (Dh D
   (∀ e : Edge (torusGraph width height), IsHorizontalTorusEdge e → bondDim e = Dh) ∧
     (∀ e : Edge (torusGraph width height), IsVerticalTorusEdge e → bondDim e = Dv)
 
+/-- A bond-dimension function invariant under torus translations is uniform
+on each orientation class.
+
+Source: arXiv:1804.04964, the orientation-wise bond-dimension conclusion at
+lines 1891--1894 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem torusUniformBondDim_of_translate
+    (bondDim : Edge (torusGraph width height) → ℕ)
+    (htranslate : ∀ (a : ZMod width) (b : ZMod height) e,
+      bondDim (translateEdge a b e) = bondDim e) :
+    TorusUniformBondDim bondDim
+      (bondDim (torusRightEdge 0)) (bondDim (torusUpEdge 0)) := by
+  refine ⟨fun e he ↦ ?_, fun e he ↦ ?_⟩
+  · obtain ⟨p, rfl⟩ := isHorizontalTorusEdge_eq_rightEdge he
+    exact bondDim_torusRightEdge_const_of_translate bondDim htranslate 0 p
+  · obtain ⟨p, rfl⟩ := isVerticalTorusEdge_eq_upEdge he
+    exact bondDim_torusUpEdge_const_of_translate bondDim htranslate 0 p
+
 /-- **A translation-invariant tensor has orientation-uniform bond dimensions.**
 
 Reading off the horizontal dimension `Dh` at the right edge of the origin and the
@@ -263,12 +323,9 @@ Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
 theorem torusUniformBondDim_of_translationInvariant {A : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) :
     TorusUniformBondDim A.bondDim
-      (A.bondDim (torusRightEdge 0)) (A.bondDim (torusUpEdge 0)) := by
-  refine ⟨fun e he => ?_, fun e he => ?_⟩
-  · obtain ⟨p, rfl⟩ := isHorizontalTorusEdge_eq_rightEdge he
-    exact bondDim_torusRightEdge_const hA 0 p
-  · obtain ⟨p, rfl⟩ := isVerticalTorusEdge_eq_upEdge he
-    exact bondDim_torusUpEdge_const hA 0 p
+      (A.bondDim (torusRightEdge 0)) (A.bondDim (torusUpEdge 0)) :=
+  torusUniformBondDim_of_translate A.bondDim
+    (bondDim_translateEdge_of_translationInvariant hA)
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex
@@ -571,134 +571,82 @@ Theorem~\ref{thm:peps_cycle_two_site_bond_uniformity_counterexample} and
     the required repeated injective tensor $B$.
 \end{proof}
 
-\begin{corollary}[Translation-invariant description of an injective 2D PEPS,
-        uniform bond dimension]%
+\begin{corollary}[Bond uniformity from translation invariance of an injective
+        PEPS state]%
+    \label{cor:peps_state_translation_bond_uniform}
+    \lean{TNLean.PEPS.%
+        bondDim_translateEdge_of_isTorusTranslationInvariantState}
+    \lean{TNLean.PEPS.%
+        bondDim_torusRightEdge_const_of_isTorusTranslationInvariantState}
+    \lean{TNLean.PEPS.%
+        bondDim_torusUpEdge_const_of_isTorusTranslationInvariantState}
+    \lean{TNLean.PEPS.%
+        torusUniformBondDim_of_isTorusTranslationInvariantState}
+    \leanok
+    \uses{def:IsVertexInjective,
+        def:peps_torus_state_translation_invariant,
+        def:peps_torus_uniform_bond_dim}
+    Let $A$ be a vertex-injective PEPS on a discrete $n\times m$ torus with
+    $n,m>1$ and positive bond dimensions. If its represented state is
+    translation invariant, then its bond dimensions are orientation-uniform.
+    Explicitly, with
+    \begin{align}
+        D_h
+         & =D_A(e_h),
+         &
+        D_v
+         & =D_A(e_v),
+        \notag
+    \end{align}
+    at the reference right and up edges, every horizontal edge has dimension
+    $D_h$ and every vertical edge has dimension $D_v$.
+
+    This is the first conclusion of the two-dimensional Applications-section
+    corollary in \cite[lines~1891--1894]{Molnar2018NormalPEPS}.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:peps_sameState_translate_of_state_translation_invariant,
+        thm:peps_injective_sameState_bondDim_eq,
+        thm:peps_torusUniformBondDim_of_translationInvariant}
+    State translation invariance identifies $A$ with
+    $A^{\tau_{a,b}}$ at every translation. Transport preserves vertex
+    injectivity and positivity of the virtual spaces, so
+    Theorem~\ref{thm:peps_injective_sameState_bondDim_eq} gives
+    \begin{align}
+        D_A(\tau_{a,b}(e))
+         & =D_A(e).
+        \notag
+    \end{align}
+    Translations act transitively on the horizontal edges and separately on
+    the vertical edges. Applying the displayed equality to the reference
+    right and up edges gives the two claimed constants.
+\end{proof}
+
+\begin{corollary}[Translation-invariant description of an injective 2D PEPS]%
     \label{cor:exists_constant_injectivePEPS_of_translationInvariantState}
     \notready
-    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond_pos, thm:fundamentalTheorem_PEPS, def:peps_torus_translation_invariant, def:peps_torus_uniform_bond_dim, thm:peps_stateCoeff_translationInvariant}
-    Let $A$ be an injective PEPS on the discrete torus with orientation-uniform
-    bond dimensions, horizontal dimension $D_h$ and vertical dimension $D_v$,
-    and positive bond dimensions. If the generated state is invariant under all
-    lattice translations $\tau_{a,b}$, that is,
+    \uses{def:IsVertexInjective, def:peps_torus_translation_invariant,
+        def:peps_torus_state_translation_invariant,
+        def:peps_torus_uniform_bond_dim, def:peps_same_state}
+    Let $A$ be a vertex-injective PEPS on a discrete $n\times m$ torus with
+    $n,m>1$ and positive bond dimensions. If the generated state is invariant
+    under all lattice translations $\tau_{a,b}$, that is,
     $\Coeff_A(\sigma\circ\tau_{a,b})=\Coeff_A(\sigma)$ for every translation
-    and every physical configuration $\sigma$, then there is an injective
-    torus tensor $B$, with the same orientation-uniform bond dimensions $D_h$
-    and $D_v$, whose constant (site-independent) family generates the same
-    state: $\Coeff_A(\sigma)=\Coeff_B(\sigma)$ for every physical
-    configuration $\sigma$.
+    and every physical configuration $\sigma$, then there are positive
+    dimensions $D_h,D_v$ such that the bond dimensions of $A$ are
+    orientation-uniform with these values, and there is a vertex-injective
+    translation-invariant torus tensor $B$ with the same bond-dimension
+    function and the same represented state as $A$.
 
-    This is the uniform-bond-dimension target corresponding to the
-    Applications-section 2D corollary of
-    \cite[lines~1892--1894]{Molnar2018NormalPEPS}. The source additionally
-    concludes that all vertical bond dimensions agree and all horizontal bond
-    dimensions agree; in the present orientation-uniform setting those two
-    clauses have already been built into the bond-dimension type, so they carry
-    no content here.
+    This is the full two-dimensional Applications-section corollary of
+    \cite[lines~1891--1894]{Molnar2018NormalPEPS}.
 \end{corollary}
 \begin{proof}
-    The source states this corollary without proof, remarking only that the
-    one-dimensional argument extends; the route below is that intended
-    extension. Write $A^{(j,k)}$ for the site tensor at lattice position
-    $(j,k)$, with horizontal virtual legs of dimension $D_h$ and vertical
-    virtual legs of dimension $D_v$. Comparing the state with its
-    $\tau_{1,0}$-translate through the injective PEPS Fundamental Theorem
-    (Theorem~\ref{thm:fundamentalTheorem_PEPS}) produces, on each horizontal
-    edge, invertible $D_h\times D_h$ gauges $X_h^{(j,k)}$ with
-    \begin{align}
-        A^{(j+1,k)}
-         & =
-        (X_h^{(j,k)})^{-1}
-        A^{(j,k)}X_h^{(j+1,k)},
-        \notag
-    \end{align}
-    acting on the two horizontal virtual legs, and comparing with the
-    $\tau_{0,1}$-translate produces, on each vertical edge, invertible
-    $D_v\times D_v$ gauges $X_v^{(j,k)}$ with
-    \begin{align}
-        A^{(j,k+1)}
-         & =
-        (X_v^{(j,k)})^{-1}
-        A^{(j,k)}X_v^{(j,k+1)}.
-        \notag
-    \end{align}
-    Telescoping the horizontal gauges along a row reduces each site to the
-    leftmost one:
-    \begin{align}
-        A^{(j,k)}
-         & =
-        (L_h^{(j,k)})^{-1}
-        A^{(0,k)}R_h^{(j,k)},
-        \notag \\
-        L_h^{(j,k)}
-         & =
-        X_h^{(0,k)}\cdots X_h^{(j-1,k)},
-        \notag \\
-        R_h^{(j,k)}
-         & =
-        X_h^{(1,k)}\cdots X_h^{(j,k)},
-        \notag
-    \end{align}
-    and the periodic boundary condition closes the row product into a single
-    residual virtual operation, the 2D analog of the one-dimensional
-    identity $R_vL_{v+1}^{-1}=Z_0^{-1}$:
-    \begin{align}
-        R_h^{(j,k)}
-        (L_h^{(j+1,k)})^{-1}
-         & =
-        (X_h^{(0,k)})^{-1}.
-        \notag
-    \end{align}
-    The same telescoping closes each column, yielding one residual vertical
-    operation. Absorbing the two residual gauges into the corner site gives
-    a single repeated tensor
-    \begin{align}
-        B
-         & =
-        (X_v^{(0,0)})^{-1}
-        (X_h^{(0,0)})^{-1}
-        A^{(0,0)},
-        \notag
-    \end{align}
-    whose constant family generates the same state. The one-dimensional
-    telescoping closure is stated as
-    Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
-    What remains is the two-directional PEPS assembly. Define the residual
-    horizontal and vertical operations by
-    \begin{align}
-        H_{j,k}
-         & =
-        R_h^{(j,k)}
-        (L_h^{(j+1,k)})^{-1},
-        \notag \\
-        V_{j,k}
-         & =
-        R_v^{(j,k)}
-        (L_v^{(j,k+1)})^{-1}.
-        \notag
-    \end{align}
-    The horizontal residual acts on $\C^{D_h}$ and the vertical residual acts
-    on $\C^{D_v}$. The missing plaquette flatness identity must therefore
-    be stated after placing them on the corner space
-    $\C^{D_h}\otimes\C^{D_v}$. Equivalently, after the row and column
-    telescopings make $H_{j,k}=H_k$ and $V_{j,k}=V_j$, one must prove, for
-    nonzero scalars $\lambda_{j,k}$,
-    \begin{align}
-        (H_k\otimes\Id_{D_v})(\Id_{D_h}\otimes V_{j+1})
-         & =
-        \lambda_{j,k}
-        (\Id_{D_h}\otimes V_j)(H_{k+1}\otimes\Id_{D_v}).
-        \notag
-    \end{align}
-    The scalar phases must also close around the two periodic seams:
-    \begin{align}
-        \prod_{k\in\Z/N_v\Z}\lambda_{j,k}
-         & =1,
-        \notag \\
-        \prod_{j\in\Z/N_h\Z}\lambda_{j,k}
-         & =1.
-        \notag
-    \end{align}
-    These identities are then absorbed into this single repeated 2D tensor.
+    \uses{cor:peps_state_translation_bond_uniform}
+    The bond-dimension assertion is
+    Corollary~\ref{cor:peps_state_translation_bond_uniform}.
+    The construction of the site-independent injective tensor $B$ is the
+    remaining part of the corollary.
 \end{proof}
 
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -379,6 +379,36 @@
     equivalence packages them with the identified bond dimensions.
 \end{proof}
 
+\begin{theorem}[Equal bond dimensions for injective PEPS]%
+    \label{thm:peps_injective_sameState_bondDim_eq}
+    \lean{TNLean.PEPS.bondDim_eq_of_matrixAlgEquiv}
+    \lean{TNLean.PEPS.bondDim_eq_of_isVertexInjective_sameState}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_same_state}
+    Let $A$ and $B$ be vertex-injective PEPS tensors on the same finite simple
+    graph, with positive virtual bond dimensions, and suppose that they
+    represent the same state. Then
+    \begin{align}
+        D_A(e)
+         & =D_B(e)
+        \notag
+    \end{align}
+    for every edge $e$. This conclusion does not require the graph to be
+    connected. It is the bond-dimension consequence of the virtual-operation
+    algebra isomorphism in
+    \cite[lines~279--282 and 571--582]{Molnar2018NormalPEPS}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:peps_edgeBlockedThreeSiteInjective,
+        thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
+    Fix an edge. Blocking around it gives two injective three-site chains.
+    Their matched insertions on the distinguished bond form an algebra
+    equivalence between
+    $\MN{D_A(e)}$ and $\MN{D_B(e)}$. Equality of the linear dimensions of
+    these full matrix algebras gives $D_A(e)^2=D_B(e)^2$, hence
+    $D_A(e)=D_B(e)$.
+\end{proof}
+
 \begin{theorem}[Fundamental Theorem for injective PEPS]%
     \label{thm:fundamentalTheorem_PEPS}
     \lean{TNLean.PEPS.fundamentalTheorem_PEPS}
@@ -398,6 +428,7 @@
     incident to $v$.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{thm:peps_injective_sameState_bondDim_eq}
     The bond dimensions agree edgewise, because blocking around an edge gives
     two injective three-site chains whose matched matrix insertions on that bond
     form an algebra equivalence between the two bond matrix algebras, forcing

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -429,9 +429,7 @@
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:peps_injective_sameState_bondDim_eq}
-    The bond dimensions agree edgewise, because blocking around an edge gives
-    two injective three-site chains whose matched matrix insertions on that bond
-    form an algebra equivalence between the two bond matrix algebras, forcing
-    equal sizes. With the bond dimensions identified, the conditional form of
-    the theorem applies.
+    By Theorem~\ref{thm:peps_injective_sameState_bondDim_eq}, the bond
+    dimensions agree edgewise. With the bond dimensions identified, the
+    conditional form of the theorem applies.
 \end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_translation_and_reference_windows.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_translation_and_reference_windows.tex
@@ -50,7 +50,8 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.translateIncidentEdge}
     \lean{TNLean.PEPS.torusEdge_horizontal_or_vertical}
     \leanok
-    The discrete $n\times m$ torus has vertex set $\Z/n\Z\times\Z/m\Z$.
+    For $n,m>1$, the discrete $n\times m$ torus has vertex set
+    $\Z/n\Z\times\Z/m\Z$.
     Its graph joins $(x,y)$ to $(x+1,y)$ and to $(x,y+1)$, with the
     coordinates read cyclically; every edge is of one of these two forms,
     so every edge is horizontal or vertical. Translation by $(a,b)$ is the
@@ -149,6 +150,62 @@ site-independent tensor and produces the global phase of
     invariance.
 \end{proof}
 
+\begin{definition}[Translation-invariant torus state]%
+    \label{def:peps_torus_state_translation_invariant}
+    \lean{TNLean.PEPS.IsTorusTranslationInvariantState}
+    \leanok
+    \uses{def:peps_stateCoeff, def:peps_torus_geometry_translation}
+    A PEPS tensor $A$ on the discrete torus represents a
+    translation-invariant state if
+    \begin{align}
+        \Coeff_A(\sigma\circ\tau_{a,b})
+         & =\Coeff_A(\sigma)
+        \notag
+    \end{align}
+    for every lattice translation $\tau_{a,b}$ and every physical
+    configuration $\sigma$. This condition concerns the contracted state;
+    the local tensor family itself may depend on the lattice site.
+\end{definition}
+
+\begin{theorem}[Tensor translation invariance implies state translation invariance]%
+    \label{thm:peps_tensor_translation_invariant_state}
+    \lean{TNLean.PEPS.IsTorusTranslationInvariant.%
+        isTorusTranslationInvariantState}
+    \leanok
+    \uses{def:peps_torus_translation_invariant,
+        def:peps_torus_state_translation_invariant}
+    A translation-invariant torus tensor represents a translation-invariant
+    state.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:peps_stateCoeff_translationInvariant}
+    This is Theorem~\ref{thm:peps_stateCoeff_translationInvariant} for every
+    translation and physical configuration.
+\end{proof}
+
+\begin{theorem}[State equality with every translated tensor]%
+    \label{thm:peps_sameState_translate_of_state_translation_invariant}
+    \lean{TNLean.PEPS.%
+        sameState_transport_of_isTorusTranslationInvariantState}
+    \leanok
+    \uses{def:peps_torus_state_translation_invariant,
+        def:peps_tensor_transport, def:peps_same_state}
+    If $A$ represents a translation-invariant state, then
+    $A$ and $A^{\tau_{a,b}}$ represent the same state for every translation:
+    \begin{align}
+        \Coeff_A(\sigma)
+         & =\Coeff_{A^{\tau_{a,b}}}(\sigma).
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:peps_stateCoeff_transport}
+    Transport gives
+    $\Coeff_{A^{\tau_{a,b}}}(\sigma)
+        =\Coeff_A(\sigma\circ\tau_{a,b})$, and state translation invariance
+    identifies the right-hand side with $\Coeff_A(\sigma)$.
+\end{proof}
+
 \begin{definition}[Orientation-uniform bond dimensions on the torus]%
     \label{def:peps_torus_uniform_bond_dim}
     \lean{TNLean.PEPS.torusRightEdge}
@@ -172,8 +229,11 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.isVerticalTorusEdge_eq_upEdge}
     \lean{TNLean.PEPS.translateEdge_torusRightEdge}
     \lean{TNLean.PEPS.translateEdge_torusUpEdge}
+    \lean{TNLean.PEPS.bondDim_torusRightEdge_const_of_translate}
+    \lean{TNLean.PEPS.bondDim_torusUpEdge_const_of_translate}
     \lean{TNLean.PEPS.bondDim_torusRightEdge_const}
     \lean{TNLean.PEPS.bondDim_torusUpEdge_const}
+    \lean{TNLean.PEPS.torusUniformBondDim_of_translate}
     \lean{TNLean.PEPS.torusUniformBondDim_of_translationInvariant}
     \leanok
     \uses{def:peps_torus_translation_invariant, def:peps_torus_uniform_bond_dim}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2638,78 +2638,45 @@ of the same horizontal and vertical bond dimensions. The source states this
 corollary without proof (lines 1892--1894); it gives a proof only for the
 one-dimensional case (lines 1807--1890) and remarks at line 1801 that ``below we
 provide the proof for injective MPS, but the proof can easily be extended to the
-other cases as well.'' The intended extension applies the one-dimensional
-argument separately along the horizontal and the vertical lattice translations:
-comparing the tensor with each translate through the injective PEPS Fundamental
-Theorem would produce per-edge gauges, which telescope around each row and each
-column and close under the periodic boundary condition. This route is the
-expected one, not a proof the source carries out.
+other cases as well.'' It does not print a plaquette identity, a
+two-directional compatibility package, or a formula for the final tensor.
 
-The load-bearing dependency, the injective PEPS Fundamental Theorem
-(\leanid{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
-\path{thm:fundamentalTheorem_PEPS}), is formalized. The one-dimensional
-repeated-tensor construction discussed above is also formalized as
-\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState_per_bond}
-under the positive-bond and at-least-three-site restrictions just stated.
-The remaining work is the PEPS-specific two-directional closure: the horizontal
-and vertical gauge telescopings must be compatible around plaquettes and
-periodic seams, and their residual virtual operations must be absorbed into one
-site-independent 2D tensor. Let $L_h^{(j,k)}$ and $R_h^{(j,k)}$ denote the
-left and right horizontal gauges at site $(j,k)$, and let $L_v^{(j,k)}$ and
-$R_v^{(j,k)}$ denote the corresponding vertical gauges. Define the residual
-horizontal and vertical gauges by
-\begin{align}
-    H_{j,k}
-        &:= R^{(j,k)}_h\bigl(L^{(j+1,k)}_h\bigr)^{-1},
-    \label{eq:peps_normal_ft_section3_route_horizontal_residual_gauge}\\
-    V_{j,k}
-        &:= R^{(j,k)}_v\bigl(L^{(j,k+1)}_v\bigr)^{-1}.
-    \label{eq:peps_normal_ft_section3_route_vertical_residual_gauge}
-\end{align}
-The residual gauge in
-(\ref{eq:peps_normal_ft_section3_route_horizontal_residual_gauge}) acts on the
-horizontal virtual leg $\mathbb C^{D_h}$, whereas the residual gauge in
-(\ref{eq:peps_normal_ft_section3_route_vertical_residual_gauge}) acts on the
-vertical virtual leg $\mathbb C^{D_v}$. Thus the plaquette condition is not an
-ordinary product of a $D_h\times D_h$ matrix with a $D_v\times D_v$ matrix. It
-must be stated on the corner virtual space
-$\mathbb C^{D_h}\otimes\mathbb C^{D_v}$. After the row and column telescopings
-make $H_{j,k}=H_k$ and $V_{j,k}=V_j$, the missing scalar plaquette flatness
-relation is
-\begin{align}
-    (H_k\otimes I_{D_v})(I_{D_h}\otimes V_{j+1})
-        &= \lambda_{j,k}\,(I_{D_h}\otimes V_j)
-           (H_{k+1}\otimes I_{D_v}),
-    \qquad \lambda_{j,k}\ne 0.
-    \label{eq:peps_normal_ft_section3_route_plaquette_flatness}
-\end{align}
-The scalars in (\ref{eq:peps_normal_ft_section3_route_plaquette_flatness}) must
-also satisfy the periodic seam conditions
-\begin{align}
-    \prod_{k\in\mathbb Z/N_v\mathbb Z}\lambda_{j,k}
-        &= 1,
-    \label{eq:peps_normal_ft_section3_route_vertical_seam_closure}\\
-    \prod_{j\in\mathbb Z/N_h\mathbb Z}\lambda_{j,k}
-        &= 1.
-    \label{eq:peps_normal_ft_section3_route_horizontal_seam_closure}
-\end{align}
-Conditions
-(\ref{eq:peps_normal_ft_section3_route_vertical_seam_closure}) and
-(\ref{eq:peps_normal_ft_section3_route_horizontal_seam_closure}) close the
-vertical and horizontal periodic seams, respectively. The blueprint records
-the restricted target as
-\path{cor:exists_constant_injectivePEPS_of_translationInvariantState}, marked
-not ready.
+The first conclusion is formalized on the existing edge-dependent torus tensor.
+Translation invariance of the represented state is
+\leanid{TNLean.PEPS.IsTorusTranslationInvariantState}. It gives equality of
+the state with every transported tensor through
+\leanid{TNLean.PEPS.sameState_transport_of_isTorusTranslationInvariantState}.
+Transport preserves vertex injectivity, and the virtual-operation algebra
+isomorphism from the proof of the injective Fundamental Theorem,
+\leanid{TNLean.PEPS.bondDim_eq_of_isVertexInjective_sameState}, then shows
+that the bond dimension at an edge agrees with the dimension at every
+translate. Since translations act transitively on each orientation class,
+\leanid{TNLean.PEPS.torusUniformBondDim_of_isTorusTranslationInvariantState}
+proves that all horizontal bond dimensions agree and all vertical bond
+dimensions agree. The corresponding blueprint entry is
+\path{cor:peps_state_translation_bond_uniform}.
 
-\emph{Verdict: scope restriction.} As in the one-dimensional case, the
-orientation-uniform torus bond-dimension type fixes the horizontal dimension
-\(D_h\) and the vertical dimension \(D_v\) in advance, so the source's
-``all vertical (resp. horizontal) bond dimensions are equal'' clauses are
-vacuous in the uniform-dimension statement. A fully faithful version requires a
-per-edge, rectangular bond model in which the adjacent invertible gauges along
-each orientation first force equality of the bond dimensions; that variant
-inherits the same uniform-dimension restriction recorded for the
-one-dimensional corollary and remains a separate follow-up.
+The full source corollary is recorded separately as
+\path{cor:exists_constant_injectivePEPS_of_translationInvariantState} and
+remains not ready. Its open conclusion is the existence of a vertex-injective
+translation-invariant tensor \(B\), with the same bond-dimension function and
+the same represented state. Since the source gives no two-dimensional proof,
+the formalization must derive this construction from the translation
+comparisons and the Fundamental Theorem; it must not introduce an unproved
+plaquette relation, seam condition, or compatibility datum as if it were part
+of the cited statement.
+
+\emph{Verdict: partial formalization.} The source's orientation-wise bond-
+dimension equalities are complete for a vertex-injective PEPS on a discrete
+torus of width and height greater than one, under the
+explicit positive-bond convention documented in
+\path{docs/paper-gaps/peps_injective_ft_section3_route.tex}. Crucially, the
+input remains site-dependent and only its represented state is assumed
+translation invariant. The translation-invariant description by a single
+tensor \(B\) remains open. The earlier proposed plaquette-flatness and
+residual-gauge formulae were project-invented proof data not present in
+Ref.~\cite{Molnar2018NormalPEPS}; they have therefore been removed rather than
+retained as an unsupported proof route.
 
 \section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,22 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### torus-translation bond uniformity — promoted
+- **Pattern:** use a translation carrying one right (respectively up) edge to
+  another to prove constancy of a bond-dimension function, then reduce an
+  arbitrary horizontal or vertical edge to the corresponding reference edge.
+- **Seen:** six occurrences across two files before promotion (2026-08-31):
+  the right-edge, up-edge, and orientation-uniformity proofs in
+  `TNLean/PEPS/TorusTranslationInvariant.lean` and
+  `TNLean/PEPS/TorusStateTranslationInvariant.lean`.
+- **Abstraction:** `bondDim_torusRightEdge_const_of_translate`,
+  `bondDim_torusUpEdge_const_of_translate`, and
+  `torusUniformBondDim_of_translate` in
+  `TNLean/PEPS/TorusTranslationInvariant.lean`.
+- **Notes:** the helpers assume only invariance of the bond-dimension function
+  under every torus translation.  Both the tensor-level and state-level
+  wrappers now supply their respective translated-edge equality theorem.
+
 ### permutation-matrix unitarity — promoted
 - **Pattern:** unfold unitary-group membership, rewrite the conjugate transpose
   of a permutation matrix as the inverse permutation matrix, and reduce their


### PR DESCRIPTION
## What changed

- prove edgewise bond-dimension equality for injective PEPS tensors representing the same state
- derive horizontal and vertical bond uniformity for torus-translation-invariant states
- use the established bond-dimension theorem directly in the Fundamental Theorem Blueprint proof
- keep construction of the site-independent tensor and the remaining two-dimensional gauge theorem explicitly open

The result matches the bond-uniformity clause of the source and does not reintroduce the earlier plaquette or seam assumptions.

## Validation

- branch rebased onto current `main`
- previous hosted full Lean build, Blueprint compilation, module policies, timing, import-aggregator, and tenkz guards were green
- Blueprint source synchronization after the review fix: 7340/7340 theorem-like entries
- `git diff --check`
- no added `sorry`, `admit`, `axiom`, `unsafe`, or `native_decide`

Advances #2921
