### PR TITLE
ci(workflows): register the 2502.20257 paper source in the path filters

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -12,6 +12,7 @@ on:
       - 'blueprint/src/**'
       - 'docs/paper-gaps/**'
       - 'Papers/1606.00608/**'
+      - 'Papers/2502.20257/**'
       - 'scripts/generate_paper_aux.sh'
       - 'texra-blueprint.toml'
       # Trees the paper-gap reference check scans (texra-blueprint

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -59,6 +59,7 @@ on:
       - 'scripts/audit_cpsv16_labels.py'
       - 'scripts/test_audit_cpsv16_labels.py'
       - 'Papers/1606.00608/**'
+      - 'Papers/2502.20257/**'
       - 'scripts/generate_paper_aux.sh'
       - 'docs/audits/2026-05-08-mps-ft-paper-coverage.md'
       - 'docs/audits/2026-08-10-cpsv16-every-label-audit.md'
@@ -122,6 +123,7 @@ on:
       - 'scripts/audit_cpsv16_labels.py'
       - 'scripts/test_audit_cpsv16_labels.py'
       - 'Papers/1606.00608/**'
+      - 'Papers/2502.20257/**'
       - 'scripts/generate_paper_aux.sh'
       - 'docs/audits/2026-05-08-mps-ft-paper-coverage.md'
       - 'docs/audits/2026-08-10-cpsv16-every-label-audit.md'
@@ -221,6 +223,7 @@ jobs:
             paper_gaps:
               - 'docs/paper-gaps/**'
               - 'Papers/1606.00608/**'
+              - 'Papers/2502.20257/**'
               - 'scripts/generate_paper_aux.sh'
               - '**.lean'
               - 'blueprint/src/**'


### PR DESCRIPTION
Adds `Papers/2502.20257/**` beside every existing `Papers/1606.00608/**` entry: the blueprint push filter, and the pr-ci push paths, pull-request paths, and `paper_gaps` change filter. Without it a change confined to that source skipped the paper-gap reference checks and the merge-triggered blueprint publication, so the generated `main-tnlean.aux` and the published gap PDF could go stale against the paper `docs/paper-gaps/fbc25_czx_defect_domains.tex` cites.

`docgen.yml` needs no change: it has no `paths` filter and already generates both auxiliary files unconditionally.

Validation: `python3 -c "import yaml; ..."` parses all three workflows clean; `git diff --check` is clean; `git diff --stat` shows only the two workflow files, +1 line at each of the four sites and no deletions.

Closes #7763

🤖 Generated with [Claude Code](https://claude.com/claude-code)