### PR TITLE
feat(Algebra): induce L-symbols from stabilizer cocycles

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -52,6 +52,7 @@ import TNLean.Algebra.ScalarThreeCocycle
 import TNLean.Algebra.ScalarThreeCocycleCyclicTwo
 import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
+import TNLean.Algebra.StabilizerCocycleLSymbol
 import TNLean.Algebra.StabilizerTransition
 import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation

--- a/TNLean/Algebra/StabilizerCocycleLSymbol.lean
+++ b/TNLean/Algebra/StabilizerCocycleLSymbol.lean
@@ -10,10 +10,11 @@ import TNLean.Algebra.StabilizerTransition
 /-!
 # L-symbols induced from stabilizer cocycles
 
-This file formalizes the scalar construction in arXiv:2502.20257, Lemma
-`lemma:h1h2` and Equations `eq:Lcocycle`, `eq:h1h2` (lines 7028–7042), using
-the corrected transition elements from `StabilizerTransition`. The same
-construction is Equation (20) of arXiv:2203.12563.
+This file formalizes the `ω = 1` scalar specialization of arXiv:2203.12563,
+Equation (20), using the corrected transition elements from
+`StabilizerTransition`. The relation to the representation-theoretic statement
+of arXiv:2502.20257, Lemma `lemma:h1h2` and Equations `eq:Lcocycle`, `eq:h1h2`
+(lines 7028–7042), is recorded only at the scalar level.
 
 For normalized representatives `k_x` and a scalar cocycle `ψ` on
 `H = Stab_G(x₀)`, define
@@ -42,8 +43,8 @@ def inducedLSymbol (K : StabilizerRepresentatives G X x₀)
   fun x g h ↦ ψ (K.transitionElement g (h • x)) (K.transitionElement h x)
 
 /-- A stabilizer cocycle induces an L-symbol compatible with the trivial scalar
-three-cochain. This is the transition-product/cocycle calculation underlying
-arXiv:2502.20257, Equation `eq:Lcocycle`. -/
+three-cochain. This is the `ω = 1` scalar specialization of arXiv:2203.12563,
+Equation (20). -/
 theorem inducedLSymbol_isCompatible (K : StabilizerRepresentatives G X x₀)
     {ψ : ScalarCocycle (MulAction.stabilizer G x₀)} (hψ : ψ.IsCocycle) :
     LSymbol.IsCompatible (K.inducedLSymbol ψ) (fun _ _ _ ↦ 1) := by
@@ -53,15 +54,6 @@ theorem inducedLSymbol_isCompatible (K : StabilizerRepresentatives G X x₀)
   simpa only [smul_smul] using
     (hψ (K.transitionElement g ((h * k) • x))
       (K.transitionElement h (k • x)) (K.transitionElement k x)).symm
-
-/-- On a stabilizer element, the transition at the basepoint is that element
-itself. -/
-theorem transitionElement_stabilizer (K : StabilizerRepresentatives G X x₀)
-    (h : MulAction.stabilizer G x₀) :
-    K.transitionElement (h : G) x₀ = h := by
-  apply Subtype.ext
-  rw [K.coe_transitionElement, MulAction.mem_stabilizer_iff.mp h.property, K.k_x₀]
-  simp
 
 /-- Restricting the induced L-symbol to the basepoint and stabilizer arguments
 recovers the original cocycle representative. -/
@@ -94,17 +86,25 @@ theorem inducedLSymbol_eq_gauge (K : StabilizerRepresentatives G X x₀)
   simp only [div_eq_mul_inv, mul_inv_rev, inv_inv]
   ac_rfl
 
-/-- Cohomologous stabilizer cocycles induce action-gauge-equivalent L-symbols,
-with no change of fusion gauge. -/
-theorem exists_actionGauge_inducedLSymbol_eq_of_cohomologousTo
+/-- Two stabilizer cocycles are cohomologous exactly when their induced
+L-symbols differ by an action-tensor gauge with no change of fusion gauge. -/
+theorem cohomologousTo_iff_exists_actionGauge_inducedLSymbol_eq
     (K : StabilizerRepresentatives G X x₀)
-    {ψ₁ ψ₂ : ScalarCocycle (MulAction.stabilizer G x₀)}
-    (hψ : ScalarCocycle.CohomologousTo ψ₁ ψ₂) :
-    ∃ γ : ActionTensorGauge G X,
-      K.inducedLSymbol ψ₁ =
-        LSymbol.gauge (fun _ _ ↦ 1) γ (K.inducedLSymbol ψ₂) := by
-  obtain ⟨φ, hφ⟩ := hψ
-  exact ⟨K.inducedActionGauge φ, K.inducedLSymbol_eq_gauge φ hφ⟩
+    (ψ₁ ψ₂ : ScalarCocycle (MulAction.stabilizer G x₀)) :
+    ScalarCocycle.CohomologousTo ψ₁ ψ₂ ↔
+      ∃ γ : ActionTensorGauge G X,
+        K.inducedLSymbol ψ₁ =
+          LSymbol.gauge (fun _ _ ↦ 1) γ (K.inducedLSymbol ψ₂) := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    exact ⟨K.inducedActionGauge φ, K.inducedLSymbol_eq_gauge φ hφ⟩
+  · rintro ⟨γ, hγ⟩
+    refine ⟨fun h ↦ (γ (h : G) x₀)⁻¹, fun a b ↦ ?_⟩
+    have hb : (b : G) • x₀ = x₀ := MulAction.mem_stabilizer_iff.mp b.property
+    have hγab := congrFun (congrFun (congrFun hγ x₀) (a : G)) (b : G)
+    simpa only [inducedLSymbol_base, LSymbol.gauge, Pi.one_apply, mul_one, hb,
+      Subgroup.coe_mul, div_eq_mul_inv, mul_inv_rev, inv_inv, mul_assoc, mul_comm,
+      mul_left_comm] using hγab
 
 end StabilizerRepresentatives
 

--- a/TNLean/Algebra/StabilizerCocycleLSymbol.lean
+++ b/TNLean/Algebra/StabilizerCocycleLSymbol.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CocycleCohomology
+import TNLean.Algebra.LSymbol
+import TNLean.Algebra.StabilizerTransition
+
+/-!
+# L-symbols induced from stabilizer cocycles
+
+This file formalizes the scalar construction in arXiv:2502.20257, Lemma
+`lemma:h1h2` and Equations `eq:Lcocycle`, `eq:h1h2` (lines 7028–7042), using
+the corrected transition elements from `StabilizerTransition`. The same
+construction is Equation (20) of arXiv:2203.12563.
+
+For normalized representatives `k_x` and a scalar cocycle `ψ` on
+`H = Stab_G(x₀)`, define
+
+`Lˣ_{g,h} = ψ(t_k(g,h • x), t_k(h,x))`.
+
+The transition-product identity reduces compatibility with the trivial scalar
+three-cochain exactly to the cocycle equation for `ψ`. At the basepoint, the
+restriction to `H × H` is `ψ`. A coboundary change of `ψ` is the action-tensor
+gauge `γ^x_g = φ(t_k(g,x))⁻¹`.
+
+No finiteness, normality, or tensor assumption is used.
+-/
+
+namespace TNLean.Algebra
+
+variable {G X : Type*} [Group G] [MulAction G X] {x₀ : X}
+
+namespace StabilizerRepresentatives
+
+/-- The L-symbol induced by a scalar cocycle on the stabilizer of the
+basepoint:
+`Lˣ_{g,h} = ψ(t_k(g,h • x), t_k(h,x))`. -/
+def inducedLSymbol (K : StabilizerRepresentatives G X x₀)
+    (ψ : ScalarCocycle (MulAction.stabilizer G x₀)) : LSymbol G X :=
+  fun x g h ↦ ψ (K.transitionElement g (h • x)) (K.transitionElement h x)
+
+/-- A stabilizer cocycle induces an L-symbol compatible with the trivial scalar
+three-cochain. This is the transition-product/cocycle calculation underlying
+arXiv:2502.20257, Equation `eq:Lcocycle`. -/
+theorem inducedLSymbol_isCompatible (K : StabilizerRepresentatives G X x₀)
+    {ψ : ScalarCocycle (MulAction.stabilizer G x₀)} (hψ : ψ.IsCocycle) :
+    LSymbol.IsCompatible (K.inducedLSymbol ψ) (fun _ _ _ ↦ 1) := by
+  intro x g h k
+  simp only [inducedLSymbol, one_mul]
+  rw [K.transitionElement_mul h k x, K.transitionElement_mul g h (k • x)]
+  simpa only [smul_smul] using
+    (hψ (K.transitionElement g ((h * k) • x))
+      (K.transitionElement h (k • x)) (K.transitionElement k x)).symm
+
+/-- On a stabilizer element, the transition at the basepoint is that element
+itself. -/
+theorem transitionElement_stabilizer (K : StabilizerRepresentatives G X x₀)
+    (h : MulAction.stabilizer G x₀) :
+    K.transitionElement (h : G) x₀ = h := by
+  apply Subtype.ext
+  rw [K.coe_transitionElement, MulAction.mem_stabilizer_iff.mp h.property, K.k_x₀]
+  simp
+
+/-- Restricting the induced L-symbol to the basepoint and stabilizer arguments
+recovers the original cocycle representative. -/
+theorem inducedLSymbol_base (K : StabilizerRepresentatives G X x₀)
+    (ψ : ScalarCocycle (MulAction.stabilizer G x₀))
+    (h₁ h₂ : MulAction.stabilizer G x₀) :
+    K.inducedLSymbol ψ x₀ (h₁ : G) (h₂ : G) = ψ h₁ h₂ := by
+  simp only [inducedLSymbol]
+  rw [show (h₂ : G) • x₀ = x₀ from MulAction.mem_stabilizer_iff.mp h₂.property]
+  simp [K.transitionElement_stabilizer]
+
+/-- A scalar cochain on the stabilizer determines the action-tensor gauge
+`γ^x_g = φ(t_k(g,x))⁻¹`. -/
+def inducedActionGauge (K : StabilizerRepresentatives G X x₀)
+    (φ : MulAction.stabilizer G x₀ → Units ℂ) : ActionTensorGauge G X :=
+  fun g x ↦ (φ (K.transitionElement g x))⁻¹
+
+/-- The coboundary relation between stabilizer cocycles becomes exactly the
+existing action-tensor gauge relation between their induced L-symbols. -/
+theorem inducedLSymbol_eq_gauge (K : StabilizerRepresentatives G X x₀)
+    {ψ₁ ψ₂ : ScalarCocycle (MulAction.stabilizer G x₀)}
+    (φ : MulAction.stabilizer G x₀ → Units ℂ)
+    (hφ : ∀ a b, ψ₁ a b = φ a * φ b * (φ (a * b))⁻¹ * ψ₂ a b) :
+    K.inducedLSymbol ψ₁ =
+      LSymbol.gauge (fun _ _ ↦ 1) (K.inducedActionGauge φ)
+        (K.inducedLSymbol ψ₂) := by
+  funext x g h
+  simp only [inducedLSymbol, LSymbol.gauge, inducedActionGauge, mul_one]
+  rw [hφ, K.transitionElement_mul]
+  simp only [div_eq_mul_inv, mul_inv_rev, inv_inv]
+  ac_rfl
+
+/-- Cohomologous stabilizer cocycles induce action-gauge-equivalent L-symbols,
+with no change of fusion gauge. -/
+theorem exists_actionGauge_inducedLSymbol_eq_of_cohomologousTo
+    (K : StabilizerRepresentatives G X x₀)
+    {ψ₁ ψ₂ : ScalarCocycle (MulAction.stabilizer G x₀)}
+    (hψ : ScalarCocycle.CohomologousTo ψ₁ ψ₂) :
+    ∃ γ : ActionTensorGauge G X,
+      K.inducedLSymbol ψ₁ =
+        LSymbol.gauge (fun _ _ ↦ 1) γ (K.inducedLSymbol ψ₂) := by
+  obtain ⟨φ, hφ⟩ := hψ
+  exact ⟨K.inducedActionGauge φ, K.inducedLSymbol_eq_gauge φ hφ⟩
+
+end StabilizerRepresentatives
+
+end TNLean.Algebra

--- a/TNLean/Algebra/StabilizerTransition.lean
+++ b/TNLean/Algebra/StabilizerTransition.lean
@@ -82,6 +82,16 @@ theorem coe_transitionElement (K : StabilizerRepresentatives G X x₀)
     (g : G) (x : X) :
     (transitionElement K g x : G) = (K.k (g • x))⁻¹ * g * K.k x := rfl
 
+/-- On a stabilizer element, the transition at the basepoint is that element
+itself. -/
+@[simp]
+theorem transitionElement_stabilizer (K : StabilizerRepresentatives G X x₀)
+    (h : MulAction.stabilizer G x₀) :
+    K.transitionElement (h : G) x₀ = h := by
+  apply Subtype.ext
+  rw [K.coe_transitionElement, MulAction.mem_stabilizer_iff.mp h.property, K.k_x₀]
+  simp
+
 /-- The transition elements obey the subgroup identity
 `t_k(g₁g₂,x) = t_k(g₁,g₂ • x)t_k(g₂,x)`. -/
 theorem transitionElement_mul (K : StabilizerRepresentatives G X x₀)

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2800,7 +2800,8 @@ show that the tensor gauge freedoms induce the joint scalar gauge
         TNLean.Algebra.StabilizerRepresentatives,
         TNLean.Algebra.StabilizerRepresentatives.ofPretransitive,
         TNLean.Algebra.StabilizerRepresentatives.transitionElement,
-        TNLean.Algebra.StabilizerRepresentatives.coe_transitionElement}
+        TNLean.Algebra.StabilizerRepresentatives.coe_transitionElement,
+        TNLean.Algebra.StabilizerRepresentatives.transitionElement_stabilizer}
     \leanok
     Suppose that $G$ acts transitively on $\mathsf X$, and fix
     $x_0\in\mathsf X$. There are representatives $k_x\in G$ satisfying
@@ -2850,11 +2851,10 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     \label{thm:mpug_stabilizer_cocycle_l_symbol}
     \lean{TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_isCompatible,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol,
-        TNLean.Algebra.StabilizerRepresentatives.transitionElement_stabilizer,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_base,
         TNLean.Algebra.StabilizerRepresentatives.inducedActionGauge,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_eq_gauge,
-        TNLean.Algebra.StabilizerRepresentatives.exists_actionGauge_inducedLSymbol_eq_of_cohomologousTo}
+        TNLean.Algebra.StabilizerRepresentatives.cohomologousTo_iff_exists_actionGauge_inducedLSymbol_eq}
     \leanok
     \uses{def:mpug_l_symbols, def:mpug_l_gauge, def:is_cocycle,
         def:cohomologous_to, thm:mpug_stabilizer_transition}
@@ -2865,32 +2865,46 @@ show that the tensor gauge freedoms induce the joint scalar gauge
          & =\psi\bigl(t_k(g,hx),t_k(h,x)\bigr).
         \label{eq:mpug_induced_stabilizer_l_symbol}
     \end{align}
-    Then $L$ satisfies (\ref{eq:mpug_l_compatibility}) with $\omega=1$, and
-    its base-point restriction recovers $\psi$:
+    Formula (\ref{eq:mpug_induced_stabilizer_l_symbol}) is the $\omega=1$
+    scalar specialization of \cite[Eq.~(20)]{GarreRubio2023MPOSym}.
+    The $L$-symbol satisfies (\ref{eq:mpug_l_compatibility}) with $\omega=1$,
+    and its base-point restriction recovers $\psi$:
     \begin{align}
         L^{x_0}_{a,b} & =\psi(a,b)
         \label{eq:mpug_induced_stabilizer_base}
     \end{align}
     for all $a,b\in H$.
 
-    If $\psi_1$ and $\psi_2$ are cohomologous through
+    More precisely, two stabilizer cocycles are cohomologous exactly when
+    their induced $L$-symbols differ by an action-tensor gauge and the trivial
+    fusion-tensor gauge:
+    \begin{align}
+        \psi_1\sim\psi_2
+         & \quad\Longleftrightarrow\quad
+        \exists\gamma,\quad
+        L[\psi_1]=(1,\gamma)\mathbin{\triangleright}L[\psi_2].
+        \label{eq:mpug_induced_cohomology_iff}
+    \end{align}
+    If the cohomology relation is witnessed by
     $\varphi\colon H\to\C^\times$, with
     \begin{align}
         \psi_1(a,b)
          & =\varphi(a)\varphi(b)\varphi(ab)^{-1}\psi_2(a,b),
         \label{eq:mpug_stabilizer_cocycle_gauge}
     \end{align}
-    then their induced $L$-symbols differ by the action-tensor gauge
+    then the forward action-tensor gauge is
     \begin{align}
-        \gamma_{g,x} & =\varphi\bigl(t_k(g,x)\bigr)^{-1}
+        \gamma_{g,x} & =\varphi\bigl(t_k(g,x)\bigr)^{-1}.
         \label{eq:mpug_induced_action_gauge}
     \end{align}
-    and the trivial fusion-tensor gauge. Thus the induced action-gauge class
-    depends only on the cohomology class of $\psi$.
-    % Source anchors: arXiv:2502.20257, lemma:h1h2 and eq:Lcocycle,
-    % lines 7028--7042; arXiv:2203.12563, Eq. (20).
-    This is only the scalar construction. It does not assert that an
-    $L$-symbol obtained from MPS and MPU tensors has this form.
+    Thus the induced action-gauge class depends only on the cohomology class
+    of $\psi$.
+
+    The representation-level lemma of
+    \cite[lines~7028--7042]{FrancoRubio2025MPUGauging} also asserts that a
+    tensor-derived $L$-symbol can be put in this form. The result here is only
+    its scalar part and does not make that representation-theoretic claim.
+    % Source anchor: arXiv:2203.12563, Eq. (20).
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2915,7 +2929,18 @@ show that the tensor gauge freedoms induce the joint scalar gauge
         =\varphi(a)\varphi(b)\varphi(ab)^{-1}.
     \end{align}
     Formula (\ref{eq:mpug_stabilizer_cocycle_gauge}) now identifies the two
-    induced $L$-symbols.
+    induced $L$-symbols. Conversely, suppose
+    $L[\psi_1]=(1,\gamma)\mathbin{\triangleright}L[\psi_2]$ and define
+    $\varphi(a)=\gamma_{a,x_0}^{-1}$ for $a\in H$. Evaluating the gauge
+    equality at $x_0$ and $a,b\in H$ gives
+    \begin{align}
+        \psi_1(a,b)
+         & =\frac{\gamma_{ab,x_0}}
+        {\gamma_{a,x_0}\gamma_{b,x_0}}\psi_2(a,b)
+        =\varphi(a)\varphi(b)\varphi(ab)^{-1}\psi_2(a,b).
+    \end{align}
+    Hence $\psi_1\sim\psi_2$, which proves the reverse implication in
+    (\ref{eq:mpug_induced_cohomology_iff}).
 \end{proof}
 
 \begin{definition}[Generalized coboundary and cocycle]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2917,10 +2917,11 @@ show that the tensor gauge freedoms induce the joint scalar gauge
         \psi(a,b)\psi(ab,c)
          & =\psi(a,bc)\psi(b,c),
     \end{align}
-    which is the cocycle equation. If $a,b\in H$, then
-    $t_k(a,x_0)=a$ and $t_k(b,x_0)=b$ because $k_{x_0}=e$, proving
-    (\ref{eq:mpug_induced_stabilizer_base}). Finally, substituting
-    (\ref{eq:mpug_induced_action_gauge}) into
+    which is the cocycle equation. If $p,q\in H$, then
+    $t_k(p,x_0)=p$ and $t_k(q,x_0)=q$ because $k_{x_0}=e$, proving
+    (\ref{eq:mpug_induced_stabilizer_base}). For the forward gauge
+    calculation, set $a=t_k(g,hx)$ and $b=t_k(h,x)$, so that
+    $t_k(gh,x)=ab$. Substituting (\ref{eq:mpug_induced_action_gauge}) into
     (\ref{eq:mpug_l_gauge}) gives the multiplier
     \begin{align}
         \frac{\gamma_{gh,x}}{\gamma_{g,hx}\gamma_{h,x}}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2850,6 +2850,7 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     \label{thm:mpug_stabilizer_cocycle_l_symbol}
     \lean{TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_isCompatible,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol,
+        TNLean.Algebra.StabilizerRepresentatives.transitionElement_stabilizer,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_base,
         TNLean.Algebra.StabilizerRepresentatives.inducedActionGauge,
         TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_eq_gauge,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2846,6 +2846,77 @@ show that the tensor gauge freedoms induce the joint scalar gauge
     corresponding specializations.
 \end{proof}
 
+\begin{theorem}[L-symbol induced by a stabilizer cocycle]
+    \label{thm:mpug_stabilizer_cocycle_l_symbol}
+    \lean{TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_isCompatible,
+        TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol,
+        TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_base,
+        TNLean.Algebra.StabilizerRepresentatives.inducedActionGauge,
+        TNLean.Algebra.StabilizerRepresentatives.inducedLSymbol_eq_gauge,
+        TNLean.Algebra.StabilizerRepresentatives.exists_actionGauge_inducedLSymbol_eq_of_cohomologousTo}
+    \leanok
+    \uses{def:mpug_l_symbols, def:mpug_l_gauge, def:is_cocycle,
+        def:cohomologous_to, thm:mpug_stabilizer_transition}
+    Let $H=\operatorname{Stab}_G(x_0)$ and let
+    $\psi\colon H\times H\to\C^\times$ be a scalar $2$-cocycle. Define
+    \begin{align}
+        L^x_{g,h}
+         & =\psi\bigl(t_k(g,hx),t_k(h,x)\bigr).
+        \label{eq:mpug_induced_stabilizer_l_symbol}
+    \end{align}
+    Then $L$ satisfies (\ref{eq:mpug_l_compatibility}) with $\omega=1$, and
+    its base-point restriction recovers $\psi$:
+    \begin{align}
+        L^{x_0}_{a,b} & =\psi(a,b)
+        \label{eq:mpug_induced_stabilizer_base}
+    \end{align}
+    for all $a,b\in H$.
+
+    If $\psi_1$ and $\psi_2$ are cohomologous through
+    $\varphi\colon H\to\C^\times$, with
+    \begin{align}
+        \psi_1(a,b)
+         & =\varphi(a)\varphi(b)\varphi(ab)^{-1}\psi_2(a,b),
+        \label{eq:mpug_stabilizer_cocycle_gauge}
+    \end{align}
+    then their induced $L$-symbols differ by the action-tensor gauge
+    \begin{align}
+        \gamma_{g,x} & =\varphi\bigl(t_k(g,x)\bigr)^{-1}
+        \label{eq:mpug_induced_action_gauge}
+    \end{align}
+    and the trivial fusion-tensor gauge. Thus the induced action-gauge class
+    depends only on the cohomology class of $\psi$.
+    % Source anchors: arXiv:2502.20257, lemma:h1h2 and eq:Lcocycle,
+    % lines 7028--7042; arXiv:2203.12563, Eq. (20).
+    This is only the scalar construction. It does not assert that an
+    $L$-symbol obtained from MPS and MPU tensors has this form.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_l_gauge, thm:mpug_stabilizer_transition}
+    Put
+    $a=t_k(g,hkx)$, $b=t_k(h,kx)$, and $c=t_k(k,x)$.
+    The product law (\ref{eq:mpug_stabilizer_transition_product}) gives
+    $t_k(gh,kx)=ab$ and $t_k(hk,x)=bc$. Compatibility is therefore exactly
+    \begin{align}
+        \psi(a,b)\psi(ab,c)
+         & =\psi(a,bc)\psi(b,c),
+    \end{align}
+    which is the cocycle equation. If $a,b\in H$, then
+    $t_k(a,x_0)=a$ and $t_k(b,x_0)=b$ because $k_{x_0}=e$, proving
+    (\ref{eq:mpug_induced_stabilizer_base}). Finally, substituting
+    (\ref{eq:mpug_induced_action_gauge}) into
+    (\ref{eq:mpug_l_gauge}) gives the multiplier
+    \begin{align}
+        \frac{\gamma_{gh,x}}{\gamma_{g,hx}\gamma_{h,x}}
+         & =\varphi(ab)^{-1}
+        \bigl(\varphi(a)^{-1}\varphi(b)^{-1}\bigr)^{-1}
+        =\varphi(a)\varphi(b)\varphi(ab)^{-1}.
+    \end{align}
+    Formula (\ref{eq:mpug_stabilizer_cocycle_gauge}) now identifies the two
+    induced $L$-symbols.
+\end{proof}
+
 \begin{definition}[Generalized coboundary and cocycle]
     \label{def:mpug_generalized_cocycle}
     \lean{TNLean.Algebra.GeneralizedThreeCochain,


### PR DESCRIPTION
## What changed

- define the scalar L-symbol induced from a cocycle on the base-point stabilizer by
  $L^x_{g,h}=\psi(t_k(g,h\cdot x),t_k(h,x))$
- prove compatibility with $\omega=1$ by the exact transition-product identity followed by the existing scalar cocycle equation
- prove that restriction to the base point and stabilizer arguments recovers $\psi$
- characterize cohomologous stabilizer cocycles by existence of an action gauge between their induced L-symbols, with the existing `CohomologousTo` and `LSymbol.gauge` orientations; the converse extracts $\varphi(h)=\gamma_{h,x_0}^{-1}$ at the base point
- place the cocycle-independent `[simp]` restriction formula beside the transition-product theorem in `StabilizerTransition`
- identify the construction as the $\omega=1$ scalar specialization of Eq. (20) in Garre-Rubio et al.; the Franco-Rubio et al. representation-level result is cited only in the scope qualification
- add one scoped Chapter 29 theorem node and regenerate the Algebra import aggregator

This is the scalar construction only. It does not assert that an L-symbol obtained from MPS and MPU tensors has this form, and it does not address the extension criterion.

## Validation

All final checks used exact `origin/main` and hot-main `89a25de3068c1659b76dae5ee5fc575a05b469c0`, including merged PR #7654.

- `lake build TNLean.Algebra.StabilizerCocycleLSymbol` (2400 jobs)
- `lake build TNLean.Algebra` (3575 jobs)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `lake exe lint_style`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7852/7852 entries formalized)
- `lake exe checkdecls blueprint/lean_decls`
- focused `chktex` and `latexindent` comparison for the combined Chapter 29
- two direct `lualatex` passes (1107 pages, 0 undefined cross-references)
- `texra-blueprint web` (no `ERROR:` or missing-file warnings)
- `python3 scripts/test_blueprint_web_render.py --web-root blueprint/web` (69 pages, 91,529 typeset elements)

No full `lake build` was run, as this algebraic leaf was validated with the exact warm cache and targeted builds.

Closes #7665.
Advances #7360.