### PR TITLE
doc(MPS/Examples): sync the cluster citation range and cite the scope note

### DIFF
--- a/TNLean/MPS/Examples/ClusterParentHamiltonian.lean
+++ b/TNLean/MPS/Examples/ClusterParentHamiltonian.lean
@@ -58,7 +58,7 @@ source's matrices.
 * Pérez-García--Verstraete--Wolf--Cirac 2007, arXiv:quant-ph/0608197, local
   TeX lines 374--387.
 * Cirac--Pérez-García--Schuch--Verstraete 2021, arXiv:2011.12127,
-  lines 2364--2371 (the tensor).
+  lines 2364--2369 (the tensor).
 -/
 
 open scoped Matrix BigOperators

--- a/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
+++ b/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
@@ -354,6 +354,9 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     $\bra{\pm}\sigma^x = \pm\bra{\pm}$ the states differ by $\sigma^z$ on
     every site, which conjugates each $K_i$ to $-K_i$ and exchanges the two
     Hamiltonians $\sum_i K_i$ and $-\sum_i K_i = \sum_i(\Id-K_i) - N\Id$.
+    The scope of what is established here for the printed cluster matrices, and
+    what is left aside, is recorded in
+    \cite{gap:rmp_example_parent_hamiltonian_scope}.
 \end{remark}
 
 \begin{theorem}[AKLT two-site parent space]\label{thm:aklt_ground_space_two}
@@ -541,7 +544,9 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
          & = 1
         \notag
     \end{align}
-    \cite[lines~1169--1174]{Cirac2021Matrix}.
+    \cite[lines~1169--1174]{Cirac2021Matrix}. Which of the review's AKLT
+    statements are established here, and which are left aside, is recorded in
+    \cite{gap:rmp_example_parent_hamiltonian_scope}.
     % Neither the polynomial form nor the open-boundary degeneracy is
     % formalized; the periodic two-site uniqueness is
     % thm:aklt_chain_ground_space_two.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -756,6 +756,16 @@
   note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/cpsv16_parent_hamiltonian_range_short_ring.pdf}},
 }
 
+@techreport{gap:rmp_example_parent_hamiltonian_scope,
+  author      = {The {TNLean} contributors},
+  title       = {Example Parent Hamiltonians in Cirac--P{\'e}rez-Garc{\'i}a--Schuch--Verstraete 2021},
+  institution = {TNLean},
+  type        = {Paper-gap note},
+  number      = {rmp\_example\_parent\_hamiltonian\_scope},
+  year        = {2026},
+  note        = {\url{https://sirui-lu.com/TNLean/paper-gaps/rmp_example_parent_hamiltonian_scope.pdf}},
+}
+
 @techreport{gap:cpgsv17_mpdo_sal_zcl_eta_local_structure,
   author      = {The {TNLean} contributors},
   title       = {The {SAL} to Eta-Local Structure Step in {Cirac}--{Perez-Garcia}--{Schuch}--{Verstraete} 2017 Appendix {C}.2},


### PR DESCRIPTION
### Motivation

Two review threads raised on #7802 concern content that reached that branch
through `main` (from #7767), not through the PR's own commits — the flagged
files are byte-identical to `main` there. Both points are valid against `main`,
so they are fixed here.

### Description

- `TNLean/MPS/Examples/ClusterParentHamiltonian.lean` cited
  `lines 2364--2371` of the review for the cluster tensor while
  `blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex` cites
  `2364--2369` twice for the same statement. In `Papers/2011.12127`, the
  cluster-state subsubsection runs 2364--2369 and lines 2370--2371 are blank,
  so the chapter's range is the correct one; the docstring now matches.
- The cluster-stabilizer and AKLT remarks now cite
  `docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex`, the
  `\gapnote{scope-restriction}{open}` note recording what those formalizations
  leave aside, with a `@techreport` bibliography entry following the existing
  paper-gap citation convention.

### Testing

- `scripts/lake_build_locked.sh TNLean.MPS.Examples.ClusterParentHamiltonian`: success, zero warnings.
- `texra-blueprint paper-gaps check`: 131 slugs resolve.
- `scripts/latexindent -l blueprint/latexindent.yaml` applied to the changed chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEiwoMV4h8dRKocFATHCRZ
