### PR TITLE
feat(MPS/MPU): land four algebraic leaves of the MPU symmetry arguments

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -56,6 +56,7 @@ import TNLean.Algebra.ScalarThreeCocycleInversion
 import TNLean.Algebra.SemisimpleTracePowers
 import TNLean.Algebra.StabilizerCocycleLSymbol
 import TNLean.Algebra.StabilizerTransition
+import TNLean.Algebra.SwapKronecker
 import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation
 import TNLean.Algebra.UnitaryCompletionClass

--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Algebra
 
+import TNLean.Algebra.BlockingSignParity
 import TNLean.Algebra.CentralStarSubalgebraMatrix
 import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology

--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -60,6 +60,7 @@ import TNLean.Algebra.SwapMatrix
 import TNLean.Algebra.TwistedRegularRepresentation
 import TNLean.Algebra.UnitaryCompletionClass
 import TNLean.Algebra.UnitaryCongruence
+import TNLean.Algebra.UnitaryConjugationTransposeSign
 import TNLean.Algebra.UnitaryEntrywiseConjugation
 import TNLean.Algebra.UnitaryFactorizationComparison
 import TNLean.Algebra.UnitaryKronecker

--- a/TNLean/Algebra/BlockingSignParity.lean
+++ b/TNLean/Algebra/BlockingSignParity.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+
+/-!
+# The scalar parity law for the blocked time-reversal sign
+
+Blocking a time-reversal-invariant matrix product unitary produces one sign for
+each blocking level. The blocking argument of arXiv:1703.09188 identifies the
+sign at level `k` as `σ⁽¹⁾ζ^{k-1}`, where `ζ = σ⁽¹⁾σ⁽²⁾` is the ratio of the
+signs at the first two levels (`paper_v2.tex` line 1687), and where the closing
+identity `σ⁽ᵏ⁾ = σ⁽¹⁾ζ^{k-1}` is stated at `paper_v2.tex` line 1732.
+
+This file isolates the scalar consequence of that identity for signs valued in
+`{1, -1}`: the sign at level `k` is the first sign for odd `k` and the second
+sign for even `k`. Only the sign algebra is treated here; the tensor-network
+unwinding that produces the identity is not.
+
+## Main results
+
+- `TNLean.Algebra.blockedSign_eq_first_of_odd`: for odd blocking length the sign
+  is the first sign.
+- `TNLean.Algebra.blockedSign_eq_second_of_even`: for even blocking length the
+  sign is the second sign.
+
+## References
+
+* [J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, *Matrix product
+  unitaries: structure, symmetries, and topological invariants*,
+  arXiv:1703.09188, lines 1687 and 1732][Cirac2017MPU]
+-/
+
+namespace TNLean.Algebra
+
+variable {σ₁ σ₂ : ℂ}
+
+/-- The ratio of the first two blocking signs squares to one. This is the
+elementary property of `ζ = σ⁽¹⁾σ⁽²⁾` from arXiv:1703.09188, `paper_v2.tex`
+line 1687. -/
+theorem sq_mul_eq_one_of_sign (h₁ : σ₁ = 1 ∨ σ₁ = -1) (h₂ : σ₂ = 1 ∨ σ₂ = -1) :
+    (σ₁ * σ₂) ^ 2 = 1 := by
+  rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂ <;> subst h₁ <;> subst h₂ <;> norm_num
+
+/-- **Odd blocking length keeps the first sign.** For signs `σ₁, σ₂ ∈ {1, -1}`
+and odd `k`, the blocked sign `σ₁(σ₁σ₂)^{k-1}` equals `σ₁`.
+
+This is the odd case of `σ⁽ᵏ⁾ = σ⁽¹⁾ζ^{k-1}` from arXiv:1703.09188,
+`paper_v2.tex` line 1732, with `ζ = σ⁽¹⁾σ⁽²⁾` from line 1687. -/
+theorem blockedSign_eq_first_of_odd (h₁ : σ₁ = 1 ∨ σ₁ = -1) (h₂ : σ₂ = 1 ∨ σ₂ = -1)
+    {k : ℕ} (hk : Odd k) : σ₁ * (σ₁ * σ₂) ^ (k - 1) = σ₁ := by
+  obtain ⟨m, hm⟩ := hk
+  have hk1 : k - 1 = 2 * m := by omega
+  rw [hk1, pow_mul, sq_mul_eq_one_of_sign h₁ h₂, one_pow, mul_one]
+
+/-- **Even blocking length gives the second sign.** For signs `σ₁, σ₂ ∈ {1, -1}`
+and even positive `k`, the blocked sign `σ₁(σ₁σ₂)^{k-1}` equals `σ₂`.
+
+This is the even case of `σ⁽ᵏ⁾ = σ⁽¹⁾ζ^{k-1}` from arXiv:1703.09188,
+`paper_v2.tex` line 1732, with `ζ = σ⁽¹⁾σ⁽²⁾` from line 1687. -/
+theorem blockedSign_eq_second_of_even (h₁ : σ₁ = 1 ∨ σ₁ = -1) (h₂ : σ₂ = 1 ∨ σ₂ = -1)
+    {k : ℕ} (hk : 0 < k) (hke : Even k) : σ₁ * (σ₁ * σ₂) ^ (k - 1) = σ₂ := by
+  obtain ⟨m, hm⟩ := hke
+  have hk1 : k - 1 = 2 * (m - 1) + 1 := by omega
+  rw [hk1, pow_succ, pow_mul, sq_mul_eq_one_of_sign h₁ h₂, one_pow, one_mul,
+    ← mul_assoc]
+  rcases h₁ with h₁ | h₁ <;> subst h₁ <;> norm_num
+
+end TNLean.Algebra

