### PR TITLE
doc(docs): record the two-binder nested-sum congruence as a tactic-pattern candidate

### DIFF
--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2035,9 +2035,9 @@ spectral split → block extraction → MPV calculation → strict bounds
   intro i _
   apply Finset.sum_congr rfl
   ```
-  descending through two nested `Finset.sum` binders to reach the summand,
-  together with its `rw [Finset.sum_comm]`-prefixed variant.
-- **Seen:** 12 occurrences across 8 files (2026-09-04 scan, scan weight 36):
+  descending through two nested `Finset.sum` binders to reach the summand.
+  A related pattern first commutes the outer binders and then descends.
+- **Seen:** 12 occurrences across 7 files (2026-09-03 scan, scan weight 36):
   `TNLean/MPS/MPU/ReflectedTransferKernel.lean:91`,
   `TNLean/MPS/MPU/DoubleLayerContraction.lean:181`,
   `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:567,728`,
@@ -2045,13 +2045,27 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/MPS/MPDO/VerticalCF.lean:298`,
   `TNLean/MPS/MPDO/ReflectedMarkedChain.lean:144,183`,
   `TNLean/MPS/MPDO/TwoSitePrefixReflectedMarkedChain.lean:72,145`.
-  The `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _` shape
-  (8 occurrences across 6+ files) is the same pattern with a commuted outer
-  binder and folds into this entry.
+  The related `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _`
+  shape occurs 8 times across 7 files:
+  `TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean:90`,
+  `TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean:240`,
+  `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:620,672`,
+  `TNLean/MPS/MPDO/InvariantProjection.lean:122`,
+  `TNLean/MPS/MPDO/LemmaC5CaseI.lean:194`,
+  `TNLean/MPS/ParentHamiltonian/MixedGram.lean:97`, and
+  `TNLean/MPS/Periodic/Applications.lean:173`.
+  It first commutes the outer binders and then descends through one of them;
+  `Finset.sum_comm` already owns the permutation step.
 - **Abstraction (proposed):** a two-binder congruence lemma, roughly
-  `Finset.sum_congr₂ : (∀ i ∈ s, ∀ j ∈ t, f i j = g i j) → ∑ i ∈ s, ∑ j ∈ t, f i j = ∑ i ∈ s, ∑ j ∈ t, g i j`,
-  stated once in the algebra layer. A lemma is the weakest sufficient
-  mechanism here; no macro or elaborator is warranted.
+  ```lean
+  Finset.sum_congr₂ :
+    (∀ i ∈ s, ∀ j ∈ t, f i j = g i j) →
+      ∑ i ∈ s, ∑ j ∈ t, f i j = ∑ i ∈ s, ∑ j ∈ t, g i j
+  ```
+  stated once in the algebra layer. This lemma applies directly to all 12
+  primary occurrences and to the descent after any separate binder
+  permutation. A lemma is the weakest sufficient mechanism here; no macro or
+  elaborator is warranted.
 - **Note:** one call site (`ReflectedTransferKernel.lean:91`) is inside the
   #7658 deletion set, so re-count before promoting.
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2028,6 +2028,33 @@ spectral split → block extraction → MPV calculation → strict bounds
   cover (membership in red/blue/crossing regions) stated once in the
   RegionBlock development.
 
+### nested finite-sum congruence under two binders — candidate
+- **Pattern:**
+  ```
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  ```
+  descending through two nested `Finset.sum` binders to reach the summand,
+  together with its `rw [Finset.sum_comm]`-prefixed variant.
+- **Seen:** 12 occurrences across 8 files (2026-09-04 scan, scan weight 36):
+  `TNLean/MPS/MPU/ReflectedTransferKernel.lean:91`,
+  `TNLean/MPS/MPU/DoubleLayerContraction.lean:181`,
+  `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:567,728`,
+  `TNLean/MPS/MPDO/CPSVBlockingChannelCounterexample.lean:380,475,490`,
+  `TNLean/MPS/MPDO/VerticalCF.lean:298`,
+  `TNLean/MPS/MPDO/ReflectedMarkedChain.lean:144,183`,
+  `TNLean/MPS/MPDO/TwoSitePrefixReflectedMarkedChain.lean:72,145`.
+  The `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _` shape
+  (8 occurrences across 6+ files) is the same pattern with a commuted outer
+  binder and folds into this entry.
+- **Abstraction (proposed):** a two-binder congruence lemma, roughly
+  `Finset.sum_congr₂ : (∀ i ∈ s, ∀ j ∈ t, f i j = g i j) → ∑ i ∈ s, ∑ j ∈ t, f i j = ∑ i ∈ s, ∑ j ∈ t, g i j`,
+  stated once in the algebra layer. A lemma is the weakest sufficient
+  mechanism here; no macro or elaborator is warranted.
+- **Note:** one call site (`ReflectedTransferKernel.lean:91`) is inside the
+  #7658 deletion set, so re-count before promoting.
+
 ### spectral_double_sum_continuity — candidate
 - **Pattern:**
   ```

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2070,9 +2070,11 @@ spectral split → block extraction → MPV calculation → strict bounds
   stated once in the algebra layer. The dependent form applies to all 12
   literal primary occurrences, including the two dependent fusion-multiplicity
   sums in `CompleteZipperFusionPentagon.lean`, and to their alpha-renamed
-  counterparts. It also handles the descent after any separate binder
-  permutation. A lemma is the weakest sufficient mechanism here; no macro or
-  elaborator is warranted.
+  counterparts. The commutation-first bucket is recorded only as a related
+  shape: this lemma applies there only when two congruence descents follow the
+  permutation. `Finset.sum_comm` and `Finset.sum_congr` already cover the
+  one-descent cases. A lemma is the weakest sufficient mechanism for the
+  two-descent pattern; no macro or elaborator is warranted.
 - **Note:** among the 12 literal primary sites,
   `ReflectedTransferKernel.lean:91` is inside the #7658 deletion set. That
   issue also removes files containing alpha-renamed sites, so re-count both

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2037,7 +2037,8 @@ spectral split → block extraction → MPV calculation → strict bounds
   ```
   descending through two nested `Finset.sum` binders to reach the summand.
   A related pattern first commutes the outer binders and then descends.
-- **Seen:** 12 occurrences across 7 files (2026-09-03 scan, scan weight 36):
+- **Seen:** the scanner's literal `i`/`_` bucket contains 12 occurrences
+  across 7 files (2026-09-03 scan, scan weight 36):
   `TNLean/MPS/MPU/ReflectedTransferKernel.lean:91`,
   `TNLean/MPS/MPU/DoubleLayerContraction.lean:181`,
   `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:567,728`,
@@ -2045,8 +2046,10 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/MPS/MPDO/VerticalCF.lean:298`,
   `TNLean/MPS/MPDO/ReflectedMarkedChain.lean:144,183`,
   `TNLean/MPS/MPDO/TwoSitePrefixReflectedMarkedChain.lean:72,145`.
-  The related `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _`
-  shape occurs 8 times across 7 files:
+  Alpha-normalizing the binder and membership-hypothesis names gives 77
+  occurrences across 44 files. The related scanner bucket
+  `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _` contains 8
+  occurrences across 7 files:
   `TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean:90`,
   `TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean:240`,
   `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:620,672`,
@@ -2054,20 +2057,26 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/MPS/MPDO/LemmaC5CaseI.lean:194`,
   `TNLean/MPS/ParentHamiltonian/MixedGram.lean:97`, and
   `TNLean/MPS/Periodic/Applications.lean:173`.
-  It first commutes the outer binders and then descends through one of them;
+  Alpha-normalizing this shape gives 58 occurrences across 33 files. It first
+  commutes the outer binders and then descends through one of them;
   `Finset.sum_comm` already owns the permutation step.
-- **Abstraction (proposed):** a two-binder congruence lemma, roughly
+- **Abstraction (proposed):** a two-binder congruence lemma supporting a
+  dependent inner binder, roughly
   ```lean
   Finset.sum_congr₂ :
-    (∀ i ∈ s, ∀ j ∈ t, f i j = g i j) →
-      ∑ i ∈ s, ∑ j ∈ t, f i j = ∑ i ∈ s, ∑ j ∈ t, g i j
+    (∀ i ∈ s, ∀ j ∈ t i, f i j = g i j) →
+      ∑ i ∈ s, ∑ j ∈ t i, f i j = ∑ i ∈ s, ∑ j ∈ t i, g i j
   ```
-  stated once in the algebra layer. This lemma applies directly to all 12
-  primary occurrences and to the descent after any separate binder
+  stated once in the algebra layer. The dependent form applies to all 12
+  literal primary occurrences, including the two dependent fusion-multiplicity
+  sums in `CompleteZipperFusionPentagon.lean`, and to their alpha-renamed
+  counterparts. It also handles the descent after any separate binder
   permutation. A lemma is the weakest sufficient mechanism here; no macro or
   elaborator is warranted.
-- **Note:** one call site (`ReflectedTransferKernel.lean:91`) is inside the
-  #7658 deletion set, so re-count before promoting.
+- **Note:** among the 12 literal primary sites,
+  `ReflectedTransferKernel.lean:91` is inside the #7658 deletion set. That
+  issue also removes files containing alpha-renamed sites, so re-count both
+  totals before promoting.
 
 ### spectral_double_sum_continuity — candidate
 - **Pattern:**

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2034,11 +2034,12 @@ spectral split → block extraction → MPV calculation → strict bounds
   apply Finset.sum_congr rfl
   intro i _
   apply Finset.sum_congr rfl
+  intro j _
   ```
   descending through two nested `Finset.sum` binders to reach the summand.
   A related pattern first commutes the outer binders and then descends.
-- **Seen:** the scanner's literal `i`/`_` bucket contains 12 occurrences
-  across 7 files (2026-09-03 scan, scan weight 36):
+- **Seen:** the scanner's literal three-line `i`/`_` prefix contains 12
+  occurrences across 7 files (2026-09-03 scan, scan weight 36):
   `TNLean/MPS/MPU/ReflectedTransferKernel.lean:91`,
   `TNLean/MPS/MPU/DoubleLayerContraction.lean:181`,
   `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean:567,728`,
@@ -2046,8 +2047,11 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/MPS/MPDO/VerticalCF.lean:298`,
   `TNLean/MPS/MPDO/ReflectedMarkedChain.lean:144,183`,
   `TNLean/MPS/MPDO/TwoSitePrefixReflectedMarkedChain.lean:72,145`.
-  Alpha-normalizing the binder and membership-hypothesis names gives 77
-  occurrences across 44 files. The related scanner bucket
+  Each site continues with the inner-binder introduction shown above, although
+  its binder name varies. The fully literal `i`/`j` four-line block occurs 8
+  times across 6 files (scan weight 32). Alpha-normalizing both binder and
+  membership-hypothesis names gives 77 occurrences across 44 files. The
+  related scanner bucket
   `rw [Finset.sum_comm]; apply Finset.sum_congr rfl; intro j _` contains 8
   occurrences across 7 files:
   `TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean:90`,


### PR DESCRIPTION
## Summary

`python3 scripts/tactic_pattern_scan.py` on `main` reports, as its top hit by weight (36), the descent

```
apply Finset.sum_congr rfl
intro i _
apply Finset.sum_congr rfl
```

in a literal bucket of **12 occurrences across 7 files**, with no covering entry in `docs/tactic_patterns.md`. That is over the rule-of-three promotion threshold and was going unrecorded.

The nearby "nested finite-sum binder permutation" entry does not cover it: that pattern *permutes* binders via `Fintype.sum_equiv`, whereas this one *descends through* them. Alpha-normalizing binder and membership-hypothesis names expands this to 77 occurrences across 44 files. The related literal `rw [Finset.sum_comm]`-prefixed bucket has 8 occurrences across 7 files, or 58 across 33 files after alpha-normalization. It commutes the outer binders before descending through one of them, so `Finset.sum_comm` already owns the permutation step.

This PR **records only**, per CLAUDE.md's tactic self-improvement loop: recording a candidate is cheap and needs no design decision, and belongs in the pass that notices the repetition. The proposed abstraction, a two-binder `Finset.sum_congr₂` congruence lemma with a dependent family of inner finsets, is the weakest mechanism that removes the primary duplication, so no macro or elaborator is warranted. A standalone dependent prototype and its use on nested dependent `Fintype` sums elaborate cleanly.

One caveat is recorded in the entry: `ReflectedTransferKernel.lean:91` is inside the #7658 deletion set, so the count must be re-derived before promotion.

## Verification

Documentation only; no Lean sources touched. The scan output is identical on the exact PR base and head. The ledger now records every primary and related location explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca

