### PR TITLE
feat(MPS/MPU): prove the diagonal source-u retained network

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -45,6 +45,7 @@ import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import TNLean.MPS.MPU.SourceIndexValue
 import TNLean.MPS.MPU.SourceUCompleteNetwork
+import TNLean.MPS.MPU.SourceURetainedInterior
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 import TNLean.MPS.MPU.SourceVIsometry

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -16,9 +16,9 @@ identify a Gram matrix for the paper gate $u=Y_2\mathbin{-}Y_1$.
 
 The source proof in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
 `lemuisometry` (lines 536--556), instead contracts the staggered paper-$u$
-network. That route remains unformalized. Similar blocked and output-tail
-shapes in this file must not be read as a formalization of the figure or as
-support for the paper source-$u$ isometry.
+network; that contraction is formalized in `SourceUCompleteNetwork`. Similar
+blocked and output-tail shapes in this file must not themselves be read as the
+paper source-$u$ identity.
 -/
 
 open scoped Matrix BigOperators ComplexOrder

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -13,11 +13,25 @@ import TNLean.MPS.MPU.SourceVIsometry
 This file follows the contraction in CPSV17 Lemma `lemuisometry`.  The source
 gate is the staggered contraction \(u=Y_2\mathbin{-}Y_1\).  Its Gram matrix is
 first expanded into the literal reflected--direct four-tensor network in
-Figure `II_uUnitary.png`; the retained physical legs are not included in the
-simple interior block.
+Figure `II_uUnitary.png`.  The network is then closed against a fixed pair
+\(E^K=|\rho)(\Phi|\), while the two retained one-site letters remain outside
+the \(K\)-site interior.  The normalized input tail gives \(u^\dagger u=\Id\)
+and \(d^2\le r\ell\).
 
-Source: arXiv:1703.09188, equations `X1X2b`, `uu`, and `uUnitary`, and Lemma
-`lemuisometry` (lines 487--557).
+**Local fix (source-weight orientation):** column stacking makes the Gram
+closure insert \(|\rho^{\mathsf T})(\Phi|\), while the source fixes \(\rho\) in
+diagonal canonical-form-II coordinates, where \(\rho^{\mathsf T}=\rho\).
+The closing theorems keep `SourceFactors U ρ` and expose this convention as
+`ρ.IsDiag`, using only `ρ.IsSymm` for the algebraic trace closure.  Documented
+in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
+
+**Scope restriction (supplied stabilized fixed pair):** the isometry and rank
+theorems below assume \(E^K=|\rho)(\Phi|\) explicitly.  CPSV17 Lemma
+`lemuisometry` uses the preceding canonical-form-II convention instead.
+Documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+
+Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, `uu`, and
+`uUnitary`, and Lemma `lemuisometry` (lines 269--280 and 487--557).
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker
@@ -333,5 +347,101 @@ theorem normalized_mpo_input_tail_eq_closed_doubleLayer_trace
   rw [normalizedDiagonal_pow_eq_sum_evalWord W K]
   simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul,
     Matrix.mul_sum, Matrix.trace_sum]
+
+namespace SourceFactors
+
+/-- For a symmetric supplied source weight, the source-$u$ Gram matrix is the
+closed direct double-layer trace for any matching fixed pair.  The source
+factors remain those constructed from `ρ`; the pair `p` is starred and `q` is
+unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed point in the diagonal coordinates of lines 269--280. -/
+theorem sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρ : ρ.IsSymm) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  rw [sourceU_gram_eq_transpose_fixed_pair_trace, hρ.eq, ← hK]
+  exact Matrix.trace_mul_cycle _ _ _
+
+/-- For the source's diagonal fixed point satisfying \(E^K=|\rho)(\Phi|\), the
+source-$u$ Gram matrix is the normalized input-first contraction with one
+length-$K$ interior and two retained one-site endpoints.  The pair `p` is
+starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed point in the diagonal coordinates of lines 269--280. -/
+theorem sourceU_gram_eq_normalized_input_tail [NeZero d]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) := by
+  rw [normalized_mpo_input_tail_eq_closed_doubleLayer_trace]
+  exact sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm U S hρdiag.isSymm K hK p q
+
+/-- For supplied source factors and a diagonal fixed pair, the paper gate
+\(u=Y_2\mathbin{-}Y_1\) of an MPU tensor is an isometry.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
+the diagonal coordinates of lines 269--280. -/
+theorem sourceU_isIsometry_of_isMPU [NeZero d] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U S).IsIsometry := by
+  change (sourceU U S)ᴴ * sourceU U S = 1
+  ext p q
+  have h := sourceU_gram_eq_normalized_input_tail U S hρdiag K hK p q
+  rw [hU.normalized_mpo_tail_isometry] at h
+  rw [Matrix.mul_apply, Matrix.one_apply, ← h]
+  exact Finset.sum_congr rfl fun lr _ ↦ by
+    rw [Matrix.conjTranspose_apply, mul_comm]
+
+/-- The rank consequence of the supplied-fixed-pair source-$u$ isometry:
+\(d^2\le r\ell\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem mul_self_le_rightRank_mul_leftRank_of_isMPU [NeZero d] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    d * d ≤ r[U] * ℓ[U] := by
+  have h := Matrix.IsIsometry.card_le _ (sourceU_isIsometry_of_isMPU U hU S hρdiag K hK)
+  simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
+
+end SourceFactors
+
+variable {U} in
+/-- For a positive diagonal fixed point, the compact-SVD paper gate $u$ of an
+MPU tensor is an isometry.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
+the diagonal coordinates of lines 269--280. -/
+theorem IsMPU.sourceU_isIsometry [NeZero d] (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U ρ hρ).IsIsometry :=
+  SourceFactors.sourceU_isIsometry_of_isMPU U hU (sourceFactors U ρ hρ) hρdiag K hK
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceURetainedInterior.lean
+++ b/TNLean/MPS/MPU/SourceURetainedInterior.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.ReflectedTransferKernel
+import TNLean.MPS.MPU.SourceUCompleteNetwork
+
+/-!
+# Retained-interior contraction for the paper source gate u
+
+In the diagonal canonical-form-II coordinates fixed in CPSV17, the right
+transfer fixed point satisfies \(\rho^{\mathsf T}=\rho\). This identifies the
+transpose-oriented closure of the source-gate Gram matrix with the direct
+fixed pair supplied by the transfer power. The normalized input tail then gives
+the complete network in Lemma `lemuisometry`.
+
+Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, and `uUnitary`,
+and Lemma `lemuisometry` (lines 269--280 and 487--557).
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+namespace SourceFactors
+
+/-- If the supplied source weight is symmetric, its source-$u$ Gram matrix is
+the closed direct double-layer trace for any matching fixed pair. The source
+factors remain those constructed from `ρ`.
+
+Source: CPSV17 equations `Erightleft`, `X1X2b`, and `uUnitary`, and Lemma
+`lemuisometry` (lines 269--280 and 487--557). -/
+theorem sourceU_gram_eq_closedDoubleLayerTrace_of_isSymm
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hρ : ρ.IsSymm) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec
+        (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+          (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  rw [sourceU_gram_eq_transpose_fixed_pair_trace, hρ.eq, ← hK]
+  exact Matrix.trace_mul_cycle _ _ _
+
+/-- In diagonal canonical-form-II coordinates, the source-$u$ Gram matrix is
+the normalized input-first contraction with one length-\(JD^2\) interior and
+two retained one-site endpoints.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
+-/
+theorem sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
+    [NeZero d] [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hρdiag : ρ.IsDiag) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower :
+      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+        Matrix.vecMulVec ρ.vec
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec)
+    (p q : Fin d × Fin d) :
+    let K := J * (D * D)
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) := by
+  dsimp only
+  let K := J * (D * D)
+  let ρ' : Fin (D * D) → ℂ :=
+    fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+  let Φ' : Fin (D * D) → ℂ :=
+    fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+      (finProdFinEquiv.symm x)
+  have hfixed := normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+    U ρ hρtrace J hpower
+  have hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec ρ' Φ' := by
+    dsimp only [K, ρ', Φ'] at hfixed ⊢
+    rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at hfixed
+    exact hfixed
+  calc
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+        Matrix.trace
+          (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+            normalizedDiagonal (doubleLayerTensor U) ^ K) :=
+      sourceU_gram_eq_closedDoubleLayerTrace_of_isSymm U S hρdiag.isSymm K hK p q
+    _ = _ := (normalized_mpo_input_tail_eq_closed_doubleLayer_trace U K p q).symm
+
+/-- In the diagonal canonical-form-II coordinates of CPSV17, the paper source
+gate \(u=Y_2\mathbin{-}Y_1\) is an isometry.
+
+Source: CPSV17 Lemma `lemuisometry` and equation `uUnitary` (lines 545--557).
+-/
+theorem sourceU_isIsometry_of_isDiag
+    [NeZero d] [NeZero D] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hρdiag : ρ.IsDiag) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower :
+      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
+        Matrix.vecMulVec ρ.vec
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    (sourceU U S).IsIsometry := by
+  rw [Matrix.IsIsometry]
+  ext p q
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
+  let K := J * (D * D)
+  have hgram := sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
+    U S hρdiag hρtrace J hpower p q
+  dsimp only at hgram
+  rw [hU.normalized_mpo_tail_isometry K p q] at hgram
+  simpa only [mul_comm] using hgram
+
+end SourceFactors
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceURetainedInterior.lean
+++ b/TNLean/MPS/MPU/SourceURetainedInterior.lean
@@ -34,7 +34,7 @@ factors remain those constructed from `ρ`.
 
 Source: CPSV17 equations `Erightleft`, `X1X2b`, and `uUnitary`, and Lemma
 `lemuisometry` (lines 269--280 and 487--557). -/
-theorem sourceU_gram_eq_closedDoubleLayerTrace_of_isSymm
+theorem sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
     (hρ : ρ.IsSymm) (K : ℕ)
     (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
@@ -93,7 +93,7 @@ theorem sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
         Matrix.trace
           (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
             normalizedDiagonal (doubleLayerTensor U) ^ K) :=
-      sourceU_gram_eq_closedDoubleLayerTrace_of_isSymm U S hρdiag.isSymm K hK p q
+      sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm U S hρdiag.isSymm K hK p q
     _ = _ := (normalized_mpo_input_tail_eq_closed_doubleLayer_trace U K p q).symm
 
 /-- In the diagonal canonical-form-II coordinates of CPSV17, the paper source

--- a/TNLean/MPS/MPU/SourceURetainedInterior.lean
+++ b/TNLean/MPS/MPU/SourceURetainedInterior.lean
@@ -7,13 +7,19 @@ import TNLean.MPS.MPU.ReflectedTransferKernel
 import TNLean.MPS.MPU.SourceUCompleteNetwork
 
 /-!
-# Retained-interior contraction for the paper source gate u
+# Transfer-power adapter for the paper source gate u
 
-In the diagonal canonical-form-II coordinates fixed in CPSV17, the right
-transfer fixed point satisfies \(\rho^{\mathsf T}=\rho\). This identifies the
-transpose-oriented closure of the source-gate Gram matrix with the direct
-fixed pair supplied by the transfer power. The normalized input tail then gives
-the complete network in Lemma `lemuisometry`.
+This module converts a supplied normalized transfer-matrix power at length
+\(J\) into the direct double-layer fixed pair at length \(JD^2\), then applies
+the arbitrary-interior complete-network theorem for the paper gate
+\(u=Y_2\mathbin{-}Y_1\).
+
+**Scope restriction (supplied stabilized fixed pair):** the theorem assumes the
+raw rank-one transfer identity and the source's diagonal canonical-form-II
+coordinates explicitly.  It keeps `SourceFactors U ρ`; no source factor is
+recomputed from \(\rho^{\mathsf T}\).  Documented in
+`docs/paper-gaps/mpu_canonical_form_full_support.tex` and
+`docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, and `uUnitary`,
 and Lemma `lemuisometry` (lines 269--280 and 487--557).
@@ -28,34 +34,12 @@ variable {d D : ℕ} (U : MPOTensor d D)
 
 namespace SourceFactors
 
-/-- If the supplied source weight is symmetric, its source-$u$ Gram matrix is
-the closed direct double-layer trace for any matching fixed pair. The source
-factors remain those constructed from `ρ`.
+/-- A trace-one transfer fixed pair at exponent \(J\) gives the normalized
+source-$u$ input-tail identity with one length-\(JD^2\) interior and two
+retained one-site endpoints.
 
-Source: CPSV17 equations `Erightleft`, `X1X2b`, and `uUnitary`, and Lemma
-`lemuisometry` (lines 269--280 and 487--557). -/
-theorem sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm
-    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
-    (hρ : ρ.IsSymm) (K : ℕ)
-    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
-      Matrix.vecMulVec
-        (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
-          (finProdFinEquiv.symm x)))
-    (p q : Fin d × Fin d) :
-    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
-      Matrix.trace
-        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
-          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
-  rw [sourceU_gram_eq_transpose_fixed_pair_trace, hρ.eq, ← hK]
-  exact Matrix.trace_mul_cycle _ _ _
-
-/-- In diagonal canonical-form-II coordinates, the source-$u$ Gram matrix is
-the normalized input-first contraction with one length-\(JD^2\) interior and
-two retained one-site endpoints.
-
-Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557).
--/
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed point in the diagonal coordinates of lines 269--280. -/
 theorem sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
     [NeZero d] [NeZero D]
     {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
@@ -88,38 +72,7 @@ theorem sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
     dsimp only [K, ρ', Φ'] at hfixed ⊢
     rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at hfixed
     exact hfixed
-  calc
-    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
-        Matrix.trace
-          (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
-            normalizedDiagonal (doubleLayerTensor U) ^ K) :=
-      sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm U S hρdiag.isSymm K hK p q
-    _ = _ := (normalized_mpo_input_tail_eq_closed_doubleLayer_trace U K p q).symm
-
-/-- In the diagonal canonical-form-II coordinates of CPSV17, the paper source
-gate \(u=Y_2\mathbin{-}Y_1\) is an isometry.
-
-Source: CPSV17 Lemma `lemuisometry` and equation `uUnitary` (lines 545--557).
--/
-theorem sourceU_isIsometry_of_isDiag
-    [NeZero d] [NeZero D] (hU : IsMPU U)
-    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
-    (hρdiag : ρ.IsDiag) (hρtrace : Matrix.trace ρ = 1)
-    (J : ℕ)
-    (hpower :
-      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ J =
-        Matrix.vecMulVec ρ.vec
-          (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
-    (sourceU U S).IsIsometry := by
-  rw [Matrix.IsIsometry]
-  ext p q
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
-  let K := J * (D * D)
-  have hgram := sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag
-    U S hρdiag hρtrace J hpower p q
-  dsimp only at hgram
-  rw [hU.normalized_mpo_tail_isometry K p q] at hgram
-  simpa only [mul_comm] using hgram
+  exact sourceU_gram_eq_normalized_input_tail U S hρdiag K hK p q
 
 end SourceFactors
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5302,7 +5302,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
          & =d^{-K}\sum_{\tau,\eta}
         \overline{U^{(K+2)}_{\eta,(p,\tau)}}
         U^{(K+2)}_{\eta,(q,\tau)}
-          =\delta_{p,q}.
+        =\delta_{p,q}.
     \end{align}
     Hence $u^\dagger u=\Id$. Since $u$ maps a space of dimension $d^2$
     isometrically into one of dimension $r\ell$, one also has $d^2\leq r\ell$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5059,7 +5059,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_diagonal_power_fixed_pair, thm:mpu_normalized_input_tail_closed_trace}
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_reflected_transfer_power, thm:mpu_normalized_input_tail_closed_trace}
     Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
     external source gates as
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5029,6 +5029,52 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Theorem~\ref{thm:mpu_source_u_staggered_gram}.
 \end{proof}
 
+\begin{theorem}[Retained-interior source-$u$ closure]
+    \label{thm:mpu_source_u_retained_interior}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm,
+        MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail}
+    \leanok
+    \discussion{7633}
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace,
+        thm:mpu_normalized_input_tail_closed_trace}
+    Let $\mathcal U$ be an MPO tensor with physical dimension $d>0$, let $W$
+    be its double layer, and put $E=d^{-1}\sum_iW^{ii}$. Let $\rho$ be
+    symmetric, set $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and
+    suppose that for some $K\geq0$,
+    \begin{align}
+        E^K & =\lvert\rho)(\Phi\rvert.
+    \end{align}
+    For supplied source factors built from the same weight $\rho$, the paper
+    gate $u=Y_2\mathbin{-}Y_1$ satisfies
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\operatorname{tr}\!\left(W^{p_1q_1}W^{p_2q_2}E^K\right).
+    \end{align}
+    If $\rho$ is diagonal, the same quantity is
+    \begin{align}
+        d^{-K}\sum_{\tau,\eta}
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}.
+    \end{align}
+    Thus only the $K$-site interior is blocked; the two endpoint letters remain
+    one-site tensors. The $p$ entries are conjugated and the $q$ entries are
+    not. This is the supplied-fixed-pair contraction in
+    \cite[Lemma~III.7]{Cirac2017MPU}.
+    % Source locator: paper_v2.tex, lines 269--280 and 545--557.
+    % Orientation: docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace,
+        thm:mpu_normalized_input_tail_closed_trace}
+    Symmetry changes the inserted vector
+    $\lvert\rho^{\mathsf T})$ to $\lvert\rho)$ in
+    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace}. Substitute the
+    fixed pair and cycle the first endpoint letter to obtain the displayed
+    trace. The normalized input-tail identity expands that trace into the
+    second displayed sum.
+\end{proof}
+
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
     \lean{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
@@ -5058,35 +5104,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source locator: paper_v2.tex, lines 545--557.
 \end{theorem}
 
-\begin{proof}
-    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm}
-    \leanok
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_reflected_transfer_power, thm:mpu_normalized_input_tail_closed_trace}
-    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
-    external source gates as
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
-        \right).
-    \end{align}
-    Diagonality gives $\rho^{\mathsf T}=\rho$. Set $K=JD^2$. The normalized
-    blocked-transfer identity supplies
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_retained_interior,
+        thm:mpu_reflected_transfer_power}
+    Set $K=JD^2$. Trace normalization makes the supplied rank-one transfer
+    matrix idempotent, and the normalized blocked-transfer identity therefore
+    gives
     \begin{align}
         E^K & =\lvert\rho)(\Phi\rvert.
     \end{align}
-    Substitute this direct fixed pair and use cyclicity of the trace to obtain
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_2q_2}E^K W^{p_1q_1}
-        \right)
-         & =\operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}E^K
-        \right).
-    \end{align}
-    Expanding the right-hand side as the normalized input tail leaves exactly
-    one $K$-site interior and the two unblocked one-site endpoints. The $p$
-    entries are starred, the $q$ entries are unstarred, and the contraction is
-    therefore the displayed input-first sum.
+    Diagonality gives $\rho^{\mathsf T}=\rho$, so
+    Theorem~\ref{thm:mpu_source_u_retained_interior} applies at this $K$ and
+    yields the displayed normalized input-tail sum.
 \end{proof}
 
 \begin{theorem}[Complete source-$v$ network]
@@ -5230,43 +5259,53 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Admissible source-$u$ isometry]
     \label{lem:mpu_admissible_source_u_isometry}
-    \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}
+    \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU,
+        MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU,
+        MPOTensor.IsMPU.sourceU_isIsometry}
     \leanok
     \discussion{5708}
-    % **Scope restriction (supplied stabilized fixed pair):** this lemma assumes
-    % the exact rank-one transfer identity explicitly, whereas source Lemma III.7
-    % uses the preceding MPU and canonical-form-II convention. Documented in
-    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv}
-    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ be diagonal with $\tr(\rho)=1$, and put
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Suppose that for some
-    $J>0$ the normalized transfer matrix satisfies
+    % **Scope restriction (supplied stabilized diagonal fixed pair):** this
+    % lemma assumes the exact rank-one identity explicitly, whereas source
+    % Lemma III.7 uses the preceding canonical-form-II convention. Documented
+    % in docs/paper-gaps/mpu_canonical_form_full_support.tex and
+    % docs/paper-gaps/mpu_source_cut_orientation.tex.
+    \uses{def:mpu, def:mpu_source_uv, def:mpu_weighted_source_factors,
+        def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$. Let $W$
+    be its double layer, put $E=d^{-1}\sum_iW^{ii}$, and let $\rho>0$ be
+    diagonal. Put $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$ and
+    suppose that for some $K\geq0$,
     \begin{align}
-        E^J & =\lvert\rho)(\Phi\rvert.
+        E^K & =\lvert\rho)(\Phi\rvert.
     \end{align}
-    Let $r$ and $\ell$ be the two source-cut ranks, and construct the source
-    factors and $u$ from $\mathcal U$ using $\rho$. Then
+    Let $r$ and $\ell$ be the source-cut ranks, and construct the compact-SVD
+    source factors and $u$ from $\mathcal U$ using $\rho$. Then
     \begin{align}
         u^\dagger u & =\Id.
     \end{align}
-    Consequently $u$ is an isometry and $r\ell\geq d^2$. This is the
-    reduced-source version of \cite[Lemma~III.7]{Cirac2017MPU}.
-    % Source lines: paper_v2.tex 545--557.
+    Moreover,
+    \begin{align}
+        d^2 & \leq r\ell.
+    \end{align}
+    Thus the compact-SVD paper gate is an isometry. This is the
+    supplied-fixed-pair version of \cite[Lemma~III.7]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 269--280 and 545--557.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_input_tail_isometry}
-    Set $K=JD^2$. The complete-network identity and input-first MPU unitarity
-    give, for all retained physical pairs $p,q$,
+    \uses{thm:mpu_source_u_retained_interior,
+        thm:mpu_normalized_input_tail_isometry}
+    The retained-interior identity and input-first MPU unitarity give, for all
+    physical pairs $p,q$,
     \begin{align}
         (u^\dagger u)_{p,q}
          & =d^{-K}\sum_{\tau,\eta}
         \overline{U^{(K+2)}_{\eta,(p,\tau)}}
-        U^{(K+2)}_{\eta,(q,\tau)}  \\
-         & =\delta_{p,q}.
+        U^{(K+2)}_{\eta,(q,\tau)}
+          =\delta_{p,q}.
     \end{align}
-    Hence $u^\dagger u=\Id$.
+    Hence $u^\dagger u=\Id$. Since $u$ maps a space of dimension $d^2$
+    isometrically into one of dimension $r\ell$, one also has $d^2\leq r\ell$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -8585,7 +8624,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     This fixes the order and normalization of the two triangles in
     \cite[equations~\texttt{uu} and~\texttt{uUnitary}]{Cirac2017MPU} for this
-    basic MPU.
+    basic MPU. It is the explicit normalization and orientation regression for
+    Theorem~\ref{thm:mpu_source_u_retained_interior} and
+    Lemma~\ref{lem:mpu_admissible_source_u_isometry}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5324,14 +5324,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     conditions is assumed. Thus $u$ is a standing isometry and
     $r\ell\geq d^2$ throughout the proof.
 
-    Suppose first that $\mathcal U$ is simple. Under the source's diagonal
-    fixed-point convention, Theorem~\ref{thm:mpu_simple_source_v_isometry}
-    gives $v^\dagger v=\Id$ for the source operator built from the same weight
-    $\rho$, hence $r\ell\leq d^2$. For a general reduced full-support datum,
-    however, $\rho$ need not be symmetric. The complete network then inserts
-    $\lvert\rho^{\mathsf T})$ while stabilization supplies
-    $\lvert\rho)$, so an additional same-gate retained-network argument is
-    still required. This is one reason the present theorem remains not ready.
+    Suppose first that $\mathcal U$ is simple. The reduced full-support datum
+    requires $\rho$ to be diagonal, so
+    Theorem~\ref{thm:mpu_simple_source_v_isometry} gives
+    $v^\dagger v=\Id$ for the source operator built from the same weight
+    $\rho$, hence $r\ell\leq d^2$.
 
     If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
     Theorem~\ref{thm:mpu_source_gates_two_site_factorization} gives the exact

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4918,15 +4918,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
     \end{align}
-    These data are supplied in one of two ways.
-    \begin{enumerate}
-        \item If $D=1$, take $J=1$ and $\rho=\Id_1$ using
-              Theorem~\ref{thm:mpu_normalized_transfer_fin_one}.
-        \item If $D>1$, choose canonical-form-II data for the normalized
-              flattening of this same tensor, with its blocks filling the
-              ambient bond space. Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}
-              supplies the fixed pair with $J=D^2-1$.
-    \end{enumerate}
+    The one-dimensional case is supplied directly: if $D=1$, take $J=1$
+    and $\rho=\Id_1$ using
+    Theorem~\ref{thm:mpu_normalized_transfer_fin_one}. If $D>1$, chosen
+    canonical-form-II data with full support give a positive trace-one ambient
+    fixed point with $J=D^2-1$ by
+    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Diagonality of
+    this ambient fixed point is an additional hypothesis: the theorem gives a
+    diagonal matrix in the unique block coordinates, but conjugation into the
+    ambient coordinates need not preserve diagonality.
     For $D>1$, this states the fixed-pair convention in
     \cite[equations labelled~\texttt{Erightleft} and~\texttt{II\_UTransfer}, and
         proof of Proposition~III.2(ii)]{Cirac2017MPU}. The $D=1$ branch is the direct
@@ -5058,7 +5058,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source locator: paper_v2.tex, lines 545--557.
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm}
+    \leanok
     \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_reflected_transfer_power, thm:mpu_normalized_input_tail_closed_trace}
     Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
     external source gates as

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4912,8 +4912,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Let $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ be the normalized
     flattening, and let $E$ be its transfer matrix. A reduced full-support source
     datum for $\mathcal U$, with physical dimension $d>0$ and positive bond
-    dimension, consists of an integer $J>0$, a positive definite matrix $\rho$
-    with $\tr(\rho)=1$, and
+    dimension, consists of an integer $J>0$, a diagonal positive definite matrix
+    $\rho$ with $\tr(\rho)=1$, and
     $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$ such that
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
@@ -5005,10 +5005,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
         \right).
     \end{align}
-    In particular, the weight is transposed rather than identified with
-    $\rho$. The retained-interior equality needed for the complete contraction
-    remains open.
-    % The retained-interior equality is tracked in Issue #7633.
+    Thus the fixed-pair weight is genuinely transposed at this stage. In the
+    diagonal canonical-form-II coordinates fixed above,
+    $\rho^{\mathsf T}=\rho$; this is the identification used in the complete
+    contraction below.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -5031,14 +5031,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
+    \leanok
     \discussion{5982}
     \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family}
     % Revalidation boundary: docs/paper-gaps/mpu_source_cut_orientation.tex.
     Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    dimension $D>0$. Let $\rho>0$ be diagonal with $\tr(\rho)=1$, and put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Suppose that for some
+    $J>0$ the normalized transfer matrix satisfies
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
     \end{align}
@@ -5057,8 +5058,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source locator: paper_v2.tex, lines 545--557.
 \end{theorem}
 
-\begin{proof}
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_diagonal_power_fixed_pair, thm:mpu_normalized_input_tail_closed_trace}
     Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
     external source gates as
     \begin{align}
@@ -5066,21 +5067,24 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
         \right).
     \end{align}
-    Cyclicity moves the first double-layer letter past the trace. It remains to
-    identify the resulting rank-one insertion with the $K$-site interior:
+    Diagonality gives $\rho^{\mathsf T}=\rho$. Set $K=JD^2$. The normalized
+    blocked-transfer identity supplies
+    \begin{align}
+        E^K & =\lvert\rho)(\Phi\rvert.
+    \end{align}
+    Substitute this direct fixed pair and use cyclicity of the trace to obtain
     \begin{align}
         \operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert
+        W^{p_2q_2}E^K W^{p_1q_1}
         \right)
          & =\operatorname{tr}\!\left(
         W^{p_1q_1}W^{p_2q_2}E^K
         \right).
     \end{align}
-    This retained-interior contraction remains open. It must preserve the two
-    unblocked endpoint letters while applying the supplied simple contractions
-    to the interior. The checked $Y_1$--$X_2$ mixed-kernel identities concern a
-    different network and do not prove this equality.
-    % The retained-interior contraction is tracked in Issue #7633.
+    Expanding the right-hand side as the normalized input tail leaves exactly
+    one $K$-site interior and the two unblocked one-site endpoints. The $p$
+    entries are starred, the $q$ entries are unstarred, and the contraction is
+    therefore the displayed input-first sum.
 \end{proof}
 
 \begin{theorem}[Complete source-$v$ network]
@@ -5224,7 +5228,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Admissible source-$u$ isometry]
     \label{lem:mpu_admissible_source_u_isometry}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}
+    \leanok
     \discussion{5708}
     % **Scope restriction (supplied stabilized fixed pair):** this lemma assumes
     % the exact rank-one transfer identity explicitly, whereas source Lemma III.7
@@ -5232,9 +5237,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv}
     Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    dimension $D>0$. Let $\rho>0$ be diagonal with $\tr(\rho)=1$, and put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Suppose that for some
+    $J>0$ the normalized transfer matrix satisfies
     \begin{align}
         E^J & =\lvert\rho)(\Phi\rvert.
     \end{align}
@@ -5248,7 +5253,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 545--557.
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
     \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_input_tail_isometry}
     Set $K=JD^2$. The complete-network identity and input-first MPU unitarity
     give, for all retained physical pairs $p,q$,

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -23,7 +23,9 @@ For the MPU index of arXiv:1703.09188:
   column-stacking transfer fixed pair differ by a transpose for non-diagonal
   $\rho$, which the source-$u$ Gram and complete source-$v$ network formulas
   carry on the inserted vector $|\rho^{\mathsf T})$ without changing the
-  source gate's weight.
+  source gate's weight. In the source's diagonal canonical-form-II coordinates,
+  $\rho^{\mathsf T}=\rho$ closes the retained source-$u$ contraction and proves
+  $u^\dagger u=I$ for the supplied fixed pair.
 - `mpu_shift_specified_tensor_index_scope.tex` records that the computed shift
   formulas are values of the displayed tensors, while the source states the
   public blocking-independent MPU index. The remaining public construction is

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -5,7 +5,7 @@
 \input{command}
 \title{Full Support in MPU Normality and Theorem III.8}
 \author{}
-\date{2026-09-04}
+\date{2026-09-03}
 \begin{document}
 \maketitle
 \gapnote{scope-restriction}{open}

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -175,13 +175,18 @@ In both branches, the positive trace-one matrix $\rho$ is the source weight
 used to construct the factors and the operators $u$ and $v$.
 
 The explicit reduced-CFII and full-support hypotheses resolve the
-ambient-positivity question tracked by \ghissue{5855}. For a supplied positive
-trace-one fixed pair whose matrix $\rho$ is diagonal, the complete source-$u$
-network and its isometry conclusion are formalized by
-\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
-and \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}. The proof
-keeps the source factors built from $\rho$, uses
-$\rho^{\mathsf T}=\rho$, and retains one $K$-site interior between two
+ambient-positivity question tracked by \ghissue{5855}. For a supplied fixed
+pair whose matrix $\rho$ is diagonal, the arbitrary-$K$ complete source-$u$
+network is formalized by
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail}.
+Input unitarity gives the isometry and rank bound in
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU} and
+\leanid{MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU};
+\leanid{MPOTensor.IsMPU.sourceU_isIsometry} applies this result to the
+compact-SVD source factors. The raw trace-one transfer-power specialization is
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}.
+These proofs keep the source factors built from $\rho$, use
+$\rho^{\mathsf T}=\rho$, and retain one $K$-site interior between two
 unblocked endpoints. This is the supplied-fixed-pair form of Lemma~III.7 of
 Ref.~\cite{Cirac2017MPU}; it does not construct such source data for an
 arbitrary MPU representative.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -5,7 +5,7 @@
 \input{command}
 \title{Full Support in MPU Normality and Theorem III.8}
 \author{}
-\date{2026-08-24}
+\date{2026-09-04}
 \begin{document}
 \maketitle
 \gapnote{scope-restriction}{open}
@@ -175,14 +175,18 @@ In both branches, the positive trace-one matrix $\rho$ is the source weight
 used to construct the factors and the operators $u$ and $v$.
 
 The explicit reduced-CFII and full-support hypotheses resolve the
-ambient-positivity question tracked by \ghissue{5855}. They do not prove the
-two complete network identities required for Theorem~III.8 of
-Ref.~\cite{Cirac2017MPU}. For the source tensor $u$, the staggered
-reflected--direct Gram expansion and the normalized input-tail trace are
-formalized separately. Their equality after inserting the simple $K$-site
-interior of Figure~\texttt{II\_uUnitary.png} remains tracked by
-\ghissue{5982} and comes from Lemma~III.7 of Ref.~\cite{Cirac2017MPU}. The
-complete source-$v$ equivalence from the proof of Theorem~III.8 of
+ambient-positivity question tracked by \ghissue{5855}. For a supplied positive
+trace-one fixed pair whose matrix $\rho$ is diagonal, the complete source-$u$
+network and its isometry conclusion are formalized by
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
+and \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}. The proof
+keeps the source factors built from $\rho$, uses
+$\rho^{\mathsf T}=\rho$, and retains one $K$-site interior between two
+unblocked endpoints. This is the supplied-fixed-pair form of Lemma~III.7 of
+Ref.~\cite{Cirac2017MPU}; it does not construct such source data for an
+arbitrary MPU representative.
+
+The complete source-$v$ equivalence from the proof of Theorem~III.8 of
 Ref.~\cite{Cirac2017MPU} is formalized as
 \leanid{MPOTensor.sourceVDressedGram_iff_simple2_transpose_fixed_pair}; it
 needs no fixed-pair datum beyond a positive definite weight, and it carries
@@ -193,8 +197,8 @@ from that same weight.
 % Source lines: paper_v2.tex 545--557 and 577--600.
 % Source equation labels: uUnitary and vUnitary.
 
-For $D>1$, the two planned results assume reduced canonical-form-II data with
-full support for the same tensor $\mathcal U$ whose cuts, ranks, and source
+For $D>1$, the admissible source results assume reduced canonical-form-II data
+with full support for the same tensor $\mathcal U$ whose cuts, ranks, and source
 operators appear in their statements. For $D=1$, the one-dimensional
 stabilization theorem supplies the source pair directly. In either branch, the
 datum supplies $J>0$, a positive trace-one matrix $\rho$, and
@@ -202,17 +206,21 @@ datum supplies $J>0$, a positive trace-one matrix $\rho$, and
     E^J &= \lvert\rho)(\Phi\rvert.
     \label{eq:mpu_canonical_form_full_support_supplied_stabilization}
 \end{align}
-The admissible source-isometry and simple-tensor equivalence nodes cite
-Lemma~III.7 and Theorem~III.8 of Ref.~\cite{Cirac2017MPU} directly. Both retain
-the source factors of $\mathcal U$.
+The source-$u$ theorem additionally assumes that $\rho$ is diagonal, as in the
+source's canonical-form-II coordinates. Supplying these same-tensor diagonal
+source data is part of the construction tracked by \ghissue{7012}; the later
+unrestricted representative remains tracked by \ghissue{7127}. The admissible
+source-isometry and simple-tensor equivalence nodes cite Lemma~III.7 and
+Theorem~III.8 of Ref.~\cite{Cirac2017MPU} directly. Both retain the source
+factors of $\mathcal U$.
 % Source lines: paper_v2.tex 545--601.
 
-Blocking occurs only within the proof of the admissible source-isometry lemma.
-Let $J$ be the supplied stabilization exponent, define $K=JD^2$, and let
-$\mathcal U^{[K]}$ denote the direct $K$-site block of $\mathcal U$. This
-internal block supplies the direct and reflected contractions used to evaluate
-the closed network for $u^\dagger u$. It does not replace the source cuts,
-ranks, or operators of $\mathcal U$, and the argument does not transport source
+Blocking occurs only within the supplied-fixed-pair source-$u$ calculation.
+Let $J$ be the supplied stabilization exponent and define $K=JD^2$. The
+reflected transfer identity converts the power at $J$ into the direct
+$K$-site double-layer fixed pair. The calculation then keeps this one interior
+between the two unblocked endpoint letters. It does not replace the source
+cuts, ranks, or operators of $\mathcal U$, and it does not transport source
 data across blocking.
 
 \section{Downstream standard-form, index, and symmetry scope}
@@ -265,8 +273,8 @@ $\mathcal U'_k$, and $\mathcal W_k$, then places $\mathcal U_{2k}$ and
 $\mathcal U'_{2k}$ in standard form and computes the ranks of
 $\mathcal W_{4k}$ \cite{Cirac2017MPU}. The admissible theorem therefore
 requires separate source data for all six exact blocked tensors. It does not
-use later-block transport. The complete source-$u$ contraction in
-\ghissue{5982} is a dependency of the admissible source-isometry proof, and the
+use later-block transport. The formalized supplied-fixed-pair source-$u$
+contraction is a dependency of the admissible source-isometry proof, and the
 formalized complete source-$v$ network is a dependency of the admissible
 simple-tensor equivalence proof. Neither establishes the unrestricted source
 statements.
@@ -520,11 +528,11 @@ The native source-data scope tracker is \ghissue{6136}. The
 dimension-bounded full-support representative is constructed by
 \ghissue{7065} and the two theorems identified above. This closes
 representative existence but does not transport selected compact-SVD factors
-between unequal bond spaces. The admissible source-unitary and standard-form
-construction is tracked by \ghissue{7012}, while \ghissue{7127} owns the later
-unrestricted standard-form representative. The independent complete-network
-issue \ghissue{5982} remains necessary for the source-$u$ conclusion; the
-source-$v$ conclusion is formalized.
+between unequal bond spaces. The supplied-fixed-pair source-$u$ network from
+\ghissue{5982} and the source-$v$ conclusion are formalized. The admissible
+source-unitary and standard-form construction remains tracked by
+\ghissue{7012}, while \ghissue{7127} owns the later unrestricted standard-form
+representative.
 
 Issue~\ghissue{6139} treats tensor products, composition, and conjugate,
 adjoint, transposed, and other transformed comparison tensors. It removes the
@@ -539,8 +547,8 @@ The twenty-nine source/scoped pairs in the continuity and symmetry subtree are
 merged only after the relevant branches close. Until then, every source label
 remains an unrestricted unformalized statement, and every reduced-source or
 path-dependent statement remains under its \texttt{mpu\_admissible} label.
-Representative existence does not discharge the independent obligation in
-\ghissue{5982}.
+The supplied-fixed-pair contraction does not by itself construct the source
+data required to remove these restrictions.
 
 \section{Verdict}
 
@@ -561,13 +569,17 @@ dimensions has been proved. The original source labels remain unrestricted and
 unformalized; the distinct admissible nodes record the current same-tensor
 source-data route.
 
-Within Theorem~III.8 itself, the remaining proof gap is the complete
-source-$u$ contraction tracked by \ghissue{5982}; the complete source-$v$
-equivalence is formalized. Downstream standard-form, index,
-continuity, and symmetry results also lack existence or preservation theorems
-for reduced source data under products, transformed comparison tensors, and
-continuous paths. Chapter~28 records these requirements as explicit
-admissibility hypotheses rather than consequences of the MPU predicate.
+Within Theorem~III.8 itself, the complete supplied-fixed-pair source-$u$
+contraction and the complete source-$v$ equivalence are formalized. The
+unrestricted source statement \texttt{lemuisometry} remains open because the
+formalization does not yet construct the required same-tensor diagonal source
+data from an arbitrary MPU. That admissible construction remains in
+\ghissue{7012}, and the unrestricted representative remains in
+\ghissue{7127}. Downstream standard-form, index, continuity, and symmetry
+results also lack existence or preservation theorems for reduced source data
+under products, transformed comparison tensors, and continuous paths.
+Chapter~28 records these requirements as explicit admissibility hypotheses
+rather than consequences of the MPU predicate.
 
 The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_r_eq_one_of_fullSupport}.

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -162,7 +162,7 @@ For the source-$u$ gate, the transpose closure and the source's diagonal
 coordinates give a direct retained-window contraction. If the normalized
 transfer power supplies
 \begin{align}
-    E^J & =\lvert\rho)(\Phi\rvert.
+    E^J & =\lvert\rho)(\Phi\rvert,
 \end{align}
 then the reflected transfer identity at $K=JD^2$ and cyclicity of the trace
 give

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -175,13 +175,21 @@ give
 \end{align}
 Expanding this trace produces one $K$-site input tail between two unblocked
 one-site endpoints. The $p$ entries are conjugated and the $q$ entries are not,
-so MPU tail isometry gives $u^\dagger u=\operatorname{Id}$. The corresponding
-declarations are
+so MPU tail isometry gives $u^\dagger u=\operatorname{Id}$ and $d^2\le r\ell$.
+The arbitrary-$K$ declarations are
 \leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm},
-\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag},
-and \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}.
-This conclusion assumes the source's diagonal fixed point; it does not assert a
-source-$u$ theorem for arbitrary nonsymmetric $\rho$.
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail},
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU}, and
+\leanid{MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU}.
+The compact-SVD wrapper is \leanid{MPOTensor.IsMPU.sourceU_isIsometry}, while
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
+converts the raw trace-one transfer power at $J$ into the direct fixed pair at
+$K=JD^2$. The independent right-shift checks
+\leanid{MPOTensor.sourceU_rightShiftPaperSourceFactors_gram} and
+\leanid{MPOTensor.sourceU_rightShiftPaperSourceFactors_isIsometry} fix the same
+normalization and orientation explicitly. These conclusions assume the
+source's diagonal fixed point; they do not assert a source-$u$ theorem for
+arbitrary nonsymmetric $\rho$.
 
 \section{Affected claims and audit boundary}
 

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -162,7 +162,7 @@ For the source-$u$ gate, the transpose closure and the source's diagonal
 coordinates give a direct retained-window contraction. If the normalized
 transfer power supplies
 \begin{align}
-    E^J & =\lvert\rho)(\Phi\rvert,
+    E^J & =\lvert\rho)(\Phi\rvert.
 \end{align}
 then the reflected transfer identity at $K=JD^2$ and cyclicity of the trace
 give

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -158,6 +158,31 @@ converse direction in
 witnesses $(\Phi\rvert$ and $\lvert\rho^{\mathsf T})$ for the same weight
 $\rho$. No source-factor definition is changed.
 
+For the source-$u$ gate, the transpose closure and the source's diagonal
+coordinates give a direct retained-window contraction. If the normalized
+transfer power supplies
+\begin{align}
+    E^J & =\lvert\rho)(\Phi\rvert,
+\end{align}
+then the reflected transfer identity at $K=JD^2$ and cyclicity of the trace
+give
+\begin{align}
+    \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+     & =\operatorname{tr}\!\left(
+       W^{p_1q_1}W^{p_2q_2}E^K
+       \right).
+    \label{eq:mpu_source_cut_orientation_direct_closure}
+\end{align}
+Expanding this trace produces one $K$-site input tail between two unblocked
+one-site endpoints. The $p$ entries are conjugated and the $q$ entries are not,
+so MPU tail isometry gives $u^\dagger u=\operatorname{Id}$. The corresponding
+declarations are
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm},
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag},
+and \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isDiag}.
+This conclusion assumes the source's diagonal fixed point; it does not assert a
+source-$u$ theorem for arbitrary nonsymmetric $\rho$.
+
 \section{Affected claims and audit boundary}
 
 The transposed first cut affected source-factor recovery, physical adjunction,
@@ -173,8 +198,10 @@ Any source-$u$ or source-$v$ result written before this correction must be
 revalidated from its current declaration rather than accepted from an older
 compiled artifact. In particular, a proof must expose the $Y_2$--$Y_1$
 contraction for $u$ or the $X_1$--$X_2$ contraction for $v$, with the product
-orders shown above. The Chapter~28 Blueprint links only to declarations that
-were rebuilt after the correction.
+orders shown above. The supplied-fixed-pair source-$u$ contraction has now been
+revalidated in the source's diagonal canonical-form-II coordinates. Results
+outside this diagonal source-$u$ boundary still require the same
+statement-by-statement check.
 
 \section{Verdict}
 
@@ -185,10 +212,11 @@ paper gates, two-site factorizations, tensor products, and shift examples now
 use one consistent leg assignment. The correction is resolved, while the
 revalidation rule remains applicable to any future recovery of source-gate
 work predating this audit. The printed weight and the column-stacking transfer
-fixed pair differ by a transpose for non-diagonal $\rho$; the complete
-source-$u$ and source-$v$ network theorems carry this transpose on the
-inserted vector without changing the source gate's weight. The source's
-diagonal fixed point removes the mismatch in Theorem~III.8.
+fixed pair differ by a transpose for non-diagonal $\rho$; the source-$u$ Gram
+and source-$v$ network theorems carry this transpose on the inserted vector
+without changing the source gate's weight. The source's diagonal fixed point
+removes the mismatch in Theorem~III.8 and proves the supplied-fixed-pair
+source-$u$ isometry.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- add `SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm`, which keeps `SourceFactors U ρ`, rewrites the transpose-oriented Gram closure only under `ρ.IsSymm`, substitutes the supplied direct fixed pair, and cycles the two retained endpoint letters
- add the paper-facing diagonal-CFII complete-network theorem `sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag`
- prove `sourceU_isIsometry_of_isDiag` from the input-first normalized MPU tail isometry
- synchronize Chapter 28 and the source-cut/full-support gap notes while preserving the separate nonsymmetric source-v limitation from #7645

CPSV17 fixes the right fixed point in diagonal CFII coordinates at `Papers/1703.09188/paper_v2.tex:269-280`, so the public theorem exposes `ρ.IsDiag` rather than changing the source metric to `ρ.transpose` or claiming the stronger arbitrary-nonsymmetric statement. The network retains one `K = J(D²)` interior and two original one-site endpoint letters, with `p` starred and `q` unstarred.

The existing right-shift declarations remain the trace-one normalization and orientation regression.

## Validation

- `lake build TNLean.MPS.MPU.SourceURetainedInterior` (9046 jobs)
- full warm-cache `lake build` (10499 jobs)
- Blueprint sync: 7700/7700 declarations; Chapter 28: 994/994
- paper-gap declaration check: 1898 unique declaration heads
- Blueprint compiled to a stable pass with zero undefined references
- `git diff --check`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the new module

Closes #7633.
Closes #5982.
