### PR TITLE
feat(MPS/MPU): prove the simple-tensor equivalence theorem for the diagonal fixed pair

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -39,6 +39,7 @@ import TNLean.MPS.MPU.ReflectedTransferKernel
 import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
+import TNLean.MPS.MPU.SimpleTensorEquivalence
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactorContraction
 import TNLean.MPS.MPU.SourceFactors

--- a/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
+++ b/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Tactic.TFAE
+import TNLean.MPS.MPU.SourceUCompleteNetwork
+import TNLean.MPS.MPU.SourceVCompleteNetwork
+
+/-!
+# The simple-tensor equivalence theorem
+
+This file proves a supplied-fixed-pair specialization of Theorem `ThmFund1`
+of arXiv:1703.09188 (lines 563--601): for an MPU tensor $\mathcal U$ with
+source-cut ranks $r$ and $\ell$ and source gates $u=Y_2\mathbin{-}Y_1$ and
+$v=X_1\mathbin{-}X_2$, the following are equivalent:
+
+1. $\mathcal U$ is simple;
+2. $r\ell=d^2$;
+3. $u$ is unitary;
+4. $v$ is unitary.
+
+The proof follows the source route $1\to2\to3\to4\to1$.  The isometry
+$u^\dagger u=\Id$ of Lemma `lemuisometry` holds before any of the four
+conditions is assumed.  Simplicity gives $v^\dagger v=\Id$ and hence
+$r\ell\le d^2$, which with $d^2\le r\ell$ gives $r\ell=d^2$; then the isometry
+$u$ is square and therefore unitary; the two-site factorization
+$\operatorname{reindex}(U^{(2)})=v\,\operatorname{swap}_{r,\ell}(u)$ of
+equations `SVDforms2`--`uuvv` makes $v$ a product of unitaries; and
+$v^\dagger v=\Id$ gives `simple2`, hence simplicity.
+
+The fixed pair is supplied as in the source: $\rho>0$ is the diagonal right
+fixed point of canonical form II (arXiv:1703.09188, line 495), and the
+normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$ with
+$(\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}$ (equation `Erightleft`,
+lines 274--280).  The source cuts, ranks, and both gates are computed from the
+same tensor $\mathcal U$ with the same weight $\rho$.
+
+**Scope restriction (supplied diagonal fixed pair):** `IsMPU.isMPUSimple_tfae`
+assumes the positive diagonal fixed point and the exact finite-power identity
+explicitly. The unrestricted source theorem uses the preceding
+canonical-form-II representative convention. This remaining representative
+scope is documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Supplied-fixed-pair specialization of Theorem `ThmFund1`: for an MPU tensor
+$\mathcal U$ whose normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$
+for the source's diagonal
+fixed point $\rho>0$ and some $J>0$, with the source-cut ranks $r$, $\ell$ and
+the source gates $u$, $v$ computed from $\mathcal U$ using $\rho$, the following
+are equivalent:
+
+1. $\mathcal U$ is simple;
+2. $r\ell=d^2$;
+3. $u$ is unitary;
+4. $v$ is unitary.
+
+The proof is the source's cycle $1\to2\to3\to4\to1$:
+`IsMPU.sourceU_isIsometry` and the same-weight
+`IsMPUSimple.sourceV_isIsometry` give $1\to2$; the standing isometry $u$ with
+$\ell r=d^2$ is unitary ($2\to3$);
+`mpo_two_reindex_eq_sourceV_mul_sourceU_swap` writes the unitary $U^{(2)}$ as
+$v$ times the reindexed $u$, so $v$ is unitary ($3\to4$); and
+`IsMPU.isMPUSimple_of_sourceV_isIsometry` gives $4\to1$.
+
+Source: arXiv:1703.09188, Theorem `ThmFund1` and its proof (lines 563--601),
+with the diagonal fixed point of line 495. -/
+theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag)
+    (J : ℕ) (hJ : 0 < J)
+    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    List.TFAE [IsMPUSimple U,
+      r[U] * ℓ[U] = d * d,
+      (sourceU U ρ hρ).IsUnitaryBetween,
+      (sourceV U ρ hρ).IsUnitaryBetween] := by
+  have hu : (sourceU U ρ hρ).IsIsometry := hU.sourceU_isIsometry ρ hρ hρdiag J hpower
+  have hrankLower : d * d ≤ r[U] * ℓ[U] := by
+    have h := Matrix.IsIsometry.card_le _ hu
+    simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
+  tfae_have 1 → 2 := fun hS ↦ by
+    have hv : (sourceV U ρ hρ).IsIsometry :=
+      hS.sourceV_isIsometry ρ hρ hρdiag J hJ hpower
+    have hrankUpper := Matrix.IsIsometry.card_le _ hv
+    apply le_antisymm
+    · simpa only [Fintype.card_prod, Fintype.card_fin] using hrankUpper
+    · exact hrankLower
+  tfae_have 2 → 3 := fun h ↦
+    hu.isUnitaryBetween_of_card_eq _ (by
+      simp only [Fintype.card_prod, Fintype.card_fin]
+      rw [mul_comm]
+      exact h)
+  tfae_have 3 → 4 := fun h ↦ by
+    have hmpo := (Matrix.isUnitaryBetween_iff_mem_unitaryGroup _).mpr
+      (hU.mpo_mem_unitaryGroup (N := 2) one_lt_two)
+    have hre := hmpo.reindex _ (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+    rw [mpo_two_reindex_eq_sourceV_mul_sourceU_swap U ρ hρ] at hre
+    exact Matrix.IsUnitaryBetween.of_mul_right _ _ (h.reindex _ _ _) hre
+  tfae_have 4 → 1 := fun h ↦ hU.isMPUSimple_of_sourceV_isIsometry ρ hρ h.1
+  tfae_finish
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5326,7 +5326,55 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     This is the unrestricted statement of
     \cite[Theorem~III.8]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 563--601.
+    % The supplied diagonal-fixed-pair specialization below is checked. The
+    % unrestricted node remains not ready for the representative scope recorded
+    % in docs/paper-gaps/mpu_canonical_form_full_support.tex.
 \end{theorem}
+
+\begin{theorem}[Simple-tensor equivalence with a supplied diagonal fixed pair]
+    \label{thm:mpu_diagonal_fixed_pair_simple_tensor_equivalence}
+    \lean{MPOTensor.IsMPU.isMPUSimple_tfae}
+    \leanok
+    \uses{def:mpu, def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$, let $W$
+    be its double layer with normalized diagonal $E$, and let $\rho>0$ be
+    diagonal. Suppose that $E^J=\lvert\rho)(\Phi\rvert$ for some $J>0$, where
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Compute the source-cut
+    ranks $r$ and $\ell$ and both source operators $u$ and $v$ from this same
+    tensor $\mathcal U$ and weight $\rho$. Then the following are equivalent:
+    \begin{enumerate}
+        \item $\mathcal U$ is simple;
+        \item $r\ell=d^2$;
+        \item $u$ is unitary;
+        \item $v$ is unitary.
+    \end{enumerate}
+    This is the supplied diagonal-fixed-pair specialization of
+    \cite[Theorem~III.8]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 495 and 563--601.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_admissible_source_u_isometry,
+        thm:mpu_simple_source_v_isometry,
+        thm:mpu_source_gates_two_site_factorization,
+        thm:mpu_simple_of_source_v_isometry}
+    The supplied fixed pair gives $u^\dagger u=\Id$ and
+    $d^2\leq r\ell$ before any of the four conditions is assumed. Follow the
+    cycle $1\to2\to3\to4\to1$.
+
+    If $\mathcal U$ is simple, the source-$v$ contraction for the same weight
+    $\rho$ gives $v^\dagger v=\Id$, hence $r\ell\leq d^2$ and therefore
+    $r\ell=d^2$. Conversely, this equality makes the standing isometry $u$
+    square, hence unitary. The two-site factorization gives
+    \begin{align}
+        \operatorname{reindex}(U^{(2)})
+         & =v\,\operatorname{swap}_{r,\ell}(u).
+    \end{align}
+    Reindexing preserves unitarity. Since $U^{(2)}$ and $u$ are unitary,
+    cancellation makes $v$ unitary. Finally, $v^\dagger v=\Id$ gives the
+    second simple contraction, while the MPU identity gives the first, so
+    $\mathcal U$ is simple.
+\end{proof}
 
 \begin{theorem}[Admissible simple-tensor equivalence theorem]
     \label{thm:mpu_admissible_simple_tensor_equivalence}

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -156,7 +156,11 @@ auxiliary statement, not as an identification of the original gate. The
 converse direction in
 \leanid{MPOTensor.IsMPU.isMPUSimple_of_sourceV_isIsometry} produces the
 witnesses $(\Phi\rvert$ and $\lvert\rho^{\mathsf T})$ for the same weight
-$\rho$. No source-factor definition is changed.
+$\rho$. Together with the diagonal source-$u$ isometry,
+\leanid{MPOTensor.IsMPU.isMPUSimple_tfae} gives the supplied-fixed-pair
+specialization of Theorem~III.8; the unrestricted representative scope remains
+recorded in \texttt{mpu\_canonical\_form\_full\_support.tex}. No source-factor
+definition is changed.
 
 For the source-$u$ gate, the transpose closure and the source's diagonal
 coordinates give a direct retained-window contraction. If the normalized


### PR DESCRIPTION
## Summary

Closes #5856.

Formalizes the supplied diagonal-fixed-pair specialization of CPSV17 Theorem `ThmFund1` (`Papers/1703.09188/paper_v2.tex`, lines 563--601) as a four-way `List.TFAE` on one MPU tensor $\mathcal U$. The source-cut ranks $r,\ell$ and both paper gates $u=Y_2\mathbin{-}Y_1$, $v=X_1\mathbin{-}X_2$ are computed from $\mathcal U$ with the same weight $\rho$:

1. $\mathcal U$ is simple;
2. $r\ell=d^2$;
3. $u$ is unitary;
4. $v$ is unitary.

The proof follows the source cycle $1\to2\to3\to4\to1$.

### Rebase onto #7662

This branch is rebased onto merged #7662 and current `main` (`89a25de30`). All duplicated source-$u$ declarations and documentation were dropped. `SourceUCompleteNetwork.lean`, `SourceURetainedInterior.lean`, and `MatchingContractions.lean` are unchanged. The diff contains only:

- `SimpleTensorEquivalence.lean`;
- its generated MPU aggregator import;
- the supplied diagonal-fixed-pair four-way Blueprint theorem and proof;
- one short status update in the source-cut orientation note.

### Hypothesis scope

`IsMPU.isMPUSimple_tfae` takes $\mathcal U$ MPU, $d>0$, a diagonal $\rho>0$, $J>0$, and $E^J=|\rho)(\Phi|$ for the normalized double-layer diagonal $E$, where $(\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}$. The unrestricted `ThmFund1` and `lemuisometry` Blueprint nodes remain `\notready` only for the remaining same-tensor representative/source-data scope. The new module has one consolidated `**Scope restriction (supplied diagonal fixed pair):**` marker citing `docs/paper-gaps/mpu_canonical_form_full_support.tex`.

### Proof

- $1\to2$: the merged source-$u$ isometry gives $d^2\le r\ell$. For a simple tensor, the same-weight gate `sourceV U ρ hρ` is an isometry by `IsMPUSimple.sourceV_isIsometry`; `Matrix.IsIsometry.card_le` gives $r\ell\le d^2$.
- $2\to3$: equal finite cardinalities upgrade the standing source-$u$ isometry to `IsUnitaryBetween`.
- $3\to4$: `mpo_two_reindex_eq_sourceV_mul_sourceU_swap` is the corrected paper-gate factorization. Unitarity of $U^{(2)}$, exact reindexing, and `IsUnitaryBetween.of_mul_right` give unitarity of $v$.
- $4\to1$: the isometry half of unitary-between feeds `IsMPU.isMPUSimple_of_sourceV_isIsometry`.

The two earlier P1 findings are addressed: the result is consistently called a specialization and marked with its scope, and the $1\to2$ proof now uses the same-weight source-$v$ gate described by the Blueprint.

## Validation

- `lake build TNLean.MPS.MPU.SimpleTensorEquivalence` (9045 jobs)
- full warm-cache `lake build` (10508 jobs)
- proof-integrity and forbidden-token scans
- generated import-aggregator check
- Blueprint source sync and strict `checkdecls` (7706/7706 theorem-like entries)
- paper-gap declaration check
- Lean file-policy tests (16 tests)
- reader-facing prose check
- `chktex` and `latexindent` idempotence
- double `lualatex` Blueprint build with no undefined cross-references
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPUnq3LLnS5CEWUavbswR
