### PR TITLE
feat(QCA): prove two-site translation covariance of the support algebras

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -35,6 +35,7 @@ import TNLean.QCA.RegionSumset
 import TNLean.QCA.RelativeCommutant
 import TNLean.QCA.SiteIndexedSupportAlgebra
 import TNLean.QCA.SupportAlgebraCommutation
+import TNLean.QCA.SupportAlgebraCovariance
 import TNLean.QCA.SupportAlgebraGeneration
 import TNLean.QCA.Translation
 import TNLean.QCA.TranslationCovariance

--- a/TNLean/QCA/SupportAlgebraCovariance.lean
+++ b/TNLean/QCA/SupportAlgebraCovariance.lean
@@ -48,10 +48,12 @@ not assumed translation covariant, so the theorems below are not covariance theo
 paper: covariance under translation of the support algebras is supplied by Schumacher--Werner,
 quant-ph/0405174, lines 1199--1206 and 1218--1226, and the translation-covariant fixed-\(d\)
 setting by Cirac et al., arXiv:1703.09188, lines 2292--2298. Schumacher--Werner state the
-translated-support identity for the cube lattice of an arbitrary dimension with a general
-neighbourhood scheme, quant-ph/0405174, lines 309--318 and 928--941; the theorems below are its
-one-dimensional nearest-neighbour instance. See
-[the homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
+translated-support identity for the cube lattice in arbitrary dimension with the cubic
+nearest-neighbour scheme, quant-ph/0405174, lines 920--941; the theorems below are its
+one-dimensional instance. See the
+[Schumacher--Werner covariance scope note](https://sirui-lu.com/TNLean/paper-gaps/sw04_support_covariance_scope.pdf)
+and the
+[homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
 
 No commutation theorem, matrix-factor classification, adjacent-block generation equality, or
 index is proved here.

--- a/TNLean/QCA/SupportAlgebraCovariance.lean
+++ b/TNLean/QCA/SupportAlgebraCovariance.lean
@@ -1,0 +1,567 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.SiteIndexedSupportAlgebra
+
+/-!
+# Two-site translation covariance of the site-indexed support algebras
+
+For a translation-covariant star-automorphism of the homogeneous quasi-local observable algebra
+with nearest-neighbour propagation, the site-indexed support algebras
+\((\mathcal R_y)_{y\in\mathbb Z}\) of `TNLean.QCA.SiteIndexedSupportAlgebra` satisfy
+\[
+  \tau_2(\mathcal R_y)=\mathcal R_{y+2},
+\]
+where \(\tau_2\) is translation by two sites of the original chain, that is, by one blocked cell.
+In the two parities this reads
+\[
+  \tau_2(\mathcal R_{2x})=\mathcal R_{2x+2},\qquad
+  \tau_2(\mathcal R_{2x+1})=\mathcal R_{2x+3}.
+\]
+Translation covariance is used only here; the construction of the family itself uses the
+star-automorphism and its propagation region alone.
+
+The corresponding one-site formula \(\tau_1(\mathcal R_y)=\mathcal R_{y+1}\) is false in general
+and is not asserted anywhere in this file: the even source pair \(E_x=\{2x,2x+1\}\) is carried to
+\(E_{x+1}\) by translation by two, while translation by one does not preserve the even pairing at
+all. Gross--Nesme--Vogts--Werner give the shift automorphism as an explicit counterexample at
+arXiv:0910.3675v2, lines 1267--1268: there the even algebra is a two-site full matrix algebra
+while the odd algebra is the scalars, and no translation carries one onto the other. That example
+repeats the even subscript on line 1268 where the odd one is meant; the intended reading is used
+in this sentence only, and no declaration below refers to the example.
+
+The proof replaces the finite matrix coefficients by their quasi-local compressions. Writing
+\(\Gamma\) and \(\Delta\) for the two ordered target regions, the left coefficient of an element
+\(V\) of the image algebra at a pair of \(\Delta\)-configurations is
+\[
+  \sum_{k}\, e_{k i}^{\Delta}\, V\, e_{j k}^{\Delta},
+\]
+a sum of products taken entirely inside the quasi-local algebra. Both matrix coefficient families
+therefore become families of quasi-local elements to which lattice translation applies directly.
+
+**Scope restriction (homogeneous chain):** as in `TNLean.QCA.SiteIndexedSupportAlgebra`, the
+one-site matrix size is the fixed positive size \(d\) of the present quasi-local algebra, whereas
+Gross--Nesme--Vogts--Werner allow it to depend on the site. Their cellular automata are moreover
+not assumed translation covariant, so the theorems below are not covariance theorems of that
+paper: covariance under translation of the support algebras is supplied by Schumacher--Werner,
+quant-ph/0405174, lines 1199--1206 and 1218--1226, and the translation-covariant fixed-\(d\)
+setting by Cirac et al., arXiv:1703.09188, lines 2292--2298. Schumacher--Werner state the
+translated-support identity for the cube lattice of an arbitrary dimension with a general
+neighbourhood scheme, quant-ph/0405174, lines 309--318 and 928--941; the theorems below are its
+one-dimensional nearest-neighbour instance. See
+[the homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).
+
+No commutation theorem, matrix-factor classification, adjacent-block generation equality, or
+index is proved here.
+
+## Main results
+
+* `Matrix.leftKroneckerEmbed_bipartiteSlice_eq_sum` and
+  `Matrix.rightKroneckerEmbed_operatorBlock_eq_sum` express a matrix coefficient of a bipartite
+  matrix through compressions by matrix units of the complementary factor.
+* `SpinChain.matrixToQuasiLocalObservable_bipartiteSlice_eq_sum` and
+  `SpinChain.matrixToQuasiLocalObservable_operatorBlock_eq_sum` are the quasi-local forms of
+  those two expressions.
+* `SpinChain.translateRegion_evenPair`, `SpinChain.translateRegion_leftPair`, and
+  `SpinChain.translateRegion_rightPair` translate the three two-site regions by two sites.
+* `SpinChain.PropagatesWithin.embeddedEvenSupportAlgebra_map_quasiLocalTranslation_two` and
+  `SpinChain.PropagatesWithin.embeddedOddSupportAlgebra_map_quasiLocalTranslation_two` are the two
+  parity formulas.
+* `SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two` is the unified
+  formula \(\tau_2(\mathcal R_y)=\mathcal R_{y+2}\).
+
+## References
+
+* Schumacher--Werner, quant-ph/0405174, definition `defBBq`, lines 1199--1206, and the
+  translated-support calculation, lines 1218--1226.
+* Gross--Nesme--Vogts--Werner, arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266, and the shift
+  example, lines 1267--1268.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, lines 2292--2298 and 2313--2328.
+-/
+
+open scoped BigOperators Kronecker
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+
+/-- A first-factor coefficient of a bipartite matrix, tensored with the identity of the second
+factor, is the sum of the compressions of that matrix by the matrix units of the second factor:
+\[
+  X_{ij}\otimes\mathbf 1=\sum_k(\mathbf 1\otimes e_{ki})\,X\,(\mathbf 1\otimes e_{jk}).
+\]
+
+This is the coefficient family of Schumacher--Werner, quant-ph/0405174, lines 1137--1169,
+rewritten so that each coefficient is a sum of products inside the ambient algebra. Neither that
+paper nor GNVW, arXiv:0910.3675v2, lines 1188--1191, displays the identity separately. -/
+theorem leftKroneckerEmbed_bipartiteSlice_eq_sum
+    (X : Matrix (m × n) (m × n) ℂ) (i j : n) :
+    leftKroneckerEmbed (n := n) (bipartiteSlice X i j) =
+      ∑ k : n, rightKroneckerEmbed (m := m) (single k i (1 : ℂ)) * X *
+        rightKroneckerEmbed (m := m) (single j k (1 : ℂ)) := by
+  ext p q
+  obtain ⟨a, u⟩ := p
+  obtain ⟨b, v⟩ := q
+  rw [Matrix.sum_apply]
+  simp only [leftKroneckerEmbed_apply, rightKroneckerEmbed_apply, Matrix.mul_apply,
+    Matrix.kroneckerMap_apply, Fintype.sum_prod_type, Matrix.one_apply, Matrix.single_apply,
+    bipartiteSlice_apply]
+  simp [ite_and, eq_comm, mul_comm]
+
+/-- A second-factor coefficient of a bipartite matrix, tensored with the identity of the first
+factor, is the sum of the compressions of that matrix by the matrix units of the first factor:
+\[
+  \mathbf 1\otimes X_{ij}=\sum_k(e_{ki}\otimes\mathbf 1)\,X\,(e_{jk}\otimes\mathbf 1).
+\]
+
+This is the symmetric counterpart of `Matrix.leftKroneckerEmbed_bipartiteSlice_eq_sum` for the
+coefficient family of GNVW, arXiv:0910.3675v2, lines 1211--1219. -/
+theorem rightKroneckerEmbed_operatorBlock_eq_sum
+    (X : Matrix (m × n) (m × n) ℂ) (i j : m) :
+    rightKroneckerEmbed (m := m) (operatorBlock X i j) =
+      ∑ k : m, leftKroneckerEmbed (n := n) (single k i (1 : ℂ)) * X *
+        leftKroneckerEmbed (n := n) (single j k (1 : ℂ)) := by
+  ext p q
+  obtain ⟨a, u⟩ := p
+  obtain ⟨b, v⟩ := q
+  rw [Matrix.sum_apply]
+  simp only [leftKroneckerEmbed_apply, rightKroneckerEmbed_apply, Matrix.mul_apply,
+    Matrix.kroneckerMap_apply, Fintype.sum_prod_type, Matrix.one_apply, Matrix.single_apply,
+    operatorBlock_apply]
+  simp [ite_and, eq_comm, mul_comm]
+
+end Matrix
+
+namespace SpinChain
+
+/-! ### Translation of the three two-site regions -/
+
+/-- Translating the even source pair by two sites advances its index:
+\(E_x+2=E_{x+1}\).
+
+Source context: this is the blocked-cell shift used by GNVW, arXiv:0910.3675v2,
+lines 1251--1266, and by Cirac et al., arXiv:1703.09188, lines 2313--2318. -/
+lemma translateRegion_evenPair (x : ℤ) :
+    translateRegion 2 (evenPair x) = evenPair (x + 1) := by
+  ext y
+  simp only [mem_translateRegion, evenPair, Finset.mem_insert, Finset.mem_singleton]
+  omega
+
+/-- Translating the left target pair by two sites advances its index:
+\(L_x+2=L_{x+1}\).
+
+Source context: GNVW, arXiv:0910.3675v2, lines 1251--1266. -/
+lemma translateRegion_leftPair (x : ℤ) :
+    translateRegion 2 (leftPair x) = leftPair (x + 1) := by
+  ext y
+  simp only [mem_translateRegion, leftPair, Finset.mem_insert, Finset.mem_singleton]
+  omega
+
+/-- Translating the right target pair by two sites advances its index:
+\(P_x+2=P_{x+1}\).
+
+Source context: GNVW, arXiv:0910.3675v2, lines 1251--1266. -/
+lemma translateRegion_rightPair (x : ℤ) :
+    translateRegion 2 (rightPair x) = rightPair (x + 1) := by
+  ext y
+  simp only [mem_translateRegion, rightPair, Finset.mem_insert, Finset.mem_singleton]
+  omega
+
+/-! ### Quasi-local compressions of the matrix coefficients -/
+
+variable {d : ℕ} [NeZero d]
+
+/-- Transporting a finite-region observable along an equality of regions does not change the
+quasi-local observable it represents. -/
+private lemma quasiLocalObservable_cast {U V : Finset ℤ} (h : U = V) (A : LocalAlgebra d U) :
+    quasiLocalObservable d V (h ▸ A) = quasiLocalObservable d U A := by
+  subst h
+  rfl
+
+omit [NeZero d] in
+/-- Reading the left Kronecker embedding back in the observable algebra of the union gives the
+canonical inclusion from the first region. -/
+private lemma bipartiteLocalAlgebraEquiv_symm_leftKroneckerEmbed {Γ Δ : Finset ℤ}
+    (hΓΔ : Disjoint Γ Δ) (M : Matrix (Config d Γ) (Config d Γ) ℂ) :
+    (bipartiteLocalAlgebraEquiv hΓΔ).symm (Matrix.leftKroneckerEmbed M) =
+      localInclusion (d := d) Finset.subset_union_left
+        (CStarMatrix.ofMatrixStarAlgEquiv M) := by
+  rw [StarAlgEquiv.symm_apply_eq]
+  exact (bipartiteLocalAlgebraEquiv_localInclusion_left hΓΔ
+    (CStarMatrix.ofMatrixStarAlgEquiv M)).symm
+
+omit [NeZero d] in
+/-- Reading the right Kronecker embedding back in the observable algebra of the union gives the
+canonical inclusion from the second region. -/
+private lemma bipartiteLocalAlgebraEquiv_symm_rightKroneckerEmbed {Γ Δ : Finset ℤ}
+    (hΓΔ : Disjoint Γ Δ) (M : Matrix (Config d Δ) (Config d Δ) ℂ) :
+    (bipartiteLocalAlgebraEquiv hΓΔ).symm (Matrix.rightKroneckerEmbed M) =
+      localInclusion (d := d) Finset.subset_union_right
+        (CStarMatrix.ofMatrixStarAlgEquiv M) := by
+  rw [StarAlgEquiv.symm_apply_eq]
+  exact (bipartiteLocalAlgebraEquiv_localInclusion_right hΓΔ
+    (CStarMatrix.ofMatrixStarAlgEquiv M)).symm
+
+/-- In bipartite coordinates for two disjoint regions, the canonical quasi-local copy of a
+first-factor matrix coefficient is a sum of compressions by matrix units of the second region.
+
+The first region supplies the left tensor factor and the second the right one, as in GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1249--1266. The identity itself is the quasi-local form
+of the coefficient family of Schumacher--Werner, quant-ph/0405174, lines 1137--1169; it is not
+displayed separately in either source. -/
+theorem matrixToQuasiLocalObservable_bipartiteSlice_eq_sum
+    {Γ Δ : Finset ℤ} (hΓΔ : Disjoint Γ Δ) (A : LocalAlgebra d (Γ ∪ Δ))
+    (i j : Config d Δ) :
+    matrixToQuasiLocalObservable d Γ
+        (Matrix.bipartiteSlice (bipartiteLocalAlgebraEquiv hΓΔ A) i j) =
+      ∑ k : Config d Δ,
+        matrixToQuasiLocalObservable d Δ (Matrix.single k i (1 : ℂ)) *
+          quasiLocalObservable d (Γ ∪ Δ) A *
+          matrixToQuasiLocalObservable d Δ (Matrix.single j k (1 : ℂ)) := by
+  have hlocal :
+      localInclusion (d := d) Finset.subset_union_left
+          (CStarMatrix.ofMatrixStarAlgEquiv
+            (Matrix.bipartiteSlice (bipartiteLocalAlgebraEquiv hΓΔ A) i j)) =
+        ∑ k : Config d Δ,
+          localInclusion (d := d) Finset.subset_union_right
+              (CStarMatrix.ofMatrixStarAlgEquiv (Matrix.single k i (1 : ℂ))) * A *
+            localInclusion (d := d) Finset.subset_union_right
+              (CStarMatrix.ofMatrixStarAlgEquiv (Matrix.single j k (1 : ℂ))) := by
+    rw [← bipartiteLocalAlgebraEquiv_symm_leftKroneckerEmbed hΓΔ,
+      Matrix.leftKroneckerEmbed_bipartiteSlice_eq_sum, map_sum]
+    refine Finset.sum_congr rfl fun k _ ↦ ?_
+    rw [map_mul, map_mul, bipartiteLocalAlgebraEquiv_symm_rightKroneckerEmbed,
+      bipartiteLocalAlgebraEquiv_symm_rightKroneckerEmbed, StarAlgEquiv.symm_apply_apply]
+  have hstart : matrixToQuasiLocalObservable d Γ
+      (Matrix.bipartiteSlice (bipartiteLocalAlgebraEquiv hΓΔ A) i j) =
+      quasiLocalObservable d Γ (CStarMatrix.ofMatrixStarAlgEquiv
+        (Matrix.bipartiteSlice (bipartiteLocalAlgebraEquiv hΓΔ A) i j)) := rfl
+  rw [hstart,
+    ← quasiLocalObservable_localInclusion d (show Γ ⊆ Γ ∪ Δ from Finset.subset_union_left),
+    hlocal, map_sum]
+  refine Finset.sum_congr rfl fun k _ ↦ ?_
+  rw [map_mul, map_mul, quasiLocalObservable_localInclusion,
+    quasiLocalObservable_localInclusion]
+  rfl
+
+/-- In bipartite coordinates for two disjoint regions, the canonical quasi-local copy of a
+second-factor matrix coefficient is a sum of compressions by matrix units of the first region.
+
+This is the symmetric counterpart of
+`SpinChain.matrixToQuasiLocalObservable_bipartiteSlice_eq_sum` for the coefficient family of GNVW,
+arXiv:0910.3675v2, lines 1211--1219. -/
+theorem matrixToQuasiLocalObservable_operatorBlock_eq_sum
+    {Γ Δ : Finset ℤ} (hΓΔ : Disjoint Γ Δ) (A : LocalAlgebra d (Γ ∪ Δ))
+    (i j : Config d Γ) :
+    matrixToQuasiLocalObservable d Δ
+        (Matrix.operatorBlock (bipartiteLocalAlgebraEquiv hΓΔ A) i j) =
+      ∑ k : Config d Γ,
+        matrixToQuasiLocalObservable d Γ (Matrix.single k i (1 : ℂ)) *
+          quasiLocalObservable d (Γ ∪ Δ) A *
+          matrixToQuasiLocalObservable d Γ (Matrix.single j k (1 : ℂ)) := by
+  have hlocal :
+      localInclusion (d := d) Finset.subset_union_right
+          (CStarMatrix.ofMatrixStarAlgEquiv
+            (Matrix.operatorBlock (bipartiteLocalAlgebraEquiv hΓΔ A) i j)) =
+        ∑ k : Config d Γ,
+          localInclusion (d := d) Finset.subset_union_left
+              (CStarMatrix.ofMatrixStarAlgEquiv (Matrix.single k i (1 : ℂ))) * A *
+            localInclusion (d := d) Finset.subset_union_left
+              (CStarMatrix.ofMatrixStarAlgEquiv (Matrix.single j k (1 : ℂ))) := by
+    rw [← bipartiteLocalAlgebraEquiv_symm_rightKroneckerEmbed hΓΔ,
+      Matrix.rightKroneckerEmbed_operatorBlock_eq_sum, map_sum]
+    refine Finset.sum_congr rfl fun k _ ↦ ?_
+    rw [map_mul, map_mul, bipartiteLocalAlgebraEquiv_symm_leftKroneckerEmbed,
+      bipartiteLocalAlgebraEquiv_symm_leftKroneckerEmbed, StarAlgEquiv.symm_apply_apply]
+  have hstart : matrixToQuasiLocalObservable d Δ
+      (Matrix.operatorBlock (bipartiteLocalAlgebraEquiv hΓΔ A) i j) =
+      quasiLocalObservable d Δ (CStarMatrix.ofMatrixStarAlgEquiv
+        (Matrix.operatorBlock (bipartiteLocalAlgebraEquiv hΓΔ A) i j)) := rfl
+  rw [hstart,
+    ← quasiLocalObservable_localInclusion d (show Δ ⊆ Γ ∪ Δ from Finset.subset_union_right),
+    hlocal, map_sum]
+  refine Finset.sum_congr rfl fun k _ ↦ ?_
+  rw [map_mul, map_mul, quasiLocalObservable_localInclusion,
+    quasiLocalObservable_localInclusion]
+  rfl
+
+/-- Translation of a quasi-local observable presented by an ordinary matrix in finite-region
+coordinates reindexes that matrix by the configuration translation. -/
+private lemma quasiLocalTranslation_matrixToQuasiLocalObservable (a : ℤ) (Θ : Finset ℤ)
+    (M : Matrix (Config d Θ) (Config d Θ) ℂ) :
+    quasiLocalTranslation d a (matrixToQuasiLocalObservable d Θ M) =
+      matrixToQuasiLocalObservable d (translateRegion a Θ)
+        (Matrix.reindex (Config.translation d a Θ) (Config.translation d a Θ) M) := by
+  rw [matrixToQuasiLocalObservable, StarAlgHom.comp_apply,
+    quasiLocalTranslation_quasiLocalObservable, matrixToQuasiLocalObservable,
+    StarAlgHom.comp_apply]
+  rfl
+
+/-- Translation of a quasi-local matrix unit in finite-region coordinates is the matrix unit at
+the translated configurations. -/
+private lemma quasiLocalTranslation_matrixToQuasiLocalObservable_single (a : ℤ) (Θ : Finset ℤ)
+    (p q : Config d Θ) :
+    quasiLocalTranslation d a (matrixToQuasiLocalObservable d Θ (Matrix.single p q (1 : ℂ))) =
+      matrixToQuasiLocalObservable d (translateRegion a Θ)
+        (Matrix.single (Config.translation d a Θ p) (Config.translation d a Θ q) (1 : ℂ)) := by
+  rw [quasiLocalTranslation_matrixToQuasiLocalObservable, Matrix.reindex_apply,
+    Matrix.submatrix_single_equiv, Equiv.symm_symm]
+
+/-! ### The quasi-local generator families -/
+
+namespace PropagatesWithin
+
+variable {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+
+/-- The compressions of the image of the observable algebra on a source region by the matrix
+units of a second region.
+
+Taking the second region to be the right target pair gives the generators of the even support
+algebra, and taking it to be the left target pair gives those of the odd support algebra. The
+remaining target region never enters. -/
+private noncomputable def compressionGenerators
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) (Λ Θ : Finset ℤ) :
+    Set (QuasiLocalAlgebra d) :=
+  {g | ∃ (B : LocalAlgebra d Λ) (i j : Config d Θ),
+    g = ∑ k : Config d Θ,
+      matrixToQuasiLocalObservable d Θ (Matrix.single k i (1 : ℂ)) *
+        ω (quasiLocalObservable d Λ B) *
+        matrixToQuasiLocalObservable d Θ (Matrix.single j k (1 : ℂ))}
+
+/-- The transported finite local image consists of the finite-region observables whose quasi-local
+copies are the images of the source observable algebra. -/
+private lemma mem_localRestrictionRange_cast (hω : PropagatesWithin ω 𝓝) {Λ U : Finset ℤ}
+    (h : regionSumset Λ 𝓝 = U) (A : LocalAlgebra d U) :
+    A ∈ h ▸ hω.localRestrictionRange Λ ↔
+      ∃ B : LocalAlgebra d Λ,
+        ω (quasiLocalObservable d Λ B) = quasiLocalObservable d U A := by
+  subst h
+  have hmem : A ∈ hω.localRestrictionRange Λ ↔
+      ∃ B : LocalAlgebra d Λ, hω.localRestriction Λ B = A := Iff.rfl
+  rw [hmem]
+  constructor
+  · rintro ⟨B, rfl⟩
+    exact ⟨B, (hω.quasiLocalObservable_localRestriction Λ B).symm⟩
+  · rintro ⟨B, hB⟩
+    refine ⟨B, ?_⟩
+    apply quasiLocalObservable_injective d (regionSumset Λ 𝓝)
+    rw [hω.quasiLocalObservable_localRestriction, hB]
+
+/-- The canonical quasi-local copy of the left support algebra is generated by the quasi-local
+compressions of the first-factor coefficients. -/
+private theorem map_leftSupportAlgebra_eq_adjoin (hω : PropagatesWithin ω 𝓝)
+    (Λ Γ Δ : Finset ℤ) (hΓΔ : Disjoint Γ Δ) (htarget : regionSumset Λ 𝓝 = Γ ∪ Δ) :
+    (Matrix.leftSupportAlgebra (hω.bipartiteLocalRestrictionRange Λ Γ Δ hΓΔ htarget)).map
+        (matrixToQuasiLocalObservable d Γ) =
+      StarAlgebra.adjoin ℂ (compressionGenerators ω Λ Δ) := by
+  rw [Matrix.leftSupportAlgebra, StarAlgHom.map_adjoin]
+  congr 1
+  ext g
+  simp only [Set.mem_image, Matrix.leftCoefficientSet, Set.mem_ofPred_eq,
+    compressionGenerators, bipartiteLocalRestrictionRange, StarSubalgebra.bipartiteReindex,
+    StarSubalgebra.mem_map]
+  constructor
+  · rintro ⟨M, ⟨X, ⟨A, hA, rfl⟩, i, j, rfl⟩, rfl⟩
+    obtain ⟨B, hB⟩ := (hω.mem_localRestrictionRange_cast htarget A).mp hA
+    refine ⟨B, i, j, ?_⟩
+    rw [show (bipartiteLocalAlgebraEquiv hΓΔ).toStarAlgHom A =
+      bipartiteLocalAlgebraEquiv hΓΔ A from rfl,
+      matrixToQuasiLocalObservable_bipartiteSlice_eq_sum hΓΔ A i j, hB]
+  · rintro ⟨B, i, j, rfl⟩
+    refine ⟨Matrix.bipartiteSlice
+      (bipartiteLocalAlgebraEquiv hΓΔ (htarget ▸ hω.localRestriction Λ B)) i j,
+      ⟨_, ⟨htarget ▸ hω.localRestriction Λ B, ?_, rfl⟩, i, j, rfl⟩, ?_⟩
+    · refine (hω.mem_localRestrictionRange_cast htarget _).mpr ⟨B, ?_⟩
+      rw [quasiLocalObservable_cast, hω.quasiLocalObservable_localRestriction]
+    · rw [matrixToQuasiLocalObservable_bipartiteSlice_eq_sum hΓΔ _ i j,
+        quasiLocalObservable_cast, hω.quasiLocalObservable_localRestriction]
+
+/-- The canonical quasi-local copy of the right support algebra is generated by the quasi-local
+compressions of the second-factor coefficients. -/
+private theorem map_rightSupportAlgebra_eq_adjoin (hω : PropagatesWithin ω 𝓝)
+    (Λ Γ Δ : Finset ℤ) (hΓΔ : Disjoint Γ Δ) (htarget : regionSumset Λ 𝓝 = Γ ∪ Δ) :
+    (Matrix.rightSupportAlgebra (hω.bipartiteLocalRestrictionRange Λ Γ Δ hΓΔ htarget)).map
+        (matrixToQuasiLocalObservable d Δ) =
+      StarAlgebra.adjoin ℂ (compressionGenerators ω Λ Γ) := by
+  rw [Matrix.rightSupportAlgebra, StarAlgHom.map_adjoin]
+  congr 1
+  ext g
+  simp only [Set.mem_image, Matrix.rightCoefficientSet, Set.mem_ofPred_eq,
+    compressionGenerators, bipartiteLocalRestrictionRange, StarSubalgebra.bipartiteReindex,
+    StarSubalgebra.mem_map]
+  constructor
+  · rintro ⟨M, ⟨X, ⟨A, hA, rfl⟩, i, j, rfl⟩, rfl⟩
+    obtain ⟨B, hB⟩ := (hω.mem_localRestrictionRange_cast htarget A).mp hA
+    refine ⟨B, i, j, ?_⟩
+    rw [show (bipartiteLocalAlgebraEquiv hΓΔ).toStarAlgHom A =
+      bipartiteLocalAlgebraEquiv hΓΔ A from rfl,
+      matrixToQuasiLocalObservable_operatorBlock_eq_sum hΓΔ A i j, hB]
+  · rintro ⟨B, i, j, rfl⟩
+    refine ⟨Matrix.operatorBlock
+      (bipartiteLocalAlgebraEquiv hΓΔ (htarget ▸ hω.localRestriction Λ B)) i j,
+      ⟨_, ⟨htarget ▸ hω.localRestriction Λ B, ?_, rfl⟩, i, j, rfl⟩, ?_⟩
+    · refine (hω.mem_localRestrictionRange_cast htarget _).mpr ⟨B, ?_⟩
+      rw [quasiLocalObservable_cast, hω.quasiLocalObservable_localRestriction]
+    · rw [matrixToQuasiLocalObservable_operatorBlock_eq_sum hΓΔ _ i j,
+        quasiLocalObservable_cast, hω.quasiLocalObservable_localRestriction]
+
+/-! ### Translation of the generator families -/
+
+/-- A star-automorphism commuting with one lattice translation commutes with it pointwise. -/
+private lemma apply_quasiLocalTranslation_of_commute {a : ℤ}
+    (hcomm : Commute ω (quasiLocalTranslation d a)) (A : QuasiLocalAlgebra d) :
+    ω (quasiLocalTranslation d a A) = quasiLocalTranslation d a (ω A) := by
+  simpa only [StarAlgEquiv.mul_apply] using DFunLike.congr_fun hcomm.eq A
+
+/-- Translating one compression produces the corresponding compression for the translated source
+and compressing regions. -/
+private lemma quasiLocalTranslation_compressionGenerator {a : ℤ}
+    (hcomm : Commute ω (quasiLocalTranslation d a)) (Λ Δ : Finset ℤ)
+    (B : LocalAlgebra d Λ) (i j : Config d Δ) :
+    quasiLocalTranslation d a
+        (∑ k : Config d Δ,
+          matrixToQuasiLocalObservable d Δ (Matrix.single k i (1 : ℂ)) *
+            ω (quasiLocalObservable d Λ B) *
+            matrixToQuasiLocalObservable d Δ (Matrix.single j k (1 : ℂ))) =
+      ∑ k : Config d (translateRegion a Δ),
+        matrixToQuasiLocalObservable d (translateRegion a Δ)
+            (Matrix.single k (Config.translation d a Δ i) (1 : ℂ)) *
+          ω (quasiLocalObservable d (translateRegion a Λ) (localTranslation d a Λ B)) *
+          matrixToQuasiLocalObservable d (translateRegion a Δ)
+            (Matrix.single (Config.translation d a Δ j) k (1 : ℂ)) := by
+  rw [map_sum, ← Equiv.sum_comp (Config.translation d a Δ)]
+  refine Finset.sum_congr rfl fun k _ ↦ ?_
+  rw [map_mul, map_mul, quasiLocalTranslation_matrixToQuasiLocalObservable_single,
+    quasiLocalTranslation_matrixToQuasiLocalObservable_single,
+    ← apply_quasiLocalTranslation_of_commute hcomm,
+    quasiLocalTranslation_quasiLocalObservable]
+
+/-- Translation carries the compressions of a source region by a second region to the
+compressions of the two translated regions. -/
+private theorem image_compressionGenerators {a : ℤ}
+    (hcomm : Commute ω (quasiLocalTranslation d a)) (Λ Θ : Finset ℤ) :
+    quasiLocalTranslation d a '' compressionGenerators ω Λ Θ =
+      compressionGenerators ω (translateRegion a Λ) (translateRegion a Θ) := by
+  ext g
+  simp only [Set.mem_image, compressionGenerators, Set.mem_ofPred_eq]
+  constructor
+  · rintro ⟨h, ⟨B, i, j, rfl⟩, rfl⟩
+    exact ⟨localTranslation d a Λ B, Config.translation d a Θ i, Config.translation d a Θ j,
+      quasiLocalTranslation_compressionGenerator hcomm Λ Θ B i j⟩
+  · rintro ⟨B, i, j, rfl⟩
+    refine ⟨_, ⟨(localTranslation d a Λ).symm B, (Config.translation d a Θ).symm i,
+      (Config.translation d a Θ).symm j, rfl⟩, ?_⟩
+    rw [quasiLocalTranslation_compressionGenerator hcomm Λ Θ, Equiv.apply_symm_apply,
+      Equiv.apply_symm_apply, StarAlgEquiv.apply_symm_apply]
+
+/-! ### Two-site covariance -/
+
+/-- Translation by two sites advances the even support algebra by one blocked cell:
+\[
+  \tau_2(\mathcal R_{2x})=\mathcal R_{2x+2}.
+\]
+
+The shift is by two sites of the original chain, that is, by one blocked cell; the corresponding
+one-site formula is false in general, as the module docstring records.
+
+Source: Schumacher--Werner, quant-ph/0405174, definition `defBBq`, lines 1199--1206, and the
+translated-support calculation, lines 1218--1226, in the fixed-\(d\) translation-covariant setting
+of Cirac et al., arXiv:1703.09188, lines 2292--2298, for the support algebras of GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266. See the homogeneous-chain scope statement in
+the module docstring. -/
+theorem embeddedEvenSupportAlgebra_map_quasiLocalTranslation_two
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (x : ℤ) :
+    (embeddedEvenSupportAlgebra hω x).map (quasiLocalTranslation d 2).toStarAlgHom =
+      embeddedEvenSupportAlgebra hω (x + 1) := by
+  rw [embeddedEvenSupportAlgebra, evenSupportAlgebra, evenPairLocalImage,
+    hω.map_leftSupportAlgebra_eq_adjoin, StarAlgHom.map_adjoin,
+    show ((quasiLocalTranslation d 2).toStarAlgHom : QuasiLocalAlgebra d → QuasiLocalAlgebra d) =
+      quasiLocalTranslation d 2 from rfl,
+    image_compressionGenerators (hcov 2), translateRegion_evenPair, translateRegion_rightPair,
+    embeddedEvenSupportAlgebra, evenSupportAlgebra, evenPairLocalImage,
+    hω.map_leftSupportAlgebra_eq_adjoin]
+
+/-- Translation by two sites advances the odd support algebra by one blocked cell:
+\[
+  \tau_2(\mathcal R_{2x+1})=\mathcal R_{2x+3}.
+\]
+
+The shift is by two sites of the original chain, that is, by one blocked cell; the corresponding
+one-site formula is false in general, as the module docstring records.
+
+Source: Schumacher--Werner, quant-ph/0405174, definition `defBBq`, lines 1199--1206, and the
+translated-support calculation, lines 1218--1226, in the fixed-\(d\) translation-covariant setting
+of Cirac et al., arXiv:1703.09188, lines 2292--2298, for the support algebras of GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266. See the homogeneous-chain scope statement in
+the module docstring. -/
+theorem embeddedOddSupportAlgebra_map_quasiLocalTranslation_two
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (x : ℤ) :
+    (embeddedOddSupportAlgebra hω x).map (quasiLocalTranslation d 2).toStarAlgHom =
+      embeddedOddSupportAlgebra hω (x + 1) := by
+  rw [embeddedOddSupportAlgebra, oddSupportAlgebra, evenPairLocalImage,
+    hω.map_rightSupportAlgebra_eq_adjoin, StarAlgHom.map_adjoin,
+    show ((quasiLocalTranslation d 2).toStarAlgHom : QuasiLocalAlgebra d → QuasiLocalAlgebra d) =
+      quasiLocalTranslation d 2 from rfl,
+    image_compressionGenerators (hcov 2), translateRegion_evenPair, translateRegion_leftPair,
+    embeddedOddSupportAlgebra, oddSupportAlgebra, evenPairLocalImage,
+    hω.map_rightSupportAlgebra_eq_adjoin]
+
+/-- Two-site translation covariance of the unified site-indexed support-algebra family:
+\[
+  \tau_2(\mathcal R_y)=\mathcal R_{y+2}\qquad(y\in\mathbb Z).
+\]
+
+The displacement is two sites of the original chain, that is, one blocked cell. The one-site
+formula \(\tau_1(\mathcal R_y)=\mathcal R_{y+1}\) is false in general and is not asserted; see the
+module docstring.
+
+Source: Schumacher--Werner, quant-ph/0405174, definition `defBBq`, lines 1199--1206, and the
+translated-support calculation, lines 1218--1226, in the fixed-\(d\) translation-covariant setting
+of Cirac et al., arXiv:1703.09188, lines 2292--2298, for the support algebras of GNVW,
+arXiv:0910.3675v2, equation `RR2x`, lines 1251--1266. GNVW allow site-dependent cell algebras and
+assume no translation covariance, so this is not a covariance theorem of that paper. See the
+homogeneous-chain scope statement in the module docstring. -/
+theorem embeddedSupportAlgebra_map_quasiLocalTranslation_two
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (y : ℤ) :
+    (embeddedSupportAlgebra hω y).map (quasiLocalTranslation d 2).toStarAlgHom =
+      embeddedSupportAlgebra hω (y + 2) := by
+  obtain ⟨x, hx | hx⟩ := Int.even_or_odd' y
+  · subst hx
+    rw [embeddedSupportAlgebra_even, show 2 * x + 2 = 2 * (x + 1) by ring,
+      embeddedSupportAlgebra_even, embeddedEvenSupportAlgebra_map_quasiLocalTranslation_two hω hcov]
+  · subst hx
+    rw [embeddedSupportAlgebra_odd, show 2 * x + 1 + 2 = 2 * (x + 1) + 1 by ring,
+      embeddedSupportAlgebra_odd, embeddedOddSupportAlgebra_map_quasiLocalTranslation_two hω hcov]
+
+/-- The even parity formula for the unified family:
+\[
+  \tau_2(\mathcal R_{2x})=\mathcal R_{2x+2}.
+\]
+
+Source: as for `SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two`,
+with the even index of GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1261--1266. -/
+theorem embeddedSupportAlgebra_map_quasiLocalTranslation_two_even
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (x : ℤ) :
+    (embeddedSupportAlgebra hω (2 * x)).map (quasiLocalTranslation d 2).toStarAlgHom =
+      embeddedSupportAlgebra hω (2 * x + 2) :=
+  embeddedSupportAlgebra_map_quasiLocalTranslation_two hω hcov (2 * x)
+
+/-- The odd parity formula for the unified family:
+\[
+  \tau_2(\mathcal R_{2x+1})=\mathcal R_{2x+3}.
+\]
+
+Source: as for `SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two`,
+with the odd index of GNVW, arXiv:0910.3675v2, equation `RR2x`, lines 1261--1266. -/
+theorem embeddedSupportAlgebra_map_quasiLocalTranslation_two_odd
+    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (x : ℤ) :
+    (embeddedSupportAlgebra hω (2 * x + 1)).map (quasiLocalTranslation d 2).toStarAlgHom =
+      embeddedSupportAlgebra hω (2 * x + 3) := by
+  have h := embeddedSupportAlgebra_map_quasiLocalTranslation_two hω hcov (2 * x + 1)
+  rwa [show 2 * x + 1 + 2 = 2 * x + 3 by ring] at h
+
+end PropagatesWithin
+
+end SpinChain

--- a/TNLean/QCA/SupportAlgebraCovariance.lean
+++ b/TNLean/QCA/SupportAlgebraCovariance.lean
@@ -41,16 +41,17 @@ The proof replaces the finite matrix coefficients by their quasi-local compressi
 a sum of products taken entirely inside the quasi-local algebra. Both matrix coefficient families
 therefore become families of quasi-local elements to which lattice translation applies directly.
 
-**Scope restriction (homogeneous chain):** as in `TNLean.QCA.SiteIndexedSupportAlgebra`, the
-one-site matrix size is the fixed positive size \(d\) of the present quasi-local algebra, whereas
+**Scope restriction (homogeneous automorphic chain):** as in
+`TNLean.QCA.SiteIndexedSupportAlgebra`, the one-site matrix size is the fixed positive size \(d\)
+of the present quasi-local algebra, whereas
 Gross--Nesme--Vogts--Werner allow it to depend on the site. Their cellular automata are moreover
 not assumed translation covariant, so the theorems below are not covariance theorems of that
 paper: covariance under translation of the support algebras is supplied by Schumacher--Werner,
 quant-ph/0405174, lines 1199--1206 and 1218--1226, and the translation-covariant fixed-\(d\)
 setting by Cirac et al., arXiv:1703.09188, lines 2292--2298. Schumacher--Werner state the
-translated-support identity for the cube lattice in arbitrary dimension with the cubic
-nearest-neighbour scheme, quant-ph/0405174, lines 920--941; the theorems below are its
-one-dimensional instance. See the
+translated-support identity for a translation-commuting homomorphism on the cube lattice in
+arbitrary dimension with the cubic nearest-neighbour scheme, quant-ph/0405174, lines 309--318 and
+920--941; the theorems below treat its one-dimensional invertible case. See the
 [Schumacher--Werner covariance scope note](https://sirui-lu.com/TNLean/paper-gaps/sw04_support_covariance_scope.pdf)
 and the
 [homogeneous-chain scope note](https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf).

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -13595,7 +13595,7 @@ left/right order below agrees with the adjacent-pair convention in
         X^{\mathrm L}_{rs}\otimes\mathbf 1
          & =\sum_{t\in J}
         (\mathbf 1\otimes e_{tr})\,X\,(\mathbf 1\otimes e_{st}),
-        \label{eq:qca_left_coefficient_compression}                    \\
+        \label{eq:qca_left_coefficient_compression} \\
         \mathbf 1\otimes X^{\mathrm R}_{ij}
          & =\sum_{k\in I}
         (e_{ki}\otimes\mathbf 1)\,X\,(e_{jk}\otimes\mathbf 1).
@@ -13635,7 +13635,7 @@ left/right order below agrees with the adjacent-pair convention in
         \widehat{A^{\mathrm L}_{rs}}
          & =\sum_{t\in\mathcal C_\Delta}
         \widehat{e^\Delta_{tr}}\ \widehat A\ \widehat{e^\Delta_{st}},
-        \label{eq:qca_quasi_local_left_compression}       \\
+        \label{eq:qca_quasi_local_left_compression} \\
         \widehat{A^{\mathrm R}_{ij}}
          & =\sum_{k\in\mathcal C_\Gamma}
         \widehat{e^\Gamma_{ki}}\ \widehat A\ \widehat{e^\Gamma_{jk}},

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -13668,7 +13668,7 @@ left/right order below agrees with the adjacent-pair convention in
         SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two_odd}
     \leanok
     \uses{def:qca_site_indexed_support_algebras, def:qca_translation_covariant,
-        def:qca_quasi_local_translation, lem:qca_pair_region_two_site_translation}
+        def:qca_quasi_local_translation}
     Let $\omega$ be a star-algebra automorphism of the homogeneous quasi-local
     algebra which propagates within $\{-1,0,1\}$ and commutes with every
     lattice translation.  Then, for every $y\in\mathbb Z$,
@@ -13705,9 +13705,10 @@ left/right order below agrees with the adjacent-pair convention in
 
     \textbf{Scope restriction (one-dimensional homogeneous chain):}
     Schumacher--Werner state the translated-support identity for the cube
-    lattice of an arbitrary dimension with a general neighbourhood scheme,
-    \cite[lines~309--318 and 928--941]{SchumacherWerner2004QCA}; the statement
-    above is its one-dimensional nearest-neighbour instance.  GNVW allow
+    lattice in arbitrary dimension with the cubic nearest-neighbour scheme,
+    \cite[lines~920--941]{SchumacherWerner2004QCA}; the statement above is its
+    one-dimensional instance, as recorded in
+    \cite{gap:sw04_support_covariance_scope}.  GNVW allow
     site-dependent cell sizes and assume no translation covariance, so
     (\ref{eq:qca_two_site_covariance}) is not a theorem of that paper; the
     fixed-$d$ restriction of the family $\mathcal R_y$ is recorded in
@@ -13718,9 +13719,8 @@ left/right order below agrees with the adjacent-pair convention in
     \uses{lem:qca_quasi_local_coefficient_compression,
         lem:qca_pair_region_two_site_translation,
         def:qca_site_indexed_support_algebras,
-        lem:qca_quasi_local_translation_action,
-        thm:qca_finite_region_restriction_embedding,
-        thm:qca_finite_region_restriction_translation}
+        def:qca_quasi_local_translation,
+        thm:qca_finite_region_restriction_embedding}
     Fix $x$ and put $\Lambda=E_x$, $\Gamma=L_x$, $\Delta=P_x$.  A
     finite-region observable belongs to the finite local image exactly when
     its quasi-local copy lies in the image of $\mathcal A_\Lambda$ under

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -13560,6 +13560,205 @@ left/right order below agrees with the adjacent-pair convention in
     physical supports, so disjoint quasi-locality applies.
 \end{proof}
 
+\begin{lemma}[Two-site translation of the pair regions]
+    \label{lem:qca_pair_region_two_site_translation}
+    \lean{SpinChain.translateRegion_evenPair,
+        SpinChain.translateRegion_leftPair,
+        SpinChain.translateRegion_rightPair}
+    \leanok
+    \uses{def:qca_nearest_neighbor_pair_regions}
+    Translation by two sites advances each of the three two-site regions by
+    one index:
+    \begin{align}
+        E_x+2 & =E_{x+1}, &
+        L_x+2 & =L_{x+1}, &
+        P_x+2 & =P_{x+1}.
+        \label{eq:qca_pair_region_two_site_translation}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:qca_nearest_neighbor_pair_regions}
+    Add $2$ to each of the two points of (\ref{eq:qca_pair_regions}) and
+    compare with the same set at the index $x+1$.
+\end{proof}
+
+\begin{lemma}[Matrix coefficients as compressions by matrix units]
+    \label{lem:qca_support_coefficient_compression}
+    \lean{Matrix.leftKroneckerEmbed_bipartiteSlice_eq_sum,
+        Matrix.rightKroneckerEmbed_operatorBlock_eq_sum}
+    \leanok
+    \uses{def:qca_left_coefficient_set, def:qca_right_coefficient_set}
+    Let $X\in M_{I\times J}(\mathbb C)$ and write $e_{rs}$ for the matrix
+    units of either factor.  Then
+    \begin{align}
+        X^{\mathrm L}_{rs}\otimes\mathbf 1
+         & =\sum_{t\in J}
+        (\mathbf 1\otimes e_{tr})\,X\,(\mathbf 1\otimes e_{st}),
+        \label{eq:qca_left_coefficient_compression}                    \\
+        \mathbf 1\otimes X^{\mathrm R}_{ij}
+         & =\sum_{k\in I}
+        (e_{ki}\otimes\mathbf 1)\,X\,(e_{jk}\otimes\mathbf 1).
+        \label{eq:qca_right_coefficient_compression}
+    \end{align}
+    Every coefficient of the expansion used at
+    \cite[lines~1188--1191]{Gross2012IndexTheory} and
+    \cite[lines~1137--1169]{SchumacherWerner2004QCA} is therefore a sum of
+    products formed inside the ambient algebra.
+\end{lemma}
+
+\begin{proof}\leanok
+    Compare entries.  On the left of
+    (\ref{eq:qca_left_coefficient_compression}), the entry at
+    $((i,t),(j,u))$ equals $X((i,r),(j,s))$ when $t=u$ and vanishes
+    otherwise.  On the right, the summand indexed by $t$ contributes
+    $X((i,r),(j,s))$ exactly when both second coordinates equal $t$, so the
+    sum over $t$ reproduces the same entry.  The second identity follows by
+    exchanging the roles of the two factors.
+\end{proof}
+
+\begin{lemma}[Quasi-local form of the coefficient compressions]
+    \label{lem:qca_quasi_local_coefficient_compression}
+    \lean{SpinChain.matrixToQuasiLocalObservable_bipartiteSlice_eq_sum,
+        SpinChain.matrixToQuasiLocalObservable_operatorBlock_eq_sum}
+    \leanok
+    \uses{lem:qca_support_coefficient_compression,
+        def:qca_bipartite_local_algebra_coordinates,
+        def:qca_quasi_local_observable,
+        def:qca_site_indexed_support_algebras}
+    Let $\Gamma$ and $\Delta$ be disjoint finite regions and let
+    $A\in\mathcal A_{\Gamma\cup\Delta}$, written in the ordered
+    $\Gamma\times\Delta$ coordinates.  For configurations
+    $r,s\in\mathcal C_\Delta$ and $i,j\in\mathcal C_\Gamma$, the canonical
+    quasi-local copies of the two coefficient families are
+    \begin{align}
+        \widehat{A^{\mathrm L}_{rs}}
+         & =\sum_{t\in\mathcal C_\Delta}
+        \widehat{e^\Delta_{tr}}\ \widehat A\ \widehat{e^\Delta_{st}},
+        \label{eq:qca_quasi_local_left_compression}       \\
+        \widehat{A^{\mathrm R}_{ij}}
+         & =\sum_{k\in\mathcal C_\Gamma}
+        \widehat{e^\Gamma_{ki}}\ \widehat A\ \widehat{e^\Gamma_{jk}},
+        \label{eq:qca_quasi_local_right_compression}
+    \end{align}
+    where a hat denotes the canonical image in the quasi-local algebra.  Both
+    right-hand sides are formed inside the quasi-local algebra alone.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:qca_support_coefficient_compression,
+        thm:qca_bipartite_local_algebra_inclusions,
+        lem:qca_quasi_local_observable}
+    In the bipartite coordinates the inclusion of $\mathcal A_\Gamma$ is
+    $X\mapsto X\otimes\mathbf 1$ and the inclusion of $\mathcal A_\Delta$ is
+    $Y\mapsto\mathbf 1\otimes Y$.  Transport
+    (\ref{eq:qca_left_coefficient_compression}) and
+    (\ref{eq:qca_right_coefficient_compression}) through the inverse of the
+    bipartite coordinate equivalence, then apply the canonical map of
+    $\mathcal A_{\Gamma\cup\Delta}$ into the quasi-local algebra, under which
+    a finite-region inclusion leaves the quasi-local observable unchanged.
+\end{proof}
+
+\begin{theorem}[Two-site translation covariance of the support algebras]
+    \label{thm:qca_site_indexed_support_algebras_two_site_covariance}
+    \lean{SpinChain.PropagatesWithin.embeddedEvenSupportAlgebra_map_quasiLocalTranslation_two,
+        SpinChain.PropagatesWithin.embeddedOddSupportAlgebra_map_quasiLocalTranslation_two,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two_even,
+        SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two_odd}
+    \leanok
+    \uses{def:qca_site_indexed_support_algebras, def:qca_translation_covariant,
+        def:qca_quasi_local_translation, lem:qca_pair_region_two_site_translation}
+    Let $\omega$ be a star-algebra automorphism of the homogeneous quasi-local
+    algebra which propagates within $\{-1,0,1\}$ and commutes with every
+    lattice translation.  Then, for every $y\in\mathbb Z$,
+    \begin{align}
+        \tau_2\bigl(\widehat{\mathcal R}_y\bigr)
+         & =\widehat{\mathcal R}_{y+2},
+        \label{eq:qca_two_site_covariance}
+    \end{align}
+    and in the two parities
+    \begin{align}
+        \tau_2\bigl(\widehat{\mathcal R}_{2x}\bigr)
+         & =\widehat{\mathcal R}_{2x+2}, &
+        \tau_2\bigl(\widehat{\mathcal R}_{2x+1}\bigr)
+         & =\widehat{\mathcal R}_{2x+3}.
+        \label{eq:qca_two_site_covariance_parities}
+    \end{align}
+    The displacement is two sites of the original chain, that is, one blocked
+    cell.  The corresponding one-site formula
+    $\tau_1(\widehat{\mathcal R}_y)=\widehat{\mathcal R}_{y+1}$ is false in
+    general and is not asserted, because translation by one does not preserve
+    the even pairing $E_x$.  For the shift automorphism at
+    \cite[lines~1267--1268]{Gross2012IndexTheory} the even algebra is a
+    two-site full matrix algebra while the odd algebra is the scalars, and no
+    translation carries one onto the other.
+
+    Covariance of the support algebras under translation is the identity
+    displayed at
+    \cite[lines~1218--1226]{SchumacherWerner2004QCA} for the algebras defined
+    at \cite[lines~1199--1206]{SchumacherWerner2004QCA}, and the ordered even
+    and odd factors are equation \texttt{RR2x} at
+    \cite[lines~1251--1266]{Gross2012IndexTheory}.  The translation-covariant
+    fixed-$d$ setting is that of
+    \cite[lines~2292--2298]{Cirac2017MPU}.
+
+    \textbf{Scope restriction (one-dimensional homogeneous chain):}
+    Schumacher--Werner state the translated-support identity for the cube
+    lattice of an arbitrary dimension with a general neighbourhood scheme,
+    \cite[lines~309--318 and 928--941]{SchumacherWerner2004QCA}; the statement
+    above is its one-dimensional nearest-neighbour instance.  GNVW allow
+    site-dependent cell sizes and assume no translation covariance, so
+    (\ref{eq:qca_two_site_covariance}) is not a theorem of that paper; the
+    fixed-$d$ restriction of the family $\mathcal R_y$ is recorded in
+    \cite{gap:gnvw12_site_dependent_adjacent_generation_scope}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:qca_quasi_local_coefficient_compression,
+        lem:qca_pair_region_two_site_translation,
+        def:qca_site_indexed_support_algebras,
+        lem:qca_quasi_local_translation_action,
+        thm:qca_finite_region_restriction_embedding,
+        thm:qca_finite_region_restriction_translation}
+    Fix $x$ and put $\Lambda=E_x$, $\Gamma=L_x$, $\Delta=P_x$.  A
+    finite-region observable belongs to the finite local image exactly when
+    its quasi-local copy lies in the image of $\mathcal A_\Lambda$ under
+    $\omega$.  Hence, by
+    (\ref{eq:qca_quasi_local_left_compression}), the canonical quasi-local
+    copy of $\mathcal R_{2x}$ is generated by the elements
+    \begin{align}
+        \sum_{t\in\mathcal C_\Delta}
+        \widehat{e^\Delta_{tr}}\ \omega\bigl(\widehat B\bigr)\
+        \widehat{e^\Delta_{st}},
+        \qquad B\in\mathcal A_\Lambda,\quad r,s\in\mathcal C_\Delta,
+        \label{eq:qca_left_support_generators}
+    \end{align}
+    and the copy of $\mathcal R_{2x+1}$ is generated by the analogous
+    elements built from (\ref{eq:qca_quasi_local_right_compression}) with
+    $\Gamma$ in place of $\Delta$.  Since a star-algebra automorphism carries
+    the algebra generated by a set to the algebra generated by the image of
+    that set, it suffices to translate the two generating families.
+
+    Translation carries a matrix unit of a region to the matrix unit of the
+    translated region at the translated configurations, and covariance gives
+    $\tau_2(\omega(\widehat B))=\omega(\tau_2(\widehat B))$, whose right-hand
+    side is $\omega$ applied to the quasi-local copy of the translated
+    observable.  Reindexing the summation over $\mathcal C_\Delta$ along the
+    configuration translation therefore turns
+    (\ref{eq:qca_left_support_generators}) into the same family for the
+    regions $\Lambda+2$ and $\Delta+2$, and the translation is a bijection
+    between the two families.  By
+    (\ref{eq:qca_pair_region_two_site_translation}) those regions are
+    $E_{x+1}$ and $P_{x+1}$, so the translated family generates
+    $\widehat{\mathcal R}_{2x+2}$.  The odd case is identical with $\Gamma$
+    in place of $\Delta$ and $L_{x+1}$ in place of $P_{x+1}$.
+
+    Finally, splitting $y$ by parity and using $2x+2=2(x+1)$ and
+    $2x+3=2(x+1)+1$ gives (\ref{eq:qca_two_site_covariance}) and
+    (\ref{eq:qca_two_site_covariance_parities}).
+\end{proof}
+
 Equation~(A1) in lines~2300--2306 of \cite{Cirac2017MPU} defines the
 local action associated with an MPU by eventual finite-chain conjugation.  In
 lines~2300--2306, eventual constancy is used to obtain a norm-preserving

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -13702,11 +13702,12 @@ left/right order below agrees with the adjacent-pair convention in
     fixed-$d$ setting is that of
     \cite[lines~2292--2298]{Cirac2017MPU}.
 
-    \textbf{Scope restriction (one-dimensional homogeneous chain):}
-    Schumacher--Werner state the translated-support identity for the cube
-    lattice in arbitrary dimension with the cubic nearest-neighbour scheme,
-    \cite[lines~920--941]{SchumacherWerner2004QCA}; the statement above is its
-    one-dimensional instance, as recorded in
+    \textbf{Scope restriction (one-dimensional homogeneous automorphism):}
+    Schumacher--Werner state the translated-support identity for a
+    translation-commuting homomorphism on the cube lattice in arbitrary
+    dimension with the cubic nearest-neighbour scheme,
+    \cite[lines~309--318 and 920--941]{SchumacherWerner2004QCA}.  The statement
+    above treats the one-dimensional invertible case, as recorded in
     \cite{gap:sw04_support_covariance_scope}.  GNVW allow
     site-dependent cell sizes and assume no translation covariance, so
     (\ref{eq:qca_two_site_covariance}) is not a theorem of that paper; the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -13624,8 +13624,7 @@ left/right order below agrees with the adjacent-pair convention in
     \leanok
     \uses{lem:qca_support_coefficient_compression,
         def:qca_bipartite_local_algebra_coordinates,
-        def:qca_quasi_local_observable,
-        def:qca_site_indexed_support_algebras}
+        def:qca_quasi_local_observable}
     Let $\Gamma$ and $\Delta$ be disjoint finite regions and let
     $A\in\mathcal A_{\Gamma\cup\Delta}$, written in the ordered
     $\Gamma\times\Delta$ coordinates.  For configurations

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1051,7 +1051,7 @@
   title       = {One-Dimensional Scope of {Schumacher--Werner} Support-Algebra Covariance},
   institution = {TNLean},
   type        = {Paper-gap note},
