### PR TITLE
feat(MPU): prove all four source-factor normalization identities

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -45,7 +45,10 @@ import TNLean.MPS.MPU.SourceURetainedInterior
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SourceVCompleteNetwork
 import TNLean.MPS.MPU.SourceVIsometry
+import TNLean.MPS.MPU.SourceXPhysicalNormalization
+import TNLean.MPS.MPU.SourceYOneNormalization
 import TNLean.MPS.MPU.SourceYPhysicalContractions
+import TNLean.MPS.MPU.SourceYTwoNormalization
 import TNLean.MPS.MPU.StaircaseGates
 import TNLean.MPS.MPU.StaircaseUnitarity
 import TNLean.MPS.MPU.StandardForm

--- a/TNLean/MPS/MPU/AdjointSimpleContraction.lean
+++ b/TNLean/MPS/MPU/AdjointSimpleContraction.lean
@@ -170,6 +170,34 @@ noncomputable def adjointSimpleContraction (U : MPOTensor d D)
   fun i j a b ↦ ∑ p : Fin d, ∑ x : Fin D, ∑ r : Fin D, ∑ t : Fin D,
     U i p x b * (∑ q : Fin d, star (U q p x r) * U q j a t) * ρ t r
 
+/-- The first source cut of the raw adjoint-simple contraction is the source
+cut Gram matrix dressed by the product-index boundary weight. The transpose
+records that `adjointSimpleContraction` uses the boundary entry `ρ t r`.
+
+Source: arXiv:2502.20257, proof of `eq:MPUnice3`, lines 1326--1398. -/
+theorem sourceCutM₁_adjointSimpleContraction_raw (T : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    sourceCutM₁ (adjointSimpleContraction T ρ) =
+      sourceCutM₁ T * (sourceCutM₁ T)ᴴ * (sourceWeight (d := d) ρ)ᵀ *
+        sourceCutM₁ T := by
+  ext ⟨i, b⟩ ⟨a, j⟩
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.transpose_apply,
+    Fintype.sum_prod_type, sourceWeight, Matrix.kroneckerMap_apply, Matrix.one_apply,
+    ite_mul, one_mul, zero_mul, Finset.sum_mul, Finset.mul_sum,
+    sourceCutM₁_apply, adjointSimpleContraction]
+  simp only [mul_ite, ite_mul, mul_zero, zero_mul, Finset.sum_ite_irrel, Finset.sum_const_zero,
+    Finset.sum_ite_eq, Finset.mem_univ, ite_true]
+  conv_rhs =>
+    rw [Fintype.sum_last_two_first_five, Finset.sum_comm]
+    arg 2; ext p
+    arg 2; ext x
+    rw [Fintype.sum_reverse_three]
+  congr 1
+  ext p
+  refine Finset.sum_congr₂ fun x _ r _ ↦ ?_
+  refine Finset.sum_congr₂ fun t _ q _ ↦ ?_
+  ring
+
 private noncomputable def sixTensorContraction (U : MPOTensor d D)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (i j k l : Fin d) (a b : Fin D) : ℂ :=
   ∑ p : Fin d, ∑ x : Fin D, ∑ q : Fin d, ∑ m : Fin D,

--- a/TNLean/MPS/MPU/SourceXPhysicalNormalization.lean
+++ b/TNLean/MPS/MPU/SourceXPhysicalNormalization.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceYOneNormalization
+import TNLean.MPS.MPU.SourceYTwoNormalization
+
+/-!
+# Physical normalizations of the source X factors
+
+The physical closures in arXiv:2502.20257, Proposition `prop:MPUsplus`,
+equation `eq:MPUnice4`, follow from the output closure of the physical
+adjoint and the source Y normalizations in `eq:MPUnice3`.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- The output-leg version of the one-letter closure, obtained by applying
+`eq:MPUnice2` to the physical adjoint. Source: arXiv:2502.20257,
+proof of Proposition `prop:MPUsplus`, `eq:MPUnice4`. -/
+theorem IsMPUCanonicalFormII.oneLetter_output_contraction
+    (hU : IsMPUCanonicalFormII U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) (i j : Fin d) :
+    (∑ x : Fin D, ∑ α : Fin D, ∑ β : Fin D, ∑ p : Fin d,
+      U i p x α * star (U j p x β) * hU.ρ β α) =
+        if i = j then 1 else 0 := by
+  simpa only [physicalAdjointTensor_apply, star_star,
+    IsMPUCanonicalFormII.physicalAdjointTensor] using
+    hU.physicalAdjointTensor.oneLetter_physical_contraction hadjoint i j
+
+/-- First physical source X closure: the canonical right boundary remains
+between the two virtual legs. Source: arXiv:2502.20257, first diagram of
+`eq:MPUnice4` in Proposition `prop:MPUsplus`. -/
+theorem IsMPUCanonicalFormII.sourceX₁_physical_contraction
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) (i j : Fin d) :
+    (∑ r : Fin r[U], ∑ α : Fin D, ∑ β : Fin D,
+      sourceX₁ U hU.ρ hU.ρ_posDef (i, α) r * hU.ρ β α *
+        star (sourceX₁ U hU.ρ hU.ρ_posDef (j, β) r)) =
+      ((r[U] : ℂ) / (d : ℂ)) * (if i = j then 1 else 0) := by
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  have hgram : sourceCutM₁ U * (sourceCutM₁ U)ᴴ =
+      ((d : ℂ) / (r[U] : ℂ)) • (S.X₁ * S.X₁ᴴ) := by
+    rw [S.sourceCutM₁_eq, Matrix.conjTranspose_mul]
+    rw [Matrix.mul_assoc, ← Matrix.mul_assoc S.Y₁,
+      hU.sourceY₁_mul_conjTranspose hsimple hadjoint]
+    simp only [Matrix.smul_mul, Matrix.one_mul, Matrix.mul_smul]
+  have hclosure : (∑ α : Fin D, ∑ β : Fin D,
+      (sourceCutM₁ U * (sourceCutM₁ U)ᴴ) (i, α) (j, β) * hU.ρ β α) =
+        if i = j then 1 else 0 := by
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+      sourceCutM₁_apply, Finset.sum_mul]
+    rw [← hU.oneLetter_output_contraction hadjoint i j]
+    conv_rhs => rw [Finset.sum_comm]; arg 2; ext α; rw [Finset.sum_comm]
+  rw [hgram] at hclosure
+  simp only [Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply,
+    Matrix.conjTranspose_apply] at hclosure
+  have htrace := hU.trace_sourceY₁_mul_conjTranspose hsimple
+  dsimp only at htrace
+  rw [hU.sourceY₁_mul_conjTranspose hsimple hadjoint,
+    Matrix.trace_smul, Matrix.trace_one] at htrace
+  simp only [Fintype.card_fin, smul_eq_mul] at htrace
+  have hd : (d : ℂ) ≠ 0 := by
+    have := hU.neZero_phys
+    exact_mod_cast (NeZero.ne d)
+  have hr : (r[U] : ℂ) ≠ 0 := right_ne_zero_of_mul (htrace.trans_ne hd)
+  rw [← hclosure]
+  simp only [Finset.mul_sum, Finset.sum_mul]
+  conv_lhs => rw [Finset.sum_comm]; arg 2; ext α; rw [Finset.sum_comm]
+  refine Finset.sum_congr₂ fun α _ β _ ↦ ?_
+  refine Finset.sum_congr rfl fun r _ ↦ ?_
+  change _ = (r[U] : ℂ) / d * (d / (r[U] : ℂ) *
+    (sourceX₁ U hU.ρ hU.ρ_posDef (i, α) r *
+      star (sourceX₁ U hU.ρ hU.ρ_posDef (j, β) r)) * hU.ρ β α)
+  field_simp
+
+private theorem sourceCutM₂_output_contraction
+    (hU : IsMPUCanonicalFormII U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) (i j : Fin d) :
+    (∑ x : Fin D, (sourceCutM₂ U * sourceWeight (d := d) hU.ρ *
+      (sourceCutM₂ U)ᴴ) (x, i) (x, j)) = if i = j then 1 else 0 := by
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+    sourceCutM₂_apply, sourceWeight, kroneckerMap_apply, Matrix.one_apply,
+    mul_ite, one_mul, mul_zero, Finset.sum_mul,
+    ite_mul, zero_mul, Finset.sum_const_zero, Finset.sum_ite_irrel,
+    Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+  rw [← hU.oneLetter_output_contraction hadjoint i j]
+  refine Finset.sum_congr rfl fun x _ ↦ ?_
+  rw [Fintype.sum_reverse_three]
+  refine Finset.sum_congr₂ fun α _ β _ ↦ ?_
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  have hρ : hU.ρ α β = hU.ρ β α :=
+    congrArg (fun M : Matrix (Fin D) (Fin D) ℂ ↦ M β α) hU.ρ_isDiag.isSymm.eq
+  rw [hρ]
+  ring
+
+/-- Second physical source X closure, with the virtual and source-rank legs
+closed and the physical legs open. Source: arXiv:2502.20257, second diagram
+of `eq:MPUnice4` in Proposition `prop:MPUsplus`. -/
+theorem IsMPUCanonicalFormII.sourceX₂_physical_contraction
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) (i j : Fin d) :
+    (∑ l : Fin ℓ[U], ∑ x : Fin D,
+      sourceX₂ U (x, i) l * star (sourceX₂ U (x, j) l)) =
+      ((ℓ[U] : ℂ) / (d : ℂ)) * (if i = j then 1 else 0) := by
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  have hgram : sourceCutM₂ U * sourceWeight (d := d) hU.ρ * (sourceCutM₂ U)ᴴ =
+      ((d : ℂ) / (ℓ[U] : ℂ)) • (S.X₂ * S.X₂ᴴ) := by
+    rw [S.sourceCutM₂_eq, Matrix.conjTranspose_mul]
+    calc
+      _ = S.X₂ * (S.Y₂ * sourceWeight (d := d) hU.ρ * S.Y₂ᴴ) * S.X₂ᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = _ := by
+        rw [hU.sourceY₂_weighted_mul_conjTranspose hsimple hadjoint]
+        simp only [Matrix.mul_smul, Matrix.mul_one, Matrix.smul_mul]
+  have hclosure := sourceCutM₂_output_contraction hU hadjoint i j
+  rw [hgram] at hclosure
+  simp only [Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply,
+    Matrix.conjTranspose_apply] at hclosure
+  have htrace := hU.trace_sourceY₂_weighted_mul_conjTranspose hsimple
+  dsimp only at htrace
+  rw [hU.sourceY₂_weighted_mul_conjTranspose hsimple hadjoint,
+    Matrix.trace_smul, Matrix.trace_one] at htrace
+  simp only [Fintype.card_fin, smul_eq_mul] at htrace
+  have hd : (d : ℂ) ≠ 0 := by
+    have := hU.neZero_phys
+    exact_mod_cast (NeZero.ne d)
+  have hl : (ℓ[U] : ℂ) ≠ 0 := right_ne_zero_of_mul (htrace.trans_ne hd)
+  rw [← hclosure]
+  simp only [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr₂ fun x _ l _ ↦ ?_
+  change _ = (ℓ[U] : ℂ) / d * (d / (ℓ[U] : ℂ) *
+    (sourceX₂ U (x, i) l * star (sourceX₂ U (x, j) l)))
+  field_simp
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceYOneNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYOneNormalization.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.MPU.SourceYPhysicalContractions
 
 The first identity of arXiv:2502.20257, equation `eq:MPUnice3`, follows by
 factoring the raw adjoint-simple contraction, cancelling the chosen source
-factors, and taking the physical trace (proof, lines 1326–1369).
+factors, and taking the physical trace (proof, lines 1326–1398).
 No additional physical-dimension normalization is inserted.
 -/
 
@@ -90,7 +90,7 @@ theorem IsMPUCanonicalFormII.trace_sourceY₁_mul_conjTranspose
 
 /-- First source-factor constant, with the exact chosen factors and no extra
 normalization: $Y_1Y_1^\dagger=(d/r)I$.
-Source: arXiv:2502.20257, first identity of `eq:MPUnice3`, proof lines 1326–1369. -/
+Source: arXiv:2502.20257, first identity of `eq:MPUnice3`, proof lines 1326–1398. -/
 theorem IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose
     (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
     (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :

--- a/TNLean/MPS/MPU/SourceYOneNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYOneNormalization.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.AdjointSimpleContraction
+import TNLean.MPS.MPU.SourceYPhysicalContractions
+
+/-!
+# Normalization of the first source Y factor
+
+The first identity of arXiv:2502.20257, equation `eq:MPUnice3`, follows by
+factoring the raw adjoint-simple contraction, cancelling the chosen source
+factors, and taking the physical trace (proof, lines 1326–1369).
+No additional physical-dimension normalization is inserted.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- Factorization of the raw contraction through the Gram matrix of the exact
+chosen first source factor. Source: arXiv:2502.20257, lines 1326–1369. -/
+theorem IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction
+    (hU : IsMPUCanonicalFormII U) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    sourceCutM₁ (adjointSimpleContraction U hU.ρ) = S.X₁ * (S.Y₁ * S.Y₁ᴴ) * S.Y₁ := by
+  change sourceCutM₁ (adjointSimpleContraction U hU.ρ) =
+    sourceX₁ U hU.ρ hU.ρ_posDef *
+      (sourceY₁ U hU.ρ hU.ρ_posDef * (sourceY₁ U hU.ρ hU.ρ_posDef)ᴴ) *
+        sourceY₁ U hU.ρ hU.ρ_posDef
+  rw [← Matrix.mul_assoc, ← sourceCutM₁_eq_sourceX₁_mul_sourceY₁, Matrix.mul_assoc]
+  ext ⟨i, b⟩ ⟨a, j⟩
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+    sourceCutM₁_apply]
+  simp_rw [sourceY₁_gram_eq_weighted_sourceCutM₁_gram]
+  simp only [adjointSimpleContraction, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr₂ fun p _ x _ ↦ ?_
+  rw [Fintype.sum_reverse_three]
+  refine Finset.sum_congr₂ fun q _ t _ ↦ ?_
+  refine Finset.sum_congr rfl fun r _ ↦ ?_
+  have hρ : hU.ρ t r = hU.ρ r t :=
+    congrArg (fun M : Matrix (Fin D) (Fin D) ℂ ↦ M r t) hU.ρ_isDiag.isSymm.eq
+  rw [hρ]
+  ring
+
+/-- The source-rank Gram matrix of the first chosen source factor is scalar.
+The weighted left inverse and the supplied right inverse cancel the dressing.
+Source: arXiv:2502.20257, proof of `eq:MPUnice3`, lines 1326–1369. -/
+theorem IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose_eq_smul
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    ∃ δ : ℂ, let S := sourceFactors U hU.ρ hU.ρ_posDef
+      S.Y₁ * S.Y₁ᴴ = δ • 1 := by
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  obtain ⟨δ, hδ⟩ := hU.adjointSimpleContraction_eq_smul hsimple hadjoint
+  refine ⟨δ, ?_⟩
+  have hcut : sourceCutM₁ (adjointSimpleContraction U hU.ρ) =
+      δ • sourceCutM₁ U := by
+    ext ⟨i, b⟩ ⟨a, j⟩
+    exact congrArg (fun M ↦ M a b) (hδ i j)
+  rw [hU.sourceCutM₁_adjointSimpleContraction, S.sourceCutM₁_eq] at hcut
+  change S.X₁ * (S.Y₁ * S.Y₁ᴴ) * S.Y₁ = δ • (S.X₁ * S.Y₁) at hcut
+  have hcancel := congrArg (fun M ↦
+    (S.X₁ᴴ * sourceWeight (d := d) hU.ρ) * M * S.Z₁) hcut
+  change S.Y₁ * S.Y₁ᴴ = δ • 1
+  simp only [Matrix.mul_smul, Matrix.smul_mul, ← Matrix.mul_assoc,
+    S.X₁_weighted_isometry, Matrix.one_mul] at hcancel
+  simpa only [Matrix.mul_assoc, S.Y₁_mul_Z₁, Matrix.mul_one] using hcancel
+
+/-- The physical closure fixes the full trace of the first source Gram matrix.
+Source: arXiv:2502.20257, equations `eq:MPUnice2` and `eq:MPUnice3`. -/
+theorem IsMPUCanonicalFormII.trace_sourceY₁_mul_conjTranspose
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    (S.Y₁ * S.Y₁ᴴ).trace = (d : ℂ) := by
+  change (sourceY₁ U hU.ρ hU.ρ_posDef *
+    (sourceY₁ U hU.ρ hU.ρ_posDef)ᴴ).trace = _
+  rw [Matrix.trace_mul_comm]
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    Fintype.sum_prod_type]
+  rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext p; rw [Finset.sum_comm]
+  simp_rw [hU.sourceY₁_physical_contraction hsimple]
+  simp
+
+/-- First source-factor constant, with the exact chosen factors and no extra
+normalization: $Y_1Y_1^\dagger=(d/r)I$.
+Source: arXiv:2502.20257, first identity of `eq:MPUnice3`, proof lines 1326–1369. -/
+theorem IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    S.Y₁ * S.Y₁ᴴ = ((d : ℂ) / (r[U] : ℂ)) • 1 := by
+  obtain ⟨δ, hδ⟩ := hU.sourceY₁_mul_conjTranspose_eq_smul hsimple hadjoint
+  have htrace := hU.trace_sourceY₁_mul_conjTranspose hsimple
+  dsimp only at hδ htrace ⊢
+  rw [hδ, Matrix.trace_smul, Matrix.trace_one] at htrace
+  simp only [Fintype.card_fin, smul_eq_mul] at htrace
+  have hd : (d : ℂ) ≠ 0 := by
+    have := hU.neZero_phys
+    exact_mod_cast (NeZero.ne d)
+  have hr : (r[U] : ℂ) ≠ 0 := by
+    intro hzero
+    rw [hzero, mul_zero] at htrace
+    exact hd htrace.symm
+  have hscalar : δ = (d : ℂ) / (r[U] : ℂ) := (eq_div_iff hr).mpr htrace
+  simpa only [hscalar] using hδ
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceYOneNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYOneNormalization.lean
@@ -104,10 +104,7 @@ theorem IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose
   have hd : (d : ℂ) ≠ 0 := by
     have := hU.neZero_phys
     exact_mod_cast (NeZero.ne d)
-  have hr : (r[U] : ℂ) ≠ 0 := by
-    intro hzero
-    rw [hzero, mul_zero] at htrace
-    exact hd htrace.symm
+  have hr : (r[U] : ℂ) ≠ 0 := right_ne_zero_of_mul (htrace.trans_ne hd)
   have hscalar : δ = (d : ℂ) / (r[U] : ℂ) := (eq_div_iff hr).mpr htrace
   simpa only [hscalar] using hδ
 

--- a/TNLean/MPS/MPU/SourceYOneNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYOneNormalization.lean
@@ -28,25 +28,21 @@ theorem IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction
     (hU : IsMPUCanonicalFormII U) :
     let S := sourceFactors U hU.ρ hU.ρ_posDef
     sourceCutM₁ (adjointSimpleContraction U hU.ρ) = S.X₁ * (S.Y₁ * S.Y₁ᴴ) * S.Y₁ := by
-  change sourceCutM₁ (adjointSimpleContraction U hU.ρ) =
-    sourceX₁ U hU.ρ hU.ρ_posDef *
-      (sourceY₁ U hU.ρ hU.ρ_posDef * (sourceY₁ U hU.ρ hU.ρ_posDef)ᴴ) *
-        sourceY₁ U hU.ρ hU.ρ_posDef
-  rw [← Matrix.mul_assoc, ← sourceCutM₁_eq_sourceX₁_mul_sourceY₁, Matrix.mul_assoc]
-  ext ⟨i, b⟩ ⟨a, j⟩
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
-    sourceCutM₁_apply]
-  simp_rw [sourceY₁_gram_eq_weighted_sourceCutM₁_gram]
-  simp only [adjointSimpleContraction, Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr₂ fun p _ x _ ↦ ?_
-  rw [Fintype.sum_reverse_three]
-  refine Finset.sum_congr₂ fun q _ t _ ↦ ?_
-  refine Finset.sum_congr rfl fun r _ ↦ ?_
-  have hρ : hU.ρ t r = hU.ρ r t :=
-    congrArg (fun M : Matrix (Fin D) (Fin D) ℂ ↦ M r t) hU.ρ_isDiag.isSymm.eq
-  rw [hρ]
-  ring
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  have hW : (sourceWeight (d := d) hU.ρ)ᵀ = sourceWeight (d := d) hU.ρ := by
+    rw [sourceWeight, ← Matrix.kroneckerMap_transpose, Matrix.transpose_one,
+      hU.ρ_isDiag.isSymm.eq]
+  rw [sourceCutM₁_adjointSimpleContraction_raw, S.sourceCutM₁_eq, hW]
+  rw [Matrix.conjTranspose_mul]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (sourceWeight (d := d) hU.ρ) S.X₁ S.Y₁,
+    ← Matrix.mul_assoc S.X₁ᴴ (sourceWeight (d := d) hU.ρ * S.X₁) S.Y₁]
+  have hX : S.X₁ᴴ * (sourceWeight (d := d) hU.ρ * S.X₁) = 1 := by
+    simpa only [Matrix.mul_assoc] using S.X₁_weighted_isometry
+  rw [hX]
+  simp only [Matrix.one_mul]
+  change S.X₁ * (S.Y₁ * (S.Y₁ᴴ * S.Y₁)) = S.X₁ * (S.Y₁ * (S.Y₁ᴴ * S.Y₁))
+  rfl
 
 /-- The source-rank Gram matrix of the first chosen source factor is scalar.
 The weighted left inverse and the supplied right inverse cancel the dressing.

--- a/TNLean/MPS/MPU/SourceYOneNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYOneNormalization.lean
@@ -23,7 +23,7 @@ namespace MPOTensor
 variable {d D : ℕ} {U : MPOTensor d D}
 
 /-- Factorization of the raw contraction through the Gram matrix of the exact
-chosen first source factor. Source: arXiv:2502.20257, lines 1326–1369. -/
+chosen first source factor. Source: arXiv:2502.20257, lines 1326–1374. -/
 theorem IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction
     (hU : IsMPUCanonicalFormII U) :
     let S := sourceFactors U hU.ρ hU.ρ_posDef
@@ -46,7 +46,7 @@ theorem IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction
 
 /-- The source-rank Gram matrix of the first chosen source factor is scalar.
 The weighted left inverse and the supplied right inverse cancel the dressing.
-Source: arXiv:2502.20257, proof of `eq:MPUnice3`, lines 1326–1369. -/
+Source: arXiv:2502.20257, proof of `eq:MPUnice3`, lines 1375–1397. -/
 theorem IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose_eq_smul
     (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
     (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :

--- a/TNLean/MPS/MPU/SourceYTwoNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYTwoNormalization.lean
@@ -23,30 +23,6 @@ namespace MPOTensor
 
 variable {d D : ℕ} {U : MPOTensor d D}
 
--- The transpose records the raw contraction's boundary entry `ρ t r`.
-private theorem sourceCutM₁_adjointSimpleContraction_raw (T : MPOTensor d D)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    sourceCutM₁ (adjointSimpleContraction T ρ) =
-      sourceCutM₁ T * (sourceCutM₁ T)ᴴ * (sourceWeight (d := d) ρ)ᵀ *
-        sourceCutM₁ T := by
-  ext ⟨i, b⟩ ⟨a, j⟩
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.transpose_apply,
-    Fintype.sum_prod_type, sourceWeight, kroneckerMap_apply, Matrix.one_apply,
-    ite_mul, one_mul, zero_mul, Finset.sum_mul, Finset.mul_sum,
-    sourceCutM₁_apply, adjointSimpleContraction]
-  simp only [mul_ite, ite_mul, mul_zero, zero_mul, Finset.sum_ite_irrel, Finset.sum_const_zero,
-    Finset.sum_ite_eq, Finset.mem_univ, ite_true]
-  conv_rhs =>
-    rw [Fintype.sum_last_two_first_five, Finset.sum_comm]
-    arg 2; ext p
-    arg 2; ext x
-    rw [Fintype.sum_reverse_three]
-  congr 1
-  ext p
-  refine Finset.sum_congr₂ fun x _ r _ ↦ ?_
-  refine Finset.sum_congr₂ fun t _ q _ ↦ ?_
-  ring
-
 /-- The adjoint raw contraction factors through the weighted Gram matrix of
 our chosen second source factor. Source: arXiv:2502.20257, proof of
 Proposition `prop:MPUsplus`, second identity of `eq:MPUnice3`. -/

--- a/TNLean/MPS/MPU/SourceYTwoNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYTwoNormalization.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.AdjointSimpleContraction
+import TNLean.MPS.MPU.SourceYPhysicalContractions
+
+/-!
+# Normalization of the second source Y factor
+
+The second identity of arXiv:2502.20257, Proposition `prop:MPUsplus`,
+`eq:MPUnice3`, is proved for the exact chosen source factors. Apply the raw
+contraction to the physical adjoint, cancel the second source factors, and
+use their physical closure to determine the scalar. No identification of
+chosen singular vectors for the adjoint is needed.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+-- The transpose records the raw contraction's boundary entry `ρ t r`.
+private theorem sourceCutM₁_adjointSimpleContraction_raw (T : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    sourceCutM₁ (adjointSimpleContraction T ρ) =
+      sourceCutM₁ T * (sourceCutM₁ T)ᴴ * (sourceWeight (d := d) ρ)ᵀ *
+        sourceCutM₁ T := by
+  ext ⟨i, b⟩ ⟨a, j⟩
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.transpose_apply,
+    Fintype.sum_prod_type, sourceWeight, kroneckerMap_apply, Matrix.one_apply,
+    ite_mul, one_mul, zero_mul, Finset.sum_mul, Finset.mul_sum,
+    sourceCutM₁_apply, adjointSimpleContraction]
+  simp only [mul_ite, ite_mul, mul_zero, zero_mul, Finset.sum_ite_irrel, Finset.sum_const_zero,
+    Finset.sum_ite_eq, Finset.mem_univ, ite_true]
+  conv_rhs =>
+    rw [Fintype.sum_last_two_first_five, Finset.sum_comm]
+    arg 2; ext p
+    arg 2; ext x
+    rw [Fintype.sum_reverse_three]
+  congr 1
+  ext p
+  refine Finset.sum_congr₂ fun x _ r _ ↦ ?_
+  refine Finset.sum_congr₂ fun t _ q _ ↦ ?_
+  ring
+
+/-- The adjoint raw contraction factors through the weighted Gram matrix of
+our chosen second source factor. Source: arXiv:2502.20257, proof of
+Proposition `prop:MPUsplus`, second identity of `eq:MPUnice3`. -/
+theorem IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction_physicalAdjoint
+    (hU : IsMPUCanonicalFormII U) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    sourceCutM₁ (adjointSimpleContraction (MPOTensor.physicalAdjointTensor U) hU.ρ) =
+      S.Y₂ᴴ * (S.Y₂ * sourceWeight (d := d) hU.ρ * S.Y₂ᴴ) * S.X₂ᴴ := by
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  have hW : (sourceWeight (d := d) hU.ρ)ᵀ = sourceWeight (d := d) hU.ρ := by
+    rw [sourceWeight, ← Matrix.kroneckerMap_transpose, Matrix.transpose_one,
+      hU.ρ_isDiag.isSymm.eq]
+  rw [sourceCutM₁_adjointSimpleContraction_raw, sourceCutM₁_physicalAdjointTensor,
+    S.sourceCutM₂_eq, hW]
+  simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+  change S.Y₂ᴴ * S.X₂ᴴ * (S.X₂ * S.Y₂) * sourceWeight hU.ρ *
+    (S.Y₂ᴴ * S.X₂ᴴ) = _
+  have hX : S.X₂ᴴ * S.X₂ = 1 := S.X₂_isometry
+  simp only [Matrix.mul_assoc] at ⊢
+  rw [← Matrix.mul_assoc S.X₂ᴴ S.X₂, hX, Matrix.one_mul]
+
+/-- The weighted source-rank Gram matrix of the second chosen factor is scalar.
+Source: arXiv:2502.20257, proof of Proposition `prop:MPUsplus`, `eq:MPUnice3`.
+The scalar is obtained from the adjoint tensor, not from the first factor of `U`. -/
+theorem IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose_eq_smul
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    ∃ ε : ℂ, let S := sourceFactors U hU.ρ hU.ρ_posDef
+      S.Y₂ * sourceWeight (d := d) hU.ρ * S.Y₂ᴴ = ε • 1 := by
+  let S := sourceFactors U hU.ρ hU.ρ_posDef
+  obtain ⟨ε, hε⟩ := hU.physicalAdjointTensor.adjointSimpleContraction_eq_smul hadjoint
+    (by simpa only [physicalAdjointTensor_physicalAdjointTensor] using hsimple)
+  refine ⟨ε, ?_⟩
+  have hcut : sourceCutM₁ (adjointSimpleContraction
+      (MPOTensor.physicalAdjointTensor U) hU.ρ) =
+      ε • sourceCutM₁ (MPOTensor.physicalAdjointTensor U) := by
+    ext ⟨i, b⟩ ⟨a, j⟩
+    exact congrArg (fun M ↦ M a b) (hε i j)
+  rw [hU.sourceCutM₁_adjointSimpleContraction_physicalAdjoint,
+    sourceCutM₁_physicalAdjointTensor, S.sourceCutM₂_eq, Matrix.conjTranspose_mul] at hcut
+  change S.Y₂ᴴ * (S.Y₂ * sourceWeight hU.ρ * S.Y₂ᴴ) * S.X₂ᴴ =
+    ε • (S.Y₂ᴴ * S.X₂ᴴ) at hcut
+  have hcancel := congrArg (fun M ↦ S.Z₂ᴴ * M * S.X₂) hcut
+  have hZ : S.Z₂ᴴ * S.Y₂ᴴ = 1 := by
+    rw [← Matrix.conjTranspose_mul, S.Y₂_mul_Z₂, Matrix.conjTranspose_one]
+  have hX : S.X₂ᴴ * S.X₂ = 1 := S.X₂_isometry
+  change S.Y₂ * sourceWeight hU.ρ * S.Y₂ᴴ = ε • 1
+  simp only [Matrix.mul_smul, Matrix.smul_mul, ← Matrix.mul_assoc, hZ,
+    Matrix.one_mul] at hcancel
+  simpa only [Matrix.mul_assoc, hX, Matrix.mul_one] using hcancel
+
+/-- Physical closure fixes the trace of the weighted second source Gram matrix.
+Source: arXiv:2502.20257, `eq:MPUnice2` and second identity of `eq:MPUnice3`. -/
+theorem IsMPUCanonicalFormII.trace_sourceY₂_weighted_mul_conjTranspose
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    (S.Y₂ * sourceWeight (d := d) hU.ρ * S.Y₂ᴴ).trace = (d : ℂ) := by
+  change (sourceY₂ U * sourceWeight (d := d) hU.ρ * (sourceY₂ U)ᴴ).trace = _
+  rw [Matrix.trace_mul_comm]
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    Fintype.sum_prod_type, sourceWeight, kroneckerMap_apply, Matrix.one_apply,
+    ite_mul, one_mul, zero_mul, Finset.mul_sum, mul_ite, mul_zero,
+    Finset.sum_ite_irrel, Finset.sum_const_zero, Finset.sum_ite_eq',
+    Finset.mem_univ, ite_true, ← mul_assoc]
+  conv_lhs => arg 2; ext p; rw [Finset.sum_comm]
+  simp_rw [hU.sourceY₂_physical_contraction hsimple]
+  simp
+
+/-- Second source-factor constant for the exact chosen factors:
+$Y_2 (I_d \otimes \rho) Y_2^\dagger=(d/\ell)I$.
+Source: arXiv:2502.20257, Proposition `prop:MPUsplus`, second identity of `eq:MPUnice3`.
+Nonzero source rank follows from the trace equation, with no extra hypothesis. -/
+theorem IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose
+    (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+    (hadjoint : IsMPUSimple (MPOTensor.physicalAdjointTensor U)) :
+    let S := sourceFactors U hU.ρ hU.ρ_posDef
+    S.Y₂ * sourceWeight (d := d) hU.ρ * S.Y₂ᴴ = ((d : ℂ) / (ℓ[U] : ℂ)) • 1 := by
+  obtain ⟨ε, hε⟩ := hU.sourceY₂_weighted_mul_conjTranspose_eq_smul hsimple hadjoint
+  have htrace := hU.trace_sourceY₂_weighted_mul_conjTranspose hsimple
+  dsimp only at hε htrace ⊢
+  rw [hε, Matrix.trace_smul, Matrix.trace_one] at htrace
+  simp only [Fintype.card_fin, smul_eq_mul] at htrace
+  have hd : (d : ℂ) ≠ 0 := by
+    have := hU.neZero_phys
+    exact_mod_cast (NeZero.ne d)
+  have hl : (ℓ[U] : ℂ) ≠ 0 := by
+    intro hzero
+    rw [hzero, mul_zero] at htrace
+    exact hd htrace.symm
+  have hscalar : ε = (d : ℂ) / (ℓ[U] : ℂ) := (eq_div_iff hl).mpr htrace
+  simpa only [hscalar] using hε
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceYTwoNormalization.lean
+++ b/TNLean/MPS/MPU/SourceYTwoNormalization.lean
@@ -132,10 +132,7 @@ theorem IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose
   have hd : (d : ℂ) ≠ 0 := by
     have := hU.neZero_phys
     exact_mod_cast (NeZero.ne d)
-  have hl : (ℓ[U] : ℂ) ≠ 0 := by
-    intro hzero
-    rw [hzero, mul_zero] at htrace
-    exact hd htrace.symm
+  have hl : (ℓ[U] : ℂ) ≠ 0 := right_ne_zero_of_mul (htrace.trans_ne hd)
   have hscalar : ε = (d : ℂ) / (ℓ[U] : ℂ) := (eq_div_iff hl).mpr htrace
   simpa only [hscalar] using hε
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2039,8 +2039,8 @@ Definition~\ref{def:mpug_group_representation}.
 
 \begin{proof}\leanok
     \uses{def:mpug_adjoint_canonical_boundaries,
-        lem:mpug_one_letter_physical_contraction, def:mpdo_physical_adjoint}
-    Apply Lemma~\ref{lem:mpug_one_letter_physical_contraction} to
+        thm:mpug_one_letter_physical_contraction, def:mpdo_physical_adjoint}
+    Apply Theorem~\ref{thm:mpug_one_letter_physical_contraction} to
     $\mathcal U^\dagger$ with its canonical presentation carrying the
     same $\rho$. Its letters are
     $(\mathcal U^\dagger)^{p,i}_{x\alpha}=\overline{\mathcal U^{i,p}_{x\alpha}}$.

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1674,6 +1674,37 @@ Definition~\ref{def:mpug_group_representation}.
 
 \subsection{Normalization of the first source factor}
 
+\begin{theorem}[The raw first-cut contraction]
+    \label{thm:mpug_raw_first_cut_contraction}
+    \lean{MPOTensor.sourceCutM₁_adjointSimpleContraction_raw}
+    \leanok
+    \uses{def:mpu_source_matrix_one, def:mpu_source_weight,
+        def:mpug_adjoint_simple_contraction}
+    For an arbitrary tensor $A$ of physical dimension $d$ and bond
+    dimension $D$, and an arbitrary $D\times D$ matrix $\rho$, put
+    $M=M_1(A)$ and $W=I_d\otimes\rho$. Then
+    \begin{align}
+        M_1(s(A,\rho)) & =MM^\dagger W^{\mathsf T}M.
+        \label{eq:mpug_raw_first_cut_contraction}
+    \end{align}
+    No positivity, canonical-form, or simplicity hypothesis is needed.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpu_source_matrix_one, def:mpu_source_weight,
+        def:mpug_adjoint_simple_contraction}
+    In the first-cut coordinates, multiplication and the physical
+    Kronecker delta in $W^{\mathsf T}$ give
+    \begin{align}
+        (MM^\dagger W^{\mathsf T}M)_{(i,b),(a,j)}
+         & =\sum_{p,q=0}^{d-1}\sum_{x,r,t=0}^{D-1}
+        A^{i,p}_{xb}\,\overline{A^{q,p}_{xr}}\,
+        A^{q,j}_{at}\,\rho_{tr}                    \\
+         & =s(A,\rho)^{i,j}_{ab}.
+    \end{align}
+    The transpose preserves the boundary entry $\rho_{tr}$ in the
+    defining contraction.
+\end{proof}
+
 \begin{theorem}[The first cut of the adjoint-simple contraction]
     \label{thm:mpug_first_cut_adjoint_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction}
@@ -1696,14 +1727,16 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_factorizations,
-        thm:mpu_source_v_four_u_expansions,
-        def:mpug_adjoint_simple_contraction}
-    Replace $X_1Y_1$ by $M_1(\mathcal U)$ and expand the remaining Gram
-    factor with the weighted first-cut identity of
-    Theorem~\ref{thm:mpu_source_v_four_u_expansions}. Reorder the finite
-    sums. Since $\rho$ is diagonal, $\rho_{tr}=\rho_{rt}$, and the result
-    is exactly the raw contraction defining $M_1(s)$.
+    \uses{thm:mpug_raw_first_cut_contraction,
+        def:mpu_weighted_source_factors, def:mpu_source_weight}
+    Put $W=I_d\otimes\rho$. Diagonality gives $W^{\mathsf T}=W$.
+    The cut factorization and weighted isometry then yield
+    \begin{align}
+        M_1(s)
+         & = (X_1Y_1)(X_1Y_1)^\dagger W(X_1Y_1)       \\
+         & =X_1(Y_1Y_1^\dagger)(X_1^\dagger W X_1)Y_1 \\
+         & =X_1(Y_1Y_1^\dagger)Y_1.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[The first source Gram matrix is scalar]
@@ -1830,10 +1863,10 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_adjoint_simple_contraction,
+    \uses{thm:mpug_raw_first_cut_contraction,
         thm:mpu_physical_adjoint_source_cuts,
-        thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
-    Expanding the raw contraction of any tensor $A$ gives
+        def:mpu_weighted_source_factors, def:mpu_source_weight}
+    Theorem~\ref{thm:mpug_raw_first_cut_contraction} gives
     \begin{align}
         M_1(s(A,\rho)) & =M_1(A)M_1(A)^\dagger W^{\mathsf T}M_1(A).
     \end{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1761,6 +1761,7 @@ Definition~\ref{def:mpug_group_representation}.
 
 \begin{proof}\leanok
     \uses{thm:mpug_raw_first_cut_contraction,
+        thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations,
         def:mpu_weighted_source_factors, def:mpu_source_weight}
     Put $W=I_d\otimes\rho$. Diagonality gives $W^{\mathsf T}=W$.
     The cut factorization and weighted isometry then yield
@@ -1898,6 +1899,7 @@ Definition~\ref{def:mpug_group_representation}.
 \begin{proof}\leanok
     \uses{thm:mpug_raw_first_cut_contraction,
         thm:mpu_physical_adjoint_source_cuts,
+        thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations,
         def:mpu_weighted_source_factors, def:mpu_source_weight}
     Theorem~\ref{thm:mpug_raw_first_cut_contraction} gives
     \begin{align}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1929,16 +1929,21 @@ Definition~\ref{def:mpug_group_representation}.
     \begin{align}
         \operatorname{tr}\bigl(Y_2(I_d\otimes\rho)Y_2^\dagger\bigr) & =d.
     \end{align}
+    This is the physical-trace calculation used, by analogy with the
+    first identity, in \cite[line~1398]{FrancoRubio2025MPUGauging}.
     Simplicity of $\mathcal U^\dagger$ is not required.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{cor:mpug_source_y_physical_contractions, def:mpu_source_weight}
-    Move the last factor to the front inside the trace and expand
-    $I_d\otimes\rho$. Grouping by the physical index gives the sum of
-    the diagonal physical closures from
-    Corollary~\ref{cor:mpug_source_y_physical_contractions}. Each of the
-    $d$ terms is one.
+    Cyclic invariance and expanding $I_d\otimes\rho$ give
+    \begin{align}
+        \operatorname{tr}\bigl(Y_2(I_d\otimes\rho)Y_2^\dagger\bigr)
+         & =\sum_{p=0}^{d-1}\sum_{x,y=0}^{D-1}\sum_{l=0}^{d_l-1}
+        \overline{(Y_2)_{l,(p,y)}}(Y_2)_{l,(p,x)}\rho_{xy}
+        =\sum_{p=0}^{d-1}1=d
+    \end{align}
+    by Corollary~\ref{cor:mpug_source_y_physical_contractions} at $q=p$.
 \end{proof}
 
 \begin{theorem}[Normalization of the weighted second source Gram matrix]

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1138,7 +1138,7 @@ gauges and scalar relation have been constructed.
 \subsection{The second network and unitarity of the staircase gates}
 
 \begin{lemma}[Isometries on the middle two legs]
-    \label{thm:mpug_staircase_middle_isometry}
+    \label{lem:mpug_staircase_middle_isometry}
     \lean{MPOTensor.staircaseMiddle_isIsometry}
     \leanok
     \uses{def:mpug_staircase_middle}
@@ -1198,7 +1198,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{lemma}[Isometry of the first staircase network]
-    \label{thm:mpug_staircase_first_network_isometry}
+    \label{lem:mpug_staircase_first_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_kronecker_sourceWR_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1212,14 +1212,14 @@ gauges and scalar relation have been constructed.
 
 \begin{proof}\leanok
     \uses{thm:mpug_staircase_network_cancelled,
-        thm:mpug_staircase_middle_isometry}
+        lem:mpug_staircase_middle_isometry}
     Theorem~\ref{thm:mpug_staircase_network_cancelled} expresses
     $w_L\otimes w_R$ as $v_{23}(u\otimes u)(u^\dagger)_{23}$.
     Each factor is an isometry, so their product is an isometry.
 \end{proof}
 
 \begin{lemma}[Isometry of the second staircase network]
-    \label{thm:mpug_staircase_second_network_isometry}
+    \label{lem:mpug_staircase_second_network_isometry}
     \lean{MPOTensor.SourceFactors.sourceWL_second_network_isIsometry}
     \leanok
     \uses{def:mpug_staircase_gates, def:mpu_source_uv}
@@ -1239,7 +1239,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{corollary}[Unitary staircase gates]
-    \label{thm:mpug_staircase_gates_unitary}
+    \label{cor:mpug_staircase_gates_unitary}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceWL_sourceWR_isUnitaryBetween}
     \leanok
     \discussion{7314}
@@ -1258,11 +1258,11 @@ gauges and scalar relation have been constructed.
 \end{corollary}
 
 \begin{proof}\leanok
-    \uses{ThmFund1, thm:mpug_staircase_first_network_isometry,
+    \uses{ThmFund1, lem:mpug_staircase_first_network_isometry,
         thm:mpug_kronecker_identity_factors,
-        thm:mpug_staircase_second_network_isometry}
+        lem:mpug_staircase_second_network_isometry}
     Theorem~\ref{ThmFund1} gives unitary $u,v$ and $d_rd_l=d^2>0$.
-    Lemma~\ref{thm:mpug_staircase_first_network_isometry} gives
+    Lemma~\ref{lem:mpug_staircase_first_network_isometry} gives
     \begin{align}
         (w_L^\dagger w_L)\otimes(w_R^\dagger w_R) & =I.
     \end{align}
@@ -1272,7 +1272,7 @@ gauges and scalar relation have been constructed.
     Each of the two left-gate layers in
     $K=(w_L\otimes I_d)(I_d\otimes w_L)$ has Gram matrix $\delta I$,
     so $K^\dagger K=\delta^2 I$. By
-    Lemma~\ref{thm:mpug_staircase_second_network_isometry}, this equals
+    Lemma~\ref{lem:mpug_staircase_second_network_isometry}, this equals
     $I$. Thus $\delta^2=1$, equivalently $\delta^{-2}=1$, and positivity
     gives $\delta=1$. Both gates are isometries between spaces of equal
     dimension, hence unitary.
@@ -1281,7 +1281,7 @@ gauges and scalar relation have been constructed.
 \subsection{Physical closures of the source factors}
 
 \begin{lemma}[The canonical one-letter physical contraction]
-    \label{thm:mpug_one_letter_physical_contraction}
+    \label{lem:mpug_one_letter_physical_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_physical_contraction}
     \leanok
     \discussion{7314}
@@ -1312,7 +1312,7 @@ gauges and scalar relation have been constructed.
 \end{proof}
 
 \begin{corollary}[Physical closures of the two source factors]
-    \label{thm:mpug_source_y_physical_contractions}
+    \label{cor:mpug_source_y_physical_contractions}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_physical_contraction,
         MPOTensor.IsMPUCanonicalFormII.sourceY₁_physical_contraction}
     \leanok
@@ -1337,19 +1337,19 @@ gauges and scalar relation have been constructed.
     on the source-cut spaces. They are the two diagrams of part~(b) of
     the staircase-gate corollary in
     \cite[lines~869--917]{FrancoRubio2025MPUGauging}.
-    % Together with thm:mpug_staircase_gates_unitary this establishes
+    % Together with cor:mpug_staircase_gates_unitary this establishes
     % cor:mpu for the source factors of the canonical-form-II presentation.
     % No adjoint-simplicity hypothesis or subsequent eq:MPUnice3/4
     % source-factor constants are asserted here.
 \end{corollary}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_one_letter_physical_contraction,
+    \uses{lem:mpug_one_letter_physical_contraction,
         thm:mpu_source_y_two_rotated_gram,
         thm:mpu_source_v_four_u_expansions}
     The rotated second-cut Gram identity rewrites the first sum as the
     one-letter contraction of
-    Lemma~\ref{thm:mpug_one_letter_physical_contraction}. The weighted
+    Lemma~\ref{lem:mpug_one_letter_physical_contraction}. The weighted
     first-cut Gram identity rewrites the second sum in the same way;
     diagonality of $\rho$ gives $\rho_{\alpha\beta}=\rho_{\beta\alpha}$.
     Both sums therefore equal $\delta_{p,q}$. These Gram identities cancel
@@ -1653,8 +1653,9 @@ Definition~\ref{def:mpug_group_representation}.
     for a single scalar $\delta\in\C$ and every physical pair $i,j$.
     This is the proportionality conclusion in
     \cite[lines~1255--1325]{FrancoRubio2025MPUGauging}.
-    % Only proportionality is proved. The scalar is not evaluated, and
-    % eq:MPUnice3, eq:MPUnice4, and the full prop:MPUsplus remain open.
+    % This theorem proves only proportionality. Normalization requires
+    % the separate source-factor and trace arguments below; the raw
+    % proportionality theorem itself does not evaluate its scalar.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1670,6 +1671,402 @@ Definition~\ref{def:mpug_group_representation}.
     $s^{ij}=c\widetilde{\mathcal U}^{ij}$ for one scalar $c$.
     Set $\delta=c/\sqrt d$.
 \end{proof}
+
+\subsection{Normalization of the first source factor}
+
+\begin{lemma}[The first cut of the adjoint-simple contraction]
+    \label{lem:mpug_first_cut_adjoint_contraction}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_weighted_source_factors,
+        def:mpu_source_matrix_one, def:mpug_adjoint_simple_contraction}
+    Let $\mathcal U$ be an MPU in canonical form II with recorded fixed
+    matrix $\rho$, and let $X_1,Y_1$ be its chosen source factors for this
+    same $\rho$. Construct $s$ from $\mathcal U,\rho$ as in
+    Definition~\ref{def:mpug_adjoint_simple_contraction}. With the first
+    cut convention $(M_1(A))_{(i,b),(a,j)}=A^{i,j}_{ab}$,
+    \begin{align}
+        M_1(s) & =X_1(Y_1Y_1^\dagger)Y_1.
+        \label{eq:mpug_first_cut_adjoint_contraction}
+    \end{align}
+    This factorization requires no simplicity assumption. It is the
+    source-factor expansion in
+    \cite[lines~1326--1374]{FrancoRubio2025MPUGauging}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factorizations,
+        thm:mpu_source_v_four_u_expansions,
+        def:mpug_adjoint_simple_contraction}
+    Replace $X_1Y_1$ by $M_1(\mathcal U)$ and expand the remaining Gram
+    factor with the weighted first-cut identity of
+    Theorem~\ref{thm:mpu_source_v_four_u_expansions}. Reorder the finite
+    sums. Since $\rho$ is diagonal, $\rho_{tr}=\rho_{rt}$, and the result
+    is exactly the raw contraction defining $M_1(s)$.
+\end{proof}
+
+\begin{lemma}[The first source Gram matrix is scalar]
+    \label{lem:mpug_source_y_one_scalar_gram}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose_eq_smul}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPU in canonical form II, and suppose that
+    both $\mathcal U$ and $\mathcal U^\dagger$ are simple. Construct the
+    source factors from $\mathcal U$ and its recorded fixed matrix
+    $\rho$. If $d_r$ is the first source-cut rank, then there is a scalar
+    $\delta\in\C$ such that
+    \begin{align}
+        Y_1Y_1^\dagger & =\delta I_{d_r}.
+    \end{align}
+    This is the scalar Gram identity in
+    \cite[lines~1375--1397]{FrancoRubio2025MPUGauging}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_adjoint_simple_scalar,
+        lem:mpug_first_cut_adjoint_contraction,
+        thm:mpu_source_factor_normalizations,
+        thm:mpu_source_factor_right_inverses,
+        thm:mpu_source_factorizations}
+    By Theorem~\ref{thm:mpug_adjoint_simple_scalar}, $s=\delta\mathcal U$.
+    Applying the first cut and
+    Lemma~\ref{lem:mpug_first_cut_adjoint_contraction} gives
+    \begin{align}
+        X_1(Y_1Y_1^\dagger)Y_1 & =\delta X_1Y_1.
+    \end{align}
+    Multiply on the left by $X_1^\dagger(I_d\otimes\rho)$ and on the
+    right by $Z_1$. The identities
+    $X_1^\dagger(I_d\otimes\rho)X_1=I_{d_r}$ and $Y_1Z_1=I_{d_r}$
+    cancel the two outer factors.
+\end{proof}
+
+\begin{lemma}[Trace of the first source Gram matrix]
+    \label{lem:mpug_source_y_one_gram_trace}
+    \lean{MPOTensor.IsMPUCanonicalFormII.trace_sourceY₁_mul_conjTranspose}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be a simple MPU in canonical form II, with physical
+    dimension $d$, bond dimension $D$, first source-cut rank $d_r$, and
+    recorded fixed matrix $\rho$. Its chosen first source factor satisfies
+    \begin{align}
+        \operatorname{tr}(Y_1Y_1^\dagger) & =d.
+    \end{align}
+    This is the physical-trace calculation used in
+    \cite[line~1398]{FrancoRubio2025MPUGauging}. It does not require
+    simplicity of $\mathcal U^\dagger$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{cor:mpug_source_y_physical_contractions}
+    Cyclic invariance gives
+    $\operatorname{tr}(Y_1Y_1^\dagger)=\operatorname{tr}(Y_1^\dagger Y_1)$.
+    Grouping the latter sum by its physical index gives
+    \begin{align}
+        \operatorname{tr}(Y_1^\dagger Y_1)
+         & =\sum_{p=0}^{d-1}\sum_{r=0}^{d_r-1}\sum_{\alpha=0}^{D-1}
+        \overline{(Y_1)_{r,(\alpha,p)}}(Y_1)_{r,(\alpha,p)}
+        =\sum_{p=0}^{d-1}1=d
+    \end{align}
+    by Corollary~\ref{cor:mpug_source_y_physical_contractions}.
+\end{proof}
+
+\begin{theorem}[Normalization of the first source Gram matrix]
+    \label{thm:mpug_source_y_one_normalization}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPU in canonical form II of physical dimension
+    $d$, and suppose that both $\mathcal U$ and $\mathcal U^\dagger$ are
+    simple. Let $Y_1$ be the first source factor constructed from
+    $\mathcal U$ and its recorded fixed matrix $\rho$, and let $d_r$ be
+    the first source-cut rank. Then
+    \begin{align}
+        Y_1Y_1^\dagger & =\frac{d}{d_r}I_{d_r}.
+    \end{align}
+    This is the first identity of the source-factor normalization
+    proposition in \cite[lines~1064--1119]{FrancoRubio2025MPUGauging}.
+    % Source: first identity of eq:MPUnice3. The other three constants
+    % and the full prop:MPUsplus are not established by this entry.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpug_source_y_one_scalar_gram,
+        lem:mpug_source_y_one_gram_trace}
+    Write $Y_1Y_1^\dagger=\delta I_{d_r}$ using
+    Lemma~\ref{lem:mpug_source_y_one_scalar_gram}. Taking traces and using
+    Lemma~\ref{lem:mpug_source_y_one_gram_trace} gives $\delta d_r=d$.
+    Canonical form II gives $d>0$, so $d_r\ne0$. Dividing gives
+    $\delta=d/d_r$, as in
+    \cite[line~1398]{FrancoRubio2025MPUGauging}.
+\end{proof}
+
+\subsection{Normalization of the weighted second source factor}
+
+\begin{lemma}[The first cut of the reflected contraction]
+    \label{lem:mpug_adjoint_cut_second_gram}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction_physicalAdjoint}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_weighted_source_factors,
+        def:mpu_source_matrix_one, def:mpug_adjoint_simple_contraction,
+        def:mpdo_physical_adjoint, def:mpu_source_weight}
+    Let $\mathcal U$ be an MPU in canonical form II with recorded fixed
+    matrix $\rho$, and let $X_2,Y_2$ be its chosen second source factors.
+    Set $W=I_d\otimes\rho$ and let $s_\dagger$ be the raw contraction of
+    Definition~\ref{def:mpug_adjoint_simple_contraction}, applied to
+    $\mathcal U^\dagger$ and this same $\rho$. Then
+    \begin{align}
+        M_1(s_\dagger) & =Y_2^\dagger(Y_2WY_2^\dagger)X_2^\dagger.
+    \end{align}
+    This is the reflected factorization used for the second identity of
+    the normalization proposition in
+    \cite[lines~1064--1119 and 1398]{FrancoRubio2025MPUGauging}.
+    No simplicity hypothesis is needed for this factorization.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_adjoint_simple_contraction,
+        thm:mpu_physical_adjoint_source_cuts,
+        thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations}
+    Expanding the raw contraction of any tensor $A$ gives
+    \begin{align}
+        M_1(s(A,\rho)) & =M_1(A)M_1(A)^\dagger W^{\mathsf T}M_1(A).
+    \end{align}
+    The transpose records the boundary coefficient $\rho_{tr}$. Here
+    $\rho$ is diagonal, so $W^{\mathsf T}=W$. Substitute
+    $M_1(\mathcal U^\dagger)=M_2(\mathcal U)^\dagger=Y_2^\dagger X_2^\dagger$
+    and cancel $X_2^\dagger X_2=I$. All factors are those of
+    $\mathcal U$, not newly chosen factors of its adjoint.
+\end{proof}
+
+\begin{lemma}[The weighted second source Gram matrix is scalar]
+    \label{lem:mpug_source_y_two_scalar_gram}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose_eq_smul}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors,
+        def:mpu_source_weight}
+    Let $\mathcal U$ be an MPU in canonical form II with recorded fixed
+    matrix $\rho$, and assume that both $\mathcal U$ and
+    $\mathcal U^\dagger$ are simple. Let $Y_2$ be its chosen second
+    source factor and $d_l$ its second source-cut rank. There is a scalar
+    $\varepsilon\in\C$ such that
+    \begin{align}
+        Y_2(I_d\otimes\rho)Y_2^\dagger & =\varepsilon I_{d_l}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_adjoint_canonical_boundaries,
+        thm:mpug_adjoint_simple_scalar, thm:mpu_physical_adjoint_identities,
+        lem:mpug_adjoint_cut_second_gram,
+        thm:mpu_physical_adjoint_source_cuts,
+        thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations,
+        thm:mpu_source_factor_right_inverses}
+    Transport canonical form II to $\mathcal U^\dagger$ with the same
+    $\rho$. Theorem~\ref{thm:mpug_adjoint_simple_scalar} gives
+    $s_\dagger=\varepsilon\mathcal U^\dagger$, since physical adjunction
+    is involutive and both required simplicity hypotheses hold.
+    Taking the first cut and applying
+    Lemma~\ref{lem:mpug_adjoint_cut_second_gram} gives
+    \begin{align}
+        Y_2^\dagger(Y_2(I_d\otimes\rho)Y_2^\dagger)X_2^\dagger
+         & =\varepsilon Y_2^\dagger X_2^\dagger.
+    \end{align}
+    Multiply on the left by $Z_2^\dagger$ and on the right by $X_2$.
+    Use $Z_2^\dagger Y_2^\dagger=I$ and $X_2^\dagger X_2=I$.
+    The scalar comes from the adjoint contraction; it has not been
+    identified with the scalar for the original tensor.
+\end{proof}
+
+\begin{lemma}[Trace of the weighted second source Gram matrix]
+    \label{lem:mpug_source_y_two_gram_trace}
+    \lean{MPOTensor.IsMPUCanonicalFormII.trace_sourceY₂_weighted_mul_conjTranspose}
+    \leanok
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpu_weighted_source_factors, def:mpu_source_weight}
+    Let $\mathcal U$ be a simple MPU in canonical form II of physical
+    dimension $d$, with recorded fixed matrix $\rho$ and chosen second
+    source factor $Y_2$. Then
+    \begin{align}
+        \operatorname{tr}\bigl(Y_2(I_d\otimes\rho)Y_2^\dagger\bigr) & =d.
+    \end{align}
+    Simplicity of $\mathcal U^\dagger$ is not required.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{cor:mpug_source_y_physical_contractions, def:mpu_source_weight}
+    Move the last factor to the front inside the trace and expand
+    $I_d\otimes\rho$. Grouping by the physical index gives the sum of
+    the diagonal physical closures from
+    Corollary~\ref{cor:mpug_source_y_physical_contractions}. Each of the
+    $d$ terms is one.
+\end{proof}
+
+\begin{theorem}[Normalization of the weighted second source Gram matrix]
+    \label{thm:mpug_source_y_two_normalization}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors,
+        def:mpu_source_weight}
+    Let $\mathcal U$ be an MPU in canonical form II of physical dimension
+    $d$, and suppose that both $\mathcal U$ and $\mathcal U^\dagger$ are
+    simple. Let $Y_2$ be the second source factor constructed from
+    $\mathcal U$ and its recorded fixed matrix $\rho$, and let $d_l$ be
+    the second source-cut rank. Then
+    \begin{align}
+        Y_2(I_d\otimes\rho)Y_2^\dagger & =\frac{d}{d_l}I_{d_l}.
+    \end{align}
+    This is the second identity of the source-factor normalization
+    proposition in \cite[lines~1064--1119]{FrancoRubio2025MPUGauging}.
+    % Source: second identity of eq:MPUnice3. Neither physical X
+    % normalization nor the full prop:MPUsplus follows from this entry alone.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpug_source_y_two_scalar_gram,
+        lem:mpug_source_y_two_gram_trace}
+    Write the Gram matrix as $\varepsilon I_{d_l}$ using
+    Lemma~\ref{lem:mpug_source_y_two_scalar_gram}. Its trace is $d$ by
+    Lemma~\ref{lem:mpug_source_y_two_gram_trace}, so $\varepsilon d_l=d$.
+    As $d>0$, the rank $d_l$ is nonzero, giving $\varepsilon=d/d_l$.
+    This is the trace argument indicated in
+    \cite[line~1398]{FrancoRubio2025MPUGauging}.
+\end{proof}
+
+\subsection{Physical normalizations of the two source X factors}
+
+\begin{lemma}[The canonical one-letter output contraction]
+    \label{lem:mpug_one_letter_output_contraction}
+    \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_output_contraction}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint}
+    Let $\mathcal U$ be an MPU in canonical form II of physical dimension
+    $d$ and bond dimension $D$, with recorded fixed matrix $\rho$.
+    Suppose that $\mathcal U^\dagger$ is simple. For $0\leq i,j<d$,
+    \begin{align}
+        \sum_{x,\alpha,\beta=0}^{D-1}\sum_{p=0}^{d-1}
+        \mathcal U^{i,p}_{x\alpha}
+        \overline{\mathcal U^{j,p}_{x\beta}}\rho_{\beta\alpha}
+         & =\delta_{i,j}.
+    \end{align}
+    The open indices are the physical output indices. This is the
+    reflected one-letter contraction used for the physical source-factor
+    normalizations in \cite[lines~1120--1162 and 1398]{FrancoRubio2025MPUGauging}.
+    Simplicity of $\mathcal U$ is not required for this contraction.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpug_adjoint_canonical_boundaries,
+        lem:mpug_one_letter_physical_contraction, def:mpdo_physical_adjoint}
+    Apply Lemma~\ref{lem:mpug_one_letter_physical_contraction} to
+    $\mathcal U^\dagger$ with its canonical presentation carrying the
+    same $\rho$. Its letters are
+    $(\mathcal U^\dagger)^{p,i}_{x\alpha}=\overline{\mathcal U^{i,p}_{x\alpha}}$.
+    Substitution and double conjugation give the displayed sum.
+\end{proof}
+
+\begin{theorem}[Physical normalization of the first source X factor]
+    \label{thm:mpug_source_x_one_physical_normalization}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceX₁_physical_contraction}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPU in canonical form II of physical dimension
+    $d$ and bond dimension $D$. Assume that both $\mathcal U$ and
+    $\mathcal U^\dagger$ are simple. Let $X_1$ be the first source factor
+    constructed from $\mathcal U$ and its recorded fixed matrix $\rho$,
+    and let $d_r$ be the first source-cut rank. For $0\leq i,j<d$,
+    \begin{align}
+        \sum_{r=0}^{d_r-1}\sum_{\alpha,\beta=0}^{D-1}
+        (X_1)_{(i,\alpha),r}\rho_{\beta\alpha}
+        \overline{(X_1)_{(j,\beta),r}}
+         & =\frac{d_r}{d}\delta_{i,j}.
+    \end{align}
+    This is the first physical source-factor normalization in
+    \cite[lines~1120--1162]{FrancoRubio2025MPUGauging}. The matrix $\rho$
+    acts on the virtual legs; the identity acts on the physical space.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_source_y_one_normalization,
+        lem:mpug_source_y_one_gram_trace, lem:mpug_one_letter_output_contraction,
+        thm:mpu_source_factorizations, def:mpu_source_matrix_one}
+    Factor $M_1(\mathcal U)=X_1Y_1$ and apply
+    Theorem~\ref{thm:mpug_source_y_one_normalization} to obtain
+    \begin{align}
+        M_1(\mathcal U)M_1(\mathcal U)^\dagger
+         & =\frac{d}{d_r}X_1X_1^\dagger.
+    \end{align}
+    Multiply the $((i,\alpha),(j,\beta))$ entry by
+    $\rho_{\beta\alpha}$ and sum over $\alpha,\beta$.
+    Lemma~\ref{lem:mpug_one_letter_output_contraction} makes the left-hand
+    side $\delta_{i,j}$. The trace identity in
+    Lemma~\ref{lem:mpug_source_y_one_gram_trace} gives $d_r\ne0$, and
+    canonical form II gives $d>0$. Multiplication by $d_r/d$ gives the
+    required physical contraction.
+\end{proof}
+
+\begin{theorem}[Physical normalization of the second source X factor]
+    \label{thm:mpug_source_x_two_physical_normalization}
+    \lean{MPOTensor.IsMPUCanonicalFormII.sourceX₂_physical_contraction}
+    \leanok
+    \discussion{7317}
+    \uses{def:mpu_canonical_form_ii, def:mpu_simple,
+        def:mpdo_physical_adjoint, def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPU in canonical form II of physical dimension
+    $d$ and bond dimension $D$. Assume that both $\mathcal U$ and
+    $\mathcal U^\dagger$ are simple. Let $X_2$ be its chosen second source
+    factor and let $d_l$ be the second source-cut rank. For $0\leq i,j<d$,
+    \begin{align}
+        \sum_{l=0}^{d_l-1}\sum_{x=0}^{D-1}
+        (X_2)_{(x,i),l}\overline{(X_2)_{(x,j),l}}
+         & =\frac{d_l}{d}\delta_{i,j}.
+    \end{align}
+    This is the second physical source-factor normalization in
+    \cite[lines~1120--1162]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_source_y_two_normalization,
+        lem:mpug_source_y_two_gram_trace, lem:mpug_one_letter_output_contraction,
+        thm:mpu_source_factorizations, def:mpu_source_matrix_two,
+        def:mpu_source_weight}
+    Put $W=I_d\otimes\rho$. The factorization $M_2(\mathcal U)=X_2Y_2$
+    and Theorem~\ref{thm:mpug_source_y_two_normalization} give
+    \begin{align}
+        M_2(\mathcal U)WM_2(\mathcal U)^\dagger
+         & =\frac{d}{d_l}X_2X_2^\dagger.
+    \end{align}
+    Sum the $((x,i),(x,j))$ entry over $x$. Expanding the left-hand side,
+    using $\rho_{\alpha\beta}=\rho_{\beta\alpha}$, gives
+    $\delta_{i,j}$ by Lemma~\ref{lem:mpug_one_letter_output_contraction}.
+    The trace identity in Lemma~\ref{lem:mpug_source_y_two_gram_trace}
+    gives $d_l\ne0$, and $d>0$. Multiply by $d_l/d$ to conclude.
+\end{proof}
+
+Theorems~\ref{thm:mpug_source_y_one_normalization},
+\ref{thm:mpug_source_y_two_normalization},
+\ref{thm:mpug_source_x_one_physical_normalization}, and
+\ref{thm:mpug_source_x_two_physical_normalization} establish all four
+identities of the source-factor normalization proposition in
+\cite[lines~1064--1162]{FrancoRubio2025MPUGauging} for the compact source
+factors constructed from the canonical presentation. Their hypotheses
+are canonical form II and simplicity of both $\mathcal U$ and
+$\mathcal U^\dagger$; no additional boundary or Gram identities are assumed.
+% This establishes prop:MPUsplus for the constructed source factors.
+% It does not identify arbitrary separately supplied factors or modify
+% the scope of the earlier raw proportionality theorem.
 
 \begin{theorem}[Comparison of factorizations from one-sided inverses]
     \label{thm:mpug_factorization_comparison}
@@ -5277,7 +5674,7 @@ by the displayed matrices.
 \end{definition}
 
 \begin{lemma}[Elementary identities for the Pauli adjoint gauge]
-    \label{thm:mpug_czx_dagger_gauge_laws}
+    \label{lem:mpug_czx_dagger_gauge_laws}
     \lean{MPOTensor.CZX.daggerGauge_conjTranspose,
         MPOTensor.CZX.daggerGauge_mul_self,
         MPOTensor.CZX.daggerGauge_mem_unitaryGroup}
@@ -5345,14 +5742,14 @@ by the displayed matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
-    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
+    \uses{lem:mpug_czx_dagger_gauge_laws, thm:mpug_czx_physical_adjoint}
+    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws} gives $Y\in\mathrm{U}(2)$
     and $Y^\dagger=Y$. Substitute into
     Theorem~\ref{thm:mpug_czx_physical_adjoint}.
 \end{proof}
 
 \begin{lemma}[The sign of the explicit CZX adjoint gauge]
-    \label{thm:mpug_czx_dagger_sign}
+    \label{lem:mpug_czx_dagger_sign}
     \lean{MPOTensor.CZX.daggerGauge_map_star,
         MPOTensor.CZX.daggerGauge_mul_map_star}
     \leanok
@@ -5370,10 +5767,10 @@ by the displayed matrices.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_dagger_gauge, thm:mpug_czx_dagger_gauge_laws}
+    \uses{def:mpug_czx_dagger_gauge, lem:mpug_czx_dagger_gauge_laws}
     Conjugating each entry of the displayed Pauli matrix gives
     $\overline{Y}=-Y$. Then $Y\overline{Y}=-Y^2=-I_2$ by
-    Lemma~\ref{thm:mpug_czx_dagger_gauge_laws}.
+    Lemma~\ref{lem:mpug_czx_dagger_gauge_laws}.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1674,8 +1674,8 @@ Definition~\ref{def:mpug_group_representation}.
 
 \subsection{Normalization of the first source factor}
 
-\begin{lemma}[The first cut of the adjoint-simple contraction]
-    \label{lem:mpug_first_cut_adjoint_contraction}
+\begin{theorem}[The first cut of the adjoint-simple contraction]
+    \label{thm:mpug_first_cut_adjoint_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction}
     \leanok
     \discussion{7317}
@@ -1693,7 +1693,7 @@ Definition~\ref{def:mpug_group_representation}.
     This factorization requires no simplicity assumption. It is the
     source-factor expansion in
     \cite[lines~1326--1374]{FrancoRubio2025MPUGauging}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_source_factorizations,
@@ -1706,8 +1706,8 @@ Definition~\ref{def:mpug_group_representation}.
     is exactly the raw contraction defining $M_1(s)$.
 \end{proof}
 
-\begin{lemma}[The first source Gram matrix is scalar]
-    \label{lem:mpug_source_y_one_scalar_gram}
+\begin{theorem}[The first source Gram matrix is scalar]
+    \label{thm:mpug_source_y_one_scalar_gram}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose_eq_smul}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpu_simple,
@@ -1722,17 +1722,17 @@ Definition~\ref{def:mpug_group_representation}.
     \end{align}
     This is the scalar Gram identity in
     \cite[lines~1375--1397]{FrancoRubio2025MPUGauging}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpug_adjoint_simple_scalar,
-        lem:mpug_first_cut_adjoint_contraction,
+        thm:mpug_first_cut_adjoint_contraction,
         thm:mpu_source_factor_normalizations,
         thm:mpu_source_factor_right_inverses,
         thm:mpu_source_factorizations}
     By Theorem~\ref{thm:mpug_adjoint_simple_scalar}, $s=\delta\mathcal U$.
     Applying the first cut and
-    Lemma~\ref{lem:mpug_first_cut_adjoint_contraction} gives
+    Theorem~\ref{thm:mpug_first_cut_adjoint_contraction} gives
     \begin{align}
         X_1(Y_1Y_1^\dagger)Y_1 & =\delta X_1Y_1.
     \end{align}
@@ -1742,8 +1742,8 @@ Definition~\ref{def:mpug_group_representation}.
     cancel the two outer factors.
 \end{proof}
 
-\begin{lemma}[Trace of the first source Gram matrix]
-    \label{lem:mpug_source_y_one_gram_trace}
+\begin{theorem}[Trace of the first source Gram matrix]
+    \label{thm:mpug_source_y_one_gram_trace}
     \lean{MPOTensor.IsMPUCanonicalFormII.trace_sourceY₁_mul_conjTranspose}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpu_simple,
@@ -1757,7 +1757,7 @@ Definition~\ref{def:mpug_group_representation}.
     This is the physical-trace calculation used in
     \cite[line~1398]{FrancoRubio2025MPUGauging}. It does not require
     simplicity of $\mathcal U^\dagger$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{cor:mpug_source_y_physical_contractions}
@@ -1795,11 +1795,11 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_source_y_one_scalar_gram,
-        lem:mpug_source_y_one_gram_trace}
+    \uses{thm:mpug_source_y_one_scalar_gram,
+        thm:mpug_source_y_one_gram_trace}
     Write $Y_1Y_1^\dagger=\delta I_{d_r}$ using
-    Lemma~\ref{lem:mpug_source_y_one_scalar_gram}. Taking traces and using
-    Lemma~\ref{lem:mpug_source_y_one_gram_trace} gives $\delta d_r=d$.
+    Theorem~\ref{thm:mpug_source_y_one_scalar_gram}. Taking traces and using
+    Theorem~\ref{thm:mpug_source_y_one_gram_trace} gives $\delta d_r=d$.
     Canonical form II gives $d>0$, so $d_r\ne0$. Dividing gives
     $\delta=d/d_r$, as in
     \cite[line~1398]{FrancoRubio2025MPUGauging}.
@@ -1807,8 +1807,8 @@ Definition~\ref{def:mpug_group_representation}.
 
 \subsection{Normalization of the weighted second source factor}
 
-\begin{lemma}[The first cut of the reflected contraction]
-    \label{lem:mpug_adjoint_cut_second_gram}
+\begin{theorem}[The first cut of the reflected contraction]
+    \label{thm:mpug_adjoint_cut_second_gram}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceCutM₁_adjointSimpleContraction_physicalAdjoint}
     \leanok
     \discussion{7317}
@@ -1827,7 +1827,7 @@ Definition~\ref{def:mpug_group_representation}.
     the normalization proposition in
     \cite[lines~1064--1119 and 1398]{FrancoRubio2025MPUGauging}.
     No simplicity hypothesis is needed for this factorization.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_adjoint_simple_contraction,
@@ -1844,8 +1844,8 @@ Definition~\ref{def:mpug_group_representation}.
     $\mathcal U$, not newly chosen factors of its adjoint.
 \end{proof}
 
-\begin{lemma}[The weighted second source Gram matrix is scalar]
-    \label{lem:mpug_source_y_two_scalar_gram}
+\begin{theorem}[The weighted second source Gram matrix is scalar]
+    \label{thm:mpug_source_y_two_scalar_gram}
     \lean{MPOTensor.IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose_eq_smul}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpu_simple,
@@ -1859,12 +1859,12 @@ Definition~\ref{def:mpug_group_representation}.
     \begin{align}
         Y_2(I_d\otimes\rho)Y_2^\dagger & =\varepsilon I_{d_l}.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_adjoint_canonical_boundaries,
         thm:mpug_adjoint_simple_scalar, thm:mpu_physical_adjoint_identities,
-        lem:mpug_adjoint_cut_second_gram,
+        thm:mpug_adjoint_cut_second_gram,
         thm:mpu_physical_adjoint_source_cuts,
         thm:mpu_source_factorizations, thm:mpu_source_factor_normalizations,
         thm:mpu_source_factor_right_inverses}
@@ -1873,7 +1873,7 @@ Definition~\ref{def:mpug_group_representation}.
     $s_\dagger=\varepsilon\mathcal U^\dagger$, since physical adjunction
     is involutive and both required simplicity hypotheses hold.
     Taking the first cut and applying
-    Lemma~\ref{lem:mpug_adjoint_cut_second_gram} gives
+    Theorem~\ref{thm:mpug_adjoint_cut_second_gram} gives
     \begin{align}
         Y_2^\dagger(Y_2(I_d\otimes\rho)Y_2^\dagger)X_2^\dagger
          & =\varepsilon Y_2^\dagger X_2^\dagger.
@@ -1884,8 +1884,8 @@ Definition~\ref{def:mpug_group_representation}.
     identified with the scalar for the original tensor.
 \end{proof}
 
-\begin{lemma}[Trace of the weighted second source Gram matrix]
-    \label{lem:mpug_source_y_two_gram_trace}
+\begin{theorem}[Trace of the weighted second source Gram matrix]
+    \label{thm:mpug_source_y_two_gram_trace}
     \lean{MPOTensor.IsMPUCanonicalFormII.trace_sourceY₂_weighted_mul_conjTranspose}
     \leanok
     \uses{def:mpu_canonical_form_ii, def:mpu_simple,
@@ -1897,7 +1897,7 @@ Definition~\ref{def:mpug_group_representation}.
         \operatorname{tr}\bigl(Y_2(I_d\otimes\rho)Y_2^\dagger\bigr) & =d.
     \end{align}
     Simplicity of $\mathcal U^\dagger$ is not required.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{cor:mpug_source_y_physical_contractions, def:mpu_source_weight}
@@ -1931,11 +1931,11 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpug_source_y_two_scalar_gram,
-        lem:mpug_source_y_two_gram_trace}
+    \uses{thm:mpug_source_y_two_scalar_gram,
+        thm:mpug_source_y_two_gram_trace}
     Write the Gram matrix as $\varepsilon I_{d_l}$ using
-    Lemma~\ref{lem:mpug_source_y_two_scalar_gram}. Its trace is $d$ by
-    Lemma~\ref{lem:mpug_source_y_two_gram_trace}, so $\varepsilon d_l=d$.
+    Theorem~\ref{thm:mpug_source_y_two_scalar_gram}. Its trace is $d$ by
+    Theorem~\ref{thm:mpug_source_y_two_gram_trace}, so $\varepsilon d_l=d$.
     As $d>0$, the rank $d_l$ is nonzero, giving $\varepsilon=d/d_l$.
     This is the trace argument indicated in
     \cite[line~1398]{FrancoRubio2025MPUGauging}.
@@ -1943,8 +1943,8 @@ Definition~\ref{def:mpug_group_representation}.
 
 \subsection{Physical normalizations of the two source X factors}
 
-\begin{lemma}[The canonical one-letter output contraction]
-    \label{lem:mpug_one_letter_output_contraction}
+\begin{theorem}[The canonical one-letter output contraction]
+    \label{thm:mpug_one_letter_output_contraction}
     \lean{MPOTensor.IsMPUCanonicalFormII.oneLetter_output_contraction}
     \leanok
     \discussion{7317}
@@ -1963,7 +1963,7 @@ Definition~\ref{def:mpug_group_representation}.
     reflected one-letter contraction used for the physical source-factor
     normalizations in \cite[lines~1120--1162 and 1398]{FrancoRubio2025MPUGauging}.
     Simplicity of $\mathcal U$ is not required for this contraction.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpug_adjoint_canonical_boundaries,
@@ -2000,7 +2000,7 @@ Definition~\ref{def:mpug_group_representation}.
 
 \begin{proof}\leanok
     \uses{thm:mpug_source_y_one_normalization,
-        lem:mpug_source_y_one_gram_trace, lem:mpug_one_letter_output_contraction,
+        thm:mpug_source_y_one_gram_trace, thm:mpug_one_letter_output_contraction,
         thm:mpu_source_factorizations, def:mpu_source_matrix_one}
     Factor $M_1(\mathcal U)=X_1Y_1$ and apply
     Theorem~\ref{thm:mpug_source_y_one_normalization} to obtain
@@ -2010,9 +2010,9 @@ Definition~\ref{def:mpug_group_representation}.
     \end{align}
     Multiply the $((i,\alpha),(j,\beta))$ entry by
     $\rho_{\beta\alpha}$ and sum over $\alpha,\beta$.
-    Lemma~\ref{lem:mpug_one_letter_output_contraction} makes the left-hand
+    Theorem~\ref{thm:mpug_one_letter_output_contraction} makes the left-hand
     side $\delta_{i,j}$. The trace identity in
-    Lemma~\ref{lem:mpug_source_y_one_gram_trace} gives $d_r\ne0$, and
+    Theorem~\ref{thm:mpug_source_y_one_gram_trace} gives $d_r\ne0$, and
     canonical form II gives $d>0$. Multiplication by $d_r/d$ gives the
     required physical contraction.
 \end{proof}
@@ -2039,7 +2039,7 @@ Definition~\ref{def:mpug_group_representation}.
 
 \begin{proof}\leanok
     \uses{thm:mpug_source_y_two_normalization,
-        lem:mpug_source_y_two_gram_trace, lem:mpug_one_letter_output_contraction,
+        thm:mpug_source_y_two_gram_trace, thm:mpug_one_letter_output_contraction,
         thm:mpu_source_factorizations, def:mpu_source_matrix_two,
         def:mpu_source_weight}
     Put $W=I_d\otimes\rho$. The factorization $M_2(\mathcal U)=X_2Y_2$
@@ -2050,8 +2050,8 @@ Definition~\ref{def:mpug_group_representation}.
     \end{align}
     Sum the $((x,i),(x,j))$ entry over $x$. Expanding the left-hand side,
     using $\rho_{\alpha\beta}=\rho_{\beta\alpha}$, gives
-    $\delta_{i,j}$ by Lemma~\ref{lem:mpug_one_letter_output_contraction}.
-    The trace identity in Lemma~\ref{lem:mpug_source_y_two_gram_trace}
+    $\delta_{i,j}$ by Theorem~\ref{thm:mpug_one_letter_output_contraction}.
+    The trace identity in Theorem~\ref{thm:mpug_source_y_two_gram_trace}
     gives $d_l\ne0$, and $d>0$. Multiply by $d_l/d$ to conclude.
 \end{proof}
 

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1827,7 +1827,7 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{cor:mpug_source_y_physical_contractions}
+    \uses{thm:mpug_source_y_physical_contractions}
     Cyclic invariance gives
     $\operatorname{tr}(Y_1Y_1^\dagger)=\operatorname{tr}(Y_1^\dagger Y_1)$.
     Grouping the latter sum by its physical index gives
@@ -1837,7 +1837,7 @@ Definition~\ref{def:mpug_group_representation}.
         \overline{(Y_1)_{r,(\alpha,p)}}(Y_1)_{r,(\alpha,p)}
         =\sum_{p=0}^{d-1}1=d
     \end{align}
-    by Corollary~\ref{cor:mpug_source_y_physical_contractions}.
+    by Theorem~\ref{thm:mpug_source_y_physical_contractions}.
 \end{proof}
 
 \begin{theorem}[Normalization of the first source Gram matrix]
@@ -1969,7 +1969,7 @@ Definition~\ref{def:mpug_group_representation}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{cor:mpug_source_y_physical_contractions, def:mpu_source_weight}
+    \uses{thm:mpug_source_y_physical_contractions, def:mpu_source_weight}
     Cyclic invariance and expanding $I_d\otimes\rho$ give
     \begin{align}
         \operatorname{tr}\bigl(Y_2(I_d\otimes\rho)Y_2^\dagger\bigr)
@@ -1977,7 +1977,7 @@ Definition~\ref{def:mpug_group_representation}.
         \overline{(Y_2)_{l,(p,y)}}(Y_2)_{l,(p,x)}\rho_{xy}
         =\sum_{p=0}^{d-1}1=d
     \end{align}
-    by Corollary~\ref{cor:mpug_source_y_physical_contractions} at $q=p$.
+    by Theorem~\ref{thm:mpug_source_y_physical_contractions} at $q=p$.
 \end{proof}
 
 \begin{theorem}[Normalization of the weighted second source Gram matrix]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,22 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### source-rank nonvanishing from a trace equation — promoted
+- **Pattern:** derive `rank ≠ 0` from `htrace : coefficient * rank = d` and
+  `hd : d ≠ 0` by assuming the rank is zero and simplifying the trace equation.
+- **Seen:** four occurrences across three files (2026-09-06):
+  `IsMPUCanonicalFormII.sourceY₁_mul_conjTranspose` in
+  `TNLean/MPS/MPU/SourceYOneNormalization.lean`,
+  `IsMPUCanonicalFormII.sourceY₂_weighted_mul_conjTranspose` in
+  `TNLean/MPS/MPU/SourceYTwoNormalization.lean`, and
+  `IsMPUCanonicalFormII.sourceX₁_physical_contraction` and
+  `IsMPUCanonicalFormII.sourceX₂_physical_contraction` in
+  `TNLean/MPS/MPU/SourceXPhysicalNormalization.lean`.
+- **Abstraction:** existing Mathlib `right_ne_zero_of_mul`, applied as
+  `right_ne_zero_of_mul (htrace.trans_ne hd)`.
+- **Notes:** resolved by direct library reuse at all four sites, removing twelve
+  proof lines. No new helper, tactic, import, or public statement is needed.
+
 ### nested finite-sum congruence under two binders — promoted
 - **Pattern:** two successive `apply Finset.sum_congr rfl` steps, each
   followed by an index and membership introduction.


### PR DESCRIPTION
## Scope

Closes #7317: the four displayed source-factor identities of arXiv:2502.20257, Proposition `prop:MPUsplus`, for the compact source factors constructed from the tensor and its recorded canonical fixed point.

Stacked on #7790 (and its #7789/#7788 prerequisites). Sequential merges only after successful current-head checks, agreeing reviews, and resolved threads.

## Results and source route

With r=d_r, ell=d_l and the exact choice S=sourceFactors U rho:

- Y₁Y₁†=(d/r) I.
- Y₂(I_d⊗rho)Y₂†=(d/ell) I.
- The weighted physical X₁ closure is (r/d) I_d, with rho_{beta,alpha}.
- The unweighted physical X₂ closure is (ell/d) I_d.

All four endpoints retain canonical form II, simplicity of U, and simplicity of its physical adjoint. No Gram equation, boundary identity, nonzero source rank, or TFAE consequence is assumed as an extra premise.

The first normalization factors the actual raw s contraction as X₁(Y₁Y₁†)Y₁, cancels the established one-sided inverses, then traces the physical closure. The second applies raw-s proportionality to U† with the SAME recorded rho, rewrites its first cut through the ORIGINAL X₂/Y₂, and determines its separate scalar by trace. The transposed weight is retained until canonical diagonality justifies symmetry. Neither argument identifies the adjoint's chosen singular vectors. The physical X equations follow from the canonical output closure and these Y identities.

The four repeated rank-nonvanishing arguments were replaced by existing Mathlib right_ne_zero_of_mul; no extra scalar theory, structures, or tactics. The promotion ledger records this direct reuse.

## Scope boundaries

This establishes all four source diagrams for the constructed compact factors, not an arbitrary-factor gauge-independence theorem. No CZX factor/action/fusion result or #7313 assembly is included. The earlier raw proportionality theorem remains correctly scoped: its separate source-factor and trace arguments, not proportionality alone, determine the constants.

## Verification

- Independent mathematical/source/Lean reviews approve all four endpoints and the full stated proposition scope.
- Targeted cached strict checks pass in Y₁→Y₂→X order; all four endpoint axiom audits contain only propext, Classical.choice, Quot.sound. No broad/root/Mathlib rebuild.
- Eleven public declarations have exact coverage in eleven independently reviewed blueprint nodes; private proof helpers are excluded.
- Correct lemma/theorem label prefixes, unique resolving dependencies and no dependency cycles; pinned latexindent 3.24.7 fixed point; CI-mode declaration synchronization passes.
- Generated import snapshot includes exactly the committed normalization modules; unrelated next-wave work is excluded.
