### PR TITLE
feat(MPS/MPU): reverse products under physical adjunction and rigidify commuting normal families

### DIFF
--- a/TNLean/MPS/Chain.lean
+++ b/TNLean/MPS/Chain.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.AlternatingNetwork
 import TNLean.MPS.Chain.BlockedChainFT
+import TNLean.MPS.Chain.CrossProductRigidity
 import TNLean.MPS.Chain.CyclicBlockAverage
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.FundamentalTheorem

--- a/TNLean/MPS/Chain/CrossProductRigidity.lean
+++ b/TNLean/MPS/Chain/CrossProductRigidity.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Kraus.NormalCommutant
+import TNLean.MPS.Chain.OneSidedInverse
+
+/-!
+# Cross-product rigidity of a commuting family
+
+Two families of square matrices $A$ and $B$ that satisfy the cross relation
+$B_iA_j=A_iB_j$ for all pairs of physical indices describe a tensor that
+commutes with the tensor of $A$ on a two-site chain.  When $A$ is normal the
+cross relation forces $B$ to be a single scalar multiple of $A$.
+
+The argument decomposes the identity in the span of the length-$N$ words of
+$A$, where $N$ is a positive blocking length at which $A$ becomes injective.
+Moving the marked letter of $B$ one step to the right through such a word
+produces a matrix $C$ with $B_i=A_iC$, and the cross relation then makes $C$
+commute with every letter of $A$; a matrix commuting with every letter of a
+normal family is scalar.
+
+## Main results
+
+* `Kraus.IsNormal.eq_smul_of_cross_mul_eq` — cross-product rigidity for a
+  normal family.
+* `Kraus.IsInjective.eq_smul_of_cross_mul_eq` — the injective special case.
+
+## References
+
+* Cirac--Garre-Rubio--Pérez-García--Ruiz-de-Alarcón--Schuch, arXiv:2502.20257,
+  the commuting-tensor step in the proof of Proposition `prop:MPUsplus`, lines
+  1255--1325.
+-/
+
+open scoped Matrix BigOperators
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- A nonempty word of a family annihilates on the right every matrix that is
+annihilated on the right by each letter. -/
+private theorem evalWord_mul_eq_zero_of_ne_nil
+    {A : Fin d → Matrix (Fin D) (Fin D) ℂ} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hX : ∀ i, A i * X = 0) :
+    ∀ w : List (Fin d), w ≠ [] → Kraus.evalWord A w * X = 0 := by
+  intro w
+  induction w with
+  | nil => exact fun h => absurd rfl h
+  | cons i w ih =>
+      cases w with
+      | nil => intro _; simpa using hX i
+      | cons j t =>
+          intro _
+          rw [Kraus.evalWord_cons, Matrix.mul_assoc, ih (List.cons_ne_nil j t),
+            Matrix.mul_zero]
+
+/-- **Cross-product rigidity for a normal family.** If $B_iA_j=A_iB_j$ holds
+for all physical indices and the family $A$ is normal, then $B$ is a single
+scalar multiple of $A$.
+
+This is the step "the tensor labeled $s$ commutes with the MPU tensor
+$\mathcal U$. Because $\mathcal U$ is normal, this implies that there exists
+$\delta\in\mathbb C$ such that ..." in the proof of Proposition `prop:MPUsplus`
+of arXiv:2502.20257, lines 1255--1325.  The paper first treats an injective
+$\mathcal U$ and then, when $\mathcal U$ is not injective, replaces the middle
+tensor by enough copies for their blocking to be injective; the proof below
+runs the blocked argument directly, so the injective case is the special case
+of blocking length one. -/
+theorem IsNormal.eq_smul_of_cross_mul_eq
+    {A B : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsNormal A)
+    (hcross : ∀ i j, B i * A j = A i * B j) :
+    ∃ c : ℂ, ∀ i, B i = c • A i := by
+  obtain ⟨N, hNpos, hN⟩ := (Kraus.isNormal_iff A).mp hA
+  obtain ⟨M, rfl⟩ : ∃ M, N = M + 1 := ⟨N - 1, (Nat.succ_pred_eq_of_pos hNpos).symm⟩
+  -- Decompose the identity in the span of the length-`M + 1` words of `A`.
+  obtain ⟨c, hone⟩ : ∃ c : (Fin (M + 1) → Fin d) → ℂ,
+      ∑ σ : Fin (M + 1) → Fin d, c σ • Kraus.evalWord A (List.ofFn σ) = 1 :=
+    ⟨Kraus.blockDecompositionMap hN 1, Kraus.blockDecompositionMap_sum hN 1⟩
+  -- Moving the marked letter of `B` one step to the right through a word of `A`.
+  have hmove : ∀ (i : Fin d) (σ : Fin (M + 1) → Fin d),
+      B i * Kraus.evalWord A (List.ofFn σ) =
+        A i * (B (σ 0) * Kraus.evalWord A (List.ofFn fun k : Fin M => σ k.succ)) := by
+    intro i σ
+    rw [List.ofFn_succ, Kraus.evalWord_cons, ← Matrix.mul_assoc, hcross, Matrix.mul_assoc]
+  obtain ⟨C, hBC⟩ : ∃ C : Matrix (Fin D) (Fin D) ℂ, ∀ i, B i = A i * C := by
+    refine ⟨∑ σ : Fin (M + 1) → Fin d,
+      c σ • (B (σ 0) * Kraus.evalWord A (List.ofFn fun k : Fin M => σ k.succ)), fun i => ?_⟩
+    calc
+      B i = B i * ∑ σ : Fin (M + 1) → Fin d, c σ • Kraus.evalWord A (List.ofFn σ) := by
+            rw [hone, Matrix.mul_one]
+      _ = ∑ σ : Fin (M + 1) → Fin d,
+            c σ • (A i * (B (σ 0) *
+              Kraus.evalWord A (List.ofFn fun k : Fin M => σ k.succ))) := by
+            rw [Finset.mul_sum]
+            exact Finset.sum_congr rfl fun σ _ => by rw [mul_smul_comm, hmove i σ]
+      _ = A i * ∑ σ : Fin (M + 1) → Fin d,
+            c σ • (B (σ 0) *
+              Kraus.evalWord A (List.ofFn fun k : Fin M => σ k.succ)) := by
+            rw [Finset.mul_sum]
+            exact Finset.sum_congr rfl fun σ _ => (mul_smul_comm _ _ _).symm
+  -- The cross relation makes `C` commute with every letter of `A`.
+  have hcomm : ∀ j, C * A j = A j * C := by
+    intro j
+    have hzero : ∀ i, A i * (C * A j - A j * C) = 0 := by
+      intro i
+      have h := hcross i j
+      rw [hBC i, hBC j] at h
+      rw [Matrix.mul_sub, ← Matrix.mul_assoc, h, sub_self]
+    have hsum : (1 : Matrix (Fin D) (Fin D) ℂ) * (C * A j - A j * C) = 0 := by
+      rw [← hone, Finset.sum_mul]
+      refine Finset.sum_eq_zero fun σ _ => ?_
+      rw [smul_mul_assoc,
+        evalWord_mul_eq_zero_of_ne_nil hzero _
+          (by rw [List.ofFn_succ]; exact List.cons_ne_nil _ _),
+        smul_zero]
+    rw [Matrix.one_mul, sub_eq_zero] at hsum
+    exact hsum
+  obtain ⟨z, hz⟩ := hA.eq_smul_one_of_commute hcomm
+  exact ⟨z, fun i => by rw [hBC i, hz, mul_smul_comm, Matrix.mul_one]⟩
+
+/-- **Cross-product rigidity for an injective family.** If $B_iA_j=A_iB_j$
+holds for all physical indices and the family $A$ is injective, then $B$ is a
+single scalar multiple of $A$.
+
+This is the injective case treated first in the proof of Proposition
+`prop:MPUsplus` of arXiv:2502.20257, lines 1255--1325. -/
+theorem IsInjective.eq_smul_of_cross_mul_eq
+    {A B : Fin d → Matrix (Fin D) (Fin D) ℂ} (hA : Kraus.IsInjective A)
+    (hcross : ∀ i j, B i * A j = A i * B j) :
+    ∃ c : ℂ, ∀ i, B i = c • A i :=
+  hA.isNormal.eq_smul_of_cross_mul_eq hcross
+
+end Kraus

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -210,6 +210,7 @@ import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalAdjoint
+import TNLean.MPS.MPDO.PhysicalAdjointProduct
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding

--- a/TNLean/MPS/MPDO/PhysicalAdjointProduct.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjointProduct.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.OperatorProduct
+import TNLean.MPS.MPDO.PhysicalAdjoint
+
+/-!
+# Physical adjunction reverses the operator product of MPO tensors
+
+Physical adjunction conjugates every coefficient of a matrix product operator
+tensor and exchanges its two physical indices, leaving the virtual chain in
+place.  Applied to a product tensor it exchanges the two factors, so the
+adjoint of a product is the product of the adjoints in the opposite order, read
+on the bond space whose two Kronecker factors have been exchanged.
+
+The two bond spaces of the factors need not have the same dimension, so the
+exchange of the two factors of a product bond space is recorded here for
+unequal dimensions.
+
+## Main definitions
+
+* `MPOTensor.bondProdSwapEquiv` — exchange of the two factors of a product bond
+  space of unequal dimensions.
+
+## Main results
+
+* `MPOTensor.physicalAdjointTensor_mulTensor` — the physical adjoint of a
+  product tensor is the reversed product of the physical adjoints, reindexed by
+  the product-bond exchange.
+
+## References
+
+* Cirac--Garre-Rubio--Pérez-García--Ruiz-de-Alarcón--Schuch, arXiv:2502.20257,
+  line 1662, for the description of the dagger operation used here, and the
+  proof of Proposition `prop:zetas`, lines 1662--1677, for the inverse-product
+  step it serves.
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor
+
+variable {d D₁ D₂ : ℕ}
+
+/-- Exchange of the two factors of a product bond space: the flattened index of
+a pair `(a, b)` is sent to the flattened index of `(b, a)`.
+
+Unlike `bondPairSwapEquiv`, the two factors are allowed to have different
+dimensions.
+
+Source: arXiv:2502.20257, line 1662, where the dagger operation swaps the two
+legs lying on the same side of a tensor. -/
+def bondProdSwapEquiv (D₁ D₂ : ℕ) : Fin (D₁ * D₂) ≃ Fin (D₂ * D₁) :=
+  finProdFinEquiv.symm.trans
+    ((Equiv.prodComm (Fin D₁) (Fin D₂)).trans finProdFinEquiv)
+
+@[simp] theorem bondProdSwapEquiv_finProdFinEquiv (a : Fin D₁) (b : Fin D₂) :
+    bondProdSwapEquiv D₁ D₂ (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
+  simp [bondProdSwapEquiv]
+
+@[simp] theorem bondProdSwapEquiv_symm :
+    (bondProdSwapEquiv D₁ D₂).symm = bondProdSwapEquiv D₂ D₁ := by
+  refine Equiv.ext fun x => ?_
+  obtain ⟨⟨b, a⟩, rfl⟩ := finProdFinEquiv.surjective x
+  rw [Equiv.symm_apply_eq, bondProdSwapEquiv_finProdFinEquiv,
+    bondProdSwapEquiv_finProdFinEquiv]
+
+/-- **Physical adjunction reverses the operator product.** The physical adjoint
+of a product tensor is the product of the physical adjoints of its factors in
+the opposite order, read on the product bond space with its two factors
+exchanged.
+
+Source: arXiv:2502.20257, the dagger operation described at line 1662 and the
+inverse-product step in the proof of Proposition `prop:zetas`, lines
+1662--1677. -/
+theorem physicalAdjointTensor_mulTensor (M : MPOTensor d D₁) (N : MPOTensor d D₂)
+    (i k : Fin d) :
+    physicalAdjointTensor (mulTensor M N) i k =
+      (mulTensor (physicalAdjointTensor N) (physicalAdjointTensor M) i k).submatrix
+        (bondProdSwapEquiv D₁ D₂) (bondProdSwapEquiv D₁ D₂) := by
+  ext x y
+  obtain ⟨⟨x₁, x₂⟩, rfl⟩ := finProdFinEquiv.surjective x
+  obtain ⟨⟨y₁, y₂⟩, rfl⟩ := finProdFinEquiv.surjective y
+  simp only [physicalAdjointTensor_apply, mulTensor_apply, Matrix.submatrix_apply,
+    Matrix.sum_apply, Matrix.kronecker_apply, Equiv.symm_apply_apply,
+    bondProdSwapEquiv_finProdFinEquiv, star_sum, star_mul']
+  exact Finset.sum_congr rfl fun j _ => mul_comm _ _
+
+end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -283,6 +283,51 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     coefficient in (\ref{eq:mpug_physical_adjoint_inverse_mpv}).
 \end{proof}
 
+\begin{theorem}[Physical adjunction reverses the operator product]
+    \label{thm:mpug_physical_adjoint_product_reversal}
+    \lean{MPOTensor.bondProdSwapEquiv,
+        MPOTensor.physicalAdjointTensor_mulTensor}
+    \leanok
+    \uses{def:mpdo_operator_product, def:mpdo_physical_adjoint}
+    Let $M$ and $N$ be MPO tensors with bond dimensions $D_M$ and $D_N$.
+    Write a left bond index of the product tensor as a pair
+    $(\alpha,\gamma)$, with $\alpha$ in the bond space of $M$ and $\gamma$ in
+    the bond space of $N$, and a right bond index as $(\beta,\delta)$
+    likewise. Then, for every pair of physical indices $i,k$,
+    \begin{align}
+        \bigl((M\mathbin{\cdot}N)^\sharp\bigr)^{ik}
+        _{(\alpha\gamma),(\beta\delta)}
+         & =\bigl(N^\sharp\mathbin{\cdot}M^\sharp\bigr)^{ik}
+        _{(\gamma\alpha),(\delta\beta)}.
+        \label{eq:mpug_physical_adjoint_product_reversal}
+    \end{align}
+    The two bond spaces need not have the same dimension, so the exchange of
+    the two factors of a product bond space is recorded here for unequal
+    dimensions.
+    % Source anchor: arXiv:2502.20257, line 1662 and prop:zetas,
+    % lines 1662--1677.
+    This is the inverse-product step used in the proof of
+    Proposition~\texttt{prop:zetas}
+    of~\cite[lines~1662--1677]{FrancoRubio2025MPUGauging}, for the dagger
+    operation described there, which conjugates every entry and exchanges the
+    two legs lying on the same side of a tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_operator_product, def:mpdo_physical_adjoint}
+    Expand both sides. The left side is the complex conjugate of the
+    $\bigl((\alpha\gamma),(\beta\delta)\bigr)$ entry of
+    $\sum_j M^{kj}\otimes N^{ji}$, namely
+    $\sum_j\overline{M^{kj}_{\alpha\beta}}\,
+        \overline{N^{ji}_{\gamma\delta}}$.
+    The right side is the
+    $\bigl((\gamma\alpha),(\delta\beta)\bigr)$ entry of
+    $\sum_j (N^\sharp)^{ij}\otimes(M^\sharp)^{jk}$, namely
+    $\sum_j\overline{N^{ji}_{\gamma\delta}}\,
+        \overline{M^{kj}_{\alpha\beta}}$.
+    The two sums agree term by term.
+\end{proof}
+
 Suppose now that the normalized flattening of every $\mathcal U_g$ is
 left-canonical.  This is the canonical-form hypothesis used in
 \cite[lines~1552--1557]{FrancoRubio2025MPUGauging}.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1058,6 +1058,50 @@ specified in Definition~\ref{def:mpug_group_representation}.
     (\ref{eq:mpug_unitary_kronecker_factors}).
 \end{proof}
 
+\begin{theorem}[Cross-product rigidity of a commuting family]
+    \label{thm:mpug_cross_product_rigidity}
+    \lean{Kraus.IsNormal.eq_smul_of_cross_mul_eq,
+        Kraus.IsInjective.eq_smul_of_cross_mul_eq}
+    \leanok
+    \uses{def:injective, def:normal, def:decomposition_map}
+    Let $A_i$ and $B_i$ be two families of square matrices of the same size,
+    indexed by the same finite alphabet, and suppose that
+    \begin{align}
+        B_iA_j & =A_iB_j\qquad\text{for all }i,j.
+        \label{eq:mpug_cross_product_rigidity}
+    \end{align}
+    If $A$ is injective, or more generally normal, then there is a scalar
+    $c\in\C$ with $B_i=cA_i$ for every $i$.
+    % Source anchor: arXiv:2502.20257, prop:MPUsplus, lines 1255--1325.
+    This is the commuting-tensor step in the proof of
+    Proposition~\texttt{prop:MPUsplus}
+    of~\cite[lines~1255--1325]{FrancoRubio2025MPUGauging}, where the tensor
+    commuting with a normal matrix product unitary tensor is shown to be a
+    multiple of it.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:decomposition_map, thm:normal_tensor_gram_rigidity}
+    Let $N\geq1$ be a blocking length at which the length-$N$ words of $A$
+    span the full matrix algebra, and decompose the identity as
+    $\mathbf 1=\sum_\sigma c_\sigma A^{\sigma_1}\cdots A^{\sigma_N}$. The
+    cross relation moves the marked letter one step to the right,
+    \begin{align}
+        B_iA^{\sigma_1}\cdots A^{\sigma_N}
+         & =A_iB^{\sigma_1}A^{\sigma_2}\cdots A^{\sigma_N},
+        \notag
+    \end{align}
+    so $B_i=A_iC$ with
+    $C=\sum_\sigma c_\sigma B^{\sigma_1}A^{\sigma_2}\cdots A^{\sigma_N}$.
+    Substituting this into (\ref{eq:mpug_cross_product_rigidity}) gives
+    $A_i(CA_j-A_jC)=0$ for all $i$ and $j$. Multiplying on the left by a
+    length-$N$ word, whose last letter absorbs one of the $A_i$, and
+    recombining the words into the identity gives $CA_j=A_jC$. A matrix
+    commuting with every letter of a normal family is a multiple of the
+    identity, so $C=c\mathbf 1$ and $B_i=cA_i$. The injective case is the
+    case of blocking length one.
+\end{proof}
+
 \begin{theorem}[Comparison of factorizations from one-sided inverses]
     \label{thm:mpug_factorization_comparison}
     \lean{Matrix.factorization_comparison_of_one_sided_inverses}


### PR DESCRIPTION
Two small leaves on the arXiv:2502.20257 MPU spine, one commit each.

## Commit 1 — Closes #7666

Source anchor: `Papers/2502.20257/main.tex:1662-1677`, the dagger operation
described at line 1662 and the inverse-product step in the proof of
Proposition `prop:zetas`.

New module `TNLean/MPS/MPDO/PhysicalAdjointProduct.lean`:

- `MPOTensor.bondProdSwapEquiv` — the exchange of the two factors of a
  product bond space, for unequal bond dimensions. The existing
  `bondPairSwapEquiv` covers only the homogeneous `D * D` case, which does
  not type-check here.
- `MPOTensor.physicalAdjointTensor_mulTensor` — the physical adjoint of a
  product tensor is the reversed product of the physical adjoints, read
  after the product-bond exchange on both bond indices.

Blueprint: `thm:mpug_physical_adjoint_product_reversal` in Chapter 29,
beside the existing physical-adjoint and product-tensor entries.

## Commit 2 — Closes #7668

Source anchor: `Papers/2502.20257/main.tex:1255-1325`, the commuting-tensor
step in the proof of Proposition `prop:MPUsplus`.

New module `TNLean/MPS/Chain/CrossProductRigidity.lean`:

- `Kraus.IsNormal.eq_smul_of_cross_mul_eq` — from `B i * A j = A i * B j`
  for all `i, j` with `A` normal, conclude `B i = c • A i` for one scalar.
- `Kraus.IsInjective.eq_smul_of_cross_mul_eq` — the injective case.

The proof follows the paper's route: decompose the identity in the word span
at a positive blocking length, move the marked `B` letter through an `A` word
by the cross relation to get `B i = A i * C`, use the cross relation and the
word span again to make `C` commute with every `A j`, and close with
`Kraus.IsNormal.eq_smul_one_of_commute`. The injective case is the case of
blocking length one, matching the paper's "replace the middle tensor with
enough copies so that their blocking is injective".

Blueprint: `thm:mpug_cross_product_rigidity` in Chapter 29, beside the other
generic matrix lemmas isolated from the same proof.

## Scope restrictions

None. Both Lean statements carry exactly the hypothesis sets of the cited
passages, so no paper-gap note was needed.

## Verification

- `scripts/lake_build_locked.sh` on both new modules and on the regenerated
  `TNLean.MPS.Chain` / `TNLean.MPS.MPDO` aggregators: clean, linters included.
- `rg -n "sorry|axiom"` on the changed Lean files: empty.
- `python3 scripts/generate_import_aggregators.py --check`: passes.
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: in sync.
- `lake exe checkdecls blueprint/lean_decls`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca
