### PR TITLE
doc(MPS/MPU): reclassify the diagonal source-u restriction as a scope restriction

### DIFF
--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -34,7 +34,7 @@ closure.  Documented in
 `docs/paper-gaps/mpu_canonical_form_full_support.tex` and
 `docs/paper-gaps/mpu_source_cut_orientation.tex`.  Elimination: replace the
 explicit fixed-pair hypotheses by the bundled canonical-form-II convention
-described in the first note.
+described in the orientation note.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, `uu`, and
 `uUnitary`, and Lemma `lemuisometry` (lines 269--280 and 487--557).

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -18,17 +18,25 @@ Figure `II_uUnitary.png`.  The network is then closed against a fixed pair
 the \(K\)-site interior.  The normalized input tail gives \(u^\dagger u=\Id\)
 and \(d^2\le r\ell\).
 
-**Local fix (source-weight orientation):** column stacking makes the Gram
-closure insert \(|\rho^{\mathsf T})(\Phi|\), while the source fixes \(\rho\) in
-diagonal canonical-form-II coordinates, where \(\rho^{\mathsf T}=\rho\).
-The closing theorems keep `SourceFactors U ρ` and expose this convention as
-`ρ.IsDiag`, using only `ρ.IsSymm` for the algebraic trace closure.  Documented
-in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
-
-**Scope restriction (supplied stabilized fixed pair):** the isometry and rank
-theorems below assume \(E^K=|\rho)(\Phi|\) explicitly.  CPSV17 Lemma
-`lemuisometry` uses the preceding canonical-form-II convention instead.
-Documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+**Scope restriction (source canonical-form-II fixed pair):** the closing
+theorems below are proved on the source's own canonical-form-II data rather
+than for an arbitrary positive definite weight.  They assume the stabilized
+fixed pair \(E^K=|\rho)(\Phi|\) explicitly, whereas CPSV17 Lemma
+`lemuisometry` inherits it from the preceding canonical-form-II convention,
+and they assume that \(\rho\) is diagonal with positive weights, which is how
+the source fixes it in `Papers/1703.09188/paper_v2.tex` at lines 269--280 and
+line 495.  Diagonality is load-bearing rather than cosmetic: column stacking
+makes the Gram closure insert \(|\rho^{\mathsf T})(\Phi|\) while stabilization
+supplies \(|\rho)(\Phi|\), and the two agree exactly when
+\(\rho^{\mathsf T}=\rho\).  The closing theorems therefore keep
+`SourceFactors U ρ` built from the printed weight, expose the convention as
+`ρ.IsDiag`, and use only `ρ.IsSymm` for the algebraic trace closure.
+Documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex` and
+`docs/paper-gaps/mpu_source_cut_orientation.tex`.  Elimination: prove the
+source-\(u\) closure for a Hermitian positive definite, not necessarily
+symmetric, \(\rho\) by a same-gate retained-network argument bridging the
+\(|\rho)\) and \(|\rho^{\mathsf T})\) insertions; the tracker is named in the
+elimination plan of `docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, `uu`, and
 `uUnitary`, and Lemma `lemuisometry` (lines 269--280 and 487--557).

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -18,25 +18,23 @@ Figure `II_uUnitary.png`.  The network is then closed against a fixed pair
 the \(K\)-site interior.  The normalized input tail gives \(u^\dagger u=\Id\)
 and \(d^2\le r\ell\).
 
-**Scope restriction (source canonical-form-II fixed pair):** the closing
-theorems below are proved on the source's own canonical-form-II data rather
-than for an arbitrary positive definite weight.  They assume the stabilized
-fixed pair \(E^K=|\rho)(\Phi|\) explicitly, whereas CPSV17 Lemma
-`lemuisometry` inherits it from the preceding canonical-form-II convention,
-and they assume that \(\rho\) is diagonal with positive weights, which is how
-the source fixes it in `Papers/1703.09188/paper_v2.tex` at lines 269--280 and
-line 495.  Diagonality is load-bearing rather than cosmetic: column stacking
-makes the Gram closure insert \(|\rho^{\mathsf T})(\Phi|\) while stabilization
-supplies \(|\rho)(\Phi|\), and the two agree exactly when
-\(\rho^{\mathsf T}=\rho\).  The closing theorems therefore keep
-`SourceFactors U ρ` built from the printed weight, expose the convention as
-`ρ.IsDiag`, and use only `ρ.IsSymm` for the algebraic trace closure.
-Documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex` and
-`docs/paper-gaps/mpu_source_cut_orientation.tex`.  Elimination: prove the
-source-\(u\) closure for a Hermitian positive definite, not necessarily
-symmetric, \(\rho\) by a same-gate retained-network argument bridging the
-\(|\rho)\) and \(|\rho^{\mathsf T})\) insertions; the tracker is named in the
-elimination plan of `docs/paper-gaps/mpu_source_cut_orientation.tex`.
+**Scope restriction (supplied canonical-form-II fixed pair):** the closing
+theorems below assume the stabilized fixed pair \(E^K=|\rho)(\Phi|\)
+explicitly, whereas CPSV17 Lemma `lemuisometry` inherits it from the preceding
+canonical-form-II convention.  In that convention, \(\rho\) is diagonal with
+positive weights; see `Papers/1703.09188/paper_v2.tex` at lines 269--280 and
+line 495.  This diagonality is part of the source's scope, not a correction or
+an additional restriction.  It is load-bearing in the coordinate proof:
+column stacking makes the Gram closure insert
+\(|\rho^{\mathsf T})(\Phi|\), while stabilization supplies
+\(|\rho)(\Phi|\), and the two agree because \(\rho^{\mathsf T}=\rho\).  The
+closing theorems keep `SourceFactors U ρ` built from the printed weight, expose
+the convention as `ρ.IsDiag`, and use only `ρ.IsSymm` for the algebraic trace
+closure.  Documented in
+`docs/paper-gaps/mpu_canonical_form_full_support.tex` and
+`docs/paper-gaps/mpu_source_cut_orientation.tex`.  Elimination: replace the
+explicit fixed-pair hypotheses by the bundled canonical-form-II convention
+described in the first note.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, `uu`, and
 `uUnitary`, and Lemma `lemuisometry` (lines 269--280 and 487--557).

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -195,6 +195,26 @@ normalization and orientation explicitly. These conclusions assume the
 source's diagonal fixed point; they do not assert a source-$u$ theorem for
 arbitrary nonsymmetric $\rho$.
 
+\section{Elimination plan for the diagonal restriction}
+
+The transposed first cut was a local correction, and it is resolved. The
+diagonal restriction recorded in the previous section is of the other kind: the
+source-$u$ closure theorems are proved on the source's own canonical-form-II
+data, where $\rho$ is diagonal with positive weights $\rho_n>0$, rather than
+for an arbitrary positive definite $\rho$. It is therefore a scope
+restriction, and the module documentation of the complete source-$u$ network
+records it as one.
+% Source lines: paper_v2.tex 269--280 and 495.
+The wider scope restriction on the source data is
+\texttt{mpu\_canonical\_form\_full\_support.tex}.
+
+Removing the restriction requires proving the source-$u$ closure for a
+Hermitian positive definite, not necessarily symmetric, $\rho$, by a same-gate
+retained-network argument bridging the $\lvert\rho)$ and
+$\lvert\rho^{\mathsf T})$ insertions for one and the same gate. That is the
+same bridge the source-$v$ isometry needs, and it is tracked by
+\ghissue{7653}.
+
 \section{Affected claims and audit boundary}
 
 The transposed first cut affected source-factor recovery, physical adjunction,

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -195,25 +195,24 @@ normalization and orientation explicitly. These conclusions assume the
 source's diagonal fixed point; they do not assert a source-$u$ theorem for
 arbitrary nonsymmetric $\rho$.
 
-\section{Elimination plan for the diagonal restriction}
+\section{Marker boundary for the complete source-$u$ network}
 
 The transposed first cut was a local correction, and it is resolved. The
-diagonal restriction recorded in the previous section is of the other kind: the
-source-$u$ closure theorems are proved on the source's own canonical-form-II
-data, where $\rho$ is diagonal with positive weights $\rho_n>0$, rather than
-for an arbitrary positive definite $\rho$. It is therefore a scope
-restriction, and the module documentation of the complete source-$u$ network
-records it as one.
+complete source-$u$ module has a separate scope restriction: its closing
+theorems assume the stabilized fixed pair explicitly, whereas Lemma~III.7
+inherits that pair from the source's standing canonical-form-II convention.
+The source itself fixes $\rho$ to be diagonal with positive weights
+$\rho_n>0$, so diagonality is not a restriction relative to the cited lemma.
 % Source lines: paper_v2.tex 269--280 and 495.
-The wider scope restriction on the source data is
+Accordingly, the module carries one scope marker for the supplied fixed pair.
+The wider source-data restriction is recorded in
 \texttt{mpu\_canonical\_form\_full\_support.tex}.
 
-Removing the restriction requires proving the source-$u$ closure for a
-Hermitian positive definite, not necessarily symmetric, $\rho$, by a same-gate
-retained-network argument bridging the $\lvert\rho)$ and
-$\lvert\rho^{\mathsf T})$ insertions for one and the same gate. That is the
-same bridge the source-$v$ isometry needs, and it is tracked by
-\ghissue{7653}.
+Eliminating the supplied-data restriction means bundling the standing
+canonical-form-II convention and restating the MPU-level results through it,
+as tracked by \ghissue{7657} and \ghissue{7659}. Issue \ghissue{7653} instead
+asks for a nonsymmetric ambient-weight strengthening that CPSV17 does not
+claim. It is not the elimination step for the source-faithful theorem.
 
 \section{Affected claims and audit boundary}
 


### PR DESCRIPTION
## Taxonomy correction

`TNLean/MPS/MPU/SourceUCompleteNetwork.lean` carried the complete-network assumptions under two markers, including a `Local fix` marker for the weight orientation. That classification conflated two separate facts.

- The first source-cut orientation was a local correction and is already recorded as resolved in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
- CPSV17 fixes $\rho$ to be diagonal with positive coefficients in canonical form II (`Papers/1703.09188/paper_v2.tex` lines 269-280 and 495). Diagonality is therefore part of the source theorem's standing convention, not a correction and not an extra restriction relative to Lemma III.7.
- The actual scope restriction in this module is that the closing theorems assume the stabilized pair $E^K=\lvert\rho)(\Phi\rvert$ explicitly, whereas Lemma III.7 inherits it from the standing canonical-form-II convention.

The module now has one `**Scope restriction (supplied canonical-form-II fixed pair):**` marker, as required by `CLAUDE.md`'s one-marker-per-(restriction,module) rule. It explains why diagonality is load-bearing in the coordinate proof without claiming that CPSV17 proves a nonsymmetric-$\rho$ theorem.

## Paper-gap and tracker alignment

`docs/paper-gaps/mpu_source_cut_orientation.tex` now separates:

1. the resolved source-cut orientation correction;
2. the open supplied-fixed-pair interface restriction; and
3. the nonsymmetric ambient-weight strengthening in #7653, which #7653 itself identifies as outside the CPSV17 claim and which is not the elimination step for the source-faithful theorem.

The source-faithful elimination plan is to bundle the standing canonical-form-II convention (#7657) and migrate the MPU-level statements through it (#7659). The wider source-data restriction remains documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.

Chapter 28 already distinguishes the unrestricted source node from the checked supplied diagonal-fixed-pair specialization. This PR does not change Chapter 28, and its current post-#7664 status is preserved by rebasing onto current base `be80834b3`.

## Validation

- `scripts/lake_build_locked.sh TNLean.MPS.MPU.SourceUCompleteNetwork`
- `python3 scripts/test_lean_file_policies.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `--ci`: 7846/7846
- `lake exe checkdecls blueprint/lean_decls`
- `texra-blueprint paper-gaps check`: 122 referenced slugs resolve
- forbidden-token scan on both changed files
- `git diff --check origin/main...HEAD`

Documentation only: no Lean statement, proof, computed value, or blueprint node changes.