-  number      = {schumacher\_werner\_support\_covariance\_scope},
+  number      = {sw04\_support\_covariance\_scope},
   year        = {2026},
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/sw04_support_covariance_scope.pdf}},
 }

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1046,6 +1046,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf}},
 }
 
+@techreport{gap:sw04_support_covariance_scope,
+  author      = {The {TNLean} contributors},
+  title       = {One-Dimensional Scope of {Schumacher--Werner} Support-Algebra Covariance},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {schumacher\_werner\_support\_covariance\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/sw04_support_covariance_scope.pdf}},
+}
+
 @techreport{gap:gnvw12_support_algebra_star_closure,
   author      = {The {TNLean} contributors},
   title       = {Star-Closure Correction for the {GNVW} Support-Algebra Lemma},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -58,6 +58,10 @@ restriction are recorded separately.
 - `gnvw12_support_algebra_full_matrix_scope.tex` records the remaining open
   restriction from arbitrary finite-dimensional $C^*$-algebra factors to
   full complex matrix factors.
+- `sw04_support_covariance_scope.tex` records that the formal
+  support-algebra covariance theorem treats a homogeneous one-dimensional
+  nearest-neighbour chain, while Schumacher--Werner state the translation
+  identity for the cubic nearest-neighbour scheme in arbitrary dimension.
 
 For the present non-periodic MPS Fundamental Theorem work, the repeated-copy and
 equal-modulus comparison has these current reference points.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -59,9 +59,9 @@ restriction are recorded separately.
   restriction from arbitrary finite-dimensional $C^*$-algebra factors to
   full complex matrix factors.
 - `sw04_support_covariance_scope.tex` records that the formal
-  support-algebra covariance theorem treats a homogeneous one-dimensional
-  nearest-neighbour chain, while Schumacher--Werner state the translation
-  identity for the cubic nearest-neighbour scheme in arbitrary dimension.
+  support-algebra covariance theorem treats star-automorphisms of a homogeneous
+  one-dimensional nearest-neighbour chain, while Schumacher--Werner allow
+  homomorphisms for the cubic nearest-neighbour scheme in arbitrary dimension.
 
 For the present non-periodic MPS Fundamental Theorem work, the repeated-copy and
 equal-modulus comparison has these current reference points.

--- a/docs/paper-gaps/sw04_support_covariance_scope.tex
+++ b/docs/paper-gaps/sw04_support_covariance_scope.tex
@@ -1,0 +1,104 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{One-Dimensional Scope of Schumacher--Werner Support-Algebra Covariance}
+\author{}
+\date{2026-09-03}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{The source identity}
+
+Schumacher--Werner define a quantum cellular automaton on the cube lattice
+$\mathbb Z^s$ with a finite neighbourhood scheme
+\cite[lines~309--318]{SchumacherWerner2004QCA}. For their main structure
+theorem they specialize to the cubic nearest-neighbour scheme, group the
+$2^s$ sites of the unit cube $\Box$, and let $Q=\{-1,+1\}^s$ denote the
+quadrant vectors \cite[lines~920--941]{SchumacherWerner2004QCA}. For each
+$q\in Q$, they define the support algebra
+\begin{align}
+    \mathcal B_q
+     & =\operatorname{Spp}\bigl(\gamma(\mathcal A(\Box)),
+    \mathcal A(\Box+q)\bigr).
+    \label{eq:sw04_support_covariance_scope_support}
+\end{align}
+Here $\gamma$ commutes with every lattice translation. Their translated
+support calculation states that
+\begin{align}
+    \operatorname{Spp}(  \gamma(\mathcal A(\Box+q_1-q)),\mathcal A(\Box+q_1))
+     & =\tau_{q_1-q}(\mathcal B_q).
+    \label{eq:sw04_support_covariance_scope_source}
+\end{align}
+The definition and calculation occur at lines~1199--1206 and 1218--1226 of
+Ref.~\cite{SchumacherWerner2004QCA}. They apply in arbitrary lattice
+dimension with this cubic nearest-neighbour scheme.
+
+\section{The formal specialization}
+
+The present quasi-local observable algebra is a homogeneous chain on
+$\mathbb Z$ with one fixed matrix size $d>0$. For a star-automorphism
+$\omega$ satisfying
+\begin{align}
+    \omega(\mathcal A_\Lambda)
+     & \subseteq\mathcal A_{\Lambda+\{-1,0,1\}},
+    \label{eq:sw04_support_covariance_scope_propagation} \\
+    \omega\tau_a
+     & =\tau_a\omega
+    \qquad(a\in\mathbb Z),
+    \label{eq:sw04_support_covariance_scope_covariance}
+\end{align}
+the support algebras are formed from the even source pair
+$E_x=\{2x,2x+1\}$ and its two neighbouring target pairs. Translation by two
+sites preserves this pairing and gives
+\begin{align}
+    \tau_2(\widehat{\mathcal R}_y)
+     & =\widehat{\mathcal R}_{y+2}.
+    \label{eq:sw04_support_covariance_scope_formal}
+\end{align}
+This is the one-dimensional, nearest-neighbour, homogeneous-chain instance of
+(\ref{eq:sw04_support_covariance_scope_source}). The fixed
+on-site dimension agrees with the QCA setting used by Cirac et al. at
+lines~2292--2298 of Ref.~\cite{Cirac2017MPU}; the ordered even and odd support
+factors agree with equation \texttt{RR2x} of
+Ref.~\cite{Gross2012IndexTheory}.
+
+The formal statement assumes exactly the propagation and translation
+covariance in
+(\ref{eq:sw04_support_covariance_scope_propagation})--%
+(\ref{eq:sw04_support_covariance_scope_covariance}). It does not
+formalize the arbitrary-dimensional cube lattice.\footnote{Formal declaration:
+    \leanid{SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two}
+    in \doclink{TNLean/QCA/SupportAlgebraCovariance}.}
+The separate restriction from site-dependent GNVW cell sizes to a homogeneous
+chain is recorded in
+\path{docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex}.
+
+\section{Elimination plan}
+
+Removing the restriction requires a quasi-local observable algebra indexed by
+$\mathbb Z^s$, finite-region translations by vectors in $\mathbb Z^s$, and a
+propagation predicate for the cubic nearest-neighbour scheme.
+For each translated source region and each target cube, the support algebra
+must then be embedded canonically into the multidimensional quasi-local
+algebra. Translation covariance and the same coefficient-compression
+argument yield the vector-valued analogue of
+(\ref{eq:sw04_support_covariance_scope_formal}), recovering
+(\ref{eq:sw04_support_covariance_scope_source}). The present
+theorem follows by specializing to $s=1$, $\mathcal N=\{-1,0,1\}$, and the
+two-site blocked pairing.
+
+Until that multidimensional observable-algebra interface is available, the
+source-labelled formal statement remains restricted to the one-dimensional
+nearest-neighbour case described above.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/sw04_support_covariance_scope.tex
+++ b/docs/paper-gaps/sw04_support_covariance_scope.tex
@@ -29,7 +29,8 @@ $q\in Q$, they define the support algebra
     \mathcal A(\Box+q)\bigr).
     \label{eq:sw04_support_covariance_scope_support}
 \end{align}
-Here $\gamma$ commutes with every lattice translation. Their translated
+Here $\gamma$ is the translation-commuting algebra homomorphism of their QCA
+definition; invertibility is not assumed. Their translated
 support calculation states that
 \begin{align}
     \operatorname{Spp}(  \gamma(\mathcal A(\Box+q_1-q)),\mathcal A(\Box+q_1))
@@ -69,11 +70,13 @@ lines~2292--2298 of Ref.~\cite{Cirac2017MPU}; the ordered even and odd support
 factors agree with equation \texttt{RR2x} of
 Ref.~\cite{Gross2012IndexTheory}.
 
-The formal statement assumes exactly the propagation and translation
-covariance in
+The formal statement assumes the propagation and translation covariance in
 (\ref{eq:sw04_support_covariance_scope_propagation})--%
-(\ref{eq:sw04_support_covariance_scope_covariance}). It does not
-formalize the arbitrary-dimensional cube lattice.\footnote{Formal declaration:
+(\ref{eq:sw04_support_covariance_scope_covariance}), but it packages $\omega$
+as a star-automorphism. Schumacher--Werner require only a translation-commuting
+algebra homomorphism. Thus the formal theorem is additionally restricted to
+the invertible case and does not formalize the arbitrary-dimensional cube
+lattice.\footnote{Formal declaration:
     \leanid{SpinChain.PropagatesWithin.embeddedSupportAlgebra_map_quasiLocalTranslation_two}
     in \doclink{TNLean/QCA/SupportAlgebraCovariance}.}
 The separate restriction from site-dependent GNVW cell sizes to a homogeneous
@@ -82,10 +85,16 @@ chain is recorded in
 
 \section{Elimination plan}
 
-Removing the restriction requires a quasi-local observable algebra indexed by
-$\mathbb Z^s$, finite-region translations by vectors in $\mathbb Z^s$, and a
-propagation predicate for the cubic nearest-neighbour scheme.
-For each translated source region and each target cube, the support algebra
+Removing the invertibility restriction first requires homomorphism-valued
+versions of finite propagation, finite local restriction, translation
+covariance, and the site-indexed support-algebra family. The compression proof
+uses multiplication, addition, the star operation, and translation commutation;
+it does not require an inverse for $\omega$.
+
+Removing the dimensional restriction then requires a quasi-local observable
+algebra indexed by $\mathbb Z^s$, finite-region translations by vectors in
+$\mathbb Z^s$, and a propagation predicate for the cubic nearest-neighbour
+scheme. For each translated source region and each target cube, the support algebra
 must then be embedded canonically into the multidimensional quasi-local
 algebra. Translation covariance and the same coefficient-compression
 argument yield the vector-valued analogue of
@@ -94,9 +103,9 @@ argument yield the vector-valued analogue of
 theorem follows by specializing to $s=1$, $\mathcal N=\{-1,0,1\}$, and the
 two-site blocked pairing.
 
-Until that multidimensional observable-algebra interface is available, the
-source-labelled formal statement remains restricted to the one-dimensional
-nearest-neighbour case described above.
+Until both interfaces are available, the source-labelled formal statement
+remains restricted to star-automorphisms of the one-dimensional
+nearest-neighbour chain described above.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/texra-blueprint.toml
+++ b/texra-blueprint.toml
@@ -35,6 +35,7 @@ pgwsvc08 = "arXiv:0802.0447 (string order and symmetries)"
 rmp     = "Cirac, Perez-Garcia, Schuch, Verstraete, Rev. Mod. Phys. 93 (2021)"
 spc11   = "arXiv:1010.3732 (SPT classification)"
 spwc10  = "arXiv:0909.5347 (quantum Wielandt inequality)"
+sw04    = "Schumacher and Werner, quant-ph/0405174 (quantum cellular automata)"
 tnlean  = "internal theorem-surface audit, no single external source"
 
 [blueprint.graphs]


### PR DESCRIPTION
## What

For a star-automorphism `ω` of the homogeneous quasi-local algebra with
nearest-neighbour propagation and `TranslationCovariant ω`, this proves

```
theorem embeddedSupportAlgebra_map_quasiLocalTranslation_two
    (hω : PropagatesWithin ω (Finset.Icc (-1) 1)) (hcov : TranslationCovariant ω) (y : ℤ) :
    (embeddedSupportAlgebra hω y).map (quasiLocalTranslation d 2).toStarAlgHom =
      embeddedSupportAlgebra hω (y + 2)
```

together with the parity formulas
`τ₂(𝓡_{2x}) = 𝓡_{2x+2}` and `τ₂(𝓡_{2x+1}) = 𝓡_{2x+3}`, both on the unified
family and on the two embedded parity families. It consumes the exact public
family from the merged #7114 (`TNLean/QCA/SiteIndexedSupportAlgebra.lean`,
PR #7141) and changes no existing definition. Translation covariance appears
only in these theorems; the reusable internal lemma that carries the work
assumes only `Commute ω (quasiLocalTranslation d a)` for a general `a`.

New module: `TNLean/QCA/SupportAlgebraCovariance.lean`.

## How

Rather than transporting the finite bipartite coordinates along a matrix
reindexing, the proof moves the coefficient families into the quasi-local
algebra, where lattice translation acts without any dependent transport. The
key identity is

```
Spp_L coefficient:   X_{ij} ⊗ 1 = Σ_k (1 ⊗ e_{ki}) X (1 ⊗ e_{jk})
Spp_R coefficient:   1 ⊗ X_{ij} = Σ_k (e_{ki} ⊗ 1) X (e_{jk} ⊗ 1)
```

(`Matrix.leftKroneckerEmbed_bipartiteSlice_eq_sum`,
`Matrix.rightKroneckerEmbed_operatorBlock_eq_sum`), transported through
`bipartiteLocalAlgebraEquiv` and the canonical quasi-local inclusion
(`SpinChain.matrixToQuasiLocalObservable_bipartiteSlice_eq_sum`,
`..._operatorBlock_eq_sum`). Each embedded support algebra is then the
star-algebra generated by a set of quasi-local elements built from `ω`, the
source region, and one compressing region; translating that set uses only
covariance, `Config.translation`, and `Equiv.sum_comp`.

**Deviation from the issue's suggested route.** Two acceptance criteria
describe an intermediate construction — factorwise reindexing naturality of
`Spp_L`/`Spp_R`, and the coherent translation square for the #7112
disjoint-union/bipartite/range coordinates. The route above discharges the
covariance theorem without either, so neither is added: adding them would
leave zero-reference declarations, which `docs/proof_debt.md` treats as debt.
The related criterion "introduce no duplicate matrix reindexing declaration"
is satisfied outright, since no reindexing star-algebra map is defined here
and none is imported from the heavy QICLean stacks. If the reindexing
naturality is wanted as reusable API in its own right, it is better filed as a
separate issue against `TNLean/QCA/BipartiteSupportAlgebra.lean`.

## Sources

- Schumacher--Werner, `Papers/quant-ph_0405174/qca.tex`: definition `defBBq`,
  lines 1199--1206 (the support algebras `B_q`), and the translated-support
  calculation, lines 1218--1226 (`Spp(grule(A(□+q₁-q)), A(□+q₁)) = τ_{q₁-q}(B_q)`),
  which is the covariance step. Their QCA definition at lines 309--318 already
  requires commutation with lattice translations, matching the hypothesis set
  used here.
- GNVW, `References/0910.3675v2/QCI12.tex`: equation `RR2x`, lines 1251--1266,
  fixing the ordered even/odd left/right support factors; Lemma `lem:spp` and
  `a2Supp` at lines 1181--1219 for the coefficient families; the shift example
  at lines 1267--1268. GNVW allow site-dependent cell algebras and assume no
  translation covariance (lines 557--600), so this is not presented as a GNVW
  covariance theorem.
- Cirac et al., `Papers/1703.09188/paper_v2.tex`: lines 2292--2298 for the
  fixed-`d`, translation-covariant setting, and lines 2313--2328 for the same
  paired localization.

The one-site formula `τ₁(𝓡_y) = 𝓡_{y+1}` is false in general and is asserted
nowhere; the module docstring, the theorem docstrings, and the blueprint node
all say the shift is by two sites of the original chain, that is, one blocked
cell, and point at the GNVW shift example. That example repeats the even
subscript on line 1268 where the odd one is meant; the printed typo is noted
in prose and copied into no declaration.

## Blueprint

Three new Chapter 28 nodes after the pairwise-commutation entry:

- `lem:qca_pair_region_two_site_translation` — `E_x+2 = E_{x+1}`, `L_x+2 = L_{x+1}`,
  `P_x+2 = P_{x+1}`.
- `lem:qca_support_coefficient_compression` and
  `lem:qca_quasi_local_coefficient_compression` — the two compression identities
  and their quasi-local form.
- `thm:qca_site_indexed_support_algebras_two_site_covariance` — the unified
  formula and both parity formulas.

The theorem node states its hypothesis set exactly as formalized and carries a
**Scope restriction (one-dimensional homogeneous chain)** paragraph. Schumacher
and Werner prove the translated-support identity for a translation-commuting
homomorphism with the cubic nearest-neighbour scheme in arbitrary dimension,
whereas the node treats star-automorphisms in one dimension. These restrictions
and their elimination plans are recorded in
`docs/paper-gaps/sw04_support_covariance_scope.tex`. The fixed-`d` restriction of
the family continues to use #7114's distinct site-dependent-scope note
`docs/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.tex`, not the
unrelated full-matrix-factor note.

## Validation (run in `/private/tmp/tnlean-issue-7115`)

- `scripts/lake_build_locked.sh TNLean.QCA` — 3144 jobs, no errors, no warnings
- `rg -n "sorry|axiom|admit|native_decide" TNLean/QCA/SupportAlgebraCovariance.lean` — clean
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py` then `--check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `--ci` — in sync
- `lake exe checkdecls blueprint/lean_decls` — exit 0
- `cd blueprint && leanblueprint pdf` — exit 0, no undefined references or citations
- `python3 scripts/tactic_pattern_scan.py` — no pattern reported in the new file
- `python3 scripts/test_lean_file_policies.py` — 16 tests OK
- `git diff --check` — clean

Review fixes through exact head `ec6fe98b3` additionally passed the pinned
`latexindent` byte-comparison gate over every Blueprint TeX source (231 files),
QCA targeted builds, generated-import checks, prose and module-policy checks,
Blueprint and paper-gap declaration checks, `texra-blueprint paper-gaps check`,
all paper-gap PDF builds, Blueprint web generation, and the 1100-page Blueprint
PDF build. The browser-only equation-layout test was unavailable locally because
Playwright is not installed; hosted CI runs it in the provisioned environment.

Closes #7115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR





