### PR TITLE
feat(Algebra): pull back scalar cohomology and extend subgroup representatives

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -12,6 +12,7 @@ import TNLean.Algebra.BlockingSignParity
 import TNLean.Algebra.CentralStarSubalgebraMatrix
 import TNLean.Algebra.CircleCohomology
 import TNLean.Algebra.CocycleCohomology
+import TNLean.Algebra.CocycleRestriction
 import TNLean.Algebra.CommonBufferLength
 import TNLean.Algebra.CommonFixedSubmodule
 import TNLean.Algebra.CommutingProjectionProduct

--- a/TNLean/Algebra/CocycleRestriction.lean
+++ b/TNLean/Algebra/CocycleRestriction.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CocycleCohomology
+
+/-!
+# Pullback of scalar cohomology and exact extension from a subgroup
+
+Pullback descends to the existing quotient of genuine `ℂˣ`-valued cocycles.
+A subgroup cocycle class lies in the range of restriction precisely when its
+chosen representative extends exactly to an ambient cocycle. The proof extends
+a subgroup cochain and adjusts the ambient representative by its coboundary.
+
+This is standard supporting representative adjustment implicit in
+arXiv:2502.20257, Proposition `prop:BI_psi`
+(`Papers/2502.20257/main.tex:7042--7064`), not the full block-independence
+criterion. We work with `ℂˣ` coefficients; no comparison with `U(1)` is asserted.
+No normality, finiteness, transitivity, or cocycle normalization is required.
+-/
+
+namespace TNLean.Algebra
+
+variable {G K : Type*} [Group G] [Group K]
+
+/-- Pull back a scalar 2-cochain along a group homomorphism. -/
+def ScalarCocycle.pullback (f : K →* G) (ω : ScalarCocycle G) : ScalarCocycle K :=
+  fun a b ↦ ω (f a) (f b)
+
+@[simp]
+theorem ScalarCocycle.pullback_apply (f : K →* G) (ω : ScalarCocycle G) (a b : K) :
+    ω.pullback f a b = ω (f a) (f b) := rfl
+
+/-- Pullback preserves the cocycle equation. -/
+theorem ScalarCocycle.IsCocycle.pullback {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (f : K →* G) : (ω.pullback f).IsCocycle := by
+  intro a b c
+  simpa only [ScalarCocycle.pullback_apply, map_mul] using hω (f a) (f b) (f c)
+
+/-- Precomposing the witnessing cochain makes pullback respect cohomology. -/
+theorem ScalarCocycle.CohomologousTo.pullback {ω₁ ω₂ : ScalarCocycle G}
+    (h : ω₁.CohomologousTo ω₂) (f : K →* G) :
+    (ω₁.pullback f).CohomologousTo (ω₂.pullback f) := by
+  obtain ⟨φ, hφ⟩ := h
+  exact ⟨φ ∘ f, fun a b ↦ by simpa using hφ (f a) (f b)⟩
+
+/-- Multiplying a genuine cocycle by a cochain coboundary preserves its equation. -/
+theorem ScalarCocycle.IsCocycle.coboundary_mul {ω : ScalarCocycle G}
+    (hω : ω.IsCocycle) (φ : G → ℂˣ) :
+    ScalarCocycle.IsCocycle (fun a b ↦ φ a * φ b * (φ (a * b))⁻¹ * ω a b) := by
+  intro a b c
+  calc
+    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
+        (ω a b * ω (a * b) c) := by simp [mul_assoc, mul_comm, mul_left_comm]
+    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
+        (ω a (b * c) * ω b c) := by rw [hω a b c]
+    _ = _ := by simp [mul_assoc, mul_comm, mul_left_comm]
+
+/-- Contravariant pullback on the existing genuine-cocycle cohomology quotient. -/
+def H2.pullback (f : K →* G) : H2 G → H2 K :=
+  Quotient.map (fun ω ↦ ⟨ω.1.pullback f, ω.2.pullback f⟩)
+    (fun _ _ h ↦ ScalarCocycle.CohomologousTo.pullback h f)
+
+/-- Pullback of a class is represented by pullback of its cocycle. -/
+@[simp]
+theorem H2.pullback_mk (f : K →* G) (ω : ScalarCocycle G) (hω : ω.IsCocycle) :
+    H2.pullback f (Quotient.mk _ ⟨ω, hω⟩) =
+      Quotient.mk _ ⟨ω.pullback f, hω.pullback f⟩ := rfl
+
+/-- Exact representative extension is equivalent to extension of the class.
+
+This is the supporting cochain adjustment implicit in arXiv:2502.20257,
+Proposition `prop:BI_psi` (`main.tex:7042--7064`), for `ℂˣ` coefficients.
+The subgroup is arbitrary, and the cocycles need not be normalized. -/
+theorem H2.mem_range_pullback_subtype_iff (H : Subgroup G)
+    (ψ : ScalarCocycle H) (hψ : ψ.IsCocycle) :
+    Quotient.mk _ ⟨ψ, hψ⟩ ∈ Set.range (H2.pullback H.subtype) ↔
+      ∃ Ψ : ScalarCocycle G, Ψ.IsCocycle ∧ ∀ a b : H, Ψ (a : G) (b : G) = ψ a b := by
+  classical
+  constructor
+  · rintro ⟨q, hq⟩
+    induction q using Quotient.inductionOn with
+    | _ ω =>
+      have hcoh : ψ.CohomologousTo (ω.1.pullback H.subtype) :=
+        Quotient.exact hq.symm
+      obtain ⟨φ, hφ⟩ := hcoh
+      let Φ : G → ℂˣ := Function.extend Subtype.val φ (fun _ ↦ 1)
+      have hΦ (a : H) : Φ (a : G) = φ a :=
+        Subtype.val_injective.extend_apply φ (fun _ ↦ 1) a
+      refine ⟨fun a b ↦ Φ a * Φ b * (Φ (a * b))⁻¹ * ω.1 a b,
+        ω.2.coboundary_mul Φ, ?_⟩
+      intro a b
+      change Φ (a : G) * Φ (b : G) * (Φ ((a : G) * (b : G)))⁻¹ *
+        ω.1 (a : G) (b : G) = ψ a b
+      rw [hΦ a, hΦ b, ← Subgroup.coe_mul, hΦ (a * b)]
+      exact (hφ a b).symm
+  · rintro ⟨Ψ, hΨ, heq⟩
+    refine ⟨Quotient.mk _ ⟨Ψ, hΨ⟩, ?_⟩
+    apply Quotient.sound
+    have hp : Ψ.pullback H.subtype = ψ := funext fun a ↦ funext fun b ↦ heq a b
+    change (Ψ.pullback H.subtype).CohomologousTo ψ
+    rw [hp]
+    exact ScalarCocycle.CohomologousTo.refl ψ
+
+end TNLean.Algebra

--- a/TNLean/Algebra/CocycleRestriction.lean
+++ b/TNLean/Algebra/CocycleRestriction.lean
@@ -28,6 +28,7 @@ variable {G K : Type*} [Group G] [Group K]
 def ScalarCocycle.pullback (f : K →* G) (ω : ScalarCocycle G) : ScalarCocycle K :=
   fun a b ↦ ω (f a) (f b)
 
+/-- Evaluate a pulled-back cochain by applying the homomorphism to both arguments. -/
 @[simp]
 theorem ScalarCocycle.pullback_apply (f : K →* G) (ω : ScalarCocycle G) (a b : K) :
     ω.pullback f a b = ω (f a) (f b) := rfl
@@ -43,7 +44,8 @@ theorem ScalarCocycle.CohomologousTo.pullback {ω₁ ω₂ : ScalarCocycle G}
     (h : ω₁.CohomologousTo ω₂) (f : K →* G) :
     (ω₁.pullback f).CohomologousTo (ω₂.pullback f) := by
   obtain ⟨φ, hφ⟩ := h
-  exact ⟨φ ∘ f, fun a b ↦ by simpa using hφ (f a) (f b)⟩
+  refine ⟨φ ∘ f, fun a b ↦ ?_⟩
+  simpa only [ScalarCocycle.pullback_apply, Function.comp_apply, map_mul] using hφ (f a) (f b)
 
 /-- Multiplying a genuine cocycle by a cochain coboundary preserves its equation. -/
 theorem ScalarCocycle.IsCocycle.coboundary_mul {ω : ScalarCocycle G}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2560,21 +2560,39 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     \label{def:mpug_h2_pullback}
     \lean{TNLean.Algebra.ScalarCocycle.pullback,
         TNLean.Algebra.ScalarCocycle.pullback_apply,
-        TNLean.Algebra.ScalarCocycle.IsCocycle.pullback,
-        TNLean.Algebra.ScalarCocycle.CohomologousTo.pullback,
         TNLean.Algebra.H2.pullback,
         TNLean.Algebra.H2.pullback_mk}
     \leanok
-    \uses{def:h2_cx, def:cohomologous_to, def:is_cocycle}
+    \uses{def:h2_cx}
     Let $f:K\to G$ be a group homomorphism. For a scalar $2$-cochain
     $\omega:G\times G\to\C^\times$, define
     $(f^*\omega)(a,b)=\omega(f(a),f(b))$.
-    Pullback preserves the cocycle equation. If $\omega_1$ and $\omega_2$
-    differ by the coboundary of $\varphi:G\to\C^\times$, their pullbacks
-    differ by the coboundary of $\varphi\circ f$. Thus pullback defines
-    $f^*:H^2(G,\C^\times)\to H^2(K,\C^\times)$ by
+    The induced pullback map
+    $f^*:H^2(G,\C^\times)\to H^2(K,\C^\times)$ is defined by
     $f^*[\omega]=[f^*\omega]$.
 \end{definition}
+
+\begin{theorem}[Pullback preserves cocycles and cohomology]
+    \label{thm:mpug_h2_pullback_preserves}
+    \lean{TNLean.Algebra.ScalarCocycle.IsCocycle.pullback,
+        TNLean.Algebra.ScalarCocycle.CohomologousTo.pullback}
+    \leanok
+    \uses{def:mpug_h2_pullback, def:cohomologous_to, def:is_cocycle}
+    Let $f:K\to G$ be a group homomorphism. If $\omega$ is a scalar
+    $2$-cocycle on $G$, then $f^*\omega$ is a scalar $2$-cocycle on $K$.
+    If $\omega_1$ and $\omega_2$ are cohomologous scalar $2$-cochains on $G$,
+    then $f^*\omega_1$ and $f^*\omega_2$ are cohomologous on $K$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_h2_pullback, def:cohomologous_to, def:is_cocycle}
+    For $a,b,c\in K$, substitute $f(a),f(b),f(c)$ in the cocycle equation
+    for $\omega$ and use $f(ab)=f(a)f(b)$ and $f(bc)=f(b)f(c)$.
+    If $\omega_1(g,h)=\varphi(g)\varphi(h)\varphi(gh)^{-1}\omega_2(g,h)$,
+    set $\eta=\varphi\circ f$. Substituting $g=f(a)$ and $h=f(b)$ gives
+    $(f^*\omega_1)(a,b)=\eta(a)\eta(b)\eta(ab)^{-1}(f^*\omega_2)(a,b)$,
+    so $\eta$ witnesses the required cohomology relation.
+\end{proof}
 
 % Partial support for #7361 (child #7754), not the full prop:BI_psi criterion.
 % No U(1) restriction naturality or tensor-level block-independence claim.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2556,6 +2556,62 @@ Theorems~\ref{thm:mpug_factorization_comparison} and
     % Rep.ofMulDistribMulAction with the explicit trivial action.
 \end{definition}
 
+\begin{definition}[Pullback of scalar cohomology]
+    \label{def:mpug_h2_pullback}
+    \lean{TNLean.Algebra.ScalarCocycle.pullback,
+        TNLean.Algebra.ScalarCocycle.pullback_apply,
+        TNLean.Algebra.ScalarCocycle.IsCocycle.pullback,
+        TNLean.Algebra.ScalarCocycle.CohomologousTo.pullback,
+        TNLean.Algebra.H2.pullback,
+        TNLean.Algebra.H2.pullback_mk}
+    \leanok
+    \uses{def:h2_cx, def:cohomologous_to, def:is_cocycle}
+    Let $f:K\to G$ be a group homomorphism. For a scalar $2$-cochain
+    $\omega:G\times G\to\C^\times$, define
+    $(f^*\omega)(a,b)=\omega(f(a),f(b))$.
+    Pullback preserves the cocycle equation. If $\omega_1$ and $\omega_2$
+    differ by the coboundary of $\varphi:G\to\C^\times$, their pullbacks
+    differ by the coboundary of $\varphi\circ f$. Thus pullback defines
+    $f^*:H^2(G,\C^\times)\to H^2(K,\C^\times)$ by
+    $f^*[\omega]=[f^*\omega]$.
+\end{definition}
+
+% Partial support for #7361 (child #7754), not the full prop:BI_psi criterion.
+% No U(1) restriction naturality or tensor-level block-independence claim.
+\begin{theorem}[Exact extension of a subgroup cocycle]
+    \label{thm:mpug_h2_exact_extension}
+    \lean{TNLean.Algebra.H2.mem_range_pullback_subtype_iff,
+        TNLean.Algebra.ScalarCocycle.IsCocycle.coboundary_mul}
+    \leanok
+    \uses{def:mpug_h2_pullback, def:is_cocycle}
+    Let $H\le G$ be any subgroup, let $\iota:H\hookrightarrow G$ be its
+    inclusion, and let $\psi:H\times H\to\C^\times$ be a $2$-cocycle.
+    Then $[\psi]$ belongs to the image of $\iota^*$ if and only if there is
+    a $2$-cocycle $\Psi:G\times G\to\C^\times$ with
+    $\Psi(a,b)=\psi(a,b)$ for every $a,b\in H$.
+    No normalization of either cocycle is required.
+    This is the representative adjustment implicit in the extension
+    condition of \cite[lines~7042--7064]{FrancoRubio2025MPUGauging},
+    here stated with $\C^\times$ coefficients.
+    % Source: Papers/2502.20257/main.tex:7042--7064.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_h2_pullback, def:cohomologous_to, def:is_cocycle}
+    Suppose $[\psi]=\iota^*[\omega]$. Choose a cochain
+    $\varphi:H\to\C^\times$ such that
+    $\psi(a,b)=\varphi(a)\varphi(b)\varphi(ab)^{-1}\omega(a,b)$.
+    Extend $\varphi$ to a function $\Phi:G\to\C^\times$, taking value $1$
+    outside $H$, and set
+    $\Psi(g,h)=\Phi(g)\Phi(h)\Phi(gh)^{-1}\omega(g,h)$.
+    In the cocycle equation for $\Psi$, cancellation leaves the common
+    factor $\Phi(g)\Phi(h)\Phi(k)\Phi(ghk)^{-1}$ multiplied by the two sides
+    of the cocycle equation for $\omega$. Hence $\Psi$ is a cocycle, and
+    $\Phi|_H=\varphi$ gives $\Psi|_{H\times H}=\psi$ exactly.
+    Conversely, any exact extension $\Psi$ satisfies
+    $\iota^*[\Psi]=[\psi]$.
+\end{proof}
+
 \begin{theorem}[Circle and nonzero-complex coefficients in degree two]
     \label{thm:mpug_circle_complex_units_h2}
     \lean{TNLean.Algebra.Complex.div_toUnits_unitsPhase,


### PR DESCRIPTION
### Motivation
- Supply the independent class-restriction slice of #7361, tracked by native child #7754 (assigned to @me).
- Source: `Papers/2502.20257/main.tex:7042–7064`, Proposition `prop:BI_psi`: “the cocycle ψ extends to G”. The representative adjustment below is standard supporting mathematics implicit in that condition, not a separately printed proof or a paper defect.

### Description
- Add `TNLean/Algebra/CocycleRestriction.lean`: universe-polymorphic scalar cochain pullback, preservation of cocycles and cohomology, and `H2.pullback` with a representative simp theorem on the existing genuine-cocycle quotient. No additional quotient.
- Prove `H2.mem_range_pullback_subtype_iff`: for every subgroup H ≤ G and genuine ℂˣ-valued cocycle ψ on H, [ψ] is in the image of restriction iff an ambient genuine cocycle restricts exactly to ψ.
- Extend the witnessing cochain using `Function.extend` and `Subtype.val_injective.extend_apply`; multiply the ambient cocycle by its coboundary and cancel to prove the cocycle equation. No normality, finiteness, transitivity, or normalized-cocycle assumptions.
- Add separate Blueprint pullback and exact-extension entries and regenerate the Algebra import aggregator.
- Keep #7361 open: no tensor/full block-independence criterion, no U(1) restriction naturality or Mathlib comparison naturality asserted. Do not touch the independently owned `StabilizerCocycleExtension.lean` or add a paper-gap note.

### Testing
- `lake env lean TNLean/Algebra/CocycleRestriction.lean` — pass.
- `scripts/lake_build_locked.sh TNLean.Algebra.CocycleRestriction` — pass, linter-bearing build; only new module built (21s), all dependencies reused from safely seeded primary cache.
- `lake env .lake/build/bin/lint_style` — pass.
- `lake env lean TNLean/Algebra.lean` — pass.
- `python3 scripts/generate_import_aggregators.py --check` — pass.
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base b1c226856 --changed-files TNLean/Algebra/CocycleRestriction.lean` — pass; no missing new declaration coverage.
- Compiled-module `#check` for all 8 new Blueprint references, with universes displayed — pass. Target theorem's `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`.
- Proof-integrity scan and `git diff --check` — pass. Algebra tactic-pattern scan found existing patterns, none introduced by this module.
- Full-root `leanblueprint checkdecls` and web/PDF rendering not run; new references checked against the compiled scoped module instead, without broad builds or Mathlib rebuilding.

Closes #7754
Addresses #7361
