### PR TITLE
doc(Blueprint): backfill merged MPU prerequisite coverage

### DIFF
--- a/blueprint/src/chapter/ch15_examples_cluster_state.tex
+++ b/blueprint/src/chapter/ch15_examples_cluster_state.tex
@@ -48,7 +48,8 @@ computation and provides another example of a non-trivial SPT phase.
 \end{proof}
 
 \begin{theorem}[Cluster-state tensor is normal]\label{thm:cluster_normal}
-    \lean{MPSTensor.cluster_isNBlkInjective_two}
+    \lean{MPSTensor.cluster_isNBlkInjective_two,
+        MPSTensor.clusterBlocked_isInjective}
     \leanok
     \uses{def:cluster_tensor, def:injective}
     Although the cluster-state tensor is not injective at a single site, its

--- a/blueprint/src/chapter/ch15_examples_ghz.tex
+++ b/blueprint/src/chapter/ch15_examples_ghz.tex
@@ -5,7 +5,8 @@ The Greenberger--Horne--Zeilinger (GHZ) state is the prototypical
 non-injective, renormalization-fixed-point MPS.
 
 \begin{definition}[GHZ tensor]\label{def:ghz_tensor}
-    \lean{MPSTensor.ghzTensor}
+    \lean{MPSTensor.ghzTensor,
+        MPSTensor.ghzTensor_apply}
     \leanok
     \uses{def:mps_tensor}
     Set $d = D = 2$. The GHZ tensor is the family

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1952,6 +1952,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mps_word_span_tensor_product}
     \lean{MPSTensor.wordSpan_tensorProduct,
         MPSTensor.isNBlkInjective_tensorProduct,
+        MPSTensor.isInjective_tensorProduct,
         MPSTensor.isNormal_tensorProduct}
     \leanok
     \uses{def:mps_independent_tensor_product, def:word_span, def:normal}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2316,18 +2316,6 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 \begin{definition}[Restricted scalar gauges]
     \label{def:mpug_restricted_scalar_gauge}
     \lean{TNLean.Algebra.ScalarCocycle.IsInverseNormalized,
-        TNLean.Algebra.ScalarCocycle.isInverseNormalized_one,
-        TNLean.Algebra.RestrictedFusionGauge.one,
-        TNLean.Algebra.RestrictedFusionGauge.mul,
-        TNLean.Algebra.RestrictedFusionGauge.inv,
-        TNLean.Algebra.RestrictedScalarGauge.one,
-        TNLean.Algebra.RestrictedScalarGauge.mul,
-        TNLean.Algebra.RestrictedScalarGauge.inv,
-        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.mul,
-        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.inv,
-        TNLean.Algebra.ActionTensorGauge.isNormalized_one,
-        TNLean.Algebra.ActionTensorGauge.IsNormalized.mul,
-        TNLean.Algebra.ActionTensorGauge.IsNormalized.inv,
         TNLean.Algebra.RestrictedFusionGauge,
         TNLean.Algebra.RestrictedScalarGauge}
     \leanok
@@ -2430,7 +2418,19 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
 
 \begin{theorem}[Action of the restricted scalar gauge group]
     \label{thm:mpug_restricted_scalar_gauge_action}
-    \lean{TNLean.Algebra.RestrictedFusionGauge.fusionGauge_one,
+    \lean{TNLean.Algebra.ScalarCocycle.isInverseNormalized_one,
+        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.mul,
+        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.inv,
+        TNLean.Algebra.ActionTensorGauge.isNormalized_one,
+        TNLean.Algebra.ActionTensorGauge.IsNormalized.mul,
+        TNLean.Algebra.ActionTensorGauge.IsNormalized.inv,
+        TNLean.Algebra.RestrictedFusionGauge.one,
+        TNLean.Algebra.RestrictedFusionGauge.mul,
+        TNLean.Algebra.RestrictedFusionGauge.inv,
+        TNLean.Algebra.RestrictedScalarGauge.one,
+        TNLean.Algebra.RestrictedScalarGauge.mul,
+        TNLean.Algebra.RestrictedScalarGauge.inv,
+        TNLean.Algebra.RestrictedFusionGauge.fusionGauge_one,
         TNLean.Algebra.RestrictedFusionGauge.isNormalized_fusionGauge,
         TNLean.Algebra.RestrictedFusionGauge.isCocycle_fusionGauge,
         TNLean.Algebra.RestrictedFusionGauge.fusionGauge_mul,
@@ -4005,8 +4005,7 @@ scalar calculation above.
 
 \begin{definition}[GHZ--blocked-cluster tensor and its two blocks]
     \label{def:mpug_ghz_blocked_cluster_tensor}
-    \lean{MPSTensor.ghzTensor_apply,
-        MPSTensor.ghzSectorTensor,
+    \lean{MPSTensor.ghzSectorTensor,
         MPSTensor.ghzSectorTensor_apply_same,
         MPSTensor.z4z2GHZClusterTensor,
         MPSTensor.z4z2GHZClusterBlock,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2442,11 +2442,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         TNLean.Algebra.RestrictedScalarGauge.gauge_inv}
     \leanok
     \discussion{7700}
-    \uses{def:mpug_restricted_scalar_gauge,
-        thm:mpug_gauge_preserves_cocycle,
-        thm:mpug_gauge_preserves_normalization,
-        thm:mpug_l_gauge_composition,
-        thm:mpug_l_gauge_preservation}
+    \uses{def:mpug_restricted_scalar_gauge}
     Let $\kappa=(\beta,\gamma)$ be a restricted scalar gauge. If $\omega$ is
     a normalized scalar $3$-cocycle and $L$ is a normalized $L$-symbol
     compatible with $\omega$, then
@@ -4020,13 +4016,13 @@ scalar calculation above.
     obtained by taking its independent tensor product with the GHZ tensor has
     physical dimension $8$ and bond dimension $4$:
     \begin{align}
-        A & =A^{\mathrm{GHZ}}\otimes C.
+        A & =A^{\mathrm{GHZ}}\boxtimes C.
         \label{eq:mpug_ghz_blocked_cluster_tensor}
     \end{align}
     For $x\in\{0,1\}$, let $E_x$ be the one-dimensional GHZ sector supported
     at the physical value $x$. The two bond-dimension-$2$ tensors
     \begin{align}
-        A_x & =E_x\otimes C
+        A_x & =E_x\boxtimes C
     \end{align}
     satisfy, for $p,x\in\{0,1\}$ and $q\in\{0,1,2,3\}$,
     \begin{align}
@@ -4050,7 +4046,7 @@ scalar calculation above.
     \leanok
     \discussion{7699}
     \uses{def:mpug_ghz_blocked_cluster_tensor, def:injective,
-        def:is_bnt_locally_orthogonal, thm:cluster_normal}
+        def:is_bnt_locally_orthogonal}
     Each tensor $A_x$ is injective. For $x\neq y$ and every
     $X\in\operatorname{Mat}_2(\C)$, their one-site mixed transfer map satisfies
     \begin{align}
@@ -4077,12 +4073,20 @@ scalar calculation above.
     \uses{def:mpug_ghz_blocked_cluster_tensor, def:injective,
         def:is_bnt_locally_orthogonal, thm:cluster_normal}
     The one-dimensional sector $E_x$ is injective, and injectivity is preserved
-    by independent tensor products, so $A_x=E_x\otimes C$ is injective.
+    by independent tensor products, so $A_x=E_x\boxtimes C$ is injective.
     If $x\neq y$, formula~(\ref{eq:mpug_ghz_blocked_cluster_blocks}) makes
     every summand in
     (\ref{eq:mpug_ghz_blocked_cluster_local_orthogonality}) vanish: a physical
-    value $p$ cannot equal both $x$ and $y$. The direct-sum identity follows by
-    comparing the same formula in the two canonical bond coordinate systems.
+    value $p$ cannot equal both $x$ and $y$. For $p,x,y\in\{0,1\}$,
+    $q\in\{0,1,2,3\}$, and $a,b\in\{0,1\}$, the direct-sum and product tensors
+    have the same entry in their canonical bond coordinates:
+    \begin{align}
+        (A_0\oplus A_1)^{(p,q)}_{(x,a),(y,b)}
+         & =A^{(p,q)}_{(x,a),(y,b)}
+        =\delta_{x,y}\delta_{p,x}C^q_{a,b}.
+    \end{align}
+    Equality of all entries proves
+    (\ref{eq:mpug_ghz_blocked_cluster_direct_sum}).
 \end{proof}
 
 \section{The gauge-invariant subspace of the CZX circuit tuple}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4039,7 +4039,6 @@ scalar calculation above.
 \begin{theorem}[Injective and locally orthogonal GHZ--cluster blocks]
     \label{thm:mpug_ghz_blocked_cluster_blocks}
     \lean{MPSTensor.ghzSectorTensor_isInjective,
-        MPSTensor.isInjective_tensorProduct,
         MPSTensor.z4z2GHZClusterBlock_isInjective,
         MPSTensor.z4z2GHZClusterBlocks_isBNTLocallyOrthogonal,
         MPSTensor.z4z2GHZClusterDirectSum_eq_tensor}
@@ -4071,7 +4070,8 @@ scalar calculation above.
 
 \begin{proof}\leanok
     \uses{def:mpug_ghz_blocked_cluster_tensor, def:injective,
-        def:is_bnt_locally_orthogonal, thm:cluster_normal}
+        def:is_bnt_locally_orthogonal, thm:mps_word_span_tensor_product,
+        thm:cluster_normal}
     The one-dimensional sector $E_x$ is injective, and injectivity is preserved
     by independent tensor products, so $A_x=E_x\boxtimes C$ is injective.
     If $x\neq y$, formula~(\ref{eq:mpug_ghz_blocked_cluster_blocks}) makes

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2346,7 +2346,6 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \gamma^x_e & =1.
         \label{eq:mpug_restricted_action_gauge}
     \end{align}
-    These pairs form a group under pointwise multiplication and inversion.
     The conditions are the standing restriction imposed at
     \cite[lines~2050--2054]{FrancoRubio2025MPUGauging} after the earlier
     fusion and action gauges have been fixed.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1655,7 +1655,7 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
         \label{eq:mpug_completion_class_nonempty}
     \end{align}
     Equivalently, there is a family
-    $R=\{U_{a,b}\}_{(a,b)\in G^2}$ of unitary operators such that, for every
+    $R=(U_{a,b})_{(a,b)\in G^2}$ of unitary operators such that, for every
     $a,b\in G$ and every $\ket{\xi}\in\mathcal K_{a,b}$,
     \begin{align}
         U_{a,b}\ket{\xi}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1640,6 +1640,47 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     of~\cite[lines~4215--4326]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
+\begin{theorem}[Existence of full unitary completions]
+    \label{thm:mpug_completion_class_nonempty}
+    \lean{TNLean.Algebra.DefectMaps.completionClass_nonempty,
+        TNLean.Algebra.DefectMaps.exists_completion}
+    \leanok
+    \discussion{7702}
+    \uses{def:mpug_defect_maps, def:mpug_completion_class}
+    Let $\mathcal H_{\mathrm m}$ be finite-dimensional. Every family of
+    prescribed defect maps satisfying (\ref{eq:mpug_defect_isometry}) admits a
+    simultaneous unitary extension:
+    \begin{align}
+        \mathfrak C(D) & \neq\varnothing.
+        \label{eq:mpug_completion_class_nonempty}
+    \end{align}
+    Equivalently, there is a family
+    $R=\{U_{a,b}\}_{(a,b)\in G^2}$ of unitary operators such that, for every
+    $a,b\in G$ and every $\ket{\xi}\in\mathcal K_{a,b}$,
+    \begin{align}
+        U_{a,b}\ket{\xi}
+         & =D_{a,b}\ket{\xi}.
+        \label{eq:mpug_completion_exists}
+    \end{align}
+    This is the finite-dimensional extension step implicit in the freedom of
+    the modified fusion operators at
+    \cite[lines~4215--4326]{FrancoRubio2025MPUGauging}. The subspaces
+    $\mathcal K_{a,b}$ and their prescribed isometries are hypotheses here.
+    % Source anchor: arXiv:2502.20257, lemma:modif and its proof,
+    % lines 4215--4326. The theorem does not assert that the defect data arise
+    % from locally orthogonal MPS blocks or action tensors; their construction
+    % remains in issues #7349, #7350, and #7569.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_defect_maps, def:mpug_completion_class}
+    For each pair $(a,b)$, regard the restriction of $D_{a,b}$ to
+    $\mathcal K_{a,b}$ as a linear isometry. Extend it to a unitary operator
+    on the whole finite-dimensional matter space. Choosing one such extension
+    for every pair gives a family $R$ satisfying
+    (\ref{eq:mpug_completion_exists}), hence a member of $\mathfrak C(D)$.
+\end{proof}
+
 \begin{theorem}[Transport identity for a completion]
     \label{thm:mpug_completion_transport}
     \lean{TNLean.Algebra.DefectMaps.IsCompletion.mulVec_eq_prescribed,
@@ -2272,6 +2313,47 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     %   eq:scalar_act_ten.
 \end{definition}
 
+\begin{definition}[Restricted scalar gauges]
+    \label{def:mpug_restricted_scalar_gauge}
+    \lean{TNLean.Algebra.ScalarCocycle.IsInverseNormalized,
+        TNLean.Algebra.ScalarCocycle.isInverseNormalized_one,
+        TNLean.Algebra.RestrictedFusionGauge.one,
+        TNLean.Algebra.RestrictedFusionGauge.mul,
+        TNLean.Algebra.RestrictedFusionGauge.inv,
+        TNLean.Algebra.RestrictedScalarGauge.one,
+        TNLean.Algebra.RestrictedScalarGauge.mul,
+        TNLean.Algebra.RestrictedScalarGauge.inv,
+        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.mul,
+        TNLean.Algebra.ScalarCocycle.IsInverseNormalized.inv,
+        TNLean.Algebra.ActionTensorGauge.isNormalized_one,
+        TNLean.Algebra.ActionTensorGauge.IsNormalized.mul,
+        TNLean.Algebra.ActionTensorGauge.IsNormalized.inv,
+        TNLean.Algebra.RestrictedFusionGauge,
+        TNLean.Algebra.RestrictedScalarGauge}
+    \leanok
+    \discussion{7700}
+    \uses{def:mpug_fusion_gauge, def:mpug_l_gauge, def:mpug_l_normalized}
+    A fusion scalar $\beta\colon G^2\to\C^\times$ is
+    \emph{inverse-normalized} when, for every $g\in G$,
+    \begin{align}
+        \beta_{g,e}=\beta_{e,g}=\beta_{g,g^{-1}}
+         & =1.
+        \label{eq:mpug_restricted_fusion_gauge}
+    \end{align}
+    A restricted scalar gauge is a pair $(\beta,\gamma)$ in which $\beta$ is
+    inverse-normalized and, for every $x\in\mathsf X$,
+    \begin{align}
+        \gamma^x_e & =1.
+        \label{eq:mpug_restricted_action_gauge}
+    \end{align}
+    These pairs form a group under pointwise multiplication and inversion.
+    The conditions are the standing restriction imposed at
+    \cite[lines~2050--2054]{FrancoRubio2025MPUGauging} after the earlier
+    fusion and action gauges have been fixed.
+    % Source anchor: arXiv:2502.20257, unlabelled display at lines 2050--2054,
+    % immediately after eq:zetas_in_gauge.
+\end{definition}
+
 \begin{theorem}[Joint scalar gauges preserve L-symbol compatibility]
     \label{thm:mpug_l_gauge_preservation}
     \lean{TNLean.Algebra.LSymbol.IsCompatible.gauge,
@@ -2345,6 +2427,56 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     (\ref{eq:mpug_l_gauge_right}) and
     (\ref{eq:mpug_l_gauge_left}), from which the normalization statements
     follow.
+\end{proof}
+
+\begin{theorem}[Action of the restricted scalar gauge group]
+    \label{thm:mpug_restricted_scalar_gauge_action}
+    \lean{TNLean.Algebra.RestrictedFusionGauge.fusionGauge_one,
+        TNLean.Algebra.RestrictedFusionGauge.isNormalized_fusionGauge,
+        TNLean.Algebra.RestrictedFusionGauge.isCocycle_fusionGauge,
+        TNLean.Algebra.RestrictedFusionGauge.fusionGauge_mul,
+        TNLean.Algebra.RestrictedFusionGauge.fusionGauge_inv,
+        TNLean.Algebra.RestrictedScalarGauge.gauge_one,
+        TNLean.Algebra.RestrictedScalarGauge.isNormalized_gauge,
+        TNLean.Algebra.RestrictedScalarGauge.isCompatible_gauge,
+        TNLean.Algebra.RestrictedScalarGauge.gauge_mul,
+        TNLean.Algebra.RestrictedScalarGauge.gauge_inv}
+    \leanok
+    \discussion{7700}
+    \uses{def:mpug_restricted_scalar_gauge,
+        thm:mpug_gauge_preserves_cocycle,
+        thm:mpug_gauge_preserves_normalization,
+        thm:mpug_l_gauge_composition,
+        thm:mpug_l_gauge_preservation}
+    Let $\kappa=(\beta,\gamma)$ be a restricted scalar gauge. If $\omega$ is
+    a normalized scalar $3$-cocycle and $L$ is a normalized $L$-symbol
+    compatible with $\omega$, then
+    \begin{align}
+        \omega' & =\beta\mathbin{\triangleright}\omega,     \\
+        L'      & =(\beta,\gamma)\mathbin{\triangleright}L.
+        \label{eq:mpug_restricted_gauge_action}
+    \end{align}
+    are again normalized, $\omega'$ is a scalar $3$-cocycle, and $L'$ is
+    compatible with $\omega'$. The identity gauge acts trivially, successive
+    restricted gauges compose by pointwise multiplication, and applying
+    $\kappa^{-1}$ after $\kappa$ recovers $(\omega,L)$.
+    These are scalar statements only.
+    % The theorem does not choose fusion tensors, action tensors, or
+    % tensor-level gauges satisfying the same normalization. Tensor-level
+    % restricted gauge choices remain issue #7325.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_restricted_scalar_gauge,
+        thm:mpug_gauge_preserves_cocycle,
+        thm:mpug_gauge_preserves_normalization,
+        thm:mpug_l_gauge_composition,
+        thm:mpug_l_gauge_preservation}
+    The three specified values of $\beta$ and the identity value of $\gamma$
+    remain equal to $1$ under pointwise products and inverses. Apply the
+    general preservation laws to~(\ref{eq:mpug_restricted_gauge_action}).
+    The group laws and the composition formulas for the two gauge actions give
+    the identity, composition, and inverse assertions.
 \end{proof}
 
 \begin{theorem}[Cocycles and coboundaries for trivial coefficients]
@@ -3868,6 +4000,91 @@ $T_sT_s^*=\sigma(s)\mathbf 1$, nor the proposition identifying the MPU anomaly
 with the nontrivial time-reversal SPT class. Both statements require the tensor
 argument in \cite[lines~5207--5338]{FrancoRubio2025MPUGauging}, beyond the
 scalar calculation above.
+
+\section{The GHZ--blocked-cluster tensor}
+\label{sec:mpug_ghz_blocked_cluster}
+
+\begin{definition}[GHZ--blocked-cluster tensor and its two blocks]
+    \label{def:mpug_ghz_blocked_cluster_tensor}
+    \lean{MPSTensor.ghzTensor_apply,
+        MPSTensor.ghzSectorTensor,
+        MPSTensor.ghzSectorTensor_apply_same,
+        MPSTensor.z4z2GHZClusterTensor,
+        MPSTensor.z4z2GHZClusterBlock,
+        MPSTensor.z4z2GHZClusterBlock_apply,
+        MPSTensor.z4z2GHZClusterDirectSum}
+    \leanok
+    \discussion{7699}
+    \uses{def:ghz_tensor, def:cluster_tensor,
+        def:mps_independent_tensor_product}
+    Let $C=\{C^q\}_{q=0}^3$ be the once-blocked cluster-state tensor. The tensor
+    obtained by taking its independent tensor product with the GHZ tensor has
+    physical dimension $8$ and bond dimension $4$:
+    \begin{align}
+        A & =A^{\mathrm{GHZ}}\otimes C.
+        \label{eq:mpug_ghz_blocked_cluster_tensor}
+    \end{align}
+    For $x\in\{0,1\}$, let $E_x$ be the one-dimensional GHZ sector supported
+    at the physical value $x$. The two bond-dimension-$2$ tensors
+    \begin{align}
+        A_x & =E_x\otimes C
+    \end{align}
+    satisfy, for $p,x\in\{0,1\}$ and $q\in\{0,1,2,3\}$,
+    \begin{align}
+        A_x^{(p,q)} & =\delta_{p,x}C^q.
+        \label{eq:mpug_ghz_blocked_cluster_blocks}
+    \end{align}
+    Their canonical direct sum is denoted $A_0\oplus A_1$. This is the tensor
+    and block formula in
+    \cite[lines~4427--4479]{FrancoRubio2025MPUGauging}.
+    % Source anchor: arXiv:2502.20257, example:z4z2, eq:z4z2MPS and
+    % lines 4427--4479.
+\end{definition}
+
+\begin{theorem}[Injective and locally orthogonal GHZ--cluster blocks]
+    \label{thm:mpug_ghz_blocked_cluster_blocks}
+    \lean{MPSTensor.ghzSectorTensor_isInjective,
+        MPSTensor.isInjective_tensorProduct,
+        MPSTensor.z4z2GHZClusterBlock_isInjective,
+        MPSTensor.z4z2GHZClusterBlocks_isBNTLocallyOrthogonal,
+        MPSTensor.z4z2GHZClusterDirectSum_eq_tensor}
+    \leanok
+    \discussion{7699}
+    \uses{def:mpug_ghz_blocked_cluster_tensor, def:injective,
+        def:is_bnt_locally_orthogonal, thm:cluster_normal}
+    Each tensor $A_x$ is injective. For $x\neq y$ and every
+    $X\in\operatorname{Mat}_2(\C)$, their one-site mixed transfer map satisfies
+    \begin{align}
+        \mathcal E_{x,y}(X)
+         & =\sum_{p=0}^1\sum_{q=0}^3
+        A_x^{(p,q)}X\bigl(A_y^{(p,q)}\bigr)^\dagger
+        =0.
+        \label{eq:mpug_ghz_blocked_cluster_local_orthogonality}
+    \end{align}
+    Thus the two blocks are locally orthogonal, and
+    \begin{align}
+        A_0\oplus A_1 & =A
+        \label{eq:mpug_ghz_blocked_cluster_direct_sum}
+    \end{align}
+    after the canonical identification of the direct-sum and product bond
+    coordinates. The local orthogonality is the observation at
+    \cite[line~4481]{FrancoRubio2025MPUGauging}.
+    % The theorem does not construct the Z4 x Z2 action, its virtual action
+    % tensors, its L-symbols, or its gauging data. The group action and gauging
+    % of this example remain issue #7352.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_ghz_blocked_cluster_tensor, def:injective,
+        def:is_bnt_locally_orthogonal, thm:cluster_normal}
+    The one-dimensional sector $E_x$ is injective, and injectivity is preserved
+    by independent tensor products, so $A_x=E_x\otimes C$ is injective.
+    If $x\neq y$, formula~(\ref{eq:mpug_ghz_blocked_cluster_blocks}) makes
+    every summand in
+    (\ref{eq:mpug_ghz_blocked_cluster_local_orthogonality}) vanish: a physical
+    value $p$ cannot equal both $x$ and $y$. The direct-sum identity follows by
+    comparing the same formula in the two canonical bond coordinate systems.
+\end{proof}
 
 \section{The gauge-invariant subspace of the CZX circuit tuple}
 \label{sec:mpug_czx_gauge_invariant}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4005,7 +4005,8 @@ scalar calculation above.
 
 \begin{definition}[GHZ--blocked-cluster tensor and its two blocks]
     \label{def:mpug_ghz_blocked_cluster_tensor}
-    \lean{MPSTensor.ghzSectorTensor,
+    \lean{MPSTensor.clusterBlocked,
+        MPSTensor.ghzSectorTensor,
         MPSTensor.ghzSectorTensor_apply_same,
         MPSTensor.z4z2GHZClusterTensor,
         MPSTensor.z4z2GHZClusterBlock,


### PR DESCRIPTION
## What changed

Backfill Chapter 29 Blueprint coverage for three source-facing groups of declarations that merged while PR #7691 owned the chapter:

- unconditional nonemptiness and existence for the abstract unitary completion class
- the inverse-normalized fusion gauge and restricted scalar gauge groups, including preservation, composition, and inverse laws
- the GHZ-blocked-cluster tensor, its exact block formula $A_x^{(p,q)}=\delta_{p,x}C^q$, injectivity, local orthogonality, and direct-sum identification

The new nodes preserve the source boundaries explicitly: this PR does not construct source-specific defect data (#7349/#7350/#7569), choose tensor-level restricted gauges (#7325), or construct the $\mathbb Z_4\times\mathbb Z_2$ action and gauging data (#7352).

The existing Chapter 15 cluster-normality and GHZ-definition nodes now link the exact checked accessor and blocked-injectivity declarations used by the Chapter 29 proof. The general independent-product injectivity theorem is linked on its Chapter 28 word-span node and used there as a proof dependency.

## Coordination

This branch is rebased on `origin/main` `842417f478357c504960ea820a64874bf1669667`, after merged PRs #7707, #7711, and #7713. It preserves their Chapter 29 changes. The product-adjoint and cross-product-rigidity nodes come only from #7707 and are not duplicated here.

The final diff is limited to four Blueprint files: 225 additions and two deletions.

## Validation

- exact statements and source scope checked against `Papers/2502.20257/main.tex`, lines 2050-2054, 4215-4326, and 4427-4481
- exact hot-main cache confirmed at `842417f478357c504960ea820a64874bf1669667` with 10,510 jobs, then cloned into this worktree
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- focused `chktex` and byte-identical pinned `latexindent` comparison
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: 7,885 / 7,885 formalized entries, Chapter 29 at 486 / 486
- `lake exe checkdecls blueprint/lean_decls` and `leanblueprint checkdecls`
- `leanblueprint web`: no renderer errors
- two direct LuaLaTeX passes: zero explicit undefined cross-references and zero duplicate labels
- `git diff --check`

Closes #7699.
Closes #7700.
Closes #7702.

