### PR TITLE
feat(MPS/MPU): bundle the canonical-form-II convention

### DIFF
--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -28,7 +28,7 @@ implies its ambient normality. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
-open scoped Matrix BigOperators Matrix.Norms.Operator Kraus
+open scoped Matrix BigOperators Matrix.Norms.Operator ComplexOrder Kraus
 
 namespace MPSTensor
 
@@ -324,6 +324,50 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
+/-- The canonical-form-II convention for an MPU tensor, including the chosen
+ambient right fixed point.
+
+The normalized flattening is represented in literal CPSV canonical form II
+with no unused ambient bond coordinates. The matrix `ρ` records the diagonal,
+positive, trace-one right eigenvector in the same ambient coordinates as the
+tensor.
+
+Source: CPSV17, `Papers/1703.09188/paper_v2.tex`, lines 269--281 (CFII),
+344--356 (normality and the standing CFII convention), and 488--502 (use of
+the positive diagonal ambient matrix). -/
+structure IsMPUCanonicalFormII (U : MPOTensor d D) where
+  /-- The periodic MPO family is unitary (CPSV17, lines 344--356). -/
+  isMPU : U.IsMPU
+  /-- Literal canonical-form-II data for the normalized flattening
+  (CPSV17, lines 269--281 and 344--356). -/
+  cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening
+  /-- The retained CFII blocks fill the ambient bond space
+  (CPSV17, lines 344--356). -/
+  fullSupport_eq : ∑ k, cfii.toCPSVCanonicalFormData.dim k = D
+  /-- The ambient right fixed matrix `ρ` from `Erightleft`
+  (CPSV17, lines 269--281). -/
+  ρ : Matrix (Fin D) (Fin D) ℂ
+  /-- The ambient right fixed matrix is positive definite
+  (CPSV17, lines 269--281 and 488--502). -/
+  ρ_posDef : ρ.PosDef
+  /-- The ambient right fixed matrix is diagonal (CPSV17, lines 269--281). -/
+  ρ_isDiag : ρ.IsDiag
+  /-- The normalization `(Φ|ρ) = 1` is the matrix trace normalization
+  (CPSV17, lines 269--281). -/
+  ρ_trace : Matrix.trace ρ = 1
+  /-- The ambient matrix is the right fixed point of the normalized transfer map
+  (CPSV17, lines 269--281). -/
+  ρ_fixed : Kraus.transferMap U.normalizedFlattening ρ = ρ
+
+namespace IsMPUCanonicalFormII
+
+/-- The CFII blocks of an MPU in canonical form II fill its ambient bond space. -/
+theorem hasFullSupport {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    hU.cfii.toCPSVCanonicalFormData.HasFullSupport :=
+  hU.fullSupport_eq
+
+end IsMPUCanonicalFormII
+
 private theorem sqrt_blockPhysDim (d p : ℕ) :
     Real.sqrt (MPSTensor.blockPhysDim d p) = Real.sqrt d ^ p := by
   suffices Real.sqrt ((d ^ p : ℕ) : ℝ) = Real.sqrt d ^ p by
@@ -398,5 +442,19 @@ theorem IsMPU.isNormalTensor_normalizedFlattening_of_cpsv
       (Kraus.transferMap U.normalizedFlattening) htrace
   exact data.isNormalTensor_of_r_eq_one_of_fullSupport
     hr hfull hrad hprim
+
+namespace IsMPUCanonicalFormII
+
+/-- The normalized flattening of an MPU in canonical form II is a normal tensor.
+
+This is the normality conclusion of CPSV17, Proposition `prop:normal-tensor`,
+`Papers/1703.09188/paper_v2.tex`, lines 344--356. -/
+theorem isNormalTensor_normalizedFlattening
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    MPSTensor.IsNormalTensor U.normalizedFlattening :=
+  hU.isMPU.isNormalTensor_normalizedFlattening_of_cpsv
+    hU.cfii.toCPSVCanonicalFormData hU.hasFullSupport
+
+end IsMPUCanonicalFormII
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4278,6 +4278,45 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $\chi_E(X)=X-1$, and Cayley--Hamilton gives $E=1$.
 \end{proof}
 
+\begin{definition}[Canonical form II for a matrix product unitary]
+    \label{def:mpu_canonical_form_ii}
+    \lean{MPOTensor.IsMPUCanonicalFormII,
+        MPOTensor.IsMPUCanonicalFormII.hasFullSupport}
+    \leanok
+    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support}
+    Let $\mathcal U$ be an MPO tensor, and write
+    $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ and
+    $E=\mathcal E_{\widetilde{\mathcal U}}$. A canonical-form-II presentation
+    of $\mathcal U$ consists of the MPU condition, a literal CPSV
+    canonical-form-II representation
+    \begin{align}
+        \widetilde{\mathcal U}^{a}
+                          & =V^\dagger\!\left(\bigoplus_{k=1}^{r}\mu_kA_k^{a}\right)V,
+        \notag                                                                         \\
+        VV^\dagger        & =\Id,
+        \notag                                                                         \\
+        \sum_{k=1}^{r}D_k & =D.
+        \label{eq:mpu_ambient_cfii}
+    \end{align}
+    The ambient fixed pair has $\Phi=\Id_D$ and positive coefficients
+    $\rho_0,\ldots,\rho_{D-1}$. It satisfies
+    \begin{align}
+        \rho      & =\sum_{n=0}^{D-1}\rho_n\ketbra{n}{n},
+        \notag                                            \\
+        \tr(\rho) & =1,
+        \notag                                            \\
+        E(\rho)   & =\rho.
+        \label{eq:mpu_ambient_cfii_fixed_pair}
+    \end{align}
+    Thus the retained blocks have literal full support, and $\rho$ is a
+    positive diagonal trace-one right fixed point in the ambient bond
+    coordinates. This is the standing convention of
+    \cite[lines~269--281, 344--356, and 488--502]{Cirac2017MPU}.
+    % The ambient diagonal rho is part of the chosen presentation. No construction
+    % from arbitrary existing CFII and full-support witnesses is asserted here;
+    % that inhabitance statement is deferred to native child #7719.
+\end{definition}
+
 \begin{theorem}[Normality of a full-support normalized MPU representative]
     \label{thm:mpu_normalized_full_support_normal}
     \lean{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}
@@ -4320,6 +4359,28 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $D$ and therefore makes $\widetilde U$ irreducible. The displayed radius
     and peripheral-spectrum identities provide its remaining normality
     fields. Consequently $\widetilde U$ is a normal tensor.
+\end{proof}
+
+\begin{theorem}[Normality in canonical form II]
+    \label{thm:mpu_canonical_form_ii_normal}
+    \lean{MPOTensor.IsMPUCanonicalFormII.isNormalTensor_normalizedFlattening}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:nt_cpsv}
+    Let $d,D>0$. If an MPO tensor $\mathcal U$ has a canonical-form-II
+    presentation in the sense of
+    Definition~\ref{def:mpu_canonical_form_ii}, then its normalized flattening
+    $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ is a normal tensor.
+    This is the normality assertion of
+    \cite[Proposition~III.1]{Cirac2017MPU} in the ambient convention
+    (\ref{eq:mpu_ambient_cfii_fixed_pair}).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_full_support_normal}
+    The presentation includes the MPU condition and the full-support identity
+    $\sum_{k=1}^{r}D_k=D$. Theorem~\ref{thm:mpu_normalized_full_support_normal}
+    therefore applies to the chosen canonical-form-II representation of
+    $\widetilde{\mathcal U}$.
 \end{proof}
 
 \section{Standard form, index, and symmetry classification}


### PR DESCRIPTION
## What changed

- add the data-carrying `MPOTensor.IsMPUCanonicalFormII` convention for the normalized MPU tensor, with:
  - the MPU property;
  - literal CPSV canonical-form-II data;
  - full ambient support;
  - the ambient positive-definite diagonal trace-one right fixed matrix `ρ`;
- expose the bundled full-support equality through `IsMPUCanonicalFormII.hasFullSupport`;
- derive `IsMPUCanonicalFormII.isNormalTensor_normalizedFlattening` from the existing full-support CPSV normality theorem;
- add formula-first Chapter 28 entries for the convention and its normality consequence.

This is the first slice of #7657. It bundles the exact standing convention used in CPSV17 lines 269-281, 344-356, and 488-502, but does not claim that arbitrary existing CFII/full-support data construct an ambient diagonal fixed point. Native child #7719 owns the identity-coordinate reduced-representative construction. Existing stabilization, matching-contraction, `HasFullSupport`, admissible-node, and pathwise APIs remain unchanged.

## Validation

- `scripts/lake_build_locked.sh -- lake build` (10,510 jobs)
- targeted `TNLean.MPS.MPU.CanonicalForm` build (9,021 jobs)
- Blueprint synchronization (7,841/7,841; Chapter 28 962/962)
- reverse changed-declaration coverage check
- `leanblueprint checkdecls`
- reader-facing prose check
- ChkTeX
- latexindent idempotence
- Blueprint web generation
- two LuaLaTeX passes with zero undefined cross-references and zero duplicate labels
- protected-node diff check
- `git diff --check`

Advances #7657.
