### PR TITLE
feat(parent): prove weighted FNW transfer decay

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -54,6 +54,7 @@ import TNLean.MPS.ParentHamiltonian.FNWBoundaryConvention
 import TNLean.MPS.ParentHamiltonian.FNWContraction
 import TNLean.MPS.ParentHamiltonian.FNWLimitMap
 import TNLean.MPS.ParentHamiltonian.FNWTransferConvention
+import TNLean.MPS.ParentHamiltonian.FNWTransferDecay
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
@@ -151,6 +151,53 @@ noncomputable def fnwMixingQuantity {D : ℕ}
   fnwTraceInverseFactor ρ * fnwWeightedOperatorNorm ρ hρ
     (fnwTransferMap A ^ n - fnwLimitMap ρ (by simp [htr]))
 
+/-- Prescribed-rate form of FNW 1992, Lemma 5.2 and equations (5.9)--(5.10).
+For every nonnegative rate strictly above the rho-weighted spectral radius of
+the FNW remainder, there is a positive, rate-dependent prefactor bounding
+\(a(n)\) for every positive power. No hypothesis that the prescribed rate is
+below one is needed for this generic power estimate, and no dimension-only
+value of the prefactor is asserted. -/
+theorem IsPrimitiveMPS.exists_fnwMixingQuantity_le_geometric [NeZero D]
+    {A : MPSTensor d D} {ρ : Mat} (hP : IsPrimitiveMPS A ρ)
+    (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1) (rate : ℝ≥0)
+    (hrate : fnwWeightedRemainderSpectralRadius ρ hρ A hP.trace_ne_zero <
+      (rate : ℝ≥0∞)) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      fnwMixingQuantity ρ hρ A htr n ≤ C * (rate : ℝ) ^ n := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  let hComplete : CompleteSpace Mat := FiniteDimensional.complete ℂ Mat
+  let : CompleteSpace Mat := hComplete
+  let Φ := Module.End.toContinuousLinearMap (𝕜 := ℂ) Mat
+  let R := fnwTransferMap A - fnwLimitMap ρ hP.trace_ne_zero
+  have hrate' : spectralRadius ℂ (Φ R) < (rate : ℝ≥0∞) := by
+    simpa only [fnwWeightedRemainderSpectralRadius] using hrate
+  obtain ⟨C₀, hC₀, hbound⟩ :=
+    geometric_bound_of_spectralRadius_lt (Φ R) rate hrate'
+  refine ⟨fnwTraceInverseFactor ρ * C₀,
+    mul_pos (fnwTraceInverseFactor_pos hρ) hC₀, ?_⟩
+  intro n hn
+  have hlinear :
+      fnwTransferMap A ^ n - fnwLimitMap ρ (by simp [htr]) = R ^ n := by
+    simpa only [R] using
+      (hP.fnwTransferMap_sub_fnwLimitMap_pow hn).symm
+  have hnorm :
+      fnwWeightedOperatorNorm ρ hρ
+          (fnwTransferMap A ^ n - fnwLimitMap ρ (by simp [htr])) =
+        ‖(Φ R) ^ n‖ := by
+    simp only [fnwWeightedOperatorNorm]
+    rw [hlinear, map_pow]
+  rw [fnwMixingQuantity, hnorm]
+  calc
+    fnwTraceInverseFactor ρ * ‖(Φ R) ^ n‖ ≤
+        fnwTraceInverseFactor ρ * (C₀ * (rate : ℝ) ^ n) :=
+      mul_le_mul_of_nonneg_left (hbound n) (fnwTraceInverseFactor_pos hρ).le
+    _ = (fnwTraceInverseFactor ρ * C₀) * (rate : ℝ) ^ n := by ring
+
 end
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.MatrixTracePairing
+import QICLean.Analysis.SpectralRadiusPowerDecay
+import TNLean.MPS.ParentHamiltonian.FNWLimitMap
+import TNLean.MPS.ParentHamiltonian.WeightedVirtualHilbert
+
+/-!
+# FNW transfer-remainder decay
+
+Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
+(1992), 443--490, Lemma 5.2 and equations (5.9)--(5.10), bound the positive
+powers of the transfer remainder in the Hilbert-space norm weighted by the
+faithful stationary density. The source quantity is
+\(a(n)=\operatorname{Tr}(\rho^{-1})\lVert E^n-E_\infty\rVert_\rho\).
+
+This module first transfers the complementary eigenvalue gap from TNLean's
+Schrödinger map to the FNW observable map through the bilinear trace adjoint.
+It then activates the rho-weighted norm from equation (5.6), derives the
+corresponding spectral-radius gap, and proves prescribed-rate geometric decay
+with an existential rate-dependent prefactor.
+
+No dimension-only value of the prefactor is asserted.
+-/
+
+open scoped ENNReal Matrix NNReal
+
+namespace MPSTensor
+
+noncomputable section
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The FNW transfer remainder has the same eigenvalues as TNLean's
+Schrödinger remainder. Hence primitivity bounds every eigenvalue in modulus by
+one strictly. This norm-independent bridge is the spectral step in FNW 1992,
+Lemma 5.2, before the weighted norm in equations (5.9)--(5.10) is chosen. -/
+theorem IsPrimitiveMPS.fnwRemainder_eigenvalue_norm_lt_one [NeZero D]
+    {A : MPSTensor d D} {ρ : Mat} (hP : IsPrimitiveMPS A ρ) (ν : ℂ)
+    (hν : Module.End.HasEigenvalue
+      (fnwTransferMap A - fnwLimitMap ρ hP.trace_ne_zero) ν) :
+    ‖ν‖ < 1 := by
+  have hremainder :
+      fnwTransferMap A - fnwLimitMap ρ hP.trace_ne_zero =
+        Matrix.traceAdjointMap
+          (Kraus.transferMap A - fixedPointProj ρ hP.trace_ne_zero) := by
+    rw [Matrix.traceAdjointMap_sub, ← fnwTransferMap_eq_traceAdjointMap,
+      ← fnwLimitMap_eq_traceAdjointMap_fixedPointProj]
+  rw [hremainder, Matrix.traceAdjointMap_hasEigenvalue_iff] at hν
+  exact hP.complement_eigenvalue_norm_lt_one ν hν
+
+end
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
@@ -144,7 +144,7 @@ theorem IsPrimitiveMPS.fnwWeightedRemainder_spectralRadius_lt_one [NeZero D]
 /-- The source mixing quantity from FNW 1992, equations (5.9)--(5.10), with
 trace-one normalization explicit:
 \(a(n)=\operatorname{Re}\operatorname{Tr}(\rho^{-1})
-\lVert E^n-E_\infty\rVert_\rho\).
+\lVert E^n-E_\infty\rVert_{\mathrm{op},\rho}\).
 The norm is the local rho-weighted continuous-operator norm. -/
 noncomputable def fnwMixingQuantity {D : ℕ}
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
@@ -26,7 +26,7 @@ with an existential rate-dependent prefactor.
 No dimension-only value of the prefactor is asserted.
 -/
 
-open scoped ENNReal Matrix NNReal
+open scoped ComplexOrder ENNReal Matrix NNReal
 
 namespace MPSTensor
 
@@ -53,6 +53,103 @@ theorem IsPrimitiveMPS.fnwRemainder_eigenvalue_norm_lt_one [NeZero D]
       ← fnwLimitMap_eq_traceAdjointMap_fixedPointProj]
   rw [hremainder, Matrix.traceAdjointMap_hasEigenvalue_iff] at hν
   exact hP.complement_eigenvalue_norm_lt_one ν hν
+
+/-- The source factor multiplying the weighted remainder norm in FNW 1992,
+equations (5.9)--(5.10): the real value of
+\(\operatorname{Tr}(\rho^{-1})\). -/
+def fnwTraceInverseFactor (ρ : Mat) : ℝ :=
+  (Matrix.trace ρ⁻¹).re
+
+/-- A faithful density matrix gives a strictly positive source factor
+\(\operatorname{Re}\operatorname{Tr}(\rho^{-1})\). This is the positivity
+used when the factor is absorbed into the prefactor in FNW Lemma 5.2. -/
+theorem fnwTraceInverseFactor_pos [NeZero D] {ρ : Mat} (hρ : ρ.PosDef) :
+    0 < fnwTraceInverseFactor ρ := by
+  have hinv : ρ⁻¹.PosDef := hρ.inv
+  exact (Complex.lt_def.mp hinv.trace_pos).1
+
+/-- The spectral radius of the FNW remainder continuous endomorphism for
+the local rho-weighted matrix norm of equation (5.6). This definition keeps
+the norm choice explicit without comparing it to TNLean's ambient matrix norm. -/
+noncomputable def fnwWeightedRemainderSpectralRadius {D : ℕ}
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    {d : ℕ} (A : MPSTensor d D) (htr : Matrix.trace ρ ≠ 0) : ℝ≥0∞ := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  let Φ := Module.End.toContinuousLinearMap (𝕜 := ℂ)
+    (Matrix (Fin D) (Fin D) ℂ)
+  exact spectralRadius ℂ (Φ (fnwTransferMap A - fnwLimitMap ρ htr))
+
+/-- The operator norm induced by the rho-weighted matrix norm of FNW 1992,
+equation (5.6). -/
+noncomputable def fnwWeightedOperatorNorm {D : ℕ}
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (F : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) : ℝ := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  let Φ := Module.End.toContinuousLinearMap (𝕜 := ℂ)
+    (Matrix (Fin D) (Fin D) ℂ)
+  exact ‖Φ F‖
+
+private theorem rhoWeighted_spectralRadius_lt_one_of_eigenvalues_lt_one
+    {D : ℕ} [NeZero D] (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (F : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hF : ∀ ν : ℂ, Module.End.HasEigenvalue F ν → ‖ν‖ < 1) :
+    letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) F) < 1 := by
+  let : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm (Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  exact spectralRadius_lt_one_of_eigenvalues_lt_one F hF
+
+/-- In the rho-weighted matrix norm, the continuous FNW remainder has spectral
+radius strictly below one. The proof uses only finite dimensionality and the
+norm-independent eigenvalue bridge, rather than comparing spectral radii
+across different matrix norm instances. -/
+theorem IsPrimitiveMPS.fnwWeightedRemainder_spectralRadius_lt_one [NeZero D]
+    {A : MPSTensor d D} {ρ : Mat} (hP : IsPrimitiveMPS A ρ)
+    (hρ : ρ.PosDef) :
+    fnwWeightedRemainderSpectralRadius ρ hρ A hP.trace_ne_zero < 1 := by
+  simpa only [fnwWeightedRemainderSpectralRadius] using
+    rhoWeighted_spectralRadius_lt_one_of_eigenvalues_lt_one ρ hρ
+      (fnwTransferMap A - fnwLimitMap ρ hP.trace_ne_zero)
+      hP.fnwRemainder_eigenvalue_norm_lt_one
+
+/-- The source mixing quantity from FNW 1992, equations (5.9)--(5.10), with
+trace-one normalization explicit:
+\(a(n)=\operatorname{Re}\operatorname{Tr}(\rho^{-1})
+\lVert E^n-E_\infty\rVert_\rho\).
+The norm is the local rho-weighted continuous-operator norm. -/
+noncomputable def fnwMixingQuantity {D : ℕ}
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    {d : ℕ} (A : MPSTensor d D) (htr : Matrix.trace ρ = 1) (n : ℕ) : ℝ :=
+  fnwTraceInverseFactor ρ * fnwWeightedOperatorNorm ρ hρ
+    (fnwTransferMap A ^ n - fnwLimitMap ρ (by simp [htr]))
 
 end
 

--- a/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWTransferDecay.lean
@@ -15,7 +15,8 @@ Fannes--Nachtergaele--Werner, *Communications in Mathematical Physics* 144
 (1992), 443--490, Lemma 5.2 and equations (5.9)--(5.10), bound the positive
 powers of the transfer remainder in the Hilbert-space norm weighted by the
 faithful stationary density. The source quantity is
-\(a(n)=\operatorname{Tr}(\rho^{-1})\lVert E^n-E_\infty\rVert_\rho\).
+\(a(n)=\operatorname{Re}\operatorname{Tr}(\rho^{-1})
+\lVert E^n-E_\infty\rVert_{\mathrm{op},\rho}\).
 
 This module first transfers the complementary eigenvalue gap from TNLean's
 Schrödinger map to the FNW observable map through the bilinear trace adjoint.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -1160,7 +1160,7 @@ include the later conclusions of Lemmas~5.3 and~6.2 of that paper.
     Apply Theorem~\ref{thm:geometric_bound_of_spectral_radius_lt} to the
     weighted remainder $R_A^\rho$.  This gives $C_0>0$ with
     $\lVert(R_A^\rho)^n\rVert_{\mathrm{op},\rho}
-        \leq C_0\lambda^n$.  For $n\geq1$,
+        \leq C_0\lambda^n$.  When $n\geq1$,
     Theorem~\ref{thm:primitive_fnw_remainder_power} identifies
     $(R_A^\rho)^n$ with
     $E_{\mathrm{FNW},A}^n-E_\infty^\rho$.  Multiply by $c_\rho>0$ and take

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -1016,6 +1016,163 @@ include the later conclusions of Lemmas~5.3 and~6.2 of that paper.
     $\lVert T^n x\rVert\leq\lVert T^n\rVert\lVert x\rVert$.
 \end{proof}
 
+\begin{theorem}[FNW remainder eigenvalue gap]
+    \label{thm:fnw_remainder_eigenvalue_gap}
+    \lean{MPSTensor.IsPrimitiveMPS.fnwRemainder_eigenvalue_norm_lt_one}
+    \leanok
+    \uses{def:primitive_mps, def:fnw_transfer_map, def:fnw_limit_map}
+    Let $A$ be a primitive MPS tensor of nonzero bond dimension with fixed-point
+    witness $\rho$, and set
+    $R_A^\rho=E_{\mathrm{FNW},A}-E_\infty^\rho$.  If $\nu$ is an eigenvalue of
+    $R_A^\rho$, then
+    \begin{align}
+        |\nu| & <1.
+        \label{eq:fnw_remainder_eigenvalue_gap}
+    \end{align}
+    This is the norm-independent spectral step in
+    \cite[Lemma~5.2]{Fannes1992Finitely}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_transfer_map_trace_adjoint, thm:fnw_limit_map_trace_adjoint}
+    The remainder $R_A^\rho$ is the bilinear trace adjoint of
+    $\E_A-P_\rho$.  A linear map and its trace adjoint have the same
+    characteristic polynomial, hence the same eigenvalues.  Primitivity places
+    every eigenvalue of $\E_A-P_\rho$ strictly inside the unit disk.
+\end{proof}
+
+\begin{definition}[Trace-inverse factor]
+    \label{def:fnw_trace_inverse_factor}
+    \lean{MPSTensor.fnwTraceInverseFactor}
+    \leanok
+    Let $\rho\in\MN{D}$.  Define
+    \begin{align}
+        c_\rho
+         & :=\operatorname{Re}\tr(\rho^{-1}).
+        \label{eq:fnw_trace_inverse_factor}
+    \end{align}
+    This is the factor multiplying the weighted remainder norm in
+    \cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
+\end{definition}
+
+\begin{theorem}[Positivity of the trace-inverse factor]
+    \label{thm:fnw_trace_inverse_factor_pos}
+    \lean{MPSTensor.fnwTraceInverseFactor_pos}
+    \leanok
+    \uses{def:fnw_trace_inverse_factor}
+    If $\rho\in\MN{D}$ is positive definite and $D>0$, then $c_\rho>0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_trace_inverse_factor}
+    The inverse $\rho^{-1}$ is positive definite, so its trace has strictly
+    positive real part.
+\end{proof}
+
+\begin{definition}[Weighted FNW remainder data]
+    \label{def:fnw_weighted_remainder_data}
+    \lean{MPSTensor.fnwWeightedRemainderSpectralRadius}
+    \lean{MPSTensor.fnwWeightedOperatorNorm}
+    \leanok
+    \uses{def:fnw_transfer_map, def:fnw_limit_map, thm:weighted-virtual-inner-product}
+    Let $\rho\in\MN{D}$ be positive definite and let $\tr(\rho)\neq0$.
+    Equip $\MN{D}$ with
+    $\langle X,Y\rangle_\rho=\tr(\rho X^\dagger Y)$.  For a linear map
+    $F\colon\MN{D}\to\MN{D}$, write
+    \begin{align}
+        \lVert F\rVert_{\mathrm{op},\rho}
+         & :=\sup_{X\neq0}\frac{\lVert F(X)\rVert_\rho}{\lVert X\rVert_\rho}.
+        \label{eq:fnw_weighted_operator_norm}
+    \end{align}
+    The weighted remainder spectral radius is
+    \begin{align}
+        r_\rho(A)
+         & :=\rho_{\mathrm{spec}}\!\left(
+        E_{\mathrm{FNW},A}-E_\infty^\rho\right),
+        \label{eq:fnw_weighted_remainder_spectral_radius}
+    \end{align}
+    where the remainder is viewed as a bounded operator on this weighted
+    Hilbert space.
+\end{definition}
+
+\begin{theorem}[Weighted FNW remainder spectral gap]
+    \label{thm:fnw_weighted_remainder_spectral_radius_lt_one}
+    \lean{MPSTensor.IsPrimitiveMPS.fnwWeightedRemainder_spectralRadius_lt_one}
+    \leanok
+    \uses{def:primitive_mps, def:fnw_weighted_remainder_data}
+    Let $A$ be primitive with nonzero bond dimension and positive-definite
+    fixed-point witness $\rho$.  Then
+    \begin{align}
+        r_\rho(A) & <1.
+        \label{eq:fnw_weighted_remainder_spectral_radius_lt_one}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_remainder_eigenvalue_gap}
+    In finite dimension the spectral radius is determined by the eigenvalues.
+    Apply Theorem~\ref{thm:fnw_remainder_eigenvalue_gap} in the weighted norm.
+\end{proof}
+
+\begin{definition}[FNW mixing quantity]
+    \label{def:fnw_mixing_quantity}
+    \lean{MPSTensor.fnwMixingQuantity}
+    \leanok
+    \uses{def:fnw_trace_inverse_factor, def:fnw_weighted_remainder_data}
+    Suppose that $\rho$ is positive definite and $\tr(\rho)=1$.  For
+    $n\in\N$, define
+    \begin{align}
+        a(n)
+         & :=c_\rho\,
+        \bigl\lVert E_{\mathrm{FNW},A}^n-E_\infty^\rho
+        \bigr\rVert_{\mathrm{op},\rho}.
+        \label{eq:fnw_mixing_quantity}
+    \end{align}
+    This is the trace-one transfer-remainder quantity formed from the factor
+    and weighted norm in
+    \cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
+\end{definition}
+
+\begin{theorem}[Prescribed-rate bound for the FNW mixing quantity]
+    \label{thm:fnw_mixing_quantity_geometric}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_fnwMixingQuantity_le_geometric}
+    \leanok
+    \uses{def:primitive_mps, def:fnw_mixing_quantity, def:fnw_weighted_remainder_data}
+    Let $A$ be primitive with nonzero bond dimension and positive-definite
+    trace-one fixed point $\rho$.  Let $\lambda\geq0$ satisfy
+    $r_\rho(A)<\lambda$.  There is a constant $C_\lambda>0$ such that, for
+    every integer $n\geq1$,
+    \begin{align}
+        a(n) & \leq C_\lambda\lambda^n.
+        \label{eq:fnw_mixing_quantity_geometric}
+    \end{align}
+    This proves the prescribed-rate transfer-remainder estimate in
+    \cite[Lemma~5.2]{Fannes1992Finitely}.  The condition $\lambda<1$ is needed
+    only when one subsequently deduces decay to zero.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:geometric_bound_of_spectral_radius_lt, thm:primitive_fnw_remainder_power, thm:fnw_trace_inverse_factor_pos}
+    Apply Theorem~\ref{thm:geometric_bound_of_spectral_radius_lt} to the
+    weighted remainder $R_A^\rho$.  This gives $C_0>0$ with
+    $\lVert(R_A^\rho)^n\rVert_{\mathrm{op},\rho}
+        \leq C_0\lambda^n$.  For $n\geq1$,
+    Theorem~\ref{thm:primitive_fnw_remainder_power} identifies
+    $(R_A^\rho)^n$ with
+    $E_{\mathrm{FNW},A}^n-E_\infty^\rho$.  Multiply by $c_\rho>0$ and take
+    $C_\lambda=c_\rho C_0$.
+\end{proof}
+
+The theorem does not identify $C_\lambda$ with $k^2$ or identify the FNW
+auxiliary dimension $k$ with the chosen bond dimension $D$.  It introduces no
+dimension prefactor.  It does not prove the boundary-map estimate in
+\cite[Equation~(5.9)]{Fannes1992Finitely}, Lemma~5.3, Lemma~6.2, or a
+replacement of the weighted argument by a finite Gram operator.
+
 \begin{theorem}[Geometric power bound below unit spectral radius]
     \label{thm:geometric_bound_of_spectral_radius_lt_one}
     \lean{geometric_bound_of_spectralRadius_lt_one}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1691,13 +1691,29 @@ then gives the open-chain anticommutator estimate through two-projection
 geometry. The length $l$ is measured in sites of the input tensor; if that
 tensor is already blocked, one such site is one blocked-chain filtration step.
 
-The weighted virtual-space foundation is now formalized.  For every
-positive-definite $\rho$, matrices carry the inner product
+The weighted virtual-space foundation and the transfer-remainder decay are now
+formalized.  For every positive-definite $\rho$, matrices carry the inner
+product
 $\langle X,Y\rangle_\rho=\operatorname{Tr}(\rho X^\dagger Y)$ from
 Equation~(5.6) of Ref.~\cite{Fannes1992Finitely}, and right multiplication by
 $\sqrt\rho$ followed by vectorization identifies this space isometrically with
-$\C^{D^2}$.  This completes only the Hilbert-space package.  Lemmas~5.2, 5.3,
-and 6.2, including the optimized numerator, remain open.
+$\C^{D^2}$.  The bilinear trace-adjoint remainder has the same nonunit
+eigenvalues as the Schrödinger remainder.  Its spectral radius in the weighted
+norm is therefore strictly below one.  With
+\begin{align}
+    a(n)
+    &=\operatorname{Re}\operatorname{Tr}(\rho^{-1})
+    \lVert E^n-E_\infty\rVert_{\operatorname{op},\rho},
+    \label{eq:cpgsv21_martingale_overlap_fnw_mixing_quantity}
+\end{align}
+the theorem
+\leanid{MPSTensor.IsPrimitiveMPS.exists_fnwMixingQuantity_le_geometric}
+gives, for every prescribed nonnegative $\lambda$ above that spectral radius,
+a constant $C_\lambda>0$ such that
+$a(n)\leq C_\lambda\lambda^n$ for every $n\geq1$.  This is the proved
+transfer-remainder part of Lemma~5.2 and Equations~(5.9)--(5.10) of
+Ref.~\cite{Fannes1992Finitely}.  The boundary-map estimate in Equation~(5.9),
+Lemmas~5.3 and~6.2, and the optimized numerator remain open.
 
 The reconstructed coefficient is not the optimized FNW expression
 \begin{align}
@@ -1707,9 +1723,10 @@ The reconstructed coefficient is not the optimized FNW expression
     \label{eq:cpgsv21_martingale_overlap_optimized_fnw_expression}
 \end{align}
 quoted as \path{boundAm} in Section~6 of
-Ref.~\cite{Nachtergaele1996Spectral}. Recovering its numerator and source
-constants requires the weighted Gram estimates in Lemmas~5.2, 5.3, and 6.2 of
-Ref.~\cite{Fannes1992Finitely}. The reconstructed constant is not identified
+Ref.~\cite{Nachtergaele1996Spectral}. Recovering its numerator requires the
+remaining boundary estimate in Lemma~5.2 and the weighted Gram estimates in
+Lemmas~5.3 and~6.2 of Ref.~\cite{Fannes1992Finitely}. The reconstructed
+constant is not identified
 with a source dimension-dependent value; the available unweighted conversion
 retains the proved $D^{3/2}$ norm factor inside $g$.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1710,8 +1710,9 @@ the theorem
 \leanid{MPSTensor.IsPrimitiveMPS.exists_fnwMixingQuantity_le_geometric}
 gives, for every prescribed nonnegative $\lambda$ above that spectral radius,
 a constant $C_\lambda>0$ such that
-$a(n)\leq C_\lambda\lambda^n$ for every $n\geq1$.  This is the proved
-transfer-remainder part of Lemma~5.2 and Equations~(5.9)--(5.10) of
+$a(n)\leq C_\lambda\lambda^n$ for every $n\geq1$.  The factor and weighted
+remainder norm are those entering Equations~(5.9)--(5.10), while the theorem
+proves the prescribed-rate estimate for $a(n)$ in Lemma~5.2 of
 Ref.~\cite{Fannes1992Finitely}.  The boundary-map estimate in Equation~(5.9),
 Lemmas~5.3 and~6.2, and the optimized numerator remain open.
 


### PR DESCRIPTION
## What changed

- transfer the primitive complementary eigenvalue gap to the FNW bilinear trace-adjoint remainder;
- define its spectral radius and operator norm under the local $\rho$-weighted virtual Hilbert structure;
- define the positive factor $\operatorname{Re}\operatorname{Tr}(\rho^{-1})$ and the trace-one source quantity
  \[
  a(n)=\operatorname{Re}\operatorname{Tr}(\rho^{-1})\lVert E_{\mathrm{FNW}}^n-E_\infty\rVert_{\mathrm{op},\rho};
  \]
- prove a prescribed-rate bound with an existential positive prefactor for every $n\geq1$;
- synchronize Chapter 13 and the #6367 paper-gap disclosure.

The prefactor remains rate-dependent and existential. This PR makes no claim that $C_\lambda=k^2$, does not identify $k$ with the bond dimension, and does not prove the boundary estimate, FNW Lemma 5.3, or FNW Lemma 6.2.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.FNWTransferDecay` (8841 jobs)
- `lake build TNLean.MPS.ParentHamiltonian` (9197 jobs)
- generated imports: 37 aggregators covering 1081 production modules
- import-generator tests, style, proof-integrity, line length, tactic-pattern, axiom, and external call-site checks
- Blueprint sync: 7312 unique Lean references and 7336 theorem-like entries
- both strict declaration checks and reverse coverage
- paper-gap declarations and references, reader-facing prose, ChkTeX, pinned formatting, labels, and dependencies
- exact-head review approved `db74991043465ad1a270be9b769192c414aafa71`

Closes #7596.
Advances #6367.
