### PR TITLE
feat(parent-hamiltonian): derive the all-length periodic MPS gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -72,6 +72,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
+import TNLean.MPS.ParentHamiltonian.Martingale.FiniteRangeKnabeGap
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -68,6 +68,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
+import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -70,6 +70,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
+import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
@@ -80,6 +81,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
+import TNLean.MPS.ParentHamiltonian.Martingale.QuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
+import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleFullRangeEstimate
@@ -22,6 +23,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
+import TNLean.MPS.ParentHamiltonian.Martingale.QuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
@@ -43,11 +45,15 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The twenty-two components are:
+The twenty-four components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
   (quadratic form implies norm bound);
+* `Martingale.QuadraticFormGap` — a positive operator's norm gap implies the
+  global quadratic-form inequality needed for a finite-range Knabe estimate;
+* `Martingale.FiberwiseQuadraticFormGap` — the same inequality persists when
+  the operator acts independently over a finite spectator coordinate;
 * `Martingale.AnalyticBounds` — the weighted inner-product and C3
   projection-composition inequalities from Nachtergaele's summation;
 * `Martingale.DifferenceProjections` — Nachtergaele's mutually orthogonal

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -10,6 +10,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
+import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
@@ -75,6 +76,8 @@ The twenty-four components are:
   and the projector-defect reduction to an anticommutator estimate;
 * `Martingale.OpenHamiltonian` — the nonwrapping finite-volume Hamiltonian and its
   kernel identification with the open MPS boundary-condition space;
+* `Martingale.CyclicWindowOpenHamiltonian` — cyclic-site coordinates, finite-range
+  disjointness, and the identification of Knabe blocks with fiberwise open Hamiltonians;
 * `Martingale.EmbeddedC2` — the unique fixed-window suffix interaction and
   condition C2 with constant one;
 * `Martingale.C3Threshold` — a uniform input-site overlap length satisfying the

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -13,9 +13,9 @@ import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
+import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
-import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.NachtergaeleFullRangeEstimate

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.DifferenceProjections
 import TNLean.MPS.ParentHamiltonian.Martingale.EmbeddedC2
 import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
+import TNLean.MPS.ParentHamiltonian.Martingale.FiniteRangeKnabeGap
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbient
 import TNLean.MPS.ParentHamiltonian.Martingale.FixedAmbientMartingaleBound
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
@@ -46,7 +47,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The twenty-four components are:
+The twenty-five components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`
@@ -55,6 +56,8 @@ The twenty-four components are:
   global quadratic-form inequality needed for a finite-range Knabe estimate;
 * `Martingale.FiberwiseQuadraticFormGap` — the same inequality persists when
   the operator acts independently over a finite spectator coordinate;
+* `Martingale.FiniteRangeKnabeGap` — the open-window gap implies a uniform
+  periodic parent-Hamiltonian gap with the finite-range Knabe coefficient;
 * `Martingale.AnalyticBounds` — the weighted inner-product and C3
   projection-composition inequalities from Nachtergaele's summation;
 * `Martingale.DifferenceProjections` — Nachtergaele's mutually orthogonal

--- a/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
+import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
+import QICLean.Analysis.FiniteRangeKnabe
+
+/-!
+# Cyclic windows as open parent Hamiltonians
+
+This file identifies a finite cyclic block of periodic parent-Hamiltonian terms
+with the corresponding open-chain Hamiltonian on its active sites.  If the
+periodic interaction range is `R` and the block contains `m` local terms, the
+active interval has exactly `W = m + R - 1` sites.
+
+The construction is the geometric input needed to apply the finite-range Knabe
+inequality after the open-chain gap estimate.  It does not compare periodic and
+open kernels.
+
+## References
+
+* Knabe, J. Stat. Phys. 52, 627 (1988).
+* Pérez-García et al., arXiv:quant-ph/0608197, lines 1483--1489.
+* Cirac--Perez-García--Schuch--Verstraete, arXiv:2011.12127, lines 2194--2197.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The periodic local-term family indexed by the cyclic group of sites. -/
+noncomputable def zmodLocalTermES {N : ℕ} [NeZero N]
+    (A : MPSTensor d D) (R : ℕ) :
+    ZMod N → EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  fun s ↦ localTermES A R ((ZMod.finEquiv N).symm s)
+
+/-- Reindexing periodic local terms by `ZMod N` preserves their total sum. -/
+theorem sum_zmodLocalTermES_eq_parentHamiltonianES {N : ℕ} [NeZero N]
+    (A : MPSTensor d D) (R : ℕ) :
+    (∑ s : ZMod N, zmodLocalTermES A R s) = parentHamiltonianES A R N := by
+  rw [parentHamiltonianES_eq_sum_localTermES]
+  calc
+    (∑ s : ZMod N, zmodLocalTermES A R s) =
+        ∑ i : Fin N, zmodLocalTermES A R (ZMod.finEquiv N i) :=
+      ((ZMod.finEquiv N).toEquiv.sum_comp (zmodLocalTermES A R)).symm
+    _ = ∑ i : Fin N, localTermES A R i := by
+      simp [zmodLocalTermES]
+
+/-- Addition in `ZMod N` is cyclic forward motion on the corresponding finite site. -/
+theorem finEquiv_symm_add_eq_cyclicForwardSite {N : ℕ} [NeZero N]
+    (s : ZMod N) (q : ℕ) :
+    (ZMod.finEquiv N).symm (s + q) =
+      cyclicForwardSite ((ZMod.finEquiv N).symm s) q := by
+  cases N with
+  | zero => exact (NeZero.ne 0 rfl).elim
+  | succ N =>
+      apply Fin.ext
+      change (s.val + (q : ZMod (N + 1)).val) % (N + 1) =
+        (s.val + q) % (N + 1)
+      rw [ZMod.val_natCast, Nat.add_mod_mod]
+
+/-- Two range-`R` cyclic windows are disjoint when their oriented start
+separation `e` satisfies `R ≤ e` and `e + R ≤ N`. -/
+theorem cyclicWindowsDisjoint_cyclicForwardSite_of_oriented_separation
+    {N R e : ℕ} (hR : R ≤ e) (he : e + R ≤ N) (i : Fin N) :
+    CyclicWindowsDisjoint R i (cyclicForwardSite i e) := by
+  intro k hki hkj
+  let a := (k.val + N - i.val) % N
+  let b := (k.val + N - (cyclicForwardSite i e).val) % N
+  have haR : a < R := hki
+  have hbR : b < R := hkj
+  have haN : a < N := by omega
+  have hbN : b < N := by omega
+  have hka : k = cyclicForwardSite i a := by
+    simpa [a, cyclicForwardSite] using
+      eq_cyclic_site_of_offset_eq (Fin.pos i) (i := i) (k := k) (r := a) rfl
+  have hkb : k = cyclicForwardSite (cyclicForwardSite i e) b := by
+    simpa [b, cyclicForwardSite] using
+      eq_cyclic_site_of_offset_eq (Fin.pos (cyclicForwardSite i e))
+        (i := cyclicForwardSite i e) (k := k) (r := b) rfl
+  have hebN : e + b < N := by omega
+  have heq : cyclicForwardSite i a = cyclicForwardSite i (e + b) := by
+    rw [← cyclicForwardSite_forwardSite]
+    exact hka.symm.trans hkb
+  have hval := congrArg Fin.val heq
+  simp only [cyclicForwardSite, Fin.val_mk] at hval
+  have hmodEq : i.val + a ≡ i.val + (e + b) [MOD N] := by
+    simpa [Nat.ModEq] using hval
+  have hcancel : a ≡ e + b [MOD N] :=
+    Nat.ModEq.add_left_cancel (Nat.ModEq.refl i.val) hmodEq
+  have hab : a = e + b := by
+    simpa [Nat.ModEq, Nat.mod_eq_of_lt haN, Nat.mod_eq_of_lt hebN] using hcancel
+  omega
+
+/-- The oriented-separation condition gives the commutation hypothesis used in
+the finite-range Knabe inequality. -/
+theorem zmodLocalTermES_commute_of_oriented_separation {N R e : ℕ} [NeZero N]
+    (A : MPSTensor d D) (hR : R ≤ e) (he : e + R ≤ N)
+    (s : ZMod N) (v : EuclideanSpace ℂ (Cfg d N)) :
+    zmodLocalTermES A R s (zmodLocalTermES A R (s + (e : ZMod N)) v) =
+      zmodLocalTermES A R (s + (e : ZMod N)) (zmodLocalTermES A R s v) := by
+  rw [zmodLocalTermES, zmodLocalTermES,
+    finEquiv_symm_add_eq_cyclicForwardSite]
+  exact localTermES_commute_of_cyclic_windows_disjoint A (by omega)
+    (cyclicWindowsDisjoint_cyclicForwardSite_of_oriented_separation hR he _) v
+
+/-- Split a periodic configuration into a cyclic active block of length `W` and
+its ordered complement. -/
+def cyclicActiveBlockConfigEquiv {N : ℕ} (d W : ℕ) (hWN : W ≤ N) (s : Fin N) :
+    Cfg d N ≃ Cfg d W × Cfg d (N - W) :=
+  ((Equiv.sumArrowEquivProdArrow (Fin W) (Fin (N - W)) (Fin d)).symm.trans
+    (Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d)
+      (cyclicWindowIndexEquiv W N hWN s))).symm
+
+/-- The Hilbert-space reindexing that exposes a cyclic active block and its
+spectator sites. -/
+noncomputable def cyclicActiveBlockConfigLinearIsometryEquiv {N : ℕ}
+    (d W : ℕ) (hWN : W ≤ N) (s : Fin N) :
+    EuclideanSpace ℂ (Cfg d N) ≃ₗᵢ[ℂ]
+      EuclideanSpace ℂ (Cfg d W × Cfg d (N - W)) :=
+  LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ
+    (cyclicActiveBlockConfigEquiv d W hWN s)
+
+/-- Joining active and spectator configurations is the inverse cyclic-block split. -/
+@[simp] theorem cyclicActiveBlockConfigEquiv_symm_apply_window {N W : ℕ}
+    (hWN : W ≤ N) (s : Fin N) (σ : Cfg d W) (τ : Cfg d (N - W))
+    (r : Fin W) :
+    (cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)
+        (cyclicForwardSite s r.val) = σ r := by
+  change Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d)
+      (cyclicWindowIndexEquiv W N hWN s)
+      ((Equiv.sumArrowEquivProdArrow (Fin W) (Fin (N - W)) (Fin d)).symm
+        (σ, τ))
+      (cyclicWindowIndexEquiv W N hWN s (Sum.inl r)) = σ r
+  rw [Equiv.piCongrLeft_apply_apply]
+  rfl
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
@@ -140,4 +140,305 @@ noncomputable def cyclicActiveBlockConfigLinearIsometryEquiv {N : ℕ}
   rw [Equiv.piCongrLeft_apply_apply]
   rfl
 
+/-- The cyclic active-block isometry evaluates by joining the active and
+spectator configurations in cyclic order. -/
+@[simp] theorem cyclicActiveBlockConfigLinearIsometryEquiv_apply_apply {N W : ℕ}
+    (hWN : W ≤ N) (s : Fin N) (v : EuclideanSpace ℂ (Cfg d N))
+    (p : Cfg d W × Cfg d (N - W)) :
+    cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s v p =
+      v ((cyclicActiveBlockConfigEquiv d W hWN s).symm p) := by
+  rw [cyclicActiveBlockConfigLinearIsometryEquiv,
+    LinearIsometryEquiv.piLpCongrLeft_apply]
+  rfl
+
+/-- The inverse cyclic active-block isometry evaluates through the block split. -/
+@[simp] theorem cyclicActiveBlockConfigLinearIsometryEquiv_symm_apply_apply
+    {N W : ℕ} (hWN : W ≤ N) (s : Fin N)
+    (v : EuclideanSpace ℂ (Cfg d W × Cfg d (N - W))) (σ : Cfg d N) :
+    (cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).symm v σ =
+      v (cyclicActiveBlockConfigEquiv d W hWN s σ) := by
+  rw [cyclicActiveBlockConfigLinearIsometryEquiv,
+    LinearIsometryEquiv.piLpCongrLeft_symm,
+    LinearIsometryEquiv.piLpCongrLeft_apply]
+  rfl
+
+/-- The complementary coordinates of the cyclic block occur after all active
+coordinates in cyclic order. -/
+@[simp] theorem cyclicActiveBlockConfigEquiv_symm_apply_spectator {N W : ℕ}
+    (hWN : W ≤ N) (s : Fin N) (σ : Cfg d W) (τ : Cfg d (N - W))
+    (r : Fin (N - W)) :
+    (cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)
+        (cyclicForwardSite s (W + r.val)) = τ r := by
+  change Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d)
+      (cyclicWindowIndexEquiv W N hWN s)
+      ((Equiv.sumArrowEquivProdArrow (Fin W) (Fin (N - W)) (Fin d)).symm
+        (σ, τ))
+      (cyclicWindowIndexEquiv W N hWN s (Sum.inr r)) = τ r
+  rw [Equiv.piCongrLeft_apply_apply]
+  rfl
+
+private theorem cyclicCfg_join_cyclicActiveBlock {N W R : ℕ}
+    (hWN : W ≤ N) (s : Fin N) (q : Fin W)
+    (hqR : q.val + R ≤ W) (ω : Cfg d R) (σ : Cfg d W)
+    (τ : Cfg d (N - W)) :
+    cyclicCfg (Fin.pos s) R (cyclicForwardSite s q.val) ω
+        ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)) =
+      (cyclicActiveBlockConfigEquiv d W hWN s).symm
+        (cyclicCfg (Fin.pos q) R q ω σ, τ) := by
+  funext k
+  let x := (cyclicWindowIndexEquiv W N hWN s).symm k
+  have hkx : cyclicWindowIndexEquiv W N hWN s x = k := by simp [x]
+  rcases x with r | r
+  · rw [← hkx, cyclicWindowIndexEquiv_inl]
+    change cyclicCfg (Fin.pos s) R (cyclicForwardSite s q.val) ω
+        ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ))
+          (cyclicForwardSite s r.val) =
+      (cyclicActiveBlockConfigEquiv d W hWN s).symm
+        (cyclicCfg (Fin.pos q) R q ω σ, τ) (cyclicForwardSite s r.val)
+    rw [cyclicActiveBlockConfigEquiv_symm_apply_window]
+    simp only [cyclicCfg]
+    by_cases hr : q.val ≤ r.val ∧ r.val < q.val + R
+    · have hglobalOffset :
+          ((cyclicForwardSite s r.val).val + N -
+            (cyclicForwardSite s q.val).val) % N = r.val - q.val := by
+          rw [show cyclicForwardSite s r.val =
+              cyclicForwardSite (cyclicForwardSite s q.val) (r.val - q.val) by
+            rw [cyclicForwardSite_forwardSite]
+            congr 1
+            omega]
+          simpa [cyclicForwardSite] using
+            offset_mod_eq (cyclicForwardSite s q.val).isLt (by omega : r.val - q.val < N)
+      have hactiveOffset : (r.val + W - q.val) % W = r.val - q.val := by
+        have hsum : r.val + W - q.val = r.val - q.val + W := by omega
+        rw [hsum, Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : r.val - q.val < W)]
+      rw [dite_eq_left (by rw [hglobalOffset]; omega),
+        dite_eq_left (by rw [hactiveOffset]; omega)]
+      congr 1
+      apply Fin.ext
+      exact hglobalOffset.trans hactiveOffset.symm
+    · have hglobalNot : ¬((cyclicForwardSite s r.val).val + N -
+          (cyclicForwardSite s q.val).val) % N < R := by
+        intro hoff
+        by_cases hqr : q.val ≤ r.val
+        · have hglobalOffset :
+              ((cyclicForwardSite s r.val).val + N -
+                (cyclicForwardSite s q.val).val) % N = r.val - q.val := by
+              rw [show cyclicForwardSite s r.val =
+                  cyclicForwardSite (cyclicForwardSite s q.val) (r.val - q.val) by
+                rw [cyclicForwardSite_forwardSite]
+                congr 1
+                omega]
+              simpa [cyclicForwardSite] using
+                offset_mod_eq (cyclicForwardSite s q.val).isLt
+                  (by omega : r.val - q.val < N)
+          rw [hglobalOffset] at hoff
+          exact hr ⟨hqr, by omega⟩
+        · have hback : N - (q.val - r.val) < R := by
+            have hEq : cyclicForwardSite s r.val =
+                cyclicForwardSite (cyclicForwardSite s q.val)
+                  (N - (q.val - r.val)) := by
+              rw [cyclicForwardSite_forwardSite]
+              apply Fin.ext
+              simp only [cyclicForwardSite, Fin.val_mk]
+              have hqN : q.val < N := by omega
+              have hrN : r.val < N := by omega
+              have hsum : q.val + (N - (q.val - r.val)) = r.val + N := by omega
+              rw [hsum]
+              simpa [Nat.add_assoc] using
+                (Nat.add_mod_right (s.val + r.val) N).symm
+            have hOffset :
+                ((cyclicForwardSite s r.val).val + N -
+                  (cyclicForwardSite s q.val).val) % N = N - (q.val - r.val) := by
+              rw [hEq]
+              simpa [cyclicForwardSite] using
+                offset_mod_eq (cyclicForwardSite s q.val).isLt
+                  (by omega : N - (q.val - r.val) < N)
+            rwa [hOffset] at hoff
+          omega
+      have hactiveNot : ¬(r.val + W - q.val) % W < R := by
+        intro hoff
+        by_cases hqr : q.val ≤ r.val
+        · have hsum : r.val + W - q.val = r.val - q.val + W := by omega
+          rw [hsum, Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : r.val - q.val < W)] at hoff
+          exact hr ⟨hqr, by omega⟩
+        · have hlt : r.val + W - q.val < W := by omega
+          rw [Nat.mod_eq_of_lt hlt] at hoff
+          omega
+      rw [dite_eq_right hglobalNot, dite_eq_right hactiveNot]
+      exact cyclicActiveBlockConfigEquiv_symm_apply_window hWN s σ τ r
+  · rw [← hkx, cyclicWindowIndexEquiv_inr]
+    have hsite :
+        (⟨(s.val + W + r.val) % N, Nat.mod_lt _ (Fin.pos s)⟩ : Fin N) =
+          cyclicForwardSite s (W + r.val) := by
+      apply Fin.ext
+      simp only [cyclicForwardSite, Fin.val_mk]
+      congr 1
+      omega
+    rw [hsite]
+    change cyclicCfg (Fin.pos s) R (cyclicForwardSite s q.val) ω
+        ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ))
+          (cyclicForwardSite s (W + r.val)) =
+      (cyclicActiveBlockConfigEquiv d W hWN s).symm
+        (cyclicCfg (Fin.pos q) R q ω σ, τ)
+          (cyclicForwardSite s (W + r.val))
+    rw [cyclicActiveBlockConfigEquiv_symm_apply_spectator]
+    simp only [cyclicCfg]
+    have hnot : ¬((cyclicForwardSite s (W + r.val)).val + N -
+        (cyclicForwardSite s q.val).val) % N < R := by
+      intro hoff
+      have hdist : W + r.val - q.val < N := by omega
+      have hEq : cyclicForwardSite s (W + r.val) =
+          cyclicForwardSite (cyclicForwardSite s q.val) (W + r.val - q.val) := by
+        rw [cyclicForwardSite_forwardSite]
+        congr 1
+        omega
+      have hOffset :
+          ((cyclicForwardSite s (W + r.val)).val + N -
+            (cyclicForwardSite s q.val).val) % N = W + r.val - q.val := by
+        rw [hEq]
+        simpa [cyclicForwardSite] using
+          offset_mod_eq (cyclicForwardSite s q.val).isLt hdist
+      rw [hOffset] at hoff
+      omega
+    rw [dite_eq_right hnot]
+    exact cyclicActiveBlockConfigEquiv_symm_apply_spectator hWN s σ τ r
+
+private theorem extractWindow_join_cyclicActiveBlock {N W R : ℕ}
+    (hWN : W ≤ N) (s : Fin N) (q : Fin W) (hqR : q.val + R ≤ W)
+    (σ : Cfg d W) (τ : Cfg d (N - W)) :
+    extractWindow R (cyclicForwardSite s q.val)
+        ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)) =
+      extractWindow R q σ := by
+  funext r
+  have hqrW : q.val + r.val < W := by omega
+  have hqrN : q.val + r.val < N := by omega
+  have hsite :
+      cyclicForwardSite (cyclicForwardSite s q.val) r.val =
+        cyclicForwardSite s (q.val + r.val) :=
+    cyclicForwardSite_forwardSite s q.val r.val
+  change (cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)
+      (cyclicForwardSite (cyclicForwardSite s q.val) r.val) =
+    σ ⟨(q.val + r.val) % W, Nat.mod_lt _ (Fin.pos q)⟩
+  rw [hsite, cyclicActiveBlockConfigEquiv_symm_apply_window hWN s σ τ
+    ⟨q.val + r.val, hqrW⟩]
+  congr 1
+  apply Fin.ext
+  simp [Nat.mod_eq_of_lt hqrW]
+
+/-- A periodic range-`R` local term inside a cyclic active block becomes the
+corresponding nonwrapping local term on the active sites, independently on each
+spectator configuration. -/
+theorem localTermES_conj_cyclicActiveBlockConfigLinearIsometryEquiv
+    {N W R : ℕ} (A : MPSTensor d D) (hWN : W ≤ N) (s : Fin N)
+    (q : Fin W) (hqR : q.val + R ≤ W) :
+    (cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).toLinearEquiv.toLinearMap.comp
+        ((localTermES A R (cyclicForwardSite s q.val)).comp
+          (cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).symm.toLinearEquiv.toLinearMap) =
+      (ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - W))
+        (LinearMap.toContinuousLinearMap (localTermES A R q))).toLinearMap := by
+  apply LinearMap.ext
+  intro x
+  apply PiLp.ext
+  rintro ⟨σ, τ⟩
+  simp only [LinearMap.comp_apply]
+  change localTermES A R (cyclicForwardSite s q.val)
+      ((cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).symm x)
+        ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ)) =
+    localTermES A R q (ContinuousLinearMap.rightFiber x τ) σ
+  rw [localTermES_apply A R (cyclicForwardSite s q.val) (by omega),
+    localTermES_apply A R q (by omega)]
+  have hrestrict :
+      cyclicRestrictES (d := d) (Fin.pos (cyclicForwardSite s q.val)) R
+          (cyclicForwardSite s q.val)
+          ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ))
+          ((cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).symm x) =
+        cyclicRestrictES (d := d) (Fin.pos q) R q σ
+          (ContinuousLinearMap.rightFiber x τ) := by
+    apply PiLp.ext
+    intro ω
+    change (cyclicActiveBlockConfigLinearIsometryEquiv d W hWN s).symm x
+        (cyclicCfg (Fin.pos (cyclicForwardSite s q.val)) R
+          (cyclicForwardSite s q.val) ω
+          ((cyclicActiveBlockConfigEquiv d W hWN s).symm (σ, τ))) =
+      x (cyclicCfg (Fin.pos q) R q ω σ, τ)
+    rw [cyclicActiveBlockConfigLinearIsometryEquiv_symm_apply_apply,
+      cyclicCfg_join_cyclicActiveBlock hWN s q hqR]
+    simp
+  rw [hrestrict,
+    extractWindow_join_cyclicActiveBlock hWN s q hqR σ τ]
+
+private def cyclicBlockStartEquiv {R m : ℕ} (hR : 1 ≤ R) :
+    Fin m ≃ NonwrappingStart R (m + R - 1) where
+  toFun q := by
+    have hq := q.isLt
+    let j : Fin (m + R - 1) := ⟨q.val, by omega⟩
+    refine ⟨j, ?_⟩
+    change q.val + R ≤ m + R - 1
+    omega
+  invFun i := ⟨i.1.val, by
+    have hi := i.2
+    omega⟩
+  left_inv q := by
+    apply Fin.ext
+    rfl
+  right_inv i := by
+    apply Subtype.ext
+    apply Fin.ext
+    rfl
+
+/-- A Knabe block of `m` consecutive range-`R` periodic terms is the
+fiberwise open parent Hamiltonian on exactly `m + R - 1` active sites.
+
+The assumptions `1 ≤ R`, `R ≤ m`, and `2 * m ≤ N` ensure that the active
+interval fits inside the periodic chain and contains every one of the `m`
+nonwrapping interaction windows. -/
+theorem cyclicWindowSum_zmodLocalTermES_conj_cyclicActiveBlock
+    {N R m : ℕ} [NeZero N] (A : MPSTensor d D)
+    (hR : 1 ≤ R) (hmR : R ≤ m) (hN : 2 * m ≤ N) (s : ZMod N) :
+    let W := m + R - 1
+    let i := (ZMod.finEquiv N).symm s
+    let U := cyclicActiveBlockConfigLinearIsometryEquiv d W (by omega) i
+    U.toLinearEquiv.toLinearMap.comp
+        ((ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s).comp
+          U.symm.toLinearEquiv.toLinearMap) =
+      (ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - W))
+        (LinearMap.toContinuousLinearMap
+          (openParentHamiltonianES A R W))).toLinearMap := by
+  classical
+  dsimp only
+  let i := (ZMod.finEquiv N).symm s
+  let U := cyclicActiveBlockConfigLinearIsometryEquiv d (m + R - 1) (by omega) i
+  apply LinearMap.ext
+  intro x
+  simp only [ProjectionGeometry.cyclicWindowSum, openParentHamiltonianES,
+    LinearMap.comp_apply, LinearMap.sum_apply, map_sum,
+    ContinuousLinearMap.rightFiberwiseMap_sum]
+  calc
+    (∑ q : Fin m,
+        U (zmodLocalTermES A R (s + (q.val : ZMod N)) (U.symm x))) =
+      ∑ q : Fin m,
+        ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - (m + R - 1)))
+          (LinearMap.toContinuousLinearMap
+            (localTermES A R (cyclicBlockStartEquiv hR q).1)) x := by
+        apply Finset.sum_congr rfl
+        intro q _
+        have hstart : (ZMod.finEquiv N).symm (s + (q.val : ZMod N)) =
+            cyclicForwardSite i q.val := by
+          simpa [i] using finEquiv_symm_add_eq_cyclicForwardSite s q.val
+        change U (localTermES A R ((ZMod.finEquiv N).symm
+            (s + (q.val : ZMod N))) (U.symm x)) = _
+        rw [hstart]
+        exact LinearMap.congr_fun
+          (localTermES_conj_cyclicActiveBlockConfigLinearIsometryEquiv A
+            (by omega) i (cyclicBlockStartEquiv hR q).1
+            (cyclicBlockStartEquiv hR q).2) x
+    _ = ∑ q : NonwrappingStart R (m + R - 1),
+        ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - (m + R - 1)))
+          (LinearMap.toContinuousLinearMap (localTermES A R q.1)) x := by
+      exact Fintype.sum_equiv (cyclicBlockStartEquiv hR) _ _ fun _ ↦ rfl
+    _ = (∑ q : NonwrappingStart R (m + R - 1),
+        ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - (m + R - 1)))
+          (LinearMap.toContinuousLinearMap (localTermES A R q.1))) x := by
+      simp
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
@@ -13,8 +13,8 @@ import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
 
 This file identifies a finite cyclic block of periodic parent-Hamiltonian terms
 with the corresponding open-chain Hamiltonian on its active sites.  If the
-periodic interaction range is `R` and the block contains `m` local terms, the
-active interval has exactly `W = m + R - 1` sites.
+periodic interaction range is \(R\) and the block contains \(m\) local terms, the
+active interval has exactly \(W = m + R - 1\) sites.
 
 The construction is the geometric input needed to apply the finite-range Knabe
 inequality after the open-chain gap estimate.  It does not compare periodic and
@@ -39,7 +39,7 @@ noncomputable def zmodLocalTermES {N : ℕ} [NeZero N]
     ZMod N → EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   fun s ↦ localTermES A R ((ZMod.finEquiv N).symm s)
 
-/-- Reindexing periodic local terms by `ZMod N` preserves their total sum. -/
+/-- Reindexing periodic local terms by \(\mathbb Z/N\mathbb Z\) preserves their total sum. -/
 theorem sum_zmodLocalTermES_eq_parentHamiltonianES {N : ℕ} [NeZero N]
     (A : MPSTensor d D) (R : ℕ) :
     (∑ s : ZMod N, zmodLocalTermES A R s) = parentHamiltonianES A R N := by
@@ -51,7 +51,8 @@ theorem sum_zmodLocalTermES_eq_parentHamiltonianES {N : ℕ} [NeZero N]
     _ = ∑ i : Fin N, localTermES A R i := by
       simp [zmodLocalTermES]
 
-/-- Addition in `ZMod N` is cyclic forward motion on the corresponding finite site. -/
+/-- Addition in \(\mathbb Z/N\mathbb Z\) is cyclic forward motion on the
+corresponding finite site. -/
 theorem finEquiv_symm_add_eq_cyclicForwardSite {N : ℕ} [NeZero N]
     (s : ZMod N) (q : ℕ) :
     (ZMod.finEquiv N).symm (s + q) =
@@ -64,8 +65,8 @@ theorem finEquiv_symm_add_eq_cyclicForwardSite {N : ℕ} [NeZero N]
         (s.val + q) % (N + 1)
       rw [ZMod.val_natCast, Nat.add_mod_mod]
 
-/-- Two range-`R` cyclic windows are disjoint when their oriented start
-separation `e` satisfies `R ≤ e` and `e + R ≤ N`. -/
+/-- Two range-\(R\) cyclic windows are disjoint when their oriented start
+separation \(e\) satisfies \(R \leq e\) and \(e + R \leq N\). -/
 theorem cyclicWindowsDisjoint_cyclicForwardSite_of_oriented_separation
     {N R e : ℕ} (hR : R ≤ e) (he : e + R ≤ N) (i : Fin N) :
     CyclicWindowsDisjoint R i (cyclicForwardSite i e) := by
@@ -109,7 +110,7 @@ theorem zmodLocalTermES_commute_of_oriented_separation {N R e : ℕ} [NeZero N]
   exact localTermES_commute_of_cyclic_windows_disjoint A (by omega)
     (cyclicWindowsDisjoint_cyclicForwardSite_of_oriented_separation hR he _) v
 
-/-- Split a periodic configuration into a cyclic active block of length `W` and
+/-- Split a periodic configuration into a cyclic active block of length \(W\) and
 its ordered complement. -/
 def cyclicActiveBlockConfigEquiv {N : ℕ} (d W : ℕ) (hWN : W ≤ N) (s : Fin N) :
     Cfg d N ≃ Cfg d W × Cfg d (N - W) :=
@@ -325,7 +326,7 @@ private theorem extractWindow_join_cyclicActiveBlock {N W R : ℕ}
   apply Fin.ext
   simp [Nat.mod_eq_of_lt hqrW]
 
-/-- A periodic range-`R` local term inside a cyclic active block becomes the
+/-- A periodic range-\(R\) local term inside a cyclic active block becomes the
 corresponding nonwrapping local term on the active sites, independently on each
 spectator configuration. -/
 theorem localTermES_conj_cyclicActiveBlockConfigLinearIsometryEquiv
@@ -386,11 +387,11 @@ private def cyclicBlockStartEquiv {R m : ℕ} (hR : 1 ≤ R) :
     apply Fin.ext
     rfl
 
-/-- A Knabe block of `m` consecutive range-`R` periodic terms is the
-fiberwise open parent Hamiltonian on exactly `m + R - 1` active sites.
+/-- A Knabe block of \(m\) consecutive range-\(R\) periodic terms is the
+fiberwise open parent Hamiltonian on exactly \(m + R - 1\) active sites.
 
-The assumptions `1 ≤ R`, `R ≤ m`, and `2 * m ≤ N` ensure that the active
-interval fits inside the periodic chain and contains every one of the `m`
+The assumptions \(1 \leq R\), \(R \leq m\), and \(2m \leq N\) ensure that the active
+interval fits inside the periodic chain and contains every one of the \(m\)
 nonwrapping interaction windows. -/
 theorem cyclicWindowSum_zmodLocalTermES_conj_cyclicActiveBlock
     {N R m : ℕ} [NeZero N] (A : MPSTensor d D)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/CyclicWindowOpenHamiltonian.lean
@@ -3,10 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import QICLean.Analysis.FiniteRangeKnabe
 import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian
 import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
-import QICLean.Analysis.FiniteRangeKnabe
 
 /-!
 # Cyclic windows as open parent Hamiltonians

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FiberwiseQuadraticFormGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FiberwiseQuadraticFormGap.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.QuadraticFormGap
+import TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport
+
+/-!
+# Fiberwise lifting of quadratic-form gaps
+
+A quadratic-form inequality for an operator on an active finite configuration
+space remains true when the operator acts independently over a finite right
+spectator coordinate.
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace ContinuousLinearMap
+
+variable {I S : Type*} [Fintype I] [Fintype S]
+
+/-- The inequality \(G^2 \geq \gamma G\) is preserved when \(G\) is applied
+independently on every right-spectator fiber. -/
+theorem quadraticForm_sq_ge_rightFiberwiseMap
+    (G : EuclideanSpace ℂ I →L[ℂ] EuclideanSpace ℂ I) {γ : ℝ}
+    (hG : ∀ u,
+      γ * (⟪G u, u⟫_ℂ).re ≤ (⟪G u, G u⟫_ℂ).re)
+    (v : EuclideanSpace ℂ (I × S)) :
+    γ * (⟪rightFiberwiseMap (S := S) G v, v⟫_ℂ).re ≤
+      (⟪rightFiberwiseMap (S := S) G v,
+        rightFiberwiseMap (S := S) G v⟫_ℂ).re := by
+  classical
+  have hleft : (⟪rightFiberwiseMap (S := S) G v, v⟫_ℂ).re =
+      ∑ s : S, (⟪G (rightFiber v s), rightFiber v s⟫_ℂ).re := by
+    rw [PiLp.inner_apply, Complex.re_sum, Fintype.sum_prod_type, Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro s _
+    rw [PiLp.inner_apply, Complex.re_sum]
+    rfl
+  have hright :
+      (⟪rightFiberwiseMap (S := S) G v,
+        rightFiberwiseMap (S := S) G v⟫_ℂ).re =
+      ∑ s : S, (⟪G (rightFiber v s), G (rightFiber v s)⟫_ℂ).re := by
+    rw [PiLp.inner_apply, Complex.re_sum, Fintype.sum_prod_type, Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro s _
+    rw [PiLp.inner_apply, Complex.re_sum]
+    rfl
+  rw [hleft, hright, Finset.mul_sum]
+  exact Finset.sum_le_sum fun s _ ↦ hG (rightFiber v s)
+
+end ContinuousLinearMap
+
+namespace LinearMap.IsPositive
+
+variable {I S : Type*} [Fintype I] [Fintype S]
+
+/-- A norm gap for a positive active operator supplies the global quadratic-form
+inequality for its independent right-spectator extension. -/
+theorem quadraticForm_sq_ge_rightFiberwiseMap_of_norm_gap
+    (G : EuclideanSpace ℂ I →L[ℂ] EuclideanSpace ℂ I)
+    (hG : G.toLinearMap.IsPositive) {γ : ℝ} (hγ : 0 ≤ γ)
+    (hGap : ∀ u ∈ (LinearMap.ker G.toLinearMap)ᗮ,
+      γ * ‖u‖ ≤ ‖G u‖) :
+    ∀ v : EuclideanSpace ℂ (I × S),
+      γ * (⟪ContinuousLinearMap.rightFiberwiseMap (S := S) G v, v⟫_ℂ).re ≤
+        (⟪ContinuousLinearMap.rightFiberwiseMap (S := S) G v,
+          ContinuousLinearMap.rightFiberwiseMap (S := S) G v⟫_ℂ).re :=
+  ContinuousLinearMap.quadraticForm_sq_ge_rightFiberwiseMap G
+    (hG.quadraticForm_sq_ge_of_norm_gap hγ hGap)
+
+end LinearMap.IsPositive

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
@@ -31,7 +31,7 @@ The arbitrary finite-range coefficient is the TNLean derivation recorded in
 `docs/paper-gaps/knabe88_finite_range_coefficient.tex`.
 -/
 
-open scoped BigOperators InnerProductSpace
+open scoped BigOperators ComplexOrder InnerProductSpace
 
 namespace MPSTensor
 
@@ -46,12 +46,12 @@ The coefficient is the finite-range cyclic Knabe coefficient derived in
 `docs/paper-gaps/knabe88_finite_range_coefficient.tex`. -/
 theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
     (A : MPSTensor d D) {R m : ℕ} (hR : 1 ≤ R) (hmR : R ≤ m)
-    {γ : ℝ} (hnum : ((R - 1 : ℕ) : ℝ) ^ 2 < (m : ℝ) * γ)
+    {γ : ℝ} (hnum : ((R : ℝ) - 1) ^ 2 < (m : ℝ) * γ)
     (hOpenGap : ∀ u ∈
       (LinearMap.ker (openParentHamiltonianES A R (m + R - 1)))ᗮ,
       γ * ‖u‖ ≤ ‖openParentHamiltonianES A R (m + R - 1) u‖) :
-    let δ := ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
-      ((m - R + 1 : ℕ) : ℝ)
+    let δ := ((m : ℝ) * γ - ((R : ℝ) - 1) ^ 2) /
+      ((m : ℝ) - (R : ℝ) + 1)
     0 < δ ∧ ∀ N : ℕ, 2 * m ≤ N → ∀ v ∈
       (LinearMap.ker (parentHamiltonianES A R N))ᗮ,
       δ * ‖v‖ ≤ ‖parentHamiltonianES A R N v‖ := by
@@ -59,17 +59,17 @@ theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
   dsimp only
   have hm : 0 < m := by omega
   have hγ : 0 < γ := by
-    have hsq : 0 ≤ ((R - 1 : ℕ) : ℝ) ^ 2 := sq_nonneg _
+    have hsq : 0 ≤ ((R : ℝ) - 1) ^ 2 := sq_nonneg _
     have hm' : 0 < (m : ℝ) := by exact_mod_cast hm
     nlinarith
-  have hden : 0 < ((m - R + 1 : ℕ) : ℝ) := by positivity
-  have hδ : 0 < ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
-      ((m - R + 1 : ℕ) : ℝ) := div_pos (sub_pos.mpr hnum) hden
+  have hden : 0 < (m : ℝ) - (R : ℝ) + 1 := by exact_mod_cast (by omega : 0 < m - R + 1)
+  have hδ : 0 < ((m : ℝ) * γ - ((R : ℝ) - 1) ^ 2) /
+      ((m : ℝ) - (R : ℝ) + 1) := div_pos (sub_pos.mpr hnum) hden
   refine ⟨hδ, ?_⟩
   intro N hN v hv
-  let δ := ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
-    ((m - R + 1 : ℕ) : ℝ)
-  haveI : NeZero N := ⟨by omega⟩
+  let δ := ((m : ℝ) * γ - ((R : ℝ) - 1) ^ 2) /
+    ((m : ℝ) - (R : ℝ) + 1)
+  let _ : NeZero N := ⟨by omega⟩
   have hProj : ∀ s : ZMod N,
       (zmodLocalTermES A R s).IsSymmetricProjection := by
     intro s
@@ -108,12 +108,6 @@ theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
       rw [hApply]
     rw [hLeft, hRight]
     exact hFiber (U x)
-  have hQuad := ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe
-    (zmodLocalTermES A R) hProj hN hR hmR
-    (fun e heR heN s x ↦ zmodLocalTermES_commute_of_oriented_separation
-      A heR heN s x)
-    (γ := γ) (δ := δ) rfl hnum hWindowGap v
-  rw [sum_zmodLocalTermES_eq_parentHamiltonianES] at hQuad
   exact FrustrationFree.spectralGap_of_martingale_of_finiteDimensional hδ
     (parentHamiltonianES_isPositive A R N) (fun x ↦ by
       have hx := ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe
@@ -131,13 +125,13 @@ The open coefficient is
 `m` is chosen so that `l ^ 2 < m * γ`. -/
 theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
-    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
     ∃ l : ℕ, ∃ ε : ℝ, ∃ m : ℕ, ∃ δ : ℝ,
       1 < l ∧ Kraus.IsNBlkInjective A l ∧
       0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
       l + 1 ≤ m ∧
       δ = ((m : ℝ) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 -
-          (l : ℝ) ^ 2) / ((m - l : ℕ) : ℝ) ∧
+          (l : ℝ) ^ 2) / ((m : ℝ) - (l : ℝ)) ∧
       0 < δ ∧
       ∀ N : ℕ, 2 * m ≤ N → ∀ v ∈
         (LinearMap.ker (parentHamiltonianES A (l + 1) N))ᗮ,
@@ -152,15 +146,17 @@ theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe
   have hγ : 0 < γ := by
     dsimp only [γ]
     positivity
-  obtain ⟨n, hn⟩ := exists_lt_nsmul hγ (l : ℝ) ^ 2
+  obtain ⟨n, hn⟩ := exists_lt_nsmul hγ ((l : ℝ) ^ 2)
   let m := n + l + 1
   have hm : l + 1 ≤ m := by omega
+  have hnm : (n : ℝ) ≤ (m : ℝ) := by exact_mod_cast (by omega : n ≤ m)
   have hnum : (l : ℝ) ^ 2 < (m : ℝ) * γ := by
     calc
       (l : ℝ) ^ 2 < n • γ := hn
-      _ ≤ m • γ := nsmul_le_nsmul_right hγ.le (by omega)
-      _ = (m : ℝ) * γ := by simp [nsmul_eq_mul]
-  let δ := ((m : ℝ) * γ - (l : ℝ) ^ 2) / ((m - l : ℕ) : ℝ)
+      _ = (n : ℝ) * γ := by simp [nsmul_eq_mul]
+      _ ≤ (m : ℝ) * γ := mul_le_mul_of_nonneg_right hnm hγ.le
+  let δ := ((m : ℝ) * γ - (l : ℝ) ^ 2) /
+    ((m : ℝ) - ((l + 1 : ℕ) : ℝ) + 1)
   have hOpenGap' : ∀ u ∈
       (LinearMap.ker (openParentHamiltonianES A (l + 1) (m + l)))ᗮ,
       γ * ‖u‖ ≤ ‖openParentHamiltonianES A (l + 1) (m + l) u‖ := by
@@ -172,7 +168,11 @@ theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe
   have hPeriodic := parentHamiltonianES_gap_of_openParentHamiltonianES_gap
     A (R := l + 1) (m := m) (by omega) hm (γ := γ) (by simpa using hnum)
     (by simpa [γ] using hOpenGap')
-  refine ⟨l, ε, m, δ, hl, hInj, hε, hεlt, hm, rfl, ?_⟩
-  simpa [δ, γ] using hPeriodic
+  refine ⟨l, ε, m, δ, hl, hInj, hε, hεlt, hm, ?_, ?_⟩
+  · dsimp only [δ, γ]
+    congr 1
+    push_cast
+    ring
+  · simpa [δ, γ] using hPeriodic
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
@@ -10,15 +10,15 @@ import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
 /-!
 # Finite-range Knabe gap for MPS parent Hamiltonians
 
-An open-chain norm gap on the `m + R - 1` sites occupied by `m` consecutive
-range-`R` interactions supplies the local quadratic-form input in the cyclic
+An open-chain norm gap on the \(m + R - 1\) sites occupied by \(m\) consecutive
+range-\(R\) interactions supplies the local quadratic-form input in the cyclic
 finite-range Knabe inequality.  The resulting periodic gap is
 
-`δ = (m * γ - (R - 1) ^ 2) / (m - R + 1)`.
+\(\delta = (m\gamma - (R - 1)^2)/(m - R + 1)\).
 
 For a primitive MPS, the open-chain martingale estimate provides
-`γ = (1 - εₗ * sqrt (l + 1)) ^ 2` at range `R = l + 1`.  Choosing `m` so that
-`l ^ 2 < m * γ` gives a positive periodic gap uniformly for `N ≥ 2 * m`.
+\(\gamma = (1 - \varepsilon_l\sqrt{l + 1})^2\) at range \(R = l + 1\).  Choosing \(m\) so that
+\(l^2 < m\gamma\) gives a positive periodic gap uniformly for \(N \geq 2m\).
 
 ## References
 
@@ -40,8 +40,8 @@ variable {d D : ℕ}
 /-- A uniform norm gap for the open Hamiltonian on the active sites of a
 Knabe window gives the finite-range periodic parent-Hamiltonian gap.
 
-Here `m` counts local terms, so the active open volume is exactly
-`W = m + R - 1`.  The hypotheses `R ≤ m` and `2 * m ≤ N` imply `W ≤ N`.
+Here \(m\) counts local terms, so the active open volume is exactly
+\(W = m + R - 1\).  The hypotheses \(R \leq m\) and \(2m \leq N\) imply \(W \leq N\).
 The coefficient is the finite-range cyclic Knabe coefficient derived in
 `docs/paper-gaps/knabe88_finite_range_coefficient.tex`. -/
 theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
@@ -118,11 +118,11 @@ theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
       rwa [sum_zmodLocalTermES_eq_parentHamiltonianES] at hx) v hv
 
 /-- A primitive MPS has a positive finite-range Knabe gap for its canonical
-range-`l + 1` parent Hamiltonian on every periodic chain with `N ≥ 2 * m`.
+range-\(l + 1\) parent Hamiltonian on every periodic chain with \(N \geq 2m\).
 
 The open coefficient is
-`γ = (1 - ε * sqrt (l + 1)) ^ 2`, the active Knabe volume is `m + l`, and
-`m` is chosen so that `l ^ 2 < m * γ`. -/
+\(\gamma = (1 - \varepsilon\sqrt{l + 1})^2\), the active Knabe volume is \(m + l\), and
+\(m\) is chosen so that \(l^2 < m\gamma\). -/
 theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/FiniteRangeKnabeGap.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.CyclicWindowOpenHamiltonian
+import TNLean.MPS.ParentHamiltonian.Martingale.FiberwiseQuadraticFormGap
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenParentGap
+
+/-!
+# Finite-range Knabe gap for MPS parent Hamiltonians
+
+An open-chain norm gap on the `m + R - 1` sites occupied by `m` consecutive
+range-`R` interactions supplies the local quadratic-form input in the cyclic
+finite-range Knabe inequality.  The resulting periodic gap is
+
+`δ = (m * γ - (R - 1) ^ 2) / (m - R + 1)`.
+
+For a primitive MPS, the open-chain martingale estimate provides
+`γ = (1 - εₗ * sqrt (l + 1)) ^ 2` at range `R = l + 1`.  Choosing `m` so that
+`l ^ 2 < m * γ` gives a positive periodic gap uniformly for `N ≥ 2 * m`.
+
+## References
+
+* Knabe, J. Stat. Phys. 52, 627 (1988).
+* Pérez-García et al., arXiv:quant-ph/0608197, lines 1460--1500.
+* Cirac--Perez-García--Schuch--Verstraete, arXiv:2011.12127,
+  lines 2184--2188 and 2194--2197.
+
+The arbitrary finite-range coefficient is the TNLean derivation recorded in
+`docs/paper-gaps/knabe88_finite_range_coefficient.tex`.
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A uniform norm gap for the open Hamiltonian on the active sites of a
+Knabe window gives the finite-range periodic parent-Hamiltonian gap.
+
+Here `m` counts local terms, so the active open volume is exactly
+`W = m + R - 1`.  The hypotheses `R ≤ m` and `2 * m ≤ N` imply `W ≤ N`.
+The coefficient is the finite-range cyclic Knabe coefficient derived in
+`docs/paper-gaps/knabe88_finite_range_coefficient.tex`. -/
+theorem parentHamiltonianES_gap_of_openParentHamiltonianES_gap
+    (A : MPSTensor d D) {R m : ℕ} (hR : 1 ≤ R) (hmR : R ≤ m)
+    {γ : ℝ} (hnum : ((R - 1 : ℕ) : ℝ) ^ 2 < (m : ℝ) * γ)
+    (hOpenGap : ∀ u ∈
+      (LinearMap.ker (openParentHamiltonianES A R (m + R - 1)))ᗮ,
+      γ * ‖u‖ ≤ ‖openParentHamiltonianES A R (m + R - 1) u‖) :
+    let δ := ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
+      ((m - R + 1 : ℕ) : ℝ)
+    0 < δ ∧ ∀ N : ℕ, 2 * m ≤ N → ∀ v ∈
+      (LinearMap.ker (parentHamiltonianES A R N))ᗮ,
+      δ * ‖v‖ ≤ ‖parentHamiltonianES A R N v‖ := by
+  classical
+  dsimp only
+  have hm : 0 < m := by omega
+  have hγ : 0 < γ := by
+    have hsq : 0 ≤ ((R - 1 : ℕ) : ℝ) ^ 2 := sq_nonneg _
+    have hm' : 0 < (m : ℝ) := by exact_mod_cast hm
+    nlinarith
+  have hden : 0 < ((m - R + 1 : ℕ) : ℝ) := by positivity
+  have hδ : 0 < ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
+      ((m - R + 1 : ℕ) : ℝ) := div_pos (sub_pos.mpr hnum) hden
+  refine ⟨hδ, ?_⟩
+  intro N hN v hv
+  let δ := ((m : ℝ) * γ - ((R - 1 : ℕ) : ℝ) ^ 2) /
+    ((m - R + 1 : ℕ) : ℝ)
+  haveI : NeZero N := ⟨by omega⟩
+  have hProj : ∀ s : ZMod N,
+      (zmodLocalTermES A R s).IsSymmetricProjection := by
+    intro s
+    exact localTermES_isSymmetricProjection A R ((ZMod.finEquiv N).symm s)
+  have hWindowGap : ∀ s : ZMod N, ∀ x : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x,
+        x⟫_ℂ).re ≤
+      (⟪ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x,
+        ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x⟫_ℂ).re := by
+    intro s x
+    let W := m + R - 1
+    let i := (ZMod.finEquiv N).symm s
+    let U := cyclicActiveBlockConfigLinearIsometryEquiv d W (by omega) i
+    let G := LinearMap.toContinuousLinearMap (openParentHamiltonianES A R W)
+    let B := ContinuousLinearMap.rightFiberwiseMap (S := Cfg d (N - W)) G
+    have hFiber : ∀ y : EuclideanSpace ℂ (Cfg d W × Cfg d (N - W)),
+        γ * (⟪B y, y⟫_ℂ).re ≤ (⟪B y, B y⟫_ℂ).re := by
+      exact LinearMap.IsPositive.quadraticForm_sq_ge_rightFiberwiseMap_of_norm_gap
+        G (openParentHamiltonianES_isPositive A R W) hγ.le hOpenGap
+    have hConj := cyclicWindowSum_zmodLocalTermES_conj_cyclicActiveBlock
+      A hR hmR hN s
+    have hApply : U (ProjectionGeometry.cyclicWindowSum
+        (zmodLocalTermES A R) m s x) = B (U x) := by
+      have := LinearMap.congr_fun hConj (U x)
+      simpa [U, B, G, W, i] using this
+    have hLeft :
+        (⟪ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x,
+          x⟫_ℂ).re = (⟪B (U x), U x⟫_ℂ).re := by
+      rw [← U.inner_map_map]
+      rw [hApply]
+    have hRight :
+        (⟪ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x,
+          ProjectionGeometry.cyclicWindowSum (zmodLocalTermES A R) m s x⟫_ℂ).re =
+          (⟪B (U x), B (U x)⟫_ℂ).re := by
+      rw [← U.inner_map_map]
+      rw [hApply]
+    rw [hLeft, hRight]
+    exact hFiber (U x)
+  have hQuad := ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe
+    (zmodLocalTermES A R) hProj hN hR hmR
+    (fun e heR heN s x ↦ zmodLocalTermES_commute_of_oriented_separation
+      A heR heN s x)
+    (γ := γ) (δ := δ) rfl hnum hWindowGap v
+  rw [sum_zmodLocalTermES_eq_parentHamiltonianES] at hQuad
+  exact FrustrationFree.spectralGap_of_martingale_of_finiteDimensional hδ
+    (parentHamiltonianES_isPositive A R N) (fun x ↦ by
+      have hx := ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe
+        (zmodLocalTermES A R) hProj hN hR hmR
+        (fun e heR heN s y ↦ zmodLocalTermES_commute_of_oriented_separation
+          A heR heN s y)
+        (γ := γ) (δ := δ) rfl hnum hWindowGap x
+      rwa [sum_zmodLocalTermES_eq_parentHamiltonianES] at hx) v hv
+
+/-- A primitive MPS has a positive finite-range Knabe gap for its canonical
+range-`l + 1` parent Hamiltonian on every periodic chain with `N ≥ 2 * m`.
+
+The open coefficient is
+`γ = (1 - ε * sqrt (l + 1)) ^ 2`, the active Knabe volume is `m + l`, and
+`m` is chosen so that `l ^ 2 < m * γ`. -/
+theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ l : ℕ, ∃ ε : ℝ, ∃ m : ℕ, ∃ δ : ℝ,
+      1 < l ∧ Kraus.IsNBlkInjective A l ∧
+      0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      l + 1 ≤ m ∧
+      δ = ((m : ℝ) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 -
+          (l : ℝ) ^ 2) / ((m - l : ℕ) : ℝ) ∧
+      0 < δ ∧
+      ∀ N : ℕ, 2 * m ≤ N → ∀ v ∈
+        (LinearMap.ker (parentHamiltonianES A (l + 1) N))ᗮ,
+        δ * ‖v‖ ≤ ‖parentHamiltonianES A (l + 1) N v‖ := by
+  obtain ⟨l, ε, hl, hInj, hε, hεlt, hOpenGap⟩ :=
+    hP.exists_openParentHamiltonianES_gap hρ
+  let γ := (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2
+  have hs : 0 < Real.sqrt ((l + 1 : ℕ) : ℝ) :=
+    Real.sqrt_pos.2 (by positivity)
+  have hεs : ε * Real.sqrt ((l + 1 : ℕ) : ℝ) < 1 :=
+    (lt_div_iff₀ hs).mp hεlt
+  have hγ : 0 < γ := by
+    dsimp only [γ]
+    positivity
+  obtain ⟨n, hn⟩ := exists_lt_nsmul hγ (l : ℝ) ^ 2
+  let m := n + l + 1
+  have hm : l + 1 ≤ m := by omega
+  have hnum : (l : ℝ) ^ 2 < (m : ℝ) * γ := by
+    calc
+      (l : ℝ) ^ 2 < n • γ := hn
+      _ ≤ m • γ := nsmul_le_nsmul_right hγ.le (by omega)
+      _ = (m : ℝ) * γ := by simp [nsmul_eq_mul]
+  let δ := ((m : ℝ) * γ - (l : ℝ) ^ 2) / ((m - l : ℕ) : ℝ)
+  have hOpenGap' : ∀ u ∈
+      (LinearMap.ker (openParentHamiltonianES A (l + 1) (m + l)))ᗮ,
+      γ * ‖u‖ ≤ ‖openParentHamiltonianES A (l + 1) (m + l) u‖ := by
+    intro u hu
+    apply hOpenGap (m + l) (by omega) u
+    rw [← ker_openParentHamiltonianES_eq_groundSpaceES_of_isNBlkInjective
+      hInj hl.le (by omega)]
+    exact hu
+  have hPeriodic := parentHamiltonianES_gap_of_openParentHamiltonianES_gap
+    A (R := l + 1) (m := m) (by omega) hm (γ := γ) (by simpa using hnum)
+    (by simpa [γ] using hOpenGap')
+  refine ⟨l, ε, m, δ, hl, hInj, hε, hεlt, hm, rfl, ?_⟩
+  simpa [δ, γ] using hPeriodic
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/QuadraticFormGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/QuadraticFormGap.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Analysis.PositiveGapTransfer
+
+/-!
+# Norm gaps as quadratic-form inequalities
+
+This file records the finite-dimensional positive-operator estimate used to
+supply the local quadratic-form hypothesis in the finite-range Knabe argument.
+A norm gap of a positive operator on the orthogonal complement of its kernel
+implies the global inequality \(H^2 \geq \gamma H\).
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsPositive
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- If a positive operator has norm gap \(\gamma\) on the orthogonal complement
+of its kernel, then it satisfies \(H^2 \geq \gamma H\) as a quadratic form on
+the whole space. -/
+theorem quadraticForm_sq_ge_of_norm_gap {H : E →ₗ[ℂ] E} (hH : H.IsPositive)
+    {γ : ℝ} (hγ : 0 ≤ γ)
+    (hGap : ∀ u ∈ (LinearMap.ker H)ᗮ, γ * ‖u‖ ≤ ‖H u‖) :
+    ∀ v : E,
+      γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re := by
+  classical
+  intro v
+  let w := v - (LinearMap.ker H).starProjection v
+  have hw : w ∈ (LinearMap.ker H)ᗮ :=
+    Submodule.sub_starProjection_mem_orthogonal v
+  have hproj : H ((LinearMap.ker H).starProjection v) = 0 := by
+    rw [← LinearMap.mem_ker]
+    exact Submodule.starProjection_apply_mem _ _
+  have hHw : H w = H v := by
+    simp [w, hproj]
+  have hcross : ⟪H v, (LinearMap.ker H).starProjection v⟫_ℂ = 0 := by
+    rw [hH.isSymmetric v, hproj, inner_zero_right]
+  have hinner : ⟪H v, v⟫_ℂ = ⟪H v, w⟫_ℂ := by
+    calc
+      ⟪H v, v⟫_ℂ = ⟪H v, w + (LinearMap.ker H).starProjection v⟫_ℂ := by
+        congr 1
+        simp [w]
+      _ = ⟪H v, w⟫_ℂ := by rw [inner_add_right, hcross, add_zero]
+  calc
+    γ * (⟪H v, v⟫_ℂ).re = γ * (⟪H v, w⟫_ℂ).re := by rw [hinner]
+    _ ≤ γ * (‖H v‖ * ‖w‖) :=
+      mul_le_mul_of_nonneg_left (re_inner_le_norm (𝕜 := ℂ) (H v) w) hγ
+    _ = ‖H v‖ * (γ * ‖w‖) := by ring
+    _ ≤ ‖H v‖ * ‖H w‖ :=
+      mul_le_mul_of_nonneg_left (hGap w hw) (norm_nonneg _)
+    _ = (⟪H v, H v⟫_ℂ).re := by
+      rw [hHw, ← pow_two]
+      exact (inner_self_eq_norm_sq (𝕜 := ℂ) (H v)).symm
+
+end LinearMap.IsPositive

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4128,9 +4128,9 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     Let $W\leq N$ and fix a site $i$.  Splitting the cyclically ordered sites
     into the first $W$ sites and their complement gives
     \begin{align}
-        [d]^N & \simeq [d]^W\times[d]^{N-W},                              \\
+        [d]^N & \simeq [d]^W\times[d]^{N-W},                 \\
         U_i\colon\ell^2([d]^N)
-          & \longrightarrow\ell^2([d]^W\times[d]^{N-W}).
+              & \longrightarrow\ell^2([d]^W\times[d]^{N-W}).
         \label{eq:cyclic_active_block_isometry}
     \end{align}
     If $(\sigma,\tau)$ is an active configuration and a complementary
@@ -4217,12 +4217,11 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
         lem:right_spectator_quadratic_form_gap,
         thm:finite_range_cyclic_knabe, lem:quadratic_form_to_norm_bound}
     Let $1\leq R\leq m$, put $W=m+R-1$, and suppose that
-    $H^{\mathrm{open}}_{W,R}(A)$ has norm gap $\gamma$:
+    $H^{\mathrm{open}}_{W,R}(A)$ has norm gap $\gamma$.  Thus, for every
+    $u\in(\ker H^{\mathrm{open}}_{W,R}(A))^\perp$,
     \begin{align}
         \gamma\lVert u\rVert
-         & \leq\left\lVert H^{\mathrm{open}}_{W,R}(A)u\right\rVert
-        &&\text{for every }u\in
-        \left(\ker H^{\mathrm{open}}_{W,R}(A)\right)^\perp.
+         & \leq\left\lVert H^{\mathrm{open}}_{W,R}(A)u\right\rVert.
         \label{eq:open_knabe_block_norm_gap}
     \end{align}
     If $(R-1)^2<m\gamma$, define
@@ -4291,8 +4290,8 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     \end{align}
     Set
     \begin{align}
-        R & =l+1,                                                            \\
-        W & =m+R-1=m+l,                                                      \\
+        R & =l+1,                                   \\
+        W & =m+R-1=m+l,                             \\
         \gamma_{\mathrm{open}}
           & =\left(1-\epsilon_l\sqrt{l+1}\right)^2.
         \label{eq:primitive_finite_range_knabe_parameters}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -3785,6 +3785,60 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     rearranging it proves the claim.
 \end{proof}
 
+\begin{lemma}[Norm gap implies the squared quadratic-form bound]
+    \label{lem:norm_gap_to_squared_quadratic_form}
+    \lean{LinearMap.IsPositive.quadraticForm_sq_ge_of_norm_gap}
+    \leanok
+    Let $H$ be a positive operator on a finite-dimensional complex Hilbert
+    space and let $\gamma\geq0$. If
+    \begin{align}
+        \gamma\lVert u\rVert & \leq \lVert Hu\rVert
+        \qquad\text{for every }u\in(\ker H)^\perp,
+    \end{align}
+    then every vector $v$ satisfies
+    \begin{align}
+        \gamma\operatorname{Re}\langle Hv,v\rangle
+         & \leq \operatorname{Re}\langle Hv,Hv\rangle.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Put $w=v-P_{\ker H}v$. Then $w\perp\ker H$, $Hw=Hv$, and symmetry gives
+    $\langle Hv,v\rangle=\langle Hv,w\rangle$. Hence
+    \begin{align}
+        \gamma\operatorname{Re}\langle Hv,v\rangle
+         & \leq \gamma\lVert Hv\rVert\lVert w\rVert
+        \leq \lVert Hv\rVert\lVert Hw\rVert
+        =\operatorname{Re}\langle Hv,Hv\rangle.
+    \end{align}
+\end{proof}
+
+\begin{lemma}[Right-spectator quadratic-form bound]
+    \label{lem:right_spectator_quadratic_form_gap}
+    \lean{ContinuousLinearMap.quadraticForm_sq_ge_rightFiberwiseMap,
+        LinearMap.IsPositive.quadraticForm_sq_ge_rightFiberwiseMap_of_norm_gap}
+    \leanok
+    \uses{lem:norm_gap_to_squared_quadratic_form, lem:right-spectator-extension}
+    Let $G$ act on a finite active configuration space. If
+    $G^2\geq\gamma G$ as a quadratic form, the same inequality holds when $G$
+    acts independently over any finite right spectator coordinate. In
+    particular, positivity and a norm gap $\gamma$ for $G$ imply this
+    fiberwise quadratic-form inequality.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Write $v_s$ for the active vector at spectator value $s$. Both quadratic
+    forms split into finite sums over $s$, and the active inequality gives
+    \begin{align}
+        \gamma\sum_s\operatorname{Re}\langle Gv_s,v_s\rangle
+         & \leq \sum_s\operatorname{Re}\langle Gv_s,Gv_s\rangle.
+    \end{align}
+    The final statement follows from
+    Lemma~\ref{lem:norm_gap_to_squared_quadratic_form}.
+\end{proof}
+
 \begin{theorem}[Cyclic window double counting]
     \label{thm:cyclic_knabe_double_counting}
     \lean{ProjectionGeometry.cyclicWindowSum,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4043,6 +4043,305 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     Theorem~\ref{thm:finite_range_cyclic_knabe}.
 \end{proof}
 
+% Source scope: Papers/quant-ph_0608197/MPSarchive.tex:1460--1500 gives
+% the gap definition, the MPS gap assertion, and the nearest-neighbor Knabe
+% threshold. Papers/2011.12127/TN-Review-main.tex:2184--2188,2194--2197 gives
+% the MPS gap assertion and the nearest-neighbor Knabe principle. The arbitrary
+% finite-range coefficient below is the TNLean derivation documented in
+% docs/paper-gaps/knabe88_finite_range_coefficient.tex.
+
+\begin{definition}[Cyclic coordinates for periodic local interactions]
+    \label{def:cyclic_parent_local_coordinates}
+    \lean{MPSTensor.zmodLocalTermES}
+    \leanok
+    \uses{rem:euclidean_local_projector_ingredients}
+    For an $N$-site periodic chain with $N>0$, index the range-$R$
+    local interactions by $\mathbb Z/N\mathbb Z$.  If
+    $s\in\mathbb Z/N\mathbb Z$ and $i\in\{0,\ldots,N-1\}$ is its standard
+    representative, write
+    \begin{align}
+        h_s^{(N,R)} & =h_{i,\mathrm{ES}}(A,R).
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Total sum in cyclic coordinates]
+    \label{thm:cyclic_parent_local_sum}
+    \lean{MPSTensor.sum_zmodLocalTermES_eq_parentHamiltonianES}
+    \leanok
+    \uses{def:cyclic_parent_local_coordinates, def:parent_hamiltonian_es}
+    The sum over the cyclic coordinates is the periodic parent Hamiltonian:
+    \begin{align}
+        \sum_{s\in\mathbb Z/N\mathbb Z}h_s^{(N,R)}
+         & =H_{N,R}^{\mathrm{ES}}(A).
+        \label{eq:cyclic_parent_local_sum}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cyclic_parent_local_coordinates, def:parent_hamiltonian_es}
+    Reindex the standard sum over $\{0,\ldots,N-1\}$ by its canonical
+    bijection with $\mathbb Z/N\mathbb Z$.  Each summand is unchanged.
+\end{proof}
+
+\begin{theorem}[Oriented separation of cyclic interactions]
+    \label{thm:cyclic_parent_oriented_separation}
+    \lean{MPSTensor.finEquiv_symm_add_eq_cyclicForwardSite,
+        MPSTensor.cyclicWindowsDisjoint_cyclicForwardSite_of_oriented_separation,
+        MPSTensor.zmodLocalTermES_commute_of_oriented_separation}
+    \leanok
+    \uses{def:cyclic_parent_local_coordinates, rem:cyclic_window_operators,
+        lem:cyclic_window_nonoverlap_positive}
+    Let $R\leq e$ and $e+R\leq N$.  Addition by $e$ in
+    $\mathbb Z/N\mathbb Z$ moves the standard representative forward by $e$
+    sites.  The two length-$R$ cyclic windows beginning at $s$ and $s+e$ are
+    disjoint.  Consequently,
+    \begin{align}
+        h_s^{(N,R)}h_{s+e}^{(N,R)}
+         & =h_{s+e}^{(N,R)}h_s^{(N,R)}.
+        \label{eq:cyclic_parent_oriented_commutation}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cyclic_parent_local_coordinates, rem:cyclic_window_operators,
+        lem:cyclic_window_nonoverlap_positive}
+    Measure every site from the first window's initial site in the forward
+    cyclic order.  Membership in both windows would give an offset smaller
+    than $R$ and also an offset of the form $e+b$ with $b<R$.  The inequalities
+    $R\leq e$ and $e+R\leq N$ exclude this possibility.  Local interactions on
+    disjoint cyclic windows commute, which gives
+    (\ref{eq:cyclic_parent_oriented_commutation}).
+\end{proof}
+
+\begin{definition}[Cyclic active-block coordinates]
+    \label{def:cyclic_active_block_coordinates}
+    \lean{MPSTensor.cyclicActiveBlockConfigEquiv,
+        MPSTensor.cyclicActiveBlockConfigLinearIsometryEquiv,
+        MPSTensor.cyclicActiveBlockConfigEquiv_symm_apply_window,
+        MPSTensor.cyclicActiveBlockConfigLinearIsometryEquiv_apply_apply,
+        MPSTensor.cyclicActiveBlockConfigLinearIsometryEquiv_symm_apply_apply,
+        MPSTensor.cyclicActiveBlockConfigEquiv_symm_apply_spectator}
+    \leanok
+    \uses{def:cyclic_window_complement_indexing}
+    Let $W\leq N$ and fix a site $i$.  Splitting the cyclically ordered sites
+    into the first $W$ sites and their complement gives
+    \begin{align}
+        [d]^N & \simeq [d]^W\times[d]^{N-W},                              \\
+        U_i\colon\ell^2([d]^N)
+          & \longrightarrow\ell^2([d]^W\times[d]^{N-W}).
+        \label{eq:cyclic_active_block_isometry}
+    \end{align}
+    If $(\sigma,\tau)$ is an active configuration and a complementary
+    configuration, then their inverse image has value $\sigma_r$ at the site
+    $i+r$ for $0\leq r<W$, and value $\tau_r$ at the site $i+W+r$ for
+    $0\leq r<N-W$.  The isometry and its inverse act by composition with this
+    configuration bijection.
+\end{definition}
+
+\begin{theorem}[A local interaction inside a cyclic active block]
+    \label{thm:cyclic_active_block_local_conjugacy}
+    \lean{MPSTensor.localTermES_conj_cyclicActiveBlockConfigLinearIsometryEquiv}
+    \leanok
+    \uses{def:cyclic_active_block_coordinates,
+        rem:euclidean_local_projector_ingredients, lem:right-spectator-extension}
+    Suppose that $W\leq N$ and $q+R\leq W$.  Under the isometry $U_i$ in
+    (\ref{eq:cyclic_active_block_isometry}), the range-$R$ interaction
+    beginning at the cyclic site $i+q$ becomes the corresponding nonwrapping
+    interaction on the active $W$-site interval, acting independently on the
+    complementary configuration:
+    \begin{align}
+        U_i h_{i+q}^{(N,R)}U_i^{-1}
+         & =\bigl(h_q^{(W,R)}\bigr)^{\oplus[d]^{N-W}}.
+        \label{eq:cyclic_active_block_local_conjugacy}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cyclic_active_block_coordinates,
+        rem:euclidean_local_projector_ingredients, lem:right-spectator-extension}
+    The condition $q+R\leq W$ places the whole interaction window inside the
+    active block.  Joining an active configuration to a complementary one
+    therefore preserves both the extracted length-$R$ word and every
+    configuration obtained by replacing that word.  The local projector acts
+    only on the active coordinates, which proves
+    (\ref{eq:cyclic_active_block_local_conjugacy}) on each complementary
+    configuration.
+\end{proof}
+
+\begin{theorem}[A cyclic Knabe block is an open parent Hamiltonian]
+    \label{thm:cyclic_knabe_block_open_parent_hamiltonian}
+    \lean{MPSTensor.cyclicWindowSum_zmodLocalTermES_conj_cyclicActiveBlock}
+    \leanok
+    \uses{def:cyclic_parent_local_coordinates,
+        def:cyclic_active_block_coordinates,
+        thm:cyclic_active_block_local_conjugacy,
+        def:open_parent_hamiltonian_es}
+    Let $1\leq R\leq m$ and $2m\leq N$, and put
+    \begin{align}
+        W & =m+R-1.
+        \label{eq:cyclic_knabe_active_volume}
+    \end{align}
+    For every $s\in\mathbb Z/N\mathbb Z$, let
+    $A_s=\sum_{q=0}^{m-1}h_{s+q}^{(N,R)}$.  The $m$ interaction windows
+    occupy exactly the $W$ cyclic sites beginning at $s$.  Under the active
+    block isometry $U_s$,
+    \begin{align}
+        U_sA_sU_s^{-1}
+         & =\left(H^{\mathrm{open}}_{W,R}(A)\right)^{\oplus[d]^{N-W}}.
+        \label{eq:cyclic_knabe_block_open_hamiltonian}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cyclic_active_block_local_conjugacy,
+        def:open_parent_hamiltonian_es}
+    The starts $q=0,\ldots,m-1$ are precisely the nonwrapping range-$R$
+    starts in an interval of length $W=m+R-1$.  Apply
+    Theorem~\ref{thm:cyclic_active_block_local_conjugacy} to every summand and
+    reindex the sum by these nonwrapping starts.  Fiberwise extension commutes
+    with finite sums, giving
+    (\ref{eq:cyclic_knabe_block_open_hamiltonian}).
+\end{proof}
+
+\begin{theorem}[Periodic finite-range gap from one open active volume]
+    \label{thm:parent_hamiltonian_gap_from_open_knabe_block}
+    \lean{MPSTensor.parentHamiltonianES_gap_of_openParentHamiltonianES_gap}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es, def:parent_hamiltonian_es,
+        thm:cyclic_parent_local_sum, thm:cyclic_parent_oriented_separation,
+        thm:cyclic_knabe_block_open_parent_hamiltonian,
+        lem:right_spectator_quadratic_form_gap,
+        thm:finite_range_cyclic_knabe, lem:quadratic_form_to_norm_bound}
+    Let $1\leq R\leq m$, put $W=m+R-1$, and suppose that
+    $H^{\mathrm{open}}_{W,R}(A)$ has norm gap $\gamma$:
+    \begin{align}
+        \gamma\lVert u\rVert
+         & \leq\left\lVert H^{\mathrm{open}}_{W,R}(A)u\right\rVert
+        &&\text{for every }u\in
+        \left(\ker H^{\mathrm{open}}_{W,R}(A)\right)^\perp.
+        \label{eq:open_knabe_block_norm_gap}
+    \end{align}
+    If $(R-1)^2<m\gamma$, define
+    \begin{align}
+        \delta
+         & =\frac{m\gamma-(R-1)^2}{m-R+1}.
+        \label{eq:parent_hamiltonian_finite_range_knabe_delta}
+    \end{align}
+    Then $\delta>0$, and for every $N\geq2m$ and every
+    $v\in(\ker H_{N,R}^{\mathrm{ES}}(A))^\perp$,
+    \begin{align}
+        \delta\lVert v\rVert
+         & \leq\left\lVert H_{N,R}^{\mathrm{ES}}(A)v\right\rVert.
+        \label{eq:parent_hamiltonian_finite_range_knabe_gap}
+    \end{align}
+    The coefficient in
+    (\ref{eq:parent_hamiltonian_finite_range_knabe_delta}) is the TNLean
+    finite-range derivation documented in
+    \path{docs/paper-gaps/knabe88_finite_range_coefficient.tex}.  It is not a
+    theorem of the
+    MPS sources cited for the gap definition and the nearest-neighbor Knabe
+    principle.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cyclic_parent_local_sum,
+        thm:cyclic_parent_oriented_separation,
+        thm:cyclic_knabe_block_open_parent_hamiltonian,
+        lem:right_spectator_quadratic_form_gap,
+        thm:finite_range_cyclic_knabe, lem:quadratic_form_to_norm_bound}
+    The norm gap (\ref{eq:open_knabe_block_norm_gap}) and positivity give
+    $(H^{\mathrm{open}}_{W,R})^2\geq\gamma H^{\mathrm{open}}_{W,R}$ as a
+    quadratic form.  Lemma~\ref{lem:right_spectator_quadratic_form_gap} gives
+    the same inequality after adjoining the $N-W$ complementary sites, and
+    Theorem~\ref{thm:cyclic_knabe_block_open_parent_hamiltonian} gives it for
+    every cyclic sum $A_s$.  The oriented-separation theorem verifies the
+    commutation hypothesis in
+    Theorem~\ref{thm:finite_range_cyclic_knabe}.  That theorem gives
+    \begin{align}
+        \delta H_{N,R}^{\mathrm{ES}}(A)
+         & \leq\left(H_{N,R}^{\mathrm{ES}}(A)\right)^2
+    \end{align}
+    as a quadratic form, using the total-sum identity
+    (\ref{eq:cyclic_parent_local_sum}).  The inequality
+    $(R-1)^2<m\gamma$ makes $\delta$ positive, and the finite-dimensional
+    spectral criterion yields
+    (\ref{eq:parent_hamiltonian_finite_range_knabe_gap}).
+\end{proof}
+
+\begin{theorem}[Uniform finite-range gap for primitive MPS parent Hamiltonians]
+    \label{thm:primitive_parent_hamiltonian_finite_range_knabe_gap}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe}
+    \leanok
+    \uses{thm:primitive_open_parent_hamiltonian_gap,
+        thm:open_parent_hamiltonian_kernel_ground_space,
+        thm:parent_hamiltonian_gap_from_open_knabe_block}
+    Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
+    positive-definite fixed point.  There exist $l>1$, $\epsilon_l\geq0$, an
+    integer $m\geq l+1$, and $\delta>0$ such that $A$ is $l$-block injective
+    and
+    \begin{align}
+        \epsilon_l
+         & <\frac{1}{\sqrt{l+1}}.
+        \label{eq:primitive_finite_range_knabe_threshold}
+    \end{align}
+    Set
+    \begin{align}
+        R & =l+1,                                                            \\
+        W & =m+R-1=m+l,                                                      \\
+        \gamma_{\mathrm{open}}
+          & =\left(1-\epsilon_l\sqrt{l+1}\right)^2.
+        \label{eq:primitive_finite_range_knabe_parameters}
+    \end{align}
+    The integer $m$ may be chosen so that
+    \begin{align}
+        l^2 & <m\gamma_{\mathrm{open}},
+        \label{eq:primitive_finite_range_knabe_numerator}
+    \end{align}
+    and
+    \begin{align}
+        \delta
+         & =\frac{m\gamma_{\mathrm{open}}-l^2}{m-l}.
+        \label{eq:primitive_finite_range_knabe_delta}
+    \end{align}
+    For every $N\geq2m$ and every
+    $v\in(\ker H_{N,l+1}^{\mathrm{ES}}(A))^\perp$,
+    \begin{align}
+        \delta\lVert v\rVert
+         & \leq\left\lVert H_{N,l+1}^{\mathrm{ES}}(A)v\right\rVert.
+        \label{eq:primitive_finite_range_knabe_gap}
+    \end{align}
+    The existence of a uniform MPS parent-Hamiltonian gap and the
+    nearest-neighbor Knabe principle are stated in
+    \cite[lines~1460--1500]{PerezGarcia2007Matrix} and
+    \cite[lines~2184--2188,2194--2197]{Cirac2021Matrix}.  Those passages do
+    not state the arbitrary finite-range coefficient
+    (\ref{eq:primitive_finite_range_knabe_delta}).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_open_parent_hamiltonian_gap,
+        thm:open_parent_hamiltonian_kernel_ground_space,
+        thm:parent_hamiltonian_gap_from_open_knabe_block}
+    Theorem~\ref{thm:primitive_open_parent_hamiltonian_gap} gives $l$,
+    $\epsilon_l$, and the norm gap $\gamma_{\mathrm{open}}$ on every open
+    volume at least $l+1$.  Since $\gamma_{\mathrm{open}}>0$, choose
+    $m\geq l+1$ with $l^2<m\gamma_{\mathrm{open}}$.  At the active volume
+    $W=m+l$, block injectivity identifies the open ground space with the kernel
+    of the open Hamiltonian, so
+    (\ref{eq:primitive_open_parent_hamiltonian_gap}) is exactly the hypothesis
+    (\ref{eq:open_knabe_block_norm_gap}) with $R=l+1$.  Apply
+    Theorem~\ref{thm:parent_hamiltonian_gap_from_open_knabe_block}.  Substituting
+    $R-1=l$ and $m-R+1=m-l$ gives
+    (\ref{eq:primitive_finite_range_knabe_delta}) and
+    (\ref{eq:primitive_finite_range_knabe_gap}).
+\end{proof}
+
 \begin{lemma}[Positive gap transfer under Loewner domination]
     \label{lem:positive_gap_transfer_loewner}
     \lean{LinearMap.IsPositive.re_inner_ge_of_norm_gap,

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1699,6 +1699,99 @@ Ref.~\cite{Fannes1992Finitely}. The reconstructed constant is not identified
 with a source dimension-dependent value; the available unweighted conversion
 retains the proved $D^{3/2}$ norm factor inside $g$.
 
+\subsection{Open-to-periodic finite-range conclusion}
+
+The compatible open-chain estimate now gives a periodic gap without a
+restriction to block-divisible lengths.  Let $A$ be primitive with nonzero
+bond dimension and positive-definite fixed point.  The theorem
+\leanid{MPSTensor.IsPrimitiveMPS.exists_openParentHamiltonianES_gap}
+provides $l>1$, $\epsilon_l\geq0$, and the exact open coefficient
+\begin{align}
+    \gamma_{\mathrm{open}}
+    &=\left(1-\epsilon_l\sqrt{l+1}\right)^2,
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_coefficient}\\
+    \epsilon_l
+    &<\frac{1}{\sqrt{l+1}}.
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_threshold}
+\end{align}
+This is the specialization of
+(\ref{eq:cpgsv21_martingale_overlap_nachtergaele_full_range_coefficient})
+with $d_{l+1}=\gamma_{l+1}=1$.  The lower-endpoint argument above is part of
+this MPS specialization.  It does not remove the stronger full-range
+hypothesis from the abstract theorem.
+
+Set
+\begin{align}
+    R&=l+1,
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_range}\\
+    W&=m+R-1=m+l.
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_volume}
+\end{align}
+The cyclic local interactions are indexed by $\mathbb Z/N\mathbb Z$, and
+\leanid{MPSTensor.sum_zmodLocalTermES_eq_parentHamiltonianES} identifies their
+sum with the periodic parent Hamiltonian.  If $R\leq e$ and $e+R\leq N$, then
+\leanid{MPSTensor.zmodLocalTermES_commute_of_oriented_separation} gives
+commutation of the interactions whose initial sites have oriented separation
+$e$.
+
+For every cyclic initial site $s$, the $m$ consecutive interactions beginning
+at $s$ occupy exactly $W$ sites.  The isometry associated with the cyclic
+active block gives
+\begin{align}
+    U_s\left(\sum_{q=0}^{m-1}h_{s+q}^{(N,R)}\right)U_s^{-1}
+    &=\left(H^{\mathrm{open}}_{W,R}(A)\right)^{\oplus[d]^{N-W}}.
+    \label{eq:cpgsv21_martingale_overlap_cyclic_open_block}
+\end{align}
+This is
+\leanid{MPSTensor.cyclicWindowSum_zmodLocalTermES_conj_cyclicActiveBlock}.
+The norm gap in
+(\ref{eq:cpgsv21_martingale_overlap_open_knabe_coefficient}) implies the
+quadratic-form inequality
+\begin{align}
+    \gamma_{\mathrm{open}}
+    \operatorname{Re}\langle H^{\mathrm{open}}_{W,R}u,u\rangle
+    &\leq
+    \operatorname{Re}\langle H^{\mathrm{open}}_{W,R}u,
+        H^{\mathrm{open}}_{W,R}u\rangle.
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_quadratic}
+\end{align}
+The declarations
+\leanid{LinearMap.IsPositive.quadraticForm_sq_ge_of_norm_gap} and
+\leanid{LinearMap.IsPositive.quadraticForm_sq_ge_rightFiberwiseMap_of_norm_gap}
+prove this implication and preserve it under the spectator sum in
+(\ref{eq:cpgsv21_martingale_overlap_cyclic_open_block}).
+
+Since $\gamma_{\mathrm{open}}>0$, choose $m\geq l+1$ such that
+\begin{align}
+    l^2
+    &<m\gamma_{\mathrm{open}}.
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_positive_numerator}
+\end{align}
+The finite-range cyclic inequality then gives
+\begin{align}
+    \delta
+    &=\frac{m\gamma_{\mathrm{open}}-l^2}{m-l}>0,
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_delta}\\
+    \delta\lVert v\rVert
+    &\leq\left\lVert H_{N,l+1}^{\mathrm{ES}}(A)v\right\rVert.
+    \label{eq:cpgsv21_martingale_overlap_open_knabe_periodic_gap}
+\end{align}
+for every $N\geq2m$ and every
+$v\in(\ker H_{N,l+1}^{\mathrm{ES}}(A))^\perp$.  The first general statement is
+\leanid{MPSTensor.parentHamiltonianES_gap_of_openParentHamiltonianES_gap}; the
+primitive-MPS conclusion is
+\leanid{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe}.
+
+The gap definition and the MPS gap assertion occur at lines~1460--1500 of the
+local source for Ref.~\cite{PerezGarcia2007Matrix} and at lines~2184--2188 of
+the local source for Ref.~\cite{Cirac2021Matrix}.  The nearest-neighbor Knabe
+principle occurs at lines~1483--1489 of the first source and
+lines~2194--2197 of the second.  These passages do not state
+(\ref{eq:cpgsv21_martingale_overlap_open_knabe_delta}).  The arbitrary
+finite-range coefficient is the TNLean derivation in
+\path{docs/paper-gaps/knabe88_finite_range_coefficient.tex}.  It is not
+attributed to those papers or to Nachtergaele's martingale theorem.
+
 \section{Verdict}
 
 \textbf{Verdict: scope restriction.} The exact whole-increment algebra, the
@@ -1709,38 +1802,30 @@ of the input tensor; the final chain length counts blocked sites. These bounds
 come from the formal inverse-Gram reconstruction and are not attributed to
 FNW. The optimized FNW numerator and its source constants remain open.
 
-The blocked-to-original comparison is proved for periodic lengths divisible by
-the chosen block length. Under the canonical configuration isometry, each
-blocked range-two term equals the original range-$2p$ term beginning at a block
-boundary. The conjugated blocked Hamiltonian is therefore the sparse sum over
-aligned starts. The omitted original local projections form a non-negative
-quadratic-form remainder. Block injectivity identifies the blocked and original
-kernels with the same periodic MPS line under this isometry. Hence
-\leanid{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul}
-proves
+The earlier blocked-to-original comparison remains valid for periodic lengths
+divisible by the chosen block length.  It gives
+\leanid{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul} and
+the explicit lower bound
 \begin{align}
     \operatorname{gap}(H_{Np,2p}(A))
     &\geq\frac{1}{8}
     \qquad(N\geq4).
     \label{eq:cpgsv21_martingale_overlap_original_aligned_length_gap}
 \end{align}
+That sparse aligned-sum theorem is no longer needed to obtain an all-length
+periodic gap.  The compatible open-chain estimate, cyclic active-block
+identity, and finite-range inequality give
+(\ref{eq:cpgsv21_martingale_overlap_open_knabe_periodic_gap}) for every
+$N\geq2m$.  No periodic boundary coercivity, comparison of unequal kernels,
+periodic uniqueness argument, divisibility substitution, or replacement by a
+different cyclic tensor is used.
 
-This finite cyclic sparse-sum comparison is a TNLean reconstruction.
-Nachtergaele formulates compatible open intervals in
-Equations~(3.12)--(3.16), and the proof of Theorem~2.1(ii) uses the rescaled
-sequence $\widetilde\Lambda_n=\Lambda_{ln}$
-\cite{Nachtergaele1996Spectral}. That source does not state the finite periodic
-operator comparison used here. The remaining case for the unrestricted normal
-MPS theorem consists of chain lengths
-\begin{align}
-    Np+r,
-    \qquad
-    0&<r<p.
-    \label{eq:cpgsv21_martingale_overlap_remainder_lengths}
-\end{align}
-It requires a boundary or remainder comparison that preserves the common
-ground-space complement and a uniform positive constant. No all-length claim
-is made.
+The abstract caveat remains unchanged.  The printed hypotheses of
+\cite[Theorem~2.1(i)]{Nachtergaele1996Spectral} do not control the initial
+indices in the full martingale sum.  The primitive MPS theorem applies because
+the compatible open-chain Hamiltonians make the early C1 and C2 terms vanish
+and the boundary C3 product is zero.  Thus the MPS specialization is complete,
+while the unrestricted abstract full-range identification is not asserted.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- add cyclic `ZMod N` coordinates for periodic parent-Hamiltonian local terms, their total-sum identity, and long-separation commutation
- identify every cyclic window of $m$ range-$R$ terms with the nonwrapping open Hamiltonian on $W=m+R-1$ active sites, acting independently over spectator sites
- convert an open norm gap into the fiberwise quadratic-form inequality required by the finite-range Knabe theorem
- prove the fixed-parameter open-to-periodic gap with
  $$
  \delta=\frac{m\gamma-(R-1)^2}{m-R+1}>0
  $$
  for every $N\ge 2m$
- specialize to primitive MPS with $R=l+1$, $W=m+l$, and
  $$
  \gamma_{\mathrm{open}}
  =\left(1-\epsilon_l\sqrt{l+1}\right)^2,
  \qquad
  \delta
  =\frac{m\gamma_{\mathrm{open}}-l^2}{m-l}>0
  $$
- synchronize Chapter 13 and the CPGSV21 paper-gap note

The nearest-neighbor Knabe principle is traced to the bundled MPS sources. The arbitrary finite-range coefficient is the existing TNLean derivation recorded in `docs/paper-gaps/knabe88_finite_range_coefficient.tex`. The proof uses no periodic boundary coercivity, unequal-kernel transfer, periodic uniqueness, or divisibility restriction.

## Validation

- changed modules with project linter options: 8944/8944
- `lake build TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian`: 9189/9189
- full `lake build`: 10446/10446
- generated import aggregators current: 37 files covering 1071 production modules
- Blueprint source synchronization: 7278/7278 entries, with zero missing changed declarations
- strict `leanblueprint checkdecls`
- paper-gap declarations and all 116 referenced slugs resolved
- pinned `latexindent` and reader-facing prose checks
- double LuaLaTeX: 1057 pages, zero undefined cross-references
- no added `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `git diff --check`

Closes #6412
