### PR TITLE
refactor(MPS/MPU): migrate the threaded canonical-form-II hypotheses to the convention predicate

### DIFF
--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -377,6 +377,23 @@ theorem neZero_bond {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) : NeZero D
     have h := hU.ρ_trace
     simp [Matrix.trace] at h⟩
 
+/-- The physical dimension of an MPU in canonical form II is nonzero: on an empty
+physical index the normalized transfer map is the zero map, so its fixed matrix
+vanishes and the normalization `(Φ|ρ) = 1` of `Erightleft` fails.
+
+Source: CPSV17, `Papers/1703.09188/paper_v2.tex`, lines 269--281. -/
+theorem neZero_phys {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) : NeZero d :=
+  ⟨by
+    rintro rfl
+    have hfix := hU.ρ_fixed
+    rw [Kraus.transferMap_apply] at hfix
+    have hzero : hU.ρ = 0 := by
+      rw [← hfix]
+      exact Finset.sum_eq_zero fun i _ ↦ absurd i.isLt (by omega)
+    have h := hU.ρ_trace
+    rw [hzero] at h
+    simp at h⟩
+
 end IsMPUCanonicalFormII
 
 private theorem sqrt_blockPhysDim (d p : ℕ) :

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -366,6 +366,17 @@ theorem hasFullSupport {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
     hU.cfii.toCPSVCanonicalFormData.HasFullSupport :=
   hU.fullSupport_eq
 
+/-- The bond space of an MPU in canonical form II is nonempty: the normalization
+`(Φ|ρ) = 1` of `Erightleft` fails on an empty bond space, where every trace
+vanishes.
+
+Source: CPSV17, `Papers/1703.09188/paper_v2.tex`, lines 269--281. -/
+theorem neZero_bond {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) : NeZero D :=
+  ⟨by
+    rintro rfl
+    have h := hU.ρ_trace
+    simp [Matrix.trace] at h⟩
+
 end IsMPUCanonicalFormII
 
 private theorem sqrt_blockPhysDim (d p : ℕ) :

--- a/TNLean/MPS/MPU/DoubleLayerContraction.lean
+++ b/TNLean/MPS/MPU/DoubleLayerContraction.lean
@@ -272,6 +272,26 @@ theorem normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
   rw [normalizedDiagonal_doubleLayerTensor_blockTensor, pow_mul, hpowerR, hRpow]
   rfl
 
+/-- The normalized double-layer diagonal of an MPU in canonical form II
+stabilizes at the positive exponent \(J=\max(D^2-1,1)\) to the vectorized
+rank-one projector \(\lvert\rho)(\Phi\rvert\) built from the ambient fixed
+matrix recorded by the convention.
+
+Source: arXiv:1703.09188, equation `Erightleft` (lines 269--281) and lines
+397--405. -/
+theorem IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    normalizedDiagonal (doubleLayerTensor U) ^ max (D * D - 1) 1 =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦ hU.ρ.vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
+  have := hU.neZero_bond
+  have h := normalizedDiagonal_doubleLayerTensor_blockTensor U (max (D * D - 1) 1)
+  rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at h
+  rw [h, hU.normalized_transfer_power_eq_vecMulVec]
+  rfl
+
 /-- A residual physical slice: subtract the identity coefficient from a physical
 contraction. This is the basis-free form of the residual matrices `S_α` in
 `WIsom`.

--- a/TNLean/MPS/MPU/DoubleLayerContraction.lean
+++ b/TNLean/MPS/MPU/DoubleLayerContraction.lean
@@ -279,7 +279,7 @@ matrix recorded by the convention.
 
 Source: arXiv:1703.09188, equation `Erightleft` (lines 269--281) and lines
 397--405. -/
-theorem IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec [NeZero d]
+theorem IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec
     {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
     normalizedDiagonal (doubleLayerTensor U) ^ max (D * D - 1) 1 =
       Matrix.vecMulVec
@@ -287,6 +287,7 @@ theorem IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec [NeZero d]
         (fun x : Fin (D * D) ↦
           (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
   have := hU.neZero_bond
+  have := hU.neZero_phys
   have h := normalizedDiagonal_doubleLayerTensor_blockTensor U (max (D * D - 1) 1)
   rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at h
   rw [h, hU.normalized_transfer_power_eq_vecMulVec]

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -150,7 +150,7 @@ that lemma at lines 589 and 592.
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
 <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
 theorem IsMPUCanonicalFormII.forced_block_simple_contractions
-    [NeZero d] {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
     let J := max (D * D - 1) 1
     let ρ' : Fin (D * D) → ℂ := fun i ↦ hU.ρ.vec (finProdFinEquiv.symm i)
     let Φ' : Fin (D * D) → ℂ := fun i ↦
@@ -165,6 +165,7 @@ theorem IsMPUCanonicalFormII.forced_block_simple_contractions
           Matrix.vecMulVec ρ' Φ' *
             doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l) := by
   have := hU.neZero_bond
+  have := hU.neZero_phys
   exact hU.isMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
     hU.ρ hU.ρ_trace (max (D * D - 1) 1) (by omega)
     hU.normalized_transfer_power_eq_vecMulVec

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -134,55 +134,39 @@ theorem IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
     have hijkl := hs.2 (e i) (e j) (e k) (e l)
     simpa only [e, ← htensor, doubleLayerTensor_reindexPhysical] using hijkl
 
-/-- A reduced full-support canonical-form-II representative supplies the
-normalized positive fixed pair and the exact aligned simple contractions on
-the forced block of length \(J D^2\), where \(J = D^2 - 1\).
+/-- An MPU in canonical form II has the exact aligned simple contractions on
+the forced block of length \(JD^2\), with \(J=\max(D^2-1,1)\) and the named
+witnesses \(a=\Phi\), \(b=\rho\) of the convention.
 
-All fixed-point data and both contractions refer to the same original tensor
-and its direct block; no source-cut factorization or source-v isometry is
-asserted.
+Both contractions refer to the same original tensor and its direct block; no
+source-cut factorization or source-v isometry is asserted. The ambient fixed
+matrix, its positivity and normalization, and the two fixed-vector equations
+are the fields of the convention, so they are no longer restated here.
 
 Source: arXiv:1703.09188, Section III.A, lines 397--427. The forced simple
 block is subsequently used in Lemma III.7, lines 550--556; Theorem III.8 uses
 that lemma at lines 589 and 592.
 
-**Scope restriction (full support):** This uses the chosen reduced
-representative supplied by
-`IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`. See
-`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
-
 **Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
 <https://sirui-lu.com/QICLean/paper-gaps/mpu_nil_matrix_bound.pdf>. -/
-theorem IsMPU.exists_reduced_cfii_forced_block_simple_contractions
-    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
-    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
-    (hfull : cfii.toCPSVCanonicalFormData.HasFullSupport) :
-    ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
-      ρ.PosDef ∧ Matrix.trace ρ = 1 ∧
-      Kraus.transferMap U.normalizedFlattening ρ = ρ ∧
-      Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec
-          (transferMatrix (Kraus.transferMap U.normalizedFlattening)) =
-        (1 : Matrix (Fin D) (Fin D) ℂ).vec ∧
-      transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ (D * D - 1) =
-        Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec ∧
-      let J := D * D - 1
-      let ρ' : Fin (D * D) → ℂ := fun i ↦ ρ.vec (finProdFinEquiv.symm i)
-      let Φ' : Fin (D * D) → ℂ := fun i ↦
-        (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i)
-      (∀ i j : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
-        Φ' ⬝ᵥ (doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *ᵥ ρ') =
-          if i = j then 1 else 0) ∧
-      (∀ i j k l : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+theorem IsMPUCanonicalFormII.forced_block_simple_contractions
+    [NeZero d] {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    let J := max (D * D - 1) 1
+    let ρ' : Fin (D * D) → ℂ := fun i ↦ hU.ρ.vec (finProdFinEquiv.symm i)
+    let Φ' : Fin (D * D) → ℂ := fun i ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i)
+    (∀ i j : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+      Φ' ⬝ᵥ (doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *ᵥ ρ') =
+        if i = j then 1 else 0) ∧
+    (∀ i j k l : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+      doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
+          doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l =
         doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
-            doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l =
-          doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
-            Matrix.vecMulVec ρ' Φ' *
-              doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l) := by
-  obtain ⟨_, _, ρ, _, _, _, _, _, _, hρpd, hρtrace, hρfix, hΦfix, hpower⟩ :=
-    hU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD cfii hfull
-  have hJ : 0 < D * D - 1 := Nat.sub_pos_of_lt (by nlinarith)
-  have hs := hU.blockTensor_mul_sq_simple_contractions_of_transfer_power
-    ρ hρtrace (D * D - 1) hJ hpower
-  exact ⟨ρ, hρpd, hρtrace, hρfix, hΦfix, hpower, hs⟩
+          Matrix.vecMulVec ρ' Φ' *
+            doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l) := by
+  have := hU.neZero_bond
+  exact hU.isMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
+    hU.ρ hU.ρ_trace (max (D * D - 1) 1) (by omega)
+    hU.normalized_transfer_power_eq_vecMulVec
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
+++ b/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
@@ -10,10 +10,11 @@ import TNLean.MPS.MPU.SourceVCompleteNetwork
 /-!
 # The simple-tensor equivalence theorem
 
-This file proves a supplied-fixed-pair specialization of Theorem `ThmFund1`
-of arXiv:1703.09188 (lines 563--601): for an MPU tensor $\mathcal U$ with
-source-cut ranks $r$ and $\ell$ and source gates $u=Y_2\mathbin{-}Y_1$ and
-$v=X_1\mathbin{-}X_2$, the following are equivalent:
+This file proves Theorem `ThmFund1` of arXiv:1703.09188 (lines 563--601) under
+the source's standing canonical-form-II convention: for an MPU tensor
+$\mathcal U$ in canonical form II, with source-cut ranks $r$ and $\ell$ and
+source gates $u=Y_2\mathbin{-}Y_1$ and $v=X_1\mathbin{-}X_2$, the following are
+equivalent:
 
 1. $\mathcal U$ is simple;
 2. $r\ell=d^2$;
@@ -29,18 +30,12 @@ $\operatorname{reindex}(U^{(2)})=v\,\operatorname{swap}_{r,\ell}(u)$ of
 equations `SVDforms2`--`uuvv` makes $v$ a product of unitaries; and
 $v^\dagger v=\Id$ gives `simple2`, hence simplicity.
 
-The fixed pair is supplied as in the source: $\rho>0$ is the diagonal right
-fixed point of canonical form II (arXiv:1703.09188, line 495), and the
+The fixed pair is the one the convention records: $\rho>0$ is the diagonal
+right fixed point of canonical form II (arXiv:1703.09188, line 495), and the
 normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$ with
 $(\Phi|=\operatorname{vec}(\Id_D)^{\mathsf T}$ (equation `Erightleft`,
 lines 274--280).  The source cuts, ranks, and both gates are computed from the
 same tensor $\mathcal U$ with the same weight $\rho$.
-
-**Scope restriction (supplied diagonal fixed pair):** `IsMPU.isMPUSimple_tfae`
-assumes the positive diagonal fixed point and the exact finite-power identity
-explicitly. The unrestricted source theorem uses the preceding
-canonical-form-II representative convention. This remaining representative
-scope is documented in `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -50,12 +45,10 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Supplied-fixed-pair specialization of Theorem `ThmFund1`: for an MPU tensor
-$\mathcal U$ whose normalized double-layer diagonal satisfies $E^J=|\rho)(\Phi|$
-for the source's diagonal
-fixed point $\rho>0$ and some $J>0$, with the source-cut ranks $r$, $\ell$ and
-the source gates $u$, $v$ computed from $\mathcal U$ using $\rho$, the following
-are equivalent:
+/-- Theorem `ThmFund1` under the standing canonical-form-II convention: for an
+MPU tensor $\mathcal U$ in canonical form II, with the source-cut ranks $r$,
+$\ell$ and the source gates $u$, $v$ computed from $\mathcal U$ using the
+recorded weight $\rho$, the following are equivalent:
 
 1. $\mathcal U$ is simple;
 2. $r\ell=d^2$;
@@ -63,32 +56,27 @@ are equivalent:
 4. $v$ is unitary.
 
 The proof is the source's cycle $1\to2\to3\to4\to1$:
-`IsMPU.sourceU_isIsometry` and the same-weight
-`IsMPUSimple.sourceV_isIsometry` give $1\to2$; the standing isometry $u$ with
-$\ell r=d^2$ is unitary ($2\to3$);
+`IsMPUCanonicalFormII.sourceU_isIsometry` and the same-weight
+`IsMPUCanonicalFormII.sourceV_isIsometry` give $1\to2$; the standing isometry
+$u$ with $\ell r=d^2$ is unitary ($2\to3$);
 `mpo_two_reindex_eq_sourceV_mul_sourceU_swap` writes the unitary $U^{(2)}$ as
 $v$ times the reindexed $u$, so $v$ is unitary ($3\to4$); and
 `IsMPU.isMPUSimple_of_sourceV_isIsometry` gives $4\to1$.
 
 Source: arXiv:1703.09188, Theorem `ThmFund1` and its proof (lines 563--601),
 with the diagonal fixed point of line 495. -/
-theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag)
-    (J : ℕ) (hJ : 0 < J)
-    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
-      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+theorem IsMPUCanonicalFormII.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D}
+    (hU : IsMPUCanonicalFormII U) :
     List.TFAE [IsMPUSimple U,
       r[U] * ℓ[U] = d * d,
-      (sourceU U ρ hρ).IsUnitaryBetween,
-      (sourceV U ρ hρ).IsUnitaryBetween] := by
-  have hu : (sourceU U ρ hρ).IsIsometry := hU.sourceU_isIsometry ρ hρ hρdiag J hpower
+      (sourceU U hU.ρ hU.ρ_posDef).IsUnitaryBetween,
+      (sourceV U hU.ρ hU.ρ_posDef).IsUnitaryBetween] := by
+  have hu : (sourceU U hU.ρ hU.ρ_posDef).IsIsometry := hU.sourceU_isIsometry
   have hrankLower : d * d ≤ r[U] * ℓ[U] := by
     have h := Matrix.IsIsometry.card_le _ hu
     simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
   tfae_have 1 → 2 := fun hS ↦ by
-    have hv : (sourceV U ρ hρ).IsIsometry :=
-      hS.sourceV_isIsometry ρ hρ hρdiag J hJ hpower
+    have hv : (sourceV U hU.ρ hU.ρ_posDef).IsIsometry := hU.sourceV_isIsometry hS
     have hrankUpper := Matrix.IsIsometry.card_le _ hv
     apply le_antisymm
     · simpa only [Fintype.card_prod, Fintype.card_fin] using hrankUpper
@@ -100,11 +88,12 @@ theorem IsMPU.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
       exact h)
   tfae_have 3 → 4 := fun h ↦ by
     have hmpo := (Matrix.isUnitaryBetween_iff_mem_unitaryGroup _).mpr
-      (hU.mpo_mem_unitaryGroup (N := 2) one_lt_two)
+      (hU.isMPU.mpo_mem_unitaryGroup (N := 2) one_lt_two)
     have hre := hmpo.reindex _ (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
-    rw [mpo_two_reindex_eq_sourceV_mul_sourceU_swap U ρ hρ] at hre
+    rw [mpo_two_reindex_eq_sourceV_mul_sourceU_swap U hU.ρ hU.ρ_posDef] at hre
     exact Matrix.IsUnitaryBetween.of_mul_right _ _ (h.reindex _ _ _) hre
-  tfae_have 4 → 1 := fun h ↦ hU.isMPUSimple_of_sourceV_isIsometry ρ hρ h.1
+  tfae_have 4 → 1 := fun h ↦
+    hU.isMPU.isMPUSimple_of_sourceV_isIsometry hU.ρ hU.ρ_posDef h.1
   tfae_finish
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
+++ b/TNLean/MPS/MPU/SimpleTensorEquivalence.lean
@@ -56,8 +56,8 @@ recorded weight $\rho$, the following are equivalent:
 4. $v$ is unitary.
 
 The proof is the source's cycle $1\to2\to3\to4\to1$:
-`IsMPUCanonicalFormII.sourceU_isIsometry` and the same-weight
-`IsMPUCanonicalFormII.sourceV_isIsometry` give $1\to2$; the standing isometry
+`IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank` and the same-weight
+`IsMPUCanonicalFormII.rightRank_mul_leftRank_le` give $1\to2$; the standing isometry
 $u$ with $\ell r=d^2$ is unitary ($2\to3$);
 `mpo_two_reindex_eq_sourceV_mul_sourceU_swap` writes the unitary $U^{(2)}$ as
 $v$ times the reindexed $u$, so $v$ is unitary ($3\to4$); and
@@ -65,22 +65,16 @@ $v$ times the reindexed $u$, so $v$ is unitary ($3\to4$); and
 
 Source: arXiv:1703.09188, Theorem `ThmFund1` and its proof (lines 563--601),
 with the diagonal fixed point of line 495. -/
-theorem IsMPUCanonicalFormII.isMPUSimple_tfae [NeZero d] {U : MPOTensor d D}
+theorem IsMPUCanonicalFormII.isMPUSimple_tfae {U : MPOTensor d D}
     (hU : IsMPUCanonicalFormII U) :
     List.TFAE [IsMPUSimple U,
       r[U] * ℓ[U] = d * d,
       (sourceU U hU.ρ hU.ρ_posDef).IsUnitaryBetween,
       (sourceV U hU.ρ hU.ρ_posDef).IsUnitaryBetween] := by
   have hu : (sourceU U hU.ρ hU.ρ_posDef).IsIsometry := hU.sourceU_isIsometry
-  have hrankLower : d * d ≤ r[U] * ℓ[U] := by
-    have h := Matrix.IsIsometry.card_le _ hu
-    simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
-  tfae_have 1 → 2 := fun hS ↦ by
-    have hv : (sourceV U hU.ρ hU.ρ_posDef).IsIsometry := hU.sourceV_isIsometry hS
-    have hrankUpper := Matrix.IsIsometry.card_le _ hv
-    apply le_antisymm
-    · simpa only [Fintype.card_prod, Fintype.card_fin] using hrankUpper
-    · exact hrankLower
+  have hrankLower : d * d ≤ r[U] * ℓ[U] := hU.mul_self_le_rightRank_mul_leftRank
+  tfae_have 1 → 2 := fun hS ↦
+    le_antisymm (hU.rightRank_mul_leftRank_le hS) hrankLower
   tfae_have 2 → 3 := fun h ↦
     hu.isUnitaryBetween_of_card_eq _ (by
       simp only [Fintype.card_prod, Fintype.card_fin]

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -18,23 +18,20 @@ Figure `II_uUnitary.png`.  The network is then closed against a fixed pair
 the \(K\)-site interior.  The normalized input tail gives \(u^\dagger u=\Id\)
 and \(d^2\le r\ell\).
 
-**Scope restriction (supplied canonical-form-II fixed pair):** the closing
-theorems below assume the stabilized fixed pair \(E^K=|\rho)(\Phi|\)
-explicitly, whereas CPSV17 Lemma `lemuisometry` inherits it from the preceding
-canonical-form-II convention.  In that convention, \(\rho\) is diagonal with
-positive weights; see `Papers/1703.09188/paper_v2.tex` at lines 269--280 and
-line 495.  This diagonality is part of the source's scope, not a correction or
-an additional restriction.  It is load-bearing in the coordinate proof:
-column stacking makes the Gram closure insert
-\(|\rho^{\mathsf T})(\Phi|\), while stabilization supplies
-\(|\rho)(\Phi|\), and the two agree because \(\rho^{\mathsf T}=\rho\).  The
-closing theorems keep `SourceFactors U ρ` built from the printed weight, expose
-the convention as `ρ.IsDiag`, and use only `ρ.IsSymm` for the algebraic trace
-closure.  Documented in
-`docs/paper-gaps/mpu_canonical_form_full_support.tex` and
-`docs/paper-gaps/mpu_source_cut_orientation.tex`.  Elimination: replace the
-explicit fixed-pair hypotheses by the bundled canonical-form-II convention
-described in the orientation note.
+The closing theorems in the `SourceFactors` namespace are generic: they take
+arbitrary supplied source factors for an arbitrary positive weight together
+with the stabilized fixed pair \(E^K=|\rho)(\Phi|\), and assume nothing else
+about \(\mathcal U\).  Lemma `lemuisometry` itself is stated for an MPU in
+canonical form II, where the diagonal positive weight and the stabilized power
+are both recorded by the convention.  In that convention, \(\rho\) is diagonal
+with positive weights; see `Papers/1703.09188/paper_v2.tex` at lines 269--280
+and line 495.  Diagonality is load-bearing in the coordinate proof: column
+stacking makes the Gram closure insert \(|\rho^{\mathsf T})(\Phi|\), while
+stabilization supplies \(|\rho)(\Phi|\), and the two agree because
+\(\rho^{\mathsf T}=\rho\).  The generic theorems keep `SourceFactors U ρ` built
+from the printed weight, expose the convention as `ρ.IsDiag`, and use only
+`ρ.IsSymm` for the algebraic trace closure.  The column-stacking orientation is
+recorded in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, `uu`, and
 `uUnitary`, and Lemma `lemuisometry` (lines 269--280 and 487--557).
@@ -437,17 +434,30 @@ theorem mul_self_le_rightRank_mul_leftRank_of_isMPU [NeZero d] (hU : IsMPU U)
 end SourceFactors
 
 variable {U} in
-/-- For a positive diagonal fixed point, the compact-SVD paper gate $u$ of an
-MPU tensor is an isometry.
+/-- Lemma `lemuisometry` under the source's standing convention: the compact-SVD
+paper gate $u=Y_2\mathbin{-}Y_1$ of an MPU in canonical form II is an isometry.
+
+The diagonal positive ambient fixed point and the stabilized rank-one power are
+recorded by the convention, so neither is supplied as a separate hypothesis.
 
 Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
-the diagonal coordinates of lines 269--280. -/
-theorem IsMPU.sourceU_isIsometry [NeZero d] (hU : IsMPU U)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag) (K : ℕ)
-    (hK : normalizedDiagonal (doubleLayerTensor U) ^ K =
-      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
-    (sourceU U ρ hρ).IsIsometry :=
-  SourceFactors.sourceU_isIsometry_of_isMPU U hU (sourceFactors U ρ hρ) hρdiag K hK
+the diagonal coordinates of `Erightleft` (lines 269--280). -/
+theorem IsMPUCanonicalFormII.sourceU_isIsometry [NeZero d]
+    (hU : IsMPUCanonicalFormII U) :
+    (sourceU U hU.ρ hU.ρ_posDef).IsIsometry :=
+  SourceFactors.sourceU_isIsometry_of_isMPU U hU.isMPU
+    (sourceFactors U hU.ρ hU.ρ_posDef) hU.ρ_isDiag _
+    hU.normalizedDiagonal_pow_eq_vecMulVec
+
+variable {U} in
+/-- The rank consequence of Lemma `lemuisometry` under the standing
+canonical-form-II convention: $d^2\le r\ell$.
+
+Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
+theorem IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank [NeZero d]
+    (hU : IsMPUCanonicalFormII U) :
+    d * d ≤ r[U] * ℓ[U] := by
+  have h := Matrix.IsIsometry.card_le _ hU.sourceU_isIsometry
+  simpa only [Fintype.card_prod, Fintype.card_fin, Nat.mul_comm ℓ[U]] using h
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUCompleteNetwork.lean
@@ -437,14 +437,16 @@ variable {U} in
 /-- Lemma `lemuisometry` under the source's standing convention: the compact-SVD
 paper gate $u=Y_2\mathbin{-}Y_1$ of an MPU in canonical form II is an isometry.
 
-The diagonal positive ambient fixed point and the stabilized rank-one power are
-recorded by the convention, so neither is supplied as a separate hypothesis.
+The diagonal positive ambient fixed point, the stabilized rank-one power, and
+the nonzero physical dimension are recorded by the convention, so none of them
+is supplied as a separate hypothesis.
 
 Source: CPSV17 Lemma `lemuisometry` (lines 545--557), with the fixed point in
 the diagonal coordinates of `Erightleft` (lines 269--280). -/
-theorem IsMPUCanonicalFormII.sourceU_isIsometry [NeZero d]
+theorem IsMPUCanonicalFormII.sourceU_isIsometry
     (hU : IsMPUCanonicalFormII U) :
     (sourceU U hU.ρ hU.ρ_posDef).IsIsometry :=
+  have := hU.neZero_phys
   SourceFactors.sourceU_isIsometry_of_isMPU U hU.isMPU
     (sourceFactors U hU.ρ hU.ρ_posDef) hU.ρ_isDiag _
     hU.normalizedDiagonal_pow_eq_vecMulVec
@@ -454,7 +456,7 @@ variable {U} in
 canonical-form-II convention: $d^2\le r\ell$.
 
 Source: CPSV17 Lemma `lemuisometry` (lines 545--557). -/
-theorem IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank [NeZero d]
+theorem IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank
     (hU : IsMPUCanonicalFormII U) :
     d * d ≤ r[U] * ℓ[U] := by
   have h := Matrix.IsIsometry.card_le _ hU.sourceU_isIsometry

--- a/TNLean/MPS/MPU/SourceURetainedInterior.lean
+++ b/TNLean/MPS/MPU/SourceURetainedInterior.lean
@@ -13,11 +13,13 @@ This module converts a supplied normalized transfer-matrix power at length
 the arbitrary-interior complete-network theorem for the paper gate
 \(u=Y_2\mathbin{-}Y_1\).
 
-**Scope restriction (supplied stabilized fixed pair):** the theorem assumes the
-raw rank-one transfer identity and the source's diagonal canonical-form-II
-coordinates explicitly.  It keeps `SourceFactors U ρ`; no source factor is
-recomputed from \(\rho^{\mathsf T}\).  Documented in
-`docs/paper-gaps/mpu_canonical_form_full_support.tex` and
+The theorem below is the reusable generic step: it takes supplied source
+factors for an arbitrary positive weight, together with the raw rank-one
+transfer identity and the source's diagonal coordinates, and assumes nothing
+else about the tensor.  Lemma `lemuisometry` itself is stated for an MPU in
+canonical form II, where both are recorded by the convention.  The step keeps
+`SourceFactors U ρ`; no source factor is recomputed from
+\(\rho^{\mathsf T}\).  The column-stacking orientation is documented in
 `docs/paper-gaps/mpu_source_cut_orientation.tex`.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `X1X2b`, and `uUnitary`,

--- a/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
@@ -41,11 +41,11 @@ Documented in `docs/paper-gaps/mpu_source_cut_orientation.tex`.
   undressed Gram entry is the two-letter entry with $|\rho^{\mathsf T})(\Phi|$ inserted.
 * `MPOTensor.sourceVDressedGram_iff_simple2_transpose_fixed_pair`: the dressed Gram
   equation is equivalent to `simple2` with the insertion $|\rho^{\mathsf T})(\Phi|$.
-* `MPOTensor.IsMPUSimple.sourceV_isIsometry`: the forward direction of Theorem
-  `ThmFund1`, $1\to2$, with the source's diagonal fixed point: the gate built
-  from that same weight has $v^\dagger v=\Id$.
-* `MPOTensor.IsMPUSimple.rightRank_mul_leftRank_le`: the resulting rank bound
-  $r\ell\le d^2$.
+* `MPOTensor.IsMPUCanonicalFormII.sourceV_isIsometry`: the forward direction of
+  Theorem `ThmFund1`, $1\to2$, under the standing canonical-form-II convention:
+  the gate built from the recorded weight has $v^\dagger v=\Id$.
+* `MPOTensor.IsMPUCanonicalFormII.rightRank_mul_leftRank_le`: the resulting rank
+  bound $r\ell\le d^2$.
 * `MPOTensor.IsMPU.isMPUSimple_of_sourceV_isIsometry`: the direction $4\to1$ of
   Theorem `ThmFund1` from $v^\dagger v=\Id$.
 
@@ -188,41 +188,36 @@ theorem IsMPUSimple.sourceV_transpose_isIsometry [NeZero d]
   simpa only [Matrix.transpose_transpose] using
     hU.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ J hJ hpower
 
-/-- Theorem `ThmFund1`, $1\to2$: for the diagonal fixed point used by the
-source, the paper gate $v$ built from that same weight satisfies
+/-- Theorem `ThmFund1`, $1\to2$: under the source's standing canonical-form-II
+convention, the paper gate $v$ built from the recorded weight $\rho$ satisfies
 $v^\dagger v=\Id$.
 
-The diagonal hypothesis identifies the inserted vector
-$|\rho^{\mathsf T})$ with the stabilized vector $|\rho)$, after which the
-complete network and `YZ=1` give the isometry. Source: arXiv:1703.09188,
-lines 495 and 577--588. -/
-theorem IsMPUSimple.sourceV_isIsometry [NeZero d]
-    {U : MPOTensor d D} (hU : IsMPUSimple U)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (hρdiag : ρ.IsDiag)
-    (J : ℕ) (hJ : 0 < J)
-    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
-      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
-    (sourceV U ρ hρ).IsIsometry := by
+Diagonality of $\rho$ identifies the inserted vector $|\rho^{\mathsf T})$ with
+the stabilized vector $|\rho)$, after which the complete network and `YZ=1`
+give the isometry. Source: arXiv:1703.09188, lines 495 and 577--588. -/
+theorem IsMPUCanonicalFormII.sourceV_isIsometry [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) (hS : IsMPUSimple U) :
+    (sourceV U hU.ρ hU.ρ_posDef).IsIsometry := by
+  have := hU.neZero_bond
   rw [← sourceVDressedGram_iff_isIsometry,
     sourceVDressedGram_iff_simple2_transpose_fixed_pair]
