### PR TITLE
refactor(Algebra): preserve cocyclicity along cohomology classes

### DIFF
--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -75,6 +75,19 @@ def ScalarCocycle.CohomologousTo (ω₁ ω₂ : ScalarCocycle G) : Prop :=
 def ScalarCocycle.IsCocycle (ω : ScalarCocycle G) : Prop :=
   ∀ g h k : G, ω g h * ω (g * h) k = ω g (h * k) * ω h k
 
+/-- A scalar cochain cohomologous to a genuine cocycle satisfies the cocycle equation. -/
+theorem ScalarCocycle.IsCocycle.of_cohomologousTo {ω₁ ω₂ : ScalarCocycle G}
+    (hω₂ : ω₂.IsCocycle) (h : ω₁.CohomologousTo ω₂) : ω₁.IsCocycle := by
+  obtain ⟨φ, hφ⟩ := h
+  intro a b c
+  simp only [hφ]
+  calc
+    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
+        (ω₂ a b * ω₂ (a * b) c) := by simp [mul_assoc, mul_comm, mul_left_comm]
+    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
+        (ω₂ a (b * c) * ω₂ b c) := by rw [hω₂ a b c]
+    _ = _ := by simp [mul_assoc, mul_comm, mul_left_comm]
+
 /-- Every projective representation of positive bond dimension has a genuine 2-cocycle
 as factor system.  This is the `Units ℂ`-level lift of
 `ProjectiveRepresentation.cocycle_of_assoc`: associativity of matrix multiplication

--- a/TNLean/Algebra/CocycleRestriction.lean
+++ b/TNLean/Algebra/CocycleRestriction.lean
@@ -51,13 +51,7 @@ theorem ScalarCocycle.CohomologousTo.pullback {ω₁ ω₂ : ScalarCocycle G}
 theorem ScalarCocycle.IsCocycle.coboundary_mul {ω : ScalarCocycle G}
     (hω : ω.IsCocycle) (φ : G → ℂˣ) :
     ScalarCocycle.IsCocycle (fun a b ↦ φ a * φ b * (φ (a * b))⁻¹ * ω a b) := by
-  intro a b c
-  calc
-    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
-        (ω a b * ω (a * b) c) := by simp [mul_assoc, mul_comm, mul_left_comm]
-    _ = (φ a * φ b * φ c * (φ (a * (b * c)))⁻¹) *
-        (ω a (b * c) * ω b c) := by rw [hω a b c]
-    _ = _ := by simp [mul_assoc, mul_comm, mul_left_comm]
+  exact hω.of_cohomologousTo ⟨φ, fun _ _ ↦ rfl⟩
 
 /-- Contravariant pullback on the existing genuine-cocycle cohomology quotient. -/
 def H2.pullback (f : K →* G) : H2 G → H2 K :=


### PR DESCRIPTION
### Motivation
Closes #7773. Reuse the cohomology-invariance argument instead of proving its fixed-coboundary special case inline.

### Description
- Add universe-polymorphic `ScalarCocycle.IsCocycle.of_cohomologousTo` in `CocycleCohomology.lean`.
- Derive the existing `coboundary_mul` API in `CocycleRestriction.lean` from the cochain witness, preserving its statement and blueprint anchor.
- This is internal scalar support for arXiv:2502.20257 `prop:BI_psi`, not completion of #7361 or the coefficient comparison. No new hypotheses or source-labelled blueprint claims.
- Mathlib/QICLean/TNLean scouted first; the direct witness argument avoids narrowing the universe-polymorphic API to the existing bundled comparison's `Type` interface.

### Testing
- Both changed modules compiled sequentially under the repository lock using cached imports and direct `lake env lean -o`, with `relaxedAutoImplicit=false`, the Mathlib standard linter set, and `maxSynthPendingDepth=3`: exit 0, 15 seconds, no diagnostics.
- `git diff --check` and forbidden-proof-token scans passed.
- Independent read-only Lean/style review approved this exact two-file diff.
- No Mathlib or broad dependency rebuild; existing blueprint anchors unchanged.
