### PR TITLE
feat(algebra): factor symmetric unitary matrices by congruence

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -42,6 +42,7 @@ import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation
+import TNLean.Algebra.UnitaryCongruence
 import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryFactorizationComparison
 import TNLean.Algebra.UnitaryKronecker

--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.CStarAlgebra.CStarMatrix
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unitary
+import Mathlib.Analysis.RCLike.Sqrt
+import Mathlib.LinearAlgebra.Eigenspace.Minpoly
+import Mathlib.LinearAlgebra.Lagrange
+
+/-!
+# Congruence factorization of symmetric unitary matrices
+
+A complex symmetric unitary matrix has a symmetric unitary square root. The square root is the
+finite spectral-projector square root from CPSV17, Lemma `lemma:conjclass-normalform-continuous`
+(arXiv:1703.09188, lines 1054--1064).
+-/
+
+open scoped Polynomial
+
+noncomputable section
+
+namespace Matrix
+
+variable {R n : Type*} [CommSemiring R] [Fintype n] [DecidableEq n]
+
+/-- Transpose commutes with evaluating a polynomial at a square matrix over a commutative
+semiring. -/
+theorem transpose_aeval (p : R[X]) (A : Matrix n n R) :
+    ((Polynomial.aeval A) p).transpose = (Polynomial.aeval A.transpose) p := by
+  simp only [Polynomial.aeval_def, Polynomial.eval₂_eq_sum_range, Matrix.transpose_sum,
+    Matrix.transpose_mul, Matrix.transpose_pow]
+  apply Finset.sum_congr rfl
+  intro i hi
+  rw [show ((algebraMap R (Matrix n n R)) (p.coeff i)).transpose =
+      (algebraMap R (Matrix n n R)) (p.coeff i) by
+    ext j k
+    simp only [Matrix.transpose_apply, Matrix.algebraMap_matrix_apply]
+    by_cases h : j = k
+    · subst k
+      rfl
+    · have hk : k ≠ j := Ne.symm h
+      simp [h, hk]]
+  exact (Algebra.commutes (p.coeff i) (A.transpose ^ i)).symm
+
+variable {n : ℕ}
+
+/-- A complex symmetric unitary matrix has a symmetric unitary square root.
+
+This is the symmetric branch of CPSV17, Lemma `lemma:conjclass-normalform-continuous`
+(arXiv:1703.09188, lines 1054--1064). -/
+theorem exists_symmetric_unitary_squareRoot
+    (x : Matrix (Fin n) (Fin n) ℂ)
+    (hx : x ∈ Matrix.unitaryGroup (Fin n) ℂ)
+    (hsym : x.transpose = x) :
+    ∃ S : Matrix (Fin n) (Fin n) ℂ,
+      S.transpose = S ∧
+      S ∈ Matrix.unitaryGroup (Fin n) ℂ ∧
+      x = S.transpose * S := by
+  let _ : PartialOrder ℂ := CStarAlgebra.spectralOrder ℂ
+  let _ : StarOrderedRing ℂ := CStarAlgebra.spectralOrderedRing ℂ
+  let e := CStarMatrix.ofMatrixStarAlgEquiv (n := Fin n) (A := ℂ)
+  let a := e x
+  have ha_unitary : a ∈ unitary (CStarMatrix (Fin n) (Fin n) ℂ) := by
+    change star a * a = 1 ∧ a * star a = 1
+    constructor
+    · change star (e x) * e x = 1
+      rw [← StarHomClass.map_star e, ← map_mul e, ← map_one e]
+      exact congrArg e (Matrix.mem_unitaryGroup_iff'.mp hx)
+    · change e x * star (e x) = 1
+      rw [← StarHomClass.map_star e, ← map_mul e, ← map_one e]
+      exact congrArg e (Matrix.mem_unitaryGroup_iff.mp hx)
+  have ha_normal : IsStarNormal a := isStarNormal_of_mem_unitary ha_unitary
+  have hspec : (spectrum ℂ a).Finite := Matrix.finite_spectrum a
+  have hsqrt_cont : ContinuousOn Complex.sqrt (spectrum ℂ a) := hspec.continuousOn _
+  have hsqrt_sq (z : ℂ) : Complex.sqrt z * Complex.sqrt z = z := by
+    change (z ^ (2 : ℂ)⁻¹) * (z ^ (2 : ℂ)⁻¹) = z
+    simpa [pow_two] using Complex.cpow_nat_inv_pow z (n := 2) (by norm_num)
+  have hroot_sq :
+      cfc (p := IsStarNormal) Complex.sqrt a * cfc (p := IsStarNormal) Complex.sqrt a = a := by
+    rw [← cfc_mul (p := IsStarNormal) Complex.sqrt Complex.sqrt a hsqrt_cont hsqrt_cont]
+    rw [cfc_congr (p := IsStarNormal) (g := fun z ↦ z) (fun z _ ↦ hsqrt_sq z),
+      cfc_id' ℂ a ha_normal]
+  have hroot_unitary :
+      cfc (p := IsStarNormal) Complex.sqrt a ∈ unitary (CStarMatrix (Fin n) (Fin n) ℂ) := by
+    rw [cfc_unitary_iff (p := IsStarNormal) Complex.sqrt a ha_normal hsqrt_cont]
+    intro z hz
+    have hz_unitary : z ∈ unitary ℂ := spectrum_subset_unitary_of_mem_unitary ha_unitary hz
+    have hz_norm_sq : ‖z‖ * ‖z‖ = 1 := by
+      have h := congrArg norm (Unitary.mem_iff_star_mul_self.mp hz_unitary)
+      simpa [norm_mul] using h
+    have hz_norm : ‖z‖ = 1 := by nlinarith [norm_nonneg z]
+    have hsqrt_norm_sq : ‖Complex.sqrt z‖ * ‖Complex.sqrt z‖ = 1 := by
+      have h := congrArg norm (hsqrt_sq z)
+      simpa [norm_mul, hz_norm] using h
+    have hsqrt_norm : ‖Complex.sqrt z‖ = 1 := by
+      nlinarith [norm_nonneg (Complex.sqrt z)]
+    rw [RCLike.star_def, ← Complex.normSq_eq_conj_mul_self,
+      Complex.normSq_eq_norm_sq, hsqrt_norm]
+    norm_num
+  let q : ℂ[X] := (Lagrange.interpolate hspec.toFinset id) Complex.sqrt
+  have hq_eval : Set.EqOn Complex.sqrt (fun z ↦ Polynomial.eval z q) (spectrum ℂ a) := by
+    intro z hz
+    symm
+    exact Lagrange.eval_interpolate_at_node Complex.sqrt (Set.injOn_id _)
+      (hspec.mem_toFinset.mpr hz)
+  have hroot_poly :
+      cfc (p := IsStarNormal) Complex.sqrt a = (Polynomial.aeval a) q := by
+    rw [cfc_congr (p := IsStarNormal) hq_eval, cfc_polynomial q a ha_normal]
+  let S : Matrix (Fin n) (Fin n) ℂ := (Polynomial.aeval x) q
+  have hmapS : e S = cfc (p := IsStarNormal) Complex.sqrt a := by
+    rw [hroot_poly]
+    change e ((Polynomial.aeval x) q) = (Polynomial.aeval (e x)) q
+    simp only [Polynomial.aeval_def]
+    change e.toRingHom (Polynomial.eval₂ (algebraMap ℂ (Matrix (Fin n) (Fin n) ℂ)) x q) = _
+    rw [Polynomial.hom_eval₂]
+    congr 1
+  have hS_sq : S * S = x := by
+    apply e.injective
+    change e (S * S) = e x
+    rw [map_mul e, hmapS]
+    simpa [a] using hroot_sq
+  have hS_unitary : S ∈ Matrix.unitaryGroup (Fin n) ℂ := by
+    rw [Matrix.mem_unitaryGroup_iff']
+    apply e.injective
+    change e (star S * S) = e 1
+    rw [map_mul e, StarHomClass.map_star e, map_one e, hmapS]
+    exact hroot_unitary.1
+  have hS_symm : S.transpose = S := by
+    change ((Polynomial.aeval x) q).transpose = (Polynomial.aeval x) q
+    rw [transpose_aeval, hsym]
+  exact ⟨S, hS_symm, hS_unitary, by simpa [hS_symm] using hS_sq.symm⟩
+
+end Matrix

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6676,10 +6676,40 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1008--1039.
 \end{proposition}
 
+\begin{lemma}[Symmetric branch of the unitary congruence normal form]
+    \label{lem:mpu_symmetric_unitary_congruence}
+    \lean{Matrix.exists_symmetric_unitary_squareRoot}
+    \leanok
+    Let $x$ be a symmetric unitary matrix. There is a symmetric unitary matrix
+    $S$ such that
+    \begin{align}
+        x & = S^T S.
+    \end{align}
+    This is the symmetric branch of
+    \cite[Lemma~\texttt{lemma:conjclass-normalform-continuous}]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 1054--1064.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write the finite spectral decomposition of $x$ as
+    \begin{align}
+        x & = \sum_{\lambda\in\sigma(x)} \lambda P_\lambda
+    \end{align}
+    and set
+    \begin{align}
+        S & = \sum_{\lambda\in\sigma(x)} \sqrt{\lambda}\,P_\lambda.
+    \end{align}
+    Each spectral value has modulus one, so its square root has modulus one,
+    and hence $S$ is unitary and $S^2=x$. On the finite spectrum, interpolate
+    the square-root function by a polynomial $q$. Then $S=q(x)$, and
+    $x^T=x$ implies $S^T=q(x^T)=q(x)=S$. Therefore $x=S^2=S^T S$.
+\end{proof}
+
 \begin{lemma}[Normal form of symmetric and skew-symmetric unitaries]
     \label{lemma:conjclass-normalform-continuous}
     \notready
     \discussion{5713}
+    \uses{lem:mpu_symmetric_unitary_congruence}
     Let $x$ be unitary and satisfy $x=x^T$ or $x=-x^T$. There are a symmetric
     unitary $S$ and a matrix $\widetilde\Lambda$ such that
     \begin{align}


### PR DESCRIPTION
## What changed

- prove that every complex symmetric unitary matrix has a symmetric unitary square root $S$ with
  \[
  x=S^T S
  \]
- implement the finite spectral-projector construction from CPSV17 through normal-element continuous functional calculus on the finite matrix spectrum
- identify the CFC square root with a Lagrange interpolation polynomial and prove transpose commutes with polynomial matrix evaluation
- add the generic algebra module `TNLean.Algebra.UnitaryCongruence` and register it in the algebra aggregator
- add a checked Chapter 28 entry for the symmetric branch while leaving the skew-inclusive paper lemma `\notready` under #7580 and #7581

The proof uses no Hermitian diagonalization, positive-element square root, extra spectral hypothesis, or continuity claim in the matrix parameter.

## Validation

- `lake build TNLean.Algebra.UnitaryCongruence` (2980/2980)
- `lake build TNLean.Algebra` (3539/3539)
- repository style linter and GitHub-format style linter
- proof-integrity scan and axiom checks
- Blueprint synchronization (7294/7294 theorem-like entries)
- strict `checkdecls`
- double LuaLaTeX, zero undefined non-citation references
- diagnostics clean
- `git diff --check`

Closes #7579
Advances #7572
Advances #7018
