### PR TITLE
fix(MPS/MPU): address source-cut documentation review

### DIFF
--- a/TNLean/MPS/MPU/MixedKernelOpenTail.lean
+++ b/TNLean/MPS/MPU/MixedKernelOpenTail.lean
@@ -155,7 +155,8 @@ theorem mul_apply_eq_sum_sourceV_mul_sourceY₁_mul_sourceY₂
 pair is \(q\), while \(j\) is the input pair. The name \(p\) remains reserved for the
 retained output pair in the conjugated factor of a later Gram contraction.
 
-Source-$v$ identity; this does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
+Source: CPSV17 equations `uuvv` and `vdagger`, lines 532--543. This source-$v$
+identity does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
 theorem mul_apply_eq_sum_sourceV_mul_sourceY₁_mul_sourceY₂_pair
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (q j : Fin d × Fin d) (α γ : Fin D) :
@@ -170,7 +171,8 @@ theorem mul_apply_eq_sum_sourceV_mul_sourceY₁_mul_sourceY₂_pair
 through $v$, $Y_1$, $Y_2$, and the unevaluated virtual tail.
 
 The retained output pair is \(q\); the pair \(j\) belongs to the input word.
-Source-$v$ identity; this does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
+Source: CPSV17 equations `uuvv` and `vdagger`, lines 532--543. This source-$v$
+identity does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
 theorem mpo_finAddTwo_eq_sum_sourceV_sourceY₁_sourceY₂_evalWord
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
     (q j : Fin d × Fin d) (τ ζ : Fin K → Fin d) :

--- a/TNLean/MPS/MPU/MixedKernelOpenTail.lean
+++ b/TNLean/MPS/MPU/MixedKernelOpenTail.lean
@@ -156,7 +156,8 @@ pair is \(q\), while \(j\) is the input pair. The name \(p\) remains reserved fo
 retained output pair in the conjugated factor of a later Gram contraction.
 
 Source: CPSV17 equations `uuvv` and `vdagger`, lines 532--543. This source-$v$
-identity does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
+identity does not prove equation `uUnitary` or Lemma `lemuisometry`, which concern
+source gate $u$. -/
 theorem mul_apply_eq_sum_sourceV_mul_sourceY₁_mul_sourceY₂_pair
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (q j : Fin d × Fin d) (α γ : Fin D) :
@@ -172,7 +173,8 @@ through $v$, $Y_1$, $Y_2$, and the unevaluated virtual tail.
 
 The retained output pair is \(q\); the pair \(j\) belongs to the input word.
 Source: CPSV17 equations `uuvv` and `vdagger`, lines 532--543. This source-$v$
-identity does not assert the source-$u$ isometry in CPSV17 equation `uu`. -/
+identity does not prove equation `uUnitary` or Lemma `lemuisometry`, which concern
+source gate $u$. -/
 theorem mpo_finAddTwo_eq_sum_sourceV_sourceY₁_sourceY₂_evalWord
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
     (q j : Fin d × Fin d) (τ ζ : Fin K → Fin d) :

--- a/TNLean/MPS/MPU/MixedKernelRangeTransport.lean
+++ b/TNLean/MPS/MPU/MixedKernelRangeTransport.lean
@@ -175,8 +175,9 @@ $p$ is starred. The theorem evaluates the displayed expansion directly; it
 does not fold the sum through the separately defined open-tail coefficient
 or identify the Gram matrix of the paper gate `sourceU`.
 
-Source-$v$ open-tail identity; it does not prove CPSV17 equation `uUnitary` or
-Lemma `lemuisometry`, which concern the source gate $u$. -/
+Source: CPSV17 equations `SVDforms2`, `uuvv`, and `vdagger`, lines 515--543.
+This source-$v$ open-tail identity does not prove equation `uUnitary` or Lemma
+`lemuisometry`, which concern the source gate $u$. -/
 theorem IsMPU.normalized_sourceV_openTail_metric [NeZero d]
     {U : MPOTensor d D} (hU : IsMPU U)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5206,10 +5206,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
     If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
     Theorem~\ref{thm:mpu_source_gates_two_site_factorization} gives the exact
-    CPSV17 two-site factorization through
-    $u=Y_2\mathbin{-}Y_1$ and $v=X_1\mathbin{-}X_2$. Since the two-site MPU
-    operator and the swapped gate $u$ are unitary, cancellation makes $v$
-    unitary. This step uses the corrected source-cut orientation recorded in
+    CPSV17 two-site factorization
+    \begin{align}
+        \operatorname{reindex}(U^{(2)})
+         & =v\,\operatorname{swap}_{r,\ell}(u).
+    \end{align}
+    Since $\operatorname{reindex}(U^{(2)})$ and $u$, hence also
+    $\operatorname{swap}_{r,\ell}(u)$, are unitary,
+    \begin{align}
+        v
+         & =\operatorname{reindex}(U^{(2)})
+        \,\operatorname{swap}_{r,\ell}(u)^\dagger.
+    \end{align}
+    Thus $v$ is a product of unitaries and is unitary. This step uses the
+    corrected source-cut orientation recorded in
     \texttt{docs/paper-gaps/mpu\_source\_cut\_orientation.tex}.
 
     Finally, suppose that $v$ is unitary. Unitarity gives the dressed Gram
@@ -8658,39 +8668,26 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     matrices under multiplication gives the two ordered products.
 \end{proof}
 
-\begin{theorem}[Supplied paper gates for $U_1$ and $U_3$]
+\begin{theorem}[Supplied paper gates for $U_1$]
     \label{thm:threeMPU_supplied_source_gates_one}
     \lean{MPOTensor.shiftExampleU₁SourceURowEquiv,
         MPOTensor.shiftExampleU₁SourceVColumnEquiv,
-        MPOTensor.shiftExampleU₃SourceURowEquiv,
-        MPOTensor.shiftExampleU₃SourceVColumnEquiv,
         MPOTensor.shiftExampleU₁_sourceU_fourSpin_apply,
-        MPOTensor.shiftExampleU₁_sourceV_fourSpin_apply,
-        MPOTensor.shiftExampleU₃_sourceU_fourSpin_apply,
-        MPOTensor.shiftExampleU₃_sourceV_fourSpin_apply}
+        MPOTensor.shiftExampleU₁_sourceV_fourSpin_apply}
     \leanok
     \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
-    Assume $d>0$. In the four-spin coordinates of the supplied source
-    factorizations,
+    In the four-spin coordinates of the supplied source factorization,
     \begin{align}
-        u_1 & =\Id\otimes\Id,                     & v_1                             & =\Id\otimes\Id, \\
-        u_3 & =d\,(\Id\otimes\mathbb S\otimes\Id)
-        (\mathbb S\otimes\mathbb S),
-            & d\,v_3                              & =\Id\otimes\mathbb S\otimes\Id.
+        u_1 & =\Id\otimes\Id,
+            & v_1             & =\Id\otimes\Id.
     \end{align}
-    The scalar factors record the unbalanced identity-weight normalization of
-    the supplied witnesses. They can be transferred between the two gates
-    without changing the represented tensor.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv,
-        thm:mpu_shift_source_cuts_ranks}
+    \uses{def:threeMPU_supplied_source_factors, def:mpu_source_uv}
     The tensor-product formulas for $u=Y_2\mathbin{-}Y_1$ and
     $v=X_1\mathbin{-}X_2$ reduce each entry to the product of two primitive
-    shift entries. The identity factors give the two identity matrices. For
-    $U_3$, the Kronecker deltas give the two displayed swap products, and the
-    normalization constants combine using $d(d^{-1/2})^2=1$.
+    identity entries.
 \end{proof}
 
 \begin{theorem}[Paper gates in the two-site factorizations of $U_2$]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -165,8 +165,9 @@ abstracted — record why, so it is not re-proposed).
   applying the reindexed equality with `congrFun` twice and simplifying the
   inverse equivalences.
 - **Seen:** eight packaging proofs in
-  `TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean` and four recovery proofs
-  in `TNLean/MPS/MPU/Examples/ShiftSourceBlockedFormulas.lean`.
+  `TNLean/MPS/MPU/Examples/ShiftSourceMixedKernels.lean` (lines 487, 547, 620,
+  696, 798, 804, 889, and 898) and four recovery proofs in
+  `TNLean/MPS/MPU/Examples/ShiftSourceBlockedFormulas.lean`.
 - **Abstraction:** none. The former project wrappers were retired with
   `QICLean.Algebra.MatrixReindex`; the direct extensionality and evaluation
   proofs are the canonical pattern.
@@ -1573,8 +1574,8 @@ current counts and full location lists).
   primitive `sourceY₁X₂`/`sourceX₁Y₂` entries, and cancel the factors
   $d(\sqrt d)^{-1}(\sqrt d)^{-1}=1$ before closing the zero and nonzero cases.
 - **Seen:** 10 four-index occurrences in
-  `TNLean/MPS/MPU/Examples/ShiftSourceFormulas.lean` (representatively lines
-  76, 121, 479, 550, and 620) and six two-index primitive-entry occurrences in
+  `TNLean/MPS/MPU/Examples/ShiftSourceMixedKernels.lean` (representatively lines
+  78, 123, 474, 534, and 607) and six two-index primitive-entry occurrences in
   `TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean` (lines 424--501), recorded
   2026-08-24.
 - **Abstraction (proposed):** scout Mathlib's indicator and `ite` product


### PR DESCRIPTION
## What changed

- cite the CPSV17 source-$v$ definitions and open-tail factorization on the three restated declarations
- update the living tactic-pattern ledger to the split shift-source modules and current line guidance
- remove the unsupported $U_3$ one-site gate claim while preserving the separate blocked $U_3$ entry
- display both equations in the source-$v$ unitarity cancellation
- retain the paper-gap note's inline formal identifiers because the note directly audits those formal source cuts, factors, gates, and factorization declarations as its mathematical objects

No source-cut formula, Lean statement, proof, import, or computed value changes.

## Validation

- `lake build TNLean.MPS.MPU.MixedKernelOpenTail TNLean.MPS.MPU.MixedKernelRangeTransport`
- Lean diagnostics: zero errors and warnings in both changed Lean files
- pinned `latexindent` byte comparison on `blueprint/src/chapter/ch28_mpu.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- double `lualatex` with the pinned tenkz package: 0 undefined cross-references

Closes #7623.
