### PR TITLE
feat(MPS/ParentHamiltonian): construct the normalized primitive gauge for a normal MPS

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -101,6 +101,7 @@ import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.PeriodicBoundaryReduction
 import TNLean.MPS.ParentHamiltonian.PhysicalDeformation
+import TNLean.MPS.ParentHamiltonian.PrimitiveGaugeExistence
 import TNLean.MPS.ParentHamiltonian.ProductPair
 import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
 import TNLean.MPS.ParentHamiltonian.RestrictTransport

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -40,21 +40,47 @@ theorem parentInteraction_idempotent (A : MPSTensor d D) (L : ℕ) :
   rw [LinearEquiv.symm_apply_apply]
   exact congr_arg e (LinearMap.congr_fun hP (e.symm v))
 
+/-- Two tensors with the same local MPS space at length \(L\) have the same
+canonical parent interaction at that length.
+
+The parent interaction is the orthogonal projector onto \(G_L(A)^\perp\), so it
+is a function of \(G_L(A)\) alone. -/
+theorem parentInteraction_eq_of_groundSpace_eq {A B : MPSTensor d D} {L : ℕ}
+    (h : groundSpace A L = groundSpace B L) :
+    parentInteraction A L = parentInteraction B L := by
+  simp [parentInteraction, groundSpaceES, h]
+
+/-- Equal parent interactions give equal translated local terms. -/
+theorem localTerm_eq_of_parentInteraction_eq {A B : MPSTensor d D} {L : ℕ}
+    (h : parentInteraction A L = parentInteraction B L) (N : ℕ) (i : Fin N) :
+    localTerm A L N i = localTerm B L N i := by
+  unfold localTerm
+  rw [h]
+
+/-- Two tensors with the same local MPS space at length \(L\) have the same
+finite-chain parent Hamiltonian on every periodic chain. -/
+theorem parentHamiltonian_eq_of_groundSpace_eq {A B : MPSTensor d D} {L : ℕ}
+    (h : groundSpace A L = groundSpace B L) (N : ℕ) :
+    parentHamiltonian A L N = parentHamiltonian B L N := by
+  unfold parentHamiltonian
+  exact Finset.sum_congr rfl fun i _ =>
+    localTerm_eq_of_parentInteraction_eq
+      (parentInteraction_eq_of_groundSpace_eq h) N i
+
 /-- A virtual gauge change leaves the canonical parent interaction unchanged.
 
 The parent interaction depends only on the local MPS space, and gauge-equivalent
 tensors have the same local MPS space at every length. -/
 theorem GaugeEquiv.parentInteraction_eq {A B : MPSTensor d D}
     (h : GaugeEquiv A B) (L : ℕ) :
-    parentInteraction A L = parentInteraction B L := by
-  simp [parentInteraction, groundSpaceES, h.groundSpace_eq L]
+    parentInteraction A L = parentInteraction B L :=
+  parentInteraction_eq_of_groundSpace_eq (h.groundSpace_eq L)
 
 /-- A virtual gauge change leaves every translated parent interaction unchanged. -/
 theorem GaugeEquiv.localTerm_eq {A B : MPSTensor d D}
     (h : GaugeEquiv A B) (L N : ℕ) (i : Fin N) :
-    localTerm A L N i = localTerm B L N i := by
-  unfold localTerm
-  rw [h.parentInteraction_eq L]
+    localTerm A L N i = localTerm B L N i :=
+  localTerm_eq_of_parentInteraction_eq (h.parentInteraction_eq L) N i
 
 /-- Pointwise formula for a translated local term when the window length is at
 most the chain length. -/

--- a/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
+++ b/TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean
@@ -152,28 +152,6 @@ private theorem IsCPSVBasisOfNormalTensors.of_family_gaugeEquiv
     rw [← hEq]
     exact hLI N hN
 
-/-- Nonzero scalar multiplication does not change a positive-length local MPS
-space. -/
-private theorem groundSpace_smul_eq_of_ne_zero
-    {s n : ℕ} (A : MPSTensor s n) (ζ : ℂ) (hζ : ζ ≠ 0) (L : ℕ) :
-    groundSpace (ζ • A) L = groundSpace A L := by
-  have hMap (X : Matrix (Fin n) (Fin n) ℂ) :
-      groundSpaceMap (ζ • A) L X = groundSpaceMap A L ((ζ ^ L) • X) := by
-    ext σ
-    rw [groundSpaceMap_apply, groundSpaceMap_apply]
-    change Matrix.trace
-        (Kraus.evalWord (fun i => ζ • A i) (List.ofFn σ) * X) = _
-    rw [Kraus.evalWord_smul]
-    simp [Matrix.trace_smul]
-  apply le_antisymm
-  · rintro _ ⟨X, rfl⟩
-    exact ⟨(ζ ^ L) • X, (hMap X).symm⟩
-  · rintro _ ⟨Y, rfl⟩
-    refine ⟨(ζ ^ L)⁻¹ • Y, ?_⟩
-    rw [hMap]
-    congr 1
-    rw [smul_smul, mul_inv_cancel₀ (pow_ne_zero L hζ), one_smul]
-
 /-- Changing only the presentation of the bond dimension does not change the
 local MPS space. -/
 private theorem groundSpace_cast_bond_dim
@@ -244,7 +222,7 @@ private theorem CPSVCanonicalFormData.groundSpace_eq_iSup_representatives
       _ = groundSpace
           (cast (congr_arg (MPSTensor s) (ref.copyDimEq k))
             (data.blocks (data.representativeIndex (data.classCopy k).1))) L :=
-        groundSpace_smul_eq_of_ne_zero _ _ hPhaseNe L
+        groundSpace_smul_eq _ _ hPhaseNe L
       _ = groundSpace
           (data.blocks (data.representativeIndex (data.classCopy k).1)) L :=
         groundSpace_cast_bond_dim (ref.copyDimEq k) _ L

--- a/TNLean/MPS/ParentHamiltonian/CoisometricReconstruction.lean
+++ b/TNLean/MPS/ParentHamiltonian/CoisometricReconstruction.lean
@@ -72,26 +72,6 @@ theorem groundSpace_eq_of_coisometry_reconstruction
     simp only [← Matrix.mul_assoc, hU, Matrix.one_mul]
     rw [Matrix.mul_assoc, hU, Matrix.mul_one]
 
-private theorem groundSpace_smul_eq (A : MPSTensor s d) (ζ : ℂ) (hζ : ζ ≠ 0)
-    (L : ℕ) :
-    groundSpace (ζ • A) L = groundSpace A L := by
-  have hMap (X : Matrix (Fin d) (Fin d) ℂ) :
-      groundSpaceMap (ζ • A) L X = groundSpaceMap A L ((ζ ^ L) • X) := by
-    ext σ
-    rw [groundSpaceMap_apply, groundSpaceMap_apply]
-    change Matrix.trace
-        (Kraus.evalWord (fun i ↦ ζ • A i) (List.ofFn σ) * X) = _
-    rw [Kraus.evalWord_smul]
-    simp [Matrix.trace_smul]
-  apply le_antisymm
-  · rintro _ ⟨X, rfl⟩
-    exact ⟨(ζ ^ L) • X, (hMap X).symm⟩
-  · rintro _ ⟨Y, rfl⟩
-    refine ⟨(ζ ^ L)⁻¹ • Y, ?_⟩
-    rw [hMap]
-    congr 1
-    rw [smul_smul, mul_inv_cancel₀ (pow_ne_zero L hζ), one_smul]
-
 private theorem groundSpace_blockTensor_cast_dim
     {D₁ D₂ : ℕ} (h : D₁ = D₂) (A : MPSTensor s D₁) (p L : ℕ) :
     groundSpace

--- a/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
@@ -84,6 +84,32 @@ theorem GaugeEquiv.groundSpace_eq {A B : MPSTensor d D}
   · exact h.symm.groundSpace_le L
   · exact h.groundSpace_le L
 
+/-- Rescaling every matrix of a tensor by a nonzero scalar leaves the local MPS
+space unchanged at every length.
+
+Multiplying each \(A^i\) by \(\zeta\) multiplies every length-\(L\) word by
+\(\zeta^L\), which is absorbed by the boundary matrix. This is the scalar half
+of the "without loss of generality" normalization taken at
+arXiv:cond-mat/9410110, equations (3.1)--(3.2b), lines 1394--1435. -/
+theorem groundSpace_smul_eq (A : MPSTensor d D) (ζ : ℂ) (hζ : ζ ≠ 0) (L : ℕ) :
+    groundSpace (ζ • A) L = groundSpace A L := by
+  have hMap (X : Matrix (Fin D) (Fin D) ℂ) :
+      groundSpaceMap (ζ • A) L X = groundSpaceMap A L ((ζ ^ L) • X) := by
+    ext σ
+    rw [groundSpaceMap_apply, groundSpaceMap_apply]
+    change Matrix.trace
+        (Kraus.evalWord (fun i ↦ ζ • A i) (List.ofFn σ) * X) = _
+    rw [Kraus.evalWord_smul]
+    simp [Matrix.trace_smul]
+  apply le_antisymm
+  · rintro _ ⟨X, rfl⟩
+    exact ⟨(ζ ^ L) • X, (hMap X).symm⟩
+  · rintro _ ⟨Y, rfl⟩
+    refine ⟨(ζ ^ L)⁻¹ • Y, ?_⟩
+    rw [hMap]
+    congr 1
+    rw [smul_smul, mul_inv_cancel₀ (pow_ne_zero L hζ), one_smul]
+
 /-- The span of the periodic MPS vectors associated to a finite family of BNT
 components.
 

--- a/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
+++ b/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
@@ -188,11 +188,12 @@ further gauge by the square root of the matrix \(\Lambda\) appearing in
 condition 2.
 
 Normality supplies the irreducibility that the Perron--Frobenius eigenvector
-requires, through the primitivity equivalences of arXiv:0909.5347,
-Proposition 3, and it survives both the rescaling and the gauge; the
-trace-preserving representative is therefore normal as well, and Proposition 3
-returns the complementary transfer-map gap with a positive definite fixed
-point. -/
+requires, through the direction of arXiv:0909.5347, Proposition 3, that imposes
+no normalization on the tensor, and it survives both the rescaling and the
+gauge; the trace-preserving representative is therefore normal as well, and the
+full equivalence of Proposition 3, which does assume the trace-preserving
+normalization, returns the complementary transfer-map gap with a positive
+definite fixed point. -/
 theorem exists_isPrimitiveMPS_gauge_of_isNormal [NeZero D] {A : MPSTensor d D}
     (hA : Kraus.IsNormal A) :
     ∃ (B : MPSTensor d D) (ζ : ℂ) (ρ : Matrix (Fin D) (Fin D) ℂ),

--- a/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
+++ b/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
@@ -80,36 +80,20 @@ variable {d D : ℕ}
 /-- Rescaling every matrix of a tensor by a nonzero scalar preserves the span of
 the length-\(N\) words.
 
-Each length-\(N\) word acquires the common factor \(\zeta^N\), which is
-invertible, so the two spans contain each other. -/
+Each length-\(N\) word acquires the common factor \(\zeta^N\), which is a unit,
+and the span of a set is unchanged by a unit scalar. -/
 theorem wordSpan_smul_eq {ζ : ℂ} (hζ : ζ ≠ 0) (A : MPSTensor d D) (N : ℕ) :
     Kraus.wordSpan (ζ • A) N = Kraus.wordSpan A N := by
   have hword : ∀ σ : Fin N → Fin d,
       Kraus.evalWord (ζ • A) (List.ofFn σ) =
-        (ζ ^ N) • Kraus.evalWord A (List.ofFn σ) := by
-    intro σ
+        (ζ ^ N) • Kraus.evalWord A (List.ofFn σ) := fun σ => by
     have h := Kraus.evalWord_smul ζ A (List.ofFn σ)
     rw [List.length_ofFn] at h
     exact h
   simp only [Kraus.wordSpan]
-  apply le_antisymm
-  · refine Submodule.span_le.2 ?_
-    rintro _ ⟨σ, rfl⟩
-    have hmem : Kraus.evalWord (ζ • A) (List.ofFn σ) ∈
-        Submodule.span ℂ (Set.range fun τ : Fin N → Fin d =>
-          Kraus.evalWord A (List.ofFn τ)) := by
-      rw [hword σ]
-      exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
-    exact hmem
-  · refine Submodule.span_le.2 ?_
-    rintro _ ⟨σ, rfl⟩
-    have hmem : Kraus.evalWord (ζ • A) (List.ofFn σ) ∈
-        Submodule.span ℂ (Set.range fun τ : Fin N → Fin d =>
-          Kraus.evalWord (ζ • A) (List.ofFn τ)) :=
-      Submodule.subset_span ⟨σ, rfl⟩
-    have hscaled := Submodule.smul_mem _ ((ζ ^ N)⁻¹) hmem
-    rw [hword σ, smul_smul, inv_mul_cancel₀ (pow_ne_zero N hζ), one_smul] at hscaled
-    exact hscaled
+  simp_rw [hword]
+  rw [Set.range_smul]
+  exact Submodule.span_smul_eq_of_isUnit _ _ (pow_ne_zero N hζ).isUnit
 
 /-- Rescaling every matrix of a tensor by a nonzero scalar preserves block
 injectivity at every blocking length. -/

--- a/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
+++ b/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Irreducible.PerronGauge
+import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.Martingale.FiniteRangeKnabeGap
+import TNLean.Wielandt.Primitivity.Equivalence
+
+/-!
+# The normalized primitive gauge of a normal tensor
+
+A normal tensor need not be trace preserving, and its transfer map need not have
+spectral radius one.  Both normalizations are taken "without loss of generality"
+by the sources: Nachtergaele, arXiv:cond-mat/9410110, rewrites the generalized
+valence-bond construction so that equations (3.2a) and (3.2b) hold (lines
+1394--1435), and Pérez-García, Verstraete, Wolf, and Cirac, arXiv:quant-ph/0608197,
+open the proof of their translation-invariant canonical form (Theorem
+`Th:TIcanonical`, statement lines 742--761, proof lines 765--770) by assuming
+that the spectral radius of the transfer map is one and gauging by the square
+root of a positive fixed point.
+
+This file performs that step. From a normal tensor \(A\) it produces a positive
+scalar \(\zeta\), a virtual gauge \(X\), and the rescaled gauged tensor
+\(B^i=\zeta\,XA^iX^{-1}\) which carries the trace-preserving normalization
+\(\sum_i (B^i)^\dagger B^i=\mathbb 1\) together with a positive definite fixed
+point of its transfer map: exactly the data bundled by the complementary
+transfer-map gap predicate.  Rescaling and gauging leave the local MPS spaces,
+the parent interaction, and the periodic chain ground spaces untouched, so every
+consequence of the gap predicate that is phrased through those objects transfers
+back to \(A\) verbatim.  The finite-range Knabe gap is one such consequence, and
+it is stated here for an arbitrary normal tensor.
+
+The orientation is the mirror of the printed one: the gauge is built from the
+Perron eigenvector of the *adjoint* transfer map, so the resulting family is
+trace preserving rather than unital.  Both orientations are already in the
+sources.  The blocks of the canonical form of arXiv:quant-ph/0608197, Theorem
+`Th:TIcanonical`, statement lines 752--758, satisfy conditions 1 and 2,
+\(\sum_i A^iA^{i\dagger}=\mathbb 1\) and
+\(\sum_i A^{i\dagger}\Lambda A^i=\Lambda\) with \(\Lambda>0\); the further gauge
+by \(\Lambda^{1/2}\) turns condition 2 into the trace-preserving normalization
+and condition 1 into the statement that \(\Lambda\) is a positive definite fixed
+point of the transfer map.  Nachtergaele's equations (3.2a) and (3.2b) impose
+the corresponding two-sided normalization on the rewritten generalized
+valence-bond construction.
+
+## Main results
+
+* `MPSTensor.isNBlkInjective_smul_iff`, `MPSTensor.isNormal_smul_iff`: block
+  injectivity and normality are invariant under a nonzero rescaling.
+* `MPSTensor.exists_isPrimitiveMPS_gauge_of_isNormal`: the normalized primitive
+  gauge of a normal tensor.
+* `MPSTensor.IsNormal.exists_parentHamiltonianES_gap`: the finite-range Knabe
+  gap for the parent Hamiltonian of an arbitrary normal tensor.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, equations (3.1)--(3.2b), lines
+  1394--1435.
+* D. Pérez-García, F. Verstraete, M. Wolf, J. I. Cirac, arXiv:quant-ph/0608197,
+  Theorem `Th:TIcanonical`, lines 742--770.
+* M. Sanz, D. Pérez-García, M. Wolf, J. I. Cirac, arXiv:0909.5347,
+  Proposition 3.
+* J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, arXiv:2011.12127,
+  lines 2183--2187.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Rescaling invariance of block injectivity -/
+
+/-- Rescaling every matrix of a tensor by a nonzero scalar preserves the span of
+the length-\(N\) words.
+
+Each length-\(N\) word acquires the common factor \(\zeta^N\), which is
+invertible, so the two spans contain each other. -/
+theorem wordSpan_smul_eq {ζ : ℂ} (hζ : ζ ≠ 0) (A : MPSTensor d D) (N : ℕ) :
+    Kraus.wordSpan (ζ • A) N = Kraus.wordSpan A N := by
+  have hword : ∀ σ : Fin N → Fin d,
+      Kraus.evalWord (ζ • A) (List.ofFn σ) =
+        (ζ ^ N) • Kraus.evalWord A (List.ofFn σ) := by
+    intro σ
+    have h := Kraus.evalWord_smul ζ A (List.ofFn σ)
+    rw [List.length_ofFn] at h
+    exact h
+  simp only [Kraus.wordSpan]
+  apply le_antisymm
+  · refine Submodule.span_le.2 ?_
+    rintro _ ⟨σ, rfl⟩
+    have hmem : Kraus.evalWord (ζ • A) (List.ofFn σ) ∈
+        Submodule.span ℂ (Set.range fun τ : Fin N → Fin d =>
+          Kraus.evalWord A (List.ofFn τ)) := by
+      rw [hword σ]
+      exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨σ, rfl⟩)
+    exact hmem
+  · refine Submodule.span_le.2 ?_
+    rintro _ ⟨σ, rfl⟩
+    have hmem : Kraus.evalWord (ζ • A) (List.ofFn σ) ∈
+        Submodule.span ℂ (Set.range fun τ : Fin N → Fin d =>
+          Kraus.evalWord (ζ • A) (List.ofFn τ)) :=
+      Submodule.subset_span ⟨σ, rfl⟩
+    have hscaled := Submodule.smul_mem _ ((ζ ^ N)⁻¹) hmem
+    rw [hword σ, smul_smul, inv_mul_cancel₀ (pow_ne_zero N hζ), one_smul] at hscaled
+    exact hscaled
+
+/-- Rescaling every matrix of a tensor by a nonzero scalar preserves block
+injectivity at every blocking length. -/
+theorem isNBlkInjective_smul_iff {ζ : ℂ} (hζ : ζ ≠ 0) (A : MPSTensor d D) (N : ℕ) :
+    Kraus.IsNBlkInjective (ζ • A) N ↔ Kraus.IsNBlkInjective A N := by
+  simp only [Kraus.IsNBlkInjective, wordSpan_smul_eq hζ A N]
+
+/-- Rescaling every matrix of a tensor by a nonzero scalar preserves normality.
+
+This is the scalar half of the normalization taken without loss of generality at
+arXiv:quant-ph/0608197, proof lines 765--767. -/
+theorem isNormal_smul_iff {ζ : ℂ} (hζ : ζ ≠ 0) (A : MPSTensor d D) :
+    Kraus.IsNormal (ζ • A) ↔ Kraus.IsNormal A := by
+  constructor
+  · rintro ⟨N, hN, hInj⟩
+    exact ⟨N, hN, (isNBlkInjective_smul_iff hζ A N).1 hInj⟩
+  · rintro ⟨N, hN, hInj⟩
+    exact ⟨N, hN, (isNBlkInjective_smul_iff hζ A N).2 hInj⟩
+
+/-- A normal tensor on a nonzero bond space has a nonzero matrix.
+
+If every matrix vanished, every positive-length word would vanish and the word
+span could not be the full matrix algebra. -/
+theorem exists_apply_ne_zero_of_isNormal [NeZero D] {A : MPSTensor d D}
+    (hA : Kraus.IsNormal A) : ∃ i : Fin d, A i ≠ 0 := by
+  obtain ⟨N, hN, hInj⟩ := hA
+  by_contra hall
+  simp only [not_exists, not_not] at hall
+  have hsub : (Set.range fun σ : Fin N → Fin d =>
+      Kraus.evalWord A (List.ofFn σ)) ⊆ {0} := by
+    rintro _ ⟨σ, rfl⟩
+    obtain ⟨N', rfl⟩ : ∃ N', N = N' + 1 := ⟨N - 1, by omega⟩
+    change Kraus.evalWord A (List.ofFn σ) ∈ ({0} : Set (Matrix (Fin D) (Fin D) ℂ))
+    rw [Set.mem_singleton_iff, List.ofFn_succ, Kraus.evalWord_cons, hall (σ 0),
+      Matrix.zero_mul]
+  have hle : (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤ ⊥ := by
+    rw [← hInj.span_eq_top, ← Submodule.span_zero_singleton (R := ℂ)
+      (M := Matrix (Fin D) (Fin D) ℂ)]
+    exact Submodule.span_mono hsub
+  have h10 : (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
+    (Submodule.mem_bot ℂ).mp (hle Submodule.mem_top)
+  have hD : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  have hentry := congrFun (congrFun h10 ⟨0, hD⟩) ⟨0, hD⟩
+  rw [Matrix.one_apply_eq] at hentry
+  exact one_ne_zero hentry
+
+/-! ### Transport of the parent Hamiltonian along equal local MPS spaces -/
+
+/-- Two tensors with the same local MPS space at length \(L\) have the same
+finite-chain parent Hamiltonian in the Euclidean realization. -/
+theorem parentHamiltonianES_eq_of_groundSpace_eq {A B : MPSTensor d D} {L : ℕ}
+    (h : groundSpace A L = groundSpace B L) (N : ℕ) :
+    parentHamiltonianES A L N = parentHamiltonianES B L N := by
+  simp only [parentHamiltonianES, parentHamiltonian_eq_of_groundSpace_eq h N]
+
+/-! ### The normalized primitive gauge -/
+
+/-- **The normalized primitive gauge of a normal tensor.**
+
+For a normal tensor \(A\) there are a nonzero scalar \(\zeta\), a virtual gauge,
+and a matrix \(\rho>0\) such that the rescaled gauged tensor \(B\) satisfies
+\(\sum_i (B^i)^\dagger B^i=\mathbb 1\) and has \(\rho\) as the distinguished
+fixed point of a complementary transfer-map gap.  The matrix product vectors of
+\(B\) are those of \(A\) rescaled by \(\zeta^N\), and the local MPS spaces, the
+parent interactions, and the periodic chain ground spaces of \(A\) and \(B\)
+coincide.
+
+This is the step taken without loss of generality at
+arXiv:cond-mat/9410110, equations (3.1)--(3.2b), lines 1394--1435, and at
+arXiv:quant-ph/0608197, Theorem `Th:TIcanonical`, proof lines 765--770: rescale
+so that the transfer map has spectral radius one and gauge by the square root of
+a positive fixed point.  The gauge here is built from the Perron eigenvector of
+the adjoint transfer map, giving the trace-preserving orientation, which is what
+conditions 1 and 2 of that theorem (statement lines 752--758) become after the
+further gauge by the square root of the matrix \(\Lambda\) appearing in
+condition 2.
+
+Normality supplies the irreducibility that the Perron--Frobenius eigenvector
+requires, through the primitivity equivalences of arXiv:0909.5347,
+Proposition 3, and it survives both the rescaling and the gauge; the
+trace-preserving representative is therefore normal as well, and Proposition 3
+returns the complementary transfer-map gap with a positive definite fixed
+point. -/
+theorem exists_isPrimitiveMPS_gauge_of_isNormal [NeZero D] {A : MPSTensor d D}
+    (hA : Kraus.IsNormal A) :
+    ∃ (B : MPSTensor d D) (ζ : ℂ) (ρ : Matrix (Fin D) (Fin D) ℂ),
+      ζ ≠ 0 ∧
+      GaugeEquiv (ζ • A) B ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) ∧
+      IsPrimitiveMPS B ρ ∧ ρ.PosDef ∧
+      (∀ L : ℕ, groundSpace A L = groundSpace B L) ∧
+      (∀ L : ℕ, parentInteraction A L = parentInteraction B L) ∧
+      (∀ L N : ℕ, chainGroundSpace A L N = chainGroundSpace B L N) := by
+  classical
+  have hIrr : Kraus.IsIrreducibleFamily (d := d) (D := D) A :=
+    isIrreducibleTensor_of_isPrimitivePaper A (isPrimitivePaper_of_isNormal A hA)
+  obtain ⟨B, r, σ, _hσ, hr, _hBdef, hBnorm, hBgauge⟩ :=
+    exists_tp_data_of_irreducible A hIrr (exists_apply_ne_zero_of_isNormal hA)
+  set ζ : ℂ := (↑((Real.sqrt r)⁻¹) : ℂ) with hζ_def
+  have hζ : ζ ≠ 0 := by
+    have hsqrt : Real.sqrt r ≠ 0 := ne_of_gt (Real.sqrt_pos.2 hr)
+    simpa [hζ_def] using inv_ne_zero hsqrt
+  have hgauge : GaugeEquiv (ζ • A) B := hBgauge
+  have hNormalScaled : Kraus.IsNormal (ζ • A) := (isNormal_smul_iff hζ A).2 hA
+  have hNormalB : Kraus.IsNormal B := isNormal_of_gaugeEquiv hNormalScaled hgauge
+  obtain ⟨ρ, hPrim, hρ⟩ :=
+    isPrimitiveMPS_of_isStronglyIrreduciblePaper B hBnorm
+      (isNormal_implies_stronglyIrreducible B hBnorm hNormalB)
+  have hGS : ∀ L : ℕ, groundSpace A L = groundSpace B L := by
+    intro L
+    rw [← groundSpace_smul_eq A ζ hζ L]
+    exact hgauge.groundSpace_eq L
+  refine ⟨B, ζ, ρ, hζ, hgauge, ?_, hPrim, hρ, hGS, ?_, ?_⟩
+  · intro N τ
+    rw [← hgauge.sameMPV N τ]
+    simp only [mpv, coeff]
+    change Matrix.trace (Kraus.evalWord (fun i => ζ • A i) (List.ofFn τ)) = _
+    rw [Kraus.evalWord_smul]
+    simp [List.length_ofFn, Matrix.trace_smul]
+  · exact fun L => parentInteraction_eq_of_groundSpace_eq (hGS L)
+  · exact fun L N => chainGroundSpace_eq_of_groundSpace_eq (hGS L)
+
+/-- **The finite-range Knabe gap for an arbitrary normal tensor.**
+
+Every normal tensor has a positive uniform lower bound on the nonzero spectrum
+of its canonical range-\(l+1\) parent Hamiltonian on every periodic chain with
+\(N\geq 2m\).  This is the matrix-product-state case of the gap statement at
+arXiv:2011.12127, lines 2183--2187, with no normalization imposed on the tensor.
+
+The normalized primitive gauge replaces \(A\) by a trace-preserving
+representative with a positive definite fixed point, which is where the
+finite-range Knabe estimate applies; the parent Hamiltonian is unchanged by that
+replacement, and block injectivity transfers back through the rescaling and the
+gauge. -/
+theorem IsNormal.exists_parentHamiltonianES_gap [NeZero D] {A : MPSTensor d D}
+    (hA : Kraus.IsNormal A) :
+    ∃ l : ℕ, ∃ ε : ℝ, ∃ m : ℕ, ∃ δ : ℝ,
+      1 < l ∧ Kraus.IsNBlkInjective A l ∧
+      0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      l + 1 ≤ m ∧
+      δ = ((m : ℝ) * (1 - ε * Real.sqrt ((l + 1 : ℕ) : ℝ)) ^ 2 -
+          (l : ℝ) ^ 2) / ((m : ℝ) - (l : ℝ)) ∧
+      0 < δ ∧
+      ∀ N : ℕ, 2 * m ≤ N → ∀ v ∈
+        (LinearMap.ker (parentHamiltonianES A (l + 1) N))ᗮ,
+        δ * ‖v‖ ≤ ‖parentHamiltonianES A (l + 1) N v‖ := by
+  obtain ⟨B, ζ, ρ, hζ, hgauge, _hmpv, hPrim, hρ, hGS, _hPI, _hCGS⟩ :=
+    exists_isPrimitiveMPS_gauge_of_isNormal hA
+  obtain ⟨l, ε, m, δ, hl, hInjB, hε, hεlt, hm, hδ_def, hδ, hGap⟩ :=
+    hPrim.exists_parentHamiltonianES_gap_of_finiteRangeKnabe hρ
+  have hInjA : Kraus.IsNBlkInjective A l :=
+    (isNBlkInjective_smul_iff hζ A l).1
+      (isNBlkInjective_of_gaugeEquiv hInjB hgauge.symm)
+  refine ⟨l, ε, m, δ, hl, hInjA, hε, hεlt, hm, hδ_def, hδ, ?_⟩
+  intro N hN v hv
+  rw [parentHamiltonianES_eq_of_groundSpace_eq (hGS (l + 1)) N] at hv ⊢
+  exact hGap N hN v hv
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
+++ b/TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean
@@ -16,10 +16,10 @@ spectral radius one.  Both normalizations are taken "without loss of generality"
 by the sources: Nachtergaele, arXiv:cond-mat/9410110, rewrites the generalized
 valence-bond construction so that equations (3.2a) and (3.2b) hold (lines
 1394--1435), and Pérez-García, Verstraete, Wolf, and Cirac, arXiv:quant-ph/0608197,
-open the proof of their translation-invariant canonical form (Theorem
-`Th:TIcanonical`, statement lines 742--761, proof lines 765--770) by assuming
-that the spectral radius of the transfer map is one and gauging by the square
-root of a positive fixed point.
+open the proof of Theorem 4, the translation-invariant canonical form
+(statement lines 742--761, proof lines 765--770), by assuming that the spectral
+radius of the transfer map is one and gauging by the square root of a positive
+fixed point.
 
 This file performs that step. From a normal tensor \(A\) it produces a positive
 scalar \(\zeta\), a virtual gauge \(X\), and the rescaled gauged tensor
@@ -35,8 +35,9 @@ it is stated here for an arbitrary normal tensor.
 The orientation is the mirror of the printed one: the gauge is built from the
 Perron eigenvector of the *adjoint* transfer map, so the resulting family is
 trace preserving rather than unital.  Both orientations are already in the
-sources.  The blocks of the canonical form of arXiv:quant-ph/0608197, Theorem
-`Th:TIcanonical`, statement lines 752--758, satisfy conditions 1 and 2,
+sources.  The blocks of the translation-invariant canonical form of
+arXiv:quant-ph/0608197, Theorem 4, statement lines 752--758, satisfy
+conditions 1 and 2,
 \(\sum_i A^iA^{i\dagger}=\mathbb 1\) and
 \(\sum_i A^{i\dagger}\Lambda A^i=\Lambda\) with \(\Lambda>0\); the further gauge
 by \(\Lambda^{1/2}\) turns condition 2 into the trace-preserving normalization
@@ -49,17 +50,19 @@ valence-bond construction.
 
 * `MPSTensor.isNBlkInjective_smul_iff`, `MPSTensor.isNormal_smul_iff`: block
   injectivity and normality are invariant under a nonzero rescaling.
+* `MPSTensor.exists_apply_ne_zero_of_isNormal`: a normal tensor on a nonzero
+  bond space has a nonzero matrix.
 * `MPSTensor.exists_isPrimitiveMPS_gauge_of_isNormal`: the normalized primitive
   gauge of a normal tensor.
-* `MPSTensor.IsNormal.exists_parentHamiltonianES_gap`: the finite-range Knabe
-  gap for the parent Hamiltonian of an arbitrary normal tensor.
+* `MPSTensor.exists_parentHamiltonianES_gap_of_isNormal`: the finite-range
+  Knabe gap for the parent Hamiltonian of an arbitrary normal tensor.
 
 ## References
 
 * B. Nachtergaele, arXiv:cond-mat/9410110, equations (3.1)--(3.2b), lines
   1394--1435.
 * D. Pérez-García, F. Verstraete, M. Wolf, J. I. Cirac, arXiv:quant-ph/0608197,
-  Theorem `Th:TIcanonical`, lines 742--770.
+  Theorem 4, lines 742--770.
 * M. Sanz, D. Pérez-García, M. Wolf, J. I. Cirac, arXiv:0909.5347,
   Proposition 3.
 * J. I. Cirac, D. Pérez-García, N. Schuch, F. Verstraete, arXiv:2011.12127,
@@ -176,7 +179,7 @@ coincide.
 
 This is the step taken without loss of generality at
 arXiv:cond-mat/9410110, equations (3.1)--(3.2b), lines 1394--1435, and at
-arXiv:quant-ph/0608197, Theorem `Th:TIcanonical`, proof lines 765--770: rescale
+arXiv:quant-ph/0608197, Theorem 4, proof lines 765--770: rescale
 so that the transfer map has spectral radius one and gauge by the square root of
 a positive fixed point.  The gauge here is built from the Perron eigenvector of
 the adjoint transfer map, giving the trace-preserving orientation, which is what
@@ -241,7 +244,7 @@ representative with a positive definite fixed point, which is where the
 finite-range Knabe estimate applies; the parent Hamiltonian is unchanged by that
 replacement, and block injectivity transfers back through the rescaling and the
 gauge. -/
-theorem IsNormal.exists_parentHamiltonianES_gap [NeZero D] {A : MPSTensor d D}
+theorem exists_parentHamiltonianES_gap_of_isNormal [NeZero D] {A : MPSTensor d D}
     (hA : Kraus.IsNormal A) :
     ∃ l : ℕ, ∃ ε : ℝ, ∃ m : ℕ, ∃ δ : ℝ,
       1 < l ∧ Kraus.IsNBlkInjective A l ∧

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -212,6 +212,46 @@ matrices, and let $\E_K$ be its Kraus map.
     Theorem~\ref{thm:wielandt_proposition_three}.
 \end{remark}
 
+\begin{theorem}[Eventual full Kraus rank gives paper primitivity]
+    \label{thm:paper_primitive_of_full_kraus_rank}
+    \lean{MPSTensor.isPrimitivePaper_of_hasEventuallyFullKrausRank}
+    \leanok
+    \uses{def:eventually_full_kraus_rank, def:paper_primitive}
+    If $S_i(A)=\MN{D}$ for some positive $i$, then $H_i(A,\varphi)=\C^D$ for
+    every $\varphi\neq0$, so $A$ is primitive in the sense of
+    Definition~\ref{def:paper_primitive}.  No normalization is imposed on
+    $A$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Applying every matrix of $\MN{D}$ to a nonzero vector $\varphi$ gives all
+    of $\C^D$, and $S_i(A)\varphi$ is the span of the length-$i$ words
+    applied to $\varphi$.
+\end{proof}
+
+\begin{theorem}[Paper primitivity gives strong irreducibility]
+    \label{thm:strongly_irreducible_of_paper_primitive}
+    \lean{MPSTensor.isStronglyIrreduciblePaper_of_isPrimitivePaper}
+    \leanok
+    \uses{def:paper_primitive, def:strongly_irreducible_paper}
+    Let $D>0$ and suppose $\sum_i(A^i)^\dagger A^i=\Id$.  If $A$ is primitive
+    in the sense of Definition~\ref{def:paper_primitive}, then $\E_A$ is
+    strongly irreducible.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Regard the matrices of $A$ as a finite Kraus family.
+    Theorems~\cite[``Positive-definite fixed point from vector spreading'']{QICLean2026Blueprint}
+    and~\cite[``Primitivity from vector spreading'']{QICLean2026Blueprint}
+    give a positive-definite fixed point and show that $1$ is the only
+    peripheral eigenvalue, and
+    Theorem~\cite[``Irreducibility from vector spreading'']{QICLean2026Blueprint}
+    gives irreducibility of $\E_A$.  Together these are the three conditions
+    of Definition~\ref{def:strongly_irreducible_paper}.
+\end{proof}
+
 \begin{theorem}[Strengthened form of the primitivity equivalence]
     \label{thm:wielandt_proposition_three}
     \lean{MPSTensor.primitivePaper_iff_hasEventuallyFullKrausRank}
@@ -235,15 +275,12 @@ matrices, and let $\E_K$ be its Kraus map.
 \end{theorem}
 
 \begin{proof}\leanok
-
-    If $S_i(A)=\MN{D}$ and $\varphi\neq0$, then
-    $S_i(A)\varphi=\C^D$, proving (2)$\Rightarrow$(1).
-    For (1)$\Rightarrow$(3), regard the matrices of $A$ as a finite Kraus
-    family. Theorems~\cite[``Positive-definite fixed point from vector spreading'']{QICLean2026Blueprint}
-    and~\cite[``Primitivity from vector spreading'']{QICLean2026Blueprint} give a positive-definite
-    fixed point and show that $1$ is the only peripheral eigenvalue.
-    Theorem~\cite[``Irreducibility from vector spreading'']{QICLean2026Blueprint} gives irreducibility.
-    Together these facts say that $\E_A$ is strongly irreducible.
+    \uses{thm:paper_primitive_of_full_kraus_rank,
+        thm:strongly_irreducible_of_paper_primitive}
+    Theorem~\ref{thm:paper_primitive_of_full_kraus_rank} is
+    (2)$\Rightarrow$(1), and
+    Theorem~\ref{thm:strongly_irreducible_of_paper_primitive} is
+    (1)$\Rightarrow$(3).
 
     For (3)$\Rightarrow$(2), write
     $\E_A^m=P_\rho+(\E_A-P_\rho)^m$. The complementary powers tend to zero.
@@ -254,8 +291,8 @@ matrices, and let $\E_K$ be its Kraus map.
     $o(\lVert B\rVert^2)$. For large $m$ this is a contradiction.
 \end{proof}
 
-\begin{corollary}[Normalized normal tensors are strongly irreducible]
-    \label{cor:normalized_normal_strongly_irreducible}
+\begin{theorem}[Normalized normal tensors are strongly irreducible]
+    \label{thm:normalized_normal_strongly_irreducible}
     \lean{MPSTensor.isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank,
         MPSTensor.isNormal_implies_stronglyIrreducible}
     \leanok
@@ -264,14 +301,16 @@ matrices, and let $\E_K$ be its Kraus map.
     Let $D>0$ and suppose $\sum_i(A^i)^\dagger A^i=\Id$.  If $A$ has
     eventually full Kraus rank, or equivalently is normal, then $\E_A$ is
     strongly irreducible.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:wielandt_proposition_three, rem:wolf_6_8_pairwise}
+    \uses{thm:paper_primitive_of_full_kraus_rank,
+        thm:strongly_irreducible_of_paper_primitive, rem:wolf_6_8_pairwise}
     Normality is eventual full Kraus rank by
-    Remark~\ref{rem:wolf_6_8_pairwise}, and the implication
-    (2)$\Rightarrow$(3) of Theorem~\ref{thm:wielandt_proposition_three}
+    Remark~\ref{rem:wolf_6_8_pairwise}.
+    Theorem~\ref{thm:paper_primitive_of_full_kraus_rank} then gives paper
+    primitivity, and Theorem~\ref{thm:strongly_irreducible_of_paper_primitive}
     gives strong irreducibility.
 \end{proof}
 

--- a/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
+++ b/blueprint/src/chapter/ch08_wielandt_cumulative_bound.tex
@@ -254,6 +254,27 @@ matrices, and let $\E_K$ be its Kraus map.
     $o(\lVert B\rVert^2)$. For large $m$ this is a contradiction.
 \end{proof}
 
+\begin{corollary}[Normalized normal tensors are strongly irreducible]
+    \label{cor:normalized_normal_strongly_irreducible}
+    \lean{MPSTensor.isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank,
+        MPSTensor.isNormal_implies_stronglyIrreducible}
+    \leanok
+    \uses{def:eventually_full_kraus_rank, def:normal,
+        def:strongly_irreducible_paper}
+    Let $D>0$ and suppose $\sum_i(A^i)^\dagger A^i=\Id$.  If $A$ has
+    eventually full Kraus rank, or equivalently is normal, then $\E_A$ is
+    strongly irreducible.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wielandt_proposition_three, rem:wolf_6_8_pairwise}
+    Normality is eventual full Kraus rank by
+    Remark~\ref{rem:wolf_6_8_pairwise}, and the implication
+    (2)$\Rightarrow$(3) of Theorem~\ref{thm:wielandt_proposition_three}
+    gives strong irreducibility.
+\end{proof}
+
 % Scope restriction (primitive channels): Proposition 1 is universal, whereas
 % the theorem below assumes paper primitivity. See
 % docs/paper-gaps/spwc10_wielandt_one_step_subspace.tex.

--- a/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
+++ b/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
@@ -480,8 +480,27 @@ formulated via a complementary transfer-map gap, directly to normality
 using the convergence of the transfer-map iterates to the
 projection onto the fixed-point subspace.
 
-\begin{lemma}[Strongly irreducible tensors are primitive with a positive-definite fixed point]%
-    \label{lem:primitive_from_strongly_irred}
+\begin{theorem}[Positive definiteness of the fixed point under map irreducibility]%
+    \label{thm:primitive_fixed_point_posdef_of_irreducible_map}
+    \lean{Kraus.HasComplementaryFixedPointGap.posDef_of_isIrreducibleMap}
+    \leanok
+    \uses{def:primitive_mps}
+    Let $D>0$, let $(A,\rho)$ be primitive in the sense of
+    Definition~\ref{def:primitive_mps}, and let $\E_A$ be irreducible.  Then
+    $\rho>0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $P$ be the support projection of $\rho$.  Since $\E_A$ is completely
+    positive and fixes $\rho$, the support of $\E_A(X)$ lies in the support
+    of $\rho$ for every $X\ge0$ supported in $P$, so $\E_A$ maps the corner
+    $P\MN{D}P$ into itself.  Irreducibility forces $P=0$ or $P=\Id$, and
+    $P\neq0$ because $\rho\neq0$; hence $P=\Id$ and $\rho>0$.
+\end{proof}
+
+\begin{theorem}[Strongly irreducible tensors are primitive with a positive-definite fixed point]%
+    \label{thm:primitive_from_strongly_irred}
     \lean{MPSTensor.isPrimitiveMPS_of_isStronglyIrreduciblePaper}
     \leanok
     \uses{def:strongly_irreducible_paper, def:primitive_mps}
@@ -490,23 +509,21 @@ projection onto the fixed-point subspace.
     Definition~\ref{def:strongly_irreducible_paper}, then there is a matrix
     $\rho>0$ such that $(A,\rho)$ is primitive in the sense of
     Definition~\ref{def:primitive_mps}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:irreducible_tensor}
-    Irreducibility of $\E_A$ gives irreducibility of the tensor $A$: if $P$
-    were a nontrivial invariant projection of $A$, then $\E_A$ would map the
-    corner $P\MN{D}P$ into itself, and $P$ would be a nontrivial invariant
-    projection of $\E_A$.  The trace-preserving normalization supplies a
-    nonzero positive semidefinite fixed point $\rho$ of $\E_A$.  Since $A$ is
-    irreducible and the peripheral spectrum of $\E_A$ is $\{1\}$, the
-    eigenvalue $1$ is simple, so the spectral radius of $\E_A-P_\rho$ is below
-    one; this is the complementary transfer-map gap of
-    Definition~\ref{def:primitive_mps}.  Finally, a nonzero positive
-    semidefinite fixed point of an irreducible transfer map is positive
-    definite, since the projection onto its kernel would otherwise be a
-    nontrivial invariant projection of $\E_A$.
+    \uses{def:irreducible_tensor, lem:blocked_irreducibility_direct_support,
+        thm:primitive_fixed_point_posdef_of_irreducible_map}
+    Irreducibility of $\E_A$ gives irreducibility of the tensor $A$ by the
+    last clause of Lemma~\ref{lem:blocked_irreducibility_direct_support}: if
+    $P$ were a nontrivial invariant projection of $A$, then $\E_A$ would map
+    the corner $P\MN{D}P$ into itself.  Tensor irreducibility, the
+    trace-preserving normalization, and the peripheral spectrum $\{1\}$ then
+    give primitive fixed-point data $(A,\rho)$ with $\rho\ge0$ nonzero by the
+    first clause of the same lemma.  Finally,
+    Theorem~\ref{thm:primitive_fixed_point_posdef_of_irreducible_map} makes
+    $\rho$ positive definite because $\E_A$ is irreducible.
 \end{proof}
 
 \begin{lemma}[Primitive tensors with positive-definite fixed point are strongly irreducible]%

--- a/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
+++ b/blueprint/src/chapter/ch08_wielandt_fixed_length_and_normality.tex
@@ -480,6 +480,35 @@ formulated via a complementary transfer-map gap, directly to normality
 using the convergence of the transfer-map iterates to the
 projection onto the fixed-point subspace.
 
+\begin{lemma}[Strongly irreducible tensors are primitive with a positive-definite fixed point]%
+    \label{lem:primitive_from_strongly_irred}
+    \lean{MPSTensor.isPrimitiveMPS_of_isStronglyIrreduciblePaper}
+    \leanok
+    \uses{def:strongly_irreducible_paper, def:primitive_mps}
+    Let $D>0$ and suppose $\sum_i(A^i)^\dagger A^i=\Id$.  If $\E_A$ is
+    strongly irreducible in the sense of
+    Definition~\ref{def:strongly_irreducible_paper}, then there is a matrix
+    $\rho>0$ such that $(A,\rho)$ is primitive in the sense of
+    Definition~\ref{def:primitive_mps}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Irreducibility of $\E_A$ gives irreducibility of the tensor $A$: if $P$
+    were a nontrivial invariant projection of $A$, then $\E_A$ would map the
+    corner $P\MN{D}P$ into itself, and $P$ would be a nontrivial invariant
+    projection of $\E_A$.  The trace-preserving normalization supplies a
+    nonzero positive semidefinite fixed point $\rho$ of $\E_A$.  Since $A$ is
+    irreducible and the peripheral spectrum of $\E_A$ is $\{1\}$, the
+    eigenvalue $1$ is simple, so the spectral radius of $\E_A-P_\rho$ is below
+    one; this is the complementary transfer-map gap of
+    Definition~\ref{def:primitive_mps}.  Finally, a nonzero positive
+    semidefinite fixed point of an irreducible transfer map is positive
+    definite, since the projection onto its kernel would otherwise be a
+    nontrivial invariant projection of $\E_A$.
+\end{proof}
+
 \begin{lemma}[Primitive tensors with positive-definite fixed point are strongly irreducible]%
     \label{lem:strongly_irred_from_primitive}
     \lean{MPSTensor.isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_all_chain_sector_graph.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_all_chain_sector_graph.tex
@@ -22,7 +22,6 @@
     \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState_two_eq_twoSiteAmplitude}
-    \lean{MPSTensor.trace_gauge_boundary}
     \lean{MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.groundSpace_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_all_chain_sector_graph.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_all_chain_sector_graph.tex
@@ -23,8 +23,6 @@
     \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState_two_eq_twoSiteAmplitude}
     \lean{MPSTensor.trace_gauge_boundary}
-    \lean{MPSTensor.GaugeEquiv.groundSpace_le}
-    \lean{MPSTensor.GaugeEquiv.groundSpace_eq}
     \lean{MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.groundSpace_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4645,7 +4645,7 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{def:parent_interaction, def:local_term_parent,
+    \uses{def:ground_space_es, def:parent_interaction, def:local_term_parent,
         def:parent_hamiltonian, def:parent_hamiltonian_es}
     The parent interaction at length $L$ is the orthogonal projector onto
     $G_L(A)^\perp$, so it depends on $G_L(A)$ alone.  Every translated local
@@ -4721,8 +4721,8 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 \begin{proof}
     \leanok
     \uses{thm:normal_irreducible_tensor,
-        cor:normalized_normal_strongly_irreducible,
-        lem:primitive_from_strongly_irred,
+        thm:normalized_normal_strongly_irreducible,
+        thm:primitive_from_strongly_irred,
         thm:normality_rescaling_invariance,
         thm:local_ground_space_rescaling, thm:normal_tensor_nonzero_matrix,
         thm:tp_data_irreducible, thm:gauge_invariance_normal,
@@ -4742,9 +4742,9 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     Theorem~\ref{thm:normality_rescaling_invariance} and gauging preserves it
     by Theorem~\ref{thm:gauge_invariance_normal}, so $B$ is normal.  Since $B$
     is trace preserving,
-    Corollary~\ref{cor:normalized_normal_strongly_irreducible} makes $B$
+    Theorem~\ref{thm:normalized_normal_strongly_irreducible} makes $B$
     strongly irreducible, and
-    Lemma~\ref{lem:primitive_from_strongly_irred} then returns a positive
+    Theorem~\ref{thm:primitive_from_strongly_irred} then returns a positive
     definite $\rho$ with $(B,\rho)$ primitive.  Gauge equivalence
     leaves the matrix product vectors unchanged by
     Theorem~\ref{thm:gauge_invariance}, and multiplying every matrix by

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4614,8 +4614,8 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     \end{align}
     for every chain length $N$ and every configuration $\sigma$.  Moreover
     \begin{align}
-        G_L(A)          & =G_L(B),                         \\
-        h_L(A)          & =h_L(B),                         \\
+        G_L(A)              & =G_L(B),             \\
+        h_L(A)              & =h_L(B),             \\
         \mathcal G_{N,L}(A) & =\mathcal G_{N,L}(B)
     \end{align}
     for all $L$ and $N$, where $h_L$ is the canonical parent interaction and

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4537,8 +4537,8 @@ assuming that the transfer map has spectral radius one and gauging by the
 square root of a positive fixed point.  This section carries out that step and
 uses it to state the finite-range gap for an arbitrary normal tensor.
 
-\begin{lemma}[Rescaling invariance of block injectivity and normality]
-    \label{lem:normality_rescaling_invariance}
+\begin{theorem}[Rescaling invariance of block injectivity and normality]
+    \label{thm:normality_rescaling_invariance}
     \lean{MPSTensor.wordSpan_smul_eq, MPSTensor.isNBlkInjective_smul_iff,
         MPSTensor.isNormal_smul_iff}
     \leanok
@@ -4546,34 +4546,50 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     Let $\zeta\neq0$ and let $A$ be a tensor.  For every $N$ the length-$N$
     word spans of $A$ and of $\zeta A$ agree, so $\zeta A$ is $N$-block
     injective exactly when $A$ is, and $\zeta A$ is normal exactly when $A$ is.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:l_blk_injective, def:normal}
     Every length-$N$ word of $\zeta A$ is the corresponding word of $A$
     multiplied by $\zeta^{N}$, and $\zeta^{N}$ is invertible, so each span
     contains the other.
 \end{proof}
 
-\begin{lemma}[Rescaling invariance of the local ground space]
-    \label{lem:local_ground_space_rescaling}
+\begin{theorem}[A normal tensor has a nonzero matrix]
+    \label{thm:normal_tensor_nonzero_matrix}
+    \lean{MPSTensor.exists_apply_ne_zero_of_isNormal}
+    \leanok
+    \uses{def:normal}
+    Let $D>0$ and let $A$ be a normal tensor.  Then $A^i\neq0$ for at least
+    one $i$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:l_blk_injective}
+    If every $A^i$ vanished, then every word of positive length would vanish,
+    so the span of the length-$N$ words would be $\{0\}$ for the length $N>0$
+    at which $A$ is block injective.  That span is $\MN{D}$, which contains
+    $\Id\neq0$ because $D>0$.
+\end{proof}
+
+\begin{theorem}[Rescaling invariance of the local ground space]
+    \label{thm:local_ground_space_rescaling}
     \lean{MPSTensor.groundSpace_smul_eq}
     \leanok
     \uses{def:ground_space_parent}
     Let $\zeta\neq0$.  For every $L$ one has $G_L(\zeta A)=G_L(A)$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:ground_space_parent}
     The boundary parametrization of $\zeta A$ at length $L$ sends $X$ to the
     value of the boundary parametrization of $A$ at $\zeta^{L}X$, and
     multiplication by $\zeta^{L}$ is a bijection of $\MN{D}$.
 \end{proof}
 
-\begin{lemma}[Local ground spaces determine the parent Hamiltonian]
-    \label{lem:parent_hamiltonian_from_ground_space}
+\begin{theorem}[Local ground spaces determine the parent Hamiltonian]
+    \label{thm:parent_hamiltonian_from_ground_space}
     \lean{MPSTensor.parentInteraction_eq_of_groundSpace_eq,
         MPSTensor.localTerm_eq_of_parentInteraction_eq,
         MPSTensor.parentHamiltonian_eq_of_groundSpace_eq,
@@ -4586,12 +4602,12 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     all their translated local terms and their parent Hamiltonians
     $H_{N,L}(A)=H_{N,L}(B)$ and $H_{N,L}^{\mathrm{ES}}(A)
         =H_{N,L}^{\mathrm{ES}}(B)$ on every periodic chain.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:ground_space_parent, def:parent_interaction,
-        def:parent_hamiltonian, def:parent_hamiltonian_es}
+    \uses{def:parent_interaction, def:parent_hamiltonian,
+        def:parent_hamiltonian_es}
     The parent interaction at length $L$ is the orthogonal projector onto
     $G_L(A)^\perp$, so it depends on $G_L(A)$ alone.  Every translated local
     term is built from that single projector, and the parent Hamiltonian is
@@ -4604,20 +4620,19 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     \leanok
     \uses{def:normal, def:primitive_mps, def:gauge_equiv, def:mpv,
         def:ground_space_parent, def:parent_interaction,
-        def:chain_ground_space, thm:wielandt_proposition_three,
-        lem:normality_rescaling_invariance, lem:local_ground_space_rescaling}
+        def:chain_ground_space}
     Let $D>0$ and let $A$ be a normal tensor.  There exist a scalar
     $\zeta\neq0$, a tensor $B$, and a matrix $\rho>0$ such that $\zeta A$ and
     $B$ are gauge equivalent, the pair $(B,\rho)$ is primitive, and
     \begin{align}
         V^{(N)}(B)_{\sigma}
-         & =\zeta^{N}V^{(N)}(A)_{\sigma}
+         & =\zeta^{N}V^{(N)}(A)_{\sigma} \notag
     \end{align}
     for every chain length $N$ and every configuration $\sigma$.  Moreover
     \begin{align}
-        G_L(A)              & =G_L(B),             \\
-        h_L(A)              & =h_L(B),             \\
-        \mathcal G_{N,L}(A) & =\mathcal G_{N,L}(B)
+        G_L(A)              & =G_L(B), \notag             \\
+        h_L(A)              & =h_L(B), \notag             \\
+        \mathcal G_{N,L}(A) & =\mathcal G_{N,L}(B) \notag
     \end{align}
     for all $L$ and $N$, where $h_L$ is the canonical parent interaction and
     $\mathcal G_{N,L}$ the periodic chain ground space.
@@ -4638,29 +4653,36 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{thm:wielandt_proposition_three, lem:normality_rescaling_invariance,
-        lem:local_ground_space_rescaling}
+    \uses{thm:wielandt_proposition_three, thm:normality_rescaling_invariance,
+        thm:local_ground_space_rescaling, thm:normal_tensor_nonzero_matrix,
+        thm:tp_data_irreducible, thm:gauge_invariance_normal,
+        thm:parent_hamiltonian_from_ground_space,
+        lem:parent_spanning_of_local_space_eq}
     Normality gives the uniform spreading condition, hence irreducibility of
-    the transfer map, so the adjoint transfer map has a positive definite
-    Perron eigenvector $\sigma$ with eigenvalue $r>0$.  Set
-    $\zeta=r^{-1/2}$ and $B^i=\zeta\,\sigma^{1/2}A^i\sigma^{-1/2}$; then
-    $\sum_i(B^i)^\dagger B^i=\Id$, and $\zeta A$ and $B$ are gauge equivalent.
-    Rescaling and gauging preserve normality, so $B$ is normal, and the
+    the transfer map, and Theorem~\ref{thm:normal_tensor_nonzero_matrix}
+    supplies the nonzero matrix that the Perron--Frobenius eigenvector
+    requires.  Theorem~\ref{thm:tp_data_irreducible} therefore returns a
+    positive definite $\sigma$ and an eigenvalue $r>0$ of the adjoint transfer
+    map.  Set $\zeta=r^{-1/2}$ and $B^i=\zeta\,\sigma^{1/2}A^i\sigma^{-1/2}$;
+    then $\sum_i(B^i)^\dagger B^i=\Id$, and $\zeta A$ and $B$ are gauge
+    equivalent.  Rescaling preserves normality by
+    Theorem~\ref{thm:normality_rescaling_invariance} and gauging preserves it
+    by Theorem~\ref{thm:gauge_invariance_normal}, so $B$ is normal, and the
     equivalence of the three primitivity conditions returns a positive definite
     $\rho$ with $(B,\rho)$ primitive.  Multiplying every matrix by $\zeta$
-    multiplies every length-$N$ coefficient by $\zeta^{N}$, and by the two
-    preceding rescaling lemmas together with gauge invariance of the local
-    ground space, $G_L(A)=G_L(\zeta A)=G_L(B)$; the parent interaction and the
-    periodic chain ground space are functions of the local ground space alone.
+    multiplies every length-$N$ coefficient by $\zeta^{N}$, and by
+    Theorem~\ref{thm:local_ground_space_rescaling} together with gauge
+    invariance of the local ground space, $G_L(A)=G_L(\zeta A)=G_L(B)$.  The
+    parent interaction then agrees by
+    Theorem~\ref{thm:parent_hamiltonian_from_ground_space} and the periodic
+    chain ground space by Lemma~\ref{lem:parent_spanning_of_local_space_eq}.
 \end{proof}
 
 \begin{theorem}[Uniform finite-range gap for normal MPS parent Hamiltonians]
     \label{thm:normal_parent_hamiltonian_finite_range_knabe_gap}
-    \lean{MPSTensor.IsNormal.exists_parentHamiltonianES_gap}
+    \lean{MPSTensor.exists_parentHamiltonianES_gap_of_isNormal}
     \leanok
-    \uses{def:normal, thm:normalized_primitive_gauge,
-        thm:primitive_parent_hamiltonian_finite_range_knabe_gap,
-        lem:parent_hamiltonian_from_ground_space}
+    \uses{def:normal, def:l_blk_injective, def:parent_hamiltonian_es}
     Let $D>0$ and let $A$ be a normal tensor.  There exist $l>1$,
     $\epsilon_l\geq0$, an integer $m\geq l+1$, and $\delta>0$ such that $A$ is
     $l$-block injective, $\epsilon_l<1/\sqrt{l+1}$,
@@ -4688,15 +4710,19 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     \leanok
     \uses{thm:normalized_primitive_gauge,
         thm:primitive_parent_hamiltonian_finite_range_knabe_gap,
-        lem:parent_hamiltonian_from_ground_space,
-        lem:normality_rescaling_invariance}
+        thm:parent_hamiltonian_from_ground_space,
+        thm:normality_rescaling_invariance,
+        lem:gauge_invariance_block_injective}
     Replace $A$ by the normalized primitive representative $B$ of
     Theorem~\ref{thm:normalized_primitive_gauge} and apply
     Theorem~\ref{thm:primitive_parent_hamiltonian_finite_range_knabe_gap} to
-    $B$.  Since $G_L(A)=G_L(B)$ for every $L$, the two parent Hamiltonians
-    coincide, so both the kernel and the norm bound transfer verbatim.  Block
-    injectivity of $B$ at length $l$ returns to $A$ through the gauge and the
-    rescaling.
+    $B$.  Since $G_L(A)=G_L(B)$ for every $L$,
+    Theorem~\ref{thm:parent_hamiltonian_from_ground_space} makes the two
+    parent Hamiltonians equal, so both the kernel and the norm bound transfer
+    verbatim.  Block injectivity of $B$ at length $l$ passes to $\zeta A$ by
+    Lemma~\ref{lem:gauge_invariance_block_injective} applied to the inverse
+    gauge, and from $\zeta A$ to $A$ by
+    Theorem~\ref{thm:normality_rescaling_invariance}.
 \end{proof}
 
 \begin{lemma}[Positive gap transfer under Loewner domination]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4528,9 +4528,10 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
 
 A normal tensor carries neither the trace-preserving normalization nor a
 positive definite fixed point of its transfer map.  Both are supplied without
-loss of generality by the sources: \cite[equations~(3.1)--(3.2b),
-lines~1394--1435]{Nachtergaele1996Spectral} rewrites the generalized
-valence-bond construction so that the two normalizations hold, and
+loss of generality by the sources:
+\cite[equations~(3.1)--(3.2b), lines~1394--1435]{Nachtergaele1996Spectral}
+rewrites the generalized valence-bond construction so that the two
+normalizations hold, and
 \cite[Theorem~4, lines~742--770]{PerezGarcia2007Matrix} opens its proof by
 assuming that the transfer map has spectral radius one and gauging by the
 square root of a positive fixed point.  This section carries out that step and

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4574,6 +4574,26 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     $\Id\neq0$ because $D>0$.
 \end{proof}
 
+\begin{theorem}[Gauge invariance of the local ground space]
+    \label{thm:local_ground_space_gauge_invariance}
+    \lean{MPSTensor.GaugeEquiv.groundSpace_le,
+        MPSTensor.GaugeEquiv.groundSpace_eq}
+    \leanok
+    \uses{def:gauge_equiv, def:ground_space_parent}
+    Let $A$ and $B$ be gauge equivalent.  For every $L$ one has
+    $G_L(A)=G_L(B)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:gauge_invariance}
+    If $B^i=XA^iX^{-1}$, then every length-$L$ word of $B$ is the conjugate
+    of the corresponding word of $A$, so the boundary parametrization of $B$
+    at $Y$ agrees with that of $A$ at $X^{-1}YX$, and conjugation by $X$ is a
+    bijection of $\MN{D}$.  This gives $G_L(B)\subseteq G_L(A)$, and the
+    symmetric argument gives the reverse inclusion.
+\end{proof}
+
 \begin{theorem}[Rescaling invariance of the local ground space]
     \label{thm:local_ground_space_rescaling}
     \lean{MPSTensor.groundSpace_smul_eq}
@@ -4608,8 +4628,8 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{def:parent_interaction, def:parent_hamiltonian,
-        def:parent_hamiltonian_es}
+    \uses{def:parent_interaction, def:local_term_parent,
+        def:parent_hamiltonian, def:parent_hamiltonian_es}
     The parent interaction at length $L$ is the orthogonal projector onto
     $G_L(A)^\perp$, so it depends on $G_L(A)$ alone.  Every translated local
     term is built from that single projector, and the parent Hamiltonian is
@@ -4682,7 +4702,8 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
         thm:normality_rescaling_invariance,
         thm:local_ground_space_rescaling, thm:normal_tensor_nonzero_matrix,
         thm:tp_data_irreducible, thm:gauge_invariance_normal,
-        thm:gauge_invariance, lem:eval_word_smul,
+        thm:gauge_invariance, thm:local_ground_space_gauge_invariance,
+        lem:eval_word_smul,
         thm:parent_hamiltonian_from_ground_space,
         lem:parent_spanning_of_local_space_eq}
     Theorem~\ref{thm:normal_irreducible_transfer} makes the transfer map of

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4550,6 +4550,7 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
+    \uses{lem:eval_word_smul}
     Every length-$N$ word of $\zeta A$ is the corresponding word of $A$
     multiplied by $\zeta^{N}$, and $\zeta^{N}$ is invertible, so each span
     contains the other.
@@ -4583,6 +4584,7 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
+    \uses{lem:eval_word_smul}
     The boundary parametrization of $\zeta A$ at length $L$ sends $X$ to the
     value of the boundary parametrization of $A$ at $\zeta^{L}X$, and
     multiplication by $\zeta^{L}$ is a bijection of $\MN{D}$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4542,7 +4542,7 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     \lean{MPSTensor.wordSpan_smul_eq, MPSTensor.isNBlkInjective_smul_iff,
         MPSTensor.isNormal_smul_iff}
     \leanok
-    \uses{def:l_blk_injective, def:normal}
+    \uses{def:word_span, def:l_blk_injective, def:normal}
     Let $\zeta\neq0$ and let $A$ be a tensor.  For every $N$ the length-$N$
     word spans of $A$ and of $\zeta A$ agree, so $\zeta A$ is $N$-block
     injective exactly when $A$ is, and $\zeta A$ is normal exactly when $A$ is.
@@ -4653,15 +4653,18 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     their sum.
 \end{proof}
 
-\begin{theorem}[Normality alone gives an irreducible transfer map]
-    \label{thm:normal_irreducible_transfer}
+\begin{theorem}[Normality alone gives an irreducible tensor]
+    \label{thm:normal_irreducible_tensor}
     \lean{MPSTensor.isPrimitivePaper_of_isNormal,
         MPSTensor.isIrreducibleTensor_of_isPrimitivePaper}
     \leanok
-    \uses{def:normal, def:paper_primitive, def:irreducible_tensor}
+    \uses{def:normal, def:paper_primitive, def:has_inv_proj,
+        def:irreducible_tensor}
     Let $A$ be a normal tensor.  Then $A$ is primitive in the sense of
-    Definition~\ref{def:paper_primitive}, and its transfer map has no
-    nontrivial invariant projection.  No normalization is imposed on $A$.
+    Definition~\ref{def:paper_primitive}, and $A$ has no nontrivial invariant
+    projection, so $A$ is irreducible in the sense of
+    Definition~\ref{def:irreducible_tensor}.  No normalization is imposed on
+    $A$.
 \end{theorem}
 
 \begin{proof}
@@ -4717,7 +4720,9 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{thm:normal_irreducible_transfer, thm:wielandt_proposition_three,
+    \uses{thm:normal_irreducible_tensor,
+        cor:normalized_normal_strongly_irreducible,
+        lem:primitive_from_strongly_irred,
         thm:normality_rescaling_invariance,
         thm:local_ground_space_rescaling, thm:normal_tensor_nonzero_matrix,
         thm:tp_data_irreducible, thm:gauge_invariance_normal,
@@ -4725,8 +4730,8 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
         lem:eval_word_smul,
         thm:parent_hamiltonian_from_ground_space,
         lem:parent_spanning_of_local_space_eq}
-    Theorem~\ref{thm:normal_irreducible_transfer} makes the transfer map of
-    $A$ irreducible, with no normalization imposed on $A$, and
+    Theorem~\ref{thm:normal_irreducible_tensor} makes $A$ an irreducible
+    tensor, with no normalization imposed on $A$, and
     Theorem~\ref{thm:normal_tensor_nonzero_matrix} supplies the nonzero matrix
     that the Perron--Frobenius eigenvector requires.
     Theorem~\ref{thm:tp_data_irreducible} therefore returns a
@@ -4736,9 +4741,11 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     equivalent.  Rescaling preserves normality by
     Theorem~\ref{thm:normality_rescaling_invariance} and gauging preserves it
     by Theorem~\ref{thm:gauge_invariance_normal}, so $B$ is normal.  Since $B$
-    is trace preserving, the equivalence of the three primitivity conditions,
-    Theorem~\ref{thm:wielandt_proposition_three}, applies to it and returns a
-    positive definite $\rho$ with $(B,\rho)$ primitive.  Gauge equivalence
+    is trace preserving,
+    Corollary~\ref{cor:normalized_normal_strongly_irreducible} makes $B$
+    strongly irreducible, and
+    Lemma~\ref{lem:primitive_from_strongly_irred} then returns a positive
+    definite $\rho$ with $(B,\rho)$ primitive.  Gauge equivalence
     leaves the matrix product vectors unchanged by
     Theorem~\ref{thm:gauge_invariance}, and multiplying every matrix by
     $\zeta$ multiplies every length-$N$ word by $\zeta^{N}$ by

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4524,6 +4524,180 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
     (\ref{eq:primitive_finite_range_knabe_gap}).
 \end{proof}
 
+\section{The normalized primitive gauge of a normal tensor}
+
+A normal tensor carries neither the trace-preserving normalization nor a
+positive definite fixed point of its transfer map.  Both are supplied without
+loss of generality by the sources: \cite[equations~(3.1)--(3.2b),
+lines~1394--1435]{Nachtergaele1996Spectral} rewrites the generalized
+valence-bond construction so that the two normalizations hold, and
+\cite[Theorem~4, lines~742--770]{PerezGarcia2007Matrix} opens its proof by
+assuming that the transfer map has spectral radius one and gauging by the
+square root of a positive fixed point.  This section carries out that step and
+uses it to state the finite-range gap for an arbitrary normal tensor.
+
+\begin{lemma}[Rescaling invariance of block injectivity and normality]
+    \label{lem:normality_rescaling_invariance}
+    \lean{MPSTensor.wordSpan_smul_eq, MPSTensor.isNBlkInjective_smul_iff,
+        MPSTensor.isNormal_smul_iff}
+    \leanok
+    \uses{def:l_blk_injective, def:normal}
+    Let $\zeta\neq0$ and let $A$ be a tensor.  For every $N$ the length-$N$
+    word spans of $A$ and of $\zeta A$ agree, so $\zeta A$ is $N$-block
+    injective exactly when $A$ is, and $\zeta A$ is normal exactly when $A$ is.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:l_blk_injective, def:normal}
+    Every length-$N$ word of $\zeta A$ is the corresponding word of $A$
+    multiplied by $\zeta^{N}$, and $\zeta^{N}$ is invertible, so each span
+    contains the other.
+\end{proof}
+
+\begin{lemma}[Rescaling invariance of the local ground space]
+    \label{lem:local_ground_space_rescaling}
+    \lean{MPSTensor.groundSpace_smul_eq}
+    \leanok
+    \uses{def:ground_space_parent}
+    Let $\zeta\neq0$.  For every $L$ one has $G_L(\zeta A)=G_L(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_parent}
+    The boundary parametrization of $\zeta A$ at length $L$ sends $X$ to the
+    value of the boundary parametrization of $A$ at $\zeta^{L}X$, and
+    multiplication by $\zeta^{L}$ is a bijection of $\MN{D}$.
+\end{proof}
+
+\begin{lemma}[Local ground spaces determine the parent Hamiltonian]
+    \label{lem:parent_hamiltonian_from_ground_space}
+    \lean{MPSTensor.parentInteraction_eq_of_groundSpace_eq,
+        MPSTensor.localTerm_eq_of_parentInteraction_eq,
+        MPSTensor.parentHamiltonian_eq_of_groundSpace_eq,
+        MPSTensor.parentHamiltonianES_eq_of_groundSpace_eq}
+    \leanok
+    \uses{def:ground_space_parent, def:parent_interaction,
+        def:parent_hamiltonian, def:parent_hamiltonian_es}
+    Let $A$ and $B$ have the same bond dimension and satisfy $G_L(A)=G_L(B)$.
+    Then their canonical parent interactions at length $L$ agree, hence so do
+    all their translated local terms and their parent Hamiltonians
+    $H_{N,L}(A)=H_{N,L}(B)$ and $H_{N,L}^{\mathrm{ES}}(A)
+        =H_{N,L}^{\mathrm{ES}}(B)$ on every periodic chain.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_parent, def:parent_interaction,
+        def:parent_hamiltonian, def:parent_hamiltonian_es}
+    The parent interaction at length $L$ is the orthogonal projector onto
+    $G_L(A)^\perp$, so it depends on $G_L(A)$ alone.  Every translated local
+    term is built from that single projector, and the parent Hamiltonian is
+    their sum.
+\end{proof}
+
+\begin{theorem}[Normalized primitive gauge of a normal tensor]
+    \label{thm:normalized_primitive_gauge}
+    \lean{MPSTensor.exists_isPrimitiveMPS_gauge_of_isNormal}
+    \leanok
+    \uses{def:normal, def:primitive_mps, def:gauge_equiv, def:mpv,
+        def:ground_space_parent, def:parent_interaction,
+        def:chain_ground_space, thm:wielandt_proposition_three,
+        lem:normality_rescaling_invariance, lem:local_ground_space_rescaling}
+    Let $D>0$ and let $A$ be a normal tensor.  There exist a scalar
+    $\zeta\neq0$, a tensor $B$, and a matrix $\rho>0$ such that $\zeta A$ and
+    $B$ are gauge equivalent, the pair $(B,\rho)$ is primitive, and
+    \begin{align}
+        V^{(N)}(B)_{\sigma}
+         & =\zeta^{N}V^{(N)}(A)_{\sigma}
+    \end{align}
+    for every chain length $N$ and every configuration $\sigma$.  Moreover
+    \begin{align}
+        G_L(A)          & =G_L(B),                         \\
+        h_L(A)          & =h_L(B),                         \\
+        \mathcal G_{N,L}(A) & =\mathcal G_{N,L}(B)
+    \end{align}
+    for all $L$ and $N$, where $h_L$ is the canonical parent interaction and
+    $\mathcal G_{N,L}$ the periodic chain ground space.
+
+    This is the normalization taken without loss of generality in
+    \cite[equations~(3.1)--(3.2b), lines~1394--1435]{Nachtergaele1996Spectral}
+    and at the start of the proof of
+    \cite[Theorem~4, lines~765--770]{PerezGarcia2007Matrix}.  The gauge here is
+    built from the Perron eigenvector of the adjoint transfer map, giving the
+    trace-preserving orientation.  That orientation is what conditions~1 and~2
+    of \cite[Theorem~4, lines~752--758]{PerezGarcia2007Matrix},
+    $\sum_iA^i(A^i)^\dagger=\Id$ and $\sum_i(A^i)^\dagger\Lambda A^i=\Lambda$
+    with $\Lambda>0$, become after the further gauge by $\Lambda^{1/2}$:
+    condition~2 turns into $\sum_i(B^i)^\dagger B^i=\Id$ and condition~1 into
+    the statement that $\Lambda$ is a positive definite fixed point of the
+    transfer map of $B$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wielandt_proposition_three, lem:normality_rescaling_invariance,
+        lem:local_ground_space_rescaling}
+    Normality gives the uniform spreading condition, hence irreducibility of
+    the transfer map, so the adjoint transfer map has a positive definite
+    Perron eigenvector $\sigma$ with eigenvalue $r>0$.  Set
+    $\zeta=r^{-1/2}$ and $B^i=\zeta\,\sigma^{1/2}A^i\sigma^{-1/2}$; then
+    $\sum_i(B^i)^\dagger B^i=\Id$, and $\zeta A$ and $B$ are gauge equivalent.
+    Rescaling and gauging preserve normality, so $B$ is normal, and the
+    equivalence of the three primitivity conditions returns a positive definite
+    $\rho$ with $(B,\rho)$ primitive.  Multiplying every matrix by $\zeta$
+    multiplies every length-$N$ coefficient by $\zeta^{N}$, and by the two
+    preceding rescaling lemmas together with gauge invariance of the local
+    ground space, $G_L(A)=G_L(\zeta A)=G_L(B)$; the parent interaction and the
+    periodic chain ground space are functions of the local ground space alone.
+\end{proof}
+
+\begin{theorem}[Uniform finite-range gap for normal MPS parent Hamiltonians]
+    \label{thm:normal_parent_hamiltonian_finite_range_knabe_gap}
+    \lean{MPSTensor.IsNormal.exists_parentHamiltonianES_gap}
+    \leanok
+    \uses{def:normal, thm:normalized_primitive_gauge,
+        thm:primitive_parent_hamiltonian_finite_range_knabe_gap,
+        lem:parent_hamiltonian_from_ground_space}
+    Let $D>0$ and let $A$ be a normal tensor.  There exist $l>1$,
+    $\epsilon_l\geq0$, an integer $m\geq l+1$, and $\delta>0$ such that $A$ is
+    $l$-block injective, $\epsilon_l<1/\sqrt{l+1}$,
+    \begin{align}
+        \delta
+         & =\frac{m\left(1-\epsilon_l\sqrt{l+1}\right)^2-l^2}{m-l},
+        \label{eq:normal_finite_range_knabe_delta}
+    \end{align}
+    and, for every $N\geq2m$ and every
+    $v\in(\ker H_{N,l+1}^{\mathrm{ES}}(A))^\perp$,
+    \begin{align}
+        \delta\lVert v\rVert
+         & \leq\left\lVert H_{N,l+1}^{\mathrm{ES}}(A)v\right\rVert.
+        \label{eq:normal_finite_range_knabe_gap}
+    \end{align}
+    No normalization is imposed on $A$.  The uniform gap of matrix product
+    state parent Hamiltonians is asserted at
+    \cite[lines~2183--2187]{Cirac2021Matrix}; the arbitrary finite-range
+    coefficient (\ref{eq:normal_finite_range_knabe_delta}) is the derivation
+    recorded in
+    \path{docs/paper-gaps/knabe88_finite_range_coefficient.tex}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:normalized_primitive_gauge,
+        thm:primitive_parent_hamiltonian_finite_range_knabe_gap,
+        lem:parent_hamiltonian_from_ground_space,
+        lem:normality_rescaling_invariance}
+    Replace $A$ by the normalized primitive representative $B$ of
+    Theorem~\ref{thm:normalized_primitive_gauge} and apply
+    Theorem~\ref{thm:primitive_parent_hamiltonian_finite_range_knabe_gap} to
+    $B$.  Since $G_L(A)=G_L(B)$ for every $L$, the two parent Hamiltonians
+    coincide, so both the kernel and the norm bound transfer verbatim.  Block
+    injectivity of $B$ at length $l$ returns to $A$ through the gauge and the
+    rescaling.
+\end{proof}
+
 \begin{lemma}[Positive gap transfer under Loewner domination]
     \label{lem:positive_gap_transfer_loewner}
     \lean{LinearMap.IsPositive.re_inner_ge_of_norm_gap,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4574,6 +4574,22 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     $\Id\neq0$ because $D>0$.
 \end{proof}
 
+\begin{lemma}[Trace pairing of a conjugated word against a boundary matrix]
+    \label{lem:trace_gauge_boundary}
+    \lean{MPSTensor.trace_gauge_boundary}
+    \leanok
+    Let $X$ be invertible and let $E$ and $Y$ be $D\times D$ matrices.  Then
+    \begin{align}
+        \tr\bigl(XEX^{-1}Y\bigr) & =\tr\bigl(E\,X^{-1}YX\bigr). \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Cyclicity of the trace moves the leading factor $X$ to the end of the
+    product.
+\end{proof}
+
 \begin{theorem}[Gauge invariance of the local ground space]
     \label{thm:local_ground_space_gauge_invariance}
     \lean{MPSTensor.GaugeEquiv.groundSpace_le,
@@ -4586,12 +4602,13 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{thm:gauge_invariance}
-    If $B^i=XA^iX^{-1}$, then every length-$L$ word of $B$ is the conjugate
-    of the corresponding word of $A$, so the boundary parametrization of $B$
-    at $Y$ agrees with that of $A$ at $X^{-1}YX$, and conjugation by $X$ is a
-    bijection of $\MN{D}$.  This gives $G_L(B)\subseteq G_L(A)$, and the
-    symmetric argument gives the reverse inclusion.
+    \uses{lem:eval_word_gauge, lem:trace_gauge_boundary}
+    If $B^i=XA^iX^{-1}$, then $B^\sigma=XA^\sigma X^{-1}$ for every length-$L$
+    configuration $\sigma$ by Lemma~\ref{lem:eval_word_gauge}, so by
+    Lemma~\ref{lem:trace_gauge_boundary} the boundary parametrization of $B$
+    at $Y$ agrees with that of $A$ at $X^{-1}YX$.  This gives
+    $G_L(B)\subseteq G_L(A)$, and the symmetric argument applied to
+    $A^i=X^{-1}B^iX$ gives the reverse inclusion.
 \end{proof}
 
 \begin{theorem}[Rescaling invariance of the local ground space]
@@ -4673,7 +4690,9 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
         V^{(N)}(B)_{\sigma}
          & =\zeta^{N}V^{(N)}(A)_{\sigma} \notag
     \end{align}
-    for every chain length $N$ and every configuration $\sigma$.  Moreover
+    for every chain length $N$ and every configuration $\sigma$.  The local
+    ground spaces, the parent interactions, and the periodic chain ground
+    spaces of $A$ and $B$ also coincide:
     \begin{align}
         G_L(A)              & =G_L(B), \notag             \\
         h_L(A)              & =h_L(B), \notag             \\

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -4526,9 +4526,9 @@ $d_{l+1}=\gamma_{l+1}=1$ and the same $\epsilon_l$ as in the source.
 
 \section{The normalized primitive gauge of a normal tensor}
 
-A normal tensor carries neither the trace-preserving normalization nor a
-positive definite fixed point of its transfer map.  Both are supplied without
-loss of generality by the sources:
+A normal tensor need not carry the trace-preserving normalization, nor need its
+transfer map have spectral radius one; normality alone forces neither.  Both
+normalizations are supplied without loss of generality by the sources:
 \cite[equations~(3.1)--(3.2b), lines~1394--1435]{Nachtergaele1996Spectral}
 rewrites the generalized valence-bond construction so that the two
 normalizations hold, and
@@ -4614,6 +4614,29 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
     their sum.
 \end{proof}
 
+\begin{theorem}[Normality alone gives an irreducible transfer map]
+    \label{thm:normal_irreducible_transfer}
+    \lean{MPSTensor.isPrimitivePaper_of_isNormal,
+        MPSTensor.isIrreducibleTensor_of_isPrimitivePaper}
+    \leanok
+    \uses{def:normal, def:paper_primitive, def:irreducible_tensor}
+    Let $A$ be a normal tensor.  Then $A$ is primitive in the sense of
+    Definition~\ref{def:paper_primitive}, and its transfer map has no
+    nontrivial invariant projection.  No normalization is imposed on $A$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:eventually_full_kraus_rank, rem:wolf_6_8_pairwise}
+    Normality is eventual full Kraus rank
+    (Remark~\ref{rem:wolf_6_8_pairwise}), so $S_N(A)=\MN{D}$ for some $N>0$.
+    Applying the length-$N$ words to a nonzero $\varphi$ then spans $\C^D$,
+    which is the spreading condition.  A subspace invariant under all matrices
+    of $A$ and containing a nonzero vector therefore contains the span of the
+    images of that vector, namely all of $\C^D$; so no invariant projection is
+    nontrivial.
+\end{proof}
+
 \begin{theorem}[Normalized primitive gauge of a normal tensor]
     \label{thm:normalized_primitive_gauge}
     \lean{MPSTensor.exists_isPrimitiveMPS_gauge_of_isNormal}
@@ -4653,24 +4676,32 @@ uses it to state the finite-range gap for an arbitrary normal tensor.
 
 \begin{proof}
     \leanok
-    \uses{thm:wielandt_proposition_three, thm:normality_rescaling_invariance,
+    \uses{thm:normal_irreducible_transfer, thm:wielandt_proposition_three,
+        thm:normality_rescaling_invariance,
         thm:local_ground_space_rescaling, thm:normal_tensor_nonzero_matrix,
         thm:tp_data_irreducible, thm:gauge_invariance_normal,
+        thm:gauge_invariance, lem:eval_word_smul,
         thm:parent_hamiltonian_from_ground_space,
         lem:parent_spanning_of_local_space_eq}
-    Normality gives the uniform spreading condition, hence irreducibility of
-    the transfer map, and Theorem~\ref{thm:normal_tensor_nonzero_matrix}
-    supplies the nonzero matrix that the Perron--Frobenius eigenvector
-    requires.  Theorem~\ref{thm:tp_data_irreducible} therefore returns a
+    Theorem~\ref{thm:normal_irreducible_transfer} makes the transfer map of
+    $A$ irreducible, with no normalization imposed on $A$, and
+    Theorem~\ref{thm:normal_tensor_nonzero_matrix} supplies the nonzero matrix
+    that the Perron--Frobenius eigenvector requires.
+    Theorem~\ref{thm:tp_data_irreducible} therefore returns a
     positive definite $\sigma$ and an eigenvalue $r>0$ of the adjoint transfer
     map.  Set $\zeta=r^{-1/2}$ and $B^i=\zeta\,\sigma^{1/2}A^i\sigma^{-1/2}$;
     then $\sum_i(B^i)^\dagger B^i=\Id$, and $\zeta A$ and $B$ are gauge
     equivalent.  Rescaling preserves normality by
     Theorem~\ref{thm:normality_rescaling_invariance} and gauging preserves it
-    by Theorem~\ref{thm:gauge_invariance_normal}, so $B$ is normal, and the
-    equivalence of the three primitivity conditions returns a positive definite
-    $\rho$ with $(B,\rho)$ primitive.  Multiplying every matrix by $\zeta$
-    multiplies every length-$N$ coefficient by $\zeta^{N}$, and by
+    by Theorem~\ref{thm:gauge_invariance_normal}, so $B$ is normal.  Since $B$
+    is trace preserving, the equivalence of the three primitivity conditions,
+    Theorem~\ref{thm:wielandt_proposition_three}, applies to it and returns a
+    positive definite $\rho$ with $(B,\rho)$ primitive.  Gauge equivalence
+    leaves the matrix product vectors unchanged by
+    Theorem~\ref{thm:gauge_invariance}, and multiplying every matrix by
+    $\zeta$ multiplies every length-$N$ word by $\zeta^{N}$ by
+    Lemma~\ref{lem:eval_word_smul}, hence every length-$N$ coefficient of $B$
+    is $\zeta^{N}$ times that of $A$.  By
     Theorem~\ref{thm:local_ground_space_rescaling} together with gauge
     invariance of the local ground space, $G_L(A)=G_L(\zeta A)=G_L(B)$.  The
     parent interaction then agrees by

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -908,6 +908,27 @@ abstracted — record why, so it is not re-proposed).
 - **Notes:** the inline existential statement and its witness are removed at
   every call site; one line each.
 
+### ground-space invariance under nonzero tensor rescaling — promoted
+- **Pattern:** identify the local MPS spaces of `ζ • A` and `A` for `ζ ≠ 0`
+  by rewriting `groundSpaceMap (ζ • A) L X` as
+  `groundSpaceMap A L ((ζ ^ L) • X)`, then use multiplication by
+  `ζ ^ L` and its inverse for the two range inclusions.
+- **Seen:** three occurrences before promotion (2026-09-04): the private
+  `groundSpace_smul_eq` in
+  `TNLean/MPS/ParentHamiltonian/CoisometricReconstruction.lean`, the private
+  `groundSpace_smul_eq_of_ne_zero` in
+  `TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean` (both 2026-08-31), and
+  the normalized primitive gauge of a normal tensor in
+  `TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean`.
+- **Abstraction:** `MPSTensor.groundSpace_smul_eq` in
+  `TNLean/MPS/ParentHamiltonian/GroundSpace.lean`, placed beside
+  `MPSTensor.GaugeEquiv.groundSpace_eq` so that the scalar and the gauge half
+  of the normalization are available together.
+- **Notes:** both private copies are deleted and their call sites now pass the
+  nonzero scalar to the public theorem; the third consumer chains it with the
+  gauge half to identify the local MPS spaces of a tensor and of its
+  normalized representative.
+
 ## Completed refactors
 
 ### Appending a tuple endpoint under `List.ofFn`
@@ -2330,22 +2351,6 @@ spectral split → block extraction → MPV calculation → strict bounds
   file's scope, `TNLean/MPS/RFP/CPSVCanonicalForm.lean:124` and
   `TNLean/Channel/Determinant/HeisenbergDual.lean:103`; a follow-up sweep can retire this
   candidate once those are also converted to `norm_star`.
-
-### ground-space invariance under nonzero tensor rescaling — candidate
-- **Pattern:** identify the local MPS spaces of `ζ • A` and `A` for `ζ ≠ 0`
-  by rewriting `groundSpaceMap (ζ • A) L X` as
-  `groundSpaceMap A L ((ζ ^ L) • X)`, then use multiplication by
-  `ζ ^ L` and its inverse for the two range inclusions.
-- **Seen:** two nearly identical private lemmas:
-  `groundSpace_smul_eq` in
-  `TNLean/MPS/ParentHamiltonian/CoisometricReconstruction.lean` and
-  `groundSpace_smul_eq_of_ne_zero` in
-  `TNLean/MPS/ParentHamiltonian/CPSVOriginalRange.lean` (2026-08-31).
-- **Abstraction (proposed):** if a third consumer appears, promote one public
-  theorem beside the ground-space definitions and replace both private proofs.
-- **Notes:** the two current callers concern different reconstruction arguments,
-  and the earlier theorem is private, so neither can reuse the other without an
-  API change. This remains below the rule-of-three promotion threshold.
 
 ### closed-chain Schur factorization of a matrix product operator — candidate
 - **Pattern:** prove positivity of the operator generated on a ring by an


### PR DESCRIPTION
Closes #7677.

## What this adds

`TNLean/MPS/ParentHamiltonian/PrimitiveGaugeExistence.lean` supplies the
"without loss of generality" normalization step that the parent-Hamiltonian
gap theorems were missing.

* `MPSTensor.exists_isPrimitiveMPS_gauge_of_isNormal` — from `Kraus.IsNormal A`
  alone (plus `[NeZero D]`, which the target predicate itself requires),
  produce `ζ ≠ 0`, a tensor `B` with `GaugeEquiv (ζ • A) B`, and `ρ.PosDef`
  with `IsPrimitiveMPS B ρ`, together with
  `mpv B σ = ζ ^ N * mpv A σ`, `groundSpace A L = groundSpace B L`,
  `parentInteraction A L = parentInteraction B L`, and
  `chainGroundSpace A L N = chainGroundSpace B L N`.
* `MPSTensor.IsNormal.exists_parentHamiltonianES_gap` — the finite-range Knabe
  gap for the parent Hamiltonian of an arbitrary normal tensor, with no
  normalization hypothesis. Previously only
  `MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_of_finiteRangeKnabe`
  existed, and its `IsPrimitiveMPS` hypothesis carries
  `∑ (A i)ᴴ * A i = 1` as a structure field.

Supporting declarations: `MPSTensor.wordSpan_smul_eq`,
`MPSTensor.isNBlkInjective_smul_iff`, `MPSTensor.isNormal_smul_iff`,
`MPSTensor.exists_apply_ne_zero_of_isNormal`,
`MPSTensor.parentHamiltonianES_eq_of_groundSpace_eq`.

## Source route

No new mathematics; the printed route is followed step by step.

* Normality gives the uniform spreading condition and hence irreducibility of
  the transfer map (`isPrimitivePaper_of_isNormal`,
  `isIrreducibleTensor_of_isPrimitivePaper`), which needs no normalization.
* `MPSTensor.exists_tp_data_of_irreducible` (already in the repository, citing
  arXiv:quant-ph/0608197 Theorem `Th:TIcanonical` proof lines 765--770 and Wolf
  Theorems 6.3/6.5) rescales by `r^{-1/2}` and gauges by the square root of the
  adjoint Perron eigenvector.
* Rescaling and gauging preserve normality, so Proposition 3 of
  arXiv:0909.5347 (`isNormal_implies_stronglyIrreducible`,
  `isPrimitiveMPS_of_isStronglyIrreduciblePaper`) returns the complementary
  transfer-map gap with a positive definite fixed point.
* Rescaling and gauging leave the local MPS space fixed, so the parent
  interaction, the periodic chain ground space and the parent Hamiltonian are
  literally the same operators for `A` and `B`; the gap statement transfers
  without any identification of the two tensors.

Exact source passages used:

* Nachtergaele, arXiv:cond-mat/9410110, equations (3.1)--(3.2b),
  `References/cond-mat_9410110/main.tex:1394-1435` — "without loss of
  generality we can assume that the following equations are satisfied".
* Pérez-García, Verstraete, Wolf, Cirac, arXiv:quant-ph/0608197,
  Theorem `Th:TIcanonical`, `Papers/quant-ph_0608197/MPSarchive.tex:742-761`
  (conditions 1 and 2: `∑ A_i A_i† = 1` and `∑ A_i† Λ A_i = Λ` with `Λ > 0`)
  and proof lines 765--770 ("we assume w.l.o.g. that the spectral radius of E
  is 1 ... and we denote by X a positive fixed point of E").
* Sanz, Pérez-García, Wolf, Cirac, arXiv:0909.5347, Proposition 3.
* Cirac, Pérez-García, Schuch, Verstraete, arXiv:2011.12127,
  `Papers/2011.12127/TN-Review-main.tex:2183-2187`.

The construction is the trace-preserving orientation of the printed one: the
gauge uses the Perron eigenvector of the adjoint transfer map. That orientation
is exactly what conditions 1 and 2 of `Th:TIcanonical` become after the further
gauge by `Λ^{1/2}`, so no marker is required. This is recorded in the module
docstring and in the blueprint statement.

## Faithfulness

The Lean signatures carry no hypothesis absent from the cited statements: the
only hypothesis is normality of the tensor. No `**Unfaithful:**`,
`**Scope restriction**` or `**Local fix**` marker is introduced, and no
`docs/paper-gaps/` note is needed.

## Deduplication

`groundSpace_smul_eq` existed twice as a private theorem, in
`ParentHamiltonian/CoisometricReconstruction.lean` and (under the name
`groundSpace_smul_eq_of_ne_zero`) in `ParentHamiltonian/CPSVOriginalRange.lean`.
Both copies are deleted and the single public
`MPSTensor.groundSpace_smul_eq` now lives in `ParentHamiltonian/GroundSpace.lean`
next to `GaugeEquiv.groundSpace_eq`. `GaugeEquiv.parentInteraction_eq` and
`GaugeEquiv.localTerm_eq` are now corollaries of the ground-space-level
statements `parentInteraction_eq_of_groundSpace_eq`,
`localTerm_eq_of_parentInteraction_eq` and
`parentHamiltonian_eq_of_groundSpace_eq` in `ParentHamiltonian/Basic.lean`.

## Blueprint

Added to `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex`:
`lem:normality_rescaling_invariance`, `lem:local_ground_space_rescaling`,
`lem:parent_hamiltonian_from_ground_space`, `thm:normalized_primitive_gauge`,
`thm:normal_parent_hamiltonian_finite_range_knabe_gap`, all `\leanok`.

## Verification

* `scripts/lake_build_locked.sh` (full `lake build TNLean`): green, 10511 jobs,
  no warnings on the changed modules.
* `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then
  `lake exe checkdecls blueprint/lean_decls`: green.
* `texra-blueprint bbl` and `texra-blueprint web`: no `ERROR:` lines.
* `scripts/check_reader_facing_prose.py`, `check_forbidden_lean_tokens.py`,
  `check_oversized_lean_files.py`, `check_numbered_lean_files.py`: no new
  violations.
* No `sorry`, `admit`, `axiom`, `native_decide` or `unsafeCast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
