### PR TITLE
feat(mpdo): place the local Gauss projector

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -160,6 +160,7 @@ import TNLean.MPS.MPDO.GSNNCHFourCycleMarkov.FourCycle
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.GSNNCHSectorRescaling
 import TNLean.MPS.MPDO.GSNNCHSectorSum
+import TNLean.MPS.MPDO.GaussProjectorPlacement
 import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.GroupedGramNormalization
 import TNLean.MPS.MPDO.GroupedReferenceCorner

--- a/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
+++ b/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.GaussProjector
+import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
+
+/-!
+# Finite-chain placement of the local Gauss projector
+
+The local Gauss projector is reindexed from a two-site matter configuration
+and two gauge-leg labels into two chain-site coordinates. It is then embedded
+on the periodic window beginning at `j`. This is the position-dependent
+projector of FBC25, Equation `eq:gauge_projs` (arXiv:2502.20257,
+lines 3494--3499).
+
+Gauged-MPS invariance, commutativity, a spectral gap, and ground-space
+completeness are not treated here.
+-/
+
+noncomputable section
+
+namespace TNLean.Algebra
+
+variable (d : ℕ) (G : Type*) [Group G] [Fintype G]
+
+/-- The coordinate equivalence from a two-site matter configuration and its
+ordered pair of gauge labels to two chain sites, each carrying one matter and
+one gauge label.
+
+This is the coordinate identification used to place the local kernel from
+FBC25, Equation `eq:gauge_projs` (arXiv:2502.20257, lines 3494--3499). -/
+def gaussLocalCoordinateEquiv :
+    ((Fin 2 → Fin d) × (G × G)) ≃
+      (Fin 2 → Fin (Fintype.card (Fin d × G))) :=
+  ((Equiv.refl (Fin 2 → Fin d)).prodCongr
+      (finTwoArrowEquiv G).symm).trans
+    ((Equiv.arrowProdEquivProdArrow (Fin 2) (fun _ ↦ Fin d)
+      (fun _ ↦ G)).symm.trans
+        (Equiv.arrowCongr (Equiv.refl (Fin 2))
+          (Fintype.equivFin (Fin d × G))))
+
+@[simp]
+theorem gaussLocalCoordinateEquiv_apply_zero
+    (x : (Fin 2 → Fin d) × (G × G)) :
+    gaussLocalCoordinateEquiv d G x 0 =
+      Fintype.equivFin (Fin d × G) (x.1 0, x.2.1) :=
+  rfl
+
+@[simp]
+theorem gaussLocalCoordinateEquiv_apply_one
+    (x : (Fin 2 → Fin d) × (G × G)) :
+    gaussLocalCoordinateEquiv d G x 1 =
+      Fintype.equivFin (Fin d × G) (x.1 1, x.2.2) :=
+  rfl
+
+variable [DecidableEq G]
+
+/-- The local Gauss projector reindexed into two-site chain-window
+coordinates. -/
+def gaussWindowProjector
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    Matrix (Fin 2 → Fin (Fintype.card (Fin d × G)))
+      (Fin 2 → Fin (Fintype.card (Fin d × G))) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ (gaussLocalCoordinateEquiv d G)
+    (gaussProjector R)
+
+/-- Reindexing the local Gauss projector into chain-window coordinates
+preserves its star-projection property. -/
+theorem isStarProjection_gaussWindowProjector
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    IsStarProjection (gaussWindowProjector d G R) := by
+  rw [isStarProjection_iff'] at *
+  obtain ⟨hidempotent, hselfAdjoint⟩ := isStarProjection_gaussProjector R
+  constructor
+  · rw [gaussWindowProjector, ← map_mul, hidempotent]
+  · rw [gaussWindowProjector, Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_reindex]
+    simpa [Matrix.star_eq_conjTranspose] using congrArg
+      (Matrix.reindex (gaussLocalCoordinateEquiv d G)
+        (gaussLocalCoordinateEquiv d G)) hselfAdjoint
+
+/-- The local Gauss projector placed on the periodic two-site window beginning
+at `j`, as in FBC25, Equation `eq:gauge_projs` (arXiv:2502.20257,
+lines 3494--3499). -/
+def placedGaussProjector
+    (N : ℕ) (hN : 2 ≤ N) (j : Fin N)
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    MPOTensor.ChainOperator (Fintype.card (Fin d × G)) N :=
+  MPOTensor.embedLocalOperator 2 N hN j (gaussWindowProjector d G R)
+
+/-- The Gauss projector placed on any periodic two-site window is a star
+projection. -/
+theorem isStarProjection_placedGaussProjector
+    (N : ℕ) (hN : 2 ≤ N) (j : Fin N)
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    IsStarProjection (placedGaussProjector d G N hN j R) :=
+  MPOTensor.embedLocalOperator_isStarProjection 2 N hN j
+    (isStarProjection_gaussWindowProjector d G R)
+
+end TNLean.Algebra

--- a/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
+++ b/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
@@ -21,7 +21,7 @@ completeness are not treated here.
 
 noncomputable section
 
-namespace TNLean.Algebra
+namespace MPOTensor
 
 variable (d : ℕ) (G : Type*) [Group G] [Fintype G]
 
@@ -66,7 +66,7 @@ def gaussWindowProjector
     Matrix (Fin 2 → Fin (Fintype.card (Fin d × G)))
       (Fin 2 → Fin (Fintype.card (Fin d × G))) ℂ :=
   Matrix.reindexAlgEquiv ℂ ℂ (gaussLocalCoordinateEquiv d G)
-    (gaussProjector R)
+    (TNLean.Algebra.gaussProjector R)
 
 /-- Reindexing the local Gauss projector into chain-window coordinates
 preserves its star-projection property. -/
@@ -74,15 +74,16 @@ theorem isStarProjection_gaussWindowProjector
     (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
     IsStarProjection (gaussWindowProjector d G R) := by
   rw [isStarProjection_iff']
-  have h := (isStarProjection_iff').mp (isStarProjection_gaussProjector R)
+  have h := (isStarProjection_iff').mp
+    (TNLean.Algebra.isStarProjection_gaussProjector R)
   constructor
   · rw [gaussWindowProjector, ← map_mul, h.1]
   · change
       (Matrix.reindex (gaussLocalCoordinateEquiv d G)
         (gaussLocalCoordinateEquiv d G)
-        (gaussProjector R)).conjTranspose =
+        (TNLean.Algebra.gaussProjector R)).conjTranspose =
       Matrix.reindex (gaussLocalCoordinateEquiv d G)
-        (gaussLocalCoordinateEquiv d G) (gaussProjector R)
+        (gaussLocalCoordinateEquiv d G) (TNLean.Algebra.gaussProjector R)
     rw [Matrix.conjTranspose_reindex]
     simpa [Matrix.star_eq_conjTranspose] using congrArg
       (Matrix.reindex (gaussLocalCoordinateEquiv d G)
@@ -106,4 +107,4 @@ theorem isStarProjection_placedGaussProjector
   MPOTensor.embedLocalOperator_isStarProjection 2 N hN j
     (isStarProjection_gaussWindowProjector d G R)
 
-end TNLean.Algebra
+end MPOTensor

--- a/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
+++ b/TNLean/MPS/MPDO/GaussProjectorPlacement.lean
@@ -41,6 +41,7 @@ def gaussLocalCoordinateEquiv :
         (Equiv.arrowCongr (Equiv.refl (Fin 2))
           (Fintype.equivFin (Fin d × G))))
 
+omit [Group G] in
 @[simp]
 theorem gaussLocalCoordinateEquiv_apply_zero
     (x : (Fin 2 → Fin d) × (G × G)) :
@@ -48,6 +49,7 @@ theorem gaussLocalCoordinateEquiv_apply_zero
       Fintype.equivFin (Fin d × G) (x.1 0, x.2.1) :=
   rfl
 
+omit [Group G] in
 @[simp]
 theorem gaussLocalCoordinateEquiv_apply_one
     (x : (Fin 2 → Fin d) × (G × G)) :
@@ -71,15 +73,20 @@ preserves its star-projection property. -/
 theorem isStarProjection_gaussWindowProjector
     (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
     IsStarProjection (gaussWindowProjector d G R) := by
-  rw [isStarProjection_iff'] at *
-  obtain ⟨hidempotent, hselfAdjoint⟩ := isStarProjection_gaussProjector R
+  rw [isStarProjection_iff']
+  have h := (isStarProjection_iff').mp (isStarProjection_gaussProjector R)
   constructor
-  · rw [gaussWindowProjector, ← map_mul, hidempotent]
-  · rw [gaussWindowProjector, Matrix.star_eq_conjTranspose,
-      Matrix.conjTranspose_reindex]
+  · rw [gaussWindowProjector, ← map_mul, h.1]
+  · change
+      (Matrix.reindex (gaussLocalCoordinateEquiv d G)
+        (gaussLocalCoordinateEquiv d G)
+        (gaussProjector R)).conjTranspose =
+      Matrix.reindex (gaussLocalCoordinateEquiv d G)
+        (gaussLocalCoordinateEquiv d G) (gaussProjector R)
+    rw [Matrix.conjTranspose_reindex]
     simpa [Matrix.star_eq_conjTranspose] using congrArg
       (Matrix.reindex (gaussLocalCoordinateEquiv d G)
-        (gaussLocalCoordinateEquiv d G)) hselfAdjoint
+        (gaussLocalCoordinateEquiv d G)) h.2
 
 /-- The local Gauss projector placed on the periodic two-site window beginning
 at `j`, as in FBC25, Equation `eq:gauge_projs` (arXiv:2502.20257,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1043,19 +1043,19 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     local kernel has row and column coordinates
     \begin{align}
         \bigl((i_0,i_1),(a,b)\bigr)
-        &\in (\{0,\ldots,d-1\}^{\{0,1\}})\times G^2.
+         & \in (\{0,\ldots,d-1\}^{\{0,1\}})\times G^2.
     \end{align}
     Identify these with two site coordinates by the bijection
     \begin{align}
         \kappa\bigl((i_0,i_1),(a,b)\bigr)
-        &=\bigl((i_0,a),(i_1,b)\bigr),
+         & =\bigl((i_0,a),(i_1,b)\bigr),
     \end{align}
     followed at each site by a fixed enumeration of
     $\{0,\ldots,d-1\}\times G$.  If $\widetilde P_G(R)$ denotes the matrix
     obtained from $P_G(R)$ by this simultaneous row and column relabelling,
     define its placement on a periodic chain of length $N\geq2$ by
     \begin{align}
-        P_j(R)&=\operatorname{Embed}_{j,j+1}\bigl(\widetilde P_G(R)\bigr).
+        P_j(R) & =\operatorname{Embed}_{j,j+1}\bigl(\widetilde P_G(R)\bigr).
         \label{eq:mpug_placed_gauss_projector}
     \end{align}
     Here the second site is $j+1$ modulo $N$.  This is the position-dependent
@@ -1063,7 +1063,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     % Source anchor: arXiv:2502.20257, eq:gauge_projs.
 \end{definition}
 
-\begin{theorem}[The placed Gauss operator is a projection]
+\begin{theorem}[The placed Gauss projector is a projection]
     \label{thm:mpug_placed_gauss_projector_projection}
     \lean{TNLean.Algebra.isStarProjection_gaussWindowProjector,
         TNLean.Algebra.isStarProjection_placedGaussProjector}
@@ -1074,8 +1074,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     For every $N\geq2$ and every position $j$, the operator
     in~(\ref{eq:mpug_placed_gauss_projector}) satisfies
     \begin{align}
-        P_j(R)^2       &=P_j(R),\\
-        P_j(R)^\dagger &=P_j(R).
+        P_j(R)^2       & =P_j(R), \\
+        P_j(R)^\dagger & =P_j(R).
     \end{align}
 \end{theorem}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1069,8 +1069,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.isStarProjection_placedGaussProjector}
     \leanok
     \discussion{7605}
-    \uses{def:mpug_placed_gauss_projector,
-        thm:mpug_gauss_projector_projection}
+    \uses{def:mpug_placed_gauss_projector}
     For every $N\geq2$ and every position $j$, the operator
     in~(\ref{eq:mpug_placed_gauss_projector}) satisfies
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1031,11 +1031,11 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{definition}[Gauss projector on a periodic chain]
     \label{def:mpug_placed_gauss_projector}
-    \lean{TNLean.Algebra.gaussLocalCoordinateEquiv,
-        TNLean.Algebra.gaussLocalCoordinateEquiv_apply_zero,
-        TNLean.Algebra.gaussLocalCoordinateEquiv_apply_one,
-        TNLean.Algebra.gaussWindowProjector,
-        TNLean.Algebra.placedGaussProjector}
+    \lean{MPOTensor.gaussLocalCoordinateEquiv,
+        MPOTensor.gaussLocalCoordinateEquiv_apply_zero,
+        MPOTensor.gaussLocalCoordinateEquiv_apply_one,
+        MPOTensor.gaussWindowProjector,
+        MPOTensor.placedGaussProjector}
     \leanok
     \discussion{7605}
     \uses{def:mpug_gauss_projector}
@@ -1065,8 +1065,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{theorem}[The placed Gauss projector is a projection]
     \label{thm:mpug_placed_gauss_projector_projection}
-    \lean{TNLean.Algebra.isStarProjection_gaussWindowProjector,
-        TNLean.Algebra.isStarProjection_placedGaussProjector}
+    \lean{MPOTensor.isStarProjection_gaussWindowProjector,
+        MPOTensor.isStarProjection_placedGaussProjector}
     \leanok
     \discussion{7605}
     \uses{def:mpug_placed_gauss_projector}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1029,6 +1029,64 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     the bijection $g\mapsto g^{-1}$.
 \end{proof}
 
+\begin{definition}[Gauss projector on a periodic chain]
+    \label{def:mpug_placed_gauss_projector}
+    \lean{TNLean.Algebra.gaussLocalCoordinateEquiv,
+        TNLean.Algebra.gaussLocalCoordinateEquiv_apply_zero,
+        TNLean.Algebra.gaussLocalCoordinateEquiv_apply_one,
+        TNLean.Algebra.gaussWindowProjector,
+        TNLean.Algebra.placedGaussProjector}
+    \leanok
+    \discussion{7605}
+    \uses{def:mpug_gauss_projector}
+    Let the matter degree of freedom at one site have dimension $d$.  The
+    local kernel has row and column coordinates
+    \begin{align}
+        \bigl((i_0,i_1),(a,b)\bigr)
+        &\in (\{0,\ldots,d-1\}^{\{0,1\}})\times G^2.
+    \end{align}
+    Identify these with two site coordinates by the bijection
+    \begin{align}
+        \kappa\bigl((i_0,i_1),(a,b)\bigr)
+        &=\bigl((i_0,a),(i_1,b)\bigr),
+    \end{align}
+    followed at each site by a fixed enumeration of
+    $\{0,\ldots,d-1\}\times G$.  If $\widetilde P_G(R)$ denotes the matrix
+    obtained from $P_G(R)$ by this simultaneous row and column relabelling,
+    define its placement on a periodic chain of length $N\geq2$ by
+    \begin{align}
+        P_j(R)&=\operatorname{Embed}_{j,j+1}\bigl(\widetilde P_G(R)\bigr).
+        \label{eq:mpug_placed_gauss_projector}
+    \end{align}
+    Here the second site is $j+1$ modulo $N$.  This is the position-dependent
+    projector $P_j$ in~\cite[lines~3494--3499]{FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, eq:gauge_projs.
+\end{definition}
+
+\begin{theorem}[The placed Gauss operator is a projection]
+    \label{thm:mpug_placed_gauss_projector_projection}
+    \lean{TNLean.Algebra.isStarProjection_gaussWindowProjector,
+        TNLean.Algebra.isStarProjection_placedGaussProjector}
+    \leanok
+    \discussion{7605}
+    \uses{def:mpug_placed_gauss_projector,
+        thm:mpug_gauss_projector_projection}
+    For every $N\geq2$ and every position $j$, the operator
+    in~(\ref{eq:mpug_placed_gauss_projector}) satisfies
+    \begin{align}
+        P_j(R)^2       &=P_j(R),\\
+        P_j(R)^\dagger &=P_j(R).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_gauss_projector_projection}
+    Simultaneous relabelling of rows and columns preserves multiplication and
+    adjoints, so $\widetilde P_G(R)$ remains idempotent and self-adjoint.
+    Embedding into the two-site periodic window also preserves multiplication
+    and adjoints, which gives both identities for $P_j(R)$.
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,


### PR DESCRIPTION
## What changed

- define the coordinate equivalence that identifies a two-site matter configuration and ordered gauge-label pair with two matter-gauge chain-site coordinates
- record the site-zero and site-one coordinate formulas explicitly
- reindex the merged local Gauss projector into the finite-chain window convention
- prove that simultaneous row and column reindexing preserves the star-projection property
- place the projector on the periodic two-site window beginning at `j` with the existing local-operator embedding
- prove every placed operator is a star projection
- add the generated MPDO export and source-facing Chapter 29 entries

## Source and scope

The source formula is

`P_j = |G|⁻¹ ∑ g, 𝒢_g^{j,j+1}`

in `Papers/2502.20257/main.tex:3494-3499`, equation `eq:gauge_projs`. This PR places the local kernel merged in #7583 on the source's cyclic two-site window. The coordinate equivalence sends

`((i₀, i₁), (a, b)) ↦ ((i₀, a), (i₁, b))`

before enumerating each finite local matter-gauge label.

This PR does not prove that the placed projector fixes the gauged MPS. That result remains in #7342 and depends on the gauged-tensor invariance part of #7341. It also makes no claim about neighboring-projector commutativity, a spectral gap, or ground-space completeness.

## Validation

- `lake build TNLean.MPS.MPDO.GaussProjectorPlacement` (9308/9308)
- `lake build TNLean.MPS.MPDO` (9645/9645)
- full warm `lake build` (10460/10460)
- `python3 scripts/generate_import_aggregators.py --root . --check` (37 generated files, 1081 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (7335/7335)
- `cd blueprint && leanblueprint checkdecls`
- CI-style Blueprint sync
- repository `latexindent` formatting and double `lualatex` passes with the pinned tenkz package; zero undefined cross-references
- reader-facing prose, tenkz lint, ChkTeX, Lean size, numbered-module, forbidden-token, whitespace, and placeholder checks
- `git diff --check origin/main...HEAD`

Closes #7605.
Advances #7342 and #7568.

