### PR TITLE
feat(MPS/Periodic): assemble the multiplicity-bearing equal-case fundamental theorem

### DIFF
--- a/TNLean/MPS/Periodic.lean
+++ b/TNLean/MPS/Periodic.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.Periodic.CornerContraction
 import TNLean.MPS.Periodic.CornerTransition
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Periodic.EqualCase
+import TNLean.MPS.Periodic.EqualCaseGlobal
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.GlobalGauge
 import TNLean.MPS.Periodic.NormalCanonicalPeriodOne

--- a/TNLean/MPS/Periodic/EqualCaseGlobal.lean
+++ b/TNLean/MPS/Periodic/EqualCaseGlobal.lean
@@ -577,7 +577,13 @@ theorem ScalarGaugeEquiv.of_gaugeEquiv_right {D₁ D₂ : ℕ} {ζ : ℂ}
 
 /-! ## The equal-case fundamental theorem over multiplicity-bearing decompositions -/
 
-/-- Repeated periodic blocks in left-canonical form have equal periods. -/
+/-- Repeated periodic blocks in left-canonical form have equal periods.
+
+This is the last clause of arXiv:1708.00029, proposition
+`equal-or-orthogonal-generalized`, lines 602--604: the repeated-block relation
+`A^i = e^{iφ} Y B^i Y^{-1}` can hold only between blocks of equal period. The
+repeated-block relation preserves the peripheral transfer spectrum, which for a
+periodic block is the set of `m`-th roots of unity. -/
 theorem IsPeriodic.period_eq_of_hetRepeatedBlocks
     {D₁ D₂ m n : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsPeriodic m A) (hB : IsPeriodic n B)
@@ -616,15 +622,18 @@ multiplicity matrix `ξ_j R_j`, which is what the source means at lines
 667--671 by absorbing the phase into `S_j`. The scalar is genuinely present:
 for period one and `B_j = e^{iθ} A_j` it is not a root of unity.
 
-The blocks are assumed left-canonical, that is, the block maps are trace
-preserving. This is the normalization of `eq:unital` at line 316, and it is
-weaker than the source's irreducible form II, which additionally requires the
-unique fixed point to be diagonal. The source theorem assumes only irreducible
-form and asserts at lines 330--332 that one passes between the forms by a
-block-diagonal similarity; that passage is not carried out here. The present
-statement is the normalized half of the pair, isolated because the periodic
-overlap dichotomy and the vanishing of an off-period block are available in the
-normalized orientation. -/
+**Scope restriction (trace-preserving blocks):** the blocks are assumed
+left-canonical, that is, their maps are trace preserving. This is the
+normalization of `eq:unital` at line 316, and it is weaker than the source's
+irreducible form II, which additionally requires the unique fixed point to be
+diagonal. The source theorem assumes only irreducible form and asserts at lines
+330--332 that one passes between the forms by a block-diagonal similarity; that
+passage is not carried out here. The present statement is the normalized half
+of the pair, isolated because the periodic overlap dichotomy and the vanishing
+of an off-period block are available in the normalized orientation. The
+restriction and its elimination plan are recorded in
+`docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`, section "Scope
+restriction: the equal case with trace-preserving blocks". -/
 theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ)

--- a/TNLean/MPS/Periodic/EqualCaseGlobal.lean
+++ b/TNLean/MPS/Periodic/EqualCaseGlobal.lean
@@ -616,14 +616,15 @@ multiplicity matrix `ξ_j R_j`, which is what the source means at lines
 667--671 by absorbing the phase into `S_j`. The scalar is genuinely present:
 for period one and `B_j = e^{iθ} A_j` it is not a root of unity.
 
-The blocks are assumed left-canonical, that is, in irreducible form II. The
-source theorem assumes only irreducible form and asserts at lines 330--332 that
-one passes between the two forms by a block-diagonal similarity; that passage
-is carried out in `fundamentalTheorem_periodic_equalCase_irreducibleForm`,
-which is the source statement itself. The present statement is the normalized
-half of that pair, isolated because the periodic overlap dichotomy and the
-vanishing of an off-period block are available in the normalized
-orientation. -/
+The blocks are assumed left-canonical, that is, the block maps are trace
+preserving. This is the normalization of `eq:unital` at line 316, and it is
+weaker than the source's irreducible form II, which additionally requires the
+unique fixed point to be diagonal. The source theorem assumes only irreducible
+form and asserts at lines 330--332 that one passes between the forms by a
+block-diagonal similarity; that passage is not carried out here. The present
+statement is the normalized half of the pair, isolated because the periodic
+overlap dichotomy and the vanishing of an off-period block are available in the
+normalized orientation. -/
 theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ)

--- a/TNLean/MPS/Periodic/EqualCaseGlobal.lean
+++ b/TNLean/MPS/Periodic/EqualCaseGlobal.lean
@@ -1,0 +1,632 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.Multi
+import TNLean.MPS.Periodic.EqualCase
+import TNLean.MPS.Periodic.ProportionalOverlap
+
+/-!
+# Global assembly of the equal-case multiplicity gauge
+
+The equal-case fundamental theorem closes by collecting the blockwise data into
+two global matrices on the bond space of the assembled tensor: the
+multiplicity gauge, which is the scalar acting by a root of unity on each
+multiplicity copy, and the similarity, which permutes the matched copies and
+applies the blockwise similarity inside each of them.
+
+This module supplies the linear algebra of that assembly.
+
+## Main declarations
+
+* `MPSTensor.blockScalarMatrix`
+* `MPSTensor.permMatrixOfEquiv`
+* `MPSTensor.toTensorFromBlocks_conj_of_matched_blocks`
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Perez-Garcia,
+  *Irreducible forms of Matrix Product States: Theory and Applications*,
+  arXiv:1708.00029, theorem `thm:bdequal`, lines 689--690.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ## Block-scalar matrices on flattened bond coordinates -/
+
+section BlockScalar
+
+variable {r : ℕ}
+
+/-- The matrix acting on the flattened bond space of a block-diagonal tensor by
+the scalar `z k` on the bond space of the `k`-th block.
+
+In the notation of arXiv:1708.00029, line 653, this is the matrix
+`⊕_k z_k 1_{D_k}`. -/
+noncomputable def blockScalarMatrix (dim : Fin r → ℕ) (z : Fin r → ℂ) :
+    Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ :=
+  Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+    (Matrix.blockDiagonal' fun k => z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))
+
+variable {dim : Fin r → ℕ}
+
+theorem blockScalarMatrix_mul (z w : Fin r → ℂ) :
+    blockScalarMatrix dim z * blockScalarMatrix dim w =
+      blockScalarMatrix dim (fun k => z k * w k) := by
+  classical
+  have hmul := map_mul (Matrix.reindexAlgEquiv ℂ ℂ
+      (finSigmaFinEquiv (m := r) (n := dim)))
+    (Matrix.blockDiagonal' fun k => z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))
+    (Matrix.blockDiagonal' fun k => w k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))
+  simp only [Matrix.coe_reindexAlgEquiv] at hmul
+  have hfun : (fun k : Fin r =>
+      (z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) *
+        (w k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))) =
+      fun k : Fin r => (z k * w k) • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) := by
+    funext k
+    simp [smul_smul, mul_comm]
+  rw [blockScalarMatrix, blockScalarMatrix, blockScalarMatrix, ← hmul,
+    ← Matrix.blockDiagonal'_mul, hfun]
+
+@[simp] theorem blockScalarMatrix_one :
+    blockScalarMatrix dim (fun _ => (1 : ℂ)) = 1 := by
+  classical
+  have h := map_one (Matrix.reindexAlgEquiv ℂ ℂ
+    (finSigmaFinEquiv (m := r) (n := dim)))
+  simp only [Matrix.coe_reindexAlgEquiv] at h
+  rw [blockScalarMatrix, ← h]
+  congr 1
+  have hfun : (fun k : Fin r => (1 : ℂ) • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) =
+      fun k : Fin r => (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) := by
+    funext k; simp
+  rw [hfun]
+  exact Matrix.blockDiagonal'_one
+
+theorem blockScalarMatrix_pow (z : Fin r → ℂ) (n : ℕ) :
+    blockScalarMatrix dim z ^ n = blockScalarMatrix dim (fun k => z k ^ n) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ, ih, blockScalarMatrix_mul]
+    simp [pow_succ]
+
+/-- Multiplying a block-diagonal tensor on the left by a block-scalar matrix
+rescales the block weights. -/
+theorem blockScalarMatrix_mul_toTensorFromBlocks
+    (z μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) (i : Fin d) :
+    blockScalarMatrix dim z * toTensorFromBlocks (d := d) (μ := μ) A i =
+      toTensorFromBlocks (d := d) (μ := fun k => z k * μ k) A i := by
+  classical
+  have hmul := map_mul (Matrix.reindexAlgEquiv ℂ ℂ
+      (finSigmaFinEquiv (m := r) (n := dim)))
+    (Matrix.blockDiagonal' fun k => z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))
+    (Matrix.blockDiagonal' fun k => μ k • A k i)
+  simp only [Matrix.coe_reindexAlgEquiv] at hmul
+  change blockScalarMatrix dim z *
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun k => μ k • A k i) = _
+  have hfun : (fun k : Fin r =>
+      (z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) * (μ k • A k i)) =
+      fun k : Fin r => (z k * μ k) • A k i := by
+    funext k
+    simp [smul_smul, mul_comm]
+  rw [blockScalarMatrix, ← hmul, ← Matrix.blockDiagonal'_mul, hfun]
+  rfl
+
+/-- Multiplying a block-diagonal tensor on the right by a block-scalar matrix
+rescales the block weights in the same way. -/
+theorem toTensorFromBlocks_mul_blockScalarMatrix
+    (z μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) (i : Fin d) :
+    toTensorFromBlocks (d := d) (μ := μ) A i * blockScalarMatrix dim z =
+      toTensorFromBlocks (d := d) (μ := fun k => z k * μ k) A i := by
+  classical
+  have hmul := map_mul (Matrix.reindexAlgEquiv ℂ ℂ
+      (finSigmaFinEquiv (m := r) (n := dim)))
+    (Matrix.blockDiagonal' fun k => μ k • A k i)
+    (Matrix.blockDiagonal' fun k => z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))
+  simp only [Matrix.coe_reindexAlgEquiv] at hmul
+  change Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun k => μ k • A k i) * blockScalarMatrix dim z = _
+  have hfun : (fun k : Fin r =>
+      (μ k • A k i) * (z k • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ))) =
+      fun k : Fin r => (z k * μ k) • A k i := by
+    funext k
+    simp [smul_smul]
+  rw [blockScalarMatrix, ← hmul, ← Matrix.blockDiagonal'_mul, hfun]
+  rfl
+
+end BlockScalar
+
+/-! ## Permutation matrices of index equivalences -/
+
+section PermMatrix
+
+variable {m n : Type*} [DecidableEq m]
+
+/-- The matrix of an index equivalence `E : n ≃ m`, sending the `t`-th basis
+vector to the `E t`-th one. -/
+def permMatrixOfEquiv (E : n ≃ m) : Matrix m n ℂ :=
+  fun x t => if x = E t then 1 else 0
+
+theorem permMatrixOfEquiv_mul [Fintype n] {p : Type*} (E : n ≃ m) (M : Matrix n p ℂ) :
+    permMatrixOfEquiv E * M = M.submatrix E.symm id := by
+  ext x u
+  rw [Matrix.mul_apply]
+  simp only [permMatrixOfEquiv, Matrix.submatrix_apply, id]
+  rw [Finset.sum_eq_single (E.symm x)]
+  · simp
+  · intro t _ ht
+    have : ¬ x = E t := fun h => ht (by rw [h, Equiv.symm_apply_apply])
+    simp [this]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+theorem mul_permMatrixOfEquiv_transpose [Fintype n] {p : Type*} (E : n ≃ m)
+    (M : Matrix p n ℂ) :
+    M * (permMatrixOfEquiv E)ᵀ = M.submatrix id E.symm := by
+  ext u y
+  rw [Matrix.mul_apply]
+  simp only [permMatrixOfEquiv, Matrix.transpose_apply, Matrix.submatrix_apply, id]
+  rw [Finset.sum_eq_single (E.symm y)]
+  · simp
+  · intro t _ ht
+    have : ¬ y = E t := fun h => ht (by rw [h, Equiv.symm_apply_apply])
+    simp [this]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+theorem permMatrixOfEquiv_mul_transpose [Fintype n] (E : n ≃ m) :
+    permMatrixOfEquiv E * (permMatrixOfEquiv E)ᵀ = 1 := by
+  rw [permMatrixOfEquiv_mul]
+  ext x y
+  simp only [Matrix.submatrix_apply, id, Matrix.transpose_apply, permMatrixOfEquiv,
+    Matrix.one_apply]
+  by_cases h : x = y
+  · subst h; simp
+  · have h' : ¬ y = x := fun hh => h hh.symm
+    have h1 : (if y = E (E.symm x) then (1 : ℂ) else 0) = 0 := by simp [h']
+    have h2 : (if x = y then (1 : ℂ) else 0) = 0 := by simp [h]
+    rw [h1, h2]
+
+theorem permMatrixOfEquiv_transpose_mul [Fintype m] [DecidableEq n] (E : n ≃ m) :
+    (permMatrixOfEquiv E)ᵀ * permMatrixOfEquiv E = 1 := by
+  ext t u
+  rw [Matrix.mul_apply]
+  simp only [Matrix.transpose_apply, permMatrixOfEquiv, Matrix.one_apply]
+  rw [Finset.sum_eq_single (E t)]
+  · by_cases h : t = u
+    · subst h; simp
+    · have : ¬ E t = E u := fun hh => h (E.injective hh)
+      simp [this, h]
+  · intro x _ hx
+    simp [hx]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- Reindexing a square matrix along an equivalence is conjugation by the
+corresponding permutation matrix. -/
+theorem reindex_eq_permMatrixOfEquiv_conj [Fintype n] (E : n ≃ m) (M : Matrix n n ℂ) :
+    Matrix.reindex E E M =
+      permMatrixOfEquiv E * M * (permMatrixOfEquiv E)ᵀ := by
+  rw [permMatrixOfEquiv_mul, mul_permMatrixOfEquiv_transpose]
+  ext x y
+  simp [Matrix.submatrix_apply]
+
+end PermMatrix
+
+/-! ## Conjugation between matched block-diagonal tensors -/
+
+/-- **Global similarity between matched block-diagonal tensors.**
+
+If the blocks of two block-diagonal tensors are matched by an equivalence of
+their index sets, with matching bond dimensions, and every matched pair of
+weighted blocks is related by a similarity, then the two assembled tensors are
+related by a single invertible matrix between their bond spaces.
+
+The matrix is the composition of the permutation of the matched blocks with the
+direct sum of the blockwise similarities, which is the matrix
+`Y = ⊕_j T_j ⊗ Y_j` of arXiv:1708.00029, line 690. -/
+theorem toTensorFromBlocks_conj_of_matched_blocks
+    {r r' : ℕ} {dim : Fin r → ℕ} {dim' : Fin r' → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (μ' : Fin r' → ℂ) (B : (t : Fin r') → MPSTensor d (dim' t))
+    (e : Fin r ≃ Fin r') (hd : ∀ k, dim k = dim' (e k))
+    (X : (t : Fin r') → GL (Fin (dim' t)) ℂ)
+    (hrel : ∀ (k : Fin r) (i : Fin d),
+      Matrix.reindex (finCongr (hd k)) (finCongr (hd k)) (μ k • A k i) =
+        μ' (e k) • ((X (e k) : Matrix (Fin (dim' (e k))) (Fin (dim' (e k))) ℂ) *
+          B (e k) i *
+          (((X (e k))⁻¹ : GL (Fin (dim' (e k))) ℂ) :
+            Matrix (Fin (dim' (e k))) (Fin (dim' (e k))) ℂ))) :
+    ∃ (Y : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ t : Fin r', dim' t)) ℂ)
+      (Y' : Matrix (Fin (∑ t : Fin r', dim' t)) (Fin (∑ k : Fin r, dim k)) ℂ),
+      Y * Y' = 1 ∧ Y' * Y = 1 ∧
+      ∀ i : Fin d,
+        toTensorFromBlocks (d := d) (μ := μ) A i =
+          Y * toTensorFromBlocks (d := d) (μ := μ') B i * Y' := by
+  classical
+  -- The conjugated `B`-family, still indexed by the `B`-side blocks.
+  set B' : (t : Fin r') → MPSTensor d (dim' t) := fun t i =>
+    (X t : Matrix (Fin (dim' t)) (Fin (dim' t)) ℂ) * B t i *
+      (((X t)⁻¹ : GL (Fin (dim' t)) ℂ) : Matrix (Fin (dim' t)) (Fin (dim' t)) ℂ)
+    with hB'
+  have hconj := toTensorFromBlocks_eq_globalGaugeOfBlocks_conj (d := d)
+    (μ := μ') (A := B) (B := B') X (fun t i => rfl)
+  -- The index permutation between the two flattened bond spaces.
+  have hblocks : ∀ (k : Fin r) (i : Fin d),
+      μ k • A k i =
+        Matrix.reindex (finCongr (hd k)).symm (finCongr (hd k)).symm
+          (μ' (e k) • B' (e k) i) := by
+    intro k i
+    have h := hrel k i
+    rw [hB']
+    rw [← h]
+    ext x y
+    simp
+  have hreindex := toTensorFromBlocks_eq_reindex_of_equiv (d := d)
+    μ A μ' B' e hd hblocks
+  set E : Fin (∑ t : Fin r', dim' t) ≃ Fin (∑ k : Fin r, dim k) :=
+    blockDimEquiv e hd with hE
+  set G : Matrix (Fin (∑ t : Fin r', dim' t)) (Fin (∑ t : Fin r', dim' t)) ℂ :=
+    (globalGaugeOfBlocks X : Matrix (Fin (∑ t : Fin r', dim' t))
+      (Fin (∑ t : Fin r', dim' t)) ℂ) with hG
+  set G' : Matrix (Fin (∑ t : Fin r', dim' t)) (Fin (∑ t : Fin r', dim' t)) ℂ :=
+    (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ t : Fin r', dim' t)) ℂ) :
+      Matrix (Fin (∑ t : Fin r', dim' t)) (Fin (∑ t : Fin r', dim' t)) ℂ) with hG'
+  have hGG' : G * G' = 1 := by
+    rw [hG, hG']
+    simp
+  have hG'G : G' * G = 1 := by
+    rw [hG, hG']
+    simp
+  refine ⟨permMatrixOfEquiv E * G, G' * (permMatrixOfEquiv E)ᵀ, ?_, ?_, ?_⟩
+  · calc permMatrixOfEquiv E * G * (G' * (permMatrixOfEquiv E)ᵀ)
+        = permMatrixOfEquiv E * (G * G') * (permMatrixOfEquiv E)ᵀ := by
+          simp [Matrix.mul_assoc]
+    _ = 1 := by rw [hGG']; simp [permMatrixOfEquiv_mul_transpose]
+  · calc G' * (permMatrixOfEquiv E)ᵀ * (permMatrixOfEquiv E * G)
+        = G' * ((permMatrixOfEquiv E)ᵀ * permMatrixOfEquiv E) * G := by
+          simp [Matrix.mul_assoc]
+    _ = 1 := by rw [permMatrixOfEquiv_transpose_mul]; simp [hG'G]
+  · intro i
+    rw [hreindex i, hconj i, reindex_eq_permMatrixOfEquiv_conj]
+    simp only [Matrix.mul_assoc]
+
+/-! ## Transport of blockwise data along equal bond dimensions -/
+
+section Transport
+
+/-- Reindexing the matrices of a tensor along an equality of bond dimensions is
+the transport of the tensor itself. -/
+theorem reindex_finCongr_apply_eq_cast {n m : ℕ} (h : n = m) (A : MPSTensor d n) (i : Fin d) :
+    Matrix.reindex (finCongr h) (finCongr h) (A i) =
+      (cast (congr_arg (MPSTensor d) h) A) i := by
+  subst h
+  ext x y
+  simp
+
+/-- A weighted conjugated block is transported along an equality of bond
+dimensions by reindexing. -/
+theorem reindex_smul_conj_eq {n m : ℕ} (h : n = m)
+    (c c' : ℂ) (A : MPSTensor d n) (A' : MPSTensor d m)
+    (Xg : GL (Fin n) ℂ) (Xg' : GL (Fin m) ℂ)
+    (hc : c = c') (hA : A ≍ A') (hX : Xg ≍ Xg') (i : Fin d) :
+    Matrix.reindex (finCongr h) (finCongr h)
+        (c • ((Xg : Matrix (Fin n) (Fin n) ℂ) * A i *
+          ((Xg⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ))) =
+      c' • ((Xg' : Matrix (Fin m) (Fin m) ℂ) * A' i *
+        ((Xg'⁻¹ : GL (Fin m) ℂ) : Matrix (Fin m) (Fin m) ℂ)) := by
+  subst h
+  subst hc
+  rw [eq_of_heq hA, eq_of_heq hX]
+  ext x y
+  simp
+
+theorem reindex_trans_finCongr {n m k : ℕ} (h₁ : n = m) (h₂ : m = k)
+    (M : Matrix (Fin n) (Fin n) ℂ) :
+    Matrix.reindex (finCongr h₂) (finCongr h₂)
+        (Matrix.reindex (finCongr h₁) (finCongr h₁) M) =
+      Matrix.reindex (finCongr (h₁.trans h₂)) (finCongr (h₁.trans h₂)) M := by
+  subst h₁
+  subst h₂
+  rfl
+
+@[simp] theorem matched_block_gauge_apply {Q : SectorDecomposition d}
+    (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
+    (t : Fin Q.totalCopies) :
+    matched_block_gauge (Q := Q) Xblock t = Xblock (Q.flatIndexEquiv.symm t).1 := rfl
+
+end Transport
+
+/-! ## The global multiplicity gauge in the equal case -/
+
+/-- **Global multiplicity gauge and similarity in the equal case.**
+
+Given the blockwise data of the equal-case fundamental theorem — a bijection of
+the two bases of periodic tensors, matched bond dimensions, blockwise
+similarities carrying unit-modulus scalars, a reordering of the multiplicity
+copies, and multiplicity ratios that are roots of unity of a common order —
+this assembles the two global matrices of arXiv:1708.00029, line 653: the
+multiplicity gauge `Z = ⊕_j Z_j ⊗ 1_{D_j}`, which commutes with every matrix of
+the first assembled tensor, and the similarity `Y = ⊕_j T_j ⊗ Y_j` carrying the
+gauged first tensor to the second.
+
+The unit-modulus scalar of each matched pair is carried explicitly by the
+hypothesis relating the multiplicity entries: the ratio that becomes a root of
+unity is the one between the multiplicity entries of the second tensor and the
+*rescaled* multiplicity entries of the first, exactly as at
+arXiv:1708.00029, lines 667--671 and 681--688. -/
+theorem equalCase_global_zgauge_of_blockwise
+    {P Q : SectorDecomposition d}
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (hDim : ∀ j, P.basisDim j = Q.basisDim (perm j))
+    (τ : (j : Fin P.basisCount) → Fin (P.copies j) ≃ Fin (Q.copies (perm j)))
+    (ξ : Fin P.basisCount → ℂ)
+    (Yb : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
+    (hConj : ∀ (j : Fin P.basisCount) (i : Fin d),
+      (cast (congr_arg (MPSTensor d) (hDim j)) (P.basis j)) i =
+        ξ j • ((Yb (perm j) :
+            Matrix (Fin (Q.basisDim (perm j))) (Fin (Q.basisDim (perm j))) ℂ) *
+          Q.basis (perm j) i *
+          (((Yb (perm j))⁻¹ : GL (Fin (Q.basisDim (perm j))) ℂ) :
+            Matrix (Fin (Q.basisDim (perm j))) (Fin (Q.basisDim (perm j))) ℂ)))
+    (z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ)
+    (hz : ∀ j q, z j q * (ξ j * P.weight j q) = Q.weight (perm j) (τ j q))
+    (period : Fin P.basisCount → ℕ)
+    (hPer : ∀ j, IsPeriodic (period j) (P.basis j))
+    (hzm : ∀ j q, z j q ^ period j = 1)
+    (L : ℕ) (hLdvd : ∀ j, period j ∣ L) :
+    ∃ (Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ)
+      (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
+      (Y' : Matrix (Fin Q.totalDim) (Fin P.totalDim) ℂ),
+      Z ^ L = 1 ∧ Y * Y' = 1 ∧ Y' * Y = 1 ∧
+      (∀ i : Fin d, Z * P.toTensor i = P.toTensor i * Z) ∧
+      (∀ i : Fin d, Z * P.toTensor i = Y * Q.toTensor i * Y') ∧
+      SameMPV₂Pos P.toTensor (fun i => Z * P.toTensor i) := by
+  classical
+  have hzL : ∀ j q, z j q ^ L = 1 := by
+    intro j q
+    obtain ⟨c, hc⟩ := hLdvd j
+    rw [hc, pow_mul, hzm, one_pow]
+  set zflat : Fin P.totalCopies → ℂ := fun s =>
+    z (P.flatIndexEquiv.symm s).1 (P.flatIndexEquiv.symm s).2 with hzflat
+  set Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ :=
+    blockScalarMatrix P.flatDim zflat with hZ
+  -- The gauged first tensor is the first tensor with rescaled multiplicities.
+  have hZmul : ∀ i : Fin d, Z * P.toTensor i =
+      toTensorFromBlocks (d := d)
+        (μ := fun s => zflat s * P.flatWeight s) P.flatBasis i := fun i =>
+    blockScalarMatrix_mul_toTensorFromBlocks zflat P.flatWeight P.flatBasis i
+  have hZmulr : ∀ i : Fin d, P.toTensor i * Z =
+      toTensorFromBlocks (d := d)
+        (μ := fun s => zflat s * P.flatWeight s) P.flatBasis i := fun i =>
+    toTensorFromBlocks_mul_blockScalarMatrix zflat P.flatWeight P.flatBasis i
+  -- The matched flattened copy indices.
+  set e : Fin P.totalCopies ≃ Fin Q.totalCopies :=
+    SectorDecomposition.sectorFlatEquiv (P := Q) (Q := P) perm τ with he
+  have hd : ∀ s, P.flatDim s = Q.flatDim (e s) := fun s =>
+    (SectorDecomposition.flatDim_sectorFlatEquiv (P := Q) (Q := P) perm
+      (fun j => (hDim j).symm) τ s).symm
+  have hrel : ∀ (s : Fin P.totalCopies) (i : Fin d),
+      Matrix.reindex (finCongr (hd s)) (finCongr (hd s))
+          ((zflat s * P.flatWeight s) • P.flatBasis s i) =
+        Q.flatWeight (e s) •
+          ((matched_block_gauge (Q := Q) Yb (e s) :
+              Matrix (Fin (Q.flatDim (e s))) (Fin (Q.flatDim (e s))) ℂ) *
+            Q.flatBasis (e s) i *
+            (((matched_block_gauge (Q := Q) Yb (e s))⁻¹ :
+                GL (Fin (Q.flatDim (e s))) ℂ) :
+              Matrix (Fin (Q.flatDim (e s))) (Fin (Q.flatDim (e s))) ℂ)) := by
+    intro s i
+    set j : Fin P.basisCount := (P.flatIndexEquiv.symm s).1 with hj
+    set q : Fin (P.copies j) := (P.flatIndexEquiv.symm s).2 with hq
+    have ht : Q.flatIndexEquiv.symm (e s) = ⟨perm j, τ j q⟩ := by
+      rw [he, SectorDecomposition.sectorFlatEquiv_apply, Equiv.symm_apply_apply]
+    have hQd : Q.flatDim (e s) = Q.basisDim (perm j) :=
+      congrArg (fun x : (k : Fin Q.basisCount) × Fin (Q.copies k) =>
+        Q.basisDim x.1) ht
+    have hQw : Q.flatWeight (e s) = Q.weight (perm j) (τ j q) :=
+      congrArg (fun x : (k : Fin Q.basisCount) × Fin (Q.copies k) =>
+        Q.weight x.1 x.2) ht
+    have hQb : Q.flatBasis (e s) ≍ Q.basis (perm j) :=
+      congr_arg_heq (fun x : (k : Fin Q.basisCount) × Fin (Q.copies k) =>
+        Q.basis x.1) ht
+    have hQx : matched_block_gauge (Q := Q) Yb (e s) ≍ Yb (perm j) :=
+      congr_arg_heq (fun x : (k : Fin Q.basisCount) × Fin (Q.copies k) =>
+        Yb x.1) ht
+    refine (Matrix.reindex (finCongr hQd) (finCongr hQd)).injective ?_
+    rw [reindex_trans_finCongr,
+      reindex_smul_conj_eq hQd (Q.flatWeight (e s)) (Q.weight (perm j) (τ j q))
+        (Q.flatBasis (e s)) (Q.basis (perm j))
+        (matched_block_gauge (Q := Q) Yb (e s)) (Yb (perm j)) hQw hQb hQx i]
+    have hsmul : Matrix.reindex (finCongr ((hd s).trans hQd))
+          (finCongr ((hd s).trans hQd))
+          ((zflat s * P.flatWeight s) • P.flatBasis s i) =
+        (z j q * P.weight j q) •
+          Matrix.reindex (finCongr (hDim j)) (finCongr (hDim j)) (P.basis j i) := by
+      have hcong : (hd s).trans hQd = hDim j := rfl
+      rw [hcong]
+      rfl
+    rw [hsmul, reindex_finCongr_apply_eq_cast, hConj j i, smul_smul]
+    congr 1
+    rw [← hz j q]
+    ring
+  obtain ⟨Y, Y', hYY', hY'Y, hconj⟩ :=
+    toTensorFromBlocks_conj_of_matched_blocks (d := d)
+      (fun s => zflat s * P.flatWeight s) P.flatBasis
+      Q.flatWeight Q.flatBasis e hd (matched_block_gauge (Q := Q) Yb) hrel
+  refine ⟨Z, Y, Y', ?_, hYY', hY'Y, ?_, ?_, ?_⟩
+  · rw [hZ, blockScalarMatrix_pow]
+    have hone : (fun s : Fin P.totalCopies => zflat s ^ L) = fun _ => (1 : ℂ) := by
+      funext s
+      exact hzL _ _
+    rw [hone, blockScalarMatrix_one]
+  · intro i; rw [hZmul i, hZmulr i]
+  · intro i; rw [hZmul i]; exact hconj i
+  · -- the gauged tensor generates the same matrix-product vectors
+    intro N _hN σ
+    have hfun : (fun i => Z * P.toTensor i) =
+        toTensorFromBlocks (d := d)
+          (μ := fun s => zflat s * P.flatWeight s) P.flatBasis := funext hZmul
+    rw [hfun]
+    change mpv (toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis) σ = _
+    rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+    refine Finset.sum_congr rfl fun s _ => ?_
+    by_cases hdvd : period (P.flatIndexEquiv.symm s).1 ∣ N
+    · obtain ⟨c, hc⟩ := hdvd
+      have hz1 : zflat s ^ N = 1 := by
+        rw [hzflat, hc, pow_mul, hzm, one_pow]
+      rw [mul_pow, hz1, one_mul]
+    · have hzero : mpv (P.flatBasis s) σ = 0 :=
+        pgvwc07_stateVector_eq_zero_of_not_dvd (P.flatBasis s)
+          (hPer (P.flatIndexEquiv.symm s).1) hdvd σ
+      rw [hzero]
+      simp
+
+/-! ## The equal-case fundamental theorem over multiplicity-bearing decompositions -/
+
+/-- Repeated periodic blocks in left-canonical form have equal periods. -/
+theorem IsPeriodic.period_eq_of_hetRepeatedBlocks
+    {D₁ D₂ m n : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsPeriodic m A) (hB : IsPeriodic n B)
+    (h : HetRepeatedBlocks A B) : m = n := by
+  obtain ⟨hDim, hRep⟩ := h
+  subst hDim
+  exact IsPeriodic.period_eq_of_repeatedBlocks hA hB hRep
+    hRep.peripheralEigenvalues_transferMap_eq
+
+/-- **Fundamental theorem for matrix product states, equal case.**
+
+Let two tensors carry the multiplicity-bearing irreducible forms
+`A^i = ⊕_{j ∈ J} (R_j ⊗ A_j^i)` and `B^i = ⊕_{k ∈ K} (S_k ⊗ B_k^i)`, with
+`R_j` and `S_k` diagonal with nonzero entries and with pairwise non-repeated
+bases of periodic tensors. If the two tensors generate the same matrix-product
+vector at every positive length, then the two bases have the same size and
+there is a bijection `π : J → K` matching each `A_j` with the single `B_{π(j)}`
+of the same period, with `A_j` and `B_{π(j)}` repeated blocks.
+
+Moreover, for every `j` of period `m_j` the multiplicity matrices `R_j` and
+`S_{π(j)}` have the same size, and after a reordering of the diagonal entries
+of `S_{π(j)}` there is a diagonal matrix `Z_j` whose entries are `m_j`-th roots
+of unity with `Z_j (ξ_j R_j) = S_{π(j)}`, where `ξ_j` is the unit-modulus scalar
+of the repeated-block relation. Collecting the `Z_j` gives a matrix `Z` on the
+bond space of the first tensor that commutes with every one of its matrices,
+whose order divides the least common multiple of the periods, that satisfies
+`Z A^i = Y B^i Y^{-1}` for an invertible `Y`, and that leaves the generated
+matrix-product vectors unchanged.
+
+Source: arXiv:1708.00029, theorem `thm:bdequal`, lines 643--693, over the
+irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582.
+
+The unit-modulus scalar of each matched pair is displayed rather than
+suppressed: the entries of `Z_j` are roots of unity against the *rescaled*
+multiplicity matrix `ξ_j R_j`, which is what the source means at lines
+667--671 by absorbing the phase into `S_j`. The scalar is genuinely present:
+for period one and `B_j = e^{iθ} A_j` it is not a root of unity.
+
+**Scope restriction (irreducible form II):** the blocks are assumed
+left-canonical, that is, in irreducible form II. The source theorem assumes
+only irreducible form, and asserts at lines 330--332 that one passes between
+the two forms by a block-diagonal similarity, so that a proof in either form
+applies to the other; that passage is not carried out here. The restriction is
+recorded in `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`,
+section "Scope restriction: the equal case in irreducible form II". -/
+theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
+    (P Q : SectorDecomposition d)
+    (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ)
+    (hPerP : ∀ j, IsPeriodic (periodP j) (P.basis j))
+    (hPerQ : ∀ k, IsPeriodic (periodQ k) (Q.basis k))
+    (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
+    (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
+    (hSame : SameMPV₂Pos P.toTensor Q.toTensor) :
+    ∃ (perm : Fin P.basisCount ≃ Fin Q.basisCount) (ξ : Fin P.basisCount → ℂ),
+      (∀ j, ‖ξ j‖ = 1) ∧
+      (∀ j, periodP j = periodQ (perm j)) ∧
+      (∀ j, HetRepeatedBlocks (P.basis j) (Q.basis (perm j))) ∧
+      (∀ j, ∃ (_hCopies : P.copies j = Q.copies (perm j))
+              (τ : Fin (P.copies j) ≃ Fin (Q.copies (perm j)))
+              (Zj : Matrix (Fin (P.copies j)) (Fin (P.copies j)) ℂ),
+            Zj ^ periodP j = 1 ∧
+            Zj * Matrix.diagonal (fun q => ξ j * P.weight j q) =
+              Matrix.diagonal (fun q => Q.weight (perm j) (τ q))) ∧
+      ∃ (Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ)
+        (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
+        (Y' : Matrix (Fin Q.totalDim) (Fin P.totalDim) ℂ),
+        Z ^ (Finset.univ.lcm periodP) = 1 ∧ Y * Y' = 1 ∧ Y' * Y = 1 ∧
+        (∀ i : Fin d, Z * P.toTensor i = P.toTensor i * Z) ∧
+        (∀ i : Fin d, Z * P.toTensor i = Y * Q.toTensor i * Y') ∧
+        SameMPV₂Pos P.toTensor (fun i => Z * P.toTensor i) := by
+  classical
+  -- Theorem 3.4 supplies the matching of the two bases of periodic tensors.
+  obtain ⟨_hCount, perm, hMatch⟩ :=
+    fundamentalTheorem_periodic_proportional P.basis Q.basis hNonRepP hNonRepQ
+      (PeriodicOverlapHypothesis.ofSectorDecompositions P Q periodP periodQ
+        hPerP hPerQ hNonRepP hNonRepQ hSame.toNonzeroProportionalMPV₂)
+  choose hDimJ ξ Yb' hξ hConj' using hMatch
+  have hξ0 : ∀ j, ξ j ≠ 0 := fun j => Complex.ne_zero_of_norm_eq_one (hξ j)
+  have hMatch' : ∀ j, HetRepeatedBlocks (P.basis j) (Q.basis (perm j)) :=
+    fun j => ⟨hDimJ j, ξ j, Yb' j, hξ j, hConj' j⟩
+  have hPeriodEq : ∀ j, periodP j = periodQ (perm j) := fun j =>
+    IsPeriodic.period_eq_of_hetRepeatedBlocks (hPerP j) (hPerQ (perm j)) (hMatch' j)
+  -- the matched matrix-product vectors differ by a power of the matched scalar
+  have hBasis : ∀ (j : Fin P.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (P.basis j) σ = ξ j ^ N * mpv (Q.basis (perm j)) σ := by
+    intro j N σ
+    rw [← mpv_cast_dim (hDimJ j) (P.basis j) N σ]
+    exact mpv_eq_pow_mul_of_gaugePhase (Q.basis (perm j))
+      (cast (congr_arg (MPSTensor d) (hDimJ j)) (P.basis j)) (Yb' j) (ξ j)
+      (hConj' j) N σ
+  -- coefficient extraction along the period progression
+  obtain ⟨N₀, hN₀⟩ :=
+    SectorDecomposition.coeff_eq_of_sameMPV_of_matched_basis
+      periodP hPerP hNonRepP perm ξ hξ0 hBasis hSame
+  have hpowdata : ∀ j, ∃ (_hCopies : P.copies j = Q.copies (perm j))
+      (τ : Fin (P.copies j) ≃ Fin (Q.copies (perm j))),
+      ∀ q, Q.weight (perm j) (τ q) ^ periodP j =
+        (ξ j * P.weight j q) ^ periodP j := by
+    intro j
+    have hm : 0 < periodP j := (hPerP j).period_pos
+    have hCoeff : ∀ n > N₀,
+        P.coeff (periodP j * n) j =
+          (ξ j)⁻¹ ^ (periodP j * n) * Q.coeff (periodP j * n) (perm j) := by
+      intro n hn
+      exact hN₀ (periodP j * n)
+        (le_trans (le_of_lt hn) (Nat.le_mul_of_pos_left n hm)) j ⟨n, rfl⟩
+    obtain ⟨hc, τ, hτ⟩ :=
+      matched_sector_weight_pow_equiv_of_period_multiple j (perm j) (periodP j)
+        (ξ j)⁻¹ (inv_ne_zero (hξ0 j)) hCoeff
+    exact ⟨hc, τ, fun q => by simpa [inv_inv] using hτ q⟩
+  choose hCopies τ hτpow using hpowdata
+  -- the multiplicity ratios are roots of unity of the block period
+  have hden : ∀ j q, ξ j * P.weight j q ≠ 0 := fun j q =>
+    mul_ne_zero (hξ0 j) (P.weight_ne_zero j q)
+  set z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ := fun j q =>
+    Q.weight (perm j) (τ j q) / (ξ j * P.weight j q) with hzdef
+  have hz : ∀ j q, z j q * (ξ j * P.weight j q) = Q.weight (perm j) (τ j q) :=
+    fun j q => div_mul_cancel₀ _ (hden j q)
+  have hzm : ∀ j q, z j q ^ periodP j = 1 := by
+    intro j q
+    rw [hzdef, div_pow, hτpow j q, div_self (pow_ne_zero _ (hden j q))]
+  refine ⟨perm, ξ, hξ, hPeriodEq, hMatch', ?_, ?_⟩
+  · -- blockwise multiplicity gauge
+    intro j
+    obtain ⟨Zj, hZjpow, hZjmul⟩ :=
+      zgauge_construction (periodP j)
+        (fun q => Q.weight (perm j) (τ j q)) (fun q => ξ j * P.weight j q)
+        (fun q => hτpow j q) (fun q => hden j q)
+    exact ⟨hCopies j, τ j, Zj, hZjpow, hZjmul⟩
+  · -- global multiplicity gauge and similarity
+    obtain ⟨Z, Y, Y', hZpow, hYY', hY'Y, hcomm, hgauge, hmpv⟩ :=
+      equalCase_global_zgauge_of_blockwise perm hDimJ τ ξ
+        (Equiv.piCongrLeft (fun k => GL (Fin (Q.basisDim k)) ℂ) perm Yb')
+        (by
+          intro j i
+          rw [Equiv.piCongrLeft_apply_apply]
+          exact hConj' j i)
+        z hz periodP hPerP hzm (Finset.univ.lcm periodP)
+        (fun j => Finset.dvd_lcm (Finset.mem_univ j))
+    exact ⟨Z, Y, Y', hZpow, hYY', hY'Y, hcomm, hgauge, hmpv⟩
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/EqualCaseGlobal.lean
+++ b/TNLean/MPS/Periodic/EqualCaseGlobal.lean
@@ -340,6 +340,52 @@ theorem reindex_trans_finCongr {n m k : ℕ} (h₁ : n = m) (h₂ : m = k)
 
 end Transport
 
+/-- The scalar attached to each flattened multiplicity copy by a blockwise
+family of multiplicity scalars.
+
+This flattens `(j, q) ↦ z_{j,q}`, so that the block-scalar matrix built from it
+is the direct sum `⊕_j Z_j ⊗ 1_{D_j}` with `Z_j` the diagonal matrix of the
+`z_{j,q}`, as at arXiv:1708.00029, line 653. -/
+noncomputable def SectorDecomposition.flatCopyScalar (P : SectorDecomposition d)
+    (z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ) : Fin P.totalCopies → ℂ :=
+  fun s => z (P.flatIndexEquiv.symm s).1 (P.flatIndexEquiv.symm s).2
+
+/-- The multiplicity gauge does not change the generated matrix-product
+vectors: on a copy whose period divides the length it contributes the factor
+one, and on a copy whose period does not divide the length the block generates
+the zero vector.
+
+Source: arXiv:1708.00029, theorem `thm:bdequal`, lines 655 and 661--663. -/
+theorem sameMPV₂Pos_blockScalarMatrix_mul_toTensor
+    (P : SectorDecomposition d)
+    (z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ)
+    (period : Fin P.basisCount → ℕ)
+    (hzm : ∀ j q, z j q ^ period j = 1)
+    (hZero : ∀ (j : Fin P.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      ¬ period j ∣ N → mpv (P.basis j) σ = 0) :
+    SameMPV₂Pos P.toTensor
+      (fun i => blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i) := by
+  classical
+  intro N _hN σ
+  have hfun :
+      (fun i => blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i) =
+        toTensorFromBlocks (d := d)
+          (μ := fun s => P.flatCopyScalar z s * P.flatWeight s) P.flatBasis :=
+    funext fun i =>
+      blockScalarMatrix_mul_toTensorFromBlocks _ P.flatWeight P.flatBasis i
+  rw [hfun]
+  change mpv (toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis) σ = _
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  refine Finset.sum_congr rfl fun s _ => ?_
+  by_cases hdvd : period (P.flatIndexEquiv.symm s).1 ∣ N
+  · obtain ⟨c, hc⟩ := hdvd
+    have hz1 : P.flatCopyScalar z s ^ N = 1 := by
+      rw [SectorDecomposition.flatCopyScalar, hc, pow_mul, hzm, one_pow]
+    rw [mul_pow, hz1, one_mul]
+  · have hzero : mpv (P.flatBasis s) σ = 0 := hZero _ N σ hdvd
+    rw [hzero]
+    simp
+
 /-! ## The global multiplicity gauge in the equal case -/
 
 /-- **Global multiplicity gauge and similarity in the equal case.**
@@ -378,20 +424,24 @@ theorem equalCase_global_zgauge_of_blockwise
     (hPer : ∀ j, IsPeriodic (period j) (P.basis j))
     (hzm : ∀ j q, z j q ^ period j = 1)
     (L : ℕ) (hLdvd : ∀ j, period j ∣ L) :
-    ∃ (Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ)
-      (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
+    ∃ (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
       (Y' : Matrix (Fin Q.totalDim) (Fin P.totalDim) ℂ),
-      Z ^ L = 1 ∧ Y * Y' = 1 ∧ Y' * Y = 1 ∧
-      (∀ i : Fin d, Z * P.toTensor i = P.toTensor i * Z) ∧
-      (∀ i : Fin d, Z * P.toTensor i = Y * Q.toTensor i * Y') ∧
-      SameMPV₂Pos P.toTensor (fun i => Z * P.toTensor i) := by
+      Y * Y' = 1 ∧ Y' * Y = 1 ∧
+      blockScalarMatrix P.flatDim (P.flatCopyScalar z) ^ L = 1 ∧
+      (∀ i : Fin d,
+        blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+          P.toTensor i * blockScalarMatrix P.flatDim (P.flatCopyScalar z)) ∧
+      (∀ i : Fin d,
+        blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+          Y * Q.toTensor i * Y') ∧
+      SameMPV₂Pos P.toTensor
+        (fun i => blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i) := by
   classical
   have hzL : ∀ j q, z j q ^ L = 1 := by
     intro j q
     obtain ⟨c, hc⟩ := hLdvd j
     rw [hc, pow_mul, hzm, one_pow]
-  set zflat : Fin P.totalCopies → ℂ := fun s =>
-    z (P.flatIndexEquiv.symm s).1 (P.flatIndexEquiv.symm s).2 with hzflat
+  set zflat : Fin P.totalCopies → ℂ := P.flatCopyScalar z with hzflat
   set Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ :=
     blockScalarMatrix P.flatDim zflat with hZ
   -- The gauged first tensor is the first tensor with rescaled multiplicities.
@@ -457,7 +507,7 @@ theorem equalCase_global_zgauge_of_blockwise
     toTensorFromBlocks_conj_of_matched_blocks (d := d)
       (fun s => zflat s * P.flatWeight s) P.flatBasis
       Q.flatWeight Q.flatBasis e hd (matched_block_gauge (Q := Q) Yb) hrel
-  refine ⟨Z, Y, Y', ?_, hYY', hY'Y, ?_, ?_, ?_⟩
+  refine ⟨Y, Y', hYY', hY'Y, ?_, ?_, ?_, ?_⟩
   · rw [hZ, blockScalarMatrix_pow]
     have hone : (fun s : Fin P.totalCopies => zflat s ^ L) = fun _ => (1 : ℂ) := by
       funext s
@@ -465,25 +515,65 @@ theorem equalCase_global_zgauge_of_blockwise
     rw [hone, blockScalarMatrix_one]
   · intro i; rw [hZmul i, hZmulr i]
   · intro i; rw [hZmul i]; exact hconj i
-  · -- the gauged tensor generates the same matrix-product vectors
-    intro N _hN σ
-    have hfun : (fun i => Z * P.toTensor i) =
-        toTensorFromBlocks (d := d)
-          (μ := fun s => zflat s * P.flatWeight s) P.flatBasis := funext hZmul
-    rw [hfun]
-    change mpv (toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis) σ = _
-    rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
-    refine Finset.sum_congr rfl fun s _ => ?_
-    by_cases hdvd : period (P.flatIndexEquiv.symm s).1 ∣ N
-    · obtain ⟨c, hc⟩ := hdvd
-      have hz1 : zflat s ^ N = 1 := by
-        rw [hzflat, hc, pow_mul, hzm, one_pow]
-      rw [mul_pow, hz1, one_mul]
-    · have hzero : mpv (P.flatBasis s) σ = 0 :=
-        pgvwc07_stateVector_eq_zero_of_not_dvd (P.flatBasis s)
-          (hPer (P.flatIndexEquiv.symm s).1) hdvd σ
-      rw [hzero]
-      simp
+  · exact sameMPV₂Pos_blockScalarMatrix_mul_toTensor P z period hzm
+      (fun j N σ h => pgvwc07_stateVector_eq_zero_of_not_dvd (P.basis j) (hPer j) h σ)
+
+/-! ## Similarity carrying a prescribed scalar -/
+
+/-- The two tensors have equal bond dimension and, after that identification,
+the matrices of the first are the prescribed scalar `ζ` times a fixed conjugate
+of those of the second.
+
+This is the repeated-block relation of arXiv:1708.00029, definition
+`def:repeated` and equation `eq:rep`, lines 276--284, with the scalar named
+instead of bound existentially. Naming it is what lets one statement use the
+same scalar in the similarity and in the multiplicity relation, as the equal
+case does at lines 667--671 and 681--688. -/
+def ScalarGaugeEquiv {D₁ D₂ : ℕ} (ζ : ℂ) (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    Prop :=
+  ∃ (h : D₁ = D₂) (Y : GL (Fin D₂) ℂ),
+    ∀ i, (cast (congr_arg (MPSTensor d) h) A) i =
+      ζ • ((Y : Matrix (Fin D₂) (Fin D₂) ℂ) * B i *
+        ((Y⁻¹ : GL (Fin D₂) ℂ) : Matrix (Fin D₂) (Fin D₂) ℂ))
+
+/-- Forgetting the name of the scalar recovers the repeated-block relation. -/
+theorem ScalarGaugeEquiv.toHetRepeatedBlocks {D₁ D₂ : ℕ} {ζ : ℂ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} (hζ : ‖ζ‖ = 1)
+    (h : ScalarGaugeEquiv ζ A B) : HetRepeatedBlocks A B := by
+  obtain ⟨hd, Y, hY⟩ := h
+  exact ⟨hd, ζ, Y, hζ, hY⟩
+
+/-- Replacing the first tensor by a purely similar one keeps the scalar. -/
+theorem ScalarGaugeEquiv.of_gaugeEquiv_left {D₁ D₂ : ℕ} {ζ : ℂ}
+    {A A' : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hAA' : GaugeEquiv A A') (h : ScalarGaugeEquiv ζ A' B) :
+    ScalarGaugeEquiv ζ A B := by
+  obtain ⟨hd, Y, hY⟩ := h
+  subst hd
+  obtain ⟨X, hX⟩ := hAA'
+  refine ⟨rfl, X⁻¹ * Y, fun i => ?_⟩
+  have hA : A i =
+      ((X⁻¹ : GL (Fin D₁) ℂ) : Matrix (Fin D₁) (Fin D₁) ℂ) * A' i *
+        (X : Matrix (Fin D₁) (Fin D₁) ℂ) := by
+    rw [hX i]
+    simp [Matrix.mul_assoc]
+  have hA' : A' i =
+      ζ • ((Y : Matrix (Fin D₁) (Fin D₁) ℂ) * B i *
+        ((Y⁻¹ : GL (Fin D₁) ℂ) : Matrix (Fin D₁) (Fin D₁) ℂ)) := hY i
+  change A i = _
+  rw [hA, hA']
+  simp [Matrix.mul_assoc, mul_inv_rev]
+
+/-- Replacing the second tensor by a purely similar one keeps the scalar. -/
+theorem ScalarGaugeEquiv.of_gaugeEquiv_right {D₁ D₂ : ℕ} {ζ : ℂ}
+    {A : MPSTensor d D₁} {B B' : MPSTensor d D₂}
+    (h : ScalarGaugeEquiv ζ A B') (hBB' : GaugeEquiv B B') :
+    ScalarGaugeEquiv ζ A B := by
+  obtain ⟨hd, Y, hY⟩ := h
+  obtain ⟨W, hW⟩ := hBB'
+  refine ⟨hd, Y * W, fun i => ?_⟩
+  rw [hY i, hW i]
+  simp [Matrix.mul_assoc, mul_inv_rev]
 
 /-! ## The equal-case fundamental theorem over multiplicity-bearing decompositions -/
 
@@ -526,13 +616,14 @@ multiplicity matrix `ξ_j R_j`, which is what the source means at lines
 667--671 by absorbing the phase into `S_j`. The scalar is genuinely present:
 for period one and `B_j = e^{iθ} A_j` it is not a root of unity.
 
-**Scope restriction (irreducible form II):** the blocks are assumed
-left-canonical, that is, in irreducible form II. The source theorem assumes
-only irreducible form, and asserts at lines 330--332 that one passes between
-the two forms by a block-diagonal similarity, so that a proof in either form
-applies to the other; that passage is not carried out here. The restriction is
-recorded in `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`,
-section "Scope restriction: the equal case in irreducible form II". -/
+The blocks are assumed left-canonical, that is, in irreducible form II. The
+source theorem assumes only irreducible form and asserts at lines 330--332 that
+one passes between the two forms by a block-diagonal similarity; that passage
+is carried out in `fundamentalTheorem_periodic_equalCase_irreducibleForm`,
+which is the source statement itself. The present statement is the normalized
+half of that pair, isolated because the periodic overlap dichotomy and the
+vanishing of an off-period block are available in the normalized
+orientation. -/
 theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ)
@@ -541,23 +632,31 @@ theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
     (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
     (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
     (hSame : SameMPV₂Pos P.toTensor Q.toTensor) :
-    ∃ (perm : Fin P.basisCount ≃ Fin Q.basisCount) (ξ : Fin P.basisCount → ℂ),
+    ∃ (perm : Fin P.basisCount ≃ Fin Q.basisCount) (ξ : Fin P.basisCount → ℂ)
+      (z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ),
       (∀ j, ‖ξ j‖ = 1) ∧
       (∀ j, periodP j = periodQ (perm j)) ∧
+      (∀ j, ScalarGaugeEquiv (ξ j) (P.basis j) (Q.basis (perm j))) ∧
       (∀ j, HetRepeatedBlocks (P.basis j) (Q.basis (perm j))) ∧
+      (∀ j, Matrix.diagonal (z j) ^ periodP j = 1) ∧
       (∀ j, ∃ (_hCopies : P.copies j = Q.copies (perm j))
-              (τ : Fin (P.copies j) ≃ Fin (Q.copies (perm j)))
-              (Zj : Matrix (Fin (P.copies j)) (Fin (P.copies j)) ℂ),
-            Zj ^ periodP j = 1 ∧
-            Zj * Matrix.diagonal (fun q => ξ j * P.weight j q) =
+              (τ : Fin (P.copies j) ≃ Fin (Q.copies (perm j))),
+            Matrix.diagonal (z j) * Matrix.diagonal (fun q => ξ j * P.weight j q) =
               Matrix.diagonal (fun q => Q.weight (perm j) (τ q))) ∧
-      ∃ (Z : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ)
-        (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
+      ∃ (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
         (Y' : Matrix (Fin Q.totalDim) (Fin P.totalDim) ℂ),
-        Z ^ (Finset.univ.lcm periodP) = 1 ∧ Y * Y' = 1 ∧ Y' * Y = 1 ∧
-        (∀ i : Fin d, Z * P.toTensor i = P.toTensor i * Z) ∧
-        (∀ i : Fin d, Z * P.toTensor i = Y * Q.toTensor i * Y') ∧
-        SameMPV₂Pos P.toTensor (fun i => Z * P.toTensor i) := by
+        Y * Y' = 1 ∧ Y' * Y = 1 ∧
+        blockScalarMatrix P.flatDim (P.flatCopyScalar z) ^
+          (Finset.univ.lcm periodP) = 1 ∧
+        (∀ i : Fin d,
+          blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+            P.toTensor i * blockScalarMatrix P.flatDim (P.flatCopyScalar z)) ∧
+        (∀ i : Fin d,
+          blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+            Y * Q.toTensor i * Y') ∧
+        SameMPV₂Pos P.toTensor
+          (fun i =>
+            blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i) := by
   classical
   -- Theorem 3.4 supplies the matching of the two bases of periodic tensors.
   obtain ⟨_hCount, perm, hMatch⟩ :=
@@ -609,24 +708,27 @@ theorem fundamentalTheorem_periodic_equalCase_sectorDecomposition
   have hzm : ∀ j q, z j q ^ periodP j = 1 := by
     intro j q
     rw [hzdef, div_pow, hτpow j q, div_self (pow_ne_zero _ (hden j q))]
-  refine ⟨perm, ξ, hξ, hPeriodEq, hMatch', ?_, ?_⟩
-  · -- blockwise multiplicity gauge
+  refine ⟨perm, ξ, z, hξ, hPeriodEq,
+    fun j => ⟨hDimJ j, Yb' j, hConj' j⟩, hMatch', ?_, ?_, ?_⟩
+  · -- each blockwise multiplicity gauge has order the block period
     intro j
-    obtain ⟨Zj, hZjpow, hZjmul⟩ :=
-      zgauge_construction (periodP j)
-        (fun q => Q.weight (perm j) (τ j q)) (fun q => ξ j * P.weight j q)
-        (fun q => hτpow j q) (fun q => hden j q)
-    exact ⟨hCopies j, τ j, Zj, hZjpow, hZjmul⟩
+    simp only [Matrix.diagonal_pow, Pi.pow_def]
+    rw [show (fun q => z j q ^ periodP j) = (1 : Fin (P.copies j) → ℂ) from
+      funext (hzm j)]
+    exact Matrix.diagonal_one
+  · -- the blockwise multiplicity gauge relates the two multiplicity matrices
+    intro j
+    refine ⟨hCopies j, τ j, ?_⟩
+    rw [Matrix.diagonal_mul_diagonal]
+    exact congrArg Matrix.diagonal (funext fun q => hz j q)
   · -- global multiplicity gauge and similarity
-    obtain ⟨Z, Y, Y', hZpow, hYY', hY'Y, hcomm, hgauge, hmpv⟩ :=
-      equalCase_global_zgauge_of_blockwise perm hDimJ τ ξ
-        (Equiv.piCongrLeft (fun k => GL (Fin (Q.basisDim k)) ℂ) perm Yb')
-        (by
-          intro j i
-          rw [Equiv.piCongrLeft_apply_apply]
-          exact hConj' j i)
-        z hz periodP hPerP hzm (Finset.univ.lcm periodP)
-        (fun j => Finset.dvd_lcm (Finset.mem_univ j))
-    exact ⟨Z, Y, Y', hZpow, hYY', hY'Y, hcomm, hgauge, hmpv⟩
+    exact equalCase_global_zgauge_of_blockwise perm hDimJ τ ξ
+      (Equiv.piCongrLeft (fun k => GL (Fin (Q.basisDim k)) ℂ) perm Yb')
+      (by
+        intro j i
+        rw [Equiv.piCongrLeft_apply_apply]
+        exact hConj' j i)
+      z hz periodP hPerP hzm (Finset.univ.lcm periodP)
+      (fun j => Finset.dvd_lcm (Finset.mem_univ j))
 
 end MPSTensor

--- a/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
@@ -2,15 +2,17 @@ The following is the equal-case theorem of
 \cite[lines~643--656]{DeLasCuevas2017Irreducible}.
 The periodic-overlap and coefficient-power hypotheses that earlier statements
 carried are now derived from equality of the generated matrix-product vectors,
-and the theorem is obtained as a single unconditional result for tensors in
-irreducible form II, Theorem~\ref{thm:periodic_ft_equal_case_form_two}. The
-source theorem for the unrestricted irreducible form, stated below, still
-awaits the passage between the two forms.
+and the theorem is obtained as a single unconditional result for tensors whose
+blocks are trace preserving,
+Theorem~\ref{thm:periodic_ft_equal_case_trace_preserving}. The source theorem
+for the unrestricted irreducible form, stated below, still awaits the passage
+to that normalization.
 
 % Remaining gap for the source-level statement: the formal equal-case theorem
-% assumes trace-preserving block maps (irreducible form II). The passage from
-% irreducible form to irreducible form II by a block-diagonal similarity,
-% asserted by the source at lines 330--332, is not formalized.
+% assumes trace-preserving block maps, the normalization of eq:unital at line
+% 316. The passage from irreducible form to that normalization by a
+% block-diagonal similarity, asserted by the source at lines 330--332, is not
+% formalized.
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
     \uses{def:irreducible_form}
@@ -44,13 +46,13 @@ awaits the passage between the two forms.
     with $[A^i,Z]=0$ and $\mc{V}(A)=\mc{V}(ZA)$.
 
     \noindent\emph{Remark.}
-    Theorem~\ref{thm:periodic_ft_equal_case_form_two} is this statement for
-    tensors in irreducible form II, that is, with trace-preserving block maps.
-    What separates the two is the passage between irreducible form and
-    irreducible form II by a block-diagonal similarity, asserted by the source
-    at lines 330--332 and recorded in
+    Theorem~\ref{thm:periodic_ft_equal_case_trace_preserving} is this statement
+    for tensors whose block maps are trace preserving, the normalization of
+    \cite[eq.~\emph{unital}, line~316]{DeLasCuevas2017Irreducible}. What
+    separates the two is the passage to that normalization by a block-diagonal
+    similarity, asserted by the source at lines 330--332 and recorded in
     \cite{gap:dccsp17_periodic_overlap_route_alignment}, section ``Scope
-    restriction: the equal case in irreducible form II''.
+    restriction: the equal case with trace-preserving blocks''.
 \end{theorem}
 
 \begin{theorem}[Diagonal multiplicity gauge from equal powers]
@@ -194,6 +196,24 @@ awaits the passage between the two forms.
     conclusion is the displayed identity.
 \end{proof}
 
+\begin{definition}[Similarity carrying a prescribed scalar]%
+    \label{def:scalar_gauge_equiv}
+    \lean{MPSTensor.ScalarGaugeEquiv}
+    \leanok
+    \uses{def:mps_tensor}
+    For a scalar $\zeta$, two tensors $A$ and $B$ are \emph{similar carrying
+    $\zeta$} if they have the same bond dimension and there is an invertible
+    matrix $Y$ with
+    \begin{align}
+        A^i=\zeta\,YB^iY^{-1}
+        \notag
+    \end{align}
+    for every physical index $i$. This is the repeated-block relation of
+    \cite[def.~\emph{repeated}, lines~276--284]{DeLasCuevas2017Irreducible}
+    with the scalar named instead of quantified away, so that one statement can
+    use the same scalar in the similarity and in the multiplicity relation.
+\end{definition}
+
 \begin{theorem}[Equal-case coefficient extraction]%
     \label{thm:periodic_equalcase_coefficient_extraction}
     \lean{MPSTensor.SectorDecomposition.coeff_eq_of_sameMPV_of_matched_basis}
@@ -285,8 +305,7 @@ awaits the passage between the two forms.
     \label{thm:periodic_equalcase_global_zgauge}
     \lean{MPSTensor.equalCase_global_zgauge_of_blockwise}
     \leanok
-    \uses{def:periodic_tensor, def:same_mpv2_pos,
-        thm:pgvwc07_periodic_state_vector_decomposition}
+    \uses{def:periodic_tensor, def:same_mpv2_pos}
     Let
     \begin{align}
         A^i & =\bigoplus_{j\in J}(R_j\otimes A_j^i),
@@ -321,6 +340,7 @@ awaits the passage between the two forms.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:pgvwc07_periodic_state_vector_decomposition}
     The multiplicity gauge acts by the scalar $z_{j,l}$ on the bond space of
     the copy $(j,l)$, so it commutes with every block-diagonal matrix and its
     $L$-th power is the identity. Multiplying $A^i$ by it rescales the
@@ -335,17 +355,32 @@ awaits the passage between the two forms.
     Theorem~\ref{thm:pgvwc07_periodic_state_vector_decomposition}.
 \end{proof}
 
-\begin{theorem}[Fundamental theorem for MPS in irreducible form II, equal case]%
-    \label{thm:periodic_ft_equal_case_form_two}
+\begin{theorem}[Matched periods for trace-preserving repeated blocks]%
+    \label{thm:periodic_repeated_blocks_period_eq_tp}
+    \lean{MPSTensor.IsPeriodic.period_eq_of_hetRepeatedBlocks}
+    \leanok
+    \uses{def:periodic_tensor}
+    Let $A$ and $B$ be periodic tensors of periods $m$ and $n$ whose block maps
+    are trace preserving. If $A$ and $B$ are repeated blocks, then $m=n$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:repeated_blocks_peripheral_spectrum}
+    Repeated blocks have the same peripheral transfer spectrum,
+    \begin{align}
+        \operatorname{spec}_{\text{per}}\left(\E_{A}\right)
+        =\operatorname{spec}_{\text{per}}\left(\E_{B}\right),
+        \notag
+    \end{align}
+    and for a periodic tensor that set is the set of $m$-th roots of unity, so
+    the two periods agree.
+\end{proof}
+
+\begin{theorem}[Fundamental theorem for MPS with trace-preserving blocks, equal case]%
+    \label{thm:periodic_ft_equal_case_trace_preserving}
     \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition}
     \leanok
-    \uses{def:periodic_tensor, def:same_mpv2_pos,
-        thm:periodic_equalcase_global_zgauge,
-        thm:periodic_equalcase_blockwise_zgauge,
-        thm:periodic_equalcase_coefficient_extraction,
-        thm:periodic_conditional_block_matching,
-        thm:periodic_multiplicity_nondecaying_overlap,
-        thm:zgauge_construction}
+    \uses{def:periodic_tensor, def:same_mpv2_pos, def:scalar_gauge_equiv}
     Let $A$ and $B$ carry the multiplicity-bearing forms
     \begin{align}
         A^i & =\bigoplus_{j\in J}(R_j\otimes A_j^i),
@@ -357,11 +392,15 @@ awaits the passage between the two forms.
     displayed families are pairwise non-repeated bases of periodic tensors
     whose blocks are trace preserving, of periods $m_j$ and $n_k$. If
     $\mc{V}^+(A)=\mc{V}^+(B)$, then there is a bijection
-    $\pi\colon J\to K$ such that, for every $j$, one has $m_j=n_{\pi(j)}$,
-    the blocks $A_j$ and $B_{\pi(j)}$ are repeated with unit-modulus scalar
-    $\xi_j$, the multiplicity matrices $R_j$ and $S_{\pi(j)}$ have the same
-    size, and there are a reordering $T_j$ of the diagonal entries of
-    $S_{\pi(j)}$ and a diagonal matrix $Z_j$ with
+    $\pi\colon J\to K$ and unit-modulus scalars $\xi_j$ such that, for every
+    $j$, one has $m_j=n_{\pi(j)}$, there is an invertible $Y_j$ with
+    \begin{align}
+        A_j^i=\xi_jY_jB_{\pi(j)}^iY_j^{-1}
+        \notag
+    \end{align}
+    for every physical index $i$, the multiplicity matrices $R_j$ and
+    $S_{\pi(j)}$ have the same size, and there are a reordering $T_j$ of the
+    diagonal entries of $S_{\pi(j)}$ and a diagonal matrix $Z_j$ with
     \begin{align}
         Z_j^{m_j}=\Id,\qquad
         Z_j\left(\xi_jR_j\right)=T_jS_{\pi(j)}T_j^\dagger.
@@ -372,41 +411,53 @@ awaits the passage between the two forms.
     $\mc{V}^+(A)=\mc{V}^+(ZA)$, and there is an invertible $Y$ with
     $ZA^i=YB^iY^{-1}$ for every $i$.
 
+    The scalar $\xi_j$ is the same in the two displayed relations: it is the
+    scalar of the similarity between the matched blocks, and the entries of
+    $Z_j$ are $m_j$-th roots of unity against the rescaled multiplicity matrix
+    $\xi_jR_j$. That is what the source means at lines 667--671 by absorbing
+    the phase into $S_j$; the scalar is genuinely present, as the period-one
+    pair $B_j=e^{i\theta}A_j$ shows.
+
     \emph{Scope restriction.}  This is
     \cite[Theorem~3.8, lines~643--693]{DeLasCuevas2017Irreducible} for tensors
-    in irreducible form II, that is, with trace-preserving block maps. The
-    source theorem assumes only irreducible form and asserts at lines 330--332
-    that one passes between the two forms by a block-diagonal similarity, so
-    that a proof in either form applies to the other; that passage is not
-    carried out here. The restriction and its elimination plan are recorded in
+    whose block maps are trace preserving, the normalization of
+    \cite[eq.~\emph{unital}, line~316]{DeLasCuevas2017Irreducible}. This is
+    less than the source's irreducible form II, which asks in addition for a
+    diagonal fixed point, so the statement is correspondingly stronger; but it
+    is more than the source's irreducible form, which asks only for
+    irreducibility and spectral radius one. The source asserts at lines
+    330--332 that one passes to the normalized form by a block-diagonal
+    similarity; that passage is not carried out here. The restriction and its
+    elimination plan are recorded in
     \cite{gap:dccsp17_periodic_overlap_route_alignment}, section ``Scope
-    restriction: the equal case in irreducible form II''. The unrestricted
-    source theorem is Theorem~\ref{thm:periodic_ft}, which remains
+    restriction: the equal case with trace-preserving blocks''. The
+    unrestricted source theorem is Theorem~\ref{thm:periodic_ft}, which remains
     unformalized.
-
-    The unit-modulus scalar of each matched pair is displayed rather than
-    suppressed. The entries of $Z_j$ are $m_j$-th roots of unity against the
-    rescaled multiplicity matrix $\xi_jR_j$, which is what the source means at
-    lines 667--671 by absorbing the phase into $S_j$; the scalar is genuinely
-    present, as the period-one pair $B_j=e^{i\theta}A_j$ shows.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:periodic_multiplicity_nondecaying_overlap,
+        thm:periodic_conditional_block_matching,
+        thm:periodic_repeated_blocks_period_eq_tp,
+        thm:periodic_equalcase_coefficient_extraction,
+        lem:matched_sector_weight_pow_equiv_period,
+        thm:periodic_equalcase_global_zgauge}
     Equality of the generated matrix-product vectors is in particular
     proportionality, so
     Theorem~\ref{thm:periodic_multiplicity_nondecaying_overlap} supplies
     non-decaying partners and
     Theorem~\ref{thm:periodic_conditional_block_matching} matches the two
-    bases; matched blocks have equal periods because repeated blocks have the
-    same peripheral spectrum. Each matched pair carries a unit-modulus scalar
-    $\xi_j$ relating its matrix-product vectors at every length, so
+    bases, each matched pair carrying a similarity with a unit-modulus scalar
+    $\xi_j$. The matched periods agree by
+    Theorem~\ref{thm:periodic_repeated_blocks_period_eq_tp}. That same $\xi_j$
+    relates the matrix-product vectors of the matched pair at every length, so
     Theorem~\ref{thm:periodic_equalcase_coefficient_extraction} compares the
     multiplicity power sums at every large multiple of $m_j$, and
-    Theorem~\ref{thm:periodic_equalcase_blockwise_zgauge} turns that
+    Lemma~\ref{lem:matched_sector_weight_pow_equiv_period} turns that
     comparison into the reordering $T_j$ and the entry identities
     $\nu_{\pi(j),\tau_j(l)}^{m_j}=(\xi_j\mu_{j,l})^{m_j}$. The ratios
-    $\nu_{\pi(j),\tau_j(l)}/(\xi_j\mu_{j,l})$ are therefore $m_j$-th roots of
-    unity, and Theorem~\ref{thm:zgauge_construction} collects them into
-    $Z_j$. Theorem~\ref{thm:periodic_equalcase_global_zgauge} assembles the
-    blockwise data into the global $Z$ and $Y$.
+    $z_{j,l}=\nu_{\pi(j),\tau_j(l)}/(\xi_j\mu_{j,l})$ are therefore $m_j$-th
+    roots of unity; they are collected into the diagonal $Z_j$, and
+    Theorem~\ref{thm:periodic_equalcase_global_zgauge} assembles them into the
+    global $Z$ and the similarity $Y$.
 \end{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
@@ -1,14 +1,16 @@
 The following is the equal-case theorem of
 \cite[lines~643--656]{DeLasCuevas2017Irreducible}.
-The statements recorded here are conditional components of that theorem: the
-final comparison still assumes periodic-overlap and power-equality hypotheses,
-so the literature theorem has not yet been obtained here as a single
-unconditional result.
+The periodic-overlap and coefficient-power hypotheses that earlier statements
+carried are now derived from equality of the generated matrix-product vectors,
+and the theorem is obtained as a single unconditional result for tensors in
+irreducible form II, Theorem~\ref{thm:periodic_ft_equal_case_form_two}. The
+source theorem for the unrestricted irreducible form, stated below, still
+awaits the passage between the two forms.
 
-% The source-level equal-case theorem remains not ready as a single theorem:
-% the present Lean statements still assume the periodic-overlap and
-% coefficient-power hypotheses which the paper derives from equality of the
-% MPV family. The Z-gauge/root-of-unity construction is already formalized.
+% Remaining gap for the source-level statement: the formal equal-case theorem
+% assumes trace-preserving block maps (irreducible form II). The passage from
+% irreducible form to irreducible form II by a block-diagonal similarity,
+% asserted by the source at lines 330--332, is not formalized.
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
     \uses{def:irreducible_form}
@@ -42,9 +44,13 @@ unconditional result.
     with $[A^i,Z]=0$ and $\mc{V}(A)=\mc{V}(ZA)$.
 
     \noindent\emph{Remark.}
-    The proof is conditional on the periodic-overlap dichotomy of
-    \cite[lines~589--609]{DeLasCuevas2017Irreducible},
-    which is left here as a separate hypothesis.
+    Theorem~\ref{thm:periodic_ft_equal_case_form_two} is this statement for
+    tensors in irreducible form II, that is, with trace-preserving block maps.
+    What separates the two is the passage between irreducible form and
+    irreducible form II by a block-diagonal similarity, asserted by the source
+    at lines 330--332 and recorded in
+    \cite{gap:dccsp17_periodic_overlap_route_alignment}, section ``Scope
+    restriction: the equal case in irreducible form II''.
 \end{theorem}
 
 \begin{theorem}[Diagonal multiplicity gauge from equal powers]
@@ -273,4 +279,134 @@ unconditional result.
     $\zeta_j\mu_{j,q}$ are nonzero,
     Theorem~\ref{thm:zgauge_construction} produces the diagonal $Z_j$ with the
     two displayed properties.
+\end{proof}
+
+\begin{theorem}[Global multiplicity gauge and similarity]%
+    \label{thm:periodic_equalcase_global_zgauge}
+    \lean{MPSTensor.equalCase_global_zgauge_of_blockwise}
+    \leanok
+    \uses{def:periodic_tensor, def:same_mpv2,
+        thm:pgvwc07_periodic_state_vector_decomposition}
+    Let
+    \begin{align}
+        A^i & =\bigoplus_{j\in J}(R_j\otimes A_j^i),
+        \notag                                       \\
+        B^i & =\bigoplus_{k\in K}(S_k\otimes B_k^i),
+        \notag
+    \end{align}
+    be two multiplicity-bearing decompositions, let $\pi\colon J\to K$ be a
+    bijection with $D_j=D_{\pi(j)}$, let $\tau_j$ reorder the multiplicity
+    copies of the matched blocks, let $\xi_j$ be scalars and $Y_j$ invertible
+    matrices with
+    \begin{align}
+        A_j^i=\xi_jY_jB_{\pi(j)}^iY_j^{-1},
+        \notag
+    \end{align}
+    and let $z_{j,l}$ be scalars with
+    \begin{align}
+        z_{j,l}\,\xi_j\mu_{j,l}=\nu_{\pi(j),\tau_j(l)},
+        \qquad z_{j,l}^{m_j}=1,
+        \notag
+    \end{align}
+    where $A_j$ is $m_j$-periodic and every $m_j$ divides $L$. Writing $Z_j$
+    for the diagonal matrix of the $z_{j,l}$ and
+    $Z=\bigoplus_{j\in J}Z_j\otimes\Id_{D_j}$, one has $Z^L=\Id$,
+    $[A^i,Z]=0$ for every $i$, $\mc{V}(A)=\mc{V}(ZA)$, and there is an
+    invertible $Y$ with $ZA^i=YB^iY^{-1}$ for every $i$.
+
+    This is the assembly of
+    \cite[lines~689--690]{DeLasCuevas2017Irreducible}, with $Y$ the direct sum
+    $\bigoplus_jT_j\otimes Y_j$ of the copy reorderings and the blockwise
+    similarities.
+\end{theorem}
+
+\begin{proof}\leanok
+    The multiplicity gauge acts by the scalar $z_{j,l}$ on the bond space of
+    the copy $(j,l)$, so it commutes with every block-diagonal matrix and its
+    $L$-th power is the identity. Multiplying $A^i$ by it rescales the
+    multiplicity entries by the $z_{j,l}$, and the hypothesis on the
+    $z_{j,l}$ makes the rescaled entries equal to the matched entries of $B$.
+    The matched blocks are therefore related copy by copy, so the two
+    assembled tensors are related by the permutation of the matched copies
+    followed by the direct sum of the blockwise similarities. For the
+    matrix-product vectors, a copy whose period divides the length contributes
+    the factor $z_{j,l}^N=1$, and a copy whose period does not divide the
+    length contributes the zero vector by
+    Theorem~\ref{thm:pgvwc07_periodic_state_vector_decomposition}.
+\end{proof}
+
+\begin{theorem}[Fundamental theorem for MPS in irreducible form II, equal case]%
+    \label{thm:periodic_ft_equal_case_form_two}
+    \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition}
+    \leanok
+    \uses{def:periodic_tensor, def:same_mpv2,
+        thm:periodic_equalcase_global_zgauge,
+        thm:periodic_equalcase_blockwise_zgauge,
+        thm:periodic_equalcase_coefficient_extraction,
+        thm:periodic_conditional_block_matching,
+        thm:periodic_multiplicity_nondecaying_overlap,
+        thm:zgauge_construction}
+    Let $A$ and $B$ carry the multiplicity-bearing forms
+    \begin{align}
+        A^i & =\bigoplus_{j\in J}(R_j\otimes A_j^i),
+        \notag                                       \\
+        B^i & =\bigoplus_{k\in K}(S_k\otimes B_k^i),
+        \notag
+    \end{align}
+    where $R_j$ and $S_k$ are diagonal with nonzero entries and the two
+    displayed families are pairwise non-repeated bases of periodic tensors
+    whose blocks are trace preserving, of periods $m_j$ and $n_k$. If
+    $\mc{V}(A)=\mc{V}(B)$ at every positive length, then there is a bijection
+    $\pi\colon J\to K$ such that, for every $j$, one has $m_j=n_{\pi(j)}$,
+    the blocks $A_j$ and $B_{\pi(j)}$ are repeated with unit-modulus scalar
+    $\xi_j$, the multiplicity matrices $R_j$ and $S_{\pi(j)}$ have the same
+    size, and there are a reordering $T_j$ of the diagonal entries of
+    $S_{\pi(j)}$ and a diagonal matrix $Z_j$ with
+    \begin{align}
+        Z_j^{m_j}=\Id,\qquad
+        Z_j\left(\xi_jR_j\right)=T_jS_{\pi(j)}T_j^\dagger.
+        \notag
+    \end{align}
+    Writing $Z=\bigoplus_{j\in J}Z_j\otimes\Id_{D_j}$, one has
+    $Z^{\operatorname{lcm}_j m_j}=\Id$, $[A^i,Z]=0$ for every $i$,
+    $\mc{V}(A)=\mc{V}(ZA)$, and there is an invertible $Y$ with
+    $ZA^i=YB^iY^{-1}$ for every $i$.
+
+    \emph{Scope restriction.}  This is
+    \cite[Theorem~3.8, lines~643--693]{DeLasCuevas2017Irreducible} for tensors
+    in irreducible form II, that is, with trace-preserving block maps. The
+    source theorem assumes only irreducible form and asserts at lines 330--332
+    that one passes between the two forms by a block-diagonal similarity, so
+    that a proof in either form applies to the other; that passage is not
+    carried out here. The restriction and its elimination plan are recorded in
+    \cite{gap:dccsp17_periodic_overlap_route_alignment}, section ``Scope
+    restriction: the equal case in irreducible form II''. The unrestricted
+    source theorem is Theorem~\ref{thm:periodic_ft}, which remains
+    unformalized.
+
+    The unit-modulus scalar of each matched pair is displayed rather than
+    suppressed. The entries of $Z_j$ are $m_j$-th roots of unity against the
+    rescaled multiplicity matrix $\xi_jR_j$, which is what the source means at
+    lines 667--671 by absorbing the phase into $S_j$; the scalar is genuinely
+    present, as the period-one pair $B_j=e^{i\theta}A_j$ shows.
+\end{theorem}
+
+\begin{proof}\leanok
+    Equality of the generated matrix-product vectors is in particular
+    proportionality, so
+    Theorem~\ref{thm:periodic_multiplicity_nondecaying_overlap} supplies
+    non-decaying partners and
+    Theorem~\ref{thm:periodic_conditional_block_matching} matches the two
+    bases; matched blocks have equal periods because repeated blocks have the
+    same peripheral spectrum. Each matched pair carries a unit-modulus scalar
+    $\xi_j$ relating its matrix-product vectors at every length, so
+    Theorem~\ref{thm:periodic_equalcase_coefficient_extraction} compares the
+    multiplicity power sums at every large multiple of $m_j$, and
+    Theorem~\ref{thm:periodic_equalcase_blockwise_zgauge} turns that
+    comparison into the reordering $T_j$ and the entry identities
+    $\nu_{\pi(j),\tau_j(l)}^{m_j}=(\xi_j\mu_{j,l})^{m_j}$. The ratios
+    $\nu_{\pi(j),\tau_j(l)}/(\xi_j\mu_{j,l})$ are therefore $m_j$-th roots of
+    unity, and Theorem~\ref{thm:zgauge_construction} collects them into
+    $Z_j$. Theorem~\ref{thm:periodic_equalcase_global_zgauge} assembles the
+    blockwise data into the global $Z$ and $Y$.
 \end{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
@@ -3,8 +3,8 @@ The following is the equal-case theorem of
 The periodic-overlap and coefficient-power hypotheses that earlier statements
 carried are now derived from equality of the generated matrix-product vectors,
 and the theorem is obtained as a single unconditional result for tensors whose
-blocks are trace preserving,
-Theorem~\ref{thm:periodic_ft_equal_case_trace_preserving}. The source theorem
+blocks are trace preserving
+(Theorem~\ref{thm:periodic_ft_equal_case_trace_preserving}). The source theorem
 for the unrestricted irreducible form, stated below, still awaits the passage
 to that normalization.
 
@@ -202,7 +202,7 @@ to that normalization.
     \leanok
     \uses{def:mps_tensor}
     For a scalar $\zeta$, two tensors $A$ and $B$ are \emph{similar carrying
-    $\zeta$} if they have the same bond dimension and there is an invertible
+        $\zeta$} if they have the same bond dimension and there is an invertible
     matrix $Y$ with
     \begin{align}
         A^i=\zeta\,YB^iY^{-1}

--- a/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
@@ -285,7 +285,7 @@ awaits the passage between the two forms.
     \label{thm:periodic_equalcase_global_zgauge}
     \lean{MPSTensor.equalCase_global_zgauge_of_blockwise}
     \leanok
-    \uses{def:periodic_tensor, def:same_mpv2,
+    \uses{def:periodic_tensor, def:same_mpv2_pos,
         thm:pgvwc07_periodic_state_vector_decomposition}
     Let
     \begin{align}
@@ -311,7 +311,7 @@ awaits the passage between the two forms.
     where $A_j$ is $m_j$-periodic and every $m_j$ divides $L$. Writing $Z_j$
     for the diagonal matrix of the $z_{j,l}$ and
     $Z=\bigoplus_{j\in J}Z_j\otimes\Id_{D_j}$, one has $Z^L=\Id$,
-    $[A^i,Z]=0$ for every $i$, $\mc{V}(A)=\mc{V}(ZA)$, and there is an
+    $[A^i,Z]=0$ for every $i$, $\mc{V}^+(A)=\mc{V}^+(ZA)$, and there is an
     invertible $Y$ with $ZA^i=YB^iY^{-1}$ for every $i$.
 
     This is the assembly of
@@ -339,7 +339,7 @@ awaits the passage between the two forms.
     \label{thm:periodic_ft_equal_case_form_two}
     \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition}
     \leanok
-    \uses{def:periodic_tensor, def:same_mpv2,
+    \uses{def:periodic_tensor, def:same_mpv2_pos,
         thm:periodic_equalcase_global_zgauge,
         thm:periodic_equalcase_blockwise_zgauge,
         thm:periodic_equalcase_coefficient_extraction,
@@ -356,7 +356,7 @@ awaits the passage between the two forms.
     where $R_j$ and $S_k$ are diagonal with nonzero entries and the two
     displayed families are pairwise non-repeated bases of periodic tensors
     whose blocks are trace preserving, of periods $m_j$ and $n_k$. If
-    $\mc{V}(A)=\mc{V}(B)$ at every positive length, then there is a bijection
+    $\mc{V}^+(A)=\mc{V}^+(B)$, then there is a bijection
     $\pi\colon J\to K$ such that, for every $j$, one has $m_j=n_{\pi(j)}$,
     the blocks $A_j$ and $B_{\pi(j)}$ are repeated with unit-modulus scalar
     $\xi_j$, the multiplicity matrices $R_j$ and $S_{\pi(j)}$ have the same
@@ -369,7 +369,7 @@ awaits the passage between the two forms.
     \end{align}
     Writing $Z=\bigoplus_{j\in J}Z_j\otimes\Id_{D_j}$, one has
     $Z^{\operatorname{lcm}_j m_j}=\Id$, $[A^i,Z]=0$ for every $i$,
-    $\mc{V}(A)=\mc{V}(ZA)$, and there is an invertible $Y$ with
+    $\mc{V}^+(A)=\mc{V}^+(ZA)$, and there is an invertible $Y$ with
     $ZA^i=YB^iY^{-1}$ for every $i$.
 
     \emph{Scope restriction.}  This is

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -694,6 +694,55 @@ overlap-hypothesis step is tracked by
 subsequent multiplicity-power extraction is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5344}{issue \#5344}.
 
+\section{Scope restriction: the equal case in irreducible form II}
+
+Theorem~3.8 of Ref.~\cite{DeLasCuevas2017Irreducible}, lines 643--693, assumes
+that the two tensors are in irreducible form, that is, that every block map is
+irreducible of spectral radius one. The formal equal-case
+theorem\footnote{Formal declaration:
+\leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition} in
+\path{EqualCaseGlobal.lean}.} assumes in addition that every block is
+left-canonical, that is, that every block map is trace preserving. In the
+language of the source, lines 320--332, the blocks are in irreducible form II.
+
+The source asserts at lines 330--332 that one passes from irreducible form to
+irreducible form II by a block-diagonal similarity, so that a result proved in
+either form applies to the other after replacing ``invertible'' by
+``unitary''. That passage is not carried out in the formal development, so the
+formal statement is the form-II statement and not the unrestricted source
+theorem.
+
+Two ingredients force the restriction. The periodic overlap
+dichotomy\footnote{Formal declaration:
+\leanid{MPSTensor.periodicOverlapDichotomy}.} and the vanishing of the
+matrix-product vector of a periodic block at lengths that its period does not
+divide\footnote{Formal declaration:
+\leanid{MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}; see also
+\path{docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex}.} are both
+available only in the normalized orientation.
+
+\subsection{Elimination plan}
+
+Normalize both bases by the sectorwise similarity of the section ``Pure
+normalization theorem'' above, apply the form-II theorem to the normalized
+decompositions, and transport the conclusion back. The multiplicity gauge is
+unchanged by the transport: it acts by a scalar on each block, so it commutes
+with every block-diagonal similarity. The global similarity is conjugated by
+the two normalizing similarities.
+
+\section{Independence of the non-zero periodic vectors}
+
+The scope restriction of the section ``Scope restriction: independence without
+spanning'' above concerned two separate weakenings: independence only along a
+common-multiple subsequence, and the missing spanning clause. The
+first is now removed: independence of the non-zero members of the family at
+every sufficiently large length is
+formalized.\footnote{Formal declaration:
+\leanid{MPSTensor.periodicBasis_nonzero_subfamily_eventuallyLinearlyIndependent}
+in \path{NonzeroSubfamily.lean}.} Only the spanning clause remains
+unformalized.
+
+
 \begin{thebibliography}{9}
 \bibitem{DeLasCuevas2017Irreducible}
 G.~de las Cuevas, J.~I.~Cirac, N.~Schuch, and D.~P\'erez-Garc\'ia,

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -694,7 +694,7 @@ overlap-hypothesis step is tracked by
 subsequent multiplicity-power extraction is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5344}{issue \#5344}.
 
-\section{Scope restriction: the equal case in irreducible form II}
+\section{Scope restriction: the equal case with trace-preserving blocks}
 
 Theorem~3.8 of Ref.~\cite{DeLasCuevas2017Irreducible}, lines 643--693, assumes
 that the two tensors are in irreducible form, that is, that every block map is
@@ -702,14 +702,22 @@ irreducible of spectral radius one. The formal equal-case
 theorem\footnote{Formal declaration:
 \leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition} in
 \path{EqualCaseGlobal.lean}.} assumes in addition that every block is
-left-canonical, that is, that every block map is trace preserving. In the
-language of the source, lines 320--332, the blocks are in irreducible form II.
+left-canonical, that is, that every block map is trace preserving. This is the
+normalization of Eq.~\emph{unital}, line 316 of the source.
+
+It is worth being precise about how much this assumes, since the source's
+irreducible form II is a different and stronger condition. Form II, described
+at lines 320--332, asks for trace-preserving block maps \emph{and} for the
+fixed point of each block map to be diagonal, the latter obtained by the
+further conjugation $A''_j = U_j^\dagger A'_j U_j$. The formal hypothesis is
+only the first of the two, so the formal statement is stronger than the form-II
+statement and weaker than the source's.
 
 The source asserts at lines 330--332 that one passes from irreducible form to
-irreducible form II by a block-diagonal similarity, so that a result proved in
-either form applies to the other after replacing ``invertible'' by
-``unitary''. That passage is not carried out in the formal development, so the
-formal statement is the form-II statement and not the unrestricted source
+irreducible form II by a block-diagonal similarity. Only the first half of that
+passage, the unitalization of Eq.~\emph{unital}, is needed to reach the formal
+hypothesis. That passage is not carried out in the formal development, so the
+formal statement is the normalized statement and not the unrestricted source
 theorem.
 
 Two ingredients force the restriction. The periodic overlap
@@ -723,12 +731,14 @@ available only in the normalized orientation.
 
 \subsection{Elimination plan}
 
-Normalize both bases by the sectorwise similarity of the section ``Pure
-normalization theorem'' above, apply the form-II theorem to the normalized
-decompositions, and transport the conclusion back. The multiplicity gauge is
-unchanged by the transport: it acts by a scalar on each block, so it commutes
-with every block-diagonal similarity. The global similarity is conjugated by
-the two normalizing similarities.
+Normalize both bases by the unitalization of Eq.~\emph{unital}, using the
+sectorwise similarity of the section ``Pure normalization theorem'' above,
+apply the normalized theorem to the normalized decompositions, and transport
+the conclusion back. The multiplicity gauge is unchanged by the transport: it
+acts by a scalar on each block, so it commutes with every block-diagonal
+similarity. The global similarity is conjugated by the two normalizing
+similarities. The second half of the source's form-II construction, the
+diagonalization of the fixed point, is not needed.
 
 \section{Independence of the non-zero periodic vectors}
 


### PR DESCRIPTION
Closes #829. Advances #82 / #619. Stacked on #7730 (`agent/issue-5344-coeff-extraction`); retarget to `main` once that merges.

The final assembly of arXiv:1708.00029 Theorem 3.8 (`thm:bdequal`, lines 643–693).

### Declarations and source anchors

| Declaration | Source anchor |
|---|---|
| `MPSTensor.blockScalarMatrix` (+ mul / pow / weight-rescaling identities) | `thm:bdequal`, line 653 (`Z = ⊕_j Z_j ⊗ 1_{D_j}`) |
| `MPSTensor.permMatrixOfEquiv` (+ reindexing-as-conjugation) | supporting linear algebra for line 690 |
| `MPSTensor.toTensorFromBlocks_conj_of_matched_blocks` | `thm:bdequal`, line 690 (`Y = ⊕_j T_j ⊗ Y_j`) |
| `MPSTensor.equalCase_global_zgauge_of_blockwise` | `thm:bdequal`, lines 653, 655, 661–663, 689–690 |
| `MPSTensor.IsPeriodic.period_eq_of_hetRepeatedBlocks` | `equal-or-orthogonal-generalized`, lines 602–604 |
| `MPSTensor.fundamentalTheorem_periodic_equalCase_sectorDecomposition` | `thm:bdequal`, lines 643–693 |

New module `TNLean/MPS/Periodic/EqualCaseGlobal.lean`.

The capstone theorem takes only the multiplicity-bearing irreducible forms, periodicity of the two bases, pairwise non-repetition, and `SameMPV₂Pos P.toTensor Q.toTensor`. It concludes the bijection with equal periods and repeated blocks, the blockwise `Z_j` with `Z_j ^ m_j = 1` and `Z_j (ξ_j R_j) = T_j S_{π(j)} T_j^†`, and the global `Z`, `Y`, `Y'` with `Z ^ lcm(m_j) = 1`, `[A^i, Z] = 0`, `Z A^i = Y B^i Y^{-1}`, and `𝒱(A) = 𝒱(ZA)`. No `PeriodicOverlapHypothesis`, no coefficient-power hypothesis, no fixed-bond-dimension assumption.

### How the unit phase is handled

Kept explicit, never absorbed silently. The scalar `ξ_j` of the repeated-block relation appears as a bound existential in the capstone's conclusion and multiplies the first tensor's multiplicity entries wherever they are compared:

* blockwise: `Z_j * diagonal (fun q => ξ j * P.weight j q) = diagonal (fun q => Q.weight (perm j) (τ q))`, with `Z_j ^ m_j = 1` — the roots-of-unity property holds against `ξ_j R_j`, never against `R_j`;
* globally: the hypothesis of `equalCase_global_zgauge_of_blockwise` is `z_{j,l} * (ξ_j * μ_{j,l}) = ν_{π(j),τ_j(l)}`, so the same scalar drives the assembly.

The conclusion is about `P.toTensor` and `Q.toTensor` themselves — no rescaled substitute anywhere. The `Z A^i = Y B^i Y^{-1}` clause is exact because the `ξ_j` in `Z_j`'s denominator cancels the `ξ_j` in the blockwise similarity; that cancellation is the source's "the phase can be absorbed in `S_j`" of lines 667–671, made visible rather than assumed.

`Y` and `Y'` are given as a mutually inverse pair of rectangular matrices rather than as an element of `GL`, so that no equality of the two total bond dimensions has to be extracted from the empty word — the point raised in the issue body.

### `thm:periodic_ft` stays `\notready` — and why

**This PR does not complete arXiv:1708.00029's theorem coverage.** The formal capstone assumes `IsPeriodic`, i.e. left-canonical (trace-preserving) blocks: the source's **irreducible form II**. Theorem 3.8 assumes only irreducible form. The source does say at lines 330–332 that one passes between the forms by a block-diagonal similarity, so a proof in either form applies to the other — but that passage is not formalized here, so the hypothesis set is strictly stronger than the source's and a `\leanok` on `thm:periodic_ft` would be false.

The restriction is forced by two upstream normalized-orientation results: `periodicOverlapDichotomy` and `pgvwc07_stateVector_eq_zero_of_not_dvd`.

Accordingly:

* new blueprint node `thm:periodic_ft_equal_case_form_two`, `\leanok`, stating the form-II restriction in its own text;
* `thm:periodic_ft` keeps `\notready` and gains a remark naming exactly what separates it from the form-II node;
* the stale comment above it (periodic-overlap and coefficient-power hypotheses) is replaced — those are now discharged;
* `**Scope restriction (irreducible form II):**` marker on the Lean declaration;
* new section in `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex` with the elimination plan (normalize both bases, apply the form-II theorem, transport back — the multiplicity gauge is invariant under the transport since it is scalar on each block).

Also new: `thm:periodic_equalcase_global_zgauge` node, and a paper-gap section recording that #5344's non-zero subfamily theorem removed the common-multiple half of the independence scope restriction.

### L7 skipped

Restating `fundamentalTheorem_periodic_equalCase` as a corollary specialised to one multiplicity copy per block was left out: it is independent of the assembly and belongs with a cleanup of that declaration's own scope markers.

### Verification

* full `lake build` clean, linters included, no new warnings
* no `sorry` / `axiom` / `native_decide` / `admit` in the changed files
* `scripts/generate_import_aggregators.py --check` passes
* `lake exe checkdecls blueprint/lean_decls` and `lake exe lint_style` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca
