### PR TITLE
feat(MPS/MPU): prove swap conjugacy for the third shift family

### DIFF
--- a/TNLean/MPS/MPU/Examples/ShiftTilde.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftTilde.lean
@@ -83,6 +83,90 @@ theorem mpo_shiftExampleTildeU₃ (d N : ℕ) [NeZero N] :
             (Equiv.Perm.permMatrix ℂ (rotateConfig N d))ᴴ) := by
   rw [shiftExampleTildeU₃, mpo_ketLeftMul, mpo_shiftExampleU₃]
 
+private def shiftExampleChainSwap (d N : ℕ) : Equiv.Perm (Fin N → Fin (d * d)) :=
+  (finTupleProdEquiv N d d).trans
+    ((Equiv.prodComm _ _).trans (finTupleProdEquiv N d d).symm)
+
+private def shiftExampleChainU₂ (d N : ℕ) : Equiv.Perm (Fin N → Fin (d * d)) :=
+  (finTupleProdEquiv N d d).trans
+    (((rotateConfig N d).symm.prodCongr (rotateConfig N d)).trans
+      (finTupleProdEquiv N d d).symm)
+
+private def shiftExampleChainU₃ (d N : ℕ) : Equiv.Perm (Fin N → Fin (d * d)) :=
+  (finTupleProdEquiv N d d).trans
+    (((rotateConfig N d).prodCongr (rotateConfig N d).symm).trans
+      (finTupleProdEquiv N d d).symm)
+
+private theorem sitewise_shiftPhysicalSwap_eq_permMatrix (d N : ℕ) :
+    sitewisePhysicalMatrix (shiftPhysicalSwap d) N =
+      Equiv.Perm.permMatrix ℂ (shiftExampleChainSwap d N) := by
+  classical
+  have hchain : shiftExampleChainSwap d N =
+      Equiv.piCongrRight (fun _ : Fin N => bondPairSwapEquiv d) := by
+    apply Equiv.ext
+    intro σ
+    funext n
+    change finProdFinEquiv ((σ n).modNat, (σ n).divNat) = bondPairSwap (σ n)
+    rfl
+  rw [hchain]
+  ext σ τ
+  simp only [sitewisePhysicalMatrix, shiftPhysicalSwap, Equiv.Perm.permMatrix,
+    PEquiv.toMatrix_apply]
+  rw [Fintype.prod_boole]
+  simp [funext_iff]
+
+private theorem shiftExampleU₂_chain_eq_permMatrix (d N : ℕ) :
+    Matrix.reindex (finTupleProdEquiv N d d).symm
+          (finTupleProdEquiv N d d).symm
+          ((Equiv.Perm.permMatrix ℂ (rotateConfig N d))ᴴ ⊗ₖ
+            Equiv.Perm.permMatrix ℂ (rotateConfig N d)) =
+      Equiv.Perm.permMatrix ℂ (shiftExampleChainU₂ d N) := by
+  classical
+  ext σ τ
+  simp [shiftExampleChainU₂, Equiv.Perm.permMatrix, PEquiv.toMatrix_apply,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply, Equiv.symm_apply_eq,
+    Prod.ext_iff, ite_and]
+  split <;> simp_all
+
+private theorem shiftExampleU₃_chain_eq_permMatrix (d N : ℕ) :
+    Matrix.reindex (finTupleProdEquiv N d d).symm
+          (finTupleProdEquiv N d d).symm
+          (Equiv.Perm.permMatrix ℂ (rotateConfig N d) ⊗ₖ
+            (Equiv.Perm.permMatrix ℂ (rotateConfig N d))ᴴ) =
+      Equiv.Perm.permMatrix ℂ (shiftExampleChainU₃ d N) := by
+  classical
+  ext σ τ
+  simp [shiftExampleChainU₃, Equiv.Perm.permMatrix, PEquiv.toMatrix_apply,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply, Equiv.symm_apply_eq,
+    Prod.ext_iff, ite_and]
+  split <;> simp_all
+
+private theorem shiftExampleChain_conjugacy (d N : ℕ) :
+    (shiftExampleChainSwap d N).trans (shiftExampleChainU₃ d N) =
+      (((shiftExampleChainSwap d N).trans (shiftExampleChainSwap d N)).trans
+        (shiftExampleChainU₂ d N)).trans (shiftExampleChainSwap d N) := by
+  apply Equiv.ext
+  intro σ
+  simp [shiftExampleChainSwap, shiftExampleChainU₂, shiftExampleChainU₃]
+
+/-- Exact all-chain conjugacy
+$\widetilde U_3^{(N)}=\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}$.
+
+Source: arXiv:1703.09188, equation `tildeU3` (lines 2059--2062). -/
+theorem mpo_shiftExampleTildeU₃_eq_swap_mul_tildeU₂_mul_swap
+    (d N : ℕ) [NeZero N] :
+    mpo (shiftExampleTildeU₃ d) N =
+      sitewisePhysicalMatrix (shiftPhysicalSwap d) N *
+        mpo (shiftExampleTildeU₂ d) N *
+          sitewisePhysicalMatrix (shiftPhysicalSwap d) N := by
+  rw [mpo_shiftExampleTildeU₃, mpo_shiftExampleTildeU₂,
+    sitewise_shiftPhysicalSwap_eq_permMatrix,
+    shiftExampleU₂_chain_eq_permMatrix, shiftExampleU₃_chain_eq_permMatrix]
+  rw [← Matrix.permMatrix_mul, ← Matrix.permMatrix_mul,
+    ← Matrix.permMatrix_mul, ← Matrix.permMatrix_mul]
+  congr 1
+  exact shiftExampleChain_conjugacy d N
+
 /-- $\widetilde U_1$ is an MPU. -/
 theorem shiftExampleTildeU₁_isMPU (d : ℕ) : IsMPU (shiftExampleTildeU₁ d) :=
   (shiftExampleU₁_isMPU d).ketLeftMul (shiftPhysicalSwap_mem_unitaryGroup d)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8576,16 +8576,34 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Thus the sitewise left action preserves the MPU property.
 \end{proof}
 
-\begin{theorem}[Remaining swap-transformation identities]
-    \label{thm:threeMPU2_remaining_formulas}
-    \notready
-    \discussion{5715}
-    \uses{threeMPU2, thm:threeMPU2_chain_formulas, def:mpu_source_uv}
-    The third transformed family also satisfies
+\begin{theorem}[Conjugacy of the third swap-transformed shift]
+    \label{tildeU3}
+    \lean{MPOTensor.mpo_shiftExampleTildeU₃_eq_swap_mul_tildeU₂_mul_swap}
+    \leanok
+    \uses{threeMPU2, thm:threeMPU2_chain_formulas}
+    On every nonempty chain,
     \begin{align}
         \widetilde U_3^{(N)}
         =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}.
     \end{align}
+    % Source lines: paper_v2.tex 2059--2062, label tildeU3.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:threeMPU2_chain_formulas}
+    Split each physical configuration into its two spin configurations.  The
+    three operators are permutation matrices.  In these coordinates,
+    $\mathbb S^{\otimes N}$ exchanges the two configurations,
+    $U_2^{(N)}$ acts by $(T^{(N)\dagger},T^{(N)})$, and $U_3^{(N)}$ acts by
+    $(T^{(N)},T^{(N)\dagger})$.  Exchanging the two factors on both sides of
+    the second action gives the third, which proves the identity.
+\end{proof}
+
+\begin{theorem}[Standard forms of the swap-transformed shifts]
+    \label{thm:threeMPU2_remaining_formulas}
+    \notready
+    \discussion{5715}
+    \uses{threeMPU2, def:mpu_source_uv}
     The first two standard forms are
     \begin{align}
         \widetilde u_1 & =\mathbb S,     &
@@ -8593,7 +8611,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \widetilde u_2 & =\Id\otimes\Id, &
         \widetilde v_2 & =\mathbb S.
     \end{align}
-    % Source lines: paper_v2.tex 2059--2099.
+    % Source lines: paper_v2.tex 2087--2099.
 \end{theorem}
 
 \begin{lemma}[Transformation with swaps and symmetry equivalence]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8577,7 +8577,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{proof}
 
 \begin{theorem}[Conjugacy of the third swap-transformed shift]
-    \label{tildeU3}
+    \label{thm:tildeU3}
     \lean{MPOTensor.mpo_shiftExampleTildeU₃_eq_swap_mul_tildeU₂_mul_swap}
     \leanok
     \uses{threeMPU2, thm:threeMPU2_chain_formulas}
@@ -8586,7 +8586,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \widetilde U_3^{(N)}
         =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}.
     \end{align}
-    % Source lines: paper_v2.tex 2059--2062, label tildeU3.
+    This is the conjugacy identity in
+    \cite[lines~2059--2062]{Cirac2017MPU}.
+    % Source label: tildeU3.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## What changed

- prove the exact all-chain CPSV17 identity
  \[
  \widetilde U_3^{(N)}
  =\mathbb S^{\otimes N}\widetilde U_2^{(N)}\mathbb S^{\otimes N}
  \]
  from the existing finite-chain shift formulas
- express the sitewise swap and both shift families as permutation matrices in split spin coordinates, then prove the conjugacy at the permutation level
- split the combined Chapter 28 node so equation `tildeU3` is checked independently while the paper standard forms remain `\notready` under #7567

This slice is independent of the source-cut orientation repair in #7558 / PR #7563 and does not touch `sourceU`, `sourceV`, or compact-SVD choices.

## Validation

- `lake build TNLean.MPS.MPU.Examples.ShiftTilde` (9214/9214, exact hot-main cache)
- repository style linter
- proof-integrity scan
- Blueprint scanner tests
- Blueprint source synchronization (7279/7279 theorem-like entries; Chapter 28 950/950 tagged entries resolve)
- strict `leanblueprint checkdecls`
- double LuaLaTeX with zero undefined cross-references; pre-existing citation warnings only
- `git diff --check`

Closes #7566
Advances #7528
Advances #5715
