### PR TITLE
feat(MPU): close source-u Gram as a transpose trace

### DIFF
--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -268,7 +268,7 @@ fixed by `finProdFinEquiv`.  The pair `p` is starred and `q` is unstarred.
 
 Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
 -/
-theorem sourceU_gram_eq_transpose_fixedPair_trace
+theorem sourceU_gram_eq_transpose_fixed_pair_trace
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (p q : Fin d × Fin d) :
     (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -261,6 +261,78 @@ theorem sourceU_gram_eq_staggered_four_u
         Fintype.sum_prod_type]
     _ = _ := rfl
 
+/-- The Gram matrix of the paper gate \(u=Y_2\mathbin{-}Y_1\) closes to a
+fixed-pair trace of two double-layer letters.  The source weight enters as
+\(\rho^{\mathsf T}\) because `Matrix.vec` uses the column-stacking coordinates
+fixed by `finProdFinEquiv`.  The pair `p` is starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem sourceU_gram_eq_transpose_fixedPair_trace
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.2 q.2 *
+          Matrix.vecMulVec
+            (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+            (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+              (finProdFinEquiv.symm x)) *
+          doubleLayerTensor U p.1 q.1) := by
+  classical
+  rcases p with ⟨p₁, p₂⟩
+  rcases q with ⟨q₁, q₂⟩
+  have hentry (a b : Fin D) :
+      (doubleLayerTensor U p₂ q₂ *
+          Matrix.vecMulVec
+            (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+            (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+              (finProdFinEquiv.symm x)) *
+          doubleLayerTensor U p₁ q₁)
+          (finProdFinEquiv (a, b)) (finProdFinEquiv (a, b)) =
+        ∑ β : Fin D, ∑ β' : Fin D, ∑ γ : Fin D,
+        ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
+            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := by
+    simpa only [Matrix.transpose_apply] using
+      doubleLayerTensor_rankOne_mul_apply_four_u U ρ.transpose
+        (p₂, p₁) (q₂, q₁) (a, a) (b, b)
+  have htrace :
+      Matrix.trace
+          (doubleLayerTensor U p₂ q₂ *
+            Matrix.vecMulVec
+              (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+              (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+                (finProdFinEquiv.symm x)) *
+            doubleLayerTensor U p₁ q₁) =
+        ∑ a : Fin D, ∑ b : Fin D, ∑ β : Fin D, ∑ β' : Fin D,
+        ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
+            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := by
+    unfold Matrix.trace
+    rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+    apply Finset.sum_congr rfl
+    intro a _
+    apply Finset.sum_congr rfl
+    intro b _
+    exact hentry a b
+  rw [sourceU_gram_eq_staggered_four_u, htrace]
+  apply Finset.sum_congr rfl
+  intro a _
+  apply Finset.sum_congr rfl
+  intro b _
+  apply Finset.sum_congr rfl
+  intro β _
+  apply Finset.sum_congr rfl
+  intro β' _
+  apply Finset.sum_congr rfl
+  intro γ _
+  apply Finset.sum_congr rfl
+  intro j₁ _
+  apply Finset.sum_congr rfl
+  intro j₂ _
+  ring
+
 end SourceFactors
 
 /-- The normalized input-tail contraction is the closed direct double-layer

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4986,6 +4986,43 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Gram identities. Reordering the finite sums yields the stated formula.
 \end{proof}
 
+\begin{lemma}[Transpose fixed-pair trace closure]
+    \label{lem:mpu_source_u_transpose_fixed_pair_trace}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixedPair_trace}
+    \leanok
+    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_source_v_four_u_expansions}
+    Let $W^{ij}$ denote the $(i,j)$ double-layer letter, let
+    $\lvert\rho^{\mathsf T})$ be the column-stacking vector of
+    $\rho^{\mathsf T}$, and set
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Then
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\operatorname{tr}\!\left(
+        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
+        \right).
+    \end{align}
+    In particular, the weight is transposed rather than identified with
+    $\rho$. The retained-interior equality needed for the complete contraction
+    remains open in Issue~\#7633.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_source_v_four_u_expansions}
+    Enumerate each doubled-bond coordinate as
+    $\operatorname{flat}(\alpha,\alpha')$. Expanding a diagonal entry of the
+    matrix under the trace gives
+    \begin{align}
+        \sum_{\beta,\beta',\gamma,j_1,j_2}
+        \overline{\mathcal U^{j_1}_{p_2,\alpha,\beta}}
+        \mathcal U^{j_1}_{q_2,\alpha',\beta'}
+        (\rho^{\mathsf T})_{\beta',\beta}
+        \overline{\mathcal U^{j_2}_{p_1,\gamma,\alpha}}
+        \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
+    \end{align}
+    Since $(\rho^{\mathsf T})_{\beta',\beta}=\rho_{\beta,\beta'}$,
+    summing over $\alpha,\alpha'$ yields the staggered Gram expansion above.
+\end{proof}
+
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
     \notready
@@ -5015,21 +5052,27 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_normalized_input_tail_closed_trace}
-    Expand both external paper gates using
-    $u=Y_2\mathbin{-}Y_1$, retaining the two $Y_2$--$Y_1$ triangles and their
-    common virtual indices in the staggered order of
-    \cite[Figure~\texttt{II\_uUnitary.png} and
-        Lemma~III.7]{Cirac2017MPU}. The remaining source-facing obligation is
-    to insert $E^J=\lvert\rho)(\Phi\rvert$ into that exact network and contract
-    it directly to the displayed normalized $(K+2)$-site MPU sum.
-
-    The staggered four-tensor expansion and the normalized input-tail trace are
-    formalized separately. The missing step is their equality after inserting
-    the fixed pair into the exact retained-interior network of
-    Figure~\texttt{II\_uUnitary.png}. The checked $Y_1$--$X_2$ mixed-kernel
-    Gram, range-projection, reflected-transfer, and terminal-boundary lemmas
-    concern a different network and do not supply that contraction.
+    \uses{lem:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
+    The preceding lemma closes the two external source gates as
+    \begin{align}
+        \operatorname{tr}\!\left(
+        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
+        \right).
+    \end{align}
+    Cyclicity moves the first double-layer letter past the trace. It remains to
+    identify the resulting rank-one insertion with the $K$-site interior:
+    \begin{align}
+        \operatorname{tr}\!\left(
+        W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert
+        \right)
+         & =\operatorname{tr}\!\left(
+        W^{p_1q_1}W^{p_2q_2}E^K
+        \right).
+    \end{align}
+    This retained-interior contraction is Issue~\#7633. It must preserve the
+    two unblocked endpoint letters while applying the supplied simple
+    contractions to the interior. The checked $Y_1$--$X_2$ mixed-kernel
+    identities concern a different network and do not prove this equality.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4986,14 +4986,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Gram identities. Reordering the finite sums yields the stated formula.
 \end{proof}
 
-\begin{lemma}[Transpose fixed-pair trace closure]
-    \label{lem:mpu_source_u_transpose_fixed_pair_trace}
+\begin{theorem}[Transpose fixed-pair trace closure]
+    \label{thm:mpu_source_u_transpose_fixed_pair_trace}
     \lean{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixedPair_trace}
     \leanok
-    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_source_v_four_u_expansions}
-    Let $W^{ij}$ denote the $(i,j)$ double-layer letter, let
-    $\lvert\rho^{\mathsf T})$ be the column-stacking vector of
-    $\rho^{\mathsf T}$, and set
+    \discussion{7632}
+    \uses{def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPO tensor, let $\rho$ be a bond matrix, and let
+    $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and $\rho$.
+    Construct the source tensor $u=Y_2\mathbin{-}Y_1$. For retained physical
+    pairs $p=(p_1,p_2)$ and $q=(q_1,q_2)$, let $W^{ij}$ denote the $(i,j)$
+    double-layer letter, let $\lvert\rho^{\mathsf T})$ be the column-stacking
+    vector of $\rho^{\mathsf T}$, and set
     $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Then
     \begin{align}
         \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
@@ -5003,8 +5007,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     In particular, the weight is transposed rather than identified with
     $\rho$. The retained-interior equality needed for the complete contraction
-    remains open in Issue~\#7633.
-\end{lemma}
+    remains open.
+    % The retained-interior equality is tracked in Issue #7633.
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_source_u_staggered_gram, thm:mpu_source_v_four_u_expansions}
@@ -5020,7 +5025,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
     \end{align}
     Since $(\rho^{\mathsf T})_{\beta',\beta}=\rho_{\beta,\beta'}$,
-    summing over $\alpha,\alpha'$ yields the staggered Gram expansion above.
+    summing over $\alpha,\alpha'$ gives the identity in
+    Theorem~\ref{thm:mpu_source_u_staggered_gram}.
 \end{proof}
 
 \begin{theorem}[Complete source-$u$ network contraction]
@@ -5052,8 +5058,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-    \uses{lem:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
-    The preceding lemma closes the two external source gates as
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
+    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
+    external source gates as
     \begin{align}
         \operatorname{tr}\!\left(
         W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
@@ -5069,10 +5076,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         W^{p_1q_1}W^{p_2q_2}E^K
         \right).
     \end{align}
-    This retained-interior contraction is Issue~\#7633. It must preserve the
-    two unblocked endpoint letters while applying the supplied simple
-    contractions to the interior. The checked $Y_1$--$X_2$ mixed-kernel
-    identities concern a different network and do not prove this equality.
+    This retained-interior contraction remains open. It must preserve the two
+    unblocked endpoint letters while applying the supplied simple contractions
+    to the interior. The checked $Y_1$--$X_2$ mixed-kernel identities concern a
+    different network and do not prove this equality.
+    % The retained-interior contraction is tracked in Issue #7633.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4988,7 +4988,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Transpose fixed-pair trace closure]
     \label{thm:mpu_source_u_transpose_fixed_pair_trace}
-    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixedPair_trace}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixed_pair_trace}
     \leanok
     \discussion{7632}
     \uses{def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer}


### PR DESCRIPTION
## What changed

- add `MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixed_pair_trace`, expressing the corrected source-u Gram sum as
  ```tex
  \operatorname{tr}\!\left(W^{p_2q_2}|\rho^{\mathsf T})(\Phi|W^{p_1q_1}\right)
  ```
- specialize `doubleLayerTensor_rankOne_mul_apply_four_u` to `ρ.transpose`, reindex the trace diagonal through `finProdFinEquiv`, and identify `(ρᵀ)_{β',β}=ρ_{β,β'}` with the staggered four-U expansion
- preserve the starred `p` and unstarred `q` source-leg order without assuming `ρ.transpose = ρ`
- add the formula-driven Chapter 28 lemma immediately after the staggered Gram endpoint; mark only this coordinate closure checked and identify #7633 as the remaining retained-interior equality

## Validation

- `lake build TNLean.MPS.MPU.SourceUCompleteNetwork` (9040 jobs)
- Lean diagnostics: no errors, warnings, or hints in the changed Lean file
- `lake build TNLean.MPS.MPU` (9303 jobs)
- `lake build` (10478 jobs, exact warm-cache base)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` (37 generated files, 1098 modules)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7493/7493 entries)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- pinned `latexindent` comparison: clean
- double LuaLaTeX: 0 undefined references on pass 2
- `python3 scripts/test_lean_file_policies.py`
- `python3 scripts/tactic_pattern_scan.py`
- changed-file proof-integrity token scan: clean

Closes #7632.
Advances #5982; the retained-interior contraction remains #7633.

