### PR TITLE
feat(MPS/MPU): reduce the retained source-u contraction

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -44,6 +44,7 @@ import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import TNLean.MPS.MPU.SourceIndexValue
 import TNLean.MPS.MPU.SourceUCompleteNetwork
+import TNLean.MPS.MPU.SourceURetainedInterior
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVIsometry
 import TNLean.MPS.MPU.StandardForm

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -74,6 +74,79 @@ private lemma sum_rotate_four_last_first {A B C P R : Type*}
     (fun _ ↦ rfl)
   simpa only [Fintype.sum_prod_type] using h
 
+/-- Coordinate expansion of the fixed-pair trace into the seven-index
+staggered network.  The endpoint letters occur in the order `p.2` then `p.1`,
+and the first-cut coefficient is `ρ β β'`.  The transpose in the rank-one
+vector records the column-stacking convention; no symmetry of `ρ` is used.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem transpose_fixed_pair_trace_eq_staggered_four_u
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (p q : Fin d × Fin d) :
+    Matrix.trace
+        (doubleLayerTensor U p.2 q.2 *
+          Matrix.vecMulVec
+            (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+            (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+              (finProdFinEquiv.symm x)) *
+          doubleLayerTensor U p.1 q.1) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D, ∑ β' : Fin D,
+      ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U j₁ p.2 α β) * ρ β β' * U j₁ q.2 α' β' *
+          (star (U j₂ p.1 γ α) * U j₂ q.1 γ α') := by
+  classical
+  rcases p with ⟨p₁, p₂⟩
+  rcases q with ⟨q₁, q₂⟩
+  have hentry (a b : Fin D) :
+      (doubleLayerTensor U p₂ q₂ *
+          Matrix.vecMulVec
+            (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+            (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+              (finProdFinEquiv.symm x)) *
+          doubleLayerTensor U p₁ q₁)
+          (finProdFinEquiv (a, b)) (finProdFinEquiv (a, b)) =
+        ∑ β : Fin D, ∑ β' : Fin D, ∑ γ : Fin D,
+        ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
+            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := by
+    simpa only [Matrix.transpose_apply] using
+      doubleLayerTensor_rankOne_mul_apply_four_u U ρ.transpose
+        (p₂, p₁) (q₂, q₁) (a, a) (b, b)
+  change Matrix.trace
+      (doubleLayerTensor U p₂ q₂ *
+        Matrix.vecMulVec
+          (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+          (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+            (finProdFinEquiv.symm x)) *
+        doubleLayerTensor U p₁ q₁) =
+    ∑ a : Fin D, ∑ b : Fin D, ∑ β : Fin D, ∑ β' : Fin D,
+    ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+      star (U j₁ p₂ a β) * ρ β β' * U j₁ q₂ b β' *
+        (star (U j₂ p₁ γ a) * U j₂ q₁ γ b)
+  unfold Matrix.trace
+  rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
+  apply Finset.sum_congr rfl
+  intro a _
+  apply Finset.sum_congr rfl
+  intro b _
+  calc
+    _ = ∑ β : Fin D, ∑ β' : Fin D, ∑ γ : Fin D,
+        ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
+            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := hentry a b
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro β _
+      apply Finset.sum_congr rfl
+      intro β' _
+      apply Finset.sum_congr rfl
+      intro γ _
+      apply Finset.sum_congr rfl
+      intro j₁ _
+      apply Finset.sum_congr rfl
+      intro j₂ _
+      ring
+
 namespace SourceFactors
 
 /-- The tensor product \(Y_1\otimes Y_2\) for supplied source factors, in the
@@ -279,59 +352,8 @@ theorem sourceU_gram_eq_transpose_fixed_pair_trace
             (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
               (finProdFinEquiv.symm x)) *
           doubleLayerTensor U p.1 q.1) := by
-  classical
-  rcases p with ⟨p₁, p₂⟩
-  rcases q with ⟨q₁, q₂⟩
-  have hentry (a b : Fin D) :
-      (doubleLayerTensor U p₂ q₂ *
-          Matrix.vecMulVec
-            (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
-            (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
-              (finProdFinEquiv.symm x)) *
-          doubleLayerTensor U p₁ q₁)
-          (finProdFinEquiv (a, b)) (finProdFinEquiv (a, b)) =
-        ∑ β : Fin D, ∑ β' : Fin D, ∑ γ : Fin D,
-        ∑ j₁ : Fin d, ∑ j₂ : Fin d,
-          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
-            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := by
-    simpa only [Matrix.transpose_apply] using
-      doubleLayerTensor_rankOne_mul_apply_four_u U ρ.transpose
-        (p₂, p₁) (q₂, q₁) (a, a) (b, b)
-  have htrace :
-      Matrix.trace
-          (doubleLayerTensor U p₂ q₂ *
-            Matrix.vecMulVec
-              (fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
-              (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
-                (finProdFinEquiv.symm x)) *
-            doubleLayerTensor U p₁ q₁) =
-        ∑ a : Fin D, ∑ b : Fin D, ∑ β : Fin D, ∑ β' : Fin D,
-        ∑ γ : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
-          star (U j₁ p₂ a β) * U j₁ q₂ b β' * ρ β β' *
-            (star (U j₂ p₁ γ a) * U j₂ q₁ γ b) := by
-    unfold Matrix.trace
-    rw [← Equiv.sum_comp finProdFinEquiv, Fintype.sum_prod_type]
-    apply Finset.sum_congr rfl
-    intro a _
-    apply Finset.sum_congr rfl
-    intro b _
-    exact hentry a b
-  rw [sourceU_gram_eq_staggered_four_u, htrace]
-  apply Finset.sum_congr rfl
-  intro a _
-  apply Finset.sum_congr rfl
-  intro b _
-  apply Finset.sum_congr rfl
-  intro β _
-  apply Finset.sum_congr rfl
-  intro β' _
-  apply Finset.sum_congr rfl
-  intro γ _
-  apply Finset.sum_congr rfl
-  intro j₁ _
-  apply Finset.sum_congr rfl
-  intro j₂ _
-  ring
+  rw [sourceU_gram_eq_staggered_four_u,
+    ← transpose_fixed_pair_trace_eq_staggered_four_u]
 
 end SourceFactors
 

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -357,6 +357,42 @@ theorem sourceU_gram_eq_transpose_fixed_pair_trace
 
 end SourceFactors
 
+/-- Cyclically move the first retained letter of a closed double-layer word to
+its right endpoint, leaving one blocked interior letter between the two
+unblocked endpoints.
+
+Source: CPSV17 equation `uUnitary` and Figure `II_uUnitary.png` (lines 545--557).
+-/
+theorem mpo_doubleLayer_finAddTwoArrowEquiv_symm_eq_endpointSeparated
+    (U : MPOTensor d D) (K : ℕ) (p q : Fin d × Fin d)
+    (σ τ : Fin K → Fin d) :
+    mpo (doubleLayerTensor U) (K + 2)
+        ((finAddTwoArrowEquiv (Fin d) K).symm (p, σ))
+        ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
+      Matrix.trace
+        (doubleLayerTensor U p.2 q.2 *
+          doubleLayerTensor (blockTensor U K)
+            ((Kraus.decodeBlockEquiv d K).symm σ)
+            ((Kraus.decodeBlockEquiv d K).symm τ) *
+          doubleLayerTensor U p.1 q.1) := by
+  rw [mpo_apply, mpoMatrixEntry]
+  calc
+    Matrix.trace
+        (evalWord (doubleLayerTensor U)
+          (List.ofFn ((finAddTwoArrowEquiv (Fin d) K).symm (p, σ)))
+          (List.ofFn ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)))) =
+      Matrix.trace
+        (evalWord (doubleLayerTensor U)
+          (List.ofFn (Fin.cons p.2 (Fin.snoc σ p.1)))
+          (List.ofFn (Fin.cons q.2 (Fin.snoc τ q.1)))) := by
+        simpa only [finAddTwoArrowEquiv_symm_apply, List.ofFn_cons, List.ofFn_snoc,
+          List.cons_append] using
+          trace_evalWord_cons_eq_append (doubleLayerTensor U) p.1 q.1
+            (p.2 :: List.ofFn σ) (q.2 :: List.ofFn τ) (by simp)
+    _ = _ := by
+      rw [evalWord_ofFn_cons_snoc,
+        doubleLayerTensor_blockTensor_decodeBlockEquiv_symm]
+
 /-- The normalized input-tail contraction is the closed direct double-layer
 network with two retained input letters followed by the (K)-site interior.
 The retained pair `p` is starred and `q` is unstarred.
@@ -389,10 +425,12 @@ theorem normalized_mpo_input_tail_eq_closed_doubleLayer_trace
           ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
         Matrix.trace (W p.1 q.1 * W p.2 q.2 *
           evalWord W (List.ofFn τ) (List.ofFn τ)) := by
-    rw [mpo_apply, mpoMatrixEntry]
-    simp only [finAddTwoArrowEquiv_symm_apply, List.ofFn_succ, evalWord_cons,
-      Fin.cons_zero, Fin.cons_succ]
-    rw [← Matrix.mul_assoc]
+    calc
+      _ = Matrix.trace
+          (W p.2 q.2 * evalWord W (List.ofFn τ) (List.ofFn τ) * W p.1 q.1) := by
+        simpa only [W, doubleLayerTensor_blockTensor_decodeBlockEquiv_symm] using
+          mpo_doubleLayer_finAddTwoArrowEquiv_symm_eq_endpointSeparated U K p q τ τ
+      _ = _ := by rw [Matrix.trace_mul_cycle]
   simp_rw [hword]
   change ((d : ℂ)⁻¹) ^ K *
       ∑ τ : Fin K → Fin d,

--- a/TNLean/MPS/MPU/SourceURetainedInterior.lean
+++ b/TNLean/MPS/MPU/SourceURetainedInterior.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.ReflectedTransferKernel
+import TNLean.MPS.MPU.SourceUCompleteNetwork
+
+/-!
+# Retained-interior contractions for the paper source gate u
+
+This module isolates the finite contractions with one blocked interior of
+length \(K=JD^2\) and two unblocked one-site endpoint letters.  The direct
+fixed pair closes the normalized input tail.  Identifying that closure with
+the transpose-oriented fixed pair of the staggered source-$u$ Gram network is
+the remaining contraction in CPSV17 Lemma `lemuisometry`.
+
+Source: arXiv:1703.09188, equation `uUnitary` and Lemma `lemuisometry`
+(lines 545--557).
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The normalized retained input tail closes against the untransposed supplied
+fixed pair.  Only the length-\(K\) interior is blocked; the endpoint letters
+remain the original one-site double-layer letters.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem normalized_mpo_input_tail_eq_fixed_pair_trace
+    [NeZero d] [NeZero D]
+    (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower :
+      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+        Matrix.vecMulVec ρ.vec
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec)
+    (p q : Fin d × Fin d) :
+    let K := J * (D * D)
+    let ρ' : Fin (D * D) → ℂ :=
+      fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+    let Φ' : Fin (D * D) → ℂ :=
+      fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+        (finProdFinEquiv.symm x)
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
+      Matrix.trace
+        (doubleLayerTensor U p.2 q.2 *
+          Matrix.vecMulVec ρ' Φ' *
+          doubleLayerTensor U p.1 q.1) := by
+  dsimp only
+  let K := J * (D * D)
+  let ρ' : Fin (D * D) → ℂ :=
+    fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+  let Φ' : Fin (D * D) → ℂ :=
+    fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+      (finProdFinEquiv.symm x)
+  have htail := normalized_mpo_input_tail_eq_closed_doubleLayer_trace U K p q
+  have hfixed := normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+    U ρ hρtrace J hpower
+  have hEK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec ρ' Φ' := by
+    dsimp only [K, ρ', Φ'] at hfixed ⊢
+    rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at hfixed
+    exact hfixed
+  rw [htail, hEK]
+  exact (Matrix.trace_mul_cycle
+    (doubleLayerTensor U p.2 q.2)
+    (Matrix.vecMulVec ρ' Φ')
+    (doubleLayerTensor U p.1 q.1)).symm
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3046,6 +3046,34 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     trace gives the displayed closed trace.
 \end{proof}
 
+\begin{lemma}[Endpoint-separated double-layer word]
+    \label{lem:mpu_endpoint_separated_double_layer_word}
+    \lean{MPOTensor.mpo_doubleLayer_finAddTwoArrowEquiv_symm_eq_endpointSeparated}
+    \leanok
+    \uses{def:mpo_family, def:mpu_double_layer,
+        thm:mpu_double_layer_blocking}
+    Let $W$ be the double layer of an MPO tensor $\mathcal U$. For words
+    $\sigma,\tau\in\{0,\ldots,d-1\}^K$ and retained pairs
+    $p=(p_1,p_2)$ and $q=(q_1,q_2)$, write
+    $(p_1,p_2,\sigma)$ and $(q_1,q_2,\tau)$ for the corresponding words of
+    length $K+2$. Then
+    \begin{align}
+        W^{(K+2)}_{(p_1,p_2,\sigma),(q_1,q_2,\tau)}
+         & =\tr\!\left[
+            W^{p_2q_2}W_K^{\sigma,\tau}W^{p_1q_1}\right],
+    \end{align}
+    where $W_K^{\sigma,\tau}$ is the blocked double-layer letter associated
+    with the two interior words.
+    % Source locator: paper_v2.tex, equation uUnitary and lines 545--557.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpo_eval_word, thm:mpu_double_layer_blocking}
+    Write the closed word with $p_1,q_1$ first and move this letter to the
+    right end by cyclicity of the trace. The remaining $K$ interior letters
+    multiply to $W_K^{\sigma,\tau}$.
+\end{proof}
+
 \begin{theorem}[Closed double-layer trace for the normalized input tail]
     \label{thm:mpu_normalized_input_tail_closed_trace}
     \lean{MPOTensor.normalized_mpo_input_tail_eq_closed_doubleLayer_trace}
@@ -3066,7 +3094,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_closed_double_layer, thm:mpu_normalized_diagonal_word_expansion}
+    \uses{lem:mpu_endpoint_separated_double_layer_word,
+        thm:mpu_closed_double_layer,
+        thm:mpu_normalized_diagonal_word_expansion}
     Closing the common output word gives the double-layer identity
     \begin{align}
         \sum_\eta
@@ -4936,6 +4966,38 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 269--280 and 397--405.
 \end{definition}
 
+\begin{lemma}[Coordinate expansion of the transpose fixed-pair trace]
+    \label{lem:mpu_transpose_fixed_pair_trace_expansion}
+    \lean{MPOTensor.transpose_fixed_pair_trace_eq_staggered_four_u}
+    \leanok
+    \uses{def:mpu_double_layer}
+    Let $W^{ij}$ be the double-layer letters of an MPO tensor $\mathcal U$,
+    let $\rho$ be a bond matrix, and put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. For retained pairs
+    $p=(p_1,p_2)$ and $q=(q_1,q_2)$,
+    \begin{align}
+        \tr\!\left(
+        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
+        \right)
+        ={} & \sum_{\alpha,\alpha',\beta,\beta',\gamma,j_1,j_2}
+        \overline{\mathcal U^{j_1}_{p_2,\alpha,\beta}}
+        \rho_{\beta,\beta'}
+        \mathcal U^{j_1}_{q_2,\alpha',\beta'} \notag            \\
+            & \qquad\qquad\cdot
+        \overline{\mathcal U^{j_2}_{p_1,\gamma,\alpha}}
+        \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
+    \end{align}
+    % Source locator: paper_v2.tex, equation uUnitary and lines 545--557.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_v_four_u_expansions}
+    Expand the trace over the diagonal doubled-bond coordinates. The inserted
+    coefficient is
+    $(\rho^{\mathsf T})_{\beta',\beta}=\rho_{\beta,\beta'}$; the two
+    double-layer letters supply the remaining five sums.
+\end{proof}
+
 \begin{theorem}[Staggered Gram expansion of the source tensor $u$]
     \label{thm:mpu_source_u_staggered_gram}
     \lean{MPOTensor.SourceFactors.sourceU_gram_eq_staggered_four_u}
@@ -5006,27 +5068,59 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \right).
     \end{align}
     In particular, the weight is transposed rather than identified with
-    $\rho$. The retained-interior equality needed for the complete contraction
-    remains open.
-    % The retained-interior equality is tracked in Issue #7633.
+    $\rho$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_u_staggered_gram, thm:mpu_source_v_four_u_expansions}
-    Enumerate each doubled-bond coordinate as
-    $\operatorname{flat}(\alpha,\alpha')$. Expanding a diagonal entry of the
-    matrix under the trace gives
-    \begin{align}
-        \sum_{\beta,\beta',\gamma,j_1,j_2}
-        \overline{\mathcal U^{j_1}_{p_2,\alpha,\beta}}
-        \mathcal U^{j_1}_{q_2,\alpha',\beta'}
-        (\rho^{\mathsf T})_{\beta',\beta}
-        \overline{\mathcal U^{j_2}_{p_1,\gamma,\alpha}}
-        \mathcal U^{j_2}_{q_1,\gamma,\alpha'}.
-    \end{align}
-    Since $(\rho^{\mathsf T})_{\beta',\beta}=\rho_{\beta,\beta'}$,
-    summing over $\alpha,\alpha'$ gives the identity in
+    \uses{lem:mpu_transpose_fixed_pair_trace_expansion,
+        thm:mpu_source_u_staggered_gram}
+    Lemma~\ref{lem:mpu_transpose_fixed_pair_trace_expansion} expands the
+    trace into the same seven-index expression as
     Theorem~\ref{thm:mpu_source_u_staggered_gram}.
+\end{proof}
+
+\begin{theorem}[Direct fixed-pair trace for the normalized input tail]
+    \label{thm:mpu_normalized_input_tail_fixed_pair_trace}
+    \lean{MPOTensor.normalized_mpo_input_tail_eq_fixed_pair_trace}
+    \leanok
+    \uses{def:mpo_family, def:mpu_double_layer,
+        def:mpu_normalized_flattening}
+    Assume $d,D>0$. Let $E$ be the transfer matrix of the normalized
+    flattening of an MPO tensor $\mathcal U$. Suppose that
+    $\tr(\rho)=1$ and
+    \begin{align}
+        E^J & =\lvert\rho)(\Phi\rvert,
+            & (\Phi\rvert              & =\operatorname{vec}(\Id_D)^{\mathsf T}.
+    \end{align}
+    Set $K=JD^2$, let $W^{ij}$ be the double-layer letters, and use the
+    column-stacking vectors $\lvert\rho)$ and $(\Phi\rvert$ on the doubled
+    bond space. Then, for retained pairs $p=(p_1,p_2)$ and $q=(q_1,q_2)$,
+    \begin{align}
+        d^{-K}\sum_{\tau,\eta}
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}
+         & =\tr\!\left(
+        W^{p_2q_2}\lvert\rho)(\Phi\rvert W^{p_1q_1}
+        \right).
+    \end{align}
+    The fixed pair is direct: the weight is $\rho$, not $\rho^{\mathsf T}$.
+    % Source locator: paper_v2.tex, equation uUnitary and lines 545--557.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_input_tail_closed_trace,
+        thm:mpu_reflected_transfer_power}
+    The normalized input-tail formula gives
+    \begin{align}
+        d^{-K}\sum_{\tau,\eta}
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}
+         & =\tr\!\left[W^{p_1q_1}W^{p_2q_2}R^K\right],
+    \end{align}
+    where $R$ is the normalized double-layer diagonal. The supplied transfer
+    power and the additional $D^2$ blocking give
+    $R^K=\lvert\rho)(\Phi\rvert$. Substitute this equality and cycle the first
+    letter to the right end of the trace.
 \end{proof}
 
 \begin{theorem}[Complete source-$u$ network contraction]
@@ -5058,29 +5152,22 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
-    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
-    external source gates as
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace,
+        thm:mpu_normalized_input_tail_fixed_pair_trace}
+    The two proved contractions reduce the desired equality to
     \begin{align}
-        \operatorname{tr}\!\left(
+        \tr\!\left(
         W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
-        \right).
-    \end{align}
-    Cyclicity moves the first double-layer letter past the trace. It remains to
-    identify the resulting rank-one insertion with the $K$-site interior:
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert
         \right)
-         & =\operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}E^K
+         & =\tr\!\left(
+        W^{p_2q_2}\lvert\rho)(\Phi\rvert W^{p_1q_1}
         \right).
     \end{align}
-    This retained-interior contraction remains open. It must preserve the two
-    unblocked endpoint letters while applying the supplied simple contractions
-    to the interior. The checked $Y_1$--$X_2$ mixed-kernel identities concern a
-    different network and do not prove this equality.
-    % The retained-interior contraction is tracked in Issue #7633.
+    Thus the remaining scalar contraction compares the transpose-oriented
+    fixed-pair trace from the source-$u$ Gram network with the direct
+    fixed-pair trace from the normalized input tail. No symmetry of $\rho$
+    has been assumed, so this comparison remains open.
+    % Remaining comparison: paper_v2.tex, equation uUnitary and lines 545--557.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -8,7 +8,7 @@
 
 \title{The First MPU Source Cut and the Orientation of the Source Gates}
 \author{}
-\date{2026-09-01}
+\date{2026-09-03}
 
 \begin{document}
 \maketitle
@@ -120,15 +120,63 @@ contraction for $u$ or the $X_1$--$X_2$ contraction for $v$, with the product
 orders shown above. The Chapter~28 Blueprint links only to declarations that
 were rebuilt after the correction.
 
+\section{Remaining source-$u$ comparison}
+
+The source-$u$ Gram contraction has now been expanded into the staggered
+four-tensor network and closed as
+\begin{align}
+    \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+     & =\operatorname{tr}\!\left(
+    W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
+    \right).
+    \label{eq:mpu_source_cut_orientation_transpose_trace}
+\end{align}
+The coordinate expansion and this closure are
+\leanid{MPOTensor.transpose_fixed_pair_trace_eq_staggered_four_u} and
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixed_pair_trace}.
+
+The retained input word can also be separated into its two one-site letters
+and its blocked interior:
+\begin{align}
+    W^{(K+2)}_{(p_1,p_2,\sigma),(q_1,q_2,\tau)}
+     & =\operatorname{tr}\!\left(
+    W^{p_2q_2}W_K^{\sigma,\tau}W^{p_1q_1}\right).
+    \label{eq:mpu_source_cut_orientation_endpoint_separated}
+\end{align}
+This is
+\leanid{MPOTensor.mpo_doubleLayer_finAddTwoArrowEquiv_symm_eq_endpointSeparated}.
+If $E^J=\lvert\rho)(\Phi\rvert$, $\operatorname{tr}(\rho)=1$, and
+$K=JD^2$, the normalized input-tail contraction is
+\begin{align}
+    d^{-K}\sum_{\tau,\eta}
+    \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+    U^{(K+2)}_{\eta,(q,\tau)}
+     & =\operatorname{tr}\!\left(
+    W^{p_2q_2}\lvert\rho)(\Phi\rvert W^{p_1q_1}
+    \right).
+    \label{eq:mpu_source_cut_orientation_direct_trace}
+\end{align}
+This is
+\leanid{MPOTensor.normalized_mpo_input_tail_eq_fixed_pair_trace}.
+
+Consequently the unresolved step is exactly the scalar equality between
+Eqs.~\eqref{eq:mpu_source_cut_orientation_transpose_trace} and
+\eqref{eq:mpu_source_cut_orientation_direct_trace}. It compares the
+transpose-oriented fixed pair of the staggered source-$u$ Gram network with
+the direct fixed pair of the normalized input tail. No symmetry of $\rho$
+is among the stated assumptions. Therefore the complete source-$u$
+contraction, the source-$u$ isometry, and the subsequent consequences do not
+follow from the established identities alone.
+
 \section{Verdict}
 
 The former definition of $M_1$ was the transpose of the source diagram. The
 correction changes no source rank, but it changes the typed source factors and
 all order-sensitive contractions. The first cut, weight, adjunction identities,
 paper gates, two-site factorizations, tensor products, and shift examples now
-use one consistent leg assignment. The correction is resolved, while the
-revalidation rule remains applicable to any future recovery of source-gate
-work predating this audit.
+use one consistent leg assignment. The orientation correction is resolved.
+The remaining source-$u$ question is the scalar comparison between the
+transpose-oriented and direct fixed-pair traces above.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- expose the transpose fixed-pair trace as the exact seven-index staggered source-$u$ network
- separate the two unblocked endpoint letters from one $K$-site double-layer interior
- close the normalized input tail against the direct supplied fixed pair, with $K=J(D^2)$
- synchronize Chapter 28 and the source-cut orientation note with the proved partial result

This advances #7633 but does not close it.

The exact remaining equality is

```lean
Matrix.trace
    (doubleLayerTensor U p.2 q.2 *
      Matrix.vecMulVec ρT Φ' *
      doubleLayerTensor U p.1 q.1) =
  Matrix.trace
    (doubleLayerTensor U p.2 q.2 *
      Matrix.vecMulVec ρ' Φ' *
      doubleLayerTensor U p.1 q.1)
```

where `ρT x = ρ.transpose.vec (finProdFinEquiv.symm x)` and
`ρ' x = ρ.vec (finProdFinEquiv.symm x)`. Hermiticity gives only
`star ρT = ρ'`; it does not identify `ρT` with `ρ'`. The missing proof is the
same-block direct/reflected finite-coordinate contraction on the common
$K$-site interior.

## Validation

- `lake build TNLean.MPS.MPU.SourceUCompleteNetwork TNLean.MPS.MPU.SourceURetainedInterior TNLean.MPS.MPU`
- `lake build` (10489 jobs)
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with the pinned tenkz package; no undefined references (pre-existing standalone citation warnings only)
- reader-facing prose, tenkz, chktex, latexindent, paper-gap reference, proof-integrity, and `git diff --check` gates
