### PR TITLE
Derive source-rank equality and rectangular inverse comparison

### DIFF
--- a/TNLean/Algebra/UnitaryKroneckerComparison.lean
+++ b/TNLean/Algebra/UnitaryKroneckerComparison.lean
@@ -35,10 +35,11 @@ matrix between the two factorizations.
 This is the one-sided-inverse step in FBC25, Lemma `lem:deco`
 (arXiv:2502.20257, lines 1052--1066). -/
 theorem factorization_comparison_of_one_sided_inverses
-    {α β γ 𝕜 : Type*} [Fintype α] [Fintype β] [Fintype γ]
-    [DecidableEq β] [Semiring 𝕜]
-    {X Xt : Matrix α β 𝕜} {Y Yt : Matrix β γ 𝕜}
-    {Lt : Matrix β α 𝕜} {R : Matrix γ β 𝕜}
+    {α β βt γ 𝕜 : Type*} [Fintype α] [Fintype β] [Fintype βt] [Fintype γ]
+    [DecidableEq β] [DecidableEq βt] [Semiring 𝕜]
+    {X : Matrix α β 𝕜} {Xt : Matrix α βt 𝕜}
+    {Y : Matrix β γ 𝕜} {Yt : Matrix βt γ 𝕜}
+    {Lt : Matrix βt α 𝕜} {R : Matrix γ β 𝕜}
     (hfac : X * Y = Xt * Yt) (hleft : Lt * Xt = 1) (hright : Y * R = 1) :
     Lt * X = Yt * R ∧ X = Xt * (Lt * X) ∧ Yt = (Lt * X) * Y := by
   have hK : Lt * X = Yt * R := by

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -22,6 +22,7 @@ import TNLean.MPS.MPU.Examples
 import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.FiniteChainConjugation
 import TNLean.MPS.MPU.GroupRepresentation
+import TNLean.MPS.MPU.InverseCompatibleCutComparison
 import TNLean.MPS.MPU.InverseCompatibleFirstCut
 import TNLean.MPS.MPU.KetLeftMul
 import TNLean.MPS.MPU.MPUCanonicalForm

--- a/TNLean/MPS/MPU/InverseCompatibleCutComparison.lean
+++ b/TNLean/MPS/MPU/InverseCompatibleCutComparison.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.UnitaryKroneckerComparison
+import TNLean.MPS.MPU.InverseCompatibleFirstCut
+
+/-!
+# Inverse comparison for the first inverse-compatible cut
+
+For the candidate factors $X=AY_2^\dagger$ and $Y=X_2^\dagger B$, the
+explicit inverses $L=Z_2^\dagger A^\dagger$ and $R=B^\dagger X_2$ give
+$L\mathcal M_1R=I_\ell$. Together with $\mathcal M_1=XY$, this proves
+$r=\ell$ without a positivity or simplicity assumption.
+
+For a positive-definite weight $\rho$, let $\tilde X,\tilde Y,\tilde Z$
+be the existing first source factors and put
+$\tilde L=\tilde X^\dagger(I_d\otimes\rho)$. The comparison matrices
+$K=\tilde L X$ and $J=L\tilde X$ satisfy $KJ=I_r$ and $JK=I_\ell$.
+We retain their rectangular index types, without transporting along $r=\ell$.
+
+Source: arXiv:2502.20257, `main.tex` lines 5432–5443. This is the algebraic
+invertible-comparison step only. The source writes an adjoint for the inverse
+before its subsequent unitarity argument. Here the inverse is kept as $J$;
+neither $J=K^\dagger$ nor unitarity nor an unweighted formula for $K$ is asserted.
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D) (T : Matrix.unitaryGroup (Fin D) ℂ)
+
+/-- The inverse-compatible first factorization has the same intermediate
+size as the first source cut. This uses $L\mathcal M_1R=I_\ell$ and
+$\operatorname{rank}(XY)\leq\ell$, not normalization or simplicity.
+Source: arXiv:2502.20257, the invertible-comparison step at lines 5432–5443. -/
+theorem rightRank_eq_leftRank_of_physicalAdjointTensor_eq_unitary_gauge
+    (hT : ∀ i j, physicalAdjointTensor U i j =
+      (T : Matrix (Fin D) (Fin D) ℂ)ᴴ * U i j * T) :
+    r[U] = ℓ[U] := by
+  let L := (sourceZ₂ U)ᴴ * (inverseCompatibleLeftGauge (d := d) T)ᴴ
+  let R := (inverseCompatibleRightGauge (d := d) T)ᴴ * sourceX₂ U
+  have hLMR : L * sourceCutM₁ U * R = 1 := by
+    rw [sourceCutM₁_eq_inverseCompatibleX₁_mul_inverseCompatibleY₁ U T hT,
+      ← Matrix.mul_assoc L (inverseCompatibleX₁ U T) (inverseCompatibleY₁ U T)]
+    rw [show L * inverseCompatibleX₁ U T = 1 from inverseCompatibleX₁_leftInverse U T,
+      Matrix.one_mul]
+    exact inverseCompatibleY₁_rightInverse U T
+  change (sourceCutM₁ U).rank = ℓ[U]
+  apply le_antisymm
+  · rw [sourceCutM₁_eq_inverseCompatibleX₁_mul_inverseCompatibleY₁ U T hT]
+    exact (Matrix.rank_mul_le_left _ _).trans
+      (by simpa only [Fintype.card_fin] using
+        Matrix.rank_le_card_width (inverseCompatibleX₁ U T))
+  · calc
+      ℓ[U] = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ).rank := by
+        rw [Matrix.rank_one, Fintype.card_fin]
+      _ = (L * sourceCutM₁ U * R).rank := by rw [hLMR]
+      _ ≤ (L * sourceCutM₁ U).rank := Matrix.rank_mul_le_left _ _
+      _ ≤ (sourceCutM₁ U).rank := Matrix.rank_mul_le_right _ _
+
+/-- The comparison $K=\tilde L X$, where
+$\tilde L=\tilde X^\dagger(I_d\otimes\rho)$ is the actual weighted left inverse.
+Source: arXiv:2502.20257, lines 5432–5443, retaining the source normalization
+of arXiv:1703.09188, `Y1Y1X1X1` (lines 487–494). -/
+noncomputable def inverseCompatibleComparisonK
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix (Fin r[U]) (Fin ℓ[U]) ℂ :=
+  ((sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ) * inverseCompatibleX₁ U T
+
+/-- The inverse comparison $J=L\tilde X$, using the actual left inverse
+$L=Z_2^\dagger A^\dagger$, without identifying $J$ with $K^\dagger$.
+Source: arXiv:2502.20257, lines 5432–5443. -/
+noncomputable def inverseCompatibleComparisonJ
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix (Fin ℓ[U]) (Fin r[U]) ℂ :=
+  ((sourceZ₂ U)ᴴ * (inverseCompatibleLeftGauge (d := d) T)ᴴ) * sourceX₁ U ρ hρ
+
+/-- The rectangular comparison matrices intertwine the candidate first cut
+with the chosen first source factors and are mutual inverses. All inverse
+identities are derived from the actual source factorizations and one-sided
+inverses. No adjoint comparison or new normalization is assumed.
+Source: arXiv:2502.20257, lines 5432–5443. -/
+theorem inverseCompatibleComparison
+    (hT : ∀ i j, physicalAdjointTensor U i j =
+      (T : Matrix (Fin D) (Fin D) ℂ)ᴴ * U i j * T)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    let X := inverseCompatibleX₁ U T
+    let Y := inverseCompatibleY₁ U T
+    let Xt := sourceX₁ U ρ hρ
+    let Yt := sourceY₁ U ρ hρ
+    let K := inverseCompatibleComparisonK U T ρ hρ
+    let J := inverseCompatibleComparisonJ U T ρ hρ
+    K = Yt * ((inverseCompatibleRightGauge (d := d) T)ᴴ * sourceX₂ U) ∧
+      X = Xt * K ∧ Yt = K * Y ∧ J = Y * sourceZ₁ U ρ hρ ∧
+      Xt = X * J ∧ Y = J * Yt ∧ K * J = 1 ∧ J * K = 1 := by
+  let X := inverseCompatibleX₁ U T
+  let Y := inverseCompatibleY₁ U T
+  let Xt := sourceX₁ U ρ hρ
+  let Yt := sourceY₁ U ρ hρ
+  let Lt := (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ
+  let L := (sourceZ₂ U)ᴴ * (inverseCompatibleLeftGauge (d := d) T)ᴴ
+  let R := (inverseCompatibleRightGauge (d := d) T)ᴴ * sourceX₂ U
+  have hfac : X * Y = Xt * Yt :=
+    (sourceCutM₁_eq_inverseCompatibleX₁_mul_inverseCompatibleY₁ U T hT).symm.trans
+      (sourceCutM₁_eq_sourceX₁_mul_sourceY₁ U ρ hρ)
+  have hLt : Lt * Xt = 1 := sourceX₁_weighted_isometry U ρ hρ
+  have hL : L * X = 1 := inverseCompatibleX₁_leftInverse U T
+  have hR : Y * R = 1 := inverseCompatibleY₁_rightInverse U T
+  have hZt : Yt * sourceZ₁ U ρ hρ = 1 := sourceY₁_mul_sourceZ₁ U ρ hρ
+  obtain ⟨hK, hX, hYt⟩ :=
+    Matrix.factorization_comparison_of_one_sided_inverses hfac hLt hR
+  obtain ⟨hJ, hXt, hY⟩ :=
+    Matrix.factorization_comparison_of_one_sided_inverses hfac.symm hL hZt
+  refine ⟨hK, hX, hYt, hJ, hXt, hY, ?_, ?_⟩
+  · change (Lt * X) * (L * Xt) = 1
+    rw [hJ, ← Matrix.mul_assoc, ← hYt, hZt]
+  · change (L * Xt) * (Lt * X) = 1
+    rw [hK, ← Matrix.mul_assoc, ← hY, hR]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -685,6 +685,147 @@ the comparison matrix $K$, or the full compatibility properties of
     and~\ref{thm:mpug_inverse_cut_right_inverse} give
     $(Z_2^\dagger A^\dagger)X=I_\ell$ and $Y(B^\dagger X_2)=I_\ell$.
 \end{proof}
+
+\subsection{Rank equality and the invertible first-cut comparison}
+
+The following results give the algebraic invertible-comparison step of
+\cite[lines~5432--5443]{FrancoRubio2025MPUGauging}. The comparison uses the
+actual one-sided inverses of the source factors. Its inverse is denoted by
+$J$, not by $K^\dagger$. No unitarity of $K$, equality $J=K^\dagger$, or full
+inverse-compatible decomposition is asserted.
+
+\begin{theorem}[Equality of the two source-cut ranks]
+    \label{thm:mpug_inverse_cut_rank_equality}
+    \lean{MPOTensor.rightRank_eq_leftRank_of_physicalAdjointTensor_eq_unitary_gauge}
+    \leanok
+    \uses{def:mpu_right_rank, def:mpu_left_rank, def:mpdo_physical_adjoint}
+    Let $\mathcal U$ be an MPO tensor of physical dimension $d$ and bond
+    dimension $D$. Suppose that $T$ is unitary on $\C^D$ and
+    $(\mathcal U^\dagger)^{ij}=T^\dagger\mathcal U^{ij}T$ for every
+    $0\leq i,j<d$, where $\mathcal U^\dagger$ denotes physical adjunction.
+    Then its source-cut ranks satisfy
+    $r=\operatorname{rank}M_1(\mathcal U)
+        =\operatorname{rank}M_2(\mathcal U)=\ell$.
+    No positivity, simplicity, or positive-dimension assumption is required.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpug_inverse_cut_factorization,
+        thm:mpug_inverse_cut_left_inverse, thm:mpug_inverse_cut_right_inverse,
+        def:mpug_inverse_cut_factors}
+    Put $X=AY_2^\dagger$, $Y=X_2^\dagger B$,
+    $L=Z_2^\dagger A^\dagger$, and $R=B^\dagger X_2$, with the gauge
+    matrices and second-cut factors of
+    Definition~\ref{def:mpug_inverse_cut_factors}. The factorization
+    $M_1=XY$ through $\C^\ell$ gives $r\leq\ell$. The identities
+    $LX=I_\ell$ and $YR=I_\ell$ give $LM_1R=I_\ell$. Hence
+    $\ell=\operatorname{rank}(LM_1R)
+        \leq\operatorname{rank}M_1=r$.
+\end{proof}
+
+\begin{definition}[The weighted comparison matrix]
+    \label{def:mpug_inverse_cut_comparison_k}
+    \lean{MPOTensor.inverseCompatibleComparisonK}
+    \leanok
+    \uses{def:mpug_inverse_cut_factors, def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPO tensor of dimensions $d,D$, let $T$ be
+    unitary on $\C^D$, and let $\rho$ be a positive-definite matrix on
+    $\C^D$. Put $r=\operatorname{rank}M_1(\mathcal U)$ and
+    $\ell=\operatorname{rank}M_2(\mathcal U)$. Let
+    $\widetilde X,\widetilde Y,\widetilde Z$ be the first source factors
+    constructed with weight $\rho$, and let $X=AY_2^\dagger$ be the
+    candidate first factor. Define
+    \begin{align}
+        \widetilde L & =\widetilde X^\dagger(I_d\otimes\rho),           \\
+        K            & =\widetilde L X\colon\C^\ell\longrightarrow\C^r.
+    \end{align}
+    Here $\widetilde L$ is the weighted left inverse supplied by
+    $\widetilde X^\dagger(I_d\otimes\rho)\widetilde X=I_r$.
+    The weight is retained; $K=\widetilde X^\dagger X$ is not asserted.
+    No adjoint gauge relation is needed to define $K$.
+\end{definition}
+
+\begin{definition}[The reverse comparison matrix]
+    \label{def:mpug_inverse_cut_comparison_j}
+    \lean{MPOTensor.inverseCompatibleComparisonJ}
+    \leanok
+    \uses{def:mpug_inverse_cut_factors, def:mpug_inverse_cut_gauges,
+        def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPO tensor of dimensions $d,D$, let $T$ be
+    unitary on $\C^D$, and let $\rho$ be positive definite on $\C^D$.
+    Let $\widetilde X$ be its first source factor with weight $\rho$,
+    and let $Y_2,Z_2$ be its second-cut factors with $Y_2Z_2=I_\ell$,
+    where $r=\operatorname{rank}M_1(\mathcal U)$ and
+    $\ell=\operatorname{rank}M_2(\mathcal U)$. For
+    $A=I_d\otimes\overline T$, define
+    \begin{align}
+        L & =Z_2^\dagger A^\dagger,                         \\
+        J & =L\widetilde X\colon\C^r\longrightarrow\C^\ell.
+    \end{align}
+    No adjoint gauge relation is needed to define $J$.
+\end{definition}
+
+\begin{theorem}[Mutually inverse rectangular comparisons]
+    \label{thm:mpug_inverse_cut_comparison}
+    \lean{MPOTensor.inverseCompatibleComparison}
+    \leanok
+    \uses{def:mpug_inverse_cut_comparison_k, def:mpug_inverse_cut_comparison_j,
+        def:mpug_inverse_cut_factors, def:mpu_weighted_source_factors,
+        def:mpdo_physical_adjoint}
+    Let $\mathcal U$ be an MPO tensor of dimensions $d,D$, let $T$ be
+    unitary on $\C^D$, and suppose that
+    $(\mathcal U^\dagger)^{ij}=T^\dagger\mathcal U^{ij}T$ for every
+    $0\leq i,j<d$. Let $\rho$ be positive definite on $\C^D$.
+    Write $\widetilde X,\widetilde Y,\widetilde Z$ for the first
+    source factors with weight $\rho$, and $X_2,Y_2,Z_2$ for the
+    second-cut factors. Set
+    \begin{align}
+        A            & =I_d\otimes\overline T,                \\
+        B            & =T^{\mathsf T}\otimes I_d,             \\
+        X            & =AY_2^\dagger,                         \\
+        Y            & =X_2^\dagger B,                        \\
+        L            & =Z_2^\dagger A^\dagger,                \\
+        R            & =B^\dagger X_2,                        \\
+        \widetilde L & =\widetilde X^\dagger(I_d\otimes\rho), \\
+        K            & =\widetilde L X,                       \\
+        J            & =L\widetilde X.
+    \end{align}
+    With $r=\operatorname{rank}M_1(\mathcal U)$ and
+    $\ell=\operatorname{rank}M_2(\mathcal U)$, the matrices
+    $K\colon\C^\ell\to\C^r$ and $J\colon\C^r\to\C^\ell$ satisfy
+    \begin{align}
+        K            & =\widetilde YR, \notag \\
+        X            & =\widetilde XK, \notag \\
+        \widetilde Y & =KY, \notag            \\
+        J            & =Y\widetilde Z, \notag \\
+        \widetilde X & =XJ, \notag            \\
+        Y            & =J\widetilde Y, \notag \\
+        KJ           & =I_r, \notag           \\
+        JK           & =I_\ell.
+        \label{eq:mpug_inverse_cut_comparison}
+    \end{align}
+    The two source-coordinate spaces are retained separately, without
+    identifying their bases along the equality $r=\ell$. These are inverse
+    identities, not adjoint or unitarity identities.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpug_factorization_comparison,
+        thm:mpug_inverse_cut_factorization, thm:mpug_inverse_cut_left_inverse,
+        thm:mpug_inverse_cut_right_inverse, thm:mpu_source_factorizations,
+        thm:mpu_source_factor_normalizations, thm:mpu_source_factor_right_inverses}
+    The two first-cut factorizations give
+    $XY=\widetilde X\widetilde Y$. Their actual one-sided inverses satisfy
+    $\widetilde L\widetilde X=I_r$, $LX=I_\ell$, $YR=I_\ell$, and
+    $\widetilde Y\widetilde Z=I_r$. Apply
+    Theorem~\ref{thm:mpug_factorization_comparison} first with
+    $\widetilde L,R$, then with the factorizations exchanged and inverses
+    $L,\widetilde Z$. This proves the factor relations in
+    (\ref{eq:mpug_inverse_cut_comparison}). Finally,
+    \begin{align}
+        KJ & =KY\widetilde Z=\widetilde Y\widetilde Z=I_r, \\
+        JK & =J\widetilde YR=YR=I_\ell.
+    \end{align}
+    This argument does not use the rank equality to transport matrices.
+\end{proof}
 \begin{definition}[Common positive physical blocking]
     \label{def:mpug_common_blocking}
     \lean{MPOTensor.GroupFamily.block}
@@ -2694,34 +2835,35 @@ $\mathcal U^\dagger$; no additional boundary or Gram identities are assumed.
     \label{thm:mpug_factorization_comparison}
     \lean{Matrix.factorization_comparison_of_one_sided_inverses}
     \leanok
-    Let $A,B,C$ be finite index sets and let $\mathbb S$ be a semiring. Suppose
-    that
+    Let $A,B,\widetilde B,C$ be finite index sets, possibly empty, and let
+    $\mathbb S$ be a semiring. Suppose that
     \begin{align}
-        X,\widetilde X & \in\operatorname{Mat}_{A\times B}(\mathbb S), &
-        Y,\widetilde Y & \in\operatorname{Mat}_{B\times C}(\mathbb S),
+        X            & \in\operatorname{Mat}_{A\times B}(\mathbb S),           \\
+        Y            & \in\operatorname{Mat}_{B\times C}(\mathbb S),           \\
+        \widetilde X & \in\operatorname{Mat}_{A\times\widetilde B}(\mathbb S), \\
+        \widetilde Y & \in\operatorname{Mat}_{\widetilde B\times C}(\mathbb S)
     \end{align}
-    and $XY=\widetilde X\widetilde Y$. If
-    $L\in\operatorname{Mat}_{B\times A}(\mathbb S)$ and
+    satisfy $XY=\widetilde X\widetilde Y$. If
+    $L\in\operatorname{Mat}_{\widetilde B\times A}(\mathbb S)$ and
     $R\in\operatorname{Mat}_{C\times B}(\mathbb S)$ satisfy
-    $L\widetilde X=\mathbf 1$ and $YR=\mathbf 1$, then the comparison matrix
-    $K=LX$ obeys
+    $L\widetilde X=I_{\widetilde B}$ and $YR=I_B$, then the rectangular
+    comparison matrix $K=LX\in\operatorname{Mat}_{\widetilde B\times B}(\mathbb S)$
+    obeys
     \begin{align}
-        K & =\widetilde YR, & X & =\widetilde XK, & \widetilde Y & =KY.
-        \label{eq:mpug_factorization_comparison}
+        K            & =\widetilde YR, \\
+        X            & =\widetilde XK, \\
+        \widetilde Y & =KY.
     \end{align}
-    % Source anchor: arXiv:2502.20257, Lemma lem:deco, lines 1061--1065.
+    The intermediate index sets $B$ and $\widetilde B$ are independent;
+    no equality of their cardinalities is assumed or concluded.
     These are the one-sided-inverse identities used in the proof of
     \cite[Lemma at lines~1052--1066]{FrancoRubio2025MPUGauging}.
 \end{theorem}
-
 \begin{proof}\leanok
     Associativity and the two inverse identities give
     \begin{align}
-        LX
-         & =(LX)(YR)
-        =L(XY)R
-        =L(\widetilde X\widetilde Y)R
-        =\widetilde YR.
+        LX & =(LX)(YR)=L(XY)R
+        =L(\widetilde X\widetilde Y)R=\widetilde YR.
     \end{align}
     Multiplying $XY=\widetilde X\widetilde Y$ on the right by $R$ gives
     $X=\widetilde XK$. Multiplying it on the left by $L$ gives


### PR DESCRIPTION
## Scope
Continues #7358 after the explicit first-cut construction in #7800. Follows the inverse-comparison step at FBC25 lines 5432–5443 without identifying inverses with adjoints prematurely.

- Derive the actual source-rank equality `r[U] = ℓ[U]` from the constructed factorization and its explicit one-sided inverses. No nonzero-dimension, simplicity, or positive-weight premise is needed for this rank theorem.
- Construct the comparison `K = X̃ᴴ (I ⊗ ρ) X` and reverse comparison `J = L X̃` in the actual rectangular spaces.
- Prove six comparison/intertwining identities and `K * J = 1`, `J * K = 1`, using the gauge relation and the actual positive-definite source weight.
- Generalize the existing one-sided-inverse comparison lemma to independent intermediate index types. Its name and proof are unchanged; existing same-intermediate callers still pass strict checking.
- Update that existing generic blueprint node to match its generalized statement and cover all four new public declarations.

## Boundaries
The inverse `J` is not yet identified with `Kᴴ`; neither comparison unitarity nor the unweighted formula `K = X̃ᴴ X` is asserted. No normalized pleasant-properties package, full appendix proposition, or `eq:UUU` is claimed. The next source step is the literal u–v contraction followed by its Kronecker argument. This PR does not close #7358.

## Verification
- Author strict cached checks pass for the generic helper, first-cut predecessor, new comparison, and existing source-decomposition-uniqueness consumer.
- Independent parent strict checks pass for the generic helper, new leaf, and unchanged consumer under the actual lock, synthesis depth 3, standard linters, and warnings as errors (22 s total).
- All audited theorem dependencies are only `propext`, `Classical.choice`, and `Quot.sound`.
- Independent source/code and blueprint-equivalence reviews approve the scope and proof route.
- Current-head CI and agreeing review remain mandatory before sequential merge.