--- a/TNLean/Algebra/BlockingSignParity.lean
+++ b/TNLean/Algebra/BlockingSignParity.lean
@@ -45,13 +45,13 @@ theorem sq_mul_eq_one_of_sign (h₁ : σ₁ = 1 ∨ σ₁ = -1) (h₂ : σ₂ = 
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂ <;> subst h₁ <;> subst h₂ <;> norm_num
 
 /-- **Odd blocking length keeps the first sign.** For signs `σ₁, σ₂ ∈ {1, -1}`
-and odd `k`, the blocked sign `σ₁(σ₁σ₂)^{k-1}` equals `σ₁`.
+and positive odd `k`, the blocked sign `σ₁(σ₁σ₂)^{k-1}` equals `σ₁`.
 
 This is the odd case of `σ⁽ᵏ⁾ = σ⁽¹⁾ζ^{k-1}` from arXiv:1703.09188,
 `paper_v2.tex` line 1732, with `ζ = σ⁽¹⁾σ⁽²⁾` from line 1687. -/
 theorem blockedSign_eq_first_of_odd (h₁ : σ₁ = 1 ∨ σ₁ = -1) (h₂ : σ₂ = 1 ∨ σ₂ = -1)
-    {k : ℕ} (hk : Odd k) : σ₁ * (σ₁ * σ₂) ^ (k - 1) = σ₁ := by
-  obtain ⟨m, hm⟩ := hk
+    {k : ℕ} (hk : 0 < k) (hko : Odd k) : σ₁ * (σ₁ * σ₂) ^ (k - 1) = σ₁ := by
+  obtain ⟨m, hm⟩ := hko
   have hk1 : k - 1 = 2 * m := by omega
   rw [hk1, pow_mul, sq_mul_eq_one_of_sign h₁ h₂, one_pow, mul_one]
 

--- a/TNLean/Algebra/SwapKronecker.lean
+++ b/TNLean/Algebra/SwapKronecker.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.SwapTrace
+
+/-!
+# The tensor-factor exchange against Kronecker products
+
+The gauge-invariance argument for the time-reversal sign of a matrix product
+unitary moves the tensor-factor exchange `𝕊` past a Kronecker product. This file
+records that step.
+
+The exchange intertwines the two orders of a Kronecker product,
+`𝕊(A ⊗ B) = (B ⊗ A)𝕊`. The source asserts the resulting gauge invariance of the
+trace formula for the sign without printing a derivation, at arXiv:1703.09188,
+`paper_v2.tex` lines 1624--1630; the identity below is the algebraic step that
+invariance rests on, and it is proved here entrywise.
+
+Because the exchange is available only in the square product coordinates
+`(Fin n) × (Fin n)`, both Kronecker factors are square of the same size.
+
+## Main results
+
+- `Matrix.swapMatrix_mul_kronecker`: the exchange carries a Kronecker product to
+  the product with its factors exchanged.
+- `Matrix.kronecker_mul_swapMatrix`: the same identity read from the other side.
+
+## References
+
+* [J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, *Matrix product
+  unitaries: structure, symmetries, and topological invariants*,
+  arXiv:1703.09188, lines 1624--1630][Cirac2017MPU]
+-/
+
+open scoped Kronecker
+
+namespace Matrix
+
+variable {n : ℕ}
+
+/-- The tensor-factor exchange intertwines the two orders of a Kronecker
+product: `𝕊(A ⊗ B) = (B ⊗ A)𝕊`.
+
+This is the algebraic step behind the gauge invariance of the trace formula for
+the time-reversal sign, which arXiv:1703.09188 asserts without a printed
+derivation at `paper_v2.tex` lines 1624--1630. -/
+theorem swapMatrix_mul_kronecker (A B : Matrix (Fin n) (Fin n) ℂ) :
+    swapMatrix n * (A ⊗ₖ B) = (B ⊗ₖ A) * swapMatrix n := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp [Matrix.mul_apply, Fintype.sum_prod_type, Matrix.kroneckerMap_apply,
+    ite_and, Finset.sum_ite_eq, mul_comm]
+
+/-- The tensor-factor exchange read from the other side:
+`(A ⊗ B)𝕊 = 𝕊(B ⊗ A)`. -/
+theorem kronecker_mul_swapMatrix (A B : Matrix (Fin n) (Fin n) ℂ) :
+    (A ⊗ₖ B) * swapMatrix n = swapMatrix n * (B ⊗ₖ A) :=
+  (swapMatrix_mul_kronecker B A).symm
+
+end Matrix

--- a/TNLean/Algebra/SwapKronecker.lean
+++ b/TNLean/Algebra/SwapKronecker.lean
@@ -9,8 +9,9 @@ import QICLean.Algebra.SwapTrace
 # The tensor-factor exchange against Kronecker products
 
 The gauge-invariance argument for the time-reversal sign of a matrix product
-unitary moves the tensor-factor exchange `𝕊` past a Kronecker product. This file
-records that step.
+unitary moves the tensor-factor exchange `𝕊` past a Kronecker product, and then
+contracts the exchange against a scalar multiple of `x ⊗ x†`. This file records
+the two algebraic steps.
 
 The exchange intertwines the two orders of a Kronecker product,
 `𝕊(A ⊗ B) = (B ⊗ A)𝕊`. The source asserts the resulting gauge invariance of the
@@ -26,12 +27,15 @@ Because the exchange is available only in the square product coordinates
 - `Matrix.swapMatrix_mul_kronecker`: the exchange carries a Kronecker product to
   the product with its factors exchanged.
 - `Matrix.kronecker_mul_swapMatrix`: the same identity read from the other side.
+- `Matrix.trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose`: contracting
+  the exchange against a scalar multiple of `x ⊗ x†` for unitary `x` returns the
+  scalar times the factor dimension.
 
 ## References
 
 * [J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, *Matrix product
   unitaries: structure, symmetries, and topological invariants*,
-  arXiv:1703.09188, lines 1624--1630][Cirac2017MPU]
+  arXiv:1703.09188, lines 1608--1610 and 1624--1630][Cirac2017MPU]
 -/
 
 open scoped Kronecker
@@ -57,5 +61,18 @@ theorem swapMatrix_mul_kronecker (A B : Matrix (Fin n) (Fin n) ℂ) :
 theorem kronecker_mul_swapMatrix (A B : Matrix (Fin n) (Fin n) ℂ) :
     (A ⊗ₖ B) * swapMatrix n = swapMatrix n * (B ⊗ₖ A) :=
   (swapMatrix_mul_kronecker B A).symm
+
+/-- Contracting the tensor-factor exchange against a scalar multiple of
+`x ⊗ x†`, for a unitary `x`, returns the scalar times the factor dimension.
+
+This is the trace evaluation `tr[𝕊 x x†] = d²` used to extract the
+time-reversal sign in arXiv:1703.09188, `paper_v2.tex` lines 1608--1610, with
+the scalar supplied by the symmetry relation. -/
+theorem trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose
+    {M : Matrix (Fin n × Fin n) (Fin n × Fin n) ℂ} {x : Matrix (Fin n) (Fin n) ℂ}
+    (σ : ℂ) (hx : x ∈ unitaryGroup (Fin n) ℂ) (hM : M = σ • (x ⊗ₖ xᴴ)) :
+    (swapMatrix n * M).trace = σ * n := by
+  rw [hM, Matrix.mul_smul, Matrix.trace_smul,
+    trace_swapMatrix_mul_kronecker_conjTranspose_of_mem_unitaryGroup x hx, smul_eq_mul]
 
 end Matrix

--- a/TNLean/Algebra/SwapKronecker.lean
+++ b/TNLean/Algebra/SwapKronecker.lean
@@ -14,10 +14,10 @@ contracts the exchange against a scalar multiple of `x ⊗ x†`. This file reco
 the two algebraic steps.
 
 The exchange intertwines the two orders of a Kronecker product,
-`𝕊(A ⊗ B) = (B ⊗ A)𝕊`. The source asserts the resulting gauge invariance of the
-trace formula for the sign without printing a derivation, at arXiv:1703.09188,
-`paper_v2.tex` lines 1624--1630; the identity below is the algebraic step that
-invariance rests on, and it is proved here entrywise.
+`𝕊(A ⊗ B) = (B ⊗ A)𝕊`. The source states the equivalent two-sided identity at
+arXiv:1703.09188, `paper_v2.tex` lines 1316--1319, and later uses it in the
+gauge-invariance argument at lines 1624--1630. The one-sided forms below are
+proved entrywise.
 
 Because the exchange is available only in the square product coordinates
 `(Fin n) × (Fin n)`, both Kronecker factors are square of the same size.
@@ -35,7 +35,8 @@ Because the exchange is available only in the square product coordinates
 
 * [J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, *Matrix product
   unitaries: structure, symmetries, and topological invariants*,
-  arXiv:1703.09188, lines 1608--1610 and 1624--1630][Cirac2017MPU]
+  arXiv:1703.09188, lines 1316--1319, 1608--1610, and
+  1624--1630][Cirac2017MPU]
 -/
 
 open scoped Kronecker
@@ -47,9 +48,9 @@ variable {n : ℕ}
 /-- The tensor-factor exchange intertwines the two orders of a Kronecker
 product: `𝕊(A ⊗ B) = (B ⊗ A)𝕊`.
 
-This is the algebraic step behind the gauge invariance of the trace formula for
-the time-reversal sign, which arXiv:1703.09188 asserts without a printed
-derivation at `paper_v2.tex` lines 1624--1630. -/
+This is one side of the exchange identity in arXiv:1703.09188,
+`paper_v2.tex` lines 1316--1319, and is the algebraic step behind the gauge
+invariance asserted at lines 1624--1630. -/
 theorem swapMatrix_mul_kronecker (A B : Matrix (Fin n) (Fin n) ℂ) :
     swapMatrix n * (A ⊗ₖ B) = (B ⊗ₖ A) * swapMatrix n := by
   ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
@@ -65,9 +66,9 @@ theorem kronecker_mul_swapMatrix (A B : Matrix (Fin n) (Fin n) ℂ) :
 /-- Contracting the tensor-factor exchange against a scalar multiple of
 `x ⊗ x†`, for a unitary `x`, returns the scalar times the factor dimension.
 
-This is the trace evaluation `tr[𝕊 x x†] = d²` used to extract the
-time-reversal sign in arXiv:1703.09188, `paper_v2.tex` lines 1608--1610, with
-the scalar supplied by the symmetry relation. -/
+The general identity gives `tr[𝕊(x ⊗ x†)] = n`. In the MPU application,
+`x` acts on a space of dimension `d²`, giving the value `d²` in
+arXiv:1703.09188, `paper_v2.tex` lines 1608--1610. -/
 theorem trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose
     {M : Matrix (Fin n × Fin n) (Fin n × Fin n) ℂ} {x : Matrix (Fin n) (Fin n) ℂ}
     (σ : ℂ) (hx : x ∈ unitaryGroup (Fin n) ℂ) (hM : M = σ • (x ⊗ₖ xᴴ)) :

--- a/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
+++ b/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
@@ -10,7 +10,7 @@ import TNLean.Algebra.UnitaryKronecker
 # A common transpose sign for the two conjugation factors
 
 Applying the conjugation relation of a matrix product unitary twice leaves the
-single Kronecker identity `x̄x ⊗ ȳy = 𝟙` between the two virtual unitaries `x`
+single Kronecker identity `conj(x) x ⊗ conj(y) y = 𝟙` between the two virtual unitaries `x`
 and `y`. This file isolates the purely algebraic consequence drawn from that
 identity in arXiv:1703.09188, `paper_v2.tex` lines 1033--1038: the identity is
 equivalent to `x = e^{iφ} xᵀ` and `y = e^{-iφ} yᵀ`, and unitarity of `x` forces
@@ -44,7 +44,7 @@ variable {m n : Type*} [Fintype m] [DecidableEq m] [Nonempty m]
 
 omit [Nonempty m] in
 /-- For a unitary matrix, the transpose is a left inverse of the entrywise
-conjugate. This is the identity behind the step `x̄ = e^{-iφ} x†` in
+conjugate. This is the identity behind the step `conj(x) = e^{-iφ} x†` in
 arXiv:1703.09188, `paper_v2.tex` lines 1035--1037. -/
 theorem transpose_mul_map_star_of_mem_unitaryGroup {x : Matrix m m ℂ}
     (hx : x ∈ unitaryGroup m ℂ) : xᵀ * x.map (starRingEnd ℂ) = 1 := by
@@ -58,7 +58,7 @@ theorem transpose_mul_map_star_of_mem_unitaryGroup {x : Matrix m m ℂ}
 omit [Nonempty m] in
 /-- A unitary matrix whose entrywise conjugate times itself is a scalar matrix
 equals that scalar times its own transpose. This is the passage from
-`x̄x = e^{iφ}𝟙` to `x = e^{iφ} xᵀ` in arXiv:1703.09188, `paper_v2.tex`
+`conj(x) x = e^{iφ}𝟙` to `x = e^{iφ} xᵀ` in arXiv:1703.09188, `paper_v2.tex`
 lines 1035--1036. -/
 theorem eq_smul_transpose_of_map_star_mul_eq_smul_one {x : Matrix m m ℂ}
     (hx : x ∈ unitaryGroup m ℂ) {c : ℂ} (hc : x.map (starRingEnd ℂ) * x = c • 1) :
@@ -71,7 +71,7 @@ theorem eq_smul_transpose_of_map_star_mul_eq_smul_one {x : Matrix m m ℂ}
 
 /-- **Common transpose sign of the two conjugation factors.** If the entrywise
 conjugation relations of two unitary matrices assemble into the Kronecker
-identity `x̄x ⊗ ȳy = 𝟙`, then one sign `σ = ±1` satisfies `x = σ • xᵀ` and
+identity `conj(x) x ⊗ conj(y) y = 𝟙`, then one sign `σ = ±1` satisfies `x = σ • xᵀ` and
 `y = σ • yᵀ`.
 
 This is the algebraic tail of the conjugation-symmetry proposition in
@@ -97,7 +97,7 @@ theorem exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one
     eq_smul_transpose_of_map_star_mul_eq_smul_one hy (by rwa [hcinv] at hcy)⟩
 
 /-- **Both factors symmetric or both skew-symmetric.** The Kronecker identity
-`x̄x ⊗ ȳy = 𝟙` between two unitary matrices leaves exactly two possibilities:
+`conj(x) x ⊗ conj(y) y = 𝟙` between two unitary matrices leaves exactly two possibilities:
 both matrices are symmetric, or both are skew-symmetric. This is the form of
 arXiv:1703.09188, `paper_v2.tex` lines 1033--1038 used in the structural
 discussion of symmetric and skew-symmetric unitaries that follows it. -/

--- a/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
+++ b/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
@@ -44,8 +44,8 @@ variable {m n : Type*} [Fintype m] [DecidableEq m] [Nonempty m]
 
 omit [Nonempty m] in
 /-- For a unitary matrix, the transpose is a left inverse of the entrywise
-conjugate. This is the identity behind the step `conj(x) = e^{-iφ} x†` in
-arXiv:1703.09188, `paper_v2.tex` lines 1035--1037. -/
+conjugate. It permits multiplying `conj(x)x = e^{iφ}𝟙` on the left by `xᵀ` in
+arXiv:1703.09188, `paper_v2.tex` lines 1035--1036. -/
 theorem transpose_mul_map_star_of_mem_unitaryGroup {x : Matrix m m ℂ}
     (hx : x ∈ unitaryGroup m ℂ) : xᵀ * x.map (starRingEnd ℂ) = 1 := by
   have hstar : xᴴ * x = 1 := by

--- a/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
+++ b/TNLean/Algebra/UnitaryConjugationTransposeSign.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.UnitaryEntrywiseConjugation
+import TNLean.Algebra.UnitaryKronecker
+
+/-!
+# A common transpose sign for the two conjugation factors
+
+Applying the conjugation relation of a matrix product unitary twice leaves the
+single Kronecker identity `x̄x ⊗ ȳy = 𝟙` between the two virtual unitaries `x`
+and `y`. This file isolates the purely algebraic consequence drawn from that
+identity in arXiv:1703.09188, `paper_v2.tex` lines 1033--1038: the identity is
+equivalent to `x = e^{iφ} xᵀ` and `y = e^{-iφ} yᵀ`, and unitarity of `x` forces
+`e^{iφ} = ±1`. The two factors therefore carry one common transpose sign: either
+both are symmetric, or both are skew-symmetric.
+
+The conjugation appearing in the source relation is entrywise complex
+conjugation, `Matrix.map (starRingEnd ℂ)`, not the conjugate transpose.
+
+## Main results
+
+- `Matrix.exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one`: the
+  Kronecker identity produces one sign `σ = ±1` with `x = σ • xᵀ` and
+  `y = σ • yᵀ`.
+- `Matrix.transpose_eq_self_or_transpose_eq_neg_of_kronecker_map_star_mul_eq_one`:
+  the same conclusion in the form "both symmetric or both skew-symmetric".
+
+## References
+
+* [J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, *Matrix product
+  unitaries: structure, symmetries, and topological invariants*,
+  arXiv:1703.09188, lines 1033--1038][Cirac2017MPU]
+-/
+
+open scoped Kronecker
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Nonempty m]
+  [Fintype n] [DecidableEq n] [Nonempty n]
+
+omit [Nonempty m] in
+/-- For a unitary matrix, the transpose is a left inverse of the entrywise
+conjugate. This is the identity behind the step `x̄ = e^{-iφ} x†` in
+arXiv:1703.09188, `paper_v2.tex` lines 1035--1037. -/
+theorem transpose_mul_map_star_of_mem_unitaryGroup {x : Matrix m m ℂ}
+    (hx : x ∈ unitaryGroup m ℂ) : xᵀ * x.map (starRingEnd ℂ) = 1 := by
+  have hstar : xᴴ * x = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using mem_unitaryGroup_iff'.mp hx
+  have h := congrArg Matrix.transpose hstar
+  rw [Matrix.transpose_mul, Matrix.transpose_one] at h
+  have hc : (xᴴ)ᵀ = x.map (starRingEnd ℂ) := by ext i j; simp
+  rwa [hc] at h
+
+omit [Nonempty m] in
+/-- A unitary matrix whose entrywise conjugate times itself is a scalar matrix
+equals that scalar times its own transpose. This is the passage from
+`x̄x = e^{iφ}𝟙` to `x = e^{iφ} xᵀ` in arXiv:1703.09188, `paper_v2.tex`
+lines 1035--1036. -/
+theorem eq_smul_transpose_of_map_star_mul_eq_smul_one {x : Matrix m m ℂ}
+    (hx : x ∈ unitaryGroup m ℂ) {c : ℂ} (hc : x.map (starRingEnd ℂ) * x = c • 1) :
+    x = c • xᵀ := by
+  calc x = xᵀ * x.map (starRingEnd ℂ) * x := by
+        rw [transpose_mul_map_star_of_mem_unitaryGroup hx, Matrix.one_mul]
+    _ = xᵀ * (x.map (starRingEnd ℂ) * x) := Matrix.mul_assoc _ _ _
+    _ = xᵀ * (c • (1 : Matrix m m ℂ)) := by rw [hc]
+    _ = c • xᵀ := by rw [Matrix.mul_smul, Matrix.mul_one]
+
+/-- **Common transpose sign of the two conjugation factors.** If the entrywise
+conjugation relations of two unitary matrices assemble into the Kronecker
+identity `x̄x ⊗ ȳy = 𝟙`, then one sign `σ = ±1` satisfies `x = σ • xᵀ` and
+`y = σ • yᵀ`.
+
+This is the algebraic tail of the conjugation-symmetry proposition in
+arXiv:1703.09188, `paper_v2.tex` lines 1033--1038: the Kronecker identity splits
+into reciprocal scalars `e^{iφ}` and `e^{-iφ}`, and `𝟙 = xx† = e^{2iφ}𝟙` forces
+`e^{iφ} = ±1`, so the two reciprocal scalars coincide. -/
+theorem exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one
+    {x : Matrix m m ℂ} {y : Matrix n n ℂ} (hx : x ∈ unitaryGroup m ℂ)
+    (hy : y ∈ unitaryGroup n ℂ)
+    (h : (x.map (starRingEnd ℂ) * x) ⊗ₖ (y.map (starRingEnd ℂ) * y) = 1) :
+    ∃ σ : ℂ, (σ = 1 ∨ σ = -1) ∧ x = σ • xᵀ ∧ y = σ • yᵀ := by
+  obtain ⟨c, -, hcx, hcy⟩ := exists_eq_smul_one_of_kronecker_eq_one h
+  have hxbar : x.map (starRingEnd ℂ) ∈ unitaryGroup m ℂ :=
+    map_star_mem_unitaryGroup_iff.mpr hx
+  have hdouble : (x.map (starRingEnd ℂ)).map (starRingEnd ℂ) = x := by ext i j; simp
+  have hself : x.map (starRingEnd ℂ) * (x.map (starRingEnd ℂ)).map (starRingEnd ℂ) =
+      c • 1 := by rw [hdouble]; exact hcx
+  have hsign : c = 1 ∨ c = -1 :=
+    scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one
+      (⟨x.map (starRingEnd ℂ), hxbar⟩ : unitaryGroup m ℂ) c hself
+  have hcinv : c⁻¹ = c := by rcases hsign with hc | hc <;> rw [hc] <;> norm_num
+  exact ⟨c, hsign, eq_smul_transpose_of_map_star_mul_eq_smul_one hx hcx,
+    eq_smul_transpose_of_map_star_mul_eq_smul_one hy (by rwa [hcinv] at hcy)⟩
+
+/-- **Both factors symmetric or both skew-symmetric.** The Kronecker identity
+`x̄x ⊗ ȳy = 𝟙` between two unitary matrices leaves exactly two possibilities:
+both matrices are symmetric, or both are skew-symmetric. This is the form of
+arXiv:1703.09188, `paper_v2.tex` lines 1033--1038 used in the structural
+discussion of symmetric and skew-symmetric unitaries that follows it. -/
+theorem transpose_eq_self_or_transpose_eq_neg_of_kronecker_map_star_mul_eq_one
+    {x : Matrix m m ℂ} {y : Matrix n n ℂ} (hx : x ∈ unitaryGroup m ℂ)
+    (hy : y ∈ unitaryGroup n ℂ)
+    (h : (x.map (starRingEnd ℂ) * x) ⊗ₖ (y.map (starRingEnd ℂ) * y) = 1) :
+    (xᵀ = x ∧ yᵀ = y) ∨ (xᵀ = -x ∧ yᵀ = -y) := by
+  obtain ⟨σ, hσ, hxσ, hyσ⟩ :=
+    exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one hx hy h
+  have hxT : xᵀ = σ • x := by simpa using congrArg Matrix.transpose hxσ
+  have hyT : yᵀ = σ • y := by simpa using congrArg Matrix.transpose hyσ
+  rcases hσ with hσ | hσ
+  · subst hσ
+    exact Or.inl ⟨by simpa using hxT, by simpa using hyT⟩
+  · subst hσ
+    exact Or.inr ⟨by simpa using hxT, by simpa using hyT⟩
+
+end Matrix

--- a/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
+++ b/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
@@ -9,13 +9,12 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 /-!
 # Scalar relations from entrywise conjugates of unitary matrices
 
-This file proves the generic unitary-matrix algebra behind the reciprocal-scalar and sign
-steps of the conjugation-symmetry proposition in arXiv:1703.09188, `paper_v2.tex`
-lines 1033--1038: there the relation `x̄x ⊗ ȳy = 𝟙` yields reciprocal scalars `e^{iφ}` and
-`e^{-iφ}`, and `𝟙 = xx† = e^{2iφ}𝟙` forces `e^{iφ} = ±1`. The same algebra is used again
-for the virtual-gauge signs in FBC25, equations `eq:defT` and `eq:intro_sigma`
-(arXiv:2502.20257, lines 1557--1567). The operation on the second matrix is entrywise
-complex conjugation `Matrix.map (starRingEnd ℂ)`, not conjugate transpose.
+This file proves the generic unitary-matrix algebra used for the virtual-gauge signs in
+FBC25, equations `eq:defT` and `eq:intro_sigma` (arXiv:2502.20257, lines 1557--1567).
+Its self-relation theorem also gives the sign step in the conjugation-symmetry
+proposition of arXiv:1703.09188, `paper_v2.tex` lines 1036--1038. The operation on the
+second matrix is entrywise complex conjugation `Matrix.map (starRingEnd ℂ)`, not
+conjugate transpose.
 
 These results are conditional on the scalar-matrix relations. They do not construct the
 virtual gauges or prove those relations for an MPU representation.
@@ -51,10 +50,8 @@ theorem scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one
   simpa [Matrix.mul_apply, Matrix.one_apply] using hii
 
 /-- For two unitary matrices, scalars in the two relations obtained by exchanging the
-matrices and entrywise conjugating the second factor are reciprocal. This is the
-reciprocity of `e^{iφ}` and `e^{-iφ}` in the conjugation-symmetry proposition of
-arXiv:1703.09188, `paper_v2.tex` lines 1033--1036; it is used again as the identity
-`σ_g σ_{g⁻¹} = 1` in FBC25, equation `eq:intro_sigma`
+matrices and entrywise conjugating the second factor are reciprocal. This is the identity
+`σ_g σ_{g⁻¹} = 1` following FBC25, equation `eq:intro_sigma`
 (arXiv:2502.20257, lines 1559--1563). -/
 theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
     (T S : Matrix.unitaryGroup n ℂ) (σ τ : ℂ)

--- a/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
+++ b/TNLean/Algebra/UnitaryEntrywiseConjugation.lean
@@ -9,10 +9,13 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 /-!
 # Scalar relations from entrywise conjugates of unitary matrices
 
-This file proves the generic unitary-matrix algebra used for the virtual-gauge signs in
-FBC25, equations `eq:defT` and `eq:intro_sigma` (arXiv:2502.20257, lines 1557--1567).
-The operation on the second matrix is entrywise complex conjugation
-`Matrix.map (starRingEnd ℂ)`, not conjugate transpose.
+This file proves the generic unitary-matrix algebra behind the reciprocal-scalar and sign
+steps of the conjugation-symmetry proposition in arXiv:1703.09188, `paper_v2.tex`
+lines 1033--1038: there the relation `x̄x ⊗ ȳy = 𝟙` yields reciprocal scalars `e^{iφ}` and
+`e^{-iφ}`, and `𝟙 = xx† = e^{2iφ}𝟙` forces `e^{iφ} = ±1`. The same algebra is used again
+for the virtual-gauge signs in FBC25, equations `eq:defT` and `eq:intro_sigma`
+(arXiv:2502.20257, lines 1557--1567). The operation on the second matrix is entrywise
+complex conjugation `Matrix.map (starRingEnd ℂ)`, not conjugate transpose.
 
 These results are conditional on the scalar-matrix relations. They do not construct the
 virtual gauges or prove those relations for an MPU representation.
@@ -48,8 +51,10 @@ theorem scalar_mul_star_eq_one_of_mul_map_star_eq_smul_one
   simpa [Matrix.mul_apply, Matrix.one_apply] using hii
 
 /-- For two unitary matrices, scalars in the two relations obtained by exchanging the
-matrices and entrywise conjugating the second factor are reciprocal. This is the identity
-`σ_g σ_{g⁻¹} = 1` following FBC25, equation `eq:intro_sigma`
+matrices and entrywise conjugating the second factor are reciprocal. This is the
+reciprocity of `e^{iφ}` and `e^{-iφ}` in the conjugation-symmetry proposition of
+arXiv:1703.09188, `paper_v2.tex` lines 1033--1036; it is used again as the identity
+`σ_g σ_{g⁻¹} = 1` in FBC25, equation `eq:intro_sigma`
 (arXiv:2502.20257, lines 1559--1563). -/
 theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
     (T S : Matrix.unitaryGroup n ℂ) (σ τ : ℂ)
@@ -83,8 +88,9 @@ theorem paired_scalars_mul_eq_one_of_mul_map_star_eq_smul_one
   exact hτunit
 
 /-- In the self relation, the scalar multiplying the identity is `1` or `-1`. This is the
-involution conclusion after FBC25, equation `eq:intro_sigma`
-(arXiv:2502.20257, lines 1563--1567). -/
+step `𝟙 = xx† = e^{2iφ}𝟙`, hence `e^{iφ} = ±1`, in the conjugation-symmetry proposition of
+arXiv:1703.09188, `paper_v2.tex` lines 1036--1038; it is used again as the involution
+conclusion after FBC25, equation `eq:intro_sigma` (arXiv:2502.20257, lines 1563--1567). -/
 theorem scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one
     (T : Matrix.unitaryGroup n ℂ) (σ : ℂ)
     (hσ : (T : Matrix n n ℂ) * (T : Matrix n n ℂ).map (starRingEnd ℂ) = σ • 1) :

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6565,7 +6565,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop1conj}
     \notready
     \discussion{5713}
-    \uses{FundamentalMPU, SF, thm:mpu_conjugation_common_transpose_sign}
+    \uses{FundamentalMPU, SF}
     An MPU in standard form is invariant under complex conjugation if and only
     if there are unitaries $x$ and $y$ such that either
     $x=x^T$ and $y=y^T$, or $x=-x^T$ and $y=-y^T$, and
@@ -7613,8 +7613,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % **Scope restriction (two-site blocked comparison):** the trace formula uses
     % the blocked source data required by Proposition~\ref{prop:mpu_admissible_local_time_reversal}.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{prop:mpu_admissible_local_time_reversal, def:mpu_reduced_full_support_source_datum,
-        thm:matrix_trace_swap_scaled_kronecker}
+    \uses{prop:mpu_admissible_local_time_reversal, def:mpu_reduced_full_support_source_datum}
     For a time-reversal-invariant MPU in admissible standard form, suppose its
     one-site tensor $\mathcal U$, its actual two-site block $\mathcal U_2$, and
     the physical-adjoint comparison tensor $\mathcal U_2^\sharp$ are simple and
@@ -7756,8 +7755,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop:sigma1-and-sigma2-equal}
     \notready
     \discussion{5714}
-    \uses{prop:sigma-well-defined, PropChiral, lem:mpu_blocking,
-        thm:mpu_blocked_sign_parity_scalar}
+    \uses{prop:sigma-well-defined, PropChiral, lem:mpu_blocking}
     Let $\mathcal U$ be a time-reversal-invariant MPU in standard form, and let
     $\sigma^{(k)}$ be the sign obtained from a standard form of its $k$-site
     block. Then

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6527,12 +6527,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \subsection{Local characterization of symmetries}
 
-\begin{lemma}[Common transpose sign of the conjugation factors]
-    \label{lem:mpu_conjugation_common_transpose_sign}
-    \lean{Matrix.exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one,
+\begin{theorem}[Common transpose sign of the conjugation factors]
+    \label{thm:mpu_conjugation_common_transpose_sign}
+    \lean{Matrix.transpose_mul_map_star_of_mem_unitaryGroup,
+        Matrix.eq_smul_transpose_of_map_star_mul_eq_smul_one,
+        Matrix.exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one,
         Matrix.transpose_eq_self_or_transpose_eq_neg_of_kronecker_map_star_mul_eq_one}
     \leanok
-    \uses{thm:mpug_kronecker_identity_factors, thm:mpug_unitary_entrywise_self_sign}
     Let $x$ and $y$ be unitary matrices over $\mathbb C$, indexed by nonempty
     finite sets, whose entrywise conjugates satisfy
     \begin{align}
@@ -6543,8 +6544,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         x & =\sigma x^T, & y & =\sigma y^T.
     \end{align}
     Equivalently, either $x=x^T$ and $y=y^T$, or $x=-x^T$ and $y=-y^T$.
+    This is the algebraic conclusion in
+    \cite[lines~1033--1038]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 1033--1038.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_kronecker_identity_factors, thm:mpug_unitary_entrywise_self_sign}
@@ -6562,7 +6565,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{prop1conj}
     \notready
     \discussion{5713}
-    \uses{FundamentalMPU, SF, lem:mpu_conjugation_common_transpose_sign}
+    \uses{FundamentalMPU, SF, thm:mpu_conjugation_common_transpose_sign}
     An MPU in standard form is invariant under complex conjugation if and only
     if there are unitaries $x$ and $y$ such that either
     $x=x^T$ and $y=y^T$, or $x=-x^T$ and $y=-y^T$, and
@@ -7538,8 +7541,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $\tr(UU^\dagger)=\tr(\Id)=n$.
 \end{proof}
 
-\begin{lemma}[The exchange intertwines the Kronecker factors]
-    \label{lem:matrix_swap_kronecker_intertwine}
+\begin{theorem}[The exchange intertwines the Kronecker factors]
+    \label{thm:matrix_swap_kronecker_intertwine}
     \lean{Matrix.swapMatrix_mul_kronecker, Matrix.kronecker_mul_swapMatrix}
     \leanok
     For matrices $A,B\in\mathbb C^{n\times n}$ and the exchange matrix
@@ -7548,9 +7551,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \mathbb S(A\otimes B) & =(B\otimes A)\mathbb S, &
         (A\otimes B)\mathbb S & =\mathbb S(B\otimes A).
     \end{align}
-    % Source lines: paper_v2.tex 1624--1630, where the gauge invariance resting
-    % on this identity is asserted without a printed derivation.
-\end{lemma}
+    The equivalent two-sided exchange identity is stated in
+    \cite[lines~1316--1319]{Cirac2017MPU}; the gauge-invariance argument at
+    \cite[lines~1624--1630]{Cirac2017MPU} uses it without a printed derivation.
+    % Source lines: paper_v2.tex 1316--1319 and 1624--1630.
+\end{theorem}
 
 \begin{proof}\leanok
     In product coordinates the exchange matrix has entries
@@ -7564,18 +7569,19 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     The second identity is the first with the two factors exchanged.
 \end{proof}
 
-\begin{lemma}[Exchange contraction of a scaled unitary Kronecker product]
-    \label{lem:matrix_trace_swap_scaled_kronecker}
+\begin{theorem}[Exchange contraction of a scaled unitary Kronecker product]
+    \label{thm:matrix_trace_swap_scaled_kronecker}
     \lean{Matrix.trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose}
     \leanok
-    \uses{lem:matrix_trace_swap_kronecker}
     Let $x\in\mathbb C^{n\times n}$ be unitary, let $\sigma\in\mathbb C$, and let
     $M=\sigma\,x\otimes x^\dagger$. Then
     \begin{align}
         \tr\!\left[\mathbb SM\right] & =\sigma n.
     \end{align}
+    This is the exchange-trace evaluation in
+    \cite[lines~1608--1610]{Cirac2017MPU}; there $n=d^2$.
     % Source lines: paper_v2.tex 1608--1610.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:matrix_trace_swap_kronecker}
@@ -7608,7 +7614,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % the blocked source data required by Proposition~\ref{prop:mpu_admissible_local_time_reversal}.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{prop:mpu_admissible_local_time_reversal, def:mpu_reduced_full_support_source_datum,
-        lem:matrix_trace_swap_scaled_kronecker}
+        thm:matrix_trace_swap_scaled_kronecker}
     For a time-reversal-invariant MPU in admissible standard form, suppose its
     one-site tensor $\mathcal U$, its actual two-site block $\mathcal U_2$, and
     the physical-adjoint comparison tensor $\mathcal U_2^\sharp$ are simple and
@@ -7639,7 +7645,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}
-    \uses{eq:sigma-from-trace, lem:matrix_swap_kronecker_intertwine}
+    \uses{eq:sigma-from-trace, thm:matrix_swap_kronecker_intertwine}
     Write $x_i$ and $y_i$ for the unitaries acting on site $i$. Then
     $u'_{12}=x_1y_2u_{12}$, $u'_{34}=x_3y_4u_{34}$, and
     $v'_{23}=v_{23}y_2^\dagger x_3^\dagger$.
@@ -7660,7 +7666,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{lem:mpu_admissible_sigma_gauge_invariant}
     \notready
     \discussion{5714}
-    \uses{lem:mpu_admissible_sigma_trace, lem:matrix_swap_kronecker_intertwine}
+    \uses{lem:mpu_admissible_sigma_trace, thm:matrix_swap_kronecker_intertwine}
     % Source proof: paper_v2.tex 1624--1630.
     Under the hypotheses of Lemma~\ref{lem:mpu_admissible_sigma_trace}, let $x$ and $y$ be
     unitaries and change the standard-form gauge by
@@ -7719,9 +7725,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1613--1631.
 \end{proposition}
 
-\begin{lemma}[Scalar parity law for the blocked sign]
-    \label{lem:mpu_blocked_sign_parity_scalar}
-    \lean{TNLean.Algebra.blockedSign_eq_first_of_odd,
+\begin{theorem}[Scalar parity law for the blocked sign]
+    \label{thm:mpu_blocked_sign_parity_scalar}
+    \lean{TNLean.Algebra.sq_mul_eq_one_of_sign,
+        TNLean.Algebra.blockedSign_eq_first_of_odd,
         TNLean.Algebra.blockedSign_eq_second_of_even}
     \leanok
     Let $\sigma^{(1)},\sigma^{(2)}\in\{1,-1\}$ and put
@@ -7733,8 +7740,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
                 \sigma^{(2)}, & k\text{ even}.
             \end{cases}
     \end{align}
-    % Source lines: paper_v2.tex 1687 and 1732.
-\end{lemma}
+    This is the scalar conclusion of
+    \cite[lines~1687 and 1730--1732]{Cirac2017MPU}.
+    % Source lines: paper_v2.tex 1687 and 1730--1732.
+\end{theorem}
 
 \begin{proof}\leanok
     Both signs square to one, hence $\zeta^2=1$. For odd $k$ the exponent $k-1$
@@ -7748,7 +7757,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \notready
     \discussion{5714}
     \uses{prop:sigma-well-defined, PropChiral, lem:mpu_blocking,
-        lem:mpu_blocked_sign_parity_scalar}
+        thm:mpu_blocked_sign_parity_scalar}
     Let $\mathcal U$ be a time-reversal-invariant MPU in standard form, and let
     $\sigma^{(k)}$ be the sign obtained from a standard form of its $k$-site
     block. Then
@@ -7794,7 +7803,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % reduced full-support source data. No preservation under blocking is
     % asserted. Documented in
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum, lem:mpu_blocked_sign_parity_scalar}
+    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum, thm:mpu_blocked_sign_parity_scalar}
     For every blocking length $k$ under consideration, suppose the endpoint
     tensor $\mathcal U_k$, its actual two-site block $\mathcal U_{2k}$, and the
     physical-adjoint comparison tensor $\mathcal U_{2k}^\sharp$ are simple and
@@ -7811,7 +7820,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{proposition}
 
 \begin{proof}
-    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, lem:mpu_blocked_sign_parity_scalar}
+    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, thm:mpu_blocked_sign_parity_scalar}
     Gauge invariance permits the standard blocked representatives used in the
     source proof. Choose
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7697,11 +7697,36 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 1613--1631.
 \end{proposition}
 
+\begin{lemma}[Scalar parity law for the blocked sign]
+    \label{lem:mpu_blocked_sign_parity_scalar}
+    \lean{TNLean.Algebra.blockedSign_eq_first_of_odd,
+        TNLean.Algebra.blockedSign_eq_second_of_even}
+    \leanok
+    Let $\sigma^{(1)},\sigma^{(2)}\in\{1,-1\}$ and put
+    $\zeta=\sigma^{(1)}\sigma^{(2)}$. For every $k\geq1$,
+    \begin{align}
+        \sigma^{(1)}\zeta^{k-1}
+         & =\begin{cases}
+                \sigma^{(1)}, & k\text{ odd},  \\
+                \sigma^{(2)}, & k\text{ even}.
+            \end{cases}
+    \end{align}
+    % Source lines: paper_v2.tex 1687 and 1732.
+\end{lemma}
+
+\begin{proof}\leanok
+    Both signs square to one, hence $\zeta^2=1$. For odd $k$ the exponent $k-1$
+    is even, so $\zeta^{k-1}=1$ and the product is $\sigma^{(1)}$. For even
+    $k\geq2$ the exponent $k-1$ is odd, so $\zeta^{k-1}=\zeta$ and the product
+    is $(\sigma^{(1)})^2\sigma^{(2)}=\sigma^{(2)}$.
+\end{proof}
+
 \begin{proposition}[Blocking parity of the time-reversal sign]
     \label{prop:sigma1-and-sigma2-equal}
     \notready
     \discussion{5714}
-    \uses{prop:sigma-well-defined, PropChiral, lem:mpu_blocking}
+    \uses{prop:sigma-well-defined, PropChiral, lem:mpu_blocking,
+        lem:mpu_blocked_sign_parity_scalar}
     Let $\mathcal U$ be a time-reversal-invariant MPU in standard form, and let
     $\sigma^{(k)}$ be the sign obtained from a standard form of its $k$-site
     block. Then
@@ -7747,7 +7772,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % reduced full-support source data. No preservation under blocking is
     % asserted. Documented in
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum}
+    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum, lem:mpu_blocked_sign_parity_scalar}
     For every blocking length $k$ under consideration, suppose the endpoint
     tensor $\mathcal U_k$, its actual two-site block $\mathcal U_{2k}$, and the
     physical-adjoint comparison tensor $\mathcal U_{2k}^\sharp$ are simple and
@@ -7764,7 +7789,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{proposition}
 
 \begin{proof}
-    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking}
+    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, lem:mpu_blocked_sign_parity_scalar}
     Gauge invariance permits the standard blocked representatives used in the
     source proof. Choose
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7564,6 +7564,27 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     The second identity is the first with the two factors exchanged.
 \end{proof}
 
+\begin{lemma}[Exchange contraction of a scaled unitary Kronecker product]
+    \label{lem:matrix_trace_swap_scaled_kronecker}
+    \lean{Matrix.trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose}
+    \leanok
+    \uses{lem:matrix_trace_swap_kronecker}
+    Let $x\in\mathbb C^{n\times n}$ be unitary, let $\sigma\in\mathbb C$, and let
+    $M=\sigma\,x\otimes x^\dagger$. Then
+    \begin{align}
+        \tr\!\left[\mathbb SM\right] & =\sigma n.
+    \end{align}
+    % Source lines: paper_v2.tex 1608--1610.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:matrix_trace_swap_kronecker}
+    The trace is linear, so
+    $\tr[\mathbb SM]=\sigma\tr[\mathbb S(x\otimes x^\dagger)]$, and
+    Lemma~\ref{lem:matrix_trace_swap_kronecker} evaluates the remaining
+    contraction as $n$.
+\end{proof}
+
 \begin{lemma}[Trace formula for the time-reversal sign]
     \label{eq:sigma-from-trace}
     \notready
@@ -7586,7 +7607,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % **Scope restriction (two-site blocked comparison):** the trace formula uses
     % the blocked source data required by Proposition~\ref{prop:mpu_admissible_local_time_reversal}.
     % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{prop:mpu_admissible_local_time_reversal, def:mpu_reduced_full_support_source_datum}
+    \uses{prop:mpu_admissible_local_time_reversal, def:mpu_reduced_full_support_source_datum,
+        lem:matrix_trace_swap_scaled_kronecker}
     For a time-reversal-invariant MPU in admissible standard form, suppose its
     one-site tensor $\mathcal U$, its actual two-site block $\mathcal U_2$, and
     the physical-adjoint comparison tensor $\mathcal U_2^\sharp$ are simple and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7803,7 +7803,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % reduced full-support source data. No preservation under blocking is
     % asserted. Documented in
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
-    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum, thm:mpu_blocked_sign_parity_scalar}
+    \uses{lem:mpu_admissible_sigma_gauge_invariant, prop:mpu_admissible_local_time_reversal, lem:mpu_blocking, def:mpu_reduced_full_support_source_datum}
     For every blocking length $k$ under consideration, suppose the endpoint
     tensor $\mathcal U_k$, its actual two-site block $\mathcal U_{2k}$, and the
     physical-adjoint comparison tensor $\mathcal U_{2k}^\sharp$ are simple and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7666,7 +7666,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{lem:mpu_admissible_sigma_gauge_invariant}
     \notready
     \discussion{5714}
-    \uses{lem:mpu_admissible_sigma_trace, thm:matrix_swap_kronecker_intertwine}
+    \uses{lem:mpu_admissible_sigma_trace}
     % Source proof: paper_v2.tex 1624--1630.
     Under the hypotheses of Lemma~\ref{lem:mpu_admissible_sigma_trace}, let $x$ and $y$ be
     unitaries and change the standard-form gauge by
@@ -7679,7 +7679,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}
-    \uses{lem:mpu_admissible_sigma_trace}
+    \uses{lem:mpu_admissible_sigma_trace, thm:matrix_swap_kronecker_intertwine}
     Write $x_i$ and $y_i$ for the unitaries acting on site $i$. Then
     $u'_{12}=x_1y_2u_{12}$, $u'_{34}=x_3y_4u_{34}$, and
     $v'_{23}=v_{23}y_2^\dagger x_3^\dagger$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7770,7 +7770,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{proposition}
 
 \begin{proof}
-    \uses{lem:mpu_sigma_gauge_invariant, PropChiral, lem:mpu_blocking}
+    \uses{lem:mpu_sigma_gauge_invariant, PropChiral, lem:mpu_blocking,
+        thm:mpu_blocked_sign_parity_scalar}
     Gauge invariance permits the standard blocked representatives used in the
     source proof. Choose
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7538,6 +7538,32 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $\tr(UU^\dagger)=\tr(\Id)=n$.
 \end{proof}
 
+\begin{lemma}[The exchange intertwines the Kronecker factors]
+    \label{lem:matrix_swap_kronecker_intertwine}
+    \lean{Matrix.swapMatrix_mul_kronecker, Matrix.kronecker_mul_swapMatrix}
+    \leanok
+    For matrices $A,B\in\mathbb C^{n\times n}$ and the exchange matrix
+    $\mathbb S$ on $\mathbb C^n\otimes\mathbb C^n$,
+    \begin{align}
+        \mathbb S(A\otimes B) & =(B\otimes A)\mathbb S, &
+        (A\otimes B)\mathbb S & =\mathbb S(B\otimes A).
+    \end{align}
+    % Source lines: paper_v2.tex 1624--1630, where the gauge invariance resting
+    % on this identity is asserted without a printed derivation.
+\end{lemma}
+
+\begin{proof}\leanok
+    In product coordinates the exchange matrix has entries
+    $\mathbb S_{(i,j),(k,l)}=\delta_{i,l}\delta_{j,k}$, so both sides of the
+    first identity have entry
+    \begin{align}
+        \left[\mathbb S(A\otimes B)\right]_{(i_1,i_2),(j_1,j_2)}
+         & =A_{i_2,j_1}B_{i_1,j_2}
+        =\left[(B\otimes A)\mathbb S\right]_{(i_1,i_2),(j_1,j_2)}.
+    \end{align}
+    The second identity is the first with the two factors exchanged.
+\end{proof}
+
 \begin{lemma}[Trace formula for the time-reversal sign]
     \label{eq:sigma-from-trace}
     \notready
@@ -7591,7 +7617,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}
-    \uses{eq:sigma-from-trace}
+    \uses{eq:sigma-from-trace, lem:matrix_swap_kronecker_intertwine}
     Write $x_i$ and $y_i$ for the unitaries acting on site $i$. Then
     $u'_{12}=x_1y_2u_{12}$, $u'_{34}=x_3y_4u_{34}$, and
     $v'_{23}=v_{23}y_2^\dagger x_3^\dagger$.
@@ -7612,7 +7638,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{lem:mpu_admissible_sigma_gauge_invariant}
     \notready
     \discussion{5714}
-    \uses{lem:mpu_admissible_sigma_trace}
+    \uses{lem:mpu_admissible_sigma_trace, lem:matrix_swap_kronecker_intertwine}
     % Source proof: paper_v2.tex 1624--1630.
     Under the hypotheses of Lemma~\ref{lem:mpu_admissible_sigma_trace}, let $x$ and $y$ be
     unitaries and change the standard-form gauge by

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -6527,11 +6527,42 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \subsection{Local characterization of symmetries}
 
+\begin{lemma}[Common transpose sign of the conjugation factors]
+    \label{lem:mpu_conjugation_common_transpose_sign}
+    \lean{Matrix.exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one,
+        Matrix.transpose_eq_self_or_transpose_eq_neg_of_kronecker_map_star_mul_eq_one}
+    \leanok
+    \uses{thm:mpug_kronecker_identity_factors, thm:mpug_unitary_entrywise_self_sign}
+    Let $x$ and $y$ be unitary matrices over $\mathbb C$, indexed by nonempty
+    finite sets, whose entrywise conjugates satisfy
+    \begin{align}
+        \overline xx\otimes\overline yy & =\Id.
+    \end{align}
+    Then there is a sign $\sigma\in\{1,-1\}$ with
+    \begin{align}
+        x & =\sigma x^T, & y & =\sigma y^T.
+    \end{align}
+    Equivalently, either $x=x^T$ and $y=y^T$, or $x=-x^T$ and $y=-y^T$.
+    % Source lines: paper_v2.tex 1033--1038.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_kronecker_identity_factors, thm:mpug_unitary_entrywise_self_sign}
+    A Kronecker product equal to the identity has reciprocal scalar factors, so
+    $\overline xx=e^{i\phi}\Id$ and $\overline yy=e^{-i\phi}\Id$. Since $x$ is
+    unitary, $x^T$ is a left inverse of $\overline x$; multiplying the first
+    relation by $x^T$ on the left gives $x=e^{i\phi}x^T$, and the same argument
+    gives $y=e^{-i\phi}y^T$. Reading the first relation as a relation for the
+    unitary $\overline x$ against its own entrywise conjugate gives
+    $\Id=xx^\dagger=e^{2i\phi}\Id$, so $e^{i\phi}=\pm1$ and
+    $e^{-i\phi}=e^{i\phi}$. The two matrices therefore carry one transpose sign.
+\end{proof}
+
 \begin{proposition}[Conjugation symmetry]
     \label{prop1conj}
     \notready
     \discussion{5713}
-    \uses{FundamentalMPU, SF}
+    \uses{FundamentalMPU, SF, lem:mpu_conjugation_common_transpose_sign}
     An MPU in standard form is invariant under complex conjugation if and only
     if there are unitaries $x$ and $y$ such that either
     $x=x^T$ and $y=y^T$, or $x=-x^T$ and $y=-y^T$, and

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -828,8 +828,9 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
         \sigma\tau & =1.
         \label{eq:mpug_unitary_entrywise_paired_scalars}
     \end{align}
-    This is the conditional matrix-algebra content of
-    $\sigma_g\sigma_{g^{-1}}=1$ in
+    This is the reciprocity of the two conjugation phases in
+    \cite[lines~1033--1036]{Cirac2017MPU}, and the conditional matrix-algebra
+    content of $\sigma_g\sigma_{g^{-1}}=1$ in
     \cite[lines~1559--1563]{FrancoRubio2025MPUGauging}.
 \end{theorem}
 
@@ -858,7 +859,8 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
         \sigma & \in\{1,-1\}.
         \label{eq:mpug_unitary_entrywise_self_sign}
     \end{align}
-    This is the involution conclusion in
+    This is the sign step $\Id=xx^\dagger=e^{2i\phi}\Id$ in
+    \cite[lines~1036--1038]{Cirac2017MPU}, and the involution conclusion in
     \cite[lines~1563--1567]{FrancoRubio2025MPUGauging}, conditional on the
     self relation.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -828,9 +828,8 @@ Assume from now until the end of this section that $G$ is finite and $d>0$.
         \sigma\tau & =1.
         \label{eq:mpug_unitary_entrywise_paired_scalars}
     \end{align}
-    This is the reciprocity of the two conjugation phases in
-    \cite[lines~1033--1036]{Cirac2017MPU}, and the conditional matrix-algebra
-    content of $\sigma_g\sigma_{g^{-1}}=1$ in
+    This is the conditional matrix-algebra content of
+    $\sigma_g\sigma_{g^{-1}}=1$ in
     \cite[lines~1559--1563]{FrancoRubio2025MPUGauging}.
 \end{theorem}
 


### PR DESCRIPTION
Four small, source-anchored algebra leaves from arXiv:1703.09188 (Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Unitaries*), each assembled from ingredients already in the library. One commit per issue.

## Contents and source anchors

**Closes #7497** — common symmetric/skew-symmetric conjugation sign. Anchor: `paper_v2.tex:1033--1038`. New module `TNLean/Algebra/UnitaryConjugationTransposeSign.lean`, following the printed route verbatim: the Kronecker identity `x̄x ⊗ ȳy = 𝟙` splits into reciprocal scalars `e^{iφ}` and `e^{-iφ}`, the transpose inverts the entrywise conjugate of a unitary, and `𝟙 = xx† = e^{2iφ}𝟙` forces `e^{iφ} = ±1`. Declarations: `Matrix.transpose_mul_map_star_of_mem_unitaryGroup`, `Matrix.eq_smul_transpose_of_map_star_mul_eq_smul_one`, `Matrix.exists_common_transpose_sign_of_kronecker_map_star_mul_eq_one`, `Matrix.transpose_eq_self_or_transpose_eq_neg_of_kronecker_map_star_mul_eq_one`.

*Docstring re-anchoring.* `Matrix.scalar_eq_one_or_neg_one_of_mul_map_star_self_eq_smul_one` in `TNLean/Algebra/UnitaryEntrywiseConjugation.lean` is also anchored to arXiv:1703.09188, `paper_v2.tex:1036--1038`, where this self-relation sign step appears; the FBC25 citation is kept as a secondary use site. The distinct reciprocal-scalar theorem remains anchored only to its direct FBC25 use.

**Closes #7500** — the factor swap intertwines the Kronecker factors. Anchors: the printed two-sided exchange identity at `paper_v2.tex:1316--1319` and its gauge-invariance use at `paper_v2.tex:1624--1630`. New module `TNLean/Algebra/SwapKronecker.lean`, entrywise over `Matrix.swapMatrix`. Declarations: `Matrix.swapMatrix_mul_kronecker`, `Matrix.kronecker_mul_swapMatrix`. The source asserts the gauge invariance that rests on this identity with "It is straightforward to check" and prints no derivation; the module docstring and blueprint node say so rather than citing those lines as a proof. Unblocks #7571.

**Closes #7501** — scalar blocking-parity law. Anchors: `ζ = σ⁽¹⁾σ⁽²⁾` at `paper_v2.tex:1687`, `σ⁽ᵏ⁾ = σ⁽¹⁾ζ^{k-1}` at `paper_v2.tex:1732`. New module `TNLean/Algebra/BlockingSignParity.lean`. Declarations: `TNLean.Algebra.sq_mul_eq_one_of_sign`, `TNLean.Algebra.blockedSign_eq_first_of_odd`, `TNLean.Algebra.blockedSign_eq_second_of_even`.

**Closes #7498** — the σ-scaled exchange trace identity. Anchor: `paper_v2.tex:1608--1610`. Added to `TNLean/Algebra/SwapKronecker.lean` on top of the already-`\leanok` general lemma (`lem:matrix_trace_swap_kronecker`, backed by QICLean's `Matrix.trace_swapMatrix_mul_kronecker_conjTranspose_of_mem_unitaryGroup`). Declaration: `Matrix.trace_swapMatrix_mul_of_eq_smul_kronecker_conjTranspose`.

## Blueprint

Four Chapter 28 nodes, each with `\lean{}`, `\leanok` on statement and proof, and reader-visible source citations: `thm:mpu_conjugation_common_transpose_sign`, `thm:matrix_swap_kronecker_intertwine`, `thm:matrix_trace_swap_scaled_kronecker`, `thm:mpu_blocked_sign_parity_scalar`. The two existing admissible proof sketches that already invoke these leaves list them as proof-local `\uses{}` dependencies; the remaining `\notready` statements do not misclassify proof ingredients as statement dependencies.

No scope-restriction or unfaithfulness markers are needed: every statement carries exactly the source's hypothesis set, and none of the four claims a tensor-network theorem. Each remains a leaf under its parent tracker (#7017, #7108, #7109, #7111).

## Verification

- Exact base `0d1f865e743b9ddfd05bbe2e88031d6111533167`, seeded from the fully warmed `worktrees/hot-main`; no cache fetch or cold build.
- `scripts/lake_build_locked.sh -- lake build` — clean (`10510` jobs), with only pre-existing replayed tactic suggestions.
- No `sorry`, `admit`, `axiom`, `unsafeCast`, or `native_decide` in the changed files.
- `python3 scripts/generate_import_aggregators.py --check` — passes (`37` generated files, `1128` production modules).
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint ...` — in sync; no changed declaration lacks Blueprint coverage (ch28 `959/959`, ch29 `448/448`).
- `python3 scripts/fetch_tenkz.py`, `leanblueprint web`, and `leanblueprint checkdecls` — pass.
- Two direct `lualatex` passes complete; there are no concrete undefined cross-reference warnings (standalone citation warnings remain because `print.bbl` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca





