### PR TITLE
feat(MPS/Periodic): prove the proportional fundamental theorem with equal matched periods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,7 @@ follow-up, not against the temporary `sorry` count.
 | `Finset.sum_eq_sum_subtype_ne_zero` | helper theorem | Restricting a finite sum to the subtype where a weight is nonzero when the remaining summands vanish | `TNLean/Algebra/FinsetSubtypeSum.lean` |
 | `Subsemigroup.exists_nonempty_list_prod_of_mem_closure` | helper theorem | Representing an element of a generated subsemigroup as a nonempty list product of generators | `TNLean/Algebra/ListProduct.lean` |
 | `Complex.ofReal_sqrt_sq` | helper theorem | Squaring the complex coercion of a nonnegative real square root | `TNLean/Algebra/ComplexSqrt.lean` |
+| `MPSTensor.transferMap_smul_eq_of_norm_eq_one` | helper theorem | Replacing the transfer map of a tensor scaled by a unit-norm complex scalar with the original transfer map | `TNLean/MPS/SharedInfra/Scaling.lean` |
 | `Matrix.IsIsometry.kronecker` | helper theorem | Preserving matrix isometries under the Kronecker product | `QICLean/Algebra/MatrixIsometryKronecker.lean` (QICLean dependency) |
 | `Matrix.reindexLinearEquiv_mul` | helper theorem | Multiplying matrices transported along compatible row, middle, and column equivalences; instantiate all three equivalences explicitly | `Mathlib/LinearAlgebra/Matrix/Reindex.lean` |
 | `Matrix.entry_eq_of_heq` | helper theorem | Equating entries of a dependent family of matrices from the index equation and two heterogeneous coordinate identifications | `TNLean/MPS/MPDO/PhysicalSectorFactorization.lean` |

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -331,6 +331,27 @@ theorem ZGaugeEquiv.blockTensor_sameMPV {m : ℕ} {A B : MPSTensor d D}
     SameMPV (blockTensor A m) (blockTensor B m) :=
   GaugeEquiv.sameMPV (ZGaugeEquiv.blockTensor_gaugeEquiv h)
 
+/-- A positive period is determined by its set of complex roots of unity.
+
+The unit-circle spectrum of a periodic block is exactly the set of roots of
+unity whose order is the period (arXiv:1708.00029, lines 257--258), so two
+periodic blocks with a common peripheral spectrum have a common period. -/
+theorem period_eq_of_setOf_pow_eq_one {m n : ℕ} (hm : 0 < m) (hn : 0 < n)
+    (h : {μ : ℂ | μ ^ m = 1} = {μ : ℂ | μ ^ n = 1}) : m = n := by
+  obtain ⟨ω, hω⟩ : ∃ ω : ℂ, IsPrimitiveRoot ω m :=
+    ⟨Complex.exp (2 * Real.pi * Complex.I / m), Complex.isPrimitiveRoot_exp m hm.ne'⟩
+  obtain ⟨η, hη⟩ : ∃ η : ℂ, IsPrimitiveRoot η n :=
+    ⟨Complex.exp (2 * Real.pi * Complex.I / n), Complex.isPrimitiveRoot_exp n hn.ne'⟩
+  have hωn : ω ^ n = 1 := by
+    have hmem : ω ∈ ({μ : ℂ | μ ^ m = 1} : Set ℂ) := hω.pow_eq_one
+    rw [h] at hmem
+    exact hmem
+  have hηm : η ^ m = 1 := by
+    have hmem : η ∈ ({μ : ℂ | μ ^ n = 1} : Set ℂ) := hη.pow_eq_one
+    rw [← h] at hmem
+    exact hmem
+  exact Nat.dvd_antisymm (hω.dvd_of_pow_eq_one _ hωn) (hη.dvd_of_pow_eq_one _ hηm)
+
 /-- Repeated periodic blocks have equal periods, provided they share peripheral spectrum. -/
 theorem IsPeriodic.period_eq_of_repeatedBlocks
     {m n : ℕ} {A B : MPSTensor d D}
@@ -338,27 +359,23 @@ theorem IsPeriodic.period_eq_of_repeatedBlocks
     (_hRep : RepeatedBlocks A B)
     (hSpec : peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) =
       peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B)) :
-    m = n := by
-  rcases hA.primitiveRoot with ⟨ω, hω⟩
-  rcases hB.primitiveRoot with ⟨η, hη⟩
-  have hωm : ω ^ m = 1 := hω.pow_eq_one
-  have hηn : η ^ n = 1 := hη.pow_eq_one
-  have hω_mem_A : ω ∈ peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) := by
-    rw [hA.peripheral_eq]
-    exact hωm
-  have hη_mem_B : η ∈ peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B) := by
-    rw [hB.peripheral_eq]
-    exact hηn
-  have hω_mem_B : ω ∈ peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B) := by
-    simpa [hSpec] using hω_mem_A
-  have hη_mem_A : η ∈ peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) := by
-    simpa [hSpec] using hη_mem_B
-  have hωn : ω ^ n = 1 := by
-    have : ω ∈ ({μ : ℂ | μ ^ n = 1} : Set ℂ) := by simpa [hB.peripheral_eq] using hω_mem_B
-    exact this
-  have hηm : η ^ m = 1 := by
-    have : η ∈ ({μ : ℂ | μ ^ m = 1} : Set ℂ) := by simpa [hA.peripheral_eq] using hη_mem_A
-    exact this
-  exact Nat.dvd_antisymm (hω.dvd_of_pow_eq_one _ hωn) (hη.dvd_of_pow_eq_one _ hηm)
+    m = n :=
+  period_eq_of_setOf_pow_eq_one hA.period_pos hB.period_pos
+    (by rw [← hA.peripheral_eq, ← hB.peripheral_eq]; exact hSpec)
+
+/-- Spectrally periodic blocks with a common peripheral transfer spectrum have
+equal periods.
+
+This is the spectral content of the last clause of arXiv:1708.00029,
+proposition `equal-or-orthogonal-generalized`, line 608: blocks related by the
+repeated-block condition can only have the same period. -/
+theorem IsSpectrallyPeriodic.period_eq_of_peripheralEigenvalues_eq
+    {m n : ℕ} {A B : MPSTensor d D}
+    (hA : IsSpectrallyPeriodic m A) (hB : IsSpectrallyPeriodic n B)
+    (hSpec : peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) =
+      peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B)) :
+    m = n :=
+  period_eq_of_setOf_pow_eq_one hA.period_pos hB.period_pos
+    (by rw [← hA.peripheral_eq, ← hB.peripheral_eq]; exact hSpec)
 
 end MPSTensor

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -352,7 +352,10 @@ theorem period_eq_of_setOf_pow_eq_one {m n : ℕ} (hm : 0 < m) (hn : 0 < n)
     exact hmem
   exact Nat.dvd_antisymm (hω.dvd_of_pow_eq_one _ hωn) (hη.dvd_of_pow_eq_one _ hηm)
 
-/-- Repeated periodic blocks have equal periods, provided they share peripheral spectrum. -/
+/-- Periodic blocks with the same peripheral transfer spectrum have equal periods.
+
+The repeated-block premise records the intended application, but the common
+peripheral spectrum is the sufficient hypothesis. -/
 theorem IsPeriodic.period_eq_of_repeatedBlocks
     {m n : ℕ} {A B : MPSTensor d D}
     (hA : IsPeriodic m A) (hB : IsPeriodic n B)
@@ -367,8 +370,8 @@ theorem IsPeriodic.period_eq_of_repeatedBlocks
 equal periods.
 
 This is the spectral content of the last clause of arXiv:1708.00029,
-proposition `equal-or-orthogonal-generalized`, line 608: blocks related by the
-repeated-block condition can only have the same period. -/
+proposition `equal-or-orthogonal-generalized`, lines 602--604: blocks related
+by the repeated-block condition can only have the same period. -/
 theorem IsSpectrallyPeriodic.period_eq_of_peripheralEigenvalues_eq
     {m n : ℕ} {A B : MPSTensor d D}
     (hA : IsSpectrallyPeriodic m A) (hB : IsSpectrallyPeriodic n B)

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -171,8 +171,8 @@ map unchanged, and the remaining bond-space similarity conjugates that map.
 Neither operation moves the unit-circle eigenvalues.
 
 Source: arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`,
-lines 276--284; the spectral invariance is the content of the last clause of
-proposition `equal-or-orthogonal-generalized`, line 608. -/
+lines 276--284; the spectral invariance supports the last clause of proposition
+`equal-or-orthogonal-generalized`, lines 602--604. -/
 theorem RepeatedBlocks.peripheralEigenvalues_transferMap_eq {D : ℕ}
     {A B : MPSTensor d D} (h : RepeatedBlocks A B) :
     peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) =
@@ -199,8 +199,8 @@ theorem RepeatedBlocks.peripheralEigenvalues_transferMap_eq {D : ℕ}
 /-- Repeated spectrally periodic blocks have the same period.
 
 This is the last clause of arXiv:1708.00029, proposition
-`equal-or-orthogonal-generalized`, line 608: the repeated-block relation can
-only hold between blocks of equal period. -/
+`equal-or-orthogonal-generalized`, lines 602--604: the repeated-block relation
+can only hold between blocks of equal period. -/
 theorem IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks
     {D₁ D₂ m n : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsSpectrallyPeriodic m A) (hB : IsSpectrallyPeriodic n B)
@@ -230,7 +230,7 @@ the two bases of periodic tensors, equality of the two matched periods, and the
 repeated-block relation for every matched pair.
 
 This strengthens `PeriodicBlockMatchingWitness` by the period equality asserted
-in arXiv:1708.00029, theorem `thm:bd`, lines 623--626 ("there is exactly one
+in arXiv:1708.00029, theorem `thm:bd`, lines 616--620 ("there is exactly one
 `k ∈ K` (with the same period)"). -/
 abbrev PeriodicBasisMatchingWitness
     {rA rB : ℕ}
@@ -429,7 +429,7 @@ their bases of periodic tensors match: equal block counts, a bijection, and per-
 `HetRepeatedBlocks` equivalence.
 
 **Scope restriction (conditional overlap hypothesis):** source theorem
-`thm:bd` at arXiv:1708.00029, lines 613--632 assumes proportional assembled
+`thm:bd` at arXiv:1708.00029, lines 613--623 assumes proportional assembled
 MPVs. Here the required non-decaying partners and their repeated-block
 classification are supplied directly through `PeriodicOverlapHypothesis`.
 Thus this theorem is a conditional matching lemma toward `thm:bd`, not its
@@ -533,7 +533,7 @@ full-cycle contraction `sectorTensor_proportional_of_blockedMatch`. The explicit
 non-decaying cross-family overlap hypotheses remain additional inputs.
 
 **Scope restriction (conditional non-decay witnesses):** source theorem
-`thm:bd` at arXiv:1708.00029, lines 613--632 assumes proportionality of the
+`thm:bd` at arXiv:1708.00029, lines 613--623 assumes proportionality of the
 assembled MPVs and derives these witnesses. This declaration is only the
 subsequent finite matching step. The gap is recorded in
 `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`. -/

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -24,9 +24,11 @@ in its equal-case strengthening:
   theorem `thm:bd` instead assumes proportionality of the assembled MPV
   families. The companion module `ProportionalOverlap` proves the deduction
   for literal multiplicity-bearing families of spectrally periodic blocks,
-  including transport through their sectorwise Perron similarities. A
-  source-labelled matching theorem retaining equality of matched periods
-  remains to be stated.
+  including transport through their sectorwise Perron similarities, and
+  assembles the source-labelled theorem
+  `fundamentalTheorem_periodic_proportional_sectorDecomposition` over the
+  stronger witness `PeriodicBasisMatchingWitness`, which retains equality of
+  the matched periods.
 
 * **Supporting lemmas for the equal-case theorem `thm:bdequal`**: The equal-case
   strengthening produces per-block Z-gauge data (diagonal Z with Z^m = 1) from the
@@ -160,6 +162,53 @@ theorem HetRepeatedBlocks.exists_phase_rescaling_sameMPV₂Pos {D₁ D₂ : ℕ}
   have hscale : mpv (fun i => ζ⁻¹ • A i) σ = ζ⁻¹ ^ N * mpv A σ :=
     mpv_eq_pow_mul_of_gaugePhase A (fun i => ζ⁻¹ • A i) 1 ζ⁻¹ (fun i => by simp) N σ
   rw [hscale, hmpv N σ, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]
+/-! ## Repeated blocks have a common period -/
+
+/-- Repeated blocks have the same peripheral transfer spectrum.
+
+Multiplying every matrix of a block by a unit-modulus phase leaves its transfer
+map unchanged, and the remaining bond-space similarity conjugates that map.
+Neither operation moves the unit-circle eigenvalues.
+
+Source: arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`,
+lines 276--284; the spectral invariance is the content of the last clause of
+proposition `equal-or-orthogonal-generalized`, line 608. -/
+theorem RepeatedBlocks.peripheralEigenvalues_transferMap_eq {D : ℕ}
+    {A B : MPSTensor d D} (h : RepeatedBlocks A B) :
+    peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) =
+      peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B) := by
+  obtain ⟨ξ, Y, hξ, hRel⟩ := h
+  have hphase : ξ * starRingEnd ℂ ξ = 1 := by
+    simp [Complex.mul_conj, Complex.normSq_eq_norm_sq, hξ]
+  have hGauge : GaugeEquiv B (fun i =>
+      (Y : Matrix (Fin D) (Fin D) ℂ) * B i *
+        (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :=
+    ⟨Y, fun _ => rfl⟩
+  have hSmul : Kraus.transferMap (d := d) (D := D) A =
+      Kraus.transferMap (d := d) (D := D) (fun i =>
+        (Y : Matrix (Fin D) (Fin D) ℂ) * B i *
+          (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) := by
+    have hAeq : A = fun i => ξ • ((Y : Matrix (Fin D) (Fin D) ℂ) * B i *
+        (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) := funext hRel
+    refine LinearMap.ext fun X => ?_
+    rw [hAeq, transferMap_smul, hphase, one_smul]
+  obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
+  rw [hSmul, hMap]
+  exact peripheralEigenvalues_similarityMap_eq (D := D) C hC _
+
+/-- Repeated spectrally periodic blocks have the same period.
+
+This is the last clause of arXiv:1708.00029, proposition
+`equal-or-orthogonal-generalized`, line 608: the repeated-block relation can
+only hold between blocks of equal period. -/
+theorem IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks
+    {D₁ D₂ m n : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsSpectrallyPeriodic m A) (hB : IsSpectrallyPeriodic n B)
+    (h : HetRepeatedBlocks A B) : m = n := by
+  obtain ⟨hDim, hRep⟩ := h
+  subst hDim
+  exact hA.period_eq_of_peripheralEigenvalues_eq hB
+    hRep.peripheralEigenvalues_transferMap_eq
 
 /-! ## Periodic block matching witness -/
 
@@ -174,6 +223,25 @@ abbrev PeriodicBlockMatchingWitness
   ∃ _h : rA = rB,
     ∃ perm : Fin rA ≃ Fin rB,
       ∀ j : Fin rA, HetRepeatedBlocks (A j) (B (perm j))
+
+/-- Witness for the matching conclusion of the proportional fundamental theorem
+for tensors in irreducible form: equal numbers of blocks, a bijection between
+the two bases of periodic tensors, equality of the two matched periods, and the
+repeated-block relation for every matched pair.
+
+This strengthens `PeriodicBlockMatchingWitness` by the period equality asserted
+in arXiv:1708.00029, theorem `thm:bd`, lines 623--626 ("there is exactly one
+`k ∈ K` (with the same period)"). -/
+abbrev PeriodicBasisMatchingWitness
+    {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (periodA : Fin rA → ℕ) (periodB : Fin rB → ℕ) : Prop :=
+  ∃ _h : rA = rB,
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∀ j : Fin rA,
+        periodA j = periodB (perm j) ∧ HetRepeatedBlocks (A j) (B (perm j))
 
 /-! ## Periodic overlap dichotomy hypothesis -/
 
@@ -384,10 +452,9 @@ hypotheses for literal multiplicity-bearing normalized periodic forms, with
 specialization. Its theorem
 `PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions` performs
 the sectorwise Perron normalization and transports the hypothesis back to the
-original spectral-radius-one blocks. The remaining source-faithfulness gap is
-to package the matching conclusion while retaining equality of matched
-periods, as recorded in
-`docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`.
+original spectral-radius-one blocks. Combining the two gives the source-labelled
+`fundamentalTheorem_periodic_proportional_sectorDecomposition`, which also
+retains equality of the matched periods.
 
 The `PeriodicOverlapHypothesis` parameter can be supplied via
 `PeriodicOverlapHypothesis.ofIsPeriodic`, which uses the proved

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -178,8 +178,6 @@ theorem RepeatedBlocks.peripheralEigenvalues_transferMap_eq {D : ℕ}
     peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) =
       peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B) := by
   obtain ⟨ξ, Y, hξ, hRel⟩ := h
-  have hphase : ξ * starRingEnd ℂ ξ = 1 := by
-    simp [Complex.mul_conj, Complex.normSq_eq_norm_sq, hξ]
   have hGauge : GaugeEquiv B (fun i =>
       (Y : Matrix (Fin D) (Fin D) ℂ) * B i *
         (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :=
@@ -190,8 +188,8 @@ theorem RepeatedBlocks.peripheralEigenvalues_transferMap_eq {D : ℕ}
           (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) := by
     have hAeq : A = fun i => ξ • ((Y : Matrix (Fin D) (Fin D) ℂ) * B i *
         (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) := funext hRel
-    refine LinearMap.ext fun X => ?_
-    rw [hAeq, transferMap_smul, hphase, one_smul]
+    rw [hAeq]
+    exact transferMap_smul_eq_of_norm_eq_one _ ξ hξ
   obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
   rw [hSmul, hMap]
   exact peripheralEigenvalues_similarityMap_eq (D := D) C hC _

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -37,7 +37,7 @@ the nonzero complex multiplicity weights.
 
 * De las Cuevas, Cirac, Schuch, Perez-Garcia,
   *Irreducible forms of Matrix Product States: Theory and Applications*,
-  arXiv:1708.00029, theorem `thm:bd`, lines 613--632.
+  arXiv:1708.00029, theorem `thm:bd`, lines 613--623.
 -/
 
 open scoped Matrix BigOperators
@@ -340,7 +340,7 @@ original representatives.
 
 Source: arXiv:1708.00029, equations `eq:bdnr` and `eq:Bbdnr`, lines 286--305
 and 575--585; normalization by block-diagonal similarity, lines 313--332; and
-theorem `thm:bd`, lines 613--632. -/
+theorem `thm:bd`, lines 613--623. -/
 theorem PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ)
@@ -399,7 +399,7 @@ or on the positive real weights.
 
 Source: arXiv:1708.00029, equations `eq:bdnr` and `eq:Bbdnr`, lines 286--305
 and 575--585; normalization by similarity, lines 313--332; and theorem
-`thm:bd`, lines 613--632.
+`thm:bd`, lines 613--623.
 
 **Scope restriction (weights, length, representation, and normalization):**
 `IsIrreducibleForm` records one positive real scalar for each periodic block,
@@ -512,10 +512,10 @@ each fixed length, the repeated-block classification from the periodic overlap
 dichotomy, and the equality of matched periods from the invariance of the
 peripheral transfer spectrum under the repeated-block relation.
 
-Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--632, over the
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623, over the
 irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582; the
 period clause is the last clause of proposition
-`equal-or-orthogonal-generalized`, line 608. -/
+`equal-or-orthogonal-generalized`, lines 602--604. -/
 theorem fundamentalTheorem_periodic_proportional_sectorDecomposition
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ)

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -29,6 +29,9 @@ the nonzero complex multiplicity weights.
   after a pure block-diagonal Perron gauge.
 * `PeriodicOverlapHypothesis.ofIsIrreducibleForm`: the scalar-weight
   irreducible-form specialization.
+* `fundamentalTheorem_periodic_proportional_sectorDecomposition`: the
+  proportional fundamental theorem itself, matching the two bases of periodic
+  tensors bijectively with equal periods and repeated blocks.
 
 ## Reference
 
@@ -488,5 +491,47 @@ theorem PeriodicOverlapHypothesis.ofIsIrreducibleForm
     exact tendsto_mpvOverlap_zero_swap (hA.blocks j₀) (hB.blocks k₀) hDecay
   exact PeriodicOverlapHypothesis.ofIsPeriodic
     hA.blocks hB.blocks hA.period hB.period hA.periodic hB.periodic hExA hExB
+
+/-! ## The proportional fundamental theorem for tensors in irreducible form -/
+
+/-- **Fundamental theorem for matrix product states, proportional case.**
+
+Let two tensors carry the multiplicity-bearing irreducible forms
+\(A^i=\bigoplus_{j\in J}(R_j\otimes A^i_j)\) and
+\(B^i=\bigoplus_{k\in K}(S_k\otimes B^i_k)\), with \(R_j\) and \(S_k\) diagonal
+with nonzero entries and with pairwise non-repeated bases of periodic tensors
+\(\{A_j\}\) and \(\{B_k\}\).  If the two generated matrix-product vectors are
+proportional by a nonzero scalar at every positive length, then the two bases
+have the same size and there is a bijection \(\pi\colon J\to K\) matching each
+\(A_j\) with the single \(B_{\pi(j)}\) of the same period, for which
+\(A^i_j=\xi_jY_jB^i_{\pi(j)}Y_j^{-1}\) with a unit-modulus scalar \(\xi_j\) and
+an invertible \(Y_j\).
+
+The non-decaying overlap partners come from grouped-coefficient comparison at
+each fixed length, the repeated-block classification from the periodic overlap
+dichotomy, and the equality of matched periods from the invariance of the
+peripheral transfer spectrum under the repeated-block relation.
+
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--632, over the
+irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582; the
+period clause is the last clause of proposition
+`equal-or-orthogonal-generalized`, line 608. -/
+theorem fundamentalTheorem_periodic_proportional_sectorDecomposition
+    (P Q : SectorDecomposition d)
+    (periodP : Fin P.basisCount → ℕ)
+    (periodQ : Fin Q.basisCount → ℕ)
+    (hPerP : ∀ j, IsSpectrallyPeriodic (periodP j) (P.basis j))
+    (hPerQ : ∀ k, IsSpectrallyPeriodic (periodQ k) (Q.basis k))
+    (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
+    (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
+    (hProp : NonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    PeriodicBasisMatchingWitness P.basis Q.basis periodP periodQ := by
+  obtain ⟨hCount, perm, hMatch⟩ :=
+    fundamentalTheorem_periodic_proportional P.basis Q.basis hNonRepP hNonRepQ
+      (PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions
+        P Q periodP periodQ hPerP hPerQ hNonRepP hNonRepQ hProp)
+  exact ⟨hCount, perm, fun j =>
+    ⟨IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks
+      (hPerP j) (hPerQ (perm j)) (hMatch j), hMatch j⟩⟩
 
 end MPSTensor

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.RFP.BeigiLoopFixedPoint
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BNTDirectSumBasis
 import TNLean.MPS.RFP.ResidualIsometry
+import TNLean.MPS.SharedInfra.Scaling
 
 /-!
 # Identification of Beigi loop sectors with normal tensors
@@ -188,25 +189,6 @@ theorem exists_mpvBlockPhaseEquiv_of_mem_span_eventually
       Submodule.span ℂ (Set.range fun j : ι => mpvState (d := d) (B j) N) := by
     simpa [C, Function.comp_def] using (linearIndependent_option.mp hLIN).2
   exact hNotMem hNmem
-
-/-- Multiplication of every tensor letter by a unit phase leaves the transfer map unchanged.
-
-The transfer map scales by `ζ * star ζ`, which is one when `‖ζ‖ = 1`. This is the
-normalization-sensitive scalar step in the BNT identification at arXiv:1606.00608, line 1307;
-the spectral normalization is that of lines 224--235, obtained from quantum Wielandt
-Proposition 3 (arXiv:0909.5347) and Wolf, Theorem 6.3.
--/
-theorem transferMap_smul_eq_of_norm_eq_one
-    (A : MPSTensor d D) (ζ : ℂ) (hζ : ‖ζ‖ = 1) :
-    Kraus.transferMap (fun i => ζ • A i) = Kraus.transferMap A := by
-  have hstar : starRingEnd ℂ ζ * ζ = 1 := by
-    simpa [Complex.normSq_eq_norm_sq, hζ] using
-      (Complex.normSq_eq_conj_mul_self (z := ζ)).symm
-  have hphase : ζ * starRingEnd ℂ ζ = 1 := by
-    rw [mul_comm, hstar]
-  apply LinearMap.ext
-  intro X
-  rw [transferMap_smul, hphase, one_smul]
 
 /-- An explicit unit-phase gauge relation transports transfer idempotence.
 

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -28,6 +28,18 @@ theorem transferMap_smul (c : ℂ) (A : MPSTensor d D) (X : Matrix (Fin D) (Fin 
   simp_rw [smul_mul_assoc, mul_smul_comm, smul_smul, ← Finset.smul_sum]
   rfl
 
+/-- Multiplying every tensor letter by a unit-norm scalar leaves the transfer
+map unchanged. -/
+theorem transferMap_smul_eq_of_norm_eq_one
+    (A : MPSTensor d D) (c : ℂ) (hc : ‖c‖ = 1) :
+    Kraus.transferMap (fun i => c • A i) = Kraus.transferMap A := by
+  apply LinearMap.ext
+  intro X
+  rw [transferMap_smul]
+  have hphase : c * starRingEnd ℂ c = 1 := by
+    simpa [Complex.normSq_eq_norm_sq, hc] using Complex.mul_conj c
+  rw [hphase, one_smul]
+
 /-- The transfer spectral radius scales by the squared modulus of the tensor scalar. -/
 theorem spectralRadius_transferMap_smul [Nonempty (Fin D)]
     (c : ℂ) (hc : c ≠ 0) (A : MPSTensor d D) :
@@ -130,12 +142,8 @@ theorem isPeriodic_smul_of_norm_one
     (A : MPSTensor d D) (hA : IsPeriodic m A) :
     IsPeriodic m (fun i => c • A i) := by
   have hc_ne : c ≠ 0 := Complex.ne_zero_of_norm_eq_one hc
-  have hTransfer : Kraus.transferMap (fun i => c • A i) = Kraus.transferMap A := by
-    ext X : 1
-    rw [transferMap_smul]
-    have hsc : c * starRingEnd ℂ c = 1 := by
-      simpa [Complex.normSq_eq_norm_sq, hc] using Complex.mul_conj c
-    simp [hsc]
+  have hTransfer : Kraus.transferMap (fun i => c • A i) = Kraus.transferMap A :=
+    transferMap_smul_eq_of_norm_eq_one A c hc
   refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
     leftCanonical_smul_of_norm_one c hc A hA.leftCanonical,
     hA.period_pos, ?_⟩

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -449,6 +449,38 @@
     cancel.
 \end{proof}
 
+\begin{lemma}[Repeated blocks share a peripheral spectrum]
+    \label{lem:repeated_blocks_peripheral_spectrum}
+    \lean{MPSTensor.RepeatedBlocks.peripheralEigenvalues_transferMap_eq}
+    \leanok
+    If $A$ and $B$ are repeated blocks, then their transfer maps have the same
+    unit-circle eigenvalues.
+\end{lemma}
+\begin{proof}\leanok
+    Write $A^i=\xi YB^iY^{-1}$ with $|\xi|=1$.  The transfer map of $\xi C$ is
+    $|\xi|^2$ times the transfer map of $C$, hence equals it, and the transfer
+    map of $YB^iY^{-1}$ is the congruence conjugate
+    $Y\mathcal{E}_B(Y^{-1}\cdot Y^{-\dagger})Y^{\dagger}$ of the transfer map
+    of $B$.  Conjugation by an invertible linear map leaves the spectrum
+    unchanged.
+\end{proof}
+
+\begin{lemma}[Repeated periodic blocks have the same period]
+    \label{lem:repeated_blocks_period_eq}
+    \lean{MPSTensor.IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks}
+    \leanok
+    \uses{def:spectral_periodic_tensor}
+    Let $A$ and $B$ be spectrally periodic tensors of periods $m$ and $n$.  If
+    $A$ and $B$ are repeated blocks, then $m=n$.
+\end{lemma}
+\begin{proof}
+    \uses{lem:repeated_blocks_peripheral_spectrum}
+    \leanok
+    The two peripheral spectra coincide, and they are the sets of roots of
+    unity of orders $m$ and $n$.  A primitive $m$-th root of unity then
+    satisfies $z^n=1$, so $m$ divides $n$, and symmetrically $n$ divides $m$.
+\end{proof}
+
 \begin{lemma}[Pure similarities preserve periodic overlap hypotheses]
     \label{lem:periodic_overlap_hypothesis_gauge_transport}
     \lean{MPSTensor.PeriodicOverlapHypothesis.of_gaugeEquiv}
@@ -638,8 +670,9 @@
 
 \begin{theorem}[Proportional Fundamental Theorem for irreducible-form MPS]
     \label{thm:periodic_ft_proportional}
-    \notready
-    \uses{def:nonzero_proportional_mpv}
+    \lean{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}
+    \leanok
+    \uses{def:nonzero_proportional_mpv, def:spectral_periodic_tensor}
     Let $A$ and $B$ have multiplicity-bearing irreducible forms
     \begin{align}
         A^i & =\bigoplus_{j\in J}(R_j\otimes A_j^i),
@@ -649,10 +682,11 @@
     \end{align}
     where $R_j$ and $S_k$ are diagonal with nonzero diagonal entries and the
     two displayed block families are pairwise non-repeated bases of periodic
-    tensors. Suppose that, for every positive $N$, the vectors
+    tensors, spectrally periodic of periods $m_j$ and $n_k$ respectively.
+    Suppose that, for every positive $N$, the vectors
     $\ket{V^{(N)}(A)}$ and $\ket{V^{(N)}(B)}$ are proportional by a nonzero
     scalar. Then there is a bijection $\pi\colon J\to K$ such that, for every
-    $j\in J$, the blocks $A_j$ and $B_{\pi(j)}$ have the same period and there
+    $j\in J$, one has $m_j=n_{\pi(j)}$ and there
     are a unit-modulus scalar $\xi_j$ and an invertible matrix $Y_j$ such that,
     for every physical index $i$,
     \begin{align}
@@ -664,10 +698,19 @@
 
     The theorem relates the two bases of periodic tensors but makes no
     assertion relating their multiplicity matrices.
-    % Formalization status: the spectrally periodic multiplicity-bearing
-    % theorem above proves the complete overlap-hypothesis step for literal
-    % irreducible forms.  A source-labelled theorem retaining equality of the
-    % matched periods is still required before this exact statement can be
-    % marked ready.  Extension from arbitrary tensors through Proposition 2.1
-    % is a separate positive-length representative question.
 \end{theorem}
+\begin{proof}
+    \uses{lem:repeated_blocks_period_eq, thm:periodic_spectral_multiplicity_nondecaying_overlap}
+    \leanok
+    By Theorem~\ref{thm:periodic_spectral_multiplicity_nondecaying_overlap},
+    every tensor of either basis has a partner in the other basis whose mixed
+    overlap does not tend to zero, and every such pair is a repeated pair.
+    Choosing one partner for each tensor of the first basis gives a map
+    $\pi\colon J\to K$.  It is injective: two tensors of the first basis with a
+    common partner would be repeated with each other, contradicting pairwise
+    non-repetition.  The same construction in the reverse direction is
+    injective as well, so $J$ and $K$ have the same finite cardinality and
+    $\pi$ is a bijection.  Finally,
+    Lemma~\ref{lem:repeated_blocks_period_eq} gives $m_j=n_{\pi(j)}$ for every
+    matched pair.
+\end{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -449,14 +449,16 @@
     cancel.
 \end{proof}
 
-\begin{lemma}[Repeated blocks share a peripheral spectrum]
-    \label{lem:repeated_blocks_peripheral_spectrum}
+\begin{theorem}[Repeated blocks share a peripheral spectrum]
+    \label{thm:repeated_blocks_peripheral_spectrum}
     \lean{MPSTensor.RepeatedBlocks.peripheralEigenvalues_transferMap_eq}
     \leanok
     If $A$ and $B$ are repeated blocks, then their transfer maps have the same
     unit-circle eigenvalues.
-\end{lemma}
-\begin{proof}\leanok
+\end{theorem}
+\begin{proof}
+    \uses{lem:transfer_map_smul, thm:cpsv_gauge_transfer_similarity, lem:peripheral_spectrum_similarity}
+    \leanok
     Write $A^i=\xi YB^iY^{-1}$ with $|\xi|=1$.  The transfer map of $\xi C$ is
     $|\xi|^2$ times the transfer map of $C$, hence equals it, and the transfer
     map of $YB^iY^{-1}$ is the congruence conjugate
@@ -465,16 +467,16 @@
     unchanged.
 \end{proof}
 
-\begin{lemma}[Repeated periodic blocks have the same period]
-    \label{lem:repeated_blocks_period_eq}
+\begin{theorem}[Repeated periodic blocks have the same period]
+    \label{thm:repeated_blocks_period_eq}
     \lean{MPSTensor.IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks}
     \leanok
     \uses{def:spectral_periodic_tensor}
     Let $A$ and $B$ be spectrally periodic tensors of periods $m$ and $n$.  If
     $A$ and $B$ are repeated blocks, then $m=n$.
-\end{lemma}
+\end{theorem}
 \begin{proof}
-    \uses{lem:repeated_blocks_peripheral_spectrum}
+    \uses{thm:repeated_blocks_peripheral_spectrum}
     \leanok
     The two peripheral spectra coincide, and they are the sets of roots of
     unity of orders $m$ and $n$.  A primitive $m$-th root of unity then
@@ -668,6 +670,30 @@
     corresponding block-diagonal tensors.
 \end{proof}
 
+\begin{theorem}[Finite matching from the periodic overlap dichotomy]
+    \label{thm:periodic_conditional_block_matching}
+    \lean{MPSTensor.fundamentalTheorem_periodic_proportional}
+    \leanok
+    Let $\{A_j\}_{j\in J}$ and $\{B_k\}_{k\in K}$ be finite pairwise
+    non-repeated families. Suppose every tensor in either family has a tensor
+    in the other family whose mixed overlap does not tend to zero, and every
+    such non-decaying pair is repeated. Then there is a bijection
+    $\pi\colon J\to K$ such that $A_j$ and $B_{\pi(j)}$ are repeated for every
+    $j\in J$.
+
+    \emph{Scope restriction.} This result assumes the overlap consequences
+    that Theorem~3.4 derives from proportionality of the assembled
+    matrix-product vectors. It is the finite matching step, not the source
+    theorem itself.
+\end{theorem}
+\begin{proof}\leanok
+    Choose a non-decaying partner $f(j)\in K$ for every $j\in J$. If
+    $f(j_1)=f(j_2)$, the two repeated-block relations compose to show that
+    $A_{j_1}$ and $A_{j_2}$ are repeated, so pairwise non-repetition makes $f$
+    injective. The symmetric construction gives an injection $K\to J$.
+    Therefore $|J|=|K|$, and the first injection is the required bijection.
+\end{proof}
+
 \begin{theorem}[Proportional Fundamental Theorem for irreducible-form MPS]
     \label{thm:periodic_ft_proportional}
     \lean{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}
@@ -694,23 +720,19 @@
         \notag
     \end{align}
     Each $B_k$ occurs for exactly one $j$. This is
-    \cite[Theorem~3.4, lines~613--632]{DeLasCuevas2017Irreducible}.
+    \cite[Theorem~3.4, lines~613--623]{DeLasCuevas2017Irreducible}.
 
     The theorem relates the two bases of periodic tensors but makes no
     assertion relating their multiplicity matrices.
 \end{theorem}
 \begin{proof}
-    \uses{lem:repeated_blocks_period_eq, thm:periodic_spectral_multiplicity_nondecaying_overlap}
+    \uses{thm:repeated_blocks_period_eq, thm:periodic_conditional_block_matching, thm:periodic_spectral_multiplicity_nondecaying_overlap}
     \leanok
-    By Theorem~\ref{thm:periodic_spectral_multiplicity_nondecaying_overlap},
-    every tensor of either basis has a partner in the other basis whose mixed
-    overlap does not tend to zero, and every such pair is a repeated pair.
-    Choosing one partner for each tensor of the first basis gives a map
-    $\pi\colon J\to K$.  It is injective: two tensors of the first basis with a
-    common partner would be repeated with each other, contradicting pairwise
-    non-repetition.  The same construction in the reverse direction is
-    injective as well, so $J$ and $K$ have the same finite cardinality and
-    $\pi$ is a bijection.  Finally,
-    Lemma~\ref{lem:repeated_blocks_period_eq} gives $m_j=n_{\pi(j)}$ for every
+    Theorem~\ref{thm:periodic_spectral_multiplicity_nondecaying_overlap}
+    supplies non-decaying partners in both directions and classifies every
+    such pair as repeated. Applying
+    Theorem~\ref{thm:periodic_conditional_block_matching} gives a bijection
+    $\pi\colon J\to K$ of repeated pairs. Finally,
+    Theorem~\ref{thm:repeated_blocks_period_eq} gives $m_j=n_{\pi(j)}$ for every
     matched pair.
 \end{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -449,6 +449,19 @@
     cancel.
 \end{proof}
 
+\begin{theorem}[Unit-norm scaling preserves the transfer map]
+    \label{thm:transfer_map_smul_unit_norm}
+    \lean{MPSTensor.transferMap_smul_eq_of_norm_eq_one}
+    \leanok
+    If $|c|=1$, then the tensors $A$ and $cA$ have the same transfer map.
+\end{theorem}
+\begin{proof}
+    \uses{lem:transfer_map_smul}
+    \leanok
+    Scaling every tensor letter by $c$ multiplies the transfer map by
+    $c\overline c=|c|^2=1$.
+\end{proof}
+
 \begin{theorem}[Repeated blocks share a peripheral spectrum]
     \label{thm:repeated_blocks_peripheral_spectrum}
     \lean{MPSTensor.RepeatedBlocks.peripheralEigenvalues_transferMap_eq}
@@ -457,7 +470,8 @@
     unit-circle eigenvalues.
 \end{theorem}
 \begin{proof}
-    \uses{lem:transfer_map_smul, thm:cpsv_gauge_transfer_similarity, lem:peripheral_spectrum_similarity}
+    \uses{thm:transfer_map_smul_unit_norm, thm:cpsv_gauge_transfer_similarity, %
+        lem:peripheral_spectrum_similarity}
     \leanok
     Write $A^i=\xi YB^iY^{-1}$ with $|\xi|=1$.  The transfer map of $\xi C$ is
     $|\xi|^2$ times the transfer map of $C$, hence equals it, and the transfer
@@ -465,6 +479,33 @@
     $Y\mathcal{E}_B(Y^{-1}\cdot Y^{-\dagger})Y^{\dagger}$ of the transfer map
     of $B$.  Conjugation by an invertible linear map leaves the spectrum
     unchanged.
+\end{proof}
+
+\begin{theorem}[A root-of-unity set determines its positive exponent]
+    \label{thm:roots_of_unity_determine_period}
+    \lean{MPSTensor.period_eq_of_setOf_pow_eq_one}
+    \leanok
+    Let $m,n>0$. If
+    $\{z\in\C:z^m=1\}=\{z\in\C:z^n=1\}$, then $m=n$.
+\end{theorem}
+\begin{proof}\leanok
+    A primitive $m$-th root belongs to the second set, so $m$ divides $n$.
+    Interchanging $m$ and $n$ gives the reverse divisibility.
+\end{proof}
+
+\begin{theorem}[A common peripheral spectrum determines the period]
+    \label{thm:spectral_period_eq_of_peripheral_spectrum}
+    \lean{MPSTensor.IsSpectrallyPeriodic.period_eq_of_peripheralEigenvalues_eq}
+    \leanok
+    \uses{def:spectral_periodic_tensor}
+    Let $A$ and $B$ be spectrally periodic tensors of periods $m$ and $n$. If
+    their transfer maps have the same peripheral spectrum, then $m=n$.
+\end{theorem}
+\begin{proof}
+    \uses{thm:roots_of_unity_determine_period}
+    \leanok
+    The two spectra are respectively the sets of $m$-th and $n$-th roots of
+    unity, so the preceding theorem applies.
 \end{proof}
 
 \begin{theorem}[Repeated periodic blocks have the same period]
@@ -476,11 +517,11 @@
     $A$ and $B$ are repeated blocks, then $m=n$.
 \end{theorem}
 \begin{proof}
-    \uses{thm:repeated_blocks_peripheral_spectrum}
+    \uses{thm:repeated_blocks_peripheral_spectrum, %
+        thm:spectral_period_eq_of_peripheral_spectrum}
     \leanok
-    The two peripheral spectra coincide, and they are the sets of roots of
-    unity of orders $m$ and $n$.  A primitive $m$-th root of unity then
-    satisfies $z^n=1$, so $m$ divides $n$, and symmetrically $n$ divides $m$.
+    Repeated blocks have the same peripheral spectrum. The preceding theorem
+    then identifies their periods.
 \end{proof}
 
 \begin{lemma}[Pure similarities preserve periodic overlap hypotheses]

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -595,10 +595,10 @@ irreducible forms.
 
 \subsection{Equality of the matched periods}
 
-The remaining clause of Theorem~3.4, lines 623--626, of
+The matching clause of Theorem~3.4, lines 616--620, of
 Ref.~\cite{DeLasCuevas2017Irreducible} asserts that the unique matched block
 carries the same period. The source justifies this by the last clause of the
-generalized equal-or-orthogonal proposition, line 608: the repeated-block
+generalized equal-or-orthogonal proposition, lines 602--604: the repeated-block
 relation ``can only happen if $m_a=m_b$''.
 
 The formal argument is the spectral one already used for different-period

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -593,13 +593,43 @@ partner fields, and prove finite block matching. Together with the spectrally
 periodic multiplicity theorem, they yield block matching for literal
 irreducible forms.
 
-The exact source-labelled theorem is not ready because the existing matching
-conclusion does not explicitly preserve equality of the matched periods. This
-is the remaining gap intrinsic to Theorem~3.4, lines 613--632, of
-Ref.~\cite{DeLasCuevas2017Irreducible}. Separately, extending the
-irreducible-form theorem to arbitrary input tensors through Proposition~2.1
-requires the positive-length, possibly lower-dimensional comparison at lines
-266--271 of the same source. That extension is not part of Theorem~3.4.
+\subsection{Equality of the matched periods}
+
+The remaining clause of Theorem~3.4, lines 623--626, of
+Ref.~\cite{DeLasCuevas2017Irreducible} asserts that the unique matched block
+carries the same period. The source justifies this by the last clause of the
+generalized equal-or-orthogonal proposition, line 608: the repeated-block
+relation ``can only happen if $m_a=m_b$''.
+
+The formal argument is the spectral one already used for different-period
+decay. If $A^i=\xi YB^iY^{-1}$ with $|\xi|=1$, then
+\begin{align}
+    \mathcal E_A(Z)
+    &=Y\mathcal E_B\!\left(Y^{-1}ZY^{-\dagger}\right)Y^\dagger,
+    \label{eq:dccsp17_periodic_overlap_route_alignment_repeated_transfer_congruence}
+\end{align}
+because the unit-modulus scalar contributes the factor $\xi\bar\xi=1$.
+Conjugation by an invertible linear map preserves the spectrum, so the
+peripheral spectra of $\mathcal E_A$ and $\mathcal E_B$ agree.\footnote{Formal
+declaration:
+\leanid{MPSTensor.RepeatedBlocks.peripheralEigenvalues_transferMap_eq}.} For
+spectrally periodic blocks those spectra are the sets of roots of unity of
+orders $m$ and $n$, and
+(\ref{eq:dccsp17_periodic_overlap_route_alignment_periodic_spectrum}) then
+forces $m=n$ by mutual divisibility of the two orders.\footnote{Formal
+declarations: \leanid{MPSTensor.period_eq_of_setOf_pow_eq_one} and
+\leanid{MPSTensor.IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks}.}
+
+The source-labelled theorem is therefore formalized. It combines the
+spectrally periodic overlap theorem with the finite matching argument and
+records the matched periods in the conclusion.\footnote{Formal declaration:
+\leanid{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition},
+over the witness \path{MPSTensor.PeriodicBasisMatchingWitness}. Blueprint
+entry: \emph{thm:periodic\_ft\_proportional}.} Its hypotheses are the source
+hypotheses: multiplicity-bearing irreducible forms with nonzero diagonal
+entries, spectrally periodic and pairwise non-repeated bases of periodic
+tensors, and nonzero proportionality of the generated matrix-product vectors
+at every positive length.
 
 \subsection{Per-length proportionality and the blockwise phase}
 
@@ -655,12 +685,11 @@ equal case, theorem \emph{thm:bdequal}, lines 643--658.
 
 \subsection{Remaining elimination plan}
 
-A source-labelled theorem must combine the spectrally periodic overlap theorem
-with the finite matching argument while retaining equality of matched periods.
-The separate extension beyond Theorem~3.4 requires a positive-length
-comparison with the representative supplied by Proposition~2.1 of
-Ref.~\cite{DeLasCuevas2017Irreducible}. The completed overlap-hypothesis step
-is tracked by
+Extending the irreducible-form theorem to arbitrary input tensors through
+Proposition~2.1 of Ref.~\cite{DeLasCuevas2017Irreducible} requires the
+positive-length, possibly lower-dimensional comparison at lines 266--271 of
+the same source. That extension is not part of Theorem~3.4. The completed
+overlap-hypothesis step is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5342}{issue \#5342}; the
 subsequent multiplicity-power extraction is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5344}{issue \#5344}.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1341,6 +1341,14 @@ abstracted — record why, so it is not re-proposed).
   6.7 seconds in the declaration profiler. The full profiled source check falls
   below 25 seconds locally, with every declaration below 7 seconds.
 
+### Unit-norm scalar invariance of the transfer map
+- **Pattern:** three modules separately expanded `transferMap_smul` and proved
+  that the factor $c\overline c$ is one from `‖c‖ = 1`.
+- **Reuse:** `MPSTensor.transferMap_smul_eq_of_norm_eq_one` in
+  `MPS/SharedInfra/Scaling.lean` states the map equality once.
+- **Result:** periodicity transport, periodic repeated-block spectrum
+  comparison, and Beigi-loop transfer idempotence now use the shared theorem.
+
 ### Anticommuting-involution projective multiplication
 - **Pattern:** split both `Z₂ × Z₂` inputs into sixteen cases, expand two concrete
   `2 × 2` matrices entrywise, and normalize every resulting scalar expression.


### PR DESCRIPTION
Closes #5387.

## What this adds

Source Theorem 3.4 of arXiv:1708.00029 (`thm:bd`, lines 613--623) is now
stated and proved over the **multiplicity-bearing** irreducible forms
`eq:bdnr` (line 294) and `eq:Bbdnr` (line 582), with **equality of the matched
periods** retained in the conclusion.

| Declaration | Source anchor |
|---|---|
| `MPSTensor.transferMap_smul_eq_of_norm_eq_one` | Unit-norm scalar invariance of the transfer map, shared by the periodic and Beigi-loop arguments |
| `MPSTensor.period_eq_of_setOf_pow_eq_one` | lines 257--258 (peripheral spectrum of an `m`-periodic block is the set of `m`-th roots of unity) |
| `MPSTensor.IsSpectrallyPeriodic.period_eq_of_peripheralEigenvalues_eq` | lines 257--258 |
| `MPSTensor.RepeatedBlocks.peripheralEigenvalues_transferMap_eq` | `def:repeated` / `eq:rep`, lines 276--284 |
| `MPSTensor.IsSpectrallyPeriodic.period_eq_of_hetRepeatedBlocks` | `equal-or-orthogonal-generalized`, last clause, lines 602--604 ("the latter can only happen if $m_a=m_b$") |
| `MPSTensor.PeriodicBasisMatchingWitness` | `thm:bd`, lines 616--620 ("there is exactly one $k \in K$ (with the same period)") |
| `MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition` | `thm:bd`, lines 613--623 |

## Design choice: a new witness rather than a new field

The task allowed either extending `PeriodicBlockMatchingWitness` with a
period-equality field or introducing a separate source-labelled witness. I took
the second option. Adding a field to `PeriodicBlockMatchingWitness` would force
every producer of that witness — including
`fundamentalTheorem_periodic_proportional`,
`fundamentalTheorem_periodic_proportional_of_isPeriodic`, and
`fundamentalTheorem_periodic_equalCase_matching` — to carry period functions it
does not otherwise need, and would change the type of every consumer. The new
`PeriodicBasisMatchingWitness` takes the two period assignments as extra
arguments and conjoins `periodA j = periodB (perm j)` to the existing
per-pair `HetRepeatedBlocks`. The existing witness and its theorems are
untouched, so the diff is confined to additions plus one proof-shortening
refactor in `Periodic/Defs.lean`.

## The period-equality step

`RepeatedBlocks A B` gives `A i = ξ • (Y * B i * Y⁻¹)` with `‖ξ‖ = 1`. The
unit-modulus scalar contributes `ξ * conj ξ = 1` to the transfer map, so
`𝓔_A(Z) = Y 𝓔_B(Y⁻¹ Z Y⁻ᴴ) Yᴴ`, a congruence conjugate. Conjugation preserves
the spectrum, hence the peripheral spectra agree. For spectrally periodic
blocks those spectra are the sets of roots of unity of orders `m` and `n`, and
mutual divisibility of the two orders gives `m = n`. This is exactly the
source's justification at lines 602--604 and reuses the spectral route already
recorded for different-period decay.

Refactor: `IsPeriodic.period_eq_of_repeatedBlocks` now delegates its
root-of-unity argument to the new `period_eq_of_setOf_pow_eq_one` instead of
repeating it; its signature is unchanged.

## Faithfulness

The Lean hypotheses are the source hypotheses, with **no extra hypothesis**:

- two `SectorDecomposition`s, i.e. the literal multiplicity-bearing forms
  $A^i=\bigoplus_j(R_j\otimes A_j^i)$, $B^i=\bigoplus_k(S_k\otimes B_k^i)$ with
  every diagonal entry of every $R_j, S_k$ nonzero — not the scalar-weight
  `IsIrreducibleForm` surrogate;
- spectral periodicity of each basis block (the source's periodic tensors of
  lines 248--261, before the trace-preserving normalization of lines 313--332,
  which the proof performs internally and transports back);
- pairwise non-repetition of each basis (the source's basis of periodic
  tensors, lines 286--305);
- `NonzeroProportionalMPV₂`, i.e. `∀ N ≥ 1, ∃ c_N ≠ 0` — per length, not one
  length-independent scalar.

The conclusion carries the bijection, `period j = period (π j)`, and the
repeated-block relation for every matched pair.

**`thm:periodic_ft_proportional` is now `\leanok`.** The `\notready` marker and
the stale "Formalization status" comment are removed, and the node is wired to
`MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition` with a
proof block. No scope-restriction marker is added to the new theorem, because
none of its hypotheses is absent from the source statement. Two supporting
blueprint lemma nodes (`lem:repeated_blocks_peripheral_spectrum`,
`lem:repeated_blocks_period_eq`) are added, both `\leanok`.

`docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex` gains a section
recording the period-equality route and the closure of this gap. The note stays
open for the unrelated restrictions it also records (independence without
spanning; extension beyond Theorem 3.4 through Proposition 2.1).

## Verification

- Exact-current-main, warmed-cache full build: `Build completed successfully
  (10514 jobs)`; no new linter output.
- Exact-current-main targeted periodic/RFP cone after the review refactor:
  `Build completed successfully (9321 jobs)`.
- `rg -n "sorry|axiom|native_decide|admit"` on all changed Lean files: empty.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`,
  `lake exe checkdecls blueprint/lean_decls`, and `leanblueprint web`: exit 0;
  7872/7872 Blueprint entries in sync at the reviewed head.
- `python3 scripts/tactic_pattern_scan.py` run; the promoted transfer-map
  pattern is recorded in both automation ledgers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca

