### PR TITLE
feat(mpdo): prove the twisted quantum dimer is not simple

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -327,7 +327,9 @@ import TNLean.MPS.MPDO.TopologicalTerminalSpectral
 import TNLean.MPS.MPDO.TwistedDimer
 import TNLean.MPS.MPDO.TwistedDimerCoefficients
 import TNLean.MPS.MPDO.TwistedDimerFlagSectors
+import TNLean.MPS.MPDO.TwistedDimerHorizontalCF
 import TNLean.MPS.MPDO.TwistedDimerMPDO
+import TNLean.MPS.MPDO.TwistedDimerNotSimple
 import TNLean.MPS.MPDO.TwistedDimerProductLaw
 import TNLean.MPS.MPDO.TwistedDimerRefine
 import TNLean.MPS.MPDO.TwistedDimerViaTS

--- a/TNLean/MPS/MPDO/TwistedDimer.lean
+++ b/TNLean/MPS/MPDO/TwistedDimer.lean
@@ -89,6 +89,10 @@ def bitF (i : Fin 8) : Fin 2 := ⟨i.val % 2, by omega⟩
 lemma physIdx_bits (i : Fin 8) : physIdx (bitL i) (bitR i) (bitF i) = i := by
   ext; simp only [physIdx, bitL, bitR, bitF]; omega
 
+/-- Every index of `Fin 8` is the bit encoding of its three bits. -/
+lemma exists_eq_physIdx (i : Fin 8) : ∃ l r f, i = physIdx l r f :=
+  ⟨_, _, _, (physIdx_bits i).symm⟩
+
 lemma physIdx_inj {l r f l' r' f' : Fin 2} :
     physIdx l r f = physIdx l' r' f' ↔ l = l' ∧ r = r' ∧ f = f' := by
   constructor

--- a/TNLean/MPS/MPDO/TwistedDimerFlagSectors.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerFlagSectors.lean
@@ -123,8 +123,8 @@ common flag value $f$. -/
 theorem flagMPO_apply_eq_T (f : Fin 2) (a b : Fin 8) (l r l' r' : Fin 2) :
     flagMPO f a b (finProdFinEquiv (l, r)) (finProdFinEquiv (l', r')) =
       ((mu : ℝ) : ℂ)⁻¹ * T (physIdx l r f) (physIdx l' r' f) a b := by
-  obtain ⟨p, p', k, rfl⟩ : ∃ p p' k, a = physIdx p p' k := ⟨_, _, _, (physIdx_bits a).symm⟩
-  obtain ⟨q, q', k', rfl⟩ : ∃ q q' k', b = physIdx q q' k' := ⟨_, _, _, (physIdx_bits b).symm⟩
+  obtain ⟨p, p', k, rfl⟩ := exists_eq_physIdx a
+  obtain ⟨q, q', k', rfl⟩ := exists_eq_physIdx b
   rw [T_apply_blocks]
   simp only [flagMPO, unitTensor, flagCoef, block, bitL_physIdx, bitR_physIdx, bitF_physIdx,
     Matrix.single_apply, finProdFinEquiv.injective.eq_iff, Prod.mk.injEq, coef_physIdx,

--- a/TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Matrix.PEquiv
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPDO.TwistedDimer
+
+/-!
+# The horizontal canonical form of the twisted quantum dimer
+
+**Scope: one-site literal canonical form.** The doubled-index tensor of the
+$\mathbb Z_2$-twisted quantum dimer `T` of `TNLean.MPS.MPDO.TwistedDimer` (a
+project example, not a tensor stated in the source) is written in the literal
+canonical form of arXiv:1606.00608, Section 2.3, lines 214--245 and eq.
+`II_CF1`. The two retained normal tensors are the displayed horizontal blocks
+`block 0`, `block 1` of bond dimension four, each rescaled by $8/5$ so that
+its ket-against-bra letters resolve the identity; both carry the weight
+$\mu = 5/8$. The ambient coisometry is the permutation of the bond index
+$(p, p', k)$ into the block label $k$ followed by the block bond index
+$(p, p')$.
+
+Only the one-site statement is made here. Blocking, the resulting BNT sector
+presentation, and non-simplicity of the tensor are treated in
+`TNLean.MPS.MPDO.TwistedDimerNotSimple`.
+
+## Main results
+
+* `normalizedBlock_toMPSTensor_isInjective` — the letters of each rescaled
+  block span the full bond matrix algebra;
+* `normalizedBlock_isLeftCanonical` — the ket-against-bra letters of each
+  rescaled block resolve the identity;
+* `normalizedBlock_isNormalTensor` — each rescaled block is a normal tensor;
+* `canonicalFormData` — the literal canonical-form data of the doubled-index
+  tensor with the two rescaled blocks and the weight $5/8$;
+* `physTraceTransfer_normalizedBlock_one` — the rescaled block $k = 1$ has
+  vanishing physical-trace transfer.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Section 2.3, lines 214--245 and eq. `II_CF1` (project example, not a
+  tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### The rescaled horizontal blocks -/
+
+/-- The horizontal block `k` of the twisted dimer rescaled by $8/5$: the
+letter at the pair `(i, j)` is the matrix unit of `block k` with coefficient
+$\tfrac85\,$`coef k i j`. The rescaling makes the ket-against-bra letters
+resolve the identity (`normalizedBlock_isLeftCanonical`), which is the
+spectral normalization of arXiv:1606.00608, lines 224--235, for this project
+example. -/
+def normalizedBlock (k : Fin 2) : MPOTensor 8 4 := fun i j => (8 / 5 : ℂ) • block k i j
+
+lemma normalizedBlock_apply (k : Fin 2) (i j : Fin 8) :
+    normalizedBlock k i j =
+      Matrix.single (finProdFinEquiv (bitL i, bitL j)) (finProdFinEquiv (bitR i, bitR j))
+        ((8 / 5 : ℂ) * coef k i j) := by
+  simp [normalizedBlock, block]
+
+/-- The doubled-index letter at `finProdFinEquiv (i, j)` is the MPO letter at `(i, j)`. -/
+lemma toMPSTensor_apply_finProdFinEquiv {d D : ℕ} (M : MPOTensor d D) (i j : Fin d) :
+    M.toMPSTensor (finProdFinEquiv (i, j)) = M i j := by
+  unfold MPOTensor.toMPSTensor
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- At flag value zero every coefficient of a block is nonzero: it is one of
+$\tfrac14$ and $\tfrac3{16}$. -/
+lemma coef_flag_zero_ne_zero (k p q p' q' : Fin 2) :
+    coef k (physIdx p q 0) (physIdx p' q' 0) ≠ 0 := by
+  rw [coef_physIdx, ite_eq_left rfl]
+  fin_cases k <;> fin_cases p <;> fin_cases p' <;> norm_num [Cmat, tau, cDiag_eq, cOff_eq]
+
+/-- **The letters of a horizontal block span the bond matrix algebra.** The
+matrix unit at the bond pair $((p,p'),(q,q'))$ is a nonzero multiple of the
+letter at the physical pair $((p,q,0),(p',q',0))$. -/
+theorem block_toMPSTensor_isInjective (k : Fin 2) :
+    Kraus.IsInjective (block k).toMPSTensor := by
+  unfold Kraus.IsInjective
+  apply le_antisymm le_top
+  rw [← (Matrix.stdBasis ℂ (Fin 4) (Fin 4)).span_eq]
+  apply Submodule.span_le.mpr
+  rintro M ⟨⟨a, b⟩, rfl⟩
+  rw [Matrix.stdBasis_eq_single]
+  obtain ⟨p, p', rfl⟩ : ∃ p p', a = finProdFinEquiv (p, p') :=
+    ⟨((finProdFinEquiv (m := 2) (n := 2)).symm a).1,
+      ((finProdFinEquiv (m := 2) (n := 2)).symm a).2, by simp⟩
+  obtain ⟨q, q', rfl⟩ : ∃ q q', b = finProdFinEquiv (q, q') :=
+    ⟨((finProdFinEquiv (m := 2) (n := 2)).symm b).1,
+      ((finProdFinEquiv (m := 2) (n := 2)).symm b).2, by simp⟩
+  have hmem : block k (physIdx p q 0) (physIdx p' q' 0) ∈
+      Submodule.span ℂ (Set.range (block k).toMPSTensor) := by
+    rw [← toMPSTensor_apply_finProdFinEquiv (block k)]
+    exact Submodule.subset_span ⟨_, rfl⟩
+  have hblock : block k (physIdx p q 0) (physIdx p' q' 0) =
+      coef k (physIdx p q 0) (physIdx p' q' 0) •
+        Matrix.single (finProdFinEquiv (p, p')) (finProdFinEquiv (q, q')) (1 : ℂ) := by
+    simp [block]
+  rw [hblock] at hmem
+  have hscaled := Submodule.smul_mem _ (coef k (physIdx p q 0) (physIdx p' q' 0))⁻¹ hmem
+  rwa [smul_smul, inv_mul_cancel₀ (coef_flag_zero_ne_zero k p q p' q'), one_smul] at hscaled
+
+/-- The letters of a rescaled block span the bond matrix algebra. -/
+theorem normalizedBlock_toMPSTensor_isInjective (k : Fin 2) :
+    Kraus.IsInjective (normalizedBlock k).toMPSTensor := by
+  have h : (normalizedBlock k).toMPSTensor = fun v => (8 / 5 : ℂ) • (block k).toMPSTensor v := rfl
+  rw [h]
+  exact (block_toMPSTensor_isInjective k).smul (by norm_num)
+
+/-! ### The ket-against-bra letters resolve the identity -/
+
+/-- Every coefficient of the twisted dimer is real. -/
+lemma star_coef (k : Fin 2) (i j : Fin 8) : star (coef k i j) = coef k i j := by
+  unfold coef
+  split_ifs <;> simp [Complex.conj_ofReal]
+
+/-- The ket-against-bra product of one letter of a rescaled block is the
+matrix unit at the right bits with the squared coefficient. -/
+lemma conjTranspose_mul_self_normalizedBlock (k : Fin 2) (i j : Fin 8) :
+    (normalizedBlock k i j)ᴴ * normalizedBlock k i j =
+      Matrix.single (finProdFinEquiv (bitR i, bitR j)) (finProdFinEquiv (bitR i, bitR j))
+        (((8 / 5 : ℂ) * coef k i j) ^ 2) := by
+  rw [normalizedBlock_apply, Matrix.conjTranspose_single, Matrix.single_mul_single_same,
+    star_mul', star_coef, sq]
+  have h : star (8 / 5 : ℂ) = 8 / 5 := by simp
+  rw [h]
+
+/-- The bit encoding of the physical index with the right bit first. -/
+def rightBitEquiv : Fin 2 × (Fin 2 × Fin 2) ≃ Fin 8 where
+  toFun x := physIdx x.2.1 x.1 x.2.2
+  invFun i := (bitR i, (bitL i, bitF i))
+  left_inv := by rintro ⟨r, l, f⟩; simp
+  right_inv i := physIdx_bits i
+
+/-- A finite sum of matrix units at one position is the matrix unit of the sum. -/
+lemma sum_single_eq_single_sum {ι m n : Type*} [DecidableEq m] [DecidableEq n]
+    (s : Finset ι) (a : m) (b : n) (c : ι → ℂ) :
+    ∑ x ∈ s, Matrix.single a b (c x) = Matrix.single a b (∑ x ∈ s, c x) := by
+  ext i j
+  simp only [Matrix.sum_apply, Matrix.single_apply]
+  by_cases h : a = i ∧ b = j <;> simp [h]
+
+/-- For fixed right bits, the squared rescaled coefficients sum to one:
+$\tfrac{64}{25}\cdot 2 \cdot \tfrac14\,(2\,C_k[0,0]^2 + 2\,C_k[0,1]^2) = 1$. -/
+lemma sum_normalizedCoef_sq (k r r' : Fin 2) :
+    ∑ x : Fin 2 × Fin 2, ∑ y : Fin 2 × Fin 2,
+      ((8 / 5 : ℂ) * coef k (physIdx x.1 r x.2) (physIdx y.1 r' y.2)) ^ 2 = 1 := by
+  simp only [Fintype.sum_prod_type, Fin.sum_univ_two, coef_physIdx]
+  fin_cases k <;> norm_num [Cmat, tau, cDiag_eq, cOff_eq]
+
+/-- **The ket-against-bra letters of a rescaled block resolve the identity.**
+Grouping the letters by the right bits of their two physical indices, the
+matrix units at $((r,r'),(r,r'))$ carry the coefficient sum of
+`sum_normalizedCoef_sq`. -/
+theorem normalizedBlock_isLeftCanonical (k : Fin 2) :
+    MPSTensor.IsLeftCanonical (normalizedBlock k).toMPSTensor := by
+  let c : Fin 8 → Fin 8 → ℂ := fun i j => ((8 / 5 : ℂ) * coef k i j) ^ 2
+  have hterm : ∀ i j : Fin 8,
+      ((normalizedBlock k).toMPSTensor (finProdFinEquiv (i, j)))ᴴ *
+        (normalizedBlock k).toMPSTensor (finProdFinEquiv (i, j)) =
+      Matrix.single (finProdFinEquiv (bitR i, bitR j)) (finProdFinEquiv (bitR i, bitR j))
+        (c i j) := by
+    intro i j
+    rw [toMPSTensor_apply_finProdFinEquiv, conjTranspose_mul_self_normalizedBlock]
+  change ∑ v : Fin (8 * 8),
+    ((normalizedBlock k).toMPSTensor v)ᴴ * (normalizedBlock k).toMPSTensor v = 1
+  rw [← (finProdFinEquiv : Fin 8 × Fin 8 ≃ Fin (8 * 8)).sum_comp, Fintype.sum_prod_type]
+  simp only [hterm]
+  rw [← rightBitEquiv.sum_comp, Fintype.sum_prod_type]
+  have hrow : ∀ (r : Fin 2) (x : Fin 2 × Fin 2),
+      ∑ j : Fin 8, Matrix.single (finProdFinEquiv (bitR (rightBitEquiv (r, x)), bitR j))
+        (finProdFinEquiv (bitR (rightBitEquiv (r, x)), bitR j)) (c (rightBitEquiv (r, x)) j) =
+      ∑ r' : Fin 2, Matrix.single (finProdFinEquiv (r, r')) (finProdFinEquiv (r, r'))
+        (∑ y : Fin 2 × Fin 2, c (physIdx x.1 r x.2) (physIdx y.1 r' y.2)) := by
+    intro r x
+    rw [← rightBitEquiv.sum_comp, Fintype.sum_prod_type]
+    simp only [rightBitEquiv, Equiv.coe_fn_mk, bitR_physIdx]
+    exact Finset.sum_congr rfl fun r' _ => sum_single_eq_single_sum _ _ _ _
+  simp only [hrow]
+  have hswap : ∀ r : Fin 2,
+      ∑ x : Fin 2 × Fin 2, ∑ r' : Fin 2,
+        Matrix.single (finProdFinEquiv (r, r')) (finProdFinEquiv (r, r'))
+          (∑ y : Fin 2 × Fin 2, c (physIdx x.1 r x.2) (physIdx y.1 r' y.2)) =
+      ∑ r' : Fin 2, Matrix.single (finProdFinEquiv (r, r')) (finProdFinEquiv (r, r')) (1 : ℂ) := by
+    intro r
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun r' _ => ?_
+    rw [sum_single_eq_single_sum]
+    congr 1
+    exact sum_normalizedCoef_sq k r r'
+  simp only [hswap]
+  calc ∑ r : Fin 2, ∑ r' : Fin 2,
+        Matrix.single (finProdFinEquiv (r, r')) (finProdFinEquiv (r, r')) (1 : ℂ)
+      = ∑ x : Fin 2 × Fin 2, Matrix.single (finProdFinEquiv x) (finProdFinEquiv x) (1 : ℂ) :=
+        (Fintype.sum_prod_type
+          (fun x : Fin 2 × Fin 2 => Matrix.single (finProdFinEquiv x) (finProdFinEquiv x)
+            (1 : ℂ))).symm
+    _ = ∑ a : Fin 4, Matrix.single a a (1 : ℂ) :=
+        finProdFinEquiv.sum_comp (fun a => Matrix.single a a (1 : ℂ))
+    _ = 1 := Matrix.sum_single_one
+
+/-- **Each rescaled horizontal block is a normal tensor** in the sense of
+arXiv:1606.00608, lines 224--235: its letters span the bond matrix algebra and
+its ket-against-bra letters resolve the identity. -/
+theorem normalizedBlock_isNormalTensor (k : Fin 2) :
+    MPSTensor.IsNormalTensor (normalizedBlock k).toMPSTensor :=
+  MPSTensor.isNormalTensor_of_isNormal_leftCanonical _
+    (normalizedBlock_toMPSTensor_isInjective k).isNormal (normalizedBlock_isLeftCanonical k)
+
+/-- The physical-trace transfer of the rescaled block $k = 1$ vanishes, as it
+does for the displayed block (`physTraceTransfer_block_one`). -/
+theorem physTraceTransfer_normalizedBlock_one : physTraceTransfer (normalizedBlock 1) = 0 := by
+  have h : physTraceTransfer (normalizedBlock 1) = (8 / 5 : ℂ) • physTraceTransfer (block 1) := by
+    unfold physTraceTransfer normalizedBlock
+    rw [Finset.smul_sum]
+  rw [h, physTraceTransfer_block_one, smul_zero]
+
+/-! ### The ambient coisometry -/
+
+/-- The bond index `(p, p', k)` of the tensor read as the block label `k`
+together with the block bond index `(p, p')`. -/
+def blockBondEquiv : (Σ _k : Fin 2, Fin 4) ≃ Fin 8 where
+  toFun x := physIdx ((finProdFinEquiv (m := 2) (n := 2)).symm x.2).1
+    ((finProdFinEquiv (m := 2) (n := 2)).symm x.2).2 x.1
+  invFun b := ⟨bitF b, finProdFinEquiv (bitL b, bitR b)⟩
+  left_inv := by rintro ⟨k, a⟩; simp
+  right_inv b := by simp [physIdx_bits]
+
+/-- The flattened retained bond index against the ambient bond index. -/
+def retainedBondEquiv : Fin (∑ _k : Fin 2, 4) ≃ Fin 8 :=
+  finSigmaFinEquiv.symm.trans blockBondEquiv
+
+/-- The ambient coisometry of the literal canonical form: the permutation
+matrix of `retainedBondEquiv`. -/
+def ambientCoisometry : Matrix (Fin (∑ _k : Fin 2, 4)) (Fin 8) ℂ :=
+  retainedBondEquiv.toPEquiv.toMatrix
+
+/-- The conjugate transpose of a permutation matrix is the permutation matrix
+of the inverse permutation. -/
+lemma conjTranspose_toMatrix_toPEquiv {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (e : α ≃ β) :
+    (e.toPEquiv.toMatrix : Matrix α β ℂ)ᴴ = e.symm.toPEquiv.toMatrix := by
+  rw [Equiv.toPEquiv_symm, PEquiv.toMatrix_symm]
+  ext i j
+  simp only [Matrix.conjTranspose_apply, Matrix.transpose_apply, PEquiv.toMatrix_apply]
+  split_ifs <;> simp
+
+lemma ambientCoisometry_mul_conjTranspose :
+    (ambientCoisometry * ambientCoisometryᴴ :
+      Matrix (Fin (∑ _k : Fin 2, 4)) (Fin (∑ _k : Fin 2, 4)) ℂ) = 1 := by
+  rw [ambientCoisometry, conjTranspose_toMatrix_toPEquiv, ← PEquiv.toMatrix_trans,
+    ← Equiv.toPEquiv_trans, Equiv.self_trans_symm, Equiv.toPEquiv_refl, PEquiv.toMatrix_refl]
+
+/-- Conjugating by the ambient coisometry permutes the bond indices. -/
+lemma conjTranspose_mul_mul_ambientCoisometry
+    (Y : Matrix (Fin (∑ _k : Fin 2, 4)) (Fin (∑ _k : Fin 2, 4)) ℂ) :
+    ambientCoisometryᴴ * Y * ambientCoisometry =
+      Y.submatrix retainedBondEquiv.symm retainedBondEquiv.symm := by
+  rw [ambientCoisometry, conjTranspose_toMatrix_toPEquiv, PEquiv.toMatrix_toPEquiv_mul,
+    PEquiv.mul_toMatrix_toPEquiv, Matrix.submatrix_submatrix]
+  rfl
+
+lemma finSigmaFinEquiv_symm_retainedBondEquiv_symm (p p' k : Fin 2) :
+    finSigmaFinEquiv.symm (retainedBondEquiv.symm (physIdx p p' k)) =
+      ⟨k, finProdFinEquiv (p, p')⟩ := by
+  simp [retainedBondEquiv, blockBondEquiv]
+
+/-- **Reconstruction of the doubled-index tensor** from the weighted direct
+sum of the two rescaled blocks: the bond matrix at the bond pair
+$((p,p',k),(q,q',k'))$ is the block-`k` entry when $k = k'$ and zero
+otherwise, exactly as in `T_apply_blocks`. -/
+theorem toMPSTensor_T_reconstruct (i : Fin (8 * 8)) :
+    T.toMPSTensor i =
+      ambientCoisometryᴴ *
+        MPSTensor.toTensorFromBlocks (d := 8 * 8) (fun _ : Fin 2 => (5 / 8 : ℂ))
+          (fun k => (normalizedBlock k).toMPSTensor) i *
+        ambientCoisometry := by
+  rw [conjTranspose_mul_mul_ambientCoisometry]
+  ext b b'
+  obtain ⟨p, p', k, rfl⟩ : ∃ p p' k, b = physIdx p p' k := ⟨_, _, _, (physIdx_bits b).symm⟩
+  obtain ⟨q, q', k', rfl⟩ : ∃ q q' k', b' = physIdx q q' k' :=
+    ⟨_, _, _, (physIdx_bits b').symm⟩
+  simp only [MPSTensor.toTensorFromBlocks, Matrix.reindex_apply, Matrix.submatrix_apply,
+    finSigmaFinEquiv_symm_retainedBondEquiv_symm]
+  change T i.divNat i.modNat (physIdx p p' k) (physIdx q q' k') = _
+  rw [T_apply_blocks]
+  by_cases hk : k = k'
+  · subst hk
+    rw [ite_eq_left rfl, Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.smul_apply, smul_eq_mul, MPOTensor.toMPSTensor, normalizedBlock]
+    ring
+  · rw [ite_eq_right hk, Matrix.blockDiagonal'_apply_ne _ _ _ hk]
+
+/-- **The literal canonical form of the doubled-index twisted dimer.** Two
+retained normal blocks of bond dimension four, namely the rescaled horizontal
+blocks, both with weight $5/8$, and the bond permutation `ambientCoisometry`.
+
+Source: arXiv:1606.00608, Section 2.3, lines 214--245 and eq. `II_CF1`
+(project example). -/
+def canonicalFormData : MPSTensor.CPSVCanonicalFormData T.toMPSTensor where
+  r := 2
+  dim := fun _ => 4
+  dim_pos := fun _ => by norm_num
+  weights := fun _ => (5 / 8 : ℂ)
+  weights_ne_zero := fun _ => by norm_num
+  blocks := fun k => (normalizedBlock k).toMPSTensor
+  blocks_normal := normalizedBlock_isNormalTensor
+  total_dim_le := by simp
+  ambient_coisometry := ambientCoisometry
+  coisometric := ambientCoisometry_mul_conjTranspose
+  reconstruct := toMPSTensor_T_reconstruct
+
+/-- The doubled-index twisted dimer is in literal canonical form.
+
+Source: arXiv:1606.00608, Section 2.3, lines 214--245 and eq. `II_CF1`
+(project example). -/
+theorem T_toMPSTensor_isCPSVCanonicalForm : MPSTensor.IsCPSVCanonicalForm T.toMPSTensor :=
+  ⟨canonicalFormData⟩
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean
@@ -286,9 +286,8 @@ theorem toMPSTensor_T_reconstruct (i : Fin (8 * 8)) :
         ambientCoisometry := by
   rw [conjTranspose_mul_mul_ambientCoisometry]
   ext b b'
-  obtain ⟨p, p', k, rfl⟩ : ∃ p p' k, b = physIdx p p' k := ⟨_, _, _, (physIdx_bits b).symm⟩
-  obtain ⟨q, q', k', rfl⟩ : ∃ q q' k', b' = physIdx q q' k' :=
-    ⟨_, _, _, (physIdx_bits b').symm⟩
+  obtain ⟨p, p', k, rfl⟩ := exists_eq_physIdx b
+  obtain ⟨q, q', k', rfl⟩ := exists_eq_physIdx b'
   simp only [MPSTensor.toTensorFromBlocks, Matrix.reindex_apply, Matrix.submatrix_apply,
     finSigmaFinEquiv_symm_retainedBondEquiv_symm]
   change T i.divNat i.modNat (physIdx p p' k) (physIdx q q' k') = _

--- a/TNLean/MPS/MPDO/TwistedDimerNotSimple.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerNotSimple.lean
@@ -57,8 +57,7 @@ length-$L$ configurations of the diagonal word evaluations, which is the
 $L$-th power of the one-site physical-trace transfer
 (`sum_evalWord_diag_eq_verticalLoop_pow`).
 
-Source: arXiv:1606.00608, Definition 4.2, lines 735--739, applied to the
-blocked tensor of lines 317--345. -/
+Source: arXiv:1606.00608, blocking construction at lines 227--230. -/
 theorem physTraceTransfer_blockTensor (M : MPOTensor d D) (L : ℕ) :
     physTraceTransfer (blockTensor M L) = physTraceTransfer M ^ L := by
   rw [← verticalLoop_eq_physTraceTransfer M, ← sum_evalWord_diag_eq_verticalLoop_pow]

--- a/TNLean/MPS/MPDO/TwistedDimerNotSimple.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerNotSimple.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.BNTRefinement
+import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.Simple
+import TNLean.MPS.MPDO.TwistedDimerHorizontalCF
+
+/-!
+# The twisted quantum dimer is not simple
+
+**Scope: Definition 4.7 fails for the twisted dimer at every blocking
+length.** The $\mathbb Z_2$-twisted quantum dimer `T` of
+`TNLean.MPS.MPDO.TwistedDimer` is a project example, not a tensor stated in
+the source. Its doubled-index tensor is in literal canonical form with the two
+rescaled horizontal blocks (`TNLean.MPS.MPDO.TwistedDimerHorizontalCF`).
+Blocking $L$ sites keeps this canonical form, and its BNT refinement supplies
+a BNT sector presentation of the blocked doubled-index tensor. The rescaled
+block $k = 1$ has vanishing physical-trace transfer, and blocking raises the
+physical-trace transfer to the $L$-th power, so the representative of the
+phase class of the blocked block $k = 1$ has nilpotent ket-against-bra
+contraction. Presentation independence of nonnilpotency
+(`MPOTensor.bnt_basis_not_isNilpotent_iff`) then rules out every presentation
+with only nonnilpotent representatives, at every positive blocking length.
+
+## Main results
+
+* `MPOTensor.physTraceTransfer_blockTensor` — blocking raises the
+  physical-trace transfer to the power of the blocking length;
+* `blockedCanonicalFormData` — the literal canonical form of the blocked
+  doubled-index tensor, on the blocked doubled alphabet;
+* `T_not_isSimple` — the twisted dimer is not simple in the sense of
+  Definition 4.7.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.7, lines 815--822, and lines 995--1010 (project example, not a
+  tensor stated in the source)
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- **Blocking raises the physical-trace transfer to a power.** The
+physical-trace transfer of the $L$-site blocking is the sum over all
+length-$L$ configurations of the diagonal word evaluations, which is the
+$L$-th power of the one-site physical-trace transfer
+(`sum_evalWord_diag_eq_verticalLoop_pow`).
+
+Source: arXiv:1606.00608, Definition 4.2, lines 735--739, applied to the
+blocked tensor of lines 317--345. -/
+theorem physTraceTransfer_blockTensor (M : MPOTensor d D) (L : ℕ) :
+    physTraceTransfer (blockTensor M L) = physTraceTransfer M ^ L := by
+  rw [← verticalLoop_eq_physTraceTransfer M, ← sum_evalWord_diag_eq_verticalLoop_pow]
+  unfold physTraceTransfer
+  simp only [blockTensor_apply, Kraus.wordOfBlock]
+  exact (MPSTensor.decodeBlockEquiv d L).sum_comp
+    fun σ => evalWord M (List.ofFn σ) (List.ofFn σ)
+
+namespace TwistedDimer
+
+/-- The literal canonical form of the $L$-site blocking of the twisted dimer,
+on the doubled alphabet of the blocked tensor: the one-site canonical form
+`canonicalFormData` blocked by `L` and relabeled along the canonical pairing of
+the blocked ket and bra words.
+
+Source: arXiv:1606.00608, Section 2.3, lines 214--245, blocked as in lines
+317--345 (project example). -/
+def blockedCanonicalFormData (L : ℕ) (hL : 0 < L) :
+    MPSTensor.CPSVCanonicalFormData
+      (Kraus.reindexPhysical (blockedDoubledIndexEquiv 8 L)
+        (MPSTensor.blockTensor T.toMPSTensor L)) :=
+  (canonicalFormData.blockTensor L hL).reindexPhysical (blockedDoubledIndexEquiv 8 L)
+
+/-- The retained blocks of the blocked canonical form are the doubled-index
+tensors of the blocked rescaled horizontal blocks. -/
+lemma blockedCanonicalFormData_blocks (L : ℕ) (hL : 0 < L) (k : Fin 2) :
+    (blockedCanonicalFormData L hL).blocks k = (blockTensor (normalizedBlock k) L).toMPSTensor := by
+  rw [toMPSTensor_blockTensor]
+  rfl
+
+/-- The blocked rescaled block $k = 1$ has vanishing ket-against-bra
+contraction: the one-site physical-trace transfer vanishes
+(`physTraceTransfer_normalizedBlock_one`), and blocking raises it to a
+positive power. -/
+lemma doubledPhysTraceTransfer_blockedCanonicalFormData_blocks_one (L : ℕ) (hL : 0 < L) :
+    doubledPhysTraceTransfer (MPSTensor.blockPhysDim 8 L)
+      ((blockedCanonicalFormData L hL).blocks (1 : Fin 2)) = 0 := by
+  have h : doubledPhysTraceTransfer (MPSTensor.blockPhysDim 8 L)
+      (blockTensor (normalizedBlock 1) L).toMPSTensor = 0 := by
+    rw [doubledPhysTraceTransfer_toMPSTensor, physTraceTransfer_blockTensor,
+      physTraceTransfer_normalizedBlock_one, zero_pow hL.ne']
+  exact (congrArg (doubledPhysTraceTransfer (MPSTensor.blockPhysDim 8 L))
+    (blockedCanonicalFormData_blocks L hL 1)).trans h
+
+/-- **The twisted quantum dimer is not simple** in the sense of
+arXiv:1606.00608, Definition 4.7, lines 815--822.
+
+Fix a positive blocking length $L$ and a BNT sector presentation $P$ of the
+blocked doubled-index tensor. The BNT refinement of the blocked literal
+canonical form `blockedCanonicalFormData` is another presentation $Q$, whose
+representatives are chosen among the two blocked rescaled horizontal blocks.
+The blocked block $k = 1$ is a gauge-phase multiple of its class
+representative, and its ket-against-bra contraction vanishes, so that
+representative has nilpotent contraction. By presentation independence
+(`bnt_basis_not_isNilpotent_iff`), $P$ also has a representative with
+nilpotent contraction.
+
+This is a project example, not a tensor stated in the source. -/
+theorem T_not_isSimple : ¬ IsSimple T := by
+  rintro ⟨_, L, hL, P, hPres, hNonNil⟩
+  rw [toMPSTensor_blockTensor] at hPres
+  let data := blockedCanonicalFormData L hL
+  let ref := data.bntRefinement
+  have hQ : MPSTensor.IsBNTSectorPresentation _ ref.representativeSectorDecomposition :=
+    ref.isBNTSectorPresentation (show (0 : ℕ) < 2 by norm_num)
+  have hAll := (bnt_basis_not_isNilpotent_iff hPres hQ).mp hNonNil
+  let k₁ : Fin data.r := (1 : Fin 2)
+  apply hAll (data.classCopy k₁).1
+  have hGauge : MPSTensor.GaugePhaseEquiv
+      (cast (congr_arg (MPSTensor (MPSTensor.blockPhysDim 8 L * MPSTensor.blockPhysDim 8 L))
+          (ref.copyDimEq k₁))
+        (data.blocks (data.representativeIndex (data.classCopy k₁).1)))
+      (data.blocks k₁) := by
+    refine ⟨ref.listedGauge k₁, ref.copyPhase k₁,
+      Complex.ne_zero_of_norm_eq_one (ref.copyPhaseNorm k₁), fun i => ?_⟩
+    rw [ref.blocksEqListedGaugeConj k₁ i, ref.regroupedBlocksEq k₁]
+    simp only [smul_mul_assoc, mul_smul_comm]
+  have hNil : IsNilpotent (doubledPhysTraceTransfer (MPSTensor.blockPhysDim 8 L)
+      (data.blocks k₁)) := by
+    rw [doubledPhysTraceTransfer_blockedCanonicalFormData_blocks_one]
+    exact IsNilpotent.zero
+  exact (isNilpotent_doubledPhysTraceTransfer_cast_iff (ref.copyDimEq k₁) _).mp
+    ((isNilpotent_doubledPhysTraceTransfer_iff_of_gaugePhaseEquiv hGauge).mpr hNil)
+
+end TwistedDimer
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1148,6 +1148,135 @@
     gives the product predicate.
 \end{proof}
 
+\begin{theorem}[Horizontal canonical form of the twisted quantum dimer]%
+    \label{thm:mpdo_twisted_dimer_horizontal_cf}
+    \lean{MPOTensor.TwistedDimer.normalizedBlock}
+    \lean{MPOTensor.TwistedDimer.normalizedBlock_apply}
+    \lean{MPOTensor.TwistedDimer.toMPSTensor_apply_finProdFinEquiv}
+    \lean{MPOTensor.TwistedDimer.coef_flag_zero_ne_zero}
+    \lean{MPOTensor.TwistedDimer.block_toMPSTensor_isInjective}
+    \lean{MPOTensor.TwistedDimer.normalizedBlock_toMPSTensor_isInjective}
+    \lean{MPOTensor.TwistedDimer.star_coef}
+    \lean{MPOTensor.TwistedDimer.conjTranspose_mul_self_normalizedBlock}
+    \lean{MPOTensor.TwistedDimer.rightBitEquiv}
+    \lean{MPOTensor.TwistedDimer.sum_single_eq_single_sum}
+    \lean{MPOTensor.TwistedDimer.sum_normalizedCoef_sq}
+    \lean{MPOTensor.TwistedDimer.normalizedBlock_isLeftCanonical}
+    \lean{MPOTensor.TwistedDimer.normalizedBlock_isNormalTensor}
+    \lean{MPOTensor.TwistedDimer.physTraceTransfer_normalizedBlock_one}
+    \lean{MPOTensor.TwistedDimer.exists_eq_physIdx}
+    \lean{MPOTensor.TwistedDimer.blockBondEquiv}
+    \lean{MPOTensor.TwistedDimer.retainedBondEquiv}
+    \lean{MPOTensor.TwistedDimer.ambientCoisometry}
+    \lean{MPOTensor.TwistedDimer.conjTranspose_toMatrix_toPEquiv}
+    \lean{MPOTensor.TwistedDimer.ambientCoisometry_mul_conjTranspose}
+    \lean{MPOTensor.TwistedDimer.conjTranspose_mul_mul_ambientCoisometry}
+    \lean{MPOTensor.TwistedDimer.finSigmaFinEquiv_symm_retainedBondEquiv_symm}
+    \lean{MPOTensor.TwistedDimer.toMPSTensor_T_reconstruct}
+    \lean{MPOTensor.TwistedDimer.canonicalFormData}
+    \lean{MPOTensor.TwistedDimer.T_toMPSTensor_isCPSVCanonicalForm}
+    \leanok
+    \uses{def:mpdo_twisted_dimer_tensor, def:cpsv_canonical_form, def:nt_cpsv, def:left_canonical_tensor}
+    Let $M_0$, $M_1$ be the two horizontal blocks of the twisted quantum
+    dimer of Definition~\ref{def:mpdo_twisted_dimer_tensor}, read as tensors
+    with the doubled physical index $((l,r,f),(l',r',f'))$ and bond dimension
+    four, and let $\widehat M_k=\frac85\,M_k$. The letters of each
+    $\widehat M_k$ span the full algebra of $4\times4$ matrices, the sum
+    $\sum_{i,j}(\widehat M_k^{ij})^\dagger\widehat M_k^{ij}$ is the identity,
+    and hence each $\widehat M_k$ is a normal tensor. The doubled-index
+    twisted dimer is in canonical form in the sense of
+    Definition~\ref{def:cpsv_canonical_form}: with the permutation $U$ of the
+    bond index $(p,p',k)$ into the block label $k$ followed by the block bond
+    index $(p,p')$,
+    \begin{align}
+        M^{ij} & =U^\dagger\Bigl(\tfrac58\,\widehat M_0^{ij}\oplus
+        \tfrac58\,\widehat M_1^{ij}\Bigr)U.
+        \notag
+    \end{align}
+    The physical-trace transfer of $\widehat M_1$ vanishes. The tensor is a
+    project example motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_twisted_dimer_closures, thm:is_normal_tensor_of_is_normal_left_canonical}
+    The letter of $M_k$ at the physical pair $((p,q,0),(p',q',0))$ is the
+    matrix unit at the bond pair $((p,p'),(q,q'))$ with the nonzero
+    coefficient $\frac12C_k[p,p']$, so the letters span the bond algebra.
+    The product $(\widehat M_k^{ij})^\dagger\widehat M_k^{ij}$ is the
+    diagonal matrix unit at the right bits $(r,r')$ of $i$ and $j$, with
+    coefficient $\frac{64}{25}$ times the squared coefficient of the letter.
+    Grouping the letters by their right bits, the coefficients at fixed
+    $(r,r')$ sum to
+    $\frac{64}{25}\cdot2\cdot\frac14\bigl(2C_k[0,0]^2+2C_k[0,1]^2\bigr)=1$,
+    so the sum of the products is the identity.
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} gives
+    normality. The reconstruction is the block decomposition of
+    Definition~\ref{def:mpdo_twisted_dimer_tensor} entry by entry, the factor
+    $\frac58\cdot\frac85=1$ restoring the displayed blocks, and $U$ is a
+    permutation matrix, hence a coisometry. The physical-trace transfer of
+    $\widehat M_1$ is $\frac85$ times that of $M_1$, which vanishes by
+    Theorem~\ref{thm:mpdo_twisted_dimer_closures}.
+\end{proof}
+
+\begin{lemma}[Blocking raises the physical-trace transfer to a power]%
+    \label{lem:mpdo_phys_trace_transfer_blocking}
+    \lean{MPOTensor.physTraceTransfer_blockTensor}
+    \leanok
+    \uses{def:mpdo_physical_blocking, def:mpo_physical_trace_transfer}
+    For every tensor $M$ and every blocking length $L$, the physical-trace
+    transfer of the $L$-site blocking of $M$ is the $L$-th power of the
+    physical-trace transfer of $M$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:mpdo_trace_loop_chain}
+    The physical-trace transfer of the blocking is the sum over all
+    length-$L$ configurations of the diagonal word evaluations, which is the
+    $L$-th power of the one-site loop by
+    Lemma~\ref{lem:mpdo_trace_loop_chain}.
+\end{proof}
+
+\begin{theorem}[The twisted quantum dimer is not simple]%
+    \label{thm:mpdo_twisted_dimer_not_simple}
+    \lean{MPOTensor.TwistedDimer.blockedCanonicalFormData}
+    \lean{MPOTensor.TwistedDimer.blockedCanonicalFormData_blocks}
+    \lean{MPOTensor.TwistedDimer.%
+        doubledPhysTraceTransfer_blockedCanonicalFormData_blocks_one}
+    \lean{MPOTensor.TwistedDimer.T_not_isSimple}
+    \leanok
+    \uses{def:mpdo_simple_tensor, def:mpdo_twisted_dimer_tensor}
+    The twisted quantum dimer of Definition~\ref{def:mpdo_twisted_dimer_tensor}
+    is not simple in the sense of Definition~\ref{def:mpdo_simple_tensor}: for
+    every positive blocking length $L$ and every BNT sector presentation of
+    the doubled-index tensor of the $L$-site blocking, some representative
+    has nilpotent physical-trace transfer. The tensor is a project example
+    motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_twisted_dimer_horizontal_cf, thm:cpsv_literal_canonical_form_positive_blocking, thm:cpsv_physical_reindexing, thm:mpdo_blocking_doubled_index, thm:cpsv_canonical_form_bnt_refinement, thm:cpsv_representative_sector_decomposition, thm:mpdo_bnt_nonnilpotency_independent, thm:mpdo_doubled_phys_trace_nilpotent_gauge_phase, lem:mpdo_doubled_phys_trace_transfer_to_mps, lem:mpdo_phys_trace_transfer_blocking}
+    Fix $L>0$ and a presentation $P$. Blocking the canonical form of
+    Theorem~\ref{thm:mpdo_twisted_dimer_horizontal_cf} by $L$ sites
+    (Theorem~\ref{thm:cpsv_literal_canonical_form_positive_blocking}) and
+    relabeling the doubled alphabet along the pairing of the blocked ket and
+    bra words (Theorems~\ref{thm:cpsv_physical_reindexing}
+    and~\ref{thm:mpdo_blocking_doubled_index}) gives a canonical form of the
+    blocked doubled-index tensor whose retained blocks are the $L$-site
+    blockings of $\widehat M_0$ and $\widehat M_1$. Its BNT refinement
+    (Theorem~\ref{thm:cpsv_canonical_form_bnt_refinement}) is a BNT sector
+    presentation $Q$
+    (Theorem~\ref{thm:cpsv_representative_sector_decomposition}) in which
+    every retained block is a gauge-phase multiple of the representative of
+    its phase class. The blocked $\widehat M_1$ has vanishing physical-trace
+    transfer by Lemma~\ref{lem:mpdo_phys_trace_transfer_blocking} together
+    with Lemma~\ref{lem:mpdo_doubled_phys_trace_transfer_to_mps}, so by
+    Theorem~\ref{thm:mpdo_doubled_phys_trace_nilpotent_gauge_phase} the
+    representative of its phase class has nilpotent physical-trace transfer.
+    Theorem~\ref{thm:mpdo_bnt_nonnilpotency_independent} transfers this to
+    $P$.
+\end{proof}
+
 \begin{lemma}[Doubled-index letters and their rank-one factorization]
     \label{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_R_apply}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -812,6 +812,21 @@ abstracted — record why, so it is not re-proposed).
 
 ---
 
+### twisted-dimer bit-encoding destructuring — promoted
+- **Pattern:** rewriting an index of the eight-valued physical or bond
+  alphabet of the twisted dimer as its bit encoding before case analysis:
+  ```lean
+  obtain ⟨p, p', k, rfl⟩ : ∃ p p' k, a = physIdx p p' k := ⟨_, _, _, (physIdx_bits a).symm⟩
+  ```
+- **Seen:** 4 occurrences across 2 files before promotion
+  (`TNLean/MPS/MPDO/TwistedDimerFlagSectors.lean`,
+  `TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean`).
+- **Abstraction:** `MPOTensor.TwistedDimer.exists_eq_physIdx`
+  (`TNLean/MPS/MPDO/TwistedDimer.lean`); call sites read
+  `obtain ⟨p, p', k, rfl⟩ := exists_eq_physIdx a`.
+- **Notes:** the inline existential statement and its witness are removed at
+  every call site; one line each.
+
 ## Completed refactors
 
 ### Successor under one-step finite rotation


### PR DESCRIPTION
## Summary

Closes #7616 (part of #7611): `T_not_isSimple : ¬ MPOTensor.IsSimple T` for the $\mathbb Z_2$-twisted quantum dimer, for every blocking length, against the repository's unchanged Definition 4.7 predicate.

* `TNLean/MPS/MPDO/TwistedDimerHorizontalCF.lean`: the rescaled blocks `normalizedBlock k = (8/5) • block k` are injective and left canonical, hence normal tensors; `canonicalFormData : CPSVCanonicalFormData T.toMPSTensor` with two blocks, weights `5/8`, and a permutation coisometry; `toMPSTensor_T_reconstruct` from `T_apply_blocks`.
* `TNLean/MPS/MPDO/TwistedDimerNotSimple.lean`: the general power law `MPOTensor.physTraceTransfer_blockTensor : physTraceTransfer (blockTensor M L) = physTraceTransfer M ^ L`; the blocked canonical-form data present `(blockTensor T L).toMPSTensor` for every `L > 0`, their BNT refinement gives a sector presentation whose block `k = 1` representative has zero doubled physical-trace transfer, and `bnt_basis_not_isNilpotent_iff` transports the nilpotent representative to every other presentation.
* `exists_eq_physIdx` added to `TwistedDimer.lean` (rule-of-three promotion of the bit-destructuring pattern; four call sites refactored; ledger entry in `docs/tactic_patterns.md`).
* Blueprint: three entries in `ch21_mpdo_rfp_bnt_coefficients.tex` (horizontal canonical form, blocking power law, non-simplicity), formatted with latexindent.

The statement is exactly `¬ T.IsSimple` with no hypotheses; no restated or weakened predicate is introduced.

## Verification

* `lake build TNLean.MPS.MPDO` passes with zero warnings; `#print axioms T_not_isSimple` gives only `propext, Classical.choice, Quot.sound`; no `sorry`, `axiom`, or `native_decide`.
* Aggregator regenerated; numbered-file, oversized-file, forbidden-token, import-syntax checks and `blueprint_lean_sync.py --ci` pass.
* An independent reviewer agent rebuilt the modules from scratch, re-checked the axioms, and confirmed the statement is the unchanged `IsSimple` predicate.

Note: this branch and the vertical canonical-form PR both edit `ch21_mpdo_rfp_bnt_coefficients.tex` and `TNLean/MPS/MPDO.lean`; whichever merges second needs a rebase.

https://claude.ai/code/session_01AgcGSvYZercYZbHeSdMRVB