### PR TITLE
feat(parent-hamiltonian): prove the nonwrapping open parent gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -77,6 +77,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleFullRangeEstimate
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -19,6 +19,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleFullRangeEstimate
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
@@ -42,7 +43,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The twenty-one components are:
+The twenty-two components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
@@ -82,6 +83,8 @@ The twenty-one components are:
   sums in Nachtergaele's martingale estimate;
 * `Martingale.NachtergaeleFullRangeEstimate` — the source's printed martingale-difference
   summation with the exact C1--C3 energy coefficient and its norm-gap form;
+* `Martingale.OpenParentGap` — the physical nonwrapping open MPS specialization,
+  with \(d_{l+1}=\gamma_{l+1}=1\) and the same \(\epsilon_l\) as condition C3;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenParentGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenParentGap.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
+import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
+import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleFullRangeEstimate
+
+/-!
+# Uniform gap for the nonwrapping open MPS parent Hamiltonian
+
+This file specializes the full-range C1--C3 martingale estimate to the canonical
+nonwrapping open parent Hamiltonian.  For interaction length \(L=l+1\), the
+source constants are
+\[
+  d_{l+1}=1,\qquad \gamma_{l+1}=1,
+\]
+while condition C3 keeps the same coefficient \(\epsilon_l\).  Hence the gap
+coefficient is exactly
+\[
+  (1-\epsilon_l\sqrt{l+1})^2.
+\]
+
+The abstract full-range theorem assumes C1--C3 at every index
+\(n=0,\ldots,N-1\), which is stronger than the lower-threshold hypotheses in
+the source.  Here the extra early indices are harmless: before a complete
+length-\(l+1\) interaction fits, the suffix Hamiltonian vanishes, its kernel
+projection is the identity, and the fixed-ambient martingale difference
+vanishes.  At the first complete window, the fixed-volume C3 product vanishes
+by the endpoint projector identity.
+
+## References
+
+* Nachtergaele, arXiv:cond-mat/9410110, conditions C1--C3, lines 1030--1094.
+* Nachtergaele, arXiv:cond-mat/9410110, Theorem 2.1(i), lines 1119--1130,
+  and proof lines 1195--1259.
+-/
+
+open scoped BigOperators ComplexOrder InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A fixed-window suffix Hamiltonian vanishes before its full interaction
+window fits.  This supplies the early-index part of the full-range C1 and C2
+hypotheses. -/
+theorem openSuffixParentHamiltonianES_eq_zero_of_lt
+    (A : MPSTensor d D) {L N n : ℕ} (hnL : n < L) :
+    openSuffixParentHamiltonianES A L L N n = 0 := by
+  rw [openSuffixParentHamiltonianES]
+  apply Finset.sum_eq_zero
+  intro i hi
+  rw [Finset.mem_filter] at hi
+  exfalso
+  omega
+
+/-- Shifting the full filtration range by one gives the C1 suffix sum.  Terms
+before the first complete length-\(L\) window are zero. -/
+theorem sum_range_openSuffixParentHamiltonianES_succ_eq_Icc
+    (A : MPSTensor d D) {L N : ℕ} (hL : 0 < L) :
+    ∑ n ∈ Finset.range N, openSuffixParentHamiltonianES A L L N (n + 1) =
+      ∑ n ∈ Finset.Icc L N, openSuffixParentHamiltonianES A L L N n := by
+  let f := fun n ↦ openSuffixParentHamiltonianES A L L N n
+  have hshift :
+      ∑ n ∈ Finset.range N, f (n + 1) = ∑ n ∈ Finset.Icc 1 N, f n := by
+    apply Finset.sum_bij (fun n _ ↦ n + 1)
+    · intro n hn
+      simp only [Finset.mem_range] at hn
+      simp only [Finset.mem_Icc]
+      omega
+    · intro n₁ hn₁ n₂ hn₂ h
+      omega
+    · intro m hm
+      simp only [Finset.mem_Icc] at hm
+      refine ⟨m - 1, ?_, ?_⟩
+      · simp only [Finset.mem_range]
+        omega
+      · omega
+    · intro n hn
+      rfl
+  have htrim :
+      ∑ n ∈ Finset.Icc L N, f n = ∑ n ∈ Finset.Icc 1 N, f n := by
+    apply Finset.sum_subset
+    · intro n hn
+      simp only [Finset.mem_Icc] at hn ⊢
+      omega
+    · intro n hn hnL
+      simp only [Finset.mem_Icc] at hn hnL
+      exact openSuffixParentHamiltonianES_eq_zero_of_lt A (by omega)
+  exact hshift.trans htrim.symm
+
+/-- Full-range C1 for interaction length \(l+1\), with the source counting
+constant \(d_{l+1}=1\).  The range indices are shifted because the local
+Hamiltonian at martingale index \(n\) acts on \([n-l,n+1)\). -/
+theorem openParentHamiltonianES_C1_full_range_quadratic_form
+    (A : MPSTensor d D) {l N : ℕ} (x : EuclideanSpace ℂ (Cfg d N)) :
+    0 ≤ ∑ n ∈ Finset.range N,
+        (⟪openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1) x, x⟫_ℂ).re ∧
+      (∑ n ∈ Finset.range N,
+        (⟪openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1) x, x⟫_ℂ).re) ≤
+        (⟪openParentHamiltonianES A (l + 1) N x, x⟫_ℂ).re := by
+  have hsum := sum_range_openSuffixParentHamiltonianES_succ_eq_Icc
+    A (L := l + 1) (N := N) (by omega)
+  have hC1 := openParentHamiltonianES_C1 A
+    (L := l + 1) (l := l + 1) (N := N) (le_refl _)
+  simp only [Nat.sub_self, zero_add, Nat.cast_one, one_smul] at hC1
+  rw [← hsum] at hC1
+  let S := ∑ n ∈ Finset.range N,
+    openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1)
+  constructor
+  · exact Finset.sum_nonneg fun n hn ↦
+      (openSuffixParentHamiltonianES_isPositive A (l + 1) (l + 1) N (n + 1)).2 x
+  · have hpos := (LinearMap.le_def S (openParentHamiltonianES A (l + 1) N)).mp hC1.2
+    have hx := hpos.2 x
+    have hSform :
+        RCLike.re ⟪S x, x⟫_ℂ =
+          ∑ n ∈ Finset.range N,
+            (⟪openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1) x,
+              x⟫_ℂ).re := by
+      simp only [S, LinearMap.sum_apply, sum_inner, map_sum, RCLike.re_to_complex]
+    change 0 ≤ RCLike.re ⟪(openParentHamiltonianES A (l + 1) N - S) x, x⟫_ℂ at hx
+    rw [LinearMap.sub_apply, inner_sub_left, map_sub, hSform] at hx
+    exact sub_nonneg.mp hx
+
+/-- Full-range norm-square form of C2 with \(\gamma_{l+1}=1\).  At early
+indices both sides vanish.  Once the window fits, the suffix Hamiltonian is the
+orthogonal projection \(I-Q_n\). -/
+theorem openSuffixParentHamiltonianES_C2_full_range_norm_sq
+    (A : MPSTensor d D) {l N n : ℕ} (hnN : n < N)
+    (x : EuclideanSpace ℂ (Cfg d N)) :
+    ‖((LinearMap.id : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ]
+          EuclideanSpace ℂ (Cfg d N)) -
+        openIntervalGroundProjectionES A (l + 1) l N n) x‖ ^ 2 ≤
+      (⟪openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1) x, x⟫_ℂ).re := by
+  by_cases hnl : n < l
+  · have hzero := openSuffixParentHamiltonianES_eq_zero_of_lt
+      A (L := l + 1) (N := N) (n := n + 1) (by omega)
+    simp only [openIntervalGroundProjectionES, hzero, LinearMap.ker_zero,
+      Submodule.starProjection_top']
+    norm_num
+  · have hln : l + 1 ≤ n + 1 := by omega
+    have hnN' : n + 1 ≤ N := by omega
+    let H := openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1)
+    have hH : H.IsSymmetricProjection :=
+      openSuffixParentHamiltonianES_isSymmetricProjection A (by omega) hln hnN'
+    have hEq :
+        H = (LinearMap.id : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ]
+          EuclideanSpace ℂ (Cfg d N)) -
+          openIntervalGroundProjectionES A (l + 1) l N n := by
+      simpa only [H, openIntervalGroundProjectionES] using
+        openSuffixParentHamiltonianES_eq_id_sub_starProjection_ker
+          A (by omega) hln hnN'
+    rw [← hEq]
+    have hIdem : H (H x) = H x := by
+      have h := congrArg (fun T : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ]
+        EuclideanSpace ℂ (Cfg d N) ↦ T x) hH.isIdempotentElem.eq
+      simpa [Module.End.mul_apply] using h
+    calc
+      ‖H x‖ ^ 2 = (⟪H x, H x⟫_ℂ).re :=
+        (inner_self_eq_norm_sq (𝕜 := ℂ) (H x)).symm
+      _ = (⟪H (H x), x⟫_ℂ).re := by rw [hH.isSymmetric (H x) x]
+      _ = (⟪H x, x⟫_ℂ).re := by rw [hIdem]
+      _ ≤ (⟪openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1) x,
+          x⟫_ℂ).re := le_rfl
+
+/-- Fixed-parameter open-chain gap obtained from the fixed-ambient C3 bound.
+For \(L=l+1\), conditions C1 and C2 have constants one, so the coefficient is
+\((1-\epsilon_l\sqrt{l+1})^2\). -/
+theorem openParentHamiltonianES_norm_gap_of_fixedAmbient_c3
+    [NeZero D] (A : MPSTensor d D) {l N : ℕ}
+    (hl : 0 < l) (hInj : Kraus.IsNBlkInjective A l) (hlN : l + 1 ≤ N)
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
+    (hC3 : ∀ n ∈ Finset.range N,
+      ‖LinearMap.toContinuousLinearMap
+        ((openIntervalGroundProjectionES A (l + 1) l N n).comp
+          ((fixedAmbientNestedGroundProjectionsES A (l + 1) N).martingaleDifference n))‖ ≤ ε) :
+    ∀ v ∈ (groundSpaceES A N)ᗮ,
+      (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ≤
+        ‖openParentHamiltonianES A (l + 1) N v‖ := by
+  let G := fixedAmbientNestedGroundProjectionsES A (l + 1) N
+  let Q := fun n ↦ openIntervalGroundProjectionES A (l + 1) l N n
+  let localHamiltonian := fun n ↦
+    openSuffixParentHamiltonianES A (l + 1) (l + 1) N (n + 1)
+  let H := openParentHamiltonianES A (l + 1) N
+  have hzero : G.projection 0 = LinearMap.id := by
+    change openPrefixGroundProjectionES A (l + 1) N 0 =
+      (1 : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N))
+    exact openPrefixGroundProjectionES_eq_one_of_lt A (N := N) (by omega)
+  have hQ : ∀ n ∈ Finset.range N, (Q n).IsSymmetricProjection := by
+    intro n hn
+    exact Submodule.isSymmetricProjection_starProjection _
+  have hcomm : ∀ n ∈ Finset.range N, ∀ m,
+      m < n - l ∨ n < m →
+        (G.martingaleDifference m).comp (Q n) =
+          (Q n).comp (G.martingaleDifference m) := by
+    intro n hn m hout
+    exact fixedAmbient_martingaleDifference_commute_openIntervalGroundProjectionES
+      A hlN hout
+  have hground : LinearMap.range (G.projection N) = LinearMap.ker H := by
+    change LinearMap.range (openPrefixGroundProjectionES A (l + 1) N N) =
+      LinearMap.ker (openParentHamiltonianES A (l + 1) N)
+    simp only [openPrefixGroundProjectionES, Submodule.range_starProjection]
+    rw [openPrefixParentHamiltonianES_self_eq_openParentHamiltonianES]
+  have hgap :=
+    FrustrationFree.NestedGroundProjections.norm_lower_bound_of_nachtergaele_c1_c3_full_range
+      G Q localHamiltonian H N l hzero
+      (γ := (1 : ℝ)) (d := (1 : ℝ)) (ε := ε)
+      (by norm_num) (by norm_num) hε hεlt hQ hcomm
+      (fun x ↦ by
+        simpa only [localHamiltonian, H, one_mul] using
+          openParentHamiltonianES_C1_full_range_quadratic_form A x)
+      (fun n hn x ↦ by
+        simpa only [localHamiltonian, Q, one_mul] using
+          openSuffixParentHamiltonianES_C2_full_range_norm_sq A
+            (Finset.mem_range.mp hn) x)
+      hC3 (openParentHamiltonianES_isPositive A (l + 1) N) hground
+  rw [ker_openParentHamiltonianES_eq_groundSpaceES_of_isNBlkInjective
+    hInj hl hlN] at hgap
+  simpa only [H, div_one, one_mul] using hgap
+
+/-- A primitive MPS has a uniform nonwrapping open-parent-Hamiltonian gap.
+The witnesses use the same \(l\) and \(\epsilon_l\) as the physical C3
+estimate, uniformly for every \(N\) with \(l+1\leq N\). -/
+theorem IsPrimitiveMPS.exists_openParentHamiltonianES_gap
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ l : ℕ, ∃ ε : ℝ, ∃ _hl : 1 < l, ∃ _hInj : Kraus.IsNBlkInjective A l,
+      0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      ∀ N : ℕ, l + 1 ≤ N → ∀ v ∈ (groundSpaceES A N)ᗮ,
+        (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ≤
+          ‖openParentHamiltonianES A (l + 1) N v‖ := by
+  obtain ⟨l, ε, hl, hInj, hε, hεlt, hC3⟩ :=
+    hP.exists_fixedAmbient_martingaleDifference_norm_lt_c3_threshold hρ
+  refine ⟨l, ε, hl, hInj, hε, hεlt, fun N hlN ↦ ?_⟩
+  exact openParentHamiltonianES_norm_gap_of_fixedAmbient_c3
+    A hl.le hInj hlN hε hεlt (fun n hn ↦ hC3 N n (Finset.mem_range.mp hn))
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenParentGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenParentGap.lean
@@ -22,13 +22,16 @@ coefficient is exactly
   (1-\epsilon_l\sqrt{l+1})^2.
 \]
 
-The abstract full-range theorem assumes C1--C3 at every index
-\(n=0,\ldots,N-1\), which is stronger than the lower-threshold hypotheses in
-the source.  Here the extra early indices are harmless: before a complete
-length-\(l+1\) interaction fits, the suffix Hamiltonian vanishes, its kernel
-projection is the identity, and the fixed-ambient martingale difference
-vanishes.  At the first complete window, the fixed-volume C3 product vanishes
-by the endpoint projector identity.
+**Scope restriction (full-range martingale hypotheses):** The abstract
+full-range theorem assumes C1--C3 at every index \(n=0,\ldots,N-1\), which is
+stronger than the lower-threshold hypotheses in the source.  Here the extra
+early indices are harmless: before a complete length-\(l+1\) interaction fits,
+the suffix Hamiltonian vanishes, its kernel projection is the identity, and
+the fixed-ambient martingale difference vanishes.  At the first complete
+window, the fixed-volume C3 product vanishes by the endpoint projector
+identity.  The distinction between the abstract restriction and this physical
+discharge is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 
 ## References
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3635,11 +3635,12 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
         lem:open_parent_hamiltonian_es_positive,
         thm:open_parent_hamiltonian_kernel_ground_space}
     Use the fixed-volume prefix ground-space projections and their differences
-    $E_n^{(N)}$. Theorems~\ref{thm:fixed-volume-c3-boundary-indices} and
-    \ref{thm:fixed-volume-c3-projector-conjugacy} identify the boundary terms
-    and the fixed-volume projectors entering C3. The outside-window
-    commutation theorem gives the locality hypothesis in the martingale
-    estimate. Theorems
+    $E_n^{(N)}$. Theorem~\ref{thm:fixed-volume-c3-boundary-indices} gives
+    $G_0^{(N)}=I$, while
+    Theorem~\ref{thm:fixed-volume-c3-projector-conjugacy} identifies
+    $\operatorname{ran}G_N^{(N)}$ with the kernel of the open Hamiltonian.
+    The outside-window commutation theorem gives the locality hypothesis in
+    the martingale estimate. Theorems
     \ref{thm:open_parent_hamiltonian_c1_full_range} and
     \ref{thm:open_suffix_parent_hamiltonian_c2_full_range} give C1 and C2 with
     $d_{l+1}=\gamma_{l+1}=1$, while

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1331,15 +1331,13 @@ norm estimate is derived here.
         \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert^2.
         \label{eq:nachtergaele_c1_c3_full_range_energy_estimate}
     \end{align}
-    This statement assumes C1--C3 for every $0\leq n<N$, whereas the
-    source imposes lower thresholds on the three conditions.  For the
-    compatible open-chain parent Hamiltonian, the terms below those thresholds
-    vanish.  Theorems~\ref{thm:open_parent_hamiltonian_c1_full_range} and
-    \ref{thm:open_suffix_parent_hamiltonian_c2_full_range} verify the resulting
-    full-range C1 and C2 estimates, while
-    Theorem~\ref{thm:literal_fixed_volume_martingale_c3} gives the full-range
-    C3 estimate with the same $\epsilon_l$.  The coefficient is exactly the
-    one in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}:
+    This full-range statement is stronger than the unrestricted source
+    theorem in general. It assumes C1, C2, and C3 for every $0\leq n<N$,
+    whereas the source imposes lower thresholds on these conditions. Without
+    separate control of the initial volumes, the source hypotheses do not
+    imply the assumptions above; see
+    \cite{gap:cpgsv21_martingale_overlap}. The coefficient is exactly the one
+    in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}:
     $\gamma_{l+1}/d_{l+1}$ times
     $(1-\epsilon_l\sqrt{l+1})^2$.
 \end{theorem}
@@ -3594,6 +3592,8 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     \leanok
     \uses{thm:nachtergaele_c1_c3_full_range_norm_gap,
         thm:physical-outside-window-martingale-cancellation,
+        thm:fixed-volume-c3-boundary-indices,
+        thm:fixed-volume-c3-projector-conjugacy,
         thm:open_parent_hamiltonian_c1_full_range,
         thm:open_suffix_parent_hamiltonian_c2_full_range,
         lem:open_parent_hamiltonian_es_positive,
@@ -3614,12 +3614,13 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
         \left\lVert H^{\mathrm{open}}_{N,l+1}(A)v\right\rVert.
         \label{eq:open_parent_hamiltonian_fixed_c3_gap}
     \end{align}
-    This intermediate theorem assumes C3 on the full range $0\leq n<N$,
-    rather than only above the lower threshold in the source statement. Under
-    this stronger hypothesis, it specializes Theorem~2.1(i) of
-    \cite{Nachtergaele1996Spectral} with $d_{l+1}=\gamma_{l+1}=1$ and the same
-    coefficient $\epsilon_l$ as in C3. The primitive existential theorem
-    below supplies the full-range C3 hypothesis from the physical open-chain
+    This intermediate MPS specialization assumes C3 on the full range
+    $0\leq n<N$, rather than only above the lower threshold in the source
+    statement. It applies the full-range estimate with
+    $d_{l+1}=\gamma_{l+1}=1$ and retains the coefficient of Theorem~2.1(i) in
+    \cite{Nachtergaele1996Spectral}. It is not a formulation of the
+    unrestricted source theorem. The primitive existential theorem below
+    supplies the full-range C3 hypothesis from the physical open-chain
     estimates.
 \end{theorem}
 
@@ -3627,13 +3628,18 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     \leanok
     \uses{thm:nachtergaele_c1_c3_full_range_norm_gap,
         thm:physical-outside-window-martingale-cancellation,
+        thm:fixed-volume-c3-boundary-indices,
+        thm:fixed-volume-c3-projector-conjugacy,
         thm:open_parent_hamiltonian_c1_full_range,
         thm:open_suffix_parent_hamiltonian_c2_full_range,
         lem:open_parent_hamiltonian_es_positive,
         thm:open_parent_hamiltonian_kernel_ground_space}
     Use the fixed-volume prefix ground-space projections and their differences
-    $E_n^{(N)}$.  The outside-window commutation theorem gives the locality
-    hypothesis in the martingale estimate.  Theorems
+    $E_n^{(N)}$. Theorems~\ref{thm:fixed-volume-c3-boundary-indices} and
+    \ref{thm:fixed-volume-c3-projector-conjugacy} identify the boundary terms
+    and the fixed-volume projectors entering C3. The outside-window
+    commutation theorem gives the locality hypothesis in the martingale
+    estimate. Theorems
     \ref{thm:open_parent_hamiltonian_c1_full_range} and
     \ref{thm:open_suffix_parent_hamiltonian_c2_full_range} give C1 and C2 with
     $d_{l+1}=\gamma_{l+1}=1$, while

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1331,15 +1331,15 @@ norm estimate is derived here.
         \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert^2.
         \label{eq:nachtergaele_c1_c3_full_range_energy_estimate}
     \end{align}
-    This statement is stronger than the source hypotheses: the source's C1
-    sum starts only at the corresponding window length, and
-    C2 and C3 are required only beyond their printed lower thresholds. Its
-    proof nevertheless applies them to every $E_n$ in the displayed
-    resolution. Here all three estimates are assumed for $0\leq n<N$.
-    This extra hypothesis is documented in
-    \cite{gap:cpgsv21_martingale_overlap}; no lower-endpoint discharge is
-    presently claimed. The coefficient is exactly the one printed in
-    Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}, namely
+    This statement assumes C1--C3 for every $0\leq n<N$, whereas the
+    source imposes lower thresholds on the three conditions.  For the
+    compatible open-chain parent Hamiltonian, the terms below those thresholds
+    vanish.  Theorems~\ref{thm:open_parent_hamiltonian_c1_full_range} and
+    \ref{thm:open_suffix_parent_hamiltonian_c2_full_range} verify the resulting
+    full-range C1 and C2 estimates, while
+    Theorem~\ref{thm:literal_fixed_volume_martingale_c3} gives the full-range
+    C3 estimate with the same $\epsilon_l$.  The coefficient is exactly the
+    one in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}:
     $\gamma_{l+1}/d_{l+1}$ times
     $(1-\epsilon_l\sqrt{l+1})^2$.
 \end{theorem}
@@ -1544,14 +1544,12 @@ continue with comparison of compatible interactions, approximate commutation
 of ground-state projectors, and a uniform gap. Theorem~2.1(i) of the same
 source obtains a gap from its three stated hypotheses. Every compatible
 Hamiltonian below is positive because it is a sum of orthogonal projections.
-In addition to the compatible Hamiltonian and its zero-energy space, the
-statements below verify condition C1 and the unit norm lower bound at the
-full-window volume $N=L$. The fixed-ambient C2 and C3 estimates apply beyond
-their source thresholds. To invoke
-Theorem~\ref{thm:nachtergaele_c1_c3_full_range_energy_estimate}, one must
-still supply its stronger lower-index hypotheses; this is precisely the open
-boundary recorded in \cite{gap:cpgsv21_martingale_overlap}. The statements in
-this subsection do not assume periodic coercivity.
+The statements below verify C1 and C2 on the full martingale range.  Before
+one complete interaction window fits, the suffix Hamiltonian vanishes.  At the
+remaining indices it is the orthogonal projection onto the local excited
+space.  Together with the fixed-volume form of C3, these identities specialize
+Theorem~\ref{thm:nachtergaele_c1_c3_full_range_norm_gap} with
+$d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}
@@ -1689,6 +1687,54 @@ this subsection do not assume periodic coercivity.
     Its local windows lie in the nonwrapping interval $[n-l,n)$.
 \end{definition}
 
+% Source: References/cond-mat_9410110/main.tex, condition C1,
+% lines 1030--1041.  The vanishing terms supply the indices below the
+% source lower endpoint when L=l+1.
+\begin{theorem}[Vanishing suffix before a complete window]
+    \label{thm:open_suffix_parent_hamiltonian_zero_before_window}
+    \lean{MPSTensor.openSuffixParentHamiltonianES_eq_zero_of_lt}
+    \leanok
+    \uses{def:open_suffix_parent_hamiltonian_es}
+    If $n<L$, then
+    \begin{align}
+        H^{\mathrm{suffix}}_{N,L;L,n}(A) & =0.
+        \label{eq:open_suffix_parent_hamiltonian_zero_before_window}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:open_suffix_parent_hamiltonian_es}
+    A summand would require a starting site $i$ satisfying both $n-L\leq i$
+    and $i+L\leq n$.  The latter inequality is impossible when $n<L$ and
+    $i\geq0$, so the defining sum is empty.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C1,
+% lines 1030--1041.
+\begin{theorem}[Shifted full-range suffix sum]
+    \label{thm:open_suffix_parent_hamiltonian_range_shift}
+    \lean{MPSTensor.sum_range_openSuffixParentHamiltonianES_succ_eq_Icc}
+    \leanok
+    \uses{def:open_suffix_parent_hamiltonian_es,
+        thm:open_suffix_parent_hamiltonian_zero_before_window}
+    If $L>0$, then
+    \begin{align}
+        \sum_{n=0}^{N-1}H^{\mathrm{suffix}}_{N,L;L,n+1}(A)
+         & =\sum_{n=L}^{N}H^{\mathrm{suffix}}_{N,L;L,n}(A).
+        \label{eq:open_suffix_parent_hamiltonian_range_shift}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_suffix_parent_hamiltonian_zero_before_window}
+    The substitution $m=n+1$ identifies the left-hand side with the sum over
+    $1\leq m\leq N$.  Every term with $m<L$ vanishes by
+    Theorem~\ref{thm:open_suffix_parent_hamiltonian_zero_before_window}, leaving
+    precisely the stated interval.
+\end{proof}
+
 \begin{theorem}[Finite-overlap condition C1 for the compatible open chain]
     \label{thm:open_parent_hamiltonian_es_c1}
     \lean{MPSTensor.openParentHamiltonianES_C1}
@@ -1724,6 +1770,38 @@ this subsection do not assume periodic coercivity.
     where $0\leq c_i\leq l-L+1$. Positivity of each local term turns the
     coefficient bound into the upper operator inequality. Positivity of their
     sum gives the lower inequality.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C1,
+% lines 1030--1041; proof of Theorem 2.1(i), lines 1250--1255.
+\begin{theorem}[Full-range compatible open-chain counting bound]
+    \label{thm:open_parent_hamiltonian_c1_full_range}
+    \lean{MPSTensor.openParentHamiltonianES_C1_full_range_quadratic_form}
+    \leanok
+    \uses{thm:open_parent_hamiltonian_es_c1,
+        thm:open_suffix_parent_hamiltonian_range_shift}
+    Set $L=l+1$.  For every vector $v$ on the $N$-site chain,
+    \begin{align}
+        0
+         & \leq \sum_{n=0}^{N-1}
+        \re\left\langle H^{\mathrm{suffix}}_{N,L;L,n+1}(A)v,v\right\rangle
+        \leq
+        \re\left\langle H^{\mathrm{open}}_{N,L}(A)v,v\right\rangle.
+        \label{eq:open_parent_hamiltonian_c1_full_range}
+    \end{align}
+    Thus the full martingale range satisfies C1 with $d_{l+1}=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_parent_hamiltonian_es_c1,
+        thm:open_suffix_parent_hamiltonian_range_shift,
+        lem:fixed-volume-hamiltonians-positive}
+    Equation~(\ref{eq:open_suffix_parent_hamiltonian_range_shift}) changes the
+    sum to the interval $L\leq n\leq N$.  Apply
+    Theorem~\ref{thm:open_parent_hamiltonian_es_c1} with suffix length $L$.
+    Each interaction then occurs once, since $L-L+1=1$.  Positivity of the
+    suffix Hamiltonians gives the lower bound.
 \end{proof}
 
 % Source anchors: References/cond-mat_9410110/main.tex, condition C2,
@@ -1796,7 +1874,7 @@ this subsection do not assume periodic coercivity.
          & =1.
     \end{align}
     The later condition C3 uses the distinct overlap parameter
-    $\varepsilon_l$.
+    $\epsilon_l$.
 \end{theorem}
 
 \begin{proof}
@@ -1835,6 +1913,41 @@ this subsection do not assume periodic coercivity.
     exact norm preservation and the unit lower bound. Condition C1 at suffix
     length $L$ gives $d_L=L-L+1=1$. With $L=l+1$, the two constants are therefore
     $d_{l+1}=1$ and $\gamma_{l+1}=1$.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C2,
+% lines 1043--1058; proof of Theorem 2.1(i), lines 1240--1248.
+\begin{theorem}[Full-range fixed-window local gap]
+    \label{thm:open_suffix_parent_hamiltonian_c2_full_range}
+    \lean{MPSTensor.openSuffixParentHamiltonianES_C2_full_range_norm_sq}
+    \leanok
+    \uses{thm:open_suffix_parent_hamiltonian_zero_before_window,
+        thm:open_suffix_parent_hamiltonian_es_c2}
+    Set $L=l+1$, let $0\leq n<N$, and let $Q_n$ be the orthogonal projection
+    onto the kernel of
+    $H^{\mathrm{suffix}}_{N,L;L,n+1}(A)$.  Then every vector $v$ satisfies
+    \begin{align}
+        \lVert (I-Q_n)v\rVert^2
+         & \leq
+        \re\left\langle H^{\mathrm{suffix}}_{N,L;L,n+1}(A)v,v\right\rangle.
+        \label{eq:open_suffix_parent_hamiltonian_c2_full_range}
+    \end{align}
+    Hence C2 holds on the full martingale range with $\gamma_{l+1}=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_suffix_parent_hamiltonian_zero_before_window,
+        thm:open_suffix_parent_hamiltonian_es_c2}
+    If $n<l$, the suffix Hamiltonian is zero and $Q_n=I$, so both sides of
+    (\ref{eq:open_suffix_parent_hamiltonian_c2_full_range}) vanish.  If
+    $n\geq l$, the suffix contains the single length-$(l+1)$ interaction and
+    equals $I-Q_n$ by Theorem~\ref{thm:open_suffix_parent_hamiltonian_es_c2}.
+    Since $I-Q_n$ is an orthogonal projection,
+    \begin{align}
+        \lVert(I-Q_n)v\rVert^2
+         & =\re\langle (I-Q_n)v,v\rangle.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Zero energy forces every compatible local constraint]
@@ -3346,11 +3459,11 @@ this subsection do not assume periodic coercivity.
     \uses{def:primitive_mps, def:l_blk_injective, def:open_chain_ground_subspaces_es, def:ground_space_es}
     Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
     positive-definite fixed point.  There are an overlap length $l>1$, measured
-    in sites of $A$, and a number $\varepsilon_l\geq0$ such that $A$ is
+    in sites of $A$, and a number $\epsilon_l\geq0$ such that $A$ is
     $l$-block injective, the projector defect is bounded
-    uniformly in the left length $K$ by $\varepsilon_l$, and
+    uniformly in the left length $K$ by $\epsilon_l$, and
     \begin{align}
-        \varepsilon_l & <\frac{1}{\sqrt{l+1}}.
+        \epsilon_l & <\frac{1}{\sqrt{l+1}}.
         \notag
     \end{align}
     Nachtergaele's projector-defect identity following condition C3
@@ -3374,7 +3487,7 @@ this subsection do not assume periodic coercivity.
     that length and above $1$ so that $cr^l<1$ and the last display is less
     than $1$.  Block injectivity propagates to $l$, and the geometric estimate
     gives the uniform defect bound with
-    $\varepsilon_l=(1-cr^l)^{-1}Cr^l$.  The open-chain projector-defect theorem
+    $\epsilon_l=(1-cr^l)^{-1}Cr^l$.  The open-chain projector-defect theorem
     gives the anticommutator statement.
 \end{proof}
 
@@ -3386,22 +3499,22 @@ this subsection do not assume periodic coercivity.
     \uses{thm:nachtergaele_c3_blocked_length, thm:exact_c3_martingale_difference_identity}
     Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
     positive-definite fixed point.  There are $l>1$ and
-    $\varepsilon_l\geq0$, with $A$ $l$-block injective, such that for every
+    $\epsilon_l\geq0$, with $A$ $l$-block injective, such that for every
     $K>0$, after setting $n=K+l$ and $n_l=l+1$,
     \begin{align}
         \left\lVert
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}E_n
         \right\rVert
-         & \leq\varepsilon_l.
+         & \leq\epsilon_l.
         \label{eq:literal_open_chain_martingale_c3}
     \end{align}
     The coefficient satisfies
     \begin{align}
-        \varepsilon_l
+        \epsilon_l
          & <\frac{1}{\sqrt{l+1}}.
         \label{eq:literal_open_chain_martingale_c3_threshold}
     \end{align}
-    The length $l$ and coefficient $\varepsilon_l$ are exactly those chosen
+    The length $l$ and coefficient $\epsilon_l$ are exactly those chosen
     by Theorem~\ref{thm:nachtergaele_c3_blocked_length}.
 \end{theorem}
 
@@ -3414,11 +3527,11 @@ this subsection do not assume periodic coercivity.
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
         -G_{\Lambda_{n+1}}
         \right\rVert
-         & \leq\varepsilon_l
+         & \leq\epsilon_l
     \end{align}
     for every $K>0$.  Rewrite its norm by
     Theorem~\ref{thm:exact_c3_martingale_difference_identity}; the existing
-    strict threshold on $\varepsilon_l$ is unchanged.
+    strict threshold on $\epsilon_l$ is unchanged.
 \end{proof}
 
 % Source: References/cond-mat_9410110/main.tex, condition C3, lines 1083--1094;
@@ -3436,15 +3549,15 @@ this subsection do not assume periodic coercivity.
         thm:literal_open_chain_martingale_c3}
     Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
     positive-definite fixed point.  There are $l>1$ and
-    $\varepsilon_l\geq0$, with $A$ $l$-block injective, such that for every
+    $\epsilon_l\geq0$, with $A$ $l$-block injective, such that for every
     final volume $N$ and every $n<N$,
     \begin{align}
         \left\lVert
         G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}^{(N)}E_n^{(N)}
         \right\rVert
-         & \leq\varepsilon_l,
+         & \leq\epsilon_l,
         \label{eq:literal_fixed_volume_martingale_c3} \\
-        \varepsilon_l
+        \epsilon_l
          & <\frac{1}{\sqrt{l+1}}.
         \label{eq:literal_fixed_volume_martingale_c3_threshold}
     \end{align}
@@ -3460,7 +3573,7 @@ this subsection do not assume periodic coercivity.
         thm:literal_open_chain_martingale_c3}
     If $n<l$, then $E_n^{(N)}=0$.  If $n=l$, the endpoint identity gives
     $G_{\Lambda_{l+1}}^{(N)}E_l^{(N)}=0$.  These cases use only
-    $\varepsilon_l\geq0$.
+    $\epsilon_l\geq0$.
 
     Suppose that $n>l$, and set $K=n-l>0$ and $r=N-(n+1)$.  The prefix and
     whole-prefix conjugacies identify $E_n^{(N)}$ with the direct sum of the
@@ -3471,6 +3584,102 @@ this subsection do not assume periodic coercivity.
     open-chain counterpart.  Isometric conjugacy preserves operator norm, and
     the fiberwise extension does not increase it.  The bound therefore follows
     from Theorem~\ref{thm:literal_open_chain_martingale_c3}.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, conditions C1--C3,
+% lines 1030--1094; Theorem 2.1(i), lines 1119--1130; proof lines 1195--1259.
+\begin{theorem}[Compatible open-chain gap from fixed-volume overlap]
+    \label{thm:open_parent_hamiltonian_fixed_c3_gap}
+    \lean{MPSTensor.openParentHamiltonianES_norm_gap_of_fixedAmbient_c3}
+    \leanok
+    \uses{thm:nachtergaele_c1_c3_full_range_norm_gap,
+        thm:physical-outside-window-martingale-cancellation,
+        thm:open_parent_hamiltonian_c1_full_range,
+        thm:open_suffix_parent_hamiltonian_c2_full_range,
+        lem:open_parent_hamiltonian_es_positive,
+        thm:open_parent_hamiltonian_kernel_ground_space}
+    Let $D\geq1$, let $l>0$, suppose that $A$ is $l$-block injective, and let
+    $N\geq l+1$.  Assume $0\leq\epsilon_l<1/\sqrt{l+1}$ and, for every
+    $0\leq n<N$,
+    \begin{align}
+        \left\lVert Q_nE_n^{(N)}\right\rVert & \leq\epsilon_l,
+        \label{eq:open_parent_hamiltonian_fixed_c3}
+    \end{align}
+    where $Q_n$ is the ground-space projection of the interval
+    $[n-l,n+1)$ and $E_n^{(N)}$ is the fixed-volume martingale difference.
+    Then every $v\in(G_N^{\mathrm{ES}}(A))^\perp$ satisfies
+    \begin{align}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert
+         & \leq
+        \left\lVert H^{\mathrm{open}}_{N,l+1}(A)v\right\rVert.
+        \label{eq:open_parent_hamiltonian_fixed_c3_gap}
+    \end{align}
+    This is Theorem~2.1(i) of \cite{Nachtergaele1996Spectral} with
+    $d_{l+1}=\gamma_{l+1}=1$ and the same coefficient $\epsilon_l$ as in C3.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:nachtergaele_c1_c3_full_range_norm_gap,
+        thm:physical-outside-window-martingale-cancellation,
+        thm:open_parent_hamiltonian_c1_full_range,
+        thm:open_suffix_parent_hamiltonian_c2_full_range,
+        lem:open_parent_hamiltonian_es_positive,
+        thm:open_parent_hamiltonian_kernel_ground_space}
+    Use the fixed-volume prefix ground-space projections and their differences
+    $E_n^{(N)}$.  The outside-window commutation theorem gives the locality
+    hypothesis in the martingale estimate.  Theorems
+    \ref{thm:open_parent_hamiltonian_c1_full_range} and
+    \ref{thm:open_suffix_parent_hamiltonian_c2_full_range} give C1 and C2 with
+    $d_{l+1}=\gamma_{l+1}=1$, while
+    (\ref{eq:open_parent_hamiltonian_fixed_c3}) is C3.  Positivity of the open
+    Hamiltonian and
+    $\ker H^{\mathrm{open}}_{N,l+1}(A)=G_N^{\mathrm{ES}}(A)$ identify the
+    final orthogonal complement.  Substitution into
+    (\ref{eq:nachtergaele_c1_c3_full_range_norm_gap}) yields
+    (\ref{eq:open_parent_hamiltonian_fixed_c3_gap}).
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, condition C3,
+% lines 1083--1094; Theorem 2.1(i), lines 1119--1130; proof lines 1195--1259.
+\begin{theorem}[Uniform gap for primitive compatible open chains]
+    \label{thm:primitive_open_parent_hamiltonian_gap}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_openParentHamiltonianES_gap}
+    \leanok
+    \uses{thm:literal_fixed_volume_martingale_c3,
+        thm:open_parent_hamiltonian_fixed_c3_gap}
+    Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
+    positive-definite fixed point.  There exist $l>1$ and $\epsilon_l\geq0$
+    such that $A$ is $l$-block injective,
+    \begin{align}
+        \epsilon_l & <\frac{1}{\sqrt{l+1}},
+        \label{eq:primitive_open_parent_hamiltonian_threshold}
+    \end{align}
+    and, for every $N\geq l+1$ and every
+    $v\in(G_N^{\mathrm{ES}}(A))^\perp$,
+    \begin{align}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert
+         & \leq
+        \left\lVert H^{\mathrm{open}}_{N,l+1}(A)v\right\rVert.
+        \label{eq:primitive_open_parent_hamiltonian_gap}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:literal_fixed_volume_martingale_c3,
+        thm:open_parent_hamiltonian_fixed_c3_gap}
+    Theorem~\ref{thm:literal_fixed_volume_martingale_c3} supplies $l>1$,
+    $\epsilon_l$, $l$-block injectivity, and the C3 estimate for every final
+    volume $N$ and every $n<N$.  Apply
+    Theorem~\ref{thm:open_parent_hamiltonian_fixed_c3_gap} for each
+    $N\geq l+1$.  The value of $\epsilon_l$ is unchanged, so the coefficient
+    is exactly the specialization
+    \begin{align}
+        \frac{\gamma_{l+1}}{d_{l+1}}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2
+         & =\left(1-\epsilon_l\sqrt{l+1}\right)^2.
+    \end{align}
 \end{proof}
 
 \begin{lemma}[Blocked three-site projector and adjacent-pair transport]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3614,8 +3614,13 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
         \left\lVert H^{\mathrm{open}}_{N,l+1}(A)v\right\rVert.
         \label{eq:open_parent_hamiltonian_fixed_c3_gap}
     \end{align}
-    This is Theorem~2.1(i) of \cite{Nachtergaele1996Spectral} with
-    $d_{l+1}=\gamma_{l+1}=1$ and the same coefficient $\epsilon_l$ as in C3.
+    This intermediate theorem assumes C3 on the full range $0\leq n<N$,
+    rather than only above the lower threshold in the source statement. Under
+    this stronger hypothesis, it specializes Theorem~2.1(i) of
+    \cite{Nachtergaele1996Spectral} with $d_{l+1}=\gamma_{l+1}=1$ and the same
+    coefficient $\epsilon_l$ as in C3. The primitive existential theorem
+    below supplies the full-range C3 hypothesis from the physical open-chain
+    estimates.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -186,12 +186,26 @@ The associated norm theorem
 reuses the existing finite-dimensional spectral theorem. These declarations
 are not identified with the unrestricted source theorem.
 
-Eliminating the restriction requires one of two source-faithful repairs: prove
-that the missing lower-index components are controlled by the stated C1--C3
-data without changing the coefficient, or supply and verify an explicit
-initial-volume convention under which those components vanish. For the MPS
-application, simply having uniform C2 and C3 estimates beyond their source
-thresholds does not discharge this obligation.
+The abstract limitation remains: the source-threshold hypotheses alone do not
+justify the full-range summation without additional control of the initial
+volumes. The nonwrapping open MPS specialization supplies this control and
+therefore satisfies the stronger full-range assumptions. The early local
+terms in C1 vanish. The early C2 expressions also vanish because the suffix
+Hamiltonian is zero and the complementary projection $\Id-Q_n$ is zero. For
+C3, $E_n^{(N)}=0$ when $n<l$, and at $n=l$ the endpoint identity
+\begin{align}
+    Q_lE_l^{(N)}
+    &=G_{l+1}^{(N)}\bigl(\Id-G_{l+1}^{(N)}\bigr)=0
+    \label{eq:cpgsv21_martingale_overlap_lower_endpoint_open_discharge}
+\end{align}
+supplies the remaining initial index. The physical estimate controls all
+$n>l$. Hence
+\leanid{MPSTensor.IsPrimitiveMPS.exists_openParentHamiltonianES_gap}
+applies the full-range theorem with $d_{l+1}=\gamma_{l+1}=1$ and preserves the
+coefficient in
+Equation~\eqref{eq:cpgsv21_martingale_overlap_nachtergaele_full_range_coefficient}.
+This does not identify the abstract full-range theorem with the unrestricted
+source statement.
 
 The scalar optimization also has a separate zero-constant case. The printed
 proof chooses


### PR DESCRIPTION
## What changed

- specialize the merged full-range Nachtergaele criterion to the compatible nonwrapping MPS parent Hamiltonian
- prove the early suffix Hamiltonians vanish and identify the shifted full-range local-energy sum with the existing C1 interval sum
- supply full-range C1 with $d_{l+1}=1$ and full-range C2 with $\gamma_{l+1}=1$
- combine the fixed-ambient C3 estimate with the abstract criterion to obtain the all-length open-chain gap
- add the primitive-MPS existential wrapper and synchronize Chapter 13

The final coefficient is the source constant

$$
\frac{\gamma_{l+1}}{d_{l+1}}
\left(1-\epsilon_l\sqrt{l+1}\right)^2
=
\left(1-\epsilon_l\sqrt{l+1}\right)^2.
$$

The proof follows Nachtergaele, arXiv:cond-mat/9410110, C1-C3 and Theorem 2.1(i). It uses no periodic, cyclic, boundary-coercivity, or cross-volume identification.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian` (9183/9183)
- full `lake build` (10442/10442)
- generated import aggregators current: 37 files covering 1067 production modules
- Blueprint source synchronization: 7260/7260 theorem-like entries formalized
- strict `leanblueprint checkdecls`
- double LuaLaTeX, with all six new cross-references resolved
- diagnostics clean; no added `sorry`, `admit`, or `axiom`
- `git diff --check`

Closes #6411
