### PR TITLE
refactor(Algebra): share List.ofFn snoc expansion

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -28,6 +28,7 @@ import TNLean.Algebra.GeneralizedCocycle
 import TNLean.Algebra.GeneralizedCocycleInversion
 import TNLean.Algebra.LSymbol
 import TNLean.Algebra.LSymbolBlockIndependence
+import TNLean.Algebra.ListOfFn
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.Matrix
 import TNLean.Algebra.MatrixCyclicPathSum

--- a/TNLean/Algebra/ListOfFn.lean
+++ b/TNLean/Algebra/ListOfFn.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Finite tuples as lists
+
+This file records generic compatibility results between `Fin` tuple constructors
+and `List.ofFn`.
+-/
+
+namespace List
+
+/-- Appending one value to a finite tuple appends the same value to its list. -/
+theorem ofFn_snoc {α : Type*} {n : ℕ} (f : Fin n → α) (x : α) :
+    List.ofFn (Fin.snoc f x) = List.ofFn f ++ [x] := by
+  conv_lhs => rw [List.ofFn_succ' (Fin.snoc f x)]
+  simp [Fin.snoc_castSucc, Fin.snoc_last]
+
+end List

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import QICLean.Kraus.Word
+import TNLean.Algebra.ListOfFn
 import TNLean.MPS.Defs
 import QICLean.Kraus.Transfer
 import Mathlib.LinearAlgebra.Matrix.PosDef
@@ -227,13 +228,8 @@ theorem evalWord_ofFn_cons_snoc (M : MPOTensor d D) {K : ℕ}
         (List.ofFn (Fin.cons i₁ (Fin.snoc σ i₂)))
         (List.ofFn (Fin.cons j₁ (Fin.snoc τ j₂))) =
       M i₁ j₁ * evalWord M (List.ofFn σ) (List.ofFn τ) * M i₂ j₂ := by
-  have hσ : List.ofFn (Fin.snoc σ i₂) = List.ofFn σ ++ [i₂] := by
-    conv_lhs => rw [List.ofFn_succ' (Fin.snoc σ i₂)]
-    simp [Fin.snoc_castSucc, Fin.snoc_last]
-  have hτ : List.ofFn (Fin.snoc τ j₂) = List.ofFn τ ++ [j₂] := by
-    conv_lhs => rw [List.ofFn_succ' (Fin.snoc τ j₂)]
-    simp [Fin.snoc_castSucc, Fin.snoc_last]
-  rw [List.ofFn_cons, List.ofFn_cons, evalWord_cons, hσ, hτ,
+  rw [List.ofFn_cons, List.ofFn_cons, evalWord_cons,
+    List.ofFn_snoc, List.ofFn_snoc,
     evalWord_append M (List.ofFn σ) (List.ofFn τ) [i₂] [j₂] (by simp)]
   simp [evalWord, Matrix.mul_assoc]
 

--- a/TNLean/MPS/ParentHamiltonian/FNWBoundaryEstimate.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWBoundaryEstimate.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import QICLean.Analysis.WeightedSupertrace
 import QICLean.Kraus.TracePairing
+import TNLean.Algebra.ListOfFn
 import TNLean.MPS.ParentHamiltonian.FNWBoundaryConvention
 import TNLean.MPS.ParentHamiltonian.FNWTransferDecay
 
@@ -362,9 +363,8 @@ private theorem fnwBoundaryMap_snoc
     (A : MPSTensor d D) (N : ℕ) (B : Mat) (μ : Fin d) (σ : Cfg d N) :
     fnwBoundaryMap (fun ν => (A ν)ᴴ) (N + 1) B (Fin.snoc σ μ) =
       fnwBoundaryMap (fun ν => (A ν)ᴴ) N (B * A μ) σ := by
-  rw [fnwBoundaryMap_apply, fnwBoundaryMap_apply, List.ofFn_succ']
-  simp only [Fin.snoc_castSucc, Fin.snoc_last]
-  rw [List.concat_eq_append, Kraus.evalWord_append]
+  rw [fnwBoundaryMap_apply, fnwBoundaryMap_apply, List.ofFn_snoc,
+    Kraus.evalWord_append]
   simp only [Kraus.evalWord, Matrix.conjTranspose_mul,
     Matrix.conjTranspose_conjTranspose, Matrix.conjTranspose_one, Matrix.one_mul,
     Matrix.mul_assoc]

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ListOfFn
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.MPS.Core.TracePairing
@@ -82,17 +83,6 @@ injectivity of the ground-space map.
 -/
 
 open scoped Matrix BigOperators
-
-namespace List
-
-/-- `List.ofFn` distributes over `Fin.snoc`: appending one element to a function
-yields the corresponding list concatenation. -/
-theorem ofFn_snoc {α : Type*} {n : ℕ} (f : Fin n → α) (x : α) :
-    List.ofFn (Fin.snoc f x) = List.ofFn f ++ [x] := by
-  conv_lhs => rw [List.ofFn_succ' (Fin.snoc f x)]
-  simp [Fin.snoc_castSucc, Fin.snoc_last]
-
-end List
 
 namespace MPSTensor
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -843,13 +843,14 @@ abstracted — record why, so it is not re-proposed).
 ## Completed refactors
 
 ### Appending a tuple endpoint under `List.ofFn`
-- **Pattern:** three proofs expanded `List.ofFn (Fin.snoc f x)` by repeating the
+- **Pattern:** four proofs expanded `List.ofFn (Fin.snoc f x)` by repeating the
   same `List.ofFn_succ'`, `Fin.snoc_castSucc`, and `Fin.snoc_last` calculation.
 - **Reuse:** `List.ofFn_snoc` in `TNLean/Algebra/ListOfFn.lean` owns the generic
   list identity.
-- **Result:** the parent-Hamiltonian word lemmas import the layer-0 result, and
-  `MPOTensor.evalWord_ofFn_cons_snoc` uses it for both endpoint words instead of
-  maintaining two local copies.
+- **Result:** the parent-Hamiltonian word lemmas and FNW boundary estimate import
+  the layer-0 result, while `MPOTensor.evalWord_ofFn_cons_snoc` uses it for both
+  endpoint words. Across Lean sources the refactor adds 31 lines and removes 21,
+  for a net increase of 10 lines.
 
 ### Successor under one-step finite rotation
 - **Pattern:** both closed-chain MPO calculations proved that `finRotate (N + 1)`

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -842,6 +842,15 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Appending a tuple endpoint under `List.ofFn`
+- **Pattern:** three proofs expanded `List.ofFn (Fin.snoc f x)` by repeating the
+  same `List.ofFn_succ'`, `Fin.snoc_castSucc`, and `Fin.snoc_last` calculation.
+- **Reuse:** `List.ofFn_snoc` in `TNLean/Algebra/ListOfFn.lean` owns the generic
+  list identity.
+- **Result:** the parent-Hamiltonian word lemmas import the layer-0 result, and
+  `MPOTensor.evalWord_ofFn_cons_snoc` uses it for both endpoint words instead of
+  maintaining two local copies.
+
 ### Successor under one-step finite rotation
 - **Pattern:** both closed-chain MPO calculations proved that `finRotate (N + 1)`
   sends `i.castSucc`, for `i : Fin N`, to `i.succ` by the same cast-heavy


### PR DESCRIPTION
### Motivation

- Late reviews on merged PR #7639 and this follow-up identified four copies of the same generic identity for `List.ofFn (Fin.snoc f x)`.
- The original blocking review is recorded at https://github.com/LionSR/TNLean/pull/7639#discussion_r3919992443.

### Description

- Add the layer-0 theorem `List.ofFn_snoc` in `TNLean/Algebra/ListOfFn.lean`.
- Import the theorem in `TNLean/MPS/MPDO/Defs.lean` and use it for both endpoint words in `MPOTensor.evalWord_ofFn_cons_snoc`.
- Import the same theorem in `TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean` and remove its local copy.
- Reuse it in `TNLean/MPS/ParentHamiltonian/FNWBoundaryEstimate.lean` for the fourth matching snoc expansion.
- Regenerate `TNLean/Algebra.lean` and record the completed four-caller refactor and its net Lean-source delta in `docs/tactic_patterns.md`.
- The retained-window trace theorem in #7633 remains open; this PR only repairs and centralizes its word-level infrastructure.

### Testing

- `lake build TNLean.Algebra.ListOfFn TNLean.MPS.MPDO.Defs TNLean.MPS.ParentHamiltonian.IntersectionProperty TNLean.MPS.ParentHamiltonian.FNWBoundaryEstimate`
- `lake build` (10488 jobs, exact base `74221e295f31e145008f55be157851245fbb3e97` and its QICLean pin)
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `lake exe lint_style --github`
- Blueprint synchronization and strict declaration checks
- paper-gap `\leanid` generation and strict declaration checks
- reader-facing prose and forbidden Lean token checks
- `git diff --check origin/main...HEAD`

---
Follow-up to #7639. Advances #7633.

### Agent assistance

- Texra Lean agent: implemented the theorem hoist, migrated all four expansions, updated the tactic ledger, and ran validation.
