### PR TITLE
feat(algebra): define the local Gauss projector

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -20,6 +20,7 @@ import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FiniteGroupUnitaryAverage
 import TNLean.Algebra.FinsetSubtypeSum
 import TNLean.Algebra.FixedPointFreeInvolutionSign
+import TNLean.Algebra.GaussProjector
 import TNLean.Algebra.GaussRepresentation
 import TNLean.Algebra.GeneralizedCocycle
 import TNLean.Algebra.GeneralizedCocycleInversion

--- a/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
+++ b/TNLean/Algebra/FiniteGroupUnitaryAverage.lean
@@ -19,15 +19,15 @@ open scoped BigOperators Matrix
 
 namespace TNLean.Algebra
 
-variable {G : Type*} {n : ℕ} [Group G] [Fintype G]
+variable {G ι : Type*} {n : ℕ} [Group G] [Fintype G] [Fintype ι] [DecidableEq ι]
 
 /-- The matrix representation on column vectors associated with a unitary
 matrix representation. -/
 noncomputable def unitaryMatrixRepresentation
-    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
-    Representation ℂ G (Fin n → ℂ) :=
+    (ρ : G →* Matrix.unitaryGroup ι ℂ) :
+    Representation ℂ G (ι → ℂ) :=
   Matrix.toLinAlgEquiv'.toMonoidHom.comp
-    ((Matrix.unitaryGroup (Fin n) ℂ).subtype.comp ρ)
+    ((Matrix.unitaryGroup ι ℂ).subtype.comp ρ)
 
 /-- The normalized finite-group average
 $|G|^{-1}\sum_{g \in G}\rho(g)$ of a unitary matrix representation.
@@ -35,15 +35,15 @@ $|G|^{-1}\sum_{g \in G}\rho(g)$ of a unitary matrix representation.
 This is the matrix-level form of the local gauge average in arXiv:2502.20257,
 lines 459--461. -/
 noncomputable def finiteGroupUnitaryAverage
-    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ :=
-  (Fintype.card G : ℂ)⁻¹ • ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)
+    (ρ : G →* Matrix.unitaryGroup ι ℂ) : Matrix ι ι ℂ :=
+  (Fintype.card G : ℂ)⁻¹ • ∑ g : G, (ρ g : Matrix ι ι ℂ)
 
 /-- The normalized average of a finite-group unitary matrix representation is
-an orthogonal projection, as asserted for the local gauge operators in
-arXiv:2502.20257, lines 457--461. -/
-theorem isOrthogonalProjection_finiteGroupUnitaryAverage
-    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
-    IsOrthogonalProjection (finiteGroupUnitaryAverage ρ) := by
+a star projection. This is the type-generic matrix form of the local gauge
+projection in arXiv:2502.20257, lines 457--461. -/
+theorem isStarProjection_finiteGroupUnitaryAverage
+    (ρ : G →* Matrix.unitaryGroup ι ℂ) :
+    IsStarProjection (finiteGroupUnitaryAverage ρ) := by
   classical
   let _ : Invertible (Fintype.card G : ℂ) :=
     invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
@@ -52,7 +52,6 @@ theorem isOrthogonalProjection_finiteGroupUnitaryAverage
       LinearMap.toMatrixAlgEquiv' σ.averageMap = finiteGroupUnitaryAverage ρ := by
     simp [σ, unitaryMatrixRepresentation, Representation.averageMap,
       GroupAlgebra.average, finiteGroupUnitaryAverage]
-  apply IsStarProjection.isOrthogonalProjection
   rw [isStarProjection_iff']
   constructor
   · have hidem := (Representation.isProj_averageMap (ρ := σ)).isIdempotentElem.eq
@@ -64,13 +63,21 @@ theorem isOrthogonalProjection_finiteGroupUnitaryAverage
     congr 1
     · simp only [star_inv₀, star_natCast]
     · calc
-        ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ)ᴴ =
-            ∑ g : G, (ρ g⁻¹ : Matrix (Fin n) (Fin n) ℂ) := by
+        ∑ g : G, (ρ g : Matrix ι ι ℂ)ᴴ =
+            ∑ g : G, (ρ g⁻¹ : Matrix ι ι ℂ) := by
               apply Finset.sum_congr rfl
               intro g _
               simp [← Matrix.star_eq_conjTranspose]
-        _ = ∑ g : G, (ρ g : Matrix (Fin n) (Fin n) ℂ) := by
+        _ = ∑ g : G, (ρ g : Matrix ι ι ℂ) := by
           simpa using Equiv.sum_comp (Equiv.inv G)
-            (fun g : G ↦ (ρ g : Matrix (Fin n) (Fin n) ℂ))
+            (fun g : G ↦ (ρ g : Matrix ι ι ℂ))
+
+/-- The normalized average of a finite-group unitary matrix representation on
+`Fin n` is an orthogonal projection, as asserted for the local gauge operators
+in arXiv:2502.20257, lines 457--461. -/
+theorem isOrthogonalProjection_finiteGroupUnitaryAverage
+    (ρ : G →* Matrix.unitaryGroup (Fin n) ℂ) :
+    IsOrthogonalProjection (finiteGroupUnitaryAverage ρ) :=
+  (isStarProjection_finiteGroupUnitaryAverage ρ).isOrthogonalProjection
 
 end TNLean.Algebra

--- a/TNLean/Algebra/GaussProjector.lean
+++ b/TNLean/Algebra/GaussProjector.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FiniteGroupUnitaryAverage
+import TNLean.Algebra.GaussRepresentation
+
+/-!
+# Local Gauss projector
+
+The normalized average of the local Gauss representation is the unplaced local
+projector kernel from FBC25, Equation `eq:gauge_projs` (arXiv:2502.20257,
+lines 3494--3499). Finite-chain placement on sites `(j, j + 1)` and invariance
+of the gauged matrix product state are not treated here.
+-/
+
+noncomputable section
+
+open scoped BigOperators
+
+namespace TNLean.Algebra
+
+variable {G n : Type*} [Group G] [Fintype G] [DecidableEq G]
+  [Fintype n] [DecidableEq n]
+
+/-- The unplaced local Gauss projector kernel obtained by averaging the Gauss
+representation over the finite group, as in FBC25, Equation `eq:gauge_projs`
+(arXiv:2502.20257, lines 3494--3499). -/
+def gaussProjector (R : G → G → Matrix.unitaryGroup n ℂ) :
+    Matrix (n × (G × G)) (n × (G × G)) ℂ :=
+  finiteGroupUnitaryAverage (gaussRepresentation R)
+
+/-- The local Gauss projector is the normalized sum of the local Gauss
+operators from FBC25, Equation `eq:gauge_projs`. -/
+theorem gaussProjector_eq_average (R : G → G → Matrix.unitaryGroup n ℂ) :
+    gaussProjector R =
+      (Fintype.card G : ℂ)⁻¹ • ∑ g : G, gaussOperator R g := by
+  simp [gaussProjector, finiteGroupUnitaryAverage]
+
+/-- The unplaced local Gauss projector kernel is a star projection. -/
+theorem isStarProjection_gaussProjector
+    (R : G → G → Matrix.unitaryGroup n ℂ) :
+    IsStarProjection (gaussProjector R) :=
+  isStarProjection_finiteGroupUnitaryAverage (gaussRepresentation R)
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1014,7 +1014,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_gauss_projector}
     The kernel in~(\ref{eq:mpug_gauss_projector}) satisfies
     \begin{align}
-        P_G(R)^2 & =P_G(R), \\
+        P_G(R)^2       & =P_G(R), \\
         P_G(R)^\dagger & =P_G(R).
     \end{align}
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -5,7 +5,8 @@
 
 \begin{definition}[Finite-group unitary average]
     \label{def:mpug_finite_group_unitary_average}
-    \lean{TNLean.Algebra.finiteGroupUnitaryAverage}
+    \lean{TNLean.Algebra.finiteGroupUnitaryAverage,
+        TNLean.Algebra.unitaryMatrixRepresentation}
     \leanok
     \discussion{7458}
     Let $G$ be a finite group and let $\rho\colon G\to\mathrm U(n)$ be a
@@ -20,7 +21,8 @@
 
 \begin{theorem}[Finite-group unitary average is an orthogonal projection]
     \label{thm:mpug_finite_group_unitary_average_projection}
-    \lean{TNLean.Algebra.isOrthogonalProjection_finiteGroupUnitaryAverage}
+    \lean{TNLean.Algebra.isStarProjection_finiteGroupUnitaryAverage,
+        TNLean.Algebra.isOrthogonalProjection_finiteGroupUnitaryAverage}
     \leanok
     \discussion{7458}
     \uses{def:mpug_finite_group_unitary_average}
@@ -985,10 +987,12 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{definition}[Unplaced local Gauss projector kernel]
     \label{def:mpug_gauss_projector}
-    \lean{TNLean.Algebra.gaussProjector}
+    \lean{TNLean.Algebra.gaussProjector,
+        TNLean.Algebra.gaussProjector_eq_average}
     \leanok
     \discussion{7578}
-    \uses{thm:mpug_gauss_representation}
+    \uses{def:mpug_finite_group_unitary_average,
+        thm:mpug_gauss_representation}
     Let $G$ be finite and let $\mathcal G_g$ act on
     $\mathcal H=\C^n\otimes\C[G]^{\otimes2}$. Define the unplaced local
     projector kernel
@@ -998,14 +1002,13 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \end{align}
     This is the local average introduced in
     \cite[lines~3494--3499]{FrancoRubio2025MPUGauging}, before a position on
-    the chain is chosen. Finite-chain placement on $(j,j+1)$ and invariance of
-    the gauged matrix product state under the placed operator remain pending.
+    the chain is chosen. This definition neither places the kernel on
+    $(j,j+1)$ nor asserts invariance of the gauged matrix product state.
 \end{definition}
 
 \begin{theorem}[The local Gauss average is a projection]
     \label{thm:mpug_gauss_projector_projection}
-    \lean{TNLean.Algebra.gaussProjector_eq_average,
-        TNLean.Algebra.isStarProjection_gaussProjector}
+    \lean{TNLean.Algebra.isStarProjection_gaussProjector}
     \leanok
     \discussion{7578}
     \uses{def:mpug_gauss_projector}
@@ -1017,7 +1020,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_gauss_representation}
+    \uses{thm:mpug_finite_group_unitary_average_projection,
+        thm:mpug_gauss_representation}
     Identify the matrix average with the averaging operator of the unitary
     representation $g\mapsto\mathcal G_g$. The invariant-space averaging
     theorem makes this operator idempotent. For self-adjointness, use

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -983,6 +983,48 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     adjoint is $\mathcal G_e=\id$, which proves unitarity.
 \end{proof}
 
+\begin{definition}[Unplaced local Gauss projector kernel]
+    \label{def:mpug_gauss_projector}
+    \lean{TNLean.Algebra.gaussProjector}
+    \leanok
+    \discussion{7578}
+    \uses{thm:mpug_gauss_representation}
+    Let $G$ be finite and let $\mathcal G_g$ act on
+    $\mathcal H=\C^n\otimes\C[G]^{\otimes2}$. Define the unplaced local
+    projector kernel
+    \begin{align}
+        P_G(R) & =\frac{1}{|G|}\sum_{g\in G}\mathcal G_g.
+        \label{eq:mpug_gauss_projector}
+    \end{align}
+    This is the local average introduced in
+    \cite[lines~3494--3499]{FrancoRubio2025MPUGauging}, before a position on
+    the chain is chosen. Finite-chain placement on $(j,j+1)$ and invariance of
+    the gauged matrix product state under the placed operator remain pending.
+\end{definition}
+
+\begin{theorem}[The local Gauss average is a projection]
+    \label{thm:mpug_gauss_projector_projection}
+    \lean{TNLean.Algebra.gaussProjector_eq_average,
+        TNLean.Algebra.isStarProjection_gaussProjector}
+    \leanok
+    \discussion{7578}
+    \uses{def:mpug_gauss_projector}
+    The kernel in~(\ref{eq:mpug_gauss_projector}) satisfies
+    \begin{align}
+        P_G(R)^2 & =P_G(R), \\
+        P_G(R)^\dagger & =P_G(R).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_gauss_representation}
+    Identify the matrix average with the averaging operator of the unitary
+    representation $g\mapsto\mathcal G_g$. The invariant-space averaging
+    theorem makes this operator idempotent. For self-adjointness, use
+    $\mathcal G_g^\dagger=\mathcal G_{g^{-1}}$ and reindex the finite sum by
+    the bijection $g\mapsto g^{-1}$.
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,


### PR DESCRIPTION
## What changed

- generalize `unitaryMatrixRepresentation` and `finiteGroupUnitaryAverage` from `Fin n` to an arbitrary finite decidable matrix index type
- prove the generic average is an `IsStarProjection` through `Representation.averageMap` and `Representation.isProj_averageMap`
- preserve `isOrthogonalProjection_finiteGroupUnitaryAverage` with its existing `Fin n` signature as a source-compatible corollary
- define `gaussProjector R` as the normalized average of the exact local `gaussRepresentation R` merged in #7577
- prove the displayed average formula and that the local Gauss average is a star projection
- add the generated Algebra export and source-facing Chapter 29 entries

## Source and scope

The source formula is `P_j = |G|⁻¹ ∑ g, 𝒢_g^{j,j+1}` in `Papers/2502.20257/main.tex:3494-3499`. This PR formalizes the unplaced local kernel

`P_G(R) = |G|⁻¹ ∑ g, gaussOperator R g`

by reusing the local unitary Gauss representation from #7503/#7577 and the finite-group averaging theorem from #7458/#7511.

This PR does not place the operator on a finite chain, prove gauged-MPS invariance, assert neighboring-projector commutativity, or make a spectral-gap or completion-independent claim. Those remain in #7342 and its downstream dependencies.

## Validation

- `lake build TNLean.Algebra.FiniteGroupUnitaryAverage TNLean.Algebra.GaussProjector TNLean.Algebra` (3501/3501)
- `python3 scripts/generate_import_aggregators.py --root . --check` (37 generated files, 1075 production modules)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (7298/7298)
- `cd blueprint && leanblueprint checkdecls`
- repository `latexindent` formatting and double `lualatex` passes with the pinned tenkz package; zero undefined cross-references
- no `sorry`, `admit`, `axiom`, `unsafeCast`, or `native_decide` in the changed Lean files
- `git diff --check origin/main...HEAD`

Closes #7578.
Advances #7342 and #7568.
