### PR TITLE
MPU: transport packaged first factors through the unitary comparison

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -28,6 +28,7 @@ import TNLean.MPS.MPU.InverseCompatibleFirstCut
 import TNLean.MPS.MPU.InverseCompatibleGateIdentity
 import TNLean.MPS.MPU.InverseCompatibleGates
 import TNLean.MPS.MPU.InverseCompatibleSourceFactors
+import TNLean.MPS.MPU.InverseCompatibleSourceTransport
 import TNLean.MPS.MPU.KetLeftMul
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions

--- a/TNLean/MPS/MPU/InverseCompatibleSourceTransport.lean
+++ b/TNLean/MPS/MPU/InverseCompatibleSourceTransport.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.InverseCompatibleSourceFactors
+
+/-!
+# Unitary transport of the inverse-compatible source factors
+
+Let $S_0$ be the chosen source factors and $S$ the inverse-compatible source
+factors at the same canonical weight. Transport the columns of the proved
+unitary comparison $K:r\times\ell$ along the explicit rank equivalence
+$e:\operatorname{Fin}\ell\simeq\operatorname{Fin}r$ to obtain a square matrix
+$C$. Then $C$ is unitary and $S.X_1=S_0.X_1C$, $S.Y_1=C^\dagger S_0.Y_1$.
+Consequently $S.X_1S.X_1^\dagger=S_0.X_1S_0.X_1^\dagger$ and
+$S.Y_1^\dagger S.Y_1=S_0.Y_1^\dagger S_0.Y_1$.
+
+Source: arXiv:2502.20257, the comparison at lines 5432–5443, justified as
+unitary at lines 5444–5487. This is coordinate transport after that unitarity
+proof, not an assumption that the inverse comparison is an adjoint. No
+transport formula is asserted for the chosen source right inverse $Z_1$.
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D) (T : Matrix.unitaryGroup (Fin D) ℂ)
+  (hU : IsMPUCanonicalFormII U) (hsimple : IsMPUSimple U)
+  (hT : ∀ i j, physicalAdjointTensor U i j =
+    (T : Matrix (Fin D) (Fin D) ℂ)ᴴ * U i j * T)
+  (σ : ℂ) (hσ : (T : Matrix (Fin D) (Fin D) ℂ) *
+    (T : Matrix (Fin D) (Fin D) ℂ).map (starRingEnd ℂ) = σ • 1)
+
+/-- The source records are related by the actual comparison after its column
+rank index is transported. Its unitarity is inherited from the proved
+rectangular comparison, and the right-factor formula uses the proved
+identity $J=K^\dagger$.
+Source: arXiv:2502.20257, lines 5432–5443 and 5444–5487. -/
+theorem inverseCompatibleSourceFactors_unitary_transport :
+    let S₀ := sourceFactors U hU.ρ hU.ρ_posDef
+    let S := inverseCompatibleSourceFactors U T hU hsimple hT σ hσ
+    let e := inverseCompatibleRankEquiv U T hT
+    let K := inverseCompatibleComparisonK U T hU.ρ hU.ρ_posDef
+    let C := Matrix.reindex (Equiv.refl _) e K
+    C.IsUnitaryBetween ∧ S.X₁ = S₀.X₁ * C ∧ S.Y₁ = Cᴴ * S₀.Y₁ := by
+  let e := inverseCompatibleRankEquiv U T hT
+  let K := inverseCompatibleComparisonK U T hU.ρ hU.ρ_posDef
+  have hK := inverseCompatibleComparisonK_isUnitaryBetween U T hU hsimple hT σ hσ
+  have hX := (inverseCompatibleComparison U T hT hU.ρ hU.ρ_posDef).2.1
+  have hY := (inverseCompatibleComparison U T hT hU.ρ hU.ρ_posDef).2.2.2.2.2.1
+  rw [inverseCompatibleComparisonJ_eq_conjTranspose U T hU hsimple hT σ hσ] at hY
+  refine ⟨hK.reindex _ (Equiv.refl _) e, ?_, ?_⟩
+  · rw [inverseCompatibleSourceFactors_X₁, hX]
+    change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e
+        (sourceX₁ U hU.ρ hU.ρ_posDef * K) =
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _)
+        (sourceX₁ U hU.ρ hU.ρ_posDef) *
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e K
+    rw [Matrix.reindexLinearEquiv_mul]
+  · rw [inverseCompatibleSourceFactors_Y₁, hY, Matrix.conjTranspose_reindex]
+    change Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _)
+        (Kᴴ * sourceY₁ U hU.ρ hU.ρ_posDef) =
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) Kᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _)
+        (sourceY₁ U hU.ρ hU.ρ_posDef)
+    rw [Matrix.reindexLinearEquiv_mul]
+
+/-- The two first-factor Gram matrices on the external source-cut spaces
+are unchanged under the proved unitary transport. This does not compare
+chosen right inverses or assert further pleasant properties.
+Source: arXiv:2502.20257, the normalization transport at lines 5486–5487. -/
+theorem inverseCompatibleSourceFactors_gram_eq :
+    let S₀ := sourceFactors U hU.ρ hU.ρ_posDef
+    let S := inverseCompatibleSourceFactors U T hU hsimple hT σ hσ
+    S.X₁ * S.X₁ᴴ = S₀.X₁ * S₀.X₁ᴴ ∧
+      S.Y₁ᴴ * S.Y₁ = S₀.Y₁ᴴ * S₀.Y₁ := by
+  obtain ⟨hC, hX, hY⟩ :=
+    inverseCompatibleSourceFactors_unitary_transport U T hU hsimple hT σ hσ
+  let C := Matrix.reindex (Equiv.refl _) (inverseCompatibleRankEquiv U T hT)
+    (inverseCompatibleComparisonK U T hU.ρ hU.ρ_posDef)
+  have hCC : C * Cᴴ = 1 := hC.2
+  constructor
+  · rw [hX, Matrix.conjTranspose_mul]
+    calc
+      _ = (sourceFactors U hU.ρ hU.ρ_posDef).X₁ * (C * Cᴴ) *
+          (sourceFactors U hU.ρ hU.ρ_posDef).X₁ᴴ := by simp only [C, Matrix.mul_assoc]
+      _ = _ := by rw [hCC, Matrix.mul_one]
+  · rw [hY, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    calc
+      _ = (sourceFactors U hU.ρ hU.ρ_posDef).Y₁ᴴ * (C * Cᴴ) *
+          (sourceFactors U hU.ρ hU.ρ_posDef).Y₁ := by simp only [C, Matrix.mul_assoc]
+      _ = _ := by rw [hCC, Matrix.mul_one]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch29_mpu_gauging.tex
+++ b/blueprint/src/chapter/ch29_mpu_gauging.tex
@@ -1184,6 +1184,79 @@ asserted in that passage.
     formulas, since $e^{-1}(e(l))=l$.
 \end{proof}
 
+\begin{theorem}[Unitary transport of the first source factors]
+    \label{thm:mpug_inverse_source_unitary_transport}
+    \lean{MPOTensor.inverseCompatibleSourceFactors_unitary_transport,
+        MPOTensor.inverseCompatibleSourceFactors_gram_eq}
+    \leanok
+    \uses{def:mpug_inverse_compatible_source_factors,
+        def:mpug_inverse_cut_rank_equiv, def:mpug_inverse_cut_comparison_k,
+        def:mpu_weighted_source_factors, def:mpu_canonical_form_ii,
+        def:mpu_simple, def:mpdo_physical_adjoint}
+    Let $\mathcal U$ be a simple MPU of dimensions $d,D$ in canonical
+    form II, with recorded positive-definite matrix $\rho$. Suppose
+    that $T$ is unitary on $\C^D$, that
+    $(\mathcal U^\dagger)^{ij}=T^\dagger\mathcal U^{ij}T$ for every
+    physical pair $i,j$, and that $T\overline T=\sigma I_D$ for a
+    scalar $\sigma\in\C$. Let $\widetilde X_1,\widetilde Y_1$ be the
+    chosen first source factors at this same weight, and let
+    $\widehat X_1,\widehat Y_1$ be the inverse-compatible first factors
+    of Definition~\ref{def:mpug_inverse_compatible_source_factors}.
+    Put $r=\operatorname{rank}M_1(\mathcal U)$ and
+    $\ell=\operatorname{rank}M_2(\mathcal U)$. Take the weighted
+    comparison $K\colon\C^\ell\to\C^r$ of
+    Definition~\ref{def:mpug_inverse_cut_comparison_k} and the
+    permutation matrix $P_e\colon\C^\ell\to\C^r$ of
+    Definition~\ref{def:mpug_inverse_cut_rank_equiv}. The square matrix
+    $C=KP_e^\dagger$ is unitary on $\C^r$, and
+    \begin{align}
+        \widehat X_1 & =\widetilde X_1C,         \\
+        \widehat Y_1 & =C^\dagger\widetilde Y_1.
+    \end{align}
+    Consequently, the Gram matrices on the external first-cut spaces
+    are unchanged:
+    \begin{align}
+        \widehat X_1\widehat X_1^\dagger
+         & =\widetilde X_1\widetilde X_1^\dagger, \\
+        \widehat Y_1^\dagger\widehat Y_1
+         & =\widetilde Y_1^\dagger\widetilde Y_1.
+    \end{align}
+    This is the transport of the comparison in
+    \cite[lines~5432--5443]{FrancoRubio2025MPUGauging}, after its
+    unitarity is established at lines~5444--5487. It asserts no
+    transport formula for the chosen first right inverse and no
+    further pleasant properties.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpug_inverse_cut_comparison_unitary,
+        thm:mpug_inverse_cut_comparison, thm:mpug_inverse_cut_unitary_consequences,
+        def:mpug_inverse_cut_rank_equiv, def:mpug_inverse_compatible_source_factors}
+    The comparison results give $K^\dagger K=I_\ell$, $KK^\dagger=I_r$,
+    $X=\widetilde X_1K$, and $Y=K^\dagger\widetilde Y_1$ for the
+    untransported candidates $X,Y$. Reindexing the columns of $K$
+    along $e$ gives $C=KP_e^\dagger$. Since $P_e$ identifies the two
+    coordinate bases,
+    \begin{align}
+        C^\dagger C & =P_eK^\dagger KP_e^\dagger=I_r, \\
+        CC^\dagger  & =KP_e^\dagger P_eK^\dagger=I_r.
+    \end{align}
+    Reindexing the two candidate factors gives
+    \begin{align}
+        \widehat X_1 & =XP_e^\dagger
+        =\widetilde X_1KP_e^\dagger=\widetilde X_1C, \\
+        \widehat Y_1 & =P_eY
+        =P_eK^\dagger\widetilde Y_1=C^\dagger\widetilde Y_1.
+    \end{align}
+    Cancel $CC^\dagger$ in the external Gram matrices:
+    \begin{align}
+        \widehat X_1\widehat X_1^\dagger
+         & =\widetilde X_1(CC^\dagger)\widetilde X_1^\dagger
+        =\widetilde X_1\widetilde X_1^\dagger,               \\
+        \widehat Y_1^\dagger\widehat Y_1
+         & =\widetilde Y_1^\dagger(CC^\dagger)\widetilde Y_1
+        =\widetilde Y_1^\dagger\widetilde Y_1.
+    \end{align}
+\end{proof}
 \begin{definition}[Literal gates on the common second-cut space]
     \label{def:mpug_inverse_compatible_gates}
     \lean{MPOTensor.inverseCompatibleU, MPOTensor.inverseCompatibleV}

--- a/docs/paper-gaps/fbc25_inverse_compatible_tilde_omission.tex
+++ b/docs/paper-gaps/fbc25_inverse_compatible_tilde_omission.tex
@@ -97,7 +97,7 @@ If $T\overline T=\sigma I_D$, unitarity of $T$ also gives $\overline T T=\sigma 
 Equation~(\ref{eq:fbc25_inverse_tilde_contraction}) locates the use of the corrected factor: its $K$ supplies the right-hand comparison in the contraction. The row orders in
 (\ref{eq:fbc25_inverse_tilde_gate_identity}) are $(\ell,r)$ for $u$ and $(r,\ell)$ for $v^\dagger$; the Kronecker product maps between them without an additional swap. This is precisely the algebraic gate identity displayed by the source
 \cite[lines~5484--5486]{FrancoRubio2025MPUGauging}.\footnote{The adjointed comparison and gate contraction are recorded in
-    \leanid{MPOTensor.sourceY}\textsubscript{2}\leanid{_eq_inverseCompatibleComparisonK_adjoint} and
+    \leanid{MPOTensor.sourceY₂_eq_inverseCompatibleComparisonK_adjoint} and
     \leanid{MPOTensor.sourceU_eq_smul_inverseCompatibleComparisonK_kronecker_sourceV_adjoint}, in
     \doclink{TNLean/MPS/MPU/InverseCompatibleGateIdentity}.}
 


### PR DESCRIPTION
## Summary
Continues #7804 and advances #7358 by explicit rank-coordinate transport after the already proved comparison unitarity.

- Reindexes the rectangular weighted comparison K into a square unitary C on the original first-rank space.
- Proves Xnew = Xold C and Ynew = C† Yold.
- Derives the two external-space Gram equalities by unitary cancellation.
- Covers both public theorems in one coherent blueprint node, with all hypotheses and source proof dependencies explicit.

No transport of the arbitrary old right inverse Z1 is asserted. This is not a new route to proving K-unitarity and does not claim the remaining pleasant properties or final truncated-chain identity.

## Verification
Author and parent strict cached leaf checks under the actual lock passed with depth3, standard linters, and warnings as errors. Both theorem axiom audits use only propext, Classical.choice, Quot.sound. Independent source/code/blueprint review approved. Actual latexindent3.24.7 fixed-point and bounded before/after bibliography-inclusive renders passed with identical diagnostics; affected pages visually checked. Declaration synchronization and changed-declaration coverage passed.

Propagated parent citation/classification, omitted-tilde documentation, and proof-only fusion timing repairs are included through the parent stack. Fresh current-head CI and agreeing review remain merge requirements.
