### PR TITLE
feat(mpdo): prove positivity and fixed-point channels for twisted dimer

### DIFF
--- a/TNLean/Algebra/FinCyclicInduction.lean
+++ b/TNLean/Algebra/FinCyclicInduction.lean
@@ -4,14 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Fin.Basic
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
-# Cyclic induction on a finite cyclic index
+# Finite cyclic-index identities
 
-This file records the induction principle for a nonempty finite cyclic index
-set: a predicate that holds at the zero index and passes from each index to its
-successor holds at every index, because repeatedly adding one to zero reaches
-the whole cycle.
+This file records an induction principle for a nonempty finite cyclic index and
+the action of one-step rotation on nonterminal indices.
 -/
 
 namespace Fin
@@ -36,5 +35,15 @@ theorem cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
       exact Nat.mod_eq_of_lt (by have := i.isLt; omega)
     rw [← e]
     exact hstep _ (ih ⟨k, hk⟩ rfl)
+
+/-- One-step rotation on `Fin (N + 1)` sends the nonterminal embedding of
+`i : Fin N` to its ordinary successor. -/
+lemma finRotate_succ_castSucc {N : ℕ} (i : Fin N) :
+    finRotate (N + 1) i.castSucc = i.succ := by
+  have h := finRotate_of_lt (n := N) i.isLt
+  have e1 : (⟨(i : ℕ), i.isLt.trans_le N.le_succ⟩ : Fin (N + 1)) = i.castSucc := Fin.ext rfl
+  have e2 : (⟨(i : ℕ) + 1, Nat.succ_lt_succ i.isLt⟩ : Fin (N + 1)) = i.succ := Fin.ext rfl
+  rw [e1, e2] at h
+  exact h
 
 end Fin

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -327,6 +327,8 @@ import TNLean.MPS.MPDO.TopologicalTerminalSpectral
 import TNLean.MPS.MPDO.TwistedDimer
 import TNLean.MPS.MPDO.TwistedDimerCoefficients
 import TNLean.MPS.MPDO.TwistedDimerMPDO
+import TNLean.MPS.MPDO.TwistedDimerRefine
+import TNLean.MPS.MPDO.TwistedDimerViaTS
 import TNLean.MPS.MPDO.TwoSitePrefixReflectedMarkedChain
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalBNT

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -326,6 +326,7 @@ import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TopologicalTerminalSpectral
 import TNLean.MPS.MPDO.TwistedDimer
 import TNLean.MPS.MPDO.TwistedDimerCoefficients
+import TNLean.MPS.MPDO.TwistedDimerMPDO
 import TNLean.MPS.MPDO.TwoSitePrefixReflectedMarkedChain
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalBNT

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinCyclicInduction
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.RingTheory.Nilpotent.Basic
@@ -699,17 +700,6 @@ lemma dotProduct_A_col_step {N : ℕ} (p q : Fin N → Fin 4) (n : Fin N) :
         then wMat (bondBit2 (p n)) (bondBit2 (q n)) else 0 :=
   dotProduct_A_col _ _ _ _
 
-/-- The one-step rotation `finRotate (N + 1)` sends the embedding `i.castSucc`
-of `i : Fin N` to `i.succ`, matching the ordinary (non-wraparound) successor
-step of the bond chain. -/
-lemma finRotate_succ_castSucc {N : ℕ} (i : Fin N) :
-    finRotate (N + 1) i.castSucc = i.succ := by
-  have h := finRotate_of_lt (n := N) i.isLt
-  have e1 : (⟨(i : ℕ), i.isLt.trans_le N.le_succ⟩ : Fin (N + 1)) = i.castSucc := Fin.ext rfl
-  have e2 : (⟨(i : ℕ) + 1, Nat.succ_lt_succ i.isLt⟩ : Fin (N + 1)) = i.succ := Fin.ext rfl
-  rw [e1, e2] at h
-  exact h
-
 /-- **Entrywise formula for the closed MPO operator.** For a positive chain
 length `N`, the `(p, q)` matrix element of `mpo R N` is `(25/32)^N` times the
 chain-OK indicator times the pullback of the `N`-fold Kronecker power `wN N`
@@ -758,7 +748,7 @@ theorem mpo_R_entry_formula {N : ℕ} (hN : 0 < N) (p q : Fin N → Fin 4) :
       (fun b : Fin 4 => A b (bondBit2 (p i.castSucc)) (bondBit2 (q i.castSucc))) ⬝ᵥ
           (fun a : Fin 4 => A a (bondBit1 (p i.succ)) (bondBit1 (q i.succ))) = g i.castSucc := by
     intro i
-    simp only [hg, finRotate_succ_castSucc]
+    simp only [hg, Fin.finRotate_succ_castSucc]
   have hlaststep :
       (fun b : Fin 4 => A b (bondBit2 (p (Fin.last n))) (bondBit2 (q (Fin.last n)))) ⬝ᵥ
           (fun a : Fin 4 => A a (bondBit1 (p 0)) (bondBit1 (q 0))) = g (Fin.last n) := by

--- a/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
@@ -81,41 +81,43 @@ segment.  A product of letters of the twisted dimer vanishes unless its ket and
 bra strings both satisfy it (`evalWord_T_ofFn`).
 
 Project example; not from CPSV16. -/
-def OpenOK {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Prop :=
+def IsOpenBondMatched {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Prop :=
   ∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)
 
 /-- The open bond-matching condition is a finite conjunction of equalities of
 bits, hence decidable. -/
-instance decidableOpenOK {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Decidable (OpenOK σ) :=
+instance decidableIsOpenBondMatched {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
+    Decidable (IsOpenBondMatched σ) :=
   inferInstanceAs (Decidable (∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)))
 
 /-- The **cyclic bond-matching condition** on a physical string: the right bit
 of each letter is the left bit of the next one around the ring, with the
 successor given by `finRotate`.  It is the open condition together with the
-wraparound step (`chainOK_succ`).
+wraparound step (`isCyclicBondMatched_succ`).
 
 Project example; not from CPSV16. -/
-def ChainOK (N : ℕ) (σ : Fin N → Fin 8) : Prop :=
+def IsCyclicBondMatched (N : ℕ) (σ : Fin N → Fin 8) : Prop :=
   ∀ n : Fin N, gate (σ n) (σ (finRotate N n))
 
 /-- The cyclic bond-matching condition is a finite conjunction of equalities of
 bits, hence decidable. -/
-instance decidableChainOK (N : ℕ) (σ : Fin N → Fin 8) : Decidable (ChainOK N σ) :=
+instance decidableIsCyclicBondMatched (N : ℕ) (σ : Fin N → Fin 8) :
+    Decidable (IsCyclicBondMatched N σ) :=
   inferInstanceAs (Decidable (∀ n : Fin N, gate (σ n) (σ (finRotate N n))))
 
 /-- Peeling the first site off the open bond-matching condition: the condition
 on a string of length at least two is the match across the first bond together
 with the condition on the tail. -/
-lemma openOK_succ {n : ℕ} (σ : Fin (n + 2) → Fin 8) :
-    OpenOK σ ↔ gate (σ 0) (σ (Fin.succ 0)) ∧ OpenOK (fun i => σ i.succ) := by
-  rw [OpenOK, OpenOK, Fin.forall_fin_succ]
+lemma isOpenBondMatched_succ {n : ℕ} (σ : Fin (n + 2) → Fin 8) :
+    IsOpenBondMatched σ ↔ gate (σ 0) (σ (Fin.succ 0)) ∧ IsOpenBondMatched (fun i => σ i.succ) := by
+  rw [IsOpenBondMatched, IsOpenBondMatched, Fin.forall_fin_succ]
   simp only [Fin.castSucc_zero, Fin.succ_castSucc]
 
 /-- The cyclic bond-matching condition is the open condition on the segment
 together with the wraparound match from the last letter back to the first. -/
-lemma chainOK_succ {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
-    ChainOK (n + 1) σ ↔ OpenOK σ ∧ gate (σ (Fin.last n)) (σ 0) := by
-  rw [ChainOK, Fin.forall_fin_succ', OpenOK]
+lemma isCyclicBondMatched_succ {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
+    IsCyclicBondMatched (n + 1) σ ↔ IsOpenBondMatched σ ∧ gate (σ (Fin.last n)) (σ 0) := by
+  rw [IsCyclicBondMatched, Fin.forall_fin_succ', IsOpenBondMatched]
   simp only [Fin.finRotate_succ_castSucc, finRotate_last]
 
 /-! ### The open-chain product of letters -/
@@ -145,7 +147,7 @@ last letters, and its coefficient is the product of the one-site coefficients.
 Project example; not from CPSV16. -/
 lemma evalWord_T_ofFn : ∀ (n : ℕ) (σ τ : Fin (n + 1) → Fin 8),
     evalWord T (List.ofFn σ) (List.ofFn τ) =
-      if OpenOK σ ∧ OpenOK τ then
+      if IsOpenBondMatched σ ∧ IsOpenBondMatched τ then
         ∑ k : Fin 2, Matrix.single (physIdx (bitL (σ 0)) (bitL (τ 0)) k)
           (physIdx (bitR (σ (Fin.last n))) (bitR (τ (Fin.last n))) k)
           (∏ i : Fin (n + 1), coef k (σ i) (τ i))
@@ -154,7 +156,7 @@ lemma evalWord_T_ofFn : ∀ (n : ℕ) (σ τ : Fin (n + 1) → Fin 8),
   induction n with
   | zero =>
       intro σ τ
-      have hopen : ∀ ρ : Fin 1 → Fin 8, OpenOK ρ := fun ρ i => i.elim0
+      have hopen : ∀ ρ : Fin 1 → Fin 8, IsOpenBondMatched ρ := fun ρ i => i.elim0
       rw [ite_eq_left ⟨hopen σ, hopen τ⟩]
       simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil, mul_one,
         Fin.last_zero, Fin.prod_univ_succ, Finset.univ_eq_empty, Finset.prod_empty]
@@ -163,20 +165,21 @@ lemma evalWord_T_ofFn : ∀ (n : ℕ) (σ τ : Fin (n + 1) → Fin 8),
       intro σ τ
       rw [List.ofFn_succ, List.ofFn_succ (f := τ), evalWord_cons,
         ih (fun i => σ i.succ) (fun i => τ i.succ)]
-      by_cases hs : OpenOK (fun i => σ i.succ) ∧ OpenOK (fun i => τ i.succ)
+      by_cases hs : IsOpenBondMatched (fun i => σ i.succ) ∧ IsOpenBondMatched (fun i => τ i.succ)
       · rw [ite_eq_left hs, T_mul_single_sum]
         by_cases hg : bitR (σ 0) = bitL (σ (Fin.succ 0)) ∧ bitR (τ 0) = bitL (τ (Fin.succ 0))
-        · rw [ite_eq_left hg,
-            ite_eq_left ⟨(openOK_succ σ).2 ⟨hg.1, hs.1⟩, (openOK_succ τ).2 ⟨hg.2, hs.2⟩⟩]
+        · rw [ite_eq_left hg, ite_eq_left ⟨
+              (isOpenBondMatched_succ σ).2 ⟨hg.1, hs.1⟩,
+              (isOpenBondMatched_succ τ).2 ⟨hg.2, hs.2⟩⟩]
           refine Finset.sum_congr rfl fun k _ => ?_
           conv_rhs => rw [Fin.prod_univ_succ]
           rw [Fin.succ_last]
         · rw [ite_eq_right hg, ite_eq_right]
           rintro ⟨hcσ, hcτ⟩
-          exact hg ⟨((openOK_succ σ).1 hcσ).1, ((openOK_succ τ).1 hcτ).1⟩
+          exact hg ⟨((isOpenBondMatched_succ σ).1 hcσ).1, ((isOpenBondMatched_succ τ).1 hcτ).1⟩
       · rw [ite_eq_right hs, mul_zero, ite_eq_right]
         rintro ⟨hcσ, hcτ⟩
-        exact hs ⟨((openOK_succ σ).1 hcσ).2, ((openOK_succ τ).1 hcτ).2⟩
+        exact hs ⟨((isOpenBondMatched_succ σ).1 hcσ).2, ((isOpenBondMatched_succ τ).1 hcτ).2⟩
 
 /-! ### The closed-chain entry formula -/
 
@@ -188,16 +191,17 @@ condition with itself, hence rank one and positive semidefinite
 
 Project example; not from CPSV16. -/
 def chainIndicator (N : ℕ) : Matrix (Fin N → Fin 8) (Fin N → Fin 8) ℂ :=
-  Matrix.of fun σ τ => if ChainOK N σ ∧ ChainOK N τ then (1 : ℂ) else 0
+  Matrix.of fun σ τ => if IsCyclicBondMatched N σ ∧ IsCyclicBondMatched N τ then (1 : ℂ) else 0
 
 /-- The chain indicator is the outer product of the indicator vector of the
 cyclic bond-matching condition with itself, hence positive semidefinite. -/
 lemma chainIndicator_posSemidef (N : ℕ) : (chainIndicator N).PosSemidef := by
-  let c : (Fin N → Fin 8) → ℂ := fun σ => if ChainOK N σ then (1 : ℂ) else 0
+  let c : (Fin N → Fin 8) → ℂ := fun σ => if IsCyclicBondMatched N σ then (1 : ℂ) else 0
   have h_eq : chainIndicator N = Matrix.vecMulVec c (star c) := by
     ext σ τ
     dsimp [chainIndicator, c, Matrix.vecMulVec, Matrix.of_apply]
-    by_cases hσ : ChainOK N σ <;> by_cases hτ : ChainOK N τ <;> simp [hσ, hτ]
+    by_cases hσ : IsCyclicBondMatched N σ <;>
+      by_cases hτ : IsCyclicBondMatched N τ <;> simp [hσ, hτ]
   rw [h_eq]
   exact Matrix.posSemidef_vecMulVec_self_star c
 
@@ -216,25 +220,26 @@ theorem mpo_T_entry_formula {N : ℕ} (hN : 0 < N) (σ τ : Fin N → Fin 8) :
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
   simp only [mpo_apply, mpoMatrixEntry]
   rw [evalWord_T_ofFn n σ τ]
-  by_cases hopen : OpenOK σ ∧ OpenOK τ
+  by_cases hopen : IsOpenBondMatched σ ∧ IsOpenBondMatched τ
   · rw [ite_eq_left hopen, Matrix.trace_sum]
     by_cases hw : gate (σ (Fin.last n)) (σ 0) ∧ gate (τ (Fin.last n)) (τ 0)
-    · have hchain : ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ :=
-        ⟨(chainOK_succ σ).2 ⟨hopen.1, hw.1⟩, (chainOK_succ τ).2 ⟨hopen.2, hw.2⟩⟩
+    · have hchain : IsCyclicBondMatched (n + 1) σ ∧ IsCyclicBondMatched (n + 1) τ :=
+        ⟨(isCyclicBondMatched_succ σ).2 ⟨hopen.1, hw.1⟩,
+          (isCyclicBondMatched_succ τ).2 ⟨hopen.2, hw.2⟩⟩
       rw [chainIndicator, Matrix.of_apply, ite_eq_left hchain, one_mul]
       refine Finset.sum_congr rfl fun k _ => ?_
       rw [show physIdx (bitR (σ (Fin.last n))) (bitR (τ (Fin.last n))) k =
           physIdx (bitL (σ 0)) (bitL (τ 0)) k from by rw [hw.1, hw.2]]
       exact Matrix.trace_single_eq_same _ _
-    · have hchain : ¬ (ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ) := fun h =>
-        hw ⟨((chainOK_succ σ).1 h.1).2, ((chainOK_succ τ).1 h.2).2⟩
+    · have hchain : ¬ (IsCyclicBondMatched (n + 1) σ ∧ IsCyclicBondMatched (n + 1) τ) := fun h =>
+        hw ⟨((isCyclicBondMatched_succ σ).1 h.1).2, ((isCyclicBondMatched_succ τ).1 h.2).2⟩
       rw [chainIndicator, Matrix.of_apply, ite_eq_right hchain, zero_mul]
       refine Finset.sum_eq_zero fun k _ => Matrix.trace_single_eq_of_ne _ _ _ ?_
       rw [Ne, physIdx_inj]
       rintro ⟨h1, h2, -⟩
       exact hw ⟨h1.symm, h2.symm⟩
-  · have hchain : ¬ (ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ) := fun h =>
-      hopen ⟨((chainOK_succ σ).1 h.1).1, ((chainOK_succ τ).1 h.2).1⟩
+  · have hchain : ¬ (IsCyclicBondMatched (n + 1) σ ∧ IsCyclicBondMatched (n + 1) τ) := fun h =>
+      hopen ⟨((isCyclicBondMatched_succ σ).1 h.1).1, ((isCyclicBondMatched_succ τ).1 h.2).1⟩
     rw [ite_eq_right hopen, chainIndicator, Matrix.of_apply, ite_eq_right hchain, zero_mul,
       Matrix.trace_zero]
 

--- a/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
@@ -1,0 +1,420 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimer
+import Mathlib.Analysis.Matrix.Order
+
+/-!
+# Positivity of the $\mathbb Z_2$-twisted quantum dimer
+
+**Scope: the closed operator family.**  This file proves that the
+$\mathbb Z_2$-twisted quantum dimer `T` of `TNLean.MPS.MPDO.TwistedDimer` is a
+matrix product density operator: the operator it generates on a ring of `N`
+sites is positive semidefinite for every positive `N`.  The tensor is a project
+example motivated by the length-dependence question after Theorem 4.14 of
+arXiv:1606.00608 (lines 995--1010); it is not a tensor stated in that source.
+
+## Main results
+
+* `mpo_T_entry_formula` — the closed-chain entry formula: the matrix element of
+  the closed operator at a pair of physical strings is the cyclic bond-matching
+  indicator times the sum over the two horizontal block labels of the product
+  of the one-site coefficients;
+* `mpo_T_eq_smul_hadamard` — the resulting Schur-product factorization of the
+  closed operator;
+* `T_isMPDO` — the closed operator is positive semidefinite on every ring of
+  positive length.
+
+## The argument
+
+Every letter of the tensor is a sum of two matrix units carrying the block
+labels $k = 0, 1$.  A product of letters therefore keeps one common block label
+and vanishes unless consecutive letters match on their bond bits; closing the
+trace adds the wraparound match, so the closed operator entry is the cyclic
+bond-matching indicator times $\sum_k\prod_n\text{coefficient}$.
+
+The one-site coefficient is half of $C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$,
+which is the entry of the four-by-four matrix `gLoc k` at the pairs
+(flag bit, left bit) read off the two physical indices.  So the coefficient
+product over the ring is $2^{-N}$ times an entry of the $N$-fold Kronecker
+power `gPow k N`, and the closed operator is $2^{-N}$ times the Hadamard
+product of the rank-one bond-matching indicator with the pullback of
+`gPow 0 N + gPow 1 N`.  The Schur product theorem reduces positivity to
+positive semidefiniteness of that sum of Kronecker powers.
+
+The sum of the two Kronecker powers is not a Kronecker power itself, so it is
+handled together with the difference: peeling the last site off the ring gives
+$$
+  g_0^{\otimes(N+1)} \pm g_1^{\otimes(N+1)}
+    = \tfrac12\Bigl[(g_0^{\otimes N} + g_1^{\otimes N})\otimes(g_0 \pm g_1)
+      + (g_0^{\otimes N} - g_1^{\otimes N})\otimes(g_0 \mp g_1)\Bigr],
+$$
+and both local combinations $g_0 \pm g_1$ are positive semidefinite: each is
+block diagonal in the flag bit, with the rank-one blocks
+$\tfrac74\,\lvert{+}\rangle\langle{+}\rvert$ and
+$\tfrac14\,\lvert{-}\rangle\langle{-}\rvert$ in the two flag sectors, the
+sectors being exchanged between the sum and the difference.  The induction
+therefore proves the two statements simultaneously.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Section 4, equation `eq:III_MPDOform`, lines 623--630 (matrix product density
+  operators) and lines 995--1010 (the length-dependence question motivating this
+  project example)
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### The bond-matching conditions -/
+
+/-- The **open bond-matching condition** on a physical string of positive
+length: the right bit of each letter is the left bit of the next one along the
+segment.  A product of letters of the twisted dimer vanishes unless its ket and
+bra strings both satisfy it (`evalWord_T_ofFn`).
+
+Project example; not from CPSV16. -/
+def OpenOK {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Prop :=
+  ∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)
+
+/-- The open bond-matching condition is a finite conjunction of equalities of
+bits, hence decidable. -/
+instance decidableOpenOK {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Decidable (OpenOK σ) :=
+  inferInstanceAs (Decidable (∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)))
+
+/-- The **cyclic bond-matching condition** on a physical string: the right bit
+of each letter is the left bit of the next one around the ring, with the
+successor given by `finRotate`.  It is the open condition together with the
+wraparound step (`chainOK_succ`).
+
+Project example; not from CPSV16. -/
+def ChainOK (N : ℕ) (σ : Fin N → Fin 8) : Prop :=
+  ∀ n : Fin N, gate (σ n) (σ (finRotate N n))
+
+/-- The cyclic bond-matching condition is a finite conjunction of equalities of
+bits, hence decidable. -/
+instance decidableChainOK (N : ℕ) (σ : Fin N → Fin 8) : Decidable (ChainOK N σ) :=
+  inferInstanceAs (Decidable (∀ n : Fin N, gate (σ n) (σ (finRotate N n))))
+
+/-- Peeling the first site off the open bond-matching condition: the condition
+on a string of length at least two is the match across the first bond together
+with the condition on the tail. -/
+lemma openOK_succ {n : ℕ} (σ : Fin (n + 2) → Fin 8) :
+    OpenOK σ ↔ gate (σ 0) (σ (Fin.succ 0)) ∧ OpenOK (fun i => σ i.succ) := by
+  rw [OpenOK, OpenOK, Fin.forall_fin_succ]
+  simp only [Fin.castSucc_zero, Fin.succ_castSucc]
+
+/-- The cyclic bond-matching condition is the open condition on the segment
+together with the wraparound match from the last letter back to the first. -/
+lemma chainOK_succ {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
+    ChainOK (n + 1) σ ↔ OpenOK σ ∧ gate (σ (Fin.last n)) (σ 0) := by
+  have hrot : ∀ i : Fin n, finRotate (n + 1) i.castSucc = i.succ := fun i => by
+    have h := finRotate_of_lt (n := n) i.isLt
+    have e1 : (⟨(i : ℕ), i.isLt.trans_le n.le_succ⟩ : Fin (n + 1)) = i.castSucc := Fin.ext rfl
+    have e2 : (⟨(i : ℕ) + 1, Nat.succ_lt_succ i.isLt⟩ : Fin (n + 1)) = i.succ := Fin.ext rfl
+    rw [e1, e2] at h
+    exact h
+  rw [ChainOK, Fin.forall_fin_succ', OpenOK]
+  simp only [hrot, finRotate_last]
+
+/-! ### The open-chain product of letters -/
+
+/-- Multiplying a letter of the twisted dimer into a sum of matrix units with
+one summand per block label keeps the block label and is gated by the
+bond-matching condition between the letter and the first index pair of the
+sum.
+
+Project example; not from CPSV16. -/
+lemma T_mul_single_sum (i j : Fin 8) (l l' r r' : Fin 2) (c : Fin 2 → ℂ) :
+    T i j * (∑ k : Fin 2, Matrix.single (physIdx l l' k) (physIdx r r' k) (c k)) =
+      if bitR i = l ∧ bitR j = l' then
+        ∑ k : Fin 2, Matrix.single (physIdx (bitL i) (bitL j) k) (physIdx r r' k)
+          (coef k i j * c k)
+      else 0 := by
+  simp only [T, Fin.sum_univ_two, add_mul, mul_add, single_mul_single_ite, physIdx_inj]
+  by_cases h1 : bitR i = l <;> by_cases h2 : bitR j = l' <;> simp [h1, h2]
+
+/-- **Open-chain product formula.**  The ordered product of the letters of the
+twisted dimer along a pair of physical strings vanishes unless both strings
+satisfy the open bond-matching condition, in which case it is the sum over the
+two horizontal block labels of a single matrix unit: its row index is read off
+the left bits of the first letters, its column index off the right bits of the
+last letters, and its coefficient is the product of the one-site coefficients.
+
+Project example; not from CPSV16. -/
+lemma evalWord_T_ofFn : ∀ (n : ℕ) (σ τ : Fin (n + 1) → Fin 8),
+    evalWord T (List.ofFn σ) (List.ofFn τ) =
+      if OpenOK σ ∧ OpenOK τ then
+        ∑ k : Fin 2, Matrix.single (physIdx (bitL (σ 0)) (bitL (τ 0)) k)
+          (physIdx (bitR (σ (Fin.last n))) (bitR (τ (Fin.last n))) k)
+          (∏ i : Fin (n + 1), coef k (σ i) (τ i))
+      else 0 := by
+  intro n
+  induction n with
+  | zero =>
+      intro σ τ
+      have hopen : ∀ ρ : Fin 1 → Fin 8, OpenOK ρ := fun ρ i => i.elim0
+      rw [ite_eq_left ⟨hopen σ, hopen τ⟩]
+      simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil, mul_one,
+        Fin.last_zero, Fin.prod_univ_succ, Finset.univ_eq_empty, Finset.prod_empty]
+      rfl
+  | succ n ih =>
+      intro σ τ
+      rw [List.ofFn_succ, List.ofFn_succ (f := τ), evalWord_cons,
+        ih (fun i => σ i.succ) (fun i => τ i.succ)]
+      by_cases hs : OpenOK (fun i => σ i.succ) ∧ OpenOK (fun i => τ i.succ)
+      · rw [ite_eq_left hs, T_mul_single_sum]
+        by_cases hg : bitR (σ 0) = bitL (σ (Fin.succ 0)) ∧ bitR (τ 0) = bitL (τ (Fin.succ 0))
+        · rw [ite_eq_left hg,
+            ite_eq_left ⟨(openOK_succ σ).2 ⟨hg.1, hs.1⟩, (openOK_succ τ).2 ⟨hg.2, hs.2⟩⟩]
+          refine Finset.sum_congr rfl fun k _ => ?_
+          conv_rhs => rw [Fin.prod_univ_succ]
+          rw [Fin.succ_last]
+        · rw [ite_eq_right hg, ite_eq_right]
+          rintro ⟨hcσ, hcτ⟩
+          exact hg ⟨((openOK_succ σ).1 hcσ).1, ((openOK_succ τ).1 hcτ).1⟩
+      · rw [ite_eq_right hs, mul_zero, ite_eq_right]
+        rintro ⟨hcσ, hcτ⟩
+        exact hs ⟨((openOK_succ σ).1 hcσ).2, ((openOK_succ τ).1 hcτ).2⟩
+
+/-! ### The closed-chain entry formula -/
+
+/-- The indicator matrix of the cyclic bond-matching condition: the entry at a
+pair of physical strings is one when both strings satisfy the condition and
+zero otherwise.  It is the outer product of the indicator vector of the
+condition with itself, hence rank one and positive semidefinite
+(`chainIndicator_posSemidef`).
+
+Project example; not from CPSV16. -/
+def chainIndicator (N : ℕ) : Matrix (Fin N → Fin 8) (Fin N → Fin 8) ℂ :=
+  Matrix.of fun σ τ => if ChainOK N σ ∧ ChainOK N τ then (1 : ℂ) else 0
+
+/-- The chain indicator is the outer product of the indicator vector of the
+cyclic bond-matching condition with itself, hence positive semidefinite. -/
+lemma chainIndicator_posSemidef (N : ℕ) : (chainIndicator N).PosSemidef := by
+  let c : (Fin N → Fin 8) → ℂ := fun σ => if ChainOK N σ then (1 : ℂ) else 0
+  have h_eq : chainIndicator N = Matrix.vecMulVec c (star c) := by
+    ext σ τ
+    dsimp [chainIndicator, c, Matrix.vecMulVec, Matrix.of_apply]
+    by_cases hσ : ChainOK N σ <;> by_cases hτ : ChainOK N τ <;> simp [hσ, hτ]
+  rw [h_eq]
+  exact Matrix.posSemidef_vecMulVec_self_star c
+
+/-- **Closed-chain entry formula.**  For a positive chain length, the matrix
+element of the closed operator at a pair of physical strings is the cyclic
+bond-matching indicator times the sum over the two horizontal block labels of
+the product of the one-site coefficients along the ring.
+
+Both horizontal blocks contribute with the same bond-matching gate, because the
+block label is part of the bond index and is preserved by every letter product;
+closing the trace adds the wraparound match to the open condition.
+
+Project example; not from CPSV16. -/
+theorem mpo_T_entry_formula {N : ℕ} (hN : 0 < N) (σ τ : Fin N → Fin 8) :
+    mpo T N σ τ = chainIndicator N σ τ * ∑ k : Fin 2, ∏ n : Fin N, coef k (σ n) (τ n) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
+  simp only [mpo_apply, mpoMatrixEntry]
+  rw [evalWord_T_ofFn n σ τ]
+  by_cases hopen : OpenOK σ ∧ OpenOK τ
+  · rw [ite_eq_left hopen, Matrix.trace_sum]
+    by_cases hw : gate (σ (Fin.last n)) (σ 0) ∧ gate (τ (Fin.last n)) (τ 0)
+    · have hchain : ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ :=
+        ⟨(chainOK_succ σ).2 ⟨hopen.1, hw.1⟩, (chainOK_succ τ).2 ⟨hopen.2, hw.2⟩⟩
+      rw [chainIndicator, Matrix.of_apply, ite_eq_left hchain, one_mul]
+      refine Finset.sum_congr rfl fun k _ => ?_
+      rw [show physIdx (bitR (σ (Fin.last n))) (bitR (τ (Fin.last n))) k =
+          physIdx (bitL (σ 0)) (bitL (τ 0)) k from by rw [hw.1, hw.2]]
+      exact Matrix.trace_single_eq_same _ _
+    · have hchain : ¬ (ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ) := fun h =>
+        hw ⟨((chainOK_succ σ).1 h.1).2, ((chainOK_succ τ).1 h.2).2⟩
+      rw [chainIndicator, Matrix.of_apply, ite_eq_right hchain, zero_mul]
+      refine Finset.sum_eq_zero fun k _ => Matrix.trace_single_eq_of_ne _ _ _ ?_
+      rw [Ne, physIdx_inj]
+      rintro ⟨h1, h2, -⟩
+      exact hw ⟨h1.symm, h2.symm⟩
+  · have hchain : ¬ (ChainOK (n + 1) σ ∧ ChainOK (n + 1) τ) := fun h =>
+      hopen ⟨((chainOK_succ σ).1 h.1).1, ((chainOK_succ τ).1 h.2).1⟩
+    rw [ite_eq_right hopen, chainIndicator, Matrix.of_apply, ite_eq_right hchain, zero_mul,
+      Matrix.trace_zero]
+
+/-! ### The local four-by-four factors -/
+
+/-- The local four-by-four factor of the horizontal block `k`, indexed by pairs
+(flag bit, left bit): it is diagonal in the flag bit, with the block
+$C_k\,(\tau_k)_{ff}$ in the flag sector $f$.  The one-site coefficient of the
+tensor is half of its entry at the flag and left bits of the two physical
+indices (`coef_eq_gLoc`).
+
+Project example; not from CPSV16. -/
+def gLoc (k : Fin 2) : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ :=
+  Matrix.of fun a b => if a.1 = b.1 then ((Cmat k a.2 b.2 * tau k a.1 : ℝ) : ℂ) else 0
+
+/-- The `N`-fold Kronecker power of the local factor `gLoc k`, written
+entrywise: the entry at a pair of strings of (flag bit, left bit) pairs is the
+product of the local entries along the string.
+
+Project example; not from CPSV16. -/
+def gPow (k : Fin 2) (N : ℕ) :
+    Matrix (Fin N → Fin 2 × Fin 2) (Fin N → Fin 2 × Fin 2) ℂ :=
+  Matrix.of fun a b => ∏ i : Fin N, gLoc k (a i) (b i)
+
+/-- Reading a physical string through its flag and left bits.  It pulls the
+Kronecker powers back to the physical configuration space of the closed
+operator.
+
+Project example; not from CPSV16. -/
+def flagLeft (N : ℕ) (σ : Fin N → Fin 8) : Fin N → Fin 2 × Fin 2 :=
+  fun i => (bitF (σ i), bitL (σ i))
+
+/-- The one-site coefficient of the tensor is half the entry of the local
+factor at the flag and left bits of the two physical indices. -/
+lemma coef_eq_gLoc (k : Fin 2) (i j : Fin 8) :
+    coef k i j = (1 / 2 : ℂ) * gLoc k (bitF i, bitL i) (bitF j, bitL j) := by
+  by_cases h : bitF i = bitF j
+  · simp only [coef, gLoc, Matrix.of_apply, h]
+    push_cast
+    ring
+  · simp [coef, gLoc, h]
+
+/-- The sum of the two local factors is positive semidefinite: it is block
+diagonal in the flag bit, equal to $\tfrac74$ times the projector onto the
+uniform vector in the sector $f = 0$ and to $\tfrac14$ times the projector onto
+the alternating vector in the sector $f = 1$. -/
+lemma gLoc_add_posSemidef : (gLoc 0 + gLoc 1).PosSemidef := by
+  set u : Fin 2 × Fin 2 → ℂ := fun a => if a.1 = 0 then 1 else 0 with hu
+  set w : Fin 2 × Fin 2 → ℂ := fun a => if a.1 = 1 then (if a.2 = 0 then 1 else -1) else 0 with hw
+  have h_eq : gLoc 0 + gLoc 1 =
+      (7 / 8 : ℂ) • Matrix.vecMulVec u (star u) + (1 / 8 : ℂ) • Matrix.vecMulVec w (star w) := by
+    ext a b
+    obtain ⟨f, l⟩ := a
+    obtain ⟨f', l'⟩ := b
+    fin_cases f <;> fin_cases l <;> fin_cases f' <;> fin_cases l' <;>
+      norm_num [gLoc, hu, hw, Cmat, cDiag_eq, cOff_eq, tau, Matrix.vecMulVec]
+  rw [h_eq]
+  exact ((Matrix.posSemidef_vecMulVec_self_star u).smul (by positivity)).add
+    ((Matrix.posSemidef_vecMulVec_self_star w).smul (by positivity))
+
+/-- The difference of the two local factors is positive semidefinite: it is the
+sum of the two projectors of `gLoc_add_posSemidef` with the flag sectors
+exchanged. -/
+lemma gLoc_sub_posSemidef : (gLoc 0 - gLoc 1).PosSemidef := by
+  set u : Fin 2 × Fin 2 → ℂ := fun a => if a.1 = 0 then (if a.2 = 0 then 1 else -1) else 0 with hu
+  set w : Fin 2 × Fin 2 → ℂ := fun a => if a.1 = 1 then 1 else 0 with hw
+  have h_eq : gLoc 0 - gLoc 1 =
+      (1 / 8 : ℂ) • Matrix.vecMulVec u (star u) + (7 / 8 : ℂ) • Matrix.vecMulVec w (star w) := by
+    ext a b
+    obtain ⟨f, l⟩ := a
+    obtain ⟨f', l'⟩ := b
+    fin_cases f <;> fin_cases l <;> fin_cases f' <;> fin_cases l' <;>
+      norm_num [gLoc, hu, hw, Cmat, cDiag_eq, cOff_eq, tau, Matrix.vecMulVec]
+  rw [h_eq]
+  exact ((Matrix.posSemidef_vecMulVec_self_star u).smul (by positivity)).add
+    ((Matrix.posSemidef_vecMulVec_self_star w).smul (by positivity))
+
+/-! ### Positivity of the Kronecker powers -/
+
+/-- **The sum and the difference of the two Kronecker powers are positive
+semidefinite.**  Neither combination is itself a Kronecker power, so the two
+statements are proved together by induction on the chain length: peeling the
+last site off the ring writes each combination at length `N + 1` as half the
+sum of the Kronecker products of the two combinations at length `N` with the
+two combinations of the local factors, all four of which are positive
+semidefinite.
+
+Project example; not from CPSV16. -/
+lemma gPow_add_sub_posSemidef (N : ℕ) :
+    (gPow 0 N + gPow 1 N).PosSemidef ∧ (gPow 0 N - gPow 1 N).PosSemidef := by
+  induction N with
+  | zero =>
+      have h : ∀ k : Fin 2, gPow k 0 = 1 := by
+        intro k
+        ext a b
+        have hab : a = b := Subsingleton.elim _ _
+        subst hab
+        simp [gPow]
+      rw [h 0, h 1]
+      exact ⟨Matrix.PosSemidef.one.add Matrix.PosSemidef.one,
+        by simpa using Matrix.PosSemidef.zero⟩
+  | succ N ih =>
+      set e : (Fin (N + 1) → Fin 2 × Fin 2) ≃ (Fin N → Fin 2 × Fin 2) × (Fin 2 × Fin 2) :=
+        Fin.succFunEquiv (Fin 2 × Fin 2) N
+      have h_fst : ∀ f : Fin (N + 1) → Fin 2 × Fin 2, (e f).1 = f ∘ Fin.castSucc :=
+        fun _ => funext fun _ => rfl
+      have h_snd : ∀ f : Fin (N + 1) → Fin 2 × Fin 2, (e f).2 = f (Fin.last N) :=
+        fun _ => rfl
+      have hadd : gPow 0 (N + 1) + gPow 1 (N + 1) =
+          ((1 / 2 : ℂ) •
+            (Matrix.kroneckerMap (· * ·) (gPow 0 N + gPow 1 N) (gLoc 0 + gLoc 1) +
+              Matrix.kroneckerMap (· * ·) (gPow 0 N - gPow 1 N)
+                (gLoc 0 - gLoc 1))).submatrix e e := by
+        ext a b
+        simp only [Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply, Matrix.submatrix_apply,
+          Matrix.kroneckerMap_apply, gPow, Matrix.of_apply, Fin.prod_univ_castSucc, smul_eq_mul,
+          h_fst, h_snd, Function.comp_apply]
+        ring
+      have hsub : gPow 0 (N + 1) - gPow 1 (N + 1) =
+          ((1 / 2 : ℂ) •
+            (Matrix.kroneckerMap (· * ·) (gPow 0 N + gPow 1 N) (gLoc 0 - gLoc 1) +
+              Matrix.kroneckerMap (· * ·) (gPow 0 N - gPow 1 N)
+                (gLoc 0 + gLoc 1))).submatrix e e := by
+        ext a b
+        simp only [Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply, Matrix.submatrix_apply,
+          Matrix.kroneckerMap_apply, gPow, Matrix.of_apply, Fin.prod_univ_castSucc, smul_eq_mul,
+          h_fst, h_snd, Function.comp_apply]
+        ring
+      refine ⟨hadd ▸ ?_, hsub ▸ ?_⟩
+      · exact (((ih.1.kronecker gLoc_add_posSemidef).add
+          (ih.2.kronecker gLoc_sub_posSemidef)).smul (by positivity)).submatrix e
+      · exact (((ih.1.kronecker gLoc_sub_posSemidef).add
+          (ih.2.kronecker gLoc_add_posSemidef)).smul (by positivity)).submatrix e
+
+/-! ### The twisted dimer is a density-operator tensor -/
+
+/-- The product of the one-site coefficients of one horizontal block along the
+ring is the corresponding entry of the Kronecker power of the local factor,
+scaled by the site normalization $2^{-N}$. -/
+lemma prod_coef_eq_gPow (k : Fin 2) {N : ℕ} (σ τ : Fin N → Fin 8) :
+    (∏ n : Fin N, coef k (σ n) (τ n)) =
+      (1 / 2 : ℂ) ^ N * gPow k N (flagLeft N σ) (flagLeft N τ) := by
+  simp only [coef_eq_gLoc, gPow, flagLeft, Matrix.of_apply, Finset.prod_mul_distrib,
+    Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+/-- **The closed operator as a Schur product.**  For a positive chain length,
+the closed operator is $2^{-N}$ times the Hadamard product of the cyclic
+bond-matching indicator with the pullback, along the flag and left bits, of the
+sum of the two Kronecker powers.
+
+Project example; not from CPSV16. -/
+theorem mpo_T_eq_smul_hadamard {N : ℕ} (hN : 0 < N) :
+    mpo T N = (1 / 2 : ℂ) ^ N •
+      (chainIndicator N ⊙ (gPow 0 N + gPow 1 N).submatrix (flagLeft N) (flagLeft N)) := by
+  ext σ τ
+  rw [mpo_T_entry_formula hN, Fin.sum_univ_two, prod_coef_eq_gPow, prod_coef_eq_gPow]
+  simp only [Matrix.smul_apply, Matrix.hadamard_apply, Matrix.submatrix_apply, Matrix.add_apply,
+    smul_eq_mul]
+  ring
+
+/-- **The twisted quantum dimer is a matrix product density operator.**  The
+closed operator is positive semidefinite for every positive chain length: it is
+a nonnegative multiple of the Hadamard product of the rank-one bond-matching
+indicator with the pullback of the sum of the two Kronecker powers, and the
+Schur product theorem turns positive semidefiniteness of the two factors into
+positive semidefiniteness of the product.
+
+Source: arXiv:1606.00608, Section 4, equation `eq:III_MPDOform`, lines
+623--630, for the notion of a matrix product density operator; the tensor is a
+project example motivated by lines 995--1010, not a tensor stated in
+CPSV16. -/
+theorem T_isMPDO : IsMPDO T := by
+  intro N hN
+  rw [mpo_T_eq_smul_hadamard hN]
+  exact ((chainIndicator_posSemidef N).hadamard
+    ((gPow_add_sub_posSemidef N).1.submatrix (flagLeft N))).smul (by positivity)
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinCyclicInduction
 import TNLean.MPS.MPDO.TwistedDimer
 import Mathlib.Analysis.Matrix.Order
 
@@ -114,14 +115,8 @@ lemma openOK_succ {n : ℕ} (σ : Fin (n + 2) → Fin 8) :
 together with the wraparound match from the last letter back to the first. -/
 lemma chainOK_succ {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
     ChainOK (n + 1) σ ↔ OpenOK σ ∧ gate (σ (Fin.last n)) (σ 0) := by
-  have hrot : ∀ i : Fin n, finRotate (n + 1) i.castSucc = i.succ := fun i => by
-    have h := finRotate_of_lt (n := n) i.isLt
-    have e1 : (⟨(i : ℕ), i.isLt.trans_le n.le_succ⟩ : Fin (n + 1)) = i.castSucc := Fin.ext rfl
-    have e2 : (⟨(i : ℕ) + 1, Nat.succ_lt_succ i.isLt⟩ : Fin (n + 1)) = i.succ := Fin.ext rfl
-    rw [e1, e2] at h
-    exact h
   rw [ChainOK, Fin.forall_fin_succ', OpenOK]
-  simp only [hrot, finRotate_last]
+  simp only [Fin.finRotate_succ_castSucc, finRotate_last]
 
 /-! ### The open-chain product of letters -/
 

--- a/TNLean/MPS/MPDO/TwistedDimerRefine.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerRefine.lean
@@ -1,0 +1,443 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimer
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# The refinement channel of the twisted quantum dimer
+
+**Scope: the refinement map only.** This file continues
+`TNLean.MPS.MPDO.TwistedDimer` and builds the first of the two
+trace-preserving completely positive maps required by the renormalization
+fixed-point condition of arXiv:1606.00608, Definition 4.1: a map carrying the
+one-site physical closure of the twisted quantum dimer to its two-site
+physical closure.  The tensor is a project example motivated by the
+length-dependence question after Theorem 4.14 of that paper (lines 995--1010);
+it is not a tensor stated in the source.  The coarse-graining map in the
+opposite direction, and the resulting fixed-point statement, are in
+`TNLean.MPS.MPDO.TwistedDimerViaTS`.
+
+## The refinement channel
+
+Reading a physical index as a pair of site qubits together with a flag qubit,
+the refinement map measures the incoming flag, prepares a fresh pair of flags
+$(f_1, f_2)$ and a fresh bond qubit in one of the two states
+$(|00\rangle \pm |11\rangle)/\sqrt2$, and returns the two-site letter whose bond
+qubits carry the prepared bond state.  The two bond states are prepared with
+the weights $x = 7/8$ and $y = 1/8$, and the incoming flag is constrained to
+$f_1 + f_2 + \varepsilon$, where $\varepsilon$ labels the prepared bond state.
+The resulting Kraus family is indexed by $(f_1, f_2, \varepsilon)$.
+
+## Main results
+
+* `pair_fiber_sum` — the fibre of a two-site letter over prescribed flags and
+  outer bits is a square of bond bits;
+* `refineAmp_tau_sum` — the scalar identity behind the refinement channel: the
+  weighted sum of the two prepared bond states reproduces the bond matrices
+  $C_0$ and $C_1$ of the twisted dimer;
+* `refineKraus_resolution` — the refinement Kraus family resolves the identity;
+* `refineMap_isKrausCPTP` — the refinement map is trace-preserving completely
+  positive;
+* `refineMap_physClose1` — the refinement map carries the one-site physical
+  closure to the two-site physical closure.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 (lines 645--659) and Theorem 4.14 with lines 995--1010
+  (the twisted dimer is a project example, not a tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### Fibres of the bit encoding -/
+
+/-- A physical index is determined by its three bits. -/
+lemma eq_of_bits {i j : Fin 8} (hL : bitL i = bitL j) (hR : bitR i = bitR j)
+    (hF : bitF i = bitF j) : i = j := by
+  rw [← physIdx_bits i, ← physIdx_bits j, hL, hR, hF]
+
+/-- A sum over the physical index is a threefold sum over its bits. -/
+lemma sum_fin_eight (h : Fin 8 → ℂ) :
+    ∑ i : Fin 8, h i = ∑ a : Fin 2, ∑ b : Fin 2, ∑ c : Fin 2, h (physIdx a b c) := by
+  rw [← physEquiv.sum_comp h, Fintype.sum_prod_type]
+  simp only [Fintype.sum_prod_type]
+  rfl
+
+/-- **The fibre over all three bits is a single index.** -/
+lemma one_site_fiber_sum (F l r : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ j : Fin 8, if bitF j = F ∧ bitL j = l ∧ bitR j = r then h j else 0) =
+      h (physIdx l r F) := by
+  rw [sum_fin_eight]
+  fin_cases F <;> fin_cases l <;> fin_cases r <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre over the flag and the first bit is indexed by the second bit.** -/
+lemma left_fiber_sum (f l : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ i : Fin 8, if bitF i = f ∧ bitL i = l then h i else 0) =
+      ∑ b : Fin 2, h (physIdx l b f) := by
+  rw [sum_fin_eight]
+  fin_cases f <;> fin_cases l <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre over the flag and the second bit is indexed by the first bit.** -/
+lemma right_fiber_sum (f r : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ i : Fin 8, if bitF i = f ∧ bitR i = r then h i else 0) =
+      ∑ b : Fin 2, h (physIdx b r f) := by
+  rw [sum_fin_eight]
+  fin_cases f <;> fin_cases r <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre of a two-site letter over prescribed flags and outer bits is a
+square of bond bits.** -/
+lemma pair_fiber_sum (f₁ f₂ l r : Fin 2) (h : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8,
+        if (bitF i.1 = f₁ ∧ bitL i.1 = l) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = r) then h i else 0) =
+      ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, h (physIdx l b₁ f₁, physIdx b₂ r f₂) := by
+  rw [Fintype.sum_prod_type]
+  have step : ∀ i₁ : Fin 8,
+      (∑ i₂ : Fin 8, if (bitF i₁ = f₁ ∧ bitL i₁ = l) ∧ (bitF i₂ = f₂ ∧ bitR i₂ = r)
+          then h (i₁, i₂) else 0) =
+        if bitF i₁ = f₁ ∧ bitL i₁ = l then ∑ b₂ : Fin 2, h (i₁, physIdx b₂ r f₂) else 0 := by
+    intro i₁
+    by_cases hP : bitF i₁ = f₁ ∧ bitL i₁ = l
+    · rw [ite_eq_left hP]
+      rw [Finset.sum_congr rfl fun i₂ _ => (by simp [hP] :
+        (if (bitF i₁ = f₁ ∧ bitL i₁ = l) ∧ (bitF i₂ = f₂ ∧ bitR i₂ = r) then h (i₁, i₂) else 0) =
+          if bitF i₂ = f₂ ∧ bitR i₂ = r then h (i₁, i₂) else 0)]
+      exact right_fiber_sum f₂ r fun i₂ => h (i₁, i₂)
+    · rw [ite_eq_right hP]
+      exact Finset.sum_eq_zero fun i₂ _ => ite_eq_right fun hc => hP hc.1
+  rw [Finset.sum_congr rfl fun i₁ _ => step i₁]
+  exact left_fiber_sum f₁ l fun i₁ => ∑ b₂ : Fin 2, h (i₁, physIdx b₂ r f₂)
+
+/-- **The one-site physical closure in bit coordinates.** -/
+lemma physClose1_T_bits (X : Matrix (Fin 8) (Fin 8) ℂ) (L R F L' R' F' : Fin 2) :
+    physClose1 T X (physIdx L R F) (physIdx L' R' F') =
+      if F = F' then
+        ∑ k : Fin 2, ((Cmat k L L' * tau k F / 2 : ℝ) : ℂ) *
+          X (physIdx R R' k) (physIdx L L' k)
+      else 0 := by
+  rw [physClose1_T]
+  simp only [bitL_physIdx, bitR_physIdx, coef_physIdx]
+  by_cases h : F = F'
+  · simp [h]
+  · simp [h]
+
+/-! ### The prepared bond states -/
+
+/-- The weight of the prepared bond state: $x$ for $(|00\rangle + |11\rangle)/\sqrt2$
+and $y$ for $(|00\rangle - |11\rangle)/\sqrt2$. -/
+def bondWeight : Fin 2 → ℝ
+  | 0 => x
+  | 1 => y
+
+/-- Both bond weights are nonnegative. -/
+lemma bondWeight_nonneg (ε : Fin 2) : 0 ≤ bondWeight ε := by
+  fin_cases ε <;> norm_num [bondWeight, x, y]
+
+/-- The Kraus amplitude of the refinement channel at the bond outcome `ε`. -/
+def refineAmp (ε : Fin 2) : ℝ := Real.sqrt (bondWeight ε) / 2
+
+/-- The squared refinement amplitude is a quarter of the bond weight. -/
+lemma refineAmp_sq (ε : Fin 2) : refineAmp ε ^ 2 = bondWeight ε / 4 := by
+  rw [refineAmp, div_pow, Real.sq_sqrt (bondWeight_nonneg ε)]
+  norm_num
+
+/-- The flag signs square to one. -/
+lemma tau_mul_self (k b : Fin 2) : tau k b * tau k b = 1 := by
+  fin_cases k <;> fin_cases b <;> norm_num [tau]
+
+/-- **The scalar identity behind the refinement channel.**  Summed over the two
+prepared bond states, the weights $x/4$ and $y/4$ together with the bond sign
+$(-1)^{\varepsilon(b + b')}$ and the flag sign reproduce half the bond matrix
+$C_k[b, b']$ of the twisted dimer. -/
+lemma refineAmp_tau_sum (k b b' f₁ f₂ : Fin 2) :
+    ∑ ε : Fin 2, refineAmp ε ^ 2 * tau ε b * tau ε b' * tau k (f₁ + f₂ + ε) =
+      tau k f₁ * tau k f₂ * Cmat k b b' / 2 := by
+  have h0 : refineAmp 0 ^ 2 = 7 / 32 := by rw [refineAmp_sq]; norm_num [bondWeight, x]
+  have h1 : refineAmp 1 ^ 2 = 1 / 32 := by rw [refineAmp_sq]; norm_num [bondWeight, y]
+  fin_cases k <;> fin_cases b <;> fin_cases b' <;> fin_cases f₁ <;> fin_cases f₂ <;>
+    simp [Fin.sum_univ_two, h0, h1, tau, Cmat, cDiag_eq, cOff_eq] <;> norm_num
+
+/-- The scalar identity of `refineAmp_tau_sum`, with the bond matrix of the outer
+bits carried along. -/
+lemma refineAmp_Cmat_sum (k b b' f₁ f₂ L L' : Fin 2) :
+    ∑ ε : Fin 2,
+        refineAmp ε ^ 2 * tau ε b * tau ε b' * (Cmat k L L' * tau k (f₁ + f₂ + ε) / 2) =
+      Cmat k L L' * tau k f₁ / 2 * (Cmat k b b' * tau k f₂ / 2) := by
+  have h := refineAmp_tau_sum k b b' f₁ f₂
+  rw [Fin.sum_univ_two] at h ⊢
+  linear_combination (Cmat k L L' / 2) * h
+
+/-! ### The refinement Kraus family -/
+
+/-- The support condition of the refinement Kraus operators: the outer bits and
+the flags of the two-site letter are prescribed by the one-site letter and the
+Kraus label, the two-site letter satisfies the bond-matching condition, and the
+one-site flag is the sum of the two prepared flags and the bond label. -/
+def refineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) : Prop :=
+  ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
+    (gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε)
+
+instance decidableRefineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    Decidable (refineOK f₁ f₂ ε i j) :=
+  inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ (_ ∧ _)))
+
+/-- The support condition, read as a condition on the one-site letter for a
+fixed two-site letter. -/
+lemma refineOK_iff_col (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    refineOK f₁ f₂ ε i j ↔
+      (gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧
+        (bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2) := by
+  simp only [refineOK]
+  constructor
+  · rintro ⟨⟨⟨hf₁, hl⟩, hf₂, hr⟩, hg, hf⟩
+    exact ⟨⟨hg, hf₁, hf₂⟩, hf, hl.symm, hr.symm⟩
+  · rintro ⟨⟨hg, hf₁, hf₂⟩, hf, hl, hr⟩
+    exact ⟨⟨⟨hf₁, hl.symm⟩, hf₂, hr.symm⟩, hg, hf⟩
+
+/-- The Kraus operator of the refinement channel at the label
+$(f_1, f_2, \varepsilon)$: it prepares the flags $f_1, f_2$ on the two output
+sites and the bond state labelled by $\varepsilon$, with the bond sign
+$(-1)^{\varepsilon b}$ at the shared bond bit `b`. -/
+def refineKraus (f₁ f₂ ε : Fin 2) : Matrix (Fin 8 × Fin 8) (Fin 8) ℂ :=
+  Matrix.of fun i j =>
+    if refineOK f₁ f₂ ε i j then ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) else 0
+
+/-- The refinement map, from one-site to two-site physical operators. -/
+def refineMap :
+    Matrix (Fin 8) (Fin 8) ℂ →ₗ[ℂ] Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ :=
+  Matrix.rectangularKrausMap fun t : Fin 2 × Fin 2 × Fin 2 => refineKraus t.1 t.2.1 t.2.2
+
+/-- The refinement Kraus entries are real. -/
+lemma refineKraus_star (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    star (refineKraus f₁ f₂ ε i j) = refineKraus f₁ f₂ ε i j := by
+  simp only [refineKraus, Matrix.of_apply]
+  split_ifs
+  · exact Complex.conj_ofReal _
+  · exact star_zero _
+
+/-- Contracting a refinement Kraus operator against a one-site vector selects
+the single one-site letter in its support. -/
+lemma refineKraus_col_sum (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (g : Fin 8 → ℂ) :
+    (∑ j : Fin 8, refineKraus f₁ f₂ ε i j * g j) =
+      if gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂ then
+        ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) *
+          g (physIdx (bitL i.1) (bitR i.2) (f₁ + f₂ + ε))
+      else 0 := by
+  by_cases hi : gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂
+  · rw [ite_eq_left hi]
+    have hcongr : ∀ j : Fin 8, refineKraus f₁ f₂ ε i j * g j =
+        if bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2 then
+          ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) * g j else 0 := by
+      intro j
+      simp only [refineKraus, Matrix.of_apply]
+      by_cases hj : bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
+      · rw [ite_eq_left ((refineOK_iff_col f₁ f₂ ε i j).2 ⟨hi, hj⟩), ite_eq_left hj]
+      · rw [ite_eq_right fun hc => hj ((refineOK_iff_col f₁ f₂ ε i j).1 hc).2,
+          ite_eq_right hj, zero_mul]
+    rw [Finset.sum_congr rfl fun j _ => hcongr j]
+    exact one_site_fiber_sum _ _ _ _
+  · rw [ite_eq_right hi]
+    refine Finset.sum_eq_zero fun j _ => ?_
+    simp only [refineKraus, Matrix.of_apply]
+    rw [ite_eq_right fun hc => hi ((refineOK_iff_col f₁ f₂ ε i j).1 hc).1, zero_mul]
+
+/-- Summing over the two-site letters in the support of a refinement Kraus
+operator leaves the two gated fibre points. -/
+lemma refineKraus_row_sum (f₁ f₂ ε : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8, if refineOK f₁ f₂ ε i j then g i else 0) =
+      if bitF j = f₁ + f₂ + ε then
+        g (physIdx (bitL j) 0 f₁, physIdx 0 (bitR j) f₂) +
+          g (physIdx (bitL j) 1 f₁, physIdx 1 (bitR j) f₂)
+      else 0 := by
+  have hcongr : ∀ i : Fin 8 × Fin 8, (if refineOK f₁ f₂ ε i j then g i else 0) =
+      if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
+        (if gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε then g i else 0) else 0 := by
+    intro i
+    by_cases h1 : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
+    · rw [ite_eq_left h1]
+      by_cases h2 : gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε
+      · rw [ite_eq_left h2, ite_eq_left (show refineOK f₁ f₂ ε i j from ⟨h1, h2⟩)]
+      · rw [ite_eq_right h2, ite_eq_right fun hc => h2 hc.2]
+    · rw [ite_eq_right h1, ite_eq_right fun hc => h1 hc.1]
+  rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
+  by_cases hf : bitF j = f₁ + f₂ + ε
+  · rw [ite_eq_left hf]
+    simp [Fin.sum_univ_two, gate, hf]
+  · rw [ite_eq_right hf]
+    simp [gate, hf]
+
+/-- **The refinement Kraus family resolves the identity.** -/
+theorem refineKraus_resolution :
+    ∑ t : Fin 2 × Fin 2 × Fin 2,
+        (refineKraus t.1 t.2.1 t.2.2)ᴴ * refineKraus t.1 t.2.1 t.2.2 =
+      (1 : Matrix (Fin 8) (Fin 8) ℂ) := by
+  have h0 : ((refineAmp 0 : ℝ) : ℂ) ^ 2 = 7 / 32 := by
+    rw [← Complex.ofReal_pow, refineAmp_sq]
+    norm_num [bondWeight, x]
+  have h1 : ((refineAmp 1 : ℝ) : ℂ) ^ 2 = 1 / 32 := by
+    rw [← Complex.ofReal_pow, refineAmp_sq]
+    norm_num [bondWeight, y]
+  ext j j'
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  by_cases hjj : j = j'
+  · subst hjj
+    rw [Matrix.one_apply_eq]
+    have hstep : ∀ t : Fin 2 × Fin 2 × Fin 2,
+        (∑ i : Fin 8 × Fin 8, star (refineKraus t.1 t.2.1 t.2.2 i j) *
+            refineKraus t.1 t.2.1 t.2.2 i j) =
+          if bitF j = t.1 + t.2.1 + t.2.2 then ((2 * refineAmp t.2.2 ^ 2 : ℝ) : ℂ) else 0 := by
+      rintro ⟨f₁, f₂, ε⟩
+      have hcongr : ∀ i : Fin 8 × Fin 8,
+          star (refineKraus f₁ f₂ ε i j) * refineKraus f₁ f₂ ε i j =
+            if refineOK f₁ f₂ ε i j then ((refineAmp ε ^ 2 : ℝ) : ℂ) else 0 := by
+        intro i
+        rw [refineKraus_star]
+        simp only [refineKraus, Matrix.of_apply]
+        split_ifs
+        · rw [← Complex.ofReal_mul]
+          congr 1
+          have := tau_mul_self ε (bitR i.1)
+          nlinarith [this]
+        · exact mul_zero _
+      rw [Finset.sum_congr rfl fun i _ => hcongr i, refineKraus_row_sum]
+      by_cases hf : bitF j = f₁ + f₂ + ε
+      · rw [ite_eq_left hf, ite_eq_left hf]
+        push_cast
+        ring
+      · rw [ite_eq_right hf, ite_eq_right hf]
+    rw [Finset.sum_congr rfl fun t _ => hstep t]
+    have hcase : ∀ a : Fin 2, a = 0 ∨ a = 1 := by decide
+    rcases hcase (bitF j) with hb | hb <;>
+      simp only [Fintype.sum_prod_type, Fin.sum_univ_two, hb, Complex.ofReal_mul,
+        Complex.ofReal_pow, Complex.ofReal_ofNat] <;>
+      norm_num [h0, h1, show (1 : Fin 2) + 1 = 0 from rfl, show (1 : Fin 2) + 1 + 1 = 1 from rfl]
+  · rw [Matrix.one_apply_ne hjj]
+    refine Finset.sum_eq_zero fun t _ => Finset.sum_eq_zero fun i _ => ?_
+    simp only [refineKraus, Matrix.of_apply]
+    by_cases h : refineOK t.1 t.2.1 t.2.2 i j
+    · have h' : ¬ refineOK t.1 t.2.1 t.2.2 i j' := by
+        rintro h2
+        exact hjj (eq_of_bits (h.1.1.2.symm.trans h2.1.1.2)
+          (h.1.2.2.symm.trans h2.1.2.2) (h.2.2.trans h2.2.2.symm))
+      rw [ite_eq_right h', mul_zero]
+    · rw [ite_eq_right h, star_zero, zero_mul]
+
+/-- **The refinement map is trace-preserving completely positive.** -/
+theorem refineMap_isKrausCPTP : IsKrausCPTP refineMap :=
+  Matrix.rectangularKrausMap_isKrausCPTP _ refineKraus_resolution
+
+/-! ### The refinement map on the physical closures -/
+
+/-- Summing over the Kraus labels whose flags are prescribed leaves a sum over
+the bond label. -/
+lemma sum_flag_selector (F₁ F₂ : Fin 2) (V : Fin 2 × Fin 2 × Fin 2 → ℂ) :
+    (∑ t : Fin 2 × Fin 2 × Fin 2, if t.1 = F₁ ∧ t.2.1 = F₂ then V t else 0) =
+      ∑ ε : Fin 2, V (F₁, F₂, ε) := by
+  fin_cases F₁ <;> fin_cases F₂ <;> simp [Fintype.sum_prod_type, Fin.sum_univ_two]
+
+/-- One Kraus term of the refinement map, evaluated at a pair of two-site
+letters. -/
+lemma refineKraus_conj_term (f₁ f₂ ε : Fin 2) (Y : Matrix (Fin 8) (Fin 8) ℂ)
+    (i₁ i₂ j₁ j₂ : Fin 8) :
+    (∑ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') *
+        star (refineKraus f₁ f₂ ε (j₁, j₂) a')) =
+      if (gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂) ∧
+          (gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂) then
+        ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) : ℝ) : ℂ) *
+          Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε))
+            (physIdx (bitL j₁) (bitR j₂) (f₁ + f₂ + ε))
+      else 0 := by
+  have hinner : ∀ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') =
+      if gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂ then
+        ((refineAmp ε * tau ε (bitR i₁) : ℝ) : ℂ) *
+          Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε)) a' else 0 :=
+    fun a' => refineKraus_col_sum f₁ f₂ ε (i₁, i₂) fun a => Y a a'
+  rw [Finset.sum_congr rfl fun a' _ => by rw [hinner a']]
+  by_cases hi : gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂
+  · rw [Finset.sum_congr rfl fun a' _ => by
+      rw [ite_eq_left hi, refineKraus_star, mul_comm]]
+    rw [refineKraus_col_sum f₁ f₂ ε (j₁, j₂)]
+    by_cases hj : gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂
+    · rw [ite_eq_left hj, ite_eq_left ⟨hi, hj⟩]
+      push_cast
+      ring
+    · rw [ite_eq_right hj, ite_eq_right fun hc => hj hc.2]
+  · rw [ite_eq_right fun hc => hi hc.1]
+    exact Finset.sum_eq_zero fun a' _ => by rw [ite_eq_right hi, zero_mul]
+
+/-- **The refinement map carries the one-site physical closure of the twisted
+dimer to its two-site physical closure.**  Together with
+`refineMap_isKrausCPTP`, this is the map `T` of arXiv:1606.00608,
+Definition 4.1 (paper label eq:Tmap). -/
+theorem refineMap_physClose1 (X : Matrix (Fin 8) (Fin 8) ℂ) :
+    refineMap (physClose1 T X) = physClose2 T X := by
+  ext ii jj
+  obtain ⟨i₁, i₂⟩ := ii
+  obtain ⟨j₁, j₂⟩ := jj
+  rw [physClose2_T]
+  change (∑ t : Fin 2 × Fin 2 × Fin 2, refineKraus t.1 t.2.1 t.2.2 * physClose1 T X *
+      (refineKraus t.1 t.2.1 t.2.2)ᴴ) (i₁, i₂) (j₁, j₂) = _
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ =>
+    refineKraus_conj_term t.1 t.2.1 t.2.2 (physClose1 T X) i₁ i₂ j₁ j₂]
+  by_cases hg : gate i₁ i₂ ∧ gate j₁ j₂
+  · rw [ite_eq_left hg]
+    by_cases e : bitF i₁ = bitF j₁ ∧ bitF i₂ = bitF j₂
+    · have hiff : ∀ t : Fin 2 × Fin 2 × Fin 2,
+          (((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) ↔
+              (t.1 = bitF i₁ ∧ t.2.1 = bitF i₂)) := by
+        intro t
+        constructor
+        · rintro ⟨⟨_, h1, h2⟩, _⟩
+          exact ⟨h1.symm, h2.symm⟩
+        · rintro ⟨h1, h2⟩
+          exact ⟨⟨hg.1, h1.symm, h2.symm⟩, hg.2, by rw [← e.1, h1], by rw [← e.2, h2]⟩
+      simp only [hiff]
+      rw [sum_flag_selector]
+      have hval : ∀ ε : Fin 2,
+          ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) : ℝ) : ℂ) *
+              physClose1 T X (physIdx (bitL i₁) (bitR i₂) (bitF i₁ + bitF i₂ + ε))
+                (physIdx (bitL j₁) (bitR j₂) (bitF i₁ + bitF i₂ + ε)) =
+            ∑ k : Fin 2,
+              ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) *
+                (Cmat k (bitL i₁) (bitL j₁) * tau k (bitF i₁ + bitF i₂ + ε) / 2) : ℝ) : ℂ) *
+                X (physIdx (bitR i₂) (bitR j₂) k) (physIdx (bitL i₁) (bitL j₁) k) := by
+        intro ε
+        rw [physClose1_T_bits, ite_eq_left rfl, Finset.mul_sum]
+        refine Finset.sum_congr rfl fun k _ => ?_
+        push_cast
+        ring
+      rw [Finset.sum_congr rfl fun ε _ => hval ε, Finset.sum_comm]
+      refine Finset.sum_congr rfl fun k _ => ?_
+      rw [← Finset.sum_mul, ← Complex.ofReal_sum, refineAmp_Cmat_sum]
+      have hb : bitL i₂ = bitR i₁ := Eq.symm hg.1
+      have hb' : bitL j₂ = bitR j₁ := Eq.symm hg.2
+      have hc1 : coef k i₁ j₁ = ((Cmat k (bitL i₁) (bitL j₁) * tau k (bitF i₁) / 2 : ℝ) : ℂ) := by
+        rw [coef, ite_eq_left e.1]
+      have hc2 : coef k i₂ j₂ = ((Cmat k (bitR i₁) (bitR j₁) * tau k (bitF i₂) / 2 : ℝ) : ℂ) := by
+        rw [coef, ite_eq_left e.2, hb, hb']
+      rw [hc1, hc2]
+      push_cast
+      ring
+    · have hzero : ∀ t : Fin 2 × Fin 2 × Fin 2,
+          ¬ ((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) := by
+        rintro t ⟨⟨_, h1, h2⟩, _, h1', h2'⟩
+        exact e ⟨h1.trans h1'.symm, h2.trans h2'.symm⟩
+      rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero]
+      refine (Finset.sum_eq_zero fun k _ => ?_).symm
+      rcases not_and_or.mp e with h | h
+      · rw [coef, ite_eq_right h, zero_mul, zero_mul]
+      · rw [coef, coef, ite_eq_right h, mul_zero, zero_mul]
+  · rw [ite_eq_right hg]
+    refine Finset.sum_eq_zero fun t _ => ite_eq_right fun hc => hg ⟨hc.1.1, hc.2.1⟩
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerRefine.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerRefine.lean
@@ -180,21 +180,21 @@ lemma refineAmp_Cmat_sum (k b b' f₁ f₂ L L' : Fin 2) :
 the flags of the two-site letter are prescribed by the one-site letter and the
 Kraus label, the two-site letter satisfies the bond-matching condition, and the
 one-site flag is the sum of the two prepared flags and the bond label. -/
-def refineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) : Prop :=
+def IsRefineSupported (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) : Prop :=
   ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
     (gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε)
 
-instance decidableRefineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
-    Decidable (refineOK f₁ f₂ ε i j) :=
+instance decidableIsRefineSupported (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    Decidable (IsRefineSupported f₁ f₂ ε i j) :=
   inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ (_ ∧ _)))
 
 /-- The support condition, read as a condition on the one-site letter for a
 fixed two-site letter. -/
-lemma refineOK_iff_col (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
-    refineOK f₁ f₂ ε i j ↔
+lemma isRefineSupported_iff_col (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    IsRefineSupported f₁ f₂ ε i j ↔
       (gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧
         (bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2) := by
-  simp only [refineOK]
+  simp only [IsRefineSupported]
   constructor
   · rintro ⟨⟨⟨hf₁, hl⟩, hf₂, hr⟩, hg, hf⟩
     exact ⟨⟨hg, hf₁, hf₂⟩, hf, hl.symm, hr.symm⟩
@@ -207,7 +207,7 @@ sites and the bond state labelled by $\varepsilon$, with the bond sign
 $(-1)^{\varepsilon b}$ at the shared bond bit `b`. -/
 def refineKraus (f₁ f₂ ε : Fin 2) : Matrix (Fin 8 × Fin 8) (Fin 8) ℂ :=
   Matrix.of fun i j =>
-    if refineOK f₁ f₂ ε i j then ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) else 0
+    if IsRefineSupported f₁ f₂ ε i j then ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) else 0
 
 /-- The refinement map, from one-site to two-site physical operators. -/
 def refineMap :
@@ -238,32 +238,32 @@ lemma refineKraus_col_sum (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (g : Fin 8
       intro j
       simp only [refineKraus, Matrix.of_apply]
       by_cases hj : bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
-      · rw [ite_eq_left ((refineOK_iff_col f₁ f₂ ε i j).2 ⟨hi, hj⟩), ite_eq_left hj]
-      · rw [ite_eq_right fun hc => hj ((refineOK_iff_col f₁ f₂ ε i j).1 hc).2,
+      · rw [ite_eq_left ((isRefineSupported_iff_col f₁ f₂ ε i j).2 ⟨hi, hj⟩), ite_eq_left hj]
+      · rw [ite_eq_right fun hc => hj ((isRefineSupported_iff_col f₁ f₂ ε i j).1 hc).2,
           ite_eq_right hj, zero_mul]
     rw [Finset.sum_congr rfl fun j _ => hcongr j]
     exact one_site_fiber_sum _ _ _ _
   · rw [ite_eq_right hi]
     refine Finset.sum_eq_zero fun j _ => ?_
     simp only [refineKraus, Matrix.of_apply]
-    rw [ite_eq_right fun hc => hi ((refineOK_iff_col f₁ f₂ ε i j).1 hc).1, zero_mul]
+    rw [ite_eq_right fun hc => hi ((isRefineSupported_iff_col f₁ f₂ ε i j).1 hc).1, zero_mul]
 
 /-- Summing over the two-site letters in the support of a refinement Kraus
 operator leaves the two gated fibre points. -/
 lemma refineKraus_row_sum (f₁ f₂ ε : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8 → ℂ) :
-    (∑ i : Fin 8 × Fin 8, if refineOK f₁ f₂ ε i j then g i else 0) =
+    (∑ i : Fin 8 × Fin 8, if IsRefineSupported f₁ f₂ ε i j then g i else 0) =
       if bitF j = f₁ + f₂ + ε then
         g (physIdx (bitL j) 0 f₁, physIdx 0 (bitR j) f₂) +
           g (physIdx (bitL j) 1 f₁, physIdx 1 (bitR j) f₂)
       else 0 := by
-  have hcongr : ∀ i : Fin 8 × Fin 8, (if refineOK f₁ f₂ ε i j then g i else 0) =
+  have hcongr : ∀ i : Fin 8 × Fin 8, (if IsRefineSupported f₁ f₂ ε i j then g i else 0) =
       if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
         (if gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε then g i else 0) else 0 := by
     intro i
     by_cases h1 : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
     · rw [ite_eq_left h1]
       by_cases h2 : gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε
-      · rw [ite_eq_left h2, ite_eq_left (show refineOK f₁ f₂ ε i j from ⟨h1, h2⟩)]
+      · rw [ite_eq_left h2, ite_eq_left (show IsRefineSupported f₁ f₂ ε i j from ⟨h1, h2⟩)]
       · rw [ite_eq_right h2, ite_eq_right fun hc => h2 hc.2]
     · rw [ite_eq_right h1, ite_eq_right fun hc => h1 hc.1]
   rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
@@ -296,7 +296,7 @@ theorem refineKraus_resolution :
       rintro ⟨f₁, f₂, ε⟩
       have hcongr : ∀ i : Fin 8 × Fin 8,
           star (refineKraus f₁ f₂ ε i j) * refineKraus f₁ f₂ ε i j =
-            if refineOK f₁ f₂ ε i j then ((refineAmp ε ^ 2 : ℝ) : ℂ) else 0 := by
+            if IsRefineSupported f₁ f₂ ε i j then ((refineAmp ε ^ 2 : ℝ) : ℂ) else 0 := by
         intro i
         rw [refineKraus_star]
         simp only [refineKraus, Matrix.of_apply]
@@ -321,8 +321,8 @@ theorem refineKraus_resolution :
   · rw [Matrix.one_apply_ne hjj]
     refine Finset.sum_eq_zero fun t _ => Finset.sum_eq_zero fun i _ => ?_
     simp only [refineKraus, Matrix.of_apply]
-    by_cases h : refineOK t.1 t.2.1 t.2.2 i j
-    · have h' : ¬ refineOK t.1 t.2.1 t.2.2 i j' := by
+    by_cases h : IsRefineSupported t.1 t.2.1 t.2.2 i j
+    · have h' : ¬ IsRefineSupported t.1 t.2.1 t.2.2 i j' := by
         rintro h2
         exact hjj (eq_of_bits (h.1.1.2.symm.trans h2.1.1.2)
           (h.1.2.2.symm.trans h2.1.2.2) (h.2.2.trans h2.2.2.symm))

--- a/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
@@ -131,12 +131,12 @@ lemma physClose2_T_fiber (X : Matrix (Fin 8) (Fin 8) ℂ) (L L' R R' f₁ f₂ b
 /-! ### The coarse-graining Kraus family -/
 
 /-- The support condition of the coarse-graining Kraus operators. -/
-def coarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) : Prop :=
+def IsCoarseSupported (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) : Prop :=
   ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
     bitF j = f₁ + f₂ + bondShift v
 
-instance decidableCoarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
-    Decidable (coarseOK v f₁ f₂ j i) :=
+instance decidableIsCoarseSupported (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
+    Decidable (IsCoarseSupported v f₁ f₂ j i) :=
   inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ _))
 
 /-- The Kraus operator of the coarse-graining channel at the label
@@ -144,7 +144,7 @@ $(v, f_1, f_2)$: it reads the bond pair in the basis vector `v`, requires the
 site flags $f_1, f_2$, and returns the one-site letter with the decoded flag. -/
 def coarseKraus (v : Fin 4) (f₁ f₂ : Fin 2) : Matrix (Fin 8) (Fin 8 × Fin 8) ℂ :=
   Matrix.of fun j i =>
-    if coarseOK v f₁ f₂ j i then ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) else 0
+    if IsCoarseSupported v f₁ f₂ j i then ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) else 0
 
 /-- The coarse-graining map, from two-site to one-site physical operators. -/
 def coarseMap :
@@ -175,7 +175,7 @@ lemma coarseKraus_row_sum (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (g : Fin 8
       intro i
       simp only [coarseKraus, Matrix.of_apply]
       by_cases hi : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
-      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from ⟨hi, hf⟩), ite_eq_left hi]
+      · rw [ite_eq_left (show IsCoarseSupported v f₁ f₂ j i from ⟨hi, hf⟩), ite_eq_left hi]
       · rw [ite_eq_right fun hc => hi hc.1, ite_eq_right hi, zero_mul]
     rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
     simp only [bitR_physIdx, bitL_physIdx]
@@ -202,12 +202,12 @@ lemma coarseKraus_res_term (v : Fin 4) (f₁ f₂ : Fin 2) (i i' : Fin 8 × Fin 
       rw [coarseKraus_star]
       simp only [coarseKraus, Matrix.of_apply]
       by_cases hj : bitF j = f₁ + f₂ + bondShift v ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
-      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from
+      · rw [ite_eq_left (show IsCoarseSupported v f₁ f₂ j i from
           ⟨⟨⟨h.1.1.1, hj.2.1.symm⟩, h.1.1.2, hj.2.2.symm⟩, hj.1⟩),
-          ite_eq_left (show coarseOK v f₁ f₂ j i' from
+          ite_eq_left (show IsCoarseSupported v f₁ f₂ j i' from
           ⟨⟨⟨h.1.2.1, (hj.2.1.trans h.2.1).symm⟩, h.1.2.2, (hj.2.2.trans h.2.2).symm⟩, hj.1⟩),
           ← Complex.ofReal_mul, ite_eq_left hj]
-      · have hz : ¬ coarseOK v f₁ f₂ j i := fun hc =>
+      · have hz : ¬ IsCoarseSupported v f₁ f₂ j i := fun hc =>
           hj ⟨hc.2, hc.1.1.2.symm, hc.1.2.2.symm⟩
         rw [ite_eq_right hz, zero_mul, ite_eq_right hj]
     rw [Finset.sum_congr rfl fun j _ => hcongr j]
@@ -216,8 +216,8 @@ lemma coarseKraus_res_term (v : Fin 4) (f₁ f₂ : Fin 2) (i i' : Fin 8 × Fin 
     refine Finset.sum_eq_zero fun j _ => ?_
     rw [coarseKraus_star]
     simp only [coarseKraus, Matrix.of_apply]
-    by_cases h1 : coarseOK v f₁ f₂ j i
-    · by_cases h2 : coarseOK v f₁ f₂ j i'
+    by_cases h1 : IsCoarseSupported v f₁ f₂ j i
+    · by_cases h2 : IsCoarseSupported v f₁ f₂ j i'
       · exact absurd ⟨⟨⟨h1.1.1.1, h1.1.2.1⟩, h2.1.1.1, h2.1.2.1⟩,
           h1.1.1.2.trans h2.1.1.2.symm, h1.1.2.2.trans h2.1.2.2.symm⟩ h
       · rw [ite_eq_right h2, mul_zero]

--- a/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
@@ -1,0 +1,389 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimerRefine
+
+/-!
+# The twisted quantum dimer is a renormalization fixed point
+
+**Scope: the coarse-graining map and the fixed-point statement.** This file
+completes `TNLean.MPS.MPDO.TwistedDimerRefine` with the second of the two
+trace-preserving completely positive maps of arXiv:1606.00608, Definition 4.1,
+and concludes that the $\mathbb Z_2$-twisted quantum dimer satisfies that
+definition.  The tensor is a project example motivated by the
+length-dependence question after Theorem 4.14 of that paper (lines 995--1010);
+it is not a tensor stated in the source.
+
+## The coarse-graining channel
+
+The coarse-graining map measures the two bond qubits shared by a two-site
+letter in the orthonormal basis
+$(|00\rangle \pm |11\rangle)/\sqrt2$, $|01\rangle$, $|10\rangle$, reads the two
+site flags, and returns the one-site letter carrying the outer site qubits and
+the flag $f_1 + f_2 + s$, where $s$ is one for the antisymmetric bond outcome
+and zero otherwise.  On the support of the two-site physical closure the two
+bond qubits agree, so only the two symmetric-basis outcomes contribute, and
+their recombination is exactly the flag sign $\tau_1$ of the twisted dimer.
+
+## Main results
+
+* `bondVec_completeness` — the bond basis is orthonormal;
+* `coarseWeight_sum` — the scalar identity behind the coarse-graining
+  channel;
+* `coarseKraus_resolution` — the coarse-graining Kraus family resolves the
+  identity;
+* `coarseMap_isKrausCPTP` — the coarse-graining map is trace-preserving
+  completely positive;
+* `coarseMap_physClose2` — the coarse-graining map carries the two-site
+  physical closure back to the one-site physical closure;
+* `isRFPViaTS_T` — the twisted quantum dimer satisfies the renormalization
+  fixed-point condition of Definition 4.1.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 (lines 645--659) and Theorem 4.14 with lines 995--1010
+  (the twisted dimer is a project example, not a tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### The bond basis -/
+
+/-- The amplitude $1/\sqrt2$ of the symmetric and antisymmetric bond states. -/
+def invSqrt2 : ℝ := 1 / Real.sqrt 2
+
+/-- The square of the bond amplitude is one half. -/
+lemma invSqrt2_mul_self : invSqrt2 * invSqrt2 = 1 / 2 := by
+  rw [invSqrt2, div_mul_div_comm, Real.mul_self_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+  norm_num
+
+/-- The orthonormal basis of the bond pair used by the coarse-graining map:
+the two states $(|00\rangle \pm |11\rangle)/\sqrt2$ followed by $|01\rangle$
+and $|10\rangle$. -/
+def bondVec : Fin 4 → Fin 2 → Fin 2 → ℝ
+  | 0, b₁, b₂ => if b₁ = b₂ then invSqrt2 else 0
+  | 1, b₁, b₂ => if b₁ = b₂ then invSqrt2 * tau 1 b₁ else 0
+  | 2, b₁, b₂ => if b₁ = 0 ∧ b₂ = 1 then 1 else 0
+  | 3, b₁, b₂ => if b₁ = 1 ∧ b₂ = 0 then 1 else 0
+
+/-- The flag shift attached to a bond outcome: the antisymmetric outcome
+flips the decoded flag, the others leave it alone. -/
+def bondShift : Fin 4 → Fin 2
+  | 0 => 0
+  | 1 => 1
+  | 2 => 0
+  | 3 => 0
+
+/-- **The bond basis is orthonormal.** -/
+lemma bondVec_completeness (b₁ b₂ c₁ c₂ : Fin 2) :
+    ∑ v : Fin 4, bondVec v b₁ b₂ * bondVec v c₁ c₂ = if b₁ = c₁ ∧ b₂ = c₂ then 1 else 0 := by
+  have h2 := invSqrt2_mul_self
+  fin_cases b₁ <;> fin_cases b₂ <;> fin_cases c₁ <;> fin_cases c₂ <;>
+    simp [Fin.sum_univ_four, bondVec, tau] <;> nlinarith [h2]
+
+/-- The real weight contributed by one coarse-graining Kraus label to the
+one-site physical closure. -/
+def coarseWeight (v : Fin 4) (k f₁ f₂ L L' : Fin 2) : ℝ :=
+  ∑ b : Fin 2, ∑ c : Fin 2,
+    bondVec v b b * bondVec v c c * (Cmat k L L' * tau k f₁ / 2 * (Cmat k b c * tau k f₂ / 2))
+
+/-- **The scalar identity behind the coarse-graining channel.**  Summed over
+the bond outcomes and the two site flags compatible with a prescribed one-site
+flag, the weights of the two symmetric bond outcomes recombine into half the
+bond matrix $C_k$ of the twisted dimer, with the flag sign $\tau_k$. -/
+lemma coarseWeight_sum (k F L L' : Fin 2) :
+    ∑ t : Fin 4 × Fin 2 × Fin 2,
+        (if t.2.1 + t.2.2 + bondShift t.1 = F then coarseWeight t.1 k t.2.1 t.2.2 L L' else 0) =
+      Cmat k L L' * tau k F / 2 := by
+  have h2 := invSqrt2_mul_self
+  fin_cases k <;> fin_cases F <;> fin_cases L <;> fin_cases L' <;>
+    simp [Fintype.sum_prod_type, Fin.sum_univ_four, Fin.sum_univ_two, coarseWeight, bondVec,
+      bondShift, tau, Cmat, cDiag_eq, cOff_eq] <;> nlinarith [h2]
+
+/-- **The two-site physical closure on a fibre of the coarse-graining map.** -/
+lemma physClose2_T_fiber (X : Matrix (Fin 8) (Fin 8) ℂ) (L L' R R' f₁ f₂ b₁ b₂ c₁ c₂ : Fin 2) :
+    physClose2 T X (physIdx L b₁ f₁, physIdx b₂ R f₂) (physIdx L' c₁ f₁, physIdx c₂ R' f₂) =
+      if b₁ = b₂ ∧ c₁ = c₂ then
+        ∑ k : Fin 2, ((Cmat k L L' * tau k f₁ / 2 * (Cmat k b₂ c₂ * tau k f₂ / 2) : ℝ) : ℂ) *
+          X (physIdx R R' k) (physIdx L L' k)
+      else 0 := by
+  rw [physClose2_T]
+  by_cases h : b₁ = b₂ ∧ c₁ = c₂
+  · rw [ite_eq_left (show gate (physIdx L b₁ f₁) (physIdx b₂ R f₂) ∧
+      gate (physIdx L' c₁ f₁) (physIdx c₂ R' f₂) from ⟨by simp [gate, h.1], by simp [gate, h.2]⟩),
+      ite_eq_left h]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [coef_physIdx, coef_physIdx, ite_eq_left rfl, ite_eq_left rfl]
+    simp only [bitL_physIdx, bitR_physIdx]
+    push_cast
+    ring
+  · rw [ite_eq_right h]
+    refine ite_eq_right fun hc => ?_
+    exact absurd ⟨by simpa [gate] using hc.1, by simpa [gate] using hc.2⟩ h
+
+/-! ### The coarse-graining Kraus family -/
+
+/-- The support condition of the coarse-graining Kraus operators. -/
+def coarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) : Prop :=
+  ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
+    bitF j = f₁ + f₂ + bondShift v
+
+instance decidableCoarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
+    Decidable (coarseOK v f₁ f₂ j i) :=
+  inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ _))
+
+/-- The Kraus operator of the coarse-graining channel at the label
+$(v, f_1, f_2)$: it reads the bond pair in the basis vector `v`, requires the
+site flags $f_1, f_2$, and returns the one-site letter with the decoded flag. -/
+def coarseKraus (v : Fin 4) (f₁ f₂ : Fin 2) : Matrix (Fin 8) (Fin 8 × Fin 8) ℂ :=
+  Matrix.of fun j i =>
+    if coarseOK v f₁ f₂ j i then ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) else 0
+
+/-- The coarse-graining map, from two-site to one-site physical operators. -/
+def coarseMap :
+    Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ →ₗ[ℂ] Matrix (Fin 8) (Fin 8) ℂ :=
+  Matrix.rectangularKrausMap fun t : Fin 4 × Fin 2 × Fin 2 => coarseKraus t.1 t.2.1 t.2.2
+
+/-- The coarse-graining Kraus entries are real. -/
+lemma coarseKraus_star (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
+    star (coarseKraus v f₁ f₂ j i) = coarseKraus v f₁ f₂ j i := by
+  simp only [coarseKraus, Matrix.of_apply]
+  split_ifs
+  · exact Complex.conj_ofReal _
+  · exact star_zero _
+
+/-- Contracting a coarse-graining Kraus operator against a two-site vector
+sums over the bond bits of its fibre. -/
+lemma coarseKraus_row_sum (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * g i) =
+      if bitF j = f₁ + f₂ + bondShift v then
+        ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+          g (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂)
+      else 0 := by
+  by_cases hf : bitF j = f₁ + f₂ + bondShift v
+  · rw [ite_eq_left hf]
+    have hcongr : ∀ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * g i =
+        if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
+          ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) * g i else 0 := by
+      intro i
+      simp only [coarseKraus, Matrix.of_apply]
+      by_cases hi : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
+      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from ⟨hi, hf⟩), ite_eq_left hi]
+      · rw [ite_eq_right fun hc => hi hc.1, ite_eq_right hi, zero_mul]
+    rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
+    simp only [bitR_physIdx, bitL_physIdx]
+  · rw [ite_eq_right hf]
+    refine Finset.sum_eq_zero fun i _ => ?_
+    simp only [coarseKraus, Matrix.of_apply]
+    rw [ite_eq_right fun hc => hf hc.2, zero_mul]
+
+/-- One diagonal term of the coarse-graining resolution of the identity. -/
+lemma coarseKraus_res_term (v : Fin 4) (f₁ f₂ : Fin 2) (i i' : Fin 8 × Fin 8) :
+    (∑ j : Fin 8, star (coarseKraus v f₁ f₂ j i) * coarseKraus v f₁ f₂ j i') =
+      if ((bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧ (bitF i'.1 = f₁ ∧ bitF i'.2 = f₂)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2) then
+        ((bondVec v (bitR i.1) (bitL i.2) * bondVec v (bitR i'.1) (bitL i'.2) : ℝ) : ℂ)
+      else 0 := by
+  by_cases h : ((bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧ (bitF i'.1 = f₁ ∧ bitF i'.2 = f₂)) ∧
+      (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)
+  · rw [ite_eq_left h]
+    have hcongr : ∀ j : Fin 8, star (coarseKraus v f₁ f₂ j i) * coarseKraus v f₁ f₂ j i' =
+        if bitF j = f₁ + f₂ + bondShift v ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2 then
+          ((bondVec v (bitR i.1) (bitL i.2) * bondVec v (bitR i'.1) (bitL i'.2) : ℝ) : ℂ)
+        else 0 := by
+      intro j
+      rw [coarseKraus_star]
+      simp only [coarseKraus, Matrix.of_apply]
+      by_cases hj : bitF j = f₁ + f₂ + bondShift v ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
+      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from
+          ⟨⟨⟨h.1.1.1, hj.2.1.symm⟩, h.1.1.2, hj.2.2.symm⟩, hj.1⟩),
+          ite_eq_left (show coarseOK v f₁ f₂ j i' from
+          ⟨⟨⟨h.1.2.1, (hj.2.1.trans h.2.1).symm⟩, h.1.2.2, (hj.2.2.trans h.2.2).symm⟩, hj.1⟩),
+          ← Complex.ofReal_mul, ite_eq_left hj]
+      · have hz : ¬ coarseOK v f₁ f₂ j i := fun hc =>
+          hj ⟨hc.2, hc.1.1.2.symm, hc.1.2.2.symm⟩
+        rw [ite_eq_right hz, zero_mul, ite_eq_right hj]
+    rw [Finset.sum_congr rfl fun j _ => hcongr j]
+    exact one_site_fiber_sum _ _ _ _
+  · rw [ite_eq_right h]
+    refine Finset.sum_eq_zero fun j _ => ?_
+    rw [coarseKraus_star]
+    simp only [coarseKraus, Matrix.of_apply]
+    by_cases h1 : coarseOK v f₁ f₂ j i
+    · by_cases h2 : coarseOK v f₁ f₂ j i'
+      · exact absurd ⟨⟨⟨h1.1.1.1, h1.1.2.1⟩, h2.1.1.1, h2.1.2.1⟩,
+          h1.1.1.2.trans h2.1.1.2.symm, h1.1.2.2.trans h2.1.2.2.symm⟩ h
+      · rw [ite_eq_right h2, mul_zero]
+    · rw [ite_eq_right h1, zero_mul]
+
+/-- Summing over the Kraus labels whose flags are prescribed leaves a sum over
+the bond outcome. -/
+lemma sum_bond_selector (F₁ F₂ : Fin 2) (V : Fin 4 × Fin 2 × Fin 2 → ℂ) :
+    (∑ t : Fin 4 × Fin 2 × Fin 2, if t.2.1 = F₁ ∧ t.2.2 = F₂ then V t else 0) =
+      ∑ v : Fin 4, V (v, F₁, F₂) := by
+  fin_cases F₁ <;> fin_cases F₂ <;>
+    simp [Fintype.sum_prod_type, Fin.sum_univ_four, Fin.sum_univ_two]
+
+/-- **The coarse-graining Kraus family resolves the identity.** -/
+theorem coarseKraus_resolution :
+    ∑ t : Fin 4 × Fin 2 × Fin 2,
+        (coarseKraus t.1 t.2.1 t.2.2)ᴴ * coarseKraus t.1 t.2.1 t.2.2 =
+      (1 : Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ) := by
+  ext i i'
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ => coarseKraus_res_term t.1 t.2.1 t.2.2 i i']
+  by_cases hb : (bitF i.1 = bitF i'.1 ∧ bitF i.2 = bitF i'.2) ∧
+      (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)
+  · have hiff : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ((((bitF i.1 = t.2.1 ∧ bitF i.2 = t.2.2) ∧ (bitF i'.1 = t.2.1 ∧ bitF i'.2 = t.2.2)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)) ↔
+            (t.2.1 = bitF i.1 ∧ t.2.2 = bitF i.2)) := by
+      intro t
+      constructor
+      · rintro ⟨⟨⟨h1, h2⟩, _⟩, _⟩
+        exact ⟨h1.symm, h2.symm⟩
+      · rintro ⟨h1, h2⟩
+        exact ⟨⟨⟨h1.symm, h2.symm⟩, by rw [← hb.1.1, h1], by rw [← hb.1.2, h2]⟩, hb.2⟩
+    simp only [hiff]
+    rw [sum_bond_selector, ← Complex.ofReal_sum, bondVec_completeness, Matrix.one_apply]
+    by_cases hc : bitR i.1 = bitR i'.1 ∧ bitL i.2 = bitL i'.2
+    · rw [ite_eq_left hc, ite_eq_left (show i = i' from Prod.ext
+        (eq_of_bits hb.2.1 hc.1 hb.1.1) (eq_of_bits hc.2 hb.2.2 hb.1.2))]
+      norm_num
+    · rw [ite_eq_right hc, ite_eq_right (show ¬ i = i' from fun hii => hc
+        ⟨by rw [hii], by rw [hii]⟩)]
+      norm_num
+  · have hzero : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ¬ (((bitF i.1 = t.2.1 ∧ bitF i.2 = t.2.2) ∧ (bitF i'.1 = t.2.1 ∧ bitF i'.2 = t.2.2)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)) := by
+      rintro t ⟨⟨⟨h1, h2⟩, h1', h2'⟩, h3⟩
+      exact hb ⟨⟨h1.trans h1'.symm, h2.trans h2'.symm⟩, h3⟩
+    rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero,
+      Matrix.one_apply]
+    refine (ite_eq_right fun hii => ?_).symm
+    exact absurd ⟨⟨by rw [hii], by rw [hii]⟩, by rw [hii], by rw [hii]⟩ hb
+
+/-- **The coarse-graining map is trace-preserving completely positive.** -/
+theorem coarseMap_isKrausCPTP : IsKrausCPTP coarseMap :=
+  Matrix.rectangularKrausMap_isKrausCPTP _ coarseKraus_resolution
+
+/-! ### The coarse-graining map on the physical closures -/
+
+/-- One Kraus term of the coarse-graining map, evaluated at a pair of one-site
+letters. -/
+lemma coarseKraus_conj_term (v : Fin 4) (f₁ f₂ : Fin 2) (X : Matrix (Fin 8) (Fin 8) ℂ)
+    (j j' : Fin 8) :
+    (∑ i' : Fin 8 × Fin 8, (∑ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * physClose2 T X i i') *
+        star (coarseKraus v f₁ f₂ j' i')) =
+      if bitF j = f₁ + f₂ + bondShift v ∧ bitF j' = f₁ + f₂ + bondShift v then
+        ∑ k : Fin 2, ((coarseWeight v k f₁ f₂ (bitL j) (bitL j') : ℝ) : ℂ) *
+          X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k)
+      else 0 := by
+  rw [Finset.sum_congr rfl fun i' _ => by
+    rw [coarseKraus_row_sum v f₁ f₂ j fun i => physClose2 T X i i']]
+  by_cases hj : bitF j = f₁ + f₂ + bondShift v
+  · rw [Finset.sum_congr rfl fun i' _ => by rw [ite_eq_left hj]]
+    have hswap : ∀ (W : Fin 2 → Fin 2 → Fin 8 × Fin 8 → ℂ) (S : Fin 8 × Fin 8 → ℂ),
+        (∑ i' : Fin 8 × Fin 8, (∑ b₁ : Fin 2, ∑ b₂ : Fin 2, W b₁ b₂ i') * S i') =
+          ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, ∑ i' : Fin 8 × Fin 8, W b₁ b₂ i' * S i' := by
+      intro W S
+      simp_rw [Finset.sum_mul]
+      rw [Finset.sum_comm]
+      exact Finset.sum_congr rfl fun b₁ _ => Finset.sum_comm
+    rw [hswap (fun b₁ b₂ i' => ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+      physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i')
+      fun i' => star (coarseKraus v f₁ f₂ j' i')]
+    have hinner : ∀ b₁ b₂ : Fin 2,
+        (∑ i' : Fin 8 × Fin 8, ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+            physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i' *
+            star (coarseKraus v f₁ f₂ j' i')) =
+          ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+            (if bitF j' = f₁ + f₂ + bondShift v then
+              ∑ c₁ : Fin 2, ∑ c₂ : Fin 2, ((bondVec v c₁ c₂ : ℝ) : ℂ) *
+                physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂)
+                  (physIdx (bitL j') c₁ f₁, physIdx c₂ (bitR j') f₂)
+            else 0) := by
+      intro b₁ b₂
+      have hterm : ∀ i' : Fin 8 × Fin 8,
+          ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+              physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i' *
+              star (coarseKraus v f₁ f₂ j' i') =
+            ((bondVec v b₁ b₂ : ℝ) : ℂ) * (coarseKraus v f₁ f₂ j' i' *
+              physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i') := by
+        intro i'
+        rw [coarseKraus_star]
+        ring
+      rw [Finset.sum_congr rfl fun i' _ => hterm i', ← Finset.mul_sum,
+        coarseKraus_row_sum v f₁ f₂ j' fun i' =>
+          physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i']
+    rw [Finset.sum_congr rfl fun b₁ _ => Finset.sum_congr rfl fun b₂ _ => hinner b₁ b₂]
+    by_cases hj' : bitF j' = f₁ + f₂ + bondShift v
+    · rw [ite_eq_left ⟨hj, hj'⟩]
+      simp only [ite_eq_left hj', physClose2_T_fiber, coarseWeight, Fin.sum_univ_two]
+      norm_num
+      ring
+    · rw [ite_eq_right fun hc => hj' hc.2]
+      simp [ite_eq_right hj']
+  · rw [ite_eq_right fun hc => hj hc.1]
+    refine Finset.sum_eq_zero fun i' _ => ?_
+    rw [ite_eq_right hj, zero_mul]
+
+/-- **The coarse-graining map carries the two-site physical closure of the
+twisted dimer back to its one-site physical closure.**  Together with
+`coarseMap_isKrausCPTP`, this is the map `S` of arXiv:1606.00608,
+Definition 4.1 (paper label eq:Smap). -/
+theorem coarseMap_physClose2 (X : Matrix (Fin 8) (Fin 8) ℂ) :
+    coarseMap (physClose2 T X) = physClose1 T X := by
+  ext j j'
+  change (∑ t : Fin 4 × Fin 2 × Fin 2, coarseKraus t.1 t.2.1 t.2.2 * physClose2 T X *
+      (coarseKraus t.1 t.2.1 t.2.2)ᴴ) j j' = _
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ => coarseKraus_conj_term t.1 t.2.1 t.2.2 X j j', physClose1_T]
+  by_cases e : bitF j = bitF j'
+  · have hiff : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ((bitF j = t.2.1 + t.2.2 + bondShift t.1 ∧ bitF j' = t.2.1 + t.2.2 + bondShift t.1) ↔
+          (t.2.1 + t.2.2 + bondShift t.1 = bitF j)) := by
+      intro t
+      exact ⟨fun h => h.1.symm, fun h => ⟨h.symm, e ▸ h.symm⟩⟩
+    simp only [hiff]
+    have hdist : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        (if t.2.1 + t.2.2 + bondShift t.1 = bitF j then
+            ∑ k : Fin 2, ((coarseWeight t.1 k t.2.1 t.2.2 (bitL j) (bitL j') : ℝ) : ℂ) *
+              X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k)
+          else 0) =
+          ∑ k : Fin 2,
+            ((if t.2.1 + t.2.2 + bondShift t.1 = bitF j then
+              coarseWeight t.1 k t.2.1 t.2.2 (bitL j) (bitL j') else 0 : ℝ) : ℂ) *
+              X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k) := by
+      intro t
+      by_cases hc : t.2.1 + t.2.2 + bondShift t.1 = bitF j
+      · simp only [ite_eq_left hc]
+      · simp [hc]
+    rw [Finset.sum_congr rfl fun t _ => hdist t, Finset.sum_comm]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [← Finset.sum_mul, ← Complex.ofReal_sum, coarseWeight_sum, coef, ite_eq_left e]
+  · have hzero : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ¬ (bitF j = t.2.1 + t.2.2 + bondShift t.1 ∧ bitF j' = t.2.1 + t.2.2 + bondShift t.1) := by
+      rintro t ⟨h1, h2⟩
+      exact e (h1.trans h2.symm)
+    rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero]
+    refine (Finset.sum_eq_zero fun k _ => ?_).symm
+    rw [coef, ite_eq_right e, zero_mul]
+
+/-- **The $\mathbb Z_2$-twisted quantum dimer is a renormalization fixed
+point.**  The coarse-graining map and the refinement map are the
+trace-preserving completely positive maps `S` and `T` of arXiv:1606.00608,
+Definition 4.1 (paper label RFPMixedTS, line 657).  The tensor is a project
+example, not a tensor stated in the source. -/
+theorem isRFPViaTS_T : IsRFPViaTS T :=
+  ⟨coarseMap, refineMap, coarseMap_isKrausCPTP, refineMap_isKrausCPTP,
+    coarseMap_physClose2, refineMap_physClose1⟩
+
+end MPOTensor.TwistedDimer

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -825,6 +825,80 @@
     nonnegative multiples, and pullbacks along an arbitrary reindexing.
 \end{proof}
 
+\begin{theorem}[The twisted quantum dimer is a renormalization fixed point]%
+    \label{thm:mpdo_twisted_dimer_is_rfp_via_ts}
+    \lean{MPOTensor.TwistedDimer.refineMap}
+    \lean{MPOTensor.TwistedDimer.refineMap_isKrausCPTP}
+    \lean{MPOTensor.TwistedDimer.refineMap_physClose1}
+    \lean{MPOTensor.TwistedDimer.coarseMap}
+    \lean{MPOTensor.TwistedDimer.coarseMap_isKrausCPTP}
+    \lean{MPOTensor.TwistedDimer.coarseMap_physClose2}
+    \lean{MPOTensor.TwistedDimer.isRFPViaTS_T}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    The twisted quantum dimer of
+    Definition~\ref{def:mpdo_twisted_dimer_tensor} is a renormalization fixed
+    point in the sense of Definition~\ref{def:is_rfp_via_ts}. The refinement
+    map $\mathcal T$ has eight Kraus operators, labelled by the two prepared
+    site flags $f_1, f_2$ and a bond label $\varepsilon$: it prepares those two
+    flags on the output sites together with the bond state
+    $(\ket{00}+(-1)^\varepsilon\ket{11})/\sqrt2$ on the bond they share, with
+    weight $x$ for $\varepsilon=0$ and $y$ for $\varepsilon=1$, and is
+    supported on the incoming flag $f=f_1+f_2+\varepsilon$. The
+    coarse-graining map $\mathcal S$ has sixteen Kraus operators, labelled by a
+    member of the orthonormal bond basis $(\ket{00}\pm\ket{11})/\sqrt2$,
+    $\ket{01}$, $\ket{10}$ together with the two site flags: it measures the
+    shared bond pair in that basis, reads the two flags, and returns the letter
+    carrying the outer site qubits and the flag $f_1+f_2+s$, where $s$ is one
+    for the antisymmetric bond outcome and zero otherwise. The tensor is a
+    project example motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    Fix a one-site letter $(l,r,f)$. The two-site letters in the support of a
+    refinement Kraus operator carry the outer bits $l$ and $r$, the two
+    prepared flags, and a free shared bond bit, so each of the four labels with
+    $f_1+f_2+\varepsilon=f$ contributes twice the squared amplitude
+    $w_\varepsilon/4$, where $w_0=x$ and $w_1=y$; two of the four labels carry
+    each value of $\varepsilon$, and the total is $x+y=1$. Supports belonging
+    to distinct one-site letters are disjoint, so the off-diagonal entries
+    vanish and the family resolves the identity. For the intertwining relation,
+    the flag signs multiply as
+    $(\tau_k)_{f_1f_1}(\tau_k)_{f_2f_2}=(\tau_k)_{gg}$ with $g=f_1+f_2$, and
+    the two prepared bond states reassemble the bond matrices through
+    \begin{align}
+        \frac{x}{4}+(-1)^{b+b'}\frac{y}{4} & =\frac12\,C_0[b,b'], &
+        \frac{x}{4}-(-1)^{b+b'}\frac{y}{4} & =\frac12\,C_1[b,b'],
+        \notag
+    \end{align}
+    for the two shared bond bits $b, b'$ of the two arguments; this is exactly
+    the coefficient of the two-site closure displayed in
+    Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
+
+    For the coarse-graining map, orthonormality of the bond basis and of the
+    pair of site flags gives the resolution of the identity: summing over the
+    bond basis identifies the two bond bits of the two arguments, and summing
+    over the flag labels identifies their flags, so all six bits of the two
+    two-site letters agree. On the support of the two-site closure the two bond
+    qubits of each argument agree, so the outcomes $\ket{01}$ and $\ket{10}$
+    contribute nothing and the two symmetric outcomes contribute
+    $\frac12(\pm1)^{b+b'}$. Summing over the two flag pairs compatible with the
+    decoded flag leaves, for each block label $k$, the single identity
+    \begin{align}
+        \frac12\Bigl(\sum_{b,b'}C_k[b,b']
+        +(\tau_k)_{11}\sum_{b,b'}(-1)^{b+b'}C_k[b,b']\Bigr) & =1,
+        \notag
+    \end{align}
+    whose left side is $\frac12\bigl(\frac74+\frac14\bigr)=1$ in both cases:
+    for $k=0$ the alternating sum is $\frac14$ and the flag sign is $1$, and
+    for $k=1$ it is $-\frac14$ and the flag sign is $-1$. The remaining factor
+    is the one-site coefficient
+    $\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$ of
+    Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
+\end{proof}
+
 \begin{theorem}[A candidate two-label coefficient family stable under every
         positive rescaling]%
     \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -763,6 +763,68 @@
     $k=1$.
 \end{proof}
 
+\begin{theorem}[Positivity of the twisted quantum dimer]%
+    \label{thm:mpdo_twisted_dimer_ismpdo}
+    \lean{MPOTensor.TwistedDimer.mpo_T_entry_formula}
+    \lean{MPOTensor.TwistedDimer.mpo_T_eq_smul_hadamard}
+    \lean{MPOTensor.TwistedDimer.T_isMPDO}
+    \leanok
+    \uses{def:mpdo, def:mpdo_twisted_dimer_tensor,
+        thm:mpdo_twisted_dimer_closures}
+    The closed operator $\rho^{(N)}$ of the twisted quantum dimer is positive
+    semidefinite for every positive chain length $N$: the twisted dimer is an
+    MPDO. Writing $l_n$, $r_n$, $f_n$ for the three bits of the $n$-th letter
+    of a physical string $\sigma$ and likewise for $\tau$, the matrix element
+    is
+    \begin{align}
+        \rho^{(N)}_{\sigma\tau}
+         & =\frac1{2^N}\,
+        \mathbb 1[\text{cyclic bond match}](\sigma,\tau)\,
+        \delta_{f f'}\left(\prod_{n}C_0[l_n,l'_n]
+            +(-1)^{\lvert f\rvert}\prod_{n}C_1[l_n,l'_n]\right),
+        \notag
+    \end{align}
+    where the indicator is one exactly when both $\sigma$ and $\tau$ match
+    their bond bits around the ring, $\delta_{ff'}$ is one exactly when the two
+    flag strings agree, and $\lvert f\rvert$ is the number of sites carrying
+    flag one. So $\rho^{(N)}$ is $2^{-N}$ times the Hadamard product of the
+    rank-one bond-matching indicator with the pullback, along the flag and left
+    bits, of the sum of the $N$-fold Kronecker powers of the two local
+    four-by-four factors $g_k[(f,l),(f',l')]=\delta_{ff'}\,C_k[l,l']\,
+        (\tau_k)_{ff}$, and the Schur product theorem gives positivity.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    Each letter is a sum of two matrix units, one per block label, so an
+    ordered product of letters keeps a common block label and vanishes unless
+    consecutive letters match on their bond bits; the surviving product is a
+    single matrix unit whose row is read off the left bits of the first letters
+    and whose column off the right bits of the last letters. Taking the trace
+    imposes the wraparound match, which completes the segment condition to the
+    cyclic one, and leaves the sum over the block label of the product of the
+    one-site coefficients. That coefficient is half of $g_k$ evaluated at the
+    flag and left bits, so the product along the ring is $2^{-N}$ times an
+    entry of the $N$-fold Kronecker power of $g_k$.
+
+    Neither the sum nor the difference of the two Kronecker powers is a
+    Kronecker power, so both are proved positive semidefinite together by
+    induction on the chain length. Peeling the last site off the ring gives
+    \begin{align}
+        g_0^{\otimes(N+1)}\pm g_1^{\otimes(N+1)}
+         & =\frac12\Bigl[
+            \bigl(g_0^{\otimes N}+g_1^{\otimes N}\bigr)\otimes(g_0\pm g_1)
+            +\bigl(g_0^{\otimes N}-g_1^{\otimes N}\bigr)\otimes(g_0\mp g_1)
+        \Bigr],
+        \notag
+    \end{align}
+    and both local combinations are positive semidefinite: each is block
+    diagonal in the flag bit, with $C_0+C_1=\frac74P_+$ in one flag sector
+    and $C_0-C_1=\frac14P_-$ in the other, the two sectors being exchanged
+    between the sum and the difference. A Kronecker product of positive
+    semidefinite matrices is positive semidefinite, and so are sums,
+    nonnegative multiples, and pullbacks along an arbitrary reindexing.
+\end{proof}
+
 \begin{theorem}[A candidate two-label coefficient family stable under every
         positive rescaling]%
     \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -876,11 +876,24 @@
     the coefficient of the two-site closure displayed in
     Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
 
-    For the coarse-graining map, orthonormality of the bond basis and of the
-    pair of site flags gives the resolution of the identity: summing over the
-    bond basis identifies the two bond bits of the two arguments, and summing
-    over the flag labels identifies their flags, so all six bits of the two
-    two-site letters agree. On the support of the two-site closure the two bond
+    For the coarse-graining map, write $B_v(b_1,b_2)$ for the amplitude of
+    the bond-basis vector $v$ at $(b_1,b_2)$. Its orthonormality gives
+    \begin{align}
+        \sum_v B_v(b_1,b_2)B_v(c_1,c_2)
+         & =\delta_{b_1c_1}\delta_{b_2c_2}.
+        \notag
+    \end{align}
+    The corresponding selector sum over the two site flags is
+    \begin{align}
+        \sum_{f_1,f_2}
+        \delta_{f_1F_1}\delta_{f_2F_2}
+        \delta_{f_1F'_1}\delta_{f_2F'_2}
+         & =\delta_{F_1F'_1}\delta_{F_2F'_2}.
+        \notag
+    \end{align}
+    These two identities identify all six bits of the two two-site letters and
+    give the resolution of the identity. On the support of the two-site closure
+    the two bond
     qubits of each argument agree, so the outcomes $\ket{01}$ and $\ket{10}$
     contribute nothing and the two symmetric outcomes contribute
     $\frac12(\pm1)^{b+b'}$. Summing over the two flag pairs compatible with the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -834,7 +834,7 @@
     \lean{MPOTensor.TwistedDimer.coarseMap_physClose2}
     \lean{MPOTensor.TwistedDimer.isRFPViaTS_T}
     \leanok
-    \uses{def:is_rfp_via_ts, def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    \uses{def:is_rfp_via_ts, def:mpdo_twisted_dimer_tensor}
     The twisted quantum dimer of
     Definition~\ref{def:mpdo_twisted_dimer_tensor} is a renormalization fixed
     point in the sense of Definition~\ref{def:is_rfp_via_ts}. The refinement

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -781,7 +781,7 @@
          & =\frac1{2^N}\,
         \mathbb 1[\text{cyclic bond match}](\sigma,\tau)\,
         \delta_{f f'}\left(\prod_{n}C_0[l_n,l'_n]
-            +(-1)^{\lvert f\rvert}\prod_{n}C_1[l_n,l'_n]\right),
+        +(-1)^{\lvert f\rvert}\prod_{n}C_1[l_n,l'_n]\right),
         \notag
     \end{align}
     where the indicator is one exactly when both $\sigma$ and $\tau$ match
@@ -814,7 +814,7 @@
          & =\frac12\Bigl[
             \bigl(g_0^{\otimes N}+g_1^{\otimes N}\bigr)\otimes(g_0\pm g_1)
             +\bigl(g_0^{\otimes N}-g_1^{\otimes N}\bigr)\otimes(g_0\mp g_1)
-        \Bigr],
+            \Bigr],
         \notag
     \end{align}
     and both local combinations are positive semidefinite: each is block

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -769,8 +769,7 @@
     \lean{MPOTensor.TwistedDimer.mpo_T_eq_smul_hadamard}
     \lean{MPOTensor.TwistedDimer.T_isMPDO}
     \leanok
-    \uses{def:mpdo, def:mpdo_twisted_dimer_tensor,
-        thm:mpdo_twisted_dimer_closures}
+    \uses{def:mpdo, def:mpdo_twisted_dimer_tensor}
     The closed operator $\rho^{(N)}$ of the twisted quantum dimer is positive
     semidefinite for every positive chain length $N$: the twisted dimer is an
     MPDO. Writing $l_n$, $r_n$, $f_n$ for the three bits of the $n$-th letter
@@ -794,7 +793,7 @@
         (\tau_k)_{ff}$, and the Schur product theorem gives positivity.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    \uses{def:mpdo_twisted_dimer_tensor}
     Each letter is a sum of two matrix units, one per block label, so an
     ordered product of letters keeps a common block label and vanishes unless
     consecutive letters match on their bond bits; the surviving product is a

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -562,6 +562,33 @@ The following notions use different transfer objects and are not interchangeable
   is distinct from pure MPS RFP, doubled-index transfer idempotence, and every
   physical-trace ZCL condition below.
 
+### Twisted-dimer matching and channel-support predicates
+
+- **Declarations:** `MPOTensor.TwistedDimer.IsOpenBondMatched` and
+  `MPOTensor.TwistedDimer.IsCyclicBondMatched` in
+  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean`, and
+  `MPOTensor.TwistedDimer.IsRefineSupported` and
+  `MPOTensor.TwistedDimer.IsCoarseSupported` in
+  `TNLean/MPS/MPDO/TwistedDimerRefine.lean` and
+  `TNLean/MPS/MPDO/TwistedDimerViaTS.lean`.
+- **Meaning:** the first two predicates require consecutive physical letters to
+  match their right and left bond bits on an open segment or around a ring. The
+  latter two specify the matrix entries supporting the refinement and
+  coarse-graining Kraus operators, including their outer bits, site flags, and
+  decoded flag.
+- **Source:** project-specific coordinate conditions for the twisted-dimer
+  example. They support the explicit realization of CPSV16 Definition 4.1 but
+  are not predicates stated in arXiv:1606.00608.
+- **Sanctioned bridges:** `isOpenBondMatched_succ` peels the first open bond,
+  `isCyclicBondMatched_succ` separates the wraparound bond, and
+  `isRefineSupported_iff_col` identifies the unique one-site fibre. The Kraus
+  definitions use the two support predicates directly; the resulting public
+  conclusions are `refineMap_physClose1`, `coarseMap_physClose2`, and
+  `isRFPViaTS_T`.
+- **Caveat:** these are proof coordinates for this one tensor, not alternative
+  definitions of `MPOTensor.IsRFPViaTS`. They imply no simplicity,
+  basis-of-normal-tensors fusion law, or coefficient attachment.
+
 ### One-letter blocking up to virtual gauge
 
 - **Declarations:** `MPOTensor.IsOneLetterRFPViaTSUpToVirtualGauge M` and

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2136,6 +2136,31 @@ spectral split → block extraction → MPV calculation → strict bounds
   and the earlier theorem is private, so neither can reuse the other without an
   API change. This remains below the rule-of-three promotion threshold.
 
+### closed-chain Schur factorization of a matrix product operator — candidate
+- **Pattern:** prove positivity of the operator generated on a ring by an
+  explicit tensor by (i) defining the cyclic bond-matching condition together
+  with its rank-one indicator matrix, proved positive semidefinite as an outer
+  product of the indicator vector with itself; (ii) proving an entrywise
+  closed-chain formula in which the indicator multiplies a product of one-site
+  factors; (iii) proving that the corresponding Kronecker power is positive
+  semidefinite by induction, peeling the last site off with the
+  last-coordinate equivalence and using that a Kronecker product of positive
+  semidefinite matrices is positive semidefinite; and (iv) assembling with the
+  Schur product theorem and a nonnegative scalar.
+- **Seen:** 2 occurrences: `R_isMPDO` in
+  `TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean` and `T_isMPDO` in
+  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean` (2026-09-02).  The one-step rotation
+  identity for the cyclic successor is also proved in both files.
+- **Abstraction (proposed):** if a third such tensor appears, extract a
+  positivity criterion parameterized by the local bond-matching relation and
+  the local factor, together with the cyclic-successor identity, and specialize
+  the existing proofs to it.
+- **Notes:** the two current instances differ in the shape of the local factor
+  (a single two-by-two matrix against a sum of two four-by-four Kronecker
+  powers proved positive semidefinite together with their difference), so a
+  common criterion would have to abstract over that as well.  Below the
+  rule-of-three promotion threshold.
+
 ---
 
 ## Rejected

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -813,6 +813,15 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Successor under one-step finite rotation
+- **Pattern:** both closed-chain MPO calculations proved that `finRotate (N + 1)`
+  sends `i.castSucc`, for `i : Fin N`, to `i.succ` by the same cast-heavy
+  specialization of `finRotate_of_lt`.
+- **Reuse:** `Fin.finRotate_succ_castSucc` in
+  `TNLean/Algebra/FinCyclicInduction.lean` is the shared finite-index lemma.
+- **Result:** the public example-specific lemma and the duplicated local proof
+  are removed; both closed-chain calculations use the algebra lemma.
+
 ### Full support across tensor-equality casts
 - **Pattern:** `PhysicalAncilla.lean` and `TensorProductCanonicalForm.lean` each
   carried the same local proof that casting canonical-form-II witness data along
@@ -2169,12 +2178,10 @@ spectral split → block extraction → MPV calculation → strict bounds
   Schur product theorem and a nonnegative scalar.
 - **Seen:** 2 occurrences: `R_isMPDO` in
   `TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean` and `T_isMPDO` in
-  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean` (2026-09-02).  The one-step rotation
-  identity for the cyclic successor is also proved in both files.
+  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean` (2026-09-02).
 - **Abstraction (proposed):** if a third such tensor appears, extract a
   positivity criterion parameterized by the local bond-matching relation and
-  the local factor, together with the cyclic-successor identity, and specialize
-  the existing proofs to it.
+  the local factor, and specialize the existing proofs to it.
 - **Notes:** the two current instances differ in the shape of the local factor
   (a single two-by-two matrix against a sum of two four-by-four Kronecker
   powers proved positive semidefinite together with their difference), so a

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -789,6 +789,26 @@ abstracted — record why, so it is not re-proposed).
   five-line term. Net source delta over the four sites: −69 lines against +37
   for the lemma.
 
+### bit-indexed Kraus support fibre sums — promoted
+- **Pattern:** a Kraus operator supported on the indicator of a condition
+  prescribing some bits of a bit-encoded physical index; a sum against it is
+  rewritten into the indicator of the fibre condition by `ite_eq_left` /
+  `ite_eq_right` under `Finset.sum_congr`, and the fibre sum is then collapsed
+  to the single index (all bits prescribed) or to a sum over the free bits.
+- **Seen:** four occurrences across two files (2026-09-02):
+  `MPS/MPDO/TwistedDimerRefine.lean` (`refineKraus_col_sum`, `refineKraus_row_sum`) and
+  `MPS/MPDO/TwistedDimerViaTS.lean` (`coarseKraus_row_sum`, `coarseKraus_res_term`).
+- **Abstraction:** `MPOTensor.TwistedDimer.one_site_fiber_sum`,
+  `left_fiber_sum`, `right_fiber_sum`, and `pair_fiber_sum` in
+  `TNLean/MPS/MPDO/TwistedDimerRefine.lean`, all stated for an arbitrary
+  summand so that each caller supplies its own Kraus amplitude and contracted
+  vector.
+- **Notes:** the pair version is proved from the two one-index versions rather
+  than by expanding sixty-four terms, which keeps its proof independent of the
+  prescribed bits. The one-index versions are proved by transporting the sum
+  along the bit encoding (`sum_fin_eight`) and deciding the eight resulting
+  cases.
+
 ---
 
 ## Completed refactors


### PR DESCRIPTION
## Summary

Completes the positivity and Definition 4.1 fixed-point steps of #7611 on top of the tensor formulas merged in #7612. The combined branch proves that the twisted quantum dimer produces positive semidefinite closed operators at every positive length and supplies explicit trace-preserving completely positive refinement and coarse-graining maps.

* `TNLean/MPS/MPDO/TwistedDimerMPDO.lean`: proves the open-chain product formula, the all-positive-length closed-chain entry formula, a Schur factorization through the cyclic bond-matching indicator, and `T_isMPDO : IsMPDO T`.
* `TNLean/MPS/MPDO/TwistedDimerRefine.lean`: constructs the eight-Kraus refinement map, proves its identity resolution and trace-preserving complete positivity, and proves that it carries the one-site physical closure of `T` to its two-site closure.
* `TNLean/MPS/MPDO/TwistedDimerViaTS.lean`: constructs the sixteen-Kraus coarse-graining map, proves the reverse closure identity, and concludes `isRFPViaTS_T : IsRFPViaTS T`.
* The generic finite-rotation identity is shared as `Fin.finRotate_succ_castSucc`; both closed-chain examples use it. The Blueprint records the positivity and fixed-point theorems with statement and proof dependencies separated accurately.

The claims remain limited to the proved tensor `MPOTensor.TwistedDimer.T`, its closed-operator positivity, and its Definition 4.1 channels. The PR does not identify the candidate two-label coefficients with tensor-attached BNT fusion data and does not assert non-simplicity or the stronger rescaling obstruction for this tensor.

## Verification

* Full `lake build`: 10472 jobs.
* `lake build TNLean.MPS.MPDO`: 9651 jobs, with no warnings in the changed modules.
* Generated imports, numbered-file, oversized-file, forbidden-token, import-syntax, and reader-facing prose checks pass.
* Strict Blueprint sync and `leanblueprint checkdecls` pass; double LuaLaTeX has no undefined cross-references.
* `#print axioms` for `T_isMPDO` and `isRFPViaTS_T` reports only `propext`, `Classical.choice`, and `Quot.sound`.

Advances #7611.
