### PR TITLE
feat(Algebra): identify finite complex star-subalgebras with trivial center

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Algebra
 
+import TNLean.Algebra.CentralStarSubalgebraMatrix
 import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.CommonBufferLength

--- a/TNLean/Algebra/CentralStarSubalgebraMatrix.lean
+++ b/TNLean/Algebra/CentralStarSubalgebraMatrix.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.StarSubalgebraFactor
+
+/-!
+# Full-matrix presentation of a star-subalgebra with scalar centre
+
+Let `S` be a unital star-subalgebra of a nonzero finite complex matrix algebra whose centre
+consists exactly of the scalar multiples of its unit. Then `S` is star-isomorphic to a single
+full complex matrix algebra `M_r(ℂ)` with `r ≥ 1`, and its complex dimension is `r * r`.
+
+The star-isomorphism itself is the companion library's theorem
+`StarSubalgebra.exists_starAlgEquiv_matrix_of_isCentral`; the statement below packages it with
+the resulting positive matrix size and the dimension identity in the single form used by the
+quantum-cellular-automaton support-algebra development.
+
+Some nontriviality hypothesis is indispensable. For an empty index type the ambient matrix
+algebra is the zero ring; its centre is still the scalar image, yet it is star-isomorphic to no
+`M_r(ℂ)` with `r ≥ 1`. Here that role is played by nonemptiness of the matrix index.
+
+## Main results
+
+* `StarSubalgebra.exists_starAlgEquiv_matrix_and_finrank_of_isCentral` — a star-subalgebra of a
+  nonzero full complex matrix algebra whose centre is scalar is star-isomorphic to `M_r(ℂ)` for
+  a positive `r`, and has complex dimension `r * r`.
+
+## References
+
+* B. Schumacher and R. F. Werner, *Reversible quantum cellular automata*, quant-ph/0405174,
+  Proposition `Csform`, lines 2082--2098.
+* D. Gross, V. Nesme, H. Vogts, and R. F. Werner, *Index theory of one-dimensional quantum walks
+  and cellular automata*, arXiv:0910.3675, lines 1276--1282.
+
+**Scope restriction (Schumacher--Werner `Csform`):** the result below is not a formalization of
+Proposition `Csform`. That proposition decomposes an abstract finite-dimensional C*-algebra into
+a direct sum of full matrix algebras, cutting by the minimal projections of its centre. What is
+formalized here is the single building block of that decomposition, for an algebra already
+presented as a star-subalgebra of a matrix algebra: neither the abstract C*-algebra generality
+nor the central cut is covered. The omitted content and its elimination plan are recorded in the
+companion library's paper-gap note
+<https://sirui-lu.com/QICLean/paper-gaps/sw04_csform_matrix_scope.pdf>.
+-/
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **A star-subalgebra of complex matrices with scalar centre is a full matrix algebra of a
+definite size.** Let `S` be a star-subalgebra of a nonzero full complex matrix algebra whose
+centre consists of the scalar multiples of its unit. Then there is an `r ≥ 1` with
+`S ≃⋆ₐ[ℂ] M_r(ℂ)` and `dim_ℂ S = r * r`.
+
+This is the building-block step of the structure theorem for finite-dimensional C*-algebras,
+Schumacher--Werner, quant-ph/0405174, Proposition `Csform`, lines 2082--2098, specialized to an
+algebra presented as a star-subalgebra of a matrix algebra; the scope restriction is described
+in the module docstring. It is the conclusion invoked by Gross--Nesme--Vogts--Werner,
+arXiv:0910.3675, `References/0910.3675/QCI12.tex`, lines 1276--1282, where a support algebra is
+first shown to have scalar centre, because a central element of it is central in the generated
+quasi-local algebra, and is then identified with `M_{r(x)}(ℂ)`. -/
+theorem exists_starAlgEquiv_matrix_and_finrank_of_isCentral [Nonempty n]
+    (S : StarSubalgebra ℂ (Matrix n n ℂ)) [Algebra.IsCentral ℂ ↥S] :
+    ∃ r : ℕ, 0 < r ∧ Nonempty (↥S ≃⋆ₐ[ℂ] Matrix (Fin r) (Fin r) ℂ) ∧
+      Module.finrank ℂ ↥S = r * r := by
+  obtain ⟨r, hr, ⟨e⟩⟩ := S.exists_starAlgEquiv_matrix_of_isCentral
+  exact ⟨r, Nat.pos_of_ne_zero hr.out, ⟨e⟩, S.finrank_eq_mul_self_of_starAlgEquiv_matrix e⟩
+
+end StarSubalgebra

--- a/TNLean/Algebra/CentralStarSubalgebraMatrix.lean
+++ b/TNLean/Algebra/CentralStarSubalgebraMatrix.lean
@@ -57,7 +57,7 @@ This is the building-block step of the structure theorem for finite-dimensional 
 Schumacher--Werner, quant-ph/0405174, Proposition `Csform`, lines 2082--2098, specialized to an
 algebra presented as a star-subalgebra of a matrix algebra; the scope restriction is described
 in the module docstring. It is the conclusion invoked by Gross--Nesme--Vogts--Werner,
-arXiv:0910.3675, `References/0910.3675/QCI12.tex`, lines 1276--1282, where a support algebra is
+arXiv:0910.3675, `References/0910.3675v2/QCI12.tex`, lines 1276--1282, where a support algebra is
 first shown to have scalar centre, because a central element of it is central in the generated
 quasi-local algebra, and is then identified with `M_{r(x)}(ℂ)`. -/
 theorem exists_starAlgEquiv_matrix_and_finrank_of_isCentral [Nonempty n]

--- a/blueprint/src/chapter/ch28_mpu_central_matrix_factor.tex
+++ b/blueprint/src/chapter/ch28_mpu_central_matrix_factor.tex
@@ -1,0 +1,63 @@
+\subsection{Full-matrix presentation of a factor with scalar centre}
+
+\begin{theorem}[Scalar centre forces a full matrix algebra of a definite size]
+    \label{thm:qca_central_star_subalgebra_matrix}
+    \lean{StarSubalgebra.exists_starAlgEquiv_matrix_and_finrank_of_isCentral}
+    \leanok
+    Let $I$ be a finite nonempty set and let $S\subseteq M_I(\C)$ be a unital
+    star-subalgebra whose centre consists of the multiples of its unit,
+    \begin{align}
+        \{z\in S\mid zs=sz\text{ for every }s\in S\}
+         & =\C\mathbf 1.
+        \label{eq:qca_central_star_subalgebra_scalar_centre}
+    \end{align}
+    Then there is an $r\geq1$ with
+    \begin{align}
+        S            & \cong\MN{r}, \notag \\
+        \dim_{\C}(S) & =r^2,
+    \end{align}
+    the first isomorphism being one of star-algebras.
+
+    Nonemptiness of $I$ cannot be dropped.  For $I=\emptyset$ the ambient
+    algebra $M_I(\C)$ is the zero algebra, its unique subalgebra still
+    satisfies (\ref{eq:qca_central_star_subalgebra_scalar_centre}), and it is
+    isomorphic to no $\MN{r}$ with $r\geq1$.
+
+    \textbf{Scope restriction (Schumacher--Werner \texttt{Csform}):}
+    This is the single building block of the structure theorem for
+    finite-dimensional $C^*$-algebras, Proposition~\texttt{Csform}
+    \cite[lines~2082--2098]{SchumacherWerner2004QCA}, for an algebra already
+    presented inside a matrix algebra.  It asserts neither the direct-sum
+    decomposition $\mathcal A\cong\bigoplus_\mu\MN{n_\mu}$ of that
+    proposition, nor its cut by the minimal projections of the centre, nor the
+    abstract $C^*$-algebra generality in which it is stated.  The omitted
+    content and its elimination plan are recorded in
+    \cite{gap:sw04_csform_matrix_scope}.
+\end{theorem}
+
+\begin{proof}\leanok
+    A star-subalgebra of a complex matrix algebra is semisimple, so it is
+    isomorphic to a finite product $\prod_{k=1}^{m}\MN{d_k}$ with every
+    $d_k\geq1$.  The element that is the unit in the $k$-th coordinate and
+    zero in the others is central, hence by
+    (\ref{eq:qca_central_star_subalgebra_scalar_centre}) a multiple
+    $\lambda\mathbf 1$; comparing its $k$-th coordinate with another one gives
+    $\lambda=1$ and $\lambda=0$, so $m\leq1$.  The unit of $M_I(\C)$ is
+    nonzero because $I$ is nonempty, so $m=1$ and $S$ is a simple ring.  The
+    Wedderburn theorem over the algebraically closed field $\C$ then produces
+    an $r\geq1$ and an isomorphism of $\C$-algebras $S\cong\MN{r}$, and
+    conjugating it by a positive definite matrix makes it preserve adjoints
+    \cite[``A $*$-subalgebra with scalar centre is a full matrix
+        algebra'']{QICLean2026Blueprint}.  A star-isomorphism is in particular
+    a $\C$-linear isomorphism, and $\dim_{\C}\MN{r}=r^2$
+    \cite[``Dimension of a subalgebra presented as a full matrix
+        algebra'']{QICLean2026Blueprint}.
+\end{proof}
+
+Gross, Nesme, Vogts and Werner apply this conclusion to the site-indexed
+support algebras \cite[lines~1276--1282]{Gross2012IndexTheory}: an element of
+$\mathcal R_x$ commuting with all of $\mathcal R_x$ commutes with every
+$\mathcal R_y$, hence with the algebra they generate, which is the whole
+quasi-local algebra; its centre is scalar, so
+(\ref{eq:qca_central_star_subalgebra_scalar_centre}) holds for $\mathcal R_x$
+and $\mathcal R_x\cong M_{r(x)}(\C)$.

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -17,6 +17,7 @@
 \input{chapter/ch20_mpdo}
 \input{chapter/ch26_mps_rfp}
 \input{chapter/ch28_mpu}
+\input{chapter/ch28_mpu_central_matrix_factor}
 \input{chapter/ch29_mpu_gauging}
 \input{chapter/ch21_mpdo_rfp}
 \input{chapter/ch21_mpdo_rfp_algebraic}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1116,6 +1116,17 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/gnvw12_site_dependent_adjacent_generation_scope.pdf}},
 }
 
+@techreport{gap:sw04_csform_matrix_scope,
+  author      = {The {QICLean} contributors},
+  title       = {The Structure Theorem for Finite-Dimensional $C^\ast$-Algebras:
+                 Matrix-Realized Single-Block Scope},
+  institution = {QICLean},
+  type        = {Paper-gap note},
+  number      = {sw04\_csform\_matrix\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/QICLean/paper-gaps/sw04_csform_matrix_scope.pdf}},
+}
+
 @techreport{gap:sw04_support_covariance_scope,
   author      = {The {TNLean} contributors},
   title       = {One-Dimensional Scope of {Schumacher--Werner} Support-Algebra Covariance},


### PR DESCRIPTION
Closes #7118.

## Statement

For a unital complex star-subalgebra `S` of a nonzero finite full matrix algebra whose centre is exactly the scalar image, `StarSubalgebra.exists_starAlgEquiv_matrix_and_finrank_of_isCentral` produces a positive `r`, a star-algebra equivalence `↥S ≃⋆ₐ[ℂ] Matrix (Fin r) (Fin r) ℂ`, and the dimension identity `Module.finrank ℂ ↥S = r * r`.

Nontriviality enters as `[Nonempty n]` on the ambient matrix index. It cannot be dropped: for an empty index the ambient algebra is the zero ring, whose centre is still the scalar image but which is star-isomorphic to no `M_r(ℂ)` with `r ≥ 1`. The scalar-centre hypothesis is the canonical `[Algebra.IsCentral ℂ ↥S]`.

## Consumption, not duplication

The classification itself is the companion library's `StarSubalgebra.exists_starAlgEquiv_matrix_of_isCentral`, with the dimension step `StarSubalgebra.finrank_eq_mul_self_of_starAlgEquiv_matrix`; both arrive with the QICLean pin moved in the base branch. Nothing here reproduces that proof, and no local duplicate of the classification is introduced. The new declaration only packages the three conclusions the support-algebra development needs into one statement.

## Faithfulness

Schumacher--Werner, `Papers/quant-ph_0405174/qca.tex`, Proposition `Csform`, lines 2082--2098, states the abstract decomposition of a finite-dimensional C*-algebra into a direct sum of full matrix algebras. What lands here is the concrete single-block specialization for a star-subalgebra of `Matrix n n ℂ`: neither the abstract generality nor the cut by the minimal central projections is formalized. The module docstring and the blueprint entry both carry a `Scope restriction (Schumacher--Werner Csform)` marker naming that gap and citing the companion library's paper-gap note `sw04_csform_matrix_scope`; a bibliography entry for that note is added, pointing at its published URL. The use anchor is Gross--Nesme--Vogts--Werner, `References/0910.3675v2/QCI12.tex`, lines 1276--1282, where a central element of a support algebra is shown central in the generated global algebra and hence scalar, and this one-block conclusion is then invoked.

## Non-goals respected

No spatial classification of the embedding, no bicommutant or double-commutant route, no new Skolem--Noether argument, no adjacent-block generation, no dependence on #7117. `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` is not used.

## Base branch

Rebased onto `main` after #7709 merged the QICLean pin that publishes the consumed declarations.

## Verification

- `scripts/lake_build_locked.sh TNLean.Algebra.CentralStarSubalgebraMatrix` — `Built TNLean.Algebra.CentralStarSubalgebraMatrix (10s)`, `Build completed successfully (3019 jobs)`, no diagnostics.
- `scripts/lake_build_locked.sh TNLean.Algebra` — `Build completed successfully (3584 jobs)`.
- `scripts/blueprint_lean_sync.py --update-lean-decls` then `lake exe checkdecls blueprint/lean_decls` — clean.
- `texra-blueprint paper-gaps check` — 122 referenced slugs resolve; `texra-blueprint bbl` regenerates the bibliography with the new entry.
- `tenkz_lint.py` on the new chapter file, `check_reader_facing_prose.py`, `check_forbidden_lean_tokens.py`, `check_numbered_lean_files.py`, `check_oversized_lean_files.py`, `lean_import_syntax.py`, `lake exe lint_style` — no findings against the new files.

No `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
