### PR TITLE
feat(mpdo): add twisted-dimer tensor formulas and candidate coefficients

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -324,6 +324,8 @@ import TNLean.MPS.MPDO.TopologicalPhysicalGibbs
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TopologicalTerminalSpectral
+import TNLean.MPS.MPDO.TwistedDimer
+import TNLean.MPS.MPDO.TwistedDimerCoefficients
 import TNLean.MPS.MPDO.TwoSitePrefixReflectedMarkedChain
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalBNT

--- a/TNLean/MPS/MPDO/TwistedDimer.lean
+++ b/TNLean/MPS/MPDO/TwistedDimer.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Matrix.Basis
+import Mathlib.LinearAlgebra.Matrix.Trace
+import TNLean.MPS.MPDO.PhysicalClosure
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# The $\mathbb Z_2$-twisted quantum dimer
+
+**Scope: tensor and closure formulas.** This file defines the MPO tensor of the
+$\mathbb Z_2$-twisted quantum dimer, a project example motivated by the
+length-dependence question after Theorem 4.14 of arXiv:1606.00608 (lines
+995--1010), and proves the entrywise formulas for its one-site and two-site
+physical closures and for its physical-trace transfer.  The fixed-point
+channels, positivity, and fusion data are formalized in separate files.
+
+## The tensor
+
+Each site is a pair of qubits $L, R$ together with a flag qubit $f$; the
+physical index `i : Fin 8` is read as the bits `(bitL i, bitR i, bitF i)`.  The
+bond index `a : Fin 8` is read as `(bitL a, bitR a, bitF a) = (p, p', k)`, where
+`k` selects one of two horizontal blocks.  With the bond weights
+$x = 7/8$, $y = 1/8$ and the $2 \times 2$ matrices
+$C_0 = x P_+ + y P_-$, $C_1 = x P_+ - y P_-$ ($P_\pm = (\mathbb 1 \pm X)/2$),
+the physical operator of the bond pair $((p,p',k),(q,q',k))$ is
+$$
+  \tfrac12\, C_k[p,p']\; E_{pp'} \otimes E_{qq'} \otimes \tau_k,
+  \qquad \tau_0 = \mathbb 1,\ \tau_1 = Z,
+$$
+and the physical operator of a bond pair with different block labels vanishes.
+Equivalently, for physical indices $i = (l,r,f)$ and $j = (l',r',f')$ the bond
+matrix $M^{ij}$ is the sum over $k$ of the matrix units at
+$((l,l',k),(r,r',k))$ with coefficient
+$\tfrac12 C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$ (`coef`).
+
+## Main results
+
+* `physClose1_T` — the one-site physical closure is the sum over $k$ of the
+  coefficient times the bond-matrix entry at the transposed matrix unit;
+* `physClose2_T` — the two-site closure is gated by the bond-matching
+  condition `bitR i₁ = bitL i₂`, `bitR j₁ = bitL j₂` and keeps a common block
+  label $k$;
+* `physTraceTransfer_T` — the physical-trace transfer lives in the block
+  $k = 0$ only: the flag trace $\operatorname{tr}\tau_1 = 0$ kills the block
+  $k = 1$, which is the nilpotency of Definition 4.7 for that block
+  (`physTraceTransfer_block_one`).
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1, Definition 4.7, Theorem 4.14 and lines 995--1010 (project
+  example, not a tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### Bit encodings of the physical and bond indices -/
+
+/-- The index `(l, r, f) ↦ 4 l + 2 r + f` of `Fin 8`. -/
+def physIdx (l r f : Fin 2) : Fin 8 := ⟨l.val * 4 + r.val * 2 + f.val, by omega⟩
+
+/-- The first bit of an index of `Fin 8`. -/
+def bitL (i : Fin 8) : Fin 2 := ⟨i.val / 4, by omega⟩
+
+/-- The second bit of an index of `Fin 8`. -/
+def bitR (i : Fin 8) : Fin 2 := ⟨i.val / 2 % 2, by omega⟩
+
+/-- The third bit of an index of `Fin 8`. -/
+def bitF (i : Fin 8) : Fin 2 := ⟨i.val % 2, by omega⟩
+
+@[simp] lemma bitL_physIdx (l r f : Fin 2) : bitL (physIdx l r f) = l := by
+  ext; simp only [bitL, physIdx]; omega
+
+@[simp] lemma bitR_physIdx (l r f : Fin 2) : bitR (physIdx l r f) = r := by
+  ext; simp only [bitR, physIdx]; omega
+
+@[simp] lemma bitF_physIdx (l r f : Fin 2) : bitF (physIdx l r f) = f := by
+  ext; simp only [bitF, physIdx]; omega
+
+lemma physIdx_bits (i : Fin 8) : physIdx (bitL i) (bitR i) (bitF i) = i := by
+  ext; simp only [physIdx, bitL, bitR, bitF]; omega
+
+lemma physIdx_inj {l r f l' r' f' : Fin 2} :
+    physIdx l r f = physIdx l' r' f' ↔ l = l' ∧ r = r' ∧ f = f' := by
+  constructor
+  · intro h
+    have h1 := congrArg bitL h
+    have h2 := congrArg bitR h
+    have h3 := congrArg bitF h
+    simp only [bitL_physIdx, bitR_physIdx, bitF_physIdx] at h1 h2 h3
+    exact ⟨h1, h2, h3⟩
+  · rintro ⟨rfl, rfl, rfl⟩; rfl
+
+/-- The bit encoding as an equivalence `Fin 2 × Fin 2 × Fin 2 ≃ Fin 8`. -/
+def physEquiv : Fin 2 × Fin 2 × Fin 2 ≃ Fin 8 where
+  toFun x := physIdx x.1 x.2.1 x.2.2
+  invFun i := (bitL i, bitR i, bitF i)
+  left_inv := by rintro ⟨l, r, f⟩; simp
+  right_inv i := physIdx_bits i
+
+/-! ### Weights and coefficients -/
+
+/-- The bond weight $x = 7/8$ of the rational point. -/
+def x : ℝ := 7 / 8
+
+/-- The bond weight $y = 1/8$ of the rational point. -/
+def y : ℝ := 1 / 8
+
+/-- The diagonal entry $(x + y)/2$ of $C_0$, equal to the off-diagonal entry of $C_1$. -/
+def cDiag : ℝ := (x + y) / 2
+
+/-- The off-diagonal entry $(x - y)/2$ of $C_0$, equal to the diagonal entry of $C_1$. -/
+def cOff : ℝ := (x - y) / 2
+
+lemma cDiag_eq : cDiag = 1 / 2 := by norm_num [cDiag, x, y]
+
+lemma cOff_eq : cOff = 3 / 8 := by norm_num [cOff, x, y]
+
+/-- The bond matrices $C_0 = x P_+ + y P_-$ and $C_1 = x P_+ - y P_-$. -/
+def Cmat (k p p' : Fin 2) : ℝ := if (p = p' ↔ k = 0) then cDiag else cOff
+
+/-- The flag sign $(\tau_k)_{ff} = (-1)^{kf}$. -/
+def tau (k f : Fin 2) : ℝ := if k = 1 ∧ f = 1 then -1 else 1
+
+lemma tau_zero (f : Fin 2) : tau 0 f = 1 := by simp [tau]
+
+lemma tau_one_sum : tau 1 0 + tau 1 1 = 0 := by simp [tau]
+
+/-- The coefficient $\tfrac12 C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$ of the matrix unit
+at the bond pair $((l,l',k),(r,r',k))$ in the physical letter $(i, j)$. -/
+def coef (k : Fin 2) (i j : Fin 8) : ℂ :=
+  if bitF i = bitF j then ((Cmat k (bitL i) (bitL j) * tau k (bitF i) / 2 : ℝ) : ℂ) else 0
+
+lemma coef_physIdx (k l r f l' r' f' : Fin 2) :
+    coef k (physIdx l r f) (physIdx l' r' f') =
+      if f = f' then ((Cmat k l l' * tau k f / 2 : ℝ) : ℂ) else 0 := by
+  simp [coef]
+
+/-! ### The tensor -/
+
+/-- The $\mathbb Z_2$-twisted quantum dimer: for physical letter `(i, j)`, the bond
+matrix is the sum over the block label `k` of the matrix unit at
+`((bitL i, bitL j, k), (bitR i, bitR j, k))` with coefficient `coef k i j`. -/
+def T : MPOTensor 8 8 := fun i j =>
+  ∑ k : Fin 2,
+    Matrix.single (physIdx (bitL i) (bitL j) k) (physIdx (bitR i) (bitR j) k) (coef k i j)
+
+/-- The two horizontal blocks, each an MPO tensor with bond dimension four. -/
+def block (k : Fin 2) : MPOTensor 8 4 := fun i j =>
+  Matrix.single (finProdFinEquiv (bitL i, bitL j)) (finProdFinEquiv (bitR i, bitR j)) (coef k i j)
+
+/-- The tensor is the direct sum of its two blocks along the block label. -/
+lemma T_apply_blocks (i j : Fin 8) (p p' k q q' k' : Fin 2) :
+    T i j (physIdx p p' k) (physIdx q q' k') =
+      if k = k' then block k i j (finProdFinEquiv (p, p')) (finProdFinEquiv (q, q')) else 0 := by
+  fin_cases k <;> fin_cases k' <;>
+    simp [T, block, Matrix.sum_apply, Matrix.single_apply, physIdx_inj, Fin.sum_univ_two,
+      finProdFinEquiv.injective.eq_iff]
+
+/-! ### Physical closures -/
+
+/-- **One-site closure.**  `physClose1 T X i j = ∑ k, coef k i j * X (r-unit) (l-unit)`. -/
+theorem physClose1_T (X : Matrix (Fin 8) (Fin 8) ℂ) (i j : Fin 8) :
+    physClose1 T X i j =
+      ∑ k : Fin 2, coef k i j *
+        X (physIdx (bitR i) (bitR j) k) (physIdx (bitL i) (bitL j) k) := by
+  simp only [physClose1_apply, T, Finset.sum_mul, Matrix.trace_sum, Matrix.trace_single_mul,
+    smul_eq_mul]
+
+lemma single_mul_single_ite {a b c e : Fin 8} (u v : ℂ) :
+    Matrix.single a b u * Matrix.single c e v =
+      if b = c then Matrix.single a e (u * v) else (0 : Matrix (Fin 8) (Fin 8) ℂ) := by
+  by_cases h : b = c
+  · subst h; simp
+  · simp [h]
+
+/-- The bond-matching condition between consecutive letters. -/
+def gate (i₁ i₂ : Fin 8) : Prop := bitR i₁ = bitL i₂
+
+instance decidableGate (i₁ i₂ : Fin 8) : Decidable (gate i₁ i₂) :=
+  inferInstanceAs (Decidable (bitR i₁ = bitL i₂))
+
+/-- The product of two letters keeps a common block label and is gated by the
+bond-matching condition. -/
+lemma T_mul_T (i₁ j₁ i₂ j₂ : Fin 8) :
+    T i₁ j₁ * T i₂ j₂ =
+      if gate i₁ i₂ ∧ gate j₁ j₂ then
+        ∑ k : Fin 2, Matrix.single (physIdx (bitL i₁) (bitL j₁) k)
+          (physIdx (bitR i₂) (bitR j₂) k) (coef k i₁ j₁ * coef k i₂ j₂)
+      else 0 := by
+  simp only [T, Fin.sum_univ_two, add_mul, mul_add, single_mul_single_ite, physIdx_inj]
+  by_cases h1 : bitR i₁ = bitL i₂ <;> by_cases h2 : bitR j₁ = bitL j₂ <;>
+    simp [gate, h1, h2]
+
+/-- **Two-site closure.** -/
+theorem physClose2_T (X : Matrix (Fin 8) (Fin 8) ℂ) (i₁ i₂ j₁ j₂ : Fin 8) :
+    physClose2 T X (i₁, i₂) (j₁, j₂) =
+      if gate i₁ i₂ ∧ gate j₁ j₂ then
+        ∑ k : Fin 2, coef k i₁ j₁ * coef k i₂ j₂ *
+          X (physIdx (bitR i₂) (bitR j₂) k) (physIdx (bitL i₁) (bitL j₁) k)
+      else 0 := by
+  rw [physClose2_apply, T_mul_T]
+  split_ifs
+  · simp only [Finset.sum_mul, Matrix.trace_sum, Matrix.trace_single_mul, smul_eq_mul]
+  · simp
+
+/-! ### The physical-trace transfer -/
+
+lemma coef_diag_sum_flag (k l r : Fin 2) :
+    ∑ f : Fin 2, coef k (physIdx l r f) (physIdx l r f) =
+      if k = 0 then ((Cmat 0 l l : ℝ) : ℂ) else 0 := by
+  simp only [coef_physIdx, ite_true, Fin.sum_univ_two]
+  fin_cases k
+  · simp [tau]
+  · simp [tau]; ring
+
+/-- **The physical-trace transfer of the block `k = 1` vanishes**: the flag trace
+$\operatorname{tr}\tau_1 = 0$ kills every entry.  This is the nilpotency of
+Definition 4.7 (arXiv:1606.00608, lines 815--822) for the second horizontal block,
+so the twisted dimer is not a simple tensor. -/
+theorem physTraceTransfer_block_one : physTraceTransfer (block 1) = 0 := by
+  unfold physTraceTransfer
+  rw [← Fintype.sum_equiv physEquiv (fun x => block 1 (physEquiv x) (physEquiv x))
+    (fun i => block 1 i i) (fun _ => rfl)]
+  simp only [Fintype.sum_prod_type, physEquiv, Equiv.coe_fn_mk, block, bitL_physIdx,
+    bitR_physIdx]
+  ext a b
+  simp only [Matrix.sum_apply, Matrix.single_apply]
+  have key : ∀ l r : Fin 2, ∑ f : Fin 2, coef 1 (physIdx l r f) (physIdx l r f) = 0 := by
+    intro l r
+    rw [coef_diag_sum_flag]; simp
+  refine Finset.sum_eq_zero fun l _ => Finset.sum_eq_zero fun r _ => ?_
+  by_cases h : finProdFinEquiv (l, l) = a ∧ finProdFinEquiv (r, r) = b
+  · simp only [h, and_self, ite_true]
+    exact key l r
+  · simp [h]
+
+/-- The physical-trace transfer of the block `k = 0` is the rank-one bond matrix
+$\sum_{l,r} C_0[l,l]\,E_{(l,l),(r,r)}$. -/
+theorem physTraceTransfer_block_zero :
+    physTraceTransfer (block 0) =
+      ∑ l : Fin 2, ∑ r : Fin 2,
+        Matrix.single (finProdFinEquiv (l, l)) (finProdFinEquiv (r, r)) ((Cmat 0 l l : ℝ) : ℂ) := by
+  unfold physTraceTransfer
+  rw [← Fintype.sum_equiv physEquiv (fun x => block 0 (physEquiv x) (physEquiv x))
+    (fun i => block 0 i i) (fun _ => rfl)]
+  simp only [Fintype.sum_prod_type, physEquiv, Equiv.coe_fn_mk, block, bitL_physIdx,
+    bitR_physIdx]
+  refine Finset.sum_congr rfl fun l _ => Finset.sum_congr rfl fun r _ => ?_
+  have hsum : ∑ f : Fin 2, coef 0 (physIdx l r f) (physIdx l r f) = ((Cmat 0 l l : ℝ) : ℂ) := by
+    rw [coef_diag_sum_flag]; simp
+  rw [← hsum]
+  simp only [Fin.sum_univ_two, Matrix.single_add]
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimer.lean
+++ b/TNLean/MPS/MPDO/TwistedDimer.lean
@@ -11,12 +11,14 @@ import TNLean.MPS.MPDO.ZCL
 /-!
 # The $\mathbb Z_2$-twisted quantum dimer
 
-**Scope: tensor and closure formulas.** This file defines the MPO tensor of the
-$\mathbb Z_2$-twisted quantum dimer, a project example motivated by the
+**Scope: tensor and local closure formulas.** This file defines an MPO tensor
+for the $\mathbb Z_2$-twisted quantum dimer, a project example motivated by the
 length-dependence question after Theorem 4.14 of arXiv:1606.00608 (lines
-995--1010), and proves the entrywise formulas for its one-site and two-site
-physical closures and for its physical-trace transfer.  The fixed-point
-channels, positivity, and fusion data are formalized in separate files.
+995--1010), and proves entrywise formulas for its one-site and two-site physical
+closures and for the physical-trace transfers of its two displayed blocks. The
+all-length closed operator identity, positivity, fixed-point channels,
+non-simplicity of the tensor, and attachment of fusion data are not asserted
+here.
 
 ## The tensor
 
@@ -44,10 +46,9 @@ $\tfrac12 C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$ (`coef`).
 * `physClose2_T` — the two-site closure is gated by the bond-matching
   condition `bitR i₁ = bitL i₂`, `bitR j₁ = bitL j₂` and keeps a common block
   label $k$;
-* `physTraceTransfer_T` — the physical-trace transfer lives in the block
-  $k = 0$ only: the flag trace $\operatorname{tr}\tau_1 = 0$ kills the block
-  $k = 1$, which is the nilpotency of Definition 4.7 for that block
-  (`physTraceTransfer_block_one`).
+* `physTraceTransfer_block_zero` and `physTraceTransfer_block_one` — the flag
+  trace $\operatorname{tr}\tau_1 = 0$ kills the displayed block $k = 1$, while
+  the transfer of the displayed block $k = 0$ has an explicit rank-one form.
 
 ## References
 
@@ -222,10 +223,10 @@ lemma coef_diag_sum_flag (k l r : Fin 2) :
   · simp [tau]
   · simp [tau]; ring
 
-/-- **The physical-trace transfer of the block `k = 1` vanishes**: the flag trace
-$\operatorname{tr}\tau_1 = 0$ kills every entry.  This is the nilpotency of
-Definition 4.7 (arXiv:1606.00608, lines 815--822) for the second horizontal block,
-so the twisted dimer is not a simple tensor. -/
+/-- **The physical-trace transfer of the displayed block `k = 1` vanishes**:
+the flag trace $\operatorname{tr}\tau_1 = 0$ kills every entry. Thus this block
+has nilpotent physical-trace transfer in the sense used by Definition 4.7 of
+arXiv:1606.00608, lines 815--822. This does not assert non-simplicity of `T`. -/
 theorem physTraceTransfer_block_one : physTraceTransfer (block 1) = 0 := by
   unfold physTraceTransfer
   rw [← Fintype.sum_equiv physEquiv (fun x => block 1 (physEquiv x) (physEquiv x))

--- a/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.LengthIndependentCoefficients
+
+/-!
+# Two-label fusion coefficients of the twisted quantum dimer
+
+**Scope: coefficient family only.** This file records the basis-of-normal-tensors
+fusion data of the $\mathbb Z_2$-twisted quantum dimer, the project example that
+answers the length-dependence question after Theorem 4.14 of arXiv:1606.00608
+(lines 995--1010) with a tensor that is not simple.  The tensor itself and its
+fixed-point channels are formalized separately; here only the two-label
+coefficient family and its rescaling behaviour are treated.
+
+The example depends on bond weights $x, y > 0$ with $x + y = 1$; its two vertical
+blocks are labelled by a flag bit $f \in \mathbb Z_2$ and fuse according to
+$$
+  M_f M_{f'} \;\simeq\; \alpha\, M_{f + f'} \;\oplus\; \beta\, M_{f + f' + 1},
+  \qquad
+  \alpha = \frac{x}{\sqrt{2(x^2+y^2)}},\quad \beta = \frac{y}{\sqrt{2(x^2+y^2)}} .
+$$
+At the rational point $x = 7/8$, $y = 1/8$ one has $\alpha = 7/10$ and
+$\beta = 1/10$, which is the instance formalized here.
+
+## Main results
+
+* `twoLabelChi` — the diagonal $\chi$-family with the single entry $\alpha$ on the
+  channel $g = f + f'$ and $\beta$ on the channel $g = f + f' + 1$;
+* `twoLabelCoeffs_coeff` — $c^{(L)}_{f f' g} = \alpha^L$ or $\beta^L$;
+* `twoLabelCoeffs_not_lengthIndependent` — the family depends on the length;
+* `twoLabelCoeffs_rescaling_stable_not_lengthIndependent` — for every pair of
+  positive block rescalings $(s_0, s_1)$, the rescaled family
+  $(s_f s_{f'} / s_g)^L c^{(L)}_{f f' g}$ still depends on the length.  The proof
+  is the inconsistency of the system $s_f s_{f'} \chi_{f f' g} = s_g$: the
+  triples $(0,0,0)$ and $(0,1,0)$ force $s_0 = 1/\alpha$ and $s_1 = 1/\beta$,
+  after which the triple $(0,0,1)$ demands $\beta^2 = \alpha^2$.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14 and lines 995--1010 (the length-dependence question; the
+  tensor is a project example)
+-/
+
+open scoped BigOperators
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-- The fusion channel of two flag labels: the label $f + f'$ (`0`) or its
+complement $f + f' + 1$ (`1`), decided by whether `g = f + f'`. -/
+def sameChannel (f f' g : Fin 2) : Prop := g = f + f'
+
+instance decidableSameChannel (f f' g : Fin 2) : Decidable (sameChannel f f' g) :=
+  inferInstanceAs (Decidable (g = f + f'))
+
+/-- The fusion weight $\alpha = 7/10$ on the channel $g = f + f'$ (rational point
+$x = 7/8$, $y = 1/8$). -/
+def alpha : ℝ := 7 / 10
+
+/-- The fusion weight $\beta = 1/10$ on the channel $g = f + f' + 1$. -/
+def beta : ℝ := 1 / 10
+
+/-- The two-label diagonal $\chi$-family of the twisted dimer: every
+$\chi_{f f' g}$ is a $1 \times 1$ block with entry $\alpha$ or $\beta$. -/
+def twoLabelChi : DiagonalChiFamily (Fin 2) where
+  dim _ _ _ := 1
+  entry f f' g _ := if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ)
+
+lemma twoLabelChi_posEntries : twoLabelChi.PosEntries := by
+  intro f f' g k
+  by_cases h : sameChannel f f' g
+  · simp only [twoLabelChi, h, ite_true]
+    exact Complex.zero_lt_real.mpr (by norm_num [alpha])
+  · simp only [twoLabelChi, h, ite_false]
+    exact Complex.zero_lt_real.mpr (by norm_num [beta])
+
+/-- The coefficient family $c^{(L)}_{f f' g} = \operatorname{tr}(\chi_{f f' g}^L)$. -/
+def twoLabelCoeffs : BNTLabelCoefficientFamily (Fin 2) :=
+  BNTLabelCoefficientFamily.ofChi twoLabelChi
+
+theorem twoLabelCoeffs_coeff (L : ℕ) (f f' g : Fin 2) :
+    twoLabelCoeffs.coeff L f f' g =
+      if sameChannel f f' g then (alpha : ℂ) ^ L else (beta : ℂ) ^ L := by
+  dsimp [twoLabelCoeffs, BNTLabelCoefficientFamily.ofChi,
+    DiagonalChiFamily.tracePowerCoeff, twoLabelChi]
+  by_cases h : sameChannel f f' g <;> simp [h]
+
+/-- The channel-$\alpha$ coefficient $(7/10)^L$ differs between lengths one and two. -/
+theorem twoLabelCoeffs_not_lengthIndependent : ¬ twoLabelCoeffs.LengthIndependent := by
+  intro h
+  have := h.coeff_eq one_pos (by norm_num : (0 : ℕ) < 2) 0 0 0
+  rw [twoLabelCoeffs_coeff, twoLabelCoeffs_coeff] at this
+  have hs : sameChannel 0 0 0 := by decide
+  simp only [hs, ite_true, alpha] at this
+  norm_num at this
+
+/-- The rescaled $\chi$-family: block rescalings $M_f \mapsto s_f M_f$ act on the
+fusion data by $\chi_{f f' g} \mapsto (s_f s_{f'} / s_g)\,\chi_{f f' g}$
+(arXiv:1606.00608, the covariance of Theorem 4.14(iii) under the normalization
+freedom of Proposition 4.12). -/
+def twoLabelChiScaled (s : Fin 2 → ℝ) : DiagonalChiFamily (Fin 2) where
+  dim _ _ _ := 1
+  entry f f' g _ :=
+    ((s f * s f' / s g : ℝ) : ℂ) * (if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ))
+
+/-- The coefficient family of the rescaled fusion data. -/
+def rescaledCoeffs (s : Fin 2 → ℝ) : BNTLabelCoefficientFamily (Fin 2) :=
+  BNTLabelCoefficientFamily.ofChi (twoLabelChiScaled s)
+
+theorem rescaledCoeffs_coeff (s : Fin 2 → ℝ) (L : ℕ) (f f' g : Fin 2) :
+    (rescaledCoeffs s).coeff L f f' g =
+      (((s f * s f' / s g : ℝ) : ℂ) *
+        (if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ))) ^ L := by
+  dsimp [rescaledCoeffs, BNTLabelCoefficientFamily.ofChi,
+    DiagonalChiFamily.tracePowerCoeff, twoLabelChiScaled]
+  simp
+
+/-- A positive real with $t = t^2$ equals one. -/
+private lemma eq_one_of_pos_of_sq_eq {t : ℝ} (ht : 0 < t) (h : t = t ^ 2) : t = 1 := by
+  nlinarith
+
+/-- **Rescaling-stable length dependence.** For every pair of positive block
+rescalings $(s_0, s_1)$ the rescaled two-label family is not length independent.
+Length independence would force $s_0\alpha = 1$ (triple $(0,0,0)$),
+$s_1\beta = 1$ (triple $(0,1,0)$) and $s_0^2\beta/s_1 = 1$ (triple $(0,0,1)$),
+hence $\beta^2 = \alpha^2$, contradicting $\alpha = 7/10 \ne 1/10 = \beta$.
+
+Source: arXiv:1606.00608, Theorem 4.14 and lines 995--1010 (the
+length-dependence question); the twisted dimer is a project example. -/
+theorem twoLabelCoeffs_rescaling_stable_not_lengthIndependent (s : Fin 2 → ℝ)
+    (hs : ∀ f, 0 < s f) : ¬ (rescaledCoeffs s).LengthIndependent := by
+  intro hLI
+  have h0 := hs 0
+  have h1 := hs 1
+  -- a positive-length coefficient equal at lengths 1 and 2 is a real number t with t = t^2
+  have key : ∀ f f' g : Fin 2,
+      (s f * s f' / s g) * (if sameChannel f f' g then alpha else beta) = 1 := by
+    intro f f' g
+    have e := hLI.coeff_eq (show (0 : ℕ) < 2 by norm_num) (show (0 : ℕ) < 1 by norm_num) f f' g
+    rw [rescaledCoeffs_coeff, rescaledCoeffs_coeff] at e
+    have hq : 0 < s f * s f' / s g := div_pos (mul_pos (hs f) (hs f')) (hs g)
+    have hw : 0 < (if sameChannel f f' g then alpha else beta) := by
+      split_ifs <;> norm_num [alpha, beta]
+    set t : ℝ := (s f * s f' / s g) * (if sameChannel f f' g then alpha else beta) with ht
+    have et : ((t : ℝ) : ℂ) ^ 2 = ((t : ℝ) : ℂ) ^ 1 := by
+      rw [ht]
+      push_cast
+      split_ifs at e ⊢ <;> simpa using e
+    rw [pow_one] at et
+    have et' : t ^ 2 = t := by exact_mod_cast et
+    have htpos : 0 < t := mul_pos hq hw
+    exact eq_one_of_pos_of_sq_eq htpos et'.symm
+  have e000 := key 0 0 0
+  have e010 := key 0 1 0
+  have e001 := key 0 0 1
+  have hs000 : sameChannel 0 0 0 := by decide
+  have hs010 : ¬ sameChannel 0 1 0 := by decide
+  have hs001 : ¬ sameChannel 0 0 1 := by decide
+  simp only [hs000, hs010, hs001, ite_true, ite_false] at e000 e010 e001
+  -- e000 : s 0 * s 0 / s 0 * alpha = 1, e010 : s 0 * s 1 / s 0 * beta = 1,
+  -- e001 : s 0 * s 0 / s 1 * beta = 1
+  have h0ne : s 0 ≠ 0 := h0.ne'
+  have h1ne : s 1 ≠ 0 := h1.ne'
+  have a0 : s 0 * alpha = 1 := by
+    field_simp at e000
+    linarith [e000]
+  have a1 : s 1 * beta = 1 := by
+    field_simp at e010
+    linarith [e010]
+  have a2 : s 0 ^ 2 * beta = s 1 := by
+    field_simp at e001
+    linarith [e001]
+  simp only [alpha, beta] at a0 a1 a2
+  nlinarith [a0, a1, a2]
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
@@ -6,24 +6,22 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 
 /-!
-# Two-label fusion coefficients of the twisted quantum dimer
+# A candidate two-label coefficient family
 
-**Scope: coefficient family only.** This file records the basis-of-normal-tensors
-fusion data of the $\mathbb Z_2$-twisted quantum dimer, the project example that
-answers the length-dependence question after Theorem 4.14 of arXiv:1606.00608
-(lines 995--1010) with a tensor that is not simple.  The tensor itself and its
-fixed-point channels are formalized separately; here only the two-label
-coefficient family and its rescaling behaviour are treated.
+**Scope: abstract coefficient family only.** Motivated by the proposed
+$\mathbb Z_2$-twisted quantum dimer, this file defines a two-label diagonal
+$\chi$-family and proves that its trace-power coefficients remain length
+dependent after every positive rescaling of the labels. It does not identify
+these labels with basis-of-normal-tensors blocks of a tensor and does not prove
+a tensor-attached product law.
 
-The example depends on bond weights $x, y > 0$ with $x + y = 1$; its two vertical
-blocks are labelled by a flag bit $f \in \mathbb Z_2$ and fuse according to
+For bond weights $x, y > 0$ with $x + y = 1$, the candidate weights are
 $$
-  M_f M_{f'} \;\simeq\; \alpha\, M_{f + f'} \;\oplus\; \beta\, M_{f + f' + 1},
-  \qquad
-  \alpha = \frac{x}{\sqrt{2(x^2+y^2)}},\quad \beta = \frac{y}{\sqrt{2(x^2+y^2)}} .
+  \alpha = \frac{x}{\sqrt{2(x^2+y^2)}},\qquad
+  \beta = \frac{y}{\sqrt{2(x^2+y^2)}} .
 $$
 At the rational point $x = 7/8$, $y = 1/8$ one has $\alpha = 7/10$ and
-$\beta = 1/10$, which is the instance formalized here.
+$\beta = 1/10$, which is the abstract instance formalized here.
 
 ## Main results
 
@@ -42,7 +40,7 @@ $\beta = 1/10$, which is the instance formalized here.
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
   Theorem 4.14 and lines 995--1010 (the length-dependence question; the
-  tensor is a project example)
+  coefficient family is a project example)
 -/
 
 open scoped BigOperators
@@ -65,8 +63,9 @@ def alpha : ℝ := 7 / 10
 /-- The fusion weight $\beta = 1/10$ on the channel $g = f + f' + 1$. -/
 def beta : ℝ := 1 / 10
 
-/-- The two-label diagonal $\chi$-family of the twisted dimer: every
-$\chi_{f f' g}$ is a $1 \times 1$ block with entry $\alpha$ or $\beta$. -/
+/-- The candidate two-label diagonal $\chi$-family: every $\chi_{f f' g}$ is a
+$1 \times 1$ block with entry $\alpha$ or $\beta$. No tensor attachment is
+asserted. -/
 def twoLabelChi : DiagonalChiFamily (Fin 2) where
   dim _ _ _ := 1
   entry f f' g _ := if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ)
@@ -99,16 +98,16 @@ theorem twoLabelCoeffs_not_lengthIndependent : ¬ twoLabelCoeffs.LengthIndepende
   simp only [hs, ite_true, alpha] at this
   norm_num at this
 
-/-- The rescaled $\chi$-family: block rescalings $M_f \mapsto s_f M_f$ act on the
-fusion data by $\chi_{f f' g} \mapsto (s_f s_{f'} / s_g)\,\chi_{f f' g}$
-(arXiv:1606.00608, the covariance of Theorem 4.14(iii) under the normalization
-freedom of Proposition 4.12). -/
+/-- The rescaled candidate $\chi$-family. Abstract label rescalings act by
+$\chi_{f f' g} \mapsto (s_f s_{f'} / s_g)\,\chi_{f f' g}$, matching the
+covariance of Theorem 4.14(iii) under the normalization freedom of Proposition
+4.12 in arXiv:1606.00608. -/
 def twoLabelChiScaled (s : Fin 2 → ℝ) : DiagonalChiFamily (Fin 2) where
   dim _ _ _ := 1
   entry f f' g _ :=
     ((s f * s f' / s g : ℝ) : ℂ) * (if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ))
 
-/-- The coefficient family of the rescaled fusion data. -/
+/-- The coefficient family of the rescaled candidate data. -/
 def rescaledCoeffs (s : Fin 2 → ℝ) : BNTLabelCoefficientFamily (Fin 2) :=
   BNTLabelCoefficientFamily.ofChi (twoLabelChiScaled s)
 
@@ -131,7 +130,8 @@ $s_1\beta = 1$ (triple $(0,1,0)$) and $s_0^2\beta/s_1 = 1$ (triple $(0,0,1)$),
 hence $\beta^2 = \alpha^2$, contradicting $\alpha = 7/10 \ne 1/10 = \beta$.
 
 Source: arXiv:1606.00608, Theorem 4.14 and lines 995--1010 (the
-length-dependence question); the twisted dimer is a project example. -/
+length-dependence question); this abstract coefficient family is a project
+example and is not attached here to a tensor. -/
 theorem twoLabelCoeffs_rescaling_stable_not_lengthIndependent (s : Fin 2 → ℝ)
     (hs : ∀ f, 0 < s f) : ¬ (rescaledCoeffs s).LengthIndependent := by
   intro hLI

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -709,14 +709,14 @@
     physical index set is $\{0,1\}^3$, read as $(l,r,f)$. The bond index set
     is also $\{0,1\}^3$, read as $(p,p',k)$, where $k$ labels one of two
     horizontal blocks. With $x=\frac78$, $y=\frac18$, $P_\pm=\frac12
-    (\mathbb 1\pm X)$, and the $2\times2$ matrices $C_0=xP_++yP_-$ and
+        (\mathbb 1\pm X)$, and the $2\times2$ matrices $C_0=xP_++yP_-$ and
     $C_1=xP_+-yP_-$, the bond matrix of the physical letter
     $((l,r,f),(l',r',f'))$ is
     \begin{align}
         M^{(l,r,f),(l',r',f')}
          & =\sum_{k\in\{0,1\}}\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}\,
         E_{(l,l',k),(r,r',k)},
-         & \tau_0 & =\mathbb 1, & \tau_1 & =Z,
+         & \tau_0                                                               & =\mathbb 1, & \tau_1 & =Z,
         \notag
     \end{align}
     a sum of two matrix units with one block label each. The tensor is the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -696,6 +696,129 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
+\begin{definition}[The $\mathbb Z_2$-twisted quantum dimer]%
+    \label{def:mpdo_twisted_dimer_tensor}
+    \lean{MPOTensor.TwistedDimer.physIdx}
+    \lean{MPOTensor.TwistedDimer.Cmat}
+    \lean{MPOTensor.TwistedDimer.tau}
+    \lean{MPOTensor.TwistedDimer.coef}
+    \lean{MPOTensor.TwistedDimer.T}
+    \lean{MPOTensor.TwistedDimer.block}
+    \leanok
+    Each site carries two qubits $L$, $R$ and a flag qubit $f$, so the
+    physical index set is $\{0,1\}^3$, read as $(l,r,f)$. The bond index set
+    is also $\{0,1\}^3$, read as $(p,p',k)$, where $k$ labels one of two
+    horizontal blocks. With $x=\frac78$, $y=\frac18$, $P_\pm=\frac12
+    (\mathbb 1\pm X)$, and the $2\times2$ matrices $C_0=xP_++yP_-$ and
+    $C_1=xP_+-yP_-$, the bond matrix of the physical letter
+    $((l,r,f),(l',r',f'))$ is
+    \begin{align}
+        M^{(l,r,f),(l',r',f')}
+         & =\sum_{k\in\{0,1\}}\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}\,
+        E_{(l,l',k),(r,r',k)},
+         & \tau_0 & =\mathbb 1, & \tau_1 & =Z,
+        \notag
+    \end{align}
+    a sum of two matrix units with one block label each. The tensor is the
+    direct sum along $k$ of the two bond-four blocks $M_k$ obtained by keeping
+    one summand. It generates the family
+    \begin{align}
+        \rho_N=\frac1{2^N}\Bigl(\sigma^{\otimes N}\otimes\mathbb 1^{\otimes N}
+        +\sigma'^{\otimes N}\otimes Z^{\otimes N}\Bigr),
+        \qquad \sigma=x\Pi_++y\Pi_-,\quad \sigma'=x\Pi_+-y\Pi_-,
+        \notag
+    \end{align}
+    with $\Pi_\pm$ the projectors onto $(\ket{00}\pm\ket{11})/\sqrt2$ on each
+    bond $(R_n,L_{n+1})$ and the flag operators acting on the flag qubits.
+    The tensor is a project example motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{definition}
+
+\begin{theorem}[Closures and physical-trace transfer of the twisted dimer]%
+    \label{thm:mpdo_twisted_dimer_closures}
+    \lean{MPOTensor.TwistedDimer.physClose1_T}
+    \lean{MPOTensor.TwistedDimer.T_mul_T}
+    \lean{MPOTensor.TwistedDimer.physClose2_T}
+    \lean{MPOTensor.TwistedDimer.physTraceTransfer_block_one}
+    \lean{MPOTensor.TwistedDimer.physTraceTransfer_block_zero}
+    \leanok
+    \uses{def:mpdo_twisted_dimer_tensor, def:mpo_physical_trace_transfer}
+    For a bond matrix $X$, the one-site physical closure of the twisted dimer
+    has entries
+    \begin{align}
+        \sum_{k}\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}\,
+        X_{(r,r',k),(l,l',k)},
+        \notag
+    \end{align}
+    and the two-site closure vanishes unless the consecutive letters satisfy
+    the bond-matching condition $r_1=l_2$, $r'_1=l'_2$, in which case it is the
+    sum over a common block label $k$ of the product of the two coefficients
+    times $X_{(r_2,r'_2,k),(l_1,l'_1,k)}$. The physical-trace transfer of the
+    block $k=0$ is $\sum_{l,r}C_0[l,l]\,E_{(l,l),(r,r)}$, and the
+    physical-trace transfer of the block $k=1$ vanishes, because
+    $\tr\tau_1=0$. The second block is therefore nilpotent in the sense of
+    \cite[Definition~4.7, lines~815--822]{Cirac2016MPDO_arXiv}, so the twisted
+    dimer is not a simple tensor.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_twisted_dimer_tensor}
+    The trace of a matrix unit against $X$ picks one entry of $X$, and the
+    product of two matrix units is a matrix unit or zero according to whether
+    the inner indices agree; since the block label is part of the bond index,
+    only common labels survive. Summing the diagonal letters over the flag
+    value gives $\sum_f(\tau_k)_{ff}$, which is $2$ for $k=0$ and $0$ for
+    $k=1$.
+\end{proof}
+
+\begin{theorem}[Two-label fusion coefficients stable under every pair of
+        block rescalings]%
+    \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}
+    \lean{MPOTensor.TwistedDimer.sameChannel}
+    \lean{MPOTensor.TwistedDimer.alpha}
+    \lean{MPOTensor.TwistedDimer.beta}
+    \lean{MPOTensor.TwistedDimer.twoLabelChi}
+    \lean{MPOTensor.TwistedDimer.twoLabelChi_posEntries}
+    \lean{MPOTensor.TwistedDimer.twoLabelCoeffs}
+    \lean{MPOTensor.TwistedDimer.twoLabelCoeffs_coeff}
+    \lean{MPOTensor.TwistedDimer.twoLabelCoeffs_not_lengthIndependent}
+    \lean{MPOTensor.TwistedDimer.twoLabelChiScaled}
+    \lean{MPOTensor.TwistedDimer.rescaledCoeffs}
+    \lean{MPOTensor.TwistedDimer.rescaledCoeffs_coeff}
+    \lean{MPOTensor.TwistedDimer.%
+        twoLabelCoeffs_rescaling_stable_not_lengthIndependent}
+    \leanok
+    \uses{def:mpdo_bnt_label_coefficient_family, def:mpdo_bnt_label_length_independent, def:mpdo_twisted_dimer_tensor}
+    The two vertical blocks of the twisted dimer are labelled by the flag
+    value $f\in\{0,1\}$ and fuse with the scalar fusion operators
+    \begin{align}
+        \chi_{ff',\,f+f'}=\alpha=\frac{7}{10},\qquad
+        \chi_{ff',\,f+f'+1}=\beta=\frac1{10},
+        \notag
+    \end{align}
+    so that $c^{(L)}_{ff'g}$ equals $\alpha^L$ on the channel $g=f+f'$ and
+    $\beta^L$ on the other channel. This coefficient family is not length
+    independent. Moreover, for every pair of positive block rescalings
+    $(s_0,s_1)$, under which $\chi_{ff'g}$ becomes $(s_fs_{f'}/s_g)\chi_{ff'g}$,
+    the rescaled family is still not length independent. Unlike the
+    one-label families of
+    Theorems~\ref{thm:mpdo_length_dependent_rfp_example} and
+    \ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}, the
+    obstruction here is not a block with two distinct entries but the
+    inconsistency of the multiplicative system
+    $s_fs_{f'}\chi_{ff'g}=s_g$ over the eight fusion channels. The attachment
+    of these coefficients to the vertical blocks of the tensor is not
+    asserted here.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_bnt_label_coefficient_family, def:mpdo_bnt_label_length_independent}
+    A positive-length coefficient that agrees at lengths one and two is a
+    positive real $t$ with $t=t^2$, hence $t=1$. The channels $(0,0,0)$ and
+    $(0,1,0)$ give $s_0\alpha=1$ and $s_1\beta=1$; the channel $(0,0,1)$ then
+    gives $s_0^2\beta/s_1=\beta^2/\alpha^2=1$, contradicting
+    $\alpha\ne\beta$.
+\end{proof}
+
 \begin{lemma}[Doubled-index letters and their rank-one factorization]
     \label{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_R_apply}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -704,6 +704,7 @@
     \lean{MPOTensor.TwistedDimer.coef}
     \lean{MPOTensor.TwistedDimer.T}
     \lean{MPOTensor.TwistedDimer.block}
+    \lean{MPOTensor.TwistedDimer.T_apply_blocks}
     \leanok
     Each site carries two qubits $L$, $R$ and a flag qubit $f$, so the
     physical index set is $\{0,1\}^3$, read as $(l,r,f)$. The bond index set
@@ -715,22 +716,13 @@
     \begin{align}
         M^{(l,r,f),(l',r',f')}
          & =\sum_{k\in\{0,1\}}\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}\,
-        E_{(l,l',k),(r,r',k)},
-         & \tau_0                                                               & =\mathbb 1, & \tau_1 & =Z,
+        E_{(l,l',k),(r,r',k)}.
         \notag
     \end{align}
-    a sum of two matrix units with one block label each. The tensor is the
-    direct sum along $k$ of the two bond-four blocks $M_k$ obtained by keeping
-    one summand. It generates the family
-    \begin{align}
-        \rho_N=\frac1{2^N}\Bigl(\sigma^{\otimes N}\otimes\mathbb 1^{\otimes N}
-        +\sigma'^{\otimes N}\otimes Z^{\otimes N}\Bigr),
-        \qquad \sigma=x\Pi_++y\Pi_-,\quad \sigma'=x\Pi_+-y\Pi_-,
-        \notag
-    \end{align}
-    with $\Pi_\pm$ the projectors onto $(\ket{00}\pm\ket{11})/\sqrt2$ on each
-    bond $(R_n,L_{n+1})$ and the flag operators acting on the flag qubits.
-    The tensor is a project example motivated by the question of
+    Here $\tau_0=\mathbb 1$ and $\tau_1=Z$. Thus the bond matrix is a sum of
+    two matrix units with one block label each. The tensor is the direct sum
+    along $k$ of the two bond-four blocks $M_k$ obtained by keeping one
+    summand. The tensor is a project example motivated by the question of
     \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
     there.
 \end{definition}
@@ -757,9 +749,9 @@
     times $X_{(r_2,r'_2,k),(l_1,l'_1,k)}$. The physical-trace transfer of the
     block $k=0$ is $\sum_{l,r}C_0[l,l]\,E_{(l,l),(r,r)}$, and the
     physical-trace transfer of the block $k=1$ vanishes, because
-    $\tr\tau_1=0$. The second block is therefore nilpotent in the sense of
-    \cite[Definition~4.7, lines~815--822]{Cirac2016MPDO_arXiv}, so the twisted
-    dimer is not a simple tensor.
+    $\tr\tau_1=0$. Thus this displayed block has nilpotent physical-trace
+    transfer in the sense used by
+    \cite[Definition~4.7, lines~815--822]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_twisted_dimer_tensor}
@@ -771,8 +763,8 @@
     $k=1$.
 \end{proof}
 
-\begin{theorem}[Two-label fusion coefficients stable under every pair of
-        block rescalings]%
+\begin{theorem}[A candidate two-label coefficient family stable under every
+        positive rescaling]%
     \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}
     \lean{MPOTensor.TwistedDimer.sameChannel}
     \lean{MPOTensor.TwistedDimer.alpha}
@@ -788,17 +780,20 @@
     \lean{MPOTensor.TwistedDimer.%
         twoLabelCoeffs_rescaling_stable_not_lengthIndependent}
     \leanok
-    \uses{def:mpdo_bnt_label_coefficient_family, def:mpdo_bnt_label_length_independent, def:mpdo_twisted_dimer_tensor}
-    The two vertical blocks of the twisted dimer are labelled by the flag
-    value $f\in\{0,1\}$ and fuse with the scalar fusion operators
+    \uses{def:mpdo_bnt_label_coefficient_family, def:mpdo_bnt_label_length_independent}
+    Independently of any tensor attachment, let the label set be
+    $\{0,1\}$ and define the scalar families
     \begin{align}
-        \chi_{ff',\,f+f'}=\alpha=\frac{7}{10},\qquad
-        \chi_{ff',\,f+f'+1}=\beta=\frac1{10},
+        \chi_{ff',\,f+f'} & =\alpha=\frac{7}{10}.
         \notag
     \end{align}
-    so that $c^{(L)}_{ff'g}$ equals $\alpha^L$ on the channel $g=f+f'$ and
+    \begin{align}
+        \chi_{ff',\,f+f'+1} & =\beta=\frac1{10}.
+        \notag
+    \end{align}
+    Then $c^{(L)}_{ff'g}$ equals $\alpha^L$ on the channel $g=f+f'$ and
     $\beta^L$ on the other channel. This coefficient family is not length
-    independent. Moreover, for every pair of positive block rescalings
+    independent. Moreover, for every pair of positive label rescalings
     $(s_0,s_1)$, under which $\chi_{ff'g}$ becomes $(s_fs_{f'}/s_g)\chi_{ff'g}$,
     the rescaled family is still not length independent. Unlike the
     one-label families of
@@ -806,9 +801,8 @@
     \ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}, the
     obstruction here is not a block with two distinct entries but the
     inconsistency of the multiplicative system
-    $s_fs_{f'}\chi_{ff'g}=s_g$ over the eight fusion channels. The attachment
-    of these coefficients to the vertical blocks of the tensor is not
-    asserted here.
+    $s_fs_{f'}\chi_{ff'g}=s_g$ over the eight channels. No identification of
+    this abstract family with tensor blocks is asserted.
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_bnt_label_coefficient_family, def:mpdo_bnt_label_length_independent}


### PR DESCRIPTION
## Summary

This is the first, deliberately local step for #7611.

- `TNLean/MPS/MPDO/TwistedDimer.lean` defines the bond-dimension-eight tensor `T` as the direct sum of two displayed bond-four blocks and proves its one-site and two-site closure formulas. It also computes the physical-trace transfers of those displayed blocks; the transfer of block `k = 1` vanishes.
- `TNLean/MPS/MPDO/TwistedDimerCoefficients.lean` defines an abstract candidate two-label diagonal $\chi$-family at $\alpha=7/10$, $\beta=1/10$. Its trace-power coefficients depend on the length, and this remains true after every pair of positive label rescalings.
- The Blueprint records exactly these tensor-local and abstract coefficient results.

The coefficient module does not identify its labels with basis-of-normal-tensors blocks of `T` and does not prove a tensor-attached product law.

## Scope boundaries and future work

This pull request does **not** assert any of the following. They remain separate follow-up steps for #7611:

- the all-length closed-state identity for `mpo T N`;
- `MPOTensor.IsMPDO T`;
- `MPOTensor.IsRFPViaTS T`;
- a canonical BNT presentation and the resulting proof of `¬ MPOTensor.IsSimple T`;
- attachment of the candidate $\chi$-family to vertical BNT blocks and its same-length product law.

The tensor and coefficient family are project examples motivated by the question after Theorem 4.14 of arXiv:1606.00608, lines 995–1010. They are not stated in that source.

## Validation

- `lake build TNLean.MPS.MPDO.TwistedDimer TNLean.MPS.MPDO.TwistedDimerCoefficients`
- `lake build` (10466 jobs)
- `scripts/latexindent -w -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- two direct `lualatex -interaction=nonstopmode -halt-on-error print.tex` passes with the pinned tenkz package; zero undefined cross-references
- generated-import-aggregator CI passes; the two imports in `TNLean/MPS/MPDO.lean` are generated output and remain in place

Advances #7611.
