### PR TITLE
doc(Blueprint): record product-adjoint and cross-rigidity lemmas

### DIFF
--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -306,9 +306,9 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     dimensions.
     % Source anchor: arXiv:2502.20257, line 1662 and prop:zetas,
     % lines 1662--1677.
-    This is the inverse-product step used in the proof of
-    Proposition~\texttt{prop:zetas}
-    of~\cite[lines~1662--1677]{FrancoRubio2025MPUGauging}, for the dagger
+    This is the inverse-product step used in the proof of the inversion
+    identities for $\zeta$ and $\omega$
+    in~\cite[lines~1662--1677]{FrancoRubio2025MPUGauging}, for the dagger
     operation described there, which conjugates every entry and exchanges the
     two legs lying on the same side of a tensor.
 \end{theorem}
@@ -1074,9 +1074,9 @@ Definition~\ref{def:mpug_group_representation}.
     If $A$ is injective, or more generally normal, then there is a scalar
     $c\in\C$ with $B_i=cA_i$ for every $i$.
     % Source anchor: arXiv:2502.20257, prop:MPUsplus, lines 1255--1325.
-    This is the commuting-tensor step in the proof of
-    Proposition~\texttt{prop:MPUsplus}
-    of~\cite[lines~1255--1325]{FrancoRubio2025MPUGauging}, where the tensor
+    This is the commuting-tensor step in the proof of the source-factor
+    contraction identities
+    in~\cite[lines~1255--1325]{FrancoRubio2025MPUGauging}, where the tensor
     commuting with a normal matrix product unitary tensor is shown to be a
     multiple of it.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -316,12 +316,12 @@ $N\geq1$. In particular, no identity at length zero is asserted.
 \begin{proof}\leanok
     \uses{def:mpdo_operator_product, def:mpdo_physical_adjoint}
     Expand both sides. The left side is the complex conjugate of the
-    $\bigl((\alpha\gamma),(\beta\delta)\bigr)$ entry of
+    $\bigl((\alpha,\gamma),(\beta,\delta)\bigr)$ entry of
     $\sum_j M^{kj}\otimes N^{ji}$, namely
     $\sum_j\overline{M^{kj}_{\alpha\beta}}\,
         \overline{N^{ji}_{\gamma\delta}}$.
     The right side is the
-    $\bigl((\gamma\alpha),(\delta\beta)\bigr)$ entry of
+    $\bigl((\gamma,\alpha),(\delta,\beta)\bigr)$ entry of
     $\sum_j (N^\sharp)^{ij}\otimes(M^\sharp)^{jk}$, namely
     $\sum_j\overline{N^{ji}_{\gamma\delta}}\,
         \overline{M^{kj}_{\alpha\beta}}$.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -296,7 +296,7 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     likewise. Then, for every pair of physical indices $i,k$,
     \begin{align}
         \bigl((M\mathbin{\cdot}N)^\sharp\bigr)^{ik}
-        _{(\alpha\gamma),(\beta\delta)}
+            _{(\alpha\gamma),(\beta\delta)}
          & =\bigl(N^\sharp\mathbin{\cdot}M^\sharp\bigr)^{ik}
         _{(\gamma\alpha),(\delta\beta)}.
         \label{eq:mpug_physical_adjoint_product_reversal}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -283,6 +283,51 @@ $N\geq1$. In particular, no identity at length zero is asserted.
     coefficient in (\ref{eq:mpug_physical_adjoint_inverse_mpv}).
 \end{proof}
 
+\begin{theorem}[Physical adjunction reverses the operator product]
+    \label{thm:mpug_physical_adjoint_product_reversal}
+    \lean{MPOTensor.productBondSwapEquiv,
+        MPOTensor.physicalAdjointTensor_mulTensor}
+    \leanok
+    \uses{def:mpdo_operator_product, def:mpdo_physical_adjoint}
+    Let $M$ and $N$ be MPO tensors with bond dimensions $D_M$ and $D_N$.
+    Write a left bond index of the product tensor as a pair
+    $(\alpha,\gamma)$, with $\alpha$ in the bond space of $M$ and $\gamma$ in
+    the bond space of $N$, and a right bond index as $(\beta,\delta)$
+    likewise. Then, for every pair of physical indices $i,k$,
+    \begin{align}
+        \bigl((M\mathbin{\cdot}N)^\sharp\bigr)^{ik}
+        _{(\alpha\gamma),(\beta\delta)}
+         & =\bigl(N^\sharp\mathbin{\cdot}M^\sharp\bigr)^{ik}
+        _{(\gamma\alpha),(\delta\beta)}.
+        \label{eq:mpug_physical_adjoint_product_reversal}
+    \end{align}
+    The two bond spaces need not have the same dimension, so the exchange of
+    the two factors of a product bond space is recorded here for unequal
+    dimensions.
+    % Source anchor: arXiv:2502.20257, line 1662 and prop:zetas,
+    % lines 1662--1677.
+    This is the inverse-product step used in the proof of
+    Proposition~\texttt{prop:zetas}
+    of~\cite[lines~1662--1677]{FrancoRubio2025MPUGauging}, for the dagger
+    operation described there, which conjugates every entry and exchanges the
+    two legs lying on the same side of a tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_operator_product, def:mpdo_physical_adjoint}
+    Expand both sides. The left side is the complex conjugate of the
+    $\bigl((\alpha\gamma),(\beta\delta)\bigr)$ entry of
+    $\sum_j M^{kj}\otimes N^{ji}$, namely
+    $\sum_j\overline{M^{kj}_{\alpha\beta}}\,
+        \overline{N^{ji}_{\gamma\delta}}$.
+    The right side is the
+    $\bigl((\gamma\alpha),(\delta\beta)\bigr)$ entry of
+    $\sum_j (N^\sharp)^{ij}\otimes(M^\sharp)^{jk}$, namely
+    $\sum_j\overline{N^{ji}_{\gamma\delta}}\,
+        \overline{M^{kj}_{\alpha\beta}}$.
+    The two sums agree term by term.
+\end{proof}
+
 Suppose now that the normalized flattening of every $\mathcal U_g$ is
 left-canonical.  This is the canonical-form hypothesis used in
 \cite[lines~1552--1557]{FrancoRubio2025MPUGauging}.
@@ -1012,6 +1057,51 @@ Definition~\ref{def:mpug_group_representation}.
     that $\delta^{-1}K_1$ and $\delta K_2$ have identity Gram matrices; these
     are $W_1$ and $W_2$ in
     (\ref{eq:mpug_unitary_kronecker_factors}).
+\end{proof}
+
+\begin{theorem}[Cross-product rigidity of a commuting family]
+    \label{thm:mpug_cross_product_rigidity}
+    \lean{Kraus.IsNormal.eq_smul_of_cross_mul_eq,
+        Kraus.IsInjective.eq_smul_of_cross_mul_eq}
+    \leanok
+    \uses{def:injective, def:normal}
+    Let $A_i$ and $B_i$ be two families of square matrices of the same size,
+    indexed by the same finite alphabet, and suppose that
+    \begin{align}
+        B_iA_j & =A_iB_j\qquad\text{for all }i,j.
+        \label{eq:mpug_cross_product_rigidity}
+    \end{align}
+    If $A$ is injective, or more generally normal, then there is a scalar
+    $c\in\C$ with $B_i=cA_i$ for every $i$.
+    % Source anchor: arXiv:2502.20257, prop:MPUsplus, lines 1255--1325.
+    This is the commuting-tensor step in the proof of
+    Proposition~\texttt{prop:MPUsplus}
+    of~\cite[lines~1255--1325]{FrancoRubio2025MPUGauging}, where the tensor
+    commuting with a normal matrix product unitary tensor is shown to be a
+    multiple of it.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:decomposition_map, thm:normal_tensor_gram_rigidity}
+    Let $N\geq1$ be a blocking length at which the length-$N$ words of $A$
+    span the full matrix algebra, and decompose the identity as
+    $\mathbf 1=\sum_\sigma c_\sigma A^{\sigma_1}\cdots A^{\sigma_N}$. The
+    cross relation moves the marked letter one step to the right,
+    \begin{align}
+        B_iA^{\sigma_1}\cdots A^{\sigma_N}
+         & =A_iB^{\sigma_1}A^{\sigma_2}\cdots A^{\sigma_N}.
+        \notag
+    \end{align}
+    Thus $B_i=A_iC$ with
+    $C=\sum_\sigma c_\sigma B^{\sigma_1}A^{\sigma_2}\cdots A^{\sigma_N}$.
+    Substituting this identity into
+    (\ref{eq:mpug_cross_product_rigidity}) gives
+    $A_i(CA_j-A_jC)=0$ for all $i$ and $j$. Multiplying on the left by a
+    length-$N$ word, whose last letter absorbs one of the $A_i$, and
+    recombining the words into the identity gives $CA_j=A_jC$. A matrix
+    commuting with every letter of a normal family is a multiple of the
+    identity, so $C=c\mathbf 1$ and $B_i=cA_i$. The injective case is the
+    case of blocking length one.
 \end{proof}
 
 \begin{theorem}[Comparison of factorizations from one-sided inverses]


### PR DESCRIPTION
## What changed

- document the heterogeneous product-bond swap and the product-reversal law for physical adjunction from merged PR #7695
- document the injective and normal cross-product rigidity theorems from merged PR #7693
- preserve the Chapter 29 source conventions and source-line anchors
- keep the decomposition-map dependency in the proof metadata only, addressing the valid review finding on superseded PR #7704
- sequence cleanly after merged Chapter 29 PR #7691, with no duplicated or conflicting edits

This isolates the only unique valid content from #7704. It does not retain either duplicate Lean implementation or duplicated history.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: 7862 / 7862 theorem-like entries in sync, Chapter 29 at 448 / 448
- `lake exe checkdecls blueprint/lean_decls`: passes after regenerating the ignored declaration list
- two direct `lualatex -interaction=nonstopmode -halt-on-error print.tex` passes with the pinned tenkz package: no undefined cross-references; only the known standalone citation warnings
- exact warmed `origin/main` delta build: 10512 / 10512 jobs
- `git diff --check`
