### PR TITLE
feat(mpdo): prove the twisted dimer is a renormalization fixed point

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -327,6 +327,8 @@ import TNLean.MPS.MPDO.TopologicalTerminalSpectral
 import TNLean.MPS.MPDO.TwistedDimer
 import TNLean.MPS.MPDO.TwistedDimerCoefficients
 import TNLean.MPS.MPDO.TwistedDimerMPDO
+import TNLean.MPS.MPDO.TwistedDimerRefine
+import TNLean.MPS.MPDO.TwistedDimerViaTS
 import TNLean.MPS.MPDO.TwoSitePrefixReflectedMarkedChain
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalBNT

--- a/TNLean/MPS/MPDO/TwistedDimerRefine.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerRefine.lean
@@ -1,0 +1,443 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimer
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# The refinement channel of the twisted quantum dimer
+
+**Scope: the refinement map only.** This file continues
+`TNLean.MPS.MPDO.TwistedDimer` and builds the first of the two
+trace-preserving completely positive maps required by the renormalization
+fixed-point condition of arXiv:1606.00608, Definition 4.1: a map carrying the
+one-site physical closure of the twisted quantum dimer to its two-site
+physical closure.  The tensor is a project example motivated by the
+length-dependence question after Theorem 4.14 of that paper (lines 995--1010);
+it is not a tensor stated in the source.  The coarse-graining map in the
+opposite direction, and the resulting fixed-point statement, are in
+`TNLean.MPS.MPDO.TwistedDimerViaTS`.
+
+## The refinement channel
+
+Reading a physical index as a pair of site qubits together with a flag qubit,
+the refinement map measures the incoming flag, prepares a fresh pair of flags
+$(f_1, f_2)$ and a fresh bond qubit in one of the two states
+$(|00\rangle \pm |11\rangle)/\sqrt2$, and returns the two-site letter whose bond
+qubits carry the prepared bond state.  The two bond states are prepared with
+the weights $x = 7/8$ and $y = 1/8$, and the incoming flag is constrained to
+$f_1 + f_2 + \varepsilon$, where $\varepsilon$ labels the prepared bond state.
+The resulting Kraus family is indexed by $(f_1, f_2, \varepsilon)$.
+
+## Main results
+
+* `pair_fiber_sum` — the fibre of a two-site letter over prescribed flags and
+  outer bits is a square of bond bits;
+* `refineAmp_tau_sum` — the scalar identity behind the refinement channel: the
+  weighted sum of the two prepared bond states reproduces the bond matrices
+  $C_0$ and $C_1$ of the twisted dimer;
+* `refineKraus_resolution` — the refinement Kraus family resolves the identity;
+* `refineMap_isKrausCPTP` — the refinement map is trace-preserving completely
+  positive;
+* `refineMap_physClose1` — the refinement map carries the one-site physical
+  closure to the two-site physical closure.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 (lines 645--659) and Theorem 4.14 with lines 995--1010
+  (the twisted dimer is a project example, not a tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### Fibres of the bit encoding -/
+
+/-- A physical index is determined by its three bits. -/
+lemma eq_of_bits {i j : Fin 8} (hL : bitL i = bitL j) (hR : bitR i = bitR j)
+    (hF : bitF i = bitF j) : i = j := by
+  rw [← physIdx_bits i, ← physIdx_bits j, hL, hR, hF]
+
+/-- A sum over the physical index is a threefold sum over its bits. -/
+lemma sum_fin_eight (h : Fin 8 → ℂ) :
+    ∑ i : Fin 8, h i = ∑ a : Fin 2, ∑ b : Fin 2, ∑ c : Fin 2, h (physIdx a b c) := by
+  rw [← physEquiv.sum_comp h, Fintype.sum_prod_type]
+  simp only [Fintype.sum_prod_type]
+  rfl
+
+/-- **The fibre over all three bits is a single index.** -/
+lemma one_site_fiber_sum (F l r : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ j : Fin 8, if bitF j = F ∧ bitL j = l ∧ bitR j = r then h j else 0) =
+      h (physIdx l r F) := by
+  rw [sum_fin_eight]
+  fin_cases F <;> fin_cases l <;> fin_cases r <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre over the flag and the first bit is indexed by the second bit.** -/
+lemma left_fiber_sum (f l : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ i : Fin 8, if bitF i = f ∧ bitL i = l then h i else 0) =
+      ∑ b : Fin 2, h (physIdx l b f) := by
+  rw [sum_fin_eight]
+  fin_cases f <;> fin_cases l <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre over the flag and the second bit is indexed by the first bit.** -/
+lemma right_fiber_sum (f r : Fin 2) (h : Fin 8 → ℂ) :
+    (∑ i : Fin 8, if bitF i = f ∧ bitR i = r then h i else 0) =
+      ∑ b : Fin 2, h (physIdx b r f) := by
+  rw [sum_fin_eight]
+  fin_cases f <;> fin_cases r <;> simp [Fin.sum_univ_two]
+
+/-- **The fibre of a two-site letter over prescribed flags and outer bits is a
+square of bond bits.** -/
+lemma pair_fiber_sum (f₁ f₂ l r : Fin 2) (h : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8,
+        if (bitF i.1 = f₁ ∧ bitL i.1 = l) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = r) then h i else 0) =
+      ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, h (physIdx l b₁ f₁, physIdx b₂ r f₂) := by
+  rw [Fintype.sum_prod_type]
+  have step : ∀ i₁ : Fin 8,
+      (∑ i₂ : Fin 8, if (bitF i₁ = f₁ ∧ bitL i₁ = l) ∧ (bitF i₂ = f₂ ∧ bitR i₂ = r)
+          then h (i₁, i₂) else 0) =
+        if bitF i₁ = f₁ ∧ bitL i₁ = l then ∑ b₂ : Fin 2, h (i₁, physIdx b₂ r f₂) else 0 := by
+    intro i₁
+    by_cases hP : bitF i₁ = f₁ ∧ bitL i₁ = l
+    · rw [ite_eq_left hP]
+      rw [Finset.sum_congr rfl fun i₂ _ => (by simp [hP] :
+        (if (bitF i₁ = f₁ ∧ bitL i₁ = l) ∧ (bitF i₂ = f₂ ∧ bitR i₂ = r) then h (i₁, i₂) else 0) =
+          if bitF i₂ = f₂ ∧ bitR i₂ = r then h (i₁, i₂) else 0)]
+      exact right_fiber_sum f₂ r fun i₂ => h (i₁, i₂)
+    · rw [ite_eq_right hP]
+      exact Finset.sum_eq_zero fun i₂ _ => ite_eq_right fun hc => hP hc.1
+  rw [Finset.sum_congr rfl fun i₁ _ => step i₁]
+  exact left_fiber_sum f₁ l fun i₁ => ∑ b₂ : Fin 2, h (i₁, physIdx b₂ r f₂)
+
+/-- **The one-site physical closure in bit coordinates.** -/
+lemma physClose1_T_bits (X : Matrix (Fin 8) (Fin 8) ℂ) (L R F L' R' F' : Fin 2) :
+    physClose1 T X (physIdx L R F) (physIdx L' R' F') =
+      if F = F' then
+        ∑ k : Fin 2, ((Cmat k L L' * tau k F / 2 : ℝ) : ℂ) *
+          X (physIdx R R' k) (physIdx L L' k)
+      else 0 := by
+  rw [physClose1_T]
+  simp only [bitL_physIdx, bitR_physIdx, coef_physIdx]
+  by_cases h : F = F'
+  · simp [h]
+  · simp [h]
+
+/-! ### The prepared bond states -/
+
+/-- The weight of the prepared bond state: $x$ for $(|00\rangle + |11\rangle)/\sqrt2$
+and $y$ for $(|00\rangle - |11\rangle)/\sqrt2$. -/
+def bondWeight : Fin 2 → ℝ
+  | 0 => x
+  | 1 => y
+
+/-- Both bond weights are nonnegative. -/
+lemma bondWeight_nonneg (ε : Fin 2) : 0 ≤ bondWeight ε := by
+  fin_cases ε <;> norm_num [bondWeight, x, y]
+
+/-- The Kraus amplitude of the refinement channel at the bond outcome `ε`. -/
+def refineAmp (ε : Fin 2) : ℝ := Real.sqrt (bondWeight ε) / 2
+
+/-- The squared refinement amplitude is a quarter of the bond weight. -/
+lemma refineAmp_sq (ε : Fin 2) : refineAmp ε ^ 2 = bondWeight ε / 4 := by
+  rw [refineAmp, div_pow, Real.sq_sqrt (bondWeight_nonneg ε)]
+  norm_num
+
+/-- The flag signs square to one. -/
+lemma tau_mul_self (k b : Fin 2) : tau k b * tau k b = 1 := by
+  fin_cases k <;> fin_cases b <;> norm_num [tau]
+
+/-- **The scalar identity behind the refinement channel.**  Summed over the two
+prepared bond states, the weights $x/4$ and $y/4$ together with the bond sign
+$(-1)^{\varepsilon(b + b')}$ and the flag sign reproduce half the bond matrix
+$C_k[b, b']$ of the twisted dimer. -/
+lemma refineAmp_tau_sum (k b b' f₁ f₂ : Fin 2) :
+    ∑ ε : Fin 2, refineAmp ε ^ 2 * tau ε b * tau ε b' * tau k (f₁ + f₂ + ε) =
+      tau k f₁ * tau k f₂ * Cmat k b b' / 2 := by
+  have h0 : refineAmp 0 ^ 2 = 7 / 32 := by rw [refineAmp_sq]; norm_num [bondWeight, x]
+  have h1 : refineAmp 1 ^ 2 = 1 / 32 := by rw [refineAmp_sq]; norm_num [bondWeight, y]
+  fin_cases k <;> fin_cases b <;> fin_cases b' <;> fin_cases f₁ <;> fin_cases f₂ <;>
+    simp [Fin.sum_univ_two, h0, h1, tau, Cmat, cDiag_eq, cOff_eq] <;> norm_num
+
+/-- The scalar identity of `refineAmp_tau_sum`, with the bond matrix of the outer
+bits carried along. -/
+lemma refineAmp_Cmat_sum (k b b' f₁ f₂ L L' : Fin 2) :
+    ∑ ε : Fin 2,
+        refineAmp ε ^ 2 * tau ε b * tau ε b' * (Cmat k L L' * tau k (f₁ + f₂ + ε) / 2) =
+      Cmat k L L' * tau k f₁ / 2 * (Cmat k b b' * tau k f₂ / 2) := by
+  have h := refineAmp_tau_sum k b b' f₁ f₂
+  rw [Fin.sum_univ_two] at h ⊢
+  linear_combination (Cmat k L L' / 2) * h
+
+/-! ### The refinement Kraus family -/
+
+/-- The support condition of the refinement Kraus operators: the outer bits and
+the flags of the two-site letter are prescribed by the one-site letter and the
+Kraus label, the two-site letter satisfies the bond-matching condition, and the
+one-site flag is the sum of the two prepared flags and the bond label. -/
+def refineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) : Prop :=
+  ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
+    (gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε)
+
+instance decidableRefineOK (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    Decidable (refineOK f₁ f₂ ε i j) :=
+  inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ (_ ∧ _)))
+
+/-- The support condition, read as a condition on the one-site letter for a
+fixed two-site letter. -/
+lemma refineOK_iff_col (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    refineOK f₁ f₂ ε i j ↔
+      (gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧
+        (bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2) := by
+  simp only [refineOK]
+  constructor
+  · rintro ⟨⟨⟨hf₁, hl⟩, hf₂, hr⟩, hg, hf⟩
+    exact ⟨⟨hg, hf₁, hf₂⟩, hf, hl.symm, hr.symm⟩
+  · rintro ⟨⟨hg, hf₁, hf₂⟩, hf, hl, hr⟩
+    exact ⟨⟨⟨hf₁, hl.symm⟩, hf₂, hr.symm⟩, hg, hf⟩
+
+/-- The Kraus operator of the refinement channel at the label
+$(f_1, f_2, \varepsilon)$: it prepares the flags $f_1, f_2$ on the two output
+sites and the bond state labelled by $\varepsilon$, with the bond sign
+$(-1)^{\varepsilon b}$ at the shared bond bit `b`. -/
+def refineKraus (f₁ f₂ ε : Fin 2) : Matrix (Fin 8 × Fin 8) (Fin 8) ℂ :=
+  Matrix.of fun i j =>
+    if refineOK f₁ f₂ ε i j then ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) else 0
+
+/-- The refinement map, from one-site to two-site physical operators. -/
+def refineMap :
+    Matrix (Fin 8) (Fin 8) ℂ →ₗ[ℂ] Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ :=
+  Matrix.rectangularKrausMap fun t : Fin 2 × Fin 2 × Fin 2 => refineKraus t.1 t.2.1 t.2.2
+
+/-- The refinement Kraus entries are real. -/
+lemma refineKraus_star (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
+    star (refineKraus f₁ f₂ ε i j) = refineKraus f₁ f₂ ε i j := by
+  simp only [refineKraus, Matrix.of_apply]
+  split_ifs
+  · exact Complex.conj_ofReal _
+  · exact star_zero _
+
+/-- Contracting a refinement Kraus operator against a one-site vector selects
+the single one-site letter in its support. -/
+lemma refineKraus_col_sum (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (g : Fin 8 → ℂ) :
+    (∑ j : Fin 8, refineKraus f₁ f₂ ε i j * g j) =
+      if gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂ then
+        ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) *
+          g (physIdx (bitL i.1) (bitR i.2) (f₁ + f₂ + ε))
+      else 0 := by
+  by_cases hi : gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂
+  · rw [ite_eq_left hi]
+    have hcongr : ∀ j : Fin 8, refineKraus f₁ f₂ ε i j * g j =
+        if bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2 then
+          ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) * g j else 0 := by
+      intro j
+      simp only [refineKraus, Matrix.of_apply]
+      by_cases hj : bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
+      · rw [ite_eq_left ((refineOK_iff_col f₁ f₂ ε i j).2 ⟨hi, hj⟩), ite_eq_left hj]
+      · rw [ite_eq_right fun hc => hj ((refineOK_iff_col f₁ f₂ ε i j).1 hc).2,
+          ite_eq_right hj, zero_mul]
+    rw [Finset.sum_congr rfl fun j _ => hcongr j]
+    exact one_site_fiber_sum _ _ _ _
+  · rw [ite_eq_right hi]
+    refine Finset.sum_eq_zero fun j _ => ?_
+    simp only [refineKraus, Matrix.of_apply]
+    rw [ite_eq_right fun hc => hi ((refineOK_iff_col f₁ f₂ ε i j).1 hc).1, zero_mul]
+
+/-- Summing over the two-site letters in the support of a refinement Kraus
+operator leaves the two gated fibre points. -/
+lemma refineKraus_row_sum (f₁ f₂ ε : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8, if refineOK f₁ f₂ ε i j then g i else 0) =
+      if bitF j = f₁ + f₂ + ε then
+        g (physIdx (bitL j) 0 f₁, physIdx 0 (bitR j) f₂) +
+          g (physIdx (bitL j) 1 f₁, physIdx 1 (bitR j) f₂)
+      else 0 := by
+  have hcongr : ∀ i : Fin 8 × Fin 8, (if refineOK f₁ f₂ ε i j then g i else 0) =
+      if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
+        (if gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε then g i else 0) else 0 := by
+    intro i
+    by_cases h1 : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
+    · rw [ite_eq_left h1]
+      by_cases h2 : gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε
+      · rw [ite_eq_left h2, ite_eq_left (show refineOK f₁ f₂ ε i j from ⟨h1, h2⟩)]
+      · rw [ite_eq_right h2, ite_eq_right fun hc => h2 hc.2]
+    · rw [ite_eq_right h1, ite_eq_right fun hc => h1 hc.1]
+  rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
+  by_cases hf : bitF j = f₁ + f₂ + ε
+  · rw [ite_eq_left hf]
+    simp [Fin.sum_univ_two, gate, hf]
+  · rw [ite_eq_right hf]
+    simp [gate, hf]
+
+/-- **The refinement Kraus family resolves the identity.** -/
+theorem refineKraus_resolution :
+    ∑ t : Fin 2 × Fin 2 × Fin 2,
+        (refineKraus t.1 t.2.1 t.2.2)ᴴ * refineKraus t.1 t.2.1 t.2.2 =
+      (1 : Matrix (Fin 8) (Fin 8) ℂ) := by
+  have h0 : ((refineAmp 0 : ℝ) : ℂ) ^ 2 = 7 / 32 := by
+    rw [← Complex.ofReal_pow, refineAmp_sq]
+    norm_num [bondWeight, x]
+  have h1 : ((refineAmp 1 : ℝ) : ℂ) ^ 2 = 1 / 32 := by
+    rw [← Complex.ofReal_pow, refineAmp_sq]
+    norm_num [bondWeight, y]
+  ext j j'
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  by_cases hjj : j = j'
+  · subst hjj
+    rw [Matrix.one_apply_eq]
+    have hstep : ∀ t : Fin 2 × Fin 2 × Fin 2,
+        (∑ i : Fin 8 × Fin 8, star (refineKraus t.1 t.2.1 t.2.2 i j) *
+            refineKraus t.1 t.2.1 t.2.2 i j) =
+          if bitF j = t.1 + t.2.1 + t.2.2 then ((2 * refineAmp t.2.2 ^ 2 : ℝ) : ℂ) else 0 := by
+      rintro ⟨f₁, f₂, ε⟩
+      have hcongr : ∀ i : Fin 8 × Fin 8,
+          star (refineKraus f₁ f₂ ε i j) * refineKraus f₁ f₂ ε i j =
+            if refineOK f₁ f₂ ε i j then ((refineAmp ε ^ 2 : ℝ) : ℂ) else 0 := by
+        intro i
+        rw [refineKraus_star]
+        simp only [refineKraus, Matrix.of_apply]
+        split_ifs
+        · rw [← Complex.ofReal_mul]
+          congr 1
+          have := tau_mul_self ε (bitR i.1)
+          nlinarith [this]
+        · exact mul_zero _
+      rw [Finset.sum_congr rfl fun i _ => hcongr i, refineKraus_row_sum]
+      by_cases hf : bitF j = f₁ + f₂ + ε
+      · rw [ite_eq_left hf, ite_eq_left hf]
+        push_cast
+        ring
+      · rw [ite_eq_right hf, ite_eq_right hf]
+    rw [Finset.sum_congr rfl fun t _ => hstep t]
+    have hcase : ∀ a : Fin 2, a = 0 ∨ a = 1 := by decide
+    rcases hcase (bitF j) with hb | hb <;>
+      simp only [Fintype.sum_prod_type, Fin.sum_univ_two, hb, Complex.ofReal_mul,
+        Complex.ofReal_pow, Complex.ofReal_ofNat] <;>
+      norm_num [h0, h1, show (1 : Fin 2) + 1 = 0 from rfl, show (1 : Fin 2) + 1 + 1 = 1 from rfl]
+  · rw [Matrix.one_apply_ne hjj]
+    refine Finset.sum_eq_zero fun t _ => Finset.sum_eq_zero fun i _ => ?_
+    simp only [refineKraus, Matrix.of_apply]
+    by_cases h : refineOK t.1 t.2.1 t.2.2 i j
+    · have h' : ¬ refineOK t.1 t.2.1 t.2.2 i j' := by
+        rintro h2
+        exact hjj (eq_of_bits (h.1.1.2.symm.trans h2.1.1.2)
+          (h.1.2.2.symm.trans h2.1.2.2) (h.2.2.trans h2.2.2.symm))
+      rw [ite_eq_right h', mul_zero]
+    · rw [ite_eq_right h, star_zero, zero_mul]
+
+/-- **The refinement map is trace-preserving completely positive.** -/
+theorem refineMap_isKrausCPTP : IsKrausCPTP refineMap :=
+  Matrix.rectangularKrausMap_isKrausCPTP _ refineKraus_resolution
+
+/-! ### The refinement map on the physical closures -/
+
+/-- Summing over the Kraus labels whose flags are prescribed leaves a sum over
+the bond label. -/
+lemma sum_flag_selector (F₁ F₂ : Fin 2) (V : Fin 2 × Fin 2 × Fin 2 → ℂ) :
+    (∑ t : Fin 2 × Fin 2 × Fin 2, if t.1 = F₁ ∧ t.2.1 = F₂ then V t else 0) =
+      ∑ ε : Fin 2, V (F₁, F₂, ε) := by
+  fin_cases F₁ <;> fin_cases F₂ <;> simp [Fintype.sum_prod_type, Fin.sum_univ_two]
+
+/-- One Kraus term of the refinement map, evaluated at a pair of two-site
+letters. -/
+lemma refineKraus_conj_term (f₁ f₂ ε : Fin 2) (Y : Matrix (Fin 8) (Fin 8) ℂ)
+    (i₁ i₂ j₁ j₂ : Fin 8) :
+    (∑ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') *
+        star (refineKraus f₁ f₂ ε (j₁, j₂) a')) =
+      if (gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂) ∧
+          (gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂) then
+        ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) : ℝ) : ℂ) *
+          Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε))
+            (physIdx (bitL j₁) (bitR j₂) (f₁ + f₂ + ε))
+      else 0 := by
+  have hinner : ∀ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') =
+      if gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂ then
+        ((refineAmp ε * tau ε (bitR i₁) : ℝ) : ℂ) *
+          Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε)) a' else 0 :=
+    fun a' => refineKraus_col_sum f₁ f₂ ε (i₁, i₂) fun a => Y a a'
+  rw [Finset.sum_congr rfl fun a' _ => by rw [hinner a']]
+  by_cases hi : gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂
+  · rw [Finset.sum_congr rfl fun a' _ => by
+      rw [ite_eq_left hi, refineKraus_star, mul_comm]]
+    rw [refineKraus_col_sum f₁ f₂ ε (j₁, j₂)]
+    by_cases hj : gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂
+    · rw [ite_eq_left hj, ite_eq_left ⟨hi, hj⟩]
+      push_cast
+      ring
+    · rw [ite_eq_right hj, ite_eq_right fun hc => hj hc.2]
+  · rw [ite_eq_right fun hc => hi hc.1]
+    exact Finset.sum_eq_zero fun a' _ => by rw [ite_eq_right hi, zero_mul]
+
+/-- **The refinement map carries the one-site physical closure of the twisted
+dimer to its two-site physical closure.**  Together with
+`refineMap_isKrausCPTP`, this is the map `T` of arXiv:1606.00608,
+Definition 4.1 (paper label eq:Tmap). -/
+theorem refineMap_physClose1 (X : Matrix (Fin 8) (Fin 8) ℂ) :
+    refineMap (physClose1 T X) = physClose2 T X := by
+  ext ii jj
+  obtain ⟨i₁, i₂⟩ := ii
+  obtain ⟨j₁, j₂⟩ := jj
+  rw [physClose2_T]
+  change (∑ t : Fin 2 × Fin 2 × Fin 2, refineKraus t.1 t.2.1 t.2.2 * physClose1 T X *
+      (refineKraus t.1 t.2.1 t.2.2)ᴴ) (i₁, i₂) (j₁, j₂) = _
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ =>
+    refineKraus_conj_term t.1 t.2.1 t.2.2 (physClose1 T X) i₁ i₂ j₁ j₂]
+  by_cases hg : gate i₁ i₂ ∧ gate j₁ j₂
+  · rw [ite_eq_left hg]
+    by_cases e : bitF i₁ = bitF j₁ ∧ bitF i₂ = bitF j₂
+    · have hiff : ∀ t : Fin 2 × Fin 2 × Fin 2,
+          (((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) ↔
+              (t.1 = bitF i₁ ∧ t.2.1 = bitF i₂)) := by
+        intro t
+        constructor
+        · rintro ⟨⟨_, h1, h2⟩, _⟩
+          exact ⟨h1.symm, h2.symm⟩
+        · rintro ⟨h1, h2⟩
+          exact ⟨⟨hg.1, h1.symm, h2.symm⟩, hg.2, by rw [← e.1, h1], by rw [← e.2, h2]⟩
+      simp only [hiff]
+      rw [sum_flag_selector]
+      have hval : ∀ ε : Fin 2,
+          ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) : ℝ) : ℂ) *
+              physClose1 T X (physIdx (bitL i₁) (bitR i₂) (bitF i₁ + bitF i₂ + ε))
+                (physIdx (bitL j₁) (bitR j₂) (bitF i₁ + bitF i₂ + ε)) =
+            ∑ k : Fin 2,
+              ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) *
+                (Cmat k (bitL i₁) (bitL j₁) * tau k (bitF i₁ + bitF i₂ + ε) / 2) : ℝ) : ℂ) *
+                X (physIdx (bitR i₂) (bitR j₂) k) (physIdx (bitL i₁) (bitL j₁) k) := by
+        intro ε
+        rw [physClose1_T_bits, ite_eq_left rfl, Finset.mul_sum]
+        refine Finset.sum_congr rfl fun k _ => ?_
+        push_cast
+        ring
+      rw [Finset.sum_congr rfl fun ε _ => hval ε, Finset.sum_comm]
+      refine Finset.sum_congr rfl fun k _ => ?_
+      rw [← Finset.sum_mul, ← Complex.ofReal_sum, refineAmp_Cmat_sum]
+      have hb : bitL i₂ = bitR i₁ := Eq.symm hg.1
+      have hb' : bitL j₂ = bitR j₁ := Eq.symm hg.2
+      have hc1 : coef k i₁ j₁ = ((Cmat k (bitL i₁) (bitL j₁) * tau k (bitF i₁) / 2 : ℝ) : ℂ) := by
+        rw [coef, ite_eq_left e.1]
+      have hc2 : coef k i₂ j₂ = ((Cmat k (bitR i₁) (bitR j₁) * tau k (bitF i₂) / 2 : ℝ) : ℂ) := by
+        rw [coef, ite_eq_left e.2, hb, hb']
+      rw [hc1, hc2]
+      push_cast
+      ring
+    · have hzero : ∀ t : Fin 2 × Fin 2 × Fin 2,
+          ¬ ((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) := by
+        rintro t ⟨⟨_, h1, h2⟩, _, h1', h2'⟩
+        exact e ⟨h1.trans h1'.symm, h2.trans h2'.symm⟩
+      rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero]
+      refine (Finset.sum_eq_zero fun k _ => ?_).symm
+      rcases not_and_or.mp e with h | h
+      · rw [coef, ite_eq_right h, zero_mul, zero_mul]
+      · rw [coef, coef, ite_eq_right h, mul_zero, zero_mul]
+  · rw [ite_eq_right hg]
+    refine Finset.sum_eq_zero fun t _ => ite_eq_right fun hc => hg ⟨hc.1.1, hc.2.1⟩
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
@@ -1,0 +1,389 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimerRefine
+
+/-!
+# The twisted quantum dimer is a renormalization fixed point
+
+**Scope: the coarse-graining map and the fixed-point statement.** This file
+completes `TNLean.MPS.MPDO.TwistedDimerRefine` with the second of the two
+trace-preserving completely positive maps of arXiv:1606.00608, Definition 4.1,
+and concludes that the $\mathbb Z_2$-twisted quantum dimer satisfies that
+definition.  The tensor is a project example motivated by the
+length-dependence question after Theorem 4.14 of that paper (lines 995--1010);
+it is not a tensor stated in the source.
+
+## The coarse-graining channel
+
+The coarse-graining map measures the two bond qubits shared by a two-site
+letter in the orthonormal basis
+$(|00\rangle \pm |11\rangle)/\sqrt2$, $|01\rangle$, $|10\rangle$, reads the two
+site flags, and returns the one-site letter carrying the outer site qubits and
+the flag $f_1 + f_2 + s$, where $s$ is one for the antisymmetric bond outcome
+and zero otherwise.  On the support of the two-site physical closure the two
+bond qubits agree, so only the two symmetric-basis outcomes contribute, and
+their recombination is exactly the flag sign $\tau_1$ of the twisted dimer.
+
+## Main results
+
+* `bondVec_completeness` — the bond basis is orthonormal;
+* `coarseWeight_sum` — the scalar identity behind the coarse-graining
+  channel;
+* `coarseKraus_resolution` — the coarse-graining Kraus family resolves the
+  identity;
+* `coarseMap_isKrausCPTP` — the coarse-graining map is trace-preserving
+  completely positive;
+* `coarseMap_physClose2` — the coarse-graining map carries the two-site
+  physical closure back to the one-site physical closure;
+* `isRFPViaTS_T` — the twisted quantum dimer satisfies the renormalization
+  fixed-point condition of Definition 4.1.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 (lines 645--659) and Theorem 4.14 with lines 995--1010
+  (the twisted dimer is a project example, not a tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### The bond basis -/
+
+/-- The amplitude $1/\sqrt2$ of the symmetric and antisymmetric bond states. -/
+def invSqrt2 : ℝ := 1 / Real.sqrt 2
+
+/-- The square of the bond amplitude is one half. -/
+lemma invSqrt2_mul_self : invSqrt2 * invSqrt2 = 1 / 2 := by
+  rw [invSqrt2, div_mul_div_comm, Real.mul_self_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+  norm_num
+
+/-- The orthonormal basis of the bond pair used by the coarse-graining map:
+the two states $(|00\rangle \pm |11\rangle)/\sqrt2$ followed by $|01\rangle$
+and $|10\rangle$. -/
+def bondVec : Fin 4 → Fin 2 → Fin 2 → ℝ
+  | 0, b₁, b₂ => if b₁ = b₂ then invSqrt2 else 0
+  | 1, b₁, b₂ => if b₁ = b₂ then invSqrt2 * tau 1 b₁ else 0
+  | 2, b₁, b₂ => if b₁ = 0 ∧ b₂ = 1 then 1 else 0
+  | 3, b₁, b₂ => if b₁ = 1 ∧ b₂ = 0 then 1 else 0
+
+/-- The flag shift attached to a bond outcome: the antisymmetric outcome
+flips the decoded flag, the others leave it alone. -/
+def bondShift : Fin 4 → Fin 2
+  | 0 => 0
+  | 1 => 1
+  | 2 => 0
+  | 3 => 0
+
+/-- **The bond basis is orthonormal.** -/
+lemma bondVec_completeness (b₁ b₂ c₁ c₂ : Fin 2) :
+    ∑ v : Fin 4, bondVec v b₁ b₂ * bondVec v c₁ c₂ = if b₁ = c₁ ∧ b₂ = c₂ then 1 else 0 := by
+  have h2 := invSqrt2_mul_self
+  fin_cases b₁ <;> fin_cases b₂ <;> fin_cases c₁ <;> fin_cases c₂ <;>
+    simp [Fin.sum_univ_four, bondVec, tau] <;> nlinarith [h2]
+
+/-- The real weight contributed by one coarse-graining Kraus label to the
+one-site physical closure. -/
+def coarseWeight (v : Fin 4) (k f₁ f₂ L L' : Fin 2) : ℝ :=
+  ∑ b : Fin 2, ∑ c : Fin 2,
+    bondVec v b b * bondVec v c c * (Cmat k L L' * tau k f₁ / 2 * (Cmat k b c * tau k f₂ / 2))
+
+/-- **The scalar identity behind the coarse-graining channel.**  Summed over
+the bond outcomes and the two site flags compatible with a prescribed one-site
+flag, the weights of the two symmetric bond outcomes recombine into half the
+bond matrix $C_k$ of the twisted dimer, with the flag sign $\tau_k$. -/
+lemma coarseWeight_sum (k F L L' : Fin 2) :
+    ∑ t : Fin 4 × Fin 2 × Fin 2,
+        (if t.2.1 + t.2.2 + bondShift t.1 = F then coarseWeight t.1 k t.2.1 t.2.2 L L' else 0) =
+      Cmat k L L' * tau k F / 2 := by
+  have h2 := invSqrt2_mul_self
+  fin_cases k <;> fin_cases F <;> fin_cases L <;> fin_cases L' <;>
+    simp [Fintype.sum_prod_type, Fin.sum_univ_four, Fin.sum_univ_two, coarseWeight, bondVec,
+      bondShift, tau, Cmat, cDiag_eq, cOff_eq] <;> nlinarith [h2]
+
+/-- **The two-site physical closure on a fibre of the coarse-graining map.** -/
+lemma physClose2_T_fiber (X : Matrix (Fin 8) (Fin 8) ℂ) (L L' R R' f₁ f₂ b₁ b₂ c₁ c₂ : Fin 2) :
+    physClose2 T X (physIdx L b₁ f₁, physIdx b₂ R f₂) (physIdx L' c₁ f₁, physIdx c₂ R' f₂) =
+      if b₁ = b₂ ∧ c₁ = c₂ then
+        ∑ k : Fin 2, ((Cmat k L L' * tau k f₁ / 2 * (Cmat k b₂ c₂ * tau k f₂ / 2) : ℝ) : ℂ) *
+          X (physIdx R R' k) (physIdx L L' k)
+      else 0 := by
+  rw [physClose2_T]
+  by_cases h : b₁ = b₂ ∧ c₁ = c₂
+  · rw [ite_eq_left (show gate (physIdx L b₁ f₁) (physIdx b₂ R f₂) ∧
+      gate (physIdx L' c₁ f₁) (physIdx c₂ R' f₂) from ⟨by simp [gate, h.1], by simp [gate, h.2]⟩),
+      ite_eq_left h]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [coef_physIdx, coef_physIdx, ite_eq_left rfl, ite_eq_left rfl]
+    simp only [bitL_physIdx, bitR_physIdx]
+    push_cast
+    ring
+  · rw [ite_eq_right h]
+    refine ite_eq_right fun hc => ?_
+    exact absurd ⟨by simpa [gate] using hc.1, by simpa [gate] using hc.2⟩ h
+
+/-! ### The coarse-graining Kraus family -/
+
+/-- The support condition of the coarse-graining Kraus operators. -/
+def coarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) : Prop :=
+  ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
+    bitF j = f₁ + f₂ + bondShift v
+
+instance decidableCoarseOK (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
+    Decidable (coarseOK v f₁ f₂ j i) :=
+  inferInstanceAs (Decidable (((_ ∧ _) ∧ (_ ∧ _)) ∧ _))
+
+/-- The Kraus operator of the coarse-graining channel at the label
+$(v, f_1, f_2)$: it reads the bond pair in the basis vector `v`, requires the
+site flags $f_1, f_2$, and returns the one-site letter with the decoded flag. -/
+def coarseKraus (v : Fin 4) (f₁ f₂ : Fin 2) : Matrix (Fin 8) (Fin 8 × Fin 8) ℂ :=
+  Matrix.of fun j i =>
+    if coarseOK v f₁ f₂ j i then ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) else 0
+
+/-- The coarse-graining map, from two-site to one-site physical operators. -/
+def coarseMap :
+    Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ →ₗ[ℂ] Matrix (Fin 8) (Fin 8) ℂ :=
+  Matrix.rectangularKrausMap fun t : Fin 4 × Fin 2 × Fin 2 => coarseKraus t.1 t.2.1 t.2.2
+
+/-- The coarse-graining Kraus entries are real. -/
+lemma coarseKraus_star (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (i : Fin 8 × Fin 8) :
+    star (coarseKraus v f₁ f₂ j i) = coarseKraus v f₁ f₂ j i := by
+  simp only [coarseKraus, Matrix.of_apply]
+  split_ifs
+  · exact Complex.conj_ofReal _
+  · exact star_zero _
+
+/-- Contracting a coarse-graining Kraus operator against a two-site vector
+sums over the bond bits of its fibre. -/
+lemma coarseKraus_row_sum (v : Fin 4) (f₁ f₂ : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8 → ℂ) :
+    (∑ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * g i) =
+      if bitF j = f₁ + f₂ + bondShift v then
+        ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+          g (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂)
+      else 0 := by
+  by_cases hf : bitF j = f₁ + f₂ + bondShift v
+  · rw [ite_eq_left hf]
+    have hcongr : ∀ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * g i =
+        if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
+          ((bondVec v (bitR i.1) (bitL i.2) : ℝ) : ℂ) * g i else 0 := by
+      intro i
+      simp only [coarseKraus, Matrix.of_apply]
+      by_cases hi : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
+      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from ⟨hi, hf⟩), ite_eq_left hi]
+      · rw [ite_eq_right fun hc => hi hc.1, ite_eq_right hi, zero_mul]
+    rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
+    simp only [bitR_physIdx, bitL_physIdx]
+  · rw [ite_eq_right hf]
+    refine Finset.sum_eq_zero fun i _ => ?_
+    simp only [coarseKraus, Matrix.of_apply]
+    rw [ite_eq_right fun hc => hf hc.2, zero_mul]
+
+/-- One diagonal term of the coarse-graining resolution of the identity. -/
+lemma coarseKraus_res_term (v : Fin 4) (f₁ f₂ : Fin 2) (i i' : Fin 8 × Fin 8) :
+    (∑ j : Fin 8, star (coarseKraus v f₁ f₂ j i) * coarseKraus v f₁ f₂ j i') =
+      if ((bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧ (bitF i'.1 = f₁ ∧ bitF i'.2 = f₂)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2) then
+        ((bondVec v (bitR i.1) (bitL i.2) * bondVec v (bitR i'.1) (bitL i'.2) : ℝ) : ℂ)
+      else 0 := by
+  by_cases h : ((bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧ (bitF i'.1 = f₁ ∧ bitF i'.2 = f₂)) ∧
+      (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)
+  · rw [ite_eq_left h]
+    have hcongr : ∀ j : Fin 8, star (coarseKraus v f₁ f₂ j i) * coarseKraus v f₁ f₂ j i' =
+        if bitF j = f₁ + f₂ + bondShift v ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2 then
+          ((bondVec v (bitR i.1) (bitL i.2) * bondVec v (bitR i'.1) (bitL i'.2) : ℝ) : ℂ)
+        else 0 := by
+      intro j
+      rw [coarseKraus_star]
+      simp only [coarseKraus, Matrix.of_apply]
+      by_cases hj : bitF j = f₁ + f₂ + bondShift v ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2
+      · rw [ite_eq_left (show coarseOK v f₁ f₂ j i from
+          ⟨⟨⟨h.1.1.1, hj.2.1.symm⟩, h.1.1.2, hj.2.2.symm⟩, hj.1⟩),
+          ite_eq_left (show coarseOK v f₁ f₂ j i' from
+          ⟨⟨⟨h.1.2.1, (hj.2.1.trans h.2.1).symm⟩, h.1.2.2, (hj.2.2.trans h.2.2).symm⟩, hj.1⟩),
+          ← Complex.ofReal_mul, ite_eq_left hj]
+      · have hz : ¬ coarseOK v f₁ f₂ j i := fun hc =>
+          hj ⟨hc.2, hc.1.1.2.symm, hc.1.2.2.symm⟩
+        rw [ite_eq_right hz, zero_mul, ite_eq_right hj]
+    rw [Finset.sum_congr rfl fun j _ => hcongr j]
+    exact one_site_fiber_sum _ _ _ _
+  · rw [ite_eq_right h]
+    refine Finset.sum_eq_zero fun j _ => ?_
+    rw [coarseKraus_star]
+    simp only [coarseKraus, Matrix.of_apply]
+    by_cases h1 : coarseOK v f₁ f₂ j i
+    · by_cases h2 : coarseOK v f₁ f₂ j i'
+      · exact absurd ⟨⟨⟨h1.1.1.1, h1.1.2.1⟩, h2.1.1.1, h2.1.2.1⟩,
+          h1.1.1.2.trans h2.1.1.2.symm, h1.1.2.2.trans h2.1.2.2.symm⟩ h
+      · rw [ite_eq_right h2, mul_zero]
+    · rw [ite_eq_right h1, zero_mul]
+
+/-- Summing over the Kraus labels whose flags are prescribed leaves a sum over
+the bond outcome. -/
+lemma sum_bond_selector (F₁ F₂ : Fin 2) (V : Fin 4 × Fin 2 × Fin 2 → ℂ) :
+    (∑ t : Fin 4 × Fin 2 × Fin 2, if t.2.1 = F₁ ∧ t.2.2 = F₂ then V t else 0) =
+      ∑ v : Fin 4, V (v, F₁, F₂) := by
+  fin_cases F₁ <;> fin_cases F₂ <;>
+    simp [Fintype.sum_prod_type, Fin.sum_univ_four, Fin.sum_univ_two]
+
+/-- **The coarse-graining Kraus family resolves the identity.** -/
+theorem coarseKraus_resolution :
+    ∑ t : Fin 4 × Fin 2 × Fin 2,
+        (coarseKraus t.1 t.2.1 t.2.2)ᴴ * coarseKraus t.1 t.2.1 t.2.2 =
+      (1 : Matrix (Fin 8 × Fin 8) (Fin 8 × Fin 8) ℂ) := by
+  ext i i'
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ => coarseKraus_res_term t.1 t.2.1 t.2.2 i i']
+  by_cases hb : (bitF i.1 = bitF i'.1 ∧ bitF i.2 = bitF i'.2) ∧
+      (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)
+  · have hiff : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ((((bitF i.1 = t.2.1 ∧ bitF i.2 = t.2.2) ∧ (bitF i'.1 = t.2.1 ∧ bitF i'.2 = t.2.2)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)) ↔
+            (t.2.1 = bitF i.1 ∧ t.2.2 = bitF i.2)) := by
+      intro t
+      constructor
+      · rintro ⟨⟨⟨h1, h2⟩, _⟩, _⟩
+        exact ⟨h1.symm, h2.symm⟩
+      · rintro ⟨h1, h2⟩
+        exact ⟨⟨⟨h1.symm, h2.symm⟩, by rw [← hb.1.1, h1], by rw [← hb.1.2, h2]⟩, hb.2⟩
+    simp only [hiff]
+    rw [sum_bond_selector, ← Complex.ofReal_sum, bondVec_completeness, Matrix.one_apply]
+    by_cases hc : bitR i.1 = bitR i'.1 ∧ bitL i.2 = bitL i'.2
+    · rw [ite_eq_left hc, ite_eq_left (show i = i' from Prod.ext
+        (eq_of_bits hb.2.1 hc.1 hb.1.1) (eq_of_bits hc.2 hb.2.2 hb.1.2))]
+      norm_num
+    · rw [ite_eq_right hc, ite_eq_right (show ¬ i = i' from fun hii => hc
+        ⟨by rw [hii], by rw [hii]⟩)]
+      norm_num
+  · have hzero : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ¬ (((bitF i.1 = t.2.1 ∧ bitF i.2 = t.2.2) ∧ (bitF i'.1 = t.2.1 ∧ bitF i'.2 = t.2.2)) ∧
+          (bitL i.1 = bitL i'.1 ∧ bitR i.2 = bitR i'.2)) := by
+      rintro t ⟨⟨⟨h1, h2⟩, h1', h2'⟩, h3⟩
+      exact hb ⟨⟨h1.trans h1'.symm, h2.trans h2'.symm⟩, h3⟩
+    rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero,
+      Matrix.one_apply]
+    refine (ite_eq_right fun hii => ?_).symm
+    exact absurd ⟨⟨by rw [hii], by rw [hii]⟩, by rw [hii], by rw [hii]⟩ hb
+
+/-- **The coarse-graining map is trace-preserving completely positive.** -/
+theorem coarseMap_isKrausCPTP : IsKrausCPTP coarseMap :=
+  Matrix.rectangularKrausMap_isKrausCPTP _ coarseKraus_resolution
+
+/-! ### The coarse-graining map on the physical closures -/
+
+/-- One Kraus term of the coarse-graining map, evaluated at a pair of one-site
+letters. -/
+lemma coarseKraus_conj_term (v : Fin 4) (f₁ f₂ : Fin 2) (X : Matrix (Fin 8) (Fin 8) ℂ)
+    (j j' : Fin 8) :
+    (∑ i' : Fin 8 × Fin 8, (∑ i : Fin 8 × Fin 8, coarseKraus v f₁ f₂ j i * physClose2 T X i i') *
+        star (coarseKraus v f₁ f₂ j' i')) =
+      if bitF j = f₁ + f₂ + bondShift v ∧ bitF j' = f₁ + f₂ + bondShift v then
+        ∑ k : Fin 2, ((coarseWeight v k f₁ f₂ (bitL j) (bitL j') : ℝ) : ℂ) *
+          X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k)
+      else 0 := by
+  rw [Finset.sum_congr rfl fun i' _ => by
+    rw [coarseKraus_row_sum v f₁ f₂ j fun i => physClose2 T X i i']]
+  by_cases hj : bitF j = f₁ + f₂ + bondShift v
+  · rw [Finset.sum_congr rfl fun i' _ => by rw [ite_eq_left hj]]
+    have hswap : ∀ (W : Fin 2 → Fin 2 → Fin 8 × Fin 8 → ℂ) (S : Fin 8 × Fin 8 → ℂ),
+        (∑ i' : Fin 8 × Fin 8, (∑ b₁ : Fin 2, ∑ b₂ : Fin 2, W b₁ b₂ i') * S i') =
+          ∑ b₁ : Fin 2, ∑ b₂ : Fin 2, ∑ i' : Fin 8 × Fin 8, W b₁ b₂ i' * S i' := by
+      intro W S
+      simp_rw [Finset.sum_mul]
+      rw [Finset.sum_comm]
+      exact Finset.sum_congr rfl fun b₁ _ => Finset.sum_comm
+    rw [hswap (fun b₁ b₂ i' => ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+      physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i')
+      fun i' => star (coarseKraus v f₁ f₂ j' i')]
+    have hinner : ∀ b₁ b₂ : Fin 2,
+        (∑ i' : Fin 8 × Fin 8, ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+            physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i' *
+            star (coarseKraus v f₁ f₂ j' i')) =
+          ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+            (if bitF j' = f₁ + f₂ + bondShift v then
+              ∑ c₁ : Fin 2, ∑ c₂ : Fin 2, ((bondVec v c₁ c₂ : ℝ) : ℂ) *
+                physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂)
+                  (physIdx (bitL j') c₁ f₁, physIdx c₂ (bitR j') f₂)
+            else 0) := by
+      intro b₁ b₂
+      have hterm : ∀ i' : Fin 8 × Fin 8,
+          ((bondVec v b₁ b₂ : ℝ) : ℂ) *
+              physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i' *
+              star (coarseKraus v f₁ f₂ j' i') =
+            ((bondVec v b₁ b₂ : ℝ) : ℂ) * (coarseKraus v f₁ f₂ j' i' *
+              physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i') := by
+        intro i'
+        rw [coarseKraus_star]
+        ring
+      rw [Finset.sum_congr rfl fun i' _ => hterm i', ← Finset.mul_sum,
+        coarseKraus_row_sum v f₁ f₂ j' fun i' =>
+          physClose2 T X (physIdx (bitL j) b₁ f₁, physIdx b₂ (bitR j) f₂) i']
+    rw [Finset.sum_congr rfl fun b₁ _ => Finset.sum_congr rfl fun b₂ _ => hinner b₁ b₂]
+    by_cases hj' : bitF j' = f₁ + f₂ + bondShift v
+    · rw [ite_eq_left ⟨hj, hj'⟩]
+      simp only [ite_eq_left hj', physClose2_T_fiber, coarseWeight, Fin.sum_univ_two]
+      norm_num
+      ring
+    · rw [ite_eq_right fun hc => hj' hc.2]
+      simp [ite_eq_right hj']
+  · rw [ite_eq_right fun hc => hj hc.1]
+    refine Finset.sum_eq_zero fun i' _ => ?_
+    rw [ite_eq_right hj, zero_mul]
+
+/-- **The coarse-graining map carries the two-site physical closure of the
+twisted dimer back to its one-site physical closure.**  Together with
+`coarseMap_isKrausCPTP`, this is the map `S` of arXiv:1606.00608,
+Definition 4.1 (paper label eq:Smap). -/
+theorem coarseMap_physClose2 (X : Matrix (Fin 8) (Fin 8) ℂ) :
+    coarseMap (physClose2 T X) = physClose1 T X := by
+  ext j j'
+  change (∑ t : Fin 4 × Fin 2 × Fin 2, coarseKraus t.1 t.2.1 t.2.2 * physClose2 T X *
+      (coarseKraus t.1 t.2.1 t.2.2)ᴴ) j j' = _
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [Finset.sum_congr rfl fun t _ => coarseKraus_conj_term t.1 t.2.1 t.2.2 X j j', physClose1_T]
+  by_cases e : bitF j = bitF j'
+  · have hiff : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ((bitF j = t.2.1 + t.2.2 + bondShift t.1 ∧ bitF j' = t.2.1 + t.2.2 + bondShift t.1) ↔
+          (t.2.1 + t.2.2 + bondShift t.1 = bitF j)) := by
+      intro t
+      exact ⟨fun h => h.1.symm, fun h => ⟨h.symm, e ▸ h.symm⟩⟩
+    simp only [hiff]
+    have hdist : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        (if t.2.1 + t.2.2 + bondShift t.1 = bitF j then
+            ∑ k : Fin 2, ((coarseWeight t.1 k t.2.1 t.2.2 (bitL j) (bitL j') : ℝ) : ℂ) *
+              X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k)
+          else 0) =
+          ∑ k : Fin 2,
+            ((if t.2.1 + t.2.2 + bondShift t.1 = bitF j then
+              coarseWeight t.1 k t.2.1 t.2.2 (bitL j) (bitL j') else 0 : ℝ) : ℂ) *
+              X (physIdx (bitR j) (bitR j') k) (physIdx (bitL j) (bitL j') k) := by
+      intro t
+      by_cases hc : t.2.1 + t.2.2 + bondShift t.1 = bitF j
+      · simp only [ite_eq_left hc]
+      · simp [hc]
+    rw [Finset.sum_congr rfl fun t _ => hdist t, Finset.sum_comm]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [← Finset.sum_mul, ← Complex.ofReal_sum, coarseWeight_sum, coef, ite_eq_left e]
+  · have hzero : ∀ t : Fin 4 × Fin 2 × Fin 2,
+        ¬ (bitF j = t.2.1 + t.2.2 + bondShift t.1 ∧ bitF j' = t.2.1 + t.2.2 + bondShift t.1) := by
+      rintro t ⟨h1, h2⟩
+      exact e (h1.trans h2.symm)
+    rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero]
+    refine (Finset.sum_eq_zero fun k _ => ?_).symm
+    rw [coef, ite_eq_right e, zero_mul]
+
+/-- **The $\mathbb Z_2$-twisted quantum dimer is a renormalization fixed
+point.**  The coarse-graining map and the refinement map are the
+trace-preserving completely positive maps `S` and `T` of arXiv:1606.00608,
+Definition 4.1 (paper label RFPMixedTS, line 657).  The tensor is a project
+example, not a tensor stated in the source. -/
+theorem isRFPViaTS_T : IsRFPViaTS T :=
+  ⟨coarseMap, refineMap, coarseMap_isKrausCPTP, refineMap_isKrausCPTP,
+    coarseMap_physClose2, refineMap_physClose1⟩
+
+end MPOTensor.TwistedDimer

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -825,6 +825,80 @@
     nonnegative multiples, and pullbacks along an arbitrary reindexing.
 \end{proof}
 
+\begin{theorem}[The twisted quantum dimer is a renormalization fixed point]%
+    \label{thm:mpdo_twisted_dimer_is_rfp_via_ts}
+    \lean{MPOTensor.TwistedDimer.refineMap}
+    \lean{MPOTensor.TwistedDimer.refineMap_isKrausCPTP}
+    \lean{MPOTensor.TwistedDimer.refineMap_physClose1}
+    \lean{MPOTensor.TwistedDimer.coarseMap}
+    \lean{MPOTensor.TwistedDimer.coarseMap_isKrausCPTP}
+    \lean{MPOTensor.TwistedDimer.coarseMap_physClose2}
+    \lean{MPOTensor.TwistedDimer.isRFPViaTS_T}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    The twisted quantum dimer of
+    Definition~\ref{def:mpdo_twisted_dimer_tensor} is a renormalization fixed
+    point in the sense of Definition~\ref{def:is_rfp_via_ts}. The refinement
+    map $\mathcal T$ has eight Kraus operators, labelled by the two prepared
+    site flags $f_1, f_2$ and a bond label $\varepsilon$: it prepares those two
+    flags on the output sites together with the bond state
+    $(\ket{00}+(-1)^\varepsilon\ket{11})/\sqrt2$ on the bond they share, with
+    weight $x$ for $\varepsilon=0$ and $y$ for $\varepsilon=1$, and is
+    supported on the incoming flag $f=f_1+f_2+\varepsilon$. The
+    coarse-graining map $\mathcal S$ has sixteen Kraus operators, labelled by a
+    member of the orthonormal bond basis $(\ket{00}\pm\ket{11})/\sqrt2$,
+    $\ket{01}$, $\ket{10}$ together with the two site flags: it measures the
+    shared bond pair in that basis, reads the two flags, and returns the letter
+    carrying the outer site qubits and the flag $f_1+f_2+s$, where $s$ is one
+    for the antisymmetric bond outcome and zero otherwise. The tensor is a
+    project example motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_twisted_dimer_tensor, thm:mpdo_twisted_dimer_closures}
+    Fix a one-site letter $(l,r,f)$. The two-site letters in the support of a
+    refinement Kraus operator carry the outer bits $l$ and $r$, the two
+    prepared flags, and a free shared bond bit, so each of the four labels with
+    $f_1+f_2+\varepsilon=f$ contributes twice the squared amplitude
+    $w_\varepsilon/4$, where $w_0=x$ and $w_1=y$; two of the four labels carry
+    each value of $\varepsilon$, and the total is $x+y=1$. Supports belonging
+    to distinct one-site letters are disjoint, so the off-diagonal entries
+    vanish and the family resolves the identity. For the intertwining relation,
+    the flag signs multiply as
+    $(\tau_k)_{f_1f_1}(\tau_k)_{f_2f_2}=(\tau_k)_{gg}$ with $g=f_1+f_2$, and
+    the two prepared bond states reassemble the bond matrices through
+    \begin{align}
+        \frac{x}{4}+(-1)^{b+b'}\frac{y}{4} & =\frac12\,C_0[b,b'], &
+        \frac{x}{4}-(-1)^{b+b'}\frac{y}{4} & =\frac12\,C_1[b,b'],
+        \notag
+    \end{align}
+    for the two shared bond bits $b, b'$ of the two arguments; this is exactly
+    the coefficient of the two-site closure displayed in
+    Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
+
+    For the coarse-graining map, orthonormality of the bond basis and of the
+    pair of site flags gives the resolution of the identity: summing over the
+    bond basis identifies the two bond bits of the two arguments, and summing
+    over the flag labels identifies their flags, so all six bits of the two
+    two-site letters agree. On the support of the two-site closure the two bond
+    qubits of each argument agree, so the outcomes $\ket{01}$ and $\ket{10}$
+    contribute nothing and the two symmetric outcomes contribute
+    $\frac12(\pm1)^{b+b'}$. Summing over the two flag pairs compatible with the
+    decoded flag leaves, for each block label $k$, the single identity
+    \begin{align}
+        \frac12\Bigl(\sum_{b,b'}C_k[b,b']
+        +(\tau_k)_{11}\sum_{b,b'}(-1)^{b+b'}C_k[b,b']\Bigr) & =1,
+        \notag
+    \end{align}
+    whose left side is $\frac12\bigl(\frac74+\frac14\bigr)=1$ in both cases:
+    for $k=0$ the alternating sum is $\frac14$ and the flag sign is $1$, and
+    for $k=1$ it is $-\frac14$ and the flag sign is $-1$. The remaining factor
+    is the one-site coefficient
+    $\frac12\,C_k[l,l']\,(\tau_k)_{ff}\,\delta_{ff'}$ of
+    Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
+\end{proof}
+
 \begin{theorem}[A candidate two-label coefficient family stable under every
         positive rescaling]%
     \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -789,6 +789,26 @@ abstracted — record why, so it is not re-proposed).
   five-line term. Net source delta over the four sites: −69 lines against +37
   for the lemma.
 
+### bit-indexed Kraus support fibre sums — promoted
+- **Pattern:** a Kraus operator supported on the indicator of a condition
+  prescribing some bits of a bit-encoded physical index; a sum against it is
+  rewritten into the indicator of the fibre condition by `ite_eq_left` /
+  `ite_eq_right` under `Finset.sum_congr`, and the fibre sum is then collapsed
+  to the single index (all bits prescribed) or to a sum over the free bits.
+- **Seen:** four occurrences across two files (2026-09-02):
+  `MPS/MPDO/TwistedDimerRefine.lean` (`refineKraus_col_sum`, `refineKraus_row_sum`) and
+  `MPS/MPDO/TwistedDimerViaTS.lean` (`coarseKraus_row_sum`, `coarseKraus_res_term`).
+- **Abstraction:** `MPOTensor.TwistedDimer.one_site_fiber_sum`,
+  `left_fiber_sum`, `right_fiber_sum`, and `pair_fiber_sum` in
+  `TNLean/MPS/MPDO/TwistedDimerRefine.lean`, all stated for an arbitrary
+  summand so that each caller supplies its own Kraus amplitude and contracted
+  vector.
+- **Notes:** the pair version is proved from the two one-index versions rather
+  than by expanding sixty-four terms, which keeps its proof independent of the
+  prescribed bits. The one-index versions are proved by transporting the sum
+  along the bit encoding (`sum_fin_eight`) and deciding the eight resulting
+  cases.
+
 ---
 
 ## Completed refactors


### PR DESCRIPTION
## Summary

Third step for #7611, stacked on #7614: the twisted quantum dimer satisfies Definition 4.1 of arXiv:1606.00608 (`IsRFPViaTS`), with explicit trace-preserving completely positive maps in Kraus form.

* `TNLean/MPS/MPDO/TwistedDimerRefine.lean` (443 lines): fibre lemmas for the bit encoding of the physical index, the refinement map `refineMap` with eight Kraus operators labelled by the two prepared flags and a bond label (it prepares the bond state `(|00⟩ + (−1)^ε|11⟩)/√2` with weight `x` or `y` and is supported on the incoming flag `f = f₁ + f₂ + ε`), `refineKraus_resolution`, `refineMap_isKrausCPTP`, and `refineMap_physClose1 : refineMap (physClose1 T X) = physClose2 T X`.
* `TNLean/MPS/MPDO/TwistedDimerViaTS.lean` (389 lines): the coarse-graining map `coarseMap` with sixteen Kraus operators (measure the shared bond pair in the orthonormal basis `(|00⟩ ± |11⟩)/√2, |01⟩, |10⟩`, read the two flags, return the outer qubits with the decoded flag `f₁ + f₂ + s`), `coarseKraus_resolution`, `coarseMap_isKrausCPTP`, `coarseMap_physClose2`, and `isRFPViaTS_T : IsRFPViaTS T`.
* Blueprint entry `thm:mpdo_twisted_dimer_is_rfp_via_ts` (statement and proof `\leanok`), a ledger entry for the bit-indexed Kraus support fibre sums (four call sites, abstracted by the fibre-sum lemmas), and the regenerated aggregator.

Claims are limited to the proved scope: the two channels and the Definition 4.1 identities for the displayed tensor. Non-simplicity, the vertical canonical form, and the fusion attachment remain follow-up work.

## Verification

* `lake build TNLean.MPS.MPDO.TwistedDimerViaTS` passes with the package linter options and no warnings; `#print axioms isRFPViaTS_T` gives only `propext, Classical.choice, Quot.sound`.
* Aggregator, numbered-file, oversized-file, forbidden-token, import-syntax, and prose checks pass for the touched files; the blueprint chapter is formatted with latexindent.

https://claude.ai/code/session_01AgcGSvYZercYZbHeSdMRVB