### PR TITLE
feat(MPS/MPU): add retained-window word encodings

### DIFF
--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -219,6 +219,24 @@ theorem evalWord_append (M : MPOTensor d D) :
           simp only [List.cons_append, evalWord_cons]
           rw [ih js l₂ k₂ (by simpa using h), Matrix.mul_assoc]
 
+/-- Evaluation of a word with one retained letter at each endpoint separates
+those letters from the interior word. -/
+theorem evalWord_ofFn_cons_snoc (M : MPOTensor d D) {K : ℕ}
+    (i₁ i₂ j₁ j₂ : Fin d) (σ τ : Fin K → Fin d) :
+    evalWord M
+        (List.ofFn (Fin.cons i₁ (Fin.snoc σ i₂)))
+        (List.ofFn (Fin.cons j₁ (Fin.snoc τ j₂))) =
+      M i₁ j₁ * evalWord M (List.ofFn σ) (List.ofFn τ) * M i₂ j₂ := by
+  have hσ : List.ofFn (Fin.snoc σ i₂) = List.ofFn σ ++ [i₂] := by
+    conv_lhs => rw [List.ofFn_succ' (Fin.snoc σ i₂)]
+    simp [Fin.snoc_castSucc, Fin.snoc_last]
+  have hτ : List.ofFn (Fin.snoc τ j₂) = List.ofFn τ ++ [j₂] := by
+    conv_lhs => rw [List.ofFn_succ' (Fin.snoc τ j₂)]
+    simp [Fin.snoc_castSucc, Fin.snoc_last]
+  rw [List.ofFn_cons, List.ofFn_cons, evalWord_cons, hσ, hτ,
+    evalWord_append M (List.ofFn σ) (List.ofFn τ) [i₂] [j₂] (by simp)]
+  simp [evalWord, Matrix.mul_assoc]
+
 /-- **Cyclicity of the closed MPO word trace.** Moving the first bra/ket letter
 to the end of both words leaves the trace of the matrix product unchanged, since
 `tr(M^{ab} \, P) = tr(P \, M^{ab})`. This is the translation invariance of the

--- a/TNLean/MPS/MPU/DoubleLayerContraction.lean
+++ b/TNLean/MPS/MPU/DoubleLayerContraction.lean
@@ -38,6 +38,17 @@ theorem doubleLayerTensor_blockTensor (U : MPOTensor d D) (L : ℕ) :
   rw [doubleLayerTensor, doubleLayerTensor, blockTensor_mulTensor,
     physicalAdjointTensor_blockTensor]
 
+/-- A blocked double-layer letter encoded by two finite words is their
+unblocked double-layer word evaluation. -/
+@[simp] theorem doubleLayerTensor_blockTensor_decodeBlockEquiv_symm
+    (U : MPOTensor d D) (L : ℕ) (σ τ : Fin L → Fin d) :
+    doubleLayerTensor (blockTensor U L)
+        ((Kraus.decodeBlockEquiv d L).symm σ)
+        ((Kraus.decodeBlockEquiv d L).symm τ) =
+      evalWord (doubleLayerTensor U) (List.ofFn σ) (List.ofFn τ) := by
+  rw [doubleLayerTensor_blockTensor, blockTensor_apply]
+  simp [Kraus.wordOfBlock]
+
 /-- Contract the two physical legs of an MPO letter against a physical matrix.
 The transpose in the coefficient makes `contractPhysical W (single j i 1) = W i j`.
 


### PR DESCRIPTION
### Motivation

- CPSV17 Lemma III.7, equations `X1X2b` through `uUnitary` in `Papers/1703.09188/paper_v2.tex:487-557`, requires two one-site endpoint letters to remain outside one blocked interior word.
- Issue #7633 needs stable conversions between that endpoint-separated word and the blocked double-layer coordinates used by the supplied contractions.

### Description

- Add `MPOTensor.evalWord_ofFn_cons_snoc`, which proves
  \[
  \operatorname{evalWord}(i_1 :: \sigma ++ [i_2],j_1 :: \tau ++ [j_2])
  =M^{i_1j_1}\operatorname{evalWord}(\sigma,\tau)M^{i_2j_2}.
  \]
- Add `MPOTensor.doubleLayerTensor_blockTensor_decodeBlockEquiv_symm`, identifying a blocked double-layer letter at the encoded pair of length-$K$ words with its unblocked word evaluation.
- The source-facing retained-window trace theorem remains open. Its exact unresolved gluing step is recorded in [the issue comment](https://github.com/LionSR/TNLean/issues/7633#issuecomment-5518054435). This PR does not absorb the endpoints into a $K+2$ simple block, introduce a $2K$ geometry, or assume $\rho^{\mathsf T}=\rho$.

### Testing

- `lake build` (10482 jobs)
- `lake build TNLean.MPS.MPDO.Defs TNLean.MPS.ParentHamiltonian.IntersectionProperty`
- `lake build TNLean.MPS.MPU.DoubleLayerContraction`
- `lake build TNLean.MPS.MPU.SourceUCompleteNetwork`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD`
- `lake exe checkdecls blueprint/lean_decls`
- paper-gap `\leanid` generation and `lake exe checkdecls`
- reader-facing prose and forbidden Lean token checks
- `git diff --check origin/main...HEAD`

---
Advances #7633

### Agent assistance

- Texra Lean agent: theorem/API scouting, implementation of the two word-encoding lemmas, and validation.
