### PR TITLE
feat(MPS/Examples): prove the source cluster ground-state theorem

### DIFF
--- a/TNLean/MPS/Examples.lean
+++ b/TNLean/MPS/Examples.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.Examples.AKLTRotation
 import TNLean.MPS.Examples.AKLTStringOrder
 import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.ClusterParentHamiltonian
+import TNLean.MPS.Examples.ClusterSourceGroundState
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.GHZCluster

--- a/TNLean/MPS/Examples/ClusterParentHamiltonian.lean
+++ b/TNLean/MPS/Examples/ClusterParentHamiltonian.lean
@@ -286,23 +286,22 @@ private lemma clusterStabilizer_cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (hN3 : 
   rw [← update_one_eq]
   exact (update_cyclicCfg hN hN3 i s τ 1 (s 1 + 1)).symm
 
-/-- A periodic vector is fixed by \(K_i\) exactly when all its cyclic windows at
-\(i\) are fixed by the three-site stabilizer. -/
+/-- A periodic vector has stabilizer eigenvalue \(\mu\) exactly when all its
+cyclic windows have that eigenvalue for the three-site stabilizer. -/
 private lemma mem_eigenspace_clusterChainStabilizer_iff {N : ℕ} (hN : 0 < N) (hN3 : 3 ≤ N)
-    (i : Fin N) (ψ : NSiteSpace 2 N) :
-    ψ ∈ Module.End.eigenspace (clusterChainStabilizer i) 1 ↔
+    (i : Fin N) (ψ : NSiteSpace 2 N) (μ : ℂ) :
+    ψ ∈ Module.End.eigenspace (clusterChainStabilizer i) μ ↔
       ∀ τ : Fin N → Fin 2,
-        cyclicRestrictₗ hN 3 i τ ψ ∈ Module.End.eigenspace clusterStabilizer 1 := by
-  simp only [Module.End.mem_eigenspace_iff, one_smul]
+        cyclicRestrictₗ hN 3 i τ ψ ∈ Module.End.eigenspace clusterStabilizer μ := by
+  simp only [Module.End.mem_eigenspace_iff]
   constructor
   · intro hψ τ
-    rw [clusterStabilizer_cyclicRestrictₗ hN hN3, hψ]
+    rw [clusterStabilizer_cyclicRestrictₗ hN hN3, hψ, map_smul]
   · intro hτ
     ext σ
     have hσ := congrFun (hτ σ) (extractWindow 3 i σ)
-    rw [clusterStabilizer_cyclicRestrictₗ hN hN3, cyclicRestrictₗ_apply, cyclicRestrictₗ_apply,
-      cyclicCfg_extractWindow hN hN3] at hσ
-    exact hσ
+    rw [clusterStabilizer_cyclicRestrictₗ hN hN3] at hσ
+    simpa only [Pi.smul_apply, cyclicRestrictₗ_apply, cyclicCfg_extractWindow hN hN3] using hσ
 
 /-- **The common \(+1\) eigenspace of the translated stabilizers is the periodic
 three-site chain ground space** of the cluster tensor, for \(N\ge3\). -/
@@ -314,7 +313,20 @@ theorem cluster_iInf_eigenspace_eq_chainGroundSpace {N : ℕ} (hN : 3 ≤ N) :
   ext ψ
   simp only [Submodule.mem_iInf, Submodule.mem_comap,
     cluster_groundSpace_three_eq_eigenspace]
-  exact forall_congr' fun i => mem_eigenspace_clusterChainStabilizer_iff hNpos hN i ψ
+  exact forall_congr' fun i => mem_eigenspace_clusterChainStabilizer_iff hNpos hN i ψ 1
+
+/-- For the cluster matrices printed in Pérez-García--Verstraete--Wolf--Cirac
+2007 (arXiv:quant-ph/0608197, local TeX lines 374--387), the periodic three-site
+ground space is the common \(-1\) eigenspace of the translated stabilizers. -/
+theorem clusterSource_iInf_eigenspace_eq_chainGroundSpace {N : ℕ} (hN : 3 ≤ N) :
+    (⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1)) =
+      chainGroundSpace clusterSourceTensor 3 N := by
+  have hNpos : 0 < N := by omega
+  rw [chainGroundSpace, dite_eq_left ⟨hNpos, hN⟩]
+  ext ψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap,
+    clusterSource_groundSpace_three_eq_eigenspace_neg_one]
+  exact forall_congr' fun i => mem_eigenspace_clusterChainStabilizer_iff hNpos hN i ψ (-1)
 
 /-- **The cluster state spans the common \(+1\) eigenspace of the stabilizers**
 \(K_i = \sigma^z_i\sigma^x_{i+1}\sigma^z_{i+2}\): on a periodic chain of

--- a/TNLean/MPS/Examples/ClusterSourceGroundState.lean
+++ b/TNLean/MPS/Examples/ClusterSourceGroundState.lean
@@ -1,0 +1,485 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Examples.ClusterParentHamiltonian
+import TNLean.Algebra.ListProduct
+import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.SharedInfra.Scaling
+
+/-!
+# Ground state of the source cluster tensor
+
+The matrices displayed for the one-dimensional cluster state in
+Pérez-García--Verstraete--Wolf--Cirac, arXiv:quant-ph/0608197, local TeX lines
+374--387, use the opposite stabilizer sign from `clusterTensor`. This module
+transports the established cluster-state results through the explicit virtual
+gauge and the physical action of `Z` on every site. It also proves the bottom
+eigenspace and energy bound for the corresponding stabilizer sum by the same
+sum-of-squares argument.
+
+## Main statements
+
+* `clusterSource_mpv_eq_globalZ` and `clusterSource_mpv_ne_zero` identify the
+  source MPV with the globally `Z`-rotated cluster MPV and prove nonvanishing.
+* `clusterSource_iInf_eigenspace_eq_mpvSubmodule` and
+  `clusterSource_stabilizer_unique_gs` identify the common `-1` stabilizer
+  eigenspace and prove its uniqueness.
+* `clusterSource_hamiltonian_eigenspace_eq_mpvSubmodule` and
+  `clusterSource_energy_lower_bound` identify the bottom eigenspace of the
+  stabilizer sum and prove its energy lower bound.
+
+## References
+
+* Pérez-García--Verstraete--Wolf--Cirac 2007, arXiv:quant-ph/0608197, local
+  TeX lines 374--387.
+-/
+
+open scoped BigOperators Matrix ComplexConjugate
+
+namespace MPSTensor
+
+noncomputable section
+
+/-- A virtual gauge relating the source and cluster tensors. -/
+private def G : Matrix (Fin 2) (Fin 2) ℂ := !![1, -1; 1, 1]
+
+/-- The inverse of `G`. -/
+private def Ginv : Matrix (Fin 2) (Fin 2) ℂ := !![1 / 2, 1 / 2; -1 / 2, 1 / 2]
+
+private lemma gauge_inv : G * Ginv = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [G, Ginv, Matrix.mul_apply, Fin.sum_univ_two]
+
+private lemma inv_gauge : Ginv * G = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [G, Ginv, Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- The pointwise gauge and physical-sign identity for the two tensors. -/
+private lemma source_tensor_relation (t : Fin 2) :
+    (↑(1 / Real.sqrt 2) : ℂ) • clusterSourceTensor t =
+      (-1 : ℂ) ^ t.val • (G * clusterTensor t * Ginv) := by
+  fin_cases t <;> ext i j <;> fin_cases i <;> fin_cases j <;>
+    simp [G, Ginv, clusterSourceTensor, clusterTensor] <;> ring
+
+/-- The global sign picked up by applying `Z` at every site. -/
+private def paritySign {N : ℕ} (s : Fin N → Fin 2) : ℂ :=
+  ∏ i : Fin N, (-1 : ℂ) ^ (s i).val
+
+/-- The coefficient-space action of on-site `Z` at every site. -/
+private def globalZ {N : ℕ} : NSiteSpace 2 N →ₗ[ℂ] NSiteSpace 2 N where
+  toFun v s := paritySign s * v s
+  map_add' v w := by
+    ext s
+    simp only [mul_add, Pi.add_apply]
+  map_smul' c v := by
+    ext s
+    simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul]
+    ring
+
+@[simp] private lemma globalZ_apply {N : ℕ} (v : NSiteSpace 2 N) (s : Fin N → Fin 2) :
+    globalZ v s = paritySign s * v s := rfl
+
+/-- The invertible virtual gauge relating the source and cluster tensors. -/
+private def Gunit : GL (Fin 2) ℂ where
+  val := G
+  inv := Ginv
+  val_inv := gauge_inv
+  inv_val := inv_gauge
+
+@[simp] private lemma Gunit_val : (Gunit : Matrix (Fin 2) (Fin 2) ℂ) = G := rfl
+
+@[simp] private lemma Gunit_inv_val :
+    ((Gunit⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = Ginv := rfl
+
+/-- The global on-site `Z` action multiplies every cluster coefficient by its parity sign. -/
+private lemma mpv_signedCluster {N : ℕ} (s : Fin N → Fin 2) :
+    mpv (fun t : Fin 2 => (-1 : ℂ) ^ t.val • clusterTensor t) s =
+      paritySign s * mpv clusterTensor s := by
+  simp only [mpv, coeff, evalWord_ofFn_eq_prod]
+  rw [List.prod_ofFn_smul, Matrix.trace_smul]
+  rfl
+
+/-- The normalized source tensor is gauge-equivalent to the physically
+`Z`-rotated cluster tensor. -/
+private lemma scaledSource_gauge_rotatedCluster :
+    GaugeEquiv (fun t : Fin 2 => (-1 : ℂ) ^ t.val • clusterTensor t)
+      (fun t : Fin 2 => (↑(1 / Real.sqrt 2) : ℂ) • clusterSourceTensor t) := by
+  refine ⟨Gunit, fun t => ?_⟩
+  change (↑(1 / Real.sqrt 2) : ℂ) • clusterSourceTensor t =
+    G * (((-1 : ℂ) ^ t.val) • clusterTensor t) * Ginv
+  rw [source_tensor_relation]
+  simp only [Matrix.mul_smul, Matrix.smul_mul]
+
+/-- The source MPV is `sqrt(2)^N` times the global on-site `Z` transform of the
+normalized library cluster MPV.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_mpv_eq_globalZ {N : ℕ} (_hN : 3 ≤ N) (s : Fin N → Fin 2) :
+    mpv clusterSourceTensor s = (↑(Real.sqrt 2) : ℂ) ^ N *
+      (∏ i, (-1 : ℂ) ^ (s i).val) * mpv clusterTensor s := by
+  have hsqrtR : Real.sqrt 2 ≠ 0 := ne_of_gt (Real.sqrt_pos.2 (by norm_num))
+  have hgauge := scaledSource_gauge_rotatedCluster.sameMPV N s
+  rw [mpv_smul, mpv_signedCluster] at hgauge
+  change _ = (↑(Real.sqrt 2) : ℂ) ^ N * paritySign s * mpv clusterTensor s
+  calc
+    mpv clusterSourceTensor s =
+        (↑(Real.sqrt 2) : ℂ) ^ N *
+          ((↑(1 / Real.sqrt 2) : ℂ) ^ N * mpv clusterSourceTensor s) := by
+            rw [← mul_assoc, ← mul_pow]
+            simp [hsqrtR]
+    _ = (↑(Real.sqrt 2) : ℂ) ^ N *
+          (paritySign s * mpv clusterTensor s) := by rw [hgauge]
+    _ = _ := by ring
+
+/-- Bundled vector form of `clusterSource_mpv_eq_globalZ`. -/
+private lemma source_mpv_vector_relation {N : ℕ} (hN : 3 ≤ N) :
+    (mpv clusterSourceTensor : NSiteSpace 2 N) =
+      (↑(Real.sqrt 2) : ℂ) ^ N • globalZ (mpv clusterTensor) := by
+  funext s
+  simp only [Pi.smul_apply, smul_eq_mul, globalZ_apply]
+  simpa only [paritySign, mul_assoc] using clusterSource_mpv_eq_globalZ hN s
+
+/-- Flipping the qubit at `j`. -/
+private def flipConfig {N : ℕ} (j : Fin N) (s : Fin N → Fin 2) : Fin N → Fin 2 :=
+  Function.update s j (s j + 1)
+
+private lemma flipConfig_involutive {N : ℕ} (j : Fin N) :
+    Function.Involutive (flipConfig j) := by
+  intro s
+  funext k
+  by_cases hkj : k = j
+  · subst k
+    simp only [flipConfig, Function.update_self]
+    generalize s j = x
+    fin_cases x <;> rfl
+  · simp [flipConfig, hkj]
+
+private lemma flipConfig_bijective {N : ℕ} (j : Fin N) :
+    Function.Bijective (flipConfig j) :=
+  (flipConfig_involutive j).bijective
+
+private lemma paritySign_ne_zero {N : ℕ} (s : Fin N → Fin 2) :
+    paritySign s ≠ 0 := by
+  simp only [paritySign]
+  apply Finset.prod_ne_zero_iff.mpr
+  intro i _
+  exact pow_ne_zero _ (by norm_num)
+
+private lemma paritySign_sq {N : ℕ} (s : Fin N → Fin 2) :
+    paritySign s * paritySign s = 1 := by
+  simp only [paritySign, ← Finset.prod_mul_distrib]
+  apply Finset.prod_eq_one
+  intro i _
+  generalize s i = x
+  fin_cases x <;> norm_num
+
+private lemma paritySign_flip {N : ℕ} (j : Fin N) (s : Fin N → Fin 2) :
+    paritySign (flipConfig j s) = -paritySign s := by
+  simp only [paritySign]
+  rw [Fintype.prod_eq_prod_compl_mul j, Fintype.prod_eq_prod_compl_mul j]
+  have hcompl :
+      (∏ i ∈ {j}ᶜ, (-1 : ℂ) ^ ((flipConfig j s i).val)) =
+        ∏ i ∈ {j}ᶜ, (-1 : ℂ) ^ ((s i).val) := by
+    apply Finset.prod_congr rfl
+    intro i hi
+    have hij : i ≠ j := by simpa using hi
+    simp [flipConfig, hij]
+  rw [hcompl]
+  have hsite :
+      (-1 : ℂ) ^ ((flipConfig j s j).val) = -((-1 : ℂ) ^ ((s j).val)) := by
+    simp only [flipConfig, Function.update_self]
+    generalize s j = x
+    fin_cases x
+    · norm_num
+    · norm_num [Fin.add_def]
+  rw [hsite]
+  ring
+
+private lemma globalZ_involutive {N : ℕ} :
+    Function.Involutive (fun v : NSiteSpace 2 N => globalZ v) := by
+  intro v
+  ext s
+  simp only [globalZ_apply]
+  rw [← mul_assoc, paritySign_sq]
+  simp
+
+private lemma globalZ_injective {N : ℕ} :
+    Function.Injective (fun v : NSiteSpace 2 N => globalZ v) :=
+  globalZ_involutive.injective
+
+/-- Applying on-site `Z` at every site anticommutes with every translated `ZXZ`
+stabilizer. -/
+private lemma globalZ_anticommute {N : ℕ} (i : Fin N) (v : NSiteSpace 2 N) :
+    clusterChainStabilizer i (globalZ v) = -globalZ (clusterChainStabilizer i v) := by
+  ext s
+  simp only [clusterChainStabilizer_apply, globalZ_apply, Pi.neg_apply]
+  change
+    (-1 : ℂ) ^ ((s i).val + (s (cyclicForwardSite i 2)).val) *
+        (paritySign (flipConfig (cyclicForwardSite i 1) s) *
+          v (flipConfig (cyclicForwardSite i 1) s)) =
+      -(paritySign s *
+        ((-1 : ℂ) ^ ((s i).val + (s (cyclicForwardSite i 2)).val) *
+          v (flipConfig (cyclicForwardSite i 1) s)))
+  rw [paritySign_flip]
+  ring
+
+private lemma globalZ_mem_common_neg_of_plus {N : ℕ} (v : NSiteSpace 2 N)
+    (hv : v ∈ ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) 1) :
+    globalZ v ∈ ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1) := by
+  rw [Submodule.mem_iInf] at hv ⊢
+  intro i
+  have hi := hv i
+  rw [Module.End.mem_eigenspace_iff] at hi ⊢
+  rw [globalZ_anticommute, hi]
+  simp
+
+private lemma globalZ_mem_common_plus_of_neg {N : ℕ} (v : NSiteSpace 2 N)
+    (hv : v ∈ ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1)) :
+    globalZ v ∈ ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) 1 := by
+  rw [Submodule.mem_iInf] at hv ⊢
+  intro i
+  have hi := hv i
+  rw [Module.End.mem_eigenspace_iff] at hi ⊢
+  rw [globalZ_anticommute, hi]
+  simp
+
+private lemma source_span_eq_globalZ_cluster_span {N : ℕ} (hN : 3 ≤ N) :
+    mpvSubmodule clusterSourceTensor N =
+      Submodule.span ℂ {globalZ (mpv clusterTensor : NSiteSpace 2 N)} := by
+  rw [mpvSubmodule, source_mpv_vector_relation hN]
+  apply Submodule.span_singleton_smul_eq
+  exact (isUnit_iff_ne_zero.mpr (pow_ne_zero N
+    (Complex.ofReal_ne_zero.mpr (ne_of_gt (Real.sqrt_pos.2 (by norm_num))))))
+
+/-- Nonvanishing transported from the normalized cluster MPV through the
+invertible global `Z` action and the nonzero scalar `sqrt(2)^N`.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_mpv_ne_zero {N : ℕ} (hN : 3 ≤ N) :
+    (mpv clusterSourceTensor : NSiteSpace 2 N) ≠ 0 := by
+  have hcluster : (mpv clusterTensor : NSiteSpace 2 N) ≠ 0 :=
+    mpv_ne_zero_of_isNBlkInjective cluster_isNBlkInjective_two
+      (by norm_num) (by omega)
+  intro hsource
+  have hrel := source_mpv_vector_relation hN
+  rw [hsource] at hrel
+  have hz : globalZ (mpv clusterTensor : NSiteSpace 2 N) = 0 := by
+    apply (smul_eq_zero.mp hrel.symm).resolve_left
+    exact pow_ne_zero N
+      (Complex.ofReal_ne_zero.mpr (ne_of_gt (Real.sqrt_pos.2 (by norm_num))))
+  exact hcluster (globalZ_injective (by simpa using hz))
+
+/-- The common source `-1` eigenspace is obtained from the normalized cluster
+`+1` eigenspace by the involutive global on-site `Z` action.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_iInf_eigenspace_eq_mpvSubmodule {N : ℕ} (hN : 3 ≤ N) :
+    (⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1)) =
+      mpvSubmodule clusterSourceTensor N := by
+  rw [source_span_eq_globalZ_cluster_span hN]
+  apply le_antisymm
+  · intro v hv
+    have hzplus := globalZ_mem_common_plus_of_neg v hv
+    have hzspan : globalZ v ∈ mpvSubmodule clusterTensor N := by
+      rw [← cluster_iInf_eigenspace_eq_mpvSubmodule hN]
+      exact hzplus
+    rw [mpvSubmodule, Submodule.mem_span_singleton] at hzspan
+    rw [Submodule.mem_span_singleton]
+    obtain ⟨c, hc⟩ := hzspan
+    refine ⟨c, ?_⟩
+    have hzc := congrArg (fun w : NSiteSpace 2 N => globalZ w) hc
+    simpa only [map_smul, globalZ_involutive v] using hzc
+  · intro v hv
+    rw [Submodule.mem_span_singleton] at hv
+    obtain ⟨c, hc⟩ := hv
+    have hzc := congrArg (fun w : NSiteSpace 2 N => globalZ w) hc
+    have hzspan : globalZ v ∈ mpvSubmodule clusterTensor N := by
+      rw [mpvSubmodule, Submodule.mem_span_singleton]
+      refine ⟨c, ?_⟩
+      simpa only [map_smul,
+        globalZ_involutive (mpv clusterTensor : NSiteSpace 2 N)] using hzc
+    have hzplus : globalZ v ∈
+        ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) 1 := by
+      rw [cluster_iInf_eigenspace_eq_mpvSubmodule hN]
+      exact hzspan
+    have hneg := globalZ_mem_common_neg_of_plus (globalZ v) hzplus
+    simpa only [globalZ_involutive v] using hneg
+
+/-- Uniqueness follows from the transported one-dimensional span, without an
+injectivity proof for the source matrices.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_stabilizer_unique_gs {N : ℕ} (hN : 3 ≤ N) :
+    HasUniqueGroundState
+      (⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1)) := by
+  rw [clusterSource_iInf_eigenspace_eq_mpvSubmodule hN, mpvSubmodule]
+  exact finrank_span_singleton (clusterSource_mpv_ne_zero hN)
+
+/-! ### The stabilizer sum as a sum of squares -/
+
+private def coefficientNormSq {N : ℕ} (v : NSiteSpace 2 N) : ℝ :=
+  ∑ s, Complex.normSq (v s)
+
+private def stabilizerEnergy {N : ℕ} (i : Fin N) (v : NSiteSpace 2 N) : ℝ :=
+  ∑ s, (star (v s) * (clusterChainStabilizer i v) s).re
+
+private def hamiltonianEnergy {N : ℕ} (v : NSiteSpace 2 N) : ℝ :=
+  ∑ s, (star (v s) * ((∑ i : Fin N, clusterChainStabilizer i) v) s).re
+
+private lemma normSq_add_eq_star_mul_re (z w : ℂ) :
+    Complex.normSq (z + w) =
+      Complex.normSq z + Complex.normSq w + 2 * (star z * w).re := by
+  rw [Complex.normSq_add]
+  change Complex.normSq z + Complex.normSq w + 2 * (z * conj w).re =
+    Complex.normSq z + Complex.normSq w + 2 * (conj z * w).re
+  simp only [Complex.mul_re, Complex.conj_re, Complex.conj_im]
+  ring
+
+private lemma stabilizer_normSq_apply {N : ℕ} (i : Fin N) (v : NSiteSpace 2 N)
+    (s : Fin N → Fin 2) :
+    Complex.normSq ((clusterChainStabilizer i v) s) =
+      Complex.normSq (v (flipConfig (cyclicForwardSite i 1) s)) := by
+  simp only [clusterChainStabilizer_apply]
+  change Complex.normSq
+      ((-1 : ℂ) ^ ((s i).val + (s (cyclicForwardSite i 2)).val) *
+        v (flipConfig (cyclicForwardSite i 1) s)) = _
+  rw [Complex.normSq_mul, map_pow]
+  norm_num
+
+private lemma stabilizer_preserves_coefficientNormSq {N : ℕ} (i : Fin N)
+    (v : NSiteSpace 2 N) :
+    ∑ s, Complex.normSq ((clusterChainStabilizer i v) s) = coefficientNormSq v := by
+  simp_rw [stabilizer_normSq_apply]
+  exact (flipConfig_bijective (cyclicForwardSite i 1)).sum_comp
+    (fun s => Complex.normSq (v s))
+
+private lemma hamiltonianEnergy_eq_sum_stabilizerEnergy {N : ℕ}
+    (v : NSiteSpace 2 N) :
+    hamiltonianEnergy v = ∑ i : Fin N, stabilizerEnergy i v := by
+  unfold hamiltonianEnergy stabilizerEnergy
+  calc
+    (∑ s, (star (v s) * ((∑ i : Fin N, clusterChainStabilizer i) v) s).re) =
+        ∑ s, ∑ i : Fin N,
+          (star (v s) * (clusterChainStabilizer i v) s).re := by
+            apply Finset.sum_congr rfl
+            intro s _
+            simp only [LinearMap.sum_apply, Finset.sum_apply, Finset.mul_sum,
+              Complex.re_sum]
+    _ = _ := Finset.sum_comm
+
+private lemma stabilizer_sumOfSquares {N : ℕ} (i : Fin N) (v : NSiteSpace 2 N) :
+    (∑ s, Complex.normSq (v s + (clusterChainStabilizer i v) s)) =
+      2 * (coefficientNormSq v + stabilizerEnergy i v) := by
+  simp_rw [normSq_add_eq_star_mul_re]
+  rw [Finset.sum_add_distrib, Finset.sum_add_distrib,
+    stabilizer_preserves_coefficientNormSq]
+  unfold coefficientNormSq stabilizerEnergy
+  rw [← Finset.mul_sum]
+  ring
+
+/-- The coefficient version of
+`sum_i ‖(I + K_i)v‖² = 2 (N ‖v‖² + Re ⟨v,Hv⟩)`. -/
+private lemma hamiltonian_sumOfSquares {N : ℕ} (v : NSiteSpace 2 N) :
+    (∑ i : Fin N, ∑ s,
+        Complex.normSq (v s + (clusterChainStabilizer i v) s)) =
+      2 * ((N : ℝ) * coefficientNormSq v + hamiltonianEnergy v) := by
+  rw [Finset.sum_congr rfl (fun i _ => stabilizer_sumOfSquares i v),
+    hamiltonianEnergy_eq_sum_stabilizerEnergy]
+  rw [← Finset.mul_sum, Finset.sum_add_distrib]
+  simp only [Finset.sum_const, nsmul_eq_mul, Finset.card_univ, Fintype.card_fin]
+
+private lemma hamiltonianEnergy_eq_of_eigen {N : ℕ} (v : NSiteSpace 2 N)
+    (hv : (∑ i : Fin N, clusterChainStabilizer i) v = (-(N : ℂ)) • v) :
+    hamiltonianEnergy v = -(N : ℝ) * coefficientNormSq v := by
+  unfold hamiltonianEnergy coefficientNormSq
+  rw [hv]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro s _
+  change (conj (v s) * (-(N : ℂ) * v s)).re =
+    -(N : ℝ) * Complex.normSq (v s)
+  rw [Complex.normSq_apply]
+  simp only [Complex.mul_re, Complex.mul_im, Complex.conj_re, Complex.conj_im,
+    Complex.neg_re, Complex.natCast_re, Complex.neg_im, Complex.natCast_im]
+  ring
+
+private lemma mem_common_neg_of_sumOfSquares_eq_zero {N : ℕ}
+    (v : NSiteSpace 2 N)
+    (hzero : (∑ i : Fin N, ∑ s,
+      Complex.normSq (v s + (clusterChainStabilizer i v) s)) = 0) :
+    v ∈ ⨅ i : Fin N, Module.End.eigenspace (clusterChainStabilizer i) (-1) := by
+  rw [Submodule.mem_iInf]
+  intro i
+  rw [Module.End.mem_eigenspace_iff]
+  ext s
+  have hi : (∑ s,
+      Complex.normSq (v s + (clusterChainStabilizer i v) s)) = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg (fun i _ =>
+      Finset.sum_nonneg fun s _ => Complex.normSq_nonneg
+        (v s + (clusterChainStabilizer i v) s))).mp hzero i (Finset.mem_univ i)
+  have hs : Complex.normSq (v s + (clusterChainStabilizer i v) s) = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg (fun s _ =>
+      Complex.normSq_nonneg (v s + (clusterChainStabilizer i v) s))).mp
+        hi s (Finset.mem_univ s)
+  have hz := Complex.normSq_eq_zero.mp hs
+  simp only [Pi.smul_apply, smul_eq_mul, neg_one_mul]
+  rw [eq_neg_iff_add_eq_zero]
+  simpa only [add_comm] using hz
+
+/-- The bottom eigenspace of the stabilizer sum is exactly the common `-1`
+eigenspace, hence the span of the source cluster MPV.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_hamiltonian_eigenspace_eq_mpvSubmodule {N : ℕ} (hN : 3 ≤ N) :
+    Module.End.eigenspace (∑ i : Fin N, clusterChainStabilizer i) (-(N : ℂ)) =
+      mpvSubmodule clusterSourceTensor N := by
+  apply le_antisymm
+  · intro v hv
+    rw [← clusterSource_iInf_eigenspace_eq_mpvSubmodule hN]
+    have hvHam : (∑ i : Fin N, clusterChainStabilizer i) v = (-(N : ℂ)) • v :=
+      Module.End.mem_eigenspace_iff.mp hv
+    apply mem_common_neg_of_sumOfSquares_eq_zero
+    rw [hamiltonian_sumOfSquares, hamiltonianEnergy_eq_of_eigen v hvHam]
+    ring
+  · rw [← clusterSource_iInf_eigenspace_eq_mpvSubmodule hN]
+    intro v hv
+    rw [Submodule.mem_iInf] at hv
+    rw [Module.End.mem_eigenspace_iff]
+    simp only [LinearMap.sum_apply]
+    calc
+      (∑ i : Fin N, clusterChainStabilizer i v) =
+          ∑ i : Fin N, (-1 : ℂ) • v := by
+            apply Finset.sum_congr rfl
+            intro i _
+            exact Module.End.mem_eigenspace_iff.mp (hv i)
+      _ = (-(N : ℂ)) • v := by
+        ext s
+        simp [Pi.smul_apply, Finset.sum_const, smul_eq_mul]
+
+/-- The Hamiltonian expectation is bounded below by minus `N` times the
+coefficient-space squared norm.
+
+See arXiv:quant-ph/0608197, local TeX lines 374--387. -/
+theorem clusterSource_energy_lower_bound {N : ℕ} (_hN : 3 ≤ N) (v : NSiteSpace 2 N) :
+    -(N : ℝ) * (∑ s, ‖v s‖ ^ 2) ≤
+      (∑ s, star (v s) * ((∑ i : Fin N, clusterChainStabilizer i) v) s).re := by
+  have hsos : 0 ≤
+      (∑ i : Fin N, ∑ s,
+        Complex.normSq (v s + (clusterChainStabilizer i v) s)) := by
+    exact Finset.sum_nonneg fun _ _ =>
+      Finset.sum_nonneg fun _ _ => Complex.normSq_nonneg _
+  rw [hamiltonian_sumOfSquares] at hsos
+  have hbound : -(N : ℝ) * coefficientNormSq v ≤ hamiltonianEnergy v := by
+    nlinarith
+  rw [Complex.re_sum]
+  simpa only [coefficientNormSq, hamiltonianEnergy,
+    Complex.normSq_eq_norm_sq] using hbound
+
+
+end
+end MPSTensor

--- a/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
+++ b/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
@@ -325,6 +325,133 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     $\dim\mathcal G_{N,3}(A_{\mathrm{cl}}) = 1$.
 \end{proof}
 
+\begin{theorem}[Periodic ground space for the source cluster matrices]
+    \label{thm:cluster_source_stabilizer_chain_ground_space}
+    \lean{MPSTensor.clusterSource_iInf_eigenspace_eq_chainGroundSpace}
+    \leanok
+    \uses{thm:cluster_source_ground_space_three_eigenspace, def:chain_ground_space, def:cluster_chain_stabilizer}
+    For $N\ge3$, the periodic three-site ground space of the source tensor is
+    the common $-1$ eigenspace of the translated stabilizers:
+    \begin{align}
+        \bigcap_i\{\psi : K_i\psi = -\psi\}
+         & = \mathcal G_{N,3}(A_{\mathrm{src}}).\notag
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:cluster_source_ground_space_three_eigenspace, rem:cyclic_window_operators, def:chain_ground_space}
+    The three-site calculation in
+    Theorem~\ref{thm:cluster_source_ground_space_three_eigenspace} identifies
+    $\mathcal G_3(A_{\mathrm{src}})$ with the $-1$ eigenspace of $K=ZXZ$.
+    The periodic ground space imposes this local condition at every position
+    around the ring. Each translated operator $K_i$ acts only on its three
+    sites, so we can apply the local calculation with the outside spins fixed.
+
+    Fix a site $i$ and fix the spins outside $[i,i+2]$ to a configuration
+    $\tau$. The remaining coefficients form a three-site vector
+    $\psi|_{[i,i+2],\tau}$. The operator $K_i$ acts only on these three
+    sites: it flips the middle spin and multiplies by the two endpoint
+    signs. Since $N\ge3$, these sites are distinct, and therefore
+    \begin{align}
+        K\bigl(\psi|_{[i,i+2],\tau}\bigr)
+         & = (K_i\psi)|_{[i,i+2],\tau}.\notag
+    \end{align}
+    It follows that $K_i\psi=-\psi$ if and only if
+    $K\bigl(\psi|_{[i,i+2],\tau}\bigr)
+    =-\psi|_{[i,i+2],\tau}$ for every $\tau$. For the reverse implication,
+    every coefficient of $K_i\psi+\psi$ occurs in one of these
+    three-site vectors, so all its coefficients vanish.
+
+    Substituting the local ground-space identity, we obtain
+    $K_i\psi=-\psi$ for every $i$ exactly when every three-site
+    restriction belongs to $\mathcal G_3(A_{\mathrm{src}})$, which is the
+    defining condition for $\psi\in\mathcal G_{N,3}(A_{\mathrm{src}})$.
+\end{proof}
+
+\begin{theorem}[Source cluster ground state]\label{thm:cluster_source_periodic_ground_state}
+    \lean{MPSTensor.clusterSource_mpv_eq_globalZ, MPSTensor.clusterSource_mpv_ne_zero, MPSTensor.clusterSource_iInf_eigenspace_eq_mpvSubmodule, MPSTensor.clusterSource_stabilizer_unique_gs, MPSTensor.clusterSource_hamiltonian_eigenspace_eq_mpvSubmodule, MPSTensor.clusterSource_energy_lower_bound}
+    \leanok
+    \uses{def:cluster_tensor, thm:cluster_source_ground_space_three_eigenspace, def:cluster_chain_stabilizer, def:mpv_submodule}
+    Let $N\ge3$ and put
+    $U=(\sigma^z)^{\otimes N}$ and $H=\sum_i K_i$. Then
+    \begin{align}
+        \ket{V^{(N)}(A_{\mathrm{src}})}
+        &=(\sqrt2)^N U\ket{V^{(N)}(A_{\mathrm{cl}})}\ne0.
+        \label{eq:cluster_source_vector}
+    \end{align}
+    The common $-1$ eigenspace of the $K_i$ and the ground eigenspace of $H$
+    are both $\C\ket{V^{(N)}(A_{\mathrm{src}})}$. More precisely, with the
+    usual inner product $\langle v,w\rangle=\sum_s\overline{v_s}w_s$, the
+    bound below holds for every vector $v$:
+    \begin{align}
+        \operatorname{Re}\langle v,Hv\rangle&\ge-N\|v\|^2,\notag\\
+        \ker(H+N\Id)&=\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
+    \end{align}
+    Thus the ground energy is $-N$, and the normalized ground state is unique
+    up to phase. This proves the periodic-chain claim for the matrices in
+    \cite{PerezGarcia2007Matrix}, for odd as well as
+    even $N\ge3$.
+    % Source location: Papers/quant-ph_0608197/MPSarchive.tex, lines 374--387.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cluster_stabilizer_unique_gs, thm:cluster_normal, thm:gauge_invariance, lem:mpv_smul}
+    Applying $\sigma^z$ at every site changes every stabilizer eigenvalue from
+    $+1$ to $-1$. We first relate the vector associated with the normalized
+    cluster tensor to the vector defined by the source matrices.
+
+    Put
+    \begin{align}
+        G=\begin{pmatrix}1&-1\\1&1\end{pmatrix},\qquad
+        G^{-1}=\frac12\begin{pmatrix}1&1\\-1&1\end{pmatrix}.\notag
+    \end{align}
+    Direct multiplication gives, for $t=0,1$,
+    \begin{align}
+        A_{\mathrm{src}}^t
+        &=\sqrt2\,(-1)^tG A_{\mathrm{cl}}^tG^{-1}.\notag
+    \end{align}
+    In a product of $N$ matrices, adjacent inverse factors cancel. Taking the
+    trace removes the remaining conjugation, so
+    \begin{align}
+        V^{(N)}(A_{\mathrm{src}})_s
+        &=(\sqrt2)^N(-1)^{\sum_j s_j}V^{(N)}(A_{\mathrm{cl}})_s.\notag
+    \end{align}
+    The parity factor is precisely the action of $U$ on the coefficient at
+    $s$. This proves (\ref{eq:cluster_source_vector}); nonvanishing follows
+    from the nonzero cluster vector, since $(\sqrt2)^N\ne0$ and $U^2=\Id$.
+
+    Conjugating by $\sigma^z$ fixes $\sigma^z$ and sends $\sigma^x$ to
+    $-\sigma^x$. The three sites in each $K_i$ are distinct, so $UK_iU=-K_i$.
+    If $K_iv=v$ for every $i$, then $K_i(Uv)=-Uv$ for every $i$.
+    Conversely, if $K_iw=-w$ for every $i$, then $K_i(Uw)=Uw$; applying $U$
+    again returns $w$. Thus $U$ maps the common $+1$ eigenspace bijectively
+    onto the common $-1$ eigenspace. By
+    Theorem~\ref{thm:cluster_stabilizer_unique_gs} and
+    (\ref{eq:cluster_source_vector}),
+    \begin{align}
+        \bigcap_i\{v:K_iv=-v\}&=\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
+    \end{align}
+    This space is one-dimensional.
+
+    Each $K_i$ is a product of Hermitian Pauli operators on distinct sites,
+    so $K_i$ and hence $H$ are Hermitian.
+    Each $K_i$ changes coefficient signs and permutes the computational basis,
+    so it preserves the norm. Expanding the squares gives
+    \begin{align}
+        \frac12\sum_i\|(\Id+K_i)v\|^2
+        &=N\|v\|^2+\operatorname{Re}\langle v,Hv\rangle\ge0.
+        \label{eq:cluster_source_energy}
+    \end{align}
+    Equality holds exactly when every $(\Id+K_i)v$ vanishes, that is, when
+    $v\in\C\ket{V^{(N)}(A_{\mathrm{src}})}$. Conversely, summing the equations
+    $K_i\ket{V^{(N)}(A_{\mathrm{src}})}=-\ket{V^{(N)}(A_{\mathrm{src}})}$
+    gives $H\ket{V^{(N)}(A_{\mathrm{src}})}=-N\ket{V^{(N)}(A_{\mathrm{src}})}$.
+    Together with (\ref{eq:cluster_source_energy}), this identifies $-N$ as
+    the attained ground energy and its eigenspace as
+    $\C\ket{V^{(N)}(A_{\mathrm{src}})}$.
+\end{proof}
+
 \begin{remark}[Cluster-state stabilizer convention]\label{rem:cluster_stabilizer_convention}
     The cluster tensor of Definition~\ref{def:cluster_tensor} is the reflected
     convention of the tensor displayed in
@@ -354,8 +481,10 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     $\bra{\pm}\sigma^x = \pm\bra{\pm}$ the states differ by $\sigma^z$ on
     every site, which conjugates each $K_i$ to $-K_i$ and exchanges the two
     Hamiltonians $\sum_i K_i$ and $-\sum_i K_i = \sum_i(\Id-K_i) - N\Id$.
-    The scope of what is established here for the printed cluster matrices, and
-    what is left aside, is recorded in
+    Theorem~\ref{thm:cluster_source_periodic_ground_state} proves this on-site
+    relation for the matrix product vectors and identifies the ground energy
+    and eigenspace for the printed matrices. The remaining operator-identity
+    and other example-level questions are recorded in
     \cite{gap:rmp_example_parent_hamiltonian_scope}.
 \end{remark}
 

--- a/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
+++ b/blueprint/src/chapter/ch15_examples_parent_hamiltonians.tex
@@ -376,7 +376,7 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     $U=(\sigma^z)^{\otimes N}$ and $H=\sum_i K_i$. Then
     \begin{align}
         \ket{V^{(N)}(A_{\mathrm{src}})}
-        &=(\sqrt2)^N U\ket{V^{(N)}(A_{\mathrm{cl}})}\ne0.
+         & =(\sqrt2)^N U\ket{V^{(N)}(A_{\mathrm{cl}})}\ne0.
         \label{eq:cluster_source_vector}
     \end{align}
     The common $-1$ eigenspace of the $K_i$ and the ground eigenspace of $H$
@@ -384,8 +384,8 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     usual inner product $\langle v,w\rangle=\sum_s\overline{v_s}w_s$, the
     bound below holds for every vector $v$:
     \begin{align}
-        \operatorname{Re}\langle v,Hv\rangle&\ge-N\|v\|^2,\notag\\
-        \ker(H+N\Id)&=\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
+        \operatorname{Re}\langle v,Hv\rangle & \ge-N\|v\|^2,\notag                       \\
+        \ker(H+N\Id)                         & =\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
     \end{align}
     Thus the ground energy is $-N$, and the normalized ground state is unique
     up to phase. This proves the periodic-chain claim for the matrices in
@@ -409,13 +409,13 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     Direct multiplication gives, for $t=0,1$,
     \begin{align}
         A_{\mathrm{src}}^t
-        &=\sqrt2\,(-1)^tG A_{\mathrm{cl}}^tG^{-1}.\notag
+         & =\sqrt2\,(-1)^tG A_{\mathrm{cl}}^tG^{-1}.\notag
     \end{align}
     In a product of $N$ matrices, adjacent inverse factors cancel. Taking the
     trace removes the remaining conjugation, so
     \begin{align}
         V^{(N)}(A_{\mathrm{src}})_s
-        &=(\sqrt2)^N(-1)^{\sum_j s_j}V^{(N)}(A_{\mathrm{cl}})_s.\notag
+         & =(\sqrt2)^N(-1)^{\sum_j s_j}V^{(N)}(A_{\mathrm{cl}})_s.\notag
     \end{align}
     The parity factor is precisely the action of $U$ on the coefficient at
     $s$. This proves (\ref{eq:cluster_source_vector}); nonvanishing follows
@@ -430,7 +430,7 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     Theorem~\ref{thm:cluster_stabilizer_unique_gs} and
     (\ref{eq:cluster_source_vector}),
     \begin{align}
-        \bigcap_i\{v:K_iv=-v\}&=\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
+        \bigcap_i\{v:K_iv=-v\} & =\C\ket{V^{(N)}(A_{\mathrm{src}})}.\notag
     \end{align}
     This space is one-dimensional.
 
@@ -440,7 +440,7 @@ We write $\GS(H)=\ker(H-E_0(H)\Id)$ for the ground eigenspace.
     so it preserves the norm. Expanding the squares gives
     \begin{align}
         \frac12\sum_i\|(\Id+K_i)v\|^2
-        &=N\|v\|^2+\operatorname{Re}\langle v,Hv\rangle\ge0.
+         & =N\|v\|^2+\operatorname{Re}\langle v,Hv\rangle\ge0.
         \label{eq:cluster_source_energy}
     \end{align}
     Equality holds exactly when every $(\Id+K_i)v$ vanishes, that is, when

--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -242,8 +242,8 @@ statement.\footnote{Formal declaration:
 The AKLT target stated in the sources is now formalized, and the cluster target
 is formalized for the reflected convention
 (\ref{eq:rmp_example_parent_hamiltonian_scope_formal_cluster_zero})--(\ref{eq:rmp_example_parent_hamiltonian_scope_formal_cluster_one});
-for the two matrices displayed in the older review it is formalized on a single
-three-site window only. The
+for the two matrices displayed in the older review the periodic ground energy
+and one-dimensional ground eigenspace are also formalized for $N\ge3$. The
 two-site AKLT parent space is cut out by the five linear constraints
 $v_{11}=v_{22}=0$, $v_{01}+v_{10}=0$, $v_{02}+v_{20}=0$,
 $2v_{00}+v_{12}+v_{21}=0$; the three-site intersection
@@ -266,17 +266,26 @@ the sign printed in
 (\ref{eq:rmp_example_parent_hamiltonian_scope_cluster_three_body}) is correct
 for those matrices; the two states differ by $\sigma^z$ on every site, which
 conjugates each stabilizer to its negative and exchanges $\sum_i K_i$ with
-$-\sum_i K_i$. That last sentence is mathematical prose here and nothing more:
-no formal statement carries the periodic uniqueness result across the on-site
-$\sigma^z$ equivalence, so for the matrices displayed in the older review the
-formal content is the single-window identity
-$\mathcal G_3(A_{\mathrm{src}})=\{v : Kv=-v\}$ alone, and the review's own
-claim that those matrices give the unique ground state of $\sum_i K_i$ on a
-periodic chain is still open.\footnote{Formal declarations:
-\leanid{MPSTensor.clusterSourceTensor} and
-\leanid{MPSTensor.clusterSource_groundSpace_three_eq_eigenspace_neg_one} in
-\path{TNLean/MPS/Examples/ClusterParentHamiltonian.lean}. The periodic
-declarations listed below are all stated for the reflected convention.} The
+$-\sum_i K_i$. The matrix product vectors satisfy
+\begin{align}
+    \ket{V^{(N)}(A_{\mathrm{src}})}
+    &=(\sqrt2)^N(\sigma^z)^{\otimes N}\ket{V^{(N)}(A_{\mathrm{cl}})}.\notag
+\end{align}
+This identity transports nonvanishing and the common eigenspace. A
+sum-of-squares argument gives the real quadratic-form lower bound $-N$ and
+identifies its equality space with the source vector's span, proving the
+periodic uniqueness claim.\footnote{Formal declarations:
+\leanid{MPSTensor.clusterSource_mpv_eq_globalZ},
+\leanid{MPSTensor.clusterSource_mpv_ne_zero},
+\leanid{MPSTensor.clusterSource_iInf_eigenspace_eq_mpvSubmodule},
+\leanid{MPSTensor.clusterSource_stabilizer_unique_gs},
+\leanid{MPSTensor.clusterSource_hamiltonian_eigenspace_eq_mpvSubmodule}, and
+\leanid{MPSTensor.clusterSource_energy_lower_bound} in
+\path{TNLean/MPS/Examples/ClusterSourceGroundState.lean}.}
+The periodic three-site parent ground space of the source tensor is exactly
+the same common $-1$ eigenspace, and hence is also one-dimensional.\footnote{
+\leanid{MPSTensor.clusterSource_iInf_eigenspace_eq_chainGroundSpace} in
+\path{TNLean/MPS/Examples/ClusterParentHamiltonian.lean}.} The
 identification
 of the parent interaction with $\tfrac12(I-K)$ as an operator identity is not
 formalized; the formal statements are the eigenspace
@@ -287,12 +296,10 @@ identities.\footnote{Formal declarations:
 \leanid{MPSTensor.cluster_stabilizer_unique_gs} in
 \path{TNLean/MPS/Examples/ClusterParentHamiltonian.lean}.}
 
-Four items remain outside the formal development: the identification of the
+Three items remain outside the formal development: the identification of the
 GHZ parent interaction with the ferromagnetic Ising interaction
 (\ref{eq:rmp_example_parent_hamiltonian_scope_ising_hamiltonian}) as an
-operator identity, the on-site $\sigma^z$ equivalence carrying the periodic
-unique-ground-state statement to the two matrices displayed in the older
-review, the polynomial AKLT Hamiltonian
+operator identity, the polynomial AKLT Hamiltonian
 (\ref{eq:rmp_example_parent_hamiltonian_scope_aklt_polynomial}) and its
 spin-$2$ projector form, and the open-boundary edge-mode degeneracy.
 
@@ -314,10 +321,10 @@ A source-faithful formalization of issue \#2315 should proceed as follows.
           index-shift equivalence. For the reflected convention both parts are
           done: the three-site parent space is the $ZXZ$ stabilizer
           eigenspace, and the general theorem gives the unique ground state on
-          $N\ge3$ periodic sites. For the matrices printed in the older review
-          only the three-site eigenspace identity is proved, with eigenvalue
-          $-1$; carrying the periodic statement to them is exactly the missing
-          on-site $\sigma^z$ equivalence.
+          $N\ge3$ periodic sites. For the matrices printed in the older review,
+          the on-site $\sigma^z$ relation now gives the common $-1$ eigenspace;
+          the sum-of-squares identity identifies it as the one-dimensional
+          ground eigenspace of the stabilizer sum, with energy $-N$.
 
     \item For AKLT, first use the two-site criterion
           (\ref{eq:rmp_example_parent_hamiltonian_scope_aklt_intersection}) and
@@ -338,10 +345,9 @@ stated in the review, explicit stabilizer or spin-projector formulas, and
 open-boundary edge-mode ground spaces. These are distinct mathematical
 statements with distinct source obligations. The first type is formalized, and
 so is the cluster stabilizer for the reflected convention, including its
-periodic unique-ground-state statement; for the two matrices printed in the
-older review only the three-site eigenspace identity is proved. The GHZ Ising
-operator identity, the on-site $\sigma^z$ equivalence that would carry the
-periodic cluster statement to those two matrices, the AKLT polynomial and
+periodic unique-ground-state statement. For the two matrices printed in the
+older review, the on-site equivalence, ground energy and periodic uniqueness
+are now proved for $N\ge3$. The GHZ Ising operator identity, the AKLT polynomial and
 spin-$2$ projector forms, and the open-boundary edge modes remain open.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
# feat(MPS/Examples): prove the source cluster ground-state theorem

### Motivation

Resolve the periodic cluster-state claim in #7810 for the matrices printed in
`Papers/quant-ph_0608197/MPSarchive.tex:374-387`. The source describes cluster
states as "unique ground states of the three-body interactions". The proof
below establishes the sign and vector convention for those matrices for every
periodic chain of length N >= 3.

### Description

The source matrix product vector is sqrt(2)^N times the normalized cluster
matrix product vector acted on by Z at every site. An explicit virtual gauge
gives this identity. The global Z action exchanges the common +1 and -1
stabilizer eigenspaces, so the nonzero source vector spans the latter.
A sum-of-squares identity then proves that the sum of the translated ZXZ
operators has ground energy -N and a one-dimensional ground eigenspace.

The common -1 eigenspace is also identified with TNLean's periodic three-site
parent ground space. This uses the existing cyclic-restriction argument,
generalized privately to arbitrary eigenvalues; the existing +1 public result
keeps its type.

The contribution adds `ClusterSourceGroundState.lean`, updates the Examples
import, and supplies the corresponding mathematical proofs in chapter 15.
The paper-gap note records the resolved cluster claim while retaining the
unrelated open problems.

### Testing

- `lake build TNLean.MPS.Examples.ClusterSourceGroundState TNLean.MPS.Examples`
  passed with the pinned toolchain and package options.
- Nine explicit expected-type tests passed, including the parent-space spanning
  and uniqueness consequences. Nine axiom inspections returned only `propext`,
  `Classical.choice`, and `Quot.sound`.
- Import-aggregator, blueprint synchronization, added-prose and whitespace
  checks passed. No proof placeholders or added axioms occur in the contribution.
- The focused blueprint PDF compiled and all three pages were visually checked.
- Independent reader reconstruction and source/Lean proof-correspondence
  reviews passed.
- The full repository build and hosted CI have not been run locally. Two
  unchanged Windows test suites have path-separator assertion failures; these
  are recorded in the local verification notes.

Closes #7810

### Agent assistance

Developed with OpenAI Codex. GPT-5.6 Sol assisted with Lean implementation and
independent proof review; GPT-6 Astra assisted with coordination, integration,
and exposition. The mathematical argument and Lean code are submitted for
human review.
