### PR TITLE
feat(algebra): formalize the local Gauss representation

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -20,6 +20,7 @@ import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FiniteGroupUnitaryAverage
 import TNLean.Algebra.FinsetSubtypeSum
 import TNLean.Algebra.FixedPointFreeInvolutionSign
+import TNLean.Algebra.GaussRepresentation
 import TNLean.Algebra.GeneralizedCocycle
 import TNLean.Algebra.GeneralizedCocycleInversion
 import TNLean.Algebra.LSymbol

--- a/TNLean/Algebra/GaussRepresentation.lean
+++ b/TNLean/Algebra/GaussRepresentation.lean
@@ -56,7 +56,7 @@ theorem gaussLegAction_mul (g h : G) :
     gaussLegAction g * gaussLegAction h = gaussLegAction (g * h) := by
   ext p <;> simp [gaussLegAction, mul_assoc]
 
-variable [Fintype G] [DecidableEq G] [Fintype n] [DecidableEq n]
+variable [Fintype n] [DecidableEq n]
 
 /-- The local Gauss operator whose unique nonzero gauge block in column
 `(a,b)` lies in row `T_g(a,b)` and equals
@@ -75,7 +75,6 @@ def gaussOperator (R : G → G → Matrix.unitaryGroup n ℂ) (g : G) :
         Matrix n n ℂ) x.1 y.1
     else 0
 
-omit [Fintype G] in
 /-- The nonzero block of the Gauss operator is the factorization comparison
 specified in FBC25, Equation `eq:mcG`. -/
 @[simp]
@@ -87,7 +86,6 @@ theorem gaussOperator_apply_target
   classical
   simp [gaussOperator]
 
-omit [Fintype G] in
 /-- Every other gauge block in a fixed column of the Gauss operator vanishes. -/
 @[simp]
 theorem gaussOperator_apply_of_ne
@@ -97,15 +95,7 @@ theorem gaussOperator_apply_of_ne
   classical
   simp [gaussOperator, hxy]
 
-omit [Group G] [Fintype G] [DecidableEq G] in
-/-- The inverse of a factorization comparison is the comparison in the
-opposite direction. -/
-@[simp]
-theorem unitaryFactorizationComparison_inv
-    (R : G → G → Matrix.unitaryGroup n ℂ) (a b c d : G) :
-    (Matrix.unitaryFactorizationComparison R a b c d)⁻¹ =
-      Matrix.unitaryFactorizationComparison R c d a b := by
-  simp [Matrix.unitaryFactorizationComparison]
+variable [Fintype G]
 
 /-- Local Gauss operators multiply according to the group law. This is the
 first conclusion of FBC25, Proposition `prop:gausslaws`
@@ -117,11 +107,11 @@ theorem gaussOperator_mul
   ext x y
   rw [Matrix.mul_apply, Fintype.sum_prod_type, Finset.sum_comm]
   rw [Fintype.sum_eq_single (gaussLegAction h y.2)]
-  · by_cases hxy : x.2 = gaussLegAction (g * h) y.2
-    · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
-          gaussLegAction (g * h) y.2 := by
-        simp [gaussLegAction, mul_assoc]
-      have hx : x.2 = gaussLegAction g (gaussLegAction h y.2) :=
+  · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
+        gaussLegAction (g * h) y.2 := by
+      simp [gaussLegAction, mul_assoc]
+    by_cases hxy : x.2 = gaussLegAction (g * h) y.2
+    · have hx : x.2 = gaussLegAction g (gaussLegAction h y.2) :=
         hxy.trans hcomp.symm
       simp only [gaussOperator, hx, hcomp, ite_true]
       rw [← Matrix.mul_apply]
@@ -129,14 +119,13 @@ theorem gaussOperator_mul
         (Matrix.unitaryFactorizationComparison_trans R y.2.1 y.2.2
           (gaussLegAction h y.2).1 (gaussLegAction h y.2).2
           (gaussLegAction (g * h) y.2).1 (gaussLegAction (g * h) y.2).2)) x.1 y.1).symm
-    · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
-          gaussLegAction (g * h) y.2 := by
-        simp [gaussLegAction, mul_assoc]
-      have hx : x.2 ≠ gaussLegAction g (gaussLegAction h y.2) := fun heq ↦
+    · have hx : x.2 ≠ gaussLegAction g (gaussLegAction h y.2) := fun heq ↦
         hxy (heq.trans hcomp)
       simp [gaussOperator, hx, hxy]
   · intro q hq
     simp [gaussOperator, hq]
+
+variable [DecidableEq G]
 
 omit [Fintype G] in
 /-- The Gauss operator of the identity group element is the identity matrix. -/
@@ -155,7 +144,7 @@ theorem gaussOperator_one (R : G → G → Matrix.unitaryGroup n ℂ) :
   · have hfull : x ≠ y := fun h ↦ hxy (congrArg Prod.snd h)
     simp [gaussOperator, hxy, hfull]
 
-omit [Fintype G] in
+omit [Fintype G] [DecidableEq G] in
 /-- The adjoint of a local Gauss operator is the operator for the inverse group
 element. -/
 theorem star_gaussOperator
@@ -174,7 +163,7 @@ theorem star_gaussOperator
     rw [← Matrix.star_apply]
     change ((Matrix.unitaryFactorizationComparison R x.2.1 x.2.2
       y.2.1 y.2.2)⁻¹ : Matrix.unitaryGroup n ℂ) x.1 y.1 = _
-    rw [unitaryFactorizationComparison_inv]
+    rw [Matrix.unitaryFactorizationComparison_inv]
   · have hyx : x.2 ≠ gaussLegAction g⁻¹ y.2 := by
       intro heq
       apply hxy

--- a/TNLean/Algebra/GaussRepresentation.lean
+++ b/TNLean/Algebra/GaussRepresentation.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+import TNLean.Algebra.UnitaryFactorizationComparison
+
+/-!
+# Local Gauss representation from unitary factorization comparisons
+
+For a finite group `G`, the gauge labels transform by
+
+`T_g(a,b) = (a * g⁻¹, g * b)`.
+
+Given unitary matter operators `R a b`, the corresponding local Gauss operator
+has the block from `(a,b)` to `T_g(a,b)` equal to
+
+`(R (T_g(a,b)))⁻¹ * R a b`.
+
+This is the representation part of FBC25, Proposition `prop:gausslaws` and
+Equation `eq:mcG` (arXiv:2502.20257, lines 3380--3387). The same telescoping
+calculation is Lemma `lem:p4-gauss-representation` in
+`Notes/OpenProblemsTN/problems/p4_gauge_invariant_subspace_growth.tex`, lines
+115--218. Gauged-tensor invariance and placement on a chain are not treated
+here.
+-/
+
+noncomputable section
+
+namespace TNLean.Algebra
+
+variable {G n : Type*} [Group G]
+
+/-- The two-leg gauge-label permutation
+`T_g(a,b) = (a * g⁻¹, g * b)` from FBC25, Equation `eq:mcG`
+(arXiv:2502.20257, lines 3380--3387). -/
+def gaussLegAction (g : G) : G × G ≃ G × G where
+  toFun p := (p.1 * g⁻¹, g * p.2)
+  invFun p := (p.1 * g, g⁻¹ * p.2)
+  left_inv p := by simp
+  right_inv p := by simp
+
+@[simp]
+theorem gaussLegAction_apply (g : G) (a b : G) :
+    gaussLegAction g (a, b) = (a * g⁻¹, g * b) :=
+  rfl
+
+@[simp]
+theorem gaussLegAction_one : gaussLegAction (1 : G) = 1 := by
+  ext p <;> simp [gaussLegAction]
+
+/-- The paper's label permutations compose in representation order:
+`T_g ∘ T_h = T_{g * h}`. -/
+theorem gaussLegAction_mul (g h : G) :
+    gaussLegAction g * gaussLegAction h = gaussLegAction (g * h) := by
+  ext p <;> simp [gaussLegAction, mul_assoc]
+
+variable [Fintype G] [DecidableEq G] [Fintype n] [DecidableEq n]
+
+/-- The local Gauss operator whose unique nonzero gauge block in column
+`(a,b)` lies in row `T_g(a,b)` and equals
+`(R (T_g(a,b)))⁻¹ R(a,b)`.
+
+This is exactly
+`G_g = ∑_{a,b} λ_{a,b}^{a g⁻¹,g b} ⊗ |a g⁻¹,g b⟩⟨a,b|`
+from FBC25, Equation `eq:mcG` (arXiv:2502.20257, lines 3380--3387), with
+`λ` supplied by `Matrix.unitaryFactorizationComparison`. -/
+def gaussOperator (R : G → G → Matrix.unitaryGroup n ℂ) (g : G) :
+    Matrix (n × (G × G)) (n × (G × G)) ℂ := by
+  classical
+  exact fun x y ↦
+    if x.2 = gaussLegAction g y.2 then
+      (Matrix.unitaryFactorizationComparison R y.2.1 y.2.2 x.2.1 x.2.2 :
+        Matrix n n ℂ) x.1 y.1
+    else 0
+
+omit [Fintype G] in
+/-- The nonzero block of the Gauss operator is the factorization comparison
+specified in FBC25, Equation `eq:mcG`. -/
+@[simp]
+theorem gaussOperator_apply_target
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g a b : G) (i j : n) :
+    gaussOperator R g (i, gaussLegAction g (a, b)) (j, (a, b)) =
+      (Matrix.unitaryFactorizationComparison R a b (a * g⁻¹) (g * b) :
+        Matrix n n ℂ) i j := by
+  classical
+  simp [gaussOperator]
+
+omit [Fintype G] in
+/-- Every other gauge block in a fixed column of the Gauss operator vanishes. -/
+@[simp]
+theorem gaussOperator_apply_of_ne
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g : G)
+    (x y : n × (G × G)) (hxy : x.2 ≠ gaussLegAction g y.2) :
+    gaussOperator R g x y = 0 := by
+  classical
+  simp [gaussOperator, hxy]
+
+omit [Group G] [Fintype G] [DecidableEq G] in
+/-- The inverse of a factorization comparison is the comparison in the
+opposite direction. -/
+@[simp]
+theorem unitaryFactorizationComparison_inv
+    (R : G → G → Matrix.unitaryGroup n ℂ) (a b c d : G) :
+    (Matrix.unitaryFactorizationComparison R a b c d)⁻¹ =
+      Matrix.unitaryFactorizationComparison R c d a b := by
+  simp [Matrix.unitaryFactorizationComparison]
+
+/-- Local Gauss operators multiply according to the group law. This is the
+first conclusion of FBC25, Proposition `prop:gausslaws`
+(arXiv:2502.20257, lines 3380--3387). -/
+theorem gaussOperator_mul
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g h : G) :
+    gaussOperator R g * gaussOperator R h = gaussOperator R (g * h) := by
+  classical
+  ext x y
+  rw [Matrix.mul_apply, Fintype.sum_prod_type, Finset.sum_comm]
+  rw [Fintype.sum_eq_single (gaussLegAction h y.2)]
+  · by_cases hxy : x.2 = gaussLegAction (g * h) y.2
+    · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
+          gaussLegAction (g * h) y.2 := by
+        simp [gaussLegAction, mul_assoc]
+      have hx : x.2 = gaussLegAction g (gaussLegAction h y.2) :=
+        hxy.trans hcomp.symm
+      simp only [gaussOperator, hx, hcomp, ite_true]
+      rw [← Matrix.mul_apply]
+      exact (congrFun₂ (congrArg Subtype.val
+        (Matrix.unitaryFactorizationComparison_trans R y.2.1 y.2.2
+          (gaussLegAction h y.2).1 (gaussLegAction h y.2).2
+          (gaussLegAction (g * h) y.2).1 (gaussLegAction (g * h) y.2).2)) x.1 y.1).symm
+    · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
+          gaussLegAction (g * h) y.2 := by
+        simp [gaussLegAction, mul_assoc]
+      have hx : x.2 ≠ gaussLegAction g (gaussLegAction h y.2) := fun heq ↦
+        hxy (heq.trans hcomp)
+      simp [gaussOperator, hx, hxy]
+  · intro q hq
+    simp [gaussOperator, hq]
+
+omit [Fintype G] in
+/-- The Gauss operator of the identity group element is the identity matrix. -/
+@[simp]
+theorem gaussOperator_one (R : G → G → Matrix.unitaryGroup n ℂ) :
+    gaussOperator R 1 = 1 := by
+  classical
+  ext x y
+  by_cases hxy : x.2 = y.2
+  · by_cases hij : x.1 = y.1
+    · have hfull : x = y := Prod.ext hij hxy
+      subst y
+      simp [gaussOperator]
+    · have hfull : x ≠ y := fun h ↦ hij (congrArg Prod.fst h)
+      simp [gaussOperator, hxy, hij, hfull]
+  · have hfull : x ≠ y := fun h ↦ hxy (congrArg Prod.snd h)
+    simp [gaussOperator, hxy, hfull]
+
+omit [Fintype G] in
+/-- The adjoint of a local Gauss operator is the operator for the inverse group
+element. -/
+theorem star_gaussOperator
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g : G) :
+    star (gaussOperator R g) = gaussOperator R g⁻¹ := by
+  classical
+  ext x y
+  rw [Matrix.star_apply]
+  by_cases hxy : y.2 = gaussLegAction g x.2
+  · have hyx : x.2 = gaussLegAction g⁻¹ y.2 := by
+      rw [hxy]
+      simp [gaussLegAction]
+    rw [gaussOperator, ite_eq_left hxy, gaussOperator, ite_eq_left hyx]
+    change star ((Matrix.unitaryFactorizationComparison R x.2.1 x.2.2
+      y.2.1 y.2.2 : Matrix n n ℂ) y.1 x.1) = _
+    rw [← Matrix.star_apply]
+    change ((Matrix.unitaryFactorizationComparison R x.2.1 x.2.2
+      y.2.1 y.2.2)⁻¹ : Matrix.unitaryGroup n ℂ) x.1 y.1 = _
+    rw [unitaryFactorizationComparison_inv]
+  · have hyx : x.2 ≠ gaussLegAction g⁻¹ y.2 := by
+      intro heq
+      apply hxy
+      rw [heq]
+      simp [gaussLegAction]
+    rw [gaussOperator, ite_eq_right hxy, gaussOperator, ite_eq_right hyx]
+    exact star_zero ℂ
+
+/-- Every local Gauss operator is unitary. -/
+theorem gaussOperator_mem_unitaryGroup
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g : G) :
+    gaussOperator R g ∈ Matrix.unitaryGroup (n × (G × G)) ℂ := by
+  rw [Matrix.mem_unitaryGroup_iff, star_gaussOperator, gaussOperator_mul]
+  simp
+
+/-- The local Gauss operators form a unitary representation of `G`. This is
+the representation part of FBC25, Proposition `prop:gausslaws`
+(arXiv:2502.20257, lines 3380--3387), isolated from the proposition's separate
+gauged-tensor invariance statement. -/
+def gaussRepresentation (R : G → G → Matrix.unitaryGroup n ℂ) :
+    G →* Matrix.unitaryGroup (n × (G × G)) ℂ where
+  toFun g := ⟨gaussOperator R g, gaussOperator_mem_unitaryGroup R g⟩
+  map_one' := Subtype.ext (gaussOperator_one R)
+  map_mul' g h := Subtype.ext (gaussOperator_mul R g h).symm
+
+@[simp]
+theorem gaussRepresentation_coe
+    (R : G → G → Matrix.unitaryGroup n ℂ) (g : G) :
+    (gaussRepresentation R g : Matrix (n × (G × G)) (n × (G × G)) ℂ) =
+      gaussOperator R g :=
+  rfl
+
+end TNLean.Algebra

--- a/TNLean/Algebra/GaussRepresentation.lean
+++ b/TNLean/Algebra/GaussRepresentation.lean
@@ -106,7 +106,7 @@ theorem gaussOperator_mul
   rw [Fintype.sum_eq_single (gaussLegAction h y.2)]
   · have hcomp : gaussLegAction g (gaussLegAction h y.2) =
         gaussLegAction (g * h) y.2 := by
-      simp [gaussLegAction, mul_assoc]
+      simpa using congrArg (fun T : G × G ≃ G × G ↦ T y.2) (gaussLegAction_mul g h)
     by_cases hxy : x.2 = gaussLegAction (g * h) y.2
     · have hx : x.2 = gaussLegAction g (gaussLegAction h y.2) :=
         hxy.trans hcomp.symm

--- a/TNLean/Algebra/GaussRepresentation.lean
+++ b/TNLean/Algebra/GaussRepresentation.lean
@@ -19,11 +19,8 @@ has the block from `(a,b)` to `T_g(a,b)` equal to
 `(R (T_g(a,b)))⁻¹ * R a b`.
 
 This is the representation part of FBC25, Proposition `prop:gausslaws` and
-Equation `eq:mcG` (arXiv:2502.20257, lines 3380--3387). The same telescoping
-calculation is Lemma `lem:p4-gauss-representation` in
-`Notes/OpenProblemsTN/problems/p4_gauge_invariant_subspace_growth.tex`, lines
-115--218. Gauged-tensor invariance and placement on a chain are not treated
-here.
+Equation `eq:mcG` (arXiv:2502.20257, lines 3380--3387). Gauged-tensor
+invariance and placement on a chain are not treated here.
 -/
 
 noncomputable section

--- a/TNLean/Algebra/UnitaryFactorizationComparison.lean
+++ b/TNLean/Algebra/UnitaryFactorizationComparison.lean
@@ -54,6 +54,15 @@ theorem unitaryFactorizationComparison_self
     unitaryFactorizationComparison R a b a b = 1 := by
   simp only [unitaryFactorizationComparison, inv_mul_cancel]
 
+/-- The inverse of a unitary factorization comparison is the comparison in the
+opposite direction. -/
+@[simp]
+theorem unitaryFactorizationComparison_inv
+    (R : ι → ι → Matrix.unitaryGroup n 𝕜) (a b c d : ι) :
+    (unitaryFactorizationComparison R a b c d)⁻¹ =
+      unitaryFactorizationComparison R c d a b := by
+  simp only [unitaryFactorizationComparison, _root_.mul_inv_rev, inv_inv]
+
 /-- Unitary factorization comparisons compose through an intermediate pair in
 the source orientation.  This is the composition law in the corollary
 following FBC25, Proposition `prop:3`

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -857,6 +857,116 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \end{align}
 \end{proof}
 
+\begin{definition}[Gauss action on the gauge legs]
+    \label{def:mpug_gauss_leg_action}
+    \lean{TNLean.Algebra.gaussLegAction,
+        TNLean.Algebra.gaussLegAction_apply}
+    \leanok
+    \discussion{7503}
+    Let $G$ be a group. For $g\in G$, define the permutation
+    $T_g\colon G^2\to G^2$ by
+    \begin{align}
+        T_g(a,b) & =\left(ag^{-1},gb\right).
+        \label{eq:mpug_gauss_leg_action}
+    \end{align}
+    These are the two gauge-leg labels in
+    \cite[Eq.~(\texttt{eq:mcG}), lines~3380--3387]
+    {FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Composition of the Gauss leg action]
+    \label{thm:mpug_gauss_leg_action_mul}
+    \lean{TNLean.Algebra.gaussLegAction_one,
+        TNLean.Algebra.gaussLegAction_mul}
+    \leanok
+    \discussion{7503}
+    \uses{def:mpug_gauss_leg_action}
+    For all $g,h\in G$,
+    \begin{align}
+        T_e & =\id, & T_g\circ T_h & =T_{gh}.
+        \label{eq:mpug_gauss_leg_action_mul}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_gauss_leg_action}
+    The two coordinates give
+    \begin{align}
+        T_g(T_h(a,b))
+         & =\left(ah^{-1}g^{-1},ghb\right)
+          =\left(a(gh)^{-1},(gh)b\right).
+    \end{align}
+\end{proof}
+
+\begin{definition}[Local Gauss operator]
+    \label{def:mpug_gauss_operator}
+    \lean{TNLean.Algebra.gaussOperator,
+        TNLean.Algebra.gaussOperator_apply_target,
+        TNLean.Algebra.gaussOperator_apply_of_ne}
+    \leanok
+    \discussion{7503}
+    \uses{def:mpug_unitary_factorization_comparison,
+        def:mpug_gauss_leg_action}
+    Let $G$ be finite, let $R_{a,b}\in\mathrm U(n)$ for $a,b\in G$, and use
+    the basis $\ket{i,a,b}$ of $\C^n\otimes\C[G]^{\otimes2}$. Define
+    \begin{align}
+        \mathcal G_g
+         & =\sum_{a,b\in G}
+            \lambda_{a,b}^{ag^{-1},gb}
+            \otimes\ket{ag^{-1},gb}\!\bra{a,b}.
+        \label{eq:mpug_gauss_operator}
+    \end{align}
+    Equivalently, the block from $(a,b)$ to $T_g(a,b)$ is
+    $(R_{T_g(a,b)})^{-1}R_{a,b}$ and every other block in that column
+    vanishes. This is the operator in
+    \cite[Eq.~(\texttt{eq:mcG}), lines~3380--3387]
+    {FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Gauss operators form a unitary representation]
+    \label{thm:mpug_gauss_representation}
+    \lean{TNLean.Algebra.gaussOperator_one,
+        TNLean.Algebra.gaussOperator_mul,
+        TNLean.Algebra.star_gaussOperator,
+        TNLean.Algebra.gaussOperator_mem_unitaryGroup,
+        TNLean.Algebra.gaussRepresentation}
+    \leanok
+    \discussion{7503}
+    \uses{thm:mpug_unitary_factorization_comparison_laws,
+        thm:mpug_gauss_leg_action_mul,
+        def:mpug_gauss_operator}
+    The local Gauss operators satisfy
+    \begin{align}
+        \mathcal G_e & =\id,                                      \\
+        \mathcal G_g\mathcal G_h & =\mathcal G_{gh},              \\
+        \mathcal G_g^\dagger & =\mathcal G_{g^{-1}}.
+        \label{eq:mpug_gauss_representation}
+    \end{align}
+    Hence $g\mapsto\mathcal G_g$ is a unitary representation. This is the
+    representation part of Proposition~\texttt{prop:gausslaws} in
+    \cite[lines~3380--3387]{FrancoRubio2025MPUGauging}; invariance of the
+    gauged tensor is a separate assertion and is not included here.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_unitary_factorization_comparison_laws,
+        thm:mpug_gauss_leg_action_mul,
+        def:mpug_gauss_operator}
+    In a column labelled by $(a,b)$, multiplication has only the intermediate
+    gauge label $T_h(a,b)$. The surviving matter block is
+    \begin{align}
+        \lambda_{T_h(a,b)}^{T_g(T_h(a,b))}
+        \lambda_{a,b}^{T_h(a,b)}
+         & =\lambda_{a,b}^{T_{gh}(a,b)},
+    \end{align}
+    by the comparison composition law and
+    $T_gT_h=T_{gh}$. This proves the product formula; the identity formula is
+    its specialization at $e$. Reversing a comparison gives
+    $(\lambda_{a,b}^{c,d})^\dagger=\lambda_{c,d}^{a,b}$, so taking the adjoint
+    gives $\mathcal G_g^\dagger=\mathcal G_{g^{-1}}$. The product with this
+    adjoint is $\mathcal G_e=\id$, which proves unitarity.
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -869,9 +869,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         T_g(a,b) & =\left(ag^{-1},gb\right).
         \label{eq:mpug_gauss_leg_action}
     \end{align}
-    These are the two gauge-leg labels in
-    \cite[Eq.~(\texttt{eq:mcG}), lines~3380--3387]
-    {FrancoRubio2025MPUGauging}.
+    These are the two gauge-leg labels in the local Gauss operator of
+    \cite[lines~3380--3387]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
 \begin{theorem}[Composition of the Gauss leg action]
@@ -922,9 +921,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \end{align}
     Equivalently, the block from $(a,b)$ to $T_g(a,b)$ is
     $(R_{T_g(a,b)})^{-1}R_{a,b}$ and every other block in that column
-    vanishes. This is the operator in
-    \cite[Eq.~(\texttt{eq:mcG}), lines~3380--3387]
-    {FrancoRubio2025MPUGauging}.
+    vanishes. This is the local Gauss operator in
+    \cite[lines~3380--3387]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
 \begin{theorem}[Gauss operators form a unitary representation]
@@ -953,7 +951,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \mathcal G_g^\dagger & =\mathcal G_{g^{-1}}.
     \end{align}
     Hence $g\mapsto\mathcal G_g$ is a unitary representation. This is the
-    representation part of Proposition~\texttt{prop:gausslaws} in
+    representation part of the local Gauss-law proposition in
     \cite[lines~3380--3387]{FrancoRubio2025MPUGauging}; invariance of the
     gauged tensor is a separate assertion and is not included here.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -833,12 +833,12 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     Reversing the comparison gives
     \begin{align}
         \left(\lambda_{a,b}^{c,d}\right)^{-1}
-        & =\lambda_{c,d}^{a,b}.
+         & =\lambda_{c,d}^{a,b}.
     \end{align}
     Comparisons compose as
     \begin{align}
         \lambda_{a,b}^{f,g}
-        & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
+         & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
         \label{eq:mpug_unitary_factorization_comparison_laws}
     \end{align}
     If $R_{c,d}=\mathbf 1$, then
@@ -906,7 +906,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         T_g(T_h(a,b))
          & =\left(ah^{-1}g^{-1},ghb\right)
-          =\left(a(gh)^{-1},(gh)b\right).
+        =\left(a(gh)^{-1},(gh)b\right).
     \end{align}
 \end{proof}
 
@@ -924,8 +924,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         \mathcal G_g
          & =\sum_{a,b\in G}
-            \lambda_{a,b}^{ag^{-1},gb}
-            \otimes\ket{ag^{-1},gb}\!\bra{a,b}.
+        \lambda_{a,b}^{ag^{-1},gb}
+        \otimes\ket{ag^{-1},gb}\!\bra{a,b}.
         \label{eq:mpug_gauss_operator}
     \end{align}
     Equivalently, the block from $(a,b)$ to $T_g(a,b)$ is
@@ -940,12 +940,11 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.gaussOperator_mul,
         TNLean.Algebra.star_gaussOperator,
         TNLean.Algebra.gaussOperator_mem_unitaryGroup,
-        TNLean.Algebra.gaussRepresentation}
+        TNLean.Algebra.gaussRepresentation,
+        TNLean.Algebra.gaussRepresentation_coe}
     \leanok
     \discussion{7503}
-    \uses{thm:mpug_unitary_factorization_comparison_laws,
-        thm:mpug_gauss_leg_action_mul,
-        def:mpug_gauss_operator}
+    \uses{def:mpug_gauss_operator}
     The local Gauss operators satisfy
     \begin{align}
         \mathcal G_e & =\id.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -817,9 +817,10 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     factorizations and is not needed in the unitary calculation.
 \end{definition}
 
-\begin{theorem}[Identity, composition, and right-reference laws]
+\begin{theorem}[Identity, inverse, composition, and right-reference laws]
     \label{thm:mpug_unitary_factorization_comparison_laws}
     \lean{Matrix.unitaryFactorizationComparison_self,
+        Matrix.unitaryFactorizationComparison_inv,
         Matrix.unitaryFactorizationComparison_trans,
         Matrix.unitaryFactorizationComparison_of_reference_eq_one,
         Matrix.unitaryFactorizationComparison_right_reference}
@@ -827,9 +828,17 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_unitary_factorization_comparison}
     For all indices $a,b,c,d,f,g\in I$,
     \begin{align}
-        \lambda_{a,b}^{a,b} & =\mathbf 1,                              \\
+        \lambda_{a,b}^{a,b} & =\mathbf 1.
+    \end{align}
+    Reversing the comparison gives
+    \begin{align}
+        \left(\lambda_{a,b}^{c,d}\right)^{-1}
+        & =\lambda_{c,d}^{a,b}.
+    \end{align}
+    Comparisons compose as
+    \begin{align}
         \lambda_{a,b}^{f,g}
-                            & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
+        & =\lambda_{c,d}^{f,g}\lambda_{a,b}^{c,d}.
         \label{eq:mpug_unitary_factorization_comparison_laws}
     \end{align}
     If $R_{c,d}=\mathbf 1$, then
@@ -847,8 +856,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{proof}\leanok
     \uses{def:mpug_unitary_factorization_comparison}
-    The identity and right-reference formulas follow from
-    $R_{a,b}^{-1}R_{a,b}=\mathbf 1$ and
+    The identity, inverse, and right-reference formulas follow from
+    $R_{a,b}^{-1}R_{a,b}=\mathbf 1$, inversion of a product, and
     $\mathbf 1^{-1}R_{a,b}=R_{a,b}$. For composition, insert the identity at
     the intermediate pair:
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -883,7 +883,11 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_gauss_leg_action}
     For all $g,h\in G$,
     \begin{align}
-        T_e & =\id, & T_g\circ T_h & =T_{gh}.
+        T_e & =\id.
+    \end{align}
+    Moreover,
+    \begin{align}
+        T_g\circ T_h & =T_{gh}.
         \label{eq:mpug_gauss_leg_action_mul}
     \end{align}
 \end{theorem}
@@ -937,10 +941,16 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         def:mpug_gauss_operator}
     The local Gauss operators satisfy
     \begin{align}
-        \mathcal G_e & =\id,                                      \\
-        \mathcal G_g\mathcal G_h & =\mathcal G_{gh},              \\
-        \mathcal G_g^\dagger & =\mathcal G_{g^{-1}}.
+        \mathcal G_e & =\id.
+    \end{align}
+    Their product law is
+    \begin{align}
+        \mathcal G_g\mathcal G_h & =\mathcal G_{gh}.
         \label{eq:mpug_gauss_representation}
+    \end{align}
+    Finally,
+    \begin{align}
+        \mathcal G_g^\dagger & =\mathcal G_{g^{-1}}.
     \end{align}
     Hence $g\mapsto\mathcal G_g$ is a unitary representation. This is the
     representation part of Proposition~\texttt{prop:gausslaws} in
@@ -960,8 +970,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
          & =\lambda_{a,b}^{T_{gh}(a,b)},
     \end{align}
     by the comparison composition law and
-    $T_gT_h=T_{gh}$. This proves the product formula; the identity formula is
-    its specialization at $e$. Reversing a comparison gives
+    $T_gT_h=T_{gh}$. At $e$, every surviving comparison is the identity.
+    Reversing a comparison gives
     $(\lambda_{a,b}^{c,d})^\dagger=\lambda_{c,d}^{a,b}$, so taking the adjoint
     gives $\mathcal G_g^\dagger=\mathcal G_{g^{-1}}$. The product with this
     adjoint is $\mathcal G_e=\id$, which proves unitarity.


### PR DESCRIPTION
## What changed

- define the paper's gauge-leg action
  `T_g(a,b) = (a g⁻¹, g b)` and prove `T_g ∘ T_h = T_(gh)`
- define the sparse local Gauss operator with comparison block
  `(R_(T_g(a,b)))⁻¹ R_(a,b)` using `Matrix.unitaryFactorizationComparison`
- prove the block action, identity, multiplication, adjoint, and unitarity laws, then package `g ↦ 𝒢_g` as a homomorphism into `Matrix.unitaryGroup`
- add the generic inverse-comparison lemma to the existing comparison API
- document the representation half of FBC25 `prop:gausslaws` in Chapter 29, separately from gauged-tensor invariance

The multiplication proof follows the source and P4 telescoping calculation exactly. It selects the unique intermediate gauge label `T_h(a,b)` and applies `Matrix.unitaryFactorizationComparison_trans`. No cocycle or associator identity is introduced.

## Source and scope

- `Papers/2502.20257/main.tex:2782–2821`, comparison transitivity
- `Papers/2502.20257/main.tex:3378–3387`, `prop:gausslaws` and `eq:mcG`
- `Papers/2502.20257/main.tex:4327–4335`, the modified state-level Gauss representation

Gauged-tensor invariance, chain placement, averaged projectors, and CZX-specific data remain in their existing issues.

## Validation

- `lake build TNLean.Algebra.GaussRepresentation TNLean.Algebra` (3500/3500)
- `python3 scripts/generate_import_aggregators.py --root . --check` (37 generated files, 1072 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (Chapter 29: 220/220; total: 7292/7292)
- double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with the project `TEXINPUTS`; zero undefined references
- no `sorry`, `admit`, `axiom`, `unsafeCast`, or `native_decide` in the new module
- `git diff --check origin/main...HEAD`

Closes #7503.
Advances #7341, #7350, and #7568.

