### PR TITLE
feat(MPS/Examples): prove GHZ-cluster representation and literal action table

### DIFF
--- a/TNLean/MPS/Examples.lean
+++ b/TNLean/MPS/Examples.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.GHZCluster
+import TNLean.MPS.Examples.GHZClusterAction
 import TNLean.MPS.Examples.GHZParentHamiltonian
 import TNLean.MPS.Examples.MajumdarGhosh
 import TNLean.MPS.Examples.WState

--- a/TNLean/MPS/Examples/GHZClusterAction.lean
+++ b/TNLean/MPS/Examples/GHZClusterAction.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.Examples.GHZCluster
 The onsite representation and virtual matrices of arXiv:2502.20257,
 `example:z4z2`, lines 4481–4489. Physical coordinates are
 `|p,s,r⟩ ↔ 4*p + 2*s + r`: the blocked cluster tensor stores its first
-factor in the least significant bit. Thus physical qubits 2 and 3 correspond
+factor as the units digit of `q = 2*s + r`. Thus physical qubits 2 and 3 correspond
 to the second and first stored cluster factors, respectively.
 
 Only the representation and block covariance are treated here, not L-symbols,
@@ -176,7 +176,7 @@ theorem z4z2GHZClusterVirtual_sq (g : ZMod 4 × ZMod 2) (x : Fin 2) :
     simp [z4z2GHZClusterVirtual, z4z2GHZClusterPauliY, pauliX_literal, pauliZ,
       Matrix.one_fin_two]
 
-/-- The onsite matrix action on each block is implemented by the literal
+/-- The onsite matrix action on each block is given by the literal
 virtual representative, while its block label changes by parity of `a`.
 This is the block action claim of arXiv:2502.20257, `example:z4z2`;
 no normalization claim about defect tensors is made here. -/
@@ -197,7 +197,7 @@ theorem z4z2GHZClusterBlock_covariance (g : Multiplicative (ZMod 4 × ZMod 2))
   simp only [← mul_assoc, z4z2GHZClusterVirtual_sq, one_mul]
   rw [mul_assoc, z4z2GHZClusterVirtual_sq, mul_one]
 
-/-- On the unbroken subgroup `(2a,b)`, the table is the existing cluster
+/-- On the unbroken subgroup `(2a,b)`, the table is the cluster
 projective representation with swapped physical coordinates and the literal
 phase `-i` at `(a,b)=(1,1)`. In particular the Y entries are not the real
 product ZX. Source: arXiv:2502.20257, line 4489. -/

--- a/TNLean/MPS/Examples/GHZClusterAction.lean
+++ b/TNLean/MPS/Examples/GHZClusterAction.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MonomialMatrix
+import TNLean.MPS.Examples.GHZCluster
+
+/-!
+# The GHZ–cluster physical representation and literal action table
+
+The onsite representation and virtual matrices of arXiv:2502.20257,
+`example:z4z2`, lines 4481–4487. Physical coordinates are
+`|p,s,r⟩ ↔ 4*p + 2*s + r`: the blocked cluster tensor stores its first
+factor in the least significant bit. Thus physical qubits 2 and 3 correspond
+to the second and first stored cluster factors, respectively.
+
+Only the representation and block covariance are treated here, not L-symbols,
+block independence, defect normalization, or gauging.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPSTensor
+
+/-- The physical basis permutation for `(a,b)`, obtained by applying
+`(X₁ ⊗ X₂) CNOT₁→₂` `a` times and `X₃` `b` times.
+Source: arXiv:2502.20257, `example:z4z2`. -/
+def z4z2GHZClusterBasisAction (g : ZMod 4 × ZMod 2) (i : Fin 8) : Fin 8 :=
+  finProdFinEquiv
+    ((![![0, 1, 2, 3], ![3, 2, 0, 1], ![1, 0, 3, 2], ![2, 3, 1, 0]]
+      g.1 ((finProdFinEquiv (m := 4) (n := 2)).symm i).1 : Fin 4),
+      ((finProdFinEquiv (m := 4) (n := 2)).symm i).2 + (⟨g.2.val, g.2.val_lt⟩ : Fin 2))
+
+private theorem basisAction_zero : ∀ i, z4z2GHZClusterBasisAction 0 i = i := by decide
+
+private theorem basisAction_add : ∀ g h i,
+    z4z2GHZClusterBasisAction (g + h) i =
+      z4z2GHZClusterBasisAction g (z4z2GHZClusterBasisAction h i) := by decide
+
+/-- The finite permutation representation underlying the onsite symmetry. -/
+def z4z2GHZClusterPerm : Multiplicative (ZMod 4 × ZMod 2) →* Equiv.Perm (Fin 8) where
+  toFun g :=
+    { toFun := z4z2GHZClusterBasisAction g.toAdd
+      invFun := z4z2GHZClusterBasisAction (-g.toAdd)
+      left_inv i := by rw [← basisAction_add, neg_add_cancel]; exact basisAction_zero i
+      right_inv i := by rw [← basisAction_add, add_neg_cancel]; exact basisAction_zero i }
+  map_one' := Equiv.ext basisAction_zero
+  map_mul' g h := Equiv.ext (basisAction_add g.toAdd h.toAdd)
+
+/-- The source's onsite Z₄ × Z₂ representation as eight-dimensional matrices. -/
+noncomputable def z4z2GHZClusterAction :
+    Multiplicative (ZMod 4 × ZMod 2) →* Matrix (Fin 8) (Fin 8) ℂ where
+  toFun g := monomial (z4z2GHZClusterPerm g) (fun _ ↦ 1)
+  map_one' := by rw [map_one]; exact monomial_one
+  map_mul' g h := by simp [monomial_mul_monomial]
+
+/-- Every physical action matrix is unitary. -/
+theorem z4z2GHZClusterAction_unitary (g : Multiplicative (ZMod 4 × ZMod 2)) :
+    z4z2GHZClusterAction g ∈ Matrix.unitaryGroup (Fin 8) ℂ :=
+  monomial_mem_unitaryGroup _ _ (by simp)
+
+/-- The literal Pauli Y, including its imaginary phases, in the source table. -/
+noncomputable def z4z2GHZClusterPauliY : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![0, -Complex.I; Complex.I, 0]
+
+/-- The two rows of the action table of arXiv:2502.20257, lines 4483–4487.
+The inner columns are ordered `(0,0),(0,1),(1,0),(1,1),...,(3,1)`;
+this is the printed table reordered by the standard product coordinates. -/
+noncomputable def z4z2GHZClusterVirtual (g : ZMod 4 × ZMod 2) (x : Fin 2) :
+    Matrix (Fin 2) (Fin 2) ℂ :=
+  (![![![1, pauliZ], ![pauliX, z4z2GHZClusterPauliY],
+        ![pauliX, z4z2GHZClusterPauliY], ![1, pauliZ]],
+      ![![1, pauliZ], ![1, pauliZ],
+        ![pauliX, z4z2GHZClusterPauliY], ![pauliX, z4z2GHZClusterPauliY]]]
+      x) g.1 g.2
+
+/-- The action on block labels is parity of the first group coordinate. -/
+def z4z2GHZClusterBlockAction (g : ZMod 4 × ZMod 2) (x : Fin 2) : Fin 2 :=
+  x + ⟨g.1.val % 2, Nat.mod_lt _ (by decide)⟩
+
+private theorem clusterBlocked_table (q : Fin 4) :
+    clusterBlocked q =
+      ![(1 / 2 : ℂ) • !![1, 0; 1, 0], (1 / 2 : ℂ) • !![1, 0; -1, 0],
+        (1 / 2 : ℂ) • !![0, 1; 0, 1], (1 / 2 : ℂ) • !![0, -1; 0, 1]] q := by
+  fin_cases q <;> simp
+
+private theorem block_table (x : Fin 2) (i : Fin 8) :
+    z4z2GHZClusterBlock x i =
+      if ((finProdFinEquiv (m := 2) (n := 4)).symm i).1 = x then
+        clusterBlocked ((finProdFinEquiv (m := 2) (n := 4)).symm i).2 else 0 := by
+  simpa using z4z2GHZClusterBlock_apply x
+    ((finProdFinEquiv (m := 2) (n := 4)).symm i).1
+    ((finProdFinEquiv (m := 2) (n := 4)).symm i).2
+
+private theorem pauliX_literal : pauliX = !![0, 1; 1, 0] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [pauliX]
+
+private theorem I_mul_mul_I (c : ℂ) : Complex.I * (c * Complex.I) = -c := by
+  rw [mul_left_comm, Complex.I_mul_I, mul_neg_one]
+
+/-- Every literal action tensor is Hermitian. -/
+theorem z4z2GHZClusterVirtual_adjoint (g : ZMod 4 × ZMod 2) (x : Fin 2) :
+    (z4z2GHZClusterVirtual g x)ᴴ = z4z2GHZClusterVirtual g x := by
+  rcases g with ⟨a, b⟩
+  fin_cases x <;> fin_cases a <;> fin_cases b <;>
+    (ext j k; fin_cases j <;> fin_cases k <;>
+      simp [z4z2GHZClusterVirtual, z4z2GHZClusterPauliY, pauliX, pauliZ,
+        Matrix.conjTranspose_apply])
+
+set_option maxHeartbeats 1600000 in
+-- Check eight group elements, two block labels, and eight physical coordinates.
+/-- Exact covariance for all sixteen virtual matrices in the printed table.
+The physical index is transported forward by the onsite permutation.
+Source: arXiv:2502.20257, `example:z4z2`, lines 4481–4487. -/
+theorem z4z2GHZClusterBlock_transport (g : ZMod 4 × ZMod 2) (x : Fin 2) (i : Fin 8) :
+    z4z2GHZClusterBlock (z4z2GHZClusterBlockAction g x)
+        (z4z2GHZClusterBasisAction g i) =
+      z4z2GHZClusterVirtual g x * z4z2GHZClusterBlock x i *
+        (z4z2GHZClusterVirtual g x)ᴴ := by
+  rcases g with ⟨a, b⟩
+  rw [z4z2GHZClusterVirtual_adjoint]
+  simp only [block_table, clusterBlocked_table]
+  fin_cases a <;> fin_cases b <;> fin_cases x <;> fin_cases i <;>
+    simp [z4z2GHZClusterBlockAction, z4z2GHZClusterBasisAction,
+      z4z2GHZClusterVirtual, z4z2GHZClusterPauliY, pauliX_literal, pauliZ,
+      finProdFinEquiv, Fin.divNat, Fin.modNat, Fin.add_def, ZMod.val,
+      mul_assoc, I_mul_mul_I]
+
+/-- Three-qubit coordinates, with the source's qubit order. -/
+def z4z2GHZClusterIndex (p s r : Fin 2) : Fin 8 :=
+  finProdFinEquiv (p, finProdFinEquiv (s, r))
+
+/-- The source generators and the square of the first generator, stated on
+computational basis columns. These are precisely `(X₁⊗X₂) CNOT₁→₂`, `X₃`,
+and `X₂`, respectively (arXiv:2502.20257, lines 4481 and 4487). -/
+theorem z4z2GHZClusterAction_generators (p s r : Fin 2) (i : Fin 8) :
+    (z4z2GHZClusterAction (.ofAdd (1, 0)) i (z4z2GHZClusterIndex p s r) =
+      if i = z4z2GHZClusterIndex (p + 1) (s + p + 1) r then 1 else 0) ∧
+    (z4z2GHZClusterAction (.ofAdd (0, 1)) i (z4z2GHZClusterIndex p s r) =
+      if i = z4z2GHZClusterIndex p s (r + 1) then 1 else 0) ∧
+    (z4z2GHZClusterAction (.ofAdd (2, 0)) i (z4z2GHZClusterIndex p s r) =
+      if i = z4z2GHZClusterIndex p (s + 1) r then 1 else 0) := by
+  have h : ∀ p s r,
+      z4z2GHZClusterBasisAction (1, 0) (z4z2GHZClusterIndex p s r) =
+        z4z2GHZClusterIndex (p + 1) (s + p + 1) r ∧
+      z4z2GHZClusterBasisAction (0, 1) (z4z2GHZClusterIndex p s r) =
+        z4z2GHZClusterIndex p s (r + 1) ∧
+      z4z2GHZClusterBasisAction (2, 0) (z4z2GHZClusterIndex p s r) =
+        z4z2GHZClusterIndex p (s + 1) r := by decide
+  simp [z4z2GHZClusterAction, monomial_apply, z4z2GHZClusterPerm,
+    (h p s r).1, (h p s r).2.1, (h p s r).2.2]
+
+/-- The exact table in the paper's printed column order, with no projective
+replacement of Y by a real Pauli product. -/
+theorem z4z2GHZClusterVirtual_table :
+    (fun x : Fin 2 ↦ ![z4z2GHZClusterVirtual (0, 0) x,
+      z4z2GHZClusterVirtual (2, 0) x, z4z2GHZClusterVirtual (0, 1) x,
+      z4z2GHZClusterVirtual (2, 1) x, z4z2GHZClusterVirtual (1, 0) x,
+      z4z2GHZClusterVirtual (3, 0) x, z4z2GHZClusterVirtual (1, 1) x,
+      z4z2GHZClusterVirtual (3, 1) x]) =
+    ![![1, pauliX, pauliZ, z4z2GHZClusterPauliY, pauliX, 1,
+        z4z2GHZClusterPauliY, pauliZ],
+      ![1, pauliX, pauliZ, z4z2GHZClusterPauliY, 1, pauliX,
+        pauliZ, z4z2GHZClusterPauliY]] := by
+  funext x
+  fin_cases x <;> rfl
+
+/-- All virtual representatives in the literal table are involutions. -/
+theorem z4z2GHZClusterVirtual_sq (g : ZMod 4 × ZMod 2) (x : Fin 2) :
+    z4z2GHZClusterVirtual g x * z4z2GHZClusterVirtual g x = 1 := by
+  rcases g with ⟨a, b⟩
+  fin_cases x <;> fin_cases a <;> fin_cases b <;>
+    simp [z4z2GHZClusterVirtual, z4z2GHZClusterPauliY, pauliX_literal, pauliZ,
+      Matrix.one_fin_two]
+
+/-- The onsite matrix action on each block is implemented by the literal
+virtual representative, while its block label changes by parity of `a`.
+This is the block action claim of arXiv:2502.20257, `example:z4z2`;
+no normalization claim about defect tensors is made here. -/
+theorem z4z2GHZClusterBlock_covariance (g : Multiplicative (ZMod 4 × ZMod 2))
+    (x : Fin 2) (i : Fin 8) :
+    twistedTensor (z4z2GHZClusterBlock x) z4z2GHZClusterAction g i =
+      z4z2GHZClusterVirtual g.toAdd x *
+        z4z2GHZClusterBlock (z4z2GHZClusterBlockAction g.toAdd x) i *
+        (z4z2GHZClusterVirtual g.toAdd x)ᴴ := by
+  obtain ⟨j, rfl⟩ := (z4z2GHZClusterPerm g).surjective i
+  have htw : twistedTensor (z4z2GHZClusterBlock x) z4z2GHZClusterAction g
+      (z4z2GHZClusterPerm g j) = z4z2GHZClusterBlock x j := by
+    simp [twistedTensor, z4z2GHZClusterAction, monomial_apply,
+      (z4z2GHZClusterPerm g).injective.eq_iff]
+  rw [htw]
+  change _ = _ * z4z2GHZClusterBlock _ (z4z2GHZClusterBasisAction g.toAdd j) * _
+  rw [z4z2GHZClusterBlock_transport, z4z2GHZClusterVirtual_adjoint]
+  simp only [← mul_assoc, z4z2GHZClusterVirtual_sq, one_mul]
+  rw [mul_assoc, z4z2GHZClusterVirtual_sq, mul_one]
+
+/-- On the unbroken subgroup `(2a,b)`, the table is the existing cluster
+projective representation with swapped physical coordinates and the literal
+phase `-i` at `(a,b)=(1,1)`. In particular the Y entries are not the real
+product ZX. Source: arXiv:2502.20257, line 4487. -/
+theorem z4z2GHZClusterVirtual_stabilizer (a b : ZMod 2) (x : Fin 2) :
+    z4z2GHZClusterVirtual (2 * (a.val : ZMod 4), b) x =
+      (if a = 1 ∧ b = 1 then -Complex.I else 1) •
+        (clusterProjRep.X (.ofAdd (b, a)) : Matrix (Fin 2) (Fin 2) ℂ) := by
+  have hv : ∀ (a b : ZMod 2) (x : Fin 2),
+      z4z2GHZClusterVirtual (2 * (a.val : ZMod 4), b) x =
+        if a = 0 then (if b = 0 then 1 else pauliZ)
+        else (if b = 0 then pauliX else z4z2GHZClusterPauliY) := by
+    intro a b x
+    fin_cases a <;> fin_cases b <;> fin_cases x <;> rfl
+  rw [hv]
+  have h : ∀ a : ZMod 2, a = 0 ∨ a = 1 := by decide
+  rcases h a with rfl | rfl <;> rcases h b with rfl | rfl <;>
+    norm_num [z4z2GHZClusterPauliY, clusterProjRep, clusterRepX,
+      pauliX_literal, pauliZ, Matrix.one_fin_two]
+
+end MPSTensor

--- a/TNLean/MPS/Examples/GHZClusterAction.lean
+++ b/TNLean/MPS/Examples/GHZClusterAction.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.Examples.GHZCluster
 # The GHZ–cluster physical representation and literal action table
 
 The onsite representation and virtual matrices of arXiv:2502.20257,
-`example:z4z2`, lines 4481–4487. Physical coordinates are
+`example:z4z2`, lines 4481–4489. Physical coordinates are
 `|p,s,r⟩ ↔ 4*p + 2*s + r`: the blocked cluster tensor stores its first
 factor in the least significant bit. Thus physical qubits 2 and 3 correspond
 to the second and first stored cluster factors, respectively.
@@ -135,7 +135,7 @@ def z4z2GHZClusterIndex (p s r : Fin 2) : Fin 8 :=
 
 /-- The source generators and the square of the first generator, stated on
 computational basis columns. These are precisely `(X₁⊗X₂) CNOT₁→₂`, `X₃`,
-and `X₂`, respectively (arXiv:2502.20257, lines 4481 and 4487). -/
+and `X₂`, respectively (arXiv:2502.20257, lines 4481 and 4489). -/
 theorem z4z2GHZClusterAction_generators (p s r : Fin 2) (i : Fin 8) :
     (z4z2GHZClusterAction (.ofAdd (1, 0)) i (z4z2GHZClusterIndex p s r) =
       if i = z4z2GHZClusterIndex (p + 1) (s + p + 1) r then 1 else 0) ∧
@@ -200,7 +200,7 @@ theorem z4z2GHZClusterBlock_covariance (g : Multiplicative (ZMod 4 × ZMod 2))
 /-- On the unbroken subgroup `(2a,b)`, the table is the existing cluster
 projective representation with swapped physical coordinates and the literal
 phase `-i` at `(a,b)=(1,1)`. In particular the Y entries are not the real
-product ZX. Source: arXiv:2502.20257, line 4487. -/
+product ZX. Source: arXiv:2502.20257, line 4489. -/
 theorem z4z2GHZClusterVirtual_stabilizer (a b : ZMod 2) (x : Fin 2) :
     z4z2GHZClusterVirtual (2 * (a.val : ZMod 4), b) x =
       (if a = 1 ∧ b = 1 then -Complex.I else 1) •

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4114,13 +4114,10 @@ scalar calculation above.
     $Y=\left(\begin{smallmatrix}0&-i\\i&0\end{smallmatrix}\right)$:
     \begin{center}
         \begin{tabular}{ccccccccc}
-            \toprule
             $g$   & $(0,0)$ & $(2,0)$ & $(0,1)$ & $(2,1)$
                   & $(1,0)$ & $(3,0)$ & $(1,1)$ & $(3,1)$                             \\
-            \midrule
             $x=0$ & $\Id$   & $X$     & $Z$     & $Y$     & $X$   & $\Id$ & $Y$ & $Z$ \\
             $x=1$ & $\Id$   & $X$     & $Z$     & $Y$     & $\Id$ & $X$   & $Z$ & $Y$ \\
-            \bottomrule
         \end{tabular}
     \end{center}
     Every $V_{g,x}$ is Hermitian and squares to the identity. For every

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4113,11 +4113,14 @@ scalar calculation above.
     Let $V_{g,x}$ be given by the following table, where
     $Y=\left(\begin{smallmatrix}0&-i\\i&0\end{smallmatrix}\right)$:
     \begin{center}
-        \begin{tabular}{c|cccccccc}
+        \begin{tabular}{ccccccccc}
+            \toprule
             $g$   & $(0,0)$ & $(2,0)$ & $(0,1)$ & $(2,1)$
-                  & $(1,0)$ & $(3,0)$ & $(1,1)$ & $(3,1)$                             \\\hline
+                  & $(1,0)$ & $(3,0)$ & $(1,1)$ & $(3,1)$                             \\
+            \midrule
             $x=0$ & $\Id$   & $X$     & $Z$     & $Y$     & $X$   & $\Id$ & $Y$ & $Z$ \\
-            $x=1$ & $\Id$   & $X$     & $Z$     & $Y$     & $\Id$ & $X$   & $Z$ & $Y$
+            $x=1$ & $\Id$   & $X$     & $Z$     & $Y$     & $\Id$ & $X$   & $Z$ & $Y$ \\
+            \bottomrule
         \end{tabular}
     \end{center}
     Every $V_{g,x}$ is Hermitian and squares to the identity. For every
@@ -4131,7 +4134,7 @@ scalar calculation above.
     cluster virtual representatives $W_{(b,a)}=Z^bX^a$ is
     $V_{(2a,b),x}=(-i)^{ab}W_{(b,a)}$.
     These are the physical representation and matrix action identities of
-    \cite[lines~4481--4487]{FrancoRubio2025MPUGauging}.
+    \cite[lines~4481--4489]{FrancoRubio2025MPUGauging}.
     % Scoped calculation only: no defect normalization, L-symbols,
     % cocycle nonextension, block independence, or gauging is asserted.
     % Those remaining parts of example:z4z2 stay open in #7352.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4140,7 +4140,7 @@ scalar calculation above.
 \begin{proof}\leanok
     \uses{def:mpug_ghz_blocked_cluster_tensor}
     On basis vectors the generators send $(p,s,r)$ to $(p+1,s+p+1,r)$
-    and $(p,s,r+1)$, with bit arithmetic modulo two. Their permutations
+    and $(p,s,r+1)$, with coordinates added modulo two. Their permutations
     have orders four and two and commute. The corresponding permutation
     matrices are unitary and preserve multiplication.
     Substitute $A_x^{(p,q)}=\delta_{p,x}C^q$ into

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4096,6 +4096,9 @@ scalar calculation above.
         MPSTensor.z4z2GHZClusterAction,
         MPSTensor.z4z2GHZClusterAction_unitary,
         MPSTensor.z4z2GHZClusterAction_generators,
+        MPSTensor.z4z2GHZClusterIndex,
+        MPSTensor.z4z2GHZClusterBlockAction,
+        MPSTensor.z4z2GHZClusterVirtual,
         MPSTensor.z4z2GHZClusterVirtual_table,
         MPSTensor.z4z2GHZClusterVirtual_adjoint,
         MPSTensor.z4z2GHZClusterVirtual_sq,
@@ -4132,13 +4135,15 @@ scalar calculation above.
     $V_{(2a,b),x}=(-i)^{ab}W_{(b,a)}$.
     These are the physical representation and matrix action identities of
     \cite[lines~4481--4489]{FrancoRubio2025MPUGauging}.
+    No claim is made about defect normalization, $L$-symbols, cocycle
+    nonextension, block independence, or gauging.
     % Scoped calculation only: no defect normalization, L-symbols,
     % cocycle nonextension, block independence, or gauging is asserted.
     % Those remaining parts of example:z4z2 stay open in #7352.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_ghz_blocked_cluster_tensor}
+    \uses{def:mpug_ghz_blocked_cluster_tensor, thm:mpug_monomial_matrix_laws}
     On basis vectors the generators send $(p,s,r)$ to $(p+1,s+p+1,r)$
     and $(p,s,r+1)$, with coordinates added modulo two. Their permutations
     have orders four and two and commute. The corresponding permutation

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4089,6 +4089,69 @@ scalar calculation above.
     (\ref{eq:mpug_ghz_blocked_cluster_direct_sum}).
 \end{proof}
 
+\begin{theorem}[GHZ--cluster physical representation and virtual action table]
+    \label{thm:mpug_ghz_cluster_action_table}
+    % Principal declaration: MPSTensor.z4z2GHZClusterBlock_covariance.
+    \lean{MPSTensor.z4z2GHZClusterBlock_covariance,
+        MPSTensor.z4z2GHZClusterAction,
+        MPSTensor.z4z2GHZClusterAction_unitary,
+        MPSTensor.z4z2GHZClusterAction_generators,
+        MPSTensor.z4z2GHZClusterVirtual_table,
+        MPSTensor.z4z2GHZClusterVirtual_adjoint,
+        MPSTensor.z4z2GHZClusterVirtual_sq,
+        MPSTensor.z4z2GHZClusterVirtual_stabilizer}
+    \leanok
+    \discussion{7747}
+    \uses{def:mpug_ghz_blocked_cluster_tensor}
+    Write the physical basis as $|p,s,r\rangle$, with integer index
+    $4p+2s+r$ for $p,s,r\in\{0,1\}$. Thus the blocked cluster index is
+    $q=2s+r$. The operators
+    $U_{(1,0)}=(X_1\otimes X_2)\mathrm{CNOT}_{1\to2}$ and
+    $U_{(0,1)}=X_3$ generate a unitary representation of
+    $G=\Z_4\times\Z_2$, with $U_{(2,0)}=X_2$.
+    Put $g\cdot x=x+a\pmod 2$ for $g=(a,b)$ and $x\in\{0,1\}$.
+    Let $V_{g,x}$ be given by the following table, where
+    $Y=\left(\begin{smallmatrix}0&-i\\i&0\end{smallmatrix}\right)$:
+    \begin{center}
+        \begin{tabular}{c|cccccccc}
+            $g$   & $(0,0)$ & $(2,0)$ & $(0,1)$ & $(2,1)$
+                  & $(1,0)$ & $(3,0)$ & $(1,1)$ & $(3,1)$                             \\\hline
+            $x=0$ & $\Id$   & $X$     & $Z$     & $Y$     & $X$   & $\Id$ & $Y$ & $Z$ \\
+            $x=1$ & $\Id$   & $X$     & $Z$     & $Y$     & $\Id$ & $X$   & $Z$ & $Y$
+        \end{tabular}
+    \end{center}
+    Every $V_{g,x}$ is Hermitian and squares to the identity. For every
+    physical index $i$, the blocks satisfy
+    \begin{align}
+        \sum_j (U_g)_{i,j} A_x^j
+         & =V_{g,x}A_{g\cdot x}^iV_{g,x}^{\dagger}.
+        \label{eq:mpug_ghz_cluster_block_covariance}
+    \end{align}
+    On the subgroup $H=\{(2a,b):a,b\in\{0,1\}\}$, the comparison with the
+    cluster virtual representatives $W_{(b,a)}=Z^bX^a$ is
+    $V_{(2a,b),x}=(-i)^{ab}W_{(b,a)}$.
+    These are the physical representation and matrix action identities of
+    \cite[lines~4481--4487]{FrancoRubio2025MPUGauging}.
+    % Scoped calculation only: no defect normalization, L-symbols,
+    % cocycle nonextension, block independence, or gauging is asserted.
+    % Those remaining parts of example:z4z2 stay open in #7352.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_ghz_blocked_cluster_tensor}
+    On basis vectors the generators send $(p,s,r)$ to $(p+1,s+p+1,r)$
+    and $(p,s,r+1)$, with bit arithmetic modulo two. Their permutations
+    have orders four and two and commute. The corresponding permutation
+    matrices are unitary and preserve multiplication.
+    Substitute $A_x^{(p,q)}=\delta_{p,x}C^q$ into
+    (\ref{eq:mpug_ghz_cluster_block_covariance}). For each of the eight group
+    elements and two block labels, matrix multiplication gives the displayed
+    table. Hermiticity and $V_{g,x}^2=\Id$ turn forward transport of the
+    physical index into the stated conjugation identity.
+    Finally, $ZX=iY$, so the only phase needed to compare the restriction
+    with $Z^bX^a$ is $-i$ when $a=b=1$.
+\end{proof}
+
 \section{The gauge-invariant subspace of the CZX circuit tuple}
 \label{sec:mpug_czx_gauge_invariant}
 


### PR DESCRIPTION
## Summary

Closes #7747. Partial progress on #7352; **leave #7352 open**.

Formalizes the source-calculation slice of arXiv:2502.20257, `example:z4z2`, lines 4481–4489:

- finite permutation homomorphism and unitary matrix representation of Z₄×Z₂;
- computational-basis formulas for `(X₁⊗X₂) CNOT₁→₂`, `X₃`, and `U_(2,0)=X₂`;
- the exact 16-entry source table in its printed column order, with literal `Y = [[0,-i],[i,0]]` (not a projective real-matrix substitute);
- Hermitian/involutive virtual matrices, forward block transport, and covariance against the existing `twistedTensor`;
- exact stabilizer comparison with `clusterProjRep`: swapped cluster coordinates and phase `-i` at `(1,1)`.

Reuses `z4z2GHZClusterBlock` and its block formula, the existing cluster tensor/projective representation, and `Matrix.monomial` multiplication/unitarity. Physical basis order is explicitly `|p,s,r⟩ ↔ 4p+2s+r`, with stored cluster index `q=2s+r`; this accounts for the cluster blocking convention's least-significant-first factors.

Adds one scoped Blueprint theorem, with the covariance theorem as principal declaration. This does **not** mark the full example complete or claim defect normalization, L-symbols, cocycle nonextension, block independence, fusion modifications, or gauging. No new proof debt, axioms, or API removals.

## Verification

Worktree `/private/tmp/tnlean-session-7352`, branched from `origin/main` at `b1c226856`; warm cache seeded using the repository script from the identical-commit primary worktree. No primary-branch edits, root Lake build, or Mathlib build.

- Targeted elaboration with package linter options, **zero errors/warnings**:
  ```sh
  scripts/lake_build_locked.sh -- /usr/bin/time -p lake env lean \
    -DrelaxedAutoImplicit=false -Dweak.linter.mathlibStandardSet=true \
    -DmaxSynthPendingDepth=3 \
    -o .lake/build/lib/lean/TNLean/MPS/Examples/GHZClusterAction.olean \
    TNLean/MPS/Examples/GHZClusterAction.lean
  ```
  Last local timing: 50.78s wall, 24.65s user, 8.24s system (shared machine; compile-time CI remains to be observed).
- All eight new Blueprint-linked declarations checked by Lean importing the emitted module.
- `#print axioms` for covariance, stabilizer comparison, and physical representation: only `propext`, `Classical.choice`, `Quot.sound`.
- `python3 scripts/blueprint_lean_sync.py --ci --changed-files TNLean/MPS/Examples/GHZClusterAction.lean`: PASS; 7918/7918 references in sync.
- `python3 scripts/generate_import_aggregators.py --check`: PASS.
- Pinned latexindent 3.24.7, formatting followed by the CI temporary-copy/byte-comparison gate on the changed chapter: PASS.
- `git diff --check` and forbidden-proof-token scan: PASS.

Full root build and full Blueprint rendering/checkdecls were intentionally not run under the targeted-check constraint.


Citation/style follow-up: corrected the subgroup and squared-generator references to source line 4489. Removed the table rules (without adding a LaTeX package dependency) after inspecting the Blueprint CI chktex failure; changed-chapter chktex and pinned formatter byte-comparison now pass. No Lean statements or proofs changed. The scope statement concerns this new theorem and open #7352, not an existing Blueprint node named `example:z4z2`.
