### PR TITLE
feat(parent): formalize the FNW limit map

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -52,6 +52,7 @@ import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.FNWBoundaryConvention
 import TNLean.MPS.ParentHamiltonian.FNWContraction
+import TNLean.MPS.ParentHamiltonian.FNWLimitMap
 import TNLean.MPS.ParentHamiltonian.FNWTransferConvention
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GramInverseConvergence

--- a/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
@@ -33,7 +33,7 @@ variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- The normalized rank-one limiting map associated with a matrix `ρ` of
+/-- The normalized rank-one limiting map associated with a matrix \(\rho\) of
 nonzero trace. For the trace-one stationary density used by FNW after equation
 (5.5), this is exactly \(E_\infty(B)=\operatorname{Tr}(\rho B)\,1\). -/
 def fnwLimitMap (ρ : Mat) (_htr : Matrix.trace ρ ≠ 0) : Mat →ₗ[ℂ] Mat where
@@ -96,10 +96,10 @@ theorem fnwTransferMap_mul_fnwLimitMap (A : MPSTensor d D) (ρ : Mat)
   ext B
   simp [Module.End.mul_apply, fnwLimitMap, fnwTransferMap_one A hA]
 
-/-- If `ρ` is stationary for TNLean's transfer map, then the FNW limiting map
+/-- If \(\rho\) is stationary for TNLean's transfer map, then the FNW limiting map
 absorbs the FNW transfer map on the left:
 \(E_\infty E=E_\infty\). Under the convention bridge of equations
-(5.1)--(5.3), this is exactly stationarity of `ρ`. -/
+(5.1)--(5.3), this is exactly stationarity of \(\rho\). -/
 theorem fnwLimitMap_mul_fnwTransferMap (A : MPSTensor d D) (ρ : Mat)
     (htr : Matrix.trace ρ ≠ 0)
     (hρ : Kraus.transferMap A ρ = ρ) :

--- a/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
@@ -75,11 +75,17 @@ theorem fnwLimitMap_eq_traceAdjointMap_fixedPointProj (ρ : Mat)
   rw [Matrix.trace_mul_comm ρ B, Matrix.trace_mul_comm B ρ]
   field_simp
 
-/-- The normalized FNW limiting map is idempotent. -/
+/-- The normalized FNW limiting map is idempotent on every observable. -/
+theorem fnwLimitMap_idempotent (ρ B : Mat) (htr : Matrix.trace ρ ≠ 0) :
+    fnwLimitMap ρ htr (fnwLimitMap ρ htr B) = fnwLimitMap ρ htr B := by
+  simp [fnwLimitMap, htr]
+
+/-- The normalized FNW limiting map is an idempotent endomorphism. -/
 theorem fnwLimitMap_mul_self (ρ : Mat) (htr : Matrix.trace ρ ≠ 0) :
     fnwLimitMap ρ htr * fnwLimitMap ρ htr = fnwLimitMap ρ htr := by
-  ext B
-  simp [Module.End.mul_apply, fnwLimitMap, htr]
+  apply LinearMap.ext
+  intro B
+  simpa [Module.End.mul_apply] using fnwLimitMap_idempotent ρ B htr
 
 /-- Under left-canonical normalization, the FNW transfer map absorbs its
 limiting rank-one map on the left: \(E E_\infty=E_\infty\). This is the
@@ -118,13 +124,9 @@ theorem fnwTransferMap_sub_fnwLimitMap_pow (A : MPSTensor d D) (ρ : Mat)
   have hPP : P * P = P := fnwLimitMap_mul_self ρ htr
   have hpowP : ∀ k : ℕ, E ^ k * P = P := by
     intro k
-    cases k with
+    induction k with
     | zero => simp
-    | succ k =>
-        rw [pow_succ, mul_assoc, hEP]
-        induction k with
-        | zero => simp
-        | succ k ih => simpa [pow_succ, mul_assoc, hEP] using ih
+    | succ k ih => rw [pow_succ, mul_assoc, hEP, ih]
   change (E - P) ^ n = E ^ n - P
   cases n with
   | zero => omega

--- a/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLimitMap.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.FNWTransferConvention
+import TNLean.MPS.Structure.PrimitiveFixedPoint
+
+/-!
+# FNW limiting rank-one map
+
+Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
+(1992), 443--490, equations (5.1)--(5.3), define the transfer map
+\(E(B)=\sum_\mu v_\mu Bv_\mu^*\). In the proof of Lemma 5.2, after the
+boundary formula (5.5), its rank-one limit is
+\(E_\infty(B)=\operatorname{Tr}(\rho B)\,1\) for a trace-one stationary
+matrix \(\rho\). We retain the source-normalized formula
+\(\operatorname{Tr}(\rho B)/\operatorname{Tr}(\rho)\) so the definition does
+not require trace-one normalization.
+
+This module proves the algebraic projection and absorption identities used
+before the rho-weighted Hilbert-space estimate. It does not define the
+weighted inner product of equation (5.6) or any quantitative decay bound.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+noncomputable section
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The normalized rank-one limiting map associated with a matrix `ρ` of
+nonzero trace. For the trace-one stationary density used by FNW after equation
+(5.5), this is exactly \(E_\infty(B)=\operatorname{Tr}(\rho B)\,1\). -/
+def fnwLimitMap (ρ : Mat) (_htr : Matrix.trace ρ ≠ 0) : Mat →ₗ[ℂ] Mat where
+  toFun B := (Matrix.trace (ρ * B) / Matrix.trace ρ) • 1
+  map_add' B C := by
+    simp only [Matrix.mul_add, Matrix.trace_add, add_div, add_smul]
+  map_smul' c B := by
+    simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul, mul_div_assoc,
+      smul_smul, RingHom.id_apply]
+
+/-- Application formula for the normalized FNW limiting map. -/
+@[simp]
+theorem fnwLimitMap_apply (ρ B : Mat) (htr : Matrix.trace ρ ≠ 0) :
+    fnwLimitMap ρ htr B =
+      (Matrix.trace (ρ * B) / Matrix.trace ρ) • 1 := rfl
+
+/-- For the trace-one normalization used in FNW Lemma 5.2, following equations
+(5.1)--(5.5), the limiting map is
+\(E_\infty(B)=\operatorname{Tr}(\rho B)\,1\). -/
+theorem fnwLimitMap_apply_of_trace_eq_one (ρ B : Mat)
+    (htr : Matrix.trace ρ = 1) :
+    fnwLimitMap ρ (by simp [htr]) B = Matrix.trace (ρ * B) • 1 := by
+  simp [fnwLimitMap, htr]
+
+/-- The normalized FNW limiting map is the bilinear trace-pairing adjoint of
+the fixed-point projection \(X\mapsto
+(\operatorname{Tr}X/\operatorname{Tr}\rho)\rho\). -/
+theorem fnwLimitMap_eq_traceAdjointMap_fixedPointProj (ρ : Mat)
+    (htr : Matrix.trace ρ ≠ 0) :
+    fnwLimitMap ρ htr = Matrix.traceAdjointMap (fixedPointProj ρ htr) := by
+  apply LinearMap.ext
+  intro B
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro X
+  rw [Matrix.trace_traceAdjointMap_mul]
+  simp only [fnwLimitMap_apply, fixedPointProj, LinearMap.coe_mk, AddHom.coe_mk,
+    Matrix.smul_mul, Matrix.mul_smul, Matrix.trace_smul, Matrix.one_mul,
+    smul_eq_mul]
+  rw [Matrix.trace_mul_comm ρ B, Matrix.trace_mul_comm B ρ]
+  field_simp
+
+/-- The normalized FNW limiting map is idempotent. -/
+theorem fnwLimitMap_mul_self (ρ : Mat) (htr : Matrix.trace ρ ≠ 0) :
+    fnwLimitMap ρ htr * fnwLimitMap ρ htr = fnwLimitMap ρ htr := by
+  ext B
+  simp [Module.End.mul_apply, fnwLimitMap, htr]
+
+/-- Under left-canonical normalization, the FNW transfer map absorbs its
+limiting rank-one map on the left: \(E E_\infty=E_\infty\). This is the
+unital identity from FNW equations (5.2)--(5.3). -/
+theorem fnwTransferMap_mul_fnwLimitMap (A : MPSTensor d D) (ρ : Mat)
+    (htr : Matrix.trace ρ ≠ 0) (hA : IsLeftCanonical A) :
+    fnwTransferMap A * fnwLimitMap ρ htr = fnwLimitMap ρ htr := by
+  ext B
+  simp [Module.End.mul_apply, fnwLimitMap, fnwTransferMap_one A hA]
+
+/-- If `ρ` is stationary for TNLean's transfer map, then the FNW limiting map
+absorbs the FNW transfer map on the left:
+\(E_\infty E=E_\infty\). Under the convention bridge of equations
+(5.1)--(5.3), this is exactly stationarity of `ρ`. -/
+theorem fnwLimitMap_mul_fnwTransferMap (A : MPSTensor d D) (ρ : Mat)
+    (htr : Matrix.trace ρ ≠ 0)
+    (hρ : Kraus.transferMap A ρ = ρ) :
+    fnwLimitMap ρ htr * fnwTransferMap A = fnwLimitMap ρ htr := by
+  ext B
+  simp only [Module.End.mul_apply, fnwLimitMap_apply]
+  rw [trace_mul_fnwTransferMap, hρ]
+
+/-- For every positive power, the FNW remainder satisfies
+\((E-E_\infty)^n=E^n-E_\infty\). The proof uses only unitality, stationarity,
+and the rank-one projection identities, before the weighted norm of FNW
+equation (5.6) enters. -/
+theorem fnwTransferMap_sub_fnwLimitMap_pow (A : MPSTensor d D) (ρ : Mat)
+    (htr : Matrix.trace ρ ≠ 0) (hA : IsLeftCanonical A)
+    (hρ : Kraus.transferMap A ρ = ρ) {n : ℕ} (hn : 1 ≤ n) :
+    (fnwTransferMap A - fnwLimitMap ρ htr) ^ n =
+      fnwTransferMap A ^ n - fnwLimitMap ρ htr := by
+  let E := fnwTransferMap A
+  let P := fnwLimitMap ρ htr
+  have hEP : E * P = P := fnwTransferMap_mul_fnwLimitMap A ρ htr hA
+  have hPE : P * E = P := fnwLimitMap_mul_fnwTransferMap A ρ htr hρ
+  have hPP : P * P = P := fnwLimitMap_mul_self ρ htr
+  have hpowP : ∀ k : ℕ, E ^ k * P = P := by
+    intro k
+    cases k with
+    | zero => simp
+    | succ k =>
+        rw [pow_succ, mul_assoc, hEP]
+        induction k with
+        | zero => simp
+        | succ k ih => simpa [pow_succ, mul_assoc, hEP] using ih
+  change (E - P) ^ n = E ^ n - P
+  cases n with
+  | zero => omega
+  | succ n =>
+      induction n with
+      | zero => simp
+      | succ n ih =>
+          rw [pow_succ, ih (by omega), pow_succ]
+          simp only [sub_mul, mul_sub, ← pow_succ, hpowP, hPE, hPP]
+          abel
+
+/-- A primitive MPS tensor supplies the trace nonvanishing, left-canonical
+normalization, and stationarity hypotheses for the FNW remainder identity. -/
+theorem IsPrimitiveMPS.fnwTransferMap_sub_fnwLimitMap_pow [NeZero D]
+    {A : MPSTensor d D} {ρ : Mat} (hP : IsPrimitiveMPS A ρ)
+    {n : ℕ} (hn : 1 ≤ n) :
+    (fnwTransferMap A - fnwLimitMap ρ hP.trace_ne_zero) ^ n =
+      fnwTransferMap A ^ n - fnwLimitMap ρ hP.trace_ne_zero :=
+  MPSTensor.fnwTransferMap_sub_fnwLimitMap_pow
+    (A := A) (ρ := ρ) hP.trace_ne_zero hP.norm hP.fixedPoint_is_fixed hn
+
+end
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -534,6 +534,200 @@ include the weighted decay estimate of
 \cite[Lemma~5.2]{Fannes1992Finitely}, and they make no assertion of a
 constant $C_\lambda=k^2$.
 
+\begin{definition}[Normalized limiting FNW observable map]
+    \label{def:fnw_limit_map}
+    \lean{MPSTensor.fnwLimitMap}
+    \lean{MPSTensor.fnwLimitMap_apply}
+    \lean{MPSTensor.fnwLimitMap_apply_of_trace_eq_one}
+    \leanok
+    Let $\rho\in\MN{D}$ satisfy $\tr(\rho)\neq0$. The normalized rank-one map
+    associated with $\rho$ is
+    \begin{align}
+        E_\infty^\rho(B)
+         & :=\frac{\tr(\!\rho B)}{\tr(\rho)}I_D.
+        \label{eq:fnw_limit_map}
+    \end{align}
+    If $\tr(\rho)=1$, this becomes
+    $E_\infty^\rho(B)=\tr(\rho B)I_D$, which is the limiting map in
+    \cite[Equation~(5.1)]{Fannes1992Finitely}.
+\end{definition}
+
+\begin{theorem}[Limiting map as a trace-pairing adjoint]
+    \label{thm:fnw_limit_map_trace_adjoint}
+    \lean{MPSTensor.fnwLimitMap_eq_traceAdjointMap_fixedPointProj}
+    \leanok
+    \uses{def:fnw_limit_map}
+    Define the fixed-point projection
+    \begin{align}
+        P_\rho(X)
+         & :=\frac{\tr(X)}{\tr(\rho)}\rho.
+        \label{eq:fnw_fixed_point_projection}
+    \end{align}
+    Then $E_\infty^\rho=P_\rho^\sharp$, where $\sharp$ denotes the adjoint for
+    the bilinear trace pairing. This is not the Hilbert adjoint for the
+    unweighted Frobenius inner product or for the $\rho$-weighted inner product
+    of \cite[Equation~(5.6)]{Fannes1992Finitely}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_limit_map}
+    For all $X,B\in\MN{D}$,
+    \begin{align}
+        \tr(P_\rho(X)B)
+         & =\frac{\tr(X)\tr(\rho B)}{\tr(\rho)}
+        =\tr\!\left(XE_\infty^\rho(B)\right).
+    \end{align}
+    Nondegeneracy of the trace pairing proves the equality of maps.
+\end{proof}
+
+\begin{theorem}[Pointwise idempotence of the limiting map]
+    \label{thm:fnw_limit_map_idempotent}
+    \lean{MPSTensor.fnwLimitMap_idempotent}
+    \leanok
+    \uses{def:fnw_limit_map}
+    For every $B\in\MN{D}$,
+    \begin{align}
+        E_\infty^\rho\!\left(E_\infty^\rho(B)\right)
+         & =E_\infty^\rho(B).
+        \label{eq:fnw_limit_map_idempotent}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_limit_map}
+    Substitute~(\ref{eq:fnw_limit_map}) and use
+    $\tr(\rho I_D)=\tr(\rho)$. The nonzero trace cancels the normalizing
+    denominator.
+\end{proof}
+
+\begin{theorem}[The limiting map is a projection]
+    \label{thm:fnw_limit_map_projection}
+    \lean{MPSTensor.fnwLimitMap_mul_self}
+    \leanok
+    \uses{def:fnw_limit_map}
+    As an endomorphism of $\MN{D}$, the limiting map satisfies
+    \begin{align}
+        (E_\infty^\rho)^2 & =E_\infty^\rho.
+        \label{eq:fnw_limit_map_projection}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_limit_map_idempotent}
+    Apply Theorem~\ref{thm:fnw_limit_map_idempotent} to every matrix $B$.
+\end{proof}
+
+\begin{theorem}[Unital absorption of the limiting map]
+    \label{thm:fnw_transfer_absorbs_limit}
+    \lean{MPSTensor.fnwTransferMap_mul_fnwLimitMap}
+    \leanok
+    \uses{def:fnw_limit_map, def:transfer_map, def:left_canonical_tensor}
+    If $A$ is left canonical, then the FNW observable map in
+    (\ref{eq:fnw_transfer_map}) satisfies
+    \begin{align}
+        E_{\mathrm{FNW},A}E_\infty^\rho & =E_\infty^\rho.
+        \label{eq:fnw_transfer_absorbs_limit}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_limit_map, def:left_canonical_tensor}
+    Left canonicity gives
+    $E_{\mathrm{FNW},A}(I_D)=\sum_\mu(A^\mu)^\dagger A^\mu=I_D$.
+    Hence
+    \begin{align}
+        E_{\mathrm{FNW},A}\!\left(E_\infty^\rho(B)\right)
+         & =\frac{\tr(\rho B)}{\tr(\rho)}E_{\mathrm{FNW},A}(I_D)
+        =E_\infty^\rho(B).
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Stationary absorption by the limiting map]
+    \label{thm:fnw_limit_absorbs_transfer}
+    \lean{MPSTensor.fnwLimitMap_mul_fnwTransferMap}
+    \leanok
+    \uses{def:fnw_limit_map, def:transfer_map}
+    Suppose that $\rho$ is stationary for the Schrödinger transfer map,
+    $\E_A(\rho)=\rho$. Then
+    \begin{align}
+        E_\infty^\rho E_{\mathrm{FNW},A} & =E_\infty^\rho.
+        \label{eq:fnw_limit_absorbs_transfer}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_limit_map}
+    The trace-pairing identity and stationarity give
+    \begin{align}
+        \tr\!\left(\rho E_{\mathrm{FNW},A}(B)\right)
+         & =\tr\!\left(\E_A(\rho)B\right)=\tr(\rho B).
+    \end{align}
+    Substitute this equality into~(\ref{eq:fnw_limit_map}).
+\end{proof}
+
+\begin{theorem}[Positive powers of the FNW remainder]
+    \label{thm:fnw_remainder_power}
+    \lean{MPSTensor.fnwTransferMap_sub_fnwLimitMap_pow}
+    \leanok
+    \uses{def:fnw_limit_map, def:transfer_map, def:left_canonical_tensor}
+    Suppose that $A$ is left canonical and that
+    $\E_A(\rho)=\rho$. For every integer $n\geq1$,
+    \begin{align}
+        (E_{\mathrm{FNW},A}-E_\infty^\rho)^n
+         & =E_{\mathrm{FNW},A}^n-E_\infty^\rho.
+        \label{eq:fnw_remainder_power}
+    \end{align}
+    The restriction $n\geq1$ is essential. At $n=0$, the two sides would be
+    $I$ and $I-E_\infty^\rho$, respectively, and
+    $E_\infty^\rho(I_D)=I_D$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_limit_map_projection, thm:fnw_transfer_absorbs_limit, thm:fnw_limit_absorbs_transfer}
+    Write $E=E_{\mathrm{FNW},A}$ and $P=E_\infty^\rho$. The three preceding
+    identities give
+    $EP=PE=P^2=P$, and hence $E^mP=P$ for every $m\geq0$. The case $n=1$ is
+    immediate. If $(E-P)^n=E^n-P$, then
+    \begin{align}
+        (E-P)^{n+1}
+         & =(E^n-P)(E-P)
+        =E^{n+1}-E^nP-PE+P^2
+        =E^{n+1}-P.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Primitive-MPS remainder identity]
+    \label{thm:primitive_fnw_remainder_power}
+    \lean{MPSTensor.IsPrimitiveMPS.fnwTransferMap_sub_fnwLimitMap_pow}
+    \leanok
+    \uses{def:primitive_mps, def:fnw_limit_map}
+    Let $A$ be a primitive MPS tensor of nonzero bond dimension with fixed-point
+    witness $\rho$. Then, for every integer $n\geq1$,
+    \begin{align}
+        (E_{\mathrm{FNW},A}-E_\infty^\rho)^n
+         & =E_{\mathrm{FNW},A}^n-E_\infty^\rho.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_remainder_power}
+    Primitivity supplies $\tr(\rho)\neq0$, left canonicity, and the stationary
+    equation $\E_A(\rho)=\rho$. Apply
+    Theorem~\ref{thm:fnw_remainder_power}.
+\end{proof}
+
+These projection and absorption identities precede the weighted Hilbert-space
+estimate in \cite[Lemma~5.2]{Fannes1992Finitely}. They do not assert a
+$\rho$-weighted norm bound or any quantitative decay constant, and they do not
+include the later conclusions of Lemmas~5.3 and~6.2 of that paper.
+
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}
     \lean{Matrix.gramReshuffle}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -564,9 +564,11 @@ constant $C_\lambda=k^2$.
         \label{eq:fnw_fixed_point_projection}
     \end{align}
     Then $E_\infty^\rho=P_\rho^\sharp$, where $\sharp$ denotes the adjoint for
-    the bilinear trace pairing. This is not the Hilbert adjoint for the
-    unweighted Frobenius inner product or for the $\rho$-weighted inner product
-    of \cite[Equation~(5.6)]{Fannes1992Finitely}.
+    the bilinear trace pairing. For the trace-one Hermitian density matrix used
+    by FNW, the same map also agrees with the Hilbert-space adjoint for the
+    unweighted Frobenius inner product. This Frobenius adjoint is generally
+    different from the adjoint for the $\rho$-weighted inner product of
+    \cite[Equation~(5.6)]{Fannes1992Finitely}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -637,8 +637,8 @@ constant $C_\lambda=k^2$.
 
 \begin{proof}
     \leanok
-    \uses{def:fnw_limit_map, def:left_canonical_tensor}
-    Left canonicity gives
+    \uses{def:fnw_limit_map, def:left_canonical_tensor, thm:fnw_transfer_map_one}
+    Apply Theorem~\ref{thm:fnw_transfer_map_one} to obtain
     $E_{\mathrm{FNW},A}(I_D)=\sum_\mu(A^\mu)^\dagger A^\mu=I_D$.
     Hence
     \begin{align}
@@ -663,8 +663,8 @@ constant $C_\lambda=k^2$.
 
 \begin{proof}
     \leanok
-    \uses{def:fnw_limit_map}
-    The trace-pairing identity and stationarity give
+    \uses{def:fnw_limit_map, thm:trace_mul_fnw_transfer_map}
+    Apply Theorem~\ref{thm:trace_mul_fnw_transfer_map} and stationarity to get
     \begin{align}
         \tr\!\left(\rho E_{\mathrm{FNW},A}(B)\right)
          & =\tr\!\left(\E_A(\rho)B\right)=\tr(\rho B).


### PR DESCRIPTION
## What changed

- define the normalized FNW rank-one limit map
  \[
  E_\infty^\rho(B)=\frac{\operatorname{Tr}(\rho B)}{\operatorname{Tr}\rho}I
  \]
- prove its trace-one specialization and equality with the bilinear trace adjoint of QICLean's fixed-point projection
- prove pointwise and endomorphism idempotence
- prove both absorption identities with the FNW transfer map
- prove the exact positive-power remainder identity
  \[
  (E-E_\infty)^n=E^n-E_\infty,
  \qquad n\geq1
  \]
- add the primitive-MPS wrapper and synchronize all ten declarations with Chapter 13

The positive-power restriction is essential: at `n = 0`, the left side is the identity endomorphism while the right side need not be.

## Source

Fannes, Nachtergaele, and Werner, CMP 144 (1992), equation (5.1) and the setup for Lemma 5.2.

## Validation

- `FNWLimitMap`: 8838 jobs
- `ParentHamiltonian`: 9196 jobs
- generated imports: 37 aggregators / 1080 production modules
- Blueprint sync: 7304 unique Lean references / 7328 theorem-like entries
- diagnostics, strict declaration checks, reverse coverage, style, proof-integrity, line length, and axiom audit passed
- reader-facing prose, ChkTeX, pinned `latexindent`, and Blueprint label/dependency checks passed
- exact three-path scope and clean-tree checks passed
- exact-head review independently compiled an explicit counterexample at `n = 0` and corrected the Frobenius-adjoint documentation

Closes #7595.
Advances #6367.
