### PR TITLE
feat(MPS/MPDO): restate the CZX gauge-invariant dimension in the library subspace

### DIFF
--- a/TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean
@@ -38,10 +38,13 @@ By the monomial fixed-space criterion, a fiber contributes one dimension exactly
 when $b=0$, and there are $2^N$ such fibers.
 
 The same value is recorded for the gauge-invariant subspace
-$\mathcal V_N(R)$ of a completion, whose general lower bound
-$\dim\mathcal V_N(R)\geq1$ is stated for that subspace; the two spellings of
-the placed projector as a linear map agree, so the exact value and the lower
-bound speak about one subspace.
+$\mathcal V_N(R)$ that the general theory attaches to an arbitrary tuple $R$:
+the two spellings of the placed projector as a linear map agree, so the exact
+dimension of the displayed tuple is a statement about that subspace. Whether
+the displayed tuple is a completion of prescribed defect maps carrying matter
+defect states with local defect support, exact defect covariance, and a
+nonvanishing gauged vector, the hypotheses under which the general lower bound
+$\dim\mathcal V_N(R)\geq1$ is available, is not settled here.
 
 The theorems concern the displayed circuit tuple acting through the local
 Gauss operator. They do not identify this tuple with a member of the full
@@ -551,17 +554,21 @@ theorem finrank_commonFixedSubmodule_placedGaussProjector_circuitTuple (N : ℕ)
       right_inv := fun p ↦ rfl }
   rw [Nat.card_congr hequiv, Nat.card_eq_fintype_card, Fintype.card_pi_const, ZMod.card]
 
-/-- **The exact dimension in the gauge-invariant subspace of a completion.** On a
-periodic chain of $N\geq3$ blocked sites with two matter qubits and one gauge
-qubit per site, the gauge-invariant subspace $\mathcal V_N(R^{\mathrm{CZX}})$ of
-the displayed CZX circuit tuple
+/-- **The exact dimension in the gauge-invariant subspace of the displayed
+tuple.** On a periodic chain of $N\geq3$ blocked sites with two matter qubits and
+one gauge qubit per site, the gauge-invariant subspace
+$\mathcal V_N(R^{\mathrm{CZX}})$ of the displayed CZX circuit tuple
 $R^{\mathrm{CZX}}=(\mathrm{id},\mathrm{id},w,\tilde\lambda)$ has dimension $2^N$.
 
-This restates the exact dimension for the subspace carrying the general lower
-bound $\dim\mathcal V_N(R)\geq1$, so that the exact value and that bound are
-statements about one subspace. The two descriptions of a placed Gauss projector
-as a linear map on the configuration space agree, and no part of the orbit,
-holonomy, or fiber count is repeated.
+This restates the exact dimension for the subspace that the general theory
+attaches to an arbitrary tuple, the two descriptions of a placed Gauss projector
+as a linear map on the configuration space being the same map; no part of the
+orbit, holonomy, or fiber count is repeated. It does not verify, for the
+displayed tuple, the hypotheses under which the general lower bound
+$\dim\mathcal V_N(R)\geq1$ is available: a completion of prescribed defect maps
+and matter defect states with local defect support, exact defect covariance, and
+a nonvanishing gauged vector. Only once those are supplied do the exact value
+and the lower bound stand beside each other.
 
 Sources: arXiv:2502.20257, lines 4503--5183 for the CZX matrix product unitary,
 its defect and fusion data, the gauged matrix product state, and the modified

--- a/TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean
+++ b/TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.MonomialFixedSubspace
 import TNLean.MPS.MPDO.CZXGaussCircuitTuple
 import TNLean.MPS.MPDO.EmbedLocalOperatorMonomial
+import TNLean.MPS.MPDO.GaugeInvariantSubspace
 import TNLean.MPS.MPDO.GaussProjectorPlacement
 
 /-!
@@ -36,8 +37,14 @@ $(G_jG_{j+1})^2\ket{s}=(-1)^{b_{j+1}(s)}\ket{s}$.
 By the monomial fixed-space criterion, a fiber contributes one dimension exactly
 when $b=0$, and there are $2^N$ such fibers.
 
-The theorem concerns the displayed circuit tuple acting through the local
-Gauss operator. It does not identify this tuple with a member of the full
+The same value is recorded for the gauge-invariant subspace
+$\mathcal V_N(R)$ of a completion, whose general lower bound
+$\dim\mathcal V_N(R)\geq1$ is stated for that subspace; the two spellings of
+the placed projector as a linear map agree, so the exact value and the lower
+bound speak about one subspace.
+
+The theorems concern the displayed circuit tuple acting through the local
+Gauss operator. They do not identify this tuple with a member of the full
 physical completion class of the CZX defect data, which would require the
 three defect domains and maps not supplied by the displayed matrices.
 -/
@@ -543,5 +550,37 @@ theorem finrank_commonFixedSubmodule_placedGaussProjector_circuitTuple (N : ℕ)
         rfl
       right_inv := fun p ↦ rfl }
   rw [Nat.card_congr hequiv, Nat.card_eq_fintype_card, Fintype.card_pi_const, ZMod.card]
+
+/-- **The exact dimension in the gauge-invariant subspace of a completion.** On a
+periodic chain of $N\geq3$ blocked sites with two matter qubits and one gauge
+qubit per site, the gauge-invariant subspace $\mathcal V_N(R^{\mathrm{CZX}})$ of
+the displayed CZX circuit tuple
+$R^{\mathrm{CZX}}=(\mathrm{id},\mathrm{id},w,\tilde\lambda)$ has dimension $2^N$.
+
+This restates the exact dimension for the subspace carrying the general lower
+bound $\dim\mathcal V_N(R)\geq1$, so that the exact value and that bound are
+statements about one subspace. The two descriptions of a placed Gauss projector
+as a linear map on the configuration space agree, and no part of the orbit,
+holonomy, or fiber count is repeated.
+
+Sources: arXiv:2502.20257, lines 4503--5183 for the CZX matrix product unitary,
+its defect and fusion data, the gauged matrix product state, and the modified
+Gauss law; lines 5198--5204 for the growth question that the value $2^N$
+answers for this one tuple.
+
+This statement concerns the displayed circuit tuple only. It makes no claim that
+the tuple belongs to the full physical completion class of the CZX defect data,
+which would require the defect domains and maps that the displayed matrices do
+not supply, and it says nothing about the minimum or the maximum of the
+dimension over completions. -/
+theorem finrank_gaugeInvariantSubspace_circuitTuple (N : ℕ) (hN : 3 ≤ N) :
+    Module.finrank ℂ
+      (gaugeInvariantSubspace 4 (Multiplicative (ZMod 2)) N (by omega) circuitTuple) = 2 ^ N := by
+  have hsubspace : gaugeInvariantSubspace 4 (Multiplicative (ZMod 2)) N (by omega) circuitTuple =
+      LinearMap.commonFixedSubmodule fun j : Fin N ↦
+        toLin' (placedGaussProjector 4 (Multiplicative (ZMod 2)) N (by omega) j circuitTuple) := by
+    simp only [gaugeInvariantSubspace, Matrix.toLin'_apply']
+  rw [hsubspace]
+  exact finrank_commonFixedSubmodule_placedGaussProjector_circuitTuple N hN
 
 end MPOTensor.CZX

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4780,7 +4780,7 @@ by the displayed matrices.
     \label{thm:mpug_czx_dimension_of_completion}
     \lean{MPOTensor.CZX.finrank_gaugeInvariantSubspace_circuitTuple}
     \leanok
-    \uses{thm:mpug_czx_dimension, def:mpug_gauge_invariant_subspace}
+    \uses{def:mpug_gauge_invariant_subspace, def:mpug_czx_circuit_tuple}
     For the gauge-invariant subspace~(\ref{eq:mpug_gauge_invariant_subspace}) at
     $R=R^{\mathrm{CZX}}$ and $N\geq3$,
     $\dim_{\C}\mathcal V_N(R^{\mathrm{CZX}})=2^N$. The value is thereby

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4776,17 +4776,22 @@ by the displayed matrices.
     \end{align}
 \end{proof}
 
-\begin{theorem}[The CZX dimension in the gauge-invariant subspace of a completion]
+\begin{theorem}[The CZX dimension in the gauge-invariant subspace of the displayed tuple]
     \label{thm:mpug_czx_dimension_of_completion}
     \lean{MPOTensor.CZX.finrank_gaugeInvariantSubspace_circuitTuple}
     \leanok
     \uses{thm:mpug_czx_dimension, def:mpug_gauge_invariant_subspace}
     For the gauge-invariant subspace~(\ref{eq:mpug_gauge_invariant_subspace}) at
     $R=R^{\mathrm{CZX}}$ and $N\geq3$,
-    $\dim_{\C}\mathcal V_N(R^{\mathrm{CZX}})=2^N$. The exact value and the
-    lower bound $\dim_{\C}\mathcal V_N(R)\geq1$ of
-    Theorem~\ref{thm:mpug_gauge_invariant_subspace_finrank} therefore concern
-    the same subspace of the same chain. The statement is about the displayed
+    $\dim_{\C}\mathcal V_N(R^{\mathrm{CZX}})=2^N$. The value is thereby
+    recorded for the subspace that
+    Definition~\ref{def:mpug_gauge_invariant_subspace} attaches to an arbitrary
+    tuple, so exhibiting $R^{\mathrm{CZX}}$ as a completion of prescribed
+    defect maps with matter defect states satisfying local defect support,
+    exact defect covariance, and nonvanishing of the gauged vector would put
+    the exact value beside the lower bound $\dim_{\C}\mathcal V_N(R)\geq1$ of
+    Theorem~\ref{thm:mpug_gauge_invariant_subspace_finrank}. None of those
+    hypotheses is established here. The statement is about the displayed
     circuit tuple and asserts no membership in the full physical completion
     class of the CZX defect data.
 \end{theorem}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -4776,6 +4776,30 @@ by the displayed matrices.
     \end{align}
 \end{proof}
 
+\begin{theorem}[The CZX dimension in the gauge-invariant subspace of a completion]
+    \label{thm:mpug_czx_dimension_of_completion}
+    \lean{MPOTensor.CZX.finrank_gaugeInvariantSubspace_circuitTuple}
+    \leanok
+    \uses{thm:mpug_czx_dimension, def:mpug_gauge_invariant_subspace}
+    For the gauge-invariant subspace~(\ref{eq:mpug_gauge_invariant_subspace}) at
+    $R=R^{\mathrm{CZX}}$ and $N\geq3$,
+    $\dim_{\C}\mathcal V_N(R^{\mathrm{CZX}})=2^N$. The exact value and the
+    lower bound $\dim_{\C}\mathcal V_N(R)\geq1$ of
+    Theorem~\ref{thm:mpug_gauge_invariant_subspace_finrank} therefore concern
+    the same subspace of the same chain. The statement is about the displayed
+    circuit tuple and asserts no membership in the full physical completion
+    class of the CZX defect data.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_dimension, def:mpug_placed_gauss_projector}
+    Both subspaces are the common fixed subspace of the placed Gauss
+    projectors $\widetilde P_j(R^{\mathrm{CZX}})$ of
+    Definition~\ref{def:mpug_placed_gauss_projector} acting on the
+    configuration space of the chain, so
+    Theorem~\ref{thm:mpug_czx_dimension} gives the value.
+\end{proof}
+
 \subsection{A second displayed circuit tuple at three and four sites}
 
 The source constrains the block $U_{1,1}$ of (\ref{eq:mpug_czx_tuple}) only


### PR DESCRIPTION
## Sources

- `Papers/2502.20257/main.tex:4503-5183` — the CZX matrix product unitary, its defect and fusion data, the gauged matrix product state, and the modified Gauss law.
- `Papers/2502.20257/main.tex:5198-5204` — the question whether the common gauge-invariant subspace stays bounded or grows with the system size.

## What is proved

`MPOTensor.CZX.finrank_gaugeInvariantSubspace_circuitTuple` in
`TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean`:

```
Module.finrank ℂ
    (gaugeInvariantSubspace 4 (Multiplicative (ZMod 2)) N (by omega) circuitTuple) = 2 ^ N
```

for every `3 ≤ N`. This restates the exact dimension already proved in
`MPOTensor.CZX.finrank_commonFixedSubmodule_placedGaussProjector_circuitTuple` for the
subspace `MPOTensor.gaugeInvariantSubspace` that carries the general lower bound
`MPOTensor.one_le_finrank_gaugeInvariantSubspace`, so the exact value and the bound are
statements about one subspace. The proof rewrites the two spellings of the placed Gauss
projector as a linear map through `Matrix.toLin'_apply'` and applies the existing theorem;
the orbit, holonomy, and fiber argument is not repeated, and the existing theorem is
unchanged. The only other Lean change is the import of
`TNLean.MPS.MPDO.GaugeInvariantSubspace` and a module-docstring sentence.

The docstring records the non-goal: the statement concerns the one displayed circuit tuple
and makes no claim that it belongs to the full physical completion class of the CZX defect
data, nor about the minimum or maximum of the dimension over completions.

The consistency corollary against `one_le_finrank_gaugeInvariantSubspace` is skipped: that
bound is stated under defect-support and defect-covariance hypotheses for a completion of
prescribed defect maps, which the displayed tuple does not yet carry (that boundary is
#7569), so it is not a one-liner and its content would be `1 ≤ 2 ^ N`.

## Blueprint

One entry beside `thm:mpug_czx_dimension` in `blueprint/src/chapter/ch29_mpu_gauging.tex`:
`thm:mpug_czx_dimension_of_completion`, with `\lean{}`, `\leanok`, and
`\uses{thm:mpug_czx_dimension, def:mpug_gauge_invariant_subspace}`.

## Validation actually run

- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.CZXGaussInvariantSubspace`, and a full
  `scripts/lake_build_locked.sh` after rebasing onto `origin/main` — 10510 jobs, completed
  successfully, no warnings.
- `rg -n "sorry|axiom|admit|native_decide"` on both changed files — no Lean placeholders.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `--ci` — in sync.
- `lake exe checkdecls blueprint/lean_decls` — clean.
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch29_mpu_gauging.tex` — clean.
- Pinned `scripts/latexindent -w -s -l blueprint/latexindent.yaml` byte comparison on a copy
  of ch29 — identical.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — clean.
- `python3 scripts/tactic_pattern_scan.py` — no pattern from this change; the reported
  clusters are pre-existing and elsewhere.
- `python3 scripts/test_lean_file_policies.py` — 16 tests, OK.
- `git diff --check` — clean.

Closes #7736

🤖 Generated with [Claude Code](https://claude.com/claude-code)