### PR TITLE
feat(algebra): define the common fixed submodule

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -10,6 +10,7 @@ Authors: TNLean contributors
 
 import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology
+import TNLean.Algebra.CommonFixedSubmodule
 import TNLean.Algebra.CommutingProjectionProduct
 import TNLean.Algebra.CommutingStarSubalgebraProduct
 import TNLean.Algebra.ComplexSqrt

--- a/TNLean/Algebra/CommonFixedSubmodule.lean
+++ b/TNLean/Algebra/CommonFixedSubmodule.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.LinearAlgebra.FixedSubmodule
+
+/-!
+# Common fixed submodule
+
+This file defines the common fixed submodule of an arbitrary family of linear
+endomorphisms and gives its elementary membership and dimension properties.
+No commutativity assumption is needed.
+-/
+
+namespace LinearMap
+
+variable {R V : Type*} [Semiring R] [AddCommMonoid V] [Module R V]
+
+/-- The intersection of the fixed submodules of a family of endomorphisms. -/
+def commonFixedSubmodule {ι : Type*} (f : ι → V →ₗ[R] V) : Submodule R V :=
+  ⨅ i, (f i).fixedSubmodule
+
+@[simp]
+theorem mem_commonFixedSubmodule_iff {ι : Type*} {f : ι → V →ₗ[R] V} {v : V} :
+    v ∈ commonFixedSubmodule f ↔ ∀ i, f i v = v := by
+  simp [commonFixedSubmodule]
+
+variable {K W : Type*} [DivisionRing K] [AddCommGroup W] [Module K W]
+  [FiniteDimensional K W]
+
+/-- A common nonzero fixed vector gives a one-dimensional subspace of common
+fixed vectors. -/
+theorem one_le_finrank_commonFixedSubmodule {ι : Type*} (f : ι → W →ₗ[K] W) {v : W}
+    (hv : v ∈ commonFixedSubmodule f) (hv0 : v ≠ 0) :
+    1 ≤ Module.finrank K (commonFixedSubmodule f) := by
+  rw [Submodule.one_le_finrank_iff]
+  exact (Submodule.ne_bot_iff _).mpr ⟨v, hv, hv0⟩
+
+end LinearMap

--- a/TNLean/Algebra/CommonFixedSubmodule.lean
+++ b/TNLean/Algebra/CommonFixedSubmodule.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!
@@ -20,20 +19,20 @@ namespace LinearMap
 variable {R V : Type*} [Semiring R] [AddCommMonoid V] [Module R V]
 
 /-- The intersection of the fixed submodules of a family of endomorphisms. -/
-def commonFixedSubmodule {ι : Type*} (f : ι → V →ₗ[R] V) : Submodule R V :=
+def commonFixedSubmodule {ι : Sort*} (f : ι → V →ₗ[R] V) : Submodule R V :=
   ⨅ i, (f i).fixedSubmodule
 
 @[simp]
-theorem mem_commonFixedSubmodule_iff {ι : Type*} {f : ι → V →ₗ[R] V} {v : V} :
+theorem mem_commonFixedSubmodule_iff {ι : Sort*} {f : ι → V →ₗ[R] V} {v : V} :
     v ∈ commonFixedSubmodule f ↔ ∀ i, f i v = v := by
-  simp [commonFixedSubmodule]
+  simp only [commonFixedSubmodule, Submodule.mem_iInf, mem_fixedSubmodule_iff]
 
 variable {K W : Type*} [DivisionRing K] [AddCommGroup W] [Module K W]
-  [FiniteDimensional K W]
+  [Module.Finite K W]
 
-/-- A common nonzero fixed vector gives a one-dimensional subspace of common
-fixed vectors. -/
-theorem one_le_finrank_commonFixedSubmodule {ι : Type*} (f : ι → W →ₗ[K] W) {v : W}
+/-- A common nonzero fixed vector ensures that the common fixed submodule has
+finrank at least one. -/
+theorem one_le_finrank_commonFixedSubmodule {ι : Sort*} (f : ι → W →ₗ[K] W) {v : W}
     (hv : v ∈ commonFixedSubmodule f) (hv0 : v ≠ 0) :
     1 ≤ Module.finrank K (commonFixedSubmodule f) := by
   rw [Submodule.one_le_finrank_iff]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1271,10 +1271,10 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     No commutativity of the operators is required. For the averaged Gauss
     projectors, this is the common $+1$ eigenspace called the gauge-invariant
     subspace in
-    \cite[lines~4327--4335 and 5198--5204]{FrancoRubio2025MPUGauging}.
+    \cite[lines~4327--4335 and line~5198]{FrancoRubio2025MPUGauging}.
     Here $P_j$ is an averaged projector, not an individual Gauss operator
     $\mathcal G_g$.
-    % Source anchors: arXiv:2502.20257, lines 4327--4335 and 5198--5204.
+    % Source anchors: arXiv:2502.20257, lines 4327--4335 and line 5198.
 \end{definition}
 
 \begin{theorem}[Membership in the common fixed subspace]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1261,13 +1261,12 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \label{def:mpug_common_fixed_subspace}
     \lean{LinearMap.commonFixedSubmodule}
     \leanok
-    Let $\mathcal H$ be a finite-dimensional complex vector space and let
-    $(P_j)_{j\in J}$ be any family of endomorphisms of $\mathcal H$. Define
+    Let $\mathcal H$ be a complex vector space and let $(P_j)_{j\in J}$ be any
+    family of endomorphisms of $\mathcal H$. Define
     their common fixed subspace by
     \begin{align}
         \mathcal V(P)
          & =\bigcap_{j\in J}\ker(P_j-\id_{\mathcal H}).
-        \label{eq:mpug_common_fixed_subspace}
     \end{align}
     No commutativity of the operators is required. For the averaged Gauss
     projectors, this is the common $+1$ eigenspace called the gauge-invariant
@@ -1284,10 +1283,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \uses{def:mpug_common_fixed_subspace}
     A vector $\psi\in\mathcal H$ belongs to $\mathcal V(P)$ if and only if
-    \begin{align}
-        P_j\psi & =\psi
-        \qquad\text{for every }j\in J.
-    \end{align}
+    $P_j\psi=\psi$ for every $j\in J$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1302,14 +1298,13 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \lean{LinearMap.one_le_finrank_commonFixedSubmodule}
     \leanok
     \uses{def:mpug_common_fixed_subspace}
-    If $\psi\in\mathcal V(P)$ and $\psi\neq0$, then
-    \begin{align}
-        1 & \leq \dim_{\C}\mathcal V(P).
-    \end{align}
+    If $\mathcal H$ is finite-dimensional, $\psi\in\mathcal V(P)$, and
+    $\psi\neq0$, then $1\leq\dim_{\C}\mathcal V(P)$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The line $\C\psi$ is a nonzero subspace of $\mathcal V(P)$.
+    The common fixed subspace is nonzero because it contains $\psi$, so its
+    dimension is at least one.
 \end{proof}
 
 \begin{definition}[Scalar cochains and normalization]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1266,7 +1266,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     their common fixed subspace by
     \begin{align}
         \mathcal V(P)
-         & =\bigcap_{j\in J}\ker(P_j-\id_{\mathcal H}).
+         & =\bigcap_{j\in J}\ker(P_j-\Id_{\mathcal H}).
     \end{align}
     No commutativity of the operators is required. For the averaged Gauss
     projectors, this is the common $+1$ eigenspace called the gauge-invariant
@@ -1289,7 +1289,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 \begin{proof}\leanok
     \uses{def:mpug_common_fixed_subspace}
     Membership in an indexed intersection is equivalent to membership in
-    every factor, and membership in $\ker(P_j-\id_{\mathcal H})$ is equivalent
+    every factor, and membership in $\ker(P_j-\Id_{\mathcal H})$ is equivalent
     to $P_j\psi=\psi$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1257,6 +1257,61 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     $P_j(R)^\dagger=P_j(R)$.
 \end{proof}
 
+\begin{definition}[Common fixed subspace]
+    \label{def:mpug_common_fixed_subspace}
+    \lean{LinearMap.commonFixedSubmodule}
+    \leanok
+    Let $\mathcal H$ be a finite-dimensional complex vector space and let
+    $(P_j)_{j\in J}$ be any family of endomorphisms of $\mathcal H$. Define
+    their common fixed subspace by
+    \begin{align}
+        \mathcal V(P)
+         & =\bigcap_{j\in J}\ker(P_j-\id_{\mathcal H}).
+        \label{eq:mpug_common_fixed_subspace}
+    \end{align}
+    No commutativity of the operators is required. For the averaged Gauss
+    projectors, this is the common $+1$ eigenspace called the gauge-invariant
+    subspace in
+    \cite[lines~4327--4335 and 5198--5204]{FrancoRubio2025MPUGauging}.
+    Here $P_j$ is an averaged projector, not an individual Gauss operator
+    $\mathcal G_g$.
+    % Source anchors: arXiv:2502.20257, lines 4327--4335 and 5198--5204.
+\end{definition}
+
+\begin{theorem}[Membership in the common fixed subspace]
+    \label{thm:mpug_mem_common_fixed_subspace}
+    \lean{LinearMap.mem_commonFixedSubmodule_iff}
+    \leanok
+    \uses{def:mpug_common_fixed_subspace}
+    A vector $\psi\in\mathcal H$ belongs to $\mathcal V(P)$ if and only if
+    \begin{align}
+        P_j\psi & =\psi
+        \qquad\text{for every }j\in J.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_common_fixed_subspace}
+    Membership in an indexed intersection is equivalent to membership in
+    every factor, and membership in $\ker(P_j-\id_{\mathcal H})$ is equivalent
+    to $P_j\psi=\psi$.
+\end{proof}
+
+\begin{theorem}[Nonzero-vector lower bound]
+    \label{thm:mpug_common_fixed_subspace_finrank}
+    \lean{LinearMap.one_le_finrank_commonFixedSubmodule}
+    \leanok
+    \uses{def:mpug_common_fixed_subspace}
+    If $\psi\in\mathcal V(P)$ and $\psi\neq0$, then
+    \begin{align}
+        1 & \leq \dim_{\C}\mathcal V(P).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The line $\C\psi$ is a nonzero subspace of $\mathcal V(P)$.
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,


### PR DESCRIPTION
### Motivation

- `Papers/2502.20257/main.tex:4327-4335` introduces the modified Gauss laws, and line 5198 identifies their common `+1` eigenspace as the gauge-invariant subspace.
- The completion-independent invariant-vector theorem in #7569 and the CZX dimension calculation in #7570 need one commutativity-free definition of that subspace.

### Description

- Add `LinearMap.commonFixedSubmodule`, the indexed intersection of the fixed submodules of an arbitrary family of endomorphisms.
- Prove that membership is equivalent to being fixed by every endomorphism.
- Prove that a nonzero common fixed vector gives finrank at least one.
- Add Chapter 29 statements for the common fixed space and lower bound, while keeping averaged projectors distinct from individual Gauss operators.

No projector commutativity, gauged-MPS invariance, CZX dimension, spectral-gap, or completion-independent growth claim is made.

### Testing

- `lake build TNLean.Algebra.CommonFixedSubmodule` passed.
- `lake build TNLean.Algebra` passed.
- Full exact-base exact-cache `lake build` passed, 10482 jobs.
- Import aggregator, Lean file policy, proof-integrity, reader-facing prose, Blueprint sync, and `leanblueprint checkdecls` checks passed.
- ChkTeX and the pinned `latexindent` comparison passed.
- Two LuaLaTeX runs passed with zero undefined cross-references. Standalone citation warnings are unchanged.
- `git diff --check origin/main...HEAD` passed.

---
Closes #7631
Advances #7568

### Agent assistance

- TeXRA `leanSearch` with GPT-5.6 searched Mathlib and TNLean for the existing fixed-submodule APIs and checked the source scope.
- TeXRA `lean` with GPT-5.6 implemented the declarations and Blueprint entries.
- TeXRA `leanSimplifier` with GPT-5.6 reviewed and generalized the implementation.
- The orchestrator checked the source anchors, reviewed the final diff, and ran the full repository gates.

