### PR TITLE
feat(MPS/MPU): package the four scalar block-independence formulations

### DIFF
--- a/TNLean/Algebra/LSymbolBlockIndependence.lean
+++ b/TNLean/Algebra/LSymbolBlockIndependence.lean
@@ -45,6 +45,8 @@ inverse gauges trivialize `L`.
   gauges trivialize a block-independent compatible L-symbol.
 * `LSymbol.hasTrivialGauge_iff_*`: the four scalar conditions are
   equivalent for a supplied compatible L-symbol.
+* `LSymbol.hasTrivialGauge_tfae`: the four scalar conditions, listed in the
+  order of `prop:technical01`, are equivalent.
 
 These results do not establish the tensor-facing fourth condition of the source
 for an MPS–MPU pair.
@@ -379,6 +381,22 @@ theorem hasTrivialGauge_iff_isBlockIndependent [Nonempty X]
   constructor
   · exact fun h ↦ h.hasBlockConstantGauge.isBlockIndependent
   · exact IsBlockIndependent.hasTrivialGauge hCompat
+
+/-- The four scalar gauge formulations of block independence are equivalent
+for a supplied compatible L-symbol, listed in the order of
+arXiv:2502.20257, `prop:technical01` (lines 6975–6989): a gauge with all
+`Lˣ_{g,h} = 1`; a gauge with `Lˣ_{g,h}` independent of `x`; a gauge with all
+`ellˣ_{a,b;g} = 1`; and block independence. The source's fourth condition is
+stated for an MPS–MPU pair; here it is the scalar condition on the supplied
+L-symbol. -/
+theorem hasTrivialGauge_tfae [Nonempty X]
+    {L : LSymbol G X} {ω : ScalarThreeCochain G} (hCompat : IsCompatible L ω) :
+    [HasTrivialGauge L, HasBlockConstantGauge L, HasTrivialEllGauge L,
+      IsBlockIndependent L].TFAE := by
+  tfae_have 1 ↔ 2 := hasTrivialGauge_iff_hasBlockConstantGauge hCompat
+  tfae_have 1 ↔ 3 := hasTrivialGauge_iff_hasTrivialEllGauge hCompat
+  tfae_have 1 ↔ 4 := hasTrivialGauge_iff_isBlockIndependent hCompat
+  tfae_finish
 
 end LSymbol
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2754,6 +2754,36 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     the original gauge.
 \end{proof}
 
+\begin{theorem}[Four scalar gauge formulations of block independence]
+    \label{thm:mpug_block_independence_four_forms}
+    \lean{TNLean.Algebra.LSymbol.hasTrivialGauge_tfae}
+    \leanok
+    \uses{def:mpug_block_independence_gauge_forms,
+        thm:mpug_trivial_iff_block_constant,
+        thm:mpug_trivial_iff_trivial_ell,
+        thm:mpug_trivial_iff_block_independent}
+    Let $L$ be a supplied $L$-symbol compatible with a scalar $3$-cochain,
+    and suppose that $\mathsf X$ is nonempty. The four scalar gauge
+    properties (\ref{eq:mpug_block_form_trivial}),
+    (\ref{eq:mpug_block_form_constant}),
+    (\ref{eq:mpug_block_form_trivial_ell}), and
+    (\ref{eq:mpug_block_form_independent_ell}) of $L$ are equivalent. This is
+    the scalar core of the block-independence proposition of
+    \cite{FrancoRubio2025MPUGauging}, whose fourth condition is stated for an
+    MPS--MPU pair.
+    % Source anchor: arXiv:2502.20257, prop:technical01, lines 6975--6989.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_trivial_iff_block_constant,
+        thm:mpug_trivial_iff_trivial_ell,
+        thm:mpug_trivial_iff_block_independent}
+    Theorems~\ref{thm:mpug_trivial_iff_block_constant},
+    \ref{thm:mpug_trivial_iff_trivial_ell}, and
+    \ref{thm:mpug_trivial_iff_block_independent} identify each of the last
+    three properties with the first.
+\end{proof}
+
 The source's fourth condition is a statement about an MPS--MPU pair. The
 results above begin instead with a supplied compatible scalar $L$-symbol and
 prove the algebraic equivalence among its four scalar gauge properties. A


### PR DESCRIPTION
## Summary

Advances #7268 (`prop:technical01`, the four equivalent formulations of block independence).

- `TNLean/Algebra/LSymbolBlockIndependence.lean`: adds `LSymbol.hasTrivialGauge_tfae`, the four-way equivalence of the scalar gauge formulations in the order of the source proposition (a gauge with all `Lˣ_{g,h} = 1`; a gauge with `Lˣ_{g,h}` independent of `x`; a gauge with all `ellˣ_{a,b;g} = 1`; block independence), assembled from the three existing pairwise equivalences of #7308. No definition is changed and block independence is not redefined.
- `blueprint/src/chapter/ch29_mpu_gauging.tex`: adds `thm:mpug_block_independence_four_forms` beside the #7308 entries, with `\lean{}`, `\leanok`, and `\uses`; the statement carries the explicit scalar scope restriction (supplied compatible L-symbol, nonempty block set), so the source-labelled tensor statement is not claimed.

## Sources

- `Papers/2502.20257/main.tex`, lines 3597--3601 (`eq:scalarfactor`) and 6965--7027 (`prop:technical01`; proof at 6988--7026).

## What remains for #7268

The source's fourth condition is stated for an MPS--MPU pair. Closing the issue needs the L-symbol derived from fusion and action tensors (`eq:defL`) and the identification of the tensor gauge rescalings with `LSymbol.gauge`, owned by #7330 and #7331 (both open, no PR). Once those land, the tensor statement is this theorem applied to the derived L-symbol.

## Validation

- `scripts/lake_build_locked.sh TNLean.Algebra.LSymbolBlockIndependence` (linter-bearing): built cleanly, no warnings.
- `rg -n "sorry|axiom|admit|native_decide"` on the changed files: only the word "admits" in prose.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `--ci`: in sync.
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`: current.
- `python3 scripts/tactic_pattern_scan.py`: no new pattern from this change.
- `python3 scripts/test_lean_file_policies.py`: 16 tests OK.
- `git diff --check`: clean.
- `lake exe checkdecls blueprint/lean_decls`: exit 0, no missing declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR

