### PR TITLE
feat(parent-hamiltonian): identify active kernels and finish fixed-volume C3 spectator transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/SpectatorTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/SpectatorTransport.lean
@@ -816,6 +816,16 @@ theorem ker_openSuffixParentHamiltonianES_eq_openChainTailGroundSpaceES
         rw [mem_groundSpaceES_iff, cyclicRestrictES_tail_window hL]
         exact hv (fun k : Fin K => τ (Fin.castAdd L k))
 
+/-- For a block-injective tensor, the kernel of the prefix Hamiltonian that
+fills its own volume is the whole open-chain ground space. -/
+theorem ker_openPrefixParentHamiltonianES_self_eq_groundSpaceES
+    {A : MPSTensor d D} [NeZero D] {L₀ n : ℕ}
+    (hInj : Kraus.IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hL₀n : L₀ + 1 ≤ n) :
+    LinearMap.ker (openPrefixParentHamiltonianES A (L₀ + 1) n n) =
+      groundSpaceES A n := by
+  rw [openPrefixParentHamiltonianES_self_eq_openParentHamiltonianES,
+    ker_openParentHamiltonianES_eq_groundSpaceES_of_isNBlkInjective hInj hL₀ hL₀n]
+
 /-- Conjugating an operator by a linear isometry equivalence conjugates its
 kernel projection to the kernel projection of the conjugated operator. -/
 theorem ker_starProjection_conj_linearIsometryEquiv
@@ -942,11 +952,8 @@ theorem openPrefixWholeGroundProjectionES_conj_rightSpectatorConfigLinearIsometr
         U.symm.toLinearEquiv.toLinearMap) =
     (ContinuousLinearMap.rightFiberwiseMap (S := Cfg d r)
       (LinearMap.ker H).starProjection).toLinearMap at hproj
-  rw [show LinearMap.ker H = groundSpaceES A n by
-    change LinearMap.ker (openPrefixParentHamiltonianES A (L₀ + 1) n n) = _
-    rw [openPrefixParentHamiltonianES_self_eq_openParentHamiltonianES,
-      ker_openParentHamiltonianES_eq_groundSpaceES_of_isNBlkInjective
-        hInj hL₀ hL₀n]] at hproj
+  rw [show LinearMap.ker H = groundSpaceES A n from
+    ker_openPrefixParentHamiltonianES_self_eq_groundSpaceES hInj hL₀ hL₀n] at hproj
   exact hproj
 
 /-- In a fixed larger volume, a full suffix-window ground projection is the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -519,6 +519,7 @@
         MPSTensor.ker_openPrefixParentHamiltonianES_eq_openChainLeftGroundSpaceES,
         MPSTensor.openSuffixParentHamiltonianES_full_window_eq_localTermES,
         MPSTensor.ker_openSuffixParentHamiltonianES_eq_openChainTailGroundSpaceES,
+        MPSTensor.ker_openPrefixParentHamiltonianES_self_eq_groundSpaceES,
         MPSTensor.openPrefixGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv,
         MPSTensor.openPrefixWholeGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv,
         MPSTensor.openIntervalGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv}
@@ -528,7 +529,9 @@
     Let $K,l,n,r\in\mathbb{N}$.  Suppose that $A$ has nonzero bond dimension,
     is block injective at length $L_0>0$, and satisfies $L_0+1\leq n$.  The
     kernel of the range-$(L_0+1)$ prefix Hamiltonian on the first $n$ sites of
-    the $(n+1)$-site volume is the left open-chain ground space.  Independently,
+    the $(n+1)$-site volume is the left open-chain ground space.  When that
+    prefix instead fills its own $n$-site volume, its kernel is the whole
+    $n$-site ground space.  Independently,
     the kernel of the full final length-$(l+1)$ suffix window beginning at $K$
     is the tail open-chain ground space.  Let $U_{\mathrm{pre}}$ and
     $U_{\mathrm{tail}}$ be the canonical right-spectator isometries for the


### PR DESCRIPTION
## Summary

Issue #7545 asks for three active-space kernel identities on the fixed-final-volume
C3 route, the three projector transports built on them, the identification of the
fixed martingale difference with the right-fiberwise extension of the open-chain
one, and the resulting bound `‖Q_n E_n‖ ≤ ε_l` on every active index with both
endpoint cases explicit.

**Almost all of that already landed on `main` in #7552** (the #7535 spectator-C3
train, commits `318bc40cb`, `323ed326c`, `fd47061e2`, `1ab8db895`, `feb4819c1`),
which merged after the parent #7535 was closed but before this planning sub-issue
was. I audited the tree against the issue body line by line rather than assuming,
and found exactly one deliverable that was proved but never named:

- the prefix kernel at level `K+l`: `MPSTensor.ker_openPrefixParentHamiltonianES_eq_openChainLeftGroundSpaceES` — present;
- the local interval kernel: `MPSTensor.ker_openSuffixParentHamiltonianES_eq_openChainTailGroundSpaceES` — present;
- **the next prefix kernel equals the whole ground space under block injectivity** — proved only inside an anonymous `show` term in the body of
  `openPrefixWholeGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv`.

This PR extracts that third identity as
`MPSTensor.ker_openPrefixParentHamiltonianES_self_eq_groundSpaceES` and rewrites
the one site that had inlined it, so all three kernel identities of the source
route are first-class, citable, and auditable on their own. Chapter 13's
`thm:fixed-volume-c3-projector-conjugacy` now lists the third declaration in its
`\lean{...}` set and states it in prose beside the other two.

## Source

`References/cond-mat_9410110/main.tex`:

- condition **C3**, lines 1083–1094: `‖G_{Λ_{n+1}\Λ_{n-l}} E_n‖ ≤ ε_l` with `ε_l < 1/√(l+1)`;
- proof of **Theorem 2.1(i)**, lines 1178–1259: the opening identity
  `G_{Λ_{n+1}\Λ_{n-l}} E_n = G_{Λ_{n+1}\Λ_{n-l}} G_{Λ_n} − G_{Λ_{n+1}}`, the
  resolution `ψ = Σ_{n<N} E_n ψ` (`resolutionpsi`), the identity `Enpsi`, the
  `E_m`/`G_{n,l}` commutation restricting the sum to `m ∈ [n−l, n]`, and the
  closing choice `c₁ = 1 − ε_l√(l+1)`, `c₂ = ε_l/√(l+1)`.

## Declaration added

- `MPSTensor.ker_openPrefixParentHamiltonianES_self_eq_groundSpaceES` —
  `TNLean/MPS/ParentHamiltonian/Martingale/SpectatorTransport.lean:821`.
  For an `L₀`-block-injective tensor with `0 < L₀` and `L₀ + 1 ≤ n`, the kernel of
  the range-`(L₀+1)` prefix Hamiltonian that fills its own `n`-site volume is
  `groundSpaceES A n`.

## State of the rest of the issue on `main` (unchanged by this PR)

Already proved, `sorry`-free, and blueprint-tagged:

- projector transports — `openPrefixGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv`,
  `openPrefixWholeGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv`,
  `openIntervalGroundProjectionES_conj_rightSpectatorConfigLinearIsometryEquiv`;
- fixed martingale difference as a right-fiberwise extension —
  `fixedAmbient_martingaleDifference_conj_rightSpectatorConfigLinearIsometryEquiv`
  and `openIntervalGroundProjectionES_comp_martingaleDifference_conj_rightSpectator`;
- the `n < l` endpoint — `openPrefixParentHamiltonianES_eq_zero_of_lt`,
  `openPrefixGroundProjectionES_eq_one_of_lt`,
  `fixedAmbient_martingaleDifference_eq_zero_of_lt`;
- the `n = l` endpoint — `openIntervalGroundProjectionES_at_endpoint` and
  `openIntervalGroundProjectionES_comp_martingaleDifference_at_endpoint`
  (`E_l = I − G_{Λ_{l+1}}`, `Q_l = G_{Λ_{l+1}}`, so `Q_l E_l = 0`);
- the full active-index bound —
  `IsPrimitiveMPS.exists_fixedAmbient_martingaleDifference_norm_lt_c3_threshold`,
  which case-splits on `lt_trichotomy n l`, sets `K = n − l` with `0 < K` in the
  `n > l` branch, and reuses the same `l` and the same `ε` as the open-chain
  estimate, with `0 ≤ ε` and `ε < 1/√(l+1)` — no shift to `ε_{l+1}`, no
  strengthening to `0 < ε`, and no `rfl` identification between the variable- and
  fixed-volume ambient spaces (they are related only through the bundled
  `≃ₗᵢ[ℂ]` built from `Fin.appendEquiv` and `LinearIsometryEquiv.piLpCongrLeft`).

## Verification

- `scripts/lake_build_locked.sh` full build: `Build completed successfully (10508 jobs)`,
  including `TNLean.MPS.ParentHamiltonian.Martingale.SpectatorTransport` and
  `...FixedAmbientMartingaleBound`.
- `lake exe checkdecls blueprint/lean_decls`: clean (chained after the build; no
  missing declarations reported).
- `lake exe lint_style`: clean.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`:
  `✓ Blueprint and Lean code are in sync.` (7847/7847, 100.0%).
- No `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.

Closes #7545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
