### PR TITLE
doc(MPU): resolve final source-gate prose findings

### DIFF
--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -490,7 +490,7 @@ theorem sourceU_rightShiftPaperSourceFactors_apply (d : ℕ) [NeZero d]
       hscale, mul_comm, mul_left_comm]
 
 /-- The trace-one right-shift source gate has identity Gram matrix.
-This is the normalization and orientation regression for the complete-network
+This is the normalization and orientation instance for the complete-network
 theorem corresponding to CPSV17 equation `uUnitary`. -/
 theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
     (p q : Fin d × Fin d) :

--- a/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
+++ b/TNLean/MPS/MPU/Examples/ShiftSourceFactors.lean
@@ -490,7 +490,7 @@ theorem sourceU_rightShiftPaperSourceFactors_apply (d : ℕ) [NeZero d]
       hscale, mul_comm, mul_left_comm]
 
 /-- The trace-one right-shift source gate has identity Gram matrix.
-This is the normalization and orientation instance for the complete-network
+This is the normalization and orientation specialization for the complete-network
 theorem corresponding to CPSV17 equation `uUnitary`. -/
 theorem sourceU_rightShiftPaperSourceFactors_gram (d : ℕ) [NeZero d]
     (p q : Fin d × Fin d) :

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -198,7 +198,7 @@ private theorem sourceYTensor_gram_eq_four_u_weighted
       simp_rw [Finset.sum_mul, Finset.mul_sum]
       conv_lhs => arg 2; ext β; arg 2; ext β'; rw [Finset.sum_comm]
 
-/-- The Gram matrix of the corrected paper gate \(u=Y_2\mathbin{-}Y_1\) is
+/-- The Gram matrix of the paper gate \(u=Y_2\mathbin{-}Y_1\) is
 the literal staggered reflected--direct four-\(\mathcal U\) network.  The pair
 `p` is starred and `q` is unstarred.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -2092,17 +2092,17 @@ The linear estimate remains separate from the aggregate contribution below.
     \begin{align}
         \left\langle L_{\ell,m,r}\Phi,F_{\ell+m+r}(B)\right\rangle
          & =0.
-        \label{eq:fnw_left_overlap_full_ground_vanishes}
+        \label{eq:fnw_left_pairing_zero}
     \end{align}
     In the right case, it gives
     \begin{align}
         \left\langle F_{\ell+m+r}(B),R_{\ell,m,r}\Psi\right\rangle
          & =0.
-        \label{eq:fnw_right_overlap_full_ground_vanishes}
+        \label{eq:fnw_right_pairing_zero}
     \end{align}
     Applying equation~(5.9) with
-    \eqref{eq:fnw_left_overlap_full_ground_vanishes} and
-    \eqref{eq:fnw_right_overlap_full_ground_vanishes} leaves the corresponding
+    (\ref{eq:fnw_left_pairing_zero}) and
+    (\ref{eq:fnw_right_pairing_zero}) leaves the corresponding
     aggregate pairings with the stated bounds. Test once more against each
     aggregate itself to obtain the two norm estimates.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -2085,11 +2085,25 @@ The linear estimate remains separate from the aggregate contribution below.
     \uses{thm:fnw_full_ground_spectator_identities,
         thm:fnw_overlap_linear_family_estimate}
     In the estimate preceding the lower-boundary conversion in
-    \cite[Equation~(6.5)]{Fannes1992Finitely}, test one overlap vector against
+    \cite[Equation~(6.5)]{Fannes1992Finitely}, test each overlap vector against
     the matching full-ground spectator family from
-    Theorem~\ref{thm:fnw_full_ground_spectator_identities}. Orthogonality makes
-    the physical pairing vanish. Equation~(5.9) leaves the corresponding
-    aggregate pairing with the stated bound. Test once more against the
+    Theorem~\ref{thm:fnw_full_ground_spectator_identities}. Orthogonality gives
+    the left identity
+    \begin{align}
+        \left\langle L_{\ell,m,r}\Phi,F_{\ell+m+r}(B)\right\rangle
+         & =0.
+        \label{eq:fnw_left_overlap_full_ground_vanishes}
+    \end{align}
+    In the right case, it gives
+    \begin{align}
+        \left\langle F_{\ell+m+r}(B),R_{\ell,m,r}\Psi\right\rangle
+         & =0.
+        \label{eq:fnw_right_overlap_full_ground_vanishes}
+    \end{align}
+    Applying equation~(5.9) with
+    \eqref{eq:fnw_left_overlap_full_ground_vanishes} and
+    \eqref{eq:fnw_right_overlap_full_ground_vanishes} leaves the corresponding
+    aggregate pairings with the stated bounds. Test once more against each
     aggregate itself to obtain the two norm estimates.
 \end{proof}
 


### PR DESCRIPTION
### Motivation

Three documentation findings arrived after PRs #7481 and #7625 merged. The permanent prose should describe the mathematics rather than its repair history, and the FNW orthogonality step should display both vanishing pairings explicitly.

### Description

- Replace “regression” with a timeless normalization-and-orientation description in `ShiftSourceFactors.lean`.
- Remove “corrected” from the paper-gate docstring in `SourceUCompleteNetwork.lean`.
- Display and separately label the left and right FNW vanishing pairings in Chapter 13, using the inner-product orientations from `FNWAggregateOrthogonality.lean`.

### Testing

- `lake build TNLean.MPS.MPU.Examples.ShiftSourceFactors TNLean.MPS.MPU.SourceUCompleteNetwork`
- Lean diagnostics on both changed Lean files: no errors or warnings
- pinned `scripts/latexindent` byte comparison
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 184f70971287cbde7048a55ad060e6ceb5f32524 --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `lualatex -interaction=nonstopmode -halt-on-error print.tex` twice with pinned tenkz on `TEXINPUTS`; zero undefined cross-references
- Blueprint tag-set comparison and `git diff --check`

Closes #7628
