### PR TITLE
refactor(Algebra): reuse the characteristic-two identity

### DIFF
--- a/TNLean/Algebra/MonomialFixedSubspace.lean
+++ b/TNLean/Algebra/MonomialFixedSubspace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Algebra.CharP.Two
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import TNLean.Algebra.CommonFixedSubmodule
@@ -108,9 +109,7 @@ def IsTrivialHolonomy (φ : Fin r → X × (Fin r → ZMod 2) → ℂ) (x : X) :
 
 /-- Adding a vector of $\mathbb F_2^r$ to itself gives zero. -/
 theorem add_self_eq_zero_pi_zmod_two (γ : Fin r → ZMod 2) : γ + γ = 0 := by
-  funext k
-  simp only [Pi.add_apply, Pi.zero_apply]
-  generalize_decide γ k
+  exact funext fun _ ↦ CharTwo.add_self_eq_zero _
 
 variable [Fintype X] [DecidableEq X]
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -579,6 +579,9 @@ abstracted — record why, so it is not re-proposed).
   `TNLean/MPS/MPDO/CZXGaussInvariantSubspace.lean`, hypercube connectivity in
   `TNLean/Algebra/HypercubePhasePotential.lean`, and the characteristic-two
   identity in `TNLean/Algebra/MonomialFixedSubspace.lean`.
+- **Mathlib replacement:** the characteristic-two identity in
+  `MonomialFixedSubspace.lean` now uses `CharTwo.add_self_eq_zero` pointwise;
+  finite-case automation is no longer needed at that call site.
 - **Abstraction:** `generalize_decide t₁, …, tₙ` macro
   (`TNLean/Algebra/GeneralizeDecide.lean`); the terms are abstracted in order
   and `decide +revert` quantifies over the fresh variables.


### PR DESCRIPTION
### Motivation

A local backup contained a Mathlib-based simplification of the characteristic-two identity used in the monomial fixed-space proof. The current proof still invokes finite-case automation.

### Description

Use `CharTwo.add_self_eq_zero` pointwise in `TNLean/Algebra/MonomialFixedSubspace.lean`, preserving the existing theorem and its blueprint reference. Record the replacement in `docs/tactic_patterns.md`.

### Testing

- `scripts/lake_build_locked.sh TNLean.Algebra.MonomialFixedSubspace` passed, including the package linters (module: 6.5 seconds).
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main` passed.
- `git diff --check` passed.
