### PR TITLE
feat(MPS/MPU): close the source-u network on the diagonal fixed point

### DIFF
--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -16,9 +16,9 @@ identify a Gram matrix for the paper gate $u=Y_2\mathbin{-}Y_1$.
 
 The source proof in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
 `lemuisometry` (lines 536--556), instead contracts the staggered paper-$u$
-network. That route remains unformalized. Similar blocked and output-tail
-shapes in this file must not be read as a formalization of the figure or as
-support for the paper source-$u$ isometry.
+network; that route is formalized in `TNLean.MPS.MPU.SourceUCompleteNetwork`.
+Similar blocked and output-tail shapes in this file must not be read as a
+formalization of the figure or as support for the paper source-$u$ isometry.
 -/
 
 open scoped Matrix BigOperators ComplexOrder

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -14,7 +14,36 @@ This file follows the contraction in CPSV17 Lemma `lemuisometry`.  The source
 gate is the staggered contraction \(u=Y_2\mathbin{-}Y_1\).  Its Gram matrix is
 first expanded into the literal reflected--direct four-tensor network in
 Figure `II_uUnitary.png`; the retained physical legs are not included in the
-simple interior block.
+simple interior block.  The network is then closed against the fixed pair
+\(E^K=|\rho)(\Phi|\) of the normalized double-layer diagonal, with the two
+retained one-site letters kept outside the \(K\)-site interior, and identified
+with the normalized input tail
+\(d^{-K}\operatorname{tr}_{1,\ldots,K}[U^{(K+2)\dagger}U^{(K+2)}]\).  Input
+unitarity then gives \(u^\dagger u=\Id\) and \(d^2\le r\ell\).
+
+**Local fix (source-weight orientation):** the weighted normalization
+\(X_1^\dagger(\Id_d\otimes\rho)X_1=\Id\) pairs the conjugated leg of \(X_1\)
+with the row index of \(\rho\), whereas the transfer fixed point inserted
+between two double-layer letters pairs the conjugated leg with the column
+index of \(\rho\) in the column-stacking coordinates of `Matrix.vec`.  The Gram
+matrix of the gate built from the weight \(\rho\) therefore closes to the
+insertion \(|\rho^{\mathsf T})(\Phi|\).  The source fixes its right fixed point
+in diagonal canonical-form-II coordinates (arXiv:1703.09188, lines 269--280
+and 356--361), where \(\rho^{\mathsf T}=\rho\); the closing theorems assume
+this diagonal convention as the named hypothesis `hρdiag` and keep the gate
+built from the same weight \(\rho\).  Documented in
+`docs/paper-gaps/mpu_source_cut_orientation.tex`.
+
+**Scope restriction (supplied stabilized fixed pair):**
+`SourceFactors.sourceU_gram_eq_normalized_input_tail`,
+`SourceFactors.sourceU_isIsometry_of_isMPU`,
+`SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU`, and
+`IsMPU.sourceU_isIsometry` take the rank-one identity \(E^K=|\rho)(\Phi|\) as
+an explicit hypothesis, whereas Lemma `lemuisometry` is stated under the
+source's standing canonical-form-II convention, which supplies this fixed pair
+together with the diagonal form of \(\rho\) (arXiv:1703.09188, lines 269--280
+and 350--361).  Documented in
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 
 Source: arXiv:1703.09188, equations `X1X2b`, `uu`, and `uUnitary`, and Lemma
 `lemuisometry` (lines 487--557).
@@ -333,5 +362,109 @@ theorem normalized_mpo_input_tail_eq_closed_doubleLayer_trace
   rw [normalizedDiagonal_pow_eq_sum_evalWord W K]
   simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul,
     Matrix.mul_sum, Matrix.trace_sum]
+
+namespace SourceFactors
+
+/-- The retained-interior closure of the source-\(u\) network for a symmetric
+weight.  For a symmetric weight \(\rho\), the inserted vector
+\(|\rho^{\mathsf T})\) is \(|\rho)\); when the normalized double-layer diagonal
+satisfies \(E^K=|\rho)(\Phi|\) with \((\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}\),
+the Gram matrix of \(u=Y_2\mathbin{-}Y_1\) built from the weight \(\rho\) is the
+closed double-layer trace of the two retained one-site letters followed by the
+\(K\)-site interior.  The pair `p` is starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed point in the diagonal coordinates of lines 269--280. -/
+theorem sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρ : ρ.IsSymm) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  rw [sourceU_gram_eq_transpose_fixed_pair_trace, hρ.eq, ← hK]
+  exact Matrix.trace_mul_cycle _ _ _
+
+/-- The complete source-\(u\) network contraction.  For the source's diagonal
+fixed point \(\rho\) with \(E^K=|\rho)(\Phi|\) and
+\((\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}\), the Gram matrix of the paper
+gate \(u=Y_2\mathbin{-}Y_1\) built from the weight \(\rho\) is the normalized
+input tail \(d^{-K}\operatorname{tr}_{1,\ldots,K}[U^{(K+2)\dagger}U^{(K+2)}]\).
+The pair `p` is starred and `q` is unstarred.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed point in the diagonal coordinates of lines 269--280. -/
+theorem sourceU_gram_eq_normalized_input_tail [NeZero d]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) := by
+  rw [normalized_mpo_input_tail_eq_closed_doubleLayer_trace]
+  exact sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm U S hρdiag.isSymm K hK p q
+
+/-- Lemma `lemuisometry` for supplied source factors: the paper gate
+\(u=Y_2\mathbin{-}Y_1\) of an MPU tensor, built from the source's diagonal
+fixed point \(\rho\) with \(E^K=|\rho)(\Phi|\), satisfies \(u^\dagger u=\Id\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
+the diagonal coordinates of lines 269--280. -/
+theorem sourceU_isIsometry_of_isMPU [NeZero d] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U S).IsIsometry := by
+  change (sourceU U S)ᴴ * sourceU U S = 1
+  ext p q
+  have h := sourceU_gram_eq_normalized_input_tail U S hρdiag K hK p q
+  rw [hU.normalized_mpo_tail_isometry] at h
+  rw [Matrix.mul_apply, Matrix.one_apply, ← h]
+  exact Finset.sum_congr rfl fun lr _ ↦ by
+    rw [Matrix.conjTranspose_apply, mul_comm]
+
+/-- Lemma `lemuisometry`, rank consequence: since \(u\) maps a space of
+dimension \(d^2\) isometrically into one of dimension \(r\ell\), the source-cut
+ranks satisfy \(d^2\le r\ell\).
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem mul_self_le_rightRank_mul_leftRank_of_isMPU [NeZero d] (hU : IsMPU U)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (hρdiag : ρ.IsDiag)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    d * d ≤ r[U] * ℓ[U] := by
+  have h := Matrix.IsIsometry.card_le _ (sourceU_isIsometry_of_isMPU U hU S hρdiag K hK)
+  simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
+
+end SourceFactors
+
+variable {U} in
+/-- Lemma `lemuisometry` for the compact-SVD gate: the paper gate
+\(u=Y_2\mathbin{-}Y_1\) of an MPU tensor, built from the source's diagonal
+positive fixed point \(\rho\) with \(E^K=|\rho)(\Phi|\), is an isometry.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
+the diagonal coordinates of lines 269--280. -/
+theorem IsMPU.sourceU_isIsometry [NeZero d] (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U ρ hρ).IsIsometry :=
+  SourceFactors.sourceU_isIsometry_of_isMPU U hU (sourceFactors U ρ hρ) hρdiag K hK
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5006,9 +5006,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \right).
     \end{align}
     In particular, the weight is transposed rather than identified with
-    $\rho$. The retained-interior equality needed for the complete contraction
-    remains open.
-    % The retained-interior equality is tracked in Issue #7633.
+    $\rho$. For the source's diagonal fixed point the inserted vector is
+    $\lvert\rho)$, and Theorem~\ref{thm:mpu_source_u_retained_interior}
+    closes the retained interior.
+    % Orientation: docs/paper-gaps/mpu_source_cut_orientation.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -5029,22 +5030,70 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Theorem~\ref{thm:mpu_source_u_staggered_gram}.
 \end{proof}
 
+\begin{theorem}[Retained-interior closure for a symmetric weight]
+    \label{thm:mpu_source_u_retained_interior}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm}
+    \leanok
+    \discussion{7633}
+    \uses{def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPO tensor with double-layer letters $W^{ij}$ and
+    normalized physical diagonal $E=d^{-1}\sum_iW^{ii}$. Let $\rho$ be a
+    symmetric bond matrix, $\rho^{\mathsf T}=\rho$, let $\lvert\rho)$ be its
+    column-stacking vector, put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
+    closed double layer of a $K$-site interior is the fixed pair,
+    \begin{align}
+        E^K & =\lvert\rho)(\Phi\rvert.
+        \label{eq:mpu_source_u_retained_interior_fixed_pair}
+    \end{align}
+    Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
+    the weight $\rho$, and let $u=Y_2\mathbin{-}Y_1$. Then, for retained
+    physical pairs $p=(p_1,p_2)$ and $q=(q_1,q_2)$,
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\tr\!\left(W^{p_1q_1}W^{p_2q_2}E^K\right).
+    \end{align}
+    The two endpoint letters remain unblocked; only the interior is the
+    $K$-site block, and the gate is built from the weight $\rho$ itself. The
+    symmetry hypothesis is the source's convention: the right fixed point is
+    taken in diagonal canonical-form-II coordinates
+    \cite[equation~\texttt{Erightleft}]{Cirac2017MPU}, and the weighted
+    normalization $X_1^\dagger(\Id_d\otimes\rho)X_1=\Id$ pairs the conjugated
+    leg with the row index of $\rho$ while $\lvert\rho)$ pairs it with the
+    column index.
+    % Source locator: paper_v2.tex, lines 269--280 and 545--557.
+    % Orientation: docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace}
+    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
+    external source gates as
+    $\tr(W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1})$. Since
+    $\rho^{\mathsf T}=\rho$, the inserted vector is $\lvert\rho)$.
+    Substituting (\ref{eq:mpu_source_u_retained_interior_fixed_pair}) and
+    cycling the letter $W^{p_1q_1}$ to the front of the trace gives
+    $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$.
+\end{proof}
+
 \begin{theorem}[Complete source-$u$ network contraction]
     \label{thm:mpu_source_u_complete_network}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail}
+    \leanok
     \discussion{5982}
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv, def:mpo_family}
+    \uses{def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer, def:mpo_family}
     % Revalidation boundary: docs/paper-gaps/mpu_source_cut_orientation.tex.
-    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    Let $\mathcal U$ be an MPO tensor with physical dimension $d>0$, let $W$
+    be its double layer, and let $E=d^{-1}\sum_iW^{ii}$ be the normalized
+    physical diagonal. Let the source's diagonal fixed point $\rho$ satisfy
     \begin{align}
-        E^J & =\lvert\rho)(\Phi\rvert.
+        E^K & =\lvert\rho)(\Phi\rvert
     \end{align}
-    Construct the source factors and $u$ from $\mathcal U$ using $\rho$, and set
-    $K=JD^2$. For retained physical pairs
-    $p,q\in\{0,\ldots,d-1\}^2$, the complete source-$u$ contraction satisfies
+    for some $K\geq0$, where $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$.
+    Let $M_i=X_iY_i$ be supplied source factorizations for $\mathcal U$ and
+    the weight $\rho$, and let $u=Y_2\mathbin{-}Y_1$. For retained physical
+    pairs $p,q\in\{0,\ldots,d-1\}^2$, the complete source-$u$ contraction
+    satisfies
     \begin{align}
         \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
          & =d^{-K}\sum_{\tau,\eta}
@@ -5053,34 +5102,19 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
     output words of length $K+2$. This is the supplied-fixed-pair form of the
-    complete-network equality in \cite[Lemma~III.7]{Cirac2017MPU}.
-    % Source locator: paper_v2.tex, lines 545--557.
+    complete-network equality in \cite[Lemma~III.7]{Cirac2017MPU}, with the
+    fixed point in the diagonal coordinates of
+    \cite[equation~\texttt{Erightleft}]{Cirac2017MPU}.
+    % Source locator: paper_v2.tex, lines 269--280 and 545--557.
 \end{theorem}
 
-\begin{proof}
-    \uses{thm:mpu_source_u_transpose_fixed_pair_trace, thm:mpu_normalized_input_tail_closed_trace}
-    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the two
-    external source gates as
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1}
-        \right).
-    \end{align}
-    Cyclicity moves the first double-layer letter past the trace. It remains to
-    identify the resulting rank-one insertion with the $K$-site interior:
-    \begin{align}
-        \operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert
-        \right)
-         & =\operatorname{tr}\!\left(
-        W^{p_1q_1}W^{p_2q_2}E^K
-        \right).
-    \end{align}
-    This retained-interior contraction remains open. It must preserve the two
-    unblocked endpoint letters while applying the supplied simple contractions
-    to the interior. The checked $Y_1$--$X_2$ mixed-kernel identities concern a
-    different network and do not prove this equality.
-    % The retained-interior contraction is tracked in Issue #7633.
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_retained_interior, thm:mpu_normalized_input_tail_closed_trace}
+    A diagonal matrix is symmetric, so
+    Theorem~\ref{thm:mpu_source_u_retained_interior} identifies the Gram
+    matrix of $u$ with $\tr(W^{p_1q_1}W^{p_2q_2}E^K)$, and
+    Theorem~\ref{thm:mpu_normalized_input_tail_closed_trace} writes the
+    normalized input tail as the same closed trace.
 \end{proof}
 
 \begin{theorem}[Complete source-$v$ network]
@@ -5220,38 +5254,55 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Consequently $u$ is an isometry and $r\ell\geq d^2$. This is the
     unrestricted statement of \cite[Lemma~III.7]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 545--557.
+    % Checked with an explicitly supplied stabilized diagonal fixed pair in
+    % Lemma~\ref{lem:mpu_admissible_source_u_isometry}. The source's standing
+    % convention supplies that pair from canonical form II (paper_v2.tex,
+    % lines 269--280 and 350--361); deriving it from the chosen
+    % canonical-form-II representative remains open. Documented in
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
 \end{lemma}
 
 \begin{lemma}[Admissible source-$u$ isometry]
     \label{lem:mpu_admissible_source_u_isometry}
-    \notready
+    \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU,
+        MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU,
+        MPOTensor.IsMPU.sourceU_isIsometry}
+    \leanok
     \discussion{5708}
-    % **Scope restriction (supplied stabilized fixed pair):** this lemma assumes
-    % the exact rank-one transfer identity explicitly, whereas source Lemma III.7
-    % uses the preceding MPU and canonical-form-II convention. Documented in
-    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{def:mpu, def:mpu_normalized_flattening, def:mpu_source_uv}
-    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
-    dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
-    some $J>0$ the normalized transfer matrix satisfies
+    % **Scope restriction (supplied stabilized diagonal fixed pair):** this
+    % lemma assumes the exact rank-one identity $E^K=|\rho)(\Phi|$ and the
+    % diagonal form of $\rho$ explicitly, whereas source Lemma III.7 uses the
+    % preceding MPU and canonical-form-II convention, which supplies both
+    % (paper_v2.tex, lines 269--280 and 350--361). Documented in
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex and
+    % docs/paper-gaps/mpu_source_cut_orientation.tex.
+    \uses{def:mpu, def:mpu_source_uv, def:mpu_weighted_source_factors, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$, let $W$
+    be its double layer, and let $E=d^{-1}\sum_iW^{ii}$ be the normalized
+    physical diagonal. Let the source's diagonal fixed point $\rho$ satisfy
     \begin{align}
-        E^J & =\lvert\rho)(\Phi\rvert.
+        E^K & =\lvert\rho)(\Phi\rvert
     \end{align}
-    Let $r$ and $\ell$ be the two source-cut ranks, and construct the source
-    factors and $u$ from $\mathcal U$ using $\rho$. Then
+    for some $K\geq0$, where $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$.
+    Let $r$ and $\ell$ be the two source-cut ranks, let $M_i=X_iY_i$ be
+    supplied source factorizations for $\mathcal U$ and the weight $\rho$,
+    and let $u=Y_2\mathbin{-}Y_1$. Then
     \begin{align}
         u^\dagger u & =\Id.
     \end{align}
-    Consequently $u$ is an isometry and $r\ell\geq d^2$. This is the
-    reduced-source version of \cite[Lemma~III.7]{Cirac2017MPU}.
-    % Source lines: paper_v2.tex 545--557.
+    Consequently $u$ is an isometry and $r\ell\geq d^2$. In particular, when
+    $\rho>0$, the source operator $u$ computed from the compact singular value
+    decompositions of $\mathcal U$ with the weight $\rho$ is an isometry. This
+    is the reduced-source version of \cite[Lemma~III.7]{Cirac2017MPU}, with
+    the fixed point in the diagonal coordinates of
+    \cite[equation~\texttt{Erightleft}]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 269--280 and 545--557.
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
     \uses{thm:mpu_source_u_complete_network, thm:mpu_normalized_input_tail_isometry}
-    Set $K=JD^2$. The complete-network identity and input-first MPU unitarity
-    give, for all retained physical pairs $p,q$,
+    The complete-network identity and input-first MPU unitarity give, for all
+    retained physical pairs $p,q$,
     \begin{align}
         (u^\dagger u)_{p,q}
          & =d^{-K}\sum_{\tau,\eta}
@@ -5259,7 +5310,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         U^{(K+2)}_{\eta,(q,\tau)}  \\
          & =\delta_{p,q}.
     \end{align}
-    Hence $u^\dagger u=\Id$.
+    Hence $u^\dagger u=\Id$. Since $u$ maps a space of dimension $d^2$
+    isometrically into a space of dimension $\ell r$, it is injective and
+    $d^2\le r\ell$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -5314,19 +5367,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpu_simple_source_v_isometry,
         thm:mpu_simple_of_source_v_isometry,
         thm:mpu_source_gates_two_site_factorization}
+    Under the source's diagonal fixed-point convention,
     Lemma~\ref{lem:mpu_admissible_source_u_isometry} gives
     $u^\dagger u=\Id$ before any of the four
     conditions is assumed. Thus $u$ is a standing isometry and
     $r\ell\geq d^2$ throughout the proof.
 
-    Suppose first that $\mathcal U$ is simple. Under the source's diagonal
-    fixed-point convention, Theorem~\ref{thm:mpu_simple_source_v_isometry}
+    Suppose first that $\mathcal U$ is simple. Under the same diagonal
+    convention, Theorem~\ref{thm:mpu_simple_source_v_isometry}
     gives $v^\dagger v=\Id$ for the source operator built from the same weight
     $\rho$, hence $r\ell\leq d^2$. For a general reduced full-support datum,
-    however, $\rho$ need not be symmetric. The complete network then inserts
+    however, $\rho$ need not be symmetric. Both complete networks then insert
     $\lvert\rho^{\mathsf T})$ while stabilization supplies
-    $\lvert\rho)$, so an additional same-gate retained-network argument is
-    still required. This is one reason the present theorem remains not ready.
+    $\lvert\rho)$, so the diagonal convention must first be transported to the
+    chosen representative. This is one reason the present theorem remains not
+    ready.
 
     If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
     Theorem~\ref{thm:mpu_source_gates_two_site_factorization} gives the exact

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -179,9 +179,16 @@ ambient-positivity question tracked by \ghissue{5855}. They do not prove the
 two complete network identities required for Theorem~III.8 of
 Ref.~\cite{Cirac2017MPU}. For the source tensor $u$, the staggered
 reflected--direct Gram expansion and the normalized input-tail trace are
-formalized separately. Their equality after inserting the simple $K$-site
-interior of Figure~\texttt{II\_uUnitary.png} remains tracked by
-\ghissue{5982} and comes from Lemma~III.7 of Ref.~\cite{Cirac2017MPU}. The
+formalized separately, and their equality after inserting the fixed pair
+$E^K=\lvert\rho)(\Phi\rvert$ of the $K$-site interior of
+Figure~\texttt{II\_uUnitary.png} is
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail}. It
+assumes the source's diagonal fixed point (paper\_v2.tex, lines 269--280) as
+an explicit hypothesis, so that the inserted vector
+$\lvert\rho^{\mathsf T})$ of \texttt{mpu\_source\_cut\_orientation.tex} is
+$\lvert\rho)$; input unitarity then gives Lemma~III.7 of
+Ref.~\cite{Cirac2017MPU} for the gate built from that same weight in
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU}. The
 complete source-$v$ equivalence from the proof of Theorem~III.8 of
 Ref.~\cite{Cirac2017MPU} is formalized as
 \leanid{MPOTensor.sourceVDressedGram_iff_simple2_transpose_fixed_pair}; it

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -148,9 +148,15 @@ identity with the insertion $\lvert\rho^{\mathsf T})(\Phi\rvert$ in
 The source gates remain the gates built from the printed weight $\rho$; replacing
 that weight by $\rho^{\mathsf T}$ recomputes $X_1,Y_1$ and gives a different
 gate when $\rho$ is not symmetric. The source's diagonal convention makes the
-two inserted vectors equal, and
-\leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry} proves the forward direction
-of Theorem~III.8 on precisely that convention. The reparametrized theorem
+two inserted vectors equal. On precisely that convention,
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm}
+closes the source-$u$ Gram of the gate built from $\rho$ against the fixed
+pair $E^K=\lvert\rho)(\Phi\rvert$ with both retained one-site letters kept
+outside the $K$-site interior,
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU} and
+\leanid{MPOTensor.IsMPU.sourceU_isIsometry} prove Lemma~III.7 for that gate,
+and \leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry} proves the forward
+direction of Theorem~III.8. The reparametrized theorem
 \leanid{MPOTensor.IsMPUSimple.sourceV_transpose_isIsometry} is retained as an
 auxiliary statement, not as an identification of the original gate. The
 converse direction in
@@ -188,7 +194,7 @@ work predating this audit. The printed weight and the column-stacking transfer
 fixed pair differ by a transpose for non-diagonal $\rho$; the complete
 source-$u$ and source-$v$ network theorems carry this transpose on the
 inserted vector without changing the source gate's weight. The source's
-diagonal fixed point removes the mismatch in Theorem~III.8.
+diagonal fixed point removes the mismatch in Lemma~III.7 and Theorem~III.8.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Closes the retained-window network of CPSV17 Lemma III.7 (`lemuisometry`) for the **original** paper gate `SourceFactors U ρ`, on the source's diagonal fixed-point convention, and derives `u†u = Id` together with `d² ≤ rℓ`.

New declarations in `TNLean/MPS/MPU/SourceUCompleteNetwork.lean`:

- `SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_isSymm` — the lowest algebraic step. For supplied factors `S : SourceFactors U ρ`, a named hypothesis `hρ : ρ.IsSymm`, and a fixed pair `hK : E^K = |ρ)(Φ|` of the normalized double-layer diagonal, the Gram sum `∑ lr, u lr q * star (u lr p)` equals `tr(W^{p₁q₁} W^{p₂q₂} E^K)`. The proof is exactly the owner's route on #7633: reuse `sourceU_gram_eq_transpose_fixed_pair_trace` for the original gate, rewrite `ρᵀ = ρ` via `IsSymm.eq`, substitute `hK`, close by `Matrix.trace_mul_cycle`. Both one-site letters stay outside the interior; nothing is absorbed into a `K+2` block, and the source factors are not reparametrized.
- `SourceFactors.sourceU_gram_eq_normalized_input_tail` — the complete-network identity `thm:mpu_source_u_complete_network` under `hρdiag : ρ.IsDiag`, combining the above with `normalized_mpo_input_tail_eq_closed_doubleLayer_trace`.
- `SourceFactors.sourceU_isIsometry_of_isMPU`, `SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU` — Lemma III.7 for supplied factors: `(sourceU U S).IsIsometry` from `IsMPU.normalized_mpo_tail_isometry`, and `d * d ≤ r[U] * ℓ[U]` from `Matrix.IsIsometry.card_le`.
- `IsMPU.sourceU_isIsometry` — the compact-SVD gate `sourceU U ρ hρ` is an isometry.

All closing theorems take the fixed pair in the `normalizedDiagonal (doubleLayerTensor U) ^ K = vecMulVec ρ' Φ'` form and `hρdiag : ρ.IsDiag`, i.e. the same hypothesis surface as the merged `IsMPUSimple.sourceV_isIsometry` (#7645), so `ThmFund1` (#5856) can combine both sides on one datum. No `hJ : 0 < J`, `tr ρ = 1`, or blocking to `JD²` is needed: the tail identity holds at the fixed-pair exponent `K` itself.

## Sources and rescoping rationale

- `Papers/1703.09188/paper_v2.tex`, lines 269–280: canonical form II fixes `|ρ) = ∑ ρ_n |n,n)` with `ρ_n > 0`, i.e. the right fixed point is diagonal. Lines 356–361: wlog `d^{-1/2} 𝒰` is in CFII before Section III.B. Lines 487–557: `X1X2b`, `uuvv`, `uu`, `uUnitary`, and `lemuisometry`.
- `sourceU_gram_eq_transpose_fixed_pair_trace` (#7634) shows that the printed weight `I_d ⊗ ρ` closes to the insertion `|ρᵀ)(Φ|` in column-stacking coordinates, while stabilization supplies `|ρ)(Φ|`. Following the owner's correction on #7633 (2026-09-03), the arbitrary-`ρ` target is stronger than the paper: `ρᵀ = ρ` is part of the source's standing setup before Lemma III.7, so the faithful theorem keeps `SourceFactors U ρ` and assumes `ρ.IsDiag` (resp. `ρ.IsSymm` in the lowest helper) as a **named** hypothesis. This PR does not repeat #7644's reparametrization to `SourceFactors U ρ.transpose`; `Matrix.transpose_transpose` is not used.
- Faithfulness of `lemuisometry` itself: the diagonal-`ρ` hypothesis is the source's convention, not an added one. The remaining difference between `lem:mpu_admissible_source_u_isometry` and the unrestricted `lemuisometry` is that the fixed pair `E^K = |ρ)(Φ|` (with diagonal `ρ`) is taken as an explicit input rather than derived from the CFII representative; the reduced full-support datum currently supplies `ρ = VΛV†`, which need not be diagonal. `lemuisometry` therefore stays `\notready`, with a comment recording what is checked and what remains, and the module carries one `**Scope restriction (supplied stabilized fixed pair)**` marker plus one `**Local fix (source-weight orientation)**` marker citing `docs/paper-gaps/mpu_canonical_form_full_support.tex` and `docs/paper-gaps/mpu_source_cut_orientation.tex`.

## Blueprint and notes

- `blueprint/src/chapter/ch28_mpu.tex`: new node `thm:mpu_source_u_retained_interior` (symmetric-weight closure); `thm:mpu_source_u_complete_network` and `lem:mpu_admissible_source_u_isometry` restated with the diagonal fixed point and marked `\lean{}`/`\leanok`; the transpose-trace node no longer says the interior is open; `lemuisometry` keeps `\notready` with a locator comment; the admissible equivalence-theorem proof sketch now states that both networks use the diagonal convention.
- `docs/paper-gaps/mpu_source_cut_orientation.tex` and `mpu_canonical_form_full_support.tex`: record the new declarations and that the diagonal fixed point removes the mismatch in Lemma III.7 as well as Theorem III.8. The orientation note already described the correct (non-reparametrized) reading; only the resolution paragraph is extended.
- `TNLean/MPS/MPU/MatchingContractions.lean`: module docstring now points at the formalized paper-`u` route.

## Validation

- `scripts/lake_build_locked.sh TNLean.MPS.MPU.SourceUCompleteNetwork TNLean.MPS.MPU.MatchingContractions` (linter-bearing; also elaborated with `-Dweak.linter.mathlibStandardSet=true`, no diagnostics)
- `rg -n "sorry|axiom|admit|native_decide"` on the changed Lean files: none
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` and `--ci`
- `scripts/lake_build_locked.sh -- lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/paper_gap_leanid_sync.py --root . --check`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex` (clean)
- pinned `scripts/latexindent -w -s -l blueprint/latexindent.yaml` on a copy of Chapter 28: byte-identical
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py` (no new candidates from this diff)
- `python3 scripts/test_lean_file_policies.py` (16 tests), `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`, `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

Closes #7633. Closes #5982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR
