### PR TITLE
feat(Algebra): add stabilizer transition elements

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -45,6 +45,7 @@ import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
+import TNLean.Algebra.StabilizerTransition
 import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation
 import TNLean.Algebra.UnitaryCongruence

--- a/TNLean/Algebra/StabilizerTransition.lean
+++ b/TNLean/Algebra/StabilizerTransition.lean
@@ -20,6 +20,10 @@ The transition element stabilizes `x₀` and obeys
 `h₂ = t_k(g₂,x)` and `h₁ = t_k(g₁,g₂ • x)`. In particular, the representative
 in `h₁` is `k_(g₂ • x)`, correcting the printed `k_(g₁ • x)`.
 
+**Local fix (printed representative index):** The source's `k_(g₁ • x)` is replaced
+by `k_(g₂ • x)`, as documented in
+`docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex`.
+
 No finiteness or normality assumption is used.
 -/
 
@@ -86,6 +90,35 @@ theorem transitionElement_mul (K : StabilizerRepresentatives G X x₀)
       transitionElement K g₁ (g₂ • x) * transitionElement K g₂ x := by
   apply Subtype.ext
   simp [mul_smul, mul_assoc]
+
+/-- The factor `h₂` in arXiv:2502.20257, Equation `eq:h1h2`. -/
+def h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
+    MulAction.stabilizer G x₀ :=
+  transitionElement K g₂ x
+
+/-- The corrected factor `h₁` in arXiv:2502.20257, Equation `eq:h1h2`.
+The final representative is `k_(g₂ • x)`, not the printed `k_(g₁ • x)`. -/
+def h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
+    MulAction.stabilizer G x₀ :=
+  transitionElement K g₁ (g₂ • x)
+
+/-- The underlying group element of `h₂` is `k_(g₂ • x)⁻¹ g₂ k_x`. -/
+@[simp]
+theorem coe_h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
+    (h₂ K g₂ x : G) = (K.k (g₂ • x))⁻¹ * g₂ * K.k x := rfl
+
+/-- The underlying group element of `h₁` uses the corrected representative
+`k_(g₂ • x)`. -/
+@[simp]
+theorem coe_h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
+    (h₁ K g₁ g₂ x : G) = (K.k ((g₁ * g₂) • x))⁻¹ * g₁ * K.k (g₂ • x) := by
+  simp [h₁, mul_smul]
+
+/-- The transition product law identifies `t_k(g₁g₂,x)` with `h₁h₂`. -/
+theorem transitionElement_mul_eq_h₁_mul_h₂
+    (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
+    transitionElement K (g₁ * g₂) x = h₁ K g₁ g₂ x * h₂ K g₂ x :=
+  K.transitionElement_mul g₁ g₂ x
 
 end StabilizerRepresentatives
 

--- a/TNLean/Algebra/StabilizerTransition.lean
+++ b/TNLean/Algebra/StabilizerTransition.lean
@@ -91,35 +91,6 @@ theorem transitionElement_mul (K : StabilizerRepresentatives G X x₀)
   apply Subtype.ext
   simp [mul_smul, mul_assoc]
 
-/-- The factor `h₂` in arXiv:2502.20257, Equation `eq:h1h2`. -/
-def h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
-    MulAction.stabilizer G x₀ :=
-  transitionElement K g₂ x
-
-/-- The corrected factor `h₁` in arXiv:2502.20257, Equation `eq:h1h2`.
-The final representative is `k_(g₂ • x)`, not the printed `k_(g₁ • x)`. -/
-def h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
-    MulAction.stabilizer G x₀ :=
-  transitionElement K g₁ (g₂ • x)
-
-/-- The underlying group element of `h₂` is `k_(g₂ • x)⁻¹ g₂ k_x`. -/
-@[simp]
-theorem coe_h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
-    (h₂ K g₂ x : G) = (K.k (g₂ • x))⁻¹ * g₂ * K.k x := rfl
-
-/-- The underlying group element of `h₁` uses the corrected representative
-`k_(g₂ • x)`. -/
-@[simp]
-theorem coe_h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
-    (h₁ K g₁ g₂ x : G) = (K.k ((g₁ * g₂) • x))⁻¹ * g₁ * K.k (g₂ • x) := by
-  simp [h₁, mul_smul]
-
-/-- The transition product law identifies `t_k(g₁g₂,x)` with `h₁h₂`. -/
-theorem transitionElement_mul_eq_h₁_mul_h₂
-    (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
-    transitionElement K (g₁ * g₂) x = h₁ K g₁ g₂ x * h₂ K g₂ x :=
-  K.transitionElement_mul g₁ g₂ x
-
 end StabilizerRepresentatives
 
 end TNLean.Algebra

--- a/TNLean/Algebra/StabilizerTransition.lean
+++ b/TNLean/Algebra/StabilizerTransition.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.Group.Action.Pretransitive
+import Mathlib.GroupTheory.GroupAction.Defs
+
+/-!
+# Stabilizer representatives and transition elements
+
+This file formalizes the representative calculation preceding
+arXiv:2502.20257, Lemma `lemma:h1h2` and Equation `eq:h1h2` (lines 7028–7042).
+For a basepoint `x₀` in a transitive left `G`-set, representatives `k_x` satisfy
+`k_x • x₀ = x` and `k_x₀ = 1`. Their transition element is
+`t_k(g,x) = k_(g • x)⁻¹ g k_x`.
+
+The transition element stabilizes `x₀` and obeys
+`t_k(g₁g₂,x) = t_k(g₁,g₂ • x)t_k(g₂,x)`. The resulting specializations are
+`h₂ = t_k(g₂,x)` and `h₁ = t_k(g₁,g₂ • x)`. In particular, the representative
+in `h₁` is `k_(g₂ • x)`, correcting the printed `k_(g₁ • x)`.
+
+No finiteness or normality assumption is used.
+-/
+
+namespace TNLean.Algebra
+
+variable (G X : Type*) [Group G] [MulAction G X]
+
+/-- Chosen representatives `k_x` for a transitive left action, normalized by
+`k_x₀ = 1`, as used before arXiv:2502.20257, Lemma `lemma:h1h2`. -/
+structure StabilizerRepresentatives (x₀ : X) where
+  /-- The representative `k_x`. -/
+  k : X → G
+  /-- Each `k_x` carries the basepoint to `x`. -/
+  k_smul_x₀ : ∀ x, k x • x₀ = x
+  /-- The representative of the basepoint is the identity. -/
+  k_x₀ : k x₀ = 1
+
+namespace StabilizerRepresentatives
+
+variable {G X : Type*} [Group G] [MulAction G X] {x₀ : X}
+
+/-- A pretransitive action admits representatives normalized at any chosen
+basepoint. -/
+noncomputable def ofPretransitive [MulAction.IsPretransitive G X] (x₀ : X) :
+    StabilizerRepresentatives G X x₀ := by
+  classical
+  exact {
+    k := fun x ↦ if x = x₀ then 1
+      else Classical.choose (MulAction.exists_smul_eq G x₀ x)
+    k_smul_x₀ := fun x ↦ by
+      by_cases hx : x = x₀
+      · simp [hx]
+      · simp only [hx, ↓reduceIte]
+        exact Classical.choose_spec (MulAction.exists_smul_eq G x₀ x)
+    k_x₀ := by simp }
+
+
+/-- The paper's transition element
+`t_k(g,x) = k_(g • x)⁻¹ g k_x`. -/
+def transitionElement (K : StabilizerRepresentatives G X x₀) (g : G) (x : X) : G :=
+  (K.k (g • x))⁻¹ * g * K.k x
+
+/-- Every transition element belongs to the stabilizer of the basepoint. -/
+theorem transitionElement_mem_stabilizer (K : StabilizerRepresentatives G X x₀)
+    (g : G) (x : X) : transitionElement K g x ∈ MulAction.stabilizer G x₀ := by
+  rw [MulAction.mem_stabilizer_iff]
+  calc
+    ((K.k (g • x))⁻¹ * g * K.k x) • x₀ =
+        (K.k (g • x))⁻¹ • (g • (K.k x • x₀)) := by
+      rw [mul_smul, mul_smul]
+    _ = (K.k (g • x))⁻¹ • (g • x) := by rw [K.k_smul_x₀]
+    _ = (K.k (g • x))⁻¹ • (K.k (g • x) • x₀) := by rw [K.k_smul_x₀]
+    _ = x₀ := by rw [← mul_smul, Group.inv_mul_cancel, one_smul]
+
+/-- The transition elements obey
+`t_k(g₁g₂,x) = t_k(g₁,g₂ • x)t_k(g₂,x)`. -/
+theorem transitionElement_mul (K : StabilizerRepresentatives G X x₀)
+    (g₁ g₂ : G) (x : X) :
+    transitionElement K (g₁ * g₂) x =
+      transitionElement K g₁ (g₂ • x) * transitionElement K g₂ x := by
+  simp [transitionElement, mul_smul, mul_assoc]
+
+/-- The factor `h₂` in arXiv:2502.20257, Equation `eq:h1h2`. -/
+def h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) : G :=
+  transitionElement K g₂ x
+
+/-- The corrected factor `h₁` in arXiv:2502.20257, Equation `eq:h1h2`.
+The final representative is `k_(g₂ • x)`, not the printed `k_(g₁ • x)`. -/
+def h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) : G :=
+  transitionElement K g₁ (g₂ • x)
+
+/-- The explicit representative formula for `h₂`. -/
+theorem h₂_eq (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
+    h₂ K g₂ x = (K.k (g₂ • x))⁻¹ * g₂ * K.k x := rfl
+
+/-- The explicit corrected representative formula for `h₁`. -/
+theorem h₁_eq (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
+    h₁ K g₁ g₂ x = (K.k ((g₁ * g₂) • x))⁻¹ * g₁ * K.k (g₂ • x) := by
+  simp [h₁, transitionElement, mul_smul]
+
+/-- Both factors in Equation `eq:h1h2` belong to the stabilizer. -/
+theorem h₁_h₂_mem_stabilizer (K : StabilizerRepresentatives G X x₀)
+    (g₁ g₂ : G) (x : X) :
+    h₁ K g₁ g₂ x ∈ MulAction.stabilizer G x₀ ∧
+      h₂ K g₂ x ∈ MulAction.stabilizer G x₀ := by
+  exact ⟨K.transitionElement_mem_stabilizer g₁ (g₂ • x),
+    K.transitionElement_mem_stabilizer g₂ x⟩
+
+/-- The transition product law identifies `t_k(g₁g₂,x)` with `h₁h₂`. -/
+theorem transitionElement_mul_eq_h₁_mul_h₂
+    (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
+    transitionElement K (g₁ * g₂) x = h₁ K g₁ g₂ x * h₂ K g₂ x :=
+  K.transitionElement_mul g₁ g₂ x
+
+end StabilizerRepresentatives
+
+end TNLean.Algebra

--- a/TNLean/Algebra/StabilizerTransition.lean
+++ b/TNLean/Algebra/StabilizerTransition.lean
@@ -57,62 +57,35 @@ noncomputable def ofPretransitive [MulAction.IsPretransitive G X] (x₀ : X) :
     k_x₀ := by simp }
 
 
-/-- The paper's transition element
+/-- The paper's stabilizer-valued transition element
 `t_k(g,x) = k_(g • x)⁻¹ g k_x`. -/
-def transitionElement (K : StabilizerRepresentatives G X x₀) (g : G) (x : X) : G :=
-  (K.k (g • x))⁻¹ * g * K.k x
+def transitionElement (K : StabilizerRepresentatives G X x₀) (g : G) (x : X) :
+    MulAction.stabilizer G x₀ :=
+  ⟨(K.k (g • x))⁻¹ * g * K.k x, by
+    rw [MulAction.mem_stabilizer_iff]
+    calc
+      ((K.k (g • x))⁻¹ * g * K.k x) • x₀ =
+          (K.k (g • x))⁻¹ • (g • (K.k x • x₀)) := by
+        rw [mul_smul, mul_smul]
+      _ = (K.k (g • x))⁻¹ • (g • x) := by rw [K.k_smul_x₀]
+      _ = (K.k (g • x))⁻¹ • (K.k (g • x) • x₀) := by rw [K.k_smul_x₀]
+      _ = x₀ := by rw [← mul_smul, Group.inv_mul_cancel, one_smul]⟩
 
-/-- Every transition element belongs to the stabilizer of the basepoint. -/
-theorem transitionElement_mem_stabilizer (K : StabilizerRepresentatives G X x₀)
-    (g : G) (x : X) : transitionElement K g x ∈ MulAction.stabilizer G x₀ := by
-  rw [MulAction.mem_stabilizer_iff]
-  calc
-    ((K.k (g • x))⁻¹ * g * K.k x) • x₀ =
-        (K.k (g • x))⁻¹ • (g • (K.k x • x₀)) := by
-      rw [mul_smul, mul_smul]
-    _ = (K.k (g • x))⁻¹ • (g • x) := by rw [K.k_smul_x₀]
-    _ = (K.k (g • x))⁻¹ • (K.k (g • x) • x₀) := by rw [K.k_smul_x₀]
-    _ = x₀ := by rw [← mul_smul, Group.inv_mul_cancel, one_smul]
+/-- The underlying group element of `t_k(g,x)` is
+`k_(g • x)⁻¹ g k_x`. -/
+@[simp]
+theorem coe_transitionElement (K : StabilizerRepresentatives G X x₀)
+    (g : G) (x : X) :
+    (transitionElement K g x : G) = (K.k (g • x))⁻¹ * g * K.k x := rfl
 
-/-- The transition elements obey
+/-- The transition elements obey the subgroup identity
 `t_k(g₁g₂,x) = t_k(g₁,g₂ • x)t_k(g₂,x)`. -/
 theorem transitionElement_mul (K : StabilizerRepresentatives G X x₀)
     (g₁ g₂ : G) (x : X) :
     transitionElement K (g₁ * g₂) x =
       transitionElement K g₁ (g₂ • x) * transitionElement K g₂ x := by
-  simp [transitionElement, mul_smul, mul_assoc]
-
-/-- The factor `h₂` in arXiv:2502.20257, Equation `eq:h1h2`. -/
-def h₂ (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) : G :=
-  transitionElement K g₂ x
-
-/-- The corrected factor `h₁` in arXiv:2502.20257, Equation `eq:h1h2`.
-The final representative is `k_(g₂ • x)`, not the printed `k_(g₁ • x)`. -/
-def h₁ (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) : G :=
-  transitionElement K g₁ (g₂ • x)
-
-/-- The explicit representative formula for `h₂`. -/
-theorem h₂_eq (K : StabilizerRepresentatives G X x₀) (g₂ : G) (x : X) :
-    h₂ K g₂ x = (K.k (g₂ • x))⁻¹ * g₂ * K.k x := rfl
-
-/-- The explicit corrected representative formula for `h₁`. -/
-theorem h₁_eq (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
-    h₁ K g₁ g₂ x = (K.k ((g₁ * g₂) • x))⁻¹ * g₁ * K.k (g₂ • x) := by
-  simp [h₁, transitionElement, mul_smul]
-
-/-- Both factors in Equation `eq:h1h2` belong to the stabilizer. -/
-theorem h₁_h₂_mem_stabilizer (K : StabilizerRepresentatives G X x₀)
-    (g₁ g₂ : G) (x : X) :
-    h₁ K g₁ g₂ x ∈ MulAction.stabilizer G x₀ ∧
-      h₂ K g₂ x ∈ MulAction.stabilizer G x₀ := by
-  exact ⟨K.transitionElement_mem_stabilizer g₁ (g₂ • x),
-    K.transitionElement_mem_stabilizer g₂ x⟩
-
-/-- The transition product law identifies `t_k(g₁g₂,x)` with `h₁h₂`. -/
-theorem transitionElement_mul_eq_h₁_mul_h₂
-    (K : StabilizerRepresentatives G X x₀) (g₁ g₂ : G) (x : X) :
-    transitionElement K (g₁ * g₂) x = h₁ K g₁ g₂ x * h₂ K g₂ x :=
-  K.transitionElement_mul g₁ g₂ x
+  apply Subtype.ext
+  simp [mul_smul, mul_assoc]
 
 end StabilizerRepresentatives
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2258,7 +2258,7 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     \begin{align}
         h_2
          & =t_k(g_2,x)=k_{g_2x}^{-1}g_2k_x,
-        \label{eq:mpug_stabilizer_h2}\\
+        \label{eq:mpug_stabilizer_h2}                  \\
         h_1
          & =t_k(g_1,g_2x)=k_{g_1g_2x}^{-1}g_1k_{g_2x}.
         \label{eq:mpug_stabilizer_h1}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2237,13 +2237,7 @@ show that the tensor gauge freedoms induce the joint scalar gauge
         TNLean.Algebra.StabilizerRepresentatives,
         TNLean.Algebra.StabilizerRepresentatives.ofPretransitive,
         TNLean.Algebra.StabilizerRepresentatives.transitionElement,
-        TNLean.Algebra.StabilizerRepresentatives.transitionElement_mem_stabilizer,
-        TNLean.Algebra.StabilizerRepresentatives.h₁,
-        TNLean.Algebra.StabilizerRepresentatives.h₂,
-        TNLean.Algebra.StabilizerRepresentatives.h₁_eq,
-        TNLean.Algebra.StabilizerRepresentatives.h₂_eq,
-        TNLean.Algebra.StabilizerRepresentatives.h₁_h₂_mem_stabilizer,
-        TNLean.Algebra.StabilizerRepresentatives.transitionElement_mul_eq_h₁_mul_h₂}
+        TNLean.Algebra.StabilizerRepresentatives.coe_transitionElement}
     \leanok
     Suppose that $G$ acts transitively on $\mathsf X$, and fix
     $x_0\in\mathsf X$. There are representatives $k_x\in G$ satisfying

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2231,6 +2231,64 @@ show that the tensor gauge freedoms induce the joint scalar gauge
 % Scope boundary: the tensor-facing bridge for arXiv:2502.20257,
 % prop:technical01 is not contained in the scalar L-symbol declarations.
 
+\begin{theorem}[Stabilizer transition elements]
+    \label{thm:mpug_stabilizer_transition}
+    \lean{TNLean.Algebra.StabilizerRepresentatives.transitionElement_mul,
+        TNLean.Algebra.StabilizerRepresentatives,
+        TNLean.Algebra.StabilizerRepresentatives.ofPretransitive,
+        TNLean.Algebra.StabilizerRepresentatives.transitionElement,
+        TNLean.Algebra.StabilizerRepresentatives.transitionElement_mem_stabilizer,
+        TNLean.Algebra.StabilizerRepresentatives.h₁,
+        TNLean.Algebra.StabilizerRepresentatives.h₂,
+        TNLean.Algebra.StabilizerRepresentatives.h₁_eq,
+        TNLean.Algebra.StabilizerRepresentatives.h₂_eq,
+        TNLean.Algebra.StabilizerRepresentatives.h₁_h₂_mem_stabilizer,
+        TNLean.Algebra.StabilizerRepresentatives.transitionElement_mul_eq_h₁_mul_h₂}
+    \leanok
+    Suppose that $G$ acts transitively on $\mathsf X$, and fix
+    $x_0\in\mathsf X$. There are representatives $k_x\in G$ satisfying
+    $k_xx_0=x$ and $k_{x_0}=e$. With
+    $H=\operatorname{Stab}_G(x_0)$, define
+    \begin{align}
+        t_k(g,x)
+         & =k_{g x}^{-1}gk_x.
+        \label{eq:mpug_stabilizer_transition}
+    \end{align}
+    Then $t_k(g,x)\in H$ and
+    \begin{align}
+        t_k(g_1g_2,x)
+         & =t_k(g_1,g_2x)t_k(g_2,x).
+        \label{eq:mpug_stabilizer_transition_product}
+    \end{align}
+    Consequently, the factors in \texttt{eq:h1h2} are
+    \begin{align}
+        h_2
+         & =t_k(g_2,x)=k_{g_2x}^{-1}g_2k_x,
+        \label{eq:mpug_stabilizer_h2}\\
+        h_1
+         & =t_k(g_1,g_2x)=k_{g_1g_2x}^{-1}g_1k_{g_2x}.
+        \label{eq:mpug_stabilizer_h1}
+    \end{align}
+    The last representative in $h_1$ corrects the printed $k_{g_1x}$
+    \cite{gap:fbc25_stabilizer_transition_index_typo}. No finiteness or
+    normality assumption is required.
+    % Local correction:
+    % docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex.
+    % Source anchor: arXiv:2502.20257, lemma:h1h2 and eq:h1h2,
+    % lines 7028--7042.
+\end{theorem}
+
+\begin{proof}\leanok
+    Transitivity supplies one element carrying $x_0$ to each $x$; choose the
+    identity at $x=x_0$. Acting with (\ref{eq:mpug_stabilizer_transition}) on
+    $x_0$ gives
+    $k_{gx}^{-1}g(k_xx_0)=k_{gx}^{-1}(gx)=x_0$.
+    For (\ref{eq:mpug_stabilizer_transition_product}), substitute
+    (\ref{eq:mpug_stabilizer_transition}) and cancel
+    $k_{g_2x}k_{g_2x}^{-1}$. The two formulas for $h_1$ and $h_2$ are the
+    corresponding specializations.
+\end{proof}
+
 \begin{definition}[Generalized coboundary and cocycle]
     \label{def:mpug_generalized_cocycle}
     \lean{TNLean.Algebra.GeneralizedThreeCochain,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2260,7 +2260,7 @@ show that the tensor gauge freedoms induce the joint scalar gauge
          & =t_k(g_1,g_2x)t_k(g_2,x).
         \label{eq:mpug_stabilizer_transition_product}
     \end{align}
-    Consequently, the factors in \texttt{eq:h1h2} are
+    Consequently, the source factors are
     \begin{align}
         h_2
          & =t_k(g_2,x)=k_{g_2x}^{-1}g_2k_x,

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -996,6 +996,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_circle_complex_units_cohomology.pdf}},
 }
 
+@techreport{gap:fbc25_stabilizer_transition_index_typo,
+  author      = {The {TNLean} contributors},
+  title       = {The Representative Index in the First Stabilizer Factor},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {fbc25\_stabilizer\_transition\_index\_typo},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/fbc25_stabilizer_transition_index_typo.pdf}},
+}
+
 @techreport{gap:fbc25_two_cochain_coboundary_index_typo,
   author      = {The {TNLean} contributors},
   title       = {The Final Index in the Block-Dependent Two-Cochain Coboundary},

--- a/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
+++ b/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
@@ -30,7 +30,8 @@ $H=\operatorname{Stab}_G(x_0)$, and direct cancellation gives
     \label{eq:fbc25_stabilizer_transition_product}
 \end{align}
 
-Equation~\texttt{eq:h1h2} at line~7038 of
+The displayed definition of the two stabilizer factors in the lemma preceding
+the block-independence proposition of
 Ref.~\cite{FrancoRubio2025MPUGauging} prints
 $h_1=k_{g_1g_2x}^{-1}g_1k_{g_1x}$. This expression does not generally
 stabilize $x_0$. Resolving the $g_2$ action first in

--- a/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
+++ b/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
@@ -45,9 +45,9 @@ stabilize $x_0$. Resolving the $g_2$ action first in
 \end{align}
 Thus the final representative in $h_1$ is $k_{g_2x}$, not $k_{g_1x}$.
 No normality or finiteness assumption is needed.\footnote{Formal declarations:
-\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement\_mem\_stabilizer},
-\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement\_mul}, and
-\leanid{TNLean.Algebra.StabilizerRepresentatives.h₁\_eq} in
+\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement},
+\leanid{TNLean.Algebra.StabilizerRepresentatives.coe\_transitionElement}, and
+\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement\_mul} in
 \doclink{TNLean/Algebra/StabilizerTransition}.}
 
 \textbf{Verdict: resolved local fix.}

--- a/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
+++ b/docs/paper-gaps/fbc25_stabilizer_transition_index_typo.tex
@@ -1,0 +1,59 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Representative Index in the First Stabilizer Factor}
+\author{}
+\date{2026-09-03}
+
+\begin{document}
+\maketitle
+\gapnote{local-correction}{resolved}
+
+Let a group $G$ act transitively on $\mathsf X$. Fix $x_0\in\mathsf X$ and
+choose $k_x\in G$ such that $k_xx_0=x$. For $g\in G$ and $x\in\mathsf X$,
+define
+\begin{align}
+    t_k(g,x)
+        &=k_{g x}^{-1}gk_x.
+    \label{eq:fbc25_stabilizer_transition}
+\end{align}
+Then $t_k(g,x)x_0=x_0$, so $t_k(g,x)$ lies in
+$H=\operatorname{Stab}_G(x_0)$, and direct cancellation gives
+\begin{align}
+    t_k(g_1g_2,x)
+        &=t_k(g_1,g_2x)t_k(g_2,x).
+    \label{eq:fbc25_stabilizer_transition_product}
+\end{align}
+
+Equation~\texttt{eq:h1h2} at line~7038 of
+Ref.~\cite{FrancoRubio2025MPUGauging} prints
+$h_1=k_{g_1g_2x}^{-1}g_1k_{g_1x}$. This expression does not generally
+stabilize $x_0$. Resolving the $g_2$ action first in
+(\ref{eq:fbc25_stabilizer_transition_product}) gives the corrected factors
+\begin{align}
+    h_2
+        &=k_{g_2x}^{-1}g_2k_x=t_k(g_2,x),
+    \label{eq:fbc25_stabilizer_h2}\\
+    h_1
+        &=k_{g_1g_2x}^{-1}g_1k_{g_2x}=t_k(g_1,g_2x).
+    \label{eq:fbc25_stabilizer_h1}
+\end{align}
+Thus the final representative in $h_1$ is $k_{g_2x}$, not $k_{g_1x}$.
+No normality or finiteness assumption is needed.\footnote{Formal declarations:
+\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement\_mem\_stabilizer},
+\leanid{TNLean.Algebra.StabilizerRepresentatives.transitionElement\_mul}, and
+\leanid{TNLean.Algebra.StabilizerRepresentatives.h₁\_eq} in
+\doclink{TNLean/Algebra/StabilizerTransition}.}
+
+\textbf{Verdict: resolved local fix.}
+The chosen-representative product determines the corrected index uniquely.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## What changed

- package normalized representatives `k_x` for a pretransitive group action and construct them from Mathlib's pretransitivity API
- define `t_k(g,x)` directly as an element of `MulAction.stabilizer G x₀`, with a coercion formula recovering `k_(g • x)⁻¹ g k_x`
- prove `t_k(g₁g₂,x) = t_k(g₁,g₂ • x)t_k(g₂,x)` as an equality in the stabilizer subgroup
- retain the paper's `h₁,h₂` notation and corrected `k_(g₂ • x)` formula in the Chapter 29 node and resolved paper-gap note, without source-local public aliases in the generic Lean API

The package assumes neither finiteness nor normality and does not introduce tensor data or claim the full stabilizer classification.

## Validation

- `lake build TNLean.Algebra.StabilizerTransition` (618 jobs)
- `lake build TNLean.Algebra` (3566 jobs)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- Blueprint forward/reverse sync and `lake exe checkdecls blueprint/lean_decls`
- paper-gap declaration extraction and `lake exe checkdecls`
- Blueprint declaration-scanner and paper-gap-scanner tests
- two direct Blueprint `lualatex` passes, with no undefined cross-references
- standalone paper-gap PDF compilation with bibliography

Closes #7649.
Advances #7360.
