### PR TITLE
doc(paper-gaps): record the pointwise admissible classification and the merge obstruction

### DIFF
--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -583,6 +583,91 @@ path-dependent statement remains under its \texttt{mpu\_admissible} label.
 The supplied-fixed-pair contraction does not by itself construct the source
 data required to remove these restrictions.
 
+\subsection*{The pointwise family is one connected group}
+
+Now that the bundled presentation carries the stabilized pair, the pointwise
+family splits three ways rather than two, and the split explains why its
+entries cannot be removed one at a time.
+
+Of the thirty-nine \texttt{mpu\_admissible} entries of Chapter~28, twenty-three
+are \texttt{def:mpu\_admissible\_equivalence\_datum} together with the entries
+whose dependencies cite it. These carry continuously varying path data and
+belong to \ghissue{6140}. The remaining sixteen are pointwise.
+
+One of the sixteen,
+\texttt{lem:mpu\_admissible\_source\_u\_isometry}, is not a duplicate. It is
+the generic step, stated for an arbitrary positive diagonal weight $\rho$ and
+an arbitrary exponent $K$ with $E^{K}=\lvert\rho)(\Phi\rvert$, and its formal
+statements still carry both inputs. The source-labelled Lemma~III.7 entry is
+proved from it together with the stabilized power of the bundled presentation,
+so it remains as the reusable step.
+
+Three of the sixteen ---
+\texttt{thm:mpu\_admissible\_simple\_tensor\_equivalence},
+\texttt{def:mpu\_admissible\_standard\_form}, and
+\texttt{thm:mpu\_admissible\_fundamental} --- restrict only the tensors that
+their source-labelled counterparts already place under the standing
+convention, and no formal statement carries their restriction any more. They
+are the only merge candidates.
+
+The other twelve restrict a tensor other than the one the source entry is
+about: an exact physical block $\mathcal U_k$, a physical-adjoint, transposed,
+or conjugate comparison tensor, a tensor product, or a composition. Assuming
+the presentation there is not the presentation on $\mathcal U$; it is the
+assertion that the presentation survives those operations. For blocking the
+source asserts exactly that, writing that the blocked tensor is again normal
+and in canonical form II \cite[line~356]{Cirac2017MPU}; for the comparison
+tensors, products, and compositions it is the content of \ghissue{6139}. In
+neither case is a preservation statement available, so all twelve keep their
+restriction.
+
+The three candidates cannot be removed while the twelve stand. Eleven retained
+entries cite them: seven pointwise entries, and the four path entries
+\texttt{prop:mpu\_admissible\_continuity\_index},
+\texttt{thm:mpu\_admissible\_index},
+\texttt{cor:mpu\_admissible\_continuous\_standard\_form}, and
+\texttt{lem:mpu\_admissible\_symmetry\_path\_criterion}. The tensors of all
+eleven carry a supplied fixed pair and nothing else. Redirecting their
+dependencies onto the convention-hypothesis entries would either strengthen
+eleven retained statements without saying so, or leave the implication
+\begin{align}
+    E^{J}=\lvert\rho)(\Phi\rvert
+     & \implies\text{canonical form II}
+    \label{eq:mpu_canonical_form_full_support_datum_to_convention}
+\end{align}
+unrecorded between the two families. Stating
+(\ref{eq:mpu_canonical_form_full_support_datum_to_convention}) as a bridge
+entry is the parallel-family-with-a-bridge configuration that the repository's
+convention rule forbids.
+
+The merge is therefore one operation on the whole pointwise group, and it
+closes when either of the following is available.
+
+\begin{itemize}
+    \item The converse of the stabilization theorem, namely
+          (\ref{eq:mpu_canonical_form_full_support_datum_to_convention}): a
+          positive diagonal trace-one $\rho$ with
+          $E^{J}=\lvert\rho)(\Phi\rvert$ for some $J>0$ leaves the transfer
+          matrix one nonzero eigenvalue, equal to one, hence a single normal
+          block filling the ambient bond space. This is the spectral step of
+          \cite[lines~344--355]{Cirac2017MPU} run from the stabilized power
+          instead of from the shifted traces. It makes every supplied fixed
+          pair a bundled presentation, and the sixteen pointwise entries then
+          go together.
+    \item Preservation of the bundled presentation under positive physical
+          blocking, physical adjunction, transposition, conjugation, identity
+          ancillas, tensor products, and composition. Full support alone is
+          already preserved under blocking, adjunction, relabelling, and
+          identity ancillas; the outstanding clause is the ambient fixed
+          matrix, whose behaviour under each operation is fixed by the
+          corresponding transfer-map identity already recorded in Chapter~28.
+          Blocking is the case the source states outright at line~356.
+\end{itemize}
+
+Until one of these exists, deleting any of the three candidates moves a
+hypothesis boundary out of sight without removing it, so the sixteen pointwise
+entries all remain.
+
 \section{Verdict}
 
 \textbf{Verdict: scope restriction.} The normal-tensor proposition,
@@ -623,7 +708,10 @@ continuity, and symmetry results also lack existence or preservation theorems
 for reduced source data under products, transformed comparison tensors, and
 continuous paths.
 Chapter~28 records these requirements as explicit admissibility hypotheses
-rather than consequences of the MPU predicate.
+rather than consequences of the MPU predicate. Those hypotheses form one
+connected group, so the corresponding entries are removed together and not
+singly; the elimination plan above records which of them are already free of a
+formal restriction and what the remaining three need.
 
 The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_r_eq_one_of_fullSupport}.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -634,10 +634,13 @@ a presentation from canonical data for a tensor equal to a normalized
 flattening, and from an arbitrary matrix product unitary by dimension
 reduction. Not one of the sixteen carries a presentation on $\mathcal U$ to a
 presentation on a physical block, an adjoint, a transpose, a conjugate, a
-tensor product, or a composition, which is the statement the twelve entries
-would need.
+tensor product, or a composition, which is what the twelve entries would need;
+for the composition entry the transport has to run through a reduced
+representative, as the last part of this subsection shows.
 
-The three candidates cannot be removed while the twelve stand. Eleven retained
+As the development stands today, the three candidates cannot be removed while
+the twelve stand, and what blocks them is a citation obstruction rather than a
+missing preservation result. Eleven retained
 entries cite them: seven pointwise entries, and the four path entries
 \texttt{prop:mpu\_admissible\_continuity\_index},
 \texttt{thm:mpu\_admissible\_index},
@@ -656,11 +659,13 @@ unrecorded between the two families. Stating
 entry is the parallel-family-with-a-bridge configuration that the repository's
 convention rule forbids.
 
-The merge is therefore one operation on the whole pointwise group, and it
-needs both of the following. Neither substitutes for the other: the first
-reaches the four entries whose restricted tensor is $\mathcal U$ itself, the
-second reaches the twelve whose restricted tensor is derived from
-$\mathcal U$.
+Two results are missing, and they unblock disjoint parts of the group in two
+independent stages rather than in one operation. The first reaches the four
+entries whose restricted tensor is $\mathcal U$ itself, and it dissolves the
+citation obstruction along with them, so the three candidates merge as soon as
+it exists, with the twelve still standing. The second reaches the twelve whose
+restricted tensor is derived from $\mathcal U$, and neither result is a
+prerequisite for the other.
 
 \begin{itemize}
     \item The converse of the stabilization theorem, namely
@@ -695,7 +700,9 @@ $\mathcal U$.
           \texttt{lem:mpu\_admissible\_source\_u\_isometry} and the three
           candidates. It also dissolves the citation obstruction above, since
           the eleven citing entries then obtain the presentation from their
-          own supplied pair instead of through a bridge entry. For the twelve
+          own supplied pair instead of through a bridge entry, so the three
+          candidates can be deleted at that point and the second item is not
+          needed for them. For the twelve
           it rewrites the restriction without weakening it, because the
           tensor carrying the datum is a derived one and the converse
           constructs no datum for a derived tensor.
@@ -708,7 +715,9 @@ $\mathcal U$.
           its normalized flattening, full support of those data, and a
           positive diagonal trace-one ambient matrix fixed by its normalized
           transfer map. Blocking is the case the source states outright at
-          line~356.
+          line~356. For composition no such statement about the product
+          tensor is available, for the reason given below; that case has to
+          go through a reduced representative instead.
 \end{itemize}
 
 The second item is not uniformly distant. For blocking, physical adjunction,
@@ -726,19 +735,66 @@ diagonal, of trace one, and fixed. Transposition and conjugation are
 transported only through their composite, physical adjunction; neither half is
 transported on its own.
 
-Composition is the far case. Unitarity of a composition is available, but the
-only recorded statement about its normalized flattening is the entrywise
-physical-contraction formula. No canonical-form-II data are constructed for a
-composition tensor, and no transfer-map identity for one is recorded, so
-neither the canonical-form-II clause nor the ambient-fixed-matrix clause of
-the presentation can be produced there at all. The composition case of the
-second item therefore needs two results and not one, and until it has them
-\texttt{lem:mpu\_admissible\_index\_composition} keeps its six per-block
-restrictions even if every other preservation statement is proved.
+Composition is the far case, and it differs from the other five in kind and
+not only in distance. Unitarity of a composition is available, but the only
+recorded statement about its normalized flattening is the entrywise
+physical-contraction formula: no canonical-form-II data are constructed for a
+composition tensor, and no transfer-map identity for one is recorded. Supplying
+those two results would still not settle the case, because for a composition
+the presentation can fail outright.
 
-Until both items exist, deleting any of the three candidates moves a
-hypothesis boundary out of sight without removing it, so the sixteen pointwise
-entries all remain.
+A composition keeps the whole product bond space $D_1D_2$, and that space can
+be too large for the full-support clause. Take the right shift on $d\geq 2$
+levels and its physical adjoint, both matrix product unitaries
+(\leanid{MPOTensor.rightShiftTensor} and \leanid{MPOTensor.leftShiftTensor}).
+Their composite generates the identity operator at every length, and in the
+product bond space $\mathbb C^{d}\otimes\mathbb C^{d}$ its one-site matrices
+are
+\begin{align}
+    A^{(i,k)} & =\lvert i,k\rangle\langle\Phi\rvert,\qquad
+    \langle\Phi\rvert=\sum_{\gamma}\langle\gamma,\gamma\rvert.
+    \label{eq:mpu_canonical_form_full_support_shift_composite}
+\end{align}
+Each of these has rank one, and they share the row functional
+$\langle\Phi\rvert$, so every product of them, at every length, again has rank
+one and every element of the span of the length-$L$ products has rank at most
+one. A tensor with full-support canonical-form-II data is a unitary conjugate
+of a direct sum of nonzero multiples of normal blocks whose dimensions add up
+to the ambient dimension. A retained block of dimension at least two would put
+a matrix of rank at least two into that span, so every block would have
+dimension one; but then the one-site matrices would all be diagonal in one
+basis and would commute, and
+Eq.~\ref{eq:mpu_canonical_form_full_support_shift_composite} gives
+$A^{(0,0)}A^{(0,1)}=0$ while
+$A^{(0,1)}A^{(0,0)}=\lvert 0,1\rangle\langle\Phi\rvert\neq 0$.
+The composite therefore has no
+full-support canonical-form-II data in the product bond space at all, and no
+amount of blocking repairs it, since the blocked matrices are the same
+products and stay of rank one.
+
+This is the enlargement phenomenon of the opening section met again: the
+composite is a nonminimal ambient representative of the operator family it
+generates, and the presentation is a property of the representative and not of
+the operators. The composition case therefore does not ask for a preservation
+statement about the product tensor. It asks for the reduced representative
+\leanid{MPOTensor.IsMPU.exists_reduced_cfii_representative} applied to the
+product, together with an identification of the source cuts and ranks of
+\texttt{lem:mpu\_admissible\_index\_composition} across that reduction, which
+is exactly what the reduced-representative theorem does not supply. The source
+takes the same route implicitly: its index-additivity argument blocks the
+composite until it is simple \cite[lines~837--841]{Cirac2017MPU}, which for a
+composite of this shape is unreachable in the product bond space, so the
+tensor it blocks is already a reduced representative. Until that reduction and
+that transport exist,
+\texttt{lem:mpu\_admissible\_index\_composition} keeps its six per-block
+restrictions even if every other preservation statement is proved, and the
+work it needs is larger than the two missing results named above.
+
+Until the first item exists, deleting any of the three candidates moves a
+hypothesis boundary out of sight without removing it, so all sixteen pointwise
+entries remain. Once it exists, the three candidates merge and thirteen remain:
+the generic supplied-pair step, which is kept deliberately, and the twelve
+derived-tensor entries, each waiting on its own operation in the second item.
 
 \section{Verdict}
 

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -646,7 +646,7 @@ eleven carry a supplied fixed pair and nothing else. Redirecting their
 dependencies onto the convention-hypothesis entries would either strengthen
 eleven retained statements without saying so, or leave the implication
 \begin{align}
-    E^{J}=\lvert\rho)(\Phi\rvert
+    \text{unitary periodic family},\ E^{J}=\lvert\rho)(\Phi\rvert
      & \implies\text{canonical form II}
     \label{eq:mpu_canonical_form_full_support_datum_to_convention}
 \end{align}
@@ -663,15 +663,32 @@ $\mathcal U$.
 
 \begin{itemize}
     \item The converse of the stabilization theorem, namely
-          (\ref{eq:mpu_canonical_form_full_support_datum_to_convention}): a
-          positive diagonal trace-one $\rho$ with
-          $E^{J}=\lvert\rho)(\Phi\rvert$ for some $J>0$ leaves the transfer
-          matrix one nonzero eigenvalue, equal to one, hence a single normal
-          block filling the ambient bond space. This is the spectral step of
+          (\ref{eq:mpu_canonical_form_full_support_datum_to_convention}): for
+          a tensor whose periodic operators are all unitary, a positive
+          diagonal trace-one $\rho$ with $E^{J}=\lvert\rho)(\Phi\rvert$ for
+          some $J>0$ leaves the transfer matrix one nonzero eigenvalue, equal
+          to one, hence a single normal block filling the ambient bond space.
+          This is the spectral step of
           \cite[lines~344--355]{Cirac2017MPU} run from the stabilized power
-          instead of from the shifted traces. It turns a supplied fixed pair
-          into the bundled presentation of the tensor that carries it, and
-          nothing more. So it removes the restriction exactly where the
+          instead of from the shifted traces. Unitarity of the periodic
+          family is a premise and not a conclusion of the spectral step: the
+          bundled presentation contains it, while an exact rank-one transfer
+          power constrains only the normalized double layer. Every entry the
+          converse is meant to serve carries it already.
+
+          The exponent premise costs nothing. The generic supplied-pair entry
+          admits the exponent zero, where the condition reads
+          $\mathbf 1=\lvert\rho)(\Phi\rvert$; the right side has rank at most
+          one, so the bond dimension is one, and in bond dimension one the
+          normalized transfer matrix of a tensor with a unitary periodic
+          family is already the identity
+          \cite[lines~397--409]{Cirac2017MPU}. The same pair then satisfies
+          the condition at the exponent one, so the converse at a positive
+          exponent covers the zero-exponent inputs as well.
+
+          It turns a supplied fixed pair into the bundled presentation of the
+          tensor that carries it, and nothing more. So it removes the
+          restriction exactly where the
           tensor carrying the datum is the tensor the standing convention
           already governs: the four entries
           \texttt{lem:mpu\_admissible\_source\_u\_isometry} and the three

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -836,10 +836,15 @@ continuity, and symmetry results also lack existence or preservation theorems
 for reduced source data under products, transformed comparison tensors, and
 continuous paths.
 Chapter~28 records these requirements as explicit admissibility hypotheses
-rather than consequences of the MPU predicate. Those hypotheses form one
-connected group, so the corresponding entries are removed together and not
-singly; the elimination plan above records which of them are already free of a
-formal restriction and what the remaining three need.
+rather than consequences of the MPU predicate. They come off in two stages,
+neither singly nor all at once. The converse of the stabilization theorem
+releases the three entries that already carry no formal restriction, together
+with the citation obstruction that holds them at present. Preservation along
+each derived-tensor operation releases the twelve whose restriction is on a
+physical block, a comparison tensor, a tensor product, or a composition, the
+last of these by way of a reduced representative rather than a preservation
+statement. The elimination plan above records both stages and what each one
+needs.
 
 The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_r_eq_one_of_fullSupport}.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -656,7 +656,10 @@ entry is the parallel-family-with-a-bridge configuration that the repository's
 convention rule forbids.
 
 The merge is therefore one operation on the whole pointwise group, and it
-closes when either of the following is available.
+needs both of the following. Neither substitutes for the other: the first
+reaches the four entries whose restricted tensor is $\mathcal U$ itself, the
+second reaches the twelve whose restricted tensor is derived from
+$\mathcal U$.
 
 \begin{itemize}
     \item The converse of the stabilization theorem, namely
@@ -666,20 +669,56 @@ closes when either of the following is available.
           matrix one nonzero eigenvalue, equal to one, hence a single normal
           block filling the ambient bond space. This is the spectral step of
           \cite[lines~344--355]{Cirac2017MPU} run from the stabilized power
-          instead of from the shifted traces. It makes every supplied fixed
-          pair a bundled presentation, and the sixteen pointwise entries then
-          go together.
-    \item Preservation of the bundled presentation under positive physical
-          blocking, physical adjunction, transposition, conjugation, identity
-          ancillas, tensor products, and composition. Full support alone is
-          already preserved under blocking, adjunction, relabelling, and
-          identity ancillas; the outstanding clause is the ambient fixed
-          matrix, whose behaviour under each operation is fixed by the
-          corresponding transfer-map identity already recorded in Chapter~28.
-          Blocking is the case the source states outright at line~356.
+          instead of from the shifted traces. It turns a supplied fixed pair
+          into the bundled presentation of the tensor that carries it, and
+          nothing more. So it removes the restriction exactly where the
+          tensor carrying the datum is the tensor the standing convention
+          already governs: the four entries
+          \texttt{lem:mpu\_admissible\_source\_u\_isometry} and the three
+          candidates. It also dissolves the citation obstruction above, since
+          the eleven citing entries then obtain the presentation from their
+          own supplied pair instead of through a bridge entry. For the twelve
+          it rewrites the restriction without weakening it, because the
+          tensor carrying the datum is a derived one and the converse
+          constructs no datum for a derived tensor.
+    \item Preservation of the bundled presentation along each operation the
+          twelve use: positive physical blocking, physical adjunction,
+          transposition, complex conjugation, independent tensor products,
+          and composition. A preservation statement must deliver all four
+          clauses of the presentation for the derived tensor: unitarity of
+          its periodic operator family, literal canonical-form-II data for
+          its normalized flattening, full support of those data, and a
+          positive diagonal trace-one ambient matrix fixed by its normalized
+          transfer map. Blocking is the case the source states outright at
+          line~356.
 \end{itemize}
 
-Until one of these exists, deleting any of the three candidates moves a
+The second item is not uniformly distant. For blocking, physical adjunction,
+and independent tensor products all four clauses are separately available and
+only the assembled statement is missing. Blocking preserves unitarity,
+transports canonical-form-II data to the blocked normalized flattening,
+preserves full support, and iterates the transfer map, so the same ambient
+matrix stays fixed. Physical adjunction preserves unitarity, transports the
+data together with their full support, and conjugates the transfer map
+entrywise. Independent tensor products preserve unitarity, carry product
+canonical-form-II data whose full support follows from full support of the two
+factors, and act on transfer maps as a Kronecker product, under which the
+Kronecker product of the two ambient matrices is again positive definite,
+diagonal, of trace one, and fixed. Transposition and conjugation are
+transported only through their composite, physical adjunction; neither half is
+transported on its own.
+
+Composition is the far case. Unitarity of a composition is available, but the
+only recorded statement about its normalized flattening is the entrywise
+physical-contraction formula. No canonical-form-II data are constructed for a
+composition tensor, and no transfer-map identity for one is recorded, so
+neither the canonical-form-II clause nor the ambient-fixed-matrix clause of
+the presentation can be produced there at all. The composition case of the
+second item therefore needs two results and not one, and until it has them
+\texttt{lem:mpu\_admissible\_index\_composition} keeps its six per-block
+restrictions even if every other preservation statement is proved.
+
+Until both items exist, deleting any of the three candidates moves a
 hypothesis boundary out of sight without removing it, so the sixteen pointwise
 entries all remain.
 

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -621,17 +621,18 @@ tensors, products, and compositions it is the content of \ghissue{6139}. In
 neither case is a preservation statement available, so all twelve keep their
 restriction.
 
-The census behind that unavailability is the following. Fifteen formal
-declarations mention the bundled presentation: the structure itself, twelve
-that consume it, and two that construct one. The twelve consumers conclude,
+The census behind that unavailability is the following. Sixteen formal
+declarations mention the bundled presentation: the structure itself, thirteen
+that consume it, and two that construct one. The thirteen consumers conclude,
 about the same tensor, that its retained blocks fill the ambient bond space,
-that its bond space is nonempty, that its normalized flattening is a normal
-tensor, that its block contractions are forced, the simplicity equivalence,
+that its bond space is nonempty, that its physical space is nonempty, that its
+normalized flattening is a normal tensor, that its block contractions are
+forced, the simplicity equivalence,
 the two stabilized transfer identities, the normalized diagonal power, and the
 four source-factor isometry and rank statements. The two constructions produce
 a presentation from canonical data for a tensor equal to a normalized
 flattening, and from an arbitrary matrix product unitary by dimension
-reduction. Not one of the fifteen carries a presentation on $\mathcal U$ to a
+reduction. Not one of the sixteen carries a presentation on $\mathcal U$ to a
 presentation on a physical block, an adjoint, a transpose, a conjugate, a
 tensor product, or a composition, which is the statement the twelve entries
 would need.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -621,6 +621,21 @@ tensors, products, and compositions it is the content of \ghissue{6139}. In
 neither case is a preservation statement available, so all twelve keep their
 restriction.
 
+The census behind that unavailability is the following. Fifteen formal
+declarations mention the bundled presentation: the structure itself, twelve
+that consume it, and two that construct one. The twelve consumers conclude,
+about the same tensor, that its retained blocks fill the ambient bond space,
+that its bond space is nonempty, that its normalized flattening is a normal
+tensor, that its block contractions are forced, the simplicity equivalence,
+the two stabilized transfer identities, the normalized diagonal power, and the
+four source-factor isometry and rank statements. The two constructions produce
+a presentation from canonical data for a tensor equal to a normalized
+flattening, and from an arbitrary matrix product unitary by dimension
+reduction. Not one of the fifteen carries a presentation on $\mathcal U$ to a
+presentation on a physical block, an adjoint, a transpose, a conjugate, a
+tensor product, or a composition, which is the statement the twelve entries
+would need.
+
 The three candidates cannot be removed while the twelve stand. Eleven retained
 entries cite them: seven pointwise entries, and the four path entries
 \texttt{prop:mpu\_admissible\_continuity\_index},

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -672,7 +672,7 @@ prerequisite for the other.
           (\ref{eq:mpu_canonical_form_full_support_datum_to_convention}): for
           a tensor whose periodic operators are all unitary, a positive
           diagonal trace-one $\rho$ with $E^{J}=\lvert\rho)(\Phi\rvert$ for
-          some $J>0$ leaves the transfer matrix one nonzero eigenvalue, equal
+          some $J>0$ leaves the transfer matrix with one nonzero eigenvalue, equal
           to one, hence a single normal block filling the ambient bond space.
           This is the spectral step of
           \cite[lines~344--355]{Cirac2017MPU} run from the stabilized power
@@ -682,11 +682,40 @@ prerequisite for the other.
           power constrains only the normalized double layer. Every entry the
           converse is meant to serve carries it already.
 
+          Trace normalization need not be added to the generic supplied-pair
+          entry. Write $P=\lvert\rho)(\Phi\rvert$ and $t=\tr(\rho)$.
+          Since $(\Phi\vert\rho)=t$, direct multiplication gives
+          \begin{align}
+              P^2&=tP, & \tr(P)&=t.
+              \label{eq:mpu_canonical_form_full_support_pair_trace}
+          \end{align}
+          The MPU trace identities hold at every length greater than one
+          \cite[lines~349--354]{Cirac2017MPU}. Thus, if $E^K=P$ and $K\geq2$,
+          \begin{align}
+              t&=\tr(P)=\tr(E^K)=1.
+              \label{eq:mpu_canonical_form_full_support_trace_large_exponent}
+          \end{align}
+          If $K=1$, use lengths two and three instead of assuming a
+          length-one trace identity. By
+          (\ref{eq:mpu_canonical_form_full_support_pair_trace}),
+          \begin{align}
+              t^2&=\tr(P^2)=\tr(E^2)=1, &
+              t^3&=\tr(P^3)=\tr(E^3)=1, & t&=1.
+              \label{eq:mpu_canonical_form_full_support_trace_exponent_one}
+          \end{align}
           The exponent premise costs nothing. The generic supplied-pair entry
           admits the exponent zero, where the condition reads
           $\mathbf 1=\lvert\rho)(\Phi\rvert$; the right side has rank at most
-          one, so the bond dimension is one, and in bond dimension one the
-          normalized transfer matrix of a tensor with a unitary periodic
+          one. The bond dimension cannot vanish, since a zero-dimensional
+          bond space gives a zero periodic operator on the nonempty physical
+          space. Hence $D=1$, and taking traces gives
+          \begin{align}
+              t&=\tr(P)=\tr(\mathbf 1_{D^2})=D^2=1.
+              \label{eq:mpu_canonical_form_full_support_trace_exponent_zero}
+          \end{align}
+          Thus the normalization required by the converse follows in every
+          case. In bond dimension one the normalized transfer matrix of a
+          tensor with a unitary periodic
           family is already the identity
           \cite[lines~397--409]{Cirac2017MPU}. The same pair then satisfies
           the condition at the exponent one, so the converse at a positive

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -535,9 +535,15 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   supplied fixed pair, so deleting them singly would strengthen those 11
   statements silently. Two independent unblockers are needed, and neither
   substitutes for the other. The converse
-  `E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII`, by the spectral step
-  of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a supplied pair
-  into a presentation of the same tensor; it therefore reaches only the 4
+  `IsMPU U → E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII U`, by the
+  spectral step of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a
+  supplied pair into a presentation of the same tensor. `IsMPU` has to stay a
+  premise, since `IsMPUCanonicalFormII` contains it and a rank-one transfer
+  power constrains only the normalized double layer; every intended call site
+  supplies it. The `K = 0` inputs the generic node admits are not lost: at
+  that exponent the condition forces `D = 1`, where
+  `IsMPU.normalized_transfer_matrix_eq_one_fin_one` gives `E = 1` and the same
+  pair works at exponent one. It therefore reaches only the 4
   nodes whose restricted tensor is the one the convention already governs
   (`lem:mpu_admissible_source_u_isometry` and the 3 candidates), and it
   dissolves the citation obstruction, but it constructs no datum for a

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -533,12 +533,35 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   `cor:mpu_admissible_continuous_standard_form`, and
   `lem:mpu_admissible_symmetry_path_criterion`) whose tensors carry only a
   supplied fixed pair, so deleting them singly would strengthen those 11
-  statements silently. The two unblockers are the converse
-  `E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII` by the spectral step
-  of `Papers/1703.09188/paper_v2.tex` lines 344--355, and preservation of
+  statements silently. Two independent unblockers are needed, and neither
+  substitutes for the other. The converse
+  `E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII`, by the spectral step
+  of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a supplied pair
+  into a presentation of the same tensor; it therefore reaches only the 4
+  nodes whose restricted tensor is the one the convention already governs
+  (`lem:mpu_admissible_source_u_isometry` and the 3 candidates), and it
+  dissolves the citation obstruction, but it constructs no datum for a
+  derived tensor and so leaves all 12 restricted. Preservation of
   `IsMPUCanonicalFormII` under positive physical blocking (asserted at source
-  line 356), physical adjunction, transposition, conjugation, identity
-  ancillas, tensor products, and composition. The
+  line 356), physical adjunction, transposition, conjugation, tensor
+  products, and composition is what reaches the 12; each such statement must
+  produce all four clauses (`isMPU`, `cfii`, `fullSupport_eq`, and the
+  positive diagonal trace-one `ρ` with `ρ_fixed`) for the derived tensor. For
+  blocking, physical adjunction, and tensor products every clause is
+  separately available (`IsMPU.blockTensor`, `blockTensorCFIIData`,
+  `hasFullSupport_blockTensor`, `transferMap_blockTensor`;
+  `IsMPU.physicalAdjointTensor`, `physicalAdjointNormalizedFlattening`,
+  `hasFullSupport_physicalAdjointNormalizedFlattening`,
+  `transferMap_mapStar`; `IsMPU.tensorProduct`, `tensorProductCFIIData`,
+  `hasFullSupport_tensorProductCFIIData`,
+  `transferMap_tensorProduct_kronecker`) and only the assembled statement is
+  missing; transposition and conjugation exist only as the composite. For
+  composition only `IsMPU.mulTensor` is available: `TNLean/MPS/MPU/` has no
+  canonical-form-II construction for `mulTensor` and no transfer-map identity
+  for it, only the entrywise `normalizedFlattening_mulTensor_apply`, so that
+  case needs two new results and
+  `lem:mpu_admissible_index_composition` stays restricted until it has them.
+  The
   nonsymmetric same-fixed-point problem in #7653 remains an optional
   out-of-source question; the transpose-reparameterized construction rejected
   in #7705 is not part of this plan.

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -536,9 +536,13 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   statements silently. Two unblockers are needed; they reach disjoint parts of
   the group, neither is a prerequisite for the other, and they land in two
   stages rather than together. The converse
-  `IsMPU U → E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII U`, by the
-  spectral step of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a
-  supplied pair into a presentation of the same tensor. `IsMPU` has to stay a
+  `IsMPU U → ρ.PosDef → ρ.IsDiag → Matrix.trace ρ = 1 → 0 < J →
+  E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII U`, by the spectral
+  step of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a supplied
+  positive-definite diagonal trace-one pair into a presentation of the same
+  tensor. These fixed-weight hypotheses match the detailed gap note; trace
+  normalization is an explicit premise, not an unproved derivation.
+  `IsMPU` has to stay a
   premise, since `IsMPUCanonicalFormII` contains it and a rank-one transfer
   power constrains only the normalized double layer; every intended call site
   supplies it. The `K = 0` inputs the generic node admits are not lost: at

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -516,6 +516,29 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   tensor-product transports and by the reduced-representative construction),
   and the `fin_one` stabilization branch (still consumed on route by
   `cor:simple1` and `blockingsimple`(ii) in `SimpleBlocking.lean`). The
+  blueprint-side merge is now blocked on preservation rather than on the
+  predicate. Of the 16 pointwise nodes,
+  `lem:mpu_admissible_source_u_isometry` is the generic supplied-fixed-pair
+  step whose Lean statements still carry `(ρ, hρ, K, hpower)` and which the
+  `lemuisometry` proof consumes; 3
+  (`thm:mpu_admissible_simple_tensor_equivalence`,
+  `def:mpu_admissible_standard_form`, `thm:mpu_admissible_fundamental`)
+  restrict only the tensor their source-labelled counterpart already places
+  under the convention and have no Lean restriction left; the other 12
+  restrict a physical block, a physical-adjoint, transposed, or conjugate
+  comparison tensor, a tensor product, or a composition, for which no
+  preservation statement of the predicate exists. The 3 are cited by 11
+  retained nodes (7 pointwise plus the path nodes
+  `prop:mpu_admissible_continuity_index`, `thm:mpu_admissible_index`,
+  `cor:mpu_admissible_continuous_standard_form`, and
+  `lem:mpu_admissible_symmetry_path_criterion`) whose tensors carry only a
+  supplied fixed pair, so deleting them singly would strengthen those 11
+  statements silently. The two unblockers are the converse
+  `E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII` by the spectral step
+  of `Papers/1703.09188/paper_v2.tex` lines 344--355, and preservation of
+  `IsMPUCanonicalFormII` under positive physical blocking (asserted at source
+  line 356), physical adjunction, transposition, conjugation, identity
+  ancillas, tensor products, and composition. The
   nonsymmetric same-fixed-point problem in #7653 remains an optional
   out-of-source question; the transpose-reparameterized construction rejected
   in #7705 is not part of this plan.

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -533,8 +533,9 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   `cor:mpu_admissible_continuous_standard_form`, and
   `lem:mpu_admissible_symmetry_path_criterion`) whose tensors carry only a
   supplied fixed pair, so deleting them singly would strengthen those 11
-  statements silently. Two independent unblockers are needed, and neither
-  substitutes for the other. The converse
+  statements silently. Two unblockers are needed; they reach disjoint parts of
+  the group, neither is a prerequisite for the other, and they land in two
+  stages rather than together. The converse
   `IsMPU U → E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII U`, by the
   spectral step of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a
   supplied pair into a presentation of the same tensor. `IsMPU` has to stay a
@@ -547,7 +548,9 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   nodes whose restricted tensor is the one the convention already governs
   (`lem:mpu_admissible_source_u_isometry` and the 3 candidates), and it
   dissolves the citation obstruction, but it constructs no datum for a
-  derived tensor and so leaves all 12 restricted. Preservation of
+  derived tensor and so leaves all 12 restricted. The 3 candidates therefore
+  merge as soon as the converse lands, with the 12 still standing; the second
+  unblocker is not needed for them. Preservation of
   `IsMPUCanonicalFormII` under positive physical blocking (asserted at source
   line 356), physical adjunction, transposition, conjugation, tensor
   products, and composition is what reaches the 12; each such statement must
@@ -564,9 +567,19 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   missing; transposition and conjugation exist only as the composite. For
   composition only `IsMPU.mulTensor` is available: `TNLean/MPS/MPU/` has no
   canonical-form-II construction for `mulTensor` and no transfer-map identity
-  for it, only the entrywise `normalizedFlattening_mulTensor_apply`, so that
-  case needs two new results and
-  `lem:mpu_admissible_index_composition` stays restricted until it has them.
+  for it, only the entrywise `normalizedFlattening_mulTensor_apply`. Supplying
+  those two would not settle that case, because no preservation statement can
+  hold for `mulTensor` as it stands: `mulTensor (rightShiftTensor d)
+  (leftShiftTensor d)` for `d ≥ 2` generates the identity operator with
+  one-site matrices `A (i, k) = |i, k⟩⟨Φ|`, `⟨Φ| = ∑ γ, ⟨γ, γ|`, which are
+  rank one with a common row functional, so every product at every length is
+  rank one, no retained block of dimension ≥ 2 fits, blocks of dimension 1
+  would force the `A (i, k)` to commute, and they do not
+  (`A (0, 0) * A (0, 1) = 0` while `A (0, 1) * A (0, 0) ≠ 0`). The composition
+  case therefore needs `IsMPU.exists_reduced_cfii_representative` applied to
+  the product plus a transport of the source cuts and ranks across that
+  reduction, which that theorem explicitly does not give, and
+  `lem:mpu_admissible_index_composition` stays restricted until both exist.
   The
   nonsymmetric same-fixed-point problem in #7653 remains an optional
   out-of-source question; the transpose-reparameterized construction rejected

--- a/docs/proof_debt_ledger.md
+++ b/docs/proof_debt_ledger.md
@@ -520,7 +520,7 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   predicate. Of the 16 pointwise nodes,
   `lem:mpu_admissible_source_u_isometry` is the generic supplied-fixed-pair
   step whose Lean statements still carry `(ρ, hρ, K, hpower)` and which the
-  `lemuisometry` proof consumes; 3
+  `lemuisometry` proof consumes. Three nodes
   (`thm:mpu_admissible_simple_tensor_equivalence`,
   `def:mpu_admissible_standard_form`, `thm:mpu_admissible_fundamental`)
   restrict only the tensor their source-labelled counterpart already places
@@ -540,11 +540,20 @@ compounding cost; D13 precedes D14 because every new MPU statement pays it.
   E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII U`, by the spectral
   step of `Papers/1703.09188/paper_v2.tex` lines 344--355, turns a supplied
   positive-definite diagonal trace-one pair into a presentation of the same
-  tensor. These fixed-weight hypotheses match the detailed gap note; trace
-  normalization is an explicit premise, not an unproved derivation.
-  `IsMPU` has to stay a
-  premise, since `IsMPUCanonicalFormII` contains it and a rank-one transfer
-  power constrains only the normalized double layer; every intended call site
+  tensor. The generic supplied-pair entry does not assume trace normalization,
+  but it follows from its power identity. Put $P=|\rho)(\Phi|$ and
+  $t=\operatorname{tr}(\rho)$, so $P^2=tP$ and $\operatorname{tr}(P)=t$.
+  For $K\geq2$, the MPU trace identity gives $t=\operatorname{tr}(E^K)=1$.
+  For $K=1$, it gives $t^2=\operatorname{tr}(E^2)=1$ and
+  $t^3=\operatorname{tr}(E^3)=1$, hence $t=1$; no length-one MPU trace
+  identity is needed. For $K=0$, $P=I$ and $D=1$ as below give $t=1$.
+  Thus this premise of the missing converse does not strengthen that entry.
+  The positive-length trace identities are formalized in
+  `IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one` for lengths
+  greater than one; the detailed gap note records the calculation.
+  `IsMPU` has to stay a premise, since `IsMPUCanonicalFormII` contains it and
+  a rank-one transfer power constrains only the normalized double layer;
+  every intended call site
   supplies it. The `K = 0` inputs the generic node admits are not lost: at
   that exponent the condition forces `D = 1`, where
   `IsMPU.normalized_transfer_matrix_eq_one_fin_one` gives `E = 1` and the same


### PR DESCRIPTION
Advances #7660. No blueprint node is deleted; the remainder is named below.

Stacked on #7728 (`agent/issue-7659-convention-migration`).

## What was checked

The 16/23 split was re-derived mechanically against the current
`blueprint/src/chapter/ch28_mpu.tex` rather than taken from the audit:
39 entries carry an `mpu_admissible` label; `def:mpu_admissible_equivalence_datum`
together with the 22 entries whose `\uses` cite it is the pathwise group
(23), and the complement is the pointwise group (16). This reproduces the
audit's counts exactly.

Each pointwise entry was then read against the Lean declarations behind it
and behind its source-labelled counterpart on this branch.

## Result: 0 merged, 23 retained as pathwise, 16 retained as still restricted

**Retained because the Lean signature still carries the restriction (1).**
`lem:mpu_admissible_source_u_isometry` is not a twin at all: it is the
generic step, and `MPOTensor.SourceFactors.sourceU_isIsometry_of_isMPU`
and `MPOTensor.SourceFactors.mul_self_le_rightRank_mul_leftRank_of_isMPU`
still take an arbitrary positive diagonal weight and an arbitrary
exponent with `E ^ K = vecMulVec ρ.vec 1.vec`. The `\leanok` proof of
`lemuisometry` consumes it.

**Free of a formal restriction, but not removable in isolation (3).**
`thm:mpu_admissible_simple_tensor_equivalence`,
`def:mpu_admissible_standard_form`, and `thm:mpu_admissible_fundamental`
restrict only the tensors that `ThmFund1`, `SF`, and `FundamentalMPU`
already place under the standing convention, and `#7728` removed the last
Lean declaration carrying that restriction. They are cited by 11 retained
entries — 7 pointwise, plus the path entries
`prop:mpu_admissible_continuity_index`, `thm:mpu_admissible_index`,
`cor:mpu_admissible_continuous_standard_form`, and
`lem:mpu_admissible_symmetry_path_criterion` — whose own tensors carry a
supplied fixed pair and nothing else. Repointing those `\uses` at the
convention-hypothesis survivors would either strengthen 11 retained
statements silently or leave the implication
`E ^ J = |ρ)(Φ| ⟹ canonical form II` unstated between the two families;
adding it as a bridge entry is the parallel-family-with-a-bridge shape
that `CLAUDE.md`'s convention rule forbids. So the merge is one operation
on the whole pointwise subgraph, not a node-by-node deletion.

**Retained because the restriction is on a different tensor (12).**
`def:mpu_admissible_index`, `prop:mpu_admissible_index_well_defined`,
`lem:mpu_admissible_index_tensor`, `lem:mpu_admissible_index_composition`,
`prop:mpu_admissible_conjugation_symmetry`,
`prop:mpu_admissible_conjugation_standard_forms`,
`cor:mpu_admissible_symplectic_to_orthogonal`,
`prop:mpu_admissible_local_time_reversal`,
`prop:mpu_admissible_local_transposition`,
`lem:mpu_admissible_sigma_trace`,
`lem:mpu_admissible_sigma_gauge_invariant`, and
`prop:mpu_admissible_sigma_blocking_parity` each supply data for an exact
physical block, a physical-adjoint, transposed, or conjugate comparison
tensor, a tensor product, or a composition. Assuming the presentation
there is the assertion that it survives those operations. No such
statement exists, and the blueprint carries only the full-support
transports.

### Correction to the census (audit fix)

The enumeration first offered here counted **twelve** declarations
mentioning `IsMPUCanonicalFormII`. That was an undercount produced by a
head-line search: the hypothesis of
`MPOTensor.IsMPUCanonicalFormII.isNormalTensor_normalizedFlattening`
(`TNLean/MPS/MPU/CanonicalForm.lean:463`, docstring opening at `:459`)
wraps onto the line after its `theorem` line, so the search never saw it.
Two declarations in `ReducedCanonicalRepresentative.lean` were missed the
same way, on the producing side.

Recounted by enclosing declaration rather than by head line, the census in
`TNLean/MPS/MPU/` is **fifteen**:

| Role | Count | Declarations |
|---|---|---|
| The structure | 1 | `IsMPUCanonicalFormII` (`CanonicalForm.lean:338`) |
| Consumers | 12 | `hasFullSupport`, `neZero_bond`, `isNormalTensor_normalizedFlattening` (`CanonicalForm.lean`); `forced_block_simple_contractions`; `isMPUSimple_tfae`; `vecMul_one_vec_transferMatrix`, `normalized_transfer_power_eq_vecMulVec`; `normalizedDiagonal_pow_eq_vecMulVec`; `sourceV_isIsometry`, `rightRank_mul_leftRank_le`; `sourceU_isIsometry`, `mul_self_le_rightRank_mul_leftRank` |
| Producers | 2 | `mpuCanonicalFormIIOfNormalizedFlatteningEq` (private), `IsMPU.exists_reduced_cfii_representative` |

**The classification does not change.** The missed consumer,
`isNormalTensor_normalizedFlattening`, takes a presentation on `U` and
concludes `IsNormalTensor U.normalizedFlattening` — a property of the same
tensor. It is not a transport of the presentation to a physical block, an
adjoint, a transpose, a conjugate, a tensor product, or a composition,
which is what the twelve entries in this group would need. The two
producers construct a presentation from canonical data or by dimension
reduction, and likewise transport nothing. So none of the fifteen supplies
the missing preservation statement, all twelve entries keep their
restriction, and **0 merged** stands.

The corrected census is recorded in
`docs/paper-gaps/mpu_canonical_form_full_support.tex` so the claim is
checkable without repeating the search.

### Correction to the elimination plan (review round 2)

Both reviewers objected that the converse
`E ^ J = vecMulVec ρ.vec 1.vec → IsMPUCanonicalFormII` was described as a
route to merging all sixteen pointwise entries. They are right. The converse
turns a supplied fixed pair into the bundled presentation of **the tensor that
carries it**; it constructs no datum for a derived tensor. It therefore
reaches only the four entries whose restricted tensor is the one the standing
convention already governs (`lem:mpu_admissible_source_u_isometry` and the
three candidates), and it dissolves the citation obstruction, but it rewrites
the twelve derived-tensor restrictions without weakening them.

The plan now states, per operation used by the twelve, what a preservation
statement must deliver — the four clauses `isMPU`, `cfii`, `fullSupport_eq`,
and the positive diagonal trace-one `ρ` with `ρ_fixed` — and which of them
exist:

| Operation | State |
|---|---|
| positive physical blocking | all four clauses available (`IsMPU.blockTensor`, `blockTensorCFIIData`, `hasFullSupport_blockTensor`, `transferMap_blockTensor`); assembled statement missing |
| physical adjunction | all four available (`IsMPU.physicalAdjointTensor`, `physicalAdjointNormalizedFlattening`, `hasFullSupport_physicalAdjointNormalizedFlattening`, `transferMap_mapStar`); assembled statement missing |
| independent tensor product | all four available (`IsMPU.tensorProduct`, `tensorProductCFIIData`, `hasFullSupport_tensorProductCFIIData`, `transferMap_tensorProduct_kronecker`); assembled statement missing |
| transposition, conjugation | transported only as their composite, physical adjunction |
| composition | only `IsMPU.mulTensor`; no preservation statement can hold for the raw product (see round 3 below) — the case needs a reduced representative plus transport of the source cuts |

The composition row answers the separate P2 thread: the `cfii` witness, not
only the ambient fixed matrix, is unreachable for a composition tensor, so
`lem:mpu_admissible_index_composition` stays restricted even if every other
preservation statement is proved.

Two follow-up threads on the same bullet are also fixed. The displayed
implication omitted its unitarity premise — `IsMPUCanonicalFormII` carries an
`isMPU` field, while a rank-one transfer power constrains only the normalized
double layer — so the premise is now in the display and in the bullet, with
the note that `sourceU_isIsometry_of_isMPU` and
`mul_self_le_rightRank_mul_leftRank_of_isMPU` already supply it. And the
generic supplied-pair entry binds `(K : ℕ)` with no positivity, so the
converse's `J > 0` did not cover its `K = 0` inputs; at that exponent the
condition forces `D = 1`, where
`IsMPU.normalized_transfer_matrix_eq_one_fin_one` gives `E = 1` and the same
pair works at exponent one. The conversion is recorded in both files.

The census was rechecked independently by enclosing declaration, and again
after the rebase onto the current base branch: **sixteen** declarations
mention the presentation (the structure, thirteen consumers, two producers).
The thirteenth consumer, `IsMPUCanonicalFormII.neZero_phys`
(`CanonicalForm.lean:385`), arrived with the base branch and concludes
nonemptiness of the physical space of the same tensor, so it transports
nothing and **0 merged** is unchanged.

The branch was rebased onto the rewritten
`agent/issue-7659-convention-migration`; the diff against that base is the two
documentation files and nothing else.

**Retained as pathwise (23).** Unchanged, per the issue.

## Source lines used

- `Papers/1703.09188/paper_v2.tex` line 356: "Note also that this tensor
  is also normal and in CFII" — the source asserts preservation of the
  convention under blocking outright, so the blocked-tensor restriction
  is a formalization gap and not a source boundary.
- lines 344--355 (`prop:normal-tensor`): the spectral step that, run from
  the stabilized power rather than the shifted traces, gives the converse
  of the stabilization theorem.
- lines 269--281 (`Erightleft`): the convention itself.

## Changes

- `docs/paper-gaps/mpu_canonical_form_full_support.tex`: a new subsection
  of the elimination plan records the three-way classification, the
  connectedness obstruction, and the two unblockers, with what each one
  actually reaches; the verdict points at it.
- `docs/proof_debt_ledger.md`: D13's status said the twins remain until
  #7657 and #7659 land. Both have landed and the twins still cannot be
  merged, so the entry now records the actual blocker.

## Validation

- `texra-blueprint paper-gaps check`: 121 referenced slugs resolve
- `texra-blueprint paper-gaps build`: the note compiles
- `chktex -q -l blueprint/.chktexrc` on the note: clean
- `scripts/check_reader_facing_prose.py --diff-base`: clean
- no Lean and no blueprint file is touched, so no build was required

### Correction to the elimination plan (review round 3)

Two further objections, both raised twice.

**The two items are not a joint prerequisite.** The plan said the merge is one
operation and that all sixteen entries stay until both items exist, while its
own analysis of the first item said that item reaches the four same-tensor
entries by itself. The reviewers are right that these cannot both hold. The
converse dissolves the citation obstruction, so the three candidates merge as
soon as it lands, with the twelve derived-tensor entries still standing. The
subsection now states two independent stages, bullet 1 says the second item is
not needed for the candidates, the obstruction paragraph is dated to the
present state, and the closing paragraph counts what remains after the first
stage: thirteen entries, the generic supplied-pair step plus the twelve.

**Composition cannot be settled by two missing lemmas.** Checked against the
definitions and confirmed. `MPOTensor.physicalAdjointTensor` conjugates without
reversing the virtual indices, so `leftShiftTensor d j k = single k j 1` and

    mulTensor (rightShiftTensor d) (leftShiftTensor d) i k
      = ∑ j, |i⟩⟨j| ⊗ |k⟩⟨j| = |i,k⟩⟨Φ|,   ⟨Φ| = ∑ γ, ⟨γ,γ|

on the product bond space. Every one-site matrix has rank one and they share
the row functional, so every product at every length has rank one, while the
periodic operator is the identity at every length. Full-support
canonical-form-II data would make the tensor a unitary conjugate of a direct
sum of nonzero multiples of normal blocks filling the ambient space; a block of
dimension at least two would put a rank-at-least-two matrix into the span of
long products, so every block would have dimension one, the one-site matrices
would commute, and `A(0,0)A(0,1) = 0` while `A(0,1)A(0,0) = |0,1⟩⟨Φ| ≠ 0`.
Blocking does not repair it, since the blocked matrices are those same
products. The note now carries the counterexample and states the actual route:
`IsMPU.exists_reduced_cfii_representative` applied to the product, plus an
identification of the source cuts and ranks of
`lem:mpu_admissible_index_composition` across that reduction, which the
reduced-representative theorem does not supply. The source takes the same route
implicitly, blocking the composite until it is simple (lines 837--841), which
for a composite of this shape is unreachable in the product bond space.

Both corrections are mirrored in `docs/proof_debt_ledger.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm



