### PR TITLE
feat(Algebra): full unitary completion class and universal invariant vector

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -49,6 +49,7 @@ import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.StabilizerTransition
 import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation
+import TNLean.Algebra.UnitaryCompletionClass
 import TNLean.Algebra.UnitaryCongruence
 import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryFactorizationComparison

--- a/TNLean/Algebra/UnitaryCompletionClass.lean
+++ b/TNLean/Algebra/UnitaryCompletionClass.lean
@@ -15,8 +15,9 @@ pair `(a, b)` of gauge labels there is a defect subspace `K a b` of the matter
 space and an isometry `D a b` defined on it. The operator used on the whole
 matter space is any unitary agreeing with `D a b` on `K a b`, and the closing
 sentence of the modified-fusion lemma of FBC25 (arXiv:2502.20257,
-lines 4215--4326) records that such an extension is not unique. A completion
-is therefore the whole family `(U a b)`, not one selected operator.
+lines 4215--4326) records that such an extension need not be unique when the
+defect vectors do not span the matter space. A completion is therefore the
+whole family `(U a b)`, not one selected operator.
 
 The matter operators are represented here as elements of
 `Matrix.unitaryGroup n ℂ`, the family type consumed by the local Gauss operator

--- a/TNLean/Algebra/UnitaryCompletionClass.lean
+++ b/TNLean/Algebra/UnitaryCompletionClass.lean
@@ -15,8 +15,8 @@ pair `(a, b)` of gauge labels there is a defect subspace `K a b` of the matter
 space and an isometry `D a b` defined on it. The operator used on the whole
 matter space is any unitary agreeing with `D a b` on `K a b`, and the closing
 sentence of the modified-fusion lemma of FBC25 (arXiv:2502.20257,
-lines 4215--4260) records that such an extension is not unique. A completion is
-therefore the whole family `(U a b)`, not one selected operator.
+lines 4215--4326) records that such an extension is not unique. A completion
+is therefore the whole family `(U a b)`, not one selected operator.
 
 The matter operators are represented here as elements of
 `Matrix.unitaryGroup n ℂ`, the family type consumed by the local Gauss operator

--- a/TNLean/Algebra/UnitaryCompletionClass.lean
+++ b/TNLean/Algebra/UnitaryCompletionClass.lean
@@ -49,7 +49,7 @@ to it is the prescribed isometry `D a b`.
 
 This is the defect subspace `K_{a,b}` together with the isometry
 `D_{a,b} : K_{a,b} → H_m` of the state-level fusion construction of FBC25
-(arXiv:2502.20257, lines 4215--4260 and 4325--4335). -/
+(arXiv:2502.20257, lines 4215--4326 and 4325--4335). -/
 structure DefectMaps (G n : Type*) [Fintype n] where
   /-- The defect subspace of the matter space attached to the labels `(a, b)`. -/
   domain : G → G → Submodule ℂ (n → ℂ)
@@ -69,7 +69,7 @@ defect maps when every member agrees with the prescribed map on its defect
 subspace.
 
 This is the membership condition of the full completion class attached to the
-modified fusion operators of FBC25 (arXiv:2502.20257, lines 4215--4260). -/
+modified fusion operators of FBC25 (arXiv:2502.20257, lines 4215--4326). -/
 def IsCompletion (R : G → G → Matrix.unitaryGroup n ℂ) : Prop :=
   ∀ a b, ∀ ξ ∈ D.domain a b,
     (R a b : Matrix n n ℂ) *ᵥ ξ = D.prescribed a b *ᵥ ξ
@@ -78,7 +78,7 @@ def IsCompletion (R : G → G → Matrix.unitaryGroup n ℂ) : Prop :=
 whole families of unitary matter operators.
 
 This is the completion class of the modified fusion operators of FBC25
-(arXiv:2502.20257, lines 4215--4260); no single pair of labels is singled
+(arXiv:2502.20257, lines 4215--4326); no single pair of labels is singled
 out. -/
 def completionClass : Set (G → G → Matrix.unitaryGroup n ℂ) :=
   {R | D.IsCompletion R}

--- a/TNLean/Algebra/UnitaryCompletionClass.lean
+++ b/TNLean/Algebra/UnitaryCompletionClass.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.GaussRepresentation
+
+/-!
+# Prescribed defect maps and their full unitary completion class
+
+When the fusion scalars of a non-injective invariant matrix product state are
+not block independent, the state-level construction of FBC25 prescribes the
+modified fusion operators only on physical defect subspaces: for every ordered
+pair `(a, b)` of gauge labels there is a defect subspace `K a b` of the matter
+space and an isometry `D a b` defined on it. The operator used on the whole
+matter space is any unitary agreeing with `D a b` on `K a b`, and the closing
+sentence of the modified-fusion lemma of FBC25 (arXiv:2502.20257,
+lines 4215--4260) records that such an extension is not unique. A completion is
+therefore the whole family `(U a b)`, not one selected operator.
+
+The matter operators are represented here as elements of
+`Matrix.unitaryGroup n ℂ`, the family type consumed by the local Gauss operator
+`TNLean.Algebra.gaussOperator`, so that a completion is literally an admissible
+argument of that operator and its gauge block
+`(U (T g (a, b)))⁻¹ * U a b` is the unitary factorization comparison
+`Matrix.unitaryFactorizationComparison`. Defect subspaces are submodules of
+`n → ℂ` and a prescribed isometry is given by an ambient matrix, whose
+restriction to the defect subspace carries all the mathematical content.
+
+The three transport results follow the derivation of the modified Gauss law in
+FBC25 (arXiv:2502.20257, lines 4325--4335) in the order it must be taken:
+agreement on the defect subspace, then an equality of images in the whole
+matter space, and only then multiplication by the adjoint of the target
+completion. No step asserts that the adjoint of a completion restricts to the
+adjoint of a prescribed defect map, which is false for a general completion.
+-/
+
+noncomputable section
+
+open scoped Matrix
+
+namespace TNLean.Algebra
+
+variable {G n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Prescribed defect maps: for every ordered pair `(a, b)` of gauge labels, a
+defect subspace `domain a b` of the matter space and a matrix whose restriction
+to it is the prescribed isometry `D a b`.
+
+This is the defect subspace `K_{a,b}` together with the isometry
+`D_{a,b} : K_{a,b} → H_m` of the state-level fusion construction of FBC25
+(arXiv:2502.20257, lines 4215--4260 and 4325--4335). -/
+structure DefectMaps (G n : Type*) [Fintype n] where
+  /-- The defect subspace of the matter space attached to the labels `(a, b)`. -/
+  domain : G → G → Submodule ℂ (n → ℂ)
+  /-- A matrix whose restriction to `domain a b` is the prescribed defect
+  isometry. -/
+  prescribed : G → G → Matrix n n ℂ
+  /-- The prescribed map is an isometry on its defect subspace. -/
+  isometry_on_domain : ∀ a b, ∀ ξ ∈ domain a b,
+    (star (prescribed a b) * prescribed a b) *ᵥ ξ = ξ
+
+namespace DefectMaps
+
+variable (D : DefectMaps G n)
+
+/-- A family of unitary matter operators is a completion of the prescribed
+defect maps when every member agrees with the prescribed map on its defect
+subspace.
+
+This is the membership condition of the full completion class attached to the
+modified fusion operators of FBC25 (arXiv:2502.20257, lines 4215--4260). -/
+def IsCompletion (R : G → G → Matrix.unitaryGroup n ℂ) : Prop :=
+  ∀ a b, ∀ ξ ∈ D.domain a b,
+    (R a b : Matrix n n ℂ) *ᵥ ξ = D.prescribed a b *ᵥ ξ
+
+/-- The full completion class of the prescribed defect maps, whose members are
+whole families of unitary matter operators.
+
+This is the completion class of the modified fusion operators of FBC25
+(arXiv:2502.20257, lines 4215--4260); no single pair of labels is singled
+out. -/
+def completionClass : Set (G → G → Matrix.unitaryGroup n ℂ) :=
+  {R | D.IsCompletion R}
+
+@[simp]
+theorem mem_completionClass_iff {R : G → G → Matrix.unitaryGroup n ℂ} :
+    R ∈ D.completionClass ↔ D.IsCompletion R :=
+  Iff.rfl
+
+variable {D}
+
+/-- A completion agrees with the prescribed defect map on its defect subspace.
+This is the first step of the transport derivation of FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+theorem IsCompletion.mulVec_eq_prescribed
+    {R : G → G → Matrix.unitaryGroup n ℂ} (hR : D.IsCompletion R) {a b : G}
+    {ξ : n → ℂ} (hξ : ξ ∈ D.domain a b) :
+    (R a b : Matrix n n ℂ) *ᵥ ξ = D.prescribed a b *ᵥ ξ :=
+  hR a b ξ hξ
+
+/-- Covariance of the prescribed defect maps on their defect subspaces implies
+the same covariance for every completion, as an equality of images in the whole
+matter space. This is the second step of the transport derivation of FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+theorem IsCompletion.mulVec_eq_mulVec
+    {R : G → G → Matrix.unitaryGroup n ℂ} (hR : D.IsCompletion R)
+    {a b c d : G} {ξ η : n → ℂ} (hξ : ξ ∈ D.domain a b)
+    (hη : η ∈ D.domain c d)
+    (hcov : D.prescribed a b *ᵥ ξ = D.prescribed c d *ᵥ η) :
+    (R a b : Matrix n n ℂ) *ᵥ ξ = (R c d : Matrix n n ℂ) *ᵥ η := by
+  rw [hR.mulVec_eq_prescribed hξ, hR.mulVec_eq_prescribed hη, hcov]
+
+/-- The transport identity: the gauge block of a completion carries a defect
+vector to the covariant one. This is the third step of the transport derivation
+of FBC25 (arXiv:2502.20257, lines 4325--4335); the adjoint of the target
+completion is applied only after the equality of images in the whole matter
+space is available. -/
+theorem IsCompletion.unitaryFactorizationComparison_mulVec
+    {R : G → G → Matrix.unitaryGroup n ℂ} (hR : D.IsCompletion R)
+    {a b c d : G} {ξ η : n → ℂ} (hξ : ξ ∈ D.domain a b)
+    (hη : η ∈ D.domain c d)
+    (hcov : D.prescribed a b *ᵥ ξ = D.prescribed c d *ᵥ η) :
+    (Matrix.unitaryFactorizationComparison R a b c d : Matrix n n ℂ) *ᵥ ξ = η := by
+  rw [Matrix.unitaryFactorizationComparison_coe, ← Matrix.mulVec_mulVec,
+    hR.mulVec_eq_mulVec hξ hη hcov, Matrix.mulVec_mulVec,
+    Matrix.UnitaryGroup.star_mul_self, Matrix.one_mulVec]
+
+variable [Group G]
+
+/-- The transport identity for the two gauge labels moved by the Gauss leg
+action. This is the exact defect-covariance identity used for the modified
+Gauss law of FBC25 (arXiv:2502.20257, lines 4325--4335). -/
+theorem IsCompletion.unitaryFactorizationComparison_gaussLegAction_mulVec
+    {R : G → G → Matrix.unitaryGroup n ℂ} (hR : D.IsCompletion R) (g : G)
+    {a b : G} {ξ η : n → ℂ} (hξ : ξ ∈ D.domain a b)
+    (hη : η ∈ D.domain (a * g⁻¹) (g * b))
+    (hcov : D.prescribed a b *ᵥ ξ = D.prescribed (a * g⁻¹) (g * b) *ᵥ η) :
+    (Matrix.unitaryFactorizationComparison R a b (a * g⁻¹) (g * b) :
+        Matrix n n ℂ) *ᵥ ξ = η :=
+  hR.unitaryFactorizationComparison_mulVec hξ hη hcov
+
+end DefectMaps
+
+end TNLean.Algebra

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -160,6 +160,7 @@ import TNLean.MPS.MPDO.GSNNCHFourCycleMarkov.FourCycle
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.GSNNCHSectorRescaling
 import TNLean.MPS.MPDO.GSNNCHSectorSum
+import TNLean.MPS.MPDO.GaugeInvariantSubspace
 import TNLean.MPS.MPDO.GaussProjectorPlacement
 import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.GroupedGramNormalization

--- a/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
@@ -10,12 +10,12 @@ import TNLean.MPS.MPDO.GaussProjectorPlacement
 /-!
 # The gauge-invariant subspace of a completion and its universal vector
 
-For a completion `R` of prescribed defect maps, the local Gauss operators are
+For a completion `R` of prescribed defect maps, the local Gauss projectors are
 placed on the periodic two-site windows of a chain of length `N`, and their
-common `+1` eigenspace is the gauge-invariant subspace. The modified Gauss
-laws of FBC25 (arXiv:2502.20257, lines 4325--4335) are of exactly this form,
-with the gauge block of the operator at the window `(j, j + 1)` comparing the
-completion at the two labels adjacent to that window.
+common `+1` eigenspace is the gauge-invariant subspace. The projectors average
+the modified Gauss laws of FBC25 (arXiv:2502.20257, lines 4325--4335), whose
+gauge block at the window `(j, j + 1)` compares the completion at the two
+labels adjacent to that window.
 
 A chain site carries one matter index and one gauge label. Matter defect
 states `Ψ α` indexed by gauge-label configurations `α` assemble into the
@@ -25,11 +25,12 @@ the matter part of that configuration, `α` being its gauge-label part; this is
 matter support inside every window lies in the defect subspace of the two
 labels adjacent to it, and the prescribed defect maps are exactly covariant
 under moving those two labels -- the gauged vector is fixed by every placed
-Gauss operator of every completion, so it lies in the gauge-invariant subspace,
-whose dimension is then at least one whenever the gauged vector does not
-vanish. This is the invariance statement following the modified Gauss laws of
-FBC25 (arXiv:2502.20257, lines 4325--4335); the question of the size of this
-subspace (arXiv:2502.20257, line 5198) is untouched.
+Gauss operator, hence by every placed projector, of every completion. It
+therefore lies in the gauge-invariant subspace, whose dimension is at least one
+whenever the gauged vector does not vanish. This is the invariance statement
+following the modified Gauss laws of FBC25 (arXiv:2502.20257, lines
+4325--4335); the question of the size of this subspace (arXiv:2502.20257,
+line 5198) is untouched.
 
 Commutativity of the placed projectors on neighbouring windows, a spectral
 gap, and any bound on the subspace beyond dimension at least one are not
@@ -465,15 +466,14 @@ theorem placedGaussProjector_mulVec_gaugedVector (hN : 2 ≤ N)
 variable (d G)
 
 /-- The gauge-invariant subspace of a completion: the common `+1` eigenspace of
-the placed Gauss operators at every window and every group element. This is the
-subspace `𝒱_N(R)` of FBC25 (arXiv:2502.20257, lines 4325--4335 and line 5198),
-described there as the common fixed subspace of the averaged projectors. No
-commutativity of the projectors on neighbouring windows is assumed. -/
+the placed Gauss projectors at every window. This is the subspace `𝒱_N(R)` of
+FBC25 (arXiv:2502.20257, lines 4325--4335 and line 5198). No commutativity of
+the projectors on neighbouring windows is assumed. -/
 def gaugeInvariantSubspace (N : ℕ) (hN : 2 ≤ N)
     (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
     Submodule ℂ ((Fin N → Fin (Fintype.card (Fin d × G))) → ℂ) :=
-  LinearMap.commonFixedSubmodule fun p : Fin N × G ↦
-    (placedGaussOperator d G N hN p.1 R p.2).mulVecLin
+  LinearMap.commonFixedSubmodule fun j : Fin N ↦
+    (placedGaussProjector d G N hN j R).mulVecLin
 
 variable {d G}
 
@@ -487,8 +487,8 @@ theorem gaugedVector_mem_gaugeInvariantSubspace (hN : 2 ≤ N)
     (hcov : HasPrescribedDefectCovariance d G hN Dd Ψ) :
     gaugedVector d G Ψ ∈ gaugeInvariantSubspace d G N hN R := by
   rw [gaugeInvariantSubspace, LinearMap.mem_commonFixedSubmodule_iff]
-  intro p
-  exact placedGaussOperator_mulVec_gaugedVector hN hR hsupp hcov p.1 p.2
+  intro j
+  exact placedGaussProjector_mulVec_gaugedVector hN hR hsupp hcov j
 
 /-- A nonvanishing gauged vector forces the gauge-invariant subspace of every
 completion to have dimension at least one. No upper bound and no bound

--- a/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
@@ -32,6 +32,12 @@ following the modified Gauss laws of FBC25 (arXiv:2502.20257, lines
 4325--4335); the question of the size of this subspace (arXiv:2502.20257,
 line 5198) is untouched.
 
+**Scope restriction (abstract defect covariance):** FBC25 derives the local
+support and covariance from locally orthogonal MPS blocks and its modified
+fusion maps. This module assumes those two properties. The remaining
+specialization is documented in
+`docs/paper-gaps/fbc25_state_level_gauging_covariance.tex` and tracked by #7569.
+
 Commutativity of the placed projectors on neighbouring windows, a spectral
 gap, and any bound on the subspace beyond dimension at least one are not
 treated here.

--- a/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
@@ -1,0 +1,509 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CommonFixedSubmodule
+import TNLean.Algebra.UnitaryCompletionClass
+import TNLean.MPS.MPDO.GaussProjectorPlacement
+
+/-!
+# The gauge-invariant subspace of a completion and its universal vector
+
+For a completion `R` of prescribed defect maps, the local Gauss operators are
+placed on the periodic two-site windows of a chain of length `N`, and their
+common `+1` eigenspace is the gauge-invariant subspace. The modified Gauss
+laws of FBC25 (arXiv:2502.20257, lines 4325--4335) are of exactly this form,
+with the gauge block of the operator at the window `(j, j + 1)` comparing the
+completion at the two labels adjacent to that window.
+
+A chain site carries one matter index and one gauge label. Matter defect
+states `Ψ α` indexed by gauge-label configurations `α` assemble into the
+gauged vector whose component at a configuration is the component of `Ψ α` at
+the matter part of that configuration, `α` being its gauge-label part; this is
+`∑_α Ψ_α ⊗ |α⟩`. Under two hypotheses on the matter defect states -- the
+matter support inside every window lies in the defect subspace of the two
+labels adjacent to it, and the prescribed defect maps are exactly covariant
+under moving those two labels -- the gauged vector is fixed by every placed
+Gauss operator of every completion, so it lies in the gauge-invariant subspace,
+whose dimension is then at least one whenever the gauged vector does not
+vanish. This is the invariance statement following the modified Gauss laws of
+FBC25 (arXiv:2502.20257, lines 4325--4335); the question of the size of this
+subspace (arXiv:2502.20257, line 5198) is untouched.
+
+Commutativity of the placed projectors on neighbouring windows, a spectral
+gap, and any bound on the subspace beyond dimension at least one are not
+treated here.
+-/
+
+noncomputable section
+
+open scoped BigOperators Matrix
+
+namespace MPOTensor
+
+/-! ### The label action at one window -/
+
+section LabelAction
+
+variable {G : Type*} [Group G] {N : ℕ}
+
+/-- The gauge-label configuration obtained by moving the two labels adjacent to
+the window `(j, j + 1)` by the Gauss leg action `T_g(a, b) = (a g⁻¹, g b)` and
+leaving every other label unchanged.
+
+This is the label configuration `T_{j,g} α` of FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+def chainLabelAction (hN : 2 ≤ N) (j : Fin N) (g : G) (α : Fin N → G) :
+    Fin N → G :=
+  MPSTensor.replaceWindow 2 hN j α
+    ![MPSTensor.extractWindow 2 j α 0 * g⁻¹, g * MPSTensor.extractWindow 2 j α 1]
+
+@[simp]
+theorem extractWindow_chainLabelAction_zero (hN : 2 ≤ N) (j : Fin N) (g : G)
+    (α : Fin N → G) :
+    MPSTensor.extractWindow 2 j (chainLabelAction hN j g α) 0 =
+      MPSTensor.extractWindow 2 j α 0 * g⁻¹ := by
+  rw [chainLabelAction, MPSTensor.extractWindow_replaceWindow]
+  rfl
+
+@[simp]
+theorem extractWindow_chainLabelAction_one (hN : 2 ≤ N) (j : Fin N) (g : G)
+    (α : Fin N → G) :
+    MPSTensor.extractWindow 2 j (chainLabelAction hN j g α) 1 =
+      g * MPSTensor.extractWindow 2 j α 1 := by
+  rw [chainLabelAction, MPSTensor.extractWindow_replaceWindow]
+  rfl
+
+@[simp]
+theorem chainLabelAction_one (hN : 2 ≤ N) (j : Fin N) (α : Fin N → G) :
+    chainLabelAction hN j (1 : G) α = α := by
+  have hvec : (![MPSTensor.extractWindow 2 j α 0 * (1 : G)⁻¹,
+      (1 : G) * MPSTensor.extractWindow 2 j α 1] : Fin 2 → G) =
+      MPSTensor.extractWindow 2 j α := by
+    funext k
+    fin_cases k <;> simp
+  rw [chainLabelAction, hvec, MPSTensor.replaceWindow_extractWindow]
+
+/-- The label actions at one window compose according to the group law, as the
+Gauss leg actions do. -/
+theorem chainLabelAction_chainLabelAction (hN : 2 ≤ N) (j : Fin N) (g h : G)
+    (α : Fin N → G) :
+    chainLabelAction hN j g (chainLabelAction hN j h α) =
+      chainLabelAction hN j (g * h) α := by
+  have hvec : (![MPSTensor.extractWindow 2 j (chainLabelAction hN j h α) 0 * g⁻¹,
+      g * MPSTensor.extractWindow 2 j (chainLabelAction hN j h α) 1] : Fin 2 → G) =
+      ![MPSTensor.extractWindow 2 j α 0 * (g * h)⁻¹,
+        g * h * MPSTensor.extractWindow 2 j α 1] := by
+    funext k
+    fin_cases k <;>
+      simp [extractWindow_chainLabelAction_zero, extractWindow_chainLabelAction_one,
+        mul_assoc, mul_inv_rev]
+  rw [chainLabelAction, hvec, chainLabelAction,
+    MPSTensor.replaceWindow_replaceWindow_same, chainLabelAction]
+
+/-- Moving the two labels adjacent to one window is a bijection of gauge-label
+configurations, with inverse the move by the inverse group element. This is the
+bijection `T_{j,g}` used to reindex the sum over gauge-label configurations in
+FBC25 (arXiv:2502.20257, lines 4325--4335). -/
+def chainLabelActionEquiv (hN : 2 ≤ N) (j : Fin N) (g : G) :
+    (Fin N → G) ≃ (Fin N → G) where
+  toFun := chainLabelAction hN j g
+  invFun := chainLabelAction hN j g⁻¹
+  left_inv α := by
+    rw [chainLabelAction_chainLabelAction, inv_mul_cancel, chainLabelAction_one]
+  right_inv α := by
+    rw [chainLabelAction_chainLabelAction, mul_inv_cancel, chainLabelAction_one]
+
+@[simp]
+theorem chainLabelActionEquiv_apply (hN : 2 ≤ N) (j : Fin N) (g : G)
+    (α : Fin N → G) :
+    chainLabelActionEquiv hN j g α = chainLabelAction hN j g α :=
+  rfl
+
+end LabelAction
+
+/-! ### Matter and gauge parts of a chain configuration -/
+
+section Configurations
+
+variable (d : ℕ) (G : Type*) [Fintype G]
+
+/-- The matter part of a configuration of sites, each carrying one matter index
+and one gauge label. -/
+def gaugedMatter {ι : Type*} (σ : ι → Fin (Fintype.card (Fin d × G))) : ι → Fin d :=
+  fun k ↦ ((Fintype.equivFin (Fin d × G)).symm (σ k)).1
+
+/-- The gauge-label part of a configuration of sites, each carrying one matter
+index and one gauge label. -/
+def gaugedLabel {ι : Type*} (σ : ι → Fin (Fintype.card (Fin d × G))) : ι → G :=
+  fun k ↦ ((Fintype.equivFin (Fin d × G)).symm (σ k)).2
+
+theorem gaugedMatter_extractWindow (L : ℕ) {M : ℕ} (i : Fin M)
+    (σ : Fin M → Fin (Fintype.card (Fin d × G))) :
+    gaugedMatter d G (MPSTensor.extractWindow L i σ) =
+      MPSTensor.extractWindow L i (gaugedMatter d G σ) :=
+  rfl
+
+theorem gaugedLabel_extractWindow (L : ℕ) {M : ℕ} (i : Fin M)
+    (σ : Fin M → Fin (Fintype.card (Fin d × G))) :
+    gaugedLabel d G (MPSTensor.extractWindow L i σ) =
+      MPSTensor.extractWindow L i (gaugedLabel d G σ) :=
+  rfl
+
+private theorem comp_replaceWindow {α β : Type*} (f : α → β) (L : ℕ) {M : ℕ}
+    (hLM : L ≤ M) (i : Fin M) (σ : Fin M → α) (τ : Fin L → α) :
+    (fun k ↦ f (MPSTensor.replaceWindow L hLM i σ τ k)) =
+      MPSTensor.replaceWindow L hLM i (fun k ↦ f (σ k)) (fun k ↦ f (τ k)) := by
+  funext k
+  unfold MPSTensor.replaceWindow
+  by_cases h : (k.val + M - i.val) % M < L <;> simp [h]
+
+theorem gaugedMatter_replaceWindow (L : ℕ) {M : ℕ} (hLM : L ≤ M) (i : Fin M)
+    (σ : Fin M → Fin (Fintype.card (Fin d × G)))
+    (τ : Fin L → Fin (Fintype.card (Fin d × G))) :
+    gaugedMatter d G (MPSTensor.replaceWindow L hLM i σ τ) =
+      MPSTensor.replaceWindow L hLM i (gaugedMatter d G σ) (gaugedMatter d G τ) :=
+  comp_replaceWindow (fun s ↦ ((Fintype.equivFin (Fin d × G)).symm s).1) L hLM i σ τ
+
+theorem gaugedLabel_replaceWindow (L : ℕ) {M : ℕ} (hLM : L ≤ M) (i : Fin M)
+    (σ : Fin M → Fin (Fintype.card (Fin d × G)))
+    (τ : Fin L → Fin (Fintype.card (Fin d × G))) :
+    gaugedLabel d G (MPSTensor.replaceWindow L hLM i σ τ) =
+      MPSTensor.replaceWindow L hLM i (gaugedLabel d G σ) (gaugedLabel d G τ) :=
+  comp_replaceWindow (fun s ↦ ((Fintype.equivFin (Fin d × G)).symm s).2) L hLM i σ τ
+
+end Configurations
+
+section GaugedVector
+
+variable (d : ℕ) (G : Type*) [Group G] [Fintype G] [DecidableEq G] {N : ℕ}
+
+omit [Group G] [DecidableEq G] in
+/-- A two-site configuration is determined by its matter and gauge-label
+parts. -/
+theorem gaussLocalCoordinateEquiv_symm_apply
+    (τ : Fin 2 → Fin (Fintype.card (Fin d × G))) :
+    (gaussLocalCoordinateEquiv d G).symm τ =
+      (gaugedMatter d G τ, (gaugedLabel d G τ 0, gaugedLabel d G τ 1)) := by
+  rw [Equiv.symm_apply_eq]
+  funext k
+  fin_cases k <;> simp [gaugedMatter, gaugedLabel]
+
+omit [Group G] [DecidableEq G] in
+@[simp]
+theorem gaugedMatter_gaussLocalCoordinateEquiv
+    (y : (Fin 2 → Fin d) × (G × G)) :
+    gaugedMatter d G (gaussLocalCoordinateEquiv d G y) = y.1 := by
+  funext k
+  fin_cases k <;> simp [gaugedMatter]
+
+omit [Group G] [DecidableEq G] in
+@[simp]
+theorem gaugedLabel_gaussLocalCoordinateEquiv
+    (y : (Fin 2 → Fin d) × (G × G)) :
+    gaugedLabel d G (gaussLocalCoordinateEquiv d G y) = ![y.2.1, y.2.2] := by
+  funext k
+  fin_cases k <;> simp [gaugedLabel]
+
+/-- The local Gauss operator reindexed into two-site chain-window
+coordinates. -/
+def gaussWindowOperator
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) (g : G) :
+    Matrix (Fin 2 → Fin (Fintype.card (Fin d × G)))
+      (Fin 2 → Fin (Fintype.card (Fin d × G))) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ (gaussLocalCoordinateEquiv d G)
+    (TNLean.Algebra.gaussOperator R g)
+
+theorem gaussWindowOperator_apply
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) (g : G)
+    (u y : (Fin 2 → Fin d) × (G × G)) :
+    gaussWindowOperator d G R g (gaussLocalCoordinateEquiv d G u)
+        (gaussLocalCoordinateEquiv d G y) =
+      TNLean.Algebra.gaussOperator R g u y := by
+  simp only [gaussWindowOperator, Matrix.coe_reindexAlgEquiv,
+    Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.symm_apply_apply]
+
+/-- The local Gauss operator of a completion placed on the periodic two-site
+window beginning at `j`. This is the modified Gauss law `𝒢̃^{j,j+1}_g(R)` of
+FBC25 (arXiv:2502.20257, lines 4325--4335). -/
+def placedGaussOperator (N : ℕ) (hN : 2 ≤ N) (j : Fin N)
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) (g : G) :
+    MPOTensor.ChainOperator (Fintype.card (Fin d × G)) N :=
+  MPOTensor.embedLocalOperator 2 N hN j (gaussWindowOperator d G R g)
+
+/-- The gauged vector `∑_α Ψ_α ⊗ |α⟩` assembled from matter defect states
+indexed by gauge-label configurations, as in FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+def gaugedVector (Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ) :
+    (Fin N → Fin (Fintype.card (Fin d × G))) → ℂ :=
+  fun σ ↦ Ψ (gaugedLabel d G σ) (gaugedMatter d G σ)
+
+omit [Group G] [DecidableEq G] in
+@[simp]
+theorem gaugedVector_apply (Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ)
+    (σ : Fin N → Fin (Fintype.card (Fin d × G))) :
+    gaugedVector d G Ψ σ = Ψ (gaugedLabel d G σ) (gaugedMatter d G σ) :=
+  rfl
+
+/-- The matter support of every defect state inside the window `(j, j + 1)`
+lies in the defect subspace of the two labels adjacent to that window. This is
+the local support hypothesis on the matter defect states of FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+def HasDefectSupport (hN : 2 ≤ N)
+    (Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d))
+    (Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ) : Prop :=
+  ∀ (α : Fin N → G) (j : Fin N) (x : Fin N → Fin d),
+    (fun m ↦ Ψ α (MPSTensor.replaceWindow 2 hN j x m)) ∈
+      Dd.domain (MPSTensor.extractWindow 2 j α 0)
+        (MPSTensor.extractWindow 2 j α 1)
+
+/-- Exact covariance of the prescribed defect maps on the matter defect states:
+applying the prescribed map of the two labels adjacent to a window gives the
+same vector as applying the prescribed map of the moved labels to the defect
+state of the moved label configuration. This is the exact defect-fusion
+covariance underlying the modified Gauss laws of FBC25
+(arXiv:2502.20257, lines 4325--4335). -/
+def HasPrescribedDefectCovariance (hN : 2 ≤ N)
+    (Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d))
+    (Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ) : Prop :=
+  ∀ (α : Fin N → G) (j : Fin N) (g : G),
+    MPOTensor.embedLocalOperator 2 N hN j
+        (Dd.prescribed (MPSTensor.extractWindow 2 j α 0)
+          (MPSTensor.extractWindow 2 j α 1)) *ᵥ Ψ α =
+      MPOTensor.embedLocalOperator 2 N hN j
+        (Dd.prescribed (MPSTensor.extractWindow 2 j α 0 * g⁻¹)
+          (g * MPSTensor.extractWindow 2 j α 1)) *ᵥ
+        Ψ (chainLabelAction hN j g α)
+
+end GaugedVector
+
+/-- A placed operator applied to a vector, evaluated at a configuration whose
+window has been replaced, is the local operator applied to the matter slice of
+that vector over the same window. -/
+theorem embedLocalOperator_mulVec_replaceWindow {D' : ℕ} (L : ℕ) (M : ℕ)
+    (hLM : L ≤ M) (i : Fin M)
+    (B : Matrix (Fin L → Fin D') (Fin L → Fin D') ℂ)
+    (v : (Fin M → Fin D') → ℂ) (x : Fin M → Fin D') (r : Fin L → Fin D') :
+    (MPOTensor.embedLocalOperator L M hLM i B *ᵥ v)
+        (MPSTensor.replaceWindow L hLM i x r) =
+      (B *ᵥ fun m ↦ v (MPSTensor.replaceWindow L hLM i x m)) r := by
+  rw [MPOTensor.embedLocalOperator_mulVec_apply]
+  simp only [MPSTensor.extractWindow_replaceWindow,
+    MPSTensor.replaceWindow_replaceWindow_same, Matrix.mulVec, dotProduct]
+
+section Invariance
+
+variable {d : ℕ} {G : Type*} [Group G] [Fintype G] [DecidableEq G] {N : ℕ}
+
+/-- Every placed Gauss operator of every completion fixes the gauged vector.
+
+This is the invariance of the gauged state under the modified Gauss laws of
+FBC25 (arXiv:2502.20257, lines 4325--4335). The proof uses the exact covariance
+of the prescribed defect maps before any adjoint is applied. -/
+theorem placedGaussOperator_mulVec_gaugedVector (hN : 2 ≤ N)
+    {Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d)}
+    {R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ}
+    (hR : Dd.IsCompletion R) {Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ}
+    (hsupp : HasDefectSupport d G hN Dd Ψ)
+    (hcov : HasPrescribedDefectCovariance d G hN Dd Ψ) (j : Fin N) (g : G) :
+    placedGaussOperator d G N hN j R g *ᵥ gaugedVector d G Ψ =
+      gaugedVector d G Ψ := by
+  classical
+  funext σ
+  set x : Fin N → Fin d := gaugedMatter d G σ with hxdef
+  set α : Fin N → G := gaugedLabel d G σ with hαdef
+  set a : G := MPSTensor.extractWindow 2 j α 0 with hadef
+  set b : G := MPSTensor.extractWindow 2 j α 1 with hbdef
+  set β : Fin N → G := chainLabelAction hN j g⁻¹ α with hβdef
+  have hβ0 : MPSTensor.extractWindow 2 j β 0 = a * g := by
+    rw [hβdef, extractWindow_chainLabelAction_zero, inv_inv]
+  have hβ1 : MPSTensor.extractWindow 2 j β 1 = g⁻¹ * b := by
+    rw [hβdef, extractWindow_chainLabelAction_one]
+  have hβα : chainLabelAction hN j g β = α := by
+    rw [hβdef, chainLabelAction_chainLabelAction, mul_inv_cancel,
+      chainLabelAction_one]
+  set ξ : (Fin 2 → Fin d) → ℂ :=
+    fun m ↦ Ψ β (MPSTensor.replaceWindow 2 hN j x m) with hξdef
+  set η : (Fin 2 → Fin d) → ℂ :=
+    fun m ↦ Ψ α (MPSTensor.replaceWindow 2 hN j x m) with hηdef
+  have hmemξ : ξ ∈ Dd.domain (a * g) (g⁻¹ * b) := by
+    have h := hsupp β j x
+    rwa [hβ0, hβ1] at h
+  have hmemη : η ∈ Dd.domain a b := hsupp α j x
+  have hcovslice :
+      Dd.prescribed (a * g) (g⁻¹ * b) *ᵥ ξ = Dd.prescribed a b *ᵥ η := by
+    have h := hcov β j g
+    rw [hβα, hβ0, hβ1] at h
+    have hleft : a * g * g⁻¹ = a := by group
+    have hright : g * (g⁻¹ * b) = b := by group
+    rw [hleft, hright] at h
+    funext r
+    have hr := congrFun h (MPSTensor.replaceWindow 2 hN j x r)
+    rw [embedLocalOperator_mulVec_replaceWindow,
+      embedLocalOperator_mulVec_replaceWindow] at hr
+    exact hr
+  have htransport :
+      (Matrix.unitaryFactorizationComparison R (a * g) (g⁻¹ * b) a b :
+        Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) *ᵥ ξ = η :=
+    hR.unitaryFactorizationComparison_mulVec hmemξ hmemη hcovslice
+  have hextract : MPSTensor.extractWindow 2 j σ =
+      gaussLocalCoordinateEquiv d G
+        (MPSTensor.extractWindow 2 j x, (a, b)) := by
+    have h := gaussLocalCoordinateEquiv_symm_apply d G
+      (MPSTensor.extractWindow 2 j σ)
+    rw [Equiv.symm_apply_eq] at h
+    rw [h, hxdef, hadef, hbdef, hαdef, gaugedMatter_extractWindow,
+      gaugedLabel_extractWindow]
+  have hmove : TNLean.Algebra.gaussLegAction g ((a * g, g⁻¹ * b) : G × G) =
+      (a, b) := by
+    rw [TNLean.Algebra.gaussLegAction_apply]
+    simp
+  have hterm : ∀ (m : Fin 2 → Fin d) (pq : G × G),
+      gaussWindowOperator d G R g (MPSTensor.extractWindow 2 j σ)
+          (gaussLocalCoordinateEquiv d G (m, pq)) *
+        gaugedVector d G Ψ
+          (MPSTensor.replaceWindow 2 hN j σ
+            (gaussLocalCoordinateEquiv d G (m, pq))) =
+      if pq = (a * g, g⁻¹ * b) then
+        (Matrix.unitaryFactorizationComparison R (a * g) (g⁻¹ * b) a b :
+          Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ)
+            (MPSTensor.extractWindow 2 j x) m * ξ m
+      else 0 := by
+    intro m pq
+    rw [hextract, gaussWindowOperator_apply]
+    by_cases hpq : pq = (a * g, g⁻¹ * b)
+    · subst hpq
+      have hentry :
+          TNLean.Algebra.gaussOperator R g
+              (MPSTensor.extractWindow 2 j x, (a, b))
+              (m, ((a * g, g⁻¹ * b) : G × G)) =
+            (Matrix.unitaryFactorizationComparison R (a * g) (g⁻¹ * b) a b :
+              Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ)
+              (MPSTensor.extractWindow 2 j x) m := by
+        rw [← hmove, TNLean.Algebra.gaussOperator_apply_target]
+        have hleft : a * g * g⁻¹ = a := by group
+        have hright : g * (g⁻¹ * b) = b := by group
+        rw [hleft, hright]
+      rw [hentry, ite_eq_left rfl]
+      congr 1
+      have hmatter : gaugedMatter d G
+          (MPSTensor.replaceWindow 2 hN j σ
+            (gaussLocalCoordinateEquiv d G (m, ((a * g, g⁻¹ * b) : G × G)))) =
+          MPSTensor.replaceWindow 2 hN j x m := by
+        rw [gaugedMatter_replaceWindow, gaugedMatter_gaussLocalCoordinateEquiv]
+      have hlabel : gaugedLabel d G
+          (MPSTensor.replaceWindow 2 hN j σ
+            (gaussLocalCoordinateEquiv d G (m, ((a * g, g⁻¹ * b) : G × G)))) =
+          β := by
+        rw [gaugedLabel_replaceWindow, gaugedLabel_gaussLocalCoordinateEquiv,
+          hβdef, chainLabelAction, inv_inv]
+      rw [gaugedVector_apply, hmatter, hlabel]
+    · have hne : ((MPSTensor.extractWindow 2 j x, (a, b)) :
+          (Fin 2 → Fin d) × (G × G)).2 ≠
+          TNLean.Algebra.gaussLegAction g
+            ((m, pq) : (Fin 2 → Fin d) × (G × G)).2 := by
+        intro hEq
+        exact hpq
+          (((TNLean.Algebra.gaussLegAction g).injective (hmove.trans hEq)).symm)
+      rw [TNLean.Algebra.gaussOperator_apply_of_ne R g _ _ hne]
+      simp [hpq]
+  rw [placedGaussOperator, MPOTensor.embedLocalOperator_mulVec_apply,
+    ← Equiv.sum_comp (gaussLocalCoordinateEquiv d G)
+      (fun τ ↦ gaussWindowOperator d G R g (MPSTensor.extractWindow 2 j σ) τ *
+        gaugedVector d G Ψ (MPSTensor.replaceWindow 2 hN j σ τ)),
+    Fintype.sum_prod_type]
+  simp only [hterm, Fintype.sum_ite_eq']
+  have hsum : ∑ m : Fin 2 → Fin d,
+      (Matrix.unitaryFactorizationComparison R (a * g) (g⁻¹ * b) a b :
+        Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ)
+          (MPSTensor.extractWindow 2 j x) m * ξ m =
+      ((Matrix.unitaryFactorizationComparison R (a * g) (g⁻¹ * b) a b :
+        Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) *ᵥ ξ)
+        (MPSTensor.extractWindow 2 j x) := rfl
+  rw [hsum, htransport]
+  have hvalue : η (MPSTensor.extractWindow 2 j x) = Ψ α x := by
+    rw [hηdef]
+    simp only [MPSTensor.replaceWindow_extractWindow]
+  rw [hvalue, gaugedVector_apply, hxdef, hαdef]
+
+/-- The placed Gauss projector is the normalized sum over the group of the
+placed Gauss operators. -/
+theorem placedGaussProjector_eq_average (hN : 2 ≤ N) (j : Fin N)
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    placedGaussProjector d G N hN j R =
+      (Fintype.card G : ℂ)⁻¹ • ∑ g : G, placedGaussOperator d G N hN j R g := by
+  classical
+  have hwindow : gaussWindowProjector d G R =
+      (Fintype.card G : ℂ)⁻¹ • ∑ g : G, gaussWindowOperator d G R g := by
+    ext u v
+    simp [gaussWindowProjector, gaussWindowOperator, Matrix.reindex_apply,
+      TNLean.Algebra.gaussProjector_eq_average]
+  ext σ τ
+  by_cases hagree : MPOTensor.AgreesOutsideWindow
+      (d := Fintype.card (Fin d × G)) 2 hN j σ τ <;>
+    simp [placedGaussProjector, placedGaussOperator, hwindow, hagree,
+      Matrix.sum_apply, embedLocalOperator_apply]
+
+/-- The gauged vector is fixed by every placed Gauss projector of every
+completion. -/
+theorem placedGaussProjector_mulVec_gaugedVector (hN : 2 ≤ N)
+    {Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d)}
+    {R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ}
+    (hR : Dd.IsCompletion R) {Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ}
+    (hsupp : HasDefectSupport d G hN Dd Ψ)
+    (hcov : HasPrescribedDefectCovariance d G hN Dd Ψ) (j : Fin N) :
+    placedGaussProjector d G N hN j R *ᵥ gaugedVector d G Ψ =
+      gaugedVector d G Ψ := by
+  have hcard : (Fintype.card G : ℂ) ≠ 0 := by
+    simp [Fintype.card_ne_zero (α := G)]
+  rw [placedGaussProjector_eq_average, Matrix.smul_mulVec, Matrix.sum_mulVec]
+  simp only [placedGaussOperator_mulVec_gaugedVector hN hR hsupp hcov j,
+    Finset.sum_const, Finset.card_univ]
+  rw [← Nat.cast_smul_eq_nsmul ℂ, smul_smul, inv_mul_cancel₀ hcard, one_smul]
+
+variable (d G)
+
+/-- The gauge-invariant subspace of a completion: the common `+1` eigenspace of
+the placed Gauss operators at every window and every group element. This is the
+subspace `𝒱_N(R)` of FBC25 (arXiv:2502.20257, lines 4325--4335 and line 5198),
+described there as the common fixed subspace of the averaged projectors. No
+commutativity of the projectors on neighbouring windows is assumed. -/
+def gaugeInvariantSubspace (N : ℕ) (hN : 2 ≤ N)
+    (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) :
+    Submodule ℂ ((Fin N → Fin (Fintype.card (Fin d × G))) → ℂ) :=
+  LinearMap.commonFixedSubmodule fun p : Fin N × G ↦
+    (placedGaussOperator d G N hN p.1 R p.2).mulVecLin
+
+variable {d G}
+
+/-- The gauged vector lies in the gauge-invariant subspace of every
+completion. -/
+theorem gaugedVector_mem_gaugeInvariantSubspace (hN : 2 ≤ N)
+    {Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d)}
+    {R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ}
+    (hR : Dd.IsCompletion R) {Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ}
+    (hsupp : HasDefectSupport d G hN Dd Ψ)
+    (hcov : HasPrescribedDefectCovariance d G hN Dd Ψ) :
+    gaugedVector d G Ψ ∈ gaugeInvariantSubspace d G N hN R := by
+  rw [gaugeInvariantSubspace, LinearMap.mem_commonFixedSubmodule_iff]
+  intro p
+  exact placedGaussOperator_mulVec_gaugedVector hN hR hsupp hcov p.1 p.2
+
+/-- A nonvanishing gauged vector forces the gauge-invariant subspace of every
+completion to have dimension at least one. No upper bound and no bound
+independent of the completion follows from this. -/
+theorem one_le_finrank_gaugeInvariantSubspace (hN : 2 ≤ N)
+    {Dd : TNLean.Algebra.DefectMaps G (Fin 2 → Fin d)}
+    {R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ}
+    (hR : Dd.IsCompletion R) {Ψ : (Fin N → G) → (Fin N → Fin d) → ℂ}
+    (hsupp : HasDefectSupport d G hN Dd Ψ)
+    (hcov : HasPrescribedDefectCovariance d G hN Dd Ψ)
+    (hne : gaugedVector d G Ψ ≠ 0) :
+    1 ≤ Module.finrank ℂ (gaugeInvariantSubspace d G N hN R) :=
+  LinearMap.one_le_finrank_commonFixedSubmodule _
+    (gaugedVector_mem_gaugeInvariantSubspace hN hR hsupp hcov) hne
+
+end Invariance
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
@@ -36,7 +36,7 @@ line 5198) is untouched.
 support and covariance from locally orthogonal MPS blocks and its modified
 fusion maps. This module assumes those two properties. The remaining
 specialization is documented in
-`docs/paper-gaps/fbc25_state_level_gauging_covariance.tex` and tracked by #7569.
+`docs/paper-gaps/fbc25_state_level_gauging_covariance.tex`.
 
 Commutativity of the placed projectors on neighbouring windows, a spectral
 gap, and any bound on the subspace beyond dimension at least one are not

--- a/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/GaugeInvariantSubspace.lean
@@ -225,7 +225,7 @@ theorem gaussWindowOperator_apply
     Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.symm_apply_apply]
 
 /-- The local Gauss operator of a completion placed on the periodic two-site
-window beginning at `j`. This is the modified Gauss law `𝒢̃^{j,j+1}_g(R)` of
+window beginning at `j`. This is the modified (tilded) Gauss law `𝒢^{j,j+1}_g(R)` of
 FBC25 (arXiv:2502.20257, lines 4325--4335). -/
 def placedGaussOperator (N : ℕ) (hN : 2 ≤ N) (j : Fin N)
     (R : G → G → Matrix.unitaryGroup (Fin 2 → Fin d) ℂ) (g : G) :

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1435,7 +1435,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_chain_label_action}
     For all $g,h\in G$,
     \begin{align}
-        T_{j,e}        & =\id,                 \\
+        T_{j,e}        & =\id,      \\
         T_{j,g}T_{j,h} & =T_{j,gh}.
         \label{eq:mpug_chain_label_action_mul}
     \end{align}
@@ -1560,6 +1560,8 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \discussion{7569}
     \uses{def:mpug_placed_gauss_operator,
+        def:mpug_completion_class,
+        def:mpug_gauged_vector,
         def:mpug_defect_state_hypotheses,
         thm:mpug_completion_transport,
         thm:mpug_chain_label_action_mul,
@@ -1570,7 +1572,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}
          & =\ket{\Psi_{\mathrm{gauged}}},
-        \label{eq:mpug_universal_invariant_vector}                      \\
+        \label{eq:mpug_universal_invariant_vector} \\
         \widetilde P_j(R)\ket{\Psi_{\mathrm{gauged}}}
          & =\ket{\Psi_{\mathrm{gauged}}}.
     \end{align}
@@ -1581,11 +1583,12 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         thm:mpug_chain_label_action_mul,
         thm:mpug_placed_gauss_projector_average,
         def:mpug_gauss_operator}
-    Fix a chain configuration and let $\alpha$ be its gauge-label part, with
-    $(a,b)=(a_j,a_{j+1})$ the two labels adjacent to the window. In the
-    column of $\widetilde{\mathcal G}^{j,j+1}_g(R)$ indexed by that
-    configuration only the gauge labels $T_{j,g^{-1}}\alpha$ survive, so with
-    $\beta=T_{j,g^{-1}}\alpha$ the component of
+    Fix an output chain configuration and let $\alpha$ be its gauge-label part,
+    with $(a,b)=(a_j,a_{j+1})$ the two labels adjacent to the window. Among the
+    columns contributing to this fixed output row of
+    $\widetilde{\mathcal G}^{j,j+1}_g(R)$, only the gauge labels
+    $T_{j,g^{-1}}\alpha$ survive. Thus, with
+    $\beta=T_{j,g^{-1}}\alpha$, the component of
     $\widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}$ equals
     the component of
     \begin{align}
@@ -1611,14 +1614,15 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \lean{MPOTensor.gaugeInvariantSubspace}
     \leanok
     \discussion{7569}
-    \uses{def:mpug_common_fixed_subspace, def:mpug_placed_gauss_operator}
+    \uses{def:mpug_common_fixed_subspace,
+        def:mpug_placed_gauss_projector}
     For $R\in\mathfrak C(D)$ and a chain of length $N\geq2$, the
     gauge-invariant subspace is the common fixed subspace
     \begin{align}
         \mathcal V_N(R)
          & =\left\{\ket{\phi}:
-        \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\phi}=\ket{\phi}
-        \text{ for every }j\text{ and every }g\in G\right\}.
+        \widetilde P_j(R)\ket{\phi}=\ket{\phi}
+        \text{ for every }j\right\}.
         \label{eq:mpug_gauge_invariant_subspace}
     \end{align}
     No commutativity of the projectors on neighbouring windows is assumed;
@@ -1655,9 +1659,9 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{thm:mpug_universal_invariant_vector,
         thm:mpug_mem_common_fixed_subspace,
         thm:mpug_common_fixed_subspace_finrank}
-    Membership is~(\ref{eq:mpug_universal_invariant_vector}) at every window
-    and every group element. A nonzero member of a subspace forces its
-    dimension to be at least one.
+    Membership is the projector identity in
+    Theorem~\ref{thm:mpug_universal_invariant_vector} at every window. A
+    nonzero member of a subspace forces its dimension to be at least one.
 \end{proof}
 
 \begin{definition}[Scalar cochains and normalization]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1350,9 +1350,9 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \label{eq:mpug_completion_class}
     \end{align}
     A completion is the entire family $(U_{a,b})_{a,b\in G}$, not one
-    selected operator of that family. The extension of $D_{a,b}$ to the whole
-    of $\mathcal H_{\mathrm m}$ is not unique, as observed at the end of the
-    proof of the modified-fusion lemma
+    selected operator of that family. If $\mathcal K_{a,b}$ does not span the
+    whole matter space, the extension of $D_{a,b}$ need not be unique, as
+    observed at the end of the proof of the modified-fusion lemma
     of~\cite[lines~4215--4326]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
@@ -1617,6 +1617,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \discussion{7569}
     \uses{def:mpug_common_fixed_subspace,
+        def:mpug_completion_class,
         def:mpug_placed_gauss_projector}
     For $R\in\mathfrak C(D)$ and a chain of length $N\geq2$, the
     gauge-invariant subspace is the common fixed subspace

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1376,10 +1376,10 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \end{align}
     Then
     \begin{align}
-        U_{a,b}\ket{\xi}          & =D_{a,b}\ket{\xi},
-        \label{eq:mpug_completion_agrees}                                    \\
-        U_{a,b}\ket{\xi}          & =U_{c,d}\ket{\eta},
-        \label{eq:mpug_completion_covariance}                                \\
+        U_{a,b}\ket{\xi}             & =D_{a,b}\ket{\xi},
+        \label{eq:mpug_completion_agrees}                  \\
+        U_{a,b}\ket{\xi}             & =U_{c,d}\ket{\eta},
+        \label{eq:mpug_completion_covariance}              \\
         \lambda_{a,b}^{c,d}\ket{\xi} & =\ket{\eta}.
         \label{eq:mpug_completion_transport}
     \end{align}
@@ -1435,7 +1435,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \uses{def:mpug_chain_label_action}
     For all $g,h\in G$,
     \begin{align}
-        T_{j,e}      & =\id,                     \\
+        T_{j,e}        & =\id,                 \\
         T_{j,g}T_{j,h} & =T_{j,gh}.
         \label{eq:mpug_chain_label_action_mul}
     \end{align}
@@ -1570,7 +1570,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \begin{align}
         \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}
          & =\ket{\Psi_{\mathrm{gauged}}},
-        \label{eq:mpug_universal_invariant_vector}                     \\
+        \label{eq:mpug_universal_invariant_vector}                      \\
         \widetilde P_j(R)\ket{\Psi_{\mathrm{gauged}}}
          & =\ket{\Psi_{\mathrm{gauged}}}.
     \end{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1353,7 +1353,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     selected operator of that family. The extension of $D_{a,b}$ to the whole
     of $\mathcal H_{\mathrm m}$ is not unique, as observed at the end of the
     proof of the modified-fusion lemma
-    of~\cite[lines~4215--4260]{FrancoRubio2025MPUGauging}.
+    of~\cite[lines~4215--4326]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
 \begin{theorem}[Transport identity for a completion]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1326,7 +1326,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \label{eq:mpug_defect_isometry}
     \end{align}
     When the fusion scalars are not block independent, the state-level
-    construction of~\cite[lines~4215--4260]{FrancoRubio2025MPUGauging}
+    construction of~\cite[lines~4215--4326]{FrancoRubio2025MPUGauging}
     prescribes the modified fusion operators only on such subspaces.
     % Source anchor: arXiv:2502.20257, lemma:modif and the sentence closing
     % its proof.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1307,6 +1307,359 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     dimension is at least one.
 \end{proof}
 
+\begin{definition}[Prescribed defect maps]
+    \label{def:mpug_defect_maps}
+    \lean{TNLean.Algebra.DefectMaps}
+    \leanok
+    \discussion{7569}
+    Let $\mathcal H_{\mathrm m}$ be the matter space of two sites. Prescribed
+    defect maps assign to every ordered pair $(a,b)\in G^2$ a defect subspace
+    \begin{align}
+        \mathcal K_{a,b} & \subseteq\mathcal H_{\mathrm m}
+    \end{align}
+    together with a map $D_{a,b}$ of $\mathcal H_{\mathrm m}$ whose
+    restriction to that subspace is an isometry: for every
+    $\ket{\xi}\in\mathcal K_{a,b}$,
+    \begin{align}
+        D_{a,b}^\dagger D_{a,b}\ket{\xi}
+         & =\ket{\xi}.
+        \label{eq:mpug_defect_isometry}
+    \end{align}
+    When the fusion scalars are not block independent, the state-level
+    construction of~\cite[lines~4215--4260]{FrancoRubio2025MPUGauging}
+    prescribes the modified fusion operators only on such subspaces.
+    % Source anchor: arXiv:2502.20257, lemma:modif and the sentence closing
+    % its proof.
+\end{definition}
+
+\begin{definition}[Full unitary completion class]
+    \label{def:mpug_completion_class}
+    \lean{TNLean.Algebra.DefectMaps.IsCompletion,
+        TNLean.Algebra.DefectMaps.completionClass,
+        TNLean.Algebra.DefectMaps.mem_completionClass_iff}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_defect_maps}
+    The full completion class of prescribed defect maps
+    $D=(D_{a,b})_{a,b\in G}$ is
+    \begin{align}
+        \mathfrak C(D)
+         & =\left\{R=(U_{a,b})_{a,b\in G}:
+        U_{a,b}\in\mathrm U(\mathcal H_{\mathrm m}),\
+        U_{a,b}|_{\mathcal K_{a,b}}=D_{a,b}|_{\mathcal K_{a,b}}\right\}.
+        \label{eq:mpug_completion_class}
+    \end{align}
+    A completion is the entire family $(U_{a,b})_{a,b\in G}$, not one
+    selected operator of that family. The extension of $D_{a,b}$ to the whole
+    of $\mathcal H_{\mathrm m}$ is not unique, as observed at the end of the
+    proof of the modified-fusion lemma
+    of~\cite[lines~4215--4260]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Transport identity for a completion]
+    \label{thm:mpug_completion_transport}
+    \lean{TNLean.Algebra.DefectMaps.IsCompletion.mulVec_eq_prescribed,
+        TNLean.Algebra.DefectMaps.IsCompletion.mulVec_eq_mulVec,
+        TNLean.Algebra.DefectMaps.IsCompletion.unitaryFactorizationComparison_mulVec,
+        TNLean.Algebra.DefectMaps.IsCompletion.unitaryFactorizationComparison_gaussLegAction_mulVec}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_completion_class,
+        def:mpug_unitary_factorization_comparison,
+        def:mpug_gauss_leg_action}
+    Let $R=(U_{a,b})\in\mathfrak C(D)$, let
+    $\ket{\xi}\in\mathcal K_{a,b}$ and $\ket{\eta}\in\mathcal K_{c,d}$, and
+    assume the exact covariance
+    \begin{align}
+        D_{a,b}\ket{\xi} & =D_{c,d}\ket{\eta}.
+        \label{eq:mpug_prescribed_covariance}
+    \end{align}
+    Then
+    \begin{align}
+        U_{a,b}\ket{\xi}          & =D_{a,b}\ket{\xi},
+        \label{eq:mpug_completion_agrees}                                    \\
+        U_{a,b}\ket{\xi}          & =U_{c,d}\ket{\eta},
+        \label{eq:mpug_completion_covariance}                                \\
+        \lambda_{a,b}^{c,d}\ket{\xi} & =\ket{\eta}.
+        \label{eq:mpug_completion_transport}
+    \end{align}
+    Taking $(c,d)=T_g(a,b)$ gives the transport identity used for the
+    modified Gauss laws of~\cite[lines~4325--4335]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_completion_class,
+        thm:mpug_unitary_factorization_comparison_laws}
+    Identity~(\ref{eq:mpug_completion_agrees}) is the defining property of a
+    completion on the defect subspace. Applying it at $(a,b)$ and at $(c,d)$
+    and inserting~(\ref{eq:mpug_prescribed_covariance})
+    gives~(\ref{eq:mpug_completion_covariance}), an equality of vectors in the
+    whole matter space. Multiplying that equality by $U_{c,d}^\dagger$ and
+    using $U_{c,d}^\dagger U_{c,d}=\Id$ gives
+    \begin{align}
+        \lambda_{a,b}^{c,d}\ket{\xi}
+         & =U_{c,d}^\dagger U_{a,b}\ket{\xi}
+        =U_{c,d}^\dagger U_{c,d}\ket{\eta}
+        =\ket{\eta}.
+    \end{align}
+    The adjoint is applied only after the equality in the whole matter space
+    is available; no step asserts that $U_{c,d}^\dagger$ restricts to
+    $D_{c,d}^\dagger$ on a defect subspace.
+\end{proof}
+
+\begin{definition}[Label action at one window]
+    \label{def:mpug_chain_label_action}
+    \lean{MPOTensor.chainLabelAction,
+        MPOTensor.extractWindow_chainLabelAction_zero,
+        MPOTensor.extractWindow_chainLabelAction_one}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_gauss_leg_action}
+    Let $\alpha=(a_1,\ldots,a_N)$ be a configuration of gauge labels on a
+    periodic chain of length $N\geq2$. For a window $(j,j+1)$ and $g\in G$,
+    the configuration $T_{j,g}\alpha$ carries the labels
+    \begin{align}
+        \left(a_jg^{-1},ga_{j+1}\right)
+    \end{align}
+    on that window and agrees with $\alpha$ at every other site.
+\end{definition}
+
+\begin{theorem}[Composition of the label action]
+    \label{thm:mpug_chain_label_action_mul}
+    \lean{MPOTensor.chainLabelAction_one,
+        MPOTensor.chainLabelAction_chainLabelAction,
+        MPOTensor.chainLabelActionEquiv,
+        MPOTensor.chainLabelActionEquiv_apply}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_chain_label_action}
+    For all $g,h\in G$,
+    \begin{align}
+        T_{j,e}      & =\id,                     \\
+        T_{j,g}T_{j,h} & =T_{j,gh}.
+        \label{eq:mpug_chain_label_action_mul}
+    \end{align}
+    In particular $T_{j,g}$ is a bijection of gauge-label configurations with
+    inverse $T_{j,g^{-1}}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_chain_label_action}
+    Outside the window both sides leave $\alpha$ unchanged. On the window,
+    replacing the labels twice keeps only the second replacement, and the two
+    labels are
+    \begin{align}
+        \left(a_jh^{-1}g^{-1},gha_{j+1}\right)
+         & =\left(a_j(gh)^{-1},(gh)a_{j+1}\right).
+    \end{align}
+    At $g=e$ the labels are unchanged, so $T_{j,e}=\id$, and the composition
+    law with $h=g^{-1}$ gives the inverse.
+\end{proof}
+
+\begin{definition}[Placed Gauss operator of a completion]
+    \label{def:mpug_placed_gauss_operator}
+    \lean{MPOTensor.gaussWindowOperator,
+        MPOTensor.gaussWindowOperator_apply,
+        MPOTensor.placedGaussOperator}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_gauss_operator,
+        def:mpug_placed_gauss_projector,
+        def:mpug_completion_class}
+    Let $R\in\mathfrak C(D)$ and let a chain site carry one matter index and
+    one gauge label. Relabelling the row and column coordinates of
+    $\mathcal G_g$ by the bijection $\kappa$ of
+    Definition~\ref{def:mpug_placed_gauss_projector} and embedding the result
+    on the periodic window $(j,j+1)$ defines
+    \begin{align}
+        \widetilde{\mathcal G}^{j,j+1}_g(R)
+         & =\operatorname{Embed}_{j,j+1}\bigl(\widetilde{\mathcal G}_g(R)\bigr),
+        \label{eq:mpug_placed_gauss_operator}
+    \end{align}
+    the modified Gauss law
+    of~\cite[lines~4325--4335]{FrancoRubio2025MPUGauging}, whose block from
+    $(a,b)$ to $T_g(a,b)$ is $U_{T_g(a,b)}^\dagger U_{a,b}$.
+\end{definition}
+
+\begin{theorem}[The placed projector is the average of the placed Gauss operators]
+    \label{thm:mpug_placed_gauss_projector_average}
+    \lean{MPOTensor.placedGaussProjector_eq_average}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_placed_gauss_operator}
+    For every window $(j,j+1)$,
+    \begin{align}
+        \widetilde P_j(R)
+         & =\frac{1}{|G|}\sum_{g\in G}\widetilde{\mathcal G}^{j,j+1}_g(R).
+        \label{eq:mpug_placed_gauss_projector_average}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_gauss_projector, def:mpug_placed_gauss_operator}
+    Comparing matrix entries, the relabelling is entrywise and the embedding
+    multiplies each entry by the indicator that the two chain configurations
+    agree outside the window. Both operations commute with the normalized sum
+    over $G$ defining the local projector kernel
+    in~(\ref{eq:mpug_gauss_projector}).
+\end{proof}
+
+\begin{definition}[Gauged vector of matter defect states]
+    \label{def:mpug_gauged_vector}
+    \lean{MPOTensor.gaugedMatter,
+        MPOTensor.gaugedLabel,
+        MPOTensor.gaugedVector,
+        MPOTensor.gaugedVector_apply}
+    \leanok
+    \discussion{7569}
+    Every chain configuration splits into its matter part and its gauge-label
+    part. Given matter defect states $\ket{\Psi_\alpha}$ indexed by the
+    gauge-label configurations $\alpha$ of a chain of length $N$, the gauged
+    vector is
+    \begin{align}
+        \ket{\Psi_{\mathrm{gauged}}}
+         & =\sum_\alpha\ket{\Psi_\alpha}\otimes\ket{\alpha},
+        \label{eq:mpug_gauged_vector}
+    \end{align}
+    whose component at a chain configuration is the component of
+    $\ket{\Psi_\alpha}$ at its matter part, $\alpha$ being its gauge-label
+    part. This is the gauged state of
+    \cite[lines~4325--4335]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{definition}[Local defect support and exact defect covariance]
+    \label{def:mpug_defect_state_hypotheses}
+    \lean{MPOTensor.HasDefectSupport,
+        MPOTensor.HasPrescribedDefectCovariance}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_defect_maps, def:mpug_chain_label_action,
+        def:mpug_gauged_vector}
+    The matter defect states have local defect support when, for every
+    $\alpha$ and every window $(j,j+1)$ whose adjacent labels are
+    $(a_j,a_{j+1})$, the matter support of $\ket{\Psi_\alpha}$ lies in
+    \begin{align}
+        \mathcal K_{a_j,a_{j+1}}\otimes\mathcal H_{\mathrm{rest}}.
+    \end{align}
+    They satisfy exact defect covariance when
+    \begin{align}
+        \left(D_{a_j,a_{j+1}}\otimes\id_{\mathrm{rest}}\right)
+        \ket{\Psi_\alpha}
+         & =\left(D_{T_g(a_j,a_{j+1})}\otimes\id_{\mathrm{rest}}\right)
+        \ket{\Psi_{T_{j,g}\alpha}}
+        \label{eq:mpug_exact_defect_covariance}
+    \end{align}
+    for every $\alpha$, every window $(j,j+1)$, and every $g\in G$.
+\end{definition}
+
+\begin{theorem}[Universal invariant vector]
+    \label{thm:mpug_universal_invariant_vector}
+    \lean{MPOTensor.embedLocalOperator_mulVec_replaceWindow,
+        MPOTensor.placedGaussOperator_mulVec_gaugedVector,
+        MPOTensor.placedGaussProjector_mulVec_gaugedVector}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_placed_gauss_operator,
+        def:mpug_defect_state_hypotheses,
+        thm:mpug_completion_transport,
+        thm:mpug_chain_label_action_mul,
+        thm:mpug_placed_gauss_projector_average}
+    Assume local defect support and exact defect
+    covariance~(\ref{eq:mpug_exact_defect_covariance}). For every
+    $R\in\mathfrak C(D)$, every window $(j,j+1)$, and every $g\in G$,
+    \begin{align}
+        \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}
+         & =\ket{\Psi_{\mathrm{gauged}}},
+        \label{eq:mpug_universal_invariant_vector}                     \\
+        \widetilde P_j(R)\ket{\Psi_{\mathrm{gauged}}}
+         & =\ket{\Psi_{\mathrm{gauged}}}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_completion_transport,
+        thm:mpug_chain_label_action_mul,
+        thm:mpug_placed_gauss_projector_average,
+        def:mpug_gauss_operator}
+    Fix a chain configuration and let $\alpha$ be its gauge-label part, with
+    $(a,b)=(a_j,a_{j+1})$ the two labels adjacent to the window. In the
+    column of $\widetilde{\mathcal G}^{j,j+1}_g(R)$ indexed by that
+    configuration only the gauge labels $T_{j,g^{-1}}\alpha$ survive, so with
+    $\beta=T_{j,g^{-1}}\alpha$ the component of
+    $\widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}$ equals
+    the component of
+    \begin{align}
+        \left(U_{a,b}^\dagger U_{ag,g^{-1}b}
+        \otimes\id_{\mathrm{rest}}\right)\ket{\Psi_\beta},
+    \end{align}
+    since the labels of $\beta$ adjacent to the window are $(ag,g^{-1}b)$ and
+    $T_g(ag,g^{-1}b)=(a,b)$, whence $T_{j,g}\beta=\alpha$ by the composition
+    law~(\ref{eq:mpug_chain_label_action_mul}). Local defect support puts the
+    matter slices of $\ket{\Psi_\beta}$ and $\ket{\Psi_\alpha}$ over that
+    window in $\mathcal K_{ag,g^{-1}b}$ and $\mathcal K_{a,b}$, and exact
+    covariance~(\ref{eq:mpug_exact_defect_covariance}) relates them, so the
+    transport identity~(\ref{eq:mpug_completion_transport}) turns that vector
+    into $\ket{\Psi_\alpha}$. Identifying the label configuration $\beta$ with
+    $\alpha$ through the bijection $T_{j,g}$ is the reindexing of the sum
+    over gauge-label configurations in~(\ref{eq:mpug_gauged_vector}). Averaging
+    over $g$ and using~(\ref{eq:mpug_placed_gauss_projector_average}) gives the
+    second identity.
+\end{proof}
+
+\begin{definition}[Gauge-invariant subspace of a completion]
+    \label{def:mpug_gauge_invariant_subspace}
+    \lean{MPOTensor.gaugeInvariantSubspace}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_common_fixed_subspace, def:mpug_placed_gauss_operator}
+    For $R\in\mathfrak C(D)$ and a chain of length $N\geq2$, the
+    gauge-invariant subspace is the common fixed subspace
+    \begin{align}
+        \mathcal V_N(R)
+         & =\left\{\ket{\phi}:
+        \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\phi}=\ket{\phi}
+        \text{ for every }j\text{ and every }g\in G\right\}.
+        \label{eq:mpug_gauge_invariant_subspace}
+    \end{align}
+    No commutativity of the projectors on neighbouring windows is assumed;
+    \cite[lines~4325--4335]{FrancoRubio2025MPUGauging} observes that the
+    modified projectors need not commute.
+\end{definition}
+
+\begin{theorem}[The gauged vector spans at least one dimension]
+    \label{thm:mpug_gauge_invariant_subspace_finrank}
+    \lean{MPOTensor.gaugedVector_mem_gaugeInvariantSubspace,
+        MPOTensor.one_le_finrank_gaugeInvariantSubspace}
+    \leanok
+    \discussion{7569}
+    \uses{def:mpug_gauge_invariant_subspace,
+        thm:mpug_universal_invariant_vector,
+        thm:mpug_common_fixed_subspace_finrank}
+    Under local defect support and exact defect
+    covariance~(\ref{eq:mpug_exact_defect_covariance}),
+    \begin{align}
+        \ket{\Psi_{\mathrm{gauged}}} & \in\mathcal V_N(R)
+    \end{align}
+    for every $R\in\mathfrak C(D)$. If moreover
+    $\ket{\Psi_{\mathrm{gauged}}}\neq0$, then
+    \begin{align}
+        \dim_{\C}\mathcal V_N(R) & \geq1.
+    \end{align}
+    Neither the minimum nor the maximum of $\dim_{\C}\mathcal V_N(R)$ over
+    $\mathfrak C(D)$ is asserted; the growth of this dimension with $N$ is the
+    question raised in
+    \cite[line~5198]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_universal_invariant_vector,
+        thm:mpug_mem_common_fixed_subspace,
+        thm:mpug_common_fixed_subspace_finrank}
+    Membership is~(\ref{eq:mpug_universal_invariant_vector}) at every window
+    and every group element. A nonzero member of a subspace forces its
+    dimension to be at least one.
+\end{proof}
+
 \begin{definition}[Scalar cochains and normalization]
     \label{def:mpug_scalar_cochains}
     \lean{TNLean.Algebra.ScalarThreeCochain,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1560,12 +1560,10 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \discussion{7569}
     \uses{def:mpug_placed_gauss_operator,
+        def:mpug_placed_gauss_projector,
         def:mpug_completion_class,
         def:mpug_gauged_vector,
-        def:mpug_defect_state_hypotheses,
-        thm:mpug_completion_transport,
-        thm:mpug_chain_label_action_mul,
-        thm:mpug_placed_gauss_projector_average}
+        def:mpug_defect_state_hypotheses}
     Assume local defect support and exact defect
     covariance~(\ref{eq:mpug_exact_defect_covariance}). Here these properties
     are hypotheses rather than consequences of locally orthogonal MPS blocks
@@ -1640,8 +1638,9 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \leanok
     \discussion{7569}
     \uses{def:mpug_gauge_invariant_subspace,
-        thm:mpug_universal_invariant_vector,
-        thm:mpug_common_fixed_subspace_finrank}
+        def:mpug_completion_class,
+        def:mpug_gauged_vector,
+        def:mpug_defect_state_hypotheses}
     Under local defect support and exact defect
     covariance~(\ref{eq:mpug_exact_defect_covariance}),
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1567,7 +1567,9 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         thm:mpug_chain_label_action_mul,
         thm:mpug_placed_gauss_projector_average}
     Assume local defect support and exact defect
-    covariance~(\ref{eq:mpug_exact_defect_covariance}). For every
+    covariance~(\ref{eq:mpug_exact_defect_covariance}). Here these properties
+    are hypotheses rather than consequences of locally orthogonal MPS blocks
+    \cite{gap:fbc25_state_level_gauging_covariance}. For every
     $R\in\mathfrak C(D)$, every window $(j,j+1)$, and every $g\in G$,
     \begin{align}
         \widetilde{\mathcal G}^{j,j+1}_g(R)\ket{\Psi_{\mathrm{gauged}}}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1006,6 +1006,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_stabilizer_transition_index_typo.pdf}},
 }
 
+@techreport{gap:fbc25_state_level_gauging_covariance,
+  author      = {The {TNLean} contributors},
+  title       = {Defect Covariance in State-Level Gauging},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_state\_level\_gauging\_covariance},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_state_level_gauging_covariance.pdf}},
+}
+
 @techreport{gap:fbc25_two_cochain_coboundary_index_typo,
   author      = {The {TNLean} contributors},
   title       = {The Final Index in the Block-Dependent Two-Cochain Coboundary},

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -699,3 +699,41 @@ The following notions use different transfer objects and are not interchangeable
   The theorem
   `MPOTensor.exists_hasBlockedAdjointFixedPointAlgebraTower_not_isZCL` shows
   that this tower does not imply doubled-index transfer idempotence.
+
+## State-level gauging
+
+### `TNLean.Algebra.DefectMaps.IsCompletion`
+
+- **Declaration:** `TNLean.Algebra.DefectMaps.IsCompletion D R : Prop`.
+- **Defined in:** `TNLean/Algebra/UnitaryCompletionClass.lean`.
+- **Meaning:** the whole family of unitaries $R=(U_{a,b})_{a,b\in G}$ agrees
+  with the prescribed defect maps $D_{a,b}$ on every defect subspace
+  $\mathcal K_{a,b}$.
+- **Source:** arXiv:2502.20257, modified-fusion Lemma `lemma:modif` and the
+  nonuniqueness observation at lines 4215--4326.
+- **Sanctioned bridges:** `DefectMaps.mem_completionClass_iff` identifies the
+  predicate with membership in the full completion class. The transport
+  theorems in the same module use exact prescribed-map covariance before
+  applying the target completion's adjoint.
+- **Caveat:** the predicate characterizes a supplied completion; it neither
+  constructs one nor asserts that the completion class has more than one
+  member. Nonuniqueness requires a nonspanning defect subspace.
+
+### `MPOTensor.HasDefectSupport` and `MPOTensor.HasPrescribedDefectCovariance`
+
+- **Declarations:** `MPOTensor.HasDefectSupport d G hN D Ψ : Prop` and
+  `MPOTensor.HasPrescribedDefectCovariance d G hN D Ψ : Prop`.
+- **Defined in:** `TNLean/MPS/MPDO/GaugeInvariantSubspace.lean`.
+- **Meaning:** every two-site matter slice of $\Psi_\alpha$ lies in the defect
+  subspace selected by the adjacent labels, and the prescribed defect maps
+  carry these slices covariantly under $(a,b)\mapsto(ag^{-1},gb)$.
+- **Source:** arXiv:2502.20257, lines 4325--4335.
+- **Sanctioned bridge:** together with `DefectMaps.IsCompletion`, these
+  predicates imply invariance of the gauged vector under every placed Gauss
+  operator and averaged projector through
+  `MPOTensor.placedGaussOperator_mulVec_gaugedVector` and
+  `MPOTensor.placedGaussProjector_mulVec_gaugedVector`.
+- **Caveat:** no current theorem derives either predicate from the paper's
+  concrete locally orthogonal MPS blocks. That missing specialization and the
+  CZX four-domain instance are recorded in
+  `docs/paper-gaps/fbc25_state_level_gauging_covariance.tex`.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -41,6 +41,10 @@ For the MPU symmetry-defect gauging paper:
   distinction between a trivial anomaly class and a pointwise trivial gauge,
   and the stable finite-periodic-chain support boundary. It is a prerequisite
   audit, not a formalization of Proposition `prop:comm_proj`.
+- `fbc25_state_level_gauging_covariance.tex` records that the current universal
+  invariant-vector theorem assumes local defect support and exact covariance,
+  while the paper derives them from its concrete locally orthogonal MPS blocks
+  and modified fusion maps. Issue #7569 tracks this specialization.
 - `fbc25_alternating_network_nondegeneracy.tex` records the one-sided
   nonvanishing convention for the alternating-network proportionality lemma.
   Both applications in the source satisfy this convention because their

--- a/docs/paper-gaps/fbc25_state_level_gauging_covariance.tex
+++ b/docs/paper-gaps/fbc25_state_level_gauging_covariance.tex
@@ -1,0 +1,55 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+\importpaperaux{fbc25-}{2502.20257/main-tnlean}
+
+\title{Defect Covariance in State-Level Gauging}
+\author{}
+\date{2026-09-03}
+
+\begin{document}
+\maketitle
+\gapnote{scope-restriction}{open}
+
+\section{Source statement}
+
+The modified-fusion lemma of
+Ref.~\cite[lines~4215--4326]{FrancoRubio2025MPUGauging} constructs unitary
+fusion operators from locally orthogonal matrix-product-state blocks. The
+resulting modified Gauss operators leave the gauged state invariant
+\cite[lines~4327--4335]{FrancoRubio2025MPUGauging}. Thus the paper derives the
+local defect support and covariance used in the invariance argument from its
+concrete defect tensors and fusion maps.
+
+\section{Current formal scope}
+
+The present universal-vector theorem starts with defect subspaces
+$\mathcal K_{a,b}$, prescribed maps $D_{a,b}$, and matter states
+$\ket{\Psi_\alpha}$. It assumes that every two-site matter slice lies in the
+corresponding defect subspace and that, for every window and $g\in G$,
+\begin{align}
+    (D_{a,b}\otimes\Id)\ket{\Psi_\alpha}
+     & =(D_{ag^{-1},gb}\otimes\Id)
+    \ket{\Psi_{T_{j,g}\alpha}}.
+\end{align}
+Under these hypotheses it proves invariance for every unitary completion of the
+prescribed maps. This is a conditional abstraction of the paper's argument,
+not yet a derivation of the hypotheses from locally orthogonal MPS blocks.
+
+\section{Elimination plan}
+
+To recover the full source construction, instantiate the defect subspaces,
+prescribed maps, and matter states from the FBC25 defect tensors; prove local
+support and the displayed covariance from local orthogonality and the modified
+fusion lemma; then specialize the abstract universal-vector theorem. The
+four-domain CZX instance and this source-to-abstraction bridge remain tracked
+by \ghissue{7569}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Source

- `Papers/2502.20257/main.tex:4215-4335` — the modified-fusion lemma `lemma:modif`, the sentence closing its proof (when the prescribed defect vectors do not span the matter space, the unitary extension need not be unique and can have infinitely many solutions), the modified Gauss laws `\tilde{\mc G}_g = \sum_{a,b} (\tilde\lambda^R_{ag^{-1},gb})^\dagger \tilde\lambda^R_{a,b} \otimes \ketbra{ag^{-1},gb}{a,b}`, and the statement that they still form a representation of `G` leaving the gauged MPS invariant while the resulting projectors need not commute.
- `Papers/2502.20257/main.tex:5198-5204` — the open question whether the common gauge-invariant subspace stays bounded or grows with the system size. Nothing here answers it.
- The planning note `Notes/OpenProblemsTN/problems/p4_gauge_invariant_subspace_growth.tex` (`def:p4-completion-class`, `lem:p4-universal-vector`) is not tracked in the repository, so every docstring and blueprint entry cites the tracked paper passages above.

## Content

New `TNLean/Algebra/UnitaryCompletionClass.lean`:

- `DefectMaps` — for every ordered pair of gauge labels, a defect subspace of the matter space and a map whose restriction to it is an isometry. The matter operators are represented as elements of `Matrix.unitaryGroup n ℂ`, the family type already consumed by `TNLean.Algebra.gaussOperator`, so that a completion is literally an admissible argument of the local Gauss operator and its gauge block is the existing `Matrix.unitaryFactorizationComparison`.
- `DefectMaps.IsCompletion` / `DefectMaps.completionClass` — a completion is the entire family `(U a b)`, not one selected operator.
- The transport results, in the order the source derivation requires: `mulVec_eq_prescribed` (agreement on the defect subspace), `mulVec_eq_mulVec` (equality of images in the whole matter space from exact covariance of the prescribed maps), `unitaryFactorizationComparison_mulVec` and its Gauss-leg-action specialization (multiplication by the adjoint of the target completion, only after that equality). No step argues that the adjoint of a completion restricts to the adjoint of a prescribed defect map.

New `TNLean/MPS/MPDO/GaugeInvariantSubspace.lean`:

- `chainLabelAction` and `chainLabelActionEquiv` — moving the two labels adjacent to one window by `T_g(a,b) = (a g⁻¹, g b)`, with `T_{j,e} = id` and `T_{j,g} T_{j,h} = T_{j,gh}`, hence a bijection of gauge-label configurations.
- `gaugedMatter`, `gaugedLabel`, `gaugedVector` — the splitting of a chain configuration into matter and gauge-label parts, and the gauged vector `∑_α Ψ_α ⊗ |α⟩`.
- `gaussWindowOperator`, `placedGaussOperator`, `placedGaussProjector_eq_average` — the Gauss operator of a completion placed on the periodic window at each bond, and the identification of the already-formalized placed projector with the normalized sum of these operators over the group.
- `HasDefectSupport`, `HasPrescribedDefectCovariance` — the local support hypothesis and the exact defect-fusion covariance identity.
- `placedGaussOperator_mulVec_gaugedVector`, `placedGaussProjector_mulVec_gaugedVector` — for every completion, every bond, and every group element, the gauged vector is fixed. The proof reduces the placed operator in the column of a chain configuration to the single surviving gauge-label pair, applies the transport identity to the matter slice over the window, and identifies the label configuration with its image under `T_{j,g}`, which is the reindexing of the sum over label configurations.
- `gaugeInvariantSubspace`, `gaugedVector_mem_gaugeInvariantSubspace`, `one_le_finrank_gaugeInvariantSubspace` — the common fixed subspace of the placed averaged projectors `placedGaussProjector … j R`, indexed by the chain windows, so the source condition `\widetilde P_j(R)\ket\phi=\ket\phi` is exactly the membership condition; then membership of the gauged vector and, for a nonvanishing gauged vector, dimension at least one, through `LinearMap.commonFixedSubmodule` from #7635.

Reused rather than restated: `TNLean.Algebra.gaussOperator` and `gaussLegAction` (#7577), `gaussProjector` (#7583), `gaussLocalCoordinateEquiv`, `gaussWindowProjector`, `placedGaussProjector` (#7606), `LinearMap.commonFixedSubmodule` (#7635), `Matrix.unitaryFactorizationComparison`, and the cyclic window machinery of `MPOTensor.embedLocalOperator`.

Out of scope, as required by the issue: no CZX-specific defect data or extension classification, no commutativity of neighbouring modified projectors, and no minimum, maximum, or asymptotic claim over the completion class.

## Scope note

The source derives the local defect support and the exact defect covariance from its locally orthogonal matrix-product-state blocks and modified fusion maps; here both are hypotheses. The restriction is recorded once in `docs/paper-gaps/fbc25_state_level_gauging_covariance.tex`, carried by a single module-level `**Scope restriction (abstract defect covariance):**` marker in `TNLean/MPS/MPDO/GaugeInvariantSubspace.lean`, and cited by the blueprint theorem through `\cite{gap:fbc25_state_level_gauging_covariance}`. The blueprint node states the two hypotheses explicitly, so its `\leanok` is against the restricted statement, not the unconditional source claim.

## Blueprint

`blueprint/src/chapter/ch29_mpu_gauging.tex` gains, after the common-fixed-subspace entries: `def:mpug_defect_maps`, `def:mpug_completion_class`, `thm:mpug_completion_transport`, `def:mpug_chain_label_action`, `thm:mpug_chain_label_action_mul`, `def:mpug_placed_gauss_operator`, `thm:mpug_placed_gauss_projector_average`, `def:mpug_gauged_vector`, `def:mpug_defect_state_hypotheses`, `thm:mpug_universal_invariant_vector`, `def:mpug_gauge_invariant_subspace`, `thm:mpug_gauge_invariant_subspace_finrank`. Each entry states exactly the hypotheses of the Lean declaration it tags, including the local support and exact covariance assumptions, so no source-labelled node carries a `\leanok` for a stronger-hypothesis statement.

## Validation

Run in the worktree `/private/tmp/tnlean-issue-7569`:

- `scripts/lake_build_locked.sh TNLean.Algebra.UnitaryCompletionClass`
- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.GaugeInvariantSubspace`
- `scripts/lake_build_locked.sh TNLean` (10490 jobs, success)
- `rg -n "sorry|axiom|admit|native_decide"` on both new files: no matches
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py` then `--check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `--ci`: in sync
- `scripts/lake_build_locked.sh -- lake exe checkdecls blueprint/lean_decls`: exit 0
- `python3 scripts/fetch_tenkz.py` and `cd blueprint && leanblueprint pdf`: 1100 pages, no undefined references or control sequences
- `python3 scripts/tactic_pattern_scan.py`: no repeated pattern in the new files
- `python3 scripts/test_lean_file_policies.py`: 16 tests pass
- `git diff --check`: clean

Advances #7569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR
