### PR TITLE
fix(ci): retry incomplete MathJax CDN reads

### DIFF
--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import functools
+import http.client
 import http.server
 import json
 import re
@@ -178,7 +179,7 @@ def _cdn_fetch(url: str) -> tuple[bytes, str]:
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
                 return response.read(), response.headers.get_content_type()
-        except OSError:
+        except (OSError, http.client.IncompleteRead):
             if attempt == 2:
                 raise
             time.sleep(2 ** attempt)


### PR DESCRIPTION
## What changed

- import `http.client` in the tenkz equation-web regression
- retry the precise transient `http.client.IncompleteRead` exception alongside existing `OSError` failures
- keep the third failure visible rather than swallowing it
- cover both the initial MathJax bundle and lazy script/font assets through their shared `_cdn_fetch` helper

## Validation

- Python syntax compilation
- simulated two-failure `IncompleteRead` recovery, including `1s` and `2s` retry delays
- simulated terminal third-failure re-raise
- full Playwright 1.55.0 equation-web regression: 17/17 rows and all expected desktop/mobile geometry
- `git diff --check`

Closes #7626.
