### PR TITLE
feat(MPU): prove raw source uniqueness and construct displayed CZX factors

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -111,6 +111,7 @@ import TNLean.MPS.MPDO.CZXGHZAction
 import TNLean.MPS.MPDO.CZXGaussCircuitTuple
 import TNLean.MPS.MPDO.CZXGaussInvariantSubspace
 import TNLean.MPS.MPDO.CZXSecondTupleCertificate
+import TNLean.MPS.MPDO.CZXSourceFactors
 import TNLean.MPS.MPDO.CZXTensor
 import TNLean.MPS.MPDO.CZXTensorInjectivity
 import TNLean.MPS.MPDO.CaseIIAbsorptionCounterexample

--- a/TNLean/MPS/MPDO/CZXSourceFactors.lean
+++ b/TNLean/MPS/MPDO/CZXSourceFactors.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CZXDaggerGauge
+import TNLean.MPS.MPU.SourceFactors
+
+/-!
+# Displayed CZX source factors
+
+Explicit factors from arXiv:2502.20257, lines 4559–4659 (`eq:modif_XY`),
+for the shared, output-Z-decorated `CZX.tensor`. Physical indices use the
+ordering `2a+b`. The first empty factor uses `Y β t`, not `Y t β`.
+These are explicit witnesses, not identifications with choice-selected SVD factors.
+-/
+
+noncomputable section
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.CZX
+
+/-- Filled left factor, arXiv:2502.20257, lines 4559–4610. -/
+def displayedX₂ : Matrix (Fin 2 × Fin 4) (Fin 4) ℂ := fun (α, i) k ↦
+  if i = k ∧ α = (Fin.divNat (m := 2) (n := 2) i) then
+    (-1 : ℂ) ^ ((Fin.divNat (m := 2) (n := 2) i).val +
+      (Fin.modNat (m := 2) (n := 2) i).val) else 0
+
+/-- Filled right factor: the two flips and unnormalized Hadamard weights,
+arXiv:2502.20257, lines 4559–4610. -/
+def displayedY₂ : Matrix (Fin 4) (Fin 4 × Fin 2) ℂ := fun k (j, β) ↦
+  if k = j.rev then
+    (-1 : ℂ) ^ ((Fin.divNat (m := 2) (n := 2) k).val *
+      (Fin.modNat (m := 2) (n := 2) k).val + (Fin.modNat (m := 2) (n := 2) k).val * β.val)
+  else 0
+
+/-- Empty left factor with the Pauli gauge on the right virtual leg,
+arXiv:2502.20257, lines 4611–4659. The order `β t` is essential. -/
+def displayedX₁ : Matrix (Fin 4 × Fin 2) (Fin 4) ℂ := fun (i, β) k ↦
+  ∑ t : Fin 2, daggerGauge β t * star (displayedY₂ k (i, t))
+
+/-- Empty right factor, arXiv:2502.20257, lines 4611–4659. -/
+def displayedY₁ : Matrix (Fin 4) (Fin 2 × Fin 4) ℂ := fun k (α, j) ↦
+  ∑ t : Fin 2, star (displayedX₂ (t, j) k) * daggerGauge t α
+
+/-- Both displayed decompositions recover the exact shared tensor,
+arXiv:2502.20257, lines 4559–4659. -/
+theorem displayed_cuts :
+    displayedX₁ * displayedY₁ = sourceCutM₁ tensor ∧
+    displayedX₂ * displayedY₂ = sourceCutM₂ tensor := by
+  have hc : ∀ j : Fin 4, complementSite j = j.rev := by decide
+  have hb : ∀ i : Fin 4, siteBits i =
+      (show ZMod 2 from Fin.divNat (m := 2) (n := 2) i,
+        show ZMod 2 from Fin.modNat (m := 2) (n := 2) i) := by decide
+  constructor <;> ext ⟨a, b⟩ ⟨c, d⟩ <;>
+    simp only [Matrix.mul_apply, Fin.sum_univ_four, sourceCutM₁, sourceCutM₂,
+      tensor_apply, hc, edgeExponent, hb] <;>
+    fin_cases a <;> fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    norm_num +decide [displayedX₁, displayedY₁, displayedX₂, displayedY₂,
+      Fin.sum_univ_two, daggerGauge, SpinCover.pauli_one,
+      Fin.divNat, Fin.modNat, Fin.rev, ZMod.val, Fin.reduceEq]
+
+/-- The four Gram identities for the displayed factors in
+arXiv:2502.20257, lines 4559–4659, with unnormalized Hadamard weights. -/
+theorem displayed_grams :
+    displayedX₁ᴴ * displayedX₁ = (2 : ℂ) • 1 ∧
+    displayedX₂ᴴ * displayedX₂ = 1 ∧
+    displayedY₁ * displayedY₁ᴴ = 1 ∧
+    displayedY₂ * displayedY₂ᴴ = (2 : ℂ) • 1 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ext i j <;>
+    fin_cases i <;> fin_cases j <;>
+    norm_num +decide [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+      Fin.sum_univ_two, Fin.sum_univ_four, displayedX₁, displayedY₁,
+      displayedX₂, displayedY₂, daggerGauge, SpinCover.pauli_one,
+      Fin.divNat, Fin.modNat, Fin.rev, Matrix.one_apply, Fin.reduceEq]
+
+/-- Explicit right inverses of the displayed right factors, compatible with
+arXiv:1703.09188, `Z1Z2`, for arXiv:2502.20257, lines 4559–4659. -/
+def displayedZ₁ : Matrix (Fin 2 × Fin 4) (Fin 4) ℂ := displayedY₁ᴴ
+
+/-- The second right inverse has the factor one half because the Hadamard
+weights in arXiv:2502.20257, lines 4559–4659 are unnormalized. -/
+def displayedZ₂ : Matrix (Fin 4 × Fin 2) (Fin 4) ℂ := (1 / 2 : ℂ) • displayedY₂ᴴ
+
+/-- The inverse identities and the first weighted normalization for the
+explicit factors, arXiv:2502.20257, lines 4559–4659 (`eq:modif_XY`). -/
+theorem displayed_normalizations :
+    displayedY₁ * displayedZ₁ = 1 ∧
+    displayedY₂ * displayedZ₂ = 1 ∧
+    displayedX₁ᴴ * sourceWeight (d := 4) (D := 2) ((1 / 2 : ℂ) • 1) * displayedX₁ = 1 := by
+  refine ⟨displayed_grams.2.2.1, ?_, ?_⟩
+  · rw [displayedZ₂, Matrix.mul_smul, displayed_grams.2.2.2, smul_smul]
+    norm_num
+  · rw [sourceWeight, Matrix.kronecker_smul, Matrix.one_kronecker_one,
+      Matrix.mul_smul, Matrix.mul_one, Matrix.smul_mul, displayed_grams.1, smul_smul]
+    norm_num
+
+private theorem rank_factorization {m n : Type*} [Fintype m] [Fintype n]
+    (X : Matrix m (Fin 4) ℂ) (Y : Matrix (Fin 4) n ℂ)
+    (L : Matrix (Fin 4) m ℂ) (Z : Matrix n (Fin 4) ℂ)
+    (hL : L * X = 1) (hZ : Y * Z = 1) : (X * Y).rank = 4 := by
+  apply le_antisymm
+  · exact (Matrix.rank_mul_le_left X Y).trans (Matrix.rank_le_card_width X)
+  · have h : L * (X * Y) * Z = 1 := by
+      rw [← Matrix.mul_assoc L X Y, hL, Matrix.one_mul, hZ]
+    have hb := (Matrix.rank_mul_le_left (L * (X * Y)) Z).trans
+      (Matrix.rank_mul_le_right L (X * Y))
+    simpa only [h, Matrix.rank_one, Fintype.card_fin] using hb
+
+/-- Both source ranks of the exact CZX tensor are four. The proof uses the
+explicit inverses, not an SVD computation (arXiv:2502.20257, lines 4559–4659). -/
+theorem displayed_ranks : rightRank tensor = 4 ∧ leftRank tensor = 4 := by
+  constructor
+  · rw [rightRank, ← displayed_cuts.1]
+    apply rank_factorization displayedX₁ displayedY₁ ((1 / 2 : ℂ) • displayedX₁ᴴ)
+      displayedZ₁ _ displayed_normalizations.1
+    rw [Matrix.smul_mul, displayed_grams.1, smul_smul]
+    norm_num
+  · rw [leftRank, ← displayed_cuts.2]
+    exact rank_factorization displayedX₂ displayedY₂ displayedX₂ᴴ displayedZ₂
+      displayed_grams.2.1 displayed_normalizations.2.1
+
+/-- Identify the first displayed four-dimensional leg with the actual source
+rank, arXiv:2502.20257, lines 4559–4659. -/
+def displayedRightEquiv : Fin (rightRank tensor) ≃ Fin 4 := finCongr displayed_ranks.1
+
+/-- Identify the second displayed four-dimensional leg with the actual source
+rank, arXiv:2502.20257, lines 4559–4659. -/
+def displayedLeftEquiv : Fin (leftRank tensor) ≃ Fin 4 := finCongr displayed_ranks.2
+
+/-- The displayed CZX factors as an explicit witness of the existing source
+factorization predicate, with virtual density `ρ = I₂/2`.
+Source: arXiv:2502.20257, lines 4559–4659; arXiv:1703.09188, `eq:sf-svd`–`YZ=1`.
+No equality with choice-selected factors is asserted. -/
+def displayedSourceFactors : SourceFactors tensor ((1 / 2 : ℂ) • 1) := by
+  refine {
+    X₁ := displayedX₁.submatrix (Equiv.refl _) displayedRightEquiv
+    Y₁ := displayedY₁.submatrix displayedRightEquiv (Equiv.refl _)
+    Z₁ := displayedZ₁.submatrix (Equiv.refl _) displayedRightEquiv
+    X₂ := displayedX₂.submatrix (Equiv.refl _) displayedLeftEquiv
+    Y₂ := displayedY₂.submatrix displayedLeftEquiv (Equiv.refl _)
+    Z₂ := displayedZ₂.submatrix (Equiv.refl _) displayedLeftEquiv
+    sourceCutM₁_eq := ?_
+    sourceCutM₂_eq := ?_
+    X₁_weighted_isometry := ?_
+    X₂_isometry := ?_
+    Y₁_mul_Z₁ := ?_
+    Y₂_mul_Z₂ := ?_ }
+  case refine_3 =>
+    rw [Matrix.conjTranspose_submatrix]
+    change displayedX₁ᴴ.submatrix displayedRightEquiv (Equiv.refl _) *
+      (sourceWeight (d := 4) (D := 2) ((1 / 2 : ℂ) • 1)).submatrix
+        (Equiv.refl _) (Equiv.refl _) *
+      displayedX₁.submatrix (Equiv.refl _) displayedRightEquiv = 1
+    rw [Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv,
+      displayed_normalizations.2.2, Matrix.submatrix_one_equiv]
+  all_goals
+    simp only [Matrix.IsIsometry, Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv, displayed_cuts.1, displayed_cuts.2,
+      displayed_grams.2.1, displayed_normalizations.1, displayed_normalizations.2.1,
+      Matrix.submatrix_one_equiv] <;> rfl
+
+/-- All six coordinates of the explicit witness, with the factor leg pulled
+back to the displayed four-dimensional space. Source: arXiv:2502.20257,
+lines 4559–4659, and arXiv:1703.09188, `Z1Z2`. -/
+theorem displayedSourceFactors_coordinates (k : Fin 4) (i : Fin 4) (α : Fin 2) :
+    displayedSourceFactors.X₁ (i, α) (displayedRightEquiv.symm k) =
+      displayedX₁ (i, α) k ∧
+    displayedSourceFactors.Y₁ (displayedRightEquiv.symm k) (α, i) =
+      displayedY₁ k (α, i) ∧
+    displayedSourceFactors.Z₁ (α, i) (displayedRightEquiv.symm k) =
+      displayedZ₁ (α, i) k ∧
+    displayedSourceFactors.X₂ (α, i) (displayedLeftEquiv.symm k) =
+      displayedX₂ (α, i) k ∧
+    displayedSourceFactors.Y₂ (displayedLeftEquiv.symm k) (i, α) =
+      displayedY₂ k (i, α) ∧
+    displayedSourceFactors.Z₂ (i, α) (displayedLeftEquiv.symm k) =
+      displayedZ₂ (i, α) k := by
+  simp [displayedSourceFactors, Matrix.submatrix_apply]
+
+/-- The empty/filled gauge identities and right-inverse coordinates survive
+transport to the actual source ranks. In particular the first gauge entry
+is `Y β t`, not its transpose. Source: arXiv:2502.20257, lines 4611–4659,
+and arXiv:1703.09188, `Z1Z2`. -/
+theorem displayedSourceFactors_inverse_coordinates (k : Fin 4) (i : Fin 4) (β : Fin 2) :
+    displayedSourceFactors.X₁ (i, β) (displayedRightEquiv.symm k) =
+      ∑ t : Fin 2, daggerGauge β t *
+        star (displayedSourceFactors.Y₂ (displayedLeftEquiv.symm k) (i, t)) ∧
+    displayedSourceFactors.Y₁ (displayedRightEquiv.symm k) (β, i) =
+      ∑ t : Fin 2, star (displayedSourceFactors.X₂ (t, i) (displayedLeftEquiv.symm k)) *
+        daggerGauge t β ∧
+    displayedSourceFactors.Z₁ (β, i) (displayedRightEquiv.symm k) =
+      star (displayedSourceFactors.Y₁ (displayedRightEquiv.symm k) (β, i)) ∧
+    displayedSourceFactors.Z₂ (i, β) (displayedLeftEquiv.symm k) =
+      (1 / 2 : ℂ) * star (displayedSourceFactors.Y₂ (displayedLeftEquiv.symm k) (i, β)) := by
+  simp [displayedSourceFactors, Matrix.submatrix_apply, displayedX₁, displayedY₁,
+    displayedZ₁, displayedZ₂, Matrix.conjTranspose_apply]
+
+end MPOTensor.CZX

--- a/TNLean/MPS/MPDO/CZXSourceFactors.lean
+++ b/TNLean/MPS/MPDO/CZXSourceFactors.lean
@@ -17,7 +17,7 @@ These are explicit witnesses, not identifications with choice-selected SVD facto
 
 noncomputable section
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Kronecker
 
 namespace MPOTensor.CZX
 
@@ -62,18 +62,54 @@ theorem displayed_cuts :
       Fin.divNat, Fin.modNat, Fin.rev, ZMod.val, Fin.reduceEq]
 
 /-- The four Gram identities for the displayed factors in
-arXiv:2502.20257, lines 4559–4659, with unnormalized Hadamard weights. -/
+arXiv:2502.20257, lines 4559–4659, with unnormalized Hadamard weights.
+The Pauli-gauge identities `displayedX₁ = (1 ⊗ₖ daggerGauge) * displayedY₂ᴴ` and
+`displayedY₁ = displayedX₂ᴴ * (daggerGauge ⊗ₖ 1)` reduce the first and third
+conjuncts to the second and fourth via unitarity of the dagger gauge. -/
 theorem displayed_grams :
     displayedX₁ᴴ * displayedX₁ = (2 : ℂ) • 1 ∧
     displayedX₂ᴴ * displayedX₂ = 1 ∧
     displayedY₁ * displayedY₁ᴴ = 1 ∧
     displayedY₂ * displayedY₂ᴴ = (2 : ℂ) • 1 := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> ext i j <;>
+  have hX₂ : displayedX₂ᴴ * displayedX₂ = (1 : Matrix (Fin 4) (Fin 4) ℂ) := by
+    ext i j
     fin_cases i <;> fin_cases j <;>
-    norm_num +decide [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
-      Fin.sum_univ_two, Fin.sum_univ_four, displayedX₁, displayedY₁,
-      displayedX₂, displayedY₂, daggerGauge, SpinCover.pauli_one,
-      Fin.divNat, Fin.modNat, Fin.rev, Matrix.one_apply, Fin.reduceEq]
+      norm_num +decide [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+        Fin.sum_univ_two, Fin.sum_univ_four, displayedX₂, Fin.divNat, Fin.modNat,
+        Matrix.one_apply, Fin.reduceEq]
+  have hY₂ : displayedY₂ * displayedY₂ᴴ = (2 : ℂ) • (1 : Matrix (Fin 4) (Fin 4) ℂ) := by
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      norm_num +decide [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type,
+        Fin.sum_univ_two, Fin.sum_univ_four, displayedY₂, Fin.divNat, Fin.modNat, Fin.rev,
+        Matrix.one_apply, Fin.reduceEq]
+  have hK1 : ((1 : Matrix (Fin 4) (Fin 4) ℂ) ⊗ₖ daggerGauge)ᴴ *
+      ((1 : Matrix (Fin 4) (Fin 4) ℂ) ⊗ₖ daggerGauge) = 1 := by
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one, daggerGauge_conjTranspose,
+      ← Matrix.mul_kronecker_mul, one_mul, daggerGauge_mul_self, Matrix.one_kronecker_one]
+  have hK2 : (daggerGauge ⊗ₖ (1 : Matrix (Fin 4) (Fin 4) ℂ)) *
+      (daggerGauge ⊗ₖ (1 : Matrix (Fin 4) (Fin 4) ℂ))ᴴ = 1 := by
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one, daggerGauge_conjTranspose,
+      ← Matrix.mul_kronecker_mul, daggerGauge_mul_self, one_mul, Matrix.one_kronecker_one]
+  have hX₁ : displayedX₁ = ((1 : Matrix (Fin 4) (Fin 4) ℂ) ⊗ₖ daggerGauge) * displayedY₂ᴴ := by
+    ext ⟨i, β⟩ k
+    simp [displayedX₁, Matrix.mul_apply, Fintype.sum_prod_type, Matrix.kroneckerMap_apply,
+      Matrix.conjTranspose_apply, Matrix.one_apply]
+  have hY₁ : displayedY₁ = displayedX₂ᴴ * (daggerGauge ⊗ₖ (1 : Matrix (Fin 4) (Fin 4) ℂ)) := by
+    ext k ⟨α, j⟩
+    simp [displayedY₁, Matrix.mul_apply, Fintype.sum_prod_type, Matrix.kroneckerMap_apply,
+      Matrix.conjTranspose_apply, Matrix.one_apply]
+  refine ⟨?_, hX₂, ?_, hY₂⟩
+  · rw [hX₁, Matrix.conjTranspose_mul, Matrix.mul_assoc,
+      ← Matrix.mul_assoc ((1 : Matrix (Fin 4) (Fin 4) ℂ) ⊗ₖ daggerGauge)ᴴ
+        ((1 : Matrix (Fin 4) (Fin 4) ℂ) ⊗ₖ daggerGauge) displayedY₂ᴴ,
+      hK1, Matrix.one_mul, Matrix.conjTranspose_conjTranspose]
+    exact hY₂
+  · rw [hY₁, Matrix.conjTranspose_mul, Matrix.mul_assoc,
+      ← Matrix.mul_assoc (daggerGauge ⊗ₖ (1 : Matrix (Fin 4) (Fin 4) ℂ))
+        (daggerGauge ⊗ₖ (1 : Matrix (Fin 4) (Fin 4) ℂ))ᴴ (displayedX₂ᴴ)ᴴ,
+      hK2, Matrix.one_mul, Matrix.conjTranspose_conjTranspose]
+    exact hX₂
 
 /-- Explicit right inverses of the displayed right factors, compatible with
 arXiv:1703.09188, `Z1Z2`, for arXiv:2502.20257, lines 4559–4659. -/

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -36,6 +36,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SimpleTensorEquivalence
 import TNLean.MPS.MPU.SourceCuts
+import TNLean.MPS.MPU.SourceDecompositionUniqueness
 import TNLean.MPS.MPU.SourceFactorContraction
 import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceFactorsTensorProduct

--- a/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
+++ b/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceCuts
+import TNLean.Algebra.UnitaryKroneckerComparison
+import TNLean.Algebra.FinSumPermutation
+import QICLean.Algebra.MatrixUnitaryBetween
+
+/-!
+# Uniqueness of the raw source decompositions
+
+FBC25, arXiv:2502.20257, Lemma `lem:deco` (main.tex lines 1052--1066).
+The factors are raw matrices on the actual source cuts, not normalized
+`SourceFactors` records. Only the unitarity of the two literal $u$ contractions
+from clause (b) is used; the unitarity of $v$ is unused. Thus the result has
+weaker premises, and applies in particular to the decompositions in the source.
+No clause (c), canonical-form, or weighted normalization hypothesis is needed.
+-/
+
+open scoped Matrix Kronecker BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- Transport of the raw source $u$ contraction under left multiplication of
+its two factors (FBC25, `lem:deco`, lines 1052--1066). The row order is
+$\ell\times r$, so the comparison operator is $K_2\otimes K_1$. -/
+theorem sourceU_contraction_transport
+    {Y₁ Yt₁ : Matrix (Fin r[U]) (Fin D × Fin d) ℂ}
+    {Y₂ Yt₂ : Matrix (Fin ℓ[U]) (Fin d × Fin D) ℂ}
+    {K₁ : Matrix (Fin r[U]) (Fin r[U]) ℂ}
+    {K₂ : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ}
+    (hY₁ : Yt₁ = K₁ * Y₁) (hY₂ : Yt₂ = K₂ * Y₂) :
+    (fun ((l, r) : Fin ℓ[U] × Fin r[U]) ((p, q) : Fin d × Fin d) ↦
+        ∑ β : Fin D, Yt₂ l (p, β) * Yt₁ r (β, q)) =
+      ((K₂ ⊗ₖ K₁) * Matrix.of
+        (fun (l, r) (p, q) ↦ ∑ β : Fin D, Y₂ l (p, β) * Y₁ r (β, q)) :
+          Matrix (Fin ℓ[U] × Fin r[U]) (Fin d × Fin d) ℂ) := by
+  classical
+  subst Yt₁ Yt₂
+  ext ⟨l, r⟩ ⟨p, q⟩
+  simp only [Matrix.mul_apply, Fintype.sum_prod_type, Matrix.kronecker_apply,
+    Matrix.of_apply, Finset.sum_mul, Finset.mul_sum]
+  rw [Fintype.sum_reverse_three]
+  refine Finset.sum_congr₂ fun l' _ r' _ ↦ ?_
+  apply Finset.sum_congr rfl
+  intro β _
+  ring
+
+/-- Reciprocal unitary gauges for two raw factorizations of the source cuts.
+
+FBC25, arXiv:2502.20257, Lemma `lem:deco` (lines 1052--1066). Only the
+$u$ part of clause (b) is required: $v$ unitarity is unused, so these weaker
+premises give a stronger result applying to the source. Chosen left inverses
+of the tilde $X$ factors and right inverses of the original $Y$ factors suffice.
+Positive physical dimension forces both ranks to be nonempty internally.
+
+The source scalars are $\delta_1=\delta^{-1}$ and $\delta_2=\delta$;
+the final equality is exactly $\delta_1\delta_2=1$. The gauges have the
+source orientation, with their adjoints acting on the $Y$ factors. -/
+theorem exists_reciprocal_unitary_source_gauges [NeZero d]
+    {X₁ Xt₁ : Matrix (Fin d × Fin D) (Fin r[U]) ℂ}
+    {Y₁ Yt₁ : Matrix (Fin r[U]) (Fin D × Fin d) ℂ}
+    {X₂ Xt₂ : Matrix (Fin D × Fin d) (Fin ℓ[U]) ℂ}
+    {Y₂ Yt₂ : Matrix (Fin ℓ[U]) (Fin d × Fin D) ℂ}
+    {Lt₁ : Matrix (Fin r[U]) (Fin d × Fin D) ℂ}
+    {R₁ : Matrix (Fin D × Fin d) (Fin r[U]) ℂ}
+    {Lt₂ : Matrix (Fin ℓ[U]) (Fin D × Fin d) ℂ}
+    {R₂ : Matrix (Fin d × Fin D) (Fin ℓ[U]) ℂ}
+    (hfac₁ : X₁ * Y₁ = sourceCutM₁ U)
+    (hfact₁ : Xt₁ * Yt₁ = sourceCutM₁ U)
+    (hfac₂ : X₂ * Y₂ = sourceCutM₂ U)
+    (hfact₂ : Xt₂ * Yt₂ = sourceCutM₂ U)
+    (hleft₁ : Lt₁ * Xt₁ = 1) (hright₁ : Y₁ * R₁ = 1)
+    (hleft₂ : Lt₂ * Xt₂ = 1) (hright₂ : Y₂ * R₂ = 1)
+    (hu : Matrix.IsUnitaryBetween
+      (fun ((l, r) : Fin ℓ[U] × Fin r[U]) ((p, q) : Fin d × Fin d) ↦
+        ∑ β : Fin D, Y₂ l (p, β) * Y₁ r (β, q)))
+    (hut : Matrix.IsUnitaryBetween
+      (fun ((l, r) : Fin ℓ[U] × Fin r[U]) ((p, q) : Fin d × Fin d) ↦
+        ∑ β : Fin D, Yt₂ l (p, β) * Yt₁ r (β, q))) :
+    ∃ (δ : ℝ) (_ : 0 < δ) (W₁ : Matrix.unitaryGroup (Fin r[U]) ℂ)
+      (W₂ : Matrix.unitaryGroup (Fin ℓ[U]) ℂ),
+      Xt₁ = (δ : ℂ)⁻¹ • (X₁ * (W₁ : Matrix (Fin r[U]) (Fin r[U]) ℂ)) ∧
+      Yt₁ = (δ : ℂ) • (star (W₁ : Matrix (Fin r[U]) (Fin r[U]) ℂ) * Y₁) ∧
+      Xt₂ = (δ : ℂ) • (X₂ * (W₂ : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ)) ∧
+      Yt₂ = (δ : ℂ)⁻¹ • (star (W₂ : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * Y₂) ∧
+      (δ : ℂ)⁻¹ * (δ : ℂ) = 1 := by
+  classical
+  have hcard := hu.1.card_le _
+  have hpos : 0 < Fintype.card (Fin ℓ[U] × Fin r[U]) :=
+    lt_of_lt_of_le Fintype.card_pos hcard
+  obtain ⟨l, r⟩ := Fintype.card_pos_iff.mp hpos
+  have : Nonempty (Fin r[U]) := ⟨r⟩
+  have : Nonempty (Fin ℓ[U]) := ⟨l⟩
+  obtain ⟨_, hX₁, hY₁⟩ := Matrix.factorization_comparison_of_one_sided_inverses
+    (hfac₁.trans hfact₁.symm) hleft₁ hright₁
+  obtain ⟨_, hX₂, hY₂⟩ := Matrix.factorization_comparison_of_one_sided_inverses
+    (hfac₂.trans hfact₂.symm) hleft₂ hright₂
+  rw [sourceU_contraction_transport hY₁ hY₂] at hut
+  have hK := Matrix.IsUnitaryBetween.of_mul_right _ _ hu hut
+  have hswap := hK.reindex _ (Equiv.prodComm _ _) (Equiv.prodComm _ _)
+  have hK' : ((Lt₁ * X₁) ⊗ₖ (Lt₂ * X₂)).IsUnitaryBetween := by
+    convert hswap using 1
+    ext ⟨r, l⟩ ⟨r', l'⟩
+    simp [Matrix.reindex_apply, mul_comm]
+  exact Matrix.exists_reciprocal_unitary_gauges_of_comparison
+    ((Matrix.isUnitaryBetween_iff_mem_unitaryGroup _).mp hK') hX₁ hY₁ hX₂ hY₂
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
+++ b/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
@@ -3,10 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.SourceCuts
-import TNLean.Algebra.UnitaryKroneckerComparison
-import TNLean.Algebra.FinSumPermutation
 import QICLean.Algebra.MatrixUnitaryBetween
+import TNLean.Algebra.FinSumPermutation
+import TNLean.Algebra.UnitaryKroneckerComparison
+import TNLean.MPS.MPU.SourceCuts
 
 /-!
 # Uniqueness of the raw source decompositions

--- a/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
+++ b/TNLean/MPS/MPU/SourceDecompositionUniqueness.lean
@@ -16,7 +16,9 @@ The factors are raw matrices on the actual source cuts, not normalized
 `SourceFactors` records. Only the unitarity of the two literal $u$ contractions
 from clause (b) is used; the unitarity of $v$ is unused. Thus the result has
 weaker premises, and applies in particular to the decompositions in the source.
-No clause (c), canonical-form, or weighted normalization hypothesis is needed.
+No positive-physical-dimension, clause (c), canonical-form, or weighted
+normalization hypothesis is needed; when `d = 0`, the source-cut ranks are zero
+and the raw physical matrix equalities are vacuous.
 -/
 
 open scoped Matrix Kronecker BigOperators
@@ -57,12 +59,14 @@ FBC25, arXiv:2502.20257, Lemma `lem:deco` (lines 1052--1066). Only the
 $u$ part of clause (b) is required: $v$ unitarity is unused, so these weaker
 premises give a stronger result applying to the source. Chosen left inverses
 of the tilde $X$ factors and right inverses of the original $Y$ factors suffice.
-Positive physical dimension forces both ranks to be nonempty internally.
+In positive physical dimension the two unitary contractions force both ranks to
+be nonempty internally. In dimension zero, the source cuts have rank zero and
+identity gauges with scalar one satisfy the vacuous raw matrix equalities.
 
 The source scalars are $\delta_1=\delta^{-1}$ and $\delta_2=\delta$;
 the final equality is exactly $\delta_1\delta_2=1$. The gauges have the
 source orientation, with their adjoints acting on the $Y$ factors. -/
-theorem exists_reciprocal_unitary_source_gauges [NeZero d]
+theorem exists_reciprocal_unitary_source_gauges
     {X₁ Xt₁ : Matrix (Fin d × Fin D) (Fin r[U]) ℂ}
     {Y₁ Yt₁ : Matrix (Fin r[U]) (Fin D × Fin d) ℂ}
     {X₂ Xt₂ : Matrix (Fin D × Fin d) (Fin ℓ[U]) ℂ}
@@ -91,9 +95,24 @@ theorem exists_reciprocal_unitary_source_gauges [NeZero d]
       Yt₂ = (δ : ℂ)⁻¹ • (star (W₂ : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * Y₂) ∧
       (δ : ℂ)⁻¹ * (δ : ℂ) = 1 := by
   classical
+  by_cases hd : d = 0
+  · subst d
+    refine ⟨1, by norm_num, 1, 1, ?_, ?_, ?_, ?_, ?_⟩
+    · ext ⟨i, _⟩ _
+      exact Fin.elim0 i
+    · ext _ ⟨_, i⟩
+      exact Fin.elim0 i
+    · ext ⟨_, i⟩ _
+      exact Fin.elim0 i
+    · ext _ ⟨i, _⟩
+      exact Fin.elim0 i
+    · norm_num
   have hcard := hu.1.card_le _
+  have hdpos : 0 < Fintype.card (Fin d × Fin d) := by
+    rw [Fintype.card_pos_iff]
+    exact ⟨⟨⟨0, Nat.pos_of_ne_zero hd⟩, ⟨0, Nat.pos_of_ne_zero hd⟩⟩⟩
   have hpos : 0 < Fintype.card (Fin ℓ[U] × Fin r[U]) :=
-    lt_of_lt_of_le Fintype.card_pos hcard
+    lt_of_lt_of_le hdpos hcard
   obtain ⟨l, r⟩ := Fintype.card_pos_iff.mp hpos
   have : Nonempty (Fin r[U]) := ⟨r⟩
   have : Nonempty (Fin ℓ[U]) := ⟨l⟩

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2184,7 +2184,7 @@ $\mathcal U^\dagger$; no additional boundary or Gram identities are assumed.
     \leanok
     \discussion{7315}
     \uses{def:mpu_source_matrix_one, def:mpu_source_matrix_two}
-    Let $U$ have positive physical dimension $d$ and bond dimension $D$.
+    Let $U$ have physical dimension $d$ and bond dimension $D$.
     Put $r=\operatorname{rank}M_1(U)$ and $\ell=\operatorname{rank}M_2(U)$.
     Suppose that
     \begin{align}
@@ -2228,7 +2228,11 @@ $\mathcal U^\dagger$; no additional boundary or Gram identities are assumed.
 \begin{proof}\leanok
     \uses{thm:mpug_factorization_comparison,
         thm:mpug_source_contraction_transport, thm:mpug_reciprocal_unitary_gauges}
-    Since $d>0$ and $u$ is an isometry, $\ell r\geq d^2>0$; hence both
+    If $d=0$, every factor equality has an empty physical row or column
+    index. Thus $\delta=1$ and identity gauges satisfy all four
+    equalities, and $\delta^{-1}\delta=1$.
+    Suppose now that $d>0$. Since $u$ is an isometry,
+    $\ell r\geq d^2>0$; hence both
     source ranks are positive. Theorem~\ref{thm:mpug_factorization_comparison}
     gives $K_i=L_iX_i=\widetilde Y_iR_i$ with
     $X_i=\widetilde X_iK_i$ and $\widetilde Y_i=K_iY_i$.
@@ -6057,7 +6061,8 @@ by the displayed matrices.
     \label{thm:mpug_czx_displayed_source_coordinates}
     \lean{MPOTensor.CZX.displayedSourceFactors_coordinates}
     \leanok
-    \uses{def:mpug_czx_displayed_source_factors}
+    \uses{def:mpug_czx_displayed_source_factors,
+        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
     For $0\leq k,i<4$ and $\alpha\in\{0,1\}$, the transported factors
     of Definition~\ref{def:mpug_czx_displayed_source_factors} satisfy
     \begin{align}
@@ -6071,7 +6076,8 @@ by the displayed matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_displayed_source_factors}
+    \uses{def:mpug_czx_displayed_source_factors,
+        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
     Evaluate the pullbacks and use $e_r(e_r^{-1}(k))=k$ and
     $e_l(e_l^{-1}(k))=k$.
 \end{proof}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -2143,13 +2143,104 @@ $\mathcal U^\dagger$; no additional boundary or Gram identities are assumed.
     $\delta^{-1}\delta=1$.
 \end{proof}
 
-The full decomposition theorem also requires the comparison matrices obtained
-from the MPU source-gate identities to have unitary Kronecker product. Once
-this tensor-specific statement is established,
-Theorems~\ref{thm:mpug_factorization_comparison} and
-\ref{thm:mpug_reciprocal_unitary_gauges} yield the claimed gauges.
-% Formalization boundary: the MPU-specific source-gate transport and the final
-% lem:deco wrapper remain outside this slice and depend on issue #7313.
+\subsection{Uniqueness of the source decompositions}
+
+\begin{theorem}[Transport of the source contraction]
+    \label{thm:mpug_source_contraction_transport}
+    \lean{MPOTensor.sourceU_contraction_transport}
+    \leanok
+    \discussion{7315}
+    \uses{def:mpu_source_matrix_one, def:mpu_source_matrix_two}
+    Let $U$ have physical dimension $d$ and bond dimension $D$, and write
+    $r=\operatorname{rank}M_1(U)$ and $\ell=\operatorname{rank}M_2(U)$.
+    Let $Y_1,\widetilde Y_1\in\operatorname{Mat}_{r\times(D\times d)}(\C)$
+    and $Y_2,\widetilde Y_2\in\operatorname{Mat}_{\ell\times(d\times D)}(\C)$.
+    For square matrices $K_1\in\operatorname{Mat}_r(\C)$ and
+    $K_2\in\operatorname{Mat}_\ell(\C)$, suppose that
+    $\widetilde Y_i=K_iY_i$ for $i=1,2$. Define
+    $u,\widetilde u\colon\C^d\otimes\C^d\to\C^\ell\otimes\C^r$ by
+    \begin{align}
+        u_{(l,r'),(p,q)}
+         & =\sum_{\beta=0}^{D-1}(Y_2)_{l,(p,\beta)}(Y_1)_{r',(\beta,q)}, \\
+        \widetilde u_{(l,r'),(p,q)}
+         & =\sum_{\beta=0}^{D-1}(\widetilde Y_2)_{l,(p,\beta)}
+        (\widetilde Y_1)_{r',(\beta,q)}.
+        \label{eq:mpug_raw_source_contractions}
+    \end{align}
+    Here $0\leq l<\ell$, $0\leq r'<r$, and $0\leq p,q<d$.
+    Then $\widetilde u=(K_2\otimes K_1)u$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitute $\widetilde Y_i=K_iY_i$ into
+    (\ref{eq:mpug_raw_source_contractions}) and interchange the three finite
+    sums. The coefficient of $u_{(l',r''),(p,q)}$ is
+    $(K_2)_{l,l'}(K_1)_{r',r''}$, the corresponding entry of $K_2\otimes K_1$.
+\end{proof}
+
+\begin{theorem}[Reciprocal unitary gauges for the source decompositions]
+    \label{thm:mpug_source_decomposition_gauges}
+    \lean{MPOTensor.exists_reciprocal_unitary_source_gauges}
+    \leanok
+    \discussion{7315}
+    \uses{def:mpu_source_matrix_one, def:mpu_source_matrix_two}
+    Let $U$ have positive physical dimension $d$ and bond dimension $D$.
+    Put $r=\operatorname{rank}M_1(U)$ and $\ell=\operatorname{rank}M_2(U)$.
+    Suppose that
+    \begin{align}
+        X_1,\widetilde X_1 & \in\operatorname{Mat}_{(d\times D)\times r}(\C),   &
+        Y_1,\widetilde Y_1 & \in\operatorname{Mat}_{r\times(D\times d)}(\C),      \\
+        X_2,\widetilde X_2 & \in\operatorname{Mat}_{(D\times d)\times\ell}(\C), &
+        Y_2,\widetilde Y_2 & \in\operatorname{Mat}_{\ell\times(d\times D)}(\C)
+    \end{align}
+    satisfy $X_iY_i=\widetilde X_i\widetilde Y_i=M_i(U)$ for $i=1,2$.
+    Suppose there are matrices $L_i,R_i$ with
+    $L_i\widetilde X_i=I$ and $Y_iR_i=I$.
+    Assume that the maps $u,\widetilde u\colon\C^d\otimes\C^d\to
+        \C^\ell\otimes\C^r$ with coordinates
+    \begin{align}
+        u_{(l,r'),(p,q)}
+         & =\sum_{\beta=0}^{D-1}(Y_2)_{l,(p,\beta)}(Y_1)_{r',(\beta,q)}, \\
+        \widetilde u_{(l,r'),(p,q)}
+         & =\sum_{\beta=0}^{D-1}(\widetilde Y_2)_{l,(p,\beta)}
+        (\widetilde Y_1)_{r',(\beta,q)}
+    \end{align}
+    are unitary. The indices range over $0\leq l<\ell$, $0\leq r'<r$,
+    and $0\leq p,q<d$. Then there exist $\delta>0$ and unitaries
+    $W_1\in\operatorname{Mat}_r(\C)$, $W_2\in\operatorname{Mat}_\ell(\C)$ such that
+    \begin{align}
+        \widetilde X_1 & =\delta^{-1}X_1W_1,          &
+        \widetilde Y_1 & =\delta W_1^\dagger Y_1,       \\
+        \widetilde X_2 & =\delta X_2W_2,              &
+        \widetilde Y_2 & =\delta^{-1}W_2^\dagger Y_2.
+        \label{eq:mpug_source_decomposition_gauges}
+    \end{align}
+    Thus $\delta_1=\delta^{-1}$ and $\delta_2=\delta$ satisfy
+    $\delta_1\delta_2=1$. This proves the decomposition lemma of
+    \cite[lines~1052--1066]{FrancoRubio2025MPUGauging}: its cut factorizations,
+    one-sided inverses, and unitarity of $u,\widetilde u$ suffice.
+    Unitarity of the second contraction $v$ is not needed.
+    % Source lem:deco, issue #7315. No clause (c), weighted normalization,
+    % canonical-form-II, density, or physical-adjoint hypothesis is used.
+    % This result does not assert completion of the separate #7313 assembly.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_factorization_comparison,
+        thm:mpug_source_contraction_transport, thm:mpug_reciprocal_unitary_gauges}
+    Since $d>0$ and $u$ is an isometry, $\ell r\geq d^2>0$; hence both
+    source ranks are positive. Theorem~\ref{thm:mpug_factorization_comparison}
+    gives $K_i=L_iX_i=\widetilde Y_iR_i$ with
+    $X_i=\widetilde X_iK_i$ and $\widetilde Y_i=K_iY_i$.
+    Theorem~\ref{thm:mpug_source_contraction_transport} yields
+    $\widetilde u=(K_2\otimes K_1)u$. Therefore
+    $K_2\otimes K_1=\widetilde u u^\dagger$ is unitary.
+    Interchanging the two tensor factors makes $K_1\otimes K_2$ unitary.
+    Apply Theorem~\ref{thm:mpug_reciprocal_unitary_gauges} to obtain
+    (\ref{eq:mpug_source_decomposition_gauges}). In particular, if
+    $K_1=\delta V_1$ and $K_2=\delta^{-1}V_2$ with $V_i$ unitary,
+    the required orientation is $W_i=V_i^\dagger$.
+\end{proof}
 
 \begin{definition}[Unitary factorization comparison]
     \label{def:mpug_unitary_factorization_comparison}
@@ -5771,6 +5862,249 @@ by the displayed matrices.
     Conjugating each entry of the displayed Pauli matrix gives
     $\overline{Y}=-Y$. Then $Y\overline{Y}=-Y^2=-I_2$ by
     Lemma~\ref{lem:mpug_czx_dagger_gauge_laws}.
+\end{proof}
+
+\subsection{The displayed CZX source factors}
+
+\begin{definition}[Four explicit CZX source factors]
+    \label{def:mpug_czx_displayed_factors}
+    \lean{MPOTensor.CZX.displayedX₂, MPOTensor.CZX.displayedY₂,
+        MPOTensor.CZX.displayedX₁, MPOTensor.CZX.displayedY₁}
+    \leanok
+    \discussion{7354}
+    \uses{def:mpug_czx_dagger_gauge}
+    For $0\leq i<4$, write $i=2a(i)+b(i)$ with $a(i),b(i)\in\{0,1\}$,
+    and put $\overline i=3-i$. Let $Y$ be the Pauli matrix of
+    Definition~\ref{def:mpug_czx_dagger_gauge}. Define matrices
+    $X_2\in\operatorname{Mat}_{(2\times4)\times4}(\C)$ and
+    $Y_2\in\operatorname{Mat}_{4\times(4\times2)}(\C)$ by
+    \begin{align}
+        (X_2)_{(\alpha,i),k}
+         & =\delta_{i,k}\delta_{\alpha,a(i)}(-1)^{a(i)+b(i)}, \\
+        (Y_2)_{k,(j,\beta)}
+         & =\delta_{k,\overline j}(-1)^{a(k)b(k)+b(k)\beta},
+    \end{align}
+    where $0\leq i,j,k<4$ and $\alpha,\beta\in\{0,1\}$. Define
+    $X_1\in\operatorname{Mat}_{(4\times2)\times4}(\C)$ and
+    $Y_1\in\operatorname{Mat}_{4\times(2\times4)}(\C)$ by
+    \begin{align}
+        (X_1)_{(i,\beta),k}
+         & =\sum_{t=0}^1Y_{\beta t}\overline{(Y_2)_{k,(i,t)}}, \\
+        (Y_1)_{k,(\alpha,j)}
+         & =\sum_{t=0}^1\overline{(X_2)_{(t,j),k}}Y_{t\alpha}.
+    \end{align}
+    Product indices in these matrix spaces retain their displayed order.
+    These are the filled and empty factors in
+    \cite[lines~4559--4659]{FrancoRubio2025MPUGauging}. The weights
+    $(-1)^{ab}$ are unnormalized Hadamard weights, and $(-1)^{a(i)+b(i)}$
+    includes both output $Z$ gates. In the formula for $X_1$, the Pauli
+    entry is $Y_{\beta t}$, not $Y_{t\beta}$.
+\end{definition}
+
+\begin{theorem}[The displayed factors recover both CZX cuts]
+    \label{thm:mpug_czx_displayed_cuts}
+    \lean{MPOTensor.CZX.displayed_cuts}
+    \leanok
+    \uses{def:mpug_czx_displayed_factors, def:mpug_czx_exact_tensor,
+        def:mpu_source_matrix_one, def:mpu_source_matrix_two}
+    For the exact once-blocked CZX tensor $B$, the factors of
+    Definition~\ref{def:mpug_czx_displayed_factors} satisfy
+    \begin{align}
+        X_1Y_1 & =M_1(B), \\
+        X_2Y_2 & =M_2(B).
+    \end{align}
+    Here $(M_1(B))_{(i,\beta),(\alpha,j)}=B^{i,j}_{\alpha\beta}$ and
+    $(M_2(B))_{(\alpha,i),(j,\beta)}=B^{i,j}_{\alpha\beta}$. These are
+    the two decompositions in
+    \cite[lines~4559--4659]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_factors, def:mpug_czx_dagger_gauge,
+        thm:mpug_czx_exact_tensor_unitary,
+        def:mpu_source_matrix_one, def:mpu_source_matrix_two}
+    Expand each matrix product over its four-dimensional factor index.
+    Substitute the displayed formulas and the coordinate formula from
+    Theorem~\ref{thm:mpug_czx_exact_tensor_unitary}. Evaluating the binary
+    bond indices and the four physical values proves both entry identities.
+\end{proof}
+
+\begin{theorem}[Four Gram matrices of the displayed CZX factors]
+    \label{thm:mpug_czx_displayed_grams}
+    \lean{MPOTensor.CZX.displayed_grams}
+    \leanok
+    \uses{def:mpug_czx_displayed_factors}
+    The four explicit factors of
+    Definition~\ref{def:mpug_czx_displayed_factors} satisfy
+    \begin{align}
+        X_1^\dagger X_1 & =2I_4, \\
+        X_2^\dagger X_2 & =I_4,  \\
+        Y_1Y_1^\dagger  & =I_4,  \\
+        Y_2Y_2^\dagger  & =2I_4.
+    \end{align}
+    The factors of two retain the unnormalized Hadamard weights of
+    \cite[lines~4559--4659]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_factors, def:mpug_czx_dagger_gauge}
+    Expand the four Gram matrices over their product-index spaces and
+    substitute the factor coordinates and the Pauli matrix. Evaluation
+    at each pair of factor indices gives the displayed scalar identities.
+\end{proof}
+
+\begin{definition}[Right inverses of the displayed CZX factors]
+    \label{def:mpug_czx_displayed_right_inverses}
+    \lean{MPOTensor.CZX.displayedZ₁, MPOTensor.CZX.displayedZ₂}
+    \leanok
+    \uses{def:mpug_czx_displayed_factors}
+    For the factors of Definition~\ref{def:mpug_czx_displayed_factors}, set
+    \begin{align}
+        Z_1 & =Y_1^\dagger,         \\
+        Z_2 & =\tfrac12Y_2^\dagger.
+    \end{align}
+    These are the right inverses associated with the explicit
+    decompositions in \cite[lines~4559--4659]{FrancoRubio2025MPUGauging}.
+\end{definition}
+
+\begin{theorem}[Right inverses and weighted normalization]
+    \label{thm:mpug_czx_displayed_normalizations}
+    \lean{MPOTensor.CZX.displayed_normalizations}
+    \leanok
+    \uses{def:mpug_czx_displayed_factors,
+        def:mpug_czx_displayed_right_inverses, def:mpu_source_weight}
+    Set $\rho=I_2/2$. The displayed factors and right inverses satisfy
+    \begin{align}
+        Y_1Z_1                         & =I_4, \\
+        Y_2Z_2                         & =I_4, \\
+        X_1^\dagger(I_4\otimes\rho)X_1 & =I_4.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_displayed_grams,
+        def:mpug_czx_displayed_right_inverses, def:mpu_source_weight}
+    The two inverse identities follow directly from
+    Theorem~\ref{thm:mpug_czx_displayed_grams}. Since
+    $I_4\otimes\rho=I_8/2$, the weighted identity is
+    $\tfrac12X_1^\dagger X_1=I_4$.
+\end{proof}
+
+\begin{theorem}[Both CZX source-cut ranks are four]
+    \label{thm:mpug_czx_displayed_ranks}
+    \lean{MPOTensor.CZX.displayed_ranks}
+    \leanok
+    \uses{def:mpug_czx_exact_tensor, def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two}
+    For the exact once-blocked CZX tensor $B$,
+    \begin{align}
+        d_r=\operatorname{rank}M_1(B) & =4, \\
+        d_l=\operatorname{rank}M_2(B) & =4.
+    \end{align}
+    Thus the four-dimensional legs in
+    \cite[lines~4559--4659]{FrancoRubio2025MPUGauging} have the actual
+    source-cut dimensions.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_displayed_cuts, thm:mpug_czx_displayed_grams,
+        thm:mpug_czx_displayed_normalizations}
+    Each cut factors through a four-dimensional space, so its rank is at
+    most four. For the first cut take $L_1=X_1^\dagger/2$, and for the
+    second take $L_2=X_2^\dagger$. The preceding identities give
+    $L_iX_i=I_4$ and $Y_iZ_i=I_4$, hence
+    $L_i(X_iY_i)Z_i=I_4$. Multiplication cannot increase rank, so each cut
+    has rank at least four.
+\end{proof}
+
+\begin{definition}[The displayed factors in source-rank coordinates]
+    \label{def:mpug_czx_displayed_source_factors}
+    \lean{MPOTensor.CZX.displayedRightEquiv, MPOTensor.CZX.displayedLeftEquiv,
+        MPOTensor.CZX.displayedSourceFactors}
+    \leanok
+    \uses{def:mpug_czx_displayed_factors,
+        def:mpug_czx_displayed_right_inverses, thm:mpug_czx_displayed_ranks,
+        def:mpug_czx_exact_tensor, def:mpu_weighted_source_factors}
+    Let $d_r,d_l$ be the two source-cut ranks of the exact CZX tensor $B$.
+    By Theorem~\ref{thm:mpug_czx_displayed_ranks}, both are four. Let
+    \begin{align}
+        e_r & :\{0,\ldots,d_r-1\}\longrightarrow\{0,1,2,3\}, \\
+        e_l & :\{0,\ldots,d_l-1\}\longrightarrow\{0,1,2,3\}
+    \end{align}
+    be the bijections that preserve each integer index. Pull back the
+    four-dimensional factor index of $X_1,Y_1,Z_1$ along $e_r$, and that
+    of $X_2,Y_2,Z_2$ along $e_l$. Denote the resulting matrices by
+    $\widehat X_i,\widehat Y_i,\widehat Z_i$. Together with $\rho=I_2/2$,
+    these give source factors for $B$ in the sense of
+    Definition~\ref{def:mpu_weighted_source_factors}, satisfying both cut
+    factorizations, the two left-factor normalizations, and both
+    right-inverse identities.
+    % This is an explicit SourceFactors witness, not an equality with the
+    % choice-selected compact SVD factors. It supplies no canonical-form-II
+    % presentation, fusion tensors, local action tensors, or anomaly data.
+\end{definition}
+
+\begin{proof}\leanok
+    \uses{thm:mpug_czx_displayed_cuts, thm:mpug_czx_displayed_grams,
+        thm:mpug_czx_displayed_normalizations}
+    Transport the cut factorizations and inverse identities along the
+    two index bijections. Products, conjugate transposes, and identities
+    are preserved. The weighted first normalization and the ordinary
+    second normalization therefore hold in the source-rank coordinates.
+\end{proof}
+
+\begin{theorem}[Coordinates of the transported CZX source factors]
+    \label{thm:mpug_czx_displayed_source_coordinates}
+    \lean{MPOTensor.CZX.displayedSourceFactors_coordinates}
+    \leanok
+    \uses{def:mpug_czx_displayed_source_factors}
+    For $0\leq k,i<4$ and $\alpha\in\{0,1\}$, the transported factors
+    of Definition~\ref{def:mpug_czx_displayed_source_factors} satisfy
+    \begin{align}
+        (\widehat X_1)_{(i,\alpha),e_r^{-1}(k)} & =(X_1)_{(i,\alpha),k}, \\
+        (\widehat Y_1)_{e_r^{-1}(k),(\alpha,i)} & =(Y_1)_{k,(\alpha,i)}, \\
+        (\widehat Z_1)_{(\alpha,i),e_r^{-1}(k)} & =(Z_1)_{(\alpha,i),k}, \\
+        (\widehat X_2)_{(\alpha,i),e_l^{-1}(k)} & =(X_2)_{(\alpha,i),k}, \\
+        (\widehat Y_2)_{e_l^{-1}(k),(i,\alpha)} & =(Y_2)_{k,(i,\alpha)}, \\
+        (\widehat Z_2)_{(i,\alpha),e_l^{-1}(k)} & =(Z_2)_{(i,\alpha),k}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_source_factors}
+    Evaluate the pullbacks and use $e_r(e_r^{-1}(k))=k$ and
+    $e_l(e_l^{-1}(k))=k$.
+\end{proof}
+
+\begin{theorem}[Pauli and inverse coordinates after transport]
+    \label{thm:mpug_czx_displayed_inverse_coordinates}
+    \lean{MPOTensor.CZX.displayedSourceFactors_inverse_coordinates}
+    \leanok
+    \uses{def:mpug_czx_displayed_source_factors, def:mpug_czx_dagger_gauge}
+    For $0\leq k,i<4$ and $\beta\in\{0,1\}$, the transported factors
+    satisfy
+    \begin{align}
+        (\widehat X_1)_{(i,\beta),e_r^{-1}(k)}
+         & =\sum_{t=0}^1Y_{\beta t}
+        \overline{(\widehat Y_2)_{e_l^{-1}(k),(i,t)}},                           \\
+        (\widehat Y_1)_{e_r^{-1}(k),(\beta,i)}
+         & =\sum_{t=0}^1\overline{(\widehat X_2)_{(t,i),e_l^{-1}(k)}}Y_{t\beta}, \\
+        (\widehat Z_1)_{(\beta,i),e_r^{-1}(k)}
+         & =\overline{(\widehat Y_1)_{e_r^{-1}(k),(\beta,i)}},                   \\
+        (\widehat Z_2)_{(i,\beta),e_l^{-1}(k)}
+         & =\tfrac12\overline{(\widehat Y_2)_{e_l^{-1}(k),(i,\beta)}}.
+    \end{align}
+    In particular, transport preserves the Pauli orientation $Y_{\beta t}$
+    in the first factor of
+    \cite[lines~4611--4659]{FrancoRubio2025MPUGauging}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_source_factors,
+        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
+    Expand the transported factors, then substitute the definitions of
+    $X_1,Y_1,Z_1,Z_2$. The inverse bijections cancel the corresponding
+    pullbacks, leaving the four displayed expressions.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -5941,9 +5941,11 @@ by the displayed matrices.
     The four explicit factors of
     Definition~\ref{def:mpug_czx_displayed_factors} satisfy
     \begin{align}
-        X_1^\dagger X_1 & =2I_4, \\
-        X_2^\dagger X_2 & =I_4,  \\
-        Y_1Y_1^\dagger  & =I_4,  \\
+        X_1^\dagger X_1 & =2I_4,
+        \label{eq:mpug_czx_displayed_gram_x1} \\
+        X_2^\dagger X_2 & =I_4,
+        \label{eq:mpug_czx_displayed_gram_x2} \\
+        Y_1Y_1^\dagger  & =I_4,               \\
         Y_2Y_2^\dagger  & =2I_4.
     \end{align}
     The factors of two retain the unnormalized Hadamard weights of
@@ -5951,10 +5953,18 @@ by the displayed matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_displayed_factors, def:mpug_czx_dagger_gauge}
-    Expand the four Gram matrices over their product-index spaces and
-    substitute the factor coordinates and the Pauli matrix. Evaluation
-    at each pair of factor indices gives the displayed scalar identities.
+    \uses{def:mpug_czx_displayed_factors, lem:mpug_czx_dagger_gauge_laws}
+    The empty factors are Pauli-gauge contractions of the filled factors,
+    $X_1=(I_4\otimes Y)Y_2^\dagger$ and $Y_1=X_2^\dagger(Y\otimes I_4)$.
+    By Lemma~\ref{lem:mpug_czx_dagger_gauge_laws}, $Y$ is unitary, hence so
+    are $I_4\otimes Y$ and $Y\otimes I_4$; composing a unitary matrix with
+    $Y_2^\dagger$, respectively with $X_2^\dagger$, leaves the Gram matrix
+    unchanged, so $X_1^\dagger X_1=Y_2Y_2^\dagger$ and
+    $Y_1Y_1^\dagger=X_2^\dagger X_2$. It remains to expand the two filled
+    Gram matrices $X_2^\dagger X_2$ and $Y_2Y_2^\dagger$ over their
+    product-index spaces and substitute the factor coordinates; evaluation
+    at each pair of factor indices gives the two displayed scalar
+    identities.
 \end{proof}
 
 \begin{definition}[Right inverses of the displayed CZX factors]
@@ -5979,8 +5989,10 @@ by the displayed matrices.
         def:mpug_czx_displayed_right_inverses, def:mpu_source_weight}
     Set $\rho=I_2/2$. The displayed factors and right inverses satisfy
     \begin{align}
-        Y_1Z_1                         & =I_4, \\
-        Y_2Z_2                         & =I_4, \\
+        Y_1Z_1                         & =I_4,
+        \label{eq:mpug_czx_displayed_right_inverse_y1} \\
+        Y_2Z_2                         & =I_4,
+        \label{eq:mpug_czx_displayed_right_inverse_y2} \\
         X_1^\dagger(I_4\otimes\rho)X_1 & =I_4.
     \end{align}
 \end{theorem}
@@ -6015,8 +6027,10 @@ by the displayed matrices.
         thm:mpug_czx_displayed_normalizations}
     Each cut factors through a four-dimensional space, so its rank is at
     most four. For the first cut take $L_1=X_1^\dagger/2$, and for the
-    second take $L_2=X_2^\dagger$. The preceding identities give
-    $L_iX_i=I_4$ and $Y_iZ_i=I_4$, hence
+    second take $L_2=X_2^\dagger$. By (\ref{eq:mpug_czx_displayed_gram_x1})
+    and (\ref{eq:mpug_czx_displayed_gram_x2}), $L_iX_i=I_4$; by
+    (\ref{eq:mpug_czx_displayed_right_inverse_y1}) and
+    (\ref{eq:mpug_czx_displayed_right_inverse_y2}), $Y_iZ_i=I_4$, hence
     $L_i(X_iY_i)Z_i=I_4$. Multiplication cannot increase rank, so each cut
     has rank at least four.
 \end{proof}
@@ -6024,11 +6038,14 @@ by the displayed matrices.
 \begin{definition}[The displayed factors in source-rank coordinates]
     \label{def:mpug_czx_displayed_source_factors}
     \lean{MPOTensor.CZX.displayedRightEquiv, MPOTensor.CZX.displayedLeftEquiv,
-        MPOTensor.CZX.displayedSourceFactors}
+        MPOTensor.CZX.displayedSourceFactors,
+        MPOTensor.CZX.displayedSourceFactors_coordinates,
+        MPOTensor.CZX.displayedSourceFactors_inverse_coordinates}
     \leanok
     \uses{def:mpug_czx_displayed_factors,
         def:mpug_czx_displayed_right_inverses, thm:mpug_czx_displayed_ranks,
-        def:mpug_czx_exact_tensor, def:mpu_weighted_source_factors}
+        def:mpug_czx_exact_tensor, def:mpu_weighted_source_factors,
+        def:mpug_czx_dagger_gauge}
     Let $d_r,d_l$ be the two source-cut ranks of the exact CZX tensor $B$.
     By Theorem~\ref{thm:mpug_czx_displayed_ranks}, both are four. Let
     \begin{align}
@@ -6043,52 +6060,19 @@ by the displayed matrices.
     Definition~\ref{def:mpu_weighted_source_factors}, satisfying both cut
     factorizations, the two left-factor normalizations, and both
     right-inverse identities.
-    % This is an explicit SourceFactors witness, not an equality with the
-    % choice-selected compact SVD factors. It supplies no canonical-form-II
-    % presentation, fusion tensors, local action tensors, or anomaly data.
-\end{definition}
 
-\begin{proof}\leanok
-    \uses{thm:mpug_czx_displayed_cuts, thm:mpug_czx_displayed_grams,
-        thm:mpug_czx_displayed_normalizations}
-    Transport the cut factorizations and inverse identities along the
-    two index bijections. Products, conjugate transposes, and identities
-    are preserved. The weighted first normalization and the ordinary
-    second normalization therefore hold in the source-rank coordinates.
-\end{proof}
-
-\begin{theorem}[Coordinates of the transported CZX source factors]
-    \label{thm:mpug_czx_displayed_source_coordinates}
-    \lean{MPOTensor.CZX.displayedSourceFactors_coordinates}
-    \leanok
-    \uses{def:mpug_czx_displayed_source_factors,
-        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
-    For $0\leq k,i<4$ and $\alpha\in\{0,1\}$, the transported factors
-    of Definition~\ref{def:mpug_czx_displayed_source_factors} satisfy
+    Explicitly, for $0\leq k,i<4$ and $\alpha,\beta\in\{0,1\}$, evaluating
+    the pullbacks gives
     \begin{align}
         (\widehat X_1)_{(i,\alpha),e_r^{-1}(k)} & =(X_1)_{(i,\alpha),k}, \\
         (\widehat Y_1)_{e_r^{-1}(k),(\alpha,i)} & =(Y_1)_{k,(\alpha,i)}, \\
         (\widehat Z_1)_{(\alpha,i),e_r^{-1}(k)} & =(Z_1)_{(\alpha,i),k}, \\
         (\widehat X_2)_{(\alpha,i),e_l^{-1}(k)} & =(X_2)_{(\alpha,i),k}, \\
         (\widehat Y_2)_{e_l^{-1}(k),(i,\alpha)} & =(Y_2)_{k,(i,\alpha)}, \\
-        (\widehat Z_2)_{(i,\alpha),e_l^{-1}(k)} & =(Z_2)_{(i,\alpha),k}.
+        (\widehat Z_2)_{(i,\alpha),e_l^{-1}(k)} & =(Z_2)_{(i,\alpha),k},
     \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:mpug_czx_displayed_source_factors,
-        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
-    Evaluate the pullbacks and use $e_r(e_r^{-1}(k))=k$ and
-    $e_l(e_l^{-1}(k))=k$.
-\end{proof}
-
-\begin{theorem}[Pauli and inverse coordinates after transport]
-    \label{thm:mpug_czx_displayed_inverse_coordinates}
-    \lean{MPOTensor.CZX.displayedSourceFactors_inverse_coordinates}
-    \leanok
-    \uses{def:mpug_czx_displayed_source_factors, def:mpug_czx_dagger_gauge}
-    For $0\leq k,i<4$ and $\beta\in\{0,1\}$, the transported factors
-    satisfy
+    and substituting the definitions of $X_1,Y_1,Z_1,Z_2$ gives the
+    Pauli and inverse coordinates
     \begin{align}
         (\widehat X_1)_{(i,\beta),e_r^{-1}(k)}
          & =\sum_{t=0}^1Y_{\beta t}
@@ -6103,14 +6087,23 @@ by the displayed matrices.
     In particular, transport preserves the Pauli orientation $Y_{\beta t}$
     in the first factor of
     \cite[lines~4611--4659]{FrancoRubio2025MPUGauging}.
-\end{theorem}
+    % This is an explicit SourceFactors witness, not an equality with the
+    % choice-selected compact SVD factors. It supplies no canonical-form-II
+    % presentation, fusion tensors, local action tensors, or anomaly data.
+\end{definition}
 
 \begin{proof}\leanok
-    \uses{def:mpug_czx_displayed_source_factors,
-        def:mpug_czx_displayed_factors, def:mpug_czx_displayed_right_inverses}
-    Expand the transported factors, then substitute the definitions of
-    $X_1,Y_1,Z_1,Z_2$. The inverse bijections cancel the corresponding
-    pullbacks, leaving the four displayed expressions.
+    \uses{thm:mpug_czx_displayed_cuts, thm:mpug_czx_displayed_grams,
+        thm:mpug_czx_displayed_normalizations, def:mpug_czx_displayed_factors,
+        def:mpug_czx_displayed_right_inverses}
+    Transport the cut factorizations and inverse identities along the
+    two index bijections. Products, conjugate transposes, and identities
+    are preserved. The weighted first normalization and the ordinary
+    second normalization therefore hold in the source-rank coordinates.
+    Evaluating the pullbacks, using $e_r(e_r^{-1}(k))=k$ and
+    $e_l(e_l^{-1}(k))=k$, gives the coordinate identities; substituting
+    the definitions of $X_1,Y_1,Z_1,Z_2$ and cancelling the inverse
+    bijections gives the Pauli and inverse coordinates.
 \end{proof}
 
 \subsection{The blocked GHZ state and its CZX invariance}


### PR DESCRIPTION
## Scope

Closes #7315: FBC25 Lemma `lem:deco`, source-decomposition uniqueness. Also advances #7354 with the literal displayed CZX source factors at `main.tex:4559–4659`.

Stacked on #7791. Parent PRs must merge sequentially; no merge before successful current-head checks, agreeing reviews, and resolved threads.

## Raw source uniqueness

`sourceU_contraction_transport` proves the exact transport utilde=(K₂⊗K₁)u in the existing ell×r coordinate order. `exists_reciprocal_unitary_source_gauges` then reuses the merged generic comparison and reciprocal-unitary-gauge theorems to produce the four source-oriented factor relations with positive reciprocal scalars delta₁=delta⁻¹, delta₂=delta, delta₁delta₂=1.

The premise surface is deliberately raw: actual source-cut factorizations, the needed one-sided inverse witnesses, positive physical dimension, and unitarity of both literal u contractions. Source-rank nonemptiness is derived from isometry/cardinality. No SourceFactors records, weighted normalization clause (c), CFII, rho, adjoint simplicity, or unused v-unitarity premise is added. This proves the source lemma without taking over #7313 or reproving the generic core.

## Explicit CZX factors

The exact shared tensor and Pauli Y gauge supply the four displayed factors, both source-cut factorizations, four Gram identities, rho=I₂/2 weighted normalization, explicit right inverses, and rank-four proofs using existing matrix rank inequalities. The first Pauli contraction uses Y_{beta,t}, not its transpose. Physical order is 2a+b; raw Hadamard weights and both output Z factors are preserved.

An explicit witness of the existing SourceFactors structure is transported to the actual rank-indexed legs, with all six coordinate formulas and inverse/gauge compatibility identities. This is not an identification with SVD-choice factors or a new canonical-form construction.

## Boundaries

No CZX local-action, fusion, anomaly, L-symbol, or gauging claim is included. The printed action pair's empty-word issue is a separate next source slice. General uniqueness stays in the structural comparison section of the blueprint, not inside the CZX example.

## Verification

- Both modules independently source/Lean reviewed and strictly checked with project options, including synthesis depth3, under the existing cache lock. Endpoint/witness axiom audits contain only propext, Classical.choice, Quot.sound. No broad/root/Mathlib rebuild.
- All 17 public declarations are covered in independently reviewed blueprint nodes; private helpers excluded.
- Pinned latexindent3.24.7 fixed point, CI-mode declaration synchronization/reverse coverage, unique/resolving dependencies, and no graph cycles.
- Final isolated Chapter29 render: 67 pages, zero undefined local labels after repeated passes; expected external-label/citation warnings remain for the standalone chapter.
- Generated aggregators match exactly the two new modules; unrelated active work excluded.
