### PR TITLE
feat(MPU): prove the adjoint-simple contraction and CZX GHZ invariance

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -106,6 +106,7 @@ import TNLean.MPS.MPDO.CPSVVerticalProductFusionDecomposition
 import TNLean.MPS.MPDO.CPSVVerticalProductSpectralFamily
 import TNLean.MPS.MPDO.CZXCompletion
 import TNLean.MPS.MPDO.CZXDefectMaps
+import TNLean.MPS.MPDO.CZXGHZAction
 import TNLean.MPS.MPDO.CZXGaussCircuitTuple
 import TNLean.MPS.MPDO.CZXGaussInvariantSubspace
 import TNLean.MPS.MPDO.CZXSecondTupleCertificate

--- a/TNLean/MPS/MPDO/CZXGHZAction.lean
+++ b/TNLean/MPS/MPDO/CZXGHZAction.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Examples.GHZ
+import TNLean.MPS.MPDO.CZXTensor
+
+/-!
+# The exact CZX operator preserves the blocked GHZ state
+
+arXiv:2502.20257, lines 4660–4670, states that the CZX MPU leaves the GHZ
+MPS invariant, with once-blocked sectors $|00\rangle$ and $|11\rangle$.
+We use the existing GHZ tensor and physical blocking, transported by the
+existing two-site index equivalence to the CZX alphabet ordered as $2a+b$.
+The exact CZX operator interchanges the two constant configurations with
+phase one. No on-site symmetry, fusion, or classification assertion is made.
+-/
+
+noncomputable section
+
+open scoped BigOperators Matrix
+
+namespace MPOTensor.CZX
+
+/-- The actual GHZ tensor blocked once, in the CZX physical order $2a+b$.
+Source: arXiv:2502.20257, lines 4660–4670. -/
+def blockedGHZTensor : MPSTensor 4 2 :=
+  Kraus.reindexPhysical (twoSiteBlockEquiv 2) (MPSTensor.blockTensor MPSTensor.ghzTensor 2)
+
+/-- The two once-blocked GHZ sectors are precisely $|00\rangle$ and
+$|11\rangle$, as displayed in arXiv:2502.20257, lines 4660–4670. -/
+theorem blockTensor_ghzSectorTensor_apply (x : Fin 2) (i : Fin 4) :
+    MPSTensor.blockTensor (MPSTensor.ghzSectorTensor x) 2 (twoSiteBlockEquiv 2 i) =
+      if i = finProdFinEquiv (x, x) then 1 else 0 := by
+  fin_cases x <;> fin_cases i <;>
+    norm_num [MPSTensor.blockTensor, Kraus.blockTensor, twoSiteBlockEquiv,
+      Kraus.wordOfBlock, MPSTensor.ghzSectorTensor, finProdFinEquiv, Fin.divNat, Fin.modNat]
+
+private theorem blockedGHZTensor_apply (i : Fin 4) :
+    blockedGHZTensor i = Matrix.diagonal (fun x : Fin 2 ↦
+      if i = finProdFinEquiv (x, x) then (1 : ℂ) else 0) := by
+  fin_cases i <;>
+    norm_num [blockedGHZTensor, Kraus.reindexPhysical, MPSTensor.blockTensor,
+      Kraus.blockTensor, twoSiteBlockEquiv, Kraus.wordOfBlock,
+      finProdFinEquiv, Fin.divNat, Fin.modNat, Pi.single_apply]
+
+private theorem evalWord_blockedGHZTensor {N : ℕ} (s : Fin N → Fin 4) :
+    Kraus.evalWord blockedGHZTensor (List.ofFn s) =
+      Matrix.diagonal (fun x : Fin 2 ↦ ∏ n,
+        if s n = finProdFinEquiv (x, x) then (1 : ℂ) else 0) := by
+  induction N with
+  | zero => simp [Matrix.diagonal_one]
+  | succ N ih =>
+    rw [List.ofFn_succ, Kraus.evalWord_cons, blockedGHZTensor_apply, ih,
+      Matrix.diagonal_mul_diagonal]
+    congr 1
+    funext x
+    simp [Fin.prod_univ_succ]
+
+/-- The MPV of the actual once-blocked GHZ tensor is the sum of the constant
+$00$ and $11$ configurations. Source: arXiv:2502.20257, lines 4660–4670. -/
+theorem mpv_blockedGHZTensor {N : ℕ} :
+    (MPSTensor.mpv blockedGHZTensor : (Fin N → Fin 4) → ℂ) =
+      Pi.single (fun _ ↦ 0) 1 + Pi.single (fun _ ↦ 3) 1 := by
+  funext s
+  rw [MPSTensor.mpv, MPSTensor.coeff, evalWord_blockedGHZTensor, Matrix.trace_diagonal]
+  simp only [Fin.sum_univ_two, Fintype.prod_boole, Pi.add_apply, Pi.single_apply]
+  have h0 : finProdFinEquiv ((0 : Fin 2), (0 : Fin 2)) = (0 : Fin 4) := rfl
+  have h3 : finProdFinEquiv ((1 : Fin 2), (1 : Fin 2)) = (3 : Fin 4) := rfl
+  rw [h0, h3]
+  simp only [← funext_iff]
+
+private theorem cyclicPhase_ghz_constant {N : ℕ} [NeZero N] (x : Fin 2) :
+    (-1 : ℂ) ^ cyclicExponent (fun _ : Fin N ↦ finProdFinEquiv (x, x)) = 1 := by
+  have he : ∀ x : Fin 2,
+      edgeExponent (finProdFinEquiv (x, x)) (siteBits (finProdFinEquiv (x, x))).1 =
+        4 * x.val := by decide
+  simp only [cyclicExponent, he, Finset.sum_const, Finset.card_univ,
+    Fintype.card_fin, nsmul_eq_mul]
+  rw [mul_comm, pow_mul]
+  fin_cases x <;> norm_num
+
+/-- The exact CZX operator leaves the actual once-blocked GHZ MPV invariant
+at every positive chain length. The physical indices are transported through
+the maintained two-site blocking equivalence, not a numerical cast.
+Source: arXiv:2502.20257, lines 4660–4670. -/
+theorem mpo_tensor_mulVec_blockedGHZ {N : ℕ} [NeZero N] :
+    mpo tensor N *ᵥ (fun s : Fin N → Fin 4 ↦
+      MPSTensor.mpv (MPSTensor.blockTensor MPSTensor.ghzTensor 2)
+        (fun n ↦ twoSiteBlockEquiv 2 (s n))) =
+      (fun s : Fin N → Fin 4 ↦
+        MPSTensor.mpv (MPSTensor.blockTensor MPSTensor.ghzTensor 2)
+          (fun n ↦ twoSiteBlockEquiv 2 (s n))) := by
+  have hv : (fun s : Fin N → Fin 4 ↦
+      MPSTensor.mpv (MPSTensor.blockTensor MPSTensor.ghzTensor 2)
+        (fun n ↦ twoSiteBlockEquiv 2 (s n))) = MPSTensor.mpv blockedGHZTensor := by
+    funext s
+    exact (MPSTensor.mpv_reindexPhysical _ _ s).symm
+  rw [hv, mpv_blockedGHZTensor, Matrix.mulVec_add, mpo_tensor,
+    Matrix.monomial_mulVec_single, Matrix.monomial_mulVec_single]
+  have hc0 : complement N (fun _ ↦ 0) = (fun _ ↦ 3) := by
+    funext n
+    exact show complementSite 0 = 3 from by decide
+  have hc3 : complement N (fun _ ↦ 3) = (fun _ ↦ 0) := by
+    funext n
+    exact show complementSite 3 = 0 from by decide
+  rw [hc0, hc3]
+  have hp0 := cyclicPhase_ghz_constant (N := N) 0
+  have hp3 := cyclicPhase_ghz_constant (N := N) 1
+  change (-1 : ℂ) ^ cyclicExponent (fun _ : Fin N ↦ 0) = 1 at hp0
+  change (-1 : ℂ) ^ cyclicExponent (fun _ : Fin N ↦ 3) = 1 at hp3
+  rw [hp0, hp3, one_smul, one_smul, add_comm]
+
+end MPOTensor.CZX

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.MPU
 
+import TNLean.MPS.MPU.AdjointSimpleContraction
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm

--- a/TNLean/MPS/MPU/AdjointSimpleContraction.lean
+++ b/TNLean/MPS/MPU/AdjointSimpleContraction.lean
@@ -33,7 +33,6 @@ This file does not prove the four normalized source-factor equations
 -/
 
 open scoped Matrix BigOperators
-open Matrix
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPU/AdjointSimpleContraction.lean
+++ b/TNLean/MPS/MPU/AdjointSimpleContraction.lean
@@ -103,8 +103,9 @@ noncomputable def IsMPUCanonicalFormII.physicalAdjointTensor
 
 /-- The reflected double layer admits canonical boundary removal using the
 same \(I,\rho\) boundaries. The adjoint-simple hypothesis is the explicit
-additional source hypothesis of arXiv:2502.20257, Proposition `eq:MPUnice3`--
-`eq:MPUnice4`, lines 1070--1163; the contraction is used in lines 1164--1254.
+additional source hypothesis of arXiv:2502.20257, lines 1070--1163 (the
+proposition establishing the normalized source-factor identities); the
+contraction is used in lines 1164--1254.
 -/
 theorem IsMPUCanonicalFormII.physicalAdjoint_doubleLayer_boundary_contractions
     {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)

--- a/TNLean/MPS/MPU/AdjointSimpleContraction.lean
+++ b/TNLean/MPS/MPU/AdjointSimpleContraction.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinSumPermutation
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Chain.CrossProductRigidity
+import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm
+import TNLean.MPS.MPU.SourceFactorContraction
+import TNLean.MPS.MPU.SuppliedFixedWitnesses
+
+/-!
+# The adjoint-simple six-tensor contraction
+
+The six-tensor argument in arXiv:2502.20257, lines 1164--1254, removes
+one double-layer letter at a canonical boundary. We align the simplicity
+witnesses with the recorded fixed matrix, expand the six-tensor network,
+and reduce it in two ways to prove the cross-product identity for the actual
+marked three-tensor contraction. Normality then implies proportionality by
+the existing cross-product rigidity theorem (source lines 1255--1325).
+The source's additional assumption that the physical adjoint is simple is
+retained explicitly.
+
+All double-layer letters and the marked contraction are raw MPO tensors.
+The transfer power used to align their boundary witnesses uses the normalized
+flattening. For rigidity we scale the cross-product identity to that normalized
+flattening, then absorb its scalar into the proportionality constant. We do not
+identify raw and normalized normality by definitional equality.
+
+This file does not prove the four normalized source-factor equations
+`eq:MPUnice3` and `eq:MPUnice4`.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Removal of a boundary letter in a pair of double-layer letters, with the
+canonical left boundary \(I\) and right boundary \(\rho\).
+
+These are the local boundary contractions needed in arXiv:2502.20257,
+lines 1164--1254. For the reflected pair, transport the canonical data to
+the physical adjoint and separately supply its simplicity; simplicity
+of the original tensor is not used as a substitute for that hypothesis.
+The witness alignment uses arXiv:1703.09188, equations `Erightleft`,
+`simple1`, and `simple2`.
+-/
+theorem IsMPUCanonicalFormII.doubleLayer_boundary_contractions
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U) :
+    let Φ : Fin (D * D) → ℂ := fun x ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+    let ρ : Fin (D * D) → ℂ := fun x ↦ hU.ρ.vec (finProdFinEquiv.symm x)
+    ∀ i j k l : Fin d,
+      Matrix.vecMul Φ (doubleLayerTensor U i j * doubleLayerTensor U k l) =
+        (if i = j then (1 : ℂ) else 0) • Matrix.vecMul Φ (doubleLayerTensor U k l) ∧
+      (doubleLayerTensor U i j * doubleLayerTensor U k l) *ᵥ ρ =
+        (if k = l then (1 : ℂ) else 0) • (doubleLayerTensor U i j *ᵥ ρ) := by
+  have := hU.neZero_phys
+  dsimp only
+  let Φ : Fin (D * D) → ℂ := fun x ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+  let ρ : Fin (D * D) → ℂ := fun x ↦ hU.ρ.vec (finProdFinEquiv.symm x)
+  have h₂ := hsimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec
+    ρ Φ (max (D * D - 1) 1) (by omega) hU.normalizedDiagonal_pow_eq_vecMulVec
+  have h₁ := hU.isMPU.simple1_of_simple2_supplied Φ ρ h₂
+  intro i j k l
+  change Matrix.vecMul Φ (_ * _) = _ • Matrix.vecMul Φ _ ∧
+    (_ * _) *ᵥ ρ = _ • (_ *ᵥ ρ)
+  rw [h₂ i j k l]
+  constructor
+  · rw [← Matrix.vecMul_vecMul, ← Matrix.vecMul_vecMul,
+      Matrix.vecMul_vecMulVec, ← Matrix.dotProduct_mulVec, h₁ i j,
+      Matrix.smul_vecMul]
+  · rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec,
+      Matrix.vecMulVec_mulVec, h₁ k l, Matrix.mulVec_smul]
+    split_ifs <;> simp
+
+/-- Physical adjunction preserves the canonical data with exactly the same
+recorded diagonal matrix \(\rho\). This supplies the canonical boundaries for
+the reflected double layer in arXiv:2502.20257, lines 1164--1254. It makes
+no claim that physical adjunction preserves simplicity.
+-/
+noncomputable def IsMPUCanonicalFormII.physicalAdjointTensor
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U) :
+    IsMPUCanonicalFormII (MPOTensor.physicalAdjointTensor U) where
+  isMPU := hU.isMPU.physicalAdjointTensor
+  cfii := hU.cfii.physicalAdjointNormalizedFlattening
+  fullSupport_eq := hU.fullSupport_eq
+  ρ := hU.ρ
+  ρ_posDef := hU.ρ_posDef
+  ρ_isDiag := hU.ρ_isDiag
+  ρ_trace := hU.ρ_trace
+  ρ_fixed := by
+    rw [normalizedFlattening_physicalAdjointTensor,
+      MPSTensor.transferMap_reindexPhysical_equiv]
+    rw [← MPSTensor.map_star_eq_self_of_posDef_isDiag hU.ρ_posDef hU.ρ_isDiag,
+      MPSTensor.transferMap_mapStar, hU.ρ_fixed,
+      MPSTensor.map_star_eq_self_of_posDef_isDiag hU.ρ_posDef hU.ρ_isDiag]
+
+/-- The reflected double layer admits canonical boundary removal using the
+same \(I,\rho\) boundaries. The adjoint-simple hypothesis is the explicit
+additional source hypothesis of arXiv:2502.20257, Proposition `eq:MPUnice3`--
+`eq:MPUnice4`, lines 1070--1163; the contraction is used in lines 1164--1254.
+-/
+theorem IsMPUCanonicalFormII.physicalAdjoint_doubleLayer_boundary_contractions
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    let V := MPOTensor.physicalAdjointTensor U
+    let Φ : Fin (D * D) → ℂ := fun x ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+    let ρ : Fin (D * D) → ℂ := fun x ↦ hU.ρ.vec (finProdFinEquiv.symm x)
+    ∀ i j k l : Fin d,
+      Matrix.vecMul Φ (doubleLayerTensor V i j * doubleLayerTensor V k l) =
+        (if i = j then (1 : ℂ) else 0) • Matrix.vecMul Φ (doubleLayerTensor V k l) ∧
+      (doubleLayerTensor V i j * doubleLayerTensor V k l) *ᵥ ρ =
+        (if k = l then (1 : ℂ) else 0) • (doubleLayerTensor V i j *ᵥ ρ) :=
+  hU.physicalAdjointTensor.doubleLayer_boundary_contractions hadjoint
+
+private theorem sum_doubled_bond (f : Fin (D * D) → ℂ) :
+    (∑ z, f z) = ∑ x : Fin D, ∑ y : Fin D, f (finProdFinEquiv (x, y)) := by
+  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+
+private theorem upper_boundary_entries
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U))
+    (i j k l : Fin d) (b r : Fin D) :
+    (∑ x : Fin D, ∑ m : Fin D, ∑ n : Fin D,
+      (∑ p : Fin d, U i p x m * star (U j p x n)) *
+        (∑ q : Fin d, U k q m b * star (U l q n r))) =
+      (if i = j then (1 : ℂ) else 0) *
+        ∑ x : Fin D, ∑ q : Fin d, U k q x b * star (U l q x r) := by
+  have h := congrArg (fun v ↦ v (finProdFinEquiv (b, r)))
+    ((hU.physicalAdjoint_doubleLayer_boundary_contractions hadjoint i j k l).1)
+  simpa [Matrix.vecMul, dotProduct, Matrix.mul_apply, sum_doubled_bond,
+    Matrix.vec, Matrix.one_apply, Matrix.sum_apply,
+    Finset.mul_sum, Finset.sum_mul] using h
+
+private theorem lower_boundary_entries
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U) (i j k l : Fin d) (x a : Fin D) :
+    (∑ r : Fin D, ∑ t : Fin D, ∑ n : Fin D, ∑ z : Fin D,
+      (∑ p : Fin d, star (U p i x n) * U p j a z) *
+        (∑ q : Fin d, star (U q k n r) * U q l z t) * hU.ρ t r) =
+      (if k = l then (1 : ℂ) else 0) *
+        ∑ r : Fin D, ∑ t : Fin D,
+          (∑ p : Fin d, star (U p i x r) * U p j a t) * hU.ρ t r := by
+  have h := congrArg (fun v ↦ v (finProdFinEquiv (x, a)))
+    ((hU.doubleLayer_boundary_contractions hsimple i j k l).2)
+  simpa [Matrix.mulVec, dotProduct, Matrix.mul_apply, sum_doubled_bond,
+    Matrix.vec, Matrix.sum_apply, Finset.mul_sum, Finset.sum_mul] using h
+
+/-- The marked three-tensor contraction \(s\) in arXiv:2502.20257,
+lines 1190--1218. Its left open bond is on the bottom tensor and its right
+open bond on the top tensor. The entry \(\rho_{tr}\) follows the vectorization
+order of the middle/bottom right boundary. There is no physical-dimension
+normalization factor: these are raw MPO letters. Explicitly,
+\[
+  s^{ij}_{ab}=\sum_{p,q,x,r,t} U^{ip}_{xb}\,
+    \overline{U^{qp}_{xr}}\,U^{qj}_{at}\,\rho_{tr}.
+\]
+For diagonal \(\rho\), the only surviving terms have \(t=r\), as in the
+source diagram. -/
+noncomputable def adjointSimpleContraction (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) : MPOTensor d D :=
+  fun i j a b ↦ ∑ p : Fin d, ∑ x : Fin D, ∑ r : Fin D, ∑ t : Fin D,
+    U i p x b * (∑ q : Fin d, star (U q p x r) * U q j a t) * ρ t r
+
+private noncomputable def sixTensorContraction (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (i j k l : Fin d) (a b : Fin D) : ℂ :=
+  ∑ p : Fin d, ∑ x : Fin D, ∑ q : Fin d, ∑ m : Fin D,
+    (U i p x m * U k q m b) *
+      (∑ r : Fin D, ∑ t : Fin D, ∑ n : Fin D, ∑ z : Fin D,
+        (∑ v : Fin d, star (U v p x n) * U v j a z) *
+          (∑ w : Fin d, star (U w q n r) * U w l z t) * ρ t r)
+
+private theorem sixTensorContraction_lower
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U) (i j k l : Fin d) (a b : Fin D) :
+    sixTensorContraction U hU.ρ i j k l a b =
+      (adjointSimpleContraction U hU.ρ i j * U k l) a b := by
+  simp only [sixTensorContraction, lower_boundary_entries hU hsimple]
+  simp only [mul_ite, one_mul, mul_zero, mul_assoc, ite_mul, zero_mul,
+    Finset.sum_ite_irrel, Finset.sum_const_zero, Finset.sum_ite_eq',
+    Finset.mem_univ, ite_true]
+  rw [Finset.sum_comm, Fintype.sum_reverse_three]
+  simp only [Matrix.mul_apply, adjointSimpleContraction,
+    Finset.mul_sum, Finset.sum_mul]
+  congr 1
+  funext m
+  apply Finset.sum_congr₂
+  intro p _ x _
+  apply Finset.sum_congr₂
+  intro r _ t _
+  apply Finset.sum_congr rfl
+  intro v _
+  ring
+
+private theorem sixTensorContraction_reorder (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (i j k l : Fin d) (a b : Fin D) :
+    sixTensorContraction U ρ i j k l a b =
+      ∑ v : Fin d, ∑ w : Fin d, ∑ z : Fin D, ∑ t : Fin D, ∑ r : Fin D,
+        (U v j a z * U w l z t * ρ t r) *
+          (∑ x : Fin D, ∑ m : Fin D, ∑ n : Fin D,
+            (∑ p : Fin d, U i p x m * star (U v p x n)) *
+              (∑ q : Fin d, U k q m b * star (U w q n r))) := by
+  simp only [sixTensorContraction, Finset.mul_sum, Finset.sum_mul]
+  let e :
+      (Fin d × Fin D × Fin d × Fin D × Fin D × Fin D × Fin D × Fin D × Fin d × Fin d) ≃
+      (Fin d × Fin d × Fin D × Fin D × Fin D × Fin D × Fin D × Fin D × Fin d × Fin d) :=
+    { toFun := fun ⟨p, x, q, m, r, t, n, z, w, v⟩ ↦ ⟨v, w, z, t, r, x, m, n, q, p⟩
+      invFun := fun ⟨v, w, z, t, r, x, m, n, q, p⟩ ↦ ⟨p, x, q, m, r, t, n, z, w, v⟩
+      left_inv := by rintro ⟨p, x, q, m, r, t, n, z, w, v⟩; rfl
+      right_inv := by rintro ⟨v, w, z, t, r, x, m, n, q, p⟩; rfl }
+  have h := Fintype.sum_equiv e
+    (fun ⟨p, x, q, m, r, t, n, z, w, v⟩ ↦
+      (U i p x m * U k q m b) *
+        ((star (U v p x n) * U v j a z) *
+          (star (U w q n r) * U w l z t) * ρ t r))
+    (fun ⟨v, w, z, t, r, x, m, n, q, p⟩ ↦
+      (U v j a z * U w l z t * ρ t r) *
+        ((U i p x m * star (U v p x n)) * (U k q m b * star (U w q n r))))
+    (by rintro ⟨p, x, q, m, r, t, n, z, w, v⟩; dsimp [e]; ring)
+  simpa only [Fintype.sum_prod_type] using h
+
+private theorem sixTensorContraction_upper
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U))
+    (i j k l : Fin d) (a b : Fin D) :
+    sixTensorContraction U hU.ρ i j k l a b =
+      (U i j * adjointSimpleContraction U hU.ρ k l) a b := by
+  rw [sixTensorContraction_reorder]
+  simp only [upper_boundary_entries hU hadjoint]
+  simp only [mul_ite, one_mul, mul_zero, mul_assoc, ite_mul, zero_mul,
+    Finset.sum_ite_irrel, Finset.sum_const_zero, Finset.sum_ite_eq,
+    Finset.mem_univ, ite_true]
+  simp only [Matrix.mul_apply, adjointSimpleContraction,
+    Finset.mul_sum, Finset.sum_mul]
+  let e : (Fin d × Fin D × Fin D × Fin D × Fin D × Fin d) ≃
+      (Fin D × Fin d × Fin D × Fin D × Fin D × Fin d) :=
+    { toFun := fun ⟨w, z, t, r, x, q⟩ ↦ ⟨z, q, x, r, t, w⟩
+      invFun := fun ⟨z, q, x, r, t, w⟩ ↦ ⟨w, z, t, r, x, q⟩
+      left_inv := by rintro ⟨w, z, t, r, x, q⟩; rfl
+      right_inv := by rintro ⟨z, q, x, r, t, w⟩; rfl }
+  have h := Fintype.sum_equiv e
+    (fun ⟨w, z, t, r, x, q⟩ ↦
+      (U i j a z * (U w l z t * hU.ρ t r)) *
+        (U k q x b * star (U w q x r)))
+    (fun ⟨z, q, x, r, t, w⟩ ↦
+      U i j a z * (U k q x b * (star (U w q x r) * U w l z t) * hU.ρ t r))
+    (by rintro ⟨w, z, t, r, x, q⟩; dsimp [e]; ring)
+  simpa only [Fintype.sum_prod_type, mul_assoc] using h
+
+/-- The two reductions of the six-tensor network give the cross-product
+identity for the actual marked contraction \(s\). The upper pair uses the
+left-boundary identity for the physical adjoint; the lower pair uses the
+right-boundary identity for the original tensor.
+
+Source: arXiv:2502.20257, lines 1164--1254. Both simplicity hypotheses are
+retained, and no cross-product identity is assumed. -/
+theorem IsMPUCanonicalFormII.adjointSimpleContraction_cross_mul
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U))
+    (i j k l : Fin d) :
+    adjointSimpleContraction U hU.ρ i j * U k l =
+      U i j * adjointSimpleContraction U hU.ρ k l := by
+  ext a b
+  exact (sixTensorContraction_lower hU hsimple i j k l a b).symm.trans
+    (sixTensorContraction_upper hU hadjoint i j k l a b)
+
+/-- The marked contraction \(s\) is one common scalar multiple of the raw
+MPU tensor. Apply normality rigidity to the normalized flattening after scaling
+the proved cross-product equation, then absorb \(1/\sqrt d\) into the scalar.
+
+Source: arXiv:2502.20257, lines 1255--1325. This is only the proportionality
+step, not the subsequent determination of the normalized source-factor constants.
+-/
+theorem IsMPUCanonicalFormII.adjointSimpleContraction_eq_smul
+    {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    ∃ δ : ℂ, ∀ i j : Fin d, adjointSimpleContraction U hU.ρ i j = δ • U i j := by
+  have := hU.neZero_phys
+  have := hU.neZero_bond
+  have hnormal : Kraus.IsNormal U.normalizedFlattening :=
+    hU.isNormalTensor_normalizedFlattening.isNormal
+  have hcross : ∀ i j : Fin (d * d),
+      (adjointSimpleContraction U hU.ρ).toMPSTensor i * U.normalizedFlattening j =
+        U.normalizedFlattening i * (adjointSimpleContraction U hU.ρ).toMPSTensor j := by
+    intro i j
+    simp only [normalizedFlattening, toMPSTensor, Matrix.mul_smul, Matrix.smul_mul]
+    rw [hU.adjointSimpleContraction_cross_mul hsimple hadjoint]
+  obtain ⟨δ, hδ⟩ := hnormal.eq_smul_of_cross_mul_eq hcross
+  refine ⟨δ * ((Real.sqrt d : ℂ)⁻¹), ?_⟩
+  intro i j
+  simpa only [normalizedFlattening, toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, smul_smul] using hδ (finProdFinEquiv (i, j))
+
+end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1280,7 +1280,6 @@ Definition~\ref{def:mpug_group_representation}.
 \begin{proof}\leanok
     \uses{thm:mpu_physical_adjoint_identities,
         def:mpu_physical_adjoint_cfii_data,
-        thm:mpu_physical_adjoint_full_support,
         thm:mpu_physical_adjoint_normalized_flattening,
         thm:cpsv_map_star_transfer_fixed_point}
     Physical adjunction preserves periodic unitarity and transports the

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1301,8 +1301,8 @@ Definition~\ref{def:mpug_group_representation}.
     put $(\Phi|_{(a,b)}=\delta_{a,b}$ and
     $|\rho)_{(a,b)}=\rho_{ba}$. For all physical indices $i,j,k,l$,
     \begin{align}
-        (\Phi|W^{ij}W^{kl}&=\delta_{ij}(\Phi|W^{kl}, \\
-        W^{ij}W^{kl}|\rho)&=\delta_{kl}W^{ij}|\rho).
+        (\Phi|W^{ij}W^{kl} & =\delta_{ij}(\Phi|W^{kl}, \\
+        W^{ij}W^{kl}|\rho) & =\delta_{kl}W^{ij}|\rho).
         \label{eq:mpug_simple_canonical_boundaries}
     \end{align}
     These are the boundary removals used in the six-tensor argument of
@@ -1333,9 +1333,9 @@ Definition~\ref{def:mpug_group_representation}.
     $|\rho)_{(a,b)}=\rho_{ba}$. For all physical indices $i,j,k,l$,
     \begin{align}
         (\Phi|W_\dagger^{ij}W_\dagger^{kl}
-         &=\delta_{ij}(\Phi|W_\dagger^{kl}, \\
+         & =\delta_{ij}(\Phi|W_\dagger^{kl}, \\
         W_\dagger^{ij}W_\dagger^{kl}|\rho)
-         &=\delta_{kl}W_\dagger^{ij}|\rho).
+         & =\delta_{kl}W_\dagger^{ij}|\rho).
     \end{align}
     The simplicity assumption is precisely the additional hypothesis used
     for the reflected reduction in
@@ -1360,10 +1360,10 @@ Definition~\ref{def:mpug_group_representation}.
     Define an MPO tensor $s$ of the same dimensions by
     \begin{align}
         s^{ij}_{ab}
-         &=\sum_{p,q=1}^d\sum_{x,r,t=1}^D
-            \mathcal U^{ip}_{xb}\,
-            \overline{\mathcal U^{qp}_{xr}}\,
-            \mathcal U^{qj}_{at}\,\rho_{tr}.
+         & =\sum_{p,q=0}^{d-1}\sum_{x,r,t=0}^{D-1}
+        \mathcal U^{ip}_{xb}\,
+        \overline{\mathcal U^{qp}_{xr}}\,
+        \mathcal U^{qj}_{at}\,\rho_{tr}.
         \label{eq:mpug_adjoint_simple_contraction}
     \end{align}
     The left open bond is on the bottom tensor and the right open bond is
@@ -1386,7 +1386,7 @@ Definition~\ref{def:mpug_group_representation}.
     by (\ref{eq:mpug_adjoint_simple_contraction}). For all physical
     indices $i,j,k,l$,
     \begin{align}
-        s^{ij}\mathcal U^{kl}&=\mathcal U^{ij}s^{kl}.
+        s^{ij}\mathcal U^{kl} & =\mathcal U^{ij}s^{kl}.
         \label{eq:mpug_adjoint_simple_cross_product}
     \end{align}
     This is the equality obtained from the two reductions in
@@ -1399,11 +1399,11 @@ Definition~\ref{def:mpug_group_representation}.
     For fixed open indices $i,j,k,l,a,b$, expand the six-tensor network as
     \begin{align}
         \mathcal N^{ij,kl}_{ab}
-         &=\sum_{p,q,v,w}\sum_{x,m,n,z,r,t}
-            \mathcal U^{ip}_{xm}\mathcal U^{kq}_{mb}
-            \overline{\mathcal U^{vp}_{xn}}
-            \overline{\mathcal U^{wq}_{nr}}
-            \mathcal U^{vj}_{az}\mathcal U^{wl}_{zt}\rho_{tr}.
+         & =\sum_{p,q,v,w}\sum_{x,m,n,z,r,t}
+        \mathcal U^{ip}_{xm}\mathcal U^{kq}_{mb}
+        \overline{\mathcal U^{vp}_{xn}}
+        \overline{\mathcal U^{wq}_{nr}}
+        \mathcal U^{vj}_{az}\mathcal U^{wl}_{zt}\rho_{tr}.
     \end{align}
     The first sum ranges over physical indices and the second over virtual
     indices. Applying the right-boundary contraction to the lower two
@@ -1426,7 +1426,7 @@ Definition~\ref{def:mpug_group_representation}.
     $\mathcal U^\dagger$ are simple. Then the tensor $s$ constructed
     from this $\rho$ satisfies
     \begin{align}
-        s^{ij}&=\delta\mathcal U^{ij}
+        s^{ij} & =\delta\mathcal U^{ij}
     \end{align}
     for a single scalar $\delta\in\C$ and every physical pair $i,j$.
     This is the proportionality conclusion in
@@ -1443,7 +1443,7 @@ Definition~\ref{def:mpug_group_representation}.
     $\widetilde{\mathcal U}$. Scaling
     (\ref{eq:mpug_adjoint_simple_cross_product}) gives
     $s^{ij}\widetilde{\mathcal U}^{kl}
-    =\widetilde{\mathcal U}^{ij}s^{kl}$.
+        =\widetilde{\mathcal U}^{ij}s^{kl}$.
     Cross-product rigidity, using blocking to an injective tensor, gives
     $s^{ij}=c\widetilde{\mathcal U}^{ij}$ for one scalar $c$.
     Set $\delta=c/\sqrt d$.
@@ -5050,7 +5050,7 @@ by the displayed matrices.
     Identify the blocked physical alphabet with $\{0,1,2,3\}$ by
     $\varphi(2a+b)=(a,b)$, for $a,b\in\{0,1\}$. Define
     \begin{align}
-        \widehat A^{2a+b}&=A^aA^b=(A^{[2]})^{\varphi(2a+b)}.
+        \widehat A^{2a+b} & =A^aA^b=(A^{[2]})^{\varphi(2a+b)}.
     \end{align}
     This is the once-blocked GHZ tensor used in
     \cite[lines~4660--4670]{FrancoRubio2025MPUGauging}, with the same
@@ -5061,11 +5061,11 @@ by the displayed matrices.
     \label{thm:mpug_czx_blocked_ghz_sectors}
     \lean{MPOTensor.CZX.blockTensor_ghzSectorTensor_apply}
     \leanok
-    \uses{def:mpug_czx_blocked_ghz}
+    \uses{def:mpug_ghz_blocked_cluster_tensor, def:blocked_tensor}
     For $x\in\{0,1\}$, let $A_x^a=\delta_{a,x}$ be the
     bond-one GHZ sector. Under $\varphi(2a+b)=(a,b)$ its two-site block is
     \begin{align}
-        (A_x^{[2]})^{\varphi(i)}&=\delta_{i,3x},
+        (A_x^{[2]})^{\varphi(i)} & =\delta_{i,3x},
         \qquad i\in\{0,1,2,3\}.
     \end{align}
     Thus the blocked sector vectors are $\ket{00}$ and $\ket{11}$, as in
@@ -5087,7 +5087,7 @@ by the displayed matrices.
     $\widehat A$ is
     \begin{align}
         \ket{\psi_N}
-         &=\ket{0}^{\otimes N}+\ket{3}^{\otimes N}.
+         & =\ket{0}^{\otimes N}+\ket{3}^{\otimes N}.
         \label{eq:mpug_czx_blocked_ghz_mpv}
     \end{align}
     In the original two-qubit alphabet the two summands are
@@ -5102,9 +5102,9 @@ by the displayed matrices.
     Hence, for $s\in\{0,1,2,3\}^N$,
     \begin{align}
         \operatorname{tr}\bigl(\widehat A^{s_1}\cdots
-            \widehat A^{s_N}\bigr)
-         &=\prod_{j=1}^N\delta_{s_j,0}
-            +\prod_{j=1}^N\delta_{s_j,3}.
+        \widehat A^{s_N}\bigr)
+         & =\prod_{j=1}^N\delta_{s_j,0}
+        +\prod_{j=1}^N\delta_{s_j,3}.
     \end{align}
     These are the coefficients of the two constant configurations.
 \end{proof}
@@ -5120,12 +5120,12 @@ by the displayed matrices.
     Transport the matrix product vector of the two-site-blocked GHZ tensor
     $A^{[2]}$ by the alphabet bijection $\varphi(2a+b)=(a,b)$:
     \begin{align}
-        \psi_N(s)&=V^{(N)}(A^{[2]})_{(\varphi(s_1),\ldots,\varphi(s_N))},
+        \psi_N(s) & =V^{(N)}(A^{[2]})_{(\varphi(s_1),\ldots,\varphi(s_N))},
         \qquad s\in\{0,1,2,3\}^N.
     \end{align}
     Then the periodic CZX operator satisfies
     \begin{align}
-        O_N(B)\ket{\psi_N}&=\ket{\psi_N}.
+        O_N(B)\ket{\psi_N} & =\ket{\psi_N}.
     \end{align}
     This is the GHZ-invariance assertion in
     \cite[lines~4660--4670]{FrancoRubio2025MPUGauging}.
@@ -5141,8 +5141,8 @@ by the displayed matrices.
     the cyclic exponent is zero on $0^N$ and $4N$ on $3^N$.
     Consequently
     \begin{align}
-        O_N(B)\ket{0}^{\otimes N}&=\ket{3}^{\otimes N}, &
-        O_N(B)\ket{3}^{\otimes N}&=\ket{0}^{\otimes N}.
+        O_N(B)\ket{0}^{\otimes N} & =\ket{3}^{\otimes N}, &
+        O_N(B)\ket{3}^{\otimes N} & =\ket{0}^{\otimes N}.
     \end{align}
     Their sum is invariant.
 \end{proof}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1258,6 +1258,197 @@ Definition~\ref{def:mpug_group_representation}.
     case of blocking length one.
 \end{proof}
 
+\begin{definition}[Canonical boundaries under physical adjunction]
+    \label{def:mpug_adjoint_canonical_boundaries}
+    \lean{MPOTensor.IsMPUCanonicalFormII.physicalAdjointTensor}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpdo_physical_adjoint}
+    Let $\mathcal U$ be an MPU with a canonical-form-II presentation and
+    recorded positive diagonal fixed matrix $\rho$, with
+    $\operatorname{tr}\rho=1$. Its physical adjoint has letters
+    $(\mathcal U^\dagger)^{ij}=\overline{\mathcal U^{ji}}$; the virtual
+    indices are not transposed. Give its normalized flattening the
+    conjugated canonical blocks with the physical indices exchanged, and
+    retain the same full support and the same fixed matrix $\rho$.
+    This defines canonical-form-II data for $\mathcal U^\dagger$ with
+    the same left and right boundaries $I,\rho$.
+    These are the reflected boundaries used in
+    \cite[lines~1164--1254]{FrancoRubio2025MPUGauging}.
+    % This construction does not assert preservation of simplicity.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_physical_adjoint_identities,
+        def:mpu_physical_adjoint_cfii_data,
+        thm:mpu_physical_adjoint_full_support,
+        thm:mpu_physical_adjoint_normalized_flattening,
+        thm:cpsv_map_star_transfer_fixed_point}
+    Physical adjunction preserves periodic unitarity and transports the
+    canonical blocks without changing their dimensions. Since $\rho$ is
+    real and diagonal, conjugating the fixed-point equation leaves $\rho$
+    unchanged. The physical-index permutation does not change the transfer
+    map, so the transported data have the same fixed matrix.
+\end{proof}
+
+\begin{theorem}[Canonical boundary contractions]
+    \label{thm:mpug_simple_canonical_boundary_contractions}
+    \lean{MPOTensor.IsMPUCanonicalFormII.doubleLayer_boundary_contractions}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple, def:mpu_double_layer}
+    Let $\mathcal U$ be a simple MPU with a canonical-form-II presentation
+    and recorded fixed matrix $\rho$. Let $W$ be its raw double layer,
+    put $(\Phi|_{(a,b)}=\delta_{a,b}$ and
+    $|\rho)_{(a,b)}=\rho_{ba}$. For all physical indices $i,j,k,l$,
+    \begin{align}
+        (\Phi|W^{ij}W^{kl}&=\delta_{ij}(\Phi|W^{kl}, \\
+        W^{ij}W^{kl}|\rho)&=\delta_{kl}W^{ij}|\rho).
+        \label{eq:mpug_simple_canonical_boundaries}
+    \end{align}
+    These are the boundary removals used in the six-tensor argument of
+    \cite[lines~1164--1254]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_canonical_form_ii_transfer_stabilization,
+        thm:mpu_supplied_projector_simple2,
+        thm:mpu_all_later_simple_blockings}
+    Align the simplicity witnesses with the canonical fixed pair using
+    the stabilized normalized transfer power. The resulting identities are
+    $W^{ij}W^{kl}=W^{ij}|\rho)(\Phi|W^{kl}$ and
+    $(\Phi|W^{ij}|\rho)=\delta_{ij}$. Contract the first identity on
+    the left with $(\Phi|$ or on the right with $|\rho)$.
+\end{proof}
+
+\begin{theorem}[Canonical boundary contractions for a simple physical adjoint]
+    \label{thm:mpug_adjoint_canonical_boundary_contractions}
+    \lean{MPOTensor.IsMPUCanonicalFormII.physicalAdjoint_doubleLayer_boundary_contractions}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_double_layer}
+    Let $\mathcal U$ be an MPU with a canonical-form-II presentation and
+    recorded fixed matrix $\rho$. Assume that $\mathcal U^\dagger$ is
+    simple. Let $W_\dagger$ be the raw double layer of
+    $\mathcal U^\dagger$, put $(\Phi|_{(a,b)}=\delta_{a,b}$ and
+    $|\rho)_{(a,b)}=\rho_{ba}$. For all physical indices $i,j,k,l$,
+    \begin{align}
+        (\Phi|W_\dagger^{ij}W_\dagger^{kl}
+         &=\delta_{ij}(\Phi|W_\dagger^{kl}, \\
+        W_\dagger^{ij}W_\dagger^{kl}|\rho)
+         &=\delta_{kl}W_\dagger^{ij}|\rho).
+    \end{align}
+    The simplicity assumption is precisely the additional hypothesis used
+    for the reflected reduction in
+    \cite[lines~1221--1254]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_adjoint_canonical_boundaries,
+        thm:mpug_simple_canonical_boundary_contractions}
+    Transport the canonical presentation to $\mathcal U^\dagger$ with
+    the same $\rho$, then apply
+    Theorem~\ref{thm:mpug_simple_canonical_boundary_contractions}
+    using the assumed simplicity of $\mathcal U^\dagger$.
+\end{proof}
+
+\begin{definition}[The three-tensor contraction $s$]
+    \label{def:mpug_adjoint_simple_contraction}
+    \lean{MPOTensor.adjointSimpleContraction}
+    \leanok
+    Let $\mathcal U$ be an MPO tensor of physical dimension $d$ and bond
+    dimension $D$, and let $\rho$ be a complex $D\times D$ matrix.
+    Define an MPO tensor $s$ of the same dimensions by
+    \begin{align}
+        s^{ij}_{ab}
+         &=\sum_{p,q=1}^d\sum_{x,r,t=1}^D
+            \mathcal U^{ip}_{xb}\,
+            \overline{\mathcal U^{qp}_{xr}}\,
+            \mathcal U^{qj}_{at}\,\rho_{tr}.
+        \label{eq:mpug_adjoint_simple_contraction}
+    \end{align}
+    The left open bond is on the bottom tensor and the right open bond is
+    on the top tensor. For diagonal $\rho$ only $t=r$ contributes.
+    This is the tensor marked $s$ in
+    \cite[lines~1190--1218]{FrancoRubio2025MPUGauging}.
+    No factor $1/d$ occurs: the letters in this contraction are unnormalized.
+\end{definition}
+
+\begin{theorem}[The two reductions of the six-tensor network]
+    \label{thm:mpug_adjoint_simple_cross_product}
+    \lean{MPOTensor.IsMPUCanonicalFormII.adjointSimpleContraction_cross_mul}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpug_adjoint_simple_contraction}
+    Let $\mathcal U$ have a canonical-form-II presentation with recorded
+    fixed matrix $\rho$, and assume that both $\mathcal U$ and
+    $\mathcal U^\dagger$ are simple. Construct $s$ from this same $\rho$
+    by (\ref{eq:mpug_adjoint_simple_contraction}). For all physical
+    indices $i,j,k,l$,
+    \begin{align}
+        s^{ij}\mathcal U^{kl}&=\mathcal U^{ij}s^{kl}.
+        \label{eq:mpug_adjoint_simple_cross_product}
+    \end{align}
+    This is the equality obtained from the two reductions in
+    \cite[lines~1164--1254]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_simple_canonical_boundary_contractions,
+        thm:mpug_adjoint_canonical_boundary_contractions}
+    For fixed open indices $i,j,k,l,a,b$, expand the six-tensor network as
+    \begin{align}
+        \mathcal N^{ij,kl}_{ab}
+         &=\sum_{p,q,v,w}\sum_{x,m,n,z,r,t}
+            \mathcal U^{ip}_{xm}\mathcal U^{kq}_{mb}
+            \overline{\mathcal U^{vp}_{xn}}
+            \overline{\mathcal U^{wq}_{nr}}
+            \mathcal U^{vj}_{az}\mathcal U^{wl}_{zt}\rho_{tr}.
+    \end{align}
+    The first sum ranges over physical indices and the second over virtual
+    indices. Applying the right-boundary contraction to the lower two
+    layers gives $\mathcal N^{ij,kl}_{ab}=(s^{ij}\mathcal U^{kl})_{ab}$.
+    Regrouping the same finite sum and applying the left-boundary
+    contraction for the physical adjoint to the upper two layers gives
+    $\mathcal N^{ij,kl}_{ab}=(\mathcal U^{ij}s^{kl})_{ab}$.
+    Both expressions are therefore equal.
+\end{proof}
+
+\begin{theorem}[The contraction $s$ is a scalar multiple of the MPU tensor]
+    \label{thm:mpug_adjoint_simple_scalar}
+    \lean{MPOTensor.IsMPUCanonicalFormII.adjointSimpleContraction_eq_smul}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpug_adjoint_simple_contraction}
+    Let $\mathcal U$ have a canonical-form-II presentation with recorded
+    fixed matrix $\rho$, and suppose that both $\mathcal U$ and
+    $\mathcal U^\dagger$ are simple. Then the tensor $s$ constructed
+    from this $\rho$ satisfies
+    \begin{align}
+        s^{ij}&=\delta\mathcal U^{ij}
+    \end{align}
+    for a single scalar $\delta\in\C$ and every physical pair $i,j$.
+    This is the proportionality conclusion in
+    \cite[lines~1255--1325]{FrancoRubio2025MPUGauging}.
+    % Only proportionality is proved. The scalar is not evaluated, and
+    % eq:MPUnice3, eq:MPUnice4, and the full prop:MPUsplus remain open.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_adjoint_simple_cross_product,
+        thm:mpu_canonical_form_ii_normal, thm:mpug_cross_product_rigidity}
+    Put $\widetilde{\mathcal U}^{ij}=d^{-1/2}\mathcal U^{ij}$.
+    Canonical form II gives $d,D>0$ and normality of
+    $\widetilde{\mathcal U}$. Scaling
+    (\ref{eq:mpug_adjoint_simple_cross_product}) gives
+    $s^{ij}\widetilde{\mathcal U}^{kl}
+      =\widetilde{\mathcal U}^{ij}s^{kl}$.
+    Cross-product rigidity, using blocking to an injective tensor, gives
+    $s^{ij}=c\widetilde{\mathcal U}^{ij}$ for one scalar $c$.
+    Set $\delta=c/\sqrt d$.
+\end{proof}
+
 \begin{theorem}[Comparison of factorizations from one-sided inverses]
     \label{thm:mpug_factorization_comparison}
     \lean{Matrix.factorization_comparison_of_one_sided_inverses}
@@ -4840,6 +5031,115 @@ by the displayed matrices.
     Thus every bond matrix unit lies in the span of the physical letters.
     Since every $2\times2$ matrix is a linear combination of these units,
     the letters span the full bond matrix algebra.
+\end{proof}
+
+\subsection{The blocked GHZ state and its CZX invariance}
+
+\begin{definition}[The GHZ tensor in the blocked CZX alphabet]
+    \label{def:mpug_czx_blocked_ghz}
+    \lean{MPOTensor.CZX.blockedGHZTensor}
+    \leanok
+    \discussion{7354}
+    \uses{def:ghz_tensor, def:blocked_tensor}
+    Let $A^0=\ketbra{0}{0}$ and $A^1=\ketbra{1}{1}$ be the GHZ tensor.
+    Identify the blocked physical alphabet with $\{0,1,2,3\}$ by
+    $\varphi(2a+b)=(a,b)$, for $a,b\in\{0,1\}$. Define
+    \begin{align}
+        \widehat A^{2a+b}&=A^aA^b=(A^{[2]})^{\varphi(2a+b)}.
+    \end{align}
+    This is the once-blocked GHZ tensor used in
+    \cite[lines~4660--4670]{FrancoRubio2025MPUGauging}, with the same
+    physical-index order as the CZX tensor $B$.
+\end{definition}
+
+\begin{theorem}[The two blocked GHZ sectors]
+    \label{thm:mpug_czx_blocked_ghz_sectors}
+    \lean{MPOTensor.CZX.blockTensor_ghzSectorTensor_apply}
+    \leanok
+    \uses{def:mpug_czx_blocked_ghz}
+    For $x\in\{0,1\}$, let $A_x^a=\delta_{a,x}$ be the
+    bond-one GHZ sector. Under $\varphi(2a+b)=(a,b)$ its two-site block is
+    \begin{align}
+        (A_x^{[2]})^{\varphi(i)}&=\delta_{i,3x},
+        \qquad i\in\{0,1,2,3\}.
+    \end{align}
+    Thus the blocked sector vectors are $\ket{00}$ and $\ket{11}$, as in
+    \cite[lines~4660--4670]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For $i=2a+b$, the block coefficient is
+    $A_x^aA_x^b=\delta_{a,x}\delta_{b,x}$, which equals one exactly when
+    $a=b=x$, or equivalently $i=3x$.
+\end{proof}
+
+\begin{theorem}[The matrix product vector of the blocked GHZ tensor]
+    \label{thm:mpug_czx_blocked_ghz_mpv}
+    \lean{MPOTensor.CZX.mpv_blockedGHZTensor}
+    \leanok
+    \uses{def:mpug_czx_blocked_ghz, def:mpv}
+    For every $N\geq0$, the periodic matrix product vector of
+    $\widehat A$ is
+    \begin{align}
+        \ket{\psi_N}
+         &=\ket{0}^{\otimes N}+\ket{3}^{\otimes N}.
+        \label{eq:mpug_czx_blocked_ghz_mpv}
+    \end{align}
+    In the original two-qubit alphabet the two summands are
+    $\ket{00}^{\otimes N}$ and $\ket{11}^{\otimes N}$.
+    At $N=0$ they are the same empty configuration, with total coefficient
+    two.
+\end{theorem}
+
+\begin{proof}\leanok
+    The blocked letters are diagonal, with
+    $\widehat A^i=\operatorname{diag}(\delta_{i,0},\delta_{i,3})$.
+    Hence, for $s\in\{0,1,2,3\}^N$,
+    \begin{align}
+        \operatorname{tr}\bigl(\widehat A^{s_1}\cdots
+            \widehat A^{s_N}\bigr)
+         &=\prod_{j=1}^N\delta_{s_j,0}
+            +\prod_{j=1}^N\delta_{s_j,3}.
+    \end{align}
+    These are the coefficients of the two constant configurations.
+\end{proof}
+
+\begin{theorem}[CZX invariance of the blocked GHZ state]
+    \label{thm:mpug_czx_blocked_ghz_invariant}
+    \lean{MPOTensor.CZX.mpo_tensor_mulVec_blockedGHZ}
+    \leanok
+    \discussion{7354}
+    \uses{def:mpug_czx_exact_tensor, def:mpug_czx_blocked_ghz, def:mpv}
+    Let $B$ be the once-blocked CZX tensor, with both output $Z$ gates and
+    the unnormalized Hadamard weights, and let $N>0$.
+    Transport the matrix product vector of the two-site-blocked GHZ tensor
+    $A^{[2]}$ by the alphabet bijection $\varphi(2a+b)=(a,b)$:
+    \begin{align}
+        \psi_N(s)&=V^{(N)}(A^{[2]})_{(\varphi(s_1),\ldots,\varphi(s_N))},
+        \qquad s\in\{0,1,2,3\}^N.
+    \end{align}
+    Then the periodic CZX operator satisfies
+    \begin{align}
+        O_N(B)\ket{\psi_N}&=\ket{\psi_N}.
+    \end{align}
+    This is the GHZ-invariance assertion in
+    \cite[lines~4660--4670]{FrancoRubio2025MPUGauging}.
+    % Only the actual blocked GHZ MPV and its positive-length invariance
+    % are asserted. Fusion, action tensors, and classification remain open.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_blocked_ghz_mpv, thm:mpug_czx_exact_tensor_unitary}
+    Reindexing the alphabet gives the vector in
+    (\ref{eq:mpug_czx_blocked_ghz_mpv}). The CZX operator complements
+    every matter bit. Its phase on either constant configuration is one:
+    the cyclic exponent is zero on $0^N$ and $4N$ on $3^N$.
+    Consequently
+    \begin{align}
+        O_N(B)\ket{0}^{\otimes N}&=\ket{3}^{\otimes N}, &
+        O_N(B)\ket{3}^{\otimes N}&=\ket{0}^{\otimes N}.
+    \end{align}
+    Their sum is invariant.
 \end{proof}
 
 \subsection{The displayed CZX circuit tuple}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1284,10 +1284,18 @@ Definition~\ref{def:mpug_group_representation}.
         thm:mpu_physical_adjoint_normalized_flattening,
         thm:cpsv_map_star_transfer_fixed_point}
     Physical adjunction preserves periodic unitarity and transports the
-    canonical blocks without changing their dimensions. Since $\rho$ is
-    real and diagonal, conjugating the fixed-point equation leaves $\rho$
-    unchanged. The physical-index permutation does not change the transfer
-    map, so the transported data have the same fixed matrix.
+    canonical blocks without changing their dimensions. Writing
+    $\mathcal E_{\mathcal U}$ for the transfer map of $\mathcal U$, the
+    transported fixed-point equation is
+    \begin{align}
+        \mathcal E_{\mathcal U^\dagger}(\rho)
+         & =\overline{\mathcal E_{\mathcal U}(\overline\rho)}
+        =\overline{\mathcal E_{\mathcal U}(\rho)}
+        =\overline\rho=\rho,
+    \end{align}
+    using $\overline\rho=\rho$ and $\mathcal E_{\mathcal U}(\rho)=\rho$. The
+    physical-index permutation does not change the transfer map, so the
+    transported data have the same fixed matrix.
 \end{proof}
 
 \begin{theorem}[Canonical boundary contractions]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1443,7 +1443,7 @@ Definition~\ref{def:mpug_group_representation}.
     $\widetilde{\mathcal U}$. Scaling
     (\ref{eq:mpug_adjoint_simple_cross_product}) gives
     $s^{ij}\widetilde{\mathcal U}^{kl}
-      =\widetilde{\mathcal U}^{ij}s^{kl}$.
+    =\widetilde{\mathcal U}^{ij}s^{kl}$.
     Cross-product rigidity, using blocking to an injective tensor, gives
     $s^{ij}=c\widetilde{\mathcal U}^{ij}$ for one scalar $c$.
     Set $\delta=c/\sqrt d$.


### PR DESCRIPTION
### Motivation
Advance the actual tensor-network argument of #7317 and the invariant-state portion of #7354 using `Papers/2502.20257/main.tex`, existing 2017 MPU canonical/factor infrastructure, and the already formalized normal-family rigidity theorem. No owner overlap or replacement paper tracker.

Stacked on #7788 to preserve the shared-workspace commit history; this PR's diff contains only the next source slices.

### Description
- `AdjointSimpleContraction.lean`: the actual raw three-tensor contraction s, canonical boundary removal with the same recorded rho for physical adjunction, two reductions of the literal six-tensor network, and `s^{ij} U^{kl} = U^{ij} s^{kl}`. Both U-simple and physical-adjoint-simple assumptions remain explicit. Existing normal-family rigidity proves one common scalar `s = δ U`, with the normalizedFlattening factor explicitly absorbed into δ. Source main.tex:1164–1325.
- `CZXGHZAction.lean`: the actual existing GHZ tensor blocked through the maintained two-site alphabet equivalence, its actual sectors and MPV coordinates, and positive-length invariance under the exact shared CZX MPO. Constant configurations have exponents 0 and 4N. Source main.tex:4660–4670. No independently substituted state or onsite-symmetry predicate.
- Generated imports and ten Chapter 29 nodes covering all ten public declarations, with explicit source hypotheses and scope.

This does NOT close #7317 or #7354: the four normalized source-factor constants, full cor:mpu, and CZX dagger/fusion/local action-tensor/L-symbol claims remain open. The scalar is not evaluated or claimed nonzero.

### Testing
- Worker strict/linter/warnings-as-errors adjoint check passed (20s); cached CZXGHZAction target passed (2.0s).
- Orchestrator's locked targeted integration build passed (49s total): refreshed only required stale TNLean prerequisites, then AdjointSimpleContraction (5.9s). No Mathlib or broad root rebuild. One pre-existing informational ring tactic hint in DoubleLayerContraction; no new warnings/errors.
- Direct importing file checked all ten public declarations; both capstones have only propext, Classical.choice, Quot.sound. Additional positive-length GHZ importing example passed.
- Independent source/Lean/style reviews approved both final modules, including normalized-vs-raw proportionality. Independent blueprint review approved all ten nodes.
- Static sync/public coverage, unique labels/resolving dependencies, whitespace/prose/LaTeX lint and generated-import checks passed; proof-bypass scans clear.
- Actual Chapter 29 two-pass XeLaTeX render passed (56 pages), no new-entry overfull warnings. Expected external-chapter/bibliography references remain unresolved in the isolated render.
- Full remote CI and fresh external review remain merge gates.
