### PR TITLE
feat(MPS/MPU): construct a reduced representative in the ambient diagonal gauge

### DIFF
--- a/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
+++ b/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
@@ -47,7 +47,7 @@ tensor generating the same positive-length matrix product vectors as its
 normalized flattening.
 
 Source: arXiv:1703.09188, lines 344--356. -/
-private theorem trace_transferMatrix_pow_eq_one_of_sameMPV
+private theorem trace_transferMatrix_pow_eq_one_of_sameMPV₂Pos
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU)
     {E : ℕ} [NeZero E] {A : MPSTensor (d * d) E}
     (hSame : MPSTensor.SameMPV₂Pos U.normalizedFlattening A)
@@ -144,7 +144,7 @@ theorem IsMPU.exists_reduced_normalizedFlattening_cfii
   let _ : NeZero Dred := NeZero.of_pos hDred
   have hTrace : ∀ N : ℕ, 1 < N →
       Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) = 1 :=
-    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSame
+    trace_transferMatrix_pow_eq_one_of_sameMPV₂Pos hU hSame
   have hBlocksNormal : ∀ k : Fin r, MPSTensor.IsNormalTensor (blocks k) := by
     intro k
     let _ : NeZero (dim k) := NeZero.of_pos (hDim k)
@@ -200,7 +200,7 @@ theorem IsMPU.exists_reduced_normalizedFlattening_cfii
     hSame.trans hGaugePos
   have hTraceB : ∀ N : ℕ, 1 < N →
       Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) = 1 :=
-    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSameB
+    trace_transferMatrix_pow_eq_one_of_sameMPV₂Pos hU hSameB
   have hFullB : dataB.toCPSVCanonicalFormData.HasFullSupport := by
     change (∑ k : Fin dataB.r, dataB.dim k) = Dred
     exact hTotalDim.trans hFull
@@ -317,7 +317,7 @@ theorem IsMPU.exists_reduced_normalizedFlattening_cfii
     hSameB.trans hSameBC
   have hTraceC : ∀ N : ℕ, 1 < N →
       Matrix.trace (transferMatrix (Kraus.transferMap C) ^ N) = 1 :=
-    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSameC
+    trace_transferMatrix_pow_eq_one_of_sameMPV₂Pos hU hSameC
   obtain ⟨hRadiusC, hPrimitiveC⟩ :=
     spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace
       (Kraus.transferMap C) hTraceC

--- a/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
+++ b/TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean
@@ -18,7 +18,9 @@ applies the canonical-form-II gauge.
 
 The reduction follows arXiv:1606.00608, lines 195--255 and 1058--1077. Its use
 for matrix product unitaries follows arXiv:1703.09188, lines 257--294, 319--326,
-and 344--356.
+and 344--356. The final gauge is the inclusion of the unique retained block, so
+the representative is written in ambient coordinates whose right fixed matrix is
+the positive diagonal trace-one matrix of equation `Erightleft`, lines 269--281.
 
 **Scope boundary (representative reduction):** The result constructs a new
 tensor of no larger bond dimension with the same positive-length periodic
@@ -40,26 +42,82 @@ private theorem mpvOverlap_two_eq_zero_of_bondDim_eq_zero
   subst E
   simp [MPSTensor.mpvOverlap, MPSTensor.mpv, MPSTensor.coeff, Matrix.trace]
 
+/-- The unit shifted transfer traces of a matrix product unitary pass to every
+tensor generating the same positive-length matrix product vectors as its
+normalized flattening.
+
+Source: arXiv:1703.09188, lines 344--356. -/
+private theorem trace_transferMatrix_pow_eq_one_of_sameMPV
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU)
+    {E : ℕ} [NeZero E] {A : MPSTensor (d * d) E}
+    (hSame : MPSTensor.SameMPV₂Pos U.normalizedFlattening A)
+    (N : ℕ) (hN : 1 < N) :
+    Matrix.trace (transferMatrix (Kraus.transferMap A) ^ N) = 1 := by
+  calc
+    Matrix.trace (transferMatrix (Kraus.transferMap A) ^ N) =
+        MPSTensor.mpvOverlap A A N :=
+      MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap A N
+    _ = MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N :=
+      (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
+        (fun {N} hN => hSame N hN) (fun {N} hN => hSame N hN)
+        (Nat.zero_lt_of_lt hN)).symm
+    _ = Matrix.trace
+        (transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ N) :=
+      (MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap
+        U.normalizedFlattening N).symm
+    _ = 1 := hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+
+/-- Assemble a canonical-form-II presentation of a matrix product unitary from
+canonical data for a tensor equal to its normalized flattening.
+
+Source: arXiv:1703.09188, lines 269--281 and 344--356. -/
+private def mpuCanonicalFormIIOfNormalizedFlatteningEq
+    {E : ℕ} {V : MPOTensor d E} {A : MPSTensor (d * d) E}
+    (hA : V.normalizedFlattening = A) (hV : V.IsMPU)
+    (cfii : MPSTensor.CPSVCanonicalFormIIData A)
+    (hfull : cfii.toCPSVCanonicalFormData.HasFullSupport)
+    (ρ : Matrix (Fin E) (Fin E) ℂ) (hρpd : ρ.PosDef) (hρdiag : ρ.IsDiag)
+    (hρtrace : Matrix.trace ρ = 1) (hρfix : Kraus.transferMap A ρ = ρ) :
+    IsMPUCanonicalFormII V := by
+  subst hA
+  exact
+    { isMPU := hV
+      cfii := cfii
+      fullSupport_eq := hfull
+      ρ := ρ
+      ρ_posDef := hρpd
+      ρ_isDiag := hρdiag
+      ρ_trace := hρtrace
+      ρ_fixed := hρfix }
+
 /-- Every matrix product unitary has a positive-dimensional, normal,
-full-support canonical-form-II representative of its normalized flattening.
-The representative has no larger bond dimension and generates the same matrix
-product vectors at every positive length.
+full-support canonical-form-II representative of its normalized flattening,
+written in ambient bond coordinates whose right fixed matrix is positive,
+diagonal, and of trace one. The representative has no larger bond dimension
+and generates the same matrix product vectors at every positive length.
 
 The canonical-form convention in arXiv:1703.09188, lines 257--294 and 319--326,
 replaces a tensor by one generating the same matrix product vectors. For a
 matrix product unitary, lines 344--356 then use the shifted transfer traces to
-obtain a normal representative in canonical form II. The dimension-bounded
-irreducible reduction and canonical-form-II gauge are those of
-arXiv:1606.00608, lines 195--255 and 1058--1077. This theorem combines those
-steps; it is not a separately stated theorem of either paper. -/
+obtain a normal representative in canonical form II. Lines 269--294 record the
+further gauge transformation placing the right fixed matrix `ρ` of equation
+`Erightleft` in the diagonal positive trace-one form; here that gauge is the
+inclusion of the unique retained block, which carries its own diagonal fixed
+matrix into the ambient coordinates. The dimension-bounded irreducible
+reduction and canonical-form-II gauge are those of arXiv:1606.00608, lines
+195--255 and 1058--1077. This theorem combines those steps; it is not a
+separately stated theorem of either paper. -/
 theorem IsMPU.exists_reduced_normalizedFlattening_cfii
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU) :
     ∃ (Dred : ℕ) (_hDred : 0 < Dred) (Ared : MPSTensor (d * d) Dred)
-      (cfii : MPSTensor.CPSVCanonicalFormIIData Ared),
+      (cfii : MPSTensor.CPSVCanonicalFormIIData Ared)
+      (ρ : Matrix (Fin Dred) (Fin Dred) ℂ),
       Dred ≤ D ∧
       MPSTensor.SameMPV₂Pos U.normalizedFlattening Ared ∧
       MPSTensor.IsNormalTensor Ared ∧
-      cfii.toCPSVCanonicalFormData.HasFullSupport := by
+      cfii.toCPSVCanonicalFormData.HasFullSupport ∧
+      ρ.PosDef ∧ ρ.IsDiag ∧ Matrix.trace ρ = 1 ∧
+      Kraus.transferMap Ared ρ = ρ := by
   classical
   obtain ⟨r, dim, blocks, hIrr, hNonzero, hDim, hSame, hDimLe⟩ :=
     MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks U.normalizedFlattening
@@ -85,21 +143,8 @@ theorem IsMPU.exists_reduced_normalizedFlattening_cfii
     exact one_ne_zero hzero
   let _ : NeZero Dred := NeZero.of_pos hDred
   have hTrace : ∀ N : ℕ, 1 < N →
-      Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) = 1 := by
-    intro N hN
-    calc
-      Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) =
-          MPSTensor.mpvOverlap Ared Ared N :=
-        MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap Ared N
-      _ = MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N :=
-        (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
-          (fun {N} hN => hSame N hN) (fun {N} hN => hSame N hN)
-          (Nat.zero_lt_of_lt hN)).symm
-      _ = Matrix.trace
-          (transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ N) :=
-        (MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap
-          U.normalizedFlattening N).symm
-      _ = 1 := hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+      Matrix.trace (transferMatrix (Kraus.transferMap Ared) ^ N) = 1 :=
+    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSame
   have hBlocksNormal : ∀ k : Fin r, MPSTensor.IsNormalTensor (blocks k) := by
     intro k
     let _ : NeZero (dim k) := NeZero.of_pos (hDim k)
@@ -154,34 +199,133 @@ theorem IsMPU.exists_reduced_normalizedFlattening_cfii
   have hSameB : MPSTensor.SameMPV₂Pos U.normalizedFlattening B :=
     hSame.trans hGaugePos
   have hTraceB : ∀ N : ℕ, 1 < N →
-      Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) = 1 := by
-    intro N hN
-    calc
-      Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) =
-          MPSTensor.mpvOverlap B B N :=
-        MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap B N
-      _ = MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N :=
-        (MPSTensor.mpvOverlap_eq_of_pos_mpv_eq
-          (fun {N} hN => hSameB N hN) (fun {N} hN => hSameB N hN)
-          (Nat.zero_lt_of_lt hN)).symm
-      _ = Matrix.trace
-          (transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ N) :=
-        (MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap
-          U.normalizedFlattening N).symm
-      _ = 1 := hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+      Matrix.trace (transferMatrix (Kraus.transferMap B) ^ N) = 1 :=
+    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSameB
   have hFullB : dataB.toCPSVCanonicalFormData.HasFullSupport := by
     change (∑ k : Fin dataB.r, dataB.dim k) = Dred
     exact hTotalDim.trans hFull
   have hBlockCountB : dataB.r = 1 :=
     dataB.toCPSVCanonicalFormData.r_eq_one_of_shifted_transfer_trace hTraceB
-  obtain ⟨hRadiusB, hPrimitiveB⟩ :=
+  -- Change gauge to the coordinates of the unique retained block. In those
+  -- ambient coordinates the diagonal positive trace-one block fixed matrix is
+  -- the ambient right fixed matrix of arXiv:1703.09188, equation `Erightleft`,
+  -- lines 269--294.
+  let baseB := dataB.toCPSVCanonicalFormData
+  let k : Fin dataB.r := ⟨0, by omega⟩
+  have hdimk : dataB.dim k = Dred :=
+    baseB.dim_eq_of_r_eq_one_of_fullSupport hBlockCountB hFullB k
+  obtain ⟨Λ₀, hΛ₀pd, hΛ₀diag, hΛ₀fix⟩ := dataB.blocks_fixed_point k
+  let _ : Nonempty (Fin (dataB.dim k)) := Fin.pos_iff_nonempty.mp (dataB.dim_pos k)
+  let Λ : Matrix (Fin (dataB.dim k)) (Fin (dataB.dim k)) ℂ :=
+    (Matrix.trace Λ₀)⁻¹ • Λ₀
+  have hΛtracePos : 0 < Matrix.trace Λ₀ := hΛ₀pd.trace_pos
+  have hΛpd : Λ.PosDef := hΛ₀pd.smul (inv_pos.mpr hΛtracePos)
+  have hΛdiag : Λ.IsDiag := hΛ₀diag.smul _
+  have hΛtrace : Matrix.trace Λ = 1 := by
+    simp [Λ, Matrix.trace_smul, ne_of_gt hΛtracePos]
+  have hΛfix : Kraus.transferMap (dataB.blocks k) Λ = Λ := by
+    simp only [Λ, map_smul, hΛ₀fix]
+  have hweight : dataB.weights k * starRingEnd ℂ (dataB.weights k) = 1 := by
+    simpa [baseB, MPSTensor.CPSVCanonicalFormData.transferEigenvalue] using
+      baseB.transferEigenvalue_eq_one hTraceB k
+  have hweightedFix :
+      Kraus.transferMap (fun i => dataB.weights k • dataB.blocks k i) Λ = Λ := by
+    rw [MPSTensor.transferMap_smul, hΛfix, hweight, one_smul]
+  let V := baseB.ambientBlockInclusion k
+  have hVstarV : Vᴴ * V = 1 :=
+    baseB.ambientBlockInclusion_conjTranspose_mul_self k
+  have hVVstar : V * Vᴴ = 1 :=
+    baseB.ambientBlockInclusion_mul_conjTranspose_eq_one hBlockCountB hFullB k
+  have hVfix : Kraus.transferMap B (V * Λ * Vᴴ) = V * Λ * Vᴴ := by
+    rw [MPSTensor.transferMap_conj_of_intertwine B
+      (fun i => dataB.weights k • dataB.blocks k i) V
+      (baseB.mul_ambientBlockInclusion k) Λ, hweightedFix]
+  let e : Fin Dred ≃ Fin (dataB.dim k) := finCongr hdimk.symm
+  let W : Matrix (Fin Dred) (Fin Dred) ℂ := V.submatrix (Equiv.refl (Fin Dred)) e
+  have hWdef : W = V.submatrix (Equiv.refl (Fin Dred)) e := rfl
+  have hWconj : Wᴴ = Vᴴ.submatrix e (Equiv.refl (Fin Dred)) := by
+    rw [hWdef, Matrix.conjTranspose_submatrix]
+  have hWWstar : W * Wᴴ = 1 := by
+    rw [hWconj, hWdef, Matrix.submatrix_mul_equiv V Vᴴ (Equiv.refl (Fin Dred)) e
+      (Equiv.refl (Fin Dred)), hVVstar]
+    simp
+  have hWstarW : Wᴴ * W = 1 := by
+    rw [hWconj, hWdef,
+      Matrix.submatrix_mul_equiv Vᴴ V e (Equiv.refl (Fin Dred)) e,
+      hVstarV, Matrix.submatrix_one_equiv]
+  let C : MPSTensor (d * d) Dred := fun i => Wᴴ * B i * W
+  have hCdef : ∀ i, C i = Wᴴ * B i * W := fun _ => rfl
+  let ρ : Matrix (Fin Dred) (Fin Dred) ℂ := Λ.submatrix e e
+  have hρdef : ρ = Λ.submatrix e e := rfl
+  have hρpd : ρ.PosDef := hΛpd.submatrix e.injective
+  have hρdiag : ρ.IsDiag := hΛdiag.submatrix e.injective
+  have hρtrace : Matrix.trace ρ = 1 := by
+    have hsum : Matrix.trace ρ = Matrix.trace Λ := by
+      rw [hρdef]
+      simp only [Matrix.trace, Matrix.diag_apply, Matrix.submatrix_apply]
+      exact Equiv.sum_comp e fun j => Λ j j
+    rw [hsum, hΛtrace]
+  have hρconj : W * ρ * Wᴴ = V * Λ * Vᴴ := by
+    rw [hWconj, hWdef, hρdef,
+      Matrix.submatrix_mul_equiv V Λ (Equiv.refl (Fin Dred)) e e,
+      Matrix.submatrix_mul_equiv (V * Λ) Vᴴ (Equiv.refl (Fin Dred)) e
+        (Equiv.refl (Fin Dred))]
+    simp
+  have hcompress : ∀ X : Matrix (Fin Dred) (Fin Dred) ℂ,
+      Wᴴ * (W * X * Wᴴ) * W = X := by
+    intro X
+    calc
+      Wᴴ * (W * X * Wᴴ) * W = (Wᴴ * W) * X * (Wᴴ * W) := by
+        simp only [Matrix.mul_assoc]
+      _ = X := by rw [hWstarW, Matrix.one_mul, Matrix.mul_one]
+  have hintertwine : ∀ i, B i * W = W * C i := by
+    intro i
+    calc
+      B i * W = (W * Wᴴ) * B i * W := by rw [hWWstar, Matrix.one_mul]
+      _ = W * C i := by rw [hCdef]; simp only [Matrix.mul_assoc]
+  have hCfix : Kraus.transferMap C ρ = ρ := by
+    have hconj := MPSTensor.transferMap_conj_of_intertwine B C W hintertwine ρ
+    calc
+      Kraus.transferMap C ρ
+          = Wᴴ * (W * Kraus.transferMap C ρ * Wᴴ) * W := (hcompress _).symm
+      _ = Wᴴ * (W * ρ * Wᴴ) * W := by rw [← hconj, hρconj, hVfix, ← hρconj]
+      _ = ρ := hcompress ρ
+  have hrecC : ∀ i, C i = (dataB.ambient_coisometry * W)ᴴ *
+      MPSTensor.toTensorFromBlocks dataB.weights dataB.blocks i *
+        (dataB.ambient_coisometry * W) := by
+    intro i
+    rw [Matrix.conjTranspose_mul, hCdef i, dataB.reconstruct i]
+    simp only [Matrix.mul_assoc]
+  let dataC : MPSTensor.CPSVCanonicalFormIIData C :=
+    { dataB with
+      ambient_coisometry := dataB.ambient_coisometry * W
+      coisometric := by
+        rw [Matrix.conjTranspose_mul, Matrix.mul_assoc,
+          ← Matrix.mul_assoc W Wᴴ, hWWstar, Matrix.one_mul, dataB.coisometric]
+      reconstruct := hrecC }
+  have hFullC : dataC.toCPSVCanonicalFormData.HasFullSupport := hFullB
+  have hSameBC : MPSTensor.SameMPV₂Pos B C :=
+    MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction B C Wᴴ
+      (by rw [Matrix.conjTranspose_conjTranspose, hWstarW])
+      (fun i => by
+        rw [Matrix.conjTranspose_conjTranspose]
+        calc
+          B i = (W * Wᴴ) * B i * (W * Wᴴ) := by
+            rw [hWWstar, Matrix.one_mul, Matrix.mul_one]
+          _ = W * C i * Wᴴ := by rw [hCdef]; simp only [Matrix.mul_assoc])
+  have hSameC : MPSTensor.SameMPV₂Pos U.normalizedFlattening C :=
+    hSameB.trans hSameBC
+  have hTraceC : ∀ N : ℕ, 1 < N →
+      Matrix.trace (transferMatrix (Kraus.transferMap C) ^ N) = 1 :=
+    trace_transferMatrix_pow_eq_one_of_sameMPV hU hSameC
+  obtain ⟨hRadiusC, hPrimitiveC⟩ :=
     spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace
-      (Kraus.transferMap B) hTraceB
-  have hBNormal : MPSTensor.IsNormalTensor B :=
-    dataB.toCPSVCanonicalFormData.isNormalTensor_of_r_eq_one_of_fullSupport
-      hBlockCountB hFullB hRadiusB hPrimitiveB
-  exact ⟨Dred, hDred, B, dataB, by simpa [Dred] using hDimLe,
-    hSameB, hBNormal, hFullB⟩
+      (Kraus.transferMap C) hTraceC
+  have hCNormal : MPSTensor.IsNormalTensor C :=
+    dataC.toCPSVCanonicalFormData.isNormalTensor_of_r_eq_one_of_fullSupport
+      hBlockCountB hFullC hRadiusC hPrimitiveC
+  exact ⟨Dred, hDred, C, dataC, ρ, by simpa [Dred] using hDimLe,
+    hSameC, hCNormal, hFullC, hρpd, hρdiag, hρtrace, hCfix⟩
 
 private noncomputable def ofNormalizedFlattening
     (A : MPSTensor (d * d) D) : MPOTensor d D :=
@@ -226,19 +370,20 @@ length.
 
 This is the representative-level form of the replacement used in
 arXiv:1703.09188, lines 257--294 and 319--326, with normality supplied by the
-shifted-transfer argument at lines 344--356. The dimension reduction and CFII
-gauge follow arXiv:1606.00608, lines 195--255 and 1058--1077. This theorem does
-not identify a virtual gauge between the original and reduced bond spaces,
-whose dimensions may differ. -/
+shifted-transfer argument at lines 344--356. The canonical-form-II presentation
+carries the positive diagonal trace-one ambient right fixed matrix of equation
+`Erightleft`, lines 269--281. The dimension reduction and CFII gauge follow
+arXiv:1606.00608, lines 195--255 and 1058--1077. This theorem does not identify
+a virtual gauge between the original and reduced bond spaces, whose dimensions
+may differ. -/
 theorem IsMPU.exists_reduced_cfii_representative
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : U.IsMPU) :
     ∃ (Dred : ℕ) (_hDred : 0 < Dred) (Ured : MPOTensor d Dred)
-      (cfii : MPSTensor.CPSVCanonicalFormIIData Ured.normalizedFlattening),
+      (_hcfii : IsMPUCanonicalFormII Ured),
       Dred ≤ D ∧
-      (∀ N : ℕ, 0 < N → mpo Ured N = mpo U N) ∧
-      Ured.IsMPU ∧
-      cfii.toCPSVCanonicalFormData.HasFullSupport := by
-  obtain ⟨Dred, hDred, Ared, cfii, hDimLe, hSame, _hNormal, hFull⟩ :=
+      (∀ N : ℕ, 0 < N → mpo Ured N = mpo U N) := by
+  obtain ⟨Dred, hDred, Ared, cfii, ρ, hDimLe, hSame, _hNormal, hFull,
+    hρpd, hρdiag, hρtrace, hρfix⟩ :=
     hU.exists_reduced_normalizedFlattening_cfii
   let Ured : MPOTensor d Dred := ofNormalizedFlattening Ared
   have hFlat : Ured.normalizedFlattening = Ared :=
@@ -258,8 +403,9 @@ theorem IsMPU.exists_reduced_cfii_representative
     intro N hN
     rw [hMpo N (Nat.zero_lt_of_lt hN)]
     exact hU N hN
-  refine ⟨Dred, hDred, Ured, ?_⟩
-  rw [hFlat]
-  exact ⟨cfii, hDimLe, hMpo, hUred, hFull⟩
+  exact ⟨Dred, hDred, Ured,
+    mpuCanonicalFormIIOfNormalizedFlatteningEq hFlat hUred cfii hFull ρ
+      hρpd hρdiag hρtrace hρfix,
+    hDimLe, hMpo⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3228,7 +3228,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_reduced_normalized_flattening_cfii, lem:mpv_smul, lem:mpdo_three_first_site_contraction_coefficients}
+    \uses{thm:mpu_reduced_normalized_flattening_cfii, lem:mpv_smul, lem:mpdo_three_first_site_contraction_coefficients, def:mpu_canonical_form_ii}
     Apply Theorem~\ref{thm:mpu_reduced_normalized_flattening_cfii} and write
     its representative as $A_{\mathrm{red}}$. Define
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3092,8 +3092,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     and moreover $\rho$ is positive definite and diagonal with
     \begin{align}
-        \tr(\rho)                        & =1,
-                                         & \mathcal E_{A_{\mathrm{red}}}(\rho) & =\rho.
+        \tr(\rho) & =1,
+                  & \mathcal E_{A_{\mathrm{red}}}(\rho) & =\rho.
         \label{eq:mpu_reduced_ambient_rho}
     \end{align}
     This organizes the dimension-bounded canonical replacement used in

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3093,7 +3093,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     and moreover $\rho$ is positive definite and diagonal with
     \begin{align}
         \tr(\rho) & =1,
-                  & \mathcal E_{A_{\mathrm{red}}}(\rho) & =\rho.
+                  & \E_{A_{\mathrm{red}}}(\rho) & =\rho.
         \label{eq:mpu_reduced_ambient_rho}
     \end{align}
     This organizes the dimension-bounded canonical replacement used in
@@ -3108,7 +3108,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:cpsv_canonical_form, thm:nonzero_irreducible_block_decomposition, lem:overlap_eq_of_pos_mpv, thm:mpu_transfer_matrix_overlap, thm:mpu_normalized_transfer_trace, thm:mpu_transfer_matrix_eigenvalues, thm:mpu_dependent_block_inclusion_identities, lem:transfer_map_corner_intertwine, lem:irreducible_transfer_perron_pair, lem:irreducible_block_spectral_normalization, thm:mpu_shifted_trace_power_spectrum, thm:mpu_shifted_transfer_trace_single_block, thm:mpu_shifted_transfer_trace_primitive, thm:mpu_unique_full_support_normal, thm:cpsv_cf_to_cfii_gauge, thm:gauge_invariance}
+    \uses{def:cpsv_canonical_form, thm:nonzero_irreducible_block_decomposition, lem:overlap_eq_of_pos_mpv, thm:mpu_transfer_matrix_overlap, thm:mpu_normalized_transfer_trace, thm:mpu_transfer_matrix_eigenvalues, thm:mpu_dependent_block_inclusion_identities, lem:transfer_map_corner_intertwine, lem:irreducible_transfer_perron_pair, lem:irreducible_block_spectral_normalization, thm:mpu_shifted_trace_power_spectrum, thm:mpu_shifted_transfer_trace_single_block, thm:mpu_shifted_transfer_trace_primitive, thm:mpu_unique_full_support_normal, thm:cpsv_cf_to_cfii_gauge, thm:gauge_invariance, thm:mpu_transfer_eigenvalue_one, thm:mpu_ambient_block_isometry_intertwining, thm:mpu_unique_full_support_geometry, thm:coisometry_reconstruction_same_mpv_pos}
     Remove the zero irreducible blocks of $\widetilde U$ and write
     \begin{align}
         A_0^i & =\bigoplus_{k=1}^{r}B_k^i,
@@ -3143,27 +3143,65 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
     The direct sum now has literal canonical-form data with full support.
     Apply the nonsingular blockwise canonical-form-II gauge. It preserves the
-    block dimensions and all periodic vectors, so the resulting tensor
-    $A_{\mathrm{red}}$ still satisfies
+    block dimensions and all periodic vectors, so the resulting tensor $A_1$
+    still satisfies
     \begin{align}
         \sum_{k=1}^{r}D_k & =D_{\mathrm{red}},
-                          & \tr(E_{A_{\mathrm{red}}}^{\,N}) & =1,
+                          & \tr(E_{A_1}^{\,N}) & =1,
     \end{align}
     for every integer $N>1$.
-    The shifted traces force $r=1$, spectral radius one, and primitivity.
-    Full support identifies the unique block with the ambient bond space, so
-    the inclusion $J_1$ of that block is unitary.
+    The shifted traces force $r=1$ and $\left|\mu_1\right|=1$, and full
+    support identifies the unique retained block with the ambient bond space,
+    so its inclusion $J_1$ is a unitary of $\mathbb C^{D_{\mathrm{red}}}$:
+    \begin{align}
+        J_1^\dagger J_1 & =\Id,
+                        & J_1J_1^\dagger & =\Id,
+                        & A_1^iJ_1       & =J_1\mu_1B_1^i.
+    \end{align}
 
     The retained block carries a diagonal positive definite fixed matrix
-    $\Lambda$ of its own transfer map. Rescale it so that $\tr(\Lambda)=1$.
-    Because the shifted traces force $|\mu_1|=1$, the matrix $\Lambda$ is also
-    fixed by the transfer map of the weighted block. Conjugating the ambient
-    tensor by $J_1$ therefore produces a tensor with the same positive-length
-    matrix product vectors, the same canonical-form-II blocks, and the ambient
-    right fixed matrix $\rho=\Lambda$ read in the ambient coordinates. It is
-    positive definite, diagonal, and of trace one, which is
-    (\ref{eq:mpu_reduced_ambient_rho}). Taking $A_{\mathrm{red}}$ to be this
-    conjugated tensor, full support and $r=1$ again make it normal.
+    $\Lambda_0$ of its own transfer map; rescale it to
+    $\Lambda=\tr(\Lambda_0)^{-1}\Lambda_0$, so that
+    \begin{align}
+        \Lambda                & >0,
+                               & \tr(\Lambda)                           & =1, \\
+        \E_{\mu_1B_1}(\Lambda) & =\left|\mu_1\right|^2\E_{B_1}(\Lambda)
+        =\Lambda,
+    \end{align}
+    the last equality because $\left|\mu_1\right|=1$. Now conjugate the
+    ambient tensor by $J_1$ and read the block matrix in the resulting
+    coordinates:
+    \begin{align}
+        A_{\mathrm{red}}^i & =J_1^\dagger A_1^iJ_1=\mu_1B_1^i,
+                           & \rho                              & =\Lambda.
+    \end{align}
+    Since $J_1$ is unitary this is a change of ambient coordinates:
+    $A_1^i=J_1A_{\mathrm{red}}^iJ_1^\dagger$, so $A_1$ and $A_{\mathrm{red}}$
+    have the same matrix product vectors at every positive length, and
+    replacing the ambient coisometry $\Phi$ of the canonical-form-II data by
+    $\Phi J_1$ leaves a coisometry reconstructing $A_{\mathrm{red}}$ from the
+    same blocks and weights. The fixed matrix transports along the same
+    conjugation:
+    \begin{align}
+        \E_{A_1}(J_1\rho J_1^\dagger)
+         & =J_1\E_{\mu_1B_1}(\Lambda)J_1^\dagger=J_1\rho J_1^\dagger, \\
+        \E_{A_{\mathrm{red}}}(\rho)
+         & =J_1^\dagger\E_{A_1}(J_1\rho J_1^\dagger)J_1=\rho,
+    \end{align}
+    and $\rho$ is positive definite, diagonal, and of trace one because
+    $\Lambda$ is. This is (\ref{eq:mpu_reduced_ambient_rho}).
+
+    It remains to see that the conjugated tensor is normal. Transport the
+    trace identity to it: for every integer $N>1$,
+    \begin{align}
+        \tr(E_{A_{\mathrm{red}}}^{\,N})
+         & =\sum_\sigma\left|V^{(N)}(A_{\mathrm{red}})_\sigma\right|^2
+        =\sum_\sigma\left|V^{(N)}(\widetilde U)_\sigma\right|^2=1.
+    \end{align}
+    These shifted traces force the spectral radius of $E_{A_{\mathrm{red}}}$
+    to be one and $E_{A_{\mathrm{red}}}$ to be primitive. Together with $r=1$
+    and full support, both preserved by the conjugation, they make
+    $A_{\mathrm{red}}$ normal.
 \end{proof}
 
 \begin{theorem}[Reduced canonical representative of an MPU]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3177,11 +3177,18 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     Since $J_1$ is unitary this is a change of ambient coordinates:
     $A_1^i=J_1A_{\mathrm{red}}^iJ_1^\dagger$, so $A_1$ and $A_{\mathrm{red}}$
-    have the same matrix product vectors at every positive length, and
-    replacing the ambient coisometry $\Phi$ of the canonical-form-II data by
-    $\Phi J_1$ leaves a coisometry reconstructing $A_{\mathrm{red}}$ from the
-    same blocks and weights. The fixed matrix transports along the same
-    conjugation:
+    have the same matrix product vectors at every positive length. The
+    canonical-form-II data travel along the same factor: if $\Phi$ is the
+    ambient coisometry reconstructing $A_1$ from the blocks $B_k$ and the
+    weights $\mu_k$, then $\Phi J_1$ is again a coisometry and reconstructs
+    $A_{\mathrm{red}}$ from those same blocks and weights,
+    \begin{align}
+        (\Phi J_1)(\Phi J_1)^\dagger
+         & =\Phi J_1J_1^\dagger\Phi^\dagger=\Phi\Phi^\dagger=\Id, \\
+        (\Phi J_1)^\dagger\left(\bigoplus_{k=1}^{r}\mu_kB_k^i\right)(\Phi J_1)
+         & =J_1^\dagger A_1^iJ_1=A_{\mathrm{red}}^i.
+    \end{align}
+    The fixed matrix transports along the same conjugation:
     \begin{align}
         \E_{A_1}(J_1\rho J_1^\dagger)
          & =J_1\E_{\mu_1B_1}(\Lambda)J_1^\dagger=J_1\rho J_1^\dagger, \\

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3080,21 +3080,30 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Let $d,D>0$, let $U$ be an MPU tensor of physical dimension $d$ and
     bond dimension $D$, and let $\widetilde U=d^{-1/2}U$ be its normalized
     doubled-index tensor. There are an integer $D_{\mathrm{red}}>0$, a normal
-    tensor $A_{\mathrm{red}}$ of bond dimension $D_{\mathrm{red}}$, and
-    canonical-form-II data for $A_{\mathrm{red}}$ such that, for every
+    tensor $A_{\mathrm{red}}$ of bond dimension $D_{\mathrm{red}}$,
+    canonical-form-II data for $A_{\mathrm{red}}$, and a matrix $\rho$ on the
+    ambient bond space of $A_{\mathrm{red}}$ such that, for every
     integer $N>0$ and every word $\sigma$ of length $N$,
     \begin{align}
         D_{\mathrm{red}}  & \leq D,                        \\
         V^{(N)}(A_{\mathrm{red}})_\sigma
                           & =V^{(N)}(\widetilde U)_\sigma, \\
-        \sum_{k=1}^{r}D_k & =D_{\mathrm{red}}.
+        \sum_{k=1}^{r}D_k & =D_{\mathrm{red}},
+    \end{align}
+    and moreover $\rho$ is positive definite and diagonal with
+    \begin{align}
+        \tr(\rho)                        & =1,
+                                         & \mathcal E_{A_{\mathrm{red}}}(\rho) & =\rho.
+        \label{eq:mpu_reduced_ambient_rho}
     \end{align}
     This organizes the dimension-bounded canonical replacement used in
     \cite[lines~257--294 and 319--326]{Cirac2017MPU}. Its irreducible
     reduction and canonical-form-II gauge are those of
     \cite[lines~195--255 and 1058--1077]{Cirac2016MPDO_arXiv}. The shifted
     transfer argument is the one used in
-    \cite[lines~344--356]{Cirac2017MPU}.
+    \cite[lines~344--356]{Cirac2017MPU}, and the diagonal positive trace-one
+    ambient right fixed matrix is the one of
+    \cite[lines~269--281]{Cirac2017MPU}.
     % Source role: replacement infrastructure, not a separately named source theorem.
 \end{theorem}
 
@@ -3143,24 +3152,38 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     for every integer $N>1$.
     The shifted traces force $r=1$, spectral radius one, and primitivity.
     Full support identifies the unique block with the ambient bond space, so
-    $A_{\mathrm{red}}$ is normal.
+    the inclusion $J_1$ of that block is unitary.
+
+    The retained block carries a diagonal positive definite fixed matrix
+    $\Lambda$ of its own transfer map. Rescale it so that $\tr(\Lambda)=1$.
+    Because the shifted traces force $|\mu_1|=1$, the matrix $\Lambda$ is also
+    fixed by the transfer map of the weighted block. Conjugating the ambient
+    tensor by $J_1$ therefore produces a tensor with the same positive-length
+    matrix product vectors, the same canonical-form-II blocks, and the ambient
+    right fixed matrix $\rho=\Lambda$ read in the ambient coordinates. It is
+    positive definite, diagonal, and of trace one, which is
+    (\ref{eq:mpu_reduced_ambient_rho}). Taking $A_{\mathrm{red}}$ to be this
+    conjugated tensor, full support and $r=1$ again make it normal.
 \end{proof}
 
 \begin{theorem}[Reduced canonical representative of an MPU]
     \label{thm:mpu_reduced_cfii_representative}
     \lean{MPOTensor.IsMPU.exists_reduced_cfii_representative}
     \leanok
-    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support}
+    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support, def:mpu_canonical_form_ii}
     Let $d,D>0$ and let $U$ be an MPU tensor. There are
-    $D_{\mathrm{red}}>0$ and an MPU tensor $U_{\mathrm{red}}$ of bond
-    dimension $D_{\mathrm{red}}$ such that, for every integer $N>0$,
+    $D_{\mathrm{red}}>0$ and an MPO tensor $U_{\mathrm{red}}$ of bond
+    dimension $D_{\mathrm{red}}$ carrying a canonical-form-II presentation in
+    the sense of Definition~\ref{def:mpu_canonical_form_ii} such that, for
+    every integer $N>0$,
     \begin{align}
         D_{\mathrm{red}}       & \leq D,   \\
         U_{\mathrm{red}}^{(N)} & =U^{(N)}.
     \end{align}
-    The normalized doubled-index tensor of $U_{\mathrm{red}}$ has
-    canonical-form-II data whose retained block dimensions sum to
-    $D_{\mathrm{red}}$. No equality is asserted at length zero, and no
+    In particular $U_{\mathrm{red}}$ is an MPU, the retained block dimensions
+    of its normalized doubled-index tensor sum to $D_{\mathrm{red}}$, and the
+    ambient right fixed matrix of that presentation is positive definite,
+    diagonal, and of trace one. No equality is asserted at length zero, and no
     virtual gauge is asserted between the two potentially unequal-dimensional
     bond spaces.
     % Source role: MPU corollary of the canonical-replacement infrastructure.
@@ -3184,7 +3207,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
          & =(U^{(N)})_{\sigma,\tau}.
     \end{align}
     Hence the periodic operators agree at every positive length. For $N>1$
-    the right side is unitary, so $U_{\mathrm{red}}$ is an MPU.
+    the right side is unitary, so $U_{\mathrm{red}}$ is an MPU. Its normalized
+    doubled-index tensor is $A_{\mathrm{red}}$, so the canonical-form-II data,
+    the full-support identity, and the diagonal positive trace-one ambient
+    right fixed matrix supplied by
+    Theorem~\ref{thm:mpu_reduced_normalized_flattening_cfii} assemble into a
+    canonical-form-II presentation of $U_{\mathrm{red}}$.
 \end{proof}
 
 \begin{theorem}[Full support under physical blocking]
@@ -4314,8 +4342,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     coordinates. This is the standing convention of
     \cite[lines~269--281, 344--356, and 488--502]{Cirac2017MPU}.
     % The ambient diagonal rho is part of the chosen presentation. No construction
-    % from arbitrary existing CFII and full-support witnesses is asserted here;
-    % that inhabitance statement is deferred to native child #7719.
+    % from arbitrary existing CFII and full-support witnesses is asserted:
+    % inhabitance is proved only for the constructed reduced representative of
+    % Theorem thm:mpu_reduced_cfii_representative.
 \end{definition}
 
 \begin{theorem}[Normality of a full-support normalized MPU representative]

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -42,6 +42,18 @@ data, and generates the same periodic operators at every positive length. It
 is a new representative; the theorem does not imply that the original ambient
 tensor is normal.
 
+The constructed representative is written in the ambient coordinates of its
+unique retained block. In those coordinates the ambient right fixed matrix is
+the block's own diagonal positive fixed matrix, normalized to trace one, which
+is the matrix $\rho$ of the source canonical form II. The construction
+therefore inhabits the bundled canonical-form-II presentation
+\leanid{MPOTensor.IsMPUCanonicalFormII}. This inhabitance is specific to the
+constructed gauge: canonical-form-II data together with full support do not by
+themselves make the ambient right fixed matrix diagonal, because a
+non-monomial unitary change of ambient coordinates carries a non-scalar
+diagonal fixed matrix to a nondiagonal one. No such general projection is
+claimed.
+
 This distinction is necessary. Given any MPU representative, adjoin a zero
 virtual direct summand. The periodic contractions do not change, so the
 enlarged tensor generates the same unitary operators at every length. However,
@@ -70,7 +82,10 @@ from the nonzero irreducible reduction, it transfers the shifted trace
 identities to the retained direct sum. Every transfer eigenvalue of a retained
 block embeds into the ambient transfer spectrum. Its positive Perron value and
 each peripheral value therefore equal one, so every retained block is normal.
-The canonical-form-II gauge preserves their total bond dimension.
+The canonical-form-II gauge preserves their total bond dimension. A final
+gauge transformation by the inclusion of the unique retained block places the
+representative in the coordinates carrying the diagonal ambient right fixed
+matrix.
 
 \section{The source factors and Theorem III.8}
 

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -44,8 +44,12 @@ tensor is normal.
 
 The constructed representative is written in the ambient coordinates of its
 unique retained block. In those coordinates the ambient right fixed matrix is
-the block's own diagonal positive fixed matrix, normalized to trace one, which
-is the matrix $\rho$ of the source canonical form II. The construction
+the block's own diagonal positive fixed matrix, normalized to trace one. This
+is the matrix denoted $\rho$ in the source canonical form II, namely the
+diagonal positive definite right fixed matrix of the normalized transfer map
+with $\tr(\rho)=1$; it is exhibited in ambient coordinates in
+Eq.~\ref{eq:mpu_canonical_form_full_support_ambient_fixed_point} below. The
+construction
 therefore inhabits the bundled canonical-form-II presentation
 \leanid{MPOTensor.IsMPUCanonicalFormII}. This inhabitance is specific to the
 constructed gauge: canonical-form-II data together with full support do not by

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -501,10 +501,12 @@ counts checked on `origin/main` at `fb847cd35`. Ranked among themselves by
 compounding cost; D13 precedes D14 because every new MPU statement pays it.
 
 ## D13. The MPU canonical-form-II convention is threaded pointwise, while admissible path nodes carry an additional continuous-source-data gap  —  api-design, impact 7/10, effort 5/10
-- **Status**: open. The source-labelled Chapter 28 nodes now contain the
-  source formulas and proof sketches needed for eventual consolidation, but
-  the 16 pointwise `mpu_admissible` twins remain until the convention predicate
-  of #7657 and the theorem migration of #7659 land. Removing them earlier would
+- **Status**: open. The convention predicate now exists, and the reduced
+  representative is constructed in the ambient diagonal gauge, so the
+  predicate is inhabited for the tensor the source arguments use. The
+  source-labelled Chapter 28 nodes contain the source formulas and proof
+  sketches needed for eventual consolidation, but the 16 pointwise
+  `mpu_admissible` twins remain until the theorem migration of #7659 lands. Removing them earlier would
   hide the current Lean hypothesis boundary. The nonsymmetric same-fixed-point
   problem in #7653 remains an optional out-of-source question; the transpose-
   reparameterized construction rejected in #7705 is not part of this plan.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2349,6 +2349,25 @@ spectral split → block extraction → MPV calculation → strict bounds
   distinction rather than identifying the two tensor shapes. Below the
   rule-of-three promotion threshold.
 
+### trace-one ambient block fixed matrix — candidate
+- **Pattern:** from canonical-form-II data with one retained block and full
+  support, rescale the block's diagonal positive fixed matrix to trace one,
+  use the unit weight forced by the shifted transfer traces, and transport the
+  rescaled matrix along the ambient block inclusion to a positive trace-one
+  right fixed matrix of the ambient transfer map.
+- **Seen:** two occurrences,
+  `TNLean/MPS/MPU/TransferStabilization.lean` (the stabilized-power theorem)
+  and `TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean` (the reduced
+  representative in the ambient diagonal gauge), recorded 2026-09-04.
+- **Abstraction:** proposed lemma on canonical-form-II data producing the
+  normalized block matrix together with its weighted-block fixed-point
+  equation, leaving each call site to choose the ambient coordinates.
+- **Notes:** below the promotion threshold at two occurrences. The two call
+  sites differ in their conclusion: one keeps the original ambient
+  coordinates and therefore cannot assert diagonality, while the other
+  changes gauge to the block coordinates and can. Only the shared normalized
+  block matrix and its fixed-point equation should be factored out.
+
 ---
 
 ## Rejected
@@ -2402,25 +2421,6 @@ spectral split → block extraction → MPV calculation → strict bounds
   `Kraus.mapLM_ne_zero_of_exists_ne_zero B hB` directly by definitional equality.
 - **Result:** the inline evaluation-at-identity proof is removed; no duplicate
   implementation remains.
-
-### trace-one ambient block fixed matrix — candidate
-- **Pattern:** from canonical-form-II data with one retained block and full
-  support, rescale the block's diagonal positive fixed matrix to trace one,
-  use the unit weight forced by the shifted transfer traces, and transport the
-  rescaled matrix along the ambient block inclusion to a positive trace-one
-  right fixed matrix of the ambient transfer map.
-- **Seen:** two occurrences,
-  `TNLean/MPS/MPU/TransferStabilization.lean` (the stabilized-power theorem)
-  and `TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean` (the reduced
-  representative in the ambient diagonal gauge), recorded 2026-09-04.
-- **Abstraction:** proposed lemma on canonical-form-II data producing the
-  normalized block matrix together with its weighted-block fixed-point
-  equation, leaving each call site to choose the ambient coordinates.
-- **Notes:** below the promotion threshold at two occurrences. The two call
-  sites differ in their conclusion: one keeps the original ambient
-  coordinates and therefore cannot assert diagonality, while the other
-  changes gauge to the block coordinates and can. Only the shared normalized
-  block matrix and its fixed-point equation should be factored out.
 
 ## Retired
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2403,6 +2403,25 @@ spectral split → block extraction → MPV calculation → strict bounds
 - **Result:** the inline evaluation-at-identity proof is removed; no duplicate
   implementation remains.
 
+### trace-one ambient block fixed matrix — candidate
+- **Pattern:** from canonical-form-II data with one retained block and full
+  support, rescale the block's diagonal positive fixed matrix to trace one,
+  use the unit weight forced by the shifted transfer traces, and transport the
+  rescaled matrix along the ambient block inclusion to a positive trace-one
+  right fixed matrix of the ambient transfer map.
+- **Seen:** two occurrences,
+  `TNLean/MPS/MPU/TransferStabilization.lean` (the stabilized-power theorem)
+  and `TNLean/MPS/MPU/ReducedCanonicalRepresentative.lean` (the reduced
+  representative in the ambient diagonal gauge), recorded 2026-09-04.
+- **Abstraction:** proposed lemma on canonical-form-II data producing the
+  normalized block matrix together with its weighted-block fixed-point
+  equation, leaving each call site to choose the ambient coordinates.
+- **Notes:** below the promotion threshold at two occurrences. The two call
+  sites differ in their conclusion: one keeps the original ambient
+  coordinates and therefore cannot assert diagonality, while the other
+  changes gauge to the block coordinates and can. Only the shared normalized
+  block matrix and its fixed-point equation should be factored out.
+
 ## Retired
 
 ### block_words — retired


### PR DESCRIPTION
Closes #7719. Advances #7657.

## What changed

`MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii` now returns, besides
the reduced canonical-form-II representative, an ambient matrix `ρ` that is
positive definite, diagonal, of trace one, and fixed by the representative's
transfer map. `MPOTensor.IsMPU.exists_reduced_cfii_representative` therefore
returns the bundled presentation `MPOTensor.IsMPUCanonicalFormII Ured` (landed
by #7720) instead of a bare canonical-form-II witness plus full support.

The construction applies one further gauge transformation: after the shifted
transfer traces force a single retained block with full support, the block
inclusion is a square unitary, and conjugating by it puts the representative in
the block's own coordinates. There the block's diagonal positive fixed matrix,
rescaled to trace one, *is* the ambient right fixed matrix. This is the gauge
transformation the source records at lines 269--294 ("For a normal tensor it is
always possible to find a gauge transformation defining a new normal tensor
that is in CFII and generates the same MPV").

No general projection is claimed. Canonical-form-II data together with full
support do **not** make the ambient right fixed matrix of a given tensor
diagonal: a non-monomial unitary change of ambient coordinates carries a
non-scalar diagonal fixed matrix to a nondiagonal one. Only the constructed
gauge inhabits the presentation, as the faithfulness boundary in #7719
requires. `TNLean/MPS/MPU/TransferStabilization.lean` and the
`HasFullSupport` wrappers are untouched; migrating their consumers stays
with #7659.

## Source lines used

- `Papers/1703.09188/paper_v2.tex` lines 269--294: canonical form II, the
  fixed pair `(Φ| = ∑ₙ (n,n|` and `|ρ) = ∑ₙ ρₙ |n,n)` with `ρₙ > 0` and
  `(Φ|ρ) = 1`, and the further gauge transformation into that form.
- `Papers/1703.09188/paper_v2.tex` lines 344--356: `prop:normal-tensor`, the
  shifted transfer traces, and the standing assumption that the normalized
  tensor is in canonical form II.
- `Papers/1606.00608/…` lines 195--255 and 1058--1077: the irreducible
  reduction and the canonical-form-II gauge.

## Declarations

- `MPOTensor.IsMPU.exists_reduced_normalizedFlattening_cfii` — strengthened
  statement (extra `ρ` binder and its four properties).
- `MPOTensor.IsMPU.exists_reduced_cfii_representative` — strengthened
  statement: the canonical-form-II presentation replaces the separate witness,
  full-support, and MPU conjuncts.
- Private helpers in the same module:
  `trace_transferMatrix_pow_eq_one_of_sameMPV` (removes two copies of the
  overlap-to-trace calculation) and
  `mpuCanonicalFormIIOfNormalizedFlatteningEq`.

No `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` is introduced.

## Documentation

- Blueprint nodes `thm:mpu_reduced_normalized_flattening_cfii` and
  `thm:mpu_reduced_cfii_representative` restated with the ambient fixed matrix
  and the final gauge step; `def:mpu_canonical_form_ii`'s deferral note updated.
- `docs/paper-gaps/mpu_canonical_form_full_support.tex` records the constructed
  gauge and states explicitly that no general projection from arbitrary
  canonical-form-II and full-support data is claimed.
- `docs/proof_debt_ledger.md` D13 status and a new candidate entry in
  `docs/tactic_patterns.md` for the trace-one ambient block fixed matrix
  pattern (two occurrences, below the promotion threshold).

## Verification

- `scripts/lake_build_locked.sh TNLean.MPS.MPU.ReducedCanonicalRepresentative`
  (linter-bearing) succeeds.
- `scripts/blueprint_lean_sync.py --ci`, `check_reader_facing_prose.py`,
  `check_forbidden_lean_tokens.py`, `check_numbered_lean_files.py`, and
  `check_oversized_lean_files.py` pass.
- A full warm `lake build` and `leanblueprint checkdecls` were still queued on
  the shared build lock when this was opened; CI on this branch is the
  remaining gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm