### PR TITLE
feat(parent): formalize the FNW transfer convention

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -51,6 +51,7 @@ import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.FNWContraction
+import TNLean.MPS.ParentHamiltonian.FNWTransferConvention
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
@@ -17,10 +17,11 @@ Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
 \(A^\mu=v(\mu)^\dagger\), the FNW map is the bilinear trace-pairing adjoint of
 TNLean's transfer map.
 
-Here "adjoint" refers only to the bilinear pairing
-\(\operatorname{Tr}(XY)\). It is neither a `ContinuousLinearMap` adjoint nor
-the Hilbert-space adjoint for the rho-weighted inner product of FNW equation
-(5.6).
+The theorem below is phrased using only the bilinear pairing
+\(\operatorname{Tr}(XY)\). For the unweighted Frobenius inner product, the
+same map also agrees with the Hilbert-space adjoint of TNLean's transfer map.
+It is generally different from the Hilbert-space adjoint for the rho-weighted
+inner product of FNW equation (5.6).
 -/
 
 open scoped Matrix
@@ -39,8 +40,9 @@ def fnwTransferMap (A : MPSTensor d D) : Mat →ₗ[ℂ] Mat :=
   Kraus.transferMap fun μ => (A μ)ᴴ
 
 /-- Under \(A^\mu=v(\mu)^\dagger\), the FNW map in equations (5.1)--(5.3) is the
-bilinear trace-pairing adjoint of TNLean's transfer map. This is not a
-`ContinuousLinearMap` adjoint or a rho-weighted Hilbert adjoint. -/
+bilinear trace-pairing adjoint of TNLean's transfer map. It also agrees with
+the Hilbert-space adjoint for the unweighted Frobenius inner product, but is
+generally different from the rho-weighted adjoint of equation (5.6). -/
 theorem fnwTransferMap_eq_traceAdjointMap (A : MPSTensor d D) :
     fnwTransferMap A = Matrix.traceAdjointMap (Kraus.transferMap A) := by
   simpa only [fnwTransferMap] using
@@ -55,9 +57,9 @@ theorem fnwTransferMap_one (A : MPSTensor d D) (hA : IsLeftCanonical A) :
     (Kraus.isTracePreservingMap_mapLM_of_isTP A hA)
 
 /-- The explicit convention bridge for FNW 1992, equations (5.1)--(5.3):
-pairing a density \(\rho\) against the FNW map equals pairing TNLean's transfer of
-\(\rho\) against the observable \(X\). The pairing is the bilinear matrix trace, not a
-`ContinuousLinearMap` or rho-weighted Hilbert adjoint pairing. -/
+pairing a density \(\rho\) against the FNW map equals pairing TNLean's transfer
+of \(\rho\) against the observable \(X\). The displayed identity uses the
+bilinear matrix trace rather than the rho-weighted Hilbert pairing. -/
 theorem trace_mul_fnwTransferMap (A : MPSTensor d D) (ρ X : Mat) :
     Matrix.trace (ρ * fnwTransferMap A X) =
       Matrix.trace (Kraus.transferMap A ρ * X) := by

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Channel.Irreducible.AdjointFamily
+import QICLean.Kraus.Transfer
+import TNLean.MPS.Core.CanonicalNormalization
+
+/-!
+# FNW transfer-map convention
+
+Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
+(1992), 443--490, equations (5.1)--(5.3), use
+\(E(B)=\sum_\mu v_\mu Bv_\mu^*\). TNLean uses the Schrödinger convention
+\(\mathcal T_A(X)=\sum_\mu A_\mu X A_\mu^*\). Under
+\(A_\mu=v_\mu^*\), the FNW map is the bilinear trace-pairing adjoint of
+TNLean's transfer map.
+
+Here "adjoint" refers only to the bilinear pairing
+\(\operatorname{Tr}(XY)\). It is neither a `ContinuousLinearMap` adjoint nor
+the Hilbert-space adjoint for the rho-weighted inner product of FNW equation
+(5.6).
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+noncomputable section
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The FNW 1992 transfer map from equations (5.1)--(5.3), in TNLean coordinates
+\(A_\mu=v_\mu^*\). -/
+def fnwTransferMap (A : MPSTensor d D) : Mat →ₗ[ℂ] Mat :=
+  Kraus.transferMap fun μ => (A μ)ᴴ
+
+/-- Under \(A_\mu=v_\mu^*\), the FNW map in equations (5.1)--(5.3) is the
+bilinear trace-pairing adjoint of TNLean's transfer map. This is not a
+`ContinuousLinearMap` adjoint or a rho-weighted Hilbert adjoint. -/
+theorem fnwTransferMap_eq_traceAdjointMap (A : MPSTensor d D) :
+    fnwTransferMap A = Matrix.traceAdjointMap (Kraus.transferMap A) := by
+  simpa only [fnwTransferMap] using
+    (Kraus.traceAdjointMap_mapLM_eq_mapLM_conjTranspose A).symm
+
+/-- The unitality identity in FNW 1992, equations (5.2)--(5.3), follows exactly
+from TNLean's left-canonical, equivalently trace-preserving, normalization. -/
+theorem fnwTransferMap_one (A : MPSTensor d D) (hA : IsLeftCanonical A) :
+    fnwTransferMap A 1 = 1 := by
+  rw [fnwTransferMap_eq_traceAdjointMap]
+  exact isTracePreservingMap_iff_traceAdjointMap_one.mp
+    (Kraus.isTracePreservingMap_mapLM_of_isTP A hA)
+
+/-- The explicit convention bridge for FNW 1992, equations (5.1)--(5.3):
+pairing a density `ρ` against the FNW map equals pairing TNLean's transfer of
+`ρ` against the observable `X`. The pairing is the bilinear matrix trace, not a
+`ContinuousLinearMap` or rho-weighted Hilbert adjoint pairing. -/
+theorem trace_mul_fnwTransferMap (A : MPSTensor d D) (ρ X : Mat) :
+    Matrix.trace (ρ * fnwTransferMap A X) =
+      Matrix.trace (Kraus.transferMap A ρ * X) := by
+  rw [fnwTransferMap_eq_traceAdjointMap, Matrix.trace_mul_comm]
+  calc
+    Matrix.trace (Matrix.traceAdjointMap (Kraus.transferMap A) X * ρ) =
+        Matrix.trace (X * Kraus.transferMap A ρ) :=
+      Matrix.trace_traceAdjointMap_mul (Kraus.transferMap A) X ρ
+    _ = Matrix.trace (Kraus.transferMap A ρ * X) := Matrix.trace_mul_comm _ _
+
+end
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferConvention.lean
@@ -13,8 +13,8 @@ import TNLean.MPS.Core.CanonicalNormalization
 Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
 (1992), 443--490, equations (5.1)--(5.3), use
 \(E(B)=\sum_\mu v_\mu Bv_\mu^*\). TNLean uses the Schrödinger convention
-\(\mathcal T_A(X)=\sum_\mu A_\mu X A_\mu^*\). Under
-\(A_\mu=v_\mu^*\), the FNW map is the bilinear trace-pairing adjoint of
+\(\E_A(X)=\sum_\mu A^\mu X (A^\mu)^\dagger\). Under
+\(A^\mu=v(\mu)^\dagger\), the FNW map is the bilinear trace-pairing adjoint of
 TNLean's transfer map.
 
 Here "adjoint" refers only to the bilinear pairing
@@ -34,11 +34,11 @@ variable {d D : ℕ}
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-- The FNW 1992 transfer map from equations (5.1)--(5.3), in TNLean coordinates
-\(A_\mu=v_\mu^*\). -/
+\(A^\mu=v(\mu)^\dagger\). -/
 def fnwTransferMap (A : MPSTensor d D) : Mat →ₗ[ℂ] Mat :=
   Kraus.transferMap fun μ => (A μ)ᴴ
 
-/-- Under \(A_\mu=v_\mu^*\), the FNW map in equations (5.1)--(5.3) is the
+/-- Under \(A^\mu=v(\mu)^\dagger\), the FNW map in equations (5.1)--(5.3) is the
 bilinear trace-pairing adjoint of TNLean's transfer map. This is not a
 `ContinuousLinearMap` adjoint or a rho-weighted Hilbert adjoint. -/
 theorem fnwTransferMap_eq_traceAdjointMap (A : MPSTensor d D) :
@@ -55,8 +55,8 @@ theorem fnwTransferMap_one (A : MPSTensor d D) (hA : IsLeftCanonical A) :
     (Kraus.isTracePreservingMap_mapLM_of_isTP A hA)
 
 /-- The explicit convention bridge for FNW 1992, equations (5.1)--(5.3):
-pairing a density `ρ` against the FNW map equals pairing TNLean's transfer of
-`ρ` against the observable `X`. The pairing is the bilinear matrix trace, not a
+pairing a density \(\rho\) against the FNW map equals pairing TNLean's transfer of
+\(\rho\) against the observable \(X\). The pairing is the bilinear matrix trace, not a
 `ContinuousLinearMap` or rho-weighted Hilbert adjoint pairing. -/
 theorem trace_mul_fnwTransferMap (A : MPSTensor d D) (ρ X : Mat) :
     Matrix.trace (ρ * fnwTransferMap A X) =

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -262,7 +262,7 @@ orthogonal projector is the canonical representative used here.
 
 The FNW convention starts from an isometry
 $V\colon\C^D\to\C^d\otimes\C^D$ written as
-$V\xi=\sum_\mu\ket{\mu}\otimes v(\mu)\xi$ in
+$V\xi=\sum_\mu\ket{\mu}\otimes v(\mu)^\dagger\xi$ in
 \cite[Equation~(5.2)]{Fannes1992Finitely}. Equations~(5.3b) and~(5.3d)
 of that paper give
 $\sum_\mu v(\mu)v(\mu)^\dagger=I_D$ and
@@ -300,9 +300,11 @@ used in the convention identities below.
          & =\tr\!\left(X\E_A^\sharp(Y)\right).
         \label{eq:fnw_transfer_map_trace_adjoint}
     \end{align}
-    Then $E_{\mathrm{FNW},A}=\E_A^\sharp$. Here $\sharp$ denotes only the
-    adjoint for $(X,Y)\mapsto\tr(XY)$. It is neither the Hilbert adjoint on the
-    unweighted Frobenius space nor the Hilbert adjoint for the
+    Then $E_{\mathrm{FNW},A}=\E_A^\sharp$. Here $\sharp$ denotes the adjoint
+    for $(X,Y)\mapsto\tr(XY)$, so the theorem is phrased as a bilinear
+    trace-adjoint identity. For the unweighted Frobenius inner product, the
+    same map also agrees with the Hilbert-space adjoint of $\E_A$. This
+    Frobenius adjoint is generally different from the adjoint for the
     $\rho$-weighted inner product in
     \cite[Equation~(5.6)]{Fannes1992Finitely}.
 \end{theorem}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -260,6 +260,119 @@ orthogonal projector is the canonical representative used here.
     \end{align}
 \end{definition}
 
+The FNW convention starts from an isometry
+$V\colon\C^D\to\C^d\otimes\C^D$ written as
+$V\xi=\sum_\mu\ket{\mu}\otimes v(\mu)\xi$ in
+\cite[Equation~(5.2)]{Fannes1992Finitely}. Equations~(5.3b) and~(5.3d)
+of that paper give
+$\sum_\mu v(\mu)v(\mu)^\dagger=I_D$ and
+$E(B)=\sum_\mu v(\mu)Bv(\mu)^\dagger$. Under the identification
+$A^\mu=v(\mu)^\dagger$, this map uses the adjoint tensor letters. The
+asymptotic identity
+$E^n(B)\to\tr(\rho B)I_D$ in
+\cite[Equation~(5.1)]{Fannes1992Finitely} is a separate assertion and is not
+used in the convention identities below.
+
+\begin{definition}[FNW transfer map]
+    \label{def:fnw_transfer_map}
+    \lean{MPSTensor.fnwTransferMap}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A$ be an MPS tensor, with $A^\mu=v(\mu)^\dagger$ in the notation of
+    \cite[Equations~(5.2)--(5.3)]{Fannes1992Finitely}. Its FNW transfer map is
+    \begin{align}
+        E_{\mathrm{FNW},A}(X)
+         & :=\sum_{\mu=0}^{d-1}(A^\mu)^\dagger X A^\mu
+        =\sum_{\mu=0}^{d-1}v(\mu)Xv(\mu)^\dagger.
+        \label{eq:fnw_transfer_map}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[FNW map as the trace-pairing adjoint]
+    \label{thm:fnw_transfer_map_trace_adjoint}
+    \lean{MPSTensor.fnwTransferMap_eq_traceAdjointMap}
+    \leanok
+    \uses{def:fnw_transfer_map, def:transfer_map}
+    Write $\E_A^\sharp$ for the adjoint of $\E_A$ with respect to the
+    bilinear trace pairing, characterized by
+    \begin{align}
+        \tr\!\left(\E_A(X)Y\right)
+         & =\tr\!\left(X\E_A^\sharp(Y)\right).
+        \label{eq:fnw_transfer_map_trace_adjoint}
+    \end{align}
+    Then $E_{\mathrm{FNW},A}=\E_A^\sharp$. Here $\sharp$ denotes only the
+    adjoint for $(X,Y)\mapsto\tr(XY)$. It is neither the Hilbert adjoint on the
+    unweighted Frobenius space nor the Hilbert adjoint for the
+    $\rho$-weighted inner product in
+    \cite[Equation~(5.6)]{Fannes1992Finitely}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_transfer_map, def:transfer_map}
+    Expanding both maps and using cyclicity of trace gives
+    \begin{align}
+        \tr\!\left(\E_A(X)Y\right)
+         & =\sum_\mu\tr\!\left(A^\mu X(A^\mu)^\dagger Y\right)
+        =\sum_\mu\tr\!\left(X(A^\mu)^\dagger YA^\mu\right).
+    \end{align}
+    The final sum is $\tr(XE_{\mathrm{FNW},A}(Y))$.
+\end{proof}
+
+\begin{theorem}[Unitality of the FNW transfer map]
+    \label{thm:fnw_transfer_map_one}
+    \lean{MPSTensor.fnwTransferMap_one}
+    \leanok
+    \uses{def:fnw_transfer_map, def:left_canonical_tensor}
+    If $A$ is left canonical, then
+    \begin{align}
+        E_{\mathrm{FNW},A}(I_D) & =I_D.
+        \label{eq:fnw_transfer_map_one}
+    \end{align}
+    Under $A^\mu=v(\mu)^\dagger$, this is the normalization
+    $\sum_\mu v(\mu)v(\mu)^\dagger=I_D$ from
+    \cite[Equation~(5.3b)]{Fannes1992Finitely}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_transfer_map_trace_adjoint, lem:trace_transfer_map_left_canonical}
+    Left canonicity makes $\E_A$ trace-preserving. Therefore, for every $X$,
+    \begin{align}
+        \tr\!\left(XE_{\mathrm{FNW},A}(I_D)\right)
+         & =\tr\!\left(\E_A(X)\right)=\tr(X).
+    \end{align}
+    Nondegeneracy of the trace pairing gives
+    $E_{\mathrm{FNW},A}(I_D)=I_D$.
+\end{proof}
+
+\begin{theorem}[FNW transfer pairing identity]
+    \label{thm:trace_mul_fnw_transfer_map}
+    \lean{MPSTensor.trace_mul_fnwTransferMap}
+    \leanok
+    \uses{def:fnw_transfer_map, def:transfer_map}
+    For all $\rho,X\in\MN{D}$,
+    \begin{align}
+        \tr\!\left(\rho E_{\mathrm{FNW},A}(X)\right)
+         & =\tr\!\left(\E_A(\rho)X\right).
+        \label{eq:trace_mul_fnw_transfer_map}
+    \end{align}
+    This is the explicit trace-pairing form of the convention
+    $A^\mu=v(\mu)^\dagger$ for the map in
+    \cite[Equations~(5.2)--(5.3)]{Fannes1992Finitely}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_transfer_map_trace_adjoint}
+    Substitute the trace-pairing adjoint identity and use cyclicity of trace.
+\end{proof}
+
+These identities only compare the two transfer-map conventions. They do not
+include the weighted decay estimate of
+\cite[Lemma~5.2]{Fannes1992Finitely}, and they make no assertion of a
+constant $C_\lambda=k^2$.
+
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}
     \lean{Matrix.gramReshuffle}


### PR DESCRIPTION
## What changed

- define the FNW observable transfer map using the pointwise conjugate-transposed MPS family
- prove that it is the bilinear trace-pairing adjoint of TNLean's transfer map
- derive unitality from left-canonical normalization and state the explicit trace-pairing identity
- document the exact FNW equations (5.1)-(5.3) convention in Chapter 13

## Source scope

Under $A^\mu=v(\mu)^\dagger$,

$$
E_{\mathrm{FNW},A}(X)
=\sum_\mu (A^\mu)^\dagger X A^\mu
=\sum_\mu v(\mu)Xv(\mu)^\dagger.
$$

This is the adjoint of TNLean's Schrödinger transfer map for the bilinear pairing $(X,Y)\mapsto\operatorname{Tr}(XY)$. It is not an identification with TNLean's transfer map itself, a Hilbert-space adjoint, FNW Lemma 5.2, or a prefactor claim.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.FNWTransferConvention` (3132/3132 before the moving-main rebase)
- `lake build TNLean.MPS.ParentHamiltonian` (9194/9194 on the rebased documented head)
- generated imports: 37 aggregators / 1078 production modules
- source synchronization: 7287 unique Lean references / 7311 theorem-like entries
- strict Blueprint declaration checking
- diagnostics, style, proof-token, scope, and diff checks
- pinned formatting, reader-facing prose, ChkTeX, label checks
- double LuaLaTeX: 1063 pages, no undefined cross-references
- exact-head Lean simplification review

Closes #7592.
Advances #6367.
