### PR TITLE
feat(mpdo): prove the vertical canonical form and algebra clause of the twisted dimer

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -325,6 +325,7 @@ import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TopologicalTerminalSpectral
 import TNLean.MPS.MPDO.TwistedDimer
+import TNLean.MPS.MPDO.TwistedDimerBNTAlgebraClause
 import TNLean.MPS.MPDO.TwistedDimerCoefficients
 import TNLean.MPS.MPDO.TwistedDimerFlagSectors
 import TNLean.MPS.MPDO.TwistedDimerHorizontalCF

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -332,6 +332,7 @@ import TNLean.MPS.MPDO.TwistedDimerMPDO
 import TNLean.MPS.MPDO.TwistedDimerNotSimple
 import TNLean.MPS.MPDO.TwistedDimerProductLaw
 import TNLean.MPS.MPDO.TwistedDimerRefine
+import TNLean.MPS.MPDO.TwistedDimerVerticalCF
 import TNLean.MPS.MPDO.TwistedDimerViaTS
 import TNLean.MPS.MPDO.TwoSitePrefixReflectedMarkedChain
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm

--- a/TNLean/MPS/MPDO/TwistedDimerBNTAlgebraClause.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerBNTAlgebraClause.lean
@@ -1,0 +1,208 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPDO.TwistedDimerProductLaw
+import TNLean.MPS.MPDO.TwistedDimerVerticalCF
+
+/-!
+# The tensor-attached algebra clause of the $\mathbb Z_2$-twisted quantum dimer
+
+**Scope: the algebra clause of Theorem 4.14(ii) attached to the vertical
+canonical form of `T`.**  The vertical canonical form of the twisted quantum
+dimer (`TNLean.MPS.MPDO.TwistedDimerVerticalCF`) has the two normalized flag
+sectors as basis of normal tensors, and the same-length product law of their
+closed operators (`TNLean.MPS.MPDO.TwistedDimerProductLaw`) carries the
+two-label coefficient family with $\alpha = 7/10$, $\beta = 1/10$.  This file
+combines the two into the tensor-attached algebra clause
+`MPOTensor.BNTAlgebraTensorClause` of arXiv:1606.00608, Theorem 4.14(ii),
+lines 972--993: the flag sectors are normal tensors in the sense of the source
+(injective at one site and left-canonical), the coefficient family is the
+trace-power family of the positive diagonal $\chi$-family `twoLabelChi`, and
+the trace scalars $m_0 = m_1 = \mu = 5/8$ satisfy the length-one idempotent law
+$$
+  m_g = \sum_{f, f'} c^{(1)}_{f f' g}\, m_f\, m_{f'}
+      = 2 (\alpha + \beta)\, \mu^2 = \tfrac{8}{5} \cdot \tfrac{25}{64} = \tfrac58 .
+$$
+The tensor is a project example motivated by the length-dependence question
+after Theorem 4.14 (lines 995--1010); it is not a tensor stated in that source.
+No comparison with a blocked basis, fusion isometry, or renormalization map is
+asserted here.
+
+## Main results
+
+* `flagFamily_isLeftCanonical` — each flag sector is left-canonical;
+* `flagFamily_isNormalTensor` — each flag sector is a normal tensor in the
+  sense of arXiv:1606.00608, lines 231--235;
+* `flagFamily_isCPSVBasisOfNormalTensors` — the flag sectors form the basis of
+  normal tensors of the vertically viewed tensor in the source's sense;
+* `sectorWeight_hasIdempotentCoefficientForm` — the length-one idempotent law
+  of the trace scalars;
+* `T_bntAlgebraTensorClause` — the tensor-attached algebra clause of `T`.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 945--959; Theorem 4.14(ii), lines 972--993; and
+  lines 995--1010 (the length-dependence question motivating this project
+  example)
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### Left-canonical normalization of the flag sectors -/
+
+/-- The letter of a flag sector, multiplied on the left by its adjoint, is a
+diagonal matrix unit at the right bits with the squared modulus of the
+coefficient. -/
+lemma conjTranspose_flagMPO_mul_self (f : Fin 2) (a b : Fin 8) :
+    (flagMPO f a b)ᴴ * flagMPO f a b =
+      Matrix.single (finProdFinEquiv (bitR a, bitR b)) (finProdFinEquiv (bitR a, bitR b))
+        (star (flagCoef f a b) * flagCoef f a b) := by
+  simp [flagMPO, unitTensor, Matrix.conjTranspose_single, Matrix.single_mul_single_same]
+
+/-- The squared modulus of the sector coefficient: the flag sign squares to
+one, leaving the squared bond-matrix entry over $(2\mu)^2$ when the block
+labels agree. -/
+lemma star_flagCoef_mul_self (f p p' k q q' k' : Fin 2) :
+    star (flagCoef f (physIdx p p' k) (physIdx q q' k')) *
+        flagCoef f (physIdx p p' k) (physIdx q q' k') =
+      if k = k' then (((Cmat k p p' / (2 * mu)) ^ 2 : ℝ) : ℂ) else 0 := by
+  simp only [flagCoef, bitF_physIdx, flagWeight_physIdx]
+  split_ifs
+  · rw [Complex.star_def, Complex.conj_ofReal, ← Complex.ofReal_mul]
+    congr 1
+    have ht : tau k f * tau k f = 1 := by fin_cases k <;> fin_cases f <;> norm_num [tau]
+    calc Cmat k p p' * tau k f / (2 * mu) * (Cmat k p p' * tau k f / (2 * mu))
+        = (Cmat k p p' / (2 * mu)) ^ 2 * (tau k f * tau k f) := by ring
+      _ = _ := by rw [ht, mul_one]
+  · simp
+
+/-- Expanding a double sum over the bond indices along their bit encodings. -/
+private lemma sum_bits (F : Fin 8 → Fin 8 → ℂ) :
+    (∑ a, ∑ b, F a b) =
+      ∑ p, ∑ p', ∑ k, ∑ q, ∑ q', ∑ k', F (physIdx p p' k) (physIdx q q' k') := by
+  rw [← physEquiv.sum_comp]
+  simp only [Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl fun p _ => Finset.sum_congr rfl fun p' _ =>
+    Finset.sum_congr rfl fun k _ => ?_
+  rw [← physEquiv.sum_comp]
+  simp only [Fintype.sum_prod_type]
+  rfl
+
+/-- **The flag sectors are left-canonical.**  The sum over the bond pairs of
+the adjoint of a sector letter times the letter is the identity: at each
+right-bit pair, the sum of the squared coefficients is
+$2 \sum_{k, p} C_k[p, p']^2 / (2\mu)^2 = 4 \cdot \tfrac{25}{64} / \tfrac{100}{64} = 1$.
+
+Project example; not from CPSV16. -/
+theorem flagFamily_isLeftCanonical (f : Fin 2) : (flagFamily f).IsLeftCanonical := by
+  unfold MPSTensor.IsLeftCanonical Kraus.IsTP
+  rw [← (finProdFinEquiv (m := 8) (n := 8)).sum_comp, Fintype.sum_prod_type]
+  simp only [flagFamily_finProdFinEquiv, conjTranspose_flagMPO_mul_self]
+  ext i j
+  simp only [Matrix.sum_apply, Matrix.single_apply, Matrix.one_apply]
+  by_cases hij : i = j
+  · subst hij
+    simp only [and_self, ite_true]
+    obtain ⟨⟨i₁, i₂⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective i
+    rw [sum_bits fun a b =>
+      if finProdFinEquiv (bitR a, bitR b) = finProdFinEquiv (i₁, i₂) then
+        star (flagCoef f a b) * flagCoef f a b else 0]
+    simp only [bitR_physIdx, finProdFinEquiv.injective.eq_iff, Prod.mk.injEq,
+      star_flagCoef_mul_self]
+    fin_cases i₁ <;> fin_cases i₂ <;>
+      simp [Fin.sum_univ_two, Cmat, cDiag_eq, cOff_eq, mu] <;> norm_num
+  · rw [ite_eq_right hij]
+    refine Finset.sum_eq_zero fun a _ => Finset.sum_eq_zero fun b _ => ?_
+    rw [ite_eq_right]
+    rintro ⟨h₁, h₂⟩
+    exact hij (h₁.symm.trans h₂)
+
+/-- **The flag sectors are normal tensors** in the sense of arXiv:1606.00608,
+lines 231--235: injective at one site and left-canonical.
+
+Project example; not from CPSV16. -/
+theorem flagFamily_isNormalTensor (f : Fin 2) : (flagFamily f).IsNormalTensor :=
+  MPSTensor.isNormalTensor_of_isNormal_leftCanonical (flagFamily f) (flagFamily_isNormal f)
+    (flagFamily_isLeftCanonical f)
+
+/-- **The flag sectors form the source's basis of normal tensors of the
+vertically viewed tensor** (arXiv:1606.00608, Proposition 4.13, lines
+945--959).
+
+Project example; not from CPSV16. -/
+theorem flagFamily_isCPSVBasisOfNormalTensors :
+    MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor T)
+      (fun f : Fin 2 => ⟨sectorDim f, flagFamily f⟩) where
+  blocks_normal := flagFamily_isNormalTensor
+  spans_mpv N hN := ⟨fun _ => ((mu : ℝ) : ℂ) ^ N, mpv_verticalTensor_T hN⟩
+  eventually_li := ⟨0, fun N hN => linearIndependent_mpvState_flagFamily N hN⟩
+
+/-! ### The algebra clause -/
+
+/-- The two-label coefficient family is the trace-power family of the positive
+diagonal $\chi$-family `twoLabelChi` (arXiv:1606.00608, Theorem 4.14(ii),
+lines 972--985). -/
+def twoLabelChiTracePowerForm : PositiveBNTLabelChiTracePowerForm twoLabelCoeffs :=
+  PositiveBNTLabelChiTracePowerForm.ofChi twoLabelChi twoLabelChi_posEntries
+
+/-- **The length-one idempotent law.**  With $m_0 = m_1 = \mu = 5/8$ and the
+length-one coefficients $\alpha = 7/10$, $\beta = 1/10$, each label $g$
+satisfies $m_g = \sum_{f, f'} c^{(1)}_{f f' g} m_f m_{f'} = 2(\alpha + \beta)\mu^2$
+(arXiv:1606.00608, Theorem 4.14(ii), lines 981--985).
+
+Project example; not from CPSV16. -/
+theorem sectorWeight_hasIdempotentCoefficientForm :
+    (verticalBNTTraceScalarFamily sectorWeight).HasIdempotentCoefficientForm twoLabelCoeffs := by
+  intro g
+  simp only [verticalBNTTraceScalarFamily_traceScalar, sectorWeight, twoLabelCoeffs_coeff,
+    Fin.sum_univ_two, Finset.sum_const, Finset.card_univ, Fintype.card_fin, one_smul]
+  fin_cases g <;> simp [sameChannel] <;> norm_num [mu, alpha, beta]
+
+/-- The algebra clause for the flag-sector operators and trace scalars. -/
+def flagAlgebraClause :
+    BNTAlgebraClause twoLabelCoeffs (verticalBNTOperatorFamily (D := 8) flagFamily)
+      (verticalBNTTraceScalarFamily sectorWeight) where
+  positiveChi := twoLabelChiTracePowerForm
+  sameLengthProduct := flagOperatorFamily_hasSameLengthProductForm
+  idempotent := sectorWeight_hasIdempotentCoefficientForm
+
+/-- **The tensor-attached algebra clause of the twisted quantum dimer.**  The
+vertical canonical form with the two flag sectors, multiplicity one each and
+weight $\mu = 5/8$, together with the two-label coefficient family
+$c^{(L)}_{f f' g} = \alpha^L$ on the channel $g = f + f'$ and $\beta^L$ on the
+channel $g = f + f' + 1$, is the algebra clause of arXiv:1606.00608, Theorem
+4.14(ii), lines 972--993, for the displayed tensor.  Together with
+`twoLabelCoeffs_rescaling_stable_not_lengthIndependent`, the attached
+coefficient family is one that no positive rescaling of the two labels makes
+length independent.  The tensor is a project example motivated by the
+length-dependence question after Theorem 4.14 (lines 995--1010); it is not a
+tensor stated in that source. -/
+def T_bntAlgebraTensorClause : BNTAlgebraTensorClause T where
+  labelCount := 2
+  bondDim := sectorDim
+  multiplicity := sectorMult
+  weight := sectorWeight
+  tensor := flagFamily
+  verticalCoisometry := verticalCoisometry
+  multiplicity_pos _ := Nat.one_pos
+  weight_pos _ _ := Complex.zero_lt_real.mpr (by norm_num [mu])
+  coisometry := verticalCoisometry_mul_conjTranspose
+  isCPSVBNT := flagFamily_isCPSVBasisOfNormalTensors
+  forward := verticalCoisometry_conj_verticalTensor
+  reconstruction := verticalTensor_T_eq_conjTranspose_mul
+  coeffs := twoLabelCoeffs
+  algebraClause := flagAlgebraClause
+
+/-- The twisted quantum dimer has a tensor-attached algebra clause. -/
+theorem T_hasBNTAlgebraTensorClause : HasBNTAlgebraTensorClause T :=
+  ⟨T_bntAlgebraTensorClause⟩
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
@@ -1,0 +1,431 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.TwistedDimerFlagSectors
+import TNLean.MPS.MPDO.VerticalSectorCoordinates
+
+/-!
+# The vertical canonical form of the $\mathbb Z_2$-twisted quantum dimer
+
+**Scope: the vertical canonical form with the flag sectors as basis.**  The
+vertically viewed tensor of the $\mathbb Z_2$-twisted quantum dimer `T` of
+`TNLean.MPS.MPDO.TwistedDimer` has letters indexed by the horizontal bond pairs
+and acting on the physical space $\mathbb C^8$ of the two qubits $L, R$ and the
+flag qubit.  Reordering the physical index $(l, r, f) \mapsto (f, (l, r))$ by a
+permutation matrix $U$ splits every vertical letter along the flag value into
+the two normalized flag sectors $\widehat M_f$ of
+`TNLean.MPS.MPDO.TwistedDimerFlagSectors`, each with the weight $\mu = 5/8$:
+$$
+  U\,\widetilde T_{ab}\,U^\dagger
+    = \mu\,\widehat M_0^{ab} \oplus \mu\,\widehat M_1^{ab}.
+$$
+This file proves that the two sectors form a basis of normal tensors of the
+vertically viewed tensor, so that `T` is in vertical canonical form in the
+sense of arXiv:1606.00608, Proposition 4.13, lines 945--959 and 1861--1922,
+with two labels, multiplicity one each, and the coefficient $\mu$.  The tensor
+is a project example motivated by the length-dependence question after
+Theorem 4.14 (lines 995--1010); it is not a tensor stated in that source.
+
+## The argument
+
+* The letters of each flag sector are nonzero multiples of matrix units, one
+  for every matrix unit of $M_4(\mathbb C)$, so each sector is injective at one
+  site and hence normal.
+* The permutation matrix $U$ conjugates the vertical letters onto the weighted
+  direct sum of the sector letters, because the letter of `T` between physical
+  indices with different flags vanishes and the letter with a common flag is
+  $\mu$ times the sector letter (`flagMPO_apply_eq_T`).
+* The matrix product vectors of the vertical tensor are therefore the sum over
+  the two sectors of $\mu^N$ times the sector matrix product vectors.
+* The two sectors are linearly independent at every positive length: on the
+  constant word of bond index $(0, 0, 0)$ both sectors evaluate to $(2/5)^N$,
+  while on the word with one bond index $(0, 0, 1)$ and the others $(0, 0, 0)$
+  they evaluate to $\pm\tfrac{3}{10}(2/5)^{N-1}$ with opposite signs.
+
+## Main definitions
+
+* `sectorCoord` — the identification of a flag value and a two-qubit index
+  with a coordinate of the retained vertical space;
+* `physCoordEquiv` — the physical index $(l, r, f)$ of the retained coordinate
+  $(f, (l, r))$;
+* `verticalCoisometry` — the permutation matrix of `physCoordEquiv`.
+
+## Main results
+
+* `flagFamily_isInjective` — each flag sector is injective at one site;
+* `verticalCoisometry_conj_verticalTensor` — the conjugated vertical letters
+  are the weighted direct sum of the sector letters;
+* `mpv_verticalTensor_T` — the vertical matrix product vectors expand along
+  the two sectors with the coefficient $\mu^N$;
+* `linearIndependent_mpvState_flagFamily` — the sector matrix product vectors
+  are linearly independent at every positive length;
+* `flagFamily_isBNT` — the flag sectors form a basis of normal tensors of the
+  vertically viewed tensor;
+* `T_isVerticalCF` — the twisted dimer is in vertical canonical form.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.12 and Proposition 4.13, lines 945--959 and 1861--1922 (the
+  vertical canonical form) and lines 995--1010 (the length-dependence question
+  motivating this project example)
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.TwistedDimer
+
+/-! ### Coordinates of the retained vertical space -/
+
+/-- The bond dimension four of each flag sector.
+
+Project example; not from CPSV16. -/
+abbrev sectorDim : Fin 2 → ℕ := fun _ => 4
+
+/-- Each flag sector occurs with multiplicity one.
+
+Project example; not from CPSV16. -/
+abbrev sectorMult : Fin 2 → ℕ := fun _ => 1
+
+/-- The single diagonal entry $\mu = 5/8$ of the positive weight matrix of each
+flag sector (arXiv:1606.00608, Proposition 4.13, lines 1863--1870).
+
+Project example; not from CPSV16. -/
+def sectorWeight : (f : Fin 2) → Fin (sectorMult f) → ℂ := fun _ _ => ((mu : ℝ) : ℂ)
+
+/-- The retained vertical space of the two flag sectors: two copies of the
+two-qubit space, one per flag value. -/
+abbrev RetainedCoordinate :=
+  Fin (∑ q : Fin (∑ α : Fin 2, sectorMult α), verticalCopyDim sectorDim sectorMult q)
+
+/-- The flag value $f$ and the two-qubit index $q$ of a retained coordinate:
+the coordinate of the sector $f$, its single multiplicity copy, and the
+two-qubit index $q$. -/
+def sectorCoord : Fin 2 × Fin 4 ≃ RetainedCoordinate :=
+  ((Equiv.sigmaEquivProd (Fin 2) (Fin 4)).symm.trans
+    (Equiv.sigmaCongrRight fun α =>
+      (Equiv.uniqueProd (Fin (sectorDim α)) (Fin (sectorMult α))).symm)).trans
+    (verticalSectorFinEquiv sectorDim sectorMult)
+
+lemma sectorCoord_apply (f : Fin 2) (q : Fin 4) :
+    sectorCoord (f, q) =
+      verticalSectorFinEquiv sectorDim sectorMult ⟨f, ((default : Fin 1), q)⟩ :=
+  rfl
+
+/-- The physical index $(l, r, f)$ of the retained coordinate $(f, (l, r))$:
+the reordering of the physical space $\mathbb C^8 = \bigoplus_f |f\rangle \otimes \mathbb C^4$
+by which the flag qubit is moved in front of the two qubits $L, R$. -/
+def physCoordEquiv : RetainedCoordinate ≃ Fin 8 :=
+  sectorCoord.symm.trans
+    ((Equiv.prodCongr (Equiv.refl (Fin 2)) (finProdFinEquiv (m := 2) (n := 2)).symm).trans
+      ((Equiv.prodComm (Fin 2) (Fin 2 × Fin 2)).trans
+        ((Equiv.prodAssoc (Fin 2) (Fin 2) (Fin 2)).trans physEquiv)))
+
+@[simp] lemma physCoordEquiv_sectorCoord (f l r : Fin 2) :
+    physCoordEquiv (sectorCoord (f, finProdFinEquiv (l, r))) = physIdx l r f := by
+  simp [physCoordEquiv, physEquiv]
+
+/-! ### The permutation matrix -/
+
+/-- The permutation matrix $(l, r, f) \mapsto (f, (l, r))$ from the physical
+space of `T` onto the retained vertical space, the isometry $U$ of the vertical
+canonical form (arXiv:1606.00608, Proposition 4.13, lines 1863--1870).
+
+Project example; not from CPSV16. -/
+def verticalCoisometry : Matrix RetainedCoordinate (Fin 8) ℂ :=
+  Matrix.of fun x i => if physCoordEquiv x = i then 1 else 0
+
+lemma verticalCoisometry_apply (x : RetainedCoordinate) (i : Fin 8) :
+    verticalCoisometry x i = if physCoordEquiv x = i then 1 else 0 :=
+  rfl
+
+/-- The permutation matrix is a coisometry. -/
+theorem verticalCoisometry_mul_conjTranspose :
+    verticalCoisometry * verticalCoisometryᴴ =
+      (1 : Matrix RetainedCoordinate RetainedCoordinate ℂ) := by
+  ext x y
+  simp [Matrix.mul_apply, Matrix.conjTranspose_apply, verticalCoisometry_apply,
+    Matrix.one_apply, physCoordEquiv.injective.eq_iff]
+
+/-- The permutation matrix is an isometry. -/
+theorem conjTranspose_mul_verticalCoisometry :
+    verticalCoisometryᴴ * verticalCoisometry = (1 : Matrix (Fin 8) (Fin 8) ℂ) := by
+  ext i j
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, verticalCoisometry_apply]
+  rw [← physCoordEquiv.symm.sum_comp]
+  simp [Matrix.one_apply, eq_comm]
+
+/-- Conjugating by the permutation matrix permutes the matrix entries. -/
+theorem verticalCoisometry_conj (M : Matrix (Fin 8) (Fin 8) ℂ) (x y : RetainedCoordinate) :
+    (verticalCoisometry * M * verticalCoisometryᴴ) x y =
+      M (physCoordEquiv x) (physCoordEquiv y) := by
+  simp [Matrix.mul_apply, Matrix.conjTranspose_apply, verticalCoisometry_apply]
+
+/-! ### The conjugated vertical letters -/
+
+/-- The letter of `T` between physical indices with different flags vanishes. -/
+lemma T_apply_eq_zero_of_bitF_ne {i j : Fin 8} (h : bitF i ≠ bitF j) : T i j = 0 := by
+  simp [T, coef, h]
+
+/-- The letter of a flag sector at an explicitly paired bond index. -/
+lemma flagFamily_finProdFinEquiv (f : Fin 2) (a b : Fin 8) :
+    flagFamily f (finProdFinEquiv (a, b)) = flagMPO f a b := by
+  unfold flagFamily MPOTensor.toMPSTensor
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- **The conjugated vertical letters.**  Conjugating the vertical letter of
+`T` at the bond pair $(a, b)$ by the permutation matrix gives the direct sum,
+over the flag value $f$, of $\mu$ times the letter of $\widehat M_f$ at $(a, b)$:
+this is the direct-sum identity $U \widetilde M U^\dagger = \bigoplus_\alpha
+\mu_\alpha \otimes M_\alpha$ of arXiv:1606.00608, Proposition 4.13, lines
+1863--1870, for the displayed tensor.
+
+Project example; not from CPSV16. -/
+theorem verticalCoisometry_conj_verticalTensor (v : Fin (8 * 8)) :
+    verticalCoisometry * verticalTensor T v * verticalCoisometryᴴ =
+      verticalAssembledTensor sectorDim sectorMult sectorWeight flagFamily v := by
+  ext x y
+  obtain ⟨⟨f, q⟩, rfl⟩ := sectorCoord.surjective x
+  obtain ⟨⟨f', q'⟩, rfl⟩ := sectorCoord.surjective y
+  obtain ⟨⟨l, r⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective q
+  obtain ⟨⟨l', r'⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective q'
+  rw [verticalCoisometry_conj, physCoordEquiv_sectorCoord, physCoordEquiv_sectorCoord,
+    verticalTensor_apply]
+  by_cases hf : f = f'
+  · subst hf
+    rw [sectorCoord_apply, sectorCoord_apply, verticalAssembledTensor_apply_copy_same]
+    have hv : flagFamily f v = flagMPO f v.divNat v.modNat := rfl
+    rw [hv, flagMPO_apply_eq_T]
+    simp only [sectorWeight]
+    have hmu : ((mu : ℝ) : ℂ) ≠ 0 := by norm_num [mu]
+    field_simp
+  · rw [sectorCoord_apply, sectorCoord_apply, verticalAssembledTensor_apply_copy_ne sectorDim
+      sectorMult sectorWeight flagFamily (fun h => hf (congrArg Sigma.fst h))]
+    rw [T_apply_eq_zero_of_bitF_ne (by simpa using hf)]
+    rfl
+
+/-- **Reconstruction of the vertical letters.**  Every vertical letter of `T`
+is recovered from the weighted direct sum of the sector letters through the
+permutation matrix (arXiv:1606.00608, Proposition 4.13, lines 1863--1870).
+
+Project example; not from CPSV16. -/
+theorem verticalTensor_T_eq_conjTranspose_mul (v : Fin (8 * 8)) :
+    verticalTensor T v =
+      verticalCoisometryᴴ * verticalAssembledTensor sectorDim sectorMult sectorWeight flagFamily v *
+        verticalCoisometry := by
+  rw [← verticalCoisometry_conj_verticalTensor v]
+  calc verticalTensor T v
+      = (verticalCoisometryᴴ * verticalCoisometry) * verticalTensor T v *
+          (verticalCoisometryᴴ * verticalCoisometry) := by
+        rw [conjTranspose_mul_verticalCoisometry, Matrix.one_mul, Matrix.mul_one]
+    _ = _ := by simp only [Matrix.mul_assoc]
+
+/-! ### Matrix product vectors of the vertical tensor -/
+
+/-- The word product of a tensor conjugated by a coisometry is the conjugated
+word product, for nonempty words. -/
+private lemma evalWord_conj {d n D : ℕ} (B : MPSTensor d n) (U : Matrix (Fin n) (Fin D) ℂ)
+    (hU : U * Uᴴ = (1 : Matrix (Fin n) (Fin n) ℂ)) (i : Fin d) (w : List (Fin d)) :
+    Kraus.evalWord (fun v => Uᴴ * B v * U) (i :: w) = Uᴴ * Kraus.evalWord B (i :: w) * U := by
+  induction w generalizing i with
+  | nil => simp
+  | cons j w ih =>
+      rw [Kraus.evalWord_cons, ih j, Kraus.evalWord_cons B i]
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
+
+/-- The positive-length matrix product vectors of a tensor conjugated by a
+coisometry are those of the tensor. -/
+private lemma mpv_conj {d n D : ℕ} (B : MPSTensor d n) (U : Matrix (Fin n) (Fin D) ℂ)
+    (hU : U * Uᴴ = (1 : Matrix (Fin n) (Fin n) ℂ)) {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin d) :
+    MPSTensor.mpv (fun v => Uᴴ * B v * U) σ = MPSTensor.mpv B σ := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
+  simp only [MPSTensor.mpv, MPSTensor.coeff, List.ofFn_succ]
+  rw [evalWord_conj B U hU, Matrix.trace_mul_cycle, hU, Matrix.one_mul]
+
+/-- **Sector expansion of the vertical matrix product vectors.**  At every
+positive length $N$ the matrix product vector of the vertically viewed tensor
+is $\mu^N$ times the sum of the matrix product vectors of the two flag sectors.
+
+Project example; not from CPSV16. -/
+theorem mpv_verticalTensor_T {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin (8 * 8)) :
+    MPSTensor.mpv (verticalTensor T) σ =
+      ∑ f : Fin 2, ((mu : ℝ) : ℂ) ^ N * MPSTensor.mpv (flagFamily f) σ := by
+  have h : verticalTensor T = fun v =>
+      verticalCoisometryᴴ *
+        verticalAssembledTensor sectorDim sectorMult sectorWeight flagFamily v *
+          verticalCoisometry :=
+    funext verticalTensor_T_eq_conjTranspose_mul
+  rw [h, mpv_conj _ _ verticalCoisometry_mul_conjTranspose hN,
+    mpv_verticalAssembledTensor_eq_sum, Fintype.sum_sigma]
+  simp [sectorWeight]
+
+/-! ### One-site injectivity of the flag sectors -/
+
+/-- The bond-matrix entries are nonzero. -/
+lemma Cmat_ne_zero (k p q : Fin 2) : Cmat k p q ≠ 0 := by
+  unfold Cmat
+  split_ifs <;> norm_num [cDiag_eq, cOff_eq]
+
+/-- The one-site weight of a bond index of the block $k = 0$ is nonzero. -/
+lemma flagWeight_physIdx_zero_ne_zero (f p p' : Fin 2) :
+    flagWeight f (physIdx p p' 0) ≠ 0 := by
+  rw [flagWeight_physIdx, tau_zero]
+  have := Cmat_ne_zero 0 p p'
+  norm_num [mu]
+  exact this
+
+/-- Every matrix unit of $M_4(\mathbb C)$ is a nonzero multiple of a letter of
+each flag sector: the bond pair $((p, q, 0), (p', q', 0))$ gives the matrix
+unit at the row $(p, p')$ and the column $(q, q')$. -/
+theorem exists_flagFamily_eq_smul_single (f : Fin 2) (p q : Fin 4) :
+    ∃ v : Fin (8 * 8), ∃ c : ℂ, c ≠ 0 ∧ flagFamily f v = c • Matrix.single p q 1 := by
+  obtain ⟨⟨p₁, p₂⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective p
+  obtain ⟨⟨q₁, q₂⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective q
+  refine ⟨finProdFinEquiv (physIdx p₁ q₁ 0, physIdx p₂ q₂ 0), flagWeight f (physIdx p₁ q₁ 0),
+    flagWeight_physIdx_zero_ne_zero f p₁ q₁, ?_⟩
+  rw [flagFamily_finProdFinEquiv, Matrix.smul_single, smul_eq_mul, mul_one]
+  simp [flagMPO, unitTensor, flagCoef]
+
+/-- **One-site injectivity of the flag sectors.**  The letters of each flag
+sector span the full matrix algebra $M_4(\mathbb C)$.
+
+Project example; not from CPSV16. -/
+theorem flagFamily_isInjective (f : Fin 2) : Kraus.IsInjective (flagFamily f) := by
+  unfold Kraus.IsInjective
+  apply le_antisymm le_top
+  rw [← (Matrix.stdBasis ℂ (Fin 4) (Fin 4)).span_eq]
+  apply Submodule.span_le.mpr
+  rintro M ⟨⟨p, q⟩, rfl⟩
+  rw [Matrix.stdBasis_eq_single]
+  obtain ⟨v, c, hc, hv⟩ := exists_flagFamily_eq_smul_single f p q
+  have hmem : flagFamily f v ∈ Submodule.span ℂ (Set.range (flagFamily f)) :=
+    Submodule.subset_span ⟨v, rfl⟩
+  rw [hv] at hmem
+  have hscaled := Submodule.smul_mem (Submodule.span ℂ (Set.range (flagFamily f))) c⁻¹ hmem
+  rwa [smul_smul, inv_mul_cancel₀ hc, one_smul] at hscaled
+
+/-- Each flag sector is normal. -/
+theorem flagFamily_isNormal (f : Fin 2) : Kraus.IsNormal (flagFamily f) :=
+  (flagFamily_isInjective f).isNormal
+
+/-! ### Linear independence of the two sectors -/
+
+/-- The one-site weight of the bond index $(0, 0, 0)$ is $2/5$ in both sectors. -/
+lemma flagWeight_physIdx_zero_zero_zero (f : Fin 2) :
+    flagWeight f (physIdx 0 0 0) = (2 / 5 : ℂ) := by
+  rw [flagWeight_physIdx, tau_zero]
+  norm_num [Cmat, cDiag_eq, mu]
+
+/-- The one-site weight of the bond index $(0, 0, 1)$ is $\tfrac{3}{10}$ times
+the flag sign $(\tau_1)_{ff}$. -/
+lemma flagWeight_physIdx_zero_zero_one (f : Fin 2) :
+    flagWeight f (physIdx 0 0 1) = (3 / 10 : ℂ) * ((tau 1 f : ℝ) : ℂ) := by
+  rw [flagWeight_physIdx]
+  norm_num [Cmat, cOff_eq, mu]
+  ring
+
+/-- The word of bond indices with $(0, 0, 1)$ at the first site and $(0, 0, 0)$
+elsewhere. -/
+private def signWord (n : ℕ) : Fin (n + 1) → Fin 8 :=
+  Fin.cons (physIdx 0 0 1) fun _ => physIdx 0 0 0
+
+private lemma bitL_signWord (n : ℕ) (m : Fin (n + 1)) : bitL (signWord n m) = 0 := by
+  refine Fin.cases ?_ (fun m => ?_) m <;> simp [signWord]
+
+private lemma bitR_signWord (n : ℕ) (m : Fin (n + 1)) : bitR (signWord n m) = 0 := by
+  refine Fin.cases ?_ (fun m => ?_) m <;> simp [signWord]
+
+private lemma isCyclicBondMatched_signWord (n : ℕ) : IsCyclicBondMatched (n + 1) (signWord n) :=
+  fun m => by rw [gate, bitR_signWord, bitL_signWord]
+
+private lemma isCyclicBondMatched_const (n : ℕ) :
+    IsCyclicBondMatched (n + 1) fun _ : Fin (n + 1) => physIdx 0 0 0 :=
+  fun _ => by simp [gate]
+
+/-- The sector matrix product vector on the doubled constant word of bond index
+$(0, 0, 0)$ is $(2/5)^{N}$. -/
+private lemma mpv_flagFamily_const (f : Fin 2) (n : ℕ) :
+    MPSTensor.mpv (flagFamily f)
+      (fun _ : Fin (n + 1) => finProdFinEquiv (physIdx 0 0 0, physIdx 0 0 0)) =
+      (2 / 5 : ℂ) ^ (n + 1) := by
+  unfold flagFamily
+  rw [MPSTensor.mpv_toMPSTensor_pairConfig, mpo_flagMPO_apply f n.succ_pos,
+    ite_eq_left ⟨isCyclicBondMatched_const n, isCyclicBondMatched_const n, fun _ => rfl⟩]
+  simp [flagWeight_physIdx_zero_zero_zero, div_pow]
+
+/-- The sector matrix product vector on the doubled word with one bond index
+$(0, 0, 1)$ is $\tfrac{3}{10} (\tau_1)_{ff} (2/5)^{N-1}$. -/
+private lemma mpv_flagFamily_signWord (f : Fin 2) (n : ℕ) :
+    MPSTensor.mpv (flagFamily f) (fun m => finProdFinEquiv (signWord n m, signWord n m)) =
+      (3 / 10 : ℂ) * ((tau 1 f : ℝ) : ℂ) * (2 / 5 : ℂ) ^ n := by
+  unfold flagFamily
+  rw [MPSTensor.mpv_toMPSTensor_pairConfig, mpo_flagMPO_apply f n.succ_pos,
+    ite_eq_left ⟨isCyclicBondMatched_signWord n, isCyclicBondMatched_signWord n, fun _ => rfl⟩,
+    Fin.prod_univ_succ]
+  simp [signWord, flagWeight_physIdx_zero_zero_zero, flagWeight_physIdx_zero_zero_one, div_pow]
+
+/-- **Linear independence of the two sectors.**  At every positive length the
+matrix product vectors of the two flag sectors are linearly independent: they
+agree on the constant word of bond index $(0, 0, 0)$ and differ by a sign on
+the word with one bond index $(0, 0, 1)$.
+
+Project example; not from CPSV16. -/
+theorem linearIndependent_mpvState_flagFamily (N : ℕ) (hN : 0 < N) :
+    LinearIndependent ℂ fun f : Fin 2 => MPSTensor.mpvState (d := 8 * 8) (flagFamily f) N := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
+  rw [Fintype.linearIndependent_iff]
+  intro g hg
+  have h₁ := congrArg (fun v : MPSTensor.MPVSpace (8 * 8) (n + 1) =>
+    v fun _ => finProdFinEquiv (physIdx 0 0 0, physIdx 0 0 0)) hg
+  have h₂ := congrArg (fun v : MPSTensor.MPVSpace (8 * 8) (n + 1) =>
+    v fun m => finProdFinEquiv (signWord n m, signWord n m)) hg
+  simp only [Fin.sum_univ_two, PiLp.add_apply, PiLp.smul_apply, PiLp.zero_apply,
+    MPSTensor.mpvState_apply, smul_eq_mul, mpv_flagFamily_const, mpv_flagFamily_signWord] at h₁ h₂
+  have t0 : tau 1 0 = 1 := by norm_num [tau]
+  have t1 : tau 1 1 = -1 := by norm_num [tau]
+  rw [t0, t1] at h₂
+  push_cast at h₂
+  have hc : (2 / 5 : ℂ) ^ (n + 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+  have hc' : (3 / 10 : ℂ) * (2 / 5 : ℂ) ^ n ≠ 0 :=
+    mul_ne_zero (by norm_num) (pow_ne_zero _ (by norm_num))
+  have e₁ : g 0 + g 1 = 0 := by
+    have : (g 0 + g 1) * (2 / 5 : ℂ) ^ (n + 1) = 0 := by linear_combination h₁
+    exact (mul_eq_zero.mp this).resolve_right hc
+  have e₂ : g 0 - g 1 = 0 := by
+    have : (g 0 - g 1) * ((3 / 10 : ℂ) * (2 / 5 : ℂ) ^ n) = 0 := by linear_combination h₂
+    exact (mul_eq_zero.mp this).resolve_right hc'
+  rw [Fin.forall_fin_two]
+  exact ⟨by linear_combination (e₁ + e₂) / 2, by linear_combination (e₁ - e₂) / 2⟩
+
+/-! ### The vertical canonical form -/
+
+/-- **The flag sectors form a basis of normal tensors of the vertical tensor.**
+Each sector is normal, the vertical matrix product vectors expand along the
+sectors with the coefficient $\mu^N$, and the sector matrix product vectors are
+linearly independent at every positive length.
+
+Project example; not from CPSV16. -/
+theorem flagFamily_isBNT : MPSTensor.IsBNT (verticalTensor T) 2 sectorDim flagFamily where
+  normal := flagFamily_isNormal
+  spans_mpv N hN := ⟨fun _ => ((mu : ℝ) : ℂ) ^ N, mpv_verticalTensor_T hN⟩
+  eventually_li := ⟨0, fun N hN => linearIndependent_mpvState_flagFamily N hN⟩
+
+/-- **The twisted quantum dimer is in vertical canonical form.**  The two flag
+sectors, each with multiplicity one and weight $\mu = 5/8$, together with the
+permutation matrix moving the flag qubit in front of the two qubits, witness
+the vertical canonical form of arXiv:1606.00608, Proposition 4.13, lines
+945--959 and 1861--1922, for the displayed tensor.  The tensor is a project
+example motivated by the length-dependence question after Theorem 4.14 (lines
+995--1010); it is not a tensor stated in that source. -/
+theorem T_isVerticalCF : IsVerticalCF T :=
+  ⟨2, sectorDim, sectorMult, sectorWeight, flagFamily, verticalCoisometry,
+    fun _ => Nat.one_pos, fun _ _ => Complex.zero_lt_real.mpr (by norm_num [mu]),
+    verticalCoisometry_mul_conjTranspose, flagFamily_isBNT,
+    verticalCoisometry_conj_verticalTensor, verticalTensor_T_eq_conjTranspose_mul⟩
+
+end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
@@ -226,27 +226,6 @@ theorem verticalTensor_T_eq_conjTranspose_mul (v : Fin (8 * 8)) :
 
 /-! ### Matrix product vectors of the vertical tensor -/
 
-/-- The word product of a tensor conjugated by a coisometry is the conjugated
-word product, for nonempty words. -/
-private lemma evalWord_conj {d n D : ℕ} (B : MPSTensor d n) (U : Matrix (Fin n) (Fin D) ℂ)
-    (hU : U * Uᴴ = (1 : Matrix (Fin n) (Fin n) ℂ)) (i : Fin d) (w : List (Fin d)) :
-    Kraus.evalWord (fun v => Uᴴ * B v * U) (i :: w) = Uᴴ * Kraus.evalWord B (i :: w) * U := by
-  induction w generalizing i with
-  | nil => simp
-  | cons j w ih =>
-      rw [Kraus.evalWord_cons, ih j, Kraus.evalWord_cons B i]
-      simp only [Matrix.mul_assoc]
-      rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
-
-/-- The positive-length matrix product vectors of a tensor conjugated by a
-coisometry are those of the tensor. -/
-private lemma mpv_conj {d n D : ℕ} (B : MPSTensor d n) (U : Matrix (Fin n) (Fin D) ℂ)
-    (hU : U * Uᴴ = (1 : Matrix (Fin n) (Fin n) ℂ)) {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin d) :
-    MPSTensor.mpv (fun v => Uᴴ * B v * U) σ = MPSTensor.mpv B σ := by
-  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
-  simp only [MPSTensor.mpv, MPSTensor.coeff, List.ofFn_succ]
-  rw [evalWord_conj B U hU, Matrix.trace_mul_cycle, hU, Matrix.one_mul]
-
 /-- **Sector expansion of the vertical matrix product vectors.**  At every
 positive length $N$ the matrix product vector of the vertically viewed tensor
 is $\mu^N$ times the sum of the matrix product vectors of the two flag sectors.
@@ -255,12 +234,11 @@ Project example; not from CPSV16. -/
 theorem mpv_verticalTensor_T {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin (8 * 8)) :
     MPSTensor.mpv (verticalTensor T) σ =
       ∑ f : Fin 2, ((mu : ℝ) : ℂ) ^ N * MPSTensor.mpv (flagFamily f) σ := by
-  have h : verticalTensor T = fun v =>
-      verticalCoisometryᴴ *
-        verticalAssembledTensor sectorDim sectorMult sectorWeight flagFamily v *
-          verticalCoisometry :=
-    funext verticalTensor_T_eq_conjTranspose_mul
-  rw [h, mpv_conj _ _ verticalCoisometry_mul_conjTranspose hN,
+  rw [MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction
+      (verticalTensor T)
+      (verticalAssembledTensor sectorDim sectorMult sectorWeight flagFamily)
+      verticalCoisometry verticalCoisometry_mul_conjTranspose
+      verticalTensor_T_eq_conjTranspose_mul N hN σ,
     mpv_verticalAssembledTensor_eq_sum, Fintype.sum_sigma]
   simp [sectorWeight]
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1277,6 +1277,93 @@
     $P$.
 \end{proof}
 
+\begin{theorem}[Vertical canonical form of the twisted quantum dimer]%
+    \label{thm:mpdo_twisted_dimer_vertical_cf}
+    \lean{MPOTensor.TwistedDimer.sectorDim}
+    \lean{MPOTensor.TwistedDimer.sectorMult}
+    \lean{MPOTensor.TwistedDimer.sectorWeight}
+    \lean{MPOTensor.TwistedDimer.RetainedCoordinate}
+    \lean{MPOTensor.TwistedDimer.sectorCoord}
+    \lean{MPOTensor.TwistedDimer.sectorCoord_apply}
+    \lean{MPOTensor.TwistedDimer.physCoordEquiv}
+    \lean{MPOTensor.TwistedDimer.physCoordEquiv_sectorCoord}
+    \lean{MPOTensor.TwistedDimer.verticalCoisometry}
+    \lean{MPOTensor.TwistedDimer.verticalCoisometry_apply}
+    \lean{MPOTensor.TwistedDimer.verticalCoisometry_mul_conjTranspose}
+    \lean{MPOTensor.TwistedDimer.conjTranspose_mul_verticalCoisometry}
+    \lean{MPOTensor.TwistedDimer.verticalCoisometry_conj}
+    \lean{MPOTensor.TwistedDimer.T_apply_eq_zero_of_bitF_ne}
+    \lean{MPOTensor.TwistedDimer.flagFamily_finProdFinEquiv}
+    \lean{MPOTensor.TwistedDimer.verticalCoisometry_conj_verticalTensor}
+    \lean{MPOTensor.TwistedDimer.verticalTensor_T_eq_conjTranspose_mul}
+    \lean{MPOTensor.TwistedDimer.mpv_verticalTensor_T}
+    \lean{MPOTensor.TwistedDimer.Cmat_ne_zero}
+    \lean{MPOTensor.TwistedDimer.flagWeight_physIdx_zero_ne_zero}
+    \lean{MPOTensor.TwistedDimer.exists_flagFamily_eq_smul_single}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isInjective}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isNormal}
+    \lean{MPOTensor.TwistedDimer.flagWeight_physIdx_zero_zero_zero}
+    \lean{MPOTensor.TwistedDimer.flagWeight_physIdx_zero_zero_one}
+    \lean{MPOTensor.TwistedDimer.linearIndependent_mpvState_flagFamily}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isBNT}
+    \lean{MPOTensor.TwistedDimer.T_isVerticalCF}
+    \leanok
+    \uses{def:mpdo_twisted_dimer_flag_sectors, def:vertical_cf_mpdo, def:vertical_tensor_mpdo, def:bnt}
+    The twisted quantum dimer of Definition~\ref{def:mpdo_twisted_dimer_tensor}
+    is in vertical canonical form in the sense of
+    Definition~\ref{def:vertical_cf_mpdo}, with the two normalized flag
+    sectors $\widehat M_0$, $\widehat M_1$ of
+    Definition~\ref{def:mpdo_twisted_dimer_flag_sectors} as basis of normal
+    tensors, multiplicity one each, and the weight $\mu=\frac58$. Let $U$ be
+    the permutation matrix reordering the physical index
+    $(l,r,f)\mapsto(f,(l,r))$, so that $U$ maps the physical space
+    $\C^8$ onto the direct sum over the flag value $f$ of two copies of the
+    two-qubit space $\C^4$. Then $UU^\dagger=U^\dagger U=I$ and, for every
+    horizontal bond pair $(a,b)$,
+    \begin{align}
+        U\,\widetilde T_{ab}\,U^\dagger
+         & =\mu\,\widehat M_0^{ab}\oplus\mu\,\widehat M_1^{ab},                       &
+        \widetilde T_{ab}
+         & =U^\dagger\bigl(\mu\,\widehat M_0^{ab}\oplus\mu\,\widehat M_1^{ab}\bigr)U.
+        \notag
+    \end{align}
+    Each flag sector is injective at one site, hence normal; the matrix
+    product vectors of the vertically viewed tensor at every positive length
+    $N$ are $\mu^N$ times the sum of those of the two sectors; and the matrix
+    product vectors of the two sectors are linearly independent at every
+    positive length. The tensor is a project example motivated by the
+    question of \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a
+    tensor stated there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_twisted_dimer_flag_sectors, lem:mpdo_twisted_dimer_flag_sector_operators, def:vertical_cf_mpdo}
+    The letter of the twisted dimer between two physical indices with
+    different flag values vanishes, because its coefficient carries the factor
+    $\delta_{ff'}$, and the letter between two indices with the common flag
+    value $f$ is $\mu$ times the letter of $\widehat M_f$ by
+    Definition~\ref{def:mpdo_twisted_dimer_flag_sectors}. Conjugating by the
+    permutation matrix therefore places the two sectors on the diagonal
+    blocks, and the reconstruction follows from $U^\dagger U=I$. The matrix
+    product vectors of the vertically viewed tensor are traces of products of
+    its letters, which conjugation by $U$ leaves unchanged, so they expand
+    along the two blocks with the coefficient $\mu^N$.
+
+    For every matrix unit $E_{(p,q),(p',q')}$ of the two-qubit space, the
+    letter of $\widehat M_f$ at the bond pair $((p,q,0),(p',q',0))$ is
+    $C_0[p,q]/(2\mu)$ times that matrix unit, with $C_0[p,q]\in\{\frac12,\frac38\}$
+    nonzero; hence the letters of each sector span the full matrix algebra and
+    the sector is normal. For the linear independence, evaluate the closed
+    sector operators of Lemma~\ref{lem:mpdo_twisted_dimer_flag_sector_operators}
+    on two cyclically bond-matched words: on the constant word of bond index
+    $(0,0,0)$ both sectors give $(2/5)^N$, since the one-site weight is
+    $C_0[0,0]/(2\mu)=\frac25$; on the word with the bond index $(0,0,1)$ at
+    the first site and $(0,0,0)$ elsewhere, the sector $f$ gives
+    $(\tau_1)_{ff}\,\frac{3}{10}\,(2/5)^{N-1}$, since $C_1[0,0]/(2\mu)=\frac3{10}$,
+    and the two flag signs are opposite. A vanishing linear combination
+    $g_0\widehat M_0+g_1\widehat M_1$ of the two matrix product vectors thus
+    forces $g_0+g_1=0$ and $g_0-g_1=0$.
+\end{proof}
+
 \begin{lemma}[Doubled-index letters and their rank-one factorization]
     \label{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_R_apply}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1364,6 +1364,77 @@
     forces $g_0+g_1=0$ and $g_0-g_1=0$.
 \end{proof}
 
+\begin{theorem}[Tensor-attached algebra clause of the twisted quantum dimer]%
+    \label{thm:mpdo_twisted_dimer_bnt_algebra_tensor_clause}
+    \lean{MPOTensor.TwistedDimer.conjTranspose_flagMPO_mul_self}
+    \lean{MPOTensor.TwistedDimer.star_flagCoef_mul_self}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isLeftCanonical}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isNormalTensor}
+    \lean{MPOTensor.TwistedDimer.flagFamily_isCPSVBasisOfNormalTensors}
+    \lean{MPOTensor.TwistedDimer.twoLabelChiTracePowerForm}
+    \lean{MPOTensor.TwistedDimer.sectorWeight_hasIdempotentCoefficientForm}
+    \lean{MPOTensor.TwistedDimer.flagAlgebraClause}
+    \lean{MPOTensor.TwistedDimer.T_bntAlgebraTensorClause}
+    \lean{MPOTensor.TwistedDimer.T_hasBNTAlgebraTensorClause}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_tensor_clause, thm:mpdo_twisted_dimer_vertical_cf, thm:mpdo_twisted_dimer_flag_sector_product_law, thm:mpdo_twisted_dimer_two_label_rescaling_stable}
+    The twisted quantum dimer of Definition~\ref{def:mpdo_twisted_dimer_tensor}
+    has a tensor-attached algebra clause in the sense of
+    Definition~\ref{def:mpdo_bnt_algebra_tensor_clause}, with the vertical
+    canonical form of Theorem~\ref{thm:mpdo_twisted_dimer_vertical_cf} as its
+    vertical decomposition and the two-label coefficient family of
+    Theorem~\ref{thm:mpdo_twisted_dimer_two_label_rescaling_stable} as its
+    coefficients. The two flag sectors are normal tensors in the sense of
+    \cite[lines~231--235]{Cirac2016MPDO_arXiv}: each is injective at one site
+    and left-canonical,
+    \begin{align}
+        \sum_{a,b}\bigl(\widehat M_f^{ab}\bigr)^\dagger\widehat M_f^{ab}
+         & =\mathbb 1,
+        \notag
+    \end{align}
+    so they form the basis of normal tensors of the vertically viewed tensor
+    in the sense of \cite[Proposition~4.13, lines~945--959]{Cirac2016MPDO_arXiv}.
+    The coefficient family is the trace-power family of the positive diagonal
+    family $\chi_{ff',f+f'}=\alpha$, $\chi_{ff',f+f'+1}=\beta$, the closed
+    sector operators satisfy the same-length product law of
+    Theorem~\ref{thm:mpdo_twisted_dimer_flag_sector_product_law}, and the
+    trace scalars $m_0=m_1=\mu=\frac58$ satisfy the length-one idempotent law
+    \begin{align}
+        m_g & =\sum_{f,f'}c^{(1)}_{ff'g}\,m_fm_{f'}
+        =2(\alpha+\beta)\mu^2=\frac85\cdot\frac{25}{64}=\frac58 .
+        \notag
+    \end{align}
+    Thus the coefficient family attached to the displayed tensor is one that
+    no positive rescaling of the two labels makes length independent. No
+    comparison with a blocked basis, fusion isometry, or renormalization map
+    is asserted. The tensor is a project example motivated by the question of
+    \cite[lines~995--1010]{Cirac2016MPDO_arXiv}; it is not a tensor stated
+    there.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_twisted_dimer_vertical_cf, thm:mpdo_twisted_dimer_flag_sector_product_law, thm:is_normal_tensor_of_is_normal_left_canonical}
+    The adjoint of a sector letter times the letter is the diagonal matrix
+    unit at the right bits $(p',q')$ of the bond pair with the squared modulus
+    of the coefficient, and the flag sign squares to one. Summing over the
+    bond pairs $((p,p',k),(q,q',k))$ with the right bits fixed gives, at each
+    diagonal entry,
+    \begin{align}
+        \frac{1}{(2\mu)^2}\sum_{k}\sum_{p,q}C_k[p,p']^2
+         & =\frac{2\cdot2\cdot\bigl(\tfrac14+\tfrac9{64}\bigr)}{4\cdot\tfrac{25}{64}}
+        =1,
+        \notag
+    \end{align}
+    and the off-diagonal entries vanish. Together with one-site injectivity
+    from Theorem~\ref{thm:mpdo_twisted_dimer_vertical_cf}, each sector is a
+    normal tensor by
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical}; the
+    spanning and linear-independence clauses are those of
+    Theorem~\ref{thm:mpdo_twisted_dimer_vertical_cf}. The same-length product
+    law is Theorem~\ref{thm:mpdo_twisted_dimer_flag_sector_product_law}, and
+    the idempotent law is the displayed scalar identity, in which each label
+    $g$ receives two channels of weight $\alpha$ and two of weight $\beta$.
+\end{proof}
+
 \begin{lemma}[Doubled-index letters and their rank-one factorization]
     \label{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_R_apply}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1322,7 +1322,11 @@
     horizontal bond pair $(a,b)$,
     \begin{align}
         U\,\widetilde T_{ab}\,U^\dagger
-         & =\mu\,\widehat M_0^{ab}\oplus\mu\,\widehat M_1^{ab},                       &
+         & =\mu\,\widehat M_0^{ab}\oplus\mu\,\widehat M_1^{ab}.
+        \notag
+    \end{align}
+    Conversely,
+    \begin{align}
         \widetilde T_{ab}
          & =U^\dagger\bigl(\mu\,\widehat M_0^{ab}\oplus\mu\,\widehat M_1^{ab}\bigr)U.
         \notag
@@ -1349,8 +1353,9 @@
     along the two blocks with the coefficient $\mu^N$.
 
     For every matrix unit $E_{(p,q),(p',q')}$ of the two-qubit space, the
-    letter of $\widehat M_f$ at the bond pair $((p,q,0),(p',q',0))$ is
-    $C_0[p,q]/(2\mu)$ times that matrix unit, with $C_0[p,q]\in\{\frac12,\frac38\}$
+    letter of $\widehat M_f$ at the bond pair $((p,p',0),(q,q',0))$ is
+    $C_0[p,p']/(2\mu)$ times that matrix unit, with
+    $C_0[p,p']\in\{\frac12,\frac38\}$
     nonzero; hence the letters of each sector span the full matrix algebra and
     the sector is normal. For the linear independence, evaluate the closed
     sector operators of Lemma~\ref{lem:mpdo_twisted_dimer_flag_sector_operators}


### PR DESCRIPTION
## Summary

Closes #7617 (part of #7611): the vertical canonical form of the $\mathbb Z_2$-twisted quantum dimer and its tensor-attached algebra clause.

* `TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean`: `T_isVerticalCF : IsVerticalCF T` with two sectors of bond dimension four, multiplicity one, weight $5/8$, and the flag-reordering permutation unitary. The proof establishes both conjugation identities, one-site injectivity, the positive-length matrix-product-vector expansion with coefficient $(5/8)^N$, and linear independence of the two sector states at every positive length.
* `TNLean/MPS/MPDO/TwistedDimerBNTAlgebraClause.lean`: `T_bntAlgebraTensorClause : BNTAlgebraTensorClause T` and `T_hasBNTAlgebraTensorClause`, assembled from source-normal flag sectors, `twoLabelChi`, the same-length product law from #7630, and the idempotent identity
  $$\frac58=2\left(\frac7{10}+\frac1{10}\right)\left(\frac58\right)^2.$$
* `blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex`: adds source-matched statements and proof sketches for the vertical canonical form and attached algebra clause.
* Review refinement: the positive-length MPV reconstruction now uses the existing project lemma `MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction`; the duplicated local word-conjugation proof was removed. The Blueprint proof also preserves the tensor's physical and bond-index order explicitly.

The statements were checked against `Papers/1606.00608/MPDO-22-12-17-2.tex`, especially Proposition 4.13 and Theorem 4.14(ii), and against the normal/canonical-form terminology in `Papers/1703.09188/paper_v2.tex`. The tensor remains identified as a project example, not as an example printed in either source. The existing `BNTAlgebraTensorClause` contains no fusion-isometry field, so Theorem 4.14(iii) is not claimed here.

## Verification

* `lake build TNLean.MPS.MPDO.TwistedDimerVerticalCF TNLean.MPS.MPDO.TwistedDimerBNTAlgebraClause`
* `lake build` from the exact warmed `origin/main` build cache: 10486 jobs, passed
* `leanblueprint checkdecls`
* `python3 scripts/blueprint_lean_sync.py --root . --ci`
* changed-declaration Blueprint coverage, reader-facing prose, import-aggregator, module-policy, numbered-module, `chktex`, and `git diff --check` gates passed
* Blueprint compiled twice with LuaLaTeX: zero undefined references
* `#print axioms` for the main canonical-form, normality, and algebra-clause theorems reports only `propext`, `Classical.choice`, and `Quot.sound`; no `sorry`, `axiom`, `native_decide`, or `unsafeCast` occurs in the new modules

PR #7637 merged first as requested. This branch is rebased onto merge commit `576ef5d3c8f1634bdb64a610d4331ea558d0a7e2`; both the horizontal non-simplicity entries and the vertical canonical-form entries are retained.

