### PR TITLE
feat(MPU): complete staircase corollary and exhibit CZX dagger gauge

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -105,6 +105,7 @@ import TNLean.MPS.MPDO.CPSVVerticalProductCornerPositivity
 import TNLean.MPS.MPDO.CPSVVerticalProductFusionDecomposition
 import TNLean.MPS.MPDO.CPSVVerticalProductSpectralFamily
 import TNLean.MPS.MPDO.CZXCompletion
+import TNLean.MPS.MPDO.CZXDaggerGauge
 import TNLean.MPS.MPDO.CZXDefectMaps
 import TNLean.MPS.MPDO.CZXGHZAction
 import TNLean.MPS.MPDO.CZXGaussCircuitTuple

--- a/TNLean/MPS/MPDO/CZXDaggerGauge.lean
+++ b/TNLean/MPS/MPDO/CZXDaggerGauge.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.SpinCover.Basic
+import TNLean.MPS.MPDO.CZXTensor
+import TNLean.MPS.MPDO.PhysicalAdjoint
+
+/-!
+# The explicit CZX dagger gauge
+
+For the exact shared tensor of arXiv:2502.20257, `eq:MPU_CZX`, the adjoint
+calculation in lines 4547–4559 gives the virtual gauge `T_g = Y` and sign
+`σ_g = -1`. Here `Y` is the existing Pauli matrix `SpinCover.pauli 1`.
+The physical adjoint swaps physical indices and conjugates entries; it does
+not transpose virtual indices. No scalar prefactor is needed.
+
+We exhibit an admissible unitary gauge, not an equality with the generic
+choice-selected dagger-inverse gauge. The subsequent decompositions in
+lines 4560–4659, local action, fusion, and anomaly symbols are not treated.
+-/
+
+noncomputable section
+
+open scoped Matrix
+
+namespace MPOTensor.CZX
+
+/-- The explicit virtual gauge `T_g = Y` in arXiv:2502.20257, lines 4547–4559. -/
+def daggerGauge : Matrix (Fin 2) (Fin 2) ℂ := SpinCover.pauli 1
+
+/-- The CZX dagger gauge is Hermitian, as used in the adjoint diagram of
+arXiv:2502.20257, lines 4547–4559. -/
+@[simp] theorem daggerGauge_conjTranspose : daggerGaugeᴴ = daggerGauge := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [daggerGauge, SpinCover.pauli_one, Matrix.conjTranspose_apply]
+
+/-- The Pauli gauge squares to the identity (arXiv:2502.20257, lines 4547–4559). -/
+@[simp] theorem daggerGauge_mul_self : daggerGauge * daggerGauge = 1 :=
+  SpinCover.pauli_mul_eq 1 1
+
+/-- The displayed gauge is unitary, hence admissible for the dagger-inverse
+convention of `eq:defT` (arXiv:2502.20257, lines 1552–1557 and 4547–4559). -/
+theorem daggerGauge_mem_unitaryGroup :
+    daggerGauge ∈ Matrix.unitaryGroup (Fin 2) ℂ := by
+  rw [Matrix.mem_unitaryGroup_iff, Matrix.star_eq_conjTranspose,
+    daggerGauge_conjTranspose, daggerGauge_mul_self]
+
+/-- The exact adjoint diagram of arXiv:2502.20257, lines 4547–4559:
+physical adjunction is conjugation by `Y`, with no extra scalar. -/
+theorem physicalAdjointTensor_tensor (u v : Fin 4) :
+    physicalAdjointTensor tensor u v = daggerGauge * tensor u v * daggerGauge := by
+  have hc : ∀ j : Fin 4, complementSite j = j.rev := by decide
+  have hb : ∀ i : Fin 4, siteBits i =
+      (show ZMod 2 from Fin.divNat (m := 2) (n := 2) i,
+        show ZMod 2 from Fin.modNat (m := 2) (n := 2) i) := by decide
+  ext l r
+  simp only [physicalAdjointTensor_apply, Matrix.mul_apply, Fin.sum_univ_two,
+    tensor_apply, hc, edgeExponent, hb]
+  fin_cases u <;> fin_cases v <;> fin_cases l <;> fin_cases r <;>
+    norm_num [daggerGauge, SpinCover.pauli_one, Fin.divNat, Fin.modNat, Fin.rev,
+      ZMod.val]
+
+/-- An explicit unitary witness for the dagger-inverse equation `eq:defT`,
+specialized to CZX (`g = g⁻¹`), arXiv:2502.20257, lines 4547–4559. -/
+def daggerGaugeUnitary : Matrix.unitaryGroup (Fin 2) ℂ :=
+  ⟨daggerGauge, daggerGauge_mem_unitaryGroup⟩
+
+/-- The CZX witness satisfies the generic convention `Tᴴ B T`, without
+identifying it with any choice-selected gauge (arXiv:2502.20257, `eq:defT`
+and lines 4547–4559). -/
+theorem physicalAdjointTensor_tensor_eq_unitaryGauge (u v : Fin 4) :
+    physicalAdjointTensor tensor u v =
+      (daggerGaugeUnitary : Matrix (Fin 2) (Fin 2) ℂ)ᴴ * tensor u v *
+        (daggerGaugeUnitary : Matrix (Fin 2) (Fin 2) ℂ) := by
+  change physicalAdjointTensor tensor u v = daggerGaugeᴴ * tensor u v * daggerGauge
+  rw [daggerGauge_conjTranspose, physicalAdjointTensor_tensor]
+
+/-- Entrywise conjugation negates `Y` (arXiv:2502.20257, lines 4547–4559). -/
+theorem daggerGauge_map_star : daggerGauge.map (starRingEnd ℂ) = -daggerGauge := by
+  rw [daggerGauge, SpinCover.pauli_one]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [Matrix.map_apply]
+
+/-- The explicit CZX sign is `σ_g = -1`, in the entrywise-conjugation
+convention of `eq:intro_sigma` (arXiv:2502.20257, lines 4547–4559). -/
+theorem daggerGauge_mul_map_star :
+    daggerGauge * daggerGauge.map (starRingEnd ℂ) = (-1 : ℂ) • 1 := by
+  rw [daggerGauge_map_star, Matrix.mul_neg, daggerGauge_mul_self, neg_one_smul]
+
+end MPOTensor.CZX

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -45,7 +45,9 @@ import TNLean.MPS.MPU.SourceURetainedInterior
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 import TNLean.MPS.MPU.SourceVIsometry
+import TNLean.MPS.MPU.SourceYPhysicalContractions
 import TNLean.MPS.MPU.StaircaseGates
+import TNLean.MPS.MPU.StaircaseUnitarity
 import TNLean.MPS.MPU.StandardForm
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.TensorProduct

--- a/TNLean/MPS/MPU/SourceYPhysicalContractions.lean
+++ b/TNLean/MPS/MPU/SourceYPhysicalContractions.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinSumPermutation
+import TNLean.MPS.MPU.DoubleLayerContraction
+import TNLean.MPS.MPU.SourceVIsometry
+import TNLean.MPS.MPU.SuppliedFixedWitnesses
+
+/-!
+# Physical closures of the source Y factors
+
+The two diagrams in arXiv:2502.20257, Corollary `cor:mpu`(b), equation
+`eq:MPUnice2` (lines 869--917), leave the physical legs open, not the
+source-rank legs. Their common contraction is the canonical one-letter
+identity in the proof (lines 1013--1050). We derive that identity with the
+recorded canonical boundaries from simplicity, then cancel the source X
+factors using the Gram equations of arXiv:1703.09188, Theorem III.8.
+No simplicity assumption on the physical adjoint is required.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- The one-letter diagram with identity left boundary and canonical right
+boundary is the physical identity. The order `ρ β α` comes from `Matrix.vec`.
+
+Source: arXiv:2502.20257, proof of Corollary `cor:mpu`(b), lines 1013--1030.
+The canonical witness alignment uses arXiv:1703.09188, equations `Erightleft`,
+`simple1`, and `simple2`, rather than assuming a supplied boundary identity. -/
+theorem IsMPUCanonicalFormII.oneLetter_physical_contraction
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U) (p q : Fin d) :
+    (∑ x : Fin D, ∑ α : Fin D, ∑ β : Fin D, ∑ z : Fin d,
+      star (U z p x α) * U z q x β * hU.ρ β α) =
+        if p = q then 1 else 0 := by
+  have := hU.neZero_phys
+  let Φ : Fin (D * D) → ℂ := fun x ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+  let ρ : Fin (D * D) → ℂ := fun x ↦ hU.ρ.vec (finProdFinEquiv.symm x)
+  have h₂ := hsimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec
+    ρ Φ (max (D * D - 1) 1) (by omega) hU.normalizedDiagonal_pow_eq_vecMulVec
+  have h₁ := hU.isMPU.simple1_of_simple2_supplied Φ ρ h₂ p q
+  have hentry (x : Fin D) :
+      (doubleLayerTensor U p q *ᵥ ρ) (finProdFinEquiv (x, x)) =
+        ∑ α : Fin D, ∑ β : Fin D, ∑ z : Fin d,
+          star (U z p x α) * U z q x β * hU.ρ β α := by
+    simp only [Matrix.mulVec, dotProduct]
+    rw [← Equiv.sum_comp finProdFinEquiv]
+    simp only [ρ, Matrix.vec, doubleLayerTensor_apply, Matrix.submatrix_apply,
+      Equiv.symm_apply_apply, Matrix.sum_apply, kroneckerMap_apply,
+      physicalAdjointTensor_apply, RCLike.star_def]
+    simp_rw [Finset.sum_mul]
+    rw [Fintype.sum_prod_type]
+  rw [dotProduct, ← Equiv.sum_comp finProdFinEquiv] at h₁
+  simpa only [Φ, Matrix.vec, Equiv.symm_apply_apply, Matrix.one_apply,
+    Fintype.sum_prod_type, ite_mul, one_mul, zero_mul, Finset.sum_ite_eq',
+    Finset.mem_univ, ite_true, hentry] using h₁
+
+/-- Closing the source-rank and virtual legs of the second source factor,
+with the canonical right boundary, gives the identity on its physical legs.
+This is a physical Gram closure, not a source-rank identity $Y_2Y_2^\dagger$.
+
+Source: arXiv:2502.20257, Corollary `cor:mpu`(b), the first diagram in
+`eq:MPUnice2` (lines 869--917); cancellation of $X_2$ in lines 1030--1050. -/
+theorem IsMPUCanonicalFormII.sourceY₂_physical_contraction
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U) (p q : Fin d) :
+    (∑ l : Fin ℓ[U], ∑ α : Fin D, ∑ β : Fin D,
+      star (sourceY₂ U l (p, α)) * sourceY₂ U l (q, β) * hU.ρ β α) =
+        if p = q then 1 else 0 := by
+  rw [Fintype.sum_reverse_three]
+  simp_rw [← Finset.sum_mul, ← sourceY₂_gram_eq_rotated_sourceCutM₂_gram,
+    Finset.sum_mul]
+  rw [Fintype.sum_last_two_first_four]
+  conv_lhs => arg 2; ext x; rw [Fintype.sum_reverse_three]
+  exact hU.oneLetter_physical_contraction hsimple p q
+
+/-- Closing the source-rank and virtual legs of the first source factor gives
+the physical identity. The weight already lies in $Y_1$; diagonality of the
+canonical matrix supplies the symmetry needed to orient that weight.
+
+Source: arXiv:2502.20257, Corollary `cor:mpu`(b), the second diagram in
+`eq:MPUnice2` (lines 869--917), and its analogous $X_1$ cancellation at line 1050. -/
+theorem IsMPUCanonicalFormII.sourceY₁_physical_contraction
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U) (p q : Fin d) :
+    (∑ r : Fin r[U], ∑ α : Fin D,
+      star (sourceY₁ U hU.ρ hU.ρ_posDef r (α, p)) *
+        sourceY₁ U hU.ρ hU.ρ_posDef r (α, q)) =
+        if p = q then 1 else 0 := by
+  rw [Finset.sum_comm]
+  simp_rw [sourceY₁_gram_eq_weighted_sourceCutM₁_gram]
+  conv_lhs => arg 2; ext x; rw [Fintype.sum_reverse_three]
+  calc
+    _ = ∑ x : Fin D, ∑ α : Fin D, ∑ β : Fin D, ∑ z : Fin d,
+        star (U z p x α) * U z q x β * hU.ρ β α := by
+      refine Finset.sum_congr₂ fun x _ α _ ↦ ?_
+      refine Finset.sum_congr₂ fun β _ z _ ↦ ?_
+      have hρ : hU.ρ α β = hU.ρ β α :=
+        congrArg (fun M : Matrix (Fin D) (Fin D) ℂ ↦ M β α) hU.ρ_isDiag.isSymm.eq
+      rw [hρ]
+      ring
+    _ = _ := hU.oneLetter_physical_contraction hsimple p q
+
+end MPOTensor

--- a/TNLean/MPS/MPU/StaircaseUnitarity.lean
+++ b/TNLean/MPS/MPU/StaircaseUnitarity.lean
@@ -154,7 +154,7 @@ theorem IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween
   have hv : (SourceFactors.sourceV U S).IsUnitaryBetween :=
     (hU.isMPUSimple_tfae.out 0 3).mp hsimple
   have hrank : r[U] * ℓ[U] = d * d := (hU.isMPUSimple_tfae.out 0 1).mp hsimple
-  let := hU.neZero_phys
+  have := hU.neZero_phys
   have hrl : 0 < r[U] * ℓ[U] := by
     rw [hrank]
     exact Nat.mul_pos (NeZero.pos d) (NeZero.pos d)

--- a/TNLean/MPS/MPU/StaircaseUnitarity.lean
+++ b/TNLean/MPS/MPU/StaircaseUnitarity.lean
@@ -1,0 +1,208 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import QICLean.Algebra.MatrixIsometryKronecker
+import TNLean.Algebra.UnitaryKronecker
+import TNLean.MPS.MPU.SimpleTensorEquivalence
+import TNLean.MPS.MPU.StaircaseGates
+
+/-!
+# Unitarity of the staircase gates
+
+For a simple MPU in canonical form II, the literal staircase gates of
+arXiv:2502.20257, `eq:wLR`, are unitary (`cor:mpu`(a), lines 905–1012).
+The first network gives reciprocal scalar Gram matrices, and the second
+network forces the left Gram scalar to equal one. The second network
+contains two left gates; neither is replaced by the right gate.
+
+The source unitaries are supplied by arXiv:1703.09188, Theorem `ThmFund1`,
+using the recorded positive fixed point of canonical form II. All cut-rank
+nonemptiness needed for scalar extraction follows from $r\ell=d^2$.
+-/
+
+open scoped Matrix Kronecker BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+/-- The middle layer of the first network preserves isometries, including its
+four-leg reshuffle. Source: arXiv:2502.20257, proof of `cor:mpu`, lines 918–974. -/
+theorem staircaseMiddle_isIsometry {A B C B' C' E : Type}
+    [Fintype A] [Fintype B] [Fintype C] [Fintype E]
+    [DecidableEq A] [DecidableEq B'] [DecidableEq C'] [DecidableEq E]
+    (M : Matrix (B × C) (B' × C') ℂ) (hM : M.IsIsometry) :
+    (staircaseMiddle (A := A) (E := E) M).IsIsometry := by
+  let e (X Y : Type) : ((A × (X × Y)) × E) ≃ ((A × X) × (Y × E)) :=
+    { toFun := fun x ↦ ((x.1.1, x.1.2.1), (x.1.2.2, x.2))
+      invFun := fun x ↦ ((x.1.1, (x.1.2, x.2.1)), x.2.2)
+      left_inv := fun _ ↦ rfl
+      right_inv := fun _ ↦ rfl }
+  have hA : (1 : Matrix A A ℂ).IsIsometry := by simp [Matrix.IsIsometry]
+  have hE : (1 : Matrix E E ℂ).IsIsometry := by simp [Matrix.IsIsometry]
+  exact ((hA.kronecker _ _ hM).kronecker _ _ hE).reindex _ (e B C) (e B' C')
+
+namespace SourceFactors
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- Entrywise second staircase network: contraction of the shared left-cut
+index converts two left gates to $uv$. This uses only the two source cut
+factorizations, not simplicity or any unitary hypothesis.
+Source: arXiv:2502.20257, proof of `cor:mpu`, lines 977–1011. -/
+theorem sourceWL_second_network_apply
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (l k : Fin ℓ[U]) (i j a b : Fin d) :
+    (∑ t : Fin ℓ[U], sourceWL U S (l, i) (a, t) *
+      sourceWL U S (t, j) (b, k)) =
+    ∑ r : Fin r[U], sourceU U S (l, r) (a, b) *
+      sourceV U S (i, j) (r, k) := by
+  classical
+  trans ∑ α : Fin D, ∑ β : Fin D,
+    S.Y₂ l (a, α) * U i b α β * S.X₂ (β, j) k
+  · simp only [sourceWL, Finset.sum_mul, Finset.mul_sum]
+    rw [Fintype.sum_reverse_three]
+    refine Finset.sum_congr₂ fun α _ β _ ↦ ?_
+    rw [← X₂_mul_Y₂_apply U S α i b β, Matrix.mul_apply]
+    simp only [Finset.sum_mul, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro t _
+    ring
+  · symm
+    simp only [sourceU_apply, sourceV_apply, Finset.sum_mul, Finset.mul_sum]
+    rw [Fintype.sum_reverse_three]
+    refine Finset.sum_congr₂ fun α _ β _ ↦ ?_
+    rw [← X₁_mul_Y₁_apply U S i β α b, Matrix.mul_apply]
+    simp only [Finset.sum_mul, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro r _
+    ring
+
+/-- Matrix form of the second network, with the associators of the three
+external legs explicit. Source: arXiv:2502.20257, proof of `cor:mpu`,
+lines 977–1011. -/
+theorem sourceWL_second_network
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ) :
+    Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+      (sourceWL U S ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) *
+      ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ sourceWL U S) =
+    ((1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) ⊗ₖ sourceV U S) *
+      Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+        (sourceU U S ⊗ₖ (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ)) := by
+  ext ⟨l, i, j⟩ ⟨a, b, k⟩
+  simp only [Matrix.mul_apply, Fintype.sum_prod_type, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Equiv.prodAssoc_symm_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply]
+  simp only [mul_ite, ite_mul, mul_zero, zero_mul, mul_one, one_mul,
+    Finset.sum_ite_eq', Finset.sum_ite_eq, Finset.mem_univ, ite_true,
+    Finset.sum_ite_irrel, Finset.sum_const_zero]
+  simpa only [mul_comm] using sourceWL_second_network_apply U S l k i j a b
+
+/-- Unitarity of the source gates makes the first staircase network an
+isometry. The hypotheses are precisely the unitary gates supplied by
+arXiv:1703.09188, Theorem `ThmFund1`; no staircase Gram premise is used.
+Source: arXiv:2502.20257, proof of `cor:mpu`, lines 918–974. -/
+theorem sourceWL_kronecker_sourceWR_isIsometry
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hu : (sourceU U S).IsUnitaryBetween)
+    (hv : (sourceV U S).IsUnitaryBetween) :
+    (sourceWL U S ⊗ₖ sourceWR U S).IsIsometry := by
+  rw [sourceWL_kronecker_sourceWR_eq U S hu.2]
+  exact ((staircaseMiddle_isIsometry _ hv.1).mul _ _
+    (hu.1.kronecker _ _ hu.1)).mul _ _
+      (staircaseMiddle_isIsometry _ (hu.conjTranspose _).1)
+
+/-- The two-left-gate network is an isometry because it equals the composition
+of the source unitaries $u$ and $v$ with identity legs.
+Source: arXiv:2502.20257, proof of `cor:mpu`, lines 977–1011. -/
+theorem sourceWL_second_network_isIsometry
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (S : SourceFactors U ρ)
+    (hu : (sourceU U S).IsIsometry) (hv : (sourceV U S).IsIsometry) :
+    (Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+      (sourceWL U S ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) *
+      ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ sourceWL U S)).IsIsometry := by
+  rw [sourceWL_second_network U S]
+  have hl : (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ).IsIsometry := by
+    simp [Matrix.IsIsometry]
+  exact (hl.kronecker _ _ hv).mul _ _
+    ((hu.kronecker _ _ hl).reindex _ _ _)
+
+end SourceFactors
+
+/-- The left and right staircase gates of a simple MPU in canonical form II
+are unitary between their rectangularly indexed coordinate spaces.
+
+Source: arXiv:2502.20257, `cor:mpu`(a), lines 905–1012. The source gates
+$u,v$ are unitary by arXiv:1703.09188, Theorem `ThmFund1`. The first network
+gives reciprocal Gram scalars. Writing $w_L^\dagger w_L=\delta I$, the
+second network has Gram $\delta^2 I$, so $\delta^2=1$. Positivity forces
+$\delta=1$. This also implies the printed conclusion $\delta^{-2}=1$;
+there is no need to identify the Gram with $\delta^{-2}I$.
+-/
+theorem IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween
+    {d D : ℕ} {U : MPOTensor d D} (hU : IsMPUCanonicalFormII U)
+    (hsimple : IsMPUSimple U) :
+    (SourceFactors.sourceWL U (sourceFactors U hU.ρ hU.ρ_posDef)).IsUnitaryBetween ∧
+    (SourceFactors.sourceWR U (sourceFactors U hU.ρ hU.ρ_posDef)).IsUnitaryBetween := by
+  classical
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  let L := SourceFactors.sourceWL U S
+  let R := SourceFactors.sourceWR U S
+  have hu : (SourceFactors.sourceU U S).IsUnitaryBetween :=
+    (hU.isMPUSimple_tfae.out 0 2).mp hsimple
+  have hv : (SourceFactors.sourceV U S).IsUnitaryBetween :=
+    (hU.isMPUSimple_tfae.out 0 3).mp hsimple
+  have hrank : r[U] * ℓ[U] = d * d := (hU.isMPUSimple_tfae.out 0 1).mp hsimple
+  let := hU.neZero_phys
+  have hrl : 0 < r[U] * ℓ[U] := by
+    rw [hrank]
+    exact Nat.mul_pos (NeZero.pos d) (NeZero.pos d)
+  let : NeZero r[U] := ⟨Nat.ne_of_gt (Nat.pos_of_mul_pos_right hrl)⟩
+  let : NeZero ℓ[U] := ⟨Nat.ne_of_gt (Nat.pos_of_mul_pos_left hrl)⟩
+  have hfirst : (Lᴴ * L) ⊗ₖ (Rᴴ * R) = 1 := by
+    rw [Matrix.mul_kronecker_mul, ← Matrix.conjTranspose_kronecker]
+    exact SourceFactors.sourceWL_kronecker_sourceWR_isIsometry U S hu hv
+  obtain ⟨δ, _, hL, hR⟩ := Matrix.exists_eq_smul_one_of_kronecker_eq_one hfirst
+  have hδnonneg : 0 ≤ δ := by
+    have h := (Matrix.posSemidef_conjTranspose_mul_self L).diag_nonneg
+      (i := (0, 0))
+    simpa [hL] using h
+  let A := Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+    (L ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))
+  let B := (1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ L
+  have hA : Aᴴ * A = δ • 1 := by
+    change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.prodAssoc _ _ _)
+        (Equiv.prodAssoc _ _ _) (L ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))ᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.prodAssoc _ _ _)
+        (Equiv.prodAssoc _ _ _) (L ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) = _
+    rw [Matrix.reindexLinearEquiv_mul, Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul, hL]
+    simp [Matrix.smul_kronecker]
+  have hB : Bᴴ * B = δ • 1 := by
+    dsimp [B]
+    rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, hL]
+    simp [Matrix.kronecker_smul]
+  have hsecond : (A * B)ᴴ * (A * B) = 1 :=
+    SourceFactors.sourceWL_second_network_isIsometry U S hu.1 hv.1
+  have hsq : δ ^ 2 = 1 := by
+    have hgram : (A * B)ᴴ * (A * B) = δ ^ 2 • 1 := by
+      rw [Matrix.conjTranspose_mul]
+      calc
+        _ = Bᴴ * (Aᴴ * A) * B := by simp only [Matrix.mul_assoc]
+        _ = δ ^ 2 • 1 := by
+          rw [hA, Matrix.mul_smul, Matrix.mul_one, Matrix.smul_mul, hB,
+            smul_smul, pow_two]
+    have h := congrFun (congrFun (hgram.symm.trans hsecond) (0, 0, 0)) (0, 0, 0)
+    simpa using h
+  have hδone : δ = 1 := by
+    rcases (sq_eq_one_iff).mp hsq with h | h
+    · exact h
+    · have := (Complex.nonneg_iff.mp hδnonneg).1
+      norm_num [h] at this
+  have hLi : L.IsIsometry := by simpa [Matrix.IsIsometry, hδone] using hL
+  have hRi : R.IsIsometry := by simpa [Matrix.IsIsometry, hδone] using hR
+  exact ⟨hLi.isUnitaryBetween_of_card_eq _ (by simp [mul_comm]),
+    hRi.isUnitaryBetween_of_card_eq _ (by simp [mul_comm])⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1135,6 +1135,228 @@ gauges and scalar relation have been constructed.
     (\ref{eq:mpug_staircase_network_cancelled}).
 \end{proof}
 
+\subsection{The second network and unitarity of the staircase gates}
+
+\begin{lemma}[Isometries on the middle two legs]
+    \label{thm:mpug_staircase_middle_isometry}
+    \lean{MPOTensor.staircaseMiddle_isIsometry}
+    \leanok
+    \uses{def:mpug_staircase_middle}
+    Let $A,B,C,E$ be finite index sets, let $B',C'$ be index sets, and let
+    $M$ be a complex matrix with rows indexed by $B\times C$ and columns
+    by $B'\times C'$. If $M^\dagger M=I$, then
+    $(M_{23})^\dagger M_{23}=I$, with the middle-leg placement of
+    Definition~\ref{def:mpug_staircase_middle}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_staircase_middle}
+    Tensoring an isometry with identity matrices preserves its Gram
+    matrix. Regrouping the four indices preserves this identity.
+\end{proof}
+
+\begin{theorem}[The second staircase network]
+    \label{thm:mpug_staircase_second_network}
+    \lean{MPOTensor.SourceFactors.sourceWL_second_network_apply,
+        MPOTensor.SourceFactors.sourceWL_second_network}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpug_staircase_gates, def:mpu_source_uv}
+    Let $\mathcal U$ have source factors as in
+    Definition~\ref{def:mpug_staircase_gates}, and form $u,v,w_L$ from
+    those same factors. Write $d_l,d_r$ for the source-cut ranks. Under
+    the natural associativity identifications of the three tensor factors,
+    \begin{align}
+        (w_L\otimes I_d)(I_d\otimes w_L)
+         & =(I_{d_l}\otimes v)(u\otimes I_{d_l}).
+        \label{eq:mpug_staircase_second_network}
+    \end{align}
+    Both sides map $\C^d\otimes\C^d\otimes\C^{d_l}$ to
+    $\C^{d_l}\otimes\C^d\otimes\C^d$. Explicitly, for
+    $0\leq l,k<d_l$ and $0\leq i,j,a,b<d$,
+    \begin{align}
+        \sum_{t=0}^{d_l-1}(w_L)_{(l,i),(a,t)}(w_L)_{(t,j),(b,k)}
+         & =\sum_{r=0}^{d_r-1}u_{(l,r),(a,b)}v_{(i,j),(r,k)}.
+    \end{align}
+    This is the second network in
+    \cite[lines~977--1011]{FrancoRubio2025MPUGauging}. It uses two copies
+    of $w_L$ and requires no simplicity or unitarity hypothesis.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_staircase_gates, def:mpu_source_uv,
+        thm:mpu_source_factorization_entries}
+    Expand the crossed gates and use $M_2=X_2Y_2$. The left-hand entry is
+    \begin{align}
+        \sum_{\alpha,\beta=0}^{D-1}
+        (Y_2)_{l,(a,\alpha)}\mathcal U^{i,b}_{\alpha\beta}
+        (X_2)_{(\beta,j),k}.
+    \end{align}
+    Expanding $u,v$ and using $M_1=X_1Y_1$ gives the same expression on
+    the right. The displayed matrix equality is this entry identity
+    after regrouping the three external indices.
+\end{proof}
+
+\begin{lemma}[Isometry of the first staircase network]
+    \label{thm:mpug_staircase_first_network_isometry}
+    \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_isIsometry}
+    \leanok
+    \uses{def:mpug_staircase_gates, def:mpu_source_uv}
+    Let $\mathcal U$ have source factors as in
+    Definition~\ref{def:mpug_staircase_gates}. If the associated operators
+    $u$ and $v$ are unitary between their respective spaces, then
+    \begin{align}
+        (w_L\otimes w_R)^\dagger(w_L\otimes w_R) & =I.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_staircase_network_cancelled,
+        thm:mpug_staircase_middle_isometry}
+    Theorem~\ref{thm:mpug_staircase_network_cancelled} expresses
+    $w_L\otimes w_R$ as $v_{23}(u\otimes u)(u^\dagger)_{23}$.
+    Each factor is an isometry, so their product is an isometry.
+\end{proof}
+
+\begin{lemma}[Isometry of the second staircase network]
+    \label{thm:mpug_staircase_second_network_isometry}
+    \lean{MPOTensor.SourceFactors.sourceWL_second_network_isIsometry}
+    \leanok
+    \uses{def:mpug_staircase_gates, def:mpu_source_uv}
+    Let $\mathcal U$ have source factors as in
+    Definition~\ref{def:mpug_staircase_gates}, with left source-cut rank
+    $d_l$. If $u^\dagger u=I$ and $v^\dagger v=I$, then
+    $K=(w_L\otimes I_d)(I_d\otimes w_L)$ satisfies $K^\dagger K=I$,
+    with the three-leg associativity identifications understood.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_staircase_second_network}
+    By Theorem~\ref{thm:mpug_staircase_second_network},
+    $K=(I_{d_l}\otimes v)(u\otimes I_{d_l})$.
+    Tensoring with an identity, regrouping indices, and composition
+    preserve isometries.
+\end{proof}
+
+\begin{corollary}[Unitary staircase gates]
+    \label{thm:mpug_staircase_gates_unitary}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpug_staircase_gates}
+    Let $\mathcal U$ be a simple MPU in canonical form II, with recorded
+    positive diagonal fixed matrix $\rho$. Construct the source factors
+    from $\mathcal U$ and this same $\rho$, and let $d_l,d_r$ be their
+    source-cut ranks. Then the staircase gates are unitary maps
+    \begin{align}
+        w_L & :\C^d\otimes\C^{d_l}\longrightarrow\C^{d_l}\otimes\C^d, \\
+        w_R & :\C^{d_r}\otimes\C^d\longrightarrow\C^d\otimes\C^{d_r}.
+    \end{align}
+    This is part~(a) of the staircase-gate corollary in
+    \cite[lines~811--1012]{FrancoRubio2025MPUGauging}.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{ThmFund1, thm:mpug_staircase_first_network_isometry,
+        thm:mpug_kronecker_identity_factors,
+        thm:mpug_staircase_second_network_isometry}
+    Theorem~\ref{ThmFund1} gives unitary $u,v$ and $d_rd_l=d^2>0$.
+    Lemma~\ref{thm:mpug_staircase_first_network_isometry} gives
+    \begin{align}
+        (w_L^\dagger w_L)\otimes(w_R^\dagger w_R) & =I.
+    \end{align}
+    By Theorem~\ref{thm:mpug_kronecker_identity_factors}, the two Gram
+    matrices are $\delta I$ and $\delta^{-1}I$ for a nonzero scalar
+    $\delta$. Positivity of the first Gram matrix makes $\delta>0$.
+    Each of the two left-gate layers in
+    $K=(w_L\otimes I_d)(I_d\otimes w_L)$ has Gram matrix $\delta I$,
+    so $K^\dagger K=\delta^2 I$. By
+    Lemma~\ref{thm:mpug_staircase_second_network_isometry}, this equals
+    $I$. Thus $\delta^2=1$, equivalently $\delta^{-2}=1$, and positivity
+    gives $\delta=1$. Both gates are isometries between spaces of equal
+    dimension, hence unitary.
+\end{proof}
+
+\subsection{Physical closures of the source factors}
+
+\begin{lemma}[The canonical one-letter physical contraction]
+    \label{thm:mpug_one_letter_physical_contraction}
+    \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_physical_contraction}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple}
+    Let $\mathcal U$ be a simple MPU in canonical form II, with physical
+    dimension $d$, bond dimension $D$, and recorded fixed matrix $\rho$.
+    For $0\leq p,q<d$,
+    \begin{align}
+        \sum_{x,\alpha,\beta=0}^{D-1}\sum_{z=0}^{d-1}
+        \overline{\mathcal U^{z,p}_{x\alpha}}
+        \mathcal U^{z,q}_{x\beta}\rho_{\beta\alpha}
+         & =\delta_{p,q}.
+    \end{align}
+    This is the one-letter diagram in the proof of part~(b) of the
+    staircase-gate corollary in
+    \cite[lines~1013--1030]{FrancoRubio2025MPUGauging}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_canonical_form_ii_transfer_stabilization,
+        thm:mpu_supplied_projector_simple2,
+        thm:mpu_all_later_simple_blockings}
+    The stabilized transfer power identifies the simplicity witnesses
+    with the canonical boundaries $I$ and $\rho$. The two-letter insertion
+    identity with these witnesses implies the one-letter physical
+    identity. Expanding its double-layer coefficient gives the displayed
+    sum; the right boundary contributes $\rho_{\beta\alpha}$.
+\end{proof}
+
+\begin{corollary}[Physical closures of the two source factors]
+    \label{thm:mpug_source_y_physical_contractions}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_physical_contraction,
+        MPOTensor.IsMPUCanonicalFormII.sourceY₁_physical_contraction}
+    \leanok
+    \discussion{7314}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be a simple MPU in canonical form II, with physical
+    dimension $d$, bond dimension $D$, and recorded positive diagonal
+    fixed matrix $\rho$. Let $Y_1,Y_2$ be the source factors constructed
+    from this tensor and this same $\rho$, with source-cut ranks $d_r,d_l$.
+    For $0\leq p,q<d$,
+    \begin{align}
+        \sum_{l=0}^{d_l-1}\sum_{\alpha,\beta=0}^{D-1}
+        \overline{(Y_2)_{l,(p,\alpha)}}(Y_2)_{l,(q,\beta)}
+        \rho_{\beta\alpha}
+         & =\delta_{p,q}, \\
+        \sum_{r=0}^{d_r-1}\sum_{\alpha=0}^{D-1}
+        \overline{(Y_1)_{r,(\alpha,p)}}(Y_1)_{r,(\alpha,q)}
+         & =\delta_{p,q}.
+    \end{align}
+    The open indices are physical; these are identities on $\C^d$, not
+    on the source-cut spaces. They are the two diagrams of part~(b) of
+    the staircase-gate corollary in
+    \cite[lines~869--917]{FrancoRubio2025MPUGauging}.
+    % Together with thm:mpug_staircase_gates_unitary this establishes
+    % cor:mpu for the source factors of the canonical-form-II presentation.
+    % No adjoint-simplicity hypothesis or subsequent eq:MPUnice3/4
+    % source-factor constants are asserted here.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_one_letter_physical_contraction,
+        thm:mpu_source_y_two_rotated_gram,
+        thm:mpu_source_v_four_u_expansions}
+    The rotated second-cut Gram identity rewrites the first sum as the
+    one-letter contraction of
+    Lemma~\ref{thm:mpug_one_letter_physical_contraction}. The weighted
+    first-cut Gram identity rewrites the second sum in the same way;
+    diagonality of $\rho$ gives $\rho_{\alpha\beta}=\rho_{\beta\alpha}$.
+    Both sums therefore equal $\delta_{p,q}$. These Gram identities cancel
+    the $X_2$ and $X_1$ factors using their respective normalizations, as
+    in \cite[lines~1030--1050]{FrancoRubio2025MPUGauging}.
+\end{proof}
+
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
 \label{sec:mpug_scalar_gauge}
 
@@ -5036,6 +5258,122 @@ by the displayed matrices.
     Thus every bond matrix unit lies in the span of the physical letters.
     Since every $2\times2$ matrix is a linear combination of these units,
     the letters span the full bond matrix algebra.
+\end{proof}
+
+\subsection{The explicit CZX adjoint gauge}
+
+\begin{definition}[The Pauli adjoint gauge]
+    \label{def:mpug_czx_dagger_gauge}
+    \lean{MPOTensor.CZX.daggerGauge}
+    \leanok
+    \discussion{7354}
+    On the bond space $\C^2$, with basis indexed by $0,1$, define the
+    Pauli matrix
+    \begin{align}
+        Y & =\begin{pmatrix}0&-\mathrm{i}\\ \mathrm{i}&0\end{pmatrix}.
+    \end{align}
+    This is the matrix on both virtual legs in the adjoint diagram of
+    \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{lemma}[Elementary identities for the Pauli adjoint gauge]
+    \label{thm:mpug_czx_dagger_gauge_laws}
+    \lean{MPOTensor.CZX.daggerGauge_conjTranspose,
+        MPOTensor.CZX.daggerGauge_mul_self,
+        MPOTensor.CZX.daggerGauge_mem_unitaryGroup}
+    \leanok
+    \uses{def:mpug_czx_dagger_gauge}
+    The matrix $Y$ of Definition~\ref{def:mpug_czx_dagger_gauge} satisfies
+    \begin{align}
+        Y^\dagger & =Y,   \\
+        Y^2       & =I_2.
+    \end{align}
+    In particular, $Y\in\mathrm{U}(2)$. These identities give the unitary
+    gauge used in \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_dagger_gauge}
+    Conjugate-transpose the displayed matrix and use the Pauli
+    multiplication rule $Y^2=I_2$. Thus $YY^\dagger=I_2$.
+\end{proof}
+
+\begin{theorem}[The physical adjoint of the exact CZX tensor]
+    \label{thm:mpug_czx_physical_adjoint}
+    \lean{MPOTensor.CZX.physicalAdjointTensor_tensor}
+    \leanok
+    \discussion{7354}
+    \uses{def:mpug_czx_exact_tensor, def:mpug_czx_dagger_gauge,
+        def:mpdo_physical_adjoint}
+    Let $B$ be the exact once-blocked CZX tensor of
+    Definition~\ref{def:mpug_czx_exact_tensor}. For $0\leq u,v<4$,
+    \begin{align}
+        (B^\dagger)^{u,v} & =YB^{u,v}Y.
+    \end{align}
+    Here $(B^\dagger)^{u,v}_{\ell r}=\overline{B^{v,u}_{\ell r}}$;
+    the virtual indices are not transposed. This is the adjoint diagram
+    in \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}, with no scalar
+    prefactor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_exact_tensor_unitary,
+        def:mpug_czx_dagger_gauge, def:mpdo_physical_adjoint}
+    Insert the coordinate formula from
+    Theorem~\ref{thm:mpug_czx_exact_tensor_unitary} on both sides and expand
+    the two matrix products over the binary bond indices. Substituting
+    the four physical values and the two bond values verifies each entry.
+\end{proof}
+
+\begin{theorem}[An explicit unitary adjoint gauge for CZX]
+    \label{thm:mpug_czx_unitary_dagger_gauge}
+    \lean{MPOTensor.CZX.daggerGaugeUnitary,
+        MPOTensor.CZX.physicalAdjointTensor_tensor_eq_unitaryGauge}
+    \leanok
+    \uses{def:mpug_czx_exact_tensor, def:mpug_czx_dagger_gauge,
+        def:mpdo_physical_adjoint}
+    For the exact once-blocked CZX tensor $B$, the matrix $T=Y$, regarded
+    as an element of $\mathrm{U}(2)$, satisfies
+    \begin{align}
+        (B^\dagger)^{u,v} & =T^\dagger B^{u,v}T,
+        \qquad 0\leq u,v<4.
+    \end{align}
+    This is the unitary gauge convention of
+    \cite[lines~1552--1557 and 4547--4559]{FrancoRubio2025MPUGauging}.
+    % This exhibits the explicit witness, not an identification with the
+    % choice-selected generic dagger-inverse gauge.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
+    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
+    and $Y^\dagger=Y$. Substitute into
+    Theorem~\ref{thm:mpug_czx_physical_adjoint}.
+\end{proof}
+
+\begin{lemma}[The sign of the explicit CZX adjoint gauge]
+    \label{thm:mpug_czx_dagger_sign}
+    \lean{MPOTensor.CZX.daggerGauge_map_star,
+        MPOTensor.CZX.daggerGauge_mul_map_star}
+    \leanok
+    \discussion{7354}
+    \uses{def:mpug_czx_dagger_gauge}
+    For the Pauli adjoint gauge $Y$, entrywise complex conjugation gives
+    \begin{align}
+        \overline{Y}  & =-Y,   \\
+        Y\overline{Y} & =-I_2.
+    \end{align}
+    Hence the sign in $Y\overline{Y}=\sigma_g I_2$ is $\sigma_g=-1$,
+    as stated in \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
+    % These entries do not determine fusion tensors, local action tensors,
+    % L-symbols, or a gauge selected by the generic existence theorem.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_dagger_gauge, thm:mpug_czx_dagger_gauge_laws}
+    Conjugating each entry of the displayed Pauli matrix gives
+    $\overline{Y}=-Y$. Then $Y\overline{Y}=-Y^2=-I_2$ by
+    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws}.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1137,8 +1137,8 @@ gauges and scalar relation have been constructed.
 
 \subsection{The second network and unitarity of the staircase gates}
 
-\begin{lemma}[Isometries on the middle two legs]
-    \label{lem:mpug_staircase_middle_isometry}
+\begin{theorem}[Isometries on the middle two legs]
+    \label{thm:mpug_staircase_middle_isometry}
     \lean{MPOTensor.staircaseMiddle_isIsometry}
     \leanok
     \uses{def:mpug_staircase_middle}
@@ -1147,7 +1147,7 @@ gauges and scalar relation have been constructed.
     by $B'\times C'$. If $M^\dagger M=I$, then
     $(M_{23})^\dagger M_{23}=I$, with the middle-leg placement of
     Definition~\ref{def:mpug_staircase_middle}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_staircase_middle}
@@ -1197,8 +1197,8 @@ gauges and scalar relation have been constructed.
     after regrouping the three external indices.
 \end{proof}
 
-\begin{lemma}[Isometry of the first staircase network]
-    \label{lem:mpug_staircase_first_network_isometry}
+\begin{theorem}[Isometry of the first staircase network]
+    \label{thm:mpug_staircase_first_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1208,18 +1208,18 @@ gauges and scalar relation have been constructed.
     \begin{align}
         (w_L\otimes w_R)^\dagger(w_L\otimes w_R) & =I.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_staircase_network_cancelled,
-        lem:mpug_staircase_middle_isometry}
+        thm:mpug_staircase_middle_isometry}
     Theorem~\ref{thm:mpug_staircase_network_cancelled} expresses
     $w_L\otimes w_R$ as $v_{23}(u\otimes u)(u^\dagger)_{23}$.
     Each factor is an isometry, so their product is an isometry.
 \end{proof}
 
-\begin{lemma}[Isometry of the second staircase network]
-    \label{lem:mpug_staircase_second_network_isometry}
+\begin{theorem}[Isometry of the second staircase network]
+    \label{thm:mpug_staircase_second_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_second_network_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1228,7 +1228,7 @@ gauges and scalar relation have been constructed.
     $d_l$. If $u^\dagger u=I$ and $v^\dagger v=I$, then
     $K=(w_L\otimes I_d)(I_d\otimes w_L)$ satisfies $K^\dagger K=I$,
     with the three-leg associativity identifications understood.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_staircase_second_network}
@@ -1238,8 +1238,8 @@ gauges and scalar relation have been constructed.
     preserve isometries.
 \end{proof}
 
-\begin{corollary}[Unitary staircase gates]
-    \label{cor:mpug_staircase_gates_unitary}
+\begin{theorem}[Unitary staircase gates]
+    \label{thm:mpug_staircase_gates_unitary}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween}
     \leanok
     \discussion{7314}
@@ -1255,24 +1255,24 @@ gauges and scalar relation have been constructed.
     \end{align}
     This is part~(a) of the staircase-gate corollary in
     \cite[lines~811--1012]{FrancoRubio2025MPUGauging}.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{ThmFund1, lem:mpug_staircase_first_network_isometry,
+    \uses{ThmFund1, thm:mpug_staircase_first_network_isometry,
         thm:mpug_kronecker_identity_factors,
-        lem:mpug_staircase_second_network_isometry}
+        thm:mpug_staircase_second_network_isometry}
     Theorem~\ref{ThmFund1} gives unitary $u,v$ and $d_rd_l=d^2>0$.
-    Lemma~\ref{lem:mpug_staircase_first_network_isometry} gives
+    Theorem~\ref{thm:mpug_staircase_first_network_isometry} gives
     \begin{align}
         (w_L^\dagger w_L)\otimes(w_R^\dagger w_R) & =I.
     \end{align}
     By Theorem~\ref{thm:mpug_kronecker_identity_factors}, the two Gram
     matrices are $\delta I$ and $\delta^{-1}I$ for a nonzero scalar
-    $\delta$. Positivity of the first Gram matrix makes $\delta>0$.
+    $\delta$. Positivity of the first Gram matrix makes $\delta\geq0$.
     Each of the two left-gate layers in
     $K=(w_L\otimes I_d)(I_d\otimes w_L)$ has Gram matrix $\delta I$,
     so $K^\dagger K=\delta^2 I$. By
-    Lemma~\ref{lem:mpug_staircase_second_network_isometry}, this equals
+    Theorem~\ref{thm:mpug_staircase_second_network_isometry}, this equals
     $I$. Thus $\delta^2=1$, equivalently $\delta^{-2}=1$, and positivity
     gives $\delta=1$. Both gates are isometries between spaces of equal
     dimension, hence unitary.
@@ -1280,8 +1280,8 @@ gauges and scalar relation have been constructed.
 
 \subsection{Physical closures of the source factors}
 
-\begin{lemma}[The canonical one-letter physical contraction]
-    \label{lem:mpug_one_letter_physical_contraction}
+\begin{theorem}[The canonical one-letter physical contraction]
+    \label{thm:mpug_one_letter_physical_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_physical_contraction}
     \leanok
     \discussion{7314}
@@ -1298,21 +1298,33 @@ gauges and scalar relation have been constructed.
     This is the one-letter diagram in the proof of part~(b) of the
     staircase-gate corollary in
     \cite[lines~1013--1030]{FrancoRubio2025MPUGauging}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_canonical_form_ii_transfer_stabilization,
         thm:mpu_supplied_projector_simple2,
         thm:mpu_all_later_simple_blockings}
-    The stabilized transfer power identifies the simplicity witnesses
-    with the canonical boundaries $I$ and $\rho$. The two-letter insertion
-    identity with these witnesses implies the one-letter physical
-    identity. Expanding its double-layer coefficient gives the displayed
-    sum; the right boundary contributes $\rho_{\beta\alpha}$.
+    The stabilized transfer power of
+    Theorem~\ref{thm:mpu_canonical_form_ii_transfer_stabilization},
+    combined with Theorem~\ref{thm:mpu_supplied_projector_simple2},
+    supplies the simplicity witnesses $a=\Phi$, $b=\rho$ aligned with the
+    canonical boundaries. Instantiating
+    Theorem~\ref{thm:mpu_all_later_simple_blockings} with these witnesses
+    gives
+    \begin{align}
+        W^{pq}W^{kl} & =W^{pq}|\rho)(\Phi|W^{kl},                     \\
+        (\Phi|W^{pq}|\rho)
+                     & =\sum_{x,\alpha,\beta=0}^{D-1}\sum_{z=0}^{d-1}
+        \overline{\mathcal U^{z,p}_{x\alpha}}
+        \mathcal U^{z,q}_{x\beta}\rho_{\beta\alpha}
+        =\delta_{p,q}.
+    \end{align}
+    The left boundary identifies the two bond indices $x$, while the
+    right boundary contributes $\rho_{\beta\alpha}$.
 \end{proof}
 
-\begin{corollary}[Physical closures of the two source factors]
-    \label{cor:mpug_source_y_physical_contractions}
+\begin{theorem}[Physical closures of the two source factors]
+    \label{thm:mpug_source_y_physical_contractions}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_physical_contraction,
         MPOTensor.IsMPUCanonicalFormII.sourceY₁_physical_contraction}
     \leanok
@@ -1337,24 +1349,39 @@ gauges and scalar relation have been constructed.
     on the source-cut spaces. They are the two diagrams of part~(b) of
     the staircase-gate corollary in
     \cite[lines~869--917]{FrancoRubio2025MPUGauging}.
-    % Together with cor:mpug_staircase_gates_unitary this establishes
+    % Together with thm:mpug_staircase_gates_unitary this establishes
     % cor:mpu for the source factors of the canonical-form-II presentation.
     % No adjoint-simplicity hypothesis or subsequent eq:MPUnice3/4
     % source-factor constants are asserted here.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_one_letter_physical_contraction,
+    \uses{thm:mpug_one_letter_physical_contraction,
         thm:mpu_source_y_two_rotated_gram,
         thm:mpu_source_v_four_u_expansions}
-    The rotated second-cut Gram identity rewrites the first sum as the
-    one-letter contraction of
-    Lemma~\ref{lem:mpug_one_letter_physical_contraction}. The weighted
-    first-cut Gram identity rewrites the second sum in the same way;
-    diagonality of $\rho$ gives $\rho_{\alpha\beta}=\rho_{\beta\alpha}$.
-    Both sums therefore equal $\delta_{p,q}$. These Gram identities cancel
-    the $X_2$ and $X_1$ factors using their respective normalizations, as
-    in \cite[lines~1030--1050]{FrancoRubio2025MPUGauging}.
+    Theorem~\ref{thm:mpu_source_y_two_rotated_gram} at $a=\alpha,b=\beta$
+    gives
+    \begin{align}
+        \sum_{l=0}^{d_l-1}\overline{(Y_2)_{l,(p,\alpha)}}(Y_2)_{l,(q,\beta)}
+         & =\sum_{x=0}^{D-1}\sum_{z=0}^{d-1}
+        \overline{\mathcal U^{z,p}_{x\alpha}}\mathcal U^{z,q}_{x\beta}.
+    \end{align}
+    Multiplying by $\rho_{\beta\alpha}$ and summing over $\alpha,\beta$
+    rewrites the first sum as the one-letter contraction of
+    Theorem~\ref{thm:mpug_one_letter_physical_contraction}. Theorem~\ref{thm:mpu_source_v_four_u_expansions}
+    at the diagonal case $a_1=b_1=\alpha$, $p_1=p$, $q_1=q$ gives
+    \begin{align}
+        \sum_{r=0}^{d_r-1}\overline{(Y_1)_{r,(\alpha,p)}}(Y_1)_{r,(\alpha,q)}
+         & =\sum_{\beta,\gamma=0}^{D-1}\sum_{z=0}^{d-1}
+        \overline{\mathcal U^{z,p}_{\alpha\beta}}\rho_{\beta\gamma}
+        \mathcal U^{z,q}_{\alpha\gamma}.
+    \end{align}
+    Summing over $\alpha$ rewrites the second sum in the same way, after
+    renaming $(\alpha,\beta,\gamma)$ to $(x,\alpha,\beta)$; diagonality of
+    $\rho$ gives $\rho_{\alpha\beta}=\rho_{\beta\alpha}$. Both sums
+    therefore equal $\delta_{p,q}$. These Gram identities cancel the $X_2$
+    and $X_1$ factors using their respective normalizations, as in
+    \cite[lines~1030--1050]{FrancoRubio2025MPUGauging}.
 \end{proof}
 
 \section{Scalar three-cocycles and fusion-tensor gauge freedom}
@@ -5276,8 +5303,8 @@ by the displayed matrices.
     \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
 \end{definition}
 
-\begin{lemma}[Elementary identities for the Pauli adjoint gauge]
-    \label{lem:mpug_czx_dagger_gauge_laws}
+\begin{theorem}[Elementary identities for the Pauli adjoint gauge]
+    \label{thm:mpug_czx_dagger_gauge_laws}
     \lean{MPOTensor.CZX.daggerGauge_conjTranspose,
         MPOTensor.CZX.daggerGauge_mul_self,
         MPOTensor.CZX.daggerGauge_mem_unitaryGroup}
@@ -5290,7 +5317,7 @@ by the displayed matrices.
     \end{align}
     In particular, $Y\in\mathrm{U}(2)$. These identities give the unitary
     gauge used in \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_czx_dagger_gauge}
@@ -5345,14 +5372,14 @@ by the displayed matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
-    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
+    \uses{thm:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
+    Theorem~\ref{thm:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
     and $Y^\dagger=Y$. Substitute into
     Theorem~\ref{thm:mpug_czx_physical_adjoint}.
 \end{proof}
 
-\begin{lemma}[The sign of the explicit CZX adjoint gauge]
-    \label{lem:mpug_czx_dagger_sign}
+\begin{theorem}[The sign of the explicit CZX adjoint gauge]
+    \label{thm:mpug_czx_dagger_sign}
     \lean{MPOTensor.CZX.daggerGauge_map_star,
         MPOTensor.CZX.daggerGauge_mul_map_star}
     \leanok
@@ -5367,13 +5394,13 @@ by the displayed matrices.
     as stated in \cite[lines~4547--4559]{FrancoRubio2025MPUGauging}.
     % These entries do not determine fusion tensors, local action tensors,
     % L-symbols, or a gauge selected by the generic existence theorem.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_dagger_gauge, lem:mpug_czx_dagger_gauge_laws}
+    \uses{def:mpug_czx_dagger_gauge, thm:mpug_czx_dagger_gauge_laws}
     Conjugating each entry of the displayed Pauli matrix gives
     $\overline{Y}=-Y$. Then $Y\overline{Y}=-Y^2=-I_2$ by
-    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws}.
+    Theorem~\ref{thm:mpug_czx_dagger_gauge_laws}.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1169,7 +1169,6 @@ gauges and scalar relation have been constructed.
     \begin{align}
         (w_L\otimes I_d)(I_d\otimes w_L)
          & =(I_{d_l}\otimes v)(u\otimes I_{d_l}).
-        \label{eq:mpug_staircase_second_network}
     \end{align}
     Both sides map $\C^d\otimes\C^d\otimes\C^{d_l}$ to
     $\C^{d_l}\otimes\C^d\otimes\C^d$. Explicitly, for
@@ -5367,10 +5366,9 @@ by the displayed matrices.
     \uses{def:mpug_czx_exact_tensor, def:mpug_czx_dagger_gauge,
         def:mpdo_physical_adjoint}
     For the exact once-blocked CZX tensor $B$, the matrix $T=Y$, regarded
-    as an element of $\mathrm{U}(2)$, satisfies
+    as an element of $\mathrm{U}(2)$, satisfies, for $0\leq u,v<4$,
     \begin{align}
-        (B^\dagger)^{u,v} & =T^\dagger B^{u,v}T,
-        \qquad 0\leq u,v<4.
+        (B^\dagger)^{u,v} & =T^\dagger B^{u,v}T.
     \end{align}
     This is the unitary gauge convention of
     \cite[lines~1552--1557 and 4547--4559]{FrancoRubio2025MPUGauging}.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1138,7 +1138,7 @@ gauges and scalar relation have been constructed.
 \subsection{The second network and unitarity of the staircase gates}
 
 \begin{lemma}[Isometries on the middle two legs]
-    \label{thm:mpug_staircase_middle_isometry}
+    \label{lem:mpug_staircase_middle_isometry}
     \lean{MPOTensor.staircaseMiddle_isIsometry}
     \leanok
     \uses{def:mpug_staircase_middle}
@@ -1198,7 +1198,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{lemma}[Isometry of the first staircase network]
-    \label{thm:mpug_staircase_first_network_isometry}
+    \label{lem:mpug_staircase_first_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1212,14 +1212,14 @@ gauges and scalar relation have been constructed.
 
 \begin{proof}\leanok
     \uses{thm:mpug_staircase_network_cancelled,
-        thm:mpug_staircase_middle_isometry}
+        lem:mpug_staircase_middle_isometry}
     Theorem~\ref{thm:mpug_staircase_network_cancelled} expresses
     $w_L\otimes w_R$ as $v_{23}(u\otimes u)(u^\dagger)_{23}$.
     Each factor is an isometry, so their product is an isometry.
 \end{proof}
 
 \begin{lemma}[Isometry of the second staircase network]
-    \label{thm:mpug_staircase_second_network_isometry}
+    \label{lem:mpug_staircase_second_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_second_network_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1239,7 +1239,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{corollary}[Unitary staircase gates]
-    \label{thm:mpug_staircase_gates_unitary}
+    \label{cor:mpug_staircase_gates_unitary}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween}
     \leanok
     \discussion{7314}
@@ -1258,11 +1258,11 @@ gauges and scalar relation have been constructed.
 \end{corollary}
 
 \begin{proof}\leanok
-    \uses{ThmFund1, thm:mpug_staircase_first_network_isometry,
+    \uses{ThmFund1, lem:mpug_staircase_first_network_isometry,
         thm:mpug_kronecker_identity_factors,
-        thm:mpug_staircase_second_network_isometry}
+        lem:mpug_staircase_second_network_isometry}
     Theorem~\ref{ThmFund1} gives unitary $u,v$ and $d_rd_l=d^2>0$.
-    Lemma~\ref{thm:mpug_staircase_first_network_isometry} gives
+    Lemma~\ref{lem:mpug_staircase_first_network_isometry} gives
     \begin{align}
         (w_L^\dagger w_L)\otimes(w_R^\dagger w_R) & =I.
     \end{align}
@@ -1272,7 +1272,7 @@ gauges and scalar relation have been constructed.
     Each of the two left-gate layers in
     $K=(w_L\otimes I_d)(I_d\otimes w_L)$ has Gram matrix $\delta I$,
     so $K^\dagger K=\delta^2 I$. By
-    Lemma~\ref{thm:mpug_staircase_second_network_isometry}, this equals
+    Lemma~\ref{lem:mpug_staircase_second_network_isometry}, this equals
     $I$. Thus $\delta^2=1$, equivalently $\delta^{-2}=1$, and positivity
     gives $\delta=1$. Both gates are isometries between spaces of equal
     dimension, hence unitary.
@@ -1281,7 +1281,7 @@ gauges and scalar relation have been constructed.
 \subsection{Physical closures of the source factors}
 
 \begin{lemma}[The canonical one-letter physical contraction]
-    \label{thm:mpug_one_letter_physical_contraction}
+    \label{lem:mpug_one_letter_physical_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_physical_contraction}
     \leanok
     \discussion{7314}
@@ -1312,7 +1312,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{corollary}[Physical closures of the two source factors]
-    \label{thm:mpug_source_y_physical_contractions}
+    \label{cor:mpug_source_y_physical_contractions}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_physical_contraction,
         MPOTensor.IsMPUCanonicalFormII.sourceY₁_physical_contraction}
     \leanok
@@ -1337,19 +1337,19 @@ gauges and scalar relation have been constructed.
     on the source-cut spaces. They are the two diagrams of part~(b) of
     the staircase-gate corollary in
     \cite[lines~869--917]{FrancoRubio2025MPUGauging}.
-    % Together with thm:mpug_staircase_gates_unitary this establishes
+    % Together with cor:mpug_staircase_gates_unitary this establishes
     % cor:mpu for the source factors of the canonical-form-II presentation.
     % No adjoint-simplicity hypothesis or subsequent eq:MPUnice3/4
     % source-factor constants are asserted here.
 \end{corollary}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_one_letter_physical_contraction,
+    \uses{lem:mpug_one_letter_physical_contraction,
         thm:mpu_source_y_two_rotated_gram,
         thm:mpu_source_v_four_u_expansions}
     The rotated second-cut Gram identity rewrites the first sum as the
     one-letter contraction of
-    Lemma~\ref{thm:mpug_one_letter_physical_contraction}. The weighted
+    Lemma~\ref{lem:mpug_one_letter_physical_contraction}. The weighted
     first-cut Gram identity rewrites the second sum in the same way;
     diagonality of $\rho$ gives $\rho_{\alpha\beta}=\rho_{\beta\alpha}$.
     Both sums therefore equal $\delta_{p,q}$. These Gram identities cancel
@@ -5277,7 +5277,7 @@ by the displayed matrices.
 \end{definition}
 
 \begin{lemma}[Elementary identities for the Pauli adjoint gauge]
-    \label{thm:mpug_czx_dagger_gauge_laws}
+    \label{lem:mpug_czx_dagger_gauge_laws}
     \lean{MPOTensor.CZX.daggerGauge_conjTranspose,
         MPOTensor.CZX.daggerGauge_mul_self,
         MPOTensor.CZX.daggerGauge_mem_unitaryGroup}
@@ -5345,14 +5345,14 @@ by the displayed matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
-    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
+    \uses{lem:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
+    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
     and $Y^\dagger=Y$. Substitute into
     Theorem~\ref{thm:mpug_czx_physical_adjoint}.
 \end{proof}
 
 \begin{lemma}[The sign of the explicit CZX adjoint gauge]
-    \label{thm:mpug_czx_dagger_sign}
+    \label{lem:mpug_czx_dagger_sign}
     \lean{MPOTensor.CZX.daggerGauge_map_star,
         MPOTensor.CZX.daggerGauge_mul_map_star}
     \leanok
@@ -5370,10 +5370,10 @@ by the displayed matrices.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_dagger_gauge, thm:mpug_czx_dagger_gauge_laws}
+    \uses{def:mpug_czx_dagger_gauge, lem:mpug_czx_dagger_gauge_laws}
     Conjugating each entry of the displayed Pauli matrix gives
     $\overline{Y}=-Y$. Then $Y\overline{Y}=-Y^2=-I_2$ by
-    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws}.
+    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws}.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -5378,7 +5378,7 @@ by the displayed matrices.
     Theorem~\ref{thm:mpug_czx_physical_adjoint}.
 \end{proof}
 
-\begin{theorem}[The sign of the explicit CZX adjoint gauge]
+\begin{theorem}[The CZX adjoint-gauge sign]
     \label{thm:mpug_czx_dagger_sign}
     \lean{MPOTensor.CZX.daggerGauge_map_star,
         MPOTensor.CZX.daggerGauge_mul_map_star}


### PR DESCRIPTION
## Scope

Closes #7314: both clauses of arXiv:2502.20257 Corollary `cor:mpu`, for the canonical source factors constructed from the tensor and its recorded fixed point. Also advances #7354 with the explicit CZX dagger gauge and involutive sign.

Stacked on #7789; do not merge ahead of #7788/#7789 or before successful current-head checks and agreeing reviews.

### Staircase corollary
- The exact second network contains two left gates and is proved from the existing two source-cut factorizations.
- Both literal staircase gates are `IsUnitaryBetween`, assuming only `IsMPUCanonicalFormII U` and `IsMPUSimple U`. Source-gate unitarity and rank nonemptiness are derived from the existing CPSV17 TFAE.
- The second network has direct Gram scalar δ². Its unitarity gives δ²=1, equivalently the source's δ⁻²=1; positivity gives δ=1. No replacement of a left gate by a right gate and no invented trace argument.
- Both `eq:MPUnice2` physical closures are proved with the recorded rho, using existing Gram identities and canonical boundary alignment. No adjoint-simplicity premise is added.

### CZX
- Reuses the exact shared `CZX.tensor` and existing `SpinCover.pauli 1`.
- Exhibits the unitary gauge Y with physicalAdjoint(B)=Yᴴ B Y and Y·conj(Y)=−I.
- Physical adjunction swaps physical indices, not virtual indices. No extra scalar and no identification with a generic choice-selected gauge.

### Boundaries
This does not prove the subsequent four source-factor constants, arbitrary-factor transport, CZX fusion/local-action tensors, or anomaly-class data. The new blueprint nodes explicitly preserve those boundaries.

## Verification
- Targeted cached strict Lean checks passed for all three modules with standard linters, strict implicit arguments, project synthesis depth, and warnings as errors; no broad/root/Mathlib rebuild.
- Independent source/Lean and blueprint reviews approve all 18 public declarations and the exact corollary scope.
- Endpoint axiom audits contain only propext, Classical.choice, Quot.sound.
- Blueprint declaration synchronization and reverse coverage pass; actual pinned latexindent 3.24.7 is a whole-chapter fixed point; dependency labels resolve and the added graph is acyclic.
- Aggregators register exactly the three new modules. Isolated chapter rendering is being checked separately; CI remains authoritative for merging.
