### PR TITLE
feat(MPS/CanonicalForm): preserve CFII under tensor products

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -86,7 +86,8 @@ namespace CPSVCanonicalFormIIData
 The fixed-point matrices are unchanged because a bijective physical relabeling leaves each block's
 transfer map unchanged. In particular, any separately supplied trace normalization is unchanged.
 
-Source: arXiv:1703.09188, CFII definition at lines 271--281. -/
+Source: arXiv:1606.00608, Appendix A, equations `TP` and `Lambda`,
+lines 1054--1077. -/
 noncomputable def reindexPhysical {A : MPSTensor d₂ D}
     (data : CPSVCanonicalFormIIData A) (e : Fin d₁ ≃ Fin d₂) :
     CPSVCanonicalFormIIData (Kraus.reindexPhysical e A) where

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -7,13 +7,14 @@ import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Core.TensorProductSpan
 
 /-!
-# Independent tensor products of left-canonical normal blocks
+# Independent tensor products of CPSV canonical-form-II data
 
-This module packages the algebraic tensor-product argument for the retained
-normal blocks of the canonical-form decomposition.  The product is
-left-canonical by a direct Kronecker calculation, algebraically normal by the
-common homogeneous word-span length, and hence a CPSV normal tensor by the
-established left-canonical bridge.
+This module packages the tensor-product argument for the retained blocks of
+the CPSV canonical-form-II decomposition.  The product of two retained blocks
+is left-canonical by a direct Kronecker calculation, algebraically normal by
+the common homogeneous word-span length, and hence a CPSV normal tensor by the
+established left-canonical bridge.  The diagonal positive fixed point is the
+reindexed Kronecker product of the two fixed points.
 
 The result is project infrastructure for the tensoring clause in
 arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--845; it is not a
@@ -28,6 +29,8 @@ claim attributed to that passage.
   normality for two left-canonical normal blocks;
   `MPSTensor.leftCanonical_tensorProduct`
   supplies the accompanying left-canonical conclusion.
+* `MPSTensor.transferMap_tensorProduct_kronecker` identifies the product
+  transfer map on a reindexed Kronecker product.
 
 ## References
 
@@ -36,6 +39,8 @@ claim attributed to that passage.
 * Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608.
 -/
+
+open scoped Matrix Kronecker BigOperators ComplexOrder
 
 namespace MPSTensor
 
@@ -71,5 +76,319 @@ theorem IsNormalTensor.tensorProduct_of_leftCanonical {A : MPSTensor d D}
   exact isNormalTensor_of_isNormal_leftCanonical (MPSTensor.tensorProduct A B)
     (isNormal_tensorProduct A B hA.isNormal hB.isNormal)
     (leftCanonical_tensorProduct A B hLeftA hLeftB)
+
+/-- The transfer map of an independent tensor product acts on a reindexed
+Kronecker product as the reindexed Kronecker product of the two transfer maps:
+\[
+  \mathcal E_{A\boxtimes B}(\operatorname{reind}(X\otimes Y))
+  =\operatorname{reind}(\mathcal E_A(X)\otimes\mathcal E_B(Y)).
+\]
+
+This is the algebraic identity used for the diagonal positive fixed points in
+the product canonical-form-II construction.  Its terminology and fixed-point
+orientation are those of arXiv:1606.00608, Appendix A, equations `TP` and
+`Lambda`, lines 1054--1077. -/
+theorem transferMap_tensorProduct_kronecker (A : MPSTensor d D)
+    (B : MPSTensor e E) (X : Matrix (Fin D) (Fin D) ℂ)
+    (Y : Matrix (Fin E) (Fin E) ℂ) :
+    Kraus.transferMap (tensorProduct A B)
+        (Matrix.reindex finProdFinEquiv finProdFinEquiv (X ⊗ₖ Y)) =
+      Matrix.reindex finProdFinEquiv finProdFinEquiv
+        (Kraus.transferMap A X ⊗ₖ Kraus.transferMap B Y) := by
+  classical
+  have hterm (i : Fin d) (k : Fin e) :
+      tensorProduct A B (finProdFinEquiv (i, k)) *
+            Matrix.reindex finProdFinEquiv finProdFinEquiv (X ⊗ₖ Y) *
+            (tensorProduct A B (finProdFinEquiv (i, k)))ᴴ =
+        Matrix.reindex finProdFinEquiv finProdFinEquiv
+          ((A i * X * (A i)ᴴ) ⊗ₖ (B k * Y * (B k)ᴴ)) := by
+    have hi : (finProdFinEquiv (i, k) : Fin (d * e)).divNat = i :=
+      congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, k))
+    have hk : (finProdFinEquiv (i, k) : Fin (d * e)).modNat = k :=
+      congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, k))
+    simp only [tensorProduct, hi, hk]
+    rw [Matrix.conjTranspose_reindex]
+    change
+      (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv (A i ⊗ₖ B k) *
+          Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv (X ⊗ₖ Y)) *
+          Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+            ((A i ⊗ₖ B k)ᴴ) = _
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ finProdFinEquiv finProdFinEquiv
+        finProdFinEquiv,
+      Matrix.reindexLinearEquiv_mul ℂ ℂ finProdFinEquiv finProdFinEquiv
+        finProdFinEquiv,
+      Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+      ← Matrix.mul_kronecker_mul]
+    rfl
+  rw [Kraus.transferMap_apply, ← Equiv.sum_comp finProdFinEquiv,
+    Fintype.sum_prod_type]
+  simp_rw [hterm]
+  change
+    ∑ i : Fin d, ∑ k : Fin e,
+        Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+          ((A i * X * (A i)ᴴ) ⊗ₖ (B k * Y * (B k)ᴴ)) =
+      Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+        (Kraus.transferMap A X ⊗ₖ Kraus.transferMap B Y)
+  apply (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv).symm.injective
+  simp only [map_sum, LinearEquiv.symm_apply_apply]
+  rw [Kraus.transferMap_apply, Kraus.transferMap_apply]
+  symm
+  change Matrix.kroneckerBilinear (R := ℂ) (α := ℂ)
+      (∑ i : Fin d, A i * X * (A i)ᴴ)
+      (∑ k : Fin e, B k * Y * (B k)ᴴ) = _
+  rw [map_sum]
+  simp_rw [map_sum]
+  rw [Finset.sum_comm]
+  simp only [LinearMap.sum_apply]
+  rfl
+
+namespace CPSVCanonicalFormIIData
+
+variable {A : MPSTensor d D} {B : MPSTensor e E}
+
+/-- Regroup a pair of dependent coordinates as one dependent coordinate over
+the product label. -/
+private def sigmaProdFiberEquiv {α β : Type*} (γ : α → Type*) (δ : β → Type*) :
+    (Sigma γ × Sigma δ) ≃ Σ ab : α × β, γ ab.1 × δ ab.2 where
+  toFun x := ⟨(x.1.1, x.2.1), (x.1.2, x.2.2)⟩
+  invFun x := (⟨x.1.1, x.2.1⟩, ⟨x.1.2, x.2.2⟩)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Bond dimension of the retained product block labelled by `ab`. -/
+private def tensorProductDim (dataA : CPSVCanonicalFormIIData A)
+    (dataB : CPSVCanonicalFormIIData B) (ab : Fin (dataA.r * dataB.r)) : ℕ :=
+  dataA.dim (finProdFinEquiv.symm ab).1 * dataB.dim (finProdFinEquiv.symm ab).2
+
+/-- Weight of the retained product block labelled by `ab`. -/
+private def tensorProductWeight (dataA : CPSVCanonicalFormIIData A)
+    (dataB : CPSVCanonicalFormIIData B) (ab : Fin (dataA.r * dataB.r)) : ℂ :=
+  dataA.weights (finProdFinEquiv.symm ab).1 *
+    dataB.weights (finProdFinEquiv.symm ab).2
+
+/-- Retained product block labelled by `ab`. -/
+private def tensorProductBlock (dataA : CPSVCanonicalFormIIData A)
+    (dataB : CPSVCanonicalFormIIData B) (ab : Fin (dataA.r * dataB.r)) :
+    MPSTensor (d * e) (tensorProductDim dataA dataB ab) :=
+  MPSTensor.tensorProduct
+    (dataA.blocks (finProdFinEquiv.symm ab).1)
+    (dataB.blocks (finProdFinEquiv.symm ab).2)
+
+/-- Canonical retained-coordinate regrouping
+`((a, α), (b, β)) ↦ ((a, b), (α, β))` for the product block family. -/
+private noncomputable def tensorProductRetainedEquiv
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B) :
+    (Fin (∑ a : Fin dataA.r, dataA.dim a) ×
+        Fin (∑ b : Fin dataB.r, dataB.dim b)) ≃
+      Fin (∑ ab : Fin (dataA.r * dataB.r), tensorProductDim dataA dataB ab) :=
+  (Equiv.prodCongr
+      (finSigmaFinEquiv (m := dataA.r) (n := dataA.dim)).symm
+      (finSigmaFinEquiv (m := dataB.r) (n := dataB.dim)).symm) |>.trans
+    (sigmaProdFiberEquiv (fun a ↦ Fin (dataA.dim a))
+      (fun b ↦ Fin (dataB.dim b))) |>.trans
+    (Equiv.sigmaCongrRight fun _ ↦ finProdFinEquiv) |>.trans
+    (Equiv.sigmaCongr finProdFinEquiv fun ab ↦ finCongr (by
+      simp [tensorProductDim])) |>.trans
+    finSigmaFinEquiv
+
+@[simp]
+private theorem tensorProductRetainedEquiv_apply
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B)
+    (a : Fin dataA.r) (b : Fin dataB.r)
+    (α : Fin (dataA.dim a)) (β : Fin (dataB.dim b)) :
+    tensorProductRetainedEquiv dataA dataB
+        (finSigmaFinEquiv ⟨a, α⟩, finSigmaFinEquiv ⟨b, β⟩) =
+      finSigmaFinEquiv
+        ⟨finProdFinEquiv (a, b),
+          finCongr (by simp [tensorProductDim]) (finProdFinEquiv (α, β))⟩ := by
+  apply finSigmaFinEquiv.symm.injective
+  simp [tensorProductRetainedEquiv, sigmaProdFiberEquiv, tensorProductDim,
+    Equiv.sigmaCongr]
+
+/-- The weighted direct sum of the product blocks is the retained-coordinate
+reindexing of the Kronecker product of the two weighted direct sums. -/
+private theorem toTensorFromBlocks_tensorProduct
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B)
+    (i : Fin d) (k : Fin e) :
+    toTensorFromBlocks (tensorProductWeight dataA dataB)
+        (tensorProductBlock dataA dataB) (finProdFinEquiv (i, k)) =
+      Matrix.reindex (tensorProductRetainedEquiv dataA dataB)
+        (tensorProductRetainedEquiv dataA dataB)
+        (toTensorFromBlocks dataA.weights dataA.blocks i ⊗ₖ
+          toTensorFromBlocks dataB.weights dataB.blocks k) := by
+  classical
+  ext x y
+  rcases (tensorProductRetainedEquiv dataA dataB).surjective x with
+    ⟨⟨xa, xb⟩, rfl⟩
+  rcases (tensorProductRetainedEquiv dataA dataB).surjective y with
+    ⟨⟨ya, yb⟩, rfl⟩
+  rcases finSigmaFinEquiv.surjective xa with ⟨⟨a, α⟩, rfl⟩
+  rcases finSigmaFinEquiv.surjective xb with ⟨⟨b, β⟩, rfl⟩
+  rcases finSigmaFinEquiv.surjective ya with ⟨⟨c, γ⟩, rfl⟩
+  rcases finSigmaFinEquiv.surjective yb with ⟨⟨f, δ⟩, rfl⟩
+  simp only [toTensorFromBlocks, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply]
+  simp only [Equiv.symm_apply_apply]
+  rw [tensorProductRetainedEquiv_apply, tensorProductRetainedEquiv_apply]
+  simp only [finSigmaFinEquiv.symm_apply_apply]
+  have hi : (finProdFinEquiv (i, k) : Fin (d * e)).divNat = i :=
+    congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, k))
+  have hk : (finProdFinEquiv (i, k) : Fin (d * e)).modNat = k :=
+    congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, k))
+  by_cases hac : a = c
+  · subst c
+    by_cases hbf : b = f
+    · subst f
+      rw [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_eq,
+        Matrix.blockDiagonal'_apply_eq]
+      have ha := congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (a, b))
+      have hb := congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (a, b))
+      simp [tensorProductWeight, tensorProductBlock, tensorProductDim, hi, hk,
+        ha, hb, Matrix.smul_apply, Matrix.reindex_apply]
+      ring_nf
+    · have hab : finProdFinEquiv (a, b) ≠ finProdFinEquiv (a, f) := by
+        exact fun h ↦ hbf (congrArg Prod.snd (finProdFinEquiv.injective h))
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hab,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hbf]
+      simp
+  · have hab : finProdFinEquiv (a, b) ≠ finProdFinEquiv (c, f) := by
+      exact fun h ↦ hac (congrArg Prod.fst (finProdFinEquiv.injective h))
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hab,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hac]
+    simp
+
+/-- Reindexed Kronecker product of the two ambient coisometries. -/
+private noncomputable def tensorProductAmbientCoisometry
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B) :
+    Matrix
+      (Fin (∑ ab : Fin (dataA.r * dataB.r), tensorProductDim dataA dataB ab))
+      (Fin (D * E)) ℂ :=
+  Matrix.reindex (tensorProductRetainedEquiv dataA dataB) finProdFinEquiv
+    (dataA.ambient_coisometry ⊗ₖ dataB.ambient_coisometry)
+
+private theorem tensorProductAmbientCoisometry_coisometric
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B) :
+    tensorProductAmbientCoisometry dataA dataB *
+        (tensorProductAmbientCoisometry dataA dataB)ᴴ = 1 := by
+  rw [tensorProductAmbientCoisometry, Matrix.conjTranspose_reindex]
+  change
+    Matrix.reindexLinearEquiv ℂ ℂ (tensorProductRetainedEquiv dataA dataB)
+        finProdFinEquiv (dataA.ambient_coisometry ⊗ₖ dataB.ambient_coisometry) *
+      Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv
+        (tensorProductRetainedEquiv dataA dataB)
+        ((dataA.ambient_coisometry ⊗ₖ dataB.ambient_coisometry)ᴴ) = 1
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (tensorProductRetainedEquiv dataA dataB)
+      finProdFinEquiv (tensorProductRetainedEquiv dataA dataB),
+    Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+    dataA.coisometric, dataB.coisometric, Matrix.one_kronecker_one,
+    Matrix.reindexLinearEquiv_one]
+
+private theorem sum_tensorProductDim
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B) :
+    (∑ ab : Fin (dataA.r * dataB.r), tensorProductDim dataA dataB ab) =
+      (∑ a : Fin dataA.r, dataA.dim a) *
+        (∑ b : Fin dataB.r, dataB.dim b) := by
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [tensorProductDim, Equiv.symm_apply_apply]
+  rw [← Fintype.sum_mul_sum]
+
+private theorem tensorProduct_reconstruct
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B)
+    (q : Fin (d * e)) :
+    MPSTensor.tensorProduct A B q =
+      (tensorProductAmbientCoisometry dataA dataB)ᴴ *
+        toTensorFromBlocks (tensorProductWeight dataA dataB)
+          (tensorProductBlock dataA dataB) q *
+        tensorProductAmbientCoisometry dataA dataB := by
+  rcases finProdFinEquiv.surjective q with ⟨⟨i, k⟩, rfl⟩
+  rw [toTensorFromBlocks_tensorProduct]
+  have hi : (finProdFinEquiv (i, k) : Fin (d * e)).divNat = i :=
+    congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, k))
+  have hk : (finProdFinEquiv (i, k) : Fin (d * e)).modNat = k :=
+    congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, k))
+  simp only [MPSTensor.tensorProduct, hi, hk]
+  rw [dataA.reconstruct i, dataB.reconstruct k]
+  rw [tensorProductAmbientCoisometry, Matrix.conjTranspose_reindex]
+  change
+    Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv
+        (((dataA.ambient_coisometryᴴ *
+              toTensorFromBlocks dataA.weights dataA.blocks i) *
+            dataA.ambient_coisometry) ⊗ₖ
+          ((dataB.ambient_coisometryᴴ *
+              toTensorFromBlocks dataB.weights dataB.blocks k) *
+            dataB.ambient_coisometry)) =
+      (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv
+          (tensorProductRetainedEquiv dataA dataB)
+          ((dataA.ambient_coisometry ⊗ₖ dataB.ambient_coisometry)ᴴ) *
+        Matrix.reindexLinearEquiv ℂ ℂ (tensorProductRetainedEquiv dataA dataB)
+          (tensorProductRetainedEquiv dataA dataB)
+          (toTensorFromBlocks dataA.weights dataA.blocks i ⊗ₖ
+            toTensorFromBlocks dataB.weights dataB.blocks k)) *
+        Matrix.reindexLinearEquiv ℂ ℂ (tensorProductRetainedEquiv dataA dataB)
+          finProdFinEquiv
+          (dataA.ambient_coisometry ⊗ₖ dataB.ambient_coisometry)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ finProdFinEquiv
+      (tensorProductRetainedEquiv dataA dataB)
+      (tensorProductRetainedEquiv dataA dataB),
+    Matrix.reindexLinearEquiv_mul ℂ ℂ finProdFinEquiv
+      (tensorProductRetainedEquiv dataA dataB) finProdFinEquiv]
+  rw [Matrix.conjTranspose_kronecker, Matrix.mul_kronecker_mul,
+    Matrix.mul_kronecker_mul]
+
+/-- Assemble canonical-form-II data for the independent tensor product.
+
+For retained labels `(a,b)`, the construction uses exactly
+`D_(a,b) = D_a E_b`, `ω_(a,b) = μ_a ν_b`,
+`C_(a,b) = A_a ⊠ B_b`, and
+`Λ_(a,b) = reind (Λ_a ⊗ Γ_b)`.  These are the weighted direct-sum and CFII
+conditions of arXiv:1606.00608, equation `II_CF1`, lines 214--245, and
+Appendix A, equations `TP` and `Lambda`, lines 1054--1077.  The construction
+is project infrastructure for the tensoring sentence in arXiv:1703.09188,
+proof of Theorem `IndexTh` (ii), lines 824--845; that paper does not state it
+as a separate theorem. -/
+noncomputable def tensorProduct (dataA : CPSVCanonicalFormIIData A)
+    (dataB : CPSVCanonicalFormIIData B) :
+    CPSVCanonicalFormIIData (MPSTensor.tensorProduct A B) where
+  r := dataA.r * dataB.r
+  dim := tensorProductDim dataA dataB
+  dim_pos := by
+    intro ab
+    exact Nat.mul_pos (dataA.dim_pos _) (dataB.dim_pos _)
+  weights := tensorProductWeight dataA dataB
+  weights_ne_zero := by
+    intro ab
+    exact mul_ne_zero (dataA.weights_ne_zero _) (dataB.weights_ne_zero _)
+  blocks := tensorProductBlock dataA dataB
+  blocks_normal := by
+    intro ab
+    exact (dataA.blocks_normal _).tensorProduct_of_leftCanonical
+      (dataB.blocks_normal _) (dataA.blocks_left_canonical _)
+      (dataB.blocks_left_canonical _)
+  total_dim_le := by
+    rw [sum_tensorProductDim]
+    exact Nat.mul_le_mul dataA.total_dim_le dataB.total_dim_le
+  ambient_coisometry := tensorProductAmbientCoisometry dataA dataB
+  coisometric := tensorProductAmbientCoisometry_coisometric dataA dataB
+  reconstruct := tensorProduct_reconstruct dataA dataB
+  blocks_left_canonical := by
+    intro ab
+    exact leftCanonical_tensorProduct (dataA.blocks _) (dataB.blocks _)
+      (dataA.blocks_left_canonical _) (dataB.blocks_left_canonical _)
+  blocks_fixed_point := by
+    intro ab
+    obtain ⟨Λ, hΛpos, hΛdiag, hΛfix⟩ :=
+      dataA.blocks_fixed_point (finProdFinEquiv.symm ab).1
+    obtain ⟨Γ, hΓpos, hΓdiag, hΓfix⟩ :=
+      dataB.blocks_fixed_point (finProdFinEquiv.symm ab).2
+    refine ⟨Matrix.reindex finProdFinEquiv finProdFinEquiv (Λ ⊗ₖ Γ), ?_, ?_, ?_⟩
+    · exact (hΛpos.kronecker hΓpos).submatrix finProdFinEquiv.symm.injective
+    · exact (hΛdiag.kronecker hΓdiag).submatrix finProdFinEquiv.symm.injective
+    · exact
+        (transferMap_tensorProduct_kronecker
+          (dataA.blocks (finProdFinEquiv.symm ab).1)
+          (dataB.blocks (finProdFinEquiv.symm ab).2) Λ Γ).trans
+          (by rw [hΛfix, hΓfix])
+
+end CPSVCanonicalFormIIData
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -25,6 +25,8 @@ claim attributed to that passage.
 
 ## Main statement
 
+* `MPSTensor.CPSVCanonicalFormIIData.tensorProduct` assembles canonical-form-II
+  data for the independent tensor product from the two supplied data.
 * `MPSTensor.IsNormalTensor.tensorProduct_of_leftCanonical` preserves CPSV
   normality for two left-canonical normal blocks;
   `MPSTensor.leftCanonical_tensorProduct`

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -146,6 +146,13 @@ namespace CPSVCanonicalFormIIData
 
 variable {A : MPSTensor d D} {B : MPSTensor e E}
 
+/-- Combine heterogeneous equalities coordinatewise. -/
+private theorem prod_heq {α β γ δ : Type} {a : α} {b : β} {c : γ} {d : δ}
+    (hac : a ≍ c) (hbd : b ≍ d) : (a, b) ≍ (c, d) := by
+  cases hac
+  cases hbd
+  rfl
+
 /-- Regroup a pair of dependent coordinates as one dependent coordinate over
 the product label. -/
 private def sigmaProdFiberEquiv {α β : Type*} (γ : α → Type*) (δ : β → Type*) :
@@ -174,6 +181,14 @@ private def tensorProductBlock (dataA : CPSVCanonicalFormIIData A)
     (dataA.blocks (finProdFinEquiv.symm ab).1)
     (dataB.blocks (finProdFinEquiv.symm ab).2)
 
+/-- Product-coordinate equivalence for the fiber over the retained label `(a,b)`. -/
+private noncomputable def tensorProductFiberEquiv
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B)
+    (a : Fin dataA.r) (b : Fin dataB.r) :
+    (Fin (dataA.dim a) × Fin (dataB.dim b)) ≃
+      Fin (tensorProductDim dataA dataB (finProdFinEquiv (a, b))) :=
+  finProdFinEquiv |>.trans (finCongr (by simp [tensorProductDim]))
+
 /-- Canonical retained-coordinate regrouping
 `((a, α), (b, β)) ↦ ((a, b), (α, β))` for the product block family. -/
 private noncomputable def tensorProductRetainedEquiv
@@ -186,9 +201,8 @@ private noncomputable def tensorProductRetainedEquiv
       (finSigmaFinEquiv (m := dataB.r) (n := dataB.dim)).symm) |>.trans
     (sigmaProdFiberEquiv (fun a ↦ Fin (dataA.dim a))
       (fun b ↦ Fin (dataB.dim b))) |>.trans
-    (Equiv.sigmaCongrRight fun _ ↦ finProdFinEquiv) |>.trans
-    (Equiv.sigmaCongr finProdFinEquiv fun ab ↦ finCongr (by
-      simp [tensorProductDim])) |>.trans
+    (Equiv.sigmaCongr finProdFinEquiv fun ab ↦
+      tensorProductFiberEquiv dataA dataB ab.1 ab.2) |>.trans
     finSigmaFinEquiv
 
 @[simp]
@@ -199,12 +213,54 @@ private theorem tensorProductRetainedEquiv_apply
     tensorProductRetainedEquiv dataA dataB
         (finSigmaFinEquiv ⟨a, α⟩, finSigmaFinEquiv ⟨b, β⟩) =
       finSigmaFinEquiv
-        ⟨finProdFinEquiv (a, b),
-          finCongr (by simp [tensorProductDim]) (finProdFinEquiv (α, β))⟩ := by
+        ⟨finProdFinEquiv (a, b), tensorProductFiberEquiv dataA dataB a b (α, β)⟩ := by
   apply finSigmaFinEquiv.symm.injective
   simp only [tensorProductRetainedEquiv, Equiv.sigmaCongr, Equiv.trans_apply,
-    Equiv.prodCongr_apply, Equiv.symm_apply_apply, Equiv.sigmaCongrRight_apply,
-    Equiv.sigmaCongrLeft_apply, sigmaProdFiberEquiv, Equiv.coe_fn_mk]
+    Equiv.prodCongr_apply, Prod.map_apply, Equiv.symm_apply_apply,
+    Equiv.sigmaCongrRight_apply, Equiv.sigmaCongrLeft_apply, sigmaProdFiberEquiv,
+    Equiv.coe_fn_mk]
+
+@[simp]
+private theorem tensorProductBlock_apply
+    (dataA : CPSVCanonicalFormIIData A) (dataB : CPSVCanonicalFormIIData B)
+    (a : Fin dataA.r) (b : Fin dataB.r) (i : Fin d) (k : Fin e)
+    (α γ : Fin (dataA.dim a)) (β δ : Fin (dataB.dim b)) :
+    tensorProductBlock dataA dataB (finProdFinEquiv (a, b))
+        (finProdFinEquiv (i, k)) (tensorProductFiberEquiv dataA dataB a b (α, β))
+        (tensorProductFiberEquiv dataA dataB a b (γ, δ)) =
+      dataA.blocks a i α γ * dataB.blocks b k β δ := by
+  let coord (p : Fin dataA.r × Fin dataB.r) :=
+    Fin (dataA.dim p.1 * dataB.dim p.2)
+  let entry (z : Σ p, coord p × coord p) : ℂ :=
+    MPSTensor.tensorProduct (dataA.blocks z.1.1) (dataB.blocks z.1.2)
+      (finProdFinEquiv (i, k)) z.2.1 z.2.2
+  have hz :
+      (⟨finProdFinEquiv.symm (finProdFinEquiv (a, b)),
+          (tensorProductFiberEquiv dataA dataB a b (α, β),
+            tensorProductFiberEquiv dataA dataB a b (γ, δ))⟩ :
+        Σ p, coord p × coord p) =
+      ⟨(a, b), (finProdFinEquiv (α, β), finProdFinEquiv (γ, δ))⟩ := by
+    apply Sigma.ext (finProdFinEquiv.symm_apply_apply (a, b))
+    have hαβ :
+        tensorProductFiberEquiv dataA dataB a b (α, β) ≍ finProdFinEquiv (α, β) := by
+      simp only [tensorProductFiberEquiv, Equiv.trans_apply, finCongr_apply]
+      rw [Fin.cast_eq_cast]
+      exact cast_heq _ _
+    have hγδ :
+        tensorProductFiberEquiv dataA dataB a b (γ, δ) ≍ finProdFinEquiv (γ, δ) := by
+      simp only [tensorProductFiberEquiv, Equiv.trans_apply, finCongr_apply]
+      rw [Fin.cast_eq_cast]
+      exact cast_heq _ _
+    exact prod_heq hαβ hγδ
+  calc
+    _ = entry
+        ⟨finProdFinEquiv.symm (finProdFinEquiv (a, b)),
+          (tensorProductFiberEquiv dataA dataB a b (α, β),
+            tensorProductFiberEquiv dataA dataB a b (γ, δ))⟩ := rfl
+    _ = entry ⟨(a, b), (finProdFinEquiv (α, β), finProdFinEquiv (γ, δ))⟩ :=
+      congrArg entry hz
+    _ = _ := MPSTensor.tensorProduct_apply (dataA.blocks a) (dataB.blocks b)
+      i k α γ β δ
 
 /-- The weighted direct sum of the product blocks is the retained-coordinate
 reindexing of the Kronecker product of the two weighted direct sums. -/
@@ -238,9 +294,8 @@ private theorem toTensorFromBlocks_tensorProduct
     · subst f
       rw [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_eq,
         Matrix.blockDiagonal'_apply_eq]
-      simp only [tensorProductWeight, tensorProductBlock, tensorProductDim,
-        Equiv.symm_apply_apply, Matrix.smul_apply, finCongr_apply, Fin.cast_eq_self,
-        MPSTensor.tensorProduct_apply, smul_eq_mul]
+      simp only [tensorProductWeight, Equiv.symm_apply_apply, Matrix.smul_apply,
+        tensorProductBlock_apply, smul_eq_mul]
       ring
     · have hab : finProdFinEquiv (a, b) ≠ finProdFinEquiv (a, f) := by
         exact fun h ↦ hbf (congrArg Prod.snd (finProdFinEquiv.injective h))

--- a/TNLean/MPS/CanonicalForm/TensorProduct.lean
+++ b/TNLean/MPS/CanonicalForm/TensorProduct.lean
@@ -202,8 +202,9 @@ private theorem tensorProductRetainedEquiv_apply
         ⟨finProdFinEquiv (a, b),
           finCongr (by simp [tensorProductDim]) (finProdFinEquiv (α, β))⟩ := by
   apply finSigmaFinEquiv.symm.injective
-  simp [tensorProductRetainedEquiv, sigmaProdFiberEquiv, tensorProductDim,
-    Equiv.sigmaCongr]
+  simp only [tensorProductRetainedEquiv, Equiv.sigmaCongr, Equiv.trans_apply,
+    Equiv.prodCongr_apply, Equiv.symm_apply_apply, Equiv.sigmaCongrRight_apply,
+    Equiv.sigmaCongrLeft_apply, sigmaProdFiberEquiv, Equiv.coe_fn_mk]
 
 /-- The weighted direct sum of the product blocks is the retained-coordinate
 reindexing of the Kronecker product of the two weighted direct sums. -/
@@ -231,21 +232,16 @@ private theorem toTensorFromBlocks_tensorProduct
   simp only [Equiv.symm_apply_apply]
   rw [tensorProductRetainedEquiv_apply, tensorProductRetainedEquiv_apply]
   simp only [finSigmaFinEquiv.symm_apply_apply]
-  have hi : (finProdFinEquiv (i, k) : Fin (d * e)).divNat = i :=
-    congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, k))
-  have hk : (finProdFinEquiv (i, k) : Fin (d * e)).modNat = k :=
-    congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, k))
   by_cases hac : a = c
   · subst c
     by_cases hbf : b = f
     · subst f
       rw [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_eq,
         Matrix.blockDiagonal'_apply_eq]
-      have ha := congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (a, b))
-      have hb := congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (a, b))
-      simp [tensorProductWeight, tensorProductBlock, tensorProductDim, hi, hk,
-        ha, hb, Matrix.smul_apply, Matrix.reindex_apply]
-      ring_nf
+      simp only [tensorProductWeight, tensorProductBlock, tensorProductDim,
+        Equiv.symm_apply_apply, Matrix.smul_apply, finCongr_apply, Fin.cast_eq_self,
+        MPSTensor.tensorProduct_apply, smul_eq_mul]
+      ring
     · have hab : finProdFinEquiv (a, b) ≠ finProdFinEquiv (a, f) := by
         exact fun h ↦ hbf (congrArg Prod.snd (finProdFinEquiv.injective h))
       rw [Matrix.blockDiagonal'_apply_ne _ _ _ hab,

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -62,6 +62,22 @@ theorem hasFullSupport_reindexPhysical {d' : ℕ} (data : CPSVCanonicalFormData 
   change ∑ k, data.dim k = D
   exact hfull
 
+end CPSVCanonicalFormData
+
+namespace CPSVCanonicalFormIIData
+
+/-- Full support is preserved when canonical-form-II data are cast along an equality of
+ambient tensors. -/
+theorem hasFullSupport_cast {A B : MPSTensor d D} (data : CPSVCanonicalFormIIData B)
+    (hfull : data.toCPSVCanonicalFormData.HasFullSupport) (h : A = B) :
+    (h.symm ▸ data).toCPSVCanonicalFormData.HasFullSupport := by
+  subst h
+  exact hfull
+
+end CPSVCanonicalFormIIData
+
+namespace CPSVCanonicalFormData
+
 /-- Tensor irreducibility is invariant under simultaneous bond-index reindexing. -/
 private theorem isIrreducibleTensor_reindexBond
     {n m : ℕ} (e : Fin n ≃ Fin m) (B : MPSTensor d n)

--- a/TNLean/MPS/MPU/PhysicalAncilla.lean
+++ b/TNLean/MPS/MPU/PhysicalAncilla.lean
@@ -322,16 +322,6 @@ theorem hasFullSupport_normalizedDiagonalLiftCFIIData
   change ∑ k, data.dim k = D
   exact hfull
 
-/-- Full support is preserved when canonical-form-II data are transported across a tensor
-identity. -/
-private theorem hasFullSupport_castCFIIData
-    {d D : ℕ} {A B : MPSTensor d D} (h : A = B)
-    (data : MPSTensor.CPSVCanonicalFormIIData B)
-    (hfull : data.toCPSVCanonicalFormData.HasFullSupport) :
-    (h.symm ▸ data).toCPSVCanonicalFormData.HasFullSupport := by
-  subst h
-  exact hfull
-
 /-- Construct canonical-form-II data for the normalized flattening after attaching a nonempty
 physical identity ancilla.
 
@@ -365,8 +355,8 @@ theorem hasFullSupport_tensorPhysicalIdCFIIData (U : MPOTensor d D)
   have hshuffle : shuffled.toCPSVCanonicalFormData.HasFullSupport :=
     MPSTensor.CPSVCanonicalFormData.hasFullSupport_reindexPhysical
       lifted.toCPSVCanonicalFormData hlift (finDoubledProdEquiv d x)
-  exact hasFullSupport_castCFIIData
-    (normalizedFlattening_tensorPhysicalId U x hx) shuffled hshuffle
+  exact shuffled.hasFullSupport_cast hshuffle
+    (normalizedFlattening_tensorPhysicalId U x hx)
 
 /-- Identity-ancilla attachment leaves the transfer map of the normalized
 flattening unchanged.

--- a/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
+++ b/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
@@ -124,14 +124,6 @@ noncomputable def tensorProductCFIIData (U : MPOTensor d D) (V : MPOTensor e E)
   (normalizedFlattening_tensorProduct U V).symm ▸
     (dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)
 
-private theorem hasFullSupport_castCFIIData
-    {d D : ℕ} {A B : MPSTensor d D} (h : A = B)
-    (data : MPSTensor.CPSVCanonicalFormIIData B)
-    (hfull : data.toCPSVCanonicalFormData.HasFullSupport) :
-    (h.symm ▸ data).toCPSVCanonicalFormData.HasFullSupport := by
-  subst h
-  exact hfull
-
 /-- The product canonical-form-II data have full support when both supplied
 input data have full support.
 
@@ -150,8 +142,8 @@ theorem hasFullSupport_tensorProductCFIIData (U : MPOTensor d D)
     MPSTensor.CPSVCanonicalFormData.hasFullSupport_reindexPhysical
       (dataU.tensorProduct dataV).toCPSVCanonicalFormData hprod
       (finDoubledProdEquiv d e)
-  exact hasFullSupport_castCFIIData
-    (normalizedFlattening_tensorProduct U V)
-    ((dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)) hreindex
+  exact
+    ((dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)).hasFullSupport_cast
+      hreindex (normalizedFlattening_tensorProduct U V)
 
 end MPOTensor

--- a/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
+++ b/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
@@ -120,9 +120,17 @@ lines 824--845, not a theorem separately stated there. -/
 noncomputable def tensorProductCFIIData (U : MPOTensor d D) (V : MPOTensor e E)
     (dataU : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
     (dataV : MPSTensor.CPSVCanonicalFormIIData V.normalizedFlattening) :
-    MPSTensor.CPSVCanonicalFormIIData (tensorProduct U V).normalizedFlattening := by
-  rw [normalizedFlattening_tensorProduct]
-  exact (dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)
+    MPSTensor.CPSVCanonicalFormIIData (tensorProduct U V).normalizedFlattening :=
+  (normalizedFlattening_tensorProduct U V).symm ▸
+    (dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)
+
+private theorem hasFullSupport_castCFIIData
+    {d D : ℕ} {A B : MPSTensor d D} (h : A = B)
+    (data : MPSTensor.CPSVCanonicalFormIIData B)
+    (hfull : data.toCPSVCanonicalFormData.HasFullSupport) :
+    (h.symm ▸ data).toCPSVCanonicalFormData.HasFullSupport := by
+  subst h
+  exact hfull
 
 /-- The product canonical-form-II data have full support when both supplied
 input data have full support.
@@ -142,6 +150,8 @@ theorem hasFullSupport_tensorProductCFIIData (U : MPOTensor d D)
     MPSTensor.CPSVCanonicalFormData.hasFullSupport_reindexPhysical
       (dataU.tensorProduct dataV).toCPSVCanonicalFormData hprod
       (finDoubledProdEquiv d e)
-  simpa [tensorProductCFIIData] using hreindex
+  exact hasFullSupport_castCFIIData
+    (normalizedFlattening_tensorProduct U V)
+    ((dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)) hreindex
 
 end MPOTensor

--- a/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
+++ b/TNLean/MPS/MPU/TensorProductCanonicalForm.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.CanonicalForm.TensorProduct
 import TNLean.MPS.Core.TensorProduct
+import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.TensorProduct
 import TNLean.MPS.MPU.TransferMatrix
 
 /-!
-# Normalized flattening of an independent tensor product
+# Canonical-form-II data for an independent tensor product
 
 This file identifies the normalized doubled-index MPS tensor of an independent
 MPO tensor product with the independent tensor product of the two normalized
@@ -17,10 +20,18 @@ flattenings.  The physical coordinate is regrouped in the canonical
 product-coordinate order
 `((i, k), (j, l)) ↦ ((i, j), (k, l))`.
 
+It then transports the generic product canonical-form-II data through this
+identity.  Full support is supplied separately for the two input data; it is
+not part of the generic canonical-form construction.
+
 ## Main statement
 
 * `MPOTensor.normalizedFlattening_tensorProduct`: normalized flattening commutes
   with independent tensor products after the doubled-product coordinate change.
+* `MPOTensor.tensorProductCFIIData`: product canonical-form-II data for the
+  normalized flattening.
+* `MPOTensor.hasFullSupport_tensorProductCFIIData`: full support of those data
+  from full support of the two inputs.
 
 ## References
 
@@ -29,7 +40,33 @@ product-coordinate order
   lines 824--845.
 -/
 
-open scoped Matrix Kronecker
+open scoped Matrix Kronecker BigOperators
+
+namespace MPSTensor.CPSVCanonicalFormIIData
+
+variable {d D e E : ℕ} {A : MPSTensor d D} {B : MPSTensor e E}
+
+/-- Full support of two canonical-form-II data is preserved by their
+independent tensor product.
+
+The dimension identity is
+`∑_(a,b) D_a E_b = (∑_a D_a)(∑_b E_b)`.  Full support is a supplied
+reduced-representative restriction, not a statement of CPSV16 or CPSV17; see
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
+theorem hasFullSupport_tensorProduct (dataA : CPSVCanonicalFormIIData A)
+    (dataB : CPSVCanonicalFormIIData B)
+    (hA : dataA.toCPSVCanonicalFormData.HasFullSupport)
+    (hB : dataB.toCPSVCanonicalFormData.HasFullSupport) :
+    (dataA.tensorProduct dataB).toCPSVCanonicalFormData.HasFullSupport := by
+  change
+    (∑ ab : Fin (dataA.r * dataB.r),
+      dataA.dim (finProdFinEquiv.symm ab).1 *
+        dataB.dim (finProdFinEquiv.symm ab).2) = D * E
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  simp only [Equiv.symm_apply_apply]
+  rw [← Fintype.sum_mul_sum, hA, hB]
+
+end MPSTensor.CPSVCanonicalFormIIData
 
 namespace MPOTensor
 
@@ -67,5 +104,44 @@ theorem normalizedFlattening_tensorProduct (U : MPOTensor d D) (V : MPOTensor e 
     Matrix.smul_apply, smul_eq_mul]
   rw [hsqrt, mul_inv]
   ring
+
+/-- Canonical-form-II data for the normalized flattening of an independent
+MPO tensor product.
+
+For retained labels `(a,b)`, this uses the CPSV16 data
+`D_(a,b) = D_a E_b`, `ω_(a,b) = μ_a ν_b`,
+`C_(a,b) = A_a ⊠ B_b`, and the reindexed fixed point
+`Λ_(a,b) = reind (Λ_a ⊗ Γ_b)`.  The canonical-form and CFII conditions are
+arXiv:1606.00608, equation `II_CF1`, lines 214--245, and Appendix A,
+equations `TP` and `Lambda`, lines 1054--1077.  The final physical relabeling
+uses `normalizedFlattening_tensorProduct`.  This is project infrastructure for
+the tensoring sentence in arXiv:1703.09188, proof of Theorem `IndexTh` (ii),
+lines 824--845, not a theorem separately stated there. -/
+noncomputable def tensorProductCFIIData (U : MPOTensor d D) (V : MPOTensor e E)
+    (dataU : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (dataV : MPSTensor.CPSVCanonicalFormIIData V.normalizedFlattening) :
+    MPSTensor.CPSVCanonicalFormIIData (tensorProduct U V).normalizedFlattening := by
+  rw [normalizedFlattening_tensorProduct]
+  exact (dataU.tensorProduct dataV).reindexPhysical (finDoubledProdEquiv d e)
+
+/-- The product canonical-form-II data have full support when both supplied
+input data have full support.
+
+**Scope restriction (full support):** full support selects TNLean's reduced
+representatives and is not asserted by the tensoring sentence in CPSV17.
+Documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
+theorem hasFullSupport_tensorProductCFIIData (U : MPOTensor d D)
+    (V : MPOTensor e E)
+    (dataU : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (dataV : MPSTensor.CPSVCanonicalFormIIData V.normalizedFlattening)
+    (hU : dataU.toCPSVCanonicalFormData.HasFullSupport)
+    (hV : dataV.toCPSVCanonicalFormData.HasFullSupport) :
+    (tensorProductCFIIData U V dataU dataV).toCPSVCanonicalFormData.HasFullSupport := by
+  have hprod := dataU.hasFullSupport_tensorProduct dataV hU hV
+  have hreindex :=
+    MPSTensor.CPSVCanonicalFormData.hasFullSupport_reindexPhysical
+      (dataU.tensorProduct dataV).toCPSVCanonicalFormData hprod
+      (finDoubledProdEquiv d e)
+  simpa [tensorProductCFIIData] using hreindex
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4001,6 +4001,101 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     (\ref{eq:mpu_tensor_normalized_flattening}).
 \end{proof}
 
+\begin{theorem}[Canonical-form-II data under independent tensor products]
+    \label{thm:mpu_tensor_product_cfii_data}
+    \lean{MPSTensor.transferMap_tensorProduct_kronecker,
+        MPSTensor.CPSVCanonicalFormIIData.tensorProduct,
+        MPSTensor.CPSVCanonicalFormIIData.hasFullSupport_tensorProduct,
+        MPOTensor.tensorProductCFIIData,
+        MPOTensor.hasFullSupport_tensorProductCFIIData}
+    \leanok
+    \uses{def:cpsv_cfii, def:mpu_full_support,
+        thm:mps_normal_block_tensor_product,
+        thm:mpu_normalized_flattening_tensor_product,
+        thm:cpsv_physical_reindexing}
+    Let $A$ and $B$ have chosen canonical-form-II data with retained blocks
+    $A_a$ and $B_b$, dimensions $D_a$ and $E_b$, weights $\mu_a$ and $\nu_b$,
+    and diagonal positive-definite fixed points $\Lambda_a$ and $\Gamma_b$.
+    Their independent tensor product has chosen retained data
+    \begin{align}
+        D_{(a,b)} & =D_aE_b,
+    \end{align}
+    \begin{align}
+        \omega_{(a,b)} & =\mu_a\nu_b,
+    \end{align}
+    \begin{align}
+        C_{(a,b)} & =A_a\boxtimes B_b,
+    \end{align}
+    and
+    \begin{align}
+        \Lambda_{(a,b)}
+         & =\operatorname{reind}(\Lambda_a\otimes\Gamma_b).
+    \end{align}
+    The weighted direct sum of these blocks reconstructs $A\boxtimes B$.
+    For MPO tensors $\mathcal U$ and $\mathcal V$, the doubled physical
+    equivalence of
+    Theorem~\ref{thm:mpu_normalized_flattening_tensor_product} identifies these
+    data with canonical-form-II data for
+    $\widetilde{\mathcal U\boxtimes\mathcal V}$.
+
+    Full support is a supplied reduced-representative restriction. If the two
+    chosen input data satisfy
+    \begin{align}
+        \sum_a D_a & =D,
+    \end{align}
+    and
+    \begin{align}
+        \sum_b E_b & =E,
+    \end{align}
+    then the chosen product data satisfy
+    \begin{align}
+        \sum_{a,b}D_aE_b
+         & =\left(\sum_aD_a\right)\left(\sum_bE_b\right)
+          =DE.
+    \end{align}
+    This full-support assertion is not stated by the tensoring sentence in
+    \cite[Theorem~IV.6(ii)]{Cirac2017MPU}; it is the supplied restriction
+    documented in \cite{gap:mpu_canonical_form_full_support}.
+
+    The data considered here do not include the separate weight-normalization
+    condition $|\mu_a|\leq1$ together with the existence of a unit-modulus
+    weight. Preservation of that additional condition is not asserted.
+    Independently, the already formalized raw source-rank formulas are recorded
+    in Theorem~\ref{thm:mpu_tensor_product_source_ranks}; they are not reproved
+    here. This result is project infrastructure and does not prove the MPU
+    Index Theorem or tensor-product additivity of the index.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mps_normal_block_tensor_product,
+        thm:mpu_normalized_flattening_tensor_product,
+        thm:cpsv_physical_reindexing}
+    Regroup retained coordinates by
+    \begin{align}
+        ((a,\alpha),(b,\beta))
+         & \longmapsto((a,b),(\alpha,\beta)).
+    \end{align}
+    Under this equivalence, the Kronecker product of the two weighted block
+    diagonals is the block diagonal with weights $\mu_a\nu_b$ and blocks
+    $A_a\boxtimes B_b$. The Kronecker product of the two ambient coisometries
+    is again coisometric. Left-canonicality and normality follow from
+    Theorem~\ref{thm:mps_normal_block_tensor_product}.
+
+    For arbitrary matrices $X$ and $Y$, direct expansion of the finite Kraus
+    sums gives
+    \begin{align}
+        \mathcal E_{A\boxtimes B}
+        \bigl(\operatorname{reind}(X\otimes Y)\bigr)
+         & =\operatorname{reind}
+        \bigl(\mathcal E_A(X)\otimes\mathcal E_B(Y)\bigr).
+    \end{align}
+    Taking $X=\Lambda_a$ and $Y=\Gamma_b$ proves the fixed-point equation;
+    Kronecker products and bijective reindexing preserve positive definiteness
+    and diagonality. The finite double-sum identity proves the supplied
+    full-support conclusion. Finally apply the normalized-flattening identity
+    and physical relabeling to obtain the MPO statement.
+\end{proof}
+
 \begin{lemma}[Normalized flattening of a composition tensor]
     \label{lem:mpu_normalized_flattening_composition}
     \lean{MPOTensor.normalizedFlattening_mulTensor_apply}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4051,7 +4051,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \sum_{a,b}D_aE_b
          & =\left(\sum_aD_a\right)\left(\sum_bE_b\right)
-          =DE.
+        =DE.
     \end{align}
     This full-support assertion is not stated by the tensoring sentence in
     \cite[Theorem~IV.6(ii)]{Cirac2017MPU}; it is the supplied restriction

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4023,7 +4023,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \chi\bigl((a,\alpha),(b,\beta)\bigr)
          & =\bigl(\pi_{r_A,r_B}(a,b),
-             \pi_{D_a,E_b}(\alpha,\beta)\bigr).
+        \pi_{D_a,E_b}(\alpha,\beta)\bigr).
     \end{align}
     The product ambient coisometry is
     \begin{align}
@@ -4040,20 +4040,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         C_{(a,b)}^{\pi_{d,e}(i,k)}
          & =\operatorname{reind}_{\pi_{D_a,E_b},\pi_{D_a,E_b}}
-            (A_a^i\otimes B_b^k),
+        (A_a^i\otimes B_b^k),
     \end{align}
     and
     \begin{align}
         \Lambda_{(a,b)}
          & =\operatorname{reind}_{\pi_{D_a,E_b},\pi_{D_a,E_b}}
-            (\Lambda_a\otimes\Gamma_b).
+        (\Lambda_a\otimes\Gamma_b).
     \end{align}
     The exact reconstruction is
     \begin{align}
         A\boxtimes B
          & =W^\dagger
-            \left(\bigoplus_{a,b}\mu_a\nu_b
-              (A_a\boxtimes B_b)\right)W.
+        \left(\bigoplus_{a,b}\mu_a\nu_b
+            (A_a\boxtimes B_b)\right)W.
         \label{eq:mpu_tensor_product_cfii_reconstruction}
     \end{align}
     Thus the retained direct sum is conjugated by the reindexed Kronecker
@@ -4087,11 +4087,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
     The data considered here do not include the separate weight-normalization
     condition $|\mu_a|\leq1$ together with the existence of a unit-modulus
-    weight. Preservation of that additional condition is not asserted.
-    Independently, the already formalized raw source-rank formulas are recorded
-    in Theorem~\ref{thm:mpu_tensor_product_source_ranks}; they are not reproved
-    here. This result is project infrastructure and does not prove the MPU
-    Index Theorem or tensor-product additivity of the index.
+    weight. For the same independent tensor product, the raw source ranks
+    satisfy
+    $r(\mathcal U\boxtimes\mathcal V)=r(\mathcal U)r(\mathcal V)$ and
+    $\ell(\mathcal U\boxtimes\mathcal V)=\ell(\mathcal U)\ell(\mathcal V)$ by
+    Theorem~\ref{thm:mpu_tensor_product_source_ranks}. These rank identities do
+    not require the chosen canonical-form-II data or full-support hypotheses
+    above, while the canonical-form construction does not use source ranks.
+    Tensor-product additivity of the index is a separate conclusion.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -4110,9 +4113,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     identity
     \begin{align}
         \bigoplus_{a,b}\mu_a\nu_b
-          C_{(a,b)}^{\pi_{d,e}(i,k)}
+        C_{(a,b)}^{\pi_{d,e}(i,k)}
          & =\operatorname{reind}_{\chi,\chi}
-            (\mathsf B_A^i\otimes\mathsf B_B^k).
+        (\mathsf B_A^i\otimes\mathsf B_B^k).
         \label{eq:mpu_tensor_product_weighted_block_diagonal}
     \end{align}
     Substitute $A^i=V_A^\dagger\mathsf B_A^iV_A$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4006,6 +4006,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.transferMap_tensorProduct_kronecker,
         MPSTensor.CPSVCanonicalFormIIData.tensorProduct,
         MPSTensor.CPSVCanonicalFormIIData.hasFullSupport_tensorProduct,
+        MPSTensor.CPSVCanonicalFormIIData.hasFullSupport_cast,
         MPOTensor.tensorProductCFIIData,
         MPOTensor.hasFullSupport_tensorProductCFIIData}
     \leanok
@@ -4015,8 +4016,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:cpsv_physical_reindexing}
     Let $A$ and $B$ have chosen canonical-form-II data with retained blocks
     $A_a$ and $B_b$, dimensions $D_a$ and $E_b$, weights $\mu_a$ and $\nu_b$,
-    and diagonal positive-definite fixed points $\Lambda_a$ and $\Gamma_b$.
-    Their independent tensor product has chosen retained data
+    diagonal positive-definite fixed points $\Lambda_a$ and $\Gamma_b$, and
+    ambient coisometries $V_A$ and $V_B$. Write $\pi_{m,n}$ for the standard
+    product-coordinate equivalence and let $\chi$ be the retained-coordinate
+    equivalence
+    \begin{align}
+        \chi\bigl((a,\alpha),(b,\beta)\bigr)
+         & =\bigl(\pi_{r_A,r_B}(a,b),
+             \pi_{D_a,E_b}(\alpha,\beta)\bigr).
+    \end{align}
+    The product ambient coisometry is
+    \begin{align}
+        W
+         & =\operatorname{reind}_{\chi,\pi_{D,E}}(V_A\otimes V_B).
+    \end{align}
+    For each retained pair $(a,b)$, the chosen product data are
     \begin{align}
         D_{(a,b)} & =D_aE_b,
     \end{align}
@@ -4024,15 +4038,27 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \omega_{(a,b)} & =\mu_a\nu_b,
     \end{align}
     \begin{align}
-        C_{(a,b)} & =A_a\boxtimes B_b,
+        C_{(a,b)}^{\pi_{d,e}(i,k)}
+         & =\operatorname{reind}_{\pi_{D_a,E_b},\pi_{D_a,E_b}}
+            (A_a^i\otimes B_b^k),
     \end{align}
     and
     \begin{align}
         \Lambda_{(a,b)}
-         & =\operatorname{reind}(\Lambda_a\otimes\Gamma_b).
+         & =\operatorname{reind}_{\pi_{D_a,E_b},\pi_{D_a,E_b}}
+            (\Lambda_a\otimes\Gamma_b).
     \end{align}
-    The weighted direct sum of these blocks reconstructs $A\boxtimes B$.
-    For MPO tensors $\mathcal U$ and $\mathcal V$, the doubled physical
+    The exact reconstruction is
+    \begin{align}
+        A\boxtimes B
+         & =W^\dagger
+            \left(\bigoplus_{a,b}\mu_a\nu_b
+              (A_a\boxtimes B_b)\right)W.
+        \label{eq:mpu_tensor_product_cfii_reconstruction}
+    \end{align}
+    Thus the retained direct sum is conjugated by the reindexed Kronecker
+    ambient coisometry, rather than identified directly with the ambient
+    tensor. For MPO tensors $\mathcal U$ and $\mathcal V$, the doubled physical
     equivalence of
     Theorem~\ref{thm:mpu_normalized_flattening_tensor_product} identifies these
     data with canonical-form-II data for
@@ -4053,7 +4079,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =\left(\sum_aD_a\right)\left(\sum_bE_b\right)
         =DE.
     \end{align}
-    This full-support assertion is not stated by the tensoring sentence in
+    Identifying canonical-form-II data along an equality of ambient tensors
+    leaves this retained-dimension sum unchanged. This full-support assertion
+    is not stated by the tensoring sentence in
     \cite[Theorem~IV.6(ii)]{Cirac2017MPU}; it is the supplied restriction
     documented in \cite{gap:mpu_canonical_form_full_support}.
 
@@ -4070,23 +4098,37 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{thm:mps_normal_block_tensor_product,
         thm:mpu_normalized_flattening_tensor_product,
         thm:cpsv_physical_reindexing}
-    Regroup retained coordinates by
+    For physical labels $i$ and $k$, set
     \begin{align}
-        ((a,\alpha),(b,\beta))
-         & \longmapsto((a,b),(\alpha,\beta)).
+        \mathsf B_A^i & =\bigoplus_a\mu_aA_a^i,
     \end{align}
-    Under this equivalence, the Kronecker product of the two weighted block
-    diagonals is the block diagonal with weights $\mu_a\nu_b$ and blocks
-    $A_a\boxtimes B_b$. The Kronecker product of the two ambient coisometries
-    is again coisometric. Left-canonicality and normality follow from
-    Theorem~\ref{thm:mps_normal_block_tensor_product}.
+    and
+    \begin{align}
+        \mathsf B_B^k & =\bigoplus_b\nu_bB_b^k.
+    \end{align}
+    Regrouping retained coordinates by $\chi$ gives the weighted-block-diagonal
+    identity
+    \begin{align}
+        \bigoplus_{a,b}\mu_a\nu_b
+          C_{(a,b)}^{\pi_{d,e}(i,k)}
+         & =\operatorname{reind}_{\chi,\chi}
+            (\mathsf B_A^i\otimes\mathsf B_B^k).
+        \label{eq:mpu_tensor_product_weighted_block_diagonal}
+    \end{align}
+    Substitute $A^i=V_A^\dagger\mathsf B_A^iV_A$ and
+    $B^k=V_B^\dagger\mathsf B_B^kV_B$. The mixed-product law for Kronecker
+    products and the definition of $W$ then give
+    equation~\eqref{eq:mpu_tensor_product_cfii_reconstruction}. Moreover,
+    $W W^\dagger=1$ follows from
+    $V_AV_A^\dagger=1$ and $V_BV_B^\dagger=1$. Left-canonicality and normality
+    follow from Theorem~\ref{thm:mps_normal_block_tensor_product}.
 
     For arbitrary matrices $X$ and $Y$, direct expansion of the finite Kraus
     sums gives
     \begin{align}
         \mathcal E_{A\boxtimes B}
-        \bigl(\operatorname{reind}(X\otimes Y)\bigr)
-         & =\operatorname{reind}
+        \left(\operatorname{reind}_{\pi_{D,E},\pi_{D,E}}(X\otimes Y)\right)
+         & =\operatorname{reind}_{\pi_{D,E},\pi_{D,E}}
         \bigl(\mathcal E_A(X)\otimes\mathcal E_B(Y)\bigr).
     \end{align}
     Taking $X=\Lambda_a$ and $Y=\Gamma_b$ proves the fixed-point equation;

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1056,6 +1056,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/mgsc18_residual_expansion_empty_word_error.pdf}},
 }
 
