### PR TITLE
feat(MPS/MPDO): reverse products under physical adjoint

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.OperatorProduct
 
 /-!
 # Physical adjoint of an MPO tensor
@@ -16,10 +16,14 @@ proves the corresponding word and periodic-operator identities.
 
 * `MPOTensor.bondPairSwap` — exchange of the two doubled virtual-bond indices.
 * `MPOTensor.bondPairSwapEquiv` — the corresponding doubled-bond equivalence.
+* `MPOTensor.productBondSwapEquiv` — exchange of two possibly unequal product-bond factors.
+* `MPOTensor.reindexBond` — transport of an MPO tensor along a bond equivalence.
 * `MPOTensor.physicalAdjointTensor` — physical adjoint without virtual reflection.
 
 ## Main results
 
+* `MPOTensor.physicalAdjointTensor_mulTensor` — the physical adjoint reverses a product after
+  exchanging the two product-bond factors.
 * `MPOTensor.evalWord_physicalAdjointTensor` — word evaluation under physical adjoint.
 * `MPOTensor.mpo_physicalAdjointTensor` — the periodic family is conjugate-transposed.
 -/
@@ -64,6 +68,45 @@ def bondPairSwapEquiv (D : ℕ) : Fin (D * D) ≃ Fin (D * D) where
     (bondPairSwapEquiv D).symm = bondPairSwapEquiv D := by
   rfl
 
+/-- The canonical equivalence exchanging two possibly unequal factors of a product bond.
+An index encoding `(a, b)` in `Fin (D₁ * D₂)` is sent to the index encoding `(b, a)` in
+`Fin (D₂ * D₁)`. -/
+def productBondSwapEquiv (D₁ D₂ : ℕ) : Fin (D₁ * D₂) ≃ Fin (D₂ * D₁) :=
+  finProdFinEquiv.symm |>.trans
+    ((Equiv.prodComm (Fin D₁) (Fin D₂)).trans finProdFinEquiv)
+
+@[simp] theorem productBondSwapEquiv_finProdFinEquiv {D₁ D₂ : ℕ}
+    (a : Fin D₁) (b : Fin D₂) :
+    productBondSwapEquiv D₁ D₂ (finProdFinEquiv (a, b)) =
+      finProdFinEquiv (b, a) := by
+  simp [productBondSwapEquiv]
+
+@[simp] theorem productBondSwapEquiv_symm (D₁ D₂ : ℕ) :
+    (productBondSwapEquiv D₁ D₂).symm = productBondSwapEquiv D₂ D₁ := by
+  apply Equiv.ext
+  intro x
+  apply (productBondSwapEquiv D₁ D₂).injective
+  rcases finProdFinEquiv.surjective x with ⟨⟨a, b⟩, rfl⟩
+  simp
+
+/-- For equal factor dimensions, the heterogeneous product-bond swap agrees with the
+established doubled-bond swap. -/
+theorem productBondSwapEquiv_self (D : ℕ) :
+    productBondSwapEquiv D D = bondPairSwapEquiv D := by
+  ext x
+  rw [show x = finProdFinEquiv (x.divNat, x.modNat) by
+    exact (finProdFinEquiv.apply_symm_apply x).symm]
+  simp
+
+/-- Transport both virtual indices of an MPO tensor along a bond-space equivalence. -/
+def reindexBond {D D' : ℕ} (e : Fin D' ≃ Fin D) (K : MPOTensor d D) :
+    MPOTensor d D' :=
+  fun i j a b ↦ K i j (e a) (e b)
+
+@[simp] theorem reindexBond_apply {D D' : ℕ} (e : Fin D' ≃ Fin D)
+    (K : MPOTensor d D) (i j : Fin d) (a b : Fin D') :
+    reindexBond e K i j a b = K i j (e a) (e b) := rfl
+
 /-- The physical adjoint of an MPO tensor swaps its ket and bra indices and conjugates each
 virtual matrix entry, without transposing the virtual indices:
 $$(K^\sharp)^{ij}_{\beta\alpha} = \overline{K^{ji}_{\beta\alpha}}.$$
@@ -80,6 +123,33 @@ def physicalAdjointTensor (K : MPOTensor d D) : MPOTensor d D :=
 @[simp] theorem physicalAdjointTensor_apply (K : MPOTensor d D)
     (i j : Fin d) (β α : Fin D) :
     physicalAdjointTensor K i j β α = star (K j i β α) := rfl
+
+/-- The physical adjoint reverses the order of an MPO tensor product. Since `mulTensor U V`
+has bond coordinates ordered as `Fin D₁ × Fin D₂`, while the reversed product has coordinates
+ordered as `Fin D₂ × Fin D₁`, the right-hand side is transported by `productBondSwapEquiv`:
+$$(U V)^\dagger = V^\dagger U^\dagger.$$
+
+This is the local product-adjoint identity used when taking the dagger of the fusion equations
+in the proof of Proposition `prop:zetas` of arXiv:2502.20257, lines 1662--1677. -/
+theorem physicalAdjointTensor_mulTensor {D₁ D₂ : ℕ}
+    (U : MPOTensor d D₁) (V : MPOTensor d D₂) :
+    physicalAdjointTensor (mulTensor U V) =
+      reindexBond (productBondSwapEquiv D₁ D₂)
+        (mulTensor (physicalAdjointTensor V) (physicalAdjointTensor U)) := by
+  classical
+  ext i k x y
+  simp only [physicalAdjointTensor_apply, mulTensor_apply, reindexBond_apply,
+    Matrix.submatrix_apply, Matrix.sum_apply, Matrix.kroneckerMap_apply]
+  rcases hx : finProdFinEquiv.symm x with ⟨x₁, x₂⟩
+  rcases hy : finProdFinEquiv.symm y with ⟨y₁, y₂⟩
+  simp only [productBondSwapEquiv, Equiv.trans_apply, Equiv.prodComm_apply,
+    Equiv.symm_apply_apply, hx, hy, Prod.swap_prod_mk]
+  calc
+    star (∑ j, U k j x₁ y₁ * V j i x₂ y₂) =
+        ∑ j, star (U k j x₁ y₁ * V j i x₂ y₂) := by
+      exact star_sum Finset.univ _
+    _ = ∑ j, star (V j i x₂ y₂) * star (U k j x₁ y₁) := by
+      exact Finset.sum_congr rfl fun j _ ↦ star_mul _ _
 
 /-- Physical slices of the physical adjoint are the conjugate transposes of the original
 physical slices.  Only physical indices are transposed.

--- a/TNLean/MPS/MPU/CompositionRanks.lean
+++ b/TNLean/MPS/MPU/CompositionRanks.lean
@@ -336,10 +336,6 @@ private theorem rightRank_blockTwo_mulTensor_blockTwo_le
       Matrix.rank_le_card_width _
     _ = d ^ 2 * r[U] * r[V] := by simp [pow_two]; ring
 
-private def reindexBond {D' : ℕ} (e : Fin D' ≃ Fin D₁) (U : MPOTensor d D₁) :
-    MPOTensor d D' :=
-  fun i j a b => U i j (e a) (e b)
-
 private theorem rightRank_reindexBond {D' : ℕ} (e : Fin D' ≃ Fin D₁)
     (U : MPOTensor d D₁) : r[reindexBond e U] = r[U] := by
   rw [rightRank]
@@ -356,10 +352,6 @@ private theorem reindexBond_blockTwo {D' : ℕ} (e : Fin D' ≃ Fin D₁)
   simp only [reindexBond, blockTwo_apply, Matrix.mul_apply]
   rw [← Equiv.sum_comp e]
 
-private def bondSwapEquiv (D₁ D₂ : ℕ) : Fin (D₂ * D₁) ≃ Fin (D₁ * D₂) :=
-  finProdFinEquiv.symm |>.trans
-    ((Equiv.prodComm (Fin D₂) (Fin D₁)).trans finProdFinEquiv)
-
 private def physicalFlip (U : MPOTensor d D₁) : MPOTensor d D₁ :=
   fun i j => U j i
 
@@ -375,10 +367,10 @@ private theorem blockTwo_physicalFlip (U : MPOTensor d D₁) :
 private theorem mulTensor_physicalFlip_swap
     (U : MPOTensor d D₁) (V : MPOTensor d D₂) :
     mulTensor (physicalFlip V) (physicalFlip U) =
-      reindexBond (bondSwapEquiv D₁ D₂) (physicalFlip (mulTensor U V)) := by
+      reindexBond (productBondSwapEquiv D₂ D₁) (physicalFlip (mulTensor U V)) := by
   classical
   ext i k x y
-  simp only [mulTensor_apply, physicalFlip, reindexBond, bondSwapEquiv,
+  simp only [mulTensor_apply, physicalFlip, reindexBond, productBondSwapEquiv,
     Equiv.trans_apply, Equiv.prodComm_apply, Equiv.symm_apply_apply,
     Matrix.submatrix_apply, Matrix.sum_apply, Matrix.kroneckerMap_apply]
   apply Finset.sum_congr rfl


### PR DESCRIPTION
## What changed

- add the canonical heterogeneous product-bond swap
  \[
  \operatorname{Fin}(D_1D_2)\simeq\operatorname{Fin}(D_2D_1)
  \]
  and prove its inverse and equal-dimension compatibility laws
- expose a public MPO bond-reindexing operation
- prove the source identity
  \[
  (UV)^\dagger=V^\dagger U^\dagger
  \]
  with the required bond-coordinate reindexing for arbitrary, potentially unequal bond dimensions
- replace the private duplicates in `CompositionRanks` by the public API

This is only the generic product/adjoint prerequisite from `Papers/2502.20257/main.tex:1662-1677`. The boundary-dressed fusion comparison remains under #7324. Chapter 29 integration is deferred while active PR #7691 owns that file; the prepared documentation patch is preserved locally and will be reconsidered after that PR settles.

## Validation

- exact warm-cache rebase on `origin/main` `9adba47289e420331f6845330c383c12a1983910`
- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.PhysicalAdjoint TNLean.MPS.MPU.CompositionRanks TNLean.MPS.MPU.DaggerInverse` (9044 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `lake exe lint_style`
- independent API and source-orientation review in execution `622b5ea36903`
- `git diff --check origin/main...HEAD`

Closes #7666.
Advances #7324.
