### PR TITLE
fix(parent-hamiltonian): finish Nachtergaele policy corrections

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -72,6 +72,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
+import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleC1C3
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
+import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleC1C3
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
@@ -38,7 +39,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The sixteen components are:
+The seventeen components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
@@ -70,6 +71,8 @@ The sixteen components are:
   original-site periodic chains of length divisible by the block length;
 * `Martingale.MovingWindowCount` — reversal and counting of the finite moving-window
   sums in Nachtergaele's martingale estimate;
+* `Martingale.NachtergaeleC1C3` — the source's printed martingale-difference
+  summation with the exact C1--C3 energy coefficient and its norm-gap form;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/DifferenceProjections.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/DifferenceProjections.lean
@@ -136,11 +136,11 @@ theorem sum_martingaleDifference_eq_id (N : ℕ)
     ∑ n ∈ Finset.range (N + 1), G.martingaleDifference n = LinearMap.id := by
   rw [G.sum_martingaleDifference, hzero, hfinal, sub_zero]
 
-/-- The squared norm of a finite martingale-difference sum is the sum of the
-squared norms of its terms. -/
-theorem norm_sq_sum_martingaleDifference (N : ℕ) (v : E) :
-    ‖∑ n ∈ Finset.range N, G.martingaleDifference n v‖ ^ 2 =
-      ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 := by
+/-- The squared norm of a martingale-difference sum over any finite index set
+is the sum of the squared norms of its terms. -/
+theorem norm_sq_sum_martingaleDifference_finset (s : Finset ℕ) (v : E) :
+    ‖∑ n ∈ s, G.martingaleDifference n v‖ ^ 2 =
+      ∑ n ∈ s, ‖G.martingaleDifference n v‖ ^ 2 := by
   let V : (n : ℕ) →
       LinearMap.range (G.martingaleDifference n) →ₗᵢ[ℂ] E :=
     fun n ↦ (LinearMap.range (G.martingaleDifference n)).subtypeₗᵢ
@@ -153,7 +153,14 @@ theorem norm_sq_sum_martingaleDifference (N : ℕ) (v : E) :
     rw [← hx, ← hy]
     exact G.inner_martingaleDifference_eq_zero hmn x' y'
   simpa [V] using hV.norm_sum
-    (fun n ↦ ⟨G.martingaleDifference n v, ⟨v, rfl⟩⟩) (Finset.range N)
+    (fun n ↦ ⟨G.martingaleDifference n v, ⟨v, rfl⟩⟩) s
+
+/-- The squared norm of an initial martingale-difference sum is the sum of the
+squared norms of its terms. -/
+theorem norm_sq_sum_martingaleDifference (N : ℕ) (v : E) :
+    ‖∑ n ∈ Finset.range N, G.martingaleDifference n v‖ ^ 2 =
+      ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 :=
+  G.norm_sq_sum_martingaleDifference_finset (Finset.range N) v
 
 /-- A vector orthogonal to the final ground space is reconstructed by the
 truncated martingale-difference sum. This is `resolutionpsi` in the proof of

--- a/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
@@ -78,4 +78,70 @@ theorem movingWindow_sum_le (a : ℕ → ℝ) (l N : ℕ) (ha : ∀ m, 0 ≤ a m
           Finset.sum_le_sum_of_subset_of_nonneg hg_sub fun m _ _ ↦ ha m
     _ = (l + 1) * ∑ m ∈ Finset.range N, a m := by simp
 
+/-- For nonnegative coefficients, the same moving-window estimate holds when
+all indices in `[0, N)` are active. The truncated windows at indices below
+`l` still count each coefficient at most `l + 1` times. -/
+theorem movingWindow_sum_range_le (a : ℕ → ℝ) (l N : ℕ) (ha : ∀ m, 0 ≤ a m) :
+    ∑ n ∈ Finset.range N, ∑ m ∈ Finset.Icc (n - l) n, a m ≤
+      (l + 1) * ∑ m ∈ Finset.range N, a m := by
+  have hwindow (n : ℕ) :
+      ∑ m ∈ Finset.Icc (n - l) n, a m =
+        ∑ k ∈ (Finset.range (l + 1)).filter (fun k ↦ k ≤ n), a (n - k) := by
+    refine Finset.sum_bij (fun m _ ↦ n - m) ?_ ?_ ?_ ?_
+    · intro m hm
+      simp only [Finset.mem_filter, Finset.mem_range]
+      have hm' := Finset.mem_Icc.mp hm
+      constructor <;> omega
+    · intro m₁ hm₁ m₂ hm₂ hEq
+      have hm₁' := Finset.mem_Icc.mp hm₁
+      have hm₂' := Finset.mem_Icc.mp hm₂
+      omega
+    · intro k hk
+      simp only [Finset.mem_filter, Finset.mem_range] at hk
+      refine ⟨n - k, ?_, ?_⟩
+      · simp only [Finset.mem_Icc]
+        omega
+      · omega
+    · intro m hm
+      have hm' := Finset.mem_Icc.mp hm
+      congr 1
+      omega
+  calc
+    ∑ n ∈ Finset.range N, ∑ m ∈ Finset.Icc (n - l) n, a m =
+        ∑ n ∈ Finset.range N,
+          ∑ k ∈ (Finset.range (l + 1)).filter (fun k ↦ k ≤ n), a (n - k) := by
+            refine Finset.sum_congr rfl fun n _ ↦ hwindow n
+    _ = ∑ n ∈ Finset.range N, ∑ k ∈ Finset.range (l + 1),
+          if k ≤ n then a (n - k) else 0 := by
+            refine Finset.sum_congr rfl fun n _ ↦ ?_
+            rw [Finset.sum_filter]
+    _ = ∑ k ∈ Finset.range (l + 1), ∑ n ∈ Finset.range N,
+          if k ≤ n then a (n - k) else 0 := Finset.sum_comm
+    _ ≤ ∑ k ∈ Finset.range (l + 1), ∑ m ∈ Finset.range N, a m := by
+      refine Finset.sum_le_sum fun k _ ↦ ?_
+      rw [← Finset.sum_filter]
+      let g : ℕ → ℕ := fun n ↦ n - k
+      have hg_inj : Set.InjOn g ((Finset.range N).filter (fun n ↦ k ≤ n)) := by
+        intro n hn n' hn' hEq
+        have hkn := (Finset.mem_filter.mp hn).2
+        have hkn' := (Finset.mem_filter.mp hn').2
+        simp only [g] at hEq
+        omega
+      have hg_sub :
+          Finset.image g ((Finset.range N).filter (fun n ↦ k ≤ n)) ⊆
+            Finset.range N := by
+        intro m hm
+        rcases Finset.mem_image.mp hm with ⟨n, hn, rfl⟩
+        simp only [Finset.mem_filter, Finset.mem_range, g] at hn ⊢
+        omega
+      calc
+        ∑ n ∈ (Finset.range N).filter (fun n ↦ k ≤ n), a (n - k) =
+            ∑ m ∈ Finset.image g ((Finset.range N).filter (fun n ↦ k ≤ n)),
+              a m := by
+                symm
+                exact Finset.sum_image hg_inj
+        _ ≤ ∑ m ∈ Finset.range N, a m :=
+          Finset.sum_le_sum_of_subset_of_nonneg hg_sub fun m _ _ ↦ ha m
+    _ = (l + 1) * ∑ m ∈ Finset.range N, a m := by simp
+
 end FrustrationFree

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
@@ -28,7 +28,7 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 /-- A positive finite-dimensional operator with an energy lower bound on the
 orthogonal complement of its kernel satisfies the corresponding norm lower
-bound. The proof converts the energy estimate into `H² ≥ γ H` in an
+bound. The proof converts the energy estimate into \(H^2 \geq \gamma H\) in an
 eigenbasis, then applies `spectralGap_of_martingale_of_finiteDimensional`. -/
 theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
     [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ) {H : E →ₗ[ℂ] E}
@@ -309,7 +309,7 @@ and C3 is the source's literal operator-norm bound
 \(\frac{\gamma_{l+1}}{d_{l+1}}
   (1-\epsilon_l\sqrt{l+1})^2\).
 
-The hypothesis `projection l = id` makes explicit the padded-filtration
+The hypothesis \(G_l=\mathbf 1\) makes explicit the padded-filtration
 convention needed when the source sums only the active indices
 \(n=l,\ldots,N-1\).  The case \(\epsilon_l=0\) is treated separately, since
 the printed choice \(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive. -/
@@ -511,7 +511,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
 /-- Norm-gap form of Nachtergaele's Theorem 2.1(i). The ground-space identity
 identifies the last filtration range with the kernel of the positive
 Hamiltonian. The energy estimate above gives the exact coefficient
-`γ / d * (1 - ε * sqrt (l + 1))²`; the final conversion reuses
+\(\frac{\gamma}{d}(1-\epsilon\sqrt{l+1})^2\); the final conversion reuses
 `spectralGap_of_martingale_of_finiteDimensional` through
 `spectralGap_of_energy_lower_bound_of_finiteDimensional`. -/
 theorem norm_lower_bound_of_nachtergaele_c1_c3

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Topology.Algebra.Module.FiniteDimension
+import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AnalyticBounds
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
@@ -24,6 +25,89 @@ open scoped BigOperators InnerProductSpace
 namespace FrustrationFree
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- A positive finite-dimensional operator with an energy lower bound on the
+orthogonal complement of its kernel satisfies the corresponding norm lower
+bound. The proof converts the energy estimate into `H² ≥ γ H` in an
+eigenbasis, then applies `spectralGap_of_martingale_of_finiteDimensional`. -/
+theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
+    [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ) {H : E →ₗ[ℂ] E}
+    (hH : H.IsPositive)
+    (hEnergy : ∀ v ∈ (LinearMap.ker H)ᗮ,
+      γ * ‖v‖ ^ 2 ≤ (⟪H v, v⟫_ℂ).re) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
+  classical
+  let hSym := hH.isSymmetric
+  set n := Module.finrank ℂ E with hn_def
+  have hn : Module.finrank ℂ E = n := hn_def.symm
+  set b := hSym.eigenvectorBasis hn with hb_def
+  set μ : Fin n → ℝ := hSym.eigenvalues hn with hμ_def
+  have hHb : ∀ i, H (b i) = ((μ i : ℂ)) • b i := fun i ↦
+    hSym.apply_eigenvectorBasis hn i
+  have hbb : ∀ i j : Fin n, ⟪b i, b j⟫_ℂ = if i = j then (1 : ℂ) else 0 :=
+    orthonormal_iff_ite.mp b.orthonormal
+  have hb_norm : ∀ i, ‖b i‖ = 1 := b.orthonormal.1
+  have hb_mem (i : Fin n) (hμi : μ i ≠ 0) : b i ∈ (LinearMap.ker H)ᗮ := by
+    rw [Submodule.mem_orthogonal]
+    intro x hx
+    have hxzero : H x = 0 := LinearMap.mem_ker.mp hx
+    have hinner : ⟪x, ((μ i : ℂ)) • b i⟫_ℂ = 0 := by
+      rw [← hHb i, ← hSym x (b i), hxzero, inner_zero_left]
+    rw [inner_smul_right] at hinner
+    exact (mul_eq_zero.mp hinner).resolve_left (by simpa using hμi)
+  have hμ_gap : ∀ i, μ i = 0 ∨ γ ≤ μ i := by
+    intro i
+    by_cases hμi : μ i = 0
+    · exact Or.inl hμi
+    · right
+      have hi := hEnergy (b i) (hb_mem i hμi)
+      rw [hHb i, inner_smul_left, hbb i i, ite_eq_left rfl, mul_one,
+        Complex.conj_ofReal, Complex.ofReal_re, hb_norm i, one_pow] at hi
+      simpa using hi
+  have hOpIneq : ∀ v,
+      γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re := by
+    intro v
+    have hEnergyCoords : (⟪H v, v⟫_ℂ).re =
+        ∑ i, μ i * ‖(b.repr v) i‖ ^ 2 := by
+      calc
+        (⟪H v, v⟫_ℂ).re = (⟪b.repr (H v), b.repr v⟫_ℂ).re := by
+          rw [b.repr.inner_map_map]
+        _ = ∑ i, (⟪(b.repr (H v)) i, (b.repr v) i⟫_ℂ).re := by
+          rw [PiLp.inner_apply]
+          simp
+        _ = ∑ i, μ i * ‖(b.repr v) i‖ ^ 2 := by
+          refine Finset.sum_congr rfl fun i _ ↦ ?_
+          rw [hSym.eigenvectorBasis_apply_self_apply hn]
+          change (((b.repr v) i) *
+            (starRingEnd ℂ) ((μ i : ℂ) * (b.repr v) i)).re =
+              μ i * ‖(b.repr v) i‖ ^ 2
+          rw [map_mul, Complex.conj_ofReal]
+          rw [← mul_assoc, mul_comm ((b.repr v) i) (μ i : ℂ), mul_assoc,
+            Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero]
+          rw [← RCLike.inner_apply]
+          congr 1
+          exact inner_self_eq_norm_sq (𝕜 := ℂ) ((b.repr v) i)
+    have hNormCoords : (⟪H v, H v⟫_ℂ).re =
+        ∑ i, μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 := by
+      calc
+        (⟪H v, H v⟫_ℂ).re = ‖H v‖ ^ 2 :=
+          inner_self_eq_norm_sq (𝕜 := ℂ) (H v)
+        _ = ∑ i, μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 := by
+          rw [← b.repr.norm_map, EuclideanSpace.norm_sq_eq]
+          refine Finset.sum_congr rfl fun i _ ↦ ?_
+          rw [hSym.eigenvectorBasis_apply_self_apply hn, norm_mul, mul_pow,
+            RCLike.norm_ofReal, sq_abs]
+    rw [hEnergyCoords, hNormCoords, Finset.mul_sum]
+    refine Finset.sum_le_sum fun i _ ↦ ?_
+    rcases hμ_gap i with hμi | hμi
+    · simp [hμi]
+    · calc
+        γ * (μ i * ‖(b.repr v) i‖ ^ 2) =
+            (γ * μ i) * ‖(b.repr v) i‖ ^ 2 := by ring
+        _ ≤ μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 :=
+          mul_le_mul_of_nonneg_right
+            (by nlinarith [hH.nonneg_eigenvalues hn i]) (sq_nonneg _)
+  exact spectralGap_of_martingale_of_finiteDimensional hγ hH hOpIneq
 
 namespace NestedGroundProjections
 
@@ -423,6 +507,70 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
         mul_le_mul_of_nonneg_left hhalf (by positivity)
       _ = (⟪H v, v⟫_ℂ).re := by
         field_simp [hδ.ne', hγ.ne', hd.ne']
+
+/-- Norm-gap form of Nachtergaele's Theorem 2.1(i). The ground-space identity
+identifies the last filtration range with the kernel of the positive
+Hamiltonian. The energy estimate above gives the exact coefficient
+`γ / d * (1 - ε * sqrt (l + 1))²`; the final conversion reuses
+`spectralGap_of_martingale_of_finiteDimensional` through
+`spectralGap_of_energy_lower_bound_of_finiteDimensional`. -/
+theorem norm_lower_bound_of_nachtergaele_c1_c3
+    [FiniteDimensional ℂ E]
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (localHamiltonian : ℕ → E →ₗ[ℂ] E) (H : E →ₗ[ℂ] E)
+    (N l : ℕ) (hlN : l ≤ N)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hl : G.projection l = LinearMap.id)
+    {γ d ε : ℝ} (hγ : 0 < γ) (hd : 0 < d) (hε : 0 ≤ ε)
+    (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
+    (hQ : ∀ n ∈ Finset.Ico l N, (Q n).IsSymmetricProjection)
+    (hcomm : ∀ n ∈ Finset.Ico l N, ∀ m,
+      m < n - l ∨ n < m →
+        (G.martingaleDifference m).comp (Q n) =
+          (Q n).comp (G.martingaleDifference m))
+    (hC1 : ∀ x,
+      0 ≤ ∑ n ∈ Finset.Ico l N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re ∧
+      (∑ n ∈ Finset.Ico l N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re) ≤
+        d * (⟪H x, x⟫_ℂ).re)
+    (hC2 : ∀ n ∈ Finset.Ico l N, ∀ x,
+      γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) x‖ ^ 2 ≤
+        (⟪localHamiltonian n x, x⟫_ℂ).re)
+    (hC3 : ∀ n ∈ Finset.Ico l N,
+      ‖(Q n).toContinuousLinearMap.comp
+          (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε)
+    (hH : H.IsPositive)
+    (hground : LinearMap.range (G.projection N) = LinearMap.ker H) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ,
+      (γ / d) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ≤
+        ‖H v‖ := by
+  let gap := (γ / d) *
+    (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2
+  have hs : 0 < Real.sqrt ((l + 1 : ℕ) : ℝ) :=
+    Real.sqrt_pos.2 (by positivity)
+  have hεs : ε * Real.sqrt ((l + 1 : ℕ) : ℝ) < 1 :=
+    (lt_div_iff₀ hs).mp hεlt
+  have hgap : 0 < gap := by
+    dsimp only [gap]
+    positivity
+  apply spectralGap_of_energy_lower_bound_of_finiteDimensional hgap hH
+  intro v hv
+  change (γ / d) *
+      (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ^ 2 ≤
+    (⟪H v, v⟫_ℂ).re
+  apply energy_lower_bound_of_nachtergaele_c1_c3 G Q localHamiltonian H
+    N l hlN v hzero hl
+  · rwa [hground]
+  · exact hγ
+  · exact hd
+  · exact hε
+  · exact hεlt
+  · exact hQ
+  · exact hcomm
+  · exact hC1
+  · exact hC2
+  · exact hC3
 
 end NestedGroundProjections
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
@@ -13,11 +13,11 @@ import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 # Nachtergaele's C1--C3 energy estimate
 
 This file follows the proof of Theorem 2.1(i) in Nachtergaele,
-arXiv:cond-mat/9410110, lines 1195--1259.  The filtration is indexed so that
-the active martingale differences are (E_l,\ldots,E_{N-1}); accordingly the
-source convention that the preceding volumes are empty is stated explicitly as
-(G_l=\mathbf 1).  This prevents the early martingale differences from being
-discarded implicitly when the C1 sum starts at (l).
+arXiv:cond-mat/9410110, lines 1195--1259. The finite-filtration statement sums
+all martingale differences (E_0,\ldots,E_{N-1}) and assumes C1--C3 on that
+full range. This avoids imposing any unsupported padding convention at the
+lower endpoint; a later physical specialization may verify the early indices
+separately.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -26,19 +26,30 @@ namespace FrustrationFree
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
-/-- A positive finite-dimensional operator with an energy lower bound on the
-orthogonal complement of its kernel satisfies the corresponding norm lower
-bound. Orthogonally removing the kernel component converts the energy estimate
-into \(H^2 \geq \gamma H\) by Cauchy--Schwarz; the final norm bound then follows
-from `spectralGap_of_martingale_of_finiteDimensional`. -/
-theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
+/-- An energy lower bound on a subspace implies the corresponding norm
+lower bound there. This is the direct Cauchy--Schwarz conversion and requires
+neither finite dimensionality nor positivity of the operator. -/
+theorem norm_lower_bound_of_energy_lower_bound
+    {γ : ℝ} {H : E →ₗ[ℂ] E}
+    (hEnergy : ∀ v ∈ (LinearMap.ker H)ᗮ,
+      γ * ‖v‖ ^ 2 ≤ (⟪H v, v⟫_ℂ).re) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
+  intro v hv
+  have henergy := hEnergy v hv
+  have hcauchy : (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ * ‖v‖ :=
+    re_inner_le_norm (𝕜 := ℂ) (H v) v
+  by_cases hvzero : ‖v‖ = 0
+  · simp [hvzero]
+  · have hvpos : 0 < ‖v‖ := lt_of_le_of_ne (norm_nonneg v) (Ne.symm hvzero)
+    nlinarith
+
+private theorem operator_inequality_of_energy_lower_bound
     [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ) {H : E →ₗ[ℂ] E}
     (hH : H.IsPositive)
     (hEnergy : ∀ v ∈ (LinearMap.ker H)ᗮ,
       γ * ‖v‖ ^ 2 ≤ (⟪H v, v⟫_ℂ).re) :
-    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
+    ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re := by
   classical
-  apply spectralGap_of_martingale_of_finiteDimensional hγ hH
   intro v
   let p := (LinearMap.ker H).starProjection v
   let w := v - p
@@ -60,27 +71,23 @@ theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
       _ = (⟪H v, w⟫_ℂ + ⟪H v, p⟫_ℂ).re := by rw [inner_add_right]
       _ = (⟪H v, w⟫_ℂ).re := by rw [hcross, add_zero]
       _ = (⟪H w, w⟫_ℂ).re := by rw [hHw]
-  have henergy := hEnergy w hw
+  have hgapnorm := norm_lower_bound_of_energy_lower_bound hEnergy w hw
+  rw [hHw] at hgapnorm
   have hcauchy : (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ * ‖w‖ := by
     rw [hform]
     calc
       (⟪H w, w⟫_ℂ).re ≤ ‖H w‖ * ‖w‖ :=
         re_inner_le_norm (𝕜 := ℂ) (H w) w
       _ = ‖H v‖ * ‖w‖ := by rw [hHw]
-  rw [← hform] at henergy
-  by_cases hwzero : ‖w‖ = 0
-  · have hw' : w = 0 := norm_eq_zero.mp hwzero
-    rw [hform, hw', map_zero, inner_zero_left, Complex.zero_re, mul_zero]
-    exact inner_self_nonneg (𝕜 := ℂ) (x := H v)
-  · have hwpos : 0 < ‖w‖ := lt_of_le_of_ne (norm_nonneg w) (Ne.symm hwzero)
-    have hgapnorm : γ * ‖w‖ ≤ ‖H v‖ := by
-      nlinarith
-    have hquad : γ * (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ ^ 2 := by
-      nlinarith [norm_nonneg (H v)]
-    calc
-      γ * (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ ^ 2 := hquad
-      _ = (⟪H v, H v⟫_ℂ).re :=
-        (inner_self_eq_norm_sq (𝕜 := ℂ) (H v)).symm
+  calc
+    γ * (⟪H v, v⟫_ℂ).re ≤ γ * (‖H v‖ * ‖w‖) :=
+      mul_le_mul_of_nonneg_left hcauchy hγ.le
+    _ = (γ * ‖w‖) * ‖H v‖ := by ring
+    _ ≤ ‖H v‖ * ‖H v‖ :=
+      mul_le_mul_of_nonneg_right hgapnorm (norm_nonneg (H v))
+    _ = ‖H v‖ ^ 2 := by ring
+    _ = (⟪H v, H v⟫_ℂ).re :=
+      (inner_self_eq_norm_sq (𝕜 := ℂ) (H v)).symm
 
 namespace NestedGroundProjections
 
@@ -282,71 +289,50 @@ and C3 is the source's literal operator-norm bound
 \(\frac{\gamma_{l+1}}{d_{l+1}}
   (1-\epsilon_l\sqrt{l+1})^2\).
 
-The hypothesis \(G_l=\mathbf 1\) makes explicit the padded-filtration
-convention needed when the source sums only the active indices
-\(n=l,\ldots,N-1\).  The case \(\epsilon_l=0\) is treated separately, since
-the printed choice \(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive. -/
+The finite sum runs over every index \(n=0,\ldots,N-1\), with only
+\(G_0=\mathbf 1\) needed for the martingale resolution. Thus C1, C2, and C3
+are assumed on that full finite range. The case \(\epsilon_l=0\) is treated
+separately, since the printed choice \(c_2=\epsilon_l/\sqrt{l+1}\) is then not
+positive. -/
 theorem energy_lower_bound_of_nachtergaele_c1_c3
     [FiniteDimensional ℂ E]
     (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
     (localHamiltonian : ℕ → E →ₗ[ℂ] E) (H : E →ₗ[ℂ] E)
-    (N l : ℕ) (hlN : l ≤ N) (v : E)
+    (N l : ℕ) (v : E)
     (hzero : G.projection 0 = LinearMap.id)
-    (hl : G.projection l = LinearMap.id)
     (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
     {γ d ε : ℝ} (hγ : 0 < γ) (hd : 0 < d) (hε : 0 ≤ ε)
     (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
-    (hQ : ∀ n ∈ Finset.Ico l N, (Q n).IsSymmetricProjection)
-    (hcomm : ∀ n ∈ Finset.Ico l N, ∀ m,
+    (hQ : ∀ n ∈ Finset.range N, (Q n).IsSymmetricProjection)
+    (hcomm : ∀ n ∈ Finset.range N, ∀ m,
       m < n - l ∨ n < m →
         (G.martingaleDifference m).comp (Q n) =
           (Q n).comp (G.martingaleDifference m))
     (hC1 : ∀ x,
-      0 ≤ ∑ n ∈ Finset.Ico l N,
+      0 ≤ ∑ n ∈ Finset.range N,
           (⟪localHamiltonian n x, x⟫_ℂ).re ∧
-      (∑ n ∈ Finset.Ico l N,
+      (∑ n ∈ Finset.range N,
           (⟪localHamiltonian n x, x⟫_ℂ).re) ≤
         d * (⟪H x, x⟫_ℂ).re)
-    (hC2 : ∀ n ∈ Finset.Ico l N, ∀ x,
+    (hC2 : ∀ n ∈ Finset.range N, ∀ x,
       γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) x‖ ^ 2 ≤
         (⟪localHamiltonian n x, x⟫_ℂ).re)
-    (hC3 : ∀ n ∈ Finset.Ico l N,
+    (hC3 : ∀ n ∈ Finset.range N,
       ‖(Q n).toContinuousLinearMap.comp
           (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε) :
     (γ / d) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ^ 2 ≤
       (⟪H v, v⟫_ℂ).re := by
-  have hvKer : v ∈ LinearMap.ker (G.projection N) := by
-    rw [(G.isSymmetricProjection N).isSymmetric.orthogonal_range] at hv
-    exact hv
-  have hGNv : G.projection N v = 0 := LinearMap.mem_ker.mp hvKer
-  have hsumMap :
-      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n =
-        G.projection l - G.projection N := by
-    rw [Finset.sum_Ico_eq_sub _ hlN, G.sum_martingaleDifference,
-      G.sum_martingaleDifference]
-    abel
-  have hactiveApply :
-      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n v = v := by
-    calc
-      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n v =
-          (∑ n ∈ Finset.Ico l N, G.martingaleDifference n) v := by simp
-      _ = (G.projection l - G.projection N) v := by rw [hsumMap]
-      _ = v := by simp [hl, hGNv]
   have hactiveNorm :
-      ∑ n ∈ Finset.Ico l N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
-    rw [← G.norm_sq_sum_martingaleDifference_finset (Finset.Ico l N) v,
-      hactiveApply]
-  have hfullNorm :
       ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
     rw [← G.norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal N v hzero hv]
   have hwindow :
-      ∑ n ∈ Finset.Ico l N,
+      ∑ n ∈ Finset.range N,
           ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 ≤
         (l + 1) * ‖v‖ ^ 2 := by
     calc
-      ∑ n ∈ Finset.Ico l N,
+      ∑ n ∈ Finset.range N,
           ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 =
-          ∑ n ∈ Finset.Ico l N, ∑ m ∈ Finset.Icc (n - l) n,
+          ∑ n ∈ Finset.range N, ∑ m ∈ Finset.Icc (n - l) n,
             ‖G.martingaleDifference m v‖ ^ 2 := by
               apply Finset.sum_congr rfl
               intro n _
@@ -354,10 +340,10 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
                 (Finset.Icc (n - l) n) v
       _ ≤ (l + 1) *
           ∑ m ∈ Finset.range N, ‖G.martingaleDifference m v‖ ^ 2 :=
-        movingWindow_sum_le
+        movingWindow_sum_range_le
           (fun m ↦ ‖G.martingaleDifference m v‖ ^ 2) l N
           (fun m ↦ sq_nonneg ‖G.martingaleDifference m v‖)
-      _ = (l + 1) * ‖v‖ ^ 2 := by rw [hfullNorm]
+      _ = (l + 1) * ‖v‖ ^ 2 := by rw [hactiveNorm]
   let s := Real.sqrt ((l + 1 : ℕ) : ℝ)
   have hs : 0 < s := Real.sqrt_pos.2 (by positivity)
   have hsquare : s ^ 2 = ((l + 1 : ℕ) : ℝ) := by
@@ -366,7 +352,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
     rw [lt_div_iff₀ hs] at hεlt
     exact hεlt
   have hδ : 0 < 1 - ε * s := sub_pos.mpr hεs
-  have hC3point : ∀ n ∈ Finset.Ico l N, ∀ x,
+  have hC3point : ∀ n ∈ Finset.range N, ∀ x,
       ‖Q n (G.martingaleDifference n x)‖ ^ 2 ≤
         ε ^ 2 * ‖G.martingaleDifference n x‖ ^ 2 := by
     intro n hn x
@@ -376,7 +362,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
       (G.martingaleDifference_isSymmetricProjection n) (hC3 n hn) x
   rcases hε.eq_or_lt with hεzero | hεpos
   · subst ε
-    have hpoint : ∀ n ∈ Finset.Ico l N,
+    have hpoint : ∀ n ∈ Finset.range N,
         ‖G.martingaleDifference n v‖ ^ 2 ≤
           (1 / (2 * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
             (1 / 2) * ‖G.martingaleDifference n v‖ ^ 2 := by
@@ -389,18 +375,18 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
         rw [← norm_eq_zero]
         nlinarith [sq_nonneg ‖Q n (G.martingaleDifference n v)‖]
       simpa using enpsi_of_c2_c3_zero G Q localHamiltonian N n l
-        (Finset.mem_Ico.mp hn).2 v
+        (Finset.mem_range.mp hn) v
         hzero hv (hQ n hn) (hcomm n hn) hγ (by norm_num : (0 : ℝ) < 1)
         (hC2 n hn v) hqzero
     have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
     have hsumPoint' : ‖v‖ ^ 2 ≤
         (1 / (2 * γ)) *
-            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
+            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
           (1 / 2) * ‖v‖ ^ 2 := by
       simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
     have henergy :
         (1 / (2 * γ)) *
-            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
           (1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
       mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
     have hhalf : (1 / 2 : ℝ) * ‖v‖ ^ 2 ≤
@@ -425,7 +411,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
       dsimp only [c₂]
       rw [← hsquare]
       field_simp [hs.ne']
-    have hpoint : ∀ n ∈ Finset.Ico l N,
+    have hpoint : ∀ n ∈ Finset.range N,
         ‖G.martingaleDifference n v‖ ^ 2 ≤
           (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
           (c₁ / 2 + ε * s / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
@@ -435,26 +421,26 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
       intro n hn
       simpa only [hεc₂] using
         enpsi2_of_c2_c3 G Q localHamiltonian N n l
-          (Finset.mem_Ico.mp hn).2 v hzero hv
+          (Finset.mem_range.mp hn) v hzero hv
           (hQ n hn) (hcomm n hn) hγ hc₁ hc₂ (hC2 n hn v) (hC3point n hn v)
     have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
     have hsumPoint' : ‖v‖ ^ 2 ≤
         (1 / (2 * c₁ * γ)) *
-            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
+            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
         (c₁ / 2 + ε * s / 2) * ‖v‖ ^ 2 +
         (c₂ / 2) *
-          (∑ n ∈ Finset.Ico l N,
+          (∑ n ∈ Finset.range N,
             ‖∑ m ∈ Finset.Icc (n - l) n,
               G.martingaleDifference m v‖ ^ 2) := by
       simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
     have henergy :
         (1 / (2 * c₁ * γ)) *
-            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
           (1 / (2 * c₁ * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
       mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
     have hwindow' :
         (c₂ / 2) *
-            (∑ n ∈ Finset.Ico l N,
+            (∑ n ∈ Finset.range N,
               ‖∑ m ∈ Finset.Icc (n - l) n,
                 G.martingaleDifference m v‖ ^ 2) ≤
           (ε * s / 2) * ‖v‖ ^ 2 := by
@@ -483,34 +469,32 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3
 
 /-- Norm-gap form of Nachtergaele's Theorem 2.1(i). The ground-space identity
 identifies the last filtration range with the kernel of the positive
-Hamiltonian. The energy estimate above gives the exact coefficient
-\(\frac{\gamma}{d}(1-\epsilon\sqrt{l+1})^2\); the final conversion reuses
-`spectralGap_of_martingale_of_finiteDimensional` through
-`spectralGap_of_energy_lower_bound_of_finiteDimensional`. -/
+Hamiltonian. The energy estimate and Cauchy--Schwarz supply the global
+quadratic-form hypothesis used by
+`spectralGap_of_martingale_of_finiteDimensional`. -/
 theorem norm_lower_bound_of_nachtergaele_c1_c3
     [FiniteDimensional ℂ E]
     (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
     (localHamiltonian : ℕ → E →ₗ[ℂ] E) (H : E →ₗ[ℂ] E)
-    (N l : ℕ) (hlN : l ≤ N)
+    (N l : ℕ)
     (hzero : G.projection 0 = LinearMap.id)
-    (hl : G.projection l = LinearMap.id)
     {γ d ε : ℝ} (hγ : 0 < γ) (hd : 0 < d) (hε : 0 ≤ ε)
     (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
-    (hQ : ∀ n ∈ Finset.Ico l N, (Q n).IsSymmetricProjection)
-    (hcomm : ∀ n ∈ Finset.Ico l N, ∀ m,
+    (hQ : ∀ n ∈ Finset.range N, (Q n).IsSymmetricProjection)
+    (hcomm : ∀ n ∈ Finset.range N, ∀ m,
       m < n - l ∨ n < m →
         (G.martingaleDifference m).comp (Q n) =
           (Q n).comp (G.martingaleDifference m))
     (hC1 : ∀ x,
-      0 ≤ ∑ n ∈ Finset.Ico l N,
+      0 ≤ ∑ n ∈ Finset.range N,
           (⟪localHamiltonian n x, x⟫_ℂ).re ∧
-      (∑ n ∈ Finset.Ico l N,
+      (∑ n ∈ Finset.range N,
           (⟪localHamiltonian n x, x⟫_ℂ).re) ≤
         d * (⟪H x, x⟫_ℂ).re)
-    (hC2 : ∀ n ∈ Finset.Ico l N, ∀ x,
+    (hC2 : ∀ n ∈ Finset.range N, ∀ x,
       γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) x‖ ^ 2 ≤
         (⟪localHamiltonian n x, x⟫_ℂ).re)
-    (hC3 : ∀ n ∈ Finset.Ico l N,
+    (hC3 : ∀ n ∈ Finset.range N,
       ‖(Q n).toContinuousLinearMap.comp
           (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε)
     (hH : H.IsPositive)
@@ -527,13 +511,11 @@ theorem norm_lower_bound_of_nachtergaele_c1_c3
   have hgap : 0 < gap := by
     dsimp only [gap]
     positivity
-  apply spectralGap_of_energy_lower_bound_of_finiteDimensional hgap hH
+  apply spectralGap_of_martingale_of_finiteDimensional hgap hH
+  apply operator_inequality_of_energy_lower_bound hgap hH
   intro v hv
-  change (γ / d) *
-      (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ^ 2 ≤
-    (⟪H v, v⟫_ℂ).re
   apply energy_lower_bound_of_nachtergaele_c1_c3 G Q localHamiltonian H
-    N l hlN v hzero hl
+    N l v hzero
   · rwa [hground]
   · exact hγ
   · exact hd

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
@@ -1,0 +1,429 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Topology.Algebra.Module.FiniteDimension
+import TNLean.MPS.ParentHamiltonian.Martingale.AnalyticBounds
+import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
+import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
+
+/-!
+# Nachtergaele's C1--C3 energy estimate
+
+This file follows the proof of Theorem 2.1(i) in Nachtergaele,
+arXiv:cond-mat/9410110, lines 1195--1259.  The filtration is indexed so that
+the active martingale differences are (E_l,\ldots,E_{N-1}); accordingly the
+source convention that the preceding volumes are empty is stated explicitly as
+(G_l=\mathbf 1).  This prevents the early martingale differences from being
+discarded implicitly when the C1 sum starts at (l).
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace FrustrationFree
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+namespace NestedGroundProjections
+
+private theorem enpsi_identity
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    (hQ : (Q n).IsSymmetricProjection)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp (Q n) =
+        (Q n).comp (G.martingaleDifference m)) :
+    ‖G.martingaleDifference n v‖ ^ 2 =
+      (⟪((LinearMap.id : E →ₗ[ℂ] E) - Q n) v,
+        G.martingaleDifference n v⟫_ℂ).re +
+      (⟪∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v,
+        Q n (G.martingaleDifference n v)⟫_ℂ).re := by
+  let En := G.martingaleDifference n
+  let T := (LinearMap.id : E →ₗ[ℂ] E) - Q n
+  let q := Q n (En v)
+  let w := ∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v
+  have hEn : En.IsSymmetricProjection :=
+    G.martingaleDifference_isSymmetricProjection n
+  have hT : T.IsSymmetric := LinearMap.IsSymmetric.id.sub hQ.isSymmetric
+  have hEnEn : En (En v) = En v := by
+    have h := congrArg (fun S : E →ₗ[ℂ] E ↦ S v) hEn.isIdempotentElem.eq
+    simpa [Module.End.mul_apply] using h
+  have hself : (⟪v, En v⟫_ℂ).re = ‖En v‖ ^ 2 := by
+    calc
+      (⟪v, En v⟫_ℂ).re = (⟪v, En (En v)⟫_ℂ).re := by rw [hEnEn]
+      _ = (⟪En v, En v⟫_ℂ).re := by rw [← hEn.isSymmetric v (En v)]
+      _ = ‖En v‖ ^ 2 := inner_self_eq_norm_sq (𝕜 := ℂ) (En v)
+  have hcross : ⟪v, q⟫_ℂ = ⟪w, q⟫_ℂ := by
+    have hresolve :=
+      G.sum_martingaleDifference_apply_of_mem_orthogonal N v hzero hv
+    have hcancel :=
+      G.inner_sum_martingaleDifference_localProjection_eq_inner_sum_Icc
+        (Q n) N n l hn hcomm v
+    calc
+      ⟪v, q⟫_ℂ =
+          ⟪∑ m ∈ Finset.range N, G.martingaleDifference m v, q⟫_ℂ := by
+            rw [hresolve]
+      _ = ⟪v, ∑ m ∈ Finset.range N,
+          G.martingaleDifference m q⟫_ℂ := by
+            simp_rw [sum_inner, inner_sum]
+            apply Finset.sum_congr rfl
+            intro m _
+            exact (G.martingaleDifference_isSymmetricProjection m).isSymmetric v q
+      _ = ⟪w, q⟫_ℂ := hcancel
+  have hsplit : (⟪v, En v⟫_ℂ).re =
+      (⟪T v, En v⟫_ℂ).re + (⟪w, q⟫_ℂ).re := by
+    have hsplitComplex : ⟪v, En v⟫_ℂ = ⟪T v, En v⟫_ℂ + ⟪w, q⟫_ℂ := by
+      calc
+        ⟪v, En v⟫_ℂ = ⟪v, T (En v) + q⟫_ℂ := by
+          simp [T, q, En]
+        _ = ⟪v, T (En v)⟫_ℂ + ⟪v, q⟫_ℂ := inner_add_right _ _ _
+        _ = ⟪T v, En v⟫_ℂ + ⟪w, q⟫_ℂ := by
+          rw [← hT v (En v), hcross]
+    simpa using congrArg Complex.re hsplitComplex
+  dsimp only [En, T, q, w] at hself hsplit ⊢
+  exact hself ▸ hsplit
+
+private theorem enpsi2
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    (hQ : (Q n).IsSymmetricProjection)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp (Q n) =
+        (Q n).comp (G.martingaleDifference m))
+    {c₁ c₂ : ℝ} (hc₁ : 0 < c₁) (hc₂ : 0 < c₂) :
+    ‖G.martingaleDifference n v‖ ^ 2 ≤
+      (1 / (2 * c₁)) * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 +
+        (c₁ / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
+      (1 / (2 * c₂)) * ‖Q n (G.martingaleDifference n v)‖ ^ 2 +
+        (c₂ / 2) *
+          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 := by
+  have hid := enpsi_identity G Q N n l hn v hzero hv hQ hcomm
+  have hfirst := re_inner_le_weighted_norm_sq
+    (((LinearMap.id : E →ₗ[ℂ] E) - Q n) v)
+    (G.martingaleDifference n v) hc₁
+  have hsecond := re_inner_le_weighted_norm_sq
+    (Q n (G.martingaleDifference n v))
+    (∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v) hc₂
+  have hre :
+      (⟪Q n (G.martingaleDifference n v),
+        ∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v⟫_ℂ).re =
+      (⟪∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v,
+        Q n (G.martingaleDifference n v)⟫_ℂ).re :=
+    inner_re_symm (𝕜 := ℂ) _ _
+  rw [hre] at hsecond
+  linarith
+
+private theorem enpsi2_of_c2_c3
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (localHamiltonian : ℕ → E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    (hQ : (Q n).IsSymmetricProjection)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp (Q n) =
+        (Q n).comp (G.martingaleDifference m))
+    {γ ε c₁ c₂ : ℝ} (hγ : 0 < γ) (hc₁ : 0 < c₁) (hc₂ : 0 < c₂)
+    (hC2 : γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 ≤
+      (⟪localHamiltonian n v, v⟫_ℂ).re)
+    (hC3 : ‖Q n (G.martingaleDifference n v)‖ ^ 2 ≤
+      ε ^ 2 * ‖G.martingaleDifference n v‖ ^ 2) :
+    ‖G.martingaleDifference n v‖ ^ 2 ≤
+      (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+      (c₁ / 2 + ε ^ 2 / (2 * c₂)) *
+        ‖G.martingaleDifference n v‖ ^ 2 +
+      (c₂ / 2) *
+        ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 := by
+  have hbase := enpsi2 G Q N n l hn v hzero hv hQ hcomm hc₁ hc₂
+  have hC2' :
+      (1 / (2 * c₁)) *
+          ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 ≤
+        (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re := by
+    calc
+      (1 / (2 * c₁)) *
+          ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 =
+          (1 / (2 * c₁ * γ)) *
+            (γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2) := by
+              field_simp [hc₁.ne', hγ.ne']
+      _ ≤ (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re :=
+        mul_le_mul_of_nonneg_left hC2 (by positivity)
+  have hC3' :
+      (1 / (2 * c₂)) * ‖Q n (G.martingaleDifference n v)‖ ^ 2 ≤
+        (1 / (2 * c₂)) *
+          (ε ^ 2 * ‖G.martingaleDifference n v‖ ^ 2) :=
+    mul_le_mul_of_nonneg_left hC3 (by positivity)
+  calc
+    ‖G.martingaleDifference n v‖ ^ 2 ≤
+        (1 / (2 * c₁)) *
+            ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 +
+          (c₁ / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
+        (1 / (2 * c₂)) * ‖Q n (G.martingaleDifference n v)‖ ^ 2 +
+          (c₂ / 2) *
+            ‖∑ m ∈ Finset.Icc (n - l) n,
+              G.martingaleDifference m v‖ ^ 2 := hbase
+    _ ≤ (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+        (c₁ / 2 + ε ^ 2 / (2 * c₂)) *
+          ‖G.martingaleDifference n v‖ ^ 2 +
+        (c₂ / 2) *
+          ‖∑ m ∈ Finset.Icc (n - l) n,
+            G.martingaleDifference m v‖ ^ 2 := by
+      calc
+        _ ≤ (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+            (c₁ / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
+          (1 / (2 * c₂)) *
+            (ε ^ 2 * ‖G.martingaleDifference n v‖ ^ 2) +
+            (c₂ / 2) *
+              ‖∑ m ∈ Finset.Icc (n - l) n,
+                G.martingaleDifference m v‖ ^ 2 := by linarith
+        _ = _ := by ring
+
+private theorem enpsi_of_c2_c3_zero
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (localHamiltonian : ℕ → E →ₗ[ℂ] E)
+    (N n l : ℕ) (hn : n < N) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    (hQ : (Q n).IsSymmetricProjection)
+    (hcomm : ∀ m, m < n - l ∨ n < m →
+      (G.martingaleDifference m).comp (Q n) =
+        (Q n).comp (G.martingaleDifference m))
+    {γ c₁ : ℝ} (hγ : 0 < γ) (hc₁ : 0 < c₁)
+    (hC2 : γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 ≤
+      (⟪localHamiltonian n v, v⟫_ℂ).re)
+    (hqzero : Q n (G.martingaleDifference n v) = 0) :
+    ‖G.martingaleDifference n v‖ ^ 2 ≤
+      (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+      (c₁ / 2) * ‖G.martingaleDifference n v‖ ^ 2 := by
+  have hid := enpsi_identity G Q N n l hn v hzero hv hQ hcomm
+  rw [hqzero, inner_zero_right, Complex.zero_re, add_zero] at hid
+  have hfirst := re_inner_le_weighted_norm_sq
+    (((LinearMap.id : E →ₗ[ℂ] E) - Q n) v)
+    (G.martingaleDifference n v) hc₁
+  have hC2' :
+      (1 / (2 * c₁)) *
+          ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 ≤
+        (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re := by
+    calc
+      (1 / (2 * c₁)) *
+          ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2 =
+          (1 / (2 * c₁ * γ)) *
+            (γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) v‖ ^ 2) := by
+              field_simp [hc₁.ne', hγ.ne']
+      _ ≤ (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re :=
+        mul_le_mul_of_nonneg_left hC2 (by positivity)
+  linarith
+
+/-- Nachtergaele's Theorem 2.1(i), in the finite-filtration notation of its
+proof.  Conditions C1 and C2 are stated as their quadratic-form inequalities,
+and C3 is the source's literal operator-norm bound
+\(\lVert Q_nE_n\rVert\leq\epsilon_l\).  The coefficient is exactly
+\(\frac{\gamma_{l+1}}{d_{l+1}}
+  (1-\epsilon_l\sqrt{l+1})^2\).
+
+The hypothesis `projection l = id` makes explicit the padded-filtration
+convention needed when the source sums only the active indices
+\(n=l,\ldots,N-1\).  The case \(\epsilon_l=0\) is treated separately, since
+the printed choice \(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive. -/
+theorem energy_lower_bound_of_nachtergaele_c1_c3
+    [FiniteDimensional ℂ E]
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (localHamiltonian : ℕ → E →ₗ[ℂ] E) (H : E →ₗ[ℂ] E)
+    (N l : ℕ) (hlN : l ≤ N) (v : E)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hl : G.projection l = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    {γ d ε : ℝ} (hγ : 0 < γ) (hd : 0 < d) (hε : 0 ≤ ε)
+    (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
+    (hQ : ∀ n ∈ Finset.Ico l N, (Q n).IsSymmetricProjection)
+    (hcomm : ∀ n ∈ Finset.Ico l N, ∀ m,
+      m < n - l ∨ n < m →
+        (G.martingaleDifference m).comp (Q n) =
+          (Q n).comp (G.martingaleDifference m))
+    (hC1 : ∀ x,
+      0 ≤ ∑ n ∈ Finset.Ico l N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re ∧
+      (∑ n ∈ Finset.Ico l N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re) ≤
+        d * (⟪H x, x⟫_ℂ).re)
+    (hC2 : ∀ n ∈ Finset.Ico l N, ∀ x,
+      γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) x‖ ^ 2 ≤
+        (⟪localHamiltonian n x, x⟫_ℂ).re)
+    (hC3 : ∀ n ∈ Finset.Ico l N,
+      ‖(Q n).toContinuousLinearMap.comp
+          (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε) :
+    (γ / d) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ^ 2 ≤
+      (⟪H v, v⟫_ℂ).re := by
+  have hvKer : v ∈ LinearMap.ker (G.projection N) := by
+    rw [(G.isSymmetricProjection N).isSymmetric.orthogonal_range] at hv
+    exact hv
+  have hGNv : G.projection N v = 0 := LinearMap.mem_ker.mp hvKer
+  have hsumMap :
+      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n =
+        G.projection l - G.projection N := by
+    rw [Finset.sum_Ico_eq_sub _ hlN, G.sum_martingaleDifference,
+      G.sum_martingaleDifference]
+    abel
+  have hactiveApply :
+      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n v = v := by
+    calc
+      ∑ n ∈ Finset.Ico l N, G.martingaleDifference n v =
+          (∑ n ∈ Finset.Ico l N, G.martingaleDifference n) v := by simp
+      _ = (G.projection l - G.projection N) v := by rw [hsumMap]
+      _ = v := by simp [hl, hGNv]
+  have hactiveNorm :
+      ∑ n ∈ Finset.Ico l N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
+    rw [← G.norm_sq_sum_martingaleDifference_finset (Finset.Ico l N) v,
+      hactiveApply]
+  have hfullNorm :
+      ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
+    rw [← G.norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal N v hzero hv]
+  have hwindow :
+      ∑ n ∈ Finset.Ico l N,
+          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 ≤
+        (l + 1) * ‖v‖ ^ 2 := by
+    calc
+      ∑ n ∈ Finset.Ico l N,
+          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 =
+          ∑ n ∈ Finset.Ico l N, ∑ m ∈ Finset.Icc (n - l) n,
+            ‖G.martingaleDifference m v‖ ^ 2 := by
+              apply Finset.sum_congr rfl
+              intro n _
+              exact G.norm_sq_sum_martingaleDifference_finset
+                (Finset.Icc (n - l) n) v
+      _ ≤ (l + 1) *
+          ∑ m ∈ Finset.range N, ‖G.martingaleDifference m v‖ ^ 2 :=
+        movingWindow_sum_le
+          (fun m ↦ ‖G.martingaleDifference m v‖ ^ 2) l N
+          (fun m ↦ sq_nonneg ‖G.martingaleDifference m v‖)
+      _ = (l + 1) * ‖v‖ ^ 2 := by rw [hfullNorm]
+  let s := Real.sqrt ((l + 1 : ℕ) : ℝ)
+  have hs : 0 < s := Real.sqrt_pos.2 (by positivity)
+  have hsquare : s ^ 2 = ((l + 1 : ℕ) : ℝ) := by
+    exact Real.sq_sqrt (by positivity)
+  have hεs : ε * s < 1 := by
+    rw [lt_div_iff₀ hs] at hεlt
+    exact hεlt
+  have hδ : 0 < 1 - ε * s := sub_pos.mpr hεs
+  have hC3point : ∀ n ∈ Finset.Ico l N, ∀ x,
+      ‖Q n (G.martingaleDifference n x)‖ ^ 2 ≤
+        ε ^ 2 * ‖G.martingaleDifference n x‖ ^ 2 := by
+    intro n hn x
+    simpa using norm_sq_apply_projection_le_of_norm_comp_le
+      (Q n).toContinuousLinearMap
+      (G.martingaleDifference n).toContinuousLinearMap
+      (G.martingaleDifference_isSymmetricProjection n) (hC3 n hn) x
+  rcases hε.eq_or_lt with hεzero | hεpos
+  · subst ε
+    have hpoint : ∀ n ∈ Finset.Ico l N,
+        ‖G.martingaleDifference n v‖ ^ 2 ≤
+          (1 / (2 * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+            (1 / 2) * ‖G.martingaleDifference n v‖ ^ 2 := by
+      intro n hn
+      have hbound : ‖Q n (G.martingaleDifference n v)‖ ^ 2 ≤ 0 := by
+        simpa using hC3point n hn v
+      have hqnorm : ‖Q n (G.martingaleDifference n v)‖ ^ 2 = 0 :=
+        le_antisymm hbound (sq_nonneg _)
+      have hqzero : Q n (G.martingaleDifference n v) = 0 := by
+        rw [← norm_eq_zero]
+        nlinarith [sq_nonneg ‖Q n (G.martingaleDifference n v)‖]
+      simpa using enpsi_of_c2_c3_zero G Q localHamiltonian N n l
+        (Finset.mem_Ico.mp hn).2 v
+        hzero hv (hQ n hn) (hcomm n hn) hγ (by norm_num : (0 : ℝ) < 1)
+        (hC2 n hn v) hqzero
+    have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
+    have hsumPoint' : ‖v‖ ^ 2 ≤
+        (1 / (2 * γ)) *
+            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
+          (1 / 2) * ‖v‖ ^ 2 := by
+      simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
+    have henergy :
+        (1 / (2 * γ)) *
+            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+          (1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
+      mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
+    have hhalf : (1 / 2 : ℝ) * ‖v‖ ^ 2 ≤
+        (1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re) := by
+      linarith
+    calc
+      (γ / d) * (1 - 0 * s) ^ 2 * ‖v‖ ^ 2 =
+          (2 * γ / d) * ((1 / 2 : ℝ) * ‖v‖ ^ 2) := by ring
+      _ ≤ (2 * γ / d) *
+          ((1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re)) :=
+        mul_le_mul_of_nonneg_left hhalf (by positivity)
+      _ = (⟪H v, v⟫_ℂ).re := by
+        field_simp [hγ.ne', hd.ne']
+  · let c₁ := 1 - ε * s
+    let c₂ := ε / s
+    have hc₁ : 0 < c₁ := hδ
+    have hc₂ : 0 < c₂ := div_pos hεpos hs
+    have hεc₂ : ε ^ 2 / (2 * c₂) = ε * s / 2 := by
+      dsimp only [c₂]
+      field_simp [hεpos.ne', hs.ne']
+    have hc₂window : (c₂ / 2) * ((l + 1 : ℕ) : ℝ) = ε * s / 2 := by
+      dsimp only [c₂]
+      rw [← hsquare]
+      field_simp [hs.ne']
+    have hpoint : ∀ n ∈ Finset.Ico l N,
+        ‖G.martingaleDifference n v‖ ^ 2 ≤
+          (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+          (c₁ / 2 + ε * s / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
+          (c₂ / 2) *
+            ‖∑ m ∈ Finset.Icc (n - l) n,
+              G.martingaleDifference m v‖ ^ 2 := by
+      intro n hn
+      simpa only [hεc₂] using
+        enpsi2_of_c2_c3 G Q localHamiltonian N n l
+          (Finset.mem_Ico.mp hn).2 v hzero hv
+          (hQ n hn) (hcomm n hn) hγ hc₁ hc₂ (hC2 n hn v) (hC3point n hn v)
+    have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
+    have hsumPoint' : ‖v‖ ^ 2 ≤
+        (1 / (2 * c₁ * γ)) *
+            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
+        (c₁ / 2 + ε * s / 2) * ‖v‖ ^ 2 +
+        (c₂ / 2) *
+          (∑ n ∈ Finset.Ico l N,
+            ‖∑ m ∈ Finset.Icc (n - l) n,
+              G.martingaleDifference m v‖ ^ 2) := by
+      simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
+    have henergy :
+        (1 / (2 * c₁ * γ)) *
+            (∑ n ∈ Finset.Ico l N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+          (1 / (2 * c₁ * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
+      mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
+    have hwindow' :
+        (c₂ / 2) *
+            (∑ n ∈ Finset.Ico l N,
+              ‖∑ m ∈ Finset.Icc (n - l) n,
+                G.martingaleDifference m v‖ ^ 2) ≤
+          (ε * s / 2) * ‖v‖ ^ 2 := by
+      calc
+        _ ≤ (c₂ / 2) * ((l + 1) * ‖v‖ ^ 2) :=
+          mul_le_mul_of_nonneg_left hwindow (by positivity)
+        _ = ((c₂ / 2) * ((l + 1 : ℕ) : ℝ)) * ‖v‖ ^ 2 := by
+          push_cast
+          ring
+        _ = (ε * s / 2) * ‖v‖ ^ 2 := by rw [hc₂window]
+    have hhalf : (c₁ / 2) * ‖v‖ ^ 2 ≤
+        (1 / (2 * c₁ * γ)) * (d * (⟪H v, v⟫_ℂ).re) := by
+      dsimp only [c₁]
+      dsimp only [c₁] at hsumPoint' henergy
+      linarith
+    calc
+      (γ / d) * (1 - ε * s) ^ 2 * ‖v‖ ^ 2 =
+          (2 * (1 - ε * s) * γ / d) *
+            (((1 - ε * s) / 2) * ‖v‖ ^ 2) := by ring
+      _ ≤ (2 * (1 - ε * s) * γ / d) *
+          ((1 / (2 * (1 - ε * s) * γ)) *
+            (d * (⟪H v, v⟫_ℂ).re)) :=
+        mul_le_mul_of_nonneg_left hhalf (by positivity)
+      _ = (⟪H v, v⟫_ℂ).re := by
+        field_simp [hδ.ne', hγ.ne', hd.ne']
+
+end NestedGroundProjections
+
+end FrustrationFree

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleC1C3.lean
@@ -28,8 +28,9 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 /-- A positive finite-dimensional operator with an energy lower bound on the
 orthogonal complement of its kernel satisfies the corresponding norm lower
-bound. The proof converts the energy estimate into \(H^2 \geq \gamma H\) in an
-eigenbasis, then applies `spectralGap_of_martingale_of_finiteDimensional`. -/
+bound. Orthogonally removing the kernel component converts the energy estimate
+into \(H^2 \geq \gamma H\) by Cauchy--Schwarz; the final norm bound then follows
+from `spectralGap_of_martingale_of_finiteDimensional`. -/
 theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
     [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ) {H : E →ₗ[ℂ] E}
     (hH : H.IsPositive)
@@ -37,77 +38,49 @@ theorem spectralGap_of_energy_lower_bound_of_finiteDimensional
       γ * ‖v‖ ^ 2 ≤ (⟪H v, v⟫_ℂ).re) :
     ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
   classical
-  let hSym := hH.isSymmetric
-  set n := Module.finrank ℂ E with hn_def
-  have hn : Module.finrank ℂ E = n := hn_def.symm
-  set b := hSym.eigenvectorBasis hn with hb_def
-  set μ : Fin n → ℝ := hSym.eigenvalues hn with hμ_def
-  have hHb : ∀ i, H (b i) = ((μ i : ℂ)) • b i := fun i ↦
-    hSym.apply_eigenvectorBasis hn i
-  have hbb : ∀ i j : Fin n, ⟪b i, b j⟫_ℂ = if i = j then (1 : ℂ) else 0 :=
-    orthonormal_iff_ite.mp b.orthonormal
-  have hb_norm : ∀ i, ‖b i‖ = 1 := b.orthonormal.1
-  have hb_mem (i : Fin n) (hμi : μ i ≠ 0) : b i ∈ (LinearMap.ker H)ᗮ := by
-    rw [Submodule.mem_orthogonal]
-    intro x hx
-    have hxzero : H x = 0 := LinearMap.mem_ker.mp hx
-    have hinner : ⟪x, ((μ i : ℂ)) • b i⟫_ℂ = 0 := by
-      rw [← hHb i, ← hSym x (b i), hxzero, inner_zero_left]
-    rw [inner_smul_right] at hinner
-    exact (mul_eq_zero.mp hinner).resolve_left (by simpa using hμi)
-  have hμ_gap : ∀ i, μ i = 0 ∨ γ ≤ μ i := by
-    intro i
-    by_cases hμi : μ i = 0
-    · exact Or.inl hμi
-    · right
-      have hi := hEnergy (b i) (hb_mem i hμi)
-      rw [hHb i, inner_smul_left, hbb i i, ite_eq_left rfl, mul_one,
-        Complex.conj_ofReal, Complex.ofReal_re, hb_norm i, one_pow] at hi
-      simpa using hi
-  have hOpIneq : ∀ v,
-      γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re := by
-    intro v
-    have hEnergyCoords : (⟪H v, v⟫_ℂ).re =
-        ∑ i, μ i * ‖(b.repr v) i‖ ^ 2 := by
-      calc
-        (⟪H v, v⟫_ℂ).re = (⟪b.repr (H v), b.repr v⟫_ℂ).re := by
-          rw [b.repr.inner_map_map]
-        _ = ∑ i, (⟪(b.repr (H v)) i, (b.repr v) i⟫_ℂ).re := by
-          rw [PiLp.inner_apply]
-          simp
-        _ = ∑ i, μ i * ‖(b.repr v) i‖ ^ 2 := by
-          refine Finset.sum_congr rfl fun i _ ↦ ?_
-          rw [hSym.eigenvectorBasis_apply_self_apply hn]
-          change (((b.repr v) i) *
-            (starRingEnd ℂ) ((μ i : ℂ) * (b.repr v) i)).re =
-              μ i * ‖(b.repr v) i‖ ^ 2
-          rw [map_mul, Complex.conj_ofReal]
-          rw [← mul_assoc, mul_comm ((b.repr v) i) (μ i : ℂ), mul_assoc,
-            Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero]
-          rw [← RCLike.inner_apply]
-          congr 1
-          exact inner_self_eq_norm_sq (𝕜 := ℂ) ((b.repr v) i)
-    have hNormCoords : (⟪H v, H v⟫_ℂ).re =
-        ∑ i, μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 := by
-      calc
-        (⟪H v, H v⟫_ℂ).re = ‖H v‖ ^ 2 :=
-          inner_self_eq_norm_sq (𝕜 := ℂ) (H v)
-        _ = ∑ i, μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 := by
-          rw [← b.repr.norm_map, EuclideanSpace.norm_sq_eq]
-          refine Finset.sum_congr rfl fun i _ ↦ ?_
-          rw [hSym.eigenvectorBasis_apply_self_apply hn, norm_mul, mul_pow,
-            RCLike.norm_ofReal, sq_abs]
-    rw [hEnergyCoords, hNormCoords, Finset.mul_sum]
-    refine Finset.sum_le_sum fun i _ ↦ ?_
-    rcases hμ_gap i with hμi | hμi
-    · simp [hμi]
-    · calc
-        γ * (μ i * ‖(b.repr v) i‖ ^ 2) =
-            (γ * μ i) * ‖(b.repr v) i‖ ^ 2 := by ring
-        _ ≤ μ i ^ 2 * ‖(b.repr v) i‖ ^ 2 :=
-          mul_le_mul_of_nonneg_right
-            (by nlinarith [hH.nonneg_eigenvalues hn i]) (sq_nonneg _)
-  exact spectralGap_of_martingale_of_finiteDimensional hγ hH hOpIneq
+  apply spectralGap_of_martingale_of_finiteDimensional hγ hH
+  intro v
+  let p := (LinearMap.ker H).starProjection v
+  let w := v - p
+  have hp_mem : p ∈ LinearMap.ker H :=
+    Submodule.starProjection_apply_mem (LinearMap.ker H) v
+  have hHp : H p = 0 := LinearMap.mem_ker.mp hp_mem
+  have hw : w ∈ (LinearMap.ker H)ᗮ :=
+    Submodule.sub_starProjection_mem_orthogonal v
+  have hv_eq : v = w + p := by
+    dsimp only [w]
+    abel
+  have hHw : H w = H v := by
+    simp only [w, map_sub, hHp, sub_zero]
+  have hcross : ⟪H v, p⟫_ℂ = 0 := by
+    rw [hH.isSymmetric v p, hHp, inner_zero_right]
+  have hform : (⟪H v, v⟫_ℂ).re = (⟪H w, w⟫_ℂ).re := by
+    calc
+      (⟪H v, v⟫_ℂ).re = (⟪H v, w + p⟫_ℂ).re := by rw [← hv_eq]
+      _ = (⟪H v, w⟫_ℂ + ⟪H v, p⟫_ℂ).re := by rw [inner_add_right]
+      _ = (⟪H v, w⟫_ℂ).re := by rw [hcross, add_zero]
+      _ = (⟪H w, w⟫_ℂ).re := by rw [hHw]
+  have henergy := hEnergy w hw
+  have hcauchy : (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ * ‖w‖ := by
+    rw [hform]
+    calc
+      (⟪H w, w⟫_ℂ).re ≤ ‖H w‖ * ‖w‖ :=
+        re_inner_le_norm (𝕜 := ℂ) (H w) w
+      _ = ‖H v‖ * ‖w‖ := by rw [hHw]
+  rw [← hform] at henergy
+  by_cases hwzero : ‖w‖ = 0
+  · have hw' : w = 0 := norm_eq_zero.mp hwzero
+    rw [hform, hw', map_zero, inner_zero_left, Complex.zero_re, mul_zero]
+    exact inner_self_nonneg (𝕜 := ℂ) (x := H v)
+  · have hwpos : 0 < ‖w‖ := lt_of_le_of_ne (norm_nonneg w) (Ne.symm hwzero)
+    have hgapnorm : γ * ‖w‖ ≤ ‖H v‖ := by
+      nlinarith
+    have hquad : γ * (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ ^ 2 := by
+      nlinarith [norm_nonneg (H v)]
+    calc
+      γ * (⟪H v, v⟫_ℂ).re ≤ ‖H v‖ ^ 2 := hquad
+      _ = (⟪H v, H v⟫_ℂ).re :=
+        (inner_self_eq_norm_sq (𝕜 := ℂ) (H v)).symm
 
 namespace NestedGroundProjections
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1071,13 +1071,23 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:nachtergaele_c1_c3_energy_estimate,
-        lem:energy_form_to_norm_bound}
+        lem:energy_form_to_norm_bound,
+        lem:quadratic_form_to_norm_bound}
     Denote the coefficient in
-    Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap} by $\kappa$. The
-    ground-space identity turns $v\in(\ker H)^\perp$ into
-    $v\perp\operatorname{ran}(G_N)$, so the energy estimate gives
-    $\kappa\lVert v\rVert^2\leq\re\langle Hv,v\rangle$. Apply
-    Lemma~\ref{lem:energy_form_to_norm_bound}.
+    Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap} by $\kappa$. For an
+    arbitrary $x$, remove its orthogonal projection onto $\ker H$ and call the
+    remainder $w$. Then $Hx=Hw$ and
+    $\re\langle Hx,x\rangle=\re\langle Hw,w\rangle$. The energy estimate and
+    Lemma~\ref{lem:energy_form_to_norm_bound} give
+    $\kappa\lVert w\rVert\leq\lVert Hx\rVert$. Hence Cauchy--Schwarz gives
+    \begin{align}
+        \kappa\,\re\langle Hx,x\rangle
+         & \leq \kappa\lVert Hx\rVert\lVert w\rVert
+        \leq \lVert Hx\rVert^2.
+    \end{align}
+    Thus the hypothesis of
+    Lemma~\ref{lem:quadratic_form_to_norm_bound} holds globally. That lemma is
+    the finite-dimensional spectral endpoint and yields the stated norm bound.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for a finite family of projections]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -90,10 +90,16 @@
 
 \begin{theorem}[Pythagorean identity for martingale differences]%
     \label{thm:martingale-difference-pythagorean-identity}
+    \lean{FrustrationFree.NestedGroundProjections.norm_sq_sum_martingaleDifference_finset}
     \lean{FrustrationFree.NestedGroundProjections.norm_sq_sum_martingaleDifference}
     \leanok
     \uses{thm:orthogonal-martingale-difference-resolution}
-    For every $v\in\mathcal H$ and $N\in\N$,
+    For every $v\in\mathcal H$ and finite $S\subset\N$,
+    \begin{align}
+        \left\lVert\sum_{n\in S}E_nv\right\rVert^2
+         & =\sum_{n\in S}\lVert E_nv\rVert^2.
+    \end{align}
+    In particular, for $S=\{0,\ldots,N-1\}$,
     \begin{align}
         \left\lVert\sum_{n=0}^{N-1}E_nv\right\rVert^2
          & =\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
@@ -926,6 +932,129 @@ norm estimate is derived here.
     \cite[Proof of Theorem~2.1(i)]{Nachtergaele1996Spectral}.
 \end{proof}
 
+% Source: References/cond-mat_9410110/main.tex, Theorem 2.1(i),
+% statement lines 1119--1130 and proof lines 1195--1259.
+\begin{theorem}[Nachtergaele's C1--C3 energy estimate]
+    \label{thm:nachtergaele_c1_c3_energy_estimate}
+    \lean{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3}
+    \leanok
+    \uses{thm:truncated-martingale-difference-reconstruction,
+        thm:martingale-difference-pythagorean-identity,
+        thm:outside-window-martingale-cancellation,
+        lem:nachtergaele_weighted_inner_product,
+        lem:nachtergaele_c3_projection_composition,
+        thm:moving_window_sum_le}
+    Let $(G_n)_{n\geq0}$ be nested orthogonal projections on a
+    finite-dimensional complex Hilbert space, and put
+    $E_n=G_n-G_{n+1}$. Fix $l\leq N$, use the padded endpoint convention
+    $G_0=G_l=I$, and let $Q_n$ be orthogonal projections for
+    $l\leq n<N$. Suppose $E_mQ_n=Q_nE_m$ whenever $m<n-l$ or $n<m$.
+    Let $H_n$ be the local Hamiltonians and $H$ the full Hamiltonian.
+    Assume the quadratic-form versions of C1 and C2,
+    \begin{align}
+        0
+         & \leq\sum_{n=l}^{N-1}\re\langle H_nv,v\rangle
+        \leq d_{l+1}\re\langle Hv,v\rangle,
+        \label{eq:nachtergaele_c1_form}\\
+        \gamma_{l+1}\lVert(I-Q_n)v\rVert^2
+         & \leq\re\langle H_nv,v\rangle,
+        \label{eq:nachtergaele_c2_form}
+    \end{align}
+    and the literal condition C3,
+    \begin{align}
+        \lVert Q_nE_n\rVert
+         & \leq\epsilon_l,
+        & 0\leq\epsilon_l
+         & <\frac{1}{\sqrt{l+1}}.
+        \label{eq:nachtergaele_c3_form}
+    \end{align}
+    If $\gamma_{l+1}>0$, $d_{l+1}>0$, and
+    $v\perp\operatorname{ran}(G_N)$, then
+    \begin{align}
+        \re\langle Hv,v\rangle
+         & \geq
+        \frac{\gamma_{l+1}}{d_{l+1}}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert^2.
+        \label{eq:nachtergaele_c1_c3_energy_estimate}
+    \end{align}
+    This is Theorem~2.1(i) of
+    \cite{Nachtergaele1996Spectral}. The indices are exactly
+    $\gamma_{l+1}$, $d_{l+1}$, and $\epsilon_l$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:truncated-martingale-difference-reconstruction,
+        thm:martingale-difference-pythagorean-identity,
+        thm:outside-window-martingale-cancellation,
+        lem:nachtergaele_weighted_inner_product,
+        lem:nachtergaele_c3_projection_composition,
+        thm:moving_window_sum_le}
+    The martingale resolution gives
+    \begin{align}
+        v
+         & =\sum_{n=l}^{N-1}E_nv,
+        & \lVert v\rVert^2
+         & =\sum_{n=l}^{N-1}\lVert E_nv\rVert^2.
+    \end{align}
+    Outside-window cancellation reduces the second term in the identity
+    labelled \textup{Enpsi} to $m\in[n-l,n]$. Apply the weighted
+    inner-product estimate with positive parameters $c_1,c_2$ and then use
+    C2 and C3. Summing over $n$ and applying the moving-window count gives
+    \begin{align}
+        \left(2-c_1-\frac{\epsilon_l^2}{c_2}-(l+1)c_2\right)
+        \lVert v\rVert^2
+         & \leq
+        \frac{d_{l+1}}{c_1\gamma_{l+1}}
+        \re\langle Hv,v\rangle.
+    \end{align}
+    For $\epsilon_l>0$, take
+    \begin{align}
+        c_1
+         & =1-\epsilon_l\sqrt{l+1},
+        & c_2
+         & =\frac{\epsilon_l}{\sqrt{l+1}}.
+    \end{align}
+    These values reduce the preceding inequality to
+    Equation~\eqref{eq:nachtergaele_c1_c3_energy_estimate}. If
+    $\epsilon_l=0$, then $c_2=0$ is not an admissible weighted parameter.
+    Instead, C3 gives $Q_nE_n=0$, so the second inner product in
+    \textup{Enpsi} vanishes; applying only the first weighted estimate with
+    $c_1=1$ yields the same formula.
+\end{proof}
+
+\begin{corollary}[Norm gap from the C1--C3 estimate]
+    \label{cor:nachtergaele_c1_c3_norm_gap}
+    \lean{FrustrationFree.spectralGap_of_energy_lower_bound_of_finiteDimensional}
+    \lean{FrustrationFree.NestedGroundProjections.norm_lower_bound_of_nachtergaele_c1_c3}
+    \leanok
+    \uses{thm:nachtergaele_c1_c3_energy_estimate,
+        lem:quadratic_form_to_norm_bound}
+    In the setting of
+    Theorem~\ref{thm:nachtergaele_c1_c3_energy_estimate}, suppose that $H$ is
+    positive and $\operatorname{ran}(G_N)=\ker H$. Then every
+    $v\in(\ker H)^\perp$ satisfies
+    \begin{align}
+        \frac{\gamma_{l+1}}{d_{l+1}}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert
+         & \leq\lVert Hv\rVert.
+        \label{eq:nachtergaele_c1_c3_norm_gap}
+    \end{align}
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:nachtergaele_c1_c3_energy_estimate,
+        lem:quadratic_form_to_norm_bound}
+    Diagonalize the positive operator $H$. Applying
+    Theorem~\ref{thm:nachtergaele_c1_c3_energy_estimate} to every eigenvector
+    with nonzero eigenvalue shows that its eigenvalue is at least the
+    coefficient in Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap}. Hence
+    $H^2\geq\gamma H$ with this coefficient. The finite-dimensional
+    quadratic-form criterion gives the stated norm lower bound on
+    $(\ker H)^\perp$.
+\end{proof}
+
 \begin{theorem}[Martingale criterion for a finite family of projections]
     \label{thm:martingale_criterion}
     \lean{MPSTensor.spectralGap_of_martingale_anticommutator_rowCol_of_finiteDimensional}
@@ -1020,8 +1149,9 @@ source obtains a gap from its three stated hypotheses. Every compatible
 Hamiltonian below is positive because it is a sum of orthogonal projections.
 In addition to the compatible Hamiltonian and its zero-energy space, the
 statements below verify condition C1 and the unit norm lower bound at the
-full-window volume $N=L$. They give no gap estimate for $N>L$ and no periodic
-coercivity.
+full-window volume $N=L$. Together with fixed-ambient instances of C2 and C3,
+Theorem~\ref{thm:nachtergaele_c1_c3_energy_estimate} gives the gap for $N>L$.
+The statements in this subsection do not assume periodic coercivity.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -955,7 +955,7 @@ norm estimate is derived here.
         0
          & \leq\sum_{n=l}^{N-1}\re\langle H_nv,v\rangle
         \leq d_{l+1}\re\langle Hv,v\rangle,
-        \label{eq:nachtergaele_c1_form}\\
+        \label{eq:nachtergaele_c1_form}                 \\
         \gamma_{l+1}\lVert(I-Q_n)v\rVert^2
          & \leq\re\langle H_nv,v\rangle,
         \label{eq:nachtergaele_c2_form}
@@ -964,7 +964,7 @@ norm estimate is derived here.
     \begin{align}
         \lVert Q_nE_n\rVert
          & \leq\epsilon_l,
-        & 0\leq\epsilon_l
+         & 0\leq\epsilon_l
          & <\frac{1}{\sqrt{l+1}}.
         \label{eq:nachtergaele_c3_form}
     \end{align}
@@ -994,7 +994,7 @@ norm estimate is derived here.
     \begin{align}
         v
          & =\sum_{n=l}^{N-1}E_nv,
-        & \lVert v\rVert^2
+         & \lVert v\rVert^2
          & =\sum_{n=l}^{N-1}\lVert E_nv\rVert^2.
     \end{align}
     Outside-window cancellation reduces the second term in the identity
@@ -1012,7 +1012,7 @@ norm estimate is derived here.
     \begin{align}
         c_1
          & =1-\epsilon_l\sqrt{l+1},
-        & c_2
+         & c_2
          & =\frac{\epsilon_l}{\sqrt{l+1}}.
     \end{align}
     These values reduce the preceding inequality to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -908,22 +908,22 @@ norm estimate is derived here.
 \begin{theorem}[Moving-window double counting]
     \label{thm:moving_window_sum_le}
     \lean{FrustrationFree.movingWindow_sum_le}
+    \lean{FrustrationFree.movingWindow_sum_range_le}
     \leanok
     Let $(a_m)_{m\geq0}$ be a nonnegative real sequence. For all $l,N\in\N$,
     \begin{align}
-        \sum_{n=l}^{N-1}\sum_{m=n-l}^{n}a_m
+        \sum_{n=0}^{N-1}\sum_{m=\max\{0,n-l\}}^{n}a_m
          & \leq (l+1)\sum_{m=0}^{N-1}a_m.
         \label{eq:moving_window_sum_le}
     \end{align}
-    When $l\geq N$, the sum on the left is empty.
+    The same bound holds after omitting the terms with $n<l$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Write $m=n-l+k$, where $0\leq k\leq l$, and reverse the order of
-    summation. For each fixed $k$, the map $n\mapsto n-l+k$ is injective on
-    $\{l,\ldots,N-1\}$ and has image in $\{0,\ldots,N-1\}$. Nonnegativity
-    therefore bounds the corresponding inner sum by
+    Write $k=n-m$. Each pair in the double sum has $0\leq k\leq l$.
+    For fixed $k$, the map $n\mapsto n-k$ is injective and has image in
+    $\{0,\ldots,N-1\}$. Nonnegativity bounds its contribution by
     $\sum_{m=0}^{N-1}a_m$. Summing over the $l+1$ values of $k$ proves
     (\ref{eq:moving_window_sum_le}). This is the counting step in the proof of
     Nachtergaele's Theorem~2.1(i), between Equation~(Enpsi2) and the following
@@ -945,15 +945,14 @@ norm estimate is derived here.
         lem:nachtergaele_c3_projection_composition,
         thm:moving_window_sum_le}
     Let $(G_n)_{n\geq0}$ be nested orthogonal projections on a
-    finite-dimensional complex Hilbert space, and put
-    $E_n=G_n-G_{n+1}$. Fix $l\leq N$, use the padded endpoint convention
-    $G_0=G_l=I$, and let $Q_n$ be orthogonal projections for
-    $l\leq n<N$. Suppose $E_mQ_n=Q_nE_m$ whenever $m<n-l$ or $n<m$.
+    finite-dimensional complex Hilbert space, put $E_n=G_n-G_{n+1}$, and
+    assume $G_0=I$. Fix $l,N\in\N$, and let $Q_n$ be orthogonal projections
+    for $0\leq n<N$. Suppose $E_mQ_n=Q_nE_m$ whenever $m<n-l$ or $n<m$.
     Let $H_n$ be the local Hamiltonians and $H$ the full Hamiltonian.
-    Assume the quadratic-form versions of C1 and C2,
+    Assume the quadratic-form versions of C1 and C2 on the full finite range,
     \begin{align}
         0
-         & \leq\sum_{n=l}^{N-1}\re\langle H_nv,v\rangle
+         & \leq\sum_{n=0}^{N-1}\re\langle H_nv,v\rangle
         \leq d_{l+1}\re\langle Hv,v\rangle,
         \label{eq:nachtergaele_c1_form}                 \\
         \gamma_{l+1}\lVert(I-Q_n)v\rVert^2
@@ -977,8 +976,10 @@ norm estimate is derived here.
         \left(1-\epsilon_l\sqrt{l+1}\right)^2\lVert v\rVert^2.
         \label{eq:nachtergaele_c1_c3_energy_estimate}
     \end{align}
-    This is Theorem~2.1(i) of
-    \cite{Nachtergaele1996Spectral}. The indices are exactly
+    This full finite-range form resolves the lower-index ambiguity in the
+    printed proof by requiring C1--C3 also for $n<l$; the later physical
+    specialization verifies those indices separately. Its coefficient is the
+    one in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}, with exactly
     $\gamma_{l+1}$, $d_{l+1}$, and $\epsilon_l$.
 \end{theorem}
 
@@ -993,9 +994,9 @@ norm estimate is derived here.
     The martingale resolution gives
     \begin{align}
         v
-         & =\sum_{n=l}^{N-1}E_nv,
+         & =\sum_{n=0}^{N-1}E_nv,
          & \lVert v\rVert^2
-         & =\sum_{n=l}^{N-1}\lVert E_nv\rVert^2.
+         & =\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
     \end{align}
     Outside-window cancellation reduces the second term in the identity
     labelled \textup{Enpsi} to $m\in[n-l,n]$. Apply the weighted
@@ -1023,12 +1024,37 @@ norm estimate is derived here.
     $c_1=1$ yields the same formula.
 \end{proof}
 
+\begin{lemma}[Energy form to norm bound]
+    \label{lem:energy_form_to_norm_bound}
+    \lean{FrustrationFree.norm_lower_bound_of_energy_lower_bound}
+    \leanok
+    Let $H$ be a linear operator on a complex Hilbert space. If
+    \begin{align}
+        \kappa\lVert v\rVert^2
+         & \leq\re\langle Hv,v\rangle
+    \end{align}
+    for every $v\in(\ker H)^\perp$, then
+    $\kappa\lVert v\rVert\leq\lVert Hv\rVert$ on the same subspace.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Cauchy--Schwarz gives
+    \begin{align}
+        \kappa\lVert v\rVert^2
+         & \leq\re\langle Hv,v\rangle
+        \leq\lVert Hv\rVert\lVert v\rVert.
+    \end{align}
+    The claim is immediate for $v=0$; otherwise cancel $\lVert v\rVert$.
+\end{proof}
+
 \begin{corollary}[Norm gap from the C1--C3 estimate]
     \label{cor:nachtergaele_c1_c3_norm_gap}
-    \lean{FrustrationFree.spectralGap_of_energy_lower_bound_of_finiteDimensional}
+    \lean{FrustrationFree.spectralGap_of_martingale_of_finiteDimensional}
     \lean{FrustrationFree.NestedGroundProjections.norm_lower_bound_of_nachtergaele_c1_c3}
     \leanok
     \uses{thm:nachtergaele_c1_c3_energy_estimate,
+        lem:energy_form_to_norm_bound,
         lem:quadratic_form_to_norm_bound}
     In the setting of
     Theorem~\ref{thm:nachtergaele_c1_c3_energy_estimate}, suppose that $H$ is
@@ -1045,26 +1071,13 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:nachtergaele_c1_c3_energy_estimate,
-        lem:quadratic_form_to_norm_bound}
+        lem:energy_form_to_norm_bound}
     Denote the coefficient in
-    Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap} by $\kappa$. For an
-    arbitrary $x$, remove its orthogonal projection onto $\ker H$ and write
-    the remainder as $w\in(\ker H)^\perp$. Symmetry gives
-    $Hx=Hw$ and $\re\langle Hx,x\rangle=\re\langle Hw,w\rangle$. The energy
-    estimate and Cauchy--Schwarz give
-    \begin{align}
-        \kappa\lVert w\rVert^2
-         & \leq\re\langle Hx,x\rangle
-        \leq\lVert Hx\rVert\lVert w\rVert.
-    \end{align}
-    If $w=0$, the desired quadratic-form inequality is immediate. Otherwise,
-    cancellation of $\lVert w\rVert$ and a second use of the upper bound give
-    \begin{align}
-        \kappa\,\re\langle Hx,x\rangle
-         & \leq\lVert Hx\rVert^2.
-    \end{align}
-    Thus $H^2\geq\kappa H$ globally. The finite-dimensional quadratic-form
-    criterion gives the stated norm lower bound on $(\ker H)^\perp$.
+    Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap} by $\kappa$. The
+    ground-space identity turns $v\in(\ker H)^\perp$ into
+    $v\perp\operatorname{ran}(G_N)$, so the energy estimate gives
+    $\kappa\lVert v\rVert^2\leq\re\langle Hv,v\rangle$. Apply
+    Lemma~\ref{lem:energy_form_to_norm_bound}.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for a finite family of projections]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1046,13 +1046,25 @@ norm estimate is derived here.
     \leanok
     \uses{thm:nachtergaele_c1_c3_energy_estimate,
         lem:quadratic_form_to_norm_bound}
-    Diagonalize the positive operator $H$. Applying
-    Theorem~\ref{thm:nachtergaele_c1_c3_energy_estimate} to every eigenvector
-    with nonzero eigenvalue shows that its eigenvalue is at least the
-    coefficient in Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap}. Hence
-    $H^2\geq\gamma H$ with this coefficient. The finite-dimensional
-    quadratic-form criterion gives the stated norm lower bound on
-    $(\ker H)^\perp$.
+    Denote the coefficient in
+    Equation~\eqref{eq:nachtergaele_c1_c3_norm_gap} by $\kappa$. For an
+    arbitrary $x$, remove its orthogonal projection onto $\ker H$ and write
+    the remainder as $w\in(\ker H)^\perp$. Symmetry gives
+    $Hx=Hw$ and $\re\langle Hx,x\rangle=\re\langle Hw,w\rangle$. The energy
+    estimate and Cauchy--Schwarz give
+    \begin{align}
+        \kappa\lVert w\rVert^2
+         & \leq\re\langle Hx,x\rangle
+        \leq\lVert Hx\rVert\lVert w\rVert.
+    \end{align}
+    If $w=0$, the desired quadratic-form inequality is immediate. Otherwise,
+    cancellation of $\lVert w\rVert$ and a second use of the upper bound give
+    \begin{align}
+        \kappa\,\re\langle Hx,x\rangle
+         & \leq\lVert Hx\rVert^2.
+    \end{align}
+    Thus $H^2\geq\kappa H$ globally. The finite-dimensional quadratic-form
+    criterion gives the stated norm lower bound on $(\ker H)^\perp$.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for a finite family of projections]


### PR DESCRIPTION
## Summary

The main mathematical commits are already represented by merged PR #7548. This draft preserves the remaining post-merge module and prose-policy correction.

## Verification

- changed files pass git diff check
- no proof-integrity blockers occur in the changed Lean files

A full project build remains to be run before review.