+@techreport{gap:mpu_canonical_form_full_support,
+  author      = {The {TNLean} contributors},
+  title       = {Full Support in {MPU} Normality and Theorem {III.8}},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {mpu\_canonical\_form\_full\_support},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/mpu_canonical_form_full_support.pdf}},
+}
+
 @article{Gross2012IndexTheory,
   author       = {Gross, David and Nesme, Vincent and Vogts, H{\'e}ctor and
                   Werner, Reinhard F.},

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -793,6 +793,16 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Full support across tensor-equality casts
+- **Pattern:** `PhysicalAncilla.lean` and `TensorProductCanonicalForm.lean` each
+  carried the same local proof that casting canonical-form-II witness data along
+  an equality of ambient tensors preserves the retained-dimension sum.
+- **Reuse:** `CPSVCanonicalFormIIData.hasFullSupport_cast` in
+  `TNLean/MPS/MPU/CanonicalForm.lean` is the single canonical-form
+  infrastructure lemma used by both constructions.
+- **Result:** both five-line local proofs are removed, and each caller states
+  only its operation-specific tensor equality and full-support witness.
+
 ### Continuous-linear-map extensionality via Mathlib
 - **Pattern:** nine call sites used `ContinuousLinearMap.coe_injective`,
   `DFunLike.ext`, and `intro` to prove equality of continuous linear maps.


### PR DESCRIPTION
## What changed

- preserve CPSV canonical-form-II block data under independent tensor products
- prove the transfer-map Kronecker identity and construct product fixed points with dimensions $D_aE_b$ and weights $\mu_a\nu_b$
- preserve supplied full support and package the result for normalized MPU tensor products
- add a formula-driven Chapter 28 infrastructure node for all five public declarations

This preserves literal `CPSVCanonicalFormIIData` and supplied full support. It does not include the separate weight-normalization predicate, prove index additivity, or complete `IndexTh`.

## Validation

- branch rebased onto current main
- targeted build: 9027/9027
- full cached build before final unrelated-main rebase: 10459/10459
- style and proof-integrity checks
- import aggregators: 37 files, 1080 production modules
- Blueprint synchronization after rebase: 7353/7353
- strict declaration checks
- double LuaLaTeX with zero undefined references or citations

Closes #7085
Advances #7029
