### PR TITLE
feat(MPU): prove the first staircase network and blocked CZX injectivity

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -110,6 +110,7 @@ import TNLean.MPS.MPDO.CZXGaussCircuitTuple
 import TNLean.MPS.MPDO.CZXGaussInvariantSubspace
 import TNLean.MPS.MPDO.CZXSecondTupleCertificate
 import TNLean.MPS.MPDO.CZXTensor
+import TNLean.MPS.MPDO.CZXTensorInjectivity
 import TNLean.MPS.MPDO.CaseIIAbsorptionCounterexample
 import TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport
 import TNLean.MPS.MPDO.CommonWeightAbsorption

--- a/TNLean/MPS/MPDO/CZXTensorInjectivity.lean
+++ b/TNLean/MPS/MPDO/CZXTensorInjectivity.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Matrix.Basis
+import QICLean.Kraus.Injectivity
+import TNLean.MPS.MPDO.CZXTensor
+
+/-!
+# Injectivity of the exact FBC25 CZX tensor
+
+The once-blocked tensor in arXiv:2502.20257, `eq:MPU_CZX`
+(lines 4505–4547), is injective. We use the shared tensor, including its
+output Z gates and unnormalized Hadamard weights, not the normalized
+2017 tensor (see `docs/paper-gaps/mpu_czx_tensor_normalization.tex`).
+
+Writing $B_{ij}$ for its physical letters and $E_{ij}$ for the bond matrix
+units, the four identities are
+$E_{00}=(B_{03}-B_{12})/2$, $E_{01}=(B_{03}+B_{12})/2$,
+$E_{10}=-(B_{21}+B_{30})/2$, and $E_{11}=(B_{30}-B_{21})/2$.
+They show that the physical letters span the full bond matrix algebra.
+-/
+
+noncomputable section
+
+open scoped BigOperators
+
+namespace MPOTensor.CZX
+
+private theorem single_eq_tensor_combination (i j : Fin 2) :
+    Matrix.single i j (1 : ℂ) =
+      (if i = 0 then (1 / 2 : ℂ) else -1 / 2) •
+        tensor (if i = 0 then 0 else 2) (if i = 0 then 3 else 1) +
+      (if j = 0 then (-1 / 2 : ℂ) else 1 / 2) •
+        tensor (if i = 0 then 1 else 3) (if i = 0 then 2 else 0) := by
+  have hc : ∀ (u d : Fin 4) (l : Fin 2),
+      (u = complementSite d ∧ l = (show Fin 2 from (siteBits u).1)) ↔
+        u = d.rev ∧ l = u.divNat (n := 2) := by decide
+  have he : ∀ (u : Fin 4) (r : Fin 2), edgeExponent u r =
+      u.val / 2 + u.val % 2 + (u.val / 2) * (u.val % 2) + (u.val % 2) * r.val := by
+    decide
+  ext l r
+  simp only [Matrix.add_apply, Matrix.smul_apply, tensor_apply, hc, he]
+  fin_cases i <;> fin_cases j <;> fin_cases l <;> fin_cases r <;>
+    norm_num [Matrix.single_apply, Fin.divNat, Fin.rev, Fin.ext_iff]
+
+/-- The once-blocked CZX tensor is injective, as asserted immediately before
+arXiv:2502.20257, `eq:MPU_CZX` (lines 4505–4547). Its four nonzero physical
+letters span all bond matrix units by half-sums and half-differences. -/
+theorem tensor_isInjective : Kraus.IsInjective tensor.toMPSTensor := by
+  rw [Kraus.IsInjective]
+  let S := Submodule.span ℂ (Set.range tensor.toMPSTensor)
+  have hletter (i j : Fin 4) : tensor i j ∈ S := by
+    apply Submodule.subset_span
+    exact ⟨finProdFinEquiv (i, j), by
+      simp only [toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+        MPSTensor.finProdFinEquiv_modNat]⟩
+  have hunit (i j : Fin 2) : Matrix.single i j (1 : ℂ) ∈ S := by
+    rw [single_eq_tensor_combination]
+    exact S.add_mem (S.smul_mem _ (hletter _ _)) (S.smul_mem _ (hletter _ _))
+  apply top_unique
+  intro M _
+  rw [Matrix.matrix_eq_sum_single M]
+  apply Submodule.sum_mem
+  intro i _
+  apply Submodule.sum_mem
+  intro j _
+  simpa only [Matrix.smul_single, smul_eq_mul, mul_one] using
+    S.smul_mem (M i j) (hunit i j)
+
+end MPOTensor.CZX

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -44,6 +44,7 @@ import TNLean.MPS.MPU.SourceURetainedInterior
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 import TNLean.MPS.MPU.SourceVIsometry
+import TNLean.MPS.MPU.StaircaseGates
 import TNLean.MPS.MPU.StandardForm
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.TensorProduct

--- a/TNLean/MPS/MPU/StaircaseGates.lean
+++ b/TNLean/MPS/MPU/StaircaseGates.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinSumPermutation
+import TNLean.MPS.MPU.StandardForm
+
+/-!
+# Staircase gates and the first network identity
+
+The gates are the literal crossed contractions in arXiv:2502.20257,
+`eq:wLR` (lines 811–869). Rows are the upper legs, columns the lower legs,
+in spatial left-to-right order. Thus $w_L:d\times\ell\to\ell\times d$
+and $w_R:r\times d\to d\times r$. Red horizontal legs are virtual indices.
+
+The first diagram in the proof of `cor:mpu` (lines 918–974) follows from
+the two source factorizations alone. Cancelling its bottom middle gate
+requires only $uu^\dagger=I$, already part of the source theorem's unitary
+claim. This file does not establish the second network or scalar normalization.
+-/
+
+open scoped Matrix Kronecker BigOperators
+open Matrix
+
+namespace MPOTensor
+
+/-- Place a two-leg gate on the middle legs of a four-leg space. The explicit
+reshuffle sends `((a,b),(c,e))` to `((a,(b,c)),e)` before applying
+$(I\otimes M)\otimes I$. This is the leg convention in arXiv:2502.20257,
+the first diagram in the proof of `cor:mpu`, lines 918–974. -/
+def staircaseMiddle {A B C B' C' E : Type*} [DecidableEq A] [DecidableEq E]
+    (M : Matrix (B × C) (B' × C') ℂ) :
+    Matrix ((A × B) × (C × E)) ((A × B') × (C' × E)) ℂ :=
+  (((1 : Matrix A A ℂ) ⊗ₖ M) ⊗ₖ (1 : Matrix E E ℂ)).submatrix
+    (fun x ↦ ((x.1.1, (x.1.2, x.2.1)), x.2.2))
+    (fun x ↦ ((x.1.1, (x.1.2, x.2.1)), x.2.2))
+
+/-- Composition of middle layers preserves the explicit reshuffle used in
+arXiv:2502.20257, proof of `cor:mpu`, lines 968–974. -/
+theorem staircaseMiddle_mul {A B C B' C' B'' C'' E : Type*}
+    [Fintype A] [Fintype B'] [Fintype C'] [Fintype E]
+    [DecidableEq A] [DecidableEq E]
+    (M : Matrix (B × C) (B' × C') ℂ)
+    (N : Matrix (B' × C') (B'' × C'') ℂ) :
+    staircaseMiddle (A := A) (E := E) M * staircaseMiddle N =
+      staircaseMiddle (M * N) := by
+  ext ⟨⟨a, b⟩, c, e⟩ ⟨⟨a', b'⟩, c', e'⟩
+  simp [staircaseMiddle, Matrix.mul_apply, Fintype.sum_prod_type,
+    Matrix.kroneckerMap_apply, Matrix.one_apply, mul_ite, ite_mul,
+    Finset.sum_ite_irrel]
+
+/-- The middle identity layer is the four-leg identity, in the reshuffle of
+arXiv:2502.20257, proof of `cor:mpu`, lines 968–974. -/
+theorem staircaseMiddle_one {A B C E : Type*}
+    [DecidableEq A] [DecidableEq B] [DecidableEq C] [DecidableEq E] :
+    staircaseMiddle (A := A) (E := E) (1 : Matrix (B × C) (B × C) ℂ) = 1 := by
+  ext ⟨⟨a, b⟩, c, e⟩ ⟨⟨a', b'⟩, c', e'⟩
+  simp [staircaseMiddle, Matrix.one_apply, Prod.mk.injEq]
+  aesop
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+namespace SourceFactors
+
+/-- $w_L=Y_2\mathbin{-}X_2$, with rows $(\ell,i)$ and columns $(j,\ell')$.
+Source: arXiv:2502.20257, `eq:wLR`, lines 811–869. -/
+def sourceWL {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    Matrix (Fin ℓ[U] × Fin d) (Fin d × Fin ℓ[U]) ℂ :=
+  fun (l, i) (j, l') ↦ ∑ β, S.Y₂ l (j, β) * S.X₂ (β, i) l'
+
+/-- $w_R=X_1\mathbin{-}Y_1$, with rows $(i,r)$ and columns $(r',j)$.
+Source: arXiv:2502.20257, `eq:wLR`, lines 811–869. -/
+def sourceWR {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    Matrix (Fin d × Fin r[U]) (Fin r[U] × Fin d) ℂ :=
+  fun (i, r) (r', j) ↦ ∑ β, S.X₁ (i, β) r' * S.Y₁ r (β, j)
+
+/-- The first graphical equality before cancelling the bottom middle $u$.
+No simplicity, normalization or unitarity hypothesis is needed: replace
+both middle two-site contractions by the same product of tensor letters.
+Source: arXiv:2502.20257, proof of `cor:mpu`, lines 918–968. -/
+theorem sourceWL_kronecker_sourceWR_mul_middle_sourceU
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    (sourceWL U S ⊗ₖ sourceWR U S) * staircaseMiddle (sourceU U S) =
+      staircaseMiddle (sourceV U S) * (sourceU U S ⊗ₖ sourceU U S) := by
+  classical
+  ext ⟨⟨l, i₂⟩, i₃, r⟩ ⟨⟨j₁, j₂⟩, j₃, j₄⟩
+  simp only [Matrix.mul_apply, Fintype.sum_prod_type, staircaseMiddle,
+    Matrix.submatrix_apply, Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp only [mul_ite, ite_mul, mul_zero, zero_mul, mul_one, one_mul,
+    Finset.sum_ite_eq', Finset.sum_ite_eq]
+  simp only [Finset.mem_univ, ite_true, Finset.sum_ite_irrel, Finset.sum_const_zero,
+    Finset.sum_ite_eq, Finset.sum_ite_eq']
+  trans ∑ γ : Fin D, ∑ α : Fin D,
+    S.Y₂ l (j₁, α) * (U i₂ j₂ * U i₃ j₃) α γ * S.Y₁ r (γ, j₄)
+  · simp only [sourceWL, sourceWR, Finset.sum_mul, Finset.mul_sum]
+    rw [Fintype.sum_last_two_first_four]
+    refine Finset.sum_congr₂ fun γ _ α _ ↦ ?_
+    rw [mul_apply_eq_sum_X₂_mul_sourceU_mul_X₁ U S]
+    simp only [Finset.mul_sum, Finset.sum_mul]
+    exact Finset.sum_congr₂ fun l' _ r' _ ↦ by ring
+  · symm
+    simp only [sourceU_apply, Finset.sum_mul, Finset.mul_sum]
+    rw [Fintype.sum_last_two_first_four]
+    refine Finset.sum_congr₂ fun γ _ α _ ↦ ?_
+    rw [mul_apply_eq_sum_sourceV_mul_Y₁_mul_Y₂ U S]
+    simp only [Finset.mul_sum, Finset.sum_mul]
+    exact Finset.sum_congr₂ fun r' _ l' _ ↦ by ring
+
+/-- The displayed first staircase network identity
+$w_L\otimes w_R=(I\otimes v\otimes I)(u\otimes u)(I\otimes u^\dagger\otimes I)$,
+with every middle-layer reshuffle explicit. The sole extra premise is
+$uu^\dagger=I$, the coisometry half of the unitarity of $u$ supplied by
+arXiv:2502.20257, Theorem `thm:mpu`. It is not a premise about either staircase
+gate, nor an assumed network equality. In particular, this theorem does not
+assert that arbitrary source factors give a unitary $u$.
+
+Source: arXiv:2502.20257, proof of `cor:mpu`, lines 918–974. -/
+theorem sourceWL_kronecker_sourceWR_eq
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hu : (sourceU U S).IsCoisometry) :
+    sourceWL U S ⊗ₖ sourceWR U S =
+      staircaseMiddle (sourceV U S) * (sourceU U S ⊗ₖ sourceU U S) *
+        staircaseMiddle ((sourceU U S)ᴴ) := by
+  calc
+    _ = ((sourceWL U S ⊗ₖ sourceWR U S) * staircaseMiddle (sourceU U S)) *
+        staircaseMiddle ((sourceU U S)ᴴ) := by
+      rw [Matrix.mul_assoc, staircaseMiddle_mul, hu, staircaseMiddle_one,
+        Matrix.mul_one]
+    _ = _ := by rw [sourceWL_kronecker_sourceWR_mul_middle_sourceU U S]
+
+end SourceFactors
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5010,6 +5010,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_admissible_simple_tensor_equivalence}
     \notready
     \discussion{5708}
+    % **Scope restriction (supplied reduced full-support fixed-pair data):**
+    % this entry assumes a chosen positive diagonal weight and stabilized
+    % fixed pair on the reduced full-support representative, rather than
+    % deriving that datum from the source's standing convention. See
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     % Retained under #7660: the source-labelled theorem now uses the bundled
     % canonical-form-II presentation, but downstream supplied-fixed-pair
     % statements cannot yet be redirected to it. The stabilization converse
@@ -5108,6 +5113,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{def:mpu_admissible_standard_form}
     \notready
     \discussion{6019}
+    % **Scope restriction (supplied reduced full-support fixed-pair data):**
+    % this standard form uses source unitaries constructed from a chosen
+    % reduced full-support datum with its positive diagonal weight and
+    % stabilized fixed pair. The passage from this supplied datum to the
+    % source's standing convention remains open; see
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     % Retained under #7660 with the supplied-fixed-pair equivalence theorem.
     % Redirecting its downstream uses to SF requires the stabilization
     % converse and normalization tracked by #7758; the bundled convention
@@ -5160,6 +5171,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_admissible_fundamental}
     \notready
     \discussion{6020}
+    % **Scope restriction (supplied reduced full-support fixed-pair data):**
+    % both tensors carry chosen reduced full-support source data, including
+    % positive diagonal weights and stabilized fixed pairs, for their
+    % admissible standard forms. These supplied hypotheses have not yet been
+    % identified with the source's standing convention; see
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     % Retained under #7660: both supplied-fixed-pair presentations must be
     % related to the standing canonical-form-II convention before downstream
     % uses can be redirected to FundamentalMPU. The converse and normalization

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5010,11 +5010,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_admissible_simple_tensor_equivalence}
     \notready
     \discussion{5708}
-    % **Scope restriction (all positive bond dimensions):** the $D=1$ branch
-    % uses one-dimensional transfer stabilization; the $D>1$ branch uses chosen
-    % reduced full-support canonical-form-II data.
-    % Source Theorem III.8 is stated under the preceding representative
-    % convention without these displayed hypotheses. Documented in
+    % Retained under #7660: the source-labelled theorem now uses the bundled
+    % canonical-form-II presentation, but downstream supplied-fixed-pair
+    % statements cannot yet be redirected to it. The stabilization converse
+    % and exponent-dependent normalization in #7758 must first justify that
+    % change of hypotheses. This is one of the three same-tensor merge
+    % candidates, not a derived-tensor preservation statement. See
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{def:mpu_simple, def:mpu_source_uv, def:mpu_reduced_full_support_source_datum}
     Let $\mathcal U$ be an MPU tensor equipped with a reduced full-support
@@ -5107,11 +5108,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{def:mpu_admissible_standard_form}
     \notready
     \discussion{6019}
-    % **Scope restriction (reduced full-support source datum):** this standard
-    % form uses Theorem~\ref{thm:mpu_admissible_simple_tensor_equivalence} for a
-    % tensor carrying the datum in
-    % Definition~\ref{def:mpu_reduced_full_support_source_datum}.
-    % Documented in docs/paper-gaps/mpu_canonical_form_full_support.tex.
+    % Retained under #7660 with the supplied-fixed-pair equivalence theorem.
+    % Redirecting its downstream uses to SF requires the stabilization
+    % converse and normalization tracked by #7758; the bundled convention
+    % alone does not justify that change of hypotheses. Keep the twelve
+    % derived-tensor restrictions and the pathwise data separate. See
+    % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{thm:mpu_admissible_simple_tensor_equivalence, def:mpu_source_uv, def:mpu_reduced_full_support_source_datum}
     Let $\mathcal U$ be a simple tensor equipped with a reduced full-support
     source datum. The admissible standard form of the two-site blocking
@@ -5158,9 +5160,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_admissible_fundamental}
     \notready
     \discussion{6020}
-    % **Scope restriction (reduced full-support source data):** both tensors
-    % carry the data required by
-    % Definition~\ref{def:mpu_admissible_standard_form}. Documented in
+    % Retained under #7660: both supplied-fixed-pair presentations must be
+    % related to the standing canonical-form-II convention before downstream
+    % uses can be redirected to FundamentalMPU. The converse and normalization
+    % in #7758 address this same-tensor obstruction, not preservation under
+    % derived-tensor operations or continuous choice along paths. The generic
+    % supplied-pair source-u lemma remains a reusable step. See
     % docs/paper-gaps/mpu_canonical_form_full_support.tex.
     \uses{def:mpu_admissible_standard_form, thm:mpu_admissible_simple_tensor_equivalence, def:mpu_reduced_full_support_source_datum}
     Let $\mathcal U$ and $\mathcal V$ be simple tensors equipped with reduced

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1019,11 +1019,11 @@ gauges and scalar relation have been constructed.
     where $\rho$ is a matrix on the virtual space. Define
     \begin{align}
         (w_L)_{(l,i),(j,l')}
-         &=\sum_{\beta=1}^D (Y_2)_{l,(j,\beta)}
-            (X_2)_{(\beta,i),l'}, \\
+         & =\sum_{\beta=1}^D (Y_2)_{l,(j,\beta)}
+        (X_2)_{(\beta,i),l'}, \\
         (w_R)_{(i,r),(r',j)}
-         &=\sum_{\beta=1}^D (X_1)_{(i,\beta),r'}
-            (Y_1)_{r,(\beta,j)}.
+         & =\sum_{\beta=1}^D (X_1)_{(i,\beta),r'}
+        (Y_1)_{r,(\beta,j)}.
     \end{align}
     Thus $w_L\colon\C^d\otimes\C^{d_l}\to\C^{d_l}\otimes\C^d$
     and $w_R\colon\C^{d_r}\otimes\C^d\to\C^d\otimes\C^{d_r}$.
@@ -1043,7 +1043,7 @@ gauges and scalar relation have been constructed.
     Its action on the middle two legs is the matrix $M_{23}$ defined by
     \begin{align}
         (M_{23})_{((a,b),(c,e)),((a',b'),(c',e'))}
-         &=\delta_{a,a'}M_{(b,c),(b',c')}\delta_{e,e'}.
+         & =\delta_{a,a'}M_{(b,c),(b',c')}\delta_{e,e'}.
     \end{align}
     This is $(I_A\otimes M)\otimes I_E$ after regrouping
     $((a,b),(c,e))$ as $((a,(b,c)),e)$, as in the first network in the
@@ -1079,7 +1079,7 @@ gauges and scalar relation have been constructed.
     Definition~\ref{def:mpug_staircase_gates}, and form $u,v,w_L,w_R$
     from those same factors. Then
     \begin{align}
-        (w_L\otimes w_R)u_{23}&=v_{23}(u\otimes u).
+        (w_L\otimes w_R)u_{23} & =v_{23}(u\otimes u).
         \label{eq:mpug_staircase_network_uncancelled}
     \end{align}
     No simplicity or unitarity assumption on $\mathcal U$ is required.
@@ -1113,9 +1113,9 @@ gauges and scalar relation have been constructed.
     $uu^\dagger=I_{d_ld_r}$, then
     \begin{align}
         w_L\otimes w_R
-         &=v_{23}(u\otimes u)(u^\dagger)_{23} \\
-         &=(I\otimes v\otimes I)(u\otimes u)
-            (I\otimes u^\dagger\otimes I).
+         & =v_{23}(u\otimes u)(u^\dagger)_{23} \\
+         & =(I\otimes v\otimes I)(u\otimes u)
+        (I\otimes u^\dagger\otimes I).
         \label{eq:mpug_staircase_network_cancelled}
     \end{align}
     The second expression uses the regrouping of
@@ -4818,7 +4818,7 @@ by the displayed matrices.
     Hadamard weights and both output $Z$ gates, is injective:
     \begin{align}
         \operatorname{span}_{\C}\{B^{i,j}:0\leq i,j<4\}
-         &=\operatorname{Mat}_2(\C).
+         & =\operatorname{Mat}_2(\C).
     \end{align}
     Here $B^{2a+b,2c+d}=B^{ab,cd}$ for binary $a,b,c,d$.
     This is the injectivity assertion preceding the tensor diagram in
@@ -4832,10 +4832,14 @@ by the displayed matrices.
     Let $E_{ab}$ be the bond matrix units, with $a,b\in\{0,1\}$.
     The coordinate formula gives
     \begin{align}
-        E_{00}&=\tfrac12(B^{0,3}-B^{1,2}), &
-        E_{01}&=\tfrac12(B^{0,3}+B^{1,2}), \\
-        E_{10}&=-\tfrac12(B^{2,1}+B^{3,0}), &
-        E_{11}&=\tfrac12(B^{3,0}-B^{2,1}).
+        E_{00}
+         & =\tfrac12(B^{0,3}-B^{1,2}), \\
+        E_{01}
+         & =\tfrac12(B^{0,3}+B^{1,2}), \\
+        E_{10}
+         & =-\tfrac12(B^{2,1}+B^{3,0}), \\
+        E_{11}
+         & =\tfrac12(B^{3,0}-B^{2,1}).
     \end{align}
     Thus every bond matrix unit lies in the span of the physical letters.
     Since every $2\times2$ matrix is a linear combination of these units,

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1000,6 +1000,141 @@ gauges and scalar relation have been constructed.
     (\ref{eq:mpug_alternating_network_proportionality}).
 \end{proof}
 
+\section{Staircase gates and the first source network}
+\label{sec:mpug_staircase_gates}
+
+\begin{definition}[Staircase gates]
+    \label{def:mpug_staircase_gates}
+    \lean{MPOTensor.SourceFactors.sourceWL,
+        MPOTensor.SourceFactors.sourceWR}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPO tensor of physical dimension $d$ and bond
+    dimension $D$. Put $d_l=\ell$ and $d_r=r$ for its source-cut ranks.
+    Let $X_1,Y_1,Z_1,X_2,Y_2,Z_2$ be source factors with
+    $M_1=X_1Y_1$, $M_2=X_2Y_2$,
+    $X_1^\dagger(I_d\otimes\rho)X_1=I_r$,
+    $X_2^\dagger X_2=I_\ell$, and $Y_iZ_i=I$ for $i=1,2$,
+    where $\rho$ is a matrix on the virtual space. Define
+    \begin{align}
+        (w_L)_{(l,i),(j,l')}
+         &=\sum_{\beta=1}^D (Y_2)_{l,(j,\beta)}
+            (X_2)_{(\beta,i),l'}, \\
+        (w_R)_{(i,r),(r',j)}
+         &=\sum_{\beta=1}^D (X_1)_{(i,\beta),r'}
+            (Y_1)_{r,(\beta,j)}.
+    \end{align}
+    Thus $w_L\colon\C^d\otimes\C^{d_l}\to\C^{d_l}\otimes\C^d$
+    and $w_R\colon\C^{d_r}\otimes\C^d\to\C^d\otimes\C^{d_r}$.
+    Rows are the upper legs and columns the lower legs, each in spatial
+    left-to-right order. These are the crossed contractions of
+    \cite[lines~811--869]{FrancoRubio2025MPUGauging}.
+    % Source: main.tex, eq:wLR, lines 811--869. This definition does not
+    % assert the unitarity or normalization conclusions of cor:mpu.
+\end{definition}
+
+\begin{definition}[An operator on the middle two legs]
+    \label{def:mpug_staircase_middle}
+    \lean{MPOTensor.staircaseMiddle}
+    \leanok
+    Let $A,B,C,B',C',E$ be index sets and let $M$ be a complex matrix with
+    rows indexed by $B\times C$ and columns by $B'\times C'$.
+    Its action on the middle two legs is the matrix $M_{23}$ defined by
+    \begin{align}
+        (M_{23})_{((a,b),(c,e)),((a',b'),(c',e'))}
+         &=\delta_{a,a'}M_{(b,c),(b',c')}\delta_{e,e'}.
+    \end{align}
+    This is $(I_A\otimes M)\otimes I_E$ after regrouping
+    $((a,b),(c,e))$ as $((a,(b,c)),e)$, as in the first network in the
+    proof of the staircase-gate corollary of
+    \cite[lines~918--974]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Composition on the middle two legs]
+    \label{thm:mpug_staircase_middle_composition}
+    \lean{MPOTensor.staircaseMiddle_mul, MPOTensor.staircaseMiddle_one}
+    \leanok
+    \uses{def:mpug_staircase_middle}
+    Let $M$ and $N$ be composable complex matrices between pairs of index
+    sets. If their common index sets and the two outer index sets are finite,
+    then $(MN)_{23}=M_{23}N_{23}$. The identity matrix satisfies $I_{23}=I$.
+\end{theorem}
+
+\begin{proof}\leanok
+    In the matrix product, the two outer Kronecker deltas fix the outer
+    indices. The remaining sum is the entry formula for $MN$.
+    For the identity, the four Kronecker deltas give equality of the two
+    four-leg indices.
+\end{proof}
+
+\begin{theorem}[The first staircase network before cancellation]
+    \label{thm:mpug_staircase_network_uncancelled}
+    \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_mul_middle_sourceU}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpug_staircase_gates, def:mpug_staircase_middle,
+        def:mpu_source_uv}
+    Let $\mathcal U$ have source factors as in
+    Definition~\ref{def:mpug_staircase_gates}, and form $u,v,w_L,w_R$
+    from those same factors. Then
+    \begin{align}
+        (w_L\otimes w_R)u_{23}&=v_{23}(u\otimes u).
+        \label{eq:mpug_staircase_network_uncancelled}
+    \end{align}
+    No simplicity or unitarity assumption on $\mathcal U$ is required.
+    This is the first diagram in the proof of the staircase-gate corollary
+    of \cite[lines~918--968]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_open_two_site, thm:mpu_source_v_open_two_site}
+    Expand the crossed contractions on both sides. For output index
+    $((l,i_2),(i_3,r))$ and input index $((j_1,j_2),(j_3,j_4))$,
+    the two open factorizations identify both entries with
+    \begin{align}
+        \sum_{\alpha,\gamma=1}^D
+        (Y_2)_{l,(j_1,\alpha)}
+        (\mathcal U^{i_2}_{j_2}\mathcal U^{i_3}_{j_3})_{\alpha,\gamma}
+        (Y_1)_{r,(\gamma,j_4)}.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[The first staircase network after cancellation]
+    \label{thm:mpug_staircase_network_cancelled}
+    \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_eq}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpug_staircase_gates, def:mpug_staircase_middle,
+        def:mpu_source_uv}
+    Let $\mathcal U$ have source factors as in
+    Definition~\ref{def:mpug_staircase_gates}, and form $u,v,w_L,w_R$
+    from those same factors. If $u$ is a coisometry, so that
+    $uu^\dagger=I_{d_ld_r}$, then
+    \begin{align}
+        w_L\otimes w_R
+         &=v_{23}(u\otimes u)(u^\dagger)_{23} \\
+         &=(I\otimes v\otimes I)(u\otimes u)
+            (I\otimes u^\dagger\otimes I).
+        \label{eq:mpug_staircase_network_cancelled}
+    \end{align}
+    The second expression uses the regrouping of
+    Definition~\ref{def:mpug_staircase_middle}. This is the displayed
+    network identity in
+    \cite[lines~969--974]{FrancoRubio2025MPUGauging}.
+    % Partial result under the explicit coisometry premise, not cor:mpu:
+    % no second network, individual gate unitarity, or scalar normalization.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_staircase_network_uncancelled,
+        thm:mpug_staircase_middle_composition}
+    Multiply (\ref{eq:mpug_staircase_network_uncancelled}) on the right by
+    $(u^\dagger)_{23}$. The middle layers compose to
+    $(uu^\dagger)_{23}=I$, giving
+    (\ref{eq:mpug_staircase_network_cancelled}).
+\end{proof}
+
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
 \label{sec:mpug_scalar_gauge}
 
@@ -4670,6 +4805,41 @@ by the displayed matrices.
     Thus the operator is the monomial matrix for complementation, with
     column phase $(-1)^{E(\kappa_N(t))}$. Each phase has absolute value one,
     so Theorem~\ref{thm:mpug_monomial_matrix_laws} proves unitarity.
+\end{proof}
+
+\begin{theorem}[Injectivity of the once-blocked CZX tensor]
+    \label{thm:mpug_czx_exact_tensor_injective}
+    \lean{MPOTensor.CZX.tensor_isInjective}
+    \leanok
+    \discussion{7354}
+    \uses{def:mpug_czx_exact_tensor, def:injective}
+    The once-blocked CZX tensor $B$ of
+    Definition~\ref{def:mpug_czx_exact_tensor}, with the unnormalized
+    Hadamard weights and both output $Z$ gates, is injective:
+    \begin{align}
+        \operatorname{span}_{\C}\{B^{i,j}:0\leq i,j<4\}
+         &=\operatorname{Mat}_2(\C).
+    \end{align}
+    Here $B^{2a+b,2c+d}=B^{ab,cd}$ for binary $a,b,c,d$.
+    This is the injectivity assertion preceding the tensor diagram in
+    \cite[lines~4505--4547]{FrancoRubio2025MPUGauging}.
+    % Source: eq:MPU_CZX. This proves only injectivity of the shared tensor;
+    % it does not complete the GHZ, fusion, or action-data scope of #7354.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_exact_tensor_unitary}
+    Let $E_{ab}$ be the bond matrix units, with $a,b\in\{0,1\}$.
+    The coordinate formula gives
+    \begin{align}
+        E_{00}&=\tfrac12(B^{0,3}-B^{1,2}), &
+        E_{01}&=\tfrac12(B^{0,3}+B^{1,2}), \\
+        E_{10}&=-\tfrac12(B^{2,1}+B^{3,0}), &
+        E_{11}&=\tfrac12(B^{3,0}-B^{2,1}).
+    \end{align}
+    Thus every bond matrix unit lies in the span of the physical letters.
+    Since every $2\times2$ matrix is a linear combination of these units,
+    the letters span the full bond matrix algebra.
 \end{proof}
 
 \subsection{The displayed CZX circuit tuple}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1019,10 +1019,10 @@ gauges and scalar relation have been constructed.
     where $\rho$ is a matrix on the virtual space. Define
     \begin{align}
         (w_L)_{(l,i),(j,l')}
-         & =\sum_{\beta=1}^D (Y_2)_{l,(j,\beta)}
-        (X_2)_{(\beta,i),l'}, \\
+         & =\sum_{\beta=0}^{D-1} (Y_2)_{l,(j,\beta)}
+        (X_2)_{(\beta,i),l'},                         \\
         (w_R)_{(i,r),(r',j)}
-         & =\sum_{\beta=1}^D (X_1)_{(i,\beta),r'}
+         & =\sum_{\beta=0}^{D-1} (X_1)_{(i,\beta),r'}
         (Y_1)_{r,(\beta,j)}.
     \end{align}
     Thus $w_L\colon\C^d\otimes\C^{d_l}\to\C^{d_l}\otimes\C^d$
@@ -1093,7 +1093,7 @@ gauges and scalar relation have been constructed.
     $((l,i_2),(i_3,r))$ and input index $((j_1,j_2),(j_3,j_4))$,
     the two open factorizations identify both entries with
     \begin{align}
-        \sum_{\alpha,\gamma=1}^D
+        \sum_{\alpha,\gamma=0}^{D-1}
         (Y_2)_{l,(j_1,\alpha)}
         (\mathcal U^{i_2}_{j_2}\mathcal U^{i_3}_{j_3})_{\alpha,\gamma}
         (Y_1)_{r,(\gamma,j_4)}.
@@ -4830,12 +4830,13 @@ by the displayed matrices.
 \begin{proof}\leanok
     \uses{thm:mpug_czx_exact_tensor_unitary}
     Let $E_{ab}$ be the bond matrix units, with $a,b\in\{0,1\}$.
-    The coordinate formula gives
+    The coordinate formula in
+    Theorem~\ref{thm:mpug_czx_exact_tensor_unitary} gives
     \begin{align}
         E_{00}
-         & =\tfrac12(B^{0,3}-B^{1,2}), \\
+         & =\tfrac12(B^{0,3}-B^{1,2}),  \\
         E_{01}
-         & =\tfrac12(B^{0,3}+B^{1,2}), \\
+         & =\tfrac12(B^{0,3}+B^{1,2}),  \\
         E_{10}
          & =-\tfrac12(B^{2,1}+B^{3,0}), \\
         E_{11}


### PR DESCRIPTION
### Motivation
Advance the oldest unowned source-network prerequisite #7314 and the concrete shared-tensor prerequisite of #7354, following `Papers/2502.20257/main.tex` and reusing the 2017 MPU factor library. Also synchronizes obsolete maintainer comments under #7660 without changing mathematical status.

Stacked on #7787 only to preserve the shared-workspace commit history; no mathematical dependency on that cleanup. No existing assigned structural/fusion lane was taken over.

### Description
- `StaircaseGates.lean`: literal `w_L,w_R` of `eq:wLR`, explicit middle-leg placement, first graphical equality, and the displayed identity obtained by the source's coisometry cancellation `uu†=I` (main.tex:811–974). Reuses `SourceFactors`, `SourceUV`, both `StandardForm` factorizations, and promoted finite-sum helpers. No new source-factor bundle.
- `CZXTensorInjectivity.lean`: the four nonzero physical letters of the exact shared FBC25 CZX tensor span all matrix units (main.tex:4505–4547). No duplicate tensor and no identification with the incorrectly normalized printed-2017 tensor.
- Generated MPU/MPDO imports; six truthful Chapter 29 nodes covering all eight public declarations.
- Chapter 28 changes are comments only; retain all supplied-data and pathwise nodes. Existing #7660/#7758 acceptance text now distinguishes the generic lemma, three same-tensor candidates, twelve derived-tensor restrictions, and twenty-three pathwise entries.

These results do NOT close `cor:mpu`, #7314, #7354, or #7660. The second staircase network/scalar normalization, GHZ/action/fusion data, and deferred canonical-form bridges remain tracked.

### Testing
- Cached locked target builds: StaircaseGates 1.0s; CZXTensorInjectivity final check 2.1s (initial CZXTensor refresh 3.3s). No Mathlib or broad dependency rebuild.
- Staircase explicit strict/project-linter check: exit 0, no diagnostics. CZX importing test and axiom audit: only `propext`, `Classical.choice`, `Quot.sound`.
- Independent source and Lean/style reviews approved both modules; independent blueprint review approved exact signatures, dependencies, and partial-result scope.
- Static blueprint/declaration sync, all-public coverage, reference/environment checks, whitespace, reader-facing prose and LaTeX lint passed.
- Actual Chapter 29 PDF rendered twice with XeLaTeX using existing macros/cache: 54 pages. Isolated render has expected external-chapter/bibliography references; no new-entry bad boxes.
- Tactic-pattern scan performed; new contraction proof reuses the existing promoted finite-sum helpers. No new bypasses or placeholders.
- Full remote CI / Lean-backed declaration check remains required before merge.
