### PR TITLE
feat(MPS/Periodic): extract the blockwise phase-power relation from repeated blocks

### DIFF
--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -113,6 +113,55 @@ theorem GaugeEquiv.toHetRepeatedBlocks {D : ℕ} {A B : MPSTensor d D}
   HetRepeatedBlocks.of_repeatedBlocks
     ((equivalentBlocks_iff_gaugeEquiv.mpr h).to_repeatedBlocks)
 
+/-! ## Phase powers carried by a repeated-block relation -/
+
+/-- Two repeated blocks have proportional matrix-product vectors at every chain
+length, and the proportionality scalar at length `N` is the `N`-th power of a
+single unit-modulus phase.
+
+This is the matrix-product-vector reading of the repeated-block relation
+`A_j^i = e^{i ξ} Y B_k^i Y^{-1}`: the similarity drops out under the closed-chain
+trace, and each of the `N` sites contributes one factor of the phase. In
+particular, the proportionality scalar genuinely depends on the length; already
+the one-site tensors `B^0 = 1` and `A^0 = e^{i ξ}` have `V_N(A) = e^{i N ξ} V_N(B)`.
+
+Source: arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`,
+lines 276--284; the proportional statement compared at every length is the
+hypothesis of theorem `thm:bd`, lines 613--623. -/
+theorem HetRepeatedBlocks.exists_unit_phase_power_mpv {D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} (h : HetRepeatedBlocks A B) :
+    ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = ζ ^ N * mpv B σ := by
+  obtain ⟨hDim, ξ, Y, hξ, hGauge⟩ := h
+  refine ⟨ξ, hξ, fun N σ => ?_⟩
+  rw [← mpv_cast_dim hDim A N σ]
+  exact mpv_eq_pow_mul_of_gaugePhase B (cast (congr_arg (MPSTensor d) hDim) A) Y ξ hGauge N σ
+
+/-- The phase of a repeated-block relation can be absorbed into one of the two
+blocks: rescaling the first block by the reciprocal phase makes the two
+matrix-product-vector families equal at every positive chain length.
+
+Source: arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`, lines
+276--284; the absorption of a repeated-block phase into the multiplicities is
+used at lines 302--305 and again in the proof of theorem `thm:bdequal`, lines
+667--671.
+
+**Scope restriction (blockwise phase):** the phase produced here belongs to one
+matched pair of basis tensors. Distinct matched pairs may carry distinct phases,
+so no single phase is asserted for the assembled tensors of lines 286--305; see
+`docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`. -/
+theorem HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos {D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} (h : HetRepeatedBlocks A B) :
+    ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂Pos (fun i => ξ • A i) B := by
+  obtain ⟨ζ, hζ, hmpv⟩ := h.exists_unit_phase_power_mpv
+  have hζ0 : ζ ≠ 0 := by
+    intro h0
+    rw [h0, norm_zero] at hζ
+    exact zero_ne_one hζ
+  refine ⟨ζ⁻¹, by rw [norm_inv, hζ, inv_one], fun N _hN σ => ?_⟩
+  have hscale : mpv (fun i => ζ⁻¹ • A i) σ = ζ⁻¹ ^ N * mpv A σ :=
+    mpv_eq_pow_mul_of_gaugePhase A (fun i => ζ⁻¹ • A i) 1 ζ⁻¹ (fun i => by simp) N σ
+  rw [hscale, hmpv N σ, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]
+
 /-! ## Periodic block matching witness -/
 
 /-- Witness for periodic block matching: equal block counts, a bijection, and per-block

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Periodic.Overlap
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.SharedInfra.Scaling
+import TNLean.MPS.Tactic.Basic
 
 /-!
 # Components of the periodic Fundamental Theorem of MPS
@@ -153,11 +154,9 @@ theorem HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos {D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} (h : HetRepeatedBlocks A B) :
     ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂Pos (fun i => ξ • A i) B := by
   obtain ⟨ζ, hζ, hmpv⟩ := h.exists_unit_phase_power_mpv
-  have hζ0 : ζ ≠ 0 := by
-    intro h0
-    rw [h0, norm_zero] at hζ
-    exact zero_ne_one hζ
-  refine ⟨ζ⁻¹, by rw [norm_inv, hζ, inv_one], fun N _hN σ => ?_⟩
+  have hζ0 : ζ ≠ 0 := Complex.ne_zero_of_norm_eq_one hζ
+  refine ⟨ζ⁻¹, by rw [norm_inv, hζ, inv_one], ?_⟩
+  mpv_ext
   have hscale : mpv (fun i => ζ⁻¹ • A i) σ = ζ⁻¹ ^ N * mpv A σ :=
     mpv_eq_pow_mul_of_gaugePhase A (fun i => ζ⁻¹ • A i) 1 ζ⁻¹ (fun i => by simp) N σ
   rw [hscale, hmpv N σ, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -52,15 +52,13 @@ private lemma mpvState_eq_smul_of_hetRepeatedBlocks
     (hRep : HetRepeatedBlocks A B) :
     ∃ α : ℕ → ℂ, ∀ N : ℕ, mpvState (d := d) A N = α N • mpvState (d := d) B N := by
   classical
-  rcases hRep with ⟨hDim, ξ, Y, _hξ, hGauge⟩
+  obtain ⟨ξ, _hξ, hmpv⟩ := hRep.exists_unit_phase_power_mpv
   refine ⟨fun N : ℕ => ξ ^ N, ?_⟩
   intro N
   apply PiLp.ext
   intro σ
   simp only [mpvState_apply]
-  rw [← mpv_cast_dim hDim A N σ]
-  exact mpv_eq_pow_mul_of_gaugePhase B
-    (cast (congr_arg (MPSTensor d) hDim) A) Y ξ hGauge N σ
+  exact hmpv N σ
 
 /-- A chosen block has a non-decaying overlap partner when two tensors with
 the prescribed periodic-basis expansions are projectively proportional.

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -400,6 +400,56 @@
     Invert the pure gauge and take the repeated-block phase to be one.
 \end{proof}
 
+\begin{lemma}[Repeated blocks scale their vectors by a phase power]
+    \label{lem:repeated_blocks_phase_power_mpv}
+    \lean{MPSTensor.HetRepeatedBlocks.exists_unit_phase_power_mpv}
+    \leanok
+    Let $A$ and $B$ be repeated blocks.  Then there is a scalar $\zeta$ with
+    $|\zeta|=1$ such that, for every length $N$,
+    \begin{align}
+        \ket{V^{(N)}(A)}=\zeta^{N}\ket{V^{(N)}(B)}.
+        \notag
+    \end{align}
+    The proportionality scalar therefore depends on the length.  Already the
+    one-dimensional blocks with a single physical index, $B^0=1$ and
+    $A^0=\zeta$, satisfy $\ket{V^{(N)}(A)}=\zeta^{N}\ket{V^{(N)}(B)}$, so no
+    scalar independent of the length works unless $\zeta=1$.
+\end{lemma}
+\begin{proof}
+    \uses{thm:gauge_phase_mpv_scaling}
+    \leanok
+    Write $A^i=\zeta YB^iY^{-1}$ with $|\zeta|=1$.  A closed chain of length
+    $N$ is the trace of a product of $N$ such factors.  The neighbouring
+    similarities cancel and the trace is invariant under the outer
+    conjugation, while each site contributes one factor $\zeta$.
+\end{proof}
+
+\begin{lemma}[Absorbing the phase of a repeated-block relation]
+    \label{lem:repeated_blocks_phase_absorption}
+    \lean{MPSTensor.HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos}
+    \leanok
+    Let $A$ and $B$ be repeated blocks.  Then there is a scalar $\xi$ with
+    $|\xi|=1$ such that $\xi A$ and $B$ generate the same vector at every
+    positive length,
+    \begin{align}
+        \ket{V^{(N)}(\xi A)}=\ket{V^{(N)}(B)},
+        \qquad N\geq1.
+        \notag
+    \end{align}
+    The phase belongs to the matched pair $A,B$; distinct matched pairs of two
+    bases of periodic tensors may require distinct phases, so no single phase
+    is asserted for the assembled tensors
+    \cite[lines~286--305, 625--627]{DeLasCuevas2017Irreducible}.
+\end{lemma}
+\begin{proof}
+    \uses{lem:repeated_blocks_phase_power_mpv, thm:gauge_phase_mpv_scaling}
+    \leanok
+    Take $\xi$ to be the reciprocal of the phase of the preceding lemma, which
+    is nonzero because it has modulus one.  Rescaling every matrix of a block
+    by $\xi$ multiplies its length-$N$ vector by $\xi^{N}$, and the two powers
+    cancel.
+\end{proof}
+
 \begin{lemma}[Pure similarities preserve periodic overlap hypotheses]
     \label{lem:periodic_overlap_hypothesis_gauge_transport}
     \lean{MPSTensor.PeriodicOverlapHypothesis.of_gaugeEquiv}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -400,8 +400,8 @@
     Invert the pure gauge and take the repeated-block phase to be one.
 \end{proof}
 
-\begin{lemma}[Repeated blocks scale their vectors by a phase power]
-    \label{lem:repeated_blocks_phase_power_mpv}
+\begin{theorem}[Repeated blocks scale their vectors by a phase power]
+    \label{thm:repeated_blocks_phase_power_mpv}
     \lean{MPSTensor.HetRepeatedBlocks.exists_unit_phase_power_mpv}
     \leanok
     Let $A$ and $B$ be repeated blocks.  Then there is a scalar $\zeta$ with
@@ -414,7 +414,7 @@
     one-dimensional blocks with a single physical index, $B^0=1$ and
     $A^0=\zeta$, satisfy $\ket{V^{(N)}(A)}=\zeta^{N}\ket{V^{(N)}(B)}$, so no
     scalar independent of the length works unless $\zeta=1$.
-\end{lemma}
+\end{theorem}
 \begin{proof}
     \uses{thm:gauge_phase_mpv_scaling}
     \leanok
@@ -424,27 +424,26 @@
     conjugation, while each site contributes one factor $\zeta$.
 \end{proof}
 
-\begin{lemma}[Absorbing the phase of a repeated-block relation]
-    \label{lem:repeated_blocks_phase_absorption}
+\begin{theorem}[Absorbing the phase of a repeated-block relation]
+    \label{thm:repeated_blocks_phase_absorption}
     \lean{MPSTensor.HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos}
     \leanok
     Let $A$ and $B$ be repeated blocks.  Then there is a scalar $\xi$ with
     $|\xi|=1$ such that $\xi A$ and $B$ generate the same vector at every
     positive length,
     \begin{align}
-        \ket{V^{(N)}(\xi A)}=\ket{V^{(N)}(B)},
-        \qquad N\geq1.
+        \ket{V^{(N)}(\xi A)}=\ket{V^{(N)}(B)}.
         \notag
     \end{align}
     The phase belongs to the matched pair $A,B$; distinct matched pairs of two
     bases of periodic tensors may require distinct phases, so no single phase
     is asserted for the assembled tensors
     \cite[lines~286--305, 625--627]{DeLasCuevas2017Irreducible}.
-\end{lemma}
+\end{theorem}
 \begin{proof}
-    \uses{lem:repeated_blocks_phase_power_mpv, thm:gauge_phase_mpv_scaling}
+    \uses{thm:repeated_blocks_phase_power_mpv, thm:gauge_phase_mpv_scaling}
     \leanok
-    Take $\xi$ to be the reciprocal of the phase of the preceding lemma, which
+    Take $\xi$ to be the reciprocal of the phase of the preceding theorem, which
     is nonzero because it has modulus one.  Rescaling every matrix of a block
     by $\xi$ multiplies its length-$N$ vector by $\xi^{N}$, and the two powers
     cancel.

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -601,6 +601,58 @@ irreducible-form theorem to arbitrary input tensors through Proposition~2.1
 requires the positive-length, possibly lower-dimensional comparison at lines
 266--271 of the same source. That extension is not part of Theorem~3.4.
 
+\subsection{Per-length proportionality and the blockwise phase}
+
+The hypothesis of Theorem~3.4, lines 613--623, of
+Ref.~\cite{DeLasCuevas2017Irreducible} is projective proportionality separately
+at each positive length:
+\begin{align}
+    \forall N\geq1,\ \exists c_N\neq0,\qquad
+    \ket{V_N(A)}
+    &=c_N\ket{V_N(B)}.
+    \label{eq:dccsp17_periodic_overlap_route_alignment_per_length_proportionality}
+\end{align}
+No scalar independent of $N$ is assumed, and none may be introduced. The
+one-dimensional blocks $B^0=1$ and $A^0=e^{i\theta}$ satisfy
+\begin{align}
+    \ket{V_N(A)}
+    &=e^{iN\theta}\ket{V_N(B)},
+    \label{eq:dccsp17_periodic_overlap_route_alignment_phase_power_example}
+\end{align}
+so a length-independent scalar is false unless the phase is trivial. The
+formal statements accordingly quantify the scalar over the length, and the
+repeated-block consequence records the scalar in the exponential form
+\begin{align}
+    \ket{V_N(A_j)}
+    &=\zeta_j^{\,N}\ket{V_N(B_{\pi(j)})},
+    \qquad|\zeta_j|=1,
+    \label{eq:dccsp17_periodic_overlap_route_alignment_blockwise_phase_power}
+\end{align}
+which follows from the repeated-block relation \emph{eq:rep}, lines 276--284,
+by cancelling the similarity inside the closed-chain trace.\footnote{Formal
+declaration:
+\leanid{MPSTensor.HetRepeatedBlocks.exists_unit_phase_power_mpv}.}
+
+The conclusion of Theorem~3.4 is blockwise. Each matched pair carries its own
+phase $\xi_j$ in
+\begin{align}
+    A_j^i
+    &=e^{i\xi_j}Y_jB_{\pi(j)}^iY_j^{-1},
+    \label{eq:dccsp17_periodic_overlap_route_alignment_blockwise_relation}
+\end{align}
+and distinct matched pairs may carry distinct phases. The source states at
+lines 625--627 that the theorem relates only the bases of periodic tensors and
+not the assembled tensors themselves, so no single phase for the assembled
+tensors is available at this stage. The formal phase-absorption statement is
+therefore also blockwise: for one matched pair it produces a unit-modulus
+$\xi$ with $\ket{V_N(\xi A_j)}=\ket{V_N(B_{\pi(j)})}$ for every $N\geq1$,
+matching the phase absorption used at lines 302--305 and again at lines
+667--671.\footnote{Formal declaration:
+\leanid{MPSTensor.HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos}.} Its
+scope restriction is recorded on the declaration itself. Relating the
+assembled tensors requires the multiplicities and is possible only in the
+equal case, theorem \emph{thm:bdequal}, lines 643--658.
+
 \subsection{Remaining elimination plan}
 
 A source-labelled theorem must combine the spectrally periodic overlap theorem


### PR DESCRIPTION
Closes #5343

## What this adds

Two theorems in `TNLean/MPS/Periodic/FundamentalTheorem.lean`, both proved (no
`sorry`, no `axiom`, no `native_decide`):

| Declaration | Source anchor |
|---|---|
| `MPSTensor.HetRepeatedBlocks.exists_unit_phase_power_mpv` | arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`, lines 276--284; the per-length proportional hypothesis compared against it is theorem `thm:bd`, lines 613--623 |
| `MPSTensor.HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos` | arXiv:1708.00029, absorption of a repeated-block phase into the multiplicities, lines 302--305, and again in the proof of `thm:bdequal`, lines 667--671 |

The first states that repeated blocks `A_j^i = e^{i ξ} Y B_k^i Y^{-1}` have

    mpv A σ = ζ ^ N * mpv B σ    for every N and σ,  with ‖ζ‖ = 1,

i.e. the length-`N` proportionality scalar is the `N`-th power of a single
unit-modulus phase. The second absorbs that phase: rescaling the first block by
the reciprocal phase gives `SameMPV₂Pos (fun i => ξ • A i) B` with `‖ξ‖ = 1`.

The private lemma `mpvState_eq_smul_of_hetRepeatedBlocks` in
`TNLean/MPS/Periodic/ProportionalOverlap.lean` now routes through the new
theorem instead of re-deriving the same gauge-phase computation.

## Faithfulness

No hypothesis is stricter than the source's. Both theorems take only the
repeated-block relation `eq:rep` and add nothing.

Three faithfulness requirements from the issue are met by construction:

* **No length-independent proportionality scalar.** The scalar is quantified
  over the chain length as `ζ ^ N`, matching the source's per-length projective
  hypothesis `∀ N ≥ 1, ∃ c_N ≠ 0, |V_N(A)⟩ = c_N |V_N(B)⟩`. The one-site tensors
  `B^0 = 1`, `A^0 = e^{iθ}` show a fixed scalar is false unless the phase is
  trivial; this witness is recorded in both the blueprint node and the paper-gap
  note.
* **No weak `ProportionalMPV₂`.** That predicate no longer exists (retired in
  #7062); nothing here reintroduces it.
* **No single global phase for the assembled tensors.** The phase produced is
  blockwise, belonging to one matched pair. This is stated as a
  `**Scope restriction (blockwise phase):**` marker on
  `exists_phase_rescaling_sameMPV₂Pos`, citing
  `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`, in line with
  the source's own warning at lines 625--627 that `thm:bd` relates only the
  bases of periodic tensors, not `A` and `B` themselves.

The paper-gap note gains a subsection *Per-length proportionality and the
blockwise phase* recording the per-length reading, the phase-power witness, and
the blockwise scope.

## `PeripheralProportionalCaseRootFromRescaling`

The issue asks whether this conditional predicate should be retired or
restated. It has no use sites because it no longer exists: PR #7062 already
removed it together with
`MPSTensor.peripheralProportionalCase_periodicFT_of_rootFromRescaling` and the
weak `ProportionalMPV₂` predicate it depended on, as recorded in
`docs/audits/2026-08-23_degenerate_readings_wave_1.md`. A repository-wide grep
over `*.lean`, `*.tex` and `*.md` finds only that audit entry. Nothing to
delete or restate.

## Blueprint

Two nodes added to
`blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex`,
each with `\lean{...}`, `\leanok`, and `\leanok` on the proof:

* `lem:repeated_blocks_phase_power_mpv`
* `lem:repeated_blocks_phase_absorption`

## Verification

* `scripts/lake_build_locked.sh TNLean.MPS.Periodic.FundamentalTheorem TNLean.MPS.Periodic.ProportionalOverlap` — clean, linters included.
* `rg -n "sorry|axiom|native_decide|admit"` over both changed Lean files — empty.
* `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `lake exe checkdecls blueprint/lean_decls` — exit 0; blueprint and Lean report 100% in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca
