### PR TITLE
feat(parent-hamiltonian): prove threshold Nachtergaele C1-C3 estimate

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/MovingWindowCount.lean
@@ -144,4 +144,56 @@ theorem movingWindow_sum_range_le (a : ℕ → ℝ) (l N : ℕ) (ha : ∀ m, 0 �
           Finset.sum_le_sum_of_subset_of_nonneg hg_sub fun m _ _ ↦ ha m
     _ = (l + 1) * ∑ m ∈ Finset.range N, a m := by simp
 
+/-- Moving-window count above a lower threshold. For nonnegative coefficients,
+summing the windows \([n-l,n]\) over \(n\in[n_0,N)\) counts each coefficient at
+most \(l+1\) times, and only the coefficients indexed by \(m\ge n_0-l\) occur.
+
+The source's conditions C2 and C3 in Nachtergaele, arXiv:cond-mat/9410110,
+lines 1043--1094, hold only above a threshold, so the summation after
+equation \(\mathrm{Enpsi2}\), lines 1220--1255, runs over
+\(n\in[n_0,N)\). This estimate is the corresponding double count. -/
+theorem movingWindow_sum_Ico_le (a : ℕ → ℝ) (l n₀ N : ℕ) (ha : ∀ m, 0 ≤ a m) :
+    ∑ n ∈ Finset.Ico n₀ N, ∑ m ∈ Finset.Icc (n - l) n, a m ≤
+      (l + 1) * ∑ m ∈ Finset.Ico (n₀ - l) N, a m := by
+  classical
+  obtain ⟨b, hb⟩ : ∃ b : ℕ → ℝ, ∀ m, b m = if n₀ - l ≤ m then a m else 0 :=
+    ⟨_, fun _ ↦ rfl⟩
+  have hb_nonneg : ∀ m, 0 ≤ b m := by
+    intro m
+    rw [hb]
+    split_ifs with hm
+    · exact ha m
+    · exact le_rfl
+  have hb_eq : ∀ m, n₀ - l ≤ m → b m = a m := by
+    intro m hm
+    rw [hb]
+    split_ifs
+    rfl
+  have hfilter :
+      Finset.Ico (n₀ - l) N =
+        (Finset.range N).filter (fun m ↦ n₀ - l ≤ m) := by
+    ext m
+    simp only [Finset.mem_Ico, Finset.mem_filter, Finset.mem_range]
+    omega
+  have hb_sum :
+      ∑ m ∈ Finset.range N, b m = ∑ m ∈ Finset.Ico (n₀ - l) N, a m := by
+    rw [hfilter, Finset.sum_filter]
+    exact Finset.sum_congr rfl fun m _ ↦ hb m
+  calc
+    ∑ n ∈ Finset.Ico n₀ N, ∑ m ∈ Finset.Icc (n - l) n, a m =
+        ∑ n ∈ Finset.Ico n₀ N, ∑ m ∈ Finset.Icc (n - l) n, b m := by
+          refine Finset.sum_congr rfl fun n hn ↦
+            Finset.sum_congr rfl fun m hm ↦ ?_
+          have hn' := Finset.mem_Ico.mp hn
+          have hm' := Finset.mem_Icc.mp hm
+          exact (hb_eq m (by omega)).symm
+    _ ≤ ∑ n ∈ Finset.range N, ∑ m ∈ Finset.Icc (n - l) n, b m := by
+          refine Finset.sum_le_sum_of_subset_of_nonneg ?_ ?_
+          · rw [Finset.range_eq_Ico]
+            exact Finset.Ico_subset_Ico (Nat.zero_le _) le_rfl
+          · exact fun n _ _ ↦ Finset.sum_nonneg fun m _ ↦ hb_nonneg m
+    _ ≤ (l + 1) * ∑ m ∈ Finset.range N, b m :=
+          movingWindow_sum_range_le b l N hb_nonneg
+    _ = (l + 1) * ∑ m ∈ Finset.Ico (n₀ - l) N, a m := by rw [hb_sum]
+
 end FrustrationFree

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
@@ -21,10 +21,12 @@ assumed only beyond their lower threshold \(n_l\), while C1, at lines
 nevertheless estimates every martingale difference \(E_0,\ldots,E_{N-1}\).
 
 `energy_lower_bound_of_nachtergaele_c1_c3_threshold` assumes the three
-estimates only on the index range \(n_0\leq n<N\) above the source's own
-threshold. It obtains the printed coefficient on the martingale mass above the
-threshold, together with the exact moving-window correction carried by the
-\(l\) differences immediately below it.
+estimates only on an index range \(n_0\leq n<N\). To obtain its C1 hypothesis
+from the source, one chooses \(n_0\geq l\), as well as above the C2--C3
+threshold; for smaller \(n_0\), its displayed C1 bound is an independent
+stronger assumption. The theorem obtains the printed coefficient on the
+martingale mass above the threshold, together with an explicit upper-bound
+correction carried by the \(l\) differences immediately below it.
 
 **Scope restriction (full finite range):**
 `energy_lower_bound_of_nachtergaele_c1_c3_full_range` and
@@ -306,25 +308,26 @@ private theorem enpsi_of_c2_c3_zero
   linarith
 
 /-- Threshold form of the summation in the proof of Nachtergaele's Theorem
-2.1(i) (arXiv:cond-mat/9410110, lines 1195--1259), stated on the index range
-that the source's own conditions cover.
+2.1(i) (arXiv:cond-mat/9410110, lines 1195--1259).
 
 Condition C2 at lines 1043--1058 and condition C3 at lines 1083--1094 hold
-only from a threshold onwards, and condition C1 at lines 1030--1041 begins at
-the window length. Here that threshold is \(n_0\): C2 and C3 appear exactly
-as the source states them, with C3 in its literal operator-norm form
-\(\lVert Q_nE_n\rVert\leq\epsilon_l\), and C1 appears as the source's
-condition at window length \(l+1\) restricted to the same range, which
-follows from it whenever the omitted local terms are nonnegative.
+only from a threshold onwards, while condition C1 at lines 1030--1041 begins
+at the window length. This theorem assumes all three estimates directly on
+\(n_0\leq n<N\). Its C2 and C3 hypotheses have the source forms, with C3 in
+its literal operator-norm form \(\lVert Q_nE_n\rVert\leq\epsilon_l\). To
+derive its C1 hypothesis from the source, choose \(n_0\geq l\), in addition
+to choosing it above the C2--C3 onset; if \(n_0<l\), the stated C1 bound is an
+independent stronger assumption.
 
 Summing the per-index estimate over \(n_0\leq n<N\) gives the printed
 coefficient
 \(\frac{\gamma_{l+1}}{d_{l+1}}(1-\epsilon_l\sqrt{l+1})^2\)
 on the martingale mass \(\sum_{n=n_0}^{N-1}\lVert E_n\psi\rVert^2\) above the
-threshold, corrected by the moving-window contribution of the \(l\)
-differences immediately below it. Both the coefficient and the correction are
-exact: the correction vanishes when \(n_0=0\), and then the conclusion is the
-printed estimate on \(\lVert\psi\rVert^2\).
+threshold, corrected by an upper bound for the moving-window contribution of
+the \(l\) differences immediately below it. The coefficient is exact, while
+the correction uses the uniform multiplicity bound \(l+1\). The correction
+vanishes when \(n_0=0\), and then the conclusion is the printed estimate on
+\(\lVert\psi\rVert^2\).
 
 The case \(\epsilon_l=0\) is treated separately, since the printed choice
 \(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive; C3 gives \(Q_nE_n=0\)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
@@ -454,7 +454,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3_threshold
           norm_num
     · have hc₂ : (0 : ℝ) < ε / s := div_pos hεpos hs
       have hεc₂ : ε ^ 2 / (2 * (ε / s)) = ε * s / 2 := by
-        field_simp
+        field_simp [hεpos.ne', hs.ne']
       have hpoint : ∀ n ∈ Finset.Ico n₀ N,
           ‖G.martingaleDifference n v‖ ^ 2 ≤
             (1 / (2 * (1 - ε * s) * γ)) *
@@ -479,7 +479,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3_threshold
         mul_le_mul_of_nonneg_left hC1' hinv
       have hcoef : ((ε / s) / 2) * ((l : ℝ) + 1) = ε * s / 2 := by
         rw [show ((l : ℝ) + 1) = s ^ 2 by rw [hsquare]; push_cast; ring]
-        field_simp
+        field_simp [hs.ne']
       have hwin :
           ((ε / s) / 2) *
               (∑ n ∈ Finset.Ico n₀ N,
@@ -500,7 +500,7 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3_threshold
           ((1 / (2 * (1 - ε * s) * γ)) * (d * A) + (ε * s / 2) * S) :=
       mul_le_mul_of_nonneg_left key hmulpos.le
     _ = A + (γ / d) * ((1 - ε * s) * (ε * s)) * S := by
-      field_simp
+      field_simp [hδ.ne', hγ.ne', hd.ne']
 
 /-- Full-range form of the summation in Nachtergaele's Theorem 2.1(i), in the
 finite-filtration notation of its proof (arXiv:cond-mat/9410110, lines

--- a/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/NachtergaeleFullRangeEstimate.lean
@@ -10,20 +10,31 @@ import TNLean.MPS.ParentHamiltonian.Martingale.MovingWindowCount
 import TNLean.MPS.ParentHamiltonian.Martingale.ProjectionCancellation
 
 /-!
-# Full-range form of Nachtergaele's C1--C3 energy estimate
+# Nachtergaele's C1--C3 energy estimate
 
 This file follows the summation in the proof of Theorem 2.1(i) in Nachtergaele,
 arXiv:cond-mat/9410110, lines 1195--1259.
 
-**Scope restriction (full finite range):** Conditions C2 and C3 in the source
-are assumed only beyond their lower threshold \(n_l\), while C1 starts at the
-corresponding window length; the printed proof nevertheless estimates every
-martingale difference \(E_0,\ldots,E_{N-1}\). The theorem below instead assumes
-the three estimates on the entire finite range. This extra hypothesis and the
-required lower-endpoint repair are recorded in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. Thus the result is a
-full-range version with the source coefficient, not a formalization of the
-unrestricted source theorem.
+Conditions C2 and C3 in the source, at lines 1043--1058 and 1083--1094, are
+assumed only beyond their lower threshold \(n_l\), while C1, at lines
+1030--1041, starts at the corresponding window length; the printed proof
+nevertheless estimates every martingale difference \(E_0,\ldots,E_{N-1}\).
+
+`energy_lower_bound_of_nachtergaele_c1_c3_threshold` assumes the three
+estimates only on the index range \(n_0\leq n<N\) above the source's own
+threshold. It obtains the printed coefficient on the martingale mass above the
+threshold, together with the exact moving-window correction carried by the
+\(l\) differences immediately below it.
+
+**Scope restriction (full finite range):**
+`energy_lower_bound_of_nachtergaele_c1_c3_full_range` and
+`norm_lower_bound_of_nachtergaele_c1_c3_full_range` are the case \(n_0=0\),
+where that correction is empty. They assume the three estimates on the entire
+finite range, which is stronger than the source's lower-threshold hypotheses.
+This extra hypothesis and the required lower-endpoint repair are recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. Thus they are a full-range
+version with the source coefficient, not a formalization of the unrestricted
+source theorem.
 
 **Local fix (zero C3 constant):** The source chooses
 \(c_2=\epsilon_l/\sqrt{l+1}\) after requiring \(c_2>0\). When
@@ -294,6 +305,200 @@ private theorem enpsi_of_c2_c3_zero
         mul_le_mul_of_nonneg_left hC2 (by positivity)
   linarith
 
+/-- Threshold form of the summation in the proof of Nachtergaele's Theorem
+2.1(i) (arXiv:cond-mat/9410110, lines 1195--1259), stated on the index range
+that the source's own conditions cover.
+
+Condition C2 at lines 1043--1058 and condition C3 at lines 1083--1094 hold
+only from a threshold onwards, and condition C1 at lines 1030--1041 begins at
+the window length. Here that threshold is \(n_0\): C2 and C3 appear exactly
+as the source states them, with C3 in its literal operator-norm form
+\(\lVert Q_nE_n\rVert\leq\epsilon_l\), and C1 appears as the source's
+condition at window length \(l+1\) restricted to the same range, which
+follows from it whenever the omitted local terms are nonnegative.
+
+Summing the per-index estimate over \(n_0\leq n<N\) gives the printed
+coefficient
+\(\frac{\gamma_{l+1}}{d_{l+1}}(1-\epsilon_l\sqrt{l+1})^2\)
+on the martingale mass \(\sum_{n=n_0}^{N-1}\lVert E_n\psi\rVert^2\) above the
+threshold, corrected by the moving-window contribution of the \(l\)
+differences immediately below it. Both the coefficient and the correction are
+exact: the correction vanishes when \(n_0=0\), and then the conclusion is the
+printed estimate on \(\lVert\psi\rVert^2\).
+
+The case \(\epsilon_l=0\) is treated separately, since the printed choice
+\(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive; C3 gives \(Q_nE_n=0\)
+instead.
+
+**Scope restriction (martingale mass above the threshold):** The source
+concludes the same coefficient on \(\lVert\psi\rVert^2\). The two conclusions
+agree exactly when the martingale differences below the threshold vanish, and
+the printed proof supplies no argument for the omitted indices. The
+discrepancy is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem energy_lower_bound_of_nachtergaele_c1_c3_threshold
+    [FiniteDimensional ℂ E]
+    (G : NestedGroundProjections (E := E)) (Q : ℕ → E →ₗ[ℂ] E)
+    (localHamiltonian : ℕ → E →ₗ[ℂ] E) (H : E →ₗ[ℂ] E)
+    (N n₀ l : ℕ) (v : E) (hn₀ : n₀ ≤ N)
+    (hzero : G.projection 0 = LinearMap.id)
+    (hv : v ∈ (LinearMap.range (G.projection N))ᗮ)
+    {γ d ε : ℝ} (hγ : 0 < γ) (hd : 0 < d) (hε : 0 ≤ ε)
+    (hεlt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ))
+    (hQ : ∀ n ∈ Finset.Ico n₀ N, (Q n).IsSymmetricProjection)
+    (hcomm : ∀ n ∈ Finset.Ico n₀ N, ∀ m,
+      m < n - l ∨ n < m →
+        (G.martingaleDifference m).comp (Q n) =
+          (Q n).comp (G.martingaleDifference m))
+    (hC1 : ∀ x,
+      0 ≤ ∑ n ∈ Finset.Ico n₀ N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re ∧
+      (∑ n ∈ Finset.Ico n₀ N,
+          (⟪localHamiltonian n x, x⟫_ℂ).re) ≤
+        d * (⟪H x, x⟫_ℂ).re)
+    (hC2 : ∀ n ∈ Finset.Ico n₀ N, ∀ x,
+      γ * ‖((LinearMap.id : E →ₗ[ℂ] E) - Q n) x‖ ^ 2 ≤
+        (⟪localHamiltonian n x, x⟫_ℂ).re)
+    (hC3 : ∀ n ∈ Finset.Ico n₀ N,
+      ‖(Q n).toContinuousLinearMap.comp
+          (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε) :
+    (γ / d) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 *
+        ∑ n ∈ Finset.Ico n₀ N, ‖G.martingaleDifference n v‖ ^ 2 ≤
+      (⟪H v, v⟫_ℂ).re +
+        (γ / d) *
+            ((1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) *
+              (ε * Real.sqrt ((l + 1 : ℕ) : ℝ))) *
+          ∑ m ∈ Finset.Ico (n₀ - l) n₀, ‖G.martingaleDifference m v‖ ^ 2 := by
+  classical
+  set s := Real.sqrt ((l + 1 : ℕ) : ℝ)
+  have hs : 0 < s := Real.sqrt_pos.2 (by positivity)
+  have hsquare : s ^ 2 = ((l + 1 : ℕ) : ℝ) := Real.sq_sqrt (by positivity)
+  have hεs : ε * s < 1 := (lt_div_iff₀ hs).mp hεlt
+  have hδ : 0 < 1 - ε * s := sub_pos.mpr hεs
+  have hc₁γ : 0 < 2 * (1 - ε * s) * γ :=
+    mul_pos (mul_pos (by norm_num) hδ) hγ
+  have hinv : 0 ≤ 1 / (2 * (1 - ε * s) * γ) := one_div_nonneg.mpr hc₁γ.le
+  have hC1' :
+      (∑ n ∈ Finset.Ico n₀ N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+        d * (⟪H v, v⟫_ℂ).re := (hC1 v).2
+  have hC3point : ∀ n ∈ Finset.Ico n₀ N, ∀ x,
+      ‖Q n (G.martingaleDifference n x)‖ ^ 2 ≤
+        ε ^ 2 * ‖G.martingaleDifference n x‖ ^ 2 := by
+    intro n hn x
+    simpa using norm_sq_apply_projection_le_of_norm_comp_le
+      (Q n).toContinuousLinearMap
+      (G.martingaleDifference n).toContinuousLinearMap
+      (G.martingaleDifference_isSymmetricProjection n) (hC3 n hn) x
+  set P := ∑ n ∈ Finset.Ico n₀ N, ‖G.martingaleDifference n v‖ ^ 2 with hP
+  set S := ∑ m ∈ Finset.Ico (n₀ - l) n₀, ‖G.martingaleDifference m v‖ ^ 2
+    with hS
+  set A := (⟪H v, v⟫_ℂ).re
+  have hwindow :
+      ∑ n ∈ Finset.Ico n₀ N,
+          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 ≤
+        ((l : ℝ) + 1) * (S + P) := by
+    have hsplit :
+        (∑ m ∈ Finset.Ico (n₀ - l) n₀, ‖G.martingaleDifference m v‖ ^ 2) +
+            ∑ m ∈ Finset.Ico n₀ N, ‖G.martingaleDifference m v‖ ^ 2 =
+          ∑ m ∈ Finset.Ico (n₀ - l) N, ‖G.martingaleDifference m v‖ ^ 2 :=
+      Finset.sum_Ico_consecutive _ (Nat.sub_le n₀ l) hn₀
+    calc
+      ∑ n ∈ Finset.Ico n₀ N,
+          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 =
+          ∑ n ∈ Finset.Ico n₀ N, ∑ m ∈ Finset.Icc (n - l) n,
+            ‖G.martingaleDifference m v‖ ^ 2 :=
+        Finset.sum_congr rfl fun n _ ↦
+          G.norm_sq_sum_martingaleDifference_finset (Finset.Icc (n - l) n) v
+      _ ≤ ((l : ℝ) + 1) *
+            ∑ m ∈ Finset.Ico (n₀ - l) N,
+              ‖G.martingaleDifference m v‖ ^ 2 :=
+        movingWindow_sum_Ico_le
+          (fun m ↦ ‖G.martingaleDifference m v‖ ^ 2) l n₀ N
+          (fun m ↦ sq_nonneg _)
+      _ = ((l : ℝ) + 1) * (S + P) := by rw [hS, hP, hsplit]
+  have key : ((1 - ε * s) / 2) * P ≤
+      (1 / (2 * (1 - ε * s) * γ)) * (d * A) + (ε * s / 2) * S := by
+    rcases hε.eq_or_lt with hεzero | hεpos
+    · subst ε
+      have hpoint : ∀ n ∈ Finset.Ico n₀ N,
+          ‖G.martingaleDifference n v‖ ^ 2 ≤
+            (1 / (2 * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
+              (1 / 2) * ‖G.martingaleDifference n v‖ ^ 2 := by
+        intro n hn
+        have hnN : n < N := (Finset.mem_Ico.mp hn).2
+        have hqzero : Q n (G.martingaleDifference n v) = 0 := by
+          have hb : ‖Q n (G.martingaleDifference n v)‖ ^ 2 ≤ 0 := by
+            simpa using hC3point n hn v
+          have hnorm : ‖Q n (G.martingaleDifference n v)‖ = 0 := by
+            nlinarith [norm_nonneg (Q n (G.martingaleDifference n v))]
+          exact norm_eq_zero.mp hnorm
+        simpa using enpsi_of_c2_c3_zero G Q localHamiltonian N n l hnN v
+          hzero hv (hQ n hn) (hcomm n hn) hγ (by norm_num : (0 : ℝ) < 1)
+          (hC2 n hn v) hqzero
+      have hsum := Finset.sum_le_sum hpoint
+      rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+        ← hP] at hsum
+      have hbudget :
+          (1 / (2 * γ)) *
+              (∑ n ∈ Finset.Ico n₀ N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+            (1 / (2 * γ)) * (d * A) :=
+        mul_le_mul_of_nonneg_left hC1' (by positivity)
+      have hgoal : (1 / 2 : ℝ) * P ≤ (1 / (2 * γ)) * (d * A) := by linarith
+      calc
+        ((1 - 0 * s) / 2) * P = (1 / 2 : ℝ) * P := by ring
+        _ ≤ (1 / (2 * γ)) * (d * A) := hgoal
+        _ = (1 / (2 * (1 - 0 * s) * γ)) * (d * A) + (0 * s / 2) * S := by
+          norm_num
+    · have hc₂ : (0 : ℝ) < ε / s := div_pos hεpos hs
+      have hεc₂ : ε ^ 2 / (2 * (ε / s)) = ε * s / 2 := by
+        field_simp
+      have hpoint : ∀ n ∈ Finset.Ico n₀ N,
+          ‖G.martingaleDifference n v‖ ^ 2 ≤
+            (1 / (2 * (1 - ε * s) * γ)) *
+                (⟪localHamiltonian n v, v⟫_ℂ).re +
+              ((1 - ε * s) / 2 + ε * s / 2) *
+                ‖G.martingaleDifference n v‖ ^ 2 +
+              ((ε / s) / 2) *
+                ‖∑ m ∈ Finset.Icc (n - l) n,
+                  G.martingaleDifference m v‖ ^ 2 := by
+        intro n hn
+        have hnN : n < N := (Finset.mem_Ico.mp hn).2
+        simpa only [hεc₂] using
+          enpsi2_of_c2_c3 G Q localHamiltonian N n l hnN v hzero hv
+            (hQ n hn) (hcomm n hn) hγ hδ hc₂ (hC2 n hn v) (hC3point n hn v)
+      have hsum := Finset.sum_le_sum hpoint
+      rw [Finset.sum_add_distrib, Finset.sum_add_distrib, ← Finset.mul_sum,
+        ← Finset.mul_sum, ← Finset.mul_sum, ← hP] at hsum
+      have hbudget :
+          (1 / (2 * (1 - ε * s) * γ)) *
+              (∑ n ∈ Finset.Ico n₀ N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
+            (1 / (2 * (1 - ε * s) * γ)) * (d * A) :=
+        mul_le_mul_of_nonneg_left hC1' hinv
+      have hcoef : ((ε / s) / 2) * ((l : ℝ) + 1) = ε * s / 2 := by
+        rw [show ((l : ℝ) + 1) = s ^ 2 by rw [hsquare]; push_cast; ring]
+        field_simp
+      have hwin :
+          ((ε / s) / 2) *
+              (∑ n ∈ Finset.Ico n₀ N,
+                ‖∑ m ∈ Finset.Icc (n - l) n,
+                  G.martingaleDifference m v‖ ^ 2) ≤
+            (ε * s / 2) * (S + P) := by
+        calc
+          _ ≤ ((ε / s) / 2) * (((l : ℝ) + 1) * (S + P)) :=
+            mul_le_mul_of_nonneg_left hwindow (by positivity)
+          _ = (((ε / s) / 2) * ((l : ℝ) + 1)) * (S + P) := by ring
+          _ = (ε * s / 2) * (S + P) := by rw [hcoef]
+      linarith
+  have hmulpos : 0 < 2 * (1 - ε * s) * γ / d := div_pos hc₁γ hd
+  calc
+    (γ / d) * (1 - ε * s) ^ 2 * P =
+        (2 * (1 - ε * s) * γ / d) * (((1 - ε * s) / 2) * P) := by ring
+    _ ≤ (2 * (1 - ε * s) * γ / d) *
+          ((1 / (2 * (1 - ε * s) * γ)) * (d * A) + (ε * s / 2) * S) :=
+      mul_le_mul_of_nonneg_left key hmulpos.le
+    _ = A + (γ / d) * ((1 - ε * s) * (ε * s)) * S := by
+      field_simp
+
 /-- Full-range form of the summation in Nachtergaele's Theorem 2.1(i), in the
 finite-filtration notation of its proof (arXiv:cond-mat/9410110, lines
 1195--1259). Conditions C1 and C2 are stated as their quadratic-form
@@ -305,8 +510,10 @@ inequalities, and C3 is the source's literal operator-norm bound
 The finite sum runs over every index \(n=0,\ldots,N-1\), with only
 \(G_0=\mathbf 1\) needed for the martingale resolution. Thus C1, C2, and C3
 are assumed on that full finite range, which is stronger than the source's
-lower-threshold hypotheses. The case \(\epsilon_l=0\) is treated separately,
-since the printed choice \(c_2=\epsilon_l/\sqrt{l+1}\) is then not positive.
+lower-threshold hypotheses. This is the threshold estimate
+`energy_lower_bound_of_nachtergaele_c1_c3_threshold` at \(n_0=0\), where the
+window correction below the threshold is empty and the martingale mass above
+it is \(\lVert\psi\rVert^2\).
 The proof uses the upper inequality in C1; its nonnegativity clause is retained
 because it is part of the source's condition C1. -/
 theorem energy_lower_bound_of_nachtergaele_c1_c3_full_range
@@ -337,150 +544,20 @@ theorem energy_lower_bound_of_nachtergaele_c1_c3_full_range
           (G.martingaleDifference n).toContinuousLinearMap‖ ≤ ε) :
     (γ / d) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 * ‖v‖ ^ 2 ≤
       (⟪H v, v⟫_ℂ).re := by
-  have hactiveNorm :
-      ∑ n ∈ Finset.range N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
-    rw [← G.norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal N v hzero hv]
-  have hwindow :
-      ∑ n ∈ Finset.range N,
-          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 ≤
-        (l + 1) * ‖v‖ ^ 2 := by
-    calc
-      ∑ n ∈ Finset.range N,
-          ‖∑ m ∈ Finset.Icc (n - l) n, G.martingaleDifference m v‖ ^ 2 =
-          ∑ n ∈ Finset.range N, ∑ m ∈ Finset.Icc (n - l) n,
-            ‖G.martingaleDifference m v‖ ^ 2 := by
-              apply Finset.sum_congr rfl
-              intro n _
-              exact G.norm_sq_sum_martingaleDifference_finset
-                (Finset.Icc (n - l) n) v
-      _ ≤ (l + 1) *
-          ∑ m ∈ Finset.range N, ‖G.martingaleDifference m v‖ ^ 2 :=
-        movingWindow_sum_range_le
-          (fun m ↦ ‖G.martingaleDifference m v‖ ^ 2) l N
-          (fun m ↦ sq_nonneg ‖G.martingaleDifference m v‖)
-      _ = (l + 1) * ‖v‖ ^ 2 := by rw [hactiveNorm]
-  let s := Real.sqrt ((l + 1 : ℕ) : ℝ)
-  have hs : 0 < s := Real.sqrt_pos.2 (by positivity)
-  have hsquare : s ^ 2 = ((l + 1 : ℕ) : ℝ) := by
-    exact Real.sq_sqrt (by positivity)
-  have hεs : ε * s < 1 := by
-    rw [lt_div_iff₀ hs] at hεlt
-    exact hεlt
-  have hδ : 0 < 1 - ε * s := sub_pos.mpr hεs
-  have hC3point : ∀ n ∈ Finset.range N, ∀ x,
-      ‖Q n (G.martingaleDifference n x)‖ ^ 2 ≤
-        ε ^ 2 * ‖G.martingaleDifference n x‖ ^ 2 := by
-    intro n hn x
-    simpa using norm_sq_apply_projection_le_of_norm_comp_le
-      (Q n).toContinuousLinearMap
-      (G.martingaleDifference n).toContinuousLinearMap
-      (G.martingaleDifference_isSymmetricProjection n) (hC3 n hn) x
-  rcases hε.eq_or_lt with hεzero | hεpos
-  · subst ε
-    have hpoint : ∀ n ∈ Finset.range N,
-        ‖G.martingaleDifference n v‖ ^ 2 ≤
-          (1 / (2 * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
-            (1 / 2) * ‖G.martingaleDifference n v‖ ^ 2 := by
-      intro n hn
-      have hbound : ‖Q n (G.martingaleDifference n v)‖ ^ 2 ≤ 0 := by
-        simpa using hC3point n hn v
-      have hqnorm : ‖Q n (G.martingaleDifference n v)‖ ^ 2 = 0 :=
-        le_antisymm hbound (sq_nonneg _)
-      have hqzero : Q n (G.martingaleDifference n v) = 0 := by
-        rw [← norm_eq_zero]
-        nlinarith [sq_nonneg ‖Q n (G.martingaleDifference n v)‖]
-      simpa using enpsi_of_c2_c3_zero G Q localHamiltonian N n l
-        (Finset.mem_range.mp hn) v
-        hzero hv (hQ n hn) (hcomm n hn) hγ (by norm_num : (0 : ℝ) < 1)
-        (hC2 n hn v) hqzero
-    have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
-    have hsumPoint' : ‖v‖ ^ 2 ≤
-        (1 / (2 * γ)) *
-            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
-          (1 / 2) * ‖v‖ ^ 2 := by
-      simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
-    have henergy :
-        (1 / (2 * γ)) *
-            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
-          (1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
-      mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
-    have hhalf : (1 / 2 : ℝ) * ‖v‖ ^ 2 ≤
-        (1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re) := by
-      linarith
-    calc
-      (γ / d) * (1 - 0 * s) ^ 2 * ‖v‖ ^ 2 =
-          (2 * γ / d) * ((1 / 2 : ℝ) * ‖v‖ ^ 2) := by ring
-      _ ≤ (2 * γ / d) *
-          ((1 / (2 * γ)) * (d * (⟪H v, v⟫_ℂ).re)) :=
-        mul_le_mul_of_nonneg_left hhalf (by positivity)
-      _ = (⟪H v, v⟫_ℂ).re := by
-        field_simp [hγ.ne', hd.ne']
-  · let c₁ := 1 - ε * s
-    let c₂ := ε / s
-    have hc₁ : 0 < c₁ := hδ
-    have hc₂ : 0 < c₂ := div_pos hεpos hs
-    have hεc₂ : ε ^ 2 / (2 * c₂) = ε * s / 2 := by
-      dsimp only [c₂]
-      field_simp [hεpos.ne', hs.ne']
-    have hc₂window : (c₂ / 2) * ((l + 1 : ℕ) : ℝ) = ε * s / 2 := by
-      dsimp only [c₂]
-      rw [← hsquare]
-      field_simp [hs.ne']
-    have hpoint : ∀ n ∈ Finset.range N,
-        ‖G.martingaleDifference n v‖ ^ 2 ≤
-          (1 / (2 * c₁ * γ)) * (⟪localHamiltonian n v, v⟫_ℂ).re +
-          (c₁ / 2 + ε * s / 2) * ‖G.martingaleDifference n v‖ ^ 2 +
-          (c₂ / 2) *
-            ‖∑ m ∈ Finset.Icc (n - l) n,
-              G.martingaleDifference m v‖ ^ 2 := by
-      intro n hn
-      simpa only [hεc₂] using
-        enpsi2_of_c2_c3 G Q localHamiltonian N n l
-          (Finset.mem_range.mp hn) v hzero hv
-          (hQ n hn) (hcomm n hn) hγ hc₁ hc₂ (hC2 n hn v) (hC3point n hn v)
-    have hsumPoint := Finset.sum_le_sum fun n hn ↦ hpoint n hn
-    have hsumPoint' : ‖v‖ ^ 2 ≤
-        (1 / (2 * c₁ * γ)) *
-            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) +
-        (c₁ / 2 + ε * s / 2) * ‖v‖ ^ 2 +
-        (c₂ / 2) *
-          (∑ n ∈ Finset.range N,
-            ‖∑ m ∈ Finset.Icc (n - l) n,
-              G.martingaleDifference m v‖ ^ 2) := by
-      simpa only [Finset.sum_add_distrib, ← Finset.mul_sum, hactiveNorm] using hsumPoint
-    have henergy :
-        (1 / (2 * c₁ * γ)) *
-            (∑ n ∈ Finset.range N, (⟪localHamiltonian n v, v⟫_ℂ).re) ≤
-          (1 / (2 * c₁ * γ)) * (d * (⟪H v, v⟫_ℂ).re) :=
-      mul_le_mul_of_nonneg_left (hC1 v).2 (by positivity)
-    have hwindow' :
-        (c₂ / 2) *
-            (∑ n ∈ Finset.range N,
-              ‖∑ m ∈ Finset.Icc (n - l) n,
-                G.martingaleDifference m v‖ ^ 2) ≤
-          (ε * s / 2) * ‖v‖ ^ 2 := by
-      calc
-        _ ≤ (c₂ / 2) * ((l + 1) * ‖v‖ ^ 2) :=
-          mul_le_mul_of_nonneg_left hwindow (by positivity)
-        _ = ((c₂ / 2) * ((l + 1 : ℕ) : ℝ)) * ‖v‖ ^ 2 := by
-          push_cast
-          ring
-        _ = (ε * s / 2) * ‖v‖ ^ 2 := by rw [hc₂window]
-    have hhalf : (c₁ / 2) * ‖v‖ ^ 2 ≤
-        (1 / (2 * c₁ * γ)) * (d * (⟪H v, v⟫_ℂ).re) := by
-      dsimp only [c₁]
-      dsimp only [c₁] at hsumPoint' henergy
-      linarith
-    calc
-      (γ / d) * (1 - ε * s) ^ 2 * ‖v‖ ^ 2 =
-          (2 * (1 - ε * s) * γ / d) *
-            (((1 - ε * s) / 2) * ‖v‖ ^ 2) := by ring
-      _ ≤ (2 * (1 - ε * s) * γ / d) *
-          ((1 / (2 * (1 - ε * s) * γ)) *
-            (d * (⟪H v, v⟫_ℂ).re)) :=
-        mul_le_mul_of_nonneg_left hhalf (by positivity)
-      _ = (⟪H v, v⟫_ℂ).re := by
-        field_simp [hδ.ne', hγ.ne', hd.ne']
+  have hnorm :
+      ∑ n ∈ Finset.Ico 0 N, ‖G.martingaleDifference n v‖ ^ 2 = ‖v‖ ^ 2 := by
+    rw [← Finset.range_eq_Ico]
+    exact (G.norm_sq_eq_sum_martingaleDifference_of_mem_orthogonal N v
+      hzero hv).symm
+  have h := energy_lower_bound_of_nachtergaele_c1_c3_threshold G Q
+    localHamiltonian H N 0 l v (Nat.zero_le N) hzero hv hγ hd hε hεlt
+    (by simpa only [Finset.range_eq_Ico] using hQ)
+    (by simpa only [Finset.range_eq_Ico] using hcomm)
+    (by simpa only [Finset.range_eq_Ico] using hC1)
+    (by simpa only [Finset.range_eq_Ico] using hC2)
+    (by simpa only [Finset.range_eq_Ico] using hC3)
+  simpa only [Nat.zero_sub, Finset.Ico_self, Finset.sum_empty, mul_zero,
+    add_zero, hnorm] using h
 
 /-- Norm-gap form of the full-range C1--C3 estimate above. The ground-space
 identity identifies the last filtration range with the kernel of the positive

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1362,15 +1362,16 @@ norm estimate is derived here.
 
 % Source: References/cond-mat_9410110/main.tex, conditions C1--C3 at
 % lines 1030--1094, Theorem 2.1(i) at lines 1119--1130, and its proof at
-% lines 1195--1259. The conditions carry lower thresholds; the statement below
-% keeps them.
+% lines 1195--1259. The statement below isolates the estimate above a chosen
+% threshold and explicitly records how its C1 range relates to source C1.
 \begin{theorem}[Threshold C1--C3 energy estimate]
     \label{thm:nachtergaele_c1_c3_threshold_energy_estimate}
     \lean{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_threshold}
     \leanok
-    Let $(G_n)_{n\geq0}$ be nested orthogonal projections on a complex
-    Hilbert space $\mathcal H$, put $E_n=G_n-G_{n+1}$, and assume
-    $G_0=\mathbf 1$. Fix $l,N,n_0\in\N$ with $n_0\leq N$, and let $Q_n$ be
+    Let $(G_n)_{n\geq0}$ be nested orthogonal projections on a
+    finite-dimensional complex Hilbert space $\mathcal H$, put
+    $E_n=G_n-G_{n+1}$, and assume $G_0=\mathbf 1$. Fix $l,N,n_0\in\N$ with
+    $n_0\leq N$, and let $Q_n$ be
     orthogonal projections for $n_0\leq n<N$. Suppose $E_mQ_n=Q_nE_m$
     whenever $m<n-l$ or $n<m$. Let $H_n$ be the local Hamiltonians and $H$
     the full Hamiltonian. Assume the quadratic-form version of C1 on the same
@@ -1411,15 +1412,17 @@ norm estimate is derived here.
         \sum_{m=\max\{0,n_0-l\}}^{n_0-1}\lVert E_mv\rVert^2.
         \label{eq:nachtergaele_c1_c3_threshold_energy_estimate}
     \end{align}
-    Conditions C2 and C3 appear here exactly as the source states them, with
-    its threshold written $n_0$, and C1 appears as the source's condition at
-    window length $l+1$, restricted to the same range; that restriction
-    follows from the source's C1 whenever the omitted local terms are
-    nonnegative. The coefficient of the martingale mass above the threshold
-    is exactly the one in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral},
-    and the correction term is carried by the at most $l$ martingale
-    differences immediately below the threshold. At $n_0=0$ that correction
-    is an empty sum.
+    Conditions C2 and C3 have the source forms, with their onset represented by
+    $n_0$. The displayed C1 inequality follows from source C1 when
+    $l\leq n_0$ and the omitted local terms are nonnegative. Thus a
+    source-derived application chooses $n_0$ above both $l$ and the C2--C3
+    onset. If $n_0<l$, the displayed C1 inequality is instead an independent
+    stronger assumption. The coefficient of the martingale mass above the
+    threshold is exactly the one in Theorem~2.1(i) of
+    \cite{Nachtergaele1996Spectral}. The correction is an explicit upper bound
+    for the contribution of the at most $l$ martingale differences immediately
+    below the threshold; it uses multiplicity $l+1$ uniformly. At $n_0=0$ the
+    correction is an empty sum.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1429,7 +1429,6 @@ norm estimate is derived here.
     \leanok
     \uses{thm:truncated-martingale-difference-reconstruction,
         thm:martingale-difference-pythagorean-identity,
-        thm:martingale-difference-final-complement-norm-decomposition,
         thm:outside-window-martingale-cancellation,
         lem:nachtergaele_weighted_inner_product,
         lem:nachtergaele_c3_projection_composition,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1325,6 +1325,7 @@ norm estimate is derived here.
     \label{thm:moving_window_sum_le}
     \lean{FrustrationFree.movingWindow_sum_le}
     \lean{FrustrationFree.movingWindow_sum_range_le}
+    \lean{FrustrationFree.movingWindow_sum_Ico_le}
     \leanok
     Let $(a_m)_{m\geq0}$ be a nonnegative real sequence. For all $l,N\in\N$,
     \begin{align}
@@ -1332,7 +1333,14 @@ norm estimate is derived here.
          & \leq (l+1)\sum_{m=0}^{N-1}a_m.
         \label{eq:moving_window_sum_le}
     \end{align}
-    The same bound holds after omitting the terms with $n<l$.
+    The same bound holds after omitting the terms with $n<l$. More generally,
+    for a threshold $n_0\in\N$ only the coefficients indexed by
+    $m\geq\max\{0,n_0-l\}$ occur, so
+    \begin{align}
+        \sum_{n=n_0}^{N-1}\sum_{m=\max\{0,n-l\}}^{n}a_m
+         & \leq (l+1)\sum_{m=\max\{0,n_0-l\}}^{N-1}a_m.
+        \label{eq:moving_window_sum_Ico_le}
+    \end{align}
 \end{theorem}
 
 \begin{proof}
@@ -1345,7 +1353,113 @@ norm estimate is derived here.
     Nachtergaele's Theorem~2.1(i), between Equation~(Enpsi2) and the following
     summed estimate: for $a_m=\lVert E_m\psi\rVert^2$, each term occurs in at
     most $l+1$ consecutive windows
-    \cite[Proof of Theorem~2.1(i)]{Nachtergaele1996Spectral}.
+    \cite[Proof of Theorem~2.1(i)]{Nachtergaele1996Spectral}. For
+    (\ref{eq:moving_window_sum_Ico_le}), replace $a_m$ by the sequence that
+    vanishes below $\max\{0,n_0-l\}$ and agrees with $a_m$ above it. Every
+    window with $n\geq n_0$ is unchanged, and the previous bound applied to
+    the replacement sequence gives the claim.
+\end{proof}
+
+% Source: References/cond-mat_9410110/main.tex, conditions C1--C3 at
+% lines 1030--1094, Theorem 2.1(i) at lines 1119--1130, and its proof at
+% lines 1195--1259. The conditions carry lower thresholds; the statement below
+% keeps them.
+\begin{theorem}[Threshold C1--C3 energy estimate]
+    \label{thm:nachtergaele_c1_c3_threshold_energy_estimate}
+    \lean{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_threshold}
+    \leanok
+    Let $(G_n)_{n\geq0}$ be nested orthogonal projections on a complex
+    Hilbert space $\mathcal H$, put $E_n=G_n-G_{n+1}$, and assume
+    $G_0=\mathbf 1$. Fix $l,N,n_0\in\N$ with $n_0\leq N$, and let $Q_n$ be
+    orthogonal projections for $n_0\leq n<N$. Suppose $E_mQ_n=Q_nE_m$
+    whenever $m<n-l$ or $n<m$. Let $H_n$ be the local Hamiltonians and $H$
+    the full Hamiltonian. Assume the quadratic-form version of C1 on the same
+    range, for every $x\in\mathcal H$,
+    \begin{align}
+        0
+         & \leq\sum_{n=n_0}^{N-1}\re\langle H_nx,x\rangle
+        \leq d_{l+1}\re\langle Hx,x\rangle,
+        \label{eq:nachtergaele_c1_threshold_form}
+    \end{align}
+    the quadratic-form version of C2 for every $x\in\mathcal H$ and
+    $n_0\leq n<N$,
+    \begin{align}
+        \gamma_{l+1}\lVert(\mathbf 1-Q_n)x\rVert^2
+         & \leq\re\langle H_nx,x\rangle,
+        \label{eq:nachtergaele_c2_threshold_form}
+    \end{align}
+    and the literal condition C3 for $n_0\leq n<N$,
+    \begin{align}
+        \lVert Q_nE_n\rVert
+         & \leq\epsilon_l,
+         & 0\leq\epsilon_l
+         & <\frac{1}{\sqrt{l+1}}.
+        \label{eq:nachtergaele_c3_threshold_form}
+    \end{align}
+    If $\gamma_{l+1}>0$, $d_{l+1}>0$, and $v\perp\operatorname{ran}(G_N)$,
+    then
+    \begin{align}
+        \frac{\gamma_{l+1}}{d_{l+1}}
+        \left(1-\epsilon_l\sqrt{l+1}\right)^2
+        \sum_{n=n_0}^{N-1}\lVert E_nv\rVert^2
+         & \leq
+        \re\langle Hv,v\rangle
+        \nonumber \\
+         & \quad
+        +\frac{\gamma_{l+1}}{d_{l+1}}
+        \left(1-\epsilon_l\sqrt{l+1}\right)\epsilon_l\sqrt{l+1}
+        \sum_{m=\max\{0,n_0-l\}}^{n_0-1}\lVert E_mv\rVert^2.
+        \label{eq:nachtergaele_c1_c3_threshold_energy_estimate}
+    \end{align}
+    Conditions C2 and C3 appear here exactly as the source states them, with
+    its threshold written $n_0$, and C1 appears as the source's condition at
+    window length $l+1$, restricted to the same range; that restriction
+    follows from the source's C1 whenever the omitted local terms are
+    nonnegative. The coefficient of the martingale mass above the threshold
+    is exactly the one in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral},
+    and the correction term is carried by the at most $l$ martingale
+    differences immediately below the threshold. At $n_0=0$ that correction
+    is an empty sum.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:truncated-martingale-difference-reconstruction,
+        thm:martingale-difference-pythagorean-identity,
+        thm:martingale-difference-final-complement-norm-decomposition,
+        thm:outside-window-martingale-cancellation,
+        lem:nachtergaele_weighted_inner_product,
+        lem:nachtergaele_c3_projection_composition,
+        thm:moving_window_sum_le}
+    Write $P=\sum_{n=n_0}^{N-1}\lVert E_nv\rVert^2$ and
+    $S=\sum_{m=\max\{0,n_0-l\}}^{n_0-1}\lVert E_mv\rVert^2$. The martingale
+    resolution $v=\sum_{n=0}^{N-1}E_nv$ and outside-window cancellation
+    reduce the identity labelled \textup{Enpsi} at index $n$ to the active
+    window $m\in[n-l,n]$; this uses only $n<N$, so it is available for every
+    $n\geq n_0$. Apply the weighted inner-product estimate with positive
+    parameters $c_1,c_2$, then C2 and C3, and sum over $n_0\leq n<N$. The
+    martingale differences are mutually orthogonal, so each window norm
+    square splits into its summands, and
+    (\ref{eq:moving_window_sum_Ico_le}) bounds the resulting double sum by
+    $(l+1)(S+P)$. With C1 this gives
+    \begin{align}
+        \left(2-c_1-\frac{\epsilon_l^2}{c_2}-(l+1)c_2\right)P
+         & \leq
+        \frac{d_{l+1}}{c_1\gamma_{l+1}}\re\langle Hv,v\rangle
+        +(l+1)c_2S.
+    \end{align}
+    For $\epsilon_l>0$, take $c_1=1-\epsilon_l\sqrt{l+1}$ and
+    $c_2=\epsilon_l/\sqrt{l+1}$, so that
+    $\epsilon_l^2/c_2=(l+1)c_2=\epsilon_l\sqrt{l+1}$ and the left factor is
+    $1-\epsilon_l\sqrt{l+1}$. Multiplying by
+    $c_1\gamma_{l+1}/d_{l+1}$ gives
+    (\ref{eq:nachtergaele_c1_c3_threshold_energy_estimate}). If
+    $\epsilon_l=0$, then $c_2=0$ is not an admissible weighted parameter. In
+    that case C3 instead gives $Q_nE_n=0$, so the second inner product in
+    \textup{Enpsi} vanishes; applying only the first weighted estimate with
+    $c_1=1$ yields $P\leq(d_{l+1}/\gamma_{l+1})\re\langle Hv,v\rangle$,
+    which is the same formula because the correction term vanishes. This
+    repair is documented in \cite{gap:cpgsv21_martingale_overlap}.
 \end{proof}
 
 % Source: References/cond-mat_9410110/main.tex, conditions C1--C3 at
@@ -1401,50 +1515,22 @@ norm estimate is derived here.
     \cite{gap:cpgsv21_martingale_overlap}. The coefficient is exactly the one
     in Theorem~2.1(i) of \cite{Nachtergaele1996Spectral}:
     $\gamma_{l+1}/d_{l+1}$ times
-    $(1-\epsilon_l\sqrt{l+1})^2$.
+    $(1-\epsilon_l\sqrt{l+1})^2$. This is
+    Theorem~\ref{thm:nachtergaele_c1_c3_threshold_energy_estimate} at
+    threshold $n_0=0$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:truncated-martingale-difference-reconstruction,
-        thm:martingale-difference-pythagorean-identity,
-        thm:martingale-difference-final-complement-norm-decomposition,
-        thm:outside-window-martingale-cancellation,
-        lem:nachtergaele_weighted_inner_product,
-        lem:nachtergaele_c3_projection_composition,
-        thm:moving_window_sum_le}
-    The martingale resolution gives
-    \begin{align}
-        v
-         & =\sum_{n=0}^{N-1}E_nv,
-         & \lVert v\rVert^2
-         & =\sum_{n=0}^{N-1}\lVert E_nv\rVert^2.
-    \end{align}
-    Outside-window cancellation reduces the second term in the identity
-    labelled \textup{Enpsi} to $m\in[n-l,n]$. Apply the weighted
-    inner-product estimate with positive parameters $c_1,c_2$ and then use
-    C2 and C3. Summing over $n$ and applying the moving-window count gives
-    \begin{align}
-        \left(2-c_1-\frac{\epsilon_l^2}{c_2}-(l+1)c_2\right)
-        \lVert v\rVert^2
-         & \leq
-        \frac{d_{l+1}}{c_1\gamma_{l+1}}
-        \re\langle Hv,v\rangle.
-    \end{align}
-    For $\epsilon_l>0$, take
-    \begin{align}
-        c_1
-         & =1-\epsilon_l\sqrt{l+1},
-         & c_2
-         & =\frac{\epsilon_l}{\sqrt{l+1}}.
-    \end{align}
-    These values reduce the preceding inequality to
-    (\ref{eq:nachtergaele_c1_c3_full_range_energy_estimate}). If
-    $\epsilon_l=0$, then $c_2=0$ is not an admissible weighted parameter.
-    In that case C3 instead gives $Q_nE_n=0$, so the second inner product in
-    \textup{Enpsi} vanishes; applying only the first weighted estimate with
-    $c_1=1$ yields the same formula. This repair is documented in
-    \cite{gap:cpgsv21_martingale_overlap}.
+    \uses{thm:nachtergaele_c1_c3_threshold_energy_estimate,
+        thm:martingale-difference-final-complement-norm-decomposition}
+    Apply
+    Theorem~\ref{thm:nachtergaele_c1_c3_threshold_energy_estimate} with
+    $n_0=0$. The correction sum is then empty, and the Pythagorean
+    decomposition of a vector orthogonal to $\operatorname{ran}(G_N)$
+    identifies the martingale mass $\sum_{n=0}^{N-1}\lVert E_nv\rVert^2$ with
+    $\lVert v\rVert^2$. This gives
+    (\ref{eq:nachtergaele_c1_c3_full_range_energy_estimate}).
 \end{proof}
 
 \begin{theorem}[Energy form to norm bound]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -182,10 +182,42 @@ at the omitted lower indices. The convention $G_{\Lambda_0}=I$ does not make
 the early differences $E_n$ vanish, and no padding convention for the early
 local Hamiltonians is stated.
 
+The threshold theorem
+\leanid{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_threshold}
+keeps the source index ranges. It assumes the C1 sum and the C2--C3 estimates
+only for $n_0\leq n<N$ and pays for the omitted indices with an explicit
+correction term. Writing
+\begin{align}
+    P
+        &=\sum_{n=n_0}^{N-1}\lVert E_n\psi\rVert^2,
+    &
+    S
+        &=\sum_{m=\max\{0,n_0-l\}}^{n_0-1}\lVert E_m\psi\rVert^2,
+    \label{eq:cpgsv21_martingale_overlap_threshold_masses}
+\end{align}
+the moving-window count over $n_0\leq n<N$ reaches down to
+$m=\max\{0,n_0-l\}$ and so is bounded by $(l+1)(S+P)$ rather than by
+$(l+1)P$. With the printed weights the estimate becomes
+\begin{align}
+    \frac{\gamma_{l+1}}{d_{l+1}}
+    \left(1-\epsilon_l\sqrt{l+1}\right)^2P
+        &\leq
+          \langle\psi\mid H_{\Lambda_N}\psi\rangle
+          +\frac{\gamma_{l+1}}{d_{l+1}}
+          \left(1-\epsilon_l\sqrt{l+1}\right)\epsilon_l\sqrt{l+1}\,S.
+    \label{eq:cpgsv21_martingale_overlap_threshold_estimate}
+\end{align}
+This is the source coefficient on the martingale mass above the threshold. It
+is not the source theorem, whose conclusion is the same coefficient on
+$\lVert\psi\rVert^2$; the two agree exactly when the martingale differences
+below the threshold vanish, in which case $S=0$ and $P=\lVert\psi\rVert^2$.
+
 The stronger full-range theorem
 \leanid{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_full_range}
-therefore assumes the C1 sum and the C2--C3 estimates on every index
-$0\leq n<N$. Under this stronger hypothesis it proves the printed coefficient
+is Equation~\eqref{eq:cpgsv21_martingale_overlap_threshold_estimate} at
+$n_0=0$, where the correction is an empty sum. It therefore assumes the C1
+sum and the C2--C3 estimates on every index $0\leq n<N$. Under this stronger
+hypothesis it proves the printed coefficient
 \begin{align}
     \frac{\gamma_{l+1}}{d_{l+1}}
     \left(1-\epsilon_l\sqrt{l+1}\right)^2.
@@ -198,7 +230,10 @@ are not identified with the unrestricted source theorem.
 
 The abstract limitation remains: the source-threshold hypotheses alone do not
 justify the full-range summation without additional control of the initial
-volumes. The nonwrapping open MPS specialization supplies this control and
+volumes. Equation~\eqref{eq:cpgsv21_martingale_overlap_threshold_estimate}
+isolates exactly what that control has to supply, namely the vanishing of the
+martingale mass below the threshold; it does not by itself remove the
+requirement. The nonwrapping open MPS specialization supplies this control and
 therefore satisfies the stronger full-range assumptions. The early local
 terms in C1 vanish. The early C2 expressions also vanish because the suffix
 Hamiltonian is zero and the complementary projection $\Id-Q_n$ is zero. For

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -184,9 +184,11 @@ local Hamiltonians is stated.
 
 The threshold theorem
 \leanid{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_threshold}
-keeps the source index ranges. It assumes the C1 sum and the C2--C3 estimates
-only for $n_0\leq n<N$ and pays for the omitted indices with an explicit
-correction term. Writing
+assumes the C1 sum and the C2--C3 estimates only for $n_0\leq n<N$. To derive
+its C1 hypothesis from source C1, choose $n_0\geq l$ as well as above the
+C2--C3 onset; for $n_0<l$, the theorem's C1 hypothesis is an independent
+stronger assumption. It pays for the omitted martingale indices with an
+explicit correction term. Writing
 \begin{align}
     P
         &=\sum_{n=n_0}^{N-1}\lVert E_n\psi\rVert^2,
@@ -207,10 +209,12 @@ $(l+1)P$. With the printed weights the estimate becomes
           \left(1-\epsilon_l\sqrt{l+1}\right)\epsilon_l\sqrt{l+1}\,S.
     \label{eq:cpgsv21_martingale_overlap_threshold_estimate}
 \end{align}
-This is the source coefficient on the martingale mass above the threshold. It
-is not the source theorem, whose conclusion is the same coefficient on
-$\lVert\psi\rVert^2$; the two agree exactly when the martingale differences
-below the threshold vanish, in which case $S=0$ and $P=\lVert\psi\rVert^2$.
+This is the source coefficient on the martingale mass above the threshold. The
+correction uses the uniform multiplicity bound $l+1$ for every term of $S$, so
+it is an upper bound rather than the exact below-threshold window count. The
+result is not the source theorem, whose conclusion is the same coefficient on
+$\lVert\psi\rVert^2$; the two agree when the martingale differences below the
+threshold vanish, in which case $S=0$ and $P=\lVert\psi\rVert^2$.
 
 The stronger full-range theorem
 \leanid{FrustrationFree.NestedGroundProjections.energy_lower_bound_of_nachtergaele_c1_c3_full_range}


### PR DESCRIPTION
### Motivation

- Nachtergaele's Theorem 2.1(i) obtains the coefficient
  `gamma_{l+1} / d_{l+1} * (1 - eps_l * sqrt (l + 1))^2` from conditions
  C1--C3.
- The exact source is `References/cond-mat_9410110/main.tex`: C1 at lines
  1030--1041, C2 at lines 1043--1058, the definition of `E_n` at lines
  1068--1074, C3 at lines 1083--1094, the theorem at lines 1119--1130, and the
  printed martingale-difference summation at lines 1195--1259.
- The three conditions carry lower endpoints. C1 sums from the window length,
  and C2 and C3 hold only for `n >= n_l`. The printed proof nevertheless
  estimates every martingale difference `E_0, ..., E_{N-1}`. PR #7548
  therefore proved the estimate under the explicitly stronger full-range
  hypotheses and left the lower-index obligation open.

### Description

- Add `energy_lower_bound_of_nachtergaele_c1_c3_threshold`, which assumes C1,
  C2, and C3 directly on `n_0 <= n < N` and keeps C3 in the source's literal
  operator-norm form. To derive its C1 hypothesis from source C1, choose
  `n_0 >= l` as well as above the C2-C3 onset; for `n_0 < l`, C1 is an
  independent stronger assumption.
- Its conclusion is the printed coefficient on the martingale mass above the
  threshold, corrected by an explicit upper bound for the moving-window contribution
  of the `l` differences immediately below it:

  ```
  (gamma / d) * (1 - eps * sqrt (l + 1))^2 * sum_{n = n_0}^{N-1} ‖E_n v‖^2
    <= re ⟪H v, v⟫
       + (gamma / d) * (1 - eps * sqrt (l + 1)) * (eps * sqrt (l + 1))
         * sum_{m = n_0 - l}^{n_0 - 1} ‖E_m v‖^2
  ```

- Rebuild `energy_lower_bound_of_nachtergaele_c1_c3_full_range` as the case
  `n_0 = 0`, where the correction is an empty sum. Its statement, and the
  statement and proof route of `norm_lower_bound_of_nachtergaele_c1_c3_full_range`
  through `FrustrationFree.spectralGap_of_martingale_of_finiteDimensional`,
  are unchanged, so downstream users are untouched.
- Add `movingWindow_sum_Ico_le`, the moving-window double count restricted to
  `n >= n_0`, which reaches down to `m = n_0 - l` and so is bounded by
  `(l + 1)` times the sum over `[n_0 - l, N)`.
- The `eps_l = 0` case keeps the separate treatment introduced in #7548, since
  the printed choice `c_2 = eps_l / sqrt (l + 1)` is then not positive.
- Synchronize the Blueprint with formula-driven, source-anchored statements and
  proofs, and record the threshold estimate in
  `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.

### Scope

This does not claim the unrestricted source theorem. For a source-derived application, the threshold must be chosen above both `l`
and the C2-C3 onset. The theorem's conclusion is the source coefficient on the martingale mass above the threshold rather than on
`‖psi‖^2`; the two coincide precisely when the martingale differences below the
threshold vanish. The remaining obligation is recorded in the paper-gap note
and tracked in #7688. No `sorry`, `axiom`,
`native_decide`, `admit`, or `unsafeCast` is introduced.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.ParentHamiltonian`
- `python3 scripts/blueprint_lean_sync.py`
- `python3 scripts/paper_gap_leanid_sync.py`
- `texra-blueprint paper-gaps check`
- `leanblueprint checkdecls`
- `chktex -q -l blueprint/.chktexrc` and pinned `scripts/latexindent`
- `python3 scripts/check_forbidden_lean_tokens.py`,
  `check_oversized_lean_files.py`, `check_numbered_lean_files.py`,
  `lean_import_syntax.py`

Advances #7478

Follow-up: #7688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
