### PR TITLE
feat(algebra): assemble the skew-unitary congruence

### DIFF
--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -12,9 +12,9 @@ import Mathlib.LinearAlgebra.Lagrange
 /-!
 # Congruence factorization of symmetric unitary matrices
 
-A complex symmetric unitary matrix has a symmetric unitary square root. The square root is the
-finite spectral-projector square root from CPSV17, Lemma `lemma:conjclass-normalform-continuous`
-(arXiv:1703.09188, lines 1054--1064).
+The two branches of the finite spectral-projector construction in CPSV17, Lemma
+`lemma:conjclass-normalform-continuous`, give congruence factorizations of symmetric and
+skew-symmetric unitary matrices (arXiv:1703.09188, lines 1054--1082).
 -/
 
 open scoped Polynomial
@@ -131,5 +131,249 @@ theorem exists_symmetric_unitary_squareRoot
     change ((Polynomial.aeval x) q).transpose = (Polynomial.aeval x) q
     rw [transpose_aeval, hsym]
   exact ⟨S, hS_symm, hS_unitary, by simpa [hS_symm] using hS_sq.symm⟩
+
+end Matrix
+
+namespace Matrix
+
+variable {ι κ m : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+  [Fintype m]
+
+/-- Multiplication of sums weighted by a complete orthogonal family of idempotents reduces
+pointwise to multiplication of their weights. -/
+theorem weighted_sum_mul_weighted_sum
+    (Q : ι → Matrix m m ℂ)
+    (hQmul : ∀ a b, Q a * Q b = if a = b then Q a else 0)
+    (u v : ι → ℂ) :
+    (∑ a, u a • Q a) * (∑ a, v a • Q a) = ∑ a, (u a * v a) • Q a := by
+  simp only [Finset.sum_mul, Finset.mul_sum, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+  simp [hQmul]
+  apply Finset.sum_congr rfl
+  intro a ha
+  rw [mul_comm]
+
+variable [DecidableEq m]
+
+/-- A sum of mutually orthogonal Hermitian idempotents with unit-modulus weights is unitary
+when the idempotents sum to the identity. -/
+theorem weighted_sum_mem_unitaryGroup
+    (Q : ι → Matrix m m ℂ)
+    (hQstar : ∀ a, (Q a)ᴴ = Q a)
+    (hQmul : ∀ a b, Q a * Q b = if a = b then Q a else 0)
+    (hQsum : ∑ a, Q a = 1)
+    (u : ι → ℂ)
+    (hu : ∀ a, ‖u a‖ = 1) :
+    (∑ a, u a • Q a) ∈ Matrix.unitaryGroup m ℂ := by
+  rw [Matrix.mem_unitaryGroup_iff']
+  change (∑ a, u a • Q a)ᴴ * (∑ a, u a • Q a) = 1
+  rw [Matrix.conjTranspose_sum]
+  simp_rw [Matrix.conjTranspose_smul, hQstar]
+  rw [weighted_sum_mul_weighted_sum Q hQmul]
+  convert hQsum using 1
+  apply Finset.sum_congr rfl
+  intro a ha
+  have hua : star (u a) * u a = 1 := by
+    change (starRingEnd ℂ) (u a) * u a = 1
+    rw [← Complex.normSq_eq_conj_mul_self, Complex.normSq_eq_norm_sq, hu]
+    norm_num
+  rw [hua, one_smul]
+
+/-- Assemble the skew-symmetric branch of the unitary congruence normal form from the paired
+spectral projectors in CPSV17, Lemma `lemma:conjclass-normalform-continuous`
+(arXiv:1703.09188, lines 1066--1082).
+
+The two summands of `Sum κ κ` index `P_E` and `P_Eᵀ`. The hypotheses say that these form a
+complete orthogonal family of Hermitian projectors. The witnesses are exactly
+`S = exp (-iπ/4) ∑_E exp (-iE/2) (P_E + P_Eᵀ)` and
+`Λ = i ∑_E (P_E - P_Eᵀ)` from the paper. -/
+theorem exists_skew_unitary_congruence_of_paired_projectors
+    (P : κ → Matrix (Sum κ κ) (Sum κ κ) ℂ)
+    (E : κ → ℝ)
+    (hPstar : ∀ k, (P k)ᴴ = P k)
+    (hPmul : ∀ a b : Sum κ κ,
+      Sum.elim P (fun k ↦ (P k).transpose) a *
+          Sum.elim P (fun k ↦ (P k).transpose) b =
+        if a = b then Sum.elim P (fun k ↦ (P k).transpose) a else 0)
+    (hPsum : ∑ a : Sum κ κ, Sum.elim P (fun k ↦ (P k).transpose) a = 1) :
+    let x := ∑ k, Complex.exp (-(E k : ℂ) * Complex.I) • (P k - (P k).transpose)
+    ∃ S Λ : Matrix (Sum κ κ) (Sum κ κ) ℂ,
+      S = Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) •
+          ∑ k, Complex.exp (-((E k : ℂ) / 2) * Complex.I) •
+            (P k + (P k).transpose) ∧
+      Λ = Complex.I • ∑ k, (P k - (P k).transpose) ∧
+      S.transpose = S ∧
+      S ∈ Matrix.unitaryGroup (Sum κ κ) ℂ ∧
+      Λ.map (starRingEnd ℂ) = Λ ∧
+      Λ.transpose = -Λ ∧
+      Λ ∈ Matrix.unitaryGroup (Sum κ κ) ℂ ∧
+      x = S.transpose * Λ * S := by
+  let Q : Sum κ κ → Matrix (Sum κ κ) (Sum κ κ) ℂ :=
+    Sum.elim P (fun k ↦ (P k).transpose)
+  let s : Sum κ κ → ℂ := fun a ↦
+    Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+      Complex.exp (-((E (Sum.elim id id a) : ℂ) / 2) * Complex.I)
+  let l : Sum κ κ → ℂ := Sum.elim (fun _ ↦ Complex.I) (fun _ ↦ -Complex.I)
+  let S : Matrix (Sum κ κ) (Sum κ κ) ℂ := ∑ a, s a • Q a
+  let Λ : Matrix (Sum κ κ) (Sum κ κ) ℂ := ∑ a, l a • Q a
+  have hQstar : ∀ a, (Q a)ᴴ = Q a := by
+    intro a
+    cases a with
+    | inl k => exact hPstar k
+    | inr k =>
+        ext i j
+        have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M j i) (hPstar k)
+        simpa [Q, Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
+  have hs_formula :
+      S = Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) •
+          ∑ k, Complex.exp (-((E k : ℂ) / 2) * Complex.I) •
+            (P k + (P k).transpose) := by
+    dsimp only [S]
+    rw [Fintype.sum_sum_type]
+    simp only [s, Q, Sum.elim_inl, Sum.elim_inr, id_eq]
+    rw [Finset.smul_sum]
+    simp_rw [smul_add, smul_smul]
+    rw [Finset.sum_add_distrib]
+  have hl_formula : Λ = Complex.I • ∑ k, (P k - (P k).transpose) := by
+    dsimp only [Λ]
+    rw [Fintype.sum_sum_type]
+    simp only [l, Q, Sum.elim_inl, Sum.elim_inr]
+    rw [Finset.smul_sum]
+    simp_rw [smul_sub]
+    rw [Finset.sum_sub_distrib]
+    simp only [neg_smul]
+    rw [sub_eq_add_neg]
+    congr 1
+    exact Finset.sum_neg_distrib (fun x : κ ↦ Complex.I • (P x).transpose)
+  have hS_transpose : S.transpose = S := by
+    rw [hs_formula]
+    simp only [Matrix.transpose_smul, Matrix.transpose_sum, Matrix.transpose_add,
+      Matrix.transpose_transpose]
+    congr 1
+    apply Finset.sum_congr rfl
+    intro k hk
+    rw [add_comm]
+  have hs_norm (a : Sum κ κ) : ‖s a‖ = 1 := by
+    simp only [s, norm_mul]
+    rw [Complex.norm_exp, Complex.norm_exp]
+    simp
+  have hS_unitary : S ∈ Matrix.unitaryGroup (Sum κ κ) ℂ := by
+    exact weighted_sum_mem_unitaryGroup Q hQstar hPmul hPsum s hs_norm
+  have hPmap (k : κ) : (P k).map (starRingEnd ℂ) = (P k).transpose := by
+    ext i j
+    have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M j i) (hPstar k)
+    simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
+  have hPtransposeMap (k : κ) : (P k).transpose.map (starRingEnd ℂ) = P k := by
+    ext i j
+    have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M i j) (hPstar k)
+    simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
+  have hmap_sub (k : κ) :
+      (P k - (P k).transpose).map (starRingEnd ℂ) = (P k).transpose - P k := by
+    rw [Matrix.map_sub (starRingEnd ℂ) (starRingEnd ℂ).map_sub, hPmap, hPtransposeMap]
+  have hmap_sum_finset (t : Finset κ) :
+      (∑ k ∈ t, (P k - (P k).transpose)).map (starRingEnd ℂ) =
+        ∑ k ∈ t, (P k - (P k).transpose).map (starRingEnd ℂ) := by
+    induction t using Finset.induction_on with
+    | empty => simp
+    | @insert a t ha ih =>
+        rw [Finset.sum_insert ha, Finset.sum_insert ha,
+          Matrix.map_add (starRingEnd ℂ) (starRingEnd ℂ).map_add, ih]
+  have hmap_sum :
+      (∑ k, (P k - (P k).transpose)).map (starRingEnd ℂ) =
+        ∑ k, (P k - (P k).transpose).map (starRingEnd ℂ) := by
+    simpa using hmap_sum_finset Finset.univ
+  have hsum_map :
+      (∑ k, (P k - (P k).transpose)).map (starRingEnd ℂ) =
+        -(∑ k, (P k - (P k).transpose)) := by
+    rw [hmap_sum]
+    simp_rw [hmap_sub]
+    rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_congr rfl
+    intro k hk
+    module
+  have hΛ_real : Λ.map (starRingEnd ℂ) = Λ := by
+    rw [hl_formula, Matrix.map_smul' (starRingEnd ℂ) Complex.I _
+      (starRingEnd ℂ).map_mul, hsum_map, Complex.conj_I]
+    module
+  have hΛ_transpose : Λ.transpose = -Λ := by
+    rw [hl_formula]
+    simp only [Matrix.transpose_smul, Matrix.transpose_sum, Matrix.transpose_sub,
+      Matrix.transpose_transpose]
+    have hneg : (∑ k, ((P k).transpose - P k)) =
+        -(∑ k, (P k - (P k).transpose)) := by
+      rw [← Finset.sum_neg_distrib]
+      apply Finset.sum_congr rfl
+      intro k hk
+      module
+    rw [hneg]
+    module
+  have hl_norm (a : Sum κ κ) : ‖l a‖ = 1 := by
+    cases a <;> simp [l]
+  have hΛ_unitary : Λ ∈ Matrix.unitaryGroup (Sum κ κ) ℂ := by
+    exact weighted_sum_mem_unitaryGroup Q hQstar hPmul hPsum l hl_norm
+  have hphase (r : ℝ) :
+      Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+          (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+            (Complex.I * (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+              Complex.exp (-((r : ℂ) / 2) * Complex.I)))) =
+        Complex.exp (-(r : ℂ) * Complex.I) := by
+    have hquarter :
+        Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+            Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) = -Complex.I := by
+      rw [← Complex.exp_add]
+      convert (Complex.exp_neg ((Real.pi : ℂ) / 2 * Complex.I)).trans
+        (congrArg Inv.inv Complex.exp_pi_div_two_mul_I) using 1 <;> ring_nf
+      simp
+    have hhalf :
+        Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+            Complex.exp (-((r : ℂ) / 2) * Complex.I) =
+          Complex.exp (-(r : ℂ) * Complex.I) := by
+      rw [← Complex.exp_add]
+      congr 1
+      ring
+    rw [show Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+        (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+          (Complex.I * (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+            Complex.exp (-((r : ℂ) / 2) * Complex.I)))) =
+        (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+          Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I)) *
+        (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+          Complex.exp (-((r : ℂ) / 2) * Complex.I)) * Complex.I by ring]
+    rw [hquarter, hhalf]
+    calc
+      (-Complex.I * Complex.exp (-(r : ℂ) * Complex.I)) * Complex.I =
+          -(Complex.I * Complex.I) * Complex.exp (-(r : ℂ) * Complex.I) := by ring
+      _ = Complex.exp (-(r : ℂ) * Complex.I) := by rw [Complex.I_mul_I]; ring
+  have hphase_neg (r : ℝ) :
+      Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+          (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+            (-Complex.I * (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+              Complex.exp (-((r : ℂ) / 2) * Complex.I)))) =
+        -Complex.exp (-(r : ℂ) * Complex.I) := by
+    rw [show Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+        (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+          (-Complex.I * (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+            Complex.exp (-((r : ℂ) / 2) * Complex.I)))) =
+      -(Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+        (Complex.exp (-((r : ℂ) / 2) * Complex.I) *
+          (Complex.I * (Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
+            Complex.exp (-((r : ℂ) / 2) * Complex.I))))) by ring, hphase]
+  have hfactor :
+      (∑ k, Complex.exp (-(E k : ℂ) * Complex.I) • (P k - (P k).transpose)) =
+        S.transpose * Λ * S := by
+    rw [hS_transpose]
+    dsimp only [S, Λ]
+    rw [weighted_sum_mul_weighted_sum Q hPmul,
+      weighted_sum_mul_weighted_sum Q hPmul]
+    rw [Fintype.sum_sum_type]
+    simp only [s, l, Q, Sum.elim_inl, Sum.elim_inr, id_eq, mul_assoc]
+    simp_rw [hphase, hphase_neg, smul_sub]
+    rw [Finset.sum_sub_distrib, sub_eq_add_neg]
+    congr 1
+    rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_congr rfl
+    intro k hk
+    rw [neg_smul]
+  exact ⟨S, Λ, hs_formula, hl_formula, hS_transpose, hS_unitary, hΛ_real,
+    hΛ_transpose, hΛ_unitary, hfactor⟩
 
 end Matrix

--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -147,7 +147,8 @@ theorem weighted_sum_mul_weighted_sum
     (u v : ι → ℂ) :
     (∑ a, u a • Q a) * (∑ a, v a • Q a) = ∑ a, (u a * v a) • Q a := by
   simp only [Finset.sum_mul, Finset.mul_sum, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-  simp [hQmul]
+  simp only [hQmul, smul_ite, smul_zero, Finset.sum_ite_eq', Finset.mem_univ,
+    ↓reduceIte]
   apply Finset.sum_congr rfl
   intro a ha
   rw [mul_comm]

--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -188,7 +188,7 @@ complete orthogonal family of Hermitian projectors. The witnesses are exactly
 `S = exp (-iπ/4) ∑_E exp (-iE/2) (P_E + P_Eᵀ)` and
 `Λ = i ∑_E (P_E - P_Eᵀ)` from the paper. -/
 theorem exists_skew_unitary_congruence_of_paired_projectors
-    (P : κ → Matrix (Sum κ κ) (Sum κ κ) ℂ)
+    (P : κ → Matrix m m ℂ)
     (E : κ → ℝ)
     (hPstar : ∀ k, (P k)ᴴ = P k)
     (hPmul : ∀ a b : Sum κ κ,
@@ -197,32 +197,32 @@ theorem exists_skew_unitary_congruence_of_paired_projectors
         if a = b then Sum.elim P (fun k ↦ (P k).transpose) a else 0)
     (hPsum : ∑ a : Sum κ κ, Sum.elim P (fun k ↦ (P k).transpose) a = 1) :
     let x := ∑ k, Complex.exp (-(E k : ℂ) * Complex.I) • (P k - (P k).transpose)
-    ∃ S Λ : Matrix (Sum κ κ) (Sum κ κ) ℂ,
+    ∃ S Λ : Matrix m m ℂ,
       S = Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) •
           ∑ k, Complex.exp (-((E k : ℂ) / 2) * Complex.I) •
             (P k + (P k).transpose) ∧
       Λ = Complex.I • ∑ k, (P k - (P k).transpose) ∧
       S.transpose = S ∧
-      S ∈ Matrix.unitaryGroup (Sum κ κ) ℂ ∧
+      S ∈ Matrix.unitaryGroup m ℂ ∧
       Λ.map (starRingEnd ℂ) = Λ ∧
       Λ.transpose = -Λ ∧
-      Λ ∈ Matrix.unitaryGroup (Sum κ κ) ℂ ∧
+      Λ ∈ Matrix.unitaryGroup m ℂ ∧
       x = S.transpose * Λ * S := by
-  let Q : Sum κ κ → Matrix (Sum κ κ) (Sum κ κ) ℂ :=
+  let Q : Sum κ κ → Matrix m m ℂ :=
     Sum.elim P (fun k ↦ (P k).transpose)
   let s : Sum κ κ → ℂ := fun a ↦
     Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *
       Complex.exp (-((E (Sum.elim id id a) : ℂ) / 2) * Complex.I)
   let l : Sum κ κ → ℂ := Sum.elim (fun _ ↦ Complex.I) (fun _ ↦ -Complex.I)
-  let S : Matrix (Sum κ κ) (Sum κ κ) ℂ := ∑ a, s a • Q a
-  let Λ : Matrix (Sum κ κ) (Sum κ κ) ℂ := ∑ a, l a • Q a
+  let S : Matrix m m ℂ := ∑ a, s a • Q a
+  let Λ : Matrix m m ℂ := ∑ a, l a • Q a
   have hQstar : ∀ a, (Q a)ᴴ = Q a := by
     intro a
     cases a with
     | inl k => exact hPstar k
     | inr k =>
         ext i j
-        have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M j i) (hPstar k)
+        have h := congrArg (fun M : Matrix m m ℂ ↦ M j i) (hPstar k)
         simpa [Q, Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
   have hs_formula :
       S = Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) •
@@ -257,15 +257,15 @@ theorem exists_skew_unitary_congruence_of_paired_projectors
     simp only [s, norm_mul]
     rw [Complex.norm_exp, Complex.norm_exp]
     simp
-  have hS_unitary : S ∈ Matrix.unitaryGroup (Sum κ κ) ℂ := by
+  have hS_unitary : S ∈ Matrix.unitaryGroup m ℂ := by
     exact weighted_sum_mem_unitaryGroup Q hQstar hPmul hPsum s hs_norm
   have hPmap (k : κ) : (P k).map (starRingEnd ℂ) = (P k).transpose := by
     ext i j
-    have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M j i) (hPstar k)
+    have h := congrArg (fun M : Matrix m m ℂ ↦ M j i) (hPstar k)
     simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
   have hPtransposeMap (k : κ) : (P k).transpose.map (starRingEnd ℂ) = P k := by
     ext i j
-    have h := congrArg (fun M : Matrix (Sum κ κ) (Sum κ κ) ℂ ↦ M i j) (hPstar k)
+    have h := congrArg (fun M : Matrix m m ℂ ↦ M i j) (hPstar k)
     simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
   have hmap_sub (k : κ) :
       (P k - (P k).transpose).map (starRingEnd ℂ) = (P k).transpose - P k := by
@@ -309,7 +309,7 @@ theorem exists_skew_unitary_congruence_of_paired_projectors
     module
   have hl_norm (a : Sum κ κ) : ‖l a‖ = 1 := by
     cases a <;> simp [l]
-  have hΛ_unitary : Λ ∈ Matrix.unitaryGroup (Sum κ κ) ℂ := by
+  have hΛ_unitary : Λ ∈ Matrix.unitaryGroup m ℂ := by
     exact weighted_sum_mem_unitaryGroup Q hQstar hPmul hPsum l hl_norm
   have hphase (r : ℝ) :
       Complex.exp (-((Real.pi : ℂ) / 4) * Complex.I) *

--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -10,7 +10,7 @@ import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 import Mathlib.LinearAlgebra.Lagrange
 
 /-!
-# Congruence factorization of symmetric unitary matrices
+# Congruence factorizations of symmetric and skew-symmetric unitary matrices
 
 The two branches of the finite spectral-projector construction in CPSV17, Lemma
 `lemma:conjclass-normalform-continuous`, give congruence factorizations of symmetric and

--- a/TNLean/Algebra/UnitaryCongruence.lean
+++ b/TNLean/Algebra/UnitaryCongruence.lean
@@ -139,7 +139,7 @@ namespace Matrix
 variable {ι κ m : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
   [Fintype m]
 
-/-- Multiplication of sums weighted by a complete orthogonal family of idempotents reduces
+/-- Multiplication of sums weighted by a family of orthogonal idempotents reduces
 pointwise to multiplication of their weights. -/
 theorem weighted_sum_mul_weighted_sum
     (Q : ι → Matrix m m ℂ)
@@ -216,6 +216,11 @@ theorem exists_skew_unitary_congruence_of_paired_projectors
   let l : Sum κ κ → ℂ := Sum.elim (fun _ ↦ Complex.I) (fun _ ↦ -Complex.I)
   let S : Matrix m m ℂ := ∑ a, s a • Q a
   let Λ : Matrix m m ℂ := ∑ a, l a • Q a
+  have hPmap (k : κ) : (P k).map (starRingEnd ℂ) = (P k).transpose := by
+    calc
+      (P k).map (starRingEnd ℂ) = (P k)ᴴ.transpose :=
+        (Matrix.conjTranspose_transpose (P k)).symm
+      _ = (P k).transpose := congrArg Matrix.transpose (hPstar k)
   have hQstar : ∀ a, (Q a)ᴴ = Q a := by
     intro a
     cases a with
@@ -259,14 +264,8 @@ theorem exists_skew_unitary_congruence_of_paired_projectors
     simp
   have hS_unitary : S ∈ Matrix.unitaryGroup m ℂ := by
     exact weighted_sum_mem_unitaryGroup Q hQstar hPmul hPsum s hs_norm
-  have hPmap (k : κ) : (P k).map (starRingEnd ℂ) = (P k).transpose := by
-    ext i j
-    have h := congrArg (fun M : Matrix m m ℂ ↦ M j i) (hPstar k)
-    simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
   have hPtransposeMap (k : κ) : (P k).transpose.map (starRingEnd ℂ) = P k := by
-    ext i j
-    have h := congrArg (fun M : Matrix m m ℂ ↦ M i j) (hPstar k)
-    simpa [Matrix.conjTranspose_apply, Matrix.transpose_apply] using h
+    rw [Matrix.transpose_map, hPmap, Matrix.transpose_transpose]
   have hmap_sub (k : κ) :
       (P k - (P k).transpose).map (starRingEnd ℂ) = (P k).transpose - P k := by
     rw [Matrix.map_sub (starRingEnd ℂ) (starRingEnd ℂ).map_sub, hPmap, hPtransposeMap]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6709,20 +6709,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{lem:mpu_skew_unitary_paired_projectors}
     \lean{Matrix.exists_skew_unitary_congruence_of_paired_projectors}
     \leanok
-    Let $E$ range over a finite set, and let $P_E$ be Hermitian projectors on
-    $\mathbb C^{E\sqcup E}$. Suppose that the family
-    $\{P_E,P_E^T\}_E$ consists of mutually orthogonal projectors and sums to
-    the identity. Define
+    Let $K$ and $I$ be finite sets, let $E_k\in\mathbb R$ for $k\in K$, and
+    let $P_k$ be Hermitian projectors on $\mathbb C^I$. Suppose that the family
+    $\{P_k,P_k^T\}_{k\in K}$ consists of mutually orthogonal projectors and
+    sums to the identity. Define
     \begin{align}
-        x & = \sum_E e^{-iE}(P_E-P_E^T).
+        x & = \sum_{k\in K} e^{-iE_k}(P_k-P_k^T).
     \end{align}
     Then the matrices
     \begin{align}
-        S & = e^{-i\pi/4}\sum_E e^{-iE/2}(P_E+P_E^T),
+        S & = e^{-i\pi/4}\sum_{k\in K} e^{-iE_k/2}(P_k+P_k^T),
     \end{align}
     and
     \begin{align}
-        \widetilde\Lambda & = i\sum_E(P_E-P_E^T)
+        \widetilde\Lambda & = i\sum_{k\in K}(P_k-P_k^T)
     \end{align}
     are unitary, $S^T=S$, $\overline{\widetilde\Lambda}=\widetilde\Lambda$,
     $\widetilde\Lambda^T=-\widetilde\Lambda$, and
@@ -6735,16 +6735,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{proof}\leanok
     Write the two projectors in each pair as separate members of one complete
     orthogonal family. A weighted sum of this family is unitary whenever every
-    weight has modulus one. This applies to $S$, whose two weights over $E$
-    both equal $e^{-i\pi/4}e^{-iE/2}$, and to
+    weight has modulus one. This applies to $S$, whose two weights at $k$
+    both equal $e^{-i\pi/4}e^{-iE_k/2}$, and to
     $\widetilde\Lambda$, whose weights are $i$ and $-i$.
     Transposition exchanges the two members of each pair, proving the symmetry
     of $S$ and the skew symmetry of $\widetilde\Lambda$. Hermiticity gives
-    $\overline{P_E}=P_E^T$, hence
+    $\overline{P_k}=P_k^T$, hence
     $\overline{\widetilde\Lambda}=\widetilde\Lambda$. Finally, orthogonality
     reduces the product to its weights, and
     \begin{align}
-        \left(e^{-i\pi/4}e^{-iE/2}\right)^2 i & = e^{-iE}.
+        \left(e^{-i\pi/4}e^{-iE_k/2}\right)^2 i & = e^{-iE_k}.
     \end{align}
     The transposed member has the negative weight, which gives
     $x=S^T\widetilde\Lambda S$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6705,11 +6705,56 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $x^T=x$ implies $S^T=q(x^T)=q(x)=S$. Therefore $x=S^2=S^T S$.
 \end{proof}
 
+\begin{lemma}[Skew congruence from paired spectral projectors]
+    \label{lem:mpu_skew_unitary_paired_projectors}
+    \lean{Matrix.exists_skew_unitary_congruence_of_paired_projectors}
+    \leanok
+    Let $E$ range over a finite set, and let $P_E$ be Hermitian projectors on
+    $\mathbb C^{E\sqcup E}$. Suppose that the family
+    $\{P_E,P_E^T\}_E$ consists of mutually orthogonal projectors and sums to
+    the identity. Define
+    \begin{align}
+        x & = \sum_E e^{-iE}(P_E-P_E^T).
+    \end{align}
+    Then the matrices
+    \begin{align}
+        S & = e^{-i\pi/4}\sum_E e^{-iE/2}(P_E+P_E^T),
+    \end{align}
+    and
+    \begin{align}
+        \widetilde\Lambda & = i\sum_E(P_E-P_E^T)
+    \end{align}
+    are unitary, $S^T=S$, $\overline{\widetilde\Lambda}=\widetilde\Lambda$,
+    $\widetilde\Lambda^T=-\widetilde\Lambda$, and
+    \begin{align}
+        x & = S^T\widetilde\Lambda S.
+    \end{align}
+    % Source lines: paper_v2.tex 1066--1082.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write the two projectors in each pair as separate members of one complete
+    orthogonal family. A weighted sum of this family is unitary whenever every
+    weight has modulus one. This applies to $S$, whose two weights over $E$
+    both equal $e^{-i\pi/4}e^{-iE/2}$, and to
+    $\widetilde\Lambda$, whose weights are $i$ and $-i$.
+    Transposition exchanges the two members of each pair, proving the symmetry
+    of $S$ and the skew symmetry of $\widetilde\Lambda$. Hermiticity gives
+    $\overline{P_E}=P_E^T$, hence
+    $\overline{\widetilde\Lambda}=\widetilde\Lambda$. Finally, orthogonality
+    reduces the product to its weights, and
+    \begin{align}
+        \left(e^{-i\pi/4}e^{-iE/2}\right)^2 i & = e^{-iE}.
+    \end{align}
+    The transposed member has the negative weight, which gives
+    $x=S^T\widetilde\Lambda S$.
+\end{proof}
+
 \begin{lemma}[Normal form of symmetric and skew-symmetric unitaries]
     \label{lemma:conjclass-normalform-continuous}
     \notready
     \discussion{5713}
-    \uses{lem:mpu_symmetric_unitary_congruence}
+    \uses{lem:mpu_symmetric_unitary_congruence, lem:mpu_skew_unitary_paired_projectors}
     Let $x$ be unitary and satisfy $x=x^T$ or $x=-x^T$. There are a symmetric
     unitary $S$ and a matrix $\widetilde\Lambda$ such that
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6729,6 +6729,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         x & = S^T\widetilde\Lambda S.
     \end{align}
+    This is the paired-projector construction in the skew branch of
+    \cite[Lemma~\texttt{lemma:conjclass-normalform-continuous}]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 1066--1082.
 \end{lemma}
 


### PR DESCRIPTION
## What changed

- formalize the explicit paired-projector construction in the skew branch of CPSV17:
  \[
  S=e^{-i\pi/4}\sum_E e^{-iE/2}(P_E+P_E^T),
  \qquad
  \widetilde\Lambda=i\sum_E(P_E-P_E^T)
  \]
- prove $S$ is symmetric and unitary, $\widetilde\Lambda$ is entrywise real, skew-symmetric, and unitary, and
  \[
  x=S^T\widetilde\Lambda S
  \]
- add reusable multiplication and unitarity lemmas for weighted complete orthogonal-projector sums
- keep the projector-label type independent of the ambient matrix index, so spectral projectors may have arbitrary multiplicity
- add a checked Chapter 28 supplied-projector lemma while leaving spectral-pair extraction (#7587), determinant one (#7588), and the full skew theorem `\notready`

The proof follows CPSV17 lines 1066-1082 and retains the source phase $e^{-i\pi/4}$. It makes no rank-one projector assumption and no continuity claim.

## Validation

- `lake build TNLean.Algebra.UnitaryCongruence` (2980/2980 on exact hot-main cache)
- independent source/mathematical review and simplifier review
- full pre-publication build (10451/10451 before final unrelated-main rebase)
- repository style and proof-integrity checks
- Blueprint synchronization (7305/7305 theorem-like entries after rebase)
- strict declaration checks
- double LuaLaTeX, zero undefined cross-references
- diagnostics clean
- `git diff --check`

Closes #7586
Advances #7580
Advances #7572
