### PR TITLE
fix(MPS/MPDO): show the CZX coefficient substitution and bind repeated calculations

### DIFF
--- a/TNLean/MPS/MPDO/CZXFusionActionCoordinates.lean
+++ b/TNLean/MPS/MPDO/CZXFusionActionCoordinates.lean
@@ -95,8 +95,9 @@ theorem fusionAction_finite_identities (x : Fin 2) :
     fusionActionLetter x * fusionW =
       fusionActionCoefficient x • (fusionActionLetter x * sequentialActionKet x) ∧
     fusionActionLetter x * fusionActionLetter x = fusionActionLetter x := by
-  rw [(fusionAction_finite_calculation x).1]
-  exact (fusionAction_finite_calculation x).2
+  have hcalc := fusionAction_finite_calculation x
+  rw [hcalc.1]
+  exact hcalc.2
 
 /-- Positive repetitions of the supported letter preserve both contractions and
 open-boundary proportionality. This is a matrix consequence of the literal CZX
@@ -108,14 +109,14 @@ theorem fusionAction_positive_power (x : Fin 2) (n : ℕ) :
     (sequentialActionBra x * fusionActionLetter x ^ (n + 1) * sequentialActionKet x) 0 0 = 1 ∧
     fusionActionLetter x ^ (n + 1) * fusionW =
       fusionActionCoefficient x • (fusionActionLetter x ^ (n + 1) * sequentialActionKet x) := by
+  have hid := fusionAction_finite_identities x
   have hp : fusionActionLetter x ^ (n + 1) = fusionActionLetter x := by
     induction n with
     | zero => simp
     | succ n ih =>
       rw [pow_succ, ih]
-      exact (fusionAction_finite_identities x).2.2
+      exact hid.2.2
   rw [hp]
-  exact ⟨rfl, rfl, (fusionAction_finite_identities x).1,
-    (fusionAction_finite_identities x).2.1⟩
+  exact ⟨rfl, rfl, hid.1, hid.2.1⟩
 
 end MPOTensor.CZX

--- a/docs/paper-gaps/fbc25_czx_fusion_coordinate_compatibility.tex
+++ b/docs/paper-gaps/fbc25_czx_fusion_coordinate_compatibility.tex
@@ -91,10 +91,15 @@ Let $e_0,e_1,e_2,e_3$ denote the standard basis of the product virtual space. Mu
 Consequently the coefficient is uniquely determined:
 \begin{align}
     c_x  & :=P_xB_xW,
-         & c_0                & =1, & c_1 & =-1,
-    \label{eq:fbc25_czx_compat_coefficients}     \\
+    \label{eq:fbc25_czx_compat_coefficients} \\
+    c_0  & =P_0(ie_1)=(-i)(i)=1, \notag      \\
+    c_1  & =P_1(-ie_2)=(-i)(-i)=-1, \notag   \\
     B_xW & =c_xB_xQ_x. \notag
 \end{align}
+The two substitutions pair the values of $B_0W$ and $B_1W$ in
+(\ref{eq:fbc25_czx_compat_normalization_idempotence}) with the second and third
+entries of $P_0$ and $P_1$ in
+(\ref{eq:fbc25_czx_compat_product_columns}).
 Indeed, applying $P_x$ to any proposed proportionality and using
 (\ref{eq:fbc25_czx_compat_normalization_idempotence}) recovers its coefficient. For every integer $n\geq1$, idempotence also gives
 \begin{align}

--- a/docs/paper-gaps/fbc25_czx_fusion_coordinate_compatibility.tex
+++ b/docs/paper-gaps/fbc25_czx_fusion_coordinate_compatibility.tex
@@ -90,8 +90,7 @@ Let $e_0,e_1,e_2,e_3$ denote the standard basis of the product virtual space. Mu
 \end{align}
 Consequently the coefficient is uniquely determined:
 \begin{align}
-    c_x  & :=P_xB_xW,
-    \label{eq:fbc25_czx_compat_coefficients} \\
+    c_x  & :=P_xB_xW, \label{eq:fbc25_czx_compat_coefficients} \\
     c_0  & =P_0(ie_1)=(-i)(i)=1, \notag      \\
     c_1  & =P_1(-ie_2)=(-i)(-i)=-1, \notag   \\
     B_xW & =c_xB_xQ_x. \notag


### PR DESCRIPTION
### Motivation

Three review threads on #7799 were still open when that PR merged — two of them
posted minutes before the merge. This PR addresses all three against `main`.

### Description

- `docs/paper-gaps/fbc25_czx_fusion_coordinate_compatibility.tex` — the display
  defining `c_x := P_xB_xW` jumped straight to `c_0=1, c_1=-1`, which
  `docs/paper-gaps/policy.tex` forbids ("do not compress a proof gap into one
  implication when the missing step occurs within a calculation"). The two
  substitutions `c_0 = P_0(ie_1) = (-i)(i) = 1` and
  `c_1 = P_1(-ie_2) = (-i)(-i) = -1` are now displayed, with a sentence naming
  the two equations they read from.
- `TNLean/MPS/MPDO/CZXFusionActionCoordinates.lean` — `fusionAction_finite_identities`
  referenced `fusionAction_finite_calculation x` twice and
  `fusionAction_positive_power` referenced `fusionAction_finite_identities x`
  three times, duplicating large proof terms. Each now binds the result once.
- The third thread asked for `TNLean/MPS/MPDO.lean` to be regenerated rather than
  hand-edited. Running `python3 scripts/generate_import_aggregators.py` on `main`
  produces no diff, so the file already matches canonical generator output; no
  change was needed and the thread is answered on #7799.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.MPDO.CZXFusionActionCoordinates`: success, zero warnings.
- `texra-blueprint paper-gaps check`: 131 slugs resolve.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEiwoMV4h8dRKocFATHCRZ
