### PR TITLE
refactor(MPS/MPDO): rename the twisted-dimer predicates to the Is-prefix convention

### DIFF
--- a/TNLean/MPS/MPDO/TwistedDimer.lean
+++ b/TNLean/MPS/MPDO/TwistedDimer.lean
@@ -187,28 +187,35 @@ lemma single_mul_single_ite {a b c e : Fin 8} (u v : ℂ) :
   · subst h; simp
   · simp [h]
 
-/-- The bond-matching condition between consecutive letters. -/
-def gate (i₁ i₂ : Fin 8) : Prop := bitR i₁ = bitL i₂
+/-- The **bond-matching condition** on an ordered pair of consecutive letters:
+the right bit of the first letter is the left bit of the second one.  It is the
+one-bond atom of the open and cyclic conditions `IsOpenBondMatched` and
+`IsCyclicBondMatched`.
 
-instance decidableGate (i₁ i₂ : Fin 8) : Decidable (gate i₁ i₂) :=
+Project example; not from CPSV16. -/
+def IsBondMatchedPair (i₁ i₂ : Fin 8) : Prop := bitR i₁ = bitL i₂
+
+/-- The bond-matching condition on a pair is an equality of bits, hence
+decidable. -/
+instance decidableIsBondMatchedPair (i₁ i₂ : Fin 8) : Decidable (IsBondMatchedPair i₁ i₂) :=
   inferInstanceAs (Decidable (bitR i₁ = bitL i₂))
 
 /-- The product of two letters keeps a common block label and is gated by the
 bond-matching condition. -/
 lemma T_mul_T (i₁ j₁ i₂ j₂ : Fin 8) :
     T i₁ j₁ * T i₂ j₂ =
-      if gate i₁ i₂ ∧ gate j₁ j₂ then
+      if IsBondMatchedPair i₁ i₂ ∧ IsBondMatchedPair j₁ j₂ then
         ∑ k : Fin 2, Matrix.single (physIdx (bitL i₁) (bitL j₁) k)
           (physIdx (bitR i₂) (bitR j₂) k) (coef k i₁ j₁ * coef k i₂ j₂)
       else 0 := by
   simp only [T, Fin.sum_univ_two, add_mul, mul_add, single_mul_single_ite, physIdx_inj]
   by_cases h1 : bitR i₁ = bitL i₂ <;> by_cases h2 : bitR j₁ = bitL j₂ <;>
-    simp [gate, h1, h2]
+    simp [IsBondMatchedPair, h1, h2]
 
 /-- **Two-site closure.** -/
 theorem physClose2_T (X : Matrix (Fin 8) (Fin 8) ℂ) (i₁ i₂ j₁ j₂ : Fin 8) :
     physClose2 T X (i₁, i₂) (j₁, j₂) =
-      if gate i₁ i₂ ∧ gate j₁ j₂ then
+      if IsBondMatchedPair i₁ i₂ ∧ IsBondMatchedPair j₁ j₂ then
         ∑ k : Fin 2, coef k i₁ j₁ * coef k i₂ j₂ *
           X (physIdx (bitR i₂) (bitR j₂) k) (physIdx (bitL i₁) (bitL j₁) k)
       else 0 := by

--- a/TNLean/MPS/MPDO/TwistedDimerBNTAlgebraClause.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerBNTAlgebraClause.lean
@@ -164,7 +164,7 @@ theorem sectorWeight_hasIdempotentCoefficientForm :
   intro g
   simp only [verticalBNTTraceScalarFamily_traceScalar, sectorWeight, twoLabelCoeffs_coeff,
     Fin.sum_univ_two, Finset.sum_const, Finset.card_univ, Fintype.card_fin, one_smul]
-  fin_cases g <;> simp [sameChannel] <;> norm_num [mu, alpha, beta]
+  fin_cases g <;> simp [IsSameChannel] <;> norm_num [mu, alpha, beta]
 
 /-- The algebra clause for the flag-sector operators and trace scalars. -/
 def flagAlgebraClause :

--- a/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerCoefficients.lean
@@ -50,11 +50,14 @@ noncomputable section
 
 namespace MPOTensor.TwistedDimer
 
-/-- The fusion channel of two flag labels: the label $f + f'$ (`0`) or its
-complement $f + f' + 1$ (`1`), decided by whether `g = f + f'`. -/
-def sameChannel (f f' g : Fin 2) : Prop := g = f + f'
+/-- The **fusion-channel condition** on three flag labels: the outgoing label
+$g$ is the sum $f + f'$ of the two incoming ones, as opposed to its complement
+$f + f' + 1$. -/
+def IsSameChannel (f f' g : Fin 2) : Prop := g = f + f'
 
-instance decidableSameChannel (f f' g : Fin 2) : Decidable (sameChannel f f' g) :=
+/-- The fusion-channel condition is an equality of flag labels, hence
+decidable. -/
+instance decidableIsSameChannel (f f' g : Fin 2) : Decidable (IsSameChannel f f' g) :=
   inferInstanceAs (Decidable (g = f + f'))
 
 /-- The fusion weight $\alpha = 7/10$ on the channel $g = f + f'$ (rational point
@@ -69,11 +72,11 @@ $1 \times 1$ block with entry $\alpha$ or $\beta$. No tensor attachment is
 asserted. -/
 def twoLabelChi : DiagonalChiFamily (Fin 2) where
   dim _ _ _ := 1
-  entry f f' g _ := if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ)
+  entry f f' g _ := if IsSameChannel f f' g then (alpha : ℂ) else (beta : ℂ)
 
 lemma twoLabelChi_posEntries : twoLabelChi.PosEntries := by
   intro f f' g k
-  by_cases h : sameChannel f f' g
+  by_cases h : IsSameChannel f f' g
   · simp only [twoLabelChi, h, ite_true]
     exact Complex.zero_lt_real.mpr (by norm_num [alpha])
   · simp only [twoLabelChi, h, ite_false]
@@ -85,17 +88,17 @@ def twoLabelCoeffs : BNTLabelCoefficientFamily (Fin 2) :=
 
 theorem twoLabelCoeffs_coeff (L : ℕ) (f f' g : Fin 2) :
     twoLabelCoeffs.coeff L f f' g =
-      if sameChannel f f' g then (alpha : ℂ) ^ L else (beta : ℂ) ^ L := by
+      if IsSameChannel f f' g then (alpha : ℂ) ^ L else (beta : ℂ) ^ L := by
   dsimp [twoLabelCoeffs, BNTLabelCoefficientFamily.ofChi,
     DiagonalChiFamily.tracePowerCoeff, twoLabelChi]
-  by_cases h : sameChannel f f' g <;> simp [h]
+  by_cases h : IsSameChannel f f' g <;> simp [h]
 
 /-- The channel-$\alpha$ coefficient $(7/10)^L$ differs between lengths one and two. -/
 theorem twoLabelCoeffs_not_lengthIndependent : ¬ twoLabelCoeffs.LengthIndependent := by
   intro h
   have := h.coeff_eq one_pos (by norm_num : (0 : ℕ) < 2) 0 0 0
   rw [twoLabelCoeffs_coeff, twoLabelCoeffs_coeff] at this
-  have hs : sameChannel 0 0 0 := by decide
+  have hs : IsSameChannel 0 0 0 := by decide
   simp only [hs, ite_true, alpha] at this
   norm_num at this
 
@@ -106,7 +109,7 @@ covariance of Theorem 4.14(iii) under the normalization freedom of Proposition
 def twoLabelChiScaled (s : Fin 2 → ℝ) : DiagonalChiFamily (Fin 2) where
   dim _ _ _ := 1
   entry f f' g _ :=
-    ((s f * s f' / s g : ℝ) : ℂ) * (if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ))
+    ((s f * s f' / s g : ℝ) : ℂ) * (if IsSameChannel f f' g then (alpha : ℂ) else (beta : ℂ))
 
 /-- The coefficient family of the rescaled candidate data. -/
 def rescaledCoeffs (s : Fin 2 → ℝ) : BNTLabelCoefficientFamily (Fin 2) :=
@@ -115,7 +118,7 @@ def rescaledCoeffs (s : Fin 2 → ℝ) : BNTLabelCoefficientFamily (Fin 2) :=
 theorem rescaledCoeffs_coeff (s : Fin 2 → ℝ) (L : ℕ) (f f' g : Fin 2) :
     (rescaledCoeffs s).coeff L f f' g =
       (((s f * s f' / s g : ℝ) : ℂ) *
-        (if sameChannel f f' g then (alpha : ℂ) else (beta : ℂ))) ^ L := by
+        (if IsSameChannel f f' g then (alpha : ℂ) else (beta : ℂ))) ^ L := by
   dsimp [rescaledCoeffs, BNTLabelCoefficientFamily.ofChi,
     DiagonalChiFamily.tracePowerCoeff, twoLabelChiScaled]
   simp
@@ -140,14 +143,14 @@ theorem twoLabelCoeffs_rescaling_stable_not_lengthIndependent (s : Fin 2 → ℝ
   have h1 := hs 1
   -- a positive-length coefficient equal at lengths 1 and 2 is a real number t with t = t^2
   have key : ∀ f f' g : Fin 2,
-      (s f * s f' / s g) * (if sameChannel f f' g then alpha else beta) = 1 := by
+      (s f * s f' / s g) * (if IsSameChannel f f' g then alpha else beta) = 1 := by
     intro f f' g
     have e := hLI.coeff_eq (show (0 : ℕ) < 2 by norm_num) (show (0 : ℕ) < 1 by norm_num) f f' g
     rw [rescaledCoeffs_coeff, rescaledCoeffs_coeff] at e
     have hq : 0 < s f * s f' / s g := div_pos (mul_pos (hs f) (hs f')) (hs g)
-    have hw : 0 < (if sameChannel f f' g then alpha else beta) := by
+    have hw : 0 < (if IsSameChannel f f' g then alpha else beta) := by
       split_ifs <;> norm_num [alpha, beta]
-    set t : ℝ := (s f * s f' / s g) * (if sameChannel f f' g then alpha else beta) with ht
+    set t : ℝ := (s f * s f' / s g) * (if IsSameChannel f f' g then alpha else beta) with ht
     have et : ((t : ℝ) : ℂ) ^ 2 = ((t : ℝ) : ℂ) ^ 1 := by
       rw [ht]
       push_cast
@@ -159,9 +162,9 @@ theorem twoLabelCoeffs_rescaling_stable_not_lengthIndependent (s : Fin 2 → ℝ
   have e000 := key 0 0 0
   have e010 := key 0 1 0
   have e001 := key 0 0 1
-  have hs000 : sameChannel 0 0 0 := by decide
-  have hs010 : ¬ sameChannel 0 1 0 := by decide
-  have hs001 : ¬ sameChannel 0 0 1 := by decide
+  have hs000 : IsSameChannel 0 0 0 := by decide
+  have hs010 : ¬ IsSameChannel 0 1 0 := by decide
+  have hs001 : ¬ IsSameChannel 0 0 1 := by decide
   simp only [hs000, hs010, hs001, ite_true, ite_false] at e000 e010 e001
   -- e000 : s 0 * s 0 / s 0 * alpha = 1, e010 : s 0 * s 1 / s 0 * beta = 1,
   -- e001 : s 0 * s 0 / s 1 * beta = 1

--- a/TNLean/MPS/MPDO/TwistedDimerFlagSectors.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerFlagSectors.lean
@@ -222,7 +222,8 @@ theorem mpo_unitTensor_apply (c : Fin 8 → Fin 8 → ℂ) {N : ℕ} (hN : 0 < N
   rw [evalWord_unitTensor_ofFn c n σ τ]
   by_cases hopen : IsOpenBondMatched σ ∧ IsOpenBondMatched τ
   · rw [ite_eq_left hopen]
-    by_cases hw : gate (σ (Fin.last n)) (σ 0) ∧ gate (τ (Fin.last n)) (τ 0)
+    by_cases hw : IsBondMatchedPair (σ (Fin.last n)) (σ 0) ∧
+        IsBondMatchedPair (τ (Fin.last n)) (τ 0)
     · have hchain : IsCyclicBondMatched (n + 1) σ ∧ IsCyclicBondMatched (n + 1) τ :=
         ⟨(isCyclicBondMatched_succ σ).2 ⟨hopen.1, hw.1⟩,
           (isCyclicBondMatched_succ τ).2 ⟨hopen.2, hw.2⟩⟩

--- a/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerMPDO.lean
@@ -82,13 +82,13 @@ bra strings both satisfy it (`evalWord_T_ofFn`).
 
 Project example; not from CPSV16. -/
 def IsOpenBondMatched {n : ℕ} (σ : Fin (n + 1) → Fin 8) : Prop :=
-  ∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)
+  ∀ i : Fin n, IsBondMatchedPair (σ i.castSucc) (σ i.succ)
 
 /-- The open bond-matching condition is a finite conjunction of equalities of
 bits, hence decidable. -/
 instance decidableIsOpenBondMatched {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
     Decidable (IsOpenBondMatched σ) :=
-  inferInstanceAs (Decidable (∀ i : Fin n, gate (σ i.castSucc) (σ i.succ)))
+  inferInstanceAs (Decidable (∀ i : Fin n, IsBondMatchedPair (σ i.castSucc) (σ i.succ)))
 
 /-- The **cyclic bond-matching condition** on a physical string: the right bit
 of each letter is the left bit of the next one around the ring, with the
@@ -97,26 +97,28 @@ wraparound step (`isCyclicBondMatched_succ`).
 
 Project example; not from CPSV16. -/
 def IsCyclicBondMatched (N : ℕ) (σ : Fin N → Fin 8) : Prop :=
-  ∀ n : Fin N, gate (σ n) (σ (finRotate N n))
+  ∀ n : Fin N, IsBondMatchedPair (σ n) (σ (finRotate N n))
 
 /-- The cyclic bond-matching condition is a finite conjunction of equalities of
 bits, hence decidable. -/
 instance decidableIsCyclicBondMatched (N : ℕ) (σ : Fin N → Fin 8) :
     Decidable (IsCyclicBondMatched N σ) :=
-  inferInstanceAs (Decidable (∀ n : Fin N, gate (σ n) (σ (finRotate N n))))
+  inferInstanceAs (Decidable (∀ n : Fin N, IsBondMatchedPair (σ n) (σ (finRotate N n))))
 
 /-- Peeling the first site off the open bond-matching condition: the condition
 on a string of length at least two is the match across the first bond together
 with the condition on the tail. -/
 lemma isOpenBondMatched_succ {n : ℕ} (σ : Fin (n + 2) → Fin 8) :
-    IsOpenBondMatched σ ↔ gate (σ 0) (σ (Fin.succ 0)) ∧ IsOpenBondMatched (fun i => σ i.succ) := by
+    IsOpenBondMatched σ ↔
+      IsBondMatchedPair (σ 0) (σ (Fin.succ 0)) ∧ IsOpenBondMatched (fun i => σ i.succ) := by
   rw [IsOpenBondMatched, IsOpenBondMatched, Fin.forall_fin_succ]
   simp only [Fin.castSucc_zero, Fin.succ_castSucc]
 
 /-- The cyclic bond-matching condition is the open condition on the segment
 together with the wraparound match from the last letter back to the first. -/
 lemma isCyclicBondMatched_succ {n : ℕ} (σ : Fin (n + 1) → Fin 8) :
-    IsCyclicBondMatched (n + 1) σ ↔ IsOpenBondMatched σ ∧ gate (σ (Fin.last n)) (σ 0) := by
+    IsCyclicBondMatched (n + 1) σ ↔
+      IsOpenBondMatched σ ∧ IsBondMatchedPair (σ (Fin.last n)) (σ 0) := by
   rw [IsCyclicBondMatched, Fin.forall_fin_succ', IsOpenBondMatched]
   simp only [Fin.finRotate_succ_castSucc, finRotate_last]
 
@@ -210,7 +212,7 @@ element of the closed operator at a pair of physical strings is the cyclic
 bond-matching indicator times the sum over the two horizontal block labels of
 the product of the one-site coefficients along the ring.
 
-Both horizontal blocks contribute with the same bond-matching gate, because the
+Both horizontal blocks contribute with the same bond-matching condition, because the
 block label is part of the bond index and is preserved by every letter product;
 closing the trace adds the wraparound match to the open condition.
 
@@ -222,7 +224,8 @@ theorem mpo_T_entry_formula {N : ℕ} (hN : 0 < N) (σ τ : Fin N → Fin 8) :
   rw [evalWord_T_ofFn n σ τ]
   by_cases hopen : IsOpenBondMatched σ ∧ IsOpenBondMatched τ
   · rw [ite_eq_left hopen, Matrix.trace_sum]
-    by_cases hw : gate (σ (Fin.last n)) (σ 0) ∧ gate (τ (Fin.last n)) (τ 0)
+    by_cases hw : IsBondMatchedPair (σ (Fin.last n)) (σ 0) ∧
+        IsBondMatchedPair (τ (Fin.last n)) (τ 0)
     · have hchain : IsCyclicBondMatched (n + 1) σ ∧ IsCyclicBondMatched (n + 1) τ :=
         ⟨(isCyclicBondMatched_succ σ).2 ⟨hopen.1, hw.1⟩,
           (isCyclicBondMatched_succ τ).2 ⟨hopen.2, hw.2⟩⟩

--- a/TNLean/MPS/MPDO/TwistedDimerProductLaw.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerProductLaw.lean
@@ -173,7 +173,7 @@ lemma sum_sector (f : Fin 2) (L : ℕ) (k : Fin L → Fin 2) :
     simpa [hφ] using this
   have hcond : ∀ t, IsCyclicBondMatched L (φ t) ∧ ∀ n, k n = bitF (φ t n) := by
     intro t
-    exact ⟨fun n => by simp [hφ, gate], fun n => by simp [hφ]⟩
+    exact ⟨fun n => by simp [hφ, IsBondMatchedPair], fun n => by simp [hφ]⟩
   symm
   calc (∑ t : Fin L → Fin 2, ∏ n, flagWeight f (φ t n))
       = ∑ t : Fin L → Fin 2,
@@ -282,6 +282,6 @@ theorem flagOperatorFamily_hasSameLengthProductForm :
   intro L hL f f'
   simp only [flagOperatorFamily_operator, twoLabelCoeffs_coeff, Fin.sum_univ_two]
   rw [mpo_flagMPO_mul hL]
-  fin_cases f <;> fin_cases f' <;> simp [sameChannel, add_comm]
+  fin_cases f <;> fin_cases f' <;> simp [IsSameChannel, add_comm]
 
 end MPOTensor.TwistedDimer

--- a/TNLean/MPS/MPDO/TwistedDimerRefine.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerRefine.lean
@@ -182,7 +182,7 @@ Kraus label, the two-site letter satisfies the bond-matching condition, and the
 one-site flag is the sum of the two prepared flags and the bond label. -/
 def IsRefineSupported (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) : Prop :=
   ((bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)) ∧
-    (gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε)
+    (IsBondMatchedPair i.1 i.2 ∧ bitF j = f₁ + f₂ + ε)
 
 instance decidableIsRefineSupported (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
     Decidable (IsRefineSupported f₁ f₂ ε i j) :=
@@ -192,7 +192,7 @@ instance decidableIsRefineSupported (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) 
 fixed two-site letter. -/
 lemma isRefineSupported_iff_col (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
     IsRefineSupported f₁ f₂ ε i j ↔
-      (gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧
+      (IsBondMatchedPair i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂) ∧
         (bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2) := by
   simp only [IsRefineSupported]
   constructor
@@ -226,11 +226,11 @@ lemma refineKraus_star (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (j : Fin 8) :
 the single one-site letter in its support. -/
 lemma refineKraus_col_sum (f₁ f₂ ε : Fin 2) (i : Fin 8 × Fin 8) (g : Fin 8 → ℂ) :
     (∑ j : Fin 8, refineKraus f₁ f₂ ε i j * g j) =
-      if gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂ then
+      if IsBondMatchedPair i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂ then
         ((refineAmp ε * tau ε (bitR i.1) : ℝ) : ℂ) *
           g (physIdx (bitL i.1) (bitR i.2) (f₁ + f₂ + ε))
       else 0 := by
-  by_cases hi : gate i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂
+  by_cases hi : IsBondMatchedPair i.1 i.2 ∧ bitF i.1 = f₁ ∧ bitF i.2 = f₂
   · rw [ite_eq_left hi]
     have hcongr : ∀ j : Fin 8, refineKraus f₁ f₂ ε i j * g j =
         if bitF j = f₁ + f₂ + ε ∧ bitL j = bitL i.1 ∧ bitR j = bitR i.2 then
@@ -258,20 +258,20 @@ lemma refineKraus_row_sum (f₁ f₂ ε : Fin 2) (j : Fin 8) (g : Fin 8 × Fin 8
       else 0 := by
   have hcongr : ∀ i : Fin 8 × Fin 8, (if IsRefineSupported f₁ f₂ ε i j then g i else 0) =
       if (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j) then
-        (if gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε then g i else 0) else 0 := by
+        (if IsBondMatchedPair i.1 i.2 ∧ bitF j = f₁ + f₂ + ε then g i else 0) else 0 := by
     intro i
     by_cases h1 : (bitF i.1 = f₁ ∧ bitL i.1 = bitL j) ∧ (bitF i.2 = f₂ ∧ bitR i.2 = bitR j)
     · rw [ite_eq_left h1]
-      by_cases h2 : gate i.1 i.2 ∧ bitF j = f₁ + f₂ + ε
+      by_cases h2 : IsBondMatchedPair i.1 i.2 ∧ bitF j = f₁ + f₂ + ε
       · rw [ite_eq_left h2, ite_eq_left (show IsRefineSupported f₁ f₂ ε i j from ⟨h1, h2⟩)]
       · rw [ite_eq_right h2, ite_eq_right fun hc => h2 hc.2]
     · rw [ite_eq_right h1, ite_eq_right fun hc => h1 hc.1]
   rw [Finset.sum_congr rfl fun i _ => hcongr i, pair_fiber_sum]
   by_cases hf : bitF j = f₁ + f₂ + ε
   · rw [ite_eq_left hf]
-    simp [Fin.sum_univ_two, gate, hf]
+    simp [Fin.sum_univ_two, IsBondMatchedPair, hf]
   · rw [ite_eq_right hf]
-    simp [gate, hf]
+    simp [IsBondMatchedPair, hf]
 
 /-- **The refinement Kraus family resolves the identity.** -/
 theorem refineKraus_resolution :
@@ -348,23 +348,23 @@ lemma refineKraus_conj_term (f₁ f₂ ε : Fin 2) (Y : Matrix (Fin 8) (Fin 8) �
     (i₁ i₂ j₁ j₂ : Fin 8) :
     (∑ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') *
         star (refineKraus f₁ f₂ ε (j₁, j₂) a')) =
-      if (gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂) ∧
-          (gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂) then
+      if (IsBondMatchedPair i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂) ∧
+          (IsBondMatchedPair j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂) then
         ((refineAmp ε ^ 2 * tau ε (bitR i₁) * tau ε (bitR j₁) : ℝ) : ℂ) *
           Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε))
             (physIdx (bitL j₁) (bitR j₂) (f₁ + f₂ + ε))
       else 0 := by
   have hinner : ∀ a' : Fin 8, (∑ a : Fin 8, refineKraus f₁ f₂ ε (i₁, i₂) a * Y a a') =
-      if gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂ then
+      if IsBondMatchedPair i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂ then
         ((refineAmp ε * tau ε (bitR i₁) : ℝ) : ℂ) *
           Y (physIdx (bitL i₁) (bitR i₂) (f₁ + f₂ + ε)) a' else 0 :=
     fun a' => refineKraus_col_sum f₁ f₂ ε (i₁, i₂) fun a => Y a a'
   rw [Finset.sum_congr rfl fun a' _ => by rw [hinner a']]
-  by_cases hi : gate i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂
+  by_cases hi : IsBondMatchedPair i₁ i₂ ∧ bitF i₁ = f₁ ∧ bitF i₂ = f₂
   · rw [Finset.sum_congr rfl fun a' _ => by
       rw [ite_eq_left hi, refineKraus_star, mul_comm]]
     rw [refineKraus_col_sum f₁ f₂ ε (j₁, j₂)]
-    by_cases hj : gate j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂
+    by_cases hj : IsBondMatchedPair j₁ j₂ ∧ bitF j₁ = f₁ ∧ bitF j₂ = f₂
     · rw [ite_eq_left hj, ite_eq_left ⟨hi, hj⟩]
       push_cast
       ring
@@ -387,12 +387,12 @@ theorem refineMap_physClose1 (X : Matrix (Fin 8) (Fin 8) ℂ) :
   simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
   rw [Finset.sum_congr rfl fun t _ =>
     refineKraus_conj_term t.1 t.2.1 t.2.2 (physClose1 T X) i₁ i₂ j₁ j₂]
-  by_cases hg : gate i₁ i₂ ∧ gate j₁ j₂
+  by_cases hg : IsBondMatchedPair i₁ i₂ ∧ IsBondMatchedPair j₁ j₂
   · rw [ite_eq_left hg]
     by_cases e : bitF i₁ = bitF j₁ ∧ bitF i₂ = bitF j₂
     · have hiff : ∀ t : Fin 2 × Fin 2 × Fin 2,
-          (((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
-            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) ↔
+          (((IsBondMatchedPair i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (IsBondMatchedPair j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) ↔
               (t.1 = bitF i₁ ∧ t.2.1 = bitF i₂)) := by
         intro t
         constructor
@@ -428,8 +428,8 @@ theorem refineMap_physClose1 (X : Matrix (Fin 8) (Fin 8) ℂ) :
       push_cast
       ring
     · have hzero : ∀ t : Fin 2 × Fin 2 × Fin 2,
-          ¬ ((gate i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
-            (gate j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) := by
+          ¬ ((IsBondMatchedPair i₁ i₂ ∧ bitF i₁ = t.1 ∧ bitF i₂ = t.2.1) ∧
+            (IsBondMatchedPair j₁ j₂ ∧ bitF j₁ = t.1 ∧ bitF j₂ = t.2.1)) := by
         rintro t ⟨⟨_, h1, h2⟩, _, h1', h2'⟩
         exact e ⟨h1.trans h1'.symm, h2.trans h2'.symm⟩
       rw [Finset.sum_congr rfl fun t _ => ite_eq_right (hzero t), Finset.sum_const_zero]

--- a/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerVerticalCF.lean
@@ -319,11 +319,11 @@ private lemma bitR_signWord (n : ℕ) (m : Fin (n + 1)) : bitR (signWord n m) = 
   refine Fin.cases ?_ (fun m => ?_) m <;> simp [signWord]
 
 private lemma isCyclicBondMatched_signWord (n : ℕ) : IsCyclicBondMatched (n + 1) (signWord n) :=
-  fun m => by rw [gate, bitR_signWord, bitL_signWord]
+  fun m => by rw [IsBondMatchedPair, bitR_signWord, bitL_signWord]
 
 private lemma isCyclicBondMatched_const (n : ℕ) :
     IsCyclicBondMatched (n + 1) fun _ : Fin (n + 1) => physIdx 0 0 0 :=
-  fun _ => by simp [gate]
+  fun _ => by simp [IsBondMatchedPair]
 
 /-- The sector matrix product vector on the doubled constant word of bond index
 $(0, 0, 0)$ is $(2/5)^{N}$. -/

--- a/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
+++ b/TNLean/MPS/MPDO/TwistedDimerViaTS.lean
@@ -116,8 +116,9 @@ lemma physClose2_T_fiber (X : Matrix (Fin 8) (Fin 8) ℂ) (L L' R R' f₁ f₂ b
       else 0 := by
   rw [physClose2_T]
   by_cases h : b₁ = b₂ ∧ c₁ = c₂
-  · rw [ite_eq_left (show gate (physIdx L b₁ f₁) (physIdx b₂ R f₂) ∧
-      gate (physIdx L' c₁ f₁) (physIdx c₂ R' f₂) from ⟨by simp [gate, h.1], by simp [gate, h.2]⟩),
+  · rw [ite_eq_left (show IsBondMatchedPair (physIdx L b₁ f₁) (physIdx b₂ R f₂) ∧
+      IsBondMatchedPair (physIdx L' c₁ f₁) (physIdx c₂ R' f₂) from
+        ⟨by simp [IsBondMatchedPair, h.1], by simp [IsBondMatchedPair, h.2]⟩),
       ite_eq_left h]
     refine Finset.sum_congr rfl fun k _ => ?_
     rw [coef_physIdx, coef_physIdx, ite_eq_left rfl, ite_eq_left rfl]
@@ -126,7 +127,8 @@ lemma physClose2_T_fiber (X : Matrix (Fin 8) (Fin 8) ℂ) (L L' R R' f₁ f₂ b
     ring
   · rw [ite_eq_right h]
     refine ite_eq_right fun hc => ?_
-    exact absurd ⟨by simpa [gate] using hc.1, by simpa [gate] using hc.2⟩ h
+    exact absurd
+      ⟨by simpa [IsBondMatchedPair] using hc.1, by simpa [IsBondMatchedPair] using hc.2⟩ h
 
 /-! ### The coarse-graining Kraus family -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -914,7 +914,7 @@
 \begin{theorem}[A candidate two-label coefficient family stable under every
         positive rescaling]%
     \label{thm:mpdo_twisted_dimer_two_label_rescaling_stable}
-    \lean{MPOTensor.TwistedDimer.sameChannel}
+    \lean{MPOTensor.TwistedDimer.IsSameChannel}
     \lean{MPOTensor.TwistedDimer.alpha}
     \lean{MPOTensor.TwistedDimer.beta}
     \lean{MPOTensor.TwistedDimer.twoLabelChi}

--- a/docs/audits/2026-09-03_twisted_dimer_predicate_renames.md
+++ b/docs/audits/2026-09-03_twisted_dimer_predicate_renames.md
@@ -1,0 +1,19 @@
+# Twisted-dimer predicate renames (issue #7622)
+
+Issue #7622 renamed the two remaining public predicates in the twisted-dimer example to follow
+the `Is`-prefix convention. Their definitions and every theorem statement using them are otherwise
+unchanged. No compatibility aliases are retained because TNLean does not promise a stable external
+Lean API.
+
+## Exact mapping
+
+| Old declaration | New declaration |
+|---|---|
+| `MPOTensor.TwistedDimer.gate` | `MPOTensor.TwistedDimer.IsBondMatchedPair` |
+| `MPOTensor.TwistedDimer.decidableGate` | `MPOTensor.TwistedDimer.decidableIsBondMatchedPair` |
+| `MPOTensor.TwistedDimer.sameChannel` | `MPOTensor.TwistedDimer.IsSameChannel` |
+| `MPOTensor.TwistedDimer.decidableSameChannel` | `MPOTensor.TwistedDimer.decidableIsSameChannel` |
+
+All non-`Archive` call sites and the affected Blueprint declaration tag were migrated to the new
+names. The glossary entry for the twisted-dimer predicate family now records the renamed
+predicates together with the four sibling predicates that already followed the convention.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -564,18 +564,24 @@ The following notions use different transfer objects and are not interchangeable
 
 ### Twisted-dimer matching and channel-support predicates
 
-- **Declarations:** `MPOTensor.TwistedDimer.IsOpenBondMatched` and
+- **Declarations:** `MPOTensor.TwistedDimer.IsBondMatchedPair` in
+  `TNLean/MPS/MPDO/TwistedDimer.lean`,
+  `MPOTensor.TwistedDimer.IsOpenBondMatched` and
   `MPOTensor.TwistedDimer.IsCyclicBondMatched` in
-  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean`, and
+  `TNLean/MPS/MPDO/TwistedDimerMPDO.lean`,
   `MPOTensor.TwistedDimer.IsRefineSupported` and
   `MPOTensor.TwistedDimer.IsCoarseSupported` in
   `TNLean/MPS/MPDO/TwistedDimerRefine.lean` and
-  `TNLean/MPS/MPDO/TwistedDimerViaTS.lean`.
-- **Meaning:** the first two predicates require consecutive physical letters to
-  match their right and left bond bits on an open segment or around a ring. The
-  latter two specify the matrix entries supporting the refinement and
+  `TNLean/MPS/MPDO/TwistedDimerViaTS.lean`, and
+  `MPOTensor.TwistedDimer.IsSameChannel` in
+  `TNLean/MPS/MPDO/TwistedDimerCoefficients.lean`.
+- **Meaning:** the first predicate requires one ordered pair of physical letters
+  to match the right bit of the first against the left bit of the second; the
+  next two quantify it over an open segment or around a ring. The two support
+  predicates specify the matrix entries carrying the refinement and
   coarse-graining Kraus operators, including their outer bits, site flags, and
-  decoded flag.
+  decoded flag. The last one selects the fusion channel $g = f + f'$ of two flag
+  labels against its complement.
 - **Source:** project-specific coordinate conditions for the twisted-dimer
   example. They support the explicit realization of CPSV16 Definition 4.1 but
   are not predicates stated in arXiv:1606.00608.


### PR DESCRIPTION
Closes #7622.

## What changed

Pure renaming; no mathematical content is added or removed.

| Old | New | Defined in |
|---|---|---|
| `MPOTensor.TwistedDimer.gate` | `MPOTensor.TwistedDimer.IsBondMatchedPair` | `TNLean/MPS/MPDO/TwistedDimer.lean` |
| `MPOTensor.TwistedDimer.decidableGate` | `MPOTensor.TwistedDimer.decidableIsBondMatchedPair` | `TNLean/MPS/MPDO/TwistedDimer.lean` |
| `MPOTensor.TwistedDimer.sameChannel` | `MPOTensor.TwistedDimer.IsSameChannel` | `TNLean/MPS/MPDO/TwistedDimerCoefficients.lean` |
| `MPOTensor.TwistedDimer.decidableSameChannel` | `MPOTensor.TwistedDimer.decidableIsSameChannel` | `TNLean/MPS/MPDO/TwistedDimerCoefficients.lean` |

### Why `IsBondMatchedPair` rather than `IsGate`

The issue offered either name. `IsGate` carries no mathematics: it names the
picture, not the condition. The two siblings that consume this predicate are
`IsOpenBondMatched σ := ∀ i, IsBondMatchedPair (σ i.castSucc) (σ i.succ)` and
`IsCyclicBondMatched N σ := ∀ n, IsBondMatchedPair (σ n) (σ (finRotate N n))`,
so naming the one-bond atom `IsBondMatchedPair` makes each of those definitions
read as its own English sentence — the open and cyclic conditions are the
pair condition quantified over a segment and over a ring. Its docstring now
says so explicitly.

`IsSameChannel` is the name the issue proposed and is used unchanged.

## Call sites updated

`TwistedDimer.lean`, `TwistedDimerMPDO.lean`, `TwistedDimerRefine.lean`,
`TwistedDimerViaTS.lean`, `TwistedDimerVerticalCF.lean`,
`TwistedDimerProductLaw.lean`, `TwistedDimerFlagSectors.lean`,
`TwistedDimerCoefficients.lean`, `TwistedDimerBNTAlgebraClause.lean`, the
`\lean{}` tag on `thm:mpdo_twisted_dimer_two_label_rescaling_stable` in
`blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex`, and the
twisted-dimer entry of `docs/glossary.md` (which now names all six predicates
of the family, not only the four renamed under #7614). English prose uses of
the word "gated"/"gate-restricted" are untouched — they are not identifiers.

Per `docs/CONTRIBUTING.md` §Mathematical-language renames, no
`@[deprecated] alias` is left behind: both are internal project predicates for
a project example, not paper-sourced terminology, and TNLean does not retain
dead compatibility aliases. The exact old-to-new declaration mapping is
recorded in
`docs/audits/2026-09-03_twisted_dimer_predicate_renames.md`.

## Sweep for the rest of the twisted-dimer API

`rg` over `TNLean/MPS/MPDO/TwistedDimer*.lean` finds exactly six public
`Prop`-valued definitions in `MPOTensor.TwistedDimer`. Four already carry the
prefix (`IsOpenBondMatched`, `IsCyclicBondMatched`, `IsRefineSupported`,
`IsCoarseSupported`); the two renamed here were the only remaining ones. The
twisted-dimer predicate API is therefore fully converted, which is the
follow-up the issue asked for.

Out of scope, reported rather than changed: `MPOTensor.RescalingStableLength\
DependentRFP.gate` in `TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean`
is a separate namespace for a different project example and carries the same
convention violation (about eighty call sites in that one file). It is not part
of the `TwistedDimer` API and folding it in would widen this diff well past the
issue's scope.

## Source

No source statement is involved: both predicates are project-specific
coordinate conditions for the twisted-dimer example, motivated by the
length-dependence question after Theorem 4.14 of arXiv:1606.00608 (lines
995--1010). The docstrings retain the "Project example; not from CPSV16."
marker used by the sibling predicates.

## Verification

- `scripts/lake_build_locked.sh` on all eleven `TNLean.MPS.MPDO.TwistedDimer*`
  modules: `Build completed successfully (9118 jobs)`, no warnings.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`:
  `Blueprint and Lean code are in sync`, 7845/7845 (100.0%).
- `lake exe checkdecls blueprint/lean_decls` after a full `lake build`.

No `sorry`, `admit`, `native_decide`, `axiom` or `unsafeCast` is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
