### PR TITLE
feat(MPS/MPU): close the source-u retained-window network and prove u is an isometry

### DIFF
--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -16,9 +16,11 @@ identify a Gram matrix for the paper gate $u=Y_2\mathbin{-}Y_1$.
 
 The source proof in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
 `lemuisometry` (lines 536--556), instead contracts the staggered paper-$u$
-network. That route remains unformalized. Similar blocked and output-tail
-shapes in this file must not be read as a formalization of the figure or as
-support for the paper source-$u$ isometry.
+network; that contraction is carried out in
+`TNLean.MPS.MPU.SourceUCompleteNetwork`, which uses from this file only the
+input-first tail isometry and the stabilized fixed pair of the simple block.
+Similar blocked and output-tail shapes in this file must not be read as a
+formalization of the figure.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -112,6 +114,43 @@ theorem IsMPU.normalized_mpo_tail_isometry [NeZero d]
     rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero K hd), one_mul]
   · rw [ite_eq_right hpq]
     simp
+
+/-- The supplied normalized transfer power remains the same rank-one
+projector after the additional positive \(D^2\) blocking: the closed double
+layer of the simple block of length \(JD^2\) is the fixed pair
+\(|\rho)(\Phi|\), written in the doubled-bond coordinates of the double layer.
+
+Source: arXiv:1703.09188, equation `Erightleft` and Proposition
+`blockingsimple`, lines 274--280 and 397--409. -/
+theorem normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+    [NeZero d] [NeZero D] (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    normalizedDiagonal (doubleLayerTensor (blockTensor U (J * (D * D)))) =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
+  let R := Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec
+  have hpair : (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ ρ.vec = 1 := by
+    rw [Matrix.vec_one_dotProduct_vec_eq_trace, hρtrace]
+  have hRidem : R * R = R := by
+    simp only [R, Matrix.vecMulVec_mul_vecMulVec, hpair, one_smul]
+  have hDsq : 0 < D * D := Nat.mul_pos (NeZero.pos D) (NeZero.pos D)
+  have hpowpos : ∀ n : ℕ, 0 < n → R ^ n = R := by
+    intro n hn
+    obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn)
+    clear hn
+    induction m with
+    | zero => simp
+    | succ m ih => rw [pow_succ, ih, hRidem]
+  have hRpow : R ^ (D * D) = R := hpowpos _ hDsq
+  have hpowerR :
+      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J = R := hpower
+  rw [normalizedDiagonal_doubleLayerTensor_blockTensor, pow_mul, hpowerR, hRpow]
+  rfl
 
 /-- The stabilized first block followed by the corrected \(D^2\) block has the
 exact simple contractions obtained from the supplied fixed matrix and the

--- a/TNLean/MPS/MPU/ReflectedTransferKernel.lean
+++ b/TNLean/MPS/MPU/ReflectedTransferKernel.lean
@@ -95,38 +95,6 @@ theorem normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor
   simp
   ring
 
-/-- The supplied normalized transfer power remains the same rank-one
-projector after the additional positive $D^2$ blocking. -/
-theorem normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
-    [NeZero d] [NeZero D] (U : MPOTensor d D)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρtrace : Matrix.trace ρ = 1)
-    (J : ℕ)
-    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
-      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
-    normalizedDiagonal (doubleLayerTensor (blockTensor U (J * (D * D)))) =
-      Matrix.vecMulVec
-        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x : Fin (D * D) ↦
-          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
-  let R := Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec
-  have hpair : (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ ρ.vec = 1 := by
-    rw [Matrix.vec_one_dotProduct_vec_eq_trace, hρtrace]
-  have hRidem : R * R = R := by
-    simp only [R, Matrix.vecMulVec_mul_vecMulVec, hpair, one_smul]
-  have hDsq : 0 < D * D := Nat.mul_pos (NeZero.pos D) (NeZero.pos D)
-  have hpowpos : ∀ n : ℕ, 0 < n → R ^ n = R := by
-    intro n hn
-    obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn)
-    clear hn
-    induction m with
-    | zero => simp
-    | succ m ih => rw [pow_succ, ih, hRidem]
-  have hRpow : R ^ (D * D) = R := hpowpos _ hDsq
-  have hpowerR :
-      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J = R := hpower
-  rw [normalizedDiagonal_doubleLayerTensor_blockTensor, pow_mul, hpowerR, hRpow]
-  rfl
-
 /-- After conjugate transposition, reflected normalized transfer witnesses
 have the boundary orientation $|1)(\rho|$ used by the output-first tail.
 The doubled-bond swap is essential for the column-stacking convention

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -13,7 +13,23 @@ This file follows the contraction in CPSV17 Lemma `lemuisometry`.  The source
 gate is the staggered contraction \(u=Y_2\mathbin{-}Y_1\).  Its Gram matrix is
 first expanded into the literal reflected--direct four-tensor network in
 Figure `II_uUnitary.png`; the retained physical legs are not included in the
-simple interior block.
+simple interior block.  The network is then closed against the fixed pair
+\(|\rho)(\Phi|\) of the simple interior block of length \(K=JD^2\) and
+identified with the normalized input tail
+\(d^{-K}\operatorname{tr}_{1,\ldots,K}[U^{(K+2)\dagger}U^{(K+2)}]\), which
+gives \(u^\dagger u=\Id\) and \(d^2\le r\ell\).
+
+## Orientation of the source weight
+
+The first source cut lists the conjugated right leg before the unconjugated
+one, so the weight \(\Id_d\otimes\rho\) of equation `X1X2b` inserts
+\(\rho_{\beta\beta'}\) between the bra leg \(\beta\) and the ket leg
+\(\beta'\).  The transfer matrix acts on column-stacked vectors, whose
+component at \((\beta,\beta')\) is \(\rho_{\beta'\beta}\).  Hence the weight
+of `X1X2b` is the transpose of the column-stacked right fixed point: the
+source factors are taken for the weight \(\rho^{\mathsf T}\) whenever
+\(E^J=|\rho)(\Phi|\).  For the diagonal fixed point of canonical form II the
+two matrices coincide.  See `docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 Source: arXiv:1703.09188, equations `X1X2b`, `uu`, and `uUnitary`, and Lemma
 `lemuisometry` (lines 487--557).
@@ -380,5 +396,139 @@ theorem normalized_mpo_input_tail_eq_closed_doubleLayer_trace
   rw [normalizedDiagonal_pow_eq_sum_evalWord W K]
   simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul,
     Matrix.mul_sum, Matrix.trace_sum]
+
+namespace SourceFactors
+
+/-- The retained-interior contraction of the source-\(u\) network.  When the
+closed double layer of the \(K\)-site interior is the fixed pair
+\(|\rho)(\Phi|\) with \((\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}\), the
+Gram matrix of \(u=Y_2\mathbin{-}Y_1\) for the source weight
+\(\rho^{\mathsf T}\) is the closed double-layer trace of the two retained
+one-site letters followed by the \(K\)-site interior.  The pair `p` is starred
+and `q` is unstarred.
+
+The weight is \(\rho^{\mathsf T}\) because the first source cut lists the
+conjugated right leg first while `Matrix.vec` stacks columns; see the module
+docstring.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem sourceU_gram_eq_closed_doubleLayer_trace
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ.transpose) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec
+        (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  rw [sourceU_gram_eq_transpose_fixed_pair_trace, Matrix.transpose_transpose, ← hK]
+  exact Matrix.trace_mul_cycle _ _ _
+
+/-- The complete source-\(u\) network contraction.  With the stabilized fixed
+pair \(E^J=|\rho)(\Phi|\), \((\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}\),
+and the simple interior block of length \(K=JD^2\), the Gram matrix of the
+paper gate \(u=Y_2\mathbin{-}Y_1\) for the source weight \(\rho^{\mathsf T}\)
+is the normalized input tail
+\(d^{-K}\operatorname{tr}_{1,\ldots,K}[U^{(K+2)\dagger}U^{(K+2)}]\).  The
+pair `p` is starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem sourceU_gram_eq_normalized_input_tail [NeZero d] [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρtrace : Matrix.trace ρ = 1) (J : ℕ)
+    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec)
+    (S : SourceFactors U ρ.transpose) (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      ((d : ℂ)⁻¹) ^ (J * (D * D)) *
+        ∑ τ : Fin (J * (D * D)) → Fin d,
+          ∑ η : Fin (J * (D * D) + 2) → Fin d,
+            star (mpo U (J * (D * D) + 2) η
+              ((finAddTwoArrowEquiv (Fin d) (J * (D * D))).symm (p, τ))) *
+            mpo U (J * (D * D) + 2) η
+              ((finAddTwoArrowEquiv (Fin d) (J * (D * D))).symm (q, τ)) := by
+  rw [normalized_mpo_input_tail_eq_closed_doubleLayer_trace]
+  have hfixed :=
+    normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+      U ρ hρtrace J hpower
+  rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at hfixed
+  exact sourceU_gram_eq_closed_doubleLayer_trace U S (J * (D * D)) hfixed p q
+
+/-- The paper gate \(u=Y_2\mathbin{-}Y_1\) of an MPU tensor satisfies
+\(u^\dagger u=\Id\) for every choice of source factors with weight
+\(\rho^{\mathsf T}\), where \(E^J=|\rho)(\Phi|\) is a stabilized fixed pair
+with \(\operatorname{tr}\rho=1\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem sourceU_isIsometry_of_isMPU [NeZero d] [NeZero D] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρtrace : Matrix.trace ρ = 1) (J : ℕ)
+    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec)
+    (S : SourceFactors U ρ.transpose) :
+    (sourceU U S).IsIsometry := by
+  change (sourceU U S)ᴴ * sourceU U S = 1
+  ext p q
+  have h := sourceU_gram_eq_normalized_input_tail U hρtrace J hpower S p q
+  rw [hU.normalized_mpo_tail_isometry] at h
+  rw [Matrix.mul_apply, Matrix.one_apply, ← h]
+  exact Finset.sum_congr rfl fun lr _ ↦ by
+    rw [Matrix.conjTranspose_apply, mul_comm]
+
+/-- Since \(u\) is an isometry from a space of dimension \(d^2\) to one of
+dimension \(r\ell\), the source-cut ranks satisfy \(d^2\le r\ell\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem mul_self_le_leftRank_mul_rightRank_of_isMPU [NeZero d] [NeZero D]
+    (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρtrace : Matrix.trace ρ = 1) (J : ℕ)
+    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec)
+    (S : SourceFactors U ρ.transpose) :
+    d * d ≤ ℓ[U] * r[U] := by
+  have h := Matrix.IsIsometry.card_le _
+    (sourceU_isIsometry_of_isMPU U hU hρtrace J hpower S)
+  simpa only [Fintype.card_prod, Fintype.card_fin] using h
+
+end SourceFactors
+
+variable {U} in
+/-- The compact-SVD paper gate \(u=Y_2\mathbin{-}Y_1\) with source weight
+\(\rho^{\mathsf T}\) is an isometry whenever \(E^J=|\rho)(\Phi|\) is a
+stabilized fixed pair with \(\rho>0\) and \(\operatorname{tr}\rho=1\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem IsMPU.sourceU_transpose_isIsometry [NeZero d] [NeZero D] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower : transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    (sourceU U ρ.transpose hρ.transpose).IsIsometry :=
+  SourceFactors.sourceU_isIsometry_of_isMPU U hU hρtrace J hpower
+    (sourceFactors U ρ.transpose hρ.transpose)
+
+variable {U} in
+/-- A reduced full-support canonical-form-II representative supplies a
+normalized positive right fixed point \(\rho\) whose transpose is the source
+weight of an isometric paper gate \(u\).
+
+**Scope restriction (full support):** the fixed pair is supplied by
+`IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`; see
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem IsMPU.exists_sourceU_transpose_isIsometry_of_reduced_cfii
+    [NeZero d] [NeZero D] (hU : IsMPU U) (hD : 1 < D)
+    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (hfull : cfii.toCPSVCanonicalFormData.HasFullSupport) :
+    ∃ (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef),
+      Matrix.trace ρ = 1 ∧ Kraus.transferMap U.normalizedFlattening ρ = ρ ∧
+      (sourceU U ρ.transpose hρ.transpose).IsIsometry := by
+  obtain ⟨_, _, ρ, _, _, _, _, _, _, hρpd, hρtrace, hρfix, _, hpower⟩ :=
+    hU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD cfii hfull
+  exact ⟨ρ, hρpd, hρtrace, hρfix,
+    hU.sourceU_transpose_isIsometry hρpd hρtrace _ hpower⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5029,20 +5029,67 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Theorem~\ref{thm:mpu_source_u_staggered_gram}.
 \end{proof}
 
+\begin{lemma}[Retained-interior contraction of the source-$u$ network]
+    \label{lem:mpu_source_u_retained_interior}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace}
+    \leanok
+    \discussion{7633}
+    \uses{def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPO tensor with double-layer letters $W^{ij}$ and
+    normalized physical diagonal $E=d^{-1}\sum_iW^{ii}$. Let $\rho$ be a bond
+    matrix, let $\lvert\rho)$ be its column-stacking vector, put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
+    closed double layer of a $K$-site interior is the fixed pair,
+    \begin{align}
+        E^K & =\lvert\rho)(\Phi\rvert.
+        \label{eq:mpu_source_u_retained_interior_fixed_pair}
+    \end{align}
+    Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
+    the weight $\rho^{\mathsf T}$, and let $u=Y_2\mathbin{-}Y_1$. Then, for
+    retained physical pairs $p=(p_1,p_2)$ and $q=(q_1,q_2)$,
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\tr\!\left(W^{p_1q_1}W^{p_2q_2}E^K\right).
+    \end{align}
+    The two endpoint letters remain unblocked; only the interior is the
+    $K$-site block. The weight is $\rho^{\mathsf T}$ because the first source
+    cut lists the conjugated right leg before the unconjugated one, while
+    $\lvert\rho)$ stacks columns: both insert the coefficient
+    $\rho_{\beta'\beta}$ between the conjugated leg $\beta$ and the
+    unconjugated leg $\beta'$. For the diagonal fixed point of canonical
+    form II this is the weight $\rho$ of equation \texttt{X1X2b} in
+    \cite{Cirac2017MPU}.
+    % Source locator: paper_v2.tex, equation uUnitary and lines 545--557.
+    % Orientation: docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace}
+    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace}, applied to the
+    weight $\rho^{\mathsf T}$, closes the two external source gates as
+    $\tr(W^{p_2q_2}\lvert\rho)(\Phi\rvert W^{p_1q_1})$, since
+    $(\rho^{\mathsf T})^{\mathsf T}=\rho$. Substituting
+    (\ref{eq:mpu_source_u_retained_interior_fixed_pair}) and cycling the
+    letter $W^{p_1q_1}$ to the front of the trace gives
+    $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$.
+\end{proof}
+
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail}
+    \leanok
     \discussion{5982}
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family}
+    \uses{def:mpu_normalized_flattening, def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpo_family}
     % Revalidation boundary: docs/paper-gaps/mpu_source_cut_orientation.tex.
-    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+    Let $\mathcal U$ be an MPO tensor with physical dimension $d>0$ and bond
+    dimension $D>0$. Let $\rho$ satisfy $\tr(\rho)=1$, put
     $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    some $J$ the normalized transfer matrix satisfies
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
     \end{align}
-    Construct the source factors and $u$ from $\mathcal U$ using $\rho$, and set
+    Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
+    the weight $\rho^{\mathsf T}$, let $u=Y_2\mathbin{-}Y_1$, and set
     $K=JD^2$. For retained physical pairs
     $p,q\in\{0,\ldots,d-1\}^2$, the complete source-$u$ contraction satisfies
     \begin{align}
@@ -5053,34 +5100,22 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
     output words of length $K+2$. This is the supplied-fixed-pair form of the
-    complete-network equality in \cite[Lemma~III.7]{Cirac2017MPU}.
+    complete-network equality in \cite[Lemma~III.7]{Cirac2017MPU}; the
+    weight $\rho^{\mathsf T}$ is explained in
+    Lemma~\ref{lem:mpu_source_u_retained_interior}.
     % Source locator: paper_v2.tex, lines 545--557.
 \end{theorem}
 
-\begin{proof}
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
-    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
-    external source gates as
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
-        \right).
-    \end{align}
-    Cyclicity moves the first double-layer letter past the trace. It remains to
-    identify the resulting rank-one insertion with the $K$-site interior:
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert
-        \right)
-         & =\operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}E^K
-        \right).
-    \end{align}
-    This retained-interior contraction remains open. It must preserve the two
-    unblocked endpoint letters while applying the supplied simple contractions
-    to the interior. The checked $Y_1$--$X_2$ mixed-kernel identities concern a
-    different network and do not prove this equality.
-    % The retained-interior contraction is tracked in Issue #7633.
+\begin{proof}\leanok
+    \uses{lem:mpu_source_u_retained_interior, thm:mpu_normalized_input_tail_closed_trace, thm:mpu_reflected_transfer_power}
+    Theorem~\ref{thm:mpu_normalized_input_tail_closed_trace} writes the
+    right-hand side as $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$. Since $(\Phi|\rho)=\tr(\rho)=1$, the
+    rank-one matrix $\lvert\rho)(\Phi\rvert$ is idempotent, so
+    Theorem~\ref{thm:mpu_reflected_transfer_power} gives
+    $E^K=(E^J)^{D^2}=\lvert\rho)(\Phi\rvert$ for the closed double layer of
+    the interior block of length $K=JD^2$.
+    Lemma~\ref{lem:mpu_source_u_retained_interior} then identifies the Gram
+    matrix of $u$ with $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]
@@ -5141,35 +5176,48 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Consequently $u$ is an isometry and $r\ell\geq d^2$. This is the
     unrestricted statement of \cite[Lemma~III.7]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 545--557.
+    % Checked with an explicitly supplied stabilized fixed pair in
+    % Lemma~\ref{lem:mpu_admissible_source_u_isometry} and, for a reduced
+    % full-support representative, in
+    % Corollary~\ref{cor:mpu_reduced_cfii_source_u_isometry}. The unrestricted
+    % canonical-form-II convention is documented in
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
 \end{lemma}
 
 \begin{lemma}[Admissible source-$u$ isometry]
     \label{lem:mpu_admissible_source_u_isometry}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU,
+        MPOTensor.SourceFactors.mul_self_le_leftRank_mul_rightRank_of_isMPU,
+        MPOTensor.IsMPU.sourceU_transpose_isIsometry}
+    \leanok
     \discussion{5708}
     % **Scope restriction (supplied stabilized fixed pair):** this lemma assumes
     % the exact rank-one transfer identity explicitly, whereas source Lemma III.7
     % uses the preceding MPU and canonical-form-II convention. Documented in
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv}
+    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpu_weighted_source_factors}
     Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+    dimension $D>0$. Let $\rho$ satisfy $\tr(\rho)=1$, put
     $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    some $J$ the normalized transfer matrix satisfies
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
     \end{align}
-    Let $r$ and $\ell$ be the two source-cut ranks, and construct the source
-    factors and $u$ from $\mathcal U$ using $\rho$. Then
+    Let $r$ and $\ell$ be the two source-cut ranks, let $M_i=X_iY_i$ be
+    source factorizations for $\mathcal U$ and the weight $\rho^{\mathsf T}$,
+    and let $u=Y_2\mathbin{-}Y_1$. Then
     \begin{align}
         u^\dagger u & =\Id.
     \end{align}
-    Consequently $u$ is an isometry and $r\ell\geq d^2$. This is the
-    reduced-source version of \cite[Lemma~III.7]{Cirac2017MPU}.
+    Consequently $u$ is an isometry and $r\ell\geq d^2$. In particular the
+    compact-SVD gate $u$ for the positive definite weight $\rho^{\mathsf T}$
+    is an isometry when $\rho>0$. This is the reduced-source version of
+    \cite[Lemma~III.7]{Cirac2017MPU}; the weight $\rho^{\mathsf T}$ is
+    explained in Lemma~\ref{lem:mpu_source_u_retained_interior}.
     % Source lines: paper_v2.tex 545--557.
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
     \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_input_tail_isometry}
     Set $K=JD^2$. The complete-network identity and input-first MPU unitarity
     give, for all retained physical pairs $p,q$,
@@ -5180,7 +5228,33 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         U^{(K+2)}_{\eta,(q,\tau)}  \\
          & =\delta_{p,q}.
     \end{align}
-    Hence $u^\dagger u=\Id$.
+    Hence $u^\dagger u=\Id$. Since $u$ maps a space of dimension $d^2$
+    isometrically into a space of dimension $\ell r$, its rank is $d^2$ and
+    $d^2\le r\ell$.
+\end{proof}
+
+\begin{corollary}[Source-$u$ isometry from a reduced representative]
+    \label{cor:mpu_reduced_cfii_source_u_isometry}
+    \lean{MPOTensor.IsMPU.exists_sourceU_transpose_isIsometry_of_reduced_cfii}
+    \leanok
+    % **Scope restriction (full support):** the fixed pair is supplied by the
+    % chosen reduced canonical-form-II representative. Documented in
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
+    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:cpsv_cfii, def:mpu_full_support}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
+    dimension $D>1$, and choose canonical-form-II data for its normalized
+    flattening whose blocks fill the ambient bond space. Then there is a
+    positive definite $\rho$ with $\tr(\rho)=1$, fixed by the normalized
+    transfer map, such that the compact-SVD gate $u=Y_2\mathbin{-}Y_1$ for
+    the weight $\rho^{\mathsf T}$ satisfies $u^\dagger u=\Id$.
+    % Source lines: paper_v2.tex 545--557.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_reduced_cfii_transfer_stabilization, lem:mpu_admissible_source_u_isometry}
+    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization} supplies
+    $\rho$ with $E^{D^2-1}=\lvert\rho)(\Phi\rvert$, and
+    Lemma~\ref{lem:mpu_admissible_source_u_isometry} applies.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3236,10 +3236,39 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     precisely the simultaneous doubled-bond swap on the row and column.
 \end{proof}
 
+\begin{theorem}[Fixed pair of the simple block]
+    \label{thm:mpu_simple_block_fixed_pair}
+    \lean{MPOTensor.normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power}
+    \leanok
+    \uses{def:mpu_double_layer, def:mpdo_physical_blocking, def:mpu_normalized_flattening}
+    Let $\mathcal U$ be an MPO tensor with $d,D>0$, and write $E$ for the
+    transfer matrix of its normalized flattening.  Suppose that
+    $\tr(\rho)=1$ and that
+    \begin{align}
+        E^J=|\rho)(1|
+    \end{align}
+    for some $J$, and set $K=JD^2$.  Then the normalized diagonal $R_K$ of
+    the double layer of the $K$-site block of $\mathcal U$ satisfies
+    \begin{align}
+        R_K=|\rho)(1|,
+    \end{align}
+    where the rank-one operators use the column-stacking identification
+    $M_D(\mathbb C)\cong\mathbb C^{D^2}$.  This is the closed double layer
+    of the simple block in
+    \cite[equation~\texttt{Erightleft} and Proposition~\texttt{blockingsimple}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_blocked_double_layer_diagonal, thm:mpu_double_layer_blocking}
+    The blocked normalized diagonal is the transfer power
+    $E^K=(E^J)^{D^2}$.  Since $(1|\rho)=\tr(\rho)=1$, the rank-one matrix
+    $|\rho)(1|$ is idempotent, so the additional positive $D^2$ power
+    leaves it unchanged.
+\end{proof}
+
 \begin{theorem}[Reflected transfer-power identities]
     \label{thm:mpu_reflected_transfer_power}
-    \lean{MPOTensor.normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power,
-        MPOTensor.conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec,
+    \lean{MPOTensor.conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec,
         MPOTensor.reflected_transfer_power_eq_vecMulVec_transpose,
         MPOTensor.conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec,
         MPOTensor.outputLayer_normalizedDiagonal_pow_eq_vecMulVec}
@@ -3259,13 +3288,11 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     No MPU, positivity, trace, positive bond-dimension, or positivity of $J$
     is needed for this implication.
 
-    Suppose in addition that $D>0$ and $\tr(\rho)=1$, and set $K=JD^2$.
-    Then the normalized diagonal $R_K$ of the double layer of the $K$-site
-    block of $\mathcal U$ satisfies
-    \begin{align}
-        R_K=|\rho)(1|.
-    \end{align}
-    More generally, if $d>0$, $\rho>0$, and the normalized diagonal $R_L$ of
+    Suppose in addition that $D>0$ and $\tr(\rho)=1$, and set $K=JD^2$, so
+    that the normalized diagonal $R_K$ of the double layer of the $K$-site
+    block of $\mathcal U$ is $|\rho)(1|$ by
+    Theorem~\ref{thm:mpu_simple_block_fixed_pair}.
+    If $d>0$, $\rho>0$, and the normalized diagonal $R_L$ of
     an $L$-site block satisfies $R_L=|\rho)(1|$, write $R_L^\sharp$ for the
     normalized diagonal of the corresponding block of $\mathcal U^\sharp$.
     Then
@@ -3283,14 +3310,14 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_blocked_double_layer_diagonal, thm:mpu_double_layer_blocking, thm:mpu_reflected_normalized_diagonal}
+    \uses{thm:mpu_blocked_double_layer_diagonal, thm:mpu_double_layer_blocking, thm:mpu_reflected_normalized_diagonal, thm:mpu_simple_block_fixed_pair}
     The blocked normalized diagonal is the corresponding transfer power.
     Reindex the reflected diagonal by the doubled-bond swap to obtain the
     transpose weight.  When $\rho$ is positive definite, its Hermitian
     symmetry converts the conjugate-transposed reflected diagonal to
-    $|1)(\rho|$.  The trace-one condition makes $|\rho)(1|$ idempotent, so the
-    additional positive $D^2$ power leaves it unchanged.  Conjugating once
-    more gives the stated output-layer orientation.
+    $|1)(\rho|$.  Theorem~\ref{thm:mpu_simple_block_fixed_pair} supplies
+    $R_K=|\rho)(1|$ for the $K$-site block.  Conjugating once more gives
+    the stated output-layer orientation.
 \end{proof}
 
 \begin{theorem}[Reflected supplied contractions]
@@ -5057,8 +5084,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $\lvert\rho)$ stacks columns: both insert the coefficient
     $\rho_{\beta'\beta}$ between the conjugated leg $\beta$ and the
     unconjugated leg $\beta'$. For the diagonal fixed point of canonical
-    form II this is the weight $\rho$ of equation \texttt{X1X2b} in
-    \cite{Cirac2017MPU}.
+    form II this is the weight $\rho$ of
+    \cite[equation~\texttt{X1X2b}]{Cirac2017MPU}.
     % Source locator: paper_v2.tex, equation uUnitary and lines 545--557.
     % Orientation: docs/paper-gaps/mpu_source_cut_orientation.tex.
 \end{lemma}
@@ -5107,11 +5134,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_source_u_retained_interior, thm:mpu_normalized_input_tail_closed_trace, thm:mpu_reflected_transfer_power}
+    \uses{lem:mpu_source_u_retained_interior, thm:mpu_normalized_input_tail_closed_trace, thm:mpu_simple_block_fixed_pair}
     Theorem~\ref{thm:mpu_normalized_input_tail_closed_trace} writes the
     right-hand side as $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$. Since $(\Phi|\rho)=\tr(\rho)=1$, the
     rank-one matrix $\lvert\rho)(\Phi\rvert$ is idempotent, so
-    Theorem~\ref{thm:mpu_reflected_transfer_power} gives
+    Theorem~\ref{thm:mpu_simple_block_fixed_pair} gives
     $E^K=(E^J)^{D^2}=\lvert\rho)(\Phi\rvert$ for the closed double layer of
     the interior block of length $K=JD^2$.
     Lemma~\ref{lem:mpu_source_u_retained_interior} then identifies the Gram

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -102,6 +102,53 @@ The contractions $Y_1$--$X_2$ and $X_1$--$Y_2$ remain useful auxiliary
 kernels, but they are not the gates $u$ and $v$. Treating either mixed kernel
 as a paper gate produces the wrong physical and auxiliary leg assignment.
 
+\section{Orientation of the source weight}
+
+Equation \texttt{X1X2b} of Ref.~\cite{Cirac2017MPU} normalizes the first cut
+by $X_1^\dagger(\operatorname{Id}_d\otimes\rho)X_1=\operatorname{Id}$, where
+$\rho$ is the right fixed point of the transfer matrix. The source takes
+$\rho$ diagonal, so it never distinguishes $\rho$ from $\rho^{\mathsf T}$; a
+general positive definite fixed point does. Two readings of the same matrix
+occur in the network of Lemma~\texttt{lemuisometry}.
+
+In the weight $\operatorname{Id}_d\otimes\rho$, the row $(i,\beta)$ of $X_1$
+carries the right leg of the conjugated tensor and the column $(i,\beta')$
+carries the right leg of the unconjugated tensor, so the Gram matrix of
+$u=Y_2\mathbin{-}Y_1$ inserts $\rho_{\beta\beta'}$ between the conjugated leg
+$\beta$ and the unconjugated leg $\beta'$
+(\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_staggered_four_u}).
+
+The transfer matrix of the normalized flattening acts on column-stacked
+vectors, $\lvert\rho)_{(\beta,\beta')}=\rho_{\beta'\beta}$, and the doubled
+bond of the double layer lists the conjugated leg first. Hence the right
+fixed vector $E^J\lvert\rho)=\lvert\rho)$ inserts $\rho_{\beta'\beta}$
+between the conjugated leg $\beta$ and the unconjugated leg $\beta'$.
+
+The two insertions agree exactly when the weight of \texttt{X1X2b} is the
+transpose of the column-stacked fixed point. With the weight $\rho$ itself,
+the Gram matrix of $u$ is $(\Phi\rvert W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})$,
+and $\lvert\rho^{\mathsf T})$ is not a fixed vector of $E$ in general; a
+gauge-transformed right shift with a complex gauge gives $u^\dagger u\neq\operatorname{Id}$
+for that pairing. The correct pairing is therefore
+\begin{align}
+    E^J & =\lvert\rho)(\Phi\rvert,
+        & X_1^\dagger(\operatorname{Id}_d\otimes\rho^{\mathsf T})X_1
+        & =\operatorname{Id}_r,
+    \label{eq:mpu_source_cut_orientation_weight_pairing}
+\end{align}
+and every source-$u$ statement built on a supplied fixed pair takes the
+source factors for the weight $\rho^{\mathsf T}$:
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace},
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail},
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU}, and
+\leanid{MPOTensor.IsMPU.sourceU_transpose_isIsometry}. For the diagonal fixed
+point of canonical form II, $\rho^{\mathsf T}=\rho$ and
+Eq.~\ref{eq:mpu_source_cut_orientation_weight_pairing} is the printed
+convention. The source-$v$ dressing
+\leanid{MPOTensor.sourceYTensor_gram_eq_four_u_weighted} inserts the weight
+in the same conjugated-first order, so the same pairing applies to the
+equivalence labelled \texttt{vUnitary}.
+
 \section{Affected claims and audit boundary}
 
 The transposed first cut affected source-factor recovery, physical adjunction,
@@ -126,9 +173,12 @@ The former definition of $M_1$ was the transpose of the source diagram. The
 correction changes no source rank, but it changes the typed source factors and
 all order-sensitive contractions. The first cut, weight, adjunction identities,
 paper gates, two-site factorizations, tensor products, and shift examples now
-use one consistent leg assignment. The correction is resolved, while the
-revalidation rule remains applicable to any future recovery of source-gate
-work predating this audit.
+use one consistent leg assignment. The weight of the first cut is the
+transpose of the column-stacked transfer fixed point, which is invisible for
+the diagonal fixed point of the source and load-bearing for a general
+positive definite one. The correction is resolved, while the revalidation
+rule remains applicable to any future recovery of source-gate work predating
+this audit.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -127,9 +127,18 @@ between the conjugated leg $\beta$ and the unconjugated leg $\beta'$.
 The two insertions agree exactly when the weight of \texttt{X1X2b} is the
 transpose of the column-stacked fixed point. With the weight $\rho$ itself,
 the Gram matrix of $u$ is $(\Phi\rvert W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})$,
-and $\lvert\rho^{\mathsf T})$ is not a fixed vector of $E$ in general; a
-gauge-transformed right shift with a complex gauge gives $u^\dagger u\neq\operatorname{Id}$
-for that pairing. The correct pairing is therefore
+and $\lvert\rho^{\mathsf T})$ is not a fixed vector of $E$ in general. A
+witness must satisfy the fixed-pair hypothesis with $(\Phi\rvert=(1\rvert$
+and have a right fixed point that is not symmetric. A gauge-transformed
+shift is not such a witness: $(\Phi\rvert=(1\rvert$ forces its gauge to be
+unitary up to a scalar, and then $\rho$ is a multiple of the identity, so
+both pairings coincide. A two-layer brickwork unitary circuit with $d=4$
+and $D=4$, brought to the gauge $\Phi=\operatorname{Id}$ and then conjugated
+by a complex unitary, has $\lVert\rho-\rho^{\mathsf T}\rVert\approx0.73$;
+its source factors for the weight $\rho$ give
+$\lVert u^\dagger u-\operatorname{Id}\rVert\approx0.22$, while the weight
+$\rho^{\mathsf T}$ gives $u^\dagger u=\operatorname{Id}$ to machine
+precision. The correct pairing is therefore
 \begin{align}
     E^J & =\lvert\rho)(\Phi\rvert,
         & X_1^\dagger(\operatorname{Id}_d\otimes\rho^{\mathsf T})X_1


### PR DESCRIPTION
## Summary

Closes #7633 and Closes #5982.

Source: `Papers/1703.09188/paper_v2.tex`, equations `X1X2b`, `uuvv`, `uu`, `uUnitary`, and Lemma `lemuisometry` (lines 487--557). The paper's proof of $u^\dagger u=\mathrm{Id}$ closes the staggered source-$u$ network with the fixed pair of a simple $k$-site block and reads off $d^{-k}\operatorname{tr}_{1..k}[U^{(k+2)\dagger}U^{(k+2)}]=\mathrm{Id}$.

### The retained-window gluing (#7633)

The open step was
`trace (W p.2 q.2 * vecMulVec ρT Φ * W p.1 q.1) = trace (W p.1 q.1 * W p.2 q.2 * normalizedDiagonal W ^ K)` with `ρT x = ρ.transpose.vec (finProdFinEquiv.symm x)`. The $\rho^{\mathsf T}$ is not an obstacle to be removed by further reflected or mixed-kernel apparatus; it is a coordinate fact about which matrix represents the right fixed point:

- The weight $\mathrm{Id}_d\otimes\rho$ of `X1X2b` inserts $\rho_{\beta\beta'}$ between the **conjugated** right leg $\beta$ and the unconjugated leg $\beta'$ (`sourceU_gram_eq_staggered_four_u`).
- The transfer matrix acts on column-stacked vectors, $|\rho)_{(\beta,\beta')}=\rho_{\beta'\beta}$, and the doubled bond of the double layer lists the conjugated leg first; so $E^J|\rho)=|\rho)$ inserts $\rho_{\beta'\beta}$ at the same pair of legs.

Hence the source factors must be taken for the weight $\rho^{\mathsf T}$ whenever $E^J=|\rho)(\Phi|$ is stated for the column-stacked $\rho$; the paper's diagonal canonical-form-II fixed point has $\rho^{\mathsf T}=\rho$, so this is the printed convention. With `S : SourceFactors U ρ.transpose`, the existing `sourceU_gram_eq_transpose_fixed_pair_trace` produces exactly $|\rho)(\Phi|$ in the double-layer coordinates, and the gluing is `Matrix.transpose_transpose`, one rewrite with $E^K=|\rho)(\Phi|$, and `Matrix.trace_mul_cycle`.

**Upstream orientation report.** The pairing "source factors for $\rho$ together with $E^J=|\rho)(\Phi|$", as previously written in the blueprint statements of `thm:mpu_source_u_complete_network`, `lem:mpu_admissible_source_u_isometry`, and `thm:mpu_source_v_complete_reduced_contraction`, is wrong for a non-symmetric positive definite $\rho$. A witness has to satisfy the fixed-pair hypothesis with $(\Phi|=(1|$ and have a non-symmetric $\rho$; a gauge-transformed shift is not one ($(\Phi|=(1|$ forces its gauge to be unitary up to scale, and then $\rho$ is a multiple of the identity, so both pairings coincide). A two-layer brickwork unitary circuit ($d=4$, $D=4$) brought to the gauge $\Phi=\mathrm{Id}$ and then conjugated by a complex Haar unitary has $\lVert\rho-\rho^{\mathsf T}\rVert\approx0.73$; its source factors for the weight $\rho$ give $\lVert u^\dagger u-\mathrm{Id}\rVert\approx0.22$, while the weight $\rho^{\mathsf T}$ gives the identity to machine precision. This is why PR #7641 got stuck at `ρT` versus `ρ'`. No Lean declaration on `main` asserts the wrong pairing; the blueprint statements are corrected here, and the source-$v$ node (sibling-owned, `\notready`) inserts the weight in the same conjugated-first order and needs the same $\rho^{\mathsf T}$ reading (`sourceYTensor_gram_eq_four_u_weighted`). Documented in `docs/paper-gaps/mpu_source_cut_orientation.tex`, new section "Orientation of the source weight".

### New declarations (`TNLean/MPS/MPU/SourceUCompleteNetwork.lean`)

- `SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace` — retained-interior contraction: given $E^K=|\rho)(\Phi|$ in double-layer coordinates and source factors for $\rho^{\mathsf T}$, the Gram of $u$ equals $\operatorname{tr}(W^{p_1q_1}W^{p_2q_2}E^K)$ with both endpoint letters unblocked (#7633).
- `SourceFactors.sourceU_gram_eq_normalized_input_tail` — the complete source-$u$ network: Gram of $u$ $=d^{-K}\sum_{\tau,\eta}\overline{U^{(K+2)}_{\eta,(p,\tau)}}U^{(K+2)}_{\eta,(q,\tau)}$ with $K=JD^2$ from $E^J=|\rho)(\Phi|$, $\operatorname{tr}\rho=1$ (`thm:mpu_source_u_complete_network`, #5982).
- `SourceFactors.sourceU_isIsometry_of_isMPU`, `SourceFactors.mul_self_le_leftRank_mul_rightRank_of_isMPU` — $u^\dagger u=\mathrm{Id}$ via `IsMPU.normalized_mpo_tail_isometry`, hence $d^2\le\ell r$ via `Matrix.IsIsometry.card_le` (`lem:mpu_admissible_source_u_isometry`).
- `IsMPU.sourceU_transpose_isIsometry` — the compact-SVD gate for weight $\rho^{\mathsf T}$.
- `IsMPU.exists_sourceU_transpose_isIsometry_of_reduced_cfii` — from a reduced full-support canonical-form-II representative (`cor:mpu_reduced_cfii_source_u_isometry`, scope restriction documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`).

`normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power` moved unchanged from `ReflectedTransferKernel.lean` to `MatchingContractions.lean`: it is not a reflected statement and is the fixed pair of the simple $JD^2$ block used here. In the blueprint it now has its own node `thm:mpu_simple_block_fixed_pair` instead of sitting under the reflected transfer-power heading. The module docstring of `MatchingContractions.lean` no longer says the source-$u$ route is unformalized.

The right-shift regression asked for in #5982 already exists on `main` (`sourceU_rightShiftPaperSourceFactors_isIsometry`, weight $\rho=\mathrm{Id}/d$, which is transpose-invariant).

### Blueprint (`blueprint/src/chapter/ch28_mpu.tex`)

- New `lem:mpu_source_u_retained_interior` (`\leanok`).
- New `thm:mpu_simple_block_fixed_pair` (`\leanok`) for the moved declaration; `thm:mpu_reflected_transfer_power` and the proof of `thm:mpu_source_u_complete_network` reference it.
- `thm:mpu_source_u_complete_network` and `lem:mpu_admissible_source_u_isometry` restated with the weight $\rho^{\mathsf T}$ and marked `\leanok`; the positivity of $\rho$ and $J>0$ were not needed and are dropped from the statements.
- New `cor:mpu_reduced_cfii_source_u_isometry` (`\leanok`, scope restriction in a comment).
- `lemuisometry` (unrestricted, canonical-form-II convention) stays `\notready` per the faithfulness rule; its comment points to the checked admissible lemma.

Supersedes the open partial PR #7641.

### Review follow-up (b0500f807)

- `SourceUCompleteNetwork.lean` module docstring carries a consolidated `**Scope restriction (supplied stabilized fixed pair):**` marker naming the four declarations that take $E^J=|\rho)(\Phi|$ as an explicit hypothesis (`docs/paper-gaps/mpu_canonical_form_full_support.tex`).
- `sourceU_gram_eq_closed_doubleLayer_trace` and `sourceU_isIsometry_of_isMPU` are spelled `lemma`, matching their `\begin{lemma}` entries.
- The `\notready` nodes `thm:mpu_source_v_complete_reduced_contraction` and `thm:mpu_admissible_simple_tensor_equivalence` now state the weight $\rho^{\mathsf T}$.

## Validation (run in the worktree)

- `scripts/lake_build_locked.sh TNLean.MPS.MPU.MatchingContractions TNLean.MPS.MPU.ReflectedTransferKernel TNLean.MPS.MPU.SourceUCompleteNetwork` (no warnings in changed modules)
- `scripts/lake_build_locked.sh TNLean.MPS.MPU` (9304 jobs)
- `rg -n "sorry|axiom|admit|native_decide"` on the three changed Lean files: none
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 | xargs -0 chktex -q -l blueprint/.chktexrc` (exit 0)
- `scripts/latexindent -w -s -l blueprint/latexindent.yaml` on a copy of `ch28_mpu.tex`, byte-identical to the source
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` and `--ci` (in sync)
- `scripts/lake_build_locked.sh -- lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `python3 scripts/tactic_pattern_scan.py` (no new candidates in the changed files)
- `python3 scripts/test_lean_file_policies.py` (16 tests OK)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR

