### PR TITLE
doc(PEPS): state the nonzero virtual-leg convention behind the scalar reduction

### DIFF
--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -73,12 +73,12 @@ $$
 with the identity in the three complementary positions forces the residual
 operators $Z$, $U$, and $W$ to be scalar multiples of the identity.
 
-**Local fix (nonzero virtual legs):** the three `Nonempty` instances fix an
-arbitrary index in each leg, from which one matrix entry names the scalar. They
-encode the source's standing assumption that virtual bond spaces are
-nonzero-dimensional, which Section 3 of arXiv:1804.04964 never states and
-which does not follow from injectivity; the three residual-form definitions
-above carry no such restriction. Documented in
+**Local fix (nonzero virtual legs):** the residual forms are defined for
+arbitrary leg index sets. This scalar-recovery statement assumes each index
+set is nonempty. If one leg is empty, equality of the induced three-leg
+operators need not constrain the residual operator on the other two legs.
+The nonempty hypotheses encode the source's nonzero-dimensional virtual bond
+spaces and do not follow from injectivity. Documented in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`. -/
 theorem threeLeg_residual_forms_scalar [Nonempty α] [Nonempty β] [Nonempty γ]
     (Z : Matrix (β × γ) (β × γ) ℂ)

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -73,8 +73,13 @@ $$
 with the identity in the three complementary positions forces the residual
 operators $Z$, $U$, and $W$ to be scalar multiples of the identity.
 
-The nonempty hypotheses express the paper's standing convention that virtual
-Hilbert spaces are nonzero finite-dimensional spaces. -/
+**Local fix (nonzero virtual legs):** the three `Nonempty` instances fix an
+arbitrary index in each leg, from which one matrix entry names the scalar. They
+encode the source's standing assumption that virtual bond spaces are
+nonzero-dimensional, which Section 3 of arXiv:1804.04964 never states and
+which does not follow from injectivity; the three residual-form definitions
+above carry no such restriction. Documented in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`. -/
 theorem threeLeg_residual_forms_scalar [Nonempty α] [Nonempty β] [Nonempty γ]
     (Z : Matrix (β × γ) (β × γ) ℂ)
     (U : Matrix (α × β) (α × β) ℂ)

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -74,11 +74,14 @@ with the identity in the three complementary positions forces the residual
 operators $Z$, $U$, and $W$ to be scalar multiples of the identity.
 
 **Local fix (nonzero virtual legs):** the residual forms are defined for
-arbitrary leg index sets. This scalar-recovery statement assumes each index
-set is nonempty. If one leg is empty, equality of the induced three-leg
-operators need not constrain the residual operator on the other two legs.
-The nonempty hypotheses encode the source's nonzero-dimensional virtual bond
-spaces and do not follow from injectivity. Documented in
+arbitrary leg index sets, while this scalar-recovery statement assumes each
+index set is nonempty.  If one of them is empty, then so is
+$\alpha\times\beta\times\gamma$, both hypotheses are equalities of functions on
+an empty domain, and they hold for arbitrary $Z$, $U$, $W$: with $\alpha$
+empty, $\beta$ a one-point set and $\gamma$ a two-point set, the matrix
+$Z=\operatorname{diag}(1,2)$ satisfies both while being no multiple of the
+identity.  The nonempty hypotheses encode the source's nonzero-dimensional
+virtual bond spaces and do not follow from injectivity.  Documented in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`. -/
 theorem threeLeg_residual_forms_scalar [Nonempty α] [Nonempty β] [Nonempty γ]
     (Z : Matrix (β × γ) (β × γ) ℂ)

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -75,7 +75,14 @@ operators $Z$, $U$, and $W$ to be scalar multiples of the identity.
 
 **Local fix (nonzero virtual legs):** the residual forms are defined for
 arbitrary leg index sets, while this scalar-recovery statement assumes each
-index set is nonempty.  If one of them is empty, then so is
+index set is nonempty.  In coordinates the two hypotheses read
+$$
+  \delta_{aa'}Z_{bc,b'c'} = U_{ab,a'b'}\delta_{cc'},
+  \qquad
+  \delta_{aa'}Z_{bc,b'c'} = W_{ac,a'c'}\delta_{bb'},
+$$
+quantified over $a,a'\in\alpha$, $b,b'\in\beta$, and $c,c'\in\gamma$.  If one
+of the three index sets is empty, then so is
 $\alpha\times\beta\times\gamma$, both hypotheses are equalities of functions on
 an empty domain, and they hold for arbitrary $Z$, $U$, $W$: with $\alpha$
 empty, $\beta$ a one-point set and $\gamma$ a two-point set, the matrix

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
@@ -272,14 +272,13 @@
     \lean{TNLean.PEPS.threeLeg_residual_forms_scalar}
     \leanok
     \uses{def:peps_threeLegLeftIdentityForm, def:peps_threeLegRightIdentityForm, def:peps_threeLegMiddleIdentityForm}
-    \emph{Local fix (nonzero virtual legs).} This statement, and only this
-    statement among the four in this group, assumes that each of the three
-    virtual leg spaces is nonzero-dimensional; the three residual forms above
-    are defined without that restriction. The reduction fixes an arbitrary
-    index in each leg and reads off one matrix entry to name the scalar, so it
-    has no content on an empty leg. The assumption is the standing one of
-    \cite[Section~3]{Molnar2018NormalPEPS}, where every virtual leg carries a
-    drawn wire, and it does not follow from injectivity; it is recorded in
+    \emph{Local fix (nonzero virtual legs).} The residual forms are defined
+    for arbitrary leg index sets. This scalar-recovery statement assumes each
+    index set is nonempty. If one leg is empty, equality of the induced
+    three-leg operators need not constrain the residual operator on the other
+    two legs. The assumption records the nonzero-dimensional virtual bond
+    spaces of \cite[Section~3]{Molnar2018NormalPEPS} and does not follow from
+    injectivity; it is recorded in
     \cite{gap:peps_injective_ft_section3_route}.
 
     In the proof of the generalized two-injective-tensor comparison, applying

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
@@ -239,12 +239,6 @@
     \label{def:peps_threeLegLeftIdentityForm}
     \lean{TNLean.PEPS.threeLegLeftIdentityForm}
     \leanok
-    Throughout this group of residual forms, the three virtual leg spaces
-    $\alpha,\beta,\gamma$ are nonzero finite-dimensional spaces, as in the
-    standing convention of \cite[Section~3]{Molnar2018NormalPEPS}, where every
-    virtual leg carries a drawn wire. The three definitions below and the
-    scalar reduction that follows all read under that convention.
-
     For three virtual leg spaces $\alpha,\beta,\gamma$ and an endomorphism
     $Z$ of $\beta\otimes\gamma$, define the induced endomorphism of
     $\alpha\otimes\beta\otimes\gamma$ by acting as the identity on the
@@ -278,9 +272,15 @@
     \lean{TNLean.PEPS.threeLeg_residual_forms_scalar}
     \leanok
     \uses{def:peps_threeLegLeftIdentityForm, def:peps_threeLegRightIdentityForm, def:peps_threeLegMiddleIdentityForm}
-    The three virtual leg spaces are nonzero, by the convention recorded in
-    Definition~\ref{def:peps_threeLegLeftIdentityForm}; the reduction below
-    selects a basis vector in each of them.
+    \emph{Local fix (nonzero virtual legs).} This statement, and only this
+    statement among the four in this group, assumes that each of the three
+    virtual leg spaces is nonzero-dimensional; the three residual forms above
+    are defined without that restriction. The reduction fixes an arbitrary
+    index in each leg and reads off one matrix entry to name the scalar, so it
+    has no content on an empty leg. The assumption is the standing one of
+    \cite[Section~3]{Molnar2018NormalPEPS}, where every virtual leg carries a
+    drawn wire, and it does not follow from injectivity; it is recorded in
+    \cite{gap:peps_injective_ft_section3_route}.
 
     In the proof of the generalized two-injective-tensor comparison, applying
     the inverse of the second injective tensor leaves three possible virtual

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
@@ -239,6 +239,12 @@
     \label{def:peps_threeLegLeftIdentityForm}
     \lean{TNLean.PEPS.threeLegLeftIdentityForm}
     \leanok
+    Throughout this group of residual forms, the three virtual leg spaces
+    $\alpha,\beta,\gamma$ are nonzero finite-dimensional spaces, as in the
+    standing convention of \cite[Section~3]{Molnar2018NormalPEPS}, where every
+    virtual leg carries a drawn wire. The three definitions below and the
+    scalar reduction that follows all read under that convention.
+
     For three virtual leg spaces $\alpha,\beta,\gamma$ and an endomorphism
     $Z$ of $\beta\otimes\gamma$, define the induced endomorphism of
     $\alpha\otimes\beta\otimes\gamma$ by acting as the identity on the
@@ -272,6 +278,10 @@
     \lean{TNLean.PEPS.threeLeg_residual_forms_scalar}
     \leanok
     \uses{def:peps_threeLegLeftIdentityForm, def:peps_threeLegRightIdentityForm, def:peps_threeLegMiddleIdentityForm}
+    The three virtual leg spaces are nonzero, by the convention recorded in
+    Definition~\ref{def:peps_threeLegLeftIdentityForm}; the reduction below
+    selects a basis vector in each of them.
+
     In the proof of the generalized two-injective-tensor comparison, applying
     the inverse of the second injective tensor leaves three possible virtual
     operators on the exposed legs of the first tensor:

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex
@@ -273,12 +273,29 @@
     \leanok
     \uses{def:peps_threeLegLeftIdentityForm, def:peps_threeLegRightIdentityForm, def:peps_threeLegMiddleIdentityForm}
     \emph{Local fix (nonzero virtual legs).} The residual forms are defined
-    for arbitrary leg index sets. This scalar-recovery statement assumes each
-    index set is nonempty. If one leg is empty, equality of the induced
-    three-leg operators need not constrain the residual operator on the other
-    two legs. The assumption records the nonzero-dimensional virtual bond
-    spaces of \cite[Section~3]{Molnar2018NormalPEPS} and does not follow from
-    injectivity; it is recorded in
+    for arbitrary leg index sets, whereas the scalar recovery below assumes
+    that each of $\alpha,\beta,\gamma$ is nonzero. In coordinates the two
+    compatibility conditions read
+    \begin{align}
+        \delta_{aa'}Z_{bc,b'c'}
+         & =
+        U_{ab,a'b'}\delta_{cc'},
+        \qquad
+        \delta_{aa'}Z_{bc,b'c'}
+        =
+        W_{ac,a'c'}\delta_{bb'},
+        \notag
+    \end{align}
+    quantified over $a,a'\in\alpha$, $b,b'\in\beta$, $c,c'\in\gamma$. If one of
+    the three index sets is empty, then so is $\alpha\times\beta\times\gamma$,
+    both conditions are equalities of functions on an empty index set, and they
+    hold for arbitrary $Z,U,W$: with $\alpha$ empty, $\beta$ a one-point set
+    and $\gamma$ a two-point set, the operator $Z=\operatorname{diag}(1,2)$ on
+    $\beta\times\gamma$ satisfies both conditions while being no multiple of
+    the identity. The assumption records the
+    nonzero-dimensional virtual bond spaces of
+    \cite[Section~3]{Molnar2018NormalPEPS} and does not follow from
+    injectivity; the counterexample above is recorded in
     \cite{gap:peps_injective_ft_section3_route}.
 
     In the proof of the generalized two-injective-tensor comparison, applying

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1250,6 +1250,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/peps_cyclic_mps_two_site_bond_uniformity.pdf}},
 }
 
+@techreport{gap:peps_injective_ft_section3_route,
+  author      = {The {TNLean} contributors},
+  title       = {Injective {PEPS} Fundamental Theorem: Section 3 Route},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {peps\_injective\_ft\_section3\_route},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/peps_injective_ft_section3_route.pdf}},
+}
+
 @techreport{gap:peps_normal_ft_section3_route,
   author      = {The {TNLean} contributors},
   title       = {Normal {PEPS} Fundamental Theorem: Section 3 Route},

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -486,6 +486,43 @@ is \leanid{TNLean.PEPS.threeLeg_residual_forms_scalar}, and the required
 inversion and regrouping are contained in
 \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison_core}.
 
+This scalar conclusion also needs nonzero legs, for a reason independent of the
+positive-bond hypotheses above. The three residual forms are defined for
+arbitrary leg index sets $\alpha$, $\beta$, $\gamma$, and the two compatibility
+hypotheses read, in coordinates,
+\begin{align}
+    \delta_{aa'}Z_{bc,b'c'}
+        &= U_{ab,a'b'}\delta_{cc'},
+    \label{eq:peps_injective_ft_section3_route_three_leg_left_right}\\
+    \delta_{aa'}Z_{bc,b'c'}
+        &= W_{ac,a'c'}\delta_{bb'},
+    \label{eq:peps_injective_ft_section3_route_three_leg_left_middle}
+\end{align}
+quantified over $a,a'\in\alpha$, $b,b'\in\beta$, and $c,c'\in\gamma$. If one of
+the three index sets is empty, then $\alpha\times\beta\times\gamma$ is empty,
+both compatibility conditions are equalities of functions on an empty domain,
+and they therefore hold for arbitrary $Z$, $U$, and $W$. The residual operator
+carried by the two legs complementary to the empty one is then unconstrained,
+and the scalar conclusion fails. For $\alpha=\varnothing$, let $\beta$ be a
+one-point set, let $\gamma$ be a two-point set, and put
+\begin{align}
+    Z &= \begin{pmatrix} 1 & 0\\ 0 & 2\end{pmatrix}
+    \qquad\text{on } \beta\times\gamma .
+    \label{eq:peps_injective_ft_section3_route_three_leg_empty_witness}
+\end{align}
+The matrices $U$ on $\alpha\times\beta$ and $W$ on $\alpha\times\gamma$ are the
+unique empty matrices, so
+(\ref{eq:peps_injective_ft_section3_route_three_leg_left_right}) and
+(\ref{eq:peps_injective_ft_section3_route_three_leg_left_middle}) hold, while no
+scalar $\lambda$ satisfies $Z=\lambda\Id$. The cases $\beta=\varnothing$ and
+$\gamma=\varnothing$ are the same statement with $W$ on $\alpha\times\gamma$ and
+$U$ on $\alpha\times\beta$ as the unconstrained operator. The three
+nonemptiness hypotheses of
+\leanid{TNLean.PEPS.threeLeg_residual_forms_scalar} are therefore load-bearing:
+like the positive-bond hypotheses elsewhere in this route, they record the
+nonzero-dimensional virtual bond spaces of Ref.~\cite{Molnar2018NormalPEPS}
+rather than a consequence of injectivity.
+
 \item
 Both injective blocks in the one-vertex-versus-complement comparison are
 formalized. The selected-vertex block is


### PR DESCRIPTION
## What changed

- Clarified the nonempty-index hypotheses of `TNLean.PEPS.threeLeg_residual_forms_scalar` in its docstring and the Blueprint node `thm:peps_twoInjectiveGaugeScalarReduction`.
- Kept the three residual-form definitions general. They are total matrix extensions for arbitrary leg index sets, including empty ones. Only scalar recovery assumes all three index sets are nonempty.
- Retained the Local-fix marker and the source/paper-gap citations. Added the bibliography entry `gap:peps_injective_ft_section3_route` for the existing note.

The full PR changes one Lean docstring, one Blueprint paragraph, and one bibliography entry. No definitions, theorem statements, hypotheses, or proofs change.

## Mathematical reason

`Papers/1804.04964/paper_normal.tex:1194–1204`, in the proof of Lemma `lem:inj_equal_tensors_2`, concludes that the underlying gauges Z, U, W are scalar, not merely that their induced three-leg operators are scalar.

If α is empty, β is a singleton, and γ has two elements, take Z = diag(1,2) and the unique empty matrices U and W. All three induced operators are the unique empty matrix, so their equality is automatic, but Z is not a scalar multiple of the identity. Z is even invertible. Conversely, when two legs are empty every scalar satisfies the residual conclusion. Thus “no scalar to produce” and “no content on an empty leg” were not accurate explanations.

## Validation

At `8dbd5f159f32d55f5f203c31a4b5f205bf216698`, relative to the previous head `150e8f26ac03dcd45dbe0b28481311412dc4723c`:

- Exactly two prose-only files changed; the bibliography addition already in the PR is preserved.
- Lean non-comment content is byte-identical, including every declaration, hypothesis, and proof.
- Blueprint declaration links, labels, dependency edges, status markers, citations, and source comments are unchanged.
- Scoped repository reader-facing prose checks pass.
- Pinned formatter 3.24.7 produces byte-identical chapter output; scoped chktex passes without diagnostics.
- No local builds or cache operations were run. Hosted CI is tracked separately.

The disputed review thread r3940047519 remains open pending explicit Codex and Claude agreement. This PR is not being merged before consensus.

Advances #7726.
