### PR TITLE
feat(parent-hamiltonian): ground-space correspondence under an invertible on-site map

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -20,6 +20,7 @@ import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Core.MultiBlockWord
 import TNLean.MPS.Core.PhysicalIndexMixing
 import TNLean.MPS.Core.PhysicalReindexTransport
+import TNLean.MPS.Core.PhysicalRotation
 import TNLean.MPS.Core.ProjectionTriangularTrace
 import TNLean.MPS.Core.Reduction
 import TNLean.MPS.Core.ReductionBlocking

--- a/TNLean/MPS/Core/PhysicalRotation.lean
+++ b/TNLean/MPS/Core/PhysicalRotation.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+
+/-!
+# Physical-index rotation of a tensor
+
+An on-site map \(\Lambda\) on the physical space \(\mathbb C^d\) acts on a tensor by mixing
+its physical matrices, \(A^i \mapsto \sum_j \Lambda_{ij} A^j\).  This is the physical
+perturbation \(A^i \to \sum_j \Lambda_{ij} A^j\) of arXiv:2011.12127, lines 2260--2262, and
+the on-site twist used for symmetric matrix product states.
+
+## Main definitions
+
+* `MPSTensor.rotatePhysical` — the rotated tensor \((\Lambda A)^i = \sum_j \Lambda_{ij} A^j\).
+
+## Main results
+
+* `MPSTensor.evalWord_rotatePhysical_ofFn` — word evaluation of the rotated tensor expands
+  over the words of the original tensor with sitewise matrix coefficients.
+* `MPSTensor.mpv_rotatePhysical` — the matrix product vector of the rotated tensor is the
+  sitewise action of \(\Lambda\) on the original matrix product vector, the identity
+  \(\ket{\psi'} = \Lambda^{\otimes N}\ket{\psi}\) of arXiv:2011.12127, line 2036.
+* `MPSTensor.rotatePhysical_rotatePhysical` — rotations compose multiplicatively.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+noncomputable section
+
+variable {d D : ℕ}
+
+/-- Physical-index rotation of a tensor by a matrix `M` on the physical leg:
+
+`(rotatePhysical M A) i = ∑ j, M i j • A j`.
+-/
+def rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTensor d D :=
+  fun i => ∑ j : Fin d, M i j • A j
+
+@[simp] lemma rotatePhysical_apply
+    (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (i : Fin d) :
+    rotatePhysical M A i = ∑ j : Fin d, M i j • A j := rfl
+
+/-- Rotating by the identity on the physical index leaves the tensor unchanged. -/
+@[simp] lemma rotatePhysical_one (A : MPSTensor d D) :
+    rotatePhysical (1 : Matrix (Fin d) (Fin d) ℂ) A = A := by
+  funext i
+  simp [rotatePhysical, Matrix.one_apply]
+
+/-- Two successive physical-index rotations compose to the rotation by the product:
+\(M (M' A) = (M M') A\). -/
+lemma rotatePhysical_rotatePhysical (M M' : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) :
+    rotatePhysical M (rotatePhysical M' A) = rotatePhysical (M * M') A := by
+  funext i
+  calc
+    rotatePhysical M (rotatePhysical M' A) i
+        = ∑ j : Fin d, ∑ k : Fin d, (M i j * M' j k) • A k := by
+          simp [rotatePhysical, Finset.smul_sum, smul_smul]
+    _ = ∑ k : Fin d, ∑ j : Fin d, (M i j * M' j k) • A k := Finset.sum_comm
+    _ = rotatePhysical (M * M') A i := by
+          simp [rotatePhysical, Matrix.mul_apply, Finset.sum_smul]
+
+/-- Expanding a word of a physically rotated tensor gives the sitewise matrix
+coefficients multiplying the corresponding unrotated words. -/
+theorem evalWord_rotatePhysical_ofFn
+    (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) :
+    ∀ (N : ℕ) (s : Fin N → Fin d),
+      Kraus.evalWord (rotatePhysical M A) (List.ofFn s) =
+        ∑ t : Fin N → Fin d,
+          (∏ n : Fin N, M (s n) (t n)) • Kraus.evalWord A (List.ofFn t) := by
+  intro N
+  induction N with
+  | zero =>
+      intro s
+      classical
+      simp
+  | succ N ih =>
+      intro s
+      classical
+      rw [List.ofFn_succ, Kraus.evalWord_cons, rotatePhysical_apply]
+      rw [ih (fun n : Fin N => s n.succ)]
+      rw [Finset.sum_mul_sum]
+      let e : (Fin d × (Fin N → Fin d)) ≃ (Fin (N + 1) → Fin d) :=
+        Fin.consEquiv (fun _ => Fin d)
+      have hreindex :
+          (∑ t : Fin (N + 1) → Fin d,
+              (∏ n : Fin (N + 1), M (s n) (t n)) •
+                Kraus.evalWord A (List.ofFn t)) =
+            ∑ p : Fin d × (Fin N → Fin d),
+              (∏ n : Fin (N + 1), M (s n) (e p n)) •
+                Kraus.evalWord A (List.ofFn (e p)) :=
+        (Fintype.sum_equiv e
+          (f := fun p : Fin d × (Fin N → Fin d) =>
+            (∏ n : Fin (N + 1), M (s n) (e p n)) •
+              Kraus.evalWord A (List.ofFn (e p)))
+          (g := fun t : Fin (N + 1) → Fin d =>
+            (∏ n : Fin (N + 1), M (s n) (t n)) •
+              Kraus.evalWord A (List.ofFn t))
+          (by intro p; rfl)).symm
+      rw [hreindex, ← Fintype.sum_prod_type']
+      refine Finset.sum_congr rfl ?_
+      rintro ⟨i, t⟩ _
+      have hprod :
+          (∏ n : Fin (N + 1), M (s n) (e (i, t) n)) =
+            M (s 0) i * ∏ n : Fin N, M (s n.succ) (t n) := by
+        rw [Fin.prod_univ_succ]
+        simp [e, Fin.consEquiv]
+      have hlist : List.ofFn (e (i, t)) = i :: List.ofFn t := by
+        simp [e, Fin.consEquiv]
+      rw [hprod, hlist, Kraus.evalWord_cons, smul_mul_smul_comm]
+
+/-- The matrix product vector of a physical-index rotation is the sitewise
+matrix action on the original matrix product vector. -/
+theorem mpv_rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ)
+    (A : MPSTensor d D) {N : ℕ} (s : Fin N → Fin d) :
+    mpv (rotatePhysical M A) s =
+      ∑ t : Fin N → Fin d, (∏ n : Fin N, M (s n) (t n)) * mpv A t := by
+  rw [mpv, coeff, evalWord_rotatePhysical_ofFn, Matrix.trace_sum]
+  simp only [Matrix.trace_smul, smul_eq_mul, mpv, coeff]
+
+end
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -100,6 +100,7 @@ import TNLean.MPS.ParentHamiltonian.MixedGram
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.PeriodicBoundaryReduction
+import TNLean.MPS.ParentHamiltonian.PhysicalDeformation
 import TNLean.MPS.ParentHamiltonian.ProductPair
 import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
 import TNLean.MPS.ParentHamiltonian.RestrictTransport

--- a/TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean
+++ b/TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean
@@ -1,0 +1,433 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.Core.PhysicalRotation
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+
+/-!
+# Ground-space correspondence under an invertible on-site map
+
+Source: arXiv:2011.12127, Section IV.C, lines 2032--2038 (the deformed parent interaction,
+equation deformed-parent-1, and the parenthetical generalization to an invertible on-site
+map), reused at lines 2190--2192 (the deformed interaction as a parent interaction for the
+physically perturbed tensor) and lines 2260--2262 (physical perturbations of the tensor).
+
+The source writes the deformed tensor as \(A^i = \sum_j \Lambda_{ij} B^j\) with \(\Lambda\)
+invertible, and the deformed state as \(\ket{\psi'} = R^{\otimes N}\ket{\psi}\).  Here the
+original tensor is \(A\) and the deformed tensor is \(\Lambda A\), with
+\((\Lambda A)^i = \sum_j \Lambda_{ij} A^j\); the on-site map \(\Lambda\) plays the role of the
+source's \(\Lambda\) and \(R\).
+
+## Main definitions
+
+* `MPSTensor.onSiteTensorPow` — the tensor power \(\Lambda^{\otimes L}\) of an on-site map,
+  as a matrix on \(L\)-site configurations.
+* `MPSTensor.IsParentInteraction` — a parent interaction in the sense of the source
+  definition, lines 1996--1999: a hermitian positive semidefinite operator whose kernel is
+  the local ground space.
+* `MPSTensor.deformedInteraction` — the deformed interaction
+  \(h' = ({\Lambda^{-1}}^\dagger)^{\otimes L} h (\Lambda^{-1})^{\otimes L}\).
+
+## Main results
+
+* `MPSTensor.groundSpace_rotatePhysical` — the local ground space of the deformed tensor is
+  the image \(\Lambda^{\otimes L}\mathcal G_L(A)\).
+* `MPSTensor.IsParentInteraction.deformedInteraction` — the deformed interaction is a parent
+  interaction for the deformed tensor.
+* `MPSTensor.chainGroundSpace_rotatePhysical` and
+  `MPSTensor.ker_parentHamiltonian_rotatePhysical` — the ground spaces of the two parent
+  Hamiltonians correspond one-to-one through \(\Lambda^{\otimes N}\).
+* `MPSTensor.hasUniqueGroundState_chainGroundSpace_rotatePhysical` — uniqueness of the
+  ground state transfers along the correspondence.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### The tensor power of an on-site map -/
+
+/-- The tensor power \(\Lambda^{\otimes L}\) of an on-site map \(\Lambda\) on \(\mathbb C^d\),
+as a matrix on \(L\)-site configurations:
+\((\Lambda^{\otimes L})_{\sigma,\tau} = \prod_{n} \Lambda_{\sigma_n \tau_n}\).
+This is the map written \(\Lambda^{\otimes k}\) and \(R^{\otimes N}\) in arXiv:2011.12127,
+lines 2035--2037 and 2190--2192. -/
+noncomputable def onSiteTensorPow (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Cfg d L) (Cfg d L) ℂ :=
+  Matrix.of fun σ τ => ∏ n : Fin L, Λ (σ n) (τ n)
+
+@[simp] lemma onSiteTensorPow_apply (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ)
+    (σ τ : Cfg d L) :
+    onSiteTensorPow L Λ σ τ = ∏ n : Fin L, Λ (σ n) (τ n) := rfl
+
+/-- The tensor power is the blocked Kronecker lift read through the decoding of blocked
+physical indices. -/
+lemma onSiteTensorPow_eq_submatrix_blockKron (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ) :
+    onSiteTensorPow L Λ =
+      (blockKron L Λ).submatrix (decodeBlockEquiv d L).symm (decodeBlockEquiv d L).symm := by
+  ext σ τ
+  simp [onSiteTensorPow, blockKron]
+
+/-- The tensor power is multiplicative: \((\Lambda\Lambda')^{\otimes L} =
+\Lambda^{\otimes L}\Lambda'^{\otimes L}\). -/
+lemma onSiteTensorPow_mul (L : ℕ) (Λ Λ' : Matrix (Fin d) (Fin d) ℂ) :
+    onSiteTensorPow L (Λ * Λ') = onSiteTensorPow L Λ * onSiteTensorPow L Λ' := by
+  rw [onSiteTensorPow_eq_submatrix_blockKron, onSiteTensorPow_eq_submatrix_blockKron,
+    onSiteTensorPow_eq_submatrix_blockKron, Matrix.submatrix_mul_equiv, blockKron_mul]
+
+/-- The tensor power of the identity is the identity. -/
+lemma onSiteTensorPow_one (L : ℕ) :
+    onSiteTensorPow L (1 : Matrix (Fin d) (Fin d) ℂ) = 1 := by
+  rw [onSiteTensorPow_eq_submatrix_blockKron, blockKron_one, Matrix.submatrix_one_equiv]
+
+/-- The tensor power commutes with the conjugate transpose:
+\((\Lambda^{\otimes L})^\dagger = (\Lambda^\dagger)^{\otimes L}\). -/
+lemma onSiteTensorPow_conjTranspose (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ) :
+    (onSiteTensorPow L Λ)ᴴ = onSiteTensorPow L Λᴴ := by
+  rw [onSiteTensorPow_eq_submatrix_blockKron, onSiteTensorPow_eq_submatrix_blockKron,
+    Matrix.conjTranspose_submatrix, blockKron_conjTranspose]
+
+/-- For an invertible on-site map, the tensor power of the inverse is a left inverse of the
+tensor power. -/
+lemma onSiteTensorPow_inv_mul (L : ℕ) {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ) :
+    onSiteTensorPow L Λ⁻¹ * onSiteTensorPow L Λ = 1 := by
+  rw [← onSiteTensorPow_mul, Matrix.nonsing_inv_mul Λ ((Matrix.isUnit_iff_isUnit_det Λ).1 hΛ),
+    onSiteTensorPow_one]
+
+/-- For an invertible on-site map, the tensor power of the inverse is a right inverse of the
+tensor power. -/
+lemma onSiteTensorPow_mul_inv (L : ℕ) {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ) :
+    onSiteTensorPow L Λ * onSiteTensorPow L Λ⁻¹ = 1 := by
+  rw [← onSiteTensorPow_mul, Matrix.mul_nonsing_inv Λ ((Matrix.isUnit_iff_isUnit_det Λ).1 hΛ),
+    onSiteTensorPow_one]
+
+/-- The matrix product vector of the deformed tensor is the tensor power applied to the
+original matrix product vector: \(\ket{\psi'} = \Lambda^{\otimes N}\ket{\psi}\), arXiv:2011.12127,
+line 2036. -/
+theorem mpv_rotatePhysical_eq_toLin' (Λ : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D)
+    (N : ℕ) :
+    (mpv (rotatePhysical Λ A) : NSiteSpace d N) =
+      Matrix.toLin' (onSiteTensorPow N Λ) (mpv A : NSiteSpace d N) := by
+  ext s
+  rw [mpv_rotatePhysical]
+  simp [Matrix.toLin'_apply, Matrix.mulVec, dotProduct]
+
+/-! ### The local ground space of the deformed tensor -/
+
+/-- The boundary map of the deformed tensor is the tensor power applied to the boundary
+map of the original tensor. -/
+theorem groundSpaceMap_rotatePhysical (Λ : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D)
+    (L : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    groundSpaceMap (rotatePhysical Λ A) L X =
+      Matrix.toLin' (onSiteTensorPow L Λ) (groundSpaceMap A L X) := by
+  ext σ
+  simp [groundSpaceMap_apply, evalWord_rotatePhysical_ofFn, Matrix.toLin'_apply, Matrix.mulVec,
+    dotProduct, Matrix.sum_mul, Matrix.trace_sum, Matrix.trace_smul]
+
+/-- The local ground space of the deformed tensor is the image of the local ground space of
+the original tensor under the tensor power: \(\mathcal G_L(\Lambda A) =
+\Lambda^{\otimes L}\mathcal G_L(A)\).  This is the parenthetical generalization of
+arXiv:2011.12127, lines 2035--2037, at the level of local ground spaces; no invertibility of
+\(\Lambda\) is needed for this inclusion-as-equality. -/
+theorem groundSpace_rotatePhysical (Λ : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D)
+    (L : ℕ) :
+    groundSpace (rotatePhysical Λ A) L =
+      (groundSpace A L).map (Matrix.toLin' (onSiteTensorPow L Λ)) := by
+  have h : groundSpaceMap (rotatePhysical Λ A) L =
+      (Matrix.toLin' (onSiteTensorPow L Λ)).comp (groundSpaceMap A L) :=
+    LinearMap.ext (groundSpaceMap_rotatePhysical Λ A L)
+  rw [groundSpace, groundSpace, h, LinearMap.range_comp]
+
+/-- The Hilbert-space realization of the local ground space of the deformed tensor is the
+image under the tensor power of the realization for the original tensor. -/
+theorem groundSpaceES_rotatePhysical (Λ : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D)
+    (L : ℕ) :
+    groundSpaceES (rotatePhysical Λ A) L =
+      (groundSpaceES A L).map (Matrix.toEuclideanLin (onSiteTensorPow L Λ)) := by
+  rw [groundSpaceES, groundSpaceES, groundSpace_rotatePhysical, ← Submodule.map_comp,
+    ← Submodule.map_comp]
+  rfl
+
+/-! ### The deformed parent interaction -/
+
+/-- A parent interaction on \(L\) sites for the tensor \(A\), in the sense of
+arXiv:2011.12127, lines 1996--1999: a hermitian positive semidefinite operator \(h \ge 0\)
+on the \(L\)-site Hilbert space whose kernel is the local ground space \(\mathcal G_L(A)\). -/
+structure IsParentInteraction (A : MPSTensor d D) (L : ℕ)
+    (h : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L)) : Prop where
+  /-- The interaction is hermitian and positive semidefinite. -/
+  isPositive : h.IsPositive
+  /-- The kernel of the interaction is the local ground space. -/
+  ker_eq : LinearMap.ker h = groundSpaceES A L
+
+/-- The canonical parent interaction, the orthogonal projector onto
+\(\mathcal G_L(A)^\perp\), is a parent interaction in the sense of the source definition. -/
+theorem isParentInteraction_parentInteractionES (A : MPSTensor d D) (L : ℕ) :
+    IsParentInteraction A L (parentInteractionES A L) where
+  isPositive := parentInteractionES_isPositive A L
+  ker_eq := by
+    ext v
+    rw [LinearMap.mem_ker, parentInteractionES_apply_eq_zero_iff]
+
+/-- The deformed interaction
+\(h' = ({\Lambda^{-1}}^\dagger)^{\otimes L}\, h\, (\Lambda^{-1})^{\otimes L}\) of
+arXiv:2011.12127, lines 2190--2192, and equation deformed-parent-1 at lines 2033--2035. -/
+noncomputable def deformedInteraction (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ)
+    (h : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L)) :
+    EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
+  Matrix.toEuclideanLin (onSiteTensorPow L (Λ⁻¹)ᴴ) ∘ₗ h ∘ₗ
+    Matrix.toEuclideanLin (onSiteTensorPow L Λ⁻¹)
+
+/-- The deformed interaction of a positive operator is positive: it is the conjugate
+\(S^\dagger h S\) with \(S = (\Lambda^{-1})^{\otimes L}\). -/
+theorem deformedInteraction_isPositive (L : ℕ) (Λ : Matrix (Fin d) (Fin d) ℂ)
+    {h : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L)}
+    (hh : h.IsPositive) : (deformedInteraction L Λ h).IsPositive := by
+  rw [deformedInteraction, ← onSiteTensorPow_conjTranspose,
+    Matrix.toEuclideanLin_conjTranspose_eq_adjoint]
+  exact hh.adjoint_conj _
+
+/-- Composition of the Hilbert-space maps of two tensor powers is the map of the tensor
+power of the product. -/
+lemma toEuclideanLin_onSiteTensorPow_mul_apply (L : ℕ) (Λ Λ' : Matrix (Fin d) (Fin d) ℂ)
+    (v : EuclideanSpace ℂ (Cfg d L)) :
+    Matrix.toEuclideanLin (onSiteTensorPow L Λ)
+        (Matrix.toEuclideanLin (onSiteTensorPow L Λ') v) =
+      Matrix.toEuclideanLin (onSiteTensorPow L (Λ * Λ')) v := by
+  rw [onSiteTensorPow_mul, Matrix.toEuclideanLin, Matrix.toLpLin_mul_same]
+  rfl
+
+/-- The kernel of the deformed interaction is the local ground space of the deformed
+tensor: \(\ker h' = \Lambda^{\otimes L}\ker h = \mathcal G_L(\Lambda A)\). -/
+theorem ker_deformedInteraction (L : ℕ) {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ)
+    {A : MPSTensor d D} {h : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L)}
+    (hker : LinearMap.ker h = groundSpaceES A L) :
+    LinearMap.ker (deformedInteraction L Λ h) = groundSpaceES (rotatePhysical Λ A) L := by
+  have hdet : IsUnit Λ.det := (Matrix.isUnit_iff_isUnit_det Λ).1 hΛ
+  have hleft : ∀ v : EuclideanSpace ℂ (Cfg d L),
+      Matrix.toEuclideanLin (onSiteTensorPow L Λ)
+        (Matrix.toEuclideanLin (onSiteTensorPow L Λ⁻¹) v) = v := by
+    intro v
+    rw [toEuclideanLin_onSiteTensorPow_mul_apply, Matrix.mul_nonsing_inv Λ hdet,
+      onSiteTensorPow_one, Matrix.toEuclideanLin, Matrix.toLpLin_one, LinearMap.id_apply]
+  have hright : ∀ v : EuclideanSpace ℂ (Cfg d L),
+      Matrix.toEuclideanLin (onSiteTensorPow L Λ⁻¹)
+        (Matrix.toEuclideanLin (onSiteTensorPow L Λ) v) = v := by
+    intro v
+    rw [toEuclideanLin_onSiteTensorPow_mul_apply, Matrix.nonsing_inv_mul Λ hdet,
+      onSiteTensorPow_one, Matrix.toEuclideanLin, Matrix.toLpLin_one, LinearMap.id_apply]
+  have hadj : ∀ v : EuclideanSpace ℂ (Cfg d L),
+      Matrix.toEuclideanLin (onSiteTensorPow L Λᴴ)
+        (Matrix.toEuclideanLin (onSiteTensorPow L (Λ⁻¹)ᴴ) v) = v := by
+    intro v
+    rw [toEuclideanLin_onSiteTensorPow_mul_apply, ← Matrix.conjTranspose_mul,
+      Matrix.nonsing_inv_mul Λ hdet, Matrix.conjTranspose_one, onSiteTensorPow_one,
+      Matrix.toEuclideanLin, Matrix.toLpLin_one, LinearMap.id_apply]
+  rw [groundSpaceES_rotatePhysical, ← hker]
+  ext v
+  simp only [LinearMap.mem_ker, deformedInteraction, LinearMap.comp_apply, Submodule.mem_map]
+  constructor
+  · intro hv
+    refine ⟨Matrix.toEuclideanLin (onSiteTensorPow L Λ⁻¹) v, ?_, hleft v⟩
+    have hzero := congrArg (Matrix.toEuclideanLin (onSiteTensorPow L Λᴴ)) hv
+    rw [hadj, map_zero] at hzero
+    simpa [LinearMap.mem_ker] using hzero
+  · rintro ⟨u, hu, rfl⟩
+    have hu' : h u = 0 := hu
+    rw [hright, hu', map_zero]
+
+/-- arXiv:2011.12127, lines 2190--2192: if \(A^i = \sum_j \Lambda_{ij} B^j\) with \(\Lambda\)
+invertible and \(h\) is a parent interaction for \(B\) on \(k\) sites, then
+\(h' = ({\Lambda^{-1}}^\dagger)^{\otimes k} h (\Lambda^{-1})^{\otimes k}\) is a parent
+interaction for \(A\).  Here \(B\) is the tensor `A` and \(A\) is `rotatePhysical Λ A`. -/
+theorem IsParentInteraction.deformedInteraction (L : ℕ) {Λ : Matrix (Fin d) (Fin d) ℂ}
+    (hΛ : IsUnit Λ) {A : MPSTensor d D}
+    {h : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L)}
+    (hh : IsParentInteraction A L h) :
+    IsParentInteraction (rotatePhysical Λ A) L (MPSTensor.deformedInteraction L Λ h) where
+  isPositive := deformedInteraction_isPositive L Λ hh.isPositive
+  ker_eq := ker_deformedInteraction L hΛ hh.ker_eq
+
+/-! ### The chain ground spaces
+
+The source argument at arXiv:2011.12127, lines 2035--2037, applies to a ground state
+\(\ket\Phi\) of the deformed chain Hamiltonian the operator \(X\) that acts as \(\Lambda\)
+on the sites of one local term and as \(\Lambda^{-1}\) on all other sites.  The identity
+below is the corresponding factorization of \(\Lambda^{\otimes N}\) across a cyclic window
+and its complement: the restriction to a window of \(\Lambda^{\otimes N}\phi\) is
+\(\Lambda^{\otimes L}\) applied to a linear combination of restrictions of \(\phi\). -/
+
+/-- The sites of the cyclic window at \(i\) are the images of the offsets below \(L\). -/
+private lemma prod_eq_window_mul_compl {N L : ℕ} (hLN : L ≤ N) (i : Fin N) (f : Fin N → ℂ) :
+    ∏ k : Fin N, f k =
+      (∏ r : Fin L, f (cyclicForwardSite i r.val)) *
+        ∏ k ∈ (cyclicWindowSupport N L i)ᶜ, f k := by
+  rw [← Finset.prod_mul_prod_compl (cyclicWindowSupport N L i) f]
+  congr 1
+  rw [cyclicWindowSupport, Finset.prod_image, Finset.prod_range]
+  intro x hx y hy hxy
+  have hxN : x < N := Nat.lt_of_lt_of_le (Finset.mem_range.1 hx) hLN
+  have hyN : y < N := Nat.lt_of_lt_of_le (Finset.mem_range.1 hy) hLN
+  have hval := congrArg (fun k : Fin N => (k.val + N - i.val) % N) hxy
+  simp only [cyclicForwardSite] at hval
+  rwa [offset_mod_eq i.isLt hxN, offset_mod_eq i.isLt hyN] at hval
+
+/-- Outside the cyclic window the replaced configuration agrees with the original one. -/
+private lemma replaceWindow_apply_of_notMem {N L : ℕ} (hLN : L ≤ N) (i : Fin N)
+    (σ : Cfg d N) (τ : Cfg d L) {k : Fin N} (hk : k ∉ cyclicWindowSupport N L i) :
+    replaceWindow L hLN i σ τ k = σ k := by
+  rw [mem_cyclicWindowSupport_iff hLN] at hk
+  simp [replaceWindow, hk]
+
+/-- Inside the cyclic window the replaced configuration reads the inserted word. -/
+private lemma replaceWindow_cyclicForwardSite {N L : ℕ} (hLN : L ≤ N) (i : Fin N)
+    (σ : Cfg d N) (τ : Cfg d L) (r : Fin L) :
+    replaceWindow L hLN i σ τ (cyclicForwardSite i r.val) = τ r :=
+  congrFun (extractWindow_replaceWindow L hLN i σ τ) r
+
+/-- The involution on pairs (word, configuration) exchanging the inserted window word with
+the window read from the configuration. -/
+private def windowSwap {N L : ℕ} (hLN : L ≤ N) (i : Fin N) :
+    Cfg d L × Cfg d N ≃ Cfg d L × Cfg d N where
+  toFun p := (extractWindow L i p.2, replaceWindow L hLN i p.2 p.1)
+  invFun p := (extractWindow L i p.2, replaceWindow L hLN i p.2 p.1)
+  left_inv p := by
+    obtain ⟨σ', ω⟩ := p
+    simp only [extractWindow_replaceWindow, replaceWindow_replaceWindow_same,
+      replaceWindow_extractWindow]
+  right_inv p := by
+    obtain ⟨σ', ω⟩ := p
+    simp only [extractWindow_replaceWindow, replaceWindow_replaceWindow_same,
+      replaceWindow_extractWindow]
+
+/-- Restricting \(\Lambda^{\otimes N}\phi\) to the cyclic window at \(i\) with outside
+configuration \(\tau\) is \(\Lambda^{\otimes L}\) applied to a linear combination of
+restrictions of \(\phi\); the coefficients are the products of the entries of \(\Lambda\)
+over the sites outside the window.  This is the factorization behind the operator \(X\) of
+arXiv:2011.12127, lines 2035--2037. -/
+theorem cyclicRestrictₗ_toLin'_onSiteTensorPow {N L : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (i : Fin N) (τ : Cfg d N) (Λ : Matrix (Fin d) (Fin d) ℂ) (φ : NSiteSpace d N) :
+    cyclicRestrictₗ hN L i τ (Matrix.toLin' (onSiteTensorPow N Λ) φ) =
+      Matrix.toLin' (onSiteTensorPow L Λ)
+        (∑ ω : Cfg d N,
+          (if extractWindow L i ω = extractWindow L i τ then
+            ∏ k ∈ (cyclicWindowSupport N L i)ᶜ, Λ (τ k) (ω k) else 0) •
+            cyclicRestrictₗ hN L i ω φ) := by
+  ext σ
+  have hcfg : ∀ (σ' : Cfg d L) (ω : Cfg d N),
+      cyclicCfg hN L i σ' ω = replaceWindow L hLN i ω σ' := fun _ _ => rfl
+  -- Reindex a double sum over (window word, configuration) by the window swap.
+  have key : ∀ F : Cfg d L → Cfg d N → ℂ,
+      ∑ σ' : Cfg d L, ∑ ω : Cfg d N, F σ' ω =
+        ∑ σ' : Cfg d L, ∑ ω : Cfg d N,
+          F (extractWindow L i ω) (replaceWindow L hLN i ω σ') := by
+    intro F
+    calc
+      ∑ σ' : Cfg d L, ∑ ω : Cfg d N, F σ' ω
+          = ∑ p : Cfg d L × Cfg d N, F p.1 p.2 := (Fintype.sum_prod_type' F).symm
+      _ = ∑ p : Cfg d L × Cfg d N,
+            F (windowSwap (d := d) hLN i p).1 (windowSwap (d := d) hLN i p).2 :=
+          ((windowSwap (d := d) hLN i).sum_comp fun p => F p.1 p.2).symm
+      _ = ∑ σ' : Cfg d L, ∑ ω : Cfg d N,
+            F (extractWindow L i ω) (replaceWindow L hLN i ω σ') :=
+          Fintype.sum_prod_type'
+            fun σ' ω => F (extractWindow L i ω) (replaceWindow L hLN i ω σ')
+  simp only [cyclicRestrictₗ_apply, Matrix.toLin'_apply, Matrix.mulVec, dotProduct,
+    onSiteTensorPow_apply, Finset.sum_apply, Pi.smul_apply, smul_eq_mul, hcfg]
+  simp only [Finset.mul_sum]
+  rw [key]
+  simp only [extractWindow_replaceWindow, replaceWindow_replaceWindow_same,
+    replaceWindow_extractWindow]
+  rw [Finset.sum_comm]
+  simp only [ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq', Finset.mem_univ,
+    ↓reduceIte]
+  refine Finset.sum_congr rfl fun ω _ => ?_
+  have hwin : ∀ r : Fin L,
+      Λ (replaceWindow L hLN i τ σ (cyclicForwardSite i r.val))
+          (ω (cyclicForwardSite i r.val)) =
+        Λ (σ r) (extractWindow L i ω r) := fun r => by
+    rw [replaceWindow_cyclicForwardSite hLN i τ σ]
+    rfl
+  have hout : ∀ k ∈ (cyclicWindowSupport N L i)ᶜ,
+      Λ (replaceWindow L hLN i τ σ k) (ω k) =
+        Λ (τ k) (replaceWindow L hLN i ω (extractWindow L i τ) k) := fun k hk => by
+    rw [replaceWindow_apply_of_notMem hLN i τ σ (Finset.mem_compl.1 hk),
+      replaceWindow_apply_of_notMem hLN i ω (extractWindow L i τ) (Finset.mem_compl.1 hk)]
+  rw [prod_eq_window_mul_compl hLN i, mul_assoc, Finset.prod_congr rfl fun r _ => hwin r,
+    Finset.prod_congr rfl hout]
+
+/-- The tensor power maps the chain ground space of \(A\) into the chain ground space of
+the deformed tensor \(\Lambda A\).  No invertibility of \(\Lambda\) is needed. -/
+theorem map_chainGroundSpace_le_chainGroundSpace_rotatePhysical
+    (Λ : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (L N : ℕ) :
+    (chainGroundSpace A L N).map (Matrix.toLin' (onSiteTensorPow N Λ)) ≤
+      chainGroundSpace (rotatePhysical Λ A) L N := by
+  intro ψ hψ
+  obtain ⟨φ, hφ, rfl⟩ := Submodule.mem_map.1 hψ
+  rw [chainGroundSpace] at hφ ⊢
+  by_cases hNL : 0 < N ∧ L ≤ N
+  · rw [dite_eq_left hNL] at hφ ⊢
+    simp only [Submodule.mem_iInf, Submodule.mem_comap] at hφ ⊢
+    intro i τ
+    rw [cyclicRestrictₗ_toLin'_onSiteTensorPow hNL.1 hNL.2 i τ Λ φ, groundSpace_rotatePhysical]
+    exact Submodule.mem_map_of_mem
+      (Submodule.sum_mem _ fun ω _ => Submodule.smul_mem _ _ (hφ i ω))
+  · rw [dite_eq_right hNL]
+    exact Submodule.mem_top
+
+/-- The one-to-one correspondence of arXiv:2011.12127, lines 2035--2037, between the ground
+states of the parent Hamiltonians of \(\ket\psi\) and \(\ket{\psi'} = R^{\otimes N}\ket\psi\)
+for an invertible on-site map \(R\): the chain ground space of the deformed tensor is the
+image of the chain ground space of the original tensor under \(R^{\otimes N}\). -/
+theorem chainGroundSpace_rotatePhysical {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ)
+    (A : MPSTensor d D) (L N : ℕ) :
+    chainGroundSpace (rotatePhysical Λ A) L N =
+      (chainGroundSpace A L N).map (Matrix.toLin' (onSiteTensorPow N Λ)) := by
+  refine le_antisymm ?_ (map_chainGroundSpace_le_chainGroundSpace_rotatePhysical Λ A L N)
+  have hdet : IsUnit Λ.det := (Matrix.isUnit_iff_isUnit_det Λ).1 hΛ
+  have hinv := map_chainGroundSpace_le_chainGroundSpace_rotatePhysical Λ⁻¹
+    (rotatePhysical Λ A) L N
+  rw [rotatePhysical_rotatePhysical, Matrix.nonsing_inv_mul Λ hdet, rotatePhysical_one] at hinv
+  intro ψ hψ
+  refine ⟨Matrix.toLin' (onSiteTensorPow N Λ⁻¹) ψ, hinv (Submodule.mem_map_of_mem hψ), ?_⟩
+  rw [← LinearMap.comp_apply, ← Matrix.toLin'_mul, onSiteTensorPow_mul_inv N hΛ,
+    Matrix.toLin'_one, LinearMap.id_apply]
+
+/-- The ground spaces of the parent Hamiltonians of \(\ket\psi\) and
+\(\ket{\psi'} = R^{\otimes N}\ket\psi\) correspond one-to-one through \(R^{\otimes N}\)
+(arXiv:2011.12127, lines 2035--2037), stated for the kernels of the finite parent
+Hamiltonians in the range \(0 < N\), \(L \le N\) where the local terms act on genuine
+cyclic windows. -/
+theorem ker_parentHamiltonian_rotatePhysical {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ)
+    (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    LinearMap.ker (parentHamiltonian (rotatePhysical Λ A) L N) =
+      (LinearMap.ker (parentHamiltonian A L N)).map (Matrix.toLin' (onSiteTensorPow N Λ)) := by
+  rw [ker_parentHamiltonian_eq_chainGroundSpace _ hN hLN,
+    ker_parentHamiltonian_eq_chainGroundSpace _ hN hLN, chainGroundSpace_rotatePhysical hΛ]
+
+/-- The tensor power of an invertible on-site map as a linear automorphism of the
+\(N\)-site space. -/
+noncomputable def onSiteTensorPowEquiv (N : ℕ) {Λ : Matrix (Fin d) (Fin d) ℂ}
+    (hΛ : IsUnit Λ) : NSiteSpace d N ≃ₗ[ℂ] NSiteSpace d N :=
+  LinearEquiv.ofLinearMap (Matrix.toLin' (onSiteTensorPow N Λ))
+    (Matrix.toLin' (onSiteTensorPow N Λ⁻¹))
+    (by rw [← Matrix.toLin'_mul, onSiteTensorPow_mul_inv N hΛ, Matrix.toLin'_one])
+    (by rw [← Matrix.toLin'_mul, onSiteTensorPow_inv_mul N hΛ, Matrix.toLin'_one])
+
+/-- arXiv:2011.12127, lines 2037--2038: if the parent Hamiltonian of \(A\) has a unique
+ground state, then so does the parent Hamiltonian of the deformed tensor \(\Lambda A\), since
+the two ground spaces correspond through the invertible map \(\Lambda^{\otimes N}\). -/
+theorem hasUniqueGroundState_chainGroundSpace_rotatePhysical
+    {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ) {A : MPSTensor d D} {L N : ℕ}
+    (hA : HasUniqueGroundState (chainGroundSpace A L N)) :
+    HasUniqueGroundState (chainGroundSpace (rotatePhysical Λ A) L N) := by
+  rw [HasUniqueGroundState, chainGroundSpace_rotatePhysical hΛ]
+  exact (LinearEquiv.finrank_map_eq (onSiteTensorPowEquiv N hΛ) (chainGroundSpace A L N)).trans hA
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean
+++ b/TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean
@@ -20,7 +20,9 @@ The source writes the deformed tensor as \(A^i = \sum_j \Lambda_{ij} B^j\) with 
 invertible, and the deformed state as \(\ket{\psi'} = R^{\otimes N}\ket{\psi}\).  Here the
 original tensor is \(A\) and the deformed tensor is \(\Lambda A\), with
 \((\Lambda A)^i = \sum_j \Lambda_{ij} A^j\); the on-site map \(\Lambda\) plays the role of the
-source's \(\Lambda\) and \(R\).
+source's \(\Lambda\) and \(R\).  The source states the correspondence for tensor network
+states on a general graph; this module formalizes its instance for matrix product states on
+the periodic chain.
 
 ## Main definitions
 
@@ -383,8 +385,9 @@ theorem map_chainGroundSpace_le_chainGroundSpace_rotatePhysical
 
 /-- The one-to-one correspondence of arXiv:2011.12127, lines 2035--2037, between the ground
 states of the parent Hamiltonians of \(\ket\psi\) and \(\ket{\psi'} = R^{\otimes N}\ket\psi\)
-for an invertible on-site map \(R\): the chain ground space of the deformed tensor is the
-image of the chain ground space of the original tensor under \(R^{\otimes N}\). -/
+for an invertible on-site map \(R\), in its instance for matrix product states on the
+periodic chain: the chain ground space of the deformed tensor is the image of the chain
+ground space of the original tensor under \(R^{\otimes N}\). -/
 theorem chainGroundSpace_rotatePhysical {Λ : Matrix (Fin d) (Fin d) ℂ} (hΛ : IsUnit Λ)
     (A : MPSTensor d D) (L N : ℕ) :
     chainGroundSpace (rotatePhysical Λ A) L N =

--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -7,6 +7,7 @@ import QICLean.Algebra.MatrixIsometryEntries
 import QICLean.Channel.KrausRepresentation
 import QICLean.Kraus.MixedMap
 import QICLean.Kraus.Transfer
+import TNLean.MPS.Core.PhysicalRotation
 import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.Periodic.Defs
 
@@ -21,10 +22,9 @@ Section 4, that depend on the periodic fundamental theorem. The refinement and
 divisibility material belongs to Section 4.1, while the symmetry-to-`Z`-gauge
 corollary belongs to Section 4.2. It contains:
 
-1. The physical-index rotation `rotatePhysical` and its matrix-product-vector expansion.
-2. A **periodic-form theorem** that isolates the periodic equal-case FT input
+1. A **periodic-form theorem** that isolates the periodic equal-case FT input
    for the symmetry corollary of arXiv:1708.00029, Section 4.2.
-3. **Preservation lemmas** showing that unitary rotation of the physical index
+2. **Preservation lemmas** showing that unitary rotation of the physical index
    preserves transfer maps, rectangular mixed transfer maps, left-canonical
    normalization, irreducibility, periodicity, and irreducible form II
    structure.
@@ -44,75 +44,6 @@ namespace MPSTensor
 noncomputable section
 
 variable {d D : ℕ}
-
-/-- Physical-index rotation of a tensor by a matrix `M` on the physical leg:
-
-`(rotatePhysical M A) i = ∑ j, M i j • A j`.
--/
-def rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTensor d D :=
-  fun i => ∑ j : Fin d, M i j • A j
-
-@[simp] lemma rotatePhysical_apply
-    (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (i : Fin d) :
-    rotatePhysical M A i = ∑ j : Fin d, M i j • A j := rfl
-
-/-- Expanding a word of a physically rotated tensor gives the sitewise matrix
-coefficients multiplying the corresponding unrotated words. -/
-theorem evalWord_rotatePhysical_ofFn
-    (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) :
-    ∀ (N : ℕ) (s : Fin N → Fin d),
-      Kraus.evalWord (rotatePhysical M A) (List.ofFn s) =
-        ∑ t : Fin N → Fin d,
-          (∏ n : Fin N, M (s n) (t n)) • Kraus.evalWord A (List.ofFn t) := by
-  intro N
-  induction N with
-  | zero =>
-      intro s
-      classical
-      simp
-  | succ N ih =>
-      intro s
-      classical
-      rw [List.ofFn_succ, Kraus.evalWord_cons, rotatePhysical_apply]
-      rw [ih (fun n : Fin N => s n.succ)]
-      rw [Finset.sum_mul_sum]
-      let e : (Fin d × (Fin N → Fin d)) ≃ (Fin (N + 1) → Fin d) :=
-        Fin.consEquiv (fun _ => Fin d)
-      have hreindex :
-          (∑ t : Fin (N + 1) → Fin d,
-              (∏ n : Fin (N + 1), M (s n) (t n)) •
-                Kraus.evalWord A (List.ofFn t)) =
-            ∑ p : Fin d × (Fin N → Fin d),
-              (∏ n : Fin (N + 1), M (s n) (e p n)) •
-                Kraus.evalWord A (List.ofFn (e p)) :=
-        (Fintype.sum_equiv e
-          (f := fun p : Fin d × (Fin N → Fin d) =>
-            (∏ n : Fin (N + 1), M (s n) (e p n)) •
-              Kraus.evalWord A (List.ofFn (e p)))
-          (g := fun t : Fin (N + 1) → Fin d =>
-            (∏ n : Fin (N + 1), M (s n) (t n)) •
-              Kraus.evalWord A (List.ofFn t))
-          (by intro p; rfl)).symm
-      rw [hreindex, ← Fintype.sum_prod_type']
-      refine Finset.sum_congr rfl ?_
-      rintro ⟨i, t⟩ _
-      have hprod :
-          (∏ n : Fin (N + 1), M (s n) (e (i, t) n)) =
-            M (s 0) i * ∏ n : Fin N, M (s n.succ) (t n) := by
-        rw [Fin.prod_univ_succ]
-        simp [e, Fin.consEquiv]
-      have hlist : List.ofFn (e (i, t)) = i :: List.ofFn t := by
-        simp [e, Fin.consEquiv]
-      rw [hprod, hlist, Kraus.evalWord_cons, smul_mul_smul_comm]
-
-/-- The matrix product vector of a physical-index rotation is the sitewise
-matrix action on the original matrix product vector. -/
-theorem mpv_rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ)
-    (A : MPSTensor d D) {N : ℕ} (s : Fin N → Fin d) :
-    mpv (rotatePhysical M A) s =
-      ∑ t : Fin N → Fin d, (∏ n : Fin N, M (s n) (t n)) * mpv A t := by
-  rw [mpv, coeff, evalWord_rotatePhysical_ofFn, Matrix.trace_sum]
-  simp only [Matrix.trace_smul, smul_eq_mul, mpv, coeff]
 
 /-- Corollary 4.1 (periodic form).
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -25,6 +25,7 @@ ground spaces arising from several normal blocks.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_blocking_transport}
+\input{chapter/ch13_parent_hamiltonian_physical_deformation}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}
 \input{chapter/ch13_parent_hamiltonian_normal_boundary}
 \input{chapter/ch13_parent_hamiltonian_normal_closing}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
@@ -219,10 +219,12 @@ is formalized for matrix product states on the periodic chain.
         \label{eq:chain_ground_space_physical_rotation}
     \end{align}
     and for $0<N$ and $L\le N$ the kernels of the parent Hamiltonians satisfy
-    $\ker H_N(\Lambda A)=\Lambda^{\otimes N}\ker H_N(A)$. This is the one-to-one
+    $\ker H_N(\Lambda A)=\Lambda^{\otimes N}\ker H_N(A)$. This is the
+    matrix-product-state instance, on the periodic chain, of the one-to-one
     correspondence, through $R^{\otimes N}$, between the ground states of the parent
     Hamiltonians of $\ket\psi$ and $\ket{\psi'}=R^{\otimes N}\ket\psi$ for an
-    invertible map $R$ stated in \cite[Section~IV.C]{Cirac2021Matrix}. Without
+    invertible map $R$ stated in \cite[Section~IV.C]{Cirac2021Matrix} for tensor
+    network states on a general graph. Without
     invertibility, the inclusion
     $\Lambda^{\otimes N}\mathcal G_{N,L}(A)\subseteq\mathcal G_{N,L}(\Lambda A)$
     still holds.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
@@ -13,8 +13,6 @@ is formalized for matrix product states on the periodic chain.
 
 \begin{definition}[Physical rotation of a tensor]\label{def:physical_rotation}
     \lean{MPSTensor.rotatePhysical}
-    \lean{MPSTensor.rotatePhysical_one}
-    \lean{MPSTensor.rotatePhysical_rotatePhysical}
     \leanok
     For a matrix $\Lambda\in\MN{d}$ and a tensor $A=(A^i)_{i=0}^{d-1}$, the
     \emph{physically rotated tensor} $\Lambda A$ has matrices
@@ -22,8 +20,46 @@ is formalized for matrix product states on the periodic chain.
         (\Lambda A)^i & =\sum_{j=0}^{d-1}\Lambda_{ij}A^j.
         \label{eq:physical_rotation}
     \end{align}
-    Rotation by the identity is trivial, and $\Lambda(\Lambda'A)=(\Lambda\Lambda')A$.
 \end{definition}
+
+\begin{lemma}[Rotation by the identity]\label{lem:physical_rotation_one}
+    \lean{MPSTensor.rotatePhysical_one}
+    \leanok
+    \uses{def:physical_rotation}
+    Rotation by the identity is trivial: $\Id A=A$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:physical_rotation}
+    Since $\Id_{ij}=\delta_{ij}$, each component in (\ref{eq:physical_rotation})
+    reduces to $\sum_j\delta_{ij}A^j=A^i$.
+\end{proof}
+
+\begin{lemma}[Composition of rotations]\label{lem:physical_rotation_mul}
+    \lean{MPSTensor.rotatePhysical_rotatePhysical}
+    \leanok
+    \uses{def:physical_rotation}
+    For $\Lambda,\Lambda'\in\MN{d}$,
+    \begin{align}
+        \Lambda(\Lambda'A) & =(\Lambda\Lambda')A.
+        \label{eq:physical_rotation_mul}
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:physical_rotation}
+    Expand both sides of (\ref{eq:physical_rotation_mul}) by
+    (\ref{eq:physical_rotation}) and swap the order of summation:
+    \begin{align}
+        \big(\Lambda(\Lambda'A)\big)^i
+         & =\sum_{j}\Lambda_{ij}\sum_{k}\Lambda'_{jk}A^k
+        =\sum_{k}\Big(\sum_{j}\Lambda_{ij}\Lambda'_{jk}\Big)A^k
+        =\big((\Lambda\Lambda')A\big)^i.
+        \notag
+    \end{align}
+\end{proof}
 
 \begin{definition}[Tensor power of an on-site map]\label{def:on_site_tensor_pow}
     \lean{MPSTensor.onSiteTensorPow}
@@ -116,15 +152,31 @@ is formalized for matrix product states on the periodic chain.
 
 \begin{definition}[Parent interaction]\label{def:is_parent_interaction}
     \lean{MPSTensor.IsParentInteraction}
-    \lean{MPSTensor.isParentInteraction_parentInteractionES}
     \leanok
     \uses{def:ground_space_es}
     Following \cite[Section~IV.C, Definition (Parent Hamiltonian)]{Cirac2021Matrix},
     a \emph{parent interaction} on $L$ sites for the tensor $A$ is a hermitian
     positive semidefinite operator $h\ge0$ on $\ell^2(\Fin{d}^{L})$ whose kernel
-    equals $G_L(A)$. The canonical parent interaction, the orthogonal projector
-    onto $G_L(A)^\perp$, is a parent interaction.
+    equals $G_L(A)$.
 \end{definition}
+
+\begin{theorem}[The canonical parent interaction is a parent interaction]\label{thm:canonical_parent_interaction_is_parent_interaction}
+    \lean{MPSTensor.isParentInteraction_parentInteractionES}
+    \leanok
+    \uses{def:is_parent_interaction, rem:euclidean_local_projector_ingredients}
+    The canonical parent interaction $P_L^{\mathrm{ES}}(A)$, the orthogonal
+    projector onto $G_L(A)^\perp$, is a parent interaction on $L$ sites for $A$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:euclidean_local_projector_positive, lem:parent_interaction_es_kernel}
+    An orthogonal projector is hermitian and positive semidefinite
+    (Lemma~\ref{lem:euclidean_local_projector_positive}), and by
+    Lemma~\ref{lem:parent_interaction_es_kernel} a vector is annihilated by the
+    projector onto $G_L(A)^\perp$ exactly when it lies in $G_L(A)$, so
+    $\ker P_L^{\mathrm{ES}}(A)=G_L(A)$.
+\end{proof}
 
 \begin{definition}[Deformed interaction]\label{def:deformed_interaction}
     \lean{MPSTensor.deformedInteraction}
@@ -195,16 +247,48 @@ is formalized for matrix product states on the periodic chain.
 
 \begin{proof}
     \leanok
-    Evaluate both sides at a window word $\sigma$. On the left,
-    $\prod_{k}\Lambda_{\rho_k\rho'_k}$ for the configuration $\rho$ obtained from
-    $\sigma$ and $\tau$ splits as the product over the window, which is
-    $\prod_{r}\Lambda_{\sigma_r\rho'_{i+r}}$, times the product over the
-    complement, which is $c_\tau(\rho')$. On the right, the pair $(\sigma',\omega)$
-    of a window word and a configuration is exchanged with the pair consisting of
-    the window of $\omega$ and the configuration obtained from $\omega$ by inserting
-    $\sigma'$; this exchange is an involution, and after it the constraint that
-    $\omega$ agree with $\tau$ on the window collapses the sum over $\sigma'$ to a
-    single term. The two sides then agree term by term.
+    Write $W=[i,i+L-1]$ for the window. For a configuration $\omega\in\Fin{d}^{N}$
+    let $\omega_W\in\Fin{d}^{L}$ be the word read off the window,
+    $(\omega_W)_r=\omega_{i+r}$, and for a window word $\sigma'\in\Fin{d}^{L}$ let
+    $\omega[\sigma']\in\Fin{d}^{N}$ be the configuration that reads $\sigma'$ on the
+    window and agrees with $\omega$ outside it, so that
+    $(\phi|_{W,\omega})(\sigma')=\phi(\omega[\sigma'])$,
+    $(\omega[\sigma'])_W=\sigma'$, $\omega[\sigma'][\omega_W]=\omega$, and
+    $c_\tau(\omega[\sigma'])=c_\tau(\omega)$. Evaluate both sides of
+    (\ref{eq:cyclic_restrict_tensor_pow}) at a window word $\sigma$. On the left,
+    the product over all sites in (\ref{eq:on_site_tensor_pow}) splits into the
+    product over the window, where $\tau[\sigma]$ reads $\sigma$, and the product
+    over its complement, where $\tau[\sigma]$ agrees with $\tau$:
+    \begin{align}
+        \big(\Lambda^{\otimes N}\phi\big)(\tau[\sigma])
+         & =\sum_{\rho}\Big(\prod_{k=0}^{N-1}\Lambda_{\tau[\sigma]_k\rho_k}\Big)\phi(\rho)
+        =\sum_{\rho}\Big(\prod_{r=0}^{L-1}\Lambda_{\sigma_r\rho_{i+r}}\Big)
+        c_\tau(\rho)\,\phi(\rho).
+        \label{eq:cyclic_restrict_tensor_pow_left}
+    \end{align}
+    On the right, with $[\,\cdot\,]$ equal to $1$ when the enclosed condition holds
+    and to $0$ otherwise,
+    \begin{align}
+        \sum_{\sigma'}\Big(\prod_{r=0}^{L-1}\Lambda_{\sigma_r\sigma'_r}\Big)
+        \sum_{\omega}[\omega_W=\tau_W]\,c_\tau(\omega)\,\phi(\omega[\sigma'])
+         & =\sum_{\sigma'}\sum_{\omega}
+        \Big(\prod_{r=0}^{L-1}\Lambda_{\sigma_r\omega_{i+r}}\Big)
+        [\sigma'=\tau_W]\,c_\tau(\omega)\,\phi(\omega)
+        \notag                                                                     \\
+         & =\sum_{\omega}\Big(\prod_{r=0}^{L-1}\Lambda_{\sigma_r\omega_{i+r}}\Big)
+        c_\tau(\omega)\,\phi(\omega),
+        \label{eq:cyclic_restrict_tensor_pow_right}
+    \end{align}
+    where the first equality reindexes the double sum by the involution
+    \begin{align}
+        (\sigma',\omega) & \longmapsto\big(\omega_W,\ \omega[\sigma']\big)
+        \label{eq:cyclic_restrict_tensor_pow_swap}
+    \end{align}
+    on pairs of a window word and a configuration, and the second collapses the sum
+    over $\sigma'$ to the single term $\sigma'=\tau_W$. The right sides of
+    (\ref{eq:cyclic_restrict_tensor_pow_left}) and
+    (\ref{eq:cyclic_restrict_tensor_pow_right}) agree term by term with
+    $\rho=\omega$.
 \end{proof}
 
 \begin{theorem}[Ground-space correspondence]\label{thm:chain_ground_space_physical_rotation}
@@ -232,7 +316,7 @@ is formalized for matrix product states on the periodic chain.
 
 \begin{proof}
     \leanok
-    \uses{lem:cyclic_restrict_tensor_pow, thm:ground_space_physical_rotation, lem:on_site_tensor_pow_mul, thm:parent_hamiltonian_kernel_eq_chain_ground_space}
+    \uses{lem:cyclic_restrict_tensor_pow, thm:ground_space_physical_rotation, lem:on_site_tensor_pow_mul, lem:physical_rotation_one, lem:physical_rotation_mul, thm:parent_hamiltonian_kernel_eq_chain_ground_space}
     Let $\phi\in\mathcal G_{N,L}(A)$, so that every window restriction of $\phi$
     lies in $G_L(A)$. By (\ref{eq:cyclic_restrict_tensor_pow}), every window
     restriction of $\Lambda^{\otimes N}\phi$ is $\Lambda^{\otimes L}$ applied to a

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex
@@ -1,0 +1,263 @@
+\section{Ground-space correspondence under an invertible on-site map}
+\label{sec:physical_deformation}
+
+An invertible map $\Lambda$ on the physical space $\C^d$ acts on a tensor by
+mixing its physical matrices, $A^i\mapsto\sum_j\Lambda_{ij}A^j$. This section
+records the correspondence, stated in \cite[Section~IV.C]{Cirac2021Matrix}, between
+the parent Hamiltonians of the original and of the deformed tensor: the deformed
+local interaction $h'=({\Lambda^{-1}}^\dagger)^{\otimes L}h(\Lambda^{-1})^{\otimes L}$
+is a parent interaction for the deformed tensor, and the ground spaces of the two
+chain Hamiltonians correspond one-to-one through $\Lambda^{\otimes N}$. The source
+states the correspondence for tensor network states on a general graph; here it
+is formalized for matrix product states on the periodic chain.
+
+\begin{definition}[Physical rotation of a tensor]\label{def:physical_rotation}
+    \lean{MPSTensor.rotatePhysical}
+    \lean{MPSTensor.rotatePhysical_one}
+    \lean{MPSTensor.rotatePhysical_rotatePhysical}
+    \leanok
+    For a matrix $\Lambda\in\MN{d}$ and a tensor $A=(A^i)_{i=0}^{d-1}$, the
+    \emph{physically rotated tensor} $\Lambda A$ has matrices
+    \begin{align}
+        (\Lambda A)^i & =\sum_{j=0}^{d-1}\Lambda_{ij}A^j.
+        \label{eq:physical_rotation}
+    \end{align}
+    Rotation by the identity is trivial, and $\Lambda(\Lambda'A)=(\Lambda\Lambda')A$.
+\end{definition}
+
+\begin{definition}[Tensor power of an on-site map]\label{def:on_site_tensor_pow}
+    \lean{MPSTensor.onSiteTensorPow}
+    \lean{MPSTensor.onSiteTensorPow_apply}
+    \leanok
+    For $\Lambda\in\MN{d}$ and $L\ge0$, the tensor power $\Lambda^{\otimes L}$ is the
+    matrix on $L$-site configurations with entries
+    \begin{align}
+        (\Lambda^{\otimes L})_{\sigma,\tau} & =\prod_{n=0}^{L-1}\Lambda_{\sigma_n\tau_n}.
+        \label{eq:on_site_tensor_pow}
+    \end{align}
+    It acts on the $L$-site space $\Fin{d}^{L}\to\C$ by matrix multiplication and on
+    its Hilbert-space realization $\ell^2(\Fin{d}^{L})$ in the same way.
+\end{definition}
+
+\begin{lemma}[Multiplicativity of the tensor power]\label{lem:on_site_tensor_pow_mul}
+    \lean{MPSTensor.onSiteTensorPow_eq_submatrix_blockKron}
+    \lean{MPSTensor.onSiteTensorPow_mul}
+    \lean{MPSTensor.onSiteTensorPow_one}
+    \lean{MPSTensor.onSiteTensorPow_conjTranspose}
+    \lean{MPSTensor.onSiteTensorPow_inv_mul}
+    \lean{MPSTensor.onSiteTensorPow_mul_inv}
+    \lean{MPSTensor.toEuclideanLin_onSiteTensorPow_mul_apply}
+    \leanok
+    \uses{def:on_site_tensor_pow}
+    For $\Lambda,\Lambda'\in\MN{d}$ one has
+    $(\Lambda\Lambda')^{\otimes L}=\Lambda^{\otimes L}\Lambda'^{\otimes L}$,
+    $\Id^{\otimes L}=\Id$, and
+    $(\Lambda^{\otimes L})^\dagger=(\Lambda^\dagger)^{\otimes L}$.
+    If $\Lambda$ is invertible, then $(\Lambda^{-1})^{\otimes L}$ is a two-sided
+    inverse of $\Lambda^{\otimes L}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Reading the blocked physical index of $L$ consecutive sites as an
+    $L$-site configuration identifies $\Lambda^{\otimes L}$ with the Kronecker
+    lift of $\Lambda$ through blocking, for which multiplicativity, the
+    identity, and the conjugate transpose are known. The inverse statements follow
+    from multiplicativity applied to $\Lambda^{-1}\Lambda=\Lambda\Lambda^{-1}=\Id$.
+\end{proof}
+
+\begin{lemma}[State and boundary map of the rotated tensor]\label{lem:physical_rotation_state}
+    \lean{MPSTensor.evalWord_rotatePhysical_ofFn}
+    \lean{MPSTensor.mpv_rotatePhysical}
+    \lean{MPSTensor.mpv_rotatePhysical_eq_toLin'}
+    \lean{MPSTensor.groundSpaceMap_rotatePhysical}
+    \leanok
+    \uses{def:physical_rotation, def:on_site_tensor_pow, def:ground_space_map}
+    For every word $\sigma$ of length $N$,
+    \begin{align}
+        (\Lambda A)^{\sigma}
+         & =\sum_{\tau}\Big(\prod_{n=0}^{N-1}\Lambda_{\sigma_n\tau_n}\Big)A^{\tau},
+        \label{eq:physical_rotation_word}
+    \end{align}
+    so that $\ket{V^{(N)}(\Lambda A)}=\Lambda^{\otimes N}\ket{V^{(N)}(A)}$ and
+    $\Gamma_L^{\Lambda A}(X)=\Lambda^{\otimes L}\,\Gamma_L^{A}(X)$ for every
+    boundary matrix $X\in\MN{D}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand each factor of $(\Lambda A)^{\sigma_1}\cdots(\Lambda A)^{\sigma_N}$ by
+    (\ref{eq:physical_rotation}) and collect the coefficient of $A^{\tau}$, by
+    induction on $N$. Taking the trace against $X$ gives the boundary-map
+    identity, and $X=\Id$ gives the state identity.
+\end{proof}
+
+\begin{theorem}[Local ground space of the rotated tensor]\label{thm:ground_space_physical_rotation}
+    \lean{MPSTensor.groundSpace_rotatePhysical}
+    \lean{MPSTensor.groundSpaceES_rotatePhysical}
+    \leanok
+    \uses{def:physical_rotation, def:on_site_tensor_pow, def:ground_space_parent, def:ground_space_es}
+    For every $\Lambda\in\MN{d}$ and $L\ge0$,
+    \begin{align}
+        G_L(\Lambda A) & =\Lambda^{\otimes L}\,G_L(A),
+        \label{eq:ground_space_physical_rotation}
+    \end{align}
+    and the same identity holds for the Hilbert-space realizations of the two
+    local ground spaces.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:physical_rotation_state}
+    By Lemma~\ref{lem:physical_rotation_state}, the boundary map of $\Lambda A$ is
+    the composition of $\Lambda^{\otimes L}$ with the boundary map of $A$, so its
+    range is the image of $G_L(A)$ under $\Lambda^{\otimes L}$.
+\end{proof}
+
+\begin{definition}[Parent interaction]\label{def:is_parent_interaction}
+    \lean{MPSTensor.IsParentInteraction}
+    \lean{MPSTensor.isParentInteraction_parentInteractionES}
+    \leanok
+    \uses{def:ground_space_es}
+    Following \cite[Section~IV.C, Definition (Parent Hamiltonian)]{Cirac2021Matrix},
+    a \emph{parent interaction} on $L$ sites for the tensor $A$ is a hermitian
+    positive semidefinite operator $h\ge0$ on $\ell^2(\Fin{d}^{L})$ whose kernel
+    equals $G_L(A)$. The canonical parent interaction, the orthogonal projector
+    onto $G_L(A)^\perp$, is a parent interaction.
+\end{definition}
+
+\begin{definition}[Deformed interaction]\label{def:deformed_interaction}
+    \lean{MPSTensor.deformedInteraction}
+    \leanok
+    \uses{def:on_site_tensor_pow}
+    For $\Lambda\in\MN{d}$ and an operator $h$ on $\ell^2(\Fin{d}^{L})$, the
+    \emph{deformed interaction} is
+    \begin{align}
+        h' & =({\Lambda^{-1}}^\dagger)^{\otimes L}\,h\,(\Lambda^{-1})^{\otimes L}.
+        \label{eq:deformed_interaction}
+    \end{align}
+    This is the operator written in \cite[Section~IV.C]{Cirac2021Matrix} as
+    $h'=(A^{-1}\otimes A^{-1})^\dagger h(A^{-1}\otimes A^{-1})$ for the
+    two-site interaction of an isometric tensor network, and as
+    $h'=({\Lambda^{-1}}^\dagger)^{\otimes k}h(\Lambda^{-1})^{\otimes k}$ for a
+    general physical perturbation.
+\end{definition}
+
+\begin{theorem}[The deformed interaction is a parent interaction]\label{thm:deformed_interaction_parent}
+    \lean{MPSTensor.deformedInteraction_isPositive}
+    \lean{MPSTensor.ker_deformedInteraction}
+    \lean{MPSTensor.IsParentInteraction.deformedInteraction}
+    \leanok
+    \uses{def:physical_rotation, def:is_parent_interaction, def:deformed_interaction}
+    Let $\Lambda\in\MN{d}$ be invertible and let $h$ be a parent interaction on $L$
+    sites for $A$. Then the deformed interaction $h'$ of
+    (\ref{eq:deformed_interaction}) is a parent interaction on $L$ sites for
+    $\Lambda A$: $h'\ge0$ and $\ker h'=G_L(\Lambda A)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:on_site_tensor_pow_mul, thm:ground_space_physical_rotation}
+    Write $S=(\Lambda^{-1})^{\otimes L}$. By Lemma~\ref{lem:on_site_tensor_pow_mul},
+    $({\Lambda^{-1}}^\dagger)^{\otimes L}=S^\dagger$, so $h'=S^\dagger hS$ is
+    positive semidefinite. Since $S$ and $S^\dagger$ are invertible with inverses
+    $\Lambda^{\otimes L}$ and $(\Lambda^\dagger)^{\otimes L}$,
+    \begin{align}
+        h'\Phi=0
+        \iff hS\Phi=0
+        \iff S\Phi\in G_L(A)
+        \iff \Phi\in\Lambda^{\otimes L}G_L(A)
+        =G_L(\Lambda A),
+        \label{eq:deformed_interaction_kernel}
+    \end{align}
+    where the last equality is (\ref{eq:ground_space_physical_rotation}).
+\end{proof}
+
+\begin{lemma}[Window factorization of the tensor power]\label{lem:cyclic_restrict_tensor_pow}
+    \lean{MPSTensor.cyclicRestrictₗ_toLin'_onSiteTensorPow}
+    \leanok
+    \uses{def:on_site_tensor_pow, rem:cyclic_window_operators, def:cyclic_window_support}
+    Let $0<N$, $L\le N$, let $i\in\Fin{N}$, and let $\tau\in\Fin{d}^{N}$ be an
+    outside configuration. For every $\phi\colon\Fin{d}^{N}\to\C$, the restriction of
+    $\Lambda^{\otimes N}\phi$ to the cyclic window $[i,i+L-1]$ with outside
+    configuration $\tau$ is
+    \begin{align}
+        \big(\Lambda^{\otimes N}\phi\big)\big|_{[i,i+L-1],\tau}
+         & =\Lambda^{\otimes L}\sum_{\omega}c_{\tau}(\omega)\,
+        \phi\big|_{[i,i+L-1],\omega},
+        \label{eq:cyclic_restrict_tensor_pow}
+    \end{align}
+    where the sum runs over the configurations $\omega\in\Fin{d}^{N}$ that agree
+    with $\tau$ on the window, and
+    $c_\tau(\omega)=\prod_{k\notin[i,i+L-1]}\Lambda_{\tau_k\omega_k}$ is the product
+    of the entries of $\Lambda$ over the sites outside the window.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Evaluate both sides at a window word $\sigma$. On the left,
+    $\prod_{k}\Lambda_{\rho_k\rho'_k}$ for the configuration $\rho$ obtained from
+    $\sigma$ and $\tau$ splits as the product over the window, which is
+    $\prod_{r}\Lambda_{\sigma_r\rho'_{i+r}}$, times the product over the
+    complement, which is $c_\tau(\rho')$. On the right, the pair $(\sigma',\omega)$
+    of a window word and a configuration is exchanged with the pair consisting of
+    the window of $\omega$ and the configuration obtained from $\omega$ by inserting
+    $\sigma'$; this exchange is an involution, and after it the constraint that
+    $\omega$ agree with $\tau$ on the window collapses the sum over $\sigma'$ to a
+    single term. The two sides then agree term by term.
+\end{proof}
+
+\begin{theorem}[Ground-space correspondence]\label{thm:chain_ground_space_physical_rotation}
+    \lean{MPSTensor.map_chainGroundSpace_le_chainGroundSpace_rotatePhysical}
+    \lean{MPSTensor.chainGroundSpace_rotatePhysical}
+    \lean{MPSTensor.ker_parentHamiltonian_rotatePhysical}
+    \leanok
+    \uses{def:physical_rotation, def:on_site_tensor_pow, def:chain_ground_space, def:parent_hamiltonian}
+    Let $\Lambda\in\MN{d}$ be invertible. Then, for all $L$ and $N$,
+    \begin{align}
+        \mathcal G_{N,L}(\Lambda A) & =\Lambda^{\otimes N}\,\mathcal G_{N,L}(A),
+        \label{eq:chain_ground_space_physical_rotation}
+    \end{align}
+    and for $0<N$ and $L\le N$ the kernels of the parent Hamiltonians satisfy
+    $\ker H_N(\Lambda A)=\Lambda^{\otimes N}\ker H_N(A)$. This is the one-to-one
+    correspondence, through $R^{\otimes N}$, between the ground states of the parent
+    Hamiltonians of $\ket\psi$ and $\ket{\psi'}=R^{\otimes N}\ket\psi$ for an
+    invertible map $R$ stated in \cite[Section~IV.C]{Cirac2021Matrix}. Without
+    invertibility, the inclusion
+    $\Lambda^{\otimes N}\mathcal G_{N,L}(A)\subseteq\mathcal G_{N,L}(\Lambda A)$
+    still holds.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:cyclic_restrict_tensor_pow, thm:ground_space_physical_rotation, lem:on_site_tensor_pow_mul, thm:parent_hamiltonian_kernel_eq_chain_ground_space}
+    Let $\phi\in\mathcal G_{N,L}(A)$, so that every window restriction of $\phi$
+    lies in $G_L(A)$. By (\ref{eq:cyclic_restrict_tensor_pow}), every window
+    restriction of $\Lambda^{\otimes N}\phi$ is $\Lambda^{\otimes L}$ applied to a
+    linear combination of window restrictions of $\phi$, hence lies in
+    $\Lambda^{\otimes L}G_L(A)=G_L(\Lambda A)$ by
+    (\ref{eq:ground_space_physical_rotation}). This proves the inclusion
+    $\Lambda^{\otimes N}\mathcal G_{N,L}(A)\subseteq\mathcal G_{N,L}(\Lambda A)$
+    for every $\Lambda$. Applying it to $\Lambda^{-1}$ and $\Lambda A$ gives
+    $(\Lambda^{-1})^{\otimes N}\mathcal G_{N,L}(\Lambda A)\subseteq\mathcal G_{N,L}(A)$,
+    and composing with $\Lambda^{\otimes N}$ gives the reverse inclusion. The kernel
+    statement follows from
+    Theorem~\ref{thm:parent_hamiltonian_kernel_eq_chain_ground_space}.
+\end{proof}
+
+\begin{theorem}[Uniqueness of the ground state is preserved]\label{thm:unique_ground_state_physical_rotation}
+    \lean{MPSTensor.onSiteTensorPowEquiv}
+    \lean{MPSTensor.hasUniqueGroundState_chainGroundSpace_rotatePhysical}
+    \leanok
+    \uses{def:physical_rotation, def:chain_ground_space, def:has_unique_ground_state}
+    Let $\Lambda\in\MN{d}$ be invertible. If $\dim\mathcal G_{N,L}(A)=1$, then
+    $\dim\mathcal G_{N,L}(\Lambda A)=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:chain_ground_space_physical_rotation, lem:on_site_tensor_pow_mul}
+    By (\ref{eq:chain_ground_space_physical_rotation}), $\mathcal G_{N,L}(\Lambda A)$
+    is the image of $\mathcal G_{N,L}(A)$ under the linear automorphism
+    $\Lambda^{\otimes N}$, which preserves dimension.
+\end{proof}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -2092,7 +2092,7 @@ spectral split → block extraction → MPV calculation → strict bounds
   `TNLean/MPS/MPDO/InvariantProjection.lean:122`,
   `TNLean/MPS/MPDO/LemmaC5CaseI.lean:194`,
   `TNLean/MPS/ParentHamiltonian/MixedGram.lean:97`, and
-  `TNLean/MPS/Periodic/Applications.lean:173`.
+  `TNLean/MPS/Periodic/Applications.lean:105`.
   It first commutes the outer binders and then descends through one of them;
   `Finset.sum_comm` already owns the permutation step.
 - **Abstraction (proposed):** a two-binder congruence lemma supporting a


### PR DESCRIPTION
### Motivation
- Closes #7678: the ground-space correspondence under an invertible on-site map was absent; only the virtual gauge (`GaugeEquiv.groundSpace_eq`), blocking, and site-relabeling transports existed, and `rotatePhysical` had never met `groundSpace`.
- Source: `Papers/2011.12127/TN-Review-main.tex:2032-2038` (equation `eq:4:deformed-parent-1`; "Clearly, the kernel of $h'$ is $\mathcal G_L$ ... (This technique can more generally be seen as establishing a one-to-one correspondence between ground states of the parent Hamiltonians of two PEPS $\ket\psi$ and $\ket{\psi'}=R^{\otimes N}\ket A$ which are related by an invertible map $R$ ...)"), reused at `:2190-2192` ("$h'=({\Lambda^{-1}}^\dagger)^{\otimes k}h(\Lambda^{-1})^{\otimes k}$ is a parent Hamiltonian for $A$") and `:2260-2262` (physical perturbations $A^i\to\sum\Lambda_{ij}A^j$). The general parent-interaction notion is the source Definition at `:1996-1999` ("any hermitian positive semidefinite operator $h\ge0$ acting on $L$ sites, whose kernel equals $\mathcal G_L$").
- The source states the correspondence for tensor network states on a general graph; this PR formalizes the 1D (periodic MPS chain) instance and says so in the module docstring and the blueprint section. The 2D target type does not exist yet (#7681).

### Description
- New `TNLean/MPS/Core/PhysicalRotation.lean`: `rotatePhysical`, `rotatePhysical_apply`, `evalWord_rotatePhysical_ofFn`, `mpv_rotatePhysical` moved verbatim out of `TNLean/MPS/Periodic/Applications.lean` (which now imports the new module), so the parent-Hamiltonian layer reuses the existing mixing map without importing the periodic fundamental-theorem stack. New lemmas `rotatePhysical_one`, `rotatePhysical_rotatePhysical`.
- New `TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean`:
  - `onSiteTensorPow L Λ`: the tensor power $\Lambda^{\otimes L}$ as a matrix on $L$-site configurations, $(\Lambda^{\otimes L})_{\sigma\tau}=\prod_n\Lambda_{\sigma_n\tau_n}$; multiplicativity, identity, conjugate transpose, and two-sided inverse for `IsUnit Λ`, all derived from the existing blocked Kronecker lift `blockKron` through `decodeBlockEquiv`.
  - `mpv_rotatePhysical_eq_toLin'`: $\ket{\psi'}=\Lambda^{\otimes N}\ket\psi$ (`:2036`).
  - (a) `groundSpaceMap_rotatePhysical`, `groundSpace_rotatePhysical`, `groundSpaceES_rotatePhysical`: $\mathcal G_L(\Lambda A)=\Lambda^{\otimes L}\mathcal G_L(A)$ (no invertibility needed).
  - (b) `IsParentInteraction A L h` (the source Definition, `:1996-1999`: `h.IsPositive` and `LinearMap.ker h = groundSpaceES A L`), `isParentInteraction_parentInteractionES`, `deformedInteraction L Λ h := ((Λ⁻¹)ᴴ)^{⊗L} ∘ h ∘ (Λ⁻¹)^{⊗L}`, `deformedInteraction_isPositive`, `ker_deformedInteraction`, and `IsParentInteraction.deformedInteraction` (`IsUnit Λ → IsParentInteraction A L h → IsParentInteraction (rotatePhysical Λ A) L (deformedInteraction L Λ h)`), the statement at `:2190-2192`.
  - (c) `cyclicRestrictₗ_toLin'_onSiteTensorPow`: the window/complement factorization of $\Lambda^{\otimes N}$ (the printed operator $X$ acting as $\Lambda$ on the window sites and $\Lambda^{-1}$ elsewhere, `:2035-2037`); `map_chainGroundSpace_le_chainGroundSpace_rotatePhysical` (any $\Lambda$); `chainGroundSpace_rotatePhysical` (`IsUnit Λ`: $\mathcal G_{N,L}(\Lambda A)=\Lambda^{\otimes N}\mathcal G_{N,L}(A)$, no restriction on $N,L$); `ker_parentHamiltonian_rotatePhysical` ($\ker H_N(\Lambda A)=\Lambda^{\otimes N}\ker H_N(A)$ for $0<N$, $L\le N$, the convention range of `ker_parentHamiltonian_eq_chainGroundSpace`).
  - The printed uniqueness transport `:2037-2038`: `onSiteTensorPowEquiv`, `hasUniqueGroundState_chainGroundSpace_rotatePhysical`.
- Hypothesis set: invertibility of $\Lambda$ only (`IsUnit Λ`), exactly the source's $\Lambda^{-1}$ / "invertible map $R$"; the unitary lemmas in `Periodic/Applications.lean` are not used. Part (a) and the inclusion half of (c) carry no hypothesis at all. No paper-gap note is needed: the source writes $\Lambda^{-1}$ explicitly.
- Blueprint: new `blueprint/src/chapter/ch13_parent_hamiltonian_physical_deformation.tex` (Chapter 13, input after the blocking-transport section), anchored to `\cite[Section~IV.C]{Cirac2021Matrix}`; formatted with the pinned `scripts/latexindent`.
- `docs/tactic_patterns.md`: one line reference into `Periodic/Applications.lean` updated for the moved declarations. Import aggregators regenerated.
- No `sorry`, `axiom`, `admit`, or `native_decide`.

### Testing
- `lake env lean` on `TNLean/MPS/Core/PhysicalRotation.lean`, `TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean`, and `TNLean/MPS/Periodic/Applications.lean`: clean, no warnings (elaboration only; it does not apply the package linter options).
- Locked build: queued behind a long-running build on the shared lock at PR-open time; the CI run on this branch is the linter-bearing verification.
- `rg -n "sorry|axiom|admit|native_decide" TNLean/MPS/Core/PhysicalRotation.lean TNLean/MPS/ParentHamiltonian/PhysicalDeformation.lean` (clean).
- `python3 scripts/blueprint_lean_sync.py --ci` (in sync), `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`, `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`, `python3 scripts/generate_import_aggregators.py --check`, `python3 scripts/check_oversized_lean_files.py`, `python3 scripts/check_numbered_lean_files.py`: all pass.
- `leanblueprint checkdecls`: deferred to CI (needs the locked build artifacts).

---
Closes #7678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQjCasbTYwhGgFVWiajwLm
