### PR TITLE
feat(MPS/Periodic): derive the period of an irreducible-form block from irreducibility and spectral radius one

### DIFF
--- a/TNLean/MPS/Periodic.lean
+++ b/TNLean/MPS/Periodic.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.Periodic.EqualCase
 import TNLean.MPS.Periodic.EqualCaseGlobal
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.GlobalGauge
+import TNLean.MPS.Periodic.IrreducibleFormPeriods
 import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 import TNLean.MPS.Periodic.Normalization
 import TNLean.MPS.Periodic.NormalizedSelfOverlap
@@ -36,6 +37,7 @@ import TNLean.MPS.Periodic.Overlap.SectorOverlapTransport
 import TNLean.MPS.Periodic.Overlap.SelfOverlap
 import TNLean.MPS.Periodic.Overlap.SelfOverlapNonrep
 import TNLean.MPS.Periodic.Overlap.SelfOverlapSetup
+import TNLean.MPS.Periodic.PeriodExistence
 import TNLean.MPS.Periodic.ProjectiveRep
 import TNLean.MPS.Periodic.ProportionalOverlap
 import TNLean.MPS.Periodic.SectorContraction

--- a/TNLean/MPS/Periodic/EqualCaseGlobal.lean
+++ b/TNLean/MPS/Periodic/EqualCaseGlobal.lean
@@ -812,17 +812,14 @@ two tensors is conjugated.
 Source: arXiv:1708.00029, theorem `thm:bdequal`, lines 643--693, over the
 irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582.
 
-**Scope restriction (supplied periods):** the periods are received as input,
-together with witnesses that each block is spectrally periodic of the given
-period. The source instead derives the period of a block from irreducibility
-and spectral radius one at lines 257--258, citing Wolf, so that it appears in
-the conclusion of the source theorem rather than among its hypotheses. A reader
-holding only the source's two conditions on the blocks therefore cannot yet
-instantiate this statement; the missing ingredient is the existence half of the
-cyclic peripheral structure. The restriction and its elimination plan are
-recorded in `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`,
-section "Scope restriction: the periods of an irreducible-form block are
-supplied". -/
+The periods are received as input here, together with witnesses that each block
+is spectrally periodic of the given period, whereas the source derives the
+period of a block from irreducibility and spectral radius one at lines
+257--258, citing Wolf. This is the working form; the source statement, with the
+periods produced from the source's two conditions on the blocks, is
+`fundamentalTheorem_periodic_equalCase_derivedPeriods`. See
+`docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex`, section "The
+periods of an irreducible-form block: restriction eliminated". -/
 theorem fundamentalTheorem_periodic_equalCase_irreducibleForm
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ)

--- a/TNLean/MPS/Periodic/IrreducibleFormPeriods.lean
+++ b/TNLean/MPS/Periodic/IrreducibleFormPeriods.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Periodic.EqualCaseGlobal
+import TNLean.MPS.Periodic.PeriodExistence
+
+/-!
+# The periodic fundamental theorems over the source's irreducible form
+
+The source states its two fundamental theorems for tensors in irreducible form,
+where a block is required only to have an irreducible transfer map of spectral
+radius one (arXiv:1708.00029, lines 248--261).  The period of a block is
+derived from those two conditions at lines 257--258 and appears in the
+conclusion of the theorems, not among their hypotheses.
+
+This file restates the proportional case (arXiv:1708.00029, Theorem 3.4, lines
+613--623) and the equal case (Theorem 3.8, lines 643--693) over exactly those
+two conditions, producing the periods rather than receiving them.  The periods
+come from
+`MPSTensor.exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one`.
+
+## Main results
+
+* `MPSTensor.fundamentalTheorem_periodic_proportional_irreducibleForm`
+* `MPSTensor.fundamentalTheorem_periodic_equalCase_derivedPeriods`
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Pérez-García, arXiv:1708.00029, Theorems 3.4
+  and 3.8.
+-/
+
+open scoped Matrix BigOperators Matrix.Norms.Operator
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **Fundamental theorem for matrix product states, proportional case, over
+the source's irreducible form.**
+
+The two block families are required only to be irreducible with transfer maps
+of spectral radius one, which is the source's irreducible form at
+arXiv:1708.00029, lines 248--261.  The periods are produced by the theorem,
+as at lines 257--258, together with the witnesses that each block is spectrally
+periodic of the produced period; the matching bijection then equates the
+periods of matched blocks.
+
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623, over the
+irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582. -/
+theorem fundamentalTheorem_periodic_proportional_irreducibleForm
+    (P Q : SectorDecomposition d)
+    (hIrrP : ∀ j, Kraus.IsIrreducibleFamily (P.basis j))
+    (hRadP : ∀ j,
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap
+            (Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ))
+          (Kraus.transferMap (d := d) (D := P.basisDim j) (P.basis j))) = 1)
+    (hIrrQ : ∀ k, Kraus.IsIrreducibleFamily (Q.basis k))
+    (hRadQ : ∀ k,
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap
+            (Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))
+          (Kraus.transferMap (d := d) (D := Q.basisDim k) (Q.basis k))) = 1)
+    (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
+    (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
+    (hProp : NonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∃ (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ),
+      (∀ j, IsSpectrallyPeriodic (periodP j) (P.basis j)) ∧
+      (∀ k, IsSpectrallyPeriodic (periodQ k) (Q.basis k)) ∧
+      PeriodicBasisMatchingWitness P.basis Q.basis periodP periodQ := by
+  choose periodP hPerP using fun j =>
+    exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one
+      (hIrrP j) (hRadP j)
+  choose periodQ hPerQ using fun k =>
+    exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one
+      (hIrrQ k) (hRadQ k)
+  exact ⟨periodP, periodQ, hPerP, hPerQ,
+    fundamentalTheorem_periodic_proportional_sectorDecomposition P Q periodP periodQ
+      hPerP hPerQ hNonRepP hNonRepQ hProp⟩
+
+/-- **Fundamental theorem for matrix product states, equal case, over the
+source's irreducible form.**
+
+The two block families are required only to be irreducible with transfer maps
+of spectral radius one, which is the source's irreducible form at
+arXiv:1708.00029, lines 248--261.  The periods are produced by the theorem, as
+at lines 257--258, together with the witnesses that each block is spectrally
+periodic of the produced period; every later clause speaks about those same
+periods.
+
+Source: arXiv:1708.00029, theorem `thm:bdequal`, lines 643--693, over the
+irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582. -/
+theorem fundamentalTheorem_periodic_equalCase_derivedPeriods
+    (P Q : SectorDecomposition d)
+    (hIrrP : ∀ j, Kraus.IsIrreducibleFamily (P.basis j))
+    (hRadP : ∀ j,
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap
+            (Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ))
+          (Kraus.transferMap (d := d) (D := P.basisDim j) (P.basis j))) = 1)
+    (hIrrQ : ∀ k, Kraus.IsIrreducibleFamily (Q.basis k))
+    (hRadQ : ∀ k,
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap
+            (Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))
+          (Kraus.transferMap (d := d) (D := Q.basisDim k) (Q.basis k))) = 1)
+    (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
+    (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
+    (hSame : SameMPV₂Pos P.toTensor Q.toTensor) :
+    ∃ (periodP : Fin P.basisCount → ℕ) (periodQ : Fin Q.basisCount → ℕ),
+      (∀ j, IsSpectrallyPeriodic (periodP j) (P.basis j)) ∧
+      (∀ k, IsSpectrallyPeriodic (periodQ k) (Q.basis k)) ∧
+      ∃ (perm : Fin P.basisCount ≃ Fin Q.basisCount) (ξ : Fin P.basisCount → ℂ)
+        (z : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ),
+        (∀ j, ‖ξ j‖ = 1) ∧
+        (∀ j, periodP j = periodQ (perm j)) ∧
+        (∀ j, ScalarGaugeEquiv (ξ j) (P.basis j) (Q.basis (perm j))) ∧
+        (∀ j, HetRepeatedBlocks (P.basis j) (Q.basis (perm j))) ∧
+        (∀ j, Matrix.diagonal (z j) ^ periodP j = 1) ∧
+        (∀ j, ∃ (_hCopies : P.copies j = Q.copies (perm j))
+                (τ : Fin (P.copies j) ≃ Fin (Q.copies (perm j))),
+              Matrix.diagonal (z j) * Matrix.diagonal (fun q => ξ j * P.weight j q) =
+                Matrix.diagonal (fun q => Q.weight (perm j) (τ q))) ∧
+        ∃ (Y : Matrix (Fin P.totalDim) (Fin Q.totalDim) ℂ)
+          (Y' : Matrix (Fin Q.totalDim) (Fin P.totalDim) ℂ),
+          Y * Y' = 1 ∧ Y' * Y = 1 ∧
+          blockScalarMatrix P.flatDim (P.flatCopyScalar z) ^
+            (Finset.univ.lcm periodP) = 1 ∧
+          (∀ i : Fin d,
+            blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+              P.toTensor i * blockScalarMatrix P.flatDim (P.flatCopyScalar z)) ∧
+          (∀ i : Fin d,
+            blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i =
+              Y * Q.toTensor i * Y') ∧
+          SameMPV₂Pos P.toTensor
+            (fun i =>
+              blockScalarMatrix P.flatDim (P.flatCopyScalar z) * P.toTensor i) := by
+  choose periodP hPerP using fun j =>
+    exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one
+      (hIrrP j) (hRadP j)
+  choose periodQ hPerQ using fun k =>
+    exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one
+      (hIrrQ k) (hRadQ k)
+  exact ⟨periodP, periodQ, hPerP, hPerQ,
+    fundamentalTheorem_periodic_equalCase_irreducibleForm P Q periodP periodQ
+      hPerP hPerQ hNonRepP hNonRepQ hSame⟩
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/PeriodExistence.lean
+++ b/TNLean/MPS/Periodic/PeriodExistence.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Analysis.MatrixSqrt
+import QICLean.Channel.Irreducible.AdjointFamily
+import QICLean.Channel.Irreducible.KrausGauge
+import QICLean.Channel.Irreducible.SpectralRadius
+import QICLean.Channel.Peripheral.AdjointSpectrum
+import QICLean.Channel.Peripheral.GroupStructure
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
+import TNLean.MPS.Periodic.Defs
+
+/-!
+# The period of an irreducible-form block
+
+The source defines the irreducible form of a tensor by two conditions on each
+block: the transfer map is an irreducible completely positive map, and its
+spectral radius is one (arXiv:1708.00029, lines 248--261).  The period of such
+a block is not a further hypothesis but a consequence: the eigenvalues of
+modulus one are exactly the `m`-th roots of unity for some positive `m`
+(arXiv:1708.00029, lines 257--258, citing Wolf).
+
+This file derives that consequence.  The block is first put in the
+trace-preserving normalization of `eq:unital` (arXiv:1708.00029, line 316) by
+the positive-definite adjoint Perron fixed point; the normalized block has a
+unital adjoint family, so the cyclic peripheral structure of Wolf Theorem
+6.6(1) applies to it.  The normalization is a similarity, so the peripheral
+spectrum obtained is that of the original block.
+
+## Main results
+
+* `IsPrimitiveRoot.powRange_eq_setOf_pow_eq_one`: the powers of a primitive
+  `m`-th root of unity are exactly the `m`-th roots of unity.
+* `MPSTensor.exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one`:
+  an irreducible tensor of spectral radius one is spectrally periodic of some
+  positive period.
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Pérez-García, arXiv:1708.00029, lines 248--261,
+  257--258 and 313--332.
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem
+  6.6][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder Matrix.Norms.Operator Kraus
+
+/-- The powers of a primitive `m`-th root of unity in `ℂ` are exactly the
+solutions of `μ ^ m = 1`. -/
+theorem IsPrimitiveRoot.powRange_eq_setOf_pow_eq_one {m : ℕ} [NeZero m] {γ : ℂ}
+    (hγ : IsPrimitiveRoot γ m) :
+    {z : ℂ | ∃ k : Fin m, z = γ ^ (k : ℕ)} = {μ : ℂ | μ ^ m = 1} := by
+  ext z
+  simp only [Set.mem_ofPred_eq]
+  constructor
+  · rintro ⟨k, rfl⟩
+    rw [← pow_mul, mul_comm, pow_mul, hγ.pow_eq_one, one_pow]
+  · intro hz
+    obtain ⟨i, hi, hip⟩ := hγ.eq_pow_of_pow_eq_one hz
+    exact ⟨⟨i, hi⟩, hip.symm⟩
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **The period of an irreducible-form block.**
+
+An MPS tensor whose transfer map is irreducible with spectral radius one — the
+two conditions defining the irreducible form of arXiv:1708.00029, lines
+248--261 — is spectrally periodic of some positive period.  The period is the
+derived one of arXiv:1708.00029, lines 257--258: the eigenvalues of modulus one
+of the transfer map are exactly the `m`-th roots of unity.
+
+The proof passes to the trace-preserving normalization of arXiv:1708.00029,
+equation `eq:unital`, line 316, by the positive-definite adjoint Perron fixed
+point.  For the normalized block the conjugate-transposed Kraus family is
+unital and its map is the trace adjoint of the transfer map, so the cyclic
+peripheral structure of Wolf Theorem 6.6(1) applies with the forward Perron
+fixed point as the required positive-definite adjoint fixed point.  Complex
+conjugation carries the resulting peripheral spectrum back to that of the
+transfer map, and the normalization is a similarity, so the peripheral spectrum
+is that of the original tensor.
+
+Source: arXiv:1708.00029, lines 248--261, 257--258 and 313--332;
+Wolf, *Quantum Channels & Operations*, Theorem 6.6(1). -/
+theorem exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one
+    {A : MPSTensor d D}
+    (hIrr : Kraus.IsIrreducibleFamily (d := d) (D := D) A)
+    (hRadius :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (Kraus.transferMap (d := d) (D := D) A)) = 1) :
+    ∃ m : ℕ, IsSpectrallyPeriodic m A := by
+  classical
+  have hD : D ≠ 0 :=
+    matrix_dim_ne_zero_of_spectralRadius_eq_one
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (Kraus.transferMap (d := d) (D := D) A))
+      hRadius
+  have : NeZero D := ⟨hD⟩
+  obtain ⟨σ, hσ, -, hLeft, -, hIrrB⟩ :=
+    exists_tpGauge_of_irreducible_spectralRadius_one hIrr hRadius
+  set B : MPSTensor d D := Kraus.tpGauge (d := d) (D := D) A σ with hBdef
+  have hSdet : (CFC.sqrt σ).det ≠ 0 :=
+    (Matrix.PosDef.isUnit_det_cfc_sqrt hσ).ne_zero
+  have hSinvDet : ((CFC.sqrt σ)⁻¹).det ≠ 0 := by
+    simpa [Matrix.det_nonsing_inv] using inv_ne_zero hSdet
+  -- The normalization is a similarity, so it changes neither the spectral
+  -- radius nor the peripheral spectrum.
+  have hRadB :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (Kraus.transferMap (d := d) (D := D) B)) = 1 := by
+    change spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (Kraus.mapLM B)) = 1
+    rw [hBdef, Kraus.mapLM_tpGauge_eq_similarityMap A σ hσ,
+      spectralRadius_similarityMap_eq (D := D) (CFC.sqrt σ)⁻¹ hSinvDet]
+    exact hRadius
+  have hPerB :
+      peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) B) =
+        peripheralEigenvalues (Kraus.transferMap (d := d) (D := D) A) := by
+    change peripheralEigenvalues (Kraus.mapLM B) = peripheralEigenvalues (Kraus.mapLM A)
+    rw [hBdef, Kraus.mapLM_tpGauge_eq_similarityMap A σ hσ]
+    exact peripheralEigenvalues_similarityMap_eq
+      (CFC.sqrt σ)⁻¹ hSinvDet (Kraus.transferMap (d := d) (D := D) A)
+  -- The normalized block is nonzero, being trace preserving.
+  have hLeft' : ∑ i : Fin d, (B i)ᴴ * B i = 1 := hLeft
+  have hBne : ∃ i, B i ≠ 0 := by
+    by_contra hzero
+    push Not at hzero
+    have hone : (1 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+      rw [← hLeft']
+      exact Finset.sum_eq_zero fun i _ => by rw [hzero i]; simp
+    exact one_ne_zero hone
+  have hIrrMapB : IsIrreducibleMap (Kraus.transferMap (d := d) (D := D) B) :=
+    Kraus.isIrreducibleMap_mapLM_of_isIrreducibleFamily B hIrrB
+  -- Its forward Perron eigenvector is a fixed point, since the spectral radius is one.
+  obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
+    exists_posDef_transferMap_eigenvector_of_irreducible (d := d) (n := D) B hIrrB hBne
+  have hrRad :
+      (spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (Kraus.transferMap (d := d) (D := D) B))).toReal = r :=
+    spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp
+      (Kraus.transferMap (d := d) (D := D) B) (Kraus.transferMap_isCPMap B) hIrrMapB
+      ρ r hρ hr hρeig
+  have hr_one : r = 1 := by
+    rw [hRadB, ENNReal.toReal_one] at hrRad
+    exact hrRad.symm
+  have hρfix : Kraus.transferMap (d := d) (D := D) B ρ = ρ := by
+    rw [hρeig, hr_one]
+    simp
+  -- The conjugate-transposed family of the normalized block is unital, and its
+  -- map is the trace adjoint of the transfer map.
+  have hUnital : KadisonSchwarz.IsUnitalKraus (d := d) (D := D) (fun i => (B i)ᴴ) := by
+    change ∑ i : Fin d, (B i)ᴴ * ((B i)ᴴ)ᴴ = 1
+    simpa using hLeft'
+  have hIrrAdj : IsIrreducibleMap (Kraus.mapLM (fun i => (B i)ᴴ)) :=
+    Kraus.isIrreducibleMap_mapLM_conjTranspose B hIrrMapB
+  have hAdjFix : Kraus.adjointMap (fun i => (B i)ᴴ) ρ = ρ := by
+    rw [Kraus.adjointMap_conjTranspose_eq_map]
+    exact hρfix
+  obtain ⟨m, γ, hm, hγ, hset⟩ :=
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure
+      (fun i => (B i)ᴴ) hUnital ρ hρ hAdjFix hIrrAdj
+  have : NeZero m := ⟨hm.ne'⟩
+  -- Transport the peripheral spectrum across the conjugation.
+  have hStarB :
+      star '' peripheralEigenvalues (Kraus.mapLM B) = {μ : ℂ | μ ^ m = 1} := by
+    rw [← Kraus.peripheralEigenvalues_mapLM_conjTranspose B, hset]
+    exact hγ.powRange_eq_setOf_pow_eq_one
+  have hPerBset :
+      peripheralEigenvalues (Kraus.mapLM B) = {μ : ℂ | μ ^ m = 1} := by
+    ext μ
+    constructor
+    · intro hμ
+      have himg : star μ ∈ star '' peripheralEigenvalues (Kraus.mapLM B) :=
+        Set.mem_image_of_mem _ hμ
+      rw [hStarB] at himg
+      have hpow : (star μ) ^ m = 1 := himg
+      simpa using congrArg star hpow
+    · intro hμ
+      have hpow : (star μ) ^ m = 1 := by
+        simpa using congrArg star (show μ ^ m = 1 from hμ)
+      have hstar : star μ ∈ star '' peripheralEigenvalues (Kraus.mapLM B) := by
+        rw [hStarB]
+        exact hpow
+      obtain ⟨x, hx, hxe⟩ := hstar
+      have hxμ : x = μ := star_injective hxe
+      exact hxμ ▸ hx
+  refine ⟨m, hIrr, hRadius, hm, ?_⟩
+  rw [← hPerB]
+  exact hPerBset
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -515,7 +515,12 @@ peripheral transfer spectrum under the repeated-block relation.
 Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623, over the
 irreducible forms `eq:bdnr`, line 294, and `eq:Bbdnr`, line 582; the
 period clause is the last clause of proposition
-`equal-or-orthogonal-generalized`, lines 602--604. -/
+`equal-or-orthogonal-generalized`, lines 602--604.
+
+The periods are received as input here, whereas the source derives them from
+irreducibility and spectral radius one at lines 257--258. This is the working
+form; the source statement, with the periods produced, is
+`fundamentalTheorem_periodic_proportional_irreducibleForm`. -/
 theorem fundamentalTheorem_periodic_proportional_sectorDecomposition
     (P Q : SectorDecomposition d)
     (periodP : Fin P.basisCount → ℕ)

--- a/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_equal_case_statement.tex
@@ -6,8 +6,10 @@ passage to that normalization, asserted by the source at lines 330--332, is the
 blockwise similarity of \cite[eq.~\emph{unital},
     line~316]{DeLasCuevas2017Irreducible} and is carried out in the proof.
 
-\begin{theorem}[Periodic Fundamental Theorem]\notready
+\begin{theorem}[Periodic Fundamental Theorem]
     \label{thm:periodic_ft}
+    \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_derivedPeriods}
+    \leanok
     \uses{def:spectral_periodic_tensor, def:same_mpv2_pos,
         def:scalar_gauge_equiv}
     Let $A$ and $B$ be MPS tensors in irreducible form, written
@@ -59,20 +61,12 @@ blockwise similarity of \cite[eq.~\emph{unital},
     dimension, whence $\mc{V}^+(A)=\mc{V}^+(ZA)$ already extends to length
     zero.
 
-    \noindent\emph{Scope restriction: the periods are supplied.}
-    The source introduces the period $m_j$ of a block as a consequence of
-    irreducibility and spectral radius one, at
-    \cite[lines~257--258]{DeLasCuevas2017Irreducible}, citing Wolf; it appears
-    in the conclusion of Theorem~3.8, not among its hypotheses. The formal
-    statement instead receives the periods together with witnesses that each
-    block is spectrally $m_j$-periodic, so a reader holding only the source's
-    two conditions on the blocks cannot yet instantiate it. The missing
-    ingredient is the existence half of the cyclic peripheral structure. The
-    restriction and its elimination plan are recorded in
-    \cite{gap:dccsp17_periodic_overlap_route_alignment}, section ``Scope
-    restriction: the periods of an irreducible-form block are supplied''. The
-    unrestricted source statement is Theorem~\ref{thm:periodic_ft} above,
-    which remains unformalized for that reason alone.
+    \noindent\emph{Remark on the periods.}
+    The period $m_j$ of a block is not a hypothesis. It is produced by
+    Theorem~\ref{thm:spectral_periodic_period_existence} from irreducibility
+    and spectral radius one alone, as the source produces it at
+    \cite[lines~257--258]{DeLasCuevas2017Irreducible}, and the periods so
+    produced are the ones occurring in every clause of the conclusion.
 
     \noindent\emph{Remark on the scalars $\xi_j$.}
     The source writes the two clauses of the last display without the
@@ -84,6 +78,17 @@ blockwise similarity of \cite[eq.~\emph{unital},
     between the two multiplicity families is $e^{i\theta}$, which is not a root
     of unity in general.
 \end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_periodic_period_existence,
+        thm:periodic_ft_supplied_periods}
+    Theorem~\ref{thm:spectral_periodic_period_existence} produces, for each
+    block of either family, a positive period for which that block is
+    spectrally periodic; irreducibility and spectral radius one are all it
+    needs. Theorem~\ref{thm:periodic_ft_supplied_periods}, applied to those
+    periods, gives every clause of the conclusion, and the periods it speaks
+    about are the produced ones.
+\end{proof}
 
 \begin{theorem}[Periodic Fundamental Theorem, periods supplied]%
     \label{thm:periodic_ft_supplied_periods}
@@ -95,7 +100,11 @@ blockwise similarity of \cite[eq.~\emph{unital},
     alongside the two block families, together with witnesses that each block is
     spectrally periodic of the given period in the sense of
     Definition~\ref{def:spectral_periodic_tensor}. Everything else, hypotheses
-    and conclusion alike, is as stated there.
+    and conclusion alike, is as stated there. This is the working form of the
+    theorem; the periods it receives are supplied by
+    Theorem~\ref{thm:spectral_periodic_period_existence} in the proof of
+    Theorem~\ref{thm:periodic_ft} above, so the source statement no longer
+    depends on them being given.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -28,20 +28,34 @@
     \cite[lines~257--258]{DeLasCuevas2017Irreducible}.
 \end{theorem}
 \begin{proof}
+    \uses{thm:pure_perron_tp_gauge, thm:cpsv_spectral_radius_similarity, lem:peripheral_spectrum_similarity, lem:irreducible_transfer_perron_pair, thm:transfer_map_irreducible_of_tensor}
     \leanok
     Let $\sigma$ be the positive definite fixed point of $\E_A^*$ and pass to
-    the similar tensor $\sigma^{1/2}A\sigma^{-1/2}$ of
+    the similar tensor $B=\sigma^{1/2}A\sigma^{-1/2}$ of
     \cite[eq.~\emph{unital}, line~316]{DeLasCuevas2017Irreducible}, whose map is
     trace preserving and still irreducible of spectral radius one. Its adjoint
     map is unital, and the positive definite Perron fixed point of the map
     itself is the positive definite fixed point required of the adjoint of that
-    unital map. The eigenvalues of modulus one of a unital irreducible map
-    possessing such a fixed point form a finite cyclic group
-    \cite[Theorem~6.6]{Wolf2012Quantum}, hence are the powers of a primitive
-    $m$-th root of unity for some positive $m$; those powers are exactly the
-    $m$-th roots of unity. Passing back from the adjoint conjugates the
-    peripheral spectrum, which leaves that set of roots of unity fixed, and the
-    similarity leaves it unchanged as well.
+    unital map. Write $B^\dagger$ for the family with matrices $(B^i)^\dagger$,
+    so that $\E_{B^\dagger}=\E_B^*$. By
+    \cite[Theorem~6.6]{Wolf2012Quantum}, there are a positive integer $m$ and a
+    primitive $m$-th root of unity $\gamma$ such that
+    \begin{align}
+        \operatorname{Spec}_{\mathrm{per}}(\E_{B^\dagger})
+         & =\{\gamma^k:0\leq k<m\}
+        =\{\mu\in\C:\mu^m=1\}.
+        \notag
+    \end{align}
+    Passing back from the adjoint conjugates the peripheral spectrum. Since
+    complex conjugation preserves the set of $m$-th roots of unity,
+    \begin{align}
+        \operatorname{Spec}_{\mathrm{per}}(\E_B)
+         & =\overline{\{\mu\in\C:\mu^m=1\}}
+        =\{\mu\in\C:\mu^m=1\}.
+        \notag
+    \end{align}
+    Finally, similarity gives
+    $\operatorname{Spec}_{\mathrm{per}}(\E_A)=\operatorname{Spec}_{\mathrm{per}}(\E_B)$.
 \end{proof}
 
 \begin{theorem}[A spectrally periodic tensor has positive bond dimension]

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -14,6 +14,36 @@
     \cite[lines~248--261 and 313--332]{DeLasCuevas2017Irreducible}.
 \end{definition}
 
+\begin{theorem}[The period of an irreducible-form block]
+    \label{thm:spectral_periodic_period_existence}
+    \lean{MPSTensor.exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one}
+    \leanok
+    \uses{def:spectral_periodic_tensor}
+    Let $A$ be an MPS tensor whose transfer map is irreducible with spectral
+    radius one; these are the two conditions imposed on a block of the
+    irreducible form of \cite[lines~248--261]{DeLasCuevas2017Irreducible}. Then
+    there is a positive integer $m$ for which $A$ is spectrally $m$-periodic,
+    that is, for which the eigenvalues of $\E_A$ of modulus one are exactly the
+    $m$-th roots of unity. This is the derived periodicity of
+    \cite[lines~257--258]{DeLasCuevas2017Irreducible}.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Let $\sigma$ be the positive definite fixed point of $\E_A^*$ and pass to
+    the similar tensor $\sigma^{1/2}A\sigma^{-1/2}$ of
+    \cite[eq.~\emph{unital}, line~316]{DeLasCuevas2017Irreducible}, whose map is
+    trace preserving and still irreducible of spectral radius one. Its adjoint
+    map is unital, and the positive definite Perron fixed point of the map
+    itself is the positive definite fixed point required of the adjoint of that
+    unital map. The eigenvalues of modulus one of a unital irreducible map
+    possessing such a fixed point form a finite cyclic group
+    \cite[Theorem~6.6]{Wolf2012Quantum}, hence are the powers of a primitive
+    $m$-th root of unity for some positive $m$; those powers are exactly the
+    $m$-th roots of unity. Passing back from the adjoint conjugates the
+    peripheral spectrum, which leaves that set of roots of unity fixed, and the
+    similarity leaves it unchanged as well.
+\end{proof}
+
 \begin{theorem}[A spectrally periodic tensor has positive bond dimension]
     \label{thm:spectral_periodic_bond_dimension_pos}
     \lean{MPSTensor.IsSpectrallyPeriodic.bondDim_ne_zero}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -770,7 +770,7 @@
 
 \begin{theorem}[Proportional Fundamental Theorem for irreducible-form MPS]
     \label{thm:periodic_ft_proportional}
-    \lean{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}
+    \lean{MPSTensor.fundamentalTheorem_periodic_proportional_irreducibleForm}
     \leanok
     \uses{def:nonzero_proportional_mpv, def:spectral_periodic_tensor}
     Let $A$ and $B$ have multiplicity-bearing irreducible forms
@@ -782,11 +782,14 @@
     \end{align}
     where $R_j$ and $S_k$ are diagonal with nonzero diagonal entries and the
     two displayed block families are pairwise non-repeated bases of periodic
-    tensors, spectrally periodic of periods $m_j$ and $n_k$ respectively.
+    tensors, each block being required only to have an irreducible transfer map
+    of spectral radius one, which is the source's irreducible form at
+    \cite[lines~248--261]{DeLasCuevas2017Irreducible}.
     Suppose that, for every positive $N$, the vectors
     $\ket{V^{(N)}(A)}$ and $\ket{V^{(N)}(B)}$ are proportional by a nonzero
-    scalar. Then there is a bijection $\pi\colon J\to K$ such that, for every
-    $j\in J$, one has $m_j=n_{\pi(j)}$ and there
+    scalar. Then the blocks carry periods $m_j$ and $n_k$ for which they are
+    spectrally periodic, and there is a bijection $\pi\colon J\to K$ such that,
+    for every $j\in J$, one has $m_j=n_{\pi(j)}$ and there
     are a unit-modulus scalar $\xi_j$ and an invertible matrix $Y_j$ such that,
     for every physical index $i$,
     \begin{align}
@@ -797,7 +800,31 @@
     \cite[Theorem~3.4, lines~613--623]{DeLasCuevas2017Irreducible}.
 
     The theorem relates the two bases of periodic tensors but makes no
-    assertion relating their multiplicity matrices.
+    assertion relating their multiplicity matrices. The periods are produced,
+    not assumed, exactly as at
+    \cite[lines~257--258]{DeLasCuevas2017Irreducible}.
+\end{theorem}
+\begin{proof}
+    \uses{thm:spectral_periodic_period_existence,
+        thm:periodic_ft_proportional_supplied_periods}
+    \leanok
+    Theorem~\ref{thm:spectral_periodic_period_existence} produces a positive
+    period for each block of either family, and
+    Theorem~\ref{thm:periodic_ft_proportional_supplied_periods} applied to
+    those periods gives the matching.
+\end{proof}
+
+\begin{theorem}[Proportional Fundamental Theorem, periods supplied]%
+    \label{thm:periodic_ft_proportional_supplied_periods}
+    \lean{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}
+    \leanok
+    \uses{def:nonzero_proportional_mpv, def:spectral_periodic_tensor}
+    Theorem~\ref{thm:periodic_ft_proportional} with the periods $m_j$ and $n_k$
+    given alongside the two block families, together with witnesses that each
+    block is spectrally periodic of the given period in the sense of
+    Definition~\ref{def:spectral_periodic_tensor}. Everything else, hypotheses
+    and conclusion alike, is as stated there. This is the working form of the
+    theorem.
 \end{theorem}
 \begin{proof}
     \uses{thm:repeated_blocks_period_eq, thm:periodic_conditional_block_matching, thm:periodic_spectral_multiplicity_nondecaying_overlap}

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -730,8 +730,7 @@ The conclusion asserts that the similarity is invertible. The source remark at
 lines 330--332 and 625 that in irreducible form II the similarity is unitary is
 a separate statement and is not asserted here.
 
-\section{Scope restriction: the periods of an irreducible-form block are
-    supplied}
+\section{The periods of an irreducible-form block: restriction eliminated}
 
 The source defines irreducible form at line 261 by two conditions on each
 block: its transfer map is an irreducible completely positive map, and its
@@ -742,35 +741,31 @@ for some $m_j$, and calls the block periodic of period $m_j$ on that basis.
 Theorem~3.8 accordingly mentions $m_j$ in its conclusion, not among its
 hypotheses.
 
-The formal equal-case theorem\footnote{Formal declaration:
-\leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_irreducibleForm}.}
-instead receives the periods as input, together with witnesses that each block
-is spectrally periodic of the given period.\footnote{Formal declaration:
-\leanid{MPSTensor.IsSpectrallyPeriodic}.} That predicate carries four fields,
-of which the source's definition supplies only the first two; the remaining
-two, positivity of $m$ and the identification of the peripheral spectrum with
-the $m$-th roots of unity, are the derived content. A reader holding exactly
-the source's hypotheses therefore cannot instantiate the formal theorem, and
-the same applies to the proportional case, Theorem~3.4.\footnote{Formal
-declaration:
-\leanid{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}.}
+That derivation is now carried out.\footnote{Formal declaration:
+\leanid{MPSTensor.exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one}.}
+The spectral periodicity predicate\footnote{Formal declaration:
+\leanid{MPSTensor.IsSpectrallyPeriodic}.} carries four fields, of which the
+source's definition supplies the first two; the remaining two, positivity of
+$m$ and the identification of the peripheral spectrum with the $m$-th roots of
+unity, are produced from them.
 
-\subsection{Elimination plan}
-
-What is missing is one existence statement: for a family $A$ with irreducible
-transfer map of spectral radius one, there is an $m$ with
-$\operatorname{Spec}_{\mathrm{per}}(\E_A) = \{\mu : \mu^m = 1\}$ and $m>0$. The
-ingredients are present.
+\subsection{The route}
 
 \begin{enumerate}
-    \item The unitalization of Eq.~\emph{unital}, line 316, is already
-          formalized from exactly the source's two conditions, and it preserves
-          irreducibility and the peripheral spectrum.\footnote{Formal
-          declaration:
+    \item The unitalization of Eq.~\emph{unital}, line 316, is formalized from
+          exactly the source's two conditions, and it preserves irreducibility
+          and the peripheral spectrum.\footnote{Formal declaration:
           \leanid{MPSTensor.exists_tpGauge_of_irreducible_spectralRadius_one}.}
+          The gauged block is trace preserving, so its conjugate-transposed
+          Kraus family is unital.
+    \item That conjugate-transposed family has the trace adjoint of the
+          transfer map for its map, and the Perron fixed point of the transfer
+          map itself, positive definite because the gauged block is irreducible
+          of spectral radius one, is exactly the positive-definite adjoint
+          fixed point that the cyclic structure theorem asks for.
     \item The cyclic structure of the peripheral spectrum of a unital
           irreducible finite-Kraus map with a positive-definite adjoint fixed
-          point is available in the companion library, in the form
+          point comes from the companion library, in the form
           $\operatorname{Spec}_{\mathrm{per}} = \{\gamma^k : k<m\}$ with
           $\gamma$ a primitive $m$-th root of unity.\footnote{Formal
           declaration:
@@ -779,15 +774,25 @@ ingredients are present.
           note on Wolf Theorem 6.6.
     \item For a primitive $m$-th root $\gamma$ over $\C$ the two descriptions
           agree, $\{\gamma^k : k<m\} = \{\mu : \mu^m=1\}$.
+    \item Passing back from the adjoint orientation conjugates the peripheral
+          spectrum, and the set of $m$-th roots of unity is closed under
+          conjugation, so the two orientations give the same period. The
+          unitalizing gauge is a similarity and changes nothing.
 \end{enumerate}
 
-The assembly has to pass between the unital and trace-preserving orientations,
-which exchange a Kraus family with its adjoint family and conjugate the
-peripheral spectrum; the same conjugation is already carried out for the
-transported statement in \path{SelfOverlapSetup.lean}. Once the existence
-statement is available, both the proportional and the equal case can be
-restated over the source's two conditions with the periods produced rather than
-supplied.
+\subsection{Consequence for the two fundamental theorems}
+
+Both fundamental theorems are consequently available over the source's two
+conditions on the blocks, with the periods produced in the conclusion:
+Theorem~3.4 in the proportional case\footnote{Formal declaration:
+\leanid{MPSTensor.fundamentalTheorem_periodic_proportional_irreducibleForm}.}
+and Theorem~3.8 in the equal case.\footnote{Formal declaration:
+\leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_derivedPeriods}.} The
+period-receiving statements\footnote{Formal declarations:
+\leanid{MPSTensor.fundamentalTheorem_periodic_proportional_sectorDecomposition}
+and
+\leanid{MPSTensor.fundamentalTheorem_periodic_equalCase_irreducibleForm}.}
+remain as the working forms through which the two are proved.
 
 \section{Independence of the non-zero periodic vectors}
 

--- a/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex
@@ -756,28 +756,64 @@ unity, are produced from them.
           exactly the source's two conditions, and it preserves irreducibility
           and the peripheral spectrum.\footnote{Formal declaration:
           \leanid{MPSTensor.exists_tpGauge_of_irreducible_spectralRadius_one}.}
-          The gauged block is trace preserving, so its conjugate-transposed
-          Kraus family is unital.
+          Write $B=(B^i)_i$ for the gauged block. It is trace preserving, so
+          the conjugate-transposed family
+          $B^\dagger=\left((B^i)^\dagger\right)_i$ is unital.
     \item That conjugate-transposed family has the trace adjoint of the
-          transfer map for its map, and the Perron fixed point of the transfer
-          map itself, positive definite because the gauged block is irreducible
-          of spectral radius one, is exactly the positive-definite adjoint
-          fixed point that the cyclic structure theorem asks for.
+          transfer map of $B$ for its map,
+          \begin{align}
+              \mathcal E_{B^\dagger}
+              &=\mathcal E_B^*,
+              \label{eq:dccsp17_periodic_overlap_route_alignment_adjoint_orientation}
+          \end{align}
+          and the Perron fixed point of $\mathcal E_B$ itself, positive
+          definite because $B$ is irreducible of spectral radius one, is
+          exactly the positive-definite adjoint fixed point that the cyclic
+          structure theorem asks for.
     \item The cyclic structure of the peripheral spectrum of a unital
           irreducible finite-Kraus map with a positive-definite adjoint fixed
-          point comes from the companion library, in the form
-          $\operatorname{Spec}_{\mathrm{per}} = \{\gamma^k : k<m\}$ with
-          $\gamma$ a primitive $m$-th root of unity.\footnote{Formal
-          declaration:
+          point comes from the companion library.\footnote{Formal declaration:
           \leanid{PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure}.}
-          It carries its own scope restriction, recorded in that library's
-          note on Wolf Theorem 6.6.
+          It supplies a positive integer $m$ and a primitive $m$-th root of
+          unity $\gamma$ for which
+          \begin{align}
+              \operatorname{spec}_{\mathrm{per}}(\mathcal E_{B^\dagger})
+              &=\left\{\gamma^k:0\leq k<m\right\}.
+              \label{eq:dccsp17_periodic_overlap_route_alignment_cyclic_peripheral_spectrum}
+          \end{align}
+          That library result carries its own scope restriction, recorded in
+          its note on Wolf Theorem 6.6.
     \item For a primitive $m$-th root $\gamma$ over $\C$ the two descriptions
-          agree, $\{\gamma^k : k<m\} = \{\mu : \mu^m=1\}$.
+          agree,
+          \begin{align}
+              \left\{\gamma^k:0\leq k<m\right\}
+              &=\left\{\mu\in\C:\mu^m=1\right\}.
+              \label{eq:dccsp17_periodic_overlap_route_alignment_primitive_root_powers}
+          \end{align}
     \item Passing back from the adjoint orientation conjugates the peripheral
           spectrum, and the set of $m$-th roots of unity is closed under
-          conjugation, so the two orientations give the same period. The
-          unitalizing gauge is a similarity and changes nothing.
+          conjugation, so
+          (\ref{eq:dccsp17_periodic_overlap_route_alignment_cyclic_peripheral_spectrum})
+          and
+          (\ref{eq:dccsp17_periodic_overlap_route_alignment_primitive_root_powers})
+          give
+          \begin{align}
+              \operatorname{spec}_{\mathrm{per}}(\mathcal E_B)
+              &=\overline{\operatorname{spec}_{\mathrm{per}}
+                  (\mathcal E_{B^\dagger})}
+              =\overline{\left\{\mu\in\C:\mu^m=1\right\}}
+              =\left\{\mu\in\C:\mu^m=1\right\}.
+              \label{eq:dccsp17_periodic_overlap_route_alignment_adjoint_conjugation_invariance}
+          \end{align}
+          The two orientations therefore give the same period. The unitalizing
+          gauge is a similarity, so
+          \begin{align}
+              \operatorname{spec}_{\mathrm{per}}(\mathcal E_A)
+              &=\operatorname{spec}_{\mathrm{per}}(\mathcal E_B),
+              \label{eq:dccsp17_periodic_overlap_route_alignment_gauge_similarity_spectrum}
+          \end{align}
+          and the period of $A$ is the $m$ of
+          (\ref{eq:dccsp17_periodic_overlap_route_alignment_adjoint_conjugation_invariance}).
 \end{enumerate}
 
 \subsection{Consequence for the two fundamental theorems}


### PR DESCRIPTION
## What this closes

Closes #7734. Advances #82 / #619.

The two headline theorems of arXiv:1708.00029 — Theorem 3.4 (`thm:bd`) and Theorem 3.8 (`thm:bdequal`) — were formalized only in a *supplied-period* form: their Lean statements took `IsSpectrallyPeriodic` witnesses, which carry each block's period and the identification of its unit-circle transfer spectrum with the roots of unity. The source assumes only that each block has an irreducible transfer map of spectral radius one (`main.tex:260-261`), derives the periodic structure at `:257-258` by citing Wolf, and reports the matched period in each theorem's **conclusion**. So a reader holding exactly the source's hypotheses could not instantiate either theorem, and both source nodes were `\notready`.

## What is added

- `MPSTensor.exists_isSpectrallyPeriodic_of_irreducible_of_spectralRadius_one` (`TNLean/MPS/Periodic/PeriodExistence.lean`): from `Kraus.IsIrreducibleFamily A` and spectral radius one, `∃ m, IsSpectrallyPeriodic m A`. Route: the unitalizing similarity of `eq:unital` (`main.tex:316`) via the existing trace-preserving gauge; QICLean's `peripheral_eigenvalues_cyclic_structure` (the finite-Kraus form of Wolf Thm 6.6(1)), applied to the conjugate-transposed family so that unitality has the orientation QICLean expects, with the spectrum conjugated back; and `IsPrimitiveRoot.powRange_eq_setOf_pow_eq_one` converting `{γ^k : k < m}` to `{μ : μ^m = 1}`. The period is transported back to the original block by similarity invariance of the peripheral spectrum.
- `fundamentalTheorem_periodic_proportional_irreducibleForm` and `fundamentalTheorem_periodic_equalCase_derivedPeriods` (`TNLean/MPS/Periodic/IrreducibleFormPeriods.lean`, `EqualCaseGlobal.lean`): Theorems 3.4 and 3.8 stated over the source's two conditions per block, with the periods obtained by `choose` and appearing in the conclusion — the source's shape. The supplied-period theorems remain as the working forms.

## Blueprint

`thm:periodic_ft_proportional` and `thm:periodic_ft` lose `\notready` and gain `\lean{}` / `\leanok` against the new source-hypothesis theorems. Each keeps a `_supplied_periods` sibling carrying the restricted form (Theorem 3.4's sibling is created here). The existence theorem gets its own node. `docs/paper-gaps/dccsp17_periodic_overlap_route_alignment.tex` records the elimination.

**With this, every theorem, lemma, proposition, corollary and definition node in the `ch22` family carries `\leanok`; the only remaining `\notready` marks are on three `remark` environments.** That is coverage of the blueprint's transcription of the paper; several nodes carry their own documented local fixes and reading conventions.

## Provenance and verification

The Lean was drafted by an agent that was rate-limited before its worktree's build cache arrived, so it committed unbuilt. I built it: one hard error (`ENNReal.one_toReal` → `toReal_one`) and four linter findings (`show` → `change` ×3, `push_neg` → `push Not`, a deprecated set lemma), all mechanical, folded into the commit. Then: targeted linter-bearing build of the four touched modules clean; `rg` for `sorry`/`axiom`/`native_decide`/`admit` empty; `generate_import_aggregators.py --check` ok; `blueprint_lean_sync.py --ci` 7904/7904 in sync; CI latexindent gate reproduced locally on all three touched chapter files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY2b1Yke8RgcRZuP8EQNca