### PR TITLE
doc(Blueprint): address CZX post-merge review

### DIFF
--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -3717,12 +3717,8 @@ by the displayed matrices.
     fails at some $(j,k,\gamma_0)$, the two paths from $(x,\gamma_0)$ to
     $(x,\gamma_0+e_j+e_k)$ give
     \begin{align}
-        v_{(x,\gamma_0+e_j+e_k)}
-         & =\varphi_j(x,\gamma_0)\varphi_k(x,\gamma_0+e_j)
-        v_{(x,\gamma_0)},                                  \\
-        v_{(x,\gamma_0+e_j+e_k)}
-         & =\varphi_k(x,\gamma_0)\varphi_j(x,\gamma_0+e_k)
-        v_{(x,\gamma_0)}.
+        v_{(x,\gamma_0+e_j+e_k)} & =\varphi_j(x,\gamma_0)\varphi_k(x,\gamma_0+e_j)\,v_{(x,\gamma_0)}, \\
+        v_{(x,\gamma_0+e_j+e_k)} & =\varphi_k(x,\gamma_0)\varphi_j(x,\gamma_0+e_k)\,v_{(x,\gamma_0)}.
     \end{align}
     The two phase products differ, so $v_{(x,\gamma_0)}=0$ and again $v$
     vanishes on the fiber.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -3714,10 +3714,18 @@ by the displayed matrices.
     Theorem~\ref{thm:mpug_hypercube_potential} make it vanish on the whole
     fiber. On a fiber with trivial holonomy, $v$ therefore vanishes as soon
     as $v_{(x,0)}=0$. On a fiber where (\ref{eq:mpug_trivial_holonomy})
-    fails at some $(j,k,\gamma_0)$, transporting $v_{(x,\gamma_0)}$ along the
-    two paths to $(x,\gamma_0+e_j+e_k)$ gives two different phases times
-    $v_{(x,\gamma_0)}$, so $v_{(x,\gamma_0)}=0$ and again $v$ vanishes on the
-    fiber.
+    fails at some $(j,k,\gamma_0)$, the two paths from $(x,\gamma_0)$ to
+    $(x,\gamma_0+e_j+e_k)$ give
+    \begin{align}
+        v_{(x,\gamma_0+e_j+e_k)}
+         & =\varphi_j(x,\gamma_0)\varphi_k(x,\gamma_0+e_j)
+        v_{(x,\gamma_0)},                                  \\
+        v_{(x,\gamma_0+e_j+e_k)}
+         & =\varphi_k(x,\gamma_0)\varphi_j(x,\gamma_0+e_k)
+        v_{(x,\gamma_0)}.
+    \end{align}
+    The two phase products differ, so $v_{(x,\gamma_0)}=0$ and again $v$
+    vanishes on the fiber.
 
     $E$ is surjective. Given $w\in\C^{X_0}$, take on each fiber with trivial
     holonomy the potential $\Phi_x$ of
@@ -3802,6 +3810,10 @@ by the displayed matrices.
         MPOTensor.CZX.tildeLambda,
         MPOTensor.CZX.siteBits,
         MPOTensor.CZX.localBits,
+        MPOTensor.CZX.localBits_apply_zero,
+        MPOTensor.CZX.localBits_apply_one,
+        MPOTensor.CZX.localBits_apply_two,
+        MPOTensor.CZX.localBits_apply_three,
         MPOTensor.CZX.matterMatrix,
         MPOTensor.CZX.gen,
         MPOTensor.CZX.circuitTuple,


### PR DESCRIPTION
### Motivation

Two Blueprint-only review findings arrived after #7654 merged. This follow-up records the missing monomial transport formulas and completes the `localBits` accessor coverage.

### Description

- display the two path-transport equations used in the monomial fixed-space injectivity argument
- attach `localBits_apply_zero`, `localBits_apply_one`, `localBits_apply_two`, and `localBits_apply_three` to the parent CZX circuit-tuple entry

Only `blueprint/src/chapter/ch29_mpu_gauging.tex` changes.

Follow-up to #7654. Addresses `discussion_r3929219901` and `discussion_r3929220797` from review execution `774aaaaa3134`.

### Testing

- `scripts/latexindent -w -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch29_mpu_gauging.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch29_mpu_gauging.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `texra-blueprint bbl`
- double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with the pinned tenkz package on `TEXINPUTS`
