### PR TITLE
feat(MPS/Examples): construct the GHZ–blocked-cluster tensor

### DIFF
--- a/TNLean/MPS/Core/TensorProductSpan.lean
+++ b/TNLean/MPS/Core/TensorProductSpan.lean
@@ -29,6 +29,7 @@ arXiv:1606.00608, equation `II_CF1`, lines 214--245.
   image of the paired constituent spans.
 * `MPSTensor.isNBlkInjective_tensorProduct` preserves full homogeneous word
   spans at a common length.
+* `MPSTensor.isInjective_tensorProduct` preserves one-site injectivity.
 * `MPSTensor.isNormal_tensorProduct` preserves algebraic normality by using
   the common length `N_A * N_B`.
 
@@ -123,6 +124,15 @@ theorem isNBlkInjective_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
   exact LinearMap.range_eq_top.mpr
     ((kroneckerLinearEquiv (Fin D) (Fin D) (Fin E) (Fin E) ℂ).trans
       (Matrix.reindexLinearEquiv ℂ ℂ finProdFinEquiv finProdFinEquiv)).surjective
+
+/-- One-site injectivity is preserved by independent tensor products. -/
+theorem isInjective_tensorProduct (A : MPSTensor d D) (B : MPSTensor e E)
+    (hA : Kraus.IsInjective A) (hB : Kraus.IsInjective B) :
+    Kraus.IsInjective (tensorProduct A B) := by
+  rw [Kraus.IsInjective, ← Kraus.wordSpan_one]
+  exact isNBlkInjective_tensorProduct A B
+    (Kraus.isNBlkInjective_one_of_isInjective hA)
+    (Kraus.isNBlkInjective_one_of_isInjective hB)
 
 /-- Algebraic normality is preserved by independent tensor products.
 

--- a/TNLean/MPS/Examples.lean
+++ b/TNLean/MPS/Examples.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.Examples.AKLTStringOrder
 import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
+import TNLean.MPS.Examples.GHZCluster
 import TNLean.MPS.Examples.GHZParentHamiltonian
 import TNLean.MPS.Examples.MajumdarGhosh
 import TNLean.MPS.Examples.WState

--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -17,12 +17,14 @@ proves its key properties.
 ## Main definitions
 
 * `ghzTensor` : the GHZ MPS tensor with `A⁰ = |0⟩⟨0|` and `A¹ = |1⟩⟨1|`
+* `ghzSectorTensor` : either one-dimensional injective sector of the GHZ tensor
 * `z2PhysicalAction` : the Z₂ on-site representation via Pauli X
 
 ## Main results
 
 * `ghz_isTransferIdempotent` : the GHZ tensor is a renormalization fixed point
 * `ghz_not_isInjective` : the GHZ tensor is not injective
+* `ghzSectorTensor_isInjective` : each one-dimensional GHZ sector is injective
 * `ghz_isOnSiteSymmetric_Z2` : the GHZ tensor is on-site symmetric under Z₂
 * `ghz_virtual_Z2_symmetric` : the virtual Z₂ symmetry, with σz commuting with every
   GHZ matrix
@@ -57,6 +59,33 @@ def ghzTensor : MPSTensor 2 2 := fun i => Matrix.diagonal (Pi.single i 1)
 
 @[simp] lemma ghzTensor_apply (i : Fin 2) :
     ghzTensor i = Matrix.diagonal (Pi.single i 1) := rfl
+
+/-- The one-dimensional GHZ sector labeled by `x`. It is supported only at
+physical value `x`. -/
+def ghzSectorTensor (x : Fin 2) : MPSTensor 2 1 := fun p =>
+  if p = x then 1 else 0
+
+/-- The GHZ sector labeled by `x` equals the one-dimensional identity at `x`. -/
+@[simp] theorem ghzSectorTensor_apply_same (x : Fin 2) :
+    ghzSectorTensor x x = 1 := by
+  simp [ghzSectorTensor]
+
+/-- Every one-dimensional GHZ sector is injective. -/
+theorem ghzSectorTensor_isInjective (x : Fin 2) :
+    Kraus.IsInjective (ghzSectorTensor x) := by
+  rw [Kraus.IsInjective]
+  apply top_unique
+  intro M _
+  have hOne : (1 : Matrix (Fin 1) (Fin 1) ℂ) ∈
+      Submodule.span ℂ (Set.range (ghzSectorTensor x)) :=
+    Submodule.subset_span ⟨x, ghzSectorTensor_apply_same x⟩
+  have hM : M = M 0 0 • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
+    ext i j
+    fin_cases i
+    fin_cases j
+    simp
+  rw [hM]
+  exact Submodule.smul_mem _ _ hOne
 
 /-! ### Transfer map and RFP -/
 

--- a/TNLean/MPS/Examples/GHZCluster.lean
+++ b/TNLean/MPS/Examples/GHZCluster.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Core.BondReindex
 import TNLean.MPS.Core.TensorProductSpan
 import TNLean.MPS.Examples.Cluster
+import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.RFP.BNTOrthogonality
 
 /-!
@@ -16,9 +17,10 @@ cluster tensor.  It has physical dimension eight and bond dimension four.  Its
 two bond-dimension-two blocks are supported on disjoint values of the GHZ
 physical qubit.
 
-The construction formalizes arXiv:2502.20257, equation `eq:z4z2MPS` and lines
-4427--4481.  It stops before the Z4 × Z2 actions, action tensors, L-symbols,
-block-independence classification, fusion operators, and gauging.
+The construction formalizes arXiv:2502.20257, equation `eq:z4z2MPS`, the block
+formulas on lines 4448--4479, and line 4481, first sentence. It stops before the
+Z4 × Z2 actions, action tensors, L-symbols, block-independence classification,
+fusion operators, and gauging.
 
 ## Main definitions
 
@@ -33,7 +35,8 @@ block-independence classification, fusion operators, and gauging.
 * `z4z2GHZClusterBlock_isInjective` proves injectivity of both blocks.
 * `z4z2GHZClusterBlocks_isBNTLocallyOrthogonal` proves local orthogonality
   directly from disjoint GHZ support.
-* `z4z2GHZClusterDirectSum_eq` identifies the direct sum with the source tensor.
+* `z4z2GHZClusterDirectSum_eq_tensor` identifies the direct sum with the source
+  tensor.
 -/
 
 open scoped Matrix BigOperators Kronecker
@@ -48,37 +51,11 @@ the GHZ tensor tensored with the once-blocked cluster tensor. -/
 def z4z2GHZClusterTensor : MPSTensor 8 4 :=
   tensorProduct ghzTensor clusterBlocked
 
-/-- The one-dimensional GHZ sector labeled by `x`.  It is supported only at
-physical GHZ value `x`. -/
-def z4z2GHZSectorTensor (x : Fin 2) : MPSTensor 2 1 := fun p =>
-  if p = x then 1 else 0
-
-@[simp] theorem z4z2GHZSectorTensor_apply_same (x : Fin 2) :
-    z4z2GHZSectorTensor x x = 1 := by
-  simp [z4z2GHZSectorTensor]
-
-/-- Every one-dimensional GHZ sector is injective. -/
-theorem z4z2GHZSectorTensor_isInjective (x : Fin 2) :
-    Kraus.IsInjective (z4z2GHZSectorTensor x) := by
-  rw [Kraus.IsInjective]
-  apply top_unique
-  intro M _
-  have hOne : (1 : Matrix (Fin 1) (Fin 1) ℂ) ∈
-      Submodule.span ℂ (Set.range (z4z2GHZSectorTensor x)) :=
-    Submodule.subset_span ⟨x, z4z2GHZSectorTensor_apply_same x⟩
-  have hM : M = M 0 0 • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
-    ext i j
-    fin_cases i
-    fin_cases j
-    simp
-  rw [hM]
-  exact Submodule.smul_mem _ _ hOne
-
 /-- The block labeled by the GHZ value `x`, on the full eight-dimensional
 physical alphabet.  This is the product of the one-dimensional GHZ sector and
 the blocked cluster tensor. -/
 def z4z2GHZClusterBlock (x : Fin 2) : MPSTensor 8 2 :=
-  tensorProduct (z4z2GHZSectorTensor x) clusterBlocked
+  tensorProduct (ghzSectorTensor x) clusterBlocked
 
 private theorem finProdFinEquiv_zero_two (a : Fin 2) :
     finProdFinEquiv ((0 : Fin 1), a) = a := by
@@ -90,22 +67,23 @@ $A^{(x),(p,q)} = \delta_{x,p} C^q$. -/
     z4z2GHZClusterBlock x (finProdFinEquiv (p, q)) =
       if p = x then clusterBlocked q else 0 := by
   ext a b
-  have h := tensorProduct_apply (z4z2GHZSectorTensor x) clusterBlocked p q 0 0 a b
+  have h := tensorProduct_apply (ghzSectorTensor x) clusterBlocked p q 0 0 a b
   rw [finProdFinEquiv_zero_two, finProdFinEquiv_zero_two] at h
   by_cases hpx : p = x <;>
-    simpa [z4z2GHZClusterBlock, z4z2GHZSectorTensor, hpx] using h
+    simpa [z4z2GHZClusterBlock, ghzSectorTensor, hpx] using h
 
 /-- Each of the two GHZ-cluster blocks is injective.  This is the tensor-product
 injectivity theorem applied to a one-dimensional GHZ sector and the existing
 injective blocked cluster tensor. -/
 theorem z4z2GHZClusterBlock_isInjective (x : Fin 2) :
     Kraus.IsInjective (z4z2GHZClusterBlock x) :=
-  isInjective_tensorProduct _ _ (z4z2GHZSectorTensor_isInjective x)
+  isInjective_tensorProduct _ _ (ghzSectorTensor_isInjective x)
     clusterBlocked_isInjective
 
 /-- The two blocks are locally orthogonal because their GHZ physical supports
 are disjoint.  The proof is the direct termwise mixed-map calculation described
-at arXiv:2502.20257, line 4481; it uses no renormalization-group limit. -/
+at arXiv:2502.20257, line 4481, first sentence; it uses no
+renormalization-group limit. -/
 theorem z4z2GHZClusterBlocks_isBNTLocallyOrthogonal :
     IsBNTLocallyOrthogonal (dim := fun _ : Fin 2 => 2) z4z2GHZClusterBlock := by
   intro x y hxy
@@ -172,8 +150,9 @@ private theorem z4z2GHZClusterDirectSum_apply (p x y : Fin 2) (q : Fin 4)
 /-- The canonical direct sum of the two injective blocks is the GHZ tensor
 product with the blocked cluster tensor.  The equality compares the
 `finSigmaFinEquiv` direct-sum coordinates with the `finProdFinEquiv`
-tensor-product coordinates, as in arXiv:2502.20257, lines 4427--4481. -/
-theorem z4z2GHZClusterDirectSum_eq :
+tensor-product coordinates from arXiv:2502.20257, equation `eq:z4z2MPS`
+and lines 4448--4479. -/
+theorem z4z2GHZClusterDirectSum_eq_tensor :
     z4z2GHZClusterDirectSum = z4z2GHZClusterTensor := by
   ext i c d
   obtain ⟨⟨p, q⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 4)).surjective i

--- a/TNLean/MPS/Examples/GHZCluster.lean
+++ b/TNLean/MPS/Examples/GHZCluster.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.BondReindex
+import TNLean.MPS.Core.TensorProductSpan
+import TNLean.MPS.Examples.Cluster
+import TNLean.MPS.RFP.BNTOrthogonality
+
+/-!
+# The Z4 × Z2 GHZ-cluster tensor
+
+This module constructs the tensor product of the GHZ tensor with the once-blocked
+cluster tensor.  It has physical dimension eight and bond dimension four.  Its
+two bond-dimension-two blocks are supported on disjoint values of the GHZ
+physical qubit.
+
+The construction formalizes arXiv:2502.20257, equation `eq:z4z2MPS` and lines
+4427--4481.  It stops before the Z4 × Z2 actions, action tensors, L-symbols,
+block-independence classification, fusion operators, and gauging.
+
+## Main definitions
+
+* `z4z2GHZClusterTensor` is the GHZ tensor product with the blocked cluster tensor.
+* `z4z2GHZClusterBlock` is either one of its two injective blocks.
+* `z4z2GHZClusterDirectSum` is their canonical block-diagonal direct sum.
+
+## Main results
+
+* `z4z2GHZClusterBlock_apply` is the formula
+  $A^{(x),(p,q)} = \delta_{x,p} C^q$.
+* `z4z2GHZClusterBlock_isInjective` proves injectivity of both blocks.
+* `z4z2GHZClusterBlocks_isBNTLocallyOrthogonal` proves local orthogonality
+  directly from disjoint GHZ support.
+* `z4z2GHZClusterDirectSum_eq` identifies the direct sum with the source tensor.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix Finset
+
+noncomputable section
+
+namespace MPSTensor
+
+/-- The Z4 × Z2 example tensor from arXiv:2502.20257, equation `eq:z4z2MPS`:
+the GHZ tensor tensored with the once-blocked cluster tensor. -/
+def z4z2GHZClusterTensor : MPSTensor 8 4 :=
+  tensorProduct ghzTensor clusterBlocked
+
+/-- The one-dimensional GHZ sector labeled by `x`.  It is supported only at
+physical GHZ value `x`. -/
+def z4z2GHZSectorTensor (x : Fin 2) : MPSTensor 2 1 := fun p =>
+  if p = x then 1 else 0
+
+@[simp] theorem z4z2GHZSectorTensor_apply_same (x : Fin 2) :
+    z4z2GHZSectorTensor x x = 1 := by
+  simp [z4z2GHZSectorTensor]
+
+/-- Every one-dimensional GHZ sector is injective. -/
+theorem z4z2GHZSectorTensor_isInjective (x : Fin 2) :
+    Kraus.IsInjective (z4z2GHZSectorTensor x) := by
+  rw [Kraus.IsInjective]
+  apply top_unique
+  intro M _
+  have hOne : (1 : Matrix (Fin 1) (Fin 1) ℂ) ∈
+      Submodule.span ℂ (Set.range (z4z2GHZSectorTensor x)) :=
+    Submodule.subset_span ⟨x, z4z2GHZSectorTensor_apply_same x⟩
+  have hM : M = M 0 0 • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
+    ext i j
+    fin_cases i
+    fin_cases j
+    simp
+  rw [hM]
+  exact Submodule.smul_mem _ _ hOne
+
+/-- The block labeled by the GHZ value `x`, on the full eight-dimensional
+physical alphabet.  This is the product of the one-dimensional GHZ sector and
+the blocked cluster tensor. -/
+def z4z2GHZClusterBlock (x : Fin 2) : MPSTensor 8 2 :=
+  tensorProduct (z4z2GHZSectorTensor x) clusterBlocked
+
+private theorem finProdFinEquiv_zero_two (a : Fin 2) :
+    finProdFinEquiv ((0 : Fin 1), a) = a := by
+  rfl
+
+/-- Exact block formula from arXiv:2502.20257, lines 4448--4479:
+$A^{(x),(p,q)} = \delta_{x,p} C^q$. -/
+@[simp] theorem z4z2GHZClusterBlock_apply (x p : Fin 2) (q : Fin 4) :
+    z4z2GHZClusterBlock x (finProdFinEquiv (p, q)) =
+      if p = x then clusterBlocked q else 0 := by
+  ext a b
+  have h := tensorProduct_apply (z4z2GHZSectorTensor x) clusterBlocked p q 0 0 a b
+  rw [finProdFinEquiv_zero_two, finProdFinEquiv_zero_two] at h
+  by_cases hpx : p = x <;>
+    simpa [z4z2GHZClusterBlock, z4z2GHZSectorTensor, hpx] using h
+
+/-- Each of the two GHZ-cluster blocks is injective.  This is the tensor-product
+injectivity theorem applied to a one-dimensional GHZ sector and the existing
+injective blocked cluster tensor. -/
+theorem z4z2GHZClusterBlock_isInjective (x : Fin 2) :
+    Kraus.IsInjective (z4z2GHZClusterBlock x) :=
+  isInjective_tensorProduct _ _ (z4z2GHZSectorTensor_isInjective x)
+    clusterBlocked_isInjective
+
+/-- The two blocks are locally orthogonal because their GHZ physical supports
+are disjoint.  The proof is the direct termwise mixed-map calculation described
+at arXiv:2502.20257, line 4481; it uses no renormalization-group limit. -/
+theorem z4z2GHZClusterBlocks_isBNTLocallyOrthogonal :
+    IsBNTLocallyOrthogonal (dim := fun _ : Fin 2 => 2) z4z2GHZClusterBlock := by
+  intro x y hxy
+  ext X a b
+  rw [Kraus.mixedMapLM_apply, Matrix.sum_apply]
+  simp only [LinearMap.zero_apply, Matrix.zero_apply]
+  apply Finset.sum_eq_zero
+  intro i _
+  obtain ⟨⟨p, q⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 4)).surjective i
+  rw [z4z2GHZClusterBlock_apply, z4z2GHZClusterBlock_apply]
+  by_cases hpx : p = x
+  · subst p
+    simp [hxy]
+  · simp [hpx]
+
+private theorem z4z2GHZCluster_totalDim :
+    (∑ _ : Fin 2, 2) = 4 := by
+  decide
+
+/-- The canonical direct sum of the two GHZ-cluster blocks, using
+`finSigmaFinEquiv` internally and then the canonical equality of its total bond
+dimension with four. -/
+def z4z2GHZClusterDirectSum : MPSTensor 8 4 :=
+  reindex z4z2GHZCluster_totalDim
+    (directSumTensor (dim := fun _ : Fin 2 => 2) z4z2GHZClusterBlock)
+
+private theorem z4z2GHZCluster_bondCoordinate (x a : Fin 2) :
+    finCongr z4z2GHZCluster_totalDim.symm (finProdFinEquiv (x, a)) =
+      finSigmaFinEquiv ⟨x, a⟩ := by
+  apply Fin.ext
+  fin_cases x
+  · simp [finSigmaFinEquiv_apply, finProdFinEquiv]
+  · simp [finSigmaFinEquiv_apply, finProdFinEquiv]
+    omega
+
+private theorem z4z2GHZClusterTensor_apply (p x y : Fin 2) (q : Fin 4)
+    (a b : Fin 2) :
+    z4z2GHZClusterTensor (finProdFinEquiv (p, q))
+        (finProdFinEquiv (x, a)) (finProdFinEquiv (y, b)) =
+      if x = y then if p = x then clusterBlocked q a b else 0 else 0 := by
+  rw [z4z2GHZClusterTensor, tensorProduct_apply]
+  simp only [ghzTensor_apply, Matrix.diagonal_apply, Pi.single_apply]
+  by_cases hxy : x = y
+  · subst y
+    simp [eq_comm]
+  · simp [hxy]
+
+private theorem z4z2GHZClusterDirectSum_apply (p x y : Fin 2) (q : Fin 4)
+    (a b : Fin 2) :
+    z4z2GHZClusterDirectSum (finProdFinEquiv (p, q))
+        (finProdFinEquiv (x, a)) (finProdFinEquiv (y, b)) =
+      if x = y then if p = x then clusterBlocked q a b else 0 else 0 := by
+  rw [z4z2GHZClusterDirectSum, reindex_apply_apply,
+    z4z2GHZCluster_bondCoordinate, z4z2GHZCluster_bondCoordinate]
+  simp only [directSumTensor, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.symm_apply_apply]
+  by_cases hxy : x = y
+  · subst y
+    rw [Matrix.blockDiagonal'_apply_eq, z4z2GHZClusterBlock_apply]
+    by_cases hpx : p = x <;> simp [hpx]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hxy]
+    simp [hxy]
+
+/-- The canonical direct sum of the two injective blocks is the GHZ tensor
+product with the blocked cluster tensor.  The equality compares the
+`finSigmaFinEquiv` direct-sum coordinates with the `finProdFinEquiv`
+tensor-product coordinates, as in arXiv:2502.20257, lines 4427--4481. -/
+theorem z4z2GHZClusterDirectSum_eq :
+    z4z2GHZClusterDirectSum = z4z2GHZClusterTensor := by
+  ext i c d
+  obtain ⟨⟨p, q⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 4)).surjective i
+  obtain ⟨⟨x, a⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective c
+  obtain ⟨⟨y, b⟩, rfl⟩ := (finProdFinEquiv (m := 2) (n := 2)).surjective d
+  rw [z4z2GHZClusterDirectSum_apply, z4z2GHZClusterTensor_apply]
+
+end MPSTensor


### PR DESCRIPTION
## What changed

- add the reusable one-dimensional GHZ sector tensor and prove its elementary support and injectivity properties
- prove that tensor products of one-site injective matrix families are one-site injective
- construct the physical-dimension-8, bond-dimension-4 GHZ–blocked-cluster tensor from Eq. `eq:z4z2MPS`
- define its two bond-dimension-2 blocks, prove the exact formula
  \[
  A_x^{(p,q)}=\delta_{p,x}C^q,
  \]
  prove block injectivity and local orthogonality, and identify their canonical direct sum with the product tensor after the canonical bond reindexing

This slice stops before the $\mathbb Z_4\times\mathbb Z_2$ action, action tensors, L-symbols, block-independence classification, modified fusion operators, and Gauss projectors. Chapter 29 integration is deferred while active PR #7691 owns that file, as required by the issue's non-overlap condition.

## Validation

- exact warm-cache rebase on `origin/main` `9adba47289e420331f6845330c383c12a1983910`
- `scripts/lake_build_locked.sh TNLean.MPS.Examples.GHZ TNLean.MPS.Examples.GHZCluster TNLean.MPS.Examples` (8957 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `lake exe lint_style`
- proof-integrity and source-faithfulness review at implementation commit `e58eb965c`, followed by the requested API placement, direct-import, naming, and source-anchor fixes in `d33b0d426`
- `git diff --check origin/main...HEAD`

Closes #7667.
Advances #7352.
