### PR TITLE
feat(MPS/MPU): close the nonsymmetric-ρ gap in the admissible simple-tensor equivalence

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -47,6 +47,7 @@ import TNLean.MPS.MPU.SourceFactorsTensorProduct
 import TNLean.MPS.MPU.SourceIndexValue
 import TNLean.MPS.MPU.SourceUCompleteNetwork
 import TNLean.MPS.MPU.SourceURetainedInterior
+import TNLean.MPS.MPU.SourceUTransposeFixedPair
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 import TNLean.MPS.MPU.SourceVIsometry

--- a/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
+++ b/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Tactic.TFAE
-import TNLean.MPS.MPU.SourceUCompleteNetwork
+import TNLean.MPS.MPU.SourceUTransposeFixedPair
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 
 /-!
@@ -29,18 +29,22 @@ $\operatorname{reindex}(U^{(2)})=v\,\operatorname{swap}_{r,\ell}(u)$ of
 equations `SVDforms2`--`uuvv` makes $v$ a product of unitaries; and
 $v^\dagger v=\Id$ gives `simple2`, hence simplicity.
 
-The fixed pair is supplied as in the source: $\rho>0$ is the diagonal right
-fixed point of canonical form II (arXiv:1703.09188, line 495), and the
-normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$ with
+The fixed pair is supplied as in the source: $\rho>0$ is the right fixed point
+of canonical form II (arXiv:1703.09188, line 495), and the normalized
+double-layer diagonal satisfies $E^J=|\rho^{\mathsf T})(\Phi|$ with
 $(\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}$ (equation `Erightleft`,
 lines 274--280).  The source cuts, ranks, and both gates are computed from the
-same tensor $\mathcal U$ with the same weight $\rho$.
+same tensor $\mathcal U$ with the same weight $\rho$.  The transpose is the
+column-stacking pairing of the weight with the fixed point recorded in
+`docs/paper-gaps/mpu_source_cut_orientation.tex`; the source works with a
+diagonal $\rho$, where $\rho^{\mathsf T}=\rho$ and the two readings coincide,
+which is the specialization `IsMPU.isMPUSimple_tfae`.
 
-**Scope restriction (supplied diagonal fixed pair):** `IsMPU.isMPUSimple_tfae`
-assumes the positive diagonal fixed point and the exact finite-power identity
-explicitly. The unrestricted source theorem uses the preceding
-canonical-form-II representative convention. This remaining representative
-scope is documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+**Scope restriction (supplied stabilized fixed pair):** both theorems below
+assume the exact finite-power identity explicitly. The unrestricted source
+theorem uses the preceding canonical-form-II representative convention. This
+remaining representative scope is documented in
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -50,12 +54,11 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Supplied-fixed-pair specialization of Theorem `ThmFund1`: for an MPU tensor
-$\mathcal U$ whose normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$
-for the source's diagonal
-fixed point $\rho>0$ and some $J>0$, with the source-cut ranks $r$, $\ell$ and
-the source gates $u$, $v$ computed from $\mathcal U$ using $\rho$, the following
-are equivalent:
+/-- Theorem `ThmFund1` for an arbitrary positive definite source weight: for an
+MPU tensor $\mathcal U$ whose normalized double-layer diagonal satisfies
+$E^J=|\rho^{\mathsf T})(\Phi|$ for a positive definite weight $\rho$ and some
+$J>0$, with the source-cut ranks $r$, $\ell$ and the source gates $u$, $v$
+computed from $\mathcal U$ using $\rho$, the following are equivalent:
 
 1. $\mathcal U$ is simple;
 2. $r\ell=d^2$;
@@ -63,32 +66,38 @@ are equivalent:
 4. $v$ is unitary.
 
 The proof is the source's cycle $1\to2\to3\to4\to1$:
-`IsMPU.sourceU_isIsometry` and the same-weight
-`IsMPUSimple.sourceV_isIsometry` give $1\to2$; the standing isometry $u$ with
-$\ell r=d^2$ is unitary ($2\to3$);
+`IsMPU.sourceU_isIsometry_of_transpose_fixed_pair` and the same-weight
+`IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair` give $1\to2$; the
+standing isometry $u$ with $\ell r=d^2$ is unitary ($2\to3$);
 `mpo_two_reindex_eq_sourceV_mul_sourceU_swap` writes the unitary $U^{(2)}$ as
 $v$ times the reindexed $u$, so $v$ is unitary ($3\to4$); and
 `IsMPU.isMPUSimple_of_sourceV_isIsometry` gives $4\to1$.
 
+No symmetry of $\rho$ is used.  Both complete networks insert the
+column-stacking vector of $\rho^{\mathsf T}$, and that is the vector the
+stabilized pair supplies, so the gates, the source cuts and the fixed pair all
+refer to the same weight and the same tensor.
+
 Source: arXiv:1703.09188, Theorem `ThmFund1` and its proof (lines 563--601),
-with the diagonal fixed point of line 495. -/
-theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag)
-    (J : ℕ) (hJ : 0 < J)
+with the fixed pair of lines 274--280. -/
+theorem IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (J : ℕ) (hJ : 0 < J)
     (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
-      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+      Matrix.vecMulVec (fun x ↦ ρᵀ.vec (finProdFinEquiv.symm x))
         (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
     List.TFAE [IsMPUSimple U,
       r[U] * ℓ[U] = d * d,
       (sourceU U ρ hρ).IsUnitaryBetween,
       (sourceV U ρ hρ).IsUnitaryBetween] := by
-  have hu : (sourceU U ρ hρ).IsIsometry := hU.sourceU_isIsometry ρ hρ hρdiag J hpower
+  have hu : (sourceU U ρ hρ).IsIsometry :=
+    hU.sourceU_isIsometry_of_transpose_fixed_pair ρ hρ J hpower
   have hrankLower : d * d ≤ r[U] * ℓ[U] := by
     have h := Matrix.IsIsometry.card_le _ hu
     simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
   tfae_have 1 → 2 := fun hS ↦ by
     have hv : (sourceV U ρ hρ).IsIsometry :=
-      hS.sourceV_isIsometry ρ hρ hρdiag J hJ hpower
+      hS.sourceV_isIsometry_of_transpose_fixed_pair ρ hρ J hJ hpower
     have hrankUpper := Matrix.IsIsometry.card_le _ hv
     apply le_antisymm
     · simpa only [Fintype.card_prod, Fintype.card_fin] using hrankUpper
@@ -106,5 +115,35 @@ theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
     exact Matrix.IsUnitaryBetween.of_mul_right _ _ (h.reindex _ _ _) hre
   tfae_have 4 → 1 := fun h ↦ hU.isMPUSimple_of_sourceV_isIsometry ρ hρ h.1
   tfae_finish
+
+/-- Supplied-fixed-pair specialization of Theorem `ThmFund1`: for an MPU tensor
+$\mathcal U$ whose normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$
+for the source's diagonal
+fixed point $\rho>0$ and some $J>0$, with the source-cut ranks $r$, $\ell$ and
+the source gates $u$, $v$ computed from $\mathcal U$ using $\rho$, the following
+are equivalent:
+
+1. $\mathcal U$ is simple;
+2. $r\ell=d^2$;
+3. $u$ is unitary;
+4. $v$ is unitary.
+
+This is the diagonal case of the preceding theorem: a diagonal weight has
+$\rho^{\mathsf T}=\rho$, so the inserted and the stabilized vector agree.
+
+Source: arXiv:1703.09188, Theorem `ThmFund1` and its proof (lines 563--601),
+with the diagonal fixed point of line 495. -/
+theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag)
+    (J : ℕ) (hJ : 0 < J)
+    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
+      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    List.TFAE [IsMPUSimple U,
+      r[U] * ℓ[U] = d * d,
+      (sourceU U ρ hρ).IsUnitaryBetween,
+      (sourceV U ρ hρ).IsUnitaryBetween] :=
+  hU.isMPUSimple_tfae_of_transpose_fixed_pair ρ hρ J hJ
+    (by simpa only [hρdiag.isSymm.eq] using hpower)
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceUTransposeFixedPair.lean
+++ b/TNLean/MPS/MPU/SourceUTransposeFixedPair.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceUCompleteNetwork
+
+/-!
+# The source gate u for a weight that need not be symmetric
+
+The complete source-$u$ network of arXiv:1703.09188, equation `uUnitary`
+(lines 545--557), closes the Gram matrix of the paper gate
+$u=Y_2\mathbin{-}Y_1$ to a trace of two double-layer letters separated by the
+rank-one insertion $|\rho^{\mathsf T})(\Phi|$, where $\rho$ is the weight
+carried by the two normalizations `X1X2b`.  That closure is exact for every
+weight.  This file pairs it with the matching stabilized fixed pair
+$E^K=|\rho^{\mathsf T})(\Phi|$ and reads off $u^\dagger u=\Id$ from input-first
+unitarity of the MPU chain, for an arbitrary positive definite weight.
+
+The weight and the fixed point are paired as the column-stacking coordinates
+of `Matrix.vec` require, so no symmetry of $\rho$ enters.  In the source's
+canonical-form-II coordinates $\rho$ is diagonal and the two matrices
+coincide, which is the case treated in `TNLean.MPS.MPU.SourceUCompleteNetwork`.
+
+**Scope restriction (supplied stabilized fixed pair):** the theorems below
+assume the exact rank-one identity $E^K=|\rho^{\mathsf T})(\Phi|$ as a
+hypothesis, whereas CPSV17 Lemma `lemuisometry` inherits the fixed pair from
+the preceding canonical-form-II convention.  Documented in
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+
+## Main results
+
+* `MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair`:
+  the source-$u$ Gram matrix is the closed direct double-layer trace with one
+  $K$-site interior.
+* `MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair`:
+  the gate $u$ of an MPU tensor is an isometry.
+* `MPOTensor.IsMPU.sourceU_isIsometry_of_transpose_fixed_pair`: the same for
+  the compact-SVD source factors.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188], equations
+  `Erightleft`, `X1X2b`, `uu`, and `uUnitary`, and Lemma `lemuisometry`
+  (lines 269--280 and 487--557).
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+namespace SourceFactors
+
+/-- For a supplied source weight whose transpose is the stabilized fixed
+point, the source-$u$ Gram matrix is the closed direct double-layer trace with
+one $K$-site interior between the two retained endpoint letters.  The pair `p`
+is starred and `q` is unstarred.
+
+No symmetry of the weight is used: the exact closure already inserts
+$|\rho^{\mathsf T})(\Phi|$, and that is the vector the stabilized pair
+supplies.
+
+Source: CPSV17 equation `uUnitary` and Lemma `lemuisometry` (lines 545--557),
+with the fixed pair of lines 269--280. -/
+theorem sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρᵀ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)))
+    (p q : Fin d × Fin d) :
+    (∑ lr, sourceU U S lr q * star (sourceU U S lr p)) =
+      Matrix.trace
+        (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2 *
+          normalizedDiagonal (doubleLayerTensor U) ^ K) := by
+  rw [sourceU_gram_eq_transpose_fixed_pair_trace, ← hK]
+  exact Matrix.trace_mul_cycle _ _ _
+
+/-- For supplied source factors whose weight has the stabilized fixed point as
+its transpose, the paper gate $u=Y_2\mathbin{-}Y_1$ of an MPU tensor is an
+isometry.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed pair of
+lines 269--280. -/
+theorem sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair [NeZero d]
+    (hU : IsMPU U) {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρᵀ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U S).IsIsometry := by
+  change (sourceU U S)ᴴ * sourceU U S = 1
+  ext p q
+  have h := sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair
+    U S K hK p q
+  rw [← normalized_mpo_input_tail_eq_closed_doubleLayer_trace,
+    hU.normalized_mpo_tail_isometry] at h
+  rw [Matrix.mul_apply, Matrix.one_apply, ← h]
+  exact Finset.sum_congr rfl fun lr _ ↦ by
+    rw [Matrix.conjTranspose_apply, mul_comm]
+
+end SourceFactors
+
+variable {U} in
+/-- For a positive definite weight whose transpose is the stabilized fixed
+point, the compact-SVD paper gate $u$ of an MPU tensor is an isometry.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed pair of
+lines 269--280. -/
+theorem IsMPU.sourceU_isIsometry_of_transpose_fixed_pair [NeZero d]
+    (hU : IsMPU U) (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
+    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
+      Matrix.vecMulVec (fun x ↦ ρᵀ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceU U ρ hρ).IsIsometry :=
+  SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair U hU
+    (sourceFactors U ρ hρ) K hK
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
@@ -31,6 +31,9 @@ in the column-stacking coordinates of `Matrix.vec`.  The formal statements keep
 the printed weight and insert the column-stacking vector of
 $\rho^{\mathsf T}$. The source works with a diagonal $\rho$, where this vector
 is $|\rho)$ and the gate remains the one built from the same weight $\rho$.
+For a weight that is not symmetric the same pairing is kept: the stabilized
+fixed pair is $|\rho^{\mathsf T})(\Phi|$ for the weight $\rho$ carried by the
+source cuts and by the gate.
 Documented in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 ## Main results
@@ -41,9 +44,12 @@ Documented in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
   undressed Gram entry is the two-letter entry with $|\rho^{\mathsf T})(\Phi|$ inserted.
 * `MPOTensor.sourceVDressedGram_iff_simple2_transpose_fixed_pair`: the dressed Gram
   equation is equivalent to `simple2` with the insertion $|\rho^{\mathsf T})(\Phi|$.
-* `MPOTensor.IsMPUSimple.sourceV_isIsometry`: the forward direction of Theorem
-  `ThmFund1`, $1\to2$, with the source's diagonal fixed point: the gate built
-  from that same weight has $v^\dagger v=\Id$.
+* `MPOTensor.IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair`: the
+  forward direction of Theorem `ThmFund1`, $1\to2$, for an arbitrary positive
+  definite weight $\rho$ whose transpose is the stabilized fixed point.
+* `MPOTensor.IsMPUSimple.sourceV_isIsometry`: the same statement with the
+  source's diagonal fixed point: the gate built from that same weight has
+  $v^\dagger v=\Id$.
 * `MPOTensor.IsMPUSimple.rightRank_mul_leftRank_le`: the resulting rank bound
   $r\ell\le d^2$.
 * `MPOTensor.IsMPU.isMPUSimple_of_sourceV_isIsometry`: the direction $4\to1$ of
@@ -167,26 +173,48 @@ theorem sourceVDressedGram_iff_simple2_transpose_fixed_pair
     dsimp only at hA hB
     rw [hA, hB, h]
 
-/-- A simple tensor whose normalized double-layer diagonal stabilizes to
-$|\rho)(\Phi|$ has $v^\dagger v=\Id$ for the auxiliary gate obtained by
-recomputing the source factors with the weight $\rho^{\mathsf T}$.
+/-- Theorem `ThmFund1`, $1\to2$, for an arbitrary positive definite source
+weight: if the stabilized normalized double-layer diagonal of a simple tensor
+is $|\rho^{\mathsf T})(\Phi|$, then the paper gate $v$ built from the weight
+$\rho$ satisfies $v^\dagger v=\Id$.
 
-This is the reparametrized-weight consequence of the complete network. It is
-not the source gate built from the fixed-point weight $\rho$ unless
-$\rho^{\mathsf T}=\rho$. The source assumes that $\rho$ is diagonal before
-its proof of Theorem `ThmFund1`, $1\to2$ (arXiv:1703.09188, lines 495 and
-577--588). -/
+No symmetry of $\rho$ is used.  The two weighted normalizations `X1X2b` make
+the complete network insert the column-stacking vector of $\rho^{\mathsf T}$,
+and that is exactly the vector the stabilized pair supplies here, so the gate,
+the source cuts, and the fixed pair all refer to the same weight and the same
+tensor.  The source works in canonical-form-II coordinates, where $\rho$ is
+diagonal and the two matrices coincide.
+
+Source: arXiv:1703.09188, equation `vUnitary` and the proof of Theorem
+`ThmFund1`, $1\to2$ (lines 495 and 577--588). -/
+theorem IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPUSimple U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (J : ℕ) (hJ : 0 < J)
+    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
+      Matrix.vecMulVec (fun x ↦ ρᵀ.vec (finProdFinEquiv.symm x))
+        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (sourceV U ρ hρ).IsIsometry := by
+  rw [← sourceVDressedGram_iff_isIsometry,
+    sourceVDressedGram_iff_simple2_transpose_fixed_pair]
+  exact hU.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ J hJ hpower
+
+/-- A simple tensor whose normalized double-layer diagonal stabilizes to
+$|\rho)(\Phi|$ has $v^\dagger v=\Id$ for the gate obtained by recomputing the
+source factors with the weight $\rho^{\mathsf T}$.
+
+This is the fixed-point reading of the previous theorem: the transfer fixed
+point is named $\rho$ and the source cuts carry the weight
+$\rho^{\mathsf T}$.  The two readings agree when $\rho^{\mathsf T}=\rho$, which
+is the case the source works in (arXiv:1703.09188, lines 495 and 577--588). -/
 theorem IsMPUSimple.sourceV_transpose_isIsometry [NeZero d]
     {U : MPOTensor d D} (hU : IsMPUSimple U)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (J : ℕ) (hJ : 0 < J)
     (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
       Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
         (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
-    (sourceV U ρᵀ hρ.transpose).IsIsometry := by
-  rw [← sourceVDressedGram_iff_isIsometry,
-    sourceVDressedGram_iff_simple2_transpose_fixed_pair]
-  simpa only [Matrix.transpose_transpose] using
-    hU.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ J hJ hpower
+    (sourceV U ρᵀ hρ.transpose).IsIsometry :=
+  hU.sourceV_isIsometry_of_transpose_fixed_pair ρᵀ hρ.transpose J hJ
+    (by simpa only [Matrix.transpose_transpose] using hpower)
 
 /-- Theorem `ThmFund1`, $1\to2$: for the diagonal fixed point used by the
 source, the paper gate $v$ built from that same weight satisfies
@@ -203,11 +231,9 @@ theorem IsMPUSimple.sourceV_isIsometry [NeZero d]
     (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
       Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
         (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
-    (sourceV U ρ hρ).IsIsometry := by
-  rw [← sourceVDressedGram_iff_isIsometry,
-    sourceVDressedGram_iff_simple2_transpose_fixed_pair]
-  simpa only [hρdiag.isSymm.eq] using
-    hU.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ J hJ hpower
+    (sourceV U ρ hρ).IsIsometry :=
+  hU.sourceV_isIsometry_of_transpose_fixed_pair ρ hρ J hJ
+    (by simpa only [hρdiag.isSymm.eq] using hpower)
 
 /-- Theorem `ThmFund1`, $1\to2$, rank consequence: a simple tensor with
 stabilized fixed pair satisfies $r\ell\le d^2$, since the isometry $v$ maps

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4912,21 +4912,25 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Let $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ be the normalized
     flattening, and let $E$ be its transfer matrix. A reduced full-support source
     datum for $\mathcal U$, with physical dimension $d>0$ and positive bond
-    dimension, consists of an integer $J>0$, a diagonal positive definite matrix
+    dimension, consists of an integer $J>0$, a positive definite matrix
     $\rho$ with $\tr(\rho)=1$, and
     $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$ such that
     \begin{align}
-        E^J & =\lvert\rho)(\Phi\rvert.
+        E^J & =\lvert\rho^{\mathsf T})(\Phi\rvert.
     \end{align}
+    Here $\rho$ is the weight carried by the two source-cut normalizations and
+    $\rho^{\mathsf T}$ is the stabilized right fixed point; the two are paired
+    this way by the column-stacking coordinates recorded in
+    \texttt{docs/paper-gaps/mpu\_source\_cut\_orientation.tex}, and they
+    coincide in the source's diagonal canonical-form-II coordinates.
     The one-dimensional case is supplied directly: if $D=1$, take $J=1$
     and $\rho=\Id_1$ using
     Theorem~\ref{thm:mpu_normalized_transfer_fin_one}. If $D>1$, chosen
     canonical-form-II data with full support give a positive trace-one ambient
-    fixed point with $J=D^2-1$ by
-    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Diagonality of
-    this ambient fixed point is an additional hypothesis: the theorem gives a
-    diagonal matrix in the unique block coordinates, but conjugation into the
-    ambient coordinates need not preserve diagonality.
+    fixed point $\sigma$ with $J=D^2-1$ by
+    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}; take
+    $\rho=\sigma^{\mathsf T}$, which is again positive definite with trace one.
+    No diagonality of the ambient fixed point is required.
     For $D>1$, this states the fixed-pair convention in
     \cite[equations labelled~\texttt{Erightleft} and~\texttt{II\_UTransfer}, and
         proof of Proposition~III.2(ii)]{Cirac2017MPU}. The $D=1$ branch is the direct
@@ -5188,6 +5192,44 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     contracted separately.
 \end{proof}
 
+\begin{theorem}[Source-$v$ isometry for a transposed fixed pair]
+    \label{thm:mpu_transpose_fixed_pair_source_v_isometry}
+    \lean{MPOTensor.IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair}
+    \leanok
+    \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer}
+    Let $\mathcal U$ be simple with physical dimension $d>0$, let $W$ be its
+    double layer with normalized diagonal $E$, and let $\rho>0$ be a weight
+    that is not assumed symmetric. Put
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$ and suppose that
+    \begin{align}
+        E^J & =\lvert\rho^{\mathsf T})(\Phi\rvert
+    \end{align}
+    for some $J>0$. Let $v$ be the source operator of $\mathcal U$ built from
+    the weight $\rho$. Then $v^\dagger v=\Id_{r\ell}$.
+
+    The weight carried by the two normalizations and the stabilized right fixed
+    point are paired here as the column-stacking coordinates require. A
+    diagonal weight has $\rho^{\mathsf T}=\rho$, which recovers the source's
+    own convention. This is the implication $1\to2$ in
+    \cite[proof of Theorem~III.8]{Cirac2017MPU}, before the standing isometry
+    of $u$ is used.
+    % Source lines: paper_v2.tex 495 and 577--588. The weight orientation is
+    % recorded in docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_supplied_projector_simple2,
+        thm:mpu_source_v_complete_contraction,
+        thm:mpu_source_v_dressed_gram_cancel}
+    Theorem~\ref{thm:mpu_supplied_projector_simple2} applied to the supplied
+    rank-one matrix gives
+    $W^{ij}W^{k\ell}=W^{ij}\lvert\rho^{\mathsf T})(\Phi\rvert W^{k\ell}$, which
+    is exactly the inserted identity produced by
+    Theorem~\ref{thm:mpu_source_v_complete_contraction} for the factors built
+    from the weight $\rho$. Hence the dressed Gram equation holds, and
+    Theorem~\ref{thm:mpu_source_v_dressed_gram_cancel} cancels the dressing.
+\end{proof}
+
 \begin{theorem}[Source-$v$ isometry of a simple tensor]
     \label{thm:mpu_simple_source_v_isometry}
     \lean{MPOTensor.IsMPUSimple.sourceV_isIsometry,
@@ -5206,13 +5248,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_supplied_projector_simple2, thm:mpu_source_v_complete_contraction, thm:mpu_source_v_dressed_gram_cancel}
-    Theorem~\ref{thm:mpu_supplied_projector_simple2} gives
-    $W^{ij}W^{k\ell}=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}$. Since $\rho$
-    is diagonal, $\rho^{\mathsf T}=\rho$, so
-    Theorem~\ref{thm:mpu_source_v_complete_contraction} gives the dressed Gram
-    equation for the factors built from the same weight $\rho$. Then
-    Theorem~\ref{thm:mpu_source_v_dressed_gram_cancel} cancels the dressing. Since $v^\dagger v=\Id$ on
+    \uses{thm:mpu_transpose_fixed_pair_source_v_isometry}
+    Since $\rho$ is diagonal, $\rho^{\mathsf T}=\rho$, so the supplied fixed
+    pair is the one required by
+    Theorem~\ref{thm:mpu_transpose_fixed_pair_source_v_isometry} for the weight
+    $\rho$, which gives $v^\dagger v=\Id$. Since $v^\dagger v=\Id$ on
     $\C^r\otimes\C^\ell$, the map $v$ is injective, so $r\ell\le d^2$.
 \end{proof}
 
@@ -5308,6 +5348,59 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     isometrically into one of dimension $r\ell$, one also has $d^2\leq r\ell$.
 \end{proof}
 
+\begin{lemma}[Source-$u$ isometry for a transposed fixed pair]
+    \label{lem:mpu_transpose_fixed_pair_source_u_isometry}
+    \lean{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair,
+        MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair,
+        MPOTensor.IsMPU.sourceU_isIsometry_of_transpose_fixed_pair}
+    \leanok
+    % **Scope restriction (supplied stabilized fixed pair):** this lemma
+    % assumes the exact rank-one identity explicitly, whereas source Lemma
+    % III.7 inherits it from the preceding canonical-form-II convention.
+    % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
+    \uses{def:mpu, def:mpu_source_uv, def:mpu_weighted_source_factors,
+        def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$. Let $W$ be
+    its double layer, put $E=d^{-1}\sum_iW^{ii}$ and
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and let $\rho>0$ be a
+    weight that is not assumed symmetric, with
+    \begin{align}
+        E^K & =\lvert\rho^{\mathsf T})(\Phi\rvert
+    \end{align}
+    for some $K\geq0$. Construct the source factors and $u$ from $\mathcal U$
+    using $\rho$. Then, for all physical pairs $p,q$,
+    \begin{align}
+        \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+         & =\operatorname{tr}\!\left(W^{p_1q_1}W^{p_2q_2}E^K\right),
+    \end{align}
+    and consequently
+    \begin{align}
+        u^\dagger u & =\Id.
+    \end{align}
+    The weight of the two normalizations and the stabilized right fixed point
+    are paired as the column-stacking coordinates require; a diagonal weight
+    has $\rho^{\mathsf T}=\rho$, which recovers
+    Lemma~\ref{lem:mpu_admissible_source_u_isometry}. This is the
+    supplied-fixed-pair version of \cite[Lemma~III.7]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 269--280 and 545--557. The weight orientation
+    % is recorded in docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_transpose_fixed_pair_trace,
+        thm:mpu_normalized_input_tail_closed_trace,
+        thm:mpu_normalized_input_tail_isometry}
+    Theorem~\ref{thm:mpu_source_u_transpose_fixed_pair_trace} closes the
+    source-$u$ Gram matrix to
+    $\operatorname{tr}(W^{p_2q_2}\lvert\rho^{\mathsf T})(\Phi\rvert W^{p_1q_1})$
+    for every weight, with no symmetry assumed. Substituting the supplied fixed
+    pair and cycling the first endpoint letter gives the displayed trace.
+    Theorem~\ref{thm:mpu_normalized_input_tail_closed_trace} expands that trace
+    as the normalized input tail, and
+    Theorem~\ref{thm:mpu_normalized_input_tail_isometry} evaluates the tail as
+    $\delta_{p,q}$.
+\end{proof}
+
 \begin{theorem}[Simple-tensor equivalence theorem]
     \label{ThmFund1}
     \notready
@@ -5330,6 +5423,58 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % unrestricted node remains not ready for the representative scope recorded
     % in docs/paper-gaps/mpu_canonical_form_full_support.tex.
 \end{theorem}
+
+\begin{theorem}[Simple-tensor equivalence with a transposed fixed pair]
+    \label{thm:mpu_transpose_fixed_pair_simple_tensor_equivalence}
+    \lean{MPOTensor.IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair}
+    \leanok
+    \uses{def:mpu, def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$, let $W$
+    be its double layer with normalized diagonal $E$, and let $\rho>0$ be a
+    weight that is not assumed symmetric. Suppose that
+    $E^J=\lvert\rho^{\mathsf T})(\Phi\rvert$ for some $J>0$, where
+    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Compute the source-cut
+    ranks $r$ and $\ell$ and both source operators $u$ and $v$ from this same
+    tensor $\mathcal U$ and weight $\rho$. Then the following are equivalent:
+    \begin{enumerate}
+        \item $\mathcal U$ is simple;
+        \item $r\ell=d^2$;
+        \item $u$ is unitary;
+        \item $v$ is unitary.
+    \end{enumerate}
+    The weight carried by the source cuts and the stabilized right fixed point
+    are paired as the column-stacking coordinates require, and no symmetry of
+    $\rho$ is used. This is the supplied-fixed-pair version of
+    \cite[Theorem~III.8]{Cirac2017MPU}, whose own convention makes $\rho$
+    diagonal.
+    % Source lines: paper_v2.tex 495 and 563--601. The weight orientation is
+    % recorded in docs/paper-gaps/mpu_source_cut_orientation.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_transpose_fixed_pair_source_u_isometry,
+        thm:mpu_transpose_fixed_pair_source_v_isometry,
+        thm:mpu_source_gates_two_site_factorization,
+        thm:mpu_simple_of_source_v_isometry}
+    Lemma~\ref{lem:mpu_transpose_fixed_pair_source_u_isometry} gives
+    $u^\dagger u=\Id$, hence $d^2\leq r\ell$, before any of the four conditions
+    is assumed. Follow the cycle $1\to2\to3\to4\to1$.
+
+    If $\mathcal U$ is simple,
+    Theorem~\ref{thm:mpu_transpose_fixed_pair_source_v_isometry} gives
+    $v^\dagger v=\Id$ for the operator built from the same weight $\rho$, hence
+    $r\ell\leq d^2$ and therefore $r\ell=d^2$. Conversely, this equality makes
+    the standing isometry $u$ square, hence unitary. The two-site factorization
+    gives
+    \begin{align}
+        \operatorname{reindex}(U^{(2)})
+         & =v\,\operatorname{swap}_{r,\ell}(u).
+    \end{align}
+    Reindexing preserves unitarity. Since $U^{(2)}$ and $u$ are unitary,
+    cancellation makes $v$ unitary. Finally, $v^\dagger v=\Id$ gives the second
+    simple contraction, while the MPU identity gives the first, so
+    $\mathcal U$ is simple.
+\end{proof}
 
 \begin{theorem}[Simple-tensor equivalence with a supplied diagonal fixed pair]
     \label{thm:mpu_diagonal_fixed_pair_simple_tensor_equivalence}
@@ -5354,31 +5499,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_admissible_source_u_isometry,
-        thm:mpu_simple_source_v_isometry,
-        thm:mpu_source_gates_two_site_factorization,
-        thm:mpu_simple_of_source_v_isometry}
-    The supplied fixed pair gives $u^\dagger u=\Id$ and
-    $d^2\leq r\ell$ before any of the four conditions is assumed. Follow the
-    cycle $1\to2\to3\to4\to1$.
-
-    If $\mathcal U$ is simple, the source-$v$ contraction for the same weight
-    $\rho$ gives $v^\dagger v=\Id$, hence $r\ell\leq d^2$ and therefore
-    $r\ell=d^2$. Conversely, this equality makes the standing isometry $u$
-    square, hence unitary. The two-site factorization gives
-    \begin{align}
-        \operatorname{reindex}(U^{(2)})
-         & =v\,\operatorname{swap}_{r,\ell}(u).
-    \end{align}
-    Reindexing preserves unitarity. Since $U^{(2)}$ and $u$ are unitary,
-    cancellation makes $v$ unitary. Finally, $v^\dagger v=\Id$ gives the
-    second simple contraction, while the MPU identity gives the first, so
-    $\mathcal U$ is simple.
+    \uses{thm:mpu_transpose_fixed_pair_simple_tensor_equivalence}
+    Since $\rho$ is diagonal, $\rho^{\mathsf T}=\rho$, so the supplied fixed
+    pair is the one required by
+    Theorem~\ref{thm:mpu_transpose_fixed_pair_simple_tensor_equivalence} for
+    the weight $\rho$.
 \end{proof}
 
 \begin{theorem}[Admissible simple-tensor equivalence theorem]
     \label{thm:mpu_admissible_simple_tensor_equivalence}
-    \notready
+    \lean{MPOTensor.IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair}
+    \leanok
     \discussion{5708}
     % **Scope restriction (all positive bond dimensions):** the $D=1$ branch
     % uses one-dimensional transfer stabilization; the $D>1$ branch uses chosen
@@ -5388,7 +5519,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_reduced_full_support_source_datum}
     Let $\mathcal U$ be an MPU tensor equipped with a reduced full-support
-    source datum, and let $\rho$ and $(\Phi\rvert$ be its normalized fixed pair.
+    source datum, and let $\rho$ and $(\Phi\rvert$ be its normalized source
+    weight and left fixed covector.
     Compute the source-cut ranks $r$ and $\ell$ and the source operators $u$ and
     $v$ from this same tensor $\mathcal U$ using $\rho$. Then the following
     conditions are equivalent:
@@ -5398,26 +5530,31 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \item $u$ is unitary;
         \item $v$ is unitary.
     \end{enumerate}
-    This is the reduced-source version of
+    The datum does not require $\rho$ to be diagonal, whereas
+    \cite[Theorem~III.8]{Cirac2017MPU} is stated under its preceding
+    canonical-form-II convention, in which $\rho$ is diagonal. Dropping that
+    convention is a generalization of the source statement and is not
+    attributed to it. This is the reduced-source version of
     \cite[Theorem~III.8]{Cirac2017MPU}.
-    % Source lines: paper_v2.tex 563--601.
+    % Source lines: paper_v2.tex 495 and 563--601.
 \end{theorem}
 
-\begin{proof}
-    \uses{lem:mpu_admissible_source_u_isometry,
-        thm:mpu_simple_source_v_isometry,
+\begin{proof}\leanok
+    \uses{lem:mpu_transpose_fixed_pair_source_u_isometry,
+        thm:mpu_transpose_fixed_pair_source_v_isometry,
         thm:mpu_simple_of_source_v_isometry,
         thm:mpu_source_gates_two_site_factorization}
-    Lemma~\ref{lem:mpu_admissible_source_u_isometry} gives
+    Lemma~\ref{lem:mpu_transpose_fixed_pair_source_u_isometry} gives
     $u^\dagger u=\Id$ before any of the four
     conditions is assumed. Thus $u$ is a standing isometry and
     $r\ell\geq d^2$ throughout the proof.
 
     Suppose first that $\mathcal U$ is simple. The reduced full-support datum
-    requires $\rho$ to be diagonal, so
-    Theorem~\ref{thm:mpu_simple_source_v_isometry} gives
-    $v^\dagger v=\Id$ for the source operator built from the same weight
-    $\rho$, hence $r\ell\leq d^2$.
+    supplies $E^J=\lvert\rho^{\mathsf T})(\Phi\rvert$, which is exactly the
+    insertion produced by the two weighted normalizations for the weight
+    $\rho$, so Theorem~\ref{thm:mpu_transpose_fixed_pair_source_v_isometry}
+    gives $v^\dagger v=\Id$ for the source operator built from that same weight
+    $\rho$, hence $r\ell\leq d^2$. No symmetry of $\rho$ is needed.
 
     If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
     Theorem~\ref{thm:mpu_source_gates_two_site_factorization} gives the exact

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -266,7 +266,8 @@ positive definite with trace one, and it
 satisfies~\eqref{eq:mpu_canonical_form_full_support_transposed_supplied_stabilization}.
 The diagonality clause previously carried by the reduced full-support source
 datum is therefore removed, and the diagonal-weight scope restriction on the
-source-$u$ and source-$v$ isometries is eliminated. What remains open in this
+source-$u$ and source-$v$ isometries is eliminated by the transposed-fixed-pair
+statements above. What remains open in this
 note is the construction of the source datum itself for an arbitrary
 representative, not the shape of its weight.
 % Source lines: paper_v2.tex 269--280 and 397--405.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -206,18 +206,16 @@ For $D>1$, the admissible source results assume reduced canonical-form-II data
 with full support for the same tensor $\mathcal U$ whose cuts, ranks, and source
 operators appear in their statements. For $D=1$, the one-dimensional
 stabilization theorem supplies the source pair directly. In either branch, the
-datum supplies $J>0$, a positive trace-one matrix $\rho$, and
+datum supplies $J>0$, a positive trace-one weight $\rho$, and
 \begin{align}
-    E^J &= \lvert\rho)(\Phi\rvert.
+    E^J &= \lvert\rho^{\mathsf T})(\Phi\rvert.
     \label{eq:mpu_canonical_form_full_support_supplied_stabilization}
 \end{align}
-The source-$u$ theorem additionally assumes that $\rho$ is diagonal, as in the
-source's canonical-form-II coordinates. Supplying these same-tensor diagonal
-source data is part of the construction tracked by \ghissue{7012}; the later
-unrestricted representative remains tracked by \ghissue{7127}. The admissible
-source-isometry and simple-tensor equivalence nodes cite Lemma~III.7 and
-Theorem~III.8 of Ref.~\cite{Cirac2017MPU} directly. Both retain the source
-factors of $\mathcal U$.
+Supplying these same-tensor source data is part of the construction tracked by
+\ghissue{7012}; the later unrestricted representative remains tracked by
+\ghissue{7127}. The admissible source-isometry and simple-tensor equivalence
+nodes cite Lemma~III.7 and Theorem~III.8 of Ref.~\cite{Cirac2017MPU} directly.
+Both retain the source factors of $\mathcal U$.
 % Source lines: paper_v2.tex 545--601.
 
 Blocking occurs only within the supplied-fixed-pair source-$u$ calculation.
@@ -227,6 +225,51 @@ $K$-site double-layer fixed pair. The calculation then keeps this one interior
 between the two unblocked endpoint letters. It does not replace the source
 cuts, ranks, or operators of $\mathcal U$, and it does not transport source
 data across blocking.
+
+\section{Pairing the source weight with the transfer fixed point}
+
+The diagonal hypothesis on the ambient matrix is not needed once the source
+weight and the transfer fixed point are paired as the column-stacking
+coordinates require. Both complete networks insert the column-stacking vector
+of $\rho^{\mathsf T}$, where $\rho$ is the weight of the two normalizations
+\texttt{X1X2b}. Supplying
+\begin{align}
+    E^J &= \lvert\rho^{\mathsf T})(\Phi\rvert
+    \label{eq:mpu_canonical_form_full_support_transposed_supplied_stabilization}
+\end{align}
+therefore matches the insertion exactly, for every positive definite $\rho$.
+% Source lines: paper_v2.tex 487--494, 545--557, and 577--588.
+
+On the source-$u$ side, the exact closure
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixed_pair_trace}
+already holds for every weight;
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair}
+substitutes~\eqref{eq:mpu_canonical_form_full_support_transposed_supplied_stabilization}
+and
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair}
+reads off $u^\dagger u=\Id$ from input-first unitarity, with the compact-SVD
+wrapper \leanid{MPOTensor.IsMPU.sourceU_isIsometry_of_transpose_fixed_pair}. On
+the source-$v$ side,
+\leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair} gives
+$v^\dagger v=\Id$ for the gate built from the same weight $\rho$. The full
+equivalence is
+\leanid{MPOTensor.IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair}. None of these
+assumes that $\rho$ is diagonal or symmetric. A diagonal weight has
+$\rho^{\mathsf T}=\rho$, so the source's own convention is the special case,
+and the diagonal statements are now derived from the general ones.
+% Source lines: paper_v2.tex 495 and 563--601.
+
+Existence is unaffected. If the reduced canonical-form-II data supply a
+positive trace-one ambient fixed point $\sigma$ with
+$E^J=\lvert\sigma)(\Phi\rvert$, take $\rho=\sigma^{\mathsf T}$: it is again
+positive definite with trace one, and it
+satisfies~\eqref{eq:mpu_canonical_form_full_support_transposed_supplied_stabilization}.
+The diagonality clause previously carried by the reduced full-support source
+datum is therefore removed, and the diagonal-weight scope restriction on the
+source-$u$ and source-$v$ isometries is eliminated. What remains open in this
+note is the construction of the source datum itself for an arbitrary
+representative, not the shape of its weight.
+% Source lines: paper_v2.tex 269--280 and 397--405.
 
 \section{Downstream standard-form, index, and symmetry scope}
 
@@ -575,9 +618,11 @@ unformalized; the distinct admissible nodes record the current same-tensor
 source-data route.
 
 Within Theorem~III.8 itself, the complete supplied-fixed-pair source-$u$
-contraction and the complete source-$v$ equivalence are formalized. The
+contraction, the complete source-$v$ equivalence, and the full four-way
+equivalence are formalized for an arbitrary positive definite source weight,
+with no diagonality or symmetry assumed. The
 unrestricted source statement \texttt{lemuisometry} remains open because the
-formalization does not yet construct the required same-tensor diagonal source
+formalization does not yet construct the required same-tensor source
 data from an arbitrary MPU. That admissible construction remains in
 \ghissue{7012}, and the unrestricted representative remains in
 \ghissue{7127}. Downstream standard-form, index, continuity, and symmetry

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -214,6 +214,19 @@ as tracked by \ghissue{7657} and \ghissue{7659}. Issue \ghissue{7653} instead
 asks for a nonsymmetric ambient-weight strengthening that CPSV17 does not
 claim. It is not the elimination step for the source-faithful theorem.
 
+That strengthening is now formalized separately, without touching the
+diagonal statements of the complete source-$u$ module. It pairs the source-cut
+weight $\rho$ with the stabilized fixed point $\rho^{\mathsf T}$, which is the
+pairing the column stacking of this note produces, and assumes no symmetry:
+\leanid{MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair},
+\leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair},
+\leanid{MPOTensor.IsMPU.sourceU_isIsometry_of_transpose_fixed_pair},
+\leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair}, and
+\leanid{MPOTensor.IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair}. The
+consequences for the reduced full-support source datum are recorded in
+\texttt{mpu\_canonical\_form\_full\_support.tex}. The source-labelled statement
+remains the diagonal one.
+
 \section{Affected claims and audit boundary}
 
 The transposed first cut affected source-factor recovery, physical adjunction,


### PR DESCRIPTION
Closes #7653.

## The gap

Both complete source networks of CPSV17 insert the column-stacking vector of the **transposed** source weight: the exact closures `MPOTensor.SourceFactors.sourceU_gram_eq_transpose_fixed_pair_trace` and `MPOTensor.sourceVDressedGram_iff_simple2_transpose_fixed_pair` hold for every weight $\rho$ and both produce $\lvert\rho^{\mathsf T})(\Phi\rvert$. The transfer stabilization was supplied as $E^J=\lvert\rho)(\Phi\rvert$ for the *same* $\rho$, so the two insertions agreed only when $\rho^{\mathsf T}=\rho$. That is why every closing theorem carried `ρ.IsDiag` (or `ρ.IsSymm`), and why `thm:mpu_admissible_simple_tensor_equivalence` was `\notready`.

## The fix

Pair the two as the column-stacking coordinates require. Supplying
$$E^J=\lvert\rho^{\mathsf T})(\Phi\rvert$$
for the weight $\rho$ carried by the two normalizations `X1X2b` matches the insertion exactly, for **every** positive definite $\rho$, with no symmetry hypothesis anywhere. The source's own convention makes $\rho$ diagonal, hence $\rho^{\mathsf T}=\rho$, and is recovered as the special case.

The existence side is unaffected: if the reduced canonical-form-II data supply a positive trace-one ambient fixed point $\sigma$ with $E^J=\lvert\sigma)(\Phi\rvert$, take $\rho=\sigma^{\mathsf T}$, again positive definite with trace one. So the reduced full-support source datum loses its diagonality clause outright, rather than trading it for another hypothesis.

## Lean

New, no symmetry assumed:

- `MPOTensor.IsMPUSimple.sourceV_isIsometry_of_transpose_fixed_pair` (`TNLean/MPS/MPU/SourceVCompleteNetwork.lean`)
- `MPOTensor.SourceFactors.sourceU_gram_eq_closed_doubleLayer_trace_of_transpose_fixed_pair`, `MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU_of_transpose_fixed_pair`, `MPOTensor.IsMPU.sourceU_isIsometry_of_transpose_fixed_pair` (new module `TNLean/MPS/MPU/SourceUTransposeFixedPair.lean`)
- `MPOTensor.IsMPU.isMPUSimple_tfae_of_transpose_fixed_pair` (`TNLean/MPS/MPU/SimpleTensorEquivalence.lean`)

Derived rather than duplicated: `IsMPUSimple.sourceV_transpose_isIsometry`, `IsMPUSimple.sourceV_isIsometry`, and `IsMPU.isMPUSimple_tfae` are now one-line consequences of the general statements. Their statements are unchanged, so every blueprint `\lean{}` tag still resolves.

`TNLean/MPS/MPU/SourceUCompleteNetwork.lean` is untouched: its diagonal theorems and the scope marker landed by #7675 remain exactly as merged, and the general source-$u$ closure lives in the new module, reusing the weight-free exact closure that module already exports.

## Faithfulness

Dropping the source's diagonal canonical-form-II convention is a **generalization** of Theorem III.8, not a claim attributed to CPSV17. Accordingly:

- the source-labelled node `ThmFund1` stays `\notready` and untouched;
- the strengthening gets its own nodes: `thm:mpu_transpose_fixed_pair_source_v_isometry`, `lem:mpu_transpose_fixed_pair_source_u_isometry`, `thm:mpu_transpose_fixed_pair_simple_tensor_equivalence`, each stating the transposed pairing explicitly and saying the source's convention is the diagonal special case;
- `thm:mpu_admissible_simple_tensor_equivalence` becomes formalized and says in its own text that the datum does not require $\rho$ diagonal and that dropping the convention is not attributed to the source. Its remaining scope restriction (the datum is a hypothesis, not a construction) is unchanged.

## Blueprint and notes

- `blueprint/src/chapter/ch28_mpu.tex`: three new `\leanok` nodes; `def:mpu_reduced_full_support_source_datum` drops its diagonality clause and states the transposed pairing; `thm:mpu_admissible_simple_tensor_equivalence` loses `\notready` and gains `\lean{}`/`\leanok`; the diagonal $v$-isometry and diagonal TFAE proofs now derive from the general nodes.
- `docs/paper-gaps/mpu_canonical_form_full_support.tex`: new section "Pairing the source weight with the transfer fixed point"; the verdict records that Theorem III.8 is now formalized for an arbitrary positive definite weight; what stays open is the construction of the source datum itself.
- `docs/paper-gaps/mpu_source_cut_orientation.tex`: the marker-boundary section names the new declarations and keeps the source-labelled statement the diagonal one, as #7675 framed it.

Unblocks the `\notready` nodes whose `\uses{}` cites `thm:mpu_admissible_simple_tensor_equivalence` (admissible standard form, admissible Fundamental Theorem of MPU, admissible index theorem and its well-definedness/tensor-product/composition lemmas) from this particular obstruction.

## Source

`Papers/1703.09188/paper_v2.tex`: equation `Y1Y1X1X1`/`X1X2b` lines 487--494 (the weighted normalization $X_1^\dagger(\Id\otimes\rho)X_1=\Id$), line 495 ("Recall that $\rho$ is a diagonal matrix with coefficients $\rho_n$"), `uUnitary` and Lemma III.7 lines 545--557, `vUnitary` lines 577--588, proof of Theorem III.8 lines 563--601, and `Erightleft` lines 269--280.

## Validation

- `lake env lean` on `TNLean/MPS/MPU/SourceUTransposeFixedPair.lean`, `TNLean/MPS/MPU/SourceVCompleteNetwork.lean`, and `TNLean/MPS/MPU/SimpleTensorEquivalence.lean`: no errors. `scripts/lake_build_locked.sh` was queued behind other worktrees' builds for the whole session; CI runs the linter-bearing build.
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast"` on the changed Lean files: no matches. No `sorry` is introduced.
- `python3 scripts/generate_import_aggregators.py`, `blueprint_lean_sync.py --update-lean-decls` (new declarations resolve; the 516 remaining warnings are QICLean declarations absent from this tree), `paper_gap_leanid_sync.py` (1909 heads, new ones present), `check_reader_facing_prose.py --ci` clean, `test_lean_file_policies.py` 16 tests OK.
- `scripts/latexindent -w -s -l blueprint/latexindent.yaml` on `blueprint/src/chapter/ch28_mpu.tex`: byte-identical. `chktex -q -l blueprint/.chktexrc`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm