### PR TITLE
feat(parent-hamiltonian): package the FNW weighted virtual Hilbert space

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -101,6 +101,7 @@ import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.TailVirtualGram
 import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+import TNLean.MPS.ParentHamiltonian.WeightedVirtualHilbert
 import TNLean.MPS.ParentHamiltonian.WholeIncrementCorrectionBounds
 import TNLean.MPS.ParentHamiltonian.WholeIncrementProjectorDefect
 import TNLean.MPS.ParentHamiltonian.WrappingWindow

--- a/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
+++ b/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
@@ -9,14 +9,14 @@ import QICLean.Analysis.MatrixSqrt
 /-!
 # Weighted virtual matrix Hilbert space
 
-A positive-definite matrix `ρ` equips the virtual matrix algebra with the
+A positive-definite matrix \(\rho\) equips the virtual matrix algebra with the
 inner product
 
-`⟪X, Y⟫_ρ = Matrix.trace (ρ * Xᴴ * Y)`.
+\(\langle X,Y\rangle_\rho = \operatorname{Tr}(\rho X^\dagger Y)\).
 
 This module activates Mathlib's weighted matrix norm and inner product locally
 and identifies the resulting Hilbert space isometrically with the Euclidean
-space of matrix entries. The isometry sends `X` to the Frobenius vectorization
+space of matrix entries. The isometry sends \(X\) to the Frobenius vectorization
 of \(X\sqrt{\rho}\); its inverse multiplies on the right by \((\sqrt{\rho})^{-1}\).
 
 The weighted inner product is equation (5.6) of Fannes--Nachtergaele--Werner,
@@ -133,8 +133,8 @@ private theorem inner_rightMul_cfcSqrt
       rw [CFC.sqrt_mul_sqrt_self ρ hρ.posSemidef.nonneg]
       simp only [Matrix.mul_assoc]
 
-/-- Right multiplication by `sqrt ρ`, followed by Frobenius vectorization,
-is a complex linear isometric equivalence from the `ρ`-weighted matrix space
+/-- Right multiplication by \(\sqrt{\rho}\), followed by Frobenius vectorization,
+is a complex linear isometric equivalence from the \(\rho\)-weighted matrix space
 to the Euclidean space of its entries. -/
 noncomputable def rhoWeightedEquivEuclidean
     {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
@@ -188,7 +188,7 @@ noncomputable def rhoWeightedEquivEuclidean
       nlinarith [norm_nonneg (frobeniusLinearEquiv D (X * CFC.sqrt ρ)), norm_nonneg X]
   }
 
-/-- The weighted Euclidean equivalence sends `X` to the Frobenius vectorization
+/-- The weighted Euclidean equivalence sends \(X\) to the Frobenius vectorization
 of \(X\sqrt{\rho}\). -/
 @[simp]
 theorem rhoWeightedEquivEuclidean_apply

--- a/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
+++ b/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
@@ -61,6 +61,8 @@ theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     inner ℂ X Y = Matrix.trace (ρ * Xᴴ * Y) := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
@@ -68,6 +70,8 @@ theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   change Matrix.trace (Y * ρ * Xᴴ) = Matrix.trace (ρ * Xᴴ * Y)
   exact (Matrix.trace_mul_cycle ρ Xᴴ Y).symm
 
@@ -80,6 +84,8 @@ theorem rhoWeighted_norm_sq {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     ‖X‖ ^ 2 = (Matrix.trace (ρ * Xᴴ * X)).re := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
@@ -87,6 +93,8 @@ theorem rhoWeighted_norm_sq {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   calc
     ‖X‖ ^ 2 = (inner ℂ X X).re := (inner_self_eq_norm_sq (𝕜 := ℂ) X).symm
     _ = (Matrix.trace (ρ * Xᴴ * X)).re :=
@@ -101,6 +109,8 @@ private theorem inner_rightMul_cfcSqrt
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     inner ℂ (frobeniusLinearEquiv D (X * CFC.sqrt ρ))
         (frobeniusLinearEquiv D (Y * CFC.sqrt ρ)) = inner ℂ X Y := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -109,6 +119,8 @@ private theorem inner_rightMul_cfcSqrt
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   rw [inner_frobeniusLinearEquiv, rhoWeighted_inner ρ hρ]
   rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_cfc_sqrt]
   calc
@@ -132,6 +144,8 @@ noncomputable def rhoWeightedEquivEuclidean
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     Matrix (Fin D) (Fin D) ℂ ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin D × Fin D) := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
@@ -139,6 +153,8 @@ noncomputable def rhoWeightedEquivEuclidean
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   exact {
     toFun X := frobeniusLinearEquiv D (X * CFC.sqrt ρ)
     invFun x := (frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹
@@ -184,6 +200,8 @@ theorem rhoWeightedEquivEuclidean_apply
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     rhoWeightedEquivEuclidean ρ hρ X =
       WithLp.toLp 2 (X * CFC.sqrt ρ).vec := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -192,6 +210,8 @@ theorem rhoWeightedEquivEuclidean_apply
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   rfl
 
 /-- The inverse weighted Euclidean equivalence applies inverse Frobenius
@@ -206,6 +226,8 @@ theorem rhoWeightedEquivEuclidean_symm_apply
       (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
     (rhoWeightedEquivEuclidean ρ hρ).symm x =
       Matrix.of (fun i j => WithLp.ofLp x (j, i)) * (CFC.sqrt ρ)⁻¹ := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -214,6 +236,8 @@ theorem rhoWeightedEquivEuclidean_symm_apply
     (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
   rfl
 
 end

--- a/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
+++ b/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.FrobeniusHilbert
+import QICLean.Analysis.MatrixSqrt
+
+/-!
+# Weighted virtual matrix Hilbert space
+
+A positive-definite matrix `ρ` equips the virtual matrix algebra with the
+inner product
+
+`⟪X, Y⟫_ρ = Matrix.trace (ρ * Xᴴ * Y)`.
+
+This module activates Mathlib's weighted matrix norm and inner product locally
+and identifies the resulting Hilbert space isometrically with the Euclidean
+space of matrix entries. The isometry sends `X` to the Frobenius vectorization
+of `X * CFC.sqrt ρ`; its inverse multiplies on the right by `(CFC.sqrt ρ)⁻¹`.
+
+The weighted inner product is equation (5.6) of Fannes--Nachtergaele--Werner,
+*Communications in Mathematical Physics* 144 (1992), 443--490,
+DOI 10.1007/BF02099178. No estimate from the subsequent lemmas is asserted here.
+
+## Main declarations
+
+* `Matrix.rhoWeighted_inner`: the weighted inner-product formula in the source convention.
+* `Matrix.rhoWeighted_norm_sq`: the corresponding squared-norm formula.
+* `Matrix.rhoWeightedEquivEuclidean`: the linear isometric Euclidean identification.
+* `Matrix.rhoWeightedEquivEuclidean_apply`: its forward formula.
+* `Matrix.rhoWeightedEquivEuclidean_symm_apply`: its inverse formula.
+-/
+
+open scoped ComplexOrder Matrix MatrixOrder Matrix.Norms.Frobenius
+
+namespace Matrix
+
+noncomputable section
+
+/-- The underlying linear equivalence of Frobenius vectorization, independent
+of the norm chosen on the matrix domain. -/
+noncomputable def frobeniusLinearEquiv (D : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
+  (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).toLinearEquiv
+
+/-- The norm-independent Frobenius linear equivalence has the same forward map
+as `Matrix.frobeniusEquivEuclidean`. -/
+@[simp]
+theorem frobeniusLinearEquiv_apply {D : ℕ} (X : Matrix (Fin D) (Fin D) ℂ) :
+    frobeniusLinearEquiv D X =
+      Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X :=
+  rfl
+
+/-- The norm-independent Frobenius linear equivalence has the same inverse map
+as `Matrix.frobeniusEquivEuclidean`. -/
+@[simp]
+theorem frobeniusLinearEquiv_symm_apply
+    {D : ℕ} (x : EuclideanSpace ℂ (Fin D × Fin D)) :
+    (frobeniusLinearEquiv D).symm x =
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x :=
+  rfl
+
+private theorem inner_frobeniusLinearEquiv
+    {D : ℕ} (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    inner ℂ (frobeniusLinearEquiv D X) (frobeniusLinearEquiv D Y) =
+      Matrix.trace (Xᴴ * Y) :=
+  Matrix.inner_frobeniusEquivEuclidean X Y
+
+/-- Mathlib's weighted matrix inner product agrees, by cyclicity of the trace,
+with the convention `Tr(ρ Xᴴ Y)` in FNW 1992, equation (5.6). -/
+theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : ρ.PosDef) (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+    inner ℂ X Y = Matrix.trace (ρ * Xᴴ * Y) := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  change Matrix.trace (Y * ρ * Xᴴ) = Matrix.trace (ρ * Xᴴ * Y)
+  exact (Matrix.trace_mul_cycle ρ Xᴴ Y).symm
+
+/-- The squared weighted norm is the real part of `Tr(ρ Xᴴ X)`. -/
+theorem rhoWeighted_norm_sq {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : ρ.PosDef) (X : Matrix (Fin D) (Fin D) ℂ) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+    ‖X‖ ^ 2 = (Matrix.trace (ρ * Xᴴ * X)).re := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  calc
+    ‖X‖ ^ 2 = (inner ℂ X X).re := (inner_self_eq_norm_sq (𝕜 := ℂ) X).symm
+    _ = (Matrix.trace (ρ * Xᴴ * X)).re :=
+      congrArg Complex.re (rhoWeighted_inner ρ hρ X X)
+
+private theorem inner_rightMul_cfcSqrt
+    {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+    inner ℂ (frobeniusLinearEquiv D (X * CFC.sqrt ρ))
+        (frobeniusLinearEquiv D (Y * CFC.sqrt ρ)) = inner ℂ X Y := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  rw [inner_frobeniusLinearEquiv, rhoWeighted_inner ρ hρ]
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_cfc_sqrt]
+  calc
+    Matrix.trace (CFC.sqrt ρ * Xᴴ * (Y * CFC.sqrt ρ)) =
+        Matrix.trace (CFC.sqrt ρ * (Xᴴ * Y) * CFC.sqrt ρ) := by
+          simp only [Matrix.mul_assoc]
+    _ = Matrix.trace (CFC.sqrt ρ * CFC.sqrt ρ * (Xᴴ * Y)) :=
+      Matrix.trace_mul_cycle (CFC.sqrt ρ) (Xᴴ * Y) (CFC.sqrt ρ)
+    _ = Matrix.trace (ρ * Xᴴ * Y) := by
+      rw [CFC.sqrt_mul_sqrt_self ρ hρ.posSemidef.nonneg]
+      simp only [Matrix.mul_assoc]
+
+/-- Right multiplication by `sqrt ρ`, followed by Frobenius vectorization,
+is a complex linear isometric equivalence from the `ρ`-weighted matrix space
+to the Euclidean space of its entries. -/
+noncomputable def rhoWeightedEquivEuclidean
+    {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    Matrix (Fin D) (Fin D) ℂ ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin D × Fin D) := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  exact {
+    toFun X := frobeniusLinearEquiv D (X * CFC.sqrt ρ)
+    invFun x := (frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹
+    map_add' X Y := by
+      rw [Matrix.add_mul, map_add]
+    map_smul' c X := by
+      rw [Matrix.smul_mul, map_smul]
+      rfl
+    left_inv X := by
+      change (frobeniusLinearEquiv D).symm
+          (frobeniusLinearEquiv D (X * CFC.sqrt ρ)) * (CFC.sqrt ρ)⁻¹ = X
+      rw [(frobeniusLinearEquiv D).symm_apply_apply, Matrix.mul_assoc,
+        Matrix.mul_nonsing_inv _ hρ.isUnit_det_cfc_sqrt, Matrix.mul_one]
+    right_inv x := by
+      change frobeniusLinearEquiv D
+          (((frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹) * CFC.sqrt ρ) = x
+      rw [Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hρ.isUnit_det_cfc_sqrt, Matrix.mul_one,
+        (frobeniusLinearEquiv D).apply_symm_apply]
+    norm_map' X := by
+      have hsquare : ‖frobeniusLinearEquiv D (X * CFC.sqrt ρ)‖ ^ 2 = ‖X‖ ^ 2 := by
+        calc
+          ‖frobeniusLinearEquiv D (X * CFC.sqrt ρ)‖ ^ 2 =
+              (inner ℂ (frobeniusLinearEquiv D (X * CFC.sqrt ρ))
+                (frobeniusLinearEquiv D (X * CFC.sqrt ρ))).re :=
+            (inner_self_eq_norm_sq (𝕜 := ℂ)
+              (frobeniusLinearEquiv D (X * CFC.sqrt ρ))).symm
+          _ = (inner ℂ X X).re :=
+            congrArg Complex.re (inner_rightMul_cfcSqrt ρ hρ X X)
+          _ = ‖X‖ ^ 2 := inner_self_eq_norm_sq (𝕜 := ℂ) X
+      change ‖frobeniusLinearEquiv D (X * CFC.sqrt ρ)‖ = ‖X‖
+      nlinarith [norm_nonneg (frobeniusLinearEquiv D (X * CFC.sqrt ρ)), norm_nonneg X]
+  }
+
+/-- The weighted Euclidean equivalence sends `X` to the Frobenius vectorization
+of `X * sqrt ρ`. -/
+@[simp]
+theorem rhoWeightedEquivEuclidean_apply
+    {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    rhoWeightedEquivEuclidean ρ hρ X =
+      frobeniusLinearEquiv D (X * CFC.sqrt ρ) := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  rfl
+
+/-- The inverse weighted Euclidean equivalence applies inverse Frobenius
+vectorization and then multiplies on the right by `(sqrt ρ)⁻¹`. -/
+@[simp]
+theorem rhoWeightedEquivEuclidean_symm_apply
+    {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (x : EuclideanSpace ℂ (Fin D × Fin D)) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    (rhoWeightedEquivEuclidean ρ hρ).symm x =
+      (frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹ := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
+  rfl
+
+end
+
+end Matrix

--- a/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
+++ b/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
@@ -17,7 +17,7 @@ inner product
 This module activates Mathlib's weighted matrix norm and inner product locally
 and identifies the resulting Hilbert space isometrically with the Euclidean
 space of matrix entries. The isometry sends `X` to the Frobenius vectorization
-of `X * CFC.sqrt ρ`; its inverse multiplies on the right by `(CFC.sqrt ρ)⁻¹`.
+of \(X\sqrt{\rho}\); its inverse multiplies on the right by \((\sqrt{\rho})^{-1}\).
 
 The weighted inner product is equation (5.6) of Fannes--Nachtergaele--Werner,
 *Communications in Mathematical Physics* 144 (1992), 443--490,
@@ -52,7 +52,7 @@ private theorem inner_frobeniusLinearEquiv
 -- norm hierarchy coherent while overriding the ambient Frobenius instances.
 
 /-- Mathlib's weighted matrix inner product agrees, by cyclicity of the trace,
-with the convention `Tr(ρ Xᴴ Y)` in FNW 1992, equation (5.6). -/
+with the convention \(\operatorname{Tr}(\rho X^\dagger Y)\) in FNW 1992, equation (5.6). -/
 theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hρ : ρ.PosDef) (X Y : Matrix (Fin D) (Fin D) ℂ) :
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -75,7 +75,7 @@ theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
   change Matrix.trace (Y * ρ * Xᴴ) = Matrix.trace (ρ * Xᴴ * Y)
   exact (Matrix.trace_mul_cycle ρ Xᴴ Y).symm
 
-/-- The squared weighted norm is the real part of `Tr(ρ Xᴴ X)`. -/
+/-- The squared weighted norm is the real part of \(\operatorname{Tr}(\rho X^\dagger X)\). -/
 theorem rhoWeighted_norm_sq {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hρ : ρ.PosDef) (X : Matrix (Fin D) (Fin D) ℂ) :
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -189,7 +189,7 @@ noncomputable def rhoWeightedEquivEuclidean
   }
 
 /-- The weighted Euclidean equivalence sends `X` to the Frobenius vectorization
-of `X * sqrt ρ`. -/
+of \(X\sqrt{\rho}\). -/
 @[simp]
 theorem rhoWeightedEquivEuclidean_apply
     {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
@@ -215,7 +215,7 @@ theorem rhoWeightedEquivEuclidean_apply
   rfl
 
 /-- The inverse weighted Euclidean equivalence applies inverse Frobenius
-vectorization and then multiplies on the right by `(sqrt ρ)⁻¹`. -/
+vectorization and then multiplies on the right by \((\sqrt{\rho})^{-1}\). -/
 @[simp]
 theorem rhoWeightedEquivEuclidean_symm_apply
     {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)

--- a/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
+++ b/TNLean/MPS/ParentHamiltonian/WeightedVirtualHilbert.lean
@@ -38,34 +38,18 @@ namespace Matrix
 
 noncomputable section
 
-/-- The underlying linear equivalence of Frobenius vectorization, independent
-of the norm chosen on the matrix domain. -/
-noncomputable def frobeniusLinearEquiv (D : ℕ) :
+private noncomputable def frobeniusLinearEquiv (D : ℕ) :
     Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
   (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).toLinearEquiv
-
-/-- The norm-independent Frobenius linear equivalence has the same forward map
-as `Matrix.frobeniusEquivEuclidean`. -/
-@[simp]
-theorem frobeniusLinearEquiv_apply {D : ℕ} (X : Matrix (Fin D) (Fin D) ℂ) :
-    frobeniusLinearEquiv D X =
-      Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X :=
-  rfl
-
-/-- The norm-independent Frobenius linear equivalence has the same inverse map
-as `Matrix.frobeniusEquivEuclidean`. -/
-@[simp]
-theorem frobeniusLinearEquiv_symm_apply
-    {D : ℕ} (x : EuclideanSpace ℂ (Fin D × Fin D)) :
-    (frobeniusLinearEquiv D).symm x =
-      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x :=
-  rfl
 
 private theorem inner_frobeniusLinearEquiv
     {D : ℕ} (X Y : Matrix (Fin D) (Fin D) ℂ) :
     inner ℂ (frobeniusLinearEquiv D X) (frobeniusLinearEquiv D Y) =
       Matrix.trace (Xᴴ * Y) :=
   Matrix.inner_frobeniusEquivEuclidean X Y
+
+-- Use the seminormed parent of the weighted normed structure below. This keeps the
+-- norm hierarchy coherent while overriding the ambient Frobenius instances.
 
 /-- Mathlib's weighted matrix inner product agrees, by cyclicity of the trace,
 with the convention `Tr(ρ Xᴴ Y)` in FNW 1992, equation (5.6). -/
@@ -74,20 +58,16 @@ theorem rhoWeighted_inner {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
     inner ℂ X Y = Matrix.trace (ρ * Xᴴ * Y) := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   change Matrix.trace (Y * ρ * Xᴴ) = Matrix.trace (ρ * Xᴴ * Y)
   exact (Matrix.trace_mul_cycle ρ Xᴴ Y).symm
 
@@ -97,20 +77,16 @@ theorem rhoWeighted_norm_sq {D : ℕ} (ρ : Matrix (Fin D) (Fin D) ℂ)
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
     ‖X‖ ^ 2 = (Matrix.trace (ρ * Xᴴ * X)).re := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   calc
     ‖X‖ ^ 2 = (inner ℂ X X).re := (inner_self_eq_norm_sq (𝕜 := ℂ) X).symm
     _ = (Matrix.trace (ρ * Xᴴ * X)).re :=
@@ -122,21 +98,17 @@ private theorem inner_rightMul_cfcSqrt
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-      (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
     inner ℂ (frobeniusLinearEquiv D (X * CFC.sqrt ρ))
         (frobeniusLinearEquiv D (Y * CFC.sqrt ρ)) = inner ℂ X Y := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   rw [inner_frobeniusLinearEquiv, rhoWeighted_inner ρ hρ]
   rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_cfc_sqrt]
   calc
@@ -157,18 +129,16 @@ noncomputable def rhoWeightedEquivEuclidean
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
     Matrix (Fin D) (Fin D) ℂ ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin D × Fin D) := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   exact {
     toFun X := frobeniusLinearEquiv D (X * CFC.sqrt ρ)
     invFun x := (frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹
@@ -211,19 +181,17 @@ theorem rhoWeightedEquivEuclidean_apply
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
     rhoWeightedEquivEuclidean ρ hρ X =
-      frobeniusLinearEquiv D (X * CFC.sqrt ρ) := by
+      WithLp.toLp 2 (X * CFC.sqrt ρ).vec := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   rfl
 
 /-- The inverse weighted Euclidean equivalence applies inverse Frobenius
@@ -235,19 +203,17 @@ theorem rhoWeightedEquivEuclidean_symm_apply
     letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixNormedAddCommGroup ρ hρ
     letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
     letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
       Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
     (rhoWeightedEquivEuclidean ρ hρ).symm x =
-      (frobeniusLinearEquiv D).symm x * (CFC.sqrt ρ)⁻¹ := by
+      Matrix.of (fun i j => WithLp.ofLp x (j, i)) * (CFC.sqrt ρ)⁻¹ := by
   let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup ρ hρ
   let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
   let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
-  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
-    (Matrix.toMatrixSeminormedAddCommGroup ρ hρ.posSemidef).toNorm
   rfl
 
 end

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1,8 +1,8 @@
 \subsection{The weighted virtual matrix space}%
 \label{subsec:weighted-virtual-matrix-space}
 
-\begin{definition}[Weighted virtual inner product]%
-    \label{def:weighted-virtual-inner-product}
+\begin{theorem}[Weighted virtual inner product]%
+    \label{thm:weighted-virtual-inner-product}
     \lean{Matrix.rhoWeighted_inner}
     \leanok
     Let $\rho\in M_D(\C)$ be positive definite.  The $\rho$-weighted inner
@@ -13,19 +13,29 @@
     \end{align}
     This is the auxiliary inner product in
     \cite[Equation~(5.6)]{Fannes1992Finitely}.
-\end{definition}
+\end{theorem}
 
 \begin{theorem}[Weighted norm formula]%
     \label{thm:weighted-virtual-norm-formula}
     \lean{Matrix.rhoWeighted_norm_sq}
     \leanok
-    \uses{def:weighted-virtual-inner-product}
+    \uses{thm:weighted-virtual-inner-product}
     For every $X\in M_D(\C)$,
     \begin{align}
         \lVert X\rVert_\rho^2
          & =\operatorname{Re}\tr\!\left(\rho X^\dagger X\right).
     \end{align}
 \end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:weighted-virtual-inner-product}
+    By Theorem~\ref{thm:weighted-virtual-inner-product} with $Y=X$,
+    \begin{align}
+        \lVert X\rVert_\rho^2
+         & =\operatorname{Re}\langle X,X\rangle_\rho             \\
+         & =\operatorname{Re}\tr\!\left(\rho X^\dagger X\right).
+    \end{align}
+\end{proof}
 
 \begin{definition}[Euclidean realization of the weighted matrix space]%
     \label{def:weighted-virtual-euclidean-realization}
@@ -33,7 +43,7 @@
     \lean{Matrix.rhoWeightedEquivEuclidean_apply}
     \lean{Matrix.rhoWeightedEquivEuclidean_symm_apply}
     \leanok
-    \uses{def:weighted-virtual-inner-product}
+    \uses{thm:weighted-virtual-inner-product}
     The map
     \begin{align}
         \Phi_\rho\colon M_D(\C) & \longrightarrow\C^{D^2},
@@ -45,9 +55,9 @@
         \Phi_\rho^{-1}(z)
          & =\operatorname{unvec}(z)\,(\sqrt\rho)^{-1}.
     \end{align}
-    This Euclidean realization packages the weighted space for subsequent
-    estimates; it is not asserted as a result of Fannes, Nachtergaele, and
-    Werner.
+    Thus the weighted matrix space has complex Hilbert dimension $D^2$.
+    This Euclidean realization is not asserted as a result of Fannes,
+    Nachtergaele, and Werner.
 \end{definition}
 
 \subsection{Nested ground projections and martingale differences}%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1,3 +1,55 @@
+\subsection{The weighted virtual matrix space}%
+\label{subsec:weighted-virtual-matrix-space}
+
+\begin{definition}[Weighted virtual inner product]%
+    \label{def:weighted-virtual-inner-product}
+    \lean{Matrix.rhoWeighted_inner}
+    \leanok
+    Let $\rho\in M_D(\C)$ be positive definite.  The $\rho$-weighted inner
+    product on $M_D(\C)$ is
+    \begin{align}
+        \langle X,Y\rangle_\rho
+         & =\tr\!\left(\rho X^\dagger Y\right).
+    \end{align}
+    This is the auxiliary inner product in
+    \cite[Equation~(5.6)]{Fannes1992Finitely}.
+\end{definition}
+
+\begin{theorem}[Weighted norm formula]%
+    \label{thm:weighted-virtual-norm-formula}
+    \lean{Matrix.rhoWeighted_norm_sq}
+    \leanok
+    \uses{def:weighted-virtual-inner-product}
+    For every $X\in M_D(\C)$,
+    \begin{align}
+        \lVert X\rVert_\rho^2
+         & =\operatorname{Re}\tr\!\left(\rho X^\dagger X\right).
+    \end{align}
+\end{theorem}
+
+\begin{definition}[Euclidean realization of the weighted matrix space]%
+    \label{def:weighted-virtual-euclidean-realization}
+    \lean{Matrix.rhoWeightedEquivEuclidean}
+    \lean{Matrix.rhoWeightedEquivEuclidean_apply}
+    \lean{Matrix.rhoWeightedEquivEuclidean_symm_apply}
+    \leanok
+    \uses{def:weighted-virtual-inner-product}
+    The map
+    \begin{align}
+        \Phi_\rho\colon M_D(\C) & \longrightarrow\C^{D^2},
+                                &
+        \Phi_\rho(X)            & =\operatorname{vec}\!\left(X\sqrt\rho\right)
+    \end{align}
+    is a complex linear isometric isomorphism.  Its inverse is
+    \begin{align}
+        \Phi_\rho^{-1}(z)
+         & =\operatorname{unvec}(z)\,(\sqrt\rho)^{-1}.
+    \end{align}
+    This Euclidean realization packages the weighted space for subsequent
+    estimates; it is not asserted as a result of Fannes, Nachtergaele, and
+    Werner.
+\end{definition}
+
 \subsection{Nested ground projections and martingale differences}%
 \label{subsec:nested-ground-projection-differences}
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1016,9 +1016,15 @@ $\operatorname{ran}\Gamma_L^{\mathrm{ES}}$. It is not
 
 To state the source estimate, let $l\in\mathbb N$ be the overlap length. Let
 $0\leq\lambda<1$ satisfy $|\mu|<\lambda$ for every non-unit eigenvalue $\mu$
-of the relevant transfer operator, and let $c\geq0$ be its prefactor. The
-source permits $c=k^2$, where $k$ is the bond dimension
-\cite[Section~6]{Nachtergaele1996Spectral}. Choose $l$ such that
+of the relevant transfer operator, and let $c\geq0$ be its prefactor.
+Nachtergaele states that one may take $c=k^2$, where $k$ is the Hilbert-space
+dimension of the minimal FNW auxiliary representation
+\cite[Section~6]{Nachtergaele1996Spectral}. The inspected FNW theorem trail
+does not yet recover this value for every faithful stationary density and every
+prescribed $\lambda$, nor does it identify the minimal dimension $k$ with the
+chosen bond dimension $D$ of an arbitrary tensor representation. The formal
+target therefore retains the prefactor $c$ until those comparisons are proved.
+Choose $l$ such that
 \begin{align}
     c\lambda^l
     &<1.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1685,6 +1685,14 @@ then gives the open-chain anticommutator estimate through two-projection
 geometry. The length $l$ is measured in sites of the input tensor; if that
 tensor is already blocked, one such site is one blocked-chain filtration step.
 
+The weighted virtual-space foundation is now formalized.  For every
+positive-definite $\rho$, matrices carry the inner product
+$\langle X,Y\rangle_\rho=\operatorname{Tr}(\rho X^\dagger Y)$ from
+Equation~(5.6) of Ref.~\cite{Fannes1992Finitely}, and right multiplication by
+$\sqrt\rho$ followed by vectorization identifies this space isometrically with
+$\C^{D^2}$.  This completes only the Hilbert-space package.  Lemmas~5.2, 5.3,
+and 6.2, including the optimized numerator, remain open.
+
 The reconstructed coefficient is not the optimized FNW expression
 \begin{align}
     c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},


### PR DESCRIPTION
## What changed

- package Mathlib's positive-definite weighted matrix inner product in the FNW convention
  \[
  \langle X,Y\rangle_\rho=\operatorname{Tr}(\rho X^\dagger Y)
  \]
- prove the corresponding squared-norm formula
- construct the linear isometric equivalence
  \[
  X\longmapsto \operatorname{vec}(X\sqrt\rho)
  \]
  with inverse right multiplication by $(\sqrt\rho)^{-1}$
- add formula-driven Chapter 13 coverage for all five public declarations
- mark only the weighted Hilbert-space foundation complete in the paper-gap note
- correct the note's source-constant wording: Nachtergaele's $k$ is the minimal FNW auxiliary Hilbert-space dimension, not automatically TNLean's chosen bond dimension $D$

This is source-neutral infrastructure for FNW 1992, Equation (5.6). It does not claim Lemmas 5.2, 5.3, or 6.2, the optimized projector numerator, $c=k^2$ in the general prescribed-rate setting, or $k=D$.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.WeightedVirtualHilbert TNLean.MPS.ParentHamiltonian` (9192/9192)
- `lake build` (10452/10452)
- generated import aggregators current: 37 files covering 1077 production modules
- Blueprint source sync: 7280 unique Lean references, 7304 theorem-like entries
- strict Blueprint declaration resolution passed
- paper-gap Lean identifier and slug checks passed
- reader-facing prose, style lint, forbidden-token, and whitespace checks passed
- LuaLaTeX stabilized at 1061 pages with zero individual undefined cross-references and no rerun warning; standalone citation warnings remain because the local build has no `print.bbl`

Closes #7582
Advances #6367
