### PR TITLE
feat(parent-hamiltonian): formalize the FNW lower boundary constant

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -54,6 +54,7 @@ import TNLean.MPS.ParentHamiltonian.FNWBoundaryConvention
 import TNLean.MPS.ParentHamiltonian.FNWBoundaryEstimate
 import TNLean.MPS.ParentHamiltonian.FNWContraction
 import TNLean.MPS.ParentHamiltonian.FNWLimitMap
+import TNLean.MPS.ParentHamiltonian.FNWLowerBoundary
 import TNLean.MPS.ParentHamiltonian.FNWTransferConvention
 import TNLean.MPS.ParentHamiltonian.FNWTransferDecay
 import TNLean.MPS.ParentHamiltonian.GramConvergence

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -251,7 +251,7 @@ theorem fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram [NeZero D]
   rw [fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf]
   exact (fnwBoundaryGram_isSymmetric ρ hρ A N).hasEigenvalue_iInf_of_finiteDimensional
 
-private theorem fnwBoundaryNormRatio_bddBelow [NeZero D]
+private theorem fnwBoundaryNormRatio_bddBelow
     (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
     BddBelow (Set.range (fnwBoundaryNormRatio ρ hρ A N)) := by
   refine ⟨0, ?_⟩

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -213,6 +213,22 @@ theorem fnwBoundaryGram_isSymmetric
     Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
   exact (fnwBoundaryMapCLM ρ hρ A N).toLinearMap.isSymmetric_adjoint_comp_self
 
+/-- The weighted Gram operator is positive. -/
+theorem fnwBoundaryGram_isPositive
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    (fnwBoundaryGram ρ hρ A N).IsPositive := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  exact (fnwBoundaryMapCLM ρ hρ A N).toLinearMap.isPositive_adjoint_comp_self
+
 /-- FNW's identity \(a_-(N)=\inf\operatorname{spec}(F_N^*F_N)\), packaged
 without ordering the complex spectrum: \(a_-(N)\), coerced to \(ℂ\), belongs to
 the spectrum of the weighted Gram operator. -/

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.FNWBoundaryEstimate
+
+/-!
+# FNW lower boundary constant
+
+This module formalizes the lower boundary constant in Fannes--Nachtergaele--Werner,
+*Communications in Mathematical Physics* 144 (1992), 443--490, Lemma 5.3.
+For the boundary map \(F_N\), the source constant is
+
+\[
+  a_-(N)=\inf_{B\ne 0}\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}.
+\]
+
+Equation (5.9) gives \(1-a(N)\le a_-(N)\). Stationarity of the faithful density
+and the exact boundary recursion show that \(a_-(N)\) is nondecreasing.
+No finite-Gram, singular-value, or periodic-chain estimate is used here.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+namespace MPSTensor
+
+noncomputable section
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- FNW 1992, equation (5.9), with its right-hand side written using the source
+mixing quantity \(a(N)\). -/
+theorem norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le_fnwMixingQuantity
+    (ρ : Mat) (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1)
+    (A : MPSTensor d D) (N : ℕ) (B C : Mat) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    ‖inner ℂ (fnwBoundaryMapCLM ρ hρ A N B)
+        (fnwBoundaryMapCLM ρ hρ A N C) - inner ℂ B C‖ ≤
+      fnwMixingQuantity ρ hρ A htr N * ‖B‖ * ‖C‖ := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  simpa only [fnwMixingQuantity, fnwTraceInverseFactor] using
+    norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le ρ hρ htr A N B C
+
+/-- The diagonal specialization of equation (5.9): the absolute defect of the
+boundary norm square is at most \(a(N)\lVert B\rVert_\rho^2\). -/
+theorem abs_fnwBoundaryMapCLM_norm_sq_sub_rhoWeighted_norm_sq_le
+    (ρ : Mat) (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1)
+    (A : MPSTensor d D) (N : ℕ) (B : Mat) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    |‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 - ‖B‖ ^ 2| ≤
+      fnwMixingQuantity ρ hρ A htr N * ‖B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  have hbound :=
+    norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le_fnwMixingQuantity
+      ρ hρ htr A N B B
+  calc
+    |‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 - ‖B‖ ^ 2| =
+        ‖((‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 - ‖B‖ ^ 2 : ℝ) : ℂ)‖ := by
+      rw [Complex.norm_real, Real.norm_eq_abs]
+    _ = ‖inner ℂ (fnwBoundaryMapCLM ρ hρ A N B)
+          (fnwBoundaryMapCLM ρ hρ A N B) - inner ℂ B B‖ := by
+      rw [inner_self_eq_norm_sq_to_K, inner_self_eq_norm_sq_to_K]
+      congr 1
+      norm_cast
+    _ ≤ fnwMixingQuantity ρ hρ A htr N * ‖B‖ * ‖B‖ := hbound
+    _ = fnwMixingQuantity ρ hρ A htr N * ‖B‖ ^ 2 := by ring
+
+/-- Equation (5.9) gives the quadratic lower estimate
+\((1-a(N))\lVert B\rVert_\rho^2\le\lVert F_N(B)\rVert^2\).
+No nonnegativity assumption on \(a(N)\) is needed. -/
+theorem one_sub_fnwMixingQuantity_mul_norm_sq_le_fnwBoundaryMapCLM_norm_sq
+    (ρ : Mat) (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1)
+    (A : MPSTensor d D) (N : ℕ) (B : Mat) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    (1 - fnwMixingQuantity ρ hρ A htr N) * ‖B‖ ^ 2 ≤
+      ‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  have hbound := abs_le.mp
+    (abs_fnwBoundaryMapCLM_norm_sq_sub_rhoWeighted_norm_sq_le
+      ρ hρ htr A N B)
+  nlinarith only [hbound.1]
+
+/-- The nonzero boundary norm-square ratio whose infimum is the source constant
+\(a_-(N)\). -/
+noncomputable def fnwBoundaryNormRatio
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ)
+    (B : {B : Mat // B ≠ 0}) : ℝ := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  exact ‖fnwBoundaryMapCLM ρ hρ A N B.1‖ ^ 2 / ‖B.1‖ ^ 2
+
+/-- The lower boundary constant \(a_-(N)\) from FNW 1992, Lemma 5.3. It is the
+infimum of the boundary norm-square ratio over nonzero virtual matrices. -/
+noncomputable def fnwLowerBoundaryConstant [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) : ℝ :=
+  ⨅ B : {B : Mat // B ≠ 0}, fnwBoundaryNormRatio ρ hρ A N B
+
+private theorem fnwBoundaryNormRatio_bddBelow [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    BddBelow (Set.range (fnwBoundaryNormRatio ρ hρ A N)) := by
+  refine ⟨0, ?_⟩
+  rintro _ ⟨B, rfl⟩
+  exact div_nonneg (sq_nonneg _) (sq_nonneg _)
+
+/-- The lower boundary constant is at most every nonzero boundary norm-square
+ratio. -/
+theorem fnwLowerBoundaryConstant_le_ratio [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ)
+    (B : Mat) (hB : B ≠ 0) :
+    fnwLowerBoundaryConstant ρ hρ A N ≤
+      fnwBoundaryNormRatio ρ hρ A N ⟨B, hB⟩ := by
+  exact ciInf_le (fnwBoundaryNormRatio_bddBelow ρ hρ A N) ⟨B, hB⟩
+
+/-- The source constant gives its universal quadratic lower bound, including at
+the zero matrix. -/
+theorem fnwLowerBoundaryConstant_mul_norm_sq_le [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) (B : Mat) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    fnwLowerBoundaryConstant ρ hρ A N * ‖B‖ ^ 2 ≤
+      ‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  rcases eq_or_ne B 0 with rfl | hB
+  · simp
+  · exact (le_div_iff₀ (sq_pos_of_pos (norm_pos_iff.mpr hB))).mp
+      (fnwLowerBoundaryConstant_le_ratio ρ hρ A N B hB)
+
+/-- A real number is at most the lower boundary constant exactly when it is a
+universal quadratic lower bound for the boundary map. -/
+theorem le_fnwLowerBoundaryConstant_iff [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) (c : ℝ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    c ≤ fnwLowerBoundaryConstant ρ hρ A N ↔
+      ∀ B : Mat, c * ‖B‖ ^ 2 ≤ ‖fnwBoundaryMapCLM ρ hρ A N B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  constructor
+  · intro hc B
+    exact (mul_le_mul_of_nonneg_right hc (sq_nonneg _)).trans
+      (fnwLowerBoundaryConstant_mul_norm_sq_le ρ hρ A N B)
+  · intro hc
+    let _ : Nonempty {B : Mat // B ≠ 0} := ⟨⟨1, one_ne_zero⟩⟩
+    apply le_ciInf
+    rintro ⟨B, hB⟩
+    exact (le_div_iff₀ (sq_pos_of_pos (norm_pos_iff.mpr hB))).mpr (hc B)
+
+/-- FNW 1992, Lemma 5.3: equation (5.9) implies
+\(1-a(N)\le a_-(N)\). -/
+theorem one_sub_fnwMixingQuantity_le_fnwLowerBoundaryConstant [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1)
+    (A : MPSTensor d D) (N : ℕ) :
+    1 - fnwMixingQuantity ρ hρ A htr N ≤
+      fnwLowerBoundaryConstant ρ hρ A N := by
+  rw [le_fnwLowerBoundaryConstant_iff]
+  exact one_sub_fnwMixingQuantity_mul_norm_sq_le_fnwBoundaryMapCLM_norm_sq
+    ρ hρ htr A N
+
+/-- The lower boundary constant is strictly positive whenever the source mixing
+quantity is strictly below one. -/
+theorem fnwLowerBoundaryConstant_pos [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (htr : Matrix.trace ρ = 1)
+    (A : MPSTensor d D) (N : ℕ)
+    (ha : fnwMixingQuantity ρ hρ A htr N < 1) :
+    0 < fnwLowerBoundaryConstant ρ hρ A N :=
+  lt_of_lt_of_le (sub_pos.mpr ha)
+    (one_sub_fnwMixingQuantity_le_fnwLowerBoundaryConstant ρ hρ htr A N)
+
+/-- Stationarity of \(ρ\) gives the weighted right-multiplication identity
+\(\sum_\mu\lVert BA^\mu\rVert_ρ^2=\lVert B\rVert_ρ^2\). -/
+theorem sum_rhoWeighted_norm_sq_mul_eq
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D)
+    (hρfix : Kraus.transferMap A ρ = ρ) (B : Mat) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    ∑ μ : Fin d, ‖B * A μ‖ ^ 2 = ‖B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  simp_rw [Matrix.rhoWeighted_norm_sq ρ hρ]
+  have htrace :
+      ∑ μ : Fin d, Matrix.trace (ρ * (B * A μ)ᴴ * (B * A μ)) =
+        Matrix.trace (Kraus.transferMap A ρ * Bᴴ * B) := by
+    rw [Kraus.transferMap_apply, Matrix.sum_mul, Finset.sum_mul,
+      Matrix.trace_sum]
+    apply Finset.sum_congr rfl
+    intro μ _
+    simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+    simpa only [Matrix.mul_assoc] using
+      Matrix.trace_mul_comm (ρ * (A μ)ᴴ * Bᴴ * B) (A μ)
+  calc
+    ∑ μ : Fin d, (Matrix.trace (ρ * (B * A μ)ᴴ * (B * A μ))).re =
+        (∑ μ : Fin d, Matrix.trace (ρ * (B * A μ)ᴴ * (B * A μ))).re :=
+      (map_sum Complex.reCLM
+        (fun μ : Fin d ↦ Matrix.trace (ρ * (B * A μ)ᴴ * (B * A μ)))
+        Finset.univ).symm
+    _ = (Matrix.trace (Kraus.transferMap A ρ * Bᴴ * B)).re :=
+      congrArg Complex.re htrace
+    _ = (Matrix.trace (ρ * Bᴴ * B)).re := by rw [hρfix]
+
+/-- Stationarity and the exact boundary recursion make the lower boundary
+constant nondecreasing in one step. -/
+theorem fnwLowerBoundaryConstant_le_succ [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D)
+    (hρfix : Kraus.transferMap A ρ = ρ) (N : ℕ) :
+    fnwLowerBoundaryConstant ρ hρ A N ≤
+      fnwLowerBoundaryConstant ρ hρ A (N + 1) := by
+  rw [le_fnwLowerBoundaryConstant_iff]
+  intro B
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  calc
+    fnwLowerBoundaryConstant ρ hρ A N * ‖B‖ ^ 2 =
+        ∑ μ : Fin d, fnwLowerBoundaryConstant ρ hρ A N * ‖B * A μ‖ ^ 2 := by
+      rw [← Finset.mul_sum, sum_rhoWeighted_norm_sq_mul_eq ρ hρ A hρfix B]
+    _ ≤ ∑ μ : Fin d, ‖fnwBoundaryMapCLM ρ hρ A N (B * A μ)‖ ^ 2 :=
+      Finset.sum_le_sum fun μ _ ↦
+        fnwLowerBoundaryConstant_mul_norm_sq_le ρ hρ A N (B * A μ)
+    _ = ‖fnwBoundaryMapCLM ρ hρ A (N + 1) B‖ ^ 2 :=
+      (fnwBoundaryMapCLM_norm_sq_succ ρ hρ A N B).symm
+
+/-- The lower boundary constants are nondecreasing with the boundary length. -/
+theorem fnwLowerBoundaryConstant_mono [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D)
+    (hρfix : Kraus.transferMap A ρ = ρ) :
+    Monotone (fnwLowerBoundaryConstant ρ hρ A) := by
+  intro N M hNM
+  induction M, hNM using Nat.le_induction with
+  | base => exact le_rfl
+  | succ M hNM ih =>
+      exact ih.trans (fnwLowerBoundaryConstant_le_succ ρ hρ A hρfix M)
+
+/-- Primitive-MPS specialization of lower-boundary monotonicity. -/
+theorem IsPrimitiveMPS.fnwLowerBoundaryConstant_mono [NeZero D]
+    {ρ : Mat} {A : MPSTensor d D} (hP : IsPrimitiveMPS A ρ)
+    (hρ : ρ.PosDef) :
+    Monotone (fnwLowerBoundaryConstant ρ hρ A) :=
+  MPSTensor.fnwLowerBoundaryConstant_mono ρ hρ A hP.fixedPoint_is_fixed
+
+end
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -171,6 +171,68 @@ noncomputable def fnwLowerBoundaryConstant [NeZero D]
     (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) : ℝ :=
   ⨅ B : {B : Mat // B ≠ 0}, fnwBoundaryNormRatio ρ hρ A N B
 
+/-- The source infimum is the infimum of the Rayleigh quotient of the weighted
+Gram operator. -/
+theorem fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    fnwLowerBoundaryConstant ρ hρ A N =
+      ⨅ B : {B : Mat // B ≠ 0},
+        RCLike.re (inner ℂ (fnwBoundaryGram ρ hρ A N B.1) B.1) / ‖B.1‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  rw [fnwLowerBoundaryConstant]
+  apply iInf_congr
+  intro B
+  exact fnwBoundaryNormRatio_eq_gram_rayleighQuotient ρ hρ A N B B.2
+
+/-- The weighted Gram operator is symmetric. -/
+theorem fnwBoundaryGram_isSymmetric
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    (fnwBoundaryGram ρ hρ A N).IsSymmetric := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  exact (fnwBoundaryMapCLM ρ hρ A N).toLinearMap.isSymmetric_adjoint_comp_self
+
+/-- FNW's identity \(a_-(N)=\inf\operatorname{spec}(F_N^*F_N)\), packaged
+without ordering the complex spectrum: \(a_-(N)\), coerced to \(ℂ\), belongs to
+the spectrum of the weighted Gram operator. -/
+theorem fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    (fnwLowerBoundaryConstant ρ hρ A N : ℂ) ∈
+      spectrum ℂ (fnwBoundaryGram ρ hρ A N) := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  rw [← Module.End.hasEigenvalue_iff_mem_spectrum]
+  rw [fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf]
+  exact (fnwBoundaryGram_isSymmetric ρ hρ A N).hasEigenvalue_iInf_of_finiteDimensional
+
 private theorem fnwBoundaryNormRatio_bddBelow [NeZero D]
     (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
     BddBelow (Set.range (fnwBoundaryNormRatio ρ hρ A N)) := by
@@ -186,6 +248,47 @@ theorem fnwLowerBoundaryConstant_le_ratio [NeZero D]
     fnwLowerBoundaryConstant ρ hρ A N ≤
       fnwBoundaryNormRatio ρ hρ A N ⟨B, hB⟩ := by
   exact ciInf_le (fnwBoundaryNormRatio_bddBelow ρ hρ A N) ⟨B, hB⟩
+
+/-- Every spectral value of the weighted Gram operator has real part at least
+\(a_-(N)\). Together with
+`fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram`, this is the ordered
+meaning of \(a_-(N)=\inf\operatorname{spec}(F_N^*F_N)\). -/
+theorem fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ)
+    (z : ℂ) (hz : z ∈ spectrum ℂ (fnwBoundaryGram ρ hρ A N)) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    fnwLowerBoundaryConstant ρ hρ A N ≤ z.re := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  have heig : Module.End.HasEigenvalue (fnwBoundaryGram ρ hρ A N) z :=
+    Module.End.hasEigenvalue_iff_mem_spectrum.mpr hz
+  have hzreal : (z.re : ℂ) = z :=
+    RCLike.conj_eq_iff_re.mp
+      ((fnwBoundaryGram_isSymmetric ρ hρ A N).conj_eigenvalue_eq_self heig)
+  rw [← hzreal] at heig
+  obtain ⟨B, hB⟩ := heig.exists_hasEigenvector
+  have hle := fnwLowerBoundaryConstant_le_ratio ρ hρ A N B hB.2
+  rw [fnwBoundaryNormRatio_eq_gram_rayleighQuotient ρ hρ A N B hB.2] at hle
+  rw [hB.apply_eq_smul] at hle
+  simp only [inner_smul_left, inner_self_eq_norm_sq_to_K,
+    Complex.conj_ofReal] at hle
+  convert hle using 1
+  field_simp [norm_ne_zero_iff.mpr hB.2]
+  norm_cast
+  change z.re * ‖B‖ ^ 2 =
+    ((z.re : ℂ) * ((‖B‖ ^ 2 : ℝ) : ℂ)).re
+  rw [Complex.mul_re]
+  norm_cast
+  ring
 
 /-- The source constant gives its universal quadratic lower bound, including at
 the zero matrix. -/

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Analysis.InnerProductSpace.Rayleigh
+import Mathlib.Analysis.InnerProductSpace.SingularValues
 import TNLean.MPS.ParentHamiltonian.FNWBoundaryEstimate
 
 /-!
@@ -120,6 +122,48 @@ noncomputable def fnwBoundaryNormRatio
     (B : {B : Mat // B ≠ 0}) : ℝ := by
   let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
   exact ‖fnwBoundaryMapCLM ρ hρ A N B.1‖ ^ 2 / ‖B.1‖ ^ 2
+
+/-- The weighted Gram operator \(F_N^*F_N\) on the virtual matrix Hilbert space. -/
+noncomputable def fnwBoundaryGram
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    Mat →ₗ[ℂ] Mat := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  exact LinearMap.adjoint (fnwBoundaryMapCLM ρ hρ A N).toLinearMap ∘ₗ
+    (fnwBoundaryMapCLM ρ hρ A N).toLinearMap
+
+/-- The boundary norm-square ratio is exactly the Rayleigh quotient of the
+weighted Gram operator \(F_N^*F_N\). -/
+theorem fnwBoundaryNormRatio_eq_gram_rayleighQuotient
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ)
+    (B : Mat) (hB : B ≠ 0) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    letI : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+    fnwBoundaryNormRatio ρ hρ A N ⟨B, hB⟩ =
+      RCLike.re (inner ℂ (fnwBoundaryGram ρ hρ A N B) B) / ‖B‖ ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let : Norm Mat := (Matrix.toMatrixNormedAddCommGroup ρ hρ).toNorm
+  rw [fnwBoundaryGram]
+  simp only [LinearMap.coe_comp, Function.comp_apply]
+  rw [LinearMap.adjoint_inner_left]
+  simp only [inner_self_eq_norm_sq]
+  rfl
 
 /-- The lower boundary constant \(a_-(N)\) from FNW 1992, Lemma 5.3. It is the
 infimum of the boundary norm-square ratio over nonzero virtual matrices. -/

--- a/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWLowerBoundary.lean
@@ -18,9 +18,11 @@ For the boundary map \(F_N\), the source constant is
   a_-(N)=\inf_{B\ne 0}\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}.
 \]
 
-Equation (5.9) gives \(1-a(N)\le a_-(N)\). Stationarity of the faithful density
-and the exact boundary recursion show that \(a_-(N)\) is nondecreasing.
-No finite-Gram, singular-value, or periodic-chain estimate is used here.
+Equation (5.9) gives \(1-a(N)\le a_-(N)\). The same source infimum is the
+least eigenvalue of the weighted Gram operator \(F_N^*F_N\), equivalently the
+least squared singular value indexed by the finite virtual domain. Stationarity
+of the faithful density and the exact boundary recursion show that \(a_-(N)\)
+is nondecreasing. No coordinate Gram or periodic-chain estimate is used here.
 -/
 
 open scoped BigOperators ComplexOrder Matrix
@@ -289,6 +291,57 @@ theorem fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram [NeZero D
   rw [Complex.mul_re]
   norm_cast
   ring
+
+/-- The lower boundary constant is the least squared singular value of the
+boundary map, indexed only over the finite-dimensional weighted virtual domain.
+The first clause gives an attaining domain index; the second gives minimality
+among all domain-indexed singular values. -/
+theorem fnwLowerBoundaryConstant_eq_least_sq_singularValue [NeZero D]
+    (ρ : Mat) (hρ : ρ.PosDef) (A : MPSTensor d D) (N : ℕ) :
+    letI : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+    letI : SeminormedAddCommGroup Mat :=
+      (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+    letI : InnerProductSpace ℂ Mat :=
+      Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+    let T := (fnwBoundaryMapCLM ρ hρ A N).toLinearMap
+    (∃ i : Fin (Module.finrank ℂ Mat),
+      T.singularValues i ^ 2 = fnwLowerBoundaryConstant ρ hρ A N) ∧
+    ∀ i : Fin (Module.finrank ℂ Mat),
+      fnwLowerBoundaryConstant ρ hρ A N ≤ T.singularValues i ^ 2 := by
+  let : NormedAddCommGroup Mat := Matrix.toMatrixNormedAddCommGroup ρ hρ
+  let : SeminormedAddCommGroup Mat :=
+    (Matrix.toMatrixNormedAddCommGroup ρ hρ).toSeminormedAddCommGroup
+  let : InnerProductSpace ℂ Mat :=
+    Matrix.toMatrixInnerProductSpace ρ hρ.posSemidef
+  let T := (fnwBoundaryMapCLM ρ hρ A N).toLinearMap
+  have hsym : (LinearMap.adjoint T ∘ₗ T).IsSymmetric :=
+    T.isSymmetric_adjoint_comp_self
+  have hminSpec : (fnwLowerBoundaryConstant ρ hρ A N : ℂ) ∈
+      spectrum ℂ (LinearMap.adjoint T ∘ₗ T) := by
+    simpa only [T, fnwBoundaryGram] using
+      fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram ρ hρ A N
+  have hminEig : Module.End.HasEigenvalue (LinearMap.adjoint T ∘ₗ T)
+      (fnwLowerBoundaryConstant ρ hρ A N : ℂ) :=
+    Module.End.hasEigenvalue_iff_mem_spectrum.mpr hminSpec
+  obtain ⟨i, hi⟩ := hsym.exists_eigenvalues_eq rfl hminEig
+  have hiReal : hsym.eigenvalues rfl i = fnwLowerBoundaryConstant ρ hρ A N :=
+    Complex.ofReal_injective hi
+  constructor
+  · refine ⟨i, ?_⟩
+    rw [T.sq_singularValues_fin rfl]
+    exact hiReal
+  · intro j
+    rw [T.sq_singularValues_fin rfl]
+    let eigenvalue := hsym.eigenvalues rfl j
+    have heig : Module.End.HasEigenvalue (LinearMap.adjoint T ∘ₗ T)
+        (eigenvalue : ℂ) := hsym.hasEigenvalue_eigenvalues rfl j
+    have hspec : (eigenvalue : ℂ) ∈
+        spectrum ℂ (fnwBoundaryGram ρ hρ A N) := by
+      rw [← Module.End.hasEigenvalue_iff_mem_spectrum]
+      simpa only [T, fnwBoundaryGram] using heig
+    have hle := fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram
+      ρ hρ A N eigenvalue hspec
+    simpa only [eigenvalue, Complex.ofReal_re] using hle
 
 /-- The source constant gives its universal quadratic lower bound, including at
 the zero matrix. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -1378,15 +1378,9 @@ $\tr(\rho)=1$, and equip $\MN{D}$ with
      & =\operatorname{Re}\tr(\rho B^\dagger B).
     \label{eq:fnw_weighted_norm}
 \end{align}
-Write $F_N$ for the length-$N$ FNW boundary map and set
-\begin{align}
-    a(N)
-     & =\operatorname{Re}\tr(\rho^{-1})
-    \bigl\lVert E_{\mathrm{FNW},A}^N-E_\infty^\rho
-    \bigr\rVert_{\mathrm{op},\rho}.
-    \label{eq:fnw_mixing_quantity}
-\end{align}
-This is the normalization used in
+Write $F_N$ for the length-$N$ FNW boundary map and let $a(N)$ be the
+source mixing quantity in (\ref{eq:fnw_mixing_quantity}). This is the
+normalization used in
 \cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
 
 \begin{theorem}[Weighted boundary near-isometry]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -1644,8 +1644,8 @@ normalization used in
     \leanok
     \uses{thm:fnw_boundary_norm_sq_succ, thm:fnw_lower_boundary_optimal,
         thm:rho_weighted_right_multiplication}
-    The exact right-multiplication recursion in
-    \cite[Equation~(5.8)]{Fannes1992Finitely} is
+    The exact right-multiplication recursion follows from
+    \cite[Equation~(5.5)]{Fannes1992Finitely} and is
     \begin{align}
         \lVert F_{N+1}(B)\rVert^2
          & =\sum_{\mu=0}^{d-1}\lVert F_N(BA^\mu)\rVert^2.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -729,306 +729,6 @@ These projection and absorption identities precede the weighted Hilbert-space
 estimate in \cite[Lemma~5.2]{Fannes1992Finitely}. They do not by themselves
 assert a $\rho$-weighted norm bound or any quantitative decay constant.
 
-\subsection{The FNW lower boundary constant}
-\label{subsec:fnw_lower_boundary_constant}
-
-Let $D>0$, let $\rho\in\MN{D}$ be positive definite with
-$\tr(\rho)=1$, and equip $\MN{D}$ with
-\begin{align}
-    \langle B,C\rangle_\rho
-     & =\tr(\rho B^\dagger C),
-    \label{eq:fnw_weighted_inner}               \\
-    \lVert B\rVert_\rho^2
-     & =\operatorname{Re}\tr(\rho B^\dagger B).
-    \label{eq:fnw_weighted_norm}
-\end{align}
-Write $F_N$ for the length-$N$ FNW boundary map and set
-\begin{align}
-    a(N)
-     & =\operatorname{Re}\tr(\rho^{-1})
-    \bigl\lVert E_{\mathrm{FNW},A}^N-E_\infty^\rho
-    \bigr\rVert_{\mathrm{op},\rho}.
-    \label{eq:fnw_mixing_quantity}
-\end{align}
-This is the normalization used in
-\cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
-
-\begin{theorem}[Weighted boundary near-isometry]
-    \label{thm:fnw_boundary_near_isometry}
-    \lean{MPSTensor.norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le_fnwMixingQuantity}
-    \lean{MPSTensor.abs_fnwBoundaryMapCLM_norm_sq_sub_rhoWeighted_norm_sq_le}
-    \lean{MPSTensor.one_sub_fnwMixingQuantity_mul_norm_sq_le_fnwBoundaryMapCLM_norm_sq}
-    \leanok
-    \uses{def:fnw_boundary_map, def:fnw_transfer_map, def:fnw_limit_map}
-    For every $B,C\in\MN{D}$,
-    \begin{align}
-        \bigl|\langle F_N(B),F_N(C)\rangle
-        -\langle B,C\rangle_\rho\bigr|
-         & \leq a(N)\lVert B\rVert_\rho\lVert C\rVert_\rho.
-        \label{eq:fnw_boundary_near_isometry}
-    \end{align}
-    In particular,
-    \begin{align}
-        \bigl|\lVert F_N(B)\rVert^2-\lVert B\rVert_\rho^2\bigr|
-         & \leq a(N)\lVert B\rVert_\rho^2,
-        \label{eq:fnw_boundary_diagonal_defect} \\
-        (1-a(N))\lVert B\rVert_\rho^2
-         & \leq\lVert F_N(B)\rVert^2.
-        \label{eq:fnw_boundary_lower_estimate}
-    \end{align}
-    No sign assumption on $a(N)$ is needed for the last inequality.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The estimate in \cite[Equation~(5.9)]{Fannes1992Finitely} gives
-    (\ref{eq:fnw_boundary_near_isometry}). Set $C=B$ and use
-    $\langle B,B\rangle_\rho=\lVert B\rVert_\rho^2$ to obtain
-    (\ref{eq:fnw_boundary_diagonal_defect}). Its lower half is
-    (\ref{eq:fnw_boundary_lower_estimate}).
-\end{proof}
-
-\begin{definition}[Lower boundary constant]
-    \label{def:fnw_lower_boundary_constant}
-    \lean{MPSTensor.fnwBoundaryNormRatio}
-    \lean{MPSTensor.fnwLowerBoundaryConstant}
-    \leanok
-    \uses{def:fnw_boundary_map}
-    For $B\neq0$, define the boundary norm-square ratio
-    \begin{align}
-        r_N(B)
-         & :=\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}.
-        \label{eq:fnw_boundary_ratio}
-    \end{align}
-    The lower boundary constant of
-    \cite[Lemma~5.3]{Fannes1992Finitely} is
-    \begin{align}
-        a_-(N)
-         & :=\inf_{B\in\MN{D},\,B\neq0}r_N(B).
-        \label{eq:fnw_lower_boundary_constant}
-    \end{align}
-\end{definition}
-
-\begin{definition}[Weighted boundary Gram operator]
-    \label{def:fnw_boundary_gram}
-    \lean{MPSTensor.fnwBoundaryGram}
-    \leanok
-    \uses{def:fnw_boundary_map}
-    The weighted Gram operator on the virtual matrix Hilbert space is
-    \begin{align}
-        G_N & :=F_N^\dagger F_N.
-        \label{eq:fnw_boundary_gram}
-    \end{align}
-\end{definition}
-
-\begin{theorem}[Rayleigh characterization of the lower boundary constant]
-    \label{thm:fnw_lower_boundary_rayleigh}
-    \lean{MPSTensor.fnwBoundaryNormRatio_eq_gram_rayleighQuotient}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf}
-    \lean{MPSTensor.fnwBoundaryGram_isSymmetric}
-    \lean{MPSTensor.fnwBoundaryGram_isPositive}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
-    The operator $G_N$ is self-adjoint and positive. For every nonzero
-    $B\in\MN{D}$,
-    \begin{align}
-        r_N(B)
-         & =\frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
-        {\lVert B\rVert_\rho^2},
-        \label{eq:fnw_boundary_rayleigh_ratio}                 \\
-        a_-(N)
-         & =\inf_{B\neq0}
-        \frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
-        {\lVert B\rVert_\rho^2}.
-        \label{eq:fnw_lower_boundary_rayleigh}
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
-    The adjoint identity gives
-    $\langle G_NB,B\rangle_\rho=\langle F_NB,F_NB\rangle$.
-    Divide by $\lVert B\rVert_\rho^2$ and take the infimum over
-    $B\neq0$. Self-adjointness and positivity follow directly from
-    $G_N=F_N^\dagger F_N$.
-\end{proof}
-
-\begin{theorem}[Least spectral value of the weighted Gram operator]
-    \label{thm:fnw_lower_boundary_spectrum}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_le_ratio}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_rayleigh}
-    The real number $a_-(N)$ is a spectral value of $G_N$, and every
-    $z\in\operatorname{spec}(G_N)$ satisfies
-    \begin{align}
-        a_-(N) & \leq\operatorname{Re}z.
-        \label{eq:fnw_lower_boundary_spectrum_min}
-    \end{align}
-    Thus $a_-(N)$ is the least spectral value in the sense of real parts.
-    The spectrum is a subset of $\C$, where no compatible order is fixed, so
-    the assertion is stated as spectral membership together with
-    (\ref{eq:fnw_lower_boundary_spectrum_min}).
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:fnw_lower_boundary_rayleigh}
-    The minimum of the Rayleigh quotient of a finite-dimensional self-adjoint
-    operator is an eigenvalue. Conversely, if $G_NB=zB$ with $B\neq0$, then
-    self-adjointness makes $z$ real and
-    \begin{align}
-        a_-(N)
-         & \leq r_N(B)=\operatorname{Re}z.
-    \end{align}
-\end{proof}
-
-\begin{theorem}[Least finite-domain singular value]
-    \label{thm:fnw_lower_boundary_singular}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_least_sq_singularValue}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_spectrum}
-    Let $m=\dim_{\C}\MN{D}$. There is an index
-    $i\in\{0,\ldots,m-1\}$ such that
-    \begin{align}
-        \sigma_i(F_N)^2 & =a_-(N),
-        \label{eq:fnw_lower_boundary_least_singular}
-    \end{align}
-    and $a_-(N)\leq\sigma_j(F_N)^2$ for every
-    $j\in\{0,\ldots,m-1\}$. The indices range only over the finite
-    virtual domain dimension. No zero-padded sequence indexed by all natural
-    numbers is used.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:fnw_lower_boundary_spectrum}
-    The squared singular values of $F_N$ are the eigenvalues of
-    $F_N^\dagger F_N=G_N$, indexed by an orthonormal eigenbasis of the
-    finite-dimensional domain. Apply
-    Theorem~\ref{thm:fnw_lower_boundary_spectrum}.
-\end{proof}
-
-\begin{theorem}[Optimal quadratic lower-bound constant]
-    \label{thm:fnw_lower_boundary_optimal}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_mul_norm_sq_le}
-    \lean{MPSTensor.le_fnwLowerBoundaryConstant_iff}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant}
-    For every $B\in\MN{D}$,
-    \begin{align}
-        a_-(N)\lVert B\rVert_\rho^2
-         & \leq\lVert F_N(B)\rVert^2.
-        \label{eq:fnw_lower_boundary_universal}
-    \end{align}
-    More generally, a real number $c$ satisfies
-    \begin{align}
-        c\leq a_-(N)
-        \quad\Longleftrightarrow\quad
-        c\lVert B\rVert_\rho^2
-        \leq\lVert F_N(B)\rVert^2
-        \text{ for every }B\in\MN{D}.
-        \label{eq:fnw_lower_boundary_optimal}
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant}
-    For $B\neq0$, divide the desired inequality by
-    $\lVert B\rVert_\rho^2$ and use the infimum in
-    (\ref{eq:fnw_lower_boundary_constant}). The zero matrix is immediate.
-    Taking the infimum over nonzero $B$ proves the reverse implication in
-    (\ref{eq:fnw_lower_boundary_optimal}).
-\end{proof}
-
-\begin{theorem}[FNW lower estimate and positivity]
-    \label{thm:fnw_lower_boundary_estimate}
-    \lean{MPSTensor.one_sub_fnwMixingQuantity_le_fnwLowerBoundaryConstant}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_pos}
-    \leanok
-    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
-    The lower boundary constant satisfies
-    \begin{align}
-        a_-(N) & \geq1-a(N).
-        \label{eq:fnw_lower_boundary_one_sub}
-    \end{align}
-    Consequently, $a_-(N)>0$ whenever $a(N)<1$. This is the lower estimate in
-    \cite[Lemma~5.3]{Fannes1992Finitely}. No equality
-    $a_-(N)=1-a(N)$ is asserted.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
-    The bound (\ref{eq:fnw_boundary_lower_estimate}) says that $1-a(N)$ is a
-    universal quadratic lower bound. Apply
-    (\ref{eq:fnw_lower_boundary_optimal}). If $a(N)<1$, then
-    $1-a(N)>0$, and (\ref{eq:fnw_lower_boundary_one_sub}) gives positivity.
-\end{proof}
-
-\begin{theorem}[Stationary weighted right-multiplication identity]
-    \label{thm:rho_weighted_right_multiplication}
-    \lean{MPSTensor.sum_rhoWeighted_norm_sq_mul_eq}
-    \leanok
-    \uses{def:transfer_map}
-    If $\E_A(\rho)=\rho$, then every $B\in\MN{D}$ satisfies
-    \begin{align}
-        \sum_{\mu=0}^{d-1}\lVert BA^\mu\rVert_\rho^2
-         & =\lVert B\rVert_\rho^2.
-        \label{eq:rho_weighted_right_multiplication}
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:transfer_map}
-    Expand the left-hand side using
-    (\ref{eq:fnw_weighted_norm}), cycle the trace, and sum over
-    $\mu$. The result is
-    $\operatorname{Re}\tr(\E_A(\rho)B^\dagger B)$, which equals the
-    right-hand side by stationarity.
-\end{proof}
-
-\begin{theorem}[Monotonicity of the lower boundary constant]
-    \label{thm:fnw_lower_boundary_mono}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_le_succ}
-    \lean{MPSTensor.fnwLowerBoundaryConstant_mono}
-    \lean{MPSTensor.IsPrimitiveMPS.fnwLowerBoundaryConstant_mono}
-    \leanok
-    \uses{def:fnw_lower_boundary_constant, thm:fnw_lower_boundary_optimal, thm:rho_weighted_right_multiplication}
-    If $\E_A(\rho)=\rho$, then
-    \begin{align}
-        a_-(N+1) & \geq a_-(N)
-        \label{eq:fnw_lower_boundary_succ}
-    \end{align}
-    for every $N\in\N$. Hence $N\mapsto a_-(N)$ is nondecreasing. The same
-    conclusion holds for every primitive MPS tensor with positive-definite
-    fixed point $\rho$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:fnw_lower_boundary_optimal, thm:rho_weighted_right_multiplication}
-    The exact right-multiplication recursion in
-    \cite[Equation~(5.8)]{Fannes1992Finitely} is
-    \begin{align}
-        \lVert F_{N+1}(B)\rVert^2
-         & =\sum_{\mu=0}^{d-1}\lVert F_N(BA^\mu)\rVert^2.
-    \end{align}
-    Apply (\ref{eq:fnw_lower_boundary_universal}) to each summand and then
-    use (\ref{eq:rho_weighted_right_multiplication}). This proves
-    (\ref{eq:fnw_lower_boundary_succ}); induction gives monotonicity.
-\end{proof}
-
-The preceding results formalize the lower-boundary assertions of
-\cite[Lemma~5.3]{Fannes1992Finitely}. They do not include Lemma~6.2, the
-projector-defect terms, a replacement by an unweighted finite Gram matrix,
-periodic coercivity, a comparison of unequal kernels, a dimension prefactor,
-or an identity $a_-(N)=1-a(N)$.
-
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}
     \lean{Matrix.gramReshuffle}
@@ -1660,11 +1360,312 @@ $A^\mu=v(\mu)^\dagger$.
 \end{proof}
 
 The preceding results establish Equations~(5.8)--(5.9) and the right-boundary
-recursion, but not Lemmas~5.3 or~6.2 of
-Ref.~\cite{Fannes1992Finitely}. In the source proof of Lemma~6.2,
-Equation~(6.5) contributes $a(m)/a_-(m)$, while the subsequent orthogonality
-estimates contribute $a(m)^2/a_-(m)$. Their sum is
+recursion used below for Lemma~5.3. They do not prove Lemma~6.2. In its source
+proof, Equation~(6.5) contributes $a(m)/a_-(m)$, while the subsequent
+orthogonality estimates contribute $a(m)^2/a_-(m)$. Their sum is
 $a(m)(1+a(m))/a_-(m)$.
+
+\subsection{The FNW lower boundary constant}
+\label{subsec:fnw_lower_boundary_constant}
+
+Let $D>0$, let $\rho\in\MN{D}$ be positive definite with
+$\tr(\rho)=1$, and equip $\MN{D}$ with
+\begin{align}
+    \langle B,C\rangle_\rho
+     & =\tr(\rho B^\dagger C),
+    \label{eq:fnw_weighted_inner}               \\
+    \lVert B\rVert_\rho^2
+     & =\operatorname{Re}\tr(\rho B^\dagger B).
+    \label{eq:fnw_weighted_norm}
+\end{align}
+Write $F_N$ for the length-$N$ FNW boundary map and set
+\begin{align}
+    a(N)
+     & =\operatorname{Re}\tr(\rho^{-1})
+    \bigl\lVert E_{\mathrm{FNW},A}^N-E_\infty^\rho
+    \bigr\rVert_{\mathrm{op},\rho}.
+    \label{eq:fnw_mixing_quantity}
+\end{align}
+This is the normalization used in
+\cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
+
+\begin{theorem}[Weighted boundary near-isometry]
+    \label{thm:fnw_boundary_near_isometry}
+    \lean{MPSTensor.norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le_fnwMixingQuantity}
+    \lean{MPSTensor.abs_fnwBoundaryMapCLM_norm_sq_sub_rhoWeighted_norm_sq_le}
+    \lean{MPSTensor.one_sub_fnwMixingQuantity_mul_norm_sq_le_fnwBoundaryMapCLM_norm_sq}
+    \leanok
+    \uses{def:fnw_mixing_quantity, thm:fnw_boundary_near_isometry_exact}
+    For every $B,C\in\MN{D}$,
+    \begin{align}
+        \bigl|\langle F_N(B),F_N(C)\rangle
+        -\langle B,C\rangle_\rho\bigr|
+         & \leq a(N)\lVert B\rVert_\rho\lVert C\rVert_\rho.
+        \label{eq:fnw_boundary_near_isometry}
+    \end{align}
+    In particular,
+    \begin{align}
+        \bigl|\lVert F_N(B)\rVert^2-\lVert B\rVert_\rho^2\bigr|
+         & \leq a(N)\lVert B\rVert_\rho^2,
+        \label{eq:fnw_boundary_diagonal_defect} \\
+        (1-a(N))\lVert B\rVert_\rho^2
+         & \leq\lVert F_N(B)\rVert^2.
+        \label{eq:fnw_boundary_lower_estimate}
+    \end{align}
+    No sign assumption on $a(N)$ is needed for the last inequality.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The estimate in \cite[Equation~(5.9)]{Fannes1992Finitely} gives
+    (\ref{eq:fnw_boundary_near_isometry}). Set $C=B$ and use
+    $\langle B,B\rangle_\rho=\lVert B\rVert_\rho^2$ to obtain
+    (\ref{eq:fnw_boundary_diagonal_defect}). Its lower half is
+    (\ref{eq:fnw_boundary_lower_estimate}).
+\end{proof}
+
+\begin{definition}[Lower boundary constant]
+    \label{def:fnw_lower_boundary_constant}
+    \lean{MPSTensor.fnwBoundaryNormRatio}
+    \lean{MPSTensor.fnwLowerBoundaryConstant}
+    \leanok
+    \uses{def:fnw_boundary_clm}
+    For $B\neq0$, define the boundary norm-square ratio
+    \begin{align}
+        r_N(B)
+         & :=\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}.
+        \label{eq:fnw_boundary_ratio}
+    \end{align}
+    The lower boundary constant of
+    \cite[Lemma~5.3]{Fannes1992Finitely} is
+    \begin{align}
+        a_-(N)
+         & :=\inf_{B\in\MN{D},\,B\neq0}r_N(B).
+        \label{eq:fnw_lower_boundary_constant}
+    \end{align}
+\end{definition}
+
+\begin{definition}[Weighted boundary Gram operator]
+    \label{def:fnw_boundary_gram}
+    \lean{MPSTensor.fnwBoundaryGram}
+    \leanok
+    \uses{def:fnw_boundary_clm}
+    The weighted Gram operator on the virtual matrix Hilbert space is
+    \begin{align}
+        G_N & :=F_N^\dagger F_N.
+        \label{eq:fnw_boundary_gram}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Rayleigh characterization of the lower boundary constant]
+    \label{thm:fnw_lower_boundary_rayleigh}
+    \lean{MPSTensor.fnwBoundaryNormRatio_eq_gram_rayleighQuotient}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf}
+    \lean{MPSTensor.fnwBoundaryGram_isSymmetric}
+    \lean{MPSTensor.fnwBoundaryGram_isPositive}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
+    The operator $G_N$ is self-adjoint and positive. For every nonzero
+    $B\in\MN{D}$,
+    \begin{align}
+        r_N(B)
+         & =\frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
+        {\lVert B\rVert_\rho^2},
+        \label{eq:fnw_boundary_rayleigh_ratio}                 \\
+        a_-(N)
+         & =\inf_{B\neq0}
+        \frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
+        {\lVert B\rVert_\rho^2}.
+        \label{eq:fnw_lower_boundary_rayleigh}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
+    The adjoint identity gives
+    $\langle G_NB,B\rangle_\rho=\langle F_NB,F_NB\rangle$.
+    Divide by $\lVert B\rVert_\rho^2$ and take the infimum over
+    $B\neq0$. Self-adjointness and positivity follow directly from
+    $G_N=F_N^\dagger F_N$.
+\end{proof}
+
+\begin{theorem}[Least spectral value of the weighted Gram operator]
+    \label{thm:fnw_lower_boundary_spectrum}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_ratio}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_rayleigh}
+    The real number $a_-(N)$ is a spectral value of $G_N$, and every
+    $z\in\operatorname{spec}(G_N)$ satisfies
+    \begin{align}
+        a_-(N) & \leq\operatorname{Re}z.
+        \label{eq:fnw_lower_boundary_spectrum_min}
+    \end{align}
+    Thus $a_-(N)$ is the least spectral value in the sense of real parts.
+    The spectrum is a subset of $\C$, where no compatible order is fixed, so
+    the assertion is stated as spectral membership together with
+    (\ref{eq:fnw_lower_boundary_spectrum_min}).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_lower_boundary_rayleigh}
+    The minimum of the Rayleigh quotient of a finite-dimensional self-adjoint
+    operator is an eigenvalue. Conversely, if $G_NB=zB$ with $B\neq0$, then
+    self-adjointness makes $z$ real and
+    \begin{align}
+        a_-(N)
+         & \leq r_N(B)=\operatorname{Re}z.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Least finite-domain singular value]
+    \label{thm:fnw_lower_boundary_singular}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_least_sq_singularValue}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_spectrum}
+    Let $m=\dim_{\C}\MN{D}$. There is an index
+    $i\in\{0,\ldots,m-1\}$ such that
+    \begin{align}
+        \sigma_i(F_N)^2 & =a_-(N),
+        \label{eq:fnw_lower_boundary_least_singular}
+    \end{align}
+    and $a_-(N)\leq\sigma_j(F_N)^2$ for every
+    $j\in\{0,\ldots,m-1\}$. The indices range only over the finite
+    virtual domain dimension. No zero-padded sequence indexed by all natural
+    numbers is used.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_lower_boundary_spectrum}
+    The squared singular values of $F_N$ are the eigenvalues of
+    $F_N^\dagger F_N=G_N$, indexed by an orthonormal eigenbasis of the
+    finite-dimensional domain. Apply
+    Theorem~\ref{thm:fnw_lower_boundary_spectrum}.
+\end{proof}
+
+\begin{theorem}[Optimal quadratic lower-bound constant]
+    \label{thm:fnw_lower_boundary_optimal}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mul_norm_sq_le}
+    \lean{MPSTensor.le_fnwLowerBoundaryConstant_iff}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant}
+    For every $B\in\MN{D}$,
+    \begin{align}
+        a_-(N)\lVert B\rVert_\rho^2
+         & \leq\lVert F_N(B)\rVert^2.
+        \label{eq:fnw_lower_boundary_universal}
+    \end{align}
+    More generally, a real number $c$ satisfies
+    \begin{align}
+        c\leq a_-(N)
+        \quad\Longleftrightarrow\quad
+        c\lVert B\rVert_\rho^2
+        \leq\lVert F_N(B)\rVert^2
+        \text{ for every }B\in\MN{D}.
+        \label{eq:fnw_lower_boundary_optimal}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant}
+    For $B\neq0$, divide the desired inequality by
+    $\lVert B\rVert_\rho^2$ and use the infimum in
+    (\ref{eq:fnw_lower_boundary_constant}). The zero matrix is immediate.
+    Taking the infimum over nonzero $B$ proves the reverse implication in
+    (\ref{eq:fnw_lower_boundary_optimal}).
+\end{proof}
+
+\begin{theorem}[FNW lower estimate and positivity]
+    \label{thm:fnw_lower_boundary_estimate}
+    \lean{MPSTensor.one_sub_fnwMixingQuantity_le_fnwLowerBoundaryConstant}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_pos}
+    \leanok
+    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
+    The lower boundary constant satisfies
+    \begin{align}
+        a_-(N) & \geq1-a(N).
+        \label{eq:fnw_lower_boundary_one_sub}
+    \end{align}
+    Consequently, $a_-(N)>0$ whenever $a(N)<1$. This is the lower estimate in
+    \cite[Lemma~5.3]{Fannes1992Finitely}. No equality
+    $a_-(N)=1-a(N)$ is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
+    The bound (\ref{eq:fnw_boundary_lower_estimate}) says that $1-a(N)$ is a
+    universal quadratic lower bound. Apply
+    (\ref{eq:fnw_lower_boundary_optimal}). If $a(N)<1$, then
+    $1-a(N)>0$, and (\ref{eq:fnw_lower_boundary_one_sub}) gives positivity.
+\end{proof}
+
+\begin{theorem}[Stationary weighted right-multiplication identity]
+    \label{thm:rho_weighted_right_multiplication}
+    \lean{MPSTensor.sum_rhoWeighted_norm_sq_mul_eq}
+    \leanok
+    \uses{def:transfer_map}
+    If $\E_A(\rho)=\rho$, then every $B\in\MN{D}$ satisfies
+    \begin{align}
+        \sum_{\mu=0}^{d-1}\lVert BA^\mu\rVert_\rho^2
+         & =\lVert B\rVert_\rho^2.
+        \label{eq:rho_weighted_right_multiplication}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:transfer_map}
+    Expand the left-hand side using
+    (\ref{eq:fnw_weighted_norm}), cycle the trace, and sum over
+    $\mu$. The result is
+    $\operatorname{Re}\tr(\E_A(\rho)B^\dagger B)$, which equals the
+    right-hand side by stationarity.
+\end{proof}
+
+\begin{theorem}[Monotonicity of the lower boundary constant]
+    \label{thm:fnw_lower_boundary_mono}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_succ}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mono}
+    \lean{MPSTensor.IsPrimitiveMPS.fnwLowerBoundaryConstant_mono}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, thm:fnw_boundary_norm_sq_succ,
+        thm:fnw_lower_boundary_optimal, thm:rho_weighted_right_multiplication}
+    If $\E_A(\rho)=\rho$, then
+    \begin{align}
+        a_-(N+1) & \geq a_-(N)
+        \label{eq:fnw_lower_boundary_succ}
+    \end{align}
+    for every $N\in\N$. Hence $N\mapsto a_-(N)$ is nondecreasing. The same
+    conclusion holds for every primitive MPS tensor with positive-definite
+    fixed point $\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_boundary_norm_sq_succ, thm:fnw_lower_boundary_optimal,
+        thm:rho_weighted_right_multiplication}
+    The exact right-multiplication recursion in
+    \cite[Equation~(5.8)]{Fannes1992Finitely} is
+    \begin{align}
+        \lVert F_{N+1}(B)\rVert^2
+         & =\sum_{\mu=0}^{d-1}\lVert F_N(BA^\mu)\rVert^2.
+    \end{align}
+    Apply (\ref{eq:fnw_lower_boundary_universal}) to each summand and then
+    use (\ref{eq:rho_weighted_right_multiplication}). This proves
+    (\ref{eq:fnw_lower_boundary_succ}); induction gives monotonicity.
+\end{proof}
+
+The preceding results formalize the lower-boundary assertions of
+\cite[Lemma~5.3]{Fannes1992Finitely}. They do not include Lemma~6.2, the
+projector-defect terms, a replacement by an unweighted finite Gram matrix,
+periodic coercivity, a comparison of unequal kernels, a dimension prefactor,
+or an identity $a_-(N)=1-a(N)$.
 
 \begin{theorem}[Geometric power bound below unit spectral radius]
     \label{thm:geometric_bound_of_spectral_radius_lt_one}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -835,7 +835,7 @@ This is the normalization used in
         r_N(B)
          & =\frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
         {\lVert B\rVert_\rho^2},
-        \label{eq:fnw_boundary_rayleigh_ratio}\
+        \label{eq:fnw_boundary_rayleigh_ratio}                 \\
         a_-(N)
          & =\inf_{B\neq0}
         \frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -890,7 +890,7 @@ This is the normalization used in
     \lean{MPSTensor.fnwLowerBoundaryConstant_eq_least_sq_singularValue}
     \leanok
     \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_spectrum}
-    Let $m=\dim_\C\MN{D}$. There is an index
+    Let $m=\dim_{\C}\MN{D}$. There is an index
     $i\in\{0,\ldots,m-1\}$ such that
     \begin{align}
         \sigma_i(F_N)^2 & =a_-(N),

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -726,9 +726,308 @@ constant $C_\lambda=k^2$.
 \end{proof}
 
 These projection and absorption identities precede the weighted Hilbert-space
-estimate in \cite[Lemma~5.2]{Fannes1992Finitely}. They do not assert a
-$\rho$-weighted norm bound or any quantitative decay constant, and they do not
-include the later conclusions of Lemmas~5.3 and~6.2 of that paper.
+estimate in \cite[Lemma~5.2]{Fannes1992Finitely}. They do not by themselves
+assert a $\rho$-weighted norm bound or any quantitative decay constant.
+
+\subsection{The FNW lower boundary constant}
+\label{subsec:fnw_lower_boundary_constant}
+
+Let $D>0$, let $\rho\in\MN{D}$ be positive definite with
+$\tr(\rho)=1$, and equip $\MN{D}$ with
+\begin{align}
+    \langle B,C\rangle_\rho
+     & =\tr(\rho B^\dagger C),
+    \label{eq:fnw_weighted_inner}               \\
+    \lVert B\rVert_\rho^2
+     & =\operatorname{Re}\tr(\rho B^\dagger B).
+    \label{eq:fnw_weighted_norm}
+\end{align}
+Write $F_N$ for the length-$N$ FNW boundary map and set
+\begin{align}
+    a(N)
+     & =\operatorname{Re}\tr(\rho^{-1})
+    \bigl\lVert E_{\mathrm{FNW},A}^N-E_\infty^\rho
+    \bigr\rVert_{\mathrm{op},\rho}.
+    \label{eq:fnw_mixing_quantity}
+\end{align}
+This is the normalization used in
+\cite[Equations~(5.9)--(5.10)]{Fannes1992Finitely}.
+
+\begin{theorem}[Weighted boundary near-isometry]
+    \label{thm:fnw_boundary_near_isometry}
+    \lean{MPSTensor.norm_inner_fnwBoundaryMapCLM_sub_rhoWeighted_le_fnwMixingQuantity}
+    \lean{MPSTensor.abs_fnwBoundaryMapCLM_norm_sq_sub_rhoWeighted_norm_sq_le}
+    \lean{MPSTensor.one_sub_fnwMixingQuantity_mul_norm_sq_le_fnwBoundaryMapCLM_norm_sq}
+    \leanok
+    \uses{def:fnw_boundary_map, def:fnw_transfer_map, def:fnw_limit_map}
+    For every $B,C\in\MN{D}$,
+    \begin{align}
+        \bigl|\langle F_N(B),F_N(C)\rangle
+        -\langle B,C\rangle_\rho\bigr|
+         & \leq a(N)\lVert B\rVert_\rho\lVert C\rVert_\rho.
+        \label{eq:fnw_boundary_near_isometry}
+    \end{align}
+    In particular,
+    \begin{align}
+        \bigl|\lVert F_N(B)\rVert^2-\lVert B\rVert_\rho^2\bigr|
+         & \leq a(N)\lVert B\rVert_\rho^2,
+        \label{eq:fnw_boundary_diagonal_defect} \\
+        (1-a(N))\lVert B\rVert_\rho^2
+         & \leq\lVert F_N(B)\rVert^2.
+        \label{eq:fnw_boundary_lower_estimate}
+    \end{align}
+    No sign assumption on $a(N)$ is needed for the last inequality.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The estimate in \cite[Equation~(5.9)]{Fannes1992Finitely} gives
+    (\ref{eq:fnw_boundary_near_isometry}). Set $C=B$ and use
+    $\langle B,B\rangle_\rho=\lVert B\rVert_\rho^2$ to obtain
+    (\ref{eq:fnw_boundary_diagonal_defect}). Its lower half is
+    (\ref{eq:fnw_boundary_lower_estimate}).
+\end{proof}
+
+\begin{definition}[Lower boundary constant]
+    \label{def:fnw_lower_boundary_constant}
+    \lean{MPSTensor.fnwBoundaryNormRatio}
+    \lean{MPSTensor.fnwLowerBoundaryConstant}
+    \leanok
+    \uses{def:fnw_boundary_map}
+    For $B\neq0$, define the boundary norm-square ratio
+    \begin{align}
+        r_N(B)
+         & :=\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}.
+        \label{eq:fnw_boundary_ratio}
+    \end{align}
+    The lower boundary constant of
+    \cite[Lemma~5.3]{Fannes1992Finitely} is
+    \begin{align}
+        a_-(N)
+         & :=\inf_{B\in\MN{D},\,B\neq0}r_N(B).
+        \label{eq:fnw_lower_boundary_constant}
+    \end{align}
+\end{definition}
+
+\begin{definition}[Weighted boundary Gram operator]
+    \label{def:fnw_boundary_gram}
+    \lean{MPSTensor.fnwBoundaryGram}
+    \leanok
+    \uses{def:fnw_boundary_map}
+    The weighted Gram operator on the virtual matrix Hilbert space is
+    \begin{align}
+        G_N & :=F_N^\dagger F_N.
+        \label{eq:fnw_boundary_gram}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Rayleigh characterization of the lower boundary constant]
+    \label{thm:fnw_lower_boundary_rayleigh}
+    \lean{MPSTensor.fnwBoundaryNormRatio_eq_gram_rayleighQuotient}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_gram_rayleigh_iInf}
+    \lean{MPSTensor.fnwBoundaryGram_isSymmetric}
+    \lean{MPSTensor.fnwBoundaryGram_isPositive}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
+    The operator $G_N$ is self-adjoint and positive. For every nonzero
+    $B\in\MN{D}$,
+    \begin{align}
+        r_N(B)
+         & =\frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
+        {\lVert B\rVert_\rho^2},
+        \label{eq:fnw_boundary_rayleigh_ratio}\
+        a_-(N)
+         & =\inf_{B\neq0}
+        \frac{\operatorname{Re}\langle G_NB,B\rangle_\rho}
+        {\lVert B\rVert_\rho^2}.
+        \label{eq:fnw_lower_boundary_rayleigh}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram}
+    The adjoint identity gives
+    $\langle G_NB,B\rangle_\rho=\langle F_NB,F_NB\rangle$.
+    Divide by $\lVert B\rVert_\rho^2$ and take the infimum over
+    $B\neq0$. Self-adjointness and positivity follow directly from
+    $G_N=F_N^\dagger F_N$.
+\end{proof}
+
+\begin{theorem}[Least spectral value of the weighted Gram operator]
+    \label{thm:fnw_lower_boundary_spectrum}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mem_spectrum_fnwBoundaryGram}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_ratio}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_re_of_mem_spectrum_fnwBoundaryGram}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_rayleigh}
+    The real number $a_-(N)$ is a spectral value of $G_N$, and every
+    $z\in\operatorname{spec}(G_N)$ satisfies
+    \begin{align}
+        a_-(N) & \leq\operatorname{Re}z.
+        \label{eq:fnw_lower_boundary_spectrum_min}
+    \end{align}
+    Thus $a_-(N)$ is the least spectral value in the sense of real parts.
+    The spectrum is a subset of $\C$, where no compatible order is fixed, so
+    the assertion is stated as spectral membership together with
+    (\ref{eq:fnw_lower_boundary_spectrum_min}).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_lower_boundary_rayleigh}
+    The minimum of the Rayleigh quotient of a finite-dimensional self-adjoint
+    operator is an eigenvalue. Conversely, if $G_NB=zB$ with $B\neq0$, then
+    self-adjointness makes $z$ real and
+    \begin{align}
+        a_-(N)
+         & \leq r_N(B)=\operatorname{Re}z.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Least finite-domain singular value]
+    \label{thm:fnw_lower_boundary_singular}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_eq_least_sq_singularValue}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, def:fnw_boundary_gram, thm:fnw_lower_boundary_spectrum}
+    Let $m=\dim_\C\MN{D}$. There is an index
+    $i\in\{0,\ldots,m-1\}$ such that
+    \begin{align}
+        \sigma_i(F_N)^2 & =a_-(N),
+        \label{eq:fnw_lower_boundary_least_singular}
+    \end{align}
+    and $a_-(N)\leq\sigma_j(F_N)^2$ for every
+    $j\in\{0,\ldots,m-1\}$. The indices range only over the finite
+    virtual domain dimension. No zero-padded sequence indexed by all natural
+    numbers is used.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_lower_boundary_spectrum}
+    The squared singular values of $F_N$ are the eigenvalues of
+    $F_N^\dagger F_N=G_N$, indexed by an orthonormal eigenbasis of the
+    finite-dimensional domain. Apply
+    Theorem~\ref{thm:fnw_lower_boundary_spectrum}.
+\end{proof}
+
+\begin{theorem}[Optimal quadratic lower-bound constant]
+    \label{thm:fnw_lower_boundary_optimal}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mul_norm_sq_le}
+    \lean{MPSTensor.le_fnwLowerBoundaryConstant_iff}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant}
+    For every $B\in\MN{D}$,
+    \begin{align}
+        a_-(N)\lVert B\rVert_\rho^2
+         & \leq\lVert F_N(B)\rVert^2.
+        \label{eq:fnw_lower_boundary_universal}
+    \end{align}
+    More generally, a real number $c$ satisfies
+    \begin{align}
+        c\leq a_-(N)
+        \quad\Longleftrightarrow\quad
+        c\lVert B\rVert_\rho^2
+        \leq\lVert F_N(B)\rVert^2
+        \text{ for every }B\in\MN{D}.
+        \label{eq:fnw_lower_boundary_optimal}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant}
+    For $B\neq0$, divide the desired inequality by
+    $\lVert B\rVert_\rho^2$ and use the infimum in
+    (\ref{eq:fnw_lower_boundary_constant}). The zero matrix is immediate.
+    Taking the infimum over nonzero $B$ proves the reverse implication in
+    (\ref{eq:fnw_lower_boundary_optimal}).
+\end{proof}
+
+\begin{theorem}[FNW lower estimate and positivity]
+    \label{thm:fnw_lower_boundary_estimate}
+    \lean{MPSTensor.one_sub_fnwMixingQuantity_le_fnwLowerBoundaryConstant}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_pos}
+    \leanok
+    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
+    The lower boundary constant satisfies
+    \begin{align}
+        a_-(N) & \geq1-a(N).
+        \label{eq:fnw_lower_boundary_one_sub}
+    \end{align}
+    Consequently, $a_-(N)>0$ whenever $a(N)<1$. This is the lower estimate in
+    \cite[Lemma~5.3]{Fannes1992Finitely}. No equality
+    $a_-(N)=1-a(N)$ is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_boundary_near_isometry, thm:fnw_lower_boundary_optimal}
+    The bound (\ref{eq:fnw_boundary_lower_estimate}) says that $1-a(N)$ is a
+    universal quadratic lower bound. Apply
+    (\ref{eq:fnw_lower_boundary_optimal}). If $a(N)<1$, then
+    $1-a(N)>0$, and (\ref{eq:fnw_lower_boundary_one_sub}) gives positivity.
+\end{proof}
+
+\begin{theorem}[Stationary weighted right-multiplication identity]
+    \label{thm:rho_weighted_right_multiplication}
+    \lean{MPSTensor.sum_rhoWeighted_norm_sq_mul_eq}
+    \leanok
+    \uses{def:transfer_map}
+    If $\E_A(\rho)=\rho$, then every $B\in\MN{D}$ satisfies
+    \begin{align}
+        \sum_{\mu=0}^{d-1}\lVert BA^\mu\rVert_\rho^2
+         & =\lVert B\rVert_\rho^2.
+        \label{eq:rho_weighted_right_multiplication}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:transfer_map}
+    Expand the left-hand side using
+    (\ref{eq:fnw_weighted_norm}), cycle the trace, and sum over
+    $\mu$. The result is
+    $\operatorname{Re}\tr(\E_A(\rho)B^\dagger B)$, which equals the
+    right-hand side by stationarity.
+\end{proof}
+
+\begin{theorem}[Monotonicity of the lower boundary constant]
+    \label{thm:fnw_lower_boundary_mono}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_le_succ}
+    \lean{MPSTensor.fnwLowerBoundaryConstant_mono}
+    \lean{MPSTensor.IsPrimitiveMPS.fnwLowerBoundaryConstant_mono}
+    \leanok
+    \uses{def:fnw_lower_boundary_constant, thm:fnw_lower_boundary_optimal, thm:rho_weighted_right_multiplication}
+    If $\E_A(\rho)=\rho$, then
+    \begin{align}
+        a_-(N+1) & \geq a_-(N)
+        \label{eq:fnw_lower_boundary_succ}
+    \end{align}
+    for every $N\in\N$. Hence $N\mapsto a_-(N)$ is nondecreasing. The same
+    conclusion holds for every primitive MPS tensor with positive-definite
+    fixed point $\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fnw_lower_boundary_optimal, thm:rho_weighted_right_multiplication}
+    The exact right-multiplication recursion in
+    \cite[Equation~(5.8)]{Fannes1992Finitely} is
+    \begin{align}
+        \lVert F_{N+1}(B)\rVert^2
+         & =\sum_{\mu=0}^{d-1}\lVert F_N(BA^\mu)\rVert^2.
+    \end{align}
+    Apply (\ref{eq:fnw_lower_boundary_universal}) to each summand and then
+    use (\ref{eq:rho_weighted_right_multiplication}). This proves
+    (\ref{eq:fnw_lower_boundary_succ}); induction gives monotonicity.
+\end{proof}
+
+The preceding results formalize the lower-boundary assertions of
+\cite[Lemma~5.3]{Fannes1992Finitely}. They do not include Lemma~6.2, the
+projector-defect terms, a replacement by an unweighted finite Gram matrix,
+periodic coercivity, a comparison of unequal kernels, a dimension prefactor,
+or an identity $a_-(N)=1-a(N)$.
 
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1727,8 +1727,8 @@ right-boundary recursion
     \label{eq:cpgsv21_martingale_overlap_fnw_boundary_recursion}
 \end{align}
 is \leanid{MPSTensor.fnwBoundaryMapCLM_norm_sq_succ}, with
-$A^\mu=v(\mu)^\dagger$. Lemmas~5.3 and~6.2 and the optimized numerator remain
-open on the publication base.
+$A^\mu=v(\mu)^\dagger$. Lemma~6.2 and the optimized numerator remain open on
+the publication base.
 
 The reconstructed coefficient is not the optimized FNW expression
 \begin{align}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -127,8 +127,11 @@ Ref.~\cite{Nachtergaele1996Spectral}; Theorem~3 of the same reference gives
 the corresponding gap lower bounds. Section~6 verifies C3$'$ for GVBS/MPS
 Hamiltonians using projection estimates inherited from
 Ref.~\cite{Fannes1992Finitely}. The formal development instead proves a
-sufficient range-two estimate after physical blocking. The optimized FNW
-numerator and the identification of its source constants remain open.
+sufficient range-two estimate after physical blocking. The source lower
+boundary constant and the conclusions of FNW Lemma~5.3 are now identified by
+\leanid{MPSTensor.fnwLowerBoundaryConstant} and
+\leanid{MPSTensor.fnwLowerBoundaryConstant_mono}. The optimized numerator
+from Lemma~6.2 remains open.
 
 \subsection{Lower-endpoint scope in Theorem 2.1(i)}
 
@@ -1735,15 +1738,16 @@ The reconstructed coefficient is not the optimized FNW expression
     \label{eq:cpgsv21_martingale_overlap_optimized_fnw_expression}
 \end{align}
 quoted as \path{boundAm} in Section~6 of
-Ref.~\cite{Nachtergaele1996Spectral}. Recovering its numerator still requires
-the lower-boundary and projector estimates in Lemmas~5.3 and~6.2 of
-Ref.~\cite{Fannes1992Finitely}. The present argument makes no unweighted
-finite-Gram substitution and uses no periodic coercivity, unequal-kernel
-transfer, cyclic substitute, dimension prefactor, or projector-defect claim
-$a/a_-+a^2/a_-$. It does not identify $k$ with $D$ or assert
-$C_\lambda=k^2$. The reconstructed constant is not identified with a source
-dimension-dependent value; the available unweighted conversion retains the
-proved $D^{3/2}$ norm factor inside $g$.
+Ref.~\cite{Nachtergaele1996Spectral}. The source constant $a_-(N)$, its lower
+bound $a_-(N)\geq1-a(N)$, and its monotonicity are formalized from
+Lemma~5.3 of Ref.~\cite{Fannes1992Finitely}. Recovering the optimized numerator
+still requires the projector estimates in Lemma~6.2. The present argument makes
+no unweighted finite-Gram substitution and uses no periodic coercivity,
+unequal-kernel transfer, cyclic substitute, dimension prefactor, or
+projector-defect claim $a/a_-+a^2/a_-$. It does not identify $k$ with $D$ or
+assert $C_\lambda=k^2$. The reconstructed constant is not identified with a
+source dimension-dependent value; the available unweighted conversion retains
+the proved $D^{3/2}$ norm factor inside $g$.
 
 \subsection{Open-to-periodic finite-range conclusion}
 
@@ -1846,7 +1850,8 @@ coefficient $7/16$, and the resulting cyclic range-two gap $1/8$ are proved
 for a suitable blocked tensor. Before blocking, lengths are measured in sites
 of the input tensor; the final chain length counts blocked sites. These bounds
 come from the formal inverse-Gram reconstruction and are not attributed to
-FNW. The optimized FNW numerator and its source constants remain open.
+FNW. The source lower boundary constant and Lemma~5.3 are formalized, but
+the optimized Lemma~6.2 numerator remains open.
 
 The earlier blocked-to-original comparison remains valid for periodic lengths
 divisible by the chosen block length.  It gives


### PR DESCRIPTION
## What changed

- define the FNW lower boundary constant
  \[
  a_-(N)=\inf_{B\ne0}\frac{\lVert F_N(B)\rVert^2}{\lVert B\rVert_\rho^2}
  \]
  on the genuine $\rho$-weighted virtual Hilbert space
- prove the diagonal consequence of FNW equation (5.9), the optimal quadratic characterization, and
  \[
  a_-(N)\ge 1-a(N)
  \]
- derive $a_-(N+1)\ge a_-(N)$ from the exact right-boundary recursion following FNW equation (5.5) and stationarity of $\rho$
- identify $a_-(N)$ with the least Rayleigh value, the least spectral value in real-part form, and the least squared singular value over the finite virtual-domain rank
- synchronize Chapter 13 and the #6367 paper-gap disclosure

The source is Fannes, Nachtergaele, and Werner, *Finitely Correlated States on Quantum Spin Chains*, CMP 144 (1992), Lemma 5.3 and equations (5.5), (5.8), and (5.9).

This keeps $a_-(N)$ distinct from $1-a(N)$. It does not use an unweighted finite Gram matrix, inverse Gram or pseudoinverse reconstruction, periodic coercivity, unequal-kernel transfer, cyclic substitutes, dimension prefactors, $k=D$, or $C_\lambda=k^2$. Lemma 6.2 and the two projector-defect numerator terms remain downstream.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.FNWLowerBoundary`: 8849 jobs
- `lake build TNLean.MPS.ParentHamiltonian`: 9200 jobs
- clean Lean diagnostics and style lint
- generated imports: 37 files covering 1090 production modules, with generator tests
- Blueprint sync: 7410 unique Lean references and 7434 theorem-like entries
- both strict declaration checks
- reader-facing prose, paper-gap declaration/source, ChkTeX, pinned formatting, proof-integrity, line-length, and diff checks
- double LuaLaTeX: 1077 pages, zero actual undefined cross-references and zero multiply-defined labels
- exact-head source and publication review: `524ef7ff5b41`

Closes #7599.
Advances #6367.
