### PR TITLE
doc(MPS/Periodic): record the trace-preservation gap in Theorem 4.1's forward direction

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
@@ -38,8 +38,9 @@ single biconditional.
 
 **Unfaithful:** This proof calls `thm_4_1_p_refinement_forward`, whose
 hypothesis `PRefinementCanonicalization` deviates from arXiv:1708.00029,
-Theorem 4.1, lines 728--731: it is refuted at bond dimension one by a positive
-rescaling of a \(p\)-refinable tensor, because the printed forward implication
+Theorem 4.1, lines 728--731: it is refuted for \(p \ge 1\) at bond dimension
+one by a positive rescaling of a \(p\)-refinable tensor, because the printed
+forward implication
 omits the trace preservation of \(\mathcal E_B\) presupposed by its definition
 of \(p\)-divisibility at lines 717--718. Documented in
 `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
@@ -31,6 +31,9 @@ hypothesis `PRefinementInverseCanonicalization`, `p`-refinability of `B` is equi
 
 This is a conditional version of arXiv:1708.00029, Theorem 4.1; the source
 statement, lines 728--731, does not assume the two canonicalization hypotheses.
+The forward hypothesis is refuted as stated, because the printed forward
+implication omits the trace preservation of the transfer map; this is
+recorded in `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`.
 The converse root/Kraus-rank gap is recorded in
 `docs/paper-gaps/dccsp17_root_kraus_rank_thm41.tex`. This theorem combines
 `thm_4_1_p_refinement_forward` and `thm_4_1_p_refinement_reverse` into a

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
@@ -31,13 +31,22 @@ hypothesis `PRefinementInverseCanonicalization`, `p`-refinability of `B` is equi
 
 This is a conditional version of arXiv:1708.00029, Theorem 4.1; the source
 statement, lines 728--731, does not assume the two canonicalization hypotheses.
-The forward hypothesis is refuted as stated, because the printed forward
-implication omits the trace preservation of the transfer map; this is
-recorded in `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`.
 The converse root/Kraus-rank gap is recorded in
 `docs/paper-gaps/dccsp17_root_kraus_rank_thm41.tex`. This theorem combines
 `thm_4_1_p_refinement_forward` and `thm_4_1_p_refinement_reverse` into a
-single biconditional. -/
+single biconditional.
+
+**Unfaithful:** This proof calls `thm_4_1_p_refinement_forward`, whose
+hypothesis `PRefinementCanonicalization` deviates from arXiv:1708.00029,
+Theorem 4.1, lines 728--731: it is refuted at bond dimension one by a positive
+rescaling of a \(p\)-refinable tensor, because the printed forward implication
+omits the trace preservation of \(\mathcal E_B\) presupposed by its definition
+of \(p\)-divisibility at lines 717--718. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+restate the forward direction over a block-form tensor with every multiplicity
+equal to one, as described in the marker of `thm_4_1_p_refinement_forward`,
+and rebuild this biconditional from the restated forward direction; tracked in
+the follow-up issue cited by the paper-gap note. -/
 theorem thm_4_1_p_refinement
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
     (p : ℕ) (hp : 0 < p)

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -417,7 +417,20 @@ source step is the construction of \(A'_j\) and
 lines 765--810. The theorem
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`
 shows that this hypothesis follows from the more precise blocked equal-case
-hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
+hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`.
+
+This hypothesis is not provable as stated. The printed forward implication of
+arXiv:1708.00029, Theorem 4.1, lines 728--731, omits the trace preservation of
+\(\mathcal E_B\) that its definition of \(p\)-divisibility at lines 717--718
+presupposes: for a \(p\)-refinable tensor \(B_0\) in irreducible form II and
+\(\lambda > 1\), the tensor \(\lambda B_0\) is again in irreducible form II
+and \(p\)-refinable, while \(\mathcal E_{\lambda B_0} = \lambda^2
+\mathcal E_{B_0}\) is not trace preserving and so is not a \(p\)-th power of a
+channel. The formal `IsIrreducibleForm` moreover fixes only the generated
+matrix product vectors, so at \(p = 1\) a non-unitary similarity of a
+left-canonical normal tensor refutes the hypothesis as well. Both
+counterexamples, the corrected source statement, and the elimination plan are
+recorded in `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. -/
 def PRefinementCanonicalization (d D p : ℕ) : Prop :=
   ∀ {B : MPSTensor d D}, IsIrreducibleForm B → IsPRefinable B p →
     ∃ A : MPSTensor d D,
@@ -479,7 +492,10 @@ This follows the same conditional pattern as
 `MPSTensor.cor_4_1_physical_symmetry_zgauge`: inputs not yet formalized are
 exposed as explicit hypotheses, while the
 algebraic structure — the blocking-commutes-with-power identity and the
-left-canonical-channel lemma — is formalized here. -/
+left-canonical-channel lemma — is formalized here. The hypothesis
+`PRefinementCanonicalization` is refuted rather than dischargeable; see its
+docstring and `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`
+for the counterexamples and the source-faithful restatement. -/
 theorem thm_4_1_p_refinement_forward
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
     (p : ℕ)

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -342,7 +342,14 @@ In the irreducible-form subcase treated in arXiv:1708.00029, lines 765--810, def
 \(\widetilde A = U^\dagger A' U\). The witness called `A'` below is this final
 tensor \(\widetilde A\). The formal statement keeps this construction as a
 conditional input for arbitrary `A`; it does not assert the irreducible block
-data of `A` as hypotheses. -/
+data of `A` as hypotheses.
+
+This hypothesis is refuted by the rescaling counterexample of
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: at physical
+and bond dimension one the tensors \(C = A^{[p]} = (\lambda)\) with
+\(\lambda > 1\) are related by the trivial \(Z\)-gauge with \(m = 1\), and
+\(C\) is in irreducible form II, while no left-canonical \(A'\) has
+\(\mathcal E_{A'}^p(x) = \lambda^2 x\). -/
 def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
     IsIrreducibleForm C →
@@ -392,7 +399,18 @@ continuation hypothesis
 
 This splits the blocked equal-case part of the forward proof into two explicit
 obligations: the equal-case \(Z\)-gauge existence step and the construction of
-\(\widetilde A\) described in arXiv:1708.00029, lines 765--810. -/
+\(\widetilde A\) described in arXiv:1708.00029, lines 765--810.
+
+**Unfaithful:** This proof relies on the hypothesis
+`PeripheralEqualCaseRootFromZGauge`, which deviates from arXiv:1708.00029,
+lines 765--810: the printed construction of \(\widetilde A\) is left canonical
+only when every multiplicity is one, and the hypothesis is refuted at physical
+and bond dimension one by \(C = A^{[p]} = (\lambda)\), \(\lambda > 1\), with
+the trivial \(Z\)-gauge. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+restate the construction over a block-form tensor with every multiplicity
+equal to one, as described in the marker of `thm_4_1_p_refinement_forward`;
+tracked in the follow-up issue cited by the paper-gap note. -/
 theorem peripheralEqualCase_periodicFT_of_sameMPV
     (hZGauge : PeripheralEqualCaseZGaugeOfSameMPV d D p)
     (hRoot : PeripheralEqualCaseRootFromZGauge d D p) :
@@ -451,7 +469,19 @@ Assuming `PeripheralEqualCasePeriodicFTOfSameMPV`, the theorem
 full forward-side canonicalization hypothesis `PRefinementCanonicalization`.
 Thus the remaining forward gap in Theorem 4.1 is exactly the blocked
 equal-case construction of \(\widetilde A\) captured by
-`PeripheralEqualCasePeriodicFTOfSameMPV`. -/
+`PeripheralEqualCasePeriodicFTOfSameMPV`.
+
+**Unfaithful:** This proof relies on the hypothesis
+`PeripheralEqualCasePeriodicFTOfSameMPV` and produces
+`PRefinementCanonicalization`; both deviate from arXiv:1708.00029,
+Theorem 4.1, lines 728--731, and both are refuted at bond dimension one by a
+positive rescaling, because the printed forward implication omits the trace
+preservation of \(\mathcal E_B\) presupposed by its definition of
+\(p\)-divisibility at lines 717--718. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+restate both hypotheses over a block-form tensor with every multiplicity equal
+to one, as described in the marker of `thm_4_1_p_refinement_forward`; tracked
+in the follow-up issue cited by the paper-gap note. -/
 theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
     (hPeripheralEq : PeripheralEqualCasePeriodicFTOfSameMPV d D p) :
     PRefinementCanonicalization d D p := by

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -365,8 +365,15 @@ In the paper this is the point where the blocked equal-case Fundamental Theorem
 (source theorem `thm:bdequal`, arXiv:1708.00029, lines 643--656) is combined
 with the phase-distribution construction in lines 765--810, where the scalars
 \(c_{j,\alpha}\) are redistributed to form \(A'_j\) and then
-\(\widetilde A = U^\dagger A' U\). The formal statement is kept as a separate
-hypothesis until that source argument is fully formalized. -/
+\(\widetilde A = U^\dagger A' U\).
+
+This hypothesis implies `PRefinementCanonicalization` (see
+`pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`)
+and is refuted by the same rescaling: at bond dimension one the tensors
+\(C = (\lambda)\) and \(A = (\lambda^{1/p})\) with \(\lambda > 1\) satisfy the
+premises, while no left-canonical \(A'\) has
+\(\mathcal E_{A'}^p(x) = \lambda^2 x\). See
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. -/
 def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
     IsIrreducibleForm C →
@@ -469,7 +476,19 @@ theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
 
 This restates `thm_4_1_p_refinement_forward` after replacing the broader
 hypothesis `PRefinementCanonicalization` by the more precise blocked-stage
-hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
+hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`.
+
+**Unfaithful:** This proof relies on the hypothesis
+`PeripheralEqualCasePeriodicFTOfSameMPV`, which deviates from
+arXiv:1708.00029, Theorem 4.1, lines 728--731, in the same way as
+`PRefinementCanonicalization`: it is refuted at bond dimension one by a
+positive rescaling, because the printed forward implication omits the trace
+preservation of \(\mathcal E_B\) presupposed by its definition of
+\(p\)-divisibility at lines 717--718. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+the same restatement over a block-form tensor with unit multiplicities
+described in the marker of `thm_4_1_p_refinement_forward`; tracked in the
+follow-up issue cited by the paper-gap note. -/
 theorem thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
     (p : ℕ)
@@ -492,10 +511,23 @@ This follows the same conditional pattern as
 `MPSTensor.cor_4_1_physical_symmetry_zgauge`: inputs not yet formalized are
 exposed as explicit hypotheses, while the
 algebraic structure — the blocking-commutes-with-power identity and the
-left-canonical-channel lemma — is formalized here. The hypothesis
-`PRefinementCanonicalization` is refuted rather than dischargeable; see its
-docstring and `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`
-for the counterexamples and the source-faithful restatement. -/
+left-canonical-channel lemma — is formalized here.
+
+**Unfaithful:** This proof relies on the hypothesis `PRefinementCanonicalization`,
+which deviates from arXiv:1708.00029, Theorem 4.1, lines 728--731: the
+hypothesis is refuted at bond dimension one by a positive rescaling of a
+\(p\)-refinable tensor, and the printed forward implication itself omits the
+trace preservation of \(\mathcal E_B\) that its definition of
+\(p\)-divisibility at lines 717--718 presupposes. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+restate the forward direction over a block-form tensor with every multiplicity
+equal to one, so that \(\mathcal E_B\) is trace preserving, consuming
+`fundamentalTheorem_periodic_equalCase_irreducibleForm` for the equal-case
+step and formalizing the blocking lemma for a periodic block (lines 432--446),
+the cyclic projector structure of a periodic block (lines 335--341), the unique
+decomposition of residues (lines 446--450), and the redistribution of the
+root-of-unity factors across the sites (lines 765--806); tracked in the
+follow-up issue cited by the paper-gap note. -/
 theorem thm_4_1_p_refinement_forward
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
     (p : ℕ)

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -345,7 +345,7 @@ conditional input for arbitrary `A`; it does not assert the irreducible block
 data of `A` as hypotheses.
 
 This hypothesis is refuted by the rescaling counterexample of
-`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: at physical
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: for \(p \ge 1\) at physical
 and bond dimension one the tensors \(C = A^{[p]} = (\lambda)\) with
 \(\lambda > 1\) are related by the trivial \(Z\)-gauge with \(m = 1\), and
 \(C\) is in irreducible form II, while no left-canonical \(A'\) has
@@ -376,7 +376,7 @@ with the phase-distribution construction in lines 765--810, where the scalars
 
 This hypothesis implies `PRefinementCanonicalization` (see
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`)
-and is refuted by the same rescaling: at bond dimension one the tensors
+and is refuted by the same rescaling for \(p \ge 1\): at bond dimension one the tensors
 \(C = (\lambda)\) and \(A = (\lambda^{1/p})\) with \(\lambda > 1\) satisfy the
 premises, while no left-canonical \(A'\) has
 \(\mathcal E_{A'}^p(x) = \lambda^2 x\). See
@@ -404,7 +404,7 @@ obligations: the equal-case \(Z\)-gauge existence step and the construction of
 **Unfaithful:** This proof relies on the hypothesis
 `PeripheralEqualCaseRootFromZGauge`, which deviates from arXiv:1708.00029,
 lines 765--810: the printed construction of \(\widetilde A\) is left canonical
-only when every multiplicity is one, and the hypothesis is refuted at physical
+only when every multiplicity is one, and the hypothesis is refuted for \(p \ge 1\) at physical
 and bond dimension one by \(C = A^{[p]} = (\lambda)\), \(\lambda > 1\), with
 the trivial \(Z\)-gauge. Documented in
 `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
@@ -447,8 +447,8 @@ hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`.
 This hypothesis is not provable as stated. The printed forward implication of
 arXiv:1708.00029, Theorem 4.1, lines 728--731, omits the trace preservation of
 \(\mathcal E_B\) that its definition of \(p\)-divisibility at lines 717--718
-presupposes: for a \(p\)-refinable tensor \(B_0\) in irreducible form II and
-\(\lambda > 1\), the tensor \(\lambda B_0\) is again in irreducible form II
+presupposes: for \(p \ge 1\), a \(p\)-refinable tensor \(B_0\) in irreducible
+form II, and \(\lambda > 1\), the tensor \(\lambda B_0\) is again in irreducible form II
 and \(p\)-refinable, while \(\mathcal E_{\lambda B_0} = \lambda^2
 \mathcal E_{B_0}\) is not trace preserving and so is not a \(p\)-th power of a
 channel. The formal `IsIrreducibleForm` moreover fixes only the generated
@@ -474,7 +474,7 @@ equal-case construction of \(\widetilde A\) captured by
 **Unfaithful:** This proof relies on the hypothesis
 `PeripheralEqualCasePeriodicFTOfSameMPV` and produces
 `PRefinementCanonicalization`; both deviate from arXiv:1708.00029,
-Theorem 4.1, lines 728--731, and both are refuted at bond dimension one by a
+Theorem 4.1, lines 728--731, and both are refuted for \(p \ge 1\) at bond dimension one by a
 positive rescaling, because the printed forward implication omits the trace
 preservation of \(\mathcal E_B\) presupposed by its definition of
 \(p\)-divisibility at lines 717--718. Documented in
@@ -511,7 +511,7 @@ hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`.
 **Unfaithful:** This proof relies on the hypothesis
 `PeripheralEqualCasePeriodicFTOfSameMPV`, which deviates from
 arXiv:1708.00029, Theorem 4.1, lines 728--731, in the same way as
-`PRefinementCanonicalization`: it is refuted at bond dimension one by a
+`PRefinementCanonicalization`: it is refuted for \(p \ge 1\) at bond dimension one by a
 positive rescaling, because the printed forward implication omits the trace
 preservation of \(\mathcal E_B\) presupposed by its definition of
 \(p\)-divisibility at lines 717--718. Documented in
@@ -545,7 +545,7 @@ left-canonical-channel lemma — is formalized here.
 
 **Unfaithful:** This proof relies on the hypothesis `PRefinementCanonicalization`,
 which deviates from arXiv:1708.00029, Theorem 4.1, lines 728--731: the
-hypothesis is refuted at bond dimension one by a positive rescaling of a
+hypothesis is refuted for \(p \ge 1\) at bond dimension one by a positive rescaling of a
 \(p\)-refinable tensor, and the printed forward implication itself omits the
 trace preservation of \(\mathcal E_B\) that its definition of
 \(p\)-divisibility at lines 717--718 presupposes. Documented in

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -61,7 +61,14 @@ This Prop isolates the channel-theoretic core of
 `C` and `blockTensor A p`, extract a CPTP root `E'` of `Kraus.transferMap C` whose
 Kraus rank is at most the ambient physical dimension `d`. Once such a root is
 available, the tensor-level reconstruction follows by choosing a Kraus family
-with `d` operators. -/
+with `d` operators.
+
+This hypothesis is refuted by the rescaling counterexample of
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: at physical
+and bond dimension one the tensors \(C = A^{[p]} = (\lambda)\) with
+\(\lambda > 1\) are related by the trivial \(Z\)-gauge with \(m = 1\), and
+\(C\) is in irreducible form II, while \(\mathcal E_C(x) = \lambda^2 x\) is
+not trace preserving and so is not a \(p\)-th power of a channel. -/
 def PeripheralEqualCaseRootChannelOfZGauge (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
     IsIrreducibleForm C →
@@ -77,7 +84,20 @@ def PeripheralEqualCaseRootChannelOfZGauge (d D p : ℕ) : Prop :=
 If a blocked `Z`-gauge witness yields a CPTP root channel of `Kraus.transferMap C`
 with Kraus rank at most `d`, then one can choose a tensor `A' : MPSTensor d D`
 realizing that root. The channel property forces `A'` to be left-canonical,
-and blocking recovers the transfer map of `C`. -/
+and blocking recovers the transfer map of `C`.
+
+**Unfaithful:** This proof relies on the hypothesis
+`PeripheralEqualCaseRootChannelOfZGauge` and produces
+`PeripheralEqualCaseRootFromZGauge`; both deviate from arXiv:1708.00029,
+lines 765--810, and both are refuted at physical and bond dimension one by
+\(C = A^{[p]} = (\lambda)\), \(\lambda > 1\), with the trivial \(Z\)-gauge,
+because the printed forward implication of Theorem 4.1, lines 728--731, omits
+the trace preservation of \(\mathcal E_B\) presupposed by its definition of
+\(p\)-divisibility at lines 717--718. Documented in
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`. Elimination:
+restate both hypotheses over a block-form tensor with every multiplicity equal
+to one, as described in the marker of `thm_4_1_p_refinement_forward`; tracked
+in the follow-up issue cited by the paper-gap note. -/
 theorem peripheralEqualCaseRootFromZGauge_of_rootChannel
     (hRoot : PeripheralEqualCaseRootChannelOfZGauge d D p) :
     PeripheralEqualCaseRootFromZGauge d D p := by

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -64,7 +64,7 @@ available, the tensor-level reconstruction follows by choosing a Kraus family
 with `d` operators.
 
 This hypothesis is refuted by the rescaling counterexample of
-`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: at physical
+`docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex`: for \(p \ge 1\) at physical
 and bond dimension one the tensors \(C = A^{[p]} = (\lambda)\) with
 \(\lambda > 1\) are related by the trivial \(Z\)-gauge with \(m = 1\), and
 \(C\) is in irreducible form II, while \(\mathcal E_C(x) = \lambda^2 x\) is
@@ -89,7 +89,7 @@ and blocking recovers the transfer map of `C`.
 **Unfaithful:** This proof relies on the hypothesis
 `PeripheralEqualCaseRootChannelOfZGauge` and produces
 `PeripheralEqualCaseRootFromZGauge`; both deviate from arXiv:1708.00029,
-lines 765--810, and both are refuted at physical and bond dimension one by
+lines 765--810, and both are refuted for \(p \ge 1\) at physical and bond dimension one by
 \(C = A^{[p]} = (\lambda)\), \(\lambda > 1\), with the trivial \(Z\)-gauge,
 because the printed forward implication of Theorem 4.1, lines 728--731, omits
 the trace preservation of \(\mathcal E_B\) presupposed by its definition of

--- a/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
@@ -251,8 +251,9 @@ additional constructions used below.
     irreducible form~II alone, and the printed forward implication of
     \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} omits the trace
     preservation of $\E_B$ that its notion of $p$-divisibility presupposes.
-    Let $B_0$ be $p$-refinable with witness $(A_0, W)$ and in irreducible
-    form~II with every multiplicity equal to one, and let $\lambda > 1$. Set
+    Let $p \ge 1$, let $B_0$ be $p$-refinable with witness $(A_0, W)$ and in
+    irreducible form~II with every multiplicity equal to one, and let
+    $\lambda > 1$. Set
     \begin{align}
         B
          & = \lambda B_0,

--- a/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
@@ -245,7 +245,7 @@ additional constructions used below.
 
 \begin{remark}[Trace preservation in the forward direction]
     \label{rem:thm_4_1_forward_trace_preservation}
-    \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
+    \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel, def:peripheral_equalcase_root_from_zgauge, def:peripheral_equalcase_periodicFT_sameMPV, def:peripheral_equalcase_root_channel_from_zgauge}
     The construction assumed in
     Theorem~\ref{thm:thm_4_1_p_refinement_forward} does not follow from
     irreducible form~II alone, and the printed forward implication of
@@ -274,13 +274,28 @@ additional constructions used below.
         \E_B
          & = \lambda^{2}\,\E_{B_0},
         \qquad
-        \tr \E_B(X) = \lambda^{2}\tr X \neq \tr X,
+        \tr \E_B(\Id) = \lambda^{2}\tr \Id \neq \tr \Id,
         \notag
     \end{align}
     so $\E_B$ is not trace preserving and is not the $p$-th power of a CPTP
-    map. The corrected statement adds trace preservation of $\E_B$,
-    equivalently unit multiplicities, under which the printed argument
-    closes \cite{gap:dccsp17_thm41_forward_trace_preservation}.
+    map. At physical and bond dimension one, with $B_0 = (1)$, the same data
+    give $C = A^{[p]} = (\lambda)$ related by the trivial $\Z_1$-gauge, and
+    no left-canonical $\widetilde A$ or CPTP root has $p$-th power
+    $x \mapsto \lambda^2 x$; so the constructions assumed in
+    Definitions~\ref{def:peripheral_equalcase_root_from_zgauge},
+    \ref{def:peripheral_equalcase_periodicFT_sameMPV},
+    and~\ref{def:peripheral_equalcase_root_channel_from_zgauge} fail as well.
+    The corrected statement takes $B$ literally in the block form of
+    irreducible form~II from \cite{DeLasCuevas2017Irreducible}, as the source
+    does, and adds trace preservation of $\E_B$; for such a block form this is
+    equivalent to every multiplicity being one, since
+    $\sum_i (B^i)^\dagger B^i = \bigoplus_j \mu_j^2 \Id$. Under this
+    hypothesis the printed argument closes
+    \cite{gap:dccsp17_thm41_forward_trace_preservation}. The equivalence does
+    not extend to the generated-family reading of
+    Definition~\ref{def:irreducible_form}: a non-unitary similarity of a
+    left-canonical normal tensor generates the same family with unit weights,
+    while its transfer map is not trace preserving.
 \end{remark}
 
 \begin{definition}[Blocked-to-root channel-root hypothesis from $Z$-gauge]

--- a/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
@@ -225,6 +225,14 @@ additional constructions used below.
     $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
     $\E_B = \E_{\widetilde A^{[p]}}$. Then
     $p$-refinability of $B$ implies $p$-divisibility of $\E_B$.
+    The assumed construction cannot be discharged in this generality:
+    the printed forward implication of
+    \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} omits the trace
+    preservation of $\E_B$ that its notion of $p$-divisibility presupposes,
+    and a positive rescaling of a $p$-refinable tensor in irreducible
+    form~II refutes it. The corrected source statement and the formal
+    boundary are recorded in
+    \cite{gap:dccsp17_thm41_forward_trace_preservation}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_refinement_divisibility.tex
@@ -225,15 +225,12 @@ additional constructions used below.
     $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
     $\E_B = \E_{\widetilde A^{[p]}}$. Then
     $p$-refinability of $B$ implies $p$-divisibility of $\E_B$.
-    The assumed construction cannot be discharged in this generality:
-    the printed forward implication of
-    \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} omits the trace
-    preservation of $\E_B$ that its notion of $p$-divisibility presupposes,
-    and a positive rescaling of a $p$-refinable tensor in irreducible
-    form~II refutes it. The corrected source statement and the formal
-    boundary are recorded in
-    \cite{gap:dccsp17_thm41_forward_trace_preservation}.
 \end{theorem}
+% Formalization status: the assumed construction is refuted, not merely
+% unproved (Remark~\ref{rem:thm_4_1_forward_trace_preservation}), so the
+% Lean theorem carries an Unfaithful marker and this node stays conditional;
+% the elimination plan is in
+% docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex.
 
 \begin{proof}\leanok
     The construction supplies $\widetilde A$ with
@@ -245,6 +242,46 @@ additional constructions used below.
     then identifies $\E_B$ with the $p$-th power of the channel
     $\E_{\widetilde A}$.
 \end{proof}
+
+\begin{remark}[Trace preservation in the forward direction]
+    \label{rem:thm_4_1_forward_trace_preservation}
+    \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
+    The construction assumed in
+    Theorem~\ref{thm:thm_4_1_p_refinement_forward} does not follow from
+    irreducible form~II alone, and the printed forward implication of
+    \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} omits the trace
+    preservation of $\E_B$ that its notion of $p$-divisibility presupposes.
+    Let $B_0$ be $p$-refinable with witness $(A_0, W)$ and in irreducible
+    form~II with every multiplicity equal to one, and let $\lambda > 1$. Set
+    \begin{align}
+        B
+         & = \lambda B_0,
+        \qquad
+        A = \lambda^{1/p} A_0.
+        \notag
+    \end{align}
+    Then $B$ is in irreducible form~II with the blocks of $B_0$ and the
+    multiplicities $\lambda$, and it is $p$-refinable with witness $(A, W)$:
+    \begin{align}
+        \ket{V^{(pN)}(A)}
+         & = \lambda^{N}\ket{V^{(pN)}(A_0)}
+        = \lambda^{N} W^{\otimes N}\ket{V^{(N)}(B_0)}
+        = W^{\otimes N}\ket{V^{(N)}(B)}.
+        \notag
+    \end{align}
+    Its transfer map satisfies
+    \begin{align}
+        \E_B
+         & = \lambda^{2}\,\E_{B_0},
+        \qquad
+        \tr \E_B(X) = \lambda^{2}\tr X \neq \tr X,
+        \notag
+    \end{align}
+    so $\E_B$ is not trace preserving and is not the $p$-th power of a CPTP
+    map. The corrected statement adds trace preservation of $\E_B$,
+    equivalently unit multiplicities, under which the printed argument
+    closes \cite{gap:dccsp17_thm41_forward_trace_preservation}.
+\end{remark}
 
 \begin{definition}[Blocked-to-root channel-root hypothesis from $Z$-gauge]
     \label{def:peripheral_equalcase_root_channel_from_zgauge}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -976,6 +976,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/dccsp17_periodic_overlap_route_alignment.pdf}},
 }
 
+@techreport{gap:dccsp17_thm41_forward_trace_preservation,
+  author      = {The {TNLean} contributors},
+  title       = {Trace Preservation in the Forward Direction of Theorem 4.1 ({de las Cuevas}--{Cirac}--{Schuch}--{P\'erez-Garc\'ia})},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {dccsp17\_thm41\_forward\_trace\_preservation},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/dccsp17_thm41_forward_trace_preservation.pdf}},
+}
+
 @techreport{gap:fbc25_alternating_network_nondegeneracy,
   author      = {The {TNLean} contributors},
   title       = {Nondegeneracy in the Alternating-Network Proportionality Lemma},

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -449,6 +449,18 @@ note.
   load-bearing κ/θ/φ phase assembly (Case 3). It also records the scope
   restriction of `periodicBasis_eventuallyLinearlyIndependent` (independence
   half only, no spanning clause).
+- `dccsp17_thm41_forward_trace_preservation.tex` records that the forward
+  implication of Theorem 4.1 is false as printed: a positive rescaling of a
+  $p$-refinable tensor in irreducible form II stays in irreducible form II and
+  $p$-refinable while its transfer map is no longer trace preserving. The
+  corrected statement adds trace preservation of the transfer map, which the
+  source's definition of $p$-divisibility presupposes. The note also records
+  why the formal forward canonicalization hypothesis, stated over the
+  generated-family reading of irreducible form, is refuted rather than
+  dischargeable, and lists the unformalized ingredients of the printed
+  argument.
+- `dccsp17_root_kraus_rank_thm41.tex` records the Kraus-rank step that the
+  converse implication of Theorem 4.1 uses without proof.
 
 For the MPU action on injective MPS blocks in arXiv:2502.20257:
 

--- a/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
+++ b/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
@@ -178,10 +178,22 @@ decomposition of residues, \path{Papers/1708.00029/main.tex:446--450}, and
 the redistribution of the root-of-unity factors across the sites,
 \path{Papers/1708.00029/main.tex:765--806}. The restatement is tracked in
 \href{https://github.com/LionSR/TNLean/issues/7762}{issue \#7762}, a child
-of \href{https://github.com/LionSR/TNLean/issues/622}{issue \#622}; the
-conditional forward theorem, its blocked-stage variant, and the bundled
-biconditional carry unfaithfulness markers naming this note until that
-restatement lands.
+of \href{https://github.com/LionSR/TNLean/issues/622}{issue \#622}. Until
+that restatement lands, every formal theorem whose proof consumes a refuted
+hypothesis carries an unfaithfulness marker naming this note: the conditional
+forward theorem, its blocked-stage variant, the bundled biconditional, and
+the three reduction theorems between the refuted hypotheses, namely
+\leanid{MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV},
+\leanid{MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV},
+and \leanid{MPSTensor.peripheralEqualCaseRootFromZGauge_of_rootChannel}. The
+hypotheses themselves are
+\leanid{MPSTensor.PeripheralEqualCaseRootChannelOfZGauge},
+\leanid{MPSTensor.PeripheralEqualCaseRootFromZGauge},
+\leanid{MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV}, and
+\leanid{MPSTensor.PRefinementCanonicalization}; each implies the next, and
+the first is already refuted by the one-dimensional data $C = A^{(p)} =
+    (\lambda)$ with the trivial $Z$-gauge, since no channel has $p$-th power
+$x\mapsto\lambda^2x$.
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
+++ b/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
@@ -64,8 +64,8 @@ $\mathcal E_B(X)=\sum_i B^iX(B^i)^\dagger$ is $p$-divisible.
 Let $B_0$ be any tensor in irreducible form~II whose multiplicities all equal
 one and whose family is $p$-refinable with witness $(A_0,W)$. The simplest
 instance has $d=D=1$, $B_0=(1)$, $A_0=(1)$, and $W=1$, for which
-$\ket{V_{pN}(A_0)}=1=\ket{V_N(B_0)}$ at every length. Fix $\lambda>1$ and
-set
+$\ket{V_{pN}(A_0)}=1=\ket{V_N(B_0)}$ at every length. Fix $p\geq1$ and
+$\lambda>1$ and set
 \begin{align}
     B
      & :=\lambda B_0,
@@ -145,7 +145,7 @@ $\mathcal E_B=\mathcal E_{\widetilde A^{[p]}}$.\footnote{The hypothesis is
     \path{TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean}.}
 
 First, the scaling counterexample refutes the hypothesis at bond dimension
-one for every physical dimension and every $p\geq1$: the tensor
+one for every positive physical dimension and every $p\geq1$: the tensor
 $\lambda B_0$ generates the same family as the weighted block sum with weight
 $\lambda$, so it is in the formal irreducible form, and the conclusion would
 identify the map $x\mapsto\lambda^2x$ with a $p$-th power of the identity.
@@ -190,10 +190,12 @@ hypotheses themselves are
 \leanid{MPSTensor.PeripheralEqualCaseRootChannelOfZGauge},
 \leanid{MPSTensor.PeripheralEqualCaseRootFromZGauge},
 \leanid{MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV}, and
-\leanid{MPSTensor.PRefinementCanonicalization}; each implies the next, and
-the first is already refuted by the one-dimensional data $C = A^{(p)} =
-    (\lambda)$ with the trivial $Z$-gauge, since no channel has $p$-th power
-$x\mapsto\lambda^2x$.
+\leanid{MPSTensor.PRefinementCanonicalization}. The first implies the
+second, the second together with the blocked $Z$-gauge extraction
+hypothesis \leanid{MPSTensor.PeripheralEqualCaseZGaugeOfSameMPV} implies the
+third, and the third implies the fourth. For $p\geq1$ each of the four is
+refuted by the one-dimensional data $C = A^{(p)} = (\lambda)$ with the
+trivial $Z$-gauge, since no channel has $p$-th power $x\mapsto\lambda^2x$.
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
+++ b/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
@@ -1,0 +1,197 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Trace Preservation in the Forward Direction of Theorem 4.1
+  (de las Cuevas--Cirac--Schuch--P\'erez-Garc\'ia)}
+\author{}
+\date{2026-09-04}
+
+\begin{document}
+\maketitle
+\gapnote{false-source}{open}
+
+\section{The assertion}
+
+This note concerns the forward implication in Theorem~4.1 of de las Cuevas,
+Cirac, Schuch, and P\'erez-Garc\'ia
+\cite[Theorem~4.1]{DeLasCuevas2017Irreducible}. The relevant source passages
+are the definition of the irreducible forms at
+\path{Papers/1708.00029/main.tex:245--266} and
+\path{Papers/1708.00029/main.tex:313--331}, the definitions of divisibility
+and refinement at \path{Papers/1708.00029/main.tex:717--724}, the theorem at
+\path{Papers/1708.00029/main.tex:728--731}, and its forward proof at
+\path{Papers/1708.00029/main.tex:735--810}. The companion note
+\path{dccsp17_root_kraus_rank_thm41.tex} records the separate gap in the
+converse implication.
+
+A tensor $B=(B^1,\ldots,B^d)$ of bond dimension $D$ is in
+\emph{irreducible form} when
+\begin{align}
+    B^i
+     & =\bigoplus_{j\in J}\mu_j\,B_j^i,
+    \qquad \mu_j>0,
+    \label{eq:dccsp17_thm41_forward_trace_preservation_irreducible_form}
+\end{align}
+with every block map $\mathcal E_{B_j}(X)=\sum_i B_j^iX(B_j^i)^\dagger$
+irreducible of spectral radius one. It is in \emph{irreducible form~II} when
+moreover every $\mathcal E_{B_j}$ is trace preserving with a diagonal
+positive fixed point. The multiplicities $\mu_j$ are arbitrary positive
+scalars in both forms; the source normalizes the blocks, not the weights.
+
+A trace-preserving completely positive map $\mathcal E$ is called
+\emph{$p$-divisible} when there is a trace-preserving completely positive map
+$\mathcal E'$ with $\mathcal E=(\mathcal E')^p$. The family $\mathcal V(B)$
+is \emph{$p$-refinable} when there are a tensor $A=(A^1,\ldots,A^d)$ and an
+isometry $W:\mathbb C^d\to(\mathbb C^d)^{\otimes p}$ with
+\begin{align}
+    \ket{V_{pN}(A)}
+     & =W^{\otimes N}\ket{V_N(B)}
+    \qquad\text{for every }N.
+    \label{eq:dccsp17_thm41_forward_trace_preservation_refinement}
+\end{align}
+Theorem~4.1 asserts, for $B$ in irreducible form~II, that $\mathcal V(B)$ is
+$p$-refinable if and only if the transfer map
+$\mathcal E_B(X)=\sum_i B^iX(B^i)^\dagger$ is $p$-divisible.
+
+\section{The counterexample}
+
+Let $B_0$ be any tensor in irreducible form~II whose multiplicities all equal
+one and whose family is $p$-refinable with witness $(A_0,W)$. The simplest
+instance has $d=D=1$, $B_0=(1)$, $A_0=(1)$, and $W=1$, for which
+$\ket{V_{pN}(A_0)}=1=\ket{V_N(B_0)}$ at every length. Fix $\lambda>1$ and
+set
+\begin{align}
+    B
+     & :=\lambda B_0,
+    \qquad
+    A
+    :=\lambda^{1/p}A_0.
+    \label{eq:dccsp17_thm41_forward_trace_preservation_scaled_tensor}
+\end{align}
+The tensor $B$ is in irreducible form~II: it has the blocks of $B_0$ and the
+multiplicities $\lambda\mu_j$, which are positive. The family
+$\mathcal V(B)$ is $p$-refinable with witness $(A,W)$, because
+\begin{align}
+    \ket{V_{pN}(A)}
+     & =\lambda^{N}\ket{V_{pN}(A_0)}
+    =\lambda^{N}W^{\otimes N}\ket{V_N(B_0)}
+    =W^{\otimes N}\ket{V_N(B)}.
+    \label{eq:dccsp17_thm41_forward_trace_preservation_scaled_refinement}
+\end{align}
+Its transfer map is $\mathcal E_B=\lambda^2\mathcal E_{B_0}$, so
+$\operatorname{tr}\mathcal E_B(X)=\lambda^2\operatorname{tr}X$. A $p$-th
+power of a trace-preserving map is trace preserving, so $\mathcal E_B$ is not
+$p$-divisible. The forward implication of Theorem~4.1 therefore fails on
+nondegenerate data satisfying its printed hypothesis.
+
+The printed argument breaks at its last line,
+\path{Papers/1708.00029/main.tex:806--810}. It constructs $\widetilde A$ with
+$\widetilde A^{(p)}=C$ and concludes
+$\mathcal E_{\widetilde A}^p=\mathcal E_C=\mathcal E_B$, which is correct,
+but $\widetilde A$ is a unitary conjugate of
+$A'=\bigoplus_j\mu_j A'_j$, whose transfer map is trace preserving only when
+every multiplicity of $A$ equals one. The argument never constrains the
+multiplicities of $B$, so it cannot deliver the trace preservation that the
+conclusion requires.
+
+\section{The corrected statement}
+
+Add to the hypothesis of the forward implication that $\mathcal E_B$ is trace
+preserving. Since
+\begin{align}
+    \sum_i (B^i)^\dagger B^i
+     & =\bigoplus_{j\in J}\mu_j^2\,\mathbf 1_{D_j}
+    \label{eq:dccsp17_thm41_forward_trace_preservation_trace_condition}
+\end{align}
+for a tensor in irreducible form~II, this is the same as requiring every
+multiplicity of $B$ to equal one. The added hypothesis is presupposed by the
+source: its definition of $p$-divisibility applies only to trace-preserving
+maps, so the conclusion ``$\mathcal E_B$ is $p$-divisible'' already asserts
+trace preservation of $\mathcal E_B$.
+
+With this hypothesis the printed argument closes. The tensor
+$C^{i_1\ldots i_p}=\sum_i W^{(i_1\ldots i_p),i}B^i$ has the blocks and
+multiplicities of $B$, all equal to one. The equal-case theorem
+\cite[Theorem~3.8]{DeLasCuevas2017Irreducible} matches the blocks of
+$A^{(p)}$ with those of $C$ and relates their multiplicities by roots of
+unity after reordering. The blocks of $A^{(p)}$ arising from a block $A_j$ of
+$A$ carry the multiplicity $\mu_j^p$, so $\mu_j^p$ is a root of unity, and
+$\mu_j>0$ forces $\mu_j=1$. Hence $A'$ and $\widetilde A=U^\dagger A'U$ are
+left canonical, $\mathcal E_{\widetilde A}$ is trace preserving, and
+$\mathcal E_B=\mathcal E_{\widetilde A}^p$ exhibits $p$-divisibility. The
+converse implication is unaffected, since it assumes $p$-divisibility and
+therefore trace preservation of $\mathcal E_B$ from the start.
+
+\section{The formal statement}
+
+The formal irreducible form is a statement about generated families rather
+than about the matrices of the tensor: a tensor is in irreducible form when it
+generates, at every length including zero, the same matrix product vectors as
+a scalar-weighted direct sum of periodic left-canonical blocks with positive
+weights.\footnote{The definition is \leanid{MPSTensor.IsIrreducibleForm} in
+    \path{TNLean/MPS/Periodic/Defs.lean}.} It does not fix the transfer map of the
+tensor. Two consequences follow for the forward canonicalization hypothesis,
+which asks, for every tensor $B$ in this formal irreducible form whose family
+is $p$-refinable, for a left-canonical tensor $\widetilde A$ with
+$\mathcal E_B=\mathcal E_{\widetilde A^{[p]}}$.\footnote{The hypothesis is
+    \leanid{MPSTensor.PRefinementCanonicalization} and the conditional forward
+    theorem is \leanid{MPSTensor.thm_4_1_p_refinement_forward}, both in
+    \path{TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean}.}
+
+First, the scaling counterexample refutes the hypothesis at bond dimension
+one for every physical dimension and every $p\geq1$: the tensor
+$\lambda B_0$ generates the same family as the weighted block sum with weight
+$\lambda$, so it is in the formal irreducible form, and the conclusion would
+identify the map $x\mapsto\lambda^2x$ with a $p$-th power of the identity.
+
+Second, even after adding trace preservation of $\mathcal E_B$, the formal
+irreducible form does not supply the block structure that the printed
+argument uses. For a left-canonical normal tensor $B_0$ and an invertible
+$Y$, the tensor $YB_0Y^{-1}$ generates the same family as $B_0$ and is in the
+formal irreducible form, while
+$\mathcal E_{YB_0Y^{-1}}$ is trace preserving exactly when $Y^\dagger Y$ is a
+fixed point of $\mathcal E_{B_0}^*$, that is, when $Y$ is a scalar multiple of
+a unitary. Recovering a unitary similarity to a block form from equality of
+families and trace preservation is a statement about arbitrary tensors that
+the cited argument does not contain; the source instead takes $B$ literally
+in the form
+(\ref{eq:dccsp17_thm41_forward_trace_preservation_irreducible_form}).
+
+The conditional formal theorems remain correct, but their hypothesis cannot
+be discharged. The elimination plan is to restate the forward direction for a
+tensor given as a multiplicity-bearing block form with every multiplicity
+equal to one, the structure already used by the formal equal-case
+theorem,\footnote{The equal-case theorem is
+    \leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_irreducibleForm} in
+    \path{TNLean/MPS/Periodic/EqualCaseGlobal.lean}.} and then to follow the
+printed argument. Its ingredients without a formal counterpart are the
+blocking lemma for a periodic block,
+\path{Papers/1708.00029/main.tex:432--446}, the cyclic projector structure of
+a periodic block, \path{Papers/1708.00029/main.tex:335--341}, the unique
+decomposition of residues, \path{Papers/1708.00029/main.tex:446--450}, and
+the redistribution of the root-of-unity factors across the sites,
+\path{Papers/1708.00029/main.tex:765--806}.
+
+\section{Conclusion}
+
+The forward implication of Theorem~4.1 is false as printed: a positive
+rescaling of any $p$-refinable tensor in irreducible form~II is again in
+irreducible form~II and $p$-refinable, while its transfer map is not trace
+preserving and hence not $p$-divisible. The corrected statement adds trace
+preservation of $\mathcal E_B$, equivalently unit multiplicities, which the
+source's definition of $p$-divisibility presupposes; the printed argument then
+proves it. The formal forward canonicalization hypothesis inherits the
+counterexample and is refuted independently by non-unitary similarities, so
+it must be replaced by a restatement over block-form tensors with
+trace-preserving transfer map rather than discharged.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
+++ b/docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex
@@ -176,7 +176,12 @@ blocking lemma for a periodic block,
 a periodic block, \path{Papers/1708.00029/main.tex:335--341}, the unique
 decomposition of residues, \path{Papers/1708.00029/main.tex:446--450}, and
 the redistribution of the root-of-unity factors across the sites,
-\path{Papers/1708.00029/main.tex:765--806}.
+\path{Papers/1708.00029/main.tex:765--806}. The restatement is tracked in
+\href{https://github.com/LionSR/TNLean/issues/7762}{issue \#7762}, a child
+of \href{https://github.com/LionSR/TNLean/issues/622}{issue \#622}; the
+conditional forward theorem, its blocked-stage variant, and the bundled
+biconditional carry unfaithfulness markers naming this note until that
+restatement lands.
 
 \section{Conclusion}
 


### PR DESCRIPTION
Advances #664 and #622; files #7762. Neither canonicalization hypothesis of Theorem 4.1 is discharged; this PR records why the forward one cannot be, so that the issue stops being re-dispatched against a hypothesis that is false.

### The finding

`PRefinementCanonicalization d D p` is refuted, not merely unproved.

* **Source side.** arXiv:1708.00029, Theorem 4.1 (`Papers/1708.00029/main.tex:728--731`) is false as printed in its forward direction. Its definition of $p$-divisibility (lines 717--718) applies only to trace-preserving maps, but irreducible form II (lines 245--266, 313--331) leaves the multiplicities $\mu_j>0$ free. For any $p$-refinable $B_0$ in irreducible form II with unit multiplicities (e.g. $d=D=1$, $B_0=(1)$) and $\lambda>1$, the tensor $B=\lambda B_0$ is again in irreducible form II and $p$-refinable with witness $\lambda^{1/p}A_0$, while $\mathcal E_B=\lambda^2\mathcal E_{B_0}$ is not trace preserving and hence not a $p$-th power of a channel. The printed argument breaks at lines 806--810: $\widetilde A=U^\dagger A'U$ with $A'=\bigoplus_j\mu_jA'_j$ is left canonical only when every multiplicity of $A$ is one, and nothing constrains the multiplicities of $B$.
* **Corrected statement.** Add trace preservation of $\mathcal E_B$ (equivalently all $\mu_j=1$, since $\sum_i(B^i)^\dagger B^i=\bigoplus_j\mu_j^2\mathbf 1$). Then the printed route closes: Theorem 3.8 relates the multiplicities $\mu_j^p$ of $A^{(p)}$ to the unit multiplicities of $C$ by roots of unity, forcing $\mu_j=1$, so $\widetilde A$ is left canonical. The converse is unaffected.
* **Formal side.** `IsIrreducibleForm` is the generated-family reading (`SameMPV₂` against a weighted block sum), so it does not fix `Kraus.transferMap B`. The scaling counterexample refutes `PRefinementCanonicalization d 1 p` for every `d ≥ 1`, `p ≥ 1`; at `p = 1` a non-unitary similarity $YB_0Y^{-1}$ of a left-canonical normal tensor refutes it for every bond dimension, since $\mathcal E_{YB_0Y^{-1}}$ is trace preserving only when $Y$ is a scalar multiple of a unitary. Recovering the block structure from equality of families plus trace preservation is a statement about arbitrary tensors the source does not contain; the source takes $B$ literally in block form.

### What is in the PR

* `docs/paper-gaps/dccsp17_thm41_forward_trace_preservation.tex` (verdict `false-source`, `open`): the assertion, the counterexample, the corrected statement with the printed proof closing under it, the formal boundary, and the elimination plan. Unformalized ingredients of the printed forward proof are listed with line anchors: `lem:blocking-arbitrary` (432--446, no Lean counterpart), the cyclic projector structure `eq:Aoffdiag` (335--341), `lem:unique-dec` (446--450), and the $c_{j,\alpha}$ redistribution (765--806).
* **Unfaithful markers (full propagation).** Every theorem whose proof consumes a refuted hypothesis carries an `**Unfaithful:**` marker naming the deviating hypothesis, the source lines, the note, and the elimination plan. The refuted hypotheses form a chain, each implying the next: `PeripheralEqualCaseRootChannelOfZGauge` → `PeripheralEqualCaseRootFromZGauge` → (together with `PeripheralEqualCaseZGaugeOfSameMPV`) `PeripheralEqualCasePeriodicFTOfSameMPV` → `PRefinementCanonicalization`; for $p \ge 1$ each is refuted by $C = A^{(p)} = (\lambda)$ with the trivial $Z$-gauge, since no channel has $p$-th power $x \mapsto \lambda^2 x$. Every refutation claim in the docstrings, the blueprint remark, and the note is qualified by $p \ge 1$ and positive physical dimension (at $p = 0$ the blocked tensor is the identity, and at $d = 0$ no tensor is in irreducible form). The marked theorems are
  * `MPSTensor.peripheralEqualCaseRootFromZGauge_of_rootChannel` (`Theorem41Reverse.lean`; consumes `PeripheralEqualCaseRootChannelOfZGauge`),
  * `MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV` (consumes `PeripheralEqualCaseRootFromZGauge`),
  * `MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV` (consumes `PeripheralEqualCasePeriodicFTOfSameMPV`),
  * `MPSTensor.thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`,
  * `MPSTensor.thm_4_1_p_refinement_forward` (consumes `PRefinementCanonicalization`),
  * `MPSTensor.thm_4_1_p_refinement` (`Theorem41Bundle.lean`; calls the forward theorem).

  The docstrings of all four hypotheses record their refutation. Not marked, because their hypotheses are not refuted: `PeripheralEqualCaseZGaugeOfSameMPV` and `zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm` (the equal-case FT step), and the reverse chain `PRefinementInverseCanonicalization`, `PRefinementInverseRootKrausRankBound`, `pRefinementInverseCanonicalization_of_rootKrausRankBound`, `thm_4_1_p_refinement_reverse` (their premise, $p$-divisibility, already carries trace preservation). No statement or proof changes.
* Blueprint: the remark `rem:thm_4_1_forward_trace_preservation` after `thm:thm_4_1_p_refinement_forward` displays the rescaling counterexample ($B=\lambda B_0$, $A=\lambda^{1/p}A_0$, the refinement identity, $\mathcal E_B=\lambda^2\mathcal E_{B_0}$, $\operatorname{tr}\mathcal E_B(\mathbf 1)\neq\operatorname{tr}\mathbf 1$), notes that the same one-dimensional data refute the three $Z$-gauge construction hypotheses, and states the corrected theorem over the source's literal block form, where trace preservation is equivalent to unit multiplicities (the equivalence fails for the generated-family reading of the formal irreducible form) and cites `gap:dccsp17_thm41_forward_trace_preservation` (bib entry added); formalization status lives in a `%` comment. No `\leanok` tag changes: the source-labelled node stays conditional and `thm:thm_4_1_p_refinement` is not marked as the source theorem.
* Follow-up: #7762 (sub-issue of #622) tracks the restatement of the forward direction over the unit-multiplicity block form; the note cites it.
* `docs/paper-gaps/README.md` indexes the new note and the existing converse note.

### Where the printed proof and the issue plan differ

The issue's forward plan ("Theorem 3.8 supplies a Z-gauge equivalence between `C` and `blockTensor A p`; reduce to a left-canonical unitary gauge") is not the printed proof. The source (lines 746--810) first replaces $A$ by its irreducible form II (Proposition `thm:irr`), blocks it (`lem:blocking-arbitrary`), applies Theorem 3.8 to get $ZA^{(p)}=UCU^\dagger$, and then constructs $A'$ with $A'^{(p)}=ZA^{(p)}$ by redistributing the root-of-unity factors $c_{j,\alpha}$ across the $p$ sites through the cyclic projectors $P_{j,u}$. There is no "reduction to a left-canonical unitary gauge" step; left-canonicality of $\widetilde A$ is exactly the point that fails without unit multiplicities. The merged equal-case theorem (`fundamentalTheorem_periodic_equalCase_irreducibleForm`, #7730--#7732) supplies the Theorem 3.8 step for `SectorDecomposition` data, which is the structure the restated forward direction should take as input.

### Reverse direction

Unchanged and still blocked on `PRefinementInverseCanonicalization`: the source's converse (lines 812--818) replaces the abstract root $\mathcal E'$ by a $d$-letter tensor root without justification (`docs/paper-gaps/dccsp17_root_kraus_rank_thm41.tex`). QICLean's `Channel/KrausRank.lean` gives minimal Kraus rank = Choi rank but nothing bounding the Choi rank of a root by that of its power; #7730--#7732 do not touch this. Discharging it needs either a proof that irreducible form II forces some root of $\mathcal E_B$ to have Choi rank $\le d$, or a restatement of $p$-refinability allowing the tensor root any physical dimension (which is not the source's definition).

### Verification

* Note compiles with pdflatex + bibtex against the local `command.tex` and `references.bib` (no undefined references or citations).
* `texra-blueprint paper-gaps check` passes; `scripts/check_reader_facing_prose.py --diff-base origin/main` passes; `scripts/latexindent` applied to both touched `.tex` files.
* Lean changes are docstring-only; `\leanid` names in the note all exist on `main`. Locked build / CI status is reported in the PR conversation.
* No `sorry`, `axiom`, `native_decide`, or `admit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm



