### PR TITLE
feat(CZX): identify displayed source movement gates

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -112,6 +112,7 @@ import TNLean.MPS.MPDO.CZXFusionTensors
 import TNLean.MPS.MPDO.CZXGHZAction
 import TNLean.MPS.MPDO.CZXGaussCircuitTuple
 import TNLean.MPS.MPDO.CZXGaussInvariantSubspace
+import TNLean.MPS.MPDO.CZXMovementCoordinates
 import TNLean.MPS.MPDO.CZXSecondTupleCertificate
 import TNLean.MPS.MPDO.CZXSourceFactors
 import TNLean.MPS.MPDO.CZXTensor

--- a/TNLean/MPS/MPDO/CZXMovementCoordinates.lean
+++ b/TNLean/MPS/MPDO/CZXMovementCoordinates.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CZXSourceFactors
+import TNLean.MPS.MPDO.CZXGaussCircuitTuple
+import TNLean.MPS.MPU.StaircaseGates
+
+/-!
+# Displayed CZX movement coordinates
+
+The contractions of the displayed factors (arXiv:2502.20257, lines 4559–4659)
+are the movement circuit and its adjoint in lines 4860–4888, with the leg
+ordering of `eq:wLR` (lines 811–869). We use the sparse formula for the existing
+circuit, rather than expanding its six matrix factors.
+-/
+
+noncomputable section
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.CZX
+
+set_option maxHeartbeats 2000000 in
+-- The sparse coordinate check has 256 cases, each with a two-term virtual contraction.
+
+/-- The displayed right movement contraction is the CZX circuit in physical
+coordinates. Source: arXiv:2502.20257, lines 811–869, 4559–4659, 4860–4888. -/
+theorem displayedSourceFactors_sourceWR_coordinates (i r a j : Fin 4) :
+    SourceFactors.sourceWR tensor displayedSourceFactors
+      (i, displayedRightEquiv.symm r) (displayedRightEquiv.symm a, j) =
+        matterMatrix w ![i, r] ![a, j] := by
+  simp only [SourceFactors.sourceWR, displayedSourceFactors, Matrix.submatrix_apply,
+    Equiv.apply_symm_apply, Equiv.refl_apply, w_eq, matterMatrix, Matrix.reindex_apply,
+    Equiv.symm_symm, Matrix.monomial_apply]
+  fin_cases i <;> fin_cases r <;> fin_cases a <;> fin_cases j <;>
+    norm_num +decide [displayedX₁, displayedY₁, displayedX₂, displayedY₂,
+      Fin.sum_univ_two, daggerGauge, SpinCover.pauli_one, Fin.divNat, Fin.modNat,
+      Fin.rev, Fin.reduceEq, localBits, siteBits, barFlip, eExponent, ZMod.val]
+
+set_option maxHeartbeats 2000000 in
+-- The sparse coordinate check has 256 cases, each with a two-term virtual contraction.
+/-- The displayed left movement contraction is the adjoint of the same CZX
+circuit. Source: arXiv:2502.20257, lines 811–869, 4559–4659, 4860–4888. -/
+theorem displayedSourceFactors_sourceWL_coordinates (l i j k : Fin 4) :
+    SourceFactors.sourceWL tensor displayedSourceFactors
+      (displayedLeftEquiv.symm l, i) (j, displayedLeftEquiv.symm k) =
+        (matterMatrix w)ᴴ ![l, i] ![j, k] := by
+  simp only [SourceFactors.sourceWL, displayedSourceFactors, Matrix.submatrix_apply,
+    Equiv.apply_symm_apply, Equiv.refl_apply, Matrix.conjTranspose_apply,
+    w_eq, matterMatrix, Matrix.reindex_apply, Equiv.symm_symm, Matrix.monomial_apply]
+  fin_cases l <;> fin_cases i <;> fin_cases j <;> fin_cases k <;>
+    norm_num +decide [displayedX₂, displayedY₂, Fin.sum_univ_two,
+      Fin.divNat, Fin.modNat, Fin.rev, Fin.reduceEq,
+      localBits, siteBits, barFlip, eExponent, ZMod.val]
+
+end MPOTensor.CZX

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -6889,6 +6889,78 @@ unbuffered defect formulas.
     all phases are unimodular.
 \end{proof}
 
+\begin{theorem}[Right movement coordinates of the displayed CZX factors]
+    \label{thm:mpug_czx_displayed_right_movement_coordinates}
+    \lean{MPOTensor.CZX.displayedSourceFactors_sourceWR_coordinates}
+    \leanok
+    \discussion{7355}
+    \uses{def:mpug_czx_displayed_source_factors, def:mpug_staircase_gates,
+        def:mpug_czx_circuit_tuple}
+    Let $w_R$ be the crossed contraction of the displayed source factors
+    of the exact CZX tensor $B$, and let $e_r$ be their right-rank
+    identification with $\{0,1,2,3\}$. Let $W$ denote the matrix of
+    $w=(X_0X_1)\mathrm{CZ}_{01}\mathrm{CZ}_{12}(Z_2Z_3)$ on two
+    four-level matter sites, with each site read in leading-bit-first
+    binary order. For every $i,r,a,j\in\{0,1,2,3\}$,
+    \begin{align}
+        (w_R)_{(i,e_r^{-1}(r)),(e_r^{-1}(a),j)}
+         & =W_{(i,r),(a,j)}.
+    \end{align}
+    This identifies the right movement contraction in
+    \cite[lines~811--869, 4559--4659, 4860--4888]{FrancoRubio2025MPUGauging}
+    without additional hypotheses.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_source_factors, def:mpug_staircase_gates,
+        def:mpug_czx_displayed_factors, thm:mpug_czx_phase_tables}
+    Pull back the rank indices and expand the crossed contraction as
+    \begin{align*}
+        \sum_{\beta=0}^1(X_1)_{(i,\beta),a}(Y_1)_{r,(\beta,j)}.
+    \end{align*}
+    Substitute the displayed factors and compare with the sparse action
+    (\ref{eq:mpug_czx_w_action}). The two expressions agree for each of
+    the $4^4$ choices of external indices.
+\end{proof}
+
+\begin{theorem}[Left movement coordinates of the displayed CZX factors]
+    \label{thm:mpug_czx_displayed_left_movement_coordinates}
+    \lean{MPOTensor.CZX.displayedSourceFactors_sourceWL_coordinates}
+    \leanok
+    \discussion{7355}
+    \uses{def:mpug_czx_displayed_source_factors, def:mpug_staircase_gates,
+        def:mpug_czx_circuit_tuple}
+    Let $w_L$ be the crossed contraction of the displayed source factors
+    of the exact CZX tensor $B$, and let $e_l$ be their left-rank
+    identification with $\{0,1,2,3\}$. Let $W$ denote the matrix of
+    $w=(X_0X_1)\mathrm{CZ}_{01}\mathrm{CZ}_{12}(Z_2Z_3)$ on two
+    four-level matter sites, with each site read in leading-bit-first
+    binary order. For every $l,i,j,k\in\{0,1,2,3\}$,
+    \begin{align}
+        (w_L)_{(e_l^{-1}(l),i),(j,e_l^{-1}(k))}
+         & =(W^\dagger)_{(l,i),(j,k)}.
+    \end{align}
+    This is the left movement identification in
+    \cite[lines~811--869, 4559--4659, 4860--4888]{FrancoRubio2025MPUGauging}
+    in the same matter coordinates, without additional hypotheses.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpug_czx_displayed_source_factors, def:mpug_staircase_gates,
+        def:mpug_czx_displayed_factors, thm:mpug_czx_phase_tables}
+    Pull back the rank indices and expand the crossed contraction as
+    \begin{align*}
+        \sum_{\beta=0}^1(Y_2)_{l,(j,\beta)}(X_2)_{(\beta,i),k}.
+    \end{align*}
+    Substitute the displayed factors and compare with the complex
+    conjugate of the $((j,k),(l,i))$ entry of the sparse matrix in
+    (\ref{eq:mpug_czx_w_action}). Check the $4^4$ external index choices.
+\end{proof}
+
+% Scope of #7355 here: only the two displayed movement-coordinate identities.
+% No full truncated-symmetry formula, associator, sign, or parent issue
+% completion is asserted.
+
 \begin{theorem}[Local monomial action of the CZX Gauss operator]
     \label{thm:mpug_czx_local_monomial_action}
     \lean{MPOTensor.CZX.iPow,


### PR DESCRIPTION
## Scope
Two source-faithful coordinate identities for the actual displayed CZX source factors: sourceWR is the existing printed two-site matrix W, and sourceWL is its adjoint, with the explicit inverse source-rank equivalences. No new gates or added premises.

Source: Papers/2502.20257/main.tex 811–869, 4559–4659, 4860–4888. Advances #7355 only; does not close it or claim full truncated symmetry, fusion/associator or anomalous sign.

## Validation
- Independent mathematical/source/orientation review approved both theorems.
- Parent strict cached locked leaf check: exit 0, no diagnostics (23s); standard linters, maxSynthPendingDepth=3, warnings as errors.
- Blueprint equivalence/dependencies independently checked; actual pinned latexindent 3.24.7 fixed point.
- Bounded exact-parent/revised chapter renders: no new undefined references, citations, or bad boxes.
- Generated import coverage included.

Stacked on #7795. Repaired parent propagation is ongoing; merges remain sequential and gated on current-head CI, resolved threads and agreeing reviews.