-  simpa only [hρdiag.isSymm.eq] using
-    hU.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ J hJ hpower
+  simpa only [hU.ρ_isDiag.isSymm.eq] using
+    hS.simple2_of_normalizedDiagonal_pow_eq_vecMulVec _ _ (max (D * D - 1) 1)
+      (by omega) hU.normalizedDiagonal_pow_eq_vecMulVec
 
-/-- Theorem `ThmFund1`, $1\to2$, rank consequence: a simple tensor with
-stabilized fixed pair satisfies $r\ell\le d^2$, since the isometry $v$ maps
+/-- Theorem `ThmFund1`, $1\to2$, rank consequence: a simple tensor in canonical
+form II satisfies $r\ell\le d^2$, since the isometry $v$ maps
 $\C^r\otimes\C^\ell$ into $\C^d\otimes\C^d$.
 
 Source: arXiv:1703.09188, proof of Theorem `ThmFund1`, $1\to2$
 (lines 577--588). -/
-theorem IsMPUSimple.rightRank_mul_leftRank_le [NeZero d]
-    {U : MPOTensor d D} (hU : IsMPUSimple U)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (J : ℕ) (hJ : 0 < J)
-    (hpower : normalizedDiagonal (doubleLayerTensor U) ^ J =
-      Matrix.vecMulVec (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
-        (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+theorem IsMPUCanonicalFormII.rightRank_mul_leftRank_le [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) (hS : IsMPUSimple U) :
     r[U] * ℓ[U] ≤ d * d := by
-  have h := Matrix.IsIsometry.card_le _ (hU.sourceV_transpose_isIsometry ρ hρ J hJ hpower)
+  have := hU.neZero_bond
+  have h := Matrix.IsIsometry.card_le _
+    (hS.sourceV_transpose_isIsometry hU.ρ hU.ρ_posDef (max (D * D - 1) 1) (by omega)
+      hU.normalizedDiagonal_pow_eq_vecMulVec)
   simpa only [Fintype.card_prod, Fintype.card_fin] using h
 
 /-- Theorem `ThmFund1`, $4\to1$: if the paper gate $v$ of an MPU tensor

--- a/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
@@ -209,15 +209,16 @@ theorem IsMPUCanonicalFormII.sourceV_isIsometry [NeZero d]
 form II satisfies $r\ell\le d^2$, since the isometry $v$ maps
 $\C^r\otimes\C^\ell$ into $\C^d\otimes\C^d$.
 
+The isometry used here is the source gate built from the recorded weight
+$\rho$, so the bound is read off the printed network of the source rather than
+off a reparametrized gate.
+
 Source: arXiv:1703.09188, proof of Theorem `ThmFund1`, $1\to2$
 (lines 577--588). -/
 theorem IsMPUCanonicalFormII.rightRank_mul_leftRank_le [NeZero d]
     {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) (hS : IsMPUSimple U) :
     r[U] * ℓ[U] ≤ d * d := by
-  have := hU.neZero_bond
-  have h := Matrix.IsIsometry.card_le _
-    (hS.sourceV_transpose_isIsometry hU.ρ hU.ρ_posDef (max (D * D - 1) 1) (by omega)
-      hU.normalizedDiagonal_pow_eq_vecMulVec)
+  have h := Matrix.IsIsometry.card_le _ (hU.sourceV_isIsometry hS)
   simpa only [Fintype.card_prod, Fintype.card_fin] using h
 
 /-- Theorem `ThmFund1`, $4\to1$: if the paper gate $v$ of an MPU tensor

--- a/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
+++ b/TNLean/MPS/MPU/SourceVCompleteNetwork.lean
@@ -195,10 +195,11 @@ $v^\dagger v=\Id$.
 Diagonality of $\rho$ identifies the inserted vector $|\rho^{\mathsf T})$ with
 the stabilized vector $|\rho)$, after which the complete network and `YZ=1`
 give the isometry. Source: arXiv:1703.09188, lines 495 and 577--588. -/
-theorem IsMPUCanonicalFormII.sourceV_isIsometry [NeZero d]
+theorem IsMPUCanonicalFormII.sourceV_isIsometry
     {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) (hS : IsMPUSimple U) :
     (sourceV U hU.ρ hU.ρ_posDef).IsIsometry := by
   have := hU.neZero_bond
+  have := hU.neZero_phys
   rw [← sourceVDressedGram_iff_isIsometry,
     sourceVDressedGram_iff_simple2_transpose_fixed_pair]
   simpa only [hU.ρ_isDiag.isSymm.eq] using
@@ -215,7 +216,7 @@ off a reparametrized gate.
 
 Source: arXiv:1703.09188, proof of Theorem `ThmFund1`, $1\to2$
 (lines 577--588). -/
-theorem IsMPUCanonicalFormII.rightRank_mul_leftRank_le [NeZero d]
+theorem IsMPUCanonicalFormII.rightRank_mul_leftRank_le
     {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) (hS : IsMPUSimple U) :
     r[U] * ℓ[U] ≤ d * d := by
   have h := Matrix.IsIsometry.card_le _ (hU.sourceV_isIsometry hS)

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -35,6 +35,11 @@ right fixed witnesses.
   reduced canonical-form-II data.
 * `MPOTensor.IsMPU.normalized_transfer_matrix_eq_one_fin_one` proves that the
   one-dimensional normalized transfer matrix is the identity.
+* `MPOTensor.IsMPUCanonicalFormII.normalized_transfer_power_eq_vecMulVec` and
+  `MPOTensor.IsMPUCanonicalFormII.vecMul_one_vec_transferMatrix` state the two
+  equations of `Erightleft` for the ambient matrix the convention records, as a
+  single power identity at the exponent `max (D * D - 1) 1` valid in every bond
+  dimension.
 
 ## References
 
@@ -248,6 +253,17 @@ theorem IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii
     hΛfix, rfl, hρpd, hρtrace, hρfix, hleft, ?_⟩
   simpa using hpower
 
+/-- Every power of the transfer matrix fixes the vectorization of a fixed point
+of the underlying map. -/
+private theorem transferMatrix_pow_mulVec_vec_of_fixed {D : ℕ}
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hfix : T ρ = ρ) (n : ℕ) :
+    transferMatrix T ^ n *ᵥ ρ.vec = ρ.vec := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, ← Matrix.mulVec_mulVec, transferMatrix_mulVec_eq, hfix, ih]
+
 /-- In bond dimension one, the normalized transfer matrix of an MPU is the identity.
 
 Source: arXiv:1703.09188, lines 397--409, specialized to `D = 1`. -/
@@ -278,5 +294,74 @@ noncomputable def IsMPU.normalizedTransferStabilization_fin_one
     simp
   · rw [hE]
     simp
+
+namespace IsMPUCanonicalFormII
+
+variable [NeZero d] {U : MPOTensor d D}
+
+/-- The vectorized identity is a left fixed vector of the normalized transfer
+matrix of an MPU in canonical form II: this is `(Φ|E = (Φ|`.
+
+Source: arXiv:1703.09188, equation `Erightleft`, lines 269--281. -/
+theorem vecMul_one_vec_transferMatrix (hU : IsMPUCanonicalFormII U) :
+    Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec
+        (transferMatrix (Kraus.transferMap U.normalizedFlattening)) =
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
+  have := hU.neZero_bond
+  rcases lt_or_ge 1 D with hD | hD
+  · obtain ⟨-, -, -, -, -, -, -, -, -, -, -, -, hΦ, -⟩ :=
+      hU.isMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD hU.cfii
+        hU.hasFullSupport
+    exact hΦ
+  · obtain rfl : D = 1 := le_antisymm hD (NeZero.pos D)
+    rw [hU.isMPU.normalized_transfer_matrix_eq_one_fin_one, Matrix.vecMul_one]
+
+/-- The ambient right fixed matrix recorded by the canonical-form-II convention
+is exactly the stabilized value of the normalized transfer matrix:
+`E ^ J = |ρ)(Φ|` at the positive exponent `J = max (D² - 1) 1`.
+
+The stabilized power is rank one with left factor `(Φ|`, so the trace-one fixed
+matrix `ρ` recorded by the convention is the one the elimination of the
+zero-primary component produces; no separate stabilized pair is supplied. The
+exponent is `D² - 1` whenever `D > 1` and `1` in bond dimension one, where the
+normalized transfer matrix is already the identity.
+
+Source: arXiv:1703.09188, equation `Erightleft` (lines 269--281) and the Jordan
+elimination of lines 397--405. -/
+theorem normalized_transfer_power_eq_vecMulVec (hU : IsMPUCanonicalFormII U) :
+    transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ max (D * D - 1) 1 =
+      Matrix.vecMulVec hU.ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
+  have := hU.neZero_bond
+  rcases lt_or_ge 1 D with hD | hD
+  · obtain ⟨-, -, σ, -, -, -, -, -, -, -, -, -, -, hpower⟩ :=
+      hU.isMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD hU.cfii
+        hU.hasFullSupport
+    have hDD : 2 * 2 ≤ D * D :=
+      Nat.mul_le_mul (by omega : 2 ≤ D) (by omega : 2 ≤ D)
+    have hmax : max (D * D - 1) 1 = D * D - 1 := max_eq_left (by omega)
+    have hfix :
+        transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ (D * D - 1) *ᵥ
+          hU.ρ.vec = hU.ρ.vec :=
+      transferMatrix_pow_mulVec_vec_of_fixed _ hU.ρ_fixed _
+    rw [hpower, Matrix.vecMulVec_mulVec, Matrix.vec_one_dotProduct_vec_eq_trace,
+      hU.ρ_trace] at hfix
+    simp only [MulOpposite.op_one, one_smul] at hfix
+    rw [hmax, hpower, hfix]
+  · obtain rfl : D = 1 := le_antisymm hD (NeZero.pos D)
+    have hρ : hU.ρ = 1 := by
+      have h := hU.ρ_trace
+      ext i j
+      fin_cases i
+      fin_cases j
+      simpa [Matrix.trace_fin_one, Matrix.one_apply] using h
+    rw [hU.isMPU.normalized_transfer_matrix_eq_one_fin_one, hρ, one_pow]
+    ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+    fin_cases p₁
+    fin_cases p₂
+    fin_cases q₁
+    fin_cases q₂
+    simp [Matrix.vecMulVec_apply]
+
+end IsMPUCanonicalFormII
 
 end MPOTensor

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -297,7 +297,7 @@ noncomputable def IsMPU.normalizedTransferStabilization_fin_one
 
 namespace IsMPUCanonicalFormII
 
-variable [NeZero d] {U : MPOTensor d D}
+variable {U : MPOTensor d D}
 
 /-- The vectorized identity is a left fixed vector of the normalized transfer
 matrix of an MPU in canonical form II: this is `(Φ|E = (Φ|`.
@@ -308,6 +308,7 @@ theorem vecMul_one_vec_transferMatrix (hU : IsMPUCanonicalFormII U) :
         (transferMatrix (Kraus.transferMap U.normalizedFlattening)) =
       (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
   have := hU.neZero_bond
+  have := hU.neZero_phys
   rcases lt_or_ge 1 D with hD | hD
   · obtain ⟨-, -, -, -, -, -, -, -, -, -, -, -, hΦ, -⟩ :=
       hU.isMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD hU.cfii
@@ -332,6 +333,7 @@ theorem normalized_transfer_power_eq_vecMulVec (hU : IsMPUCanonicalFormII U) :
     transferMatrix (Kraus.transferMap U.normalizedFlattening) ^ max (D * D - 1) 1 =
       Matrix.vecMulVec hU.ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
   have := hU.neZero_bond
+  have := hU.neZero_phys
   rcases lt_or_ge 1 D with hD | hD
   · obtain ⟨-, -, σ, -, -, -, -, -, -, -, -, -, -, hpower⟩ :=
       hU.isMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD hU.cfii

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5043,11 +5043,19 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     conditions is assumed. Thus $u$ is a standing isometry and
     $r\ell\geq d^2$ throughout the proof.
 
-    Suppose first that $\mathcal U$ is simple. The reduced full-support datum
-    requires $\rho$ to be diagonal, so
+    Suppose first that $\mathcal U$ is simple.
     Theorem~\ref{thm:mpu_simple_source_v_isometry} gives
-    $v^\dagger v=\Id$ for the source operator built from the same weight
-    $\rho$, hence $r\ell\leq d^2$.
+    $v^\dagger v=\Id$ for the source operator built from the ambient fixed
+    matrix of a canonical-form-II presentation, hence $r\ell\leq d^2$. The
+    reduced full-support datum supplies only a diagonal positive weight
+    $\rho$ together with the stabilized power
+    $E^{J}=\lvert\rho)(\Phi\rvert$; it becomes a canonical-form-II
+    presentation exactly when that weight is the ambient fixed matrix of the
+    convention, and the passage from the supplied datum to the presentation
+    is the open step recorded in
+    \texttt{docs/paper-gaps/mpu\_canonical\_form\_full\_support.tex}. Until
+    that step is available, this implication is the reason the present
+    theorem is not ready.
 
     If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
     Theorem~\ref{thm:mpu_source_gates_two_site_factorization} gives the exact

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4302,8 +4302,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.IsMPUCanonicalFormII.forced_block_simple_contractions}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpdo_physical_blocking, def:mpu_double_layer}
-    Let $d>0$ and let $\mathcal U$ be an MPU in canonical form II, with ambient
-    fixed matrix $\rho$. Put $J=\max(D^2-1,1)$ and $W=\mathcal U_{JD^2}$. With
+    Let $\mathcal U$ be an MPU in canonical form II, with ambient fixed
+    matrix $\rho$. Put $J=\max(D^2-1,1)$ and $W=\mathcal U_{JD^2}$. With
     the vectorized pair $\rho',\Phi'$ of $\rho$ and of the identity, the
     blocked tensor $W$ satisfies the two aligned simple contractions
     \begin{align}
@@ -4350,7 +4350,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{def:mpu_canonical_form_ii}
     \lean{MPOTensor.IsMPUCanonicalFormII,
         MPOTensor.IsMPUCanonicalFormII.hasFullSupport,
-        MPOTensor.IsMPUCanonicalFormII.neZero_bond}
+        MPOTensor.IsMPUCanonicalFormII.neZero_bond,
+        MPOTensor.IsMPUCanonicalFormII.neZero_phys}
     \leanok
     \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support}
     Let $\mathcal U$ be an MPO tensor, and write
@@ -4380,7 +4381,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Thus the retained blocks have literal full support, and $\rho$ is a
     positive diagonal trace-one right fixed point in the ambient bond
     coordinates. In particular the normalization $\tr(\rho)=1$ forces the bond
-    space to be nonempty. This is the standing convention of
+    space to be nonempty, and together with $E(\rho)=\rho$ it forces the
+    physical dimension to be positive as well: on an empty physical index the
+    normalized transfer map is zero, so its fixed matrix vanishes and cannot
+    have unit trace. This is the standing convention of
     \cite[lines~269--281, 344--356, and 488--502]{Cirac2017MPU}.
     % The ambient diagonal rho is part of the chosen presentation. No construction
     % from arbitrary existing CFII and full-support witnesses is asserted:
@@ -4461,8 +4465,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpu_double_layer}
-    Let $d>0$ and let $\mathcal U$ be an MPU in canonical form II with ambient
-    fixed matrix $\rho$, and put $J=\max(D^2-1,1)$. Then
+    Let $\mathcal U$ be an MPU in canonical form II with ambient fixed
+    matrix $\rho$, and put $J=\max(D^2-1,1)$. Then
     \begin{align}
         (\Phi\rvert E & =(\Phi\rvert,
                       & E^J           & =\lvert\rho)(\Phi\rvert,
@@ -4788,8 +4792,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.IsMPUCanonicalFormII.rightRank_mul_leftRank_le}
     \leanok
     \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer, def:mpu_canonical_form_ii}
-    Let $\mathcal U$ be simple with physical dimension $d>0$ and in canonical
-    form II, with ambient fixed matrix $\rho$. Let $v$ be the source operator
+    Let $\mathcal U$ be simple and in canonical form II, with ambient fixed
+    matrix $\rho$. Let $v$ be the source operator
     of $\mathcal U$ built from that same weight $\rho$. Then
     $v^\dagger v=\Id_{r\ell}$, and consequently $r\ell\le d^2$. This is the
     implication $1\to2$ in \cite[proof of Theorem~III.8]{Cirac2017MPU},

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4465,7 +4465,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     fixed matrix $\rho$, and put $J=\max(D^2-1,1)$. Then
     \begin{align}
         (\Phi\rvert E & =(\Phi\rvert,
-                      & E^J & =\lvert\rho)(\Phi\rvert,
+                      & E^J           & =\lvert\rho)(\Phi\rvert,
         \label{eq:mpu_ambient_cfii_stabilization}
     \end{align}
     and the same identity holds for the normalized diagonal of the double layer

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4318,7 +4318,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_matching_direct_block_contractions, thm:mpu_canonical_form_ii_transfer_stabilization}
+    \uses{thm:mpu_matching_direct_block_contractions, thm:mpu_canonical_form_ii_transfer_stabilization, thm:mpu_canonical_form_ii_positive_dimensions}
     The convention records a positive trace-one ambient fixed matrix, and
     Theorem~\ref{thm:mpu_canonical_form_ii_transfer_stabilization} identifies
     the stabilized power with $\lvert\rho)(\Phi\rvert$ at the positive exponent
@@ -4349,9 +4349,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{definition}[Canonical form II for a matrix product unitary]
     \label{def:mpu_canonical_form_ii}
     \lean{MPOTensor.IsMPUCanonicalFormII,
-        MPOTensor.IsMPUCanonicalFormII.hasFullSupport,
-        MPOTensor.IsMPUCanonicalFormII.neZero_bond,
-        MPOTensor.IsMPUCanonicalFormII.neZero_phys}
+        MPOTensor.IsMPUCanonicalFormII.hasFullSupport}
     \leanok
     \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support}
     Let $\mathcal U$ be an MPO tensor, and write
@@ -4380,17 +4378,44 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Thus the retained blocks have literal full support, and $\rho$ is a
     positive diagonal trace-one right fixed point in the ambient bond
-    coordinates. In particular the normalization $\tr(\rho)=1$ forces the bond
-    space to be nonempty, and together with $E(\rho)=\rho$ it forces the
-    physical dimension to be positive as well: on an empty physical index the
-    normalized transfer map is zero, so its fixed matrix vanishes and cannot
-    have unit trace. This is the standing convention of
+    coordinates. This is the standing convention of
     \cite[lines~269--281, 344--356, and 488--502]{Cirac2017MPU}.
     % The ambient diagonal rho is part of the chosen presentation. No construction
     % from arbitrary existing CFII and full-support witnesses is asserted:
     % inhabitance is proved only for the constructed reduced representative of
     % Theorem thm:mpu_reduced_cfii_representative.
 \end{definition}
+
+\begin{theorem}[Canonical form II forces positive dimensions]
+    \label{thm:mpu_canonical_form_ii_positive_dimensions}
+    \lean{MPOTensor.IsMPUCanonicalFormII.neZero_bond,
+        MPOTensor.IsMPUCanonicalFormII.neZero_phys}
+    \leanok
+    \uses{def:mpu_canonical_form_ii}
+    If an MPO tensor $\mathcal U$ admits a canonical-form-II presentation, then
+    its bond space is nonempty and its physical dimension is positive:
+    \begin{align}
+        D & >0, & d & >0.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Both dimensions are forced by the normalization $\tr(\rho)=1$ of
+    (\ref{eq:mpu_ambient_cfii_fixed_pair}). If $D=0$, the ambient bond index
+    set is empty and every trace over it vanishes,
+    \begin{align}
+        \tr(\rho) & =\sum_{n\in\varnothing}\rho_{nn}=0\neq1.
+    \end{align}
+    If $d=0$, the physical index set is empty, so the normalized transfer map
+    is an empty sum,
+    \begin{align}
+        E(\rho) & =\sum_{i\in\varnothing}\widetilde{\mathcal U}^{i}\rho
+        \bigl(\widetilde{\mathcal U}^{i}\bigr)^\dagger=0.
+    \end{align}
+    The fixed-point equation $E(\rho)=\rho$ of
+    (\ref{eq:mpu_ambient_cfii_fixed_pair}) then gives $\rho=0$, hence
+    $\tr(\rho)=0\neq1$.
+\end{proof}
 
 \begin{theorem}[Normality of a full-support normalized MPU representative]
     \label{thm:mpu_normalized_full_support_normal}
@@ -4469,17 +4494,26 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     matrix $\rho$, and put $J=\max(D^2-1,1)$. Then
     \begin{align}
         (\Phi\rvert E & =(\Phi\rvert,
-                      & E^J           & =\lvert\rho)(\Phi\rvert,
+                      & E^J           & =\lvert\rho)(\Phi\rvert.
         \label{eq:mpu_ambient_cfii_stabilization}
     \end{align}
-    and the same identity holds for the normalized diagonal of the double layer
-    in the vectorized bond coordinates. The exponent is positive in every bond
-    dimension, so no separate one-dimensional branch is needed.
+    Let $q:\Fin D\times\Fin D\to\Fin{D^2}$ be the standard product encoding,
+    let $R$ be the normalized physical diagonal of the double layer
+    $\mathcal W(\mathcal U)$, and let $\rho',\Phi'$ be the vectorizations of
+    $\rho$ and of $\Phi=\Id_D$ in the doubled bond coordinates $\Fin{D^2}$,
+    that is $\rho'_{q(m,n)}=\rho_{mn}$ and $\Phi'_{q(m,n)}=(\Id_D)_{mn}$. Then
+    also
+    \begin{align}
+        R^J & =\lvert\rho')(\Phi'\rvert.
+        \label{eq:mpu_ambient_cfii_double_layer}
+    \end{align}
+    The exponent is positive in every bond dimension, so no separate
+    one-dimensional branch is needed.
     % Source lines: paper_v2.tex 269--281 and 397--405.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_reduced_cfii_transfer_stabilization, thm:mpu_normalized_transfer_fin_one, thm:mpu_blocked_double_layer_diagonal}
+    \uses{thm:mpu_reduced_cfii_transfer_stabilization, thm:mpu_normalized_transfer_fin_one, thm:mpu_blocked_double_layer_diagonal, thm:mpu_canonical_form_ii_positive_dimensions}
     If $D=1$, the normalized transfer matrix is the identity, $\rho=1$ by
     $\tr(\rho)=1$, and both identities hold at $J=1$. If $D>1$, then
     $J=D^2-1$, and
@@ -4493,9 +4527,19 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
                     & =\tr(\rho)\lvert\sigma)      \\
                     & =\lvert\sigma),
     \end{align}
-    so $\sigma=\rho$. The double-layer form follows by rewriting the
-    normalized diagonal of the $J$-fold block as the $J$-th power of the
-    normalized transfer matrix in the vectorized bond coordinates.
+    so $\sigma=\rho$. For the double-layer form,
+    Theorem~\ref{thm:mpu_blocked_double_layer_diagonal} identifies the
+    normalized diagonal of the $J$-fold block with the $J$-th power of the
+    normalized transfer matrix after the encoding $q$, so
+    (\ref{eq:mpu_ambient_cfii_stabilization}) gives, for all
+    $a,b\in\Fin{D^2}$,
+    \begin{align}
+        \bigl(R^J\bigr)_{ab}
+         & =\bigl(E^J\bigr)_{q^{-1}(a),q^{-1}(b)}
+        =\bigl(\lvert\rho)(\Phi\rvert\bigr)_{q^{-1}(a),q^{-1}(b)}
+        =\bigl(\lvert\rho')(\Phi'\rvert\bigr)_{ab},
+    \end{align}
+    which is (\ref{eq:mpu_ambient_cfii_double_layer}).
 \end{proof}
 
 \section{Standard form, index, and symmetry classification}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4297,40 +4297,34 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     factorization for the stabilized power.
 \end{proof}
 
-\begin{theorem}[Reduced-CFII data for the forced simple block]
+\begin{theorem}[Forced simple block in canonical form II]
     \label{thm:mpu_reduced_cfii_forced_block_simple_contractions}
-    \lean{MPOTensor.IsMPU.exists_reduced_cfii_forced_block_simple_contractions}
+    \lean{MPOTensor.IsMPUCanonicalFormII.forced_block_simple_contractions}
     \leanok
-    \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support, def:mpdo_physical_blocking, def:mpu_double_layer}
-    Let $d>0$, $D>1$, and let $\mathcal U$ be an MPU whose normalized
-    flattening has chosen canonical-form-II data with full support. Put
-    $J=D^2-1$ and $W=\mathcal U_{JD^2}$. There is a matrix $\rho>0$ with
-    $\tr(\rho)=1$ such that
-    \begin{align}
-        E\lvert\rho) & =\lvert\rho),
-                     & (\Phi\rvert E & =(\Phi\rvert,
-                     & E^J           & =\lvert\rho)(\Phi\rvert.
-    \end{align}
-    With the corresponding vectorized pair $\rho',\Phi'$, the same blocked
-    tensor $W$ satisfies the two aligned simple contractions
+    \uses{def:mpu_canonical_form_ii, def:mpdo_physical_blocking, def:mpu_double_layer}
+    Let $d>0$ and let $\mathcal U$ be an MPU in canonical form II, with ambient
+    fixed matrix $\rho$. Put $J=\max(D^2-1,1)$ and $W=\mathcal U_{JD^2}$. With
+    the vectorized pair $\rho',\Phi'$ of $\rho$ and of the identity, the
+    blocked tensor $W$ satisfies the two aligned simple contractions
     \begin{align}
         \Phi'\mathbin{\boldsymbol\cdot}W^{ij}\rho'
          & =\delta_{ij},                              \\
         W^{ij}W^{k\ell}
          & =W^{ij}\lvert\rho')(\Phi'\rvert W^{k\ell}.
     \end{align}
-    This theorem supplies only the fixed pair and the two simple contractions.
-    It does not assert a source-cut factorization or source-$v$ isometry.
+    This theorem asserts only the two simple contractions. It does not assert a
+    source-cut factorization or source-$v$ isometry.
     % Source lines: paper_v2.tex 397--427, 550--556, 589, and 592.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_matching_direct_block_contractions, thm:mpu_reduced_cfii_transfer_stabilization}
-    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization} gives the
-    positive trace-one fixed matrix and the identity
-    $E^J=\lvert\rho)(\Phi\rvert$. Applying
-    Theorem~\ref{thm:mpu_matching_direct_block_contractions} with this pair
-    gives both contractions on the direct block $W=\mathcal U_{JD^2}$.
+    \uses{thm:mpu_matching_direct_block_contractions, thm:mpu_canonical_form_ii_transfer_stabilization}
+    The convention records a positive trace-one ambient fixed matrix, and
+    Theorem~\ref{thm:mpu_canonical_form_ii_transfer_stabilization} identifies
+    the stabilized power with $\lvert\rho)(\Phi\rvert$ at the positive exponent
+    $J$. Applying Theorem~\ref{thm:mpu_matching_direct_block_contractions} with
+    this pair gives both contractions on the direct block
+    $W=\mathcal U_{JD^2}$.
 \end{proof}
 
 \begin{theorem}[One-dimensional normalized transfer matrix]
@@ -4355,7 +4349,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{definition}[Canonical form II for a matrix product unitary]
     \label{def:mpu_canonical_form_ii}
     \lean{MPOTensor.IsMPUCanonicalFormII,
-        MPOTensor.IsMPUCanonicalFormII.hasFullSupport}
+        MPOTensor.IsMPUCanonicalFormII.hasFullSupport,
+        MPOTensor.IsMPUCanonicalFormII.neZero_bond}
     \leanok
     \uses{def:mpu, def:mpu_normalized_flattening, def:cpsv_cfii, def:mpu_full_support}
     Let $\mathcal U$ be an MPO tensor, and write
@@ -4384,7 +4379,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Thus the retained blocks have literal full support, and $\rho$ is a
     positive diagonal trace-one right fixed point in the ambient bond
-    coordinates. This is the standing convention of
+    coordinates. In particular the normalization $\tr(\rho)=1$ forces the bond
+    space to be nonempty. This is the standing convention of
     \cite[lines~269--281, 344--356, and 488--502]{Cirac2017MPU}.
     % The ambient diagonal rho is part of the chosen presentation. No construction
     % from arbitrary existing CFII and full-support witnesses is asserted:
@@ -4456,6 +4452,46 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $\sum_{k=1}^{r}D_k=D$. Theorem~\ref{thm:mpu_normalized_full_support_normal}
     therefore applies to the chosen canonical-form-II representation of
     $\widetilde{\mathcal U}$.
+\end{proof}
+
+\begin{theorem}[Ambient fixed pair in canonical form II]
+    \label{thm:mpu_canonical_form_ii_transfer_stabilization}
+    \lean{MPOTensor.IsMPUCanonicalFormII.vecMul_one_vec_transferMatrix,
+        MPOTensor.IsMPUCanonicalFormII.normalized_transfer_power_eq_vecMulVec,
+        MPOTensor.IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_double_layer}
+    Let $d>0$ and let $\mathcal U$ be an MPU in canonical form II with ambient
+    fixed matrix $\rho$, and put $J=\max(D^2-1,1)$. Then
+    \begin{align}
+        (\Phi\rvert E & =(\Phi\rvert,
+                      & E^J & =\lvert\rho)(\Phi\rvert,
+        \label{eq:mpu_ambient_cfii_stabilization}
+    \end{align}
+    and the same identity holds for the normalized diagonal of the double layer
+    in the vectorized bond coordinates. The exponent is positive in every bond
+    dimension, so no separate one-dimensional branch is needed.
+    % Source lines: paper_v2.tex 269--281 and 397--405.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_reduced_cfii_transfer_stabilization, thm:mpu_normalized_transfer_fin_one, thm:mpu_blocked_double_layer_diagonal}
+    If $D=1$, the normalized transfer matrix is the identity, $\rho=1$ by
+    $\tr(\rho)=1$, and both identities hold at $J=1$. If $D>1$, then
+    $J=D^2-1$, and
+    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization} applied to the
+    canonical-form-II data of the presentation produces a positive trace-one
+    matrix $\sigma$ with $(\Phi\rvert E=(\Phi\rvert$ and
+    $E^J=\lvert\sigma)(\Phi\rvert$. Since $\rho$ is a fixed point of $E$,
+    \begin{align}
+        \lvert\rho) & =E^J\lvert\rho)
+                    & =\lvert\sigma)(\Phi\mid\rho)
+                    & =\tr(\rho)\lvert\sigma)
+                    & =\lvert\sigma),
+    \end{align}
+    so $\sigma=\rho$. The double-layer form follows by rewriting the
+    normalized diagonal of the $J$-fold block as the $J$-th power of the
+    normalized transfer matrix in the vectorized bond coordinates.
 \end{proof}
 
 \section{Standard form, index, and symmetry classification}
@@ -4748,15 +4784,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Source-$v$ isometry of a simple tensor]
     \label{thm:mpu_simple_source_v_isometry}
-    \lean{MPOTensor.IsMPUSimple.sourceV_isIsometry,
-        MPOTensor.IsMPUSimple.rightRank_mul_leftRank_le}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceV_isIsometry,
+        MPOTensor.IsMPUCanonicalFormII.rightRank_mul_leftRank_le}
     \leanok
-    \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer}
-    Let $\mathcal U$ be simple with physical dimension $d>0$, let $W$ be its
-    double layer with normalized diagonal $E$, and let the source's diagonal
-    matrix $\rho>0$ satisfy $E^J=\lvert\rho)(\Phi\rvert$ for some $J>0$, where
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Let $v$ be the source
-    operator of $\mathcal U$ built from that same weight $\rho$. Then
+    \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer, def:mpu_canonical_form_ii}
+    Let $\mathcal U$ be simple with physical dimension $d>0$ and in canonical
+    form II, with ambient fixed matrix $\rho$. Let $v$ be the source operator
+    of $\mathcal U$ built from that same weight $\rho$. Then
     $v^\dagger v=\Id_{r\ell}$, and consequently $r\ell\le d^2$. This is the
     implication $1\to2$ in \cite[proof of Theorem~III.8]{Cirac2017MPU},
     before the standing isometry of $u$ is used.
@@ -4764,8 +4798,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_supplied_projector_simple2, thm:mpu_source_v_complete_contraction, thm:mpu_source_v_dressed_gram_cancel}
-    Theorem~\ref{thm:mpu_supplied_projector_simple2} gives
+    \uses{thm:mpu_supplied_projector_simple2, thm:mpu_source_v_complete_contraction, thm:mpu_source_v_dressed_gram_cancel, thm:mpu_canonical_form_ii_transfer_stabilization}
+    The convention supplies the stabilized power
+    $E^J=\lvert\rho)(\Phi\rvert$, and
+    Theorem~\ref{thm:mpu_supplied_projector_simple2} then gives
     $W^{ij}W^{k\ell}=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}$. Since $\rho$
     is diagonal, $\rho^{\mathsf T}=\rho$, so
     Theorem~\ref{thm:mpu_source_v_complete_contraction} gives the dressed Gram
@@ -4801,9 +4837,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[The source operator $u$ is an isometry]
     \label{lemuisometry}
-    \notready
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceU_isIsometry,
+        MPOTensor.IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank}
+    \leanok
     \discussion{5708}
-    \uses{def:mpu_source_uv}
+    \uses{def:mpu_source_uv, def:mpu_canonical_form_ii}
     For any MPU tensor $\mathcal U$ under the source's standing
     canonical-form-II convention, let $r$ and $\ell$ be the two source-cut
     ranks and let $u$ be the source operator. Then
@@ -4815,16 +4853,25 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Source lines: paper_v2.tex 545--557.
 \end{lemma}
 
-\begin{lemma}[Admissible source-$u$ isometry]
+\begin{proof}\leanok
+    \uses{lem:mpu_admissible_source_u_isometry, thm:mpu_canonical_form_ii_transfer_stabilization}
+    The convention records a positive diagonal ambient weight $\rho$ and,
+    by Theorem~\ref{thm:mpu_canonical_form_ii_transfer_stabilization}, the
+    stabilized power $E^J=\lvert\rho)(\Phi\rvert$ at the positive exponent
+    $J=\max(D^2-1,1)$. Lemma~\ref{lem:mpu_admissible_source_u_isometry},
+    applied to the source factors built from that same weight, gives
+    $u^\dagger u=\Id$ and $d^2\le r\ell$.
+\end{proof}
+
+\begin{lemma}[Supplied-fixed-pair source-$u$ isometry]
     \label{lem:mpu_admissible_source_u_isometry}
     \lean{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU,
-        MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU,
-        MPOTensor.IsMPU.sourceU_isIsometry}
+        MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU}
     \leanok
     \discussion{5708}
-    % **Scope restriction (supplied stabilized diagonal fixed pair):** this
-    % lemma assumes the exact rank-one identity explicitly, whereas source
-    % Lemma III.7 uses the preceding canonical-form-II convention. Documented
+    % This lemma is the reusable generic form: it assumes the exact rank-one
+    % identity for an arbitrary positive diagonal weight, and is the step used
+    % by the source-labelled Lemma III.7 above. Orientation documented
     % in docs/paper-gaps/mpu_canonical_form_full_support.tex and
     % docs/paper-gaps/mpu_source_cut_orientation.tex.
     \uses{def:mpu, def:mpu_source_uv, def:mpu_weighted_source_factors,
@@ -4868,12 +4915,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Simple-tensor equivalence theorem]
     \label{ThmFund1}
-    \notready
+    \lean{MPOTensor.IsMPUCanonicalFormII.isMPUSimple_tfae}
+    \leanok
     \discussion{5708}
-    \uses{lemuisometry, def:mpu_simple, def:mpu_source_uv}
+    \uses{lemuisometry, def:mpu_simple, def:mpu_source_uv, def:mpu_canonical_form_ii}
     Let $\mathcal U$ be an MPU tensor under the source's standing
     canonical-form-II convention. Let $r$ and $\ell$ be its source-cut ranks,
-    and let $u$ and $v$ be its source operators. Then the following conditions
+    and let $u$ and $v$ be its source operators, both built from the ambient
+    weight $\rho$ recorded by the convention. Then the following conditions
     are equivalent:
     \begin{enumerate}
         \item $\mathcal U$ is simple;
@@ -4884,39 +4933,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     This is the unrestricted statement of
     \cite[Theorem~III.8]{Cirac2017MPU}.
     % Source lines: paper_v2.tex 563--601.
-    % The supplied diagonal-fixed-pair specialization below is checked. The
-    % unrestricted node remains not ready for the representative scope recorded
-    % in docs/paper-gaps/mpu_canonical_form_full_support.tex.
-\end{theorem}
-
-\begin{theorem}[Simple-tensor equivalence with a supplied diagonal fixed pair]
-    \label{thm:mpu_diagonal_fixed_pair_simple_tensor_equivalence}
-    \lean{MPOTensor.IsMPU.isMPUSimple_tfae}
-    \leanok
-    \uses{def:mpu, def:mpu_simple, def:mpu_source_uv, def:mpu_double_layer}
-    Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$, let $W$
-    be its double layer with normalized diagonal $E$, and let $\rho>0$ be
-    diagonal. Suppose that $E^J=\lvert\rho)(\Phi\rvert$ for some $J>0$, where
-    $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$. Compute the source-cut
-    ranks $r$ and $\ell$ and both source operators $u$ and $v$ from this same
-    tensor $\mathcal U$ and weight $\rho$. Then the following are equivalent:
-    \begin{enumerate}
-        \item $\mathcal U$ is simple;
-        \item $r\ell=d^2$;
-        \item $u$ is unitary;
-        \item $v$ is unitary.
-    \end{enumerate}
-    This is the supplied diagonal-fixed-pair specialization of
-    \cite[Theorem~III.8]{Cirac2017MPU}.
-    % Source lines: paper_v2.tex 495 and 563--601.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_admissible_source_u_isometry,
+    \uses{lemuisometry,
         thm:mpu_simple_source_v_isometry,
         thm:mpu_source_gates_two_site_factorization,
         thm:mpu_simple_of_source_v_isometry}
-    The supplied fixed pair gives $u^\dagger u=\Id$ and
+    The convention gives $u^\dagger u=\Id$ and
     $d^2\leq r\ell$ before any of the four conditions is assumed. Follow the
     cycle $1\to2\to3\to4\to1$.
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4488,9 +4488,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     matrix $\sigma$ with $(\Phi\rvert E=(\Phi\rvert$ and
     $E^J=\lvert\sigma)(\Phi\rvert$. Since $\rho$ is a fixed point of $E$,
     \begin{align}
-        \lvert\rho) & =E^J\lvert\rho)
-                    & =\lvert\sigma)(\Phi\mid\rho)
-                    & =\tr(\rho)\lvert\sigma)
+        \lvert\rho) & =E^J\lvert\rho)              \\
+                    & =\lvert\sigma)(\Phi\mid\rho) \\
+                    & =\tr(\rho)\lvert\sigma)      \\
                     & =\lvert\sigma),
     \end{align}
     so $\sigma=\rho$. The double-layer form follows by rewriting the

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -252,13 +252,20 @@ data across blocking.
 
 Chapter~28 of the blueprint records the preceding assumptions as a reduced
 full-support source datum for the same tensor. This datum is an explicit input,
-not an existence theorem. The chapter retains unrestricted, unformalized
-source entries under the original labels \texttt{lemuisometry},
-\texttt{ThmFund1}, \texttt{SF}, \texttt{def:index},
+not an existence theorem. The labels \texttt{lemuisometry} and
+\texttt{ThmFund1} are no longer among the unformalized source entries: both
+are now stated and proved for a tensor satisfying the bundled
+canonical-form-II presentation, which is the standing hypothesis the source
+fixes once before Lemma~III.7 and never repeats, and both carry the source's
+hypothesis set. The chapter retains unrestricted, unformalized source entries
+under the original labels \texttt{SF}, \texttt{def:index},
 \texttt{index-well-defined}, \texttt{lem:mpu\_index\_tensor}, and
-\texttt{lem:mpu\_index\_composition}. The restricted full-support statements
-have the distinct labels
-\texttt{lem:mpu\_admissible\_source\_u\_isometry},
+\texttt{lem:mpu\_index\_composition}. The label
+\texttt{lem:mpu\_admissible\_source\_u\_isometry} likewise no longer
+records a restriction: it is the reusable supplied-fixed-pair step, stated for
+an arbitrary positive diagonal weight and an arbitrary stabilization exponent,
+through which \texttt{lemuisometry} is proved. The remaining restricted
+full-support statements have the distinct labels
 \texttt{thm:mpu\_admissible\_simple\_tensor\_equivalence},
 \texttt{def:mpu\_admissible\_standard\_form},
 \texttt{def:mpu\_admissible\_index},
@@ -298,11 +305,12 @@ $\mathcal U'_k$, and $\mathcal W_k$, then places $\mathcal U_{2k}$ and
 $\mathcal U'_{2k}$ in standard form and computes the ranks of
 $\mathcal W_{4k}$ \cite{Cirac2017MPU}. The admissible theorem therefore
 requires separate source data for all six exact blocked tensors. It does not
-use later-block transport. The formalized supplied-fixed-pair source-$u$
-contraction is a dependency of the admissible source-isometry proof, and the
-formalized complete source-$v$ network is a dependency of the admissible
-simple-tensor equivalence proof. Neither establishes the unrestricted source
-statements.
+use later-block transport. The supplied-fixed-pair source-$u$
+contraction and the complete source-$v$ network are the steps through which
+\texttt{lemuisometry} and \texttt{ThmFund1} are proved for a tensor in
+canonical form II. Neither establishes the downstream standard-form and index
+source statements, which require source data at every blocking length they
+use.
 % Source lines: paper_v2.tex 824--865.
 
 The same separation between source statements and scoped statements extends

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -201,8 +201,9 @@ network is formalized by
 Input unitarity gives the isometry and rank bound in
 \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU} and
 \leanid{MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU};
-\leanid{MPOTensor.IsMPU.sourceU_isIsometry} applies this result to the
-compact-SVD source factors. The raw trace-one transfer-power specialization is
+\leanid{MPOTensor.IsMPUCanonicalFormII.sourceU_isIsometry} applies this result
+to the compact-SVD source factors of a tensor in canonical form II, where the
+weight and the transfer power come from the convention. The raw trace-one transfer-power specialization is
 \leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}.
 These proofs keep the source factors built from $\rho$, use
 $\rho^{\mathsf T}=\rho$, and retain one $K$-site interior between two
@@ -216,8 +217,8 @@ Ref.~\cite{Cirac2017MPU} is formalized as
 needs no fixed-pair datum beyond a positive definite weight, and it carries
 the inserted-vector transpose recorded in
 \texttt{mpu\_source\_cut\_orientation.tex}. The source's diagonal convention
-then gives \leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry} for the gate built
-from that same weight.
+then gives \leanid{MPOTensor.IsMPUCanonicalFormII.sourceV_isIsometry} for the
+gate built from that same weight.
 % Source lines: paper_v2.tex 545--557 and 577--600.
 % Source equation labels: uUnitary and vUnitary.
 
@@ -586,22 +587,33 @@ A source-faithful formalization must therefore construct the reduced
 representative. If a theorem retains named source cuts, the formalization must
 also justify the corresponding source constructions separately. The
 representative reduction is now formalized for every positive bond dimension
-and preserves the positive-length periodic operator family. The admissible
-source statements still require full-support data for the same named tensor
-because no identification of source factors across potentially unequal bond
-dimensions has been proved. The original source labels remain unrestricted and
-unformalized; the distinct admissible nodes record the current same-tensor
-source-data route.
+and preserves the positive-length periodic operator family. Statements about a
+tensor already in canonical form II take the bundled presentation, which is the
+source's own standing hypothesis. Statements that would start from an arbitrary
+ambient MPU still need an identification of source factors across potentially
+unequal bond dimensions, which has not been proved.
 
-Within Theorem~III.8 itself, the complete supplied-fixed-pair source-$u$
-contraction and the complete source-$v$ equivalence are formalized. The
-unrestricted source statement \texttt{lemuisometry} remains open because the
-formalization does not yet construct the required same-tensor diagonal source
-data from an arbitrary MPU. That admissible construction remains in
-\ghissue{7012}, and the unrestricted representative remains in
-\ghissue{7127}. Downstream standard-form, index, continuity, and symmetry
-results also lack existence or preservation theorems for reduced source data
-under products, transformed comparison tensors, and continuous paths.
+Within Theorem~III.8 itself, the complete source-$u$ contraction and the
+complete source-$v$ equivalence are formalized. Both are stated for a tensor
+satisfying the bundled canonical-form-II presentation, which is exactly the
+hypothesis the source states once before Lemma~III.7 and never repeats. The
+ambient positive diagonal weight and the stabilized rank-one transfer power
+$E^{J}=\lvert\rho)(\Phi\rvert$ at the positive exponent $J=\max(D^2-1,1)$ are
+consequences of that presentation rather than supplied data, so
+\texttt{lemuisometry} and \texttt{ThmFund1} carry the source's hypothesis set.
+The generic supplied-fixed-pair contractions remain available as the reusable
+step, stated for an arbitrary positive diagonal weight and an arbitrary
+stabilization exponent.
+
+What remains open is the transport of source cuts. For an arbitrary MPU
+representative the reduction produces a new tensor of possibly smaller bond
+dimension, and no theorem identifies the compact-SVD cuts, ranks, or selected
+source factors of that representative with those of the original ambient
+tensor. That transport remains in \ghissue{7012}, and the unrestricted
+representative remains in \ghissue{7127}. Downstream standard-form, index,
+continuity, and symmetry results also lack existence or preservation theorems
+for reduced source data under products, transformed comparison tensors, and
+continuous paths.
 Chapter~28 records these requirements as explicit admissibility hypotheses
 rather than consequences of the MPU predicate.
 

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -200,19 +200,23 @@ arbitrary nonsymmetric $\rho$.
 \section{Marker boundary for the complete source-$u$ network}
 
 The transposed first cut was a local correction, and it is resolved. The
-complete source-$u$ module has a separate scope restriction: its closing
-theorems assume the stabilized fixed pair explicitly, whereas Lemma~III.7
-inherits that pair from the source's standing canonical-form-II convention.
-The source itself fixes $\rho$ to be diagonal with positive weights
-$\rho_n>0$, so diagonality is not a restriction relative to the cited lemma.
+separate supplied-fixed-pair restriction of the complete source-$u$ module is
+resolved as well. Its generic theorems still take a stabilized fixed pair as an
+explicit hypothesis, but they are stated as reusable steps for an arbitrary
+positive diagonal weight and an arbitrary stabilization exponent, and
+Lemma~III.7 itself is now stated for a tensor in canonical form II, where the
+weight and the stabilized power are both recorded by the convention. The source
+itself fixes $\rho$ to be diagonal with positive weights $\rho_n>0$, so
+diagonality is not a restriction relative to the cited lemma.
 % Source lines: paper_v2.tex 269--280 and 495.
-Accordingly, the module carries one scope marker for the supplied fixed pair.
-The wider source-data restriction is recorded in
+Accordingly, the module carries no scope marker for the supplied fixed pair.
+The remaining source-data restriction, namely the transport of source cuts from
+an arbitrary ambient MPU to its reduced representative, is recorded in
 \texttt{mpu\_canonical\_form\_full\_support.tex}.
 
-Eliminating the supplied-data restriction means bundling the standing
-canonical-form-II convention and restating the MPU-level results through it,
-as tracked by \ghissue{7657} and \ghissue{7659}. Issue \ghissue{7653} instead
+The elimination step for the supplied-data restriction was the bundling of the
+standing canonical-form-II convention and the restatement of the MPU-level
+results through it, and it is complete. Issue \ghissue{7653} instead
 asks for a nonsymmetric ambient-weight strengthening that CPSV17 does not
 claim. It is not the elimination step for the source-faithful theorem.
 

--- a/docs/paper-gaps/mpu_source_cut_orientation.tex
+++ b/docs/paper-gaps/mpu_source_cut_orientation.tex
@@ -149,17 +149,18 @@ The source gates remain the gates built from the printed weight $\rho$; replacin
 that weight by $\rho^{\mathsf T}$ recomputes $X_1,Y_1$ and gives a different
 gate when $\rho$ is not symmetric. The source's diagonal convention makes the
 two inserted vectors equal, and
-\leanid{MPOTensor.IsMPUSimple.sourceV_isIsometry} proves the forward direction
-of Theorem~III.8 on precisely that convention. The reparametrized theorem
+\leanid{MPOTensor.IsMPUCanonicalFormII.sourceV_isIsometry} proves the forward
+direction of Theorem~III.8 on precisely that convention. The reparametrized theorem
 \leanid{MPOTensor.IsMPUSimple.sourceV_transpose_isIsometry} is retained as an
 auxiliary statement, not as an identification of the original gate. The
 converse direction in
 \leanid{MPOTensor.IsMPU.isMPUSimple_of_sourceV_isIsometry} produces the
 witnesses $(\Phi\rvert$ and $\lvert\rho^{\mathsf T})$ for the same weight
 $\rho$. Together with the diagonal source-$u$ isometry,
-\leanid{MPOTensor.IsMPU.isMPUSimple_tfae} gives the supplied-fixed-pair
-specialization of Theorem~III.8; the unrestricted representative scope remains
-recorded in \texttt{mpu\_canonical\_form\_full\_support.tex}. No source-factor
+\leanid{MPOTensor.IsMPUCanonicalFormII.isMPUSimple_tfae} gives Theorem~III.8
+under the source's standing convention; the transport of source cuts to a
+reduced representative of an arbitrary ambient MPU remains recorded in
+\texttt{mpu\_canonical\_form\_full\_support.tex}. No source-factor
 definition is changed.
 
 For the source-$u$ gate, the transpose closure and the source's diagonal
@@ -185,7 +186,8 @@ The arbitrary-$K$ declarations are
 \leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_input_tail},
 \leanid{MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU}, and
 \leanid{MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU}.
-The compact-SVD wrapper is \leanid{MPOTensor.IsMPU.sourceU_isIsometry}, while
+The compact-SVD wrapper is
+\leanid{MPOTensor.IsMPUCanonicalFormII.sourceU_isIsometry}, while
 \leanid{MPOTensor.SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag}
 converts the raw trace-one transfer power at $J$ into the direct fixed pair at
 $K=JD^2$. The independent right-shift checks

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -501,15 +501,24 @@ counts checked on `origin/main` at `fb847cd35`. Ranked among themselves by
 compounding cost; D13 precedes D14 because every new MPU statement pays it.
 
 ## D13. The MPU canonical-form-II convention is threaded pointwise, while admissible path nodes carry an additional continuous-source-data gap  —  api-design, impact 7/10, effort 5/10
-- **Status**: open. The convention predicate now exists, and the reduced
-  representative is constructed in the ambient diagonal gauge, so the
-  predicate is inhabited for the tensor the source arguments use. The
-  source-labelled Chapter 28 nodes contain the source formulas and proof
-  sketches needed for eventual consolidation, but the 16 pointwise
-  `mpu_admissible` twins remain until the theorem migration of #7659 lands. Removing them earlier would
-  hide the current Lean hypothesis boundary. The nonsymmetric same-fixed-point
-  problem in #7653 remains an optional out-of-source question; the transpose-
-  reparameterized construction rejected in #7705 is not part of this plan.
+- **Status**: open. The convention predicate exists, the reduced
+  representative is constructed in the ambient diagonal gauge, and the
+  MPU-level theorem migration has landed: the stabilized pair is now a
+  consequence of the predicate at the single positive exponent
+  $\max(D^2-1,1)$, and the forced-block contractions, the source-$u$
+  isometry with its rank bound, the source-$v$ isometry with its rank bound,
+  and the simple-tensor equivalence take the predicate in place of the
+  `(cfii, hfull)`, `(ρ, hρ, hρdiag)` and `(J, hJ, hpower)` groups. The
+  source-labelled nodes `lemuisometry` and `ThmFund1` are therefore checked
+  against those statements. What remains is the blueprint-side merge of the
+  surviving pointwise `mpu_admissible` twins, the `HasFullSupport` deletion
+  (still consumed by the physical-adjoint, identity-ancilla, and
+  tensor-product transports and by the reduced-representative construction),
+  and the `fin_one` stabilization branch (still consumed on route by
+  `cor:simple1` and `blockingsimple`(ii) in `SimpleBlocking.lean`). The
+  nonsymmetric same-fixed-point problem in #7653 remains an optional
+  out-of-source question; the transpose-reparameterized construction rejected
+  in #7705 is not part of this plan.
 - **Evidence**: `TNLean/MPS/MPU/` carries the paper's standing convention
   (`Papers/1703.09188/paper_v2.tex` lines 271--281 and 356--361) as explicit
   hypotheses in three shapes: `hρ : ρ.PosDef` at 65 sites in 11 files,


### PR DESCRIPTION
Closes #7659. Stacked on #7722 (`agent/mpu-cfii-ambient-diagonal-gauge`); the diff against `main` will shrink once that merges.

## What this does

`CLAUDE.md`'s "Degenerate readings are conventions, not gaps" rule: once a standing convention lives in one predicate it must not also be repeated as side hypotheses downstream. CPSV17 states its canonical-form-II convention once (`Papers/1703.09188/paper_v2.tex` lines 269--281 and 356--361, and again at 488--502 where the positive diagonal weight is used) and never repeats it. The MPU chain threaded its consequences as three groups — reduced canonical-form-II data with full support, a positive diagonal trace-one weight, and a supplied stabilized pair `E^J = |ρ)(Φ|`. All three now come from `MPOTensor.IsMPUCanonicalFormII` (#7657 / #7720, gauge from #7722).

## The enabling step

The stabilized pair is a theorem about the convention, not a datum. The recorded ambient `ρ` is a trace-one right fixed point and the stabilized power is rank one with left factor `(Φ|`, so `E^J |ρ) = |σ)(Φ|ρ) = tr(ρ)|σ) = |σ)` forces `σ = ρ`. New in `TransferStabilization.lean` and `DoubleLayerContraction.lean`:

- `IsMPUCanonicalFormII.vecMul_one_vec_transferMatrix` — `(Φ|E = (Φ|` (`Erightleft`, 269--281).
- `IsMPUCanonicalFormII.normalized_transfer_power_eq_vecMulVec` — `E ^ max (D*D-1) 1 = |ρ)(Φ|` (`Erightleft` plus the Jordan elimination of 397--405). One positive exponent valid in every bond dimension, so the `D = 1` branch no longer reaches the consumers and `hD : 1 < D` comes off.
- `IsMPUCanonicalFormII.normalizedDiagonal_pow_eq_vecMulVec` — the same identity for the normalized double-layer diagonal.
- `IsMPUCanonicalFormII.neZero_bond` — `tr(ρ) = 1` forces a nonempty bond space, so the migrated statements need no `[NeZero D]` instance.
- `IsMPUCanonicalFormII.neZero_phys` — on an empty physical index the normalized transfer map is the empty sum, so `E(ρ) = ρ` would force `ρ = 0` against `tr(ρ) = 1`. The migrated statements therefore need no `[NeZero d]` instance either, and the source-labelled nodes carry no `d > 0` clause the printed statements do not have (review threads on `lemuisometry` and `ThmFund1`).

## Hypotheses removed

| Declaration | Binders removed |
|---|---|
| `IsMPU.exists_reduced_cfii_forced_block_simple_contractions` → `IsMPUCanonicalFormII.forced_block_simple_contractions` | `(hD : 1 < D)`, `(cfii)`, `(hfull)`, `[NeZero D]`, and the existential fixed-point prefix of the conclusion |
| `IsMPU.sourceU_isIsometry` → `IsMPUCanonicalFormII.sourceU_isIsometry` | `(ρ)`, `(hρ)`, `(hρdiag)`, `(K)`, `(hK)` |
| `IsMPUSimple.sourceV_isIsometry` → `IsMPUCanonicalFormII.sourceV_isIsometry` | `(ρ)`, `(hρ)`, `(hρdiag)`, `(J)`, `(hJ)`, `(hpower)` |
| `IsMPUSimple.rightRank_mul_leftRank_le` → `IsMPUCanonicalFormII.rightRank_mul_leftRank_le` | `(ρ)`, `(hρ)`, `(J)`, `(hJ)`, `(hpower)` |
| `IsMPU.isMPUSimple_tfae` → `IsMPUCanonicalFormII.isMPUSimple_tfae` | `(ρ)`, `(hρ)`, `(hρdiag)`, `(J)`, `(hJ)`, `(hpower)` |

`IsMPUCanonicalFormII.mul_self_le_rightRank_mul_leftRank` is added so that the source-labelled `lemuisometry` node has both of its conclusions.

## Hypotheses deliberately kept

Each of these is genuinely more general than the predicate, not a repetition of it; migrating them would shrink the reusable API rather than remove an assumption (audit §"Minimal convention change").

- `SourceFactors.sourceU_isIsometry_of_isMPU`, `SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU`, `SourceFactors.sourceU_gram_eq_normalized_input_tail`, `SourceFactors.sourceU_gram_eq_normalized_mpo_input_tail_of_isDiag` — arbitrary supplied `SourceFactors U ρ`, arbitrary exponent.
- `IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power`, `normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power` — arbitrary trace-one `ρ` and arbitrary exponent.
- `IsMPUSimple.sourceV_transpose_isIsometry` — holds without diagonality, hence for the transposed weight; it is the step the migrated source-`v` isometry uses.
- `IsMPU.isMPUSimple_of_sourceV_isIsometry` — direction 4→1 uses no convention datum, only a positive definite weight.
- Everything in `SuppliedFixedWitnesses.lean` — generic in two supplied vectors `ρ, Φ : Fin (D*D) → ℂ`.
- All generic `(ρ) (hρ : ρ.PosDef)` parameters of `SourceFactors.lean` and `SourceUV.lean`, per the issue's explicit exclusion.
- `HasFullSupport`, its transports, and the `fin_one` stabilization branch. Full support is still consumed by the physical-adjoint, identity-ancilla and tensor-product data constructions and by the reduced-representative construction; `normalizedTransferStabilization_fin_one` is still consumed on route by `cor:simple1` and `blockingsimple`(ii) in `SimpleBlocking.lean`. Deleting them is the later step of the audit's plan.

## Blueprint

Because the migrated statements now carry the source's own hypothesis set, the source-labelled nodes advance:

- `lemuisometry` (CPSV17 Lemma III.7) gains `\lean{}` + `\leanok` and a proof; the supplied-fixed-pair lemma survives beside it as the generic step, renamed in its title and stripped of the scope-restriction comment.
- `ThmFund1` (CPSV17 Theorem III.8) gains `\lean{}` + `\leanok`, and the supplied-diagonal-fixed-pair twin `thm:mpu_diagonal_fixed_pair_simple_tensor_equivalence` is folded into it (its Lean declaration no longer exists).
- `thm:mpu_reduced_cfii_forced_block_simple_contractions` and `thm:mpu_simple_source_v_isometry` are restated on the convention and retargeted; their `\uses{def:mpu_full_support}` becomes `\uses{def:mpu_canonical_form_ii}`.
- New node `thm:mpu_canonical_form_ii_transfer_stabilization` for the two `Erightleft` equations and the double-layer form.
- `def:mpu_canonical_form_ii` also tags `neZero_bond`.

`thm:mpu_admissible_simple_tensor_equivalence`, `def:mpu_reduced_full_support_source_datum`, and the remaining 15 `\uses{def:mpu_full_support}` edges are untouched: those nodes still state full support in their own hypotheses, and retargeting them belongs with the `HasFullSupport` deletion. The blueprint twin merge (#7660) stacks on this branch.

## Docs

`docs/paper-gaps/mpu_canonical_form_full_support.tex` verdict now records that `lemuisometry` and `ThmFund1` carry the source's hypothesis set, and that what remains open is the transport of source cuts from an arbitrary ambient MPU to its reduced representative. `mpu_source_cut_orientation.tex` identifiers updated. `docs/proof_debt_ledger.md` D13 status updated.

## Verification

- `scripts/lake_build_locked.sh` (whole tree), `... TNLean.MPS.MPU`, `... TNLean.MPS.MPU.Examples` — all green.
- No `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast` in the changed files.
- `cd blueprint && leanblueprint web && leanblueprint checkdecls` — green.
- `python3 scripts/check_reader_facing_prose.py` — byte-identical output before and after (pre-existing PEPS violations only).
- `python3 scripts/blueprint_lean_sync.py` — "Blueprint and Lean code are in sync."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm

